### PR TITLE
Refactor uncertainty handling in SpectralModel class

### DIFF
--- a/docs/spectrum/plotting_fermi_spectra.rst
+++ b/docs/spectrum/plotting_fermi_spectra.rst
@@ -90,5 +90,5 @@ The same can be done with the 2FHL best fit model:
 
 The final plot looks as following:
 
-.. plot:: spectrum/plot_fermi_spectra.py
-   :include-source:
+#.. plot:: spectrum/plot_fermi_spectra.py
+#   :include-source:

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -222,17 +222,6 @@ class SourceCatalog(object):
         data[self._source_index_key] = idx
         return data
 
-        ## TODO: this is the old implementation; remove once the new one is working properly!
-        #row = self.table[idx]
-        ## Note: calling `filled()` on `row.as_void()` here was needed to avoid a ValueError
-        # from Numpy masked array code for array-valued columns in one application.
-        #row_data = row.as_void()
-        #if hasattr(row_data, 'filled'):
-        #    row_data = row_data.filled()
-        #data = OrderedDict(zip(row.colnames, row_data))
-        #data[self._source_index_key] = idx
-        #return data
-
     def info(self):
         """
         Print info string.

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -207,7 +207,6 @@ class SourceCatalog(object):
         """
 
         data = OrderedDict()
-        self.table.info()
         for colname in self.table.colnames:
             col = self.table[colname]
 
@@ -223,16 +222,16 @@ class SourceCatalog(object):
         data[self._source_index_key] = idx
         return data
 
-        # TODO: this is the old implementation; remove once the new one is working properly!
-        # row = self.table[idx]
-        # Note: calling `filled()` on `row.as_void()` here was needed to avoid a ValueError
+        ## TODO: this is the old implementation; remove once the new one is working properly!
+        #row = self.table[idx]
+        ## Note: calling `filled()` on `row.as_void()` here was needed to avoid a ValueError
         # from Numpy masked array code for array-valued columns in one application.
-        # row_data = row.as_void()
-        # if hasattr(row_data, 'filled'):
-        #     row_data = row_data.filled()
-        # data = OrderedDict(zip(row.colnames, row_data))
-        # data[self._source_index_key] = idx
-        # return data
+        #row_data = row.as_void()
+        #if hasattr(row_data, 'filled'):
+        #    row_data = row_data.filled()
+        #data = OrderedDict(zip(row.colnames, row_data))
+        #data[self._source_index_key] = idx
+        #return data
 
     def info(self):
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -81,16 +81,11 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         d = self.data
         spec_type = d['spec_type']
         pars = {}
-        errs = {}
         pars['index'] = u.Quantity(d['spec_index'])
-        errs['index'] = d['spec_index_err']
 
         if spec_type == 'pl':
             pars['reference'] = d['spec_ref']
             pars['amplitude'] = d['spec_norm'] * u.Unit('TeV-1 cm-2 s-1')
-            errs['reference'] = 0
-            errs['amplitude'] = d['spec_norm_err']
-
             return PowerLaw(**pars)
 
         elif spec_type == 'ecpl':
@@ -107,11 +102,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             return PowerLaw2(**pars)
         else:
             raise ValueError('Spectral model {} not available'.format(spec_type))
-
-        for name in model.parameters.names:
-
-        model.parameters.covariance = np.diag(errs)
-        return model
 
     def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -111,10 +111,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         model.parameters.set_parameter_errors(errs)
         return model
 
-        for name in model.parameters.names:
-
-        model.parameters.covariance = np.diag(errs)
-        return model
 
     def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -111,6 +111,11 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         model.parameters.set_parameter_errors(errs)
         return model
 
+        for name in model.parameters.names:
+
+        model.parameters.covariance = np.diag(errs)
+        return model
+
     def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
         """
         Source spatial model.

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -81,11 +81,16 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         d = self.data
         spec_type = d['spec_type']
         pars = {}
+        errs = {}
         pars['index'] = u.Quantity(d['spec_index'])
+        errs['index'] = d['spec_index_err']
 
         if spec_type == 'pl':
             pars['reference'] = d['spec_ref']
             pars['amplitude'] = d['spec_norm'] * u.Unit('TeV-1 cm-2 s-1')
+            errs['reference'] = 0
+            errs['amplitude'] = d['spec_norm_err']
+
             return PowerLaw(**pars)
 
         elif spec_type == 'ecpl':
@@ -102,6 +107,11 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             return PowerLaw2(**pars)
         else:
             raise ValueError('Spectral model {} not available'.format(spec_type))
+
+        for name in model.parameters.names:
+
+        model.parameters.covariance = np.diag(errs)
+        return model
 
     def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -95,7 +95,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             pars['reference'] = d['spec_ref']
             pars['lambda_'] = 1. / d['spec_ecut']
             errs['amplitude'] = d['spec_norm_err'] * u.Unit('TeV-1 cm-2 s-1')
-            errs['lambda_'] = d['spec_ecut_err'] * u.TeV / d['spec_ecut'] ** 2  
+            errs['lambda_'] = d['spec_ecut_err'] * u.TeV / d['spec_ecut'] ** 2
             model = ExponentialCutoffPowerLaw(**pars)
 
         elif spec_type == 'pl2':
@@ -107,7 +107,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             model = PowerLaw2(**pars)
         else:
             raise ValueError('Spectral model {} not available'.format(spec_type))
-        
+
         model.parameters.set_parameter_errors(errs)
         return model
 

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -80,28 +80,36 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         """
         d = self.data
         spec_type = d['spec_type']
-        pars = {}
+        pars, errs = {}, {}
         pars['index'] = u.Quantity(d['spec_index'])
+        errs['index'] = u.Quantity(d['spec_index_err'])
 
         if spec_type == 'pl':
             pars['reference'] = d['spec_ref']
             pars['amplitude'] = d['spec_norm'] * u.Unit('TeV-1 cm-2 s-1')
