### PR TITLE
Radially symmetric field of view background model

### DIFF
--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -117,3 +117,6 @@ Reference/API
 
 .. automodapi:: gammapy.utils.wcs
     :no-inheritance-diagram:
+
+.. automodapi:: gammapy.utils.axis
+    :no-inheritance-diagram:

--- a/examples/test_curve.py
+++ b/examples/test_curve.py
@@ -3,6 +3,7 @@
 import numpy as np
 from astropy.coordinates import Angle
 from astropy.table import Table
+from astropy.units import Quantity
 from gammapy.datasets import gammapy_extra
 from gammapy.background import EnergyOffsetBackgroundModel
 from gammapy.utils.energy import EnergyBounds, Energy
@@ -14,9 +15,13 @@ def make_model():
     dir = str(gammapy_extra.dir) + '/datasets/hess-crab4-hd-hap-prod2'
     data_store = DataStore.from_dir(dir)
     obs_table = data_store.obs_table
-
     ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
-    offset = Angle(np.linspace(0, 2.5, 100), "deg")
+    theta2_min=Quantity(0, "deg2")
+    theta2_max=Quantity(2.5**2, "deg2")
+    theta2_bin=100
+    theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
+    offset=Angle(np.sqrt(theta2))
+    #offset = Angle(np.linspace(0, 2.5, 100), "deg")
     multi_array = EnergyOffsetBackgroundModel(ebounds, offset)
     multi_array.fill_obs(obs_table, data_store)
     multi_array.compute_rate()
@@ -42,10 +47,10 @@ def plot_model():
     multi_array.livetime.plot_image()
     pt.figure(3)
     multi_array.bg_rate.plot_image()
-
+    pt.figure(4)
     pt.plot(table["offset"], table["Acceptance"])
     pt.xlabel("offset (deg)")
-    pt.ylabel("Acceptance (s-1)")
+    pt.ylabel("Acceptance (s-1 sr-1)")
 
     input()
 

--- a/examples/test_curve.py
+++ b/examples/test_curve.py
@@ -1,41 +1,84 @@
 """Example how to make an acceptance curve and background model image.
 """
-import numpy as np
-from astropy.coordinates import Angle
 from astropy.table import Table
+import astropy.units as u
+from astropy.io import fits
+from astropy.coordinates import SkyCoord, Angle
 from astropy.units import Quantity
 from gammapy.datasets import gammapy_extra
 from gammapy.background import EnergyOffsetBackgroundModel
 from gammapy.utils.energy import EnergyBounds, Energy
 from gammapy.data import DataStore
+from gammapy.utils.axis import sqrt_space
+from gammapy.image import bin_events_in_image, make_empty_image, disk_correlate
+from gammapy.background import fill_acceptance_image
+from gammapy.stats import significance
+# from gammapy.detect import compute_ts_map
 import pylab as pt
+
 pt.ion()
+
 
 def make_model():
     dir = str(gammapy_extra.dir) + '/datasets/hess-crab4-hd-hap-prod2'
     data_store = DataStore.from_dir(dir)
     obs_table = data_store.obs_table
     ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
-    theta_min=0
-    theta_max=2.5
-    theta2_bin=100
-    theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
-    offset=Angle(np.sqrt(theta2))
-    #offset = Angle(np.linspace(0, 2.5, 100), "deg")
+    offset = sqrt_space(start=0, stop=2.5, num=100) * u.deg
     multi_array = EnergyOffsetBackgroundModel(ebounds, offset)
     multi_array.fill_obs(obs_table, data_store)
     multi_array.compute_rate()
 
-    bgarray=multi_array.bg_rate
-    energ_range = Energy([1, 10], 'TeV')
-    bins = 10
-    table = bgarray.acceptance_curve_in_energy_band(energ_range, bins)
+    bgarray = multi_array.bg_rate
+    energy_range = Energy([1, 10], 'TeV')
+    table = bgarray.acceptance_curve_in_energy_band(energy_range, energy_bins=10)
 
     multi_array.write('energy_offset_array.fits', overwrite=True)
     table.write('acceptance_curve.fits', overwrite=True)
 
+
 def make_image():
