### PR TITLE
Add PowerLaw2 spectral model

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -9,7 +9,7 @@ from astropy.utils.data import download_file
 from astropy.units import Quantity
 from ..utils.energy import EnergyBounds
 from ..spectrum import DifferentialFluxPoints, IntegralFluxPoints
-from ..spectrum.models import PowerLaw, ExponentialCutoffPowerLaw, LogParabola
+from ..spectrum.models import PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw, LogParabola
 from ..spectrum.powerlaw import power_law_flux
 from ..datasets import gammapy_extra
 from .core import SourceCatalog, SourceCatalogObject
@@ -389,16 +389,11 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         emin, emax = self.energy_range
         g = Quantity(self.data['Spectral_Index'], '')
 
-        # The pivot energy information is missing in the 2FHL catalog. Set it to
-        # 100 GeV per default.
-        ref = Quantity(100, 'GeV')
-
         pars = {}
-        flux = Quantity(self.data['Flux50'], 'cm-2 s-1')
-        pars['amplitude'] = power_law_flux(flux, g, ref, emin, emax).to('cm-2 s-1 GeV-1')
-        pars['reference'] = ref
+        pars['amplitude'] = Quantity(self.data['Flux50'], 'cm-2 s-1')
+        pars['emin'], pars['emax'] = self.energy_range
         pars['index'] = g
-        return PowerLaw(**pars)
+        return PowerLaw2(**pars)
 
 
 class SourceCatalog3FGL(SourceCatalog):

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose, pytest
-from ..models import PowerLaw, ExponentialCutoffPowerLaw, LogParabola
+from ..models import PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw, LogParabola
 from ...utils.testing import requires_dependency
 
 TEST_MODELS = [
@@ -17,6 +17,20 @@ TEST_MODELS = [
         integral_1_10TeV=u.Quantity(2.9227116204223784, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(6.650836884969039, 'TeV cm-2 s-1'),
     ),
+
+    dict(
+        name='powerlaw2',
+        model=PowerLaw2(
+            amplitude=u.Quantity(2.9227116204223784, 'cm-2 s-1'),
+            index=2.3 * u.Unit(''),
+            emin=1 * u.TeV,
+            emax=10 * u.TeV
+        ),
+        val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), 'cm-2 s-1 TeV-1'),
+        integral_1_10TeV=u.Quantity(2.9227116204223784, 'cm-2 s-1'),
+        eflux_1_10TeV=u.Quantity(6.650836884969039, 'TeV cm-2 s-1'),
+    ),
+
     dict(
         name='ecpl',
         model=ExponentialCutoffPowerLaw(


### PR DESCRIPTION
This PR adds a `PowerLaw2` model with a parametrization that follows http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html#PowerLaw2 