### PR TITLE
Add a selected region for the 3D analysis

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -327,7 +327,7 @@ class SkyCube(object):
         energy = self.energy_axis.wcs_pix2world(z)
         return (position, energy)
 
-    def to_sherpa_data3d(self, dstype='Data3D'):
+    def to_sherpa_data3d(self, dstype='Data3D', select_region= False, index_selected_region= None):
         """
         Convert sky cube to sherpa `Data3D` or `Data3DInt` object.
 
@@ -342,6 +342,7 @@ class SkyCube(object):
         ehi = energies[1:]
         n_ebins = len(elo)
         if dstype == 'Data3DInt':
+
             coordinates = self.sky_image_ref.coordinates(mode="edges")
             ra = coordinates.data.lon.degree
             dec = coordinates.data.lat.degree
@@ -351,9 +352,14 @@ class SkyCube(object):
             dec_cube_lo = np.tile(dec[0:-1, 0:-1], (n_ebins, 1, 1))
             elo_cube = elo.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
-            return Data3DInt('', elo_cube.ravel(), ra_cube_lo.ravel(), dec_cube_lo.ravel(), ehi_cube.ravel(),
+            if not select_region:
+                return Data3DInt('', elo_cube.ravel(), ra_cube_lo.ravel(), dec_cube_lo.ravel(), ehi_cube.ravel(),
                              ra_cube_hi.ravel(), dec_cube_hi.ravel(), self.data.value.ravel(),
-                             self.data.value.shape)
+                             self.data.value.ravel().shape)
+            else:
+                return Data3DInt('', elo_cube[index_selected_region].ravel(), ra_cube_lo[index_selected_region].ravel(), dec_cube_lo[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(),
+                             ra_cube_hi[index_selected_region].ravel(), dec_cube_hi[index_selected_region].ravel(), self.data.value[index_selected_region].ravel(),
+                             self.data.value[index_selected_region].ravel().shape)
         if dstype == 'Data3D':
             coordinates = self.sky_image_ref.coordinates()
             ra = coordinates.data.lon.degree
@@ -362,9 +368,14 @@ class SkyCube(object):
             dec_cube = np.tile(dec, (n_ebins, 1, 1))
             elo_cube = elo.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
-            return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),
+            if not select_region:
+                return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),
                           dec_cube.ravel(), self.data.value.ravel(),
-                          self.data.value.shape)
+                          self.data.value.ravel().shape)
+            else:
+                return Data3D('', elo_cube[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(), ra_cube[index_selected_region].ravel(),
+                          dec_cube[index_selected_region].ravel(), self.data.value[index_selected_region].ravel(),
+                          self.data.value[index_selected_region].ravel().shape)
 
         else:
             raise ValueError('Invalid sherpa data type.')

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -327,7 +327,7 @@ class SkyCube(object):
         energy = self.energy_axis.wcs_pix2world(z)
         return (position, energy)
 
-    def to_sherpa_data3d(self, dstype='Data3D', select_region= False, index_selected_region= None):
+    def to_sherpa_data3d(self, dstype='Data3D', select_region=False, index_selected_region=None):
         """
         Convert sky cube to sherpa `Data3D` or `Data3DInt` object.
 
@@ -335,6 +335,10 @@ class SkyCube(object):
         ----------
         dstype : {'Data3D', 'Data3DInt'}
             Sherpa data type.
