### PR TITLE
Support observations with different energy binning in SpectrumFit

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -421,6 +421,14 @@ class PHACountsSpectrum(CountsSpectrum):
                                     np.ones(len(retval.data.data)),
                                     np.zeros(len(retval.data.data)))
         retval.quality = np.array(quality_rebinned, dtype=int)
+
+        # if backscal is not the same in all channels cannot merge
+        if not np.isscalar(retval.backscal):
+            if not np.isclose(np.diff(retval.backscal), 0).all():
+                raise ValueError('Cannot merge energy dependent backscal')
+            else:
+                retval.meta.backscal = retval.backscal[0] * np.ones(retval.energy.nbins)
+
         return retval
 
     @property

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -40,7 +40,7 @@ class SpectrumFit(object):
     obs_list : `~gammapy.spectrum.SpectrumObservationList`, `~gammapy.spectrum.SpectrumObservation`
         Observation(s) to fit
     model : `~gammapy.spectrum.models.SpectralModel`
-        Source model 
+        Source model. Should return counts if ``forward_folded`` is False and a flux otherwise
     stat : {'wstat', 'cash'} 
         Fit statistic 
     forward_folded : bool, default: True
@@ -204,11 +204,8 @@ class SpectrumFit(object):
                                               e_reco=binning)
             counts = temp.data.data
         else:
-            temp = calculate_predicted_counts(model=model,
-                                              livetime=obs.livetime,
-                                              aeff=obs.aeff,
-                                              e_reco=binning)
-            counts = temp.data.data
+            # TODO: This could also be part of calculate predicted counts
+            counts = model.integral(binning[:-1], binning[1:])
 
         # Check count unit (~unit of model amplitude)
         cond = counts.unit.is_equivalent('ct') or counts.unit.is_equivalent('')

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -204,8 +204,11 @@ class SpectrumFit(object):
                                               e_reco=binning)
             counts = temp.data.data
         else:
-            # TODO: This could also be part of calculate predicted counts
-            counts = model.integral(binning[:-1], binning[1:])
+            temp = calculate_predicted_counts(model=model,
+                                              livetime=obs.livetime,
+                                              aeff=obs.aeff,
+                                              e_reco=binning)
+            counts = temp.data.data
 
         # Check count unit (~unit of model amplitude)
         cond = counts.unit.is_equivalent('ct') or counts.unit.is_equivalent('')

--- a/gammapy/spectrum/sherpa_utils.py
+++ b/gammapy/spectrum/sherpa_utils.py
@@ -88,7 +88,7 @@ class SherpaStat(Likelihood):
     def _calc(self, data, model, *args, **kwargs):
         self.fit.calc_statval()
         # Sum likelihood over all observations
-        total_stat = np.sum(self.fit.statval, dtype=np.float64)
+        total_stat = np.sum([np.sum(v) for v in self.fit.statval], dtype=np.float64)
         # sherpa return pattern: total stat, fvec
         return total_stat, None
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -268,6 +268,22 @@ class TestSpectralFit:
         assert_quantity_allclose(fit.model.parameters.amplitude,
                                  2.32727036907038e-7 * u.Unit('m-2 s-1 TeV-1'))
 
+        # Change energy binnig of one observation
+        # TODO: Add Rebin method to SpectrumObservation
+        on_vector = self.obs_list[0].on_vector.rebin(2)
+        off_vector = self.obs_list[0].off_vector.rebin(2)
+        self.obs_list[0].on_vector = on_vector
+        self.obs_list[0].off_vector = off_vector
+        fit = SpectrumFit(self.obs_list, self.pwl)
+        fit.fit()
+
+        # TODO: Check if such a large deviation makes sense
+        assert_quantity_allclose(fit.model.parameters.index,
+                                 2.170167464415323)
+        assert_quantity_allclose(fit.model.parameters.amplitude,
+                                 3.165490768576638e-11 * u.Unit('m-2 s-1 TeV-1'))
+
+
     def test_stacked_fit(self):
         stacked_obs = self.obs_list.stack()
         obs_list = SpectrumObservationList([stacked_obs])


### PR DESCRIPTION
This PR fixes the stat computation in ``SpectrumFit`` for the case that observation with different energy binning are given and add a regression test.