### PR TITLE
Add Fermi-LAT 3FHL catalogue 

### DIFF
--- a/examples/example_fermi_catalogs.py
+++ b/examples/example_fermi_catalogs.py
@@ -1,8 +1,5 @@
 """ Example to show how to plot spectrum of Fermi/LAT sources
 """
-
-"""Example how to plot Fermi-LAT catalog spectra.
-"""
 import matplotlib.pyplot as plt
 
 from gammapy.catalog import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL, SourceCatalog3FHL

--- a/examples/example_fermi_catalogs.py
+++ b/examples/example_fermi_catalogs.py
@@ -1,0 +1,97 @@
+""" Example to show how to plot spectrum of Fermi/LAT sources
+"""
+
+"""Example how to plot Fermi-LAT catalog spectra.
+"""
+import matplotlib.pyplot as plt
+
+from gammapy.catalog import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL, SourceCatalog3FHL
+from gammapy.utils.energy import EnergyBounds
+
+# # 2155
+name = 'PKS 2155-304'
+
+# load catalogs
+fermi_3fgl = SourceCatalog3FGL()
+fermi_2fhl = SourceCatalog2FHL()
+fermi_1fhl = SourceCatalog1FHL()
+fermi_3fhl = SourceCatalog3FHL()
+
+# access crab data by corresponding identifier
+src_3fgl = fermi_3fgl[name]
+src_2fhl = fermi_2fhl[name]
+src_1fhl = fermi_1fhl[name]
+src_3fhl = fermi_3fhl[name]
+
+# 3FHL
+ax = src_3fgl.spectral_model.plot(src_3fgl.energy_range, energy_power=2,
+                                  label='Fermi 3FGL', color='r',
+                                  flux_unit='erg-1 cm-2 s-1')
+
+# set up an energy array to evaluate the butterfly
+emin, emax = src_3fgl.energy_range
+energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+butterfly_3fg = src_3fgl.spectrum.butterfly(energy)
+
+butterfly_3fg.plot(src_3fgl.energy_range, ax=ax, energy_power=2, color='r',
+                   flux_unit='erg-1 cm-2 s-1', facecolor='r')
+
+src_3fgl.flux_points.plot(ax=ax, sed_type='eflux', color='r',
+                          flux_unit='erg cm-2 s-1')
+
+# 2FHL
+src_2fhl.spectral_model.plot(src_2fhl.energy_range, ax=ax, energy_power=2,
+                             c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
+
+# set up an energy array to evaluate the butterfly
+emin, emax = src_2fhl.energy_range
+energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+butterfly_2fhl = src_2fhl.spectrum.butterfly(energy)
+
+# plot butterfly and flux points
+butterfly_2fhl.plot(src_2fhl.energy_range, ax=ax, energy_power=2, color='g',
+                    flux_unit='erg-1 cm-2 s-1', facecolor='g')
+src_2fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='g',
+                          flux_unit='cm-2 s-1 erg-1')
+
+
+# 1FHL
+src_1fhl.spectral_model.plot(src_1fhl.energy_range, ax=ax, energy_power=2,
+                             c='c', label='Fermi 1FHL',
+                             flux_unit='erg-1 cm-2 s-1')
+
+# set up an energy array to evaluate the butterfly 
+emin, emax = src_1fhl.energy_range
+energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+butterfly_1fhl = src_1fhl.spectrum.butterfly(energy)
+
+# plot butterfly and flux points
+butterfly_1fhl.plot(src_1fhl.energy_range, ax=ax, energy_power=2, color='c',
+                    flux_unit='erg-1 cm-2 s-1', facecolor='c')
+src_1fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='c',
+                          flux_unit='cm-2 s-1 erg-1')
+
+
+# 3FHL
+src_3fhl.spectral_model.plot(src_3fhl.energy_range, ax=ax, energy_power=2,
+                             c='b', label='Fermi 3FHL',
+                             flux_unit='erg-1 cm-2 s-1')
+
+# set up an energy array to evaluate the butterfly 
+emin, emax = src_3fhl.energy_range
+energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
+butterfly_3fhl = src_3fhl.spectrum.butterfly(energy)
+
+# plot butterfly and flux points
+butterfly_3fhl.plot(src_3fhl.energy_range, ax=ax, energy_power=2, color='b',
+                    flux_unit='erg-1 cm-2 s-1', facecolor='b')
+
+src_3fhl.flux_points.plot(ax=ax, sed_type='eflux', color='b',
+                          flux_unit='erg cm-2 s-1')
+
+
+ax.set_ylim(1.e-12, 7.e-11)
+ax.set_xlim(1.e-4, 2.)
+ax.set_ylabel('dN/dE [erg cm-2 s-1]')
+plt.legend(loc=0)
+plt.show()

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -324,8 +324,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     @property
     def spectrum(self):
         """Spectrum model fit result (`~gammapy.spectrum.SpectrumFitResult`)
-
-        TODO: remove!???
         """
         data = self.data
         model = self.spectral_model
