### PR TITLE
Add King profile PSF class

### DIFF
--- a/docs/irf/psf.rst
+++ b/docs/irf/psf.rst
@@ -9,3 +9,10 @@ represent radially-symmetric PSFs where the PSF is given at a number of offsets:
 .. plot:: irf/plot_fermi_psf.py
 
 TODO: discuss noise when PSF is estimated from real or simulated data.
+
+King PSF
+--------
+
+Example of using `~gammapy.irf.PSFKing`:
+
+.. plot:: irf/plot_fermi_psf.py

--- a/examples/test_psf_king.py
+++ b/examples/test_psf_king.py
@@ -1,0 +1,87 @@
+import numpy as np
+from astropy.coordinates import Angle
+from gammapy.irf import PSFKing
+from gammapy.background import EnergyOffsetArray
+
+
+def load_psf(chain='hd', tool='gammapy'):
+    """Load a test PSF."""
+    if chain == 'hd':
+        filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2-input/run023400-023599/run023523/hess_psf_king_023523.fits.gz'
+        if tool == 'gammalib':
+            filename += '[PSF_2D_KING]'
+    elif chain == 'pa':
+        filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-pa/run23400-23599/run23523/psf_king_23523.fits.gz'
+    else:
+        raise ValueError('Invalid chain: {}'.format(chain))
+
+    print('Reading {}'.format(filename))
+
+    if tool == 'gammapy':
+        return PSFKing.read(filename)
+    elif tool == 'gammalib':
+        from gammalib import GCTAPsfKing
+        return GCTAPsfKing(filename)
+    else:
+        raise ValueError('Invalid tool: {}'.format(tool))
+
+
+def test_psf_king():
+    psf = load_psf(chain='hd')
+    print('HD PSF')
+    print(psf.info())
+
+    psf = load_psf(chain='pa')
+    print('PA PSF')
+    print(psf.info())
+
+
+def containment_radius(psf, fraction, energy, offset):
+    """Compute containment radius with Gammalib.
+
+    http://cta.irap.omp.eu/gammalib/doxygen/classGCTAPsfKing.html#ffa8ff988290ccc0927ea3e73ca639e2
+    """
+    radius = np.empty((len(energy), len(offset)))
+    for ii in range(len(energy)):
+        for jj in range(len(offset)):
+            logE = float(np.log10(energy.value[ii]))
+            theta = float(offset.radian[jj])
+            val = psf.containment_radius(float(fraction), logE, theta)
+            # print(ii, jj, fraction, logE, theta, val)
+            radius[ii, jj] = val
+
+    return Angle(radius.T, 'radian').to('deg')
+
+
+def plot_psf_king(chain='hd'):
+    psf = load_psf(chain=chain)
+    gamma = EnergyOffsetArray(energy=psf.energy, offset=psf.offset,
+                              data=psf.gamma, data_units=psf.gamma.unit)
+    sigma = EnergyOffsetArray(energy=psf.energy, offset=psf.offset,
+                              data=psf.sigma, data_units=psf.sigma.unit)
+
+    # For now, let's use Gammalib to compute containment radii
+    gpsf = load_psf(chain=chain, tool='gammalib')
+    r68 = containment_radius(gpsf, 0.68, psf.energy, psf.offset)
+    r68 = EnergyOffsetArray(energy=psf.energy, offset=psf.offset,
+                            data=r68, data_units='deg')
+
+    import matplotlib.pyplot as plt
+    fig, ax = plt.subplots(1, 3, figsize=(10, 3))
+    gamma.plot_image(ax=ax[0])
+    sigma.plot_image(ax=ax[1])
+    r68.plot_image(ax=ax[2], vmin=0, vmax=0.3)
+    # import IPython; IPython.embed()
+    # ax[2].colorbar()
+    fig.tight_layout()
+    # fig.show()
+    filename = 'test_psf_king_{}.png'.format(chain)
+    print('Writing {}'.format(filename))
+    fig.savefig(filename)
+    # input()
+
+
+if __name__ == '__main__':
+    # test_psf_king()
+    plot_psf_king(chain='hd')
+    plot_psf_king(chain='pa')

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -97,7 +97,7 @@ class EnergyOffsetArray(object):
         ax.set_title('Energy_offset Array')
         ax.legend()
         image = ax.imshow(self.data.value, extent=extent, **kwargs)
-        plt.colorbar(image)
+        # plt.colorbar(image)
         return ax
 
     @classmethod

--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -5,5 +5,6 @@ from .effective_area_table import *
 from .psf_core import *
 from .psf_table import *
 from .psf_analytical import *
