### PR TITLE
Misc updates to gammapy.spectrum

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -241,6 +241,32 @@ class CountsSpectrum(NDDataArray):
 
         return spectral_index
 
+    def rebin(self, parameter):
+        """Rebin
+
+        Parameters
+        ----------
+        parameter, int
+            Number of bins to merge
+
+        Returns
+        -------
+        rebinned_spectrum : `~gammapy.spectrum.CountsSpectrum`
+            Rebinned spectrum
+        """
+        if len(self.data) % parameter != 0:
+            raise ValueError("Invalid rebin parameter: {}, nbins: {}".format(
+                parameter, len(self.data)))
+
+        retval = self.copy()
+        retval.energy.data = retval.energy.data[0::parameter]
+        split_indices = np.arange(parameter, len(retval.data), parameter)
+        counts_grp = np.split(retval.data, split_indices)
+        counts_rebinned = np.sum(counts_grp, axis=1)
+        retval.data = counts_rebinned * u.ct
+
+        return retval
+
 
 class PHACountsSpectrum(CountsSpectrum):
     """OGIP PHA equivalent

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -13,33 +13,34 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
+
 class SpectrumSimulation(object):
     """Simulate `~gammapy.spectrum.SpectrumObservation`.
 
     Parameters
     ----------
-    aeff : `~gammapy.irf.EffectiveAreaTable`
-        Effective Area
-    edisp : `~gammapy.irf.EnergyDispersion`,
-        Energy Dispersion
-    source_model : `~gammapy.spectrum.models.SpectralModel`
-        Source model
     livetime : `~astropy.units.Quantity`
         Livetime
+    source_model : `~gammapy.spectrum.models.SpectralModel`
+        Source model
+    aeff : `~gammapy.irf.EffectiveAreaTable`
+        Effective Area
+    edisp : `~gammapy.irf.EnergyDispersion`, optional
+        Energy Dispersion
     e_reco : `~astropy.units.Quantity`, optional
