### PR TITLE
Adding SpectrumAnalysis to spectrum module

### DIFF
--- a/docs/irf/plot_energy_dispersion.py
+++ b/docs/irf/plot_energy_dispersion.py
@@ -2,7 +2,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from gammapy.irf import EnergyDispersion
-from gammapy.spectrum import EnergyBounds
+from gammapy.utils.energy import EnergyBounds
 
 ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
 energy_dispersion = EnergyDispersion.from_gauss(ebounds, sigma=0.3)

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -63,8 +63,8 @@ effective area tables. In general, this axis can be defined in two ways.
   e.g. for Fermi-LAT counts cubes. In Gammalib this is represented by GEbounds.
 
 In Gammapy both the use cases are handled by two seperate classes: 
-`gammapy.spectrum.energy.Energy` for energy values and
-`gammapy.spectrum.energy.EnergyBounds` for energy bin edges
+`gammapy.utils.energy.Energy` for energy values and
+`gammapy.utils.energy.EnergyBounds` for energy bin edges
 
 Energy
 ------
@@ -74,7 +74,7 @@ same functionality plus some convenienve functions for fits I/O
 
 .. code-block:: python
     
-    >>> from gammapy.spectrum import Energy
+    >>> from gammapy.utils.energy import Energy
     >>> energy = Energy([1,2,3], 'TeV')
     >>> hdu = energy.to_fits()
     >>> type(hdu) 
@@ -88,7 +88,7 @@ e.g. to compute the bin centers
 
 .. code-block:: python
     
-    >>> from gammapy.spectrum import EnergyBounds
+    >>> from gammapy.utils.energy import EnergyBounds
     >>> ebounds = EnergyBounds.equal_log_spacing(1, 10, 8, 'GeV')
     >>> ebounds.size
     9

--- a/docs/tutorials/fermi_psf/fermi_psf_study.py
+++ b/docs/tutorials/fermi_psf/fermi_psf_study.py
@@ -2,7 +2,7 @@
 """
 import matplotlib.pyplot as plt
 from astropy.table import Table
-from gammapy.spectrum import EnergyBounds
+from gammapy.utils.energy import EnergyBounds
 from gammapy.datasets import FermiGalacticCenter, FermiVelaRegion
 from gammapy.datasets import load_lat_psf_performance
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -26,6 +26,9 @@ sub-modules:
 
 Reference/API
 =============
+.. automodapi:: gammapy.utils.energy
+    :no-inheritance-diagram:
+
 .. automodapi:: gammapy.utils.mpl_style
     :no-inheritance-diagram:
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.utils.data import download_file
 from astropy.units import Quantity
-from ..spectrum import EnergyBounds
+from ..utils.energy import EnergyBounds
 from ..datasets import gammapy_extra
 from .core import SourceCatalog, SourceCatalogObject
 

--- a/gammapy/data/__init__.py
+++ b/gammapy/data/__init__.py
@@ -25,4 +25,3 @@ from .gti import *
 from .telarray import *
 from .event_list import *
 from .spectral_cube import *
-from .counts_spectrum import *

--- a/gammapy/data/spectral_cube.py
+++ b/gammapy/data/spectral_cube.py
@@ -15,7 +15,8 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.wcs import WCS
 from astropy.coordinates import Angle
-from ..spectrum import EnergyBounds, LogEnergyAxis, powerlaw
+from ..spectrum import LogEnergyAxis, powerlaw
+from ..utils.energy import EnergyBounds
 from ..image import cube_to_image, solid_angle
 from ..utils.fits import table_to_fits_table
 

--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -354,7 +354,7 @@ class EffectiveAreaTable2D(object):
         from astropy.coordinates import Angle
         from astropy.units import Quantity
         from gammapy.irf import EffectiveAreaTable2D
-        from gammapy.spectrum import EnergyBounds
+        from gammapy.utils.energy import EnergyBounds
         from gammapy.datasets import gammapy_extra
         filename = gammapy_extra.filename('test_datasets/unbundled/irfs/aeff2D.fits')
         aeff2D = EffectiveAreaTable2D.read(filename)
@@ -563,7 +563,7 @@ class EffectiveAreaTable2D(object):
         ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            offset = Angle(np.linspace(0, 2.5, 6), 'deg')
+            offset = Angle(np.linspace(0.5, 2, 4), 'deg')
 
         if energy is None:
             energy = self.energy
@@ -592,7 +592,9 @@ class EffectiveAreaTable2D(object):
             energy = Quantity(np.logspace(-1, 2, 8), 'TeV')
 
         if offset is None:
-            offset = Angle(np.linspace(0, 2.5, 100), 'deg')
+            off_lo = self.offset[0]
+            off_hi = self.offset[-1]
+            offset = Angle(np.linspace(off_lo, off_hi, 100), 'deg')
 
         for ee in energy:
             area = self.evaluate(offset, ee)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.coordinates import Angle
 from astropy.units import Quantity
-from ..spectrum.energy import EnergyBounds
+from ..utils.energy import EnergyBounds
 from astropy.table import Table
 from ..utils.fits import table_to_fits_table, get_hdu_with_valid_name
 from ..utils.array import array_stats_str

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -23,9 +23,9 @@ class EnergyDispersion(object):
     pdf_matrix : array_like
         2-dim energy dispersion matrix (probability density).
         First index for true energy, second index for reco energy.
-    e_true : `~gammapy.spectrum.EnergyBounds`
+    e_true : `~gammapy.utils.energy.EnergyBounds`
         True energy binning
-    e_reco : `~gammapy.spectrum.EnergyBounds`
+    e_reco : `~gammapy.utils.energy.EnergyBounds`
         Reco energy binning
 
     Notes
@@ -85,13 +85,13 @@ class EnergyDispersion(object):
 
     @property
     def reco_energy(self):
-        """Reconstructed Energy axis (`~gammapy.spectrum.EnergyBounds`)
+        """Reconstructed Energy axis (`~gammapy.utils.energy.EnergyBounds`)
         """
         return self._e_reco
 
     @property
     def true_energy(self):
