### PR TITLE
Update .travis.yml to add conda-forge channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject'
         - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy libgfortran runipy regions reproject'
         - PIP_DEPENDENCIES='uncertainties'
-        - CONDA_CHANNELS='astropy sherpa'
+        - CONDA_CHANNELS='conda-forge astropy sherpa'
         - FETCH_GAMMAPY_EXTRA=true
         - FETCH_GAMMA_CAT=true
         - MAIN_CMD='python setup.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ matrix:
 
         # Test IPython notebooks
         - os: linux
-          env: PYTHON_VERSION=3.4 MAIN_CMD='make' SETUP_CMD='test-notebooks'
+          env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-notebooks'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA
 
         - os: linux
@@ -136,8 +136,13 @@ matrix:
 
     # You can move builds that temporarily fail because of some non-Gammapy here.
     # Please add a link to a GH issue that tracks the upstream issue.
-#    allow_failures:
-#        # copy the part from the `include` section above here.
+    # copy the part from the `include` section above here.
+    allow_failures:
+        # See https://github.com/gammapy/gammapy/pull/899#issuecomment-281001655
+        - os: linux
+          env: PYTHON_VERSION=3.4 SETUP_CMD='test -V'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
+
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/gammapy/cube/tests/test_cube_pipe.py
+++ b/gammapy/cube/tests/test_cube_pipe.py
@@ -9,7 +9,7 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy.units import Quantity
 from gammapy.extern.pathlib import Path
 from ...data import DataStore
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, pytest
 from ...image import SkyMask
 from .. import StackedObsCubeMaker
 from ...background import OffDataBackgroundMaker
@@ -43,6 +43,8 @@ def make_empty_cube(image_size, energy, center, data_unit=None):
     return empty_cube
 
 
+# Temp xfail for this: https://github.com/gammapy/gammapy/pull/899#issuecomment-281001655
+@pytest.mark.xfail
 @requires_dependency('reproject')
 @requires_data('gammapy-extra')
 def test_cube_pipe(tmpdir):

--- a/gammapy/scripts/tests/test_image_pipe.py
+++ b/gammapy/scripts/tests/test_image_pipe.py
@@ -2,14 +2,15 @@
 """
 from astropy.coordinates import SkyCoord, Angle
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data, requires_dependency, pytest
 from ...utils.energy import Energy
 from ...data import DataStore
 from ...image import SkyImage, SkyMask
 from ...background import OffDataBackgroundMaker
 from ...scripts import StackedObsImageMaker
 
-
+# Temp xfail for this: https://github.com/gammapy/gammapy/pull/899#issuecomment-281001655
+@pytest.mark.xfail
 @requires_dependency('reproject')
 @requires_data('gammapy-extra')
 def test_image_pipe(tmpdir):
@@ -56,6 +57,7 @@ def test_image_pipe(tmpdir):
     exclusion_mask = SkyMask.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
     exclusion_mask = exclusion_mask.reproject(reference=ref_image)
 
+    # TODO: fix this:
     # Pb with the load psftable for one of the run that is not implemented yet...
     data_store.hdu_table.remove_row(14)
 


### PR DESCRIPTION
@bsipocz Is this what you meant in https://github.com/astropy/regions/issues/112#issuecomment-280966219 ?

My main goal would be to get travis-ci for `master` passing again, so that it becomes useful for pull requests this week.

We don't really use photutils at the moment (except for one example script that doesn't run in continuous integration). So would removing `photutils` from `.travis.yml` help resolve this issue? Or would we just run into the same issue with other affiliated packages (like Naima)?