### PR TITLE
Rework cube energy axes

### DIFF
--- a/docs/cube/index.rst
+++ b/docs/cube/index.rst
@@ -28,9 +28,9 @@ Use `~gammapy.cube.SkyCube` to read a Fermi-LAT diffuse model cube::
 
     >>> from gammapy.cube import SkyCube
     >>> filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/fermi/gll_iem_v02_cutout.fits'
-    >>> cube = SkyCube.read(filename)
+    >>> cube = SkyCube.read(filename, format='fermi-background')
     >>> print(cube)
-    Sky cube None with shape=(30, 21, 61) and unit=1 / (cm2 MeV s sr):
+    Sky cube flux with shape=(30, 21, 61) and unit=1 / (cm2 MeV s sr):
      n_lon:       61  type_lon:    GLON-CAR         unit_lon:    deg
      n_lat:       21  type_lat:    GLAT-CAR         unit_lat:    deg
      n_energy:    30  unit_energy: MeV
@@ -38,8 +38,8 @@ Use `~gammapy.cube.SkyCube` to read a Fermi-LAT diffuse model cube::
 Use the cube methods to do computations::
 
     import astropy.units as u
-    energy_band = [1, 10] * u.GeV
-    image = cube.integral_flux_image(energy_band=energy_band)
+    emin, emax = [1, 10] * u.GeV
+    image = cube.sky_image_integral(emin=emin, emax=emax)
     image.show('ds9')
 
 TODO: also show how to work with counts and exposure cube using the example at ``test_datasets/unbundled/fermi``

--- a/docs/tutorials/catalog/simulated_image_demo.py
+++ b/docs/tutorials/catalog/simulated_image_demo.py
@@ -53,7 +53,7 @@ image = catalog_image(reference, psf, catalog='simulation', source_type='point',
                       total_flux=True, sim_table=table)
 
 # Plot
-fig = FITSFigure(image.to_fits()[0], figsize=(15, 5))
+fig = FITSFigure(image.to_fits(format='fermi-background')[0], figsize=(15, 5))
 fig.show_colorscale(interpolation='bicubic', cmap='afmhot', stretch='log', vmin=1E30, vmax=1E35)
 fig.tick_labels.set_xformat('ddd')
 fig.tick_labels.set_yformat('dd')

--- a/docs/tutorials/catalog/source_image_demo.py
+++ b/docs/tutorials/catalog/source_image_demo.py
@@ -17,7 +17,7 @@ image = catalog_image(reference, psf, catalog='1FHL', source_type='point',
                       total_flux='True')
 
 # Plot
-fig = FITSFigure(image.to_fits()[0], figsize=(15, 5))
+fig = FITSFigure(image.to_fits(format='fermi-background')[0], figsize=(15, 5))
 fig.show_colorscale(interpolation='bicubic', cmap='afmhot', stretch='log', vmin=1E-12, vmax=1E-8)
 fig.tick_labels.set_xformat('ddd')
 fig.tick_labels.set_yformat('dd')

--- a/docs/tutorials/npred/npred_general.py
+++ b/docs/tutorials/npred/npred_general.py
@@ -17,8 +17,8 @@ def prepare_images():
     background_file = FermiVelaRegion.filenames()['diffuse_model']
     exposure_file = FermiVelaRegion.filenames()['exposure_cube']
     counts_file = FermiVelaRegion.filenames()['counts_cube']
-    background_model = SkyCube.read(background_file)
-    exposure_cube = SkyCube.read(exposure_file)
+    background_model = SkyCube.read(background_file, format='fermi-background')
+    exposure_cube = SkyCube.read(exposure_file, format='fermi-exposure')
 
     # Add correct units
     exposure_cube.data = Quantity(exposure_cube.data.value, 'cm2 s')

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -199,7 +199,7 @@ class SkyCube(object):
 
     @property
     def _bins_energy(self):
-        return np.arange(self.data.shape[0] + 1)
+        return np.arange(self.data.shape[0] + 1) - 0.5
 
     @classmethod
     def empty(cls, emin=0.5, emax=100, enumbins=10, eunit='TeV', **kwargs):

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -31,19 +31,21 @@ __all__ = ['SkyCube']
 
 
 class SkyCube(object):
-    """Sky cube with dimensions lon, lat and energy.
+    """
+    Sky cube with dimensions lon, lat and energy.
 
-    Can be used e.g. for Fermi or GALPROP diffuse model cubes.
 
-    Note that there is a very nice ``SkyCube`` implementation here:
-    http://spectral-cube.readthedocs.io/en/latest/index.html
+    .. note::
 
