### PR TITLE
Fix failing test_wcs_object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,9 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.4 OPTIONAL_DEPS=false SETUP_CMD='test -V'
 
-        # Test with old numpy versions
+        # Test with other numpy versions
+        - os: linux
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=dev SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
         - os: linux
@@ -88,12 +90,12 @@ matrix:
     # You can move builds that temporarily fail because of some non-Gammapy issue here
     # Please add a link to a GH issue that tracks the upstream issue.
     allow_failures:
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=dev SETUP_CMD='test'
+      - env: PYTHON_VERSION=3.4 NUMPY_VERSION=dev SETUP_CMD='test -V'
       # Tests for old Numpy versions currently don't work:
       # https://github.com/astropy/conda-builder-affiliated/issues/40
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
+      # - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
       - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test -V'
-      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test -V'
+      # - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.6 SETUP_CMD='test -V'
 
 install:
     - source .continuous-integration/travis/setup_environment_$TRAVIS_OS_NAME.sh

--- a/gammapy/utils/wcs.py
+++ b/gammapy/utils/wcs.py
@@ -102,14 +102,6 @@ def linear_arrays_to_wcs(name_x, name_y, bin_edges_x, bin_edges_y):
         ss_error += " Is this expected?"
         raise ValueError(ss_error)
 
-    # check that bins are linear (edges equally spaced)
-    bin_widths_x = np.diff(bin_edges_x)
-    if not np.allclose(bin_widths_x, bin_widths_x[0]):
-        raise ValueError("The X bins are not linear! Diff = {}".format(np.diff(bin_edges_x.value)))
-    bin_widths_y = np.diff(bin_edges_y)
-    if not np.allclose(bin_widths_y, bin_widths_y[0]):
-        raise ValueError("The Y bins are not linear! Diff = {}".format(np.diff(bin_edges_y.value)))
-
     # Create a new WCS object. The number of axes must be set from the start
     wcs = WCS(naxis=2)
 


### PR DESCRIPTION
I now see the same error reported by @dlennarz  in https://github.com/gammapy/gammapy/issues/366#issuecomment-147386710, the test_wcs_object fails like this:
https://gist.github.com/cdeil/c4febeecc7626f421420

I still don't fully understand when this occurs, it's somehow Numpy or Astropy version specific.

So before fixing it in this PR, I'll try and add extra builds on travis-ci for Numpy dev or Astropy dev versions that  reproduce the issue.