### PR TITLE
Rename tevpy to gammapy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,6 @@ MANIFEST
 
 *.ipynb_checkpoints
 
-tevpy/tevpy.cfg
+gammapy/gammapy.cfg
 
 docs/_generated

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include README.rst
 
 include distribute_setup.py
-recursive-include tevpy *.pyx *.c
+recursive-include gammapy *.pyx *.c
 
 recursive-include docs *
 recursive-include licenses *

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
-tevpy
+gammapy
 =====
 
 TeV gamma-ray astronomy high-level data analysis Python package
 
-* Code: https://github.com/gammapy/tevpy
-* Docs: https://tevpy.readthedocs.org/
+* Code: https://github.com/gammapy/gammapy
+* Docs: https://gammapy.readthedocs.org/
 
-.. image:: https://travis-ci.org/gammapy/tevpy.png
-    :target: https://travis-ci.org/gammapy/tevpy
+.. image:: https://travis-ci.org/gammapy/gammapy.png
+    :target: https://travis-ci.org/gammapy/gammapy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,19 +46,19 @@ rst_epilog += """
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
-project = u'tevpy'
-author = u'The tevpy Developers'
+project = u'gammapy'
+author = u'The gammapy Developers'
 copyright = u'2012, ' + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-import tevpy
+import gammapy
 # The short X.Y version.
-version = tevpy.__version__.split('-', 1)[0]
+version = gammapy.__version__.split('-', 1)[0]
 # The full version, including alpha/beta/rc tags.
-release = tevpy.__version__
+release = gammapy.__version__
 
 
 # -- Options for HTML output ---------------------------------------------------
