### PR TITLE
Correct export to OGIP

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -335,7 +335,7 @@ class PHACountsSpectrum(CountsSpectrum):
         super(PHACountsSpectrum, self).__init__(energy, data)
         self.obs_id=obs_id
         if quality is None:
-            quality = np.zeros(self.energy.nbins, dtype=int)
+            quality = np.zeros(self.energy.nbins, dtype='i2')
         self.quality = quality
         self.is_bkg = is_bkg
         self.meta = Bunch(kwargs)


### PR DESCRIPTION
Change dtype of quality array in PHACountSpectrum to have correct type w.r.t. OGIP specifications (2 byte integer)
see:  https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node7.html