### PR TITLE
Improve travis-ci test matrix and fix misc issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy sherpa'
         - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy'
         - PIP_DEPENDENCIES='uncertainties reproject'
-        - SHERPA=false
         - CONDA_CHANNELS='astropy sherpa'
         - FETCH_GAMMAPY_EXTRA=true
         - MAIN_CMD='python setup.py'
@@ -62,19 +61,18 @@ matrix:
         # Coverage is measured on Python 2 (where Sherpa is available)
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test -V --coverage'
-               SHERPA=true
 
         - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
 
         # Build docs
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
-               SHERPA=true
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES_WO_SHERPA
@@ -86,19 +84,17 @@ matrix:
         # Test with Astropy dev and LTS versions
 #        - os: linux
 #          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts SETUP_CMD='test -V'
-#               SHERPA=true
 #        - os: linux
 #          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts SETUP_CMD='test -V'
+#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='test -V'
-               SHERPA=true
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
-               SHERPA=true
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES_WO_SHERPA
@@ -123,21 +119,19 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
 #        - os: linux
 #          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test -V'
-#               SHERPA=true ASTROPY_VERSION=lts
+#               ASTROPY_VERSION=lts
 #        - os: linux
 #          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
-#               SHERPA=true ASTROPY_VERSION=lts
+#               ASTROPY_VERSION=lts
 #               CONDA_CHANNELS='astropy-ci-extras astropy'
 #               CONDA_DEPENDENCIES='Cython click matplotlib'
 #               PIP_DEPENDENCIES=''
 
-    # You can move builds that temporarily fail because of some non-Gammapy issue here
+    # You can move builds that temporarily fail because of some non-Gammapy
+    # issue here
     # Please add a link to a GH issue that tracks the upstream issue.
 #    allow_failures:
-#      - env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
-#      - env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7 SETUP_CMD='test -V'
-#             SHERPA=true
-#             CONDA_CHANNELS='astropy-ci-extras astropy'
+
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git
@@ -154,16 +148,6 @@ install:
           sh -e /etc/init.d/xvfb start;
           export QT_API=pyqt;
       fi
-
-#    # Reinstalling the required numpy version as it may be downgraded.
-#    # TODO It may be removed when/if Sherpa becomes np version agnostic
-#    # (maybe as soon as v4.8). See discussion in
-#    # https://travis-ci.org/gammapy/gammapy/jobs/99867950#L639
-#    - if $SHERPA; then
-#          conda install --yes --channel astropy numpy=$NUMPY_VERSION iminuit;
-#          conda install --yes --no-pin --channel https://conda.anaconda.org/cxc/channel/dev sherpa;
-#          conda install --yes -q numpy=$NUMPY_VERSION;
-#      fi
 
 script:
     - $MAIN_CMD $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,6 @@ matrix:
         # Try MacOS X
         - os: osx
           env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-               CONDA_DEPENDENCIES='Cython click'
-               PIP_DEPENDENCIES=''
 
         - os: osx
           env: PYTHON_VERSION=3.5 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,13 @@ env:
     global:
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=1.1
-        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy'
+        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes sherpa'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy sherpa'
+        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy'
         - PIP_DEPENDENCIES='uncertainties reproject'
         - SHERPA=false
-        - CONDA_CHANNELS='astropy'
+        - CONDA_CHANNELS='astropy sherpa'
         - FETCH_GAMMAPY_EXTRA=true
         - MAIN_CMD='python setup.py'
 
@@ -64,6 +66,7 @@ matrix:
 
         - os: linux
           env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
 
@@ -74,12 +77,12 @@ matrix:
                SHERPA=true
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
+               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES_WO_SHERPA
 
         # Run tests without GAMMAPY_EXTRA available
         - os: linux
           env: FETCH_GAMMAPY_EXTRA=false PYTHON_VERSION=3.5 SETUP_CMD='test -V'
-
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         # Test with Astropy dev and LTS versions
 #        - os: linux
 #          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts SETUP_CMD='test -V'
