### PR TITLE
Adding build with numpy pre-release to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,9 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
+
 #        - os: linux
 #          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test -V'
 #               ASTROPY_VERSION=lts

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,7 +142,10 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
-
+        # this halts at the moment and thus allowing it to fail, to be able to go
+        # ahead with the release
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/gammapy/data/tests/test_obsgroup.py
+++ b/gammapy/data/tests/test_obsgroup.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
-from ...utils.testing import requires_data
+from ...utils.testing import requires_data, requires_dependency
 from ...datasets import gammapy_extra
 from ..observation import ObservationTable
 from ..obsgroup import ObservationGroups, ObservationGroupAxis
@@ -69,6 +69,7 @@ def test_obsgroup():
     assert len(obs_table_group_5) + len(obs_table_grouped_not5) == len(obs_table_grouped)
 
 
+@requires_dependency('pyyaml')
 @requires_data('gammapy-extra')
 def test_obsgroup_io():
     obs_groups = make_test_obs_groups()

--- a/gammapy/spectrum/counts_spectrum.py
+++ b/gammapy/spectrum/counts_spectrum.py
@@ -2,7 +2,6 @@
 from __future__ import (print_function)
 
 import numpy as np
-from astropy import log
 from astropy.coordinates import Angle
 
 from ..extern.bunch import Bunch
@@ -20,15 +19,19 @@ __all__ = ['CountsSpectrum']
 
 class CountsSpectrum(object):
     """Counts spectrum dataset
+
     Parameters
     ----------
     counts : `~numpy.array`, list
         Counts
     energy : `~gammapy.utils.energy.EnergyBounds`
         Energy axis
+
     Examples
     --------
+
     .. code-block:: python
+
         from gammapy.utils.energy import Energy, EnergyBounds
         from gammapy.data import CountsSpectrum
         ebounds = EnergyBounds.equal_log_spacing(1,10,10,'TeV')
@@ -55,9 +58,11 @@ class CountsSpectrum(object):
     @classmethod
     def read_pha(cls, phafile, rmffile=None):
         """Read PHA fits file
+
         The energy binning is not contained in the PHA standard. Therefore is
         is inferred from the corresponding RMF EBOUNDS extension.
         Todo: Should the energy binning be in the PHA file?
+
         Parameters
         ----------
         phafile : str
@@ -107,9 +112,11 @@ class CountsSpectrum(object):
     @classmethod
     def read_bkg(cls, bkgfile, rmffile):
         """Read BKG fits file
+
         The energy binning is not contained in the PHA standard. Therefore is
         is inferred from the corresponding RMF EBOUNDS extension.
         Todo: Should the energy binning be in the BKG file?
+
         Parameters
         ----------
         phafile : str
@@ -135,6 +142,7 @@ class CountsSpectrum(object):
         """Create CountsSpectrum from fits 'EVENTS' extension (`CountsSpectrum`).
         Subsets of the event list should be chosen via the appropriate methods
         in `~gammapy.data.EventList`.
