### PR TITLE
Add up- and downsampling to SkyImage

### DIFF
--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -19,7 +19,7 @@ from ..irf import multi_gauss_psf_kernel
 from ..morphology import Shell2D
 from ..extern.bunch import Bunch
 from ..image import (measure_containment_radius, SkyImageCollection)
-from ..image.utils import _shape_2N
+from ..utils.array import shape_2N, symmetric_crop_pad_width
 
 __all__ = [
     'compute_ts_map',
@@ -142,7 +142,8 @@ def compute_ts_map_multiscale(skyimages, psf_parameters, scales=[0], downsample=
         skyimages_ = SkyImageCollection()
         for name, func in zip(skyimages._map_names, funcs):
             if downsampled:
-                skyimages_[name] = skyimages[name].pad(shape=_shape_2N(shape))
+                pad_width = symmetric_crop_pad_width(shape, shape_2N(shape))
+                skyimages_[name] = skyimages[name].pad(pad_width)
                 skyimages_[name] = skyimages_[name].downsample(factor, func)
             else:
                 skyimages_[name] = skyimages[name]
@@ -180,7 +181,7 @@ def compute_ts_map_multiscale(skyimages, psf_parameters, scales=[0], downsample=
         if downsampled:
             for name, order in zip(['ts', 'sqrt_ts', 'amplitude', 'niter'], [1, 1, 1, 0]):
                 ts_results[name] = ts_results[name].upsample(factor, order=order)
-                ts_results[name] = ts_results[name].crop(shape=shape)
+                ts_results[name] = ts_results[name].crop(crop_width=pad_width)
 
         multiscale_result.append(ts_results)
 

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -10,7 +10,7 @@ from astropy.io import fits
 from ...utils.testing import requires_dependency, requires_data
 from ...detect import compute_ts_map, compute_lima_map, compute_lima_on_off_map
 from ...datasets import load_poisson_stats_image, gammapy_extra
-from ...image import SkyImageCollection
+from ...image import SkyImageCollection, SkyImage
 
 from ...extern.pathlib import Path
 
@@ -21,7 +21,11 @@ def test_compute_lima_map():
     """
     Test Li&Ma map against TS map for Tophat kernel
     """
-    data = load_poisson_stats_image(extra_info=True)
+    filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
+    data = SkyImageCollection()
+    data.counts = SkyImage.read(filenames['counts'])
+    data.background = SkyImage.read(filenames['background'])
+    data.exposure = SkyImage.read(filenames['exposure'])
 
     kernel = Tophat2DKernel(5)
     result_lima = compute_lima_map(data['counts'], data['background'], kernel,

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -6,24 +6,28 @@ from astropy.convolution import Gaussian2DKernel
 from ...utils.testing import requires_dependency, requires_data
 from ...detect import compute_ts_map
 from ...datasets import load_poisson_stats_image
-from ...image.utils import upsample_2N, downsample_2N
+from ...image import SkyImage, SkyImageCollection
 
 @requires_dependency('scipy')
 @requires_dependency('skimage')
 @requires_data('gammapy-extra')
 def test_compute_ts_map(tmpdir):
     """Minimal test of compute_ts_map"""
-    data = load_poisson_stats_image(extra_info=True)
-    kernel = Gaussian2DKernel(2.5)
-    data['exposure'] = np.ones(data['counts'].shape) * 1E12
-    for _, func in zip(['counts', 'background', 'exposure'], [np.nansum, np.nansum, np.mean]):
-        data[_] = downsample_2N(data[_], 2, func)
+    filenames = load_poisson_stats_image(extra_info=True, return_filenames=True)
+    data = SkyImageCollection()
+    data.counts = SkyImage.read(filenames['counts'])
+    data.background = SkyImage.read(filenames['background'])
+    data.exposure = SkyImage.read(filenames['exposure'])
 
-    result = compute_ts_map(data['counts'], data['background'], data['exposure'],
-                            kernel, method='leastsq iter')
+    kernel = Gaussian2DKernel(2.5)
+    for _, func in zip(['counts', 'background', 'exposure'], [np.nansum, np.nansum, np.mean]):
+        data[_] = data[_].downsample(2, func)
+
+    result = compute_ts_map(data.counts, data.background, data.exposure, kernel,
+                            method='leastsq iter')
     for name, order in zip(['ts', 'amplitude', 'niter'], [2, 5, 0]):
-        result[name] = np.nan_to_num(result[name])
-        result[name] = upsample_2N(result[name], 2, order=order)
+        result[name].data = np.nan_to_num(result[name].data)
+        result[name] = result[name].upsample(2, order=order)
 
     assert_allclose(1705.840212274973, result.ts.data[99, 99], rtol=1e-3)
     assert_allclose([[99], [99]], np.where(result.ts.data == result.ts.data.max()))

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -547,7 +547,7 @@ class SkyImage(object):
 
         return SkyImage(data=data, wcs=wcs)
 
-    def upsample(self, factor, order=3, crop=False):
+    def upsample(self, factor, order=3):
         """
         Up sample image by a given factor.
 
@@ -559,8 +559,6 @@ class SkyImage(object):
             up sampling factor, must be power of two.
         order : int
             Order of the interpolation usef for upsampling.
-        crop : bool
-            Crop image after upsampling to ''
 
         Returns
         -------

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -463,8 +463,7 @@ class SkyImage(object):
             width = shape_divisible_by - (np.array(self.data.shape) % shape_divisible_by)
             width = [(0, width[0]), (0, width[1])]
 
-
-        if shape is not None:
+        if where == 'symmetric':
             x_pad = (shape[1] - image.shape[1]) // 2
             y_pad = (shape[0] - image.shape[0]) // 2
             #converting from unicode to ascii string as a workaround
@@ -498,15 +497,17 @@ class SkyImage(object):
         """
         xdiff = (self.data.shape[1] - shape[1])
         ydiff = (self.data.shape[0] - shape[0])
-        if mode == 'symmetric':
+        if where == 'symmetric':
             x_crop = xdiff // 2
             y_crop = ydiff // 2
             data = self.data[y_crop:-y_crop, x_crop:-x_crop]
 
-            # adjust WCS
-            wcs = None
-        elif mode == 'top & right':
+            # adjust WCS, so that image center remains unchanged
+            wcs = _get_resampled_wcs(self, data, factor, downsampled=False)
+        elif where == 'top & right':
             data = self.data[:-ydiff, :-xdiff]
+
+            # WCS reamins unchanged
             wcs = self.wcs
 
         return SkyImage(data=data, wcs=wcs)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -531,7 +531,7 @@ class SkyImage(object):
         factor = int(factor)
         if not (np.mod(shape, factor) == 0).all():
             raise ValueError('Data shape {0} is not divisable by {1} in all axes.'
-                             'Pad image prior to downsamling to a correct'
+                             'Pad image prior to downsamling to correct'
                              ' shape.'.format(shape, factor))
 
         data = block_reduce(self.data, (factor, factor), method)
@@ -1046,8 +1046,3 @@ def _get_resampled_wcs(skyimage, factor, downsampled):
     wcs.wcs.cdelt *= factor
     wcs.wcs.crpix = (wcs.wcs.crpix - 0.5) / factor + 0.5
     return wcs
-
-def _get_resized_wcs(skyimage, shape):
-    """
-    Get resized WCS object.
-    """

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -18,6 +18,7 @@ from astropy.wcs.utils import (pixel_to_skycoord, skycoord_to_pixel,
                                proj_plane_pixel_scales)
 from ..extern.bunch import Bunch
 from ..utils.scripts import make_path
+from ..utils.wcs import get_resampled_wcs
 from ..image.utils import make_header, _bin_events_in_cube
 from ..data import EventList
 
@@ -520,7 +521,7 @@ class SkyImage(object):
         data = block_reduce(self.data, (factor, factor), method)
 
         # Adjust WCS
-        wcs = _get_resampled_wcs(self.wcs, factor, downsampled=True)
+        wcs = get_resampled_wcs(self.wcs, factor, downsampled=True)
         return SkyImage(data=data, wcs=wcs)
 
     def upsample(self, factor, **kwargs):
@@ -546,7 +547,7 @@ class SkyImage(object):
         data = zoom(self.data, factor, **kwargs)
 
         # Adjust WCS
-        wcs = _get_resampled_wcs(self.wcs, factor, downsampled=False)
+        wcs = get_resampled_wcs(self.wcs, factor, downsampled=False)
         return SkyImage(data=data, wcs=wcs)
 
     def lookup_max(self, region=None):
@@ -1014,17 +1015,3 @@ class SkyImageCollection(Bunch):
             info += self[name].__str__()
             info += '\n'
         return info
-
-
-def _get_resampled_wcs(wcs, factor, downsampled):
-    """
-    Get resampled WCS object.
-    """
-    wcs = wcs.deepcopy()
-
-    if not downsampled:
-        factor = 1. / factor
-
-    wcs.wcs.cdelt *= factor
-    wcs.wcs.crpix = (wcs.wcs.crpix - 0.5) / factor + 0.5
-    return wcs

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -285,7 +285,7 @@ class TestSkyMapPoisson:
         separation = image.center().separation(image_upsampled.center())
 
         # check WCS
-        assert_quantity_allclose(separation, Quantity(0, 'deg'))
+        assert_quantity_allclose(separation, Quantity(0, 'deg'), atol=Quantity(1E-17, 'deg'))
 
         # check data shape
         assert image_upsampled.data.shape == (shape[0] * factor, shape[1] * factor)

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -261,6 +261,7 @@ class TestSkyMapPoisson:
         with pytest.raises(WcsError):
             image.paste(cutout)
 
+    @requires_dependency('skimage')
     @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((4, 6), 2, 'CAR'),
                                                            ((9, 12), 3, 'CAR')])
     def test_downsample(self, shape, factor, proj):
@@ -276,6 +277,7 @@ class TestSkyMapPoisson:
         assert image_downsampled.data.shape == (shape[0] // factor, shape[1] // factor)
 
 
+    @requires_dependency('scipy')
     @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((2, 3), 2, 'TAN'),
                                                            ((3, 4), 3, 'TAN')])
     def test_upsample(self, shape, factor, proj):
@@ -290,7 +292,8 @@ class TestSkyMapPoisson:
         # check data shape
         assert image_upsampled.data.shape == (shape[0] * factor, shape[1] * factor)
 
-
+    @requires_dependency('scipy')
+    @requires_dependency('skimage')
     @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((4, 4), 2, 'AIT'),
                                                            ((9, 9), 3, 'AIT')])
     def test_down_and_upsample(self, shape, factor, proj):

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -261,11 +261,11 @@ class TestSkyMapPoisson:
         with pytest.raises(WcsError):
             image.paste(cutout)
 
