### PR TITLE
WIP: Rework kernel background estimator

### DIFF
--- a/docs/tutorials/background/source_diffuse_estimation.py
+++ b/docs/tutorials/background/source_diffuse_estimation.py
@@ -2,72 +2,58 @@
 """
 import numpy as np
 import matplotlib.pyplot as plt
+from astropy import units as u
 from astropy.io import fits
-from gammapy import datasets
-from gammapy.image import binary_disk
-from gammapy.detect import KernelBackgroundEstimator, KernelBackgroundEstimatorData
-
-# *** PREPARATION ***
+from astropy.convolution import Tophat2DKernel
+from gammapy.datasets import FermiGalacticCenter
+from gammapy.image import SkyImageList
+from gammapy.detect import KernelBackgroundEstimator
 
 # Parameters
-
 CORRELATION_RADIUS = 10  # Pixels
 SIGNIFICANCE_THRESHOLD = 5  # Sigma
 MASK_DILATION_RADIUS = 10  # Pixels
 
-psf_file = datasets.FermiGalacticCenter.psf()
+# Load example images.
+filename = ('$GAMMAPY_EXTRA/datasets/source_diffuse_separation/'
+            'galactic_simulations/fermi_counts.fits')
+images = SkyImageList.read(filename)
 
-# Load/create example model images.
-filename = datasets.gammapy_extra.filename(
-    'datasets/source_diffuse_separation/galactic_simulations/fermi_counts.fits')
-
-# *** LOADING INPUT ***
-
-# Counts must be provided as an ImageHDU
-counts = fits.open(filename)[0].data
-header = fits.open(filename)[0].header
-images = KernelBackgroundEstimatorData(counts=counts, header=header)
-
-source_kernel = binary_disk(CORRELATION_RADIUS)
-
+source_kernel = Tophat2DKernel(CORRELATION_RADIUS).array
 background_kernel = np.ones((10, 100))
 
-# *** ITERATOR ***
-
 kbe = KernelBackgroundEstimator(
-    images=images,
-    source_kernel=source_kernel,
-    background_kernel=background_kernel,
+    kernel_src=source_kernel,
+    kernel_bkg=background_kernel,
     significance_threshold=SIGNIFICANCE_THRESHOLD,
     mask_dilation_radius=MASK_DILATION_RADIUS,
 )
 
-n_iterations = 4
+niter_max = 4
+result = kbe.run(images, niter_max=niter_max)
 
-# *** RUN & PLOT ***
-plt.figure(figsize=(8, 4))
+fig = plt.figure(figsize=(8, 4))
 
-for iteration in range(n_iterations):
-    kbe.run_iteration()
-    mask_hdu = kbe.mask_image_hdu
-    mask = mask_hdu.data[:, 1400:2000]
+niter_max = len(kbe.images_stack)
+crop_width = ((0, 1), (500, 500))
+fig = plt.figure(figsize=(12, 6))
 
-    plt.subplot(n_iterations, 2, 2 * iteration + 1)
-    background_hdu = kbe.background_image_hdu
-    data = background_hdu.data[:, 1400:2000]
-    plt.imshow(data, vmin=0, vmax=1)
-    plt.contour(mask, levels=[0], linewidths=2, colors='white')
-    plt.axis('off')
-    plt.title('Background Estimation, Iteration {0}'.format(iteration),
-              fontsize='small')
+for idx, images in enumerate(kbe.images_stack):
+    ax_bkg = fig.add_subplot(niter_max + 1, 2, 2 * idx + 1)
+    bkg = images['background'].crop(crop_width)
+    bkg.plot(ax=ax_bkg, vmin=0, vmax=1)
+    ax_bkg.set_title('Background Estimation, Iteration {0}'.format(idx),
+                     fontsize='small')
+    ax_bkg.set_axis_off()
 
-    plt.subplot(n_iterations, 2, 2 * iteration + 2)
-    significance_hdu = kbe.significance_image_hdu
-    data = significance_hdu.data[:, 1400:2000]
-    plt.imshow(data, vmin=-3, vmax=5, cmap=plt.cm.Greys_r)
-    plt.contour(mask, levels=[0], linewidths=2, colors='red')
-    plt.axis('off')
-    plt.title('Significance Image, Iteration {0}'.format(iteration),
-              fontsize='small')
+    ax_sig = fig.add_subplot(niter_max + 1, 2, 2 * idx + 2)
+    sig = images['significance'].crop(crop_width)
+    sig.plot(ax=ax_sig, vmin=-3, vmax=20)
+    ax_sig.set_title('Significance, Iteration {0}'.format(idx),
+                     fontsize='small')
+    ax_sig.set_axis_off()
+    mask = images['exclusion'].crop(crop_width).data
+    ax_sig.contour(mask, levels=[0], linewidths=2, colors='green')
 
-plt.subplots_adjust(wspace=0.05, hspace=0.05, left=0.05, right=0.95)
+plt.tight_layout()
+plt.show()

--- a/docs/tutorials/background/source_diffuse_estimation.py
+++ b/docs/tutorials/background/source_diffuse_estimation.py
@@ -3,57 +3,37 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy import units as u
-from astropy.io import fits
+from astropy.coordinates import SkyCoord
 from astropy.convolution import Tophat2DKernel
 from gammapy.datasets import FermiGalacticCenter
-from gammapy.image import SkyImageList
+from gammapy.image import SkyImageList, SkyImage
 from gammapy.detect import KernelBackgroundEstimator
 
 # Parameters
 CORRELATION_RADIUS = 10  # Pixels
 SIGNIFICANCE_THRESHOLD = 5  # Sigma
-MASK_DILATION_RADIUS = 10  # Pixels
+MASK_DILATION_RADIUS = 0.5 * u.deg
 
 # Load example images.
 filename = ('$GAMMAPY_EXTRA/datasets/source_diffuse_separation/'
             'galactic_simulations/fermi_counts.fits')
-images = SkyImageList.read(filename)
+counts = SkyImage.read(filename)
+center = SkyCoord(0, 0, frame='galactic', unit='deg')
 
-source_kernel = Tophat2DKernel(CORRELATION_RADIUS).array
-background_kernel = np.ones((10, 100))
+images = SkyImageList()
+images['counts'] = counts.cutout(center, (10 * u.deg, 80 * u.deg))
+
+kernel_src = Tophat2DKernel(CORRELATION_RADIUS).array
+kernel_bkg = np.ones((10, 150))
 
 kbe = KernelBackgroundEstimator(
-    kernel_src=source_kernel,
-    kernel_bkg=background_kernel,
+    kernel_src=kernel_src,
+    kernel_bkg=kernel_bkg,
     significance_threshold=SIGNIFICANCE_THRESHOLD,
     mask_dilation_radius=MASK_DILATION_RADIUS,
 )
 
-niter_max = 4
-result = kbe.run(images, niter_max=niter_max)
-
-fig = plt.figure(figsize=(8, 4))
-
-niter_max = len(kbe.images_stack)
-crop_width = ((0, 1), (500, 500))
-fig = plt.figure(figsize=(12, 6))
-
-for idx, images in enumerate(kbe.images_stack):
-    ax_bkg = fig.add_subplot(niter_max + 1, 2, 2 * idx + 1)
-    bkg = images['background'].crop(crop_width)
-    bkg.plot(ax=ax_bkg, vmin=0, vmax=1)
-    ax_bkg.set_title('Background Estimation, Iteration {0}'.format(idx),
-                     fontsize='small')
-    ax_bkg.set_axis_off()
-
-    ax_sig = fig.add_subplot(niter_max + 1, 2, 2 * idx + 2)
-    sig = images['significance'].crop(crop_width)
-    sig.plot(ax=ax_sig, vmin=-3, vmax=20)
-    ax_sig.set_title('Significance, Iteration {0}'.format(idx),
-                     fontsize='small')
-    ax_sig.set_axis_off()
-    mask = images['exclusion'].crop(crop_width).data
-    ax_sig.contour(mask, levels=[0], linewidths=2, colors='green')
-
-plt.tight_layout()
+result = kbe.run(images)
+kbe.images_stack_show()
 plt.show()
+

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -79,7 +79,7 @@ class KernelBackgroundEstimator(object):
 
         Parameters
         ----------
-        images : `SkyImageList`
+        images : `gammapy.image.SkyImageList`
             Input sky images.
         niter_min : int
             Minimum number of iterations, to prevent early termination of the
@@ -91,7 +91,7 @@ class KernelBackgroundEstimator(object):
 
         Returns
         -------
-        images : `SkyImageList`
+        images : `gammapy.image.SkyImageList`
             List of sky images containing 'background', 'exclusion' mask and
             'significance' images.
         """
