### PR TITLE
mock h5py install in readthedocs

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -61,6 +61,10 @@ if [[ $SETUP_CMD == build_sphinx* ]]
 then
   $CONDA_INSTALL sphinx pygments matplotlib scipy
   conda install --yes --channel astropy wcsaxes aplpy
+  if [[ $PYTHON_VERSION == 2.7 ]]
+  then
+      conda install --yes mock
+  fi
 fi
 
 # COVERAGE DEPENDENCIES

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,22 @@ except ImportError:
         if os.path.isdir(a_h_path):
             sys.path.insert(1, a_h_path)
 
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+
+if on_rtd:
+    if sys.version_info.major > 2:
+        from unittest.mock import MagicMock
+    else:
+        from mock import Mock as MagicMock
+
+    class Mock(MagicMock):
+        @classmethod
+        def __getattr__(cls, name):
+                return Mock()
+
+    MOCK_MODULES = ['h5py',]
+    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 


### PR DESCRIPTION
As mentioned in https://github.com/zblz/naima/issues/88, this is needed to build in readthedocs with a C-package dependency.