### PR TITLE
Rename method to_psf_table in the PSF classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,9 +156,9 @@ See the complete `Gammapy 0.5 merged pull requests list on Github <https://githu
 - [#530] Update readthedocs links from .org to .io (Brigitta Sipocz)
 - [#529] Add data_summary method to DataStore (Johannes King)
 - [#527] Add n-dim data base class for gammapy.irf (Johannes King)
-- [#526] Add King PSF evaluate and to_table_psf methods (Léa Jouvin)
+- [#526] Add King PSF evaluate and to_energy_dependent_table_psf methods (Léa Jouvin)
 - [#524] Improve image pipe class (Léa Jouvin)
-- [#523] Add Gauss PSF to_table_psf method (Axel Donath)
+- [#523] Add Gauss PSF to_energy_dependent_table_psf method (Axel Donath)
 - [#521] Fix image pipe class (Léa Jouvin)
 
 .. _gammapy_0p4_release:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,9 +156,9 @@ See the complete `Gammapy 0.5 merged pull requests list on Github <https://githu
 - [#530] Update readthedocs links from .org to .io (Brigitta Sipocz)
 - [#529] Add data_summary method to DataStore (Johannes King)
 - [#527] Add n-dim data base class for gammapy.irf (Johannes King)
-- [#526] Add King PSF evaluate and to_energy_dependent_table_psf methods (Léa Jouvin)
+- [#526] Add King PSF evaluate and to_table_psf methods (Léa Jouvin)
 - [#524] Improve image pipe class (Léa Jouvin)
-- [#523] Add Gauss PSF to_energy_dependent_table_psf method (Axel Donath)
+- [#523] Add Gauss PSF to_table_psf method (Axel Donath)
 - [#521] Fix image pipe class (Léa Jouvin)
 
 .. _gammapy_0p4_release:

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -16,7 +16,7 @@ from ..utils.energy import Energy
 from .obs_table import ObservationTable
 from .hdu_index_table import HDUIndexTable
 from .utils import _earth_location_from_dict
-from ..irf import EnergyDependentTablePSF, IRFStacker
+from ..irf import EnergyDependentTablePSF, IRFStacker, PSF3D
 
 __all__ = [
     'DataStore',
@@ -662,12 +662,16 @@ class DataStoreObservation(object):
 
         offset = position.separation(self.pointing_radec)
         if not energy:
-            energy = self.psf.to_table_psf(theta=offset).energy
+            energy = self.psf.to_energy_dependent_table_psf(theta=offset).energy
         if not theta:
-            theta = self.psf.to_table_psf(theta=offset).offset
+            theta = self.psf.to_energy_dependent_table_psf(theta=offset).offset
 
-        psf_value = self.psf.to_table_psf(theta=offset, offset=theta)\
-            .evaluate(energy)
+        if (type(self.psf) == PSF3D):
+            psf_value = self.psf.to_energy_dependent_table_psf(theta=offset) \
+                .evaluate(energy)
+        else:
+            psf_value = self.psf.to_energy_dependent_table_psf(theta=offset, offset=theta) \
+                .evaluate(energy)
         arf = self.aeff.evaluate(offset=offset, energy=energy)
         exposure = arf * self.observation_live_time_duration
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -666,7 +666,8 @@ class DataStoreObservation(object):
         if not theta:
             theta = self.psf.to_energy_dependent_table_psf(theta=offset).offset
 
-        if (type(self.psf) == PSF3D):
+        #TODO: make axis names consistent
+        if isinstance(self.psf, PSF3D):
             psf_value = self.psf.to_energy_dependent_table_psf(theta=offset) \
                 .evaluate(energy)
         else:

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -666,7 +666,7 @@ class DataStoreObservation(object):
         if not theta:
             theta = self.psf.to_energy_dependent_table_psf(theta=offset).offset
 
-        #TODO: make axis names consistent
+        # TODO: make axis names consistent
         if isinstance(self.psf, PSF3D):
             psf_value = self.psf.to_energy_dependent_table_psf(theta=offset) \
                 .evaluate(energy)

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -21,7 +21,7 @@ class EnergyDependentMultiGaussPSF(object):
     """
     Triple Gauss analytical PSF depending on energy and theta.
 
-    To evaluate the PSF call the ``to_table_psf`` or ``psf_at_energy_and_theta`` methods.
+    To evaluate the PSF call the ``to_energy_dependent_table_psf`` or ``psf_at_energy_and_theta`` methods.
 
     Parameters
     ----------
@@ -362,7 +362,7 @@ class EnergyDependentMultiGaussPSF(object):
                            "".format(100 * fraction, theta, energy, radius))
         return ss
 
-    def to_table_psf(self, theta=None, offset=None, exposure=None):
+    def to_energy_dependent_table_psf(self, theta=None, offset=None, exposure=None):
         """
         Convert triple Gaussian PSF ot table PSF.
 

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -211,7 +211,7 @@ class PSFKing(object):
         param["gamma"] = gamma
         return param
 
-    def to_table_psf(self, theta=None, offset=None, exposure=None):
+    def to_energy_dependent_table_psf(self, theta=None, offset=None, exposure=None):
         """
         Convert king PSF in table PSF.
 

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -65,7 +65,7 @@ class FitsProductionTester:
     def test_psf(self):
         psf = self.obs.load(hdu_type='psf', hdu_class=self.ref_dict['psf_type'])
         print(psf)
-        table_psf = psf.to_table_psf(offset=self.ref_offset, theta=self.ref_theta)
+        table_psf = psf.to_energy_dependent_table_psf(offset=self.ref_offset, theta=self.ref_theta)
         actual = table_psf.evaluate(energy=self.ref_energy)
         desired = self.ref_dict['psf_ref']
         assert_quantity_allclose(actual[0][4], desired)

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -53,7 +53,7 @@ def test_to_table_psf(energy):
     psf = EnergyDependentMultiGaussPSF.read(filename, hdu='PSF_2D_GAUSS')
     theta = Angle(0, 'deg')
 
-    table_psf = psf.to_table_psf(theta)
+    table_psf = psf.to_energy_dependent_table_psf(theta)
     interpol_param = dict(method='nearest', bounds_error=False)
     table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
     psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -32,8 +32,8 @@ def test_psf_king_evaluate(psf_king):
 def test_psf_king_to_table(psf_king):
     theta1 = Angle(0, "deg")
     theta2 = Angle(1, "deg")
-    psf_king_table_off1 = psf_king.to_table_psf(theta=theta1)
-    psf_king_table_off2 = psf_king.to_table_psf(theta=theta2)
+    psf_king_table_off1 = psf_king.to_energy_dependent_table_psf(theta=theta1)
+    psf_king_table_off2 = psf_king.to_energy_dependent_table_psf(theta=theta2)
     offset = Angle(1, "deg")
     # energy = Quantity(1, "TeV") match with bin number 8
     # offset equal 1 degre match with the bin 200 in the psf_table

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -25,7 +25,7 @@ def test_cta_irf():
 
     # TODO: clean up these PSF classes, e.g. to return quantities.
     # Also: add an `evaluate(energy, offset, theta)` to the loaded PSF class.
-    # psf = irf.psf.to_table_psf(offset=offset)
+    # psf = irf.psf.to_energy_dependent_table_psf(offset=offset)
     psf = irf.psf.psf_at_energy_and_theta(energy=energy, theta=offset)
     val = psf(Quantity(0.1, 'deg'))
     assert_quantity_allclose(val, 5.423486126591272)

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -211,7 +211,7 @@ class SpectrumExtraction(object):
             if self.containment_correction:
                 # First need psf
                 angles = np.linspace(0., 1.5, 150) * u.deg
-                psf = obs.psf.to_table_psf(offset, angles)
+                psf = obs.psf.to_energy_dependent_table_psf(offset, angles)
 
                 center_energies = arf.energy.nodes
                 for index, energy in enumerate(center_energies):


### PR DESCRIPTION
@cdeil 
This method rename the method ```to_table_psf```in to ```to_energy_dependent_table_psf```since this is how it is called in the ```PSF3D class```. We are returning a ```EnergyDependentTablePSF```so I think it's better to call it like that.

Moreover in my class ```ObservationList```in the Datastore, I compute the mean psf fir a set ob observation so I don't want to change the name of the method depending if it is a table psf or 3d gauss or king profile.

Cheers,

