### PR TITLE
Add nice true-reco bg cube model comparison plot script to the high-level docs

### DIFF
--- a/docs/background/make_models.rst
+++ b/docs/background/make_models.rst
@@ -99,3 +99,39 @@ same model (except for absolute normalization). The models can be
 used to test the cube bg model production and can be compared to each
 other using the :download:`plot_bg_cube_model_comparison.py
 <../../examples/plot_bg_cube_model_comparison.py>` example script.
+
+Comparing true-reco models
+**************************
+
+Two model files located in the `~gammapy-extra` repository have been
+produced using the example script :download:`make_bg_cube_models_true_reco.py
+<../../examples/make_bg_cube_models_true_reco.py>`:
+
+* `bg_cube_model_true.fits.gz
+  <https://github.com/gammapy/gammapy-extra/blob/master/test_datasets/background/bg_cube_model_true.fits.gz>`_
+  is a true bg cube model produced with
+  `~gammapy.datasets.make_test_bg_cube_model`.
+* `bg_cube_model_reco.fits.gz
+  <https://github.com/gammapy/gammapy-extra/blob/master/test_datasets/background/bg_cube_model_reco.fits.gz>`_
+  is a reco bg cube model produced with
+  `~gammapy.background.make_bg_cube_model`, using dummy data produced
+  with `~gammapy.datasets.make_test_dataset`.
+
+The following plots are produced with a modified version of the
+:download:`plot_bg_cube_model_comparison.py
+<../../examples/plot_bg_cube_model_comparison.py>` example script:
+
+.. plot:: background/plot_bgcube_true_reco.py
+
+The input counts spectrum is a power-law with an index of 1.5, in
+order to have some counts at high energies with a reasonable amount
+of simulated data. In reality the background spectrum has a spectral
+index close to 2.7.
+
+The bg rate appears as a spectrum of **index + 1** (2.5 in this
+example).
+The reason being that, in order to produce the bg model, the
+contents of the cube (counts per unit time) have to be divided by the
+bin volume (delta x * delta y * delta E). When computing
+counts/delta E, the index of the bg rate increases by 1 w.r.t. the
+index of the power-law spectrum used to sample (or model) the counts.

