### PR TITLE
Update data access and example dataset

### DIFF
--- a/docs/background/energy_offset_array.rst
+++ b/docs/background/energy_offset_array.rst
@@ -6,9 +6,7 @@ EnergyOffset Array
 The `~gammapy.background.EnergyOffsetArray` class represents a 2D array *(energy,offset)* that is filled with an eventlist.
 For a set of observations, by giving an energy binning and an offset binning, you fill the events in this histogram.
 
-
-Four Crab observations are located in the ``gammapy-extra`` repository as examples:
-`hess_events_simulated_023523.fits`_ , `hess_events_simulated_023526.fits`_ , `hess_events_simulated_023559.fits`_ and `hess_events_simulated_023592.fits`_
+Four Crab observations are located at ``$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2``
 
 An example script of how to fill this array from these four observations and plots the result is given in the ``examples`` directory:
 :download:`example_energy_offset_array.py <../../examples/example_energy_offset_array.py>`
@@ -16,9 +14,3 @@ An example script of how to fill this array from these four observations and plo
 .. plot:: ../examples/example_energy_offset_array.py
    :include-source:
 
-
-
-.. _hess_events_simulated_023523.fits: https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4/hess_events_simulated_023523.fits
-.. _hess_events_simulated_023526.fits: https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4/hess_events_simulated_023526.fits
-.. _hess_events_simulated_023559.fits: https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4/hess_events_simulated_023559.fits
-.. _hess_events_simulated_023592.fits: https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4/hess_events_simulated_023592.fits

--- a/docs/data/dm.rst
+++ b/docs/data/dm.rst
@@ -27,7 +27,7 @@ Getting Started
 
 The following example demonstrates how data management is done in Gammapy. It uses a test data set, which is available
 in the `gammapy-extra <https://github.com/gammapy/gammapy-extra>`__ repository. Please clone this repository and
-navigate to ``gammapy-extra/datasets/``. The folder ``hess-crab4`` contains IRFs and simulated event lists for 4
+navigate to ``gammapy-extra/datasets/``. The folder ``hess-crab4-hd-hap-prod2`` contains IRFs and simulated event lists for 4
 observations of the Crab nebula. It also contains two index files:
 
 * Observation table `observations.fits.gz`
@@ -45,7 +45,7 @@ Exploring the data using the DataStore class works like this
 .. code-block:: python
 
     >>> from gammapy.data import DataStore
-    >>> data_store = DataStore.from_dir('hess-crab4')
+    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
     >>> data_store.info()
     Data store summary info:
     name: noname

--- a/docs/data/example-data-register.yaml
+++ b/docs/data/example-data-register.yaml
@@ -1,6 +1,6 @@
 stores:
   - name: crab_example
-    base_dir: <path-to-gammapy-extra>/datasets/hess-crab4
-    obs_table: observations.fits.gz
-    file_table: files.fits.gz
+    base_dir: $GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2
+    obs_table: obs-index.fits.gz
+    hdu_table: hdu-index.fits.gz
 

--- a/docs/spectrum/spectrum_analysis_example.yaml
+++ b/docs/spectrum/spectrum_analysis_example.yaml
@@ -1,7 +1,7 @@
 # Example Gammapy spectrum analysis pipeline config file
 
 general:
-  datastore: $GAMMAPY_EXTRA/datasets/hess-crab4
+  datastore: $GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2
   runlist : [23592, 23526]
   nruns : 0
   outdir : test_dir

--- a/docs/tutorials/gammapy-spectrum/spectrum_extraction_example.yaml
+++ b/docs/tutorials/gammapy-spectrum/spectrum_extraction_example.yaml
@@ -2,7 +2,7 @@
 
 extraction:
   data:
-    datastore: $GAMMAPY_EXTRA/datasets/hess-crab4
+    datastore: $GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2
     runlist : [23592, 23526]
     nruns : 0
 

--- a/examples/data_examples.py
+++ b/examples/data_examples.py
@@ -1,5 +1,6 @@
 import logging
 from gammapy.data import DataManager, DataStore
+from gammapy.datasets import gammapy_extra
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -26,6 +27,13 @@ def test_data_store():
     print(events.__class__)
 
 
+def test_data_store2():
+    dir = gammapy_extra.dir / 'datasets/hess-crab4-hd-hap-prod2'
+    ds = DataStore.from_dir(dir)
+    ds.info()
+
+
 if __name__ == '__main__':