-    pass
+    table = Table.read('acceptance_curve.fits')
+    table.pprint()
+    center = SkyCoord(83.63, 22.01, unit='deg').galactic
+
+    counts_image = make_empty_image(nxpix=1000, nypix=1000, binsz=0.01, xref=center.l.deg, yref=center.b.deg,
+                                    proj='TAN')
+    bkg_image = counts_image.copy()
+
+    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
+
+    for events in data_store.load_all("events"):
+        center = events.pointing_radec.galactic
+        livetime = events.observation_live_time_duration
+        solid_angle = Angle(0.01,"deg")**2
+
+        counts_image.data += bin_events_in_image(events, counts_image).data
+
+        interp_param = dict(bounds_error=False, fill_value= None)
+
+        acc_hdu = fill_acceptance_image(bkg_image.header, center, table["offset"], table["Acceptance"], interp_param)
+        acc = Quantity(acc_hdu.data, table["Acceptance"].unit) * solid_angle * livetime
+        bkg_image.data += acc.decompose()
+        print(acc.decompose().sum())
+
+    counts_image.writeto("counts_image.fits", clobber=True)
+    bkg_image.writeto("bkg_image.fits", clobber=True)
+
+    # result = compute_ts_map(counts_stacked_image.data, bkg_stacked_image.data,
+    #  maps['ExpGammaMap'].data, kernel)
+
+def make_significance_image():
+    counts_image=fits.open("counts_image.fits")[1]
+    bkg_image=fits.open("bkg_image.fits")[1]
+    counts = disk_correlate(counts_image.data, 10)
+    bkg = disk_correlate(bkg_image.data, 10)
+    s = significance(counts, bkg)
+    s_image =fits.ImageHDU(data=s, header= counts_image.header)
+    s_image.writeto("significance_image.fits", clobber=True)
+
+
+
 
 
 def plot_model():

--- a/examples/test_curve.py
+++ b/examples/test_curve.py
@@ -99,5 +99,7 @@ def plot_model():
 
 
 if __name__ == '__main__':
-    # make_model()
-    plot_model()
+    make_model()
+    #plot_model()
+    make_image()
+    make_significance_image()

--- a/examples/test_curve.py
+++ b/examples/test_curve.py
@@ -16,8 +16,8 @@ def make_model():
     data_store = DataStore.from_dir(dir)
     obs_table = data_store.obs_table
     ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
-    theta2_min=Quantity(0, "deg2")
-    theta2_max=Quantity(2.5**2, "deg2")
+    theta_min=0
+    theta_max=2.5
     theta2_bin=100
     theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
     offset=Angle(np.sqrt(theta2))

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -35,26 +35,6 @@ class EnergyOffsetArray(object):
         else:
             self.data = Quantity(data, data_units)
 
-    @classmethod
-    def theta2_linspace(cls, energy, theta2_min, theta2_max, theta2_bin, data=None):
-        """
-        Define an `EnergyOffsetArray` with a square root offset binning
-        From a linsopace distribution in theta square you define a square root distribution in theta
-
-        Parameters
-        ----------
-        energy : `~gammapy.utils.energy.EnergyBounds`
-            energy bin vector
-        theta2_min: `~astropy.units.Quantity`, deg2
-        theta2_max: `~astropy.units.Quantity`, deg2
-        theta2_bin: int
-        data : `~numpy.ndarray`, optional
-        data array (2D)
-
-        """
-        theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
-        theta=Angle(np.sqrt(theta2))
-        return cls(energy, theta, data)
 
 
     def fill_events(self, event_lists):
@@ -92,6 +72,8 @@ class EnergyOffsetArray(object):
     def plot_image(self, ax=None, offset=None, energy=None, **kwargs):
         """
         Plot Energy_offset Array image (x=offset, y=energy).
+        TODO: Currently theta axis is not shown correctly if theta scale is not linear (like square root). Can be fixed by creating a matplotlib square root scale r using contourf or placing tick manually
+        
         """
         import matplotlib.pyplot as plt
 

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -182,13 +182,15 @@ class EnergyOffsetArray(object):
             offset value
         interp_kwargs: dict
             give the options for the RegularGridInterpolator
