### PR TITLE
Fermi basic image estimator

### DIFF
--- a/docs/image/sky_image.rst
+++ b/docs/image/sky_image.rst
@@ -70,7 +70,8 @@ The image can be easily displayed with an image viewer, by calling ``image.show(
 Cutout and paste
 ----------------
 
-The `~gammapy.image.SkyImage` class offers `.paste()` and `.cutout()`
+The `~gammapy.image.SkyImage` class offers `~gammapy.image.SkyImage.paste()` and
+`~gammapy.image.SkyImage.cutout()`
 methods, that can be used to cut out smaller parts of a image.
 Here we cut out a 5 deg x 5 deg patch out of an example image:
 
@@ -90,7 +91,7 @@ Here we cut out a 5 deg x 5 deg patch out of an example image:
 
 `cutout` is again a `~gammapy.image.SkyImage` object.
 
-Here's a more complicated example, that uses `.paste()` and `.cutout()`
+Here's a more complicated example, that uses `.paste()` and `~gammapy.image.SkyImage.cutout()`
 to evaluate Gaussian model images on small cut out patches and paste
 them again into a larger image. This offer a very efficient way
 of computing large model sky images:

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -270,6 +270,22 @@ class SkyCube(object):
             z = np.arange(self.data.shape[0] + 1) - 0.5
         return self.energy_axis.wcs_pix2world(z)
 
+    def cutout(self, position, size):
+        """
+        Cut out rectangular piece of a cube. See `~gammapy.image.SkyImage.cutout()`
+        for details.
+        """
+        out = []
+        for energy in self.energies():
+            image = self.sky_image(energy)
+            cutout = image.cutout(position=position, size=size)
+            out.append(cutout.data)
+
+        data = Quantity(np.stack(out, axis=0), self.data.unit)
+        wcs = cutout.wcs.copy()
+        return self.__class__(name=self.name, data=data, wcs=wcs, meta=self.meta,
+                              energy_axis=self.energy_axis)
+
     def wcs_skycoord_to_pixel(self, position, energy):
         """Convert world to pixel coordinates.
 

--- a/gammapy/image/__init__.py
+++ b/gammapy/image/__init__.py
@@ -3,6 +3,7 @@
 Sky images (2-dimensional: lon, lat).
 """
 from .utils import *
+from .basic import *
 from .measure import *
 from .profile import *
 from .plotting import *

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -15,12 +15,13 @@ from ..spectrum.models import PowerLaw2
 SPECTRAL_INDEX = 2.3
 
 
-class FermiLATImageEstimator(object):
+class FermiLATBasicImageEstimator(object):
     """
-    Make basic Fermi sky images in given energy band.
+    Make basic (counts, exposure and background) Fermi sky images in given
+    energy band.
 
     TODO: allow different background estimation methods
-    
+
     Parameters
     ----------
     reference : `~gammapy.image.SkyImage`

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -1,0 +1,185 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Basic sky image estimator classes
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
+
+import numpy as np
+from astropy import units as u
+
+from .core import SkyImage, SkyImageList
+from ..cube import SkyCube, compute_npred_cube
+from ..spectrum.models import PowerLaw2
+
+SPECTRAL_INDEX = 2.3
+
+
+class FermiLATImageEstimator(object):
+    """
+    Make basic Fermi sky images in given energy band.
+
+    TODO: allow different background estimation methods
+    
+    Parameters
+    ----------
+    reference : `~gammapy.image.SkyImage`
+        Reference sky image.
+    emin : `~astropy.units.Quantity`
+        Lower bound of energy range.
+    emax : `~astropy.units.Quantity`
+        Upper bound of energy range.
+    spectral_model : `~gammapy.spectrum.models.SpectralModel`
+        Spectral model assumption to compute mean exposure and psf images.
+    """
+
+    def __init__(self, reference, emin, emax, spectral_model=None):
+        self.reference = reference
+
+        if spectral_model is None:
+            index = SPECTRAL_INDEX
+            amplitude = u.Quantity(1, '')
+            spectral_model = PowerLaw2(index=index, amplitude=amplitude,
+                                       emin=emin, emax=emax)
+
+        self.spectral_model = spectral_model
+        self.parameters = OrderedDict(emin=emin, emax=emax)
+
+    def _get_empty_skyimage(self, name):
+        """
+        Get empty sky image like reference image.
+        """
+        p = self.parameters
+        image = SkyImage.empty_like(self.reference)
+        image.meta['emin'] = str(p['emin'])
+        image.meta['emax'] = str(p['emax'])
+        image.name
+        return image
+
+    def _counts_image(self, dataset):
+        """
+        Compute counts image in energy band
+        """
+        p = self.parameters
+        events = dataset.events.select_energy((p['emin'], p['emax']))
+
+        counts = self._get_empty_skyimage('counts')
+        counts.fill_events(events)
+        return counts
+
+    #TODO: move this method to a separate GalacticDiffuseBackgroundEstimator?
+    def _background_image(self, dataset):
+        """
+        Compute predicted counts background image in energy band.
+        """
+        p = self.parameters
+        erange = u.Quantity([p['emin'], p['emax']])
+
+        exposure_cube = dataset.exposure
+
+        background_total = dataset.galactic_diffuse.reproject(exposure_cube)
+
+        # evaluate and add isotropic diffuse model
+        energies = background_total.energies()
+        flux = dataset.isotropic_diffuse(energies)
+        background_total.data += flux.reshape(-1, 1, 1)
+
+        # compute npred cube
+        npred_cube = compute_npred_cube(background_total, exposure_cube, energy_bins=erange)
+
+        # extract the only image from the npred_cube
+        npred_total = npred_cube.sky_image_idx(0)
+
+        psf_mean = dataset.psf.table_psf_in_energy_band(erange, spectrum=self.spectral_model)
+
+        # convolve with PSF kernel
+        kernel = psf_mean.kernel(npred_total)
+        npred_total = npred_total.convolve(kernel)
+
+        # reproject to reference image and renormalize
+        norm = (npred_total.wcs_pixel_scale() / self.reference.wcs_pixel_scale())
+        npred_total = npred_total.reproject(self.reference)
+
+        npred_total.data /= (norm.mean()) ** 2
+        return npred_total
+
+    def _exposure_image(self, dataset):
+        """
+        Compute a powerlaw weighted exposure image from an exposure cube.
+        """
+        p = self.parameters
+
+        exposure_cube = dataset.exposure
+        exposure_weighted = SkyCube.empty_like(exposure_cube)
+        energies = exposure_weighted.energies('center')
+
+        weights = self.spectral_model(energies)
+        exposure_weighted.data = exposure_cube.data * weights.reshape(-1, 1, 1)
+
+        exposure = exposure_weighted.sky_image_integral(emin=p['emin'], emax=p['emax'])
+        exposure.data = exposure.data.to('cm2 s').value
+        exposure.unit = u.Unit('cm2 s')
+        exposure.name = 'exposure'
+        return exposure.reproject(self.reference)
+
+    def _psf_image(self, dataset, nxpix=101, nypix=101, binsz=0.02):
+        """
+        Compute fermi PSF image.
+        """
+        p = self.parameters
+        psf = dataset.psf
+
+        erange = u.Quantity((p['emin'], p['emax']))
+        psf_mean = psf.table_psf_in_energy_band(erange, spectrum=self.spectral_model)
+
+        psf_image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=binsz)
+
+        coordinates = psf_image.coordinates()
+        offset = coordinates.separation(psf_image.center)
+        psf_image.data = psf_mean.evaluate(offset)
+
+        # normalize PSF
+        psf_image.data = (psf_image.data / psf_image.data.sum()).value
+        return psf_image
+
+    def run(self, dataset):
+        """
+        Make sky images.
+
+        The following images will be computed:
+
+            * counts
+            * background (predicted counts)
+            * exposure
+            * excess
+            * flux
+            * psf
+
+        Parameters
+        ----------
+        dataset : `FermiDataset`
+            Fermi basic dataset to compute images for.
+
+        Returns
+        -------
+        images : `~gammapy.images.SkyImageList`
+            List of sky images.
+        """
+        images = SkyImageList()
+        counts = self._counts_image(dataset)
+        images['counts'] = counts
+
+        background = self._background_image(dataset)
+        images['background'] = background
+
+        exposure = self._exposure_image(dataset)
+        images['exposure'] = exposure
+
+        images['excess'] = self._get_empty_skyimage('excess')
+        images['excess'].data = counts.data - background.data
+
+        images['flux'] = self._get_empty_skyimage('flux')
+        images['flux'].data = images['excess'].data / exposure.data
+
+        images['psf'] = self._psf_image(dataset)
+        return images

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -125,8 +125,9 @@ class FermiLATBasicImageEstimator(object):
         # add margin of 1 pixel
         margin = galactic_diffuse.sky_image_ref.wcs_pixel_scale()
 
-        width = self.reference.width + margin[1]
-        height = self.reference.height + margin[0]
+        footprint = self.reference.footprint(mode='edges')
+        width = footprint['width'] + margin[1]
+        height = footprint['height'] + margin[0]
 
         cutout = galactic_diffuse.cutout(position=self.reference.center,
                                          size=(height, width))

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -386,6 +386,27 @@ class SkyImage(object):
 
         return coordinates
 
+    @property
+    def width(self):
+        """
+        Width of the image (`~astropy.coordinates.Angle`).
+        """
+        footprint = self.footprint(mode='corner')
+        width_low = footprint['lower left'].separation(footprint['lower right'])
+        width_up = footprint['upper left'].separation(footprint['upper right'])
+
+        return Angle([width_low, width_up]).max()
+
+    @property
+    def height(self):
+        """
+        Height of the image (`~astropy.coordinates.Angle`).
+        """
+        footprint = self.footprint(mode='corner')
+        height_left = footprint['lower left'].separation(footprint['upper left'])
+        height_right = footprint['lower right'].separation(footprint['upper right'])
+        return Angle([height_right, height_left]).max()
+
     def _get_boundaries(self, image_ref, image, wcs_check):
         """
         Get boundary coordinates of one image in the pixel coordinate system
@@ -1152,7 +1173,7 @@ class SkyImage(object):
             Further keyword arguments passed to `~scipy.ndimage.convolve`.
         """
         from scipy.ndimage import convolve
-        data = convolve(self.data, kernel, **kwargs)
+        data = convolve(self.data.copy(), kernel, **kwargs)
         wcs = self.wcs.deepcopy() if self.wcs else None
         return self.__class__(name=self.name, data=data, wcs=wcs)
 

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -344,13 +344,13 @@ class SkyImage(object):
         x, y = self.wcs_skycoord_to_pixel(coords=position)
         return (x >= 0.5) & (x <= nx + 0.5) & (y >= 0.5) & (y <= ny + 0.5)
 
-    def footprint(self, mode='corner'):
+    def footprint(self, mode='edges'):
         """
         Footprint of the image on the sky.
 
         Parameters
         ----------
-        mode : {'center', 'corner'}
+        mode : {'center', 'edges'}
             Use corner pixel centers or corners?
 
         Returns
@@ -373,39 +373,27 @@ class SkyImage(object):
 
         if mode == 'center':
             pixcoord = [(0, 0), (0, naxis2), (naxis1, naxis2), (naxis1, 0)]
-        elif mode == 'corner':
+        elif mode == 'edges':
             pixcoord = [(-0.5, -0.5), (-0.5, naxis2 + 0.5),
                         (naxis1 + 0.5, naxis2 + 0.5), (naxis1 + 0.5, -0.5)]
         else:
             raise ValueError('Invalid mode: {}'.format(mode))
 
-        coordinates = OrderedDict()
+        footprint = OrderedDict()
         keys = ['lower left', 'upper left', 'upper right', 'lower right']
         for key, (x, y) in zip(keys, pixcoord):
-            coordinates[key] = self.wcs_pixel_to_skycoord(xp=x, yp=y)
+            footprint[key] = self.wcs_pixel_to_skycoord(xp=x, yp=y)
 
-        return coordinates
-
-    @property
-    def width(self):
-        """
-        Width of the image (`~astropy.coordinates.Angle`).
-        """
-        footprint = self.footprint(mode='corner')
         width_low = footprint['lower left'].separation(footprint['lower right'])
         width_up = footprint['upper left'].separation(footprint['upper right'])
+        footprint['width'] = Angle([width_low, width_up]).max()
 
-        return Angle([width_low, width_up]).max()
-
-    @property
-    def height(self):
-        """
-        Height of the image (`~astropy.coordinates.Angle`).
-        """
-        footprint = self.footprint(mode='corner')
         height_left = footprint['lower left'].separation(footprint['upper left'])
         height_right = footprint['lower right'].separation(footprint['upper right'])
-        return Angle([height_right, height_left]).max()
+        footprint['height'] = Angle([height_right, height_left]).max()
+
+        footprint['center'] = self.center
+        return footprint
 
     def _get_boundaries(self, image_ref, image, wcs_check):
         """
@@ -1173,7 +1161,7 @@ class SkyImage(object):
             Further keyword arguments passed to `~scipy.ndimage.convolve`.
         """
         from scipy.ndimage import convolve
-        data = convolve(self.data.copy(), kernel, **kwargs)
+        data = convolve(self.data, kernel, **kwargs)
         wcs = self.wcs.deepcopy() if self.wcs else None
         return self.__class__(name=self.name, data=data, wcs=wcs)
 

--- a/gammapy/image/lists.py
+++ b/gammapy/image/lists.py
@@ -6,8 +6,8 @@ from astropy.extern import six
 from astropy.extern.six.moves import UserList
 from astropy.io import fits
 from astropy.io.fits import HDUList
+from .core import SkyImage
 from ..utils.scripts import make_path
-from ..image import SkyImage
 
 __all__ = ['SkyImageList']
 

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -2,20 +2,32 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
+from numpy.testing.utils import assert_allclose
+
 from astropy import units as u
 from ..basic import FermiLATBasicImageEstimator
+from .. import SkyImage
 from ...datasets import FermiLATDataset
+from ...utils.testing import requires_dependency, requires_data
 
-
-def TestFermiLATBasicImageEstimator:
-
+@requires_data('fermi-lat')
+@requires_dependency('healpy')
+@requires_dependency('scipy')
+@requires_dependency('yaml')
+class TestFermiLATBasicImageEstimator:
     def setup(self):
         kwargs = {}
-        kwargs['reference'] = SkyImage.empty(nxpix=21, nypix=11)
+        kwargs['reference'] = SkyImage.empty(nxpix=21, nypix=11, binsz=0.1)
         kwargs['emin'] = 10 * u.GeV
-        kwargs['emax'] = 100 * u.GeV
+        kwargs['emax'] = 3000 * u.GeV
         self.estimator = FermiLATBasicImageEstimator(**kwargs)
-        self.dataset = FermiLATDataset('')
+
+        filename = '$FERMI_LAT_DATA/2fhl/fermi_2fhl_data_config.yaml'
+        self.dataset = FermiLATDataset(filename)
 
     def test_run(self):
         result = self.estimator.run(self.dataset)
+        desired = [155.0, 1294.44777903, 7.16714933731e+13, -1139.44777903,
+                  -3.67226151181e-09, 1.0]
+        for image, value in zip(result, desired):
+            assert_allclose(image.data.sum(), value)

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+
+from astropy import units as u
+from ..basic import FermiLATBasicImageEstimator
+from ...datasets import FermiLATDataset
+
+
+def TestFermiLATBasicImageEstimator:
+
+    def setup(self):
+        kwargs = {}
+        kwargs['reference'] = SkyImage.empty(nxpix=21, nypix=11)
+        kwargs['emin'] = 10 * u.GeV
+        kwargs['emax'] = 100 * u.GeV
+        self.estimator = FermiLATBasicImageEstimator(**kwargs)
+        self.dataset = FermiLATDataset('')
+
+    def test_run(self):
+        result = self.estimator.run(self.dataset)

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -28,6 +28,6 @@ class TestFermiLATBasicImageEstimator:
     def test_run(self):
         result = self.estimator.run(self.dataset)
         desired = [155.0, 1294.44777903, 7.16714933731e+13, -1139.44777903,
-                  -3.67226151181e-09, 1.0]
+                  -3.67226151181e-09, 1.]
         for image, value in zip(result, desired):
             assert_allclose(image.data.sum(), value)


### PR DESCRIPTION
This PR adds a `FermiLATBasicImageEstimator` class , which allows to compute a set of `basic` sky images for any given reference region. `basic` sky images may contain `counts`, `background`, `exposure`, `flux`, `excess` and `psf`. Where `psf` is just a `SkyImage` containing an image of the PSF.