@@ -95,7 +95,7 @@ html_theme_options = {
 
 # First TeV gamma-ray image: the supernova remnant RX J1713 with HESS
 # http://apod.nasa.gov/apod/ap041105.html
-html_favicon = '_static/tevpy_logo.ico'
+html_favicon = '_static/gammapy_logo.ico'
 
 # TODO: set this image also in the title bar
 # (html_logo is not the right option)
@@ -134,8 +134,8 @@ extensions += ['astropy.sphinx.ext.edit_on_github']
 
 # Don't import the module as "version" or it will override the
 # "version" configuration parameter
-from tevpy import version as versionmod
-edit_on_github_project = "gammapy/tevpy"
+from gammapy import version as versionmod
+edit_on_github_project = "gammapy/gammapy"
 if versionmod.release:
     edit_on_github_branch = "v" + versionmod.version
 else:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ this package is here:
 .. toctree::
   :maxdepth: 2
 
-  tevpy/index.rst
+  gammapy/index.rst
 
 .. note:: Do not edit this page - instead, place all documentation for the
           affiliated package inside ``packagename/``

--- a/docs/tevpy/astro/index.rst
+++ b/docs/tevpy/astro/index.rst
@@ -1,13 +1,13 @@
 **********************************************************
-Astrophysical source and population models (`tevpy.astro`)
+Astrophysical source and population models (`gammapy.astro`)
 **********************************************************
 
-.. currentmodule:: tevpy.astro
+.. currentmodule:: gammapy.astro
 
 Introduction
 ============
 
-`tevpy.astro` implements some common astrophysical source and population models.
+`gammapy.astro` implements some common astrophysical source and population models.
 
 TODO: describe
 
@@ -19,5 +19,5 @@ TODO: describe
 Reference/API
 =============
 
-.. automodapi:: tevpy.astro
+.. automodapi:: gammapy.astro
     :no-inheritance-diagram:

--- a/docs/tevpy/background/index.rst
+++ b/docs/tevpy/background/index.rst
@@ -1,18 +1,18 @@
 ********************************************************
-Background estimation and modeling  (`tevpy.background`)
+Background estimation and modeling  (`gammapy.background`)
 ********************************************************
 
-.. currentmodule:: tevpy.background
+.. currentmodule:: gammapy.background
 
 Introduction
 ============
 
-`tevpy.background` contains methods to estimate and model background.
+`gammapy.background` contains methods to estimate and model background.
 
 At the moment it also contains a lot of image-processing related functionality
 that maybe should be split into a separate `image` package.
 
-The main data structure is the `~tevpy.background.maps.Maps` container ... TODO
+The main data structure is the `~gammapy.background.maps.Maps` container ... TODO
 
 Most of the methods implemented are described in [Berge2007]_.
 Section 7.3 "Background subtraction"
@@ -25,6 +25,6 @@ Getting Started
 
 TODO
 
-.. automodapi:: tevpy.background
+.. automodapi:: gammapy.background
     :no-inheritance-diagram:
 

--- a/docs/tevpy/data/formats/run_lists.rst
+++ b/docs/tevpy/data/formats/run_lists.rst
@@ -31,7 +31,7 @@ Usually it has many more columns with information about each run::
    Run,Telescope_Pattern,Date,Duration,GLON,GLAT,Target,Zenith
    1234,24,2013-03-22 14:32,1832,83.7,-5.2,Crab Nebula,32
 
-Special column names that the `tevpy` analysis tools understand:
+Special column names that the `gammapy` analysis tools understand:
 
 * `Run` --- Run number (int)
 * `Telescope_Pattern` --- Binary pattern describing which telescopes participated in the run

--- a/docs/tevpy/data/index.rst
+++ b/docs/tevpy/data/index.rst
@@ -1,17 +1,17 @@
 ***********************
-Datasets (`tevpy.data`)
+Datasets (`gammapy.data`)
 ***********************
 
-.. currentmodule:: tevpy.data
+.. currentmodule:: gammapy.data
 
 Introduction
 ============
 
-`tevpy.data` holds a few datasets used in the examples and tests. 
-Some are included with `tevpy`, some are downloaded from the web via
+`gammapy.data` holds a few datasets used in the examples and tests. 
+Some are included with `gammapy`, some are downloaded from the web via
 
-   >>> import tevpy.data
-   >>> tevpy.data.download_datasets()
+   >>> import gammapy.data
+   >>> gammapy.data.download_datasets()
 
 TODO: Give summary table of available datasets here.
 
@@ -31,5 +31,5 @@ TODO: give an example.
 Reference/API
 =============
 
-.. automodapi:: tevpy.data
+.. automodapi:: gammapy.data
     :no-inheritance-diagram:

--- a/docs/tevpy/detect/index.rst
+++ b/docs/tevpy/detect/index.rst
@@ -1,13 +1,13 @@
 ***************************************
-Source detection tools (`tevpy.detect`)
+Source detection tools (`gammapy.detect`)
 ***************************************
 
-.. currentmodule:: tevpy.detect
+.. currentmodule:: gammapy.detect
 
 Introduction
 ============
 
-`tevpy.detect` holds source detection methods that turn event lists or images or cubes
+`gammapy.detect` holds source detection methods that turn event lists or images or cubes
 into source catalogs. 
 
 * TODO: Describe references: [Stewart2009]_
@@ -24,21 +24,21 @@ Getting Started
 Reference/API
 =============
 
-.. automodapi:: tevpy.detect.blob
+.. automodapi:: gammapy.detect.blob
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.detect.cwt
+.. automodapi:: gammapy.detect.cwt
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.detect.matched_filter
+.. automodapi:: gammapy.detect.matched_filter
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.detect.sex
+.. automodapi:: gammapy.detect.sex
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.detect.test_statistic
+.. automodapi:: gammapy.detect.test_statistic
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.detect.utils
+.. automodapi:: gammapy.detect.utils
     :no-inheritance-diagram:
     

--- a/docs/tevpy/image/index.rst
+++ b/docs/tevpy/image/index.rst
@@ -1,17 +1,17 @@
 ***************************************************
-Image processing and analysis tools (`tevpy.image`)
+Image processing and analysis tools (`gammapy.image`)
 ***************************************************
 
-.. currentmodule:: tevpy.image
+.. currentmodule:: gammapy.image
 
 Introduction
 ============
 
-`tevpy.image` contains image processing and analysis methods that are
+`gammapy.image` contains image processing and analysis methods that are
 not readily found (yet) in `scipy.ndimage`, `scikit-image`, `astropy` or `photutils`:
 
-* `tevpy.image.profile`: Compute 1D profiles from 2D images
-* `tevpy.image.measure`: Measure source properties in labeled regions
+* `gammapy.image.profile`: Compute 1D profiles from 2D images
+* `gammapy.image.measure`: Measure source properties in labeled regions
 
 
 Getting Started
@@ -22,5 +22,5 @@ TODO
 Reference/API
 =============
 
-.. automodapi:: tevpy.image
+.. automodapi:: gammapy.image
     :no-inheritance-diagram:

--- a/docs/tevpy/index.rst
+++ b/docs/tevpy/index.rst
@@ -1,22 +1,22 @@
-`tevpy`
+`gammapy`
 =======
 
 What is it?
 -----------
 
-`tevpy` is an open source (BSD licensed) TeV gamma-ray astronomy high-level data analysis Python package.
+`gammapy` is an open source (BSD licensed) TeV gamma-ray astronomy high-level data analysis Python package.
 
 It contains some analysis methods,
 but it's main purpose is to be the glue between the many
 existing data formats and other tools.
 
-* Code / Bug reports / Feature requests / Development: https://github.com/gammapy/tevpy
-* Docs: https://tevpy.readthedocs.org/
+* Code / Bug reports / Feature requests / Development: https://github.com/gammapy/gammapy
+* Docs: https://gammapy.readthedocs.org/
 * Mailing list: http://groups.google.com/group/gammapy
 * License: BSD-3-Clause
 
 
-Using `tevpy`
+Using `gammapy`
 -------------
 
 Start by reading the :ref:`introduction`.
@@ -50,5 +50,5 @@ Contact
 
 Found a bug or missing feature?
 
-Make an issue or pull request on `GitHub <https://github.com/gammapy/tevpy>`_. 
+Make an issue or pull request on `GitHub <https://github.com/gammapy/gammapy>`_. 
 

--- a/docs/tevpy/install.rst
+++ b/docs/tevpy/install.rst
@@ -3,22 +3,22 @@
 Installation
 ============
 
-To install the latest `tevpy` stable version the easiest way is using the `pip <http://www.pip-installer.org/>`_ installer::
+To install the latest `gammapy` stable version the easiest way is using the `pip <http://www.pip-installer.org/>`_ installer::
 
-   pip install tevpy
+   pip install gammapy
 
-To install the latest developer version of `tevpy`, use::
+To install the latest developer version of `gammapy`, use::
 
-   git clone https://github.com/gammapy/tevpy.git
+   git clone https://github.com/gammapy/gammapy.git
    cd astropy
    python setup.py install
 
-To check if `tevpy` is correctly installed, start up python or ipython, import `tevpy` and run the unit tests::
+To check if `gammapy` is correctly installed, start up python or ipython, import `gammapy` and run the unit tests::
 
-   >>> import tevpy
-   >>> tevpy.test()
+   >>> import gammapy
+   >>> gammapy.test()
 
-To check if the `tevpy` command line tools are on your `$PATH` try this::
+To check if the `gammapy` command line tools are on your `$PATH` try this::
 
    $ tev-lookup-map-values --help
 
@@ -43,7 +43,7 @@ Optional dependencies (imported and used only where needed):
 * `imfun`_ for a trous wavelet decomposition
 
 .. note:: I didn't put any effort into minimizing the number of dependencies,
-   since `tevpy` is a prototype. Should it develop into a package that is actually used
+   since `gammapy` is a prototype. Should it develop into a package that is actually used
    by a few people I'll limit the optional packages to what is actually necessary.
 
 .. _scikit-image: http://scikit-image.org

--- a/docs/tevpy/introduction.rst
+++ b/docs/tevpy/introduction.rst
@@ -6,28 +6,28 @@ Introduction
 Show me some code!
 ------------------
 
-`tevpy` gives you easy access to some frequently used methods in TeV gamma-ray astronomy from Python.
+`gammapy` gives you easy access to some frequently used methods in TeV gamma-ray astronomy from Python.
 
 What's the statistical significance when 10 events have been observed with a known background level of 4.2
 according to [LiMa1983]_?
-`tevpy.stats` knows::
+`gammapy.stats` knows::
 
-   >>> from tevpy.stats import significance
+   >>> from gammapy.stats import significance
    >>> significance(n_observed=10, mu_background=4.2, method='lima')
    2.3979181291475453
 
 What's the differential gamma-ray flux and spectral index of the Crab nebula at 3 TeV
 according to [Meyer2010]_?
-`tevpy.spec` knows::
+`gammapy.spec` knows::
 
-   >>> from tevpy.spec import crab
+   >>> from gammapy.spec import crab
    >>> energy = 3
    >>> crab.diff_flux(energy, ref='meyer')
    1.8993523278650278e-12
    >>> crab.spectral_index(energy, ref='meyer')
    2.6763224503600429
 
-All functionality is in subpackages (e.g. `tevpy.stats` or `tevpy.spec`) ...
+All functionality is in subpackages (e.g. `gammapy.stats` or `gammapy.spec`) ...
 browse their docs (see list below) to see if it contains the methods you want.
 
 But I don't know how to code in Python!
@@ -35,7 +35,7 @@ But I don't know how to code in Python!
 
 Hmm ... OK.
 
-Some of the `tevpy` functionality can be called from command line tools.
+Some of the `gammapy` functionality can be called from command line tools.
 
 But, to be honest, if you're an astronomer, you should learn to code in Python.
 Start at http://python4astronomers.github.io or `here <http://www.astropy.org>`_  
@@ -65,11 +65,11 @@ Other related packages
 There are several other great open source packages for
 TeV data analysis (alphabetical order):
 
-* `act-analysis`_ --- a similar package as ``tevpy`` by Karl Kosack
+* `act-analysis`_ --- a similar package as ``gammapy`` by Karl Kosack
 * `gammafits`_ --- an SED modeling and fitting package by Victor Zabalza
 * `gammalib`_ and `ctools`_ --- Gamma-ray data analysis library and tools by Jürgen Knödlseder
 * `gamma-speed`_ --- benchmarking of TeV data analysis tools by Andrei Ignat
-* `PyFACT`_ --- a similar package as ``tevpy`` by Martin Raue
+* `PyFACT`_ --- a similar package as ``gammapy`` by Martin Raue
 
 .. _act-analysis: https://bitbucket.org/kosack/act-analysis
 .. _PyFACT: http://pyfact.readthedocs.org

--- a/docs/tevpy/irf/index.rst
+++ b/docs/tevpy/irf/index.rst
@@ -1,13 +1,13 @@
 **************************************************************
-Instrument response function (IRF) functionality (`tevpy.irf`)
+Instrument response function (IRF) functionality (`gammapy.irf`)
 **************************************************************
 
-.. currentmodule:: tevpy.irf
+.. currentmodule:: gammapy.irf
 
 Introduction
 ============
 
-`tevpy.irf` contains functions and classes to access and model
+`gammapy.irf` contains functions and classes to access and model
 instrument response functions (IRFs).
 
 TODO: document
@@ -20,5 +20,5 @@ TODO: document
 Reference/API
 =============
 
-.. automodapi:: tevpy.irf
+.. automodapi:: gammapy.irf
     :no-inheritance-diagram:

--- a/docs/tevpy/obs/index.rst
+++ b/docs/tevpy/obs/index.rst
@@ -1,13 +1,13 @@
 **************************************
-Observation bookkeeping  (`tevpy.obs`)
+Observation bookkeeping  (`gammapy.obs`)
 **************************************
 
-.. currentmodule:: tevpy.obs
+.. currentmodule:: gammapy.obs
 
 Introduction
 ============
 
-`tevpy.obs` contains methods to do the bookkeeping for processing multiple observations.
+`gammapy.obs` contains methods to do the bookkeeping for processing multiple observations.
 
 In TeV astronomy an observation (a.k.a. a run) means pointing the telescopes at some
 position on the sky (fixed in celestial coordinates, not in horizon coordinates)
@@ -60,5 +60,5 @@ at the command line or read the usage help `here <TODO>`_
       is a nice example for a run selection tool.
 
 
-.. automodapi:: tevpy.obs
+.. automodapi:: gammapy.obs
     :no-inheritance-diagram:

--- a/docs/tevpy/references.rst
+++ b/docs/tevpy/references.rst
@@ -1,7 +1,7 @@
 References
 ==========
 
-This is the bibliography containing the literature references for the implemented methods referenced from the ``tevpy`` docs.
+This is the bibliography containing the literature references for the implemented methods referenced from the ``gammapy`` docs.
 
 The best reference to TeV data analysis is Chapter 7 of Mathieu de Naurois's habilitation thesis.
 

--- a/docs/tevpy/shower/index.rst
+++ b/docs/tevpy/shower/index.rst
@@ -1,13 +1,13 @@
 **************************************************
-Air shower image I/O and analysis (`tevpy.shower`)
+Air shower image I/O and analysis (`gammapy.shower`)
 **************************************************
 
-.. currentmodule:: tevpy.shower
+.. currentmodule:: gammapy.shower
 
 Introduction
 ============
 
-`tevpy.shower` contains air shower image I/O and analysis methods.
+`gammapy.shower` contains air shower image I/O and analysis methods.
 
 TODO: document
 
@@ -19,5 +19,5 @@ TODO: document
 Reference/API
 =============
 
-.. automodapi:: tevpy.shower
+.. automodapi:: gammapy.shower
     :no-inheritance-diagram:

--- a/docs/tevpy/spectrum/index.rst
+++ b/docs/tevpy/spectrum/index.rst
@@ -1,13 +1,13 @@
 ***************************************************
-Spectrum estimation and modeling (`tevpy.spectrum`)
+Spectrum estimation and modeling (`gammapy.spectrum`)
 ***************************************************
 
-.. currentmodule:: tevpy.spectrum
+.. currentmodule:: gammapy.spectrum
 
 Introduction
 ============
 
-`tevpy.spectrum` holds functions and classes to fit spectral models and compute flux points.
+`gammapy.spectrum` holds functions and classes to fit spectral models and compute flux points.
 
 Explain spectrum estimation basics.
 
@@ -23,8 +23,8 @@ Getting Started
 TODO
 
 
-.. automodapi:: tevpy.spectrum
+.. automodapi:: gammapy.spectrum
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.spectrum.crab
+.. automodapi:: gammapy.spectrum.crab
     :no-inheritance-diagram:

--- a/docs/tevpy/stats/index.rst
+++ b/docs/tevpy/stats/index.rst
@@ -1,13 +1,13 @@
 ********************************
-Statistics tools (`tevpy.stats`)
+Statistics tools (`gammapy.stats`)
 ********************************
 
-.. currentmodule:: tevpy.stats
+.. currentmodule:: gammapy.stats
 
 Introduction
 ============
 
-`tevpy.stats` holds statistical estimators,
+`gammapy.stats` holds statistical estimators,
 fit statistics and algorithms commonly used in gamma-ray astronomy.
 
 It is mostly concerned with the evaluation of one or several observations
@@ -31,7 +31,7 @@ and that is :math:`a_{off}/a_{on}=10` times larger than the on-region.
 Here's how you compute the statistical significance of your detection 
 with the Li \& Ma formula:
 
-   >>> from tevpy.stats import significance_on_off
+   >>> from gammapy.stats import significance_on_off
    >>> significance_on_off(n_on=18, n_off=97, alpha=1. / 10, method='lima')
    2.2421704424844875
 
@@ -43,11 +43,11 @@ TODO: More examples.
 Reference/API
 =============
 
-.. automodapi:: tevpy.stats.poisson
+.. automodapi:: gammapy.stats.poisson
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.stats.fit_statistics
+.. automodapi:: gammapy.stats.fit_statistics
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.stats.utils
+.. automodapi:: gammapy.stats.utils
     :no-inheritance-diagram:

--- a/docs/tevpy/tools.rst
+++ b/docs/tevpy/tools.rst
@@ -3,7 +3,7 @@
 Command line tools
 ==================
 
-The following command line tools will be available after you install `tevpy`:
+The following command line tools will be available after you install `gammapy`:
 
 TODO: auto-generate the command line tool descriptions (include help output in docs)
 For now have a look in the `scripts` folder.

--- a/docs/tevpy/utils/index.rst
+++ b/docs/tevpy/utils/index.rst
@@ -1,27 +1,27 @@
 *********************************************
-Utility functions and classes (`tevpy.utils`)
+Utility functions and classes (`gammapy.utils`)
 *********************************************
 
 Introduction
 ============
 
-`tevpy.utils` is a collection of utility functions that are used in many places
+`gammapy.utils` is a collection of utility functions that are used in many places
 or don't fit in one of the other packages.
 
 Reference/API
 =============
 
-.. automodapi:: tevpy.utils.coordinates
+.. automodapi:: gammapy.utils.coordinates
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.utils.const
+.. automodapi:: gammapy.utils.const
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.utils.fits
+.. automodapi:: gammapy.utils.fits
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.utils.region
+.. automodapi:: gammapy.utils.region
     :no-inheritance-diagram:
 
-.. automodapi:: tevpy.utils.root
+.. automodapi:: gammapy.utils.root
     :no-inheritance-diagram:

--- a/examples/plot_rings.py
+++ b/examples/plot_rings.py
@@ -4,7 +4,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import ImageGrid
-from tevpy.background import ring
+from gammapy.background import ring
 
 
 def add_inner_title(ax, title, loc, size=None, **kwargs):

--- a/examples/sherpa/README.txt
+++ b/examples/sherpa/README.txt
@@ -15,4 +15,4 @@ Sherpa: http://cxc.cfa.harvard.edu/sherpa/
 TODO:
 - add unit tests
 - add documentation
-- integrate in astropy or tevpy
+- integrate in astropy or gammapy

--- a/examples/significance_study.ipynb
+++ b/examples/significance_study.ipynb
@@ -29,7 +29,7 @@
       "%pylab inline\n",
       "import matplotlib.pyplot as plt\n",
       "from scipy.stats import poisson\n",
-      "from tevpy import stats"
+      "from gammapy import stats"
      ],
      "language": "python",
      "metadata": {},