+        interp_kwargs : dict
+        option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
 
         Returns
         -------
         Interpolated value
         """
         if not interp_kwargs:
-            interp_kwargs = dict(bounds_error=False)
+            interp_kwargs = dict(bounds_error=False, fill_value=None)
 
         from scipy.interpolate import RegularGridInterpolator
         if energy is None:
@@ -208,7 +210,7 @@ class EnergyOffsetArray(object):
         pix_coords = np.column_stack([ee.flat, off.flat])
 
         data_interp = interpolator(pix_coords)
-        return data_interp.reshape(shape)
+        return Quantity(data_interp.reshape(shape), self.data.unit)
 
     @property
     def offset_bin_center(self):
@@ -240,6 +242,8 @@ class EnergyOffsetArray(object):
         Parameters
         ----------
         energy : `~astropy.units.Quantity`
+        interp_kwargs : dict
+            option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
 
         Returns
         -------
@@ -259,6 +263,8 @@ class EnergyOffsetArray(object):
         Parameters
         ----------
         offset : `~astropy.coordinates.Angle`
+        interp_kwargs : dict
+            option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
 
         Returns
         -------
@@ -283,11 +289,13 @@ class EnergyOffsetArray(object):
             Tuple ``(energy_min, energy_max)``
         energy_bins : int or `~astropy.units.Quantity`
             Energy bin definition.
+        interp_kwargs : dict
+            option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
 
         Returns
         -------
         table : `~astropy.table.Table`
-            two column: energy and acceptance
+            two column: offset and integral values (units = self.data.unit * self.energy.units)
 
         """
         [emin, emax] = energy_band
@@ -295,10 +303,10 @@ class EnergyOffsetArray(object):
         energy_bins = energy_edges.log_centers
         acceptance = self.evaluate(energy_bins, None, interp_kwargs)
         # Sum over the energy (axis=1 since we used .T to broadcast acceptance and energy_edges.bands
-        acceptance_tot = np.sum(acceptance.T * energy_edges.bands.to('MeV'), axis=1)
+        acceptance_tot = np.sum(acceptance.T * energy_edges.bands, axis=1)
         table = Table()
         table["offset"] = self.offset_bin_center
-        table["Acceptance"] = acceptance_tot
+        table["Acceptance"] = acceptance_tot.decompose()
         return table
 
     def to_cube(self, coordx_edges=None, coordy_edges=None, energy_edges=None, interp_kwargs=None):
@@ -312,6 +320,8 @@ class EnergyOffsetArray(object):
             Spatial bin edges vector (low and high). Y coordinate.
         energy_edges : `~gammapy.utils.energy.EnergyBounds`, optional
             Energy bin edges vector (low and high).
+        interp_kwargs : dict
+            option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
 
         Returns
         -------

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -132,7 +132,7 @@ class EnergyOffsetArray(object):
         return cls(energy_edges, offset_edges, data)
 
     def write(self, filename, data_name="data", **kwargs):
-        """ Write EnergyOffsetArray to FITS file.
+        """ Write `EnergyOffsetArray` to FITS file.
 
         Parameters
         ----------
@@ -286,8 +286,8 @@ class EnergyOffsetArray(object):
             two column: energy and acceptance
 
         """
-        [Emin, Emax] = energy_band
-        energy_edges = EnergyBounds.equal_log_spacing(Emin, Emax, energy_bins)
+        [emin, emax] = energy_band
+        energy_edges = EnergyBounds.equal_log_spacing(emin, emax, energy_bins)
         energy_bins = energy_edges.log_centers
         acceptance = self.evaluate(energy_bins, None, interp_kwargs)
         # Sum over the energy (axis=1 since we used .T to broadcast acceptance and energy_edges.bands

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -23,7 +23,7 @@ class EnergyOffsetArray(object):
          energy bin vector
     offset : `~astropy.coordinates.Angle`
         offset bin vector
-    data : `~numpy.ndarray`
+    data : `~numpy.ndarray`, optional
         data array (2D)
     """
 
@@ -34,6 +34,28 @@ class EnergyOffsetArray(object):
             self.data = Quantity(np.zeros((len(energy) - 1, len(offset) - 1)), data_units)
         else:
             self.data = Quantity(data, data_units)
