### PR TITLE
Change IRF plotting from imshow to pcolormesh

### DIFF
--- a/examples/example_energy_offset_array.py
+++ b/examples/example_energy_offset_array.py
@@ -23,5 +23,5 @@ def make_counts_array():
 
 if __name__ == '__main__':
     array = make_counts_array()
-    array.plot_image()
+    array.plot()
     plt.show()

--- a/gammapy/background/energy_offset_array.py
+++ b/gammapy/background/energy_offset_array.py
@@ -74,7 +74,7 @@ class EnergyOffsetArray(object):
 
         return hist
 
-    def plot_image(self, ax=None, offset=None, energy=None, **kwargs):
+    def plot(self, ax=None, **kwargs):
         """Plot Energy_offset Array image (x=offset, y=energy).
 
         TODO: Currently theta axis is not shown correctly if theta scale is not linear (like square root).
@@ -83,30 +83,19 @@ class EnergyOffsetArray(object):
         """
         import matplotlib.pyplot as plt
 
-        kwargs.setdefault('cmap', 'afmhot')
-        kwargs.setdefault('origin', 'bottom')
-        kwargs.setdefault('interpolation', 'nearest')
+        kwargs.setdefault('cmap', 'GnBu')
+        #kwargs.setdefault('interpolation', 'None')
 
         ax = plt.gca() if ax is None else ax
 
-        if offset is None:
-            offset = self.offset
-
-        if energy is None:
-            energy = self.energy
-
-        extent = [
-            offset.value.min(), offset.value.max(),
-            energy.value.min(), energy.value.max(),
-        ]
-        ax.imshow(self.data.value, extent=extent, **kwargs)
+        offset, energy = self.offset, self.energy.log_centers
+        x, y, z = offset.value, energy.value, self.data.value
+        caxes = ax.pcolormesh(x, y, z,  **kwargs)
+        unit = self.data.unit
+        cbar = ax.figure.colorbar(caxes, ax=ax, label='Value ({0})'.format(unit))
         ax.semilogy()
         ax.set_xlabel('Offset ({0})'.format(offset.unit))
         ax.set_ylabel('Energy ({0})'.format(energy.unit))
-        ax.set_title('Energy_offset Array')
-        ax.legend()
-        image = ax.imshow(self.data.value, extent=extent, **kwargs)
-        # plt.colorbar(image)
         return ax
 
     @classmethod

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -76,7 +76,7 @@ def test_energy_offset_array_fill_evaluate():
 @requires_dependency('matplotlib')
 def test_energy_offset_array_plot():
     array = make_test_array()
-    array.plot_image()
+    array.plot()
 
 
 def test_energy_offset_array_read_write(tmpdir):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -382,7 +382,7 @@ class EnergyDispersion(object):
             e_reco=EnergyBounds(e_reco)
             reco_nodes=e_reco.log_centers
         if e_true is None:
-            true_nodes = self.e_true.nodes 
+            true_nodes = self.e_true.nodes
         else:
             e_true = EnergyBounds(e_true)
             true_nodes = e_true.log_centers
@@ -402,8 +402,9 @@ class EnergyDispersion(object):
         y=self.e_reco.bins[[0, -1]].value
         return x[0], x[1], y[0], y[1]
 
-    def plot_matrix(self, ax=None, show_energy=None, **kwargs):
-        """Plot PDF matrix.
+    def plot_matrix(self, ax=None, show_energy=None, add_cbar=True, **kwargs):
+        """
+        Plot PDF matrix.
 
         Parameters
         ----------
@@ -411,6 +412,8 @@ class EnergyDispersion(object):
             Axis
         show_energy : `~astropy.units.Quantity`, optional
             Show energy, e.g. threshold, as vertical line
+        add_cbar : bool
+            Add a colorbar to the plot.
 
         Returns
         -------
@@ -420,25 +423,30 @@ class EnergyDispersion(object):
         import matplotlib.pyplot as plt
         from matplotlib.colors import PowerNorm
 
