### PR TITLE
Fix missing parameter and call of non-existing method in image_ts.py

### DIFF
--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -98,7 +98,7 @@ When ``--residual`` is set an excess model must be provided using the ``--model`
 
 
 Iterative detection
------------------
+-------------------
 In addition to ``gammapy-image-ts`` there is also command-line tool ``gammapy-detect-iterative``, which runs iterative multi-scale source detection. 
 It takes as arguments count, background and exposure FITS maps(in separate files, unlike previous tool) and a list of ``--scales`` and calls ``~gammapy.detect.iterfind.IterativeSourceDetection`` class.
 
@@ -108,8 +108,7 @@ It implements the following algorithm:
 2. Largest peak on any scale gives a seed position / extension (the scale)
 3. Fit a 2D Gauss-model source using the seed parameters
 4. Add the source to a list of detected sources and the background model
-5. Restart at 1, but this time with detected sources added to the background
-   model, i.e. significance maps will be "residual significance" maps.
+5. Restart at 1, but this time with detected sources added to the background model, i.e. significance maps will be "residual significance" maps.
 
 Usage example:
 

--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -14,8 +14,6 @@ into source catalogs.
 
 * TODO: Describe references: [Stewart2009]_
 * TODO: general intro
-* TODO: describe the ``gammapy-iterative-source-detect`` tool.
-* TODO: describe the ``gammapy-image-decompose-a-trous`` tool.
 
 
 Getting Started
@@ -75,17 +73,17 @@ The TS map itself can bes accessed using the ``ts`` attribute of the `~gammapy.d
 Command line tool
 -----------------
 
-Gammapy also provides a command line tool ``gammapy-ts-image`` for TS map computation, which can be run
+Gammapy also provides a command line tool ``gammapy-image-ts`` for TS map computation, which can be run
 on the Fermi example dataset by:
 
 .. code-block:: bash
 
 	$ cd gammapy-extra/datasets/fermi_survey
-	$ gammapy-ts-image all.fits.gz ts_map_0.00.fits --scale 0 
+	$ gammapy-image-ts all.fits.gz ts_map_0.00.fits --scale 0 
 
 The command line tool additionally requires a psf json file, where the psf shape is defined by the parameters
 of a triple Gaussian model. See also `gammapy.irf.multi_gauss_psf_kernel`. By default the command line tool uses
-a Gaussian source kernel, where the width in degree can be defined by the ``--scale`` parameter. When setting
+a Gaussian source kernel, where the width in degree can be defined by the ``--scale`` parameter. Multiple scales can be selected by passing a list to the ``scales`` parameter.  When setting
 ``--scale 0`` only the psf is used as source model, which is the preferred setting to detect point sources.
 When using scales that are larger than five times the binning of the data, the data is sampled down and later
 sampled up again to speed up the performance. See `~gammapy.image.downsample_2N` and `~gammapy.image.upsample_2N` for details.   
@@ -94,9 +92,32 @@ Furthermore it is possible to compute residual TS maps. Using the following opti
  
 .. code-block:: bash
 
-	$ gammapy-ts-image all.fits.gz residual_ts_map_0.00.fits --scale 0 --residual --model model.fits.gz 
+	$ gammapy-image-ts all.fits.gz residual_ts_map_0.00.fits --scale 0 --residual --model model.fits.gz 
 
 When ``--residual`` is set an excess model must be provided using the ``--model`` option.
+
+
+Iterative detection
+-----------------
+In addition to ``gammapy-image-ts`` there is also command-line tool ``gammapy-detect-iterative``, which runs iterative multi-scale source detection. 
+It takes as arguments count, background and exposure FITS maps(in separate files, unlike previous tool) and a list of ```--scales``` and calls ``~gammapy.detect.iterfind.IterativeSourceDetection`` class.
+
+
+It implements the following algorithm:
+1. Compute significance maps on multiple scales (disk-correlate)
+2. Largest peak on any scale gives a seed position / extension (the scale)
+3. Fit a 2D Gauss-model source using the seed parameters
+4. Add the source to a list of detected sources and the background model
+5. Restart at 1, but this time with detected sources added to the background
+   model, i.e. significance maps will be "residual significance" maps.
+
+Usage example:
+
+.. code-block:: bash
+	$ cd gammapy-extra/datasets/source_diffuse_separation/galactic_simulations
+	$ gammapy-detect-iterative --counts fermi_counts.fits --background fermi_diffuse.fits --exposure fermi_exposure_gal.fits output_fits output_regions
+
+
 
 Reference/API
 =============