-    @pytest.mark.parametrize(('shape', 'factor'), [((4, 4), 2),
-                                                   ((9, 9), 3)])
-    def test_downsample(self, shape, factor):
+    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((4, 4), 2, 'CAR'),
+                                                           ((9, 9), 3, 'CAR')])
+    def test_downsample(self, shape, factor, proj):
         nypix, nxpix = shape
-        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
+        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02, proj=proj)
         image_downsampled = image.downsample(factor=factor)
         separation = image.center.separation(image_downsampled.center)
 
@@ -276,11 +276,11 @@ class TestSkyMapPoisson:
         assert image_downsampled.data.shape == (shape[0] // factor, shape[1] // factor)
 
 
-    @pytest.mark.parametrize(('shape', 'factor'), [((2, 2), 2),
-                                                   ((3, 3), 3)])
-    def test_upsample(self, shape, factor):
+    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((2, 2), 2, 'TAN'),
+                                                           ((3, 3), 3, 'TAN')])
+    def test_upsample(self, shape, factor, proj):
         nypix, nxpix = shape
-        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
+        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02, proj=proj)
         image_upsampled = image.upsample(factor=factor)
         separation = image.center.separation(image_upsampled.center)
 
@@ -291,11 +291,11 @@ class TestSkyMapPoisson:
         assert image_upsampled.data.shape == (shape[0] * factor, shape[1] * factor)
 
 
