### PR TITLE
Fix travis-ci issues

### DIFF
--- a/.continuous-integration/travis/setup_dependencies_common.sh
+++ b/.continuous-integration/travis/setup_dependencies_common.sh
@@ -69,6 +69,10 @@ fi
 # the script installed by 'coveralls', unless it's installed first.
 if [[ $SETUP_CMD == 'test -V --coverage' ]]
 then
+  # TODO can use latest version of coverage (4.0) once
+  # https://github.com/astropy/astropy/issues/4175 is addressed in
+  # astropy release version.
+  pip install coverage==3.7.1;
   pip install cpp-coveralls;
-  pip install coverage coveralls;
+  pip install coveralls;
 fi


### PR DESCRIPTION
* Pin version number of coverage to 3.7.1 for now until https://github.com/astropy/astropy/issues/4175 is fixed in an Astropy release version (taken from https://github.com/kbarbary/sncosmo/commit/58761648def87bbb26e25ec542a37f32d24ae5cd)
* Update astropy-helpers to fix build errors on travis-ci (see [here](https://groups.google.com/forum/#!topic/astropy-dev/LU2NOxAoph0) and [here](https://groups.google.com/forum/#!topic/astropy-dev/DF-lAsNZDOY))