### PR TITLE
Updated astropy-helpers to v0.4.4

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -304,7 +304,7 @@ def _do_download(version='', find_links=None, index_url=None):
             allow_hosts = None
         # Annoyingly, setuptools will not handle other arguments to
         # Distribution (such as options) before handling setup_requires, so it
-        # is not straightfoward to programmatically augment the arguments which
+        # is not straightforward to programmatically augment the arguments which
         # are passed to easy_install
         class _Distribution(Distribution):
             def get_option_dict(self, command_name):
@@ -405,7 +405,7 @@ def _check_submodule(path, use_git=True, offline=False):
     Check if the given path is a git submodule.
 
     See the docstrings for ``_check_submodule_using_git`` and
-    ``_check_submodule_no_git`` for futher details.
+    ``_check_submodule_no_git`` for further details.
     """
 
     if use_git:
@@ -512,7 +512,7 @@ def _check_submodule_no_git(path):
 
     # This is a minimal reader for gitconfig-style files.  It handles a few of
     # the quirks that make gitconfig files incompatible with ConfigParser-style
-    # files, but does not support the full gitconfig syntaix (just enough
+    # files, but does not support the full gitconfig syntax (just enough
     # needed to read a .gitmodules file).
     gitmodules_fileobj = io.StringIO()
 


### PR DESCRIPTION
Update astropy-helpers to v0.4.4 using the commands here:
http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html#updating-to-the-latest-template-files
