### PR TITLE
Speed up EDISP integration

### DIFF
--- a/dev/profiling/profile_edisp_int.py
+++ b/dev/profiling/profile_edisp_int.py
@@ -1,0 +1,48 @@
+import cProfile
+import pstats
+from gammapy.irf import EnergyDispersion2D
+from gammapy.utils.energy import EnergyBounds
+from gammapy.data import DataStore
+import astropy.units as u
+import numpy as np
+
+# Copied from gp-extra/notebooks/data-iact
+
+data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+obs = data_store.obs(obs_id=23523)
+edisp = obs.edisp
+cProfile.run('edisp.peek()', 'restats')
+p = pstats.Stats('restats')
+p.sort_stats('cumtime').print_stats(10)
+#p.sort_stats('cumtime').print_stats(20)
+#p.strip_dirs().sort_stats('cumtime').print_callers(20)
+
+
+#filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_edisp_2d_023523.fits.gz'
+
+#edisp2d = EnergyDispersion2D.read(filename)
+#print(edisp2d)
+
+#cProfile.run('edisp2d.peek()', 'restats')
+#p = pstats.Stats('restats')
+#p.sort_stats('cumtime').print_stats(20)
+#p.strip_dirs().sort_stats('cumtime').print_callers(20)
+
+#edisp2d.peek()
+
+
+#offset = 1.2 * u.deg
+#e_true = 1 * u.TeV
+#e_reco = EnergyBounds.equal_log_spacing(100 * u.GeV, 10 * u.TeV, 100)
+#cProfile.run('c = edisp2d.get_response(offset=offset, e_true=e_true, e_reco=e_reco)', 'restats')
+#p = pstats.Stats('restats')
+#p.sort_stats('cumtime').print_stats(20)
+#p.strip_dirs().sort_stats('cumtime').print_callers(20)
+
+#print(c)
+#idx = np.where(np.nonzero(c))[0]
+#print(len(idx))
+#resp = edisp2d.get_response(offset=offset, e_true=e_true, e_reco=e_reco)
+#print(resp)
+#edisp = edisp2d.to_energy_dispersion(offset=offset)  
+#print(edisp)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -735,12 +735,9 @@ class EnergyDispersion2D(object):
         # oversample migra
         migra_lo = migra[:-1]
         migra_hi = migra[1:]
-        #migra_range = np.column_stack([migra_lo, migra_hi]])
-        migra_grid = list()
-
-        # TODO: Get rid of this loop
-        for mlo, mhi in zip(migra_lo, migra_hi):
-            migra_grid.append(np.linspace(mlo, mhi, oversampling))
+        migra_range = migra_hi - migra_lo
+        migra_offset = np.linspace(0, 1, oversampling) * migra_range[:, np.newaxis]
+        migra_grid = migra_lo[:, np.newaxis] + migra_offset
 
         val = self.data.evaluate(offset=offset, e_true=e_true,
                                  migra=np.array(migra_grid))

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -703,7 +703,8 @@ class EnergyDispersion2D(object):
                                 e_reco_lo=ereco_lo, e_reco_hi=ereco_hi,
                                 data=rm)
 
-    def get_response(self, offset, e_true, e_reco, oversampling=10):
+    def get_response(self, offset, e_true, e_reco, oversampling=10,
+                     normalize=True):
         """Detector response R(Delta E_reco, E_true)
 
         Probability to reconstruct a given true energy in a given reconstructed
@@ -719,6 +720,8 @@ class EnergyDispersion2D(object):
             Offset
         oversampling : int, optional
             Migra oversampling factor for each bin of e_reco
+        normalize : bool, optional
+            Normalize response to 1
 
         Returns
         -------
@@ -743,6 +746,10 @@ class EnergyDispersion2D(object):
 
         dx = migra_grid[0][1] - migra_grid[0][0]
         response = np.trapz(val, dx=dx)
+        
+        if normalize:
+            norm = np.sum(response)
+            response = np.nan_to_num(response / norm)
 
         return response
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -45,7 +45,7 @@ class EnergyDispersion(object):
     default_interp_kwargs = dict(bounds_error=False, fill_value=0)
     """Default Interpolation kwargs for `~NDDataArray`"""
 
-    def __init__(self, e_true_lo, e_true_hi, e_reco_lo, e_reco_hi,  data,
+    def __init__(self, e_true_lo, e_true_hi, e_reco_lo, e_reco_hi, data,
                  interp_kwargs=None, meta=None):
         if interp_kwargs is None:
             interp_kwargs = self.default_interp_kwargs
@@ -55,10 +55,10 @@ class EnergyDispersion(object):
             BinnedDataAxis(e_reco_lo, e_reco_hi,
                            interpolation_mode='log', name='e_reco')
         ]
-        self.data=NDDataArray(axes=axes, data=data,
+        self.data = NDDataArray(axes=axes, data=data,
                                 interp_kwargs=interp_kwargs)
         if meta is not None:
-            self.meta=Bunch(meta)
+            self.meta = Bunch(meta)
 
     @property
     def e_reco(self):
@@ -87,10 +87,10 @@ class EnergyDispersion(object):
         hi_threshold : `~astropy.units.Quantity`
             High reco energy threshold
         """
