### PR TITLE
Fix issue for PSFtable3D for the containment fraction correction for the Full IRF

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -11,6 +11,7 @@ from ..data import Target
 from ..background import ReflectedRegionsBackgroundEstimator
 from .core import PHACountsSpectrum
 from .observation import SpectrumObservation, SpectrumObservationList
+from ..irf import PSF3D
 
 __all__ = [
     'SpectrumExtraction',
@@ -213,7 +214,10 @@ class SpectrumExtraction(object):
             if self.containment_correction:
                 # First need psf
                 angles = np.linspace(0., 1.5, 150) * u.deg
-                psf = obs.psf.to_energy_dependent_table_psf(offset, angles)
+                if isinstance(obs.psf, PSF3D):
+                    psf = obs.psf.to_energy_dependent_table_psf(theta=offset)
+                else:
+                    psf = obs.psf.to_energy_dependent_table_psf(offset, angles)
 
                 center_energies = arf.energy.nodes
                 for index, energy in enumerate(center_energies):


### PR DESCRIPTION
@cdeil 
There was a small bug for the psf if a PSF3D type... I don't know in the test ```test_extract``` in ```spectrum/test``` how to force the test to use the PSF3D psf in the gammapy_extra repository to test this?