### PR TITLE
Make API of SpectralModel.integral consistent with analytical methods

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -54,7 +54,10 @@ class SpectralModel(object):
 
             F(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}\phi(E)dE
 
-        kwargs are forwared to :func:`~gammapy.spectrum.integrate_spectrum``.
+        kwargs are forwared to :func:`~gammapy.spectrum.integrate_spectrum`.
+        
+        If array input for ``emin`` and ``emax`` is given you have to set
+        ``intervals=True`` if you want the integral in each energy bin.
 
         Parameters
         ----------
@@ -243,7 +246,7 @@ class PowerLaw(SpectralModel):
     def evaluate(energy, index, amplitude, reference):
         return amplitude * np.power((energy / reference), -index)
 
-    def integral(self, emin, emax):
+    def integral(self, emin, emax, **kwargs):
         r"""
         Integrate power law analytically.
 
@@ -262,6 +265,8 @@ class PowerLaw(SpectralModel):
             Upper bound of integration range.
 
         """
+        # kwargs are passed to this function but not used
+        # this is to get a consistent API with SpectralModel.integral()
         pars = self.parameters
 
         val = -1 * pars.index + 1
@@ -275,6 +280,7 @@ class PowerLaw(SpectralModel):
         Compute energy flux in given energy range analytically.
 
         .. math::
+
 
             G(E_{min}, E_{max}) = \int_{E_{min}}^{E_{max}}E \phi(E)dE = \left.
             \phi_0 \frac{E_0^2}{-\Gamma + 2} \left( \frac{E}{E_0} \right)^{-\Gamma + 2}

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -154,13 +154,14 @@ def calculate_predicted_counts(model, aeff, livetime, edisp=None, e_reco=None):
 
     if edisp is not None:
         true_energy = aeff.energy.data.to('TeV')
-        flux = model.integral(emin=true_energy[:-1], emax=true_energy[1:])
+        flux = model.integral(emin=true_energy[:-1], emax=true_energy[1:],
+                              intervals=True)
         # Need to fill nan values in aeff due to matrix multiplication with RMF
         counts = flux * livetime * aeff.evaluate(fill_nan=True)
         counts = counts.to('')
         reco_counts = edisp.apply(counts, e_reco=e_reco)
     else:
-        flux = model.integral(emin=e_reco[:-1], emax=e_reco[1:])
+        flux = model.integral(emin=e_reco[:-1], emax=e_reco[1:], intervals=True)
         reco_counts = flux * livetime * aeff.evaluate(energy=e_reco.log_centers,
                                                       fill_nan=True)
         reco_counts = reco_counts.to('')


### PR DESCRIPTION
As discussed offline with @adonath this PR allows kwargs in ``PowerLaw.integral``.
This needs to be introduced to get a consistent behaviour of the integration method of a spectral model.
before ``PowerLaw.integral`` gave array output on array input and ``SpectralModel.integral`` gave array output on array input **only** if ``intervals=True`` was set.
Bottom line. Now one can write ``AnyModel.integral(intervals=True)`` and get array output; This is important for the spectrum simulation to work.