### PR TITLE
Refactor reflected regions background estimation

### DIFF
--- a/gammapy/background/background_estimate.py
+++ b/gammapy/background/background_estimate.py
@@ -2,12 +2,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .ring import ring_area_factor
-from .reflected import find_reflected_regions
 
 __all__ = [
     'BackgroundEstimate',
     'ring_background_estimate',
-    'reflected_regions_background_estimate'
 ]
 
 
@@ -68,26 +66,3 @@ def ring_background_estimate(pos, on_radius, inner_radius, outer_radius, events)
     return BackgroundEstimate(off_region, off_events, a_on, a_off, tag='ring')
 
 
-def reflected_regions_background_estimate(on_region, pointing, exclusion,
-                                          events, **kwargs):
-    """Reflected regions background estimate
-
-    kwargs are forwaded to :func:`gammapy.background.find_reflected_regions`
-
-    Parameters
-    ----------
-    on_region : `~regions.CircleSkyRegion`
-        On region
-    pointing : `~astropy.coordinates.SkyCoord`
-        Pointing position
-    exclusion : `~gammapy.image.SkyImage`
-        Exclusion mask
-    events : `gammapy.data.EventList`
-        Events
-    """
-    off_region = find_reflected_regions(on_region, pointing, exclusion, **kwargs)
-    off_events = events.select_circular_region(off_region)
-    a_on = 1
-    a_off = len(off_region)
-
-    return BackgroundEstimate(off_region, off_events, a_on, a_off, tag='reflected')

--- a/gammapy/background/background_estimate.py
+++ b/gammapy/background/background_estimate.py
@@ -15,8 +15,7 @@ class BackgroundEstimate(object):
     This container holds the result from a region based background estimation
     for one observation. Currently, it is filled by the functions
     :func:`~gammapy.background.ring_background_estimate` and
-    :func:`~gammapy.background.reflected_regions_background_estimate`. At some
-    points this should be replaced by a more elaborate analysis class.
+    the `~gammapy.background.ReflectedRegionsBackgroundEstimator`. 
 
     Parameters
     ----------

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -4,10 +4,10 @@ from astropy.tests.helper import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
-from ..reflected import find_reflected_regions
+from ..reflected import find_reflected_regions, ReflectedRegionsBackgroundEstimator
 from ...image import SkyMask
 from ...utils.testing import requires_data, requires_dependency
-
+from ...data import Target, DataStore
 
 @pytest.fixture
 def mask():
@@ -15,15 +15,50 @@ def mask():
     filename = '$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits'
     return SkyMask.read(filename, hdu=1)
 
-
-@requires_dependency('scipy')
-@requires_data('gammapy-extra')
-def test_find_reflected_regions(mask):
+@pytest.fixture
+def on_region():
+    """Example on_region for testing."""
     pos = SkyCoord(80.2, 23.5, unit='deg', frame='icrs')
     radius = Angle(0.4, 'deg')
     region = CircleSkyRegion(pos, radius)
