### PR TITLE
Add SherpaExponentialCutoffPowerLaw

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -32,7 +32,7 @@ class SpectrumFit(object):
         Fit statistic to be used
     """
     FLUX_FACTOR = 1e-20
-    """Numerical constant to bring Sherpa optimizers in valid range"""
+    """Numerical constant to make model amplitude O(1) during the fit"""
     DEFAULT_STAT = 'wstat'
     """Default statistic to be used for the fit"""
 
@@ -127,9 +127,11 @@ class SpectrumFit(object):
             temp = self.obs_list[ii].to_sherpa()
             if self.fit_range is not None:
                 temp.notice(fitmin, fitmax)
-                temp.get_background().notice(fitmin, fitmax)
+                if temp.get_background() is not None:
+                    temp.get_background().notice(fitmin, fitmax)
             temp.ignore_bad()
-            temp.get_background().ignore_bad()
+            if temp.get_background() is not None:
+                temp.get_background().ignore_bad()
             pha.append(temp)
             # Forward folding
             resp = Response1D(pha[ii])
@@ -138,6 +140,7 @@ class SpectrumFit(object):
         data = DataSimulFit('simul fit data', pha)
         fitmodel = SimulFitModel('simul fit model', folded_model)
 
+        log.debug(fitmodel)
         fit = Fit(data, fitmodel, self.statistic)
         fitresult = fit.fit()
         log.debug(fitresult)
@@ -184,7 +187,8 @@ def _sherpa_to_fitresult(shmodel, covar, efilter, fitresult):
     amplfact = SpectrumFit.FLUX_FACTOR
     pardict = dict(gamma=['index', u.Unit('')],
                    ref=['reference', u.keV],
-                   ampl=['amplitude', amplfact * u.Unit('cm-2 s-1 keV-1')])
+                   ampl=['amplitude', amplfact * u.Unit('cm-2 s-1 keV-1')],
+                   cutoff=['lambda_', u.Unit('keV-1')])
     kwargs = dict()
 
     for par in shmodel.pars:
@@ -193,6 +197,8 @@ def _sherpa_to_fitresult(shmodel, covar, efilter, fitresult):
 
     if 'powlaw1d' in shmodel.name:
         model = models.PowerLaw(**kwargs)
+    elif 'ecpl' in shmodel.name:
+        model = models.ExponentialCutoffPowerLaw(**kwargs)
     else:
         raise NotImplementedError(str(shmodel))
 

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -188,7 +188,7 @@ def _sherpa_to_fitresult(shmodel, covar, efilter, fitresult):
     pardict = dict(gamma=['index', u.Unit('')],
                    ref=['reference', u.keV],
                    ampl=['amplitude', amplfact * u.Unit('cm-2 s-1 keV-1')],
-                   cutoff=['lambda_', u.Unit('keV-1')])
+                   cutoff=['lambda_', u.Unit('TeV-1')])
     kwargs = dict()
 
     for par in shmodel.pars:

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -9,6 +9,7 @@ from ..extern.bunch import Bunch
 from ..utils.energy import EnergyBounds
 
 # This cannot be made a delayed import because the pytest matrix fails if it is
+# https://travis-ci.org/gammapy/gammapy/jobs/151539845#L1799
 try:
     from .sherpa_models import SherpaExponentialCutoffPowerLaw
 except ImportError:
@@ -153,7 +154,7 @@ class SpectralModel(object):
         return ax
 
     def to_sherpa(self, name='default'):
-        """Convert to sherpa model
+        """Convert to Sherpa model
 
         To be implemented by subclasses
         """
@@ -239,8 +240,8 @@ class PowerLaw(SpectralModel):
         lower = (emin / pars.reference) ** val
         return prefactor * (upper - lower)
 
-    def to_sherpa(self, name='ecpl.default'):
-        """Return `~sherpa.models.PowLaw1d`
+    def to_sherpa(self, name='default'):
+        """Return Sherpa `~sherpa.models.PowLaw1d`
 
         Parameters
         ----------
@@ -353,17 +354,13 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         return pwl * cutoff
 
     def to_sherpa(self, name='default'):