+        select_region: True
+            If True select only the points of the region of interest for the fit
+        index_selected_region: tuple
+            tuple of three `~numpy.ndarray` containing the indexes of the points of the Cube to keep in the fit (Energy, x, y)
         """
         from .sherpa_ import Data3D, Data3DInt
         energies = self.energies(mode='edges').to("TeV").value
@@ -354,12 +358,14 @@ class SkyCube(object):
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
             if not select_region:
                 return Data3DInt('', elo_cube.ravel(), ra_cube_lo.ravel(), dec_cube_lo.ravel(), ehi_cube.ravel(),
-                             ra_cube_hi.ravel(), dec_cube_hi.ravel(), self.data.value.ravel(),
-                             self.data.value.ravel().shape)
+                                 ra_cube_hi.ravel(), dec_cube_hi.ravel(), self.data.value.ravel(),
+                                 self.data.value.ravel().shape)
             else:
-                return Data3DInt('', elo_cube[index_selected_region].ravel(), ra_cube_lo[index_selected_region].ravel(), dec_cube_lo[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(),
-                             ra_cube_hi[index_selected_region].ravel(), dec_cube_hi[index_selected_region].ravel(), self.data.value[index_selected_region].ravel(),
-                             self.data.value[index_selected_region].ravel().shape)
+                return Data3DInt('', elo_cube[index_selected_region].ravel(), ra_cube_lo[index_selected_region].ravel(),
+                                 dec_cube_lo[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(),
+                                 ra_cube_hi[index_selected_region].ravel(), dec_cube_hi[index_selected_region].ravel(),
+                                 self.data.value[index_selected_region].ravel(),
+                                 self.data.value[index_selected_region].ravel().shape)
         if dstype == 'Data3D':
             coordinates = self.sky_image_ref.coordinates()
             ra = coordinates.data.lon.degree
@@ -370,12 +376,13 @@ class SkyCube(object):
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
             if not select_region:
                 return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),
-                          dec_cube.ravel(), self.data.value.ravel(),
-                          self.data.value.ravel().shape)
+                              dec_cube.ravel(), self.data.value.ravel(),
+                              self.data.value.ravel().shape)
             else:
-                return Data3D('', elo_cube[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(), ra_cube[index_selected_region].ravel(),
-                          dec_cube[index_selected_region].ravel(), self.data.value[index_selected_region].ravel(),
-                          self.data.value[index_selected_region].ravel().shape)
+                return Data3D('', elo_cube[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(),
+                              ra_cube[index_selected_region].ravel(),
+                              dec_cube[index_selected_region].ravel(), self.data.value[index_selected_region].ravel(),
+                              self.data.value[index_selected_region].ravel().shape)
 
         else:
             raise ValueError('Invalid sherpa data type.')

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -327,7 +327,7 @@ class SkyCube(object):
         energy = self.energy_axis.wcs_pix2world(z)
         return (position, energy)
 
-    def to_sherpa_data3d(self, dstype='Data3D', select_region=False, index_selected_region=None):
+    def to_sherpa_data3d(self, dstype='Data3D'):
         """
         Convert sky cube to sherpa `Data3D` or `Data3DInt` object.
 
@@ -335,10 +335,6 @@ class SkyCube(object):
         ----------
         dstype : {'Data3D', 'Data3DInt'}
             Sherpa data type.
-        select_region: True
-            If True select only the points of the region of interest for the fit
-        index_selected_region: tuple
-            tuple of three `~numpy.ndarray` containing the indexes of the points of the Cube to keep in the fit (Energy, x, y)
         """
         from .sherpa_ import Data3D, Data3DInt
         energies = self.energies(mode='edges').to("TeV").value
@@ -356,16 +352,10 @@ class SkyCube(object):
             dec_cube_lo = np.tile(dec[0:-1, 0:-1], (n_ebins, 1, 1))
             elo_cube = elo.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
-            if not select_region:
-                return Data3DInt('', elo_cube.ravel(), ra_cube_lo.ravel(), dec_cube_lo.ravel(), ehi_cube.ravel(),
+            return Data3DInt('', elo_cube.ravel(), ra_cube_lo.ravel(), dec_cube_lo.ravel(), ehi_cube.ravel(),
                                  ra_cube_hi.ravel(), dec_cube_hi.ravel(), self.data.value.ravel(),
                                  self.data.value.ravel().shape)
-            else:
-                return Data3DInt('', elo_cube[index_selected_region].ravel(), ra_cube_lo[index_selected_region].ravel(),
-                                 dec_cube_lo[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(),
-                                 ra_cube_hi[index_selected_region].ravel(), dec_cube_hi[index_selected_region].ravel(),
-                                 self.data.value[index_selected_region].ravel(),
-                                 self.data.value[index_selected_region].ravel().shape)
+
         if dstype == 'Data3D':
             coordinates = self.sky_image_ref.coordinates()
             ra = coordinates.data.lon.degree
@@ -374,15 +364,9 @@ class SkyCube(object):
             dec_cube = np.tile(dec, (n_ebins, 1, 1))
             elo_cube = elo.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
-            if not select_region:
-                return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),
+            return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),
                               dec_cube.ravel(), self.data.value.ravel(),
                               self.data.value.ravel().shape)
-            else:
-                return Data3D('', elo_cube[index_selected_region].ravel(), ehi_cube[index_selected_region].ravel(),
-                              ra_cube[index_selected_region].ravel(),
-                              dec_cube[index_selected_region].ravel(), self.data.value[index_selected_region].ravel(),
-                              self.data.value[index_selected_region].ravel().shape)
 
         else:
             raise ValueError('Invalid sherpa data type.')

--- a/gammapy/cube/sherpa_.py
+++ b/gammapy/cube/sherpa_.py
@@ -214,6 +214,7 @@ class Data3DInt(DataND):
 class CombinedModel3D(ArithmeticModel):
     """
     Combined spatial and spectral 3D model.
