### PR TITLE
remove from ogip run with reflected region=0

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -134,7 +134,7 @@ class SpectrumExtraction(object):
                 on_region=self.target.on_region,
                 obs_list=self.obs,
                 exclusion=exclusion,
-                config=config) 
+                config=config)
             refl.run()
             self.background = refl.result
         else:
@@ -164,7 +164,8 @@ class SpectrumExtraction(object):
         if not isinstance(self.background, list):
             raise ValueError("Invalid background estimate: {}".format(self.background))
         for obs, bkg in zip(self.obs, self.background):
-            if bkg.a_off==0:
+            if bkg.a_off == 0:
+                log.info('The run {} is excluded since no off region was found'.format(obs.obs_id))
                 continue
             log.info('Extracting spectrum for observation\n {}'.format(obs))
             offset = obs.pointing_radec.separation(self.target.on_region.center)
@@ -232,8 +233,8 @@ class SpectrumExtraction(object):
                                        off_vector=off_vec,
                                        edisp=rmf)
 
-            temp.hi_threshold=obs.aeff.high_threshold
-            temp.lo_threshold=obs.aeff.low_threshold
+            temp.hi_threshold = obs.aeff.high_threshold
+            temp.lo_threshold = obs.aeff.low_threshold
 
             spectrum_observations.append(temp)
 

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -164,6 +164,8 @@ class SpectrumExtraction(object):
         if not isinstance(self.background, list):
             raise ValueError("Invalid background estimate: {}".format(self.background))
         for obs, bkg in zip(self.obs, self.background):
+            if bkg.a_off==0:
+                continue
             log.info('Extracting spectrum for observation\n {}'.format(obs))
             offset = obs.pointing_radec.separation(self.target.on_region.center)
             log.info('Offset : {}\n'.format(offset))


### PR DESCRIPTION
Hi,
I found why there was an issue with sherpa when we fit the 4runs: 23523,23526, 23559 and 23992 with a radius size=0.4 degree for Efit_max=50 TeV and why it was working for Efit_max=25 TeV.
It was not only covar, the fit didn't converge... The reason is that for the run 23523 the number of reflected region is 0 so all the bkg counts are equal to zero. Moreover, for this run, the number of on counts for the three last energy bins are 0. If you look at the sherpa documentation for wstat (https://github.com/sherpa/sherpa/blob/master/sherpa/include/sherpa/stats.hh), you see that if the number of on counts  is equal to zero in an energy bin, it is calculating `ts_msubi - bkg_raw[ ii ] * ln_tb_div_src_bkg_time`and to calculate `ln_tb_div_src_bkg_time`, they use the off backscale_ratio. For this run, backscale_ratio=0 this is why the rstat at the end is equal to nan.
I'm not sure I am very clear but the reason why it was working until 25 TeV is that for the run  23523, the on counts are equal to zero only for energies>25 TeV so it never pass in the loop `for on counts =0` and in this case this variable `ln_tb_div_src_bkg_time` is not calculated in wstat.  To sum up, in wstat, they used the off backscale ratio only when the on counts in an energy bin is equal to 0. So if in this case, the off backscale ratio is 0, it fails...
When I was using the PA, I did'nt see the pb since their hi energy threshold is very low so even we you fix Efitmax=50 TeV, the fit doens't go that far.
The thing to solve this issue is to not fit the run when the backscale of the off is 0, there is no point to use it if there is no off regions. What I propose in this PR is to not add it in the ana_observation_list. @cdeil @joleroi Do you agree?