-        """Return `~sherpa.models.Arithmetic model`
+        """Return Sherpa `~sherpa.models.Arithmetic model`
 
         Parameters
         ----------
         name : str, optional
             Name of the sherpa model instance
         """
-        # NOTE: we cannot use naima.sherpa_models.SherpaModelECPL since it is
-        # meant to be used as abstract base class (Arithmetic model only
-        # initialized in daughter classes)
-        # see https://github.com/zblz/naima/blob/master/naima/sherpa_models.py#L149
         model = SherpaExponentialCutoffPowerLaw(name='ecpl.' + name)
         pars = self.parameters
         model.gamma = pars.index.value

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -8,6 +8,13 @@ from . import integrate_spectrum
 from ..extern.bunch import Bunch
 from ..utils.energy import EnergyBounds
 
+# This cannot be made a delayed import because the pytest matrix fails if it is
+try:
+    from .sherpa_models import SherpaExponentialCutoffPowerLaw
+except ImportError:
+    pass
+
+
 __all__ = [
     'SpectralModel',
     'PowerLaw',
@@ -357,7 +364,6 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         # meant to be used as abstract base class (Arithmetic model only
         # initialized in daughter classes)
         # see https://github.com/zblz/naima/blob/master/naima/sherpa_models.py#L149
-        from .sherpa_models import SherpaExponentialCutoffPowerLaw
         model = SherpaExponentialCutoffPowerLaw(name='ecpl.' + name)
         pars = self.parameters
         model.gamma = pars.index.value

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -45,7 +45,7 @@ class SpectralModel(object):
         .. math::
 
             F(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}\phi(E)dE
-            
+
         kwargs are forwared to :func:`~gammapy.spectrum.integrate_spectrum``.
 
         Parameters
@@ -147,7 +147,7 @@ class SpectralModel(object):
 
     def to_sherpa(self, name='default'):
         """Convert to sherpa model
-        
+
         To be implemented by subclasses
         """
         raise NotImplementedError('{}'.format(self.__class__.__name__))
@@ -285,7 +285,6 @@ class PowerLaw2(SpectralModel):
         bottom = emax ** (-index + 1) - emin ** (-index + 1)
         return amplitude * (top / bottom) * np.power(energy, -index)
 
-
     def integral(self, emin, emax):
         r"""
         Integrate power law analytically.
@@ -348,7 +347,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
 
     def to_sherpa(self, name='default'):
         """Return `~sherpa.models.Arithmetic model`
-        
+
         Parameters
         ----------
         name : str, optional
@@ -356,10 +355,10 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         """
         # NOTE: we cannot use naima.sherpa_models.SherpaModelECPL since it is
         # meant to be used as abstract base class (Arithmetic model only
-        # initialized in daughter classes
+        # initialized in daughter classes)
         # see https://github.com/zblz/naima/blob/master/naima/sherpa_models.py#L149
         from .sherpa_models import SherpaExponentialCutoffPowerLaw
-        model = SherpaExponentialCutoffPowerLaw(name='ecpl.'+name)
+        model = SherpaExponentialCutoffPowerLaw(name='ecpl.' + name)
         pars = self.parameters
         model.gamma = pars.index.value
         model.ref = pars.reference.to('keV').value

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -47,7 +47,7 @@ class SpectrumFitResult(object):
         self.model = model
         self.covariance = covariance
         self.covar_axis = covar_axis
-        self.fit_range = fit_range.to('TeV')
+        self.fit_range = fit_range
         self.statname = statname
         self.statval = statval
         self.npred = npred
@@ -108,7 +108,7 @@ class SpectrumFitResult(object):
         if modeldict['name'] == 'PowerLaw':
             model = models.PowerLaw.from_dict(modeldict)
         else:
-            raise NotImplementedError()
+            raise NotImplementedError('{}'.format(modeldict['name']))
         try:
             erange = val['fit_range']
             energy_range = (erange['min'], erange['max']) * u.Unit(erange['unit'])
