### PR TITLE
Add some classes to store point-like CTA performance for convenience

### DIFF
--- a/gammapy/scripts/__init__.py
+++ b/gammapy/scripts/__init__.py
@@ -30,4 +30,4 @@ from .detect_iterative import *
 from .catalog_browser import *
 # from .catalog_query import *
 
-from .cta_irf import CTAIrf
+from .cta_irf import *

--- a/gammapy/scripts/cta_irf.py
+++ b/gammapy/scripts/cta_irf.py
@@ -1,14 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from astropy.io import fits
+from astropy.table import Table
 from ..utils.scripts import make_path
-from ..irf import EffectiveAreaTable2D
+from ..utils.nddata import NDDataArray, BinnedDataAxis
+from ..irf import EffectiveAreaTable2D, EffectiveAreaTable
 from ..background import FOVCube
-from ..irf import EnergyDispersion2D
+from ..irf import EnergyDispersion2D, EnergyDispersion
 from ..irf import EnergyDependentMultiGaussPSF
+
 
 __all__ = [
     'CTAIrf',
+    'BgRateTable',
+    'Psf68Table',
+    'CTAPerf'
 ]
 
 
@@ -72,13 +79,13 @@ class CTAIrf(object):
         bkg = FOVCube.from_fits_table(table, scheme='bg_cube')
 
         # Dealing energy dispersion matrix
-        # table_hdu_disp = get_hdu(filename + '[ENERGY DISPERSION]')
-        # edisp = EnergyDispersion2D.from_fits(table_hdu_disp)
+        # Fix offset values a la gammapy (theta_lo=theta_hi)
         edisp = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
 
         # Dealing with psf and fix values to get a single gaussian component
         # by setting the amplitudes and the sigmas of the last two components
         # to 0 and 1, respectively
+        # Fix offset values a la gammapy (theta_lo=theta_hi)
         table_hdu_psf = fits.open(filename)['POINT SPREAD FUNCTION']
 
         table_hdu_psf.data[0]['AMPL_2'] = 0
@@ -95,3 +102,219 @@ class CTAIrf(object):
             edisp=edisp,
             psf=psf,
         )