+    If you ask for a selected region, it will only compare the data and the Combined model on the selected region
     """
 
     def __init__(self, name='cube-model', spatial_model=None, spectral_model=None):
@@ -242,6 +243,7 @@ class CombinedModel3D(ArithmeticModel):
 class CombinedModel3DInt(ArithmeticModel):
     """
     Combined spatial and spectral 3D model with the possibility to convolve the spatial model*exposure by the PSF.
+    If you ask for a selected region, it will only compare the data and the Combined model on the selected region
 
     Parameters
     ----------
@@ -255,7 +257,10 @@ class CombinedModel3DInt(ArithmeticModel):
         Exposure cube
     psf: `~gammapy.cube.SkyCube`
         Psf cube
-
+    select_region: True
+        If True select only the points of the region of interest for the fit
+    index_selected_region: tuple
+        tuple of three `~numpy.ndarray` containing the indexes of the points of the Cube to keep in the fit (Energy, x, y)
     """
 
     def __init__(self, coord, energies, name='cube-model', use_psf=True, exposure=None, psf=None, spatial_model=None,
@@ -343,6 +348,11 @@ class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
         spectral sherpa model
     edisp: `~numpy.array`
         2D array in (Ereco,Etrue) for the energy dispersion
+    select_region: True
+        If True select only the points of the region of interest for the fit
+    index_selected_region: tuple
+        tuple of three `~numpy.ndarray` containing the indexes of the points of the Cube to keep in the fit (Energy, x, y)
+
     """
 
     def __init__(self,coord, energies, name='cube-model', use_psf=True, exposure=None, psf=None, spatial_model=None,

--- a/gammapy/cube/sherpa_.py
+++ b/gammapy/cube/sherpa_.py
@@ -245,6 +245,10 @@ class CombinedModel3DInt(ArithmeticModel):
 
     Parameters
     ----------
+    coord: `~astropy.coordinates.SkyCoord`
+        Position of the edges of the pixel on the sky.
+    energies: `~astropy.units.Quantity`
+        Reconstructed energy used for the counts cube
     use_psf: bool
         if true will convolve the spatial model by the psf
     exposure: `~gammapy.cube.SkyCube`
@@ -254,8 +258,8 @@ class CombinedModel3DInt(ArithmeticModel):
 
     """
 
-    def __init__(self, name='cube-model', use_psf=True, exposure=None, psf=None, spatial_model=None,
-                 spectral_model=None):
+    def __init__(self, coord, energies, name='cube-model', use_psf=True, exposure=None, psf=None, spatial_model=None,
+                 spectral_model=None, select_region= False, index_selected_region= None):
         from scipy import signal
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
@@ -263,6 +267,17 @@ class CombinedModel3DInt(ArithmeticModel):
         self.exposure = exposure
         self.psf = psf
         self._fftconvolve = signal.fftconvolve
+        xx = coord.data.lon.degree
+        yy = coord.data.lat.degree
+        self.xx_lo = xx[0:-1, 1:]
+        self.xx_hi = xx[0:-1, 0:-1]
+        self.yy_lo = yy[0:-1, 0:-1]
+        self.yy_hi = yy[1:, 0:-1]
+        self.ee_lo = energies[:-1].value
+        self.ee_hi = energies[1:].value
+        self.select_region=select_region
+        self.index_selected_region=index_selected_region
+
 
         # Fix spectral ampl parameter
         spectral_model.ampl = 1
@@ -280,29 +295,29 @@ class CombinedModel3DInt(ArithmeticModel):
     def calc(self, pars, elo, xlo, ylo, ehi, xhi, yhi):
 
         if self.use_psf:
-            shape = self.exposure.data.shape
+            shape=(len(self.ee_lo),len(self.xx_lo[:,0]), len(self.xx_lo[0,:]))
             result_convol = np.zeros(shape)
-            xx_lo = xlo.reshape(shape)[0, :, :]
-            xx_hi = xhi.reshape(shape)[0, :, :]
-            yy_lo = ylo.reshape(shape)[0, :, :]
-            yy_hi = yhi.reshape(shape)[0, :, :]
-            ee_lo = elo.reshape(shape)[:, 0, 0]
-            ee_hi = ehi.reshape(shape)[:, 0, 0]
-            a = self.spatial_model.calc(pars[self._spatial_pars], xx_lo.ravel(), xx_hi.ravel(),
-                                        yy_lo.ravel(), yy_hi.ravel()).reshape(xx_lo.shape)
+            a = self.spatial_model.calc(pars[self._spatial_pars], self.xx_lo .ravel(), self.xx_hi.ravel(),
+                                        self.yy_lo.ravel(), self.yy_hi.ravel()).reshape(self.xx_lo .shape)
             # Convolve the spatial model * exposure by the psf
             for ind_E in range(shape[0]):
                 result_convol[ind_E, :, :] = self._fftconvolve(a * self.exposure.data[ind_E, :, :],
                                                                self.psf.data[ind_E, :, :] /
                                                                (self.psf.data[ind_E, :, :].sum()), mode='same')
 
-            _spatial = result_convol.ravel()
-            spectral_1d = self.spectral_model.calc(pars[self._spectral_pars], ee_lo, ee_hi)
-            _spectral = (spectral_1d.reshape(len(ee_lo), 1, 1) * np.ones_like(xx_lo)).ravel()
+            spectral_1d = self.spectral_model.calc(pars[self._spectral_pars], self.ee_lo, self.ee_hi)
+            if not self.select_region:
+                _spatial = result_convol.ravel()
+                _spectral = (spectral_1d.reshape(len(self.ee_lo), 1, 1) * np.ones_like(self.xx_lo )).ravel()
+            else:
+                _spatial = result_convol[self.index_selected_region].ravel()
+                _spectral = (spectral_1d.reshape(len(self.ee_lo), 1, 1) * np.ones_like(self.xx_lo ))[self.index_selected_region].ravel()
+
         else:
             _spatial = self.spatial_model.calc(pars[self._spatial_pars], xlo, xhi, ylo, yhi)
             _spectral = self.spectral_model.calc(pars[self._spectral_pars], elo, ehi)
         return _spatial * _spectral
+
 
 
 class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
@@ -312,9 +327,10 @@ class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
 
     Parameters
     ----------
-    dimensions: tuple
-        tuple containing the dimension for the images (x,y) and for the reco and true energies. It has to be like
-        [dim_x,dim_y,dim_Ereco,dim_Etrue]
+    coord: `~astropy.coordinates.SkyCoord`
+        Position of the edges of the pixel on the sky.
+    energies: `~astropy.units.Quantity`
+        Reconstructed energy used for the counts cube
     use_psf: bool
         if true will convolve the spatial model by the psf
     exposure: `~gammapy.cube.SkyCube`
@@ -329,23 +345,34 @@ class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
         2D array in (Ereco,Etrue) for the energy dispersion
     """
 
-    def __init__(self, dimensions, name='cube-model', use_psf=True, exposure=None, psf=None, spatial_model=None,
-                 spectral_model=None, edisp=None):
+    def __init__(self,coord, energies, name='cube-model', use_psf=True, exposure=None, psf=None, spatial_model=None,
+                 spectral_model=None, edisp=None, select_region= False, index_selected_region= None):
         from scipy import signal
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
-        self.dim_x, self.dim_y, self.dim_Ereco, self.dim_Etrue = dimensions
+        xx = coord.data.lon.degree
+        yy = coord.data.lat.degree
+        self.xx_lo = xx[0:-1, 1:]
+        self.xx_hi = xx[0:-1, 0:-1]
+        self.yy_lo = yy[0:-1, 0:-1]
+        self.yy_hi = yy[1:, 0:-1]
+        self.ee_lo = energies[:-1].value
+        self.ee_hi = energies[1:].value
         self.use_psf = use_psf
         self.exposure = exposure
         self.psf = psf
         self.edisp = edisp
         self.true_energy = EnergyBounds(self.exposure.energies("edges"))
+        self.dim_x, self.dim_y, self.dim_Ereco, self.dim_Etrue=len(self.xx_lo[:,0]), len(self.xx_lo[0,:]),\
+                                                               len(self.ee_lo),len(self.true_energy)-1
         self._fftconvolve = signal.fftconvolve
         # The shape of the counts cube in (Ereco,x,y)
         self.shape_data = (self.dim_Ereco, self.dim_x, self.dim_y)
         # Array that will store the result after multipliying by the energy resolution in (x,y,Etrue,Ereco)
         self.convolve_edisp = np.zeros(
             (self.dim_x, self.dim_y, self.dim_Etrue, self.dim_Ereco))
+        self.select_region=select_region
+        self.index_selected_region=index_selected_region
 
         # Fix spectral ampl parameter
         spectral_model.ampl = 1
@@ -361,28 +388,24 @@ class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
         ArithmeticModel.__init__(self, name, pars)
 
     def calc(self, pars, elo, xlo, ylo, ehi, xhi, yhi):
-        xx_lo = xlo.reshape(self.shape_data)[0, :, :]
-        xx_hi = xhi.reshape(self.shape_data)[0, :, :]
-        yy_lo = ylo.reshape(self.shape_data)[0, :, :]
-        yy_hi = yhi.reshape(self.shape_data)[0, :, :]
         etrue_centers = self.true_energy.log_centers
         if self.use_psf:
             # Convolve the spatial model * exposure by the psf in etrue
             spatial = np.zeros((self.dim_Etrue, self.dim_x, self.dim_y))
-            a = self.spatial_model.calc(pars[self._spatial_pars], xx_lo.ravel(), xx_hi.ravel(),
-                                        yy_lo.ravel(), yy_hi.ravel()).reshape(xx_lo.shape)
+            a = self.spatial_model.calc(pars[self._spatial_pars], self.xx_lo.ravel(), self.xx_hi.ravel(),
+                                        self.yy_lo.ravel(), self.yy_hi.ravel()).reshape(self.xx_lo.shape)
             for ind_E in range(self.dim_Etrue):
                 spatial[ind_E, :, :] = self._fftconvolve(a * self.exposure.data[ind_E, :, :],
                                                          self.psf.data[ind_E, :, :] /
                                                          (self.psf.data[ind_E, :, :].sum()), mode='same')
                 spatial[np.isnan(spatial)] = 0
         else:
-            spatial_2d = self.spatial_model.calc(pars[self._spatial_pars], xx_lo.ravel(), xx_hi.ravel(),
-                                                 yy_lo.ravel(), yy_hi.ravel()).reshape(xx_lo.shape)
+            spatial_2d = self.spatial_model.calc(pars[self._spatial_pars], self.xx_lo.ravel(), self.xx_hi.ravel(),
+                                                 self.yy_lo.ravel(), self.yy_hi.ravel()).reshape(self.xx_lo.shape)
             spatial = np.tile(spatial_2d, (len(etrue_centers), 1, 1))
         # Calculate the spectral model in etrue
         spectral_1d = self.spectral_model.calc(pars[self._spectral_pars], etrue_centers)
-        spectral = spectral_1d.reshape(len(etrue_centers), 1, 1) * np.ones_like(xx_lo)
+        spectral = spectral_1d.reshape(len(etrue_centers), 1, 1) * np.ones_like(self.xx_lo)
 
         # Convolve by the energy resolution
         etrue_band = self.true_energy.bands
@@ -391,5 +414,7 @@ class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
                                                   self.edisp[:, ireco] * etrue_band
         # Integration in etrue
         model = np.moveaxis(np.sum(self.convolve_edisp, axis=2), -1, 0)
-
-        return model.ravel()
+        if not self.select_region:
+            return model.ravel()
+        else:
+            return model[self.index_selected_region].ravel()

--- a/gammapy/cube/sherpa_.py
+++ b/gammapy/cube/sherpa_.py
@@ -278,8 +278,8 @@ class CombinedModel3DInt(ArithmeticModel):
         self.xx_hi = xx[0:-1, 0:-1]
         self.yy_lo = yy[0:-1, 0:-1]
         self.yy_hi = yy[1:, 0:-1]
-        self.ee_lo = energies[:-1].value
-        self.ee_hi = energies[1:].value
+        self.ee_lo = energies[:-1]
+        self.ee_hi = energies[1:]
         self.select_region=select_region
         self.index_selected_region=index_selected_region
 
@@ -366,8 +366,8 @@ class CombinedModel3DIntConvolveEdisp(ArithmeticModel):
         self.xx_hi = xx[0:-1, 0:-1]
         self.yy_lo = yy[0:-1, 0:-1]
         self.yy_hi = yy[1:, 0:-1]
-        self.ee_lo = energies[:-1].value
-        self.ee_hi = energies[1:].value
+        self.ee_lo = energies[:-1]
+        self.ee_hi = energies[1:]
         self.use_psf = use_psf
         self.exposure = exposure
         self.psf = psf

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -133,12 +133,9 @@ def testCombinedModel3DInt():
     cube_mask = SkyCube.read(filename_mask)
     index_region_selected_3d = np.where(cube_mask.data.value == 1)
 
-    # Set the counts and create a gammapy Data3DInt object used by sherpa only on the selected region
-    cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt', select_region=True,
-                                      index_selected_region=index_region_selected_3d)
-
-    size_remove_index = len(np.where(cube_mask.data.value == 0)[0])
-    assert len(cube.x0lo) == len(counts_3d.data.ravel()) - size_remove_index
+    # Set the counts and create a gammapy Data3DInt object on which we apply a mask for the region we don't want to use in the fit
+    cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt')
+    cube.mask = cube_mask.data.value.ravel()
 
     # Set the bkg and select only the data points of the selected region
     bkg = TableModel('bkg')
