### PR TITLE
Add function to fill acceptance image from curve

### DIFF
--- a/gammapy/background/fov.py
+++ b/gammapy/background/fov.py
@@ -5,6 +5,7 @@ Field-of-view (FOV) background estimation
 from __future__ import print_function, division
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_skycoord
+import numpy as np
 from scipy.interpolate import interp1d
 
 __all__ = ['fill_acceptance_image',
@@ -12,44 +13,50 @@ __all__ = ['fill_acceptance_image',
 
 
 def fill_acceptance_image(image, center, offset, acceptance):
-    """Generate a 2D image of a radial acceptance curve given as
-    an array of values defined at the specified offsets.
+    """Generate a 2D image of a radial acceptance curve.
+
+    The radial acceptance curve is given as an array of values
+    defined at the specified offsets.
 
     Parameters
     ----------
-    image : ImageHDU
+    image : `~astropy.io.fits.ImageHDU`
         Empty image to fill.
-    center : SkyCoord
+    center : `~astropy.coordinates.SkyCoord`
         Coordinate of the center of the image.
-    offset : `~numpy.ndarray`
+    offset : `~numpy.ndarray` of `~astropy.coordinates.Angle`
         Array of offset values in degrees where acceptance is defined.
     acceptance : `~numpy.ndarray`
         Array of acceptance values.
 
     Returns
     -------
-    image : ImageHDU
+    image : `~astropy.io.fits.ImageHDU`
         Image filled with radial acceptance.
     """
     #initialize WCS to the header of the image
     w = WCS(image.header)
-    #loop over pixels and fill acceptance according to offset angle
-    nx, ny = image.shape
-    for ix in range(0, nx):
-        print(ix) #debug
-        for iy in range(0, ny):
-            print(" ", iy) #debug
-            #calculate pixel offset from center (in world coordinates)
-            coord = pixel_to_skycoord(ix, iy, w, 1)
-            pix_off = coord.separation(center)
-            #interpolate
-            f = interp1d(offset, acceptance, kind='cubic')
-            pix_acc = f(pix_off)
-            #fill value in image
-            image.data[ix, iy] = pix_acc
 
-    #TODO: method very slow (pixel_to_skycoord + separation in loop)
-    #      interpolate makes it even slower
-    #      try to avoid explicit loop: I think it can work with arrays directly without the need to loop (maybe it's faster).
+    #define grids of pixel coorinates
+    nx, ny = image.shape
+    xpix_coord_grid = np.zeros(image.shape)
+    for y in range(0, ny):
+        xpix_coord_grid[0:nx, y] = np.arange(0, nx)
+    print(xpix_coord_grid) #debug
+    ypix_coord_grid = np.zeros(image.shape)
+    for x in range(0, nx):
+        ypix_coord_grid[x, 0:nx] = np.arange(0, ny)
+    print(ypix_coord_grid) #debug
+
+    #calculate pixel offset from center (in world coordinates)
+    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 1)
+    pix_off = coord.separation(center)
+
+    #interpolate
+    f = interp1d(offset, acceptance, kind='cubic')
+    pix_acc = f(pix_off)
+
+    #fill value in image
+    image.data = pix_acc
 
     return image

--- a/gammapy/background/fov.py
+++ b/gammapy/background/fov.py
@@ -3,3 +3,53 @@
 Field-of-view (FOV) background estimation
 """
 from __future__ import print_function, division
+from astropy.wcs import WCS
+from astropy.wcs.utils import pixel_to_skycoord
+from scipy.interpolate import interp1d
+
+__all__ = ['fill_acceptance_image',
+           ]
+
+
+def fill_acceptance_image(image, center, offset, acceptance):
+    """Generate a 2D image of a radial acceptance curve given as
+    an array of values defined at the specified offsets.
+
+    Parameters
+    ----------
+    image : ImageHDU
+        Empty image to fill.
+    center : SkyCoord
+        Coordinate of the center of the image.
+    offset : `~numpy.ndarray`
+        Array of offset values in degrees where acceptance is defined.
+    acceptance : `~numpy.ndarray`
+        Array of acceptance values.
+
+    Returns
+    -------
+    image : ImageHDU
+        Image filled with radial acceptance.
+    """
+    #initialize WCS to the header of the image
+    w = WCS(image.header)
+    #loop over pixels and fill acceptance according to offset angle
+    nx, ny = image.shape
+    for ix in range(0, nx):
+        print(ix) #debug
+        for iy in range(0, ny):
+            print(" ", iy) #debug
+            #calculate pixel offset from center (in world coordinates)
+            coord = pixel_to_skycoord(ix, iy, w, 1)
+            pix_off = coord.separation(center)
+            #interpolate
+            f = interp1d(offset, acceptance, kind='cubic')
+            pix_acc = f(pix_off)
+            #fill value in image
+            image.data[ix, iy] = pix_acc
+
+    #TODO: method very slow (pixel_to_skycoord + separation in loop)
+    #      interpolate makes it even slower
+    #      try to avoid explicit loop: I think it can work with arrays directly without the need to loop (maybe it's faster).
+
+    return image

--- a/gammapy/background/tests/test_fov.py
+++ b/gammapy/background/tests/test_fov.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 
-from gammapy.background import fill_acceptance_image
-from gammapy.image import make_empty_image
+import numpy as np
 
 from astropy.io import fits
 from astropy.coordinates import SkyCoord, Angle
@@ -10,101 +9,70 @@ from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_skycoord
 import astropy.units as u
 from astropy.units.quantity import Quantity
+from astropy.modeling import models
 
-import numpy as np
-from scipy.integrate import quad
-
-def radial_gaussian_2D(r, sig):
-    """Radially symmetric Gaussian function for emulating acceptance curve.
-
-    Please give parameters in radians.
-
-    TODO: I can't define parameters as `~astropy.coordinates.Angle` because it conflicts with the integral call afterwards!!!
-
-    Parameters
-    ----------
-    r : `~numpy.ndarray`
-    Radial coordinate.
-    sig : float
-    Gaussian width.
-
-    Returns
-    -------
-    val: `~numpy.ndarray`
-    Gaussian evaluated at the requested radii.
-    """
-    ##norm = 1./(sig * np.sqrt(2. * np.pi))
-    ##norm *= 2. #due to definition only for r>=0
-    ##norm /= (2.*np.pi) #due to radial symmetry
-    norm = 1.
-    val = norm * np.exp(-np.power(r, 2.) / (2. * np.power(sig, 2.)))
-    return val
+from ...background import fill_acceptance_image
+from ...image import make_empty_image
+from ...image.utils import coordinates
 
 
 def test_fill_acceptance_image():
 
-    #create empty image
+    from scipy.integrate import quad
+
     image = make_empty_image()
 
-    #define center coordinate of the image
-    #in FITS the reference pixel is given by CRPIXn, and its coordinate by CRVALn
-    #the coordinate increment along the axis is given by CDELTn
+    # define center coordinate of the image:
+    #  in FITS the reference pixel is given by CRPIXn
+    #  and the coordinate by CRVALn
+    #  the coordinate increment along the axis is given by CDELTn
     x = image.header['CRVAL1']
     y = image.header['CRVAL2']
 
-    #sanity checks: am I using galactic coordinates in degrees?
-    assert image.header['CTYPE1'] == 'GLON-CAR', "Error: x coordinate is not in Galactic coordinates!"
-    assert image.header['CTYPE2'] == 'GLAT-CAR', "Error: y coordinate is not in Galactic coordinates!"
-    assert image.header['CUNIT1'] == 'deg', "Error: x coordinate is not in degrees!"
-    assert image.header['CUNIT2'] == 'deg', "Error: y coordinate is not in degrees!"
-
     center = SkyCoord(l=x*u.degree, b=y*u.degree, frame='galactic')
 
-    #define pixel sizes
+    # define pixel sizes
     x_pix_size = Angle(abs(image.header['CDELT1'])*u.degree)
     y_pix_size = Angle(abs(image.header['CDELT2'])*u.degree)
 
-    #define radial acceptance and offset angles
+    # define radial acceptance and offset angles
     offset = Angle(np.arange(0., 30., 0.1), unit=u.degree)
     acceptance = np.zeros_like(offset)
-    sigma = Angle(1.0, unit=u.degree) #gaussian width
-    acceptance = radial_gaussian_2D(offset.to(u.radian).value, sigma.to(u.radian).value)
+    sigma = Angle(1.0, unit=u.degree)  # gaussian width
+    gaus_model = models.Gaussian1D(amplitude=1, mean=0., stddev=sigma.to(u.radian).value)
+    acceptance = gaus_model(offset.to(u.radian).value)
 
-    #fill acceptance in the image
+    # fill acceptance in the image
     image = fill_acceptance_image(image, center, offset, acceptance)
 
-    #test: sum of the image (weigthed by the pixel areas) should be equal to the integral of the radial acceptance
+    # test: sum of the image (weigthed by the pixel areas) should be
+    # equal to the integral of the radial acceptance
 
-    #initialize WCS to the header of the image
+    # initialize WCS to the header of the image
     w = WCS(image.header)
 
-    #define grids of pixel coorinates
-    nx, ny = image.data.shape
-    xpix_coord_grid = np.zeros(image.shape)
-    for y in range(0, ny):
-        xpix_coord_grid[0:nx, y] = np.arange(0, nx)
-    ypix_coord_grid = np.zeros(image.shape)
-    for x in range(0, nx):
-        ypix_coord_grid[x, 0:nx] = np.arange(0, ny)
+    # define grids of pixel coorinates
+    xpix_coord_grid, ypix_coord_grid = coordinates(image, world=False)
 
-    #calculate pixel coordinates (in world coordinates)
-    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 1)
+    # calculate pixel coordinates (in world coordinates)
+    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 0)
 
