### PR TITLE
Add background model component to SpectrumFit

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -67,6 +67,9 @@ class SpectrumFit(object):
 
         # TODO: Check if IRFs are given for forward folding
 
+        if stat == 'wstat' and obs_list[0].off_vector is None:
+            raise ValueError('Off vector required for WStat fit')
+
         self.obs_list = obs_list
         self.model = model
         self.stat = stat
@@ -337,13 +340,19 @@ class SpectrumFit(object):
         will change the model parameters and statval again
         """
         from . import SpectrumFitResult
-        for idx, obs in enumerate(self.obs_list):
-            model = self.model.copy()
-            covariance = None
-            covar_axis = None
 
+        model = self.model.copy()
+        if self.background_model is not None:
+            bkg_model = self.background_model.copy()
+        else:
+            bkg_model = None
+
+        covariance = None
+        covar_axis = None
+        statname = self.stat
+
+        for idx, obs in enumerate(self.obs_list):
             fit_range = self.true_fit_range[idx]
-            statname = self.stat
             statval = np.sum(self.statval[idx])
             npred_src = copy.deepcopy(self.predicted_counts[idx][0])
             npred_bkg = copy.deepcopy(self.predicted_counts[idx][1])
@@ -356,6 +365,7 @@ class SpectrumFit(object):
                 statval=statval,
                 npred_src=npred_src,
                 npred_bkg=npred_bkg,
+                background_model = bkg_model,
                 obs=obs
             ))
 

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -263,7 +263,6 @@ class SpectrumFit(object):
                                      mu_on=mu_on)
                 off_stat = np.zeros_like(on_stat)
 
-
         elif self.stat == 'wstat':
             kwargs = dict(n_on=obs.on_vector.data.data.value,
                           n_off=obs.off_vector.data.data.value,

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -396,6 +396,8 @@ class SpectrumFit(object):
         -------
         result : `~gammapy.spectrum.SpectrumResult`
         """
+        raise NotImplementedError()
+
     def run(self, outdir=None):
         """Run all steps and write result to disk
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -277,11 +277,19 @@ class PowerLaw(SpectralModel):
         # this is to get a consistent API with SpectralModel.integral()
         pars = self.parameters
 
-        val = -1 * pars.index + 1
-        prefactor = pars.amplitude * pars.reference / val
-        upper = np.power((emax / pars.reference), val)
-        lower = np.power((emin / pars.reference), val)
-        return prefactor * (upper - lower)
+        if np.isclose(pars.index, 1):
+            e_unit = emin.unit
+            prefactor = pars.amplitude * pars.reference.to(e_unit)
+            upper = np.log(emax.to(e_unit).value)
+            lower = np.log(emin.value)
+        else:
+            val = -1 * pars.index + 1
+            prefactor = pars.amplitude * pars.reference / val
+            upper = np.power((emax / pars.reference), val)
+            lower = np.power((emin / pars.reference), val)
+
+        integral = prefactor * (upper - lower)
+        return integral
 
     def energy_flux(self, emin, emax):
         r"""

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -314,9 +314,9 @@ class PowerLaw(SpectralModel):
         val = -1 * pars.index + 2
 
         try:
-            val_zero = (val.n == 0)
+            val_zero = np.isclose(val.n, 0)
         except AttributeError:
-            val_zero = (val == 0)
+            val_zero = np.isclose(val, 0)
 
         if val_zero:
             # see https://www.wolframalpha.com/input/?i=a+*+x+*+(x%2Fb)+%5E+(-2)

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -331,24 +331,19 @@ class SpectrumFitResult(object):
         """`~gammapy.spectrum.CountsSpectrum` of predicted source counts
         """
         energy = self.obs.on_vector.energy
-        data = self.npred * u.ct
-        idx = np.isnan(data)
-        data[idx] = 0
+        data = self.npred_src * u.ct
         return CountsSpectrum(data=data, energy=energy)
 
     @property
     def expected_background_counts(self):
         """`~gammapy.spectrum.CountsSpectrum` of predicted background counts
-
-        According to profile likelihood, see :ref:`wstat`.
         """