-    @pytest.mark.parametrize(('shape', 'factor'), [((4, 4), 2),
-                                                   ((9, 9), 3)])
-    def test_down_and_upsample(self, shape, factor):
+    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((4, 4), 2, 'AIT'),
+                                                           ((9, 9), 3, 'AIT')])
+    def test_down_and_upsample(self, shape, factor, proj):
         nypix, nxpix = shape
-        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02, fill=1.)
+        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=10, fill=1.)
         image_downsampled = image.downsample(factor=factor, method=np.nanmean)
         image_upsampled = image_downsampled.upsample(factor=factor)
         assert_allclose(image.data, image_upsampled.data)

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -267,7 +267,7 @@ class TestSkyMapPoisson:
         nypix, nxpix = shape
         image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
         image_downsampled = image.downsample(factor=factor)
-        separation = image.center().separation(image_downsampled.center())
+        separation = image.center.separation(image_downsampled.center)
 
         # check WCS
         assert_quantity_allclose(separation, Quantity(0, 'deg'))
@@ -282,7 +282,7 @@ class TestSkyMapPoisson:
         nypix, nxpix = shape
         image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
         image_upsampled = image.upsample(factor=factor)
-        separation = image.center().separation(image_upsampled.center())
+        separation = image.center.separation(image_upsampled.center)
 
         # check WCS
         assert_quantity_allclose(separation, Quantity(0, 'deg'), atol=Quantity(1E-17, 'deg'))