-    #pixel area = delta x * delta y * cos(zenith)
+    # pixel area = delta x * delta y * cos(zenith)
     pix_area_grid = np.cos(coord.l.to(u.radian))*x_pix_size.to(u.radian)*y_pix_size.to(u.radian)
 
-    #sum image, weighted by pixel sizes (i.e. calculate integral of the image)
+    # sum image, weighted by pixel sizes (i.e. calculate integral of the image)
     image_int_grid = image.data*pix_area_grid
     image_int = image_int_grid.sum()
 
-    #integrate acceptance (i.e. gaussian function)
-    #1st integrate in r
-    acc_int = Quantity(quad(radial_gaussian_2D, Angle(0.*u.degree).to(u.radian).value,  Angle(10.*u.degree).to(u.radian).value, args=(sigma.to(u.radian).value))*u.radian)
+    # integrate acceptance (i.e. gaussian function)
+    # 1st integrate in r
+    acc_int = Quantity(quad(gaus_model, Angle(0.*u.degree).to(u.radian).value,  Angle(10.*u.degree).to(u.radian).value, args=(sigma.to(u.radian).value))*u.radian)
+
     acc_int_value = acc_int[0]
-    #2nd integrate in phi: phi range [0, 2pi)
+    # 2nd integrate in phi: phi range [0, 2pi)
     acc_int_value *= Angle(2.*np.pi*u.radian)
 
