### PR TITLE
Fix skymap.solid_angle

### DIFF
--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from astropy.io import fits
 from astropy.coordinates import SkyCoord, Longitude, Latitude
+from astropy.coordinates.angle_utilities import angular_separation
 from astropy.wcs import WCS, WcsError
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 from astropy.units import Quantity, Unit
@@ -416,26 +417,17 @@ class SkyMap(object):
 
     def solid_angle(self):
         """
-        Solid angle image
-        TODO: description
+        Solid angle image (2-dim `astropy.units.Quantity` in `sr`).
         """
-        import sys
-        print (sys.stderr, "SOLID ANGLE")
         coordinates = self.coordinates(mode='edges')
-        lon = coordinates.data.lon
-        lat = coordinates.data.lat
+        lon = coordinates.data.lon.radian
+        lat = coordinates.data.lat.radian
 
-        # Convert to radians
-        lon = np.radians(lon)
-        lat = np.radians(lat)
-        # Find the dx and dy arrays
-        from astropy.coordinates.angle_utilities import angular_separation
         dx = angular_separation(lon[:, :-1], lat[:, :-1],
-                                lon[:, 1:], lat[:, :-1])
+                                    lon[:, 1:], lat[:, :-1])
 
         dy = angular_separation(lon[:-1, :], lat[:-1, :],
                                 lon[1:, :], lat[1:, :])
-        print ('DX-DY', dx.shape, dy.shape)
         return dx[1:, :] * dy[:, 1:]
 
     def center(self):

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -418,11 +418,29 @@ class SkyMap(object):
         """
         Solid angle image
         """
-        coordinates = self.coordinates(mode='edges')
-        xsky = coordinates.data.lon
-        ysky = coordinates.data.lat
-        omega = np.abs(np.diff(xsky, axis=1)[1:, :] * np.diff(ysky, axis=0)[:, 1:])
-        return omega.to('sr')
+
+    def solid_angle(self):
+        """
+        Solid angle image
+        TODO: description
+        """
+        import sys
+        print (sys.stderr, "SOLID ANGLE")
+        coordinates = self.coordinates()
+        lon = coordinates.data.lon
+        lat = coordinates.data.lat
+
+        # Convert to radians
+        lon = np.radians(lon)
+        lat = np.radians(lat)
+        # Find the dx and dy arrays
+        from astropy.coordinates.angle_utilities import angular_separation
+        dx = angular_separation(lon[:, :-1], lat[:, :-1],
+                                lon[:, 1:], lat[:, :-1])
+
+        dy = angular_separation(lon[:-1, :], lat[:-1, :],
+                                lon[1:, :], lat[1:, :])
+        return dx[1:, :] * dy[:, 1:]
 
     def center(self):
         """

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -428,7 +428,7 @@ class SkyMap(object):
 
         dy = angular_separation(lon[:-1, :], lat[:-1, :],
                                 lon[1:, :], lat[1:, :])
-        return dx[1:, :] * dy[:, 1:]
+        return Quantity(dx[1:, :] * dy[:, 1:], "sr")
 
     def center(self):
         """

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -417,16 +417,11 @@ class SkyMap(object):
     def solid_angle(self):
         """
         Solid angle image
-        """
-
-    def solid_angle(self):
-        """
-        Solid angle image
         TODO: description
         """
         import sys
         print (sys.stderr, "SOLID ANGLE")
-        coordinates = self.coordinates()
+        coordinates = self.coordinates(mode='edges')
         lon = coordinates.data.lon
         lat = coordinates.data.lat
 
@@ -440,6 +435,7 @@ class SkyMap(object):
 
         dy = angular_separation(lon[:-1, :], lat[:-1, :],
                                 lon[1:, :], lat[1:, :])
+        print ('DX-DY', dx.shape, dy.shape)
         return dx[1:, :] * dy[:, 1:]
 
     def center(self):

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -423,12 +423,17 @@ class SkyMap(object):
         lon = coordinates.data.lon.radian
         lat = coordinates.data.lat.radian
 
