### PR TITLE
Update BinnedDataAxis to accept bin_lo and bin_hi on input

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -288,7 +288,7 @@ class EffectiveAreaTable2D(object):
     energy : `~astropy.units.Quantity`
         Bin edges of energy axis
     offset : `~astropy.units.Quantity`
-        Nodes of Offset axis
+        Bin edges of offset axis
     data : `~astropy.units.Quantity`
         Effective area
     low_threshold : `~astropy.units.Quantity`, optional 
@@ -320,7 +320,7 @@ class EffectiveAreaTable2D(object):
                 energy,
                 interpolation_mode='log',
                 name='energy'),
-            DataAxis(
+            BinnedDataAxis(
                 offset,
                 interpolation_mode='linear',
                 name='offset')
@@ -358,8 +358,10 @@ class EffectiveAreaTable2D(object):
 
         energy_lo = table['{}_LO'.format(energy_col)].quantity[0]
         energy_hi = table['{}_HI'.format(energy_col)].quantity[0]
-        energy = np.append(energy_lo.value, energy_hi[-1].value) * energy_lo.unit
-        offset = table['{}_HI'.format(offset_col)].quantity[0]
+        energy = BinnedDataAxis.from_lower_and_upper_bounds(energy_lo, energy_hi)
+        o_lo = table['{}_HI'.format(offset_col)].quantity[0]
+        o_hi = table['{}_HI'.format(offset_col)].quantity[0]
+        offset = BinnedDataAxis.from_lower_and_upper_bounds(o_lo, o_hi)
         # see https://github.com/gammasky/hess-host-analyses/issues/32
         data = table['{}'.format(data_col)].quantity[0].transpose()
         return cls(offset=offset, energy=energy, data=data, meta=table.meta)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -31,22 +31,29 @@ class EnergyDispersion(object):
 
     Parameters
     ----------
-    e_true : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
-        Bin edges of true energy axis
-    e_reco : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
-        Bin edges of reconstruced energy axis
+    e_true_lo : `~astropy.units.Quantity`
+        Lower bin edges of true energy axis
+    e_true_hi : `~astropy.units.Quantity`
+        Upper bin edges of true energy axis
+    e_reco_lo : `~astropy.units.Quantity`
+        Lower bin edges of reconstruced energy axis
+    e_reco_hi : `~astropy.units.Quantity`
+        Upper bin edges of reconstruced energy axis
     data : array_like
         2-dim energy dispersion matrix (probability density).
     """
     default_interp_kwargs = dict(bounds_error=False, fill_value=0)
     """Default Interpolation kwargs for `~NDDataArray`"""
 
-    def __init__(self, e_true, e_reco, data, interp_kwargs=None, meta=None):
+    def __init__(self, e_true_lo, e_true_hi, e_reco_lo, e_reco_hi,  data,
+                 interp_kwargs=None, meta=None):
         if interp_kwargs is None:
             interp_kwargs = self.default_interp_kwargs
         axes = [
-            BinnedDataAxis(e_true, interpolation_mode='log', name='e_true'),
-            BinnedDataAxis(e_reco, interpolation_mode='log', name='e_reco')
+            BinnedDataAxis(e_true_lo, e_true_hi,
+                           interpolation_mode='log', name='e_true'),
+            BinnedDataAxis(e_reco_lo, e_reco_hi,
+                           interpolation_mode='log', name='e_reco')
         ]
         self.data=NDDataArray(axes=axes, data=data,
                                 interp_kwargs=interp_kwargs)
@@ -124,7 +131,10 @@ class EnergyDispersion(object):
 
         pdf[np.where(pdf < pdf_threshold)]=0
 
-        return cls(e_true=e_true, e_reco=e_reco, data=pdf)
+        e_lo, e_hi = (e_true[:-1], e_true[1:])
+        ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
+        return cls(e_true_lo=e_lo, e_true_hi=e_hi,
+                   e_reco_lo=ereco_lo, e_reco_hi=ereco_hi, data=pdf)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu1='MATRIX', hdu2='EBOUNDS'):
@@ -159,7 +169,9 @@ class EnergyDispersion(object):
         e_reco=EnergyBounds.from_ebounds(ebounds_hdu)
         e_true=EnergyBounds.from_rmf_matrix(matrix_hdu)
 
-        return cls(data=pdf_matrix, e_true=e_true, e_reco=e_reco)
+        return cls(e_true_lo=e_true.lower_bounds, e_true_hi=e_true.upper_bounds,
+                   e_reco_lo=e_reco.lower_bounds, e_reco_hi=e_reco.upper_bounds,
+                   data=pdf_matrix)
 
     @classmethod
     def read(cls, filename, hdu1='MATRIX', hdu2='EBOUNDS', **kwargs):
@@ -227,7 +239,7 @@ class EnergyDispersion(object):
         hdu=fits.BinTableHDU.from_columns([c0, c1, c2, c3, c4, c5],
                                             header=header, name=name)
 
-        ebounds=energy_axis_to_ebounds(self.e_reco.data)
+        ebounds=energy_axis_to_ebounds(self.e_reco.bins)
         prim_hdu=fits.PrimaryHDU()
 
         return fits.HDUList([prim_hdu, hdu, ebounds])
@@ -265,8 +277,8 @@ class EnergyDispersion(object):
             n_chan[i]=n_chan_temp
             matrix[i]=row[pos]
 
-        table['ENERG_LO']=self.e_true.data[:-1]
-        table['ENERG_HI']=self.e_true.data[1:]
+        table['ENERG_LO']=self.e_true.lo
+        table['ENERG_HI']=self.e_true.hi
         table['N_GRP']=np.asarray(n_grp, dtype=np.int16)
         table['F_CHAN']=f_chan
         table['N_CHAN']=n_chan
@@ -386,8 +398,8 @@ class EnergyDispersion(object):
 
         x stands for true energy and y for reconstructed energy
         """
-        x=self.e_true.data[[0, -1]].value
-        y=self.e_reco.data[[0, -1]].value
+        x=self.e_true.bins[[0, -1]].value
+        y=self.e_reco.bins[[0, -1]].value
         return x[0], x[1], y[0], y[1]
 
     def plot_matrix(self, ax=None, show_energy=None, **kwargs):
@@ -518,12 +530,18 @@ class EnergyDispersion2D(object):
 
     Parameters
     ----------
-    e_true : `~gammapy.utils.energy.Energy`
-        True energy axis bounds
-    migra : `~numpy.ndarray`, list
-        Migration axis bounds
-    offset : `~astropy.coordinates.Angle`
-        Offset axis nodes
+    e_true_lo : `~astropy.units.Quantity`
+        True energy axis lower bounds
+    e_true_hi : `~astropy.units.Quantity`
+        True energy axis upper bounds
+    migra_lo : `~numpy.ndarray`, list
+        Migration axis lower bounds
+    migra_hi : `~numpy.ndarray`, list
+        Migration axis upper bounds
+    offset_lo : `~astropy.coordinates.Angle`
+        Offset axis lower bounds
+    offset_hi : `~astropy.coordinates.Angle`
+        Offset axis upper bounds
     data : `~numpy.ndarray`
         PDF matrix
 
@@ -580,13 +598,17 @@ class EnergyDispersion2D(object):
     default_interp_kwargs = dict(bounds_error=False, fill_value=0)
     """Default Interpolation kwargs for `~NDDataArray`"""
 
-    def __init__(self, e_true, migra, offset, data, interp_kwargs=None):
+    def __init__(self, e_true_lo, e_true_hi, migra_lo, migra_hi, offset_lo,
+                 offset_hi, data, interp_kwargs=None):
         if interp_kwargs is None:
             interp_kwargs = self.default_interp_kwargs
         axes = [
-            BinnedDataAxis(e_true, interpolation_mode='log', name='e_true'),
-            BinnedDataAxis(migra, interpolation_mode='linear', name='migra'),
-            DataAxis(offset, interpolation_mode='linear', name='offset')
+            BinnedDataAxis(e_true_lo, e_true_hi,
+                           interpolation_mode='log', name='e_true'),
+            BinnedDataAxis(migra_lo, migra_hi,
+                           interpolation_mode='linear', name='migra'),
+            BinnedDataAxis(offset_lo, offset_hi,
+                           interpolation_mode='linear', name='offset')
         ]
         self.data = NDDataArray(axes=axes, data=data,
                                 interp_kwargs=interp_kwargs)                       
@@ -609,16 +631,15 @@ class EnergyDispersion2D(object):
         """
         e_lo=table['ETRUE_LO'].quantity.squeeze()
         e_hi=table['ETRUE_HI'].quantity.squeeze()
-        etrue = EnergyBounds.from_lower_and_upper_bounds(e_lo, e_hi)
         o_lo=table['THETA_LO'].quantity.squeeze()
         o_hi=table['THETA_HI'].quantity.squeeze()
-        offset = (o_lo + o_hi) / 2
-        m_lo=table['MIGRA_LO'].data.squeeze()
-        m_hi=table['MIGRA_HI'].data.squeeze()
-        migra = np.append(m_lo, m_hi[-1])
+        m_lo=table['MIGRA_LO'].quantity.squeeze()
+        m_hi=table['MIGRA_HI'].quantity.squeeze()
 
         matrix=table['MATRIX'].squeeze().transpose()
-        return cls(e_true=etrue, offset=offset, migra=migra, data=matrix)
+        return cls(e_true_lo=e_lo, e_true_hi=e_hi,
+                   offset_lo=o_lo, offset_hi=o_hi,
+                   migra_lo=m_lo, migra_hi=m_hi, data=matrix)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu='edisp_2d'):
@@ -662,8 +683,8 @@ class EnergyDispersion2D(object):
             Energy disperion matrix
         """
         offset=Angle(offset)
-        e_true=self.e_true.data if e_true is None else e_true
-        e_reco=self.e_true.data if e_reco is None else e_reco
+        e_true=self.e_true.bins if e_true is None else e_true
+        e_reco=self.e_true.bins if e_reco is None else e_reco
         e_true = EnergyBounds(e_true)
         e_reco = EnergyBounds(e_reco)
 
@@ -674,7 +695,12 @@ class EnergyDispersion2D(object):
             rm.append(vec)
 
         rm=np.asarray(rm)
-        return EnergyDispersion(data=rm, e_true=e_true, e_reco=e_reco)
+        e_lo, e_hi = (e_true[:-1], e_true[1:])
+        ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
+
+        return EnergyDispersion(e_true_lo=e_lo, e_true_hi=e_hi,
+                                e_reco_lo=ereco_lo, e_reco_hi=ereco_hi,
+                                data=rm)
 
     def get_response(self, offset, e_true, e_reco=None):
         """Detector response R(Delta E_reco, E_true)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -88,8 +88,8 @@ class EnergyDispersion(object):
             High reco energy threshold
         """
         data=self.pdf_matrix.copy()
-        idx=np.where((self.e_reco.data[:-1] < lo_threshold) |
-                       (self.e_reco.data[1:] > hi_threshold))
+        idx=np.where((self.e_reco.lo < lo_threshold) |
+                       (self.e_reco.hi > hi_threshold))
         data[:, idx]=0
         return data
 

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -78,7 +78,8 @@ class IRFStacker(object):
 
         stacked_data = aefft / livetime_tot
         self.stacked_aeff = EffectiveAreaTable(
-            energy=self.list_aeff[0].energy.data,
+            energy_lo=self.list_aeff[0].energy.lo,
+            energy_hi=self.list_aeff[0].energy.hi,
             data=stacked_data.to('cm2')
         )
 
@@ -104,6 +105,8 @@ class IRFStacker(object):
 
         stacked_edisp = np.nan_to_num(aefftedisp / aefft)
         self.stacked_edisp = EnergyDispersion(
-            e_true=self.list_edisp[0].e_true.data,
-            e_reco=self.list_edisp[0].e_reco.data,
+            e_true_lo=self.list_edisp[0].e_true.lo,
+            e_true_hi=self.list_edisp[0].e_true.hi,
+            e_reco_lo=self.list_edisp[0].e_reco.lo,
+            e_reco_hi=self.list_edisp[0].e_reco.hi,
             data=stacked_edisp.transpose())

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -31,6 +31,7 @@ def test_EffectiveAreaTable2D(tmpdir):
     test_e = 14 * u.TeV
     test_o = 0.2 * u.deg
     test_val = aeff.data.evaluate(energy=test_e, offset=test_o)
+    import pdb; pdb.set_trace()
     assert_allclose(test_val.value, 740929.645, atol=1e-2)
 
     aeff.plot_image()
@@ -88,7 +89,7 @@ def test_EffectiveAreaTable(tmpdir, data_manager):
     assert ener_below < test_ener and test_ener < ener_above
 
     elo_threshold = arf.find_energy(0.1 * arf.max_area)
-    assert_quantity_allclose(elo_threshold, 0.4367 * u.TeV, rtol=1e-3)
+    assert_quantity_allclose(elo_threshold, 0.4378992335005205 * u.TeV, rtol=1e-3)
 
     # Test evaluation outside safe range
     data = [np.nan, np.nan, 0, 0, 1, 2, 3, np.nan, np.nan]

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -31,7 +31,6 @@ def test_EffectiveAreaTable2D(tmpdir):
     test_e = 14 * u.TeV
     test_o = 0.2 * u.deg
     test_val = aeff.data.evaluate(energy=test_e, offset=test_o)
-    import pdb; pdb.set_trace()
     assert_allclose(test_val.value, 740929.645, atol=1e-2)
 
     aeff.plot_image()
@@ -45,7 +44,9 @@ def test_EffectiveAreaTable2D(tmpdir):
 
     energy = np.sqrt(e_axis[:-1] * e_axis[1:])
     area = aeff.data.evaluate(offset=offset, energy=energy)
-    effarea1d = EffectiveAreaTable(energy=e_axis, data=area)
+    effarea1d = EffectiveAreaTable(energy_lo=e_axis[:-1],
+                                   energy_hi=e_axis[1:],
+                                   data=area)
 
     test_energy = 2.34 * u.TeV
     actual = effareafrom2d.data.evaluate(energy=test_energy)
@@ -89,12 +90,14 @@ def test_EffectiveAreaTable(tmpdir, data_manager):
     assert ener_below < test_ener and test_ener < ener_above
 
     elo_threshold = arf.find_energy(0.1 * arf.max_area)
-    assert_quantity_allclose(elo_threshold, 0.4378992335005205 * u.TeV, rtol=1e-3)
+    assert_quantity_allclose(elo_threshold, 0.43669092057562997 * u.TeV)
 
     # Test evaluation outside safe range
     data = [np.nan, np.nan, 0, 0, 1, 2, 3, np.nan, np.nan]
     energy = np.logspace(0, 10, 10) * u.TeV
-    aeff = EffectiveAreaTable(data=data, energy=energy)
+    aeff = EffectiveAreaTable(data=data,
+                              energy_lo=energy[:-1],
+                              energy_hi=energy[1:])
     vals = aeff.evaluate_fill_nan()
     assert vals[1] == 0
     assert vals[-1] == 3

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -28,8 +28,10 @@ class CountsSpectrum(object):
 
     Parameters
     ----------
-    energy : `~gammapy.utils.energy.EnergyBounds`
-        Bin edges of energy axis
+    energy_lo : `~astropy.units.Quantity`
+        Lower bin edges of energy axis
+    energy_hi : `~astropy.units.Quantity`
+        Upper bin edges of energy axis
     data : `~astropy.units.Quantity`, array-like
         Counts
 
@@ -50,8 +52,9 @@ class CountsSpectrum(object):
     default_interp_kwargs = dict(bounds_error=False, method='nearest')
     """Default interpolation kwargs"""
 
-    def __init__(self, energy, data=None, interp_kwargs=None):
-        axes = [BinnedDataAxis(energy, interpolation_mode='log', name='energy')]
+    def __init__(self, energy_lo, energy_hi, data=None, interp_kwargs=None):
+        axes = [BinnedDataAxis(energy_lo, energy_hi,
+                               interpolation_mode='log', name='energy')]
         # Set data unit to counts for coherence
         if data is not None:
             if isinstance(data, u.Quantity):
@@ -302,8 +305,10 @@ class PHACountsSpectrum(CountsSpectrum):
     ----------
     data : `~numpy.array`, list
         Counts
-    energy : `~astropy.units.Quantity`
-        Bin edges of energy axis
+    energy_lo : `~astropy.units.Quantity`
+        Lower bin edges of energy axis
+    energy_hi : `~astropy.units.Quantity`
+        Upper bin edges of energy axis
     obs_id : int, optional
         Unique identifier, default: 0
     quality : int, array-lik
@@ -330,9 +335,10 @@ class PHACountsSpectrum(CountsSpectrum):
         Zenith Angle
     """
 
-    def __init__(self, energy, data=None, obs_id=0, quality=None, is_bkg=False,
+    def __init__(self, energy_lo, energy_hi, data=None,
+                 obs_id=0, quality=None, is_bkg=False,
                  **kwargs):
-        super(PHACountsSpectrum, self).__init__(energy, data)
+        super(PHACountsSpectrum, self).__init__(energy_lo, energy_hi, data)
         self.obs_id=obs_id
         if quality is None:
             quality = np.zeros(self.energy.nbins, dtype='i2')

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -513,7 +513,7 @@ def calculate_flux_point_binning(obs_list, min_signif):
     max_bin = (current_ebins.find_node(obs.hi_threshold))[0]
 
     # List holding final energy binning
-    binning = [current_ebins.data[current_bin]]
+    binning = [current_ebins.lo[current_bin]]
 
     # Precompute ObservationStats for each bin
     obs_stats = [obs.stats(i) for i in range(current_ebins.nbins)]
@@ -527,7 +527,7 @@ def calculate_flux_point_binning(obs_list, min_signif):
             continue
 
         # Append upper bin edge of good energy bin to final binning
-        binning.append(current_ebins.data[current_bin + rebin_factor])
+        binning.append(current_ebins.lo[current_bin + rebin_factor])
         current_bin += rebin_factor
 
     binning = Quantity(binning)

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -174,7 +174,8 @@ class SpectrumExtraction(object):
             idx = self.target.on_region.contains(obs.events.radec)
             on_events = obs.events.select_row_subset(idx)
 
-            counts_kwargs = dict(energy=self.e_reco,
+            counts_kwargs = dict(energy_lo=self.e_reco[:-1],
+                                 energy_hi=self.e_reco[1:],
                                  livetime=obs.observation_live_time_duration,
                                  obs_id=obs.obs_id)
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -108,12 +108,12 @@ class SpectrumObservation(object):
     @property
     def e_reco(self):
         """Reconstruced energy bounds array."""
-        return EnergyBounds(self.on_vector.energy.data)
+        return EnergyBounds(self.on_vector.energy.bins)
 
     @property
     def e_true(self):
         """True energy bounds array."""
-        return EnergyBounds(self.aeff.energy.data)
+        return EnergyBounds(self.aeff.energy.bins)
 
     @property
     def nbins(self):
@@ -154,7 +154,8 @@ class SpectrumObservation(object):
         """
         energy = self.off_vector.energy
         data = self.off_vector.data.data * self.alpha
-        return CountsSpectrum(data=data, energy=energy)
+        return CountsSpectrum(data=data, energy_lo=energy.lo,
+                              energy_hi=energy.hi)
 
     @property
     def total_stats(self):
@@ -312,14 +313,19 @@ class SpectrumObservation(object):
 
         # Write in keV and cm2 for sherpa
         if use_sherpa:
-            self.on_vector.energy.data = self.on_vector.energy.data.to('keV')
-            self.aeff.energy.data = self.aeff.energy.data.to('keV')
+            self.on_vector.energy.lo = self.on_vector.energy.lo.to('keV')
+            self.on_vector.energy.hi = self.on_vector.energy.hi.to('keV')
+            self.aeff.energy.lo = self.aeff.energy.lo.to('keV')
+            self.aeff.energy.hi = self.aeff.energy.hi.to('keV')
             self.aeff.data.data = self.aeff.data.data.to('cm2')
             if self.off_vector is not None:
-                self.off_vector.energy.data = self.off_vector.energy.data.to('keV')
+                self.off_vector.energy.lo = self.off_vector.energy.lo.to('keV')
+                self.off_vector.energy.hi = self.off_vector.energy.hi.to('keV')
             if self.edisp is not None:
-                self.edisp.e_reco.data = self.edisp.e_reco.data.to('keV')
-                self.edisp.e_true.data = self.edisp.e_true.data.to('keV')
+                self.edisp.e_reco.lo = self.edisp.e_reco.lo.to('keV')
+                self.edisp.e_reco.hi = self.edisp.e_reco.hi.to('keV')
+                self.edisp.e_true.lo = self.edisp.e_true.lo.to('keV')
+                self.edisp.e_true.hi = self.edisp.e_true.hi.to('keV')
                 # Set data to itself to trigger reset of the interpolator
                 # TODO: Make NDData notice change of axis
                 self.edisp.data.data = self.edisp.data.data
@@ -658,7 +664,8 @@ class SpectrumObservationStacker(object):
                                             spec.quality)
 
         stacked_spectrum = PHACountsSpectrum(data=stacked_data,
-                                             energy=energy.data,
+                                             energy_lo=energy.lo,
+                                             energy_hi=energy.hi,
                                              quality=stacked_quality)
         return stacked_spectrum
 

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -332,7 +332,8 @@ class SpectrumFitResult(object):
         """
         energy = self.obs.on_vector.energy
         data = self.npred_src * u.ct
-        return CountsSpectrum(data=data, energy=energy)
+        return CountsSpectrum(data=data, energy_lo=energy.lo,
+                              energy_hi=energy.hi)
 
     @property
     def expected_background_counts(self):
@@ -341,7 +342,8 @@ class SpectrumFitResult(object):
         try:
             energy = self.obs.e_reco
             data = self.npred_bkg * u.ct
-            return CountsSpectrum(data=data, energy=energy)
+            return CountsSpectrum(data=data, energy_hi=energy.upper_bounds,
+                                  energy_lo=energy.lower_bounds)
         except TypeError:
             return None 
 

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import astropy.units as u
 import logging
 from ..utils.random import get_random_state
+from ..utils.energy import EnergyBounds 
 from .utils import calculate_predicted_counts
 from .core import PHACountsSpectrum
 from .observation import SpectrumObservation, SpectrumObservationList
@@ -43,7 +44,8 @@ class SpectrumSimulation(object):
         self.source_model = source_model
         self.aeff = aeff
         self.edisp = edisp
-        self.e_reco = e_reco or edisp.e_reco.data
+        temp = e_reco or edisp.e_reco.bins
+        self.e_reco = EnergyBounds(temp)
         self.background_model = background_model
         self.alpha = alpha
 
@@ -141,7 +143,8 @@ class SpectrumSimulation(object):
         """
         on_counts = rand.poisson(self.npred_source.data.data.value)
 
