### PR TITLE
Add binary operations to SkyMask

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -809,6 +809,9 @@ class SkyImage(object):
             ax = fig.add_subplot(1, 1, 1, projection=self.wcs)
 
         kwargs['origin'] = kwargs.get('origin', 'lower')
+        kwargs['cmap'] = kwargs.get('cmap', 'afmhot')
+        kwargs['interpolation'] = kwargs.get('interpolation', 'None')
+
         caxes = ax.imshow(self.data, **kwargs)
         unit = self.unit or 'A.U.'
         if unit == 'ct':

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -154,7 +154,6 @@ class SkyMask(SkyImage):
         from matplotlib import colors
 
         kwargs.setdefault('cmap', colors.ListedColormap(['black', 'lightgrey']))
-        kwargs.setdefault('origin', 'lower')
 
         super(SkyMask, self).plot(ax, fig, **kwargs)
 
@@ -260,7 +259,7 @@ def make_tevcat_exclusion_mask():
 
 def _validate_structure_element(structure):
     """
-    Validate structuring for binary operations.
+    Validate structuring element for binary operations.
     """
     if isinstance(structure, Kernel):
         if not structure.is_bool:

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -62,7 +62,7 @@ class SkyMask(SkyImage):
 
         Parameters
         ----------
-        structure : `~astropy.convolution.Kernel` or `~numpy.ndarray`
+        structure : `~numpy.ndarray`
             Structuring kernel. Must be boolean i.e. only contain 1 and 0 values.
 
         Returns
@@ -71,7 +71,6 @@ class SkyMask(SkyImage):
             Opened sky mask.
         """
         from scipy.ndimage import binary_opening
-        structure = _validate_structure_element(structure)
         data = binary_opening(self.data, structure)
         return SkyMask(data=data, wcs=self.wcs)
 
@@ -83,7 +82,7 @@ class SkyMask(SkyImage):
 
         Parameters
         ----------
-        structure : `~astropy.convolution.Kernel` or `~numpy.ndarray`
+        structure : `~numpy.ndarray`
             Structuring kernel. Must be boolean i.e. only contain 1 and 0 values.
 
         Returns
@@ -92,7 +91,6 @@ class SkyMask(SkyImage):
             Dilated sky mask.
         """
         from scipy.ndimage import binary_dilation
-        structure = _validate_structure_element(structure)
         data = binary_dilation(self.data, structure)
         return SkyMask(data=data, wcs=self.wcs)
 
@@ -104,7 +102,7 @@ class SkyMask(SkyImage):
 
         Parameters
         ----------
-        structure : `~astropy.convolution.Kernel` or `~numpy.ndarray`
+        structure : `~numpy.ndarray`
             Structuring kernel. Must be boolean i.e. only contain 1 and 0 values.
 
         Returns
@@ -113,7 +111,6 @@ class SkyMask(SkyImage):
             Closed sky mask.
         """
         from scipy.ndimage import binary_closing
-        structure = _validate_structure_element(structure)
         data = binary_closing(self.data, structure)
         return SkyMask(data=data, wcs=self.wcs)
 
@@ -125,7 +122,7 @@ class SkyMask(SkyImage):
 
         Parameters
         ----------
-        structure : `~astropy.convolution.Kernel` or `~numpy.ndarray`
+        structure : `~numpy.ndarray`
             Structuring kernel. Must be boolean i.e. only contain 1 and 0 values.
 
         Returns
@@ -134,7 +131,6 @@ class SkyMask(SkyImage):
             Eroded sky mask.
         """
         from scipy.ndimage import binary_erosion
-        structure = _validate_structure_element(structure)
         data = binary_erosion(self.data, structure)
         return SkyMask(data=data, wcs=self.wcs)
 
@@ -256,20 +252,3 @@ def make_tevcat_exclusion_mask():
 
     return all_sky_exclusion
 
-
-def _validate_structure_element(structure):
-    """
-    Validate structuring element for binary operations.
-    """
-    if isinstance(structure, Kernel):
-        if not structure.is_bool:
-            raise ValueError('Structuring element must be bool.')
-        structure.normalize('peak')
-        structure = structure.array.astype('int')
-    elif isinstance(structure, np.ndarray):
-        if not ((structure == 0) | (structure == 1)).all():
-            raise ValueError('Structuring element must be bool.')
-    else:
-        raise TypeError('Structuring element must be either `numpy.ndarray` or'
-                        '`astropy.convolution.Kernel`')
-    return structure

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -161,7 +161,7 @@ def measure_containment_radius(image, position, containment_fraction=0.8):
 
     Returns
     -------
