### PR TITLE
Improved EnergyDispersion2D.get_response and associated tests

### DIFF
--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -182,7 +182,7 @@ def test_make_mean_edisp(tmpdir):
 
     assert len(rmf.e_true.nodes) == 80
     assert len(rmf.e_reco.nodes) == 15
-    assert_quantity_allclose(rmf.data.data[53, 8], 0.0559785805550798)
+    assert_quantity_allclose(rmf.data.data[53, 8], 0.056, atol=2e-2)
 
     rmf2 = obslist.make_mean_edisp(position=position, e_true=e_true,
                                    e_reco=e_reco,

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -754,8 +754,9 @@ class EnergyDispersion2D(object):
         tmp = np.cumsum(vals) / np.sum(vals)
 
         # Determine positions (bin indices) of e_reco bounds in migration array
+        pos_mig = np.digitize(migra_e_reco, mig_array) - 1
         # We ensure that no negative values are found
-        pos_mig = np.maximum(np.digitize(migra_e_reco, mig_array)-1 , 0)
+        pos_mig = np.maximum(pos_mig, 0)
 
         # We compute the difference between 2 successive bounds in e_reco to get integral over reco energy bin
         integral = np.diff(tmp[pos_mig])

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -626,12 +626,12 @@ class EnergyDispersion2D(object):
         return self.data.axis('offset')
 
     @classmethod
-    def _from_gaus(cls, e_true, migra, bias, sigma, offset=None):
+    def from_gauss(cls, e_true, migra, bias, sigma, offset):
         """Create Gaussian `EnergyDispersion2D` matrix.
 
-         The output matrix will be Gaussian in (e_true / e_reco)
-         The output matrix is flat in offset
-         TODO: add option to have log normal distribution
+         The output matrix will be Gaussian in (e_true / e_reco).
+         bias and sigma should be either floats or arrays of same dimension than e_true.
+         Note that, the output matrix is flat in offset.
 
          Parameters
          ----------
@@ -639,14 +639,13 @@ class EnergyDispersion2D(object):
              Bin edges of true energy axis
          migra : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`
              Bin edges of migra axis
-         sigma : float, optional
+         bias : float or `~np.array`
+             Center of Gaussian energy dispersion, bias
+         sigma : float or `~np.array`
              RMS width of Gaussian energy dispersion, resolution
          offset : `~astropy.units.Quantity`, `~gammapy.utils.nddata.BinnedDataAxis`, optional
              Bin edges of offset
          """
-        if offset is None:
-            offset = np.linspace(0.,3.,10)*u.deg
-
         from scipy.special import erf
 
         e_true = EnergyBounds(e_true)
@@ -744,7 +743,7 @@ class EnergyDispersion2D(object):
                                 e_reco_lo=ereco_lo, e_reco_hi=ereco_hi,
                                 data=rm)
 
-    def get_response(self, offset, e_true, e_reco=None, mig_step=5e-3):
+    def get_response(self, offset, e_true, e_reco=None, migra_step=5e-3):
         """Detector response R(Delta E_reco, E_true)
 
         Probability to reconstruct a given true energy in a given reconstructed
@@ -787,7 +786,7 @@ class EnergyDispersion2D(object):
         # Define a vector of migration with mig_step step
         mrec_min = self.migra.lo[0]
         mrec_max = self.migra.hi[-1]
-        mig_array = np.arange(mrec_min, mrec_max, mig_step)
+        mig_array = np.arange(mrec_min, mrec_max, migra_step)
 
         # Compute energy dispersion probabilty dP/dm for each element of migration array
         vals = self.data.evaluate(offset=offset, e_true=e_true, migra=mig_array)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -58,6 +58,10 @@ class TestEnergyDispersion:
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
+
+# First we define a fake EnergyDispersion2D
+
+
 class TestEnergyDispersion2D():
     def setup(self):
         filename = gammapy_extra.filename(
@@ -92,10 +96,11 @@ class TestEnergyDispersion2D():
                    self.edisp.offset.nbins)
         assert_equal(actual, desired)
 
+
     def test_get_response(self):
         # Here we test get_response with an expected gaussian shape for edisp
         from scipy.special import erf
-        # First we define a fake EnergyDispersion2D
+
         size_true = 50
         size_mig = 1000
         size_off = 4
@@ -105,22 +110,22 @@ class TestEnergyDispersion2D():
         offsets = np.linspace(0., 2.5, size_off + 1) * u.deg
 
         # Resolution with energy
-        sigma = 0.15 / ((etrues[:-1] / (1 * u.TeV)).value)**0.3
+        sigma = 0.15 / ((etrues[:-1] / (1 * u.TeV)).value) ** 0.3
         # Bias with energy
         mu = 1.0 + 1e-3 * (etrues[:-1] - 1 * u.TeV).value
 
-        edisp = EnergyDispersion2D._from_gaus(etrues, migras, mu, sigma, offsets)
+        edisp = EnergyDispersion2D.from_gauss(etrues, migras, mu, sigma, offsets)
 
         for i in [5, 10, 15, 20, 25, 30, 35, 40]:
             e_true = etrues[i]
             e_reco = np.array([0.25, 0.5, 1.0, 1.5, 2.0]) * e_true
-            actual = edisp.get_response(offset=0.7 * u.deg, e_true=e_true, e_reco=e_reco, mig_step=1e-2)
+            actual = edisp.get_response(offset=0.7 * u.deg, e_true=e_true, e_reco=e_reco)
 
             val = ((e_reco / e_true).value - mu[i]) / (np.sqrt(2) * sigma[i])
             desired = np.diff(erf(val)) * 0.5
 
-            # We want the absolute precision to be less than 5%
-            assert_allclose(actual, desired, atol=5e-2)
+            # We want the absolute precision to be less than 3%
+            assert_allclose(actual, desired, atol=3e-2)
 
     def test_exporter(self):
         # Check RMF exporter


### PR DESCRIPTION
This introduces a different get_response() where integration is done with a given step in migration rather than with a fixed oversampling of e_reco bins.

- The default value for the migra_step allows a significant decrease of computation time and allow for absolute precision <0.05.
- Tests have been modified to test for a gaussian edisp where we can compute the desired value with satisfactory precision (<5% absolute)
- Note that all tests on EnergyDispersion2D could be done with gaussian edisp rather than stored one. 