### PR TITLE
Fix an issue with the energies binning in Cube_pipe

### DIFF
--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -46,7 +46,7 @@ class SingleObsCubeMaker(object):
 
     def __init__(self, obs, empty_cube_images, empty_exposure_cube, offset_band, exclusion_mask=None,
                  save_bkg_scale=True):
-        self.energy_reco = empty_cube_images.energies()
+        self.energy_reco = empty_cube_images.energies(mode="edges")
         self.offset_band = offset_band
         self.counts_cube = SkyCube.empty_like(empty_cube_images)
         self.bkg_cube = SkyCube.empty_like(empty_cube_images)

--- a/gammapy/cube/tests/test_cube_pipe.py
+++ b/gammapy/cube/tests/test_cube_pipe.py
@@ -101,13 +101,13 @@ def test_cube_pipe(tmpdir):
     cube_maker.make_cubes(make_background_image=True, radius=10.)
 
     assert_allclose(cube_maker.counts_cube.data.sum(), 4898.0, atol=3)
-    assert_allclose(cube_maker.bkg_cube.data.sum(), 4259.818621739171, atol=3)
+    assert_allclose(cube_maker.bkg_cube.data.sum(), 4260.120595293951, atol=3)
     cube_maker.significance_cube.data[np.where(np.isinf(cube_maker.significance_cube.data))] = 0
-    assert_allclose(np.nansum(cube_maker.significance_cube.data), 57442.86760518042, atol=3)
-    assert_allclose(cube_maker.excess_cube.data.sum(), 638.1813782608283, atol=3)
+    assert_allclose(np.nansum(cube_maker.significance_cube.data), 67613.24519908393, atol=3)
+    assert_allclose(cube_maker.excess_cube.data.sum(), 637.8794047060486, atol=3)
     assert_quantity_allclose(np.nansum(cube_maker.exposure_cube.data), Quantity(4891844242766714.0, "m2 s"),
                              atol=Quantity(3, "m2 s"))
-    assert_allclose(cube_maker.table_bkg_scale[0]["bkg_scale"], 1.2631250488423862)
+    assert_allclose(cube_maker.table_bkg_scale[0]["bkg_scale"], 0.8956177614218819)
 
     assert len(cube_maker.counts_cube.energies()) == 5
     assert len(cube_maker.bkg_cube.energies()) == 5


### PR DESCRIPTION
There was an issue in the code of cube_pipe when I was calling the method energies() of a ```SkyCube```. I forgot to specify mode="edges" so the last bin in energy for the background was always zero...
Sorry for the mistake