### PR TITLE
WIP: Add SkyImageHealpix class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ sdist
 develop-eggs
 .installed.cfg
 distribute-*.tar.gz
+.eggs
 
 # Other
 .*.swp

--- a/gammapy/cube/healpix.py
+++ b/gammapy/cube/healpix.py
@@ -1,0 +1,127 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+
+from astropy.io import fits
+from astropy.table import Table
+from astropy import units as u
+
+from .core import SkyCube
+from ..image.healpix import SkyImageHealpix, WCSHealpix
+from ..spectrum.utils import LogEnergyAxis
+from ..utils.scripts import make_path
+
+__all__ = ['SkyCubeHealpix']
+
+
+class SkyCubeHealpix(object):
+    """
+    Sky cube object with healpix pixelisation.
+
+    First axis is energy axis.
+    """
+    def __init__(self, name=None, data=None, wcs=None, energy_axis=None, meta=None):
+        # TODO: check validity of inputs
+        self.name = name
+        self.data = data
+        self.wcs = wcs
+        self.meta = meta
+        self.energy_axis = energy_axis
+
+    @classmethod
+    def read(cls, filename, format='fermi-exposure'):
+        """Read sky cube healpix from FITS file.
+
+        Parameters
+        ----------
+        filename : str
+            File name
+        format : {'fermi-exposure'}
+            Fits file format.
+
+        Returns
+        -------
+        sky_cube_healpix : `SkyCubeHealpix`
+            Sky cube
+        """
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename))
+
+        if format == 'fermi-exposure':
+            energy = Table.read(hdulist['ENERGIES'])['Energy']
+            energy_axis = LogEnergyAxis(u.Quantity(energy, 'MeV'), mode='center')
+            data = hdulist['HPXEXPOSURES'].data
+            data = np.vstack([data[energy] for energy in data.columns.names])
+            data = u.Quantity(data, 'cm2 s')
+            name = 'exposure'
+            header = hdulist['HPXEXPOSURES'].header
+            nside = header['NSIDE']
+            scheme = header.get('ORDERING', 'ring').lower()
+            wcs = WCSHealpix(nside, scheme=scheme)
+        else:
+            raise ValueError('Not a valid cube fits format')
+
+        return cls(name=name, data=data, wcs=wcs, energy_axis=energy_axis)
+
+    def sky_image_healpix(self, energy):
+        """
+        Slice a 2-dim `~gammapy.image.healpix.SkyImageHealpix` from the cube
+        at a given energy.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Energy value
+        """
+        z = self.energy_axis.wcs_world2pix(energy)
+        data = self.data[int(np.rint(z))].copy()
+        wcs = self.wcs
+        return SkyImageHealpix(name=self.name, data=data, wcs=wcs)
+
+    def reproject(self, reference, **kwargs):
+        """Spatially reprojects a `SkyCube` onto a reference.
+
+        Parameters
+        ----------
+        reference : `~astropy.io.fits.Header`, `SkyImage` or `SkyCube`
+            Reference wcs specification to reproject the data on.
+        **kwargs : dict
+            Keyword arguments passed to `~reproject.reproject_from_healpix`
+
+        Returns
+        -------
+        reprojected_cube : `SkyCube`
+            Cube spatially reprojected to the reference.
+        """
+        if isinstance(reference, SkyCube):
+            reference = reference.sky_image_ref
+
+        out = []
+        for energy in self.energies():
+            image_hpx = self.sky_image_healpix(energy)
+            image_out = image_hpx.reproject(reference, **kwargs)
+            out.append(image_out.data)
+
+        data = u.Quantity(np.stack(out, axis=0), self.data.unit)
+        wcs = image_out.wcs.copy()
+        return SkyCube(name=self.name, data=data, wcs=wcs, meta=self.meta,
+                              energy_axis=self.energy_axis)
+
+    def energies(self, mode='center'):
+        """
+        Energy coordinate vector.
+
+        Parameters
+        ----------
+        mode : {'center', 'edges'}
+            Return coordinate values at the pixels edges or pixel centers.
+
+        Returns
+        -------
+        coordinates : `~astropy.units.Quantity`
+            Energy
+        """
+        if mode == 'center':
+            z = np.arange(self.data.shape[0])
+        elif mode == 'edges':
+            z = np.arange(self.data.shape[0] + 1) - 0.5
+        return self.energy_axis.wcs_pix2world(z)

