### PR TITLE
Add paste, cutout and look_up methods to SkyMap class

### DIFF
--- a/docs/image/skymaps.rst
+++ b/docs/image/skymaps.rst
@@ -63,3 +63,72 @@ The sky map can be easily displayed with an image viewer, by calling ``skymap.sh
         counts = SkyMap.read(filename)
         counts.name = 'Counts'
         counts.show()
+
+
+Working with the cutout and paste method
+----------------------------------------
+
+The `~gammapy.image.SkyMap` class offers `.paste()` and `.cutout()`
+methods, that can be used to cut out smaller parts of a sky map.
+Here we cut out a 2 deg x 2 deg patch out of an example image:
+
+.. plot::
+    :include-source:
+
+    from astropy.units import Quantity
+    from astropy.coordinates import SkyCoord
+    from gammapy.image import SkyMap
+    from gammapy.datasets import load_poisson_stats_image
+
+    filename = load_poisson_stats_image(return_filenames=True)
+    counts = SkyMap.read(filename)
+    
+    position = SkyCoord(0, 0, frame='galactic', unit='deg')
+    size = Quantity([1, 1], 'deg')
+    cutout = counts.cutout(position, size)
+    cutout.show()
+
+`cutout` is again a `~gammapy.image.SkyMap` object.
+
+Here's a more complicated example, that uses `.paste()` and `.cutout()`
+to evaluate Gaussian model images on small cut out patches and paste
+them again into a larger sky map. This offer a very efficient way 
+of computing large model sky images:
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    from gammapy.image import SkyMap
+    from astropy.coordinates import SkyCoord
+    from astropy.modeling.models import Gaussian2D
+    from astropy import units as u
+
+    BINSZ = 0.02
+    sigma = 0.2
+    ampl = 1. / (2 * np.pi * (sigma / BINSZ) ** 2)
+    sources = [Gaussian2D(ampl, 0, 0, sigma, sigma),
+               Gaussian2D(ampl, 2, 0, sigma, sigma),
+               Gaussian2D(ampl, 0, 2, sigma, sigma), 
+               Gaussian2D(ampl, 0, -2, sigma, sigma),
+               Gaussian2D(ampl, -2, 0, sigma, sigma),
+               Gaussian2D(ampl, 2, -2, sigma, sigma),
+               Gaussian2D(ampl, -2, 2, sigma, sigma),
+               Gaussian2D(ampl, -2, -2, sigma, sigma),
+               Gaussian2D(ampl, 2, 2, sigma, sigma),]
+
+
+    skymap = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+    skymap.name = 'Flux'
+
+    for source in sources:
+        # Evaluate on cut out
+        pos = SkyCoord(source.x_mean, source.y_mean,
+                       unit='deg', frame='galactic')
+        cutout = skymap.cutout(pos, size=(3.2 * u.deg, 3.2 * u.deg))
+        c = cutout.coordinates()
+        l, b = c.galactic.l.wrap_at('180d'), c.galactic.b
+        cutout.data = source(l.deg, b.deg)
+        skymap.paste(cutout)
+
+    skymap.show()

--- a/docs/image/skymaps.rst
+++ b/docs/image/skymaps.rst
@@ -65,12 +65,14 @@ The sky map can be easily displayed with an image viewer, by calling ``skymap.sh
         counts.show()
 
 
-Working with the cutout and paste method
-----------------------------------------
+.. _skymap-cutpaste:
+
+Cutout and paste
+----------------
 
 The `~gammapy.image.SkyMap` class offers `.paste()` and `.cutout()`
 methods, that can be used to cut out smaller parts of a sky map.
-Here we cut out a 2 deg x 2 deg patch out of an example image:
+Here we cut out a 1 deg x 1 deg patch out of an example image:
 
 .. plot::
     :include-source:

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -299,11 +299,12 @@ class SkyMap(object):
         Paste smaller skymap into sky map. 
 
         WCS specifications of both skymaps must be aligned. If not call
-        `SkyMap.reproject()` on one of the maps first.
+        `SkyMap.reproject()` on one of the maps first. See :ref:`skymap-cutpaste`
+        more for information how to cut and paste sky images.
 
         Parameters
         ----------
-        skymap: `SkyMap`
+        skymap : `SkyMap`
             Smaller sky map to paste.
         method : {'sum', 'replace'}, optional
             Sum or replace total values with cutout values.