@@ -675,7 +673,6 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
     def __str__(self):
         """Print summary info."""
-        # TODO: can we share code with 3FGL summary funtion?
         d = self.data
 
         ss = 'Source: {}\n'.format(d['Source_Name'])
@@ -686,10 +683,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         ss += 'GLON        : {}\n'.format(d['GLON'])
         ss += 'GLAT        : {}\n'.format(d['GLAT'])
         ss += '\n'
-
-        # val, err = d['Energy_Flux100'], d['Unc_Energy_Flux100']
-        # ss += 'Energy flux (100 MeV - 100 GeV) : {} +- {} erg cm^-2 s^-1\n'.format(val, err)
-        # ss += 'Detection significance : {}\n'.format(d['Signif_Avg'])
+        ss += 'Detection significance : {}\n'.format(d['Signif_Avg'])
 
         return ss
 
@@ -773,8 +767,6 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     @property
     def spectrum(self):
         """Spectrum model fit result (`~gammapy.spectrum.SpectrumFitResult`)
-
-        TODO: remove!???
         """
         data = self.data
         model = self.spectral_model

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -317,7 +317,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         for column in ['eflux', 'eflux_errp', 'eflux_errn']:
             table[column][is_ul] = np.nan
 
-        # TODO: check if nuFnu is maybe integral flux
         table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
         return FluxPoints(table)
 
@@ -760,7 +759,6 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         for column in ['eflux', 'eflux_errp', 'eflux_errn']:
             table[column][is_ul] = np.nan
 
-        # TODO: check if nuFnu is maybe integral flux
         table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
         return FluxPoints(table)
     

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import tarfile
 import numpy as np
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import Table, Column
 from astropy.utils.data import download_file
 from astropy.units import Quantity
 from ..utils.energy import EnergyBounds
@@ -25,9 +25,11 @@ __all__ = [
     'SourceCatalog1FHL',
     'SourceCatalog2FHL',
     'SourceCatalog3FGL',
+    'SourceCatalog3FHL',
     'SourceCatalogObject1FHL',
     'SourceCatalogObject2FHL',
     'SourceCatalogObject3FGL',
+    'SourceCatalogObject3FHL',
 ]
 
 
