### PR TITLE
Add ECPL model, energy flux and integration methods

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -2,10 +2,10 @@
 """Spectral models for Gammapy.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ..extern.bunch import Bunch
-import astropy.units as u
-from . import CountsSpectrum
 import numpy as np
+import astropy.units as u
+from . import integrate_spectrum
+from ..extern.bunch import Bunch
 
 
 __all__ = [
@@ -33,6 +33,41 @@ class SpectralModel(object):
         for parname, parval in self.parameters.items():
             ss += '\n{parname} : {parval:.3g}'.format(**locals())
         return ss
+
+    def integral(self, emin, emax, **kwargs):
+        """
+        Integrate spectral model numerically.
+
+        .. math:: 
+
+            F(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}\phi(E)dE
+
+        Parameters
+        ----------
+        emin : float, `~astropy.units.Quantity`
+            Lower bound of integration range.
+        emax : float, `~astropy.units.Quantity`
+            Upper bound of integration range
+        """
+        return integrate_spectrum(self, emin, emax, **kwargs)
+
+    def energy_flux(self, emin, emax, **kwargs):
+        """
+        Compute energy flux in given energy range.
+
+        .. math::
+
+            G(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}E \phi(E)dE
+
+        Parameters
+        ----------
+        emin : float, `~astropy.units.Quantity`
+            Lower bound of integration range.
+        emax : float, `~astropy.units.Quantity`
+            Upper bound of integration range
+        """
+        f = lambda x: x * self(x)
+        return integrate_spectrum(f, emin, emax, **kwargs)
 
     def to_dict(self):
         """Serialize to dict"""
@@ -106,14 +141,14 @@ class PowerLaw(SpectralModel):
     
     .. math:: 
 
-        F(E) = F_0 \cdot \left( \frac{E}{E_0} \right)^{-\Gamma}
+        \phi(E) = \phi_0 \cdot \left( \frac{E}{E_0} \right)^{-\Gamma}
 
     Parameters
     ----------
     index : float, `~astropy.units.Quantity`
         :math:`\Gamma`
     amplitude : float, `~astropy.units.Quantity` 
-        :math:`F_0`
+        :math:`Phi_0`
     reference : float, `~astropy.units.Quantity` 
         :math:`E_0`
     """
@@ -127,14 +162,49 @@ class PowerLaw(SpectralModel):
         return amplitude * ( energy / reference ) ** (-1 * index)
 
     def integral(self, emin, emax):
-        """Integrate using analytic formula"""
+        r"""
+        Integrate power law analytically.
+
+        .. math:: 
+
+            F(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}\phi(E)dE = \left.
+            \phi_0 \frac{E_0}{-\Gamma + 1} \left( \frac{E}{E_0} \right)^{-\Gamma + 1}
+            \right \vert _{E_{min}}^{E_{max}}
+
+
+        """
         pars = self.parameters 
         
         val = -1 * pars.index + 1
         prefactor = pars.amplitude * pars.reference / val
         upper = (emax / pars.reference) ** val
         lower = (emin / pars.reference) ** val
+        return prefactor * (upper - lower)
 
+    def energy_flux(self, emin, emax):
+        r"""
+        Compute energy flux in given energy range analytically.
+
+        .. math::
+
+            G(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}E \phi(E)dE = \left.
+            \phi_0 \frac{E_0^2}{-\Gamma + 2} \left( \frac{E}{E_0} \right)^{-\Gamma + 2}
+            \right \vert _{E_{min}}^{E_{max}}
+
+
+        Parameters
+        ----------
+        emin : float, `~astropy.units.Quantity`
+            Lower bound of integration range.
+        emax : float, `~astropy.units.Quantity`
+            Upper bound of integration range
+        """
+        pars = self.parameters 
+        val = -1 * pars.index + 2
+
+        prefactor = pars.amplitude * pars.reference ** 2 / val
+        upper = (emax / pars.reference) ** val
+        lower = (emin / pars.reference) ** val
         return prefactor * (upper - lower)
 
     def to_sherpa(self, name='default'):
@@ -150,11 +220,40 @@ class PowerLaw(SpectralModel):
         model.gamma = self.parameters.index.value
         model.ref = self.parameters.reference.to('keV').value
         model.ampl = self.parameters.amplitude.to('cm-2 s-1 keV-1').value
