### PR TITLE
Rework cube convolution and npred computation

### DIFF
--- a/docs/irf/plot_fermi_psf.py
+++ b/docs/irf/plot_fermi_psf.py
@@ -1,27 +1,23 @@
 """Plot Fermi PSF."""
 import matplotlib.pyplot as plt
-from astropy.coordinates import Angle
-from astropy.units import Quantity
-from astropy.visualization import LogStretch
-from astropy.visualization.mpl_normalize import ImageNormalize
+from astropy import units as u
 from gammapy.datasets import FermiGalacticCenter
 from gammapy.irf import EnergyDependentTablePSF
+from gammapy.image import SkyImage
 
 filename = FermiGalacticCenter.filenames()['psf']
 fermi_psf = EnergyDependentTablePSF.read(filename)
 
-plt.figure(figsize=(6, 6))
+fig = plt.figure(figsize=(6, 5))
 
-energies = Quantity([1], 'GeV')
+# Create an empty sky image to show the PSF
+image_psf = SkyImage.empty()
+
+energies = [1] * u.GeV
 for energy in energies:
     psf = fermi_psf.table_psf_at_energy(energy=energy)
-    psf.normalize()
-    kernel = psf.kernel(pixel_size=Angle(0.1, 'deg'))
-    norm = ImageNormalize(vmin=0., vmax=kernel.max(), stretch=LogStretch())
-    plt.imshow(kernel.value, norm=norm)
-    # psf.plot_psf_vs_theta()
+    image_psf.data = psf.kernel(image_psf)
+    norm = image_psf.plot_norm('log')
+    image_psf.plot(fig=fig, add_cbar=True, norm=norm)
 
-# plt.xlim(1e-2, 10)
-# plt.gca().set_xscale('linear')
-# plt.gca().set_yscale('linear')
 plt.show()

--- a/docs/tutorials/npred/npred_convolved.py
+++ b/docs/tutorials/npred/npred_convolved.py
@@ -24,10 +24,10 @@ f2.tick_labels.set_yformat('dd')
 
 image3 = fits.ImageHDU(data=ratio, header=header)
 f3 = FITSFigure(image3, figure=fig, subplot=(1, 3, 3), convention='wells')
-f3.show_colorscale(vmin=0.9, vmax=1.1, cmap='RdBu')
+f3.show_colorscale(vmin=0.95, vmax=1.05, cmap='RdBu')
 f3.tick_labels.set_xformat('ddd')
 f3.tick_labels.set_yformat('dd')
-f3.add_colorbar(ticks=[0.9, 0.95, 1, 1.05, 1.1])
+f3.add_colorbar(ticks=[0.95, 0.975, 1, 1.025, 1.05])
 
 fig.text(0.12, 0.95, "Gammapy Background")
 fig.text(0.45, 0.95, "Fermi Tools Background")

--- a/docs/tutorials/npred/npred_convolved_significance.py
+++ b/docs/tutorials/npred/npred_convolved_significance.py
@@ -17,7 +17,7 @@ correlated_counts = disk_correlate(counts, correlation_radius)
 correlated_model = disk_correlate(model, correlation_radius)
 
 # Fermi significance
