### PR TITLE
Refactor catalog uncertainty handling

### DIFF
--- a/docs/spectrum/plot_fermi_spectra.py
+++ b/docs/spectrum/plot_fermi_spectra.py
@@ -1,47 +1,47 @@
 """Example how to plot Fermi-LAT catalog spectra.
 """
 import matplotlib.pyplot as plt
-from gammapy.catalog import SourceCatalog3FGL, SourceCatalog2FHL
-from gammapy.utils.energy import EnergyBounds
+from gammapy.catalog import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL
 
 plt.style.use('ggplot')
 
 # load catalogs
 fermi_3fgl = SourceCatalog3FGL()
 fermi_2fhl = SourceCatalog2FHL()
+fermi_1fhl = SourceCatalog1FHL()
 
 # access crab data by corresponding identifier
-crab_3fgl = fermi_3fgl['3FGL J0534.5+2201']
-crab_2fhl = fermi_2fhl['2FHL J0534.5+2201']
+src_3fgl = fermi_3fgl['3FGL J2158.8-3013']
+src_2fhl = fermi_2fhl['2FHL J2158.8-3013']
+src_1fhl = fermi_1fhl['1FHL J2158.8-3013']
 
-ax = crab_3fgl.spectral_model.plot(crab_3fgl.energy_range, energy_power=2,
-                                   label='Fermi 3FGL', color='r',
-                                   flux_unit='erg-1 cm-2 s-1')
-ax.set_ylim(1e-12, 1E-9)
+# 3FHL
+ax = src_3fgl.spectral_model.plot(src_3fgl.energy_range, energy_power=2,
+                                  label='Fermi 3FGL', color='r',
+                                  flux_unit='erg-1 cm-2 s-1')
+src_3fgl.spectral_model.plot_error(src_3fgl.energy_range, energy_power=2,
+                                  color='r',
+                                  flux_unit='erg-1 cm-2 s-1', ax=ax)
+src_3fgl.flux_points.plot(ax=ax, sed_type='eflux', color='r',
+                          flux_unit='erg cm-2 s-1')
 
-# set up an energy array to evaluate the butterfly
-emin, emax = crab_3fgl.energy_range
-energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-butterfly_3fg = crab_3fgl.spectrum.butterfly(energy)
+# 2FHL
+src_2fhl.spectral_model.plot(src_2fhl.energy_range, ax=ax, energy_power=2,
+                             c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
+src_2fhl.spectral_model.plot_error(src_2fhl.energy_range, ax=ax, energy_power=2,
+                                    color='g', flux_unit='erg-1 cm-2 s-1')
+src_2fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='g',
+                          flux_unit='cm-2 s-1 erg-1')
 
-butterfly_3fg.plot(crab_3fgl.energy_range, ax=ax, energy_power=2, color='r',
-                   flux_unit='erg-1 cm-2 s-1')
+# 1FHL
+src_1fhl.spectral_model.plot(src_1fhl.energy_range, ax=ax, energy_power=2,
+                             c='b', label='Fermi 1FHL', flux_unit='erg-1 cm-2 s-1')
+src_1fhl.spectral_model.plot_error(src_1fhl.energy_range, ax=ax, energy_power=2,
+                             color='b', flux_unit='erg-1 cm-2 s-1')
+src_1fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='b',
+                          flux_unit='cm-2 s-1 erg-1')
 
-crab_3fgl.flux_points.plot(ax=ax, sed_type='eflux', color='r',
-                           flux_unit='erg cm-2 s-1')
-
-crab_2fhl.spectral_model.plot(crab_2fhl.energy_range, ax=ax, energy_power=2,
-                              c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
-
-# set up an energy array to evaluate the butterfly using the 2FHL energy range
-emin, emax = crab_2fhl.energy_range
-energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-butterfly_2fhl = crab_2fhl.spectrum.butterfly(energy)
-
-# plot butterfly and flux points
-butterfly_2fhl.plot(crab_2fhl.energy_range, ax=ax, energy_power=2, color='g',
-                    flux_unit='erg-1 cm-2 s-1')
-crab_2fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='g',
-                           flux_unit='cm-2 s-1 erg-1')
+ax.set_ylim(5.e-12, 8.e-11)
+ax.set_ylabel('dN/dE [erg cm-2 s-1]')
 plt.legend(loc=0)
 plt.show()

