### PR TITLE
Use example dataset from PyGamma15 for testing

### DIFF
--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -4,6 +4,7 @@ import numpy as np
 from astropy.wcs import WCS
 from astropy.io import fits
 from ..image import exclusion_distance, lon_lat_circle_mask, coordinates
+from ..utils.scripts import make_path
 
 __all__ = [
     'ExclusionMask',
@@ -78,7 +79,8 @@ class ExclusionMask(object):
         excl_file : str
             fits file containing an Exclusion extension
         """
-        hdulist = fits.open(excl_file)
+        path = make_path(excl_file)
+        hdulist = fits.open(str(path))
         hdu = hdulist['Exclusion']
         return cls.from_hdu(hdu)
 

--- a/gammapy/obs/data_store.py
+++ b/gammapy/obs/data_store.py
@@ -8,6 +8,7 @@ from astropy.units import Quantity
 from astropy.io import fits
 from ..extern.pathlib import Path
 from ..obs import ObservationTable
+from ..utils.scripts import make_path
 
 __all__ = [
     'DataStore',
@@ -35,7 +36,7 @@ class DataStore(object):
     DEFAULT_NAME = 'noname'
 
     def __init__(self, base_dir, file_table=None, obs_table=None, name=None):
-        self.base_dir = Path(base_dir)
+        self.base_dir = make_path(base_dir)
         self.file_table = file_table
         self.obs_table = obs_table
         self.name = name
@@ -104,15 +105,15 @@ class DataStore(object):
         """Try different DataStore construtors.
         
         Currently tried
-        - from_name
         - from_dir
+        - from_name
         """
         try:
-            store = cls.from_name(val)
-        except(KeyError):
+            store = cls.from_dir(val)
+        except(OSError):
             try:
-                store = cls.from_dir(val)
-            except(OSError):
+                store = cls.from_name(val)
+            except(KeyError):
                 raise ValueError('Not able to contruct DataStore'
                                  ' using key: {}'.format(val))
                 
@@ -258,7 +259,7 @@ class DataStore(object):
         for ii in range(len(observation_table)):
             obs_id = observation_table['OBS_ID'][ii]
             filename = self.filename(obs_id)
-            if not Path(filename).is_file():
+            if not make_path(filename).is_file():
                 file_available[ii] = False
                 if logger:
                     logger.warning('For OBS_ID = {:06d} the event list file is missing: {}'
@@ -274,8 +275,8 @@ def _find_file(filename, dir):
     - Second tris Path(dir) / filename
     - Raises OSError if both don't exist.
     """
-    path1 = Path(filename)
-    path2 = Path(dir) / filename
+    path1 = make_path(filename)
+    path2 = make_path(dir) / filename
     if path1.is_file():
         filename = path1
     elif path2.is_file():

--- a/gammapy/obs/data_store.py
+++ b/gammapy/obs/data_store.py
@@ -99,6 +99,25 @@ class DataStore(object):
         dm = DataManager()
         return dm[name]
 
+    @classmethod
+    def from_all(cls, val):
+        """Try different DataStore construtors.
+        
+        Currently tried
+        - from_name
+        - from_dir
+        """
+        try:
+            store = cls.from_name(val)
+        except(KeyError):
+            try:
+                store = cls.from_dir(val)
+            except(OSError):
+                raise ValueError('Not able to contruct DataStore'
+                                 ' using key: {}'.format(val))
+                
+        return store
+
     def info(self, stream=None):
         """Print some info"""
         if not stream:

--- a/gammapy/spectrum/spectrum_analysis.py
+++ b/gammapy/spectrum/spectrum_analysis.py
@@ -43,8 +43,8 @@ class SpectrumAnalysis(object):
 
     Parameters
     ----------
-    datastore : str
-        Name of a `~gammapy.obs.Data store`
+    datastore : `~gammapy.obs.Data store`
+        Data for the analysis
     obs : list, str
         List of observations or file containing such a list
     on_region : `gammapy.region.SkyCircleRegion`
@@ -64,7 +64,7 @@ class SpectrumAnalysis(object):
                  nobs=-1, ebounds=None):
 
         self.on_region = on_region
-        self.store = DataStore.from_name(datastore)
+        self.store = datastore
         self.exclusion = exclusion
         if ebounds is None:
             ebounds = EnergyBounds.equal_log_spacing(0.1, 10, 20, 'TeV')
@@ -444,7 +444,8 @@ def run_spectrum_analysis_using_config(config):
 
     # Observations
     obs = config['general']['runlist']
-    store = config['general']['datastore']
+    store_val = config['general']['datastore']
+    store = DataStore.from_all(store_val)
     nobs = config['general']['nruns']
 
     # Binning

--- a/gammapy/spectrum/tests/test_spectrum_analysis.py
+++ b/gammapy/spectrum/tests/test_spectrum_analysis.py
@@ -18,11 +18,11 @@ def test_spectrum_analysis_from_configfile(tmpdir):
     import yaml
     config = read_yaml(configfile)
     config['general']['outdir'] = str(tmpdir)
