### PR TITLE
Fix name conflict gauss2d / Gauss2D in Sphinx build

### DIFF
--- a/gammapy/morphology/gauss.py
+++ b/gammapy/morphology/gauss.py
@@ -4,12 +4,15 @@ from copy import deepcopy
 import numpy as np
 from numpy import pi, exp, sqrt, log
 
-__all__ = ['Gauss2D', 'MultiGauss2D', 'gaussian_sum_moments']
+__all__ = ['Gauss2DPDF',
+           'MultiGauss2D',
+           'gaussian_sum_moments'
+           ]
 
 __doctest_requires__ = {('gaussian_sum_moments'): ['uncertainties']}
 
 
-class Gauss2D(object):
+class Gauss2DPDF(object):
     """2D symmetric Gaussian PDF.
 
     Parameters
@@ -76,7 +79,7 @@ class MultiGauss2D(object):
     def __init__(self, sigmas, norms=None):
         # If no norms are given, you have a PDF.
         sigmas = np.asarray(sigmas, 'f')
-        self.components = [Gauss2D(sigma) for sigma in sigmas]
+        self.components = [Gauss2DPDF(sigma) for sigma in sigmas]
         if norms is None:
             self.norms = np.ones(len(self.components))
         else:
@@ -178,7 +181,7 @@ class MultiGauss2D(object):
         approximates this one, such that theta matches for a given
         containment."""
         theta1 = self.containment_radius(containment_fraction)
-        theta2 = Gauss2D(sigma=1).containment_radius(containment_fraction)
+        theta2 = Gauss2DPDF(sigma=1).containment_radius(containment_fraction)
         return theta1 / theta2
 
     def convolve(self, sigma, norm=1):

--- a/gammapy/morphology/psf.py
+++ b/gammapy/morphology/psf.py
@@ -20,13 +20,17 @@ import numpy as np
 from numpy import log, exp
 from astropy.convolution import Gaussian2DKernel
 from .utils import read_json
-from .gauss import Gauss2D, MultiGauss2D
+from .gauss import Gauss2DPDF, MultiGauss2D
 from ..utils.const import sigma_to_fwhm, fwhm_to_sigma
 
-__all__ = ['GaussPSF', 'HESS', 'Sherpa', 'multi_gauss_psf_kernel']
+__all__ = ['GaussPSF',
+           'HESSMultiGaussPSF',
+           'SherpaMultiGaussPSF',
+           'multi_gauss_psf_kernel'
+           ]
 
 
-class GaussPSF(Gauss2D):
+class GaussPSF(Gauss2DPDF):
     """Extension of Gauss2D PDF by PSF-specific functionality."""
 
     def to_hess(self):
@@ -41,13 +45,14 @@ class GaussPSF(Gauss2D):
         return {'psf1': d}
 
 
-class Sherpa(object):
+class SherpaMultiGaussPSF(object):
     """Multi-Gauss PSF as represented in the Sherpa software.
 
     Note that Sherpa uses the following function
     f(x,y) = f(r) = A exp[-f(r/F)^2]
     f = 2.7725887 = 4log2 relates the full-width
-    at half-maximum F to the Gaussian sigma."""
+    at half-maximum F to the Gaussian sigma
+    """
     def __init__(self, source):
         if isinstance(source, dict):
             # Assume source is a dict with correct format
@@ -121,7 +126,7 @@ class Sherpa(object):
         return fraction
 
 
-class HESS(object):
+class HESSMultiGaussPSF(object):
     """Multi-Gauss PSF as represented in the HESS software.
 
     The 2D Gaussian is represented as a 1D exponential

--- a/gammapy/morphology/tests/plot_psf_distributions.py
+++ b/gammapy/morphology/tests/plot_psf_distributions.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 import numpy as np
-from ..gauss import Gauss2D, MultiGauss2D
-from ..psf import HESS
+from ..gauss import Gauss2DPDF, MultiGauss2D
+from ..psf import HESSMultiGaussPSF
 
 
 def make_theta(theta_max=5, n_bins=100):
