### PR TITLE
Disable click unicode literals warning

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -710,6 +710,22 @@ for the command line scripts at the moment).
 
 See ``gammapy/scripts/find_obs.py`` as an example.
 
+
+Command line tools using click
+------------------------------
+
+Command line tools that use the `click <http://click.pocoo.org/>`_ module should disable
+the unicode literals warnings to clean up the output of the tool:
+
+.. code-block:: python
+
+    import click
+    click.disable_unicode_literals_warning = True
+
+See `here <http://click.pocoo.org/5/python3/#unicode-literals>`_ for further
+information.  
+
+
 BSD or GPL license?
 -------------------
 
@@ -813,3 +829,5 @@ To see what is there, check out the ``gammapy/extern`` directory locally or on
 `Github <https://github.com/gammapy/gammapy/tree/master/gammapy/extern>`__.
 Notes on the bundled files are kept in the docstring of
 `gammapy/extern/__init__.py <https://github.com/gammapy/gammapy/blob/master/gammapy/extern/__init__.py>`__.
+
+

--- a/gammapy/scripts/catalog_browser/__init__.py
+++ b/gammapy/scripts/catalog_browser/__init__.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import click
+click.disable_unicode_literals_warning = True
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/scripts/catalog_query.py
+++ b/gammapy/scripts/catalog_query.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import click
+click.disable_unicode_literals_warning = True
 from ..catalog import source_catalogs
 
 __all__ = []

--- a/gammapy/scripts/data_manage.py
+++ b/gammapy/scripts/data_manage.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import click
+click.disable_unicode_literals_warning = True
 
 __all__ = ['data_manage']
 

--- a/gammapy/scripts/data_show.py
+++ b/gammapy/scripts/data_show.py
@@ -8,6 +8,7 @@ from astropy.io import fits
 from astropy.units import Quantity
 from astropy.table import Table
 import click
+click.disable_unicode_literals_warning = True
 from .. import irf
 from ..data import EventList
 

--- a/gammapy/scripts/spectrum.py
+++ b/gammapy/scripts/spectrum.py
@@ -1,5 +1,6 @@
 import logging
 import click
+click.disable_unicode_literals_warning = True
 from ..spectrum import run_spectrum_extraction_using_config
 from ..spectrum.results import SpectrumResult, SpectrumFitResult
 from ..spectrum.results import SpectrumResultDict


### PR DESCRIPTION
Disable click unicode literals warning to clean up the output of the command line tools that use it. 