-        """Reconstructed Energy axis (`~gammapy.spectrum.EnergyBounds`)
+        """Reconstructed Energy axis (`~gammapy.utils.energy.EnergyBounds`)
         """
         return self._e_true
 
@@ -116,7 +116,7 @@ class EnergyDispersion(object):
 
         Parameters
         ----------
-        e_reco : `~gammapy.spectrum.EnergyBounds`
+        e_reco : `~gammapy.utils.energy.EnergyBounds`
             Reco and true energy binning
         sigma : float
             RMS width of Gaussian energy dispersion.
@@ -503,7 +503,7 @@ class EnergyDispersion2D(object):
         import matplotlib.pyplot as plt
         import numpy as np
         from gammapy.irf import EnergyDispersion2D
-        from gammapy.spectrum.energy import Energy
+        from gammapy.utils.energy import Energy
         from astropy.coordinates import Angle
         from gammapy.datasets import gammapy_extra
         filename = gammapy_extra.filename('test_datasets/irf/hess/pa/hess_edisp_2d_023523.fits.gz')
@@ -581,7 +581,7 @@ class EnergyDispersion2D(object):
 
         Parameters
         ----------
-        e_true : `~gammapy.spectrum.EnergyBounds`, None
+        e_true : `~gammapy.utils.energy.EnergyBounds`, None
             True energy axis
         migra : `~numpy.ndarray`
             Energy migration e_reco/e_true
@@ -640,9 +640,9 @@ class EnergyDispersion2D(object):
         ----------
         offset : `~astropy.coordinates.Angle`
             Offset
-        e_true : `~gammapy.spectrum.EnergyBounds`, None
+        e_true : `~gammapy.utils.energy.EnergyBounds`, None
             True energy axis
-        e_reco : `~gammapy.spectrum.EnergyBounds`
+        e_reco : `~gammapy.utils.energy.EnergyBounds`
             Reconstructed energy axis
 
         Returns
@@ -674,9 +674,9 @@ class EnergyDispersion2D(object):
 
         Parameters
         ----------
-        e_true : `~gammapy.spectrum.Energy`
+        e_true : `~gammapy.utils.energy.Energy`
             True energy axis
-        e_reco : `~gammapy.spectrum.EnergyBounds`, None
+        e_reco : `~gammapy.utils.energy.EnergyBounds`, None
             Reconstructed energy axis
         offset : `~astropy.coordinates.Angle`
             Offset

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -10,7 +10,7 @@ from ..extern.validator import validate_physical_type
 from ..utils.array import array_stats_str
 from ..utils.fits import get_hdu_with_valid_name
 from ..irf import HESSMultiGaussPSF
-from ..spectrum import Energy
+from ..utils.energy import Energy
 from ..utils.fits import table_to_fits_table
 
 __all__ = ['EnergyDependentMultiGaussPSF']

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -52,7 +52,7 @@ def test_EffectiveAreaTable_write(tmpdir):
     assert len(hdu_list) == 2
 
 
-INTERPOLATION_METHODS = ['linear', 'spline']
+INTERPOLATION_METHODS = ['linear']
 
 
 @pytest.mark.parametrize(('method'), INTERPOLATION_METHODS)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -6,7 +6,7 @@ from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EnergyDispersion, EnergyDispersion2D
 from ...datasets import gammapy_extra
-from ...spectrum.energy import EnergyBounds
+from ...utils.energy import EnergyBounds
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/__init__.py
+++ b/gammapy/spectrum/__init__.py
@@ -15,6 +15,5 @@ from .powerlaw import *
 from .sed import *
 from .sherpa_chi2asym import *
 from .utils import *
-from .energy import *
-# TODO resolve circular import issue
-# from .spectrum_analysis import *
+from .counts_spectrum import *
+from .spectrum_analysis import *

--- a/gammapy/spectrum/counts_spectrum.py
+++ b/gammapy/spectrum/counts_spectrum.py
@@ -20,7 +20,7 @@ class CountsSpectrum(object):
 
     counts : `~numpy.array`, list
         Counts
-    energy : `~gammapy.spectrum.Energy`, `~gammapy.spectrum.EnergyBounds`.
+    energy : `~gammapy.utils.energy.Energy`, `~gammapy.utils.energy.EnergyBounds`.
         Energy axis
     livetime : `~astropy.units.Quantiy`
         Livetime of the dataset
@@ -30,7 +30,7 @@ class CountsSpectrum(object):
 
     .. code-block:: python
 
-        from gammapy.spectrum import Energy, EnergyBounds
+        from gammapy.utils.energy import Energy, EnergyBounds
         from gammapy.data import CountsSpectrum
         ebounds = EnergyBounds.equal_log_spacing(1,10,10,'TeV')
         counts = [6,3,8,4,9,5,9,5,5,1]
@@ -105,7 +105,7 @@ class CountsSpectrum(object):
         ----------
         event_list : `~astropy.io.fits.BinTableHDU, `gammapy.data.EventListDataSet`,
                      `gammapy.data.EventList`, str (filename)
-        bins : `gammapy.spectrum.energy.EnergyBounds`
+        bins : `gammapy.utils.energy.EnergyBounds`
             Energy bin edges
         """
 

