### PR TITLE
Fermi 3FGL and 2FHL spectrum plotting

### DIFF
--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -29,6 +29,7 @@ Content
 .. toctree::
    fitting
    simulation
+   plotting_fermi_spectra
 
 Reference/API
 =============

--- a/docs/spectrum/plotting_fermi_spectra.rst
+++ b/docs/spectrum/plotting_fermi_spectra.rst
@@ -1,0 +1,140 @@
+.. _plotting_fermi_spectra:
+
+************************************
+Plotting Fermi 2FHL and 3FGL spectra
+************************************
+
+.. currentmodule:: gammapy.spectrum
+
+In the following we will show how to plot spectra for Fermi 2FHL and 3FGL
+sources, by using the `~gammapy.spectrum.models.SpectralModel`, `~gammapy.spectrum.SpectrumButterfly`
+and `~gammapy.spectrum.DifferentialFluxPoints` classes.
+
+
+As a first example we plot the spectral energy distribution for the Crab,
+namely ``'3FGL J0534.5+2201'`` and ``'2FHL J0534.5+2201'``, including best fit
+model, butterfly and flux points. First we load the corresponding catalog from
+`~gammapy.catalog` and access the data for the crab:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+    from gammapy.catalog import SourceCatalog3FGL, SourceCatalog2FHL
+
+    plt.style.use('ggplot')
+
+    # load catalogs
+    fermi_3fgl = SourceCatalog3FGL()
+    fermi_2fhl = SourceCatalog2FHL()
+
+    # access crab data by corresponding identifier
+    crab_3fgl = fermi_3fgl['3FGL J0534.5+2201']
+    crab_2fhl = fermi_2fhl['2FHL J0534.5+2201']
+
+First we plot the best fit model for the 3FGL model:
+
+.. code-block:: python
+
+    ax = crab_3fgl.spectral_model.plot(crab_3fgl.energy_range, energy_power=2,
+                                       label='Fermi 3FGL', color='r',
+                                       flux_unit='erg-1 cm-2 s-1')
+    ax.set_ylim(1e-12, 1E-9)
+
+The ``crab_3fgl.energy_range`` attribute specifies the energy range of the 3FGL
+model. By setting the argument ``energy_power=2`` we can plot the actual energy
+distribution instead of the differential flux density. The `~gammapy.spectrum.models.SpectralModel.plot`
+method returns an `~matplotlib.pyplot.Axes` object that can be reused later to plot
+additional information on it. Here we just modify the y-limits of the plot.
+
+As the next step we compute the butterfly for the best fit model and add it to
+the plot:
+
+.. code-block:: python
+
+    from gammapy.utils.energy import EnergyBounds
+
+    # set up an energy array to evaluate the butterfly
+    emin, emax = crab_3fgl.energy_range
+    energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+    butterfly_3fg = crab_3fgl.spectrum.butterfly(energy)
+
+    butterfly_3fg.plot(crab_3fgl.energy_range, ax=ax, energy_power=2, color='r',
+                       flux_unit='erg-1 cm-2 s-1')
+
+Finally we add the flux points by calling:
+
+.. code-block:: python
+
+    crab_3fgl.flux_points.plot(ax=ax, energy_power=2, color='r',
+                               flux_unit='erg-1 cm-2 s-1')
+
+
+The same can be done with the 2FHL best fit model:
+
+.. code-block:: python
+
+    crab_2fhl.spectral_model.plot(crab_2fhl.energy_range, ax=ax, energy_power=2,
+                                  c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
+
+    # set up an energy array to evaluate the butterfly using the 2FHL energy range
+    emin, emax = crab_2fhl.energy_range
+    energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+    butterfly_2fhl = crab_2fhl.spectrum.butterfly(energy)
+
+    # plot butterfly and flux points
+    butterfly_2fhl.plot(crab_2fhl.energy_range, ax=ax, energy_power=2, color='g',
+                        flux_unit='erg-1 cm-2 s-1')
+    crab_2fhl.flux_points.plot(ax=ax, energy_power=2, color='g',
+                               flux_unit='erg-1 cm-2 s-1')
+
+
+The final plot looks as following:
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+    from gammapy.catalog import SourceCatalog3FGL, SourceCatalog2FHL
+    from gammapy.utils.energy import EnergyBounds
+
+    plt.style.use('ggplot')
+
+    # load catalogs
+    fermi_3fgl = SourceCatalog3FGL()
+    fermi_2fhl = SourceCatalog2FHL()
+
+    # access crab data by corresponding identifier
+    crab_3fgl = fermi_3fgl['3FGL J0534.5+2201']
+    crab_2fhl = fermi_2fhl['2FHL J0534.5+2201']
+
+    ax = crab_3fgl.spectral_model.plot(crab_3fgl.energy_range, energy_power=2,
+                                       label='Fermi 3FGL', color='r',
+                                       flux_unit='erg-1 cm-2 s-1')
+    ax.set_ylim(1e-12, 1E-9)
+
+
+    # set up an energy array to evaluate the butterfly
+    emin, emax = crab_3fgl.energy_range
+    energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+    butterfly_3fg = crab_3fgl.spectrum.butterfly(energy)
+
+    butterfly_3fg.plot(crab_3fgl.energy_range, ax=ax, energy_power=2, color='r',
+                       flux_unit='erg-1 cm-2 s-1')
+
+    crab_3fgl.flux_points.plot(ax=ax, energy_power=2, color='r',
+                               flux_unit='erg-1 cm-2 s-1')
+
+    crab_2fhl.spectral_model.plot(crab_2fhl.energy_range, ax=ax, energy_power=2,
+                                  c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
+
+    # set up an energy array to evaluate the butterfly using the 2FHL energy range
+    emin, emax = crab_2fhl.energy_range
+    energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+    butterfly_2fhl = crab_2fhl.spectrum.butterfly(energy)
+
+    # plot butterfly and flux points
+    butterfly_2fhl.plot(crab_2fhl.energy_range, ax=ax, energy_power=2, color='g',
+                        flux_unit='erg-1 cm-2 s-1')
+    crab_2fhl.flux_points.plot(ax=ax, energy_power=2, color='g',
+                               flux_unit='erg-1 cm-2 s-1' )
+    plt.legend(loc=0)
+    plt.show()

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -276,18 +276,22 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         """
         Differential flux points (`~gammapy.spectrum.DifferentialFluxPoints`).
         """
-
         energy = self._ebounds.log_centers
+        energy_err_lo = energy - self._ebounds.lower_bounds
+        energy_err_hi = self._ebounds.upper_bounds - energy
 
         nuFnu = self._get_flux_values('nuFnu', 'erg cm-2 s-1')
-        diff_flux = (nuFnu * energy ** -2).to('erg-1 cm-2 s-1')
+        diff_flux = (nuFnu * energy ** -2).to('TeV-1 cm-2 s-1')
 
         # Get relativ error on integral fluxes
         int_flux_points = self.flux_points_integral
         diff_flux_err_hi = diff_flux * int_flux_points['INT_FLUX_ERR_HI_%'] / 100
         diff_flux_err_lo = diff_flux * int_flux_points['INT_FLUX_ERR_LO_%'] / 100
 
-        return DifferentialFluxPoints.from_arrays(energy=energy, diff_flux=diff_flux,
+        return DifferentialFluxPoints.from_arrays(energy=energy,
+                                                  energy_err_hi=energy_err_hi,
+                                                  energy_err_lo=energy_err_lo,
+                                                  diff_flux=diff_flux,
                                                   diff_flux_err_lo=diff_flux_err_lo,
                                                   diff_flux_err_hi=diff_flux_err_hi)
 
@@ -299,8 +303,8 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         flux = self._get_flux_values()
         flux_err = self._get_flux_values('Unc_Flux')
 
-        return IntegralFluxPoints.from_arrays(self._ebounds, flux, flux + flux_err[:, 1],
-                                              flux + flux_err[:, 0])
+        return IntegralFluxPoints.from_arrays(self._ebounds, flux, flux_err[:, 1],
+                                              flux_err[:, 0])
 
     def _get_flux_values(self, prefix='Flux', unit='cm-2 s-1'):
         if prefix not in ['Flux', 'Unc_Flux', 'nuFnu']:

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -3,12 +3,13 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import tarfile
+import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils.data import download_file
 from astropy.units import Quantity
 from ..utils.energy import EnergyBounds
-from ..spectrum import DifferentialFluxPoints, IntegralFluxPoints
+from ..spectrum import DifferentialFluxPoints, IntegralFluxPoints, SpectrumFitResult
 from ..spectrum.models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
                                ExponentialCutoffPowerLaw3FGL, LogParabola)
 from ..spectrum.powerlaw import power_law_flux

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -9,7 +9,8 @@ from astropy.utils.data import download_file
 from astropy.units import Quantity
 from ..utils.energy import EnergyBounds
 from ..spectrum import DifferentialFluxPoints, IntegralFluxPoints
-from ..spectrum.models import PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw, LogParabola
+from ..spectrum.models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
+                               ExponentialCutoffPowerLaw3FGL, LogParabola)
 from ..spectrum.powerlaw import power_law_flux
 from ..datasets import gammapy_extra
 from .core import SourceCatalog, SourceCatalogObject
@@ -255,8 +256,8 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
         elif spec_type == 'PLExpCutoff':
             pars['index'] = Quantity(self.data['Spectral_Index'], '')
-            pars['lambda_'] = Quantity(1. / self.data['Cutoff'], 'MeV-1')
-            return ExponentialCutoffPowerLaw(**pars)
+            pars['ecut'] = Quantity(self.data['Cutoff'], 'MeV')
+            return ExponentialCutoffPowerLaw3FGL(**pars)
 
         elif spec_type == 'LogParabola':
             pars['alpha'] = Quantity(self.data['Spectral_Index'], '')

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -4,14 +4,15 @@ from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from ..fermi import SourceCatalog3FGL, SourceCatalog2FHL
-from ...spectrum.models import PowerLaw, ExponentialCutoffPowerLaw, LogParabola
+from ...spectrum.models import (PowerLaw, ExponentialCutoffPowerLaw, LogParabola,
+                                ExponentialCutoffPowerLaw3FGL)
 from ...utils.testing import requires_data
 
 
 
 MODEL_TEST_DATA = [(0, PowerLaw, Quantity(1.4351261e-9, 'GeV-1 s -1 cm-2')),
                    (4, LogParabola, Quantity(8.3828599e-10, 'GeV-1 s -1 cm-2')),
-                   (55, ExponentialCutoffPowerLaw, Quantity(7.4397387e-10, 'GeV-1 s -1 cm-2'))]
+                   (55, ExponentialCutoffPowerLaw3FGL, Quantity(1.8666925e-09, 'GeV-1 s-1 cm-2'))]
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog3FGL:
@@ -67,9 +68,9 @@ class TestFermi3FGLObject:
 
         assert len(flux_points) == 5
 
