### PR TITLE
Improvments to Feldman Cousins code

### DIFF
--- a/docs/stats/feldman_cousins.rst
+++ b/docs/stats/feldman_cousins.rst
@@ -105,7 +105,7 @@ background and no true signal. It can be calculated using `~gammapy.stats.fc_fin
 
 .. code-block:: python
 
-   >>> gstats.fc_average_upper_limit(x_bins[0:14], matrix, UpperLimitNum, mu_bins)
+   >>> gstats.fc_find_average_upper_limit(x_bins, matrix, UpperLimitNum, mu_bins)
    4.41
 
 General Case

--- a/gammapy/stats/feldman_cousins.py
+++ b/gammapy/stats/feldman_cousins.py
@@ -35,7 +35,7 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
         Width of the Gaussian
     x_bins : array-like
         Bins in x
-    alpha : double
+    alpha : float
         Desired confidence level
 
     Returns
@@ -333,7 +333,7 @@ def fc_find_limit(x_value, x_values, y_values):
 
     Parameters
     ----------
-    x_value : double
+    x_value : float
         The measured x value for which the upper limit is wanted.
     x_values : array-like
         The x coordinates of the confidence belt.
@@ -342,7 +342,7 @@ def fc_find_limit(x_value, x_values, y_values):
 
     Returns
     -------
-    limit : double
+    limit : float
         The Feldman Cousins limit
     """
 
@@ -381,13 +381,13 @@ def fc_find_average_upper_limit(x_bins, matrix, upper_limit, mu_bins,
         Feldman Cousins upper limit x-coordinates
     mu_bins : array-like
         The bins used in mue direction.
-    prob_limit : double
+    prob_limit : float
         Probability value at which x values are no longer considered for the
         average limit.
 
     Returns
     -------
-    average_limit : double
+    average_limit : float
         Average upper limit
     """
 

--- a/gammapy/stats/feldman_cousins.py
+++ b/gammapy/stats/feldman_cousins.py
@@ -401,8 +401,8 @@ def fc_find_average_upper_limit(x_bins, matrix, upper_limit, mu_bins,
         try:
             limit = fc_find_limit(x_bins[i], upper_limit, mu_bins)
         except:
-            print("Warning: Calculation of average limit incomplete!")
-            print("Add more bins in mue direction or decrease prob_limit.")
+            log.warning("Warning: Calculation of average limit incomplete!")
+            log.warning("Add more bins in mu direction or decrease prob_limit.")
             return avergage_limit
         avergage_limit += matrix[0][i] * limit
 

--- a/gammapy/stats/feldman_cousins.py
+++ b/gammapy/stats/feldman_cousins.py
@@ -363,7 +363,8 @@ def fc_find_limit(x_value, x_values, y_values):
             return y_values[i + 1]
 
 
-def fc_find_average_upper_limit(x_bins, matrix, upper_limit, mu_bins):
+def fc_find_average_upper_limit(x_bins, matrix, upper_limit, mu_bins,
+                                prob_limit = 1E-5):
     r"""
     Function to calculate the average upper limit for a confidence belt
 
@@ -380,6 +381,9 @@ def fc_find_average_upper_limit(x_bins, matrix, upper_limit, mu_bins):
         Feldman Cousins upper limit x-coordinates
     mu_bins : array-like
         The bins used in mue direction.
+    prob_limit : double
+        Probability value at which x values are no longer considered for the
+        average limit.
 
     Returns
     -------
@@ -391,7 +395,15 @@ def fc_find_average_upper_limit(x_bins, matrix, upper_limit, mu_bins):
     number_points = len(x_bins)
 
     for i in range(number_points):
-        limit = fc_find_limit(x_bins[i], upper_limit, mu_bins)
+        # Bins with very low probability will not contribute to average limit
+        if matrix[0][i] < prob_limit:
+            continue
+        try:
+            limit = fc_find_limit(x_bins[i], upper_limit, mu_bins)
+        except:
+            print("Warning: Calculation of average limit incomplete!")
+            print("Add more bins in mue direction or decrease prob_limit.")
+            return avergage_limit
         avergage_limit += matrix[0][i] * limit
 
     return avergage_limit

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -105,7 +105,7 @@ def test_numerical_confidence_interval_pdfs():
     # Calculate the average upper limit. The upper limit calculated here is
     # only defined for a small x range, so limit the x bins here so the
     # calculation of the average limit is meaningful.
-    average_upper_limit = fc_find_average_upper_limit(x_bins[0:14], matrix,
+    average_upper_limit = fc_find_average_upper_limit(x_bins, matrix,
                                                       upper_limit_num, mu_bins)
 
     # Values are taken from Table XII in the Feldman and Cousins paper.


### PR DESCRIPTION
In the calculation of average upper limit, the code now skip bins with low probability. This makes this code more robust and the user does not have to find a good range of x-values. The value for low probability is a new optional option of the fc_find_average_upper_limit. Add "try and except" for calculation of average upper limit and give user useful instructions on how to fix the problem.

Fixed an error in the documentation and removed the now unnecessary  selection of x-bins.