### PR TITLE
Extend SpectrumObservation test

### DIFF
--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -203,14 +203,21 @@ class SpectrumObservation(object):
         -------
         stats : `~gammapy.spectrum.SpectrumStats`
             Stats
-        """
+        """ 
+        if self.off_vector is not None:
+            n_off = int(self.off_vector.data.value[idx])
+            a_off = self.off_vector._backscal_array[idx]
+        else:
+            n_off = 0
+            a_off = 1 # avoid zero division error
+
         return SpectrumStats(
             energy_min=self.e_reco[idx],
             energy_max=self.e_reco[idx + 1],
             n_on=int(self.on_vector.data.value[idx]),
-            n_off=int(self.off_vector.data.value[idx]),
+            n_off=n_off,
             a_on=self.on_vector._backscal_array[idx],
-            a_off=self.off_vector._backscal_array[idx],
+            a_off=a_off,
             obs_id=self.obs_id,
             livetime=self.livetime,
         )

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -96,8 +96,7 @@ class SpectrumSimulation(object):
             progress = ((counter + 1) / n_obs) * 100
             if progress % 10 == 0:
                 log.info("Progress : {} %".format(progress))
-            self.simulate_obs(seed=current_seed)
-            self.obs.obs_id = current_seed
+            self.simulate_obs(seed=current_seed, obs_id=current_seed)
             self.result.append(self.obs)
 
     def reset(self):
@@ -107,24 +106,27 @@ class SpectrumSimulation(object):
         self.on_vector = None
         self.off_vector = None
 
-    def simulate_obs(self, seed='random-seed'):
+    def simulate_obs(self, obs_id, seed='random-seed'):
         """Simulate one `~gammapy.spectrum.SpectrumObservation`.
 
         The result is stored as ``obs`` attribute
 
         Parameters
         ----------
+        obs_id : int
+            Observation identifier
         seed : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
             see :func:~`gammapy.utils.random.get_random_state`
         """
-        rand = get_random_state(seed)
-        self.simulate_source_counts(rand)
+        random_state = get_random_state(seed)
+        self.simulate_source_counts(random_state)
         if self.background_model is not None:
-            self.simulate_background_counts(rand)
+            self.simulate_background_counts(random_state)
         obs = SpectrumObservation(on_vector=self.on_vector,
                                   off_vector=self.off_vector,
                                   aeff=self.aeff,
                                   edisp=self.edisp)
+        obs.obs_id = obs_id
         self.obs = obs
 
     def simulate_source_counts(self, rand):

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -3,37 +3,95 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose, pytest
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.scripts import make_path
+from ...datasets import gammapy_extra
 from ...spectrum import (
     SpectrumObservation,
     SpectrumObservationList,
     SpectrumObservationStacker,
-    models
+    models,
+    SpectrumSimulation,
 )
+from ...irf import EffectiveAreaTable, EnergyDispersion
 
 
+def get_test_obs():
+    test_obs = list()
+    if not gammapy_extra.is_available:
+        return test_obs
+    try:
+        import scipy
+    except ImportError:
+        return test_obs
+
+    # Obs read from file
+    obs_1 = SpectrumObservation.read(
+        gammapy_extra.filename('datasets/hess-crab4_pha/pha_obs23523.fits'))
+    test_obs.append(dict(
+        obs=obs_1,
+        total_on=172,
+        livetime = 1581.73681640625 * u.second,
+        excess = 166.428,
+        excess_safe_range = 135.428)
+    )
+    # Simulated obs without background
+    energy = np.logspace(-2, 2, 100) * u.TeV
+    aeff = EffectiveAreaTable.from_parametrization(energy=energy)
+    edisp = EnergyDispersion.from_gauss(e_true = energy, e_reco = energy)
+    livetime = 1 * u.h
+    source_model = models.PowerLaw(index = 2.3 * u.Unit(''),
+                                   amplitude = 2.3e-11 * u.Unit('cm-2 s-1 TeV-1'),
+                                   reference = 1.4 * u.TeV)
+    sim = SpectrumSimulation(aeff=aeff, edisp=edisp, source_model=source_model,
+                             livetime=livetime)
+    sim.simulate_obs(seed=2309, obs_id=2309)
+    test_obs.append(dict(
+        obs=sim.obs,
+        total_on=821,
+        livetime = livetime, 
+        excess = 821, 
+        excess_safe_range = 821)
+    )
+    return test_obs
+
+@pytest.mark.parametrize('obs', get_test_obs())
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-class TestSpectrumObservation:
-    def setup(self):
-        self.obs = SpectrumObservation.read('$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23523.fits')
+def test_spectrum_observation(obs):
+    tester=SpectrumObservationTester(obs)
+    tester.test_all()
+
+class SpectrumObservationTester:
+    def __init__(self, obs_dict):
+        self.obs=obs_dict.pop('obs')
+        self.vals=obs_dict
+
+    def test_all(self):
+        self.test_basic()
+        self.test_stats_table()
+        self.test_total_stats()
+        self.test_stats_in_safe_range()
+        self.test_peek()
+
+    def test_basic(self):
+        assert 'Observation summary report' in str(self.obs)
 
     def test_stats_table(self):
