### PR TITLE
Debian package for Gammapy

### DIFF
--- a/licenses/LICENSE.rst
+++ b/licenses/LICENSE.rst
@@ -1,4 +1,5 @@
 Copyright (c) 2014, Gammapy Developers
+Scipy developers, Thomas Robitaille <- Because of the files in extern
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -23,3 +24,6 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Add MIT license for xmltodict.py


### PR DESCRIPTION
This Friday I'll join the [Debian Astro packaging tutorial](https://wiki.debian.org/Sprints/2015/Astro) by @olebole and I'd like to try and create a Debian package for Gammapy 0.3 (which I'll release tomorrow).

The maintainer for the package will be the "Debian Astronomy Team" as explained [here](https://wiki.debian.org/DebianAstro/AstropyPackagingTutorial/Preparation). Anyone interested to follow this or help out is welcome to join their mailing list.

I'll use this ticket to discuss any issues that come up during packaging.