--- a/docs/background/plot_bgcube_true_reco.py
+++ b/docs/background/plot_bgcube_true_reco.py
@@ -1,0 +1,204 @@
+"""
+Script to produce plots comparing 2 background cube models.
+
+Details in stringdoc of the plot_bg_cube_model_comparison function.
+
+Inspired on the Gammapy examples/plot_bg_cube_model_comparison.py script.
+"""
+
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.units import Quantity
+from astropy.coordinates import Angle
+from astropy.table import Table
+from astropy.io import ascii
+from gammapy.background import CubeBackgroundModel
+from gammapy import datasets
+
+E_REF = Quantity(1., 'TeV') # reference energy
+NORM = 1
+INDEX = 1.5
+
+
+def power_law(energy, E_0, norm, index):
+    return norm*(energy/E_0)**-index
+
+
+def int_power_law(energy_band, E_0, norm, index):
+    return norm/(1 - index)/E_0**-index*(energy_band[1]**(1 - index) - energy_band[0]**(1 - index))
+
+
+def plot_bg_cube_model_comparison(input_file1, name1,
+                                  input_file2, name2):
+    """
+    Plot background cube model comparison.
+
+    Produce a figure for comparing 2 bg cube models (1 and 2).
+
+    Plot strategy in each figure:
+
+    * Images:
+        * rows: similar energy bin
+        * cols: same bg cube model set
+    * Spectra:
+        * rows: similar det bin
+        * cols: compare both bg cube model sets
+
+    Parameters
+    ----------
+    input_file1, input_file2 : str
+        File where the corresponding bg cube model is stored.
+    name1, name2 : str
+        Name to use for plot labels/legends.
+    """
+    # get cubes
+    filename1 = input_file1
+    filename2 = input_file2
+    print('filename1', filename1)
+    print('filename2', filename2)
+    bg_cube_model1 = CubeBackgroundModel.read(filename1,
+                                              format='table').background_cube
+    bg_cube_model2 = CubeBackgroundModel.read(filename2,
+                                              format='table').background_cube
+
+    # normalize 1 w.r.t. 2 (i.e. true w.r.t. reco)
+    # normalize w.r.t. cube integral
+    integral1 = bg_cube_model1.integral
+    integral2 = bg_cube_model2.integral
+    bg_cube_model1.data *= integral2/integral1
+
+    # make sure that both cubes use the same units for the plots
+    bg_cube_model2.data = bg_cube_model2.data.to(bg_cube_model1.data.unit)
+
+    # plot
+    fig, axes = plt.subplots(nrows=2, ncols=3)
+    fig.set_size_inches(30., 15., forward=True)
+    group_info = 'group 27: ALT = [72.0, 90.0) deg, AZ = [90.0, 270.0) deg'
+    plt.suptitle(group_info)
+
+    # plot images
+    #  rows: similar energy bin
+    #  cols: same file
+    bg_cube_model1.plot_image(energy=Quantity(1., 'TeV'), ax=axes[0, 0])
+    axes[0, 0].set_title("{0}: {1}".format(name1, axes[0, 0].get_title()))
+    bg_cube_model1.plot_image(energy=Quantity(10., 'TeV'), ax=axes[1, 0])
+    axes[1, 0].set_title("{0}: {1}".format(name1, axes[1, 0].get_title()))
+    bg_cube_model2.plot_image(energy=Quantity(1., 'TeV'), ax=axes[0, 1])
+    axes[0, 1].set_title("{0}: {1}".format(name2, axes[0, 1].get_title()))
+    bg_cube_model2.plot_image(energy=Quantity(10., 'TeV'), ax=axes[1, 1])
+    axes[1, 1].set_title("{0}: {1}".format(name2, axes[1, 1].get_title()))
+
+    # plot spectra
+    #  rows: similar det bin
+    #  cols: compare both files
+    bg_cube_model1.plot_spectrum(coord=Angle([0., 0.], 'degree'),
+                                 ax=axes[0, 2],
+                                 style_kwargs=dict(color='blue',
+                                                   label=name1))
+    spec_title1 = axes[0, 2].get_title()
+    bg_cube_model2.plot_spectrum(coord=Angle([0., 0.], 'degree'),
+                                 ax=axes[0, 2],
+                                 style_kwargs=dict(color='red',
+                                                   label=name2))
+    spec_title2 = axes[0, 2].get_title()
+    if spec_title1 != spec_title2:
+        s_error = "Expected same det binning, but got "
+        s_error += "\"{0}\" and \"{1}\"".format(spec_title1, spec_title2)
+        raise ValueError(s_error)
+    else:
+        axes[0, 2].set_title(spec_title1)
+
+    # plot normalized models on top
+
+    E_0 = E_REF
+    norm = NORM
+    index = INDEX
+
+    plot_data_x = axes[0, 2].get_lines()[0].get_xydata()[:,0]
+    plot_data_y = axes[0, 2].get_lines()[0].get_xydata()[:,1]
+    plot_data_int = np.trapz(y=plot_data_y, x=plot_data_x)
+    energy_band = np.array([plot_data_x[0], plot_data_x[-1]])
+    model_int = int_power_law(energy_band, E_0, norm, index)
+    normed_PL1 = plot_data_int/model_int*power_law(plot_data_x, E_0, norm, index)
+    axes[0, 2].plot(plot_data_x, normed_PL1, color='blue',
+                    linestyle='dotted', linewidth=2,
+                    label='model index = {}'.format(index))
+
+    index = INDEX + 1
+
+    plot_data_x = axes[0, 2].get_lines()[0].get_xydata()[:,0]
+    plot_data_y = axes[0, 2].get_lines()[0].get_xydata()[:,1]
+    plot_data_int = np.trapz(y=plot_data_y, x=plot_data_x)
+    energy_band = np.array([plot_data_x[0], plot_data_x[-1]])
+    model_int = int_power_law(energy_band, E_0, norm, index)
+    normed_PL2 = plot_data_int/model_int*power_law(plot_data_x, E_0, norm, index)
+    axes[0, 2].plot(plot_data_x, normed_PL2, color='blue',
+                    linestyle='dashed', linewidth=2,
+                    label='model index = {}'.format(index))
+
+    axes[0, 2].legend()
+
+    bg_cube_model1.plot_spectrum(coord=Angle([2., 2.], 'degree'),
+                                 ax=axes[1, 2],
+                                 style_kwargs=dict(color='blue',
+                                                   label=name1))
+    spec_title1 = axes[1, 2].get_title()
+    bg_cube_model2.plot_spectrum(coord=Angle([2., 2.], 'degree'),
+                                 ax=axes[1, 2],
+                                 style_kwargs=dict(color='red',
+                                                   label=name2))
+    spec_title2 = axes[1, 2].get_title()
+    if spec_title1 != spec_title2:
+        s_error = "Expected same det binning, but got "
+        s_error += "\"{0}\" and \"{1}\"".format(spec_title1, spec_title2)
+        raise ValueError(s_error)
+    else:
+        axes[1, 2].set_title(spec_title1)
+
+    # plot normalized models on top
+
+    E_0 = E_REF
+    norm = NORM
+    index = INDEX
+
+    plot_data_x = axes[1, 2].get_lines()[0].get_xydata()[:,0]
+    plot_data_y = axes[1, 2].get_lines()[0].get_xydata()[:,1]
+    plot_data_int = np.trapz(y=plot_data_y, x=plot_data_x)
+    energy_band = np.array([plot_data_x[0], plot_data_x[-1]])
+    model_int = int_power_law(energy_band, E_0, norm, index)
+    normed_PL1 = plot_data_int/model_int*power_law(plot_data_x, E_0, norm, index)
+    axes[1, 2].plot(plot_data_x, normed_PL1, color='blue',
+                    linestyle='dotted', linewidth=2,
+                    label='model index = {}'.format(index))
+
+    index = INDEX + 1
+
+    plot_data_x = axes[1, 2].get_lines()[0].get_xydata()[:,0]
+    plot_data_y = axes[1, 2].get_lines()[0].get_xydata()[:,1]
+    plot_data_int = np.trapz(y=plot_data_y, x=plot_data_x)
+    energy_band = np.array([plot_data_x[0], plot_data_x[-1]])
+    model_int = int_power_law(energy_band, E_0, norm, index)
+    normed_PL2 = plot_data_int/model_int*power_law(plot_data_x, E_0, norm, index)
+    axes[1, 2].plot(plot_data_x, normed_PL2, color='blue',
+                    linestyle='dashed', linewidth=2,
+                    label='model index = {}'.format(index))
+
+    axes[1, 2].legend()
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    """Main function: define arguments and launch the whole analysis chain.
+    """
+    input_file1 = '../test_datasets/background/bg_cube_model_true.fits.gz'
+    input_file1 = datasets.get_path(input_file1, location='remote')
+    name1 = 'true'
+
+    input_file2 = '../test_datasets/background/bg_cube_model_reco.fits.gz'
+    input_file2 = datasets.get_path(input_file2, location='remote')
+    name2 = 'reco'
+
+    plot_bg_cube_model_comparison(input_file1, name1,
+                                  input_file2, name2)