@@ -658,5 +660,202 @@ class SourceCatalog1FHL(SourceCatalog):
         source_name_key = 'Source_Name'
         source_name_alias = ('ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM')
         super(SourceCatalog1FHL, self).__init__(table=table,
+                                                source_name_key=source_name_key,
+                                                source_name_alias=source_name_alias)
+
+
+
+class SourceCatalogObject3FHL(SourceCatalogObject):
+    """One source from the Fermi-LAT 3FHL catalog.
+    """
+    _ebounds = EnergyBounds([10, 20, 50, 150, 500, 2000], 'GeV')
+    _ebounds_suffix = ['10_20', '20_50', '50_150', '150_500', '500_2000']
+    energy_range = Quantity([0.01, 2], 'TeV')
+    """Energy range of the Fermi 1FHL source catalog"""
+
+    def __str__(self):
+        """Print summary info."""
+        # TODO: can we share code with 3FGL summary funtion?
+        d = self.data
+
+        ss = 'Source: {}\n'.format(d['Source_Name'])
+        ss += '\n'
+
+        ss += 'RA (J2000)  : {}\n'.format(d['RAJ2000'])
+        ss += 'Dec (J2000) : {}\n'.format(d['DEJ2000'])
+        ss += 'GLON        : {}\n'.format(d['GLON'])
+        ss += 'GLAT        : {}\n'.format(d['GLAT'])
+        ss += '\n'
+
+        # val, err = d['Energy_Flux100'], d['Unc_Energy_Flux100']
+        # ss += 'Energy flux (100 MeV - 100 GeV) : {} +- {} erg cm^-2 s^-1\n'.format(val, err)
+        # ss += 'Detection significance : {}\n'.format(d['Signif_Avg'])
+
+        return ss
+
+    def _get_flux_values(self, prefix='Flux', unit='cm-2 s-1'):
+        if prefix not in ['Flux', 'Unc_Flux']:
+            raise ValueError(
+                "Must be one of the following: 'Flux', 'Unc_Flux'")
+
+        values = [self.data[prefix + _ + 'GeV'] for _ in self._ebounds_suffix]
+        return Quantity(values, unit)
+
+
+    @property
+    def spectral_model(self):
+        """
+        Best fit spectral model `~gammapy.spectrum.models.SpectralModel`.
+        """
+        spec_type = self.data['SpectrumType'].strip()
+        pars = {}
+        pars['amplitude'] = Quantity(
+            self.data['Flux_Density'], 'GeV-1 cm-2 s-1')
+        pars['reference'] = Quantity(self.data['Pivot_Energy'], 'GeV')
+
+        if spec_type == 'PowerLaw':
+            pars['index'] = Quantity(self.data['Spectral_Index'], '')
+            return PowerLaw(**pars)
+
+        elif spec_type == 'LogParabola':
+            pars['alpha'] = Quantity(self.data['Spectral_Index'], '')
+            pars['beta'] = Quantity(self.data['beta'], '')
+            return LogParabola(**pars)
+
+        else:
+            raise ValueError(
+                'Spectral model {} not available'.format(spec_type))
+
+    @property
+    def flux_points(self):
+        """
+        Differential flux points (`~gammapy.spectrum.FluxPoints`).
+        """
+        table = Table()
+        table.meta['SED_TYPE'] = 'flux'
+        e_ref = self._ebounds.log_centers
+        table['e_ref'] = e_ref
+        table['e_min'] = self._ebounds.lower_bounds
+        table['e_max'] = self._ebounds.upper_bounds
+
+        flux = self._get_flux_values()
+        flux_err = self._get_flux_values('Unc_Flux')
+        table['flux'] = flux
+        table['flux_errn'] = np.abs(flux_err[:, 0])
+        table['flux_errp'] = flux_err[:, 1]
+
+        nuFnu = self._get_flux_values('nuFnu', 'erg cm-2 s-1')
+        table['eflux'] = nuFnu
+        table['eflux_errn'] = np.abs(nuFnu * flux_err[:, 0] / flux)
+        table['eflux_errp'] = nuFnu * flux_err[:, 1] / flux
+
+        is_ul = np.isnan(table['flux_errn'])
+        table['is_ul'] = is_ul
+
+        # handle upper limits
+        table['flux_ul'] = np.nan * flux_err.unit
+        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
+
+        for column in ['flux', 'flux_errp', 'flux_errn']:
+            table[column][is_ul] = np.nan
+
+        # handle upper limits
+        table['eflux_ul'] = np.nan * nuFnu.unit
+        table['eflux_ul'][is_ul] = table['eflux_errp'][is_ul]
+
+        for column in ['eflux', 'eflux_errp', 'eflux_errn']:
+            table[column][is_ul] = np.nan
+
+        # TODO: check if nuFnu is maybe integral flux
+        table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
+        return FluxPoints(table)
+    
+    @property
+    def spectrum(self):
+        """Spectrum model fit result (`~gammapy.spectrum.SpectrumFitResult`)
+
+        TODO: remove!???
+        """
+        data = self.data
+        model = self.spectral_model
+
+        spec_type = self.data['SpectrumType'].strip()
+
+        if spec_type == 'PowerLaw':
+            par_names = ['index', 'amplitude']
+            par_errs = [data['Unc_Spectral_Index'],
+                        data['Unc_Flux_Density']]
+        elif spec_type == 'LogParabola':
+            par_names = ['amplitude', 'alpha', 'beta']
+            par_errs = [data['Unc_Flux_Density'],
+                        data['Unc_Spectral_Index'],
+                        data['Unc_beta']]
+        else:
+            raise ValueError(
+                'Spectral model {} not available'.format(spec_type))
+
+        covariance = np.diag(par_errs) ** 2
+
+        return SpectrumFitResult(
+            model=model,
+            fit_range=self.energy_range,
+            covariance=covariance,
+            covar_axis=par_names,
+        )
+
+
+    def _get_flux_values(self, prefix='Flux', unit='cm-2 s-1'):
+        if prefix not in ['Flux', 'Unc_Flux', 'nuFnu']:
+            raise ValueError(
+                "Must be one of the following: 'Flux', 'Unc_Flux', 'nuFnu'")
+
+        values = [self.data[prefix + _ + 'GeV'] for _ in self._ebounds_suffix]
+        return Quantity(values, unit)
+
+
+class SourceCatalog3FHL(SourceCatalog):
+    """Fermi-LAT 3FHL source catalog.
+    """
+    name = '3fhl'
+    description = 'LAT third high-energy source catalog'
+    source_object_class = SourceCatalogObject3FHL
+
+    def __init__(self, filename=None):
+        if not filename:
+            filename = gammapy_extra.filename(
+                'datasets/catalogs/fermi/gll_psch_v11.fit.gz')
+
+        self.hdu_list = fits.open(filename)
+        self.extended_sources_table = Table(
+            self.hdu_list['ExtendedSources'].data)
+        self.rois = Table(self.hdu_list['ROIs'].data)
+        table = Table(self.hdu_list['LAT_Point_Source_Catalog'].data)
+        # Definition of energy bounds
+        self.energy_bounds_table = Table(self.hdu_list['EnergyBounds'].data)
+
+        # Add integrated flux columns (defined in the same way as in the
+        # other Fermi catalogs (e.g. FluxY_ZGeV))
+        for i, band in enumerate(self.energy_bounds_table):
+            col_flux_name = 'Flux{:d}_{:d}GeV'.format(int(band['LowerEnergy']),
+                                                      int(band['UpperEnergy']))
+            col_flux_value = table['Flux_Band'][:,i].data
+            col_flux = Column(col_flux_value, name=col_flux_name)
+
+            col_unc_flux_name = 'Unc_' + col_flux_name
+            col_unc_flux_value = table['Unc_Flux_Band'][:,i].data
+            col_unc_flux = Column(col_unc_flux_value, name=col_unc_flux_name)
+
+            col_nufnu_name = 'nuFnu{:d}_{:d}GeV'.format(int(band['LowerEnergy']),
+                                                        int(band['UpperEnergy']))
+            col_nufnu_value = table['nuFnu'][:,i].data
+            col_nufnu = Column(col_nufnu_value, name=col_nufnu_name)
+
+            table.add_column(col_flux)
+            table.add_column(col_unc_flux)
+            table.add_column(col_nufnu)
+            
+        source_name_key = 'Source_Name'
+        source_name_alias = ('ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM')
+        super(SourceCatalog3FHL, self).__init__(table=table,
                                                 source_name_key=source_name_key,
                                                 source_name_alias=source_name_alias)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -4,13 +4,16 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.tests.helper import pytest, assert_quantity_allclose
