### PR TITLE
Update reflected regions computation

### DIFF
--- a/gammapy/background/background_estimate.py
+++ b/gammapy/background/background_estimate.py
@@ -68,8 +68,11 @@ def ring_background_estimate(pos, on_radius, inner_radius, outer_radius, events)
     return BackgroundEstimate(off_region, off_events, a_on, a_off, tag='ring')
 
 
-def reflected_regions_background_estimate(on_region, pointing, exclusion, events):
+def reflected_regions_background_estimate(on_region, pointing, exclusion,
+                                          events, **kwargs):
     """Reflected regions background estimate
+
+    kwargs are forwaded to :func:`gammapy.background.find_reflected_regions`
 
     Parameters
     ----------
@@ -82,7 +85,7 @@ def reflected_regions_background_estimate(on_region, pointing, exclusion, events
     events : `gammapy.data.EventList`
         Events
     """
-    off_region = find_reflected_regions(on_region, pointing, exclusion)
+    off_region = find_reflected_regions(on_region, pointing, exclusion, **kwargs)
     off_events = events.select_circular_region(off_region)
     a_on = 1
     a_off = len(off_region)

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -3,14 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.coordinates import Angle
 from regions import PixCoord, CirclePixelRegion
+from ..image import SkyMask
+import logging
 
 __all__ = [
     'find_reflected_regions',
 ]
 
 
-def find_reflected_regions(region, center, exclusion_mask, angle_increment=None,
-                           min_distance=None, min_distance_input=None):
+log = logging.getLogger(__name__)
+
+def find_reflected_regions(region, center, exclusion_mask=None,
+                           angle_increment=None, min_distance=None,
+                           min_distance_input=None):
     """Find reflected regions.
 
     Converts to pixel coordinates internally.
@@ -21,14 +26,14 @@ def find_reflected_regions(region, center, exclusion_mask, angle_increment=None,
         Region
     center : `~astropy.coordinates.SkyCoord`
         Rotation point
-    exclusion_mask : `~gammapy.image.SkyMask`
+    exclusion_mask : `~gammapy.image.SkyMask`, optional
         Exclusion mask
     angle_increment : `~astropy.coordinates.Angle`
-        Rotation angle for each step
+        Rotation angle for each step, default: 0.1 rad
     min_distance : `~astropy.coordinates.Angle`
-        Minimal distance between to reflected regions
+        Minimal distance between to reflected regions, default: 0 rad
     min_distance_input : `~astropy.coordinates.Angle`
-        Minimal distance from input region
+        Minimal distance from input region, default: 0 rad
 
     Returns
     -------
@@ -39,17 +44,41 @@ def find_reflected_regions(region, center, exclusion_mask, angle_increment=None,
     min_distance = Angle('0 rad') if min_distance is None else Angle(min_distance)
     min_distance_input = Angle('0 rad') if min_distance_input is None else Angle(min_distance_input)
 
+    # Create empty exclusion mask if None is provided
+    if exclusion_mask is None:
+        min_size = region.center.separation(center)
+        binsz = 0.02
+        npix = int((3 * min_size / binsz).value)
+        exclusion_mask = SkyMask.empty(name='empty exclusion mask',
+                                      xref=center.galactic.l.value,
+                                      yref=center.galactic.b.value,
+                                      binsz=binsz,
+                                      nxpix=npix,
+                                      nypix=npix,
+                                      fill=1)
+
     reflected_regions_pix = list()
     wcs = exclusion_mask.wcs
     pix_region = region.to_pixel(wcs)
     pix_center = PixCoord(*center.to_pixel(wcs, origin=1))
+
+    # Compute angle of the ON regions
     dx = pix_region.center.x - pix_center.x
     dy = pix_region.center.y - pix_center.y
     offset = np.hypot(dx, dy)
     angle = Angle(np.arctan2(dx, dy), 'rad')
-    min_ang = Angle(2 * pix_region.radius / offset, 'rad') + min_distance
+
+    # Get the minimum angle a Circle has to be moved in order to not overlap
+    # with the previous one
+    min_ang = Angle(2 * np.arcsin(pix_region.radius / offset), 'rad')
+
+    # Add required minimal distance between two off regions
+    min_ang += min_distance
+
+    # Maximum allowd angle before the an overlap with the ON regions happens
     max_angle = angle + Angle('360deg') - min_ang - min_distance_input
 
+    # Starting angle
     curr_angle = angle + min_ang + min_distance_input
     while curr_angle < max_angle:
         test_pos = _compute_xy(pix_center, offset, curr_angle)
@@ -61,6 +90,8 @@ def find_reflected_regions(region, center, exclusion_mask, angle_increment=None,
             curr_angle = curr_angle + angle_increment
 
     reflected_regions = [_.to_sky(wcs) for _ in reflected_regions_pix]
+    log.debug('Found {} reflected regions:\n {}'.format(len(reflected_regions),
+                                                            reflected_regions))
     return reflected_regions
 
 

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -33,7 +33,7 @@ def find_reflected_regions(region, center, exclusion_mask=None,
     min_distance : `~astropy.coordinates.Angle`
         Minimal distance between to reflected regions, default: 0 rad
     min_distance_input : `~astropy.coordinates.Angle`
-        Minimal distance from input region, default: 0 rad
+        Minimal distance from input region, default: 0.1 rad
 
     Returns
     -------
@@ -42,7 +42,7 @@ def find_reflected_regions(region, center, exclusion_mask=None,
     """
     angle_increment = Angle('0.1 rad') if angle_increment is None else Angle(angle_increment)
     min_distance = Angle('0 rad') if min_distance is None else Angle(min_distance)