-    center = SkyCoord(83.2, 22.7, unit='deg', frame='icrs')
-    regions = find_reflected_regions(region, center, mask,
+    return region
+
+@pytest.fixture
+def obs_list():
+    """Example observation list for testing."""
+    DATA_DIR = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
+    datastore = DataStore.from_dir(DATA_DIR)
+    obs_ids = [23523, 23526]
+    return datastore.obs_list(obs_ids)
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_find_reflected_regions(mask, on_region):
+    pointing = SkyCoord(83.2, 22.7, unit='deg', frame='icrs')
+    regions = find_reflected_regions(region=on_region, center=pointing,
+                                     exclusion_mask=mask,
                                      min_distance_input=Angle('0 deg'))
     assert (len(regions)) == 20
     assert_quantity_allclose(regions[3].center.icrs.ra, Angle('81.752 deg'), rtol=1e-2)
+
+
+class TestReflectedRegionBackgroundEstimator:
+    def setup(self):
+        temp = ReflectedRegionsBackgroundEstimator(on_region = on_region(),
+                                                   exclusion = mask(),
+                                                   obs_list = obs_list())
+        self.bg_maker = temp
+
+    def test_basic(self):
+        assert 'ReflectedRegionsBackgroundEstimator' in str(self.bg_maker)
+
+    def test_process(self, on_region, obs_list, mask):
+        bg_estimate = self.bg_maker.process(on_region=on_region,
+                                            obs=obs_list[1],
+                                            exclusion=mask)
+        assert len(bg_estimate.off_region) == 22
+
+    def test_run(self):
+        self.bg_maker.config.update(min_distance = '0.2 deg')
+        self.bg_maker.run()
+        assert len(self.bg_maker.result[1].off_region) == 21

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -42,6 +42,8 @@ def test_find_reflected_regions(mask, on_region):
     assert_quantity_allclose(regions[3].center.icrs.ra, Angle('81.752 deg'), rtol=1e-2)
 
 
+@requires_data('gammapy-extra')
+@requires_dependency('scipy')
 class TestReflectedRegionBackgroundEstimator:
     def setup(self):
         temp = ReflectedRegionsBackgroundEstimator(on_region = on_region(),

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -202,6 +202,21 @@ class DataStore(object):
             data_store=self,
         )
 
+    def obs_list(self, obs_id):
+        """Generate a `~gammapy.data.ObservationList`.
+
+        Parameters
+        ----------
+        obs_id : list
+            Observation IDs.
+
+        Returns
+        -------
+        obs : `~gammapy.data.ObservationList`
+            List of `~gammapy.data.DataStoreObservation`
+        """
+        return ObservationList(self.obs(_) for _ in obs_id)
+
     def load_all(self, hdu_type=None, hdu_class=None):
         """Load a given file type for all observations
 
@@ -653,6 +668,12 @@ class ObservationList(UserList):
 
     Could be extended to hold a more generic class of observations
     """
+    def __str__(self):
+        s = self.__class__.__name__ + '\n'
+        s += 'Number of observations: {}\n'.format(len(self))
+        for obs in self:
+            s += str(obs)
+        return s
 
     def make_psf(self, position, energy=None, theta=None):
         """Make energy-dependent mean PSF for a given position and a set of observations.

--- a/gammapy/data/target.py
+++ b/gammapy/data/target.py
@@ -9,7 +9,6 @@ from ..stats import Stats
 
 __all__ = [
     'Target',
-    'TargetSummary',
 ]
 
 

--- a/gammapy/data/target.py
+++ b/gammapy/data/target.py
@@ -72,11 +72,6 @@ class Target(object):
         ss += "Observations: {}\n".format(len(self.obs_id))
         return ss
 
-    @property
-    def summary(self):
-        """`~gammapy.data.TargetSummary`"""
-        return TargetSummary(self)
-
     @classmethod
     def from_config(cls, config):
         """Initialize target from config

--- a/gammapy/data/target.py
+++ b/gammapy/data/target.py
@@ -16,13 +16,11 @@ __all__ = [
 class Target(object):
     """Observation Target.
 
-    This class represents an observation target. It serves as input for several
-    analysis classes, e.g. `~gammapy.spectrum.SpectrumExtraction` and
-    `~gammapy.data.TargetSummary`. Some analyses, e.g. background estimation,
-    are functions on the ``Target`` class, but should be refactored as separate
-    analysis classes. Each analysis class can add attributes to the ``Target``
-    instance in order to make some analysis steps, e.g. background estimation
-    reusable.
+    This class represents an observation target. It can serve as input for several
+    analysis classes, e.g. `~gammapy.spectrum.SpectrumExtraction`.
+
+    TODO: This is usefull for pipelines when you want to attach a tag to a
+    certain analysis. However, it does not do much. Should we keep it?
 
     Parameters
     ----------
@@ -58,33 +56,6 @@ class Target(object):
         Center:<SkyCoord (ICRS): (ra, dec) in deg
             (83.63, 22.01)>
         Radius:0.3 deg
-
-    Add data and background estimate
-
-    >>> from gammapy.data import DataStore
-    >>> store_dir = "$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2")
-    >>> data_store = DataStore.from_dir(store_dir)
-    >>> target.obs_id = [23523, 23592]
-    >>> target.add_obs_from_store(data_store)
-    >>> print(target.obs[0])
-    Info for OBS_ID = 23523
-    - Start time: 53343.92 s
-    - Pointing pos: RA 83.63 deg / Dec 21.51 deg
-    - Observation duration: 1687.0 s
-    - Dead-time fraction: 6.240 %
-    >>> target.estimate_background(method='ring', inner_radius=inner_radius, outer_radius=outer_radius)
-    >>> print(len(target.background[0].off_events))
-    37
-
-    Create `~gammapy.data.TargetSummary` and `~gammapy.stats.data.Stats`
-
-    >>> summary = target.summary
-    >>> type(summary)
-    <class 'gammapy.data.target.TargetSummary'>
-    >>> stats = summary.stats
-    >>> type(stats)
-    <class 'gammapy.stats.data.Stats'>
-
     """
 
     def __init__(self, on_region, position=None, obs_id=None, name='Target', tag='target'):
@@ -127,91 +98,3 @@ class Target(object):
                      name=config['name'], tag=config['tag'])
         target.config = config
         return target
-
-    def add_obs_from_store(self, data_store):
-        """Add a list of `~gammapy.data.DataStoreObservations`"""
-        if self.obs_id is None:
-            raise ValueError("No observations specified")
-        self.obs = [data_store.obs(_) for _ in self.obs_id]
-
-    # TODO: This should probably go into a separat BackgroundEstimator class
-    def estimate_background(self, method='ring', **kwargs):
-        """Wrapper for different background estimators"""
-
-        if method == 'ring':
-            from gammapy.background import ring_background_estimate as ring
-            pos = self.position
-            on_radius = self.on_region.radius
-            inner_radius = kwargs['inner_radius']
-            outer_radius = kwargs['outer_radius']
-            self.background = [ring(pos, on_radius, inner_radius, outer_radius,
-                                    _.events) for _ in self.obs]
-        elif method == 'reflected':
-            on_region = self.on_region
-            exclusion = kwargs['exclusion']
-            from gammapy.background import reflected_regions_background_estimate as refl
-            bkg = [refl(on_region, _.pointing_radec, exclusion,
-                        _.events) for _ in self.obs]
-            self.background = bkg
-        else:
-            raise NotImplementedError('{}'.format(method))
-
-    def run_spectral_analysis(self, outdir=None):
-        """Run spectral analysis
-
-        This runs a spectral analysis with the parameters attached as config
-        dict
-
-        Parameters
-        ----------
-        outdir : Path
-            Analysis dir
-        """
-        from . import DataStore
-        from ..image import SkyMask
-        from ..spectrum import SpectrumExtraction
-
-        conf = self.config
-        data_store = DataStore.from_all(conf['datastore'])
-        self.add_obs_from_store(data_store)
-        exclusion = SkyMask.read(conf['exclusion_mask']) or None
-        conf.update(exclusion=exclusion)
-        self.estimate_background(method=conf['background_method'], **conf)
-        # Use default energy binning
-        self.extraction = SpectrumExtraction(self)
-        self.extraction.run(outdir=outdir)
-
-
-class TargetSummary(object):
-    """Summary Info for an observation Target
-    
-    For an examples see `~gammapy.data.Target`
-
-    Parameters
-    ----------
-    target : `~gammapy.data.Target`
-        Observation target
-    """
-
-    def __init__(self, target):
-        self.target = target
-
-    @property
-    def stats(self):
-        """Total `~gammapy.stats.Stats`"""
-        if self.target.background is None:
-            raise ValueError("Need Background estimate for target")
-
-        idx = self.target.on_region.contains(self.events.radec)
-        on_events = self.events[idx]
-        n_on = len(on_events)
-
-        n_off = np.sum([len(_.off_events) for _ in self.target.background])
-        # FIXME : This is only true for the ring bg
-        bkg = self.target.background[0]
-        return Stats(n_on, n_off, bkg.a_on, bkg.a_off)
-
-    @property
-    def events(self):
-        """All events"""
-        return table_vstack([_.events for _ in self.target.obs])

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from regions import CircleSkyRegion
 from ...data import DataStore, ObservationList, ObservationStats, Target
 from ...utils.testing import requires_data, requires_dependency
-from ...background import reflected_regions_background_estimate as refl
+from ...background import ReflectedRegionsBackgroundEstimator
 from ...image import SkyMask
 
 
@@ -42,7 +42,9 @@ def mask():
 @pytest.fixture(scope='session')
 def stats(target, mask):
     obs = get_obs(23523)
-    bg = refl(target.on_region, obs.pointing_radec, mask, obs.events)
+    bg = ReflectedRegionsBackgroundEstimator.process(on_region = target.on_region,
+                                                     exclusion = mask,
+                                                     obs = obs)
     return ObservationStats.from_target(obs, target, bg)
 
 
@@ -51,7 +53,9 @@ def stats_stacked(target, mask):
     obs_list = get_obs_list()
     obs_stats = list()
     for obs in obs_list:
-        bg = refl(target.on_region, obs.pointing_radec, mask, obs.events)
+        bg = ReflectedRegionsBackgroundEstimator.process(on_region = target.on_region,
+                                                         exclusion = mask,
+                                                         obs = obs)
         obs_stats.append(ObservationStats.from_target(obs, target, bg))
 
     return ObservationStats.stack(obs_stats)

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -8,7 +8,7 @@ from ...data import DataStore, ObservationTableSummary, ObservationSummary
 from ...data import ObservationStats, ObservationStatsList, ObservationList
 from ...data import Target
 from ...utils.testing import requires_data, requires_dependency
-from ...background import reflected_regions_background_estimate as refl
+from ...background import ReflectedRegionsBackgroundEstimator
 from ...image import SkyMask
 
 
@@ -58,7 +58,9 @@ def obs_summary():
     obs_stats = ObservationStatsList()
 
     for index, run in enumerate(obs_list):
-        bkg = refl(on_region, run.pointing_radec, mask, run.events)
+        bkg = ReflectedRegionsBackgroundEstimator.process(on_region=on_region,
+                                                          obs=run,
+                                                          exclusion=mask)
 
         obs_stats.append(ObservationStats.from_target(run, target, bkg))
 

--- a/gammapy/data/tests/test_target.py
+++ b/gammapy/data/tests/test_target.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from .. import Target, TargetSummary
+from .. import Target
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from regions import CircleSkyRegion
@@ -15,14 +15,4 @@ def test_targetsummary(data_manager):
     on_region = CircleSkyRegion(pos, on_size)
     target = Target(on_region, name='Test Target', obs_id=[23523, 23592])
 
-    data_store = data_manager['hess-crab4-hd-hap-prod2']
-    target.add_obs_from_store(data_store)
-
-    irad = 0.5 * u.deg
-    orad = 0.7 * u.deg
-    target.estimate_background(method='ring', inner_radius=irad, outer_radius=orad)
-
-    summary = TargetSummary(target)
-
-    stats = summary.stats
-    assert stats.n_on == 432
+    assert 'Target' in str(target)

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -8,7 +8,7 @@ from regions import CircleSkyRegion
 from ..extern.pathlib import Path
 from ..utils.scripts import make_path
 from ..data import Target
-from ..background import reflected_regions_background_estimate
+from ..background import ReflectedRegionsBackgroundEstimator
 from .core import PHACountsSpectrum
 from .observation import SpectrumObservation, SpectrumObservationList
 
@@ -128,14 +128,14 @@ class SpectrumExtraction(object):
         if method == 'reflected':
             kwargs = self.background.copy()
             kwargs.pop('n_min', None)
-            bkg = [reflected_regions_background_estimate(
+            refl = ReflectedRegionsBackgroundEstimator(
                 on_region=self.target.on_region,
-                pointing=_.pointing_radec,
-                events=_.events,
-                **kwargs) for _ in self.obs]
+                obs_list=self.obs,
+                **kwargs) 
+            refl.run()
+            self.background = refl.result
         else:
             raise NotImplementedError("Method: {}".format(method))
-        self.background = bkg
 
     def filter_observations(self):
         """Filter observations by number of reflected regions"""

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -118,6 +118,7 @@ class SpectrumExtraction(object):
         method creates one given a dict of parameters. 
 
         TODO: Link to high-level docs page.
+        TODO: Refactor
 
         Parameters
         ----------
@@ -126,12 +127,14 @@ class SpectrumExtraction(object):
         """
         method = self.background.pop('method')
         if method == 'reflected':
-            kwargs = self.background.copy()
-            kwargs.pop('n_min', None)
+            config = self.background.copy()
+            config.pop('n_min', None)
+            exclusion = config.pop('exclusion', None)
             refl = ReflectedRegionsBackgroundEstimator(
                 on_region=self.target.on_region,
                 obs_list=self.obs,
-                **kwargs) 
+                exclusion=exclusion,
+                config=config) 
             refl.run()
             self.background = refl.result
         else:


### PR DESCRIPTION
This PR

* removes the function  ``gammapy.background.reflected_regions_background_estimate``
* add the class ``gammapy.background.ReflectedRegionsBackgroundEstimator``
* removes the ``gammapy.data.TargetSummary`` class which was not used anywhere and bad

which leads to a nicer API.

This needs a follow up PR where the new class is properly used in all places (at the moment I changed as little as possible to not break anything)