-from ..fermi import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL
+from ..fermi import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL, SourceCatalog3FHL
 from ...spectrum.models import PowerLaw, LogParabola, ExponentialCutoffPowerLaw3FGL
 from ...utils.testing import requires_data, requires_dependency
 
-MODEL_TEST_DATA = [(0, PowerLaw, u.Quantity(1.4351261e-9, 'GeV-1 s -1 cm-2')),
+MODEL_TEST_DATA_3FGL = [(0, PowerLaw, u.Quantity(1.4351261e-9, 'GeV-1 s -1 cm-2')),
                    (4, LogParabola, u.Quantity(8.3828599e-10, 'GeV-1 s -1 cm-2')),
                    (55, ExponentialCutoffPowerLaw3FGL, u.Quantity(1.8666925e-09, 'GeV-1 s-1 cm-2'))]
+
+MODEL_TEST_DATA_3FHL = [(352, PowerLaw, u.Quantity(5.79746841775092e-12, 'GeV-1 s -1 cm-2')),
+                        (1444, LogParabola, u.Quantity(2.056998292908196e-12, 'GeV-1 s -1 cm-2'))]
 
 CRAB_NAMES_3FGL = ['Crab', '3FGL J0534.5+2201', '1FHL J0534.5+2201',
                    '2FGL J0534.5+2201', 'PSR J0534+2200', '0FGL J0534.6+2201']
@@ -18,6 +21,8 @@ CRAB_NAMES_2FHL = ['Crab', '3FGL J0534.5+2201i', '1FHL J0534.5+2201',
                    'TeV J0534+2200']
 CRAB_NAMES_1FHL = ['Crab', '1FHL J0534.5+2201', '2FGL J0534.5+2201', 'PSR J0534+2200',
                    'Crab']
+CRAB_NAMES_3FHL = ['Crab Pulsar', '3FHL J0534.5+2201', 'PSR J0534+2200',
+                   '3FGL J0534.5+2201i']
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog3FGL:
@@ -60,7 +65,7 @@ class TestFermi3FGLObject:
         assert 'Source: 3FGL J0534.5+2201' in ss
         assert 'RA (J2000)  : 83.63' in ss
 
-    @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA)
+    @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FGL)
     def test_spectral_model(self, index, model_type, desired):
         energy = u.Quantity(1, 'GeV')
         model = self.cat[index].spectral_model
