### PR TITLE
Shorten argument names in gammapy.stats

### DIFF
--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -26,8 +26,8 @@ Variable          Definition
 ``n_off``         Total observed counts in the off region
 ``mu_on``         Total expected counts in the on region
 ``mu_off``        Total expected counts in the off region
-``mu_signal``     Signal expected counts in the on region
-``mu_background`` Background expected counts in the on region
+``mu_sig``        Signal expected counts in the on region
+``mu_bkg``        Background expected counts in the on region
 ``a_on``          Relative background efficiency in the on region
 ``a_off``         Relative background efficiency in the off region
 ``alpha``         Background efficiency ratio ``a_on`` / ``a_off``
@@ -55,14 +55,8 @@ the maximum likelihood estimate of a signal excess is
    n_{excess} = n_{on} - n_{bkg}.
 
 When the background is known and there is only an "on" region (sometimes also called "source region"),
-we use the variable names ``n_observed``, ``mu_expected``, ``mu_signal`` and ``mu_background``.
+we use the variable names ``n_on``, ``mu_on``, ``mu_sig`` and ``mu_bkg``.
 
-================= ====================================================
-Variable          Definition
-================= ====================================================
-``n_observed``    Observed counts
-``mu_expected``   Expected counts (signal + background)
-================= ====================================================
 
 These are references describing the available methods:
 [LiMa1983]_, [Cash1979]_, [Stewart2009]_, [Rolke2005]_, [Feldman1998]_, [Cousins2007]_.

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -22,40 +22,42 @@ If you want the summed statistics for all bins,
 call sum on the output array yourself.
 Here's an example for the `~cash` statistic::
 
-    >>> from gammapy.stats import cash
-    >>> data = [3, 5, 9]
-    >>> model = [3.3, 6.8, 9.2]
-    >>> cash(data, model)
-    array([ -0.56353481,  -5.56922612, -21.54566271])
-    >>> cash(data, model).sum()
-    -27.678423645645118
+>>> from gammapy.stats import cash
+>>> data = [3, 5, 9]
+>>> model = [3.3, 6.8, 9.2]
+>>> cash(data, model)
+array([ -0.56353481,  -5.56922612, -21.54566271])
+>>> cash(data, model).sum()
+-27.678423645645118
+
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
-__all__ = ['cash', 'cstat', 'wstat', 'lstat', 'pgstat',
-           'chi2', 'chi2constvar', 'chi2datavar',
-           'chi2gehrels', 'chi2modvar', 'chi2xspecvar',
-           ]
+__all__ = [
+    'cash', 'cstat', 'wstat', 'lstat', 'pgstat',
+    'chi2', 'chi2constvar', 'chi2datavar',
+    'chi2gehrels', 'chi2modvar', 'chi2xspecvar',
+]
 
-N_OBSERVED_MIN = 1e-25
+N_ON_MIN = 1e-25
 
 
-def cash(n_observed, mu_predicted):
+def cash(n_on, mu_on):
     r"""Cash statistic, for Poisson data.
 
     The Cash statistic is defined as:
 
     .. math::
-        C = 2 \left( n_{observed} - n_{observed} \log \mu_{prediced} \right)
+        C = 2 \left( n_{on} - n_{on} \log \mu_{on} \right)
 
     and :math:`C = 0` where :math:`\mu <= 0`.
 
     Parameters
     ----------
-    n_observed : array_like
+    n_on : array_like
         Observed counts
-    mu_predicted : array_like
+    mu_on : array_like
         Expected counts
 
     Returns
@@ -72,36 +74,36 @@ def cash(n_observed, mu_predicted):
     * `Cash 1979, ApJ 228, 939
       <http://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
-    n_observed = np.asanyarray(n_observed, dtype=np.float64)
-    mu_predicted = np.asanyarray(mu_predicted, dtype=np.float64)
+    n_on = np.asanyarray(n_on, dtype=np.float64)
+    mu_on = np.asanyarray(mu_on, dtype=np.float64)
 
-    stat = 2 * (mu_predicted - n_observed * np.log(mu_predicted))
-    stat = np.where(mu_predicted > 0, stat, 0)
+    stat = 2 * (mu_on - n_on * np.log(mu_on))
+    stat = np.where(mu_on > 0, stat, 0)
     return stat
 
 
-def cstat(n_observed, mu_predicted, n_observed_min=N_OBSERVED_MIN):
+def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
     r"""C statistic, for Poisson data.
 
     The C statistic is defined as
 
     .. math::