@@ -316,23 +317,40 @@ class SkyMap(object):
         elif method == 'replace':
             self.data[ylo:yhi, xlo:xhi] = skymap.data[ylo_c:yhi_c, xlo_c:xhi_c]
         else:
-            raise ValueError('Invalid method: {0}'.format(method))
+            raise ValueError('Invalid method: {}'.format(method))
 
     def cutout(self, position, size):
         """
         Cut out rectangular piece of a sky map.
 
+        See :ref:`skymap-cutpaste` for more information how to cut and paste
+        sky images.
+
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`
             Position of the center of the sky map to cut out.
-        size : tuple
-            Tuple of `~astropy.units.Angle`, specifying the size of
-            the cutout.
+        size : int, array-like, `~astropy.units.Quantity`
+            The size of the cutout array along each axis.  If ``size``
+            is a scalar number or a scalar `~astropy.units.Quantity`,
+            then a square cutout of ``size`` will be created.  If
+            ``size`` has two elements, they should be in ``(ny, nx)``
+            order.  Scalar numbers in ``size`` are assumed to be in
+            units of pixels.  ``size`` can also be a
+            `~astropy.units.Quantity` object or contain
+            `~astropy.units.Quantity` objects.  Such
+            `~astropy.units.Quantity` objects must be in pixel or
+            angular units.  For all cases, ``size`` will be converted to
+            an integer number of pixels, rounding the the nearest
+            integer.  See the ``mode`` keyword for additional details on
+            the final cutout size.
 
-        Examples
-        --------
-
+            .. note::
+                If ``size`` is in angular units, the cutout size is
+                converted to pixels using the pixel scales along each
+                axis of the image at the ``CRPIX`` location.  Projection
+                and other non-linear distortions are not taken into
+                account.
 
         Returns
         -------

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -340,7 +340,7 @@ class SkyMap(object):
         if region:
             mask = region.contains(self.coordinates())
         else:
-            mask =np.ones_like(self.data)
+            mask = np.ones_like(self.data)
 
         idx = np.nanargmax(self.data * mask)
         y, x = np.unravel_index(idx, self.data.shape)

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -323,16 +323,26 @@ class SkyMap(object):
         skymap._parent_skymap_id = id(self)
         return skymap
 
-    def lookup_max(self, mask=None):
+    def lookup_max(self, region=None):
         """
         Find position of maximum in a skymap.
+
+        Parameters
+        ----------
+        region : `~gammapy.extern.regions.core.SkyRegion` (optional)
+            Limit lookup of maximum to that given sky region.
 
         Returns
         -------
         (position, value): `~astropy.coordinates.SkyCoord`, float
             Position and value of the maximum.
         """
-        idx = np.nanargmax(self.data)
+        if region:
+            mask = region.contains(self.coordinates())
+        else:
+            mask =np.ones_like(self.data)
+
+        idx = np.nanargmax(self.data * mask)
         y, x = np.unravel_index(idx, self.data.shape)
         pos = pixel_to_skycoord(x, y, self.wcs, self.wcs_origin)
         return pos, self.data[y, x]

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -236,7 +236,7 @@ class SkyMap(object):
 
     def coordinates_pix(self, mode='center'):
         """
-        Pixel sky coordinate images.
+        Pixel coordinate images.
 
         Parameters
         ----------
@@ -257,22 +257,22 @@ class SkyMap(object):
             raise ValueError('Invalid mode to compute coordinates.')
         return x, y
 
-    def coordinates(self, origin=0, mode='center'):
+    def coordinates(self, mode='center'):
         """
         Sky coordinate images.
+
         Parameters
         ----------
-        origin : {0, 1}
-            Pixel coordinate origin.
         mode : {'center', 'edges'}
             Return coordinate values at the pixels edges or pixel centers.
+
         Returns
         -------
         coordinates : `~astropy.coordinates.SkyCoord`
             Position on the sky.
         """
         x, y = self.coordinates_pix(mode=mode)
-        coordinates = pixel_to_skycoord(x, y, self.wcs, origin)
+        coordinates = pixel_to_skycoord(x, y, self.wcs, self.wcs_origin)
         return coordinates
     
     def _get_boundaries(self, skymap_ref, skymap):
