### PR TITLE
Consistent random number handling and improve sample_sphere

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ Pull requests
 - Remove gammapy.shower package [#291] (Christoph Deil)
 - Add cube background model class [#299] (Manuel Paz Arribas)
 - Use assert_quantity_allclose from Astropy [#306] (Manuel Paz Arribas)
-- sample_sphere should use Quantity objects [#283] (Manuel Paz Arribas)
+- Change sample_sphere to use Angle objects [#283] (Manuel Paz Arribas)
 
 .. _gammapy_0p2_release:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Pull requests
 - Remove gammapy.shower package [#291] (Christoph Deil)
 - Add cube background model class [#299] (Manuel Paz Arribas)
 - Use assert_quantity_allclose from Astropy [#306] (Manuel Paz Arribas)
+- sample_sphere should use Quantity objects [#283] (Manuel Paz Arribas)
 
 .. _gammapy_0p2_release:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ Pull requests
 - Remove gammapy.shower package [#291] (Christoph Deil)
 - Add cube background model class [#299] (Manuel Paz Arribas)
 - Use assert_quantity_allclose from Astropy [#306] (Manuel Paz Arribas)
-- Change sample_sphere to use Angle objects [#283] (Manuel Paz Arribas)
+- Consistent random number handling and improve sample_sphere [#283] (Manuel Paz Arribas)
 
 .. _gammapy_0p2_release:
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -394,7 +394,6 @@ an optional dependency we use for speed, or whether we use the much more establi
 At the time of writing (April 2015), the TS map computation code uses Cython and multiprocessing
 and Numba is not used yet.
 
-
 What belongs in Gammapy and what doesn't?
 -----------------------------------------
 
@@ -447,3 +446,36 @@ In this case, use
 
 at the top of the file and then just use ``assert_quantity_allclose``
 for the tests.
+
+Random numbers
+--------------
+
+When generating random numbers it is useful to define a `random
+state` (a.k.a. `seed`) in order to produce pseudo-random numbers.
+This has the advantage of having random number that are reproducible
+if using the same `random state`, so the results can be reproduced.
+
+In Gammapy, there is a utility function to deal with random states:
+`~gammapy.utils.random.check_random_state`. The best way is to
+import it on top of the file that should use it with
+
+.. code-block:: python
+
+    from gammapy.utils.random import check_random_state
+
+and define a random number generator as
+
+.. code-block:: python
+
+    rng = check_random_state(random_state)
+
+where ``random_state`` is either an int or a
+`~numpy.random.RandomState`. If using it on a function, ``random_state`` should be made a parameter of it. Then one can call the desired random generator method on top of ``rng``. For example
+
+.. code-block:: python
+
+    rng.uniform(low, high, size)
+
+For more details, please see the
+`scikit-learn <http://scikit-learn.org/stable/developers/#random-numbers>`__
+doc on random numbers.

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -81,7 +81,9 @@ def make_catalog_random_positions_cube(size=100, dimension=3, dmax=10,
     return table
 
 
-def make_catalog_random_positions_sphere(size, center='Earth', distance=Quantity([0, 1], 'Mpc')):
+def make_catalog_random_positions_sphere(size, center='Earth',
+                                         distance=Quantity([0, 1], 'Mpc'),
+                                         random_state=None):
     """Sample random source locations in a sphere.
 
     This can be used to generate an isotropic source population
@@ -95,6 +97,10 @@ def make_catalog_random_positions_sphere(size, center='Earth', distance=Quantity
         Sphere center
     distance : `~astropy.units.Quantity` tuple
         Distance min / max range.
+    random_state : int or `~numpy.random.RandomState`, optional
+        Pseudo-random number generator state used for random
+        sampling. Separate function calls with the same parameters
+        and ``random_state`` will generate identical result.
 
     Returns
     -------
@@ -105,8 +111,9 @@ def make_catalog_random_positions_sphere(size, center='Earth', distance=Quantity
         - GLON, GLAT (deg)
         - Distance (Mpc)
     """
-    lon, lat = sample_sphere(size)
-    radius = sample_sphere_distance(distance[0], distance[1], size)
+    lon, lat = sample_sphere(size, random_state=random_state)
+    radius = sample_sphere_distance(distance[0], distance[1], size,
+                                    random_state=random_state)
 
     # TODO: it shouldn't be necessary here to convert to cartesian ourselves ...
     x, y, z = spherical_to_cartesian(radius, lat, lon)

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -145,6 +145,7 @@ def make_catalog_random_positions_sphere(size, center='Earth',
     return table
 
 
+'''
 def make_cat_gauss_random(n_sources=100, glon_sigma=30, glat_sigma=1,
                           extension_mean=0, extension_sigma=0.3,
                           flux_index=1, flux_min=10, flux_max=1000,
@@ -154,7 +155,10 @@ def make_cat_gauss_random(n_sources=100, glon_sigma=30, glat_sigma=1,
     Default GLON, GLAT, EXTENSION, FLUX distributions
     are similar to what was observed by HESS.
 
-    Useful for simulations of detection and fitting methods."""
+    Useful for simulations of detection and fitting methods.
+
+    TODO: this function is commented out: improve/remove it?
+    """
     # initialise random number generator
     rng = check_random_state(random_state)
 
@@ -175,7 +179,10 @@ def make_cat_gauss_random(n_sources=100, glon_sigma=30, glat_sigma=1,
 
 def make_cat_gauss_grid(nside=3, sigma_min=0.05, flux_min=1e-11):
     """A test catalog for fitting which contains
-    just a few Gaussians in a grid"""
+    just a few Gaussians in a grid
+
+    TODO: this function is commented out: improve/remove it?
+    """
     n_sources = nside ** 2
     GLON = np.zeros(n_sources)
     GLAT = np.zeros(n_sources)
@@ -197,6 +204,7 @@ def make_cat_gauss_grid(nside=3, sigma_min=0.05, flux_min=1e-11):
              'sigma', 'flux', 'ampl']
     table = make_fits_table(locals(), names)
     return add_missing_morphology_columns(table)
+'''
 
 
 def make_base_catalog_galactic(n_sources, rad_dis='YK04', vel_dis='H05',

--- a/gammapy/catalog/tests/test_xmatch.py
+++ b/gammapy/catalog/tests/test_xmatch.py
@@ -10,13 +10,19 @@ from ...catalog import (
     table_xmatch_circle_criterion,
     table_xmatch,
 )
+from ...utils.random import check_random_state
 
 
 def test_catalog_xmatch_circle():
+    # initialise random number generator
     np.random.seed(0)
+    #rng = check_random_state(0)
+
     catalog = make_catalog_random_positions_sphere(size=100, center='Milky Way')
     catalog['Source_Name'] = ['source_{:04d}'.format(_) for _ in range(len(catalog))]
     catalog['Association_Radius'] = Angle(10 * np.random.random(len(catalog)), unit='deg')
+    #catalog['Association_Radius'] = Angle(rng.uniform(0, 10, len(catalog)), unit='deg')
+    # TODO: not working with rng!!! (but why did it work before??!!!)
     other_catalog = make_catalog_random_positions_sphere(size=100, center='Milky Way')
     other_catalog['Source_Name'] = ['source_{:04d}'.format(_) for _ in range(len(other_catalog))]
     result = catalog_xmatch_circle(catalog, other_catalog)

--- a/gammapy/catalog/tests/test_xmatch.py
+++ b/gammapy/catalog/tests/test_xmatch.py
@@ -15,15 +15,14 @@ from ...utils.random import check_random_state
 
 def test_catalog_xmatch_circle():
     # initialise random number generator
-    np.random.seed(0)
-    #rng = check_random_state(0)
+    rng = check_random_state(0)
 
-    catalog = make_catalog_random_positions_sphere(size=100, center='Milky Way')
+    catalog = make_catalog_random_positions_sphere(size=100, center='Milky Way',
+                                                   random_state=rng)
     catalog['Source_Name'] = ['source_{:04d}'.format(_) for _ in range(len(catalog))]
-    catalog['Association_Radius'] = Angle(10 * np.random.random(len(catalog)), unit='deg')
-    #catalog['Association_Radius'] = Angle(rng.uniform(0, 10, len(catalog)), unit='deg')
-    # TODO: not working with rng!!! (but why did it work before??!!!)
-    other_catalog = make_catalog_random_positions_sphere(size=100, center='Milky Way')
+    catalog['Association_Radius'] = Angle(rng.uniform(0, 10, len(catalog)), unit='deg')
+    other_catalog = make_catalog_random_positions_sphere(size=100, center='Milky Way',
+                                                         random_state=rng)
     other_catalog['Source_Name'] = ['source_{:04d}'.format(_) for _ in range(len(other_catalog))]
     result = catalog_xmatch_circle(catalog, other_catalog)
     assert len(result) == 23

--- a/gammapy/datasets/make.py
+++ b/gammapy/datasets/make.py
@@ -170,8 +170,8 @@ def make_test_observation_table(observatory_name, n_obs, debug=False):
     # az, alt
     # random points in a sphere above 45 deg altitude
     az, alt = sample_sphere(len(obs_id),
-                            Quantity([0, 360], 'degree'),
-                            Quantity([45, 90], 'degree'))
+                            Angle([0, 360], 'degree'),
+                            Angle([45, 90], 'degree'))
     az = Angle(az, 'degree')
     alt = Angle(alt, 'degree')
     obs_table['AZ'] = az

--- a/gammapy/datasets/make.py
+++ b/gammapy/datasets/make.py
@@ -169,7 +169,9 @@ def make_test_observation_table(observatory_name, n_obs, debug=False):
 
     # az, alt
     # random points in a sphere above 45 deg altitude
-    az, alt = sample_sphere(len(obs_id), (0, 360), (45, 90), 'degree')
+    az, alt = sample_sphere(len(obs_id),
+                            Quantity([0, 360], 'degree'),
+                            Quantity([45, 90], 'degree'))
     az = Angle(az, 'degree')
     alt = Angle(alt, 'degree')
     obs_table['AZ'] = az

--- a/gammapy/detect/tests/test_matched_filter.py
+++ b/gammapy/detect/tests/test_matched_filter.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.convolution import Gaussian2DKernel
 from ...detect import matched_filter
+from ...utils.random import check_random_state
 
 try:
     import scipy
@@ -52,8 +53,9 @@ def test_image():
     excess = total_excess * Gaussian2DKernel(3, x_size=x_size_image, y_size=y_size_image).array
     background = total_background * ones / ones.sum()
     counts = excess + background
-    #np.random.seed(0)
-    #counts = np.random.poisson(counts)
+    # initialise random number generator
+    #rng = check_random_state(0)
+    #counts = rng.poisson(counts)
     images = dict(counts=counts, background=background)
 
     probability = matched_filter.probability_image(images, kernel)

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -21,6 +21,7 @@ from ...image import (coordinates,
                       lookup,
                       lon_lat_rectangle_mask,
                       )
+from ...utils.random import check_random_state
 
 try:
     import skimage
@@ -118,9 +119,11 @@ def test_process_image_pixels():
         process_image_pixels(images, kernel, out, convolve_function)
         return out['image']
 
-    np.random.seed(0)
-    image = np.random.random((7, 10))
-    kernel = np.random.random((3, 5))
+    # initialise random number generator
+    rng = check_random_state(0)
+
+    image = rng.uniform(size=(7, 10))
+    kernel = rng.uniform(size=(3, 5))
     actual = convolve(image, kernel)
     desired = astropy_convolve(image, kernel, boundary='fill')
     assert_allclose(actual, desired)

--- a/gammapy/spectrum/fitting_utils.py
+++ b/gammapy/spectrum/fitting_utils.py
@@ -5,6 +5,7 @@ TODO: Unusable at the moment. Refactor into classes and clean up.
 """
 from __future__ import print_function, division
 import numpy as np
+from ..utils.random import check_random_state
 
 __all__ = ['generate_MC_data',
            'plot_chi2',
@@ -24,7 +25,7 @@ def set_off_diagonal_to_zero(matrix):
     return matrix
 
 
-def generate_MC_data(model, xlim, yerr, npoints=5, verbose=0):
+def generate_MC_data(model, xlim, yerr, npoints=5, verbose=0, random_state=None):
     """Generate points with equal-log spacing in x given by the model.
 
     model = [function, parameters, constants]
@@ -33,6 +34,9 @@ def generate_MC_data(model, xlim, yerr, npoints=5, verbose=0):
     Returns:
     data = x, y, ydn, yup
     """
+    # initialise random number generator
+    rng = check_random_state(random_state)
+
     # Generate equal-log spaced x points
     logx = np.linspace(np.log10(xlim[0]), np.log10(xlim[1]), npoints)
     x = 10 ** logx
@@ -50,11 +54,11 @@ def generate_MC_data(model, xlim, yerr, npoints=5, verbose=0):
     #
 
     # First decide if an up or down fluctuation occurs
-    fluctuate_up = np.random.randint(0, 2, npoints)  # 1 = yes, 2 = no
+    fluctuate_up = rng.randint(0, 2, npoints)  # 1 = yes, 2 = no
 
     # Then draw a random y value
-    yobs_dn = np.fabs(np.random.normal(0, ydn, size=npoints))
-    yobs_up = np.fabs(np.random.normal(0, yup, size=npoints))
+    yobs_dn = np.fabs(rng.normal(0, ydn, size=npoints))
+    yobs_up = np.fabs(rng.normal(0, yup, size=npoints))
     yobs = y + np.where(fluctuate_up == 1, yobs_up, -yobs_dn)
 
     if verbose > 0:

--- a/gammapy/spectrum/tests/test_powerlaw.py
+++ b/gammapy/spectrum/tests/test_powerlaw.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from ...spectrum import powerlaw
+from ...utils.random import check_random_state
 
 try:
     import scipy
@@ -47,15 +48,18 @@ def test_closure(g_error_mag=0):
     I and g have correlated errors, but we
     effectively throw away these correlations!"""
 
+    # initialise random number generator
+    rng = check_random_state(0)
+
     npoints = 100
     # Generate some random f values with errors
-    f_val = 10 ** (10 * np.random.random(npoints) - 5)
-    f_err = f_val * np.random.normal(1, 0.1, npoints)
+    f_val = 10 ** (10 * rng.uniform(size=npoints) - 5)
+    f_err = f_val * rng.normal(1, 0.1, npoints)
     # f = unumpy.uarray((f_val, f_err))
 
     # Generate some random g values with errors
-    g_val = 5 * np.random.random(npoints)
-    g_err = g_val * np.random.normal(1, 0.1, npoints)
+    g_val = 5 * rng.uniform(size=npoints)
+    g_err = g_val * rng.normal(1, 0.1, npoints)
     # g = unumpy.uarray((g_val, g_err))
 
     I_val, I_err = powerlaw.I_with_err(f_val, f_err, g_val, g_err)

--- a/gammapy/stats/data.py
+++ b/gammapy/stats/data.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
+from ..utils.random import check_random_state
 
 __all__ = ['Stats',
            'make_stats',
@@ -68,15 +69,18 @@ class Stats(object):
 
 
 def make_stats(signal, background, area_factor, weight_method="background",
-               poisson_fluctuate=False):
+               poisson_fluctuate=False, random_state=None):
     """Fill using some weight method for the exposure.
     """
+    # initialise random number generator
+    rng = check_random_state(random_state)
+
     # Compute counts
     n_on = signal + background
     n_off = area_factor * background
     if poisson_fluctuate:
-        n_on = np.random.poisson(n_on)
-        n_off = np.random.poisson(n_off)
+        n_on = rng.poisson(n_on)
+        n_off = rng.poisson(n_off)
 
     # Compute weight
     if weight_method == "none":

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -8,6 +8,7 @@ from ...stats import (cash,
                       cstat,
                       chi2datavar,
                       )
+from ...utils.random import check_random_state
 
 # TODO: test against Sherpa results
 # see scripts here: https://github.com/gammapy/gammapy/tree/master/dev/sherpa/stats
@@ -16,8 +17,9 @@ from ...stats import (cash,
 def test_likelihood_stats():
     # Create some example input
     M = np.array([[0.2, 0.5, 1, 2], [10, 10.5, 100.5, 1000]])
-    np.random.seed(0)
-    D = np.random.poisson(M)
+    # initialise random number generator
+    rng = check_random_state(0)
+    D = rng.poisson(M)
 
     assert_allclose(cash(D, M), 42)
     assert_allclose(cstat(D, M), 42)

--- a/gammapy/stats/tests/test_fitting.py
+++ b/gammapy/stats/tests/test_fitting.py
@@ -20,8 +20,9 @@ def test_PoissonLikelihoodFitter():
     model = Gaussian1D(amplitude=1000, mean=2, stddev=3)
     x = np.arange(-10, 20, 0.1)
     dx = 0.1 * np.ones_like(x)
-    np.random.seed(0)
-    y = np.random.poisson(dx * model(x))
+    # initialise random number generator
+    rng = check_random_state(0)
+    y = rng.poisson(dx * model(x))
 
     fitter = PoissonLikelihoodFitter()
     model = fitter(model, x, y, dx)

--- a/gammapy/time/simulate.py
+++ b/gammapy/time/simulate.py
@@ -20,7 +20,6 @@ def make_random_times_poisson_process(size, rate, dead_time=TimeDelta(0, format=
     `here <http://stackoverflow.com/questions/1155539/how-do-i-generate-a-poisson-process>`__,
     as well as `numpy.random.exponential`.
 
-
     TODO: I think usually one has a given observation duration,
     not a given number of events to generate.
     Implementing this is more difficult because then the number
@@ -32,8 +31,12 @@ def make_random_times_poisson_process(size, rate, dead_time=TimeDelta(0, format=
         Number of samples
     rate : `~astropy.units.Quantity`
         Event rate (dimension: 1 / TIME)
-    dead_time : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`
+    dead_time : `~astropy.units.Quantity` or `~astropy.time.TimeDelta`, optional
         Dead time after event (dimension: TIME)
+    random_state : int or `~numpy.random.RandomState`, optional
+        Pseudo-random number generator state used for random
+        sampling. Separate function calls with the same parameters
+        and ``random_state`` will generate identical results.
 
     Returns
     -------

--- a/gammapy/time/simulate.py
+++ b/gammapy/time/simulate.py
@@ -43,7 +43,9 @@ def make_random_times_poisson_process(size, rate, dead_time=TimeDelta(0, format=
     time : `~astropy.time.TimeDelta`
         Time differences (second) after time zero.
     """
+    # initialise random number generator
     rng = check_random_state(random_state)
+
     dead_time = TimeDelta(dead_time)
 
     scale = (1 / rate).to('second').value

--- a/gammapy/utils/distributions/general_random.py
+++ b/gammapy/utils/distributions/general_random.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 import numpy as np
 from astropy.extern.six.moves import range
+from ...utils.random import check_random_state
 
 __all__ = ['GeneralRandom']
 
@@ -76,15 +77,32 @@ class GeneralRandom(object):
         self.delta_inversecdf = \
             np.concatenate((np.diff(self.inversecdf), [0]))
 
-    def draw(self, N=1000):
+    def draw(self, N=1000, random_state=None):
         """Returns an array of random numbers with the requested distribution.
 
-        N: array length
-
         The random numbers x are generated using the lookups
-        inversecdf and delta_inversecdf."""
+        inversecdf and delta_inversecdf.
+
+        Parameters
+        ----------
+        N: int
+            array length
+
+        random_state : int or `~numpy.random.RandomState`, optional
+            Pseudo-random number generator state used for random
+            sampling. Separate function calls with the same parameters
+            and ``random_state`` will generate identical results.
+
+        Returns
+        -------
+        x : `~numpy.ndarray`
+            random numbers
+        """
+        # initialise random number generator
+        rng = check_random_state(random_state)
+
         # Generate uniform random float index in range [0, ninversecdf-1]
-        idx_f = np.random.uniform(size=N, high=self.ninversecdf - 1)
+        idx_f = rng.uniform(size=N, high=self.ninversecdf - 1)
         # Round down to next integer
         idx = np.array(idx_f, 'i')
         # Use the inversecdf lookup to get the corresponding x

--- a/gammapy/utils/distributions/general_random_array.py
+++ b/gammapy/utils/distributions/general_random_array.py
@@ -1,6 +1,7 @@
 """Implementation of the GeneralRandomArray class"""
 from __future__ import print_function, division
 import numpy as np
+from ...utils.random import check_random_state
 
 __all__ = ['GeneralRandomArray']
 
@@ -18,10 +19,13 @@ class GeneralRandomArray(object):
     http://www.cs.utk.edu/~parker/Courses/CS302-Fall06/Notes/PQueues/random_num_gen.html
     """
 
-    def __init__(self, pdf):
+    def __init__(self, pdf, random_state=None):
         """
         Computes the cdf from the pdf
         """
+        # initialise random number generator
+        rng = check_random_state(random_state)
+
         # Note that numpy flattens the array automatically,
         # i.e. cdf is a 1D array (normalization not necessary)
         self.cdf = pdf.cumsum()
@@ -34,7 +38,7 @@ class GeneralRandomArray(object):
     def draw(self, n=1, return_flat_index=False):
         """Returns n draws from the pdf
         If return_flat_index == true, a linearized index is returned."""
-        u = np.random.uniform(0, self.cdfmax, size=n)
+        u = rng.uniform(0, self.cdfmax, size=n)
         indices = self.cdf.searchsorted(u)
         if return_flat_index:
             return indices

--- a/gammapy/utils/pyfact.py
+++ b/gammapy/utils/pyfact.py
@@ -25,6 +25,7 @@ from ..irf import (np_to_rmf,
                    )
 from ..spectrum import np_to_pha
 from ..version import version
+from ..utils.random import check_random_state
 
 
 __all__ = ['ChisquareFitter',
@@ -296,7 +297,8 @@ def sim_evlist(flux=.1,
                output_filename_base=None,
                write_pha=False,
                do_graphical_output=True,
-               loglevel='INFO'):
+               loglevel='INFO',
+               random_state=None):
     """Simulate IACT eventlist using an ARF file.
 
     TODO: describe.
@@ -312,6 +314,10 @@ def sim_evlist(flux=.1,
     from scipy.interpolate import UnivariateSpline
     from scipy.integrate import quad
     import matplotlib.pyplot as plt
+
+    # initialise random number generator
+    rng = check_random_state(random_state)
+
     #---------------------------------------------------------------------------
 
     logging.info('Exposure: {0} h'.format(obstime))
@@ -461,7 +467,7 @@ def sim_evlist(flux=.1,
     logging.debug('Number of photons : {0}'.format(n_events))
 
     # Generate energy event list
-    evlist_e = ev_gen_f(np.random.rand(n_events))
+    evlist_e = ev_gen_f(rng.rand(n_events))
 
     # Sanity
     logging.debug('Number of photons with E = NaN : {0}'.format(np.sum(np.isnan(evlist_e))))
@@ -488,10 +494,10 @@ def sim_evlist(flux=.1,
         evlist_psf = bpl(psf_p1, 10. ** evlist_e)
         logging.warning('Using dummy PSF extracted from SubarrayE_IFAE_50hours_20101102')
 
-    evlist_dec = obj_dec + np.random.randn(n_events) * evlist_psf
-    evlist_ra = obj_ra + np.random.randn(n_events) * evlist_psf / objcosdec
+    evlist_dec = obj_dec + rng.randn(n_events) * evlist_psf
+    evlist_ra = obj_ra + rng.randn(n_events) * evlist_psf / objcosdec
 
-    evlist_t = t_min + obstime * np.random.rand(n_events) / 86400.
+    evlist_t = t_min + obstime * rng.rand(n_events) / 86400.
 
     #---------------------------------------------------------------------------
     # Background
@@ -533,30 +539,30 @@ def sim_evlist(flux=.1,
     logging.debug('Number of protons : {0}'.format(n_events_bg))
 
     tplt_multi = 5
-    evlist_bg_e = ev_gen_f(np.random.rand(n_events_bg * (tplt_multi + 1)))
+    evlist_bg_e = ev_gen_f(rng.rand(n_events_bg * (tplt_multi + 1)))
 
     temp42 = quad(lambda x: cam_acc(cam_acc_par, x) * 2. * x * np.pi, 0., 4.)[0]
     ev_gen_f2 = UnivariateSpline(int_cam_acc / temp42,
                                  r_steps, s=0, k=1)
 
-    evlist_bg_r = ev_gen_f2(np.random.rand(n_events_bg * (tplt_multi + 1)))
+    evlist_bg_r = ev_gen_f2(rng.rand(n_events_bg * (tplt_multi + 1)))
 
     r_max = 4.
-    # evlist_bg_r = np.sqrt(np.random.rand(n_events_bg * (tplt_multi + 1))) * r_max
-    rnd = np.random.rand(n_events_bg * (1 + tplt_multi))
-    evlist_bg_rx = np.sqrt(rnd) * evlist_bg_r * np.where(np.random.randint(2, size=(n_events_bg * (tplt_multi + 1))) == 0, -1., 1.)
-    evlist_bg_ry = np.sqrt(1. - rnd) * evlist_bg_r * np.where(np.random.randint(2, size=(n_events_bg * (tplt_multi + 1))) == 0, -1., 1.)
+    # evlist_bg_r = np.sqrt(rng.rand(n_events_bg * (tplt_multi + 1))) * r_max
+    rnd = rng.rand(n_events_bg * (1 + tplt_multi))
+    evlist_bg_rx = np.sqrt(rnd) * evlist_bg_r * np.where(rng.randint(2, size=(n_events_bg * (tplt_multi + 1))) == 0, -1., 1.)
+    evlist_bg_ry = np.sqrt(1. - rnd) * evlist_bg_r * np.where(rng.randint(2, size=(n_events_bg * (tplt_multi + 1))) == 0, -1., 1.)
 
-    # evlist_bg_sky_r = np.sqrt(np.random.rand(n_events_bg * (tplt_multi + 1))) * r_max
-    # evlist_bg_sky_r = ev_gen_f2(np.random.rand(n_events_bg * (tplt_multi + 1)))
-    rnd = np.random.rand(n_events_bg * (tplt_multi + 1))
+    # evlist_bg_sky_r = np.sqrt(rng.rand(n_events_bg * (tplt_multi + 1))) * r_max
+    # evlist_bg_sky_r = ev_gen_f2(rng.rand(n_events_bg * (tplt_multi + 1)))
+    rnd = rng.rand(n_events_bg * (tplt_multi + 1))
     evlist_bg_ra = np.sin(2. * np.pi * rnd) * evlist_bg_r / objcosdec
     evlist_bg_dec = np.cos(2. * np.pi * rnd) * evlist_bg_r
 
     # plt.hist(evlist_bg_rx ** 2. + evlist_bg_ry**2., bins=50)
 
     # print float(n_events_bg * (tplt_multi + 1)) / np.sum(p_rate_area) / 86400.
-    evlist_bg_t = t_min + obstime * np.random.rand(n_events_bg * (tplt_multi + 1)) / 86400.
+    evlist_bg_t = t_min + obstime * rng.rand(n_events_bg * (tplt_multi + 1)) / 86400.
 
     #---------------------------------------------------------------------------
     # Plots & debug

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, division
 import numbers
 import numpy as np
+from astropy.units import Quantity
 
 __all__ = ['check_random_state',
            'sample_sphere',
@@ -30,7 +31,7 @@ def check_random_state(seed):
                      ' instance'.format(seed))
 
 
-def sample_sphere(size, lon_range=None, lat_range=None, unit='rad'):
+def sample_sphere(size, lon_range=None, lat_range=None):
     """Sample random points on the sphere.
 
     Reference: http://mathworld.wolfram.com/SpherePointPicking.html
@@ -39,38 +40,32 @@ def sample_sphere(size, lon_range=None, lat_range=None, unit='rad'):
     ----------
     size : int
         Number of samples to generate
-    lon_range : tuple
-        Longitude range (min, max) tuple in range (0, 360)
-    lat_range : tuple
-        Latitude range (min, max) tuple in range (-90, 90)
-    units : {'rad', 'deg'}
-        Units of input range and returned angles
+    lon_range : `~astropy.units.Quantity`, optional
+        Longitude range (min, max) in range (0, 360) deg
+    lat_range : `~astropy.units.Quantity`, optional
+        Latitude range (min, max) in range (-90, 90) deg
 
     Returns
     -------
-    lon, lat: arrays
+    lon, lat: `~astropy.units.Quantity`
         Longitude and latitude coordinate arrays
     """
-    # Correctly interpret units at an early stage
-    if unit in ['rad', 'radian', 'radians']:
-        unit = 'rad'
-    elif unit in ['deg', 'degree', 'degrees']:
-        unit = 'deg'
-    else:
-        raise ValueError('Invalid unit: {0}'.format(unit))
-
     # Convert inputs to internal format (all radians)
     size = int(size)
 
-    if (lon_range is not None) and (unit == 'deg'):
-        lon_range = np.radians(lon_range)
+    if lon_range is not None:
+        lon_unit = lon_range.unit
+        lon_range.to('radian')
     else:
-        lon_range = 0, 2 * np.pi
+        lon_unit = 'radian'
+        lon_range = Quantity([0., 2*np.pi], lon_unit)
 
-    if (lat_range is not None) and (unit == 'deg'):
-        lat_range = np.radians(lat_range)
+    if lat_range is not None:
+        lat_unit = lon_range.unit
+        lat_range.to('radian')
     else:
-        lat_range = -np.pi / 2, np.pi / 2
+        lat_unit = 'radian'
+        lat_range = Quantity([-np.pi/2., np.pi/2.], lat_unit)
 
     # Sample random longitude
     u = np.random.random(size)
@@ -78,16 +73,14 @@ def sample_sphere(size, lon_range=None, lat_range=None, unit='rad'):
 
     # Sample random latitude
     v = np.random.random(size)
-    z_range = np.sin(np.array(lat_range))
+    #z_range = np.sin(np.array(lat_range))
+    z_range = np.sin(lat_range)
     z = z_range[0] + (z_range[1] - z_range[0]) * v
     # This is not the formula given in the reference, but it is equivalent.
     lat = np.arcsin(z)
 
     # Return result
-    if unit == 'rad':
-        return lon, lat
-    elif unit == 'deg':
-        return np.degrees(lon), np.degrees(lat)
+    return lon.to(lon_unit), lat.to(lat_unit)
 
 
 def sample_powerlaw(x_min, x_max, gamma, size=None):

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 import numbers
 import numpy as np
-from astropy.coordinates import Longitude, Latitude
+from astropy.coordinates import Angle
 
 __all__ = ['check_random_state',
            'sample_sphere',
@@ -40,9 +40,9 @@ def sample_sphere(size, lon_range=None, lat_range=None, random_state=None):
     ----------
     size : int
         Number of samples to generate
-    lon_range : `~astropy.coordinates.Longitude`, optional
+    lon_range : `~astropy.coordinates.Angle`, optional
         Longitude range (min, max)
-    lat_range : `~astropy.coordinates.Latitude`, optional
+    lat_range : `~astropy.coordinates.Angle`, optional
         Latitude range (min, max)
     random_state : int or `~numpy.random.RandomState`, optional
         Pseudo-random number generator state used for random
@@ -51,7 +51,7 @@ def sample_sphere(size, lon_range=None, lat_range=None, random_state=None):
 
     Returns
     -------
-    lon, lat: `~astropy.units.Longitude`, `~astropy.coordinates.Latitude`
+    lon, lat: `~astropy.units.Angle`
         Longitude and latitude coordinate arrays
     """
     # initialise random number generator
@@ -59,20 +59,10 @@ def sample_sphere(size, lon_range=None, lat_range=None, random_state=None):
 
     #Check input parameters
     if lon_range is None:
-        epsilon = 1.e-8
-        lon_range = Longitude([0., 2*np.pi-epsilon], 'radian')
+        lon_range = Angle([0., 360.], 'degree')
 
     if lat_range is None:
-        lat_range = Latitude([-np.pi/2., np.pi/2.], 'radian')
-
-    ##import IPython; IPython.embed()
-
-#    if lon_range[0] < 0:
-#        # convert to (0, 360) deg
-#        lon_format = '-180_180_deg'
-#        lon_range += Angle(180., 'degree')
-#    else:
-#        lon_format = '0_360_deg'
+        lat_range = Angle([-90., 90.], 'degree')
 
     # Sample random longitude
     u = rng.uniform(size=size)
@@ -85,9 +75,6 @@ def sample_sphere(size, lon_range=None, lat_range=None, random_state=None):
     lat = np.arcsin(z)
 
     # Return result
-#    if lon_format == '-180_180_deg':
-#        # convert back to (-180, 180) deg
-#        lon -= Angle(180., 'degree')
     return lon, lat
 
 

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 import numbers
 import numpy as np
-from astropy.coordinates import Angle
+from astropy.coordinates import Longitude, Latitude
 
 __all__ = ['check_random_state',
            'sample_sphere',
@@ -40,29 +40,32 @@ def sample_sphere(size, lon_range=None, lat_range=None):
     ----------
     size : int
         Number of samples to generate
-    lon_range : `~astropy.coordinates.Angle`, optional
-        Longitude range (min, max) in range (0, 360) deg or (-180, 180) deg
-    lat_range : `~astropy.coordinates.Angle`, optional
-        Latitude range (min, max) in range (-90, 90) deg
+    lon_range : `~astropy.coordinates.Longitude`, optional
+        Longitude range (min, max)
+    lat_range : `~astropy.coordinates.Latitude`, optional
+        Latitude range (min, max)
 
     Returns
     -------
-    lon, lat: `~astropy.units.Angle`
+    lon, lat: `~astropy.units.Longitude`, `~astropy.coordinates.Latitude`
         Longitude and latitude coordinate arrays
     """
     #Check input parameters
     if lon_range is None:
-        lon_range = Angle([0., 2*np.pi], 'radian')
+        epsilon = 1.e-8
+        lon_range = Longitude([0., 2*np.pi-epsilon], 'radian')
 
     if lat_range is None:
-        lat_range = Angle([-np.pi/2., np.pi/2.], 'radian')
+        lat_range = Latitude([-np.pi/2., np.pi/2.], 'radian')
 
-    if lon_range[0] < 0:
-        # convert to (0, 360) deg
-        lon_format = '-180_180_deg'
-        lon_range += Angle(180., 'degree')
-    else:
-        lon_format = '0_360_deg'
+    ##import IPython; IPython.embed()
+
+#    if lon_range[0] < 0:
+#        # convert to (0, 360) deg
+#        lon_format = '-180_180_deg'
+#        lon_range += Angle(180., 'degree')
+#    else:
+#        lon_format = '0_360_deg'
 
     # Sample random longitude
     u = np.random.random(size)
@@ -76,9 +79,9 @@ def sample_sphere(size, lon_range=None, lat_range=None):
     lat = np.arcsin(z)
 
     # Return result
-    if lon_format == '-180_180_deg':
-        # convert back to (-180, 180) deg
-        lon -= Angle(180., 'degree')
+#    if lon_format == '-180_180_deg':
+#        # convert back to (-180, 180) deg
+#        lon -= Angle(180., 'degree')
     return lon, lat
 
 

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -31,7 +31,7 @@ def check_random_state(seed):
                      ' instance'.format(seed))
 
 
-def sample_sphere(size, lon_range=None, lat_range=None):
+def sample_sphere(size, lon_range=None, lat_range=None, random_state=None):
     """Sample random points on the sphere.
 
     Reference: http://mathworld.wolfram.com/SpherePointPicking.html
@@ -44,12 +44,19 @@ def sample_sphere(size, lon_range=None, lat_range=None):
         Longitude range (min, max)
     lat_range : `~astropy.coordinates.Latitude`, optional
         Latitude range (min, max)
+    random_state : int or `~numpy.random.RandomState`, optional
+        Pseudo-random number generator state used for random
+        sampling. Separate function calls with the same parameters
+        and ``random_state`` will generate identical results.
 
     Returns
     -------
     lon, lat: `~astropy.units.Longitude`, `~astropy.coordinates.Latitude`
         Longitude and latitude coordinate arrays
     """
+    # initialise random number generator
+    rng = check_random_state(random_state)
+
     #Check input parameters
     if lon_range is None:
         epsilon = 1.e-8
@@ -68,14 +75,13 @@ def sample_sphere(size, lon_range=None, lat_range=None):
 #        lon_format = '0_360_deg'
 
     # Sample random longitude
-    u = np.random.random(size)
+    u = rng.uniform(size=size)
     lon = lon_range[0] + (lon_range[1] - lon_range[0]) * u
 
     # Sample random latitude
-    v = np.random.random(size)
+    v = rng.uniform(size=size)
     z_range = np.sin(lat_range)
     z = z_range[0] + (z_range[1] - z_range[0]) * v
-    # This is not the formula given in the reference, but it is equivalent.
     lat = np.arcsin(z)
 
     # Return result
@@ -85,7 +91,7 @@ def sample_sphere(size, lon_range=None, lat_range=None):
     return lon, lat
 
 
-def sample_powerlaw(x_min, x_max, gamma, size=None):
+def sample_powerlaw(x_min, x_max, gamma, size=None, random_state=None):
     """Sample random values from a power law distribution.
 
     f(x) = x ** (-gamma) in the range x_min to x_max
@@ -100,25 +106,31 @@ def sample_powerlaw(x_min, x_max, gamma, size=None):
         x range maximum
     gamma : float
         Power law index
-    size : int
+    size : int, optional
         Number of samples to generate
+    random_state : int or `~numpy.random.RandomState`, optional
+        Pseudo-random number generator state used for random
+        sampling. Separate function calls with the same parameters
+        and ``random_state`` will generate identical results.
 
     Returns
     -------
     x : array
         Array of samples from the distribution
     """
+    # initialise random number generator
+    rng = check_random_state(random_state)
+
     size = int(size)
 
-    u = np.random.random(size)
     exp = 1. - gamma
-    base = x_min ** exp + u * (x_max ** exp - x_min ** exp)
+    base = rng.uniform(x_min ** exp, x_max ** exp, size)
     x = base ** (1 / exp)
 
     return x
 
 
-def sample_sphere_distance(distance_min=0, distance_max=1, size=None):
+def sample_sphere_distance(distance_min=0, distance_max=1, size=None, random_state=None):
     """Sample random distances if the 3-dim space density is constant.
 
     This function uses inverse transform sampling
@@ -128,16 +140,23 @@ def sample_sphere_distance(distance_min=0, distance_max=1, size=None):
 
     Parameters
     ----------
-    size : int
-        Number of samples
-    distance_min, distance_max : float
+    distance_min, distance_max : float, optional
         Distance range in which to sample
+    size : int, optional
+        Number of samples
+    random_state : int or `~numpy.random.RandomState`, optional
+        Pseudo-random number generator state used for random
+        sampling. Separate function calls with the same parameters
+        and ``random_state`` will generate identical results.
 
     Returns
     -------
     distance : array
         Array of samples
     """
+    # initialise random number generator
+    rng = check_random_state(random_state)
+
     # Since the differential distribution is dP / dr ~ r ^ 2,
     # we have a cumulative distribution
     #     P(r) = a * r ^ 3 + b
@@ -152,7 +171,7 @@ def sample_sphere_distance(distance_min=0, distance_max=1, size=None):
     #     u = a * r ^ 3 + b
     # which is
     #     r = [(u - b)/ a] ^ (1 / 3)
-    u = np.random.random(size)
+    u = rng.uniform(size=size)
     distance = ((u - b) / a) ** (1. / 3)
 
     return distance

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, division
 import numbers
 import numpy as np
-from astropy.units import Quantity
+from astropy.coordinates import Angle
 
 __all__ = ['check_random_state',
            'sample_sphere',
@@ -40,14 +40,14 @@ def sample_sphere(size, lon_range=None, lat_range=None):
     ----------
     size : int
         Number of samples to generate
-    lon_range : `~astropy.units.Quantity`, optional
+    lon_range : `~astropy.coordinates.Angle`, optional
         Longitude range (min, max) in range (0, 360) deg
-    lat_range : `~astropy.units.Quantity`, optional
+    lat_range : `~astropy.coordinates.Angle`, optional
         Latitude range (min, max) in range (-90, 90) deg
 
     Returns
     -------
-    lon, lat: `~astropy.units.Quantity`
+    lon, lat: `~astropy.units.Angle`
         Longitude and latitude coordinate arrays
     """
     # Convert inputs to internal format (all radians)
@@ -58,14 +58,14 @@ def sample_sphere(size, lon_range=None, lat_range=None):
         lon_range.to('radian')
     else:
         lon_unit = 'radian'
-        lon_range = Quantity([0., 2*np.pi], lon_unit)
+        lon_range = Angle([0., 2*np.pi], lon_unit)
 
     if lat_range is not None:
         lat_unit = lon_range.unit
         lat_range.to('radian')
     else:
         lat_unit = 'radian'
-        lat_range = Quantity([-np.pi/2., np.pi/2.], lat_unit)
+        lat_range = Angle([-np.pi/2., np.pi/2.], lat_unit)
 
     # Sample random longitude
     u = np.random.random(size)

--- a/gammapy/utils/tests/test_random.py
+++ b/gammapy/utils/tests/test_random.py
@@ -8,10 +8,32 @@ from ..random import sample_sphere, sample_powerlaw, sample_sphere_distance
 
 
 def test_sample_sphere():
+
+    # test general case
     np.random.seed(0)
     lon, lat = sample_sphere(size=2)
     assert_quantity_allclose(lon, Angle([3.44829694, 4.49366732], 'radian'))
     assert_quantity_allclose(lat, Angle([0.20700192, 0.08988736], 'radian'))
+
+    # test specify a limited range
+    lon_min = Angle(40., 'degree')
+    lon_max = Angle(45., 'degree')
+    lat_min = Angle(10., 'degree')
+    lat_max = Angle(15., 'degree')
+    lon, lat = sample_sphere(size=10,
+                             lon_range=Angle([lon_min, lon_max]),
+                             lat_range=Angle([lat_min, lat_max]))
+    assert (lon_min <= lon).all() & (lon < lon_max).all()
+    assert (lat_min <= lat).all() & (lat < lat_max).all()
+
+    # test long in (-180, 180) deg range
+    lon_min = Angle(-40., 'degree')
+    lon_max = Angle(0., 'degree')
+    lon, lat = sample_sphere(size=10, lon_range=Angle([lon_min, lon_max]))
+    assert (lon_min <= lon).all() & (lon < lon_max).all()
+    lat_min = Angle(-90., 'degree')
+    lat_max = Angle(90., 'degree')
+    assert (lat_min <= lat).all() & (lat < lat_max).all()
 
 
 def test_sample_powerlaw():

--- a/gammapy/utils/tests/test_random.py
+++ b/gammapy/utils/tests/test_random.py
@@ -2,15 +2,16 @@
 from __future__ import print_function, division
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.units import Quantity
+from astropy.coordinates import Angle
+from astropy.tests.helper import assert_quantity_allclose
 from ..random import sample_sphere, sample_powerlaw, sample_sphere_distance
 
 
 def test_sample_sphere():
     np.random.seed(0)
     lon, lat = sample_sphere(size=2)
-    assert_allclose(lon, Quantity([3.44829694, 4.49366732], 'radian'))
-    assert_allclose(lat, Quantity([0.20700192, 0.08988736], 'radian'))
+    assert_quantity_allclose(lon, Angle([3.44829694, 4.49366732], 'radian'))
+    assert_quantity_allclose(lat, Angle([0.20700192, 0.08988736], 'radian'))
 
 
 def test_sample_powerlaw():

--- a/gammapy/utils/tests/test_random.py
+++ b/gammapy/utils/tests/test_random.py
@@ -4,14 +4,17 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle, Longitude, Latitude
 from astropy.tests.helper import assert_quantity_allclose
-from ..random import sample_sphere, sample_powerlaw, sample_sphere_distance
+from ..random import (sample_sphere, sample_powerlaw,
+                      sample_sphere_distance, check_random_state)
 
 
 def test_sample_sphere():
 
+    # initialise random number generator
+    rng = check_random_state(0)
+
     # test general case
-    np.random.seed(0)
-    lon, lat = sample_sphere(size=2)
+    lon, lat = sample_sphere(size=2, random_state=rng)
     assert_quantity_allclose(lon, Longitude([3.44829694, 4.49366732], 'radian'))
     assert_quantity_allclose(lat, Latitude([0.20700192, 0.08988736], 'radian'))
 
@@ -20,13 +23,14 @@ def test_sample_sphere():
     lat_range = Latitude([10., 15.], 'degree')
     lon, lat = sample_sphere(size=10,
                              lon_range=lon_range,
-                             lat_range=lat_range)
+                             lat_range=lat_range,
+                             random_state=rng)
     assert ((lon_range[0] <= lon) & (lon < lon_range[1])).all()
     assert ((lat_range[0] <= lat) & (lat < lat_range[1])).all()
 
     # test lon within (-180, 180) deg range
     lon_range = Longitude([-40., 0.], 'degree', wrap_angle=Angle(180., 'degree'))
-    lon, lat = sample_sphere(size=10, lon_range=lon_range)
+    lon, lat = sample_sphere(size=10, lon_range=lon_range, random_state=rng)
     assert ((lon_range[0] <= lon) & (lon < lon_range[1])).all()
     lat_range = Latitude([-90., 90.], 'degree')
     assert ((lat_range[0] <= lat) & (lat < lat_range[1])).all()
@@ -34,7 +38,7 @@ def test_sample_sphere():
     # test lon range explicitly (0, 360) deg
     epsilon = 1.e-8
     lon_range = Longitude([0., 360.-epsilon], 'degree')
-    lon, lat = sample_sphere(size=100, lon_range=lon_range)
+    lon, lat = sample_sphere(size=100, lon_range=lon_range, random_state=rng)
     angle_0 = Angle(0., 'degree')
     angle_360 = Angle(360., 'degree')
     angle_m90 = Angle(-90., 'degree')
@@ -54,16 +58,20 @@ def test_sample_sphere():
 
 
 def test_sample_powerlaw():
-    np.random.seed(0)
-    x = sample_powerlaw(x_min=0.1, x_max=10, gamma=2, size=2)
+    # initialise random number generator
+    rng = check_random_state(0)
+
+    x = sample_powerlaw(x_min=0.1, x_max=10, gamma=2, size=2, random_state=rng)
     assert_allclose(x, [0.21897428, 0.34250971])
 
 
 def test_sample_sphere_distance():
-    np.random.seed(0)
-    x = sample_sphere_distance(distance_min=0.1, distance_max=42, size=2)
+    # initialise random number generator
+    rng = check_random_state(0)
+
+    x = sample_sphere_distance(distance_min=0.1, distance_max=42, size=2, random_state=rng)
     assert_allclose(x, [34.386731, 37.559774])
 
-    x = sample_sphere_distance(distance_min=0.1, distance_max=42, size=1e3)
+    x = sample_sphere_distance(distance_min=0.1, distance_max=42, size=1e3, random_state=rng)
     assert x.min() >= 0.1
     assert x.max() <= 42

--- a/gammapy/utils/tests/test_random.py
+++ b/gammapy/utils/tests/test_random.py
@@ -2,14 +2,15 @@
 from __future__ import print_function, division
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.units import Quantity
 from ..random import sample_sphere, sample_powerlaw, sample_sphere_distance
 
 
 def test_sample_sphere():
     np.random.seed(0)
     lon, lat = sample_sphere(size=2)
-    assert_allclose(lon, [3.44829694, 4.49366732])
-    assert_allclose(lat, [0.20700192, 0.08988736])
+    assert_allclose(lon, Quantity([3.44829694, 4.49366732], 'radian'))
+    assert_allclose(lat, Quantity([0.20700192, 0.08988736], 'radian'))
 
 
 def test_sample_powerlaw():


### PR DESCRIPTION
`~gammapy.utils.random.sample_sphere` should use astropy `Angle` objects for better handling / less error prone.
TODO:
 - [x] decide if we use `Angle` or `Longitude` and `Latitude` objects
 - [x] update/revise other functions using `sample_sphere`
 - [x] finish applying issue #238 (`random_state` parameters)