-    #check sum of the image:
-    # int ~= sum (bin content * bin size)
+    # check sum of the image:
+    #  int ~= sum (bin content * bin size)
     epsilon = 1.e-4
     assert abs(image_int.to(u.rad**2).value - acc_int_value.to(u.rad**2).value) < epsilon, "image integral not compatible with radial acceptance integral"

--- a/gammapy/background/tests/test_fov.py
+++ b/gammapy/background/tests/test_fov.py
@@ -6,7 +6,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.coordinates import SkyCoord, Angle
 from astropy.wcs import WCS
-from astropy.wcs.utils import pixel_to_skycoord
+from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 import astropy.units as u
 from astropy.units.quantity import Quantity
 from astropy.modeling import models
@@ -20,59 +20,70 @@ def test_fill_acceptance_image():
 
     from scipy.integrate import quad
 
-    image = make_empty_image()
+    # create empty image
+    # odd number of pixels needed for having the center in its own pixel
+    n_pix_x = 101
+    n_pix_y = 101
+    bin_size = Angle(0.1, 'degree')
+    image = make_empty_image(n_pix_x, n_pix_y, bin_size.to(u.degree).value,
+                             xref=0, yref=0, fill=0,
+                             proj='CAR', coordsys='GAL',
+                             xrefpix=None, yrefpix=None, dtype='float32')
 
-    # define center coordinate of the image:
-    #  in FITS the reference pixel is given by CRPIXn
-    #  and the coordinate by CRVALn
-    #  the coordinate increment along the axis is given by CDELTn
+    # define center coordinate of the image in wolrd and pixel coordinates
     x = image.header['CRVAL1']
     y = image.header['CRVAL2']
 
     center = SkyCoord(l=x*u.degree, b=y*u.degree, frame='galactic')
+
+    # initialize WCS to the header of the image
+    w = WCS(image.header)
+
+    x_center_pix, y_center_pix = skycoord_to_pixel(center, w, 0)
 
     # define pixel sizes
     x_pix_size = Angle(abs(image.header['CDELT1'])*u.degree)
     y_pix_size = Angle(abs(image.header['CDELT2'])*u.degree)
 
     # define radial acceptance and offset angles
