### PR TITLE
Production of true/reco bg cube models should use the same model.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Pull requests
 +++++++++++++
 
 - Make background cube models [#319] (Manuel Paz Arribas)
+-  Production of true/reco bg cube models should use the same model. [#335] (Manuel Paz Arribas)
 
 .. _gammapy_0p3_release:
 

--- a/docs/background/make_models.rst
+++ b/docs/background/make_models.rst
@@ -77,6 +77,16 @@ Datasets for testing
 
 In order to test the background model generation tools, real
 data from existing experiments such as H.E.S.S. can be used. Since
-the data of current experiments is not public, rudimentary tools to
+the data of current experiments is not public, tools to
 prepare a dummy dataset have been placed in Gammapy:
 :ref:`datasets_make_datasets_for_testing`.
+
+There is also a tool in Gammapy to simulate background cube models:
+`~gammapy.datasets.make_test_bg_cube_model`.
+It can be used to produce true background cube models to use to
+compare to the reconstructed ones produced with the machinery
+described above, using a simulated dataset using the tools from
+:ref:`datasets_make_datasets_for_testing`. If using the same model
+for producing the simulated dataset and the true background cube
+models, the reconstructed ones produced with
+``gammapy-make-bg-cube-models`` should match the true ones.

--- a/gammapy/background/make.py
+++ b/gammapy/background/make.py
@@ -34,6 +34,10 @@ def make_bg_cube_model(observation_table, fits_path, method='default'):
     The background cube model contains 3 cubes: events, livetime and background.
     The latter contains the bg cube model.
 
+    The reconstructed background cube models produced with this method
+    can be tested against the true (simulated) ones produced with
+    `~gammapy.datasets.make_test_bg_cube_model`.
+
     Parameters
     ----------
     observation_table : `~gammapy.obs.ObservationTable`


### PR DESCRIPTION
Revised functions to produce true bg cube models and simulated data: the models should match.
In addition, the high-level docs have been updated to include a paragraph on doing true/reco bg cube models.
