### PR TITLE
Delete solid_angle function and update all usages of it

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -17,7 +17,6 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.wcs import WCS
 
-from .utils import cube_to_image
 from ..spectrum import LogEnergyAxis, powerlaw
 from ..utils.energy import EnergyBounds
 from ..image import SkyMap
@@ -318,6 +317,8 @@ class SkyCube(object):
     def solid_angle_image(self):
         """Solid angle image in steradian (`~astropy.units.Quantity`)"""
         cube_hdu = fits.ImageHDU(self.data, self.wcs.to_header())
+
+        from .utils import cube_to_image
         image_hdu = cube_to_image(cube_hdu)
         image_hdu.header['WCSAXES'] = 2
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -17,12 +17,12 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.wcs import WCS
 
+from .utils import cube_to_image
 from ..spectrum import LogEnergyAxis, powerlaw
 from ..utils.energy import EnergyBounds
-from ..image import cube_to_image, SkyMap
+from ..image import SkyMap
 from ..image.utils import _bin_events_in_cube
 from ..utils.fits import table_to_fits_table
-from ..utils.wcs import get_wcs_ctype
 
 __all__ = ['SkyCube']
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -19,7 +19,7 @@ from astropy.wcs import WCS
 
 from ..spectrum import LogEnergyAxis, powerlaw
 from ..utils.energy import EnergyBounds
-from ..image import cube_to_image, solid_angle, SkyMap
+from ..image import cube_to_image, SkyMap
 from ..image.utils import _bin_events_in_cube
 from ..utils.fits import table_to_fits_table
 from ..utils.wcs import get_wcs_ctype
@@ -321,7 +321,8 @@ class SkyCube(object):
         image_hdu = cube_to_image(cube_hdu)
         image_hdu.header['WCSAXES'] = 2
 
-        return solid_angle(image_hdu).to('sr')
+        sky_map = SkyMap.read(image_hdu)
+        return sky_map.solid_angle()
 
     def flux(self, lon, lat, energy):
         """Differential flux.

--- a/gammapy/cube/tests/test_utils.py
+++ b/gammapy/cube/tests/test_utils.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+
+from ..utils import cube_to_image
+from ...image import images_to_cube, SkyMap
+
+
+def test_cube_to_image():
+    layer = SkyMap.empty(nxpix=101, nypix=101, fill=1.).to_image_hdu()
+    hdu_list = [layer, layer, layer, layer]
+    cube = images_to_cube(hdu_list)
+    case1 = cube_to_image(cube)
+    case2 = cube_to_image(cube, slicepos=1)
+    # Check that layers are summed if no layer is specified (case1),
+    # or only a specified layer is extracted (case2)
+    assert_allclose(case1.data, 4 * layer.data)
+    assert_allclose(case2.data, layer.data)

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -17,7 +17,6 @@ from ...image import (
     separation,
     make_header,
     contains,
-    solid_angle,
     images_to_cube,
     cube_to_image,
     block_reduce_hdu,
@@ -78,15 +77,6 @@ class TestImageCoordinates(object):
         x = y = np.zeros((3, 2))
         inside = contains(self.image, x, y)
         assert_equal(inside, np.ones((3, 2), dtype=bool))
-
-    # TODO: this works on my machine, but fails for unknown reasons
-    # with an IndexError with the `numpy` used here:
-    # https://travis-ci.org/gammapy/gammapy/jobs/26836201#L1123
-    @pytest.mark.xfail
-    def test_image_area(self):
-        actual = solid_angle(self.image)
-        expected = 99.61946869
-        assert_allclose(actual, expected)
 
 
 @pytest.mark.xfail

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -18,7 +18,6 @@ from ...image import (
     make_header,
     contains,
     images_to_cube,
-    cube_to_image,
     block_reduce_hdu,
     wcs_histogram2d,
     lon_lat_rectangle_mask,
@@ -155,18 +154,6 @@ def test_ref_pixel():
     footprint_1 = WCS(image_1.header).calc_footprint(center=False)
     # Lower left corner shouldn't change
     assert_allclose(footprint[0], footprint_1[0])
-
-
-def test_cube_to_image():
-    layer = SkyMap.empty(nxpix=101, nypix=101, fill=1.).to_image_hdu()
-    hdu_list = [layer, layer, layer, layer]
-    cube = images_to_cube(hdu_list)
-    case1 = cube_to_image(cube)
-    case2 = cube_to_image(cube, slicepos=1)
-    # Check that layers are summed if no layer is specified (case1),
-    # or only a specified layer is extracted (case2)
-    assert_allclose(case1.data, 4 * layer.data)
-    assert_allclose(case2.data, layer.data)
 
 
 def test_wcs_histogram2d():

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -10,7 +10,7 @@ from ...utils.testing import requires_dependency, requires_data
 from ...datasets import FermiGalacticCenter
 from ...data import DataStore
 from ...utils.energy import EnergyBounds
-from ...cube import SkyCube
+from ...cube import SkyCube, cube_to_image
 from ...image import (
     binary_disk,
     binary_ring,

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -7,7 +7,6 @@ from astropy.units import Quantity
 from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.wcs import WCS
-from .maps import SkyMap
 from ..utils.wcs import get_wcs_ctype
 from ..utils.energy import EnergyBounds
 # TODO:
@@ -940,6 +939,7 @@ def cube_to_spec(cube, mask, weighting='none'):
         Summed spectrum of pixels in the mask.
     """
     value = cube.dat
