### PR TITLE
WIP: Rewrite most parts of EnergyDispersion class (Fits I/O)

### DIFF
--- a/docs/irf/plot_energy_dispersion.py
+++ b/docs/irf/plot_energy_dispersion.py
@@ -1,12 +1,11 @@
 """Plot energy dispersion example."""
 import numpy as np
 import matplotlib.pyplot as plt
-from gammapy import irf
+from gammapy.irf import EnergyDispersion
 from gammapy.spectrum import EnergyBounds
 
 ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
-pdf_matrix = irf.gauss_energy_dispersion_matrix(ebounds, sigma=0.2)
-energy_dispersion = irf.EnergyDispersion(pdf_matrix, ebounds)
+energy_dispersion = EnergyDispersion.from_gauss(ebounds, sigma=0.3)
 
 energy_dispersion.plot(type='matrix')
 plt.show()

--- a/docs/irf/plot_energy_dispersion.py
+++ b/docs/irf/plot_energy_dispersion.py
@@ -2,8 +2,9 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from gammapy import irf
+from gammapy.spectrum import EnergyBounds
 
-ebounds = np.logspace(-1, 2, 100)
+ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
 pdf_matrix = irf.gauss_energy_dispersion_matrix(ebounds, sigma=0.2)
 energy_dispersion = irf.EnergyDispersion(pdf_matrix, ebounds)
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -249,8 +249,7 @@ class EventList(Table):
         mask = separation < radius
         return self[mask]
 
-    def select_sky_ring(self, center, inner_radius=None, outer_radius=None,
-                        thickness=None):
+    def select_sky_ring(self, center, inner_radius, outer_radius):
         """Select events in sky circle.
 
         Parameters
@@ -259,10 +258,8 @@ class EventList(Table):
             Sky ring center
         inner_radius : `~astropy.coordinates.Angle`
             Sky ring inner radius
-        outer_radius : `~astropy.coordinates.Angle`, None
+        outer_radius : `~astropy.coordinates.Angle`
             Sky ring outer radius
-        inner_radius : `~astropy.coordinates.Angle`
-            Sky ring thinkness
 
         Returns
         -------
@@ -270,27 +267,12 @@ class EventList(Table):
             Copy of event list with selection applied.
         """
 
-        if outer_radius is None:
-            if thickness is None or inner_radius is None:
-                raise ValueError("Not enough information specified")
-            else:
-                outer_radius = inner_radius + thickness
-
-        else:
-            if inner_radius is None:
-                if thickness is None:
-                    raise ValueError("Not enough information specified")
-                else:
-                    inner_radius = outer_radius + thickness
-
-            else:
-                thickness = outer_radius - inner_radius
-
         position = self.radec
         separation = center.separation(position)
-        mask1 = inner_radius > separation
-        mask2 = outer_radius < separation
+        mask1 = inner_radius < separation
+        mask2 = separation < outer_radius
         mask = mask1 * mask2
+
         return self[mask]
 
     def select_sky_box(self, lon_lim, lat_lim, frame='icrs'):

--- a/gammapy/hspec/wstat.py
+++ b/gammapy/hspec/wstat.py
@@ -10,6 +10,7 @@ class spectral_data(object):
     """
 
     def __init__(self, data, bkg):
+
         self.bkg = bkg
         self.data = data
         self.ONexpo = data.exposure
@@ -61,6 +62,7 @@ class w_statistic(object):
         for dataid in dataids:
             spec = spectral_data(sau.get_data(dataid), sau.get_bkg(dataid))
             self.datasets.append(spec)
+            
         self.bkg = np.concatenate([a.fit_bkg for a in self.datasets])
         self.alpha = np.concatenate([a.fit_alpha for a in self.datasets])
         self.Ttot = np.concatenate([a.fit_Ttot for a in self.datasets])

--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -484,8 +484,8 @@ class EffectiveAreaTable2D(object):
         """
 
         if energy_lo is None and energy_hi is None:
-            energy_lo = self.energy_lo
-            energy_hi = self.energy_hi
+            energy_lo = self.energ_lo
+            energy_hi = self.energ_hi
         elif energy_lo is None or energy_hi is None:
             raise ValueError("Only 1 energy vector given, need 2")
         if not isinstance(energy_lo, Quantity) or not isinstance(energy_hi, Quantity):

--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -198,12 +198,14 @@ class EffectiveAreaTable(object):
         hdu.add_datasum()
         return fits.HDUList([prim_hdu, hdu])
 
-    def write(self, filename, *args, **kwargs):
+    def write(self, filename, energy_unit='TeV', effarea_unit='m2',
+              *args, **kwargs):
         """Write ARF to FITS file.
 
         Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
         """
-        self.to_fits().writeto(filename, *args, **kwargs)
+        self.to_fits(energy_unit=energy_unit, effarea_unit=effarea_unit).writeto(
+            filename, *args, **kwargs)
 
     @classmethod
     def read(cls, filename):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -45,16 +45,16 @@ class EnergyDispersion(object):
     def __init__(self, pdf_matrix, e_true, e_reco=None,
                  pdf_threshold=DEFAULT_PDF_THRESHOLD):
         
+        if e_reco is None:
+            e_reco = e_true
+
         if not isinstance(e_true, EnergyBounds) or not isinstance(
             e_reco, EnergyBounds):
             raise ValueError("Energies must be Energy objects")
 
         self._pdf_matrix = np.asarray(pdf_matrix)
         self._e_true = e_true
-        if e_reco is None:
-            self._e_reco = np.asarray(e_true)
-        else:
-            self._e_reco = e_reco
+        self._e_reco = e_reco
 
         self._pdf_threshold = 0
         self.pdf_threshold = pdf_threshold
@@ -375,8 +375,8 @@ class EnergyDispersion(object):
 
         x stands for true energy and y for reconstructed energy
         """
-        x = self.energy_range('true')
-        y = self.energy_range('reco')
+        x = self.true_energy.range.value
+        y = self.reco_energy.range.value
         return x[0], x[1], y[0], y[1]
 
     def _plot_matrix(self):
@@ -429,8 +429,11 @@ def gauss_energy_dispersion_matrix(ebounds, sigma=0.2):
     """
     from scipy.special import erf
 
-    nbins = len(ebounds) - 1
-    logerange = np.log10(ebounds)
+    #Quick hack to make it work with new Edisp class
+    e_bounds = ebounds.value
+
+    nbins = len(e_bounds) - 1
+    logerange = np.log10(e_bounds)
 
     logemingrid = logerange[:-1] * np.ones([nbins, nbins])
     logemaxgrid = logerange[1:] * np.ones([nbins, nbins])

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -80,7 +80,7 @@ class EnergyDispersion(object):
         """Reconstructed Energy axis (`~gammapy.spectrum.EnergyBounds`)
         """
         return self._e_reco
-
+    @property
     def true_energy(self):
         """Reconstructed Energy axis (`~gammapy.spectrum.EnergyBounds`)
         """

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -48,11 +48,11 @@ class EnergyDispersion(object):
             raise ValueError("Energies must be Energy objects")
 
         self._pdf_matrix = np.asarray(pdf_matrix)
-        self.e_true = e_true
+        self._e_true = e_true
         if e_reco is None:
-            self.e_reco = np.asarray(e_true)
+            self._e_reco = np.asarray(e_true)
         else:
-            self.e_reco = e_reco
+            self._e_reco = e_reco
 
         self._pdf_threshold = pdf_threshold
         self._interpolate2d_func = None
@@ -75,43 +75,16 @@ class EnergyDispersion(object):
         m = self._pdf_matrix
         m[m < value] = 0
 
