### PR TITLE
Add energy true for 3D spectral analysis

### DIFF
--- a/gammapy/cube/sherpa_.py
+++ b/gammapy/cube/sherpa_.py
@@ -200,7 +200,7 @@ class CombinedModel3D(ArithmeticModel):
 
 class CombinedModel3DInt(ArithmeticModel):
     """
-    Combined spatial and spectral 3D model with the possibility to convolve the spatial model*exposure by the PSF
+    Combined spatial and spectral 3D model with the possibility to convolve the spatial model*exposure by the PSF.
 
     Parameters
     ----------
@@ -266,7 +266,7 @@ class CombinedModel3DInt(ArithmeticModel):
 class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
     """
     Combined spatial and spectral 3D model taking into account the energy resolution
-     with the possibility to convolve the spatial model*exposure by the PSF
+     with the possibility to convolve the spatial model*exposure by the PSF.
 
     Parameters
     ----------

--- a/gammapy/cube/sherpa_.py
+++ b/gammapy/cube/sherpa_.py
@@ -2,12 +2,66 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from ..utils.energy import EnergyBounds
+import sherpa.astro.ui as sau
+from sherpa.astro.ui import erf
+import astropy.wcs as pywcs
 from sherpa.models import ArithmeticModel, Parameter, modelCacher1d
 from sherpa.data import DataND, BaseData
 from sherpa.utils.err import DataErr, NotImplementedErr
 from sherpa.utils import SherpaFloat, NoNewAttributesAfterInit, \
     print_fields, create_expr, calc_total_error, bool_cast, \
     filter_bins, interpolate, linear_interp
+
+"""
+Definition of the model NormGauss2DInt: Integrated 2D gaussian
+"""
+fwhm_to_sigma = 1 / (2 * np.sqrt(2 * np.log(2)))
+fwhm_to_sigma_erf = np.sqrt(2) * fwhm_to_sigma
+
+
+class NormGauss2DInt(ArithmeticModel):
+    """Integrated 2D gaussian for sherpa models
+    """
+    def __init__(self, name='normgauss2dint'):
+        # Gauss source parameters
+        self.wcs = pywcs.WCS()
+        self.coordsys = "galactic"  # default
+        self.binsize = 1.0
+        self.xpos = Parameter(name, 'xpos', 0)  # p[0]
+        self.ypos = Parameter(name, 'ypos', 0)  # p[1]
+        self.ampl = Parameter(name, 'ampl', 1)  # p[2]
+        self.fwhm = Parameter(name, 'fwhm', 1, min=0)  # p[3]
+        self.shape = None
+        self.n_ebins = None
+        ArithmeticModel.__init__(self, name, (self.xpos, self.ypos, self.ampl, self.fwhm))
+
+    def set_wcs(self, wcs):
+        self.wcs = wcs
+        # We assume bins have the same size along x and y axis
+        self.binsize = np.abs(self.wcs.wcs.cdelt[0])
+        if self.wcs.wcs.ctype[0][0:4] == 'GLON':
+            self.coordsys = 'galactic'
+        elif self.wcs.wcs.ctype[0][0:2] == 'RA':
+            self.coordsys = 'fk5'
+            #        print self.coordsys
+
+    def calc(self, p, xlo, xhi, ylo, yhi, *args, **kwargs):
+        """
+        The normgauss2dint model uses the error function to evaluate the
+        the gaussian. This corresponds to an integration over bins.
+        """
+
+        return self.normgauss2d(p, xlo, xhi, ylo, yhi)
+
+    def normgauss2d(self, p, xlo, xhi, ylo, yhi):
+        sigma_erf = p[3] * fwhm_to_sigma_erf
+        return p[2] / 4. * ((erf.calc.calc([1, p[0], sigma_erf], xhi)
+                             - erf.calc.calc([1, p[0], sigma_erf], xlo))
+                            * (erf.calc.calc([1, p[1], sigma_erf], yhi)
+                               - erf.calc.calc([1, p[1], sigma_erf], ylo)))
+
+
+sau.add_model(NormGauss2DInt)
 
 
 # This class was copy pasted from sherpa.data.Data2D and modified to account

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -8,7 +8,6 @@ from ...datasets import gammapy_extra
 from ...irf import EnergyDispersion
 from ...utils.testing import requires_dependency, requires_data
 from .. import SkyCube
