### PR TITLE
Fix bug with energy range used in spectral fit

### DIFF
--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -245,6 +245,8 @@ class SpectrumFitResult(object):
         flux_errors = Bunch()
         flux_errors['1TeV'] = parameter_errors['norm']
 
+        npred = model(1)
+
         return cls(fit_range=energy_range,
                    parameters=parameters,
                    parameter_errors=parameter_errors,
@@ -252,7 +254,7 @@ class SpectrumFitResult(object):
                    spectral_model=spectral_model,
                    statname=fitresult.statname,
                    statval=fitresult.statval,
-                   n_pred=model(1),
+                   n_pred=npred,
                    fluxes=fluxes,
                    flux_errors=flux_errors)
 

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -68,9 +68,10 @@ class SpectrumExtraction(object):
         self.obs = obs
         self.background = background
         self.target = target
-        # This is the 14 bpd setup used in HAP Fitspectrum
-        self.e_reco = e_reco or np.logspace(-2, 2, 96) * u.TeV
-        self.e_true = e_true or np.logspace(-2, 2.3, 250) * u.TeV
+
+        # TODO: Decide on default binning
+        self.e_reco = e_reco or np.logspace(-2, 2, 72) * u.TeV
+        self.e_true = e_true or np.logspace(-2, 2.5, 108) * u.TeV
         self._observations = None
         self.containment_correction = containment_correction
         if self.containment_correction and not isinstance(target.on_region,
@@ -190,6 +191,7 @@ class SpectrumExtraction(object):
                                                  e_true=self.e_true)
 
             # If required, correct arf for psf leakage
+            # TODO: write correction factor as AREASCAL column in PHAFILE
             if self.containment_correction:
                 # First need psf
                 angles = np.linspace(0., 1.5, 150) * u.deg
@@ -202,6 +204,7 @@ class SpectrumExtraction(object):
                                                   0. * u.deg,
                                                   self.target.on_region.radius)
                     except:
+                        # TODO: Why is this necessary?
                         correction = np.nan
 
                     arf.data[index] = arf.data[index] * correction

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -38,8 +38,8 @@ class SpectrumExtraction(object):
     and off counts vectors as well as an effective area vector and an energy
     dispersion matrix.  For more info see :ref:`spectral_fitting`.
 
-    For point sources analyzed with 'full containement' IRFs, a correction for PSF
-    leakage out of the circular ON region can be applied.
+    For point sources analyzed with 'full containement' IRFs, a correction for
+    PSF leakage out of the circular ON region can be applied.
 
     Parameters
     ----------
@@ -52,7 +52,7 @@ class SpectrumExtraction(object):
     e_reco : `~astropy.units.Quantity`, optional
         Reconstructed energy binning
     containment_correction : bool
-        Flag to apply containment correction for point sources and circular ON regions.
+        Apply containment correction for point sources and circular ON regions.
 
     Examples
     --------
@@ -60,7 +60,9 @@ class SpectrumExtraction(object):
     OGIP_FOLDER = 'ogip_data'
     """Folder that will contain the output ogip data"""
 
-    def __init__(self, target, obs, background, e_reco=None, e_true=None, containment_correction=False):
+    def __init__(self, target, obs, background, e_reco=None, e_true=None,
+                 containment_correction=False):
+
         if isinstance(target, CircleSkyRegion):
             target = Target(target)
         self.obs = obs
@@ -71,8 +73,10 @@ class SpectrumExtraction(object):
         self.e_true = e_true or np.logspace(-2, 2.3, 250) * u.TeV
         self._observations = None
         self.containment_correction = containment_correction
-        if self.containment_correction and not isinstance(target.on_region, CircleSkyRegion):
-            raise TypeError("Incorrect region type for containment correction. Should be CircleSkyRegion.")
+        if self.containment_correction and not isinstance(target.on_region,
+                                                          CircleSkyRegion):
+            raise TypeError("Incorrect region type for containment correction."
+                            " Should be CircleSkyRegion.")
 
     @property
     def observations(self):
@@ -147,7 +151,6 @@ class SpectrumExtraction(object):
             idx = self.target.on_region.contains(obs.events.radec)
             on_events = obs.events[idx]
 
