### PR TITLE
Fix bug in EffectiveAreaTable2d.read

### DIFF
--- a/gammapy/irf/effective_area_table.py
+++ b/gammapy/irf/effective_area_table.py
@@ -398,9 +398,9 @@ class EffectiveAreaTable2D(object):
         o_lo = Angle(data['THETA_LO'].squeeze(), 'deg')
         o_hi = Angle(data['THETA_HI'].squeeze(), 'deg')
         if column == 'reco':
-            ef = Quantity(data['EFFAREA'].squeeze(), 'm^2')
-        else:
             ef = Quantity(data['EFFAREA_RECO'].squeeze(), 'm^2')
+        else:
+            ef = Quantity(data['EFFAREA'].squeeze(), 'm^2')
 
         return cls(e_lo, e_hi, o_lo, o_hi, ef, thres_lo=thres_lo, thres_hi=thres_hi)
 

--- a/gammapy/spectrum/tests/test_counts_spectrum.py
+++ b/gammapy/spectrum/tests/test_counts_spectrum.py
@@ -71,4 +71,4 @@ def test_n_pred():
     n_pred_vec = [CountsSpectrum.get_npred(fit, o) for o in obs]
     n_pred = np.sum(n_pred_vec)
 
-    assert_allclose(max(n_pred.counts), 51.2, atol=0.1)
+    assert_allclose(max(n_pred.counts), 52.5, atol=0.1)


### PR DESCRIPTION
This fixes a bug in the original ``EffectiveAreaTable2d.read`` method. I want to fix this in order to be able to verify the new IRF classes properly. See https://github.com/gammapy/gammapy/pull/541