-from ..sherpa_ import NormGauss2DInt
 
 
 @requires_dependency('sherpa')
@@ -69,7 +68,7 @@ def testCombinedModel3DInt():
     from sherpa.optmethods import NelderMead
     from sherpa.stats import Cash
     from sherpa.fit import Fit
-    from ..sherpa_ import CombinedModel3DInt
+    from ..sherpa_ import CombinedModel3DInt, NormGauss2DInt
 
     # Set the counts
     filename = gammapy_extra.filename('test_datasets/cube/counts_cube.fits')
@@ -133,7 +132,7 @@ def testCombinedModel3DIntConvolveEdisp():
     from sherpa.optmethods import NelderMead
     from sherpa.stats import Cash
     from sherpa.fit import Fit
-    from ..sherpa_ import CombinedModel3DIntConvolveEdisp
+    from ..sherpa_ import CombinedModel3DIntConvolveEdisp, NormGauss2DInt
 
     # Set the counts
     filename = gammapy_extra.filename('test_datasets/cube/counts_cube.fits')

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -1,10 +1,66 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing.utils import assert_allclose
+import numpy as np
 from astropy.io import fits
+from astropy.coordinates import SkyCoord
+import sherpa.astro.ui as sau
+from sherpa.astro.ui import erf
+from sherpa.models import ArithmeticModel, Parameter
+import astropy.wcs as pywcs
 from ...datasets import gammapy_extra
+from ...irf import EnergyDispersion
 from ...utils.testing import requires_dependency, requires_data
 from .. import SkyCube
+
+"""
+Definition of the model NormGauss2DInt: Integrated 2D gaussian
+"""
+fwhm_to_sigma = 1 / (2 * np.sqrt(2 * np.log(2)))
+fwhm_to_sigma_erf = np.sqrt(2) * fwhm_to_sigma
+
+
+class NormGauss2DInt(ArithmeticModel):
+    def __init__(self, name='normgauss2dint'):
+        # Gauss source parameters
+        self.wcs = pywcs.WCS()
+        self.coordsys = "galactic"  # default
+        self.binsize = 1.0
+        self.xpos = Parameter(name, 'xpos', 0)  # p[0]
+        self.ypos = Parameter(name, 'ypos', 0)  # p[1]
+        self.ampl = Parameter(name, 'ampl', 1)  # p[2]
+        self.fwhm = Parameter(name, 'fwhm', 1, min=0)  # p[3]
+        self.shape = None
+        self.n_ebins = None
+        ArithmeticModel.__init__(self, name, (self.xpos, self.ypos, self.ampl, self.fwhm))
+
+    def set_wcs(self, wcs):
+        self.wcs = wcs
+        # We assume bins have the same size along x and y axis
+        self.binsize = np.abs(self.wcs.wcs.cdelt[0])
+        if self.wcs.wcs.ctype[0][0:4] == 'GLON':
+            self.coordsys = 'galactic'
+        elif self.wcs.wcs.ctype[0][0:2] == 'RA':
+            self.coordsys = 'fk5'
+            #        print self.coordsys
+
+    def calc(self, p, xlo, xhi, ylo, yhi, *args, **kwargs):
+        """
+        The normgauss2dint model uses the error function to evaluate the
+        the gaussian. This corresponds to an integration over bins.
+        """
+
+        return self.normgauss2d(p, xlo, xhi, ylo, yhi)
+
+    def normgauss2d(self, p, xlo, xhi, ylo, yhi):
+        sigma_erf = p[3] * fwhm_to_sigma_erf
+        return p[2] / 4. * ((erf.calc.calc([1, p[0], sigma_erf], xhi)
+                             - erf.calc.calc([1, p[0], sigma_erf], xlo))
+                            * (erf.calc.calc([1, p[1], sigma_erf], yhi)
+                               - erf.calc.calc([1, p[1], sigma_erf], ylo)))
+
+
+sau.add_model(NormGauss2DInt)
 
 
 @requires_dependency('sherpa')
