### PR TITLE
Add flux points computation methods

### DIFF
--- a/examples/example_calculate_fluxpoints.py
+++ b/examples/example_calculate_fluxpoints.py
@@ -1,0 +1,58 @@
+"""Compute flux points
+
+This is an example script that show how to compute flux points in Gammapy. 
+TODO: Refactor and add to FluxPointsComputation class or so
+"""
+
+from gammapy.spectrum import (
+    SpectrumObservation,
+    SpectrumFit,
+    DifferentialFluxPoints,
+    SpectrumFitResult,
+    SpectrumResult
+)
+import astropy.units as u
+import numpy as np
+import copy
+import matplotlib.pyplot as plt
+
+obs = SpectrumObservation.read('$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23523.fits')
+
+fit = SpectrumFit(obs)
+fit.run()
+best_fit = copy.deepcopy(fit.result[0].fit)
+
+# Define Flux points binning
+emin = np.log10(obs.lo_threshold.to('TeV').value)
+emax = np.log10(40)
+binning = np.logspace(emin, emax, 8) * u.TeV
+
+# Fix index
+fit.model.gamma.freeze()
+
+# Fit norm in bands
+diff_flux = list()
+diff_flux_err = list()
+e_err_hi = list()
+e_err_lo = list()
+energy = list()
+for ii in range(len(binning)-1):
+    energ= np.sqrt(binning[ii] * binning[ii+1])
+    energy.append(energ)
+    e_err_hi.append(binning[ii+1] - energ)
+    e_err_lo.append(energ - binning[ii])
+    fit.fit_range = binning[[ii,ii+1]]
+    fit.run()
+    res = fit.result[0].fit
+    diff_flux.append(res.model(energ).to('cm-2 s-1 TeV-1'))
+    err = res.model_with_uncertainties(energ.to('keV').value)
+    diff_flux_err.append(err.s * u.Unit('cm-2 s-1 keV-1'))
+
+points = DifferentialFluxPoints.from_arrays(energy=energy, diff_flux=diff_flux,
+                                            diff_flux_err_hi=diff_flux_err,
+                                            diff_flux_err_lo=diff_flux_err,
+                                            energy_err_hi = e_err_hi,
+                                            energy_err_lo = e_err_lo)
+result = SpectrumResult(fit=best_fit, points=points)
+result.plot_spectrum()
+plt.show()

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -63,17 +63,21 @@ class DifferentialFluxPoints(Table):
         # Set errors to zero by default
         def_f = np.zeros(len(energy)) * diff_flux.unit
         def_e = np.zeros(len(energy)) * energy.unit
-        energy_err_hi = def_e if energy_err_hi is None else energy_err_hi
-        energy_err_lo = def_e if energy_err_lo is None else energy_err_lo
-        diff_flux_err_hi = def_f if diff_flux_err_hi is None else diff_flux_err_hi
-        diff_flux_err_lo = def_f if diff_flux_err_lo is None else diff_flux_err_lo
+        if energy_err_hi is None:
+            energy_err_hi = def_e
+        if energy_err_lo is None:
+            energy_err_lo = def_e
+        if diff_flux_err_hi is None:
+            diff_flux_err_hi = def_f
+        if diff_flux_err_lo is None:
+            diff_flux_err_lo = def_f
 
         t['ENERGY'] = energy
-        t['ENERGY_ERR_HI'] = energy_err_hi
-        t['ENERGY_ERR_LO'] = energy_err_lo
+        t['ENERGY_ERR_HI'] = Quantity(energy_err_hi)
+        t['ENERGY_ERR_LO'] = Quantity(energy_err_lo)
         t['DIFF_FLUX'] = diff_flux
-        t['DIFF_FLUX_ERR_HI'] = diff_flux_err_hi
-        t['DIFF_FLUX_ERR_LO'] = diff_flux_err_lo
+        t['DIFF_FLUX_ERR_HI'] = Quantity(diff_flux_err_hi)
+        t['DIFF_FLUX_ERR_LO'] = Quantity(diff_flux_err_lo)
         return cls(t)
 
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -34,19 +34,6 @@ class SpectralModel(object):
             ss += '\n{parname} : {parval:.3g}'.format(**locals())
         return ss
     
