### PR TITLE
Use runipy to test the Gammapy notebooks

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -72,3 +72,8 @@ then
   pip install cpp-coveralls;
   pip install coverage coveralls;
 fi
+
+if [[ $SETUP_CMD == 'test-notebooks' ]]
+then
+  pip install runipy
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test -V'
 
+        # Test IPython notebooks
+        - os: linux
+          env: PYTHON_VERSION=3.4 MAIN_CMD='make' SETUP_CMD='test-notebooks'
+
     # You can move builds that temporarily fail because of some non-Gammapy issue here
     # Please add a link to a GH issue that tracks the upstream issue.
     allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -58,4 +58,13 @@ pylint:
 	       --msg-template='{C}: {path}:{line}:{column}: {msg} ({symbol})'
 
 # TODO: add test and code quality checks for `examples`
+
+gammapy-extra: 
+	git clone git@github.com:gammapy/gammapy-extra.git
+
 # TODO: add test for IPython notebooks in gammapy-extra
+# TODO: probably best to put this in a Python script?
+test-notebooks: gammapy-extra
+	# For now just run one example ... should run all
+	runipy gammapy-extra/notebooks/Index.ipynb 
+	runipy gammapy-extra/notebooks/source_catalogs.ipynb


### PR DESCRIPTION
This PR adds a build on travis-ci should be added that executes all the Gammapy notebooks:
https://github.com/gammapy/gammapy-extra/tree/master/notebooks

The [runipy](https://github.com/paulgb/runipy) tool makes it easy  ... it returns status code zero if no exception occurs and non-zero if there is an exception.

The Astropy tutorials also use it:
https://github.com/astropy/astropy-tutorials/blob/master/prepare_deploy.py#L70

I probably won't have time to fix the broken notebooks we have and we might have to find a way to skip the ones that take too long and only run those on Jenkins (or make them faster).