-        table = self.obs.stats_table()
-        assert table['n_on'].sum() == 172
-        assert_quantity_allclose(table['livetime'].max(), 1581.73681640625 * u.second)
+        table=self.obs.stats_table()
+        assert table['n_on'].sum() == self.vals['total_on']
+        assert_quantity_allclose(table['livetime'].max(), self.vals['livetime'])
 
     def test_total_stats(self):
-        excess = self.obs.total_stats.excess
-        assert_allclose(excess, 166.428, atol=1e-3)
+        excess=self.obs.total_stats.excess
+        assert_allclose(excess, self.vals['excess'], atol=1e-3)
 
     def test_stats_in_safe_range(self):
-        stats = self.obs.total_stats_safe_range
+        stats=self.obs.total_stats_safe_range
         assert_quantity_allclose(stats.energy_min, self.obs.lo_threshold)
         assert_quantity_allclose(stats.energy_max, self.obs.hi_threshold)
-        assert_allclose(stats.excess, 135.428, atol=1e-3)
+        assert_allclose(stats.excess, self.vals['excess_safe_range'], atol=1e-3)
 
     @requires_dependency('matplotlib')
     def test_peek(self):
@@ -44,37 +102,37 @@ class TestSpectrumObservation:
 @requires_data('gammapy-extra')
 class TestSpectrumObservationStacker:
     def setup(self):
