### PR TITLE
Add extra terms to Wstat implementation

### DIFF
--- a/docs/stats/fit_statistics.rst
+++ b/docs/stats/fit_statistics.rst
@@ -20,13 +20,13 @@ All functions compute per-bin statistics. If you want the summed statistics for
 all bins, call sum on the output array yourself. Here's an example for the
 `~cash` statistic:: 
 
->>> from gammapy.stats import cash
->>> data = [3, 5, 9] 
->>> model = [3.3, 6.8, 9.2]
->>> cash(data, model)
-array([ -0.56353481,  -5.56922612, -21.54566271])
->>> cash(data, model).sum()
--27.678423645645118
+    >>> from gammapy.stats import cash
+    >>> data = [3, 5, 9] 
+    >>> model = [3.3, 6.8, 9.2]
+    >>> cash(data, model)
+    array([ -0.56353481,  -5.56922612, -21.54566271])
+    >>> cash(data, model).sum()
+    -27.678423645645118
 
 Gaussian data
 -------------

--- a/docs/stats/fit_statistics.rst
+++ b/docs/stats/fit_statistics.rst
@@ -18,7 +18,7 @@ X-ray analysis packages.
 
 All functions compute per-bin statistics. If you want the summed statistics for
 all bins, call sum on the output array yourself. Here's an example for the
-`~cash` statistic:: 
+`~gammapy.stats.cash` statistic:: 
 
     >>> from gammapy.stats import cash
     >>> data = [3, 5, 9] 

