### PR TITLE
Switch Python 3.2 testing on travis-ci back on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
     - 2.6
     - 2.7
-    # - 3.2
+    - 3.2
     - 3.3
 
 env:
@@ -21,8 +21,8 @@ matrix:
           env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
         - python: 2.7
           env: ASTROPY_VERSION=stable NUMPY_VERSION=1.5.1 SETUP_CMD='test'
-        # - python: 3.2
-        #  env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
+        - python: 3.2
+          env: ASTROPY_VERSION=stable NUMPY_VERSION=1.6.2 SETUP_CMD='test'
         # numpy < 1.6 does not work on py 3.x
 
         # try latest developer version of astropy

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,8 @@ existing data formats and other tools.
 * Mailing list: http://groups.google.com/group/gammapy
 * Ohloh: https://www.ohloh.net/p/gammapy
 * License: BSD-3-Clause
-* Python: works with 2.6, 2.7 and 3.3+ (see tests on https://travis-ci.org/gammapy/gammapy/)
+* Operating system: Linux, Mac (Windows untested, no particular reason why it wouldn't work)
+* Python: works with 2.6, 2.7, 3.2 and 3.3  (see tests on https://travis-ci.org/gammapy/gammapy/)
 
 
 Using `gammapy`

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-`gammapy` works with Python 2 and Python 3 (specifically 2.6, 2.7 and 3.3 or later).
+`gammapy` works with Python 2 and Python 3 (specifically 2.6, 2.7, 3.2 and 3.3).
 
 To install the latest `gammapy` stable version the easiest way is using the `pip <http://www.pip-installer.org/>`_ installer::
 


### PR DESCRIPTION
(and state that it's supported in the docs)