-        kwargs.setdefault('cmap', 'afmhot')
-        kwargs.setdefault('origin', 'bottom')
-        kwargs.setdefault('interpolation', 'nearest')
-        kwargs.setdefault('norm', PowerNorm(gamma=0.5))
+        kwargs.setdefault('cmap', 'GnBu')
+        norm =  PowerNorm(gamma=0.5)
+        kwargs.setdefault('norm', norm)
 
-        ax=plt.gca() if ax is None else ax
+        ax = plt.gca() if ax is None else ax
 
-        image=self.pdf_matrix.transpose()
-        ax.imshow(image, extent=self._extent(), **kwargs)
+        z = self.pdf_matrix
+        x = self.e_true.bins
+        y = self.e_reco.bins
+
+        caxes = ax.pcolormesh(x.value, y.value, z.T, **kwargs)
+
         if show_energy is not None:
             ener_val=Quantity(show_energy).to(self.reco_energy.unit).value
             ax.hlines(ener_val, 0, 200200, linestyles='dashed')
 
-        ax.set_xlabel('True energy (TeV)')
-        ax.set_ylabel('Reco energy (TeV)')
+        if add_cbar:
+            label = 'Probability density (A.U.)'
+            cbar = ax.figure.colorbar(caxes, ax=ax, label=label)
 
+        ax.set_xlabel('True energy ({unit})'.format(unit=x.unit))
+        ax.set_ylabel('Reco energy ({unit})'.format(unit=y.unit))
         ax.set_xscale('log')
         ax.set_yscale('log')
-
         return ax
 
     def plot_bias(self, ax=None, **kwargs):
@@ -611,7 +619,7 @@ class EnergyDispersion2D(object):
                            interpolation_mode='linear', name='offset')
         ]
         self.data = NDDataArray(axes=axes, data=data,
-                                interp_kwargs=interp_kwargs)                       
+                                interp_kwargs=interp_kwargs)
 
     @property
     def e_true(self):

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -371,7 +371,6 @@ class PSF3D(object):
 
         ax = plt.gca() if ax is None else ax
 
-
         energy = self.energy_logcenter()
         offset = self.offset
 
@@ -384,13 +383,13 @@ class PSF3D(object):
         kwargs.setdefault('vmax', np.nanmax(containment.value))
 
         # Plotting
-        caxes = ax.pcolormesh(offset.value, energy.value,
-                              containment.value, **kwargs)
+        caxes = ax.pcolormesh(energy.value, offset.value,
+                              containment.value.T, **kwargs)
 
         # Axes labels and ticks, colobar