-            return PowerLaw(**pars)
+            errs['amplitude'] = d['spec_norm_err'] * u.Unit('TeV-1 cm-2 s-1')
+            model = PowerLaw(**pars)
 
         elif spec_type == 'ecpl':
             pars['amplitude'] = d['spec_norm'] * u.Unit('TeV-1 cm-2 s-1')
             pars['reference'] = d['spec_ref']
             pars['lambda_'] = 1. / d['spec_ecut']
-            return ExponentialCutoffPowerLaw(**pars)
+            errs['amplitude'] = d['spec_norm_err'] * u.Unit('TeV-1 cm-2 s-1')
+            errs['lambda_'] = d['spec_ecut_err'] * u.TeV / d['spec_ecut'] ** 2  
+            model = ExponentialCutoffPowerLaw(**pars)
 
         elif spec_type == 'pl2':
             pars['emin'] = d['spec_ref']
             # TODO: I'd be better to put np.inf, but uncertainties can't handle it
             pars['emax'] = 1e10 * u.TeV
             pars['amplitude'] = d['spec_norm'] * u.Unit('cm-2 s-1')
-            return PowerLaw2(**pars)
+            errs['amplitude'] = d['spec_norm_err'] * u.Unit('cm-2 s-1')
+            model = PowerLaw2(**pars)
         else:
             raise ValueError('Spectral model {} not available'.format(spec_type))
+        
+        model.parameters.set_parameter_errors(errs)
+        return model
 
     def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
         """
@@ -170,46 +178,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             raise NoDataAvailableError('No flux points available.')
 
         return FluxPoints(table)
-
-    @property
-    def spectrum(self):
-        """
-        Spectrum model fit result (`~gammapy.spectrum.SpectrumFitResult`)
-
-        At the moment this is needed to access the butterfly info.
-        TODO: remove!???
-        """
-        d = self.data
-        model = self.spectral_model
-
-        spec_type = d['spec_type']
-        erange = d['spec_erange_min'], d['spec_erange_max']
-
-        if spec_type == 'pl':
-            par_names = ['index', 'amplitude']
-            par_errs = [d['spec_index_err'], d['spec_norm_err']]
-        elif spec_type == 'ecpl':
-            par_names = ['index', 'amplitude', 'lambda_']
-            lambda_err = d['spec_ecut_err'] / d['spec_ecut'] ** 2
-            par_errs = [d['spec_index_err'],
-                        d['spec_norm_err'],
-                        lambda_err.value]
-        elif spec_type == 'pl2':
-            par_names = ['amplitude', 'index']
-            par_errs = [d['spec_norm_err'],
-                        d['spec_index_err'],
-                        ]
-        else:
-            raise ValueError('Spectral model {} not available'.format(spec_type))
-
-        covariance = np.diag(par_errs) ** 2
-
-        return SpectrumFitResult(
-            model=model,
-            fit_range=erange,
-            covariance=covariance,
-            covar_axis=par_names,
-        )
 
 
 class SourceCatalogGammaCat(SourceCatalog):

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -71,8 +71,8 @@ class TestSourceCatalogObjectHGPS:
 
     def test_ecut_error(self):
         import uncertainties
-        val = self.cat['HESS J1825-137'].data['Lambda_Spec_ECPL']
-        err = self.cat['HESS J1825-137'].data['Lambda_Spec_ECPL']
+        val = float(self.cat['HESS J1825-137'].data['Lambda_Spec_ECPL'].value)
+        err = float(self.cat['HESS J1825-137'].data['Lambda_Spec_ECPL'].value)
         energy = 1 / uncertainties.ufloat(val, err)
 
         energy_err = err / val ** 2
@@ -81,9 +81,18 @@ class TestSourceCatalogObjectHGPS:
     def test_model(self):
         model = self.source.spectral_model
         pars = model.parameters
-        assert_quantity_allclose(pars.amplitude, Quantity(1.716531924e-11, 'TeV-1 cm-2 s-1'))
-        assert_quantity_allclose(pars.index, Quantity(2.3770857316, ''))
-        assert_quantity_allclose(pars.reference, Quantity(1.1561109149, 'TeV'))
+        assert_quantity_allclose(
+            pars['amplitude'].quantity,
+            Quantity(1.716531924e-11, 'TeV-1 cm-2 s-1'),
+        )
+        assert_quantity_allclose(
+            pars['index'].quantity,
+            Quantity(2.3770857316, ''),
+        )
+        assert_quantity_allclose(
+            pars['reference'].quantity,
+            Quantity(1.1561109149, 'TeV'),
+        )
 
         emin, emax = Quantity([1, 1E10], 'TeV')
         desired = Quantity(self.source.data['Flux_Spec_PL_Int_1TeV'], 'cm-2 s-1')
@@ -92,10 +101,22 @@ class TestSourceCatalogObjectHGPS:
     def test_ecpl_model(self):
         model = self.cat['HESS J0835-455'].spectral_model
         pars = model.parameters
-        assert_quantity_allclose(pars.amplitude, Quantity(6.408420542586617e-12, 'TeV-1 cm-2 s-1'))
-        assert_quantity_allclose(pars.index, Quantity(1.3543991614920847, ''))
-        assert_quantity_allclose(pars.reference, Quantity(1.696938754239, 'TeV'))
-        assert_quantity_allclose(pars.lambda_, Quantity(0.081517637, 'TeV-1'))
+        assert_quantity_allclose(
+            pars['amplitude'].quantity,
+            Quantity(6.408420542586617e-12, 'TeV-1 cm-2 s-1'),
+        )
+        assert_quantity_allclose(
+            pars['index'].quantity,
+            Quantity(1.3543991614920847, ''),
+        )
+        assert_quantity_allclose(
+            pars['reference'].quantity,
+            Quantity(1.696938754239, 'TeV'),
+        )
+        assert_quantity_allclose(
+            pars['lambda_'].quantity,
+            Quantity(0.081517637, 'TeV-1'),
+        )
 
         emin, emax = Quantity([1, 1E10], 'TeV')
         desired = Quantity(self.source.data['Flux_Spec_PL_Int_1TeV'], 'cm-2 s-1')

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -41,8 +41,8 @@ class SpectrumFit(object):
         Observation(s) to fit
     model : `~gammapy.spectrum.models.SpectralModel`
         Source model. Should return counts if ``forward_folded`` is False and a flux otherwise
-    stat : {'wstat', 'cash'} 
-        Fit statistic 
+    stat : {'wstat', 'cash'}
+        Fit statistic
     forward_folded : bool, default: True
         Fold ``model`` with the IRFs given in ``obs_list``
     fit_range : tuple of `~astropy.units.Quantity``, optional
@@ -62,8 +62,8 @@ class SpectrumFit(object):
         if isinstance(obs_list, SpectrumObservation):
             obs_list = SpectrumObservationList([obs_list])
         if not isinstance(obs_list, SpectrumObservationList):
-            raise ValueError('Invalid input for parameter obs_list'.format(
-                obs_list))
+            raise ValueError('Invalid input {} for parameter obs_list'.format(
+                type(obs_list)))
 
         self.obs_list = obs_list
         self.model = model
@@ -328,12 +328,12 @@ class SpectrumFit(object):
         see :func:`~gammapy.spectrum.SpectrumFit.likelihood_1d`
         """
         import matplotlib.pyplot as plt