@@ -91,13 +94,14 @@ matrix:
                SHERPA=true
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
                SHERPA=true
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
+               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES_WO_SHERPA
 
         # Test with with optional dependencies disabled
         - os: linux
@@ -116,6 +120,7 @@ matrix:
         # these tests (so we can avoid building it from source).
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
 #        - os: linux
 #          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test -V'
 #               SHERPA=true ASTROPY_VERSION=lts
@@ -150,15 +155,15 @@ install:
           export QT_API=pyqt;
       fi
 
-    # Reinstalling the required numpy version as it may be downgraded.
-    # TODO It may be removed when/if Sherpa becomes np version agnostic
-    # (maybe as soon as v4.8). See discussion in
-    # https://travis-ci.org/gammapy/gammapy/jobs/99867950#L639
-    - if $SHERPA; then
-          conda install --yes --channel astropy numpy=$NUMPY_VERSION iminuit;
-          conda install --yes --no-pin --channel https://conda.anaconda.org/cxc/channel/dev sherpa;
-          conda install --yes -q numpy=$NUMPY_VERSION;
-      fi
+#    # Reinstalling the required numpy version as it may be downgraded.
+#    # TODO It may be removed when/if Sherpa becomes np version agnostic
+#    # (maybe as soon as v4.8). See discussion in
+#    # https://travis-ci.org/gammapy/gammapy/jobs/99867950#L639
+#    - if $SHERPA; then
+#          conda install --yes --channel astropy numpy=$NUMPY_VERSION iminuit;
+#          conda install --yes --no-pin --channel https://conda.anaconda.org/cxc/channel/dev sherpa;
+#          conda install --yes -q numpy=$NUMPY_VERSION;
+#      fi
 
 script:
     - $MAIN_CMD $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,12 @@ matrix:
                CONDA_DEPENDENCIES='Cython click'
                PIP_DEPENDENCIES=''
 
+        # Test the dev version of Sherpa, this may take a longer time
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
+               PIP_DEPENDENCIES='uncertainties reproject https://github.com/sherpa/sherpa/archive/master.zip'
+
         # Run tests
         # Coverage is measured on Python 2 (where Sherpa is available)
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
       - graphviz
       - texlive-latex-extra
       - dvipng
+      - gfortran
 
 env:
     global:

--- a/docs/image/bounding_box.rst
+++ b/docs/image/bounding_box.rst
@@ -29,19 +29,17 @@ Let's say you have a large image, but are only interested in a small box (a rect
    np.sum(full_array)
    np.sum(sub_array)
 
-Numpy supports working with such boxes efficiently through the concept of 
+Numpy supports working with such boxes efficiently through the concept of
 `slicing <http://scipy-lectures.github.io/intro/numpy/array_object.html#indexing-and-slicing>`__
-and 
+and
 `views <http://scipy-lectures.github.io/intro/numpy/array_object.html#copies-and-views>`__.
 
 By slicing ``[1000:1010, 2000:2020]`` we created a view (not a copy) ``sub_array`` into the ``full_array``.
-On my machine making a measurement on ``sub_array`` is about 1000 times as fast as for ``full_array``:
-
-.. code-block:: python
+On my machine making a measurement on ``sub_array`` is about 1000 times as fast as for ``full_array``::
 
    In [34]: %timeit np.sum(full_array)
    100 loops, best of 3: 5.32 ms per loop
-   
+
    In [35]: %timeit np.sum(sub_array)
    100000 loops, best of 3: 7.41 µs per loop
 
@@ -49,7 +47,7 @@ How to represent bounding boxes and pass them around in code?
 -------------------------------------------------------------
 
 In gammapy we frequently need to bass bounding boxes around, e.g. from a function that detects
-many small objects in a large survey image to another function that measures some properties of these objects.  
+many small objects in a large survey image to another function that measures some properties of these objects.
 
 Python does have a built-in `slice <https://docs.python.org/3/library/functions.html#slice>`__ class,
 and we can use it to represent 1-dimensional slices:
