### PR TITLE
Change ExclusionMask to SkyMask

### DIFF
--- a/docs/background/make_reflected_regions.py
+++ b/docs/background/make_reflected_regions.py
@@ -1,11 +1,11 @@
 """Example how to compute and plot reflected regions."""
 from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
-from gammapy.image import ExclusionMask
+from gammapy.image import SkyMask
 from gammapy.background import find_reflected_regions
 
-mask = ExclusionMask.empty(name='Exclusion Mask', nxpix=801, nypix=701, binsz=0.01,
-                           coordsys='CEL', xref=83.2, yref=22.7)
+mask = SkyMask.empty(name='Exclusion Mask', nxpix=801, nypix=701, binsz=0.01,
+                     coordsys='CEL', xref=83.2, yref=22.7)
 mask.fill_random_circles(n=8, min_rad=30, max_rad=80)
 
 pos = SkyCoord(80.2, 23.5, unit='deg')

--- a/examples/test_curve.py
+++ b/examples/test_curve.py
@@ -4,7 +4,7 @@
 from astropy.coordinates import SkyCoord, Angle
 from gammapy.utils.energy import Energy
 from gammapy.data import DataStore
-from gammapy.image import SkyImage, ExclusionMask
+from gammapy.image import SkyImage, SkyMask
 from gammapy.background import OffDataBackgroundMaker
 from gammapy.scripts import MosaicImage
 import matplotlib.pyplot as plt
@@ -63,7 +63,7 @@ def make_image_from_2d_bg():
                            yref=center.b.deg, proj='TAN', coordsys='GAL')
 
     refheader = image.to_image_hdu().header
