### PR TITLE
Stack EDISP for a set of observations

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -714,10 +714,11 @@ class ObservationList(UserList):
                                           psf_value=psf_value.T)
         return psf_tot
 
-    def make_mean_edisp(self, position, e_true, e_reco, low_reco_threshold=None, high_reco_threshold=None):
-        r"""Make mean rmf for a given position and a set of observations.
+    def make_mean_edisp(self, position, e_true, e_reco, low_reco_threshold=Energy(0.002, "TeV"),
+                        high_reco_threshold=Energy(150, "TeV")):
+        r"""Make mean edisp for a given position and a set of observations.
 
-        Compute the mean rmf of a set of observations j at a given position
+        Compute the mean edisp of a set of observations j at a given position
 
         The stacking of :math:`j` observations is implemented as follows.  :math:`k`
         and :math:`l` denote a bin in reconstructed and true energy, respectively.
@@ -745,17 +746,13 @@ class ObservationList(UserList):
             high energy threshold in reco energy , default 150 TeV
         Returns
         -------
-        stacked_rmf: `~gammapy.irf.EnergyDispersion`
-            Stacked RMF for a set of observation
+        stacked_edisp: `~gammapy.irf.EnergyDispersion`
+            Stacked EDISP for a set of observation
         """
 
         list_arf = list()
         list_edisp = list()
         list_livetime = list()
-        if not low_reco_threshold:
-            low_reco_threshold = Energy(0.002, "TeV")
-        if not high_reco_threshold:
-            high_reco_threshold = Energy(150, "TeV")
         list_low_threshold = [low_reco_threshold] * len(self)
         list_high_threshold = [high_reco_threshold] * len(self)
         for obs in self:

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -714,7 +714,7 @@ class ObservationList(UserList):
                                           psf_value=psf_value.T)
         return psf_tot
 
-    def make_mean_rmf(self, position, e_true, e_reco, low_reco_threshold=None, high_reco_threshold=None):
+    def make_mean_edisp(self, position, e_true, e_reco, low_reco_threshold=None, high_reco_threshold=None):
         r"""Make mean rmf for a given position and a set of observations.
 
         Compute the mean rmf of a set of observations j at a given position