@@ -251,11 +248,9 @@ def testCombinedModel3DIntConvolveEdisp():
     cube_mask = SkyCube.read(filename_mask)
     index_region_selected_3d = np.where(cube_mask.data.value == 1)
 
-    # Set the counts and create a gammapy Data3DInt object used by sherpa only on the selected region
-    cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt', select_region=True,
-                                      index_selected_region=index_region_selected_3d)
-    size_remove_index = len(np.where(cube_mask.data.value == 0)[0])
-    assert len(cube.x0lo) == len(counts_3d.data.ravel()) - size_remove_index
+    # Set the counts and create a gammapy Data3DInt object on which we apply a mask for the region we don't want to use in the fit
+    cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt')
+    cube.mask = cube_mask.data.value.ravel()
 
     # Set the bkg and select only the data points of the selected region
     bkg = TableModel('bkg')

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -128,20 +128,16 @@ def testCombinedModel3DInt():
 
     # Add a region to exclude in the fit: Here we will exclude some events from the Crab since there is no region to
     # exclude in the FOV for this example. It's just an example to show how it works and how to proceed in the fit.
-    # First you define the coord of your cube that you want to use for the fit
-    center_excluded_region = SkyCoord(83.60, 21.88, unit='deg')
-    radius_excluded_region = Angle(0.1, "deg")
-    coord_center_pix = counts_3d.sky_image_ref.coordinates(mode="center").icrs
-    lon = np.tile(coord_center_pix.data.lon.degree, (len(energies) - 1, 1, 1))
-    lat = np.tile(coord_center_pix.data.lat.degree, (len(energies) - 1, 1, 1))
-    coord_3d_center_pix = SkyCoord(lon, lat, unit="deg")
-    index_region_selected_3d = np.where(center_excluded_region.separation(coord_3d_center_pix) > radius_excluded_region)
+    # Read the mask for the exclude region
+    filename_mask = gammapy_extra.filename('test_datasets/cube/mask.fits')
+    cube_mask = SkyCube.read(filename_mask)
+    index_region_selected_3d = np.where(cube_mask.data.value == 1)
 
     # Set the counts and create a gammapy Data3DInt object used by sherpa only on the selected region
     cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt', select_region=True,
                                       index_selected_region=index_region_selected_3d)