-    exclusion_mask = ExclusionMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
+    exclusion_mask = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
     exclusion_mask = exclusion_mask.reproject(reference=refheader)
     mosaic_images = MosaicImage(image, energy_band=energy_band, offset_band=offset_band, data_store=data_store,
                                 obs_table=data_store.obs_table, exclusion_mask=exclusion_mask)

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -21,7 +21,7 @@ def find_reflected_regions(region, center, exclusion_mask, angle_increment=None,
         Region
     center : `~astropy.coordinates.SkyCoord`
         Rotation point
-    exclusion_mask : `~gammapy.image.ExclusionMask`
+    exclusion_mask : `~gammapy.image.SkyMask`
         Exclusion mask
     angle_increment : `~astropy.coordinates.Angle`
         Rotation angle for each step

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -5,7 +5,7 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
 from ..reflected import find_reflected_regions
-from ...image import ExclusionMask
+from ...image import SkyMask
 from ...datasets import gammapy_extra
 from ...utils.testing import requires_data, requires_dependency
 
@@ -15,7 +15,7 @@ def mask():
     """Example mask for testing."""
     testfile = gammapy_extra.filename('datasets/exclusion_masks/tevcat_exclusion.fits')
     hdu = fits.open(testfile)[1]
-    return ExclusionMask.from_image_hdu(hdu)
+    return SkyMask.from_image_hdu(hdu)
 
 
 @requires_dependency('scipy')

--- a/gammapy/data/target.py
+++ b/gammapy/data/target.py
@@ -167,13 +167,13 @@ class Target(object):
             Analysis dir
         """
         from . import DataStore
-        from ..image import ExclusionMask
+        from ..image import SkyMask
         from ..spectrum import SpectrumExtraction
 
         conf = self.config
         data_store = DataStore.from_all(conf['datastore'])
         self.add_obs_from_store(data_store)
-        exclusion = ExclusionMask.read(conf['exclusion_mask']) or None
+        exclusion = SkyMask.read(conf['exclusion_mask']) or None
         conf.update(exclusion=exclusion)
         self.estimate_background(method=conf['background_method'], **conf)
         # Use default energy binning

--- a/gammapy/data/tests/test_observation_stats.py
+++ b/gammapy/data/tests/test_observation_stats.py
@@ -8,7 +8,7 @@ from regions import CircleSkyRegion
 from ...data import DataStore, ObservationList, ObservationStats, Target
 from ...utils.testing import requires_data, requires_dependency
 from ...background import reflected_regions_background_estimate as refl
-from ...image import ExclusionMask
+from ...image import SkyMask
 
 
 @requires_data('gammapy-extra')
@@ -43,7 +43,7 @@ def target():
 @requires_data('gammapy-extra')
 @pytest.fixture
 def get_mask():
-    mask = ExclusionMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
+    mask = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
     return mask
 
 

--- a/gammapy/data/tests/test_observation_summary.py
+++ b/gammapy/data/tests/test_observation_summary.py
@@ -10,7 +10,7 @@ from ...data import ObservationStats, ObservationStatsList, ObservationList
 from ...data import Target
 from ...utils.testing import requires_data, requires_dependency
 from ...background import reflected_regions_background_estimate as refl
-from ...image import ExclusionMask
+from ...image import SkyMask
 
 
 def table_summary():
@@ -53,7 +53,7 @@ def obs_summary():
     target = Target(position=pos, on_region=on_region,
                     name='Crab Nebula', tag='crab')
 
-    mask = ExclusionMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
+    mask = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
 
     obs_list = ObservationList([datastore.obs(_) for _ in run_list])
     obs_stats = ObservationStatsList()

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -4,7 +4,7 @@ import logging
 from subprocess import call
 from tempfile import NamedTemporaryFile
 from copy import deepcopy
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 import numpy as np
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
@@ -13,6 +13,7 @@ from astropy.wcs import WCS, WcsError
 from astropy.wcs.utils import pixel_to_skycoord, skycoord_to_pixel
 from astropy.units import Quantity, Unit
 from astropy.nddata.utils import Cutout2D
+from regions import PixCoord
 from ..extern.bunch import Bunch
 from ..utils.scripts import make_path
 from ..image.utils import make_header, _bin_events_in_cube
@@ -25,16 +26,6 @@ log = logging.getLogger(__name__)
 _DEFAULT_WCS_ORIGIN = 0
 _DEFAULT_WCS_MODE = 'all'
 
-# It might be a good option to inherit from `~astropy.nddata.NDData` later, but
-# as astropy.nddata is still in development, I decided to not inherit for now.
-
-# The class provides Fits I/O and generic methods, that are not specific to the
-# data it contains. Special data classes, such as an ExclusionMap, FluxMap or
-# CountsMap should inherit from this class and implement special, data related
-# methods themselves.
-
-# Actually this class is generic enough to be rather in astropy and not in
-# gammapy and should maybe be moved to there...
 
 class SkyImage(object):
     """
@@ -53,14 +44,40 @@ class SkyImage(object):
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
     """
+    AxisIndex = namedtuple('AxisIndex', ['x', 'y'])
+    ax_idx = AxisIndex(x=1, y=0)
 
     def __init__(self, name=None, data=None, wcs=None, unit=None, meta=None):
         # TODO: validate inputs
         self.name = name
         self.data = data
         self.wcs = wcs
-        self.meta = meta
+
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
+
         self.unit = unit
+
+    @property
+    def center_pix(self):
+        """Center pixel coordinate of the image (`~regions.PixCoord`)."""
+        x = 0.5 * (self.data.shape[self.ax_idx.x] - 1)
+        y = 0.5 * (self.data.shape[self.ax_idx.y] - 1)
+        return PixCoord(x=x, y=y)
+
+    @property
+    def center_sky(self):
+        """Center sky coordinate of the image (`~astropy.coordinates.SkyCoord`)."""
+        center = self.center_pix
+        return SkyCoord.from_pixel(
+            xp=center.x,
+            yp=center.y,
+            wcs=self.wcs,
+            origin=_DEFAULT_WCS_ORIGIN,
+            mode=_DEFAULT_WCS_MODE,
+        )
 
     @classmethod
     def read(cls, filename, **kwargs):
@@ -199,7 +216,9 @@ class SkyImage(object):
             wcs = WCS(image.header)
         else:
             raise TypeError("Can't create image from type {}".format(type(image)))
+
         data = fill * np.ones_like(image.data)
+
         return cls(name, data, wcs, unit, meta=wcs.to_header())
 
     def fill(self, value):
@@ -221,7 +240,6 @@ class SkyImage(object):
             self.data.fill(value)
         else:
             raise TypeError("Can't fill value of type {}".format(type(value)))
-
 
     def write(self, filename, *args, **kwargs):
         """
@@ -261,6 +279,7 @@ class SkyImage(object):
             y, x = y - 0.5, x - 0.5
         else:
             raise ValueError('Invalid mode to compute coordinates.')
+
         return x, y
 
     def coordinates(self, mode='center'):
@@ -321,6 +340,7 @@ class SkyImage(object):
             if not np.allclose(bounds_ref, np.rint(bounds_ref)):
                 raise WcsError('World coordinate systems not aligned. Try to call'
                                ' .reproject() on one of the maps first.')
+
         return xlo, xhi, ylo, yhi
 
     def paste(self, image, method='sum', wcs_check=True):
@@ -350,7 +370,6 @@ class SkyImage(object):
             self.data[ylo:yhi, xlo:xhi] = image.data[ylo_c:yhi_c, xlo_c:xhi_c]
         else:
             raise ValueError('Invalid method: {}'.format(method))
-
 
     def cutout(self, position, size):
         """
@@ -492,15 +511,6 @@ class SkyImage(object):
         omega = Quantity(dx * dy, 'sr')
         return omega
 
-    def center(self):
-        """
-        Center sky coordinates of the image.
-        """
-        return SkyCoord.from_pixel((self.data.shape[0] - 1) / 2.,
-                                   (self.data.shape[1] - 1) / 2.,
-                                   wcs=self.wcs, origin=_DEFAULT_WCS_ORIGIN,
-                                   mode=_DEFAULT_WCS_MODE)
-
     def lookup(self, position, interpolation=None):
         """
         Lookup value at given sky position.
@@ -616,10 +626,10 @@ class SkyImage(object):
 
         if mode == 'interp':
             out = reproject_interp((self.data, self.wcs), wcs_reference,
-                                    shape_out=shape_out, *args, **kwargs)
+                                   shape_out=shape_out, *args, **kwargs)
         elif mode == 'exact':
             out = reproject_exact((self.data, self.wcs), wcs_reference,
-                                   shape_out=shape_out, *args, **kwargs)
+                                  shape_out=shape_out, *args, **kwargs)
         else:
             raise TypeError("Invalid reprojection mode, either choose 'interp' or 'exact'")
 
