### PR TITLE
Fix Sherpa PSF centering bug

### DIFF
--- a/dev/sherpa/sherpa_ts_image.py
+++ b/dev/sherpa/sherpa_ts_image.py
@@ -52,7 +52,7 @@ from time import time
 import numpy as np
 from sherpa.astro.ui import *
 from sherpa.utils.err import FitErr
-from const import sigma_to_fwhm
+from astropy.stats import gaussian_sigma_to_fwhm
 import morphology.utils
 import morphology.psf
 
@@ -102,7 +102,7 @@ else:
 
 set_full_model('background + exposure * psf(' + get_source().name + ')')
 [par.freeze() for par in get_model().pars]
-test_source.fwhm = sigma_to_fwhm * args.sigma
+test_source.fwhm = gaussian_signma_to_fwhm * args.sigma
 #test_source.ampl.min = 0
 thaw(test_source.ampl)
 

--- a/gammapy/irf/psf_core.py
+++ b/gammapy/irf/psf_core.py
@@ -78,16 +78,14 @@ class SherpaMultiGaussPSF(object):
     def center_psf(self):
         """Set ``xpos`` and ``ypos`` of the PSF to the dataspace center."""
         import sherpa.astro.ui as sau
-
-        #from IPython import embed; embed()
         try:
             ny, nx = sau.get_data().shape
             for _ in ['psf1', 'psf2', 'psf3']:
                 par = sau.get_par(_ + '.xpos')
-                par.val = (nx) / 2.
+                par.val = nx / 2.
                 
                 par = sau.get_par(_ + '.ypos')
-                par.val = (ny) / 2.
+                par.val = ny / 2.
         except:
             raise Exception('PSF is not centered.')
 

--- a/gammapy/irf/psf_core.py
+++ b/gammapy/irf/psf_core.py
@@ -78,13 +78,16 @@ class SherpaMultiGaussPSF(object):
     def center_psf(self):
         """Set ``xpos`` and ``ypos`` of the PSF to the dataspace center."""
         import sherpa.astro.ui as sau
+
+        #from IPython import embed; embed()
         try:
             ny, nx = sau.get_data().shape
-            for par in sau.get_psf().kernel.pars:
-                if par.name is 'xpos':
-                    par.val = (nx + 1) / 2.
-                elif par.name is 'ypos':
-                    par.val = (ny + 1) / 2.
+            for _ in ['psf1', 'psf2', 'psf3']:
+                par = sau.get_par(_ + '.xpos')
+                par.val = (nx) / 2.
+                
+                par = sau.get_par(_ + '.ypos')
+                par.val = (ny) / 2.
         except:
             raise Exception('PSF is not centered.')
 
@@ -94,9 +97,9 @@ class SherpaMultiGaussPSF(object):
         # from morphology.utils import read_json
         read_json(self.pars, sau.set_model)
         sau.load_psf('psf', sau.get_model())
-        sau.set_psf('psf')
         self.center_psf()
-
+        sau.set_psf('psf')
+        
     def evaluate(self, t, ampl1, fwhm1, ampl2, fwhm2, ampl3, fwhm3):
         """Hand-coded evaluate for debugging."""
         f = 4 * np.log(2)

--- a/gammapy/irf/psf_core.py
+++ b/gammapy/irf/psf_core.py
@@ -20,7 +20,7 @@ import numpy as np
 from astropy.convolution import Gaussian2DKernel
 from astropy.io import fits
 from astropy import log
-from ..utils.const import sigma_to_fwhm, fwhm_to_sigma
+from astropy.stats import gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm
 from ..morphology import read_json
 from ..morphology import Gauss2DPDF, MultiGauss2D
 
