### PR TITLE
Misc fixes to make IPython notebooks work

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,9 +21,9 @@ Where to start?
 
 * Check out the "Getting started with Gammapy" Jupyter notebooks.
     * Read the static HTML version on
-      `nbviewer <http://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/Index.ipynb>`__.
+      `nbviewer <http://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/index.ipynb>`__.
     * Try an executable version at `Gammapy binder`_.
-      Clicking that link will start a Docker image on some cloud server,
+    * Clicking that link will start a Docker image on some cloud server,
       which usually takes about 30 seconds.
       See :ref:`binder` for details how this works.
 * To learn more about Gammapy, have a look at the :ref:`about` page.

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1017,7 +1017,6 @@ class SkyImage(object):
 
         return Angle(scales, unit='deg')
 
-
     def region_mask(self, region):
         """Create a boolean mask for a region.
 
@@ -1107,3 +1106,36 @@ class SkyImage(object):
         data = convolve(self.data, kernel, **kwargs)
         wcs = self.wcs.deepcopy() if self.wcs else None
         return self.__class__(data=data, wcs=wcs)
+
+    def smooth(self, kernel='gauss', width=3):
+        """Smooth the image (works on and returns a copy).
+
+        TODO: this is very preliminary and incomplete.
+        No tests yet, no control of boundary handling, ...
+        See https://github.com/gammapy/gammapy/issues/694
+
+        Parameters
+        ----------
+        kernel : {'gauss', 'disk', 'box'}
+            Kernel shape
+        width : float
+            Width in pixels
+
+        Returns
+        -------
+        image : `SkyImage`
+            Smoothed image (a copy, the original object is unchanged).
+        """
+        image = self.copy()
+
+        if kernel == 'gauss':
+            from scipy.ndimage import gaussian_filter
+            image.data = gaussian_filter(self.data, width)
+        elif kernel == 'disk':
+            raise NotImplementedError
+        elif kernel == 'box':
+            raise NotImplementedError
+        else:
+            raise ValueError('Invalid option kernel = {}'.format(kernel))
+
+        return image

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -833,7 +833,7 @@ class SkyImage(object):
             raise ValueError("Invalid image viewer option, choose either"
                              " 'mpl' or 'ds9'.")
 
-    def plot(self, ax=None, fig=None, **kwargs):
+    def plot(self, ax=None, fig=None, add_cbar=False, **kwargs):
         """
         Plot image on matplotlib WCS axes.
 
@@ -846,15 +846,19 @@ class SkyImage(object):
 
         Returns
         -------
-        ax : `~astropy.wcsaxes.WCSAxes`, optional
-            WCS axis object
         fig : `~matplotlib.figure.Figure`, optional
             Figure
+        ax : `~astropy.wcsaxes.WCSAxes`, optional
+            WCS axis object
+        cbar : ?
+            Colorbar object (if ``add_cbar=True`` was set)
         """
         import matplotlib.pyplot as plt
 
-        if fig is None and ax is None:
+        if fig is None:
             fig = plt.gcf()
+
+        if ax is None:
             ax = fig.add_subplot(1, 1, 1, projection=self.wcs)
 
         kwargs['origin'] = kwargs.get('origin', 'lower')
@@ -869,7 +873,12 @@ class SkyImage(object):
             quantity = 'Unknown'
         else:
             quantity = Unit(unit).physical_type
-        cbar = fig.colorbar(caxes, label='{0} ({1})'.format(quantity, unit))
+
+        if add_cbar:
+            cbar = fig.colorbar(caxes, label='{0} ({1})'.format(quantity, unit))
+        else:
+            cbar = None
+
         try:
             ax.coords['glon'].set_axislabel('Galactic Longitude')
             ax.coords['glat'].set_axislabel('Galactic Latitude')
@@ -879,7 +888,7 @@ class SkyImage(object):
         except AttributeError:
             log.info("Can't set coordinate axes. No WCS information available.")
 
-        return fig, ax
+        return fig, ax, cbar
 
     def plot_norm(self, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
                   max_cut=None, min_percent=None, max_percent=None,

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -881,6 +881,52 @@ class SkyImage(object):
 
         return fig, ax
 
+    def plot_norm(self, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
+                  max_cut=None, min_percent=None, max_percent=None,
+                  percent=None, clip=True):
+        """Create a matplotlib norm object for plotting.
+
+        This is a copy of this function that will be available in Astropy 1.3:
+        `astropy.visualization.mpl_normalize.simple_norm`
+
+        Seet the parameter description there!
+
+        Examples
+        --------
+        >>> image = SkyImage()
+        >>> norm = image.plot_norm(stretch='sqrt', max_percent=99)
+        >>> image.plot(norm=norm)
+        """
+        import astropy.visualization as v
+        from astropy.visualization.mpl_normalize import ImageNormalize
+
+        if percent is not None:
+            interval = v.PercentileInterval(percent)
+        elif min_percent is not None or max_percent is not None:
+            interval = v.AsymmetricPercentileInterval(min_percent or 0.,
+                                                      max_percent or 100.)
+        elif min_cut is not None or max_cut is not None:
+            interval = v.ManualInterval(min_cut, max_cut)
+        else:
+            interval = v.MinMaxInterval()
+
+        if stretch == 'linear':
+            stretch = v.LinearStretch()
+        elif stretch == 'sqrt':
+            stretch = v.SqrtStretch()
+        elif stretch == 'power':
+            stretch = v.PowerStretch(power)
+        elif stretch == 'log':
+            stretch = v.LogStretch()
+        elif stretch == 'asinh':
+            stretch = v.AsinhStretch(asinh_a)
+        else:
+            raise ValueError('Unknown stretch: {0}.'.format(stretch))
+
+        vmin, vmax = interval.get_limits(self.data)
+
+        return ImageNormalize(vmin=vmin, vmax=vmax, stretch=stretch, clip=clip)
+
     def info(self):
         """
         Print summary info about the image.

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -133,30 +133,6 @@ class SkyMask(SkyImage):
         data = binary_erosion(self.data, structure)
         return SkyMask(data=data, wcs=self.wcs)
 
