### PR TITLE
Update readthedocs links from .org to .io

### DIFF
--- a/LONG_DESCRIPTION.rst
+++ b/LONG_DESCRIPTION.rst
@@ -1,6 +1,6 @@
 
 * Code: https://github.com/gammapy/gammapy
-* Docs: https://gammapy.readthedocs.org/
+* Docs: http://docs.gammapy.org/
 
 **Gammapy** is an open source (BSD licensed) gamma-ray astronomy Python package.
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ help:
 	@echo ' More info:'
 	@echo ''
 	@echo ' * Gammapy code: https://github.com/gammapy/gammapy'
-	@echo ' * Gammapy docs: https://gammapy.readthedocs.org/'
+	@echo ' * Gammapy docs: http://docs.gammapy.org/'
 	@echo ''
 	@echo ' Environment:'
 	@echo ''

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Gammapy
 A Python Package for Gamma-ray Astronomy.
 
 * Code: https://github.com/gammapy/gammapy
-* Docs: https://gammapy.readthedocs.org/
+* Docs: http://docs.gammapy.org/
 * License: BSD-3
 
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
@@ -32,7 +32,7 @@ Status shields
     :alt: Benchmarks
 
 * .. image:: https://readthedocs.org/projects/gammapy/badge/?version=latest
-    :target: https://readthedocs.org/projects/gammapy/?badge=latest
+    :target: http://docs.gammapy.org/en/latest/
     :alt: Documentation Status
 
 * .. image:: http://img.shields.io/pypi/l/gammapy.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,22 +62,22 @@ setup_cfg = dict(conf.items('metadata'))
 # so we override the `intersphinx_mapping` entry pointing to the stable docs version
 # that is listed in `astropy/sphinx/conf.py`.
 intersphinx_mapping['astropy'] = ('http://docs.astropy.org/en/latest/', None)
-intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.org/en/latest/', None)
-intersphinx_mapping['gadf'] = ('http://gamma-astro-data-formats.readthedocs.org/en/latest/', None)
+intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/', None)
+intersphinx_mapping['gadf'] = ('http://gamma-astro-data-formats.readthedocs.io/en/latest/', None)
 
 # Extend intersphinx_mapping with packages we use in gammapy
 intersphinx_mapping['uncertainties'] = ('http://pythonhosted.org/uncertainties/', None)
 intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
 intersphinx_mapping['sklearn'] = ('http://scikit-learn.org/stable/', None)
-intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.org/en/latest/', None)
-intersphinx_mapping['wcsaxes'] = ('http://wcsaxes.readthedocs.org/en/latest/', None)
-intersphinx_mapping['aplpy'] = ('http://aplpy.readthedocs.org/en/latest/', None)
-intersphinx_mapping['naima'] = ('http://naima.readthedocs.org/en/latest/', None)
-intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.org/en/latest/', None)
-intersphinx_mapping['gwcs'] = ('http://gwcs.readthedocs.org/en/latest/', None)
-intersphinx_mapping['astroplan'] = ('http://astroplan.readthedocs.org/en/latest/', None)
-# intersphinx_mapping['astroquery'] = ('http://astroquery.readthedocs.org/en/latest/', None)
+intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/', None)
+intersphinx_mapping['wcsaxes'] = ('http://wcsaxes.readthedocs.io/en/latest/', None)
+intersphinx_mapping['aplpy'] = ('http://aplpy.readthedocs.io/en/latest/', None)
+intersphinx_mapping['naima'] = ('http://naima.readthedocs.io/en/latest/', None)
+intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/', None)
+intersphinx_mapping['gwcs'] = ('http://gwcs.readthedocs.io/en/latest/', None)
+intersphinx_mapping['astroplan'] = ('http://astroplan.readthedocs.io/en/latest/', None)
+# intersphinx_mapping['astroquery'] = ('http://astroquery.readthedocs.io/en/latest/', None)
 # intersphinx_mapping['astroml'] = ('http://www.astroml.org/', None)
 
 

--- a/docs/dataformats/file_formats.rst
+++ b/docs/dataformats/file_formats.rst
@@ -4,7 +4,7 @@ File formats
 ============
 
 .. note:: This section is not very useful for astronomers trying to get some analysis done.
