### PR TITLE
Consistent use of tmpdir in tests

### DIFF
--- a/gammapy/background/__init__.py
+++ b/gammapy/background/__init__.py
@@ -6,7 +6,6 @@ from .energy_offset_array import *
 from .background_estimate import *
 from .fov import *
 from .cube import *
-from .on_off import *
 from .ring import *
 from .kernel import *
 from .models import *

--- a/gammapy/background/__init__.py
+++ b/gammapy/background/__init__.py
@@ -8,7 +8,6 @@ from .fov import *
 from .cube import *
 from .on_off import *
 from .ring import *
-from .template import *
 from .kernel import *
 from .models import *
 from .off_data_background_maker import *

--- a/gammapy/background/off_data_background_maker.py
+++ b/gammapy/background/off_data_background_maker.py
@@ -201,7 +201,7 @@ class OffDataBackgroundMaker(object):
     def save_model(self, modeltype, ngroup, smooth=False):
         """Save model to fits for one group.
 
-          Parameters
+        Parameters
         ----------
         modeltype : {'3D', '2D'}
             Type of the background modelisation
@@ -239,7 +239,6 @@ class OffDataBackgroundMaker(object):
         ----------
         modeltype : {'3D', '2D'}
             Type of the background modelisation
-
         """
         for ngroup in range(self.ntot_group):
             self.smooth_model(modeltype, ngroup)
@@ -253,7 +252,6 @@ class OffDataBackgroundMaker(object):
             Type of the background modelisation
         ngroup : int
             Groups ID