@@ -14,7 +14,7 @@ def make_theta(theta_max=5, n_bins=100):
 def plot_theta_distributions():
     import matplotlib.pyplot as plt
     theta, theta2 = make_theta()
-    g = Gauss2D(sigma=1)
+    g = Gauss2DPDF(sigma=1)
     m = MultiGauss2D(sigmas=[1, 3], norms=[0.5, 0.5])
     plt.figure(figsize=(15, 8))
     for ylog in [0, 1]:
@@ -45,7 +45,7 @@ def plot_theta_distributions():
 
 def plot_convolution():
     import matplotlib.pyplot as plt
-    g = Gauss2D(sigma=1)
+    g = Gauss2DPDF(sigma=1)
     sigma = np.linspace(0, 5, 100)
     r80 = g.convolve(sigma).theta(0.68)
     plt.figure()
@@ -57,8 +57,8 @@ def plot_convolution():
 
 def plot_HESS_PSF_convolution(containment=0.8):
     import matplotlib.pyplot as plt
-    m = HESS('input/gc_psf.txt').to_MultiGauss2D(normalize=True)
-    m_approx = Gauss2D(m.match_sigma(containment))
+    m = HESSMultiGaussPSF('input/gc_psf.txt').to_MultiGauss2D(normalize=True)
+    m_approx = Gauss2DPDF(m.match_sigma(containment))
     print('HESS PSF approx sigma = {0}'.format(m_approx.sigma))
     # 0.047 for containment 0.8
     # 0.055 for containment 0.9
@@ -75,6 +75,7 @@ def plot_HESS_PSF_convolution(containment=0.8):
     plt.xlabel('sigma')
     plt.ylabel('r%s' % (100 * containment))
     plt.savefig('output/plot_HESS_PSF_convolution.pdf')
+
 
 if __name__ == '__main__':
     # plot_theta_distributions()

--- a/gammapy/morphology/tests/test_gauss.py
+++ b/gammapy/morphology/tests/test_gauss.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing.utils import assert_allclose
 from numpy.testing import assert_equal, assert_almost_equal
 
-from ..gauss import Gauss2D, MultiGauss2D, gaussian_sum_moments
+from ..gauss import Gauss2DPDF, MultiGauss2D, gaussian_sum_moments
 
 try:
     import scipy
@@ -22,11 +22,11 @@ except ImportError:
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-class TestGauss2D(unittest.TestCase):
+class TestGauss2DPDF(unittest.TestCase):
     """Note that we test __call__ and dpdtheta2 by
     checking that their integrals as advertised are 1."""
     def setUp(self):
-        self.gs = [Gauss2D(0.1), Gauss2D(1), Gauss2D(1)]
+        self.gs = [Gauss2DPDF(0.1), Gauss2DPDF(1), Gauss2DPDF(1)]
 
     def test_call(self):
         from scipy.integrate import dblquad
@@ -60,7 +60,7 @@ class TestGauss2D(unittest.TestCase):
             assert_almost_equal(g.containment_radius(0.95), g.sigma * 2.4477467332775422)
 
     def test_convolve(self):
-        g = Gauss2D(sigma=3).convolve(sigma=4)
+        g = Gauss2DPDF(sigma=3).convolve(sigma=4)
         assert_equal(g.sigma, 5)
 
 
@@ -90,7 +90,7 @@ class TestMultiGauss2D(unittest.TestCase):
         assert_equal(m.integral, 1)
 
     def test_containment(self):
-        g, g2 = Gauss2D(sigma=1), Gauss2D(sigma=2)
+        g, g2 = Gauss2DPDF(sigma=1), Gauss2DPDF(sigma=2)
         m = MultiGauss2D(sigmas=[1])
         m2 = MultiGauss2D(sigmas=[1, 2], norms=[3, 4])
         for theta in [0, 0.1, 1, 5]:

--- a/gammapy/morphology/tests/test_psf.py
+++ b/gammapy/morphology/tests/test_psf.py
@@ -5,7 +5,7 @@ from astropy.tests.helper import pytest
 from numpy.testing import assert_almost_equal, assert_allclose
 import numpy as np
 from astropy.utils.data import get_pkg_data_filename
-from ..psf import HESS, multi_gauss_psf_kernel
+from ..psf import HESSMultiGaussPSF, multi_gauss_psf_kernel
 
 try:
     import scipy
@@ -35,7 +35,7 @@ class TestHESS(unittest.TestCase):
         of the events.
         """
         filename = get_pkg_data_filename('data/psf.txt')
-        hess = HESS(filename)
+        hess = HESSMultiGaussPSF(filename)
         m = hess.to_MultiGauss2D(normalize=False)
         if 0:
             print('integral:', m.integral)
@@ -65,7 +65,7 @@ class TestHESS(unittest.TestCase):
                 (40, 0.0379536),
                 (80, 0.088608)]
         filename = get_pkg_data_filename('data/psf.txt')
-        hess = HESS(filename)
+        hess = HESSMultiGaussPSF(filename)
         m = hess.to_MultiGauss2D()
         assert_almost_equal(m.integral, 1)
         for containment, theta in vals:

--- a/gammapy/morphology/tests/test_theta.py
+++ b/gammapy/morphology/tests/test_theta.py
@@ -19,7 +19,7 @@ class TestThetaCalculator(unittest.TestCase):
     solutions for theta and containment."""
     def setUp(self):
         # Single Gauss
-        self.g = gauss.Gauss2D(sigma=1)
+        self.g = gauss.Gauss2DPDF(sigma=1)
         self.g_tc = theta.ThetaCalculator(self.g.dpdtheta2, theta_max=5, n_bins=1e6)
         self.g_tcs = theta.ThetaCalculatorScipy(self.g.dpdtheta2, theta_max=5)
         # Multi Gauss
@@ -60,10 +60,9 @@ class TestThetaCalculator(unittest.TestCase):
 def _test_ModelThetaCalculator():
     """Check that Gaussian widths add in quadrature
     i.e. sigma_psf = 3, sigma_source = 4 ===> sigma_model = 5"""
-    from morphology.gauss import Gauss2D
-    source, psf = Gauss2D(3), Gauss2D(4)
+    source, psf = gauss.Gauss2DPDF(3), gauss.Gauss2DPDF(4)
     # Correct analytical reference
-    ana = Gauss2D(5)
+    ana = gauss.Gauss2DPDF(5)
     ana_angle = ana.containment_radius(0.5)
     ana_containment = ana.containment(ana_angle)
     # Numerical method


### PR DESCRIPTION
Now that https://github.com/astropy/astropy/pull/1826 is merged I get an error because in `gammapy.morphology` I have a `gauss2d` function and a `Gauss2D` class:

```
/Users/deil/code/gammapy/docs/morphology/index.rst:30: WARNING: toctree references unknown document u'api/gammapy.morphology.gauss2d'
None:None: WARNING: toctree contains reference to nonexisting document u'api/gammapy.morphology.gauss2d'
<autosummary>:None: WARNING: toctree contains reference to nonexisting document u'api/gammapy.morphology.gauss2d'
```

The `docs/api/gammapy.morphology.gauss2d.rst` file is no longer generated:

```
$ ls -1 docs/api/gammapy.morphology.*2*
docs/api/gammapy.morphology.Gauss2D.rst
docs/api/gammapy.morphology.MultiGauss2D.rst
docs/api/gammapy.morphology.ThetaCalculator2D.rst
docs/api/gammapy.morphology.delta2d.rst
docs/api/gammapy.morphology.shell2d.rst
docs/api/gammapy.morphology.sphere2d.rst
```

CC @kbarbary @eteq @astrofrog Can you fix this?