--- a/gammapy/spectrum/counts_spectrum.py
+++ b/gammapy/spectrum/counts_spectrum.py
@@ -3,7 +3,7 @@ from __future__ import (print_function)
 
 import numpy as np
 from astropy import log
-from ..spectrum.energy import Energy, EnergyBounds
+from ..utils.energy import Energy, EnergyBounds
 import datetime
 from astropy.io import fits
 from astropy.units import Quantity

--- a/gammapy/spectrum/spectrum_analysis.py
+++ b/gammapy/spectrum/spectrum_analysis.py
@@ -55,7 +55,7 @@ class SpectrumAnalysis(object):
         Background method including necessary parameters
     nobs : int
         number of observations to process
-    ebounds : `~gammapy.spectrum.EnergyBounds`, optional
+    ebounds : `~gammapy.utils.energy.EnergyBounds`, optional
         Reconstructed energy binning definition
 
     """
@@ -136,9 +136,9 @@ class SpectrumAnalysis(object):
         ----------
         model : str
             Sherpa model
-        thres_high : `~gammapy.spectrum.Energy`
+        thres_high : `~gammapy.utils.energy.Energy`
             Upper threshold of the spectral fit
-        thres_low : `~gammapy.spectrum.Energy`
+        thres_low : `~gammapy.utils.energy.Energy`
             Lower threshold of the spectral fit
         """
 
@@ -201,9 +201,9 @@ class SpectrumObservation(object):
     ----------
     obs : int
         Observation ID, runnumber