-        self.obs_list = SpectrumObservationList.read(
+        self.obs_list=SpectrumObservationList.read(
             '$GAMMAPY_EXTRA/datasets/hess-crab4_pha')
 
         # Change threshold to make stuff more interesting
-        self.obs_list.obs(23523).lo_threshold = 1.2 * u.TeV
-        self.obs_stacker = SpectrumObservationStacker(self.obs_list)
+        self.obs_list.obs(23523).lo_threshold=1.2 * u.TeV
+        self.obs_stacker=SpectrumObservationStacker(self.obs_list)
         self.obs_stacker.run()
 
     def test_basic(self):
         assert 'Stacker' in str(self.obs_stacker)
-        counts1 = self.obs_list[0].total_stats_safe_range.n_on
-        counts2 = self.obs_list[1].total_stats_safe_range.n_on
-        summed_counts = counts1 + counts2
-        stacked_counts = self.obs_stacker.stacked_obs.total_stats.n_on
+        counts1=self.obs_list[0].total_stats_safe_range.n_on
+        counts2=self.obs_list[1].total_stats_safe_range.n_on
+        summed_counts=counts1 + counts2
+        stacked_counts=self.obs_stacker.stacked_obs.total_stats.n_on
         assert summed_counts == stacked_counts
 
     def test_verify_npred(self):
         """Veryfing npred is preserved during the stacking"""
-        pwl = models.PowerLaw(index=2 * u.Unit(''),
+        pwl=models.PowerLaw(index=2 * u.Unit(''),
                               amplitude=2e-11 * u.Unit('cm-2 s-1 TeV-1'),
                               reference=1 * u.TeV)
 
-        npred_stacked = self.obs_stacker.stacked_obs.predicted_counts(model=pwl)
+        npred_stacked=self.obs_stacker.stacked_obs.predicted_counts(model=pwl)
 
-        npred1 = self.obs_list[0].predicted_counts(model=pwl)
-        npred2 = self.obs_list[1].predicted_counts(model=pwl)
+        npred1=self.obs_list[0].predicted_counts(model=pwl)
+        npred2=self.obs_list[1].predicted_counts(model=pwl)
         # Set npred outside safe range to 0
-        npred1.data[np.nonzero(self.obs_list[0].on_vector.quality)] = 0
-        npred2.data[np.nonzero(self.obs_list[1].on_vector.quality)] = 0
+        npred1.data[np.nonzero(self.obs_list[0].on_vector.quality)]=0
+        npred2.data[np.nonzero(self.obs_list[1].on_vector.quality)]=0
 
-        npred_summed = npred1.data + npred2.data
+        npred_summed=npred1.data + npred2.data
 
         assert_allclose(npred_stacked.data, npred_summed)
 
@@ -83,11 +141,11 @@ class TestSpectrumObservationStacker:
 @requires_data('gammapy-extra')
 class TestSpectrumObservationList:
     def setup(self):
-        self.obs_list = SpectrumObservationList.read(
+        self.obs_list=SpectrumObservationList.read(
             '$GAMMAPY_EXTRA/datasets/hess-crab4_pha')
 
     def test_stack_method(self):
-        stacked_obs = self.obs_list.stack()
+        stacked_obs=self.obs_list.stack()
         assert 'Observation summary report' in str(stacked_obs)
         assert stacked_obs.obs_id == [23523, 23592]
         assert_quantity_allclose(stacked_obs.aeff.data[10], 86443352.23037884 * u.cm ** 2)
@@ -95,12 +153,11 @@ class TestSpectrumObservationList:
 
     def test_write(self, tmpdir):
         self.obs_list.write(outdir=str(tmpdir), pha_typeII=False)
-        written_files = make_path(tmpdir).glob('*')
+        written_files=make_path(tmpdir).glob('*')
         assert len(list(written_files)) == len(self.obs_list) * 4
 
-        outdir = tmpdir / 'pha_typeII'
+        outdir=tmpdir / 'pha_typeII'
         self.obs_list.write(outdir=str(outdir), pha_typeII=True)
 
-        test_list = SpectrumObservationList.read(outdir, pha_typeII=True)
+        test_list=SpectrumObservationList.read(outdir, pha_typeII=True)
         assert str(test_list[0].total_stats) == str(self.obs_list[0].total_stats)
-

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -40,14 +40,14 @@ class TestSpectrumSimulation:
                                       livetime=4 * u.h)
 
     def test_without_background(self):
-        self.sim.simulate_obs(seed=23)
+        self.sim.simulate_obs(seed=23, obs_id=23)
         assert self.sim.obs.on_vector.total_counts == 156 * u.ct
         # print(np.sum(self.sim.npred_source.data.value))
 
     def test_with_background(self):
         self.sim.background_model = self.background_model
         self.sim.alpha = self.alpha
-        self.sim.simulate_obs(seed=23)
+        self.sim.simulate_obs(seed=23, obs_id=23)
         assert self.sim.obs.on_vector.total_counts == 525 * u.ct
         assert self.sim.obs.off_vector.total_counts == 1096 * u.ct
 
@@ -63,7 +63,7 @@ class TestSpectrumSimulation:
 
     def test_without_edisp(self):
         self.sim.edisp=None
-        self.sim.simulate_obs(seed=23)
+        self.sim.simulate_obs(seed=23, obs_id=23)
         assert self.sim.obs.on_vector.total_counts == 160 * u.ct
         # The test value is taken from the test with edisp
         assert_allclose(np.sum(self.sim.npred_source.data.value),


### PR DESCRIPTION
This PR

* Parametrized the test for ``SpectrumObservation`` to make sure all methods work also if no background spectrum was given
* Modifies ``SpectrumSimulation.simulate_obs`` to require an observation to be set