+
+    @classmethod
+    def theta2_linspace(cls, energy, theta2_min, theta2_max, theta2_bin, data=None):
+        """
+        Define an `EnergyOffsetArray` with a square root offset binning
+        From a linsopace distribution in theta square you define a square root distribution in theta
+
+        Parameters
+        ----------
+        energy : `~gammapy.utils.energy.EnergyBounds`
+            energy bin vector
+        theta2_min: `~astropy.units.Quantity`, deg2
+        theta2_max: `~astropy.units.Quantity`, deg2
+        theta2_bin: int
+        data : `~numpy.ndarray`, optional
+        data array (2D)
+
+        """
+        theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
+        theta=Angle(np.sqrt(theta2))
+        return cls(energy, theta, data)
+
 
     def fill_events(self, event_lists):
         """Fill events histogram.

--- a/gammapy/background/fov.py
+++ b/gammapy/background/fov.py
@@ -3,8 +3,10 @@
 Field-of-view (FOV) background estimation
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from astropy.wcs import WCS
 from astropy.wcs.utils import pixel_to_skycoord
+from astropy.io import fits
 from ..image.utils import coordinates
 
 __all__ = [
@@ -12,7 +14,7 @@ __all__ = [
 ]
 
 
-def fill_acceptance_image(image, center, offset, acceptance):
+def fill_acceptance_image(header, center, offset, acceptance, offset_max=None, interp_kwargs=None):
     """Generate a 2D image of a radial acceptance curve.
 
     The radial acceptance curve is given as an array of values
@@ -20,24 +22,32 @@ def fill_acceptance_image(image, center, offset, acceptance):
 
     Parameters
     ----------
-    image : `~astropy.io.fits.ImageHDU`
-        Empty image to fill.
+    header : `~astropy.io.fits.Header`
+        Fits header of the reference image
     center : `~astropy.coordinates.SkyCoord`
         Coordinate of the center of the image.
     offset : `~astropy.coordinates.Angle`
         1D array of offset values where acceptance is defined.
     acceptance : `~numpy.ndarray`
         Array of acceptance values.
+    interp_kwargs : dict
+        option for interpolation for `~scipy.interpolate.interp1d`
 
     Returns
     -------
     image : `~astropy.io.fits.ImageHDU`
-        Image filled with radial acceptance.
+        New image filled with radial acceptance.
     """
     from scipy.interpolate import interp1d
+    if not offset_max:
+        offset_max= offset[-1]
+    if not interp_kwargs:
+            interp_kwargs = dict(bounds_error= None, fill_value=acceptance[0])
 
     # initialize WCS to the header of the image
-    wcs = WCS(image.header)
+    wcs = WCS(header)
+    data=np.zeros((header["NAXIS2"], header["NAXIS1"]))
+    image = fits.ImageHDU(data=data, header=header)
 
     # define grids of pixel coorinates
     xpix_coord_grid, ypix_coord_grid = coordinates(image, world=False)
@@ -46,11 +56,11 @@ def fill_acceptance_image(image, center, offset, acceptance):
     coord = pixel_to_skycoord(xpix_coord_grid, ypix_coord_grid, wcs, origin=0)
     pix_off = coord.separation(center)
 
-    # interpolate
-    model = interp1d(offset, acceptance, kind='cubic')
-    pix_acc = model(pix_off)
 
-    # fill value in image
-    image.data = pix_acc
+
+    # interpolate
+    model = interp1d(offset, acceptance, kind='cubic', **interp_kwargs)
+    image.data += model(pix_off)
+    image.data[pix_off.value >= offset_max]=0
 
     return image

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -49,6 +49,7 @@ def make_empty_cube():
     empty_cube = Cube(coordx_edges, coordy_edges, energy_edges)
     return empty_cube
 
+
 @requires_data('gammapy-extra')
 def test_energy_offset_array_fill():
     dir = str(gammapy_extra.dir) + '/datasets/hess-crab4-hd-hap-prod2'
@@ -105,6 +106,7 @@ def test_energy_offset_array_bin_volume():
     bin_volume = array.bin_volume
     assert_quantity_allclose(expected_volume, bin_volume[3, 4])
 
+
 @requires_dependency('scipy')
 def test_evaluate_at_energy():
     array, offset, energy = make_test_array(True)
@@ -116,6 +118,7 @@ def test_evaluate_at_energy():
     assert_equal(table_energy["value"][23], 1)
 
 
+@requires_dependency('scipy')
 def test_evaluate_at_offset():
     array, offset, energy = make_test_array(True)
     off_eval = offset[0]
@@ -126,6 +129,7 @@ def test_evaluate_at_offset():
     assert_equal(table_offset["value"][2], 1)
 
 
+@requires_dependency('scipy')
 def test_acceptance_curve_in_energy_band():
     """
     I define an energy range on witch I want to compute the acceptance curve that has the same boundaries as the
@@ -151,6 +155,7 @@ def test_acceptance_curve_in_energy_band():
                              1 * array.energy.bands[91].to('MeV'))
 
 