-        energy = self.obs.e_reco
-        n_on = self.obs.on_vector.data.data.value
-        n_off = self.obs.off_vector.data.data.value
-        alpha = self.obs.alpha
-        mu_sig = self.expected_source_counts.data.data.value
-        data = stats.get_wstat_mu_bkg(n_on=n_on, n_off=n_off, alpha=alpha, mu_sig=mu_sig)
-        return CountsSpectrum(data=data, energy=energy)
+        try:
+            energy = self.obs.e_reco
+            data = self.npred_bkg * u.ct
+            return CountsSpectrum(data=data, energy=energy)
+        except TypeError:
+            return None 
 
     @property
     def expected_on_counts(self):

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -37,8 +37,10 @@ class SpectrumFitResult(object):
         Statistic used for the fit
     statval : float, optional
         Final fit statistic
-    npred : array-like, optional
-        On counts predicted by the fit
+    npred_src : array-like, optional
+        source counts predicted by the fit 
+    npred_bkg : array-like, optional
+        background counts predicted by the fit 
     flux_at_1TeV : dict, optional
         Flux for the fitted model at 1 TeV
     flux_at_1TeV_err : dict, optional
@@ -48,8 +50,8 @@ class SpectrumFitResult(object):
     """
 
     def __init__(self, model, covariance=None, covar_axis=None, fit_range=None,
-                 statname=None, statval=None, npred=None, fluxes=None,
-                 flux_errors=None, obs=None):
+                 statname=None, statval=None, npred_src=None, npred_bkg=None,
+                 fluxes=None, flux_errors=None, obs=None):
 
         self.model = model
         self.covariance = covariance
@@ -57,7 +59,8 @@ class SpectrumFitResult(object):
         self.fit_range = fit_range
         self.statname = statname
         self.statval = statval
-        self.npred = npred
+        self.npred_src = npred_src
+        self.npred_bkg = npred_bkg
         self.fluxes = fluxes
         self.flux_errors = flux_errors
         self.obs = obs

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -38,9 +38,11 @@ class SpectrumFitResult(object):
     statval : float, optional
         Final fit statistic
     npred_src : array-like, optional
-        source counts predicted by the fit 
+        Source counts predicted by the fit 
     npred_bkg : array-like, optional
-        background counts predicted by the fit 
+        Background counts predicted by the fit 
+    background_model : `~gammapy.spectrum.SpectralModel`
+        Best-fit background model
     flux_at_1TeV : dict, optional
         Flux for the fitted model at 1 TeV
     flux_at_1TeV_err : dict, optional
@@ -51,7 +53,7 @@ class SpectrumFitResult(object):
 
     def __init__(self, model, covariance=None, covar_axis=None, fit_range=None,
                  statname=None, statval=None, npred_src=None, npred_bkg=None,
-                 fluxes=None, flux_errors=None, obs=None):
+                 background_model=None, fluxes=None, flux_errors=None, obs=None):
 
         self.model = model
         self.covariance = covariance
@@ -61,6 +63,7 @@ class SpectrumFitResult(object):
         self.statval = statval
         self.npred_src = npred_src
         self.npred_bkg = npred_bkg
+        self.background_model = background_model
         self.fluxes = fluxes
         self.flux_errors = flux_errors
         self.obs = obs

--- a/gammapy/spectrum/sherpa_utils.py
+++ b/gammapy/spectrum/sherpa_utils.py
@@ -28,7 +28,20 @@ class SherpaModel(ArithmeticModel):
     def __init__(self, fit):
         # TODO: add Parameter and ParameterList class
         self.fit = fit
-        self.sorted_pars = OrderedDict(**self.fit.model.parameters)
+        source_pars = OrderedDict(**self.fit.model.parameters)
+        # "Freeze reference by removing it from fit parameters
+        # TODO: Add proper
+        source_pars.pop('reference')
+        self.sorted_pars = source_pars
+        
+        # Add background model pars if needed
+        if self.fit.background_model is not None:
+            bkg_pars = OrderedDict(**self.fit.background_model.parameters)
+            bkg_pars.pop('reference')
+            for par in bkg_pars:
+                # TODO: Find better way do mark background parameters
+                self.sorted_pars['bkg_{}'.format(par)] = bkg_pars[par]
+
         sherpa_name = 'sherpa_model'
         par_list = list()
         for name, par in self.sorted_pars.items():
@@ -42,15 +55,17 @@ class SherpaModel(ArithmeticModel):
         ArithmeticModel.__init__(self, sherpa_name, par_list)
         self._use_caching = True
         self.cache = 10
-        # TODO: Remove after introduction of proper parameter class
-        self.reference.freeze()
 
     @modelCacher1d
     def calc(self, p, x, xhi=None):
         # Adjust model parameters
         for par, parval in zip(self.sorted_pars, p):
             par_unit = self.sorted_pars[par].unit
-            self.fit.model.parameters[par] = parval * par_unit
+            if 'bkg' in par:
+                self.fit.background_model.parameters[par[4:]] = parval * par_unit
+            else:
+                self.fit.model.parameters[par] = parval * par_unit
+
         self.fit.predict_counts()
         # Return ones since sherpa does some check on the shape
         return np.ones_like(self.fit.obs_list[0].e_reco)

--- a/gammapy/spectrum/sherpa_utils.py
+++ b/gammapy/spectrum/sherpa_utils.py
@@ -88,7 +88,7 @@ class SherpaStat(Likelihood):
     def _calc(self, data, model, *args, **kwargs):
         self.fit.calc_statval()
         # Sum likelihood over all observations
-        total_stat = np.sum(self.fit.statval)
+        total_stat = np.sum(self.fit.statval, dtype=np.float64)
         # sherpa return pattern: total stat, fvec
         return total_stat, None
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -65,7 +65,7 @@ class TestFit:
         assert 'Spectrum' in str(fit)
 
         fit.predict_counts()
-        assert_allclose(fit.predicted_counts[0][5], 660.5171280778071)
+        assert_allclose(fit.predicted_counts[0][0][5], 660.5171280778071)
 
         fit.calc_statval()
         assert_allclose(np.sum(fit.statval[0]), -107346.5291329714)
@@ -77,6 +77,28 @@ class TestFit:
                         1.9955563477414806)
         assert_allclose(fit.model.parameters.amplitude.value,
                         100250.33102108649)
+
+    def test_cash_with_bkg(self):
+        """Cash fit taking into account background model"""
+        on_vector = self.src.copy()
+        on_vector.data.data += self.bkg.data.data
+        obs = SpectrumObservation(on_vector=on_vector, off_vector=self.off)
+        obs_list = SpectrumObservationList([obs])
+
+        self.source_model.parameters.index = 1 * u.Unit('')
+        self.bkg_model.parameters.index = 1 * u.Unit('')
+        fit = SpectrumFit(obs_list=obs_list, model=self.source_model,
+                          stat='cash', forward_folded=False,
+                          background_model=self.bkg_model)
+        assert 'Background' in str(fit)
+
+        fit.fit()
+        print('\nSOURCE\n {}'.format(fit.model))
+        print('\nBKG\n {}'.format(fit.background_model))
+        assert_allclose(fit.result[0].model.parameters.index,
+                        1.996272386763962)
+        assert_allclose(fit.background_model.parameters.index,
+                        2.9926225268193418)
 
     def test_wstat(self):
         """WStat with on source and background spectrum"""

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -28,7 +28,8 @@ class TestSpectrumFitResult:
             fit_range=self.fit_range,
             statname='wstat',
             statval=42,
-            npred=self.npred,
+            npred_src=self.npred,
+            npred_bkg=self.npred * 0.5,
             obs=self.obs,
         )
 


### PR DESCRIPTION
This PR

* Allows a background model to be passed to ``SpectrumFit``. If a cash fit is performed it is added to the fit model
* Add the possibility to calculate & plot likelihood profiles to ``SpectrumFit``

Does NOT

* Add a Parameter class, the code as it is contains many hacks, but I wanted to keep the diff small. I will start a follow-up PR now

No need to review