### PR TITLE
Add Sherpa cube analysis prototype

### DIFF
--- a/docs/tutorials/npred/npred_general.py
+++ b/docs/tutorials/npred/npred_general.py
@@ -56,7 +56,6 @@ def prepare_images():
 
     # Header is required for plotting, so returned here
     wcs = npred_cube.wcs
-    wcs = wcs.dropaxis(2)
     header = wcs.to_header()
 
     return model, gtmodel, ratio, counts, header

--- a/gammapy/cube/sherpa_.py
+++ b/gammapy/cube/sherpa_.py
@@ -1,0 +1,144 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+import numpy
+
+from sherpa.models import ArithmeticModel, Parameter, modelCacher1d
+from sherpa.data import DataND, BaseData
+from sherpa.utils.err import DataErr, NotImplementedErr
+from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
+     print_fields, create_expr, calc_total_error, bool_cast, \
+     filter_bins, interpolate, linear_interp
+        
+
+
+# This class was copy pasted from sherpa.data.Data2D and modified to account
+# for the third dimension
+# it is set up to integrate over the energy (first) axis, but not all class
+# methods are adapted to that yet (TODO)
+
+class Data3D(DataND):
+    "3-D data set"
+
+    def _set_mask(self, val):
+        DataND._set_mask(self, val)
+        try:
+            self._lo = self.apply_filter(self.xlo)
+            self._hi = self.apply_filter(self.xhi)
+            self._x1 = self.apply_filter(self.x1)
+            self._x2 = self.apply_filter(self.x2)
+        except DataErr:
+            self._hi = self.xhi
+            self._lo = self.xlo
+            self._x1 = self.x1
+            self._x2 = self.x2
+
+    mask = property(DataND._get_mask, _set_mask,
+                    doc='Mask array for dependent variable')
+
+    def __init__(self, name, xlo, xhi, x1, x2, y, shape=None, staterror=None,
+                 syserror=None):
+        self._lo = xlo
+        self._hi = xhi
+        self._x1 = x1
+        self._x2 = x2
+        BaseData.__init__(self)
+
+    def get_indep(self, filter=False):
+        filter=bool_cast(filter)
+        if filter:
+            return (self._lo, self._hi, self._x1, self._x2)
+        return (self.xlo, self.xhi, self.x1, self.x2)
+
+    def get_x0(self, filter=False):
+        return self.get_indep(filter)[0]
+
+    def get_x1(self, filter=False):
+        return self.get_indep(filter)[1]
+
+    def get_x2(self, filter=False):
+        return self.get_indep(filter)[2]
+    
+    def get_axes(self):
+        self._check_shape()
+        # FIXME: how to filter an axis when self.mask is size of self.y?
+        return (numpy.arange(self.shape[1])+1, numpy.arange(self.shape[0])+1, numpy.arange(self.shape[0])+1)
+
+    def get_dims(self, filter=False):
+        #self._check_shape()
+        if self.shape is not None:
+            return self.shape[::-1]
+        return (len(self.get_x0(filter)), len(self.get_x1(filter)), len(self.get_x2(filter)))
+
+    def get_filter_expr(self):
+        return ''
+
+    get_filter = get_filter_expr
+
+    def _check_shape(self):
+        if self.shape is None:
+            raise DataErr('shape',self.name)
+
+    def get_max_pos(self, dep=None):
+        if dep is None:
+            dep = self.get_dep(True)
+        x0 = self.get_x0(True)
+        x1 = self.get_x1(True)
+        x2 = self.get_x2(True)
+
+        pos = numpy.asarray(numpy.where(dep == dep.max())).squeeze()
+        if pos.ndim == 0:
+            pos = int(pos)
+            return (x0[pos], x1[pos], x2[pos])
+
+        return [(x0[index], x1[index], x2[index]) for index in pos]
+
+    def get_img(self, yfunc=None):
+        self._check_shape()
+        y_img = self.get_y(False, yfunc)
+        if yfunc is not None:
+            y_img = (y_img[0].reshape(*self.shape),
+                     y_img[1].reshape(*self.shape))
+        else:
+            y_img = y_img.reshape(*self.shape)
+        return y_img
+
+    def get_imgerr(self):
+        self._check_shape()
+        err = self.get_error()
+        if err is not None:
+            err = err.reshape(*self.shape)
+        return err
+
+    def notice(self, x0lo=None, x0hi=None, x1lo=None, x1hi=None, x2lo=None, x2hi=None, ignore=False):
+        BaseData.notice(self, (x0lo, x1lo, x2lo), (x0hi, x1hi, x2hi), self.get_indep(),
+                        ignore)
+
+
+
+class CombinedModel3D(ArithmeticModel):
+    """
+    Combined spatial and spectral 3D model.
+    """
+    def __init__(self, name='cube-model', spatial_model=None, spectral_model=None):
+        self.spatial_model = spatial_model
+        self.spectral_model = spectral_model
+        
+        # Fix spectral ampl parameter
+        spectral_model.ampl = 1
+        spectral_model.ampl.freeze()
+        
+        pars = []
+        for _ in spatial_model.pars + spectral_model.pars:
+            setattr(self, _.name, _)
+            pars.append(_)
+        
+        self._spatial_pars = slice(0, len(spatial_model.pars))
+        self._spectral_pars = slice(len(spatial_model.pars), len(pars))
+        ArithmeticModel.__init__(self, name, pars)
+        
+    def calc(self, pars, elo, ehi, x, y):
+        _spatial = self.spatial_model.calc(pars[self._spatial_pars], x, y)
+        _spectral = self.spectral_model.calc(pars[self._spectral_pars], elo, ehi)
+        return _spatial * _spectral
+