+@requires_dependency('scipy')
 def test_to_cube():
     """
     There are three events in the energyoffsetarray at three offset and energies. I define a Cube with the same energy

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -97,7 +97,7 @@ def test_energy_offset_array_read_write(tmpdir):
     assert_equal(array.offset, array2.offset)
 
 
-def test_energy_offset_array_bin_volume(tmpdir):
+def test_energy_offset_array_bin_volume():
     array = make_test_array()
     energy_bin = array.energy.bands
     offset_bin = np.pi * (array.offset[1:] ** 2 - array.offset[:-1] ** 2)

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -49,17 +49,6 @@ def make_empty_cube():
     empty_cube = Cube(coordx_edges, coordy_edges, energy_edges)
     return empty_cube
 
-def test_energy_offset_array_theta2_linspace():
-    ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
-    theta2_min=Quantity(0, "deg2")
-    theta2_max=Quantity(2.5**2, "deg2")
-    theta2_bin=100
-    array = EnergyOffsetArray.theta2_linspace(ebounds, theta2_min, theta2_max, theta2_bin)
-    theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
-    theta=Angle(np.sqrt(theta2))
-    assert_quantity_allclose(array.energy, ebounds)
-    assert_quantity_allclose(array.offset, theta)
-
 @requires_data('gammapy-extra')
 def test_energy_offset_array_fill():
     dir = str(gammapy_extra.dir) + '/datasets/hess-crab4-hd-hap-prod2'

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_equal
 import astropy.units as u
+from astropy.units import Quantity
 from astropy.tests.helper import assert_quantity_allclose
 import numpy as np
 from astropy.table import Table
@@ -48,6 +49,16 @@ def make_empty_cube():
     empty_cube = Cube(coordx_edges, coordy_edges, energy_edges)
     return empty_cube
 
+def test_energy_offset_array_theta2_linspace():
+    ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
+    theta2_min=Quantity(0, "deg2")
+    theta2_max=Quantity(2.5**2, "deg2")
+    theta2_bin=100
+    array = EnergyOffsetArray.theta2_linspace(ebounds, theta2_min, theta2_max, theta2_bin)
+    theta2=Quantity(np.linspace(theta2_min.value, theta2_max.value, theta2_bin), theta2_min.unit)
+    theta=Angle(np.sqrt(theta2))
+    assert_quantity_allclose(array.energy, ebounds)
+    assert_quantity_allclose(array.offset, theta)
 
 @requires_data('gammapy-extra')
 def test_energy_offset_array_fill():

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -105,7 +105,7 @@ def test_energy_offset_array_bin_volume():
     bin_volume = array.bin_volume
     assert_quantity_allclose(expected_volume, bin_volume[3, 4])
 
-
+@requires_dependency('scipy')
 def test_evaluate_at_energy():
     array, offset, energy = make_test_array(True)
     e_eval = energy[0]

--- a/gammapy/background/tests/test_fov.py
+++ b/gammapy/background/tests/test_fov.py
@@ -49,7 +49,7 @@ def test_fill_acceptance_image():
     acceptance = gaus_model(offset.radian)
 
     # fill acceptance in the image
-    image = fill_acceptance_image(image, center, offset, acceptance)
+    image = fill_acceptance_image(image.header, center, offset, acceptance)
 
     # test: check points at the offsets where the acceptance is defined
     # along the x axis

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -666,7 +666,7 @@ def bin_events_in_image(events, reference_image):
 
     Parameters
     ----------
-    events : `~astropy.table.Table`
+    events : `~gammapy.events.data.EventList`
         Event list table
     reference_image : `~astropy.io.fits.ImageHDU`
         An image defining the spatial bins.
@@ -677,13 +677,11 @@ def bin_events_in_image(events, reference_image):
         Count image
     """
     if 'GLON' in reference_image.header['CTYPE1']:
-        lon = events['GLON']
-        lat = events['GLAT']
+        pos = events.galactic
     else:
-        lon = events['RA']
-        lat = events['DEC']
+        pos = events.radec
 
-    return wcs_histogram2d(reference_image.header, lon, lat)
+    return wcs_histogram2d(reference_image.header, pos.data.lon.deg, pos.data.lat.deg)
 
 
 def bin_events_in_cube(events, reference_cube, energies):

--- a/gammapy/utils/axis.py
+++ b/gammapy/utils/axis.py
@@ -3,10 +3,6 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from astropy.units import Quantity
-from astropy.coordinates import Angle
-
-
 
 
 def sqrt_space(start, stop, num):