@@ -670,7 +680,7 @@ class SkyImage(object):
 
         if fig is None and ax is None:
             fig = plt.gcf()
-            ax = fig.add_subplot(1,1,1, projection=self.wcs)
+            ax = fig.add_subplot(1, 1, 1, projection=self.wcs)
 
         kwargs['origin'] = kwargs.get('origin', 'lower')
         caxes = ax.imshow(self.data, **kwargs)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -719,7 +719,7 @@ class SkyImage(object):
 
     def threshold(self, threshold):
         """
-        Threshold sykmap data to create a `~gammapy.image.ExclusionMask`.
+        Threshold sykmap data to create a `~gammapy.image.SkyMask`.
 
         Parameters
         ----------
@@ -728,13 +728,13 @@ class SkyImage(object):
 
         Returns
         -------
-        mask : `~gammapy.image.ExclusionMask`
+        mask : `~gammapy.image.SkyMask`
             Exclusion mask object.
 
         TODO: some more docs and example
         """
-        from .mask import ExclusionMask
-        mask = ExclusionMask.empty_like(self)
+        from .mask import SkyMask
+        mask = SkyMask.empty_like(self)
         mask.data = np.where(self.data > threshold, 0, 1)
         return mask
 

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -12,13 +12,13 @@ from .core import SkyImage
 
 
 __all__ = [
-    'ExclusionMask',
+    'SkyMask',
     'make_tevcat_exclusion_mask'
 ]
 
 
-class ExclusionMask(SkyImage):
-    """Exclusion mask
+class SkyMask(SkyImage):
+    """Sky image mask.
 
     """
 
@@ -90,7 +90,7 @@ class ExclusionMask(SkyImage):
         kwargs.setdefault('cmap', colors.ListedColormap(['black', 'lightgrey']))
         kwargs.setdefault('origin', 'lower')
 
-        super(ExclusionMask, self).plot(ax, fig, **kwargs)
+        super(SkyMask, self).plot(ax, fig, **kwargs)
 
     @lazyproperty
     def distance_image(self):
@@ -122,9 +122,9 @@ class ExclusionMask(SkyImage):
 
         Examples
         --------
-        >>> from gammapy.image import ExclusionMask
+        >>> from gammapy.image import SkyMask
         >>> data = np.array([[0., 0., 1.], [1., 1., 1.]])
-        >>> mask = ExclusionMask(data=data)
+        >>> mask = SkyMask(data=data)
         >>> print(mask.distance_image.data)
         [[-1, -1, 1], [1, 1, 1.41421356]]
         """
