### PR TITLE
Running the script gammapy-xspec results in an ImportError

### DIFF
--- a/gammapy/scripts/bin_cube.py
+++ b/gammapy/scripts/bin_cube.py
@@ -22,7 +22,6 @@ def main(args=None):
 
 def bin_cube(event_file,
              reference_file,
-             cube_file,
              out_file,
              overwrite):
     """Bin events into a LON-LAT-Energy cube."""
@@ -34,6 +33,6 @@ def bin_cube(event_file,
 
     events = Table.read(event_file)
     reference_cube = fits.open(reference_file)
-    energies = Table.read(cube_file, 'ENERGIES')
+    energies = Table.read(reference_file, 'ENERGIES')
     out_cube = bin_events_in_cube(events, reference_cube, energies)
     out_cube.writeto(out_file, clobber=overwrite)

--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -42,7 +42,9 @@ def info(version=False, tools=False, dependencies=False):
     if dependencies:
         _info_dependencies()
 
+
 def _info_version():
+    """Print Gammapy version info."""
     from gammapy import version
     print('\n*** Gammapy version info ***\n')
     print('version: {0}'.format(version.version))
@@ -52,27 +54,38 @@ def _info_version():
 
 
 def _info_tools():
-    # TODO: re-write ... this doesn't work any more
-    raise NotImplementedError
+    """Print info about Gammapy command line tools."""
     print('\n*** Gammapy tools ***\n')
+
+    # TODO: how to get a one-line description or
+    # full help text from the docstring or ArgumentParser?
+    # This is the function names, we want the command-line names
+    # that are defined in setup.py !???
+    from gammapy.utils.scripts import get_all_main_functions
+    scripts = get_all_main_functions()
+    names = sorted(scripts.keys())
+    for name in names:
+        print(name)
+
+    # Old stuff that doesn't work any more ...
     # We assume all tools are installed in the same folder as this script
     # and their names start with "gammapy-".
-    import os
-    from glob import glob
-    DIR = os.path.dirname(__file__)
-    os.chdir(DIR)
-    tools = glob('gammapy-*')
-    for tool in tools:
-        # Extract first line from docstring as description
-        description = 'no description available'
-        lines = open(tool).readlines()
-        for line in lines:
-            if line.startswith('"""'):
-                description = line.strip()[3:]
-                if description.endswith('"""'):
-                    description = description[:-3]
-                break
-        print('{0:35s} : {1}'.format(tool, description))
+    # import os
+    # from glob import glob
+    # DIR = os.path.dirname(__file__)
+    # os.chdir(DIR)
+    # tools = glob('gammapy-*')
+    # for tool in tools:
+    #     # Extract first line from docstring as description
+    #     description = 'no description available'
+    #     lines = open(tool).readlines()
+    #     for line in lines:
+    #         if line.startswith('"""'):
+    #             description = line.strip()[3:]
+    #             if description.endswith('"""'):
+    #                 description = description[:-3]
+    #             break
+    #     print('{0:35s} : {1}'.format(tool, description))
 
     print('')
 

--- a/gammapy/scripts/tests/test_all.py
+++ b/gammapy/scripts/tests/test_all.py
@@ -6,12 +6,12 @@ from ...utils.scripts import get_all_main_functions
 
 SCRIPTS = get_all_main_functions()
 NAMES = sorted(SCRIPTS.keys())
+NAMES2 = sorted(set(NAMES) - set(['check']))
 
 
 @pytest.mark.parametrize("name", NAMES)
 def test_help(name):
     """Test that --help works for all scripts."""
-    # main = SCRIPTS[name].resolve()
     main = SCRIPTS[name]
     with pytest.raises(SystemExit) as exc:
         main(['--help'])
@@ -20,3 +20,11 @@ def test_help(name):
     # Assert exit code or what was printed to sys.stdout?
     # print(exc.value)
     # assert exc.value == SystemExit(0)
+
+
+# @pytest.mark.parametrize("name", NAMES2)
+# def test_no_args(name):
+#     """Test that passing no args prints a usage error message for all scripts."""
+#     main = SCRIPTS[name]
+#     with pytest.raises(SystemExit) as exc:
+#         main()

--- a/gammapy/scripts/tests/test_bin_image.py
+++ b/gammapy/scripts/tests/test_bin_image.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from tempfile import NamedTemporaryFile
+from astropy.tests.helper import pytest, remote_data
+from ...datasets import get_path
+from ..bin_image import main as bin_image_main
+
+
+def test_bin_image_main():
+    with pytest.raises(SystemExit) as exc:
+        bin_image_main()
+
+    with pytest.raises(SystemExit) as exc:
+        bin_image_main(['--help'])
+
+    # TODO: how to assert that it ran OK?
+    # Assert exit code or what was printed to sys.stdout?
+    # print(exc.value)
+    # assert exc.value == SystemExit(0)
+
+    # TODO: make a better example dataset where the counts are actually
+    # inside the image, then add useful asserts
+
+    event_file = get_path('hess/run_0023037_hard_eventlist.fits.gz')
+    reference_file = get_path('fermi/fermi_exposure.fits.gz')
+    with NamedTemporaryFile(suffix='.fits') as temp_file:
+        open(temp_file.name, 'w').write('hi')
+        text = open(temp_file.name).read()
+        assert text == 'hi'
+    # TODO: this doesn't currently work because bin_image_main has an issue
+    # (could be considered a bug)
+    # bin_image_main([event_file, reference_file, out_file])
+    # read output file and assert something

--- a/gammapy/scripts/xspec.py
+++ b/gammapy/scripts/xspec.py
@@ -25,4 +25,4 @@ def xspec():
     TODO: describe
     """
     # TODO: implement
-    raise NotImplementedError
+    print('error: this tool is not implemented')

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -63,8 +63,6 @@ def get_all_main_functions():
     path = os.path.join(os.path.dirname(__file__), '../scripts')
     names = glob.glob1(path, '*.py')
     names = [_.replace('.py', '') for _ in names]
-    print(names)
-    print(path)
     for name in ['__init__']:
         names.remove(name)
 
@@ -72,4 +70,5 @@ def get_all_main_functions():
     for name in names:
         module = importlib.import_module('gammapy.scripts.{}'.format(name))
         out[name] = module.main
+
     return out

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ entry_points['console_scripts'] = [
     'gammapy-simulate-source-catalog = gammapy.scripts.simulate_source_catalog:main',
     'gammapy-test = gammapy.scripts.check:main',
     'gammapy-ts-image = gammapy.scripts.ts_image:main',
-    'gammapy-xspec = gammapy.scripts.xpsec:main',
+    'gammapy-xspec = gammapy.scripts.xspec:main',
 ]
 
 # Note: usually the `affiliated_package/data` folder is used for data files.


### PR DESCRIPTION
I understand that xspec functionality isn't actually implemented, but noticed while trying to build a conda package for gammapy that one of the tests the conda builder runs, executing all command-line scripts with `--help`, fails for `gammapy-xspec` in a surprising way (traceback below). Other scripts which aren't actually implemented (e.g. `detect`) pass this test.

```python
$ gammapy-xspec --help
Traceback (most recent call last):
  File "/Users/mcraig/anaconda/envs/_test/bin/gammapy-xspec", line 4, in <module>
    from gammapy.scripts.xpsec import main
ImportError: No module named xpsec
```