### PR TITLE
Implement skyimage smooth method

### DIFF
--- a/docs/image/colormap_example.py
+++ b/docs/image/colormap_example.py
@@ -2,18 +2,13 @@
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from gammapy.datasets import load_poisson_stats_image
-from gammapy.image import disk_correlate
-from gammapy.stats import significance
 from gammapy.image import colormap_hess, colormap_milagro
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.visualization import LinearStretch
+from gammapy.image import SkyImage
 
-# Compute an example significance image
-counts = load_poisson_stats_image()
-counts = disk_correlate(counts, radius=5, mode='reflect')
-background = np.median(counts) * np.ones_like(counts)
-image = significance(counts, background)
+filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz'
+image = SkyImage.read(filename, extname='sqrt_ts')
 
 # Plot with the HESS and Milagro colormap
 vmin, vmax, vtransition = -5, 15, 5

--- a/docs/tutorials/npred/npred_convolved_significance.py
+++ b/docs/tutorials/npred/npred_convolved_significance.py
@@ -2,19 +2,21 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from astropy.io import fits
+from astropy.convolution import Tophat2DKernel
+from scipy.ndimage import convolve
 from gammapy.stats import significance
-from gammapy.image.utils import disk_correlate
 from aplpy import FITSFigure
 from npred_general import prepare_images
 
 model, gtmodel, ratio, counts, header = prepare_images()
 
 # Top hat correlation
-correlation_radius = 3
+tophat = Tophat2DKernel(3)
+tophat.normalize('peak')
 
