### PR TITLE
Add code quality build in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,16 +69,16 @@ cython:
 trailing-spaces:
 	find $(PROJECT) examples docs -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
 
+black:
+	black $(PROJECT)/ examples/ docs/ \
+	--exclude="_astropy_init.py|version.py|extern/|docs/_static|docs/_build" \
+	--line-length 88
+
 # Note: flake8 is very fast and almost never has false positives
 flake8:
 	flake8 $(PROJECT) \
     --exclude=gammapy/extern,gammapy/conftest.py,gammapy/_astropy_init.py,__init__.py \
     --ignore=E501
-
-black:
-	black $(PROJECT)/ examples/ docs/ \
-	--exclude="_astropy_init.py|version.py|extern/|docs/_static|docs/_build" \
-	--line-length 88
 
 # TODO: once the errors are fixed, remove the -E option and tackle the warnings
 # Note: pylint is very thorough, but slow, and has false positives or nitpicky stuff
@@ -86,13 +86,32 @@ pylint:
 	pylint -E $(PROJECT)/ \
 	--ignore=_astropy_init.py,gammapy/extern \
 	-d E0611,E1101,E1103 \
-	--msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})' -f colorized
+	--msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})'
 
+# TODO: fix and re-activate check for the following:
+# D103: Missing docstring in public function
+# D201: No blank lines allowed before function docstring (found 1)
+# D202: No blank lines allowed after function docstring (found 1)
+# D204: 1 blank line required after class docstring (found 0)
+# D205: 1 blank line required between summary line and description (found 0)
+# D207: Docstring is under-indented
+# D209: Multi-line docstring closing quotes should be on a separate line
+# D210: No whitespaces allowed surrounding docstring text
+# D300: Use """triple double quotes""" (found """"-quotes)
+# D301: Use r""" if any backslashes in a docstring
+# D400: First line should end with a period (not ')')
+# D401: First line should be in imperative mood; try rephrasing (found 'Function')
+# D403: First word of the first line should be properly capitalized ('Add', not 'add')
+# D404: First word of the docstring should not be `This`
+# D405: Section name should be properly capitalized ('See Also', not 'See also')
+# D409: Section underline should match the length of its name (Expected 7 dashes in section 'Returns', got 8)
+# D412: No blank lines allowed between a section header and its content ('Examples')
+# D414: Section has no content ('Returns')
 pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
-	--add-ignore=D100,D102,D104,D105,D200,D410 \
-	--add-ignore=D301 # TODO: re-activate and fix this one
+	--match-dir='^(?!extern).*' \
+	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D207,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410,D412,D414
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,11 @@ pylint:
 # D405: Section name should be properly capitalized ('See Also', not 'See also')
 # D409: Section underline should match the length of its name (Expected 7 dashes in section 'Returns', got 8)
 # D412: No blank lines allowed between a section header and its content ('Examples')
-# D414: Section has no content ('Returns')
 pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410,D412,D414
+	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410,D412
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ pylint:
 # D202: No blank lines allowed after function docstring (found 1)
 # D204: 1 blank line required after class docstring (found 0)
 # D205: 1 blank line required between summary line and description (found 0)
-# D207: Docstring is under-indented
 # D209: Multi-line docstring closing quotes should be on a separate line
 # D210: No whitespaces allowed surrounding docstring text
 # D300: Use """triple double quotes""" (found """"-quotes)
@@ -111,7 +110,7 @@ pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D207,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410,D412,D414
+	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410,D412,D414
 
 # TODO: add test and code quality checks for `examples`
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,32 @@ jobs:
       testRunTitle: 'Python $(python.version)'
     condition: succeededOrFailed()
 
+- job: 'Lint'
+
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.x'
+      architecture: 'x64'
+
+  - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
+    displayName: Add conda to PATH
+
+  - script: |
+      conda env create --file environment-dev.yml
+      source activate gammapy-dev
+      pip install -e .
+      gammapy info
+    displayName: 'Create gammapy-dev conda environment'
+
+  - script: |
+      source activate gammapy-dev
+      make flake8
+    displayName: 'Run flake8'
+
 
 - job: 'DevDocs'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,19 +85,19 @@ jobs:
   - script: |
       source activate gammapy-dev
       make flake8
-      exit 1  # allow fail
+      exit 0  # allow fail
     displayName: 'Run flake8'
 
   - script: |
       source activate gammapy-dev
       make pylint
-      exit 1  # allow fail
+      exit 0  # allow fail
     displayName: 'Run pylint'
 
   - script: |
       source activate gammapy-dev
       make pydocstyle
-      exit 1  # allow fail
+      exit 0  # allow fail
     displayName: 'Run pydocstyle'
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,20 @@ jobs:
   - script: |
       source activate gammapy-dev
       make flake8
+      exit 1  # allow fail
     displayName: 'Run flake8'
+
+  - script: |
+      source activate gammapy-dev
+      make pylint
+      exit 1  # allow fail
+    displayName: 'Run pylint'
+
+  - script: |
+      source activate gammapy-dev
+      make pydocstyle
+      exit 1  # allow fail
+    displayName: 'Run pydocstyle'
 
 
 - job: 'DevDocs'

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -4,9 +4,8 @@ import numpy as np
 import astropy.units as u
 from astropy.units import Quantity
 from astropy.table import Table
-from astropy.utils import lazyproperty
 from ...utils.scripts import make_path
