### PR TITLE
Bump to require Astropy v1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ env:
     global:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa libgfortran regions reproject'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes sherpa regions reproject'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes regions reproject'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy sherpa libgfortran regions reproject'
-        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes pygments aplpy regions reproject'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy sherpa libgfortran runipy regions reproject'
-        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils wcsaxes aplpy libgfortran runipy regions reproject'
+        - CONDA_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa regions reproject'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils regions reproject'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject'
+        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy regions reproject'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject'
+        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy libgfortran runipy regions reproject'
         - PIP_DEPENDENCIES='uncertainties'
         - CONDA_CHANNELS='astropy sherpa'
         - FETCH_GAMMAPY_EXTRA=true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Summary
 
 For plans and progress for Gammapy 0.6, see https://github.com/gammapy/gammapy/milestones/0.6
 
+- Requires Astropy 1.3 or later. (Almost everything will probably still work with older Astropy versions,
+  but we don't test against older versions.)
+
 Contributors
 ++++++++++++
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/',
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
 intersphinx_mapping['sklearn'] = ('http://scikit-learn.org/stable/', None)
 intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/', None)
-intersphinx_mapping['wcsaxes'] = ('http://wcsaxes.readthedocs.io/en/latest/', None)
 intersphinx_mapping['aplpy'] = ('http://aplpy.readthedocs.io/en/latest/', None)
 intersphinx_mapping['naima'] = ('http://naima.readthedocs.io/en/latest/', None)
 intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/', None)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,9 +9,7 @@ dependencies:
   - scipy
   - scikit-image
   - matplotlib
-  - astropy-helpers
   - astropy
   - regions
   - reproject
-  - wcsaxes
   - aplpy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,7 +46,7 @@ functionality available:
 
     conda install \
         scikit-image scikit-learn h5py pandas \
-        aplpy wcsaxes photutils reproject
+        aplpy photutils reproject
 
     pip install iminuit
 
@@ -170,7 +170,7 @@ The following packages have to be installed with pip:
 .. code-block:: bash
 
     pip3 install --user \
-        gammapy naima photutils reproject wcsaxes gwcs astroplan \
+        gammapy naima photutils reproject gwcs astroplan \
         iminuit emcee healpy
 
 Sherpa currently doesn't work on Python 3.
@@ -213,7 +213,7 @@ Having multiple Python versions simultaneously works well, but is only really us
 .. code-block:: bash
 
     pip install --user \
-        gammapy naima photutils reproject wcsaxes gwcs astroplan \
+        gammapy naima photutils reproject gwcs astroplan \
         iminuit
 
 
@@ -314,7 +314,6 @@ Currently optional dependencies that are being considered as core dependencies:
 Allowed optional dependencies:
 
 * `matplotlib`_ for plotting
-* `wcsaxes`_ for sky image plotting (provides a low-level API)
 * `aplpy`_ for sky image plotting (provides a high-level API)
 * `pandas`_ CSV read / write; DataFrame
 * `scikit-learn`_ for some data analysis tasks

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -16,7 +16,6 @@
 .. _photutils: http://photutils.readthedocs.io
 .. _astroplan: http://astroplan.readthedocs.io
 .. _gwcs: http://gwcs.readthedocs.io
-.. _wcsaxes: https://github.com/astrofrog/wcsaxes
 .. _iminuit: https://github.com/iminuit/iminuit
 .. _probfit: https://github.com/iminuit/probfit
 .. _h5py: http://www.h5py.org/

--- a/gammapy-conda-install.sh
+++ b/gammapy-conda-install.sh
@@ -46,11 +46,10 @@ conda install gammapy naima \
 # Nice to have extras
 conda install \
     scikit-image scikit-learn h5py pandas \
-    aplpy wcsaxes photutils
+    aplpy photutils
 # Disk space now: 747 MB
 
 pip install reproject
 pip install iminuit
 
-# This will only work on Python 2:
 conda install sherpa

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -17,7 +17,6 @@ TESTED_VERSIONS[packagename] = version.version
 # Declare for which packages version numbers should be displayed
 # when running the tests
 PYTEST_HEADER_MODULES['cython'] = 'cython'
-PYTEST_HEADER_MODULES['pandas'] = 'pandas'
 PYTEST_HEADER_MODULES['skimage'] = 'skimage'
 PYTEST_HEADER_MODULES['sklearn'] = 'sklearn'
 PYTEST_HEADER_MODULES['uncertainties'] = 'uncertainties'
@@ -28,8 +27,6 @@ PYTEST_HEADER_MODULES['gammapy'] = 'gammapy'
 PYTEST_HEADER_MODULES['naima'] = 'naima'
 PYTEST_HEADER_MODULES['reproject'] = 'reproject'
 PYTEST_HEADER_MODULES['photutils'] = 'photutils'
-PYTEST_HEADER_MODULES['gwcs'] = 'gwcs'
-PYTEST_HEADER_MODULES['wcsaxes'] = 'wcsaxes'
 PYTEST_HEADER_MODULES['aplpy'] = 'aplpy'
 PYTEST_HEADER_MODULES['regions'] = 'regions'
 PYTEST_HEADER_MODULES['astroplan'] = 'astroplan'

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -840,7 +840,7 @@ class SkyImage(object):
 
         Parameters
         ----------
-        ax : `~astropy.wcsaxes.WCSAxes`, optional
+        ax : `~astropy.visualization.wcsaxes.WCSAxes`, optional
             WCS axis object to plot on.
         fig : `~matplotlib.figure.Figure`, optional
             Figure
@@ -849,7 +849,7 @@ class SkyImage(object):
         -------
         fig : `~matplotlib.figure.Figure`, optional
             Figure
-        ax : `~astropy.wcsaxes.WCSAxes`, optional
+        ax : `~astropy.visualization.wcsaxes.WCSAxes`, optional
             WCS axis object
         cbar : ?
             Colorbar object (if ``add_cbar=True`` was set)

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     # To find out if everything works run the Gammapy tests.
     install_requires=[
       'numpy>=1.8',
-      'astropy>=1.2',
+      'astropy>=1.3',
       'regions',
       'click',
     ],
@@ -124,7 +124,6 @@ setup(
       ],
       plotting=[
           'matplotlib>=1.4',
-          'wcsaxes>=0.3',
           'aplpy>=0.9',
       ],
       gui=[
@@ -150,6 +149,7 @@ setup(
       'Programming Language :: Python :: 3',
       'Programming Language :: Python :: 3.4',
       'Programming Language :: Python :: 3.5',
+      'Programming Language :: Python :: 3.6',
       'Programming Language :: Python :: Implementation :: CPython',
       'Topic :: Scientific/Engineering :: Astronomy',
       'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This PR bumps the Astropy dependency requirement to v1.3.

At the moment the only motivation is that I want to use `astropy.vizualisation.wcsaxes` instead of the old external separate `wcsaxes` package.
