### PR TITLE
Fix SpectrumObservation write bug

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -89,7 +89,7 @@ class SpectrumExtraction(object):
             self.extract_spectrum()
         return self._observations
 
-    def run(self, outdir=None):
+    def run(self, outdir=None, use_sherpa=False):
         """Run all steps
 
         Extract spectrum, update observation table, filter observations,
@@ -99,14 +99,16 @@ class SpectrumExtraction(object):
         ----------
         outdir : Path, str
             directory to write results files to
+        use_sherpa : bool, optional
+            Write Sherpa compliant files, default: False
         """
-        outdir = make_path(outdir) 
+        outdir = make_path(outdir)
         outdir.mkdir(exist_ok=True, parents=True)
         if not isinstance(self.background, list):
             log.info('Estimate background with config {}'.format(self.background))
             self.estimate_background(self.background)
         self.extract_spectrum()
-        self.write(outdir)
+        self.write(outdir, use_sherpa=use_sherpa)
 
     def estimate_background(self, config):
         """Create `~gammapy.background.BackgroundEstimate`
@@ -193,7 +195,7 @@ class SpectrumExtraction(object):
                 counts_kwargs.update(zen_pnt=obs.pointing_zen)
             except KeyError:
                 pass
-            
+
             on_vec = PHACountsSpectrum(backscal=bkg.a_on, **counts_kwargs)
             off_vec = PHACountsSpectrum(backscal=bkg.a_off, is_bkg=True,
                                         **counts_kwargs)
@@ -271,7 +273,7 @@ class SpectrumExtraction(object):
                 raise ValueError('Undefine method for low threshold: {}'.format(
                     method_lo_threshold))
 
-    def write(self, outdir, ogipdir='ogip_data'):
+    def write(self, outdir, ogipdir='ogip_data', use_sherpa=False):
         """Write results to disk
         
         Parameters
@@ -280,7 +282,9 @@ class SpectrumExtraction(object):
             Output folder
         ogipdir : str, optional
             Folder name for OGIP data, default: 'ogip_data'
+        use_sherpa : bool, optional
+            Write Sherpa compliant files, default: False
         """
         log.info("Writing OGIP files to {}".format(outdir / ogipdir))
-        self.observations.write(outdir / ogipdir)
+        self.observations.write(outdir / ogipdir, use_sherpa=use_sherpa)
         # TODO : add more debug plots etc. here

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -203,13 +203,13 @@ class SpectrumObservation(object):
         -------
         stats : `~gammapy.spectrum.SpectrumStats`
             Stats
-        """ 
+        """
         if self.off_vector is not None:
             n_off = int(self.off_vector.data.data.value[idx])
             a_off = self.off_vector._backscal_array[idx]
         else:
             n_off = 0
-            a_off = 1 # avoid zero division error
+            a_off = 1  # avoid zero division error
 
         return SpectrumStats(
             energy_min=self.e_reco[idx],
@@ -314,7 +314,7 @@ class SpectrumObservation(object):
         if use_sherpa:
             self.on_vector.energy.data = self.on_vector.energy.data.to('keV')
             self.aeff.energy.data = self.aeff.energy.data.to('keV')
-            self.aeff.data = self.aeff.data.to('cm2')
+            self.aeff.data.data = self.aeff.data.data.to('cm2')
             if self.off_vector is not None:
                 self.off_vector.energy.data = self.off_vector.energy.data.to('keV')
             if self.edisp is not None:
@@ -322,7 +322,7 @@ class SpectrumObservation(object):
                 self.edisp.e_true.data = self.edisp.e_true.data.to('keV')
                 # Set data to itself to trigger reset of the interpolator
                 # TODO: Make NDData notice change of axis
-                self.edisp.data = self.edisp.data
+                self.edisp.data.data = self.edisp.data.data
 
         self.on_vector.write(outdir / phafile, clobber=overwrite)
         self.aeff.write(outdir / arffile, clobber=overwrite)

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -105,6 +105,15 @@ class TestSpectrumExtraction:
                                  extraction.observations[0].on_vector.data.data)
         assert_quantity_allclose(testobs.on_vector.energy.nodes,
                                  extraction.observations[0].on_vector.energy.nodes)
+        # Test if use_sherpa = True
+        extraction.run(outdir=tmpdir, use_sherpa=True)
+        testobs = SpectrumObservation.read(tmpdir / 'ogip_data' / 'pha_obs23523.fits')
+        assert_quantity_allclose(testobs.aeff.data.data,
+                                 extraction.observations[0].aeff.data.data)
+        assert_quantity_allclose(testobs.on_vector.data.data,
+                                 extraction.observations[0].on_vector.data.data)
+        assert_quantity_allclose(testobs.on_vector.energy.nodes,
+                                 extraction.observations[0].on_vector.energy.nodes)
 
     def test_define_energy_threshold(self, extraction):
         # TODO: Find better API for this


### PR DESCRIPTION
There was an issue in the method ```write```of the class ```SpectrumObservation```. The option use_sherpa was not tested and with the modification you did for the type of area.data or edisp.data it was not working anymore.
I fix the issue and add a test for use_sherpa=True