### PR TITLE
Add new module for spectrum energy grouping

### DIFF
--- a/gammapy/spectrum/__init__.py
+++ b/gammapy/spectrum/__init__.py
@@ -8,6 +8,7 @@ from .observation import *
 from .cosmic_ray import *
 from .crab import *
 from .diffuse import *
+from .energy_group import *
 from .fitter import *
 from .fitting_utils import *
 from .flux_point import *

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -1,0 +1,72 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.units import Quantity
+from ..data import ObservationStats
+from .observation import SpectrumObservation
+
+__all__ = [
+    'calculate_flux_point_binning',
+]
+
+
+def calculate_flux_point_binning(obs_list, min_signif):
+    """Compute energy binning.
+
+    This is useful to get an energy binning to use with
+    :func:`~gammapy.spectrum.DifferentialFluxPoints.compute` Each bin in the
+    resulting energy binning will include a ``min_signif`` source detection.
+
+    TODO: It is required that at least two fine bins be included in one
+    flux point interval, otherwise the sherpa covariance method breaks
+    down.
+
+    Parameters
+    ----------
+    obs_list : `~gammapy.spectrum.SpectrumObservationList`
+        Observations
+    min_signif : float
+        Required significance for each bin
+
+    Returns
+    -------
+    binning : `~astropy.units.Quantity`
+        Energy binning
+    """
+    # NOTE: Results may vary from FitSpectrum since there the rebin
+    # parameter can only have fixed values, here it grows linearly. Also it
+    # has to start at 2 here (see docstring)
+
+    # rebin_factor = 1
+    rebin_factor = 2
+
+    obs = SpectrumObservation.stack(obs_list)
+
+    # First first bin above low threshold and last bin below high threshold
+    current_ebins = obs.on_vector.energy
+    current_bin = (current_ebins.find_node(obs.lo_threshold) + 1)[0]
+    max_bin = (current_ebins.find_node(obs.hi_threshold))[0]
+
+    # List holding final energy binning
+    binning = [current_ebins.data[current_bin]]
+
+    # Precompute ObservationStats for each bin
+    obs_stats = [obs.stats(i) for i in range(current_ebins.nbins)]
+    while current_bin + rebin_factor <= max_bin:
+        # Merge bins together until min_signif is reached
+        stats_list = obs_stats[current_bin:current_bin + rebin_factor:1]
+        stats = ObservationStats.stack(stats_list)
+        sigma = stats.sigma
+        if sigma < min_signif or np.isnan(sigma):
+            rebin_factor += 1
+            continue
+
+        # Append upper bin edge of good energy bin to final binning
+        binning.append(current_ebins.data[current_bin + rebin_factor])
+        current_bin += rebin_factor
+
+    binning = Quantity(binning)
+    # Replace highest bin edge by high threshold
+    binning[-1] = obs.hi_threshold
+
+    return binning

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -1,0 +1,20 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from astropy.units import Quantity
+from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import requires_dependency, requires_data
+from ...datasets import gammapy_extra
+from ...spectrum import (
+    calculate_flux_point_binning,
+    SpectrumObservation,
+)
+
+
+@requires_data('gammapy-extra')
+@requires_dependency('scipy')
+def test_flux_points_binning():
+    phafile = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23523.fits")
+    obs = SpectrumObservation.read(phafile)
+    energy_binning = calculate_flux_point_binning(obs_list=[obs], min_signif=3)
+    assert_quantity_allclose(energy_binning[5], Quantity(1.668, 'TeV'), rtol=1e-3)

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -4,12 +4,9 @@ from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
-from ...datasets import gammapy_extra
 from ...spectrum import (
     LogEnergyAxis,
     integrate_spectrum,
-    calculate_flux_point_binning,
-    SpectrumObservation,
 )
 from ..powerlaw import power_law_energy_flux, power_law_evaluate, power_law_flux
 
@@ -29,16 +26,6 @@ def test_LogEnergyAxis():
 
     world = energy_axis.pix2world(pix)
     assert_quantity_allclose(world, energy)