@@ -290,7 +290,6 @@ class SkyMap(object):
         bounds_ref = skymap_ref.wcs.wcs_world2pix(bounds[0], bounds[1], skymap_ref.wcs_origin)
 
         # round to nearest integer and clip at the boundaries
-        xlo, xhi = np.rint(np.clip(bounds_ref[0], 0, xmax_ref))
         xlo, xhi = np.rint(np.clip(bounds_ref[0], 0, xmax_ref))
         ylo, yhi = np.rint(np.clip(bounds_ref[1], 0, ymax_ref))
         return xlo, xhi, ylo, yhi
@@ -330,6 +329,10 @@ class SkyMap(object):
         size : tuple
             Tuple of `~astropy.units.Angle`, specifying the size of
             the cutout.
+
+        Examples
+        --------
+
 
         Returns
         -------
@@ -377,7 +380,7 @@ class SkyMap(object):
 
     def center(self):
         """
-        Center coordinates of the sky map.
+        Center sky coordinates of the sky map.
         """
         return SkyCoord.from_pixel((self.data.shape[0] - 1) / 2.,
                                    (self.data.shape[1] - 1) / 2.,
@@ -406,7 +409,7 @@ class SkyMap(object):
             xsky, ysky = position[0], position[1]
 
         x, y = self.wcs.wcs_world2pix(xsky, ysky, self.wcs_origin)
-        return self.data[np.round(y).astype('int'), np.round(x).astype('int')]
+        return self.data[np.rint(y), np.rint(x)]
 
     def to_quantity(self):
         """

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.coordinates import SkyCoord, Longitude, Latitude
 from astropy.wcs import WCS
-from astropy.wcs.utils import pixel_to_skycoord, proj_plane_pixel_scales, skycoord_to_pixel
+from astropy.wcs.utils import pixel_to_skycoord
 from astropy.units import Quantity, Unit
 from astropy.extern import six
 from astropy.nddata.utils import Cutout2D
@@ -279,8 +279,6 @@ class SkyMap(object):
         """
         Paste cutout into sky map. 
 
-        The WCS of the skymap and the cutout have to be aligned.
-
         Parameters
         ----------
         skymap: `SkyMap`
@@ -325,7 +323,7 @@ class SkyMap(object):
         skymap._parent_skymap_id = id(self)
         return skymap
 
-    def lookup_max(self):
+    def lookup_max(self, mask=None):
         """
         Find position of maximum in a skymap.
 

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -275,7 +275,7 @@ class SkyMap(object):
         coordinates = pixel_to_skycoord(x, y, self.wcs, origin)
         return coordinates
     
-    def paste(self, cutout, method='sum'):
+    def paste(self, skymap, method='sum'):
         """
         Paste cutout into sky map. 
 
@@ -286,6 +286,14 @@ class SkyMap(object):
         method : {'sum', 'replace'}, optional
             Sum or replace total values with cutout values.
         """
+        lo = pixel_to_skycoord(0, 0, skymap.wcs, skymap.wcs_origin)
+        xlo, ylo = skycoord_to_pixel(lo, self.wcs, self.wcs_origin)
+
+        hi = pixel_to_skycoord(-1, -1, skymap.wcs, skymap.wcs_origin)
+        xhi, yhi = skycoord_to_pixel(hi, self.wcs, self.wcs_origin)
+
+        self.data[ylo:yhi, xlo:xhi] = cutout.data
+
         if not getattr(cutout, '_parent_skymap_id', 0) == id(self):
             raise TypeError('Can only paste into sky map, the smaller sky map was'
                             ' cut out from.')

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -7,7 +7,6 @@ from astropy.io import fits
 from astropy.coordinates import Latitude, Longitude, Angle
 from astropy.utils import lazyproperty
 
-from ..utils.scripts import make_path
 from ..image import (
     exclusion_distance,
     lon_lat_circle_mask,

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -1,16 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.wcs import WCS
 from astropy.io import fits
-from ..utils.scripts import make_path
 from astropy.coordinates import Latitude, Longitude, Angle
 from astropy.utils import lazyproperty
+
+from ..utils.scripts import make_path
 from ..image import (
     exclusion_distance,
     lon_lat_circle_mask,
 )
 from .maps import SkyMap
+
 
 __all__ = [
     'ExclusionMask',

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -9,7 +9,6 @@ from .utils import coordinates
 __all__ = [
     'BoundingBox',
     'bbox',
-    'lookup_max',
     'measure_containment_fraction',
     'measure_containment_radius',
     'measure_image_moments',
@@ -230,33 +229,6 @@ def measure_labeled_regions(data, labels, tag='IMAGE',
         table.add_column(Column(data=mean, name=tag + '_MEAN'))
 
     return table
-
-
-
-
-
-def lookup_max(image, GLON, GLAT, theta):
-    """Look up the max image values within a circle of radius theta
-    around lists of given positions (nan if outside)"""
-    from .utils import coordinates
-    GLON = np.asarray(GLON)
-    GLON = np.where(GLON > 180, GLON - 360, GLON)
-    GLAT = np.asarray(GLAT)
-    n_pos = len(GLON)
-    theta = np.asarray(theta) * np.ones(n_pos, dtype='float32')
-
-    ll, bb = coordinates(image)
-
-    val = np.nan * np.ones(n_pos, dtype='float32')
-    for ii in range(n_pos):
-        mask = ((GLON[ii] - ll) ** 2 +
-                (GLAT[ii] - bb) ** 2 <=
-                theta[ii] ** 2)
-        try:
-            val[ii] = image.data[mask].max()
-        except ValueError:
-            pass
-    return val
 
 
 def measure_image_moments(image):

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -9,7 +9,6 @@ from .utils import coordinates
 __all__ = [
     'BoundingBox',
     'bbox',
-    'find_max',
     'lookup_max',
     'measure_containment_fraction',
     'measure_containment_radius',
@@ -233,29 +232,7 @@ def measure_labeled_regions(data, labels, tag='IMAGE',
     return table
 
 
-def find_max(image):
-    """Find position of maximum in an image.
 
-    Parameters
-    ----------
-    image : `~astropy.io.fits.ImageHDU`
-        Input image
-
-    Returns
-    -------
-    lon, lat, value : float
-        Maximum value and its position
-    """
-    from scipy.ndimage import maximum_position
-    from astropy.wcs import WCS
-    proj = WCS(image.header)
-    data = image.data
-    data[np.isnan(data)] = -np.inf
-    y, x = maximum_position(data)
-    origin = 0  # convention for gammapy
-    GLON, GLAT = proj.wcs_pix2world(x, y, origin)
-    val = data[int(y), int(x)]
-    return GLON, GLAT, val
 
 
 def lookup_max(image, GLON, GLAT, theta):

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -9,6 +9,7 @@ from ..maps import SkyMap
 from ...data import DataStore
 from ...datasets import load_poisson_stats_image
 from ...utils.testing import requires_dependency, requires_data
+from ...extern.regions.shapes import CircleSkyRegion
 
 
 @requires_data('gammapy-extra')
@@ -113,7 +114,6 @@ class TestSkyMapPoisson():
         assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
 
     def test_lookup_max_region(self):
-        from ...extern.regions.shapes import CircleSkyRegion
         center = SkyCoord(0, 0, unit='deg', frame='galactic')
         circle = CircleSkyRegion(center, radius=Quantity(1, 'deg'))
         pos, value = self.skymap.lookup_max(circle) 
@@ -121,19 +121,19 @@ class TestSkyMapPoisson():
         assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
 
     def test_cutout_paste(self):
-        positions = SkyCoord([0, 0, 0, 2, -2], [0, 2, -2, 0, 0],
+        positions = SkyCoord([0, 0, 0, 0.4, -0.4], [0, 0.4, -0.4, 0, 0],
                            unit='deg', frame='galactic')
         BINSZ = 0.02
 
         # setup coordinate images
-        lon = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
-        lat = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        lon = SkyMap.empty(nxpix=41, nypix=41, binsz=BINSZ)
+        lat = SkyMap.empty(nxpix=41, nypix=41, binsz=BINSZ)
 
         c = lon.coordinates()
         lon.data = c.galactic.l.deg
         lat.data = c.galactic.b.deg
 
-        size = Quantity([2, 2], 'deg')
+        size = Quantity([0.3, 0.3], 'deg')
         for pos in positions:
             cutout = lon.cutout(pos, size=size)
             

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import SkyCoord, Angle
+from astropy.modeling.models import Gaussian2D
 from astropy.io import fits
 import astropy.units as u
 from ..maps import SkyMap
@@ -119,6 +120,31 @@ class TestSkyMapPoisson():
         pos, value = self.skymap.lookup_max(circle) 
         assert value == 15
         assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
+
+    def test_cutout_paste(self):
+        BINSZ = 0.02
+        sigma = 0.2
+        ampl = 1. / (2 * np.pi * (sigma / BINSZ) ** 2)
+        sources = [Gaussian2D(ampl, 0, 0, sigma, sigma),
+                   Gaussian2D(ampl, 1.9, 0, sigma, sigma),
+                   Gaussian2D(ampl, 0, -1.9, sigma, sigma)]
+
+        skymap_all = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        skymap_cutout = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        for source in sources:
+            # Evaluate on whole image
+            l, b = skymap_all.coordinates('galactic')
+            skymap_all.data += source(l.deg, b.deg)
+
+            # Evaluate on cut out
+            pos = SkyCoord(source.x_mean, source.y_mean,
+                           unit='deg', frame='galactic')
+            cutout = skymap_cutout.cutout(pos, size=(2 * u.deg, 2 * u.deg))
+            l, b = cutout.coordinates('galactic')
+            cutout.data = source(l.deg, b.deg)
+            skymap_cutout.paste(cutout)
+
+        assert_allclose(skymap_all, skymap_cutout, atol=1E-8, rtol=0)
 
 class TestSkyMapCrab():
     """

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -3,9 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import SkyCoord, Angle
-from astropy.modeling.models import Gaussian2D
 from astropy.io import fits
-import astropy.units as u
+from astropy.units import Quantity
 from ..maps import SkyMap
 from ...data import DataStore
 from ...datasets import load_poisson_stats_image
@@ -116,7 +115,7 @@ class TestSkyMapPoisson():
     def test_lookup_max_region(self):
         from ...extern.regions.shapes import CircleSkyRegion
         center = SkyCoord(0, 0, unit='deg', frame='galactic')
-        circle = CircleSkyRegion(center, radius=1 * u.deg)
+        circle = CircleSkyRegion(center, radius=Quantity(1, 'deg'))
         pos, value = self.skymap.lookup_max(circle) 
         assert value == 15
         assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
@@ -134,8 +133,9 @@ class TestSkyMapPoisson():
         lon.data = c.galactic.l.deg
         lat.data = c.galactic.b.deg
 
+        size = Quantity([2, 2], 'deg')
         for pos in positions:
-            cutout = lon.cutout(pos, size=(2 * u.deg, 2 * u.deg))
+            cutout = lon.cutout(pos, size=size)
             
             # recompute coordinates and paste into coordinate images
             c = cutout.coordinates()

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -125,23 +125,29 @@ class TestSkyMapPoisson():
         positions = SkyCoord([0, 0, 0, 2, -2], [0, 2, -2, 0, 0],
                            unit='deg', frame='galactic')
         BINSZ = 0.02
-        lon_all = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
-        lat_all = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
-        lon_all.data = lon_all.coordinates().galactic.l.deg
-        lon_all.data = lon_all.coordinates().galactic.b.deg
 
-        skymap_cutout = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        # setup coordinate images
+        lon = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        lat = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+
+        c = lon.coordinates()
+        lon.data = c.galactic.l.deg
+        lat.data = c.galactic.b.deg
+
         for pos in positions:
-            # Evaluate on whole image
-            l, b = skymap_all.coordinates('galactic')
+            cutout = lon.cutout(pos, size=(2 * u.deg, 2 * u.deg))
             
-            # Evaluate on cut out
-            cutout = skymap_cutout.cutout(pos, size=(2 * u.deg, 2 * u.deg))
-            l, b = cutout.coordinates('galactic')
-            cutout.data = source(l.deg, b.deg)
-            skymap_cutout.paste(cutout)
+            # recompute coordinates and paste into coordinate images
+            c = cutout.coordinates()
+            cutout.data = c.galactic.l.deg
+            lon.paste(cutout, method='replace')
 
-        assert_allclose(skymap_all, skymap_cutout, atol=1E-8, rtol=0)
+            cutout.data = c.galactic.b.deg
+            lat.paste(cutout, method='replace')
+
+        c = lon.coordinates()
+        assert_allclose(lon.data, c.galactic.l.deg)
+        assert_allclose(lat.data, c.galactic.b.deg)
 
 class TestSkyMapCrab():
     """

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -106,6 +106,14 @@ class TestSkyMapPoisson():
         skymap_1_repr = skymap_1.reproject(skymap_2)
         assert_allclose(skymap_1_repr.data, np.full((100, 100), 1))
 
+    def test_paste(self):
+        from .test_measure import generate_gaussian_image
+
+        cutout = generate_gaussian_image()
+
+        empty = SkyMap.empty(nxpix=401, nypix=401, binsz=0.02)
+        empty.paste(cutout)
+        
 
 class TestSkyMapCrab():
     """

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -106,14 +106,11 @@ class TestSkyMapPoisson():
         skymap_1_repr = skymap_1.reproject(skymap_2)
         assert_allclose(skymap_1_repr.data, np.full((100, 100), 1))
 
-    def test_paste(self):
-        from .test_measure import generate_gaussian_image
+    def test_lookup_max(self):
+        pos, value = self.skymap.lookup_max() 
+        assert value == 15
+        assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
 
-        cutout = generate_gaussian_image()
-
-        empty = SkyMap.empty(nxpix=401, nypix=401, binsz=0.02)
-        empty.paste(cutout)
-        
 
 class TestSkyMapCrab():
     """

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -122,23 +122,20 @@ class TestSkyMapPoisson():
         assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
 
     def test_cutout_paste(self):
+        positions = SkyCoord([0, 0, 0, 2, -2], [0, 2, -2, 0, 0],
+                           unit='deg', frame='galactic')
         BINSZ = 0.02
-        sigma = 0.2
-        ampl = 1. / (2 * np.pi * (sigma / BINSZ) ** 2)
-        sources = [Gaussian2D(ampl, 0, 0, sigma, sigma),
-                   Gaussian2D(ampl, 1.9, 0, sigma, sigma),
-                   Gaussian2D(ampl, 0, -1.9, sigma, sigma)]
+        lon_all = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        lat_all = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
+        lon_all.data = lon_all.coordinates().galactic.l.deg
+        lon_all.data = lon_all.coordinates().galactic.b.deg
 
-        skymap_all = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
         skymap_cutout = SkyMap.empty(nxpix=201, nypix=201, binsz=BINSZ)
-        for source in sources:
+        for pos in positions:
             # Evaluate on whole image
             l, b = skymap_all.coordinates('galactic')
-            skymap_all.data += source(l.deg, b.deg)
-
+            
             # Evaluate on cut out
-            pos = SkyCoord(source.x_mean, source.y_mean,
-                           unit='deg', frame='galactic')
             cutout = skymap_cutout.cutout(pos, size=(2 * u.deg, 2 * u.deg))
             l, b = cutout.coordinates('galactic')
             cutout.data = source(l.deg, b.deg)

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import SkyCoord, Angle
 from astropy.io import fits
+import astropy.units as u
 from ..maps import SkyMap
 from ...data import DataStore
 from ...datasets import load_poisson_stats_image
@@ -111,6 +112,13 @@ class TestSkyMapPoisson():
         assert value == 15
         assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
 
+    def test_lookup_max_region(self):
+        from ...extern.regions.shapes import CircleSkyRegion
+        center = SkyCoord(0, 0, unit='deg', frame='galactic')
+        circle = CircleSkyRegion(center, radius=1 * u.deg)
+        pos, value = self.skymap.lookup_max(circle) 
+        assert value == 15
+        assert_allclose((359.93, -0.01), (pos.galactic.l.deg, pos.galactic.b.deg))
 
 class TestSkyMapCrab():
     """

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -60,7 +60,7 @@ def generate_gaussian_image():
     sigma = 0.2
     source = Gaussian2D(1. / (2 * np.pi * (sigma / BINSZ) ** 2), 0, 0, sigma, sigma)
     skymap.data += source(l.degree, b.degree)
-    return skymap.to_image_hdu()
+    return skymap
 
 
 @requires_dependency('scipy')
@@ -74,14 +74,14 @@ def test_measure():
 
 def test_measure_image_moments():
     """Test measure_image_moments function"""
-    image = generate_gaussian_image()
+    image = generate_gaussian_image().to_image_hdu()
     moments = measure_image_moments(image)
     assert_almost_equal(moments, [1, 0, 0, 0.2, 0.2, 0.2])
 
 
 def test_measure_containment():
     """Test measure_containment function"""
-    image = generate_gaussian_image()
+    image = generate_gaussian_image().to_image_hdu()
     frac = measure_containment(image, 0, 0, 0.2 * np.sqrt(2 * np.log(5)))
     assert_allclose(frac, 0.8, rtol=0.01)
 
@@ -89,14 +89,14 @@ def test_measure_containment():
 @requires_dependency('scipy')
 def test_measure_containment_radius():
     """Test measure_containment_radius function"""
-    image = generate_gaussian_image()
+    image = generate_gaussian_image().to_image_hdu()
     rad = measure_containment_radius(image, 0, 0, 0.8)
     assert_allclose(rad, 0.2 * np.sqrt(2 * np.log(5)), rtol=0.01)
 
 
 def test_measure_curve_of_growth():
     """Test measure_curve_of_growth function"""
-    image = generate_gaussian_image()
+    image = generate_gaussian_image().to_image_hdu()
     radius, containment = measure_curve_of_growth(image, 0, 0, 0.6, 0.05)
     sigma = 0.2
     containment_ana = 1 - np.exp(-0.5 * (radius / sigma) ** 2)

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -24,7 +24,6 @@ __all__ = [
     'binary_ring',
     'block_reduce_hdu',
     'contains',
-    'crop_image',
     'dict_to_hdulist',
     'disk_correlate',
     'downsample_2N',
@@ -34,7 +33,6 @@ __all__ = [
     'lon_lat_rectangle_mask',
     'lon_lat_circle_mask',
     'make_header',
-    'paste_cutout_into_image',
     'process_image_pixels',
     'ring_correlate',
     'shape_2N',
@@ -825,33 +823,6 @@ def make_header(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0,
     return header
 
 
-def crop_image(image, bounding_box):
-    """Crop an image (cut out a rectangular part).
-
-    Parameters
-    ----------
-    image : `~astropy.io.fits.ImageHDU`
-        Image
-    bounding_box : `~gammapy.image.BoundingBox`
-        Bounding box
-
-    Returns
-    -------
-    new_image : `~astropy.io.fits.ImageHDU`
-        Cropped image
-
-    See Also
-    --------
-    paste_cutout_into_image
-    """
-    data = image.data[bounding_box.slice]
-    header = image.header.copy()
-
-    # TODO: fix header keywords and test against ftcopy
-
-    return fits.ImageHDU(data=data, header=header)
-
-
 def contains(image, x, y, world=True):
     """Check if given pixel or world positions are in an image.
 
@@ -880,42 +851,6 @@ def contains(image, x, y, world=True):
 
     nx, ny = header['NAXIS2'], header['NAXIS1']
     return (x >= 0.5) & (x <= nx + 0.5) & (y >= 0.5) & (y <= ny + 0.5)
-
-
-def paste_cutout_into_image(total, cutout, method='sum'):
-    """Paste cutout into a total image.
-
-    Parameters
-    ----------
-    total, cutout : `~astropy.io.fits.ImageHDU`
-        Total and cutout image.
-    method : {'sum', 'replace'}, optional
-        Sum or replace total values with cutout values.
-
-    Returns
-    -------
-    total : `~astropy.io.fits.ImageHDU`
-        A reference to the total input HDU that was modified in-place.
-
-    See Also
-    --------
-    crop_image
-    """
-    # find offset
-    origin = 0  # convention for gammapy
-    lon, lat = WCS(cutout.header).wcs_pix2world(0, 0, origin)
-    x, y = WCS(total.header).wcs_world2pix(lon, lat, origin)
-    x, y = int(np.round(x)), int(np.round(y))
-    dy, dx = cutout.shape
-
-    if method == 'sum':
-        total.data[y: y + dy, x: x + dx] += cutout.data
-    elif method == 'replace':
-        total.data[y: y + dy, x: x + dx] = cutout.data
-    else:
-        raise ValueError('Invalid method: {0}'.format(method))
-
-    return total
 
 
 def block_reduce_hdu(input_hdu, block_size, func, cval=0):


### PR DESCRIPTION
This PR adds `cutout()`, `paste()` and `lookup_max()` methods to the `SkyMap` class and removes it from `gammapy.image.utils`