-    def energy_bounds(self, axis='true'):
-        """Energy bounds array.
-
-        Parameters
-        ----------
-        axis : {'true', 'reco'}
-            Which axis?
-
-        Returns
-        -------
-        energy_bounds : array
-            Energy bounds array.
+    @property
+    def reco_energy(self):
+        """Reconstructed Energy axis (`~gammapy.spectrum.EnergyBounds`)
         """
-        if axis == 'true':
-            return self.e_true
-        elif axis == 'reco':
-            return self.e_reco
-        else:
-            ss = 'Invalid axis: {0}\n'.format(axis)
-            ss += 'Valid options: true, reco'
-            raise ValueError(ss)
+        return self._e_reco
 
-    def energy_range(self, axis='true'):
-        """Energy axis range.
-
-        Parameters
-        ----------
-        axis : {'true', 'reco'}
-            Which axis?
-
-        Returns
-        -------
-        (emin, emax) : tuple of float
-            Energy axis range.
+    def true_energy(self):
+        """Reconstructed Energy axis (`~gammapy.spectrum.EnergyBounds`)
         """
-        ebounds = self.energy_bounds(axis)
-        return ebounds[0], ebounds[-1]
+        return self._e_true
 
     def __str__(self):
         ss = 'Energy dispersion information:\n'
@@ -212,8 +185,8 @@ class EnergyDispersion(object):
         filter='NONE'
         minprob = 0.001
         rm = self._pdf_matrix
-        erange = self.e_true
-        ebounds = self.e_reco
+        erange = self._e_true
+        ebounds = self._e_reco
 
         # Intialize the arrays to be used to construct the RM extension
         n_rows = len(rm)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -185,23 +185,19 @@ class EnergyDispersion(object):
         table = self.to_table()
         cols = table.columns
  
-        c0 = fits.Column(name=cols[0].name, format='E', array=cols[0])
-        c1 = fits.Column(name=cols[1].name, format='E', array=cols[1])
+        c0 = fits.Column(name=cols[0].name, format='E', array=cols[0],
+                         unit='{}'.format(cols[0].unit))
+        c1 = fits.Column(name=cols[1].name, format='E', array=cols[1],
+                         unit='{}'.format(cols[1].unit))
         c2 = fits.Column(name=cols[2].name, format='J', array=cols[2])
-        c3 = fits.Column(name=cols[3].name, format='PJ', array=cols[3])
-        c4 = fits.Column(name=cols[4].name, format='PJ()', array=cols[4])
+        c3 = fits.Column(name=cols[3].name, format='PI()', array=cols[3])
+        c4 = fits.Column(name=cols[4].name, format='PI()', array=cols[4])
         c5 = fits.Column(name=cols[5].name, format='PE()', array=cols[5])
         
         hdu = fits.BinTableHDU.from_columns([c0, c1, c2, c3, c4, c5])
 
         if header is None:
-            from gammapy.datasets import get_path
-            filename = get_path("../test_datasets/irf/hess/ogip/run_rmf60741.fits",
-                                location='remote')
-            header = fits.open(filename)[1].header
-            
-        if header == 'pyfact':
-            header = hdu.header
+            header=hdu.header
 
             header['EXTNAME'] = 'MATRIX', 'name of this binary table extension'
             header['TELESCOP'] = 'DUMMY', 'Mission/satellite name'
@@ -261,7 +257,7 @@ class EnergyDispersion(object):
             pos = np.nonzero(row)[0]
             borders = np.where(np.diff(pos) != 1)[0]
             groups = np.asarray(np.split(pos, borders))
-            n_grp_temp = groups.size if groups.size > 0 else 1
+            n_grp_temp = groups.shape[0] if groups.size > 0 else 1
             n_chan_temp = np.asarray([val.size for val in groups])
             try:
                 f_chan_temp = np.asarray([val[0] for val in groups])

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -61,6 +61,11 @@ class EnergyDispersion(object):
         self._interpolate2d_func = None
 
     @property
