### PR TITLE
Adapt CTAPerf and CTA simulations (point-like analysis)

### DIFF
--- a/gammapy/scripts/cta_utils.py
+++ b/gammapy/scripts/cta_utils.py
@@ -12,7 +12,7 @@ from ..spectrum.models import AbsorbedSpectralModel, TableModel
 __all__ = [
     'Target',
     'ObservationParameters',
-    'CTASpectrumObservation',
+    'CTAObservationSimulation',
 ]
 
 
@@ -46,9 +46,9 @@ class Target(object):
         elif ebl_model_name in 'dominguez':
             filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz'
         elif ebl_model_name in 'finke':
-            filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz'
+            filename = '$GAMMAPY_EXTRA/datasets/ebl/frd_abs.fits.gz'
         else:
-            print('No redshift?')
+            pass
 
         if redshift is not None:
             absorption = TableModel.read_xspec_model(filename, redshift)
@@ -61,8 +61,8 @@ class Target(object):
         """Target report (`str`)."""
         ss = '*** Target parameters ***\n'
         ss += 'Name={}\n'.format(self.name)
-        for idx, param in enumerate(self.model.parameters):
-            ss += '{}={}\n'.format(param, self.model.parameters[str(param)])
+        for par in self.model.parameters.parameters:
+            ss += '{}={} {}\n'.format(par.name, str(par.value), par.unit)
         ss += 'Redshift={}'.format(self.redshift)
         return ss
 
@@ -79,10 +79,6 @@ class ObservationParameters(object):
         Normalisation between ON and OFF regions
     livetime :  `~astropy.units.Quantity`
         Observation time
-    offset :  `~astropy.units.Quantity`
-        Offset of the source
-    zenith :  `~astropy.units.Quantity`
-        Zenith of the source
     emin :  `~astropy.units.Quantity`
         Minimal energy for simulation
     emax :  `~astropy.units.Quantity`
@@ -90,12 +86,9 @@ class ObservationParameters(object):
     """
 
     def __init__(self, alpha=None, livetime=None,
-                 offset=None, zenith=None, emin=None,
-                 emax=None):
+                 emin=None, emax=None):
         self.alpha = alpha
         self.livetime = livetime
-        self.offset = offset
-        self.zenith = zenith
         self.emin = emin
         self.emax = emax
 
@@ -104,16 +97,12 @@ class ObservationParameters(object):
         ss = '*** Observation parameters summary ***\n'
         ss += 'alpha={} [{}]\n'.format(self.alpha.value, self.alpha.unit)
         ss += 'livetime={} [{}]\n'.format(self.livetime.value, self.livetime.unit)
-        if self.offset is not None:
-            ss += 'offset={} [{}]\n'.format(self.offset.value, self.offset.unit)
-        if self.zenith is not None:
-            ss += 'zenith={} [{}]\n'.format(self.zenith.value, self.zenith.unit)
         ss += 'emin={} [{}]\n'.format(self.emin.value, self.emin.unit)
         ss += 'emax={} [{}]\n'.format(self.emax.value, self.emax.unit)
         return ss
 
 
-class CTASpectrumObservation(object):
+class CTAObservationSimulation(object):
     """Class dedicated to simulate observation from one set
     of IRF and one target.
 
@@ -127,122 +116,107 @@ class CTASpectrumObservation(object):
         Source
     """
 
-    def __init__(self, perf=None, target=None):
-        self.perf = perf
-        self.target = target
-        self.simu = None
-        self.on_vector = None
-        self.off_vector = None
-
-    def simulate_obs(self, obs_param):
+    @staticmethod
+    def simulate_obs(perf, target, obs_param):
         """
         Simulate observation with given parameters
 
         Parameters
         ----------
+        perf : `~gammapy.scripts.CTAPerf`
+            CTA performance
+        target : `~gammapy.scripts.Target`
+            Source
         obs_param : `~gammapy.scripts.ObservationParameters`