-    containment_radius : 
+    containment_radius :
         Containment radius (pix)
     """
     from scipy.optimize import brentq
@@ -189,7 +189,7 @@ def measure_containment_fraction(image, radius, separation):
         Containment radius.
     separation : `~astropy.coordinates.Angle`
          Separation from the source position array.
-    
+
     Returns
     -------
     containment_fraction : float

--- a/gammapy/image/tests/test_mask.py
+++ b/gammapy/image/tests/test_mask.py
@@ -38,7 +38,7 @@ def test_distance_image():
 def test_open():
     mask = SkyMask.empty(nxpix=5, nypix=5)
     mask.data[2:3, 2:3] = 1
-    structure = Box2DKernel(3)
+    structure = Box2DKernel(3).array
     mask = mask.open(structure)
     assert (mask.data == 0).all()
 
@@ -47,7 +47,7 @@ def test_close():
     mask = SkyMask.empty(nxpix=5, nypix=5)
     mask.data[1:-1, 1:-1] = 1
     mask.data[2, 2] = 0
-    structure = Box2DKernel(3)
+    structure = Box2DKernel(3).array
     mask = mask.close(structure)
     assert mask.data.sum() == 9
 
@@ -55,9 +55,9 @@ def test_close():
 def test_erode():
     mask = SkyMask.empty(nxpix=5, nypix=5)
     mask.data[1:-1, 1:-1] = 1
-    structure = np.array([[1, 1, 1],
-                          [1, 1, 1],
-                          [1, 1, 1]])
+    structure = [[1, 1, 1],
+                 [1, 1, 1],
+                 [1, 1, 1]]
     mask = mask.erode(structure)
     assert mask.data[2, 2] == 1
     assert mask.data.sum() == 1
@@ -66,8 +66,8 @@ def test_erode():
 def test_dilate():
     mask = SkyMask.empty(nxpix=5, nypix=5)
     mask.data[2, 2] = 1
-    structure = np.array([[1, 1, 1],
-                          [1, 1, 1],
-                          [1, 1, 1]])
+    structure = [[1, 1, 1],
+                 [1, 1, 1],
+                 [1, 1, 1]]
     mask = mask.dilate(structure)
     assert mask.data.sum() == 9

--- a/gammapy/image/tests/test_mask.py
+++ b/gammapy/image/tests/test_mask.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.convolution import Box2DKernel
 from .. import SkyMask
 from ...utils.testing import requires_dependency
 
@@ -31,3 +32,42 @@ def test_distance_image():
     distance = mask.distance_image.data
     expected = [[-1, -1, 1], [1, 1, 1.41421356]]
     assert_allclose(distance, expected)
+
+
+@requires_dependency('scipy')
+def test_open():
+    mask = SkyMask.empty(nxpix=5, nypix=5)
+    mask.data[2:3, 2:3] = 1
+    structure = Box2DKernel(3)
+    mask = mask.open(structure)
+    assert (mask.data == 0).all()
+
+@requires_dependency('scipy')
+def test_close():
+    mask = SkyMask.empty(nxpix=5, nypix=5)
+    mask.data[1:-1, 1:-1] = 1
+    mask.data[2, 2] = 0
+    structure = Box2DKernel(3)
+    mask = mask.close(structure)
+    assert mask.data.sum() == 9
+
+@requires_dependency('scipy')
+def test_erode():
+    mask = SkyMask.empty(nxpix=5, nypix=5)
+    mask.data[1:-1, 1:-1] = 1
+    structure = np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]])
+    mask = mask.erode(structure)
+    assert mask.data[2, 2] == 1
+    assert mask.data.sum() == 1
+
+@requires_dependency('scipy')
+def test_dilate():
+    mask = SkyMask.empty(nxpix=5, nypix=5)
+    mask.data[2, 2] = 1
+    structure = np.array([[1, 1, 1],
+                          [1, 1, 1],
+                          [1, 1, 1]])
+    mask = mask.dilate(structure)
+    assert mask.data.sum() == 9

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -18,9 +18,7 @@ __all__ = [
     'atrous_hdu',
     'atrous_image',
     'bin_events_in_image',
-    'binary_dilation_circle',
     'binary_disk',
-    'binary_opening_circle',
     'binary_ring',
     'block_reduce_hdu',
     'dict_to_hdulist',
@@ -581,49 +579,6 @@ def threshold(array, threshold=5):
     # it only sets values below the threshold to 0,
     # which is not what we want here.
     return data.astype(np.bool).astype(np.uint8)
-
-
-def binary_dilation_circle(input, radius):
-    """Dilate with disk of given radius.
-
-    Parameters
-    ----------
-    input : `~numpy.ndarray`
-        Input array
-    radius : float
-        Dilation radius (pix)
-
-    Returns
-    -------
-    binary_dilation : `~numpy.ndarray` of bools
-        Dilation of the input array by a disk of the given radius.
-    """
-    from scipy.ndimage import binary_dilation
-    structure = binary_disk(radius)
-    return binary_dilation(input, structure)
-
-
-def binary_opening_circle(input, radius):
-    """Binary opening with circle as structuring element.
-
-    This calls `scipy.ndimage.morphology.binary_opening` with a `binary_disk`
-    as structuring element.
-
-    Parameters
-    ----------
-    input : `~numpy.ndarray`
-        Input array
-    radius : float
-        Dilation radius (pix)
-
-    Returns
-    -------
-    binary_opening : `~numpy.ndarray` of bools
-        Opening of the input array by a disk of the given radius.
-    """
-    from scipy.ndimage import binary_opening
-    structure = binary_disk(radius)
-    return binary_opening(input, structure)
 
 
 def make_header(nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0,


### PR DESCRIPTION
This PR moves binary operations from `image/utils.py` to the `SkyMask` class, adds `.close()` and `.erode()` and corresponding test.