### PR TITLE
Fix Fermi catalog flux point upper limits

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -441,7 +441,6 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         covariance = np.diag([
             data['Unc_Spectral_Index'] ** 2,
             data['Unc_Flux50'] ** 2,
-            0,
         ])
 
         covar_axis = ['index', 'amplitude']
@@ -588,7 +587,6 @@ class SourceCatalogObject1FHL(SourceCatalogObject):
         covariance = np.diag([
             data['Unc_Spectral_Index'] ** 2,
             data['Unc_Flux'] ** 2,
-            0,
         ])
 
         covar_axis = ['index', 'amplitude']

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -298,6 +298,23 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         table['eflux_errn'] = np.abs(nuFnu * flux_err[:, 0] / flux)
         table['eflux_errp'] = nuFnu * flux_err[:, 1] / flux
 
+        is_ul = np.isnan(table['flux_errn'])
+        table['is_ul'] = is_ul
+
+        # handle upper limits
+        table['flux_ul'] = np.nan * flux_err.unit
+        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
+
+        for column in ['flux', 'flux_errp', 'flux_errn']:
+            table[column][is_ul] = np.nan
+
+        # handle upper limits
+        table['eflux_ul'] = np.nan * nuFnu.unit
+        table['eflux_ul'][is_ul] = table['eflux_errp'][is_ul]
+
+        for column in ['eflux', 'eflux_errp', 'eflux_errn']:
+            table[column][is_ul] = np.nan
+
         # TODO: check if nuFnu is maybe integral flux
         table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
         return FluxPoints(table)
@@ -411,6 +428,16 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         flux_err = self._get_flux_values('Unc_Flux')
         table['flux_errn'] = np.abs(flux_err[:, 0])
         table['flux_errp'] = flux_err[:, 1]
+
+        # handle upper limits
+        is_ul = np.isnan(table['flux_errn'])
+        table['is_ul'] = is_ul
+        table['flux_ul'] = np.nan * flux_err.unit
+        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
+
+        for column in ['flux', 'flux_errp', 'flux_errn']:
+            table[column][is_ul] = np.nan
+
         flux_points = FluxPoints(table)
 
         flux_points_dnde = compute_flux_points_dnde(
@@ -557,6 +584,16 @@ class SourceCatalogObject1FHL(SourceCatalogObject):
         flux_err = self._get_flux_values('Unc_Flux')
         table['flux_errn'] = np.abs(flux_err[:, 0])
         table['flux_errp'] = flux_err[:, 1]
+
+        # handle upper limits
+        is_ul = np.isnan(table['flux_errn'])
+        table['is_ul'] = is_ul
+        table['flux_ul'] = np.nan * flux_err.unit
+        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
+
+        for column in ['flux', 'flux_errp', 'flux_errn']:
+            table[column][is_ul] = np.nan
+
         flux_points = FluxPoints(table)
 
         flux_points_dnde = compute_flux_points_dnde(

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -155,10 +155,10 @@ class TestSourceCatalog1FHL:
 @requires_data('gammapy-extra')
 class TestFermi1FHLObject:
     def setup(self):
-        cat = SourceCatalog1FHL()
+        self.cat = SourceCatalog1FHL()
         # Use 1FHL J0534.5+2201 (Crab) as a test source
         self.source_name = '1FHL J0534.5+2201'
-        self.source = cat[self.source_name]
+        self.source = self.cat[self.source_name]
 
     def test_name(self):
         assert self.source.name == self.source_name
@@ -168,6 +168,18 @@ class TestFermi1FHLObject:
         energy = u.Quantity(100, 'GeV')
         desired = u.Quantity(4.7717464131e-12, 'cm-2 GeV-1 s-1')
         assert_quantity_allclose(model(energy), desired)
+
+    def test_flux_points(self):
+        # test flux point on  PKS 2155-304
+        src = self.cat['1FHL J0153.1+7515']
+        flux_points = src.flux_points
+        actual = flux_points.table['flux']
+        desired = [5.523017e-11, np.nan, np.nan] * u.Unit('cm-2 s-1')
+        assert_quantity_allclose(actual, desired)
+
+        actual = flux_points.table['flux_ul']
+        desired = [np.nan, 2.081589e-11, 1.299698e-11] * u.Unit('cm-2 s-1')
+        assert_quantity_allclose(actual, desired, rtol=1E-5)
 
     @requires_dependency('uncertainties')
     def test_spectrum(self):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -1,15 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from numpy.testing import assert_allclose
-from astropy.units import Quantity
+from astropy import units as u
 from astropy.tests.helper import pytest, assert_quantity_allclose
 from ..fermi import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL
 from ...spectrum.models import PowerLaw, LogParabola, ExponentialCutoffPowerLaw3FGL
 from ...utils.testing import requires_data, requires_dependency
 
-MODEL_TEST_DATA = [(0, PowerLaw, Quantity(1.4351261e-9, 'GeV-1 s -1 cm-2')),
-                   (4, LogParabola, Quantity(8.3828599e-10, 'GeV-1 s -1 cm-2')),
-                   (55, ExponentialCutoffPowerLaw3FGL, Quantity(1.8666925e-09, 'GeV-1 s-1 cm-2'))]
+MODEL_TEST_DATA = [(0, PowerLaw, u.Quantity(1.4351261e-9, 'GeV-1 s -1 cm-2')),
+                   (4, LogParabola, u.Quantity(8.3828599e-10, 'GeV-1 s -1 cm-2')),
+                   (55, ExponentialCutoffPowerLaw3FGL, u.Quantity(1.8666925e-09, 'GeV-1 s-1 cm-2'))]
 
 CRAB_NAMES_3FGL = ['Crab', '3FGL J0534.5+2201', '1FHL J0534.5+2201',
                    '2FGL J0534.5+2201', 'PSR J0534+2200', '0FGL J0534.6+2201']
@@ -61,7 +62,7 @@ class TestFermi3FGLObject:
 
     @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA)
     def test_spectral_model(self, index, model_type, desired):
-        energy = Quantity(1, 'GeV')
+        energy = u.Quantity(1, 'GeV')
         model = self.cat[index].spectral_model
         assert isinstance(model, model_type)
         actual = model(energy)
@@ -71,6 +72,7 @@ class TestFermi3FGLObject:
         flux_points = self.source.flux_points
 
         assert len(flux_points.table) == 5
+        assert 'flux_ul' in flux_points.table.colnames
 
         desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06,
                    1.308784e-08]