-    test_data_manager()
-    test_data_store()
+    # test_data_manager()
+    # test_data_store()
+    test_data_store2()

--- a/examples/example_energy_offset_array.py
+++ b/examples/example_energy_offset_array.py
@@ -4,14 +4,13 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from gammapy.data import DataStore
-from gammapy.datasets import gammapy_extra
 from gammapy.background import EnergyOffsetArray
 from gammapy.utils.energy import EnergyBounds
 
 
 def make_counts_array():
     """Make an example counts array with energy and offset axes."""
-    data_store = DataStore.from_dir(gammapy_extra.dir / 'datasets/hess-crab4')
+    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
 
     event_lists = data_store.load_all('events')
     ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')

--- a/examples/make_tables.py
+++ b/examples/make_tables.py
@@ -1,0 +1,64 @@
+from astropy.io import fits
+from astropy.table import Table
+
+# Write minimal files and observations table needed for the gammapy data store
+
+obs_ids = [23523, 23526, 23559, 23592]
+file_types = ['events', 'aeff', 'edisp', 'psf', 'background']
+
+# FILE TABLE
+
+rows = []
+for obs in obs_ids:
+    for filetype in file_types:
+        #name = "hess_" + filetype + "_" + obs + ".fits.gz"
+        name = "hess_{}_{:06d}.fits.gz".format(filetype, obs)
+        if filetype == 'events':
+        #    name = "hess_events_simulated_" + obs + ".fits"
+            name = "hess_events_simulated_{:06d}.fits".format(obs)
+        if filetype == 'background':
+        #    name = "hess_bkg_offruns_" + obs + ".fits.gz"
+            name = "hess_bkg_offruns_{:06d}.fits.gz".format(obs)
+        data = dict()
+        data['OBS_ID'] = obs
+        data['TYPE'] = filetype
+        data['NAME'] = name
+        data['SIZE'] = ''
+        data['MTIME'] = ''
+        data['MD5'] = ''
+
+        hdu_list = fits.open(str(name))
+        hdu = hdu_list[1]
+        header = hdu.header
+        data['HDUNAME'] = hdu.name
+        if 'HDUCLAS2' in header:
+            data['HDUCLASS'] = header['HDUCLAS2']
+        else:
+            data['HDUCLASS'] = 'EVENTS'
+        rows.append(data)
+
+names = [
+    'OBS_ID', 'TYPE',
+    'NAME', 'SIZE', 'MTIME', 'MD5',
+    'HDUNAME', 'HDUCLASS',
+    ]
+table = Table(rows=rows, names=names)
+table.write("files.fits.gz", overwrite=True)
+
+
+
+# OBS TABLE
+
+rows = []
+for obs in obs_ids:
+
+    data = dict()
+    #data['OBS_ID'] = obs
+    data['OBS_ID'] = obs
+    rows.append(data)
+
+table = Table(rows=rows)
+table.meta['MJDREFI'] = 51544
+table.meta['MJDREFF'] = 0.5
+table.write("observations.fits.gz", overwrite=True)
+

