### PR TITLE
Add SNRCat dataset access function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Pull requests
 - EventList class fixes and new features [#256] (Christoph Deil)
 - Add offset-dependent effective area IRF class [#260] (Johannes King)
 - Fix spiral arm model bar radius [#261] (Stefan Klepser)
+- Add SNRCat dataset access function [#262] (Christoph Deil)
 - Add hspec - spectral analysis using Sherpa [#264] (Regis Terrier, Ignasi Reichardt, Christoph Deil)
 
 .. _gammapy_0p2_release:

--- a/gammapy/datasets/catalogs.py
+++ b/gammapy/datasets/catalogs.py
@@ -4,14 +4,17 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from astropy.table import Table
+import numpy as np
+from astropy.utils.data import download_file
+from astropy.coordinates import Angle
+from astropy.table import Table, Column
 from ..datasets import get_path
 
 __all__ = ['load_catalog_atnf',
            'load_catalog_hess_galactic',
            # 'load_catalog_hgps',
            'load_catalog_green',
-           # 'load_catalog_snrcat',
+           'fetch_catalog_snrcat',
            'load_catalog_tevcat',
            ]
 
@@ -116,25 +119,82 @@ def load_catalog_tevcat():
     filename = get_path('catalogs/tevcat.fits.gz', location='remote')
     return Table.read(filename)
 
-# TODO: implement properly
-def load_catalog_snrcat():
-    """Load SNRcat supernova remnant catalog.
+
+def fetch_catalog_snrcat(cache=True):
+    """Fetch SNRcat supernova remnant catalog.
 
     `SNRcat <http://www.physics.umanitoba.ca/snr/SNRcat/>`__
     is a census of high-energy observations of Galactic supernova remnants.
 
-    Unfortunately the SNRCat information is not available in electronic format.
+    This function obtains the CSV table from
+    http://www.physics.umanitoba.ca/snr/SNRcat/SNRdownload.php?table=SNR
+    and adds some useful columns and unit information.
 
-    This is a dump of http://www.physics.umanitoba.ca/snr/SNRcat/SNRlist.php?textonly from 2015-02-08.
-    It doesn't contain position and extension columns and is really a HTML page with lots of hidden stuff that
-    would have to be scraped, i.e. we can't be simply ``requests.get`` the latest version from there ... sigh.
-    I've contacted them and they might provide a useful version of their catalog in the future ...
+    Note that this only represents a subset of the information available in SNRCat,
+    to get at the rest (e.g. observations and papers) we would have to scrape their
+    web pages.
+
+    Parameters
+    ----------
+    cache : bool, optional
+        Whether to use the cache
 
     Returns
     -------
     catalog : `~astropy.table.Table`
         Source catalog
     """
-    filename = get_path('catalogs/SNRCat.csv', location='remote')
-    return Table.read(filename, format='ascii.csv')
+    url = 'http://www.physics.umanitoba.ca/snr/SNRcat/SNRdownload.php?table=SNR'
+    filename = download_file(url, cache=cache)
 
+    # Note: currently the first line contains this comment, which we skip via `header_start=1`
+    # This file was downloaded on 2015-05-11T03:00:55 CDT from http://www.physics.umanitoba.ca/snr/SNRcat
+    table = Table.read(filename, format='ascii.csv', header_start=1, delimiter=';')
+
+    # Fix the columns to have common column names and add unit info
+
+    table.rename_column('G', 'Source_Name')
+    table.rename_column('J', 'Source_JName')
+
+    table.rename_column('G_lon', 'GLON')
+    table['GLON'].unit = 'deg'
+    table.rename_column('G_lat', 'GLAT')
+    table['GLAT'].unit = 'deg'
+
+    table.rename_column('J_ra', 'RAJ2000_str')
+    table.rename_column('J_dec', 'DEJ2000_str')
+
+    data = Angle(table['RAJ2000_str'], unit='hour').deg
+    index = table.index_column('RAJ2000_str') + 1
+    table.add_column(Column(data=data, name='RAJ2000', unit='deg'), index=index)
+
+    data = Angle(table['DEJ2000_str'], unit='deg').deg
+    index = table.index_column('DEJ2000_str') + 1
+    table.add_column(Column(data=data, name='DEJ2000', unit='deg'), index=index)
+
+    table.rename_column('age_min (yr)', 'age_min')
+    table['age_min'].unit = 'year'
+    table.rename_column('age_max (yr)', 'age_max')
+    table['age_max'].unit = 'year'
+    distance = np.mean([table['age_min'], table['age_max']], axis=0)
+    index = table.index_column('age_max') + 1
+    table.add_column(Column(distance, name='age', unit='year'), index=index)
+
+    table.rename_column('distance_min (kpc)', 'distance_min')
+    table['distance_min'].unit = 'kpc'
+    table.rename_column('distance_max (kpc)', 'distance_max')
+    table['distance_max'].unit = 'kpc'
+    distance = np.mean([table['distance_min'], table['distance_max']], axis=0)
+    index = table.index_column('distance_max') + 1
+    table.add_column(Column(distance, name='distance', unit='kpc'), index=index)
+
+    table.rename_column('size_radio', 'size_radio_str')
+    table.rename_column('size_X', 'size_xray_str')
+
+    table.rename_column('size_coarse (arcmin)', 'size_radio_mean')
+    table['size_radio_mean'].unit = 'arcmin'
+
+    # TODO: maybe we should parse the size_xray_str to get a float column?
+    # https://github.com/gammapy/gammapy-extra/blob/master/datasets/catalogs/green_snrcat_check.ipynb
+
+    return table

--- a/gammapy/datasets/tests/test_catalogs.py
+++ b/gammapy/datasets/tests/test_catalogs.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from tempfile import NamedTemporaryFile
 from astropy.tests.helper import remote_data
 from ... import datasets
 
@@ -10,6 +11,10 @@ def test_load_catalog_atnf():
     catalog = datasets.load_catalog_atnf()
     assert len(catalog) == 2399
 
+    # Check if catalog can be serialised to FITS
+    filename = NamedTemporaryFile(suffix='.fits').name
+    catalog.write(filename)
+
 
 # TODO: activate test when available
 @remote_data
@@ -17,21 +22,37 @@ def _test_load_catalog_hess_galactic():
     catalog = datasets.load_catalog_hess_galactic()
     assert len(catalog) == 42
 
+    # Check if catalog can be serialised to FITS
+    filename = NamedTemporaryFile(suffix='.fits').name
+    catalog.write(filename)
+
 
 @remote_data
 def test_load_catalog_green():
     catalog = datasets.load_catalog_green()
     assert len(catalog) == 294
 
+    # Check if catalog can be serialised to FITS
+    filename = NamedTemporaryFile(suffix='.fits').name
+    catalog.write(filename)
 
-# TODO: activate test when available
+
 @remote_data
-def _test_load_catalog_snrcat():
-    catalog = datasets.load_catalog_snrcat()
-    assert len(catalog) == 338
+def test_load_catalog_snrcat():
+    catalog = datasets.fetch_catalog_snrcat()
+    assert len(catalog) > 300
+    assert set(['Source_Name', 'RAJ2000']).issubset(catalog.colnames)
+
+    # Check if catalog can be serialised to FITS
+    filename = NamedTemporaryFile(suffix='.fits').name
+    catalog.write(filename)
 
 
 @remote_data
 def test_load_catalog_tevcat():
     catalog = datasets.load_catalog_tevcat()
     assert len(catalog) == 173
+
+    # Check if catalog can be serialised to FITS
+    filename = NamedTemporaryFile(suffix='.fits').name
+    catalog.write(filename)


### PR DESCRIPTION
This PR adds the `gammapy.datasets.fetch_catalog_snrcat` function.

The SNR parameters were extensively checked against Green's catalog (see [here](https://github.com/gammapy/gammapy-extra/blob/master/datasets/catalogs/green_snrcat_check.ipynb)) and the differences observed there will be corrected in the catalogs (all in Green's catalog I think).

Just in case the CSV version of SNRCat gets removed or changes too frequently, I've put a FITS version as of 2015-05-19 with file size 35K in https://github.com/gammapy/gammapy-extra/commit/fd2f1ed3fd3d9c33c53decc824e9d04122742cb5 generated using this command:
```
python -c 'from gammapy.datasets import fetch_catalog_snrcat; t = fetch_catalog_snrcat(cache=False); t.write("snrcat.fits.gz")'
```