+    def pdf_matrix(self):
+        """PDF matrix ~numpy.ndarray"""
+        return self._pdf_matrix
+
+    @property
     def pdf_threshold(self):
         """PDF matrix zero-suppression threshold (float)"""
         return self._pdf_threshold

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -235,8 +235,10 @@ class EnergyDispersion(object):
         hdu.add_checksum()
         hdu.add_datasum()
 
+        hdu2 = self._e_reco.to_ebounds()
+
         prim_hdu = fits.PrimaryHDU()
-        return fits.HDUList([prim_hdu, hdu])
+        return fits.HDUList([prim_hdu, hdu, hdu2])
 
         return hdu_list
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -173,25 +173,13 @@ class EnergyDispersion(object):
 
         return cls(pdf_matrix, energy_true_bounds, energy_reco_bounds, pdf_threshold)
 
-    def write(self, filename, format='RMF'):
-        """Write to file.
+    def write(self, filename, *args, **kwargs):
+        """Write RMF to FITS file.
 
-        Parameters
-        ----------
-        filename : str
-            File name
-        format : {'RMF'}
-            File format
-        pdf_threshold : float
-            Zero suppression threshold for energy distribution matrix
+        Calls `~astropy.io.fits.HDUList.writeto`, forwarding all arguments.
         """
-        if format == 'RMF':
-            self._write_rmf(filename)
-        else:
-            ss = 'Invalid format: {0}.\n'.format(format)
-            ss += 'Available formats: RMF'
-            raise ValueError(ss)
-
+        self.to_fits().writeto(filename, *args, **kwargs)
+        
     def to_fits(self, header=None, energy_unit='TeV'):
         """
         Convert RM to FITS HDU list format.

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -141,3 +141,6 @@ def test_EffectiveAreaTable2D(method):
     actual = effareafrom2d.effective_area_at_energy(test_energy)
     desired = effarea1d.effective_area_at_energy(test_energy)
     assert_equal(actual, desired)
+
+    #Test ARF export #2
+    effareafrom2dv2 = effarea.to_effective_area_table(offset)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -24,11 +24,11 @@ def test_EnergyDispersion():
     #Set PDF threshold
     threshold = 1e-2
     edisp.pdf_threshold = threshold
-    a = edisp._pdf_matrix > threshold
-    b = edisp._pdf_matrix == 0
+    a = edisp.pdf_matrix > threshold
+    b = edisp.pdf_matrix == 0
     c = a+b
     actual = np.sum(c)
-    desired = edisp._pdf_matrix.flatten().shape[0]
+    desired = edisp.pdf_matrix.flatten().shape[0]
     assert_equal(actual, desired)
 
 @remote_data
@@ -38,11 +38,11 @@ def test_EnergyDispersion_write(tmpdir):
 
     edisp = EnergyDispersion.read(filename)
     indices = np.array([[1,3,6],[3,3,2]])
-    desired = edisp._pdf_matrix[indices]
+    desired = edisp.pdf_matrix[indices]
     writename = str(tmpdir.join('rmf_test.fits'))
     edisp.write(writename)
     edisp2 = EnergyDispersion.read(writename)
-    actual = edisp2._pdf_matrix[indices]
+    actual = edisp2.pdf_matrix[indices]
     rtol = edisp2.pdf_threshold
     assert_allclose(actual, desired, rtol=rtol)
 
@@ -81,6 +81,6 @@ def test_EnergyDispersion2D():
     e_reco = EnergyBounds.equal_log_spacing(1,10,5,'TeV')
     rmf = edisp.to_energy_dispersion(e_reco, offset)
 
-    actual = rmf._pdf_matrix[5]
+    actual = rmf.pdf_matrix[5]
     desired = edisp.get_response(offset, edisp.energy[5], e_reco=e_reco)
     assert_equal(actual, desired)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -31,7 +31,20 @@ def test_EnergyDispersion():
     desired = edisp._pdf_matrix.flatten().shape[0]
     assert_equal(actual, desired)
 