--- a/examples/plot_irfs.py
+++ b/examples/plot_irfs.py
@@ -5,8 +5,7 @@ more to check that all the plotting functions work,
 until we implement proper tests for them.
 """
 import matplotlib.pyplot as plt
-from gammapy.datasets import gammapy_extra
-from gammapy import irf
+from gammapy.data import DataStore
 from gammapy.utils.mpl_style import gammapy_mpl_style
 
 # TODO: Update once this issue is resolved:
@@ -17,41 +16,35 @@ plt.rcParams.update(gammapy_mpl_style)
 fig, axes = plt.subplots(2, 4, figsize=(20, 8))
 axes = axes.flat
 
-# TODO: event list summary plots not implemented yet:
-# https://github.com/gammapy/gammapy/issues/297
-# hess_events_023523.fits.gz
+ds = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
 
-filename = gammapy_extra.filename('test_datasets/irf/hess/pa/hess_aeff_2d_023523.fits.gz')
-aeff2d = irf.EffectiveAreaTable2D.read(filename)
+events = ds.load(obs_id=23523, filetype='events')
+events.peek()
+
+aeff2d = ds.load(obs_id=23523, filetype='aeff')
 aeff2d.plot_energy_dependence(ax=next(axes))
 aeff2d.plot_offset_dependence(ax=next(axes))
 
 aeff = aeff2d.to_effective_area_table(offset='1 deg')
 aeff.plot_area_vs_energy(ax=next(axes))
 
-
-filename = gammapy_extra.filename('test_datasets/irf/hess/pa/hess_edisp_2d_023523.fits.gz')
-edisp2d = irf.EnergyDispersion2D.read(filename)
+edisp2d = ds.load(obs_id=23523, filetype='edisp')
 edisp2d.plot_bias(ax=next(axes))
 edisp2d.plot_migration(ax=next(axes))
 
 edisp = edisp2d.to_energy_dispersion(offset='1 deg')
-edisp.plot(type='matrix', ax=next(axes))
+edisp.plot_matrix(ax=next(axes))
 # TODO: bias plot not implemented yet
-# edisp.plot(type='bias', ax=next(axes))
+# edisp.plot_bias(ax=next(axes))
 
 # TODO: This PSF type isn't implemented yet.
 # filename = gammapy_extra.filename('test_datasets/irf/hess/pa/hess_psf_king_023523.fits.gz')
 # psf = irf.EnergyDependentMultiGaussPSF.read(filename)
 # psf.plot_containment(ax=next(axes))
 
-filename = gammapy_extra.filename('test_datasets/unbundled/irfs/psf.fits')
-psf = irf.EnergyDependentMultiGaussPSF.read(filename)
+psf = ds.load(obs_id=23523, filetype='psf')
 psf.plot_containment(0.68, show_safe_energy=False, ax=next(axes))
 
-
 # TODO: hess_bkg_offruns_023523.fits.gz
-
-
 
 plt.show()

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -36,7 +36,7 @@ def make_test_array(dummy_data=False):
 @requires_dependency('matplotlib')
 @requires_data('gammapy-extra')
 def test_energy_offset_array_fill():
-    dir = str(gammapy_extra.dir) + '/datasets/hess-crab4'
+    dir = str(gammapy_extra.dir) + '/datasets/hess-crab4-hd-hap-prod2'
     data_store = DataStore.from_dir(dir)
     ev_list = data_store.load_all('events')
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -501,15 +501,11 @@ class EventList(Table):
         .. plot::
             :include-source:
 
-            from gammapy.datasets import gammapy_extra
-
             import matplotlib.pyplot as plt
-            import matplotlib.pyplot as plt
-            from gammapy.data import EventList
-            from gammapy.datasets import gammapy_extra
+            from gammapy.data import DataStore
 
-            filename = gammapy_extra.filename('datasets/hess-crab4/hess_events_simulated_023523.fits')
-            event_list = EventList.read(filename, hdu='EVENTS')
+            ds = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
+            event_list = ds.load(obs_id=23523, filetype='events')
 
             event_list.plot_time_map()
 

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -63,7 +63,7 @@ def test_DataStore_load(data_manager):
 @requires_data('hess')
 def test_DataStore_load_all():
     """Test loading data and IRF files via the DataStore"""
-    dir = str(gammapy_extra.dir) + '/datasets/hess-crab4'
+    dir = str(gammapy_extra.dir) + '/datasets/hess-crab4-hd-hap-prod2'
     data_store = DataStore.from_dir(dir)
     event_lists = data_store.load_all(filetype='events')
     assert_allclose(event_lists[0]['ENERGY'][0], 1.1156039)

--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -616,7 +616,10 @@ class EffectiveAreaTable2D(object):
         ax = plt.gca() if ax is None else ax
 
         if energy is None:
-            energy = Quantity(np.logspace(-1, 2, 8), 'TeV')
+            # TODO: choose values in a better way here? Not sure how ...
+            emin = self.energy_lo[1]
+            emax = self.energy_hi[-2]
+            energy = Energy.equal_log_spacing(emin, emax, nbins=5)
 
         if offset is None:
             off_lo = self.offset[0].to('deg').value

--- a/gammapy/irf/exposure.py
+++ b/gammapy/irf/exposure.py
@@ -36,9 +36,7 @@ def exposure_cube(pointing,
     lon, lat, en = ref_cube.pix2world(xx, yy, 0)
     coord = SkyCoord(lon, lat, frame=ref_cube.wcs.wcs.radesys.lower())  # don't care about energy
     offset = coord.separation(pointing)
-    ###this is a hack to make the current code work in spite of issues with offset binning from HAP export
-    ###TODO remove once the issue has been fixed
-    offset = np.clip(offset, Angle(0.2, 'deg'), Angle(2.2, 'deg'))
+    offset = np.clip(offset, Angle(0, 'deg'), Angle(2.2, 'deg'))
 
     exposure = aeff2D.evaluate(offset, ref_cube.energy)
     exposure = np.rollaxis(exposure, 2)

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -90,20 +90,20 @@ class EnergyDependentMultiGaussPSF(object):
             File name
         """
         hdu_list = fits.open(filename)