@@ -70,7 +68,7 @@ and we can use it to represent 1-dimensional slices:
                stop = ii
                object_slices.append(slice(start, stop))
        return object_slices
-   
+
    def measure_objects(array, object_slices):
        """Measure something for all objects and print the result."""
        for object_slice in object_slices:
@@ -100,7 +98,7 @@ Before inventing our own, let's look at what kinds of representations others hav
   .. code-block:: python
 
       bbox = (slice(1, 3, None), slice(2, 5, None))
-  
+
   This has the advantage that for a numpy array it is very easy to create views
   for the rectangles represented by the bounding box:
 
@@ -115,7 +113,7 @@ Before inventing our own, let's look at what kinds of representations others hav
   As far as I can see no other function except `scipy.ndimage.measurements.find_objects` uses
   this bbox format, though. E.g. all other functions in `scipy.ndimage.measurements` take a
   ``label`` array as input, none has a ``bboxes`` argument.
- 
+
 * The `skimage.measure.regionprops` function returns ``properties``, a list of dict-like objects
   with (among many other things) a ``bbox`` entry, which is a Python tuple of integers::
 
@@ -132,17 +130,17 @@ Before inventing our own, let's look at what kinds of representations others hav
           return (self._slice[0].start, self._slice[1].start,
                   self._slice[0].stop, self._slice[1].stop)
 
-  As for `scipy.ndimage`, as far as I can see, ``bbox`` is not used elsewhere in `skimage`. 
+  As for `scipy.ndimage`, as far as I can see, ``bbox`` is not used elsewhere in `skimage`.
 
 * `photutils` has this `coordinate convention <http://photutils.readthedocs.org/en/latest/photutils/overview.html#coordinate-conventions>`__.
   Looking at the `photutils.aperture_photometry` implementation, it looks like they don't have an official ``bbox`` representation,
   but simply compute ``(x_min, x_max, y_min, y_max)`` where needed and then use ``data[y_min:y_max, x_min:x_max]`` views.
-  TODO: update once this is in: https://github.com/astropy/astropy/issues/2607 
+  TODO: update once this is in: https://github.com/astropy/astropy/issues/2607
 
 * `imutils <http://imutils.readthedocs.org/en/latest/>`__ has a
   `Cutout <http://imutils.readthedocs.org/en/latest/api/imutils.Cutout.html>`__ class.
 
-I also found 
+I also found
 `this <http://stackoverflow.com/questions/9525313/rectangular-bounding-box-around-blobs-in-a-monochrome-image-using-python>`__
 and
 `this <http://stackoverflow.com/questions/4087919/how-can-i-improve-my-paw-detection>`__

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -291,7 +291,7 @@ def make_base_catalog_galactic(n_sources, rad_dis='YK04', vel_dis='H05',
 
     # For now we only simulate shell-type SNRs.
     # Later we might want to simulate certain fractions of object classes
-    # index = random_integers(0, 0, n_sources)
+    # index = randint(0, 1, n_sources)
     index = 2 * np.ones(n_sources, dtype=np.int)
     morph_type = np.array(list(morph_types.keys()))[index]
 

--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -490,7 +490,7 @@ class FaucherSpiral(LogSpiral):
         """
         random_state = get_random_state(random_state)
 
-        N = random_state.random_integers(0, 3, radius.size)  # Choose Spiralarm
+        N = random_state.randint(0, 4, radius.size)  # Choose Spiralarm
         theta = self.k[N] * log(radius / self.r_0[N]) + self.theta_0[N]  # Compute angle
         spiralarm = self.spiralarms[N]  # List that contains in wich spiralarm a postion lies
 


### PR DESCRIPTION
The new sherpa release is now working with the stock and dev numpy, and thus can be installed along with the other dependencies using ci-helpers.

This PR also removes the deprecated usage of numpy.random that changed very recently in numpy dev and caused build failure here.

I've also checked, that Sherpa is still has deprecated numpy usage, thus we can't switch back to raise the deprecation warning as exceptions.