-        desired = [5.10239849e-03, 4.79114673e-04, 3.81966743e-05,
-                   2.09147089e-06, 8.16878884e-09]
-        assert_allclose(flux_points['DIFF_FLUX'], desired)
+        desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06,
+                   1.308784e-08]
+        assert_allclose(flux_points['DIFF_FLUX'].data, desired, rtol=1E-5)
 
 
 

--- a/gammapy/spectrum/butterfly.py
+++ b/gammapy/spectrum/butterfly.py
@@ -50,7 +50,10 @@ class SpectrumButterfly(QTable):
         ax.fill_between(energy.value, y_lo.value, y_hi.value, where=where, **kwargs)
 
         ax.set_xlabel('Energy [{}]'.format(self['energy'].unit))
-        ax.set_ylabel('Flux [{}]'.format(y_lo.unit))
+        if energy_power > 0:
+            ax.set_ylabel('E{0} * Flux [{1}]'.format(energy_power, y_lo.unit))
+        else:
+            ax.set_ylabel('Flux [{}]'.format(y_lo.unit))
         ax.set_xscale("log", nonposx='clip')
         ax.set_yscale("log", nonposy='clip')
         return ax

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -105,6 +105,7 @@ class DifferentialFluxPoints(Table):
         yerr = (y_lo.value[~is_ul], y_hi.value[~is_ul])
         xerr = (energy_lo.value[~is_ul], energy_hi.value[~is_ul])
 
