### PR TITLE
Add gamma-cat access by source name alias and fix for #781

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -477,7 +477,14 @@ class SourceCatalog3FGL(SourceCatalog):
         self.extended_sources_table = Table(self.hdu_list['ExtendedSources'].data)
 
         table = Table(self.hdu_list['LAT_Point_Source_Catalog'].data)
-        super(SourceCatalog3FGL, self).__init__(table=table)
+
+        source_name_key='Source_Name'
+        source_name_alias = ('Extended_Source_Name', '0FGL_Name', '1FGL_Name',
+                             '2FGL_Name', '1FHL_Name', 'ASSOC_TEV', 'ASSOC1',
+                             'ASSOC2')
+        super(SourceCatalog3FGL, self).__init__(table=table,
+                                source_name_key=source_name_key,
+                                source_name_alias=source_name_alias)
 
 
 class SourceCatalog2FHL(SourceCatalog):
@@ -495,6 +502,10 @@ class SourceCatalog2FHL(SourceCatalog):
         self.count_map_hdu = self.hdu_list['Count Map']
         self.extended_sources_table = Table(self.hdu_list['Extended Sources'].data)
         self.rois = Table(self.hdu_list['ROIs'].data)
-
         table = Table(self.hdu_list['2FHL Source Catalog'].data)
-        super(SourceCatalog2FHL, self).__init__(table=table)
+
+        source_name_key='Source_Name'
+        source_name_alias = ('ASSOC', '3FGL_Name', '1FHL_Name', 'TeVCat_Name')
+        super(SourceCatalog2FHL, self).__init__(table=table,
+                                source_name_key=source_name_key,
+                                source_name_alias=source_name_alias)

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -175,47 +175,11 @@ class SourceCatalogGammaCat(SourceCatalog):
 
         self.filename = str(filename)
         table = QTable.read(self.filename)
