### PR TITLE
Fix SpectrumObservation

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -150,7 +150,6 @@ class EffectiveAreaTable2D(NDDataArray):
 
     @property
     def low_threshold(self):
-
         """Low energy threshold"""
         return self.meta.LO_THRES * u.TeV
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -104,8 +104,8 @@ class EnergyDispersion(object):
         ss += 'PDF matrix threshold: {0}\n'.format(self.pdf_threshold)
         m = self._pdf_matrix
         ss += 'PDF matrix filling factor: {0}\n'.format(np.sum(m > 0) / m.size)
-        ss += 'True energy range: {0}\n'.format(self.energy_range('true'))
-        ss += 'Reco energy range: {0}\n'.format(self.energy_range('reco'))
+        ss += 'True energy min: {:.2f}\n'.format(self.reco_energy[0])
+        ss += 'Reco energy min: {:.2f}\n'.format(self.true_energy[0])
         return ss
 
     @classmethod

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -4,6 +4,11 @@ from astropy.table import Table
 from .. import version
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.scripts import make_path
+from ..utils.fits import (
+    energy_axis_to_ebounds,
+    fits_table_to_table,
+    ebounds_to_energy_axis,
+)
 from ..data import EventList
 from ..extern.pathlib import Path
 import astropy.units as u
@@ -49,12 +54,12 @@ class CountsSpectrum(NDDataArray):
     interp_kwargs = dict(bounds_error=False, method='nearest')
 
     @classmethod
-    def from_table(cls, table):
-        """Read OGIP format table"""
-        counts = table['COUNTS'].quantity
-        energy_unit = table['BIN_LO'].quantity.unit
-        energy = np.append(table['BIN_LO'].data, table['BIN_HI'].data[-1])
-        return cls(data=counts, energy=energy*energy_unit)
+    def from_hdulist(cls, hdulist):
+        """Read OGIP format hdulist"""
+        counts_table = fits_table_to_table(hdulist[1])
+        counts = counts_table['COUNTS'] * u.ct
+        ebounds = ebounds_to_energy_axis(hdulist[2])
+        return cls(data=counts, energy=ebounds)
 
     def to_table(self):
         """Convert to `~astropy.table.Table`
@@ -64,14 +69,21 @@ class CountsSpectrum(NDDataArray):
         channel = np.arange(self.energy.nbins, dtype=np.int16)
         counts = np.array(self.data.value, dtype=np.int32)
 
-        # This is how sherpa save energy information in PHA files
-        # https://github.com/sherpa/sherpa/blob/master/sherpa/astro/io/pyfits_backend.py#L643
-        bin_lo = self.energy.data[:-1]
-        bin_hi = self.energy.data[1:]
-        names = ['CHANNEL', 'COUNTS', 'BIN_LO', 'BIN_HI']
+        names = ['CHANNEL', 'COUNTS']
         meta = dict()
-        return Table([channel, counts, bin_lo, bin_hi], names=names, meta=meta)
-        
+        return Table([channel, counts], names=names, meta=meta)
+
+    def to_hdulist(self):
+        """Convert to `~astropy.io.fits.HDUList`
+
+        This adds an ``EBOUNDS`` extension to the ``BinTableHDU`` produced by 
+        ``to_table``, in order to store the energy axis
+        """
+        hdulist = super(CountsSpectrum, self).to_hdulist()
+        ebounds = energy_axis_to_ebounds(self.energy)
+        hdulist.append(ebounds)
+        return hdulist
+
     def fill(self, events):
         """Fill with list of events 
         
@@ -220,9 +232,6 @@ class PHACountsSpectrum(CountsSpectrum):
     def to_table(self):
         """Write"""
         table = super(PHACountsSpectrum, self).to_table()