@@ -44,7 +44,7 @@ class GaussPSF(Gauss2DPDF):
         that the integral is 1"""
         d = {}
         d['ampl'] = binsz ** 2 * self.norm
-        d['fwhm'] = sigma_to_fwhm / binsz * self.sigma
+        d['fwhm'] = gaussian_sigma_to_fwhm / binsz * self.sigma
         return {'psf1': d}
 
 
@@ -219,7 +219,7 @@ class HESSMultiGaussPSF(object):
             A = self.pars['A_{0}'.format(ii)]
             sigma = self.pars['sigma_{0}'.format(ii)]
             d['ampl'] = A
-            d['fwhm'] = sigma_to_fwhm * sigma / binsz
+            d['fwhm'] = gaussian_sigma_to_fwhm * sigma / binsz
             name = 'psf{0}'.format(ii)
             pars[name] = d
         return pars
@@ -360,7 +360,7 @@ def multi_gauss_psf_kernel(psf_parameters, BINSZ=0.02, NEW_BINSZ=0.02, **kwargs)
     for ii in range(1, 4):
         # Convert sigma and amplitude
         pars = psf_parameters['psf{0}'.format(ii)]
-        sigma = fwhm_to_sigma * pars['fwhm'] * BINSZ / NEW_BINSZ
+        sigma = gaussian_fwhm_to_sigma * pars['fwhm'] * BINSZ / NEW_BINSZ
         ampl = 2 * np.pi * sigma ** 2 * pars['ampl']
         if psf is None:
             psf = float(ampl) * Gaussian2DKernel(sigma, **kwargs)

--- a/gammapy/morphology/model.py
+++ b/gammapy/morphology/model.py
@@ -6,7 +6,7 @@ At the moment you can have any number of Gaussians.
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
-from ..utils.const import fwhm_to_sigma
+from astropy.stats import gaussian_fwhm_to_sigma
 from ..utils.random import get_random_state
 
 __all__ = [
@@ -86,7 +86,7 @@ class MorphModelImageCreator(object):
             # TODO: Add other source models
             if cfg[source]['Type'] != 'NormGaussian':
                 raise ValueError('So far only normgauss2d models can be handled.')
-            sigma = fwhm_to_sigma * float(cfg[source]['fwhm'])
+            sigma = gaussian_fwhm_to_sigma * float(cfg[source]['fwhm'])
             ampl = float(cfg[source]['ampl']) * 1 / (2 * np.pi * sigma ** 2)
             xpos = float(cfg[source]['xpos']) - 1
             ypos = float(cfg[source]['ypos']) - 1
@@ -124,9 +124,9 @@ class MorphModelImageCreator(object):
         psf_data = json.load(open(self.psf_file))
 
         # Convert sigma and amplitude
-        sigma_1 = fwhm_to_sigma * psf_data['psf1']['fwhm']
-        sigma_2 = fwhm_to_sigma * psf_data['psf2']['fwhm']
-        sigma_3 = fwhm_to_sigma * psf_data['psf3']['fwhm']
+        sigma_1 = gaussian_fwhm_to_sigma * psf_data['psf1']['fwhm']
+        sigma_2 = gaussian_fwhm_to_sigma * psf_data['psf2']['fwhm']
+        sigma_3 = gaussian_fwhm_to_sigma * psf_data['psf3']['fwhm']
         ampl_1 = psf_data['psf1']['ampl'] * 2 * np.pi * sigma_1 ** 2
         ampl_2 = psf_data['psf2']['ampl'] * 2 * np.pi * sigma_2 ** 2
         ampl_3 = psf_data['psf3']['ampl'] * 2 * np.pi * sigma_3 ** 2

--- a/gammapy/morphology/utils.py
+++ b/gammapy/morphology/utils.py
@@ -8,7 +8,7 @@ __all__ = ['read_ascii', 'read_json', 'write_all', 'write_ascii', 'write_json']
 
 def _name(ii):
     """Use this to make the model name for source number `ii`."""
-    return 'gauss2d.source_{0:02d}'.format(ii)
+    return 'normgauss2d.source_{0:02d}'.format(ii)
 
 
 def _set(name, par, val):
@@ -23,7 +23,7 @@ def _set(name, par, val):
 
 def _model(source_names):
     """Build additive model string for Gaussian sources."""
-    return ' + '.join(['gauss2d.' + name for name in source_names])
+    return ' + '.join(['normgauss2d.' + name for name in source_names])
 
 
 def read_json(source, setter):

--- a/gammapy/scripts/image_fit.py
+++ b/gammapy/scripts/image_fit.py
@@ -64,8 +64,8 @@ def image_fit(counts,
     log.info('Reading background: {0}'.format(background))
     sherpa.astro.ui.load_table_model('background', background)
 
-    log.info('Reading PSF: {0}'.format(psf))
-    SherpaMultiGaussPSF(psf).set()
+    #log.info('Reading PSF: {0}'.format(psf))
+    #SherpaMultiGaussPSF(psf).set()
 
     if roi:
         log.info('Reading ROI: {0}'.format(roi))
@@ -81,9 +81,14 @@ def image_fit(counts,
     # ---------------------------------------------------------
     # Scale exposure by 1e-10 to get ampl or order unity and avoid some fitting problems
     name = sherpa.astro.ui.get_source().name
-    full_model = 'background + 1e-12 * exposure * psf ({})'.format(name)
+    # full_model = 'background + 1e-12 * exposure * psf ({})'.format(name)
+    # sherpa.astro.ui.set_full_model(full_model)
+    # sherpa.astro.ui.freeze('background', 'exposure', 'psf')
+
+    full_model = 'background + 1e-12 * exposure * {}'.format(name)
     sherpa.astro.ui.set_full_model(full_model)
-    sherpa.astro.ui.freeze('background', 'exposure', 'psf')
+    sherpa.astro.ui.freeze('background', 'exposure')
+
 
     # ---------------------------------------------------------
     # Set up the fit

--- a/gammapy/scripts/image_fit.py
+++ b/gammapy/scripts/image_fit.py
@@ -68,7 +68,7 @@ def image_fit(counts,
         log.info('Reading PSF: {0}'.format(psf))
         SherpaMultiGaussPSF(psf).set()
     else:
-        log.info("Not applying PSF convolution.")
+        log.warning("No PSF convolution.")
 
     if roi:
         log.info('Reading ROI: {0}'.format(roi))

--- a/gammapy/scripts/image_fit.py
+++ b/gammapy/scripts/image_fit.py
@@ -16,7 +16,7 @@ def image_fit_main(args=None):
                         help='Exposure FITS file name')
     parser.add_argument('--background', type=str, default='background.fits',
                         help='Background FITS file name')
-    parser.add_argument('--psf', type=str, default='psf.json',
+    parser.add_argument('--psf', type=str, default=None,
                         help='PSF JSON file name')
     parser.add_argument('--sources', type=str, default='sources.json',
                         help='Sources JSON file name (contains start '
@@ -64,8 +64,11 @@ def image_fit(counts,
     log.info('Reading background: {0}'.format(background))
     sherpa.astro.ui.load_table_model('background', background)
 
-    #log.info('Reading PSF: {0}'.format(psf))
-    #SherpaMultiGaussPSF(psf).set()
+    if psf: 
+        log.info('Reading PSF: {0}'.format(psf))
+        SherpaMultiGaussPSF(psf).set()
+    else:
+        log.info("Not applying PSF convolution.")
 
     if roi:
         log.info('Reading ROI: {0}'.format(roi))
@@ -81,13 +84,14 @@ def image_fit(counts,
     # ---------------------------------------------------------
     # Scale exposure by 1e-10 to get ampl or order unity and avoid some fitting problems
     name = sherpa.astro.ui.get_source().name
-    # full_model = 'background + 1e-12 * exposure * psf ({})'.format(name)
-    # sherpa.astro.ui.set_full_model(full_model)
-    # sherpa.astro.ui.freeze('background', 'exposure', 'psf')
-
-    full_model = 'background + 1e-12 * exposure * {}'.format(name)
-    sherpa.astro.ui.set_full_model(full_model)
-    sherpa.astro.ui.freeze('background', 'exposure')
+    if psf:
+        full_model = 'background + 1e-12 * exposure * psf ({})'.format(name)
+        sherpa.astro.ui.set_full_model(full_model)
+        sherpa.astro.ui.freeze('background', 'exposure', 'psf')
+    else:
+        full_model = 'background + 1e-12 * exposure * {}'.format(name)
+        sherpa.astro.ui.set_full_model(full_model)
+        sherpa.astro.ui.freeze('background', 'exposure')
 
 
     # ---------------------------------------------------------

--- a/gammapy/scripts/tests/test_image_fit.py
+++ b/gammapy/scripts/tests/test_image_fit.py
@@ -26,7 +26,7 @@ def test_sherpa_like(tmpdir):
         json.dump(sources_data, fh)
 
     # set up args
-    args = {'counts': str(filenames['counts']),
+    args = {'counts': str(filenames['source']),
             'exposure': str(filenames['exposure']),
             'background': str(filenames['background']),
             'psf': filenames['psf'],

--- a/gammapy/scripts/tests/test_image_fit.py
+++ b/gammapy/scripts/tests/test_image_fit.py
@@ -2,16 +2,27 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import json
 from numpy.testing.utils import assert_allclose
+from astropy.stats import gaussian_sigma_to_fwhm
+from astropy.tests.helper import pytest
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import load_poisson_stats_image
 from ..image_fit import image_fit
 
 
+EXPECTED = ([9.016526, 99.865985, 100.147877, 1010.824189],
+            [4 * gaussian_sigma_to_fwhm, 100, 100, 1E3],
+            [5 * gaussian_sigma_to_fwhm, 100, 100, 1E3])
+RTOL = (1E-5, 1E-3, 1E-3)
+PSF = (True, True, False)
+DATA = (True, False, False)
+
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
-def test_sherpa_like_psf(tmpdir):
+@pytest.mark.parametrize('expected, rtol, psf, data',
+                          zip(EXPECTED, RTOL, PSF, DATA))
+def test_sherpa_like(tmpdir, expected, rtol, psf, data):
     """
