### PR TITLE
Travis-ci conda install fails because of pinned versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ install:
     # https://travis-ci.org/gammapy/gammapy/jobs/99867950#L639
     - if $SHERPA; then
           conda install --yes --channel astropy numpy=$NUMPY_VERSION iminuit;
-          conda install --yes --channel https://conda.anaconda.org/cxc/channel/dev sherpa;
+          conda install --yes --no-pin --channel https://conda.anaconda.org/cxc/channel/dev sherpa;
           conda install --yes -q numpy=$NUMPY_VERSION;
       fi
 


### PR DESCRIPTION
Some of the travis-ci builds in #383 fail because conda package version conflicts.
Example: https://travis-ci.org/gammapy/gammapy/jobs/103639817

@bsipocz - Any idea how to fix this?