### PR TITLE
Improve PSF checker and add a test

### DIFF
--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -6,6 +6,7 @@ from .effective_area import *
 from .psf_core import *
 from .psf_table import *
 from .psf_3d import *
+from .psf_check import *
 from .psf_analytical import *
 from .psf_king import *
 from .energy_dispersion import *

--- a/gammapy/irf/psf_check.py
+++ b/gammapy/irf/psf_check.py
@@ -4,8 +4,12 @@ from collections import OrderedDict
 import math
 import numpy as np
 
+__all__ = [
+    'PSF3DChecker',
+]
 
-class TablePSFChecker(object):
+
+class PSF3DChecker(object):
     """Automated quality checks for `gammapy.irf.PSF3D`.
     
     At the moment used for HESS HAP HD.

--- a/gammapy/irf/tests/test_psf_check.py
+++ b/gammapy/irf/tests/test_psf_check.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from ...utils.testing import requires_dependency, requires_data
+from ..psf_3d import PSF3D
+from ..psf_check import PSF3DChecker
+
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+class TestPSF3DChecker:
+    def setup(self):
+        filename = '$GAMMAPY_EXTRA/datasets/hess-hap-hd-prod3/psf_table.fits.gz'
+        self.psf = PSF3D.read(filename)
+
+    def test_all(self):
+        checker = PSF3DChecker(psf=self.psf)
+        checker.check_all()
+        res = checker.results
+
+        # Make sure defaults don't change unnoticed
+        conf = checker.config
+        assert_allclose(conf['d_norm'], 0.01)
+        assert_allclose(conf['containment_fraction'], 0.68)
+        assert_allclose(conf['d_rel_containment'], 0.7)
+
+        # Check results
+        assert res['nan']['status'] == 'failed'
+        assert res['nan']['n_failed_bins'] == 4
+        assert res['normalise']['status'] == 'ok'
+        assert res['containment']['status'] == 'ok'
+        assert res['status'] == 'failed'


### PR DESCRIPTION
This pull request is a continuation of #763 

- [x] Rename file and class
- [x] Add `__all__` and import in `gammapy/irf/__init__.py` so that it's exposed and visible in the docs
- [x] Add global status summarising all checks to results dict
- [x] Misc improvements, e.g. how config options are handled, docstrings, ...
- [x] Add [$GAMMAPY_EXTRA/datasets/hess-hap-hd-prod3/psf_table.fits.gz](https://github.com/gammapy/gammapy-extra/blob/master/datasets/hess-hap-hd-prod3/psf_table.fits.gz) and a test for the PSF checker for one PSF.