### PR TITLE
Python 3 tests exit with code 247 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,16 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development SETUP_CMD='test'
-        #- python: 3.3
-        #  env: ASTROPY_VERSION=development SETUP_CMD='test'
+        - python: 3.3
+          env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try all python versions with the latest numpy
         - python: 2.7
           env: SETUP_CMD='test'
-        #- python: 3.3
-        #  env: SETUP_CMD='test'
-        #- python: 3.4
-        #  env: SETUP_CMD='test'
+        - python: 3.3
+          env: SETUP_CMD='test'
+        - python: 3.4
+          env: SETUP_CMD='test'
 
         # Try older numpy versions
         - python: 2.7

--- a/dev/docker/README.rst
+++ b/dev/docker/README.rst
@@ -9,6 +9,9 @@ These are some notes how to run Gammapy in a Docker containers.
 This is useful e.g. to debug travis-ci fails locally, e.g. this one:
 https://github.com/gammapy/gammapy/issues/226
 
+If this doesn't work, you can ask travis-ci via email to provide you
+with ssh access to a temp VM that you can use to debug the issue.
+
 How does this work?
 -------------------
 
@@ -23,7 +26,7 @@ To run the docker image::
     docker run  -t -i cdeil/gammapy-travis:latest bash
 
 Then you can run Numpy or Astropy or Gammapy tests or do whatever you need.
-    
+
 References
 ----------
 
@@ -38,3 +41,17 @@ One issue i have on my Mac is this
 http://stackoverflow.com/questions/26686358/docker-cant-connect-to-boot2docker-because-of-tcp-timeout
 and running this command fixes it:
 http://stackoverflow.com/a/26804653/498873
+
+To replay the commands from travis-ci you can make a bash script with
+those commands like this:
+
+    wget https://s3.amazonaws.com/archive.travis-ci.org/jobs/46079771/log.txt
+    grep '$ ' log.txt | grep -v '# '
+    # This output looks OK, but it has a ton of non-visible characters.
+    # I did not find a way to get rid of those, but this works:
+    # Manually copy the output on the terminal into a gist on github.
+    # Then manually copy that gist content into a file log2.txt
+    cat log2.txt | cut -c 3- > commands.sh
+
+    # You have to add this at the top
+    export TRAVIS_PYTHON_VERSION=3.4

--- a/dev/docker/commands.sh
+++ b/dev/docker/commands.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# This is what travis-ci does for a build of the master branch
+export OWNER=gammapy
+export REPO=gammapy
+export BRANCH=master
+export SHA=39caf3bf78c877629bd6bd7513a272f76c8e1ca2
+git clone --depth=50 --branch=${BRANCH} http://github.com/${OWNER}/${REPO}.git ${OWNER}/${REPO}
+cd ${OWNER}/${REPO}
+git checkout -qf ${SHA}
+git submodule init
+git submodule update
+
+# Define environment variables
+export NUMPY_VERSION=1.9
+export ASTROPY_VERSION=development
+export CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
+export PIP_INSTALL='pip install'
+export ASTROPY_VERSION=development
+export SETUP_CMD='test'
+
+# Execute commands
+source ~/virtualenv/python3.3/bin/activate
+python --version
+pip --version
+export PYTHONIOENCODING=UTF8
+wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b
+export PATH=/home/travis/miniconda/bin:$PATH
+conda update --yes conda
+sudo apt-get update
+if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export TRAVIS_PYTHON_VERSION=2.7.8; fi
+conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
+source activate test
+export CONDA_INSTALL="conda install -c astropy-ci-extras --yes python=$TRAVIS_PYTHON_VERSION numpy=$NUMPY_VERSION"
+if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
+if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
+if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
+if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
+if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL scipy scikit-image pandas; fi
+if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL uncertainties; fi
+if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+http://github.com/astrofrog/reproject.git#egg=reproject; fi
+if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib scipy; fi
+if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL linkchecker; fi
+if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL aplpy; fi
+if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+python setup.py $SETUP_CMD
+if [[ $SETUP_CMD == build_sphinx* ]]; then linkchecker docs/_build/html; fi

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -169,7 +169,7 @@ def _ydiff_excess_equals_expected(yint, xmin, xmax, x, model):
     return y_model * (yint / yint_model)
 
 
-def _integrate(xmin, xmax, function, segments=1e6):
+def _integrate(xmin, xmax, function, segments=1e3):
     """Integrates method function using the trapezium rule between xmin and xmax.
     """
     indices = np.arange(len(xmin))

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -181,7 +181,7 @@ def test_compute_differential_flux_points(x_method, y_method):
     assert_allclose(actual_energy, desired_energy, rtol=1e-3)
     # Test flux
     actual = result_table['DIFF_FLUX'].data
-    assert_allclose(actual, desired, rtol=1e-3)
+    assert_allclose(actual, desired, rtol=1e-2)
     # Test error
     actual = result_table['DIFF_FLUX_ERR'].data
     desired = 0.1 * result_table['DIFF_FLUX'].data


### PR DESCRIPTION
Since today the Gammapy Python 3 tests fail on travis-ci ... they simply abort with exit code 247, e.g. in `test_diffuse.py` or `test_flux_point.py`:

https://travis-ci.org/gammapy/gammapy/jobs/46076272#L2124
https://travis-ci.org/gammapy/gammapy/jobs/46079771#L2124

Most likely the issue is a segfault in `numpy` (called via `Quantity`).

@astrofrog @eteq Have you seen this with Astropy or other affiliated packages? Do you know how to debug this, e.g. how to get a C traceback printed to the log?

I'll try to reproduce it in an Ubuntu VM locally now ... 