### PR TITLE
Fix bugs in spectral cube class

### DIFF
--- a/gammapy/data/spectral_cube.py
+++ b/gammapy/data/spectral_cube.py
@@ -310,8 +310,8 @@ class SpectralCube(object):
         if isinstance(energy_bins, int):
             energy_bins = energy_bounds_equal_log_spacing(energy_band, energy_bins)
 
-        energy1 = energy_bins[:-1]
-        energy2 = energy_bins[1:]
+        energy1 = energy_bins[:-1].to('MeV')
+        energy2 = energy_bins[1:].to('MeV')
 
         # Compute differential flux at energy bin edges of all pixels
         xx = np.arange(self.data.shape[2])
@@ -335,7 +335,8 @@ class SpectralCube(object):
         integral_flux = integral_flux.sum(axis=0)
 
         header = self.wcs.sub(['longitude', 'latitude']).to_header()
-        hdu = fits.ImageHDU(data=Quantity(integral_flux, 'cm^-2 s^-1 sr^-1'),
+
+        hdu = fits.ImageHDU(data=integral_flux,
                             header=header, name='integral_flux')
 
         return hdu


### PR DESCRIPTION
Fixes bug mentioned in issue #178, and deals with the Quantity/ImageHDU issue.

---

from astropy.units import Quantity
energy_range = Quantity([10, 500], 'GeV')
flux_background = fermi_diffuse.integral_flux_image(energy_range)
print flux_background.data
[[  4.96538718e-08   5.08790160e-08   5.16831888e-08 ...,   8.34615912e-08
    8.27155529e-08   8.25761185e-08]
 [  5.15609632e-08   5.20233728e-08   5.20025838e-08 ...,   8.38200572e-08
    8.27546690e-08   8.26082274e-08]
 [  5.66285891e-08   5.53183727e-08   5.51376924e-08 ...,   8.54037376e-08
    8.49908847e-08   8.45082814e-08]
 ..., 
 [  7.91854550e-08   7.92956875e-08   8.16965935e-08 ...,   7.36334291e-08
    7.59015607e-08   7.62683800e-08]
 [  7.86396735e-08   7.92222013e-08   8.11234297e-08 ...,   7.34012929e-08
    7.62491752e-08   7.74276834e-08]
 [  7.84162988e-08   7.85808745e-08   8.04845338e-08 ...,   7.27042248e-08
    7.62317234e-08   7.81416615e-08]]

energy_range = Quantity([10E3, 500E3], 'MeV')
flux_background = fermi_diffuse.integral_flux_image(energy_range)
flux_background.data

array([[  4.96538718e-08,   5.08790160e-08,   5.16831888e-08, ...,
          8.34615912e-08,   8.27155529e-08,   8.25761185e-08],
       [  5.15609632e-08,   5.20233728e-08,   5.20025838e-08, ...,
          8.38200572e-08,   8.27546690e-08,   8.26082274e-08],
       [  5.66285891e-08,   5.53183727e-08,   5.51376924e-08, ...,
          8.54037376e-08,   8.49908847e-08,   8.45082814e-08],
       ..., 
       [  7.91854550e-08,   7.92956875e-08,   8.16965935e-08, ...,
          7.36334291e-08,   7.59015607e-08,   7.62683800e-08],
       [  7.86396735e-08,   7.92222013e-08,   8.11234297e-08, ...,
          7.34012929e-08,   7.62491752e-08,   7.74276834e-08],
       [  7.84162988e-08,   7.85808745e-08,   8.04845338e-08, ...,
          7.27042248e-08,   7.62317234e-08,   7.81416615e-08]])

---

So these are now the same (sorry, I haven't figured out how to write code blocks on here).