+from .psf_king import *
 from .energy_dispersion import *
 from .exposure import *

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -1,0 +1,133 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.table import Table
+from astropy.units import Quantity
+from astropy.coordinates import Angle
+from ..utils.energy import Energy
+from ..utils.scripts import make_path
+from ..utils.array import array_stats_str
+
+__all__ = ['PSFKing']
+
+
+class PSFKing(object):
+    """King profile analytical PSF depending on energy and theta.
+
+    This PSF parametrisation and FITS data format is described here: :ref:`gadf:psf_king`.
+
+    Parameters
+    ----------
+    offset : `~astropy.coordinates.Angle`
+        Offset nodes (1D)
+    energy : `~gammapy.utils.energy.Energy`
+        Energy nodes (1D)
+    gamma : `~numpy.ndarray`
+        PSF parameter (2D)
+    sigma : `~astropy.coordinates.Angle`
+        PSF parameter (2D)
+    """
+
+    def __init__(self, offset, energy, gamma, sigma):
+        self.offset = Angle(offset)
+        self.energy = Energy(energy)
+        self.gamma = np.asanyarray(gamma)
+        self.sigma = Angle(sigma)
+
+    def info(self):
+        """Print some basic info.
+        """
+        ss = "\nSummary PSFKing info\n"
+        ss += "---------------------\n"
+        ss += array_stats_str(self.offset, 'offset')
+        ss += array_stats_str(self.energy, 'energy')
+        ss += array_stats_str(self.gamma, 'gamma')
+        ss += array_stats_str(self.sigma, 'sigma')
+
+        # TODO: should quote containment values also
+
+        return ss
+
+    @classmethod
+    def read(cls, filename, hdu=1):
+        """Create `PSFKing` from FITS file.
+
+        Parameters
+        ----------
+        filename : str
+            File name
+        """
+        filename = str(make_path(filename))
+        # TODO: implement it so that HDUCLASS is used
+        # http://gamma-astro-data-formats.readthedocs.org/en/latest/data_storage/hdu_index/index.html
+
+        table = Table.read(filename, hdu=hdu)
+        return cls.from_table(table)
+
+        # hdu_list = fits.open(filename)
+        # hdu = hdu_list[hdu]
+        # return cls.from_fits(hdu)
+
+    @classmethod
+    def from_table(cls, table):
+        """Create `PSFKing` from `~astropy.table.Table`.
+
+        Parameters
+        ----------
+        table : `~astropy.table.Table`
+            Table King PSF info.
+        """
+        theta_lo = table['THETA_LO'].squeeze()
+        theta_hi = table['THETA_HI'].squeeze()
+        offset = (theta_hi + theta_lo) / 2
+        offset = Angle(offset, unit=table['THETA_LO'].unit)
+
+        energy_lo = table['ENERG_LO'].squeeze()
+        energy_hi = table['ENERG_HI'].squeeze()
+        energy = np.sqrt(energy_lo * energy_hi)
+        energy = Energy(energy, unit=table['ENERG_LO'].unit)
+
+        gamma = Quantity(table['GAMMA'].squeeze(), table['GAMMA'].unit)
+        sigma = Quantity(table['SIGMA'].squeeze(), table['SIGMA'].unit)
+
+        return cls(offset, energy, gamma, sigma)
+
+    @staticmethod
+    def evaluate_direct(r, gamma, sigma):
+        """Evaluate formula from here: :ref:`gadf:psf_king`.
+
+        Parameters
+        ----------
+        TODO
+
+        Returns
+        -------
+        TODO
+        """
+        r2 = r * r
+        sigma2 = sigma * sigma
+
+        term1 = 1 / (2 * np.pi * sigma2)
+        term2 = 1 - 1 / gamma
+        term3 = (1 + r2 / 2 * gamma * sigma2) ** (-gamma)
+
+        return term1 * term2 * term3
+
+    def evaluate(self, offset=None, energy=None, interp_kwargs=None):
+        """Interpolate the value of the `EnergyOffsetArray` at a given offset and Energy.
+
+        Parameters
+        ----------
+        offset : `~astropy.coordinates.Angle`
+            offset value
+        energy : `~astropy.units.Quantity`
+            energy value
+        interp_kwargs : dict
+            option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
+
+        Returns
+        -------
+        values : `~astropy.units.Quantity`
+            Interpolated value
+        """
+        raise NotImplementedError

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.tests.helper import pytest, assert_quantity_allclose
+from astropy.coordinates import Angle
+from ...utils.testing import requires_dependency, requires_data
+from ...utils.energy import Energy
+from ...irf import PSFKing
+
+test_psf_king_args = [
+    {
+        'chain': 'hap-hd',
+        'filename': '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2-input/run023400-023599/run023523/hess_psf_king_023523.fits.gz',
+        'energy': 0.25178512930870056,
+        'offset': 1.25,
+        'gamma': 3.8902931213378906,
+        'sigma': 0.04095194861292839,
+    },
+    {
+        'chain': 'pa',
+        'filename': '$GAMMAPY_EXTRA/datasets/hess-crab4-pa/run23400-23599/run23523/psf_king_23523.fits.gz',
+        'energy': 1.2574334144592285,
+        'offset': 1.0,
+        'gamma': 2.02886700630188,
+        'sigma': 0.021144593134522438,
+    }
+]
+
+
+@pytest.mark.parametrize('args', test_psf_king_args)
+@requires_data('gammapy-extra')
+@requires_dependency('scipy')
+def test_psf_king(args):
+    psf = PSFKing.read(args['filename'])
+    psf.info()
+
+    assert_quantity_allclose(psf.offset[2], Angle(args['offset'], 'deg'))
+    assert_quantity_allclose(psf.energy[5], Energy(args['energy'], 'TeV'))
+    assert_quantity_allclose(psf.gamma[2, 5], args['gamma'])
+    assert_quantity_allclose(psf.sigma[2, 5], Angle(args['sigma'], 'deg'))


### PR DESCRIPTION
This PR adds a first version of the King profile PSF class:
http://gamma-astro-data-formats.readthedocs.org/en/latest/irfs/psf/psf_king/index.html

The goal is to make this work and print useful info and plot R68 and R95 / R68 as a function of energy and offset:
```
gammapy-data-show $GAMMAPY_EXTRA/test_datasets/irf/hess/pa/hess_psf_king_023523.fits.gz psf_king -p
```
