### PR TITLE
Improve per-pixel solid angle functions

### DIFF
--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -209,3 +209,12 @@ def test_lon_lat_rectangle_mask():
                                         lon_max = None, lat_min = None,
                                         lat_max = None)
     assert_allclose(mask.sum(), 80601)
+
+
+def test_solid_angle():
+    from astropy.units import Quantity
+    nxpix, nypix, binsz = 50, 10, 0.1
+    image = utils.make_empty_image(nxpix=nxpix, nypix=nypix, binsz=binsz)
+    actual = utils.solid_angle(image, method='2').sum()
+    expected = Quantity(nxpix * nypix * binsz ** 2, 'deg^2').to('sr').value
+    assert_allclose(actual, expected, rtol=1e-4)

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -1,4 +1,4 @@
-gammapy/image/utils.py# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Image utility functions"""
 from __future__ import print_function, division
 import logging
@@ -645,11 +645,12 @@ def solid_angle(image, method='1'):
     wcs = WCS(image.header)
     lon, lat = wcs.wcs_pix2world(x_pix, y_pix, 0)
 
+    lon, lat = np.radians(lon), np.radians(lat)
     corners = []
-    corners.append(dict(lon=lon[:-1], lat=lat[:-1])) # Case: x-, y-
-    corners.append(dict(lon=lon[1:],  lat=lat[:-1])) # Case: x+, y-
-    corners.append(dict(lon=lon[1:],  lat=lat[1:]))  # Case: x+, y+
-    corners.append(dict(lon=lon[:-1], lat=lat[1:]))  # Case: x-, y+
+    corners.append(dict(lon=lon[ :-1,  :-1], lat=lat[ :-1,  :-1])) # Case: x-, y-
+    corners.append(dict(lon=lon[1:  ,  :-1], lat=lat[1:  ,  :-1])) # Case: x+, y-
+    corners.append(dict(lon=lon[1:  , 1:  ], lat=lat[1:  , 1:  ])) # Case: x+, y+
+    corners.append(dict(lon=lon[ :-1, 1:  ], lat=lat[ :-1, 1:  ])) # Case: x-, y+
 
     """
     TODO: this should be more efficient because spherical_to_cartesian
@@ -684,12 +685,43 @@ def make_header(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0,
 
     Parameters
     ----------
-    TODO
-
+    nxpix, nypix : int
+        Length of data axis (NAXIS1, NAXIS2)
+    binsz : float
+        Pixel size (CDELT1, CDELT2)
+    xref, yref : float
+        Value at ref. pixel (CRVAL1, CRVAL2) 
+    proj : str
+        Type of co-ordinate projection (CTYPE1, CTYPE2)
+    coordsys : str
+        Type of co-ordinate system (CTYPE1, CTYPE2)
+    xrefpix, yrefpix : float or None
+        Reference pixel on axis (CRPIX1, CRPIX2)
+        Computed as the center pixel if `None` is given.
+    
     Returns
     -------
-    header : `~astropy.io.fits.Header`
+    header : `astropy.io.fits.Header`
         Header
+    
+    Examples
+    --------
+    >>> from gammapy.image import make_header
+    >>> header = make_header()
+    >>> print(repr(header))
+    NAXIS   =                    2                                                  
+    NAXIS1  =                  100                                                  
+    NAXIS2  =                  100                                                  
+    CTYPE1  = 'GLON-CAR'                                                            
+    CTYPE2  = 'GLAT-CAR'                                                            
+    CRVAL1  =                    0                                                  
+    CRVAL2  =                    0                                                  
+    CRPIX1  =                 50.5                                                  
+    CRPIX2  =                 50.5                                                  
+    CDELT1  =                 -0.1                                                  
+    CDELT2  =                  0.1                                                  
+    CUNIT1  = 'deg     '                                                            
+    CUNIT2  = 'deg     '                                                            
     """
     nxpix = int(nxpix)
     nypix = int(nypix)