-    Here is some discussion if / how it could be used:
-    https://github.com/radio-astro-tools/spectral-cube/issues/110
+        There is a very nice ``SkyCube`` implementation here:
+        http://spectral-cube.readthedocs.io/en/latest/index.html
+
+        Here is some discussion if / how it could be used:
+        https://github.com/radio-astro-tools/spectral-cube/issues/110
 
     For now we re-implement what we need here.
 
-    The order of the sky cube axes can be very confusing ... this should help:
+    The order of the sky cube axes is defined as following:
 
     * The ``data`` array axis order is ``(energy, lat, lon)``.
     * The ``wcs`` object is a two dimensional celestial WCS with axis order ``(lon, lat)``.
@@ -51,36 +53,16 @@ class SkyCube(object):
     Parameters
     ----------
     name : str
-        Name of the sky cube.
-    data : `~astropy.units.Quantity`
-        Data array (3-dim)
+        Name of the cube.
+    data : `~numpy.ndarray`
+        Data array.
     wcs : `~astropy.wcs.WCS`
-        Word coordinate system transformation
-    energy : `~astropy.units.Quantity`
-        Energy array
-
-    Attributes
-    ----------
-    data : `~astropy.units.Quantity`
-        Data array (3-dim)
-    wcs : `~astropy.wcs.WCS`
-        Word coordinate system transformation
-    energy : `~astropy.units.Quantity`
-        Energy values, at the center of the bin.
+        WCS transformation object.
     energy_axis : `~gammapy.spectrum.LogEnergyAxis`
-        Energy axis
+        Energy axis object, defining the energy transformation.
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
 
-
-    Notes
-    -----
-    Diffuse model files in this format are distributed with the Fermi Science tools
-    software and can also be downloaded at
-    http://fermi.gsfc.nasa.gov/ssc/data/access/lat/BackgroundModels.html
-
-    E.g. the 2-year diffuse model that was used in the 2FGL catalog production is at
-    http://fermi.gsfc.nasa.gov/ssc/data/analysis/software/aux/gal_2yearp7v6_v0.fits
     """
 
     def __init__(self, name=None, data=None, wcs=None, energy_axis=None, meta=None):

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -477,8 +477,10 @@ class SkyCube(object):
             z, y, x = np.meshgrid(z, y, x, indexing='ij')
             data = self._interpolate_data(z, y, x)
         else:
-            energy = self.energies()
-            data = self.data
+            zmin = np.rint(self.energy_axis.world2pix(emin)).astype('int')
+            zmax = np.rint(self.energy_axis.world2pix(emax)).astype('int')
+            energy = self.energies()[zmin:zmax]
+            data = self.data[zmin:zmax]
         integral = _trapz_loglog(data, energy, axis=0)
         name = 'integrated {}'.format(self.name)
         return SkyImage(name=name, data=integral, wcs=self.wcs.celestial)

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -36,17 +36,17 @@ def exposure_cube(pointing,
     expcube : `~gammapy.data.SkyCube`
         Exposure cube (3D)
     """
-    coordinates = ref_cube.ref_sky_image.coordinates()
+    coordinates = ref_cube.sky_image_ref.coordinates()
     offset = coordinates.separation(pointing)
     offset = np.clip(offset, Angle(0, 'deg'), offset_max)
 
-    energy = EnergyBounds(ref_cube.energy).log_centers
+    energy = ref_cube.energy_axis.energy
     exposure = aeff2d.evaluate(offset=offset, energy=energy)
     exposure *= livetime
 
     expcube = SkyCube(data=exposure,
                       wcs=ref_cube.wcs,
-                      energy=ref_cube.energy)
+                      energy=energy)
     return expcube
 
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -40,13 +40,13 @@ def exposure_cube(pointing,
     offset = coordinates.separation(pointing)
     offset = np.clip(offset, Angle(0, 'deg'), offset_max)
 
-    energy = ref_cube.energy_axis.energy
+    energy = ref_cube.energies()
     exposure = aeff2d.evaluate(offset=offset, energy=energy)
     exposure *= livetime
 
     expcube = SkyCube(data=exposure,
                       wcs=ref_cube.wcs,
-                      energy=energy)
+                      energy_axis=ref_cube.energy_axis)
     return expcube
 
 

--- a/gammapy/cube/images.py
+++ b/gammapy/cube/images.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
 from .core import SkyCube
+from ..spectrum import LogEnergyAxis
 
 __all__ = ['SkyCubeImages']
 
@@ -41,4 +42,6 @@ class SkyCubeImages(object):
         else:
             unit = None
         data = Quantity([image.data for image in self.images], unit)