+    from .maps import SkyMap
     sky_map = SkyMap.read(cube)
     A = sky_map.solid_angle()
     # Note that this is the correct way to get an average flux:

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -24,8 +24,6 @@ __all__ = [
     'binary_ring',
     'block_reduce_hdu',
     'contains',
-    'cube_to_image',
-    'cube_to_spec',
     'crop_image',
     'dict_to_hdulist',
     'disk_correlate',
@@ -887,65 +885,6 @@ def crop_image(image, bounding_box):
     # TODO: fix header keywords and test against ftcopy
 
     return fits.ImageHDU(data=data, header=header)
-
-
-def cube_to_image(cube, slicepos=None):
-    """Slice or project 3-dim cube into a 2-dim image.
-
-    Parameters
-    ----------
-    cube : `~astropy.io.fits.ImageHDU`
-        3-dim FITS cube
-    slicepos : int or None, optional
-        Slice position (None means to sum along the spectral axis)
-
-    Returns
-    -------
-    image : `~astropy.io.fits.ImageHDU`
-        2-dim FITS image
-    """
-    from astropy.io.fits import ImageHDU
-    header = cube.header.copy()
-    header['NAXIS'] = 2
-
-    for key in ['NAXIS3', 'CRVAL3', 'CDELT3', 'CTYPE3', 'CRPIX3', 'CUNIT3']:
-        if key in header:
-            del header[key]
-
-    if slicepos is None:
-        data = cube.data.sum(0)
-    else:
-        data = cube.data[slicepos]
-    return ImageHDU(data, header)
-
-
-def cube_to_spec(cube, mask, weighting='none'):
-    """Integrate spatial dimensions of a FITS cube to give a spectrum.
-
-    TODO: give formulas.
-
-    Parameters
-    ----------
-    cube : `~astropy.io.fits.ImageHDU`
-        3-dim FITS cube
-    mask : numpy.array
-        2-dim mask array.
-    weighting : {'none', 'solid_angle'}, optional
-        Weighting factor to use.
-
-    Returns
-    -------
-    spectrum : numpy.array
-        Summed spectrum of pixels in the mask.
-    """
-    value = cube.dat
-    from .maps import SkyMap
-    sky_map = SkyMap.read(cube)
-    A = sky_map.solid_angle()
-    # Note that this is the correct way to get an average flux:
-
-    spec = (value * A).sum(-1).sum(-1)
-    return spec
 
 
 def contains(image, x, y, world=True):


### PR DESCRIPTION
I removed solid_angle function from `image\utils.py` and test from `image\tests\test_utils.py`. Also I looked through all the usages of this function and updated it with help of SkyMap.solid_angle().

Also I want to notice that the results of function solid_angle and method of class `SkyMap.solid_angle()` are differ a little by few percents. The only unittest for solid_angle function was disabled, so I've just compared the values of the solid_angle function and `SkyMap.solid_angle()` using this test. The output was

```
[[ 0.03046174  0.03046174  0.03046174]
 [ 0.03046174  0.03046174  0.03046174]] 
[[ 0.03034583  0.03034583  0.03034583]
 [ 0.03034583  0.03034583  0.03034583]]
```