### PR TITLE
Add changelog for Gammapy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,125 @@
+1.0 (August 24, 2015)
+---------------------
+
+Gammapy 1.0 will be released on August 24, 2015.
+
+For plans and progress see https://github.com/gammapy/gammapy/milestones/1.0
+
+0.4 (June 11, 2015)
+-------------------
+
+Gammapy 0.4 will be released on June 11, 2015.
+
+For plans and progress see https://github.com/gammapy/gammapy/milestones/0.4
+
+Pull requests
++++++++++++++
+
+0.3 (May 18 , 2015)
+-------------------
+
+Gammapy 0.3 will be released on April 13, 2015.
+
+For plans and progress see https://github.com/gammapy/gammapy/milestones/0.3
+
+0.2 (April 13, 2015)
+--------------------
+
+Release notes
++++++++++++++
+
+- Will be released on April 13, 2015 (`Gammapy 0.2 on PyPI <https://pypi.python.org/pypi/gammapy/0.2>`__)
+- Contributors: Manuel Paz Arribas (new), Axel Donath, Ellis Owen, Christoph Deil
+- 8 months of work (from August 25, 2014 to April 13, 2015)
+- 40 pull requests, 4 authors
+- Requires Astropy version 1.0 or later.
+- Gammapy now uses `Cython <http://cython.org/>`__,
+  i.e. requires a C compiler for end-users and in addition Cython for developers.
+
+Pull requests
++++++++++++++
+
+- Add iterative kernel background estimator [#186] (Ellis Owen)
+- Fix bugs in spectral cube class [#187] (Ellis Owen)
+- Add tests for spectral_cube.integral_flux_image [#188] (Ellis Owen)
+- Add Fermi PSF dataset and example [#191] (Ellis Owen)
+- Bundle TeVCat in gammapy.datasets [#194] (Christoph Deil)
+- Remove warning statements in profile function [#199] (Ellis Owen)
+- Fix quantity errors from astro source models [#200] (Christoph Deil)
+- Remove healpix_to_image function (moved to reproject repo) [#205] (Christoph Deil)
+- Restructure image measurement functions [#210] (Axel Donath)
+- Bundle xmltodict.py in gammapy/extern [#212] (Christoph Deil)
+- Restructure TS map computation [#215] (Axel Donath)
+- TS map calculation update and docs [#221] (Axel Donath)
+- Change gammafit name to naima [#224] (Victor Zabalza)
+- Misc cleanup [#225] (Christoph Deil)
+- Fix flux point test. Add script and notes how to debug with Docker [#226] (Christoph Deil)
+- Use setuptools entry_points for scripts [#230] (Christoph Deil)
+- Add observatory and data classes [#231] (Christoph Deil)
+- Add multi-scale TS image computation [#234] (Axel Donath)
+- Add some catalog utilities [#235] (Christoph Deil)
+- Add likelihood converter function [#236] (Christoph Deil)
+- Add 3FGL to dataset fetch functions [#244] (Manuel Paz Arribas)
+- Add colormap and PSF inset plotting functions [#245] (Axel Donath)
+- Add catalog and plotting utils [#246] (Axel Donath)
+- Various fixes to image utils docstrings [#247] (Manuel Paz Arribas)
+- Add function to fill acceptance image from curve [#248] (Manuel Paz Arribas)
+- Add data store and observation table classes, improve event list classes [#249] (Christoph Deil)
+- Implement TS map computation in Cython [#252] (Axel Donath)
+- Add changelog for Gammapy [#254] (Christoph Deil)
+
+0.1 (August 25, 2014)
+---------------------
+
+Release notes
++++++++++++++
+
+- Released on August 25, 2014 (`Gammapy 0.1 on PyPI <https://pypi.python.org/pypi/gammapy/0.1>`__)
+- Contributors: Axel Donath, Ellis Owen, Regis Terrier, Rolf Bühler, Christoph Deil
+- 15 months of work (from May 15, 2013 to August 25, 2014)
+- 82 pull requests, 5 authors
+- Requires Astropy version 0.4 or later.
+
+Pull requests
++++++++++++++
+
+Note that Gammapy development started out directly in the master branch,
+i.e. for some things there is no pull request we can list here.
+
+- Start tevpy repo with `commit 11af4c <https://github.com/gammapy/gammapy/commit/11af4c7436bb79f8e2cae8d0441693232eebe1ba>`__ (Christoph Deil)
+- Rename tevpy to Gammapy in `commit 7e955f <https://github.com/cdeil/gammapy/commit/7e955ffae71353f7b10c9de4a69b977e7c036c6d>`__ on Aug 19, 2013 (Christoph Deil)
+- Add blob detection [#11] (Axel Donath)
+- Add coverage reports to continuous integration on coveralls [#12] (Christoph Deil)
+- Add continuous wavelet transform class [#25] (Regis Terrier)
+- Rename tevpy to gammapy [#34] (Christoph Deil)
+- Add sphere and power-law sampling functions [#48] (Christoph Deil)
+- Add per-pixel solid angle function in image utils [#58] (Ellis Owen)
+- Add coordinate string IAU designation format [#64] (Christoph Deil)
+- Add model image and image measurement functionality [#65] (Axel Donath)
+- Add plotting module and HESS colormap [#66] (Axel Donath)
+- Add image measure methods [#67] (Christoph Deil)
+- Integrate PyFACT functionality in Gammapy [#68] (Christoph Deil)
+- Add TablePSF and Fermi PSF [#84] (Christoph Deil)
+- Add block reduce function for HDUs [#88] (Ellis Owen)
+- Add wstat likelihood function for spectra and images [#96] (Christoph Deil)
+- Add image plotting routines [#100] (Christoph Deil)
+- Add datasets functions to fetch Fermi catalogs [#103] (Ellis Owen)
+- Python 2 / 3 compatibility with a single codebase [#109] (Christoph Deil)
+- Add Galactic source catalog simulation methods [#116] (Christoph Deil)
+- Improve synthetic Milky Way modeling [#117] (Christoph Deil)
+- Add morphology models as Astropy models [#122] (Axel Donath)
+- Add flux point computation using Lafferty & Wyatt (1995) [#128] (Ellis Owen)
+- Add Crab flux point dataset [#138] (Rolf Bühler)
+- Add EffectiveAreaTable and EnergyDependentMultiGaussPSF classes [#142] (Axel Donath)
+- Add npred cube computation [#150] (Christoph Deil and Ellis Owen)
+- Improve npred cube functionality [#151] (Ellis Owen)
+- Add Fermi PSF convolution method [#154] (Ellis Owen)
+- Add PSF convolve function [#155] (Ellis Owen)
+- Add Fermi Vela dataset [#156] (Ellis Owen)
+- Re-write Galaxy modelling code [#157] (Axel Donath)
+- Add code to make model images from a source catalog [#160] (Ellis Owen)
+- Add SED from Cube function [#166] (Ellis Owen)
+- Add image profile function [#167] (Ellis Owen)
+- Add new gammapy.data sub-package [#176] (Christoph Deil)
+- Misc code and docs cleanup [#177] (Christoph Deil)
+- Clean up datasets code and docs [#180] (Christoph Deil)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include CHANGES.rst
 
 recursive-include gammapy *.pyx *.c
 include ez_setup.py

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,16 @@
+.. _changelog:
+
+*********
+Changelog
+*********
+
+This is the changelog for Gammapy.
+For now we use a one-line description of every pull request, roughly in chronological order.
+
+We don't list every pull request.
+Maintenance and cleanup changes (e.g. to update astropy-helpers or fix the docs build)
+are not of interest to users and are not listed here.
+
+After the 1.0 release we will keep a more detailed changelog for users.
+
+.. include:: ../CHANGES.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,3 +191,5 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
+
+github_issues_url = 'https://github.com/gammapy/gammapy/issues/'

--- a/docs/credit.rst
+++ b/docs/credit.rst
@@ -10,13 +10,8 @@ This is a short summary of who contributed what to Gammapy.
 * Christoph Deil (MPIK Heidelberg) started Gammapy in 2013 and is maintaining it.
 * Contributions by Axel Donath (MPIK Heidelberg):
     - Some code committed by Christoph Deil (e.g. functionality in `gammapy.image`)
-      are actually code written by Axel for his bachelor and master's thesis. 
+      are actually code written by Axel for his bachelor and master's thesis.
     - Various image analysis and simulation functionality.
-* Contributions by Ellis Owen (MPIK Heidelberg):
-    - Various bugfixes.
-* Contributions by Regis Terrier (APC Paris): 
-    - Continuous wavelet transform for images with Poisson statistics
-      (`GH PR 25 <https://github.com/gammapy/gammapy/pull/25>`__)
 * Martin Raue (DESY, Hamburg) wrote `PyFACT`_ in 2012 to prototype FITS gamma-ray
   data analysis as part of the first CTA data challenge.
   Martin has left astronomy and the last commit for PyFACT was in June 2012.
@@ -30,6 +25,6 @@ and the `Gammapy project summary on Open HUB`_.
 Note that because Gammapy started out as a fork of the
 `Astropy affiliated package template <https://github.com/astropy/package-template>`__,
 the automatic contributors summary on Github and Ohloh is not accurate in the sense
-that it contains the contributions to the (non-Gammapy-specific) Astropy affiliated project template. 
+that it contains the contributions to the (non-Gammapy-specific) Astropy affiliated project template.
 
 .. _PyFACT: http://pyfact.readthedocs.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ but the idea is that Gammapy is a place to share and collaborate for gamma-ray a
 * Ask questions on the `Gammapy mailing list`_.
 * Request features, report bugs or contribute on the `Gammapy GitHub page`_.
 * Check out the `Gammapy project summary on Open HUB`_ or the `Gammapy page on PyPI`_.
-* Requires Python (version 2.7 and 3.3 or later), Numpy (version 1.6 or later) and Astropy (version 0.4 or later)
+* Requires Python (version 2.7 and 3.3 or later), Numpy (version 1.6 or later) and Astropy (version 1.0 or later)
 
 General documentation
 ---------------------
@@ -35,6 +35,7 @@ General documentation
   references
   credit
   development/index
+  changelog
 
 The Gammapy toolbox
 -------------------


### PR DESCRIPTION
This PR adds a changelog to Gammapy (similar to how Astropy does it).
I've also set release dates and defined milestones on Github for the coming months.