### PR TITLE
Download gammapy-extra on read the docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,23 @@ htmlhelp_basename = project + 'doc'
 html_static_path = ['_static']
 
 
+# download gammapy-extra for read the docs build
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+if on_rtd:
+    from zipfile import ZipFile
+    from astropy.extern.six.moves import urllib
+    from tempfile import mktemp
+
+    filename = mktemp('gammapy-extra-master.zip')
+    url = 'https://github.com/gammapy/gammapy-extra/archive/master.zip'
+    name, hdrs = urllib.request.urlretrieve(url, filename)
+    gp_extra_zip = ZipFile(filename)
+    path = os.path.dirname(filename)
+    gp_extra_zip.extractall(path)
+    gp_extra_zip.close()
+    os.environ['GAMMAPY_EXTRA'] = os.path.join(path, 'gammapy-extra-master')
+
+
 def copy_gp_extra_file(source, target):
     """Copy file from `gammapy-extra` to `gammapy/docs` folder."""
     cmd = 'cp $GAMMAPY_EXTRA/{} {}'.format(source, target)


### PR DESCRIPTION
This PR addresses issue #400. I've modified `conf.py` to download gammapy-extra using `urllib` and extract it via `zipfile` in a temporay directory. On my private read the docs build it seems to work:

http://adonathgammapy.readthedocs.io/en/remote_download_gammapy_extra/image/sky_image.html