### PR TITLE
Add flux point class

### DIFF
--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -18,7 +18,7 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.coordinates import Angle
 from ..extern.pathlib import Path
-from ..spectrum import DifferentialFluxPoints, SpectrumFitResult
+from ..spectrum import FluxPoints, SpectrumFitResult
 from ..spectrum.models import PowerLaw, ExponentialCutoffPowerLaw
 from .core import SourceCatalog, SourceCatalogObject
 from .gammacat import SourceCatalogGammaCat, GammaCatNotFoundError
@@ -314,13 +314,13 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         ss += 'Number of flux points: {}\n'.format(d['N_Flux_Points'])
         ss += 'Flux points table: \n\n\t'
 
-        flux_points = self.flux_points['ENERGY', 'DIFF_FLUX', 'DIFF_FLUX_ERR_HI',
-                                       'DIFF_FLUX_ERR_LO'][:int(d['N_Flux_Points'])]
+        flux_points = self.flux_points.table.copy()
+        flux_points = flux_points[['e_ref', 'dnde', 'dnde_errn', 'dnde_errp']]
+        flux_points['e_ref'].format = '.3f'
 
-        flux_points['ENERGY'].format = '.3f'
 
-        flux_unit = Unit('1E-12 cm^-2 s^-1 TeV^-1')
-        for _ in ['DIFF_FLUX', 'DIFF_FLUX_ERR_HI', 'DIFF_FLUX_ERR_LO']:
+        flux_unit = Unit('1E-12 ph cm-2 s-1 TeV-1')
+        for _ in ['dnde', 'dnde_errp', 'dnde_errn']:
             flux_points[_] = flux_points[_].to(flux_unit)
             flux_points[_].format = '.3f'
             flux_points[_].unit = flux_unit
@@ -411,18 +411,19 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
     @property
     def flux_points(self):
-        """Flux points (`~gammapy.spectrum.DifferentialFluxPoints`)
+        """Flux points (`~gammapy.spectrum.FluxPoints`)
         """
-        energy = Quantity(self.data['Flux_Points_Energy'], 'TeV')
-        diff_flux = Quantity(self.data['Flux_Points_Flux'], 's^-1 cm^-2 TeV^-1')
-        energy_err_hi = Quantity(self.data['Flux_Points_Energy_Err_Hi'], 'TeV')
-        energy_err_lo = Quantity(self.data['Flux_Points_Energy_Err_Lo'], 'TeV')
-        diff_flux_err_hi = Quantity(self.data['Flux_Points_Flux_Err_Hi'], 's^-1 cm^-2 TeV^-1')
-        diff_flux_err_lo = Quantity(self.data['Flux_Points_Flux_Err_Lo'], 's^-1 cm^-2 TeV^-1')
-        return DifferentialFluxPoints.from_arrays(
-            energy, diff_flux, energy_err_hi,
-            energy_err_lo, diff_flux_err_hi, diff_flux_err_lo,
-        )
+        table = Table()
+        table.meta['SED_TYPE'] = 'dnde'
+        mask = ~np.isnan(self.data['Flux_Points_Energy'])
+        e_ref = Quantity(self.data['Flux_Points_Energy'][mask], 'TeV')
+        table['e_ref'] = e_ref
+        table['e_min'] = e_ref - Quantity(self.data['Flux_Points_Energy_Err_Lo'][mask], 'TeV')
+        table['e_max'] = e_ref + Quantity(self.data['Flux_Points_Energy_Err_Hi'][mask], 'TeV')
+        table['dnde'] = Quantity(self.data['Flux_Points_Flux'][mask], 'ph s-1 cm-2 TeV-1')
+        table['dnde_errp'] = Quantity(self.data['Flux_Points_Flux_Err_Hi'][mask], 'ph s-1 cm-2 TeV-1')
+        table['dnde_errn'] = Quantity(self.data['Flux_Points_Flux_Err_Lo'][mask], 'ph s-1 cm-2 TeV-1')
+        return FluxPoints(table)
 
 
 class SourceCatalogHGPS(SourceCatalog):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -75,8 +75,7 @@ class FluxPoints(object):
     @property
     def sed_type(self):
         """
-        Flux points SED type.
-
+        Flux points sed type.
 
         Returns
         -------
@@ -315,9 +314,6 @@ class FluxPoints(object):
         if 'SED_TYPE' not in table.meta.keys():
             sed_type = cls._guess_sed_type(table)
             table.meta['SED_TYPE'] = sed_type
-
-        if 'UL_CONF' not in table.meta.keys():
-            table.meta['UL_CONF'] = 0.95
 
         return cls(table=table)
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -54,9 +54,9 @@ class FluxPoints(object):
     table : `~astropy.table.Table`
         Input data table, with the following minimal required columns:
 
-        * Format 'dnde': 'dnde' and 'e_ref'
-        * Format 'flux': 'flux' and 'e_ref'
-        * Format 'elfux': 'eflux' and 'e_ref'
+        * Format `'dnde'`: `'dnde'` and `'e_ref'`
+        * Format `'flux'`: `'flux'` and `'e_ref'`
+        * Format `'eflux'`: `'eflux'` and `'e_ref'`
 
     Examples
     --------

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -126,7 +126,7 @@ class FluxPoints(object):
         except IndexError:
             return u.Unit('TeV')
 