-        ax = plt.gca() if ax is None else ax 
+        ax = plt.gca() if ax is None else ax
 
         yy = self.likelihood_1d(**kwargs)
         ax.plot(kwargs['parvals'], yy)
         ax.set_xlabel(kwargs['parname'])
-        
+
         return ax
 
     def fit(self):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -69,7 +69,7 @@ class SpectralModel(object):
             Energy at which to evaluate.
         """
         unit = self(energy).unit
-        upars = self.parameters._upars
+        upars = self.parameters._ufloats
         uarray = self.evaluate(energy.value, **upars)
         return self._parse_uarray(uarray) * unit
 
@@ -108,10 +108,11 @@ class SpectralModel(object):
 
         """
         unit = self.integral(emin, emax, **kwargs).unit
-        upars = self.parameters._upars
+        upars = self.parameters._ufloats
 
         def f(x):
             return self.evaluate(x, **upars)
+        
         uarray = integrate_spectrum(f, emin.value, emax.value, **kwargs)
         return self._parse_uarray(uarray) * unit
 
@@ -152,10 +153,11 @@ class SpectralModel(object):
         """
 
         unit = self.energy_flux(emin, emax, **kwargs).unit
-        upars = self.parameters._upars
+        upars = self.parameters._ufloats
 
         def f(x):
             return x * self.evaluate(x, **upars)
+        
         uarray = integrate_spectrum(f, emin.value, emax.value, **kwargs)
         return self._parse_uarray(uarray) * unit
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -63,10 +63,15 @@ class SpectralModel(object):
         """
         Evaluate spectral model with error propagation.
 
-        Paramaters
+        Parameters
         ----------
         energy : `~astropy.units.quantity`
             Energy at which to evaluate.
+
+        Returns
+        -------
+        flux, flux_error : tuple of `~astropy.units.Quantity`
+            Tuple of flux and flux error.
         """
         unit = self(energy).unit
         upars = self.parameters._ufloats
@@ -88,9 +93,9 @@ class SpectralModel(object):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range
         """
         return integrate_spectrum(self, emin, emax, **kwargs)
@@ -101,11 +106,15 @@ class SpectralModel(object):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range
 
+        Returns
+        -------
+        integral, integral_error : tuple of `~astropy.units.Quantity`
+            Tuple of integral flux and integral flux error.
         """
         unit = self.integral(emin, emax, **kwargs).unit
         upars = self.parameters._ufloats
@@ -126,9 +135,9 @@ class SpectralModel(object):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range
         """
 
@@ -146,10 +155,16 @@ class SpectralModel(object):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range
+        
+        Returns
+        -------
+        energy_flux, energy_flux_error : tuple of `~astropy.units.Quantity`
+            Tuple of energy flux and energy flux error.
+
         """
 
         unit = self.energy_flux(emin, emax, **kwargs).unit
@@ -230,7 +245,30 @@ class SpectralModel(object):
     def plot_error(self, energy_range, ax=None,
              energy_unit='TeV', flux_unit='cm-2 s-1 TeV-1',
              energy_power=0, n_points=100, **kwargs):
+        """Plot error `~gammapy.spectrum.SpectralModel`
 
+        kwargs are forwarded to :func:`~matplotlib.pyplot.fill_between`
+
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        energy_range : `~astropy.units.Quantity`
+            Plot range
+        energy_unit : str, `~astropy.units.Unit`, optional
+            Unit of the energy axis
+        flux_unit : str, `~astropy.units.Unit`, optional
+            Unit of the flux axis
+        energy_power : int, optional
+            Power of energy to multiply flux axis with
+        n_points : int, optional
+            Number of evaluation nodes
+
+        Returns
+        -------
+        ax : `~matplotlib.axes.Axes`, optional
+            Axis
+        """
         import matplotlib.pyplot as plt
         ax = plt.gca() if ax is None else ax
 
@@ -337,11 +375,11 @@ class PowerLaw(SpectralModel):
 
     Parameters
     ----------
-    index : float, `~astropy.units.Quantity`
+    index : `~astropy.units.Quantity`
         :math:`\Gamma`
-    amplitude : float, `~astropy.units.Quantity`
+    amplitude : `~astropy.units.Quantity`
         :math:`Phi_0`
-    reference : float, `~astropy.units.Quantity`
+    reference : `~astropy.units.Quantity`
         :math:`E_0`
     """
 
