### PR TITLE
Implement FermiLATDataset class

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -18,7 +18,6 @@ from astropy.table import Table
 from astropy.wcs import WCS
 from astropy.utils import lazyproperty
 from ..utils.scripts import make_path
-from ..utils.testing import assert_wcs_allclose
 from ..utils.energy import EnergyBounds, Energy
 from ..utils.fits import table_to_fits_table
 from ..image import SkyImage
@@ -66,6 +65,9 @@ class SkyCube(object):
     def __init__(self, name=None, data=None, wcs=None, energy_axis=None, meta=None):
         # TODO: check validity of inputs
         self.name = name
+        if not data.ndim == 3:
+            raise ValueError('Dimension of the data must be ndim = 3, but is '
+                             'ndim = {}'.format(data.ndim))
         self.data = data
         self.wcs = wcs
         self.meta = meta
@@ -696,6 +698,7 @@ class SkyCube(object):
 
     @staticmethod
     def assert_allclose(cube1, cube2):
+        from ..utils.testing import assert_wcs_allclose
         assert cube1.name == cube2.name
         assert_allclose(cube1.data, cube2.data)
         assert_wcs_allclose(cube1.wcs, cube2.wcs)

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -65,7 +65,9 @@ class SkyCube(object):
     def __init__(self, name=None, data=None, wcs=None, energy_axis=None, meta=None):
         # TODO: check validity of inputs
         self.name = name