-        return SkyCube(name=self.name, data=data, wcs=self.wcs, energy=self.energy, meta=self.meta)
+        energy_axis = LogEnergyAxis(self.energy)
+        return SkyCube(name=self.name, data=data, wcs=self.wcs,
+                       energy_axis=energy_axis, meta=self.meta)

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -121,7 +121,7 @@ class TestSkyCube(object):
         """)
         assert actual == expected
 
-
+@requires_dependency('scipy')
 class TestSkyCubeInterpolation(object):
     def setup(self):
         # Set up powerlaw
@@ -158,10 +158,10 @@ class TestSkyCubeInterpolation(object):
 
         # Check if reprojection conserves total flux
         integral = self.sky_cube.sky_image_integral(emin, emax)
-        flux = (integral.data * integral.solid_angle().data).sum()
+        flux = (integral.data * integral.solid_angle()).sum()
 
         integral_rep = reprojected.sky_image_integral(emin, emax)
-        flux_rep = (integral_rep.data * integral_rep.solid_angle().data).sum()
+        flux_rep = (integral_rep.data * integral_rep.solid_angle()).sum()
 
         assert_quantity_allclose(flux, flux_rep)
 

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -43,7 +43,7 @@ class TestSkyCube(object):
 
     def test_read_write(self, tmpdir):
         filename = str(tmpdir / 'sky_cube.fits')
-        self.sky_cube.write(filename)
+        self.sky_cube.write(filename, format='fermi-background')
 
         sky_cube = SkyCube.read(filename, format='fermi-background')
         assert sky_cube.data.shape == (30, 21, 61)
@@ -133,7 +133,7 @@ class TestSkyCubeInterpolation(object):
 
         # Set up data cube
         cube = SkyCube.empty(emin=emin, emax=emax, enumbins=4, nxpix=3, nypix=3)
-        data = pwl(cube.energy_axis.energy).reshape(-1, 1, 1) * np.ones(cube.data.shape[1:])
+        data = pwl(cube.energies()).reshape(-1, 1, 1) * np.ones(cube.data.shape[1:])
         cube.data = data
         self.sky_cube = cube
         self.pwl = pwl

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
 from astropy.tests.helper import pytest, assert_quantity_allclose
-from astropy.units import Quantity
+import astropy.units as u
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
 
@@ -16,6 +16,7 @@ from ...datasets import FermiGalacticCenter
 from ...image import make_header
 from ...irf import EnergyDependentTablePSF
 from ...spectrum.powerlaw import power_law_evaluate
+from ...spectrum.models import PowerLaw2
 from .. import SkyCube, compute_npred_cube, convolve_cube
 
 
@@ -26,11 +27,16 @@ class TestSkyCube(object):
         self.sky_cube = FermiGalacticCenter.diffuse_model()
         assert self.sky_cube.data.shape == (30, 21, 61)
 
+    def test_to_images(self):
+        images = self.sky_cube.to_images()
+        cube = images.to_cube()
+        SkyCube.assert_allclose(self.sky_cube, cube)
+
     def test_init(self):
         name = 'Axel'
         data = self.sky_cube.data
         wcs = self.sky_cube.wcs
-        energy = self.sky_cube.energy
+        energy = self.sky_cube.energy_axis.energy
 
         sky_cube = SkyCube(name, data, wcs, energy)
         assert sky_cube.data.shape == (30, 21, 61)
@@ -39,20 +45,20 @@ class TestSkyCube(object):
         filename = str(tmpdir / 'sky_cube.fits')
         self.sky_cube.write(filename)
 
-        sky_cube = SkyCube.read(filename)
+        sky_cube = SkyCube.read(filename, format='fermi-background')
         assert sky_cube.data.shape == (30, 21, 61)
 
     def test_pixel_to_skycoord(self):
         # Corner pixel with index [0, 0, 0]
         position, energy = self.sky_cube.wcs_pixel_to_skycoord(0, 0, 0)
         lon, lat = position.galactic.l, position.galactic.b
-        assert_quantity_allclose(lon, Quantity(344.75, 'deg'))
-        assert_quantity_allclose(lat, Quantity(-5.25, 'deg'))
-        assert_quantity_allclose(energy, Quantity(50, 'MeV'))
+        assert_quantity_allclose(lon, 344.75 * u.deg)
+        assert_quantity_allclose(lat, -5.25 * u.deg)
+        assert_quantity_allclose(energy, 50 * u.MeV)
 
     def test_skycoord_to_pixel(self):
         position = SkyCoord(344.75, -5.25, frame='galactic', unit='deg')
-        energy = Quantity(50, 'MeV')
+        energy = 50 * u.MeV
         x, y, z = self.sky_cube.wcs_skycoord_to_pixel(position, energy)
         assert_allclose((x, y, z), (0, 0, 0))
 
@@ -69,36 +75,10 @@ class TestSkyCube(object):
         pix2 = self.sky_cube.wcs_skycoord_to_pixel(*world)
         assert_allclose(pix2, pix)
 
-    @pytest.mark.xfail
-    def test_flux_scalar(self):
-        # Corner pixel with index [0, 0, 0]
-        lon = Quantity(344.75, 'deg')  # pixel 0
-        lat = Quantity(-5.25, 'deg')  # pixel 0
-        energy = Quantity(50, 'MeV')  # slice 0
-        actual = self.sky_cube.flux(lon, lat, energy)
-        expected = self.sky_cube.data[0, 0, 0]
-        assert_quantity_allclose(actual, expected)
-
-        # Galactic center position
-        lon = Quantity(0, 'deg')  # beween pixel 11 and 12 in ds9 viewer
-        lat = Quantity(0, 'deg')  # beween pixel 30 and 31 in ds9 viewer
-        energy = Quantity(528.9657943133443, 'MeV')  # slice 10 in ds9 viewer
-        actual = self.sky_cube.flux(lon, lat, energy)
-        # Compute expected value by interpolating 4 neighbors
-        # Use data axis order: energy, lat, lon
-        # and remember that numpy starts counting at 0 whereas FITS start at 1
-        s = self.sky_cube.data
-        expected = s[9, 10:12, 29:31].mean()
-
-        # TODO: why are these currently inconsistent by a few % !?
-        # actual   =  9.67254380e-07
-        # expected = 10.13733026e-07
-        assert_quantity_allclose(actual, expected)
-
     def test_lookup(self):
         # Corner pixel with index [0, 0, 0]
         position = SkyCoord(344.75, -5.25, frame='galactic', unit='deg')
-        energy = Quantity(50, 'MeV')  # slice 0
+        energy = 50 * u.MeV  # slice 0
         actual = self.sky_cube.lookup(position, energy)
         expected = self.sky_cube.data[0, 0, 0]
         assert_quantity_allclose(actual, expected)
@@ -111,47 +91,62 @@ class TestSkyCube(object):
         # Quantity([3.50571123e-07, 2], '1 / (cm2 MeV s sr)')
         assert_quantity_allclose(actual, expected)
 
-    def test_integral_flux_image(self):
+    def test_sky_image_integral(self):
         # For a very small energy band the integral flux should be roughly
         # differential flux times energy bin width
         position, energy = self.sky_cube.wcs_pixel_to_skycoord(0, 0, 0)
         denergy = 0.001 * energy
-        energy_band = Quantity([energy, energy + denergy])
-        dflux = self.sky_cube.lookup(position, energy)
+        emin, emax = energy, energy + denergy
+        dflux = self.sky_cube.lookup(position, energy, interpolation='linear')
         expected = dflux * denergy
-        actual = Quantity(self.sky_cube.integral_flux_image(energy_band).data[0, 0],
-                          '1 / (cm2 s sr)')
-        assert_quantity_allclose(actual, expected, rtol=1e-3)
+        actual = self.sky_cube.sky_image_integral(emin, emax, nbins=100)
+        assert_quantity_allclose(actual.data[0, 0], expected, rtol=1e-3)
 
         # Test a wide energy band
-        energy_band = Quantity([1, 10], 'GeV')
-        image = self.sky_cube.integral_flux_image(energy_band)
-        actual = image.data.sum()
+        emin, emax = [1, 10] * u.GeV
+        image = self.sky_cube.sky_image_integral(emin, emax, nbins=100)
+        unit = '1 / (s sr cm2)'
+        actual = image.data.sum().to(unit)
         # TODO: the reference result is not verified ... just pasted from the test output.
-        expected = 5.2481972772213124e-02
+        expected = 0.05098313774120132 * u.Unit(unit)
         assert_allclose(actual, expected)
-
-        # Test integral flux for energy bands with units.
-        energy_band_check = Quantity([1000, 10000], 'MeV')
-        new_image = self.sky_cube.integral_flux_image(energy_band_check)
-        assert_allclose(new_image.data, image.data)
-
-        assert new_image.wcs.axis_type_names == ['GLON', 'GLAT']
-
-    def test_to_images(self):
-        images = self.sky_cube.to_images()
-        cube = images.to_cube()
-        SkyCube.assert_allclose(self.sky_cube, cube)
 
     def test_repr(self):
         actual = repr(self.sky_cube)
         expected = textwrap.dedent("""\