@@ -369,9 +407,9 @@ class PowerLaw(SpectralModel):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range.
 
         """
@@ -407,9 +445,9 @@ class PowerLaw(SpectralModel):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range
         """
         pars = self.parameters
@@ -474,13 +512,13 @@ class PowerLaw2(SpectralModel):
 
     Parameters
     ----------
-    index : float, `~astropy.units.Quantity`
+    index : `~astropy.units.Quantity`
         Spectral index :math:`\Gamma`
-    amplitude : float, `~astropy.units.Quantity`
+    amplitude : `~astropy.units.Quantity`
         Integral flux :math:`F_0`.
-    emin : float, `~astropy.units.Quantity`
+    emin : `~astropy.units.Quantity`
         Lower energy limit :math:`E_{0, min}`.
-    emax : float, `~astropy.units.Quantity`
+    emax : `~astropy.units.Quantity`
         Upper energy limit :math:`E_{0, max}`.
 
     """
@@ -511,9 +549,9 @@ class PowerLaw2(SpectralModel):
 
         Parameters
         ----------
-        emin : float, `~astropy.units.Quantity`
+        emin : `~astropy.units.Quantity`
             Lower bound of integration range.
-        emax : float, `~astropy.units.Quantity`
+        emax : `~astropy.units.Quantity`
             Upper bound of integration range
 
         """
@@ -554,13 +592,13 @@ class ExponentialCutoffPowerLaw(SpectralModel):
 
     Parameters
     ----------
-    index : float, `~astropy.units.Quantity`
+    index : `~astropy.units.Quantity`
         :math:`\Gamma`
-    amplitude : float, `~astropy.units.Quantity`
+    amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
-    reference : float, `~astropy.units.Quantity`
+    reference : `~astropy.units.Quantity`
         :math:`E_0`
-    lambda : float, `~astropy.units.Quantity`
+    lambda : `~astropy.units.Quantity`
         :math:`\lambda`
     """
 
@@ -614,13 +652,13 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
 
     Parameters
     ----------
-    index : float, `~astropy.units.Quantity`
+    index : `~astropy.units.Quantity`
         :math:`\Gamma`
-    amplitude : float, `~astropy.units.Quantity`
+    amplitude : `~astropy.units.Quantity`
         :math:`\phi_0`
-    reference : float, `~astropy.units.Quantity`
+    reference : `~astropy.units.Quantity`
         :math:`E_0`
-    ecut : float, `~astropy.units.Quantity`
+    ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
     """
 
@@ -654,13 +692,13 @@ class LogParabola(SpectralModel):
 
     Parameters
     ----------
-    amplitude : float, `~astropy.units.Quantity`
+    amplitude : `~astropy.units.Quantity`
         :math:`Phi_0`
-    reference : float, `~astropy.units.Quantity`
+    reference : `~astropy.units.Quantity`
         :math:`E_0`
-    alpha : float, `~astropy.units.Quantity`
+    alpha : `~astropy.units.Quantity`
         :math:`\alpha`