--- a/licenses/LICENSE.rst
+++ b/licenses/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011, tevpy Developers
+Copyright (c) 2011, gammapy Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/scripts/tev-cwt
+++ b/scripts/tev-cwt
@@ -44,7 +44,7 @@ if  os.path.isfile(args.outfile) and not args.clobber:
 
 # Execute script
 
-from tevpy.detect.cwt import CWT
+from gammapy.detect.cwt import CWT
 
 cwt = CWT(args.min_scale, args.nscales, args.scale_step)
 cwt.set_file(args.infile)

--- a/scripts/tev-detect
+++ b/scripts/tev-detect
@@ -15,7 +15,7 @@ args = vars(args)
 
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
-from tevpy import detect
+from gammapy import detect
 
 raise NotImplementedError
 # TODO: implement me

--- a/scripts/tev-find-runs
+++ b/scripts/tev-find-runs
@@ -4,7 +4,7 @@
 
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
-from tevpy.obs import RunList
+from gammapy.obs import RunList
 
 # Parse command line arguments
 

--- a/scripts/tev-image-decompose-a-trous
+++ b/scripts/tev-image-decompose-a-trous
@@ -39,7 +39,7 @@ args = vars(args)
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
 from astropy.io import fits
-from tevpy.image.utils import atrous_hdu
+from gammapy.image.utils import atrous_hdu
 
 logging.info('Reading {0}'.format(args['infile']))
 hdu = fits.open(args['infile'])[0]