-    size_remove_index = len(
-        np.where(center_excluded_region.separation(coord_3d_center_pix) < radius_excluded_region)[0])
+
+    size_remove_index = len(np.where(cube_mask.data.value == 0)[0])
     assert len(cube.x0lo) == len(counts_3d.data.ravel()) - size_remove_index
 
     # Set the bkg and select only the data points of the selected region
@@ -250,20 +246,15 @@ def testCombinedModel3DIntConvolveEdisp():
 
     # Add a region to exclude in the fit: Here we will exclude some events from the Crab since there is no region to
     # exclude in the FOV for this example. It's just an example to show how it works and how to proceed in the fit.
-    # First you define the coord of your cube that you want to use for the fit
-    center_excluded_region = SkyCoord(83.60, 21.88, unit='deg')
-    radius_excluded_region = Angle(0.1, "deg")
-    coord_center_pix = counts_3d.sky_image_ref.coordinates(mode="center").icrs
-    lon = np.tile(coord_center_pix.data.lon.degree, (len(energies) - 1, 1, 1))
-    lat = np.tile(coord_center_pix.data.lat.degree, (len(energies) - 1, 1, 1))
-    coord_3d_center_pix = SkyCoord(lon, lat, unit="deg")
-    index_region_selected_3d = np.where(center_excluded_region.separation(coord_3d_center_pix) > radius_excluded_region)
+    # Read the mask for the exclude region
+    filename_mask = gammapy_extra.filename('test_datasets/cube/mask.fits')
+    cube_mask = SkyCube.read(filename_mask)
+    index_region_selected_3d = np.where(cube_mask.data.value == 1)
 
     # Set the counts and create a gammapy Data3DInt object used by sherpa only on the selected region
     cube = counts_3d.to_sherpa_data3d(dstype='Data3DInt', select_region=True,
                                       index_selected_region=index_region_selected_3d)
