### PR TITLE
Add AbsorbedSpectralModel class

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -729,8 +729,8 @@ class AbsorbedSpectralModel(SpectralModel):
         self.parameters = {}
 
     def evaluate(self, energy):
-        flux = self.spectral_model.__call__(energy)
-        absorption = self.table_model.__call__(energy)
+        flux = self.spectral_model(energy)
+        absorption = self.table_model(energy)
         return flux * absorption
 
     def to_sherpa(self, name='default'):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -27,6 +27,7 @@ __all__ = [
     'ExponentialCutoffPowerLaw3FGL',
     'LogParabola',
     'TableModel',
+    'AbsorbedSpectralModel',
 ]
 
 
@@ -708,3 +709,33 @@ class TableModel(SpectralModel):
         if self.scale_logy:
             ax.set_yscale("log", nonposy='clip')
         return ax
+
+
+class AbsorbedSpectralModel(SpectralModel):
+
+    def __init__(self, spectral_model, table_model):
+        """Absorbed spectral model
+
+        Parameters
+        ---------
+        spectral_model : `~gammapy.spectrum.models.SpectralModel`
+            spectral model
+        table_model : `~gammapy.spectrum.models.TableModel`
+            table model
+        """
+        self.spectral_model = spectral_model
+        self.table_model = table_model
+        # Will be implemented later for sherpa fit
+        self.parameters = {}
+
+    def evaluate(self, energy):
+        flux = self.spectral_model.__call__(energy)
+        absorption = self.table_model.__call__(energy)
+        return flux * absorption
+
+    def to_sherpa(self, name='default'):
+        """Convert to Sherpa model
+
+        To be implemented by subclasses
+        """
+        raise NotImplementedError('{}'.format(self.__class__.__name__))

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -4,7 +4,8 @@ import astropy.units as u
 from gammapy.utils.energy import EnergyBounds
 from astropy.tests.helper import assert_quantity_allclose, pytest
 from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
-                      ExponentialCutoffPowerLaw3FGL, LogParabola, TableModel)
+                      ExponentialCutoffPowerLaw3FGL, LogParabola,
+                      TableModel, AbsorbedSpectralModel)
 from ...utils.testing import requires_dependency, requires_data
 
 
@@ -168,3 +169,31 @@ def test_table_model_from_file():
     absorption_z03 = TableModel.read_xspec_model(filename=filename, param=0.3)
     absorption_z03.plot(energy_range=(0.03, 10),
                         energy_unit=u.TeV)
+
+
+@requires_data('gammapy-extra')
+def test_absorbed_spectral_model():
+    filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
+    # absorption values for given redshift
+    redshift = 0.117
+    absorption = TableModel.read_xspec_model(filename, redshift)
+    # Spectral model corresponding to PKS 2155-304 (quiescent state)
+    index = 3.53
+    amplitude = 1.81 * 1e-12 * u.Unit('cm-2 s-1 TeV-1')
+    reference = 1 * u.TeV
+    pwl = PowerLaw(index=index, amplitude=amplitude, reference=reference)
+    # EBL + PWL model
+    model = AbsorbedSpectralModel(spectral_model=pwl, table_model=absorption)
+
+    # Test if the absorption factor at the reference energy
+    # corresponds to the ratio of the absorbed flux
+    # divided by the flux of the spectral model
+    model_ref_energy = model.evaluate(energy=reference)
+    pwl_ref_energy = pwl.evaluate(energy=reference,
+                                  index=index,
+                                  amplitude=amplitude,
+                                  reference=reference)
+
+    desired = absorption.evaluate(energy=reference, amplitude=1.)
+    actual = model_ref_energy/pwl_ref_energy
+    assert_quantity_allclose(actual, desired)


### PR DESCRIPTION
Hi @cdeil and @joleroi , 

I added a small class, `AbsorbedSpectralModel`, which takes in input one `SpectralModel` and one `TableModel` objects. Only the `evaluate` method is implemented for now. I also added a test.

For now it does not handle sherpa stuff for fitting, it's the basic implementation to be able to do some predictions at very high energy (step 1). Do you mind if we merge it as it is, since people might be interrested in things like that?

I'll discuss tomorrow with @registerrier to see if it's possible to find an easy way to fit together the parameter from the `TableModel` and the parameters of the models (à la sherpa, step 2).

Step 1 is fine for now.

See ya! ++


