### PR TITLE
Add Fermi-LAT 3FGL catalog object lightcurve property

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -203,7 +203,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         # TODO: Change lightcurve class to support this,
         # then fill appropriately here
         # for now, we just use the mean
-        flux_err = 0.5 * (flux_err_lo + flux_err_hi)
+        flux_err = 0.5 * (-flux_err_lo + flux_err_hi)
 
         # Really the time binning is stored in a separate HDU in the FITS
         # catalog file called `Hist_Start`, with a single column `Hist_Start`

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -191,7 +191,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         return Quantity(values, unit)
 
     @property
-    def get_lightcurve(self):
+    def lightcurve(self):
         """Get corresponding lightcurve object.
         """
         flux = self.data['Flux_History']

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -190,6 +190,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         values = [self.data[prefix + _] for _ in self._ebounds_suffix]
         return Quantity(values, unit)
 
+    @property
     def get_lightcurve(self, ax=None):
         """Get corresponding lightcurve object.
         """

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -191,7 +191,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         return Quantity(values, unit)
 
     @property
-    def get_lightcurve(self, ax=None):
+    def get_lightcurve(self):
         """Get corresponding lightcurve object.
         """
         flux = self.data['Flux_History']

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -204,7 +204,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         # then fill appropriately here
         # for now, we just use the mean
         flux_err = 0.5 * (-flux_err_lo + flux_err_hi)
-
+        flux_unit = Quantity(1, 'eV / ((cm ** 2) * s)')
         # Really the time binning is stored in a separate HDU in the FITS
         # catalog file called `Hist_Start`, with a single column `Hist_Start`
         # giving the time binning in MET (mission elapsed time)
@@ -224,8 +224,8 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         table = QTable()
         table['TIME_MIN'] = time_bounds[:-1]
         table['TIME_MAX'] = time_bounds[1:]
-        table['FLUX'] = flux
-        table['FLUX_ERR'] = flux_err
+        table['FLUX'] = flux * flux_unit
+        table['FLUX_ERR'] = flux_err * flux_unit
         lc = LightCurve(table)
         return lc
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -77,6 +77,20 @@ class TestFermi3FGLObject:
         desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06, 1.308784e-08]
         assert_allclose(flux_points.table['dnde'].data, desired, rtol=1E-5)
 
+    def test_lightcurve(self):
+        lc = self.source.lightcurve
+        assert len(lc) == 48
+        assert 'TIME_MIN' in lc.colnames
+        assert 'TIME_MAX' in lc.colnames
+        assert 'FLUX' in lc.colnames
+        assert 'FLUX_ERR' in lc.colnames
+        flux_unit = u.Quantity(1, 'eV / ((cm ** 2) * s)')
+        actual = [lc['FLUX'][0], lc['FLUX'][-1],
+                  lc['FLUX_ERR'][0], lc['FLUX_ERR'][-1]]
+        desired = [2.38471262e-06, 2.57482816e-06,
+                   8.07127023e-08, 8.07989267e-08] * flux_unit
+        assert_quantity_allclose(actual, desired, rtol=1E-5)
+
     @pytest.mark.parametrize('name', CRAB_NAMES_3FGL)
     def test_crab_alias(self, name):
         assert str(self.cat['Crab']) == str(self.cat[name])


### PR DESCRIPTION
This pull request implements part of what is suggested in #853
* Add `lightcurve` property to `SourceCatalogObject3FGL` with tests.