### PR TITLE
Add keywords to PHA files

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -593,7 +593,7 @@ class DataStoreObservation(object):
     def __str__(self):
         """Generate summary info string."""
         ss = 'Info for OBS_ID = {}\n'.format(self.obs_id)
-        ss += '- Start time: {}\n'.format(self.tstart)
+        ss += '- Start time: {:.2f}\n'.format(self.tstart.mjd)
         ss += '- Pointing pos: RA {:.2f} / Dec {:.2f}\n'.format(self.pointing_radec.ra, self.pointing_radec.dec)
         ss += '- Observation duration: {}\n'.format(self.observation_time_duration)
         ss += '- Dead-time fraction: {:5.3f} %\n'.format(100 * self.observation_dead_time_fraction)

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -8,6 +8,7 @@ import subprocess
 from astropy.table import Table
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
+from astropy.time import Time
 from astropy.coordinates import SkyCoord
 from ..utils.scripts import make_path
 from ..utils.energy import Energy
@@ -509,6 +510,33 @@ class DataStoreObservation(object):
     def tstart(self):
         """Observation start time (`~astropy.time.Time`)."""
         info = self._obs_info
+        return Time(info['TSTART'], format='mjd')
+
+    @lazyproperty
+    def tstop(self):
+        """Observation stop time (`~astropy.time.Time`)."""
+        info = self._obs_info
+        return Time(info['TSTOP'], format='mjd')
+
+    @lazyproperty
+    def muoneff(self):
+        """Observation muon efficiency."""
+        info = self._obs_info
+        return info['MUONEFF']
+
+    @lazyproperty
+    def pointing_altaz(self):
+        """Pointing ALT / AZ sky coordinates (`~astropy.coordinates.SkyCoord`)"""
+        info = self._obs_info
+        alt, az = info['ALT_PNT'], info['AZ_PNT']
+        return SkyCoord(az, alt, unit='deg', frame='altaz')
+
+    @lazyproperty
+    def pointing_zen(self):
+        """Pointing zenith angle sky (`~astropy.units.Quantity`)"""
+        info = self._obs_info
+        zen = info['ZEN_PNT']
+        return Quantity(zen, unit='deg')
         return Quantity(info['TSTART'], 'second')
 
     @lazyproperty
@@ -565,7 +593,7 @@ class DataStoreObservation(object):
     def __str__(self):
         """Generate summary info string."""
         ss = 'Info for OBS_ID = {}\n'.format(self.obs_id)
-        ss += '- Start time: {:.2f}\n'.format(self.tstart)
+        ss += '- Start time: {}\n'.format(self.tstart)
         ss += '- Pointing pos: RA {:.2f} / Dec {:.2f}\n'.format(self.pointing_radec.ra, self.pointing_radec.dec)
         ss += '- Observation duration: {}\n'.format(self.observation_time_duration)
         ss += '- Dead-time fraction: {:5.3f} %\n'.format(100 * self.observation_dead_time_fraction)

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -227,6 +227,14 @@ class PHACountsSpectrum(CountsSpectrum):
         Instrument, detector
     creator : str, optional
         Software used to produce the PHA file
+    tstart :  `~astropy.time.Time`, optional
+        Time start MJD
+    tstop :  `~astropy.time.Time`, optional
+        Time stop MJD
+    muoneff : float, optional
+        Muon efficiency
+    zen_pnt : `~astropy.coordinates.Angle`, optional
+        Zenith Angle
     """
 
     def __init__(self, **kwargs):
@@ -281,6 +289,19 @@ class PHACountsSpectrum(CountsSpectrum):
         else:
             meta.update(hduclas2='BKG', )
 
+        # Add general optional keywords if the member exists rather than default value. LBYL approach
+        if hasattr(self,'tstart'):
+            meta.update(tstart=self.tstart.mjd)
+
+        if hasattr(self,'tstop'):
+            meta.update(tstop=self.tstop.mjd)
+
+        if hasattr(self,'muoneff'):
+            meta.update(muoneff=self.muoneff)
+
+        if hasattr(self,'zen_pnt'):
+            meta.update(zen_pnt=self.zen_pnt.to('deg').value)
+            
         table.meta = meta
         return table
 

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -154,6 +154,25 @@ class SpectrumExtraction(object):
                                  hi_threshold=obs.aeff.high_threshold,
                                  lo_threshold=obs.aeff.low_threshold)
 
+            # We now add a number of optional keywords for the DataStoreObservation
+            # We first check that the entry exists in the table
+            try:
+                counts_kwargs.update(tstart=obs.tstart)
+            except KeyError:
+                pass
+            try:
+                counts_kwargs.update(tstop=obs.tstop)
+            except KeyError:
+                pass
+            try:
+                counts_kwargs.update(muoneff=obs.muoneff)
+            except KeyError:
+                pass
+            try:
+                counts_kwargs.update(zen_pnt=obs.pointing_zen)
+            except KeyError:
+                pass
+
             on_vec = PHACountsSpectrum(backscal=bkg.a_on, **counts_kwargs)
             off_vec = PHACountsSpectrum(backscal=bkg.a_off, is_bkg=True, **counts_kwargs)
 


### PR DESCRIPTION
This PR adds some keywords to the PHA file.

To do so some members have been added to DataStoreObservation.
     tstart property is now an '~astropy.time.Time' instance

Should we add a test to check that columns are really present before adding properties to the DataStoreObservation? 

