### PR TITLE
Further SkyMap improvements

### DIFF
--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -55,18 +55,18 @@ In the following the computation of a TS map for prepared Fermi survey data, whi
 	result = compute_ts_map(hdu_list['counts'].data, hdu_list['background'].data,
 							hdu_list['exposure'].data, kernel)
 
-The function returns a `~gammapy.detect.TSMapResult` object, that bundles all relevant
+The function returns a `~gammapy.image.SkyMapCollection` object, that bundles all relevant
 data. E.g. the time needed for the TS map computation can be checked by:
 
 .. code-block:: python
 
-	print(result.runtime)
+	print(result.meta['runtime'])
 
-The TS map itself can be accessed using the ``ts`` attribute of the `~gammapy.detect.TSMapResult` object:
+The TS map itself can be accessed using the ``ts`` attribute of the `~gammapy.image.SkyMapCollection` object:
 
 .. code-block:: python
 
-	print(result.ts.max())
+	print(result.ts.data.max())
 
 Command line tool
 -----------------

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -138,7 +138,7 @@ Functions that return more than a single value shouldn't return a list
 or dictionary of values but rather a Python Bunch result object. A Bunch
 is similar to a dict, except that it allows attribute access to the result
 values. The approach is the same as e.g. the use of `~scipy.optimize.OptimizeResult`.
-An example of how Bunches are used in gammapy is given by the `~gammapy.detect.TSMapResult`
+An example of how Bunches are used in gammapy is given by the `~gammapy.image.SkyMapCollection`
 class.
 
 .. _development-python2and3:

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -69,8 +69,8 @@ class RingBgMaker(object):
         n_on = maps['n_on']
         a_on = maps['a_on']
         exclusion = maps['exclusion']
-        maps['n_off'] = self.correlate(n_on * exclusion)
-        maps['a_off'] = self.correlate(a_on * exclusion)
+        maps['n_off'] = self.correlate(n_on.data * exclusion.data)
+        maps['a_off'] = self.correlate(a_on.data * exclusion.data)
         maps.is_off_correlated = True
 
 

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -26,7 +26,9 @@ class TestRingBgMaker:
         maps = SkyMapCollection()
         maps['n_on'] = n_on
         maps['a_on'] = n_on
