### PR TITLE
Improve LogEnergyAxis object

### DIFF
--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -31,7 +31,7 @@ class TestSkyCube(object):
         name = 'Axel'
         data = self.sky_cube.data
         wcs = self.sky_cube.wcs
-        energy = self.sky_cube.energy_axis.energy
+        energy = self.sky_cube.energies()
 
         sky_cube = SkyCube(name, data, wcs, energy)
         assert sky_cube.data.shape == (30, 21, 61)

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -208,7 +208,7 @@ def test_compute_npred_cube():
 
     assert_allclose(actual, desired, rtol=0.001)
 
-
+@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_bin_events_in_cube():
     filename = ('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599'

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -27,14 +27,13 @@ def test_exposure_cube():
     offset_max = Angle(2.2, 'deg')
     exp_cube = exposure_cube(pointing, livetime, aeff2d, count_cube,
                              offset_max=offset_max)
-    exp_ref = Quantity(4.7e8, 'm^2 s')
+    exp_ref = Quantity(4.7e8, 'm2 s')
     coordinates = exp_cube.sky_image_ref.coordinates()
     offset = coordinates.separation(pointing)
 
     assert np.shape(exp_cube.data)[1:] == np.shape(count_cube.data)[1:]
     assert np.shape(exp_cube.data)[0] == np.shape(count_cube.data)[0]
     assert exp_cube.wcs == count_cube.wcs
-    assert_equal(count_cube.energy_axis.energy, exp_cube.energy_axis.energy)
     assert_quantity_allclose(np.nanmax(exp_cube.data), exp_ref, rtol=100)
     assert exp_cube.data.unit == exp_ref.unit
     assert exp_cube.data[:, offset > offset_max].sum() == 0

--- a/gammapy/cube/tests/test_images.py
+++ b/gammapy/cube/tests/test_images.py
@@ -21,7 +21,6 @@ class TestSkyCubeImages:
         assert_array_equal(image_list.images[0].data, sky_cube_original.data[0])
 
         assert_array_equal(sky_cube_restored.data, sky_cube_original.data)
-        assert_array_equal(sky_cube_restored.energy_axis.energy, sky_cube_original.energy_axis.energy)
         assert sky_cube_restored.name == sky_cube_original.name
         assert sky_cube_restored.wcs == sky_cube_original.wcs
 
@@ -47,8 +46,7 @@ class TestBlockReduceHDU:
     def test_cube(self, operation):
         for energy in self.energy:
             image = self.cube.sky_image(energy)
-            idx = int(self.cube.energy_axis.world2pix(energy))
-            layer = self.cube.data[idx]
+            layer = image.data
             layer_hdu = fits.ImageHDU(data=layer, header=image.wcs.to_header())
             image_1 = block_reduce_hdu(layer_hdu, (2, 4), func=operation)
             if operation == np.sum:

--- a/gammapy/cube/tests/test_images.py
+++ b/gammapy/cube/tests/test_images.py
@@ -11,6 +11,7 @@ from ...image import SkyImage, block_reduce_hdu
 from ..images import SkyCubeImages
 
 
+@requires_dependency('scipy')
 @requires_data("gammapy-extra")
 class TestSkyCubeImages:
     def test_to_cube(self):

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -31,11 +31,13 @@ class TestFermiGalacticCenter:
         assert counts.data.shape == (201, 401)
         assert counts.data.sum() == 24803
 
+    @requires_dependency('scipy')
     def test_diffuse_model(self):
         diffuse_model = FermiGalacticCenter.diffuse_model()
         assert diffuse_model.data.shape == (30, 21, 61)
         assert_quantity_allclose(diffuse_model.energies()[0], Quantity(50, 'MeV'))
 
+    @requires_dependency('scipy')
     def test_exposure_cube(self):
         exposure_cube = FermiGalacticCenter.exposure_cube()
         assert exposure_cube.data.shape == (21, 11, 31)
@@ -62,6 +64,7 @@ class TestFermiVelaRegion:
         angle = psf.containment_radius(energy, fraction, interpol_param)
         assert_quantity_allclose(angle, Angle(0.13185321269896136, 'deg'), rtol=1e-1)
 
+    @requires_dependency('scipy')
     def test_diffuse_model(self):
         diffuse_model = FermiVelaRegion.diffuse_model()
         assert diffuse_model.data.shape == (30, 161, 161)
@@ -80,6 +83,7 @@ class TestFermiVelaRegion:
         events_list = FermiVelaRegion.events()
         assert events_list['EVENTS'].data.shape == (2042,)
 
+    @requires_dependency('scipy')
     def test_exposure_cube(self):
         exposure_cube = FermiVelaRegion.exposure_cube()
         assert exposure_cube.data.shape == (21, 50, 50)

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -17,7 +17,7 @@ def test_extended_image():
     # TODO: implement me
     pass
 
-
+@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_source_image():
     reference_hdu = SkyImage.empty(nxpix=10, nypix=10, binsz=1).to_image_hdu()

--- a/gammapy/spectrum/tests/test_sed.py
+++ b/gammapy/spectrum/tests/test_sed.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
-from ...utils.testing import requires_data
+from ...utils.testing import requires_data, requires_dependency
 from ...datasets import FermiGalacticCenter
 from ...image import lon_lat_rectangle_mask
 from ...spectrum import SED, add_spec, cube_sed
@@ -108,7 +108,7 @@ def test_42():
     # sed.add(['2FGL J0534.5+2201']) # Crab
     sed.plot('sed.png')
 
-
+@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_cube_sed1():
     """Tests against known results with differential cube of 1s.
@@ -137,7 +137,7 @@ def test_cube_sed1():
                           errors=True, counts=counts)
     assert_allclose(sed_table3['DIFF_FLUX_ERR_HI'].data, 2560 * np.sqrt(1. / 256))
 
-
+@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_cube_sed2():
     """Tests against known results with integral cube of 1s.

--- a/gammapy/spectrum/tests/test_sed.py
+++ b/gammapy/spectrum/tests/test_sed.py
@@ -156,8 +156,8 @@ def test_cube_sed2():
 
     sed_table1 = cube_sed(spec_cube, mask, flux_type='integral')
 
-    assert_allclose(sed_table1['ENERGY'][0], 53.37451755960359)
-    assert_allclose(sed_table1['DIFF_FLUX'][0], 365.64943655965686)
+    assert_allclose(sed_table1['ENERGY'][0], 49.9571490582045)
+    assert_allclose(sed_table1['DIFF_FLUX'][0], 194.78719630693772)
     assert_allclose(sed_table1['DIFF_FLUX_ERR_HI'], 0)
 
     sed_table2 = cube_sed(spec_cube, mask, flux_type='integral',

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -18,14 +18,11 @@ def test_LogEnergyAxis():
     energy = Quantity([1, 10, 100], 'TeV')
     energy_axis = LogEnergyAxis(energy)
 
-    assert_allclose(energy_axis.x, [0, 1, 2])
-    assert_quantity_allclose(energy_axis.energy, energy)
-
     energy = Quantity(gmean([1, 10]), 'TeV')
-    pix = energy_axis.world2pix(energy.to('MeV'))
+    pix = energy_axis.wcs_world2pix(energy.to('MeV'))
     assert_allclose(pix, 0.5)
 
-    world = energy_axis.pix2world(pix)
+    world = energy_axis.wcs_pix2world(pix)
     assert_quantity_allclose(world, energy)
 
 


### PR DESCRIPTION
This PR addresses #787. It changes `LogEnergyAxis` to use scipy's `RegularGridInterpolator`, which allows extrapolation of pixel and energy values. This is needed for extrapolation of `SkyCube` objects