@@ -101,19 +103,31 @@ class TestSourceCatalog2FHL:
 @requires_data('gammapy-extra')
 class TestFermi2FHLObject:
     def setup(self):
-        cat = SourceCatalog2FHL()
+        self.cat = SourceCatalog2FHL()
         # Use 2FHL J0534.5+2201 (Crab) as a test source
         self.source_name = '2FHL J0534.5+2201'
-        self.source = cat[self.source_name]
+        self.source = self.cat[self.source_name]
 
     def test_name(self):
         assert self.source.name == self.source_name
 
     def test_spectral_model(self):
         model = self.source.spectral_model
-        energy = Quantity(100, 'GeV')
-        desired = Quantity(6.8700477298e-12, 'cm-2 GeV-1 s-1')
+        energy = u.Quantity(100, 'GeV')
+        desired = u.Quantity(6.8700477298e-12, 'cm-2 GeV-1 s-1')
         assert_quantity_allclose(model(energy), desired)
+
+    def test_flux_points(self):
+        # test flux point on  PKS 2155-304
+        src = self.cat['PKS 2155-304']
+        flux_points = src.flux_points
+        actual = flux_points.table['flux']
+        desired = [2.866363e-10, 6.118736e-11, np.nan] * u.Unit('cm-2 s-1')
+        assert_quantity_allclose(actual, desired)
+
+        actual = flux_points.table['flux_ul']
+        desired = [np.nan, np.nan, 6.470300e-12] * u.Unit('cm-2 s-1')
+        assert_quantity_allclose(actual, desired)
 
     @requires_dependency('uncertainties')
     def test_spectrum(self):
@@ -151,8 +165,8 @@ class TestFermi1FHLObject:
 
     def test_spectral_model(self):
         model = self.source.spectral_model
-        energy = Quantity(100, 'GeV')
-        desired = Quantity(4.7717464131e-12, 'cm-2 GeV-1 s-1')
+        energy = u.Quantity(100, 'GeV')
+        desired = u.Quantity(4.7717464131e-12, 'cm-2 GeV-1 s-1')
         assert_quantity_allclose(model(energy), desired)
 
     @requires_dependency('uncertainties')

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -150,49 +150,6 @@ def test_compute_flux_points_dnde_exp(method):
     assert_quantity_allclose(actual, desired, rtol=1e-8)
 
 
-@pytest.mark.xfail
-@requires_data('gammapy-extra')
-@requires_dependency('scipy')
-def test_3fgl_flux_points():
-    """Test reading flux points from 3FGL and also conversion from int to diff points"""
-    from gammapy.catalog import source_catalogs
-    cat_3fgl = source_catalogs['3fgl']
-    source = cat_3fgl['3FGL J0018.9-8152']
-    index = source.data['Spectral_Index']
-
-    diff_points = source.flux_points
-    fluxes = diff_points['DIFF_FLUX'].quantity
-    energies = diff_points['ENERGY'].quantity
-    eflux = fluxes * energies ** 2
-
-    actual = eflux.to('erg cm-2 s-1').value
-    diff_desired = [2.25564e-12, 1.32382e-12, 9.54129e-13, 8.63484e-13, 1.25145e-12]
-
-    assert_allclose(actual, diff_desired, rtol=1e-4)
-
-    int_points = source.flux_points_integral
-    actual = int_points['INT_FLUX'].quantity.to('cm-2 s-1').value
-
-    int_desired = [9.45680e-09, 1.94538e-09, 4.00020e-10, 1.26891e-10, 7.24820e-11]
-
-    assert_allclose(actual, int_desired, rtol=1e-4)
-
-    diff2 = int_points.to_differential_flux_points(x_method='log_center',
-                                                   y_method='power_law',
-                                                   spectral_index=index)
-
-    actual = diff2['DIFF_FLUX'].quantity.to('TeV-1 cm-2 s-1').value
-    desired = fluxes.to('TeV-1 cm-2 s-1').value
-
-    # Todo : Is this precision good enough?
-    assert_allclose(actual, desired, rtol=1e-2)
-
-    # Compare errors from 3 method to get diff points
-    method1 = diff_points['DIFF_FLUX_ERR_HI'].quantity.to('cm-2 s-1 TeV-1').value
-    method2 = diff2['DIFF_FLUX_ERR_HI'].quantity.to('cm-2 s-1 TeV-1').value
-    assert_allclose(method1, method2, rtol=1e-2)
-
-
 @requires_data('gammapy-extra')
 @requires_dependency('sherpa')
 @requires_dependency('scipy')


### PR DESCRIPTION
This PR addresses the issues described in #856:

1.  Fix an issue with the covariance matrix in `SourceCatalogObject2FHL` and `SourceCatalogObject1FHL`.
2. Add upper limit information in to the flux points

For `PKS 2155-304` the plot looks now as following:
![fermi_pks_2155_304](https://cloud.githubusercontent.com/assets/3715928/22426717/9cd904f6-e700-11e6-9d54-1281f8e77de8.png)

@jjlk Does it look allright to you?