@@ -172,7 +172,7 @@ class KernelBackgroundEstimator(object):
 
         Parameters
         ----------
-        images : `SkyImageList`
+        images : `gammapy.image.SkyImageList`
             Input sky images
         """
         images.check_required(['counts', 'exclusion', 'background'])

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -193,3 +193,44 @@ class KernelBackgroundEstimator(object):
 
         background = self._estimate_background(images['counts'], exclusion)
         return SkyImageList([images['counts'], background, exclusion, significance])
+
+    def images_stack_show(self, dpi=120):
+        """
+        Show image stack.
+
+        Parameters
+        ----------
+        dpi : int
+            Dots per inch to scale the image.
+        """
+        import matplotlib.pyplot as plt
+        niter_max = len(self.images_stack)
+        wcs = self.images_stack[0]['background'].wcs
+
+        height_pix, width_pix = self.images_stack[0]['background'].data.shape
+        width = 2 * (width_pix / dpi + 1.)
+        height = niter_max * (height_pix / dpi + .5)
+        fig = plt.figure(figsize=(width, height))
+
+        for idx, images in enumerate(self.images_stack):
+            ax_bkg = fig.add_subplot(niter_max + 1, 2, 2 * idx + 1, projection=wcs)
+            bkg = images['background']
+            bkg.plot(ax=ax_bkg, vmin=0)
+            ax_bkg.set_title('Background, N_iter = {0}'.format(idx),
+                             fontsize='small')
+
+            ax_sig = fig.add_subplot(niter_max + 1, 2, 2 * idx + 2, projection=wcs)
+            sig = images['significance']
+            sig.plot(ax=ax_sig, vmin=0, vmax=20)
+            ax_sig.set_title('Significance, N_Iter = {0}'.format(idx),
+                             fontsize='small')
+            mask = images['exclusion'].data
+            ax_sig.contour(mask, levels=[0], linewidths=2, colors='green')
+            if idx < (niter_max - 1):
+                for ax in [ax_sig, ax_bkg]:
+                    ax.set_xlabel('')
+                    ax.coords['glon'].ticklabels.set_visible(False)
+            ax_bkg.set_ylabel('')
+            ax_sig.set_ylabel('')
+
+        plt.tight_layout(pad=1.08, h_pad=1.5, w_pad=0.2, rect=[0, 0, 1, 0.98])

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -39,6 +39,7 @@ def compute_lima_image(counts, background, kernel, exposure=None):
     """
     from scipy.ndimage import convolve
 
