### PR TITLE
Fix setup.py and docs/conf.py configparser import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,11 @@ plot_rcparams = gammapy_mpl_style
 plot_apply_rcparams = True
 
 # Get configuration information from setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,11 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
This PR fixes an issue with `ConfigParser` import in `setup.py` and `docs/conf.py`, which we inherited from the Astropy package template, that made installing Gammapy and building the docs fail on Python 3.5.2+.

If someone cares: the issue is that in Python 3.5.2 they changed an import in the Python stdlib in `distutils.config` from `ConfigParser` to `RawConfigParser` and the Astropy package-template `setup.py` and `docs/conf.py` was importing `ConfigParser` from there (relying on an implementation detail, which it never should have done). See https://github.com/astropy/package-template/pull/180