-    size_remove_index = len(
-        np.where(center_excluded_region.separation(coord_3d_center_pix) < radius_excluded_region)[0])
+    size_remove_index = len(np.where(cube_mask.data.value == 0)[0])
     assert len(cube.x0lo) == len(counts_3d.data.ravel()) - size_remove_index
 
     # Set the bkg and select only the data points of the selected region

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -297,5 +297,5 @@ def testCombinedModel3DIntConvolveEdisp():
                   23691.982850052769,
                   4.3353099316360773,
                   2.1965569221451813]
-    
+
     assert_allclose(result2.parvals, reference2, rtol=1E-5)

--- a/gammapy/cube/tests/test_sherpa_.py
+++ b/gammapy/cube/tests/test_sherpa_.py
@@ -297,6 +297,5 @@ def testCombinedModel3DIntConvolveEdisp():
                   23691.982850052769,
                   4.3353099316360773,
                   2.1965569221451813]
-    import pdb;
-    pdb.set_trace()
+    
     assert_allclose(result2.parvals, reference2, rtol=1E-5)


### PR DESCRIPTION
@cdeil @adonath 
This PR add the possibility to add a selected region of the Cube for the 3D Fit. For the moment it was computing the fit on the whole Cube but in general we want to exclude some parts of the FOV in the fit.

I added some test to show that it works. It is always difficult to add this kind of stuff since sherpa has not this kind of philosophy to estimate the model on some bins and then to compare the model with the data on other bin values...
This is why now in the class ```CombinedModel3D```or ```CombinedModel3DIntConvolveEdisp``` you give the whole energy bins and SkyCoords of the Cube on which the model is computed and then if you want to do the fit only on a selected region of the Cube you give a tuple of indices to these classes to compare only the data and the models on the selected region. In this case, when you define the ```Data3DInt``` object for the data you also have to give the indices of the Cube of the selected region. The same if you use a Cube for the background, you have to give only the background data of the selected region. I hope this is clear in the test I add.