-
-
-@requires_data('gammapy-extra')
-@requires_dependency('scipy')
-def test_flux_points_binning():
-
-    phafile = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23523.fits")
-    obs = SpectrumObservation.read(phafile)
-    energy_binning = calculate_flux_point_binning(obs_list=[obs], min_signif=3)
-    assert_quantity_allclose(energy_binning[5], Quantity(1.668, 'TeV'), rtol=1e-3)
 
 
 def test_integrate_spectrum():

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -2,12 +2,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.units import Quantity
-from gammapy.data import ObservationStats
 
 __all__ = [
     'LogEnergyAxis',
     'calculate_predicted_counts',
-    'calculate_flux_point_binning',
     'integrate_spectrum',
 ]
 
@@ -169,69 +167,6 @@ def calculate_predicted_counts(model, aeff, edisp, livetime, e_reco=None):
     reco_counts = edisp.apply(counts, e_reco=e_reco)
     e_reco = e_reco or edisp.e_reco.data
     return CountsSpectrum(data=reco_counts, energy=e_reco)
-
-
-def calculate_flux_point_binning(obs_list, min_signif):
-    """Compute energy binning
-
-    This is usefule to get an energy binning to use with
-    :func:`~gammapy.spectrum.DifferentialFluxPoints.compute` Each bin in the
-    resulting energy binning will include a ``min_signif`` source detection. 
-
-    TODO: It is required that at least two fine bins be included in one
-    flux point interval, otherwise the sherpa covariance method breaks
-    down.
-
-    Parameters
-    ----------
-    obs_list : `~gammapy.spectrum.SpectrumObservationList`
-        Observations
-    min_signif : float
-        Required significance for each bin
-
-    Returns
-    -------
-    binning : `~astropy.units.Quantity` 
-        Energy binning
-    """
-    from . import SpectrumObservation
-    # NOTE: Results may vary from FitSpectrum since there the rebin
-    # parameter can only have fixed values, here it grows linearly. Also it
-    # has to start at 2 here (see docstring)
-
-    # rebin_factor = 1
-    rebin_factor = 2
-    
-    obs = SpectrumObservation.stack(obs_list)
-
-    # First first bin above low threshold and last bin below high threshold
-    current_ebins = obs.on_vector.energy
-    current_bin = (current_ebins.find_node(obs.lo_threshold) + 1)[0]
-    max_bin = (current_ebins.find_node(obs.hi_threshold))[0]
-
-    # List holding final energy binning
-    binning = [current_ebins.data[current_bin]]
-
-    # Precompute ObservationStats for each bin
-    obs_stats = [obs.stats(i) for i in range(current_ebins.nbins)]
-    while(current_bin + rebin_factor <= max_bin):
-        # Merge bins together until min_signif is reached
-        stats_list = obs_stats[current_bin:current_bin + rebin_factor:1]
-        stats = ObservationStats.stack(stats_list)
-        sigma = stats.sigma
-        if (sigma < min_signif or np.isnan(sigma)):
-            rebin_factor += 1
-            continue
-
-        # Append upper bin edge of good energy bin to final binning
-        binning.append(current_ebins.data[current_bin + rebin_factor])
-        current_bin += rebin_factor
-
-    binning = Quantity(binning)
-    # Replace highest bin edge by high threshold
-    binning[-1] = obs.hi_threshold
-
-    return binning
 
 
 def integrate_spectrum(func, xmin, xmax, ndecade=100, intervals=False):


### PR DESCRIPTION
This pull request
- [x] introduces `gammapy/spectrum/energy_group.py` and moves the `calculate_flux_point_binning` function which was in `gammapy/spectrum/utils.py` there.
- [ ] renames `gammapy/spectrum/group.py` to `gammapy/spectrum/obs_group.py` to make the distinction between grouping energy bins or observations clear.

I will then implement energy bin grouping methods, probably in a follow-up PR to have a small diff that can be easily reviewed.

@joleroi - OK?