-    If this is you, maybe try to use the search field to find the specific info / method you want? 
+    If this is you, maybe try to use the search field to find the specific info / method you want?
     The info is for developers or advanced users that are writing analysis scripts.
 
 This section gives an introdution to the various file formats used in various
@@ -20,7 +20,7 @@ Introduction
 ------------
 
 In Gammapy we use existing file formats by
-`Fermi-LAT <http://fermi.gsfc.nasa.gov/>`__ and 
+`Fermi-LAT <http://fermi.gsfc.nasa.gov/>`__ and
 `CTA <https://www.cta-observatory.org/>`__ where available.
 
 This increases inter-operability with the
@@ -44,17 +44,17 @@ Or we could define a JSON file format for fit results:
 .. code-block:: json
 
    {
-       "convergence": true, 
+       "convergence": true,
        "sources": [
            {
-               "type": "point", 
+               "type": "point",
                "parameters": { "y": 3.2, "x": 4.9, "flux": 99 }
-           }, 
+           },
            {
-               "type": "gauss", 
+               "type": "gauss",
                "parameters": { "y": -2.3, "x": 3.3, "stddev": 0.13, "flux": 49 }
            }
-       ], 
+       ],
        "likelihood": 4.2
    }
 
@@ -64,7 +64,7 @@ we can store and exchange any information between tools written in any programmi
 All we have to do it agree on the structure
 (e.g. to use XML and the fact that there's ``psf`` and ``parameter`` elements,
 and that ``parameter`` elements have ``name`` and ``value`` attributes)
-and semantics (e.g. that the ``stddev`` parameter of the ``gauss`` PSF is the Gaussian width in degrees). 
+and semantics (e.g. that the ``stddev`` parameter of the ``gauss`` PSF is the Gaussian width in degrees).
 
 If we don't write the structure down somewhere everyone will invent their own format,
 severly limiting our ability as a community to share results and scripts and build up analysis pipelines
@@ -101,7 +101,7 @@ encounter at some point in your life as a gamma-ray astronomer.
 ====== ========= ==== ===== ===== ===== ======
 Format File type Supported data content Schema
 ------ --------- ---------------------- ------
-\                Meta Table Array Tree 
+\                Meta Table Array Tree
 ====== ========= ==== ===== ===== ===== ======
 INI    text      Yes  No    No    No    Yes
 CSV    text      No   Yes   No    No    Yes
@@ -114,7 +114,7 @@ ROOT   binary    No   Yes   Yes   Yes   No
 
 Almost all entries in the above table are debatable ... here's some caveats:
 
-* The definition of "text" or "binary" file type given here should be read as 
+* The definition of "text" or "binary" file type given here should be read as
   "are files of this type in gamma-ray astronomy commonly opened up in text editors"?
   In reality the distinction is not always clear, e.g. XML can contain binary data
   and FITS contains text headers.
@@ -136,7 +136,7 @@ INI
 are the most easy to write and edit for humans and can contain ``#`` comments
 and are thus a good for configuration files.
 file extensions of ``.ini``, ``.conf`` and ``.cfg`` are common.
-Astropy bundles `configobj <http://configobj.readthedocs.org/>`__ to read, write and validate
+Astropy bundles `configobj <http://configobj.readthedocs.io/>`__ to read, write and validate
 INI files ... to use it in your code
 
 .. code-block:: python
