### PR TITLE
Double plot issue in Jupyter and changing the events.peek() function.

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -539,5 +539,5 @@ class EffectiveAreaTable2D(object):
         self.plot_energy_dependence(ax=axes[1])
         self.plot_offset_dependence(ax=axes[2])
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -899,8 +899,8 @@ class EnergyDispersion2D(object):
         edisp.plot_matrix(ax=axes[2])
 
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig
 
     def __str__(self):
         ss = self.__class__.__name__

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -425,5 +425,5 @@ class PSF3D(object):
         # psf.plot_components(ax=axes[2])
 
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -318,8 +318,8 @@ class EnergyDependentMultiGaussPSF(object):
         # psf.plot_components(ax=axes[2])
 
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig
 
     def info(self, fractions=[0.68, 0.95], energies=Quantity([1., 10.], 'TeV'),
              thetas=Quantity([0.], 'deg')):

--- a/gammapy/scripts/cta_irf.py
+++ b/gammapy/scripts/cta_irf.py
@@ -481,8 +481,8 @@ class CTAPerf(object):
         ax_sens.grid(which='both')
         ax_psf.grid(which='both')
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig
 
     @staticmethod
     def superpose_perf(cta_perf, labels):
@@ -522,5 +522,5 @@ class CTAPerf(object):
         ax_sens.grid(which='both')
 
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig

--- a/gammapy/scripts/cta_utils.py
+++ b/gammapy/scripts/cta_utils.py
@@ -236,5 +236,5 @@ class CTAObservationSimulation(object):
                  style='italic', transform=ax2.transAxes, fontsize=7,
                  bbox={'facecolor': 'white', 'alpha': 1, 'pad': 10})
         plt.tight_layout()
-        plt.show()
-        return fig
+        #plt.show()
+        #return fig

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -376,7 +376,7 @@ class SpectrumObservation(object):
 
         # TODO: optimize layout
         # plt.subplots_adjust(hspace = .2, left=.1)
-        return fig
+        #return fig
 
     def to_sherpa(self):
         """Create a `~sherpa.astro.data.DataPHA`


### PR DESCRIPTION
changing peek() to show image in RA/DEC and event rate vs time.
Fixed the double plot issue in jupyter for all the peek functions.
Double plot was due to return fig in plot routine. 
In peek routine the plt.plot() was showing the figure then the peek() function was returning a fig object. If .peek() was the last line of the notebook cell then the fig object was displayed by Jupyter therefore showing the figure twice.