+
         Parameters
         ----------
         event_list : `~astropy.io.fits.BinTableHDU, `gammapy.data.EventListDataSet`,
@@ -160,6 +168,7 @@ class CountsSpectrum(object):
     @classmethod
     def get_npred(cls, fit, obs):
         """Get N_pred vector from spectral fit
+
         Parameters
         ----------
         fit : SpectrumFitResult
@@ -230,8 +239,10 @@ class CountsSpectrum(object):
 
     def to_fits(self, bkg=None, corr=None, rmf=None, arf=None):
         """Convert to FITS format
+
         This can be used to write a :ref:`gadf:ogip-pha`. Meta info is written
         in the fits header.
+
         Parameters
         ----------
         bkg : str
@@ -242,10 +253,12 @@ class CountsSpectrum(object):
             :ref:`gadf:ogip-rmf` containing the corresponding energy resolution
         arf : str
             :ref:`gadf:ogip-arf` containing the corresponding effective area
+
         Returns
         -------
         pha : `~astropy.io.fits.BinTableHDU`
             PHA FITS HDU
+
         Notes
         -----
         For more info on the PHA FITS file format see:
@@ -331,12 +344,14 @@ class CountsSpectrum(object):
         """
         Plot counts vector
         kwargs are forwarded to matplotlib.pyplot.hist
+
         Parameters
         ----------
         ax : `~matplotlib.axis` (optional)
             Axis instance to be used for the plot
         weight : float
             Weighting factor for the counts
+
         Returns
         -------
         ax: `~matplotlib.axis`

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -613,7 +613,8 @@ class SpectrumObservation(object):
 
 
 class SpectrumObservationList(list):
-    """List of `~gammapy.spectrum.SpectrumObservation`
+    """
+    List of `~gammapy.spectrum.SpectrumObservation`.
     """
 
     def get_obslist_from_ids(self, id_list):

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -8,7 +8,6 @@ from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
 from astropy.extern import six
 from astropy.wcs.utils import skycoord_to_pixel
-from astropy.table import Table
 from . import CountsSpectrum
 from .results import SpectrumStats
 from ..extern.pathlib import Path
@@ -19,9 +18,8 @@ from ..image import ExclusionMask
 from ..region import SkyCircleRegion, find_reflected_regions
 from ..utils.energy import EnergyBounds, Energy
 from ..irf import EffectiveAreaTable, EnergyDispersion
-from ..utils.scripts import (
-    get_parser, set_up_logging_from_args, read_yaml, make_path,
-)
+from ..utils.scripts import make_path
+
 
 __all__ = [
     'SpectrumExtraction',
@@ -126,7 +124,7 @@ class SpectrumExtraction(object):
                     '\nError: \n{}'.format(val, self.store.base_dir, err))
                 nobs += 1
                 continue
-                
+
             observations.append(temp)
             if i == nobs - 1:
                 break
@@ -522,7 +520,7 @@ class SpectrumObservation(object):
 
         The arf, rmf and bkg files are set in the :ref:`gadf:ogip-pha` FITS
         header. If no filenames are given, default names will be chosen.
-       
+
         Parameters
         ----------
         phafile : `~gammapy.extern.pathlib.Path`, str
@@ -568,7 +566,7 @@ class SpectrumObservation(object):
         """Plot exclusion mask for this observation
 
         The plot will be centered at the pointing position
-       
+
         Parameters
         ----------
         size : `~astropy.coordinates.Angle`
@@ -620,7 +618,7 @@ class SpectrumObservationList(list):
 
     def get_obslist_from_ids(self, id_list):
         """Return an subset of the observation list
-        
+
         Parameters
         ----------
         id_list : list of int

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -255,9 +255,9 @@ class SpectrumObservation(object):
 
     @classmethod
     def read_ogip(cls, phafile):
-        """Read `~gammapy.spectrum.SpectrumObservation` from OGIP files
+        """Read `~gammapy.spectrum.SpectrumObservation` from OGIP files.
 
-        BKG file, ARF, and RMF must be set in the PHA header
+        BKG file, ARF, and RMF must be set in the PHA header.
 
         Parameters
         ----------
@@ -657,9 +657,8 @@ class SpectrumObservationList(list):
         return ss
 
     def filter_by_reflected_regions(self, n_min):
-        """Filter observation list according to number of reflected regions
-
-        Condition: number of reflected regions >= nmin
+        """Filter observation list according to number of reflected regions.
+        Condition: number of reflected regions >= nmin.
 
         Parameters
         ----------
@@ -689,14 +688,14 @@ class SpectrumObservationList(list):
 
     @classmethod
     def read_ogip(cls, dir='ogip_data'):
-        """Create `~gammapy.spectrum.SpectrumObservationList` from OGIP files
+        """Create `~gammapy.spectrum.SpectrumObservationList` from OGIP files.
 
         The pha file need to be contained in one directroy and have '.pha' as
-        suffix
+        suffix.
 
         Parameters
         ----------
-        dir : str, Path
+        dir : str, `~gammapy.extern.pathlib.Path`
             Directory holding the OGIP data
         """
         dir = make_path(dir)
@@ -704,7 +703,8 @@ class SpectrumObservationList(list):
         return cls(obs)
 
     def to_observation_table(self):
-        """Create `~gammapy.data.ObservationTable`"""
+        """Create `~gammapy.data.ObservationTable`."""
+
         observation_table = ObservationTable()
 
         files = np.array([o.meta.phafile for o in self])

--- a/gammapy/spectrum/spectrum_fit.py
+++ b/gammapy/spectrum/spectrum_fit.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 class SpectrumFit(object):
     """
     Spectral Fit
+
     Parameters
     ----------
     obs_list : SpectrumObservationList
@@ -57,6 +58,7 @@ class SpectrumFit(object):
     @classmethod
     def from_configfile(cls, configfile):
         """Create `~gammapy.spectrum.SpectrumFit` from configfile
+
         Parameters
         ----------
         configfile : str
@@ -130,6 +132,7 @@ class SpectrumFit(object):
     @statistic.setter
     def statistic(self, stat):
         """Set Statistic to be used in the fit
+
         Parameters
         ----------
         stat : `~sherpa.stats.Stat`, str
@@ -163,6 +166,7 @@ class SpectrumFit(object):
     def energy_threshold_low(self, energy):
         """
         Low energy threshold setter
+
         Parameters
         ----------
         energy : `~gammapy.utils.energy.Energy`, str
@@ -192,6 +196,7 @@ class SpectrumFit(object):
     def energy_threshold_high(self, energy):
         """
         High energy threshold setter
+
         Parameters
         ----------
         energy : `~gammapy.utils.energy.Energy`, str

--- a/gammapy/spectrum/spectrum_grouping.py
+++ b/gammapy/spectrum/spectrum_grouping.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 class SpectrumGrouping(object):
     """
     Class that will define the band and the observations in each band from an observation list.
+
     Parameters
     ----------
     spectrum_observation_list : `~gammapy.spectrum.SpectrumObservationList`
@@ -29,7 +30,7 @@ class SpectrumGrouping(object):
     def define_spectral_groups(self, offset_range=[0, 2.5], n_off_bin=5, eff_range=[0, 100], n_eff_bin=4,
                                zen_range=[0., 70.], n_zen_bin=7):
         """Define the number of bands in zenith, efficiency and offset.
-    
+
         Parameters
         ----------
         offset_range : tuple
@@ -44,6 +45,7 @@ class SpectrumGrouping(object):
             Min/Max zenith angle boundaries for the band
         n_zen_bin : int
             Number of zenith bin
+
         Returns
         -------
         obs_group : `~gammapy.data.ObservationGroups`
@@ -66,10 +68,12 @@ class SpectrumGrouping(object):
 
     def apply_grouping(self, obs_groups):
         """Attribute the number of the band to each observation and stack the observations together.
+
         Parameters
         ----------
         obs_groups : `~gammapy.data.ObservationGroups`
                 Contains the boundaries of the different band
+
         Returns
         -------
         list_band : `~gammapy.spectrum.SpectrumObservationList`
@@ -99,6 +103,7 @@ class SpectrumGrouping(object):
                                 zen_range=[0., 70.], n_zen_bin=7):
         """Define the number of bands in zenith, efficiency and offset and stack the events in each band
         using the previous method
+
         Parameters
         ----------
         offset_range : tuple
@@ -113,6 +118,7 @@ class SpectrumGrouping(object):
             Min/Max zenith angle boundaries for the band
         n_zen_bin : int
             Number of zenith bin
+
         Returns
         -------
         list_band : `~gammapy.spectrum.SpectrumObservationList`


### PR DESCRIPTION
Using python2.7, thus it can be tested with sherpa (and the numpy dev has been already tested with 3.5).