--- a/scripts/tev-info
+++ b/scripts/tev-info
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Print various info on tevpy to the console"""
+"""Print various info on gammapy to the console"""
 
 # Parse command line arguments
 
 from astropy.utils.compat import argparse
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('--version', action='store_true',
-                    help='Print tevpy version number')
+                    help='Print gammapy version number')
 parser.add_argument('--tools', action='store_true',
                     help='Print available command line tools')
 args = parser.parse_args()
@@ -24,15 +24,15 @@ if len(sys.argv) <= 1:
     sys.exit(1)
 
 if args['version']:
-    from tevpy import version
-    print('\n*** tevpy version info ***\n')
+    from gammapy import version
+    print('\n*** gammapy version info ***\n')
     print('version: {0}'.format(version.version))
     print('release: {0}'.format(version.release))
     print('githash: {0}'.format(version.githash))
     print('')
 
 if args['tools']:
-    print('\n*** tevpy tools ***\n')
+    print('\n*** gammapy tools ***\n')
     # We assume all tools are installed in the same folder as this script
     # and their names start with "tev-".
     import os

--- a/scripts/tev-iterative-source-detect
+++ b/scripts/tev-iterative-source-detect
@@ -2,7 +2,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """An iterative multi-scale source detection method.
 """
-from tevpy.detect.iterfind import run_detection
+from gammapy.detect.iterfind import run_detection
 
 def parse_args():
     # Parse command line arguments

--- a/scripts/tev-look-up-map-values
+++ b/scripts/tev-look-up-map-values
@@ -27,8 +27,8 @@ args = vars(args)
 
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
-from tevpy.utils.fits import get_hdu
-from tevpy.image.utils import lookup
+from gammapy.utils.fits import get_hdu
+from gammapy.image.utils import lookup
 
 logging.debug('Reading {0}'.format(args['infile']))
 hdu = get_hdu(args['infile'])

--- a/scripts/tev-make-derived-maps
+++ b/scripts/tev-make-derived-maps
@@ -28,7 +28,7 @@ args = vars(args)
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
 from astropy.io import fits
-from tevpy.background import Maps
+from gammapy.background import Maps
 
 logging.info('Reading {0}'.format(args['infile']))
 hdus = fits.open(args['infile'])

--- a/scripts/tev-make-off-regions
+++ b/scripts/tev-make-off-regions
@@ -34,7 +34,7 @@ args = vars(args)
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
 from astropy.io import fits
-from tevpy.background import ReflectedRegionMaker
+from gammapy.background import ReflectedRegionMaker
 
 logging.info('Reading {0}'.format(args['exclusion']))
 exclusion = fits.open(args['exclusion'])[0]

--- a/scripts/tev-make-profile-maps
+++ b/scripts/tev-make-profile-maps
@@ -28,7 +28,7 @@ args = vars(args)
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
 from astropy.io import fits
-from tevpy.utils.fits import get_hdu
+from gammapy.utils.fits import get_hdu
 
 logging.info('Reading {0}'.format(args['infile']))
 hdu = get_hdu(args['infile'])
@@ -36,14 +36,14 @@ hdu = get_hdu(args['infile'])
 out_hdus = fits.HDUList()
 
 if args['make_coordinate_maps']:
-    from tevpy.utils.image import coordinates
+    from gammapy.utils.image import coordinates
     logging.info('Computing LON and LAT maps')
     lon, lat = coordinates(hdu)
     out_hdus.append(fits.ImageHDU(lon, hdu.header, 'LON'))
     out_hdus.append(fits.ImageHDU(lat, hdu.header, 'LAT'))
 
 if args['make_distance_map']:
-    from tevpy.utils.image import exclusion_distance
+    from gammapy.utils.image import exclusion_distance
     logging.info('Computing DIST map')
     dist = exclusion_distance(hdu.data)
     out_hdus.append(fits.ImageHDU(dist, hdu.header, 'DIST'))

--- a/scripts/tev-test
+++ b/scripts/tev-test
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Run tevpy unit tests"""
+"""Run gammapy unit tests"""
 
 # Parse command line arguments
 
