### PR TITLE
Fix issue in the to_energy_dependent_table_psf of Multi Gauss

### DIFF
--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -396,7 +396,7 @@ class EnergyDependentMultiGaussPSF(object):
             theta = Angle(0, 'deg')
 
         if offset:
-            offset = Angle(offset)
+            offset = Angle(offset).to('deg')
         else:
             offset = Angle(np.arange(0, 1.5, 0.005), 'deg')
 


### PR DESCRIPTION
@cdeil 
Fix the issue in ```to_energy_dependent_table_psf ```. It was evaluating the psf at different offset not checking if it was in degree or radian. So it was giving wrong psf table if ``offset``` was in radian