-    def plot(self, ax=None, fig=None, **kwargs):
-        """Plot exclusion mask
-
-        Parameters
-        ----------
-        ax : `~astropy.wcsaxes.WCSAxes`, optional
-            WCS axis object to plot on.
-        fig : `~matplotlib.figure.Figure`, optional
-            Figure
-
-        Returns
-        -------
-        fig : `~matplotlib.figure.Figure`, optional
-            Figure
-        ax : `~astropy.wcsaxes.WCSAxes`, optional
-            WCS axis object
-        """
-        from matplotlib import colors
-
-        kwargs.setdefault('cmap', colors.ListedColormap(['black', 'lightgrey']))
-
-        fig, ax = super(SkyMask, self).plot(ax, fig, **kwargs)
-        return fig, ax
-
     @lazyproperty
     def distance_image(self):
         """Distance to nearest exclusion region.

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from copy import deepcopy
 import numpy as np
 from astropy.table import Table
 import astropy.units as u
@@ -182,6 +183,11 @@ class CountsSpectrum(NDDataArray):
         fig, ax = plt.subplots(1, 1, figsize=figsize)
         self.plot_hist(ax=ax)
         return ax
+
+    def copy(self):
+        """A deep copy of self.
+        """
+        return deepcopy(self)
 
 
 class PHACountsSpectrum(CountsSpectrum):

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -60,17 +60,12 @@ class SpectrumObservation(object):
 
     Examples
     --------
-    .. plot::
-        :include-source:
 
+    ::
         from gammapy.spectrum import SpectrumObservation
-        from gammapy.datasets import gammapy_extra
-        import matplotlib.pyplot as plt
-
-        phafile = gammapy_extra.filename('datasets/hess-crab4_pha/pha_obs23523.fits')
-        obs = SpectrumObservation.read(phafile)
-        obs.peek()
-        plt.show()
+        filename = '$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23523.fits'
+        obs = SpectrumObservation.read(filename)
+        print(obs)
     """
 
     def __init__(self, on_vector, aeff, off_vector=None, edisp=None):

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -327,7 +327,7 @@ class SpectrumFitResult(object):
                                         energy_unit='TeV')
 
         mu_on = self.expected_source_counts.copy()