--- a/gammapy/cube/spectral_cube.py
+++ b/gammapy/cube/spectral_cube.py
@@ -238,7 +238,7 @@ class SpectralCube(object):
         lon = lon.to('deg').value
         lat = lat.to('deg').value
         origin = 0  # convention for gammapy
-        x, y, _ = self.wcs.wcs_world2pix(lon, lat, 0, origin)
+        x, y = self.wcs.wcs_world2pix(lon, lat, origin)
 
         z = self.energy_axis.world2pix(energy)
 
@@ -499,9 +499,9 @@ class SpectralCube(object):
         except:
             pass
 
-        wcs_out = WCS(header_out)
+        wcs_out = WCS(header_out).celestial
 
-        return SpectralCube(new_cube, wcs_out, energy)
+        return SpectralCube(data=new_cube, wcs=wcs_out, energy=energy)
 
     def to_fits(self):
         """Writes SpectralCube to FITS hdu_list.

--- a/gammapy/cube/spectral_cube.py
+++ b/gammapy/cube/spectral_cube.py
@@ -163,7 +163,7 @@ class SpectralCube(object):
             data = Quantity(data, '1 / (cm2 MeV s sr)')
         elif format == 'fermi-counts':
             energy = EnergyBounds.from_ebounds(fits.open(filename)['EBOUNDS'], unit='keV')
-            data = Quantity(data, 'counts')
+            data = Quantity(data, 'count')
         else:
             raise ValueError('Not a valid cube fits format')
         return cls(data=data, wcs=wcs, energy=energy)
@@ -311,8 +311,8 @@ class SpectralCube(object):
         ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra)
  
         return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),    
-                      dec_cube.ravel(), counts.data.value.ravel(),
-                      counts.data.value.shape)
+                      dec_cube.ravel(), self.data.value.ravel(),
+                      self.data.value.shape)
 
 
     @property

--- a/gammapy/cube/spectral_cube.py
+++ b/gammapy/cube/spectral_cube.py
@@ -81,6 +81,7 @@ class SpectralCube(object):
         # TODO: check validity of inputs
         self.data = data
         self.wcs = wcs
+        self.header = wcs.to_header()
 
         # TODO: decide whether we want to use an EnergyAxis object or just use the array directly.
         self.energy = energy
@@ -245,6 +246,7 @@ class SpectralCube(object):
         lon, lat, _ = self.pix2world(i_lon, i_lat, 0)
 
         return lon, lat
+
 
     @property
     def solid_angle_image(self):

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -5,10 +5,10 @@ from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
-from ...irf import exposure_cube
-from ...data import SpectralCube
 from ...irf import EffectiveAreaTable2D
 from ...datasets import gammapy_extra
+from .. import exposure_cube
+from .. import SpectralCube
 
 
 @requires_dependency('scipy')
@@ -20,12 +20,12 @@ def test_exposure_cube():
     pointing = SkyCoord(83.633, 21.514, unit='deg')
     livetime = Quantity(1581.17, 's')
     aeff2d = EffectiveAreaTable2D.read(aeff_filename)
-    count_cube = SpectralCube.read_counts(ccube_filename)
+    count_cube = SpectralCube.read(ccube_filename, format='fermi-counts')
     exp_cube = exposure_cube(pointing, livetime, aeff2d, count_cube, offset_max=Angle(2.2, 'deg'))
     exp_ref = Quantity(4.7e8, 'm^2 s')
 
     assert np.shape(exp_cube.data)[1:] == np.shape(count_cube.data)[1:]
-    assert np.shape(exp_cube.data)[0] == np.shape(count_cube.data)[0] + 1
+    assert np.shape(exp_cube.data)[0] == np.shape(count_cube.data)[0]
     assert exp_cube.wcs == count_cube.wcs
     assert_equal(count_cube.energy, exp_cube.energy)
     assert_quantity_allclose(np.nanmax(exp_cube.data), exp_ref, rtol=100)

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -10,7 +10,6 @@ from astropy.table import Table
 from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
 
-from ..sherpa_ import Data3D, CombinedModel3D
 from .. import SpectralCube
 from ...datasets import gammapy_extra
 from ...utils.testing import requires_dependency
@@ -24,6 +23,7 @@ def test_sherpa_crab_fit():
     from sherpa.stats import Chi2ConstVar
     from sherpa.optmethods import LevMar
     from sherpa.fit import Fit
+    from ..sherpa_ import Data3D, CombinedModel3D
 
     filename = gammapy_extra.filename('experiments/sherpa_cube_analysis/counts.fits.gz')
     counts = SpectralCube.read(filename)

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -1,0 +1,65 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from numpy.testing.utils import assert_allclose
+
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.table import Table
+from astropy.units import Quantity
+from astropy.coordinates import SkyCoord
+
+from ..sherpa_ import Data3D, CombinedModel3D
+from .. import SpectralCube
+from ...datasets import gammapy_extra
+from ...utils.testing import requires_dependency
+from ...utils.testing import requires_data
+
+
+@requires_dependency('sherpa')
+@requires_data('gammapy-extra')
+def test_sherpa_crab_fit():
+    from sherpa.models import NormGauss2D, PowLaw1D, TableModel, Const2D
+    from sherpa.stats import Chi2ConstVar
+    from sherpa.optmethods import LevMar
+    from sherpa.fit import Fit
+
+    filename = gammapy_extra.filename('experiments/sherpa_cube_analysis/counts.fits.gz')
+    counts = SpectralCube.read(filename)
+    cube = counts.to_sherpa_data3d()
+
+    # Set up exposure table model
+    filename = gammapy_extra.filename('experiments/sherpa_cube_analysis/exposure.fits.gz')
+    exposure_data = fits.getdata(filename)
+    exposure = TableModel('exposure')
+    exposure.load(None, exposure_data.ravel())
+
+    # Freeze exposure amplitude
+    exposure.ampl.freeze()
+
+    # Setup combined spatial and spectral model
+    spatial_model = NormGauss2D('spatial-model')
+    spectral_model = PowLaw1D('spectral-model')
+    source_model = CombinedModel3D(spatial_model=spatial_model, spectral_model=spectral_model)
+
+    # Set starting values
+    source_model.gamma = 2.2
+    source_model.xpos = 83.6
+    source_model.ypos = 22.01
+    source_model.fwhm = 0.12
+    source_model.ampl = 0.05
+
+    model = 1E-9 * exposure * (source_model) # 1E-9 flux factor
+
+    # Fit
+    fit = Fit(data=cube, model=model, stat=Chi2ConstVar(), method=LevMar())
+    result = fit.fit()
+
+    reference = (0.11925401159500593,
+                 83.640630749333056,
+                 22.020525848447541,
+                 0.036353759774770608,
+                 1.1900312815970555)
+
+    assert_allclose(result.parvals, reference, rtol=1E-8) 

--- a/gammapy/cube/tests/test_spectral_cube.py
+++ b/gammapy/cube/tests/test_spectral_cube.py
@@ -8,10 +8,10 @@ from astropy.units import Quantity
 from astropy.wcs import WCS
 from ...utils.testing import requires_dependency
 from ...datasets import FermiGalacticCenter
-from ...data import SpectralCube, compute_npred_cube, convolve_cube
 from ...image import make_header
 from ...irf import EnergyDependentTablePSF
 from ...spectrum.powerlaw import power_law_evaluate
+from .. import SpectralCube, compute_npred_cube, convolve_cube
 
 
 @requires_dependency('scipy.interpolate.RegularGridInterpolator')

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
-from ..image.utils import coordinates
+from .utils import coordinates
 
 __all__ = [
     'BoundingBox',

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -6,6 +6,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 
 from ..maps import SkyMap
+from ...data import DataStore
 from ...datasets import load_poisson_stats_image
 from ...utils.testing import requires_dependency, requires_data
 
@@ -67,3 +68,17 @@ class TestSkyMapPoisson():
         empty = SkyMap.empty()
         assert empty.data.shape == (200, 200)
 
+
+    @requires_data('gammapy-extra')
+    def test_fill(self):
+        dirname = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
+        data_store = DataStore.from_dir(dirname)
+
+        events = data_store.load(obs_id=23523, filetype='events')
+
+        counts = SkyMap.empty(nxpix=200, nypix=200, xref=events.meta['RA_OBJ'],
+                              yref=events.meta['DEC_OBJ'], dtype='int', 
+                              coordsys='CEL')
+        counts.fill(events)
+        assert counts.data.sum() == 1233
+        assert counts.data.shape == (200, 200)

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -80,5 +80,5 @@ class TestSkyMapPoisson():
                               yref=events.meta['DEC_OBJ'], dtype='int', 
                               coordsys='CEL')
         counts.fill(events)
-        assert counts.data.sum() == 1233
+        assert counts.data.sum().value == 1233
         assert counts.data.shape == (200, 200)

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -74,7 +74,7 @@ class TestSkyMapPoisson():
         dirname = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
         data_store = DataStore.from_dir(dirname)
 
-        events = data_store.load(obs_id=23523, filetype='events')
+        events = data_store.obs(obs_id=23523).events
 
         counts = SkyMap.empty(nxpix=200, nypix=200, xref=events.meta['RA_OBJ'],
                               yref=events.meta['DEC_OBJ'], dtype='int', 

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -221,7 +221,7 @@ def test_bin_events_in_cube():
     dirname = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
     data_store = DataStore.from_dir(dirname)
 
-    events = data_store.load(obs_id=23523, filetype='events')
+    events = data_store.obs(obs_id=23523).events
 
     counts = SpectralCube.empty(emin=0.5, emax=80, enbins=8, eunit='TeV',
                                 nxpix=200, nypix=200, xref=events.meta['RA_OBJ'],

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -228,7 +228,7 @@ def test_bin_events_in_cube():
                                 yref=events.meta['DEC_OBJ'], dtype='int', 
                                 coordsys='CEL')
     counts.fill(events)
-    assert counts.data.sum() == 1233
+    assert counts.data.sum().value == 1233
 
 
 

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -725,10 +725,8 @@ def _bin_events_in_cube(events, wcs, shape, energies=None, origin=0):
     # This was checked against the `ctskymap` ctool
     # http://cta.irap.omp.eu/ctools/
     bins = np.arange(shape[0]), np.arange(shape[1] + 1) - 0.5, np.arange(shape[2] + 1) - 0.5
-    return np.histogramdd([zz, yy, xx], bins)[0]
+    return Quantity(np.histogramdd([zz, yy, xx], bins)[0], 'count')
         
- 
-
 
 def threshold(array, threshold=5):
     """Set all pixels below threshold to zero.

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -715,17 +715,14 @@ def bin_events_in_cube(events, reference_cube, energies):
     # We're not interested in the energy axis, so we give a dummy value of 1
     origin = 0  # convention for gammapy
     xx, yy = wcs.wcs_world2pix(lon, lat, 1, origin)[:-1]
