### PR TITLE
Fix docstrings in background sub-package

### DIFF
--- a/gammapy/background/__init__.py
+++ b/gammapy/background/__init__.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Background estimation and modeling methods.
-"""
+"""Background estimation and modeling methods."""
 from .energy_offset_array import *
 from .background_estimate import *
 from .fov import *

--- a/gammapy/background/background_estimate.py
+++ b/gammapy/background/background_estimate.py
@@ -10,7 +10,7 @@ __all__ = [
 
 
 class BackgroundEstimate(object):
-    """Container class for background estimate
+    """Container class for background estimate.
 
     This container holds the result from a region based background estimation
     for one observation. Currently, it is filled by the functions
@@ -40,7 +40,7 @@ class BackgroundEstimate(object):
 
 
 def ring_background_estimate(pos, on_radius, inner_radius, outer_radius, events):
-    """Simple ring background estimate
+    """Simple ring background estimate.
 
     No acceptance correction is applied
 

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -58,7 +58,7 @@ class EnergyOffsetArray(object):
         self.data_err = np.sqrt(self.data)
 
     def _fill_one_event_list(self, events):
-        """Histogram the counts of an EventList object in 2D (energy,offset)
+        """Histogram the counts of an EventList object in 2D (energy,offset).
 
         Parameters
         ----------
@@ -151,7 +151,7 @@ class EnergyOffsetArray(object):
         return cls(energy_edges, offset_edges, data, data_units=str(data.unit), data_err=data_err)
 
     def write(self, filename, data_name="data", **kwargs):
-        """ Write `EnergyOffsetArray` to FITS file.
+        """Write `EnergyOffsetArray` to FITS file.
 
         Parameters
         ----------
@@ -265,7 +265,6 @@ class EnergyOffsetArray(object):
         table : `~astropy.table.Table`
             Table with two columns: offset, value
         """
-
         table = Table()
         table["offset"] = self.offset_bin_center
         table["value"] = self.evaluate(energy, None, interp_kwargs)[0, :]

--- a/gammapy/background/fov.py
+++ b/gammapy/background/fov.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Field-of-view (FOV) background estimation
-"""
+"""Field-of-view (FOV) background estimation."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.wcs import WCS

--- a/gammapy/background/fov_cube.py
+++ b/gammapy/background/fov_cube.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""FOVCube container.
-"""
+"""FOVCube container."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
@@ -40,9 +39,7 @@ def _make_bin_edges_array(lo, hi):
 
 
 def _parse_data_units(data_unit):
-    """
-    Utility function to parse the data units correctly.
-    """
+    """Utility function to parse the data units correctly."""
     # try 1st to parse them as astropy units
     try:
         u.Unit(data_unit)
@@ -144,8 +141,7 @@ class FOVCube(object):
 
     @property
     def scheme_dict(self):
-        """Naming scheme, depending on the kind of cube (dict)"""
-
+        """Naming scheme, depending on the kind of cube (dict)."""
         return self.define_scheme(self.scheme)
 
     @staticmethod
@@ -226,7 +222,6 @@ class FOVCube(object):
         cube : `~gammapy.background.FOVCube`
             FOVCube object.
         """
-
         header = hdu.header
         data = hdu.data
 
@@ -509,7 +504,7 @@ class FOVCube(object):
 
     @property
     def image_extent(self):
-        """Image extent (`~astropy.coordinates.Angle`)
+        """Image extent (`~astropy.coordinates.Angle`).
 
         The output array format is ``(x_lo, x_hi, y_lo, y_hi)``.
         """
@@ -519,7 +514,7 @@ class FOVCube(object):
 
     @property
     def spectrum_extent(self):