@@ -53,5 +109,140 @@ def test_sherpa_crab_fit():
                  22.015564,
                  0.096903,
                  2.240989]
+
+    assert_allclose(result.parvals, reference, rtol=1E-5)
+
+
+@requires_dependency('sherpa')
+@requires_data('gammapy-extra')
+def testCombinedModel3DInt():
+    from sherpa.models import PowLaw1D, TableModel
+    from sherpa.estmethods import Covariance
+    from sherpa.optmethods import NelderMead
+    from sherpa.stats import Cash
+    from sherpa.fit import Fit
+    from ..sherpa_ import CombinedModel3DInt
+
+    # Set the counts
+    filename = gammapy_extra.filename('test_datasets/cube/counts_cube.fits')
+    counts_3d = SkyCube.read(filename)
+    cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt')
+
+    # Set the bkg
+    filename = gammapy_extra.filename('test_datasets/cube/bkg_cube.fits')
+    bkg_3d = SkyCube.read(filename)
+    bkg = TableModel('bkg')
+    bkg.load(None, bkg_3d.data.value.ravel())
+    bkg.ampl = 1
+    bkg.ampl.freeze()
+
+    # Set the exposure
+    filename = gammapy_extra.filename('test_datasets/cube/exposure_cube.fits')
+    exposure_3d = SkyCube.read(filename)
+    i_nan = np.where(np.isnan(exposure_3d.data))
+    exposure_3d.data[i_nan] = 0
+    # In order to have the exposure in cm2 s
+    exposure_3d.data = exposure_3d.data * 1e4
+
+    # Set the mean psf model
+    filename = gammapy_extra.filename('test_datasets/cube/psf_cube.fits')
+    psf_3d = SkyCube.read(filename)
+
+    # Setup combined spatial and spectral model
+    spatial_model = NormGauss2DInt('spatial-model')
+    spectral_model = PowLaw1D('spectral-model')
+    source_model = CombinedModel3DInt(use_psf=True, exposure=exposure_3d, psf=psf_3d,
+                                      spatial_model=spatial_model, spectral_model=spectral_model)
+
+    # Set starting values
+    center = SkyCoord.from_name("Crab").galactic
+    source_model.gamma = 2.2
+    source_model.xpos = center.l.value
+    source_model.ypos = center.b.value
+    source_model.fwhm = 0.12
+    source_model.ampl = 1.0
+
+    # Fit
+    model = bkg + 1E-11 * (source_model)
+    fit = Fit(data=cube, model=model, stat=Cash(), method=NelderMead(), estmethod=Covariance())
+    result = fit.fit()
+
+    # TODO: The fact that it doesn't converge to the right Crab postion is due to the dummy psf
+    reference = [184.2009249783969,
+                 -6.1708090667404374,
+                 5.1433080482386968,
+                 0.078883847523875297,
+                 2.2778084618363268]
+
+    assert_allclose(result.parvals, reference, rtol=1E-5)
+
+
+@requires_dependency('sherpa')
+@requires_data('gammapy-extra')
+def testCombinedModel3DIntConvolveEdisp():
+    from sherpa.models import PowLaw1D, TableModel
+    from sherpa.estmethods import Covariance
+    from sherpa.optmethods import NelderMead
+    from sherpa.stats import Cash
+    from sherpa.fit import Fit
+    from ..sherpa_ import CombinedModel3DIntConvolveEdisp
+
+    # Set the counts
+    filename = gammapy_extra.filename('test_datasets/cube/counts_cube.fits')
+    counts_3d = SkyCube.read(filename)
+    cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt')
+
+    # Set the bkg
+    filename = gammapy_extra.filename('test_datasets/cube/bkg_cube.fits')
+    bkg_3d = SkyCube.read(filename)
+    bkg = TableModel('bkg')
+    bkg.load(None, bkg_3d.data.value.ravel())
+    bkg.ampl = 1
+    bkg.ampl.freeze()
+
+    # Set the exposure
+    filename = gammapy_extra.filename('test_datasets/cube/exposure_cube_etrue.fits')
+    exposure_3d = SkyCube.read(filename)
+    i_nan = np.where(np.isnan(exposure_3d.data))
+    exposure_3d.data[i_nan] = 0
+    # In order to have the exposure in cm2 s
+    exposure_3d.data = exposure_3d.data * 1e4
+
+    # Set the mean psf model
+    filename = gammapy_extra.filename('test_datasets/cube/psf_cube_etrue.fits')
+    psf_3d = SkyCube.read(filename)
+
+    # Set the mean rmf
+    filename = gammapy_extra.filename('test_datasets/cube/rmf.fits')
+    rmf = EnergyDispersion.read(filename)
+
+    # Setup combined spatial and spectral model
+    spatial_model = NormGauss2DInt('spatial-model')
+    spectral_model = PowLaw1D('spectral-model')
+    dimensions = [exposure_3d.data.shape[1], exposure_3d.data.shape[2], rmf.data.shape[1], exposure_3d.data.shape[0]]
+    source_model = CombinedModel3DIntConvolveEdisp(dimensions=dimensions, use_psf=True, exposure=exposure_3d,
+                                                   psf=psf_3d,
+                                                   spatial_model=spatial_model, spectral_model=spectral_model,
+                                                   edisp=rmf.data)
+
+    # Set starting values
+    center = SkyCoord.from_name("Crab").galactic
+    source_model.gamma = 2.2
+    source_model.xpos = center.l.value
+    source_model.ypos = center.b.value
+    source_model.fwhm = 0.12
+    source_model.ampl = 1.0
+
+    # Fit
+    model = bkg + 1E-11 * (source_model)
+    fit = Fit(data=cube, model=model, stat=Cash(), method=NelderMead(), estmethod=Covariance())
+    result = fit.fit()
+
+    # TODO: The fact that it doesn't converge to the right Crab postion, flux and source size is due to the dummy psf
+    reference = [183.73086704623555,
+                 -11.426439339270253,
+                 35843.352273899836,
+                 3.7381063514549009,
+                 2.2288775690653875]
 
     assert_allclose(result.parvals, reference, rtol=1E-5)

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -103,7 +103,7 @@ def testCombinedModel3DInt():
                                       spatial_model=spatial_model, spectral_model=spectral_model)
 
     # Set starting values
