### PR TITLE
Closed: test issue with Astropy wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,8 @@ install:
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "Cython==0.19.1"; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "pytest==2.5.1"; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_WHEEL_COMMAND "pytest-xdist==1.10"; fi
-    - if [[ $ASTROPY_VERSION == stable ]]; then $PIP_WHEEL_COMMAND "astropy"; fi
+    - if [[ $ASTROPY_VERSION == stable && $USE_HUBS == true ]]; then $PIP_WHEEL_STRICT_NUMPY --find-links=$WHEELHOUSE_SPOKE --upgrade --force-reinstall astropy; fi
+    - if [[ $ASTROPY_VERSION == stable && $USE_HUBS == false ]]; then $PIP_WHEEL_COMMAND "astropy"; fi
     - if [[ $ASTROPY_VERSION == development ]]; then pip -q install git+http://github.com/astropy/astropy.git#egg=astropy --use-mirrors; fi
 
     # OPTIONAL DEPENDENCIES


### PR DESCRIPTION
The failure reported in astropy/package-template#37 was thought to be because the astropy wheel was built against a different version of numpy than the numpy wheel used on travis.

The solution in astropy/package-template#44 addresses that by building astropy and scipy wheels for each version of numpy.

This PR is an easy way to see if that solution actually fixes this problem.