@@ -161,7 +161,7 @@ as well as astronomy table programs such as e.g.
 `TOPCAT <http://www.star.bris.ac.uk/~mbt/topcat/>`__.
 Since it's a simple text format it's easy to read or edit in any text editor or
 put under version control (using e.g. `git <http://git-scm.com/>`__ or
-`SVN <http://en.wikipedia.org/wiki/Apache_Subversion>`__). 
+`SVN <http://en.wikipedia.org/wiki/Apache_Subversion>`__).
 CSV files are not standardised (there's many variants which causes problems in practice),
 don't support metadata (e.g. units or descriptions of columns).
 
@@ -170,7 +170,7 @@ been defined with a clear CSV format specification and associated metadata in an
 (see also `here <https://github.com/astropy/astropy-APEs/pull/7>`__).
 
 To read and write CSV data from Python you can use the extensible `astropy.io.ascii` methods
-via the `unified Astropy table I/O interface <http://astropy.readthedocs.org/en/latest/io/unified.html>`__
+via the `unified Astropy table I/O interface <http://docs.astropy.org/en/latest/io/unified.html>`__
 
 .. code-block:: python
 
@@ -179,7 +179,7 @@ via the `unified Astropy table I/O interface <http://astropy.readthedocs.org/en/
    table.write('measurements.tex', format='latex')
 
 There's also the
-`Python standard library csv module <http://pymotw.com/2/csv/>`__ as well as the 
+`Python standard library csv module <http://pymotw.com/2/csv/>`__ as well as the
 `numpy text I/O methods <http://docs.scipy.org/doc/numpy/reference/routines.io.html#text-files>`__ and the
 `pandas text I/O methods <http://pandas.pydata.org/pandas-docs/stable/io.html>`__ ...
 each have certain advantages / disadvantages (e.g. availability, features, speed).
@@ -221,7 +221,7 @@ possible to exchange those files and read them from C++, Python (via
 `PyROOT <http://root.cern.ch/drupal/content/pyroot>`__ or  `rootpy <http://www.rootpy.org/>`__).
 Access to your own serialised C++ objects is only possible if you distribute ROOT and
 a C++ library ... but storing data this way is anyways a bad idea
-(see e.g. `here <https://www.youtube.com/watch?v=7KnfGDajDQw>`__).  
+(see e.g. `here <https://www.youtube.com/watch?v=7KnfGDajDQw>`__).
 
 TODO: give examples how to read / convert ROOT data (e.g. to FITS).
 
@@ -301,7 +301,7 @@ The following tools are available for schema validation of the file formats list
 use of such schemas
 
 * http://embray.github.io/PyFITS/schema/users_guide/users_schema.html
-* https://groups.google.com/d/msg/astropy-dev/CFGnVguRlgs/yObfzPTWvNkJ 
+* https://groups.google.com/d/msg/astropy-dev/CFGnVguRlgs/yObfzPTWvNkJ
 * http://spacetelescope.github.io/understanding-json-schema/index.html
 
 With Gammapy
@@ -312,7 +312,7 @@ data formats (e.g. event lists, ...).
 
 Useful links
 ------------
- 
-* http://sedfitter.readthedocs.org/en/stable/creating_model_packages.html#sed-files
+
+* http://sedfitter.readthedocs.io/en/stable/creating_model_packages.html#sed-files
 * http://fits.gsfc.nasa.gov/fits_registry.html
- 
+

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -131,7 +131,7 @@ Python 2 and 3 support
 We support Python 2.7 and 3.4 or later using a single code base.
 This is the strategy adopted by most scientific Python projects and a good starting point to learn about it is
 `here <http://python3porting.com/noconv.html>`__ and
-`here <http://astropy.readthedocs.org/en/latest/development/codeguide.html#writing-portable-code-for-python-2-and-3>`__.
+`here <http://docs.astropy.org/en/latest/development/codeguide.html#writing-portable-code-for-python-2-and-3>`__.
 
 For developers, it would have been nice to only support Python 3 in Gammapy.
 But the CIAO and Fermi Science tools software are distributed with Python 2.7
@@ -152,7 +152,7 @@ weren't available for testing on travis-ci.
 Wipe readthedocs
 ----------------
 
-As described `here <http://read-the-docs.readthedocs.org/en/latest/builds.html#deleting-a-stale-or-broken-build-environment>`__,
+As described `here <http://read-the-docs.readthedocs.io/en/latest/builds.html#deleting-a-stale-or-broken-build-environment>`__,
 if the docs on readthedocs show old stuff, you need to first log in `here <https://readthedocs.org/accounts/login/>`__
 and then wipe it to create a fresh / clean version by hitting this URL::
 
@@ -355,7 +355,7 @@ Pixel coordinate convention
 
 All code in Gammapy should follow the Astropy pixel coordinate convention that the center of the first pixel
 has pixel coordinates ``(0, 0)`` (and not ``(1, 1)`` as shown e.g. in ds9).
-It's currently documented `here <http://photutils.readthedocs.org/en/latest/photutils/overview.html#coordinate-conventions>`__
+It's currently documented `here <http://photutils.readthedocs.io/en/latest/photutils/overview.html#coordinate-conventions>`__
 but I plan to document it in the Astropy docs soon (see `issue 2607 <https://github.com/astropy/astropy/issues/2607>`__).
 
 You should use ``origin=0`` when calling any of the pixel to world or world to pixel coordinate transformations in `astropy.wcs`.
@@ -705,7 +705,7 @@ the unicode literals warnings to clean up the output of the tool:
     click.disable_unicode_literals_warning = True
 
 See `here <http://click.pocoo.org/5/python3/#unicode-literals>`_ for further
-information.  
+information.
 
 
 BSD or GPL license?
@@ -923,16 +923,16 @@ The Gammapy tests contain a mechanism to track changes in these exporters.
 
 In the ``gammapy-extra`` repository there is a script ``test_datasets/reference/make_reference_files.py`` that reads
 IRF files from different chains and prints the output of the ``__str__`` method to a file. It also creates a YAML file
-holding information about the datastore used for each chain, the observations used, etc. 
+holding information about the datastore used for each chain, the observations used, etc.
 
 
 The test ``gammapy/irf/tests/test_hess_chains.py`` load exactly the same files as the script and compares the output of the
 ``__str__`` function to the reference files on disk. That way all changes in the exporters or the way the IRF files are read by
-Gammapy can be tracked. So, if you made changes to the H.E.S.S. IRF exporters you have to run the ``make_reference_files.py`` script 
+Gammapy can be tracked. So, if you made changes to the H.E.S.S. IRF exporters you have to run the ``make_reference_files.py`` script
 again to ensure the passing of all Gammapy tests.
 
 
-If you want to compare the IRF files between two different datastores (to compare between to chains or fits productions) you have to 
+If you want to compare the IRF files between two different datastores (to compare between to chains or fits productions) you have to
  manually edit the YAML file written by ``make_reference_files.py`` and include the info which datastore should be compared to which reference file.
 
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -9,7 +9,7 @@ Developer documentation
 The developer documentation is a collection of notes for Gammapy developers and maintainers.
 
 If something is not covered here, have a look at the very extensive Astropy developer documentation
-`here <http://astropy.readthedocs.org/en/latest/#developer-documentation>`__,
+`here <http://docs.astropy.org/en/latest/#developer-documentation>`__,
 we do most things the same way.
 
 But you don't have to read all this stuff if you want to contribute something to Gammapy.

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -45,7 +45,7 @@ Pre release
 
    This can be used to take notes and discuss any release-related issues.
 
-#. Follow the instructions `here <http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html#updating-to-the-latest-template-files>`__
+#. Follow the instructions `here <http://docs.astropy.org/en/latest/development/affiliated-packages.html#updating-to-the-latest-template-files>`__
    to check that the astropy-helpers sub-module in Gammapy is pointing to the latest stable astropy-helpers release
    and whether there have been any fixes / changes to the Astropy
    `package-template <https://github.com/astropy/package-template/blob/master/TEMPLATE_CHANGES.md>`__
@@ -77,10 +77,10 @@ These are the steps you should do on the day of the release:
 #. Update the Gammapy version in the :ref:`install` section.
 #. Mention release in the :ref:`gammapy_news` section.
 #. Follow the instructions how to release an Astropy affiliated package
-   `here <http://astropy.readthedocs.org/en/latest/development/affiliated-packages.html#releasing-an-affiliated-package>`__.
+   `here <http://docs.astropy.org/en/latest/development/affiliated-packages.html#releasing-an-affiliated-package>`__.
 #. Check that the tarball and description (which is from ``LONG_DESCRIPTION.rst``) on PyPI is OK.
 #. Update the Gammapy stable branch to point to the new tag
-   as described `here <http://astropy.readthedocs.org/en/latest/development/releasing.html>`__.
+   as described `here <http://docs.astropy.org/en/latest/development/releasing.html>`__.
 #. Add the new version on readthedocs.
 #. Make a pull request that updates the Gammapy version number in this file to trigger a conda package build:
    https://github.com/astropy/conda-builder-affiliated/blob/master/requirements.txt

--- a/docs/image/bounding_box.rst
+++ b/docs/image/bounding_box.rst
@@ -132,13 +132,13 @@ Before inventing our own, let's look at what kinds of representations others hav
 
   As for `scipy.ndimage`, as far as I can see, ``bbox`` is not used elsewhere in `skimage`.
 
-* `photutils` has this `coordinate convention <http://photutils.readthedocs.org/en/latest/photutils/overview.html#coordinate-conventions>`__.
+* `photutils` has this `coordinate convention <http://photutils.readthedocs.io/en/latest/photutils/overview.html#coordinate-conventions>`__.
   Looking at the `photutils.aperture_photometry` implementation, it looks like they don't have an official ``bbox`` representation,
   but simply compute ``(x_min, x_max, y_min, y_max)`` where needed and then use ``data[y_min:y_max, x_min:x_max]`` views.
   TODO: update once this is in: https://github.com/astropy/astropy/issues/2607
 
-* `imutils <http://imutils.readthedocs.org/en/latest/>`__ has a
-  `Cutout <http://imutils.readthedocs.org/en/latest/api/imutils.Cutout.html>`__ class.
+* `imutils <http://imutils.readthedocs.io/en/latest/>`__ has a
+  `Cutout <http://imutils.readthedocs.io/en/latest/api/imutils.Cutout.html>`__ class.
 
 I also found
 `this <http://stackoverflow.com/questions/9525313/rectangular-bounding-box-around-blobs-in-a-monochrome-image-using-python>`__

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -11,10 +11,10 @@
 .. _Numpy: http://www.numpy.org/
 .. _Astropy: http://astropy.org
 .. _affiliated package: http://www.astropy.org/affiliated/index.html
-.. _reproject: http://reproject.readthedocs.org
-.. _photutils: http://photutils.readthedocs.org
-.. _astroplan: http://astroplan.readthedocs.org
-.. _gwcs: http://gwcs.readthedocs.org
+.. _reproject: http://reproject.readthedocs.io
+.. _photutils: http://photutils.readthedocs.io
+.. _astroplan: http://astroplan.readthedocs.io
+.. _gwcs: http://gwcs.readthedocs.io
 .. _wcsaxes: https://github.com/astrofrog/wcsaxes
 .. _iminuit: https://github.com/iminuit/iminuit
 .. _probfit: https://github.com/iminuit/probfit
@@ -33,7 +33,7 @@
 .. _pip: https://pip.pypa.io/en/stable/
 .. _conda: http://conda.pydata.org/
 .. _PyFACT: http://adsabs.harvard.edu/abs/2012AIPC.1505..789R
-.. _healpy: https://healpy.readthedocs.org/en/latest/
+.. _healpy: https://healpy.readthedocs.io/en/latest/
 .. _PyYAML: https://pypi.python.org/pypi/PyYAML/
 .. _emcee: http://dan.iel.fm/emcee/current/
 .. _ctapipe: https://github.com/cta-observatory/ctapipe
@@ -63,7 +63,7 @@
 .. _MAGIC: https://magic.mpp.mpg.de/
 .. _Fermi-LAT: http://fermi.gsfc.nasa.gov/
 .. _FermiPy: https://github.com/fermiPy/fermipy
-.. _gadf: http://gamma-astro-data-formats.readthedocs.org/
+.. _gadf: http://gamma-astro-data-formats.readthedocs.io/
 
 .. _April 2016 IACT data meeting: https://github.com/open-gamma-ray-astro/2016-04_IACT_DL3_Meeting/
 
@@ -78,9 +78,9 @@
 
 .. _Gammapy mailing list: http://groups.google.com/group/gammapy
 .. _Gammapy Github page: https://github.com/gammapy/gammapy
-.. _Gammapy documentation: https://gammapy.readthedocs.org/
+.. _Gammapy documentation: http://docs.gammapy.org/
 .. _Gammapy project summary on Open HUB: https://www.openhub.net/p/gammapy
-.. _Gammapy page on PyPI: https://pypi.python.org/pypi/gammapy 
+.. _Gammapy page on PyPI: https://pypi.python.org/pypi/gammapy
 .. _Gammapy contributors page on Github: https://github.com/gammapy/gammapy/graphs/contributors
 .. _Slack: https://slack.com/
 .. _Gammapy on Slack: https://gammapy.slack.com

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -31,7 +31,7 @@ Some references (please add what you find useful
 * https://github.com/nanograv/PINT
 * http://www.astroml.org/modules/classes.html#module-astroML.time_series
 * http://www.astroml.org/book_figures/chapter10/index.html
-* http://astropy.readthedocs.org/en/latest/api/astropy.stats.bayesian_blocks.html
+* http://docs.astropy.org/en/latest/api/astropy.stats.bayesian_blocks.html
 * https://github.com/samconnolly/DELightcurveSimulation
 * https://github.com/cokelaer/spectrum
 * https://github.com/YSOVAR/YSOVAR
@@ -95,7 +95,7 @@ E.g. when converting celestial (RA/DEC) to horizontal (ALT/AZ) coordinates, the
 This is done automatically by `astropy.coordinates.AltAz` when the
 `astropy.coordinates.AltAz.obstime` is set with a `~astropy.time.Time` object in any scale,
 no need for explicit time scale transformations in Gammapy
-(although if you do want to explicitly compute it, it's easy, see `here <http://astropy.readthedocs.org/en/latest/time/index.html#sidereal-time>`__).
+(although if you do want to explicitly compute it, it's easy, see `here <http://docs.astropy.org/en/latest/time/index.html#sidereal-time>`__).
 
 The "Time Systems in a nutshell" section `here <http://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html>`__
 gives a good, brief explanation of the differences between the relevant time scales ``UT1``, ``UTC`` and ``TT``.

--- a/docs/tutorials/gammapy-spectrum/index.rst
+++ b/docs/tutorials/gammapy-spectrum/index.rst
@@ -20,7 +20,7 @@ into this folder
 
     mkdir gammapy_crab_analysis
     cd gammapy_crab_analysis
-    wget https://gammapy.readthedocs.org/en/latest/_downloads/spectrum_analysis_example.yaml
+    wget http://docs.gammapy.org/en/latest/_downloads/spectrum_analysis_example.yaml
 
 Now run
 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -66,11 +66,11 @@ It's possible to learn the basics within a day and to become productive within a
 * Tom Robitaille Python for scientists workshop –– http://www2.mpia-hd.mpg.de/~robitaille/PY4SCI_SS_2015/
 * Scientific Python lecture notes –– https://scipy-lectures.github.io/
 * Practical Python for astronomers — http://python4astronomers.github.io
-* MPIK Astropy workshop — https://astropy4mpik.readthedocs.org/
+* MPIK Astropy workshop — https://astropy4mpik.readthedocs.io/
 * CEA Python for astronomers workshop –– https://github.com/kosack/CEAPythonWorkshopForAstronomers
 * ctools — http://cta.irap.omp.eu/ctools-devel/
 * Astropy tutorials — http://www.astropy.org/astropy-tutorials/
-* Naima examples — http://naima.readthedocs.org/en/latest/
+* Naima examples — http://naima.readthedocs.io/en/latest/
 * Fermi ScienceTools analysis threads ––– http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/
 * CIAO Sherpa threads ––– http://cxc.harvard.edu/sherpa/threads/index.html
 * `Astropy tutorial by Axel Donath from December 2013

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -14,4 +14,4 @@ All code and tests should eventually go in the Gammapy package.
 Note that we also have example scripts in the `docs` folder and example IPython notebooks
 in the `gammapy-extra` repo.
 
-See info at: https://gammapy.readthedocs.org/
+See info at: http://docs.gammapy.org/

--- a/examples/example_make_iact_data_index_tables.py
+++ b/examples/example_make_iact_data_index_tables.py
@@ -1,7 +1,7 @@
 """Example how to construct index tables.
 
-* Observation index: http://gamma-astro-data-formats.readthedocs.org/en/latest/data_storage/obs_index/index.html
-* HDU index: http://gamma-astro-data-formats.readthedocs.org/en/latest/data_storage/hdu_index/index.html
+* Observation index: http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/obs_index/index.html
+* HDU index: http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/hdu_index/index.html
 * Dataset examples:
   * https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4-hd-hap-prod2
   * https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4-pa

--- a/gammapy/__init__.py
+++ b/gammapy/__init__.py
@@ -4,7 +4,7 @@ Gammapy: A Python package for gamma-ray astronomy
 =================================================
 
 * Code: https://github.com/gammapy/gammapy
-* Docs: https://gammapy.readthedocs.org/
+* Docs: http://docs.gammapy.org/
 
 The top-level `gammapy` namespace is almost empty,
 it only contains this:

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -33,7 +33,7 @@ class SkyCube(object):
     Can be used e.g. for Fermi or GALPROP diffuse model cubes.
 
     Note that there is a very nice ``SkyCube`` implementation here:
-    http://spectral-cube.readthedocs.org/en/latest/index.html
+    http://spectral-cube.readthedocs.io/en/latest/index.html
 
     Here is some discussion if / how it could be used:
     https://github.com/radio-astro-tools/spectral-cube/issues/110

--- a/gammapy/data/observation.py
+++ b/gammapy/data/observation.py
@@ -50,7 +50,7 @@ class ObservationTable(Table):
     @lazyproperty
     def _index_dict(self):
         """Dict containing row index for all obs ids"""
-        # TODO: Switch to http://astropy.readthedocs.org/en/latest/table/indexing.html once it is more stable
+        # TODO: Switch to http://docs.astropy.org/en/latest/table/indexing.html once it is more stable
         temp = (zip(self['OBS_ID'], np.arange(len(self))))
         return dict(temp)
 

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -55,7 +55,7 @@ class ExclusionMask(SkyMap):
         """Create exclusion mask from ds9 regions file
 
         Uses the pyregion package
-        (http://pyregion.readthedocs.org/en/latest/index.html)
+        (http://pyregion.readthedocs.io/en/latest/index.html)
 
         Parameters
         ----------

--- a/gammapy/image/plotting.py
+++ b/gammapy/image/plotting.py
@@ -232,7 +232,7 @@ class GalacticPlaneSurveyPanelPlot(object):
     TODO: describe how the callbacks work
 
     References:
-    http://aplpy.readthedocs.org/en/latest/howto_subplot.html
+    http://aplpy.readthedocs.io/en/latest/howto_subplot.html
 
     Attributes:
 

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -72,7 +72,7 @@ class PSFKing(object):
         """
         filename = str(make_path(filename))
         # TODO: implement it so that HDUCLASS is used
-        # http://gamma-astro-data-formats.readthedocs.org/en/latest/data_storage/hdu_index/index.html
+        # http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/hdu_index/index.html
 
         table = Table.read(filename, hdu=hdu)
         return cls.from_table(table)

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -26,7 +26,7 @@ class LogEnergyAxis(object):
       and ``pix=0.3`` is ``0.5 * (0.3 * x[0] + 0.7 * x[1])``
 
     .. note::
-        The `specutils.Spectrum1DLookupWCS <http://specutils.readthedocs.org/en/latest/api/specutils.wcs.specwcs.Spectrum1DLookupWCS.html>`__
+        The `specutils.Spectrum1DLookupWCS <http://specutils.readthedocs.io/en/latest/api/specutils.wcs.specwcs.Spectrum1DLookupWCS.html>`__
         class is similar (only that it doesn't include the ``log`` transformation and the API is different.
         Also see this Astropy feature request: https://github.com/astropy/astropy/issues/2362
 

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -237,7 +237,7 @@ class EnergyBounds(Energy):
         """
 
         # np.append renders Quantities dimensionless
-        # http://astropy.readthedocs.org/en/latest/known_issues.html#quantity-issues
+        # http://docs.astropy.org/en/latest/known_issues.html#quantity-issues
 
         lower = cls(lower, unit)
         upper = cls(upper, unit)


### PR DESCRIPTION
This PR updates the docs links from `readthedocs.org` to `readthedocs.io`.
(a recent change, see http://blog.readthedocs.com/securing-subdomains/ )