### PR TITLE
Add coverage reports to continuous integration on coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ gammapy/gammapy.cfg
 
 docs/_generated
 docs/api
+.coverage
 
 # Data files and images are usually generated
 *.png

--- a/gammapy/tests/coveragerc
+++ b/gammapy/tests/coveragerc
@@ -1,0 +1,26 @@
+[run]
+source = gammapy
+omit =
+   *tests*
+   *setup_package*
+   gammapy/version*
+   gammapy/extern/*
+   gammapy/conftest.py
+
+[report]
+exclude_lines =
+   # Have to re-enable the standard pragma
+   pragma: no cover
+
+   # Don't complain about packages we have installed
+   except ImportError
+
+   # Don't complain if tests don't hit assertions
+   raise AssertionError
+   raise NotImplementedError
+
+   # Don't complain about script hooks
+   def main\(.*\):
+
+   # Ignore branches that don't pertain to this version of Python
+   pragma: py{ignore_python_version}

--- a/gammapy/tests/setup_package.py
+++ b/gammapy/tests/setup_package.py
@@ -1,0 +1,2 @@
+def get_package_data():
+    return {'gammapy.tests': ['coveragerc']}


### PR DESCRIPTION
Set up automatic coverage reports via https://coveralls.io/ for `gammapy`