--- a/examples/make_bg_cube_models_true_reco.py
+++ b/examples/make_bg_cube_models_true_reco.py
@@ -20,10 +20,8 @@ from gammapy.obs import (DataStore, ObservationGroups,
 from gammapy.background import make_bg_cube_model
 from gammapy.utils.scripts import _create_dir
 
-
 #TEST = True # create a small dataset
 TEST = False # create a large dataset (slow)
-
 
 # define model parameters
 SIGMA = Angle(5., 'deg')

--- a/examples/plot_bg_cube_model_comparison.py
+++ b/examples/plot_bg_cube_model_comparison.py
@@ -12,11 +12,7 @@ from astropy.coordinates import Angle
 from astropy.table import Table
 from astropy.io import ascii
 from gammapy.background import CubeBackgroundModel
-
 from gammapy.obs import ObservationGroups, ObservationGroupAxis
-
-GRAPH_DEBUG = 0
-SAVE = 0
 
 NORMALIZE = 0 # normalize 1 w.r.t. 2 (i.e. true w.r.t. reco)
               # 0: do not normalize
@@ -40,6 +36,7 @@ NAME2 = 'michi'
 #  - alt_bin_ids_selection = [7, 10, 13]
 #  - az_bin_ids_selection = [0, 1]
 group_ids_selection = [14, 15, 20, 21, 26, 27]
+
 
 def convert_obs_groups_binning_def_michi_to_default():
     """Convert observation groups binning definition "michi" to "default".
@@ -122,7 +119,6 @@ def look_obs_groups_michi(group_id):
     return i_alt, i_az
 
 
-
 def plot_bg_cube_model_comparison(input_dir1, binning_format1, name1,
                                   input_dir2, binning_format2, name2):
     """
@@ -158,13 +154,6 @@ def plot_bg_cube_model_comparison(input_dir1, binning_format1, name1,
             is is the way how smoothing method *michi* normalizes the
             background cube model, hence it is necessary to compare
             to those models that use that particular smoothing
-
-    * **SAVE**: set to 1 (True) to save the output:
-          * comparison plots as png
-          * *michi* binning groups and lookup as ECVS files
-
-    * **GRAPH_DEBUG**: if set to 1 (True) the program waits between
-      each observation group iteration until the image is closed
 
     Parameters
     ----------
@@ -324,11 +313,10 @@ def plot_bg_cube_model_comparison(input_dir1, binning_format1, name1,
                 axes[1, 2].set_title(spec_title1)
             axes[1, 2].legend()
 
-            if GRAPH_DEBUG:
-                plt.show() # wait until image is closed
+            plt.draw()
 
-            if SAVE:
-                outfile = "bg_cube_model_comparison_group{}.png".format(group)
+            # save
+            outfile = "bg_cube_model_comparison_group{}.png".format(group)
                 print('Writing {}'.format(outfile))
                 fig.savefig(outfile)
 


### PR DESCRIPTION
Adding nice true-reco bg cube model comparison plot script to the high-level docs, following the discussion in #338:
 https://github.com/gammapy/gammapy/pull/338#issuecomment-138095084
 https://github.com/gammapy/gammapy/pull/338#issuecomment-138124274
I added a plot to `gammapy-extra` as suggested. In addition I added 2 fits files (true and reco bg cube models), in order to produce the plot in the docs via a script, without waiting for the re-structuring/integration of `gammapy-extra`.

I also did some cleanup in the scripts added/modified in #338.

I am **not** adding an entry to CHANGES log, as the it was recently suggested.