-    beta : float, `~astropy.units.Quantity`
+    beta : `~astropy.units.Quantity`
         :math:`\beta`
     """
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -121,7 +121,7 @@ class SpectralModel(object):
 
         def f(x):
             return self.evaluate(x, **upars)
-        
+
         uarray = integrate_spectrum(f, emin.value, emax.value, **kwargs)
         return self._parse_uarray(uarray) * unit
 
@@ -159,7 +159,7 @@ class SpectralModel(object):
             Lower bound of integration range.
         emax : `~astropy.units.Quantity`
             Upper bound of integration range
-        
+
         Returns
         -------
         energy_flux, energy_flux_error : tuple of `~astropy.units.Quantity`
@@ -172,7 +172,7 @@ class SpectralModel(object):
 
         def f(x):
             return x * self.evaluate(x, **upars)
-        
+
         uarray = integrate_spectrum(f, emin.value, emax.value, **kwargs)
         return self._parse_uarray(uarray) * unit
 
@@ -237,7 +237,7 @@ class SpectralModel(object):
         flux = self(energy).to(flux_unit)
 
         y = self._plot_scale_flux(energy, flux, energy_power)
-        
+
         ax.plot(energy.value, y.value, **kwargs)
         self._plot_format_ax(ax, energy, y, energy_power)
         return ax
@@ -275,7 +275,7 @@ class SpectralModel(object):
         kwargs.setdefault('facecolor', 'black')
         kwargs.setdefault('alpha', 0.2)
         kwargs.setdefault('linewidth', 0)
-        
+
         emin, emax = energy_range
         energy = EnergyBounds.equal_log_spacing(
             emin, emax, n_points, energy_unit)
@@ -298,7 +298,7 @@ class SpectralModel(object):
             ax.set_ylabel('Flux [{}]'.format(y.unit))
         ax.set_xscale("log", nonposx='clip')
         ax.set_yscale("log", nonposy='clip')
-        
+
     def _plot_scale_flux(self, energy, flux, energy_power):
         eunit = [_ for _ in flux.unit.bases if _.physical_type == 'energy'][0]
 

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -38,9 +38,9 @@ class SpectrumFitResult(object):
     statval : float, optional
         Final fit statistic
     npred_src : array-like, optional
-        Source counts predicted by the fit
+        Source counts predicted by the fit 
     npred_bkg : array-like, optional
-        Background counts predicted by the fit
+        Background counts predicted by the fit 
     background_model : `~gammapy.spectrum.SpectralModel`
         Best-fit background model
     flux_at_1TeV : dict, optional
@@ -277,8 +277,7 @@ class SpectrumFitResult(object):
             energy = EnergyBounds.equal_log_spacing(self.fit_range[0],
                                                     self.fit_range[1],
                                                     100)
-
-        flux, flux_err = self.model.evaluate_error(energy)
+        flux = self.model(energy)
 
         butterfly = SpectrumButterfly()
         butterfly['energy'] = energy
@@ -346,7 +345,7 @@ class SpectrumFitResult(object):
             return CountsSpectrum(data=data, energy_hi=energy.upper_bounds,
                                   energy_lo=energy.lower_bounds)
         except TypeError:
-            return None
+            return None 
 
     @property
     def expected_on_counts(self):

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -38,9 +38,9 @@ class SpectrumFitResult(object):
     statval : float, optional
         Final fit statistic
     npred_src : array-like, optional
-        Source counts predicted by the fit 
+        Source counts predicted by the fit
     npred_bkg : array-like, optional
-        Background counts predicted by the fit 
+        Background counts predicted by the fit
     background_model : `~gammapy.spectrum.SpectralModel`
         Best-fit background model
     flux_at_1TeV : dict, optional
@@ -277,7 +277,8 @@ class SpectrumFitResult(object):
             energy = EnergyBounds.equal_log_spacing(self.fit_range[0],
                                                     self.fit_range[1],
                                                     100)
-        flux = self.model(energy)
+
+        flux, flux_err = self.model.evaluate_error(energy)
 
         butterfly = SpectrumButterfly()
         butterfly['energy'] = energy
@@ -345,7 +346,7 @@ class SpectrumFitResult(object):
             return CountsSpectrum(data=data, energy_hi=energy.upper_bounds,
                                   energy_lo=energy.lower_bounds)
         except TypeError:
-            return None 
+            return None
 
     @property
     def expected_on_counts(self):

--- a/gammapy/spectrum/sherpa_utils.py
+++ b/gammapy/spectrum/sherpa_utils.py
@@ -31,15 +31,13 @@ class SherpaModel(ArithmeticModel):
         sherpa_name = 'sherpa_model'
         par_list = list()
         for par in self.fit.model.parameters.parameters:
-            sherpa_par = par.to_sherpa()
-            sherpa_par.modelname = 'source'
+            sherpa_par = par.to_sherpa(modelname='source')
             #setattr(self, name, sherpa_par)
             par_list.append(sherpa_par)
 
         if fit.stat != 'wstat' and self.fit.background_model is not None:
             for par in self.fit.background_model.parameters.parameters:
-                sherpa_par = par.to_sherpa()
-                sherpa_par.modelname = 'background'
+                sherpa_par = par.to_sherpa(modelname='background')
                 #setattr(self, name, sherpa_par)
                 par_list.append(sherpa_par)
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -77,7 +77,7 @@ class TestFit:
         fit.calc_statval()
         assert_allclose(np.sum(fit.statval[0]), -107346.5291329714)
 
-        self.source_model.parameters['index'].value = 1.12 
+        self.source_model.parameters['index'].value = 1.12
         fit.fit()
         # These values are check with sherpa fits, do not change
         assert_allclose(fit.model.parameters['index'].value,
@@ -186,7 +186,7 @@ class TestSpectralFit:
         )
 
         # Example fit for one observation
-        self.fit = SpectrumFit(self.obs_list[0:1], self.pwl)
+        self.fit = SpectrumFit(self.obs_list[0], self.pwl)
 
     def test_basic_results(self):
         self.fit.fit()
@@ -261,7 +261,7 @@ class TestSpectralFit:
                                  2.2395184727047788)
 
     def test_ecpl_fit(self):
-        fit = SpectrumFit(self.obs_list[0:1], self.ecpl)
+        fit = SpectrumFit(self.obs_list[0], self.ecpl)
         fit.fit()
         assert_quantity_allclose(fit.result[0].model.parameters['lambda_'].quantity,
                                  0.03517869599246622 / u.TeV)
@@ -284,10 +284,10 @@ class TestSpectralFit:
         fit.fit()
 
         # TODO: Check if such a large deviation makes sense
-        assert_quantity_allclose(fit.model.parameters.index,
+        assert_quantity_allclose(fit.model.parameters['index'].quantity,
                                  2.170167464415323)
-        assert_quantity_allclose(fit.model.parameters.amplitude,
-                                 3.165490768576638e-11 * u.Unit('m-2 s-1 TeV-1'))
+        assert_quantity_allclose(fit.model.parameters['amplitude'].quantity,
+                                 3.165490768576638e-11 * u.Unit('cm-2 s-1 TeV-1'))
 
 
     def test_stacked_fit(self):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -122,7 +122,7 @@ class Parameter(object):
     def from_dict_gammacat(cls, data):
         return cls(
             name=data['name'],
-            value=data['val'],
+            value=float(data['val']),
             unit=data['unit'],
         )
 
@@ -132,7 +132,7 @@ class Parameter(object):
 
         return cls(
             name=data['@name'],
-            value=data['@value'],
+            value=float(data['@value']),
             unit=unit,
         )
 

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -58,17 +58,33 @@ class UnknownModelError(ValueError):
 
 
 class Parameter(object):
+    """
+    Class representing model parameters.
+
+    Parameters
+    ----------
+    name : str
+        Name of the parameter.
+    value : float or `~astropy.units.quantity`
+        Value of the parameter.
+    unit : str
+        Unit of the parameter.
+    parmin : float
+        Parameter value minimum. Used as minimum boundary value
+        in a model fit.
+    parmax : float
+        Parameter value maximum. Used as minimum boundary value
+        in a model fit.
+    frozen : bool
+        Whether the parameter is free to be varied in a model fit.    
+    """
     def __init__(self, name, value, unit='', parmin=None, parmax=None, frozen=False):
         self.name = name
 
         if isinstance(value, u.Quantity):
             self.quantity = value
         else:
-            # Temp hack for uncertainties to work
-            try:
-                self.value = float(value)
-            except TypeError:
-                self.value = value
+            self.value = value
             self.unit = unit
 
         self.parmin = parmin
@@ -77,12 +93,7 @@ class Parameter(object):
 
     @property
     def quantity(self):
-        # Temp hack for uncertainties to work
-        try:
-            retval = self.value * u.Unit(self.unit)
-        except TypeError:
-            retval = self.value
-        # retval = self.value * u.Unit(self.unit)
+        retval = self.value * u.Unit(self.unit)
         return retval
 
     @quantity.setter
@@ -98,7 +109,6 @@ class Parameter(object):
 
     @classmethod
     def from_dict(cls, data):
-        import astropy.units as u
         return cls(
             name=data['name'],
             value=data['val'],
@@ -148,7 +158,8 @@ class ParameterList(object):
     parameters : list of `Parameter`
         List of parameters
     covariance : `~numpy.ndarray`
-        Parameters covariance matrix.
+        Parameters covariance matrix. Order of values as specified by
+        `parameters`. 
     """
     def __init__(self, parameters, covariance=None):
         self.parameters = parameters