@@ -155,7 +155,7 @@ class ExclusionMask(SkyImage):
     def read(cls, fobj, *args, **kwargs):
         # Check if extension name is given, else default to 'exclusion'
         kwargs['extname'] = kwargs.get('extname', 'exclusion')
-        return super(ExclusionMask, cls).read(fobj, *args, **kwargs)
+        return super(SkyMask, cls).read(fobj, *args, **kwargs)
 
     def contains(self, position):
         """
@@ -180,16 +180,16 @@ def make_tevcat_exclusion_mask():
 
     Returns
     -------
-    mask : `~gammapy.image.ExclusionMask`
+    mask : `~gammapy.image.SkyMask`
         Exclusion mask
     """
 
-    # TODO: make this a method ExclusionMask.from_catalog()?
+    # TODO: make this a method SkyMask.from_catalog()?
     from gammapy.catalog import load_catalog_tevcat
 
     tevcat = load_catalog_tevcat()
-    all_sky_exclusion = ExclusionMask.empty(nxpix=3600, nypix=1800, binsz=0.1,
-                                            fill=1, dtype='int')
+    all_sky_exclusion = SkyMask.empty(nxpix=3600, nypix=1800, binsz=0.1,
+                                      fill=1, dtype='int')
     val_lon, val_lat = all_sky_exclusion.coordinates()
     lons = Longitude(val_lon, 'deg')
     lats = Latitude(val_lat, 'deg')

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -1,15 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import numpy as np
-from astropy.wcs import WCS
 from astropy.coordinates import Latitude, Longitude, Angle
 from astropy.utils import lazyproperty
-
 from ..image import lon_lat_circle_mask
-
 from .core import SkyImage