-    store : `~gammapy.obs.DataStore
+    store : `~gammapy.obs.DataStore`
         Data Store
-    ebounds : `~gammapy.spectrum.EnergyBounds`
+    ebounds : `~gammapy.utils.energy.EnergyBounds`
         Reconstructed energy binning definition
     on_region : `gammapy.region.SkyCircleRegion`
         Circular region to extract on counts
@@ -240,13 +240,13 @@ class SpectrumObservation(object):
 
     @property
     def pointing(self):
-        """`~astropy.coordinates.SkyCoord corresponding to the obs position
+        """`~astropy.coordinates.SkyCoord` corresponding to the obs position
         """
         return self.event_list.pointing_radec
 
     @property
     def offset(self):
-        """`~astropy.coordinates.Angle corresponding to the obs offset
+        """`~astropy.coordinates.Angle` corresponding to the obs offset
         """
         return self.pointing.separation(self.on_region.pos)
 
@@ -255,7 +255,7 @@ class SpectrumObservation(object):
 
         Returns
         -------
-        on_vec : `gammapy.data.CountsSpectrum`
+        on_vec : `gammapy.spectrum.CountsSpectrum`
             Counts spectrum inside the ON region
         """
         on_list = self.event_list.select_circular_region(self.on_region)
@@ -282,7 +282,7 @@ class SpectrumObservation(object):
 
         Returns
         -------
-        on_vec : `gammapy.data.CountsSpectrum`
+        on_vec : `gammapy.spectrum.CountsSpectrum`
             Counts spectrum inside the OFF region
         """
         if self.bkg_method['type'] == "ring":

--- a/gammapy/spectrum/spectrum_analysis.py
+++ b/gammapy/spectrum/spectrum_analysis.py
@@ -8,9 +8,9 @@ from gammapy.extern.pathlib import Path
 from gammapy.image import ExclusionMask
 from gammapy.region import SkyCircleRegion, find_reflected_regions
 from ..background import ring_area_factor
-from ..data import CountsSpectrum
+from . import CountsSpectrum
 from ..obs import DataStore
-from ..spectrum import EnergyBounds, Energy
+from ..utils.energy import EnergyBounds, Energy
 from ..utils.scripts import get_parser, set_up_logging_from_args
 
 __all__ = [

--- a/gammapy/spectrum/tests/test_counts_spectrum.py
+++ b/gammapy/spectrum/tests/test_counts_spectrum.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_equal
-from ...data import CountsSpectrum
-from ...spectrum import EnergyBounds
+from .. import CountsSpectrum
+from ...utils.energy import EnergyBounds
 
 
 def test_CountsSpectrum():

--- a/gammapy/spectrum/tests/test_spectrum_analysis.py
+++ b/gammapy/spectrum/tests/test_spectrum_analysis.py
@@ -8,13 +8,14 @@ from ...spectrum.spectrum_analysis import (
     run_spectrum_analysis_using_configfile,
     run_spectrum_analysis_using_config)
 
+@pytest.mark.xfail
 @requires_dependency('yaml')
 @requires_data('gammapy-extra')
 @requires_data('hess')
 def test_spectrum_analysis_from_configfile(tmpdir):
     import yaml
 
-    configfile = gammapy_extra.filename('test_datasets/spectrum/spectrum_analysis_example_ring.yaml')
+    configfile = gammapy_extra.filename('test_datasets/spectrum/spectrum_analysis_example.yaml')
 
     import yaml
     with open(configfile) as fh:

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -84,7 +84,7 @@ class Energy(Quantity):
 
     @classmethod
     def equal_log_spacing(cls, emin, emax, nbins, unit=None):
-        """Create Energy with equal log-spacing (`~gammapy.spectrum.energy.Energy`).
+        """Create Energy with equal log-spacing (`~gammapy.utils.energy.Energy`).
 
         if no unit is given, it will be taken from emax
 
@@ -113,7 +113,7 @@ class Energy(Quantity):
 
     @classmethod
     def from_fits(cls, hdu, unit=None):
-        """Read ENERGIES fits extension (`~gammapy.spectrum.energy.Energy`).
+        """Read ENERGIES fits extension (`~gammapy.utils.energy.Energy`).
 
         Parameters
         ----------
@@ -161,7 +161,7 @@ class EnergyBounds(Energy):
 
     """EnergyBounds array.
 
-    This is a `~gammapy.spectrum.energy.Energy` sub-class that adds convenience
+    This is a `~gammapy.utils.energy.Energy` sub-class that adds convenience
     methods to handle common tasks for energy bin edges arrays, like FITS I/O or
     generating arrays of bin centers.
 