-        Sky cube None with shape=(30, 21, 61) and unit=1 / (cm2 MeV s sr):
+        Sky cube flux with shape=(30, 21, 61) and unit=1 / (cm2 MeV s sr):
          n_lon:       61  type_lon:    GLON-CAR         unit_lon:    deg
          n_lat:       21  type_lat:    GLAT-CAR         unit_lat:    deg
          n_energy:    30  unit_energy: MeV
         """)
         assert actual == expected
+
+
+class TestSkyCubeInterpolation(object):
+    def setup(self):
+        # Set up powerlaw
+        amplitude = 1E-12 * u.Unit('1 / (s cm2)')
+        index = 2
+        emin = 1 * u.TeV
+        emax = 100 * u.TeV
+        pwl = PowerLaw2(amplitude, index, emin, emax)
+
+        # Set up data cube
+        cube = SkyCube.empty(emin=emin, emax=emax, enumbins=4, nxpix=3, nypix=3)
+        data = pwl(cube.energy_axis.energy).reshape(-1, 1, 1) * np.ones(cube.data.shape[1:])
+        cube.data = data
+        self.sky_cube = cube
+        self.pwl = pwl
+
+    def test_sky_image(self):
+        energy = 50 * u.TeV
+        image = self.sky_cube.sky_image(energy, interpolation='linear')
+        assert_quantity_allclose(image.data, self.pwl(energy))
+
+    def test_sky_image_integrate(self):
+        emin, emax = [1, 100] * u.TeV
+        integral = self.sky_cube.sky_image_integral(emin, emax)
+        assert_quantity_allclose(integral.data, self.pwl.integral(emin, emax))
 
 
 @pytest.mark.xfail
@@ -301,7 +296,7 @@ def test_reproject_cube():
 def test_bin_events_in_cube():
     filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_events_023523.fits.gz'
     events = EventList.read(filename)
-    counts = SkyCube.empty(emin=0.5, emax=80, enbins=8, eunit='TeV',
+    counts = SkyCube.empty(emin=0.5, emax=80, enumbins=8, eunit='TeV',
                            nxpix=200, nypix=200, xref=events.meta['RA_OBJ'],
                            yref=events.meta['DEC_OBJ'], dtype='int',
                            coordsys='CEL')

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -125,7 +125,7 @@ class TestSkyCube(object):
 class TestSkyCubeInterpolation(object):
     def setup(self):
         # Set up powerlaw
-        amplitude = 1E-12 * u.Unit('1 / (s cm2)')
+        amplitude = 1E-12 * u.Unit('1 / (s sr cm2)')
         index = 2
         emin = 1 * u.TeV
         emax = 100 * u.TeV
@@ -147,6 +147,24 @@ class TestSkyCubeInterpolation(object):
         emin, emax = [1, 100] * u.TeV
         integral = self.sky_cube.sky_image_integral(emin, emax)
         assert_quantity_allclose(integral.data, self.pwl.integral(emin, emax))
+
+
+    def test_reproject(self):
+        emin = 1 * u.TeV
+        emax = 100 * u.TeV
+        ref = SkyCube.empty(emin=emin, emax=emax, enumbins=4, nxpix=6, nypix=6,
+                            binsz=0.01)
+        reprojected = self.sky_cube.reproject(ref)
+
+        # Check if reprojection conserves total flux
+        integral = self.sky_cube.sky_image_integral(emin, emax)
+        flux = (integral.data * integral.solid_angle().data).sum()
+
+        integral_rep = reprojected.sky_image_integral(emin, emax)
+        flux_rep = (integral_rep.data * integral_rep.solid_angle().data).sum()
+
+        assert_quantity_allclose(flux, flux_rep)
+
 
 
 @pytest.mark.xfail

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -148,7 +148,7 @@ class TestSkyCubeInterpolation(object):
         integral = self.sky_cube.sky_image_integral(emin, emax)
         assert_quantity_allclose(integral.data, self.pwl.integral(emin, emax))
 
-
+    @requires_dependency('reproject')
     def test_reproject(self):
         emin = 1 * u.TeV
         emax = 100 * u.TeV

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -87,7 +87,7 @@ class TestSkyCube(object):
         pix = [2, 2], [3, 3], [4, 4]
         position, energy = self.sky_cube.wcs_pixel_to_skycoord(*pix)
         actual = self.sky_cube.lookup(position, energy)
-        expected = self.sky_cube.data[2, 3, 4]
+        expected = self.sky_cube.data[4, 3, 2]
         # Quantity([3.50571123e-07, 2], '1 / (cm2 MeV s sr)')
         assert_quantity_allclose(actual, expected)
 

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -27,6 +27,6 @@ def test_exposure_cube():
     assert np.shape(exp_cube.data)[1:] == np.shape(count_cube.data)[1:]
     assert np.shape(exp_cube.data)[0] == np.shape(count_cube.data)[0]
     assert exp_cube.wcs == count_cube.wcs
-    assert_equal(count_cube.energy, exp_cube.energy)
+    assert_equal(count_cube.energy_axis.energy, exp_cube.energy_axis.energy)
     assert_quantity_allclose(np.nanmax(exp_cube.data), exp_ref, rtol=100)
     assert exp_cube.data.unit == exp_ref.unit

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -48,10 +48,10 @@ def test_sherpa_crab_fit():
     fit = Fit(data=cube, model=model, stat=Chi2ConstVar(), method=LevMar())
     result = fit.fit()
 
-    reference = [1.216745e-01,
-                 8.362456e+01,
-                 2.201813e+01,
-                 7.811623e-02,
-                 2.201211e+00]
+    reference = [0.121556,
+                 83.625627,
+                 22.015564,
+                 0.096903,
+                 2.240989]
 
     assert_allclose(result.parvals, reference, rtol=1E-5)

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -17,7 +17,8 @@ def test_sherpa_crab_fit():
     from ..sherpa_ import CombinedModel3D
 
     filename = gammapy_extra.filename('experiments/sherpa_cube_analysis/counts.fits.gz')
-    counts = SkyCube.read(filename)
+    # Note: The cube is stored in incorrect format
+    counts = SkyCube.read(filename, format='fermi-counts')
     cube = counts.to_sherpa_data3d()
 
     # Set up exposure table model
@@ -47,10 +48,10 @@ def test_sherpa_crab_fit():
     fit = Fit(data=cube, model=model, stat=Chi2ConstVar(), method=LevMar())
     result = fit.fit()
 
-    reference = (0.11925401159500593,
-                 83.640630749333056,
-                 22.020525848447541,
-                 0.036353759774770608,
-                 1.1900312815970555)
+    reference = [1.216745e-01,
+                 8.362456e+01,
+                 2.201813e+01,
+                 7.811623e-02,
+                 2.201211e+00]
 
-    assert_allclose(result.parvals, reference, rtol=1E-8)
+    assert_allclose(result.parvals, reference, rtol=1E-5)

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -74,7 +74,7 @@ class FermiGalacticCenter(object):
         """Diffuse model (`~gammapy.data.SkyCube`)"""
         from ..cube import SkyCube
         filename = FermiGalacticCenter.filenames()['diffuse_model']
-        return SkyCube.read(filename)
+        return SkyCube.read(filename, format='fermi-background')
 
     @staticmethod
     def exposure_cube():
@@ -134,7 +134,7 @@ class FermiVelaRegion(object):
         """Diffuse model (`~gammapy.data.SkyCube`)"""
         from ..cube import SkyCube
         filename = FermiVelaRegion.filenames()['diffuse_model']
-        return SkyCube.read(filename)
+        return SkyCube.read(filename, format='fermi-background')
 
     @staticmethod
     def background_image():

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -81,7 +81,7 @@ class FermiGalacticCenter(object):
         """Exposure cube (`~gammapy.data.SkyCube`)"""
         from ..cube import SkyCube
         filename = FermiGalacticCenter.filenames()['exposure_cube']
-        return SkyCube.read(filename)
+        return SkyCube.read(filename, format='fermi-exposure')
 
 
 class FermiVelaRegion(object):
@@ -172,7 +172,7 @@ class FermiVelaRegion(object):
         """Exposure cube (`~gammapy.data.SkyCube`)."""
         from ..cube import SkyCube
         filename = FermiVelaRegion.filenames()['exposure_cube']
-        return SkyCube.read(filename)
+        return SkyCube.read(filename, format='fermi-exposure')
 
     @staticmethod
     def livetime_cube():

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -34,12 +34,12 @@ class TestFermiGalacticCenter:
     def test_diffuse_model(self):
         diffuse_model = FermiGalacticCenter.diffuse_model()
         assert diffuse_model.data.shape == (30, 21, 61)
-        assert_quantity_allclose(diffuse_model.energy[0], Quantity(50, 'MeV'))
+        assert_quantity_allclose(diffuse_model.energies()[0], Quantity(50, 'MeV'))
 
     def test_exposure_cube(self):
         exposure_cube = FermiGalacticCenter.exposure_cube()
         assert exposure_cube.data.shape == (21, 11, 31)
-        assert_quantity_allclose(exposure_cube.energy[0], Quantity(50, 'MeV'))
+        assert_quantity_allclose(exposure_cube.energies()[0], Quantity(50, 'MeV'))
 
 
 @requires_data('gammapy-extra')
@@ -84,7 +84,7 @@ class TestFermiVelaRegion:
         exposure_cube = FermiVelaRegion.exposure_cube()
         assert exposure_cube.data.shape == (21, 50, 50)
         assert exposure_cube.data.value.sum(), 4.978616e+15
-        assert_quantity_allclose(exposure_cube.energy[0], Quantity(10000, 'MeV'))
+        assert_quantity_allclose(exposure_cube.energies()[0], Quantity(10000, 'MeV'))
 
     def test_livetime(self):
         livetime_list = FermiVelaRegion.livetime_cube()

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -8,6 +8,7 @@ from astropy.wcs import WCS
 from astropy.units import Quantity
 from astropy.table import Table
 
+
 __all__ = [
     'catalog_image',
     'catalog_table',
@@ -102,12 +103,13 @@ def catalog_image(reference, psf, catalog='1FHL', source_type='point',
     # This import is here instead of at the top to avoid an ImportError
     # due to circular dependencies
     from ..cube import SkyCube
+    from ..spectrum import LogEnergyAxis
 
     wcs = WCS(reference.header)
     # Uses dummy energy for now to construct spectral cube
     # TODO : Fix this hack
     reference_cube = SkyCube(data=Quantity(np.array(reference.data), ''),
-                             wcs=wcs, energy=Quantity([1e-3, 1], 'GeV'))
+                             wcs=wcs)
 
     if source_type == 'extended':
         raise NotImplementedError
@@ -128,7 +130,7 @@ def catalog_image(reference, psf, catalog='1FHL', source_type='point',
     else:
         raise ValueError
 
-    total_point_image = SkyCube(data=new_image, wcs=wcs, energy=energy)
+    total_point_image = SkyCube(data=new_image, wcs=wcs, energy_axis=LogEnergyAxis(energy))
     convolved_cube = new_image.copy()
 
     psf = psf.table_psf_in_energy_band(Quantity([np.min(energy).value,
@@ -142,8 +144,7 @@ def catalog_image(reference, psf, catalog='1FHL', source_type='point',
     convolved_cube = convolve(new_image, kernel_array, mode='constant')
 
     out_cube = SkyCube(data=Quantity(convolved_cube, ''),
-                       wcs=total_point_image.wcs,
-                       energy=energy)
+                       wcs=total_point_image.wcs, energy_axis=LogEnergyAxis(energy))
 
     return out_cube
 

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -9,6 +9,8 @@ from ...image import SkyImage
 from ...irf import EnergyDependentTablePSF
 from ...cube import SkyCube
 from ...datasets import FermiGalacticCenter
+from ...spectrum import LogEnergyAxis
+
 
 
 def test_extended_image():
@@ -20,9 +22,9 @@ def test_extended_image():
 def test_source_image():
     reference_hdu = SkyImage.empty(nxpix=10, nypix=10, binsz=1).to_image_hdu()
     reference_wcs = WCS(reference_hdu.header)
-    energy = Quantity([10, 500], 'GeV')
+    energy_axis = LogEnergyAxis(Quantity([10, 500], 'GeV'))
     reference = SkyCube(data=reference_hdu.data,
-                        wcs=reference_wcs, energy=energy)
+                        wcs=reference_wcs, energy_axis=energy_axis)
 
     psf_file = FermiGalacticCenter.filenames()['psf']
     psf = EnergyDependentTablePSF.read(psf_file)

--- a/gammapy/spectrum/sed.py
+++ b/gammapy/spectrum/sed.py
@@ -317,7 +317,7 @@ def cube_sed(cube, mask=None, flux_type='differential', counts=None,
         errors = np.zeros_like(values)
 
     if flux_type == 'differential':
-        energy = cube.energy
+        energy = cube.energies()
         table = Table()
         table['ENERGY'] = energy
         table['DIFF_FLUX'] = Quantity(values, cube.data.unit)
@@ -326,8 +326,9 @@ def cube_sed(cube, mask=None, flux_type='differential', counts=None,
 
     elif flux_type == 'integral':
 
-        emins = cube.energy[:-1]
-        emaxs = cube.energy[1:]
+        energies = cube.energies(mode='edges')
+        emins = energies[:-1]
+        emaxs = energies[1:]
         table = compute_differential_flux_points(x_method='lafferty',
                                                  y_method='power_law',
                                                  spectral_index=spectral_index,

--- a/gammapy/spectrum/tests/test_sed.py
+++ b/gammapy/spectrum/tests/test_sed.py
@@ -119,7 +119,7 @@ def test_cube_sed1():
     counts = FermiGalacticCenter.diffuse_model()
     counts.data = np.ones_like(counts.data)
 
-    coordinates = spec_cube.ref_sky_image.coordinates()
+    coordinates = spec_cube.sky_image_ref.coordinates()
     lons = coordinates.data.lon
     lats = coordinates.data.lat
 
@@ -148,7 +148,7 @@ def test_cube_sed2():
     counts = FermiGalacticCenter.diffuse_model()
     counts.data = np.ones_like(counts.data[:-1])
 
-    coordinates = spec_cube.ref_sky_image.coordinates()
+    coordinates = spec_cube.sky_image_ref.coordinates()
     lons = coordinates.data.lon
     lats = coordinates.data.lat
 
@@ -156,8 +156,8 @@ def test_cube_sed2():
 
     sed_table1 = cube_sed(spec_cube, mask, flux_type='integral')
 
-    assert_allclose(sed_table1['ENERGY'][0], 56.95239033587774)
-    assert_allclose(sed_table1['DIFF_FLUX'][0], 170.86224025271986)
+    assert_allclose(sed_table1['ENERGY'][0], 53.37451755960359)
+    assert_allclose(sed_table1['DIFF_FLUX'][0], 365.64943655965686)
     assert_allclose(sed_table1['DIFF_FLUX_ERR_HI'], 0)
 
     sed_table2 = cube_sed(spec_cube, mask, flux_type='integral',

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -32,10 +32,13 @@ class LogEnergyAxis(object):
         Energy array
     """
 