+    wcs = counts.wcs.copy()
     # Kernel is modified later make a copy here
     kernel = deepcopy(kernel)
 
@@ -54,10 +55,10 @@ def compute_lima_image(counts, background, kernel, exposure=None):
     significance_conv = significance(counts_conv, background_conv, method='lima')
 
     images = SkyImageList([
-        SkyImage(name='significance', data=significance_conv),
-        SkyImage(name='counts', data=counts_conv),
-        SkyImage(name='background', data=background_conv),
-        SkyImage(name='excess', data=excess_conv),
+        SkyImage(name='significance', data=significance_conv, wcs=wcs),
+        SkyImage(name='counts', data=counts_conv, wcs=wcs),
+        SkyImage(name='background', data=background_conv, wcs=wcs),
+        SkyImage(name='excess', data=excess_conv, wcs=wcs),
     ])
 
     # TODO: should we be doing this here?

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -3,38 +3,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
-from astropy.units import Quantity
+import astropy.units as u
 from astropy.coordinates.angles import Angle
+from astropy.convolution import CustomKernel
 from ...utils.testing import requires_dependency, requires_data
-from ...image import SkyImage
+from ...image import SkyImage, SkyImageList, SkyMask
 from ...stats import significance
 from ...datasets import FermiGalacticCenter
