### PR TITLE
Update numpy and astropy version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,13 @@ env:
     global:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - LIBGFORTRAN_VERSION=1.0
-        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa libgfortran=$LIBGFORTRAN_VERSION'
+        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa libgfortran'
         - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy sherpa libgfortran=$LIBGFORTRAN_VERSION'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy sherpa libgfortran'
         - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy sherpa libgfortran=$LIBGFORTRAN_VERSION runipy'
-        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy libgfortran=$LIBGFORTRAN_VERSION runipy'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy sherpa libgfortran runipy'
+        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy libgfortran runipy'
         - PIP_DEPENDENCIES='regions uncertainties reproject'
         - CONDA_CHANNELS='astropy sherpa'
         - FETCH_GAMMAPY_EXTRA=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,26 +115,15 @@ matrix:
                CONDA_DEPENDENCIES='Cython click'
                PIP_DEPENDENCIES='regions'
 
-        # Test with other numpy versions. Not all of the packages are
-        # available with these on conda, thus moving some of them to pip
-        # install. Latest astropy stable (1.1) is also not available for
-        # older numpies, but using lts version should be good enough for
-        # these tests (so we can avoid building it from source).
+        # Test with other numpy versions.
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
-
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9 SETUP_CMD='test -V'
-#               ASTROPY_VERSION=lts
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.8 SETUP_CMD='test -V'
-#               ASTROPY_VERSION=lts
-#               CONDA_CHANNELS='astropy-ci-extras astropy'
-#               CONDA_DEPENDENCIES='Cython click matplotlib'
-#               PIP_DEPENDENCIES=''
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10 SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
 
         # Test IPython notebooks
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ addons:
 
 env:
     global:
-        - NUMPY_VERSION=1.10
-        - ASTROPY_VERSION=1.1
+        - NUMPY_VERSION=stable
+        - ASTROPY_VERSION=stable
         - LIBGFORTRAN_VERSION=1.0
         - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa libgfortran=$LIBGFORTRAN_VERSION'
         - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa'

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ env:
     global:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa libgfortran'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy sherpa libgfortran'
-        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy sherpa libgfortran runipy'
-        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy libgfortran runipy'
-        - PIP_DEPENDENCIES='regions uncertainties reproject'
+        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa libgfortran regions reproject'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa regions reproject'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes regions reproject'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy sherpa libgfortran regions reproject'
+        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy regions reproject'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy sherpa libgfortran runipy regions reproject'
+        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy libgfortran runipy regions reproject'
+        - PIP_DEPENDENCIES='uncertainties'
         - CONDA_CHANNELS='astropy sherpa'
         - FETCH_GAMMAPY_EXTRA=true
         - MAIN_CMD='python setup.py'
@@ -66,7 +66,7 @@ matrix:
         #- os: linux
         #  env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
         #       CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
-        #       PIP_DEPENDENCIES='uncertainties reproject git+http://github.com/sherpa/sherpa.git#egg=sherpa'
+        #       PIP_DEPENDENCIES='uncertainties git+http://github.com/sherpa/sherpa.git#egg=sherpa'
 
         # Run tests
         # Coverage is measured on Python 2 (where Sherpa is available)
@@ -107,12 +107,12 @@ matrix:
         # Test with with optional dependencies disabled
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
-               CONDA_DEPENDENCIES='Cython click'
-               PIP_DEPENDENCIES='regions'
+               CONDA_DEPENDENCIES='Cython click regions'
+               PIP_DEPENDENCIES=''
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
-               CONDA_DEPENDENCIES='Cython click'
-               PIP_DEPENDENCIES='regions'
+               CONDA_DEPENDENCIES='Cython click regions'
+               PIP_DEPENDENCIES=''
 
         # Test with other numpy versions.
         - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,12 +16,12 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "1.1"
-        NUMPY_VERSION: "1.10"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.5"
-        ASTROPY_VERSION: "1.1"
-        NUMPY_VERSION: "1.10"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
 
 platform:


### PR DESCRIPTION
I was testing some things in ci-helpers using gammapy, and noticed that CI is not run with the latest stable versions of astropy and numpy. I didn't find any discussions on this being intentional.

However there seem to be a few conflicts when they are update to "stable", I'll try to fix them, too.