@@ -16,5 +16,5 @@ args = vars(args)
 import logging
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s - %(message)s')
 
-import tevpy
-tevpy.test(args['package'], verbose=True)
+import gammapy
+gammapy.test(args['package'], verbose=True)

--- a/setup.py
+++ b/setup.py
@@ -33,16 +33,16 @@ from astropy.setup_helpers import (register_commands, adjust_compiler,
                                    get_debug_option)
 from astropy.version_helpers import get_git_devstr, generate_version_py
 
-import tevpy
+import gammapy
 
 # Set affiliated package-specific settings
-PACKAGENAME = 'tevpy'
+PACKAGENAME = 'gammapy'
 DESCRIPTION = 'TeV gamma-ray astronomy high-level data analysis Python package'
 LONG_DESCRIPTION = ''
 AUTHOR = 'Christoph Deil'
 AUTHOR_EMAIL = 'Deil.Christoph@gmail.com'
 LICENSE = 'BSD'
-URL = 'https://github.com/gammapy/tevpy'
+URL = 'https://github.com/gammapy/gammapy'
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 VERSION = '0.1'

--- a/tevpy/__init__.py
+++ b/tevpy/__init__.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""tevpy --- TeV gamma-ray astronomy high-level data analysis Python package
+"""gammapy --- TeV gamma-ray astronomy high-level data analysis Python package
 
-* Code: https://github.com/gammapy/tevpy
-* Docs: https://tevpy.readthedocs.org/
+* Code: https://github.com/gammapy/gammapy
+* Docs: https://gammapy.readthedocs.org/
 
 TODO: List sub-packages with one-line description here.
 """