-        return cls.from_fits(hdu_list)
+        # TODO: improve this ... use HDUCLASS
+        valid_extnames = ['POINT SPREAD FUNCTION', 'PSF_2D', 'PSF_2D_GAUSS']
+        hdu = get_hdu_with_valid_name(hdu_list, valid_extnames)
+        return cls.from_fits(hdu)
 
     @classmethod
-    def from_fits(cls, hdu_list):
+    def from_fits(cls, hdu):
         """Create `EnergyDependentMultiGaussPSF` from HDU list.
 
         Parameters
         ----------
-        hdu_list : `~astropy.io.fits.HDUList`
-            HDU list with correct extensions.
+        hdu : `~astropy.io.fits.BintableHDU`
+            HDU with serialised PSF.
         """
-        valid_extnames = ['POINT SPREAD FUNCTION', 'PSF_2D']
-        hdu = get_hdu_with_valid_name(hdu_list, valid_extnames)
-
         energy_lo = Quantity(hdu.data['ENERG_LO'][0], 'TeV')
         energy_hi = Quantity(hdu.data['ENERG_HI'][0], 'TeV')
         theta = Angle(hdu.data['THETA_LO'][0], 'deg')

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import Angle

--- a/gammapy/irf/tests/test_exposure.py
+++ b/gammapy/irf/tests/test_exposure.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
+from astropy.tests.helper import pytest
 from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_dependency
@@ -11,13 +12,18 @@ from ...irf import EffectiveAreaTable2D
 from ...datasets import gammapy_extra
 
 
+# TODO: Fix this test
+# The aeff interpolation fails currently.
+# Need to write a script to make another example cube and / or
+# change the interpolation to not raise error / put useful fill value
+@pytest.mark.xfail
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_exposure_cube():
     exp_ref = Quantity(4.7e8, 'm^2 s')
 
-    aeff_filename = gammapy_extra.filename("datasets/hess-crab4/hess_aeff_023523.fits.gz")
-    ccube_filename = gammapy_extra.filename("datasets/hess-crab4/hess_events_simulated_023523_cntcube.fits")
+    aeff_filename = gammapy_extra.filename('datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz')
+    ccube_filename = gammapy_extra.filename('datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits')
 
     pointing = SkyCoord(83.633, 21.514, frame='fk5', unit='deg')
     livetime = Quantity(1581.17, 's')

--- a/gammapy/spectrum/tests/test_spectrum_extraction.py
+++ b/gammapy/spectrum/tests/test_spectrum_extraction.py
@@ -37,7 +37,7 @@ def test_spectrum_extraction(tmpdir):
     bounds = EnergyBounds.equal_log_spacing(1, 10, 40, unit='TeV')
 
     obs = [23523, 23559, 11111]
-    store = gammapy_extra.filename("datasets/hess-crab4")
+    store = gammapy_extra.filename("datasets/hess-crab4-hd-hap-prod2")
     ds = DataStore.from_dir(store)
 
     ana = SpectrumExtraction(datastore=ds, obs_ids=obs, on_region=on_region,
@@ -50,7 +50,7 @@ def test_spectrum_extraction(tmpdir):
     obs23523 = obs.get_obs_by_id(23523)
     assert obs23523.on_vector.total_counts == 123
 
-@pytest.mark.xskip
+# @pytest.mark.xfail
 @requires_dependency('yaml')
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')


### PR DESCRIPTION
This PR updates Gammapy to the new agreed [data storage](http://gamma-astro-data-formats.readthedocs.org/en/latest/data_storage/index.html) formats. Older index files will not work any more.

This PR also changes the reference dataset used for many tests:
* old: https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4 
* new: https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4-hd-hap-prod2

Producing correct simulated event lists is work in progress:  #437 
It's intertwined with this PR, but either could go first and then the other finishes the job / clean things up.

So some things will break today, but after this things should be more stable.

Also, the transition isn't finished ... I want to improve the data access further soon.

cc @joleroi @leajouvin