--- a/docs/stats/fit_statistics.rst
+++ b/docs/stats/fit_statistics.rst
@@ -1,0 +1,104 @@
+.. _fit-statistics:
+
+Fit statistics
+==============
+
+Introduction
+------------
+
+This page describes common fit statistics used in gamma-ray astronomy.
+Results were tested against results from the
+`Sherpa <http://cxc.harvard.edu/sherpa/>`_ and
+`XSpec <https://heasarc.gsfc.nasa.gov/xanadu/xspec/>`_
+X-ray analysis packages.
+
+.. Likelihood defined per bin -> take sum
+.. Stat = -2 log (L)
+.. Code example
+
+All functions compute per-bin statistics. If you want the summed statistics for
+all bins, call sum on the output array yourself. Here's an example for the
+`~cash` statistic:: 
+
+>>> from gammapy.stats import cash
+>>> data = [3, 5, 9] 
+>>> model = [3.3, 6.8, 9.2]
+>>> cash(data, model)
+array([ -0.56353481,  -5.56922612, -21.54566271])
+>>> cash(data, model).sum()
+-27.678423645645118
+
+Gaussian data
+-------------
+TODO
+
+Poisson data
+------------
+TODO
+
+.. _wstat:
+
+Poisson data with background measurement
+----------------------------------------
+If you not only have a  measurement of counts  ``n_on`` in the signal region,
+but also a measurement ``n_off`` in a background region you can write down the
+likelihood formula as 
+
+.. math::
+
+    L = \frac{(\mu_{sig}+\alpha \mu_{bkg})^{n_{on}}}{n_{on} !}
+        \exp{(-(\mu_{sig}-\alpha \mu_{bkg}))}\times 
+        \frac{(\mu_{bkg})^{n_{off}}}{n_{off} !}\exp{(-mu_{bkg})},
+
+where :math:`\mu_{sig}` is the number of expected counts in the signal regions,
+and :math:`\mu_{bkg}` is the number of expected counts in the background region,
+as defined in the :ref:`stats-introduction`.
+
+Most of the times you probably won't have a model in order to get
+:math:`\mu_{bkg}`. The strategy in this case is to treat :math:`\mu_{bkg}` as
+so-called nuisance parameter, i.e. a free parameter that is of no physical
+interest.  Of course you don't want an additional free parameter for each bin
+during a fit. Therefore one calculates an estimator for :math:`\mu_{bkg}` by
+analytically minimizing the likelihood function. This is called 'profile
+likelihood'.
+
+.. math::
+    \frac{\mathrm d L}{\mathrm d \mu_{bkg}} = 0
+    
+This yields a quadratic equation for :math:`\mu_{bkg}` 
+
+.. math::
+    \frac{\alpha n_{on}}{mu_{sig}+\alpha \mu_{bkg}} +
+    \frac{n_{off}}{\mu_{bkg}} - (\alpha + 1) = 0
+
+with the solution
+
+.. math::
+
+    \mu_{bkg} = \frac{C + D}{2\alpha(\alpha + 1)}
+
+where
+
+.. math::
+
+    C = \alpha(n_{on} + n_{off}) - (\alpha+1)\mu_{sig} \\
+    D^2 = C^2 + 4 (\alpha+1)\alpha n_{off} \mu_{sig}
+
+
+By inserting this into the original likelihood formula we define the **WStat**.
+
+.. math::
+
+    W = 2 (\mu_{sig} + (1 + \alpha)\mu_{bkg}
+    - n_{on} \log{(\mu_{sig} + \alpha \mu_{bkg})}
+    - n_{off} \log{(\mu_{bkg})}
+
+TODO: Explaing extra terms and show example table
+
+
+Further references
+------------------
+* `Sherpa statistics page <http://cxc.cfa.harvard.edu/sherpa/statistics>`_ 
+* `XSpec manual statistics page
+  <http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
+ 

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -6,6 +6,8 @@ Statistics tools (``gammapy.stats``)
 
 .. currentmodule:: gammapy.stats
 
+.. _stats-introduction:
+
 Introduction
 ============
 
@@ -111,6 +113,7 @@ Using `gammapy.stats`
    :maxdepth: 1
 
    feldman_cousins
+   fit_statistics
 
 Reference/API
 =============

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -110,7 +110,7 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
 def wstat(n_on, n_off, alpha, mu_signal, extra_terms=False):
     r"""W statistic, for Poisson data with Poisson background.
 
-    For a definition of the WStat see :ref:`fit-statistics`
+    For a definition of WStat see :ref:`wstat`.
 
     Parameters
     ----------

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -1,36 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Common fit statistics used in gamma-ray astronomy.
 
-References
-----------
-
-Results were tested against results from the
-`Sherpa <http://cxc.harvard.edu/sherpa/>`_ and
-`XSpec <https://heasarc.gsfc.nasa.gov/xanadu/xspec/>`_
-X-ray analysis packages.
-
-Each function contains references for the implemented formulae,
-to get an overview have a look at the
-`Sherpa statistics page <http://cxc.cfa.harvard.edu/sherpa/statistics>`_ or the
-`XSpec manual statistics page <http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_.
-
-Examples
---------
-
-All functions compute per-bin statistics.
-If you want the summed statistics for all bins,
-call sum on the output array yourself.
-Here's an example for the `~cash` statistic::
-
->>> from gammapy.stats import cash
->>> data = [3, 5, 9]
->>> model = [3.3, 6.8, 9.2]
->>> cash(data, model)
-array([ -0.56353481,  -5.56922612, -21.54566271])
->>> cash(data, model).sum()
--27.678423645645118
-
+see :ref:`fit-statistics`
 """
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
@@ -52,6 +25,7 @@ def cash(n_on, mu_on):
         C = 2 \left( n_{on} - n_{on} \log \mu_{on} \right)
 
     and :math:`C = 0` where :math:`\mu <= 0`.
+    For more information see :ref:`fit-statistics`
 
     Parameters
     ----------
@@ -95,6 +69,7 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
 
     ``n_on_min`` handles the case where ``n_on`` is 0 or less and
     the log cannot be taken.
+    For more information see :ref:`fit-statistics`
 
     Parameters
     ----------
@@ -135,7 +110,7 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
 def wstat(n_on, n_off, alpha, mu_signal, extra_terms=False):
     r"""W statistic, for Poisson data with Poisson background.
 
-    Consult the references for a definition of WStat.
+    For a definition of the WStat see :ref:`fit-statistics`
 
     Parameters
     ----------
@@ -158,7 +133,6 @@ def wstat(n_on, n_off, alpha, mu_signal, extra_terms=False):
 
     References
     ----------
-    * Statistics page :ref:`stats`
     * `Habilitation M. de Naurois, p. 141
       <http://inspirehep.net/record/1122589/files/these_short.pdf>`_
     * `XSPEC page on Poisson data with Poisson background

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -107,7 +107,7 @@ def cstat(n_on, mu_on, n_on_min=N_ON_MIN):
     return stat
 
 
-def wstat(n_on, n_off, alpha, mu_signal, extra_terms=False):
+def wstat(n_on, n_off, alpha, mu_sig, extra_terms=False):
     r"""W statistic, for Poisson data with Poisson background.
 
     For a definition of WStat see :ref:`wstat`.
@@ -120,7 +120,7 @@ def wstat(n_on, n_off, alpha, mu_signal, extra_terms=False):
         Total observed background counts
     alpha : array_like
         Exposure ratio between on and off region
-    mu_signal : array_like
+    mu_sig : array_like
         Signal expected counts
     extra_terms : bool, optional
         Add model independent terms to convert stat into goodness-of-fit
@@ -140,44 +140,43 @@ def wstat(n_on, n_off, alpha, mu_signal, extra_terms=False):
     """
     # Note: This is equivalent to what's defined on the XSPEC page under the
     # following assumptions
-    # t_s * m_i = mu_signal
-    # t_b * m_b = mu_background
+    # t_s * m_i = mu_sig
+    # t_b * m_b = mu_bkg
     # t_s / t_b = alpha
 
     n_on = np.asanyarray(n_on, dtype=np.float64)
     n_off = np.asanyarray(n_off, dtype=np.float64)
     alpha = np.asanyarray(alpha, dtype=np.float64)
-    mu_signal = np.asanyarray(mu_signal, dtype=np.float64)
+    mu_sig = np.asanyarray(mu_sig, dtype=np.float64)
    
-    mu_background = _get_wstat_background(n_on, n_off, alpha, mu_signal)
+    mu_bkg = _get_wstat_background(n_on, n_off, alpha, mu_sig)
 
     
-    term1 = mu_signal + (1 + alpha) * mu_background 
-    term2 = - n_on * np.log(mu_signal + alpha * mu_background)
-    term3 = - n_off * np.log(mu_background) 
+    term1 = mu_sig + (1 + alpha) * mu_bkg 
+    term2 = - n_on * np.log(mu_sig + alpha * mu_bkg)
+    term3 = - n_off * np.log(mu_bkg) 
     
     stat = 2 * (term1 + term2 + term3)
 
     if extra_terms:
-        term = _get_wstat_extra_terms(n_on, n_off)
-        stat += term 
+        stat += _get_wstat_extra_terms(n_on, n_off)
 
     return stat
 
-def _get_wstat_background(n_on, n_off, alpha, mu_signal):
-    """Calculate nuisance parameter mu_background (profile likelihood)
+def _get_wstat_background(n_on, n_off, alpha, mu_sig):
+    """Calculate nuisance parameter mu_bkg (profile likelihood)
     """
     # Get mu_backgroud
-    C = alpha * (n_on + n_off) - (1 + alpha) * mu_signal
-    D = np.sqrt(C ** 2 + 4 * alpha * (alpha + 1) * n_off * mu_signal)
+    C = alpha * (n_on + n_off) - (1 + alpha) * mu_sig
+    D = np.sqrt(C ** 2 + 4 * alpha * (alpha + 1) * n_off * mu_sig)
 
     # TODO : Investigate this
-    # For n_off = 0, mu_background = 0. Effect?
+    # For n_off = 0, mu_bkg = 0. Effect?
     # temp_plus = (C + D) / (2 * alpha * (alpha + 1))
     # temp_minus = (C - D) / (2 * alpha * (alpha + 1))
-    # mu_background = np.where(temp_plus > 0, temp_plus, temp_minus)
-    mu_background = (C + D)/ (2 * alpha * (alpha + 1))
-    return mu_background
+    # mu_bkg = np.where(temp_plus > 0, temp_plus, temp_minus)
+    mu_bkg = (C + D)/ (2 * alpha * (alpha + 1))
+    return mu_bkg
 
 def _get_wstat_extra_terms(n_on, n_off):
     """Calculate additional term that can be added to wstat

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -13,7 +13,7 @@ from ... import stats as gammapy_stats
 def get_test_data():
     random_state = get_random_state(3)
     # put factor to 100 to not run into special cases in WStat
-    model = random_state.rand(10) * 10
+    model = random_state.rand(10) * 100
     data = random_state.poisson(model)
     staterror = np.sqrt(data)
     off_vec = random_state.poisson(0.7 * model)
@@ -21,6 +21,10 @@ def get_test_data():
 
 
 # TODO : Produce reference numbers outside of test (avoid sherpa dependency)
+# Note: There is an independent implementation of the XSPEC  wstat that can
+# be used for debugging: gammapy/dev/sherpa/stats/xspec_stats.py    
+# Also there is the script dev/sherpa/stats/compare_stats.py that is very
+# usefull for debugging
 
 @requires_dependency('sherpa')
 def test_cstat():
@@ -46,9 +50,6 @@ def test_cash():
     assert_allclose(actual, desired)
 
 
-# Note: There is an independent implementation of the XSPEC  wstat that can
-# be used for debugging: gammapy/dev/sherpa/stats/xspec_stats.py    
-@pytest.mark.xfail(reason="Sherpa implementation is different")
 @requires_dependency('sherpa')
 def test_wstat():
     import sherpa.stats as ss
@@ -59,7 +60,8 @@ def test_wstat():
     statsvec = gammapy_stats.wstat(n_on=data,
                                    mu_signal=model,
                                    n_off=off_vec,
-                                   alpha=alpha)
+                                   alpha=alpha,
+                                   extra_terms=True)
 
     # This is how sherpa wants the background (found by trial and error)
     bkg = dict(bkg=off_vec,

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -58,7 +58,7 @@ def test_wstat():
     alpha = np.ones(len(data)) * 0.2
 
     statsvec = gammapy_stats.wstat(n_on=data,
-                                   mu_signal=model,
+                                   mu_sig=model,
                                    n_off=off_vec,
                                    alpha=alpha,
                                    extra_terms=True)


### PR DESCRIPTION
This adds

* the extra terms described here
https://heasarc.gsfc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
to the WStat implementation

see also https://github.com/gammapy/gammapy/issues/601

* A WStat description in the docs

TODO
* [ ] add table to docs
* [ ] handle corner cases of 0 counts (maybe other PR)

Will do in future PR