--- a/docs/spectrum/plotting_fermi_spectra.rst
+++ b/docs/spectrum/plotting_fermi_spectra.rst
@@ -11,8 +11,8 @@ sources, by using the `~gammapy.spectrum.models.SpectralModel`, `~gammapy.spectr
 and `~gammapy.spectrum.DifferentialFluxPoints` classes.
 
 
-As a first example we plot the spectral energy distribution for the Crab,
-namely ``'3FGL J0534.5+2201'`` and ``'2FHL J0534.5+2201'``, including best fit
+As a first example we plot the spectral energy distribution for the source PKS 2155-304,
+namely ``'3FGL J2158.8-3013'`` and ``'2FHL J2158.8-3013'``, including best fit
 model, butterfly and flux points. First we load the corresponding catalog from
 `~gammapy.catalog` and access the data for the crab:
 
@@ -28,8 +28,8 @@ model, butterfly and flux points. First we load the corresponding catalog from
     fermi_2fhl = SourceCatalog2FHL()
 
     # access crab data by corresponding identifier
-    crab_3fgl = fermi_3fgl['3FGL J0534.5+2201']
-    crab_2fhl = fermi_2fhl['2FHL J0534.5+2201']
+    crab_3fgl = fermi_3fgl['3FGL J2158.8-3013']
+    crab_2fhl = fermi_2fhl['2FHL J2158.8-3013']
 
 First we plot the best fit model for the 3FGL model:
 
@@ -46,20 +46,13 @@ distribution instead of the differential flux density. The `~gammapy.spectrum.mo
 method returns an `~matplotlib.axes.Axes` object that can be reused later to plot
 additional information on it. Here we just modify the y-limits of the plot.
 
-As the next step we compute the butterfly for the best fit model and add it to
-the plot:
+As the next step we add the butterfly for the best fit model by calling
+`.plot_error`:
 
 .. code-block:: python
 
-    from gammapy.utils.energy import EnergyBounds
-
-    # set up an energy array to evaluate the butterfly
-    emin, emax = crab_3fgl.energy_range
-    energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-    butterfly_3fg = crab_3fgl.spectrum.butterfly(energy)
-
-    butterfly_3fg.plot(crab_3fgl.energy_range, ax=ax, energy_power=2, color='r',
-                       flux_unit='erg-1 cm-2 s-1')
+    crab_3fgl.spectral_model.plot_error(crab_3fgl.energy_range, ax=ax, energy_power=2, color='r',
+                                        flux_unit='erg-1 cm-2 s-1')
 
 Finally we add the flux points by calling:
 