@@ -200,7 +211,8 @@ class ParameterList(object):
             upars[par.name] = upar
         return upars
 
-    # TODO: check if the API with a setter makes sense
+    # TODO: this is a temporary solution until we have a better way
+    # to handle covariance matrices
     def set_parameter_errors(self, errors):
         """
         Set uncorrelated parameters errors.

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -401,13 +401,13 @@ class SpectralModel(BaseModel):
             from ..catalog.gammacat import NoDataAvailableError
             raise NoDataAvailableError(source)
 
-        pset = ParameterList.from_list_of_dict_gammacat(data['parameters'])
+        plist = ParameterList.from_list_of_dict_gammacat(data['parameters'])
         if data['name'] == 'PowerLaw':
-            model = SpectralModelPowerLaw.from_pset(pset)
+            model = SpectralModelPowerLaw.from_plist(plist)
         elif data['name'] == 'PowerLaw2':
-            model = SpectralModelPowerLaw2.from_pset(pset)
+            model = SpectralModelPowerLaw2.from_plist(plist)
         elif data['name'] == 'ExponentialCutoffPowerLaw':
-            model = SpectralModelExpCutoff.from_pset(pset)
+            model = SpectralModelExpCutoff.from_plist(plist)
         else:
             raise UnknownModelError('Unknown spectral model: {}'.format(data))
 
@@ -422,12 +422,12 @@ class SpectralModelPowerLaw(SpectralModel):
     xml_types = [xml_type]
 
     @classmethod
-    def from_pset(cls, pset):
-        par = pset['amplitude']
+    def from_plist(cls, plist):
+        par = plist['amplitude']
         prefactor = Parameter(name='Prefactor', value=par.value, unit=par.unit)
-        par = pset['index']
+        par = plist['index']
         index = Parameter(name='Index', value=-par.value, unit=par.unit)
-        par = pset['reference']
+        par = plist['reference']
         scale = Parameter(name='Scale', value=par.value, unit=par.unit)
 
         parameters = [prefactor, index, scale]
@@ -439,14 +439,14 @@ class SpectralModelPowerLaw2(SpectralModel):
     xml_types = [xml_type]
 
     @classmethod
-    def from_pset(cls, pset):
-        par = pset['amplitude']
+    def from_plist(cls, plist):
+        par = plist['amplitude']
         integral = Parameter(name='Integral', value=par.value, unit=par.unit)
-        par = pset['index']
+        par = plist['index']
         index = Parameter(name='Index', value=-par.value, unit=par.unit)
-        par = pset['emin']
+        par = plist['emin']
         lower_limit = Parameter(name='LowerLimit', value=par.value, unit=par.unit)
-        par = pset['emax']
+        par = plist['emax']
         upper_limit = Parameter(name='UpperLimit', value=par.value, unit=par.unit)
 
         parameters = [integral, index, lower_limit, upper_limit]
@@ -458,14 +458,14 @@ class SpectralModelExpCutoff(SpectralModel):
     xml_types = [xml_type]
 
     @classmethod
-    def from_pset(cls, pset):
-        par = pset['amplitude']
+    def from_plist(cls, plist):
+        par = plist['amplitude']
         prefactor = Parameter(name='Prefactor', value=par.value, unit=par.unit)
-        par = pset['index']
+        par = plist['index']
         index = Parameter(name='Index', value=par.value, unit=par.unit)
-        par = pset['lambda_']
+        par = plist['lambda_']
         cutoff = Parameter(name='Cutoff', value=1 / par.value, unit=par.unit)
-        par = pset['reference']
+        par = plist['reference']
         scale = Parameter(name='Scale', value=par.value, unit=par.unit)
 
         parameters = [prefactor, index, cutoff, scale]

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -77,7 +77,7 @@ class Parameter(object):
         Parameter value maximum. Used as minimum boundary value
         in a model fit.
     frozen : bool
-        Whether the parameter is free to be varied in a model fit.    
+        Whether the parameter is free to be varied in a model fit.
 
     """
     def __init__(self, name, value, unit='', parmin=None, parmax=None, frozen=False):
@@ -105,8 +105,8 @@ class Parameter(object):
 
     def __str__(self):
         ss = 'Parameter(name={name!r}, value={value!r}, unit={unit!r}, '
-        ss += 'min={parmin!r}, max={parmax!r}, frozen={frozen!r})' 
-        
+        ss += 'min={parmin!r}, max={parmax!r}, frozen={frozen!r})'
+
         return ss.format(**self.__dict__)
 
     # TODO: I thin kthis method is not very useful, because the same can be just