@@ -316,7 +316,7 @@ class TestSkyImage:
         assert_allclose(center.y, 2.0)
 
     def test_center_sky(self):
-        center = self.image.center_sky
+        center = self.image.center
         assert_allclose(center.l.deg, self.center.l.deg, atol=1e-5)
         assert_allclose(center.b.deg, self.center.b.deg, atol=1e-5)
 
@@ -325,7 +325,7 @@ def test_image_pad():
     image = SkyImage.empty(nxpix=10, nypix=13)
     assert image.data.shape == (13, 10)
 
-    image2 = image.pad(shape_divisible_by=4, mode='reflect')
+    image2 = image.pad(pad_to_factor=4, mode='reflect')
     assert image2.data.shape == (16, 12)
 
 

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -261,6 +261,27 @@ class TestSkyMapPoisson:
         with pytest.raises(WcsError):
             image.paste(cutout)
 
+    @pytest.mark.parametrize(('shape', 'factor'), [((4, 4), 2),
+                                                   ((9, 9), 3)])
+    def test_downsample(self, shape, factor):
+        nypix, nxpix = shape
+        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
+        image_downsampled = image.downsample(factor=factor)
+        separation = image.center().separation(image_downsampled.center())
+        assert_quantity_allclose(separation, Quantity(0, 'deg'))
+        assert image_downsampled.data.shape == (shape[0] // factor, shape[1] // factor)
+
+    @pytest.mark.parametrize(('shape', 'factor'), [((2, 2), 2),
+                                                   ((3, 3), 3)])
+    def test_upsample(self, shape, factor):
+        nypix, nxpix = shape
+        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
+        image_upsampled = image.upsample(factor=factor)
+        separation = image.center().separation(image_upsampled.center())
+        assert_quantity_allclose(separation, Quantity(0, 'deg'))
+        assert image_upsampled.data.shape == (shape[0] * factor, shape[1] * factor)
+
+
 
 class TestSkyImage:
     def setup(self):
@@ -286,7 +307,7 @@ def test_image_pad():
     image = SkyImage.empty(nxpix=10, nypix=13)
     assert image.data.shape == (13, 10)
 
-    image2 = image.pad(pad_to_factor=4, mode='reflect')
+    image2 = image.pad(shape_divisible_by=4, mode='reflect')
     assert image2.data.shape == (16, 12)
 
 

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -268,8 +268,13 @@ class TestSkyMapPoisson:
         image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
         image_downsampled = image.downsample(factor=factor)
         separation = image.center().separation(image_downsampled.center())
+
+        # check WCS
         assert_quantity_allclose(separation, Quantity(0, 'deg'))
+
+        # check data shape
         assert image_downsampled.data.shape == (shape[0] // factor, shape[1] // factor)
+
 
     @pytest.mark.parametrize(('shape', 'factor'), [((2, 2), 2),
                                                    ((3, 3), 3)])
@@ -278,9 +283,22 @@ class TestSkyMapPoisson:
         image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02)
         image_upsampled = image.upsample(factor=factor)
         separation = image.center().separation(image_upsampled.center())
+
+        # check WCS
         assert_quantity_allclose(separation, Quantity(0, 'deg'))
+
+        # check data shape
         assert image_upsampled.data.shape == (shape[0] * factor, shape[1] * factor)
 
+
+    @pytest.mark.parametrize(('shape', 'factor'), [((4, 4), 2),
+                                                   ((9, 9), 3)])
+    def test_down_and_upsample(self, shape, factor):
+        nypix, nxpix = shape
+        image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02, fill=1.)
+        image_downsampled = image.downsample(factor=factor, method=np.nanmean)
+        image_upsampled = image_downsampled.upsample(factor=factor)
+        assert_allclose(image.data, image_upsampled.data)
 
 
 class TestSkyImage:

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -300,6 +300,17 @@ class TestSkyMapPoisson:
         image_upsampled = image_downsampled.upsample(factor=factor)
         assert_allclose(image.data, image_upsampled.data)
 