@@ -705,15 +737,21 @@ def make_header(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0,
     else:
         raise Exception('Unsupported coordsys: {0}'.format(proj))
 
-    pars = {'NAXIS': 2, 'NAXIS1': nxpix, 'NAXIS2': nypix,
-            'CTYPE1': ctype1 + proj,
-            'CRVAL1': xref, 'CRPIX1': xrefpix, 'CUNIT1': 'deg', 'CDELT1': -binsz,
-            'CTYPE2': ctype2 + proj,
-            'CRVAL2': yref, 'CRPIX2': yrefpix, 'CUNIT2': 'deg', 'CDELT2': binsz,
-            }
-
     header = fits.Header()
-    header.update(pars)
+
+    header['NAXIS'] = 2
+    header['NAXIS1'] = nxpix
+    header['NAXIS2'] = nypix
+    header['CTYPE1'] = ctype1 + proj
+    header['CTYPE2'] = ctype2 + proj
+    header['CRVAL1'] = xref
+    header['CRVAL2'] = yref
+    header['CRPIX1'] = xrefpix
+    header['CRPIX2'] = yrefpix
+    header['CDELT1'] = -binsz
+    header['CDELT2'] = binsz
+    header['CUNIT1'] = 'deg'
+    header['CUNIT2'] = 'deg'
 
     return header
 
@@ -735,6 +773,7 @@ def make_empty_image(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0, fill=0,
         Data type, default is float32
     fill : float or 'checkerboard'
         Creates checkerboard image or uniform image of any float
+
     Returns
     -------
     image : `~astropy.io.fits.ImageHDU`
@@ -743,7 +782,6 @@ def make_empty_image(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0, fill=0,
     header = make_header(nxpix, nypix, binsz, xref, yref,
                          proj, coordsys, xrefpix, yrefpix)
 
-    # Note that FITS and NumPy axis order are reversed
     shape = (header['NAXIS2'], header['NAXIS1'])
     if fill == 'checkerboard':
         A = np.zeros(shape, dtype=dtype)

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -1,4 +1,4 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+gammapy/image/utils.py# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Image utility functions"""
 from __future__ import print_function, division
 import logging
@@ -617,33 +617,59 @@ def binary_opening_circle(input, radius):
     return binary_opening(input, structure)
 
 
-def solid_angle(image):
+def solid_angle(image, method='1'):
     """Compute the solid angle of each pixel.
 
-    This will only give correct results for CAR maps!
+    Estimates solid angles of pixels using the Girard equation for excess area
+    Reference: http://mathworld.wolfram.com/SphericalPolygon.html
+    See GWcs::solidangle in GammaLib
 
     Parameters
     ----------
     image : `~astropy.io.fits.ImageHDU`
         Input image
+    method : {'1', '2'}
+        Method to compute the solid angle
 
     Returns
     -------
     area_image : `~astropy.units.Quantity`
         Solid angle image (matching the input image) in steradians.
     """
-    # Area of one pixel at the equator
-    cdelt0 = image.header['CDELT1']
-    cdelt1 = image.header['CDELT2']
-    equator_area = Quantity(abs(cdelt0 * cdelt1), 'sr')
+    from astropy.wcs import WCS
+    from ..utils.coordinates import pixel_solid_angle
 
-    # Compute image with fraction of pixel area at equator
-    glat = coordinates(image)[1]
-    area_fraction = np.cos(np.radians(glat))
+    # Compute pixel corner coordinates
+    shape = np.array(image.data.shape) + np.array([1, 1])
+    y_pix, x_pix = np.indices(shape, dtype=np.float64)    
+    wcs = WCS(image.header)
+    lon, lat = wcs.wcs_pix2world(x_pix, y_pix, 0)
 
-    result = area_fraction * equator_area
+    corners = []
+    corners.append(dict(lon=lon[:-1], lat=lat[:-1])) # Case: x-, y-
+    corners.append(dict(lon=lon[1:],  lat=lat[:-1])) # Case: x+, y-
+    corners.append(dict(lon=lon[1:],  lat=lat[1:]))  # Case: x+, y+
+    corners.append(dict(lon=lon[:-1], lat=lat[1:]))  # Case: x-, y+
 
-    return result
+    """
+    TODO: this should be more efficient because spherical_to_cartesian
+          is called on fewer points.
+    if method == 'vector':
+        from astropy.coordinates import spherical_to_cartesian
+        x, y , z = spherical_to_cartesian(1, lon, lat)
+        corners.append(dict(lon=lon[:-1], lat=lat[:-1])) # Case: x-, y-
+        corners.append(dict(lon=lon[1:],  lat=lat[:-1])) # Case: x+, y-
+        corners.append(dict(lon=lon[1:],  lat=lat[1:]))  # Case: x+, y+
+        corners.append(dict(lon=lon[:-1], lat=lat[1:]))  # Case: x-, y+
+        
+    elif method == 'triangle':
+        corners.append(dict(lon=lon[:-1], lat=lat[:-1])) # Case: x-, y-
+        corners.append(dict(lon=lon[1:],  lat=lat[:-1])) # Case: x+, y-
+        corners.append(dict(lon=lon[1:],  lat=lat[1:]))  # Case: x+, y+
+        corners.append(dict(lon=lon[:-1], lat=lat[1:]))  # Case: x-, y+
+    """
+
+    return pixel_solid_angle(corners, method=method)
 
 
 def make_header(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0,

--- a/gammapy/utils/coordinates/__init__.py
+++ b/gammapy/utils/coordinates/__init__.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Astronomical coordinate calculation utility functions.
 """
 from .celestial import *

--- a/gammapy/utils/coordinates/__init__.py
+++ b/gammapy/utils/coordinates/__init__.py
@@ -2,3 +2,4 @@
 """
 from .celestial import *
 from .other import *
+from .spherical import *

--- a/gammapy/utils/coordinates/celestial.py
+++ b/gammapy/utils/coordinates/celestial.py
@@ -3,7 +3,7 @@
 """
 from __future__ import print_function, division
 import numpy as np
-from numpy import (cos, sin, arccos, arcsin,
+from numpy import (cos, sin, arcsin,
                    arctan2, radians, degrees, pi)
 
 __all__ = ['galactic_to_radec', 'radec_to_galactic',

--- a/gammapy/utils/coordinates/spherical.py
+++ b/gammapy/utils/coordinates/spherical.py
@@ -5,7 +5,8 @@ from __future__ import print_function, division
 import numpy as np
 from numpy import (cos, sin, arccos, radians, degrees)
 
-__all__ = ['separation', 'minimum_separation', 'pair_correlation']
+__all__ = ['separation', 'minimum_separation', 'pair_correlation',
+           'pixel_solid_angle']
 
 
 def separation(lon1, lat1, lon2, lat2, unit='deg'):
@@ -87,7 +88,6 @@ def pair_correlation(lon, lat, theta_bins, unit='deg'):
         Array of point separations per `theta` bin.
     """
     # TODO: Implement speedups:
-    # - use radians
     # - avoid processing each pair twice (distance a to b and b to a)
     counts = np.zeros(shape=len(theta_bins) - 1, dtype=int)
     # If there are many points this should have acceptable performance
@@ -98,3 +98,107 @@ def pair_correlation(lon, lat, theta_bins, unit='deg'):
         counts += hist
 
     return counts
+
+
+def pixel_solid_angle(corners, method='vector'):
+    """Pixel solid angle on the sphere.
+
+    Parameters
+    ----------
+    corners : list
+        List of dict with `lon` and `lat` keys and array-like values.
+     method : {'1', '2'}
+        Method to compute the solid angle
+
+    Returns
+    -------
+    solid_angle : `numpy.array`
+        Per-pixel solid angle image in steradians
+        
+    See also
+    --------
+    `image.utils.solid_angle`
+    """
+    if method == '1':
+        return _pixel_solid_angle_1(corners)
+    elif method == '2':
+        return _pixel_solid_angle_2(corners)
+    else:
+        raise ValueError('Unknown method: {0}'.format(method))
+
+
+def _pixel_solid_angle_1(corners):
+    """Compute pixel solid angle using 3D cartesian vectors.
+    
+    And Girard's theorem:
+    http://mathworld.wolfram.com/GirardsSphericalExcessFormula.html
+    
+    Reference: http://mail.scipy.org/pipermail/astropy/2013-December/002940.html
+    """
+    from astropy.coordinates import spherical_to_cartesian
+    
+    vec = []
+    for corner in corners:
+        x, y, z = spherical_to_cartesian(1, corner['lon'], corner['lat'])
+        vec.append(dict(x=x, y=y, z=z))
+
+    angles = []
+    N = 4
+    for i in range(N):
+        A = vec[(i + 1) % N]
+        B = vec[(i + 2) % N]
+        C = vec[(i + 3) % N]
+        vec_a = np.cross(A, (np.cross(A, B)))
+        vec_b = np.cross(B, (np.cross(C, B)))
+        angle = np.arccos(np.dot(vec_a, vec_b))
+        angles.append(angle)
+
+    # Use Girard equation for excess area to determine solid angle
+    solid_angle = np.sum(angles) - 2 * np.pi
+
+    return solid_angle    
+
+
+def _pixel_solid_angle_2(corners):
+    """Compute pixel solid angle using spherical polygon area formulas.
+    
+    And Girard's theorem:
+    http://mathworld.wolfram.com/GirardsSphericalExcessFormula.html
+    
+    TODO: possible to replace duplicated code with array expression or loop?
+    """
+    from astropy.coordinates.angle_utilities import angular_separation
+
+    # Compute angular distances between corners
+    def dist(i, j):
+        return angular_separation(corners[i-1]['lon'], corners[i-1]['lat'],
+                                  corners[j-1]['lon'], corners[j-1]['lat'])
+    a12 = dist(1, 2)
+    a14 = dist(1, 4)
+    a23 = dist(2, 3)
+    a34 = dist(3, 4)
+    a13 = dist(1, 3)
+    a24 = dist(2, 4)
+    
+    # Compute sines and cosines of the corner distance angles
+    sin_a12 = np.sin(a12)
+    sin_a14 = np.sin(a14)
+    sin_a23 = np.sin(a23)
+    sin_a34 = np.sin(a34)
+    cos_a12 = np.cos(a12)
+    cos_a13 = np.cos(a13)
+    cos_a14 = np.cos(a14)
+    cos_a23 = np.cos(a23)
+    cos_a24 = np.cos(a24)
+    cos_a34 = np.cos(a34)
+
+    # Compute inner angles
+    angle1 = np.arccos((cos_a13 - cos_a34 * cos_a14) / (sin_a34 * sin_a14))
+    angle2 = np.arccos((cos_a24 - cos_a23 * cos_a34) / (sin_a23 * sin_a34))
+    angle3 = np.arccos((cos_a13 - cos_a12 * cos_a23) / (sin_a12 * sin_a23))
+    angle4 = np.arccos((cos_a24 - cos_a14 * cos_a12) / (sin_a14 * sin_a12))
+
+    # Use Girard equation for excess area to determine solid angle
+    solid_angle = (angle1 + angle2 + angle3 + angle4) - 2 * np.pi
+    
+    return solid_angle

--- a/gammapy/utils/coordinates/spherical.py
+++ b/gammapy/utils/coordinates/spherical.py
@@ -1,0 +1,100 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Spherical coordinate utility functions.
+"""
+from __future__ import print_function, division
+import numpy as np
+from numpy import (cos, sin, arccos, radians, degrees)
+
+__all__ = ['separation', 'minimum_separation', 'pair_correlation']
+
+
+def separation(lon1, lat1, lon2, lat2, unit='deg'):
+    """Angular separation between points on the sphere.
+    
+    Parameters
+    ----------
+    lon1, lat1, lon2, lat2 : array_like
+        Coordinates of the two points
+    unit : {'deg', 'rad'}
+        Units of input and output coordinates
+
+    Returns
+    -------
+    separation : array_like
+        Angular separation
+    """
+    if unit == 'deg':
+        lon1, lat1, lon2, lat2 = map(radians, (lon1, lat1, lon2, lat2))
+
+    term1 = cos(lat1) * cos(lon1) * cos(lat2) * cos(lon2)
+    term2 = cos(lat1) * sin(lon1) * cos(lat2) * sin(lon2)
+    term3 = sin(lat1) * sin(lat2)
+    mu = term1 + term2 + term3
+    separation = arccos(mu)
+    
+    if unit == 'deg':
+        separation = degrees(separation)
+
+    return separation
+
+
+def minimum_separation(lon1, lat1, lon2, lat2, unit='deg'):
+    """Compute minimum distance of each (lon1, lat1) to any (lon2, lat2).
+
+    Parameters
+    ----------
+    lon1, lat1 : array_like
+        Primary coordinates of interest
+    lon2, lat2 : array_like
+        Counterpart coordinate array
+    unit : {'deg', 'rad'}
+        Units of input and output coordinates
+
+    Returns
+    -------
+    theta_min : array
+        Minimum distance
+    """
+    lon1 = np.asanyarray(lon1)
+    lat1 = np.asanyarray(lat1)
+    
+    theta_min = np.empty_like(lon1, dtype=np.float64)
+
+    for i1 in range(lon1.size):
+        thetas = separation(lon1[i1], lat1[i1],
+                            lon2, lat2, unit=unit)
+        theta_min[i1] = thetas.min()
+
+    return theta_min
+
+
+def pair_correlation(lon, lat, theta_bins, unit='deg'):
+    """Compute pair correlation function for points on the sphere.
+    
+    Parameters
+    ----------
+    lon, lat : array_like
+        Coordinate arrays
+    theta_bins : array_like
+        Array defining the `theta` binning.
+        `theta` is the angular offset between positions.
+    unit : {'deg', 'rad'}
+        Units of input and output coordinates
+
+    Returns
+    -------
+    counts : array
+        Array of point separations per `theta` bin.
+    """
+    # TODO: Implement speedups:
+    # - use radians
+    # - avoid processing each pair twice (distance a to b and b to a)
+    counts = np.zeros(shape=len(theta_bins) - 1, dtype=int)
+    # If there are many points this should have acceptable performance
+    # because the inner loop is in np.histogram, not in Python
+    for ii in range(len(lon)):
+        theta = separation(lon[ii], lat[ii], lon, lat, unit=unit)
+        hist = np.histogram(theta, theta_bins)[0]
+        counts += hist
+
+    return counts

--- a/gammapy/utils/coordinates/spherical.py
+++ b/gammapy/utils/coordinates/spherical.py
@@ -100,14 +100,14 @@ def pair_correlation(lon, lat, theta_bins, unit='deg'):
     return counts
 
 
-def pixel_solid_angle(corners, method='vector'):
+def pixel_solid_angle(corners, method='1'):
     """Pixel solid angle on the sphere.
 
     Parameters
     ----------
     corners : list
-        List of dict with `lon` and `lat` keys and array-like values.
-     method : {'1', '2'}
+            List of dict with `lon` and `lat` keys and array-like values.
+    method : {'1', '2'}
         Method to compute the solid angle
 
     Returns
@@ -117,7 +117,7 @@ def pixel_solid_angle(corners, method='vector'):
         
     See also
     --------
-    `image.utils.solid_angle`
+    image.utils.solid_angle
     """
     if method == '1':
         return _pixel_solid_angle_1(corners)
@@ -179,6 +179,9 @@ def _pixel_solid_angle_2(corners):
     a34 = dist(3, 4)
     a13 = dist(1, 3)
     a24 = dist(2, 4)
+    #for i in range(4):
+    #    print(corners[i]['lon'][0, 0], corners[i]['lat'][0, 0])
+    #print(a12.shape, a12[0, 0])
     
     # Compute sines and cosines of the corner distance angles
     sin_a12 = np.sin(a12)

--- a/gammapy/utils/coordinates/tests/test_spherical.py
+++ b/gammapy/utils/coordinates/tests/test_spherical.py
@@ -22,3 +22,13 @@ def test_minimum_separation():
 
 def test_pair_correlation():
     pass
+
+
+def test_pixel_solid_angle():
+    corners = []
+    corners.append(dict(lon=0, lat=0))
+    corners.append(dict(lon=1, lat=0))
+    corners.append(dict(lon=1, lat=1))
+    corners.append(dict(lon=0, lat=1))
+    solid_angle = spherical.pixel_solid_angle(corners, method='2')
+    assert_allclose(solid_angle, 0.8617784049059853)

--- a/gammapy/utils/coordinates/tests/test_spherical.py
+++ b/gammapy/utils/coordinates/tests/test_spherical.py
@@ -1,0 +1,24 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import print_function, division
+import numpy as np
+from numpy.testing import assert_allclose
+from .. import spherical
+
+def test_separation():
+    assert_allclose(spherical.separation(0, 0, 180, 0), 180)
+    assert_allclose(spherical.separation(270, 0, 180, 0), 90)
+    assert_allclose(spherical.separation(0, 0, 0, 90), 90)
+    assert_allclose(spherical.separation(0, 89, 180, 89), 2)
+
+
+def test_minimum_separation():
+    lon1 = [0, 1, 1]
+    lat1 = [0, 0, 1]
+    lon2 = [1, 1]
+    lat2 = [0, 0.5]
+    separation = spherical.minimum_separation(lon1, lat1, lon2, lat2)
+    assert_allclose(separation, [1, 0, 0.5])
+
+
+def test_pair_correlation():
+    pass

--- a/gammapy/utils/distributions/__init__.py
+++ b/gammapy/utils/distributions/__init__.py
@@ -1,5 +1,7 @@
-"""Utility functions / classes for working with distributions
-(e.g. probability density functions)
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Utility functions / classes for working with distributions.
+
+For example probability density functions.
 """
 from .general_random import *
 from .general_random_array import *

--- a/gammapy/utils/distributions/general_random.py
+++ b/gammapy/utils/distributions/general_random.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 import numpy as np
 from astropy.extern.six.moves import range

--- a/gammapy/utils/distributions/general_random_array.py
+++ b/gammapy/utils/distributions/general_random_array.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Implementation of the GeneralRandomArray class"""
 from __future__ import print_function, division
 import numpy as np

--- a/gammapy/utils/distributions/tests/test_general_random.py
+++ b/gammapy/utils/distributions/tests/test_general_random.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 import numpy as np
 from astropy.tests.helper import pytest

--- a/gammapy/utils/distributions/tests/test_general_random_array.py
+++ b/gammapy/utils/distributions/tests/test_general_random_array.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 import numpy as np
 from ..general_random_array import GeneralRandomArray

--- a/gammapy/utils/distributions/utils.py
+++ b/gammapy/utils/distributions/utils.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Helper functions to work with distributions."""
 from __future__ import print_function, division
 


### PR DESCRIPTION
Add several methods (with precision / speed tradeoffs) to compute per-pixel solid angle images.
This should probably be added to [imageutils](https://github.com/astropy/imageutils) and then only used in various places in Gammapy.

Methods:
1. Differential: Assume WCS transformation is linear within the pixel. Compute Jacobian numerically using finite differences using dx and dy (at the pixel corner or center)
2. Great circles: Assume pixel edges are great circles and use 4-corner polygon area formula.

In both of these methods the accuracy can be increased by sub-dividing the pixel into N x N smaller pixels and summing their solid angle.

Tests: use a variety of projections and check near the edges / poles.

Codes:
* [SpectralCube._pix_size](https://github.com/radio-astro-tools/spectral-cube/blob/31b45f13a358cf7b045ac9f1c8cba34d01a5eb62/spectral_cube/spectral_cube.py#L694) for a nice method / implementation.
* [SphericalPolygon.area](http://spacetelescope.github.io/sphere/api/spherical_geometry.polygon.SphericalPolygon.html#spherical_geometry.polygon.SphericalPolygon.area) and maybe profile it.

Probably the spherical polygon method (using Girard's theorem) is slow and numerically unstable for very small pixels (e.g. optical or X-ray images).

Tasks:

- [ ] Implement methods
- [ ] Add basic tests
- [ ] Add precision tests (including very large and small pixels and a few projections / regions)
- [ ] Add speed benchmarks