### PR TITLE
Add image profile class

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1172,8 +1172,8 @@ class SkyImage(object):
             interpreted as smoothing width in pixels. If an (angular) quantity
             is given it converted to pixels using `SkyImage.wcs_pixel_scale()`.
         kwargs : dict
-            Keyword arguments passed to `~scipy.ndimage.filters.uniform_filter`
-            ('box'), `~scipy.ndimage.filters.gaussian_filter` ('gauss') or
+            Keyword arguments passed to `~scipy.ndimage.uniform_filter`
+            ('box'), `~scipy.ndimage.gaussian_filter` ('gauss') or
             `~scipy.ndimage.convolve` ('disk').
 
         Returns

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -272,8 +272,8 @@ class ImageProfile(object):
         else:
             raise ValueError("Not valid kernel choose either 'box' or 'gauss'")
 
-        table['profile'] = smoothed
-        table['profile_err'] = smoothed_err
+        table['profile'] = smoothed * self.table['profile'].unit
+        table['profile_err'] = smoothed_err * self.table['profile'].unit
         return self.__class__(table)
 
     def plot(self, ax=None, **kwargs):

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -245,11 +245,11 @@ class ImageProfile(object):
             Kernel shape
         radius : `~astropy.units.Quantity` or float
             Smoothing width given as quantity or float. If a float is given it
-            interpreted as smoothing width in pixels. If an (angular) quantity
-            is given it converted to pixels.
+            is interpreted as smoothing width in pixels. If an (angular) quantity
+            is given it is converted to pixels using `xref[1] - x_ref[0]`.
         kwargs : dict
             Keyword arguments passed to `~scipy.ndimage.uniform_filter`
-            ('box'), `~scipy.ndimage.gaussian_filter` ('gauss').
+            ('box') and `~scipy.ndimage.gaussian_filter` ('gauss').
 
         Returns
         -------
@@ -265,8 +265,8 @@ class ImageProfile(object):
         profile_err = table['profile_err']
 
         radius = np.abs(radius / np.diff(self.x_ref))[0]
-
         width = 2 * radius.value + 1
+
         if kernel == 'box':
             smoothed = uniform_filter(profile.astype('float'), width, **kwargs)
             # renormalize data

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -203,11 +203,16 @@ class ImageProfile(object):
     The image profile data is stored in `~astropy.table.Table` object, with the
     following columns:
 
-        * `x_ref` Coordinate bin center (required). 
+        * `x_ref` Coordinate bin center (required).
         * `x_min` Coordinate bin minimum (optional).
         * `x_max` Coordinate bin maximum (optional).
         * `profile` Image profile data (required).
         * `profile_err` Image profile data error (optional).
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        Table instance with the columns specified as above.
 
     """
     def __init__(self, table):
@@ -223,7 +228,16 @@ class ImageProfile(object):
 
                 x_j = \sum_i x_{(j - i)} h_i
 
-        Where :math:h_i are coefficients of the convolution kernel.
+        Where :math:`h_i` are the coefficients of the convolution kernel.
+
+        The corresponding error on :math:`x_j` is then estimated using Gaussian
+        error propagation, neglecting correlations between the individual
+        :math:`x_{(j - i)}`:
+
+        .. math::
+
+                \Delta x_j = \sqrt{\sum_i \Delta x^{2}_{(j - i)} h^{2}_i}
+
 
         Parameters
         ----------
@@ -293,7 +307,7 @@ class ImageProfile(object):
             Axes object
         """
         import matplotlib.pyplot as plt
-        
+
         if ax is None:
             ax = plt.gca()
 
@@ -322,10 +336,10 @@ class ImageProfile(object):
             Axes object
         """
         import matplotlib.pyplot as plt
-        
+
         if ax is None:
             ax = plt.gca()
-        
+
         y = self.table['profile'].data
         ymin = y - self.table['profile_err'].data
         ymax = y + self.table['profile_err'].data
@@ -426,7 +440,7 @@ class ImageProfile(object):
         table['profile'] /= norm
 
         if 'profile_err' in table.colnames:
-            table['profile_err'] /= norm            
+            table['profile_err'] /= norm
 
         return self.__class__(table)
 

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -258,7 +258,7 @@ class ImageProfile(object):
         """
         from scipy.ndimage.filters import uniform_filter, gaussian_filter
         from scipy.ndimage import convolve
-        from astropy.convolution import Gaussian1DKernel
+        from astropy.convolution import Gaussian1DKernel, Box1DKernel
 
         table = self.table.copy()
         profile = table['profile']
