### PR TITLE
Add sky cube computation for IACT data

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -6,3 +6,4 @@ from .core import *
 from .images import *
 from .exposure import *
 from .utils import *
+from .cube_pipe import *

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -1,0 +1,279 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+import logging
+import numpy as np
+from astropy.units import Quantity
+from astropy.table import Table
+from ..utils.energy import Energy
+from astropy.convolution import Tophat2DKernel
+from ..stats import significance
+from ..background import fill_acceptance_image
+from ..cube import SkyCube
+from .exposure import exposure_cube
+
+__all__ = ['SingleObsCubeMaker', 'StackedObsCubeMaker']
+
+log = logging.getLogger(__name__)
+
+
+class SingleObsCubeMaker(object):
+    """Compute '~gammapy.cube.SkyCube' images for one observation.
+
+    The computed images are stored in a ``images`` attribute of
+    type `~gammapy.image.SkyImageList` with the following keys:
+
+    * ``counts`` : Counts
+    * ``bkg`` : Background model
+    * ``exposure`` : Exposure
+    * ``excess`` : Excess
+    * ``significance`` : Significance
+
+    Parameters
+    ----------
+    obs : `~gammapy.data.DataStoreObservation`
+        Observation data
+    empty_cube_images : `~gammapy.cube.SkyCube`
+        Reference Cube for images in reco energy
+    empty_exposure_cube : `~gammapy.cube.SkyCube`
+        Reference Cube for exposure in true energy
+    offset_band : `astropy.coordinates.Angle`
+        Offset band selection
+    exclusion_mask : `~gammapy.image.SkyCube`
+        Cube of `~gammapy.image.SkyMask`
+    save_bkg_scale: bool
+        True if you want to save the normalisation of the bkg computed outside the exlusion region in a Table
+    """
+
+    def __init__(self, obs, empty_cube_images, empty_exposure_cube,
+                 offset_band, exclusion_mask=None, save_bkg_scale=True):
+        self.energy_reco = empty_cube_images.energies()
+        self.offset_band = offset_band
+        self.counts_cube = SkyCube.empty_like(empty_cube_images)
+        self.bkg_cube = SkyCube.empty_like(empty_cube_images)
+        self.significance_cube = SkyCube.empty_like(empty_cube_images)
+        self.excess_cube = SkyCube.empty_like(empty_cube_images)
+        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube)
+
+        self.obs_id = obs.obs_id
+        events = obs.events
+        self.events = events.select_offset(self.offset_band)
+
+        self.header = empty_cube_images.sky_image_ref.to_image_hdu().header
+        self.cube_exclusion_mask=exclusion_mask
+        self.aeff = obs.aeff
+        self.edisp = obs.edisp
+        self.psf = obs.psf
+        self.bkg = obs.bkg
+        self.obs_center = obs.pointing_radec
+        self.livetime = obs.observation_live_time_duration
+        self.save_bkg_scale = save_bkg_scale
+        if self.save_bkg_scale:
+            self.table_bkg_scale = Table(names=["OBS_ID", "bkg_scale"])
+
+    def make_counts_cube(self):
+        """Fill the counts image for the events of one observation."""
+        self.counts_cube.fill_events(self.events)
+
+    def make_bkg_cube(self, bkg_norm=True):
+        """
+        Make the background image for one observation from a bkg model.
+
+        Parameters
+        ----------
+        bkg_norm : bool
+            If true, apply the scaling factor from the number of counts
+            outside the exclusion region to the bkg image
+        """
+        for i_E in range(len(self.energy_reco) - 1):
+            energy_band = Energy(
+                [self.energy_reco[i_E].value, self.energy_reco[i_E + 1].value],
+                self.energy_reco.unit)
+            table = self.bkg.acceptance_curve_in_energy_band(
+                energy_band=energy_band)
+            center = self.obs_center.galactic
+            bkg_hdu = fill_acceptance_image(self.header, center,
+                                            table["offset"],
+                                            table["Acceptance"],
+                                            self.offset_band[1])
+            bkg_image = Quantity(bkg_hdu.data, table[
+                "Acceptance"].unit) * self.bkg_cube.sky_image_ref.solid_angle() * self.livetime
+            self.bkg_cube.data[i_E, :, :] = bkg_image.decompose().value
+
+        if bkg_norm:
+            scale = self.background_norm_factor(self.counts_cube,
+                                                self.bkg_cube)
+            self.bkg_cube.data = scale * self.bkg_cube.data
+            if self.save_bkg_scale:
+                self.table_bkg_scale.add_row([self.obs_id, scale])
+
+    def background_norm_factor(self, counts, bkg):
+        """Determine the scaling factor to apply to the background image.
+
+        Compares the events in the counts images and the bkg image outside the exclusion images.
+
+        Parameters
+        ----------
+        counts : `~gammapy.cube.SkyCube`
+            counts images cube
+        bkg : `~gammapy.cube.SkyCube`
+            bkg images cube
+
+        Returns
+        -------
+        scale : float
+            scaling factor between the counts and the bkg images outside the exclusion region.
+        """
+        counts_sum = np.sum(
+            self.counts_cube.data * self.cube_exclusion_mask.data)
+        bkg_sum = np.sum(self.bkg_cube.data * self.cube_exclusion_mask.data)
+        scale = counts_sum / bkg_sum
+
+        return scale
+
+    def make_exposure_cube(self):
+        """
+        Compute the exposure cube
+        """
+        self.exposure_cube = exposure_cube(pointing=self.obs_center,
+                                           livetime=self.livetime,
+                                           aeff2d=self.aeff,
+                                           ref_cube=self.exposure_cube,
+                                           offset_max=self.offset_band[1])
+
+    def make_significance_cube(self, radius):
+        """Make the significance image from the counts and bkg images.
+
+        Parameters
+        ----------
+        radius : float
+            Disk radius in pixels.
+        """
+        disk = Tophat2DKernel(radius)
+        disk.normalize('peak')
+        list_kernel = [disk.array] * (len(self.significance_cube.energies()))
+        counts = self.counts_cube.convolve(list_kernel)
+        bkg = self.bkg_cube.convolve(list_kernel)
+        self.significance_cube.data = significance(counts.data, bkg.data)
+
+    def make_excess_cube(self):
+        """Compute excess between counts and bkg image."""
+        self.excess_cube.data = self.counts_cube - self.bkg_cube
+
+
+class StackedObsCubeMaker(object):
+    """Compute stacked images for many observations.
+
+    The computed images are stored in a ``images`` attribute of
+    type `~gammapy.image.SkyImageList` with the following keys:
+
+    * ``counts`` : Counts
+    * ``bkg`` : Background model
+    * ``exposure`` : Exposure
+    * ``excess`` : Excess
+    * ``significance`` : Significance
+
+    Parameters
+    ----------
+    empty_cube_images : `~gammapy.cube.SkyCube`
+        Reference Cube for images in reco energy
+    empty_exposure_cube : `~gammapy.cube.SkyCube`
+        Reference Cube for exposure in true energy
+    offset_band : `astropy.coordinates.Angle`
+        Offset band selection
+    data_store : `~gammapy.data.DataStore`
+        Data store
+    obs_table : `~astropy.table.Table`
+        Required columns: OBS_ID
+    exclusion_mask : `~gammapy.image.SkyCube`
+        Cube of `~gammapy.image.SkyMask`
+    save_bkg_scale: bool
+        True if you want to save the normalisation of the bkg for each run in a `Table` table_bkg_norm with two columns:
+         "OBS_ID" and "bkg_scale"
+    """
+
+    def __init__(self, empty_cube_images, empty_exposure_cube=None,
+                 offset_band=None,
+                 data_store=None, obs_table=None, exclusion_mask=None,
+                 ncounts_min=0, save_bkg_scale=True):
+
+        self.empty_cube_images = empty_cube_images
+        if not empty_exposure_cube:
+            self.empty_exposure_cube = SkyCube.empty_like(empty_cube_images)
+        else:
+            self.empty_exposure_cube = empty_exposure_cube
+
+        self.counts_cube = SkyCube.empty_like(empty_cube_images)
+        self.bkg_cube = SkyCube.empty_like(empty_cube_images)
+        self.significance_cube = SkyCube.empty_like(empty_cube_images)
+        self.excess_cube = SkyCube.empty_like(empty_cube_images)
+        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube)
+
+        self.data_store = data_store
+        self.obs_table = obs_table
+        self.offset_band = offset_band
+
+        self.header = empty_cube_images.sky_image_ref.to_image_hdu().header
+        self.cube_exclusion_mask = exclusion_mask
+
+        self.save_bkg_scale = save_bkg_scale
+        if self.save_bkg_scale:
+            self.table_bkg_scale = Table(names=["OBS_ID", "bkg_scale"])
+
+    def make_images(self, make_background_image=False, bkg_norm=True, radius=10):
+        """Compute the counts, bkg, exposure, excess and significance images for a set of observation.
+
+        Parameters
+        ----------
+        make_background_image : bool
+            True if you want to compute the background and exposure images
+        bkg_norm : bool
+            If true, apply the scaling factor to the bkg image
+        spectral_index : float
+            Assumed power-law spectral index
+        for_integral_flux : bool
+            True if you want that the total excess / exposure gives the integrated flux
+        radius : float
+            Disk radius in pixels for the significance image
+        """
+
+        for obs_id in self.obs_table['OBS_ID']:
+            obs = self.data_store.obs(obs_id)
+            cube_images = SingleObsCubeMaker(obs=obs,
+                                             empty_cube_images=self.empty_cube_images,
+                                             empty_exposure_cube=self.empty_exposure_cube,
+                                             offset_band=self.offset_band,
+                                             exclusion_mask=self.cube_exclusion_mask,
+                                             save_bkg_scale=self.save_bkg_scale)
+            cube_images.make_counts_cube()
+            self.counts_cube.data += cube_images.counts_cube.data
+            if make_background_image:
+                cube_images.make_bkg_cube(bkg_norm)
+                if self.save_bkg_scale:
+                    self.table_bkg_scale.add_row(
+                        cube_images.table_bkg_scale[0])
+                cube_images.make_exposure_cube()
+                self.bkg_cube.data += cube_images.bkg_cube.data
+                self.exposure_cube.data += cube_images.exposure_cube.data.to("m2 s")
+        if make_background_image:
+            self.make_significance_cube(radius)
+            self.make_excess_cube()
+
+    def make_significance_cube(self, radius):
+        """Make the significance image from the counts and bkg images.
+
+        Parameters
+        ----------
+        radius : float
+            Disk radius in pixels.
+        """
+        disk = Tophat2DKernel(radius)
+        disk.normalize('peak')
+        list_kernel = [disk.array] * (len(self.significance_cube.energies()))
+        counts = self.counts_cube.convolve(list_kernel)
+        bkg = self.bkg_cube.convolve(list_kernel)
+        self.significance_cube.data = significance(counts.data, bkg.data)
+
+    def make_excess_cube(self):
+        """Compute excess between counts and bkg image."""
+        self.excess_cube.data = self.counts_cube.data - self.bkg_cube.data

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 class SingleObsCubeMaker(object):
     """Compute '~gammapy.cube.SkyCube' images for one observation.
 
-    The computed cubes are stored in a `~gammapy.image.SkyCube` with the following name:
+    The computed cubes are stored in a `~gammapy.cube.SkyCube` with the following name:
 
     * ``counts_cube`` : Counts
     * ``bkg_cube`` : Background model
@@ -38,7 +38,7 @@ class SingleObsCubeMaker(object):
         Reference Cube for exposure in true energy
     offset_band : `astropy.coordinates.Angle`
         Offset band selection
-    exclusion_mask : `~gammapy.image.SkyCube`
+    exclusion_mask : `~gammapy.cube.SkyCube`
         Cube of `~gammapy.image.SkyMask`
     save_bkg_scale: bool
         True if you want to save the normalisation of the bkg computed outside the exclusion region in a Table

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -215,7 +215,7 @@ class StackedObsCubeMaker(object):
         if self.save_bkg_scale:
             self.table_bkg_scale = Table(names=["OBS_ID", "bkg_scale"])
 
-    def make_images(self, make_background_image=False, bkg_norm=True, radius=10):
+    def make_cubes(self, make_background_image=False, bkg_norm=True, radius=10):
         """Compute the total counts, bkg, exposure, excess and significance cubes for a set of observation.
 
         Parameters