-    
+
     ana = run_spectrum_analysis_using_config(config)
-    assert_allclose(ana.fit['parvals'][0], 2.24, rtol = 1e-2)
+    assert_allclose(ana.fit['parvals'][0], 2.0, rtol = 1e-1)
 
     config['off_region']['type'] = 'reflected'
     ana = run_spectrum_analysis_using_config(config)
-    assert_allclose(ana.fit['parvals'][0], 2.24, rtol = 1e-2)
+    assert_allclose(ana.fit['parvals'][0], 2.0, rtol = 1e-1)
 

--- a/gammapy/spectrum/tests/test_spectrum_analysis.py
+++ b/gammapy/spectrum/tests/test_spectrum_analysis.py
@@ -1,33 +1,28 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.tests.helper import pytest
-from ...utils.testing import requires_dependency, requires_data
 from numpy.testing import assert_allclose
+from ...utils.testing import requires_dependency, requires_data
 from ...datasets import gammapy_extra
+from ...utils.scripts import read_yaml
 from ...spectrum.spectrum_analysis import (
     SpectrumAnalysis,
-    run_spectrum_analysis_using_configfile,
-    run_spectrum_analysis_using_config)
+    run_spectrum_analysis_using_config,
+)
 
 @requires_dependency('yaml')
 @requires_data('gammapy-extra')
-@requires_data('hess')
 def test_spectrum_analysis_from_configfile(tmpdir):
+
+    configfile = gammapy_extra.filename('test_datasets/spectrum/spectrum_analysis_example.yaml')
+
     import yaml
-
-    configfile = gammapy_extra.filename('test_datasets/spectrum/spectrum_analysis_example_ring.yaml')
-
-    import yaml
-    with open(configfile) as fh:
-        config = yaml.safe_load(fh)
-
-    config['general']['outdir']=str(tmpdir)
-
+    config = read_yaml(configfile)
+    config['general']['outdir'] = str(tmpdir)
+    
     ana = run_spectrum_analysis_using_config(config)
-
-    assert_allclose(ana.fit['parvals'][0], 2.44, rtol = 1e-2)
+    assert_allclose(ana.fit['parvals'][0], 2.24, rtol = 1e-2)
 
     config['off_region']['type'] = 'reflected'
-
     ana = run_spectrum_analysis_using_config(config)
-    assert_allclose(ana.fit['parvals'][0], 2.44, rtol = 1e-2)
+    assert_allclose(ana.fit['parvals'][0], 2.24, rtol = 1e-2)
 

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -9,7 +9,8 @@ import os
 import glob
 import logging
 import shutil
-from astropy.extern import six
+from os.path import expandvars
+from ..extern.pathlib import Path
 
 __all__ = [
     'GammapyFormatter',
@@ -135,7 +136,7 @@ def _configure_root_logger(level='info', format=None):
 
 def read_yaml(filename, logger=None):
     """
-    Read config from YAML file resolving environment variables.
+    Read config from YAML file 
     """
     import yaml
     if logger is not None:
@@ -143,25 +144,7 @@ def read_yaml(filename, logger=None):
     with open(filename) as fh:
         config = yaml.safe_load(fh)
     
-    _resolve_environ(config)
-
     return config
-
-def _resolve_environ(ddict):
-    """
-    Helper function to resolve environment variables in YAML config files
-    """
-    for k in ddict.keys():
-        val = ddict[k]
-        if isinstance(val, six.string_types):
-            pos = val.find('$')
-            if pos != -1:
-                pos2 = val[pos:].find('/')
-                variable = val[pos:pos2]
-                resolved = os.environ[variable[1:]]
-                ddict[k] = val.replace(variable,resolved)
-        elif type(val) == dict:
-            _resolve_environ(val)
 
 def write_yaml(config, filename, logger=None):
     """
@@ -175,3 +158,10 @@ def write_yaml(config, filename, logger=None):
         logger.info('Writing {}'.format(filename))
     with open(filename, 'w') as outfile:
         outfile.write(yaml.dump(config, default_flow_style=False))
+
+
+def make_path(path):
+    """
+    Expand environment varibles on `~pathlib.Path` construction
+    """
+    return Path(expandvars(path))

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -96,13 +96,10 @@ def requires_data(name):
     return pytest.mark.skipif(skip_it, reason=reason)
 
 
-# TODO: create one or two datastores with simulated data and use that
-# for many Gammapy tests
 # https://pytest.org/latest/tmpdir.html#the-tmpdir-factory-fixture
 @pytest.fixture
 def data_manager():
-    # filename = get_pkg_data_filename('data/data-register.yaml')
-    # return DataManager.from_yaml(filename)
-    dm = DataManager()
-    return dm
+    test_register = gammapy_extra.filename('test_datasets/test-data-register.yaml')
+    return DataManager.from_yaml(test_register)
+    
 


### PR DESCRIPTION
This PR sets up a yaml file parser that resolves environment variables. This way the example datastore created for the PyGamma15 workshope ($GAMMAPY_EXTRA/datasets/hess-crab4) can be used for testing.