-        if not data.ndim == 3:
+        # TODO: In gammapy SkyCube is used sometimes with ndim = 2 for cubes
+        # with a single energy band
+        if not data.ndim > 1:
             raise ValueError('Dimension of the data must be ndim = 3, but is '
                              'ndim = {}'.format(data.ndim))
         self.data = data

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -8,6 +8,7 @@ from astropy.utils.data import download_file
 from .core import gammapy_extra
 
 __all__ = [
+    'FermiLATDataset'
     'FermiGalacticCenter',
     'FermiVelaRegion',
     'fetch_fermi_diffuse_background_model',
@@ -32,7 +33,6 @@ def fetch_fermi_diffuse_background_model(filename='gll_iem_v02.fit'):
 
     url = BASE_URL + filename
     filename = download_file(url, cache=True)
-
     return filename
 
 
@@ -225,3 +225,188 @@ def load_lat_psf_performance(performance_file):
     table['containment_angle'].unit = 'deg'
 
     return table
+
+
+class FermiLATDataset(object):
+    """
+    Fermi dataset container class, with lazy data access.
+
+    Parameters
+    ----------
+    path : str
+        Path to the parent data folder. Must contain a 'config.yaml' file.
+    """
+
+    def __init__(self, filename='$FERMI_LAT_DATA/config.yaml'):
+        filename = make_path(filename)
+        self._path = filename.parents[0].resolve()
+        self.config = yaml.load(open(str(filename), 'r'))
+
+    def validate(self):
+        raise NotImplementedError
+
+    @lazyproperty
+    def filenames(self):
+        """
+        Absolut path filenames.
+        """
+        filenames = OrderedDict()
+        filenames_config = self.config['filenames']
+
+        # merge with base path
+        for _ in filenames_config:
+            filenames[_] = str(self._path / filenames_config[_])
+
+        filenames['galdiff'] = str(make_path('$FERMI_DIFFUSE_DIR/gll_iem_v06.fits'))
+        return filenames
+
+    @lazyproperty
+    def exposure(self):
+        """
+        Exposure cube.
+
+        Returns
+        -------
+        cube : `~gammapy.cube.SkyCube` or `~gammapy.cube.SkyCubeHealpix`
+            Exposure cube.
+        """
+        filename = self.filenames['exposure']
+        try:
+            cube = SkyCube.read(, format='fermi-exposure')
+        except:
+            cube = SkyCubeHealpix.read(, format='fermi-exposure')
+        cube.name = 'exposure'
+        #TODO: check why fixing the unit is needed
+        cube.data = u.Quantity(cube.data.value, 'cm2 s')
+        return cube
+
+    @lazyproperty
+    def counts(self):
+        """
+        Counts cube.
+
+        Returns
+        -------
+        cube : `~gammapy.cube.SkyCube` or `~gammapy.cube.SkyCubeHealpix`
+            Counts cube.
+        """
+        try:
+            filename = self.filenames['counts']
+        except KeyError:
+            raise NoDataAvailableError('Counts cube not available.')
+
+        try:
+            cube = SkyCube.read(filename, format='fermi-counts')
+        except:
+            cube = SkyCubeHealpix.read(filename, format='fermi-counts')
+
+        cube.name = 'counts'
+        return cube
+
+    @lazyproperty
+    def background(self):
+        """
+        Predicted total background counts cube.
+
+        Returns
+        -------
+        cube : `~gammapy.cube.SkyCube`
+            Predicted total background counts cube.
+        """
+        try:
+            filename = self.filenames['background']
+        except KeyError:
+            raise NoDataAvailableError('Predicted background counts cube not available.')
+
+        cube = SkyCube.read(filename, format='fermi-counts')
+        cube.name = 'background'
+        return cube
+
+    @lazyproperty
+    def galactic_diffuse(self):
+        """
+        Diffuse galactic background model flux cube.
+
+        Returns
+        -------
+        cube : `~gammapy.cube.SkyCube`
+            Diffuse galactic background cube.
+        """
+        try:
+            filename = self.filenames['galdiff']
+            cube = SkyCube.read(filename, format='fermi-background')
+            cube.name = 'galactic diffuse'
+            return cube
+        except IOError:
+            raise NoDataAvailableError('Fermi galactic diffuse model cube not available. '
+                                       'Please set $FERMI_DIFFUSE_DIR environment variable')
+
+    @lazyproperty
+    def isotropic_diffuse(self):
+        """
+        Isotropic diffuse background model table.
+
+        Returns
+        -------
+        spectral_model : `~gammapy.spectrum.models.TabelModel`
+            Isotropic diffuse background model.
+        """
+        table = self._read_iso_diffuse_table()
+
+        background_isotropic = TableModel(table['Energy'].quantity,
+                                          table['Flux'].quantity)
+
+        return background_isotropic
+
+    def _read_iso_diffuse_table(self):
+        filename = self.filenames['isodiff']
+        table = Table.read(filename, format='ascii')
+
+        table.rename_column('col1', 'Energy')
+        table['Energy'].unit = 'MeV'
+
+        table.rename_column('col2', 'Flux')
+        table['Flux'].unit = '1 / (cm2 MeV s sr)'
+
+        table.rename_column('col3', 'Flux_Err')
+        table['Flux_Err'].unit = '1 / (cm2 MeV s sr)'
+        return table
+
+    @property
+    def events(self):
+        """
+        Event list.
+
+        Returns
+        -------
+        events : `~gammapy.data.EventList`
+            Event list.
+        """
+        return EventList.read(self.filenames['events'])
+
+    @property
+    def psf(self):
+        """
+        PSF info.
+
+        Returns
+        -------
+        psf : `~gammapy.irf.EnergyDependentTablePSF`
+            PSF model.
+        """
+        return EnergyDependentTablePSF.read(self.filenames['psf'])
+
+    def info(self):
+        """
+        Print Summary info about the dataset.
+        """
+        print(self)
+
+    def __str__(self):
+        """
+        Summary info string about the dataset.
+        """
+        info =  'Fermi dataset\n'
+        info += '=============\n'
+        info += yaml.dump(self.config, default_flow_style=False)
+        return info

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -243,11 +243,11 @@ class FermiLATDataset(object):
 
     Parameters
     ----------
-    path : str
-        Path to the parent data folder. Must contain a 'config.yaml' file.
+    filename : str
+        Filename of the yaml file that specifies the data filenames.
     """
 
-    def __init__(self, filename='$FERMI_LAT_DATA/config.yaml'):
+    def __init__(self, filename):
         import yaml
         filename = make_path(filename)
         self._path = filename.parents[0].resolve()

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -419,6 +419,7 @@ class FermiLATDataset(object):
         """
         Summary info string about the dataset.
         """
+        import yaml
         info =  'Fermi dataset\n'
         info += '=============\n'
         info += yaml.dump(self.config, default_flow_style=False)

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing.utils import assert_allclose
+from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import (
+    FermiLATDataset,
     FermiGalacticCenter,
     FermiVelaRegion,
     load_lat_psf_performance,
@@ -117,3 +120,34 @@ def test_load_lat_psf_performance():
     table_p7_95 = load_lat_psf_performance('P7SOURCEV6_95')
     assert table_p7_95['energy'][0] == 31.6227766017
     assert table_p7_95['containment_angle'][0] == 38.3847234362
+
+@requires_data('fermi-lat')
+@requires_dependency('healpy')
+class TestFermiLATDataset:
+    def setup(self):
+        filename = '$FERMI_LAT_DATA/2fhl/fermi_2fhl_data_config.yaml'
+        self.data_2fhl = data = FermiLATDataset(filename)
+
+    def test_events(self):
+        events = self.data_2fhl.events
+        assert len(events.table) == 60275
+
+    def test_exposure(self):
+        exposure = self.data_2fhl.exposure
+        assert exposure.name == 'exposure'
+
+    def test_counts(self):
+        counts = self.data_2fhl.counts
+        assert_quantity_allclose(counts.data.sum(), 60275 * u.count)
+
+    def test_psf(self):
+        psf = self.data_2fhl.psf
+        actual = self.data_2fhl.psf.integral(100 * u.GeV, 0 * u.deg, 2 * u.deg)
+        desired = 1.00048
+        assert_allclose(actual, desired, rtol=1e-4)
+
+    def test_isodiff(self):
+        isodiff = self.data_2fhl.isotropic_diffuse
+        actual = isodiff(10 * u.GeV)
+        desired = 6.3191722098744606e-12 * u.Unit('1 / (cm2 MeV s sr)')
+        assert_quantity_allclose(actual, desired)

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -123,6 +123,7 @@ def test_load_lat_psf_performance():
 
 @requires_data('fermi-lat')
 @requires_dependency('healpy')
+@requires_dependency('yaml')
 class TestFermiLATDataset:
     def setup(self):
         filename = '$FERMI_LAT_DATA/2fhl/fermi_2fhl_data_config.yaml'

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -18,7 +18,6 @@ def test_extended_image():
     # TODO: implement me
     pass
 
-@pytest.mark.xfail
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_source_image():
@@ -40,7 +39,6 @@ def test_source_image():
     expected = 1.6098631760996795e-07
     assert_allclose(actual, expected)
 
-@pytest.mark.xfail
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_catalog_image():

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from astropy.wcs import WCS
+from astropy.tests.helper import pytest
 from ...utils.testing import requires_dependency, requires_data
 from .. import catalog
 from ...image import SkyImage
@@ -17,6 +18,7 @@ def test_extended_image():
     # TODO: implement me
     pass
 
+@pytest.mark.xfail
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_source_image():
@@ -38,7 +40,7 @@ def test_source_image():
     expected = 1.6098631760996795e-07
     assert_allclose(actual, expected)
 
-
+@pytest.mark.xfail
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_catalog_image():

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -82,6 +82,8 @@ def has_data(name):
         return ('HGPS_DATA' in os.environ) and ('HGPS_ANALYSIS' in os.environ)
     elif name == 'gamma-cat':
         return ('GAMMA_CAT' in os.environ)
+    elif name == 'fermi-lat':
+        return ('FERMI_LAT_DATA' in os.environ)
     else:
         raise ValueError('Invalid name: {}'.format(name))
 


### PR DESCRIPTION
This PR implements a `FermiLATDataset` class, which allows easy access to prepared Fermi-LAT datasets. It returns instances of the corresponding gammapy data classes i.e. `SkyCubeHealpix` for exposure and counts, `EnergyDependentTablePSF` for the psf and `EventList` for the events.