### PR TITLE
Question: cython installation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,7 +36,7 @@ and then run these commands:
 
     conda config --add channels astropy --add channels sherpa
     conda install gammapy naima \
-        scipy matplotlib ipython-notebook
+        scipy matplotlib ipython-notebook cython
 
 We strongly recommend that you install the optional dependencies of Gammapy to have the full
 functionality available:


### PR DESCRIPTION
Hi,

when I tried to install gammapy on my local machine this weekend, I did not work out of the box as described in the docs.
More specifically the python setup.py build_ext command crashed with a cryptic error message.

'conda install cython' solved all problems, should we just add it to the docs? Or should I look into more detail what the error was? Strangely I did not have the cython package installed on the MPIK cluster