-from ..kernel import KernelBackgroundEstimatorData, KernelBackgroundEstimator
+from ..kernel import KernelBackgroundEstimator
 
-
-@requires_dependency('scipy')
-def test_KernelBackgroundEstimatorData():
-    """Tests compute correlated images in KernelBackgroundEstimatorData.
-    This is the only method in KernelBackgroundEstimatorData that actually calculates anything.
-    """
-    # Set up test counts and background
-    counts_hdu = SkyImage.empty(nxpix=10, nypix=10, binsz=1, fill=42).to_image_hdu()
-    counts_hdu.data[4][4] = 1000
-    counts = counts_hdu.data
-
-    background_data = 42 * np.ones_like(counts, dtype=float)
-
-    # Single unit pixel kernel so should actually be no change.
-    background_kernel = np.ones((1, 1))
-
-    images = KernelBackgroundEstimatorData(counts, background_data)
-    images.compute_correlated_images(background_kernel)
-
-    # Test significance image against Li & Ma significance value
-    expected = significance(counts, background_data)
-    actual = images.significance
-
-    assert_allclose(actual, expected)
 
 
 @requires_dependency('scipy')
@@ -44,117 +21,78 @@ class TestKernelBackgroundEstimator(object):
     def setup_class(self):
         """Prepares appropriate input and defines inputs for test cases.
         """
-        from scipy.ndimage import convolve
-        # Load/create example model images
-        counts_hdu = SkyImage.empty(nxpix=10, nypix=10, binsz=1, fill=42).to_image_hdu()
-        counts_hdu.data[4][4] = 1000
-        counts = counts_hdu.data
-        # Initial counts required by one of the tests.
-        self.counts = counts
-
-        psf = FermiGalacticCenter.psf()
-        psf = psf.table_psf_in_energy_band(Quantity([10, 500], 'GeV'))
-        kernel_array = psf.kernel(pixel_size=Angle(1, 'deg'),
-                                  offset_max=Angle(3, 'deg'), normalize=True)
-
-        counts_blob = convolve(counts, kernel_array, mode='constant')
-
-        self.counts_blob = counts_blob
-
-        # Start with flat background estimate
-        # Background must be provided as an ImageHDU
-
-        images = KernelBackgroundEstimatorData(counts=counts, header=counts_hdu.header)
-
-        images_blob = KernelBackgroundEstimatorData(counts=counts_blob, header=counts_hdu.header)
-
         source_kernel = np.ones((1, 3))
-
         background_kernel = np.ones((5, 3))
-
-        significance_threshold = 4
-        mask_dilation_radius = 1
 
         # Loads prepared inputs into estimator
 
         self.kbe = KernelBackgroundEstimator(
-            images,
-            source_kernel,
-            background_kernel,
-            significance_threshold,
-            mask_dilation_radius
+            kernel_src=source_kernel,
+            kernel_bkg=background_kernel,
+            significance_threshold=4,
+            mask_dilation_radius=1 * u.deg
         )
 
-        self.kbe2 = KernelBackgroundEstimator(
-            images,
-            source_kernel,
-            background_kernel,
-            significance_threshold,
-            mask_dilation_radius
-        )
+    def _images_point(self):
+        """
+        Test images for a point source
+        """
+        counts = SkyImage.empty(name='counts', nxpix=10, nypix=10, binsz=1, fill=42.)
+        counts.data[4][4] = 1000
 
