### PR TITLE
Remove arithmetic from CountsSpectrum

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -101,25 +101,6 @@ class CountsSpectrum(NDDataArray):
         """
         return self.data.sum()
 
-    def __add__(self, other):
-        """Add two counts spectra and returns new instance
-
-        The two spectra need to have the same binning
-        """
-        if (self.energy.data != other.energy.data).all():
-            raise ValueError("Cannot add counts spectra with different binning")
-        counts = self.data + other.data
-        return CountsSpectrum(data=counts, energy=self.energy)
-
-    def __mul__(self, other):
-        """Scale counts by a factor"""
-        temp = self.data * other
-        return CountsSpectrum(data=temp, energy=self.energy)
-
-    def __sub__(self, other):
-        """Subtract two CountsSpectra"""
-        return self.__add__(other.__mul__(-1))
-
     def plot(self, ax=None, energy_unit='TeV', show_poisson_errors=False,
              show_energy=None, **kwargs):
         """Plot as datapoint

--- a/gammapy/spectrum/tests/test_counts_spectrum.py
+++ b/gammapy/spectrum/tests/test_counts_spectrum.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numpy as np
-from numpy.testing import assert_equal, assert_allclose
+from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from ...utils.testing import requires_data, requires_dependency
@@ -33,16 +32,5 @@ def test_CountsSpectrum(tmpdir):
     filename = tmpdir / 'test.fits'
     spec.write(filename)
     spec2 = CountsSpectrum.read(filename)
-    assert_quantity_allclose(spec2.energy.data,
-                             EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV'))
-
-    # Add, Sub, Mult
-    energy = np.logspace(0, 1, 5) * u.TeV
-    spec1 = CountsSpectrum(data=np.arange(4), energy=energy)
-    spec2 = CountsSpectrum(data=np.arange(4, 8), energy=energy)
-
-    spec_sum = np.sum([spec1, spec2]) * 2
-    spec_diff = spec2 - spec1
-
-    assert_equal(spec_sum.data[1], 12)
-    assert_equal(spec_diff.data[1], 4)
+    expected = EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV')
+    assert_quantity_allclose(spec2.energy.data, expected)

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest, assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...spectrum import SpectrumObservation, models
 
@@ -34,9 +34,9 @@ class TestSpectrumObservation:
         npred1.data[np.nonzero(self.obs.on_vector.quality)] = 0
         npred2.data[np.nonzero(self.obs2.on_vector.quality)] = 0
 
-        npred_summed = npred1 + npred2
+        npred_summed = npred1.data + npred2.data
 
-        assert_allclose(npred_stacked.data, npred_summed.data)
+        assert_allclose(npred_stacked.data, npred_summed)
 
     def test_stats_table(self):
         table = self.obs.stats_table()


### PR DESCRIPTION
@joleroi - Can we remove arithmetic methods (`__mul__`, `__add__`, ...) from `CountsSpectrum`, please?
https://github.com/gammapy/gammapy/blob/85832ae599bac466f69b675aa1096534e3c11572/gammapy/spectrum/core.py#L114

I think if we do it there, we'd have to do it in many places and would have to write a lot of boilerplate code and tests, without much gain. See  https://github.com/gammapy/gammapy/pull/713#discussion_r79771141 where I suggested to not add it to `SkyImage`.

I can do it here and fix up users / tests for this, but I wanted to ask if it's OK before making the PR.