-from ...utils.fitting import Parameter, Parameters
+from ...utils.fitting import Parameter
 from ...spectrum.models import SpectralModel, TableModel
 
 __all__ = ["PrimaryFlux", "DMAnnihilation"]

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities to compute J-factor maps."""
-import numpy as np
 import astropy.units as u
 
 __all__ = ["JFactory"]

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.units import Quantity
 
 __all__ = ["fill_map_counts"]
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 from astropy.utils import lazyproperty
 import astropy.units as u
-from ..utils.fitting import Fit, Parameters
+from ..utils.fitting import Parameters
 from ..stats import cash, cstat
 from ..maps import Map, MapAxis
 from .models import SkyModel, SkyModels

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
 import numpy as np
-from astropy.utils.decorators import lazyproperty
 import astropy.units as u
-from ..utils.fitting import Parameters, Parameter, Model
+from ..utils.fitting import Parameter, Model
 from ..utils.scripts import make_path
 from ..maps import Map
 

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates.angle_utilities import angular_separation
 from astropy.coordinates import Angle, Longitude, Latitude, SkyCoord
-from ...utils.fitting import Parameter, Parameters, Model
+from ...utils.fitting import Parameter, Model
 from ...maps import Map
 from scipy.integrate import quad
 

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -348,6 +348,7 @@ class SkyEllipse(SkySpatialModel):
         radius = self.parameters["semi_major"].quantity
         return radius
 
+    @staticmethod
     def compute_norm(semi_major, e):
         """Compute the normalization factor."""
         semi_minor = semi_major * np.sqrt(1 - e ** 2)

--- a/gammapy/image/plotting.py
+++ b/gammapy/image/plotting.py
@@ -82,9 +82,9 @@ class MapPanelPlotter:
         ax.set_ylim(*ylim_pix)
         return ax
 
-    def plot_panel(self, image, panel=1, panel_fov=None, **kwargs):
+    def plot_panel(self, map, panel=1, panel_fov=None, **kwargs):
         """
-        Plot sky image on one panel.
+        Plot sky map on one panel.
 
         Parameters
         ----------
@@ -96,27 +96,27 @@ class MapPanelPlotter:
         if panel_fov is None:
             panel_fov = panel
         spec = self.grid_spec[panel]
-        ax = self.figure.add_subplot(spec, projection=image.geom.wcs)
+        ax = self.figure.add_subplot(spec, projection=map.geom.wcs)
         try:
-            ax = image.plot(ax=ax, **kwargs)[1]
+            ax = map.plot(ax=ax, **kwargs)[1]
         except AttributeError:
-            ax = image.plot_rgb(ax=ax, **kwargs)
+            ax = map.plot_rgb(ax=ax, **kwargs)
         ax = self._set_ax_fov(ax, panel_fov)
         return ax
 
-    def plot(self, image, **kwargs):
+    def plot(self, map, **kwargs):
         """
-        Plot sky image on all panels.
+        Plot sky map on all panels.
 
         Parameters
         ----------
-       map : `~gammapy.maps.WcsNDMap`
+        map : `~gammapy.maps.WcsNDMap`
             Map to plot.
         """
         p = self.parameters
         axes = []
         for panel in range(p["npanels"]):
-            ax = self.plot_panel(image, panel=panel, **kwargs)
+            ax = self.plot_panel(map, panel=panel, **kwargs)
             axes.append(ax)
         return axes
 

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-import astropy.units as u
 from ..utils.energy import Energy
-from . import PSF3D, EnergyDependentTablePSF, IRFStacker, EffectiveAreaTable
+from . import EnergyDependentTablePSF, IRFStacker, EffectiveAreaTable
 
 __all__ = ["make_psf", "make_mean_psf", "make_mean_edisp", "apply_containment_fraction"]
 

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -15,7 +15,6 @@ from ..psf_table import EnergyDependentTablePSF, TablePSF
 from ...data import DataStore, Observations
 from ...utils.testing import requires_data, assert_quantity_allclose
 from ...utils.energy import Energy, EnergyBounds
-from ...spectrum.models import PowerLaw
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
-from ...utils.testing import assert_quantity_allclose
 from ...irf import TablePSF, EnergyDependentTablePSF
 
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -7,7 +7,6 @@ from astropy import units as u
 from astropy.io.registry import IORegistryError
 from ..utils.scripts import make_path
 from ..utils.table import table_standardise_units_copy, table_from_row_data
-from ..utils.fitting import Fit
 from ..utils.interpolation import ScaledRegularGridInterpolator
 from .models import PowerLaw, ScaleModel
 from .powerlaw import power_law_integral_flux

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -11,7 +11,7 @@ from ...utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
 )
-from ...utils.fitting import Parameters, Fit
+from ...utils.fitting import Fit
 from ..models import PowerLaw, SpectralModel
 from ..flux_point import FluxPoints, FluxPointsDataset
 

--- a/gammapy/stats/data.py
+++ b/gammapy/stats/data.py
@@ -86,6 +86,8 @@ def make_stats(
 
     Returns
     -------
+    stats : `Stats`
+        Statistics
     """
     random_state = get_random_state(random_state)
 

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from astropy.table import Table
 from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
-from ..utils.fitting import Parameter, Parameters, Model
+from ..utils.fitting import Parameter, Model
 
 __all__ = ["PhaseCurveTableModel", "LightCurveTableModel"]
 


### PR DESCRIPTION
Now that we have some make targets to check code quality (added in #314), we should run them on travis-ci.
- [ ] Make pylint run OK on travis-ci (i.e. fail the build if there's an issue)
- [ ] Fix pylint warnings

On my machine I get these errors: https://gist.github.com/cdeil/25601836ca0a8584ffcd
(at the end, pylint crashes when trying to do some code analysis for ROOT ... this should be fixed or skipped)

This can be extended to cover pylint warnings or flake8 in this or separate future PRs.
