### PR TITLE
Fix exposure cube test on Python 2.6

### DIFF
--- a/gammapy/datasets/tests/test_load.py
+++ b/gammapy/datasets/tests/test_load.py
@@ -52,8 +52,6 @@ class TestFermiGalacticCenter():
         assert diffuse_model.data.shape == (30, 21, 61)
         assert_quantity(diffuse_model.energy[0], Quantity(50, 'MeV'))
 
-    # temporarily disable test ... weird fail in astropy.io.fits for Python 2.6 only
-    @pytest.mark.xfail
     def test_exposure_cube(self):
         exposure_cube = FermiGalacticCenter.exposure_cube()
         assert exposure_cube.data.shape == (21, 11, 31)


### PR DESCRIPTION
I see this error from `astropy.io.fits` with Python 2.6 :
https://gist.github.com/cdeil/0875c51b495f51066f2e

The same error can be seen on travis-ci on Linux:
https://travis-ci.org/gammapy/gammapy/jobs/30449578#L623

We'll probably have to wait for https://github.com/astropy/astropy/issues/2774 to fix this and until the fix is in a stable version before we can merge this PR.