--- a/tevpy/astro/tests/plot_pwn.py
+++ b/tevpy/astro/tests/plot_pwn.py
@@ -5,9 +5,9 @@ from ..pwn import PWN
 
 def plot_hoppe(pwn):
     import matplotlib.pyplot as plt
-    from tevpy.spectrum.models import PowerLaw
-    from tevpy.spectrum.inverse_compton import InverseCompton
-    from tevpy.spectrum.synchrotron import Synchrotron
+    from gammapy.spectrum.models import PowerLaw
+    from gammapy.spectrum.inverse_compton import InverseCompton
+    from gammapy.spectrum.synchrotron import Synchrotron
     plt.subplot(311)
     injection_spectrum = PowerLaw()
     pwn = PWN(T=1e3, B=10, E_c=1000, injection_type='constant')

--- a/tevpy/data/__init__.py
+++ b/tevpy/data/__init__.py
@@ -3,17 +3,17 @@
 
 Example how to load a dataset from file:
 
-    >>> from tevpy import data
+    >>> from gammapy import data
     >>> image = data.poisson_stats_image()
 
 To get a summary table of available datasets::
 
-    >>> from tevpy import data
+    >>> from gammapy import data
     >>> data.list_datasets()
 
 To download all datasets into a local cache::
 
-    >>> from tevpy import data
+    >>> from gammapy import data
     >>> data.download_datasets()
 """
 from astropy.utils.data import get_pkg_data_filename

--- a/tevpy/data/setup_package.py
+++ b/tevpy/data/setup_package.py
@@ -3,4 +3,4 @@
 def get_package_data():
     files = ['README.rst',
              'poisson_stats_image/*']
-    return {'tevpy.data': files}
+    return {'gammapy.data': files}

--- a/tevpy/data/tests/test_all.py
+++ b/tevpy/data/tests/test_all.py
@@ -6,7 +6,7 @@ from .. import poisson_stats_image
 
 
 def test_poisson_stats_image():
-    """Get the data file via the tevpy.data.poisson_stats_image function"""
+    """Get the data file via the gammapy.data.poisson_stats_image function"""
     data = poisson_stats_image()
     assert data.sum() == 40896
 

--- a/tevpy/detect/iterfind.py
+++ b/tevpy/detect/iterfind.py
@@ -18,7 +18,7 @@ TODO: tons of things, e.g.
       and info (e.g. sources_guess positions).
     * Add PSF convolution
 * Use TS maps with Gauss source morphology instead of tophat.
-* Make it more modular and more abstract; put in tevpy.detect
+* Make it more modular and more abstract; put in gammapy.detect
   - user should be able to plug-in their significance map computation?
   - support different source models?
   - Separate Iterator, SignificanceMapCalculator, Guesser, Fitter ...

--- a/tevpy/detect/setup_package.py
+++ b/tevpy/detect/setup_package.py
@@ -2,4 +2,4 @@
 
 def get_package_data():
     files = ['sex.cfg', 'sex.param']
-    return {'tevpy.detect': files}
+    return {'gammapy.detect': files}

--- a/tevpy/image/utils.py
+++ b/tevpy/image/utils.py
@@ -326,7 +326,7 @@ def process_image_pixels(images, kernel, out, pixel_function):
     
         def convolve(image, kernel):
             '''Convolve image with kernel'''
-            from tevpy.image.utils import process_image_pixels
+            from gammapy.image.utils import process_image_pixels
             images = dict(image=np.asanyarray(image))
             kernel = np.asanyarray(kernel)
             out = dict(image=np.empty_like(image))

--- a/tevpy/utils/coordinates/__init__.py
+++ b/tevpy/utils/coordinates/__init__.py
@@ -1,6 +1,6 @@
 """Astronomical coordinate calculation utility functions.
 
-Possibly this will be removed from tevpy when coordinates in astropy have
+Possibly this will be removed from gammapy when coordinates in astropy have
 matured a bit (e.g. support array operations).
 """
 from .celestial import *


### PR DESCRIPTION
I decided that `gammapy` is a better name than `tevpy` for this package, because many of the methods can be applied to HESS / CTA TeV data as well as Fermi TeV data.