-        dx = angular_separation(lon[:, :-1], lat[:, :-1],
-                                    lon[:, 1:], lat[:, :-1])
+        # Compute solid angle using the approximation that it's
+        # the product between angular separation of pixel corners.
+        # First index is "y", second index is "x"
+        ylo_xlo = lon[:-1, :-1], lat[:-1, :-1]
+        ylo_xhi = lon[:-1, 1:], lat[:-1, 1:]
+        yhi_xlo = lon[1:, :-1], lat[1:, :-1]
 
-        dy = angular_separation(lon[:-1, :], lat[:-1, :],
-                                lon[1:, :], lat[1:, :])
-        return Quantity(dx[1:, :] * dy[:, 1:], "sr")
+        dx = angular_separation(*ylo_xlo, *ylo_xhi)
+        dy = angular_separation(*ylo_xlo, *yhi_xlo)
+        omega = Quantity(dx * dy, 'sr')
+        return omega
 
     def center(self):
         """

--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -430,8 +430,8 @@ class SkyMap(object):
         ylo_xhi = lon[:-1, 1:], lat[:-1, 1:]
         yhi_xlo = lon[1:, :-1], lat[1:, :-1]
 
-        dx = angular_separation(*ylo_xlo, *ylo_xhi)
-        dy = angular_separation(*ylo_xlo, *yhi_xlo)
+        dx = angular_separation(*(ylo_xlo + ylo_xhi))
+        dy = angular_separation(*(ylo_xlo + yhi_xlo))
         omega = Quantity(dx * dy, 'sr')
         return omega
 

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -54,7 +54,7 @@ class TestSkyMapPoisson():
 
     def test_solid_angle(self):
         solid_angle = self.skymap.solid_angle()
-        assert_allclose(solid_angle.to("deg2")[0, 0], Angle(0.02, "deg") ** 2)
+        assert_allclose(solid_angle.to("deg2")[0, 0], Angle(0.02, "deg") ** 2, rtol=1e-5)
 
     def test_contains(self):
         position = SkyCoord(0, 0, frame='galactic', unit='deg')

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import SkyCoord, Angle
 from astropy.io import fits
 from astropy.units import Quantity
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.wcs import WcsError
 from ..maps import SkyMap
 from ...data import DataStore
@@ -54,7 +54,7 @@ class TestSkyMapPoisson():
 
     def test_solid_angle(self):
         solid_angle = self.skymap.solid_angle()
-        assert_allclose(solid_angle[0, 0].value, 1.21774218981e-07, rtol=1e-3)
+        assert_quantity_allclose(solid_angle[0, 0], Angle(0.02, "deg") ** 2, rtol=1e-3)
 
     def test_contains(self):
         position = SkyCoord(0, 0, frame='galactic', unit='deg')

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -54,7 +54,7 @@ class TestSkyMapPoisson():
 
     def test_solid_angle(self):
         solid_angle = self.skymap.solid_angle()
-        assert_allclose(solid_angle.to("deg2")[0, 0], Angle(0.02, "deg") ** 2, rtol=1e-5)
+        assert_allclose(solid_angle.to("deg2")[0, 0], Angle(0.02, "deg") ** 2, rtol=1e-3)
 
     def test_contains(self):
         position = SkyCoord(0, 0, frame='galactic', unit='deg')

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -54,7 +54,7 @@ class TestSkyMapPoisson():
 
     def test_solid_angle(self):
         solid_angle = self.skymap.solid_angle()
-        assert_allclose(solid_angle.to("deg2")[0, 0], Angle(0.02, "deg") ** 2, rtol=1e-3)
+        assert_allclose(solid_angle[0, 0].value, 1.21774218981e-07, rtol=1e-3)
 
     def test_contains(self):
         position = SkyCoord(0, 0, frame='galactic', unit='deg')


### PR DESCRIPTION
The existing solid_angle doesn't work if pixel and sky coordinates are not aligned.

@cdeil 
Idea of angular_separation taken from https://github.com/radio-astro-tools/spectral-cube/blob/529eef048bd5440863e39ba9e06bf39ae41eb8d2/spectral_cube/spectral_cube.py#L1328
Proper method description and tests are to be done.
Existing test works with rtol=1e-3