-fermi_significance = np.nan_to_num(significance(correlated_counts, gtmodel,
+fermi_significance = np.nan_to_num(significance(correlated_counts, correlated_gtmodel,
                                                 method='lima'))
 # Gammapy significance
 significance = np.nan_to_num(significance(correlated_counts, correlated_model,
@@ -33,7 +33,7 @@ f1 = FITSFigure(hdu1, figure=fig, convention='wells', subplot=(1, 2, 1))
 f1.set_tick_labels_font(size='x-small')
 f1.tick_labels.set_xformat('ddd')
 f1.tick_labels.set_yformat('ddd')
-f1.show_colorscale(vmin=0, vmax=10, cmap='afmhot')
+f1.show_colorscale(vmin=0, vmax=20, cmap='afmhot', stretch='sqrt')
 f1.add_colorbar(axis_label_text='Significance')
 f1.colorbar.set_width(0.1)
 f1.colorbar.set_location('right')
@@ -44,7 +44,7 @@ f2.set_tick_labels_font(size='x-small')
 f2.tick_labels.set_xformat('ddd')
 f2.hide_ytick_labels()
 f2.hide_yaxis_label()
-f2.show_colorscale(vmin=0, vmax=10, cmap='afmhot')
+f2.show_colorscale(vmin=0, vmax=20, cmap='afmhot', stretch='sqrt')
 f2.add_colorbar(axis_label_text='Significance')
 f2.colorbar.set_width(0.1)
 f2.colorbar.set_location('right')

--- a/docs/tutorials/npred/npred_general.py
+++ b/docs/tutorials/npred/npred_general.py
@@ -4,7 +4,7 @@ from astropy.coordinates import Angle
 from astropy.units import Quantity
 from astropy.io import fits
 from astropy.wcs import WCS
-from gammapy.cube import SkyCube, compute_npred_cube, convolve_cube
+from gammapy.cube import SkyCube, compute_npred_cube
 from gammapy.datasets import FermiVelaRegion
 from gammapy.irf import EnergyDependentTablePSF
 from gammapy.utils.energy import EnergyBounds
@@ -14,14 +14,12 @@ __all__ = ['prepare_images']
 
 def prepare_images():
     # Read in data
+    fermi_vela = FermiVelaRegion()
     background_file = FermiVelaRegion.filenames()['diffuse_model']
     exposure_file = FermiVelaRegion.filenames()['exposure_cube']
     counts_file = FermiVelaRegion.filenames()['counts_cube']
     background_model = SkyCube.read(background_file, format='fermi-background')
     exposure_cube = SkyCube.read(exposure_file, format='fermi-exposure')
-
-    # Add correct units
-    exposure_cube.data = Quantity(exposure_cube.data.value, 'cm2 s')
 
     # Re-project background cube
     repro_bg_cube = background_model.reproject(exposure_cube)
@@ -30,12 +28,13 @@ def prepare_images():
     energies = EnergyBounds([10, 500], 'GeV')
 
     # Compute the predicted counts cube
-    npred_cube = compute_npred_cube(repro_bg_cube, exposure_cube, energies)
+    npred_cube = compute_npred_cube(repro_bg_cube, exposure_cube, energies,
+                                    integral_resolution=5)
 
     # Convolve with Energy-dependent Fermi LAT PSF
     psf = EnergyDependentTablePSF.read(FermiVelaRegion.filenames()['psf'])
-    convolved_npred_cube = convolve_cube(npred_cube, psf,
-                                         offset_max=Angle(3, 'deg'))
+    kernels = psf.kernels(npred_cube)
+    convolved_npred_cube = npred_cube.convolve(kernels, mode='reflect')
 
     # Counts data
     counts_cube = SkyCube.read(counts_file, format='fermi-counts')
@@ -53,5 +52,4 @@ def prepare_images():
     # Header is required for plotting, so returned here
     wcs = npred_cube.wcs
     header = wcs.to_header()
-
     return model, gtmodel, ratio, counts, header

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -374,8 +374,9 @@ class SkyCube(object):
             z, y, x = np.meshgrid(z, y, x, indexing='ij')
             data = self._interpolate_data(z, y, x)[0]
         else:
-            data = self.data[int(z)]
-        return SkyImage(name=self.name, data=data, wcs=self.wcs)
+            data = self.data[int(np.rint(z))].copy()
+        wcs = self.wcs.deepcopy() if self.wcs else None
+        return SkyImage(name=self.name, data=data, wcs=wcs)
 
     def sky_image_idx(self, idx):
         """
@@ -391,8 +392,9 @@ class SkyCube(object):
         image : `~gammapy.image.SkyImage`
             2-dim sky image
         """
-        data = self.data[idx]
-        return SkyImage(name=self.name, data=data, wcs=self.wcs)
+        data = self.data[idx].copy()
+        wcs = self.wcs.deepcopy() if self.wcs else None
+        return SkyImage(name=self.name, data=data, wcs=wcs)
 
     @lazyproperty
     def sky_image_ref(self):

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -641,7 +641,7 @@ class SkyCube(object):
         spectrum : numpy.array
             Summed spectrum of pixels in the mask.
         """
-
+        raise NotImplementedError
         # TODO: clean up API and implementation and add test
         value = cube.dat
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -568,7 +568,7 @@ class SkyCube(object):
             image = self.sky_image_idx(idx)
             data.append(image.convolve(kernel, **kwargs).data)
 
-        convolved = np.stack(data, axis=0)
+        convolved = u.Quantity(data)
         wcs = self.wcs.deepcopy() if self.wcs else None
         return self.__class__(name=self.name, data=convolved, wcs=wcs,
                               energy_axis=self.energy_axis)

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -565,7 +565,7 @@ class SkyCube(object):
                              ' of the cube.')
 
         for idx, kernel in enumerate(kernels):
-            image = cube.sky_image_idx(idx)
+            image = self.sky_image_idx(idx)
             data.append(image.convolve(kernel, **kwargs).data)
 
         convolved = np.stack(data, axis=0)

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -4,17 +4,14 @@ Cube analysis utility functions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from astropy.io.fits import ImageHDU
-from astropy.units import Quantity
-from astropy.coordinates import Angle
+from astropy import units as u
 from ..image import SkyImage
 from .core import SkyCube
 from ..spectrum import LogEnergyAxis
+from ..utils.energy import EnergyBounds
 
 __all__ = [
     'compute_npred_cube',
-    'convolve_cube',
-    'cube_to_spec',
 ]
 
 
@@ -28,9 +25,6 @@ def compute_npred_cube(flux_cube, exposure_cube, energy_bins,
         Differential flux cube.
     exposure_cube : `SkyCube`
         Instrument exposure cube.
-    energy_bins : `~gammapy.utils.energy.EnergyBounds`
-        An array of Quantities specifying the edges of the energy band
-        required for the predicted counts cube.
     integral_resolution : int (optional)
         Number of integration steps in energy bin when computing integral flux.
 
@@ -44,120 +38,21 @@ def compute_npred_cube(flux_cube, exposure_cube, energy_bins,
                          'flux_cube: {0}\nexposure_cube: {1}'
                          ''.format(flux_cube.data.shape[1:], exposure_cube.data.shape[1:]))
 
-    energy_centers = energy_bins.log_centers
-    wcs = exposure_cube.wcs
-    coordinates = exposure_cube.sky_image_ref.coordinates()
-    solid_angle = exposure_cube.sky_image_ref.solid_angle()
+    energy_axis = LogEnergyAxis(energy_bins, mode='edges')
+    wcs = exposure_cube.wcs.deepcopy()
 
-    npred_cube = np.zeros((len(energy_bins) - 1,
-                           exposure_cube.data.shape[1], exposure_cube.data.shape[2]))
-    for i in range(len(energy_bins) - 1):
-        emin, emax = energy_bins[i:i + 2]
-        int_flux = flux_cube.sky_image_integral(emin, emax, interpolation='linear', nbins=integral_resolution)
-        int_flux = Quantity(int_flux.data, '1 / (cm2 s sr)')
-        energy = energy_centers[i] * np.ones(coordinates.shape)
-        exposure = Quantity(exposure_cube.lookup(coordinates, energy, interpolation='linear'), 'cm2 s')
-        npred_image = int_flux * exposure * solid_angle
-        npred_cube[i] = npred_image.to('')
-    npred_cube = np.nan_to_num(npred_cube)
-
-    energy_axis = LogEnergyAxis(energy_bins)
-    npred_cube = SkyCube(data=npred_cube,
-                         wcs=wcs,
-                         energy_axis=energy_axis)
-    return npred_cube
-
-
-def convolve_cube(cube, psf, offset_max):
-    """Convolves a predicted counts cube in energy bins with the an
-    energy-dependent PSF.
-
-    Parameters
-    ----------
-    cube : `SkyCube`
-        Counts cube in energy bins.
-    psf : `~gammapy.irf.EnergyDependentTablePSF`
-        Energy dependent PSF.
-    offset_max : `~astropy.units.Quantity`
-        Maximum offset in degrees of the PSF convolution kernel from its center.
-
-    Returns
-    -------
-    convolved_cube : `SkyCube`
-        PSF convolved predicted counts cube in energy bins.
-    """
-    energy_edges = cube.energies(mode='edges')
-    convolved_cube = SkyCube.empty_like(cube)
+    energy_centers = EnergyBounds(energy_bins).log_centers
 
     data = []
-    pixel_size = cube.sky_image_ref.wcs_pixel_scale()[0]
+    # TODO: find a nicer way to do the iteration
+    for ecenter, emin, emax in zip(energy_centers, energy_bins[:-1], energy_bins[1:]):
+        flux_int = flux_cube.sky_image_integral(emin, emax, interpolation='linear',
+                                                nbins=integral_resolution)
 
-    for i, energy in enumerate(cube.energies()):
-        image = cube.sky_image(energy)
-        energy_band = energy_edges[i:i + 2]
-        psf_at_energy = psf.table_psf_in_energy_band(energy_band)
-        kernel = psf_at_energy.kernel(pixel_size, offset_max, normalize=True)
-        convolved = image.convolve(kernel)
-        data.append(convolved.data)
+        exposure = exposure_cube.sky_image(ecenter, interpolation='linear')
+        npred = flux_int.data * exposure.data * exposure.solid_angle()
+        data.append(npred)
 
-    convolved_cube.data = np.stack(data, axis=0)
-    return convolved_cube
+    data = u.Quantity(data)
+    return SkyCube(data=data, wcs=wcs, energy_axis=energy_axis)
 
-
-def cube_to_image(cube, slicepos=None):
-    """Slice or project 3-dim cube into a 2-dim image.
-
-    Parameters
-    ----------
-    cube : `~astropy.io.fits.ImageHDU`
-        3-dim FITS cube
-    slicepos : int or None, optional
-        Slice position (None means to sum along the spectral axis)
-
-    Returns
-    -------
-    image : `~astropy.io.fits.ImageHDU`
-        2-dim FITS image
-    """
-    header = cube.header.copy()
-    header['NAXIS'] = 2
-
-    for key in ['NAXIS3', 'CRVAL3', 'CDELT3', 'CTYPE3', 'CRPIX3', 'CUNIT3']:
-        if key in header:
-            del header[key]
-
-    if slicepos is None:
-        data = cube.data.sum(0)
-    else:
-        data = cube.data[slicepos]
-    return ImageHDU(data, header)
-
-
-def cube_to_spec(cube, mask, weighting='none'):
-    """Integrate spatial dimensions of a FITS cube to give a spectrum.
-
-    TODO: give formulas.
-
-    Parameters
-    ----------
-    cube : `~astropy.io.fits.ImageHDU`
-        3-dim FITS cube
-    mask : numpy.array
-        2-dim mask array.
-    weighting : {'none', 'solid_angle'}, optional
-        Weighting factor to use.
-
-    Returns
-    -------
-    spectrum : numpy.array
-        Summed spectrum of pixels in the mask.
-    """
-
-    # TODO: clean up API and implementation and add test
-    value = cube.dat
-    image = SkyImage.read(cube)
-    A = image.solid_angle()
-    # Note that this is the correct way to get an average flux:
-
-    spec = (value * A).sum(-1).sum(-1)
-    return spec

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -53,6 +53,6 @@ def compute_npred_cube(flux_cube, exposure_cube, energy_bins,
         npred = flux_int.data * exposure.data * exposure.solid_angle()
         data.append(npred)
 
-    data = u.Quantity(data)
+    data = u.Quantity(data, '')
     return SkyCube(data=data, wcs=wcs, energy_axis=energy_axis)
 

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -138,12 +138,13 @@ class FermiVelaRegion(object):
 
     @staticmethod
     def background_image():
-        """Predicted background counts image (`~astropy.io.fits.PrimaryHDU`).
+        """Predicted background counts image (`~gammapy.image.SkyImage`).
 
         Based on the Fermi Diffuse model (see class docstring).
         """
+        from ..image import SkyImage
         filename = FermiVelaRegion.filenames()['background_image']
-        return fits.open(filename)[0]
+        return SkyImage.read(filename)
 
     @staticmethod
     def predicted_image():

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -51,9 +51,7 @@ class TestKernelBackgroundEstimator(object):
         psf = FermiGalacticCenter.psf()
         erange = [10, 500] * u.GeV
         psf = psf.table_psf_in_energy_band(erange)
-        kernel_array = psf.kernel(pixel_size=Angle(1, 'deg'),
-                                  offset_max=Angle(3, 'deg'),
-                                  normalize=True)
+        kernel_array = psf.kernel(images['counts'])
 
         images['counts'] = images['counts'].convolve(kernel_array, mode='constant')
         return images

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -137,9 +137,8 @@ def catalog_image(reference, psf, catalog='1FHL', source_type='point',
                                                  np.max(energy).value], energy.unit))
 
     resolution = abs(reference.header['CDELT1'])
-
-    kernel_array = psf.kernel(pixel_size=Angle(resolution, 'deg'),
-                              offset_max=Angle(5, 'deg'), normalize=True)
+    ref = total_point_image.sky_image_ref
+    kernel_array = psf.kernel(ref, normalize=True)
 
     convolved_cube = convolve(new_image, kernel_array, mode='constant')
 

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -863,12 +863,12 @@ class SkyImage(object):
         kwargs['origin'] = kwargs.get('origin', 'lower')
         kwargs['cmap'] = kwargs.get('cmap', 'afmhot')
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
-
         caxes = ax.imshow(self.data, **kwargs)
+
         if add_cbar:
             unit = self.unit or 'A.U.'
             label = self.name or 'None'
-            cbar = fig.colorbar(caxes, label='{0} ({1})'.format(label.title(), unit))
+            cbar = fig.colorbar(caxes, ax=ax, label='{0} ({1})'.format(label.title(), unit))
         else:
             cbar = None
 
@@ -1146,7 +1146,7 @@ class SkyImage(object):
         Parameters
         ----------
         kernel : `~numpy.ndarray`
-            Convolution kernel.
+            2D array representing the convolution kernel.
         **kwargs : dict
             Further keyword arguments passed to `~scipy.ndimage.convolve`.
         """

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -704,8 +704,8 @@ class SkyImage(object):
 
         if dstype == 'Data2D':
             coordinates = self.coordinates(mode='center')
-            x = coordinates.data.lon
-            y = coordinates.data.lat
+            x = coordinates.data.lon.degree
+            y = coordinates.data.lat.degree
             return Data2D(self.name, x.ravel(), y.ravel(), self.data.ravel(),
                           self.data.shape)
         elif dstype == 'Data2DInt':

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -95,7 +95,7 @@ class TablePSF(object):
         >>> from astropy.coordinates import Angle
         >>> from gammapy.irf import TablePSF
         >>> TablePSF.from_shape(shape='gauss', width=Angle(0.2, 'deg'),
-        ...                     offset=Angle(np.linspace(0, 0.7, 100), 'deg'))
+                             offset=Angle(np.linspace(0, 0.7, 100), 'deg'))
         """
         width = Angle(width)
         offset = Angle(offset)
@@ -157,7 +157,7 @@ class TablePSF(object):
         Parameters
         ----------
         reference : `~gammapy.image.SkyImage` or `~gammapy.cube.SkyCube`
-            Reference sky image or sky cube.
+            Reference sky image or sky cube defining the spatial grid.
         containment : float
             Minimal containment fraction of the kernel image.
         normalize : bool
@@ -171,10 +171,11 @@ class TablePSF(object):
         """
         from ..cube import SkyCube
         offset_max = self.containment_radius(containment)
-        pixel_size = reference.wcs_pixel_scale()[0]
 
         if isinstance(reference, SkyCube):
             reference = reference.sky_image_ref
+
+        pixel_size = reference.wcs_pixel_scale()[0]
 
         def _model(x, y):
             """Model in the appropriate format for discretize_model."""
@@ -532,7 +533,7 @@ class EnergyDependentTablePSF(object):
 
     def kernels(self, cube, **kwargs):
         """
-        Make a set of 2-dimensional kernel images.
+        Make a set of 2D kernel images, representing the PSF at different energies.
 
         The kernel image is evaluated on the spatial and energy grid defined by
         the reference sky cube.
@@ -542,13 +543,12 @@ class EnergyDependentTablePSF(object):
         cube : `~gammapy.cube.SkyCube`
             Reference sky cube.
         kwargs : dict
-            Keyword arguments passed to
-            `EnergyDependentTablePSF.table_psf_in_energy_band()`.
+            Keyword arguments passed to `EnergyDependentTablePSF.table_psf_in_energy_band()`.
 
         Returns
         -------
-        kernels : list
-            List of 2D image kernels.
+        kernels : list of `~numpy.ndarray`
+            List of 2D convolution kernels.
         """
         energies = cube.energies(mode='edges')
 
@@ -560,7 +560,8 @@ class EnergyDependentTablePSF(object):
             kernels.append(kernel)
         return kernels
 
-    def table_psf_in_energy_band(self, energy_band, spectral_index=2, spectrum=None, **kwargs):
+    def table_psf_in_energy_band(self, energy_band, spectral_index=2,
+                                 spectrum=None, **kwargs):
         """Average PSF in a given energy band.
 
         Expected counts in sub energy bands given the given exposure

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -146,65 +146,47 @@ class TablePSF(object):
         offset = center.separation(point)
         return self.evaluate(offset)
 
-    def kernel(self, pixel_size, offset_max=None, normalize=True,
-               discretize_model_kwargs=dict(factor=1)):
-        """Make a 2-dimensional kernel image.
+    def kernel(self, reference, containment=0.95, normalize=True):
+        """
+        Make a 2-dimensional kernel image.
 
-        The kernel image is evaluated on a cartesian
-        grid with ``pixel_size`` spacing, not on the sphere.
-
-        Calls `astropy.convolution.discretize_model`,
-        allowing for accurate discretization.
+        The kernel image is evaluated on a cartesian grid defined by the
+        reference sky image.
 
         Parameters
         ----------
-        pixel_size : `~astropy.coordinates.Angle`
-            Kernel pixel size
-        discretize_model_kwargs : dict
-            Keyword arguments passed to
-            `astropy.convolution.discretize_model`
+        reference : `~gammapy.image.SkyImage` or `~gammapy.cube.SkyCube`
+            Reference sky image or sky cube.
+        containment : float
+            Minimal containment fraction of the kernel image.
+        normalize : bool
+            Whether to nomalize the kernel.
 
         Returns
         -------
         kernel : `~astropy.units.Quantity`
             Kernel 2D image of Quantities
 
-        Notes
-        -----
-        * In the future, `astropy.modeling.Fittable2DModel` and
-          `astropy.convolution.Model2DKernel` could be used to construct
-          the kernel.
         """
-        if offset_max is None:
-            offset_max = self._offset.max()
+        from ..cube import SkyCube
 
-        def _model(x, y):
-            """Model in the appropriate format for discretize_model."""
-            offset = np.sqrt(x * x + y * y) * pixel_size
-            return self.evaluate(offset)
+        if isinstance(reference, SkyCube):
+            reference = reference.sky_image_ref
 
-        npix = int(offset_max.radian / pixel_size.radian)
-        pix_range = (-npix, npix + 1)
+        # compute offset for given containment
+        offset_max = self.containment_radius(containment)
 
-        # FIXME: Using `discretize_model` is currently very cumbersome due to these issue:
-        # https://github.com/astropy/astropy/issues/2274
-        # https://github.com/astropy/astropy/issues/1763#issuecomment-39552900
-        # from astropy.modeling import Fittable2DModel
-        #
-        # class TempModel(Fittable2DModel):
-        #    @staticmethod
-        #    def evaluate(x, y):
-        #        return 42 temp_model_function(x, y)
-        #
-        # temp_model = TempModel()
+        # setup coordinate grid
+        cutout = reference.cutout(reference.center, size=offset_max)
+        coordinates = cutout.coordinates()
+        offset = coordinates.separation(cutout.center)
 
-        array = discretize_oversample_2D(_model,
-                                         x_range=pix_range, y_range=pix_range,
-                                         **discretize_model_kwargs)
+        # evalute PSF model
+        kernel = self.evaluate(offset)
         if normalize:
-            return array / array.value.sum()
+            return kernel / kernel.sum()
         else:
-            return array
+            return kernel
 
     def evaluate(self, offset, quantity='dp_domega'):
         r"""Evaluate PSF.
@@ -543,8 +525,37 @@ class EnergyDependentTablePSF(object):
         """
         psf_value = self.evaluate(energy, None, interp_kwargs)[0, :]
         table_psf = TablePSF(self.offset, psf_value, **kwargs)
-
         return table_psf
+
+    def kernels(self, cube, **kwargs):
+        """
+        Make a set of 2-dimensional kernel images.
+
+        The kernel image is evaluated on the spatial and energy grid defined by
+        the reference sky cube.
+
+        Parameters
+        ----------
+        cube : `~gammapy.cube.SkyCube`
+            Reference sky cube.
+        kwargs : dict
+            Keyword arguments passed to
+            `EnergyDependentTablePSF.table_psf_in_energy_band()`.
+
+        Returns
+        -------
+        kernels : list
+            List of 2D image kernels.
+        """
+        energies = cube.energies(mode='edges')
+
+        kernels = []
+        for emin, emax in zip(energies[:-1], energies[1:]):
+            energy_band = Quantity([emin, emax])
+            psf = self.table_psf_in_energy_band(energy_band, **kwargs)
+            kernel = psf.kernel(cube.sky_image_ref)
+            kernels.append(kernel)
+        return kernels
 
     def table_psf_in_energy_band(self, energy_band, spectral_index=2, spectrum=None, **kwargs):
         """Average PSF in a given energy band.

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -9,6 +9,7 @@ from ...utils.testing import requires_dependency, requires_data
 from ...datasets import gammapy_extra
 from ...datasets import FermiGalacticCenter
 from ...irf import TablePSF, EnergyDependentTablePSF
+from ...image import SkyImage
 
 
 @requires_dependency('scipy')
@@ -79,17 +80,14 @@ def test_TablePSF():
 @requires_data('gammapy-extra')
 def test_EnergyDependentTablePSF():
     # TODO: test __init__
-
-    filename = FermiGalacticCenter.filenames()['psf']
-    psf = EnergyDependentTablePSF.read(filename)
+    fermi_gc = FermiGalacticCenter()
+    psf = fermi_gc.psf()
 
     # Test cases
     energy = Quantity(1, 'GeV')
     offset = Angle(0.1, 'deg')
     energies = Quantity([1, 2], 'GeV').to('TeV')
     offsets = Angle([0.1, 0.2], 'deg')
-
-    pixel_size = Angle(0.1, 'deg')
 
     # actual = psf.evaluate(energy=energy, offset=offset)
     # desired = Quantity(17760.814249206363, 'sr^-1')
@@ -114,8 +112,9 @@ def test_EnergyDependentTablePSF():
     desired = 1.0
     energy_band = Quantity([10, 500], 'GeV')
     psf_band = psf.table_psf_in_energy_band(energy_band)
-    actual = psf_band.kernel(pixel_size, pixel_size, normalize=True).value.sum()
 
+    ref = SkyImage.empty(binsz=0.1)
+    actual = psf_band.kernel(ref, normalize=True).value.sum()
     assert_allclose(actual, desired)
 
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -42,7 +42,7 @@ class LogEnergyAxis(object):
             self.pix = np.arange(len(self.x)) - 0.5
         else:
             raise ValueError('Not a valid mode.')
-
+        self.mode = mode
 
     def world2pix(self, energy):
         """TODO: document.


### PR DESCRIPTION
This is the third part of the major `SkyCube` rework. These are the most important changes in this PR:

* Move stand-alone `convolve_cube` function to `SkyCube.convolve()`
* Move stand-alone `cube_to_spec` function to `SkyCube.to_spectrum`, but currently not working.
* Add a `EnergyDependentTablePSF.kernels()` method to get a set of kernels for cube convolution
* Rewrite `compute_npred_cube` function

When running the script `docs/tutorials/npred/npred_convolved.py `, I get very good agreement with the result from the fermi science tools. The total number of counts agrees within >1%, depending on the precision of the flux image integration.