### PR TITLE
Fix quantity errors from astro source models

### DIFF
--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -105,7 +105,10 @@ class PWN(object):
             raise ValueError('Need time variable or age attribute.')
         # Radius at time of collision
         r_coll = self._radius_free_expansion(self._collision_time)
-        return Quantity(np.where(t < self._collision_time, self._radius_free_expansion(t), r_coll), 'cm')
+        r = np.where(t < self._collision_time,
+                     self._radius_free_expansion(t).value,
+                     r_coll.value)
+        return Quantity(r, 'cm')
 
     def magnetic_field(self, t=None):
         """

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -81,8 +81,8 @@ class SNR(object):
         else:
             raise ValueError('Need time variable or age attribute.')
         r = np.where(t > self.sedov_taylor_begin,
-                     self._radius_sedov_taylor(t).to('cm'),
-                     self._radius_free_expansion(t).to('cm'))
+                     self._radius_sedov_taylor(t).to('cm').value,
+                     self._radius_free_expansion(t).to('cm').value)
         return Quantity(r, 'cm')
 
     def _radius_free_expansion(self, t):
@@ -270,8 +270,9 @@ class SNRTrueloveMcKee(SNR):
             t = self.age
         else:
             raise ValueError('Need time variable or age attribute.')
-        r = np.where(t > self.sedov_taylor_begin, self._radius_sedov_taylor(t).to('cm'),
-                     self._radius_free_expansion(t).to('cm'))
+        r = np.where(t > self.sedov_taylor_begin,
+                     self._radius_sedov_taylor(t).to('cm').value,
+                     self._radius_free_expansion(t).to('cm').value)
         return Quantity(r, 'cm')
 
     def _radius_free_expansion(self, t):
@@ -347,4 +348,7 @@ class SNRTrueloveMcKee(SNR):
         term2 = (1.49 - 0.16 * term1 - 0.46 * np.log(t / t_core))
         R_1 = self._radius_free_expansion(t) / 1.19
         R_RS = term2 * (self.r_c / self.t_c) * t
-        return Quantity(np.where(t < t_core, R_1.to('cm'), R_RS.to('cm')), 'cm')
+        r = np.where(t < t_core,
+                     R_1.to('cm').value,
+                     R_RS.to('cm').value)
+        return Quantity(r, 'cm')


### PR DESCRIPTION
@adonath After updating to Numpy 1.9, I'm getting unit test fails on my Mac from the `SNR` and `PWN` code and tests you wrote.

E.g. this code:

``` python
from astropy.units import Quantity
from gammapy.astro.source import SNR
t = Quantity([0, 1, 10, 100, 1000, 10000], 'yr')
snr = SNR()
snr.radius(t)
```

fails like this:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/private/tmp/gammapy/a.py in <module>()
      4 t = Quantity([0, 1, 10, 100, 1000, 10000], 'yr')
      5 snr = SNR()
----> 6 snr.radius(t)
      7 

/private/tmp/gammapy/gammapy/astro/source/snr.py in radius(self, t)
     85                      self._radius_free_expansion(t).to('cm'))
     86         import IPython; IPython.embed()
---> 87         return Quantity(r, 'cm')
     88 
     89     def _radius_free_expansion(self, t):

/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev9928-py3.4-macosx-10.9-x86_64.egg/astropy/units/quantity.py in __new__(cls, value, unit, dtype, copy, order, subok, ndmin)
    176         if isinstance(value, Quantity):
    177             if unit is not None and unit is not value.unit:
--> 178                 value = value.to(unit)
    179                 # the above already makes a copy (with float dtype)
    180                 copy = False

/Users/deil/Library/Python/3.4/lib/python/site-packages/astropy-1.0.dev9928-py3.4-macosx-10.9-x86_64.egg/astropy/units/quantity.py in to(self, unit, equivalencies)
    577         unit = Unit(unit)
    578         new_val = np.asarray(
--> 579             self.unit.to(unit, self.value, equivalencies=equivalencies))
    580         return self._new_view(new_val, unit)
    581 

AttributeError: 'NoneType' object has no attribute 'to'
```

I've traced it down to the `np.where` calls ... they return an un-initialised Quantity as mentioned [here](http://astropy.readthedocs.org/en/latest/units/quantity.html#known-issues-with-conversion-to-numpy-arrays) (I think this is a new issue that appeared with the update to numpy 1.9 !?):

``` python
>>> np.where([True, False], Quantity([1,2], 'cm'), Quantity([10, 20], 'cm'))
<Quantity [  1., 20.] (Unit not initialised)>
```

Fixing this now ... something to watch out in the future.
