### PR TITLE
Fix image origin consistently.

### DIFF
--- a/gammapy/background/fov.py
+++ b/gammapy/background/fov.py
@@ -46,7 +46,7 @@ def fill_acceptance_image(image, center, offset, acceptance):
     xpix_coord_grid, ypix_coord_grid = coordinates(image, world=False)
 
     # calculate pixel offset from center (in world coordinates)
-    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 0)
+    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, origin=0)
     pix_off = coord.separation(center)
 
     # interpolate

--- a/gammapy/background/tests/test_fov.py
+++ b/gammapy/background/tests/test_fov.py
@@ -39,7 +39,7 @@ def test_fill_acceptance_image():
     # initialize WCS to the header of the image
     w = WCS(image.header)
 
-    x_center_pix, y_center_pix = skycoord_to_pixel(center, w, 0)
+    x_center_pix, y_center_pix = skycoord_to_pixel(center, w, origin=0)
 
     # define pixel sizes
     x_pix_size = Angle(abs(image.header['CDELT1'])*u.degree)
@@ -66,13 +66,13 @@ def test_fill_acceptance_image():
     xpix_coord_grid, ypix_coord_grid = coordinates(image, world=False)
 
     # calculate pixel offset from center (in world coordinates)
-    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, 0)
+    coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, w, origin=0)
     pix_off = coord.separation(center)
 
-    # x axis defined in the array positions [y_center_pix - 1,:]
-    # only interested in semi axis, so [y_center_pix - 1, x_center_pix - 1:]
-    ix_min = int(round(x_center_pix - 1))
-    iy = int(round(y_center_pix - 1))
+    # x axis defined in the array positions [y_center_pix,:]
+    # only interested in semi axis, so [y_center_pix, x_center_pix:]
+    ix_min = int(x_center_pix)
+    iy = int(y_center_pix)
     pix_off_x_axis = pix_off[iy, ix_min:]
     image.data_x_axis = image.data[iy, ix_min:]
 

--- a/gammapy/data/spectral_cube.py
+++ b/gammapy/data/spectral_cube.py
@@ -157,7 +157,8 @@ class SpectralCube(object):
         """
         lon = lon.to('deg').value
         lat = lat.to('deg').value
-        x, y, _ = self.wcs.wcs_world2pix(lon, lat, 0, 0)
+        origin = 0  # convention for gammapy
+        x, y, _ = self.wcs.wcs_world2pix(lon, lat, 0, origin)
 
         z = self.energy_axis.world2pix(energy)
 
@@ -185,7 +186,8 @@ class SpectralCube(object):
         -------
         lon, lat, energy
         """
-        lon, lat, _ = self.wcs.wcs_pix2world(x, y, 0, 0)
+        origin = 0  # convention for gammapy
+        lon, lat, _ = self.wcs.wcs_pix2world(x, y, 0, origin)
         energy = self.energy_axis.pix2world(z)
 
         lon = Quantity(lon, 'deg')

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -53,7 +53,8 @@ def _source_image(catalog, reference_cube, sim_table=None, total_flux=True):
             if (glat_min < lat) & (lat < glat_max):
                 flux = source_table['flux'][source]
                 wcs = reference_cube.wcs
-                x, y = wcs.wcs_world2pix(lon, lat, 0)
+                origin = 0  # convention for gammapy
+                x, y = wcs.wcs_world2pix(lon, lat, origin)
                 xi, yi = x.astype(int), y.astype(int)
                 new_image[yi, xi] = new_image[yi, xi] + flux
     if total_flux:

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -246,7 +246,8 @@ def find_max(image):
     data = image.data
     data[np.isnan(data)] = -np.inf
     y, x = maximum_position(data)
-    GLON, GLAT = proj.wcs_pix2world(x, y, 0)
+    origin = 0  # convention for gammapy
+    GLON, GLAT = proj.wcs_pix2world(x, y, origin)
     val = data[int(y), int(x)]
     return GLON, GLAT, val
 