-    
-    event_energies = events['Energy']
-    zz = np.searchsorted(event_energies, energies)
-
+    event_energies = events['ENERGY']
+    zz = np.searchsorted(energies.value, event_energies.data)
     # Histogram pixel coordinates with appropriate binning.
     # This was checked against the `ctskymap` ctool
     # http://cta.irap.omp.eu/ctools/
     shape = reference_cube.data.shape
     bins = np.arange(shape[0]), np.arange(shape[1] + 1) - 0.5, np.arange(shape[2] + 1) - 0.5
     data = np.histogramdd([zz, yy, xx], bins)[0]
-
     hdu = fits.ImageHDU(data, reference_cube.header)
     return hdu
 

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -7,6 +7,8 @@ from astropy.units import Quantity
 from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.wcs import WCS
+from ..utils.wcs import get_wcs_ctype
+from ..utils.energy import EnergyBounds
 # TODO:
 # Remove this when/if https://github.com/astropy/astropy/issues/4429 is fixed
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -15,7 +17,6 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 __all__ = [
     'atrous_hdu',
     'atrous_image',
-    'bin_events_in_cube',
     'bin_events_in_image',
     'binary_dilation_circle',
     'binary_disk',
@@ -358,10 +359,9 @@ def atrous_hdu(hdu, n_levels):
 
 def coordinates(image, world=True, lon_sym=True, radians=False):
     """Get coordinate images for a given image.
-
     This function is useful if you want to compute
     an image with values that are a function of position.
-
+    
     Parameters
     ----------
     image : `~astropy.io.fits.ImageHDU` or `~numpy.ndarray`
@@ -372,13 +372,13 @@ def coordinates(image, world=True, lon_sym=True, radians=False):
         Use symmetric longitude range ``(-180, 180)`` (or ``(0, 360)``)?
     radians : bool, optional
         Return coordinates in radians or degrees?
-
+    
     Returns
     -------
     (lon, lat) : tuple of arrays
         Images as numpy arrays with values
         containing the position of the given pixel.
-
+    
     Examples
     --------
     >>> import numpy as np
@@ -684,47 +684,50 @@ def bin_events_in_image(events, reference_image):
     return wcs_histogram2d(reference_image.header, pos.data.lon.deg, pos.data.lat.deg)
 
 
-def bin_events_in_cube(events, reference_cube, energies):
-    """Bin events in LON-LAT-Energy cube.
 
+def _bin_events_in_cube(events, wcs, shape, energies=None, origin=0):
+    """Bin events in LON-LAT-Energy cube.
     Parameters
     ----------
-    events : `~astropy.table.Table`
+    events : `~astropy.data.EventList`
         Event list table
-    reference_cube : `~astropy.io.fits.ImageHDU`
-        A cube defining the spatial bins.
-    energies : `~astropy.table.Table`
-        Table defining the energy bins.
+    wcs : `~astropy.wcs.WCS`
+        WCS instance defining celestial coordinates.
+    shape : tuple
+        Tuple defining the spatial shape.
+    energies : `~gammapy.utils.energy.EnergyBounds`
+        Energy bounds defining the binning. If None only one energy bin defined 
+        by the minimum and maximum event energy is used.
+    origin : {0, 1}
+        Pixel coordinate origin.
 
     Returns
     -------
-    count_cube : `~astropy.io.fits.ImageHDU`
-        Count cube
+    data : `~numpy.ndarray`
+        Counts cube.
     """
-    # TODO: this duplicates code from `bin_events_in_image`
-
-    if 'GLON' in reference_cube.header['CTYPE1']:
-        lon = events['GLON']
-        lat = events['GLAT']
+    if get_wcs_ctype(wcs) == 'galactic':
+        lon, lat = events['GLON'], events['GLAT']
     else:
-        lon = events['RA']
-        lat = events['DEC']
+        lon, lat = events['RA'], events['DEC']
 
-    # Get pixel coordinates
-    wcs = WCS(reference_cube.header)
-    # We're not interested in the energy axis, so we give a dummy value of 1
-    origin = 0  # convention for gammapy
-    xx, yy = wcs.wcs_world2pix(lon, lat, 1, origin)[:-1]
+    xx, yy = wcs.wcs_world2pix(lon, lat, origin)
     event_energies = events['ENERGY']
+    
+    if energies is None:
+        emin = np.min(event_energies)
+        emax = np.max(event_energies)
+        energies = EnergyBounds.equal_log_spacing(emin, emax, nbins=1, unit='TeV')
+        shape = (2, ) + shape
+
     zz = np.searchsorted(energies.value, event_energies.data)
     # Histogram pixel coordinates with appropriate binning.
     # This was checked against the `ctskymap` ctool
     # http://cta.irap.omp.eu/ctools/
-    shape = reference_cube.data.shape
     bins = np.arange(shape[0]), np.arange(shape[1] + 1) - 0.5, np.arange(shape[2] + 1) - 0.5
-    data = np.histogramdd([zz, yy, xx], bins)[0]
-    hdu = fits.ImageHDU(data, reference_cube.header)
-    return hdu
+    return np.histogramdd([zz, yy, xx], bins)[0]
+        
+ 
 
 
 def threshold(array, threshold=5):

--- a/gammapy/scripts/cube_bin.py
+++ b/gammapy/scripts/cube_bin.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from astropy.io import fits
 from astropy.table import Table
-from ..image.utils import bin_events_in_cube
+from ..cube import SpectralCube
 from ..utils.scripts import get_parser
 
 __all__ = ['cube_bin']
@@ -31,7 +31,7 @@ def cube_bin(event_file,
              overwrite):
     """Bin events into a LON-LAT-Energy cube."""
     events = Table.read(event_file)
-    reference_cube = fits.open(reference_file)
-    energies = Table.read(reference_file, 'ENERGIES')
-    out_cube = bin_events_in_cube(events, reference_cube, energies)
-    out_cube.writeto(out_file, clobber=overwrite)
+    refcube = SpectralCube.read(reference_file)
+    cube = SpectralCube.empty_like(refcube)
+    cube.fill(events)
+    cube.writeto(out_file, clobber=overwrite)


### PR DESCRIPTION
This PR implements basic Sherpa classes for  simple cube style analysis. An example notebook how to use it, can be found [here](https://github.com/gammapy/gammapy-extra/blob/master/experiments/sherpa_cube_analysis_prototype/sherpa_cube_analysis_prototype.ipynb). Any suggestion how to proceed with this? @cdeil @joleroi 
E.g. add PSF and background handling and create a command-line tool? So, we can say cube style analysis is possible in gammapy? 