-    def with_uncertainties(self, covariance, axis):
-        """Connect model to uncertainties module
-        
-        This uses the uncertainties packages as explained here
-        https://pythonhosted.org/uncertainties/user_guide.html#use-of-a-covariance-matrix
-
-        Examples
-        --------
-        TODO
-        """
-        import IPython; IPython.embed()
-
-
     def to_sherpa(self, name='default'):
         """Return `~sherpa.models.ArithmeticModel`
 
@@ -66,28 +53,6 @@ class SpectralModel(object):
         model.ampl = self.parameters.amplitude.to('cm-2 s-1 keV-1').value
 
         return model
-
-    @classmethod
-    def from_sherpa(cls, model):
-        """Create `~gammapy.spectrum.models.SpectrumModel` from
-        `~sherpa.models.ArithmeticModel`
-
-        Parameters
-        ----------
-        model : `~sherpa.models.ArithmeticModel`
-            Sherpa model
-        """
-        from . import SpectrumFit
-        pardict = dict(gamma = ['index', u.Unit('')],
-                       ref = ['reference', u.keV],
-                       ampl = ['amplitude', SpectrumFit.FLUX_FACTOR * u.Unit('cm-2 s-1 keV-1')])
-        kwargs = dict()
-
-        for par in model.pars:
-            name = par.name
-            kwargs[pardict[name][0]] =  par.val * pardict[name][1]
-
-        return cls(**kwargs)
 
     def to_dict(self):
         """Serialize to dict"""
@@ -174,8 +139,8 @@ class PowerLaw(SpectralModel):
     """
     def __init__(self, index, amplitude, reference):
         self.parameters = Bunch(index = index,
-                                amplitude = amplitude.to('cm-2 s-1 TeV-1'),
-                                reference = reference.to('TeV'))
+                                amplitude = amplitude,
+                                reference = reference)
         
     @staticmethod
     def evaluate(energy, index, amplitude, reference):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -33,26 +33,6 @@ class SpectralModel(object):
         for parname, parval in self.parameters.items():
             ss += '\n{parname} : {parval:.3g}'.format(**locals())
         return ss
-    
-    def to_sherpa(self, name='default'):
-        """Return `~sherpa.models.ArithmeticModel`
-
-        Parameters
-        ----------
-        name : str, optional
-            Name of the sherpa model instance
-        """
-        import sherpa.models as m
-        if isinstance(self, PowerLaw):
-            model = m.PowLaw1D('powlaw1d.' + name)
-            model.gamma = self.parameters.index.value
-        else:
-            raise NotImplementedError
-
-        model.ref = self.parameters.reference.to('keV').value
-        model.ampl = self.parameters.amplitude.to('cm-2 s-1 keV-1').value
-
-        return model
 
     def to_dict(self):
         """Serialize to dict"""
@@ -74,7 +54,7 @@ class SpectralModel(object):
             kwargs[_['name']] = _['val'] * u.Unit(_['unit'])
         return cls(**kwargs)
 