@@ -275,7 +275,9 @@ class ImageProfile(object):
                 smoothed_err = np.sqrt(smoothed)
             else:
                 # use gaussian error propagation
-                smoothed_err = np.sqrt(uniform_filter(profile_err ** 2, width))
+                box = Box1DKernel(width)
+                err_sum = convolve(profile_err ** 2, box.array ** 2)
+                smoothed_err = np.sqrt(err_sum)
         elif kernel == 'gauss':
             smoothed = gaussian_filter(profile.astype('float'), width, **kwargs)
             # use gaussian error propagation

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -248,8 +248,8 @@ class ImageProfile(object):
             interpreted as smoothing width in pixels. If an (angular) quantity
             is given it converted to pixels.
         kwargs : dict
-            Keyword arguments passed to `~scipy.ndimage.filters.uniform_filter`
-            ('box'), `~scipy.ndimage.filters.gaussian_filter` ('gauss').
+            Keyword arguments passed to `~scipy.ndimage.uniform_filter`
+            ('box'), `~scipy.ndimage.gaussian_filter` ('gauss').
 
         Returns
         -------
@@ -301,7 +301,7 @@ class ImageProfile(object):
         ax : `~matplotlib.axes.Axes`
             Axes object
         **kwargs : dict
-            Keyword arguments passed to plt.plot()
+            Keyword arguments passed to `~matplotlib.axes.Axes.plot`
 
         Returns
         -------

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -4,10 +4,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.table import Table
 from astropy.units import Quantity
+from astropy import units as u
 from .core import SkyImage
 
 __all__ = [
     'FluxProfile',
+    'ImageProfile',
     'image_profile',
 ]
 
@@ -254,7 +256,7 @@ class ImageProfile(object):
         if kernel == 'box':
             smoothed = uniform_filter(profile.astype('float'), width, **kwargs)
             # renormalize data
-            if tanle['profile'].unit.isequivalent('counts'):
+            if table['profile'].unit.isequivalent('counts'):
                 smoothed *= int(width)
                 smoothed_err = np.sqrt(smoothed)
             else:
@@ -412,7 +414,6 @@ class ImageProfile(object):
         return self.__class__(table)
 
 
-
 def image_profile(profile_axis, image, lats, lons, binsz, counts=None,
                   mask=None, errors=False, standard_error=0.1):
     """Creates a latitude or longitude profile from input flux image HDU.
@@ -527,13 +528,13 @@ def image_profile(profile_axis, image, lats, lons, binsz, counts=None,
                        Quantity(glats_max, 'deg'),
                        values,
                        error_vals],
-                      names=('GLAT_MIN', 'GLAT_MAX', 'BIN_VALUE', 'BIN_ERR'))
+                      names=('x_min', 'x_max', 'profile', 'profile_err'))
 
     elif profile_axis == 'lon':
         table = Table([Quantity(glons_min, 'deg'),
                        Quantity(glons_max, 'deg'),
                        values,
                        error_vals],
-                      names=('GLON_MIN', 'GLON_MAX', 'BIN_VALUE', 'BIN_ERR'))
+                      names=('x_min', 'x_max', 'profile', 'profile_err'))
 
-    return table
+    return ImageProfile(table)

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -386,7 +386,7 @@ class ImageProfile(object):
         """
         Image profile error quantity.
         """
-        return self.table['profile'].quantity
+        return self.table['profile_err'].quantity
 
     def peek(self, figsize=(8, 4.5), **kwargs):
         """

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -256,7 +256,7 @@ class ImageProfile(object):
         if kernel == 'box':
             smoothed = uniform_filter(profile.astype('float'), width, **kwargs)
             # renormalize data
-            if table['profile'].unit.isequivalent('counts'):
+            if table['profile'].unit.is_equivalent('counts'):
                 smoothed *= int(width)
                 smoothed_err = np.sqrt(smoothed)
             else:
@@ -293,11 +293,12 @@ class ImageProfile(object):
             Axes object
         """
         import matplotlib.pyplot as plt
+        
         if ax is None:
             ax = plt.gca()
 
-        y = self.table['profile']
-        x = self.x_ref
+        y = self.table['profile'].data
+        x = self.x_ref.value
         ax.plot(x, y, **kwargs)
         ax.set_xlabel('lon')
         ax.set_ylabel('profile')
@@ -321,15 +322,17 @@ class ImageProfile(object):
             Axes object
         """
         import matplotlib.pyplot as plt
