### PR TITLE
Remove unused event_lists_to_counts_image function

### DIFF
--- a/examples/wip_make_survey_map.py
+++ b/examples/wip_make_survey_map.py
@@ -93,7 +93,6 @@ def make_counts_image(energy_band):
     print('Filling counts image ...')
     header = fits.getheader(REF_IMAGE)
     image = event_list.fill_counts_header(header)
-    # image = event_lists_to_counts_image(header, TOTAL_EVENTS_FILE)
 
     print('Writing {}'.format(COUNTS_IMAGE))
     image.writeto(COUNTS_IMAGE, clobber=True)

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -21,7 +21,6 @@ __all__ = [
     'EventList',
     'EventListDataset',
     'EventListDatasetChecker',
-    'event_lists_to_counts_image',
 ]
 
 log = logging.getLogger(__name__)
@@ -917,37 +916,3 @@ class EventListDatasetChecker(object):
             return False
         else:
             return True
-
-
-def event_lists_to_counts_image(header, table_of_files, logger=None):
-    """Make count image from event lists (like gtbin).
-
-    TODO: what's a good API and location for this?
-
-    Parameters
-    ----------
-    header : `~astropy.io.fits.Header`
-        FITS header
-    table_of_files : `~astropy.table.Table`
-        Table of event list filenames
-    logger : `logging.Logger` or None
-        Logger to use
-
-    Returns
-    -------
-    image : `~astropy.io.fits.ImageHDU`
-        Count image
-    """
-    shape = (header['NAXIS2'], header['NAXIS1'])
-    data = np.zeros(shape, dtype='int')
-
-    for row in table_of_files:
-        if row['filetype'] != 'events':
-            continue
-        ds = EventListDataset.read(row['filename'])
-        if logger:
-            logger.info('Processing OBS_ID = {:06d} with {:6d} events.'
-                        ''.format(row['OBS_ID'], len(ds.event_list)))
-            # TODO: fill events in image.
-
-    return fits.ImageHDU(data=data, header=header)


### PR DESCRIPTION
This PR removes the unused `event_lists_to_counts_image` function.

This functionality is now available in `SkyMap.fill` for one run.
I'm not sure if we currently have a version for many runs and if so how it's implemented (should be done such that one run is processed at a time and then deleted from  memory).

Still, I'm just removing this now ... this is definitely the right API and the implementation is unfinished.