### PR TITLE
Change hi and low threshold for spectral extraction

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -265,7 +265,7 @@ class PHACountsSpectrum(CountsSpectrum):
     @property
     def counts_in_safe_range(self):
         """Counts with bins outside safe range set to 0"""
-        data = self.data.copy() 
+        data = self.data.copy()
         data[np.nonzero(self.quality)] = 0
         return data
 
@@ -277,7 +277,7 @@ class PHACountsSpectrum(CountsSpectrum):
 
     @lo_threshold.setter
     def lo_threshold(self, thres):
-        idx = np.where(self.energy.data[1:] < thres)[0]
+        idx = np.where(self.energy.data < thres)[0]
         self.quality[idx] = 1
 
     @property
@@ -289,6 +289,8 @@ class PHACountsSpectrum(CountsSpectrum):
     @hi_threshold.setter
     def hi_threshold(self, thres):
         idx = np.where(self.energy.data[:-1] > thres)[0]
+        if len(idx) != 0:
+            idx = np.insert(idx, 0, idx[0] - 1)
         self.quality[idx] = 1
 
     @property

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -11,7 +11,6 @@ from .. import CountsSpectrum, PHACountsSpectrum
 
 @requires_dependency('scipy')
 class TestCountsSpectrum:
-
     def setup(self):
         self.counts = [0, 0, 2, 5, 17, 3] * u.ct
         self.bins = EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV')
@@ -41,7 +40,6 @@ class TestCountsSpectrum:
 
 @requires_dependency('scipy')
 class TestPHACountsSpectrum:
-
     def setup(self):
         counts = [1, 2, 5, 6, 1, 7, 23]
         self.binning = EnergyBounds.equal_log_spacing(1, 10, 7, 'TeV')
@@ -64,9 +62,9 @@ class TestPHACountsSpectrum:
         self.spec.quality = np.zeros(self.spec.energy.nbins, dtype=int)
         self.spec.lo_threshold = 1.5 * u.TeV
         self.spec.hi_threshold = 4.5 * u.TeV
-        assert (self.spec.quality == [1, 0, 0, 0, 0, 1, 1]).all()
-        assert_quantity_allclose(self.spec.lo_threshold, 1.3894955 * u.TeV)
-        assert_quantity_allclose(self.spec.hi_threshold, 5.1794747 * u.TeV)
+        assert (self.spec.quality == [1, 1, 0, 0, 1, 1, 1]).all()
+        assert_quantity_allclose(self.spec.lo_threshold, 1.93069773 * u.TeV)
+        assert_quantity_allclose(self.spec.hi_threshold, 3.72759372 * u.TeV)
 
     def test_io(self, tmpdir):
         filename = tmpdir / 'test2.fits'

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -111,5 +111,5 @@ class TestSpectrumExtraction:
         extraction.define_energy_threshold(method_lo_threshold="area_max",
                                            percent=10)
         assert_quantity_allclose(extraction.observations[0].lo_threshold,
-                                 0.5994842503189409 * u.TeV,
+                                 0.6812920690579611 * u.TeV,
                                  rtol=1e-3)


### PR DESCRIPTION
I change the setter function for the low and hi threshold in spectrum extraction. For the moment you were taking the bin under/upper the user low/hi requested threshold. I think it's better to be less optimistic and to not take the energy reco bin where are located the hi or lo threshold. 