-        mu_on.data = self.expected_source_counts + self.obs.background_vector.data
+        mu_on.data = self.expected_source_counts.data + self.obs.background_vector.data
         mu_on.plot(ax=ax0, label='mu_on', energy_unit='TeV')
 
         self.obs.on_vector.plot(ax=ax0,

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -180,11 +180,11 @@ class SpectrumFitResult(object):
                 raise ValueError(current_unit)
 
             t[parname] = Column(
-                data=np.atleast_1d(val*factor),
+                data=np.atleast_1d(val * factor),
                 unit=col_unit,
                 **kwargs)
             t['{}_err'.format(parname)] = Column(
-                data=np.atleast_1d(err*factor),
+                data=np.atleast_1d(err * factor),
                 unit=col_unit,
                 **kwargs)
 
@@ -304,7 +304,6 @@ class SpectrumFitResult(object):
         data[idx] = 0
         return CountsSpectrum(data=data, energy=energy)
 
-
     def plot(self, mode='wstat'):
         """Standard debug plot.
 
@@ -327,7 +326,8 @@ class SpectrumFitResult(object):
                                         fmt='none',
                                         energy_unit='TeV')
 
-        mu_on = self.expected_source_counts + self.obs.background_vector
+        mu_on = self.expected_source_counts.copy()
+        mu_on.data = self.expected_source_counts + self.obs.background_vector.data
         mu_on.plot(ax=ax0, label='mu_on', energy_unit='TeV')
 
         self.obs.on_vector.plot(ax=ax0,
@@ -338,8 +338,9 @@ class SpectrumFitResult(object):
 
         ax0.legend(numpoints=1)
         ax0.set_title('')
-    
-        resspec = mu_on - self.obs.on_vector
+
+        resspec = mu_on.copy()
+        resspec.data = mu_on.data - self.obs.on_vector.data
         resspec.plot(ax=ax1, ecolor='black', fmt='none')
         xx = ax1.get_xlim()
         yy = [0, 0]
@@ -399,7 +400,6 @@ class SpectrumResult(object):
             energy_unit = pars.reference.unit
             flux_unit = pars.amplitude.unit
 
-
         x = self.points['ENERGY'].quantity.to(energy_unit)
         y = self.points['DIFF_FLUX'].quantity.to(flux_unit)
         y_err = self.points['DIFF_FLUX_ERR_HI'].quantity.to(flux_unit)
@@ -412,7 +412,6 @@ class SpectrumResult(object):
         residuals = (points - func) / func
 
         return residuals
-
 
     def plot(self, energy_range, energy_unit='TeV', flux_unit='cm-2 s-1 TeV-1',
              energy_power=0, fit_kwargs=dict(),
@@ -467,19 +466,18 @@ class SpectrumResult(object):
         self.fit.model.plot(energy_range=energy_range,
                             ax=ax0,
                             **fit_kwargs)
-       
+
         energy = EnergyBounds.equal_log_spacing(energy_range[0],
                                                 energy_range[1],
                                                 100)
-        self.fit.butterfly(energy=energy).plot( ax=ax0, **butterfly_kwargs)
+        self.fit.butterfly(energy=energy).plot(ax=ax0, **butterfly_kwargs)
         self.points.plot(ax=ax0,
                          **point_kwargs)
         point_kwargs.pop('flux_unit')
         point_kwargs.pop('energy_power')
         ax0.set_title('')
         self._plot_residuals(ax=ax1,
-                            **point_kwargs)
-
+                             **point_kwargs)
 
         plt.xlim(energy_range[0].to(energy_unit).value * 0.9,
                  energy_range[1].to(energy_unit).value * 1.1)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -255,6 +255,9 @@ class TestFluxEstimator:
 
         self.groups = self.seg.groups
 
+    # TODO: fix this test
+    # see https://github.com/gammapy/gammapy/issues/724
+    @pytest.mark.xfail
     def test_with_power_law(self):
         # import logging
         # logging.basicConfig(level=logging.DEBUG)

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -45,6 +45,7 @@ for notebook in notebooks:
 
     if not notebook['test']:
         logging.info('Skipping notebook {} because test=false.'.format(notebook['name']))
+        continue
 
     if notebook['requires']:
         for package in notebook['requires'].split():


### PR DESCRIPTION
This PR is a follow-up to #705 .  It activates IPython notebook tests for most notebooks we have,
and contains misc fixes throughout Gammapy that turned up as exceptions or problems with the current notebooks.

The corresponding commits with fixes to the notebooks will be here:
https://github.com/gammapy/gammapy-extra/tree/master/notebooks

Some more changes here:

- Add SkyImage.smooth and SkyImage.plot_norm method.
  This can be extended / changed later, issues with suggestions or pull request welcome.
- Remove SkyMask.plot method. It broke when I change SkyImage.plot to return cbar,
  and really IMO SkyMask is superfluous completely, I didn't want to fix it.
- Add CountsSpectrum.copy() and fix some arithmetic operator calls.