+        kwargs.setdefault('marker', 'None')
         ax.errorbar(energy.value[~is_ul], y.value[~is_ul],
                     yerr=yerr, xerr=xerr, **kwargs)
 
@@ -122,7 +123,10 @@ class DifferentialFluxPoints(Table):
         ax.errorbar(energy.value[is_ul], 2 * y_hi.value[is_ul], xerr=xerr, **kwargs)
 
         ax.set_xlabel('Energy [{}]'.format(energy_unit))
-        ax.set_ylabel('Flux [{}]'.format(flux_unit))
+        if energy_power > 0:
+            ax.set_ylabel('E{0} * Flux [{1}]'.format(energy_power, yunit))
+        else:
+            ax.set_ylabel('Flux [{}]'.format(yunit))
         ax.set_xscale("log", nonposx='clip')
         ax.set_yscale("log", nonposy='clip')
         return ax

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -89,7 +89,9 @@ class DifferentialFluxPoints(Table):
         energy_lo = self['ENERGY_ERR_LO'].quantity.to(energy_unit)
 
         flux = self['DIFF_FLUX'].quantity.to(flux_unit)
-        flux_lo = self['DIFF_FLUX_ERR_LO'].quantity.to(flux_unit)
+
+        # lower flux error is stored with negative sign, account for that
+        flux_lo = np.abs(self['DIFF_FLUX_ERR_LO'].quantity.to(flux_unit))
         flux_hi = self['DIFF_FLUX_ERR_HI'].quantity.to(flux_unit)
 
         eunit = [_ for _ in flux.unit.bases if _.physical_type == 'energy'][0]
