### PR TITLE
Remove spectrum.energy from top-level namespace

### DIFF
--- a/docs/tutorials/fermi_psf/fermi_psf_study.py
+++ b/docs/tutorials/fermi_psf/fermi_psf_study.py
@@ -2,7 +2,7 @@
 """
 import matplotlib.pyplot as plt
 from astropy.table import Table
-from gammapy.spectrum import EnergyBounds
+from gammapy.spectrum.energy import EnergyBounds
 from gammapy.datasets import FermiGalacticCenter, FermiVelaRegion
 from gammapy.datasets import load_lat_psf_performance
 

--- a/gammapy/data/counts_spectrum.py
+++ b/gammapy/data/counts_spectrum.py
@@ -28,7 +28,7 @@ class CountsSpectrum(object):
 
     .. code-block:: python
     
-        from gammapy.spectrum import Energy, EnergyBounds
+        from gammapy.spectrum.energy import Energy, EnergyBounds
         from gammapy.data import CountsSpectrum
         ebounds = EnergyBounds.equal_log_spacing(1,10,10,'TeV') 
         counts = [6,3,8,4,9,5,9,5,5,1]

--- a/gammapy/data/spectral_cube.py
+++ b/gammapy/data/spectral_cube.py
@@ -15,7 +15,8 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.wcs import WCS
 from astropy.coordinates import Angle
-from ..spectrum import EnergyBounds, LogEnergyAxis, powerlaw
+from ..spectrum.energy import EnergyBounds
+from ..spectrum import LogEnergyAxis, powerlaw
 from ..image import cube_to_image, solid_angle
 from ..utils.fits import table_to_fits_table
 

--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -373,7 +373,7 @@ class EffectiveAreaTable2D(object):
         from astropy.coordinates import Angle
         from astropy.units import Quantity
         from gammapy.irf import EffectiveAreaTable2D
-        from gammapy.spectrum import EnergyBounds
+        from gammapy.spectrum.energy import EnergyBounds
         from gammapy.datasets import load_aeff2D_fits_table
         aeff2D = EffectiveAreaTable2D.from_fits(load_aeff2D_fits_table())
         offset = Angle(0.43, 'degree')

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -5,7 +5,7 @@ from ..obs import DataStore, ObservationTable
 from ..irf import EnergyDispersion, EnergyDispersion2D
 from ..irf import EffectiveAreaTable, EffectiveAreaTable2D
 from ..data import CountsSpectrum, EventList
-from ..spectrum import EnergyBounds, Energy
+from ..spectrum.energy import EnergyBounds, Energy
 from ..background import ring_area_factor
 from astropy.coordinates import Angle, SkyCoord
 import logging

--- a/gammapy/spectrum/__init__.py
+++ b/gammapy/spectrum/__init__.py
@@ -14,4 +14,3 @@ from .powerlaw import *
 from .sed import *
 from .sherpa_chi2asym import *
 from .utils import *
-from .energy import *

--- a/gammapy/spectrum/tests/test_energy.py
+++ b/gammapy/spectrum/tests/test_energy.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
 from numpy.testing import assert_equal
-from ...spectrum import Energy, EnergyBounds
+from ..energy import Energy, EnergyBounds
 from astropy.tests.helper import remote_data
 from ...datasets import get_path
 from astropy.io import fits


### PR DESCRIPTION
This PR remove gammapy.spectrum.energy from the namespace gammapy.spectum, because it might introduce circular import if other classes want to use spectrum.energy

more concretely this happend, when spectrum.spectrum_analysis (see [361]) used data.CountsSpectrum and CountsSpecturm used specturm.EnergyBounds