### PR TITLE
Move powerlaw utility functions to separate namespace

### DIFF
--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -36,3 +36,6 @@ Reference/API
 
 .. automodapi:: gammapy.spectrum.models
     :no-inheritance-diagram:
+
+.. automodapi:: gammapy.spectrum.powerlaw
+    :no-inheritance-diagram:

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -18,7 +18,8 @@ from ..utils.energy import EnergyBounds
 from ..utils.fits import table_to_fits_table
 from ..image import SkyMap
 from ..image.utils import _bin_events_in_cube
-from ..spectrum import LogEnergyAxis, powerlaw
+from ..spectrum import LogEnergyAxis
+from ..spectrum.powerlaw import power_law_I_from_points
 
 __all__ = ['SkyCube']
 
@@ -443,7 +444,7 @@ class SkyCube(object):
         flux2 = flux[1:, :, :]
         energy1 = energy1[:, np.newaxis, np.newaxis].value
         energy2 = energy2[:, np.newaxis, np.newaxis].value
-        integral_flux = powerlaw.I_from_points(energy1, energy2, flux1, flux2)
+        integral_flux = power_law_I_from_points(energy1, energy2, flux1, flux2)
 
         integral_flux = integral_flux.sum(axis=0)
 

--- a/gammapy/spectrum/__init__.py
+++ b/gammapy/spectrum/__init__.py
@@ -10,7 +10,6 @@ from .fitter import *
 from .fitting_utils import *
 from .flux_point import *
 from .isrf import *
-from .powerlaw import *
 from .sed import *
 from .sherpa_chi2asym import *
 from .utils import *

--- a/gammapy/spectrum/tests/test_powerlaw.py
+++ b/gammapy/spectrum/tests/test_powerlaw.py
@@ -5,7 +5,21 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.units import Quantity
 from ...utils.testing import requires_dependency
-from ...spectrum import powerlaw
+from ..powerlaw import (
+    power_law_evaluate,
+    power_law_pivot_energy,
+    power_law_df_over_f,
+    power_law_flux,
+    power_law_energy_flux,
+    power_law_integral_flux,
+    power_law_g_from_f,
+    power_law_g_from_points,
+    power_law_I_from_points,
+    power_law_f_from_points,
+    power_law_f_with_err,
+    power_law_I_with_err,
+    power_law_compatibility,
+)
 
 
 @pytest.mark.xfail
@@ -15,15 +29,15 @@ def test_powerlaw():
     f, f_err = 1, 0.1
     g, g_err = 2, 0.1
 
-    I_unc, I_unc_err = powerlaw.I_with_err(e1, e2, e, f, f_err, g, g_err)
-    f_unc, f_unc_err = powerlaw.f_with_err(e1, e2, e, I_unc, I_unc_err, g, g_err)
+    I_unc, I_unc_err = power_law_I_with_err(e1, e2, e, f, f_err, g, g_err)
+    f_unc, f_unc_err = power_law_f_with_err(e1, e2, e, I_unc, I_unc_err, g, g_err)
 
     # TODO: add asserts
 
 
 def test_one():
     """Test one case"""
-    I = powerlaw.power_law_integral_flux(f=1, g=2)
+    I = power_law_integral_flux(f=1, g=2)
     assert_allclose(I, 1)
 
 
@@ -37,7 +51,7 @@ def test_powerlaw_energy_flux():
     g = 2.3
     I = Quantity(1E-12, 'cm-2 s-1')
 
-    val = powerlaw.power_law_energy_flux(I=I, g=g, e=e, e1=e1, e2=e2)
+    val = power_law_energy_flux(I=I, g=g, e=e, e1=e1, e2=e2)
     ref = Quantity(2.1615219876151536e-12, 'TeV cm-2 s-1')
     assert_quantity_allclose(val, ref)
 
@@ -66,11 +80,11 @@ def test_closure(g_error_mag=0):
     g_err = g_val * random_state.normal(1, 0.1, npoints)
     # g = unumpy.uarray((g_val, g_err))
 
-    I_val, I_err = powerlaw.I_with_err(f_val, f_err, g_val, g_err)
+    I_val, I_err = power_law_I_with_err(f_val, f_err, g_val, g_err)
     # I_val = unumpy.nominal_values(f)
     # I_err = unumpy.std_devs(f)
 
-    f_val2, f_err2 = powerlaw.f_with_err(I_val, I_err, g_val, g_err)
+    f_val2, f_err2 = power_law_f_with_err(I_val, I_err, g_val, g_err)
 
     assert_allclose(f_val, f_val2)
     assert_allclose(f_err, f_err2)
@@ -84,7 +98,7 @@ def test_e_pivot():
     d_gamma = 0.0318377
     cov = 6.56889442e-14
 
-    e_pivot = powerlaw.power_law_pivot_energy(e0, f0, d_gamma, cov)
+    e_pivot = power_law_pivot_energy(e0, f0, d_gamma, cov)
     assert_allclose(e_pivot, 3.3540034240210987)
 
 
@@ -117,7 +131,7 @@ def test_compatibility():
     par_hess = (e_hess, f_hess, f_err_hess, g_hess, g_err_hess)
 
     g_match, sigma_low, sigma_high, sigma_comb = \
-        powerlaw.compatibility(par_fermi, par_hess)
+        power_law_compatibility(par_fermi, par_hess)
 
 
 @requires_dependency('scipy')
@@ -142,7 +156,7 @@ def test_SED_error(I=1., e1=1, e2=10):
     f = I / (e2 - e1)
     e2f = e ** 2 * f  # Note: e ** 2 = e1 * e2 here.
     for Index in np.arange(1.5, 3.5, 0.5):
-        f_correct = powerlaw.power_law_flux(I, Index, e, e1, e2)
+        f_correct = power_law_flux(I, Index, e, e1, e2)
         e2f_correct = e ** 2 * f_correct
         # We compute ratios, which corresponds to differences
         # on a log scale

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -4,8 +4,8 @@ from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency
-from ...spectrum import (LogEnergyAxis, integrate_spectrum, power_law_energy_flux,
-                         power_law_evaluate, power_law_flux)
+from ...spectrum import LogEnergyAxis, integrate_spectrum
+from ..powerlaw import power_law_energy_flux, power_law_evaluate, power_law_flux
 
 
 @requires_dependency('scipy')


### PR DESCRIPTION
I'd like to propose that the functions from [gammapy.spectrum.powerlaw](https://github.com/gammapy/gammapy/blob/master/gammapy/spectrum/powerlaw.py) are moved to a separate namespace.

Currently those functions are part of the main [gammapy.spectrum](https://gammapy.readthedocs.io/en/latest/spectrum/index.html#module-gammapy.spectrum) namespace and IMO it's a mess to find something.

So I'd like to propose to either have those functions in
* a sub-module `gammapy.spectrum.powerlaw` or
* a class `gammapy.spectrum.PowerLawUtils`, i.e. use a class to group the functions and have them as `staticmethod`.

I don't think that we should add all those functions to the [gammapy.spectrum.PowerLaw](https://gammapy.readthedocs.io/en/latest/api/gammapy.spectrum.models.PowerLaw.html) class, but that is an option as well. Power-law is special, everything is available analytically and it's usually the building block for a lot of other code (like numerical integration in energy).

This change is very easy to implement, but it will break a lot of scripts that call that functionality from Gammapy. I think there aren't many people using it and they can just adapt when going to Gammapy 0.5, I don't want to do a deprecation cycle.

@adonath @joleroi - Do you agree? Do you have a preference where to put it?