-        """Spectrum extent (`~astropy.units.Quantity`)
+        """Spectrum extent (`~astropy.units.Quantity`).
 
         The output array format is  ``(e_lo, e_hi)``.
         """
@@ -528,7 +523,7 @@ class FOVCube(object):
 
     @property
     def image_bin_centers(self):
-        """Image bin centers **(x, y)** (2x `~astropy.coordinates.Angle`)
+        """Image bin centers **(x, y)** (2x `~astropy.coordinates.Angle`).
 
         Returning two separate elements for the X and Y bin centers.
         """
@@ -538,12 +533,12 @@ class FOVCube(object):
 
     @property
     def energy_edges(self):
-        """Energy binning (`~gammapy.utils.energy.EnergyBounds`)"""
+        """Energy binning (`~gammapy.utils.energy.EnergyBounds`)."""
         return self._energy_edges
 
     @property
     def coord_wcs(self):
-        """WCS object describing the coordinates of the coord (X, Y) bins (`~astropy.wcs.WCS`)
+        """WCS object describing the coordinates of the coord (X, Y) bins (`~astropy.wcs.WCS`).
 
         This method gives the correct answer only for linear X, Y binning.
         """
@@ -683,7 +678,7 @@ class FOVCube(object):
 
     def make_spectrum(self, coord, ebounds=None):
         """
-        Generate energy spectrum at a certain position in the FOV
+        Generate energy spectrum at a certain position in the FOV.
 
         Parameters
         ----------
@@ -777,7 +772,7 @@ class FOVCube(object):
 
     @property
     def integral(self):
-        """Integral of the cube (`~astropy.units.Quantity`)
+        """Integral of the cube (`~astropy.units.Quantity`).
 
         The returned quantity has dimension of the data in the cube
         times solid angle times energy.
@@ -795,7 +790,7 @@ class FOVCube(object):
 
     @property
     def integral_images(self):
-        """Integral of the cube images (`~astropy.units.Quantity`)
+        """Integral of the cube images (`~astropy.units.Quantity`).
 
         Calculate the integral of each energy bin (slice) in the
         cube. Returns an array of integrals.
@@ -849,7 +844,7 @@ class FOVCube(object):
         This add the counts to the existing value array.
 
         Parameters
-        -------------
+        ----------
         event_lists : list of `~gammapy.data.EventList`
            Python list of event list objects.
         """
@@ -861,7 +856,7 @@ class FOVCube(object):
         """Fill one event list into a counts array.
 
         Parameters
-        -------------
+        ----------
         events :`~gammapy.data.EventList`
            Event list objects.
         """

--- a/gammapy/background/models.py
+++ b/gammapy/background/models.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Background models.
-"""
+"""Background models."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.coordinates import Angle, SkyCoord
@@ -23,7 +22,7 @@ DEFAULT_SPLINE_KWARGS = dict(k=1, s=0)
 
 
 def _add_column_and_sort_table(sources, pointing_position):
-    """Sort the table and add the column separation (offset from the source) and phi (position angle from the source)
+    """Sort the table and add the column separation (offset from the source) and phi (position angle from the source).
 
     Parameters
     ----------
@@ -179,13 +178,11 @@ class GaussianBand2D(object):
         self._par_model = s
 
     def _evaluate_y(self, y, pars):
-        """Evaluate Gaussian model at a given ``y`` position.
-        """
+        """Evaluate Gaussian model at a given ``y`` position."""
         return Gaussian1D.evaluate(y, **pars)
 
     def parvals(self, x):
-        """Interpolated parameter values at a given ``x``.
-        """
+        """Interpolated parameter values at a given ``x``."""
         x = np.asanyarray(x, dtype=float)
         parvals = dict()
         for parname in self.parnames:
@@ -196,15 +193,13 @@ class GaussianBand2D(object):
         return parvals
 
     def y_model(self, x):
-        """Create model at a given ``x`` position.
-        """
+        """Create model at a given ``x`` position."""
         x = np.asanyarray(x, dtype=float)
         parvals = self.parvals(x)
         return Gaussian1D(**parvals)
 
     def evaluate(self, x, y):
-        """Evaluate model at a given position ``(x, y)`` position.
-        """
+        """Evaluate model at a given position ``(x, y)`` position."""
         x = np.asanyarray(x, dtype=float)
         y = np.asanyarray(y, dtype=float)
         parvals = self.parvals(x)
@@ -547,8 +542,7 @@ class FOVCubeBackgroundModel(object):
             self.background_cube.data[i_energy] *= (integral_images / integral_images_smooth)[i_energy]
 
     def compute_rate(self):
-        """Compute background_cube from count_cube and livetime_cube.
-        """
+        """Compute background_cube from count_cube and livetime_cube."""
         bg_rate = self.counts_cube.data / self.livetime_cube.data
 
         bg_rate /= self.counts_cube.bin_volume
@@ -693,8 +687,7 @@ class EnergyOffsetBackgroundModel(object):
             self.livetime.data += obs.observation_live_time_duration * (1 - pie_fraction)
 
     def compute_rate(self):
-        """Compute background rate cube from count_cube and livetime_cube.
-        """
+        """Compute background rate cube from count_cube and livetime_cube."""
         bg_rate = self.counts.data / self.livetime.data
 
         bg_rate /= self.counts.bin_volume

--- a/gammapy/background/off_data_background_maker.py
+++ b/gammapy/background/off_data_background_maker.py
@@ -114,7 +114,6 @@ class OffDataBackgroundMaker(object):
 
         For now we'll just use the zenith binning from HAP.
         """