-correlated_gtmodel = disk_correlate(gtmodel, correlation_radius)
-correlated_counts = disk_correlate(counts, correlation_radius)
-correlated_model = disk_correlate(model, correlation_radius)
+correlated_gtmodel = convolve(gtmodel, tophat.array)
+correlated_counts = convolve(counts, tophat.array)
+correlated_model = convolve(model, tophat.array)
 
 # Fermi significance
 fermi_significance = np.nan_to_num(significance(correlated_counts, correlated_gtmodel,

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -43,9 +43,6 @@ def compute_lima_image(counts, background, kernel, exposure=None):
     # Kernel is modified later make a copy here
     kernel = deepcopy(kernel)
 
-    if not kernel.is_bool:
-        log.warn('Using weighted kernels can lead to biased results.')
-
     kernel.normalize('peak')
     conv_opt = dict(mode='constant', cval=np.nan)
 
@@ -101,9 +98,6 @@ def compute_lima_on_off_image(n_on, n_off, a_on, a_off, kernel, exposure=None):
 
     # Kernel is modified later make a copy here
     kernel = deepcopy(kernel)
-
-    if not kernel.is_bool:
-        log.warn('Using weighted kernels can lead to biased results.')
 
     kernel.normalize('peak')
     conv_opt = dict(mode='constant', cval=np.nan)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1159,7 +1159,7 @@ class SkyImage(object):
         """
         Smooth the image (works on and returns a copy).
 
-        The definition of the smoothing parameter radius is equivalent to the 
+        The definition of the smoothing parameter radius is equivalent to the
         one that is used in ds9 (see `ds9 smoothing <http://ds9.si.edu/doc/ref/how.html#Smoothing>`_).
 
         Parameters
@@ -1183,13 +1183,13 @@ class SkyImage(object):
         from scipy.ndimage import gaussian_filter, uniform_filter
         from scipy.ndimage import convolve
         from scipy.stats import gmean
-        
+
         image = self.copy()
 
         if isinstance(radius, u.Quantity):
             # use geometric mean if x an y pixel scale differ
             radius = gmean((radius / self.wcs_pixel_scale()).value)
-        
+
         if kernel in ['box', 'disk']:
             width = 2 * radius + 1
         else:
@@ -1200,6 +1200,7 @@ class SkyImage(object):
             image.data = gaussian_filter(self.data, width, **kwargs)
         elif kernel == 'disk':
             disk = Tophat2DKernel(width)
+            disk.normalize('integral')
             image.data = convolve(self.data, disk.array, **kwargs)
         elif kernel == 'box':
             image.data = uniform_filter(self.data, width, **kwargs)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1190,19 +1190,16 @@ class SkyImage(object):
             # use geometric mean if x an y pixel scale differ
             radius = gmean((radius / self.wcs_pixel_scale()).value)
 
-        if kernel in ['box', 'disk']:
-            width = 2 * radius + 1
-        else:
-            # gaussian
-            width = radius / 2.
-
         if kernel == 'gauss':
+            width = radius / 2.
             image.data = gaussian_filter(self.data, width, **kwargs)
         elif kernel == 'disk':
+            width = 2 * radius + 1
             disk = Tophat2DKernel(width)
             disk.normalize('integral')
             image.data = convolve(self.data, disk.array, **kwargs)
         elif kernel == 'box':
+            width = 2 * radius + 1
             image.data = uniform_filter(self.data, width, **kwargs)
         else:
             raise ValueError('Invalid option kernel = {}'.format(kernel))

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1166,9 +1166,10 @@ class SkyImage(object):
         ----------
         kernel : {'gauss', 'disk', 'box'}
             Kernel shape
-        width : `~astropy.units.Quantity` or float
+        radius : `~astropy.units.Quantity` or float
             Smoothing width given as quantity or float. If a float is given it
-            interpreted as smoothing width in pixels.
+            interpreted as smoothing width in pixels. If an (angular) quantity
+            is given it converted to pixels using `SkyImage.wcs_pixel_scale()`.
         kwargs : dict
             Keyword arguments passed to `~scipy.ndimage.filters.uniform_filter`
             ('box'), `~scipy.ndimage.filters.gaussian_filter` ('gauss') or

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -11,7 +11,8 @@ from numpy.lib.arraypad import _validate_lengths
 from astropy.io import fits
 from astropy.coordinates import SkyCoord, Angle
 from astropy.coordinates.angle_utilities import angular_separation
-from astropy.units import Quantity, Unit
+from astropy.convolution import Tophat2DKernel
+from astropy import units as u
 from astropy.nddata.utils import Cutout2D
 from regions import PixCoord, PixelRegion, SkyRegion
 from astropy.wcs import WCS, WcsError
@@ -123,7 +124,7 @@ class SkyImage(object):
             name = header.get('EXTNAME')
         try:
             # Validate unit string
-            unit = Unit(header['BUNIT'], format='fits').to_string()
+            unit = u.Unit(header['BUNIT'], format='fits').to_string()
         except (KeyError, ValueError):
             unit = None
 
@@ -668,7 +669,7 @@ class SkyImage(object):
 
         dx = angular_separation(*(ylo_xlo + ylo_xhi))
         dy = angular_separation(*(ylo_xlo + yhi_xlo))
-        omega = Quantity(dx * dy, 'sr')
+        omega = u.Quantity(dx * dy, 'sr')
         return omega
 
     def lookup(self, position, interpolation=None):
@@ -689,7 +690,7 @@ class SkyImage(object):
         """
         Convert image to `~astropy.units.Quantity`.
         """
-        return Quantity(self.data, self.unit)
+        return u.Quantity(self.data, self.unit)
 
     def to_sherpa_data2d(self, dstype='Data2D'):
         """
@@ -744,7 +745,7 @@ class SkyImage(object):
             header.update(header_wcs)
 
         if self.unit is not None:
-            header['BUNIT'] = Unit(self.unit).to_string('fits')
+            header['BUNIT'] = u.Unit(self.unit).to_string('fits')
 
         if self.name is not None:
             header['EXTNAME'] = self.name
@@ -1055,7 +1056,6 @@ class SkyImage(object):
         >>> image.wcs_pixel_scale()
         <Angle [ 0.02, 0.02] deg>
         """
-        import astropy.units as u
         if method == 'cdelt':
             scales = np.abs(self.wcs.wcs.cdelt)
         elif method == 'proj_plane':
@@ -1155,34 +1155,53 @@ class SkyImage(object):
         wcs = self.wcs.deepcopy() if self.wcs else None
         return self.__class__(name=self.name, data=data, wcs=wcs)
 
-    def smooth(self, kernel='gauss', width=3):
-        """Smooth the image (works on and returns a copy).
+    def smooth(self, kernel='gauss', radius=0.1 * u.deg, **kwargs):
+        """
+        Smooth the image (works on and returns a copy).
 
-        TODO: this is very preliminary and incomplete.
-        No tests yet, no control of boundary handling, ...
-        See https://github.com/gammapy/gammapy/issues/694
+        The definition of the smoothing parameter radius is equivalent to the 
+        one that is used in ds9 (see `ds9 smoothing <http://ds9.si.edu/doc/ref/how.html#Smoothing>`_).
 
         Parameters
         ----------
         kernel : {'gauss', 'disk', 'box'}
             Kernel shape
-        width : float
-            Width in pixels
+        width : `~astropy.units.Quantity` or float
+            Smoothing width given as quantity or float. If a float is given it
+            interpreted as smoothing width in pixels.
+        kwargs : dict
+            Keyword arguments passed to `~scipy.ndimage.filters.uniform_filter`
+            ('box'), `~scipy.ndimage.filters.gaussian_filter` ('gauss') or
+            `~scipy.ndimage.convolve` ('disk').
 
         Returns
         -------
         image : `SkyImage`
             Smoothed image (a copy, the original object is unchanged).
         """
+        from scipy.ndimage import gaussian_filter, uniform_filter
+        from scipy.ndimage import convolve
+        from scipy.stats import gmean
+        
         image = self.copy()
 
+        if isinstance(radius, u.Quantity):
+            # use geometric mean if x an y pixel scale differ
+            radius = gmean((radius / self.wcs_pixel_scale()).value)
+        
+        if kernel in ['box', 'disk']:
+            width = 2 * radius + 1
+        else:
+            # gaussian
+            width = radius / 2.
+
         if kernel == 'gauss':
-            from scipy.ndimage import gaussian_filter
-            image.data = gaussian_filter(self.data, width)
+            image.data = gaussian_filter(self.data, width, **kwargs)
         elif kernel == 'disk':
-            raise NotImplementedError
+            disk = Tophat2DKernel(width)
+            image.data = convolve(self.data, disk.array, **kwargs)
         elif kernel == 'box':
-            raise NotImplementedError
+            image.data = uniform_filter(self.data, width, **kwargs)
         else:
             raise ValueError('Invalid option kernel = {}'.format(kernel))
 

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import SkyCoord, Angle
 from astropy.io import fits
+from astropy import units as u
 from astropy.units import Quantity
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.wcs import WcsError
@@ -316,6 +317,14 @@ class TestSkyImage:
         center = self.image.center
         assert_allclose(center.l.deg, self.center.l.deg, atol=1e-5)
         assert_allclose(center.b.deg, self.center.b.deg, atol=1e-5)
+
+    @requires_dependency('scipy')
+    @pytest.mark.parametrize('kernel', ['gauss', 'box', 'disk'])
+    def test_smooth(self, kernel):
+        desired = self.image.data.sum()
+        smoothed = self.image.smooth(kernel, 0.2 * u.deg)
+        actual = smoothed.data.sum()
+        assert_allclose(actual, desired)
 
 
 def test_image_pad():

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -307,6 +307,7 @@ class TestSkyImage:
             xref=self.center.l.deg, yref=self.center.b.deg,
             proj='TAN', coordsys='GAL',
         )
+        self.image.data = np.arange(50, dtype=float).reshape((5, 10))
 
     def test_center_pix(self):
         center = self.image.center_pix

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -7,19 +7,10 @@ from astropy.wcs import WCS
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import FermiGalacticCenter
 from ...image import (
-    binary_disk,
     block_reduce_hdu,
     lon_lat_rectangle_mask,
     SkyImage,
 )
-
-
-def test_binary_disk():
-    actual = binary_disk(1)
-    desired = np.array([[False, True, False],
-                        [True, True, True],
-                        [False, True, False]])
-    assert_equal(actual, desired)
 
 
 @pytest.mark.xfail

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -1,4 +1,4 @@
-    # Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Image utility functions"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -1,4 +1,4 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+    # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Image utility functions"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
@@ -10,14 +10,10 @@ import numpy as np
 from astropy.coordinates import Angle
 from astropy.convolution import Gaussian2DKernel
 from astropy.io import fits
-# TODO:
-# Remove this when/if https://github.com/astropy/astropy/issues/4429 is fixed
-from astropy.utils.exceptions import AstropyDeprecationWarning
+
 
 __all__ = [
-    'binary_disk',
     'block_reduce_hdu',
-    'disk_correlate',
     'image_groupby',
     'lon_lat_rectangle_mask',
     'lon_lat_circle_mask',
@@ -73,77 +69,6 @@ def scale_cube(data, kernels, parallel=True):
     else:
         result = map(wrap, kernels)
     return np.dstack(result)
-
-
-def _get_structure_indices(radius):
-    """Get arrays of indices for a symmetric structure.
-
-    Always generate an odd number of pixels and 0 at the center.
-
-    Parameters
-    ----------
-    radius : float
-        Structure radius in pixels.
-
-    Returns
-    -------
-    y, x : mesh-grid `~numpy.ndarrays` all of the same dimensions
-        Structure indices arrays.
-    """
-    radius = int(radius)
-    y, x = np.mgrid[-radius: radius + 1, -radius: radius + 1]
-    return x, y
-
-
-def binary_disk(radius):
-    """Generate a binary disk mask.
-
-    Value 1 inside and 0 outside.
-
-    Useful as a structure element for morphological transformations.
-
-    Note that the returned structure always has an odd number
-    of pixels so that shifts during correlation are avoided.
-
-    Parameters
-    ----------
-    radius : float
-        Disk radius in pixels
-
-    Returns
-    -------
-    structure : `numpy.array`
-        Structure element (bool array)
-    """
-    x, y = _get_structure_indices(radius)
-    structure = x ** 2 + y ** 2 <= radius ** 2
-    return structure
-
-
-def disk_correlate(image, radius, mode='constant'):
-    """Correlate image with binary disk kernel.
-
-    Parameters
-    ----------
-    image : `~numpy.ndarray`
-        Image to be correlated.
-    radius : float
-        Disk radius in pixels.
-    mode : {'reflect','constant','nearest','mirror', 'wrap'}, optional
-        the mode parameter determines how the array borders are handled.
-        For 'constant' mode, values beyond borders are set to be cval.
-        Default is 'constant'.
-
-    Returns
-    -------
-    convolve : `~numpy.ndarray`
-        The result of convolution of image with disk of given radius.
-
-    """
-    from scipy.ndimage import convolve
-    structure = binary_disk(radius)
-    return convolve(image, structure, mode=mode)
-
 
 def process_image_pixels(images, kernel, out, pixel_function):
     """Process images for a given kernel and per-pixel function.

--- a/gammapy/scripts/image_pipe.py
+++ b/gammapy/scripts/image_pipe.py
@@ -220,11 +220,11 @@ class SingleObsImageMaker(object):
             Disk radius in pixels.
         """
         image = SkyImage.empty_like(self.empty_image)
-        disk = Tophat2Dkernel(radius)
+        disk = Tophat2DKernel(radius)
         disk.normalize('peak')
         counts = self.images["counts"].convolve(disk.array)
         bkg = self.images["bkg"].convolve(disk.array)
-        image.data = significance(counts, bkg)
+        image.data = significance(counts.data, bkg.data)
         self.images["significance"] = image
 
     def excess_image(self):
@@ -347,12 +347,12 @@ class StackedObsImageMaker(object):
             Disk radius in pixels.
         """
         image = SkyImage.empty_like(self.empty_image, name='significance')
-        
-        disk = Tophat2Dkernel(radius)
+
+        disk = Tophat2DKernel(radius)
         disk.normalize('peak')
         counts = self.images["counts"].convolve(disk.array)
         bkg = self.images["bkg"].convolve(disk.array)
-        image.data = significance(counts, bkg)
+        image.data = significance(counts.data, bkg.data)
 
         self.images['significance'] = image
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -170,7 +170,7 @@ class SpectrumObservation(object):
 
     def stats_in_range(self, bin_min, bin_max):
         """Compute stats for a range of energy bins
-        
+
         Parameters
         ----------
         bin_min, bin_max: int
@@ -454,7 +454,7 @@ class SpectrumObservationList(UserList):
     @classmethod
     def read(cls, directory):
         """Read multiple observations
-        
+
         This methods reads all PHA files contained in a given directory
 
         Parameters
@@ -464,7 +464,9 @@ class SpectrumObservationList(UserList):
         """
         obs_list = cls()
         directory = make_path(directory)
-        filelist = directory.glob('pha*.fits')
+        # glob default order depends on OS, so we call sorted() explicitely to
+        # get reproducable results
+        filelist = sorted(directory.glob('pha*.fits'))
         for phafile in filelist:
             obs = SpectrumObservation.read(phafile)
             obs_list.append(obs)
@@ -476,28 +478,28 @@ class SpectrumObservationStacker(object):
 
     The stacking of :math:`j` observations is implemented as follows.
     :math:`k` and :math:`l` denote a bin in reconstructed and true energy,
-    respectively. 
+    respectively.
 
-    .. math:: 
+    .. math::
 
         \epsilon_{jk} =\left\{\begin{array}{cl} 1, & \mbox{if
             bin k is inside the energy thresholds}\\ 0, & \mbox{otherwise} \end{array}\right.
 
         \overline{\mathrm{n_{on}}}_k = \sum_{j} \mathrm{n_{on}}_{jk} \cdot
-            \epsilon_{jk} 
+            \epsilon_{jk}
 
         \overline{\mathrm{n_{off}}}_k = \sum_{j} \mathrm{n_{off}}_{jk} \cdot
-            \epsilon_{jk} 
+            \epsilon_{jk}
 
         \overline{\alpha}_k = \frac{\sum_{j}\alpha_{jk} \cdot
             \mathrm{n_{off}}_{jk} \cdot \epsilon_{jk}}{\overline{\mathrm {n_{off}}}}
 
         \overline{t} = \sum_{j} t_i
 
-        \overline{\mathrm{aeff}}_l = \frac{\sum_{j}\mathrm{aeff}_{jl} 
+        \overline{\mathrm{aeff}}_l = \frac{\sum_{j}\mathrm{aeff}_{jl}
             \cdot t_j}{\overline{t}}
 
-        \overline{\mathrm{edisp}}_{kl} = \frac{\sum_{j} \mathrm{edisp}_{jkl} 
+        \overline{\mathrm{edisp}}_{kl} = \frac{\sum_{j} \mathrm{edisp}_{jkl}
             \cdot \mathrm{aeff}_{jl} \cdot t_j \cdot \epsilon_{jk}}{\sum_{j} \mathrm{aeff}_{jl}
             \cdot t_j}
 
@@ -625,7 +627,7 @@ class SpectrumObservationStacker(object):
 
     def stack_aeff(self):
         """Stack effective areas (weighted by livetime)
-    
+
         calls :func:`~gammapy.irf.IRFStacker.stack_aeff`
         """
         list_arf = list()
@@ -640,7 +642,7 @@ class SpectrumObservationStacker(object):
 
     def stack_edisp(self):
         """Stack energy dispersion (weighted by exposure)
-        
+
         calls :func:`~gammapy.irf.IRFStacker.stack_edisp`
         """
         list_arf = list()


### PR DESCRIPTION
This PR addresses issue #694:
 * Finish implementation of `SkyImage.smooth()` using parameter definitions of ds9
 * Remove `disk_correlate` and related functions from `gammapy/image/utils`
 * Add minimal test for all smoothing options  