### PR TITLE
Add SkyImageList -- bridge between list of SkyMaps and SkyCube, add conversion methods and test

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -526,6 +526,14 @@ class SkyCube(object):
 
         return hdu_list
 
+
+    def to_image_list(self):
+        """ Writes SkyCube to `gammapy.image.SkyImageList` as a list of `gammapy.image.SkyMap` objects.
+        """
+        skymaps = [SkyMap(self.name, Quantity(slice_data, self.data.unit), self.wcs) for slice_data in self.data]
+        from gammapy.image.lists import SkyImageList
+        return SkyImageList(self.name, skymaps, self.wcs, self.energy)
+
     def writeto(self, filename, **kwargs):
         """Writes SkyCube to FITS file.
 

--- a/gammapy/image/lists.py
+++ b/gammapy/image/lists.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from astropy.units import Quantity
+from astropy.wcs import WCS
+from ..utils.testing import requires_dependency, requires_data
+from . import catalog
+from ..image import SkyMap
+from ..irf import EnergyDependentTablePSF
+from ..cube import SkyCube
+from ..datasets import FermiGalacticCenter
+import numpy as np
+
+__all__ = ['SkyImageList']
+
+
+class SkyImageList(object):
+    """
+    Class to represent connection between `~gammapy.image.SkyMap` and `~gammapy.cube.SkyCube`.
+    Keeps list of images and has methods to convert between them and SkyCube.
+
+    Parameters
+    ----------
+    name : str
+        Name of the sky image list.
+    skymaps : list of `~gammapy.image.SkyMap`
+        Data array as list of skymaps.
+    wcs : `~astropy.wcs.WCS`
+        Word coordinate system transformation
+    energy : `~astropy.units.Quantity`
+        Energy array
+    """
+
+    def __init__(self, name=None, skymaps=None, wcs=None, energy=None):
+        self.name = None
+        self.skymaps = skymaps
+        self.wcs = wcs
+        self.energy = energy
+
+    def to_cube(self):
+        """Convert a list of image HDUs into one cube.
+        """
+        data = Quantity([skymap.data for skymap in self.skymaps],
+                        self.skymaps[0].data.unit)
+        return SkyCube(name=self.name, data=data, wcs=self.wcs, energy=self.energy)

--- a/gammapy/image/tests/test_lists.py
+++ b/gammapy/image/tests/test_lists.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from gammapy.datasets import FermiGalacticCenter
+import numpy as np
+
+
+def test_to_cube():
+    sky_cube_original = FermiGalacticCenter.diffuse_model()
+    image_list = sky_cube_original.to_image_list()
+    assert np.array_equal(image_list.skymaps[0].data, sky_cube_original.data[0])
+    sky_cube_restored = image_list.to_cube()
+
+    for key in set(sky_cube_original.__dict__.keys() + sky_cube_restored.__dict__.keys()):
+        # the __init__ of SkyCube initializes energy_axis from energy, but the original cube may not have this field.
+        # Thus the deep equality is not possible and we have to go through it's fields
+        if key == 'energy_axis':
+            continue
+
+        if isinstance(sky_cube_original.__dict__[key], np.ndarray):
+            assert np.array_equal(sky_cube_original.__dict__[key], sky_cube_restored.__dict__[key]),\
+                "differs on {} ".format(key)
+        else:
+            assert sky_cube_original.__dict__[key] == sky_cube_restored.__dict__[key], "differs on {} ".format(key)


### PR DESCRIPTION
Initial pull request for `SkyImageList`
Now it's possible to do

```
cube = SkyCube.read()
sky_image_list = cube.to_image_list()
cube2 = sky_image_list.to_cube()
# cube2 should be the same as cube1

```
and to access individual skymaps like 'sky_image_list.skymaps[i]`

Hi @cdeil,
please take a look and say how close it to what you have imagined and what other functionality should I add :)