### PR TITLE
Add Sherpa Python 3 build on travis-ci

### DIFF
--- a/gammapy/irf/psf_core.py
+++ b/gammapy/irf/psf_core.py
@@ -17,6 +17,7 @@ by issueing center_psf()
 from __future__ import absolute_import, division, print_function, unicode_literals
 import json
 import numpy as np
+from astropy.extern import six
 from astropy.convolution import Gaussian2DKernel
 from astropy.io import fits
 from astropy.stats import gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm
@@ -63,7 +64,7 @@ class SherpaMultiGaussPSF(object):
             # elif isinstance(source, HESS):
             # Get pars dict by from HESS object
             # self.pars = source.to_sherpa()
-        elif isinstance(source, (str, unicode)):
+        elif isinstance(source, six.string_types):
             # Assume it is a JSON filename
             fh = open(source)
             self.pars = json.load(fh)


### PR DESCRIPTION
Since yesterday, Sherpa master supports Python 3.
- [ ] Add Sherpa Python 3 build that builds sherpa from source on travis-ci
- [ ] Change the main build that measures coverage to Python 3.5 on travis-ci
- [x] Fix this test fail in `gammapy/scripts/tests/test_image_fit.py`: [gist](https://gist.github.com/cdeil/147d8c7ace94bceba9eb39d20d9b69d7)
- [x] Fix this test fail in `gammapy/spectrum/tests/test_fit.py`: [gist](https://gist.github.com/cdeil/a96000e2471c40cedf89532535d38eab)

@joleroi - Any thoughts about the `gammapy/spectrum/tests/test_fit.py` fail?
