### PR TITLE
Add gammapy-bin-image test

### DIFF
--- a/docs/background/make_models.rst
+++ b/docs/background/make_models.rst
@@ -76,17 +76,16 @@ Datasets for testing
 ~~~~~~~~~~~~~~~~~~~~
 
 In order to test the background model generation tools, real
-data from existing experiments such as H.E.S.S. can be used. Since
-the data of current experiments is not public, tools to
-prepare a dummy dataset have been placed in Gammapy:
-:ref:`datasets_make_datasets_for_testing`.
+data from existing experiments such as H.E.S.S. can be used.
+Since the data of current experiments is not public, tools to
+simulate datasets are described in :ref:`datasets_obssim`.
 
 There is also a tool in Gammapy to simulate background cube models:
 `~gammapy.datasets.make_test_bg_cube_model`.
 It can be used to produce true background cube models to use to
 compare to the reconstructed ones produced with the machinery
 described above, using a simulated dataset using the tools from
-:ref:`datasets_make_datasets_for_testing`. If using the same model
+:ref:`datasets_obssim`. If using the same model
 for producing the simulated dataset and the true background cube
 models, the reconstructed ones produced with
 ``gammapy-make-bg-cube-models`` should match the true ones.

--- a/docs/datasets/make_datasets.rst
+++ b/docs/datasets/make_datasets.rst
@@ -1,7 +1,45 @@
-.. _datasets_make_datasets_for_testing:
+.. include:: ../references.txt
 
-Make datasets for testing
-=========================
+.. _datasets_obssim:
+
+Simulate event lists
+====================
+
+Here we describe how to simulate event lists for a given
+observation list, source model and instrument.
+
+Gammapy is mostly an analysis package for binned analysis,
+and so far we haven't implemented general tools to sample
+arbitrary spatial and spectral density distributions.
+
+An excellent tool `ctobssim`_ is available within the ctools
+package, so here we'll describe how to use that first and then
+mention the existing functionality in Gammapy.
+
+.. _datasets_obssim_ctobssim:
+
+Using ctobssim
+++++++++++++++
+
+Using HESS IRFs and a real event list as input (for header info),
+it's possible to simulate event lists according to any source and background model you like.
+
+See https://github.com/gammapy/gammapy-extra/blob/master/datasets/hess_crab/make2.py
+as an example, which was used to generated the
+https://github.com/gammapy/gammapy-extra/blob/master/test_datasets/irf/hess/pa/hess_events_023523.fits.gz
+example file.
+
+TODO: we should extend this to a Gammapy command line tool that:
+
+- can simulate simple IRF files for HESS or CTA (so that we don't have to use real HESS IRFs)
+- can process an observation list, i.e. it's not necessary to have real observations.
+
+For now this one simulated HESS observation can be used for testing in Gammapy.
+
+.. _datasets_obssim_gammapy:
+
+Using Gammapy
++++++++++++++
 
 In order to test some of the tools from Gammapy, such as the
 background generation tools
@@ -27,7 +65,7 @@ addition, the effective area files produced, are empty except fot
 the low energy threshold header entry.
 
 The tools are very easy to use. A H.E.S.S.-like test dataset can be
-produced with a few lines of python code:
+produced with a few lines of Python code:
 
 .. code-block:: python
 
@@ -42,7 +80,8 @@ produced with a few lines of python code:
                       random_state=random_state)
 
 Then the data can be read back using the `~gammapy.obs.DataStore`
-class, and eg. print the observation table and the names of the filescreated with a few extra lines of python code:
+class, and eg. print the observation table and the names of the files
+created with a few extra lines of Python code:
 
 .. code-block:: python
 

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -63,3 +63,5 @@
 .. _Gammapy contributors page on Github: https://github.com/gammapy/gammapy/graphs/contributors
 
 .. _scientific Python stack: http://www.scipy.org/about.html
+
+.. _ctobssim: http://cta.irap.omp.eu/ctools-devel/reference_manual/ctobssim.html

--- a/gammapy/datasets/make.py
+++ b/gammapy/datasets/make.py
@@ -411,7 +411,7 @@ def make_test_dataset(fits_path, overwrite=False,
     This method is useful for instance to produce samples in order
     to test the machinery for reconstructing background (cube) models.
 
-    See also :ref:`datasets_make_datasets_for_testing`.
+    See also :ref:`datasets_obssim`.
 
     Parameters
     ----------
@@ -515,7 +515,7 @@ def make_test_eventlist(observation_table,
     In addition, an effective area table is produced. For the moment
     only the low energy threshold is filled.
 
-    See also :ref:`datasets_make_datasets_for_testing`.
+    See also :ref:`datasets_obssim`.
 
     Parameters
     ----------

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -651,7 +651,8 @@ def wcs_histogram2d(header, lon, lat, weights=None):
     bins = np.arange(shape[0] + 1) - 0.5, np.arange(shape[1] + 1) - 0.5
     data = np.histogramdd([yy, xx], bins, weights=weights)[0]
 
-    return fits.ImageHDU(data, header, name='COUNTS')
+    # return fits.ImageHDU(data, header, name='COUNTS')
+    return fits.PrimaryHDU(data, header)
 
 
 def bin_events_in_image(events, reference_image):

--- a/gammapy/scripts/tests/test_bin_image.py
+++ b/gammapy/scripts/tests/test_bin_image.py
@@ -1,22 +1,30 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from numpy.testing import assert_equal, assert_almost_equal
+from astropy.io import fits
+from astropy.tests.helper import remote_data
 from ...datasets import get_path
 from ..bin_image import main as bin_image_main
 
 
+@remote_data
 def test_bin_image_main(tmpdir):
-    # TODO: make a better example dataset where the counts are actually
-    # inside the image, then add useful asserts
+    """Run ``gammapy-bin-image`` and compare result to ``ctskymap``.
+    """
+    event_file = get_path('../test_datasets/irf/hess/pa/hess_events_023523.fits.gz', location='remote')
+    reference_file = get_path('../test_datasets/irf/hess/pa/ctskymap.fits.gz', location='remote')
+    out_file = str(tmpdir.join('gammapy_ctskymap.fits.gz'))
+    bin_image_main([event_file, reference_file, out_file])
 
-    event_file = get_path('hess/run_0023037_hard_eventlist.fits.gz')
-    reference_file = get_path('fermi/fermi_exposure.fits.gz')
+    gammapy_hdu = fits.open(out_file)[0]
+    ctools_hdu = fits.open(reference_file)[0]
+    assert_equal(gammapy_hdu.data, ctools_hdu.data)
 
-    filename = str(tmpdir.join('bin_image_test.fits'))
-    open(filename, 'w').write('hi')
-    text = open(filename).read()
-    assert text == 'hi'
-    # TODO: this doesn't currently work because bin_image_main has an issue
-    # (could be considered a bug)
-    # bin_image_main([event_file, reference_file, out_file])
-    # read output file and assert something
+    # I'm not sure if a header info comparison is useful here.
+    # At the moment probably no ... the header is just copied
+    # from the input to the output.
+    # In the future we might implement similar sky and energy
+    # selection options as `ctskymap` and then this could become
+    # useful ...
+    assert_almost_equal(gammapy_hdu.header['NAXIS1'], ctools_hdu.header['NAXIS1'])


### PR DESCRIPTION
This PR adds a test for `gammapy-bin-image` as well as some info in the docs about how to simulate event lists.

I wanted to do more here, but now I prefer to continue in new PRs ...