### PR TITLE
Improve gammapy catalog implementation and tests

### DIFF
--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -205,3 +205,6 @@ Reference/API
 
 .. automodapi:: gammapy.utils.time
     :no-inheritance-diagram:
+
+.. automodapi:: gammapy.utils.modeling
+    :no-inheritance-diagram:

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -266,21 +266,21 @@ class SourceCatalogGammaCat(SourceCatalog):
             source_name_alias=source_name_alias,
         )
 
-    def _make_source_dict(self, index):
-        """Make one source data dict.
-
-        Parameters
-        ----------
-        index : int
-            Row index
-
-        Returns
-        -------
-        data : dict
-            Source data dict
-        """
-        row = self.table[index]
-        return row
+    # def _make_source_dict(self, index):
+    #     """Make one source data dict.
+    #
+    #     Parameters
+    #     ----------
+    #     index : int
+    #         Row index
+    #
+    #     Returns
+    #     -------
+    #     data : dict
+    #         Source data dict
+    #     """
+    #     row = self.table[index]
+    #     return row
 
     def to_source_library(self):
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -266,22 +266,6 @@ class SourceCatalogGammaCat(SourceCatalog):
             source_name_alias=source_name_alias,
         )
 
-    # def _make_source_dict(self, index):
-    #     """Make one source data dict.
-    #
-    #     Parameters
-    #     ----------
-    #     index : int
-    #         Row index
-    #
-    #     Returns
-    #     -------
-    #     data : dict
-    #         Source data dict
-    #     """
-    #     row = self.table[index]
-    #     return row
-
     def to_source_library(self):
         """
         TODO: add an option whether to skip or raise on missing models or data.

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -1,16 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 from numpy.testing import assert_allclose
-from astropy.tests.helper import pytest
-from astropy.table import Table
+from astropy.tests.helper import pytest, assert_quantity_allclose
+from astropy.table import Table, Column
+from astropy.units import Quantity
 from ..core import SourceCatalog
 
 
 def make_test_catalog():
     table = Table()
     table['Source_Name'] = ['a', 'bb', 'ccc']
-    table['RA'] = [42.2, 43.3, 44.4]
-    table['DEC'] = [1, 2, 3]
+    table['RA'] = Column([42.2, 43.3, 44.4])
+    table['DEC'] = Column([1, 2, 3], unit='deg')
 
     catalog = SourceCatalog(table)
 
@@ -64,13 +66,23 @@ class TestSourceCatalog:
 class TestSourceCatalogObject:
     def setup(self):
         self.cat = make_test_catalog()
-        self.source = self.cat['a']
+        self.source = self.cat['bb']
 
     def test_name(self):
-        assert self.source.name == 'a'
+        assert self.source.name == 'bb'
 
     def test_index(self):
-        assert self.source.index == 0
+        assert self.source.index == 1
+
+    def test_data(self):
+        d = self.source.data
+        print(d)
+        assert isinstance(d, OrderedDict)
+        assert isinstance(d['RA'], float)
+        assert_allclose(d['RA'], 43.3)
+
+        assert isinstance(d['DEC'], Quantity)
+        assert_quantity_allclose(d['DEC'], Quantity(2, 'deg'))
 
     def test_pprint(self):
         # TODO: capture output and assert that it contains some substring

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -31,11 +31,12 @@ CRAB_NAMES_3FHL = ['Crab Pulsar', '3FHL J0534.5+2201', 'PSR J0534+2200',
 
 @requires_data('gammapy-extra')
 class TestFermi3FGLObject:
-    def setup(self):
-        self.cat = SourceCatalog3FGL()
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog3FGL()
         # Use 3FGL J0534.5+2201 (Crab) as a test source
-        self.source_name = '3FGL J0534.5+2201'
-        self.source = self.cat[self.source_name]
+        cls.source_name = '3FGL J0534.5+2201'
+        cls.source = cls.cat[cls.source_name]
 
     def test_name(self):
         assert self.source.name == self.source_name
@@ -47,6 +48,7 @@ class TestFermi3FGLObject:
         assert_allclose(self.source.data['Signif_Avg'], 30.669872283935547)
 
     def test_pprint(self):
+        # TODO: add assert on output
         self.source.pprint()
 
     @pytest.mark.xfail
@@ -72,8 +74,7 @@ class TestFermi3FGLObject:
         assert len(flux_points.table) == 5
         assert 'flux_ul' in flux_points.table.colnames
 
-        desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06,
-                   1.308784e-08]
+        desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06, 1.308784e-08]
         assert_allclose(flux_points.table['dnde'].data, desired, rtol=1E-5)
 
     @pytest.mark.parametrize('name', CRAB_NAMES_3FGL)
@@ -83,11 +84,12 @@ class TestFermi3FGLObject:
 
 @requires_data('gammapy-extra')
 class TestFermi1FHLObject:
-    def setup(self):
-        self.cat = SourceCatalog1FHL()
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog1FHL()
         # Use 1FHL J0534.5+2201 (Crab) as a test source
-        self.source_name = '1FHL J0534.5+2201'
-        self.source = self.cat[self.source_name]
+        cls.source_name = '1FHL J0534.5+2201'
+        cls.source = cls.cat[cls.source_name]
 
     def test_name(self):
         assert self.source.name == self.source_name
@@ -118,11 +120,12 @@ class TestFermi1FHLObject:
 
 @requires_data('gammapy-extra')
 class TestFermi2FHLObject:
-    def setup(self):
-        self.cat = SourceCatalog2FHL()
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog2FHL()
         # Use 2FHL J0534.5+2201 (Crab) as a test source
-        self.source_name = '2FHL J0534.5+2201'
-        self.source = self.cat[self.source_name]
+        cls.source_name = '2FHL J0534.5+2201'
+        cls.source = cls.cat[cls.source_name]
 
     def test_name(self):
         assert self.source.name == self.source_name
@@ -153,11 +156,12 @@ class TestFermi2FHLObject:
 
 @requires_data('gammapy-extra')
 class TestFermi3FHLObject:
-    def setup(self):
-        self.cat = SourceCatalog3FHL()
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog3FHL()
         # Use 3FHL J0534.5+2201 (Crab) as a test source
-        self.source_name = '3FHL J0534.5+2201'
-        self.source = self.cat[self.source_name]
+        cls.source_name = '3FHL J0534.5+2201'
+        cls.source = cls.cat[cls.source_name]
 
     def test_name(self):
         assert self.source.name == self.source_name
@@ -190,8 +194,7 @@ class TestFermi3FHLObject:
         assert len(flux_points.table) == 5
         assert 'flux_ul' in flux_points.table.colnames
 
-        desired = [5.12440652532e-07, 7.37024993524e-08, 9.04493849264e-09, 7.68135443661e-10,
-                   4.30737078315e-11]
+        desired = [5.12440652532e-07, 7.37024993524e-08, 9.04493849264e-09, 7.68135443661e-10, 4.30737078315e-11]
         assert_allclose(flux_points.table['dnde'].data, desired, rtol=1E-5)
 
     @pytest.mark.parametrize('name', CRAB_NAMES_3FHL)
@@ -201,20 +204,23 @@ class TestFermi3FHLObject:
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog3FGL:
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog3FGL()
+
     def test_main_table(self):
-        cat = SourceCatalog3FGL()
-        assert len(cat.table) == 3034
+        assert len(self.cat.table) == 3034
 
     def test_extended_sources(self):
-        cat = SourceCatalog3FGL()
-        table = cat.extended_sources_table
+        table = self.cat.extended_sources_table
         assert len(table) == 25
 
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog1FHL:
-    def setup(self):
-        self.cat = SourceCatalog1FHL()
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog1FHL()
 
     def test_main_table(self):
         assert len(self.cat.table) == 514
@@ -230,8 +236,9 @@ class TestSourceCatalog1FHL:
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog2FHL:
-    def setup(self):
-        self.cat = SourceCatalog2FHL()
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog2FHL()
 
     def test_main_table(self):
         assert len(self.cat.table) == 360
@@ -247,11 +254,13 @@ class TestSourceCatalog2FHL:
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog3FHL:
+    @classmethod
+    def setup_class(cls):
+        cls.cat = SourceCatalog3FHL()
+
     def test_main_table(self):
-        cat = SourceCatalog3FHL()
-        assert len(cat.table) == 1558
+        assert len(self.cat.table) == 1558
 
     def test_extended_sources(self):
-        cat = SourceCatalog3FHL()
-        table = cat.extended_sources_table
+        table = self.cat.extended_sources_table
         assert len(table) == 55

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import OrderedDict
+
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose, pytest
 from astropy import units as u
@@ -90,6 +93,15 @@ class TestSourceCatalogGammaCat:
 
 @requires_data('gammapy-extra')
 class TestSourceCatalogObjectGammaCat:
+
+    def test_data(self, gammacat):
+        source = gammacat[0]
+        # TODO: change the implementation and activate the following assert
+        # assert isinstance(source.data, OrderedDict)
+        # source.pprint()
+        assert source.data['common_name'] == 'CTA 1'
+        assert_allclose(source.data['dec'].value, 72.782997)
+
     @pytest.mark.parametrize(['name', 'desired'], zip(SOURCES, DESIRED_SM))
     def test_spectral_model(self, gammacat, name, desired):
         source = gammacat[name]

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -96,11 +96,9 @@ class TestSourceCatalogObjectGammaCat:
 
     def test_data(self, gammacat):
         source = gammacat[0]
-        # TODO: change the implementation and activate the following assert
-        # assert isinstance(source.data, OrderedDict)
-        # source.pprint()
+        assert isinstance(source.data, OrderedDict)
         assert source.data['common_name'] == 'CTA 1'
-        assert_allclose(source.data['dec'].value, 72.782997)
+        assert_quantity_allclose(source.data['dec'], 72.782997 * u.deg)
 
     @pytest.mark.parametrize(['name', 'desired'], zip(SOURCES, DESIRED_SM))
     def test_spectral_model(self, gammacat, name, desired):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -54,11 +54,13 @@ W28_NAMES = ['W28', 'HESS J1801-233', 'W 28', 'SNR G6.4-0.1', 'SNR G006.4-00.1',
 
 SORT_KEYS = ['ra', 'dec', 'reference_id']
 
+filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat.fits.gz'
 
-@requires_data('gamma-cat')
+
+@requires_data('gammapy-extra')
 class TestSourceCatalogGammaCat:
     def setup(self):
-        self.cat = SourceCatalogGammaCat()
+        self.cat = SourceCatalogGammaCat(filename=filename)
 
     def test_source_table(self):
         assert self.cat.name == 'gamma-cat'
@@ -78,17 +80,17 @@ class TestSourceCatalogGammaCat:
     def test_to_source_library(self):
         sources = self.cat.to_source_library()
 
-        assert len(sources.source_list) == 48
+        assert len(sources.source_list) == 60
 
         source = sources.source_list[0]
-        assert source.source_name == 'CTB 37B'
-        assert_allclose(source.spectral_model.parameters.par('Index').value, -2.6500000953674316)
+        assert source.source_name == 'CTA 1'
+        assert_allclose(source.spectral_model.parameters.par('Index').value, -2.2)
 
 
-@requires_data('gamma-cat')
+@requires_data('gammapy-extra')
 class TestSourceCatalogObjectGammaCat:
     def setup(self):
-        self.cat = SourceCatalogGammaCat()
+        self.cat = SourceCatalogGammaCat(filename=filename)
 
     @pytest.mark.parametrize(['name', 'desired'], zip(SOURCES, DESIRED_SM))
     def test_spectral_model(self, name, desired):


### PR DESCRIPTION
Changing the reference paper values for Vela X in gamma-cat recently  caused a test fail (https://travis-ci.org/gammapy/gammapy/jobs/183176472#L985) in gammapy master, where Vela X is used as a test source. As a quick fix, I marked the tests as `xfail`, but we need a better solution.

@cdeil  Suggested to re-enable the tests, as soon as gamma-cat has version numbers assigned.

 