@@ -25,6 +21,6 @@ def sqrt_space(start, stop, num):
     tab = `~numpy.ndarray`
         1D array with a square root scale
     """
-    tab2=np.linspace(start, stop, num)
+    tab2=np.linspace(start**2, stop**2, num)
     tab=np.sqrt(tab2)
     return tab

--- a/gammapy/utils/axis.py
+++ b/gammapy/utils/axis.py
@@ -1,0 +1,30 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Axis method
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.units import Quantity
+from astropy.coordinates import Angle
+
+
+
+
+def sqrt_space(start, stop, num):
+    """
+    Define a square root binning
+    From a linspace distribution in the square of the value, you define a square root distribution in theta
+
+    Parameters
+    ----------
+    start : float
+    stop : float
+    num : int
+
+    Returns
+    -------
+    tab = `~numpy.ndarray`
+        1D array with a square root scale
+    """
+    tab2=np.linspace(start, stop, num)
+    tab=np.sqrt(tab2)
+    return tab

--- a/gammapy/utils/axis.py
+++ b/gammapy/utils/axis.py
@@ -6,21 +6,31 @@ import numpy as np
 
 
 def sqrt_space(start, stop, num):
-    """
-    Define a square root binning
-    From a linspace distribution in the square of the value, you define a square root distribution in theta
+    """Return numbers spaced evenly on a square root scale.
+
+    This function is similar to `numpy.linspace` and `numpy.logspace`.
 
     Parameters
     ----------
     start : float
+        start is the starting value of the sequence
     stop : float
+        stop is the final value of the sequence
     num : int
+        Number of samples to generate.
 
     Returns
     -------
-    tab = `~numpy.ndarray`
+    samples : `~numpy.ndarray`
         1D array with a square root scale
+
+    Examples
+    --------
+    >>> from gammapy.utils.axis import sqrt_space
+    >>> samples = sqrt_space(0, 2, 5)
+    array([ 0.        ,  1.        ,  1.41421356,  1.73205081,  2.        ])
+
     """
-    tab2=np.linspace(start**2, stop**2, num)
-    tab=np.sqrt(tab2)
-    return tab
+    samples2 = np.linspace(start ** 2, stop ** 2, num)
+    samples = np.sqrt(samples2)
+    return samples

--- a/gammapy/utils/tests/test_axis.py
+++ b/gammapy/utils/tests/test_axis.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from numpy.testing import assert_allclose
+
 import astropy.units as u
 from ..axis import sqrt_space
-
 
 
 def test_sqrt_space():
@@ -11,3 +12,6 @@ def test_sqrt_space():
     theta_max=2.5
     theta_bin=100
     offset = sqrt_space(theta_min, theta_max, theta_bin) * u.deg
+    assert_allclose(len(offset), theta_bin)
+    assert_allclose(offset[0].value, theta_min)
+    assert_allclose(offset[-1].value, theta_max)

--- a/gammapy/utils/tests/test_axis.py
+++ b/gammapy/utils/tests/test_axis.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+import astropy.units as u
+from ..axis import sqrt_space
+
+
+
+def test_sqrt_space():
+    theta_min=0
+    theta_max=2.5
+    theta_bin=100
+    offset = sqrt_space(theta_min, theta_max, theta_bin) * u.deg

--- a/gammapy/utils/tests/test_axis.py
+++ b/gammapy/utils/tests/test_axis.py
@@ -1,17 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numpy as np
 from numpy.testing import assert_allclose
-
-import astropy.units as u
 from ..axis import sqrt_space
 
 
 def test_sqrt_space():
-    theta_min=0
-    theta_max=2.5
-    theta_bin=100
-    offset = sqrt_space(theta_min, theta_max, theta_bin) * u.deg
-    assert_allclose(len(offset), theta_bin)
-    assert_allclose(offset[0].value, theta_min)
-    assert_allclose(offset[-1].value, theta_max)
+    values = sqrt_space(0, 2, 5)
+
+    assert_allclose(values, [0., 1., 1.41421356, 1.73205081, 2.])


### PR DESCRIPTION
This pull request implements some steps towards radially symmetric FOV background modeling:

- [x] Implement full example in `test_curve.py` that builds radially symmetric background models and evaluates them on a sky map.
- [x] Add `sqrt_space` utility function to new `gammapy.utils.axis`
- [x]  Misc improvements and small fixes