+
+
+class BgRateTable(NDDataArray):
+    """Background rate Table
+
+    The IRF format should be compliant with the one discussed
+    at http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/.
+    Work will be done to fix this.
+
+    Parameters
+    -----------
+    energy : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
+        Bin edges of energy axis
+    data : `~astropy.units.Quantity`
+        Background rate
+    """
+    energy = BinnedDataAxis(interpolation_mode='log')
+    """Energy Axis"""
+    axis_names = ['energy']
+
+    @classmethod
+    def from_table(cls, table):
+        """Background rate reader"""
+        energy_col = 'ENERG'
+        data_col = 'BGD'
+
+        energy_lo = table['{}_LO'.format(energy_col)].quantity
+        energy_hi = table['{}_HI'.format(energy_col)].quantity
+        energy = np.append(energy_lo.value,
+                           energy_hi[-1].value) * energy_lo.unit
+        data = table['{}'.format(data_col)].quantity
+        return cls(energy=energy, data=data)
+
+    def plot(self, ax=None, energy=None, **kwargs):
+        """Plot background rate
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        energy : `~astropy.units.Quantity`
+            Energy nodes
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`
+            Axis
+
+        """
+        import matplotlib.pyplot as plt
+        ax = plt.gca() if ax is None else ax
+
+        if energy is None:
+            energy = self.energy.nodes
+        values = self.evaluate(energy=energy)
+        xerr = (energy.value - self.energy.data[:-1].value,
+                self.energy.data[1:].value - energy.value)
+        ax.errorbar(energy.value, values.value, xerr=xerr, fmt='o', **kwargs)
+        ax.set_xscale('log')
+        ax.set_yscale('log')
+        ax.set_xlabel('Energy [{}]'.format(self.energy.unit))
+        ax.set_ylabel('Background rate [{}]'.format(self.data.unit))
+
+        return ax
+
+
+class Psf68Table(NDDataArray):
+    """Background rate Table
+
+    The IRF format should be compliant with the one discussed
+    at http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/.
+    Work will be done to fix this.
+
+    Parameters
+    -----------
+    energy : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
+        Bin edges of energy axis
+    data : `~astropy.units.Quantity`
+        Background rate
+    """
+    energy = BinnedDataAxis(interpolation_mode='log')
+    """Energy Axis"""
+    axis_names = ['energy']
+
+    @classmethod
+    def from_table(cls, table):
+        """PSF reader"""
+        energy_col = 'ENERG'
+        data_col = 'PSF68'
+
+        energy_lo = table['{}_LO'.format(energy_col)].quantity
+        energy_hi = table['{}_HI'.format(energy_col)].quantity
+        energy = np.append(
+            energy_lo.value, energy_hi[-1].value) * energy_lo.unit
+        data = table['{}'.format(data_col)].quantity
+        return cls(energy=energy, data=data)
+
+    def plot(self, ax=None, energy=None, **kwargs):
+        """Plot point spread function
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        energy : `~astropy.units.Quantity`
+            Energy nodes
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`
+            Axis
+
+        """
+        import matplotlib.pyplot as plt
+        ax = plt.gca() if ax is None else ax
+
+        if energy is None:
+            energy = self.energy.nodes
+        values = self.evaluate(energy=energy)
+        xerr = (energy.value - self.energy.data[:-1].value,
+                self.energy.data[1:].value - energy.value)
+        ax.errorbar(energy.value, values.value, xerr=xerr, fmt='o', **kwargs)
+        ax.set_xscale('log')
+        ax.set_xlabel('Energy [{}]'.format(self.energy.unit))
+        ax.set_ylabel(
+            'Angular resolution 68 % containment [{}]'.format(self.data.unit)
+        )
+
+        return ax
+
+
+class CTAPerf(object):
+    """CTA instrument response function container.
+
+    Class handling CTA performance.
+
+    For now we use the production 2 of the CTA IRF
+    (https://portal.cta-observatory.org/Pages/CTA-Performance.aspx)
+
+    The IRF format should be compliant with the one discussed
+    at http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/.
+    Work will be done to handle better the PSF and the background rate.
+
+    This class is similar to `~gammapy.data.DataStoreObservation`,
+    but only contains performance (no event data or livetime info).
+    TODO: maybe re-factor code somehow to avoid code duplication.
+
+    Parameters
+    ----------
+    aeff : `~gammapy.irf.EffectiveAreaTable`
+        Effective area
+    edisp : `~gammapy.irf.EnergyDispersion`
+        Energy dispersion
+    psf : `~gammapy.scripts.Psf68Table`
+        Point spread function
+    bkg : `~gammapy.scripts.BgRateTable`
+        Background rate
+    """
+
+    def __init__(self, aeff=None, edisp=None, psf=None, bkg=None):
+        self.aeff = aeff
+        self.edisp = edisp
+        self.psf = psf
+        self.bkg = bkg
+
+    @classmethod
+    def read(cls, filename):
+        """
+        Read from a FITS file.
+
+        Parameters
+        ----------
+        filename : `str`
+            File containing the IRFs
+        """
+        filename = str(make_path(filename))
+
+        aeff = EffectiveAreaTable.read(filename, hdu='SPECRESP')
+
+        # Get EnergyDispersion from HDUList
+        hdu_list = fits.open(filename)
+        edisp = EnergyDispersion.from_hdulist(hdu_list=hdu_list)
+
+        # Do not work, can't understand why, see BgRateTable and Psf68Table class
+        # bkg = BgRateTable.read(filename, hdu='BACKGROUND')
+        bkg = BgRateTable.from_hdulist(
+            fits.HDUList([hdu_list[0], hdu_list['BACKGROUND']])
+        )
+
+        psf = Psf68Table.from_hdulist(
+            fits.HDUList([hdu_list[0], hdu_list['POINT SPREAD FUNCTION']])
+        )
+
+        return cls(
+            aeff=aeff,
+            bkg=bkg,
+            edisp=edisp,
+            psf=psf,
+        )
+
+    def peek(self, figsize=(10, 10)):
+        """Quick-look summary plots."""
+        import matplotlib.pyplot as plt
+        fig, axes = plt.subplots(nrows=2, ncols=2, figsize=figsize)
+
+        self.bkg.plot(ax=axes[0][0])
+        aeff = self.aeff.plot(ax=axes[0][1])
+        aeff.set_yscale('log')
+
+        self.psf.plot(ax=axes[1][0])
+
+        self.edisp.plot_matrix(ax=axes[1][1])
+
+        plt.tight_layout()
+        plt.show()
+        return fig

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
 from ...utils.testing import requires_data, requires_dependency
-from ...scripts import CTAIrf
+from ...scripts import CTAIrf, CTAPerf
 
 
 @requires_dependency('scipy')
@@ -34,5 +34,16 @@ def test_cta_irf():
     # val = irf.bkg.evaluate(energy=energy, x=offset, y=Quantity(0, 'deg'))
     # assert_quantity_allclose(val, Quantity(247996.974414962, 'm^2'))
 
+
+@requires_dependency('matplotlib')
+@requires_data('gammapy-extra')
+def test_point_like_perf():
+    filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/\
+CTA-Performance-South-20150511/CTA-Performance-South-50h_20150511.fits'
+    cta_perf = CTAPerf.read(filename)
+    cta_perf.peek()
+    
+    
 if __name__ == '__main__':
     test_cta_irf()
+    test_point_like_perf()


### PR DESCRIPTION
Hi @cdeil , 
I added some classes to handle point-like performance for the offical CTA's point-like IRF. I tried to stay as close as possible to the recommandations of https://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/.
I added: 
 - one class to handle the background rate, BgRateTable (following what is done for EffectiveAreaTable)
 - one class to handle the angular resolution, Psf68Table (following what is done for EffectiveAreaTable)
 - one class to store the four response functions, CTAPerf
Thanks