+        
         if ax is None:
             ax = plt.gca()
-        y = self.table['profile']
-        ymin = y - self.table['profile_err']
-        ymax = y + self.table['profile_err']
-        x = self.x_ref
+        
+        y = self.table['profile'].data
+        ymin = y - self.table['profile_err'].data
+        ymax = y + self.table['profile_err'].data
+        x = self.x_ref.value
 
         # plotting defaults
-        kwargs.set_default('alpha', 0.5)
+        kwargs.setdefault('alpha', 0.5)
 
         ax.fill_between(x, ymin, ymax, **kwargs)
         ax.set_xlabel('x (deg)')
@@ -356,6 +359,20 @@ class ImageProfile(object):
         Max. x coordinates.
         """
         return self.table['x_max'].quantity
+
+    @property
+    def profile(self):
+        """
+        Image profile quantity.
+        """
+        return self.table['profile'].quantity
+
+    @property
+    def profile_err(self):
+        """
+        Image profile error quantity.
+        """
+        return self.table['profile'].quantity
 
     def peek(self, figsize=(8, 4.5), **kwargs):
         """

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -40,21 +40,21 @@ def test_image_lat_profile():
     # Test output
     lat_profile1 = image_profile('lat', image.to_image_hdu(), lat, lon, binsz, errors=True)
     # atol 0.1 is sufficient to check if correct number of pixels are included
-    assert_allclose(lat_profile1['BIN_VALUE'].data.astype(float),
+    assert_allclose(lat_profile1.table['profile'].data.astype(float),
                     2000 * np.ones(39), rtol=1, atol=0.1)
-    assert_allclose(lat_profile1['BIN_ERR'].data,
-                    0.1 * lat_profile1['BIN_VALUE'].data)
+    assert_allclose(lat_profile1.table['profile_err'].data,
+                    0.1 * lat_profile1.table['profile'].data)
 
     lat_profile2 = image_profile('lat', image.to_image_hdu(), lat, lon, binsz,
                                  counts.to_image_hdu(), errors=True)
     # atol 0.1 is sufficient to check if correct number of pixels are included
-    assert_allclose(lat_profile2['BIN_ERR'].data,
+    assert_allclose(lat_profile2.table['profile_err'].data,
                     44.721359549995796 * np.ones(39), rtol=1, atol=0.1)
 
     lat_profile3 = image_profile('lat', image.to_image_hdu(), lat, lon, binsz,
                                  counts.to_image_hdu(), mask_array, errors=True)
 
-    assert_allclose(lat_profile3['BIN_VALUE'].data, np.zeros(39))
+    assert_allclose(lat_profile3.table['profile'].data, np.zeros(39))
 
 
 @requires_data('gammapy-extra')
@@ -83,18 +83,18 @@ def test_image_lon_profile():
     lon_profile1 = image_profile('lon', image, lat, lon, binsz,
                                  errors=True)
     # atol 0.1 is sufficient to check if correct number of pixels are included
-    assert_allclose(lon_profile1['BIN_VALUE'].data.astype(float),
+    assert_allclose(lon_profile1.table['profile'].data.astype(float),
                     1000 * np.ones(79), rtol=1, atol=0.1)
-    assert_allclose(lon_profile1['BIN_ERR'].data,
-                    0.1 * lon_profile1['BIN_VALUE'].data)
+    assert_allclose(lon_profile1.table['profile_err'].data,
+                    0.1 * lon_profile1.table['profile'].data)
 
     lon_profile2 = image_profile('lon', image, lat, lon, binsz,
                                  counts, errors=True)
     # atol 0.1 is sufficient to check if correct number of pixels are included
-    assert_allclose(lon_profile2['BIN_ERR'].data,
+    assert_allclose(lon_profile2.table['profile_err'].data,
                     31.622776601683793 * np.ones(79), rtol=1, atol=0.1)
 
     lon_profile3 = image_profile('lon', image, lat, lon, binsz, counts,
                                  mask_array, errors=True)
 
-    assert_allclose(lon_profile3['BIN_VALUE'].data, np.zeros(79))
+    assert_allclose(lon_profile3.table['profile'].data, np.zeros(79))


### PR DESCRIPTION
This PR implements a generic `ImageProfile` class, which offers plotting, smoothing and renormalization methods. The main data structure is an astropy table, which stores the coordinate values `x_ref` or `x_min` and `x_max` and the profile data values `profile` and `profile_err`.