### PR TITLE
Add ImageProfileEstimator class

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -50,7 +50,7 @@ class SkyImage(object):
     _AxisIndex = namedtuple('AxisIndex', ['x', 'y'])
     _ax_idx = _AxisIndex(x=1, y=0)
 
-    def __init__(self, name=None, data=None, wcs=None, unit=None, meta=None):
+    def __init__(self, name=None, data=None, wcs=None, unit=u.Unit(''), meta=None):
         # TODO: validate inputs
         self.name = name
         self.data = data

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -303,15 +303,15 @@ class ImageProfileEstimator(object):
 
         label_image = SkyImage.empty_like(image)
         coordinates = image.coordinates()
-        x_ref = self._get_x_ref(image)
+        x_edges = self._get_x_edges(image)
 
         if p['axis'] == 'lon':
             lon = coordinates.data.lon.wrap_at('180d')
-            data = np.digitize(lon.degree, x_ref.deg)
+            data = np.digitize(lon.degree, x_edges.deg)
 
         elif p['axis'] == 'lat':
-            lat = coordinates.data.lat.degree
-            data = np.digitize(lat.degree, x_ref.deg)
+            lat = coordinates.data.lat
+            data = np.digitize(lat.degree, x_edges.deg)
 
         label_image.data = data
         return label_image
@@ -441,6 +441,7 @@ class ImageProfile(object):
                 smoothed *= int(width)
                 smoothed_err = np.sqrt(smoothed)
             elif 'profile_err' in table.colnames:
+                profile_err = table['profile_err']
                 # use gaussian error propagation
                 box = Box1DKernel(width)
                 err_sum = convolve(profile_err ** 2, box.array ** 2)

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -199,15 +199,15 @@ class FluxProfile(object):
 
 
 # TODO: implement measuring profile along arbitrary directions
-# TODO: think better about error handling
+# TODO: think better about error handling. e.g. MC based methods
 class ImageProfileEstimator(object):
     """
     Estimate profile from image.
 
     Parameters
     ----------
-    x_ref : `~astropy.coordinates.Angle`
-        Reference coordinates to define the measument grid.
+    x_edges : `~astropy.coordinates.Angle`
+        Coordinate edges to define the measument grid.
     method : ['sum', 'mean']
         Compute sum or mean within profile bins.
     axis : ['lon', 'lat']
@@ -229,7 +229,7 @@ class ImageProfileEstimator(object):
         """
         Get x_ref coordinate array.
         """
-        if self._x_edges:
+        if self._x_edges is not None:
             return self._x_edges
 
         p = self.parameters
@@ -249,7 +249,7 @@ class ImageProfileEstimator(object):
         p = self.parameters
 
         label_image = SkyImage.empty_like(image)
-        coordinates = image.coordinates(mode='edges')
+        coordinates = image.coordinates()
         x_edges = self._get_x_edges(image)
 
         if p['axis'] == 'lon':
@@ -257,7 +257,7 @@ class ImageProfileEstimator(object):
             data = np.digitize(lon.degree, x_edges.deg)
 
         elif p['axis'] == 'lat':
-            lat = coordinates.data.lat.degree
+            lat = coordinates.data.lat
             data = np.digitize(lat.degree, x_edges.deg)
 
         label_image.data = data

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -10,9 +10,8 @@ from astropy import units as u
 from .core import SkyImage
 
 __all__ = [
-    'FluxProfile',
     'ImageProfile',
-    'image_profile',
+    'ImageProfileEstimator'
 ]
 
 

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -211,7 +211,7 @@ class ImageProfileEstimator(object):
     method : ['sum', 'mean']
         Compute sum or mean within profile bins.
     axis : ['lon', 'lat']
-        Along which axis to make the profile.
+        Along which axis to estimate the profile.
     """
     def __init__(self, x_edges=None, method='sum', axis='lon', apply_mask=False):
 
@@ -570,7 +570,7 @@ class ImageProfile(object):
         Parameters
         ----------
         **kwargs : dict
-            Keyword arguments passed to plt.plot()
+            Keyword arguments passed to `ImageProfile.plot_profile()`
 
         Returns
         -------

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -290,14 +290,14 @@ class ImageProfileEstimator(object):
         label_image.data = data
         return label_image
 
-    def _estimate_profile(self, image, image_err):
+    def _estimate_profile(self, image, image_err, mask):
         """
         Estimate image profile.
         """
         from scipy import ndimage
 
         p = self.parameters
-        labels = self._label_image(image)
+        labels = self._label_image(image, mask)
 
         profile_err = None
 
@@ -323,7 +323,7 @@ class ImageProfileEstimator(object):
 
         return profile, profile_err
 
-    def _label_image(self, image):
+    def _label_image(self, image, mask=None):
         """
         Compute label image.
         """
@@ -340,6 +340,10 @@ class ImageProfileEstimator(object):
         elif p['axis'] == 'lat':
             lat = coordinates.data.lat
             data = np.digitize(lat.degree, x_edges.deg)
+
+        if mask is not None:
+            # assign masked values to background
+            data[mask.data] = 0
 
         label_image.data = data
         return label_image
@@ -373,12 +377,7 @@ class ImageProfileEstimator(object):
         if image_err:
             image_err = image_err.copy()
 
-        if mask is not None:
-            # TODO: handle nan values with the mask
-            image.data *= mask
-            image_err.data *= mask
-
-        profile, profile_err = self._estimate_profile(image, image_err)
+        profile, profile_err = self._estimate_profile(image, image_err, mask)
 
         result = Table()
         x_edges = self._get_x_edges(image)

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -174,11 +174,7 @@ def test_image_lon_profile():
 class TestImageProfile(object):
     def setup(self):
         table = Table()
-<<<<<<< HEAD
-        table['x_ref'] = np.linspace(-90, 90, 10) * u.deg
-=======
         table['x_ref'] = np.linspace(-90, 90, 11) * u.deg
->>>>>>> Add TestImageProfileEstimator test class
         table['profile'] = np.cos(table['x_ref'].to('rad')) * u.Unit('cm-2 s-1')
         table['profile_err'] = 0.1 * table['profile']
         self.profile = ImageProfile(table)
@@ -192,12 +188,9 @@ class TestImageProfile(object):
         profile = normalized.profile
         assert_quantity_allclose(profile.max(), 1 * u.Unit('cm-2 s-1'))
 
-<<<<<<< HEAD
-=======
     def test_profile_x_edges(self):
         assert_quantity_allclose(self.profile.x_ref.sum(), 0 * u.deg)
 
->>>>>>> Add TestImageProfileEstimator test class
     @requires_dependency('scipy')
     @pytest.mark.parametrize('kernel', ['gauss', 'box'])
     def test_smooth(self, kernel):


### PR DESCRIPTION
This PR implements an `ImageProfileEstimator` class. Taking an `SkyImage` as input it is able to measure image profiles along `lon` and `lat` axis, taking image errors and a mask (if supplied...) into account. The class could be extended later to measure radial profiles or profiles along arbitrary directions (e.g. as some users like to do to separate close by sources..) . This class supersedes the old `image_profile` function.