### PR TITLE
Update to reproject API changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,9 @@ For plans and progress see https://github.com/gammapy/gammapy/milestones/0.3
 Pull requests
 +++++++++++++
 
-- No changes yet
+- EventList class fixes and new features [#256] (Christoph Deil)
+- Add offset-dependent effective area IRF class [#260] (Johannes King)
+- Fix spiral arm model bar radius [#261] (Stefan Klepser)
 
 .. _gammapy_0p2_release:
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -189,7 +189,9 @@ it has full-text search and git history view:
 * https://github.com/sherpa/sherpa
 * https://github.com/zblz/naima
 * https://github.com/woodmd/gammatools
+* https://github.com/fermiPy/fermipy
 * https://github.com/kialio/VHEObserverTools
+* https://github.com/taldcroft/xrayevents
 
 These are unofficial, unmaintained copies on open codes on Github:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,8 +31,12 @@ News
 
 To get notifications for Gammapy releases, join the `Gammapy mailing list`_ or follow `Gammapy on Twitter`_.
 
-* April 13, 2015: Gammapy 0.2 release. See changelog: :ref:`gammapy_0p2_release`
-* August 25, 2014: Gammapy 0.1 release. See changelog: :ref:`gammapy_0p1_release`
+* May - August 2015 --- Manuel Paz Arribas GSoC 2015 on `gammapy.background`
+  (`project description <https://github.com/astropy/astropy/wiki/GSoC-2015-Application-Manuel-Paz-Arribas:-Astropy:-background-modeling-for-Gammapy>`__)
+* April 20, 2015 --- Sherpa becomes an open project (`blog post <http://pysherpa.blogspot.de/2015/04/sherpa-becomes-open-project.html>`_)
+  ... will be used more in Gammapy.
+* April 13, 2015 --- Gammapy 0.2 release. See changelog: :ref:`gammapy_0p2_release`
+* August 25, 2014 --- Gammapy 0.1 release. See changelog: :ref:`gammapy_0p1_release`
 
 .. _gammapy_general_docs:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -141,7 +141,7 @@ Optional dependencies (imported and used only where needed):
 * `photutils`_ for image photometry
 * `imfun`_ for a trous wavelet decomposition
 * `uncertainties`_ for Gaussian error propagation
-* `reproject`_ for image reprojection (temporary, will become `astropy.reproject`)
+* `reproject`_ for image reprojection
 * `naima`_ for SED modeling
 
 .. note:: We didn't put any effort into minimizing the number of dependencies ...

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -82,6 +82,8 @@ Make sure to also check out the following packages that contain very useful func
 * `gammatools`_ --- Python tools for Fermi-LAT gamma-ray data analysis by Matthew Wood
 * `naima`_ --- an SED modeling and fitting package by Victor Zabalza
 * `GamERa`_ --- a C++ gamma-ray source modeling package (SED, SNR model, Galactic population model) by Joachim Hahn
+* http://voparis-cta-client.obspm.fr/ --- prototype web app for CTA data access / analysis, not open source.
+
 
 .. _Sherpa: http://cxc.cfa.harvard.edu/sherpa/
 .. _GammaLib: http://gammalib.sourceforge.net
@@ -100,3 +102,15 @@ Some other projects:
 .. _act-analysis: https://bitbucket.org/kosack/act-analysis
 .. _VHEObserverTools: https://github.com/kialio/VHEObserverTools
 .. _photon_simulator: http://yt-project.org/doc/analyzing/analysis_modules/photon_simulator.html
+
+Other useful packages
+---------------------
+
+In addition to the packages mentioned in the last section and at :ref:`install-requirements`,
+here's a few other Python packages you might find useful / interesting:
+
+* See the list here: http://www.astropy.org/affiliated/
+* Pulsar timing package `PINT <https://github.com/nanograv/PINT>`__
+* `iminuit <https://github.com/iminuit/iminuit>`__ fitter and
+  `probfit <https://github.com/iminuit/probfit>`__ likelihood function builder.
+

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -58,7 +58,20 @@ see `here <http://nbviewer.ipython.org/github/gammapy/gammapy-extra/blob/master/
 External
 ========
 
-TODO: make a separate sub-page for presentations / posters / papers about Gammapy and move this:
+Here's some links to good external resources to learn Python, Numpy, Scipy, Astropy, ...
 
+Python is very popular in astronomy (and data science in general).
+It's possible to learn the basics within a day and to become productive within a week.
+
+* Tom Robitaille Python for scientists workshop –– http://www2.mpia-hd.mpg.de/~robitaille/PY4SCI_SS_2015/
+* Scientific Python lecture notes –– https://scipy-lectures.github.io/
+* Practical Python for astronomers — http://python4astronomers.github.io
+* MPIK Astropy workshop — https://astropy4mpik.readthedocs.org/
+* CEA Python for astronomers workshop –– https://github.com/kosack/CEAPythonWorkshopForAstronomers
+* ctools — http://cta.irap.omp.eu/ctools-devel/
+* Astropy tutorials — http://www.astropy.org/astropy-tutorials/
+* Naima examples — http://naima.readthedocs.org/en/latest/
+* Fermi ScienceTools analysis threads ––– http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/
+* CIAO Sherpa threads ––– http://cxc.harvard.edu/sherpa/threads/index.html
 * `Astropy tutorial by Axel Donath from December 2013
   <http://nbviewer.ipython.org/github/adonath/gamma_astropy_talk/blob/master/gamma_astropy_talk.ipynb>`_

--- a/gammapy/data/spectral_cube.py
+++ b/gammapy/data/spectral_cube.py
@@ -364,7 +364,7 @@ class SpectralCube(object):
         reprojected_cube : `SpectralCube`
             Cube spatially reprojected to the reference cube.
         """
-        from reproject import reproject
+        from reproject import reproject_interp
 
         reference = reference_cube.data
         shape_out = reference[0].shape
@@ -388,7 +388,7 @@ class SpectralCube(object):
         for i in energy_slices:
             array = cube[i]
             data_in = (array.value, wcs_in)
-            new_cube[i] = reproject(data_in, wcs_out, shape_out, projection_type)[0]
+            new_cube[i] = reproject_interp(data_in, wcs_out, shape_out, order=projection_type)[0]
         new_cube = Quantity(new_cube, array.unit)
         # Create new wcs
         header_in = self.wcs.to_header()


### PR DESCRIPTION
Use [pytest.mark.importorskip](https://pytest.org/latest/builtin.html#_pytest.runner.importorskip) as a simpler way to skip tests that require optional dependencies.