-        Desired energy axis of the prediced counts vector By default, the reco
-        energy axis of the energy dispersion matrix is used.
+        see :func:`gammapy.spectrum.utils.calculate_predicted_counts`
     background_model : `~gammapy.spectrum.models.SpectralModel`, optional
         Background model
     alpha : float, optional
         Exposure ratio between source and background
     """
-    def __init__(self, aeff, edisp, source_model, livetime,
+
+    def __init__(self, livetime, source_model, aeff, edisp=None,
                  e_reco=None, background_model=None, alpha=None):
+        self.livetime = livetime
+        self.source_model = source_model
         self.aeff = aeff
         self.edisp = edisp
-        self.source_model = source_model
-        self.livetime = livetime
         self.e_reco = e_reco or edisp.e_reco.data
         self.background_model = background_model
         self.alpha = alpha
@@ -51,20 +52,28 @@ class SpectrumSimulation(object):
 
     @property
     def npred_source(self):
-        """Predicted source `~gammapy.spectrum.CountsSpectrum`"""
+        """Predicted source `~gammapy.spectrum.CountsSpectrum`
+
+        calls :func:`gammapy.spectrum.utils.calculate_predicted_counts`
+        """
         npred = calculate_predicted_counts(livetime=self.livetime,
                                            aeff=self.aeff,
                                            edisp=self.edisp,
-                                           model=self.source_model)
+                                           model=self.source_model,
+                                           e_reco=self.e_reco)
         return npred
 
     @property
     def npred_background(self):
-        """Predicted background `~gammapy.spectrum.CountsSpectrum`"""
+        """Predicted background `~gammapy.spectrum.CountsSpectrum`
+
+        calls :func:`gammapy.spectrum.utils.calculate_predicted_counts`
+        """
         npred = calculate_predicted_counts(livetime=self.livetime,
                                            aeff=self.aeff,
                                            edisp=self.edisp,
-                                           model=self.background_model)
+                                           model=self.background_model,
+                                           e_reco=self.e_reco)
         return npred
 
     def run(self, seed):

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -48,6 +48,15 @@ class TestCountsSpectrum:
         spec2 = CountsSpectrum.read(filename)
         assert_quantity_allclose(spec2.energy.data, self.bins)
 
+    def test_rebin(self):
+        rebinned_spec = self.spec.rebin(2)
+        assert rebinned_spec.energy.nbins == self.spec.energy.nbins / 2
+        assert rebinned_spec.data.shape[0] == self.spec.data.shape[0] / 2
+        assert rebinned_spec.total_counts == self.spec.total_counts
+
+        with pytest.raises(ValueError):
+            rebinned_spec = self.spec.rebin(4)
+
 
 @requires_dependency('scipy')
 class TestPHACountsSpectrum:

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -62,9 +62,9 @@ class TestCountsSpectrum:
 class TestPHACountsSpectrum:
 
     def setup(self):
-        counts = [1, 2, 5, 6, 1, 7, 23]
-        self.binning = EnergyBounds.equal_log_spacing(1, 10, 7, 'TeV')
-        quality = [1, 1, 1, 0, 0, 1, 1]
+        counts = [1, 2, 5, 6, 1, 7, 23, 2]
+        self.binning = EnergyBounds.equal_log_spacing(1, 10, 8, 'TeV')
+        quality = [1, 1, 1, 0, 0, 1, 1, 1]
         self.spec = PHACountsSpectrum(data=counts,
                                       energy=self.binning,
                                       quality=quality)
@@ -93,9 +93,9 @@ class TestPHACountsSpectrum:
         self.spec.quality = np.zeros(self.spec.energy.nbins, dtype=int)
         self.spec.lo_threshold = 1.5 * u.TeV
         self.spec.hi_threshold = 4.5 * u.TeV
-        assert (self.spec.quality == [1, 1, 0, 0, 1, 1, 1]).all()
-        assert_quantity_allclose(self.spec.lo_threshold, 1.93069773 * u.TeV)
-        assert_quantity_allclose(self.spec.hi_threshold, 3.72759372 * u.TeV)
+        assert (self.spec.quality == [1, 1, 0, 0, 0, 1, 1, 1]).all()
+        assert_quantity_allclose(self.spec.lo_threshold, 1.778279410038922 * u.TeV)
+        assert_quantity_allclose(self.spec.hi_threshold, 4.216965034285822 * u.TeV)
 
     def test_io(self, tmpdir):
         filename = tmpdir / 'test2.fits'
@@ -107,3 +107,10 @@ class TestPHACountsSpectrum:
         self.spec.backscal = np.arange(self.spec.energy.nbins)
         table = self.spec.to_table()
         assert table['BACKSCAL'][2] == 2
+
+    def test_rebin(self):
+        spec_rebinned = self.spec.rebin(2)
+        assert (spec_rebinned.quality == [1, 0, 0, 1]).all()
+        assert_quantity_allclose(spec_rebinned.hi_threshold, 5.623413251903491 * u.TeV)
+        assert_quantity_allclose(spec_rebinned.lo_threshold, 1.778279410038922 * u.TeV)
+

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -57,6 +57,10 @@ class TestCountsSpectrum:
         with pytest.raises(ValueError):
             rebinned_spec = self.spec.rebin(4)
 
+        actual = rebinned_spec.evaluate(energy = [2, 3, 5] * u.TeV)
+        desired = [0, 7, 20] * u.ct
+        assert (actual == desired).all()
+
 
 @requires_dependency('scipy')
 class TestPHACountsSpectrum:

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
 import numpy as np
+from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency
 from ...irf import EnergyDispersion, EffectiveAreaTable
 from .. import SpectrumExtraction, SpectrumSimulation
@@ -41,6 +42,7 @@ class TestSpectrumSimulation:
     def test_without_background(self):
         self.sim.simulate_obs(seed=23)
         assert self.sim.obs.on_vector.total_counts == 156 * u.ct
+        # print(np.sum(self.sim.npred_source.data.value))
 
     def test_with_background(self):
         self.sim.background_model = self.background_model
@@ -58,3 +60,12 @@ class TestSpectrumSimulation:
         assert self.sim.result[2].on_vector.total_counts == 151 * u.ct
         assert self.sim.result[3].on_vector.total_counts == 163 * u.ct
         assert self.sim.result[4].on_vector.total_counts == 185 * u.ct
+
+    def test_without_edisp(self):
+        self.sim.edisp=None
+        self.sim.simulate_obs(seed=23)
+        assert self.sim.obs.on_vector.total_counts == 160 * u.ct
+        # The test value is taken from the test with edisp
+        assert_allclose(np.sum(self.sim.npred_source.data.value),
+                        167.467572145, rtol=0.01)
+


### PR DESCRIPTION
* ``SpectrumSimulation`` edisp argument is now optional (passed through to ``calculate_prediced_counts``)
* ``CountsSpectrum`` now has a ``rebin`` method, analog to https://root.cern.ch/doc/master/classTH1.html#aff6520fdae026334bf34fa1800946790