### PR TITLE
Remove NDDataArray subclassing

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -969,21 +969,15 @@ If you want to compare the IRF files between two different datastores (to compar
 
 .. _use-nddata:
 
-Using the NDData base class
----------------------------
+Using the NDDataArray
+---------------------
 
-Gammapy has a base class for n-dimensional data arrays,
+Gammapy has a class for generic n-dimensional data arrays,
 `~gammapy.utils.nddata.NDDataArray`. Classes that represent such an array
-should subclass this base class. The goal is to reuse code for interpolation
-and have an coherent I/O interface, mainly in `~gammapy.irf`. Below you
-find a list of  classes currently using the
-`~gammapy.utils.nddata.NDDataArray`.  If you want to add a new class using the
-`~gammapy.utils.nddata.NDDataArray` as base class, you can look at these
-examples.
+should use this class. The goal is to reuse code for interpolation
+and have an coherent I/O interface, mainly in `~gammapy.irf`.
 
-* `~gammapy.irf.EffectiveAreaTable`
-* `~gammapy.irf.EffectiveAreaTable2D`
-* `~gammapy.spectrum.CountsSpectrum`
+A usage example can be found in :gp-extra-notebooks:``nddata_demo``.
 
 Also, consult :ref:`interpolation-extrapolation` if you are not sure how to
 setup your interpolator. 
@@ -1001,6 +995,7 @@ to run ``test_notebooks.py`` until all notebooks run without raising an error.
 If you add a new notebook and want it to be under test (which of course is what
 you want) you have to add it to ``gammapy-extra/notebooks/notebooks.yaml``.
 Note that there is also the command ``make test-notebooks`` which is used for
+
 continuous integration on travis CI. It is not recommended to use this locally,
 since it overwrides your gammapy installation (see issue 727).
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -41,7 +41,7 @@ def exposure_cube(pointing,
     offset = coordinates.separation(pointing)
 
     energy = ref_cube.energies()
-    exposure = aeff2d.evaluate(offset=offset, energy=energy)
+    exposure = aeff2d.data.evaluate(offset=offset, energy=energy)
     exposure *= livetime
     exposure[:, offset >= offset_max] = 0
     expcube = SkyCube(data=exposure,

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -22,7 +22,7 @@ def test_exposure_cube():
 
     pointing = SkyCoord(83.633, 21.514, unit='deg')
     livetime = Quantity(1581.17, 's')
-    aeff2d = EffectiveAreaTable2D.read(aeff_filename)
+    aeff2d = EffectiveAreaTable2D.read(aeff_filename, hdu='AEFF_2D')
     count_cube = SkyCube.read(ccube_filename, format='fermi-counts')
     offset_max = Angle(2.2, 'deg')
     exp_cube = exposure_cube(pointing, livetime, aeff2d, count_cube,

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -668,12 +668,12 @@ class DataStoreObservation(object):
 
         # TODO: make axis names consistent
         if isinstance(self.psf, PSF3D):
-            psf_value = self.psf.to_energy_dependent_table_psf(theta=offset) \
-                .evaluate(energy)
+            psf_value = self.psf.to_energy_dependent_table_psf(
+                theta=offset).evaluate(energy)
         else:
-            psf_value = self.psf.to_energy_dependent_table_psf(theta=offset, offset=theta) \
-                .evaluate(energy)
-        arf = self.aeff.evaluate(offset=offset, energy=energy)
+            psf_value = self.psf.to_energy_dependent_table_psf(
+                theta=offset, offset=theta).evaluate(energy)
+        arf = self.aeff.data.evaluate(offset=offset, energy=energy)
         exposure = arf * self.observation_live_time_duration
 
         psf = EnergyDependentTablePSF(energy=energy, offset=theta,

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -182,19 +182,19 @@ def test_make_mean_edisp(tmpdir):
 
     assert len(rmf.e_true.nodes) == 80
     assert len(rmf.e_reco.nodes) == 15
-    assert_quantity_allclose(rmf.data[53, 8], 0.0559785805550798)
+    assert_quantity_allclose(rmf.data.data[53, 8], 0.0559785805550798)
 
     rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true,
                                    e_reco=e_reco,
                                    low_reco_threshold=Energy(1, "TeV"),
                                    high_reco_threshold=Energy(60, "TeV"))
-    i2 = np.where(rmf2.evaluate(e_reco=Energy(0.8, "TeV")) != 0)[0]
+    i2 = np.where(rmf2.data.evaluate(e_reco=Energy(0.8, "TeV")) != 0)[0]
     assert len(i2) == 0
-    i2 = np.where(rmf2.evaluate(e_reco=Energy(61, "TeV")) != 0)[0]
+    i2 = np.where(rmf2.data.evaluate(e_reco=Energy(61, "TeV")) != 0)[0]
     assert len(i2) == 0
-    i = np.where(rmf.evaluate(e_reco=Energy(1.5, "TeV")) != 0)[0]
-    i2 = np.where(rmf2.evaluate(e_reco=Energy(1.5, "TeV")) != 0)[0]
+    i = np.where(rmf.data.evaluate(e_reco=Energy(1.5, "TeV")) != 0)[0]
+    i2 = np.where(rmf2.data.evaluate(e_reco=Energy(1.5, "TeV")) != 0)[0]
     assert_equal(i, i2)
-    i = np.where(rmf.evaluate(e_reco=Energy(55, "TeV")) != 0)[0]
-    i2 = np.where(rmf2.evaluate(e_reco=Energy(55, "TeV")) != 0)[0]
+    i = np.where(rmf.data.evaluate(e_reco=Energy(55, "TeV")) != 0)[0]
+    i2 = np.where(rmf2.data.evaluate(e_reco=Energy(55, "TeV")) != 0)[0]
     assert_equal(i, i2)

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -2,8 +2,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
+from astropy.io import fits
 from astropy.table import Table
+from ..extern.bunch import Bunch
 from ..utils.nddata import NDDataArray, DataAxis, BinnedDataAxis
+from ..utils.energy import EnergyBounds
+from ..utils.scripts import make_path
+from ..utils.fits import fits_table_to_table, table_to_fits_table
 
 __all__ = [
     'EffectiveAreaTable',
@@ -11,14 +16,14 @@ __all__ = [
 ]
 
 
-class EffectiveAreaTable(NDDataArray):
+class EffectiveAreaTable(object):
     """Effective Area Table
 
     TODO: Document
 
     Parameters
     -----------
-    energy : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
+    energy : `~astropy.units.Quantity`
         Bin edges of energy axis
     data : `~astropy.units.Quantity`
         Effective area
@@ -60,9 +65,12 @@ class EffectiveAreaTable(NDDataArray):
     >>> print(ener)
     0.185368478744 TeV
     """
-    energy = BinnedDataAxis(interpolation_mode='log')
-    """Energy Axis"""
-    axis_names = ['energy']
+
+    def __init__(self, energy, data, meta=None):
+        axes = [BinnedDataAxis(energy, interpolation_mode='log', name='energy')]
+        self.data = NDDataArray(axes=axes, data=data)
+        if meta is not None:
+            self.meta = Bunch(meta)
 
     def plot(self, ax=None, energy=None, show_energy=None, **kwargs):
         """Plot effective area
@@ -88,18 +96,18 @@ class EffectiveAreaTable(NDDataArray):
         kwargs.setdefault('lw', 2)
 
         if energy is None:
-            energy = self.energy.nodes
-        eff_area = self.evaluate(energy=energy)
-        xerr = (energy.value - self.energy.data[:-1].value,
-                self.energy.data[1:].value - energy.value)
+            energy = self.data.axis('energy').nodes
+        eff_area = self.data.evaluate(energy=energy)
+        xerr = (energy.value - self.data.axis('energy').data[:-1].value,
+                self.data.axis('energy').data[1:].value - energy.value)
         ax.errorbar(energy.value, eff_area.value, xerr=xerr, **kwargs)
         if show_energy is not None:
             ener_val = u.Quantity(show_energy).to(self.energy.unit).value
             ax.vlines(ener_val, 0, 1.1 * self.max_area.value,
                       linestyles='dashed')
         ax.set_xscale('log')
-        ax.set_xlabel('Energy [{}]'.format(self.energy.unit))
-        ax.set_ylabel('Effective Area [{}]'.format(self.data.unit))
+        ax.set_xlabel('Energy [{}]'.format(self.data.axis('energy').unit))
+        ax.set_ylabel('Effective Area [{}]'.format(self.data.data.unit))
 
         return ax
 
@@ -121,6 +129,7 @@ class EffectiveAreaTable(NDDataArray):
         instrument : {'HESS', 'HESS2', 'CTA'}
             Instrument name
         """
+        energy = EnergyBounds(energy)
         # Put the parameters g in a dictionary.
         # Units: g1 (cm^2), g2 (), g3 (MeV)
         # Note that whereas in the paper the parameter index is 1-based,
@@ -134,8 +143,7 @@ class EffectiveAreaTable(NDDataArray):
             ss += 'Valid instruments: HESS, HESS2, CTA'
             raise ValueError(ss)
 
-        ret = cls(energy=energy)
-        xx = ret.energy.nodes.to('MeV').value
+        xx = energy.log_centers.to('MeV').value
 
         g1 = pars[instrument][0]
         g2 = pars[instrument][1]
@@ -143,9 +151,9 @@ class EffectiveAreaTable(NDDataArray):
 
         value = g1 * xx ** (-g2) * np.exp(g3 / xx)
 
-        ret.data = value * u.cm ** 2
+        data = value * u.cm ** 2
 
-        return ret
+        return cls(data=data, energy=energy)
 
     @classmethod
     def from_table(cls, table):
@@ -159,7 +167,47 @@ class EffectiveAreaTable(NDDataArray):
         data = table['{}'.format(data_col)].quantity
         return cls(energy=energy, data=data)
 
-    def evaluate(self, fill_nan=False, **kwargs):
+    @classmethod
+    def from_hdulist(cls, hdulist, hdu='SPECRESP'):
+        fits_table = hdulist[hdu]
+        table = fits_table_to_table(fits_table)
+        return cls.from_table(table)
+
+    @classmethod
+    def read(cls, filename, hdu='SPECRESP', **kwargs):
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename), **kwargs)
+        try:
+            return cls.from_hdulist(hdulist, hdu=hdu)
+        except KeyError:
+            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
+            msg += '\n Available {}'.format([_.name for _ in hdulist])
+            raise ValueError(msg)
+
+    def to_table(self):
+        """Convert to `~astropy.table.Table`
+
+        http://gamma-astro-data-formats.readthedocs.io/en/latest/ogip/index.html#arf-file
+        """
+        energy = self.data.axis('energy').data
+        ener_lo = energy[:-1]
+        ener_hi = energy[1:]
+        data = self.evaluate_fill_nan()
+        names = ['ENERG_LO', 'ENERG_HI', 'SPECRESP']
+        meta = dict(name='SPECRESP', hduclass='OGIP', hduclas1='RESPONSE',
+                    hduclas2='SPECRESP')
+        return Table([ener_lo, ener_hi, data], names=names, meta=meta)
+
+    def to_hdulist(self):
+        hdu = table_to_fits_table(self.to_table())
+        prim_hdu = fits.PrimaryHDU()
+        return fits.HDUList([prim_hdu, hdu])
+
+    def write(self, filename, **kwargs):
+        filename = make_path(filename)
+        self.to_hdulist().writeto(str(filename), **kwargs)
+
+    def evaluate_fill_nan(self, **kwargs):
         """Modified evalute function
 
         Calls :func:`gammapy.utils.nddata.NDDataArray.evaluate` and replaces
@@ -168,42 +216,26 @@ class EffectiveAreaTable(NDDataArray):
         other Sofwares, e.g. sherpa, don't like nan values in FITS files. Make
         sure that the replacement happens outside of the energy range, where
         the `~gammapy.irf.EffectiveAreaTable` is used.
-
-        Parameters
-        ----------
-        fill_nan : bool, optional
-            Replace nan values after evaluation
         """
-        retval = super(EffectiveAreaTable, self).evaluate(**kwargs)
-        if fill_nan:
-            idx = np.where(np.isfinite(retval))[0]
-            retval[np.arange(idx[0])] = 0
-            retval[np.arange(idx[-1], len(retval))] = retval[idx[-1]]
+        retval = self.data.evaluate(**kwargs)
+        idx = np.where(np.isfinite(retval))[0]
+        retval[np.arange(idx[0])] = 0
+        retval[np.arange(idx[-1], len(retval))] = retval[idx[-1]]
         return retval
-
-    def to_table(self):
-        """Convert to `~astropy.table.Table`
-
-        http://gamma-astro-data-formats.readthedocs.io/en/latest/ogip/index.html#arf-file
-        """
-        ener_lo = self.energy.data[:-1]
-        ener_hi = self.energy.data[1:]
-        data = self.evaluate(fill_nan=True)
-        names = ['ENERG_LO', 'ENERG_HI', 'SPECRESP']
-        meta = dict(name='SPECRESP', hduclass='OGIP', hduclas1='RESPONSE',
-                    hduclas2='SPECRESP')
-        return Table([ener_lo, ener_hi, data], names=names, meta=meta)
 
     @property
     def max_area(self):
         """Maximum effective area"""
-        return self.data[np.where(~np.isnan(self.data))].max()
+        cleaned_data = self.data.data[np.where(~np.isnan(self.data.data))]
+        return cleaned_data.max()
 
     def find_energy(self, aeff):
         """Find energy for given effective area
 
         A linear interpolation is performed between the two nodes closest to
         the desired effective area value.
+
+        TODO: Move to `~gammapy.utils.nddata.NDDataArray`
 
         Parameters
         ----------
@@ -215,14 +247,13 @@ class EffectiveAreaTable(NDDataArray):
         energy: `~astropy.units.Quantity`
             Energy corresponing to aeff
         """
-        # TODO: Move to base class?
-        idx = np.where(self.data > aeff)[0][0]
+        idx = np.where(self.data.data > aeff)[0][0]
 
         # Linear interpolation between two energy nodes
         energy = np.interp(aeff.value,
-                           (self.data[[idx - 1, idx]].value),
-                           (self.energy.nodes[[idx - 1, idx]].value))
-        return energy * self.energy.unit
+                           (self.data.data[[idx - 1, idx]].value),
+                           (self.data.axis('energy').nodes[[idx - 1, idx]].value))
+        return energy * self.data.axis('energy').unit
 
     def to_sherpa(self, name):
         """Return `~sherpa.astro.data.DataARF`
@@ -245,20 +276,21 @@ class EffectiveAreaTable(NDDataArray):
         return DataARF(**kwargs)
 
 
-class EffectiveAreaTable2D(NDDataArray):
+class EffectiveAreaTable2D(object):
     """2D Effective Area Table
 
     Parameters
     -----------
-    energy : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
+    energy : `~astropy.units.Quantity`
         Bin edges of energy axis
-    offset : `~astropy.units.Quantity`, `~gammapy.utils.nddata.DataAxis`
+    offset : `~astropy.units.Quantity`
         Nodes of Offset axis
     data : `~astropy.units.Quantity`
         Effective area
-    meta : dict
-        Optional meta information, TODO: Replace with real arguments
-        supported: ``low_threshold``, ``high_threshold``
+    low_threshold : `~astropy.units.Quantity`, optional 
+        Low energy threshold
+    high_threshold : `~astropy.units.Quantity`, optional 
+        High energy threshold
 
     Examples
     --------
@@ -278,11 +310,20 @@ class EffectiveAreaTable2D(NDDataArray):
     Data           : size =    40, min =  1.000 cm2, max =  1.000 cm2
     """
 
-    energy = BinnedDataAxis(interpolation_mode='log')
-    """Primary axis: Energy"""
-    offset = DataAxis()
-    """Secondary axis: Offset from pointing position"""
-    axis_names = ['energy', 'offset']
+    def __init__(self, energy, offset, data, meta=None):
+        axes = [
+            BinnedDataAxis(
+                energy,
+                interpolation_mode='log',
+                name='energy'),
+            DataAxis(
+                offset,
+                interpolation_mode='linear',
+                name='offset')
+        ]
+        self.data = NDDataArray(axes=axes, data=data)
+        if meta is not None:
+            self.meta = Bunch(meta)
 
     @property
     def low_threshold(self):
@@ -311,6 +352,23 @@ class EffectiveAreaTable2D(NDDataArray):
         data = table['{}'.format(data_col)].quantity[0].transpose()
         return cls(offset=offset, energy=energy, data=data, meta=table.meta)
 
+    @classmethod
+    def from_hdulist(cls, hdulist, hdu='EFFECTIVE AREA'):
+        fits_table = hdulist[hdu]
+        table = fits_table_to_table(fits_table)
+        return cls.from_table(table)
+
+    @classmethod
+    def read(cls, filename, hdu='EFFECTIVE AREA'):
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename))
+        try:
+            return cls.from_hdulist(hdulist, hdu=hdu)
+        except KeyError:
+            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
+            msg += '\n Available {}'.format([_.name for _ in hdulist])
+            raise ValueError(msg)
+
     def to_effective_area_table(self, offset, energy=None):
         """Evaluate at a given offset and return `~gammapy.irf.EffectiveAreaTable`
 
@@ -322,11 +380,11 @@ class EffectiveAreaTable2D(NDDataArray):
             Energy axis bin edges
         """
         if energy is None:
-            energy = self.energy
+            energy = self.data.axis('energy')
         else:
             energy = BinnedDataAxis(data=energy, interpolation_mode='log')
 
-        area = self.evaluate(offset=offset, energy=energy.nodes)
+        area = self.data.evaluate(offset=offset, energy=energy.nodes)
         return EffectiveAreaTable(energy=energy.data, data=area)
 
     def plot_energy_dependence(self, ax=None, offset=None, energy=None, **kwargs):
@@ -354,20 +412,20 @@ class EffectiveAreaTable2D(NDDataArray):
         ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            off_min, off_max = self.offset.nodes[[0, -1]].value
-            offset = np.linspace(off_min, off_max, 4) * self.offset.unit
+            off_min, off_max = self.data.axis('offset').nodes[[0, -1]].value
+            offset = np.linspace(off_min, off_max, 4) * self.data.axis('offset').unit
 
         if energy is None:
-            energy = self.energy.nodes
+            energy = self.data.axis('energy').nodes
 
         for off in offset:
-            area = self.evaluate(offset=off, energy=energy)
+            area = self.data.evaluate(offset=off, energy=energy)
             label = 'offset = {:.1f}'.format(off)
             ax.plot(energy, area.value, label=label, **kwargs)
 
         ax.set_xscale('log')
-        ax.set_xlabel('Energy [{0}]'.format(self.energy.unit))
-        ax.set_ylabel('Effective Area [{0}]'.format(self.data.unit))
+        ax.set_xlabel('Energy [{0}]'.format(self.data.axis('energy').unit))
+        ax.set_ylabel('Effective Area [{0}]'.format(self.data.data.unit))
         ax.set_xlim(min(energy.value), max(energy.value))
         ax.legend(loc='upper left')
 
@@ -395,15 +453,15 @@ class EffectiveAreaTable2D(NDDataArray):
         ax = plt.gca() if ax is None else ax
 
         if energy is None:
-            e_min, e_max = np.log10(self.energy.nodes[[0, -1]].value)
-            energy = np.logspace(e_min, e_max, 4) * self.energy.unit
+            e_min, e_max = np.log10(self.data.axis('energy').nodes[[0, -1]].value)
+            energy = np.logspace(e_min, e_max, 4) * self.data.axis('energy').unit
 
         if offset is None:
-            off_lo, off_hi = self.offset.nodes[[0, -1]].to('deg').value
+            off_lo, off_hi = self.data.axis('offset').nodes[[0, -1]].to('deg').value
             offset = np.linspace(off_lo, off_hi, 100) * u.deg
 
         for ee in energy:
-            area = self.evaluate(offset=offset, energy=ee)
+            area = self.data.evaluate(offset=offset, energy=ee)
             area /= np.nanmax(area)
             if np.isnan(area).all():
                 continue
@@ -411,7 +469,7 @@ class EffectiveAreaTable2D(NDDataArray):
             ax.plot(offset, area, label=label, **kwargs)
 
         ax.set_ylim(0, 1.1)
-        ax.set_xlabel('Offset ({0})'.format(self.offset.unit))
+        ax.set_xlabel('Offset ({0})'.format(self.data.axis('offset').unit))
         ax.set_ylabel('Relative Effective Area')
         ax.legend(loc='best')
 
@@ -429,15 +487,16 @@ class EffectiveAreaTable2D(NDDataArray):
         ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            vals = self.offset.nodes.value
+            vals = self.data.axis('offset').nodes.value
             offset = np.linspace(vals.min(), vals.max(), 100)
-            offset = offset * self.offset.unit
+            offset = offset * self.data.axis('offset').unit
 
         if energy is None:
-            vals = np.log10(self.energy.nodes.value)
-            energy = np.logspace(vals.min(), vals.max(), 100) * self.energy.unit
+            vals = np.log10(self.data.axis('energy').nodes.value)
+            energy = np.logspace(
+                vals.min(), vals.max(), 100) * self.data.axis('energy').unit
 
-        aeff = self.evaluate(offset=offset, energy=energy)
+        aeff = self.data.evaluate(offset=offset, energy=energy)
         extent = [
             offset.value.min(), offset.value.max(),
             energy.value.min(), energy.value.max(),

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-class EnergyDispersion(NDDataArray):
+class EnergyDispersion(object):
     """Energy dispersion matrix.
 
     We use a dense matrix (`numpy.ndarray`) for the energy dispersion matrix.
@@ -31,21 +31,27 @@ class EnergyDispersion(NDDataArray):
 
     Parameters
     ----------
-    data : array_like
-        2-dim energy dispersion matrix (probability density).
     e_true : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
         Bin edges of true energy axis
     e_reco : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
         Bin edges of reconstruced energy axis
+    data : array_like
+        2-dim energy dispersion matrix (probability density).
     """
-    e_true = BinnedDataAxis(interpolation_mode='log')
-    """True energy axis"""
-    e_reco = BinnedDataAxis(interpolation_mode='log')
-    """Reconstructed energy axis"""
-    axis_names = ['e_true', 'e_reco']
-    """Axis names (in order)"""
-    interp_kwargs = dict(bounds_error=False, fill_value=0)
-    """Interpolation kwargs"""
+    default_interp_kwargs = dict(bounds_error=False, fill_value=0)
+    """Default Interpolation kwargs for `~NDDataArray`"""
+
+    def __init__(self, e_true, e_reco, data, interp_kwargs=None, meta=None):
+        if interp_kwargs is None:
+            interp_kwargs = self.default_interp_kwargs
+        axes = [
+            BinnedDataAxis(e_true, interpolation_mode='log', name='e_true'),
+            BinnedDataAxis(e_reco, interpolation_mode='log', name='e_reco')
+        ]
+        self.data=NDDataArray(axes=axes, data=data,
+                                interp_kwargs=interp_kwargs)
+        if meta is not None:
+            self.meta=Bunch(meta)
 
     @property
     def pdf_matrix(self):
@@ -54,7 +60,7 @@ class EnergyDispersion(NDDataArray):
         Rows (first index): True Energy
         Columns (second index): Reco Energy
         """
-        return self.data
+        return self.data.data.value
 
     def pdf_in_safe_range(self, lo_threshold, hi_threshold):
         """PDF matrix with bins outside threshold set to 0
@@ -66,10 +72,10 @@ class EnergyDispersion(NDDataArray):
         hi_threshold : `~astropy.units.Quantity`
             High reco energy threshold
         """
-        data = self.data.copy()
-        idx = np.where((self.e_reco.data[:-1] < lo_threshold) |
-                       (self.e_reco.data[1:] > hi_threshold))
-        data[:, idx] = 0
+        data=self.pdf_matrix.copy()
+        idx=np.where((self.data.axis('e_reco').data[:-1] < lo_threshold) |
+                       (self.data.axis('e_reco').data[1:] > hi_threshold))
+        data[:, idx]=0
         return data
 
     @classmethod
@@ -96,50 +102,78 @@ class EnergyDispersion(NDDataArray):
         """
         from scipy.special import erf
 
-        # Init array without data
-        retval = cls(e_true=e_true, e_reco=e_reco)
+        e_reco = EnergyBounds(e_reco)
+        e_true = EnergyBounds(e_true)
 
         # erf does not work with Quantities
-        reco = retval.e_reco.data.to('TeV').value
-        true = retval.e_true.nodes.to('TeV').value
-        migra_min = np.log10(reco[:-1] / true[:, np.newaxis])
-        migra_max = np.log10(reco[1:] / true[:, np.newaxis])
+        reco=e_reco.to('TeV').value
+        true=e_true.log_centers.to('TeV').value
+        migra_min=np.log10(reco[:-1] / true[:, np.newaxis])
+        migra_max=np.log10(reco[1:] / true[:, np.newaxis])
 
-        pdf = .5 * (erf(migra_max / (np.sqrt(2.) * sigma))
+        pdf=.5 * (erf(migra_max / (np.sqrt(2.) * sigma))
                     - erf(migra_min / (np.sqrt(2.) * sigma)))
 
-        pdf[np.where(pdf < pdf_threshold)] = 0
-        retval.data = pdf
+        pdf[np.where(pdf < pdf_threshold)]=0
 
-        return retval
+        return cls(e_true=e_true, e_reco=e_reco, data=pdf)
 
     @classmethod
-    def from_hdulist(cls, hdu_list):
+    def from_hdulist(cls, hdulist, hdu1='MATRIX', hdu2='EBOUNDS'):
         """Create `EnergyDispersion` object from `~astropy.io.fits.HDUList`.
 
         Parameters
         ----------
-        hdu_list : `~astropy.io.fits.HDUList`
+        hdulist : `~astropy.io.fits.HDUList`
             HDU list with ``MATRIX`` and ``EBOUNDS`` extensions.
+        hdu1 : str, optional
+            HDU containing the energy dispersion matrix, default: MATRIX
+        hdu2 : str, optional
+            HDU containing the energy axis information, default, EBOUNDS
         """
-        data = hdu_list['MATRIX'].data
-        header = hdu_list['MATRIX'].header
+        matrix_hdu = hdulist[hdu1]
+        ebounds_hdu = hdulist[hdu2]
 
-        pdf_matrix = np.zeros([len(data), header['DETCHANS']], dtype=np.float64)
+        data=matrix_hdu.data
+        header=matrix_hdu.header
+
+        pdf_matrix=np.zeros([len(data), header['DETCHANS']], dtype=np.float64)
 
         for i, l in enumerate(data):
             if l.field('N_GRP'):
-                m_start = 0
+                m_start=0
                 for k in range(l.field('N_GRP')):
                     pdf_matrix[i, l.field('F_CHAN')[k]: l.field(
-                        'F_CHAN')[k] + l.field('N_CHAN')[k]] = l.field(
+                        'F_CHAN')[k] + l.field('N_CHAN')[k]]=l.field(
                         'MATRIX')[m_start:m_start + l.field('N_CHAN')[k]]
                     m_start += l.field('N_CHAN')[k]
 
-        e_reco = EnergyBounds.from_ebounds(hdu_list['EBOUNDS'])
-        e_true = EnergyBounds.from_rmf_matrix(hdu_list['MATRIX'])
+        e_reco=EnergyBounds.from_ebounds(ebounds_hdu)
+        e_true=EnergyBounds.from_rmf_matrix(matrix_hdu)
 
         return cls(data=pdf_matrix, e_true=e_true, e_reco=e_reco)
+
+    @classmethod
+    def read(cls, filename, hdu1='MATRIX', hdu2='EBOUNDS', **kwargs):
+        """Read from file
+
+        Parameters
+        ----------
+        filename : `~gammapy.extern.pathlib.Path`, str
+            File to read
+        hdu1 : str, optional
+            HDU containing the energy dispersion matrix, default: MATRIX
+        hdu2 : str, optional
+            HDU containing the energy axis information, default, EBOUNDS
+        """
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename), **kwargs)
+        try:
+            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
+        except KeyError:
+            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
+            msg += '\n Available {}'.format([_.name for _ in hdulist])
+            raise ValueError(msg)
 
     def to_hdulist(self, **kwargs):
         """
@@ -166,27 +200,27 @@ class EnergyDispersion(NDDataArray):
         # Cannot use table_to_fits here due to variable length array
         # http://docs.astropy.org/en/v1.0.4/io/fits/usage/unfamiliar.html
 
-        table = self.to_table()
-        name = table.meta.pop('name')
+        table=self.to_table()
+        name=table.meta.pop('name')
 
-        header = fits.Header()
+        header=fits.Header()
         header.update(table.meta)
 
-        cols = table.columns
-        c0 = fits.Column(name=cols[0].name, format='E', array=cols[0],
+        cols=table.columns
+        c0=fits.Column(name=cols[0].name, format='E', array=cols[0],
                          unit='{}'.format(cols[0].unit))
-        c1 = fits.Column(name=cols[1].name, format='E', array=cols[1],
+        c1=fits.Column(name=cols[1].name, format='E', array=cols[1],
                          unit='{}'.format(cols[1].unit))
-        c2 = fits.Column(name=cols[2].name, format='I', array=cols[2])
-        c3 = fits.Column(name=cols[3].name, format='PI()', array=cols[3])
-        c4 = fits.Column(name=cols[4].name, format='PI()', array=cols[4])
-        c5 = fits.Column(name=cols[5].name, format='PE()', array=cols[5])
+        c2=fits.Column(name=cols[2].name, format='I', array=cols[2])
+        c3=fits.Column(name=cols[3].name, format='PI()', array=cols[3])
+        c4=fits.Column(name=cols[4].name, format='PI()', array=cols[4])
+        c5=fits.Column(name=cols[5].name, format='PE()', array=cols[5])
 
-        hdu = fits.BinTableHDU.from_columns([c0, c1, c2, c3, c4, c5],
+        hdu=fits.BinTableHDU.from_columns([c0, c1, c2, c3, c4, c5],
                                             header=header, name=name)
 
-        ebounds = energy_axis_to_ebounds(self.e_reco)
-        prim_hdu = fits.PrimaryHDU()
+        ebounds=energy_axis_to_ebounds(self.data.axis('e_reco'))
+        prim_hdu=fits.PrimaryHDU()
 
         return fits.HDUList([prim_hdu, hdu, ebounds])
 
@@ -196,59 +230,63 @@ class EnergyDispersion(NDDataArray):
         The output table is in the OGIP RMF format.
         http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#Tab:1
         """
-        table = Table()
+        table=Table()
 
-        rows = self.pdf_matrix.shape[0]
-        n_grp = []
-        f_chan = np.ndarray(dtype=np.object, shape=rows)
-        n_chan = np.ndarray(dtype=np.object, shape=rows)
-        matrix = np.ndarray(dtype=np.object, shape=rows)
+        rows=self.pdf_matrix.shape[0]
+        n_grp=[]
+        f_chan=np.ndarray(dtype=np.object, shape=rows)
+        n_chan=np.ndarray(dtype=np.object, shape=rows)
+        matrix=np.ndarray(dtype=np.object, shape=rows)
 
         # Make RMF type matrix
-        for i, row in enumerate(self.data.value):
-            subsets = 1
-            pos = np.nonzero(row)[0]
-            borders = np.where(np.diff(pos) != 1)[0]
+        for i, row in enumerate(self.data.data.value):
+            subsets=1
+            pos=np.nonzero(row)[0]
+            borders=np.where(np.diff(pos) != 1)[0]
             # add 1 to borders for correct behaviour of np.split
-            groups = np.asarray(np.split(pos, borders + 1))
-            n_grp_temp = groups.shape[0] if groups.size > 0 else 1
-            n_chan_temp = np.asarray([val.size for val in groups])
+            groups=np.asarray(np.split(pos, borders + 1))
+            n_grp_temp=groups.shape[0] if groups.size > 0 else 1
+            n_chan_temp=np.asarray([val.size for val in groups])
             try:
-                f_chan_temp = np.asarray([val[0] for val in groups])
+                f_chan_temp=np.asarray([val[0] for val in groups])
             except(IndexError):
-                f_chan_temp = np.zeros(1)
+                f_chan_temp=np.zeros(1)
 
             n_grp.append(n_grp_temp)
-            f_chan[i] = f_chan_temp
-            n_chan[i] = n_chan_temp
-            matrix[i] = row[pos]
+            f_chan[i]=f_chan_temp
+            n_chan[i]=n_chan_temp
+            matrix[i]=row[pos]
 
-        table['ENERG_LO'] = self.e_true.data[:-1]
-        table['ENERG_HI'] = self.e_true.data[1:]
-        table['N_GRP'] = np.asarray(n_grp, dtype=np.int16)
-        table['F_CHAN'] = f_chan
-        table['N_CHAN'] = n_chan
-        table['MATRIX'] = matrix
+        table['ENERG_LO']=self.data.axis('e_true').data[:-1]
+        table['ENERG_HI']=self.data.axis('e_true').data[1:]
+        table['N_GRP']=np.asarray(n_grp, dtype=np.int16)
+        table['F_CHAN']=f_chan
+        table['N_CHAN']=n_chan
+        table['MATRIX']=matrix
 
         # Get total number of groups and channel subsets
-        numgrp, numelt = 0, 0
+        numgrp, numelt=0, 0
         for val, val2 in zip(table['N_GRP'], table['N_CHAN']):
             numgrp += np.sum(val)
             numelt += np.sum(val2)
 
-        meta = dict(name='MATRIX',
+        meta=dict(name='MATRIX',
                     chantype='PHA',
                     hduclass='OGIP',
                     hduclas1='RESPONSE',
                     hduclas2='RSP_MATRIX',
-                    detchans=self.e_reco.nbins,
+                    detchans=self.data.axis('e_reco').nbins,
                     numgrp=numgrp,
                     numelt=numelt,
                     tlmin4=0,
                     )
 
-        table.meta = meta
+        table.meta=meta
         return table
+
+    def write(self, filename, **kwargs):
+        filename = make_path(filename)
+        self.to_hdulist().writeto(str(filename), **kwargs)
 
     def get_resolution(self, e_true):
         """Get energy resolution for a fiven true energy
@@ -261,10 +299,10 @@ class EnergyDispersion(NDDataArray):
             True energy
         """
         # Variance is 2nd moment of PDF
-        pdf = self.evaluate(e_true=e_true)
-        mean = self._get_mean(e_true)
-        temp = (self.e_reco._interp_nodes() - mean) ** 2
-        var = np.sum(temp * pdf)
+        pdf=self.data.evaluate(e_true=e_true)
+        mean=self._get_mean(e_true)
+        temp=(self.data.axis('e_reco')._interp_nodes() - mean) ** 2
+        var=np.sum(temp * pdf)
         return np.sqrt(var)
 
     def get_bias(self, e_true):
@@ -281,18 +319,18 @@ class EnergyDispersion(NDDataArray):
         e_true : `~astropy.units.Quantity`
             True energy
         """
-        mean = self._get_mean(e_true)
-        e_reco = (10 ** mean) * self.e_reco.unit
-        bias = (e_true - e_reco) / e_true
+        mean=self._get_mean(e_true)
+        e_reco=(10 ** mean) * self.data.axis('e_reco').unit
+        bias=(e_true - e_reco) / e_true
         return bias
 
     def _get_mean(self, e_true):
         r"""Get mean log reconstructed energy
         """
         # Reconstructed energy is 1st moment of PDF
-        pdf = self.evaluate(e_true=e_true)
-        norm = np.sum(pdf)
-        temp = np.sum(pdf * self.e_reco._interp_nodes())
+        pdf=self.data.evaluate(e_true=e_true)
+        norm=np.sum(pdf)
+        temp=np.sum(pdf * self.data.axis('e_reco')._interp_nodes())
         return temp / norm
 
     def apply(self, data, e_reco=None):
@@ -317,10 +355,10 @@ class EnergyDispersion(NDDataArray):
             1-dim data array after multiplication with the energy dispersion matrix
         """
         if e_reco is None:
-            e_reco = self.e_reco.nodes
+            e_reco=self.data.axis('e_reco').nodes
         else:
-            e_reco = np.sqrt(e_reco[:-1] * e_reco[1:])
-        edisp_pdf = self.evaluate(e_reco=e_reco)
+            e_reco=np.sqrt(e_reco[:-1] * e_reco[1:])
+        edisp_pdf=self.data.evaluate(e_reco=e_reco)
         return np.dot(data, edisp_pdf)
 
     def _extent(self):
@@ -328,8 +366,8 @@ class EnergyDispersion(NDDataArray):
 
         x stands for true energy and y for reconstructed energy
         """
-        x = self.e_true.data[[0, -1]].value
-        y = self.e_reco.data[[0, -1]].value
+        x=self.data.axis('e_true').data[[0, -1]].value
+        y=self.data.axis('e_reco').data[[0, -1]].value
         return x[0], x[1], y[0], y[1]
 
     def plot_matrix(self, ax=None, show_energy=None, **kwargs):
@@ -355,12 +393,12 @@ class EnergyDispersion(NDDataArray):
         kwargs.setdefault('interpolation', 'nearest')
         kwargs.setdefault('norm', PowerNorm(gamma=0.5))
 
-        ax = plt.gca() if ax is None else ax
+        ax=plt.gca() if ax is None else ax
 
-        image = self.pdf_matrix.transpose()
+        image=self.pdf_matrix.transpose()
         ax.imshow(image, extent=self._extent(), **kwargs)
         if show_energy is not None:
-            ener_val = Quantity(show_energy).to(self.reco_energy.unit).value
+            ener_val=Quantity(show_energy).to(self.reco_energy.unit).value
             ax.hlines(ener_val, 0, 200200, linestyles='dashed')
 
         ax.set_xlabel('True energy (TeV)')
@@ -383,10 +421,10 @@ class EnergyDispersion(NDDataArray):
         """
         import matplotlib.pyplot as plt
 
-        ax = plt.gca() if ax is None else ax
+        ax=plt.gca() if ax is None else ax
 
-        x = self.e_true.nodes.to('TeV').value
-        y = self.get_bias(self.e_true.nodes)
+        x=self.data.axis('e_true').nodes.to('TeV').value
+        y=self.get_bias(self.data.axis('e_true').nodes)
 
         ax.plot(x, y, **kwargs)
         ax.set_xlabel('True energy [TeV]')
@@ -408,37 +446,37 @@ class EnergyDispersion(NDDataArray):
         # Need to modify RMF data
         # see https://github.com/sherpa/sherpa/blob/master/sherpa/astro/io/pyfits_backend.py#L727
 
-        table = self.to_table()
-        n_grp = table['N_GRP'].data.astype(SherpaUInt)
-        f_chan = table['F_CHAN'].data
-        f_chan = np.concatenate([row for row in f_chan]).astype(SherpaUInt)
-        n_chan = table['N_CHAN'].data
-        n_chan = np.concatenate([row for row in n_chan]).astype(SherpaUInt)
-        matrix = table['MATRIX'].data
+        table=self.to_table()
+        n_grp=table['N_GRP'].data.astype(SherpaUInt)
+        f_chan=table['F_CHAN'].data
+        f_chan=np.concatenate([row for row in f_chan]).astype(SherpaUInt)
+        n_chan=table['N_CHAN'].data
+        n_chan=np.concatenate([row for row in n_chan]).astype(SherpaUInt)
+        matrix=table['MATRIX'].data
 
-        good = n_grp > 0
-        matrix = matrix[good]
-        matrix = np.concatenate([row for row in matrix])
-        matrix = matrix.astype(SherpaFloat)
+        good=n_grp > 0
+        matrix=matrix[good]
+        matrix=np.concatenate([row for row in matrix])
+        matrix=matrix.astype(SherpaFloat)
 
         # TODO: Not sure if we need this if statement
         if f_chan.ndim > 1 and n_chan.ndim > 1:
-            f_chan = []
-            n_chan = []
+            f_chan=[]
+            n_chan=[]
             for grp, fch, nch, in izip(n_grp, f_chan, n_chan):
                 for i in xrange(grp):
                     f_chan.append(fch[i])
                     n_chan.append(nch[i])
 
-            f_chan = numpy.asarray(f_chan, SherpaUInt)
-            n_chan = numpy.asarray(n_chan, SherpaUInt)
+            f_chan=numpy.asarray(f_chan, SherpaUInt)
+            n_chan=numpy.asarray(n_chan, SherpaUInt)
         else:
             if len(n_grp) == len(f_chan):
-                good = n_grp > 0
-                f_chan = f_chan[good]
-                n_chan = n_chan[good]
+                good=n_grp > 0
+                f_chan=f_chan[good]
+                n_chan=n_chan[good]
 
-        kwargs = dict(
+        kwargs=dict(
             name=name,
             energ_lo=table['ENERG_LO'].quantity.to('keV').value.astype(SherpaFloat),
             energ_hi=table['ENERG_HI'].quantity.to('keV').value.astype(SherpaFloat),
@@ -446,9 +484,9 @@ class EnergyDispersion(NDDataArray):
             n_grp=n_grp,
             n_chan=n_chan,
             f_chan=f_chan,
-            detchans=self.e_reco.nbins,
-            e_min=self.e_reco.data[:-1].to('keV').value,
-            e_max=self.e_reco.data[1:].to('keV').value,
+            detchans=self.data.axis('e_reco').nbins,
+            e_min=self.data.axis('e_reco').data[:-1].to('keV').value,
+            e_max=self.data.axis('e_reco').data[1:].to('keV').value,
             offset=0,
         )
 
@@ -538,19 +576,19 @@ class EnergyDispersion2D(object):
         if not isinstance(offset_lo, Angle) or not isinstance(offset_hi, Angle):
             raise ValueError("Offsets must be Angle objects.")
 
-        self.migra_lo = migra_lo
-        self.migra_hi = migra_hi
-        self.offset_lo = offset_lo
-        self.offset_hi = offset_hi
-        self.dispersion = dispersion
+        self.migra_lo=migra_lo
+        self.migra_hi=migra_hi
+        self.offset_lo=offset_lo
+        self.offset_hi=offset_hi
+        self.dispersion=dispersion
 
-        self.ebounds = EnergyBounds.from_lower_and_upper_bounds(etrue_lo, etrue_hi)
-        self.energy = self.ebounds.log_centers
-        self.offset = (offset_hi + offset_lo) / 2
-        self.migra = (migra_hi + migra_lo) / 2
+        self.ebounds=EnergyBounds.from_lower_and_upper_bounds(etrue_lo, etrue_hi)
+        self.energy=self.ebounds.log_centers
+        self.offset=(offset_hi + offset_lo) / 2
+        self.migra=(migra_hi + migra_lo) / 2
 
         if not interp_kwargs:
-            interp_kwargs = dict(bounds_error=False, fill_value=0)
+            interp_kwargs=dict(bounds_error=False, fill_value=0)
 
         self._prepare_linear_interpolator(interp_kwargs)
 
@@ -564,15 +602,15 @@ class EnergyDispersion2D(object):
             ``ENERGY DISPERSION`` extension.
 
         """
-        data = hdu.data
-        header = hdu.header
-        e_lo = EnergyBounds(data['ETRUE_LO'].squeeze(), header['TUNIT1'])
-        e_hi = EnergyBounds(data['ETRUE_HI'].squeeze(), header['TUNIT2'])
-        o_lo = Angle(data['THETA_LO'].squeeze(), header['TUNIT5'])
-        o_hi = Angle(data['THETA_HI'].squeeze(), header['TUNIT6'])
-        m_lo = data['MIGRA_LO'].squeeze()
-        m_hi = data['MIGRA_HI'].squeeze()
-        matrix = data['MATRIX'].squeeze()
+        data=hdu.data
+        header=hdu.header
+        e_lo=EnergyBounds(data['ETRUE_LO'].squeeze(), header['TUNIT1'])
+        e_hi=EnergyBounds(data['ETRUE_HI'].squeeze(), header['TUNIT2'])
+        o_lo=Angle(data['THETA_LO'].squeeze(), header['TUNIT5'])
+        o_hi=Angle(data['THETA_HI'].squeeze(), header['TUNIT6'])
+        m_lo=data['MIGRA_LO'].squeeze()
+        m_hi=data['MIGRA_HI'].squeeze()
+        matrix=data['MATRIX'].squeeze()
 
         return cls(e_lo, e_hi, m_lo, m_hi, o_lo, o_hi, matrix)
 
@@ -587,9 +625,9 @@ class EnergyDispersion2D(object):
         filename : str
             File name
         """
-        filename = make_path(filename)
-        hdulist = fits.open(str(filename))
-        hdu = hdulist[hdu]
+        filename=make_path(filename)
+        hdulist=fits.open(str(filename))
+        hdu=hdulist[hdu]
         return cls.from_fits(hdu)
 
     def evaluate(self, offset=None, e_true=None, migra=None):
@@ -605,26 +643,26 @@ class EnergyDispersion2D(object):
             Offset
         """
 
-        offset = self.offset if offset is None else Angle(offset)
-        e_true = self.energy if e_true is None else Energy(e_true)
-        migra = self.migra if migra is None else migra
+        offset=self.offset if offset is None else Angle(offset)
+        e_true=self.energy if e_true is None else Energy(e_true)
+        migra=self.migra if migra is None else migra
 
-        offset = offset.to('deg')
-        e_true = e_true.to('TeV')
+        offset=offset.to('deg')
+        e_true=e_true.to('TeV')
 
-        val = self._eval(offset=offset, e_true=e_true, migra=migra)
+        val=self._eval(offset=offset, e_true=e_true, migra=migra)
 
         return val
 
     def _eval(self, offset=None, e_true=None, migra=None):
 
-        x = np.atleast_1d(offset.value)
-        y = np.atleast_1d(migra)
-        z = np.atleast_1d(np.log10(e_true.value))
-        in_shape = (x.size, y.size, z.size)
+        x=np.atleast_1d(offset.value)
+        y=np.atleast_1d(migra)
+        z=np.atleast_1d(np.log10(e_true.value))
+        in_shape=(x.size, y.size, z.size)
 
-        pts = [[xx, yy, zz] for xx in x for yy in y for zz in z]
-        val_array = self._linear(pts)
+        pts=[[xx, yy, zz] for xx in x for yy in y for zz in z]
+        val_array=self._linear(pts)
 
         return val_array.reshape(in_shape).squeeze()
 
@@ -648,17 +686,17 @@ class EnergyDispersion2D(object):
         edisp : `~gammapy.irf.EnergyDispersion`
             Energy disperion matrix
         """
-        offset = Angle(offset)
-        e_true = self.ebounds if e_true is None else EnergyBounds(e_true)
-        e_reco = self.ebounds if e_reco is None else EnergyBounds(e_reco)
+        offset=Angle(offset)
+        e_true=self.ebounds if e_true is None else EnergyBounds(e_true)
+        e_reco=self.ebounds if e_reco is None else EnergyBounds(e_reco)
 
-        rm = []
+        rm=[]
 
         for energy in e_true.log_centers:
-            vec = self.get_response(offset=offset, e_true=energy, e_reco=e_reco)
+            vec=self.get_response(offset=offset, e_true=energy, e_reco=e_reco)
             rm.append(vec)
 
-        rm = np.asarray(rm)
+        rm=np.asarray(rm)
         return EnergyDispersion(data=rm, e_true=e_true, e_reco=e_reco)
 
     def get_response(self, offset, e_true, e_reco=None):
@@ -682,31 +720,31 @@ class EnergyDispersion2D(object):
             Redistribution vector
         """
 
-        e_true = Energy(e_true)
+        e_true=Energy(e_true)
 
         # Default: e_reco nodes = migra nodes * e_true nodes
         if e_reco is None:
-            e_reco = EnergyBounds.from_lower_and_upper_bounds(
+            e_reco=EnergyBounds.from_lower_and_upper_bounds(
                 self.migra_lo * e_true, self.migra_hi * e_true)
-            migra = self.migra
+            migra=self.migra
 
         # Translate given e_reco binning to migra at bin center
         else:
-            e_reco = EnergyBounds(e_reco)
-            center = e_reco.log_centers
-            migra = center / e_true
+            e_reco=EnergyBounds(e_reco)
+            center=e_reco.log_centers
+            migra=center / e_true
 
         # ensure to have a normalized edisp
-        migra_bin = self.migra_hi - self.migra_lo
+        migra_bin=self.migra_hi - self.migra_lo
         if (migra_bin[0] == migra_bin[1]):
-            migra_mean = 1 / 2. * (self.migra_hi + self.migra_lo)
+            migra_mean=1 / 2. * (self.migra_hi + self.migra_lo)
         else:
-            migra_mean = np.sqrt(self.migra_hi * self.migra_lo)
-        val_norm = self.evaluate(offset=offset, e_true=e_true, migra=migra_mean)
-        norm = np.sum(val_norm * migra_bin)
+            migra_mean=np.sqrt(self.migra_hi * self.migra_lo)
+        val_norm=self.evaluate(offset=offset, e_true=e_true, migra=migra_mean)
+        norm=np.sum(val_norm * migra_bin)
 
-        migra_e_reco = e_reco / e_true
-        integral = np.zeros(len(e_reco) - 1)
+        migra_e_reco=e_reco / e_true
+        integral=np.zeros(len(e_reco) - 1)
         if norm != 0:
             for i, migra_int in enumerate(migra_e_reco[:-1]):
                 # The migra_e_reco bin is inferior to the migra min in the dispersion fits file
@@ -717,30 +755,30 @@ class EnergyDispersion2D(object):
                     continue
                 else:
                     if migra_e_reco[i] < migra_mean[0]:
-                        i_min = 0
+                        i_min=0
                     else:
-                        i_min = np.where(migra_mean < migra_e_reco[i])[0][-1]
-                    i_max = np.where(migra_mean < migra_e_reco[i + 1])[0][-1]
+                        i_min=np.where(migra_mean < migra_e_reco[i])[0][-1]
+                    i_max=np.where(migra_mean < migra_e_reco[i + 1])[0][-1]
 
-                    migra_bin_reco = migra_bin[i_min + 1:i_max]
+                    migra_bin_reco=migra_bin[i_min + 1:i_max]
                     if migra_e_reco[i + 1] > migra_mean[-1]:
-                        index = np.arange(i_min, i_max, 1)
-                        migra_bin_reco = np.insert(migra_bin_reco, 0, (migra_mean[i_min + 1] - migra_e_reco[i]))
+                        index=np.arange(i_min, i_max, 1)
+                        migra_bin_reco=np.insert(migra_bin_reco, 0, (migra_mean[i_min + 1] - migra_e_reco[i]))
                     elif migra_e_reco[i] < migra_mean[0]:
                         if i_max == 0:
-                            index = np.arange(i_min, i_max + 1, 1)
+                            index=np.arange(i_min, i_max + 1, 1)
                         else:
-                            index = np.arange(i_min + 1, i_max + 1, 1)
-                        migra_bin_reco = np.append(migra_bin_reco, migra_e_reco[i + 1] - migra_mean[i_max])
+                            index=np.arange(i_min + 1, i_max + 1, 1)
+                        migra_bin_reco=np.append(migra_bin_reco, migra_e_reco[i + 1] - migra_mean[i_max])
                     elif i_min == i_max:
-                        index = np.arange(i_min, i_max + 1, 1)
-                        migra_bin_reco = np.insert(migra_bin_reco, 0, (migra_e_reco[i + 1] - migra_e_reco[i]))
+                        index=np.arange(i_min, i_max + 1, 1)
+                        migra_bin_reco=np.insert(migra_bin_reco, 0, (migra_e_reco[i + 1] - migra_e_reco[i]))
                     else:
-                        index = np.arange(i_min, i_max + 1, 1)
-                        migra_bin_reco = np.insert(migra_bin_reco, 0, (migra_mean[i_min + 1] - migra_e_reco[i]))
-                        migra_bin_reco = np.append(migra_bin_reco, migra_e_reco[i + 1] - migra_mean[i_max])
-                    val = self.evaluate(offset=offset, e_true=e_true, migra=migra_mean[index])
-                    integral[i] = np.sum(val * migra_bin_reco) / norm
+                        index=np.arange(i_min, i_max + 1, 1)
+                        migra_bin_reco=np.insert(migra_bin_reco, 0, (migra_mean[i_min + 1] - migra_e_reco[i]))
+                        migra_bin_reco=np.append(migra_bin_reco, migra_e_reco[i + 1] - migra_mean[i_max])
+                    val=self.evaluate(offset=offset, e_true=e_true, migra=migra_mean[index])
+                    integral[i]=np.sum(val * migra_bin_reco) / norm
         return integral
 
     def plot_migration(self, ax=None, offset=None, e_true=None,
@@ -765,22 +803,22 @@ class EnergyDispersion2D(object):
         """
         import matplotlib.pyplot as plt
 
-        ax = plt.gca() if ax is None else ax
+        ax=plt.gca() if ax is None else ax
 
         if offset is None:
-            offset = Angle([1], 'deg')
+            offset=Angle([1], 'deg')
         else:
-            offset = np.atleast_1d(Angle(offset))
+            offset=np.atleast_1d(Angle(offset))
         if e_true is None:
-            e_true = Energy([0.1, 1, 10], 'TeV')
+            e_true=Energy([0.1, 1, 10], 'TeV')
         else:
-            e_true = np.atleast_1d(Energy(e_true))
-        migra = self.migra if migra is None else migra
+            e_true=np.atleast_1d(Energy(e_true))
+        migra=self.migra if migra is None else migra
 
         for ener in e_true:
             for off in offset:
-                disp = self.evaluate(offset=off, e_true=ener, migra=migra)
-                label = 'offset = {0:.1f}\nenergy = {1:.1f}'.format(off, ener)
+                disp=self.evaluate(offset=off, e_true=ener, migra=migra)
+                label='offset = {0:.1f}\nenergy = {1:.1f}'.format(off, ener)
                 ax.plot(migra, disp, label=label, **kwargs)
 
         ax.set_xlabel('E_Reco / E_True')
@@ -815,18 +853,18 @@ class EnergyDispersion2D(object):
         kwargs.setdefault('cmap', 'afmhot')
         kwargs.setdefault('norm', PowerNorm(gamma=0.5))
 
-        ax = plt.gca() if ax is None else ax
+        ax=plt.gca() if ax is None else ax
 
         if offset is None:
-            offset = Angle([1], 'deg')
+            offset=Angle([1], 'deg')
         if e_true is None:
-            e_true = self.energy
+            e_true=self.energy
         if migra is None:
-            migra = self.migra
+            migra=self.migra
 
-        z = self.evaluate(offset=offset, e_true=e_true, migra=migra)
-        x = e_true.value
-        y = migra
+        z=self.evaluate(offset=offset, e_true=e_true, migra=migra)
+        x=e_true.value
+        y=migra
 
         ax.pcolor(x, y, z, **kwargs)
         ax.semilogx()
@@ -844,10 +882,10 @@ class EnergyDispersion2D(object):
             Size of the resulting plot
         """
         import matplotlib.pyplot as plt
-        fig, axes = plt.subplots(nrows=1, ncols=3, figsize=figsize)
+        fig, axes=plt.subplots(nrows=1, ncols=3, figsize=figsize)
         self.plot_bias(ax=axes[0])
         self.plot_migration(ax=axes[1])
-        edisp = self.to_energy_dispersion(offset='1 deg')
+        edisp=self.to_energy_dispersion(offset='1 deg')
         edisp.plot_matrix(ax=axes[2])
 
         plt.tight_layout()
@@ -857,18 +895,18 @@ class EnergyDispersion2D(object):
     def _prepare_linear_interpolator(self, interp_kwargs):
         from scipy.interpolate import RegularGridInterpolator
 
-        x = self.offset
-        y = self.migra
-        z = np.log10(self.energy.value)
-        points = (x, y, z)
-        values = self.dispersion
+        x=self.offset
+        y=self.migra
+        z=np.log10(self.energy.value)
+        points=(x, y, z)
+        values=self.dispersion
 
-        self._linear = RegularGridInterpolator(points, values, **interp_kwargs)
+        self._linear=RegularGridInterpolator(points, values, **interp_kwargs)
 
     def info(self):
         """Print some basic info.
         """
-        ss = "\nSummary EnergyDispersion2D info\n"
+        ss="\nSummary EnergyDispersion2D info\n"
         ss += "--------------------------------\n"
         # Summarise data members
         ss += array_stats_str(self.energy, 'energy')
@@ -876,10 +914,10 @@ class EnergyDispersion2D(object):
         ss += array_stats_str(self.migra, 'migra')
         ss += array_stats_str(self.dispersion, 'dispersion')
 
-        energy = Energy('1 TeV')
-        e_reco = EnergyBounds([0.8, 1.2], 'TeV')
-        offset = Angle('0.5 deg')
-        p = self.get_response(offset, energy, e_reco)[0]
+        energy=Energy('1 TeV')
+        e_reco=EnergyBounds([0.8, 1.2], 'TeV')
+        offset=Angle('0.5 deg')
+        p=self.get_response(offset, energy, e_reco)[0]
 
         ss += 'Probability to reconstruct a {} photon in the range {} at {}' \
               ' offset: {:.2f}'.format(energy, e_reco, offset, p)

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -72,13 +72,15 @@ class IRFStacker(object):
         livetime_tot = np.sum(self.list_livetime)
 
         for i, aeff in enumerate(self.list_aeff):
-            aeff_data = aeff.evaluate(fill_nan=True)
+            aeff_data = aeff.evaluate_fill_nan()
             aefft_current = aeff_data * self.list_livetime[i]
             aefft += aefft_current
 
         stacked_data = aefft / livetime_tot
-        self.stacked_aeff = EffectiveAreaTable(energy=self.list_aeff[0].energy,
-                                               data=stacked_data.to('cm2'))
+        self.stacked_aeff = EffectiveAreaTable(
+            energy=self.list_aeff[0].energy.data,
+            data=stacked_data.to('cm2')
+        )
 
     def stack_edisp(self):
         """
@@ -92,7 +94,7 @@ class IRFStacker(object):
         aefftedisp = Quantity(temp, 'cm2 s')
 
         for i, edisp in enumerate(self.list_edisp):
-            aeff_data = self.list_aeff[i].evaluate(fill_nan=True)
+            aeff_data = self.list_aeff[i].evaluate_fill_nan()
             aefft_current = aeff_data * self.list_livetime[i]
             aefft += aefft_current
             edisp_data = edisp.pdf_in_safe_range(self.list_low_threshold[i],
@@ -101,6 +103,7 @@ class IRFStacker(object):
             aefftedisp += edisp_data.transpose() * aefft_current
 
         stacked_edisp = np.nan_to_num(aefftedisp / aefft)
-        self.stacked_edisp = EnergyDispersion(e_true=self.list_edisp[0].e_true,
-                                              e_reco=self.list_edisp[0].e_reco,
-                                              data=stacked_edisp.transpose())
+        self.stacked_edisp = EnergyDispersion(
+            e_true=self.list_edisp[0].e_true.data,
+            e_reco=self.list_edisp[0].e_reco.data,
+            data=stacked_edisp.transpose())

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -17,11 +17,11 @@ def test_EffectiveAreaTable2D(tmpdir):
         'datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz')
     aeff = EffectiveAreaTable2D.read(filename, hdu='AEFF_2D')
 
-    assert aeff.data.axis('energy').nbins == 73
+    assert aeff.energy.nbins == 73
     assert aeff.data.axis('offset').nbins == 6
     assert aeff.data.data.shape == (73, 6)
 
-    assert aeff.data.axis('energy').unit == 'TeV'
+    assert aeff.energy.unit == 'TeV'
     assert aeff.data.axis('offset').unit == 'deg'
     assert aeff.data.data.unit == 'm2'
 
@@ -80,7 +80,7 @@ def test_EffectiveAreaTable(tmpdir, data_manager):
 
     test_aeff = 0.6 * arf.max_area
     node_above = np.where(arf.data.data > test_aeff)[0][0]
-    energy = arf.data.axis('energy')
+    energy = arf.energy
     ener_above = energy.nodes[node_above]
     ener_below = energy.nodes[node_above - 1]
     test_ener = arf.find_energy(test_aeff)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -21,7 +21,7 @@ def test_EnergyDispersion():
 
     test_e = 3.34 * u.TeV
     # Check for correct normalization
-    test_pdf = edisp.evaluate(e_true=test_e)
+    test_pdf = edisp.data.evaluate(e_true=test_e)
     assert_allclose(np.sum(test_pdf), 1, atol=1e-4)
     # Check bias
     assert_allclose(edisp.get_bias(test_e), 0, atol=1e-4)

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -50,7 +50,7 @@ class FitsProductionTester:
 
     def test_aeff(self):
         aeff = self.obs.load(hdu_type='aeff', hdu_class='aeff_2d')
-        actual = aeff.evaluate(energy=self.ref_energy, offset=self.ref_theta)
+        actual = aeff.data.evaluate(energy=self.ref_energy, offset=self.ref_theta)
         desired = self.ref_dict['aeff_ref']
         assert_quantity_allclose(actual, desired)
 

--- a/gammapy/scripts/image_pipe.py
+++ b/gammapy/scripts/image_pipe.py
@@ -131,7 +131,7 @@ class SingleObsImageMaker(object):
         eref = EnergyBounds(self.energy_band).log_centers
         spectrum = (energy_bin / eref) ** (-spectral_index)
         offset = Angle(np.linspace(self.offset_band[0].value, self.offset_band[1].value, 10), self.offset_band.unit)
-        arf = self.aeff.evaluate(offset=offset, energy=energy_bin).T
+        arf = self.aeff.data.evaluate(offset=offset, energy=energy_bin).T
         npred = np.sum(arf * spectrum * energy_band, axis=1)
         npred *= self.livetime
 

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -17,7 +17,7 @@ def test_cta_irf():
     offset = Quantity(3, 'deg')
     migra = 1
 
-    val = irf.aeff.evaluate(energy=energy, offset=offset)
+    val = irf.aeff.data.evaluate(energy=energy, offset=offset)
     assert_quantity_allclose(val, Quantity(247996.974414962, 'm^2'))
 
     val = irf.edisp.evaluate(offset=offset, e_true=energy, migra=migra)
@@ -43,7 +43,8 @@ CTA-Performance-South-20150511/CTA-Performance-South-50h_20150511.fits'
     cta_perf = CTAPerf.read(filename)
     cta_perf.peek()
     
-    
+ 
+# TODO: Remove?
 if __name__ == '__main__':
     test_cta_irf()
     test_point_like_perf()

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -22,15 +22,15 @@ __all__ = [
 ]
 
 
-class CountsSpectrum(NDDataArray):
+class CountsSpectrum(object):
     """Generic counts spectrum
 
     Parameters
     ----------
-    data : `~astropy.units.Quantity`, array-like
-        Counts
     energy : `~gammapy.utils.energy.EnergyBounds`
         Bin edges of energy axis
+    data : `~astropy.units.Quantity`, array-like
+        Counts
 
     Examples
     --------
@@ -46,16 +46,13 @@ class CountsSpectrum(NDDataArray):
         spec = CountsSpectrum(data=counts, energy=ebounds)
         spec.plot(show_poisson_errors=True)
     """
-    energy = BinnedDataAxis(interpolation_mode='log')
-    """Energy axis"""
-    axis_names = ['energy']
-    # Use nearest neighbour interpolation for counts
-    interp_kwargs = dict(bounds_error=False, method='nearest')
+    default_interp_kwargs = dict(bounds_error=False, method='nearest')
+    """Default interpolation kwargs"""
 
-    def __init__(self, **kwargs):
-        # Special case this to set data unit to counts for coherence
-        if 'data' in kwargs.keys():
-            data = kwargs['data']
+    def __init__(self, energy, data=None, interp_kwargs=None):
+        axes = [BinnedDataAxis(energy, interpolation_mode='log', name='energy')]
+        # Set data unit to counts for coherence
+        if data is not None:
             if isinstance(data, u.Quantity):
                 if data.unit.is_equivalent('ct'):
                     pass
@@ -63,28 +60,42 @@ class CountsSpectrum(NDDataArray):
                     data = data.value
                 else:
                     raise ValueError('Invalid data unit {}'.format(data.unit))
-            kwargs['data'] = u.Quantity(data, 'ct')
+            data = u.Quantity(data, 'ct')
 
-        self = super(CountsSpectrum, self).__init__(**kwargs)        
+        if interp_kwargs is None:
+            interp_kwargs = self.default_interp_kwargs
+        self.data = NDDataArray(axes=axes, data=data, interp_kwargs=interp_kwargs)
 
     @classmethod
-    def from_hdulist(cls, hdulist):
+    def from_hdulist(cls, hdulist, hdu1='COUNTS', hdu2='EBOUNDS'):
         """Read OGIP format hdulist"""
-        counts_table = fits_table_to_table(hdulist[1])
-        counts = counts_table['COUNTS'] * u.ct
-        ebounds = ebounds_to_energy_axis(hdulist[2])
+        counts_table = fits_table_to_table(hdulist[hdu1])
+        counts = counts_table['COUNTS'].data
+        ebounds = ebounds_to_energy_axis(hdulist[hdu2])
         return cls(data=counts, energy=ebounds)
+
+    @classmethod
+    def read(cls, filename, hdu1='COUNTS', hdu2='EBOUNDS', **kwargs):
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename), **kwargs)
+        try:
+            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
+        except KeyError:
+            msg = 'File {} does not contain HDUs "{}"'.format(
+                filename, [hdu1, hdu2])
+            msg += '\n Available {}'.format([_.name for _ in hdulist])
+            raise ValueError(msg)
 
     def to_table(self):
         """Convert to `~astropy.table.Table`
 
         http://gamma-astro-data-formats.readthedocs.io/en/latest/ogip/index.html
         """
-        channel = np.arange(self.energy.nbins, dtype=np.int16)
-        counts = np.array(self.data.value, dtype=np.int32)
+        channel = np.arange(self.data.axis('energy').nbins, dtype=np.int16)
+        counts = np.array(self.data.data.value, dtype=np.int32)
 
         names = ['CHANNEL', 'COUNTS']
-        meta = dict()
+        meta = dict(name='COUNTS')
         return Table([channel, counts], names=names, meta=meta)
 
     def to_hdulist(self):
@@ -93,10 +104,14 @@ class CountsSpectrum(NDDataArray):
         This adds an ``EBOUNDS`` extension to the ``BinTableHDU`` produced by
         ``to_table``, in order to store the energy axis
         """
-        hdulist = super(CountsSpectrum, self).to_hdulist()
-        ebounds = energy_axis_to_ebounds(self.energy)
-        hdulist.append(ebounds)
-        return hdulist
+        hdu = table_to_fits_table(self.to_table())
+        prim_hdu = fits.PrimaryHDU()
+        ebounds = energy_axis_to_ebounds(self.data.axis('energy').data)
+        return fits.HDUList([prim_hdu, hdu, ebounds])
+
+    def write(self, filename, **kwargs):
+        filename = make_path(filename)
+        self.to_hdulist().writeto(str(filename), **kwargs)
 
     def fill(self, events):
         """Fill with list of events
@@ -106,19 +121,18 @@ class CountsSpectrum(NDDataArray):
         events: `~astropy.units.Quantity`, `gammapy.data.EventList`,
             List of event energies
         """
-
         if isinstance(events, EventList):
             events = events.energy
 
-        energy = events.to(self.energy.unit)
-        binned_val = np.histogram(energy.value, self.energy.data.value)[0]
-        self.data = binned_val * u.ct
+        energy = events.to(self.data.axis('energy').unit)
+        binned_val = np.histogram(energy.value, self.data.axis('energy').data.value)[0]
+        self.data.data = binned_val * u.ct
 
     @property
     def total_counts(self):
         """Total number of counts
         """
-        return self.data.sum()
+        return self.data.data.sum()
 
     def plot(self, ax=None, energy_unit='TeV', show_poisson_errors=False,
              show_energy=None, **kwargs):
@@ -145,21 +159,21 @@ class CountsSpectrum(NDDataArray):
         import matplotlib.pyplot as plt
 
         ax = plt.gca() if ax is None else ax
-        counts = self.data.value
-        x = self.energy.nodes.to(energy_unit).value
-        bounds = self.energy.data.to(energy_unit).value
+        counts = self.data.data.value
+        x = self.data.axis('energy').nodes.to(energy_unit).value
+        bounds = self.data.axis('energy').data.to(energy_unit).value
         xerr = [x - bounds[:-1], bounds[1:] - x]
         yerr = np.sqrt(counts) if show_poisson_errors else 0
         kwargs.setdefault('fmt', '')
         ax.errorbar(x, counts, xerr=xerr, yerr=yerr, **kwargs)
         if show_energy is not None:
             ener_val = u.Quantity(show_energy).to(energy_unit).value
-            ax.vlines(ener_val, 0, 1.1 * max(self.data.value),
+            ax.vlines(ener_val, 0, 1.1 * max(self.data.data.value),
                       linestyles='dashed')
         ax.set_xlabel('Energy [{0}]'.format(energy_unit))
         ax.set_ylabel('Counts')
         ax.set_xscale('log')
-        ax.set_ylim(0, 1.2 * max(self.data.value))
+        ax.set_ylim(0, 1.2 * max(self.data.data.value))
         return ax
 
     def plot_hist(self, ax=None, energy_unit='TeV', show_energy=None, **kwargs):
@@ -181,13 +195,13 @@ class CountsSpectrum(NDDataArray):
         ax = plt.gca() if ax is None else ax
         kwargs.setdefault('lw', 2)
         kwargs.setdefault('histtype', 'step')
-        weights = self.data.value
-        bins = self.energy.data.to(energy_unit).value[:-1]
-        x = self.energy.nodes.to(energy_unit).value
+        weights = self.data.data.value
+        bins = self.data.axis('energy').data.to(energy_unit).value[:-1]
+        x = self.data.axis('energy').nodes.to(energy_unit).value
         ax.hist(x, bins=bins, weights=weights, **kwargs)
         if show_energy is not None:
             ener_val = u.Quantity(show_energy).to(energy_unit).value
-            ax.vlines(ener_val, 0, 1.1 * max(self.data.value),
+            ax.vlines(ener_val, 0, 1.1 * max(self.data.data.value),
                       linestyles='dashed')
         ax.set_xlabel('Energy [{0}]'.format(energy_unit))
         ax.set_ylabel('Counts')
@@ -254,17 +268,18 @@ class CountsSpectrum(NDDataArray):
         rebinned_spectrum : `~gammapy.spectrum.CountsSpectrum`
             Rebinned spectrum
         """
-        if len(self.data) % parameter != 0:
+        if len(self.data.data) % parameter != 0:
             raise ValueError("Invalid rebin parameter: {}, nbins: {}".format(
-                parameter, len(self.data)))
+                parameter, len(self.data.data)))
 
         # Copy to keep attributes
         retval = self.copy()
-        retval.energy.data = retval.energy.data[0::parameter]
-        split_indices = np.arange(parameter, len(retval.data), parameter)
-        counts_grp = np.split(retval.data, split_indices)
+        energy = retval.data.axis('energy')
+        energy.data = energy.data[0::parameter]
+        split_indices = np.arange(parameter, len(retval.data.data), parameter)
+        counts_grp = np.split(retval.data.data, split_indices)
         counts_rebinned = np.sum(counts_grp, axis=1)
-        retval.data = counts_rebinned * u.ct
+        retval.data.data = counts_rebinned * u.ct
 
         return retval
 
@@ -276,22 +291,24 @@ class PHACountsSpectrum(CountsSpectrum):
     background estimate or not (this slightly affectes the FITS header
     information when writing to disk).
 
+    TODO: Bundle optional parameters as meta
+
     Parameters
     ----------
     data : `~numpy.array`, list
         Counts
     energy : `~astropy.units.Quantity`
         Bin edges of energy axis
-    obs_id : int
-        Unique identifier
-    livetime : `~astropy.units.Quantity`
-        Observation live time
-    backscal : float, array-like
-        Scaling factor for each bin
+    obs_id : int, optional
+    Unique identifier, default: 0
     quality : int, array-lik
         Mask bins in safe energy range (1 = bad, 0 = good)
     is_bkg : bool, optional
         Background or soure spectrum, default: False
+    livetime : `~astropy.units.Quantity`
+        Observation live time
+    backscal : float, array-like
+        Scaling factor for each bin
     telescope : str, optional
         Mission name
     instrument : str, optional
@@ -308,12 +325,14 @@ class PHACountsSpectrum(CountsSpectrum):
         Zenith Angle
     """
 
-    def __init__(self, **kwargs):
-        kwargs.setdefault('is_bkg', False)
-        kwargs.setdefault('quality', None)
-        super(PHACountsSpectrum, self).__init__(**kwargs)
-        if self.quality is None:
-            self.quality = np.zeros(self.energy.nbins, dtype=int)
+    def __init__(self, energy, data, obs_id=0, quality=None, is_bkg=False,
+                 **kwargs):
+        super(PHACountsSpectrum, self).__init__(energy, data)
+        self.obs_id=obs_id
+        if quality is None:
+            quality = np.zeros(self.data.axis('energy').nbins, dtype=int)
+        self.quality = quality
+        self.is_bkg = is_bkg
 
     @property
     def phafile(self):
@@ -344,7 +363,7 @@ class PHACountsSpectrum(CountsSpectrum):
     @property
     def counts_in_safe_range(self):
         """Counts with bins outside safe range set to 0"""
-        data = self.data.copy()
+        data = self.data.data.copy()
         data[np.nonzero(self.quality)] = 0
         return data
 
@@ -352,22 +371,22 @@ class PHACountsSpectrum(CountsSpectrum):
     def lo_threshold(self):
         """Low energy threshold of the observation (lower bin edge)"""
         idx = self.bins_in_safe_range[0]
-        return self.energy.data[idx]
+        return self.data.axis('energy').data[idx]
 
     @lo_threshold.setter
     def lo_threshold(self, thres):
-        idx = np.where(self.energy.data < thres)[0]
+        idx = np.where(self.data.axis('energy').data < thres)[0]
         self.quality[idx] = 1
 
     @property
     def hi_threshold(self):
         """High energy threshold of the observation (upper bin edge)"""
         idx = self.bins_in_safe_range[-1]
-        return self.energy.data[idx + 1]
+        return self.data.axis('energy').data[idx + 1]
 
     @hi_threshold.setter
     def hi_threshold(self, thres):
-        idx = np.where(self.energy.data[:-1] > thres)[0]
+        idx = np.where(self.data.axis('energy').data[:-1] > thres)[0]
         if len(idx) != 0:
             idx = np.insert(idx, 0, idx[0] - 1)
         self.quality[idx] = 1
@@ -379,14 +398,14 @@ class PHACountsSpectrum(CountsSpectrum):
         quality vector correctly
         """
         retval = super(PHACountsSpectrum, self).rebin(parameter)
-        split_indices = np.arange(parameter, len(self.data), parameter)
+        split_indices = np.arange(parameter, len(self.data.data), parameter)
         quality_grp = np.split(retval.quality, split_indices)
         quality_summed = np.sum(quality_grp, axis=1)
         # Exclude groups where not all bins are within the safe threshold
         condition = (quality_summed == parameter)
         quality_rebinned = np.where(condition,
-                                    np.ones(len(retval.data)),
-                                    np.zeros(len(retval.data)))
+                                    np.ones(len(retval.data.data)),
+                                    np.zeros(len(retval.data.data)))
         retval.quality = np.array(quality_rebinned, dtype=int)
         return retval
 
@@ -394,7 +413,7 @@ class PHACountsSpectrum(CountsSpectrum):
     def _backscal_array(self):
         """Helper function to always return backscal as an array"""
         if np.isscalar(self.backscal):
-            return np.ones(self.energy.nbins) * self.backscal
+            return np.ones(self.data.axis('energy').nbins) * self.backscal
         else:
             return self.backscal
 
@@ -413,7 +432,7 @@ class PHACountsSpectrum(CountsSpectrum):
                     corrscal='',
                     areascal=1,
                     chantype='PHA',
-                    detchans=self.energy.nbins,
+                    detchans=self.data.axis('energy').nbins,
                     filter='None',
                     corrfile='',
                     poisserr=True,
@@ -453,12 +472,12 @@ class PHACountsSpectrum(CountsSpectrum):
         return table
 
     @classmethod
-    def from_hdulist(cls, hdulist):
+    def from_hdulist(cls, hdulist, hdu1='SPECTRUM', hdu2='EBOUNDS'):
         """Read"""
-        counts_table = fits_table_to_table(hdulist[1])
+        counts_table = fits_table_to_table(hdulist[hdu1])
         kwargs = dict(
             data=counts_table['COUNTS'] * u.ct,
-            energy=ebounds_to_energy_axis(hdulist[2]),
+            energy=ebounds_to_energy_axis(hdulist[hdu2]),
             backscal=counts_table['BACKSCAL'].data,
             quality=counts_table['QUALITY'].data,
             obs_id=hdulist[1].header['OBS_ID'],
@@ -467,6 +486,18 @@ class PHACountsSpectrum(CountsSpectrum):
         if hdulist[1].header['HDUCLAS2'] == 'BKG':
             kwargs.update(is_bkg=True)
         return cls(**kwargs)
+
+    @classmethod
+    def read(cls, filename, hdu1='SPECTRUM', hdu2='EBOUNDS', **kwargs):
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename), **kwargs)
+        try:
+            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
+        except KeyError:
+            msg = 'File {} does not contain HDUs "{}"'.format(
+                filename, [hdu1, hdu2])
+            msg += '\n Available {}'.format([_.name for _ in hdulist])
+            raise ValueError(msg)
 
     def to_sherpa(self, name):
         """Return `~sherpa.astro.data.DataPHA`

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -193,7 +193,7 @@ class SpectrumExtraction(object):
                 counts_kwargs.update(zen_pnt=obs.pointing_zen)
             except KeyError:
                 pass
-
+            
             on_vec = PHACountsSpectrum(backscal=bkg.a_on, **counts_kwargs)
             off_vec = PHACountsSpectrum(backscal=bkg.a_off, is_bkg=True,
                                         **counts_kwargs)
@@ -223,7 +223,7 @@ class SpectrumExtraction(object):
                         # TODO: Why is this necessary?
                         correction = np.nan
 
-                    arf.data[index] = arf.data[index] * correction
+                    arf.data.data[index] = arf.data.data[index] * correction
 
             temp = SpectrumObservation(on_vector=on_vec,
                                        aeff=arf,

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -153,7 +153,7 @@ class SpectrumObservation(object):
         average value for alpha.
         """
         energy = self.off_vector.energy
-        data = self.off_vector.data * self.alpha
+        data = self.off_vector.data.data * self.alpha
         return CountsSpectrum(data=data, energy=energy)
 
     @property
@@ -205,7 +205,7 @@ class SpectrumObservation(object):
             Stats
         """ 
         if self.off_vector is not None:
-            n_off = int(self.off_vector.data.value[idx])
+            n_off = int(self.off_vector.data.data.value[idx])
             a_off = self.off_vector._backscal_array[idx]
         else:
             n_off = 0
@@ -214,7 +214,7 @@ class SpectrumObservation(object):
         return SpectrumStats(
             energy_min=self.e_reco[idx],
             energy_max=self.e_reco[idx + 1],
-            n_on=int(self.on_vector.data.value[idx]),
+            n_on=int(self.on_vector.data.data.value[idx]),
             n_off=n_off,
             a_on=self.on_vector._backscal_array[idx],
             a_off=a_off,
@@ -654,7 +654,7 @@ class SpectrumObservationStacker(object):
                                             spec.quality)
 
         stacked_spectrum = PHACountsSpectrum(data=stacked_data,
-                                             energy=energy,
+                                             energy=energy.data,
                                              quality=stacked_quality)
         return stacked_spectrum
 
@@ -672,13 +672,13 @@ class SpectrumObservationStacker(object):
             bkscal_off_data = o.off_vector._backscal_array.copy()
             bkscal_off += bkscal_off_data * o.off_vector.counts_in_safe_range
 
-        stacked_bkscal_on = bkscal_on / self.stacked_off_vector.data.value
-        stacked_bkscal_off = bkscal_off / self.stacked_off_vector.data.value
+        stacked_bkscal_on = bkscal_on / self.stacked_off_vector.data.data.value
+        stacked_bkscal_off = bkscal_off / self.stacked_off_vector.data.data.value
 
         # there should be no nan values in backscal_on or backscal_off
         # this leads to problems when fitting the data
         alpha_correction = - 1
-        idx = np.where(self.stacked_off_vector.data == 0)[0]
+        idx = np.where(self.stacked_off_vector.data.data == 0)[0]
         stacked_bkscal_on[idx] = alpha_correction
         stacked_bkscal_off[idx] = alpha_correction
 
@@ -688,10 +688,10 @@ class SpectrumObservationStacker(object):
     def setup_counts_vectors(self):
         """Add correct attributes to stacked counts vectors"""
         total_livetime = self.obs_list.total_livetime
-        self.stacked_on_vector.livetime = total_livetime
-        self.stacked_off_vector.livetime = total_livetime
-        self.stacked_on_vector.backscal = self.stacked_bkscal_on
-        self.stacked_off_vector.backscal = self.stacked_bkscal_off
+        self.stacked_on_vector.meta.livetime = total_livetime
+        self.stacked_off_vector.meta.livetime = total_livetime
+        self.stacked_on_vector.meta.backscal = self.stacked_bkscal_on
+        self.stacked_off_vector.meta.backscal = self.stacked_bkscal_off
         self.stacked_on_vector.obs_id = self.obs_list.obs_id
         self.stacked_off_vector.obs_id = self.obs_list.obs_id
 

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -305,10 +305,10 @@ class SpectrumFitResult(object):
         fit_range : bool, optional
             Set bins outside the fitted range to 0, default: True
         """
-        n_on = self.obs.on_vector.data.value
-        n_off = self.obs.off_vector.data.value
+        n_on = self.obs.on_vector.data.data.value
+        n_off = self.obs.off_vector.data.data.value
         alpha = self.obs.alpha
-        mu_sig = self.expected_source_counts.data.value
+        mu_sig = self.expected_source_counts.data.data.value
         stat = stats.wstat(n_on=n_on, n_off=n_off, alpha=alpha, mu_sig=mu_sig)
         if fit_range:
             # TODO: make active bins during the fit available more easily
@@ -335,10 +335,10 @@ class SpectrumFitResult(object):
         According to profile likelihood, see :ref:`wstat`.
         """
         energy = self.obs.e_reco
-        n_on = self.obs.on_vector.data.value
-        n_off = self.obs.off_vector.data.value
+        n_on = self.obs.on_vector.data.data.value
+        n_off = self.obs.off_vector.data.data.value
         alpha = self.obs.alpha
-        mu_sig = self.expected_source_counts.data.value
+        mu_sig = self.expected_source_counts.data.data.value
         data = stats.get_wstat_mu_bkg(n_on=n_on, n_off=n_off, alpha=alpha, mu_sig=mu_sig)
         return CountsSpectrum(data=data, energy=energy)
 
@@ -347,7 +347,7 @@ class SpectrumFitResult(object):
         """`~gammapy.spectrum.CountsSpectrum` of predicted on counts
         """
         mu_on = self.expected_source_counts.copy()
-        mu_on.data += self.expected_background_counts.data
+        mu_on.data.data += self.expected_background_counts.data.data
         return mu_on
 
     @property
@@ -357,7 +357,7 @@ class SpectrumFitResult(object):
         Prediced on counts - expected on counts
         """
         resspec = self.expected_on_counts.copy()
-        resspec.data -= self.obs.on_vector.data
+        resspec.data.data -= self.obs.on_vector.data.data
         return resspec
 
     def plot(self):
@@ -403,7 +403,7 @@ class SpectrumFitResult(object):
         yy = [0, 0]
         ax.plot(xx, yy, color='black')
 
-        ymax = 1.4 * max(self.residuals.data.value)
+        ymax = 1.4 * max(self.residuals.data.data.value)
         ax.set_ylim(-ymax, ymax)
 
         xmin = self.fit_range.to('TeV').value[0] * 0.8

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -139,7 +139,7 @@ class SpectrumSimulation(object):
         rand: `~numpy.random.RandomState`
             random state
         """
-        on_counts = rand.poisson(self.npred_source.data.value)
+        on_counts = rand.poisson(self.npred_source.data.data.value)
 
         counts_kwargs = dict(energy=self.e_reco,
                              livetime=self.livetime,
@@ -165,11 +165,11 @@ class SpectrumSimulation(object):
         rand: `~numpy.random.RandomState`
             random state
         """
-        bkg_counts = rand.poisson(self.npred_background.data.value)
-        off_counts = rand.poisson(self.npred_background.data.value / self.alpha)
+        bkg_counts = rand.poisson(self.npred_background.data.data.value)
+        off_counts = rand.poisson(self.npred_background.data.data.value / self.alpha)
 
         # Add background to on_vector
-        self.on_vector.data += bkg_counts * u.ct
+        self.on_vector.data.data += bkg_counts * u.ct
 
         # Create off vector
         off_vector = PHACountsSpectrum(energy=self.e_reco,

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -46,11 +46,11 @@ class TestCountsSpectrum:
         filename = tmpdir / 'test.fits'
         self.spec.write(filename)
         spec2 = CountsSpectrum.read(filename)
-        assert_quantity_allclose(spec2.data.axis('energy').data, self.bins)
+        assert_quantity_allclose(spec2.energy.data, self.bins)
 
     def test_rebin(self):
         rebinned_spec = self.spec.rebin(2)
-        assert rebinned_spec.data.axis('energy').nbins == self.spec.data.axis('energy').nbins / 2
+        assert rebinned_spec.energy.nbins == self.spec.energy.nbins / 2
         assert rebinned_spec.data.data.shape[0] == self.spec.data.data.shape[0] / 2
         assert rebinned_spec.total_counts == self.spec.total_counts
 
@@ -72,9 +72,9 @@ class TestPHACountsSpectrum:
         self.spec = PHACountsSpectrum(data=counts,
                                       energy=self.binning,
                                       quality=quality)
-        self.spec.backscal = 0.3
+        self.spec.meta.backscal = 0.3
         self.spec.obs_id = 42
-        self.spec.livetime = 3 * u.h
+        self.spec.meta.livetime = 3 * u.h
 
     def test_init_wo_unit(self):
         counts = [2, 5]
@@ -94,7 +94,7 @@ class TestPHACountsSpectrum:
                                  self.binning[5])
 
     def test_thresholds(self):
-        self.spec.quality = np.zeros(self.spec.data.axis('energy').nbins, dtype=int)
+        self.spec.quality = np.zeros(self.spec.energy.nbins, dtype=int)
         self.spec.lo_threshold = 1.5 * u.TeV
         self.spec.hi_threshold = 4.5 * u.TeV
         assert (self.spec.quality == [1, 1, 0, 0, 0, 1, 1, 1]).all()
@@ -105,11 +105,11 @@ class TestPHACountsSpectrum:
         filename = tmpdir / 'test2.fits'
         self.spec.write(filename)
         spec2 = PHACountsSpectrum.read(filename)
-        assert_quantity_allclose(spec2.data.axis('energy').data,
-                                 self.spec.data.axis('energy').data)
+        assert_quantity_allclose(spec2.energy.data,
+                                 self.spec.energy.data)
 
     def test_backscal_array(self, tmpdir):
-        self.spec.backscal = np.arange(self.spec.data.axis('energy').nbins)
+        self.spec.meta.backscal = np.arange(self.spec.energy.nbins)
         table = self.spec.to_table()
         assert table['BACKSCAL'][2] == 2
 

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -85,7 +85,7 @@ class TestSpectrumExtraction:
         extraction.estimate_background(extraction.background)
         extraction.extract_spectrum()
         obs = extraction.observations[0]
-        aeff_actual = obs.aeff.evaluate(energy=5 * u.TeV)
+        aeff_actual = obs.aeff.data.evaluate(energy=5 * u.TeV)
 
         # TODO: Introduce assert_stats_allclose
         n_on_actual = obs.total_stats.n_on
@@ -99,10 +99,10 @@ class TestSpectrumExtraction:
         """Test the run method and check if files are written correctly"""
         extraction.run(outdir=tmpdir)
         testobs = SpectrumObservation.read(tmpdir / 'ogip_data' / 'pha_obs23523.fits')
-        assert_quantity_allclose(testobs.aeff.data,
-                                 extraction.observations[0].aeff.data)
-        assert_quantity_allclose(testobs.on_vector.data,
-                                 extraction.observations[0].on_vector.data)
+        assert_quantity_allclose(testobs.aeff.data.data,
+                                 extraction.observations[0].aeff.data.data)
+        assert_quantity_allclose(testobs.on_vector.data.data,
+                                 extraction.observations[0].on_vector.data.data)
         assert_quantity_allclose(testobs.on_vector.energy.nodes,
                                  extraction.observations[0].on_vector.energy.nodes)
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -59,7 +59,7 @@ class TestSpectralFit:
         assert_allclose(par_errors.amplitude.s, 2.2154024177186417e-08)
 
     def test_npred(self):
-        actual = self.result.obs.predicted_counts(self.result.model).data.value
+        actual = self.result.obs.predicted_counts(self.result.model).data.data.value
         desired = self.result.npred
         assert_allclose(actual, desired)
 

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -161,12 +161,12 @@ class TestSpectrumObservationStacker:
         npred1=self.obs_list[0].predicted_counts(model=pwl)
         npred2=self.obs_list[1].predicted_counts(model=pwl)
         # Set npred outside safe range to 0
-        npred1.data[np.nonzero(self.obs_list[0].on_vector.quality)]=0
-        npred2.data[np.nonzero(self.obs_list[1].on_vector.quality)]=0
+        npred1.data.data[np.nonzero(self.obs_list[0].on_vector.quality)]=0
+        npred2.data.data[np.nonzero(self.obs_list[1].on_vector.quality)]=0
 
-        npred_summed=npred1.data + npred2.data
+        npred_summed=npred1.data.data + npred2.data.data
 
-        assert_allclose(npred_stacked.data, npred_summed)
+        assert_allclose(npred_stacked.data.data, npred_summed)
 
 
 @requires_dependency('scipy')
@@ -180,8 +180,10 @@ class TestSpectrumObservationList:
         stacked_obs=self.obs_list.stack()
         assert 'Observation summary report' in str(stacked_obs)
         assert stacked_obs.obs_id == [23523, 23592]
-        assert_quantity_allclose(stacked_obs.aeff.data[10], 86443352.23037884 * u.cm ** 2)
-        assert_quantity_allclose(stacked_obs.edisp.data[50, 52], 0.029627067949207702)
+        assert_quantity_allclose(stacked_obs.aeff.data.data[10],
+                                 86443352.23037884 * u.cm ** 2)
+        assert_quantity_allclose(stacked_obs.edisp.data.data[50, 52],
+                                 0.029627067949207702)
 
     def test_write(self, tmpdir):
         self.obs_list.write(outdir=str(tmpdir), pha_typeII=False)

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -17,7 +17,7 @@ class TestSpectrumFitResult:
         self.best_fit_model = PowerLaw(index=2 * u.Unit(''),
                                        amplitude=1e-11 * u.Unit('cm-2 s-1 TeV-1'),
                                        reference=1 * u.TeV)
-        self.npred = self.obs.predicted_counts(self.best_fit_model).data.value
+        self.npred = self.obs.predicted_counts(self.best_fit_model).data.data.value
         self.covar_axis = ['index', 'amplitude']
         self.covar = np.diag([0.1 ** 2, 1e-12 ** 2])
         self.fit_range = [0.1, 50] * u.TeV

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -66,6 +66,6 @@ class TestSpectrumSimulation:
         self.sim.simulate_obs(seed=23, obs_id=23)
         assert self.sim.obs.on_vector.total_counts == 160 * u.ct
         # The test value is taken from the test with edisp
-        assert_allclose(np.sum(self.sim.npred_source.data.value),
+        assert_allclose(np.sum(self.sim.npred_source.data.data.value),
                         167.467572145, rtol=0.01)
 

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -157,13 +157,12 @@ def calculate_predicted_counts(model, aeff, livetime, edisp=None, e_reco=None):
         flux = model.integral(emin=true_energy[:-1], emax=true_energy[1:],
                               intervals=True)
         # Need to fill nan values in aeff due to matrix multiplication with RMF
-        counts = flux * livetime * aeff.evaluate(fill_nan=True)
+        counts = flux * livetime * aeff.evaluate_fill_nan()
         counts = counts.to('')
         reco_counts = edisp.apply(counts, e_reco=e_reco)
     else:
         flux = model.integral(emin=e_reco[:-1], emax=e_reco[1:], intervals=True)
-        reco_counts = flux * livetime * aeff.evaluate(energy=e_reco.log_centers,
-                                                      fill_nan=True)
+        reco_counts = flux * livetime * aeff.evaluate_fill_nan(energy=e_reco.log_centers)
         reco_counts = reco_counts.to('')
 
     return CountsSpectrum(data=reco_counts, energy=e_reco)

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -6,7 +6,6 @@ from astropy.io import fits
 from astropy import log
 from astropy.table import Table
 from astropy.extern import six
-from ..utils.fits import table_to_fits_table
 
 
 __all__ = [
@@ -358,50 +357,6 @@ class EnergyBounds(Energy):
             Array of energies to test
         """
         return (energy > self[0]) & (energy < self[-1])
-
-
-    def to_table(self, unit=None):
-        """Convert to `~astropy.table.Table`.
-        """
-        if unit is None:
-            unit = self.unit
-
-        table = Table()
-
-        table['CHANNEL'] = np.arange(self.nbins, dtype=np.int16)
-        table['E_MIN'] = Quantity(self.lower_bounds, unit=unit, dtype=np.float32)
-        table['E_MAX'] = Quantity(self.upper_bounds, unit=unit, dtype=np.float32)
-
-        return table
-
-    def to_ebounds(self, unit=None, **kwargs):
-        """Write EBOUNDS fits extension
-
-        Returns
-        -------
-        hdu: `~astropy.io.fits.BinTableHDU`
-            EBOUNDS fits extension
-        """
-
-        hdu = table_to_fits_table(self.to_table(unit))
-        header = hdu.header
-        header['EXTNAME'] = 'EBOUNDS', 'Name of this binary table extension'
-        header['TELESCOP'] = 'DUMMY', 'Mission/satellite name'
-        header['INSTRUME'] = 'DUMMY', 'Instrument/detector'
-        header['FILTER'] = '', 'Filter information'
-        header['CHANTYPE'] = 'PHA', 'Type of channels (PHA, PI etc)'
-        header['DETCHANS'] = self.nbins, 'Total number of detector PHA channels'
-        header['HDUCLASS'] = 'OGIP', 'Organisation devising file format'
-        header['HDUCLAS1'] = 'RESPONSE', 'File relates to response of instrument'
-        header['HDUCLAS2'] = 'EBOUNDS', 'This is an EBOUNDS extension'
-        header['HDUVERS'] = '1.2.0', 'Version of file format'
-
-        # Obsolet EBOUNDS headers, included for the benefit of old software
-        header['RMFVERSN'] = '1992a', 'Obsolete'
-        header['HDUVERS1'] = '1.0.0', 'Obsolete'
-        header['HDUVERS2'] = '1.1.0', 'Obsolete'
-
-        return hdu
 
     def to_dict(self):
         """Construct dict representing an energy range"""

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -6,6 +6,7 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.io import fits
 from astropy.table import Table, QTable
+from .energy import EnergyBounds
 
 __all__ = [
     'table_from_row_data',
@@ -153,17 +154,17 @@ def fits_table_to_table(tbhdu):
 
 
 def energy_axis_to_ebounds(energy):
-    """Convert energy `~gammapy.utils.nddata.BinnedEnergyAxis` to OGIP
-    ``EBOUNDS`` extension
+    """Convert `~gammapy.utils.energy.EnergyBounds` to OGIP ``EBOUNDS`` extension
 
     see
     http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.2
     """
+    energy = EnergyBounds(energy)
     table = Table()
 
     table['CHANNEL'] = np.arange(energy.nbins, dtype=np.int16)
-    table['E_MIN'] = energy.data[:-1]
-    table['E_MAX'] = energy.data[1:]
+    table['E_MIN'] = energy[:-1]
+    table['E_MAX'] = energy[1:]
 
     hdu = table_to_fits_table(table)
 
@@ -183,12 +184,11 @@ def energy_axis_to_ebounds(energy):
 
 
 def ebounds_to_energy_axis(ebounds):
-    """Convert ``EBOUNDS`` extension to energy
-    `~gammapy.utils.nddata.BinnedEnergyAxis`
+    """Convert ``EBOUNDS`` extension to `~gammapy.utils.energy.EnergyBounds`
     """
     from .nddata import BinnedDataAxis
     table = fits_table_to_table(ebounds)
     emin = table['E_MIN'].quantity
     emax = table['E_MAX'].quantity
     energy = np.append(emin.value, emax.value[-1]) * emin.unit
-    return BinnedDataAxis(data=energy)
+    return EnergyBounds(energy)

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -24,6 +24,8 @@ __all__ = [
 class NDDataArray(object):
     """ND Data Array Base class
 
+    for usage examples see :gp-extra-notebook:`nddata_demo`
+
     Parameters
     ----------
     axes : list
@@ -235,6 +237,15 @@ class DataAxis(object):
         self.data = Quantity(data)
         self.name = name
         self._interpolation_mode = interpolation_mode
+
+    def __str__(self):
+        ss = self.__class__.__name__
+        ss += '\nName: {}'.format(self.name)
+        ss += '\nUnit: {}'.format(self.unit)
+        ss += '\nNodes: {}'.format(self.nbins)
+        ss += '\nInterpolation mode: {}'.format(self.interpolation_mode)
+
+        return ss
 
     @property
     def unit(self):

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -58,6 +58,14 @@ class NDDataArray(object):
         """Array holding the axes in correct order"""
         return self._axes
 
+    def axis(self, name):
+        """Return axis by name"""
+        try:
+            idx = [_.name for _ in self.axes].index(name)
+        except ValueError:
+            raise ValueError('Axis {} not found'.format(name))
+        return self.axes[idx]
+
     @property
     def data(self):
         """Array holding the n-dimensional data"""

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -230,6 +230,8 @@ class DataAxis(object):
     """
 
     def __init__(self, data, name='Default', interpolation_mode='linear'):
+        if isinstance(data, self.__class__):
+            data = data.data
         self.data = Quantity(data)
         self.name = name
         self._interpolation_mode = interpolation_mode

--- a/gammapy/utils/tests/test_energy.py
+++ b/gammapy/utils/tests/test_energy.py
@@ -140,35 +140,3 @@ def test_EnergyBounds():
     actual = bands[0]
     desired = energy[1] - energy[0]
     assert_equal(actual, desired)
-
-
-@requires_data('gammapy-extra')
-def test_EnergyBounds_read():
-    # read EBOUNDS extension
-    filename = gammapy_extra.filename('test_datasets/irf/hess/ogip/run_rmf60741.fits')
-
-    hdulist = fits.open(filename)
-    ebounds = EnergyBounds.from_ebounds(hdulist['EBOUNDS'])
-    desired = hdulist['EBOUNDS'].data['E_MAX'][-1]
-    actual = ebounds[-1].value
-    assert_equal(actual, desired)
-
-    # read MATRIX extension
-    ebounds = EnergyBounds.from_rmf_matrix(hdulist['MATRIX'])
-    desired = hdulist['MATRIX'].data['ENERG_LO'][3]
-    actual = ebounds[3].value
-    assert_equal(actual, desired)
-
-
-def test_EnergyBounds_write(tmpdir):
-    ebounds = EnergyBounds.equal_log_spacing(1 * u.TeV, 10 * u.TeV, 10)
-    writename = str(tmpdir / 'ebounds_test.fits')
-    hdu = ebounds.to_ebounds()
-    prim_hdu = fits.PrimaryHDU()
-    hdulist = fits.HDUList([prim_hdu, hdu])
-    hdulist.writeto(writename)
-
-    ebounds2 = EnergyBounds.from_ebounds(hdulist[1])
-    actual = ebounds2
-    desired = ebounds
-    assert_allclose(actual, desired)

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -126,7 +126,6 @@ class NDDataArrayTester:
             return
 
         # Case 1: axis1 = scalar, axis2 = array
-
         kwargs = {self.axes[0].name: self.axes[0].data[1] * 0.75,
                   self.axes[1].name: self.axes[1].data[0:-1] * 1.1}
         actual = self.nddata.evaluate(**kwargs).shape
@@ -140,11 +139,13 @@ class NDDataArrayTester:
         desired = (2, 3)
         assert actual == desired
 
-        # Case 6: axis1 array, axis2 = 2Darray
+        # Case 3: axis1 array, axis2 = 2Darray
         nx, ny = (12, 3)
-        eval_field = np.linspace(self.axes[1].data[1],
-                                 self.axes[1].data[2],
-                                 nx * ny).reshape(nx, ny)
+
+        # NOTE:  np.linspace does not work with Quantities and numpy 1.10
+        eval_field = np.linspace(self.axes[1].data[1].value,
+                                 self.axes[1].data[2].value,
+                                 nx * ny).reshape(nx, ny) * self.axes[1].unit
         kwargs = {self.axes[0].name: self.axes[0].data[0:2],
                   self.axes[1].name: eval_field}
         actual = self.nddata.evaluate(**kwargs).shape

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -1,0 +1,152 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.tests.helper import (
+    pytest,
+    assert_quantity_allclose,
+)
+import numpy as np
+import astropy.units as u
+from astropy.utils.compat import NUMPY_LT_1_9
+from numpy.testing import assert_allclose
+from ..testing import requires_dependency
+from ..nddata import NDDataArray, BinnedDataAxis, DataAxis
+
+
+def get_test_arrays():
+    data_arrays = list()
+    data_arrays.append(dict(
+        tag='1D linear',
+        data=np.arange(10),
+        axes=[
+            DataAxis(np.arange(10), name='x-axis')
+        ],
+        linear_val={'x-axis': 8.5},
+        linear_res=8.5,
+    ))
+    data_arrays.append(dict(
+        tag='2D log-linear',
+        data=np.arange(12).reshape(3, 4) * u.cm * u.cm,
+        axes=[
+            BinnedDataAxis.logspace(1, 10, 3, unit=u.TeV, name='energy',
+                                    interpolation_mode='log'),
+            DataAxis([0.2, 0.3, 0.4, 0.5] * u.deg, name='offset')
+        ],
+        linear_val={'energy': 4.54 * u.TeV, 'offset': 0.23 * u.deg},
+        linear_res=6.184670234285248 * u.cm ** 2,
+    ))
+    return data_arrays
+
+
+@pytest.mark.parametrize('config', get_test_arrays())
+@requires_dependency('scipy')
+def test_nddata(config):
+    tester = NDDataArrayTester(config)
+    tester.test_all()
+
+
+class NDDataArrayTester:
+
+    def __init__(self, config):
+        self.config = config
+        self.data = config['data']
+        self.axes = config['axes']
+        self.nddata = NDDataArray(axes=self.axes, data=self.data)
+
+    def test_all(self):
+        self.test_basic()
+        self.test_wrong_init()
+        self.test_find_node()
+        self.test_evaluate_nodes()
+        self.test_linear_interpolation()
+        self.test_return_shape()
+        self.test_1d()
+        self.test_2d()
+
+    def test_basic(self):
+        assert self.axes[0].name in str(self.nddata)
+
+    def test_wrong_init(self):
+        wrong_data = np.arange(8).reshape(4, 2)
+        with pytest.raises(ValueError):
+            nddata = NDDataArray(axes=self.axes, data=wrong_data)
+
+    def test_find_node(self):
+        kwargs = {}
+        for axis in self.nddata.axes:
+            kwargs[axis.name] = axis.nodes[1] * 1.24
+        node = self.nddata.find_node(**kwargs)
+        actual = self.data[node]
+        desired = self.nddata.evaluate(method='nearest', **kwargs)
+        assert_quantity_allclose(actual, desired)
+
+    def test_evaluate_nodes(self):
+        nodes = [2, 3, 1]
+        kwargs = dict()
+        for dim, axis in enumerate(self.axes):
+            kwargs[axis.name] = axis.nodes[nodes[dim]]
+
+        actual = self.nddata.evaluate(method='nearest', **kwargs)
+        desired = self.nddata.data[tuple(nodes[0:dim + 1])]
+        assert_allclose(actual, desired)
+
+        actual = self.nddata.evaluate(method='linear', **kwargs)
+        desired = self.nddata.data[tuple(nodes[0:dim + 1])]
+        assert_allclose(actual, desired)
+
+    def test_linear_interpolation(self):
+        actual = self.nddata.evaluate(method='linear',
+                                      **self.config['linear_val'])
+        desired = self.config['linear_res']
+        assert_quantity_allclose(actual, desired)
+
+    def test_return_shape(self):
+        # Case 0; no kwargs
+        actual = self.nddata.evaluate().shape
+        desired = self.data.shape
+        assert actual == desired
+
+    def test_1d(self):
+        if self.nddata.dim != 1:
+            return
+
+        # Case 1: scalar input
+        kwargs = {self.axes[0].name: self.axes[0].data[2] * 0.75}
+        actual = self.nddata.evaluate(**kwargs).shape
+        desired = ()
+        assert actual == desired
+
+        # Case 2: array input
+        kwargs = {self.axes[0].name: self.axes[0].data[0:2] * 0.75}
+        actual = self.nddata.evaluate(**kwargs).shape
+        desired = np.zeros(2).shape
+        assert actual == desired
+
+    def test_2d(self):
+        if self.nddata.dim != 2:
+            return
+
+        # Case 1: axis1 = scalar, axis2 = array
+
+        kwargs = {self.axes[0].name: self.axes[0].data[1] * 0.75,
+                  self.axes[1].name: self.axes[1].data[0:-1] * 1.1}
+        actual = self.nddata.evaluate(**kwargs).shape
+        desired = np.zeros(len(self.axes[1].data) - 1).shape
+        assert actual == desired
+
+        # Case 2: axis1 = array, axis2 = array
+        kwargs = {self.axes[0].name: self.axes[0].data[1:3] * 0.75,
+                  self.axes[1].name: self.axes[1].data[0:3] * 1.1}
+        actual = self.nddata.evaluate(**kwargs).shape
+        desired = (2, 3)
+        assert actual == desired
+
+        # Case 6: axis1 array, axis2 = 2Darray
+        nx, ny = (12, 3)
+        eval_field = np.linspace(self.axes[1].data[1],
+                                 self.axes[1].data[2],
+                                 nx * ny).reshape(nx, ny)
+        kwargs = {self.axes[0].name: self.axes[0].data[0:2],
+                  self.axes[1].name: eval_field}
+        actual = self.nddata.evaluate(**kwargs).shape
+        desired = np.zeros([2, nx, ny]).shape
+        assert actual == desired


### PR DESCRIPTION
This PR:

* [x] Rewrites ``NDDataArray`` as standalone class (instead of an abstract base class)
* [x] Adds a tutorial notebook, for the ``NDDataArray`` class
* [x] Rewrites all former NDDataArray subclasses to now have an ``NDDataArray`` as attributed (composition over inheritance)
* [x] Updates the documentation of the relevant classes
* [x] Reexposes the Dataarray axes as properties everywhere

This PR does NOT:

* Reexpose the data numpy array, thus all calls like ``aeff2d.data.value`` now look like ``aeff2d.data.data.value``
* Reexpose the evaluate method ``aeff2d.evaluate`` -> ``aeff2d.data.evaluate``