-        self.kbe_blob = KernelBackgroundEstimator(
-            images_blob,
-            source_kernel,
-            background_kernel,
-            significance_threshold,
-            mask_dilation_radius
-        )
+        background = SkyImage.empty_like(counts, fill=42., name='background')
+        exclusion = SkyMask.empty_like(counts, name='exclusion', fill=1.)
+        return SkyImageList([counts, background, exclusion])
+
+    def _images_psf(self):
+         # Initial counts required by one of the tests.
+        images = self._images_point()
+
+        psf = FermiGalacticCenter.psf()
+        erange = [10, 500] * u.GeV
+        psf = psf.table_psf_in_energy_band(erange)
+        kernel_array = psf.kernel(pixel_size=Angle(1, 'deg'),
+                                  offset_max=Angle(3, 'deg'),
+                                  normalize=True)
+
+        images['counts'] = images['counts'].convolve(kernel_array, mode='constant')
+        return images
 
     def test_run_iteration_point(self):
         """Asserts that mask and background are as expected according to input."""
 
-        # Call the run_iteration code as this is what is explicitly being tested
-        self.kbe.run_iteration()
-        # Should be run twice to update the mask
-        self.kbe.run_iteration()
-        mask = self.kbe.mask_image_hdu.data
-        background = self.kbe.background_image_hdu.data
+        images = self._images_point()
 
-        # Check mask matches expectations
-        expected_mask = np.ones_like(self.counts)
-        expected_mask[4][3] = 0
-        expected_mask[4][4] = 0
-        expected_mask[4][5] = 0
+        # Call the _run_iteration code as this is what is explicitly being tested
+        result = self.kbe._run_iteration(images)
+        mask, background = result['exclusion'].data, result['background'].data
 
-        assert_allclose(mask.astype(int), expected_mask)
+        # Check mask
+        idx = [(4, 3), (4, 4), (4, 5), (3, 4), (5, 4)]
+        i, j = zip(*idx)
+        assert_allclose(mask[i, j], 0)
+        assert_allclose((1. - mask).sum(), 11)
+
         # Check background, should be 42 uniformly
-        assert_allclose(background.astype(float), 42 * np.ones((10, 10)))
+        assert_allclose(background, 42 * np.ones((10, 10)))
 
     def test_run_iteration_blob(self):
         """Asserts that mask and background are as expected according to input."""
 
+        images = self._images_psf()
+
         # Call the run_iteration code as this is what is explicitly being tested
-        self.kbe_blob.run_iteration()
-        # Should be run twice to update the mask
-        self.kbe_blob.run_iteration()
-        background = self.kbe_blob.background_image_hdu.data
+        result = self.kbe._run_iteration(images)
+        mask, background = result['exclusion'].data, result['background'].data
+
         # Check background, should be 42 uniformly within 10%
-        assert_allclose(background, 42 * np.ones((10, 10)), rtol=0.15)
+        assert_allclose(background, 42 * np.ones((10, 10)), rtol=0.1)
 
     def test_run(self):
         """Tests run script."""
-        mask, background = self.kbe2.run()
+        images = self._images_point()
+        result = self.kbe.run(images)
+        mask, background = result['exclusion'].data, result['background'].data
 
-        assert_allclose(mask.sum(), 97)
+        assert_allclose(mask.sum(), 89)
         assert_allclose(background, 42 * np.ones((10, 10)))
-
-    def test_save_files(self, tmpdir):
-        """Tests that files are saves, and checks values within them."""
-        # Create temporary file to write output into
-        self.kbe.run_iteration(1)
-        self.kbe.save_files(base_dir=str(tmpdir), index=0)
-
-        filename = tmpdir / '00_mask.fits'
-        mask = fits.open(str(filename))[1].data
-
-        filename = tmpdir / '00_significance.fits'
-        significance = fits.open(str(filename))[1].data
-
-        filename = tmpdir / '00_background.fits'
-        background = fits.open(str(filename))[1].data
-
-        # Checks values in files against known results for one iteration.
-        assert_allclose(mask.sum(), 97)
-        assert_allclose(significance.sum(), 157.316195729298)
-        assert_allclose(background.sum(), 4200)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -866,16 +866,10 @@ class SkyImage(object):
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
 
         caxes = ax.imshow(self.data, **kwargs)
