### PR TITLE
Add new subpackage: gammapy.time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Pull requests
 - Add SNRCat dataset access function [#262] (Christoph Deil)
 - Add hspec - spectral analysis using Sherpa [#264] (Regis Terrier, Ignasi Reichardt, Christoph Deil)
 - Improve SNRcat dataset [#279] (Christoph Deil)
+- Add new subpackage: gammapy.time [#280] (Christoph Deil)
 
 .. _gammapy_0p2_release:
 

--- a/docs/dataformats/index.rst
+++ b/docs/dataformats/index.rst
@@ -28,7 +28,8 @@ in the :ref:`dataformats_file_formats` section.
    maps
    cubes
    spectra
-   
+   lightcurves
+
    psf
    observation_lists
    source_models

--- a/docs/dataformats/lightcurves.rst
+++ b/docs/dataformats/lightcurves.rst
@@ -1,0 +1,12 @@
+.. _dataformats_lightcurves:
+
+Lightcurves
+===========
+
+TODO: Are there any standard formats for light curves?
+
+TODO: Should we support this?
+
+* Monthly light-curves in the Fermi catalogs
+* http://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/ap_lcs.php
+* https://github.com/gammapy/gammapy/issues/281

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,7 @@ The Gammapy toolbox
   obs/index
   shower/index
   spectrum/index
+  time/index
   stats/index
   utils/index
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -82,6 +82,7 @@ Make sure to also check out the following packages that contain very useful func
 * `gammatools`_ --- Python tools for Fermi-LAT gamma-ray data analysis by Matthew Wood
 * `naima`_ --- an SED modeling and fitting package by Victor Zabalza
 * `GamERa`_ --- a C++ gamma-ray source modeling package (SED, SNR model, Galactic population model) by Joachim Hahn
+* `Enrico <https://github.com/gammapy/enrico/>`__ --- helps you with your Fermi data analysis
 * http://voparis-cta-client.obspm.fr/ --- prototype web app for CTA data access / analysis, not open source.
 
 

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -29,6 +29,7 @@
 .. _healpy: https://healpy.readthedocs.org/en/latest/
 .. _PyYAML: https://pypi.python.org/pypi/PyYAML/
 .. _emcee: http://dan.iel.fm/emcee/current/
+.. _Enrico: https://github.com/gammapy/enrico/
 
 .. _Gammapy mailing list: http://groups.google.com/group/gammapy
 .. _Gammapy on Twitter: https://twitter.com/Gammapy

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1,0 +1,48 @@
+.. _time:
+
+********************************
+Timing analysis (`gammapy.time`)
+********************************
+
+.. currentmodule:: gammapy.time
+
+Introduction
+============
+
+`gammapy.time` contains methods for timing analysis.
+
+At the moment there's almost no functionality here.
+Any contributions welcome, e.g.
+
+* utility functions for time computations
+* lightcurve analysis functions
+* pulsar periodogram
+* event dead time calculations and checks for constant rate
+
+Although where possible we shouldn't duplicate timing analysis functionality
+that's already available elsewhere. In some cases it's enough to refer
+gamma-ray astronomers to other packages, sometimes a convenience wrapper for
+our data formats or units might make sense.
+
+Some references (please add what you find useful
+
+* https://github.com/matteobachetti/MaLTPyNT
+* https://github.com/nanograv/PINT
+* http://www.astroml.org/modules/classes.html#module-astroML.time_series
+* http://www.astroml.org/book_figures/chapter10/index.html
+* http://astropy.readthedocs.org/en/latest/api/astropy.stats.bayesian_blocks.html
+* https://github.com/samconnolly/DELightcurveSimulation
+* https://github.com/cokelaer/spectrum
+* https://github.com/YSOVAR/YSOVAR
+* http://nbviewer.ipython.org/github/YSOVAR/Analysis/blob/master/TimeScalesinYSOVAR.ipynb
+
+Getting Started
+===============
+
+TODO: document
+
+Reference/API
+=============
+
+.. automodapi:: gammapy.time
+    :no-inheritance-diagram:

--- a/gammapy/time/__init__.py
+++ b/gammapy/time/__init__.py
@@ -1,0 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Timing analysis tools.
+"""
+from .plot import *
+from .simulate import *

--- a/gammapy/time/plot.py
+++ b/gammapy/time/plot.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+__all__ = ['plot_time_difference_distribution',
+           ]
+
+
+def plot_time_difference_distribution(time, ax=None):
+    """Plot event time difference distribution.
+
+    Parameters
+    ----------
+    time : `~astropy.time.Time`
+        Event times (must be sorted)
+    ax : `~matplotlib.axes.Axes` or None
+        Axes
+
+    Returns
+    -------
+    ax : `~matplotlib.axes.Axes`
+        Axes
+    """
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        ax = plt.gcf()
+
+    td = time[1:] - time[:-1]
+
+    # TODO: implement!
+    raise NotImplementedError

--- a/gammapy/time/simulate.py
+++ b/gammapy/time/simulate.py
@@ -1,0 +1,52 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from astropy.time import TimeDelta
+from ..utils.random import check_random_state
+
+__all__ = ['make_random_times_poisson_process',
+           ]
+
+
+def make_random_times_poisson_process(size, rate, dead_time=TimeDelta(0, format='sec'),
+                                      random_state=None):
+    """Make random times assuming a Poisson process.
+
+    This function can be used to test event time series,
+    to have a comparison what completely random data looks like.
+
+    For the implementation see
+    `here <http://preshing.com/20111007/how-to-generate-random-timings-for-a-poisson-process/>`__ and
+    `here <http://stackoverflow.com/questions/1155539/how-do-i-generate-a-poisson-process>`__,
+    as well as `numpy.random.exponential`.
+
+
+    TODO: I think usually one has a given observation duration,
+    not a given number of events to generate.
+    Implementing this is more difficult because then the number
+    of samples to generate is variable.
+
+    Parameters
+    ----------
+    size : int
+        Number of samples
+    rate : `~astropy.units.Quantity`
+        Event rate (dimension: 1 / TIME)
+    dead_time : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`
+        Dead time after event (dimension: TIME)
+
+    Returns
+    -------
+    time : `~astropy.time.TimeDelta`
+        Time differences (second) after time zero.
+    """
+    rng = check_random_state(random_state)
+    dead_time = TimeDelta(dead_time)
+
+    scale = (1 / rate).to('second').value
+    time_delta = rng.exponential(scale=scale, size=size)
+
+    time_delta = TimeDelta(time_delta, format='sec')
+    time_delta += dead_time
+
+    return time_delta

--- a/gammapy/time/tests/test_plot.py
+++ b/gammapy/time/tests/test_plot.py
@@ -1,0 +1,16 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from astropy.tests.helper import pytest
+from ..plot import plot_time_difference_distribution
+
+try:
+    import matplotlib
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
+
+@pytest.mark.skipif('not HAS_MATPLOTLIB')
+def test_plot_time_difference_distribution():
+    pass

--- a/gammapy/time/tests/test_simulate.py
+++ b/gammapy/time/tests/test_simulate.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+import numpy as np
+from numpy.testing import assert_almost_equal
+from astropy.units import Quantity
+from ..simulate import make_random_times_poisson_process as random_times
+
+
+def test_make_random_times_poisson_process():
+    time = random_times(size=10,
+                        rate=Quantity(10, 'Hz'),
+                        dead_time=Quantity(0.1, 'second'),
+                        random_state=0)
+    assert np.min(time) >= Quantity(0.1, 'second')
+    assert_almost_equal(time[0].sec, 0.179587450816311)
+    assert_almost_equal(time[-1].sec, 0.14836021009022532)

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -1,12 +1,33 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Random sampling for some common distributions"""
 from __future__ import print_function, division
+import numbers
 import numpy as np
 
-__all__ = ['sample_sphere',
+__all__ = ['check_random_state',
+           'sample_sphere',
            'sample_sphere_distance',
            'sample_powerlaw',
            ]
+
+def check_random_state(seed):
+    """Turn seed into a `numpy.random.RandomState` instance.
+
+    * If seed is None, return the RandomState singleton used by np.random.
+    * If seed is an int, return a new RandomState instance seeded with seed.
+    * If seed is already a RandomState instance, return it.
+    * Otherwise raise ValueError.
+
+    This function was copied from scikit-learn.
+    """
+    if seed is None or seed is np.random:
+        return np.random.mtrand._rand
+    if isinstance(seed, (numbers.Integral, np.integer)):
+        return np.random.RandomState(seed)
+    if isinstance(seed, np.random.RandomState):
+        return seed
+    raise ValueError('{} cannot be used to seed a numpy.random.RandomState'
+                     ' instance'.format(seed))
 
 
 def sample_sphere(size, lon_range=None, lat_range=None, unit='radians'):


### PR DESCRIPTION
This PR adds a new subpackage: `gammapy.time`.

The main purpose is to make it clear to potential contributors that code for light curves, variability analysis, pulsar periodograms, dead time calculations, ... whatever is useful to gamma-ray astronomers, is welcome in Gammapy and there's a place to put things.