### PR TITLE
Misc fixes

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -53,16 +53,18 @@ class CountsSpectrum(NDDataArray):
     interp_kwargs = dict(bounds_error=False, method='nearest')
 
     def __init__(self, **kwargs):
-        data = kwargs['data']
-        if isinstance(data, u.Quantity):
-            if data.unit.is_equivalent('ct'):
-                pass
-            elif data.unit.is_equivalent(u.Unit('')):
-                data = data.value
-            else:
-                raise ValueError('Invalid data unit {}'.format(data.unit))
+        # Special case this to set data unit to counts for coherence
+        if 'data' in kwargs.keys():
+            data = kwargs['data']
+            if isinstance(data, u.Quantity):
+                if data.unit.is_equivalent('ct'):
+                    pass
+                elif data.unit.is_equivalent(u.Unit('')):
+                    data = data.value
+                else:
+                    raise ValueError('Invalid data unit {}'.format(data.unit))
+            kwargs['data'] = u.Quantity(data, 'ct')
 
-        kwargs['data'] = u.Quantity(data, 'ct')
         self = super(CountsSpectrum, self).__init__(**kwargs)        
 
     @classmethod

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -27,7 +27,7 @@ class CountsSpectrum(NDDataArray):
 
     Parameters
     ----------
-    data : `~numpy.array`, list
+    data : `~astropy.units.Quantity`, array-like
         Counts
     energy : `~gammapy.utils.energy.EnergyBounds`
         Bin edges of energy axis
@@ -51,6 +51,19 @@ class CountsSpectrum(NDDataArray):
     axis_names = ['energy']
     # Use nearest neighbour interpolation for counts
     interp_kwargs = dict(bounds_error=False, method='nearest')
+
+    def __init__(self, **kwargs):
+        data = kwargs['data']
+        if isinstance(data, u.Quantity):
+            if data.unit.is_equivalent('ct'):
+                pass
+            elif data.unit.is_equivalent(u.Unit('')):
+                data = data.value
+            else:
+                raise ValueError('Invalid data unit {}'.format(data.unit))
+
+        kwargs['data'] = u.Quantity(data, 'ct')
+        self = super(CountsSpectrum, self).__init__(**kwargs)        
 
     @classmethod
     def from_hdulist(cls, hdulist):
@@ -269,7 +282,7 @@ class PHACountsSpectrum(CountsSpectrum):
     def __init__(self, **kwargs):
         kwargs.setdefault('is_bkg', False)
         kwargs.setdefault('quality', None)
-        super(CountsSpectrum, self).__init__(**kwargs)
+        super(PHACountsSpectrum, self).__init__(**kwargs)
         if self.quality is None:
             self.quality = np.zeros(self.energy.nbins, dtype=int)
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -664,8 +664,8 @@ class SpectrumObservationStacker(object):
             bkscal_off_data = o.off_vector._backscal_array.copy()
             bkscal_off += bkscal_off_data * o.off_vector.counts_in_safe_range
 
-        stacked_bkscal_on = bkscal_on / self.stacked_off_vector.data
-        stacked_bkscal_off = bkscal_off / self.stacked_off_vector.data
+        stacked_bkscal_on = bkscal_on / self.stacked_off_vector.data.value
+        stacked_bkscal_off = bkscal_off / self.stacked_off_vector.data.value
 
         # there should be no nan values in backscal_on or backscal_off
         # this leads to problems when fitting the data

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -126,7 +126,7 @@ class SpectrumSimulation(object):
         rand: `~numpy.random.RandomState`
             random state
         """
-        on_counts = rand.poisson(self.npred_source.data)
+        on_counts = rand.poisson(self.npred_source.data.value)
 
         counts_kwargs = dict(energy=self.e_reco,
                              livetime=self.livetime,
@@ -152,11 +152,11 @@ class SpectrumSimulation(object):
         rand: `~numpy.random.RandomState`
             random state
         """
-        bkg_counts = rand.poisson(self.npred_background.data)
-        off_counts = rand.poisson(self.npred_background.data / self.alpha)
+        bkg_counts = rand.poisson(self.npred_background.data.value)
+        off_counts = rand.poisson(self.npred_background.data.value / self.alpha)
 
         # Add background to on_vector