-        counts_kwargs = dict(energy=self.e_reco,
+        counts_kwargs = dict(energy_lo=self.e_reco.lower_bounds,
+                             energy_hi=self.e_reco.upper_bounds,
                              livetime=self.livetime,
                              creator=self.__class__.__name__)
 
@@ -172,7 +175,8 @@ class SpectrumSimulation(object):
         self.on_vector.data.data += bkg_counts * u.ct
 
         # Create off vector
-        off_vector = PHACountsSpectrum(energy=self.e_reco,
+        off_vector = PHACountsSpectrum(energy_lo=self.e_reco.lower_bounds,
+                                       energy_hi=self.e_reco.upper_bounds,
                                        data=off_counts,
                                        livetime=self.livetime,
                                        backscal=1. / self.alpha,

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -15,22 +15,27 @@ class TestCountsSpectrum:
     def setup(self):
         self.counts = [0, 0, 2, 5, 17, 3] * u.ct
         self.bins = EnergyBounds.equal_log_spacing(1, 10, 6, 'TeV')
-        self.spec = CountsSpectrum(data=self.counts, energy=self.bins)
+        self.spec = CountsSpectrum(data=self.counts, energy_lo=self.bins[:-1],
+                                   energy_hi=self.bins[1:])
 
     def test_init_wo_unit(self):
         counts = [2, 5]
         energy = [1, 2, 3] * u.TeV
-        spec = CountsSpectrum(data=counts, energy=energy)
+        spec = CountsSpectrum(data=counts, energy_lo=energy[:-1],
+                              energy_hi=energy[1:])
         assert spec.data.data.unit.is_equivalent(u.ct)
 
         counts = u.Quantity([2, 5])
-        spec = CountsSpectrum(data=counts, energy=energy)
+        spec = CountsSpectrum(data=counts, energy_lo=energy[:-1],
+                              energy_hi=energy[:-1])
+
         assert spec.data.data.unit.is_equivalent(u.ct)
 
     def test_wrong_init(self):
         bins = EnergyBounds.equal_log_spacing(1, 10, 7, 'TeV')
         with pytest.raises(ValueError):
-            CountsSpectrum(data=self.counts, energy=bins)
+            CountsSpectrum(data=self.counts, energy_lo=bins.lower_bounds,
+                          energy_hi=bins.upper_bounds)
 
     def test_evaluate(self):
         test_e = self.bins[2] + 0.1 * u.TeV
@@ -46,7 +51,7 @@ class TestCountsSpectrum:
         filename = tmpdir / 'test.fits'
         self.spec.write(filename)
         spec2 = CountsSpectrum.read(filename)
-        assert_quantity_allclose(spec2.energy.data, self.bins)
+        assert_quantity_allclose(spec2.energy.bins, self.bins)
 
     def test_rebin(self):
         rebinned_spec = self.spec.rebin(2)
@@ -70,7 +75,8 @@ class TestPHACountsSpectrum:
         self.binning = EnergyBounds.equal_log_spacing(1, 10, 8, 'TeV')
         quality = [1, 1, 1, 0, 0, 1, 1, 1]
         self.spec = PHACountsSpectrum(data=counts,
-                                      energy=self.binning,
+                                      energy_lo=self.binning.lower_bounds,
+                                      energy_hi=self.binning.upper_bounds,
                                       quality=quality)
         self.spec.meta.backscal = 0.3
         self.spec.obs_id = 42
@@ -79,11 +85,13 @@ class TestPHACountsSpectrum:
     def test_init_wo_unit(self):
         counts = [2, 5]
         energy = [1, 2, 3] * u.TeV
-        spec = PHACountsSpectrum(data=counts, energy=energy)
+        spec = PHACountsSpectrum(data=counts, energy_lo=energy[:-1],
+                                 energy_hi=energy[1:])
         assert spec.data.data.unit.is_equivalent(u.ct)
 
         counts = u.Quantity([2, 5])
-        spec = PHACountsSpectrum(data=counts, energy=energy)
+        spec = PHACountsSpectrum(data=counts, energy_lo=energy[:-1],
+                                 energy_hi=energy[1:])
         assert spec.data.data.unit.is_equivalent(u.ct)
 
     def test_basic(self):
@@ -105,8 +113,8 @@ class TestPHACountsSpectrum:
         filename = tmpdir / 'test2.fits'
         self.spec.write(filename)
         spec2 = PHACountsSpectrum.read(filename)
-        assert_quantity_allclose(spec2.energy.data,
-                                 self.spec.energy.data)
+        assert_quantity_allclose(spec2.energy.bins,
+                                 self.spec.energy.bins)
 
     def test_backscal_array(self, tmpdir):
         self.spec.meta.backscal = np.arange(self.spec.energy.nbins)

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -45,15 +45,21 @@ class TestFit:
         random_state = get_random_state(23)
         npred = self.source_model.integral(binning[:-1], binning[1:])
         source_counts = random_state.poisson(npred)
-        self.src = PHACountsSpectrum(energy=binning, data=source_counts,
+        self.src = PHACountsSpectrum(energy_lo=binning[:-1],
+                                     energy_hi=binning[1:],
+                                     data=source_counts,
                                      backscal=1)
 
         npred_bkg = self.bkg_model.integral(binning[:-1], binning[1:])
 
         bkg_counts = random_state.poisson(npred_bkg)
         off_counts = random_state.poisson(npred_bkg * 1. / self.alpha)
-        self.bkg = PHACountsSpectrum(energy=binning, data=bkg_counts)
-        self.off = PHACountsSpectrum(energy=binning, data=off_counts,
+        self.bkg = PHACountsSpectrum(energy_lo=binning[:-1],
+                                     energy_hi=binning[1:],
+                                     data=bkg_counts)
+        self.off = PHACountsSpectrum(energy_lo=binning[:-1],
+                                     energy_hi=binning[1:],
+                                     data=off_counts,
                                      backscal=1. / self.alpha)
 
     def test_cash(self):
@@ -234,7 +240,7 @@ class TestSpectralFit:
         self.fit.fit_range = fit_range
 
         range_bin = obs.on_vector.energy.find_node(fit_range[1])
-        desired = obs.on_vector.energy.data[range_bin]
+        desired = obs.on_vector.energy.lo[range_bin]
         actual = self.fit.true_fit_range[0][1]
         assert_quantity_allclose(actual, desired)
 

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -61,12 +61,14 @@ def get_test_obs():
     # 3 : obs without edisp
     energy = np.logspace(-1,1, 20) * u.TeV
     livetime = 2 * u.h
-    on_vector = PHACountsSpectrum(energy=energy,
+    on_vector = PHACountsSpectrum(energy_lo=energy[:-1],
+                                  energy_hi=energy[1:],
                                   data=np.arange(19),
                                   obs_id=2,
                                   backscal=1,
                                   livetime=livetime)
-    aeff = EffectiveAreaTable(energy=energy,
+    aeff = EffectiveAreaTable(energy_lo=energy[:-1],
+                              energy_hi=energy[1:],
                               data=np.ones(19) * 1e5 * u.m**2)
     obs_3 = SpectrumObservation(on_vector=on_vector, aeff=aeff)
     test_obs.append(dict(

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -1,4 +1,3 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import astropy.units as u
 import numpy as np
@@ -62,10 +61,15 @@ class TestSpectrumSimulation:
         assert self.sim.result[4].on_vector.total_counts == 185 * u.ct
 
     def test_without_edisp(self):
-        self.sim.edisp=None
-        self.sim.simulate_obs(seed=23, obs_id=23)
-        assert self.sim.obs.on_vector.total_counts == 160 * u.ct
+        sim = SpectrumSimulation(aeff=self.sim.aeff,
+                                 source_model=self.sim.source_model,
+                                 livetime=4*u.h,
+                                 e_reco=self.sim.edisp.e_reco.bins
+                                )
+        
+        sim.simulate_obs(seed=23, obs_id=23)
+        assert sim.obs.on_vector.total_counts == 160 * u.ct
         # The test value is taken from the test with edisp
-        assert_allclose(np.sum(self.sim.npred_source.data.data.value),
+        assert_allclose(np.sum(sim.npred_source.data.data.value),
                         167.467572145, rtol=0.01)
 

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -154,7 +154,7 @@ def calculate_predicted_counts(model, aeff, livetime, edisp=None, e_reco=None):
 
     if edisp is not None:
         # TODO: True energy is converted to TeV. See issue 869 
-        true_energy = aeff.energy.data.to('TeV')
+        true_energy = aeff.energy.bins.to('TeV')
 
         flux = model.integral(emin=true_energy[:-1], emax=true_energy[1:],
                               intervals=True)
@@ -167,7 +167,8 @@ def calculate_predicted_counts(model, aeff, livetime, edisp=None, e_reco=None):
         reco_counts = flux * livetime * aeff.evaluate_fill_nan(energy=e_reco.log_centers)
         reco_counts = reco_counts.to('')
 
-    return CountsSpectrum(data=reco_counts, energy=e_reco)
+    return CountsSpectrum(data=reco_counts, energy_lo=e_reco.lower_bounds,
+                          energy_hi=e_reco.upper_bounds)
 
 
 def integrate_spectrum(func, xmin, xmax, ndecade=100, intervals=False):

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -110,13 +110,13 @@ class NDDataArrayTester:
             return
 
         # Case 1: scalar input
-        kwargs = {self.axes[0].name: self.axes[0].data[2] * 0.75}
+        kwargs = {self.axes[0].name: self.axes[0].nodes[2] * 0.75}
         actual = self.nddata.evaluate(**kwargs).shape
         desired = ()
         assert actual == desired
 
         # Case 2: array input
-        kwargs = {self.axes[0].name: self.axes[0].data[0:2] * 0.75}
+        kwargs = {self.axes[0].name: self.axes[0].nodes[0:2] * 0.75}
         actual = self.nddata.evaluate(**kwargs).shape
         desired = np.zeros(2).shape
         assert actual == desired
@@ -126,15 +126,15 @@ class NDDataArrayTester:
             return
 
         # Case 1: axis1 = scalar, axis2 = array
-        kwargs = {self.axes[0].name: self.axes[0].data[1] * 0.75,
-                  self.axes[1].name: self.axes[1].data[0:-1] * 1.1}
+        kwargs = {self.axes[0].name: self.axes[0].lo[1] * 0.75,
+                  self.axes[1].name: self.axes[1].nodes[0:-1] * 1.1}
         actual = self.nddata.evaluate(**kwargs).shape
-        desired = np.zeros(len(self.axes[1].data) - 1).shape
+        desired = np.zeros(len(self.axes[1].nodes) - 1).shape
         assert actual == desired
 
         # Case 2: axis1 = array, axis2 = array
-        kwargs = {self.axes[0].name: self.axes[0].data[1:3] * 0.75,
-                  self.axes[1].name: self.axes[1].data[0:3] * 1.1}
+        kwargs = {self.axes[0].name: self.axes[0].lo[1:3] * 0.75,
+                  self.axes[1].name: self.axes[1].nodes[0:3] * 1.1}
         actual = self.nddata.evaluate(**kwargs).shape
         desired = (2, 3)
         assert actual == desired
@@ -143,10 +143,10 @@ class NDDataArrayTester:
         nx, ny = (12, 3)
 
         # NOTE:  np.linspace does not work with Quantities and numpy 1.10
-        eval_field = np.linspace(self.axes[1].data[1].value,
-                                 self.axes[1].data[2].value,
+        eval_field = np.linspace(self.axes[1].nodes[1].value,
+                                 self.axes[1].nodes[2].value,
                                  nx * ny).reshape(nx, ny) * self.axes[1].unit
-        kwargs = {self.axes[0].name: self.axes[0].data[0:2],
+        kwargs = {self.axes[0].name: self.axes[0].lo[0:2],
                   self.axes[1].name: eval_field}
         actual = self.nddata.evaluate(**kwargs).shape
         desired = np.zeros([2, nx, ny]).shape


### PR DESCRIPTION
This PR updates `~gammapy.utils.nddata.BinnedDataAxis` to reflect the data format typically encountered in IRF files, namely the specification of ``bin_lo`` and ``bin_hi``.

Fixes https://github.com/gammapy/gammapy/issues/861