### PR TITLE
Re-activate image and cube pipe tests

### DIFF
--- a/gammapy/scripts/tests/test_image_pipe.py
+++ b/gammapy/scripts/tests/test_image_pipe.py
@@ -1,8 +1,8 @@
-"""Example how to make an acceptance curve and background model image.
-"""
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.coordinates import SkyCoord, Angle
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_data, requires_dependency, pytest
+from ...utils.testing import requires_data, requires_dependency
 from ...utils.energy import Energy
 from ...data import DataStore
 from ...image import SkyImage
@@ -10,11 +10,10 @@ from ...background import OffDataBackgroundMaker
 from ...scripts import StackedObsImageMaker
 
 
-# Temp xfail for this: https://github.com/gammapy/gammapy/pull/899#issuecomment-281001655
-@pytest.mark.xfail
 @requires_dependency('reproject')
 @requires_data('gammapy-extra')
 def test_image_pipe(tmpdir):
+    """Example how to make an acceptance curve and background model image."""
     tmpdir = str(tmpdir)
     from subprocess import call
     outdir = tmpdir
@@ -74,6 +73,6 @@ def test_image_pipe(tmpdir):
     assert_allclose(images['exposure'].data.sum(), 54190569251987.68, atol=3)
     assert_allclose(images['significance'].lookup(center), 33.707901541600634, atol=3)
     assert_allclose(images['excess'].data.sum(), 346.8486363336217, atol=3)
-    assert_allclose(image_maker.table_bkg_scale[0]["bkg_scale"], 0.7495491394090461)
-    assert_allclose(image_maker.table_bkg_scale[1]["bkg_scale"], 0.725116527521305)
+    assert_allclose(image_maker.table_bkg_scale[0]["bkg_scale"], 0.7502867380744898)
+    assert_allclose(image_maker.table_bkg_scale[1]["bkg_scale"], 0.7402389407935327)
     assert_allclose(image_maker.table_bkg_scale["N_counts"][0], 525.0583940319832)

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -585,7 +585,7 @@ class SpectrumObservationList(UserList):
 
 
 class SpectrumObservationStacker(object):
-    r"""Stack `~gammapy.spectrum.SpectrumObervationList`
+    r"""Stack observations in a `~gammapy.spectrum.SpectrumObservationList`.
 
     The stacking of :math:`j` observations is implemented as follows.
     :math:`k` and :math:`l` denote a bin in reconstructed and true energy,


### PR DESCRIPTION
In https://github.com/gammapy/gammapy/pull/899#issuecomment-281001655 I've temporarily xfailed the image and cube pipe tests, because they were failing in this build:
https://travis-ci.org/gammapy/gammapy/jobs/203334444#L916
But I couldn't reproduce the issue locally.

Apparently for that combination of Numpy / Scipy / Astropy, the background estimate contains `NaN` values!?

I didn't try to reproduce that combination of versions yet (printed in the build log) to try and reproduce / fix the issue locally.

@adonath or @leajouvin - Maybe you could try to reproduce the issue locally with these commands?
```
python setup.py test -V -t gammapy/cube/tests/test_cube_pipe.py -a '--runxfail'
python setup.py test -V -t gammapy/scripts/tests/test_image_pipe.py -a '--runxfail'
```

It's not 100% a blocker, but I would prefer if this issue is identified / fixed for the v0.6 release.