### PR TITLE
Add test to make sure OGIP files are readable with sherpa

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -335,7 +335,7 @@ class PHACountsSpectrum(CountsSpectrum):
         super(PHACountsSpectrum, self).__init__(energy, data)
         self.obs_id=obs_id
         if quality is None:
-            quality = np.zeros(self.energy.nbins, dtype=int)
+            quality = np.zeros(self.energy.nbins, dtype='i2')
         self.quality = quality
         self.is_bkg = is_bkg
         self.meta = Bunch(kwargs)

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -105,15 +105,18 @@ class TestSpectrumExtraction:
                                  extraction.observations[0].on_vector.data.data)
         assert_quantity_allclose(testobs.on_vector.energy.nodes,
                                  extraction.observations[0].on_vector.energy.nodes)
-        # Test if use_sherpa = True
+
+    @requires_dependency('sherpa')
+    def test_sherpa(self, tmpdir, extraction):
+        """Same as above for files to be used with sherpa"""
         extraction.run(outdir=tmpdir, use_sherpa=True)
-        testobs = SpectrumObservation.read(tmpdir / 'ogip_data' / 'pha_obs23523.fits')
-        assert_quantity_allclose(testobs.aeff.data.data,
-                                 extraction.observations[0].aeff.data.data)
-        assert_quantity_allclose(testobs.on_vector.data.data,
-                                 extraction.observations[0].on_vector.data.data)
-        assert_quantity_allclose(testobs.on_vector.energy.nodes,
-                                 extraction.observations[0].on_vector.energy.nodes)
+
+        import sherpa.astro.ui as sau
+        sau.load_pha(str(tmpdir / 'ogip_data' / 'pha_obs23523.fits'))
+        arf = sau.get_arf()
+        actual = arf._arf._specresp
+        desired = extraction.observations[0].aeff.data.data.value
+        assert_allclose(actual, desired)
 
     def test_define_energy_threshold(self, extraction):
         # TODO: Find better API for this


### PR DESCRIPTION
I received the following issue via slack from @registerrier 

>it seems it is not possible to open the ogip files produced with SpectrumExtraction directly into sherpa at the moment.
It ends up with SystemError: error return without exception set.
Any idea on why that is?

Indeed, there was not test to make sure that our OGIP files are readable with Sherpa, so I added one. However, I cannot reproduce the issue described. @registerrier can you have a look at [the test](https://github.com/gammapy/gammapy/pull/847/files#diff-8a3a149acc144cd2c63f9bffb70e6a84R115) and tell me if I'm doing something different from what you do?