-    def __init__(self, energy):
+    def __init__(self, energy, mode='center'):
         self.energy = energy
         self.x = np.log10(energy.value)
-        self.pix = np.arange(len(self.x))
+        if mode == 'center':
+            self.pix = np.arange(len(self.x))
+        elif mode == 'edges':
+            self.pix = np.arange(len(self.x)) - 0.5
 
     def world2pix(self, energy):
         """TODO: document.

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -35,10 +35,14 @@ class LogEnergyAxis(object):
     def __init__(self, energy, mode='center'):
         self.energy = energy
         self.x = np.log10(energy.value)
+
         if mode == 'center':
             self.pix = np.arange(len(self.x))
         elif mode == 'edges':
             self.pix = np.arange(len(self.x)) - 0.5
+        else:
+            raise ValueError('Not a valid mode.')
+
 
     def world2pix(self, energy):
         """TODO: document.

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -46,7 +46,7 @@ class LogEnergyAxis(object):
         # Interpolate in `x`
         pix = np.interp(x, self.x, self.pix)
 
-        return pix
+        return np.atleast_1d(pix)
 
     def pix2world(self, pix):
         """TODO: document.
@@ -95,7 +95,7 @@ class LogEnergyAxis(object):
 
 
 def calculate_predicted_counts(model, aeff, edisp, livetime, e_reco=None):
-    """Get npred 
+    """Get npred
 
     The true energy binning is inferred from the provided
     `~gammapy.irf.EffectiveAreaTable`. The reco energy binning can be inferred
@@ -122,7 +122,7 @@ def calculate_predicted_counts(model, aeff, edisp, livetime, e_reco=None):
 
     Examples
     --------
-    Calculate prediced counts in a desired reconstruced energy binning 
+    Calculate prediced counts in a desired reconstruced energy binning
 
     .. plot::
         :include-source:
@@ -183,7 +183,7 @@ def integrate_spectrum(func, xmin, xmax, ndecade=100, intervals=False):
         Function to integrate.
     xmin : `~astropy.units.Quantity` or array-like
         Integration range minimum
-    xmax : `~astropy.units.Quantity` or array-like 
+    xmax : `~astropy.units.Quantity` or array-like
         Integration range minimum
     ndecade : int, optional
         Number of grid points per decade used for the integration.

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -83,7 +83,7 @@ class Energy(Quantity):
         return self[0:self.size:self.size - 1]
 
     @classmethod
-    def equal_log_spacing(cls, emin, emax, nbins, unit=None):
+    def equal_log_spacing(cls, emin, emax, nbins, unit=None, per_decade=False):
         """Create Energy with equal log-spacing (`~gammapy.utils.energy.Energy`).
 
         if no unit is given, it will be taken from emax
