### PR TITLE
WIP: Add Wstat to gammapy.stats

### DIFF
--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -31,6 +31,7 @@ Variable          Definition
 ``a_on``          Relative background efficiency in the on region
 ``a_off``         Relative background efficiency in the off region
 ``alpha``         Background efficiency ratio ``a_on`` / ``a_off``
+``n_bkg``         Background estimate in the on region
 ================= ====================================================
 
 The following formulae show how an on-off measurement :math:`(n_{on}, n_{off})`
@@ -42,22 +43,28 @@ is related to the quantities in the above table:
 
     n_{off} \sim Pois(\mu_{off})\text{ with }\mu_{off} = \mu_b / \alpha\text{ with }\alpha = a_{on} / a_{off}
 
-The maximum likelihood estimate of a signal excess is
+With the background estimate in the on region
 
 .. math::
-   n_{excess} = n_{on} - \alpha\ n_{off}.
+
+   n_{bkg} = \alpha\ n_{off},
+
+the maximum likelihood estimate of a signal excess is
+
+.. math::
+   n_{excess} = n_{on} - n_{bkg}.
 
 When the background is known and there is only an "on" region (sometimes also called "source region"),
-we use the variable names ``n_observed``, ``mu_observed``, ``mu_signal`` and ``mu_background``.
+we use the variable names ``n_observed``, ``mu_expected``, ``mu_signal`` and ``mu_background``.
 
 ================= ====================================================
 Variable          Definition
 ================= ====================================================
 ``n_observed``    Observed counts
-``mu_observed``   Expected counts (signal + background)
+``mu_expected``   Expected counts (signal + background)
 ================= ====================================================
 
-Here's some references describing the available methods:
+These are references describing the available methods:
 [LiMa1983]_, [Cash1979]_, [Stewart2009]_, [Rolke2005]_, [Feldman1998]_, [Cousins2007]_.
 
 Getting Started

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -73,9 +73,9 @@ def cash(n_observed, mu_predicted):
       <http://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
     n_observed = np.asanyarray(n_observed, dtype=np.float64)
-    mu_predicted = np.asanyarray(mu_prediced, dtype=np.float64)
+    mu_predicted = np.asanyarray(mu_predicted, dtype=np.float64)
 
-    stat = 2 * (mu_predicted - n_observed * np.log(mu_prediced))
+    stat = 2 * (mu_predicted - n_observed * np.log(mu_predicted))
     stat = np.where(mu_predicted > 0, stat, 0)
     return stat
 
@@ -118,7 +118,7 @@ def cstat(n_observed, mu_predicted, n_observed_min=N_OBSERVED_MIN):
       <http://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
     n_observed = np.asanyarray(n_observed, dtype=np.float64)
-    mu_predicted = np.asanyarray(mu_prediced, dtype=np.float64)
+    mu_predicted = np.asanyarray(mu_predicted, dtype=np.float64)
     n_observed_min = np.asanyarray(n_observed_min, dtype=np.float64)
 
     n_observed = np.where(n_observed <= n_observed_min, n_observed_min, n_observed)
@@ -164,9 +164,9 @@ def wstat(n_on, n_bkg, mu_signal):
 
     # variable names are geared to the names on the XSPEC reference page
     d_term1 = 2 * mu_signal - n_on - n_bkg
-    d_term2 = 8 * n_on * mu_signal
+    d_term2 = 8 * n_bkg * mu_signal
     d = np.sqrt(d_term1**2 + d_term2)
-
+    
     f_temp = n_on + n_bkg - 2 * mu_signal
     f_temp_plus = f_temp + d
     f_temp_minus = f_temp - d
@@ -180,7 +180,7 @@ def wstat(n_on, n_bkg, mu_signal):
     term3 = n_bkg * np.log(mu_background)
     term4 = n_on * (1-np.log(n_on)) + n_bkg * (1-np.log(n_bkg))
 
-    stat = term1 - term2 - term3 - term4
+    stat = 2 * (term1 - term2 - term3 - term4)
     # This may contain nan values where n_on or n_bkg are zero 
 
     np.seterr(**original_state)