-    #Write RMF
+@remote_data
+def test_EnergyDispersion_write(tmpdir):
+    filename = get_path("../test_datasets/irf/hess/ogip/run_rmf60741.fits",
+                        location='remote')
+
+    edisp = EnergyDispersion.read(filename)
+    indices = np.array([[1,3,6],[3,3,2]])
+    desired = edisp._pdf_matrix[indices]
+    writename = str(tmpdir.join('rmf_test.fits'))
+    edisp.write(writename)
+    edisp2 = EnergyDispersion.read(writename)
+    actual = edisp2._pdf_matrix[indices]
+    rtol = edisp2.pdf_threshold
+    assert_allclose(actual, desired, rtol=rtol)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @remote_data

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from astropy.tests.helper import pytest, remote_data
 from ...irf import EnergyDispersion, EnergyDispersion2D
 from ...datasets import get_path
+from astropy.coordinates import  Angle
+from gammapy.spectrum.energy import EnergyBounds        
+import numpy as np
 
 try:
     import scipy
@@ -11,13 +14,23 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
-
-@pytest.mark.xfail
+@remote_data
 def test_EnergyDispersion():
-    edisp = EnergyDispersion()
-    pdf = edisp(3, 4)
-    assert_allclose(pdf, 42)
+    filename = get_path("../test_datasets/irf/hess/ogip/run_rmf60741.fits",
+                        location='remote')
 
+    edisp = EnergyDispersion.read(filename)
+
+    #Set PDF threshold
+    threshold = 1e-2
+    edisp.pdf_threshold = threshold
+    a = edisp._pdf_matrix > threshold
+    b = edisp._pdf_matrix == 0
+    c = a+b
+    actual = np.sum(c)
+    desired = edisp._pdf_matrix.flatten().shape[0]
+    assert_equal(actual, desired)
+    
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @remote_data
@@ -48,3 +61,12 @@ def test_EnergyDispersion2D():
     e_val = (energy + energy2) / 2
     actual = edisp.evaluate(offset, e_val, migra)
     # assert_equal(lower > actual and actual > upper, True)
+
+    # Check RMF exporter
+    offset = Angle([0.612], 'deg')    
+    e_reco = EnergyBounds.equal_log_spacing(1,10,5,'TeV')
+    rmf = edisp.to_energy_dispersion(e_reco, offset)
+
+    actual = rmf._pdf_matrix[5]
+    desired = edisp.get_response(offset, edisp.energy[5], e_reco=e_reco)
+    assert_equal(actual, desired)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing import assert_allclose, assert_equal
+from numpy.testing import assert_allclose, assert_equal, assert_raises
 from astropy.tests.helper import pytest, remote_data
 from ...irf import EnergyDispersion, EnergyDispersion2D
 from ...datasets import get_path
@@ -29,6 +29,17 @@ def test_EnergyDispersion():
     c = a+b
     actual = np.sum(c)
     desired = edisp.pdf_matrix.flatten().shape[0]
+    assert_equal(actual, desired)
+
+    #lower pdf threshold
+    #assert_raises did not work
+    actual = 0
+    threshold = 1e-3
+    try:
+        edisp.pdf_threshold = threshold
+    except(Exception):
+        actual = 1
+    desired = 1
     assert_equal(actual, desired)
 
 @remote_data

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -30,7 +30,8 @@ def test_EnergyDispersion():
     actual = np.sum(c)
     desired = edisp._pdf_matrix.flatten().shape[0]
     assert_equal(actual, desired)
-    
+
+    #Write RMF
 
 @pytest.mark.skipif('not HAS_SCIPY')
 @remote_data

--- a/gammapy/spectrum/energy.py
+++ b/gammapy/spectrum/energy.py
@@ -74,7 +74,7 @@ class Energy(Quantity):
         """
         The covered energy range (tuple)
         """
-        return self[0], self[-1]
+        return self[0:self.size:self.size-1]
 
 
     @classmethod