+    def test_crop(self):
+        image = SkyImage.empty(nxpix=9, nypix=9, binsz=0.02, proj='AIT', xref=135,
+                               yref=60)
+        image_cropped = image.crop((5, 5))
+
+        separation = image.center.separation(image_cropped.center)
+        assert_quantity_allclose(separation, Quantity(0, 'deg'), atol=Quantity(1E-17, 'deg'))
+
+        # check data shape
+        assert image_cropped.data.shape == (5, 5)
+
 
 class TestSkyImage:
     def setup(self):

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -261,8 +261,8 @@ class TestSkyMapPoisson:
         with pytest.raises(WcsError):
             image.paste(cutout)
 
-    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((4, 4), 2, 'CAR'),
-                                                           ((9, 9), 3, 'CAR')])
+    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((4, 6), 2, 'CAR'),
+                                                           ((9, 12), 3, 'CAR')])
     def test_downsample(self, shape, factor, proj):
         nypix, nxpix = shape
         image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02, proj=proj)
@@ -276,8 +276,8 @@ class TestSkyMapPoisson:
         assert image_downsampled.data.shape == (shape[0] // factor, shape[1] // factor)
 
 
-    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((2, 2), 2, 'TAN'),
-                                                           ((3, 3), 3, 'TAN')])
+    @pytest.mark.parametrize(('shape', 'factor', 'proj'), [((2, 3), 2, 'TAN'),
+                                                           ((3, 4), 3, 'TAN')])
     def test_upsample(self, shape, factor, proj):
         nypix, nxpix = shape
         image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=0.02, proj=proj)
@@ -303,7 +303,7 @@ class TestSkyMapPoisson:
     def test_crop(self):
         image = SkyImage.empty(nxpix=9, nypix=9, binsz=0.02, proj='AIT', xref=135,
                                yref=60)
-        image_cropped = image.crop((5, 5))
+        image_cropped = image.crop(((2, 2), (2, 2)))
 
         separation = image.center.separation(image_cropped.center)
         assert_quantity_allclose(separation, Quantity(0, 'deg'), atol=Quantity(1E-17, 'deg'))
@@ -336,8 +336,8 @@ def test_image_pad():
     image = SkyImage.empty(nxpix=10, nypix=13)
     assert image.data.shape == (13, 10)
 
-    image2 = image.pad(pad_to_factor=4, mode='reflect')
-    assert image2.data.shape == (16, 12)
+    image2 = image.pad(pad_width=4, mode='reflect')
+    assert image2.data.shape == (21, 18)
 
 
 def test_skycoord_pixel_conversion():

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -6,7 +6,6 @@ from astropy.tests.helper import pytest
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.units import Quantity
-from ..utils import _shape_2N
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import FermiGalacticCenter
 from ...data import DataStore
@@ -117,12 +116,6 @@ def test_ref_pixel():
     footprint_1 = WCS(image_1.header).calc_footprint(center=False)
     # Lower left corner shouldn't change
     assert_allclose(footprint[0], footprint_1[0])
