### PR TITLE
Fix in cube_to_image

### DIFF
--- a/gammapy/image/_old_utils.py
+++ b/gammapy/image/_old_utils.py
@@ -320,9 +320,9 @@ def cube_to_image(cube, slicepos=None):
     del header['CRPIX3']
     del header['CUNIT3']
     if slicepos == None:
-        data = cube.data[slicepos]
+        data = cube.data.sum()
     else:
-        data = cube.data.sum(0)
+        data = cube.data[slicepos]
     return fits.ImageHDU(data, header)
 
 


### PR DESCRIPTION
corrects error in cube_to_image - previously the outputs were the wrong way round on the if statement such that giving a slice position would not work and the output would be the image from the sum over cubes. Now the image at slicepos will be given.