-
         return model
 
 
 class ExponentialCutoffPowerLaw(SpectralModel):
-    """Spectral exponential cutoff power-law model.
-    """
+    r"""Spectral exponential cutoff power-law model.
+    
+    .. math:: 
 
+        \phi(E) = \phi_0 \cdot \left(\frac{E}{E_0}\right)^{-\Gamma} \exp(-\lambda E)
+
+    Parameters
+    ----------
+    index : float, `~astropy.units.Quantity`
+        :math:`\Gamma`
+    amplitude : float, `~astropy.units.Quantity` 
+        :math:`\phi_0`
+    reference : float, `~astropy.units.Quantity` 
+        :math:`E_0`
+    lambda : float, `~astropy.units.Quantity`
+        :math:`\lambda`
+    """
+    def __init__(self, index, amplitude, reference, lambda_):
+        self.parameters = Bunch(index = index,
+                                amplitude = amplitude,
+                                reference = reference,
+                                lambda_ = lambda_)
+
+    @staticmethod
+    def evaluate(energy, index, amplitude, reference, lambda_):
+        pwl = amplitude * ( energy / reference ) ** (- index)
+        try:
+            cutoff = np.exp(-energy * lambda_)
+        except TypeError:
+            from uncertainties.unumpy import exp
+            cutoff = exp(-energy * lambda_)
+        return pwl * cutoff
+ 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -14,8 +14,8 @@ __all__ = [
     'ExponentialCutoffPowerLaw',
 ]
 
-# Note: Consider to move stuff from _models_old.py here
 
+# Note: Consider to move stuff from _models_old.py here
 class SpectralModel(object):
     """Spectral model base class.
 
@@ -38,7 +38,7 @@ class SpectralModel(object):
         """
         Integrate spectral model numerically.
 
-        .. math:: 
+        .. math::
 
             F(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}\phi(E)dE
 
@@ -66,7 +66,7 @@ class SpectralModel(object):
         emax : float, `~astropy.units.Quantity`
             Upper bound of integration range
         """
-        f = lambda x: x * self(x)
+        def f(x): return x * self(x)
         return integrate_spectrum(f, emin, emax, **kwargs)
 
     def to_dict(self):
@@ -89,10 +89,10 @@ class SpectralModel(object):
             kwargs[_['name']] = _['val'] * u.Unit(_['unit'])
         return cls(**kwargs)
 
-    def plot(self, energy_range, ax=None, 
+    def plot(self, energy_range, ax=None,
              energy_unit='TeV', flux_unit='cm-2 s-1 TeV-1',
              energy_power=0, n_points=100, **kwargs):
-        """Plot `~gammapy.spectrum.SpectralModel` 
+        """Plot `~gammapy.spectrum.SpectralModel`
 
         kwargs are forwarded to :func:`~matplotlib.pyplot.errorbar`
 
@@ -138,8 +138,8 @@ class SpectralModel(object):
 
 class PowerLaw(SpectralModel):
     r"""Spectral power-law model.
-    
-    .. math:: 
+
+    .. math::
 
         \phi(E) = \phi_0 \cdot \left( \frac{E}{E_0} \right)^{-\Gamma}
 
@@ -147,25 +147,25 @@ class PowerLaw(SpectralModel):
     ----------
     index : float, `~astropy.units.Quantity`
         :math:`\Gamma`
-    amplitude : float, `~astropy.units.Quantity` 
+    amplitude : float, `~astropy.units.Quantity`
         :math:`Phi_0`
-    reference : float, `~astropy.units.Quantity` 
+    reference : float, `~astropy.units.Quantity`
         :math:`E_0`
     """
     def __init__(self, index, amplitude, reference):
-        self.parameters = Bunch(index = index,
-                                amplitude = amplitude,
-                                reference = reference)
-        
+        self.parameters = Bunch(index=index,
+                                amplitude=amplitude,
+                                reference=reference)
+
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
-        return amplitude * ( energy / reference ) ** (-1 * index)
+        return amplitude * (energy / reference) ** (-index)
 
     def integral(self, emin, emax):
         r"""
         Integrate power law analytically.
 
-        .. math:: 
+        .. math::
 
             F(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}\phi(E)dE = \left.
             \phi_0 \frac{E_0}{-\Gamma + 1} \left( \frac{E}{E_0} \right)^{-\Gamma + 1}