-        self.on_vector.data += bkg_counts
+        self.on_vector.data += bkg_counts * u.ct
 
         # Create off vector
         off_vector = PHACountsSpectrum(energy=self.e_reco,

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -11,10 +11,21 @@ from .. import CountsSpectrum, PHACountsSpectrum
 
 @requires_dependency('scipy')
 class TestCountsSpectrum:
+
     def setup(self):
         self.counts = [0, 0, 2, 5, 17, 3] * u.ct
         self.bins = EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV')
         self.spec = CountsSpectrum(data=self.counts, energy=self.bins)
+
+    def test_init_wo_unit(self):
+        counts = [2, 5]
+        energy = [1, 2, 3] * u.TeV
+        spec = CountsSpectrum(data=counts, energy=energy)
+        assert spec.data.unit.is_equivalent(u.ct)
+
+        counts = u.Quantity([2, 5])
+        spec = CountsSpectrum(data=counts, energy=energy)
+        assert spec.data.unit.is_equivalent(u.ct)
 
     def test_wrong_init(self):
         bins = EnergyBounds.equal_log_spacing(1, 10, 7, 'TeV')
@@ -40,6 +51,7 @@ class TestCountsSpectrum:
 
 @requires_dependency('scipy')
 class TestPHACountsSpectrum:
+
     def setup(self):
         counts = [1, 2, 5, 6, 1, 7, 23]
         self.binning = EnergyBounds.equal_log_spacing(1, 10, 7, 'TeV')
@@ -50,6 +62,16 @@ class TestPHACountsSpectrum:
         self.spec.backscal = 0.3
         self.spec.obs_id = 42
         self.spec.livetime = 3 * u.h
+
+    def test_init_wo_unit(self):
+        counts = [2, 5]
+        energy = [1, 2, 3] * u.TeV
+        spec = PHACountsSpectrum(data=counts, energy=energy)
+        assert spec.data.unit.is_equivalent(u.ct)
+
+        counts = u.Quantity([2, 5])
+        spec = PHACountsSpectrum(data=counts, energy=energy)
+        assert spec.data.unit.is_equivalent(u.ct)
 
     def test_basic(self):
         assert 'PHACountsSpectrum' in str(self.spec)

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -40,21 +40,21 @@ class TestSpectrumSimulation:
 
     def test_without_background(self):
         self.sim.simulate_obs(seed=23)
-        assert self.sim.obs.on_vector.total_counts == 156
+        assert self.sim.obs.on_vector.total_counts == 156 * u.ct
 
     def test_with_background(self):
         self.sim.background_model = self.background_model
         self.sim.alpha = self.alpha
         self.sim.simulate_obs(seed=23)
-        assert self.sim.obs.on_vector.total_counts == 525
-        assert self.sim.obs.off_vector.total_counts == 1096
+        assert self.sim.obs.on_vector.total_counts == 525 * u.ct
+        assert self.sim.obs.off_vector.total_counts == 1096 * u.ct
 
     def test_observations_list(self):
         seeds = np.arange(5)
         self.sim.run(seed=seeds)
         assert (self.sim.result.obs_id == seeds).all()
-        assert self.sim.result[0].on_vector.total_counts == 169
-        assert self.sim.result[1].on_vector.total_counts == 159
-        assert self.sim.result[2].on_vector.total_counts == 151
-        assert self.sim.result[3].on_vector.total_counts == 163
-        assert self.sim.result[4].on_vector.total_counts == 185
+        assert self.sim.result[0].on_vector.total_counts == 169 * u.ct
+        assert self.sim.result[1].on_vector.total_counts == 159 * u.ct
+        assert self.sim.result[2].on_vector.total_counts == 151 * u.ct
+        assert self.sim.result[3].on_vector.total_counts == 163 * u.ct
+        assert self.sim.result[4].on_vector.total_counts == 185 * u.ct

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -19,7 +19,7 @@ __all__ = [
     'assert_skycoord_allclose',
 ]
 
-SHERPA_LT_4_8 = not minversion('sherpa', '4.8')
+SHERPA_LT_4_8 = not minversion('sherpa', '4.8.2+81')
 
 # Cache for `requires_dependency`
 _requires_dependency_cache = dict()


### PR DESCRIPTION
This PR

* Reactivate the tests on SpectrumFit, they work with the Sherpa head version. Many values changed over the quite long time this test was inactive. It's impossible to track down which pull requests changed this. :disappointed: 

* Always cast inputs to ``CountsSpectrum`` as Quantity with unit ``ct``. Before more  cases (numpy array, dimensionless quantity, quantity with unit counts) were supported, which lead to unwanted behaviour in some places

* Resturctures the plot method on ``SpectrumFitResult``

There will be a follow up PR, splitting out the test on ``SpectrumFitResult`` an make it independent from the test in ``SpectrumFitResult``. It will also add functionality to display/debug stats per bin