-    offset = Angle(np.arange(0., 30., 0.1), unit=u.degree)
+    # using bin_size for the offset step makes the test comparison easier
+    offset = Angle(np.arange(0., 30., bin_size.to(u.degree).value), 'degree')
     acceptance = np.zeros_like(offset)
-    sigma = Angle(1.0, unit=u.degree)  # gaussian width
-    gaus_model = models.Gaussian1D(amplitude=1, mean=0., stddev=sigma.to(u.radian).value)
+    sigma = Angle(1.0, 'degree')  # gaussian width
+    amplitude = 1.
+    mean = 0.
+    stddev = sigma.to(u.radian).value
+    gaus_model = models.Gaussian1D(amplitude, mean, stddev)
     acceptance = gaus_model(offset.to(u.radian).value)
 
     # fill acceptance in the image
     image = fill_acceptance_image(image, center, offset, acceptance)
 
-    # test: sum of the image (weigthed by the pixel areas) should be
-    # equal to the integral of the radial acceptance
-
-    # initialize WCS to the header of the image
-    w = WCS(image.header)
+    # test: check points at the offsets where the acceptance is defined
+    # along the x axis
 
     # define grids of pixel coorinates
     xpix_coord_grid, ypix_coord_grid = coordinates(image, world=False)
 
-    # calculate pixel coordinates (in world coordinates)
+    # calculate pixel offset from center (in world coordinates)
     coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 0)
+    pix_off = coord.separation(center)
 
-    # pixel area = delta x * delta y * cos(zenith)
-    pix_area_grid = np.cos(coord.l.to(u.radian))*x_pix_size.to(u.radian)*y_pix_size.to(u.radian)
+    # x axis defined in the array positions [y_center_pix - 1,:]
+    # only interested in semi axis, so [y_center_pix - 1, x_center_pix - 1:]
+    ix_min = int(round(x_center_pix - 1))
+    iy = int(round(y_center_pix - 1))
+    pix_off_x_axis = pix_off[iy, ix_min:]
+    image.data_x_axis = image.data[iy, ix_min:]
 
-    # sum image, weighted by pixel sizes (i.e. calculate integral of the image)
-    image_int_grid = image.data*pix_area_grid
-    image_int = image_int_grid.sum()
+    # cut offset and acceptance arrays to match image size
+    # this is only valid if the offset step matches the pixel size
+    n = pix_off_x_axis.size
+    offset_cut = offset[0:n]
+    acceptance_cut = acceptance[0:n]
 
-    # integrate acceptance (i.e. gaussian function)
-    # 1st integrate in r
-    acc_int = Quantity(quad(gaus_model, Angle(0.*u.degree).to(u.radian).value,  Angle(10.*u.degree).to(u.radian).value, args=(sigma.to(u.radian).value))*u.radian)
-
-    acc_int_value = acc_int[0]
-    # 2nd integrate in phi: phi range [0, 2pi)
-    acc_int_value *= Angle(2.*np.pi*u.radian)
-
-    # check sum of the image:
-    #  int ~= sum (bin content * bin size)
-    epsilon = 1.e-4
-    assert abs(image_int.to(u.rad**2).value - acc_int_value.to(u.rad**2).value) < epsilon, "image integral not compatible with radial acceptance integral"
+    # check acceptance of the image:
+    decimal = 4
+    s_error = "image acceptance not compatible with defined radial acceptance"
+    np.testing.assert_almost_equal(image.data_x_axis, acceptance_cut,
+                                   decimal, s_error)

