### PR TITLE
Move SpectralCube import to exposure_cube function

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -144,7 +144,7 @@ class DataStore(object):
         ----------
         obs_id : int
             Observation ID.
-        filetype : {'events', 'aeff', 'edisp', 'psf', 'background'}
+        filetype : {'events', 'aeff', 'edisp', 'psf', 'bkg'}
             Type of file.
         abspath : bool
             Absolute path (including data store base_dir)?
@@ -187,7 +187,7 @@ class DataStore(object):
         ----------
         obs_id : int
             Observation ID.
-        filetype : {'events', 'aeff', 'edisp', 'psf', 'background'}
+        filetype : {'events', 'aeff', 'edisp', 'psf', 'bkg'}
             Type of file.
 
         Returns
@@ -210,7 +210,7 @@ class DataStore(object):
             return irf.EnergyDispersion2D.read(filename)
         elif filetype == 'psf':
             return irf.EnergyDependentMultiGaussPSF.read(filename)
-        elif filetype == 'background':
+        elif filetype == 'bkg':
             return Cube.read(filename)
         else:
             raise ValueError('Invalid filetype.')
@@ -220,7 +220,7 @@ class DataStore(object):
 
         Parameters
         ----------
-        filetype : {'events', 'aeff', 'edisp', 'psf', 'background'}
+        filetype : {'events', 'aeff', 'edisp', 'psf', 'bkg'}
             Type of file.
 
         Returns
@@ -317,7 +317,7 @@ def _find_file(filename, dir):
 
 
 def _validate_filetype(filetype):
-    VALID_FILETYPES = ['events', 'aeff', 'edisp', 'psf', 'background']
+    VALID_FILETYPES = ['events', 'aeff', 'edisp', 'psf', 'bkg']
     if not filetype in VALID_FILETYPES:
         msg = "Invalid filetype: '{}'. ".format(filetype)
         msg += 'Valid filetypes are: {}'.format(VALID_FILETYPES)

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -1,12 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from ...data import EventList
 from ...data import DataStore, DataManager
-from ...utils.testing import requires_data, data_manager, requires_dependency
+from ...utils.testing import data_manager, requires_data, requires_dependency
 from ...utils.scripts import make_path
 from ...datasets import gammapy_extra
-from numpy.testing import assert_allclose
+from ...extern.pathlib import Path
+
 
 @requires_data('gammapy-extra')
 @requires_dependency('yaml')
@@ -18,7 +20,6 @@ def test_DataStore_construction(data_manager):
     DataManager.DEFAULT_CONFIG_FILE = gammapy_extra.filename('datasets/data-register.yaml')
     data_store = DataStore.from_name('hess-crab4-hd-hap-prod2')
     data_store.info()
-
 
     base_dir = make_path('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
     data_store = DataStore.from_dir(base_dir)
@@ -46,16 +47,17 @@ def test_DataStore_filenames(data_manager):
     with pytest.raises(ValueError):
         data_store.filename(obs_id=89565, filetype='effective area')
 
+
 @requires_data('gammapy-extra')
 @requires_dependency('yaml')
 def test_DataStore_filenames_pa(data_manager):
-
     data_store = data_manager['hess-crab4-pa']
 
     filename = data_store.filename(obs_id=23523, filetype='aeff')
 
     assert filename == str(make_path(
         '$GAMMAPY_EXTRA/datasets/hess-crab4-pa/run23400-23599/run23523/aeff_2d_23523.fits.gz'))
+
 
 @requires_data('gammapy-extra')
 @requires_dependency('yaml')
@@ -76,6 +78,7 @@ def test_DataStore_load_all(data_manager):
     assert_allclose(event_lists[0]['ENERGY'][0], 1.1156039)
     assert_allclose(event_lists[-1]['ENERGY'][0], 1.0204216)
 
+
 @pytest.mark.xfail
 @requires_data('gammapy-extra')
 @requires_dependency('yaml')
@@ -87,3 +90,15 @@ def test_DataStore_other(data_manager):
     #                           lon=(-100, 50), lat=(-5, 5), border=2)
     # run_list = data_store.make_run_list(run_list_selection)
     # print(len(run_list))
+
+
+@requires_data('gammapy-extra')
+def test_load_background():
+    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-pa/')
+
+    filename = data_store.filename(23523, 'bkg')
+    assert Path(filename).parts[-1] == 'bgmodel_alt7_az0.fits.gz'
+
+    # TODO: loading doesn't work yet
+    # KeyError: "Extension 'DATA' not found."
+    # ds.load(23523, 'bkg')

--- a/gammapy/irf/exposure.py
+++ b/gammapy/irf/exposure.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from ..data import SpectralCube
 from astropy.coordinates import SkyCoord, Angle
 
 __all__ = [
@@ -35,6 +34,12 @@ def exposure_cube(pointing,
     expcube : `~gammapy.data.SpectralCube`
         Exposure cube (3D)
     """
+    # Delayed import to avoid circular import issues
+    # TODO: figure out if `gammapy.irf` is a good location for
+    # exposure computation functionality, or if this should be
+    # moved to `gammapy.data` or `gammapy.spectrum` or ...
+    from ..data import SpectralCube
+
     ny, nx = ref_cube.data.shape[1:]
     xx, yy = np.meshgrid(np.arange(nx), np.arange(ny))
     lon, lat, en = ref_cube.pix2world(xx, yy, 0)


### PR DESCRIPTION
This is an attempt to avoid the circular import issue @leajouvin is having here:
https://github.com/gammapy/gammapy/pull/464#discussion_r53627915

@leajouvin - Can you confirm that this fixes your issue?

Placing exposure computation functionality is quite tricky.
* `gammapy.irf` (current location) is natural because the main ingredient is effective area.
* `gammapy.data` would make sense in this case because the `SpectrumCube` class is there (which we use as an exposure cube here.
* Maybe `gammapy.spectrum` would be better (even if no spectrum is involved in the exposure cube computation)?
* Anyone know where the equivalent functionality is located in the Fermi ScienceTools or Gammalib?

@joleroi @adonath @tibaldo - Thoughts?