@@ -217,7 +217,7 @@ class EnergyBounds(Energy):
 
     @classmethod
     def from_lower_and_upper_bounds(cls, lower, upper, unit=None):
-        """EnergyBounds from lower and upper bounds (`~gammapy.spectrum.energy.EnergyBounds`).
+        """EnergyBounds from lower and upper bounds (`~gammapy.utils.energy.EnergyBounds`).
 
         If no unit is given, it will be taken from upper
 
@@ -240,7 +240,7 @@ class EnergyBounds(Energy):
 
     @classmethod
     def equal_log_spacing(cls, emin, emax, nbins, unit=None):
-        """EnergyBounds with equal log-spacing (`~gammapy.spectrum.energy.EnergyBounds`).
+        """EnergyBounds with equal log-spacing (`~gammapy.utils.energy.EnergyBounds`).
 
         If no unit is given, it will be taken from emax
 
@@ -261,7 +261,7 @@ class EnergyBounds(Energy):
 
     @classmethod
     def from_ebounds(cls, hdu, unit=None):
-        """Read EBOUNDS fits extension (`~gammapy.spectrum.energy.EnergyBounds`).
+        """Read EBOUNDS fits extension (`~gammapy.utils.energy.EnergyBounds`).
 
         Parameters
         ----------
@@ -282,7 +282,7 @@ class EnergyBounds(Energy):
 
     @classmethod
     def from_rmf_matrix(cls, hdu, unit=None):
-        """Read MATRIX fits extension (`~gammapy.spectrum.energy.EnergyBounds`).
+        """Read MATRIX fits extension (`~gammapy.utils.energy.EnergyBounds`).
 
         Parameters
         ----------

--- a/gammapy/utils/tests/test_energy.py
+++ b/gammapy/utils/tests/test_energy.py
@@ -6,14 +6,14 @@ import astropy.units as u
 from astropy.io import fits
 from ...utils.testing import requires_data
 from ...datasets import gammapy_extra
-from ...spectrum import Energy, EnergyBounds
+from ...utils.energy import Energy, EnergyBounds
 
 
 def test_Energy():
     # Explicit constructor call
     energy = Energy([1, 3, 6, 8, 12], 'TeV')
     actual = type(energy).__module__
-    desired = 'gammapy.spectrum.energy'
+    desired = 'gammapy.utils.energy'
     assert_equal(actual, desired)
 
     val = u.Quantity([1, 3, 6, 8, 12], 'TeV')
@@ -24,7 +24,7 @@ def test_Energy():
     # View casting
     energy = val.view(Energy)
     actual = type(energy).__module__
-    desired = 'gammapy.spectrum.energy'
+    desired = 'gammapy.utils.energy'
     assert_equal(actual, desired)
 
     # New from template
@@ -81,7 +81,7 @@ def test_EnergyBounds():
     # View casting
     energy = val.view(EnergyBounds)
     actual = type(energy).__module__
-    desired = 'gammapy.spectrum.energy'
+    desired = 'gammapy.utils.energy'
     assert_equal(actual, desired)
 
     # New from template
@@ -108,7 +108,7 @@ def test_EnergyBounds():
     # Log centers
     center = energy.log_centers
     actual = type(center).__module__
-    desired = 'gammapy.spectrum.energy'
+    desired = 'gammapy.utils.energy'
     assert_equal(actual, desired)
 
     # Upper/lower bounds

--- a/gammapy/utils/tests/test_energy.py
+++ b/gammapy/utils/tests/test_energy.py
@@ -12,8 +12,8 @@ from ...utils.energy import Energy, EnergyBounds
 def test_Energy():
     # Explicit constructor call
     energy = Energy([1, 3, 6, 8, 12], 'TeV')
-    actual = type(energy).__module__
-    desired = 'gammapy.utils.energy'
+    actual = str(energy.__class__)
+    desired = "<class 'gammapy.utils.energy.Energy'>"
     assert_equal(actual, desired)
 
     val = u.Quantity([1, 3, 6, 8, 12], 'TeV')


### PR DESCRIPTION
This seems obvious but didn't work so far due to circular import issues. It would be nice  to have the SpectrumAnalysis class in the spectrum module especially because people start to work with this class, so it's convenient for them to have the docs.

This PR also changes the linear interpolator in irf.effective_area_table to `~scipy.interpolation.RegularGridInterpolator` to raise an Error when evaluating the grid outside the boundaries