### PR TITLE
Add spectrum energy flux computation

### DIFF
--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -11,6 +11,7 @@ __all__ = [
     'power_law_pivot_energy',
     'df_over_f',
     'power_law_flux',
+    'power_law_energy_flux',
     'power_law_integral_flux',
     'g_from_f',
     'g_from_points',
@@ -101,6 +102,37 @@ def power_law_flux(I=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):
     return I / _conversion_factor(g, e, e1, e2)
 
 
+def power_law_energy_flux(I, g=g_DEFAULT, e=1, e1=1, e2=10):
+    """
+    Compute energy flux between e1 and e2 for a given integral flux.
+
+    The analytical solution for the powerlaw case is given by:
+
+    .. math::
+
+        G(E_1, E_2) = I(\\epsilon, \\infty) \\, \\frac{1-\\Gamma}
+        {2-\\Gamma} \\, \\frac{E_1^{2-\\Gamma} - E_2^{2-\\Gamma}}{\\epsilon^{1-\\Gamma}}
+
+    Parameters
+    ----------
+    I : array_like
+        Integral flux in ``energy_min``, ``energy_max`` band
+    g : array_like
+        Power law spectral index
+    e : array_like
+        Energy at above which the integral flux is given.
+    e1 : array_like
+        Energy band minimum
+    e2 : array_like
+        Energy band maximum
+
+    """
+    g1     = 1. - g
+    g2     = 2. - g
+    factor = g1 / g2 * (e1 ** g2 - e2 ** g2) / e ** g1
+    return I * factor
+
+
 def power_law_integral_flux(f=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):
     """Compute integral flux for a given differential flux.
 
@@ -123,6 +155,9 @@ def power_law_integral_flux(f=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):
         Integral flux in ``energy_min``, ``energy_max`` band
     """
     return f * _conversion_factor(g, e, e1, e2)
+
+
+
 
 
 def g_from_f(e, f, de=1):

--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -103,15 +103,15 @@ def power_law_flux(I=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):
 
 
 def power_law_energy_flux(I, g=g_DEFAULT, e=1, e1=1, e2=10):
-    """
+    r"""
     Compute energy flux between e1 and e2 for a given integral flux.
 
     The analytical solution for the powerlaw case is given by:
 
     .. math::
 
-        G(E_1, E_2) = I(\\epsilon, \\infty) \\, \\frac{1-\\Gamma}
-        {2-\\Gamma} \\, \\frac{E_1^{2-\\Gamma} - E_2^{2-\\Gamma}}{\\epsilon^{1-\\Gamma}}
+        G(E_1, E_2) = I(\epsilon, \infty) \, \frac{1-\Gamma}
+        {2-\Gamma} \, \frac{E_1^{2-\Gamma} - E_2^{2-\Gamma}}{\epsilon^{1-\Gamma}}
 
     Parameters
     ----------

--- a/gammapy/spectrum/tests/test_powerlaw.py
+++ b/gammapy/spectrum/tests/test_powerlaw.py
@@ -5,8 +5,7 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.units import Quantity
 from ...utils.testing import requires_dependency
-from ...spectrum import (powerlaw, power_law_flux, power_law_energy_flux,
-                         power_law_evaluate, integrate_loglog)
+from ...spectrum import powerlaw, power_law_flux, power_law_energy_flux
 
 
 @pytest.mark.xfail
@@ -28,12 +27,10 @@ def test_one():
     assert_allclose(I, 1)
 
 
-@requires_dependency('naima')
 def test_powerlaw_energy_flux():
     """
     Test energy flux computation for power law against numerical solution.
     """
-    from naima.utils import trapz_loglog
     e1 = Quantity(1, 'TeV')
     e2 = Quantity(10, 'TeV')
     einf = Quantity(1E10, 'TeV')
@@ -41,13 +38,9 @@ def test_powerlaw_energy_flux():
     g = 2.3
     I  = Quantity(1E-12, 'cm-2 s-1')
     
-    eflux = power_law_energy_flux(I=I, g=g, e=e, e1=e1, e2=e2)
-
-    norm = power_law_flux(I=I, g=g, e=e, e1=e1, e2=einf)
-    f = lambda x: x * power_law_evaluate(x, norm, g, e)
-    val = integrate_loglog(f, e1, e2)
-
-    assert_quantity_allclose(val, eflux)
+    val = power_law_energy_flux(I=I, g=g, e=e, e1=e1, e2=e2)
+    ref = Quantity(2.1615219876151536e-12, 'TeV cm-2 s-1')
+    assert_quantity_allclose(val, ref)
 
 
 # TODO: failing assert at the moment -> fix!

--- a/gammapy/spectrum/tests/test_powerlaw.py
+++ b/gammapy/spectrum/tests/test_powerlaw.py
@@ -2,9 +2,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, assert_quantity_allclose
+from astropy.units import Quantity
 from ...utils.testing import requires_dependency
-from ...spectrum import powerlaw
+from ...spectrum import (powerlaw, power_law_flux, power_law_energy_flux,
+                         power_law_evaluate, integrate_loglog)
 
 
 @pytest.mark.xfail
@@ -24,6 +26,28 @@ def test_one():
     """Test one case"""
     I = powerlaw.power_law_integral_flux(f=1, g=2)
     assert_allclose(I, 1)
+
+
+@requires_dependency('naima')
+def test_powerlaw_energy_flux():
+    """
+    Test energy flux computation for power law against numerical solution.
+    """
+    from naima.utils import trapz_loglog
+    e1 = Quantity(1, 'TeV')
+    e2 = Quantity(10, 'TeV')
+    einf = Quantity(1E10, 'TeV')
+    e = Quantity(1, 'TeV')
+    g = 2.3
+    I  = Quantity(1E-12, 'cm-2 s-1')
+    
+    eflux = power_law_energy_flux(I=I, g=g, e=e, e1=e1, e2=e2)
+
+    norm = power_law_flux(I=I, g=g, e=e, e1=e1, e2=einf)
+    f = lambda x: x * power_law_evaluate(x, norm, g, e)
+    val = integrate_loglog(f, e1, e2)
+
+    assert_quantity_allclose(val, eflux)
 
 
 # TODO: failing assert at the moment -> fix!

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -10,6 +10,7 @@ from ..utils.scripts import read_yaml
 __all__ = [
     'LogEnergyAxis',
     'plot_npred_vs_excess',
+    'integrate_loglog',
 ]
 
 
@@ -156,23 +157,23 @@ def plot_npred_vs_excess(ogip_dir='ogip_data', npred_dir='n_pred', ax=None):
 
 def integrate_loglog(func, xmin, xmax, ndecade=100):
     """
-    Integrate 1d function using log-log integration. 
+    Integrate 1d function using log-log trapezoidal rule. 
     
     Parameters
     ----------
     func : callable
         Function to integrate.
-    xmin : 
-
-    xmax : 
-
+    xmin : `~astropy.units.Quantity`
+        Integration range minimum
+    xmax : `~astropy.units.Quantity`
+        Integration range minimum
     ndecade : int
         Number of grid points per decade used for the integration.
     """
     from naima.utils import trapz_loglog
-    logmin = np.log10(emin)
-    logmax = np.log10(emax)
+    logmin = np.log10(xmin.value)
+    logmax = np.log10(xmax.to(xmin.unit).value)
 
     n = (logmax - logmin) * ndecade
-    x = np.logspace(logmin, logmax, n)  # 100 points per decade
+    x = Quantity(np.logspace(logmin, logmax, n), xmin.unit)
     return trapz_loglog(func(x), x)

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -152,3 +152,27 @@ def plot_npred_vs_excess(ogip_dir='ogip_data', npred_dir='n_pred', ax=None):
     plt.xscale('log')
 
     return ax
+
+
+def integrate_loglog(func, xmin, xmax, ndecade=100):
+    """
+    Integrate 1d function using log-log integration. 
+    
+    Parameters
+    ----------
+    func : callable
+        Function to integrate.
+    xmin : 
+
+    xmax : 
+
+    ndecade : int
+        Number of grid points per decade used for the integration.
+    """
+    from naima.utils import trapz_loglog
+    logmin = np.log10(emin)
+    logmax = np.log10(emax)
+
+    n = (logmax - logmin) * ndecade
+    x = np.logspace(logmin, logmax, n)  # 100 points per decade
+    return trapz_loglog(func(x), x)


### PR DESCRIPTION
This PR adds an `integrate_loglog` helper function, which is a thin wrapper around Naima's [trapz_loglog](https://github.com/zblz/naima/blob/master/naima/utils.py#L261) to handle the integration min / max with units. 
Furthermore this PR implements a `power_law_energy_flux` function to compute energy fluxes from integral flux in a certain energy range.