### PR TITLE
TS performance improvements

### DIFF
--- a/gammapy/detect/_test_statistics_cython.pyx
+++ b/gammapy/detect/_test_statistics_cython.pyx
@@ -61,13 +61,11 @@ def _x_best_leastsq(np.ndarray[np.float_t, ndim=2] counts,
     weights : `~numpy.ndarray`
         Fit weights.
     """
-    cdef np.float_t sum
-    cdef np.float_t norm
+    cdef np.float_t sum = 0
+    cdef np.float_t norm = 0
     cdef unsigned int i, j, ni, nj
     ni = counts.shape[1]
     nj = counts.shape[0]
-    sum = 0
-    norm = 0
     for j in range(nj):
         for i in range(ni):
             if model[j, i] > 0 and weights[j, i] > 0:
@@ -114,10 +112,21 @@ def _amplitude_bounds_cython(np.ndarray[np.float_t, ndim=2] counts,
     return b_min / FLUX_FACTOR, b_max / FLUX_FACTOR
 
 
-cdef extern from "math.h":
-    float log2(float x)
+IF UNAME_SYSNAME == "Windows":
+    # Windows fall back for log2, which was only introduced in MSVC 2010
+    cdef extern from "math.h":
+        float log(float x)
 
-cdef np.float_t LOG2_TO_E = 0.69314718055994529
+    cdef np.float_t LOG2_TO_E = 1.
+
+    def log2(x):
+        return log(x)
+ELSE:
+    cdef extern from "math.h":
+        float log2(float x)
+
+    cdef np.float_t LOG2_TO_E = 0.69314718055994529
+
 
 @cython.cdivision(True)
 @cython.boundscheck(False)

--- a/gammapy/detect/_test_statistics_cython.pyx
+++ b/gammapy/detect/_test_statistics_cython.pyx
@@ -117,7 +117,6 @@ def _amplitude_bounds_cython(np.ndarray[np.float_t, ndim=2] counts,
 cdef extern from "math.h":
     float log2(float x)
 
-
 cdef np.float_t LOG2_TO_E = 0.69314718055994529
 
 @cython.cdivision(True)

--- a/gammapy/detect/_test_statistics_cython.pyx
+++ b/gammapy/detect/_test_statistics_cython.pyx
@@ -115,9 +115,13 @@ def _amplitude_bounds_cython(np.ndarray[np.float_t, ndim=2] counts,
 
 
 cdef extern from "math.h":
-    float log(float x)
+    float log2(float x)
 
 
+cdef np.float_t LOG2_TO_E = 0.69314718055994529
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
 def _cash_cython(np.ndarray[np.float_t, ndim=2] counts,
                  np.ndarray[np.float_t, ndim=2] model):
     """
@@ -139,10 +143,11 @@ def _cash_cython(np.ndarray[np.float_t, ndim=2] counts,
     for j in range(nj):
         for i in range(ni):
             if model[j, i] > 0:
-                cash[j, i] = 2 * (model[j, i] - counts[j, i] * log(model[j, i]))
+                cash[j, i] = 2 * (model[j, i] - counts[j, i] * log2(model[j, i]) * LOG2_TO_E)
     return cash
 
-
+@cython.cdivision(True)
+@cython.boundscheck(False)
 def _cash_sum_cython(np.ndarray[np.float_t, ndim=2] counts,
                      np.ndarray[np.float_t, ndim=2] model):
     """
@@ -162,6 +167,6 @@ def _cash_sum_cython(np.ndarray[np.float_t, ndim=2] counts,
     for j in range(nj):
         for i in range(ni):
             if model[j, i] > 0:
-                sum += model[j, i] - counts[j, i] * log(model[j, i])
+                sum += model[j, i] - counts[j, i] * log2(model[j, i]) * LOG2_TO_E
     return 2 * sum
 

--- a/gammapy/detect/_test_statistics_cython.pyx
+++ b/gammapy/detect/_test_statistics_cython.pyx
@@ -41,6 +41,43 @@ def _f_cash_root_cython(np.float_t x, np.ndarray[np.float_t, ndim=2] counts,
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
+def _x_best_leastsq(np.ndarray[np.float_t, ndim=2] counts,
+                    np.ndarray[np.float_t, ndim=2] background,
+                    np.ndarray[np.float_t, ndim=2] model,
+                    np.ndarray[np.float_t, ndim=2] weights):
+    """
+    Best fit amplitude using weighted least squares fit.
+
+    For a single parameter amplitude fit this can be solved analytically.
+
+    Parameters
+    ----------
+    counts : `~numpy.ndarray`
+        Count map.
+    background : `~numpy.ndarray`
+        Background map.
+    model : `~numpy.ndarray`
+        Source template (multiplied with exposure).
+    weights : `~numpy.ndarray`
+        Fit weights.
+    """
+    cdef np.float_t sum
+    cdef np.float_t norm
+    cdef unsigned int i, j, ni, nj
+    ni = counts.shape[1]
+    nj = counts.shape[0]
+    sum = 0
+    norm = 0
+    for j in range(nj):
+        for i in range(ni):
+            if model[j, i] > 0 and weights[j, i] > 0:
+                sum += (counts[j, i] - background[j, i]) * model[j, i] / weights[j, i]
+                norm += model[j, i] * model[j, i] / weights[j, i]
+    return sum / norm
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
 def _amplitude_bounds_cython(np.ndarray[np.float_t, ndim=2] counts,
                              np.ndarray[np.float_t, ndim=2] background,
                              np.ndarray[np.float_t, ndim=2] model):
@@ -127,3 +164,4 @@ def _cash_sum_cython(np.ndarray[np.float_t, ndim=2] counts,
             if model[j, i] > 0:
                 sum += model[j, i] - counts[j, i] * log(model[j, i])
     return 2 * sum
+

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -9,18 +9,23 @@ from itertools import product
 from functools import partial
 from multiprocessing import Pool, cpu_count
 import numpy as np
-from astropy.convolution import Tophat2DKernel, Model2DKernel, Gaussian2DKernel
+from astropy.convolution import Model2DKernel, Gaussian2DKernel
 from astropy.convolution.kernels import _round_up_to_odd_integer
-from astropy.nddata.utils import extract_array
 from astropy.io import fits
+from ._test_statistics_cython import (_cash_cython, _amplitude_bounds_cython,
+                                      _cash_sum_cython, _f_cash_root_cython,
+                                      _x_best_leastsq)
 from ..irf import multi_gauss_psf_kernel
 from ..morphology import Shell2D
-from ..extern.zeros import newton
 from ..extern.bunch import Bunch
 from ..image import (measure_containment_radius, upsample_2N, downsample_2N,
+<<<<<<< HEAD
                      shape_2N, SkyMapCollection)
 from ._test_statistics_cython import (_cash_cython, _amplitude_bounds_cython,
                                       _cash_sum_cython, _f_cash_root_cython)
+=======
+                     shape_2N)
+>>>>>>> add iterative least sqares to ts computation
 
 __all__ = [
     'compute_ts_map',
@@ -33,6 +38,31 @@ log = logging.getLogger(__name__)
 FLUX_FACTOR = 1E-12
 MAX_NITER = 20
 CONTAINMENT = 0.8
+
+
+def _extract_array(array, shape, position):
+    """Helper function to extract parts of a larger array.
+
+    Simple implementation of an array extract function , because
+    `~astropy.ndata.utils.extract_array` introduces to much overhead.`
+
+    Parameters
+    ----------
+    array : `~numpy.ndarray`
+        The array from which to extract.
+    shape : tuple or int
+        The shape of the extracted array.
+    position : tuple of numbers or number
+        The position of the small array's center with respect to the
+        large array.
+    """
+    x_width = shape[0] // 2
+    y_width = shape[0] // 2
+    y_lo = position[0] - y_width
+    y_hi = position[0] + y_width + 1
+    x_lo = position[1] - x_width
+    x_hi = position[1] + x_width + 1
+    return array[y_lo:y_hi, x_lo:x_hi]
 
 
 def f_cash(x, counts, background, model):
@@ -276,14 +306,12 @@ def compute_ts_map(counts, background, exposure, kernel, mask=None, flux=None,
         exposure[mask_] = 0
 
     if (flux is None and method != 'root brentq') or threshold is not None:
-        from scipy.ndimage import convolve
-        radius = _flux_correlation_radius(kernel)
-        tophat = Tophat2DKernel(radius, mode='oversample') * np.pi * radius ** 2
-        log.info('Using correlation radius of {0:.1f} pix to estimate'
-                 ' initial flux.'.format(radius))
+        from scipy.signal import fftconvolve
+
         with np.errstate(invalid='ignore', divide='ignore'):
             flux = (counts - background) / exposure / FLUX_FACTOR
-        flux = convolve(flux, tophat.array) / CONTAINMENT
+        flux[~np.isfinite(flux)] = 0
+        flux = fftconvolve(flux, kernel.array, mode='same') / np.sum(kernel.array ** 2)
 
     # Compute null statistics for the whole map
     C_0_map = _cash_cython(counts.astype(float), background.astype(float))
@@ -357,10 +385,10 @@ def _ts_value(position, counts, exposure, background, C_0_map, kernel, flux,
         TS value at the given pixel position.
     """
     # Get data slices
-    counts_ = extract_array(counts, kernel.shape, position).astype(float)
-    background_ = extract_array(background, kernel.shape, position).astype(float)
-    exposure_ = extract_array(exposure, kernel.shape, position).astype(float)
-    C_0_ = extract_array(C_0_map, kernel.shape, position)
+    counts_ = _extract_array(counts, kernel.shape, position).astype(float)
+    background_ = _extract_array(background, kernel.shape, position).astype(float)
+    exposure_ = _extract_array(exposure, kernel.shape, position).astype(float)
+    C_0_ = _extract_array(C_0_map, kernel.shape, position)
     model = (exposure_ * kernel._array).astype(float)
 
     C_0 = C_0_.sum()
@@ -377,11 +405,16 @@ def _ts_value(position, counts, exposure, background, C_0_map, kernel, flux,
                                                  flux[position])
     elif method == 'fit scipy':
         amplitude, niter = _fit_amplitude_scipy(counts_, background_, model)
+
     elif method == 'root newton':
         amplitude, niter = _root_amplitude(counts_, background_, model,
                                            flux[position])
     elif method == 'root brentq':
         amplitude, niter = _root_amplitude_brentq(counts_, background_, model)
+
+    elif method == 'leastsq iter':
+        amplitude, niter = _leastsq_iter_amplitude(counts_, background_, model)
+
     else:
         raise ValueError('Invalid fitting method.')
 
@@ -394,6 +427,42 @@ def _ts_value(position, counts, exposure, background, C_0_map, kernel, flux,
 
     # Compute and return TS value
     return (C_0 - C_1) * np.sign(amplitude), amplitude * FLUX_FACTOR, niter
+
+
+def _leastsq_iter_amplitude(counts, background, model, maxiter=MAX_NITER, rtol=0.01):
+    """Fit amplitude using an iterative least squares algorithm.
+
+    Parameters
+    ----------
+    counts : `~numpy.ndarray`
+        Slice of count map.
+    background : `~numpy.ndarray`
+        Slice of background map.
+    model : `~numpy.ndarray`
+        Model template to fit.
+    maxiter : int 
+        Maximum number of iterations.
+    rtol : float
+        Relative flux error.
+
+    Returns
+    -------
+    amplitude : float
+        Fitted flux amplitude.
+    niter : int
+        Number of function evaluations needed for the fit.
+    """
+    weights = np.ones(model.shape)
+
+    x_old = 0
+    for i in range(maxiter):
+        x =_x_best_leastsq(counts, background, model, weights)
+        if abs((x - x_old) / x) < rtol:
+            return x / FLUX_FACTOR, i + 1
+        else:
+            weights = x * model + background
+            x_old = x
+    return x, MAX_NITER
 
 
 def _root_amplitude(counts, background, model, flux):
@@ -419,11 +488,13 @@ def _root_amplitude(counts, background, model, flux):
     niter : int
         Number of function evaluations needed for the fit.
     """
+    from scipy.optimize import newton
+
     args = (counts, background, model)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         try:
-            return newton(_f_cash_root_cython, flux, args=args, maxiter=MAX_NITER, tol=0.1)
+            return newton(_f_cash_root_cython, flux, args=args, maxiter=MAX_NITER, tol=1E-2), 0
         except RuntimeError:
             # Where the root finding fails NaN is set as amplitude
             return np.nan, MAX_NITER
@@ -491,6 +562,7 @@ def _fit_amplitude_scipy(counts, background, model, optimizer='Brent'):
         Number of function evaluations needed for the fit.
     """
     from scipy.optimize import minimize_scalar
+
     args = (counts, background, model)
     amplitude_min, amplitude_max = _amplitude_bounds_cython(counts, background, model)
     try:

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -19,17 +19,9 @@ from ..irf import multi_gauss_psf_kernel
 from ..morphology import Shell2D
 from ..extern.bunch import Bunch
 from ..image import (measure_containment_radius, upsample_2N, downsample_2N,
-<<<<<<< HEAD
-<<<<<<< HEAD
                      shape_2N, SkyMapCollection)
 from ._test_statistics_cython import (_cash_cython, _amplitude_bounds_cython,
                                       _cash_sum_cython, _f_cash_root_cython)
-=======
-                     shape_2N)
->>>>>>> add iterative least sqares to ts computation
-=======
-                     shape_2N)
->>>>>>> add iterative least sqares to ts computation
 
 __all__ = [
     'compute_ts_map',
@@ -394,27 +386,11 @@ def _ts_value(position, counts, exposure, background, C_0_map, kernel, flux,
         TS value at the given pixel position.
     """
     # Get data slices
-<<<<<<< HEAD
-<<<<<<< HEAD
     counts_ = _extract_array(counts, kernel.shape, position)
     background_ = _extract_array(background, kernel.shape, position)
     exposure_ = _extract_array(exposure, kernel.shape, position)
     C_0_ = _extract_array(C_0_map, kernel.shape, position)
     model = (exposure_ * kernel._array)
-=======
-    counts_ = _extract_array(counts, kernel.shape, position).astype(float)
-    background_ = _extract_array(background, kernel.shape, position).astype(float)
-    exposure_ = _extract_array(exposure, kernel.shape, position).astype(float)
-    C_0_ = _extract_array(C_0_map, kernel.shape, position)
-    model = (exposure_ * kernel._array).astype(float)
->>>>>>> add iterative least sqares to ts computation
-=======
-    counts_ = _extract_array(counts, kernel.shape, position)
-    background_ = _extract_array(background, kernel.shape, position)
-    exposure_ = _extract_array(exposure, kernel.shape, position)
-    C_0_ = _extract_array(C_0_map, kernel.shape, position)
-    model = (exposure_ * kernel._array)
->>>>>>> Minor performace improvements to TS map computation
 
     C_0 = C_0_.sum()
 
@@ -437,15 +413,6 @@ def _ts_value(position, counts, exposure, background, C_0_map, kernel, flux,
     elif method == 'root newton':
         amplitude, niter = _root_amplitude(counts_, background_, model,
                                            flux[position])
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    elif method == 'root brentq':
-        amplitude, niter = _root_amplitude_brentq(counts_, background_, model)
-
->>>>>>> add iterative least sqares to ts computation
-=======
->>>>>>> Minor performace improvements to TS map computation
     elif method == 'leastsq iter':
         amplitude, niter = _leastsq_iter_amplitude(counts_, background_, model)
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -40,7 +40,7 @@ def _extract_array(array, shape, position):
     """Helper function to extract parts of a larger array.
 
     Simple implementation of an array extract function , because
-    `~astropy.ndata.utils.extract_array` introduces to much overhead.`
+    `~astropy.ndata.utils.extract_array` introduces too much overhead.`
 
     Parameters
     ----------

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -20,8 +20,6 @@ from ..morphology import Shell2D
 from ..extern.bunch import Bunch
 from ..image import (measure_containment_radius, upsample_2N, downsample_2N,
                      shape_2N, SkyMapCollection)
-from ._test_statistics_cython import (_cash_cython, _amplitude_bounds_cython,
-                                      _cash_sum_cython, _f_cash_root_cython)
 
 __all__ = [
     'compute_ts_map',

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -1,21 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import sys
-
 import numpy as np
 from numpy.testing.utils import assert_allclose, assert_equal
-
 from astropy.convolution import Gaussian2DKernel
-from astropy.tests.helper import pytest
-
 from ...utils.testing import requires_dependency, requires_data
 from ...detect import compute_ts_map
 from ...datasets import load_poisson_stats_image
 from ...image.utils import upsample_2N, downsample_2N
 
-OS_WINDOWS = sys.platform.startswith('win') and sys.version_info < (3,0)
-
-@pytest.mark.skipif('OS_WINDOWS')
 @requires_dependency('scipy')
 @requires_dependency('skimage')
 @requires_data('gammapy-extra')

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -25,8 +25,15 @@ def test_compute_ts_map(tmpdir):
         result[name] = np.nan_to_num(result[name])
         result[name] = upsample_2N(result[name], 2, order=order)
 
+<<<<<<< HEAD
     assert_allclose(1705.840212274973, result.ts.data[99, 99], rtol=1e-3)
     assert_allclose([[99], [99]], np.where(result.ts == result.ts.data.max()))
     assert_allclose(6, result.niter.data[99, 99])
     assert_allclose(1.0227934338735763e-09, result.amplitude.data[99, 99], rtol=1e-3)
+=======
+    assert_allclose(1705.840212274973, result.ts[99, 99], rtol=1e-3)
+    assert_allclose([[99], [99]], np.where(result.ts == result.ts.max()))
+    assert_allclose(3, result.niter[99, 99])
+    assert_allclose(1.0227934338735763e-09, result.amplitude[99, 99], rtol=1e-3)
+>>>>>>> Minor performace improvements to TS map computation
 

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -20,7 +20,7 @@ def test_compute_ts_map(tmpdir):
         data[_] = downsample_2N(data[_], 2, func)
 
     result = compute_ts_map(data['counts'], data['background'], data['exposure'],
-                            kernel)
+                            kernel, method='leastsq iter')
     for name, order in zip(['ts', 'amplitude', 'niter'], [2, 5, 0]):
         result[name] = np.nan_to_num(result[name])
         result[name] = upsample_2N(result[name], 2, order=order)

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -1,13 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
+
 import numpy as np
 from numpy.testing.utils import assert_allclose, assert_equal
+
 from astropy.convolution import Gaussian2DKernel
+from astropy.tests.helper import pytest
+
 from ...utils.testing import requires_dependency, requires_data
 from ...detect import compute_ts_map
 from ...datasets import load_poisson_stats_image
 from ...image.utils import upsample_2N, downsample_2N
 
+OS_WINDOWS = sys.platform.startswith('win') and sys.version_info < (3,0)
+
+@pytest.mark.skipif('OS_WINDOWS')
 @requires_dependency('scipy')
 @requires_dependency('skimage')
 @requires_data('gammapy-extra')
@@ -25,15 +33,8 @@ def test_compute_ts_map(tmpdir):
         result[name] = np.nan_to_num(result[name])
         result[name] = upsample_2N(result[name], 2, order=order)
 
-<<<<<<< HEAD
     assert_allclose(1705.840212274973, result.ts.data[99, 99], rtol=1e-3)
-    assert_allclose([[99], [99]], np.where(result.ts == result.ts.data.max()))
-    assert_allclose(6, result.niter.data[99, 99])
+    assert_allclose([[99], [99]], np.where(result.ts.data == result.ts.data.max()))
+    assert_allclose(3, result.niter.data[99, 99])
     assert_allclose(1.0227934338735763e-09, result.amplitude.data[99, 99], rtol=1e-3)
-=======
-    assert_allclose(1705.840212274973, result.ts[99, 99], rtol=1e-3)
-    assert_allclose([[99], [99]], np.where(result.ts == result.ts.max()))
-    assert_allclose(3, result.niter[99, 99])
-    assert_allclose(1.0227934338735763e-09, result.amplitude[99, 99], rtol=1e-3)
->>>>>>> Minor performace improvements to TS map computation
 

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -84,9 +84,9 @@ class SkyMap(object):
         wcs = WCS(header)
         meta = header
 
-        name = header.get('HDUNAME')
+        name = header.get('EXTNAME')
         if name is None:
-            name = header.get('EXTNAME')
+            name = header.get('HDUNAME')
         try:
             # Valitade unit string
             unit = Unit(header['BUNIT'], format='fits').to_string()
@@ -335,6 +335,7 @@ class SkyMap(object):
             # Add meta data
             header.update(self.meta)
             header['BUNIT'] = self.unit
+            header['HDUNAME'] = self.name
         else:
             header = None
         return fits.ImageHDU(data=self.data, header=header, name=self.name)

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -359,7 +359,6 @@ class SkyMap(object):
         Returns
         -------
         skymap : `SkyMap`
-<<<<<<< HEAD
             Skymap reprojected onto ``reference``.
         """
 
@@ -384,19 +383,6 @@ class SkyMap(object):
 
         return SkyMap(name=self.name, data=out[0], wcs=wcs_reference,
                       unit=self.unit, meta=self.meta)
-=======
-            Skymap reprojected onto ``refheader``.
-        """
-        from reproject import reproject_interp
-        out = reproject_interp(
-            input_data=self.to_image_hdu(),
-            output_projection=refheader,
-            *args,
-            **kwargs
-        )
-        map = SkyMap(name=self.name, data=out[0], wcs=self.wcs, unit=self.unit, meta=self.meta)
-        return map
->>>>>>> Minor performace improvements to TS map computation
 
     def show(self, viewer='mpl', **kwargs):
         """

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -359,6 +359,7 @@ class SkyMap(object):
         Returns
         -------
         skymap : `SkyMap`
+<<<<<<< HEAD
             Skymap reprojected onto ``reference``.
         """
 
@@ -383,6 +384,19 @@ class SkyMap(object):
 
         return SkyMap(name=self.name, data=out[0], wcs=wcs_reference,
                       unit=self.unit, meta=self.meta)
+=======
+            Skymap reprojected onto ``refheader``.
+        """
+        from reproject import reproject_interp
+        out = reproject_interp(
+            input_data=self.to_image_hdu(),
+            output_projection=refheader,
+            *args,
+            **kwargs
+        )
+        map = SkyMap(name=self.name, data=out[0], wcs=self.wcs, unit=self.unit, meta=self.meta)
+        return map
+>>>>>>> Minor performace improvements to TS map computation
 
     def show(self, viewer='mpl', **kwargs):
         """

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -75,9 +75,8 @@ def cash(n_observed, mu_observed):
     n_observed = np.asanyarray(n_observed, dtype=np.float64)
     mu_observed = np.asanyarray(mu_observed, dtype=np.float64)
 
-    stat = 2 * (mu_observed - n_observed * np.log(mu_observed))
-    stat = np.where(mu_observed > 0, stat, 0)
-
+    _ = mu_observed > 0
+    stat = 2 * (mu_observed[_] - n_observed[_] * np.log2(mu_observed[_]) * 0.69314718055994529)
     return stat
 
 

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -75,8 +75,8 @@ def cash(n_observed, mu_observed):
     n_observed = np.asanyarray(n_observed, dtype=np.float64)
     mu_observed = np.asanyarray(mu_observed, dtype=np.float64)
 
-    _ = mu_observed > 0
-    stat = 2 * (mu_observed[_] - n_observed[_] * np.log2(mu_observed[_]) * 0.69314718055994529)
+    stat = 2 * (mu_observed - n_observed * np.log(mu_observed))
+    stat = np.where(mu_observed > 0, stat, 0)
     return stat
 
 


### PR DESCRIPTION
This PR includes some further performance improvements to the computation of TS maps, that have been laying around on my hard disk for a while. An interesting lesson I've learned is that on most machines `np.log2(x) * 0.69314718055994529` seems to be faster than just `np.log(x)`, because of different underlying implementations in `glibc`'s `math.h` (here's a link to a [discussion on stackoverflow](http://stackoverflow.com/questions/33809789/why-are-log2-and-log1p-so-much-faster-than-log-and-log10)). While this might not be the case on any platform, I definitely see a significant (~50%) speed-up on my Linux machines. So I'm keeping the change.

Furthermore I've added a `leastsq iter` method to the TS computation function. Right now this is not particularly useful, the performance and accuracy is comparable with the other methods, but it is still a nice cross check to the standard root finding methods.

I don't request any feedback, I'll wait for Travis-CI to pass and then merge.