@@ -173,8 +173,8 @@ class PowerLaw(SpectralModel):
 
 
         """
-        pars = self.parameters 
-        
+        pars = self.parameters
+
         val = -1 * pars.index + 1
         prefactor = pars.amplitude * pars.reference / val
         upper = (emax / pars.reference) ** val
@@ -199,7 +199,7 @@ class PowerLaw(SpectralModel):
         emax : float, `~astropy.units.Quantity`
             Upper bound of integration range
         """
-        pars = self.parameters 
+        pars = self.parameters
         val = -1 * pars.index + 2
 
         prefactor = pars.amplitude * pars.reference ** 2 / val
@@ -225,8 +225,8 @@ class PowerLaw(SpectralModel):
 
 class ExponentialCutoffPowerLaw(SpectralModel):
     r"""Spectral exponential cutoff power-law model.
-    
-    .. math:: 
+
+    .. math::
 
         \phi(E) = \phi_0 \cdot \left(\frac{E}{E_0}\right)^{-\Gamma} \exp(-\lambda E)
 
@@ -234,26 +234,25 @@ class ExponentialCutoffPowerLaw(SpectralModel):
     ----------
     index : float, `~astropy.units.Quantity`
         :math:`\Gamma`
-    amplitude : float, `~astropy.units.Quantity` 
+    amplitude : float, `~astropy.units.Quantity`
         :math:`\phi_0`
-    reference : float, `~astropy.units.Quantity` 
+    reference : float, `~astropy.units.Quantity`
         :math:`E_0`
     lambda : float, `~astropy.units.Quantity`
         :math:`\lambda`
     """
     def __init__(self, index, amplitude, reference, lambda_):
-        self.parameters = Bunch(index = index,
-                                amplitude = amplitude,
-                                reference = reference,
-                                lambda_ = lambda_)
+        self.parameters = Bunch(index=index,
+                                amplitude=amplitude,
+                                reference=reference,
+                                lambda_=lambda_)
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, lambda_):
-        pwl = amplitude * ( energy / reference ) ** (- index)
+        pwl = amplitude * (energy / reference) ** (-index)
         try:
             cutoff = np.exp(-energy * lambda_)
-        except TypeError:
+        except AttributeError:
             from uncertainties.unumpy import exp
             cutoff = exp(-energy * lambda_)
         return pwl * cutoff
- 