--- a/gammapy/spectrum/energy.py
+++ b/gammapy/spectrum/energy.py
@@ -307,4 +307,62 @@ class EnergyBounds(Energy):
         hdu.name = 'EBOUNDS'
         hdu.header['TUNIT1'] = "{0}".format(self.unit.to_str('fits'))
 
+            # Create EBOUNDS FITS table extension from data
+        tbhdu2 = fits.new_table(
+            [fits.Column(name='CHANNEL',
+                         format='1I',
+                         array=np.arange(len(ebounds) - 1)),
+             fits.Column(name='E_MIN',
+                         format='1E',
+                         array=ebounds[:-1],
+                         unit='TeV'),
+             fits.Column(name='E_MAX',
+                         format='1E',
+                         array=ebounds[1:],
+                         unit='TeV')
+             ]
+            )
+
+        chan_min, chan_max, chan_n = 0, rm.shape[0] - 1, rm.shape[0]
+
+        header = tbhdu2.header
+        header['EXTNAME'] = 'EBOUNDS', 'Name of this binary table extension'
+        header['TELESCOP'] = telescope, 'Mission/satellite name'
+        header['INSTRUME'] = instrument, 'Instrument/detector'
+        header['FILTER'] = filter, 'Filter information'
+        header['CHANTYPE'] = 'PHA', 'Type of channels (PHA, PI etc)'
+        header['DETCHANS'] = chan_n, 'Total number of detector PHA channels'
+        header['TLMIN1'] = chan_min, 'First legal channel number'
+        header['TLMAX1'] = chan_max, 'Highest legal channel number'
+        header['HDUCLASS'] = 'OGIP', 'Organisation devising file format'
+        header['HDUCLAS1'] = 'RESPONSE', 'File relates to response of instrument'
+        header['HDUCLAS2'] = 'EBOUNDS', 'This is an EBOUNDS extension'
+        header['HDUVERS'] = '1.2.0', 'Version of file format'
+        header['HDUCLAS3'] = 'DETECTOR', 'Keyword information for Caltools Software.'
+        header['CCNM0001'] = 'EBOUNDS', 'Keyword information for Caltools Software.'
+        header['CCLS0001'] = 'CPF', 'Keyword information for Caltools Software.'
+        header['CDTP0001'] = 'DATA', 'Keyword information for Caltools Software.'
+        
+        # UTC date when this calibration should be first used (yyyy-mm-dd)
+        header['CVSD0001'] = '2011-01-01 ', 'Keyword information for Caltools Software.'
+
+        # UTC time on the dat when this calibration should be first used (hh:mm:ss)
+        header['CVST0001'] = '00:00:00', 'Keyword information for Caltools Software.'
+
+        # Optional - name of the PHA file for which this file was produced
+    #header('PHAFILE', '', 'Keyword information for Caltools Software.')
+
+        # String giving a brief summary of this data set
+        header['CDES0001'] = 'dummy description', 'Keyword information for Caltools Software.'
+
+    # Obsolet EBOUNDS headers, included for the benefit of old software
+        header['RMFVERSN'] = '1992a', 'Obsolete'
+        header['HDUVERS1'] = '1.0.0', 'Obsolete'
+        header['HDUVERS2'] = '1.1.0', 'Obsolete'
+
+        # Create primary HDU and HDU list to be stored in the output file
+        # TODO: can remove PrimaryHDU here?
+
+
+
         return hdu

