### PR TITLE
Use assert_quantity_allclose from Astropy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,7 +52,8 @@ Pull requests
 - Add EffectiveAreaTable exporter to EffectiveAreaTable2D [#276] (Johannes King)
 - Add interface to HESS FitSpectrum JSON output [#296] (Christoph Deil)
 - Remove gammapy.shower package [#291] (Christoph Deil)
--  Add cube background model class [#299] (Manuel Paz Arribas)
+- Add cube background model class [#299] (Manuel Paz Arribas)
+- Use assert_quantity_allclose from Astropy [#306] (Manuel Paz Arribas)
 
 .. _gammapy_0p2_release:
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -422,7 +422,9 @@ Assert convention
 When performing tests, the preferred numerical assert method is
 `numpy.testing.assert_allclose`. Use
 
-``from numpy.testing import assert_allclose``
+.. code-block:: python
+
+    from numpy.testing import assert_allclose
 
 at the top of the file and then just use ``assert_allclose`` for
 the tests. This makes the lines shorter, i.e. there is more space
@@ -439,7 +441,9 @@ following method can be used:
 `astropy.tests.helper.assert_quantity_allclose`.
 In this case, use
 
-``from astropy.tests.helper import assert_quantity_allclose``
+.. code-block:: python
+
+    from astropy.tests.helper import assert_quantity_allclose
 
 at the top of the file and then just use ``assert_quantity_allclose``
 for the tests.

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -436,4 +436,10 @@ places.
 In case of assertion on arrays of quantity objects, such as
 `~astropy.units.Quantity` or `~astropy.coordinates.Angle`, the
 following method can be used:
-`~gammapy.utils.testing.assert_quantity`.
+`astropy.tests.helper.assert_quantity_allclose`.
+In this case, use
+
+``from astropy.tests.helper import assert_quantity_allclose``
+
+at the top of the file and then just use ``assert_quantity_allclose``
+for the tests.

--- a/gammapy/background/tests/test_models.py
+++ b/gammapy/background/tests/test_models.py
@@ -3,7 +3,7 @@ from __future__ import print_function, division
 from tempfile import NamedTemporaryFile
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest, remote_data
+from astropy.tests.helper import pytest, remote_data, assert_quantity_allclose
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 from astropy.units import Quantity
@@ -123,14 +123,14 @@ class TestCubeBackgroundModel():
 
         # test if values are correct in the saved file: compare both files
         bg_model_2 = CubeBackgroundModel.read(outfile, format='table')
-        assert_allclose(bg_model_2.background,
-                        bg_model_1.background)
-        assert_allclose(bg_model_2.detx_bins,
-                        bg_model_1.detx_bins)
-        assert_allclose(bg_model_2.dety_bins,
-                        bg_model_1.dety_bins)
-        assert_allclose(bg_model_2.energy_bins,
-                        bg_model_1.energy_bins)
+        assert_quantity_allclose(bg_model_2.background,
+                                 bg_model_1.background)
+        assert_quantity_allclose(bg_model_2.detx_bins,
+                                 bg_model_1.detx_bins)
+        assert_quantity_allclose(bg_model_2.dety_bins,
+                                 bg_model_1.dety_bins)
+        assert_quantity_allclose(bg_model_2.energy_bins,
+                                 bg_model_1.energy_bins)
 
     @remote_data
     def test_read_write_fits_image(self):
@@ -144,11 +144,11 @@ class TestCubeBackgroundModel():
 
         # test if values are correct in the saved file: compare both files
         bg_model_2 = CubeBackgroundModel.read(outfile, format='image')
-        assert_allclose(bg_model_2.background,
-                        bg_model_1.background)
-        assert_allclose(bg_model_2.detx_bins,
-                        bg_model_1.detx_bins)
-        assert_allclose(bg_model_2.dety_bins,
-                        bg_model_1.dety_bins)
-        assert_allclose(bg_model_2.energy_bins,
-                        bg_model_1.energy_bins)
+        assert_quantity_allclose(bg_model_2.background,
+                                 bg_model_1.background)
+        assert_quantity_allclose(bg_model_2.detx_bins,
+                                 bg_model_1.detx_bins)
+        assert_quantity_allclose(bg_model_2.dety_bins,
+                                 bg_model_1.dety_bins)
+        assert_quantity_allclose(bg_model_2.energy_bins,
+                                 bg_model_1.energy_bins)

--- a/gammapy/data/tests/test_spectral_cube.py
+++ b/gammapy/data/tests/test_spectral_cube.py
@@ -161,7 +161,7 @@ class TestSpectralCube(object):
     def test_solid_angle_image(self):
         actual = self.spectral_cube.solid_angle_image[10][30]
         expected = Quantity(self.spectral_cube.wcs.wcs.cdelt[:-1].prod(), 'deg2')
-        assert_quantity_allclose(actual, expected.to('sr'), rtol=1e-4)
+        assert_quantity_allclose(actual, expected, rtol=1e-4)
 
     def test_spatial_coordinate_images(self):
         lon, lat = self.spectral_cube.spatial_coordinate_images

--- a/gammapy/data/tests/test_spectral_cube.py
+++ b/gammapy/data/tests/test_spectral_cube.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.wcs import WCS
 from ...datasets import FermiGalacticCenter
@@ -13,7 +13,6 @@ from ...data import SpectralCube, compute_npred_cube, convolve_cube
 from ...image import solid_angle, make_header, make_empty_image
 from ...irf import EnergyDependentTablePSF
 from ...spectrum.powerlaw import power_law_evaluate
-from ...utils.testing import assert_quantity
 
 
 try:
@@ -60,9 +59,9 @@ class TestSpectralCube(object):
     def test_pix2world(self):
         # Corner pixel with index [0, 0, 0]
         lon, lat, energy = self.spectral_cube.pix2world(0, 0, 0)
-        assert_quantity(lon, Quantity(344.75, 'deg'))
-        assert_quantity(lat, Quantity(-5.25, 'deg'))
-        assert_quantity(energy, Quantity(50, 'MeV'))
+        assert_quantity_allclose(lon, Quantity(344.75, 'deg'))
+        assert_quantity_allclose(lat, Quantity(-5.25, 'deg'))
+        assert_quantity_allclose(energy, Quantity(50, 'MeV'))
 
     def test_world2pix(self):
         lon = Quantity(344.75, 'deg')
@@ -92,7 +91,7 @@ class TestSpectralCube(object):
         energy = Quantity(50, 'MeV')  # slice 0
         actual = self.spectral_cube.flux(lon, lat, energy)
         expected = self.spectral_cube.data[0, 0, 0]
-        assert_quantity(actual, expected)
+        assert_quantity_allclose(actual, expected)
 
         # Galactic center position
         lon = Quantity(0, 'deg')  # beween pixel 11 and 12 in ds9 viewer
@@ -108,7 +107,7 @@ class TestSpectralCube(object):
         # TODO: why are these currently inconsistent by a few % !?
         # actual   =  9.67254380e-07
         # expected = 10.13733026e-07
-        assert_quantity(actual, expected)
+        assert_quantity_allclose(actual, expected)
 
     def test_flux_mixed(self):
         # Corner pixel with index [0, 0, 0]
@@ -117,7 +116,7 @@ class TestSpectralCube(object):
         energy = Quantity(50, 'MeV')  # slice 0
         actual = self.spectral_cube.flux(lon, lat, energy)
         expected = self.spectral_cube.data[0, 0, 0]
-        assert_quantity(actual, expected)
+        assert_quantity_allclose(actual, expected)
 
     def test_flux_array(self):
         pix = [2, 2], [3, 3], [4, 4]
@@ -125,7 +124,7 @@ class TestSpectralCube(object):
         actual = self.spectral_cube.flux(*world)
         expected = self.spectral_cube.data[4, 3, 2]
         # Quantity([3.50571123e-07, 2], '1 / (cm2 MeV s sr)')
-        assert_quantity(actual, expected)
+        assert_quantity_allclose(actual, expected)
 
     def test_integral_flux_image(self):
         # For a very small energy band the integral flux should be roughly
@@ -137,7 +136,7 @@ class TestSpectralCube(object):
         expected = dflux * denergy
         actual = Quantity(self.spectral_cube.integral_flux_image(energy_band).data[0, 0],
                           '1 / (cm2 s sr)')
-        assert_quantity(actual, expected, rtol=1e-3)
+        assert_quantity_allclose(actual, expected, rtol=1e-3)
 
         # Test a wide energy band
         energy_band = Quantity([1, 10], 'GeV')
@@ -162,7 +161,7 @@ class TestSpectralCube(object):
     def test_solid_angle_image(self):
         actual = self.spectral_cube.solid_angle_image[10][30]
         expected = Quantity(self.spectral_cube.wcs.wcs.cdelt[:-1].prod(), 'deg2')
-        assert_quantity(actual, expected.to('sr'), rtol=1e-4)
+        assert_quantity_allclose(actual, expected.to('sr'), rtol=1e-4)
 
     def test_spatial_coordinate_images(self):
         lon, lat = self.spectral_cube.spatial_coordinate_images
@@ -315,4 +314,4 @@ def test_reproject_cube():
     expected = 0.0625 * original_cube.sum()
     actual = reprojected_cube.sum()
 
-    assert_quantity(actual, expected, rtol=1e-2)
+    assert_quantity_allclose(actual, expected, rtol=1e-2)

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -32,7 +32,7 @@ class TestFermiGalacticCenter():
         energy = Quantity(100, 'GeV')
         fraction = 0.68
         angle = psf.containment_radius(energy, fraction)
-        assert_quantity_allclose(angle, Angle('0.1927459865412511 deg'))
+        assert_quantity_allclose(angle, Angle(0.1927459865412511, 'degree'))
 
     def test_counts(self):
         counts = FermiGalacticCenter.counts()
@@ -70,7 +70,7 @@ class TestFermiVelaRegion():
         energy = Quantity(100, 'GeV')
         fraction = 0.68
         angle = psf.containment_radius(energy, fraction)
-        assert_quantity_allclose(angle, Angle('0.13185321269896136 deg'))
+        assert_quantity_allclose(angle, Angle(0.13185321269896136, 'degree'))
 
     @remote_data
     def test_diffuse_model(self):

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -1,11 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.coordinates import Angle
 from astropy.tests.helper import remote_data
-from ...utils.testing import assert_quantity
 from ...datasets import (FermiGalacticCenter,
                          FermiVelaRegion,
                          fetch_fermi_catalog,
@@ -33,7 +32,7 @@ class TestFermiGalacticCenter():
         energy = Quantity(100, 'GeV')
         fraction = 0.68
         angle = psf.containment_radius(energy, fraction)
-        assert_quantity(angle, Angle('0.1927459865412511 deg'))
+        assert_quantity_allclose(angle, Angle('0.1927459865412511 deg'))
 
     def test_counts(self):
         counts = FermiGalacticCenter.counts()
@@ -43,12 +42,12 @@ class TestFermiGalacticCenter():
     def test_diffuse_model(self):
         diffuse_model = FermiGalacticCenter.diffuse_model()
         assert diffuse_model.data.shape == (30, 21, 61)
-        assert_quantity(diffuse_model.energy[0], Quantity(50, 'MeV'))
+        assert_quantity_allclose(diffuse_model.energy[0], Quantity(50, 'MeV'))
 
     def test_exposure_cube(self):
         exposure_cube = FermiGalacticCenter.exposure_cube()
         assert exposure_cube.data.shape == (21, 11, 31)
-        assert_quantity(exposure_cube.energy[0], Quantity(50, 'MeV'))
+        assert_quantity_allclose(exposure_cube.energy[0], Quantity(50, 'MeV'))
 
 
 class TestFermiVelaRegion():
@@ -71,7 +70,7 @@ class TestFermiVelaRegion():
         energy = Quantity(100, 'GeV')
         fraction = 0.68
         angle = psf.containment_radius(energy, fraction)
-        assert_quantity(angle, Angle('0.13185321269896136 deg'))
+        assert_quantity_allclose(angle, Angle('0.13185321269896136 deg'))
 
     @remote_data
     def test_diffuse_model(self):
@@ -100,7 +99,7 @@ class TestFermiVelaRegion():
         exposure_cube = FermiVelaRegion.exposure_cube()
         assert exposure_cube.data.shape == (21, 50, 50)
         assert exposure_cube.data.value.sum(), 4.978616e+15
-        assert_quantity(exposure_cube.energy[0], Quantity(10000, 'MeV'))
+        assert_quantity_allclose(exposure_cube.energy[0], Quantity(10000, 'MeV'))
 
     @remote_data
     def test_livetime(self):

--- a/gammapy/datasets/tests/test_make.py
+++ b/gammapy/datasets/tests/test_make.py
@@ -2,10 +2,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
 from astropy.units import Quantity
-from ...utils.testing import assert_quantity
+from astropy.tests.helper import assert_quantity_allclose
 from ...datasets import (make_test_psf, make_test_observation_table,
                          make_test_bg_cube_model)
 from ...obs import ObservationTable
@@ -75,4 +74,4 @@ def test_make_test_bg_cube_model():
     bg = bg_cube_model.background[e_bin_index, det_bin_index[1], det_bin_index[0]]
 
     # assert that values are 0
-    assert_allclose(bg, 0.)
+    assert_quantity_allclose(bg, Quantity(0., bg.unit))

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -2,11 +2,10 @@
 from __future__ import print_function, division
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.coordinates import Angle
 from astropy.utils.data import get_pkg_data_filename
-from ...utils.testing import assert_quantity
 from ...irf import TablePSF, EnergyDependentTablePSF
 from ...datasets import FermiGalacticCenter
 
@@ -54,7 +53,7 @@ def test_TablePSF_disk():
     # TODO
     #actual = psf.containment_radius([0.01, 0.25, 0.99])
     #desired = Angle([0, 1, 2], 'deg')
-    #assert_quantity(actual, desired, rtol=1e-3)
+    #assert_quantity_allclose(actual, desired, rtol=1e-3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
@@ -70,11 +69,11 @@ def test_TablePSF():
 
     actual = psf.evaluate(offset=offset, quantity='dp_domega')
     desired = Quantity([5491.52067694, 3521.07804604], 'sr^-1')
-    assert_quantity(actual, desired)
+    assert_quantity_allclose(actual, desired)
 
     actual = psf.evaluate(offset=offset, quantity='dp_dtheta')
     desired = Quantity([60.22039017, 115.83738017], 'rad^-1')
-    assert_quantity(actual, desired, rtol=1e-6)
+    assert_quantity_allclose(actual, desired, rtol=1e-6)
 
     offset_min = Angle([0.0, 0.1, 0.3], 'deg')
     offset_max = Angle([0.1, 0.3, 2.0], 'deg')
@@ -101,11 +100,11 @@ def test_EnergyDependentTablePSF():
 
     #actual = psf.evaluate(energy=energy, offset=offset)
     #desired = Quantity(17760.814249206363, 'sr^-1')
-    #assert_quantity(actual, desired)
+    #assert_quantity_allclose(actual, desired)
 
     #actual = psf.evaluate(energy=energies, offset=offsets)
     #desired = Quantity([17760.81424921, 5134.17706619], 'sr^-1')
-    #assert_quantity(actual, desired)
+    #assert_quantity_allclose(actual, desired)
 
     psf1 = psf.table_psf_at_energy(energy)
 

--- a/gammapy/spectrum/tests/test_cosmic_ray.py
+++ b/gammapy/spectrum/tests/test_cosmic_ray.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 from astropy.units import Quantity
+from astropy.tests.helper import assert_quantity_allclose
 from ...spectrum import cosmic_ray_flux
-from ...utils.testing import assert_quantity
 
 
 def test_cosmic_ray_flux():
     energy = Quantity(1, 'TeV')
     actual = cosmic_ray_flux(energy, 'proton')
     desired = Quantity(0.096, '1 / (m2 s sr TeV)')
-    assert_quantity(actual, desired)
+    assert_quantity_allclose(actual, desired)
 
     # TODO: test array quantities and other particles

--- a/gammapy/spectrum/tests/test_diffuse.py
+++ b/gammapy/spectrum/tests/test_diffuse.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function, division
 from astropy.units import Quantity
-from ...utils.testing import assert_quantity
+from astropy.tests.helper import assert_quantity_allclose
 from ...spectrum import diffuse_gamma_ray_flux
 
 
@@ -10,4 +10,4 @@ def test_diffuse_gamma_ray_flux():
     actual = diffuse_gamma_ray_flux(energy)
     # TODO: this is a dummy value ... needs to be implemented
     desired = Quantity(1.0, 'm^-2 s^-1 sr^-1 TeV^-1')
-    assert_quantity(actual, desired)
+    assert_quantity_allclose(actual, desired)

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -2,12 +2,11 @@
 from __future__ import print_function, division
 from tempfile import NamedTemporaryFile
 from astropy.units import Quantity
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.time import Time
 from astropy.table import Table
-from ...utils.testing import assert_quantity
 from ...spectrum import np_to_pha, LogEnergyAxis, energy_bin_centers_log_spacing
 
 try:
@@ -54,18 +53,18 @@ def test_LogEnergyAxis():
     energy_axis = LogEnergyAxis(energy)
 
     assert_allclose(energy_axis.x, [0, 1, 2])
-    assert_quantity(energy_axis.energy, energy)
+    assert_quantity_allclose(energy_axis.energy, energy)
 
     energy = Quantity(gmean([1, 10]), 'TeV')
     pix = energy_axis.world2pix(energy.to('MeV'))
     assert_allclose(pix, 0.5)
 
     world = energy_axis.pix2world(pix)
-    assert_quantity(world, energy)
+    assert_quantity_allclose(world, energy)
 
 
 def test_energy_bin_centers_log_spacing():
     energy_bounds = Quantity([1, 2, 10], 'GeV')
     actual = energy_bin_centers_log_spacing(energy_bounds)
     desired = Quantity([1.41421356, 4.47213595], 'GeV')
-    assert_quantity(actual, desired)
+    assert_quantity_allclose(actual, desired)

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -1,23 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utils to create scripts and command-line tools"""
 from __future__ import print_function, division
-from numpy.testing import assert_allclose
-from astropy.units import Quantity
-from astropy.coordinates import Angle
 
-__all__ = ['assert_quantity',
-           ]
-
-
-def assert_quantity(actual, desired, *args, **kwargs):
-    """Assert value and unit for astropy Quantity.
-
-    Calls `numpy.testing.assert_allclose`.
-    """
-    if not isinstance(actual, Quantity):
-        raise ValueError("actual must be a Quantity object.")
-    if not isinstance(desired, Quantity):
-        raise ValueError("desired must be a Quantity object.")
-
-    assert actual.unit == desired.unit
-    assert_allclose(actual, desired, *args, **kwargs)
+__all__ = []

--- a/gammapy/utils/tests/test_wcs.py
+++ b/gammapy/utils/tests/test_wcs.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
+from astropy.tests.helper import assert_quantity_allclose
 from ...utils.wcs import (linear_wcs_to_arrays,
                           linear_arrays_to_wcs)
 
@@ -16,5 +16,5 @@ def test_wcs_object():
     reco_bins_x, reco_bins_y = linear_wcs_to_arrays(wcs, nbins_x, nbins_y)
 
     # test: reconstructed bins should match original bins
-    assert_allclose(reco_bins_x, bins_x)
-    assert_allclose(reco_bins_y, bins_y)
+    assert_quantity_allclose(reco_bins_x, bins_x)
+    assert_quantity_allclose(reco_bins_y, bins_y)


### PR DESCRIPTION
This function: `gammapy.utils.testing.assert_quantity` seems to be a duplication of `astropy.tests.helper.assert_quantity_allclose`. Maybe we don't need it?

If changed/removed, the docs here should be updated too: http://gammapy.readthedocs.org/en/latest/development/index.html
(the entry for the assert section (at the end of the mentioned page) is as of now missing, because it is being added in PR #299, still not merged).

Triggered by this astropy issue: https://github.com/astropy/astropy/issues/3978