-
-
-def test_shape_2N():
-    shape = (34, 89, 120, 444)
-    expected_shape = (40, 96, 128, 448)
-    assert expected_shape == _shape_2N(shape=shape, N=3)
 
 
 def test_wcs_histogram2d():

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -25,7 +25,6 @@ __all__ = [
     'block_reduce_hdu',
     'dict_to_hdulist',
     'disk_correlate',
-    'downsample_2N',
     'image_groupby',
     'images_to_cube',
     'lon_lat_rectangle_mask',
@@ -34,7 +33,6 @@ __all__ = [
     'process_image_pixels',
     'ring_correlate',
     'threshold',
-    'upsample_2N',
     'wcs_histogram2d',
 ]
 
@@ -163,85 +161,6 @@ def ring_correlate(image, r_in, r_out, mode='constant'):
     from scipy.ndimage import convolve
     structure = binary_ring(r_in, r_out)
     return convolve(image, structure, mode=mode)
-
-
-def downsample_2N(image, factor, method=np.nansum, shape=None):
-    """
-    Down sample image by a power of two.
-
-    The image is down sampled using `skimage.measure.block_reduce`. Only
-    down sampling factor, that are a power of two are allowed. The image is
-    padded to a given size using the 'reflect' method, before the down sampling
-    is done.
-
-    Parameters
-    ----------
-    image : `~numpy.ndarray`
-        Image to be down sampled.
-    factor : int
-        Down sampling factor, must be power of two.
-    method : np.ufunc (np.nansum), optional
-        Method how to combine the image blocks.
-    shape : tuple (None), optional
-        If shape is specified, the image is padded prior to the down sampling
-        symmetrically in x and y direction to the given shape.
-
-    Returns
-    -------
-    image : `~numpy.ndarray`
-        Down sampled image.
-    """
-    from skimage.measure import block_reduce
-    if not np.log2(factor).is_integer():
-        raise ValueError('Downsampling factor must be power of 2.')
-    factor = int(factor)
-
-    if shape is not None:
-        x_pad = (shape[1] - image.shape[1]) // 2
-        y_pad = (shape[0] - image.shape[0]) // 2
-        #converting from unicode to ascii string as a workaround
-        #for https://github.com/numpy/numpy/issues/7112
-        image = np.pad(image, ((y_pad, y_pad), (x_pad, x_pad)), mode=str('reflect'))
-    return block_reduce(image, (factor, factor), method)
-
-
-def upsample_2N(image, factor, order=3, shape=None):
-    """
-    Up sample image by a power of two.
-
-    The image is up sampled using `scipy.ndimage.zoom`. Only
-    up sampling factors, that are a power of two are allowed. The image is
-    cropped to a given size.
-
-    Parameters
-    ----------
-    image : `~numpy.ndarray`
-        Image to be up sampled.
-    factor : int
-        up sampling factor, must be power of two.
-    order : np.ufunc (np.nansum), optional
-        Method how to combine the image blocks.
-    shape : tuple (None), optional
-        If shape is specified, the image is cropped after the up sampling
-        symmetrically in x and y direction to the given shape.
-
-    Returns
-    -------
-    image : `~numpy.ndarray`
-        Down sampled image.
-    """
-    from scipy.ndimage import zoom
-    if not np.log2(factor).is_integer():
-        raise ValueError('Up sampling factor must be power of 2.')
-    factor = int(factor)
-
-    if shape is not None:
-        x_crop = (factor * image.shape[1] - shape[1]) // 2
-        y_crop = (factor * image.shape[0] - shape[0]) // 2
-        # Sample up result and crop to original size
-        return zoom(image, factor, order=order)[y_crop:-y_crop, x_crop:-x_crop]
-    else:
-        return zoom(image, factor, order=order)
 
 
 def _shape_2N(shape, N=3):

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -163,27 +163,6 @@ def ring_correlate(image, r_in, r_out, mode='constant'):
     return convolve(image, structure, mode=mode)
 
 
-def _shape_2N(shape, N=3):
-    """
-    Round a given shape to values that are divisible by 2^N.
-
-    Parameters
-    ----------
-    shape : tuple
-        Input shape.
-    N : int (default = 3), optional
-        Exponent of two.
-
-    Returns
-    -------
-    new_shape : Tuple
-        New shape extended to integers divisible by 2^N
-    """
-    shape = np.array(shape)
-    new_shape = shape + (2 ** N - np.mod(shape, 2 ** N))
-    return tuple(new_shape)
-
-
 def atrous_image(image, n_levels):
     """Compute a trous transform for a given image.
 

--- a/gammapy/utils/array.py
+++ b/gammapy/utils/array.py
@@ -4,7 +4,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
-__all__ = ['array_stats_str']
+__all__ = ['array_stats_str',
+           'shape_2N',
+           'shape_divisible_by',
+           'symmetric_crop_pad_width']
 
 
 def array_stats_str(x, label=''):
@@ -36,3 +39,70 @@ def array_stats_str(x, label=''):
     ss += fmt.format(**locals())
 
     return ss
+
+
+def shape_2N(shape, N=3):
+    """
+    Round a given shape to values that are divisible by 2^N.
+
+    Parameters
+    ----------
+    shape : tuple
+        Input shape.
+    N : int (default = 3), optional
+        Exponent of two.
+
+    Returns
+    -------
+    new_shape : Tuple
+        New shape extended to integers divisible by 2^N
+    """
+    shape = np.array(shape)
+    new_shape = shape + (2 ** N - np.mod(shape, 2 ** N))
+    return tuple(new_shape)
+
+
+def shape_divisible_by(shape, factor):
+    """
+    Round a given shape to values that are divisible by factor.
+
+    Parameters
+    ----------
+    shape : tuple
+        Input shape.
+    factor : int
+        Divisor.
+
+    Returns
+    -------
+    new_shape : Tuple
+        New shape extended to integers divisible by factor
+    """
+    shape = np.array(shape)
+    new_shape = shape + (shape % factor)
+    return tuple(new_shape)
+
+
+def symmetric_crop_pad_width(shape, new_shape):
+    """
+    Compute symmetric crop or pad width to obtain a new shape from a given old
+    shape of an array.
+
+    Parameters
+    ----------
+    shape : tuple
+        Old shape
+    new_shape : tuple or str
+        New shape.
+
+    """
+    xdiff = abs(shape[1] - new_shape[1])
+    ydiff = abs(shape[0] - new_shape[0])
+
+    if (np.array([xdiff, ydiff]) % 2).any():
+        raise ValueError('For symmetric crop / pad width, difference to new shape '
+                         'must be even in all axes.')
+
+    ywidth = (ydiff // 2, ydiff // 2)
+    xwidth = (xdiff // 2, xdiff // 2)
+    return (ywidth, xwidth)

--- a/gammapy/utils/tests/test_array.py
+++ b/gammapy/utils/tests/test_array.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from ..array import array_stats_str
+from ..array import array_stats_str, shape_2N
 
 
 def test_array_stats_str():
@@ -10,3 +10,9 @@ def test_array_stats_str():
 
     actual = array_stats_str([np.pi, 42])
     assert actual == 'size =     2, min =  3.142, max = 42.000\n'
+
+
+def test_shape_2N():
+    shape = (34, 89, 120, 444)
+    expected_shape = (40, 96, 128, 448)
+    assert expected_shape == shape_2N(shape=shape, N=3)

--- a/gammapy/utils/wcs.py
+++ b/gammapy/utils/wcs.py
@@ -8,7 +8,8 @@ from astropy.coordinates import Angle
 __all__ = [
     'linear_wcs_to_arrays',
     'linear_arrays_to_wcs',
-    'get_wcs_ctype'
+    'get_wcs_ctype',
+    'get_resampled_wcs'
 ]
 
 def get_wcs_ctype(wcs):
@@ -33,6 +34,19 @@ def get_wcs_ctype(wcs):
         return 'icrs'
     else:
         raise TypeError("Can't determine WCS coordinate type.")
+
+def get_resampled_wcs(wcs, factor, downsampled):
+    """
+    Get resampled WCS object.
+    """
+    wcs = wcs.deepcopy()
+
+    if not downsampled:
+        factor = 1. / factor
+
+    wcs.wcs.cdelt *= factor
+    wcs.wcs.crpix = (wcs.wcs.crpix - 0.5) / factor + 0.5
+    return wcs
 
 
 def linear_wcs_to_arrays(wcs, nbins_x, nbins_y):


### PR DESCRIPTION
This PR adds the up- and downsampling to `SkyImage` and makes the following related changes:

* Add `SkyImage.upsample()` and `SkyImage.downsample()` methods and tests
* Modify `SkyImage.pad()` to take an additional `shape` parameter and recompute the wcs specs.
* Add a `SkyImage.crop()` method to crop a skyimage and recompute the wcs specs.
* Make `compute_ts_map` and `compute_ts_map_multiscale` work with `SkyImage` and `SkyImageCollection`