### PR TITLE
Add SkyImageList

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -541,6 +541,14 @@ class SkyCube(object):
 
         return hdu_list
 
+
+    def to_image_list(self):
+        """ Writes SkyCube to `gammapy.image.SkyImageList` as a list of `gammapy.image.SkyMap` objects.
+        """
+        skymaps = [SkyMap(self.name, Quantity(slice_data, self.data.unit), self.wcs) for slice_data in self.data]
+        from gammapy.image.lists import SkyImageList
+        return SkyImageList(self.name, skymaps, self.wcs, self.energy)
+
     def writeto(self, filename, **kwargs):
         """Writes SkyCube to FITS file.
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -39,11 +39,7 @@ class SkyCube(object):
     The order of the sky cube axes can be very confusing ... this should help:
 
     * The ``data`` array axis order is ``(energy, lat, lon)``.
-    * The ``wcs`` object axis order is ``(lon, lat, energy)``.
-    * Methods use the ``wcs`` order of ``(lon, lat, energy)``,
-      but internally when accessing the data often the reverse order is used.
-      We use ``(xx, yy, zz)`` as pixel coordinates for ``(lon, lat, energy)``,
-      as that matches the common definition of ``x`` and ``y`` in image viewers.
+    * The ``wcs`` object is a two dimensional celestial WCS with axis order ``(lon, lat)``.
 
     Parameters
     ----------
@@ -545,7 +541,7 @@ class SkyCube(object):
     def to_image_list(self):
         """ Writes SkyCube to `gammapy.image.SkyImageList` as a list of `gammapy.image.SkyMap` objects.
         """
-        skymaps = [SkyMap(self.name, Quantity(slice_data, self.data.unit), self.wcs) for slice_data in self.data]
+        skymaps = [self.sky_image(slicepos) for slicepos in range(len(self.data))]
         from gammapy.image.lists import SkyImageList
         return SkyImageList(self.name, skymaps, self.wcs, self.energy)
 

--- a/gammapy/image/lists.py
+++ b/gammapy/image/lists.py
@@ -1,14 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing import assert_allclose
 from astropy.units import Quantity
-from astropy.wcs import WCS
-from ..utils.testing import requires_dependency, requires_data
-from . import catalog
-from ..image import SkyMap
-from ..irf import EnergyDependentTablePSF
-from ..cube import SkyCube
-from ..datasets import FermiGalacticCenter
-import numpy as np
 
 __all__ = ['SkyImageList']
 
@@ -39,6 +31,7 @@ class SkyImageList(object):
     def to_cube(self):
         """Convert a list of image HDUs into one cube.
         """
+        from ..cube import SkyCube
         data = Quantity([skymap.data for skymap in self.skymaps],
                         self.skymaps[0].data.unit)
         return SkyCube(name=self.name, data=data, wcs=self.wcs, energy=self.energy)

--- a/gammapy/image/lists.py
+++ b/gammapy/image/lists.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from astropy.units import Quantity
+from astropy.wcs import WCS
+from ..utils.testing import requires_dependency, requires_data
+from . import catalog
+from ..image import SkyMap
+from ..irf import EnergyDependentTablePSF
+from ..cube import SkyCube
+from ..datasets import FermiGalacticCenter
+import numpy as np
+
+__all__ = ['SkyImageList']
+
+
+class SkyImageList(object):
+    """
+    Class to represent connection between `~gammapy.image.SkyMap` and `~gammapy.cube.SkyCube`.
+    Keeps list of images and has methods to convert between them and SkyCube.
+
+    Parameters
+    ----------
+    name : str
+        Name of the sky image list.
+    skymaps : list of `~gammapy.image.SkyMap`
+        Data array as list of skymaps.
+    wcs : `~astropy.wcs.WCS`
+        Word coordinate system transformation
+    energy : `~astropy.units.Quantity`
+        Energy array
+    """
+
+    def __init__(self, name=None, skymaps=None, wcs=None, energy=None):
+        self.name = None
+        self.skymaps = skymaps
+        self.wcs = wcs
+        self.energy = energy
+
+    def to_cube(self):
+        """Convert a list of image HDUs into one cube.
+        """
+        data = Quantity([skymap.data for skymap in self.skymaps],
+                        self.skymaps[0].data.unit)
+        return SkyCube(name=self.name, data=data, wcs=self.wcs, energy=self.energy)

--- a/gammapy/image/tests/test_lists.py
+++ b/gammapy/image/tests/test_lists.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+from gammapy.datasets import FermiGalacticCenter
+import numpy as np
+
+
+def test_to_cube():
+    sky_cube_original = FermiGalacticCenter.diffuse_model()
+    image_list = sky_cube_original.to_image_list()
+    assert np.array_equal(image_list.skymaps[0].data, sky_cube_original.data[0])
+    sky_cube_restored = image_list.to_cube()
+
+    for key in set(sky_cube_original.__dict__.keys() + sky_cube_restored.__dict__.keys()):
+        # the __init__ of SkyCube initializes energy_axis from energy, but the original cube may not have this field.
+        # Thus the deep equality is not possible and we have to go through it's fields
+        if key == 'energy_axis':
+            continue
+
+        if isinstance(sky_cube_original.__dict__[key], np.ndarray):
+            assert np.array_equal(sky_cube_original.__dict__[key], sky_cube_restored.__dict__[key]),\
+                "differs on {} ".format(key)
+        else:
+            assert sky_cube_original.__dict__[key] == sky_cube_restored.__dict__[key], "differs on {} ".format(key)

--- a/gammapy/image/tests/test_lists.py
+++ b/gammapy/image/tests/test_lists.py
@@ -13,6 +13,6 @@ def test_to_cube():
     assert_array_equal(image_list.skymaps[0].data, sky_cube_original.data[0])
 
     assert_array_equal(sky_cube_restored.data, sky_cube_original.data)
-    assert sky_cube_restored.energy == sky_cube_original.energy
+    assert_array_equal(sky_cube_restored.energy, sky_cube_original.energy)
     assert sky_cube_restored.name == sky_cube_original.name
     assert sky_cube_restored.wcs == sky_cube_original.wcs

--- a/gammapy/image/tests/test_lists.py
+++ b/gammapy/image/tests/test_lists.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from gammapy.utils.testing import requires_data
 from gammapy.datasets import FermiGalacticCenter

--- a/gammapy/image/tests/test_lists.py
+++ b/gammapy/image/tests/test_lists.py
@@ -1,22 +1,18 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+from gammapy.utils.testing import requires_data
 from gammapy.datasets import FermiGalacticCenter
-import numpy as np
+from numpy.testing import assert_array_equal
 
 
+@requires_data("gammapy-extra")
 def test_to_cube():
     sky_cube_original = FermiGalacticCenter.diffuse_model()
     image_list = sky_cube_original.to_image_list()
-    assert np.array_equal(image_list.skymaps[0].data, sky_cube_original.data[0])
     sky_cube_restored = image_list.to_cube()
 
-    for key in set(sky_cube_original.__dict__.keys() + sky_cube_restored.__dict__.keys()):
-        # the __init__ of SkyCube initializes energy_axis from energy, but the original cube may not have this field.
-        # Thus the deep equality is not possible and we have to go through it's fields
-        if key == 'energy_axis':
-            continue
+    assert_array_equal(image_list.skymaps[0].data, sky_cube_original.data[0])
 
-        if isinstance(sky_cube_original.__dict__[key], np.ndarray):
-            assert np.array_equal(sky_cube_original.__dict__[key], sky_cube_restored.__dict__[key]),\
-                "differs on {} ".format(key)
-        else:
-            assert sky_cube_original.__dict__[key] == sky_cube_restored.__dict__[key], "differs on {} ".format(key)
+    assert_array_equal(sky_cube_restored.data, sky_cube_original.data)
+    assert sky_cube_restored.energy == sky_cube_original.energy
+    assert sky_cube_restored.name == sky_cube_original.name
+    assert sky_cube_restored.wcs == sky_cube_original.wcs


### PR DESCRIPTION
Initial pull request for SkyImageList -- bridge between SkyMap and SkyCube
Now it's possible to do
```
cube = SkyCube.read()
sky_image_list = cube.to_image_list()
cube2 = sky_image_list.to_cube()

 cube2 == cube1
```
and to access individual skymaps like 'sky_image_list.skymaps[i]`

Hi @cdeil,
please take a look and say how close it to what you have imagined and what other functionality should I add :)