-    center = SkyCoord.from_name("Crab").galactic
+    center = SkyCoord(83.633083, 22.0145, unit="deg").galactic
     source_model.gamma = 2.2
     source_model.xpos = center.l.value
     source_model.ypos = center.b.value
@@ -174,7 +174,7 @@ def testCombinedModel3DIntConvolveEdisp():
                                                    edisp=rmf.data)
 
     # Set starting values
-    center = SkyCoord.from_name("Crab").galactic
+    center = SkyCoord(83.633083, 22.0145, unit="deg").galactic
     source_model.gamma = 2.2
     source_model.xpos = center.l.value
     source_model.ypos = center.b.value

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -4,63 +4,11 @@ from numpy.testing.utils import assert_allclose
 import numpy as np
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
-import sherpa.astro.ui as sau
-from sherpa.astro.ui import erf
-from sherpa.models import ArithmeticModel, Parameter
-import astropy.wcs as pywcs
 from ...datasets import gammapy_extra
 from ...irf import EnergyDispersion
 from ...utils.testing import requires_dependency, requires_data
 from .. import SkyCube
-
-"""
-Definition of the model NormGauss2DInt: Integrated 2D gaussian
-"""
-fwhm_to_sigma = 1 / (2 * np.sqrt(2 * np.log(2)))
-fwhm_to_sigma_erf = np.sqrt(2) * fwhm_to_sigma
-
-
-class NormGauss2DInt(ArithmeticModel):
-    def __init__(self, name='normgauss2dint'):
-        # Gauss source parameters
-        self.wcs = pywcs.WCS()
-        self.coordsys = "galactic"  # default
-        self.binsize = 1.0
-        self.xpos = Parameter(name, 'xpos', 0)  # p[0]
-        self.ypos = Parameter(name, 'ypos', 0)  # p[1]
-        self.ampl = Parameter(name, 'ampl', 1)  # p[2]
-        self.fwhm = Parameter(name, 'fwhm', 1, min=0)  # p[3]
-        self.shape = None
-        self.n_ebins = None
-        ArithmeticModel.__init__(self, name, (self.xpos, self.ypos, self.ampl, self.fwhm))
-
-    def set_wcs(self, wcs):
-        self.wcs = wcs
-        # We assume bins have the same size along x and y axis
-        self.binsize = np.abs(self.wcs.wcs.cdelt[0])
-        if self.wcs.wcs.ctype[0][0:4] == 'GLON':
-            self.coordsys = 'galactic'
-        elif self.wcs.wcs.ctype[0][0:2] == 'RA':
-            self.coordsys = 'fk5'
-            #        print self.coordsys
-
-    def calc(self, p, xlo, xhi, ylo, yhi, *args, **kwargs):
-        """
-        The normgauss2dint model uses the error function to evaluate the
-        the gaussian. This corresponds to an integration over bins.
-        """
-
-        return self.normgauss2d(p, xlo, xhi, ylo, yhi)
-
-    def normgauss2d(self, p, xlo, xhi, ylo, yhi):
-        sigma_erf = p[3] * fwhm_to_sigma_erf
-        return p[2] / 4. * ((erf.calc.calc([1, p[0], sigma_erf], xhi)
-                             - erf.calc.calc([1, p[0], sigma_erf], xlo))
-                            * (erf.calc.calc([1, p[1], sigma_erf], yhi)
-                               - erf.calc.calc([1, p[1], sigma_erf], ylo)))
-
-
-sau.add_model(NormGauss2DInt)
+from ..sherpa_ import NormGauss2DInt
 
 
 @requires_dependency('sherpa')

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -167,11 +167,12 @@ def testCombinedModel3DIntConvolveEdisp():
     # Setup combined spatial and spectral model
     spatial_model = NormGauss2DInt('spatial-model')
     spectral_model = PowLaw1D('spectral-model')