--- a/gammapy/spectrum/energy.py
+++ b/gammapy/spectrum/energy.py
@@ -15,6 +15,7 @@ __all__ = [
 
 
 class Energy(Quantity):
+
     """Energy quantity scalar or array.
 
     This is a `~astropy.units.Quantity` sub-class that adds convenience methods
@@ -74,8 +75,7 @@ class Energy(Quantity):
         """
         The covered energy range (tuple)
         """
-        return self[0:self.size:self.size-1]
-
+        return self[0:self.size:self.size - 1]
 
     @classmethod
     def equal_log_spacing(cls, emin, emax, nbins, unit=None):
@@ -153,6 +153,7 @@ class Energy(Quantity):
 
 
 class EnergyBounds(Energy):
+
     """EnergyBounds array.
 
     This is a `~gammapy.spectrum.energy.Energy` sub-class that adds convenience 
@@ -214,7 +215,7 @@ class EnergyBounds(Energy):
         """EnergyBounds from lower and upper bounds (`~gammapy.spectrum.energy.EnergyBounds`). 
 
         If no unit is given, it will be taken from upper
-        
+
         Parameters
         ----------
         lower,upper : `~astropy.units.Quantity`, float
@@ -226,8 +227,8 @@ class EnergyBounds(Energy):
         # np.append renders Quantities dimensionless
         # http://astropy.readthedocs.org/en/latest/known_issues.html#quantity-issues
 
-        lower = cls(lower, unit);
-        upper = cls(upper, unit);
+        lower = cls(lower, unit)
+        upper = cls(upper, unit)
         unit = upper.unit
         energy = np.hstack((lower, upper[-1]))
         return cls(energy.value, unit)
@@ -317,7 +318,7 @@ class EnergyBounds(Energy):
         """
 
         hdu = table_to_fits_table(self.to_table(unit))
-        
+
         header = hdu.header
         header['EXTNAME'] = 'EBOUNDS', 'Name of this binary table extension'
         header['TELESCOP'] = 'DUMMY', 'Mission/satellite name'
@@ -329,7 +330,7 @@ class EnergyBounds(Energy):
         header['HDUCLAS1'] = 'RESPONSE', 'File relates to response of instrument'
         header['HDUCLAS2'] = 'EBOUNDS', 'This is an EBOUNDS extension'
         header['HDUVERS'] = '1.2.0', 'Version of file format'
-        
+
         # Obsolet EBOUNDS headers, included for the benefit of old software
         header['RMFVERSN'] = '1992a', 'Obsolete'
         header['HDUVERS1'] = '1.0.0', 'Obsolete'

--- a/gammapy/spectrum/energy.py
+++ b/gammapy/spectrum/energy.py
@@ -218,7 +218,7 @@ class EnergyBounds(Energy):
         lower = cls(lower, unit);
         upper = cls(upper, unit);
         unit = upper.unit
-        energy = np.append(lower, upper[-1])
+        energy = np.hstack((lower, upper[-1]))
         return cls(energy.value, unit)
 
     @classmethod
@@ -243,7 +243,7 @@ class EnergyBounds(Energy):
             emin, emax, nbins + 1, unit)
 
     @classmethod
-    def from_fits(cls, hdu, unit=None):
+    def from_ebounds(cls, hdu, unit=None):
         """Read EBOUNDS fits extension (`~gammapy.spectrum.energy.EnergyBounds`).
 
         Parameters
@@ -257,9 +257,34 @@ class EnergyBounds(Energy):
         if hdu.name != 'EBOUNDS':
             log.warn('This does not seem like an EBOUNDS extension. Are you sure?')
 
-        return super(EnergyBounds, cls).from_fits(cls, hdu, unit)
+        header = hdu.header
+        unit = header.get('TUNIT2')
+        low = hdu.data['E_MIN']
+        high = hdu.data['E_MAX']
+        return cls.from_lower_and_upper_bounds(low, high, unit)
 
-    def to_fits(self, **kwargs):
+    @classmethod
+    def from_rmf_matrix(cls, hdu, unit=None):
+        """Read MATRIX fits extension (`~gammapy.spectrum.energy.EnergyBounds`).
+
+        Parameters
+        ----------
+        hdu: `~astropy.io.fits.BinTableHDU`
+            ``MATRIX`` extensions.
+        unit : `~astropy.units.UnitBase`, str, None
+            Energy unit
+        """
+
+        if hdu.name != 'MATRIX':
+            log.warn('This does not seem like a MATRIX extension. Are you sure?')
+
+        header = hdu.header
+        unit = header.get('TUNIT1')
+        low = hdu.data['ENERG_LO']
+        high = hdu.data['ENERG_HI']
+        return cls.from_lower_and_upper_bounds(low, high, unit)
+
+    def to_ebounds(self, **kwargs):
         """Write EBOUNDS fits extension
 
         Returns

