### PR TITLE
Simplified attribute docstrings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,7 @@ Pull requests
 - Use assert_quantity_allclose from Astropy [#306] (Manuel Paz Arribas)
 - Consistent random number handling and improve sample_sphere [#283] (Manuel Paz Arribas)
 - Add Feldman Cousins algorithm [#311] (Dirk Lennarz)
+- Simplified attribute docstrings [#301] (Manuel Paz Arribas)
 
 .. _gammapy_0p2_release:
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -508,3 +508,25 @@ This pattern was inspired by the way
 We have changed the ``None`` option of `sklearn.utils.check_random_state` to ``'global-rng'``,
 because we felt that this meaning for ``None`` was confusing given that `numpy.random.RandomState`
 uses a different meaning (for which we use the option ``'global-rng'``).
+
+Attributes docstring format
+---------------------------
+
+The convention for class attribute docstrings is a simplified version
+of the typical function docstrings. Class attributes are class
+functions easily identifiable via the ``@property`` decorator.
+Such functions always return exactly one element, which is already
+described in the first line.
+
+In order to avoid unnecessary repetition in the docstring, the
+``Returns`` section should be avoided, and the type of the returned
+element should be placed in parentheses at the end of the first line.
+This format is also more convenient and explicative, when rendered
+for the ``Attributes Summary`` section of the class documentation.
+An example of this format can be found in the
+`~gammapy.data.EventList` class.
+
+In case N (more than one) elements of the same type are returned
+(i.e. for X and Y coordinates), a `Nx` string should preceed the
+type.
+

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -40,7 +40,7 @@ class SimplePulsar(object):
     @property
     def luminosity_spindown(self):
         """
-        Spin-down luminosity.
+        Spin-down luminosity (`~astropy.units.Quantity`)
 
         Notes
         -----
@@ -55,7 +55,7 @@ class SimplePulsar(object):
     @property
     def tau(self):
         """
-        Characteristic age.
+        Characteristic age (`~astropy.units.Quantity`)
 
         Notes
         -----
@@ -70,7 +70,7 @@ class SimplePulsar(object):
     @property
     def magnetic_field(self):
         """
-        Magnetic field strength at the polar cap.
+        Magnetic field strength at the polar cap (`~astropy.units.Quantity`)
 
         Notes
         -----

--- a/gammapy/background/kernel.py
+++ b/gammapy/background/kernel.py
@@ -219,7 +219,7 @@ class IterativeKernelBackgroundEstimator(object):
 
     @property
     def background_image_hdu(self):
-        """Resulting background estimate (`~astropy.io.fits.ImageHDU`)"""
+        """Background estimate (`~astropy.io.fits.ImageHDU`)"""
 
         header = self.header
         return fits.ImageHDU(data=self._data[-1].background,
@@ -227,7 +227,7 @@ class IterativeKernelBackgroundEstimator(object):
 
     @property
     def significance_image_hdu(self):
-        """Resulting background estimate (`~astropy.io.fits.ImageHDU`)"""
+        """Significance estimate (`~astropy.io.fits.ImageHDU`)"""
 
         header = self.header
         return fits.ImageHDU(data=self._data[-1].significance,

--- a/gammapy/background/kernel.py
+++ b/gammapy/background/kernel.py
@@ -211,7 +211,7 @@ class IterativeKernelBackgroundEstimator(object):
 
     @property
     def mask_image_hdu(self):
-        """Returns mask as `~astropy.io.fits.ImageHDU`."""
+        """Mask (`~astropy.io.fits.ImageHDU`)"""
 
         header = self.header
         return fits.ImageHDU(data=self._data[-1].mask.astype(np.uint8),
@@ -219,7 +219,7 @@ class IterativeKernelBackgroundEstimator(object):
 
     @property
     def background_image_hdu(self):
-        """Returns resulting background estimate as `~astropy.io.fits.ImageHDU`."""
+        """Resulting background estimate (`~astropy.io.fits.ImageHDU`)"""
 
         header = self.header
         return fits.ImageHDU(data=self._data[-1].background,
@@ -227,7 +227,7 @@ class IterativeKernelBackgroundEstimator(object):
 
     @property
     def significance_image_hdu(self):
-        """Returns resulting background estimate as `~astropy.io.fits.ImageHDU`."""
+        """Resulting background estimate (`~astropy.io.fits.ImageHDU`)"""
 
         header = self.header
         return fits.ImageHDU(data=self._data[-1].significance,

--- a/gammapy/background/maps.py
+++ b/gammapy/background/maps.py
@@ -105,7 +105,7 @@ class Maps(fits.HDUList):
 
         Returns
         -------
-        image : `numpy.array`
+        image : `numpy.ndarray`
             Map data
         """
         # Build a list of maps requiring correlation
@@ -133,7 +133,7 @@ class Maps(fits.HDUList):
 
         Returns
         -------
-        image : `numpy.array`
+        image : `numpy.ndarray`
             Map data
         """
         try:
@@ -163,7 +163,7 @@ class Maps(fits.HDUList):
 
     @property
     def alpha(self):
-        """Alpha map HDU."""
+        """Alpha map (`~astropy.io.fits.ImageHDU`)"""
         a_on = self.get_basic('a_on')
         a_off = self.get_basic('a_off')
         alpha = a_on / a_off
@@ -172,7 +172,7 @@ class Maps(fits.HDUList):
 
     @property
     def area_factor(self):
-        """Area factor map HDU."""
+        """Area factor map (`~astropy.io.fits.ImageHDU`)"""
         alpha = self.get_derived('alpha')
         area_factor = 1. / alpha
 
@@ -180,7 +180,7 @@ class Maps(fits.HDUList):
 
     @property
     def background(self):
-        """Background map HDU."""
+        """Background map (`~astropy.io.fits.ImageHDU`)"""
         n_off = self.get_basic('n_off')
         alpha = self.get_derived('alpha')
         background = stats.background(n_off, alpha)
@@ -189,7 +189,7 @@ class Maps(fits.HDUList):
 
     @property
     def make_excess(self):
-        """Excess map HDU."""
+        """Excess map (`~astropy.io.fits.ImageHDU`)"""
         n_on = self.get_basic('n_on')
         background = self.get_derived('background')
         excess = n_on - background
@@ -198,7 +198,7 @@ class Maps(fits.HDUList):
 
     @property
     def significance(self, method='lima', neglect_background_uncertainty=False):
-        """Significance map HDU."""
+        """Significance map (`~astropy.io.fits.ImageHDU`)"""
         n_on = self.get_basic('n_on')
         n_off = self.get_basic('n_off')
         alpha = self.get_derived('alpha')
@@ -209,7 +209,7 @@ class Maps(fits.HDUList):
 
     @property
     def flux(self):
-        """Flux map HDU."""
+        """Flux map (`~astropy.io.fits.ImageHDU`)"""
         exposure = self.get_basic('exposure')
         excess = self.get_derived('excess')
 

--- a/gammapy/background/models.py
+++ b/gammapy/background/models.py
@@ -510,8 +510,8 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        det : `~numpy.ndarray`
-            array of `~astropy.coordinates.Angle` det (X, Y) pairs to search for
+        det : `~astropy.coordinates.Angle`
+            array of det (X, Y) pairs to search for
 
         Returns
         -------
@@ -539,8 +539,8 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        energy : `~numpy.ndarray`
-            array of `~astropy.units.Quantity` energies to search for
+        energy : `~astropy.units.Quantity`
+            array of energies to search for
 
         Returns
         -------
@@ -563,8 +563,8 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        det : `~numpy.ndarray`
-            array of `~astropy.coordinates.Angle` det (X, Y) pairs to search for
+        det : `~astropy.coordinates.Angle`
+            array of det (X, Y) pairs to search for
 
         Returns
         -------
@@ -584,8 +584,8 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        energy : `~numpy.ndarray`
-            array of `~astropy.units.Quantity` energies to search for
+        energy : `~astropy.units.Quantity`
+            array of energies to search for
 
         Returns
         -------

--- a/gammapy/background/models.py
+++ b/gammapy/background/models.py
@@ -92,14 +92,14 @@ def _make_bin_edges_array(lo, hi):
 
     Parameters
     ----------
-    lo : `~numpy.array`
+    lo : `~numpy.ndarray`
         lower boundaries
-    hi : `~numpy.array`
+    hi : `~numpy.ndarray`
         higher boundaries
 
     Returns
     -------
-    bin_edges : `~numpy.array`
+    bin_edges : `~numpy.ndarray`
         array of bin edges as [[low], [high]]
     """
     return np.append(lo.flatten(), hi.flatten()[-1:])
@@ -453,12 +453,9 @@ class CubeBackgroundModel(object):
 
     @property
     def image_extent(self):
-        """Image extent `(x_lo, x_hi, y_lo, y_hi)`.
+        """Image extent (`~astropy.coordinates.Angle`)
 
-        Returns
-        -------
-        im_extent : `~astropy.coordinates.Angle`
-            array of bins with the image extent
+        The output array format is `(x_lo, x_hi, y_lo, y_hi)`.
         """
         bx = self.detx_bins
         by = self.dety_bins
@@ -466,40 +463,26 @@ class CubeBackgroundModel(object):
 
     @property
     def spectrum_extent(self):
-        """Spectrum extent `(e_lo, e_hi)`.
+        """Spectrum extent (`~astropy.units.Quantity`)
 
-        Returns
-        -------
-        spec_extent : `~astropy.units.Quantity`
-            array of bins with the spectrum extent
+        The output array format is  `(e_lo, e_hi)`.
         """
         b = self.energy_bins
         return Quantity([b[0], b[-1]])
 
     @property
     def image_bin_centers(self):
-        """Image bin centers `(x, y)`.
+        """Image bin centers `(x, y)` (2x `~astropy.coordinates.Angle`)
 
-        Returns
-        -------
-        detx_edges_centers : `~astropy.coordinates.Angle`
-            array of image bin centers (X coord)
-        dety_edges_centers : `~astropy.coordinates.Angle`
-            array of image bin centers (Y coord)
+        Returning two separate elements for the X and Y bin centers.
         """
-        detx_edges_centers = 0.5 * (self.detx_bins[:-1] + self.detx_bins[1:])
-        dety_edges_centers = 0.5 * (self.dety_bins[:-1] + self.dety_bins[1:])
-        return detx_edges_centers, dety_edges_centers
+        detx_bin_centers = 0.5 * (self.detx_bins[:-1] + self.detx_bins[1:])
+        dety_bin_centers = 0.5 * (self.dety_bins[:-1] + self.dety_bins[1:])
+        return detx_bin_centers, dety_bin_centers
 
     @property
     def energy_bin_centers(self):
-        """Energy bin centers (logarithmic center).
-
-        Returns
-        -------
-        energy_bin_centers : `~astropy.units.Quantity`
-            array of spectrum bin centers
-        """
+        """Energy bin centers (logarithmic center) (`~astropy.units.Quantity`)"""
         log_bin_edges = np.log(self.energy_bins.value)
         log_bin_centers = 0.5 * (log_bin_edges[:-1] + log_bin_edges[1:])
         energy_bin_centers = Quantity(np.exp(log_bin_centers), self.energy_bins.unit)
@@ -512,14 +495,9 @@ class CubeBackgroundModel(object):
 
     @property
     def det_wcs(self):
-        """WCS object describing the coordinates of the det (X, Y) bins.
+        """WCS object describing the coordinates of the det (X, Y) bins (`~astropy.wcs.WCS`)
 
         This method gives the correct answer only for linear X, Y binning.
-
-        Returns
-        -------
-        wcs : `~astropy.wcs.WCS`
-            WCS object describing the bin coordinates
         """
         wcs = linear_arrays_to_wcs(name_x="DETX",
                                    name_y="DETY",
@@ -532,12 +510,12 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        det : `~numpy.array`
+        det : `~numpy.ndarray`
             array of `~astropy.coordinates.Angle` det (X, Y) pairs to search for
 
         Returns
         -------
-        bin_index : `~numpy.array`
+        bin_index : `~numpy.ndarray`
             array of integers with the indices (x, y) of the det
             bin containing the specified det (X, Y) pair
         """
@@ -561,12 +539,12 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        energy : `~numpy.array`
+        energy : `~numpy.ndarray`
             array of `~astropy.units.Quantity` energies to search for
 
         Returns
         -------
-        bin_index : `~numpy.array`
+        bin_index : `~numpy.ndarray`
             indices of the energy bins containing the specified energies
         """
         # check that the specified energy is within the boundaries of the model
@@ -585,7 +563,7 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        det : `~numpy.array`
+        det : `~numpy.ndarray`
             array of `~astropy.coordinates.Angle` det (X, Y) pairs to search for
 
         Returns
@@ -606,7 +584,7 @@ class CubeBackgroundModel(object):
 
         Parameters
         ----------
-        energy : `~numpy.array`
+        energy : `~numpy.ndarray`
             array of `~astropy.units.Quantity` energies to search for
 
         Returns

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -71,7 +71,7 @@ class EventList(Table):
 
     @property
     def time(self):
-        """Event times (`~astropy.time.Time`).
+        """Event times (`~astropy.time.Time`)
 
         Notes
         -----
@@ -95,7 +95,7 @@ class EventList(Table):
 
     @property
     def galactic(self):
-        """Event Galactic sky coordinates (`~astropy.coordinates.SkyCoord`).
+        """Event Galactic sky coordinates (`~astropy.coordinates.SkyCoord`)
 
         Note: uses the ``GLON`` and ``GLAT`` columns.
         If only ``RA`` and ``DEC`` are present use the explicit
@@ -131,7 +131,7 @@ class EventList(Table):
 
     @property
     def energy(self):
-        """Event energies (`~astropy.units.Quantity`)."""
+        """Event energies (`~astropy.units.Quantity`)"""
         energy = self['ENERGY']
         return Quantity(energy, self.meta['EUNIT'])
 
@@ -147,7 +147,7 @@ class EventList(Table):
 
     @property
     def observation_time_duration(self):
-        """Observation time duration in seconds (`~astropy.units.Quantity`).
+        """Observation time duration in seconds (`~astropy.units.Quantity`)
 
         The wall time, including dead-time.
         """
@@ -155,7 +155,7 @@ class EventList(Table):
 
     @property
     def observation_live_time_duration(self):
-        """Live-time duration in seconds (`~astropy.units.Quantity`).
+        """Live-time duration in seconds (`~astropy.units.Quantity`)
 
         The dead-time-corrected observation time.
 
@@ -166,7 +166,7 @@ class EventList(Table):
 
     @property
     def observation_dead_time_fraction(self):
-        """Dead-time fraction.
+        """Dead-time fraction (float)
 
         Defined as dead-time over observation time.
 

--- a/gammapy/data/spectral_cube.py
+++ b/gammapy/data/spectral_cube.py
@@ -81,6 +81,7 @@ class SpectralCube(object):
 
     @property
     def _interpolate(self):
+        """Interpolated data (`~scipy.interpolate.RegularGridInterpolator`)"""
         if self._interpolate_cache is None:
             # Initialise the interpolator
             # This doesn't do any computations ... I'm not sure if it allocates extra arrays.
@@ -199,12 +200,10 @@ class SpectralCube(object):
 
     @property
     def spatial_coordinate_images(self):
-        """Spatial coordinate images.
+        """Spatial coordinate images (2x `~astropy.units.Quantity`)
 
-        Returns
-        -------
-        lon, lat : `~astropy.units.Quantity`
-            Arrays of longitude and latitude pixel coordinates.
+        Returns two separate objects for the arrays of longitude
+        and latitude pixel coordinates.
         """
         n_lon = self.data.shape[2]
         n_lat = self.data.shape[1]
@@ -215,13 +214,7 @@ class SpectralCube(object):
 
     @property
     def solid_angle_image(self):
-        """Solid angle image.
-
-        Returns
-        -------
-        solid_angle_image : `~astropy.units.Quantity`
-            Solid angle image (steradian)
-        """
+        """Solid angle image in steradian (`~astropy.units.Quantity`)"""
         cube_hdu = fits.ImageHDU(self.data, self.wcs.to_header())
         image_hdu = cube_to_image(cube_hdu)
         image_hdu.header['WCSAXES'] = 2

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -116,7 +116,9 @@ class BoundingBox(object):
 
     @property
     def ftcopy_string(self):
-        """Bounding box in ftcopy string format.
+        """Bounding box in ftcopy string format (str)
+
+        The output is given as [x_start:x_stop,y_start:y_stop]
 
         Examples
         --------
@@ -129,7 +131,7 @@ class BoundingBox(object):
 
     @property
     def slice(self):
-        """Bounding box in slice format.
+        """Bounding box in slice format (y, x) (tuple)
 
         Examples
         --------
@@ -142,14 +144,17 @@ class BoundingBox(object):
 
     @property
     def x_slice(self):
+        """Bounding box X component in slice format (slice)"""
         return slice(self.x_start, self.x_stop)
 
     @property
     def y_slice(self):
+        """Bounding box Y component in slice format (slice)"""
         return slice(self.y_start, self.y_stop)
 
     @property
     def is_empty(self):
+        """Check if the bounding box is empty (bool)"""
         x_is_empty = (self.x_start >= self.x_stop)
         y_is_empty = (self.y_start >= self.y_stop)
         return x_is_empty or y_is_empty

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -46,7 +46,7 @@ class EnergyDispersion(object):
 
     @property
     def pdf_threshold(self):
-        """PDF matrix zero-suppression threshold."""
+        """PDF matrix zero-suppression threshold (float)"""
         return self._pdf_threshold
 
     @pdf_threshold.setter
@@ -280,7 +280,10 @@ class EnergyDispersion(object):
 
     @property
     def _extent(self):
-        """Extent (x0, x1, y0, y1) for plotting"""
+        """Extent (x0, x1, y0, y1) for plotting (4x float)
+
+        x stands for true energy and y for reconstructed energy
+        """
         x = self.energy_range('true')
         y = self.energy_range('reco')
         return x[0], x[1], y[0], y[1]

--- a/gammapy/morphology/gauss.py
+++ b/gammapy/morphology/gauss.py
@@ -25,16 +25,28 @@ class Gauss2DPDF(object):
 
     @property
     def _sigma2(self):
+        """Sigma squared (float)"""
         return self.sigma * self.sigma
 
     @property
     def amplitude(self):
-        """PDF amplitude at the center."""
+        """PDF amplitude at the center (float)"""
         return self.__call(0, 0)
 
     def __call__(self, x, y=0):
-        """dp / (dx dy) at position (x, y).
+        """dp / (dx dy) at position (x, y)
+        
+        Parameters
+        ----------
+        x : `~numpy.ndarray`
+            x coordinate
+        y : `~numpy.ndarray`, optional
+            y coordinate
 
+        Returns
+        -------
+        dpdxdy : `~numpy.ndarray`
+            dp / (dx dy)
         """
         x = np.asarray(x, dtype=np.float64)
         y = np.asarray(y, dtype=np.float64)
@@ -45,7 +57,17 @@ class Gauss2DPDF(object):
         return amplitude * np.exp(exponent)
 
     def dpdtheta2(self, theta2):
-        """dp / dtheta2 at position theta2 = theta ^ 2.
+        """dp / dtheta2 at position theta2 = theta ^ 2
+
+        Parameters
+        ----------
+        theta2 : `~numpy.ndarray`
+            Offset squared
+
+        Returns
+        -------
+        dpdtheta2 : `~numpy.ndarray`
+            dp / dtheta2
         """
         theta2 = np.asarray(theta2, dtype=np.float64)
 
@@ -58,8 +80,13 @@ class Gauss2DPDF(object):
 
         Parameters
         ----------
-        theta : array_like
+        theta : `~numpy.ndarray`
             Offset
+
+        Returns
+        -------
+        containment_fraction : `~numpy.ndarray`
+            Containment fraction
         """
         theta = np.asarray(theta, dtype=np.float64)
 
@@ -67,6 +94,16 @@ class Gauss2DPDF(object):
 
     def containment_radius(self, containment_fraction):
         """Containment angle for a given containment fraction.
+
+        Parameters
+        ----------
+        containment_fraction : `~numpy.ndarray`
+            Containment fraction
+
+        Returns
+        -------
+        containment_radius : `~numpy.ndarray`
+            Containment radius
         """
         containment_fraction = np.asarray(containment_fraction, dtype=np.float64)
 
@@ -77,11 +114,13 @@ class Gauss2DPDF(object):
 
         Parameters
         ----------
-        TODO
+        sigma : `~numpy.ndarray` or float
+            Gaussian width of the new Gaussian 2D PDF to covolve with.
 
         Returns
         -------
-        TODO
+        gauss_convolve : `~gammapy.morphology.Gauss2DPDF`
+            Convolution of both Gaussians.
         """
         sigma = np.asarray(sigma, dtype=np.float64)
 
@@ -94,7 +133,10 @@ class MultiGauss2D(object):
 
     Parameters
     ----------
-    TODO
+    sigmas : `~numpy.ndarray`
+            widths of the Gaussians to add
+    norms : `~numpy.ndarray`, optional
+            normalizations of the Gaussians to add
 
     Notes
     -----
@@ -113,7 +155,19 @@ class MultiGauss2D(object):
             self.norms = np.asarray(norms, dtype=np.float64)
 
     def __call__(self, x, y=0):
-        """TODO
+        """dp / (dx dy) at position (x, y)
+        
+        Parameters
+        ----------
+        x : `~numpy.ndarray`
+            x coordinate
+        y : `~numpy.ndarray`, optional
+            y coordinate
+
+        Returns
+        -------
+        total : `~numpy.ndarray`
+            dp / (dx dy)
         """
         x = np.asarray(x, dtype=np.float64)
         y = np.asarray(y, dtype=np.float64)
@@ -125,36 +179,58 @@ class MultiGauss2D(object):
 
     @property
     def n_components(self):
+        """Number of components (int)"""
         return len(self.components)
 
     @property
     def sigmas(self):
+        """Array of Gaussian widths (`~numpy.ndarray`)"""
         return np.array([_.sigma for _ in self.components])
 
     @property
     def integral(self):
+        """Integral as sum of norms (`~numpy.ndarray`)"""
         return np.nansum(self.norms)
 
     @property
     def amplitude(self):
+        """Amplitude at the center (float)"""
         return self.__call__(0, 0)
 
     @property
     def max_sigma(self):
+        """Largest Gaussian width (float)"""
         return self.sigmas.max()
 
     @property
     def eff_sigma(self):
-        """Effective sigma for single-Gauss approximation.
+        r"""Effective Gaussian width for single-Gauss approximation (float)
 
-        TODO: give formula.
+        Notes
+        -----
+        The effective Gaussian width is given by:
+
+        .. math:: \sigma_\mathrm{eff} = \sqrt{\sum_i N_i \sigma_i^2}
+
+        where ``N`` is normalization and ``sigma`` is width.
+
         """
         sigma2s = np.array([component._sigma2 for component
                             in self.components])
         return np.sqrt(np.sum(self.norms * sigma2s))
 
     def dpdtheta2(self, theta2):
-        """TODO: document
+        """dp / dtheta2 at position theta2 = theta ^ 2
+
+        Parameters
+        ----------
+        theta2 : `~numpy.ndarray`
+            Offset squared
+
+        Returns
+        -------
+        dpdtheta2 : `~numpy.ndarray`
+            dp / dtheta2
         """
         # Actually this is only a PDF if sum(norms) == 1
         theta2 = np.asarray(theta2, dtype=np.float64)
@@ -165,7 +241,13 @@ class MultiGauss2D(object):
         return total
 
     def normalize(self):
-        """TODO: document"""
+        """Normalize function.
+        
+        Returns
+        -------
+        norm_multigauss : `~gammapy.morphology.MultiGauss2D`
+           normalized function
+        """
         self.norms /= self.integral
         return self
 
@@ -174,8 +256,13 @@ class MultiGauss2D(object):
 
         Parameters
         ----------
-        theta : array_like
-            Containment angle
+        theta : `~numpy.ndarray`
+            Offset
+
+        Returns
+        -------
+        containment_fraction : `~numpy.ndarray`
+            Containment fraction
         """
         theta = np.asarray(theta, dtype=np.float64)
 
@@ -186,12 +273,17 @@ class MultiGauss2D(object):
         return total
 
     def containment_radius(self, containment_fraction):
-        """Containment angle.
+        """Containment angle for a given containment fraction.
 
         Parameters
         ----------
-        fraction : float
+        containment_fraction : `~numpy.ndarray`
             Containment fraction
+
+        Returns
+        -------
+        containment_radius : `~numpy.ndarray`
+            Containment radius
         """
         # I had big problems with fsolve running into negative thetas.
         # So instead I'll find a theta_max myself so that theta
@@ -218,7 +310,18 @@ class MultiGauss2D(object):
 
         Find the sigma of a single-Gaussian distribution that
         approximates this one, such that theta matches for a given
-        containment."""
+        containment.
+
+        Parameters
+        ----------
+        containment_fraction : `~numpy.ndarray`
+            Containment fraction
+
+        Returns
+        -------
+        sigma : `~numpy.ndarray`
+            Equivalent containment radius
+        """
         theta1 = self.containment_radius(containment_fraction)
         theta2 = Gauss2DPDF(sigma=1).containment_radius(containment_fraction)
         return theta1 / theta2
@@ -236,15 +339,15 @@ class MultiGauss2D(object):
 
         Parameters
         ----------
-        sigma : array_like
-            TODO
-        norm : TODO
-            TODO
+        sigma : `~numpy.ndarray` or float
+            Gaussian width of the new Gaussian 2D PDF to covolve with.
+        norm : `~numpy.ndarray` or float
+            Normalization of the new Gaussian 2D PDF to covolve with.
 
         Returns
         -------
-        new_multi_gauss_2d : MultiGauss2D
-            New  MultiGauss2D
+        new_multi_gauss_2d : `~gammapy.morphology.MultiGauss2D`
+            Convolution as new MultiGauss2D
         """
         sigma = np.asarray(sigma, dtype=np.float64)
         norm = np.asarray(norm, dtype=np.float64)

--- a/gammapy/spectrum/spectrum_results.py
+++ b/gammapy/spectrum/spectrum_results.py
@@ -108,6 +108,7 @@ class Spectrum(Table):
 
     @property
     def nonzero_exposure_part(self):
+        """Table of bins with exposure (`~astropy.table.Table`)"""
         bins = self.meta['bins_with_exposure']
         table = self[bins[0]: bins[1]]
         return table
@@ -199,16 +200,30 @@ class SpectralModel:
 
     @property
     def covariance_matrix(self):
+        """Covariance matrix (`numpy.ndarray`)"""
         d = self.meta['covariance_matrix']
         self._matrix_dict_to_array(d)
 
     @property
     def correlation_matrix(self):
+        """Correlation matrix (`numpy.ndarray`)"""
         d = self.meta['correlation_matrix']
         self._matrix_dict_to_array(d)
 
     @staticmethod
     def _matrix_dict_to_array(d):
+        """Convert matrix dict entry to array
+
+        Parameters
+        ----------
+        d : `~array_like`
+            matrix dict value
+
+        Returns
+        -------
+        d_array : `~numpy.ndarray`
+            matrix array
+        """
         return np.array(d)
 
     def info(self, out=None):

--- a/gammapy/stats/data.py
+++ b/gammapy/stats/data.py
@@ -37,25 +37,25 @@ class Stats(object):
 
     @property
     def alpha(self):
-        r"""Background exposure ratio.
+        r"""Background exposure ratio (float)
 
-        .. math:: \alpha = a_{on} / a_{off}
+        .. math:: \alpha = a_\mathrm{on} / a_\mathrm{off}
         """
         return self.a_on / self.a_off
 
     @property
     def background(self):
-        r"""Background estimate.
+        r"""Background estimate (float)
 
-        .. math:: \mu_{background} = \alpha\ n_{off}
+        .. math:: \mu_\mathrm{bg} = \alpha\ n_\mathrm{off}
         """
         return self.alpha * self.n_off
 
     @property
     def excess(self):
-        r"""Excess.
+        r"""Excess (float)
 
-        .. math:: n_{excess} = n_{on} - \mu_{background}
+        .. math:: n_\mathrm{ex} = n_\mathrm{on} - \mu_\mathrm{bg}
         """
         return self.n_on - self.background
 


### PR DESCRIPTION
While reviewing #299 by @mapazarr I noticed that the documentation for attributes is very verbose and basically repeats the same info twice:

![screen shot 2015-07-15 at 11 13 00](https://cloud.githubusercontent.com/assets/852409/8694992/d1161168-2ae2-11e5-8f69-10b914ea3a26.png)

I think I'd prefer we don't use `Returns` sections for attributes, but instead just have one line that also mentions the return type like I've done it here:
https://gammapy.readthedocs.org/en/latest/api/gammapy.data.EventList.html
If more explanations are needed / wanted, that's OK, extra lines can be added.
My point is only that `Returns` doesn't make much sense because attributes always return exactly one thing, and that's already described in the first line.

@mapazarr @adonath @kingj90 – What do you think?

If we agree on this, the TODOs here are:
- [x] Add an entry explaining this convention here: https://gammapy.readthedocs.org/en/latest/development/index.html
- [x] Go through the existing attributes and clean them up. E.g. [SpectralCube](https://gammapy.readthedocs.org/en/latest/api/gammapy.data.SpectralCube.html) ... there don't seem to be too many: https://github.com/gammapy/gammapy/search?utf8=%E2%9C%93&q=property