### PR TITLE
Rewrite crab spectrum as class

### DIFF
--- a/docs/tutorials/crab_mwl_sed/crab_mwl_sed.py
+++ b/docs/tutorials/crab_mwl_sed/crab_mwl_sed.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import astropy.units as u
 from gammapy.datasets import load_crab_flux_points
-from gammapy.spectrum import crab_flux
+from gammapy.spectrum import CrabSpectrum
 
 # Plot flux points
 for component in ['pulsar', 'nebula']:
@@ -16,7 +16,10 @@ for component in ['pulsar', 'nebula']:
 
 # Plot SED model
 energy = np.logspace(2, 8, 100) * u.MeV
-flux = u.Quantity(crab_flux(energy.to('TeV').value), 'cm^-2 s^-1 TeV^-1')
+
+crab = CrabSpectrum(reference='meyer')
+
+flux = crab.model(energy)
 energy_flux = (energy ** 2 * flux).to('erg cm^-2 s^-1')
 plt.plot(energy.value, energy_flux.value, label='Meyer (2010) model', lw=3)
 

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -77,15 +77,25 @@ class CrabSpectrum(object):
 
     The following references are available:
 
-        * 'meyer', 2010arXiv1008.4524M
-        * 'hegra', 2004ApJ...614..897A
-        * 'hess_pl', 2006A&A...457..899A
-        * 'hess_ecpl', 2006A&A...457..899A
+    * 'meyer', 2010arXiv1008.4524M
+    * 'hegra', 2004ApJ...614..897A
+    * 'hess_pl', 2006A&A...457..899A
+    * 'hess_ecpl', 2006A&A...457..899A
 
     Parameters
     ----------
     reference : {'meyer', 'hegra', 'hess_pl', 'hess_ecpl'}
         Which reference to use for the spectral model.
+
+    Examples
+    --------
+    Plot the 'hess_ecpl' reference crab spectrum between 1 TeV and 100 TeV:
+
+        >>> from gammapy.spectrum import CrabSpectrum
+        >>> import astropy.units as u
+        >>> crab_hess_ecpl = CrabSpectrum('hess_ecpl')
+        >>> crab_hess_ecpl.model.plot([1, 100] * u.TeV)
+
     """
     def __init__(self, reference='meyer'):
         if reference == 'meyer':

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -65,7 +65,7 @@ class MeyerCrabModel(SpectralModel):
     @staticmethod
     def evaluate(energy, coefficients):
         polynomial = np.poly1d(coefficients)
-        log_energy = np.log10(energy.value)
+        log_energy = np.log10(energy.to('TeV').value)
         log_flux = polynomial(log_energy)
         flux = np.power(10, log_flux) * u.Unit('erg / (cm2 s)')
         return flux / energy ** 2

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -96,6 +96,35 @@ class CrabSpectrum(object):
         >>> crab_hess_ecpl = CrabSpectrum('hess_ecpl')
         >>> crab_hess_ecpl.model.plot([1, 100] * u.TeV)
 
+    Use a reference crab spectrum as unit to measure flux:
+
+        >>> from astropy import units as u
+        >>> from gammapy.spectrum import CrabSpectrum
+        >>> from gammapy.spectrum.models import PowerLaw
+        >>>
+        >>> # define power law model
+        >>> amplitude = 1E-12 * u.Unit('1 / (cm2 s TeV)')
+        >>> index = 2.3
+        >>> reference = 1 * u.TeV
+        >>> pwl = PowerLaw(index, amplitude, reference)
+        >>>
+        >>> # define crab reference
+        >>> crab = CrabSpectrum('hess_pl').model
+        >>>
+        >>> # compute flux at 10 TeV in crab units
+        >>> energy = 10 * u.TeV
+        >>> flux_cu = (pwl(energy) / crab(energy)).to('%')
+        >>> print(flux_cu)
+        6.19699156377 %
+
+    And the same for integral fluxes:
+
+        >>> # compute integral flux in crab units
+        >>> emin, emax = [1, 10] * u.TeV
+        >>> flux_int_cu = (pwl.integral(emin, emax) / crab.integral(emin, emax)).to('%')
+        >>> print(flux_int_cu)
+        3.5350582166 %
+
     """
     def __init__(self, reference='meyer'):
         if reference == 'meyer':

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -167,25 +167,26 @@ class SpectralModel(object):
         """
         raise NotImplementedError('{}'.format(self.__class__.__name__))
 
-    def spectral_index(self, energy):
+    def spectral_index(self, energy, epsilon=1E-5):
         """
         Compute spectral index at given energy using a local powerlaw
