### PR TITLE
Add PointingInfo class

### DIFF
--- a/gammapy/data/__init__.py
+++ b/gammapy/data/__init__.py
@@ -16,3 +16,4 @@ from .obsgroup import *
 from .observers import *
 from .utils import *
 from .observation_summary import *
+from .pointing import *

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,0 +1,135 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.utils import lazyproperty
+from astropy.units import Quantity
+from astropy.table import Table
+from astropy.coordinates import SkyCoord, AltAz
+from ..utils.scripts import make_path
+from ..time.utils import time_ref_from_dict
+from .utils import _earth_location_from_dict
+
+__all__ = [
+    'PointingInfo',
+]
+
+
+class PointingInfo(object):
+    """IACT array pointing info.
+
+    TODO: link to open spec.
+    TODO: share code with the `~gammapy.data.EventList` and `~gammapy.data.ObservationTable` classes.
+
+    This class has many cached properties.
+    Should be used as read-only.
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        Table (with meta header info) on pointing
+
+    Examples
+    --------
+
+    >>> from gammapy.data import PointingInfo
+    >>> pointing_info = PointingInfo.read('$GAMMAPY_EXTRA/test_datasets/hess_event_list.fits')
+    >>> print(pointing_info)
+    """
+
+    def __init__(self, table):
+        self.table = table
+
+    @classmethod
+    def read(cls, filename, hdu=None):
+        """Read `PointingInfo` table from file.
+
+        Parameters
+        ----------
+        filename : str
+            File name
+        hdu : int or str
+            HDU number or name
+
+        Returns
+        -------
+        pointing_info : `PointingInfo`
+            Pointing info object
+        """
+        filename = make_path(filename)
+
+        if hdu is None:
+            hdu = 'POINTING'
+
+        table = Table.read(str(filename), hdu=hdu)
+        return cls(table=table)
+
+    def __str__(self):
+        """Basic info."""
+        ss = 'Pointing info:\n\n'
+        ss += 'Location:     {}\n'.format(self.location.geodetic)
+        m = self.table.meta
+        ss += 'MJDREFI, MJDREFF, TIMESYS = {}\n'.format((m['MJDREFI'], m['MJDREFF'], m['TIMESYS']))
+        ss += 'Time ref:     {}\n'.format(self.time_ref.fits)
+        ss += 'Time ref:     {} MJD (TT)\n'.format(self.time_ref.mjd)
+        sec = self.duration.to('second').value
+        hour = self.duration.to('hour').value
+        ss += 'Duration:     {} sec = {} hours\n'.format(sec, hour)
+        ss += 'Table length: {}\n'.format(len(self.table))
+
+        ss += '\nSTART:\n' + self._str_for_index(0) + '\n'
+        ss += '\nEND:\n' + self._str_for_index(-1) + '\n'
+
+        return ss
+
+    def _str_for_index(self, idx):
+        """Information for one point in the pointing table"""
+        ss = 'Time:  {}\n'.format(self.time[idx].fits)
+        ss += 'Time:  {} MJD (TT)\n'.format(self.time[idx].mjd)
+        ss += 'RADEC: {} deg\n'.format(self.radec[idx].to_string())
+        ss += 'ALTAZ: {} deg\n'.format(self.altaz[idx].to_string())
+        return ss
+
+    @lazyproperty
+    def location(self):
+        """Observatory location (`~astropy.coordinates.EarthLocation`)"""
+        return _earth_location_from_dict(self.table.meta)
+
+    @lazyproperty
+    def time_ref(self):
+        """Time reference (`~astropy.time.Time`)"""
+        # For debugging ... change TIMESYS
+        # self.table.meta['TIMESYS'] = 'utc'
+        return time_ref_from_dict(self.table.meta)
+
+    @lazyproperty
+    def duration(self):
+        """Pointing table duration (`~astropy.time.TimeDelta`).
+
+        The time difference between the first and last entry.
+        """
+        return self.time[-1] - self.time[0]
+
+    @lazyproperty
+    def time(self):
+        """Time array (`~astropy.time.Time`)"""
+        met = Quantity(self.table['TIME'].astype('float64'), 'second')
+        time = self.time_ref + met
+        return time.tt
+
+    @lazyproperty
+    def radec(self):
+        """RA / DEC position from table (`~astropy.coordinates.SkyCoord`)"""
+        lon = self.table['RA_PNT'].astype('float64')
+        lat = self.table['DEC_PNT'].astype('float64')
+        return SkyCoord(lon, lat, unit='deg', frame='icrs')
+
+    @lazyproperty
+    def altaz_frame(self):
+        """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
+        return AltAz(obstime=self.time, location=self.location)
+
+    @lazyproperty
+    def altaz(self):
+        """ALT / AZ position from table (`~astropy.coordinates.SkyCoord`)"""
+        lon = self.table['AZ_PNT'].astype('float64')
+        lat = self.table['ALT_PNT'].astype('float64')
+        return SkyCoord(lon, lat, unit='deg', frame=self.altaz_frame)

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -1,0 +1,65 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from ...utils.testing import requires_data
+from ..pointing import PointingInfo
+
+
+@requires_data('gammapy-extra')
+class TestPointingInfo:
+    def setup(self):
+        filename = '$GAMMAPY_EXTRA/test_datasets/hess_event_list.fits'
+        self.pointing_info = PointingInfo.read(filename)
+
+    def test_str(self):
+        ss = str(self.pointing_info)
+        assert 'Pointing info' in ss
+
+    def test_location(self):
+        lon, lat, height = self.pointing_info.location.geodetic
+        assert_allclose(lon.deg, 16.5002222222222)
+        assert_allclose(lat.deg, -23.2717777777778)
+        assert_allclose(height.value, 1834.999999999783)
+
+    def test_time_ref(self):
+        assert self.pointing_info.time_ref.fits == '2001-01-01T00:01:04.184(TT)'
+
+    def test_table(self):
+        assert len(self.pointing_info.table) == 100
+
+    def test_time(self):
+        time = self.pointing_info.time
+        assert len(time) == 100
+        assert time.fits[0] == '2004-01-21T19:50:02.184(TT)'
+
+    def test_duration(self):
+        duration = self.pointing_info.duration
+        assert duration.sec == 1586.0000000044238
+
+    def test_radec(self):
+        pos = self.pointing_info.radec[0]
+        assert_allclose(pos.ra.deg, 83.633333333333)
+        assert_allclose(pos.dec.deg, 24.51444444)
+        assert pos.name == 'icrs'
+
+    def test_altaz(self):
+        pos = self.pointing_info.altaz[0]
+        assert_allclose(pos.az.deg, 11.20432353385406)
+        assert_allclose(pos.alt.deg, 41.37921408774436)
+        assert pos.name == 'altaz'
+
+    def test_position_consistency(self):
+        """
+        Test if ALT / AZ in the table is consistent
+        with ALT / AZ computed from TIME, LOCATION, RA / DEC
+        and Astropy coordinates.
+        """
+        altaz_hess = self.pointing_info.altaz
+        altaz_astropy = self.pointing_info.radec.transform_to(self.pointing_info.altaz_frame)
+        sky_diff = altaz_astropy.separation(altaz_hess).to('arcsec')
+
+        # TODO: positions currently don't match ... should be very close to zero.
+        # Investigation ongoing here:
+        # https://github.com/cdeil/astrometric_checks/blob/master/test_pointing.py
+        # https://github.com/gammasky/hess-host-analyses/issues/47
+        assert_allclose(sky_diff.max().arcsec, 697.9085394803815)

--- a/gammapy/data/utils.py
+++ b/gammapy/data/utils.py
@@ -4,11 +4,22 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy.coordinates import Angle, EarthLocation
 from astropy.units import Quantity
 
-__all__ = []
+__all__ = [
+
+]
 
 
 def _earth_location_from_dict(meta):
+    """Create `~astropy.coordinates.EarthLocation` from FITS header dict."""
     lon = Angle(meta['GEOLON'], 'deg')
     lat = Angle(meta['GEOLAT'], 'deg')
-    height = Quantity(meta['ALTITUDE'], 'meter')
+    # TODO: should we support both here?
+    # Check latest spec if ALTITUDE is used somewhere.
+    if 'GEOALT' in meta:
+        height = Quantity(meta['GEOALT'], 'meter')
+    elif 'ALTITUDE' in meta:
+        height = Quantity(meta['ALTITUDE'], 'meter')
+    else:
+        raise KeyError('The GEOALT or ALTITUDE header keyword must be set')
+
     return EarthLocation(lon=lon, lat=lat, height=height)


### PR DESCRIPTION
This PR adds a `gammapy.data.PointingInfo` class.

I added a test file with a `POINTING` extension just now here:
https://github.com/gammapy/gammapy-extra/blob/master/test_datasets/hess_event_list.fits
The writing of the spec for this and debugging of the HESS pointing table is still work in progress.

My plan is to add some basic tests and [this check](https://github.com/cdeil/astrometric_checks/blob/master/test_pointing.py#L11) in this PR, but then merge and make an issue listing future work (e.g. interpolation of AZ / ALT to arbitrary times, format and content validation).