@@ -185,3 +190,63 @@ class TestFermi1FHLObject:
     def test_spectrum(self):
         spectrum = self.source.spectrum
         assert "Fit result info" in str(spectrum)
+
+
+@requires_data('gammapy-extra')
+class TestSourceCatalog3FHL:
+    def test_main_table(self):
+        cat = SourceCatalog3FHL()
+        assert len(cat.table) == 1558
+
+    def test_extended_sources(self):
+        cat = SourceCatalog3FHL()
+        table = cat.extended_sources_table
+        assert len(table) == 55
+
+
+@requires_data('gammapy-extra')
+class TestFermi3FHLObject:
+    def setup(self):
+        self.cat = SourceCatalog3FHL()
+        # Use 3FHL J0534.5+2201 (Crab) as a test source
+        self.source_name = '3FHL J0534.5+2201'
+        self.source = self.cat[self.source_name]
+
+    def test_name(self):
+        assert self.source.name == self.source_name
+
+    def test_index(self):
+        assert self.source.index == 352
+
+    def test_data(self):
+        assert_allclose(self.source.data['Signif_Avg'], 168.64082)
+
+    def test_pprint(self):
+        self.source.pprint()
+
+    def test_str(self):
+        ss = str(self.source)
+        assert 'Source: 3FHL J0534.5+2201' in ss
+        assert 'RA (J2000)  : 83.63' in ss
+
+    @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FHL)
+    def test_spectral_model(self, index, model_type, desired):
+        energy = u.Quantity(100, 'GeV')
+        model = self.cat[index].spectral_model
+        assert isinstance(model, model_type)
+        actual = model(energy)
+        assert_quantity_allclose(actual, desired)
+
+    def test_flux_points(self):
+        flux_points = self.source.flux_points
+
+        assert len(flux_points.table) == 5
+        assert 'flux_ul' in flux_points.table.colnames
+
+        desired = [5.12440652532e-07, 7.37024993524e-08, 9.04493849264e-09, 7.68135443661e-10,
+                   4.30737078315e-11]
+        assert_allclose(flux_points.table['dnde'].data, desired, rtol=1E-5)
+
+    @pytest.mark.parametrize('name', CRAB_NAMES_3FHL)
+    def test_crab_alias(self, name):
+        assert str(self.cat['Crab Pulsar']) == str(self.cat[name])


### PR DESCRIPTION
Hi @cdeil and @adonath ,

I added two classes to handle the Fermi/LAT 3FHL catalogue. I followed again what did @adonath for the 3FGL catalogue and it seems to work (see attached plot for PKS 2155-304).

Here are some comments for this new catalogue: 
 - integrated fluxes (like errors and energy fluxes) in energy bands are stored as vector in the Flux_Band column (Unc_Flux_Band, nuFnu)
 - energy bands are given in a table (EnergyBounds)
 - two different models are possible, power law and log parabola

In the SourceCatalog3FHL class I added columns to the point-like table to have integrated fluxes (and Co) as it is done in previous catalogs (e.g. Flux10_20GeV)

What do you think?

![figure_1](https://cloud.githubusercontent.com/assets/15717586/22619670/29a7346e-eafa-11e6-96e6-58f79bcae6b7.png)
