### PR TITLE
Add ExponentialCutoffPowerLaw3FGL, tests and modify model plotting

### DIFF
--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose, pytest
-from ..models import PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw, LogParabola
+from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
+                      ExponentialCutoffPowerLaw3FGL, LogParabola)
 from ...utils.testing import requires_dependency
 
 TEST_MODELS = [
@@ -44,6 +45,21 @@ TEST_MODELS = [
         integral_1_10TeV=u.Quantity(2.3556579120286796, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(4.83209019773561, 'TeV cm-2 s-1'),
     ),
+
+    dict(
+        name='ecpl_3fgl',
+        model=ExponentialCutoffPowerLaw3FGL(
+            index=2.3 * u.Unit(''),
+            amplitude=4 / u.cm ** 2 / u.s / u.TeV,
+            reference=1 * u.TeV,
+            ecut=10 * u.TeV
+        ),
+
+        val_at_2TeV=u.Quantity(0.7349563611124971, 'cm-2 s-1 TeV-1'),
+        integral_1_10TeV=u.Quantity(2.6034046173089, 'cm-2 s-1'),
+        eflux_1_10TeV=u.Quantity(5.340285560055799, 'TeV cm-2 s-1'),
+    ),
+
     dict(
         name='logpar',
         model=LogParabola(


### PR DESCRIPTION
This PR adds a `ExponentialCutoffPowerLaw3FGL`, because the parametrization used in the paper is different from the current `ExponentialCutoffPowerLaw`. It further includes some minor changes to model plotting.