-        C = 2 \left[ \mu_{prediced} - n_{observed} + n_{observed}
-            (\log(n_{observed}) - log(\mu_{prediced}) \right]
+        C = 2 \left[ \mu_{on} - n_{on} + n_{on}
+            (\log(n_{on}) - log(\mu_{on}) \right]
 
-    and :math:`C = 0` where :math:`\mu_{observed} <= 0`.
+    and :math:`C = 0` where :math:`\mu_{on} <= 0`.
 
-    ``n_observed_min`` handles the case where ``n_observed`` is 0 or less and
+    ``n_on_min`` handles the case where ``n_on`` is 0 or less and
     the log cannot be taken.
 
     Parameters
     ----------
-    n_observed : array_like
+    n_on : array_like
         Observed counts
-    mu_predicted : array_like
+    mu_on : array_like
         Expected counts
-    n_observed_min : array_like
-        ``n_observed`` = ``n_observed_min`` where ``n_observed`` <= ``n_observed_min.``
+    n_on_min : array_like
+        ``n_on`` = ``n_on_min`` where ``n_on`` <= ``n_on_min.``
 
     Returns
     -------
@@ -117,15 +119,15 @@ def cstat(n_observed, mu_predicted, n_observed_min=N_OBSERVED_MIN):
     * `Cash 1979, ApJ 228, 939
       <http://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
-    n_observed = np.asanyarray(n_observed, dtype=np.float64)
-    mu_predicted = np.asanyarray(mu_predicted, dtype=np.float64)
-    n_observed_min = np.asanyarray(n_observed_min, dtype=np.float64)
+    n_on = np.asanyarray(n_on, dtype=np.float64)
+    mu_on = np.asanyarray(mu_on, dtype=np.float64)
+    n_on_min = np.asanyarray(n_on_min, dtype=np.float64)
 
-    n_observed = np.where(n_observed <= n_observed_min, n_observed_min, n_observed)
+    n_on = np.where(n_on <= n_on_min, n_on_min, n_on)
 
-    term1 = np.log(n_observed) - np.log(mu_predicted)
-    stat = 2 * (mu_predicted - n_observed + n_observed * term1)
-    stat = np.where(mu_predicted > 0, stat, 0)
+    term1 = np.log(n_on) - np.log(mu_on)
+    stat = 2 * (mu_on - n_on + n_on * term1)
+    stat = np.where(mu_on > 0, stat, 0)
 
     return stat
 
@@ -159,28 +161,28 @@ def wstat(mu_signal, n_on, n_off, alpha):
     * `XSPEC page on Poisson data with Poisson background
       <http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
     """
-    
+
     mu_signal = np.asanyarray(mu_signal, dtype=np.float64)
     n_on = np.asanyarray(n_on, dtype=np.float64)
     n_off = np.asanyarray(n_off, dtype=np.float64)
     alpha = np.asanyarray(alpha, dtype=np.float64)
-   
+
     # Get mu_backgroud
-    C = alpha * ( n_on + n_off ) - (1 + alpha) * mu_signal
-    D = np.sqrt(C ** 2 + 4 * alpha * ( alpha + 1) * n_off * mu_signal) 
+    C = alpha * (n_on + n_off) - (1 + alpha) * mu_signal
+    D = np.sqrt(C ** 2 + 4 * alpha * (alpha + 1) * n_off * mu_signal)
 
     # TODO : Investigate this
     # For n_off = 0, mu_background = 0. Effect?
     # temp_plus = (C + D) / (2 * alpha * (alpha + 1))
     # temp_minus = (C - D) / (2 * alpha * (alpha + 1))
     # mu_background = np.where(temp_plus > 0, temp_plus, temp_minus)
-    mu_background = (C + D)/ (2 * alpha * (alpha + 1))
-    
+    mu_background = (C + D) / (2 * alpha * (alpha + 1))
+
     # calc stat
     term1 = n_on * np.log(mu_signal + alpha * mu_background)
     term2 = n_off * np.log(mu_background)
     term3 = (1 + alpha) * mu_background + mu_signal
-    
+
     stat = -2 * (term1 + term2 - term3)
 
     return stat

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -3,10 +3,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-from ... import stats as gammapy_stats
 from ...utils.testing import requires_dependency
 from ...utils.random import get_random_state
+from ... import stats as gammapy_stats
 
+
+# TODO; change to a test dataset that doesn't use random values (just list the numbers)
+# and use `pytest.fixture` to use it in the tests.
 def get_test_data():
     random_state = get_random_state(3)
     # put factor to 100 to not run into special cases in WStat
@@ -16,6 +19,7 @@ def get_test_data():
     off_vec = random_state.poisson(0.7 * model)
     return data, model, staterror, off_vec
 
+
 # TODO : Produce reference numbers outside of test (avoid sherpa dependency)
 
 @requires_dependency('sherpa')
@@ -23,11 +27,11 @@ def test_cstat():
     import sherpa.stats as ss
     sherpa_stat = ss.CStat()
     data, model, staterror, off_vec = get_test_data()
-    desired, fvec  = sherpa_stat.calc_stat(data, model, staterror=staterror)
-        
-    statsvec = gammapy_stats.cstat(n_observed=data, mu_predicted=model)
+    desired, fvec = sherpa_stat.calc_stat(data, model, staterror=staterror)
+
+    statsvec = gammapy_stats.cstat(n_on=data, mu_on=model)
     actual = np.sum(statsvec)
-    assert_allclose(actual, desired) 
+    assert_allclose(actual, desired)
 
 
 @requires_dependency('sherpa')
@@ -35,11 +39,11 @@ def test_cash():
     import sherpa.stats as ss
     sherpa_stat = ss.Cash()
     data, model, staterror, off_vec = get_test_data()
-    desired, fvec  = sherpa_stat.calc_stat(data, model, staterror=staterror)
-        
-    statsvec = gammapy_stats.cash(n_observed=data, mu_predicted=model)
+    desired, fvec = sherpa_stat.calc_stat(data, model, staterror=staterror)
+
+    statsvec = gammapy_stats.cash(n_on=data, mu_on=model)
     actual = np.sum(statsvec)
-    assert_allclose(actual, desired) 
+    assert_allclose(actual, desired)
 
 
 # Note: There is an independent implementation of the XSPEC  wstat that can
@@ -51,7 +55,7 @@ def test_wstat():
     sherpa_stat = ss.WStat()
     data, model, staterror, off_vec = get_test_data()
     alpha = np.ones(len(data)) * 0.2
-    
+
     statsvec = gammapy_stats.wstat(n_on=data,
                                    mu_signal=model,
                                    n_off=off_vec,
@@ -60,30 +64,29 @@ def test_wstat():
     # This is how sherpa wants the background (found by trial and error)
     bkg = dict(bkg=off_vec,
                exposure_time=[1, 1],
-               backscale_ratio=1./alpha,
+               backscale_ratio=1. / alpha,
                data_size=len(data)
-              )
+               )
 
     # Check for one bin first
     test_bin = 0
     bkg_testbin = dict(bkg=off_vec[test_bin],
-                      exposure_time=[1,1],
-                      backscale_ratio=1./alpha[test_bin],
-                      data_size=1)
+                       exposure_time=[1, 1],
+                       backscale_ratio=1. / alpha[test_bin],
+                       data_size=1)
 
-    desired_testbin, fvec  = sherpa_stat.calc_stat(data[test_bin],
+    desired_testbin, fvec = sherpa_stat.calc_stat(data[test_bin],
                                                   model[test_bin],
                                                   staterror=staterror[test_bin],
                                                   bkg=bkg_testbin)
 
     actual_testbin = statsvec[test_bin]
-#    assert_allclose(actual_testbin, desired_testbin) 
+    #    assert_allclose(actual_testbin, desired_testbin)
 
     # Now check total stat for all bins
-    desired, fvec  = sherpa_stat.calc_stat(data, model, staterror=staterror,
-                                           bkg=bkg)
-        
+    desired, fvec = sherpa_stat.calc_stat(data, model, staterror=staterror,
+                                          bkg=bkg)
+
     actual = np.sum(statsvec)
     print(fvec)
-    assert_allclose(actual, desired) 
-
+    assert_allclose(actual, desired)

--- a/gammapy/stats/tests/test_poisson.py
+++ b/gammapy/stats/tests/test_poisson.py
@@ -43,7 +43,7 @@ def test_docstring_examples():
     assert_allclose(result, 3.6850322025333071)
 
     # Check that the Li & Ma limit formula is correct
-    actual = significance(n_observed=1300, mu_background=1100, method='lima')
+    actual = significance(n_on=1300, mu_bkg=1100, method='lima')
     assert_allclose(actual, 5.8600870406703329)
     actual = significance_on_off(n_on=1300, n_off=1100 / 1.e-8, alpha=1e-8, method='lima')
     assert_allclose(actual, 5.8600864348078519)


### PR DESCRIPTION
This PR shortens the argument names in `gammapy.stats`.

@joleroi - Please review.