-        maps['exclusion'] = n_on[100:110, 100:110] = 0
+        exclusion = np.ones((200, 200))
+        exclusion[100:110, 100:110] = 0
+        maps['exclusion'] = exclusion
         r = RingBgMaker(10, 13, 1)
         r.correlate_maps(maps)
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -26,7 +26,6 @@ __all__ = [
     'compute_ts_map',
     'compute_ts_map_multiscale',
     'compute_maximum_ts_map',
-    'TSMapResult',
 ]
 
 log = logging.getLogger(__name__)

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -86,7 +86,7 @@ def compute_ts_map_multiscale(maps, psf_parameters, scales=[0], downsample='auto
     Returns
     -------
     multiscale_result : list
-        List of `TSMapResult` objects.
+        List of `~gammapy.image.SkyMapCollection` objects.
     """
     BINSZ = abs(maps[0].header['CDELT1'])
     shape = maps[0].data.shape
@@ -162,17 +162,17 @@ def compute_ts_map_multiscale(maps, psf_parameters, scales=[0], downsample='auto
 
 def compute_maximum_ts_map(ts_map_results):
     """
-    Compute maximum TS map across a list of given `TSMapResult` objects.
+    Compute maximum TS map across a list of given ts maps.
 
     Parameters
     ----------
     ts_map_results : list
-        List of `TSMapResult` objects.
+        List of `~gammapy.image.SkyMapCollection` objects.
 
     Returns
     -------
-    TS : `TSMapResult`
-        `TSMapResult` object.
+    TS : `~gammapy.image.SkyMapCollection`
+        `~gammapy.image.SkyMapCollection` objects.
     """
 
     # Get data
@@ -236,8 +236,8 @@ def compute_ts_map(counts, background, exposure, kernel, mask=None, flux=None,
 
     Returns
     -------
-    TS : `TSMapResult`
-        `TSMapResult` object.
+    TS : `~gammapy.image.SkyMapCollection`
+        `~gammapy.image.SkyMapCollection` object.
 
 
     Notes

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -50,7 +50,7 @@ def test_compute_lima_on_off_map():
                                           maps.offexposure.data, kernel)
     
     # reproduce safe significance threshold from HESS software
-    result_lima.significance[result_lima.n_on < 5] = 0
+    result_lima.significance.data[result_lima.n_on.data < 5] = 0
 
     # Set boundary to NaN in reference image
     maps.significance.data[np.isnan(result_lima.significance)] = np.nan

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -4,10 +4,9 @@ import numpy as np
 from numpy.testing.utils import assert_allclose, assert_equal
 from astropy.convolution import Gaussian2DKernel
 from ...utils.testing import requires_dependency, requires_data
-from ...detect import compute_ts_map, TSMapResult
+from ...detect import compute_ts_map
 from ...datasets import load_poisson_stats_image
 from ...image.utils import upsample_2N, downsample_2N
-
 
 @requires_dependency('scipy')
 @requires_dependency('skimage')
@@ -26,15 +25,8 @@ def test_compute_ts_map(tmpdir):
         result[name] = np.nan_to_num(result[name])
         result[name] = upsample_2N(result[name], 2, order=order)
 
-    assert_allclose(1705.840212274973, result.ts[99, 99], rtol=1e-3)
-    assert_allclose([[99], [99]], np.where(result.ts == result.ts.max()))
-    assert_allclose(6, result.niter[99, 99])
-    assert_allclose(1.0227934338735763e-09, result.amplitude[99, 99], rtol=1e-3)
+    assert_allclose(1705.840212274973, result.ts.data[99, 99], rtol=1e-3)
+    assert_allclose([[99], [99]], np.where(result.ts == result.ts.data.max()))
+    assert_allclose(6, result.niter.data[99, 99])
+    assert_allclose(1.0227934338735763e-09, result.amplitude.data[99, 99], rtol=1e-3)
 
-    # test write method
-    filename = str(tmpdir / 'ts_test.fits')
-    result.write(filename, header=data['header'])
-    read_result = TSMapResult.read(filename)
-    for _ in ['ts', 'sqrt_ts', 'amplitude', 'niter']:
-        assert result[_].dtype == read_result[_].dtype
-        assert_equal(result[_], read_result[_])

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -104,7 +104,6 @@ def catalog_image(reference, psf, catalog='1FHL', source_type='point',
     # due to circular dependencies
     from ..cube import SpectralCube
 
-    lons, lats = SkyMap.read(reference).coordinates()
     wcs = WCS(reference.header)
     # Uses dummy energy for now to construct spectral cube
     # TODO : Fix this hack

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -252,6 +252,12 @@ class SkyMap(object):
         omega = -np.diff(xsky, axis=1)[1:, :] * np.diff(ysky, axis=0)[:, 1:]
         return Quantity(omega, 'deg2').to('sr')
 
+    def center(self):
+        """
+        Center coordinates of the sky map.
+        """
+        return SkyCoord.from_pixel(self.data.shape[0] / 2., self.data.shape[1] / 2., self.wcs)
+
     def lookup(self, position, interpolation=None, origin=0):
         """
         Lookup value at given sky position.
@@ -332,11 +338,7 @@ class SkyMap(object):
 
     def reproject(self, reference, mode='interp', *args, **kwargs):
         """
-        Reproject sky map to given reference header.
-
-        Calls `reproject.reproject.interp`, passing along ``args`` and ``kwargs``.
-
-        TODO: ``mode`` isn't use yet ... should dispatch to correct method.
+        Reproject sky map to given reference.
 
         Parameters
         ----------
@@ -499,11 +501,11 @@ class SkyMapCollection(Bunch):
     meta = None
     wcs = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, name=None, wcs=None, meta=None, **kwargs):
         # Set real class attributes 
-        self.meta = kwargs.pop('meta', None)
-        self.wcs = kwargs.pop('wcs', None)
-        self.name = kwargs.pop('name', None)
+        self.name = name
+        self.wcs = wcs
+        self.meta = meta
         
         # Everything else is stored as dict entries
         for key in kwargs:
@@ -568,6 +570,12 @@ class SkyMapCollection(Bunch):
             else:
                 log.warn("Can't save {} to file, not a sky map.".format(name))
         hdulist.writeto(filename, **kwargs)
+
+    def info(self):
+        """
+        Print summary info about the sky map collection.
+        """
+        print(str(self))
 
     def __str__(self):
         """

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from subprocess import call
 from tempfile import NamedTemporaryFile
-
+from copy import deepcopy
 import numpy as np
 
 from astropy.io import fits

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -242,7 +242,8 @@ def image_profile(profile_axis, image, lats, lons, binsz, counts=None,
         boundaries, profile values and errors.
     """
 
-    lon, lat = SkyMap.read(image).coordinates()
+    l, b = SkyMap.read(image).coordinates('galactic')
+    lon, lat = l.degree, b.degree
     mask_init = (lats[0] <= lat) & (lat < lats[1])
     mask_bounds = mask_init & (lons[0] <= lon) & (lon < lons[1])
     if mask != None:

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -33,7 +33,7 @@ class TestSkyMapPoisson():
         assert self.skymap.name == skymap.name
 
     def test_lookup(self):
-        assert self.skymap.lookup((0, 0)) == 8
+        assert self.skymap.lookup((0, 0)) == 5
 
     def test_lookup_skycoord(self):
         position = SkyCoord(0, 0, frame='galactic', unit='deg')
@@ -41,8 +41,8 @@ class TestSkyMapPoisson():
 
     def test_coordinates(self):
         coordinates = self.skymap.coordinates('galactic')
-        assert coordinates[0][98, 98] == 0
-        assert coordinates[1][98, 98] == 0
+        assert_allclose(coordinates[0][100, 100].degree, 0.01)
+        assert_allclose(coordinates[1][100, 100].degree, 0.01)
 
     def test_info(self):
         refstring = ""
@@ -68,6 +68,10 @@ class TestSkyMapPoisson():
         empty = SkyMap.empty()
         assert empty.data.shape == (200, 200)
 
+    def test_center(self):
+        center = self.skymap.center()
+        assert center.galactic.l == 0
+        assert center.galactic.b == 0
 
     @requires_data('gammapy-extra')
     def test_fill(self):

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -40,7 +40,7 @@ class TestSkyMapPoisson():
         assert self.skymap.lookup(position) == self.skymap.lookup((0, 0))
 
     def test_coordinates(self):
-        coordinates = self.skymap.coordinates()
+        coordinates = self.skymap.coordinates('galactic')
         assert coordinates[0][98, 98] == 0
         assert coordinates[1][98, 98] == 0
 
@@ -52,7 +52,7 @@ class TestSkyMapPoisson():
         refstring += "Data unit: None\n"
         refstring += "Data mean: 1.022e+00\n"
         refstring += "WCS type: ['GLON-CAR', 'GLAT-CAR']\n"
-        assert repr(self.skymap) == refstring
+        assert str(self.skymap) == refstring
 
     def test_to_quantity(self):
         q = self.skymap.to_quantity()

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -54,10 +54,10 @@ def generate_gaussian_image():
     Generate some greyscale image to run the detection on.
     """
     skymap = SkyMap.empty(nxpix=201, nypix=201, binsz=0.02)
-    GLON, GLAT = skymap.coordinates()
+    l, b = skymap.coordinates('galactic')
     sigma = 0.2
     source = Gaussian2D(1. / (2 * np.pi * (sigma / BINSZ) ** 2), 0, 0, sigma, sigma)
-    skymap.data += source(GLON, GLAT)
+    skymap.data += source(l.degree, b.degree)
     return skymap.to_image_hdu()
 
 

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -26,8 +26,9 @@ def test_compute_binning():
 def test_image_lat_profile():
     """Tests GLAT profile with image of 1s of known size and shape."""
     image = SkyMap.empty_like(FermiGalacticCenter.counts(), fill=1.)
-    lons, lats = image.coordinates()
-
+    l, b = image.coordinates('galactic')
+    lons, lats = l.degree, b.degree
+    
     counts = SkyMap.empty_like(FermiGalacticCenter.counts(), fill=1.)
     
     mask = np.zeros_like(image.data)
@@ -62,7 +63,8 @@ def test_image_lon_profile():
     """Tests GLON profile with image of 1s of known size and shape."""
     image = FermiGalacticCenter.counts()
 
-    lons, lats = SkyMap.read(image).coordinates()
+    l, b = SkyMap.read(image).coordinates('galactic')
+    lons, lats = l.degree, b.degree
     image.data = np.ones_like(image.data)
 
     counts = FermiGalacticCenter.counts()

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -205,12 +205,12 @@ def test_wcs_histogram2d():
 @requires_data('gammapy-extra')
 def test_lon_lat_rectangle_mask():
     counts = SkyMap.read(FermiGalacticCenter.counts())
-    lons, lats = counts.coordinates()
-    mask = lon_lat_rectangle_mask(lons, lats, lon_min=-1,
+    lons, lats = counts.coordinates('galactic')
+    mask = lon_lat_rectangle_mask(lons.degree, lats.degree, lon_min=-1,
                                   lon_max=1, lat_min=-1, lat_max=1)
     assert_allclose(mask.sum(), 400)
 
-    mask = lon_lat_rectangle_mask(lons, lats, lon_min=None,
+    mask = lon_lat_rectangle_mask(lons.degree, lats.degree, lon_min=None,
                                   lon_max=None, lat_min=None,
                                   lat_max=None)
     assert_allclose(mask.sum(), 80601)

--- a/gammapy/scripts/image_ts.py
+++ b/gammapy/scripts/image_ts.py
@@ -95,10 +95,10 @@ def image_ts(input_file, output_file, psf, model, scales, downsample, residual,
             fn = Path(folder) / filename_
             
             log.info('Writing {}'.format(fn))
-            result.write(str(fn), header, overwrite=overwrite)
+            result.write(str(fn), header, clobber=overwrite)
     elif results:
         log.info('Writing {}'.format(output_file))
-        results[0].write(output_file, header, overwrite=overwrite)
+        results[0].write(output_file, header, clobber=overwrite)
     else:
         log.info("No results to write to file: all scales have failed")
   

--- a/gammapy/scripts/tests/test_image_ts.py
+++ b/gammapy/scripts/tests/test_image_ts.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 from numpy.testing.utils import assert_allclose
 from ...utils.testing import requires_dependency, requires_data
-from ...detect import TSMapResult
+from ...image import SkyMapCollection
 from ...datasets import load_poisson_stats_image
 from ..image_ts import image_ts_main
 from astropy.io import fits
@@ -69,15 +69,8 @@ def test_command_line_gammapy_image_ts(tmpdir):
     for scale_test in scales_test_list:
         output_filename_ = output_filename.replace('.fits', '_{0}.fits'.format(scale_test))
         expected_filename_ = expected_filename.replace('.fits', '_{0}.fits'.format(scale_test))
-
-        read_console = TSMapResult.read(output_filename_)
-        for name, order in zip(['ts', 'sqrt_ts', 'amplitude', 'niter'], [1, 1, 1, 0]):
-                read_console[name] = np.nan_to_num(read_console[name])
-        output_filename_without_nan_ = output_filename_without_nan.replace('.fits',
-                                                                           '_{0}.fits'.format(scale_test))
-        read_console.write(output_filename_without_nan_, header=data['header'])
-
-        expected_hdu = fits.open(expected_filename_)[0]
-        console_hdu = fits.open(output_filename_without_nan_)[0]
-
-        assert_allclose(expected_hdu.data, console_hdu.data, rtol=1e-2, atol=1e-15)
+        actual = SkyMapCollection.read(output_filename_)
+        expected = SkyMapCollection.read(expected_filename_)
+        
+        for name in ['ts', 'sqrt_ts', 'amplitude', 'niter']:
+            assert_allclose(np.nan_to_num(actual[name].data), expected[name].data, rtol=1e-2, atol=1e-15)


### PR DESCRIPTION
This PR includes further improvements to the `SkyMap` and `SkyMapCollection` classes:
* Implement different modes for `.reproject()`
* Implement a `.center()` method
* Implement a `.copy()` method
* Change default return type of `.coordinates()` to `SkyCoord`
* Fix `binarize()` method and rename it to `threshold()`. Any suggestions for better names?
* The `SkyMapCollection` can be initialized by passing `np.ndarray` objects and the `SkyMap` object is then created internally without WCS. This avoids instantiating explicitly a lot of sky maps in functions that return several maps such as `compute_ts_map` (see [here](https://github.com/gammapy/gammapy/compare/master...adonath:skymap_improvements?expand=1#diff-fa4f6a49a25a7de5ec4fb23cbfc9e3afR329)). 
* The `TSMapResult` object was removed and replaced by the `SkyMapCollection`. 
* Docs and test were adapted to the changes.