-    def plot(self, ax=None, energy_range=[0.1, 10] * u.TeV,
+    def plot(self, energy_range, ax=None, 
              energy_unit='TeV', flux_unit='cm-2 s-1 TeV-1',
              energy_power=0, n_points=100, **kwargs):
         """Plot `~gammapy.spectrum.SpectralModel` 
@@ -91,9 +71,9 @@ class SpectralModel(object):
             Unit of the energy axis
         flux_unit : str, `~astropy.units.Unit`, optional
             Unit of the flux axis
-        energy_power : int
+        energy_power : int, optional
             Power of energy to multiply flux axis with
-        n_points : int
+        n_points : int, optional
             Number of evaluation nodes
 
         Returns
@@ -156,6 +136,22 @@ class PowerLaw(SpectralModel):
         lower = (emin / pars.reference) ** val
 
         return prefactor * (upper - lower)
+
+    def to_sherpa(self, name='default'):
+        """Return `~sherpa.models.PowLaw1d`
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the sherpa model instance
+        """
+        import sherpa.models as m
+        model = m.PowLaw1D('powlaw1d.' + name)
+        model.gamma = self.parameters.index.value
+        model.ref = self.parameters.reference.to('keV').value
+        model.ampl = self.parameters.amplitude.to('cm-2 s-1 keV-1').value
+
+        return model
 
 
 class ExponentialCutoffPowerLaw(SpectralModel):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -33,6 +33,19 @@ class SpectralModel(object):
         for parname, parval in self.parameters.items():
             ss += '\n{parname} : {parval:.3g}'.format(**locals())
         return ss
+    
+    def with_uncertainties(self, covariance, axis):
+        """Connect model to uncertainties module
+        
+        This uses the uncertainties packages as explained here
+        https://pythonhosted.org/uncertainties/user_guide.html#use-of-a-covariance-matrix
+
+        Examples
+        --------
+        TODO
+        """
+        import IPython; IPython.embed()
+
 
     def to_sherpa(self, name='default'):
         """Return `~sherpa.models.ArithmeticModel`
@@ -81,9 +94,20 @@ class SpectralModel(object):
         retval = dict()
 
         retval['name'] = self.__class__.__name__
+        retval['parameters'] = list()
         for parname, parval in self.parameters.items():
-            retval[parname] = str(parval)
+            retval['parameters'].append(dict(name=parname,
+                                             val=parval.value,
+                                             unit=str(parval.unit)))
         return retval
+
+    @classmethod
+    def from_dict(cls, val):
+        """Serialize from dict"""
+        kwargs = dict()
+        for _ in val['parameters']:
+            kwargs[_['name']] = _['val'] * u.Unit(_['unit'])
+        return cls(**kwargs)
 
     def plot(self, ax=None, energy_range=[0.1, 10] * u.TeV,
              energy_unit='TeV', flux_unit='cm-2 s-1 TeV-1',

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import uncertainties
 import numpy as np
 from astropy.extern import six
 from astropy.table import Table, Column, QTable, hstack, vstack
@@ -168,6 +167,7 @@ class SpectrumFitResult(object):
         --------
         TODO
         """
+        import uncertainties
         unit_dict = dict(amplitude = 'cm-2 s-1 keV-1',
                          reference = 'keV',
                          index = '')
@@ -250,13 +250,14 @@ class SpectrumResult(object):
         residuals : `~uncertainties.ufloat`
             Residuals
         """
+        from uncertainties import ufloat
         x = self.points['ENERGY'].quantity.to('keV')
         y = self.points['DIFF_FLUX'].quantity.to('cm-2 s-1 keV-1')
         y_err = self.points['DIFF_FLUX_ERR_HI'].quantity.to('cm-2 s-1 keV-1')
 
         points = list()
         for val, err in zip(y.value, y_err.value):
-            points.append(uncertainties.ufloat(val, err))
+            points.append(ufloat(val, err))
 
         func = self.fit.model_with_uncertainties(x.to('keV').value)
         residuals = (points - func) / points

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from astropy.extern import six
-from astropy.modeling import models
 from astropy.table import Table, Column, QTable, hstack, vstack
 import astropy.units as u
 
-from ..spectrum import DifferentialFluxPoints, CountsSpectrum
+from ..spectrum import DifferentialFluxPoints, CountsSpectrum, models
 from ..extern.bunch import Bunch
 from ..utils.energy import EnergyBounds
 from ..utils.scripts import read_yaml, make_path
@@ -91,12 +90,13 @@ class SpectrumFitResult(object):
         val = dict()
         val['model'] = self.model.to_dict()
         if self.fit_range is not None:
-            val['fit_range'] = dict(min = str(self.fit_range[0]),
-                                    max = str(self.fit_range[1]))
+            val['fit_range'] = dict(min = self.fit_range[0].value,
+                                    max = self.fit_range[1].value,
+                                    unit = str(self.fit_range.unit))
         if self.statval is not None:
             val['statval'] = self.statval
         if self.statname is not None:
-            val['statval'] = self.statname
+            val['statname'] = self.statname
         if self.covariance is not None:
             val['covariance'] = dict(matrix = self.covariance.tolist(),
                                      axis = self.covar_axis)
@@ -104,19 +104,16 @@ class SpectrumFitResult(object):
 
     @classmethod
     def from_dict(cls, val):
+        modeldict = val['model']
+        if modeldict['name'] == 'PowerLaw':
+            model = models.PowerLaw.from_dict(modeldict)
+        else:
+            raise NotImplementedError()
         try:
             erange = val['fit_range']
             energy_range = (erange['min'], erange['max']) * u.Unit(erange['unit'])
         except KeyError:
             energy_range = None
-        pars = val['parameters']
-        parameters = Bunch()
-        parameter_errors = Bunch()
-        for par in pars:
-            parameters[par] = pars[par]['value'] * u.Unit(pars[par]['unit'])
-            parameter_errors[par] = pars[par]['error'] * u.Unit(pars[par]['unit'])
-        spectral_model = val['spectral_model']
-
         try:
             fl = val['fluxes']
         except KeyError:
@@ -129,9 +126,9 @@ class SpectrumFitResult(object):
                 fluxes[flu] = fl[flu]['value'] * u.Unit(fl[flu]['unit'])
                 flux_errors[flu] = fl[flu]['error'] * u.Unit(fl[flu]['unit'])
 
-        return cls(fit_range=energy_range, parameters=parameters,
-                   parameter_errors=parameter_errors,
-                   spectral_model=spectral_model, fluxes=fluxes,
+        return cls(model=model,
+                   fit_range=energy_range,
+                   fluxes=fluxes,
                    flux_errors=flux_errors)
 
     def to_table(self, **kwargs):
@@ -155,14 +152,9 @@ class SpectrumFitResult(object):
     def model_with_uncertainties(self):
         """Model with uncertainties
 
-        This uses the uncertainties packages as explained here
-        https://pythonhosted.org/uncertainties/user_guide.html#use-of-a-covariance-matrix
-
-        Examples
-        --------
-        TODO
+        see :func:`~gammapy.spectrum.models.SpectralModel.with_uncertainties`
         """
-        raise NotImplementedError()
+        return self.model.with_uncertainties(self.covariance, self.covar_axis)
 
     def __str__(self):
         """
@@ -210,18 +202,45 @@ class SpectrumResult(object):
 
     @property
     def expected_on_vector(self):
-        """Counts predicted by a model plus background estimate"""
+        """Npred
+        
+        Counts predicted by best fit model plus background estimate
+        """
         energy = self.obs.background_vector.energy
         data = (self.obs.background_vector.data.value + self.fit.npred) * u.ct
         idx = np.isnan(data)
         data[idx] = 0
         return CountsSpectrum(data=data, energy=energy)
 
+    @property
+    def flux_point_residuals(self):
+        """Calculate residuals and residual errors
+
+        Based on best fit model and fluxpoints
+
+        Returns
+        -------
+        residuals : `~astropy.units.Quantity`
+            Residuals
+        residuals_err : `~astropy.units.Quantity`
+            Residual errors
+        """
+        x = self.points['ENERGY'].quantity
+        y = self.points['DIFF_FLUX'].quantity
+        y_err = self.points['DIFF_FLUX_ERR_HI'].quantity
+
+        func_y = self.fit.model(x)
+        err_y = self.fit.model_with_uncertainties(x)
+        residuals = (y - func_y) / y
+        residuals_err = np.sqrt(y_err ** 2 + err_y[0] ** 2) / y
+
+        return residuals.decompose(), residuals_err.decompose()
+
     def plot_fit(self):
         """Standard debug plot
         
         Plot ON counts in comparison to background estimate plus source
-        counts predicted by a model
+        counts predicted by best fit model
         """
         from matplotlib import gridspec
         import matplotlib.pyplot as plt
@@ -271,7 +290,9 @@ class SpectrumResult(object):
 
     def plot_spectrum(self, energy_unit='TeV', flux_unit='cm-2 s-1 TeV-1',
                       energy_power=0, fit_kwargs=None, point_kwargs=None):
-        """Plot full spectrum including flux points and residuals
+        """Plot spectrum 
+        
+        Plot best fit model, flux points and residuals
 
         Parameters
         ----------
@@ -310,13 +331,12 @@ class SpectrumResult(object):
 
         if fit_kwargs is None:
             fit_kwargs = dict(label='Best Fit {}'.format(
-                    self.fit.spectral_model), color='navy', lw=2)
+                    self.fit.model.__class__.__name__), color='navy', lw=2)
         if point_kwargs is None:
             point_kwargs = dict(color='navy')
 
-
-        self.fit.plot(energy_unit=energy_unit, flux_unit=flux_unit,
-                      energy_power=energy_power, ax=ax0, **fit_kwargs)
+        self.fit.model.plot(energy_unit=energy_unit, flux_unit=flux_unit,
+                            energy_power=energy_power, ax=ax0, **fit_kwargs)
         self.points.plot(energy_unit=energy_unit, flux_unit=flux_unit,
                          energy_power=energy_power, ax=ax0, **point_kwargs)
         self._plot_residuals(energy_unit=energy_unit, ax=ax1, **point_kwargs)
@@ -348,7 +368,7 @@ class SpectrumResult(object):
 
         kwargs.setdefault('fmt', 'o')
 
-        y, y_err = self._calculate_residuals_points()
+        y, y_err = self.flux_point_residuals
         x = self.points['ENERGY'].quantity
         x = x.to(energy_unit).value
         ax.errorbar(x, y, yerr=y_err, **kwargs)
@@ -362,27 +382,3 @@ class SpectrumResult(object):
 
         return ax
 
-    def _calculate_residuals_points(self):
-        """Calculate residuals and residual errors
-
-        Based on `~gammapy.spectrum.results.SpectrumFitResult` and
-        `~gammapy.spectrum.results.FluxPoints`
-
-        Returns
-        -------
-        residuals : `~astropy.units.Quantity`
-            Residuals
-        residuals_err : `~astropy.units.Quantity`
-            Residual errors
-        """
-        x = self.points['ENERGY'].quantity
-        y = self.points['DIFF_FLUX'].quantity
-        y_err = self.points['DIFF_FLUX_ERR_HI'].quantity
-
-        func_y = self.fit.evaluate(x)
-        err_y = self.fit.evaluate_butterfly(x)
-        residuals = (y - func_y) / y
-        # Todo: add correct formular (butterfly)
-        residuals_err = np.sqrt(y_err ** 2 + err_y[0] ** 2) / y
-
-        return residuals.decompose(), residuals_err.decompose()

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -37,4 +37,5 @@ def test_models(model, results):
 @pytest.mark.parametrize("model, results", get_test_data())
 def test_to_sherpa(model, results):
     model.to_sherpa()
-    model.plot()    
+    energy_range = [1,10] * u.TeV
+    model.plot(energy_range = energy_range)

--- a/gammapy/spectrum/tests/test_spectrum_fit.py
+++ b/gammapy/spectrum/tests/test_spectrum_fit.py
@@ -42,6 +42,9 @@ def test_spectral_fit(tmpdir):
     assert_allclose(result.fit.statval, 103.595, rtol=1e-3)
     assert_quantity_allclose(result.fit.model.parameters.index,
                              2.116 * u.Unit(''), rtol=1e-3)
+    model_with_errors = result.fit.model_with_uncertainties
+    assert_allclose(model_with_errors.parameters.index.s,
+                    0.0543, rtol=1e-3)
 
     # Actual fit range can differ from threshold due to binning effects
     # We take the lowest bin that is completely within threshold


### PR DESCRIPTION
This PR

* [x] removes to/from sherpa methods from model base class as discussed in https://github.com/gammapy/gammapy/pull/627
* [x] Adds possibility to fit model with fixed index
* [x] Adds script to compute flux points
* [x] Add ``model_with_uncertainties`` property to ``SpectrumResult`` to evaluate/plot butterlflies