### PR TITLE
add interpolation for EnergyDependentTablePSF

### DIFF
--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -20,10 +20,11 @@ class TestFermiGalacticCenter:
     @requires_dependency('scipy')
     def test_psf(self):
         psf = FermiGalacticCenter.psf()
-        energy = Quantity(100, 'GeV')
+        energy = Quantity(110, 'GeV')
         fraction = 0.68
-        angle = psf.containment_radius(energy, fraction)
-        assert_quantity_allclose(angle, Angle(0.1927459865412511, 'deg'))
+        interpol_param = dict(method='nearest', bounds_error=False)
+        angle = psf.containment_radius(energy, fraction, interpol_param)
+        assert_quantity_allclose(angle, Angle(0.1927459865412511, 'deg'), rtol=1e-2)
 
     def test_counts(self):
         counts = FermiGalacticCenter.counts()
@@ -55,10 +56,11 @@ class TestFermiVelaRegion:
     @requires_dependency('scipy')
     def test_psf(self):
         psf = FermiVelaRegion.psf()
-        energy = Quantity(100, 'GeV')
+        energy = Quantity(110, 'GeV')
         fraction = 0.68
-        angle = psf.containment_radius(energy, fraction)
-        assert_quantity_allclose(angle, Angle(0.13185321269896136, 'deg'))
+        interpol_param = dict(method='nearest', bounds_error=False)
+        angle = psf.containment_radius(energy, fraction, interpol_param)
+        assert_quantity_allclose(angle, Angle(0.13185321269896136, 'deg'), rtol=1e-1)
 
     def test_diffuse_model(self):
         diffuse_model = FermiVelaRegion.diffuse_model()

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -564,6 +564,27 @@ class EnergyDependentTablePSF(object):
 
         return table_psf
 
+    def table_psf_at_energy_old(self, energy, **kwargs):
+        """TablePSF at a given energy.
+
+        Extra ``kwargs`` are passed to the `~gammapy.irf.TablePSF` constructor.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy
+
+        Returns
+        -------
+        psf : `~gammapy.irf.TablePSF`
+            PSF
+        """
+        if not isinstance(energy, Quantity):
+            raise ValueError("energy must be a Quantity object.")
+
+        energy_index = self._energy_index(energy)
+        return self._get_1d_table_psf(energy_index, **kwargs)
+
     def table_psf_in_energy_band(self, energy_band, spectral_index=2, spectrum=None, **kwargs):
         """Average PSF in a given energy band.
 

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -431,7 +431,7 @@ class EnergyDependentTablePSF(object):
 
         # Default for exposure
         exposure = exposure or Quantity(np.ones(len(energy)), 'cm^2 s')
-        
+
         if not isinstance(energy, Quantity):
             raise ValueError("energy must be a Quantity object.")
         if not isinstance(offset, Angle):
@@ -540,7 +540,6 @@ class EnergyDependentTablePSF(object):
         ee, off = np.meshgrid(energy.value, offset.value, indexing='ij')
         shape = ee.shape
         pix_coords = np.column_stack([ee.flat, off.flat])
-
         data_interp = interpolator(pix_coords)
         return Quantity(data_interp.reshape(shape), self.psf_value.unit)
 

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -563,27 +563,6 @@ class EnergyDependentTablePSF(object):
 
         return table_psf
 
-    def table_psf_at_energy_old(self, energy, **kwargs):
-        """TablePSF at a given energy.
-
-        Extra ``kwargs`` are passed to the `~gammapy.irf.TablePSF` constructor.
-
-        Parameters
-        ----------
-        energy : `~astropy.units.Quantity`
-            Energy
-
-        Returns
-        -------
-        psf : `~gammapy.irf.TablePSF`
-            PSF
-        """
-        if not isinstance(energy, Quantity):
-            raise ValueError("energy must be a Quantity object.")
-
-        energy_index = self._energy_index(energy)
-        return self._get_1d_table_psf(energy_index, **kwargs)
-
     def table_psf_in_energy_band(self, energy_band, spectral_index=2, spectrum=None, **kwargs):
         """Average PSF in a given energy band.
 
