### PR TITLE
Change the method worldtopix in LogEnergyAxis class

### DIFF
--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -65,11 +65,11 @@ class LogEnergyAxis(object):
         Energy fix to nan if the pix value are outside the pixel range
         """
         # Interpolate in `x = log10(energy)`
-        x = np.interp(pix, self.pix, self.x)
+        x = np.interp(pix, self.pix, self.x, left=np.nan,
+                        right=np.nan)
 
         # Convert `x` to `energy`
-        energy = Quantity(10 ** x, self.energy.unit, left=np.nan,
-                        right=np.nan)
+        energy = Quantity(10 ** x, self.energy.unit)
 
         return energy
 

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -66,7 +66,7 @@ class LogEnergyAxis(object):
         """
         # Interpolate in `x = log10(energy)`
         x = np.interp(pix, self.pix, self.x, left=np.nan,
-                        right=np.nan)
+                      right=np.nan)
 
         # Convert `x` to `energy`
         energy = Quantity(10 ** x, self.energy.unit)
@@ -301,7 +301,8 @@ def _trapz_loglog(y, x, axis=-1, intervals=False):
         # powerlaw integration
         trapzs = np.where(
             np.abs(b + 1.) > 1e-10, (y[slice1] * (
-                x[slice2] * (x[slice2] / x[slice1]) ** b - x[slice1])) / (b + 1),
+                x[slice2] * (x[slice2] / x[slice1]) ** b - x[slice1])) / (
+            b + 1),
             x[slice1] * y[slice1] * np.log(x[slice2] / x[slice1]))
 
     tozero = (y[slice1] == 0.) + (y[slice2] == 0.) + (x[slice1] == x[slice2])

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -46,7 +46,10 @@ class LogEnergyAxis(object):
         self.mode = mode
 
     def world2pix(self, energy):
-        """TODO: document.
+        """
+        pix value fix to self.pix[0]-0.5 (respectively self.pix[-1]+0.5) if the
+        energy is lower than the min energy range (respectively greater than
+        the max energy range).
         """
         # Convert `energy` to `x = log10(energy)`
         x = np.log10(energy.to(self.energy.unit).value)
@@ -58,14 +61,15 @@ class LogEnergyAxis(object):
         return np.atleast_1d(pix)
 
     def pix2world(self, pix):
-        """TODO: document.
-        change interp for left and right no?
+        """
+        Energy fix to nan if the pix value are outside the pixel range
         """
         # Interpolate in `x = log10(energy)`
         x = np.interp(pix, self.pix, self.x)
 
         # Convert `x` to `energy`
-        energy = Quantity(10 ** x, self.energy.unit)
+        energy = Quantity(10 ** x, self.energy.unit, left=np.nan,
+                        right=np.nan)
 
         return energy
 

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 import numpy as np
 from astropy.units import Quantity
 
@@ -51,12 +52,14 @@ class LogEnergyAxis(object):
         x = np.log10(energy.to(self.energy.unit).value)
 
         # Interpolate in `x`
-        pix = np.interp(x, self.x, self.pix)
+        pix = np.interp(x, self.x, self.pix, left=self.pix[0] - 0.5,
+                        right=self.pix[1] + 0.5)
 
         return np.atleast_1d(pix)
 
     def pix2world(self, pix):
         """TODO: document.
+        change interp for left and right no?
         """
         # Interpolate in `x = log10(energy)`
         x = np.interp(pix, self.pix, self.x)
@@ -294,7 +297,8 @@ def _trapz_loglog(y, x, axis=-1, intervals=False):
         # powerlaw integration
         trapzs = np.where(
             np.abs(b + 1.) > 1e-10, (y[slice1] * (
-                x[slice2] * (x[slice2] / x[slice1]) ** b - x[slice1])) / (b + 1),
+                x[slice2] * (x[slice2] / x[slice1]) ** b - x[slice1])) / (
+            b + 1),
             x[slice1] * y[slice1] * np.log(x[slice2] / x[slice1]))
 
     tozero = (y[slice1] == 0.) + (y[slice2] == 0.) + (x[slice1] == x[slice2])

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -297,8 +297,7 @@ def _trapz_loglog(y, x, axis=-1, intervals=False):
         # powerlaw integration
         trapzs = np.where(
             np.abs(b + 1.) > 1e-10, (y[slice1] * (
-                x[slice2] * (x[slice2] / x[slice1]) ** b - x[slice1])) / (
-            b + 1),
+                x[slice2] * (x[slice2] / x[slice1]) ** b - x[slice1])) / (b + 1),
             x[slice1] * y[slice1] * np.log(x[slice2] / x[slice1]))
 
     tozero = (y[slice1] == 0.) + (y[slice2] == 0.) + (x[slice1] == x[slice2])


### PR DESCRIPTION
@adonath 
This PR add a left and right value for the worldtopix method. Indeed, before for the energy < self.energy[0], it was returning the first pixel. I don"t think this is a good idea and it causes a problem in the fill events method of ```SkyCube```. Indeed the events with an energy < self.energy_axis.energy[0] were filled in the first bin of the cube wheread we don't want to.... So now all the events with an 
energy < self.energy[0] will have the value of the first pixel -0.5 and with an 
energy > self.energy[-1] will have the value of the last pixel + 0.5. Maybe you have a better idea on which value to put for the left and right values?