-        approximisation.
+        approximation.
 
         Parameters
         ----------
         energy : `~astropy.units.Quantity`
             Energy at which to estimate the index
+        epsilon : float
+            Fractional energy increment to use for determining the spectral index.
 
         Returns
         -------
         index : float
             Estimated spectral index.
         """
-        eps = np.sqrt(np.finfo(float).eps)
-        f1 = self(energy).value
-        f2 = self(energy * np.exp(-eps)).value
-        return (np.log(f2) - np.log(f1)) / eps
+        f1 = self(energy)
+        f2 = self(energy * (1 + epsilon))
+        return np.log(f1 / f2) / np.log(1 + epsilon)
 
 
 class PowerLaw(SpectralModel):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -167,6 +167,26 @@ class SpectralModel(object):
         """
         raise NotImplementedError('{}'.format(self.__class__.__name__))
 
+    def spectral_index(self, energy):
+        """
+        Compute spectral index at given energy using a local powerlaw
+        approximisation.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy at which to estimate the index
+
+        Returns
+        -------
+        index : float
+            Estimated spectral index.
+        """
+        eps = np.sqrt(np.finfo(float).eps)
+        f1 = self(energy).value
+        f2 = self(energy * np.exp(-eps)).value
+        return (np.log(f2) - np.log(f1)) / eps
+
 
 class PowerLaw(SpectralModel):
     r"""Spectral power-law model.
@@ -468,7 +488,7 @@ class TableModel(SpectralModel):
     log-space, returning 0 for energies outside of the limits of the provided
     energy array.
 
-    Class implementation follows closely what has been done in 
+    Class implementation follows closely what has been done in
     `naima.models.TableModel`
 
     Parameters

--- a/gammapy/spectrum/tests/test_butterfly.py
+++ b/gammapy/spectrum/tests/test_butterfly.py
@@ -4,15 +4,14 @@ from astropy.units import Quantity
 from astropy.tests.helper import assert_quantity_allclose, pytest
 from ...utils.testing import requires_dependency
 from ..butterfly import SpectrumButterfly
-from ..crab import crab_flux
-
+from ..crab import CrabSpectrum
 
 @pytest.fixture
 def butterfly():
     bf = SpectrumButterfly()
-
+    crab = CrabSpectrum()
     bf['energy'] = Quantity([1, 2, 10], 'TeV')
-    bf['flux'] = Quantity(crab_flux(bf['energy'].value), 'cm^-2 s^-1 TeV^-1')
+    bf['flux'] = crab.model(bf['energy'])
     bf['flux_lo'] = [0.9, 0.8, 0.9] * bf['flux']
     bf['flux_hi'] = [1.1, 1.2, 1.1] * bf['flux']
 

--- a/gammapy/spectrum/tests/test_crab.py
+++ b/gammapy/spectrum/tests/test_crab.py
@@ -1,29 +1,42 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from numpy.testing import assert_allclose
-from astropy.units import Unit
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose, pytest
 from ...utils.testing import requires_dependency
-from ...spectrum import crab
+from ...spectrum import CrabSpectrum
 
 
-@requires_dependency('scipy')
-def test_evaluate():
-    e, e1, e2 = 2, 1, 1e3
+desired = dict()
+desired['meyer'] = [u.Quantity(5.57243750e-12, 'cm-2 s-1 TeV-1'),
+                    u.Quantity(2.0744425607241013e-11, 'cm-2 s-1'),
+                    2.631535530090332]
+desired['hegra'] = [u.Quantity(4.60349681e-12, 'cm-2 s-1 TeV-1'),
+                    u.Quantity(1.74688947e-11, 'cm-2 s-1'),
+                    2.62000000]
+desired['hess_pl'] = [u.Quantity(5.57327158e-12, 'cm-2 s-1 TeV-1'),
+                      u.Quantity(2.11653715e-11, 'cm-2 s-1'),
+                      2.63000000]
+desired['hess_ecpl'] = [u.Quantity(6.23714253e-12, 'cm-2 s-1 TeV-1'),
+                        u.Quantity(2.267957713046026e-11, 'cm-2 s-1'),
+                        2.529860258102417]
 
-    # This is just a test that the functions run
-    # These results are not verified
-    vals = dict()
-    vals['meyer'] = [5.57243750e-12, 2.07445434e-11, 2.63159544e+00]
-    vals['hegra'] = [4.60349681e-12, 1.74688947e-11, 2.62000000e+00]
-    vals['hess_pl'] = [5.57327158e-12, 2.11653715e-11, 2.63000000e+00]
-    vals['hess_ecpl'] = [6.23714253e-12, 2.26797344e-11, 2.52993006e+00]
 
-    for reference in crab.CRAB_REFERENCES:
-        f = crab.crab_flux(e, reference)
-        I = crab.crab_integral_flux(e1, e2, reference)
-        g = crab.crab_spectral_index(e, reference)
-        assert_allclose([f, I, g], vals[reference])
+class TestCrabSpectrum(object):
+
+    @pytest.mark.parametrize('reference', ['meyer', 'hegra', 'hess_pl', 'hess_ecpl'])
+    def test_evaluate(self, reference):
+        e = 2 * u.TeV
+        emin, emax = [1, 1E3] * u.TeV
+
+        crab_spectrum = CrabSpectrum(reference)
+        f = crab_spectrum.model(e)
+        I = crab_spectrum.model.integral(emin, emax)
+        g = crab_spectrum.model.spectral_index(e)
+        assert_quantity_allclose(f, desired[reference][0])
+        assert_quantity_allclose(I, desired[reference][1])
+        assert_quantity_allclose(g, desired[reference][2])
+
 
 
 # TODO: move this to the docs (this is not a test)

--- a/gammapy/spectrum/tests/test_crab.py
+++ b/gammapy/spectrum/tests/test_crab.py
@@ -8,8 +8,8 @@ from ...spectrum import CrabSpectrum
 
 
 desired = dict()
-desired['meyer'] = [u.Quantity(5.57243750e-12, 'cm-2 s-1 TeV-1'),
-                    u.Quantity(2.0744425607241013e-11, 'cm-2 s-1'),
+desired['meyer'] = [u.Quantity(5.572437502365652e-12, 'cm-2 s-1 TeV-1'),
+                    u.Quantity(2.0744425607240974e-11, 'cm-2 s-1'),
                     2.631535530090332]
 desired['hegra'] = [u.Quantity(4.60349681e-12, 'cm-2 s-1 TeV-1'),
                     u.Quantity(1.74688947e-11, 'cm-2 s-1'),
@@ -33,9 +33,9 @@ class TestCrabSpectrum(object):
         f = crab_spectrum.model(e)
         I = crab_spectrum.model.integral(emin, emax)
         g = crab_spectrum.model.spectral_index(e)
-        assert_quantity_allclose(f, desired[reference][0])
-        assert_quantity_allclose(I, desired[reference][1])
-        assert_quantity_allclose(g, desired[reference][2])
+        assert_quantity_allclose(desired[reference][0], f)
+        assert_quantity_allclose(desired[reference][1], I)
+        assert_quantity_allclose(desired[reference][2], g)
 
 
 

--- a/gammapy/spectrum/tests/test_crab.py
+++ b/gammapy/spectrum/tests/test_crab.py
@@ -35,7 +35,8 @@ class TestCrabSpectrum(object):
         g = crab_spectrum.model.spectral_index(e)
         assert_quantity_allclose(desired[reference][0], f)
         assert_quantity_allclose(desired[reference][1], I)
-        assert_quantity_allclose(desired[reference][2], g)
+        # for spectral indices rtol=1E-5 is more then sufficient
+        assert_quantity_allclose(desired[reference][2], g, rtol=1E-5)
 
 
 


### PR DESCRIPTION
This PR introduces a `CrabSpectrum` class, with the different reference models represented as `SpectrumModel`. This has the advantage, that all the methods of `SpectrumModel`, such as `.integral()`
and `energy_flux()` can be reused. It has now full `Quantity` support as well.

