### PR TITLE
Fix header commentary cards in SkyMap.meta

### DIFF
--- a/gammapy/image/maps.py
+++ b/gammapy/image/maps.py
@@ -109,6 +109,13 @@ class SkyMap(object):
             unit = None
 
         meta = OrderedDict(header)
+
+        # parse astropy.io.fits.header._HeaderCommentaryCards as strings
+        if 'HISTORY' in meta:
+            meta['HISTORY'] = str(meta['HISTORY'])
+        if 'COMMENT' in meta:
+            meta['COMMENT'] = str(meta['COMMENT'])
+
         return cls(name, data, wcs, unit, meta)
 
     @classmethod

--- a/gammapy/image/tests/test_maps.py
+++ b/gammapy/image/tests/test_maps.py
@@ -8,6 +8,7 @@ from astropy.io import fits
 from astropy.units import Quantity
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.wcs import WcsError
+from astropy.extern.six import string_types
 from ...extern.regions import CircleSkyRegion
 from ...utils.testing import requires_dependency, requires_data
 from ...data import DataStore
@@ -117,9 +118,13 @@ class TestSkyMapPoisson:
 
     def test_io(self, tmpdir):
         filename = tmpdir / 'test_skymap.fits'
+        self.skymap.meta['COMMENT'] = 'Test comment'
+        self.skymap.meta['HISTORY'] = 'Test history'
         self.skymap.write(str(filename))
         skymap = SkyMap.read(str(filename))
         assert self.skymap.name == skymap.name
+        assert isinstance(skymap.meta['COMMENT'], string_types)
+        assert isinstance(skymap.meta['HISTORY'], string_types)
 
     def test_unit_io(self, tmpdir):
         filename = tmpdir / 'test_skymap_unit.fits'


### PR DESCRIPTION
This fixes an issue with `SkyMap.write()` reported by @leajouvin.

The FITS header `COMMENT` and `HISTORY` cards are parsed as an `astropy.io.fits.header._HeaderCommentaryCards` object and stored as such in the `SkyMap.meta` dictionary. When writing the data to file and updating the header with the meta information in `SkyMap.to_image_hdu()` this caused an error, because `header['COMMENT']` was represented with an  `astropy.io.fits.header._HeaderCommentaryCards` object, which is not a valid data type, that can be written to file.

This PR changes the `COMMENT` and `HISTORY` keywords to be stored as string in the `SkyMap.meta` attribute.