### PR TITLE
Rework SkyCube class

### DIFF
--- a/docs/tutorials/npred/npred_general.py
+++ b/docs/tutorials/npred/npred_general.py
@@ -24,7 +24,7 @@ def prepare_images():
     exposure_cube.data = Quantity(exposure_cube.data.value, 'cm2 s')
 
     # Re-project background cube
-    repro_bg_cube = background_model.reproject_to(exposure_cube)
+    repro_bg_cube = background_model.reproject(exposure_cube)
 
     # Define energy band required for output
     energies = EnergyBounds([10, 500], 'GeV')
@@ -38,12 +38,8 @@ def prepare_images():
                                          offset_max=Angle(3, 'deg'))
 
     # Counts data
-    counts_data = fits.open(counts_file)[0].data
-    counts_wcs = WCS(fits.open(counts_file)[0].header)
-    counts_cube = SkyCube(data=Quantity(counts_data, ''),
-                          wcs=counts_wcs,
-                          energy=energies)
-    counts_cube = counts_cube.reproject_to(npred_cube, projection_type='nearest-neighbor')
+    counts_cube = SkyCube.read(counts_file, format='fermi-counts')
+    counts_cube = counts_cube.reproject(npred_cube)
 
     counts = counts_cube.data[0]
     model = convolved_npred_cube.data[0]

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -491,18 +491,19 @@ class SkyCube(object):
         reprojected_cube : `SkyCube`
             Cube spatially reprojected to the reference.
         """
+        if isinstance(reference, SkyCube):
+            reference = reference.spatial
+
         out = []
         for idx in range(len(self.data)):
             image = self.sky_image(idx)
             image_out = image.reproject(reference, mode=mode, *args, **kwargs)
             out.append(image_out.data)
 
-        data = np.dstack(out)
+        data = Quantity(np.stack(out, axis=0), self.data.unit)
         wcs = image_out.wcs.copy()
-        return self.__class__(
-            name=self.name, data=data, wcs=wcs,
-            unit=self.unit, meta=self.meta,
-        )
+        return self.__class__(name=self.name, data=data, wcs=wcs, meta=self.meta,
+                              energy=self.energy)
 
  
     def to_fits(self):

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -515,7 +515,7 @@ class SkyCube(object):
                          meta=header)
         return image
 
-    def reproject_to(self, reference_cube, projection_type='bicubic'):
+    def reproject(self, reference_cube, projection_type='bicubic'):
         """Spatially reprojects a `SkyCube` onto a reference cube.
 
         Parameters

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -174,11 +174,10 @@ class SkyCube(object):
         if weights is not None:
             weights = events[weights]
 
-        image = self.ref_sky_image
-        xx, yy = image._events_xy(events)
+        xx, yy = self.spatial._events_xy(events)
         zz = self._energy_to_zz(events.energy)
 
-        bins = self._bins_energy, image._bins_pix[0], image._bins_pix[1]
+        bins = self._bins_energy, self.spatial._bins_pix[0], self.spatial._bins_pix[1]
         data = np.histogramdd([zz, yy, xx], bins, weights=weights)[0]
 
         self.data = self.data + data
@@ -255,7 +254,7 @@ class SkyCube(object):
         z = self.energy_axis.world2pix(energy)
         
         #TODO: check order, so that it corresponds to data axis order