-
         """
         if modeltype == "3D":
             if str(ngroup) in self.models3D.keys():
@@ -282,7 +280,6 @@ class OffDataBackgroundMaker(object):
             name of the file containing the `~astropy.table.Table` with the group infos
         smooth : bool
             True if you want to use the smooth bkg model
-
 
         Returns
         -------

--- a/gammapy/background/on_off.py
+++ b/gammapy/background/on_off.py
@@ -1,4 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""On-off background estimation.
-"""
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/gammapy/background/template.py
+++ b/gammapy/background/template.py
@@ -1,6 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Template background estimation.
-
-Reference: http://adsabs.harvard.edu/abs/2003A%26A...410..389R
-"""
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/gammapy/background/tests/test_off_data_background_maker.py
+++ b/gammapy/background/tests/test_off_data_background_maker.py
@@ -3,11 +3,8 @@ from astropy.table import Table
 import numpy as np
 from ...utils.testing import requires_dependency, requires_data
 from ...data import ObservationTable, DataStore
-from ..models import CubeBackgroundModel, EnergyOffsetBackgroundModel
+from ..models import EnergyOffsetBackgroundModel
 from ..off_data_background_maker import OffDataBackgroundMaker
-from ...datasets import gammapy_extra
-import os
-from ...extern.pathlib import Path
 
 
 @requires_dependency('scipy')
@@ -39,7 +36,9 @@ def test_background_model(tmpdir):
 
     index_table_new = bgmaker.make_total_index_table(data_store, "2D", None, None)
     table_bkg = index_table_new[np.where(index_table_new["HDU_NAME"] == "bkg_2d")]
+
     name_bkg_run023523 = table_bkg[np.where(table_bkg["OBS_ID"] == 23523)]["FILE_NAME"]
     assert str(tmpdir) + "/" + name_bkg_run023523[0] == str(tmpdir) + '/background_2D_group_001_table.fits.gz'
+
     name_bkg_run023526 = table_bkg[np.where(table_bkg["OBS_ID"] == 23526)]["FILE_NAME"]
     assert str(tmpdir) + "/" + name_bkg_run023526[0] == str(tmpdir) + '/background_2D_group_000_table.fits.gz'

--- a/gammapy/background/tests/test_on_off.py
+++ b/gammapy/background/tests/test_on_off.py
@@ -1,2 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.io import fits
 from ...background import RingBgMaker, ring_r_out
 from ...image import SkyMapCollection
 from ...utils.testing import requires_dependency

--- a/gammapy/background/tests/test_template.py
+++ b/gammapy/background/tests/test_template.py
@@ -1,2 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -30,8 +30,8 @@ class TestSkyCube(object):
         sky_cube = SkyCube(name, data, wcs, energy)
         assert sky_cube.data.shape == (30, 21, 61)
 
-    def test_read_write(self):
-        filename = 'sky_cube_test.fits'
+    def test_read_write(self, tmpdir):
+        filename = str(tmpdir / 'sky_cube.fits')
         self.sky_cube.writeto(filename)
 
         sky_cube = SkyCube.read(filename)

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -1,21 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
 from numpy.testing.utils import assert_allclose
-
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
 from astropy.units import Quantity
 from astropy.tests.helper import pytest
 from astropy.coordinates import Angle
-
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EnergyDependentMultiGaussPSF
 from ...datasets import gammapy_extra
 
-
 ENERGIES = Quantity([1, 10, 25], 'TeV')
+
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
@@ -60,7 +57,7 @@ def test_to_table_psf(energy):
     interpol_param = dict(method='nearest', bounds_error=False)
     table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
     psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
-    
+
     containment = np.linspace(0, 0.95, 10)
     desired = [psf_at_energy.containment_radius(_) for _ in containment]
     actual = table_psf_at_energy.containment_radius(containment)

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -1,59 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.coordinates import Angle
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.table import Table
-import numpy as np
-from ...irf import PSFKing
-from ...utils.energy import Energy
 from ...utils.testing import requires_data
-from ...datasets import gammapy_extra
+from ...irf import PSFKing
+
+
+@pytest.fixture(scope='session')
+def psf_king():
+    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_psf_king_023523.fits.gz'
+    return PSFKing.read(filename)
 
 
 @requires_data('gammapy-extra')
-def test_psf_king_read():
-    filename = str(gammapy_extra.dir) + "/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523" \
-                                        "/hess_psf_king_023523.fits.gz"
-    psf_king = PSFKing.read(filename)
-    table = Table.read(filename)
-    elo = table["ENERG_LO"].squeeze()
-    ehi = table["ENERG_HI"].squeeze()
-    offlo = table["THETA_LO"].squeeze()
-    offhi = table["THETA_HI"].squeeze()
-    sigma = table["SIGMA"].squeeze()
-    gamma = table["GAMMA"].squeeze()
-    energy = np.sqrt(elo * ehi)
-    offset = (offlo + offhi) / 2.
-    offset = Angle(offset, unit=table['THETA_LO'].unit)
-    energy = Energy(energy, unit=table['ENERG_LO'].unit)
-    gamma = Quantity(gamma, table['GAMMA'].unit)
-    sigma = Quantity(sigma, table['SIGMA'].unit)
-
-    assert_quantity_allclose(energy, psf_king.energy)
-    assert_quantity_allclose(offset, psf_king.offset)
-    assert_quantity_allclose(gamma, psf_king.gamma)
-    assert_quantity_allclose(sigma, psf_king.sigma)
-
-
-@requires_data('gammapy-extra')
-def test_psf_king_write():
-    filename = str(gammapy_extra.dir) + "/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523" \
-                                        "/hess_psf_king_023523.fits.gz"
-    psf_king = PSFKing.read(filename)
-    psf_king.write("king.fits")
-    psf_king2 = PSFKing.read("king.fits")
-    assert_quantity_allclose(psf_king2.energy, psf_king.energy)
-    assert_quantity_allclose(psf_king2.offset, psf_king.offset)
-    assert_quantity_allclose(psf_king2.gamma, psf_king.gamma)
-    assert_quantity_allclose(psf_king2.sigma, psf_king.sigma)
-
-
-@requires_data('gammapy-extra')
-def test_psf_king_evaluate():
-    filename = str(gammapy_extra.dir) + "/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523" \
-                                        "/hess_psf_king_023523.fits.gz"
-    psf_king = PSFKing.read(filename)
+def test_psf_king_evaluate(psf_king):
     energy = Quantity(1, "TeV")
     off1 = Angle(0, "deg")
     off2 = Angle(1, "deg")
@@ -67,10 +29,7 @@ def test_psf_king_evaluate():
 
 
 @requires_data('gammapy-extra')
-def test_psf_king_to_table():
-    filename = str(gammapy_extra.dir) + "/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523" \
-                                        "/hess_psf_king_023523.fits.gz"
-    psf_king = PSFKing.read(filename)
+def test_psf_king_to_table(psf_king):
     theta1 = Angle(0, "deg")
     theta2 = Angle(1, "deg")
     psf_king_table_off1 = psf_king.to_table_psf(theta=theta1)
@@ -87,5 +46,16 @@ def test_psf_king_to_table():
 
     # Test that the integral value is close to one
     bin_off = (psf_king_table_off1.offset[1] - psf_king_table_off1.offset[0])
-    int = np.sum(psf_king_table_off1.psf_value[8] * 2 * np.pi * psf_king_table_off1.offset * bin_off)
-    assert_quantity_allclose(int, 1, rtol=1e-1)
+    integral = np.sum(psf_king_table_off1.psf_value[8] * 2 * np.pi * psf_king_table_off1.offset * bin_off)
+    assert_quantity_allclose(integral, 1, rtol=1e-1)
+
+
+@requires_data('gammapy-extra')
+def test_psf_king_write(psf_king, tmpdir):
+    filename = str(tmpdir / 'king.fits')
+    psf_king.write(filename)
+    psf_king2 = PSFKing.read(filename)
+    assert_quantity_allclose(psf_king2.energy, psf_king.energy)
+    assert_quantity_allclose(psf_king2.offset, psf_king.offset)
+    assert_quantity_allclose(psf_king2.gamma, psf_king.gamma)
+    assert_quantity_allclose(psf_king2.sigma, psf_king.sigma)

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -104,7 +104,7 @@ def test_EnergyDependentTablePSF():
     psf1 = psf.table_psf_at_energy(energy)
     containment = np.linspace(0, 0.95, 3)
     containment_radius = psf1.containment_radius(containment)
-    assert_allclose(containment_radius, Angle([0,0.19426847,1.03806372], "deg"))
+    assert_allclose(containment_radius, Angle([0, 0.19426847, 1.03806372], "deg"))
     # TODO: test average_psf
     # psf2 = psf.psf_in_energy_band(energy_band, spectrum)
 
@@ -156,12 +156,13 @@ def test_PSF3D_read():
 
 
 @requires_data('gammapy-extra')
-def test_PSF3D_write():
+def test_PSF3D_write(tmpdir):
     filename = str(gammapy_extra.dir) + '/test_datasets/psf_table_023523.fits.gz'
-
     psf = PSF3D.read(filename)
-    psf.write("psf.fits")
-    psf2 = PSF3D.read("psf.fits")
+
+    filename = str(tmpdir / 'psf.fits')
+    psf.write(filename)
+    psf2 = PSF3D.read(filename)
     assert_quantity_allclose(psf.energy_lo, psf2.energy_lo)
     assert_quantity_allclose(psf.energy_hi, psf2.energy_hi)
     assert_quantity_allclose(psf.offset, psf2.offset)

--- a/gammapy/spectrum/tests/test_counts_spectrum.py
+++ b/gammapy/spectrum/tests/test_counts_spectrum.py
@@ -1,18 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
+from numpy.testing import assert_equal, assert_allclose
 import astropy.units as u
 from astropy.tests.helper import pytest, assert_quantity_allclose
-from numpy.testing import assert_equal, assert_allclose
-
-from .. import CountsSpectrum, SpectrumExtraction, SpectrumFitResult, \
-    SpectrumObservation
-
-from ...data import ObservationTable
 from ...datasets import gammapy_extra
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.energy import EnergyBounds
+from .. import CountsSpectrum, SpectrumFitResult, SpectrumObservation
+
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
@@ -20,23 +16,13 @@ def test_CountsSpectrum(tmpdir):
     # create from scratch
     counts = [0, 0, 2, 5, 17, 3] * u.ct
     bins = EnergyBounds.equal_log_spacing(1, 10, 7, 'TeV')
-    actual = False
-    try:
-        spec = CountsSpectrum(data=counts, energy=bins)
-    except(ValueError):
-        actual = True
-    desired = True
-    assert_equal(actual, desired)
+
+    with pytest.raises(ValueError):
+        CountsSpectrum(data=counts, energy=bins)
 
     bins = EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV')
-    actual = False
-    try:
-        spec = CountsSpectrum(data=counts, energy=bins)
-    except(ValueError):
-        actual = True
-    desired = False
-    assert_equal(actual, desired)
-    
+    spec = CountsSpectrum(data=counts, energy=bins)
+
     test_e = bins[2] + 0.1 * u.TeV
     test_eval = spec.evaluate(energy=test_e, method='nearest')
     assert_allclose(test_eval, spec.data[2])
@@ -45,13 +31,13 @@ def test_CountsSpectrum(tmpdir):
     spec.peek()
 
     # Test I/O 
-    f = tmpdir / 'test.fits'
-    spec.write(f)
-    spec2 = CountsSpectrum.read(f)
+    filename = tmpdir / 'test.fits'
+    spec.write(filename)
+    spec2 = CountsSpectrum.read(filename)
     assert_quantity_allclose(spec2.energy.data,
                              EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV'))
 
-    #add two spectra
+    # add two spectra
     bins = spec.energy.nbins
     counts = np.array(np.random.rand(bins) * 10, dtype=int) * u.ct
     pha2 = CountsSpectrum(data=counts, energy=spec.energy)


### PR DESCRIPTION
I noticed that when running the tests via the `test` function,  the following files are written to the working directory:
```
$ python -c 'import gammapy; gammapy.test()'
$ ls -1
king.fits
multidata.fits
psf.fits
run.lis
sky_cube_test.fits
```

This is bad, tests should always write files to temp directories.

When running the tests via `python setup.py test`, this doesn't happen.

@bsipocz @astrofrog - Is this a bug in the `test` function implementation (the fact that it behaves differently compared to `python setup.py test`)?

I.e. should / will the `test` function be changed?

Or is this normal, and we should use the [tmpdir](http://docs.pytest.org/en/latest/tmpdir.html) fixture in every test that writes to disk?

We use `tmpdir` in many tests
https://github.com/gammapy/gammapy/search?utf8=%E2%9C%93&q=tmpdir
but e.g. this one doesn't and results in the `king.fits` file in the working directory:
https://github.com/gammapy/gammapy/blob/80ed90e843d44f0912304edef48559d65c71f4ea/gammapy/irf/tests/test_psf_king.py#L44