@@ -125,11 +125,20 @@ class SpectrumFitResult(object):
             for flu in fl:
                 fluxes[flu] = fl[flu]['value'] * u.Unit(fl[flu]['unit'])
                 flux_errors[flu] = fl[flu]['error'] * u.Unit(fl[flu]['unit'])
+        try: 
+            covar = val['covariance']
+            covar_axis = covar['axis']
+            covariance = np.array(covar['matrix'])
+        except KeyError:
+            covar_axis = None
+            covariance = None
 
         return cls(model=model,
                    fit_range=energy_range,
                    fluxes=fluxes,
-                   flux_errors=flux_errors)
+                   flux_errors=flux_errors,
+                   covar_axis=covar_axis,
+                   covariance=covariance)
 
     def to_table(self, **kwargs):
         t = Table()
@@ -250,7 +259,7 @@ class SpectrumResult(object):
 
     Parameters
     ----------
-    fit: `~gammapy.spectrum.results.SpectrumFitResult`
+    fit: `~gammapy.spectrum.SpectrumFitResult`
         Spectrum fit result
     obs: `~gammapy.spectrum.SpectrumObservation`, optional
         Observation used for the fit

--- a/gammapy/spectrum/sherpa_models.py
+++ b/gammapy/spectrum/sherpa_models.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Sherpa spectral models
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from sherpa.models import ArithmeticModel, Parameter, modelCacher1d
+from .models import ExponentialCutoffPowerLaw
+
+__all__ = [
+    'SherpaExponentialCutoffPowerLaw',
+]
+
+# Partly copied from https://github.com/zblz/naima/blob/master/naima/sherpa_models.py#L33
+
+class SherpaExponentialCutoffPowerLaw(ArithmeticModel):
+    """Exponential CutoffPowerLaw
+    
+    Note that the cutoff is given in units '1/TeV' in order to bring the Sherpa
+    optimizers into a valid range. All other parameters still have units 'keV'
+    and 'cm2'.
+    """
+    def __init__(self, name='ecpl'):
+        self.gamma = Parameter(name, 'gamma', 2, min=-10, max=10)
+        self.ref = Parameter(name, 'ref', 1, frozen=True) 
+        self.ampl = Parameter(name, 'ampl', 1, min=0) 
+        self.cutoff = Parameter(name, 'cutoff', 1, min=0, units='1/TeV')
+        ArithmeticModel.__init__(self, name, (self.gamma, self.ref, self.ampl,
+                                              self.cutoff))
+        self._use_caching = True
+        self.cache = 10
+
+    @modelCacher1d
+    def calc(self, p, x, xhi=None):
+        model = ExponentialCutoffPowerLaw(index=p[0],
+                                          reference=p[1],
+                                          amplitude=p[2],
+                                          lambda_=p[3]*1e-9)
+        if xhi is None:
+            val = model(x)
+        else:
+            val = model.integral(x, xhi, intervals=True)
+
+        return val

--- a/gammapy/spectrum/sherpa_models.py
+++ b/gammapy/spectrum/sherpa_models.py
@@ -32,10 +32,11 @@ class SherpaExponentialCutoffPowerLaw(ArithmeticModel):
     @modelCacher1d
     def calc(self, p, x, xhi=None):
         from .models import ExponentialCutoffPowerLaw
+        kev_to_tev = 1e-9
         model = ExponentialCutoffPowerLaw(index=p[0],
                                           reference=p[1],
                                           amplitude=p[2],
-                                          lambda_=p[3] * 1e-9)
+                                          lambda_=p[3] * kev_to_tev)
         if xhi is None:
             val = model(x)
         else:

--- a/gammapy/spectrum/sherpa_models.py
+++ b/gammapy/spectrum/sherpa_models.py
@@ -3,7 +3,6 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 from sherpa.models import ArithmeticModel, Parameter, modelCacher1d
-from .models import ExponentialCutoffPowerLaw
 
 __all__ = [
     'SherpaExponentialCutoffPowerLaw',
@@ -11,17 +10,19 @@ __all__ = [
 
 # Partly copied from https://github.com/zblz/naima/blob/master/naima/sherpa_models.py#L33
 
+
 class SherpaExponentialCutoffPowerLaw(ArithmeticModel):
     """Exponential CutoffPowerLaw
-    
+
     Note that the cutoff is given in units '1/TeV' in order to bring the Sherpa
     optimizers into a valid range. All other parameters still have units 'keV'
     and 'cm2'.
     """
+
     def __init__(self, name='ecpl'):
         self.gamma = Parameter(name, 'gamma', 2, min=-10, max=10)
-        self.ref = Parameter(name, 'ref', 1, frozen=True) 
-        self.ampl = Parameter(name, 'ampl', 1, min=0) 
+        self.ref = Parameter(name, 'ref', 1, frozen=True)
+        self.ampl = Parameter(name, 'ampl', 1, min=0)
         self.cutoff = Parameter(name, 'cutoff', 1, min=0, units='1/TeV')
         ArithmeticModel.__init__(self, name, (self.gamma, self.ref, self.ampl,
                                               self.cutoff))
@@ -30,10 +31,11 @@ class SherpaExponentialCutoffPowerLaw(ArithmeticModel):
 
     @modelCacher1d
     def calc(self, p, x, xhi=None):
+        from .models import ExponentialCutoffPowerLaw
         model = ExponentialCutoffPowerLaw(index=p[0],
                                           reference=p[1],
                                           amplitude=p[2],
-                                          lambda_=p[3]*1e-9)
+                                          lambda_=p[3] * 1e-9)
         if xhi is None:
             val = model(x)
         else:

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -66,7 +66,7 @@ class SpectrumSimulation(object):
         on_counts = rand.poisson(self.npred.data)
 
         counts_kwargs = dict(energy=self.npred.energy,
-                             exposure=self.livetime,
+                             livetime=self.livetime,
                              obs_id=obs_id,
                              creator=self.__class__.__name__,
                              lo_threshold=lo_threshold,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -80,6 +80,18 @@ def test_spectral_fit(tmpdir):
 
     assert_quantity_allclose(actual, desired)
 
+    # Test ECPL
+    ecpl = models.ExponentialCutoffPowerLaw(
+        index = 2 * u.Unit(''),
+        amplitude = 10 ** -12 * u.Unit('cm-2 s-1 TeV-1'),
+        reference = 1 * u.TeV,
+        lambda_ = 0.1 / u.TeV
+    )
+
+    fit = SpectrumFit(obs_list, ecpl)
+    fit.fit()
+    assert_quantity_allclose(fit.result[0].fit.model.parameters.lambda_,
+                             0.06321 / u.TeV, rtol=1e-3)
 
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -100,8 +100,16 @@ def test_models(spectrum):
 def test_to_sherpa(spectrum):
     model = spectrum['model']
     try:
-        model.to_sherpa()
-    except AttributeError:
+        sherpa_model = model.to_sherpa()
+    except NotImplementedError:
         pass
+    else:
+        test_e = 1.56 * u.TeV
+        desired = model(test_e)
+        actual = sherpa_model(test_e.to('keV').value) * u.Unit('cm-2 s-1 keV-1')
+        assert_quantity_allclose(actual, desired)
+
+    #test plot
     energy_range = [1, 10] * u.TeV
     model.plot(energy_range=energy_range)
+

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -76,6 +76,7 @@ TEST_MODELS = [
 ]
 
 
+@requires_dependency('uncertainties')
 @pytest.mark.parametrize(
     "spectrum", TEST_MODELS, ids=[_['name'] for _ in TEST_MODELS]
 )
@@ -109,7 +110,6 @@ def test_to_sherpa(spectrum):
         actual = sherpa_model(test_e.to('keV').value) * u.Unit('cm-2 s-1 keV-1')
         assert_quantity_allclose(actual, desired)
 
-    #test plot
+    # test plot
     energy_range = [1, 10] * u.TeV
     model.plot(energy_range=energy_range)
-


### PR DESCRIPTION
* [x] Add Exponential Cutoff PowerLaw for Sherpa fitting
* [x] Make ``SpectralModel.integral accept`` xmin and xmax arrays

Note: The ExpCutoff fit gives sensible results, but they don't agree 100% with HAP FitSpectrum. This has to be debugged in the future.