-    min_distance_input = Angle('0 rad') if min_distance_input is None else Angle(min_distance_input)
+    min_distance_input = Angle('0.1 rad') if min_distance_input is None else Angle(min_distance_input)
 
     # Create empty exclusion mask if None is provided
     if exclusion_mask is None:

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -26,10 +26,10 @@ def test_find_reflected_regions(mask):
     radius = Angle(0.4, 'deg')
     region = CircleSkyRegion(pos, radius)
     center = SkyCoord(83.2, 22.7, unit='deg', frame='icrs')
-    regions = find_reflected_regions(region, center, mask)
+    regions = find_reflected_regions(region, center, mask,
+                                     min_distance_input=Angle('0 deg'))
     assert (len(regions)) == 20
     assert_quantity_allclose(regions[3].center.icrs.ra,
                              Angle('81.752 deg'),
                              rtol=1e-2)
     
-

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -69,4 +69,4 @@ def test_stack(target):
         obs_stats.append(ObservationStats.from_target(run, target, bg))
     sum_obs_stats = ObservationStats.stack(obs_stats)
     assert_allclose(sum_obs_stats.alpha, 0.284, rtol=1e-2)
-    assert_allclose(sum_obs_stats.sigma, 23.35, rtol=1e-3)
+    assert_allclose(sum_obs_stats.sigma, 23.5757575757, rtol=1e-3)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -803,6 +803,15 @@ class SkyImage(object):
         ----------
         ax : `~astropy.wcsaxes.WCSAxes`, optional
             WCS axis object to plot on.
+        fig : `~matplotlib.figure.Figure`, optional
+            Figure
+
+        Returns
+        -------
+        ax : `~astropy.wcsaxes.WCSAxes`, optional
+            WCS axis object
+        fig : `~matplotlib.figure.Figure`, optional
+            Figure
         """
         import matplotlib.pyplot as plt
 
@@ -831,6 +840,8 @@ class SkyImage(object):
             ax.coords['dec'].set_axislabel('Declination')
         except AttributeError:
             log.info("Can't set coordinate axes. No WCS information available.")
+
+        return fig, ax
 
     def info(self):
         """

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -139,10 +139,14 @@ class SkyMask(SkyImage):
         Parameters
         ----------
         ax : `~astropy.wcsaxes.WCSAxes`, optional
-            WCS axis object
+            WCS axis object to plot on.
+        fig : `~matplotlib.figure.Figure`, optional
+            Figure
 
         Returns
         -------
+        fig : `~matplotlib.figure.Figure`, optional
+            Figure
         ax : `~astropy.wcsaxes.WCSAxes`, optional
             WCS axis object
         """
@@ -150,7 +154,8 @@ class SkyMask(SkyImage):
 
         kwargs.setdefault('cmap', colors.ListedColormap(['black', 'lightgrey']))
 
-        super(SkyMask, self).plot(ax, fig, **kwargs)
+        fig, ax = super(SkyMask, self).plot(ax, fig, **kwargs)
+        return fig, ax
 
     @lazyproperty
     def distance_image(self):

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -126,12 +126,13 @@ class SpectrumExtraction(object):
         """
         method = self.background.pop('method')
         if method == 'reflected':
-            exclusion = self.background.pop('exclusion', None)
+            kwargs = self.background.copy()
+            kwargs.pop('n_min', None)
             bkg = [reflected_regions_background_estimate(
-                self.target.on_region,
-                _.pointing_radec,
-                exclusion,
-                _.events) for _ in self.obs]
+                on_region=self.target.on_region,
+                pointing=_.pointing_radec,
+                events=_.events,
+                **kwargs) for _ in self.obs]
         else:
             raise NotImplementedError("Method: {}".format(method))
         self.background = bkg

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -47,7 +47,7 @@ def test_spectral_fit(tmpdir):
                              2.116 * u.Unit(''), rtol=1e-3)
     model_with_errors = result.fit.model_with_uncertainties
     assert_allclose(model_with_errors.parameters.index.s,
-                    0.0543, rtol=1e-3)
+                    0.0542, rtol=1e-3)
 
     # Actual fit range can differ from threshold due to binning effects
     # We take the lowest bin that is completely within threshold
@@ -97,5 +97,5 @@ def test_sherpa_fit(tmpdir):
     model.gamma = 2
     sau.set_model(model * 1e-20)
     sau.fit()
-    assert_allclose(model.pars[0].val, 2.0202, atol=1e-4) 
-    assert_allclose(model.pars[2].val, 2.3568, atol=1e-4) 
+    assert_allclose(model.pars[0].val, 2.0198, atol=1e-4) 
+    assert_allclose(model.pars[2].val, 2.3564, atol=1e-4) 


### PR DESCRIPTION
In the reflected regions placement a small angle approximation was used which led to overlapping OFF regions for ON regions (large circles -> large angles). This PR fixes this.

It also

* makes the exclusion mask optional
* makes ``SkyImage.plot()`` return the figure and axis instance
* adjusts default reflected regions behaviour to HAP for easier comparison (min distance to ON region)