-        super(SourceCatalogGammaCat, self).__init__(table=table, source_name_key='common_name')
-
-    @lazyproperty
-    def _name_to_index_cache(self):
-        """
-        Name to index cache with alias names.
-        """
-        names = {}
-        for index, row in enumerate(self.table):
-            name = row['common_name'].strip()
-            names[name] = index
-            for alias in row['gamma_names'].split(','):
-                names[alias] = index
-            for alias in row['other_names'].split(','):
-                names[alias] = index
-        return names
-
-    def row_index(self, name):
-        """Look up row index of source by name.
-
-        Parameters
-        ----------
-        name : str
-            Source name
-
-        Returns
-        -------
-        index : int
-            Row index of source in table
-        """
-        index = self._name_to_index_cache[name]
-
-        row = self.table[index]
-        possible_names = [row['common_name']] + row['gamma_names'].split(',') + \
-                          row['other_names'].split(',')
-
-        if not name in possible_names:
-            self.__dict__.pop('_name_to_index_cache')
-            index = self._name_to_index_cache[name]
-
-        return index
+        source_name_key='common_name'
+        source_name_alias = ('other_names', 'gamma_names')
+        super(SourceCatalogGammaCat, self).__init__(table=table,
+                                source_name_key=source_name_key,
+                                source_name_alias=source_name_alias)
 
     def _make_source_dict(self, index):
         """Make one source data dict.

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -440,7 +440,9 @@ class SourceCatalogHGPS(SourceCatalog):
             raise ValueError("Must be one of the following: 'HGPS_SOURCES',"
                              "'HGPS_SOURCES_PA' or 'HESS_GALACTIC'")
 
-        super(SourceCatalogHGPS, self).__init__(table=table)
+        source_name_alias = ('Associated_Object',)
+        super(SourceCatalogHGPS, self).__init__(table=table,
+                                            source_name_alias=source_name_alias)
 
 
     def _make_source_object(self, index):

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -129,7 +129,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         ss += '{:<20s} : {}\n'.format('Analysis reference', d['Analysis_Reference'])
         ss += '{:<20s} : {}\n'.format('Source class', d['Source_Class'])
         ss += '{:<20s} : {}\n'.format('Associated object', d['Associated_Object'])
-        ss += '{:<20s} : {}\n'.format('TeVCat reference', d['TeVCat_Reference'])
+        ss += '{:<20s} : {}\n'.format('Gamma-Cat id', d['Gamma_Cat_Source_ID'])
         ss += '\n'
 
         return ss

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -14,6 +14,11 @@ MODEL_TEST_DATA = [(0, PowerLaw, Quantity(1.4351261e-9, 'GeV-1 s -1 cm-2')),
                    (4, LogParabola, Quantity(8.3828599e-10, 'GeV-1 s -1 cm-2')),
                    (55, ExponentialCutoffPowerLaw3FGL, Quantity(1.8666925e-09, 'GeV-1 s-1 cm-2'))]
 
+CRAB_NAMES_3FGL = ['Crab', '3FGL J0534.5+2201', '1FHL J0534.5+2201',
+                   '2FGL J0534.5+2201', 'PSR J0534+2200', '0FGL J0534.6+2201']
+CRAB_NAMES_2FHL = ['Crab', '3FGL J0534.5+2201i', '1FHL J0534.5+2201',
+                   'TeV J0534+2200']
+
 @requires_data('gammapy-extra')
 class TestSourceCatalog3FGL:
     def test_main_table(self):
@@ -72,11 +77,12 @@ class TestFermi3FGLObject:
                    1.308784e-08]
         assert_allclose(flux_points['DIFF_FLUX'].data, desired, rtol=1E-5)
 
-
-
     def test_flux_points_integral(self):
         assert len(self.source.flux_points_integral) == 5
 
+    @pytest.mark.parametrize('name', CRAB_NAMES_3FGL)
+    def test_crab_alias(self, name):
+        assert str(self.cat['Crab']) == str(self.cat[name])
 
 
 @requires_data('gammapy-extra')
@@ -90,6 +96,10 @@ class TestSourceCatalog2FHL:
     def test_extended_sources(self):
         table = self.cat.extended_sources_table
         assert len(table) == 25
+
+    @pytest.mark.parametrize('name', CRAB_NAMES_2FHL)
+    def test_crab_alias(self, name):
+        assert str(self.cat['Crab']) == str(self.cat[name])
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -9,6 +9,7 @@ from ...utils.energy import Energy
 
 
 SOURCES = ['Vela X', 'HESS J1848-018', 'HESS J1813-178']
+
 DESIRED_SM = [ {'flux_at_1TeV': 1.36e-11 * u.Unit('1 / (cm2 TeV s)'),
                 'flux_above_1TeV': 2.104e-11 * u.Unit('1 / (cm2 s)'),
                 'eflux_1_10TeV': 5.783e-11 * u.Unit('TeV / (cm2 s)')},
@@ -37,6 +38,10 @@ DESIRED_BF = [{'energy_sum': 40.8695 * u.TeV,
                'flux_lo_sum': 5.691e-12 * u.Unit('1 / (cm2 s TeV)'),
                'flux_hi_sum': 7.181e-12 * u.Unit('1 / (cm2 s TeV)')}]
 
+W28_NAMES = ['W28', 'HESS J1801-233', 'W 28', 'SNR G6.4-0.1', 'SNR G006.4-00.1',
+             'GRO J1801-2320']
+
+SORT_KEYS = ['ra', 'dec', 'paper_id']
 
 @requires_data('gamma-cat')
 class TestSourceCatalogGammaCat:
@@ -46,6 +51,17 @@ class TestSourceCatalogGammaCat:
     def test_source_table(self):
         assert self.cat.name == 'gamma-cat'
         assert len(self.cat.table) == 162
+
+    @pytest.mark.parametrize('name', W28_NAMES)
+    def test_w28_alias_names(self, name):
+        assert str(self.cat[name]) == str(self.cat['W28'])
+
+    @pytest.mark.parametrize(['name', 'key'], zip(SOURCES, SORT_KEYS))
+    def test_sort_table(self, name, key):
+        before = str(self.cat[name])
+        self.cat.table.sort(key)
+        after = str(self.cat[name])
+        assert before == after
 
 
 @requires_data('gamma-cat')


### PR DESCRIPTION
This PR implements the source access for `SourceCatalogGammaCat` by other source names.
E.g.  `'W28'` can be accessed with ` 'HESS J1801-233', 'W 28', 'SNR G6.4-0.1', 'SNR G006.4-00.1', ...` as well.

Furthermore this PR fixes #781. This was achieved by making `_name_to_index_cache` a `lazyproperty` and recomputing it, if the requested name doesn't agree with the returned name.