-
             counts_kwargs = dict(energy=self.e_reco,
                                  exposure=obs.observation_live_time_duration,
                                  obs_id=obs.obs_id,
@@ -174,7 +177,8 @@ class SpectrumExtraction(object):
                 pass
 
             on_vec = PHACountsSpectrum(backscal=bkg.a_on, **counts_kwargs)
-            off_vec = PHACountsSpectrum(backscal=bkg.a_off, is_bkg=True, **counts_kwargs)
+            off_vec = PHACountsSpectrum(backscal=bkg.a_off, is_bkg=True,
+                                        **counts_kwargs)
 
             on_vec.fill(on_events)
             off_vec.fill(bkg.off_events)

--- a/gammapy/spectrum/spectrum_extraction.py
+++ b/gammapy/spectrum/spectrum_extraction.py
@@ -232,10 +232,15 @@ class SpectrumExtraction(object):
             method for defining the low energy threshold
         """
         # TODO: define method for the high energy threshold
+
+        # It is important to update the low and high threshold for ON and OFF
+        # vector, otherwise Sherpa will not understand the files
         for obs in self.observations:
             if method_lo_threshold == 'area_max':
-                obs.on_vector.lo_threshold = obs.aeff.find_energy(
-                    kwargs['percent'] / 100 * obs.aeff.max_area)
+                aeff_thres = kwargs['percent'] / 100 * obs.aeff.max_area
+                thres = obs.aeff.find_energy(aeff_thres) 
+                obs.on_vector.lo_threshold = thres
+                obs.off_vector.lo_threshold = thres
             else:
                 raise ValueError('Undefine method for low threshold: {}'.format(
                     method_lo_threshold))

--- a/gammapy/spectrum/tests/test_spectrum_extraction.py
+++ b/gammapy/spectrum/tests/test_spectrum_extraction.py
@@ -14,7 +14,6 @@ from ...data import DataStore, Target, ObservationList
 from ...datasets import gammapy_extra
 from ...image import ExclusionMask
 from ...spectrum import SpectrumExtraction, SpectrumObservation
-import logging
 import numpy as np
 
 @pytest.mark.parametrize("pars,results", [
@@ -30,7 +29,6 @@ import numpy as np
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_spectrum_extraction(pars, results, tmpdir):
-    logging.basicConfig(level=logging.INFO)
 
     center = SkyCoord(83.63, 22.01, unit='deg', frame='icrs')
     radius = Angle('0.11 deg')

--- a/gammapy/spectrum/tests/test_spectrum_extraction.py
+++ b/gammapy/spectrum/tests/test_spectrum_extraction.py
@@ -19,12 +19,12 @@ import logging
 @pytest.mark.parametrize("pars,results", [
     (dict(containment_correction=False), dict(n_on=172,
                                               sigma=24.06,
-                                              aeff=549861.8268659255 * u.m ** 2,
-                                              ethresh=0.427 * u.TeV)),
+                                              aeff=549861.8 * u.m ** 2,
+                                              ethresh=0.4355 * u.TeV)),
     (dict(containment_correction=True), dict(n_on=172,
                                              sigma=24.06,
-                                             aeff=393356.18322397786 * u.m ** 2,
-                                             ethresh=0.610 * u.TeV)),
+                                             aeff=393356.2 * u.m ** 2,
+                                             ethresh=0.623 * u.TeV)),
 ])
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/tests/test_spectrum_fit.py
+++ b/gammapy/spectrum/tests/test_spectrum_fit.py
@@ -10,13 +10,16 @@ from ...spectrum.spectrum_extraction import SpectrumObservationList, SpectrumObs
 from ...spectrum.spectrum_fit import SpectrumFit
 from ...utils.testing import requires_dependency, requires_data, SHERPA_LT_4_8
 from astropy.utils.compat import NUMPY_LT_1_9
-
+import logging
 
 @pytest.mark.skipif('NUMPY_LT_1_9')
 @pytest.mark.skipif('SHERPA_LT_4_8')
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
 def test_spectral_fit():
+
+    logging.basicConfig(level=logging.INFO)
+
     pha1 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23592.fits")
     pha2 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23523.fits")
     obs1 = SpectrumObservation.read(pha1)
@@ -24,19 +27,29 @@ def test_spectral_fit():
     obs_list = SpectrumObservationList([obs1, obs2])
 
     fit = SpectrumFit(obs_list)
-    
     fit.run()
-    assert fit.result.fit.spectral_model == 'PowerLaw'
-    assert_allclose(fit.result.fit.statval, 100.433, rtol=1e-3)
-    assert_quantity_allclose(fit.result.fit.parameters.index,
+
+    assert fit.result[0].fit.spectral_model == 'PowerLaw'
+    assert_allclose(fit.result[0].fit.statval, 100.433, rtol=1e-3)
+    assert_quantity_allclose(fit.result[0].fit.parameters.index,
                              2.405 * u.Unit(''), rtol=1e-3)
+    print(obs1.lo_threshold)
+    1/0
+    assert_quantity_allclose(obs1.lo_threshold, fit.result[0].fit.fit_range[0])
     
     # Compare Npred vectors
     # TODO: Read model from FitResult
     from gammapy.spectrum.models import PowerLaw
-    model = PowerLaw(index=fit.result.fit.parameters.index,
-                     reference=fit.result.fit.parameters.reference,
-                     amplitude=fit.result.fit.parameters.norm
+    model = PowerLaw(index=fit.result[0].fit.parameters.index,
+                     reference=fit.result[0].fit.parameters.reference,
+                     amplitude=fit.result[0].fit.parameters.norm
                     )
     npred = obs1.predicted_counts(model)
-    assert_allclose(fit.result.fit.n_pred, npred.data, rtol=1e-3)
+    assert_allclose(fit.result[0].fit.n_pred, npred.data, rtol=1e-3)
+
+
+    # Restrict fit range
+    fit.fit_range = [4, 20] * u.TeV
+    fit.run()
+    print(fit.result.fit)
+    1/0

--- a/gammapy/spectrum/tests/test_spectrum_fit.py
+++ b/gammapy/spectrum/tests/test_spectrum_fit.py
@@ -10,15 +10,12 @@ from ...spectrum.spectrum_extraction import SpectrumObservationList, SpectrumObs
 from ...spectrum.spectrum_fit import SpectrumFit
 from ...utils.testing import requires_dependency, requires_data, SHERPA_LT_4_8
 from astropy.utils.compat import NUMPY_LT_1_9
-import logging
 
 @pytest.mark.skipif('NUMPY_LT_1_9')
 @pytest.mark.skipif('SHERPA_LT_4_8')
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
 def test_spectral_fit():
-
-    logging.basicConfig(level=logging.INFO)
 
     pha1 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23592.fits")
     pha2 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23523.fits")

--- a/gammapy/spectrum/tests/test_spectrum_fit.py
+++ b/gammapy/spectrum/tests/test_spectrum_fit.py
@@ -30,12 +30,14 @@ def test_spectral_fit():
     fit.run()
 
     assert fit.result[0].fit.spectral_model == 'PowerLaw'
-    assert_allclose(fit.result[0].fit.statval, 100.433, rtol=1e-3)
+    assert_allclose(fit.result[0].fit.statval, 145.34, rtol=1e-3)
     assert_quantity_allclose(fit.result[0].fit.parameters.index,
-                             2.405 * u.Unit(''), rtol=1e-3)
-    print(obs1.lo_threshold)
-    1/0
-    assert_quantity_allclose(obs1.lo_threshold, fit.result[0].fit.fit_range[0])
+                             2.114 * u.Unit(''), rtol=1e-3)
+
+    # Actual fit range can differ from threshold due to binning effects
+    assert_quantity_allclose(obs1.lo_threshold,
+                             fit.result[0].fit.fit_range[0],
+                             atol = 50 * u.GeV)
     
     # Compare Npred vectors
     # TODO: Read model from FitResult
@@ -45,6 +47,9 @@ def test_spectral_fit():
                      amplitude=fit.result[0].fit.parameters.norm
                     )
     npred = obs1.predicted_counts(model)
+
+    print(npred)
+    1/0
     assert_allclose(fit.result[0].fit.n_pred, npred.data, rtol=1e-3)
 
 

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -122,6 +122,7 @@ def calculate_predicted_counts(model, aeff, edisp, livetime):
 
     true_energy = aeff.energy.data
     flux = model.integral(emin=true_energy[:-1], emax=true_energy[1:]) 
+    
     counts = flux * livetime * aeff.evaluate()
     counts = counts.decompose()
     counts = edisp.apply(counts.decompose())

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -238,14 +238,20 @@ class NDDataArray(object):
 
         return res
 
-    def _add_regular_grid_interp(self):
+    def _add_regular_grid_interp(self, interp_kwargs=None):
         """Add `~scipy.interpolate.RegularGridInterpolator`
 
-
         http://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.interpolate.RegularGridInterpolator.html
+
+        Parameters
+        ----------
+        interp_kwargs : dict, optional
+            Interpolation kwargs
         """
         from scipy.interpolate import RegularGridInterpolator
         
+        if interp_kwargs is None:
+            interp_kwargs = self.interp_kwargs
         points = [a._interp_nodes() for a in self.axes]
         values = self.data.value
 
@@ -260,7 +266,7 @@ class NDDataArray(object):
                 values = values[mask]
 
         self._regular_grid_interp = RegularGridInterpolator(points, values,
-                                                            **self.interp_kwargs)
+                                                            **interp_kwargs)
 
 
 class DataAxis(object):


### PR DESCRIPTION
This fixes a bug discovered by @registerrier, namely that the fit range attribute of ``gammapy.spectrum.SpectrumFit`` was not taken into account at all when fitting with Sherpa.

I also changes the fit output insofar as one result per obs is returned, they all have the same best fit values, but differ e.g. in ``npred`` and ``fit_range`` (due to different thresholds)