### PR TITLE
fix: debian pip command

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -154,7 +154,7 @@ The following packages have to be installed with pip:
 
 .. code-block:: bash
 
-    pip install --user \
+    pip3 install --user \
         gammapy naima photutils reproject wcsaxes gwcs astroplan \
         iminuit emcee healpy
 


### PR DESCRIPTION
In debian, pip and python (still) point to python 2, you have to specify pip3 to install things in python 3.