--- a/gammapy/background/tests/test_fov.py
+++ b/gammapy/background/tests/test_fov.py
@@ -1,2 +1,110 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
+
+from gammapy.background import fill_acceptance_image
+from gammapy.image import make_empty_image
+
+from astropy.io import fits
+from astropy.coordinates import SkyCoord, Angle
+from astropy.wcs import WCS
+from astropy.wcs.utils import pixel_to_skycoord
+import astropy.units as u
+from astropy.units.quantity import Quantity
+
+import numpy as np
+from scipy.integrate import quad
+
+def radial_gaussian_2D(r, sig):
+    """Radially symmetric Gaussian function for emulating acceptance curve.
+
+    Please give parameters in radians.
+
+    TODO: I can't define parameters as `~astropy.coordinates.Angle` because it conflicts with the integral call afterwards!!!
+
+    Parameters
+    ----------
+    r : `~numpy.ndarray`
+    Radial coordinate.
+    sig : float
+    Gaussian width.
+
+    Returns
+    -------
+    val: `~numpy.ndarray`
+    Gaussian evaluated at the requested radii.
+    """
+    ##norm = 1./(sig * np.sqrt(2. * np.pi))
+    ##norm *= 2. #due to definition only for r>=0
+    ##norm /= (2.*np.pi) #due to radial symmetry
+    norm = 1.
+    val = norm * np.exp(-np.power(r, 2.) / (2. * np.power(sig, 2.)))
+    return val
+
+
+def test_fill_acceptance_image():
+
+    #create empty image
+    image = make_empty_image()
+
+    #define center coordinate of the image
+    #in FITS the reference pixel is given by CRPIXn, and its coordinate by CRVALn
+    #the coordinate increment along the axis is given by CDELTn
+    x = image.header['CRVAL1']
+    y = image.header['CRVAL2']
+
+    #sanity checks: am I using galactic coordinates in degrees?
+    assert image.header['CTYPE1'] == 'GLON-CAR', "Error: x coordinate is not in Galactic coordinates!"
+    assert image.header['CTYPE2'] == 'GLAT-CAR', "Error: y coordinate is not in Galactic coordinates!"
+    assert image.header['CUNIT1'] == 'deg', "Error: x coordinate is not in degrees!"
+    assert image.header['CUNIT2'] == 'deg', "Error: y coordinate is not in degrees!"
+
+    center = SkyCoord(l=x*u.degree, b=y*u.degree, frame='galactic')
+
+    #define pixel sizes
+    x_pix_size = Angle(abs(image.header['CDELT1'])*u.degree)
+    y_pix_size = Angle(abs(image.header['CDELT2'])*u.degree)
+
+    #define radial acceptance and offset angles
+    offset = Angle(np.arange(0., 30., 0.1), unit=u.degree)
+    acceptance = np.zeros_like(offset)
+    sigma = Angle(1.0, unit=u.degree) #gaussian width
+    acceptance = radial_gaussian_2D(offset.to(u.radian).value, sigma.to(u.radian).value)
+
+    #fill acceptance in the image
+    image = fill_acceptance_image(image, center, offset, acceptance)
+
+    #test: sum of the image (weigthed by the pixel areas) should be equal to the integral of the radial acceptance
+
+    #initialize WCS to the header of the image
+    w = WCS(image.header)
+
+    #define grids of pixel coorinates
+    nx, ny = image.data.shape
+    xpix_coord_grid = np.zeros(image.shape)
+    for y in range(0, ny):
+        xpix_coord_grid[0:nx, y] = np.arange(0, nx)
+    ypix_coord_grid = np.zeros(image.shape)
+    for x in range(0, nx):
+        ypix_coord_grid[x, 0:nx] = np.arange(0, ny)
+
+    #calculate pixel coordinates (in world coordinates)
+    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 1)
+
+    #pixel area = delta x * delta y * cos(zenith)
+    pix_area_grid = np.cos(coord.l.to(u.radian))*x_pix_size.to(u.radian)*y_pix_size.to(u.radian)
+
+    #sum image, weighted by pixel sizes (i.e. calculate integral of the image)
+    image_int_grid = image.data*pix_area_grid
+    image_int = image_int_grid.sum()
+
+    #integrate acceptance (i.e. gaussian function)
+    #1st integrate in r
+    acc_int = Quantity(quad(radial_gaussian_2D, Angle(0.*u.degree).to(u.radian).value,  Angle(10.*u.degree).to(u.radian).value, args=(sigma.to(u.radian).value))*u.radian)
+    acc_int_value = acc_int[0]
+    #2nd integrate in phi: phi range [0, 2pi)
+    acc_int_value *= Angle(2.*np.pi*u.radian)
+
+    #check sum of the image:
+    # int ~= sum (bin content * bin size)
+    epsilon = 1.e-4
+    assert abs(image_int.to(u.rad**2).value - acc_int_value.to(u.rad**2).value) < epsilon, "image integral not compatible with radial acceptance integral"


### PR DESCRIPTION
This pull request addresses issue #5.

The method is slow (loop over pixels for calculating offset and interpolate the acceptance value), so maybe it could still be improved.

I still am thinking about a good test for the method. While developping the method I used a script that plots the radial acceptance image that I can see, but I am not sure how to best implement an automatic test on a method working on images. In addition, since the mthod is slow, the test might take longer than desirable. Suggestions are welcome!