--- a/gammapy/cube/tests/test_cube_pipe.py
+++ b/gammapy/cube/tests/test_cube_pipe.py
@@ -1,0 +1,112 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.coordinates import SkyCoord, Angle
+from astropy.units import Quantity
+from ...data import DataStore
+from ...utils.testing import requires_dependency, requires_data
+from ...image import SkyMask
+from .. import StackedObsCubeMaker
+from ...background import OffDataBackgroundMaker
+from .. import SkyCube
+from ...utils.energy import Energy
+
+
+def make_empty_cube(image_size, energy, center, data_unit=None):
+    """
+    Parameters
+    ----------
+    image_size:int, Total number of pixel of the 2D map
+    energy: Tuple for the energy axis: (Emin,Emax,nbins)
+    center: SkyCoord of the source
+    unit : str, Data unit.
+    """
+    def_image = dict()
+    def_image["nxpix"] = image_size
+    def_image["nypix"] = image_size
+    def_image["binsz"] = 0.02
+    def_image["xref"] = center.galactic.l.deg
+    def_image["yref"] = center.galactic.b.deg
+    def_image["proj"] = 'TAN'
+    def_image["coordsys"] = 'GAL'
+    def_image["unit"] = data_unit
+    e_min, e_max, nbins = energy
+    empty_cube = SkyCube.empty(emin=e_min.value, emax=e_max.value, enumbins=nbins, eunit=e_min.unit, mode='edges',
+                               **def_image)
+    return empty_cube
+
+
+@requires_dependency('reproject')
+@requires_data('gammapy-extra')
+def test_cube_pipe(tmpdir):
+    tmpdir = str(tmpdir)
+    from subprocess import call
+    outdir = tmpdir
+    outdir2 = outdir + '/background'
+
+    cmd = 'mkdir -p {}'.format(outdir2)
+    print('Executing: {}'.format(cmd))
+    call(cmd, shell=True)
+
+    ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2")
+    ds.copy_obs(ds.obs_table, tmpdir)
+    data_store = DataStore.from_dir(tmpdir)
+
+    bgmaker = OffDataBackgroundMaker(data_store, outdir=outdir2)
+
+    bgmaker.select_observations(selection='all')
+    bgmaker.group_observations()
+    bgmaker.make_model("2D")
+    bgmaker.save_models("2D")
+
+    fn = outdir2 + '/group-def.fits'
+
+    hdu_index_table = bgmaker.make_total_index_table(
+        data_store=data_store,
+        modeltype='2D',
+        out_dir_background_model=outdir2,
+        filename_obs_group_table=fn
+    )
+
+    fn = outdir + '/hdu-index.fits.gz'
+    hdu_index_table.write(fn, overwrite=True)
+
+    center = SkyCoord(83.63, 22.01, unit='deg').galactic
+    offset_band = Angle([0, 2.49], 'deg')
+
+    ref_cube_images = make_empty_cube(image_size=250, energy=[Energy(0.5, "TeV"), Energy(100, "TeV"), 5], center=center)
+    ref_cube_exposure = make_empty_cube(image_size=250, energy=[Energy(0.1, "TeV"), Energy(120, "TeV"), 80],
+                                        center=center, data_unit="m2 s")
+
+    data_store = DataStore.from_dir(tmpdir)
+
+    refheader = ref_cube_images.sky_image_ref.to_image_hdu().header
+    exclusion_mask = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
+    exclusion_mask = exclusion_mask.reproject(reference=refheader)
+
+    # Pb with the load psftable for one of the run that is not implemented yet...
+    data_store.hdu_table.remove_row(14)
+
+    cube_maker = StackedObsCubeMaker(empty_cube_images=ref_cube_images, empty_exposure_cube=ref_cube_exposure,
+                                     offset_band=offset_band, data_store=data_store, obs_table=data_store.obs_table,
+                                     exclusion_mask=exclusion_mask, save_bkg_scale=True)
+    cube_maker.make_images(make_background_image=True, radius=10.)
+
+    assert_allclose(cube_maker.counts_cube.data.sum(), 4898.0, atol=3)
+    assert_allclose(cube_maker.bkg_cube.data.sum(), 4259.818621739171, atol=3)
+    cube_maker.significance_cube.data[np.where(np.isnan(cube_maker.significance_cube.data))] = 0
+    cube_maker.significance_cube.data[np.where(np.isinf(cube_maker.significance_cube.data))] = 0
+    assert_allclose(cube_maker.significance_cube.data.sum(), 57442.86760518042, atol=3)
+    assert_allclose(cube_maker.excess_cube.data.sum(), 638.1813782608283, atol=3)
+    cube_maker.exposure_cube.data[np.where(np.isnan(cube_maker.exposure_cube.data))] = 0
+    assert_quantity_allclose(cube_maker.exposure_cube.data.sum(), Quantity(4891844242766714.0,"m2 s"),
+                             atol=Quantity(3,"m2 s"))
+    assert_allclose(cube_maker.table_bkg_scale[0]["bkg_scale"], 1.2631250488423862)
+
+    assert len(cube_maker.counts_cube.energies()) == 5
+    assert len(cube_maker.bkg_cube.energies()) == 5
+    assert len(cube_maker.significance_cube.energies()) == 5
+    assert len(cube_maker.excess_cube.energies()) == 5
+    assert len(cube_maker.exposure_cube.energies()) == 80


### PR DESCRIPTION
@cdeil @adonath 
Hi,
This PR is for cube analysis with two new class ```StackedObsCubeMaker```and ```SingleObsCubeMaker```. It allow to compute counts, bkg, significance, excess and exposure cube for a set of observations. In addition, you can compute the exposure cube in true energy what you need for the 3D spectral analysis if you want to take into account the energy resolution.

The test called all the methods of these two classe and build a background model from acceptance curve as for the test of image_pipe from the events of the 4 crab runs outside the exclusion region. I made also this kind of Cube analysis for the Crab with HAP-Fr data and a real bkg model base on the AGN runs. Then I apply the spectral 3D analysis taking into account the energy resolution (I will do soon a PR for that) and I give really the same result than for the 1D spectral analysis with pointlike IRF.

Cheers,
Lea