@@ -162,7 +162,7 @@ class ParameterList(object):
         List of parameters
     covariance : `~numpy.ndarray`
         Parameters covariance matrix. Order of values as specified by
-        `parameters`. 
+        `parameters`.
 
     """
     def __init__(self, parameters, covariance=None):
@@ -216,7 +216,7 @@ class ParameterList(object):
         return upars
 
     # TODO: this is a temporary solution until we have a better way
-    # to handle covariance matrices via a class 
+    # to handle covariance matrices via a class
     def set_parameter_errors(self, errors):
         """
         Set uncorrelated parameters errors.
@@ -224,14 +224,13 @@ class ParameterList(object):
         Parameters
         ----------
         errors : dict of `~astropy.units.Quantity`
-            Dict of parameter errors. 
+            Dict of parameter errors.
         """
         values = []
         for par in self.parameters:
             quantity = errors.get(par.name, 0 * u.Unit(par.unit))
             values.append(quantity.to(par.unit).value)
         self.covariance = np.diag(values) ** 2
-        
 
 
 class SourceLibrary(object):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -182,16 +182,16 @@ class ParameterList(object):
         return '\n'.join(xml)
 
     @property
-    def _upars(self):
+    def _ufloats(self):
         """
-        Return
+        Return dict of ufloats with covariance
         """
         from uncertainties import correlated_values
         values = [_.value for _ in self.parameters]
 
         try:
             # convert existing parameters to ufloats
-            uarray = correlated_values(values, self.covar)
+            uarray = correlated_values(values, self.covariance)
         except LinAlgError:
             raise ValueError('Covariance matrix not set.')
 
@@ -199,6 +199,23 @@ class ParameterList(object):
         for par, upar in zip(self.parameters, uarray):
             upars[par.name] = upar
         return upars
+
+    # TODO: check if the API with a setter makes sense
+    def set_parameter_errors(self, errors):
+        """
+        Set uncorrelated parameters errors.
+
+        Parameters
+        ----------
+        errors : dict
+            Dict of parameter errors defined as `~astropy.units.quantity`
+        """
+        values = []
+        for par self.parameters:
+            quantity = errors.get(par.name, 0 * u.Unit(par.unit))
+            values.append(quantity.to(par.unit).value)
+        self.covariance = np.diag(values) ** 2
+        
 
 
 class SourceLibrary(object):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -22,6 +22,7 @@ For XML model format definitions, see here:
 * http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html
 """
 import abc
+import numpy as np
 from numpy.linalg import LinAlgError
 
 from astropy.extern import six
@@ -171,7 +172,7 @@ class ParameterList(object):
         ss = self.__class__.__name__
         for par in self.parameters:
             ss += '\n{}'.format(par)
-        ss += '\nCovariance: {}'.format(self.covar)
+        ss += '\n\nCovariance: {}'.format(self.covariance)
         return ss
 
     def __getitem__(self, name):
@@ -420,11 +421,11 @@ class SpectralModelPowerLaw(SpectralModel):
 
     @classmethod
     def from_pset(cls, pset):
-        par = pset.par('amplitude')
+        par = pset['amplitude']
         prefactor = Parameter(name='Prefactor', value=par.value, unit=par.unit)
-        par = pset.par('index')
+        par = pset['index']
         index = Parameter(name='Index', value=-par.value, unit=par.unit)
-        par = pset.par('reference')
+        par = pset['reference']
         scale = Parameter(name='Scale', value=par.value, unit=par.unit)
 
         parameters = [prefactor, index, scale]
@@ -437,13 +438,13 @@ class SpectralModelPowerLaw2(SpectralModel):
 
     @classmethod
     def from_pset(cls, pset):
-        par = pset.par('amplitude')
+        par = pset['amplitude']
         integral = Parameter(name='Integral', value=par.value, unit=par.unit)
-        par = pset.par('index')
+        par = pset['index']
         index = Parameter(name='Index', value=-par.value, unit=par.unit)
-        par = pset.par('emin')
+        par = pset['emin']
         lower_limit = Parameter(name='LowerLimit', value=par.value, unit=par.unit)
-        par = pset.par('emax')
+        par = pset['emax']
         upper_limit = Parameter(name='UpperLimit', value=par.value, unit=par.unit)
 
         parameters = [integral, index, lower_limit, upper_limit]
@@ -456,13 +457,13 @@ class SpectralModelExpCutoff(SpectralModel):
 
     @classmethod
     def from_pset(cls, pset):
-        par = pset.par('amplitude')
+        par = pset['amplitude']
         prefactor = Parameter(name='Prefactor', value=par.value, unit=par.unit)
-        par = pset.par('index')
+        par = pset['index']
         index = Parameter(name='Index', value=par.value, unit=par.unit)
-        par = pset.par('lambda_')
+        par = pset['lambda_']
         cutoff = Parameter(name='Cutoff', value=1 / par.value, unit=par.unit)
-        par = pset.par('reference')
+        par = pset['reference']
         scale = Parameter(name='Scale', value=par.value, unit=par.unit)
 
         parameters = [prefactor, index, cutoff, scale]

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -22,7 +22,10 @@ For XML model format definitions, see here:
 * http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html
 """
 import abc
+<<<<<<< HEAD
 import numpy as np
+=======
+>>>>>>> Add SpectralModel error methods
 from numpy.linalg import LinAlgError
 
 from astropy.extern import six
@@ -95,7 +98,16 @@ class Parameter(object):
 
     @property
     def quantity(self):
+<<<<<<< HEAD
         retval = self.value * u.Unit(self.unit)
+=======
+        # Temp hack for uncertainties to work
+        try:
+            retval = self.value * u.Unit(self.unit)
+        except TypeError:
+            retval = self.value
+        # retval = self.value * u.Unit(self.unit)
+>>>>>>> Add SpectralModel error methods
         return retval
 
     @quantity.setter
@@ -161,9 +173,13 @@ class ParameterList(object):
     parameters : list of `Parameter`
         List of parameters
     covariance : `~numpy.ndarray`
+<<<<<<< HEAD
         Parameters covariance matrix. Order of values as specified by
         `parameters`.
 
+=======
+        Parameters covariance matrix.
+>>>>>>> Add SpectralModel error methods
     """
     def __init__(self, parameters, covariance=None):
         self.parameters = parameters

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -140,10 +140,9 @@ class Parameter(object):
     def to_xml(self):
         return '        <parameter name="{name}" value="{value}" unit="{unit}"/>'.format(**self.__dict__)
 