-        data=self.pdf_matrix.copy()
-        idx=np.where((self.e_reco.lo < lo_threshold) |
+        data = self.pdf_matrix.copy()
+        idx = np.where((self.e_reco.lo < lo_threshold) |
                        (self.e_reco.hi > hi_threshold))
-        data[:, idx]=0
+        data[:, idx] = 0
         return data
 
     @classmethod
@@ -121,15 +121,15 @@ class EnergyDispersion(object):
         e_true = EnergyBounds(e_true)
 
         # erf does not work with Quantities
-        reco=e_reco.to('TeV').value
-        true=e_true.log_centers.to('TeV').value
-        migra_min=np.log10(reco[:-1] / true[:, np.newaxis])
-        migra_max=np.log10(reco[1:] / true[:, np.newaxis])
+        reco = e_reco.to('TeV').value
+        true = e_true.log_centers.to('TeV').value
+        migra_min = np.log10(reco[:-1] / true[:, np.newaxis])
+        migra_max = np.log10(reco[1:] / true[:, np.newaxis])
 
-        pdf=.5 * (erf(migra_max / (np.sqrt(2.) * sigma))
+        pdf = .5 * (erf(migra_max / (np.sqrt(2.) * sigma))
                     - erf(migra_min / (np.sqrt(2.) * sigma)))
 
-        pdf[np.where(pdf < pdf_threshold)]=0
+        pdf[np.where(pdf < pdf_threshold)] = 0
 
         e_lo, e_hi = (e_true[:-1], e_true[1:])
         ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
@@ -152,22 +152,22 @@ class EnergyDispersion(object):
         matrix_hdu = hdulist[hdu1]
         ebounds_hdu = hdulist[hdu2]
 
-        data=matrix_hdu.data
-        header=matrix_hdu.header
+        data = matrix_hdu.data
+        header = matrix_hdu.header
 
-        pdf_matrix=np.zeros([len(data), header['DETCHANS']], dtype=np.float64)
+        pdf_matrix = np.zeros([len(data), header['DETCHANS']], dtype=np.float64)
 
         for i, l in enumerate(data):
             if l.field('N_GRP'):
-                m_start=0
+                m_start = 0
                 for k in range(l.field('N_GRP')):
                     pdf_matrix[i, l.field('F_CHAN')[k]: l.field(
-                        'F_CHAN')[k] + l.field('N_CHAN')[k]]=l.field(
+                        'F_CHAN')[k] + l.field('N_CHAN')[k]] = l.field(
                         'MATRIX')[m_start:m_start + l.field('N_CHAN')[k]]
                     m_start += l.field('N_CHAN')[k]
 
-        e_reco=EnergyBounds.from_ebounds(ebounds_hdu)
-        e_true=EnergyBounds.from_rmf_matrix(matrix_hdu)
+        e_reco = EnergyBounds.from_ebounds(ebounds_hdu)
+        e_true = EnergyBounds.from_rmf_matrix(matrix_hdu)
 
         return cls(e_true_lo=e_true.lower_bounds, e_true_hi=e_true.upper_bounds,
                    e_reco_lo=e_reco.lower_bounds, e_reco_hi=e_reco.upper_bounds,
@@ -220,27 +220,27 @@ class EnergyDispersion(object):
         # Cannot use table_to_fits here due to variable length array
         # http://docs.astropy.org/en/v1.0.4/io/fits/usage/unfamiliar.html
 
-        table=self.to_table()
-        name=table.meta.pop('name')
+        table = self.to_table()
+        name = table.meta.pop('name')
 
-        header=fits.Header()
+        header = fits.Header()
         header.update(table.meta)
 
-        cols=table.columns
-        c0=fits.Column(name=cols[0].name, format='E', array=cols[0],
+        cols = table.columns
+        c0 = fits.Column(name=cols[0].name, format='E', array=cols[0],
                          unit='{}'.format(cols[0].unit))
-        c1=fits.Column(name=cols[1].name, format='E', array=cols[1],
+        c1 = fits.Column(name=cols[1].name, format='E', array=cols[1],
                          unit='{}'.format(cols[1].unit))
-        c2=fits.Column(name=cols[2].name, format='I', array=cols[2])
-        c3=fits.Column(name=cols[3].name, format='PI()', array=cols[3])
-        c4=fits.Column(name=cols[4].name, format='PI()', array=cols[4])
-        c5=fits.Column(name=cols[5].name, format='PE()', array=cols[5])
+        c2 = fits.Column(name=cols[2].name, format='I', array=cols[2])
+        c3 = fits.Column(name=cols[3].name, format='PI()', array=cols[3])
+        c4 = fits.Column(name=cols[4].name, format='PI()', array=cols[4])
+        c5 = fits.Column(name=cols[5].name, format='PE()', array=cols[5])
 
-        hdu=fits.BinTableHDU.from_columns([c0, c1, c2, c3, c4, c5],
+        hdu = fits.BinTableHDU.from_columns([c0, c1, c2, c3, c4, c5],
                                             header=header, name=name)
 
-        ebounds=energy_axis_to_ebounds(self.e_reco.bins)
-        prim_hdu=fits.PrimaryHDU()
+        ebounds = energy_axis_to_ebounds(self.e_reco.bins)
+        prim_hdu = fits.PrimaryHDU()
 
         return fits.HDUList([prim_hdu, hdu, ebounds])
 
@@ -250,47 +250,47 @@ class EnergyDispersion(object):
         The output table is in the OGIP RMF format.
         http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#Tab:1
         """
-        table=Table()
+        table = Table()
 
-        rows=self.pdf_matrix.shape[0]
-        n_grp=[]
-        f_chan=np.ndarray(dtype=np.object, shape=rows)
-        n_chan=np.ndarray(dtype=np.object, shape=rows)
-        matrix=np.ndarray(dtype=np.object, shape=rows)
+        rows = self.pdf_matrix.shape[0]
+        n_grp = []
+        f_chan = np.ndarray(dtype=np.object, shape=rows)
+        n_chan = np.ndarray(dtype=np.object, shape=rows)
+        matrix = np.ndarray(dtype=np.object, shape=rows)
 
         # Make RMF type matrix
         for i, row in enumerate(self.data.data.value):
-            subsets=1
-            pos=np.nonzero(row)[0]
-            borders=np.where(np.diff(pos) != 1)[0]
+            subsets = 1
+            pos = np.nonzero(row)[0]
+            borders = np.where(np.diff(pos) != 1)[0]
             # add 1 to borders for correct behaviour of np.split
-            groups=np.asarray(np.split(pos, borders + 1))
-            n_grp_temp=groups.shape[0] if groups.size > 0 else 1
-            n_chan_temp=np.asarray([val.size for val in groups])
+            groups = np.asarray(np.split(pos, borders + 1))
+            n_grp_temp = groups.shape[0] if groups.size > 0 else 1
+            n_chan_temp = np.asarray([val.size for val in groups])
             try:
-                f_chan_temp=np.asarray([val[0] for val in groups])
+                f_chan_temp = np.asarray([val[0] for val in groups])
             except(IndexError):
-                f_chan_temp=np.zeros(1)
+                f_chan_temp = np.zeros(1)
 
             n_grp.append(n_grp_temp)
-            f_chan[i]=f_chan_temp
-            n_chan[i]=n_chan_temp
-            matrix[i]=row[pos]
+            f_chan[i] = f_chan_temp
+            n_chan[i] = n_chan_temp
+            matrix[i] = row[pos]
 
-        table['ENERG_LO']=self.e_true.lo
-        table['ENERG_HI']=self.e_true.hi
-        table['N_GRP']=np.asarray(n_grp, dtype=np.int16)
-        table['F_CHAN']=f_chan
-        table['N_CHAN']=n_chan
-        table['MATRIX']=matrix
+        table['ENERG_LO'] = self.e_true.lo
+        table['ENERG_HI'] = self.e_true.hi
+        table['N_GRP'] = np.asarray(n_grp, dtype=np.int16)
+        table['F_CHAN'] = f_chan
+        table['N_CHAN'] = n_chan
+        table['MATRIX'] = matrix
 
         # Get total number of groups and channel subsets
-        numgrp, numelt=0, 0
+        numgrp, numelt = 0, 0
         for val, val2 in zip(table['N_GRP'], table['N_CHAN']):
             numgrp += np.sum(val)
             numelt += np.sum(val2)
 
-        meta=dict(name='MATRIX',
+        meta = dict(name='MATRIX',
                     chantype='PHA',
                     hduclass='OGIP',
                     hduclas1='RESPONSE',
@@ -301,7 +301,7 @@ class EnergyDispersion(object):
                     tlmin4=0,
                     )
 
-        table.meta=meta
+        table.meta = meta
         return table
 
     def write(self, filename, **kwargs):
@@ -319,10 +319,10 @@ class EnergyDispersion(object):
             True energy
         """
         # Variance is 2nd moment of PDF
-        pdf=self.data.evaluate(e_true=e_true)
-        mean=self._get_mean(e_true)
-        temp=(self.e_reco._interp_nodes() - mean) ** 2
-        var=np.sum(temp * pdf)
+        pdf = self.data.evaluate(e_true=e_true)
+        mean = self._get_mean(e_true)
+        temp = (self.e_reco._interp_nodes() - mean) ** 2
+        var = np.sum(temp * pdf)
         return np.sqrt(var)
 
     def get_bias(self, e_true):
@@ -339,18 +339,18 @@ class EnergyDispersion(object):
         e_true : `~astropy.units.Quantity`
             True energy
         """
-        mean=self._get_mean(e_true)
-        e_reco=(10 ** mean) * self.e_reco.unit
-        bias=(e_true - e_reco) / e_true
+        mean = self._get_mean(e_true)
+        e_reco = (10 ** mean) * self.e_reco.unit
+        bias = (e_true - e_reco) / e_true
         return bias
 
     def _get_mean(self, e_true):
         r"""Get mean log reconstructed energy
         """
         # Reconstructed energy is 1st moment of PDF
-        pdf=self.data.evaluate(e_true=e_true)
-        norm=np.sum(pdf)
-        temp=np.sum(pdf * self.e_reco._interp_nodes())
+        pdf = self.data.evaluate(e_true=e_true)
+        norm = np.sum(pdf)
+        temp = np.sum(pdf * self.e_reco._interp_nodes())
         return temp / norm
 
     def apply(self, data, e_reco=None, e_true=None):
@@ -377,17 +377,17 @@ class EnergyDispersion(object):
             1-dim data array after multiplication with the energy dispersion matrix
         """
         if e_reco is None:
-            reco_nodes=self.e_reco.nodes
+            reco_nodes = self.e_reco.nodes
         else:
-            e_reco=EnergyBounds(e_reco)
-            reco_nodes=e_reco.log_centers
+            e_reco = EnergyBounds(e_reco)
+            reco_nodes = e_reco.log_centers
         if e_true is None:
-            true_nodes = self.e_true.nodes 
+            true_nodes = self.e_true.nodes
         else:
             e_true = EnergyBounds(e_true)
             true_nodes = e_true.log_centers
 
-        edisp_pdf=self.data.evaluate(e_reco=reco_nodes, e_true=true_nodes)
+        edisp_pdf = self.data.evaluate(e_reco=reco_nodes, e_true=true_nodes)
         if len(data) != len(true_nodes):
             raise ValueError("Input size {} does not match true energy axis {}".format(
                 len(data), len(true_nodes)))
@@ -398,8 +398,8 @@ class EnergyDispersion(object):
 
         x stands for true energy and y for reconstructed energy
         """
-        x=self.e_true.bins[[0, -1]].value
-        y=self.e_reco.bins[[0, -1]].value
+        x = self.e_true.bins[[0, -1]].value
+        y = self.e_reco.bins[[0, -1]].value
         return x[0], x[1], y[0], y[1]
 
     def plot_matrix(self, ax=None, show_energy=None, **kwargs):
@@ -425,12 +425,12 @@ class EnergyDispersion(object):
         kwargs.setdefault('interpolation', 'nearest')
         kwargs.setdefault('norm', PowerNorm(gamma=0.5))
 
-        ax=plt.gca() if ax is None else ax
+        ax = plt.gca() if ax is None else ax
 
-        image=self.pdf_matrix.transpose()
+        image = self.pdf_matrix.transpose()
         ax.imshow(image, extent=self._extent(), **kwargs)
         if show_energy is not None:
-            ener_val=Quantity(show_energy).to(self.reco_energy.unit).value
+            ener_val = Quantity(show_energy).to(self.reco_energy.unit).value
             ax.hlines(ener_val, 0, 200200, linestyles='dashed')
 
         ax.set_xlabel('True energy (TeV)')
@@ -453,10 +453,10 @@ class EnergyDispersion(object):
         """
         import matplotlib.pyplot as plt
 
-        ax=plt.gca() if ax is None else ax
+        ax = plt.gca() if ax is None else ax
 
-        x=self.e_true.nodes.to('TeV').value
-        y=self.get_bias(self.e_true.nodes)
+        x = self.e_true.nodes.to('TeV').value
+        y = self.get_bias(self.e_true.nodes)
 
         ax.plot(x, y, **kwargs)
         ax.set_xlabel('True energy [TeV]')
@@ -478,37 +478,37 @@ class EnergyDispersion(object):
         # Need to modify RMF data
         # see https://github.com/sherpa/sherpa/blob/master/sherpa/astro/io/pyfits_backend.py#L727
 
-        table=self.to_table()
-        n_grp=table['N_GRP'].data.astype(SherpaUInt)
-        f_chan=table['F_CHAN'].data
-        f_chan=np.concatenate([row for row in f_chan]).astype(SherpaUInt)
-        n_chan=table['N_CHAN'].data
-        n_chan=np.concatenate([row for row in n_chan]).astype(SherpaUInt)
-        matrix=table['MATRIX'].data
+        table = self.to_table()
+        n_grp = table['N_GRP'].data.astype(SherpaUInt)
+        f_chan = table['F_CHAN'].data
+        f_chan = np.concatenate([row for row in f_chan]).astype(SherpaUInt)
+        n_chan = table['N_CHAN'].data
+        n_chan = np.concatenate([row for row in n_chan]).astype(SherpaUInt)
+        matrix = table['MATRIX'].data
 
-        good=n_grp > 0
-        matrix=matrix[good]
-        matrix=np.concatenate([row for row in matrix])
-        matrix=matrix.astype(SherpaFloat)
+        good = n_grp > 0
+        matrix = matrix[good]
+        matrix = np.concatenate([row for row in matrix])
+        matrix = matrix.astype(SherpaFloat)
 
         # TODO: Not sure if we need this if statement
         if f_chan.ndim > 1 and n_chan.ndim > 1:
-            f_chan=[]
-            n_chan=[]
+            f_chan = []
+            n_chan = []
             for grp, fch, nch, in izip(n_grp, f_chan, n_chan):
                 for i in xrange(grp):
                     f_chan.append(fch[i])
                     n_chan.append(nch[i])
 
-            f_chan=numpy.asarray(f_chan, SherpaUInt)
-            n_chan=numpy.asarray(n_chan, SherpaUInt)
+            f_chan = numpy.asarray(f_chan, SherpaUInt)
+            n_chan = numpy.asarray(n_chan, SherpaUInt)
         else:
             if len(n_grp) == len(f_chan):
-                good=n_grp > 0
-                f_chan=f_chan[good]
-                n_chan=n_chan[good]
+                good = n_grp > 0
+                f_chan = f_chan[good]
+                n_chan = n_chan[good]
 
-        kwargs=dict(
+        kwargs = dict(
             name=name,
             energ_lo=table['ENERG_LO'].quantity.to('keV').value.astype(SherpaFloat),
             energ_hi=table['ENERG_HI'].quantity.to('keV').value.astype(SherpaFloat),
@@ -611,7 +611,7 @@ class EnergyDispersion2D(object):
                            interpolation_mode='linear', name='offset')
         ]
         self.data = NDDataArray(axes=axes, data=data,
-                                interp_kwargs=interp_kwargs)                       
+                                interp_kwargs=interp_kwargs)
 
     @property
     def e_true(self):
@@ -629,14 +629,14 @@ class EnergyDispersion2D(object):
     def from_table(cls, table):
         """Create from `~astropy.table.Table`
         """
-        e_lo=table['ETRUE_LO'].quantity.squeeze()
-        e_hi=table['ETRUE_HI'].quantity.squeeze()
-        o_lo=table['THETA_LO'].quantity.squeeze()
-        o_hi=table['THETA_HI'].quantity.squeeze()
-        m_lo=table['MIGRA_LO'].quantity.squeeze()
-        m_hi=table['MIGRA_HI'].quantity.squeeze()
+        e_lo = table['ETRUE_LO'].quantity.squeeze()
+        e_hi = table['ETRUE_HI'].quantity.squeeze()
+        o_lo = table['THETA_LO'].quantity.squeeze()
+        o_hi = table['THETA_HI'].quantity.squeeze()
+        m_lo = table['MIGRA_LO'].quantity.squeeze()
+        m_hi = table['MIGRA_HI'].quantity.squeeze()
 
-        matrix=table['MATRIX'].squeeze().transpose()
+        matrix = table['MATRIX'].squeeze().transpose()
         return cls(e_true_lo=e_lo, e_true_hi=e_hi,
                    offset_lo=o_lo, offset_hi=o_hi,
                    migra_lo=m_lo, migra_hi=m_hi, data=matrix)
@@ -658,8 +658,8 @@ class EnergyDispersion2D(object):
         filename : str
             File name
         """
-        filename=make_path(filename)
-        hdulist=fits.open(str(filename))
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename))
         return cls.from_hdulist(hdulist, hdu)
 
     def to_energy_dispersion(self, offset, e_true=None, e_reco=None):
@@ -682,20 +682,20 @@ class EnergyDispersion2D(object):
         edisp : `~gammapy.irf.EnergyDispersion`
             Energy disperion matrix
         """
-        offset=Angle(offset)
+        offset = Angle(offset)
         # Set both energy axis to self.e_true by default
-        e_true=self.e_true.bins if e_true is None else e_true
-        e_reco=self.e_true.bins if e_reco is None else e_reco
+        e_true = self.e_true.bins if e_true is None else e_true
+        e_reco = self.e_true.bins if e_reco is None else e_reco
         e_true = EnergyBounds(e_true)
         e_reco = EnergyBounds(e_reco)
 
-        rm=[]
+        rm = []
 
         for energy in e_true.log_centers:
-            vec=self.get_response(offset=offset, e_true=energy, e_reco=e_reco)
+            vec = self.get_response(offset=offset, e_true=energy, e_reco=e_reco)
             rm.append(vec)
 
-        rm=np.asarray(rm)
+        rm = np.asarray(rm)
         e_lo, e_hi = (e_true[:-1], e_true[1:])
         ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
 
@@ -703,12 +703,12 @@ class EnergyDispersion2D(object):
                                 e_reco_lo=ereco_lo, e_reco_hi=ereco_hi,
                                 data=rm)
 
-    def get_response(self, offset, e_true, e_reco, oversampling=100):
+    def get_response(self, offset, e_true, e_reco, oversampling=10):
         """Detector response R(Delta E_reco, E_true)
 
         Probability to reconstruct a given true energy in a given reconstructed
         energy band.
-        
+
         Parameters
         ----------
         e_true : `~gammapy.utils.energy.Energy`
@@ -717,8 +717,8 @@ class EnergyDispersion2D(object):
             Reconstructed energy axis
         offset : `~astropy.coordinates.Angle`
             Offset
-        oversampling : int, optiona;
-            Migra oversampling factor for each bin of e_reco, default=10
+        oversampling : int, optional
+            Migra oversampling factor for each bin of e_reco
 
         Returns
         -------
@@ -726,11 +726,11 @@ class EnergyDispersion2D(object):
             Redistribution vector
         """
 
-        e_true=Energy(e_true)
+        e_true = Energy(e_true)
 
         # Translate given e_reco binning to migra binning
-        e_reco=EnergyBounds(e_reco)
-        migra= (e_reco / e_true).to('').value
+        e_reco = EnergyBounds(e_reco)
+        migra = (e_reco / e_true).to('').value
 
         # oversample migra
         migra_lo = migra[:-1]
@@ -739,13 +739,12 @@ class EnergyDispersion2D(object):
         migra_offset = np.linspace(0, 1, oversampling) * migra_range[:, np.newaxis]
         migra_grid = migra_lo[:, np.newaxis] + migra_offset
 
-        val = self.data.evaluate(offset=offset, e_true=e_true,
-                                 migra=np.array(migra_grid))
+        val = self.data.evaluate(offset=offset, e_true=e_true, migra=migra_grid)
 
-        dx = migra_grid[0][1] -migra_grid[0][0]
+        dx = migra_grid[0][1] - migra_grid[0][0]
         response = np.trapz(val, dx=dx)
 
-        return response 
+        return response
 
     def plot_migration(self, ax=None, offset=None, e_true=None,
                        migra=None, **kwargs):
@@ -769,22 +768,22 @@ class EnergyDispersion2D(object):
         """
         import matplotlib.pyplot as plt
 
-        ax=plt.gca() if ax is None else ax
+        ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            offset=Angle([1], 'deg')
+            offset = Angle([1], 'deg')
         else:
-            offset=np.atleast_1d(Angle(offset))
+            offset = np.atleast_1d(Angle(offset))
         if e_true is None:
-            e_true=Energy([0.1, 1, 10], 'TeV')
+            e_true = Energy([0.1, 1, 10], 'TeV')
         else:
-            e_true=np.atleast_1d(Energy(e_true))
-        migra=self.migra.nodes if migra is None else migra
+            e_true = np.atleast_1d(Energy(e_true))
+        migra = self.migra.nodes if migra is None else migra
 
         for ener in e_true:
             for off in offset:
-                disp=self.data.evaluate(offset=off, e_true=ener, migra=migra)
-                label='offset = {0:.1f}\nenergy = {1:.1f}'.format(off, ener)
+                disp = self.data.evaluate(offset=off, e_true=ener, migra=migra)
+                label = 'offset = {0:.1f}\nenergy = {1:.1f}'.format(off, ener)
                 ax.plot(migra, disp, label=label, **kwargs)
 
         ax.set_xlabel('E_Reco / E_True')
@@ -819,18 +818,18 @@ class EnergyDispersion2D(object):
         kwargs.setdefault('cmap', 'afmhot')
         kwargs.setdefault('norm', PowerNorm(gamma=0.5))
 
-        ax=plt.gca() if ax is None else ax
+        ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            offset=Angle([1], 'deg')
+            offset = Angle([1], 'deg')
         if e_true is None:
-            e_true=self.e_true.nodes
+            e_true = self.e_true.nodes
         if migra is None:
-            migra=self.migra.nodes
+            migra = self.migra.nodes
 
-        z=self.data.evaluate(offset=offset, e_true=e_true, migra=migra)
-        #y=e_true.value
-        #x=migra
+        z = self.data.evaluate(offset=offset, e_true=e_true, migra=migra)
+        # y=e_true.value
+        # x=migra
         #ax.pcolor(x, y, z, **kwargs)
 
         extent = [
@@ -853,10 +852,10 @@ class EnergyDispersion2D(object):
             Size of the resulting plot
         """
         import matplotlib.pyplot as plt
-        fig, axes=plt.subplots(nrows=1, ncols=3, figsize=figsize)
+        fig, axes = plt.subplots(nrows=1, ncols=3, figsize=figsize)
         self.plot_bias(ax=axes[0])
         self.plot_migration(ax=axes[1])
-        edisp=self.to_energy_dispersion(offset='1 deg')
+        edisp = self.to_energy_dispersion(offset='1 deg')
         edisp.plot_matrix(ax=axes[2])
 
         plt.tight_layout()

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -106,8 +106,13 @@ class TestEnergyDispersion2D():
         assert_allclose(actual, desired, rtol=1e-1)
 
         # Check value
-        response2 = self.edisp.get_response(offset=0.2 * u.deg,
-                                            e_true=1.2 * u.TeV)
+        offset = 0.2 * u.deg
+        e_true = 1.2 * u.TeV
+        e_reco = EnergyBounds.from_lower_and_upper_bounds(
+            self.edisp.migra.lo * e_true, self.edisp.migra.hi * e_true)
+        response2 = self.edisp.get_response(offset=offset,
+                                            e_true=e_true,
+                                            e_reco=e_reco)
         assert_allclose(response2[20], 9.2941217306683827e-05) 
 
     def test_exporter(self):


### PR DESCRIPTION
This PR adresses #862 and related issues

I extracted the edisp.peek() method from http://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/notebooks/data_iact.ipynb (this is mentioned in #862) to [this script](https://github.com/joleroi/gammapy/blob/2d51c79f6a1e1e29671c4c7e1758ff93a396bfe8/dev/profiling/profile_edisp_int.py).

## Status

I get the following performance using gammapy master

```
[profiling] python profile_edisp_int.py 
/home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/axes/_base.py:1322: UserWarning: aspect is not supported for Axes with xscale=log, yscale=linear
  'yscale=%s' % (xscale, yscale))
/home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/image.py:375: UserWarning: Images are not supported on non-linear axes.
  warnings.warn("Images are not supported on non-linear axes.")
Fri Feb 17 13:44:16 2017    restats

         4439850 function calls (4407717 primitive calls) in 7.240 seconds

   Ordered by: cumulative time
   List reduced from 2472 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    7.240    7.240 <string>:1(<module>)
        1    0.001    0.001    7.240    7.240 /home/kingj/Software/gammapy/gammapy/irf/energy_dispersion.py:886(peek)
        1    0.001    0.001    3.834    3.834 /home/kingj/Software/gammapy/gammapy/irf/energy_dispersion.py:665(to_energy_dispersion)
       73    0.169    0.002    3.830    0.052 /home/kingj/Software/gammapy/gammapy/irf/energy_dispersion.py:705(get_response)
     1112    0.050    0.000    2.145    0.002 /home/kingj/Software/gammapy/gammapy/utils/nddata.py:133(evaluate)
        1    0.000    0.000    1.862    1.862 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/pyplot.py:235(show)
        1    0.000    0.000    1.862    1.862 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/backend_bases.py:148(__call__)
        1    0.000    0.000    1.856    1.856 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/backends/backend_qt5.py:147(mainloop)
        1    1.184    1.184    1.856    1.856 {built-in method exec_}
    29437    0.299    0.000    1.554    0.000 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/astropy-1.3-py2.7-linux-x86_64.egg/astropy/units/quantity.py:354(__array_prepare__)
```

Baseline : 7.2 seconds, bottleneck is ``get_response`` btw. calls to ``nddata.evaluate``


## Update

With the reimplementation in this PR I get (after fixes discussed in this PR)

```
[profiling] python profile_edisp_int.py 
/home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/axes/_base.py:1322: UserWarning: aspect is not supported for Axes with xscale=log, yscale=linear
  'yscale=%s' % (xscale, yscale))
/home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/image.py:375: UserWarning: Images are not supported on non-linear axes.
  warnings.warn("Images are not supported on non-linear axes.")
Fri Feb 17 15:59:32 2017    restats

         1910255 function calls (1880397 primitive calls) in 3.583 seconds

   Ordered by: cumulative time
   List reduced from 2472 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    3.583    3.583 <string>:1(<module>)
        1    0.001    0.001    3.583    3.583 /home/kingj/Software/gammapy/gammapy/irf/energy_dispersion.py:847(peek)
        1    0.000    0.000    1.067    1.067 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/pyplot.py:235(show)
        1    0.000    0.000    1.067    1.067 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/backend_bases.py:148(__call__)
        1    0.000    0.000    1.061    1.061 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/backends/backend_qt5.py:147(mainloop)
        1    0.379    0.379    1.061    1.061 {built-in method exec_}
        1    0.000    0.000    1.007    1.007 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/pyplot.py:1369(tight_layout)
        1    0.000    0.000    1.007    1.007 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/figure.py:1718(tight_layout)
        1    0.000    0.000    1.001    1.001 /home/kingj/Software/miniconda3/envs/headversions/lib/python2.7/site-packages/matplotlib/tight_layout.py:263(get_tight_layout_figure)
        1    0.001    0.001    1.001    1.001 /home/kingj/Software/gammapy/gammapy/irf/energy_dispersion.py:665(to_energy_dispersion)

```

Which runs faster and is limited by matplotlib.

## Correctness

Obviously, the integration need not only to run fast but also give correct results. By just looking at the pictures there is a difference (rightmost panel)

### Master

![peek_master](https://cloud.githubusercontent.com/assets/11678435/23065971/6e964fba-f518-11e6-9fa4-50781e511e24.png)

### This PR

![peek_update](https://cloud.githubusercontent.com/assets/11678435/23065995/8af4810e-f518-11e6-94aa-db30930daef0.png)

I think the difference is that the EDISP is normalized to 1 in the integration method that is in master, whereas the new integration does not do any renormalization. @JouvinLea @registerrier @cdeil - which of the images makes more sense?