-        return (z, y, x)
+        return (x, y, z)
 
     def wcs_pixel_to_skycoord(self, x, y, z):
         """Convert pixel to world coordinates.

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -401,6 +401,37 @@ class SkyCube(object):
 
         return Quantity(values, '1 / (cm2 MeV s sr)')
 
+    def show(self, viewer='mpl', ds9options=None, **kwargs):
+        """
+        Show sky cube in image viewer.
+
+        Parameters
+        ----------
+        viewer : {'mpl', 'ds9'}
+            Which image viewer to use. Option 'ds9' requires ds9 to be installed.
+        ds9options : list, optional
+            List of options passed to ds9. E.g. ['-cmap', 'heat', '-scale', 'log'].
+            Any valid ds9 command line option can be passed.
+            See http://ds9.si.edu/doc/ref/command.html for details.
+        **kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.imshow`.
+        """
+        import matplotlib.pyplot as plt
+        from ipywidgets import interact
+
+        if viewer == 'mpl':
+            max_ = self.data.shape[0] - 1
+            
+            def show_image(idx):
+                image = self.sky_image(idx)
+                image.data = image.data.value
+                image.show(**kwargs)
+
+            return interact(show_image, idx=(0, max_, 1))
+        elif viewer == 'ds9':
+            raise NotImplementedError
+
+
     def spectral_index(self, lon, lat, energy, dz=1e-3):
         """Power law spectral index (`numpy.array`).
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -299,23 +299,6 @@ class SkyCube(object):
 
         return lon, lat, energy
 
-    def coordinates(self, mode='center'):
-        """Spatial coordinate images.
-
-        Wrapper of `gammapy.image.SkyImage.coordinates`
-
-        Parameters
-        ----------
-        mode : {'center', 'edges'}
-            Return coordinate values at the pixels edges or pixel centers.
-
-        Returns
-        -------
-        coordinates : `~astropy.coordinates.SkyCoord`
-            Position on the sky.
-        """
-        return self.ref_sky_image.coordinates(mode)
-
     def to_sherpa_data3d(self):
         """
         Convert sky cube to sherpa `Data3D` object.
@@ -382,18 +365,6 @@ class SkyCube(object):
         wcs = self.wcs.celestial.copy()
         return SkyImage(name=self.name, data=data, wcs=wcs)
 
-    @property
-    def ref_sky_image(self):
-        """Reference `~gammapy.image.SkyImage` that matches the cube.
-        """
-        image = self.sky_image(idx_energy=0, copy=True)
-        image.data = 0 * image.data
-        return image
-
-    @property
-    def solid_angle(self):
-        """Solid angle image in steradian (`~astropy.units.Quantity`)"""
-        return self.ref_sky_image.solid_angle()
 
     def flux(self, lon, lat, energy):
         """Differential flux.

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -362,6 +362,26 @@ class SkyCube(object):
         image = SkyImage(name=self.name, data=data, wcs=self.wcs)
         return image.copy() if copy else image
 
+    @property        
+    def spatial(self):
+        """
+        Spatial part of the cube obtained by summing over all energy bins.
+
+        Examples
+        --------
+        Can be used to acces the spatial information of the cube:
+
+            >>> from gammapy.cube import SkyCube
+            >>> cube = SkyCube.empty()
+            >>> coords = cube.spatial.coordinates()
+            >>> solid_angle = cube.spatial.solid_angle()
+
+        """
+        #TODO: what about meta info?
+        data = np.nansum(self.data, axis=0)
+        wcs = self.wcs.celestial.copy()
+        return SkyImage(name=self.name, data=data, wcs=wcs)
+
     @property
     def ref_sky_image(self):
         """Reference `~gammapy.image.SkyImage` that matches the cube.

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -401,41 +401,6 @@ class SkyCube(object):
         elif viewer == 'ds9':
             raise NotImplementedError
 
-
-    def spectral_index(self, lon, lat, energy, dz=1e-3):
-        """Power law spectral index (`numpy.array`).
-
-        A forward finite difference method with step ``dz`` is used along
-        the ``z = log10(energy)`` axis.
-
-        Parameters
-        ----------
-        lon : `~astropy.coordinates.Angle`
-            Longitude
-        lat : `~astropy.coordinates.Angle`
-            Latitude
-        energy : `~astropy.units.Quantity`
-            Energy
-        """
-        raise NotImplementedError
-        # Compute flux at `z = log(energy)`
-        pix_coord = self.world2pix(lon, lat, energy, combine=True)
-        flux1 = self._interpolate(pix_coord)
-
-        # Compute flux at `z + dz`
-        pix_coord[:, 0] += dz
-        # pixel_coordinates += np.zeros(pixel_coordinates.shape)
-        flux2 = self._interpolate(pix_coord)
-
-        # Power-law spectral index through these two flux points
-        # d_log_flux = np.log(flux2 / flux1)
-        # spectral_index = d_log_flux / dz
-        energy1 = energy
-        energy2 = (1. + dz) * energy
-        spectral_index = powerlaw.g_from_points(energy1, energy2, flux1, flux2)
-
-        return spectral_index
-
     def integral_flux_image(self, energy_band, energy_bins=10):
         """Integral flux image for a given energy band.
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -358,7 +358,7 @@ class SkyCube(object):
         data = np.nansum(np.nansum(self.data, axis=1), axis=1)
         return CountsSpectrum(data=data, energy=self.energy)
 
-    def lookup(self, position, energy, interpolation=None):
+    def lookup(self, position, energy, interpolation=False):
         """Differential flux.
 
         Parameters
@@ -379,8 +379,14 @@ class SkyCube(object):
 
         z, y, x = self.wcs_skycoord_to_pixel(position, energy)
        
-        return self.data[np.rint(z).astype('int'), np.rint(y).astype('int'),
-                         np.rint(x).astype('int')]
+        if interpolation:
+            shape = z.shape
+            pix_coords = np.column_stack([x.flat, y.flat, z.flat])
+            vals = self._interpolate(pix_coords)
+            return vals.reshape(shape)
+        else:
+            return self.data[np.rint(z).astype('int'), np.rint(y).astype('int'),
+                             np.rint(x).astype('int')]
 
     def show(self, viewer='mpl', ds9options=None, **kwargs):
         """

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -36,7 +36,7 @@ def exposure_cube(pointing,
     expcube : `~gammapy.data.SkyCube`
         Exposure cube (3D)
     """
-    coordinates = ref_cube.spatial.coordinates()
+    coordinates = ref_cube.ref_sky_image.coordinates()
     offset = coordinates.separation(pointing)
     offset = np.clip(offset, Angle(0, 'deg'), offset_max)
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -36,11 +36,8 @@ def exposure_cube(pointing,
     expcube : `~gammapy.data.SkyCube`
         Exposure cube (3D)
     """
-    ny, nx = ref_cube.data.shape[1:]
-    xx, yy = np.meshgrid(np.arange(nx), np.arange(ny))
-    lon, lat, en = ref_cube.pix2world(xx, yy, 0)
-    coord = SkyCoord(lon, lat, frame=ref_cube.wcs.wcs.radesys.lower())  # don't care about energy
-    offset = coord.separation(pointing)
+    coordinates = ref_cube.spatial.coordinates()
+    offset = coordinates.separation(pointing)
     offset = np.clip(offset, Angle(0, 'deg'), offset_max)
 
     energy = EnergyBounds(ref_cube.energy).log_centers

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -45,19 +45,17 @@ def compute_npred_cube(flux_cube, exposure_cube, energy_bins,
 
     energy_centers = energy_bins.log_centers
     wcs = exposure_cube.wcs
-    coordinates = exposure_cube.coordinates()
-    lon = coordinates.data.lon
-    lat = coordinates.data.lat
+    coordinates = exposure_cube.spatial.coordinates()
+    solid_angle = exposure_cube.spatial.solid_angle()
 
-    solid_angle = exposure_cube.solid_angle
     npred_cube = np.zeros((len(energy_bins) - 1,
                            exposure_cube.data.shape[1], exposure_cube.data.shape[2]))
     for i in range(len(energy_bins) - 1):
         energy_bound = energy_bins[i:i + 2]
         int_flux = flux_cube.integral_flux_image(energy_bound, integral_resolution)
         int_flux = Quantity(int_flux.data, '1 / (cm2 s sr)')
-        exposure = Quantity(exposure_cube.flux(lon, lat,
-                                               energy_centers[i]).value, 'cm2 s')
+        energy = energy_centers[i] * np.ones(coordinates.shape)
+        exposure = Quantity(exposure_cube.lookup(coordinates, energy, interpolation=True), 'cm2 s')
         npred_image = int_flux * exposure * solid_angle
         npred_cube[i] = npred_image.to('')
     npred_cube = np.nan_to_num(npred_cube)

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -45,8 +45,8 @@ def compute_npred_cube(flux_cube, exposure_cube, energy_bins,
 
     energy_centers = energy_bins.log_centers
     wcs = exposure_cube.wcs
-    coordinates = exposure_cube.spatial.coordinates()
-    solid_angle = exposure_cube.spatial.solid_angle()
+    coordinates = exposure_cube.ref_sky_image.coordinates()
+    solid_angle = exposure_cube.ref_sky_image.solid_angle()
 
     npred_cube = np.zeros((len(energy_bins) - 1,
                            exposure_cube.data.shape[1], exposure_cube.data.shape[2]))

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -253,13 +253,10 @@ class SkyImage(object):
         if weights is not None:
             weights = events[weights]
 
-        xx, yy = self._events_xy(events)
+        xx, yy = self.wcs_skycoord_to_pixel(events.radec)
         bins = self._bins_pix
         data = np.histogramdd([yy, xx], bins, weights=weights)[0]
         self.data = self.data + data
-
-    def _events_xy(self, events):
-        return self.wcs_skycoord_to_pixel(events.radec)
 
     @property
     def _bins_pix(self):

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -189,6 +189,39 @@ class CountsSpectrum(NDDataArray):
         """
         return deepcopy(self)
 
+    def spectral_index(self, energy, dz=1e-3):
+        """Power law spectral index (`numpy.array`).
+
+        A forward finite difference method with step ``dz`` is used along
+        the ``z = log10(energy)`` axis.
+
+        Parameters
+        ----------
+        lon : `~astropy.coordinates.Angle`
+            Longitude
+        lat : `~astropy.coordinates.Angle`
+            Latitude
+        energy : `~astropy.units.Quantity`
+            Energy
+        """
+        raise NotImplementedError
+        # Compute flux at `z = log(energy)`
+        pix_coord = self.world2pix(lon, lat, energy, combine=True)
+        flux1 = self._interpolate(pix_coord)
+
+        # Compute flux at `z + dz`
+        pix_coord[:, 0] += dz
+        # pixel_coordinates += np.zeros(pixel_coordinates.shape)
+        flux2 = self._interpolate(pix_coord)
+
+        # Power-law spectral index through these two flux points
+        # d_log_flux = np.log(flux2 / flux1)
+        # spectral_index = d_log_flux / dz
+        energy1 = energy
+        energy2 = (1. + dz) * energy
+        spectral_index = powerlaw.g_from_points(energy1, energy2, flux1, flux2)
+
+        return spectral_index
 
 class PHACountsSpectrum(CountsSpectrum):
     """OGIP PHA equivalent

--- a/gammapy/spectrum/tests/test_sed.py
+++ b/gammapy/spectrum/tests/test_sed.py
@@ -119,7 +119,7 @@ def test_cube_sed1():
     counts = FermiGalacticCenter.diffuse_model()
     counts.data = np.ones_like(counts.data)
 
-    coordinates = spec_cube.spatial.coordinates()
+    coordinates = spec_cube.ref_sky_image.coordinates()
     lons = coordinates.data.lon
     lats = coordinates.data.lat
 
@@ -148,7 +148,7 @@ def test_cube_sed2():
     counts = FermiGalacticCenter.diffuse_model()
     counts.data = np.ones_like(counts.data[:-1])
 
-    coordinates = spec_cube.spatial.coordinates()
+    coordinates = spec_cube.ref_sky_image.coordinates()
     lons = coordinates.data.lon
     lats = coordinates.data.lat
 

--- a/gammapy/spectrum/tests/test_sed.py
+++ b/gammapy/spectrum/tests/test_sed.py
@@ -119,7 +119,7 @@ def test_cube_sed1():
     counts = FermiGalacticCenter.diffuse_model()
     counts.data = np.ones_like(counts.data)
 
-    coordinates = spec_cube.coordinates()
+    coordinates = spec_cube.spatial.coordinates()
     lons = coordinates.data.lon
     lats = coordinates.data.lat
 
@@ -148,7 +148,7 @@ def test_cube_sed2():
     counts = FermiGalacticCenter.diffuse_model()
     counts.data = np.ones_like(counts.data[:-1])
 
-    coordinates = spec_cube.coordinates()
+    coordinates = spec_cube.spatial.coordinates()
     lons = coordinates.data.lon
     lats = coordinates.data.lat
 


### PR DESCRIPTION
This PR refactors the `SkyCube` class as following:

* Removed `.coordinates()` and `.solid_angle()` methods. These can be now accessed via `SkyCube.spatial.coordinates()`, where `SkyCube.spatial` is a property returning a reference `SkyImage`
* Add a simple  `SkyCube.show()` method that works in notebooks with a slider
* Simplify `SkyCube.reproject()` by reusing `SkyImage.reproject()`
* Replace `SkyCube.world2pix()` by `SkyCube. wcs_skycoord_to_pixel()` which takes `SkyCoord` objects and makes it consistent with `SkyImage`
* Replace `SkyCube.pix2world()` by `SkyCube. wcs_pixel_to_skycoord()` which returns `SkyCoord` objects and makes it consistent with `SkyImage`
* Rename `SkyCube.flux()` to `SkyCube.lookup()`, which is now consistent with `SkyImage`