-    Fit fake data.
+    Fit Poisson stats image test data.
     """
 
     # load test data
@@ -23,122 +34,36 @@ def test_sherpa_like_psf(tmpdir):
     sources_data['gaussian'] = {'ampl': 1E3,
                                 'xpos': 99,
                                 'ypos': 99,
-                                'fwhm': 4 * 2.3548}
+                                'fwhm': 4 * gaussian_sigma_to_fwhm}
 
     filename = tmpdir / 'test_sherpa_like_sources.json'
     with filename.open('w') as fh:
         json.dump(sources_data, fh)
 
     # set up args
-    args = {'counts': str(filenames['counts']),
-            'exposure': str(filenames['exposure']),
+    args = {'exposure': str(filenames['exposure']),
             'background': str(filenames['background']),
-            'psf': filenames['psf'],
             'sources': str(filename),
             'roi': None,
             'outfile': str(outfile)}
+
+    if data:
+        args['counts'] = str(filenames['counts'])
+    else:
+        args['counts'] = str(filenames['model'])
+    if psf:
+        args['psf'] = filenames['psf']
+    else:
+        args['psf'] = None
+
     image_fit(**args)
 
     with outfile.open() as fh:
         data = json.load(fh)
 
-    # Note: the reference results here changed once and
-    # we didn't track down why at the time:
-    # See https://github.com/gammapy/gammapy/issues/349
-    # old: [  9.016334  ,  99.365574   ,  99.647234   , 10.97365    ]
-    # new: [ 10.7427035 ,  98.16618776 ,  98.45487028 ,  7.73529899 ]
+    # This recovers the values from the test dataset documented here:
+    # https://github.com/gammapy/gammapy-extra/tree/master/
+    # test_datasets/unbundled/poisson_stats_image#data
     actual = data['fit']['parvals']
-    expected = [9.016526, 99.865985, 100.147877, 1010.824189]
-    assert_allclose(actual, expected)
-
-
-@requires_dependency('sherpa')
-@requires_data('gammapy-extra')
-def test_sherpa_like_no_psf_model(tmpdir):
-    """
-    Fit model image without PSF.
-    """
-    # load test data
-    filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
-    outfile = tmpdir / 'test_sherpa_like.json'
-
-    # write test source json file
-    sources_data = {}
-    sources_data['gaussian'] = {'ampl': 1E3,
-                                'xpos': 99,
-                                'ypos': 99,
-                                'fwhm': 4 * 2.3548}
-
-    filename = tmpdir / 'test_sherpa_like_sources.json'
-    with filename.open('w') as fh:
-        json.dump(sources_data, fh)
-
-    # set up args
-    args = {'counts': str(filenames['model']),
-            'exposure': str(filenames['exposure']),
-            'background': str(filenames['background']),
-            'sources': str(filename),
-            'psf': None,
-            'roi': None,
-            'outfile': str(outfile)}
-    image_fit(**args)
-
-    with outfile.open() as fh:
-        data = json.load(fh)
-
-    # Note: the reference results here changed once and
-    # we didn't track down why at the time:
-    # See https://github.com/gammapy/gammapy/issues/349
-    # old: [  9.016334  ,  99.365574   ,  99.647234   , 10.97365    ]
-    # new: [ 10.7427035 ,  98.16618776 ,  98.45487028 ,  7.73529899 ]
-    actual = data['fit']['parvals']
-    expected = [5 * 2.3548, 100, 100, 1E3]
-
-    assert_allclose(actual, expected, rtol=1E-3)
-
-
-@requires_dependency('sherpa')
-@requires_data('gammapy-extra')
-def test_sherpa_like_psf_model(tmpdir):
-    """
-    Fit model image with PSF.
-    """
-    # load test data
-    filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
-    outfile = tmpdir / 'test_sherpa_like.json'
-
-    # write test source json file
-    # fit starting values
-    sources_data = {}
-    sources_data['gaussian'] = {'ampl': 1E3,
-                                'xpos': 99,
-                                'ypos': 99,
-                                'fwhm': 4 * 2.3548}
-
-    filename = tmpdir / 'test_sherpa_like_sources.json'
-    with filename.open('w') as fh:
-        json.dump(sources_data, fh)
-
-    # set up args
-    args = {'counts': str(filenames['model']),
-            'exposure': str(filenames['exposure']),
-            'background': str(filenames['background']),
-            'sources': str(filename),
-            'psf': filenames['psf'],
-            'roi': None,
-            'outfile': str(outfile)}
-    image_fit(**args)
-
-    with outfile.open() as fh:
-        data = json.load(fh)
-
-    # Note: the reference results here changed once and
-    # we didn't track down why at the time:
-    # See https://github.com/gammapy/gammapy/issues/349
-    # old: [  9.016334  ,  99.365574   ,  99.647234   , 10.97365    ]
-    # new: [ 10.7427035 ,  98.16618776 ,  98.45487028 ,  7.73529899 ]
-    actual = data['fit']['parvals']
-    expected = [4 * 2.3548, 100, 100, 1E3]
-
-    assert_allclose(actual, expected, rtol=1E-3)
+    assert_allclose(actual, expected, rtol=rtol)
 

--- a/gammapy/scripts/tests/test_image_fit.py
+++ b/gammapy/scripts/tests/test_image_fit.py
@@ -9,7 +9,11 @@ from ..image_fit import image_fit
 
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
-def test_sherpa_like(tmpdir):
+def test_sherpa_like_psf(tmpdir):
+    """
+    Fit fake data.
+    """
+
     # load test data
     filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
     outfile = tmpdir / 'test_sherpa_like.json'
@@ -26,7 +30,7 @@ def test_sherpa_like(tmpdir):
         json.dump(sources_data, fh)
 
     # set up args
-    args = {'counts': str(filenames['source']),
+    args = {'counts': str(filenames['counts']),
             'exposure': str(filenames['exposure']),
             'background': str(filenames['background']),
             'psf': filenames['psf'],
@@ -44,5 +48,97 @@ def test_sherpa_like(tmpdir):
     # old: [  9.016334  ,  99.365574   ,  99.647234   , 10.97365    ]
     # new: [ 10.7427035 ,  98.16618776 ,  98.45487028 ,  7.73529899 ]
     actual = data['fit']['parvals']
-    expected = [10.7427035, 98.16618776, 98.45487028, 7.73529899]
+    expected = [9.016526, 99.865985, 100.147877, 1010.824189]
     assert_allclose(actual, expected)
+
+
+@requires_dependency('sherpa')
+@requires_data('gammapy-extra')
+def test_sherpa_like_no_psf_model(tmpdir):
+    """
+    Fit model image without PSF.
+    """
+    # load test data
+    filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
+    outfile = tmpdir / 'test_sherpa_like.json'
+
+    # write test source json file
+    sources_data = {}
+    sources_data['gaussian'] = {'ampl': 1E3,
+                                'xpos': 99,
+                                'ypos': 99,
+                                'fwhm': 4 * 2.3548}
+
+    filename = tmpdir / 'test_sherpa_like_sources.json'
+    with filename.open('w') as fh:
+        json.dump(sources_data, fh)
+
+    # set up args
+    args = {'counts': str(filenames['model']),
+            'exposure': str(filenames['exposure']),
+            'background': str(filenames['background']),
+            'sources': str(filename),
+            'psf': None,
+            'roi': None,
+            'outfile': str(outfile)}
+    image_fit(**args)
+
+    with outfile.open() as fh:
+        data = json.load(fh)
+
+    # Note: the reference results here changed once and
+    # we didn't track down why at the time:
+    # See https://github.com/gammapy/gammapy/issues/349
+    # old: [  9.016334  ,  99.365574   ,  99.647234   , 10.97365    ]
+    # new: [ 10.7427035 ,  98.16618776 ,  98.45487028 ,  7.73529899 ]
+    actual = data['fit']['parvals']
+    expected = [5 * 2.3548, 100, 100, 1E3]
+
+    assert_allclose(actual, expected, rtol=1E-3)
+
+
+@requires_dependency('sherpa')
+@requires_data('gammapy-extra')
+def test_sherpa_like_psf_model(tmpdir):
+    """
+    Fit model image with PSF.
+    """
+    # load test data
+    filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
+    outfile = tmpdir / 'test_sherpa_like.json'
+
+    # write test source json file
+    # fit starting values
+    sources_data = {}
+    sources_data['gaussian'] = {'ampl': 1E3,
+                                'xpos': 99,
+                                'ypos': 99,
+                                'fwhm': 4 * 2.3548}
+
+    filename = tmpdir / 'test_sherpa_like_sources.json'
+    with filename.open('w') as fh:
+        json.dump(sources_data, fh)
+
+    # set up args
+    args = {'counts': str(filenames['model']),
+            'exposure': str(filenames['exposure']),
+            'background': str(filenames['background']),
+            'sources': str(filename),
+            'psf': filenames['psf'],
+            'roi': None,
+            'outfile': str(outfile)}
+    image_fit(**args)
+
+    with outfile.open() as fh:
+        data = json.load(fh)
+
+    # Note: the reference results here changed once and
+    # we didn't track down why at the time:
+    # See https://github.com/gammapy/gammapy/issues/349
+    # old: [  9.016334  ,  99.365574   ,  99.647234   , 10.97365    ]
+    # new: [ 10.7427035 ,  98.16618776 ,  98.45487028 ,  7.73529899 ]
+    actual = data['fit']['parvals']
+    expected = [4 * 2.3548, 100, 100, 1E3]
+
+    assert_allclose(actual, expected, rtol=1E-3)
+

--- a/gammapy/utils/const.py
+++ b/gammapy/utils/const.py
@@ -6,8 +6,6 @@ from astropy.units import Unit, Quantity
 
 __all__ = ['conversion_factor',
            'd_sun_to_galactic_center',
-           'sigma_to_fwhm',
-           'fwhm_to_sigma',
            ]
 
 
@@ -24,10 +22,6 @@ def conversion_factor(old, new):
 
 """ Astronomical constants """
 d_sun_to_galactic_center = Quantity(8.5, 'kpc')  # Distance Sun to Galactic center (kpc)
-
-""" Additional constants """
-sigma_to_fwhm = np.sqrt(8 * np.log(2))  # ~ 2.35
-fwhm_to_sigma = 1 / sigma_to_fwhm
 
 # Here's how to compute the conversion factors in astropy that I used in my old code:
 # See https://gist.github.com/cdeil/5990465


### PR DESCRIPTION
This PR fixes a bug in `SherpaMultiGaussPSF`, where the PSF was not correctly centered and off by 1/2 a pixel. I added regression tests and made PSF convolution optional in the command line script and changed to the `normgauss2d` model. The current fitting results are again closer to the old ones (see  #349).