@@ -750,7 +750,7 @@ class ObservationList(UserList):
         """
 
         list_arf = list()
-        list_rmf = list()
+        list_edisp = list()
         list_livetime = list()
         if not low_reco_threshold:
             low_reco_threshold = Energy(0.002, "TeV")
@@ -761,10 +761,10 @@ class ObservationList(UserList):
         for obs in self:
             offset = position.separation(obs.pointing_radec)
             list_arf.append(obs.aeff.to_effective_area_table(offset, energy=e_true))
-            list_rmf.append(obs.edisp.to_energy_dispersion(offset, e_reco=e_reco, e_true=e_true))
+            list_edisp.append(obs.edisp.to_energy_dispersion(offset, e_reco=e_reco, e_true=e_true))
             list_livetime.append(obs.observation_live_time_duration)
 
-        irf_stack = IRFStacker(list_arf=list_arf, list_rmf=list_rmf, list_livetime=list_livetime,
+        irf_stack = IRFStacker(list_arf=list_arf, list_edisp=list_edisp, list_livetime=list_livetime,
                                list_low_threshold=list_low_threshold, list_high_threshold=list_high_threshold)
         irf_stack.mean_edisp()
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -693,7 +693,7 @@ class ObservationList(UserList):
         theta : `~astropy.coordinates.Angle`
             1-dim offset array for the output PSF.
             If none is given, the energy array of the PSF from the first
-             observation is used.
+            observation is used.
 
         Returns
         -------
@@ -722,7 +722,7 @@ class ObservationList(UserList):
     def make_mean_edisp(self, position, e_true, e_reco,
                         low_reco_threshold=Energy(0.002, "TeV"),
                         high_reco_threshold=Energy(150, "TeV")):
-        r"""Make mean edisp for a given position and a set of observations.
+        """Make mean edisp for a given position and a set of observations.
 
         Compute the mean edisp of a set of observations j at a given position
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -734,7 +734,7 @@ class ObservationList(UserList):
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`
-            Position at which to compute the PSF
+            Position at which to compute the mean EDISP
         e_true : `~gammapy.utils.energy.EnergyBounds`
             True energy axis
         e_reco : `~gammapy.utils.energy.EnergyBounds`
@@ -766,6 +766,6 @@ class ObservationList(UserList):
 
         irf_stack = IRFStacker(list_arf=list_arf, list_rmf=list_rmf, list_livetime=list_livetime,
                                list_low_threshold=list_low_threshold, list_high_threshold=list_high_threshold)
-        irf_stack.mean_rmf()
+        irf_stack.mean_edisp()
 
         return irf_stack.stacked_edisp

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -720,17 +720,7 @@ class ObservationList(UserList):
 
         Compute the mean edisp of a set of observations j at a given position
 
-        The stacking of :math:`j` observations is implemented as follows.  :math:`k`
-        and :math:`l` denote a bin in reconstructed and true energy, respectively.
-
-        .. math::
-
-            \epsilon_{jk} =\left\{\begin{array}{cl} 1, & \mbox{if
-                bin k is inside the energy thresholds}\\ 0, & \mbox{otherwise} \end{array}\right.
-
-            \overline{\mathrm{edisp}}_{kl} = \frac{\sum_{j} \mathrm{edisp}_{jkl}
-                \cdot \mathrm{aeff}_{jl} \cdot t_j \cdot \epsilon_{jk}}{\sum_{j} \mathrm{aeff}_{jl}
-                \cdot t_j}
+        The stacking is implemented in :func:`~gammapy.irf.IRFStacker.stack_edisp
 
         Parameters
         ----------
@@ -744,24 +734,25 @@ class ObservationList(UserList):
             low energy threshold in reco energy, default 0.002 TeV
         high_reco_threshold : `~gammapy.utils.energy.Energy`
             high energy threshold in reco energy , default 150 TeV
+
         Returns
         -------
-        stacked_edisp: `~gammapy.irf.EnergyDispersion`
+        stacked_edisp : `~gammapy.irf.EnergyDispersion`
             Stacked EDISP for a set of observation
         """
 
-        list_arf = list()
+        list_aeff = list()
         list_edisp = list()
         list_livetime = list()
         list_low_threshold = [low_reco_threshold] * len(self)
         list_high_threshold = [high_reco_threshold] * len(self)
         for obs in self:
             offset = position.separation(obs.pointing_radec)
-            list_arf.append(obs.aeff.to_effective_area_table(offset, energy=e_true))
+            list_aeff.append(obs.aeff.to_effective_area_table(offset, energy=e_true))
             list_edisp.append(obs.edisp.to_energy_dispersion(offset, e_reco=e_reco, e_true=e_true))
             list_livetime.append(obs.observation_live_time_duration)
 