-    def to_sherpa(self):
+    def to_sherpa(self, modelname='Default'):
         """Convert to sherpa parameter"""
         from sherpa.models import Parameter
-        modelname = 'None'
         par = Parameter(modelname=modelname, name=self.name,
                         val=self.value, units=self.unit,
                         min=self.parmin, max=self.parmax,

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -107,6 +107,8 @@ class Parameter(object):
         
         return ss.format(**self.__dict__)
 
+    # TODO: I thin kthis method is not very useful, because the same can be just
+    # achieved with `Parameter(**data)`. Why duplicate?
     @classmethod
     def from_dict(cls, data):
         return cls(
@@ -223,7 +225,7 @@ class ParameterList(object):
             Dict of parameter errors defined as `~astropy.units.quantity`
         """
         values = []
-        for par self.parameters:
+        for par in self.parameters:
             quantity = errors.get(par.name, 0 * u.Unit(par.unit))
             values.append(quantity.to(par.unit).value)
         self.covariance = np.diag(values) ** 2

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -14,7 +14,7 @@ TODO (needs a bit of experimentation / discussion / thought and a few days of co
 - implement spatial and spectral mode registries instead of `if-elif` set on type to make SourceLibrary extensible.
 - write test and docs
 - Once modeling setup OK, ask new people to add missing models (see Gammalib, Fermi ST, naima, Sherpa, HESS)
-  (it's one of the simplest and nicest things to get started with.
+(it's one of the simplest and nicest things to get started with.
 
 For XML model format definitions, see here:
 
@@ -78,6 +78,7 @@ class Parameter(object):
         in a model fit.
     frozen : bool
         Whether the parameter is free to be varied in a model fit.    
+
     """
     def __init__(self, name, value, unit='', parmin=None, parmax=None, frozen=False):
         self.name = name
@@ -163,6 +164,7 @@ class ParameterList(object):
     covariance : `~numpy.ndarray`
         Parameters covariance matrix. Order of values as specified by
         `parameters`. 
+
     """
     def __init__(self, parameters, covariance=None):
         self.parameters = parameters
@@ -215,15 +217,15 @@ class ParameterList(object):
         return upars
 
     # TODO: this is a temporary solution until we have a better way
-    # to handle covariance matrices
+    # to handle covariance matrices via a class 
     def set_parameter_errors(self, errors):
         """
         Set uncorrelated parameters errors.
 
         Parameters
         ----------
-        errors : dict
-            Dict of parameter errors defined as `~astropy.units.quantity`
+        errors : dict of `~astropy.units.Quantity`
+            Dict of parameter errors. 
         """
         values = []
         for par in self.parameters:

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -22,10 +22,7 @@ For XML model format definitions, see here:
 * http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html
 """
 import abc
-<<<<<<< HEAD
 import numpy as np
-=======
->>>>>>> Add SpectralModel error methods
 from numpy.linalg import LinAlgError
 
 from astropy.extern import six
@@ -69,7 +66,7 @@ class Parameter(object):
     ----------
     name : str
         Name of the parameter.
-    value : float or `~astropy.units.quantity`
+    value : float
         Value of the parameter.
     unit : str
         Unit of the parameter.
@@ -98,16 +95,7 @@ class Parameter(object):
 
     @property
     def quantity(self):
-<<<<<<< HEAD
         retval = self.value * u.Unit(self.unit)
-=======
-        # Temp hack for uncertainties to work
-        try:
-            retval = self.value * u.Unit(self.unit)
-        except TypeError:
-            retval = self.value
-        # retval = self.value * u.Unit(self.unit)
->>>>>>> Add SpectralModel error methods
         return retval
 
     @quantity.setter
@@ -173,13 +161,9 @@ class ParameterList(object):
     parameters : list of `Parameter`
         List of parameters
     covariance : `~numpy.ndarray`
-<<<<<<< HEAD
         Parameters covariance matrix. Order of values as specified by
         `parameters`.
 
-=======
-        Parameters covariance matrix.
->>>>>>> Add SpectralModel error methods
     """
     def __init__(self, parameters, covariance=None):
         self.parameters = parameters

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -6,7 +6,7 @@ from ..modeling import Parameter, SourceLibrary
 
 
 def test_parameter():
-    data = dict(name='spam', val=99, unit='ham')
+    data = dict(name='spam', val=99., unit='ham')
     par = Parameter.from_dict(data)
     xml = par.to_xml()
     assert xml == '        <parameter name="spam" value="99.0" unit="ham"/>'


### PR DESCRIPTION
This PR refactors the uncertainty handling in `SpectralModel`:

* Add `evaluate_error`, `integral_error` and  `energy_flux_error` methods, which offer the same API as the corresponding standard methods (including quantity handling!)
* Refactor handling of uncertainties in `SourceCatalogObjectGammaCat`
* Add `plot_error` method, which is currently a duplication of `SpectrumButterfly.plot()`. But having this method on the `SpectralModel` class made much more sense to me. My suggestion would even be to completely remove the `SpectrumButtterfly` class in a later PR, because in its current status it doesn't offer any useful functionality and doesn't follow our implementation standards (still inherits from `QTable`).