-    def plot(self, ax, sed_type=None, energy_unit='TeV', y_unit=None,
+    def plot(self, ax=None, sed_type=None, energy_unit='TeV', y_unit=None,
              energy_power=0, **kwargs):
         """
         Plot flux points
@@ -152,6 +152,9 @@ class FluxPoints(object):
             Axis object
         """
         import matplotlib.pyplot as plt
+
+        if ax is None:
+            ax = plt.gca()
 
         sed_type = sed_type or self.sed_type
         y_unit = y_unit or DEFAULT_UNIT[sed_type]
@@ -217,7 +220,7 @@ class FluxPoints(object):
         try:
             e_min = self.table['e_min'].quantity
             e_max = self.table['e_max'].quantity
-            e_ref = np.sqrt(e_min * e_max)
+            e_ref = self.e_ref
             x_err = ((e_ref - e_min), (e_max - e_ref))
         except KeyError:
             x_err = None
@@ -295,14 +298,6 @@ class FluxPoints(object):
         kwargs : dict
             Keyword arguments passed to `~astropy.table.Table.read`.
 
-        Examples
-        --------
-
-        >>> from gammapy.spectrum import FluxPoints
-        >>> filename = '$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/flux_points.fits'
-        >>> flux_points = FluxPoints.read(filename)
-        >>> flux_points.show()
-
         """
         filename = make_path(filename)
         try:
@@ -328,6 +323,7 @@ class FluxPoints(object):
         kwargs : dict
             Keyword arguments passed to `~astropy.table.Table.write`.
         """
+        filename = make_path(filename)
         try:
             self.table.write(str(filename), **kwargs)
         except IORegistryError:
@@ -367,10 +363,7 @@ class FluxPoints(object):
         e_min : `~astropy.units.Quantity`
             Lower bound of energy bin.
         """
-        try:
-            return self.table['e_min'].quantity
-        except KeyError:
-            raise NotImplementedError
+        return self.table['e_min'].quantity
 
     # TODO: handle with Energy or EnergyBounds classes?
     @property
@@ -385,11 +378,7 @@ class FluxPoints(object):
         e_max : `~astropy.units.Quantity`
             Upper bound of energy bin.
         """
-        try:
-            return self.table['e_max'].quantity
-        except KeyError:
-            raise NotImplementedError
-
+        return self.table['e_max'].quantity
 
 
 class DifferentialFluxPoints(Table):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -332,7 +332,11 @@ class FluxPoints(object):
         kwargs : dict
             Keyword arguments passed to `~astropy.table.Table.write`.
         """
-        self.table.write(filename, **kwargs)
+        try:
+            self.table.write(str(filename), **kwargs)
+        except IORegistryError:
+            kwargs.setdefault('format', 'ascii.ecsv')
+            self.table.write(str(filename), **kwargs)
 
     # TODO: handle with Energy or EnergyBounds classes?
     @property

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -351,9 +351,11 @@ class TestFluxPoints:
     def test_write_fits(self, tmpdir, flux_points):
         filename = tmpdir / 'flux_points.fits'
         flux_points.write(filename)
-        pass
+        actual = FluxPoints.read(filename)
+        assert str(flux_points) == str(actual)
 
     def test_write_ecsv(self, tmpdir, flux_points):
         filename = tmpdir / 'flux_points.ecsv'
         flux_points.write(filename)
-        assert True
+        actual = FluxPoints.read(filename)
+        assert str(flux_points) == str(actual)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -310,7 +310,7 @@ def flux_points(request):
     path = '$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/' + request.param
     return FluxPoints.read(path)
 
-
+@requires_dependency('yaml')
 @requires_data('gammapy-extra')
 class TestFluxPoints:
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -13,7 +13,7 @@ from ...utils.testing import requires_dependency, requires_data
 from ..flux_point import (_x_lafferty, _integrate, _ydiff_excess_equals_expected,
                           compute_differential_flux_points,
                           _energy_lafferty_power_law, DifferentialFluxPoints,
-                          IntegralFluxPoints, FluxPointEstimator)
+                          IntegralFluxPoints, FluxPointEstimator, FluxPoints)
 from ..flux_point import SEDLikelihoodProfile
 from ...spectrum.powerlaw import power_law_evaluate, power_law_integral_flux
 
@@ -297,3 +297,30 @@ class TestSEDLikelihoodProfile:
     @requires_dependency('matplotlib')
     def test_plot(self):
         ax = self.sed.plot()
+
+
+FILENAMES = [#'1es0229_hess_spectrum.ecsv',
+             #'1es0229_hess_spectrum.fits',
+             'diff_flux_points.ecsv',
+             'diff_flux_points.fits',
+             'flux_points.ecsv',
+             'flux_points.fits']
+
+@pytest.fixture(params=FILENAMES)
+def flux_points(request):
+    path = '$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/' + request.param
+    return FluxPoints.read(path)
+
+@requires_data('gammapy-extra')
+class TestFluxPoints:
+    @requires_dependency('matplotlib')
+    def test_plot(self, flux_points):
+        import matplotlib.pyplot as plt
+        ax = plt.gca()
+        flux_points.plot(ax=ax)
+
+    def test_to_sed_type(self):
+        pass
+
+    def test_table(self):
+        pass


### PR DESCRIPTION
This PR adds a prototype for the `FluxPoints` class, that implements the data specification defined by
http://gamma-astro-data-formats.readthedocs.io/en/latest/results/flux_points/index.html#flux-points

So far it mainly handles validation of the input tables and plotting of flux points with errors and upper limits. I'll make a second PR to adapt `gammapy.catalog` to use this class.

@cdeil @joleroi @woodmd 