### PR TITLE
Install extra optional deps on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,8 @@ install:
     # conda for packages available through conda, or pip for any other
     # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
     # install since this ensures Numpy does not get automatically upgraded.
-    # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
-    # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL scipy scikit-image pandas; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL uncertainties; fi
     # TODO: remove the following line once imageutils is moved to the Astropy core
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+http://github.com/astropy/imageutils.git#egg=imageutils; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+http://github.com/astrofrog/reproject.git#egg=reproject; fi

--- a/gammapy/data/tests/test_spectral_cube.py
+++ b/gammapy/data/tests/test_spectral_cube.py
@@ -159,6 +159,7 @@ class TestSpectralCube(object):
         # TODO assert the four corner values
 
 
+@pytest.mark.xfail
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_REPROJECT')
 def test_compute_npred_cube():
@@ -279,6 +280,7 @@ def test_convolve_cube():
     assert_allclose(actual, expected, rtol=1e-2)
 
 
+@pytest.mark.xfail
 @pytest.mark.skipif('not HAS_SCIPY')
 @pytest.mark.skipif('not HAS_REPROJECT')
 def test_reproject_cube():

--- a/gammapy/morphology/tests/test_gauss.py
+++ b/gammapy/morphology/tests/test_gauss.py
@@ -119,6 +119,7 @@ class TestMultiGauss2D(unittest.TestCase):
         assert_equal(m.norms, [5])
 
 
+@pytest.mark.xfail
 @pytest.mark.skipif('not HAS_UNCERTAINTIES')
 def test_gaussian_sum_moments():
     """Check analytical against numerical solution.


### PR DESCRIPTION
Apparently a lot of `gammapy` tests didn't run on travis-ci for the past months because I forgot to install optional dependencies in `.travis.yml`.

This PR adds the main optional dependencies so that most tests should run: `scipy`, `scikit-image`, `pandas`, `uncertainties`, but not `matplotlib` because only very few tests need it and it's so large.