-
 
 __all__ = [
     'SkyMask',
@@ -20,6 +15,14 @@ __all__ = [
 class SkyMask(SkyImage):
     """Sky image mask.
 
+    `SkyMask` is a `~gammapy.image.SkyMap` sub-class, i.e. it inherits
+    all of it's features. The distinction is that `SkyMask` is to
+    represent boolean masks and has methods that only make sense for
+    mask data. The data array can be integer or float, but if it is,
+    it should only contain pixel values of 0 or 1.
+
+    TODO: explain about semantics and give examples what 0 and 1 mean
+    in different applications (or link to other docs).
     """
 
     def fill_random_circles(self, n=4, min_rad=0, max_rad=40):
@@ -37,8 +40,8 @@ class SkyMask(SkyImage):
             Maximum circle radius in pixels
         """
         # TODO: is it worth to change this to take the radius in deg?
-        mask = np.ones(self.data.shape, dtype=int)
-        nx, ny = mask.shape
+        data = np.ones(self.data.shape, dtype=int)
+        nx, ny = data.shape
         xx = np.random.choice(np.arange(nx), n)
         yy = np.random.choice(np.arange(ny), n)
         rr = min_rad + np.random.rand(n) * (max_rad - min_rad)
@@ -46,31 +49,9 @@ class SkyMask(SkyImage):
         for x, y, r in zip(xx, yy, rr):
             xd, yd = np.ogrid[-x:nx - x, -y:ny - y]
             val = xd * xd + yd * yd <= r * r
-            mask[val] = 0
-        self.data = mask
+            data[val] = 0
 
-    @classmethod
-    def from_ds9(cls, excl_file, hdu):
-        """Create exclusion mask from ds9 regions file
-
-        Uses the pyregion package
-        (http://pyregion.readthedocs.io/en/latest/index.html)
-
-        TODO: change to use the https://github.com/astropy/regions package.
-
-        Parameters
-        ----------
-        excl_file : str
-            ds9 region file
-        hdu : `~astropy.fits.ImageHDU`
-            Map to fill exclusion mask
-        """
-        import pyregion
-        r = pyregion.open(excl_file)
-        val = r.get_mask(hdu=hdu)
-        mask = np.invert(val)
-        wcs = WCS(hdu.header)
-        return cls(data=mask, wcs=wcs)
+        self.data = data
 
     def plot(self, ax=None, fig=None, **kwargs):
         """Plot exclusion mask
@@ -128,25 +109,24 @@ class SkyMask(SkyImage):
         >>> print(mask.distance_image.data)
         [[-1, -1, 1], [1, 1, 1.41421356]]
         """
-        MAX_VALUE = 1e10
-        if np.all(self.mask == 1):
-            return SkyImage.empty_like(self, fill=MAX_VALUE)
-        if np.all(self.mask == 0):
-            return SkyImage.empty_like(self, fill=-MAX_VALUE)
-
         from scipy.ndimage import distance_transform_edt
-        distance_outside = distance_transform_edt(self.mask)
-        invert_mask = np.invert(np.array(self.mask, dtype=np.bool))
-        distance_inside = distance_transform_edt(invert_mask)
-        distance = np.where(self.mask, distance_outside, -distance_inside)
-        image = SkyImage(data=distance)
-        return image
 
-    # Set alias for mask
-    # TODO: Add mask attribute to image class or rename self.mask to self.data
-    @property
-    def mask(self):
-        return self.data
+        max_value = 1e10
+
+        if np.all(self.data == 1):
+            return SkyImage.empty_like(self, fill=max_value)
+
+        if np.all(self.data == 0):
+            return SkyImage.empty_like(self, fill=-max_value)
+
+        distance_outside = distance_transform_edt(self.data)
+
+        invert_mask = np.invert(np.array(self.data, dtype=np.bool))
+        distance_inside = distance_transform_edt(invert_mask)
+
+        distance = np.where(self.data, distance_outside, -distance_inside)
+
+        return SkyImage(data=distance)
 
     # TODO: right now the extension name is hardcoded to 'exclusion', because
     # single image Fits file often contain a PrimaryHDU and an ImageHDU.
@@ -156,23 +136,6 @@ class SkyMask(SkyImage):
         # Check if extension name is given, else default to 'exclusion'
         kwargs['extname'] = kwargs.get('extname', 'exclusion')
         return super(SkyMask, cls).read(fobj, *args, **kwargs)
-
-    def contains(self, position):
-        """
-        Check if given position on the sky is inside the exclusion region.
-
-        Parameters
-        ----------
-        position : `~astropy.coordinates.SkyCoord`
-            Position on the sky. 
-
-        Returns
-        -------
-        containment : array
-            Bool array
-        """
-        x, y = self.wcs_skycoord_to_pixel(coords=position)
-        return self.data[y, x]
 
 
 def make_tevcat_exclusion_mask():

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -184,14 +184,9 @@ class TestSkyMapPoisson:
         empty = SkyImage.empty()
         assert empty.data.shape == (200, 200)
 
-    def test_center(self):
-        center = self.image.center()
-        assert center.galactic.l == 0
-        assert center.galactic.b == 0
-
     def test_fill_float(self):
         image = SkyImage.empty(nxpix=200, nypix=200, xref=0, yref=0, dtype='int',
-                                coordsys='CEL')
+                               coordsys='CEL')
         image.fill(42)
         assert_equal(image.data, np.full((200, 200), 42))
 
@@ -213,7 +208,7 @@ class TestSkyMapPoisson:
     def test_reproject(self):
         image_1 = SkyImage.empty(nxpix=200, nypix=200, xref=0, yref=0, coordsys='CEL')
         image_2 = SkyImage.empty(nxpix=100, nypix=100, xref=0, yref=0, binsz=0.04,
-                                  coordsys='CEL')
+                                 coordsys='CEL')
         image_1.fill(1)
         image_1_repr = image_1.reproject(image_2)
         assert_allclose(image_1_repr.data, np.full((100, 100), 1))
@@ -267,25 +262,24 @@ class TestSkyMapPoisson:
             image.paste(cutout)
 
 
-class TestSkyMapCrab:
-    """
-    Test image class.
-    """
-
-    def crab_coord(self):
-        coord = SkyCoord(83.63, 22.01, unit='deg').galactic
-        return coord
-
+class TestSkyImage:
     def setup(self):
-        center = self.crab_coord()
-        self.image = SkyImage.empty(nxpix=250, nypix=250, binsz=0.02, xref=center.l.deg,
-                                     yref=center.b.deg, proj='TAN', coordsys='GAL')
+        self.center = SkyCoord(83.63, 22.01, unit='deg').galactic
+        self.image = SkyImage.empty(
+            nxpix=10, nypix=5, binsz=0.2,
+            xref=self.center.l.deg, yref=self.center.b.deg,
+            proj='TAN', coordsys='GAL',
+        )
 
-    def test_center(self):
-        crab_coord = self.crab_coord()
-        center = self.image.center()
-        assert_allclose(center.galactic.l, crab_coord.l, rtol=1e-2)
-        assert_allclose(center.galactic.b, crab_coord.b, rtol=1e-2)
+    def test_center_pix(self):
+        center = self.image.center_pix
+        assert_allclose(center.x, 4.5)
+        assert_allclose(center.y, 2.0)
+
+    def test_center_sky(self):
+        center = self.image.center_sky
+        assert_allclose(center.l.deg, self.center.l.deg, atol=1e-5)
+        assert_allclose(center.b.deg, self.center.b.deg, atol=1e-5)
 
 
 def test_image_pad():
@@ -301,7 +295,7 @@ def test_skycoord_pixel_conversion():
 
     x, y = [5, 3.4], [8, 11.2]
     coords = image.wcs_pixel_to_skycoord(xp=x, yp=y)
-    assert_allclose(coords.data.lon.deg, [3.5999e+02,   2.2e-02])
+    assert_allclose(coords.data.lon.deg, [3.5999e+02, 2.2e-02])
     assert_allclose(coords.data.lat.deg, [0.02, 0.084])
 
     x_new, y_new = image.wcs_skycoord_to_pixel(coords=coords)

--- a/gammapy/image/tests/test_mask.py
+++ b/gammapy/image/tests/test_mask.py
@@ -10,9 +10,9 @@ from ...utils.testing import requires_dependency
 def test_random_creation():
     exclusion = SkyMask.empty(nxpix=300, nypix=100)
     exclusion.fill_random_circles(n=6, max_rad=10)
-    assert exclusion.mask.shape[0] == 100
+    assert exclusion.data.shape[0] == 100
 
-    excluded = np.where(exclusion.mask == 0)
+    excluded = np.where(exclusion.data == 0)
     assert excluded[0].size != 0
 
 

--- a/gammapy/image/tests/test_mask.py
+++ b/gammapy/image/tests/test_mask.py
@@ -2,13 +2,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
-from .. import ExclusionMask
+from .. import SkyMask
 from ...utils.testing import requires_dependency
 
 
 @requires_dependency('scipy')
 def test_random_creation():
-    exclusion = ExclusionMask.empty(nxpix=300, nypix=100)
+    exclusion = SkyMask.empty(nxpix=300, nypix=100)
     exclusion.fill_random_circles(n=6, max_rad=10)
     assert exclusion.mask.shape[0] == 100
 
@@ -18,16 +18,16 @@ def test_random_creation():
 
 @requires_dependency('scipy')
 def test_distance_image():
-    mask = ExclusionMask.empty(nxpix=3, nypix=2)
+    mask = SkyMask.empty(nxpix=3, nypix=2)
     distance = mask.distance_image.data
     assert_allclose(distance, -1e10)
 
-    mask = ExclusionMask.empty(nxpix=3, nypix=2, fill=1.)
+    mask = SkyMask.empty(nxpix=3, nypix=2, fill=1.)
     distance = mask.distance_image.data
     assert_allclose(distance, 1e10)
 
     data = np.array([[0., 0., 1.], [1., 1., 1.]])
-    mask = ExclusionMask(data=data)
+    mask = SkyMask(data=data)
     distance = mask.distance_image.data
     expected = [[-1, -1, 1], [1, 1, 1.41421356]]
     assert_allclose(distance, expected)

--- a/gammapy/scripts/image_coordinates.py
+++ b/gammapy/scripts/image_coordinates.py
@@ -39,7 +39,7 @@ def image_coordinates(infile,
     """
     from astropy.io import fits
     from gammapy.utils.fits import get_hdu
-    from gammapy.image import SkyImage, ExclusionMask
+    from gammapy.image import SkyImage, SkyMask
 
     log.info('Reading {0}'.format(infile))
     hdu = get_hdu(infile)
@@ -54,7 +54,7 @@ def image_coordinates(infile,
         out_hdus.append(fits.ImageHDU(lat, hdu.header, 'LAT'))
 
     if make_distance_map:
-        excl = ExclusionMask.from_image_hdu(hdu)
+        excl = SkyMask.from_image_hdu(hdu)
         log.info('Computing DIST map')
         dist = excl.exclusion_distance
         out_hdus.append(fits.ImageHDU(dist, hdu.header, 'DIST'))

--- a/gammapy/scripts/image_pipe.py
+++ b/gammapy/scripts/image_pipe.py
@@ -39,7 +39,7 @@ class ObsImage(object):
         Energy band for which we want to compute the image
     offset_band : `astropy.coordinates.Angle`
         Offset Band where you compute the image
-    exclusion_mask : `~gammapy.image.ExclusionMask`
+    exclusion_mask : `~gammapy.image.SkyMask`
             Exclusion regions
     ncounts_min : int
             Minimum counts required for the observation
@@ -251,7 +251,7 @@ class MosaicImage(object):
         `DataStore` where are situated the events
     obs_table : `~astropy.table.Table`
             Required columns: OBS_ID
-    exclusion_mask : `~gammapy.image.ExclusionMask`
+    exclusion_mask : `~gammapy.image.SkyMask`
             Exclusion regions
     ncounts_min : int
             Minimum counts required for the observation

--- a/gammapy/scripts/tests/test_image_pipe.py
+++ b/gammapy/scripts/tests/test_image_pipe.py
@@ -4,7 +4,7 @@ from astropy.coordinates import SkyCoord, Angle
 from numpy.testing import assert_allclose
 from gammapy.utils.energy import Energy
 from gammapy.data import DataStore
-from gammapy.image import SkyImage, ExclusionMask
+from gammapy.image import SkyImage, SkyMask
 from gammapy.background import OffDataBackgroundMaker
 from gammapy.scripts import MosaicImage
 from ...utils.testing import requires_data, requires_dependency
@@ -57,7 +57,7 @@ def test_image_pipe(tmpdir):
                            yref=center.b.deg, proj='TAN', coordsys='GAL')
 
     refheader = image.to_image_hdu().header
-    exclusion_mask = ExclusionMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
+    exclusion_mask = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
     exclusion_mask = exclusion_mask.reproject(reference=refheader)
     # Pb with the load psftable for one of the run that is not implemented yet...
     data_store.hdu_table.remove_row(14)

--- a/gammapy/scripts/tests/test_spectrum.py
+++ b/gammapy/scripts/tests/test_spectrum.py
@@ -5,7 +5,7 @@ from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
 from ...datasets import gammapy_extra
 from ...data import ObservationList
-from ...image import ExclusionMask
+from ...image import SkyMask
 from ...utils.testing import data_manager, requires_dependency, requires_data, run_cli
 from ...spectrum.results import SpectrumFitResult
 from ...spectrum import SpectrumExtraction
@@ -59,7 +59,7 @@ def test_spectrum(tmpdir, data_manager):
     radius = Angle('0.3 deg')
     on_region = CircleSkyRegion(center, radius)
 
-    exclusion = ExclusionMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
+    exclusion = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
     bkg_method = dict(method='reflected', exclusion=exclusion)
 
     extraction = SpectrumExtraction(target=on_region, obs=obs, background=bkg_method)

--- a/gammapy/spectrum/tests/test_spectrum_extraction.py
+++ b/gammapy/spectrum/tests/test_spectrum_extraction.py
@@ -10,7 +10,7 @@ from ...utils.scripts import make_path
 from ...utils.testing import requires_dependency, requires_data
 from ...data import DataStore, Target, ObservationList
 from ...datasets import gammapy_extra
-from ...image import ExclusionMask
+from ...image import SkyMask
 from ...spectrum import SpectrumExtraction, SpectrumObservation
 import numpy as np
 
@@ -40,7 +40,7 @@ def test_spectrum_extraction(pars, results, tmpdir):
 
     exclusion_file = gammapy_extra.filename(
         "datasets/exclusion_masks/tevcat_exclusion.fits")
-    excl = ExclusionMask.read(exclusion_file)
+    excl = SkyMask.read(exclusion_file)
 
     bk = dict(method='reflected', n_min=2, exclusion=excl)
 


### PR DESCRIPTION
This PR:
- [x] Changes `ExclusionMask` to `SkyMask`
- [x] Removes the `mask` property and the `contains` method
- [x] Add a little info in the the `SkyMask` docstring
- [x] Fix `SkyImage.center` (x,y axis order was interchanged before). Make it a property called `center_sky` and update tests
- [x] Add property `SkyImage.center_pix`

The changes to the mask are the result of the discussion in #650 and offline discussion with @adonath and @joleroi.