--- a/gammapy/image/healpix.py
+++ b/gammapy/image/healpix.py
@@ -1,0 +1,150 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from collections import OrderedDict
+
+import healpy as hp
+
+from astropy.wcs import WCS
+from .core import SkyImage
+from ..utils.scripts import make_path
+
+
+__all__ = ['SkyImageHealpix']
+
+
+#TODO: check if inheritance from SkyImage is resonable
+class SkyImageHealpix(object):
+    """
+    Sky image object with healpix pixelisation.
+
+    Parameters
+    ----------
+    name : str
+        Name of the image.
+    data : `~numpy.ndarray`
+        Data array.
+    wcs : `WCSHealpix`
+        Healpix WCS transformation object.
+    unit : str
+        String specifying the data units.
+    meta : `~collections.OrderedDict`
+        Dictionary to store meta data.
+    """
+    def __init__(self, name=None, data=None, wcs=None, meta=None, unit=None):
+        self.name = name
+        if not len(data) == wcs.npix:
+            raise ValueError("'data' must have length of {}".format(wcs.npix))
+        self.data = data
+        self.wcs = wcs
+
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
+
+        self.unit = unit
+
+    @classmethod
+    def read(cls, filename, **kwargs):
+        """Read image from FITS file.
+
+        Parameters
+        ----------
+        filename : str
+            FITS file name
+        **kwargs : dict
+            Keyword arguments passed `~healpy.read_map`.
+        """
+        filename = make_path(filename)
+        data, header = hp.read_map(str(filename), h=True)
+        header = OrderedDict(header)
+        nside = header['NSIDE']
+        scheme = header.get('ORDERING', 'ring').lower()
+        wcs = WCSHealpix(nside, scheme=scheme)
+        return cls(data=data, wcs=wcs)
+
+    def reproject(self, reference, **kwargs):
+        """
+        Reproject healpix image to given reference.
+
+        Parameters
+        ----------
+        reference : `~astropy.io.fits.Header`, or `~gammapy.image.SkyImage`
+            Reference image specification to reproject the data on.
+        **kwargs : dict
+            Keyword arguments passed to `~reproject.reproject_from_helapix`.
+
+        Returns
+        -------
+        image : `~gammapy.image.SkyImage`
+            Image reprojected onto ``reference``.
+        """
+        from reproject import reproject_from_healpix
+
+        if isinstance(reference, SkyImage):
+            wcs_reference = reference.wcs.deepcopy()
+            shape_out = reference.data.shape
+        elif isinstance(reference, fits.Header):
+            wcs_reference = WCS(reference)
+            shape_out = (reference['NAXIS2'], reference['NAXIS1'])
+        else:
+            raise TypeError("Invalid reference image. Must be either instance"
+                            "of `Header`, `WCS` or `SkyImage`.")
+
+        out = reproject_from_healpix((self.data, self.wcs.coordsys), wcs_reference,
+                                      nested=self.wcs.nested, shape_out=shape_out)
+        return SkyImage(name=self.name, data=out[0], wcs=wcs_reference)
+
+    def plot(self, ax=None, projection='mollweide', **kwargs):
+        """
+        Plot healpix sky image using a global projection.
+
+        Parameters
+        ----------
+        projection : ['mollweide', 'cartesian']
+            Which projection to use for plotting.
+        """
+        #TODO: add other projections
+        if projection == 'mollweide':
+            hp.mollview(map=self.data, nest=self.wcs.nested, **kwargs)
+        elif projection == 'cartesian':
+            hp.cartview(map=self.data, nest=self.wcs.nested, **kwargs)
+        else:
+            raise ValueError("Projection must be 'cartesian' or 'mollweide'")
+
+
+class WCSHealpix(object):
+    """
+    Healpix projection that behave WCS object like.
+
+    TODO: check if this can be handled by `~astropy.wcs.WCS` as well and if this
+    class is needed at all.
+    """
+    def __init__(self, nside, scheme='nested', coordsys='galactic'):
+        self.coordsys = coordsys
+
+        # check if nside is power of 2, taken from:
+        # http://code.activestate.com/recipes/577514-chek-if-a-number-is-a-power-of-two/
+        if not ((nside & (nside - 1)) == 0) and nside > 0:
+            raise ValueError("'nside' must be power of 2!")
+        self.nside = nside
+        if not scheme in ['nested', 'ring']:
+            raise ValueError("Scheme must be 'nested' or 'ring'")
+        self.scheme = scheme
+
+    def wcs_pix2world(self, ipix):
+        theta, phi = hp.pix2ang(self.nside, ipix, nest=self.nested)
+        return theta, phi
+
+    def wcs_world2pix(self, skycoord):
+        ipix = hp.ang2pix(self.nside, theta=theta, phi=phi, nest=self.nested)
+        return ipix
+
+    @property
+    def nested(self):
+        """Whether pixel ordering scheme is nested"""
+        return self.scheme == 'nested'
+
+    @property
+    def npix(self):
+        """Number of pixels corresponding to nside"""
+        return hp.nside2npix(self.nside)

--- a/gammapy/image/healpix.py
+++ b/gammapy/image/healpix.py
@@ -71,7 +71,7 @@ class SkyImageHealpix(object):
         reference : `~astropy.io.fits.Header`, or `~gammapy.image.SkyImage`
             Reference image specification to reproject the data on.
         **kwargs : dict
-            Keyword arguments passed to `~reproject.reproject_from_helapix`.
+            Keyword arguments passed to `~reproject.reproject_from_healpix`.
 
         Returns
         -------
@@ -114,7 +114,7 @@ class SkyImageHealpix(object):
 
 class WCSHealpix(object):
     """
-    Healpix projection that behave WCS object like.
+    Healpix transformation that behave WCS object like.
 
     TODO: check if this can be handled by `~astropy.wcs.WCS` as well and if this
     class is needed at all.

--- a/gammapy/image/tests/test_healpix.py
+++ b/gammapy/image/tests/test_healpix.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from numpy.testing.utils import assert_allclose
+
+from ...utils.testing import requires_dependency, requires_data
+from ..core import SkyImage
+
+@requires_dependency('healpy')
+class TestSkyImageHealpix:
+    def setup(self):
+        from ..healpix import SkyImageHealpix, WCSHealpix
+        wcs = WCSHealpix(nside=2)
+        data = np.ones(wcs.npix)
+        self.skyimage_hpx = SkyImageHealpix(name='test', data=data, wcs=wcs)
+
+    @requires_dependency('reproject')
+    def test_reproject(self):
+        reference = SkyImage.empty(nxpix=21, nypix=11, binsz=1.)
+        reprojected = self.skyimage_hpx.reproject(reference)
+        assert_allclose(reprojected.data, 1.)


### PR DESCRIPTION
This PR adds a `SkyImageHealpix` and `SkyCubeHealpix` class to handle healpix allsky data (right now only Fermi-LAT exposure cubes).

Todo:
- [x] Add minimal tests