@@ -94,10 +94,12 @@ class Energy(Quantity):
             Lowest energy bin
         emax : `~astropy.units.Quantity`, float
             Highest energy bin
-        bins : int
+        nbins : int
             Number of bins
         unit : `~astropy.units.UnitBase`, str
             Energy unit
+        per_decade : bool
+            Whether nbins is per decade.
         """
 
         if unit is not None:
@@ -110,6 +112,9 @@ class Energy(Quantity):
             emin = emin.to(unit)
 
         x_min, x_max = np.log10([emin.value, emax.value])
+
+        if per_decade:
+            nbins = (x_max - x_min) * nbins
         energy = np.logspace(x_min, x_max, nbins)
 
         return cls(energy, unit, copy=False)


### PR DESCRIPTION
This PR is the second part of a major rework of the `SkyCube` class. These are the mos important changes:

* Rename `SkyCube.integral_flux_image()` to `SkyCube.sky_image_integral()`, and reimplement the method using `_trapz_loglog`.
* Add the interpolation options back and modify the interpolation to work in log-log
* Introduce the format options `'fermi-counts',` `'fermi-background'` and `'fermi-exposure'`in  `SkyCube.read()`, because in the previous implementation units and energy ranges were not read and set correctly.
*  Replace `SkyCube.energy` by `SkyCube.energies()` which has the options `'center'` and `'edges'`. This was done because the former `SkyCube.energy` was not well defined. In some cases it represented the edges in some cases the centers.
* Minor: Rename `SkyCube.ref_sky_image` to `SkyCube.sky_image_ref`. This has the advantage that all sky image related properties and methods start with `sky_image_...` and will be listed by tab completion.
* Add more interpolation and reprojection tests in general