-        unit = self.unit or 'A.U.'
-        if unit == 'ct':
-            quantity = 'counts'
-        elif unit is 'A.U.':
-            quantity = 'Unknown'
-        else:
-            quantity = Unit(unit).physical_type
-
         if add_cbar:
-            cbar = fig.colorbar(caxes, label='{0} ({1})'.format(quantity, unit))
+            unit = self.unit or 'A.U.'
+            label = self.name or 'None'
+            cbar = fig.colorbar(caxes, label='{0} ({1})'.format(label.title(), unit))
         else:
             cbar = None
 
@@ -1160,7 +1154,7 @@ class SkyImage(object):
         from scipy.ndimage import convolve
         data = convolve(self.data, kernel, **kwargs)
         wcs = self.wcs.deepcopy() if self.wcs else None
-        return self.__class__(data=data, wcs=wcs)
+        return self.__class__(name=self.name, data=data, wcs=wcs)
 
     def smooth(self, kernel='gauss', width=3):
         """Smooth the image (works on and returns a copy).

--- a/gammapy/image/mask.py
+++ b/gammapy/image/mask.py
@@ -53,7 +53,7 @@ class SkyMask(SkyImage):
 
         self.data = data
 
-    def open(self, structure):
+    def open(self, structure, **kwargs):
         """
         Binary opening with structuring element.
 
@@ -70,10 +70,10 @@ class SkyMask(SkyImage):
             Opened sky mask.
         """
         from scipy.ndimage import binary_opening
-        data = binary_opening(self.data, structure)
-        return SkyMask(data=data, wcs=self.wcs)
+        data = binary_opening(self.data, structure, **kwargs)
+        return SkyMask(name=self.name, data=data.astype(self.data.dtype), wcs=self.wcs)
 
-    def dilate(self, structure):
+    def dilate(self, structure, **kwargs):
         """
         Binary dilation with structuring element.
 
@@ -90,10 +90,10 @@ class SkyMask(SkyImage):
             Dilated sky mask.
         """
         from scipy.ndimage import binary_dilation
-        data = binary_dilation(self.data, structure)
-        return SkyMask(data=data, wcs=self.wcs)
+        data = binary_dilation(self.data, structure, **kwargs)
+        return SkyMask(name=self.name, data=data.astype(self.data.dtype), wcs=self.wcs)
 
-    def close(self, structure):
+    def close(self, structure, **kwargs):
         """
         Binary closing with structuring element.
 
@@ -110,10 +110,10 @@ class SkyMask(SkyImage):
             Closed sky mask.
         """
         from scipy.ndimage import binary_closing
-        data = binary_closing(self.data, structure)
-        return SkyMask(data=data, wcs=self.wcs)
+        data = binary_closing(self.data, structure, **kwargs)
+        return SkyMask(name=self.name, data=data.astype(self.data.dtype), wcs=self.wcs)
 
-    def erode(self, structure):
+    def erode(self, structure, **kwargs):
         """
         Binary erosion with structuring element.
 
@@ -130,8 +130,8 @@ class SkyMask(SkyImage):
             Eroded sky mask.
         """
         from scipy.ndimage import binary_erosion
-        data = binary_erosion(self.data, structure)
-        return SkyMask(data=data, wcs=self.wcs)
+        data = binary_erosion(self.data, structure, **kwargs)
+        return SkyMask(name=self.name, data=data.astype(self.data.dtype), wcs=self.wcs)
 
     @lazyproperty
     def distance_image(self):


### PR DESCRIPTION
This PR is a rework of the `KernelBackgroundEstimator` class. It includes the following changes:
* Get rid of the `KernelBackroundEstimatorData` class and replace its use by `SkyImageList`
* Get rid of I/O functionality of the `KernelBackgroundEstimator` class, as I/O is attached to `SkyImageList`
* Make use of `SkyImage` class everywhere
* Restructure code into methods and simplify implementation

Some things are left to be done:
- [ ] Adapt notebooks in `gammapy-extra`
- [x] Add docs with a short usage example and link to notebooks
- [x] Move plotting code in `docs/tutorials/background/source_diffuse_estimation.py` in a `show_image_stack()` method