@@ -201,7 +201,7 @@ def wstat(n_on, n_bkg, mu_signal):
                 raise ValueError("This should never be reached")
             special_cases[pos] = statval
 
-    stat = stat + special_cases
+        stat = stat + special_cases
 
     return stat
 

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -3,29 +3,62 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-from ...stats import cash, cstat, chi2datavar
+from ... import stats as gammapy_stats
+from ...utils.testing import requires_dependency
+from ...utils.random import get_random_state
+
+def get_test_data():
+    random_state = get_random_state(3)
+    # put factor to 100 to not run into special cases in WStat
+    model = random_state.rand(10) * 10
+    data = random_state.poisson(model)
+    staterror = np.sqrt(data)
+    off_vec = random_state.poisson(0.7 * model)
+    return data, model, staterror, off_vec
 
 
-# TODO: test against Sherpa results
-# see scripts here: https://github.com/gammapy/gammapy/tree/master/dev/sherpa/stats
-
-@pytest.mark.xfail
-def test_likelihood_stats():
-    # Create some example input
-    M = np.array([[0.2, 0.5, 1, 2], [10, 10.5, 100.5, 1000]])
-    # initialise random number generator
-    random_state = np.random.RandomState(seed=0)
-    D = random_state.poisson(M)
-
-    assert_allclose(cash(D, M), 42)
-    assert_allclose(cstat(D, M), 42)
+@requires_dependency('sherpa')
+def test_cstat():
+    import sherpa.stats as ss
+    sherpa_stat = ss.CStat()
+    data, model, staterror, off_vec = get_test_data()
+    desired, fvec  = sherpa_stat.calc_stat(data, model, staterror=staterror)
+        
+    statsvec = gammapy_stats.cstat(n_observed=data, mu_predicted=model)
+    actual = np.sum(statsvec)
+    assert_allclose(actual, desired) 
 
 
-@pytest.mark.xfail
-def test_chi2_stats():
-    A_S = np.array([[0, 0.5, 1, 2], [10, 10.5, 100.5, 1000]])
-    A_B = A_S
-    N_S = A_S
-    N_B = A_S
-    actual = chi2datavar(N_S, N_B, A_S, A_B)
-    assert_allclose(actual, 43)
+@requires_dependency('sherpa')
+def test_cash():
+    import sherpa.stats as ss
+    sherpa_stat = ss.Cash()
+    data, model, staterror, off_vec = get_test_data()
+    desired, fvec  = sherpa_stat.calc_stat(data, model, staterror=staterror)
+        
+    statsvec = gammapy_stats.cash(n_observed=data, mu_predicted=model)
+    actual = np.sum(statsvec)
+    assert_allclose(actual, desired) 
+
+
+@pytest.mark.xfail(reason='values do not match, under investigation')
+@requires_dependency('sherpa')
+def test_wstat():
+    import sherpa.stats as ss
+    sherpa_stat = ss.WStat()
+    data, model, staterror, off_vec = get_test_data()
+    alpha = 0.2
+    bkg_vec = alpha * off_vec
+    # This is how sherpa wants the background (found by trial and error)
+    bkg = dict(bkg=off_vec,
+               exposure_time=[1, 1],
+               backscale_ratio=[1./alpha] * len(data),
+               data_size=len(data)
+              )
+    desired, fvec  = sherpa_stat.calc_stat(data, model, staterror=staterror,
+                                           bkg=bkg)
+        
+    statsvec = gammapy_stats.wstat(n_on=data, mu_signal=model, n_bkg=bkg_vec)
+    actual = np.sum(statsvec)
+    assert_allclose(actual, desired) 
+


### PR DESCRIPTION
* This add the WStat statistic as described in 
https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html 
to ``gammapy.stats``.

Note that another implementation using exactly the same notation as for XSPEC exists here
https://github.com/gammapy/gammapy/blob/master/dev/sherpa/stats/xspec_stats.py

* This PR also add tests comparing the existing stats to sherpa