@@ -288,7 +290,8 @@ def compute_differential_flux_points(x_method='lafferty', y_method='power_law',
         energy_max = np.asanyarray(table['ENERGY_MAX'])
         int_flux = np.asanyarray(table['INT_FLUX'])
         try:
-            int_flux_err = np.asanyarray(table['INT_FLUX_ERR'])
+            int_flux_err_hi = np.asanyarray(table['INT_FLUX_ERR_HI'])
+            int_flux_err_lo = np.asanyarray(table['INT_FLUX_ERR_LO'])
         except:
             pass
     # Compute x point

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -138,7 +138,10 @@ class SpectralModel(object):
 
         ax.plot(energy.value, y.value, **kwargs)
         ax.set_xlabel('Energy [{}]'.format(energy.unit))
-        ax.set_ylabel('Flux [{}]'.format(y.unit))
+        if energy_power > 0:
+            ax.set_ylabel('E{0} * Flux [{1}]'.format(energy_power, y.unit))
+        else:
+            ax.set_ylabel('Flux [{}]'.format(y.unit))
         ax.set_xscale("log", nonposx='clip')
         ax.set_yscale("log", nonposy='clip')
         return ax

--- a/gammapy/spectrum/sed.py
+++ b/gammapy/spectrum/sed.py
@@ -301,7 +301,7 @@ def cube_sed(cube, mask=None, flux_type='differential', counts=None,
     if errors:
         if counts is None:
             # Counts cube required to calculate poisson errors
-            errors = np.ones_like([values]) * standard_error
+            errors = np.ones_like(values) * standard_error
         else:
             errors = []
             for i in np.arange(counts.data.shape[0]):
@@ -311,17 +311,17 @@ def cube_sed(cube, mask=None, flux_type='differential', counts=None,
                     bin = counts.data[i][mask].sum()
                 r_error = 1. / (np.sqrt(bin.value))
                 errors.append(r_error)
-            errors = np.array([errors])
+            errors = np.array(errors)
     else:
-        errors = np.zeros_like([values])
+        errors = np.zeros_like(values)
 
     if flux_type == 'differential':
         energy = cube.energy
         table = Table()
-        table['ENERGY'] = energy,
-        table['DIFF_FLUX'] = Quantity(values, cube.data.unit),
+        table['ENERGY'] = energy
+        table['DIFF_FLUX'] = Quantity(values, cube.data.unit)
         table['DIFF_FLUX_ERR_HI'] = Quantity(errors * values, cube.data.unit)
-        table['DIFF_FLUX_ERR_LO'] = -Quantity(errors * values, cube.data.unit)
+        table['DIFF_FLUX_ERR_LO'] = Quantity(-errors * values, cube.data.unit)
 
     elif flux_type == 'integral':
 

--- a/gammapy/spectrum/sed.py
+++ b/gammapy/spectrum/sed.py
@@ -320,7 +320,8 @@ def cube_sed(cube, mask=None, flux_type='differential', counts=None,
         table = Table()
         table['ENERGY'] = energy,
         table['DIFF_FLUX'] = Quantity(values, cube.data.unit),
-        table['DIFF_FLUX_ERR'] = Quantity(errors * values, cube.data.unit)
+        table['DIFF_FLUX_ERR_HI'] = Quantity(errors * values, cube.data.unit)
+        table['DIFF_FLUX_ERR_LO'] = -Quantity(errors * values, cube.data.unit)
 
     elif flux_type == 'integral':
 
@@ -331,7 +332,8 @@ def cube_sed(cube, mask=None, flux_type='differential', counts=None,
                                                  spectral_index=spectral_index,
                                                  energy_min=emins, energy_max=emaxs,
                                                  int_flux=values,
-                                                 int_flux_err=errors * values)
+                                                 int_flux_err_hi=errors * values,
+                                                 int_flux_err_lo=-errors * values)
 
     else:
         raise ValueError('Unknown flux_type: {0}'.format(flux_type))

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -110,7 +110,8 @@ def test_array_broadcasting(index, x_method, y_method):
                                              energy_min=energy_min,
                                              energy_max=energy_max,
                                              int_flux=int_flux,
-                                             int_flux_err=int_flux_err)
+                                             int_flux_err_hi=int_flux_err,
+                                             int_flux_err_lo=int_flux_err,)
     # Check output sized
     energy = table['ENERGY']
     actual = len(energy)
@@ -165,7 +166,8 @@ def test_compute_differential_flux_points(x_method, y_method):
         int_flux = int_flux_model(energy_min, energy_max)
     int_flux_err = 0.1 * int_flux
     table['INT_FLUX'] = int_flux
-    table['INT_FLUX_ERR'] = int_flux_err
+    table['INT_FLUX_ERR_HI'] = int_flux_err
+    table['INT_FLUX_ERR_LO'] = -int_flux_err
 
     result_table = compute_differential_flux_points(x_method,
                                                     y_method,
@@ -180,7 +182,7 @@ def test_compute_differential_flux_points(x_method, y_method):
     actual = result_table['DIFF_FLUX'].data
     assert_allclose(actual, desired, rtol=1e-2)
     # Test error
-    actual = result_table['DIFF_FLUX_ERR'].data
+    actual = result_table['DIFF_FLUX_ERR_HI'].data
     desired = 0.1 * result_table['DIFF_FLUX'].data
     assert_allclose(actual, desired, rtol=1e-3)
 

--- a/gammapy/spectrum/tests/test_sed.py
+++ b/gammapy/spectrum/tests/test_sed.py
@@ -127,15 +127,15 @@ def test_cube_sed1():
 
     sed_table1 = cube_sed(spec_cube, mask, flux_type='differential')
     assert_allclose(sed_table1['DIFF_FLUX'].data, 2560)  # * np.ones(30))
-    assert_allclose(sed_table1['DIFF_FLUX_ERR'].data, 0)
+    assert_allclose(sed_table1['DIFF_FLUX_ERR_HI'].data, 0)
 
     sed_table2 = cube_sed(spec_cube, mask, flux_type='differential',
                           errors=True, standard_error=0.1)
-    assert_allclose(sed_table2['DIFF_FLUX_ERR'].data, 256)
+    assert_allclose(sed_table2['DIFF_FLUX_ERR_HI'].data, 256)
 
     sed_table3 = cube_sed(spec_cube, mask, flux_type='differential',
                           errors=True, counts=counts)
-    assert_allclose(sed_table3['DIFF_FLUX_ERR'].data, 2560 * np.sqrt(1. / 256))
+    assert_allclose(sed_table3['DIFF_FLUX_ERR_HI'].data, 2560 * np.sqrt(1. / 256))
 
 
 @requires_data('gammapy-extra')
@@ -158,16 +158,16 @@ def test_cube_sed2():
 
     assert_allclose(sed_table1['ENERGY'][0], 56.95239033587774)
     assert_allclose(sed_table1['DIFF_FLUX'][0], 170.86224025271986)
-    assert_allclose(sed_table1['DIFF_FLUX_ERR'], 0)
+    assert_allclose(sed_table1['DIFF_FLUX_ERR_HI'], 0)
 
     sed_table2 = cube_sed(spec_cube, mask, flux_type='integral',
                           errors=True, standard_error=0.1)
 
-    assert_allclose(sed_table2['DIFF_FLUX_ERR'][0],
+    assert_allclose(sed_table2['DIFF_FLUX_ERR_HI'][0],
                     0.1 * sed_table2['DIFF_FLUX'][0])
 
     sed_table3 = cube_sed(spec_cube, mask, flux_type='integral',
                           errors=True, counts=counts)
 
-    assert_allclose(sed_table3['DIFF_FLUX_ERR'][0],
+    assert_allclose(sed_table3['DIFF_FLUX_ERR_HI'][0],
                     np.sqrt(1. / 256) * sed_table3['DIFF_FLUX'][0])


### PR DESCRIPTION
This PR implements all what's needed to plot Fermi 2FHL and 3FGL spectra including best fit model,
butterfly and flux points:

* change to  `ExponentialCutoffPowerLaw3FGL`
* add `.spectrum` properties to `SourceCatalogObject3FGL` and `SourceCatalogObject3FGL`
* allow asymmetrical flux errors in `compute_differential_flux_points`
* add an example to the docs 