--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -100,7 +100,7 @@ When ``--residual`` is set an excess model must be provided using the ``--model`
 Iterative detection
 -----------------
 In addition to ``gammapy-image-ts`` there is also command-line tool ``gammapy-detect-iterative``, which runs iterative multi-scale source detection. 
-It takes as arguments count, background and exposure FITS maps(in separate files, unlike previous tool) and a list of ```--scales``` and calls ``~gammapy.detect.iterfind.IterativeSourceDetection`` class.
+It takes as arguments count, background and exposure FITS maps(in separate files, unlike previous tool) and a list of ``--scales`` and calls ``~gammapy.detect.iterfind.IterativeSourceDetection`` class.
 
 
 It implements the following algorithm:
@@ -114,6 +114,7 @@ It implements the following algorithm:
 Usage example:
 
 .. code-block:: bash
+
 	$ cd gammapy-extra/datasets/source_diffuse_separation/galactic_simulations
 	$ gammapy-detect-iterative --counts fermi_counts.fits --background fermi_diffuse.fits --exposure fermi_exposure_gal.fits output_fits output_regions
 

--- a/gammapy/data/__init__.py
+++ b/gammapy/data/__init__.py
@@ -6,7 +6,6 @@
 class InvalidDataError(Exception):
     """Invalid data found."""
 
-
 from .data_manager import *
 from .data_store import *
 from .event_list import *

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -154,77 +154,73 @@ def compute_ts_map_multiscale(maps, psf_parameters, scales=[0], downsample='auto
     BINSZ = abs(maps[0].header['CDELT1'])
     shape = maps[0].data.shape
     multiscale_result = []
-       
+
     for scale in scales:
-        try:
-            log.info('Computing {0}TS map for scale {1:.3f} deg and {2}'
-                     ' morphology.'.format('residual ' if residual else '',
-                                           scale, morphology))
+        log.info('Computing {0}TS map for scale {1:.3f} deg and {2}'
+                 ' morphology.'.format('residual ' if residual else '',
+                                       scale,
+                                       morphology))  # Sample down and require that scale parameters is at least 5 pix
+        if downsample == 'auto':
+            factor = int(np.select([scale < 5 * BINSZ, scale < 10 * BINSZ,
+                                    scale < 20 * BINSZ, scale < 40 * BINSZ],
+                                   [1, 2, 4, 4], 8))
+        else:
+            factor = int(downsample)
+        if factor == 1:
+            log.info('No down sampling used.')
+            downsampled = False
+        else:
+            if morphology == 'Shell2D':
+                factor /= 2
+            log.info('Using down sampling factor of {0}'.format(factor))
+            downsampled = True
 
-            # Sample down and require that scale parameters is at least 5 pix
-            if downsample == 'auto':
-                factor = int(np.select([scale < 5 * BINSZ, scale < 10 * BINSZ,
-                                        scale < 20 * BINSZ, scale < 40 * BINSZ],
-                                       [1, 2, 4, 4], 8))
-            else:
-                factor = int(downsample)
-            if factor == 1:
-                log.info('No down sampling used.')
-                downsampled = False
-            else:
-                if morphology == 'Shell2D':
-                    factor /= 2
-                log.info('Using down sampling factor of {0}'.format(factor))
-                downsampled = True
-
-            funcs = [np.nansum, np.mean, np.nansum, np.nansum, np.nansum]
-            maps_ = {}
-            for map_, func in zip(maps, funcs):
-                if downsampled:
-                    maps_[map_.name.lower()] = downsample_2N(map_.data, factor, func,
-                                                             shape=shape_2N(shape))
-                else:
-                    maps_[map_.name.lower()] = map_.data
-
-            # Set up PSF and source kernel
-            kernel = multi_gauss_psf_kernel(psf_parameters, BINSZ=BINSZ,
-                                            NEW_BINSZ=BINSZ * factor,
-                                            mode='oversample')
-
-            if scale > 0:
-                from astropy.convolution import convolve
-                sigma = scale / (BINSZ * factor)
-                if morphology == 'Gaussian2D':
-                    source_kernel = Gaussian2DKernel(sigma, mode='oversample')
-                elif morphology == 'Shell2D':
-                    model = Shell2D(1, 0, 0, sigma, sigma * width)
-                    x_size = _round_up_to_odd_integer(2 * sigma * (1 + width)
-                                                      + kernel.shape[0] / 2)
-                    source_kernel = Model2DKernel(model, x_size=x_size, mode='oversample')
-                else:
-                    raise ValueError('Unknown morphology: {}'.format(morphology))
-                kernel = convolve(source_kernel, kernel)
-                kernel.normalize()
-
-            # Compute TS map
-            if residual:
-                background = (maps_['background'] + maps_['diffuse'] + maps_['onmodel'])
-            else:
-                background = maps_['background']  # + maps_['diffuse']
-            ts_results = compute_ts_map(maps_['on'], background, maps_['expgammamap'],
-                                        kernel, *args, **kwargs)
-            log.info('TS map computation took {0:.1f} s \n'.format(ts_results.runtime))
-            ts_results['scale'] = scale
-            ts_results['morphology'] = morphology
+        funcs = [np.nansum, np.mean, np.nansum, np.nansum, np.nansum]
+        maps_ = {}
+        for map_, func in zip(maps, funcs):
             if downsampled:
-                for name, order in zip(['ts', 'sqrt_ts', 'amplitude', 'niter'], [1, 1, 1, 0]):
-                    ts_results[name] = upsample_2N(ts_results[name], factor,
-                                                   order=order, shape=shape)
-            multiscale_result.append(ts_results)
-        except:
-            log.info("Exception during computation of scale {}, ".format(scale) +
-                     "perhaps the kernel size is bigger than the image" +
-                     "and positions are empty because of that" ,exc_info=1)
+                maps_[map_.name.lower()] = downsample_2N(map_.data, factor, func,
+                                                         shape=shape_2N(shape))
+            else:
+                maps_[map_.name.lower()] = map_.data
+
+        # Set up PSF and source kernel
+        kernel = multi_gauss_psf_kernel(psf_parameters, BINSZ=BINSZ,
+                                        NEW_BINSZ=BINSZ * factor,
+                                        mode='oversample')
+
+        if scale > 0:
+            from astropy.convolution import convolve
+            sigma = scale / (BINSZ * factor)
+            if morphology == 'Gaussian2D':
+                source_kernel = Gaussian2DKernel(sigma, mode='oversample')
+            elif morphology == 'Shell2D':
+                model = Shell2D(1, 0, 0, sigma, sigma * width)
+                x_size = _round_up_to_odd_integer(2 * sigma * (1 + width)
+                                                  + kernel.shape[0] / 2)
+                source_kernel = Model2DKernel(model, x_size=x_size, mode='oversample')
+            else:
+                raise ValueError('Unknown morphology: {}'.format(morphology))
+            kernel = convolve(source_kernel, kernel)
+            kernel.normalize()
+
+        # Compute TS map
+        if residual:
+            background = (maps_['background'] + maps_['diffuse'] + maps_['onmodel'])
+        else:
+            background = maps_['background']  # + maps_['diffuse']
+        ts_results = compute_ts_map(maps_['on'], background, maps_['expgammamap'],
+                                    kernel, *args, **kwargs)
+        log.info('TS map computation took {0:.1f} s \n'.format(ts_results.runtime))
+        ts_results['scale'] = scale
+        ts_results['morphology'] = morphology
+        if downsampled:
+            for name, order in zip(['ts', 'sqrt_ts', 'amplitude', 'niter'], [1, 1, 1, 0]):
+                ts_results[name] = upsample_2N(ts_results[name], factor,
+                                               order=order, shape=shape)
+        multiscale_result.append(ts_results)
+
+
     return multiscale_result
 
 
@@ -377,6 +373,8 @@ def compute_ts_map(counts, background, exposure, kernel, mask=None, flux=None,
     else:
         results = map(wrap, positions)
 
+    assert positions, ("Positions are empty: possibly kernel " +
+                       "{} is larger than counts {}".format(kernel.shape, counts.shape))
     # Set TS values at given positions
     j, i = zip(*positions)
     TS = np.empty(counts.shape) * np.nan

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -10,6 +10,7 @@ from astropy.wcs import WCS
 # TODO:
 # Remove this when/if https://github.com/astropy/astropy/issues/4429 is fixed
 from astropy.utils.exceptions import AstropyDeprecationWarning
+ 
 
 __all__ = [
     'atrous_hdu',
@@ -208,7 +209,9 @@ def downsample_2N(image, factor, method=np.nansum, shape=None):
     if shape is not None:
         x_pad = (shape[1] - image.shape[1]) // 2
         y_pad = (shape[0] - image.shape[0]) // 2
-        image = np.pad(image, ((y_pad, y_pad), (x_pad, x_pad)), mode='reflect')
+        #converting from unicode to ascii string as a workaround 
+        #for https://github.com/numpy/numpy/issues/7112
+        image = np.pad(image, ((y_pad, y_pad), (x_pad, x_pad)), mode=str('reflect'))
     return block_reduce(image, (factor, factor), method)
 
 

--- a/gammapy/scripts/image_ts.py
+++ b/gammapy/scripts/image_ts.py
@@ -79,7 +79,7 @@ def image_ts(input_file, output_file, psf, model, scales, downsample, residual,
         maps.append(fits.ImageHDU(data, header, 'OnModel'))
 
     results = compute_ts_map_multiscale(maps, psf_parameters, scales, downsample,
-                                        residual, morphology, width)
+                                        residual, morphology, width, threshold)
 
     filename = Path(output_file).name
     folder = Path(output_file).parent

--- a/gammapy/scripts/image_ts.py
+++ b/gammapy/scripts/image_ts.py
@@ -37,9 +37,6 @@ def image_ts_main(args=None):
                              "using the '--model' parameter.")
     parser.add_argument('--model', type=str,
                         help='Input excess model FITS file name')
-    parser.add_argument('--threshold', type=float, default=None,
-                        help="Minimal required initial (before fitting) TS value,"
-                             " that the fit is done at all.")
     parser.add_argument('--overwrite', action='store_true',
                         help='Overwrite output files.')
     parser.add_argument("-l", "--loglevel", default='info',
@@ -81,17 +78,14 @@ def image_ts(input_file, output_file, psf, model, scales, downsample, residual,
     results = compute_ts_map_multiscale(maps, psf_parameters, scales, downsample,
                                         residual, morphology, width)
 
-    # TODO: changed to `Path` ... untested!
-    folder, filename = Path(output_file).split()
-    Path(folder).mkdir(exist_ok=False)
-
+    
     # Write results to file
     header = maps[0].header
     if len(results) > 1:
         for scale, result in zip(scales, results):
             # TODO: this is unnecessarily complex
             # Simplify, e.g. by letting the user specify a `base_dir`.
-            filename_ = filename.replace('.fits', '_{0:.3f}.fits'.format(scale))
+            filename_ = output_file.replace('.fits', '_{0:.3f}.fits'.format(scale))
             fn = Path(folder) / filename_
             log.info('Writing {}'.format(fn))
             result.write(str(fn), header, overwrite=overwrite)


### PR DESCRIPTION
Working on my first task: fixing documentation of https://gammapy.readthedocs.org/en/latest/detect/index.html

The python code works well, but the command line tool
$ cd gammapy-extra/datasets/fermi_survey
$ gammapy-ts-image all.fits.gz ts_map_0.00.fits --scale 0
Needs more changes than just renaming.

I can attach other fixes for this documentation page to this pull request later or make a new one.