-        # Remove BIN_LO and BIN_HI columns for now
-        # see https://github.com/gammapy/gammapy/issues/561
-        table.remove_columns(['BIN_LO', 'BIN_HI'])
         
         meta = dict(name='SPECTRUM',
                     hduclass='OGIP',
@@ -264,21 +273,22 @@ class PHACountsSpectrum(CountsSpectrum):
         return table
 
     @classmethod
-    def from_table(cls, table):
+    def from_hdulist(cls, hdulist):
         """Read"""
-        # This will fail since BIN_LO and BIN_HI are not present
-        # spec = CountsSpectrum.from_table(table)
-        counts = table['COUNTS'].quantity
-        # FIXME : set energy to CHANNELS * u.eV, WRONG 
-        energy = np.append([0], table['CHANNEL'].data) * u.eV
+        spec = CountsSpectrum.from_hdulist(hdulist)
+        counts = spec.data
+        energy = spec.energy
         meta = dict(
-            obs_id=table.meta['OBS_ID'],
-            exposure=table.meta['EXPOSURE'] * u.s,
-            backscal=table.meta['BACKSCAL']
+            obs_id=hdulist[1].header['OBS_ID'],
+            exposure=hdulist[1].header['EXPOSURE'] * u.s,
+            backscal=hdulist[1].header['BACKSCAL']
         )
-        if table.meta["HDUCLAS2"] == "TOTAL":
-            meta.update(lo_threshold=table.meta['lo_threshold'] * u.TeV,
-                        hi_threshold=table.meta['hi_threshold'] * u.TeV)
+        if hdulist[1].header['HDUCLAS2'] == 'TOTAL':
+            meta.update(lo_threshold=hdulist[1].header['LO_THRES'] * u.TeV,
+                        hi_threshold=hdulist[1].header['HI_THRES'] * u.TeV,
+                        is_bkg = False)
+        elif hdulist[1].header['HDUCLAS2'] == 'BKG':
+            meta.update(is_bkg = True)
         return cls(energy=energy, data=counts, **meta)
 
 
@@ -405,14 +415,14 @@ class SpectrumObservation(object):
         self._phafile = outdir / phafile
         # Write in keV and cm2
         self.on_vector.energy.data = self.on_vector.energy.data.to('keV')
-        self.on_vector.write(outdir / phafile, overwrite=overwrite)
+        self.on_vector.write(outdir / phafile, clobber=overwrite)
 
         self.off_vector.energy.data = self.off_vector.energy.data.to('keV')
-        self.off_vector.write(outdir / bkgfile, overwrite=overwrite)
+        self.off_vector.write(outdir / bkgfile, clobber=overwrite)
 
         self.aeff.data = self.aeff.data.to('cm2')
         self.aeff.energy.data = self.aeff.energy.data.to('keV')
-        self.aeff.write(outdir / arffile, overwrite=overwrite)
+        self.aeff.write(outdir / arffile, clobber=overwrite)
 
         self.edisp.write(str(outdir / rmffile), energy_unit='keV',
                          clobber=overwrite)

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -275,9 +275,9 @@ class PHACountsSpectrum(CountsSpectrum):
     @classmethod
     def from_hdulist(cls, hdulist):
         """Read"""
-        spec = CountsSpectrum.from_hdulist(hdulist)
-        counts = spec.data
-        energy = spec.energy
+        counts_table = fits_table_to_table(hdulist[1])
+        counts = counts_table['COUNTS'] * u.ct
+        ebounds = ebounds_to_energy_axis(hdulist[2])
         meta = dict(
             obs_id=hdulist[1].header['OBS_ID'],
             exposure=hdulist[1].header['EXPOSURE'] * u.s,
@@ -289,7 +289,7 @@ class PHACountsSpectrum(CountsSpectrum):
                         is_bkg = False)
         elif hdulist[1].header['HDUCLAS2'] == 'BKG':
             meta.update(is_bkg = True)
-        return cls(energy=energy, data=counts, **meta)
+        return cls(energy=ebounds, data=counts, **meta)
 
 
 class SpectrumObservation(object):

--- a/gammapy/spectrum/spectrum_fit.py
+++ b/gammapy/spectrum/spectrum_fit.py
@@ -301,8 +301,6 @@ class SpectrumFit(object):
                 thres_hi = self.obs_list[i].hi_threshold.to('keV').value
             else:
                 thres_hi = self._thres_hi.to('keV').value
-            import IPython;
-            IPython.embed()
             datastack.notice_id(i + 1, thres_lo, thres_hi)
             namedataset.append(i + 1)
         datastack.set_stat(self.statistic)
@@ -347,4 +345,4 @@ class SpectrumFit(object):
             self.make_npred()
         for key, val in self.n_pred.items():
             filename = "npred_run{}.fits".format(key)
-            val.write(str(outdir / filename), overwrite=True)
+            val.write(str(outdir / filename), clobber=True)

--- a/gammapy/spectrum/tests/test_counts_spectrum.py
+++ b/gammapy/spectrum/tests/test_counts_spectrum.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 import astropy.units as u
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from numpy.testing import assert_equal, assert_allclose
 
 from .. import CountsSpectrum, SpectrumExtraction, SpectrumFitResult, \
@@ -14,9 +14,6 @@ from ...datasets import gammapy_extra
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.energy import EnergyBounds
 
-# TODO for Johannes:
-# https://travis-ci.org/gammapy/gammapy/jobs/136111773#L938
-@pytest.mark.xfail(reason='BIN_LO and BIN_HI have been removed')
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_CountsSpectrum(tmpdir):
@@ -48,8 +45,8 @@ def test_CountsSpectrum(tmpdir):
     f = tmpdir / 'test.fits'
     spec.write(f)
     spec2 = CountsSpectrum.read(f)
-
-    assert (spec.energy.data == spec2.energy.data).all()
+    assert_quantity_allclose(spec2.energy.data,
+                             EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV'))
 
     #add two spectra
     bins = spec.energy.nbins
@@ -59,6 +56,7 @@ def test_CountsSpectrum(tmpdir):
     desired = spec.data[5] + counts[5]
     actual = pha_sum.data[5]
     assert_equal(actual, desired)
+
 
 @pytest.mark.xfail(reason='broken')
 @requires_dependency('sherpa')

--- a/gammapy/spectrum/tests/test_spectrum_extraction.py
+++ b/gammapy/spectrum/tests/test_spectrum_extraction.py
@@ -91,10 +91,13 @@ def test_spectrum_extraction(pars,results,tmpdir):
         outdir = gammapy_extra.filename("datasets/hess-crab4_pha")
         ana.observations.write(outdir)
         testobs = SpectrumObservation.read(make_path(outdir)/'pha_obs23523.fits') 
-        assert str(testobs.aeff) == str(obs23523.aeff) 
-        assert str(testobs.on_vector) == str(obs23523.on_vector) 
-        assert str(testobs.off_vector) == str(obs23523.off_vector) 
-        assert str(testobs.edisp) == str(obs23523.edisp) 
+        assert_quantity_allclose(testobs.aeff.data,
+                                 obs23523.aeff.data) 
+        assert_quantity_allclose(testobs.on_vector.data,
+                                 obs23523.on_vector.data) 
+        assert_quantity_allclose(testobs.on_vector.energy.nodes,
+                                 obs23523.on_vector.energy.nodes) 
+
     
 @pytest.mark.xfail(reason='This needs some changes to the API')
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/tests/test_spectrum_extraction.py
+++ b/gammapy/spectrum/tests/test_spectrum_extraction.py
@@ -23,7 +23,7 @@ from ...spectrum import (
 )
 from ...utils.energy import EnergyBounds
 from ...utils.testing import requires_dependency, requires_data
-from ...utils.scripts import read_yaml
+from ...utils.scripts import read_yaml, make_path
 
 
 @pytest.mark.parametrize("pars,results",[
@@ -84,7 +84,17 @@ def test_spectrum_extraction(pars,results,tmpdir):
     assert_allclose(ana.observations[0].lo_threshold,results['ethresh'])
 
     assert_quantity_allclose(obs23523.aeff.evaluate(energy=5*u.TeV),results['aeff'])
-
+    
+    # Write on set of output files to gammapy-extra as input for other tests
+    # and check I/O
+    if not pars['containment_correction']:
+        outdir = gammapy_extra.filename("datasets/hess-crab4_pha")
+        ana.observations.write(outdir)
+        testobs = SpectrumObservation.read(make_path(outdir)/'pha_obs23523.fits') 
+        assert str(testobs.aeff) == str(obs23523.aeff) 
+        assert str(testobs.on_vector) == str(obs23523.on_vector) 
+        assert str(testobs.off_vector) == str(obs23523.off_vector) 
+        assert str(testobs.edisp) == str(obs23523.edisp) 
     
 @pytest.mark.xfail(reason='This needs some changes to the API')
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/tests/test_spectrum_fit.py
+++ b/gammapy/spectrum/tests/test_spectrum_fit.py
@@ -11,27 +11,24 @@ from ...utils.testing import requires_dependency, requires_data, SHERPA_LT_4_8
 from astropy.utils.compat import NUMPY_LT_1_9
 
 
-#TODO : PHACount should not expect a BIN_LO and BIN_HI columns
-#https://travis-ci.org/gammapy/gammapy/jobs/136170992#L939 
-@pytest.mark.xfail(reason='BIN_LO and BIN_HI columns in the pha file must be removed')
 @pytest.mark.skipif('NUMPY_LT_1_9')
 @pytest.mark.skipif('SHERPA_LT_4_8')
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
-@pytest.mark.xfail
 def test_spectral_fit():
     pha1 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23592.fits")
     pha2 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23523.fits")
-
     obs1 = SpectrumObservation.read(pha1)
     obs2 = SpectrumObservation.read(pha2)
     obs_list = SpectrumObservationList([obs1, obs2])
+
     fit = SpectrumFit(obs_list)
-    #fit = SpectrumFit(SpectrumObservationList([obs1]))
+    
     fit.model = 'PL'
     fit.energy_threshold_low = '1 TeV'
     fit.energy_threshold_high = '10 TeV'
+
     fit.run(method='sherpa')
     assert fit.result.spectral_model == 'PowerLaw'
-    print (fit.result)
-    1/0
+    
+    #TODO: add real asserts here

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -2,6 +2,7 @@
 """FITS utility functions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 
@@ -9,6 +10,7 @@ __all__ = [
     'get_hdu',
     'table_to_fits_table',
     'fits_table_to_table',
+    'energy_axis_to_ebounds',
 ]
 
 
@@ -110,3 +112,45 @@ def fits_table_to_table(tbhdu):
         table[colname].unit = tbhdu.columns[colname].unit
 
     return table
+
+
+def energy_axis_to_ebounds(energy):
+    """Convert energy `~gammapy.utils.nddata.BinnedEnergyAxis` to OGIP
+    ``EBOUNDS`` extension 
+
+    see
+    http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.2
+    """
+    table = Table()
+
+    table['CHANNEL'] = np.arange(energy.nbins, dtype=np.int16)
+    table['E_MIN'] = energy.data[:-1] 
+    table['E_MAX'] = energy.data[1:]
+
+    hdu = table_to_fits_table(table)
+    
+    header = hdu.header
+    header['EXTNAME'] = 'EBOUNDS', 'Name of this binary table extension'
+    header['TELESCOP'] = 'DUMMY', 'Mission/satellite name'
+    header['INSTRUME'] = 'DUMMY', 'Instrument/detector'
+    header['FILTER'] = 'None', 'Filter information'
+    header['CHANTYPE'] = 'PHA', 'Type of channels (PHA, PI etc)'
+    header['DETCHANS'] = energy.nbins, 'Total number of detector PHA channels'
+    header['HDUCLASS'] = 'OGIP', 'Organisation devising file format'
+    header['HDUCLAS1'] = 'RESPONSE', 'File relates to response of instrument'
+    header['HDUCLAS2'] = 'EBOUNDS', 'This is an EBOUNDS extension'
+    header['HDUVERS'] = '1.2.0', 'Version of file format'
+
+    return hdu
+
+
+def ebounds_to_energy_axis(ebounds):
+    """Convert ``EBOUNDS`` extension to energy
+    `~gammapy.utils.nddata.BinnedEnergyAxis`
+    """
+    from .nddata import BinnedDataAxis
+    table = fits_table_to_table(ebounds)
+    energy = np.append(table['E_MIN'], table['E_MAX'][-1])
+
+    return BinnedDataAxis(data=energy)
+

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -150,7 +150,8 @@ def ebounds_to_energy_axis(ebounds):
     """
     from .nddata import BinnedDataAxis
     table = fits_table_to_table(ebounds)
-    energy = np.append(table['E_MIN'], table['E_MAX'][-1])
-
+    emin = table['E_MIN'].quantity
+    emax = table['E_MAX'].quantity
+    energy = np.append(emin.value, emax.value[-1]) * emin.unit
     return BinnedDataAxis(data=energy)
 

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import itertools
 import numpy as np
 import abc
+import copy
 from ..extern.bunch import Bunch
 from astropy.units import Quantity
 from astropy.table import Table, Column
@@ -59,8 +60,12 @@ class NDDataArray(object):
                 value = value.data
             elif not isinstance(value, Quantity):
                 raise ValueError('No unit for axis "{}"'.format(axis_name))
-            axis = getattr(self, axis_name)
+            # This is needed to transform the class level axis attribute to an
+            # instance level attribute
+            template_axis = getattr(self, axis_name)
+            axis = copy.deepcopy(template_axis)
             axis.data = value
+            setattr(self, axis_name, axis)
             self._axes.append(axis)
 
         # Set remaining kwargs as attributes


### PR DESCRIPTION
Due to several issues the disk I/O for ``gammapy.spectrum.SpectrumObservation`` was broken. This PR fixes this

* [x] Add ``EBOUNDS`` extension to PHA file
* [x] Change axes in ``NDData`` from class level to instance level attributes
* [x] Auto generate example files in gammapy-extra 