### PR TITLE
Add sherpa method as a attribut of the Class SpectrumFit

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -44,7 +44,7 @@ class SpectrumFit(object):
     """Numerical constant to make model amplitude O(1) during the fit"""
     DEFAULT_STAT = 'wstat'
     """Default statistic to be used for the fit"""
-    DEFAULT_METHOD = 'NelderMead'
+    DEFAULT_METHOD = 'simplex'
     """Default method to be used for the fit"""
 
     def __init__(self, obs_list, model, stat=DEFAULT_STAT, method=DEFAULT_METHOD):
@@ -105,11 +105,11 @@ class SpectrumFit(object):
     def method_fit(self, method):
         import sherpa.optmethods as optmethod
         if isinstance(method, six.string_types):
-            if method == 'NelderMead':
+            if method == 'simplex':
                 method = optmethod.NelderMead()
-            elif method == 'MonCar':
+            elif method == 'moncar':
                 method = optmethod.MonCar()
-            elif method == 'LevMar':
+            elif method == 'levmar':
                 method = optmethod.LevMar()
             else:
                 raise ValueError("Undefined method string: {}".format(method))

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -37,19 +37,24 @@ class SpectrumFit(object):
         Model to be fit
     stat : str, `~sherpa.stats.Stat`
         Fit statistic to be used
