### PR TITLE
Add psf kernel cube method

### DIFF
--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -147,8 +147,7 @@ class TablePSF(object):
         offset = center.separation(point)
         return self.evaluate(offset)
 
-    def kernel(self, reference, containment=0.99, normalize=True,
-               discretize_model_kwargs=dict(factor=10)):
+    def kernel(self, reference):
         """
         Make a 2-dimensional kernel image.
 
@@ -159,8 +158,8 @@ class TablePSF(object):
         ----------
         reference : `~gammapy.image.SkyImage` or `~gammapy.cube.SkyCube`
             Reference sky image or sky cube defining the spatial grid.
-        containment : float
-            Minimal containment fraction of the kernel image.
+        offset_max : `~astropy.coordinates.Angle`
+             maximal radius up to which the PSF is evaluated.
         normalize : bool
             Whether to normalize the kernel.
 
@@ -171,28 +170,13 @@ class TablePSF(object):
 
         """
         from ..cube import SkyCube
-        offset_max = self.containment_radius(containment)
-
+        from ..background import fill_acceptance_image
         if isinstance(reference, SkyCube):
             reference = reference.sky_image_ref
-
-        pixel_size = reference.wcs_pixel_scale()[0]
-
-        def _model(x, y):
-            """Model in the appropriate format for discretize_model."""
-            offset = np.sqrt(x * x + y * y) * pixel_size
-            return self.evaluate(offset)
-
-        npix = int(offset_max.radian / pixel_size.radian)
-        pix_range = (-npix, npix + 1)
-
-        kernel = discretize_oversample_2D(_model, x_range=pix_range, y_range=pix_range,
-                                          **discretize_model_kwargs)
-        if normalize:
-            return kernel / kernel.sum()
-        else:
-            return kernel
-
+        header = reference.to_image_hdu().header
+        kernel=fill_acceptance_image(header, reference.center, self._offset.to("deg"),
+                                                         self._dp_domega, self._offset.to("deg")[-1]).data
+        return kernel
     def evaluate(self, offset, quantity='dp_domega'):
         r"""Evaluate PSF.
 
@@ -586,7 +570,7 @@ class EnergyDependentTablePSF(object):
         for iE, (emin, emax) in enumerate(zip(energies[:-1], energies[1:])):
             energy_band = Quantity([emin, emax])
             psf = self.table_psf_in_energy_band(energy_band, **kwargs)
-            psf_cube.data[iE,:,:] = psf.kernel(cube.sky_image_ref).data
+            psf_cube.data[iE,:,:] = psf.kernel(cube.sky_image_ref)
 
         return psf_cube
 


### PR DESCRIPTION
@adonath @cdeil 
I started this PR to add a cube method to the ```EnergyDependentTablePSF```. I change the method ```kernel```in the ```TablePSF``` class to use fiil_acceptance  and the skyimage that you give as argument.

@adonath 
We need this method different from the kernels one to create directly a SkyCube, Christoph said that this is good to have both method...

For the moment I haven't the same result with this method and with the method in my notebook where I was oversampling the energy binning for each band of the Cube... I will not have the time to investigate this week end ...