### PR TITLE
Add methods to convert analytical to Table PSF

### DIFF
--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -19,7 +19,7 @@ DEFAULT_PSF_SPLINE_KWARGS = dict(k=1, s=0)
 
 
 class TablePSF(object):
-    r"""Radially-symmetric table PSF.
+    """Radially-symmetric table PSF.
 
     This PSF represents a :math:`PSF(\theta)=dP / d\Omega(\theta)`
     spline interpolation curve for a given set of offset :math:`\theta`
@@ -324,7 +324,7 @@ class TablePSF(object):
         self._compute_splines(self._spline_kwargs)
 
     def broaden(self, factor, normalize=True):
-        r"""Broaden PSF by scaling the offset array.
+        """Broaden PSF by scaling the offset array.
 
         For a broadening factor :math:`f` and the offset
         array :math:`\theta`, the offset array scaled


### PR DESCRIPTION
So far the PSF functionality is somewhat messy, in the sense that there is no clear path from a 2D PSF (as function of energy and offset) to a 1D PSF (as function of energy)

* TripleGaus:
2D (gammapy.irf.EnergyDependentMultiGaussPSF) -> 1D (gammapy.morphology.MultiGauss2D)

* King:
2D (gammapy.irf.PSFKing) -> 1D (missing)

* Table
2D (gammapy.irf.EnergyDependentTablePSF) -> 1D (gammapy.irf.TablePSF)

This PR tries to order this somehow, by
* [ ] Add to_table_psf to KingPSF and 3GaussPSF
* [ ] Use EnergyDependentTablePSF for plotting and converting to 1D