+    method : str, `~sherpa.optmethods.OptMethod`
+        Fit statistic to be used
     """
     FLUX_FACTOR = 1e-20
     """Numerical constant to make model amplitude O(1) during the fit"""
     DEFAULT_STAT = 'wstat'
     """Default statistic to be used for the fit"""
+    DEFAULT_METHOD = 'NelderMead'
+    """Default method to be used for the fit"""
 
-    def __init__(self, obs_list, model, stat=DEFAULT_STAT):
+    def __init__(self, obs_list, model, stat=DEFAULT_STAT, method=DEFAULT_METHOD):
         if isinstance(obs_list, SpectrumObservation):
             obs_list = [obs_list]
 
         self.obs_list = SpectrumObservationList(obs_list)
         self.model = model
         self.statistic = stat
+        self.method_fit = method
         self._fit_range = None
         self._result = list()
         self._global_result = list()
@@ -89,6 +94,30 @@ class SpectrumFit(object):
             raise ValueError("Only sherpa statistics are supported")
 
         self._stat = stat
+
+    @property
+    def method_fit(self):
+        """Sherpa `~sherpa.optmethods.OptMethod` to be used for the fit"""
+
+        return self._method
+
+    @method_fit.setter
+    def method_fit(self, method):
+        import sherpa.optmethods as optmethod
+        if isinstance(method, six.string_types):
+            if method == 'NelderMead':
+                method = optmethod.NelderMead()
+            elif method == 'MonCar':
+                method = optmethod.MonCar()
+            elif method == 'LevMar':
+                method = optmethod.LevMar()
+            else:
+                raise ValueError("Undefined method string: {}".format(method))
+
+        if not isinstance(method, optmethod.OptMethod):
+            raise ValueError("Only sherpa method are supported")
+
+        self._method = method
 
     @property
     def fit_range(self):
@@ -164,7 +193,7 @@ class SpectrumFit(object):
         fitmodel = SimulFitModel('simul fit model', folded_model)
         log.debug(fitmodel)
 
-        fit = Fit(data, fitmodel, self.statistic)
+        fit = Fit(data, fitmodel, self.statistic, method=self.method_fit)
 
         fitresult = fit.fit()
         log.debug(fitresult)
@@ -187,9 +216,9 @@ class SpectrumFit(object):
         global_result = copy.deepcopy(self.result[valid_result])
         global_result.npred = None
         global_result.obs = None
-        all_fitranges = [_.fit_range for _ in self._result if _ is not None] 
+        all_fitranges = [_.fit_range for _ in self._result if _ is not None]
         fit_range_min = min([_[0] for _ in all_fitranges])
-        fit_range_max = max([_[1] for _ in all_fitranges]) 
+        fit_range_max = max([_[1] for _ in all_fitranges])
         global_result.fit_range = u.Quantity((fit_range_min, fit_range_max))
         self._global_result = global_result
 
@@ -279,15 +308,15 @@ def _sherpa_to_fitresult(shmodel, covar, efilter, fitresult):
         covar_axis.append(pardict[name][0])
         temp = covariance[idx] * pardict[name][1]
         covariance[idx] = temp
-        temp2 = covariance[:,idx] * pardict[name][1]
-        covariance[:,idx] = temp2
+        temp2 = covariance[:, idx] * pardict[name][1]
+        covariance[:, idx] = temp2
 
     # Efilter sometimes contains ','
     if ':' in efilter:
         temp = efilter.split(':')
     else:
         temp = efilter.split(',')
-    
+
     # Special case only one noticed bin
     if len(temp) == 1:
         fit_range = ([float(temp[0]), float(temp[0])] * u.keV).to('TeV')

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.tests.helper import pytest, assert_quantity_allclose
-import sherpa.optmethods as optmethods
 import astropy.units as u
 import numpy as np
 from astropy.utils.compat import NUMPY_LT_1_9
@@ -45,7 +44,7 @@ def test_spectral_fit(tmpdir):
     test_e = 12.5 * u.TeV
     assert_quantity_allclose(fit.result[0].model(test_e),
                              read_result.model(test_e))
-    assert_string_equal(fit.method_fit.name, optmethods.NelderMead().name)
+    assert_string_equal(fit.method_fit.name, "simplex")
     result = fit.result[0]
     result.plot()
 
@@ -95,10 +94,10 @@ def test_spectral_fit(tmpdir):
 
     # Test method fit
     fit = SpectrumFit(obs_list, model)
-    fit.method_fit = "LevMar"
+    fit.method_fit = "levmar"
     fit.run(outdir=tmpdir)
     result = fit.result[0]
-    assert_string_equal(fit.method_fit.name, optmethods.LevMar().name)
+    assert_string_equal(fit.method_fit.name, "levmar")
     assert_quantity_allclose(result.model.parameters.index,
                              2.116 * u.Unit(''), rtol=1e-3)
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.tests.helper import pytest, assert_quantity_allclose
+import sherpa.optmethods as optmethods
 import astropy.units as u
 import numpy as np
 from astropy.utils.compat import NUMPY_LT_1_9
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_string_equal
 from ...datasets import gammapy_extra
 from ...spectrum import (
     SpectrumObservationList,
@@ -44,7 +45,7 @@ def test_spectral_fit(tmpdir):
     test_e = 12.5 * u.TeV
     assert_quantity_allclose(fit.result[0].model(test_e),
                              read_result.model(test_e))
-
+    assert_string_equal(fit.method_fit.name, optmethods.NelderMead().name)
     result = fit.result[0]
     result.plot()
 
@@ -92,6 +93,15 @@ def test_spectral_fit(tmpdir):
 
     assert_quantity_allclose(actual, desired)
 
+    # Test method fit
+    fit = SpectrumFit(obs_list, model)
+    fit.method_fit = "LevMar"
+    fit.run(outdir=tmpdir)
+    result = fit.result[0]
+    assert_string_equal(fit.method_fit.name, optmethods.LevMar().name)
+    assert_quantity_allclose(result.model.parameters.index,
+                             2.116 * u.Unit(''), rtol=1e-3)
+
     # Test ECPL
     ecpl = models.ExponentialCutoffPowerLaw(
         index=2 * u.Unit(''),
@@ -108,7 +118,7 @@ def test_spectral_fit(tmpdir):
 
 @requires_dependency('sherpa')
 @pytest.mark.skipif('NUMPY_LT_1_9')
-@pytest.mark.xfail(reason = 'wait for https://github.com/sherpa/sherpa/pull/249')
+@pytest.mark.xfail(reason='wait for https://github.com/sherpa/sherpa/pull/249')
 @requires_data('gammapy-extra')
 def test_stacked_fit():
     pha1 = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23592.fits")


### PR DESCRIPTION
Hi,
This PR add an attribut method in the Class SpectrumFit in order for the user to choose the sherpa method he wants to use in the FIt. For the moment by default it was LevMar(). I encountered some issues with this method that is optimized for chi2 statistic. With Cash it's better to use NelderMead() (See http://cxc.harvard.edu/sherpa/methods/). This is why now by default this is NedelMead() but the user can change it.

For the test, I add some lines. But it is marked as xfails for other reasons than this PR so I can't really test it. I copy the same line that I added in the test on a script and it was working with the data in gammapy_extra used in the test.