-
         obs_table = self.define_obs_table()
 
         # Define observation groups
@@ -151,7 +150,6 @@ class OffDataBackgroundMaker(object):
         offset : `~astropy.coordinates.Angle`
             Offset vector (1D)
         """
-
         groups = sorted(np.unique(self.obs_table['GROUP_ID']))
         log.info('Groups: {}'.format(groups))
         for group in groups:
@@ -233,7 +231,7 @@ class OffDataBackgroundMaker(object):
             self.save_model(modeltype, ngroup, smooth)
 
     def smooth_models(self, modeltype):
-        """Smooth the bkg model for each group
+        """Smooth the bkg model for each group.
 
         Parameters
         ----------
@@ -244,7 +242,7 @@ class OffDataBackgroundMaker(object):
             self.smooth_model(modeltype, ngroup)
 
     def smooth_model(self, modeltype, ngroup):
-        """Smooth the bkg model for one group
+        """Smooth the bkg model for one group.
 
         Parameters
         ----------
@@ -344,7 +342,6 @@ class OffDataBackgroundMaker(object):
         index_table_new : `~astropy.table.Table`
             Index hdu table with a background row
         """
-
         index_table_bkg = self.make_bkg_index_table(data_store, modeltype, out_dir_background_model,
                                                     filename_obs_group_table, smooth)
         index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_3d")[0].tolist()

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -98,7 +98,7 @@ def find_reflected_regions(region, center, exclusion_mask=None,
 
 
 def _compute_xy(pix_center, offset, angle):
-    """Compute x, y position for a given position angle and offset
+    """Compute x, y position for a given position angle and offset.
 
     # TODO: replace by calculation using `astropy.coordinates`
     """
@@ -119,7 +119,7 @@ def _is_inside_exclusion(pixreg, exclusion):
 
 
 class ReflectedRegionsBackgroundEstimator(object):
-    """Reflected Regions background estimator
+    """Reflected Regions background estimator.
 
     Parameters
     ----------
@@ -141,6 +141,7 @@ class ReflectedRegionsBackgroundEstimator(object):
         self.config = config
 
     def __str__(self):
+        """String representation of the class."""
         s = self.__class__.__name__ + '\n'
         s += str(self.on_region)
         s += '\n'.format(self.config)
@@ -148,7 +149,7 @@ class ReflectedRegionsBackgroundEstimator(object):
 
     @staticmethod
     def process(on_region, obs, exclusion, **kwargs):
-        """Estimate background for one observation
+        """Estimate background for one observation.
 
         kwargs are forwaded to :func:`gammapy.background.find_reflected_regions`
 
@@ -177,7 +178,7 @@ class ReflectedRegionsBackgroundEstimator(object):
         return BackgroundEstimate(off_region, off_events, a_on, a_off, tag='reflected')
 
     def run(self):
-        """Process all observations"""
+        """Process all observations."""
         result = []
         for obs in self.obs_list:
             temp = self.process(on_region=self.on_region,

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Ring background estimation.
-"""
+"""Ring background estimation."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 from itertools import product
@@ -69,6 +68,7 @@ class AdaptiveRingBackgroundEstimator(object):
     RingBackgroundEstimator, gammapy.detect.KernelBackgroundEstimator
 
     """
+
     def __init__(self, r_in, r_out_max, width, stepsize=0.02 * u.deg,
                  threshold_alpha=0.1, theta=0.22 * u.deg, method='fixed_width'):
 
@@ -119,7 +119,9 @@ class AdaptiveRingBackgroundEstimator(object):
 
     def _alpha_approx_cube(self, cubes):
         """
-        Compute alpha as on_exposure / off_exposure. Where off_exposure < 0,
+        Compute alpha as on_exposure / off_exposure.
+        
+        Where off_exposure < 0,
         alpha is set to infinity.
         """
         exposure_on = cubes['exposure_on']
@@ -130,7 +132,9 @@ class AdaptiveRingBackgroundEstimator(object):
 
     def _exposure_off_cube(self, images, kernels):
         """
-        Compute off exposure cube by convolving the on exposure with different
+        Compute off exposure cube.
+
+        The on exposure is convolved with different
         ring kernels and stacking the data along the third dimension.
         """
         exposure  = images['exposure_on'].data
@@ -139,7 +143,9 @@ class AdaptiveRingBackgroundEstimator(object):
 
     def _exposure_on_cube(self, images, kernels):
         """
-        Compute on exposure cube, by convolving the on exposure with a tophat
+        Compute on exposure cube.
+
+        Calculated by convolving the on exposure with a tophat
         of radius theta, and stacking all images along the third dimension.
         """
         from scipy.ndimage import convolve
@@ -156,7 +162,9 @@ class AdaptiveRingBackgroundEstimator(object):
 
     def _off_cube(self, images, kernels):
         """
-        Compute off cube by convolving the raw counts with different ring kernels
+        Compute off cube.
+
+        Calculated by convolving the raw counts with different ring kernels
         and stacking the data along the third dimension.
         """
         counts = images['counts'].data
@@ -165,7 +173,9 @@ class AdaptiveRingBackgroundEstimator(object):
 
     def _reduce_cubes(self, cubes):
         """
-        Compute off and off exposure map, by reducing the cubes. The data is
+        Compute off and off exposure map.
+
+        Calulated by reducing the cubes. The data is
         iterated along the third axis (i.e. increasing ring sizes), the value
         with the first approximate alpha < threshold is taken.
         """
@@ -265,6 +275,7 @@ class RingBackgroundEstimator(object):
     gammapy.detect.KernelBackgroundEstimator, AdaptiveRingBackgroundEstimator
 
     """
+
     def __init__(self, r_in, width):
         self.parameters = dict(r_in=r_in, width=width)
 
@@ -327,15 +338,11 @@ class RingBackgroundEstimator(object):
         return result
 
     def info(self):
-        """
-        Print summary info about the parameters.
-        """
+        """Print summary info about the parameters."""
         print(str(self))
 
     def __str__(self):
-        """
-        String representation of the class.
-        """
+        """String representation of the class."""
         info = "RingBackground parameters: \n"
         info += 'r_in : {}\n'.format(self.parameters['r_in'])
         info += 'width: {}\n'.format(self.parameters['width'])


### PR DESCRIPTION
All docstring errors generated by the command `pydocstyle --convention=numpy --add-ignore=D410,D104,D102,D100 gammapy/background` have been fixed.