### PR TITLE
Fix image_profile None comparison

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,18 +133,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 MAIN_CMD='make' SETUP_CMD='test-notebooks'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
-    # You can move builds that temporarily fail because of some non-Gammapy
-    # issue here
+
+    # You can move builds that temporarily fail because of some non-Gammapy here.
     # Please add a link to a GH issue that tracks the upstream issue.
-    allow_failures:
-        # see https://github.com/gammapy/gammapy/issues/439
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=dev SETUP_CMD='test -V'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
-        # this halts at the moment and thus allowing it to fail, to be able to go
-        # ahead with the release
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
+#    allow_failures:
+#        # copy the part from the `include` section above here.
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -240,6 +240,7 @@ class ImageProfileEstimator(object):
         plt.show()
 
     """
+
     def __init__(self, x_edges=None, method='sum', axis='lon'):
 
         self._x_edges = x_edges
@@ -348,7 +349,6 @@ class ImageProfileEstimator(object):
         label_image.data = data
         return label_image
 
-
     def run(self, image, image_err=None, mask=None):
         """
         Run image profile estimator.
@@ -412,6 +412,7 @@ class ImageProfile(object):
         Table instance with the columns specified as above.
 
     """
+
     def __init__(self, table):
         self.table = table
 
@@ -702,14 +703,14 @@ def image_profile(profile_axis, image, lats, lons, binsz, counts=None,
     lat = coordinates.data.lat.degree
     mask_init = (lats[0] <= lat) & (lat < lats[1])
     mask_bounds = mask_init & (lons[0] <= lon) & (lon < lons[1])
-    if mask != None:
+    if mask is not None:
         mask = mask_bounds & mask
     else:
         mask = mask_bounds
 
     # Need to preserve shape here so use multiply
     cut_image = image.data * mask
-    if counts != None:
+    if counts is not None:
         cut_counts = counts.data * mask
     values = []
     count_vals = []
@@ -726,7 +727,7 @@ def image_profile(profile_axis, image, lats, lons, binsz, counts=None,
             lat_mask = (bounds['GLAT_MIN'][bin] <= lat) & (lat < bounds['GLAT_MAX'][bin])
             lat_band = cut_image[lat_mask]
             values.append(lat_band.sum())
-            if counts != None:
+            if counts is not None:
                 count_band = cut_counts[lat_mask]
                 count_vals.append(count_band.sum())
             else:
@@ -744,14 +745,14 @@ def image_profile(profile_axis, image, lats, lons, binsz, counts=None,
             lon_mask = (bounds['GLON_MIN'][bin] <= lon) & (lon < bounds['GLON_MAX'][bin])
             lon_band = cut_image[lon_mask]
             values.append(lon_band.sum())
-            if counts != None:
+            if counts is not None:
                 count_band = cut_counts[lon_mask]
                 count_vals.append(count_band.sum())
             else:
                 count_vals.append(0)
 
-    if errors == True:
-        if counts != None:
+    if errors is True:
+        if counts is not None:
             rel_errors = 1. / np.sqrt(count_vals)
             error_vals = values * rel_errors
         else:


### PR DESCRIPTION
This pull request should fix a bug in image_profile that shows up with Numpy dev:
https://travis-ci.org/gammapy/gammapy/jobs/193710741#L1837

I don't see the issue locally, because I'm on Numpy 1.12, not dev:
```
python setup.py test -V -t gammapy/image/tests/test_profile.py -a '-k test_image_lat_profile'
```

I first mentioned this issue in #843, that issue can be closed if this PR fixes the travis-ci Numpy dev build.