@@ -275,7 +276,8 @@ def _lookup_world(image, lon, lat):
     """
     from astropy.wcs import WCS
     wcs = WCS(image.header)
-    x, y = wcs.wcs_world2pix(lon, lat, 0)
+    origin = 0  # convention for gammapy
+    x, y = wcs.wcs_world2pix(lon, lat, origin)
     return _lookup_pix(image.data, x, y)
 
 

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -380,14 +380,14 @@ def coordinates(image, world=True, lon_sym=True, radians=False):
     >>> dist = np.sqrt(lon ** 2 + lat ** 2)
     """
     # Create arrays of pixel coordinates
+    y, x = np.indices(image.shape, dtype='int32')
+
     if not world:
-        y, x = np.indices(image.shape, dtype='int32') + 1
         return x, y
-    else:
-        y, x = np.indices(image.data.shape, dtype='int32') + 1
 
     wcs = WCS(image.header)
-    lon, lat = wcs.wcs_pix2world(x, y, 1)
+    origin = 0  # convention for gammapy
+    lon, lat = wcs.wcs_pix2world(x, y, origin)
 
     if lon_sym:
         lon = np.where(lon > 180, lon - 360, lon)
@@ -641,7 +641,8 @@ def wcs_histogram2d(header, lon, lat, weights=None):
 
     # Get pixel coordinates
     wcs = WCS(header)
-    xx, yy = wcs.wcs_world2pix(lon, lat, 0)
+    origin = 0  # convention for gammapy
+    xx, yy = wcs.wcs_world2pix(lon, lat, origin)
 
     # Histogram pixel coordinates with appropriate binning.
     # This was checked against the `ctskymap` ctool
@@ -707,7 +708,8 @@ def bin_events_in_cube(events, reference_cube, energies):
     # Get pixel coordinates
     wcs = WCS(reference_cube.header)
     # We're not interested in the energy axis, so we give a dummy value of 1
-    xx, yy = wcs.wcs_world2pix(lon, lat, 1, 0)[:-1]
+    origin = 0  # convention for gammapy
+    xx, yy = wcs.wcs_world2pix(lon, lat, 1, origin)[:-1]
 
     event_energies = events['Energy']
     zz = np.searchsorted(event_energies, energies)
@@ -1050,7 +1052,8 @@ def contains(image, x, y, world=True):
 
     if world:
         wcs = WCS(header)
-        x, y = wcs.wcs_world2pix(x, y, 0)
+        origin = 0  # convention for gammapy
+        x, y = wcs.wcs_world2pix(x, y, origin)
 
     nx, ny = header['NAXIS2'], header['NAXIS1']
     return (x >= 0.5) & (x <= nx + 0.5) & (y >= 0.5) & (y <= ny + 0.5)