-    dimensions = [exposure_3d.data.shape[1], exposure_3d.data.shape[2], rmf.data.shape[1], exposure_3d.data.shape[0]]
+    dimensions = [exposure_3d.data.shape[1], exposure_3d.data.shape[2], rmf.data.data.shape[1],
+                  exposure_3d.data.shape[0]]
     source_model = CombinedModel3DIntConvolveEdisp(dimensions=dimensions, use_psf=True, exposure=exposure_3d,
                                                    psf=psf_3d,
                                                    spatial_model=spatial_model, spectral_model=spectral_model,
-                                                   edisp=rmf.data)
+                                                   edisp=rmf.data.data)
 
     # Set starting values
     center = SkyCoord(83.633083, 22.0145, unit="deg").galactic


### PR DESCRIPTION
@adonath 
Hi,
This PR is for taking into account the true energy for the spectral analysis.
For taking into account this true energy you have to reshape your model in the good shape to have your spectral and spatial model in true energy and then convolve by the energy dispersion. When you use the ```to_sherpa_data3d``` in the class ```SkyCube```, you can not store the true energy since the elo and eli must have the same shape than the data. The data are the counts cube in reconstructed energy. So when you want to take into account the true energy you have to do it directly in the method calc of the object ```CombinedModel3DIntConvolveEdisp```.
Therefore, in order to have the same philosophy in ```CombinedModel3DIntConvolveEdisp```and in ```CombinedModel3DInt```, I changed a little bit the class ```CombinedModel3DInt```. More over you gain a little bit in time to not compute the spectral model for all the (x,y) and to not compute the spatial_model for the energies.

I hope this is clear.
I don't know what I can add for test since we don't have a model that take xlo,xhi,ylo,yhi,elo,ehi and that I am using the mine locally from your Gauss2dInt.
But I test it with my script on the crab for HAP-FR data and I have the same result with 1D analysis and 3D analysis if I take into account the energy resolution.
cheers,
Lea