### PR TITLE
Use matplotlib agg backend when running tests

### DIFF
--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -52,3 +52,12 @@ def pytest_configure(config):
 
     var = os.environ.get('GAMMAPY_EXTRA', 'not set')
     print('GAMMAPY_EXTRA = {}'.format(var))
+
+    try:
+        # Switch to non-interactive plotting backend to avoid GUI windows
+        # popping up while running the tests.
+        import matplotlib
+        matplotlib.use('agg')
+        print('Setting matplotlib backend to "agg" for the tests.')
+    except ImportError:
+        pass

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -281,9 +281,8 @@ class SpectrumObservation(object):
     def peek(self, figsize=(15, 15)):
         """Quick-look summary plots."""
         import matplotlib.pyplot as plt
-        plt.style.use('ggplot')
 
-        fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=figsize)
+        fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(nrows=2, ncols=2, figsize=figsize)
 
         ax1.set_title('Counts')
         energy_unit = 'TeV'

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -534,7 +534,6 @@ def get_plot_axis(figsize=(15, 10)):
     """
     from matplotlib import gridspec
     import matplotlib.pyplot as plt
-    plt.style.use('ggplot')
     plt.figure(figsize=figsize)
 
     gs = gridspec.GridSpec(5, 1)


### PR DESCRIPTION
This pull request
- [x] forces the matplotlib agg backend when running tests (to avoid GUI windows popping up)
- [x] removes `matplotlib.style.use` calls from `gammapy.spectrum`. Setting the style should be left up to the user, or at least let the user explicitly set this. Changing the style from some library function is too inflexible / confusing.