@@ -653,25 +632,6 @@ class EnergyDependentTablePSF(object):
         """
         # TODO: useless at the moment ... support array inputs or remove!
         psf = self.table_psf_at_energy(energy, interp_kwargs)
-        return psf.containment_radius(fraction)
-
-    def containment_radius_old(self, energy, fraction):
-        """Containment radius.
-
-        Parameters
-        ----------
-        energy : `~astropy.units.Quantity`
-            Energy
-        fraction : float
-            Containment fraction in %
-
-        Returns
-        -------
-        radius : `~astropy.units.Quantity`
-            Containment radius in deg
-        """
-        # TODO: useless at the moment ... support array inputs or remove!
-        psf = self.table_psf_at_energy_old(energy)
         return psf.containment_radius(fraction)
 
     def integral(self, energy, offset_min, offset_max):

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -636,7 +636,7 @@ class EnergyDependentTablePSF(object):
         # making a `TablePSF`.
         return TablePSF(self.offset, total_psf_value, **kwargs)
 
-    def containment_radius(self, energy, fraction):
+    def containment_radius(self, energy, fraction, interp_kwargs=None):
         """Containment radius.
 
         Parameters
@@ -652,7 +652,26 @@ class EnergyDependentTablePSF(object):
             Containment radius in deg
         """
         # TODO: useless at the moment ... support array inputs or remove!
-        psf = self.table_psf_at_energy(energy)
+        psf = self.table_psf_at_energy(energy, interp_kwargs)
+        return psf.containment_radius(fraction)
+
+    def containment_radius_old(self, energy, fraction):
+        """Containment radius.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy
+        fraction : float
+            Containment fraction in %
+
+        Returns
+        -------
+        radius : `~astropy.units.Quantity`
+            Containment radius in deg
+        """
+        # TODO: useless at the moment ... support array inputs or remove!
+        psf = self.table_psf_at_energy_old(energy)
         return psf.containment_radius(fraction)
 
     def integral(self, energy, offset_min, offset_max):

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -58,7 +58,8 @@ def test_to_table_psf(energy):
 
     table_psf = psf.to_table_psf(theta)
     interpol_param = dict(method='nearest', bounds_error=False)
-    table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
+    #table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
+    table_psf_at_energy = table_psf.table_psf_at_energy_old(energy)
     psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
     
     containment = np.linspace(0, 0.95, 10)

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -15,7 +15,7 @@ from ...irf import EnergyDependentMultiGaussPSF
 from ...datasets import gammapy_extra
 
 
-ENERGIES = Quantity([1, 10, 30], 'TeV')
+ENERGIES = Quantity([1, 10, 25], 'TeV')
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
@@ -58,8 +58,7 @@ def test_to_table_psf(energy):
 
     table_psf = psf.to_table_psf(theta)
     interpol_param = dict(method='nearest', bounds_error=False)
-    #table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
-    table_psf_at_energy = table_psf.table_psf_at_energy_old(energy)
+    table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
     psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
     
     containment = np.linspace(0, 0.95, 10)

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -57,7 +57,8 @@ def test_to_table_psf(energy):
     theta = Angle(0, 'deg')
 
     table_psf = psf.to_table_psf(theta)
-    table_psf_at_energy = table_psf.table_psf_at_energy(energy)
+    interpol_param = dict(method='nearest', bounds_error=False)
+    table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
     psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
     
     containment = np.linspace(0, 0.95, 10)

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -100,7 +100,9 @@ def test_EnergyDependentTablePSF():
     # assert_quantity_allclose(actual, desired)
 
     psf1 = psf.table_psf_at_energy(energy)
-
+    containment = np.linspace(0, 0.95, 3)
+    containment_radius = psf1.containment_radius(containment)
+    assert_allclose(containment_radius, Angle([0,0.19426847,1.03806372], "deg"))
     # TODO: test average_psf
     # psf2 = psf.psf_in_energy_band(energy_band, spectrum)
 


### PR DESCRIPTION
@adonath 
As we discussed on chat, I changed the way you define the method ```table_psf_at_energy()``` for the class ```EnergyDependentTablePSF``` in order to really interpolate on the energy in a linear way not a closest interpolation.

I take the same evaluate() method than the one I defined in the EnergyArrayClass. As you proposed maybe a good idea would be to directly store this EnergyDependentTablePSF as an EnergyOffsetArray class.

Maybe in order to have a short PR, we can leave it as it is for the moment if you agree with what I changed of course. It's just that I need this interpolation to create the mean PSF images for a set of observations.