### PR TITLE
Install libgfortran explicitly on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@ env:
     global:
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=1.1
-        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes sherpa'
+        - LIBGFORTRAN_VERSION=1.0
+        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes sherpa libgfortran=$LIBGFORTRAN_VERSION'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes sherpa'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy sherpa'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy sherpa libgfortran=$LIBGFORTRAN_VERSION'
         - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas pyregion naima photutils wcsaxes pygments aplpy'
         - PIP_DEPENDENCIES='uncertainties reproject'
         - CONDA_CHANNELS='astropy sherpa'
@@ -50,16 +52,20 @@ matrix:
         # Try MacOS X
         - os: osx
           env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OSX
 
         - os: osx
           env: PYTHON_VERSION=3.5 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
 
+        # Temporarily disabled because of this issue:
+        # https://travis-ci.org/gammapy/gammapy/jobs/115820975
+        # https://github.com/gammapy/gammapy/pull/483
         # Test the dev version of Sherpa, this may take a longer time
-        - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
-               PIP_DEPENDENCIES='uncertainties reproject git+http://github.com/sherpa/sherpa.git#egg=sherpa'
+        #- os: linux
+        #  env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
+        #       CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
+        #       PIP_DEPENDENCIES='uncertainties reproject git+http://github.com/sherpa/sherpa.git#egg=sherpa'
 
         # Run tests
         # Coverage is measured on Python 2 (where Sherpa is available)


### PR DESCRIPTION
Since recently the Gammapy builds on travis-ci that use Sherpa fail with an error that libgfortran isn't found:
https://travis-ci.org/gammapy/gammapy/jobs/113736146#L1909

This is an attempt to solve the issue by installing libgfortran explicitly, as done by @olaurino for Sherpa:
https://github.com/sherpa/sherpa/pull/191

@olaurino - Is this the right fix? Or will there be a change on the Sherpa conda package side which results in libgfortran being installed automatically again soon?