--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -34,7 +34,6 @@ __all__ = [
     'power_law_pivot_energy',
     'power_law_df_over_f',
     'power_law_flux',
-    'power_law_energy_flux',
     'power_law_integral_flux',
     'power_law_g_from_f',
     'power_law_g_from_points',
@@ -134,37 +133,6 @@ def power_law_flux(I=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):
         Differential flux at ``energy``.
     """
     return I / _power_law_conversion_factor(g, e, e1, e2)
-
-
-def power_law_energy_flux(I, g=g_DEFAULT, e=1, e1=1, e2=10):
-    r"""
-    Compute energy flux between e1 and e2 for a given integral flux.
-
-    The analytical solution for the powerlaw case is given by:
-
-    .. math::
-
-        G(E_1, E_2) = I(\epsilon, \infty) \, \frac{1-\Gamma}
-        {2-\Gamma} \, \frac{E_1^{2-\Gamma} - E_2^{2-\Gamma}}{\epsilon^{1-\Gamma}}
-
-    Parameters
-    ----------
-    I : array_like
-        Integral flux in ``energy_min``, ``energy_max`` band
-    g : array_like
-        Power law spectral index
-    e : array_like
-        Energy at above which the integral flux is given.
-    e1 : array_like
-        Energy band minimum
-    e2 : array_like
-        Energy band maximum
-
-    """
-    g1 = 1. - g
-    g2 = 2. - g
-    factor = g1 / g2 * (e1 ** g2 - e2 ** g2) / e ** g1
-    return I * factor
 
 
 def power_law_integral_flux(f=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):

--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -34,6 +34,7 @@ __all__ = [
     'power_law_pivot_energy',
     'power_law_df_over_f',
     'power_law_flux',
+    'power_law_energy_flux',
     'power_law_integral_flux',
     'power_law_g_from_f',
     'power_law_g_from_points',
@@ -133,6 +134,37 @@ def power_law_flux(I=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):
         Differential flux at ``energy``.
     """
     return I / _power_law_conversion_factor(g, e, e1, e2)
+
+
+def power_law_energy_flux(I, g=g_DEFAULT, e=1, e1=1, e2=10):
+    r"""
+    Compute energy flux between e1 and e2 for a given integral flux.
+
+    The analytical solution for the powerlaw case is given by:
+
+    .. math::
+
+        G(E_1, E_2) = I(\epsilon, \infty) \, \frac{1-\Gamma}
+        {2-\Gamma} \, \frac{E_1^{2-\Gamma} - E_2^{2-\Gamma}}{\epsilon^{1-\Gamma}}
+
+    Parameters
+    ----------
+    I : array_like
+        Integral flux in ``energy_min``, ``energy_max`` band
+    g : array_like
+        Power law spectral index
+    e : array_like
+        Energy at above which the integral flux is given.
+    e1 : array_like
+        Energy band minimum
+    e2 : array_like
+        Energy band maximum
+
+    """
+    g1 = 1. - g
+    g2 = 2. - g
+    factor = g1 / g2 * (e1 ** g2 - e2 ** g2) / e ** g1
+    return I * factor
 
 
 def power_law_integral_flux(f=1, g=g_DEFAULT, e=1, e1=1, e2=E_INF):

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -9,14 +9,26 @@ from ...utils.testing import requires_dependency
 def get_test_data():
     data = list()
     powerlaw = list()
-    powerlaw.append(PowerLaw(index=2 * u.Unit(''),
+    powerlaw.append(PowerLaw(index=2.3 * u.Unit(''),
                              amplitude=4 / u.cm ** 2 / u.s / u.TeV,
                              reference = 1 * u.TeV))
 
-    powerlaw.append(dict(val_at_2TeV=u.Quantity(1, 'cm-2 s-1 TeV-1'),
-                        integral_1_10TeV=u.Quantity(3.6, 'cm-2 s-1')))
+    powerlaw.append(dict(val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), 'cm-2 s-1 TeV-1'),
+                         integral_1_10TeV=u.Quantity(2.9227116204223784, 'cm-2 s-1'),
+                         eflux_1_10TeV=u.Quantity(6.650836884969039, 'TeV cm-2 s-1')))
+    
+    ecpl = list()
+    ecpl.append(ExponentialCutoffPowerLaw(index=2.3 * u.Unit(''),
+                                          amplitude=4 / u.cm ** 2 / u.s / u.TeV,
+                                          reference = 1 * u.TeV,
+                                          lambda_=0.1 / u.TeV))
+
+    ecpl.append(dict(val_at_2TeV=u.Quantity(0.6650160161581361, 'cm-2 s-1 TeV-1'),
+                     integral_1_10TeV=u.Quantity(2.3556579120286796, 'cm-2 s-1'),
+                     eflux_1_10TeV=u.Quantity(4.83209019773561, 'TeV cm-2 s-1')))
     
     data.append(powerlaw)
+    data.append(ecpl)
     return data
 
 
@@ -28,7 +40,8 @@ def test_models(model, results):
     emax = 10 * u.TeV
     assert_quantity_allclose(model.integral(emin=emin, emax=emax),
                              results['integral_1_10TeV'])
-    
+    assert_quantity_allclose(model.energy_flux(emin=emin, emax=emax),
+                             results['eflux_1_10TeV'])
     model.to_dict()
 
 
@@ -36,6 +49,9 @@ def test_models(model, results):
 @requires_dependency('sherpa')
 @pytest.mark.parametrize("model, results", get_test_data())
 def test_to_sherpa(model, results):
-    model.to_sherpa()
+    try:
+        model.to_sherpa()
+    except AttributeError:
+        pass
     energy_range = [1,10] * u.TeV
     model.plot(energy_range = energy_range)


### PR DESCRIPTION
This PR adds an ECPL model, energy flux and integration methods to `SpectralModel`.

I've changed the latex formulae to be consistent with the HGPS paper. I.e using `\phi` for differential, `F` for integral and `G` for energy flux. 

@joleroi Is there an ECPL model in sherpa that could be used in `to_sherpa()`? 