+            Observation parameters
         """
         livetime = obs_param.livetime
         alpha = obs_param.alpha.value
-        offset = obs_param.offset
         emin = obs_param.emin
         emax = obs_param.emax
 
-        model = self.target.abs_model
+        model = target.abs_model
 
         # Create energy dispersion
-        e_reco_min = self.perf.bkg.energy.data[0]
-        e_reco_max = self.perf.bkg.energy.data[-1]
-        e_reco_bin = self.perf.bkg.energy.nbins
+        e_reco_min = perf.bkg.energy.lo[0]
+        e_reco_max = perf.bkg.energy.hi[-1]
+        e_reco_bin = perf.bkg.energy.nbins
         e_reco_axis = EnergyBounds.equal_log_spacing(e_reco_min,
                                                      e_reco_max,
                                                      e_reco_bin,
                                                      'TeV')
 
-        e_true_min = self.perf.aeff.energy.data[0]
-        e_true_max = self.perf.aeff.energy.data[-1]
-        e_true_bin = self.perf.aeff.energy.nbins
-        e_true_axis = EnergyBounds.equal_log_spacing(e_true_min,
-                                                     e_true_max,
-                                                     e_true_bin,
-                                                     'TeV')
-
-        rmf = self.perf.edisp.to_energy_dispersion(offset,
-                                                   e_reco=e_reco_axis,
-                                                   e_true=e_true_axis)
-
         # Compute expected counts
-        reco_energy = self.perf.bkg.energy
-        bkg_rate_values = self.perf.bkg.data.data * livetime.to('s')
+        reco_energy = perf.bkg.energy
+        bkg_rate_values = perf.bkg.data.data * livetime.to('s')
         predicted_counts = calculate_predicted_counts(model=model,
-                                                      aeff=self.perf.aeff,
+                                                      aeff=perf.aeff,
                                                       livetime=livetime,
-                                                      edisp=rmf,
+                                                      edisp=perf.rmf,
                                                       e_reco=e_reco_axis)
 
         # Randomise counts
         rand = get_random_state('random-seed')
         on_counts = rand.poisson(predicted_counts.data.data.value)  # excess
         bkg_counts = rand.poisson(bkg_rate_values.value)  # bkg in ON region
-        off_counts = rand.poisson(
-            bkg_rate_values.value / alpha)  # bkg in OFF region
+        off_counts = rand.poisson(bkg_rate_values.value / alpha)  # bkg in OFF region
 
         on_counts += bkg_counts  # evts in ON region
 
-        # Create SpectrumObservation
-        counts_kwargs = dict(energy=reco_energy,
+        counts_kwargs = dict(energy_lo=reco_energy.lo,
+                             energy_hi=reco_energy.hi,
                              livetime=livetime,
                              creator='gammapy')
+        on_vector = PHACountsSpectrum(data=on_counts,
+                                      backscal=1,
+                                      **counts_kwargs)
 
-        self.on_vector = PHACountsSpectrum(data=on_counts,
-                                           backscal=1,
-                                           **counts_kwargs)
+        off_vector = PHACountsSpectrum(energy_lo=reco_energy.lo,
+                                       energy_hi=reco_energy.hi,
+                                       data=off_counts,
+                                       livetime=livetime,
+                                       backscal=1. / alpha,
+                                       is_bkg=True,
+                                       creator='gammapy')
 
-        self.off_vector = PHACountsSpectrum(energy=reco_energy,
-                                            data=off_counts,
-                                            livetime=livetime,
-                                            backscal=1. / alpha,
-                                            is_bkg=True,
-                                            creator='gammapy')
-
-        obs = SpectrumObservation(on_vector=self.on_vector,
-                                  off_vector=self.off_vector,
-                                  aeff=self.perf.aeff,
-                                  edisp=rmf)
+        
+        obs = SpectrumObservation(on_vector=on_vector,
+                                  off_vector=off_vector,
+                                  aeff=perf.aeff,
+                                  edisp=perf.rmf)
 
         # Set threshold according to the closest energy reco from bkg bins
-        idx_min = np.abs(reco_energy.data - emin).argmin()
-        idx_max = np.abs(reco_energy.data - emax).argmin()
-        obs.lo_threshold = reco_energy.data[idx_min]
-        obs.hi_threshold = reco_energy.data[idx_max]
+        idx_min = np.abs(reco_energy.lo - emin).argmin()
+        idx_max = np.abs(reco_energy.lo - emax).argmin()
+        obs.lo_threshold = reco_energy.lo[idx_min]
+        obs.hi_threshold = reco_energy.lo[idx_max]
 
-        # print('{},{}'.format())
-        self.simu = obs
+        return obs
 
-    def peek(self):
+    @staticmethod
+    def plot_simu(simu, target):
         import matplotlib.pyplot as plt
         fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2,
                                        figsize=(10, 5))
 
         # Spectrum plot
-        #energy_range = [self.simu.lo_threshold, self.simu.hi_threshold]
         energy_range = [0.01 * u.TeV, 100 * u.TeV]
-        self.target.abs_model.plot(ax=ax1, energy_range=energy_range,
-                                   label='Absorbed model')
-        plt.text(0.55, 0.65, self.target.__str__(),
+        target.abs_model.plot(ax=ax1, energy_range=energy_range,
+                              label='Model')
+        plt.text(0.55, 0.65, target.__str__(),
                  style='italic', transform=ax1.transAxes, fontsize=7,
                  bbox={'facecolor': 'white', 'alpha': 1, 'pad': 10})
         ax1.set_xlim([energy_range[0].value, energy_range[1].value])
-        ax1.set_ylim([1.e-15, 1.e-8])
+        ax1.set_ylim(1.e-17, 1.e-5)
         ax1.grid(which='both')
         ax1.legend(loc=0)
 
         # Counts plot
-        on_off = self.on_vector.data.data.value
-        off = 1. / self.off_vector.backscal * self.off_vector.data.data.value
+        on_off = simu.on_vector.data.data.value
+        off = 1. / simu.off_vector.backscal * simu.off_vector.data.data.value
         excess = on_off - off
-        bins = self.on_vector.energy.data.value[:-1]
-        x = self.on_vector.energy.nodes.value
+        bins = simu.on_vector.energy.lo.value
+        x = simu.on_vector.energy.nodes.value
         ax2.hist(x, bins=bins, weights=on_off,
                  facecolor='blue', alpha=1, label='ON')
         ax2.hist(x, bins=bins, weights=off,
@@ -255,10 +229,10 @@ class CTASpectrumObservation(object):
         ax2.set_ylabel('Expected counts')
         ax2.set_xlim([energy_range[0].value, energy_range[1].value])
         ax2.set_ylim([0.0001, on_off.max()*(1+0.05)])
-        ax2.vlines(self.simu.lo_threshold.value, 0, 1.1 * on_off.max(),
+        ax2.vlines(simu.lo_threshold.value, 0, 1.1 * on_off.max(),
                   linestyles='dashed')
         ax2.grid(which='both')
-        plt.text(0.55, 0.05, self.simu.__str__(),
+        plt.text(0.55, 0.05, simu.__str__(),
                  style='italic', transform=ax2.transAxes, fontsize=7,
                  bbox={'facecolor': 'white', 'alpha': 1, 'pad': 10})
         plt.tight_layout()

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -35,10 +35,9 @@ def test_cta_irf():
     # assert_quantity_allclose(val, Quantity(247996.974414962, 'm^2'))
 
 
-# @requires_dependency('matplotlib')
-# @requires_data('gammapy-extra')
-# def test_point_like_perf():
-#     filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/\
-# CTA-Performance-South-20150511/CTA-Performance-South-50h_20150511.fits'
-#     cta_perf = CTAPerf.read(filename)
-#     cta_perf.peek()
+@requires_dependency('matplotlib')
+@requires_data('gammapy-extra')
+def test_point_like_perf():
+    filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
+    cta_perf = CTAPerf.read(filename)
+    cta_perf.peek()


### PR DESCRIPTION
Hi @cdeil, 

This PR: 
 - adapt the `CTAPerf` class to the new `BinnedDataAxis` class. Add rmf as attribute. 
 - add a minimal test for `CTAPerf`
 - rename `CTASpectrumObservation` to `CTASimulationObservation`
 - use static methods
 - simplify the `ObservationParameters` class
 - add minimal tests for each classes of `cta_utils.py`

I need that for the gammapy meeting next week. I'll merge that in a bit if you are not available (all tests should work when https://github.com/gammapy/gammapy-extra/pull/52 will be merged)

This PR does not change the fact that `CTASimulationObservation` should be merge with `SpectrumSimulation` in a near future. 

Output example for the extrapolation of a Fermi/LAT source is shown below (~0.015 s for a simulation, it's ultra fast!).

![example_simu](https://cloud.githubusercontent.com/assets/15717586/22980681/7be98e0e-f39a-11e6-9585-8d90e41e545f.png)
