### PR TITLE
Change from deprecated build_sphinx to new build_docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,10 @@ matrix:
 
         # Build docs
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
+          env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
+          env: PYTHON_VERSION=3.5 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES_WO_SHERPA
 
         # Run tests without GAMMAPY_EXTRA available
@@ -103,12 +103,6 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
-        - os: linux
-          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES_WO_SHERPA
 
         # Test with with optional dependencies disabled
         - os: linux

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 	@echo '     python setup.py develop'
 	@echo '     python setup.py test -V'
 	@echo '     python setup.py test --help # to see available options'
-	@echo '     python setup.py build_sphinx # use `-l` for clean build'
+	@echo '     python setup.py build_docs # use `-l` for clean build'
 	@echo ''
 	@echo ' More info:'
 	@echo ''

--- a/dev/docker/commands.sh
+++ b/dev/docker/commands.sh
@@ -29,7 +29,7 @@ chmod +x miniconda.sh
 export PATH=/home/travis/miniconda/bin:$PATH
 conda update --yes conda
 sudo apt-get update
-if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+if [[ $SETUP_CMD == build_docs* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export TRAVIS_PYTHON_VERSION=2.7.8; fi
 conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
 source activate test
@@ -41,9 +41,9 @@ if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA
 if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL scipy scikit-image pandas; fi
 if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL uncertainties; fi
 if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+http://github.com/astrofrog/reproject.git#egg=reproject; fi
-if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib scipy; fi
-if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL linkchecker; fi
-if [[ $SETUP_CMD == build_sphinx* ]]; then $PIP_INSTALL aplpy; fi
+if [[ $SETUP_CMD == build_docs* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib scipy; fi
+if [[ $SETUP_CMD == build_docs* ]]; then $PIP_INSTALL linkchecker; fi
+if [[ $SETUP_CMD == build_docs* ]]; then $PIP_INSTALL aplpy; fi
 if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
 python setup.py $SETUP_CMD
-if [[ $SETUP_CMD == build_sphinx* ]]; then linkchecker docs/_build/html; fi
+if [[ $SETUP_CMD == build_docs* ]]; then linkchecker docs/_build/html; fi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@
 # done. If the sys.path entry above is added, when the astropy.sphinx.conf
 # import occurs, it will import the *source* version of astropy instead of the
 # version installed (if invoked as "make html" or directly with sphinx), or the
-# version in the build directory (if "python setup.py build_sphinx" is used).
+# version in the build directory (if "python setup.py build_docs" is used).
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -59,9 +59,9 @@ such as Sphinx warnings or import errors or code that works locally because it u
 on travis-ci or for other developers.
 
 * The ``build`` folder is where ``python setup.py build`` or ``python setup.py install`` generate files.
-* The ``docs/api`` folder is where ``python setup.py build_sphinx`` generates [RST]_ files from the docstrings
+* The ``docs/api`` folder is where ``python setup.py build_docs`` generates [RST]_ files from the docstrings
   (temporary files part of the HTML documentation generation).
-* The  ``docs/_build`` folder is where ``python setup.py build_sphinx`` generates the HTML and other Sphinx
+* The  ``docs/_build`` folder is where ``python setup.py build_docs`` generates the HTML and other Sphinx
   documentation output files.
 * The ``htmlcov`` folder is where ``python setup.py test --coverage`` generates the HTML coverage report.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[build_sphinx]
+[build_docs]
 source-dir = docs
 build-dir = docs/_build
 all_files = 1


### PR DESCRIPTION
The `build_sphinx` command has been deprecated in `astropy-helpers`.
This PR changes to the new equivalent command (that has existed for a long time) of `build_docs`.