@@ -1076,8 +1079,9 @@ def paste_cutout_into_image(total, cutout, method='sum'):
     crop_image
     """
     # find offset
-    lon, lat = WCS(cutout.header).wcs_pix2world(0, 0, 0)
-    x, y = WCS(total.header).wcs_world2pix(lon, lat, 0)
+    origin = 0  # convention for gammapy
+    lon, lat = WCS(cutout.header).wcs_pix2world(0, 0, origin)
+    x, y = WCS(total.header).wcs_world2pix(lon, lat, origin)
     x, y = int(np.round(x)), int(np.round(y))
     dy, dx = cutout.shape
 

--- a/gammapy/morphology/overlap.py
+++ b/gammapy/morphology/overlap.py
@@ -79,7 +79,8 @@ def write_test_model_components(component_table):
     w.wcs.ctype = ["GLON-CAR", "GLAT-CAR"]
     header = w.to_header()
     y, x = np.indices((401, 401))
-    glon, glat = w.wcs_pix2world(x, y, 0)
+    origin = 0  # convention for gammapy
+    glon, glat = w.wcs_pix2world(x, y, origin)
 
     # All source components added
     all_components = np.zeros_like(x, dtype=np.float32)
@@ -175,7 +176,8 @@ def get_containment_mask(glon_pos, glat_pos, r_containment, shape):
     hdulist = fits.open('../counts.fits')
     w = WCS(hdulist[0].header)
     y, x = np.indices(shape)
-    glon, glat = w.wcs_pix2world(x, y, 0)
+    origin = 0  # convention for gammapy
+    glon, glat = w.wcs_pix2world(x, y, origin)
 
     # Fix glon and glon_pos
     glon = np.select([glon > 180, glon <= 180], [glon - 360, glon])
@@ -195,7 +197,8 @@ def get_containment_mask_from_sigma(glon_pos, glat_pos, sigma, frac, shape):
     hdulist = fits.open('../counts.fits')
     w = WCS(hdulist[0].header)
     y, x = np.indices(shape)
-    glon, glat = w.wcs_pix2world(x, y, 0)
+    origin = 0  # convention for gammapy
+    glon, glat = w.wcs_pix2world(x, y, origin)
 
     # Compute containment radius
     r_containment = sqrt(2 * log(1 / (1 - frac))) * sigma  # Has to be tested!
@@ -545,7 +548,8 @@ def overlap_plot(profile_A, profile_B, w, y_slice):
     ax2.tick_params(axis='both', which='major', labelsize=16)
 
     pos = np.linspace(0, profile_A.size, 11)
-    y_labels, x_labels = w.wcs_pix2world(pos, np.ones_like(pos) * y_slice, 0)
+    origin = 0  # convention for gammapy
+    y_labels, x_labels = w.wcs_pix2world(pos, np.ones_like(pos) * y_slice, origin)
     plt.xticks(pos, x_labels)
     plt.setp(ax1.get_xticklabels(), visible=False)
     plt.legend()
@@ -562,7 +566,8 @@ def make_example_plots(component_table):
     w = WCS(hdulist[0].header)
 
     # Slice through center
-    y_slice, x_slice = w.wcs_world2pix(0, 0, 0)
+    origin = 0  # convention for gammapy
+    y_slice, x_slice = w.wcs_world2pix(0, 0, origin)
 
     for row_A in range(len(component_table)):
         for row_B in range(len(component_table)):

--- a/gammapy/morphology/overlap.py
+++ b/gammapy/morphology/overlap.py
@@ -175,7 +175,7 @@ def get_containment_mask(glon_pos, glat_pos, r_containment, shape):
     hdulist = fits.open('../counts.fits')
     w = WCS(hdulist[0].header)
     y, x = np.indices(shape)
-    glon, glat = w.wcs_pix2world(x, y, 1)
+    glon, glat = w.wcs_pix2world(x, y, 0)
 
     # Fix glon and glon_pos
     glon = np.select([glon > 180, glon <= 180], [glon - 360, glon])
@@ -195,7 +195,7 @@ def get_containment_mask_from_sigma(glon_pos, glat_pos, sigma, frac, shape):
     hdulist = fits.open('../counts.fits')
     w = WCS(hdulist[0].header)
     y, x = np.indices(shape)
-    glon, glat = w.wcs_pix2world(x, y, 1)
+    glon, glat = w.wcs_pix2world(x, y, 0)
 
     # Compute containment radius
     r_containment = sqrt(2 * log(1 / (1 - frac))) * sigma  # Has to be tested!

--- a/gammapy/morphology/tests/test_gauss.py
+++ b/gammapy/morphology/tests/test_gauss.py
@@ -157,7 +157,8 @@ def test_gaussian_sum_moments():
     cov_matrix = np.zeros((12, 12))
     F = [F_1, F_2, F_3]
     sigma = np.array([sigma_1, sigma_2, sigma_3]) * BINSZ
-    x, y = wcs.wcs_pix2world([x_1, x_2, x_3], [y_1, y_2, y_3], 0)
+    origin = 0  # convention for gammapy
+    x, y = wcs.wcs_pix2world([x_1, x_2, x_3], [y_1, y_2, y_3], origin)
 
     # Fix longitude range, is there a wcs option for this?
     x = np.where(x > 180, x - 360, x)


### PR DESCRIPTION
Fix image origin for WCS coordinate transformations in `wcs_world2pix` and `wcs_pix2world` method.
This pull request addresses issue #251.