### PR TITLE
Add read/write methods for PHA type II file to SpectrumObservationList

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -226,6 +226,7 @@ class CountsSpectrum(NDDataArray):
 
         return spectral_index
 
+
 class PHACountsSpectrum(CountsSpectrum):
     """OGIP PHA equivalent
 
@@ -447,11 +448,12 @@ class PHACountsSpectrum(CountsSpectrum):
 
 class PHACountsSpectrumList(list):
     """List of `~gammapy.spectrum.PHACountsSpectrum
-    
+
     All spectra must have the same energy binning. This represent the PHA type
     II data format. See
     https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node8.html
     """
+
     def write(self, outdir, **kwargs):
         """Write to file"""
         outdir = make_path(outdir)
@@ -460,7 +462,7 @@ class PHACountsSpectrumList(list):
     def to_hdulist(self):
         """Create `~astropy.fits.HDUList`"""
         prim_hdu = fits.PrimaryHDU()
-        hdu = table_to_fits_table(self.to_table()) 
+        hdu = table_to_fits_table(self.to_table())
         ebounds = energy_axis_to_ebounds(self[0].energy)
         return fits.HDUList([prim_hdu, hdu, ebounds])
 
@@ -522,10 +524,10 @@ class PHACountsSpectrumList(list):
         counts_table = fits_table_to_table(hdulist[1])
         speclist = cls()
         for row in counts_table:
-            kwargs['data']=row['COUNTS'] * u.ct
-            kwargs['backscal']=row['BACKSCAL']
-            kwargs['quality']=row['QUALITY']
-            kwargs['obs_id']=row['SPEC_NUM']
+            kwargs['data'] = row['COUNTS'] * u.ct
+            kwargs['backscal'] = row['BACKSCAL']
+            kwargs['quality'] = row['QUALITY']
+            kwargs['obs_id'] = row['SPEC_NUM']
             speclist.append(PHACountsSpectrum(**kwargs))
 
-        return speclist 
+        return speclist

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -438,12 +438,12 @@ class SpectrumObservationList(UserList):
         return Quantity(np.sum(livetimes), 's')
 
     @property
-    def on_vector_list(self): 
+    def on_vector_list(self):
         """On `~gammapy.spectrum.PHACountsSpectrumList`"""
         return PHACountsSpectrumList([o.on_vector for o in self])
 
     @property
-    def off_vector_list(self): 
+    def off_vector_list(self):
         """Off `~gammapy.spectrum.PHACountsSpectrumList`"""
         return PHACountsSpectrumList([o.off_vector for o in self])
 
@@ -455,7 +455,7 @@ class SpectrumObservationList(UserList):
 
     def write(self, outdir=None, pha_typeII=False, **kwargs):
         """Create OGIP files
-        
+
         Each observation will be written as seperate set of FITS files by
         default. If the option ``pha_typeII`` is enabled all on and off counts
         spectra will be collected into one
@@ -463,7 +463,7 @@ class SpectrumObservationList(UserList):
         All datasets will be associated to the same response files.
         see
         https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node8.html
-        
+
         TODO: File written with the ``pha_typeII`` option are not read
         properly with sherpa. This could be a sherpa issue. Investigate and
         file issue.
@@ -490,12 +490,11 @@ class SpectrumObservationList(UserList):
             rmf_file = onlist.to_table().meta['respfile']
             self[0].aeff.write(outdir / arf_file, **kwargs)
             self[0].edisp.write(outdir / rmf_file, **kwargs)
-            
 
     @classmethod
     def read(cls, directory, pha_typeII=False):
         """Read multiple observations
-        
+
         This methods reads all PHA files contained in a given directory. Enable
         ``pha_typeII`` to read a PHA type II file.
 
@@ -528,7 +527,6 @@ class SpectrumObservationList(UserList):
             aeff = EffectiveAreaTable.read(directory / 'arf.fits')
             edisp = EnergyDispersion.read(directory / 'rmf.fits')
 
-            
             for on, off in zip(on_vectors, off_vectors):
                 obs = SpectrumObservation(on_vector=on, off_vector=off,
                                           aeff=aeff, edisp=edisp)
@@ -736,4 +734,3 @@ class SpectrumObservationStacker(object):
                                   edisp=self.stacked_edisp
                                   )
         self.stacked_obs = obs
-

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -522,7 +522,17 @@ class SpectrumObservationList(UserList):
                 obs = SpectrumObservation.read(phafile)
                 obs_list.append(obs)
         else:
-            1/0 
+            # NOTE: filenames for type II PHA files are hardcoded
+            on_vectors = PHACountsSpectrumList.read(directory / 'pha2.fits')
+            off_vectors = PHACountsSpectrumList.read(directory / 'bkg.fits')
+            aeff = EffectiveAreaTable.read(directory / 'arf.fits')
+            edisp = EnergyDispersion.read(directory / 'rmf.fits')
+
+            
+            for on, off in zip(on_vectors, off_vectors):
+                obs = SpectrumObservation(on_vector=on, off_vector=off,
+                                          aeff=aeff, edisp=edisp)
+                obs_list.append(obs)
 
         return obs_list
 
@@ -726,3 +736,4 @@ class SpectrumObservationStacker(object):
                                   edisp=self.stacked_edisp
                                   )
         self.stacked_obs = obs
+

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -4,6 +4,7 @@ import numpy as np
 from copy import deepcopy
 from astropy.extern.six.moves import UserList
 from astropy.units import Quantity
+from astropy.table import Table
 from ..extern.pathlib import Path
 from ..utils.scripts import make_path
 from ..utils.energy import EnergyBounds
@@ -11,7 +12,7 @@ from ..utils.fits import table_from_row_data
 from ..data import ObservationStats
 from ..irf import EffectiveAreaTable, EnergyDispersion
 from ..irf import IRFStacker
-from .core import CountsSpectrum, PHACountsSpectrum
+from .core import CountsSpectrum, PHACountsSpectrum, PHACountsSpectrumList
 from .utils import calculate_predicted_counts
 
 __all__ = [
@@ -427,12 +428,24 @@ class SpectrumObservationList(UserList):
 
     @property
     def obs_id(self):
+        """List of observations ids"""
         return [o.obs_id for o in self]
 
     @property
     def total_livetime(self):
+        """Summed livetime"""
         livetimes = [o.livetime.to('s').value for o in self]
         return Quantity(np.sum(livetimes), 's')
+
+    @property
+    def on_vector_list(self): 
+        """On `~gammapy.spectrum.PHACountsSpectrumList`"""
+        return PHACountsSpectrumList([o.on_vector for o in self])
+
+    @property
+    def off_vector_list(self): 
+        """Off `~gammapy.spectrum.PHACountsSpectrumList`"""
+        return PHACountsSpectrumList([o.off_vector for o in self])
 
     def stack(self):
         """Return stacked `~gammapy.spectrum.SpectrumObservation`"""
@@ -440,36 +453,77 @@ class SpectrumObservationList(UserList):
         stacker.run()
         return stacker.stacked_obs
 
-    def write(self, outdir=None, **kwargs):
+    def write(self, outdir=None, pha_typeII=False, **kwargs):
         """Create OGIP files
+        
+        Each observation will be written as seperate set of FITS files by
+        default. If the option ``pha_typeII`` is enabled all on and off counts
+        spectra will be collected into one
+        `~gammapy.spectrum.PHACountsSpectrumList` and written to one FITS file.
+        All datasets will be associated to the same response files.
+        see
+        https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node8.html
+        
+        TODO: File written with the ``pha_typeII`` option are not read
+        properly with sherpa. This could be a sherpa issue. Investigate and
+        file issue.
 
         Parameters
         ----------
         outdir : str, `~gammapy.extern.pathlib.Path`, optional
             Output directory, default: pwd
+        pha_typeII : bool, default: False
+            Collect PHA datasets into one file
         """
-        for obs in self:
-            obs.write(outdir=outdir, **kwargs)
+        outdir = make_path(outdir)
+        outdir.mkdir(exist_ok=True, parents=True)
+        if not pha_typeII:
+            for obs in self:
+                obs.write(outdir=outdir, **kwargs)
+        else:
+            onlist = self.on_vector_list
+            onlist.write(outdir / 'pha2.fits', **kwargs)
+            offlist = self.off_vector_list
+            # This filename is hardcoded since it is a column in the on list
+            offlist.write(outdir / 'bkg.fits', **kwargs)
+            arf_file = onlist.to_table().meta['ancrfile']
+            rmf_file = onlist.to_table().meta['respfile']
+            self[0].aeff.write(outdir / arf_file, **kwargs)
+            self[0].edisp.write(outdir / rmf_file, **kwargs)
+            
 
     @classmethod
-    def read(cls, directory):
+    def read(cls, directory, pha_typeII=False):
         """Read multiple observations
+        
+        This methods reads all PHA files contained in a given directory. Enable
+        ``pha_typeII`` to read a PHA type II file.
 
-        This methods reads all PHA files contained in a given directory
+        see
+        https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node8.html
+
+        TODO: Replace with more sophisticated file managment system
 
         Parameters
         ----------
         directory : `~gammapy.extern.pathlib.Path`
             Directory holding the observations
+        pha_typeII : bool, default: False
+            Read PHA typeII file
         """
         obs_list = cls()
         directory = make_path(directory)
-        # glob default order depends on OS, so we call sorted() explicitely to
-        # get reproducable results
-        filelist = sorted(directory.glob('pha*.fits'))
-        for phafile in filelist:
-            obs = SpectrumObservation.read(phafile)
-            obs_list.append(obs)
+
+        if not pha_typeII:
+            # glob default order depends on OS, so we call sorted() explicitely to
+            # get reproducable results
+            filelist = sorted(directory.glob('pha*.fits'))
+            for phafile in filelist:
+                obs = SpectrumObservation.read(phafile)
+                obs_list.append(obs)
+        else:
+            1/0 
+
         return obs_list
 
 

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -79,6 +79,7 @@ class TestSpectrumObservationStacker:
         assert_allclose(npred_stacked.data, npred_summed)
 
 
+@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 class TestSpectrumObservationList:
     def setup(self):
@@ -93,9 +94,13 @@ class TestSpectrumObservationList:
         assert_quantity_allclose(stacked_obs.edisp.data[50, 52], 0.029627067949207702)
         
     def test_write(self, tmpdir):
-        self.obs_list.write(outdir=str(tmpdir), single_file=False)
+        self.obs_list.write(outdir=str(tmpdir), pha_typeII=False)
         written_files = make_path(tmpdir).glob('*')
         assert len(list(written_files)) == len(self.obs_list) * 4
 
-        self.obs_list.write(outdir=str(tmpdir / 'single_file'),
-                            pha_typeII=True)
+        outdir = tmpdir / 'pha_typeII'
+        self.obs_list.write(outdir=str(outdir), pha_typeII=True)
+         
+        test_list = SpectrumObservationList.read(outdir, pha_typeII=True)
+        assert str(test_list[0].total_stats) == str(self.obs_list[0].total_stats)
+


### PR DESCRIPTION
the PR

* Add the class ``PHACountsSpectrumList`` for a list of on or off vectors
* Add methods to read/write a ``SpectrumObservationList`` as PHA type II files

This is useful for simulations, e.g. when simulation many spectra with the same instrument response functions. The written files are at the moment not properly read by sherpa (background datasets are not detected automatically). 

see https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node8.html