--- a/gammapy/spectrum/energy.py
+++ b/gammapy/spectrum/energy.py
@@ -66,6 +66,14 @@ class Energy(Quantity):
         """
         return self.size
 
+    @property
+    def range(self):
+        """
+        The covered energy range (tuple)
+        """
+        return self[0], self[-1]
+
+
     @classmethod
     def equal_log_spacing(cls, emin, emax, nbins, unit=None):
         """Create Energy with equal log-spacing (`~gammapy.spectrum.energy.Energy`).

--- a/gammapy/spectrum/tests/test_energy.py
+++ b/gammapy/spectrum/tests/test_energy.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import astropy.units as u
 from numpy.testing import assert_equal
 from ...spectrum import Energy, EnergyBounds
-
+from astropy.tests.helper import remote_data
+from ...datasets import get_path
+from astropy.io import fits
 
 def test_Energy():
     # Explicit constructor call
@@ -49,7 +51,7 @@ def test_Energy():
     desired = 3
     assert_equal(actual, desired)
 
-
+@remote_data
 def test_EnergyBounds():
     val = u.Quantity([1, 2, 3, 4, 5], 'TeV')
     actual = EnergyBounds(val, 'GeV')
@@ -102,4 +104,20 @@ def test_EnergyBounds():
     upper = [3, 4, 5, 8]
     actual = EnergyBounds.from_lower_and_upper_bounds(lower, upper, 'TeV')
     desired = EnergyBounds([1, 3, 4, 5, 8], 'TeV')
+    assert_equal(actual, desired)
+
+    #read EBOUNDS extension
+    filename = get_path("../test_datasets/irf/hess/ogip/run_rmf60741.fits",
+                        location='remote')
+
+    hdulist = fits.open(filename);
+    ebounds = EnergyBounds.from_ebounds(hdulist['EBOUNDS'])
+    desired = hdulist['EBOUNDS'].data['E_MAX'][-1]
+    actual = ebounds[-1].value
+    assert_equal(actual, desired)
+
+    #read MATRIX extension
+    ebounds = EnergyBounds.from_rmf_matrix(hdulist['MATRIX'])
+    desired = hdulist['MATRIX'].data['ENERG_LO'][3]
+    actual = ebounds[3].value
     assert_equal(actual, desired)

--- a/gammapy/spectrum/tests/test_energy.py
+++ b/gammapy/spectrum/tests/test_energy.py
@@ -106,6 +106,15 @@ def test_EnergyBounds():
     desired = EnergyBounds([1, 3, 4, 5, 8], 'TeV')
     assert_equal(actual, desired)
 
+    # Range
+    erange = energy.range
+    actual = erange[0]
+    desired = energy[0]
+    assert_equal(actual, desired)
+    actual = erange[1]
+    desired = energy[-1]
+    assert_equal(actual, desired)
+
     #read EBOUNDS extension
     filename = get_path("../test_datasets/irf/hess/ogip/run_rmf60741.fits",
                         location='remote')


### PR DESCRIPTION
This PR updates the EnergyDispersion class that wraps the OGIP RMF format: 
Changes include:
* Fits output transferred from external np_to_rm function to class member and rewritten (use numpy instead of for loops)
* Energy handling updated in order to use gammapy.spectrum.energy (including some updates in the Energy classes)

NOT included
* Update RMF reader (from_hdu_list)
* Updates of plot routines
* Test for EnergyDispersion2D -> EnergyDispersion