-        ax.semilogy()
-        ax.set_xlabel('Offset ({unit})'.format(unit=offset.unit))
-        ax.set_ylabel('Energy ({unit})'.format(unit=energy.unit))
+        ax.semilogx()
+        ax.set_ylabel('Offset ({unit})'.format(unit=offset.unit))
+        ax.set_xlabel('Energy ({unit})'.format(unit=energy.unit))
 
         if show_safe_energy:
             self._plot_safe_energy_range(ax)

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -243,50 +243,48 @@ class EnergyDependentMultiGaussPSF(object):
         add_cbar : bool
             Add a colorbar
         """
-        from matplotlib.colors import PowerNorm
         import matplotlib.pyplot as plt
+
         ax = plt.gca() if ax is None else ax
 
-        kwargs.setdefault('cmap', 'afmhot')
-        kwargs.setdefault('norm', PowerNorm(gamma=0.5))
-        kwargs.setdefault('origin', 'lower')
-        kwargs.setdefault('interpolation', 'nearest')
-        # kwargs.setdefault('vmin', 0.1)
-        # kwargs.setdefault('vmax', 0.2)
+        energy = self.energy_hi
+        offset = self.theta
 
         # Set up and compute data
-        containment = self.containment_radius(self.energy_hi, self.theta, fraction)
+        containment = self.containment_radius(energy, offset, fraction)
 
-        extent = [
-            self.theta[0].value, self.theta[-1].value,
-            self.energy_lo[0].value, self.energy_hi[-1].value,
-        ]
+        # plotting defaults
+        kwargs.setdefault('cmap', 'GnBu')
+        kwargs.setdefault('vmin', np.nanmin(containment.value))
+        kwargs.setdefault('vmax', np.nanmax(containment.value))
 
         # Plotting
-        ax.imshow(containment.T.value, extent=extent, **kwargs)
-
-        if show_safe_energy:
-            # Log scale transformation for position of energy threshold
-            e_min = self.energy_hi.value.min()
-            e_max = self.energy_hi.value.max()
-            e = (self.energy_thresh_lo.value - e_min) / (e_max - e_min)
-            x = (np.log10(e * (e_max / e_min - 1) + 1) / np.log10(e_max / e_min)
-                 * (len(self.energy_hi) + 1))
-            ax.vlines(x, -0.5, len(self.theta) - 0.5)
-            ax.text(x + 0.5, 0, 'Safe energy threshold: {0:3.2f}'.format(self.energy_thresh_lo))
+        caxes = ax.pcolormesh(energy.value, offset.value,
+                              containment.value, **kwargs)
 
         # Axes labels and ticks, colobar
-        ax.semilogy()
-        ax.set_xlabel('Offset (deg)')
-        ax.set_ylabel('Energy (TeV)')
+        ax.semilogx()
+        ax.set_ylabel('Offset ({unit})'.format(unit=offset.unit))
+        ax.set_xlabel('Energy ({unit})'.format(unit=energy.unit))
+
+        if show_safe_energy:
+            self._plot_safe_energy_range(ax)
 
         if add_cbar:
-            ax_cbar = plt.colorbar(fraction=0.1, pad=0.01, shrink=0.9,
-                                   mappable=ax.images[0], ax=ax)
-            label = 'Containment radius R{0:.0f} (deg)'.format(100 * fraction)
-            ax_cbar.set_label(label)
+            label = 'Containment radius R{0:.0f} ({1})'.format(100 * fraction,
+                                                               containment.unit)
+            cbar = ax.figure.colorbar(caxes, ax=ax, label=label)
 
         return ax
+
+    def _plot_safe_energy_range(self, ax):
+        """add safe energy range lines to the plot"""
+        esafe = self.energy_thresh_lo
+        omin = self.offset.value.min()
+        omax = self.offset.value.max()
+        ax.hlines(y=esafe.value, xmin=omin, xmax=omax)
+        label = 'Safe energy threshold: {0:3.2f}'.format(esafe)
+        ax.text(x=0.1, y=0.9 * esafe.value, s=label, va='top')
 
     def plot_containment_vs_energy(self, fractions=[0.68, 0.95],
                                    thetas=Angle([0, 1], 'deg'), ax=None, **kwargs):

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -33,7 +33,7 @@ def test_EffectiveAreaTable2D(tmpdir):
     test_val = aeff.data.evaluate(energy=test_e, offset=test_o)
     assert_allclose(test_val.value, 740929.645, atol=1e-2)
 
-    aeff.plot_image()
+    aeff.plot()
     aeff.plot_energy_dependence()
     aeff.plot_offset_dependence()
 


### PR DESCRIPTION
In #823 we agreed it is a good solution to change the plotting of IRFs from ´plt.imshow()´ to `plt.pcolormesh()`, because is correctly handles log axes and calls to `plt.xlim()` etc.

Further changes:
* changed the default colormap for this plots from `afmhot` to the more neutral  `GnBu`
* remove any resampling of data for the plotting. All IRFs are now plotted with the binning defined by the data.

Just for the record:
When saved to pdf the plot created with `plt.pcolormesh()` is rendered as set of rectangles. The behaviour can be changed by calling  `plt.pcolormesh(..., rasterized=True)`.