-        irf_stack = IRFStacker(list_arf=list_arf, list_edisp=list_edisp, list_livetime=list_livetime,
+        irf_stack = IRFStacker(list_aeff=list_aeff, list_edisp=list_edisp, list_livetime=list_livetime,
                                list_low_threshold=list_low_threshold, list_high_threshold=list_high_threshold)
         irf_stack.mean_edisp()
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -727,7 +727,7 @@ class ObservationList(UserList):
         Compute the mean edisp of a set of observations j at a given position
 
         The stacking is implemented in
-        :func:`~gammapy.irf.IRFStacker.stack_edisp
+        :func:`~gammapy.irf.IRFStacker.stack_edisp`
 
         Parameters
         ----------

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -655,12 +655,13 @@ class DataStoreObservation(object):
         if not theta:
             theta = self.psf.to_table_psf(theta=offset).offset
 
-        psf_value = self.psf.to_table_psf(theta=offset, offset=theta).evaluate(energy)
+        psf_value = self.psf.to_table_psf(theta=offset, offset=theta)\
+            .evaluate(energy)
         arf = self.aeff.evaluate(offset=offset, energy=energy)
         exposure = arf * self.observation_live_time_duration
 
-        psf = EnergyDependentTablePSF(energy=energy, offset=theta, exposure=exposure,
-                                      psf_value=psf_value)
+        psf = EnergyDependentTablePSF(energy=energy, offset=theta,
+                                      exposure=exposure, psf_value=psf_value)
         return psf
 
 
@@ -678,7 +679,8 @@ class ObservationList(UserList):
         return s
 
     def make_psf(self, position, energy=None, theta=None):
-        """Make energy-dependent mean PSF for a given position and a set of observations.
+        """Make energy-dependent mean PSF for a given position and a set of
+        observations.
 
         Parameters
         ----------
@@ -686,10 +688,12 @@ class ObservationList(UserList):
             Position at which to compute the PSF
         energy : `~astropy.units.Quantity`
             1-dim energy array for the output PSF.
-            If none is given, the energy array of the PSF from the first observation is used.
+            If none is given, the energy array of the PSF from the first
+            observation is used.
         theta : `~astropy.coordinates.Angle`
             1-dim offset array for the output PSF.
-            If none is given, the energy array of the PSF from the first observation is used.
+            If none is given, the energy array of the PSF from the first
+             observation is used.
 
         Returns
         -------
@@ -710,17 +714,20 @@ class ObservationList(UserList):
             psf_value += psf.psf_value.T * psf.exposure
 
         psf_value /= exposure
-        psf_tot = EnergyDependentTablePSF(energy=energy, offset=theta, exposure=exposure,
+        psf_tot = EnergyDependentTablePSF(energy=energy, offset=theta,
+                                          exposure=exposure,
                                           psf_value=psf_value.T)
         return psf_tot
 
-    def make_mean_edisp(self, position, e_true, e_reco, low_reco_threshold=Energy(0.002, "TeV"),
+    def make_mean_edisp(self, position, e_true, e_reco,
+                        low_reco_threshold=Energy(0.002, "TeV"),
                         high_reco_threshold=Energy(150, "TeV")):
         r"""Make mean edisp for a given position and a set of observations.
 
         Compute the mean edisp of a set of observations j at a given position
 
-        The stacking is implemented in :func:`~gammapy.irf.IRFStacker.stack_edisp
+        The stacking is implemented in
+        :func:`~gammapy.irf.IRFStacker.stack_edisp
 
         Parameters
         ----------
@@ -748,12 +755,17 @@ class ObservationList(UserList):
         list_high_threshold = [high_reco_threshold] * len(self)
         for obs in self:
             offset = position.separation(obs.pointing_radec)
-            list_aeff.append(obs.aeff.to_effective_area_table(offset, energy=e_true))
-            list_edisp.append(obs.edisp.to_energy_dispersion(offset, e_reco=e_reco, e_true=e_true))
+            list_aeff.append(obs.aeff.to_effective_area_table(offset,
+                                                              energy=e_true))
+            list_edisp.append(obs.edisp.to_energy_dispersion(offset,
+                                                             e_reco=e_reco,
+                                                             e_true=e_true))
             list_livetime.append(obs.observation_live_time_duration)
 
-        irf_stack = IRFStacker(list_aeff=list_aeff, list_edisp=list_edisp, list_livetime=list_livetime,
-                               list_low_threshold=list_low_threshold, list_high_threshold=list_high_threshold)
+        irf_stack = IRFStacker(list_aeff=list_aeff, list_edisp=list_edisp,
+                               list_livetime=list_livetime,
+                               list_low_threshold=list_low_threshold,
+                               list_high_threshold=list_high_threshold)
         irf_stack.mean_edisp()
 
         return irf_stack.stacked_edisp

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -726,8 +726,7 @@ class ObservationList(UserList):
 
         Compute the mean edisp of a set of observations j at a given position
 
-        The stacking is implemented in
-        :func:`~gammapy.irf.IRFStacker.stack_edisp`
+        The stacking is implemented in :func:`~gammapy.irf.IRFStacker.stack_edisp`
 
         Parameters
         ----------
@@ -766,6 +765,6 @@ class ObservationList(UserList):
                                list_livetime=list_livetime,
                                list_low_threshold=list_low_threshold,
                                list_high_threshold=list_high_threshold)
-        irf_stack.mean_edisp()
+        irf_stack.stack_edisp()
 
         return irf_stack.stacked_edisp

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -158,7 +158,7 @@ def test_make_meanrmf(tmpdir):
     data_store = DataStore.from_dir(store)
 
     obs1 = data_store.obs(23523)
-    obs2 = data_store.obs(23523)
+    obs2 = data_store.obs(23592)
     obslist = ObservationList([obs1, obs2])
 
     e_true = EnergyBounds.equal_log_spacing(0.01, 150, 80, "TeV")
@@ -167,4 +167,4 @@ def test_make_meanrmf(tmpdir):
 
     assert len(rmf.e_true.nodes) == 80
     assert len(rmf.e_reco.nodes) == 15
-    assert_quantity_allclose(rmf.data[53, 8], 0.06075748606173905)
+    assert_quantity_allclose(rmf.data[53, 8], 0.0559785805550798)

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -122,17 +122,26 @@ def test_data_summary(data_manager):
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("pars,result", [
     (dict(energy=None, theta=None),
-     dict(energy_shape=18, theta_shape=300, psf_energy=2.5178505859375 * u.TeV, psf_theta=0.05 * u.deg,
-          psf_exposure=Quantity(6878545291473.34, "cm2 s"), psf_value=Quantity(205215.42446175334, "1/sr"))),
+     dict(energy_shape=18, theta_shape=300, psf_energy=2.5178505859375 * u.TeV,
+          psf_theta=0.05 * u.deg,
+          psf_exposure=Quantity(6878545291473.34, "cm2 s"),
+          psf_value=Quantity(205215.42446175334, "1/sr"))),
     (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"), theta=None),
-     dict(energy_shape=101, theta_shape=300, psf_energy=1.2589254117941673 * u.TeV, psf_theta=0.05 * u.deg,
-          psf_exposure=Quantity(4622187644084.735, "cm2 s"), psf_value=Quantity(119662.71915415104, "1/sr"))),
+     dict(energy_shape=101, theta_shape=300,
+          psf_energy=1.2589254117941673 * u.TeV, psf_theta=0.05 * u.deg,
+          psf_exposure=Quantity(4622187644084.735, "cm2 s"),
+          psf_value=Quantity(119662.71915415104, "1/sr"))),
     (dict(energy=None, theta=Angle(np.arange(0, 2, 0.002), 'deg')),
-     dict(energy_shape=18, theta_shape=1000, psf_energy=2.5178505859375 * u.TeV, psf_theta=0.02 * u.deg,
-          psf_exposure=Quantity(6878545291473.34, "cm2 s"), psf_value=Quantity(23082.369133891403, "1/sr"))),
-    (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"), theta=Angle(np.arange(0, 2, 0.002), 'deg')),
-     dict(energy_shape=101, theta_shape=1000, psf_energy=1.2589254117941673 * u.TeV, psf_theta=0.02 * u.deg,
-          psf_exposure=Quantity(4622187644084.735, "cm2 s"), psf_value=Quantity(27987.773313506143, "1/sr"))),
+     dict(energy_shape=18, theta_shape=1000,
+          psf_energy=2.5178505859375 * u.TeV, psf_theta=0.02 * u.deg,
+          psf_exposure=Quantity(6878545291473.34, "cm2 s"),
+          psf_value=Quantity(23082.369133891403, "1/sr"))),
+    (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"),
+          theta=Angle(np.arange(0, 2, 0.002), 'deg')),
+     dict(energy_shape=101, theta_shape=1000,
+          psf_energy=1.2589254117941673 * u.TeV, psf_theta=0.02 * u.deg,
+          psf_exposure=Quantity(4622187644084.735, "cm2 s"),
+          psf_value=Quantity(27987.773313506143, "1/sr"))),
 ])
 def test_make_psf(pars, result):
     position = SkyCoord(83.63, 22.01, unit='deg')
@@ -140,12 +149,14 @@ def test_make_psf(pars, result):
     data_store = DataStore.from_dir(store)
 
     obs1 = data_store.obs(23523)
-    psf = obs1.make_psf(position=position, energy=pars["energy"], theta=pars["theta"])
+    psf = obs1.make_psf(position=position, energy=pars["energy"],
+                        theta=pars["theta"])
 
     assert_allclose(psf.offset.shape, result["theta_shape"])
     assert_allclose(psf.energy.shape, result["energy_shape"])
     assert_allclose(psf.exposure.shape, result["energy_shape"])
-    assert_allclose(psf.psf_value.shape, (result["energy_shape"], result["theta_shape"]))
+    assert_allclose(psf.psf_value.shape, (result["energy_shape"],
+                                          result["theta_shape"]))
 
     assert_quantity_allclose(psf.offset[10], result["psf_theta"])
     assert_quantity_allclose(psf.energy[10], result["psf_energy"])
@@ -166,14 +177,17 @@ def test_make_mean_edisp(tmpdir):
 
     e_true = EnergyBounds.equal_log_spacing(0.01, 150, 80, "TeV")
     e_reco = EnergyBounds.equal_log_spacing(0.5, 100, 15, "TeV")
-    rmf = obslist.make_mean_edisp(position=position, e_true=e_true, e_reco=e_reco)
+    rmf = obslist.make_mean_edisp(position=position, e_true=e_true,
+                                  e_reco=e_reco)
 
     assert len(rmf.e_true.nodes) == 80
     assert len(rmf.e_reco.nodes) == 15
     assert_quantity_allclose(rmf.data[53, 8], 0.0559785805550798)
 
-    rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true, e_reco=e_reco,
-                                   low_reco_threshold=Energy(1, "TeV"), high_reco_threshold=Energy(60, "TeV"))
+    rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true,
+                                   e_reco=e_reco,
+                                   low_reco_threshold=Energy(1, "TeV"),
+                                   high_reco_threshold=Energy(60, "TeV"))
     i2 = np.where(rmf2.evaluate(e_reco=Energy(0.8, "TeV")) != 0)[0]
     assert len(i2) == 0
     i2 = np.where(rmf2.evaluate(e_reco=Energy(61, "TeV")) != 0)[0]

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -174,17 +174,13 @@ def test_make_mean_edisp(tmpdir):
 
     rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true, e_reco=e_reco,
                                    low_reco_threshold=Energy(1, "TeV"), high_reco_threshold=Energy(60, "TeV"))
-    # Test that the energy dispersion is equal to zero for the reco energy bin inferior to low_reco_threshold and
-    #  superior to high_reco_threshold
-    i2 = np.where(rmf2.data[:, 13] != 0)[0]
+    i2 = np.where(rmf2.evaluate(e_reco=Energy(0.8, "TeV")) != 0)[0]
     assert len(i2) == 0
-    i2 = np.where(rmf2.data[:, 1] != 0)[0]
+    i2 = np.where(rmf2.evaluate(e_reco=Energy(61, "TeV")) != 0)[0]
     assert len(i2) == 0
-    # Test that for the reco energy bin inside the thresholds, the edisp defined without threshold in the same than
-    # the edisp defined with the low and high reco energy thresholds
-    i = np.where(rmf.data[:, 12] != 0)[0]
-    i2 = np.where(rmf2.data[:, 12] != 0)[0]
+    i = np.where(rmf.evaluate(e_reco=Energy(1.5, "TeV")) != 0)[0]
+    i2 = np.where(rmf2.evaluate(e_reco=Energy(1.5, "TeV")) != 0)[0]
     assert_equal(i, i2)
-    i = np.where(rmf.data[:, 2] != 0)[0]
-    i2 = np.where(rmf2.data[:, 2] != 0)[0]
+    i = np.where(rmf.evaluate(e_reco=Energy(55, "TeV")) != 0)[0]
+    i2 = np.where(rmf2.evaluate(e_reco=Energy(55, "TeV")) != 0)[0]
     assert_equal(i, i2)

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -153,6 +153,8 @@ def test_make_psf(pars, result):
     assert_quantity_allclose(psf.psf_value[10, 50], result["psf_value"])
 
 
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
 def test_make_meanedisp(tmpdir):
     position = SkyCoord(83.63, 22.01, unit='deg')
     store = gammapy_extra.filename("datasets/hess-crab4-hd-hap-prod2")
@@ -171,7 +173,7 @@ def test_make_meanedisp(tmpdir):
     assert_quantity_allclose(rmf.data[53, 8], 0.0559785805550798)
 
     rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true, e_reco=e_reco,
-                                 low_reco_threshold=Energy(1, "TeV"), high_reco_threshold=Energy(60, "TeV"))
+                                   low_reco_threshold=Energy(1, "TeV"), high_reco_threshold=Energy(60, "TeV"))
     # Test that the energy dispersion is equal to zero for the reco energy bin inferior to low_reco_threshold and
     #  superior to high_reco_threshold
     i2 = np.where(rmf2.data[:, 13] != 0)[0]

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -155,7 +155,7 @@ def test_make_psf(pars, result):
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_make_meanedisp(tmpdir):
+def test_make_mean_edisp(tmpdir):
     position = SkyCoord(83.63, 22.01, unit='deg')
     store = gammapy_extra.filename("datasets/hess-crab4-hd-hap-prod2")
     data_store = DataStore.from_dir(store)

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -153,7 +153,7 @@ def test_make_psf(pars, result):
     assert_quantity_allclose(psf.psf_value[10, 50], result["psf_value"])
 
 
-def test_make_meanrmf(tmpdir):
+def test_make_meanedisp(tmpdir):
     position = SkyCoord(83.63, 22.01, unit='deg')
     store = gammapy_extra.filename("datasets/hess-crab4-hd-hap-prod2")
     data_store = DataStore.from_dir(store)

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -164,13 +164,13 @@ def test_make_meanrmf(tmpdir):
 
     e_true = EnergyBounds.equal_log_spacing(0.01, 150, 80, "TeV")
     e_reco = EnergyBounds.equal_log_spacing(0.5, 100, 15, "TeV")
-    rmf = obslist.make_mean_rmf(position=position, e_true=e_true, e_reco=e_reco)
+    rmf = obslist.make_mean_edisp(position=position, e_true=e_true, e_reco=e_reco)
 
     assert len(rmf.e_true.nodes) == 80
     assert len(rmf.e_reco.nodes) == 15
     assert_quantity_allclose(rmf.data[53, 8], 0.0559785805550798)
 
-    rmf2 = obslist.make_mean_rmf(position=position, e_true=e_true, e_reco=e_reco,
+    rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true, e_reco=e_reco,
                                  low_reco_threshold=Energy(1, "TeV"), high_reco_threshold=Energy(60, "TeV"))
     # Test that the energy dispersion is equal to zero for the reco energy bin inferior to low_reco_threshold and
     #  superior to high_reco_threshold

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -80,7 +80,7 @@ class IRFStacker(object):
         self.stacked_aeff = EffectiveAreaTable(energy=self.list_arf[0].energy,
                                                data=stacked_data.to('cm2'))
 
-    def mean_rmf(self):
+    def mean_edisp(self):
         """
         Compute mean energy dispersion
         """

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -39,7 +39,7 @@ class IRFStacker(object):
 
     Parameters
     ----------
-    list_arf: list
+    list_aeff: list
         list of `~gammapy.irf.EffectiveAreaTable`
     list_livetime: list
         list of `~astropy.units.Quantity` (livetime)
@@ -53,9 +53,9 @@ class IRFStacker(object):
 
     """
 
-    def __init__(self, list_arf, list_livetime, list_edisp=None,
+    def __init__(self, list_aeff, list_livetime, list_edisp=None,
                  list_low_threshold=None, list_high_threshold=None):
-        self.list_arf = list_arf
+        self.list_aeff = list_aeff
         self.list_livetime = Quantity(list_livetime)
         self.list_edisp = list_edisp
         self.list_low_threshold = list_low_threshold
@@ -67,17 +67,17 @@ class IRFStacker(object):
         """
         Compute mean effective area
         """
-        nbins = self.list_arf[0].energy.nbins
+        nbins = self.list_aeff[0].energy.nbins
         aefft = Quantity(np.zeros(nbins), 'cm2 s')
         livetime_tot = np.sum(self.list_livetime)
 
-        for i, arf in enumerate(self.list_arf):
-            aeff_data = arf.evaluate(fill_nan=True)
+        for i, aeff in enumerate(self.list_aeff):
+            aeff_data = aeff.evaluate(fill_nan=True)
             aefft_current = aeff_data * self.list_livetime[i]
             aefft += aefft_current
 
         stacked_data = aefft / livetime_tot
-        self.stacked_aeff = EffectiveAreaTable(energy=self.list_arf[0].energy,
+        self.stacked_aeff = EffectiveAreaTable(energy=self.list_aeff[0].energy,
                                                data=stacked_data.to('cm2'))
 
     def mean_edisp(self):
@@ -92,7 +92,7 @@ class IRFStacker(object):
         aefftedisp = Quantity(temp, 'cm2 s')
 
         for i, edisp in enumerate(self.list_edisp):
-            aeff_data = self.list_arf[i].evaluate(fill_nan=True)
+            aeff_data = self.list_aeff[i].evaluate(fill_nan=True)
             aefft_current = aeff_data * self.list_livetime[i]
             aefft += aefft_current
             edisp_data = edisp.pdf_in_safe_range(self.list_low_threshold[i],

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -80,7 +80,7 @@ class IRFStacker(object):
         self.stacked_aeff = EffectiveAreaTable(energy=self.list_aeff[0].energy,
                                                data=stacked_data.to('cm2'))
 
-    def mean_edisp(self):
+    def stack_edisp(self):
         """
         Compute mean energy dispersion
         """

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -16,7 +16,7 @@ class IRFStacker(object):
     r"""
     Stack instrument response functions
     
-    Compute mean effective area and the mean energy dispersio for a given for a
+    Compute mean effective area and the mean energy dispersion for a given for a
     given list of instrument response functions. Results are stored as
     attributes.
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -659,7 +659,7 @@ class SpectrumObservationStacker(object):
                                list_rmf=list_rmf,
                                list_low_threshold=list_elo_threshold,
                                list_high_threshold=list_ehi_threshold)
-        irf_stack.mean_rmf()
+        irf_stack.mean_edisp()
         self.stacked_edisp = irf_stack.stacked_edisp
 
     def stack_obs(self):

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -659,7 +659,7 @@ class SpectrumObservationStacker(object):
                                list_edisp=list_edisp,
                                list_low_threshold=list_elo_threshold,
                                list_high_threshold=list_ehi_threshold)
-        irf_stack.mean_edisp()
+        irf_stack.stack_edisp()
         self.stacked_edisp = irf_stack.stacked_edisp
 
     def stack_obs(self):

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -633,7 +633,7 @@ class SpectrumObservationStacker(object):
         for o in self.obs_list:
             list_arf.append(o.aeff)
             list_livetime.append(o.livetime)
-        irf_stack = IRFStacker(list_arf=list_arf, list_livetime=list_livetime)
+        irf_stack = IRFStacker(list_aeff=list_arf, list_livetime=list_livetime)
         irf_stack.stack_aeff()
 
         self.stacked_aeff = irf_stack.stacked_aeff
@@ -654,7 +654,7 @@ class SpectrumObservationStacker(object):
             list_edisp.append(o.edisp)
             list_elo_threshold.append(o.lo_threshold)
             list_ehi_threshold.append(o.hi_threshold)
-        irf_stack = IRFStacker(list_arf=list_arf,
+        irf_stack = IRFStacker(list_aeff=list_arf,
                                list_livetime=list_livetime,
                                list_edisp=list_edisp,
                                list_low_threshold=list_elo_threshold,

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -644,19 +644,19 @@ class SpectrumObservationStacker(object):
         calls :func:`~gammapy.irf.IRFStacker.stack_edisp`
         """
         list_arf = list()
-        list_rmf = list()
+        list_edisp = list()
         list_livetime = list()
         list_elo_threshold = list()
         list_ehi_threshold = list()
         for o in self.obs_list:
             list_arf.append(o.aeff)
             list_livetime.append(o.livetime)
-            list_rmf.append(o.edisp)
+            list_edisp.append(o.edisp)
             list_elo_threshold.append(o.lo_threshold)
             list_ehi_threshold.append(o.hi_threshold)
         irf_stack = IRFStacker(list_arf=list_arf,
                                list_livetime=list_livetime,
-                               list_rmf=list_rmf,
+                               list_edisp=list_edisp,
                                list_low_threshold=list_elo_threshold,
                                list_high_threshold=list_ehi_threshold)
         irf_stack.mean_edisp()


### PR DESCRIPTION
@cdeil 
This is a PR for stacking the RMF for a set of observation and a given source position. This is coded in the same philosophy than the mean PSF. You will need it for 3D spectral analysis if you want to convert your exposure in true energy to reco energy.