@@ -76,14 +69,9 @@ The same can be done with the 2FHL best fit model:
     crab_2fhl.spectral_model.plot(crab_2fhl.energy_range, ax=ax, energy_power=2,
                                   c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
 
-    # set up an energy array to evaluate the butterfly using the 2FHL energy range
-    emin, emax = crab_2fhl.energy_range
-    energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-    butterfly_2fhl = crab_2fhl.spectrum.butterfly(energy)
-
     # plot butterfly and flux points
-    butterfly_2fhl.plot(crab_2fhl.energy_range, ax=ax, energy_power=2, color='g',
-                        flux_unit='erg-1 cm-2 s-1')
+    crab_2fhl.spectral_model.plot(crab_2fhl.energy_range, ax=ax, energy_power=2, color='g',
+                                  flux_unit='erg-1 cm-2 s-1')
     crab_2fhl.flux_points.plot(ax=ax, energy_power=2, color='g',
                                flux_unit='erg-1 cm-2 s-1')
 

--- a/examples/example_fermi_catalogs.py
+++ b/examples/example_fermi_catalogs.py
@@ -25,13 +25,8 @@ ax = src_3fgl.spectral_model.plot(src_3fgl.energy_range, energy_power=2,
                                   label='Fermi 3FGL', color='r',
                                   flux_unit='erg-1 cm-2 s-1')
 
-# set up an energy array to evaluate the butterfly
-emin, emax = src_3fgl.energy_range
-energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-butterfly_3fg = src_3fgl.spectrum.butterfly(energy)
-
-butterfly_3fg.plot(src_3fgl.energy_range, ax=ax, energy_power=2, color='r',
-                   flux_unit='erg-1 cm-2 s-1', facecolor='r')
+src_3fgl.spectral_model.plot_error(src_3fgl.energy_range, ax=ax, energy_power=2,
+                                  facecolor='r', flux_unit='erg-1 cm-2 s-1')
 
 src_3fgl.flux_points.plot(ax=ax, sed_type='eflux', color='r',
                           flux_unit='erg cm-2 s-1')
@@ -40,14 +35,9 @@ src_3fgl.flux_points.plot(ax=ax, sed_type='eflux', color='r',
 src_2fhl.spectral_model.plot(src_2fhl.energy_range, ax=ax, energy_power=2,
                              c='g', label='Fermi 2FHL', flux_unit='erg-1 cm-2 s-1')
 
-# set up an energy array to evaluate the butterfly
-emin, emax = src_2fhl.energy_range
-energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-butterfly_2fhl = src_2fhl.spectrum.butterfly(energy)
+src_2fhl.spectral_model.plot_error(src_2fhl.energy_range, ax=ax, energy_power=2,
+                                   facecolor='g', flux_unit='erg-1 cm-2 s-1')
 
-# plot butterfly and flux points
-butterfly_2fhl.plot(src_2fhl.energy_range, ax=ax, energy_power=2, color='g',
-                    flux_unit='erg-1 cm-2 s-1', facecolor='g')
 src_2fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='g',
                           flux_unit='cm-2 s-1 erg-1')
 
@@ -56,14 +46,8 @@ src_1fhl.spectral_model.plot(src_1fhl.energy_range, ax=ax, energy_power=2,
                              c='c', label='Fermi 1FHL',
                              flux_unit='erg-1 cm-2 s-1')
 
-# set up an energy array to evaluate the butterfly 
-emin, emax = src_1fhl.energy_range
-energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-butterfly_1fhl = src_1fhl.spectrum.butterfly(energy)
-
-# plot butterfly and flux points
-butterfly_1fhl.plot(src_1fhl.energy_range, ax=ax, energy_power=2, color='c',
-                    flux_unit='erg-1 cm-2 s-1', facecolor='c')
+src_1fhl.spectral_model.plot_error(src_1fhl.energy_range, ax=ax, energy_power=2,
+                                   facecolor='c', flux_unit='erg-1 cm-2 s-1')
 src_1fhl.flux_points.plot(ax=ax, sed_type='dnde', energy_power=2, color='c',
                           flux_unit='cm-2 s-1 erg-1')
 
@@ -72,14 +56,8 @@ src_3fhl.spectral_model.plot(src_3fhl.energy_range, ax=ax, energy_power=2,
                              c='b', label='Fermi 3FHL',
                              flux_unit='erg-1 cm-2 s-1')
 
-# set up an energy array to evaluate the butterfly 
-emin, emax = src_3fhl.energy_range
-energy = EnergyBounds.equal_log_spacing(emin, emax, 100)
-butterfly_3fhl = src_3fhl.spectrum.butterfly(energy)
-
-# plot butterfly and flux points
-butterfly_3fhl.plot(src_3fhl.energy_range, ax=ax, energy_power=2, color='b',
-                    flux_unit='erg-1 cm-2 s-1', facecolor='b')
+src_3fhl.spectral_model.plot_error(src_3fhl.energy_range, ax=ax, energy_power=2,
+                                   facecolor='b', flux_unit='erg-1 cm-2 s-1')
 
 src_3fhl.flux_points.plot(ax=ax, sed_type='eflux', color='b',
                           flux_unit='erg cm-2 s-1')

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -354,15 +354,15 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         pars, errs = {}, {}
 
         if spec_type == 'PL':
-            pars['index'] = Quantity(data['Index_Spec_PL'], '')
-            pars['amplitude'] = Quantity(data['Flux_Spec_PL_Diff_Pivot'], 's^-1 cm^-2 TeV^-1')
-            pars['reference'] = Quantity(data['Energy_Spec_PL_Pivot'], 'TeV')
+            pars['index'] = data['Index_Spec_PL']
+            pars['amplitude'] = data['Flux_Spec_PL_Diff_Pivot']
+            pars['reference'] = data['Energy_Spec_PL_Pivot']
             model = PowerLaw(**pars)
         elif spec_type == 'ECPL':
-            pars['index'] = Quantity(data['Index_Spec_ECPL'], ''),
-            pars['amplitude'] = Quantity(data['Flux_Spec_ECPL_Diff_Pivot'], 's^-1 cm^-2 TeV^-1'),
-            pars['reference'] = Quantity(data['Energy_Spec_ECPL_Pivot'], 'TeV'),
-            pars['lambda_'] = Quantity(data['Lambda_Spec_ECPL'], 'TeV-1'),
+            pars['index'] = data['Index_Spec_ECPL']
+            pars['amplitude'] = data['Flux_Spec_ECPL_Diff_Pivot']
+            pars['reference'] = data['Energy_Spec_ECPL_Pivot']
+            pars['lambda_'] = data['Lambda_Spec_ECPL']
             model = ExponentialCutoffPowerLaw(**pars)
         else:
             raise ValueError('Invalid spectral model: {}'.format(spec_type))

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -9,9 +9,12 @@ from ...spectrum.models import PowerLaw, LogParabola, ExponentialCutoffPowerLaw3
 from ...utils.testing import requires_data, requires_dependency
 
 MODEL_TEST_DATA_3FGL = [
-    (0, PowerLaw, u.Quantity(1.4351261e-9, 'cm-2 s-1 GeV-1')),
-    (4, LogParabola, u.Quantity(8.3828599e-10, 'cm-2 s-1 GeV-1')),
-    (55, ExponentialCutoffPowerLaw3FGL, u.Quantity(1.8666925e-09, 'cm-2 s-1 GeV-1')),
+    (0, PowerLaw, u.Quantity(1.4351261e-9, 'cm-2 s-1 GeV-1'),
+                  u.Quantity(2.1356270e-10, 'cm-2 s-1 GeV-1')),
+    (4, LogParabola, u.Quantity(8.3828599e-10, 'cm-2 s-1 GeV-1'),
+                     u.Quantity(2.6713238e-10, 'cm-2 s-1 GeV-1')),
+    (55, ExponentialCutoffPowerLaw3FGL, u.Quantity(1.8666925e-09, 'cm-2 s-1 GeV-1'),
+                                        u.Quantity(2.2068837e-10, 'cm-2 s-1 GeV-1'),),
 ]
 
 MODEL_TEST_DATA_3FHL = [
@@ -60,13 +63,21 @@ class TestFermi3FGLObject:
         assert 'Source: 3FGL J0534.5+2201' in ss
         assert 'RA (J2000)  : 83.63' in ss
 
-    @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FGL)
-    def test_spectral_model(self, index, model_type, desired):
+    @pytest.mark.parametrize('index, model_type, desired, desired_err', MODEL_TEST_DATA_3FGL)
+    def test_spectral_model(self, index, model_type, desired, desired_err):
         energy = u.Quantity(1, 'GeV')
         model = self.cat[index].spectral_model
         assert isinstance(model, model_type)
         actual = model(energy)
         assert_quantity_allclose(actual, desired)
+
+    @requires_dependency('uncertainties')
+    @pytest.mark.parametrize('index, model_type, desired, desired_err', MODEL_TEST_DATA_3FGL)
+    def test_spectral_model_error(self, index, model_type, desired, desired_err):
+        energy = u.Quantity(1, 'GeV')
+        model = self.cat[index].spectral_model
+        actual = model.evaluate_error(energy)
+        assert_quantity_allclose(actual[1], desired_err)
 
     def test_flux_points(self):
         flux_points = self.source.flux_points

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -124,11 +124,6 @@ class TestFermi1FHLObject:
         desired = [np.nan, 2.081589e-11, 1.299698e-11] * u.Unit('cm-2 s-1')
         assert_quantity_allclose(actual, desired, rtol=1E-5)
 
-    @requires_dependency('uncertainties')
-    def test_spectrum(self):
-        spectrum = self.source.spectrum
-        assert "Fit result info" in str(spectrum)
-
 
 @requires_data('gammapy-extra')
 class TestFermi2FHLObject:
@@ -159,11 +154,6 @@ class TestFermi2FHLObject:
         actual = flux_points.table['flux_ul']
         desired = [np.nan, np.nan, 6.470300e-12] * u.Unit('cm-2 s-1')
         assert_quantity_allclose(actual, desired)
-
-    @requires_dependency('uncertainties')
-    def test_spectrum(self):
-        spectrum = self.source.spectrum
-        assert "Fit result info" in str(spectrum)
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -23,7 +23,6 @@ class TestSourceCatalogHGPS:
         assert len(self.cat.associations) == 223
 
 
-@requires_dependency('uncertainties')
 @requires_data('hgps')
 class TestSourceCatalogObjectHGPS:
     def setup(self):
@@ -65,10 +64,7 @@ class TestSourceCatalogObjectHGPS:
         assert 'Source name          : HESS J1825-137' in ss
         assert 'Component HGPSC 065:' in ss
 
-    def test_spectrum(self):
-        source = self.cat['HESS J1825-137']
-        assert 'Fit result info' in str(source.spectrum)
-
+    @requires_dependency('uncertainties')
     def test_ecut_error(self):
         import uncertainties
         val = float(self.cat['HESS J1825-137'].data['Lambda_Spec_ECPL'].value)

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -424,6 +424,7 @@ class SpectrumFit(object):
         for res in self.result:
             res.covar_axis = self.covar_axis
             res.covariance = self.covariance
+            res.model.parameters.set_parameter_covariance(self.covariance, self.covar_axis)
 
     def _est_errors_sherpa(self):
         """Wrapper around Sherpa error estimator"""

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -622,16 +622,13 @@ class FluxPointEstimator(object):
 
         e_max = energy_group.energy_range.max
         e_min = energy_group.energy_range.min
-        diff_flux = res.model(energy_ref).to('m-2 s-1 TeV-1')
-        err = res.model_with_uncertainties(energy_ref.to('TeV').value)
-        diff_flux_err = err.s * u.Unit('m-2 s-1 TeV-1')
-
+        diff_flux, diff_flux_err = res.model.evaluate_err(energy_ref)
         return OrderedDict(
             e_ref=energy_ref,
             e_min=e_min,
             e_max=e_max,
-            dnde=diff_flux,
-            dnde_err=diff_flux_err,
+            dnde=diff_flux.to('m-2 s-1 TeV-1'),
+            dnde_err=diff_flux_err.to('m-2 s-1 TeV-1'),
         )
 
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -622,7 +622,7 @@ class FluxPointEstimator(object):
 
         e_max = energy_group.energy_range.max
         e_min = energy_group.energy_range.min
-        diff_flux, diff_flux_err = res.model.evaluate_err(energy_ref)
+        diff_flux, diff_flux_err = res.model.evaluate_error(energy_ref)
         return OrderedDict(
             e_ref=energy_ref,
             e_min=e_min,

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -59,6 +59,13 @@ class SpectralModel(object):
         errors = unumpy.std_devs(uarray)
         return values, errors
 
+    def _convert_energy(self, energy):
+        try:
+            energy = energy.to(self.parameters['reference'].unit)
+        except IndexError:
+            energy = energy.to(self.parameters['emin'].unit)
+        return energy
+
     def evaluate_error(self, energy):
         """
         Evaluate spectral model with error propagation.
@@ -73,12 +80,10 @@ class SpectralModel(object):
         flux, flux_error : tuple of `~astropy.units.Quantity`
             Tuple of flux and flux error.
         """
+        energy = self._convert_energy(energy)
+        
         unit = self(energy).unit
         upars = self.parameters._ufloats
-        try:
-            energy = energy.to(self.parameters['reference'].unit)
-        except IndexError:
-            energy = energy.to(self.parameters['emin'].unit)
         uarray = self.evaluate(energy.value, **upars)
         return self._parse_uarray(uarray) * unit
 
@@ -120,6 +125,8 @@ class SpectralModel(object):
         integral, integral_error : tuple of `~astropy.units.Quantity`
             Tuple of integral flux and integral flux error.
         """
+        emin = self._convert_energy(emin)
+        emax = self._convert_energy(emax)
         unit = self.integral(emin, emax, **kwargs).unit
         upars = self.parameters._ufloats
 
@@ -170,7 +177,9 @@ class SpectralModel(object):
             Tuple of energy flux and energy flux error.
 
         """
-
+        emin = self._convert_energy(emin)
+        emax = self._convert_energy(emax)
+        
         unit = self.energy_flux(emin, emax, **kwargs).unit
         upars = self.parameters._ufloats
 

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -236,6 +236,10 @@ class SpectrumFitResult(object):
         butterfly : `~gammapy.spectrum.SpectrumButterfly`
             Butterfly object.
         """
+        if energy is None:
+            energy = EnergyBounds.equal_log_spacing(self.fit_range[0],
+                                                    self.fit_range[1], 100)
+
         flux, flux_err = self.model.evaluate_error(energy)
 
         butterfly = SpectrumButterfly()

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -207,9 +207,9 @@ class TestSpectralFit:
         self.fit.fit()
         self.fit.est_errors()
         result = self.fit.result[0]
-        par_errors = result.model_with_uncertainties.parameters
-        assert_allclose(par_errors['index'].value.s, 0.09773507974970663)
-        assert_allclose(par_errors['amplitude'].value.s, 2.133509118228815e-12)
+        par_errors = result.model.parameters._ufloats
+        assert_allclose(par_errors['index'].s, 0.09773507974970663)
+        assert_allclose(par_errors['amplitude'].s, 2.133509118228815e-12)
 
         t = self.fit.result[0].to_table()
         assert_allclose(t['index_err'].data[0], 0.09773507974970663)

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -48,9 +48,9 @@ class TestSpectrumFitResult:
                                  read_result.model(test_e))
 
     @requires_dependency('uncertainties')
-    def test_model_with_uncertainties(self):
-        actual = self.fit_result.model_with_uncertainties.parameters['index'].value.s
-        desired = np.sqrt(self.covar[0][0])
+    def test_model_covariance(self):
+        actual = self.fit_result.model.parameters.covariance[1][1]
+        desired = self.covar[1][1]
         assert actual == desired
 
     @requires_dependency('matplotlib')

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -197,6 +197,11 @@ class ParameterList(object):
         return '\n'.join(xml)
 
     @property
+    def names(self):
+        """List of parameter names"""
+        return [par.name for par in self.parameters]
+    
+    @property
     def _ufloats(self):
         """
         Return dict of ufloats with covariance
@@ -231,6 +236,32 @@ class ParameterList(object):
             quantity = errors.get(par.name, 0 * u.Unit(par.unit))
             values.append(quantity.to(par.unit).value)
         self.covariance = np.diag(values) ** 2
+
+    # TODO: this is a temporary solution until we have a better way
+    # to handle covariance matrices via a class
+    def set_parameter_covariance(self, covariance, covar_axis):
+        """
+        Set full correlated parameters errors.
+
+        Parameters
+        ----------
+        covariance : array-like
+            Covariance matrix
+        covar_axis : list
+            List of strings defining the parameter order in covariance
+        """
+        shape = (len(self.parameters), len(self.parameters))
+        covariance_new = np.zeros(shape)
+        idx_lookup = dict([(par.name, idx) for idx, par in enumerate(self.parameters)])
+        
+        #TODO: make use of covariance matrix symmetry
+        for i, par in enumerate(covar_axis):
+            i_new = idx_lookup[par]
+            for j, par_other in enumerate(covar_axis):
+                j_new = idx_lookup[par_other]
+                covariance_new[i_new, j_new] = covariance[i, j]
+        
+        self.covariance = covariance_new
 
 
 class SourceLibrary(object):


### PR DESCRIPTION
This PR refactors the uncertainty handling in `gammapy/catalog`. It mainly removes the `.spectrum` properties from the `SourceCatalogObject` classes.