### PR TITLE
Add Python 3.5 builds on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,6 @@ matrix:
                SHERPA=true
 
         - os: linux
-          env: PYTHON_VERSION=3.3 SETUP_CMD='test -V'
-        - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
@@ -71,30 +69,30 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
                SHERPA=true
         - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='build_sphinx -w'
+          env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
 
         # Run tests without GAMMAPY_EXTRA available
         - os: linux
-          env: FETCH_GAMMAPY_EXTRA=false PYTHON_VERSION=3.4 SETUP_CMD='test -V'
+          env: FETCH_GAMMAPY_EXTRA=false PYTHON_VERSION=3.5 SETUP_CMD='test -V'
 
         # Test with Astropy dev and LTS versions
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts SETUP_CMD='test -V'
                SHERPA=true
         - os: linux
-          env: PYTHON_VERSION=3.4 ASTROPY_VERSION=lts SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='test -V'
                SHERPA=true
         - os: linux
-          env: PYTHON_VERSION=3.4 ASTROPY_VERSION=dev SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
                SHERPA=true
         - os: linux
-          env: PYTHON_VERSION=3.4 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
+          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
 
         # Test with with optional dependencies disabled
@@ -103,7 +101,7 @@ matrix:
                CONDA_DEPENDENCIES='Cython click'
                PIP_DEPENDENCIES=''
         - os: linux
-          env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES='Cython click'
                PIP_DEPENDENCIES=''
 
@@ -113,7 +111,7 @@ matrix:
         # older numpies, but using lts version should be good enough for
         # these tests (so we can avoid building it from source).
         - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=dev SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test -V'
                SHERPA=true ASTROPY_VERSION=lts
@@ -127,7 +125,7 @@ matrix:
     # You can move builds that temporarily fail because of some non-Gammapy issue here
     # Please add a link to a GH issue that tracks the upstream issue.
     allow_failures:
-      - env: PYTHON_VERSION=3.4 NUMPY_VERSION=dev SETUP_CMD='test -V'
+      - env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
       - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test -V'
              SHERPA=true
              CONDA_CHANNELS='astropy-ci-extras astropy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
-
+        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
 
 matrix:
 
@@ -59,7 +59,11 @@ matrix:
                SHERPA=true
 
         - os: linux
+          env: PYTHON_VERSION=3.3 SETUP_CMD='test -V'
+        - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
+        - os: linux
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
 
         # Build docs
         - os: linux

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -332,9 +332,9 @@ def compute_ts_map(counts, background, exposure, kernel, mask=None, flux=None,
     # to fail, this is a temporary fix
     mask_ = np.logical_and(background == 0, exposure > 0)
     if mask_.any():
-        log.warn('There are pixels in the data, that have exposure, but zero '
-                 'background, which can cause the ts computation to fail. '
-                 'Setting exposure of this pixels to zero.')
+        log.warning('There are pixels in the data, that have exposure, but '
+                    'zero background, which can cause the ts computation to '
+                    'fail. Setting exposure of this pixels to zero.')
         exposure[mask_] = 0
 
     if (flux is None and method != 'root brentq') or threshold is not None:

--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -241,7 +241,7 @@ class EffectiveAreaTable(object):
             return EffectiveAreaTable(energy_lo, energy_hi, effective_area,
                                       energy_thresh_lo, energy_thresh_hi)
         except KeyError:
-            log.warn('No safe energy thresholds found. Setting to default')
+            log.warning('No safe energy thresholds found. Setting to default')
             return cls(energy_lo, energy_hi, effective_area)
 
     def effective_area_at_energy(self, energy):

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -124,7 +124,7 @@ class EnergyDependentMultiGaussPSF(object):
             return cls(energy_lo, energy_hi, theta, sigmas,
                        norms, energy_thresh_lo, energy_thresh_hi)
         except KeyError:
-            log.warn('No safe energy thresholds found. Setting to default')
+            log.warning('No safe energy thresholds found. Setting to default')
             return cls(energy_lo, energy_hi, theta, sigmas, norms)
 
     def to_fits(self):

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import (print_function)
 
-from gammapy.extern.pathlib import Path
 from gammapy.spectrum.spectrum_analysis import (
     SpectrumAnalysis,
     run_spectral_fit_using_config,
@@ -64,7 +63,7 @@ class SpectrumPipe(object):
         config = read_yaml(filename, log)
         base_config = config.pop('base_config')
         analist = list([])
-        
+
         for analysis in config.keys():
             log.info("Creating analysis {}".format(analysis))
             anaconf = base_config.copy()
@@ -146,8 +145,8 @@ class SpectrumPipe(object):
             try:
                 sec = ref[target]
             except KeyError:
-                log.warn('No reference values found in {0} for '
-                         'analysis {1}'.format(filename, target))
+                log.warning('No reference values found in {0} for '
+                            'analysis {1}'.format(filename, target))
 
             else:
                 labels.append(target)

--- a/gammapy/spectrum/spectrum_analysis.py
+++ b/gammapy/spectrum/spectrum_analysis.py
@@ -81,8 +81,8 @@ class SpectrumAnalysis(object):
                 temp = SpectrumObservation(val, self.store, on_region,
                                            bkg_method, ebounds, exclusion)
             except IndexError:
-                log.warn(
-                        'Observation {} not in store {}'.format(val, datastore))
+                log.warning(
+                    'Observation {} not in store {}'.format(val, datastore))
                 nobs += 1
                 continue
             self._observations.append(temp)

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -128,7 +128,7 @@ class Energy(Quantity):
 
         if fitsunit is None:
             if unit is not None:
-                log.warn("No unit found in the FITS header."
+                log.warning("No unit found in the FITS header."
                          " Setting it to {0}".format(unit))
                 fitsunit = unit
             else:
@@ -272,7 +272,8 @@ class EnergyBounds(Energy):
         """
 
         if hdu.name != 'EBOUNDS':
-            log.warn('This does not seem like an EBOUNDS extension. Are you sure?')
+            log.warning('This does not seem like an EBOUNDS extension. '
+                        'Are you sure?')
 
         header = hdu.header
         unit = header.get('TUNIT2')
@@ -293,7 +294,8 @@ class EnergyBounds(Energy):
         """
 
         if hdu.name != 'MATRIX':
-            log.warn('This does not seem like a MATRIX extension. Are you sure?')
+            log.warning('This does not seem like a MATRIX extension. '
+                        'Are you sure?')
 
         header = hdu.header
         unit = header.get('TUNIT1')


### PR DESCRIPTION
Changes deprecated ``log.warn()`` to ``log.warning()``, thus python 3.5 builds are passing even when the deprecation warnings are raised as exceptions.

Closes #407.

(@cdeil - I've tried to add a build for python 3.3, but they are too many version conflicts. (There isn't a np 1.10 build for python 3.3, and then there isn't an astropy 1.1 for np 1.9. Also there isn't a pyregion one for python 3.3. If you you think it would be a useful addition I can add one more build for: python3.3 with numpy 1.9 with astropy lts with pip installed pyregion) 