### PR TITLE
Add spectral table model

### DIFF
--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -1,10 +1,25 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
+import numpy as np
+from gammapy.utils.energy import EnergyBounds
 from astropy.tests.helper import assert_quantity_allclose, pytest
 from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
-                      ExponentialCutoffPowerLaw3FGL, LogParabola)
+                      ExponentialCutoffPowerLaw3FGL, LogParabola, TableModel)
 from ...utils.testing import requires_dependency
+
+def table_model():
+    energy_edges = EnergyBounds.equal_log_spacing(0.1 * u.TeV, 100 * u.TeV, 1000)
+    energy = energy_edges.log_centers
+
+    index = 2.3 * u.Unit('')
+    amplitude = 4 / u.cm ** 2 / u.s / u.TeV
+    reference = 1 * u.TeV
+
+    flux = np.zeros(energy.size)
+    flux = PowerLaw.evaluate(energy, index, amplitude, reference)
+
+    return TableModel(energy, flux, 1 * u.Unit(''))
 
 TEST_MODELS = [
     dict(
@@ -73,6 +88,14 @@ TEST_MODELS = [
         integral_1_10TeV=u.Quantity(2.255689748270628, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(3.9586515834989267, 'TeV cm-2 s-1')
     ),
+    dict(
+        name='table_model',
+        model=table_model(),
+        # Values took from power law expectation
+        val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), 'cm-2 s-1 TeV-1'),
+        integral_1_10TeV=u.Quantity(2.9227116204223784, 'cm-2 s-1'),
+        eflux_1_10TeV=u.Quantity(6.650836884969039, 'TeV cm-2 s-1'),
+    ),
 ]
 
 
@@ -113,3 +136,4 @@ def test_to_sherpa(spectrum):
     # test plot
     energy_range = [1, 10] * u.TeV
     model.plot(energy_range=energy_range)
+

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
-import numpy as np
 from gammapy.utils.energy import EnergyBounds
 from astropy.tests.helper import assert_quantity_allclose, pytest
 from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
                       ExponentialCutoffPowerLaw3FGL, LogParabola, TableModel)
 from ...utils.testing import requires_dependency
+
 
 def table_model():
     energy_edges = EnergyBounds.equal_log_spacing(0.1 * u.TeV, 100 * u.TeV, 1000)
@@ -15,11 +15,11 @@ def table_model():
     index = 2.3 * u.Unit('')
     amplitude = 4 / u.cm ** 2 / u.s / u.TeV
     reference = 1 * u.TeV
-
-    flux = np.zeros(energy.size)
-    flux = PowerLaw.evaluate(energy, index, amplitude, reference)
+    pl = PowerLaw(index, amplitude, reference)
+    flux = pl(energy)
 
     return TableModel(energy, flux, 1 * u.Unit(''))
+
 
 TEST_MODELS = [
     dict(
@@ -88,15 +88,21 @@ TEST_MODELS = [
         integral_1_10TeV=u.Quantity(2.255689748270628, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(3.9586515834989267, 'TeV cm-2 s-1')
     ),
-    dict(
+]
+
+# The table model imports scipy.interpolate in `__init__`,
+# so we skip it if scipy is not available
+try:
+    TEST_MODELS.append(dict(
         name='table_model',
         model=table_model(),
         # Values took from power law expectation
         val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), 'cm-2 s-1 TeV-1'),
         integral_1_10TeV=u.Quantity(2.9227116204223784, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(6.650836884969039, 'TeV cm-2 s-1'),
-    ),
-]
+    ))
+except ImportError:
+    pass
 
 
 @requires_dependency('uncertainties')
@@ -136,4 +142,3 @@ def test_to_sherpa(spectrum):
     # test plot
     energy_range = [1, 10] * u.TeV
     model.plot(energy_range=energy_range)
-


### PR DESCRIPTION
The purpose of this PR is to implement a spectral class initiated with energy and flux values (array).  The class implementation follows closely what has been done in [naima](http://naima.readthedocs.io/en/latest/_modules/naima/models.html#TableModel).
