### PR TITLE
Enable doctests for `python setup.py test`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ show-response = 1
 [pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
-#doctest_plus = enabled
+doctest_plus = enabled
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This is a continuation of #95 ... I didn't realise merging those commits manually into master would close that github issue. Copy of issue description in one of the comments there ...

---

I fixed most doctests ... what remains to be done is to configure the doctest runner to skip the following files:
- `gammapy/data/poisson_stats_image/fit_sherpa.py`
- `gammapy/data/poisson_stats_image/simulate_data.py`
- `gammapy/docs/background/estimate_significance_image.py`
- `gammapy/docs/tutorials/image/sherpa_fit_image.py`
- `docs//image/colormap_example.py`

The first four contain imports or non-functioning code and should not be executed.
The last one causes the tests to hang because a matplotlib figure pops up and has to be closed by hand.

I don't know how I can configure the test runner to skip these files entirely?

I currently have this in my `setup.cfg`:

```
[pytest]
minversion = 2.2
norecursedirs = build docs/_build
doctest_plus = enabled
```

I tried putting `__doctest_skip__ = ['*']` at the top of these files or adding their filenames `norecuredirs` list in `setup.cfg` ... but this doesn't work.
