### PR TITLE
Extend SkyCube.empty_like() method

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -221,9 +221,7 @@ class SkyCube(object):
         
         Examples
         --------
-        Create an empty sky cube:
-
-        .. code::
+        Create an empty sky cube::
 
             from gammapy.cube import SkyCube
             cube = SkyCube.empty(nxpix=11, nypix=7, enumbins=3, mode='center',
@@ -258,36 +256,28 @@ class SkyCube(object):
         ----------
         reference : `~gammapy.cube.SkyCube` or `~gammapy.image.SkyImage`
             Reference sky cube or image.
-        energies : `~gammapy.utils.Energy` or `~gammapy.utils.EnergyBounds` (optional)
+        energies : `~gammapy.utils.energy.Energy` or `~gammapy.utils.energy.EnergyBounds` (optional)
             Reference energies, mandatory when a `~gammapy.image.SkyImage` is passed.
         fill : float
             Value to fill the data array with.
 
         Examples
         --------
-        Create an empty sky cube from an image and energy center specification:
+        Create an empty sky cube from an image and energy center specification::
         
-        .. code::
-
             from astropy import units as u
             from gammapy.image import SkyImage
             from gammapy.cube import SkyCube
-            from gammapy.utils.energy import Energy
+            from gammapy.utils.energy import Energy, EnergyBounds
 
+            # define reference image
             image = SkyImage.empty(nxpix=11, nypix=7)
+            
+            # define energy binning centers 
             energies = Energy.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 3)
             cube = SkyCube.empty_like(reference=image, energies=energies)
 
-        Create an empty sky cube from an image and energy bounds specification:
-
-        .. code::
-
-            from astropy import units as u
-            from gammapy.image import SkyImage
-            from gammapy.cube import SkyCube
-            from gammapy.utils.energy import EnergyBounds
-
-            image = SkyImage.empty(nxpix=11, nypix=7)
+            # define energy binning bounds
             energies = EnergyBounds.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 3)
             cube = SkyCube.empty_like(reference=image, energies=energies)
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -218,6 +218,22 @@ class SkyCube(object):
         kwargs : dict
             Keyword arguments passed to `~gammapy.image.SkyImage.empty` to create
             the spatial part of the cube.
+        
+        Examples
+        --------
+        Create an empty sky cube:
+
+        .. code::
+
+            from gammapy.cube import SkyCube
+            cube = SkyCube.empty(nxpix=11, nypix=7, enumbins=3, mode='center',
+                            emin=1, emax=100, eunit='TeV')
+
+        Returns
+        -------
+        empty_cube : `SkyCube`
+            Empty sky cube object.    
+
         """
         image = SkyImage.empty(**kwargs)
 
@@ -246,6 +262,35 @@ class SkyCube(object):
             Reference energies, mandatory when a `~gammapy.image.SkyImage` is passed.
         fill : float
             Value to fill the data array with.
+
+        Examples
+        --------
+        Create an empty sky cube from an image and energy center specification:
+        
+        .. code::
+
+            from astropy import units as u
+            from gammapy.image import SkyImage
+            from gammapy.cube import SkyCube
+            from gammapy.utils.energy import Energy
+
+            image = SkyImage.empty(nxpix=11, nypix=7)
+            energies = Energy.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 3)
+            cube = SkyCube.empty_like(reference=image, energies=energies)
+
+        Create an empty sky cube from an image and energy bounds specification:
+
+        .. code::
+
+            from astropy import units as u
+            from gammapy.image import SkyImage
+            from gammapy.cube import SkyCube
+            from gammapy.utils.energy import EnergyBounds
+
+            image = SkyImage.empty(nxpix=11, nypix=7)
+            energies = EnergyBounds.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 3)
+            cube = SkyCube.empty_like(reference=image, energies=energies)
+
 
         Returns
         -------

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -17,6 +17,7 @@ from ...spectrum.models import PowerLaw2
 from .. import SkyCube, compute_npred_cube
 
 
+@requires_dependency('scipy')
 def test_empty_like_energy():
     image = SkyImage.empty(nxpix=11, nypix=7)
     energies = Energy.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 3)
@@ -26,6 +27,8 @@ def test_empty_like_energy():
                             emin=1, emax=100, eunit='TeV')
     SkyCube.assert_allclose(actual, desired)
 
+
+@requires_dependency('scipy')
 def test_empty_like_energy_bounds():
     image = SkyImage.empty(nxpix=11, nypix=7)
     energies = EnergyBounds.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 4)

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -9,11 +9,31 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 
 from ...utils.testing import requires_dependency, requires_data
+from ...utils.energy import Energy, EnergyBounds
 from ...image import SkyImage
 from ...data import EventList
 from ...datasets import FermiGalacticCenter, FermiVelaRegion
 from ...spectrum.models import PowerLaw2
 from .. import SkyCube, compute_npred_cube
+
+
+def test_empty_like_energy():
+    image = SkyImage.empty(nxpix=11, nypix=7)
+    energies = Energy.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 3)
+    actual = SkyCube.empty_like(reference=image, energies=energies)
+
+    desired = SkyCube.empty(nxpix=11, nypix=7, enumbins=3, mode='center',
+                            emin=1, emax=100, eunit='TeV')
+    SkyCube.assert_allclose(actual, desired)
+
+def test_empty_like_energy_bounds():
+    image = SkyImage.empty(nxpix=11, nypix=7)
+    energies = EnergyBounds.equal_log_spacing(1 * u.TeV, 100 * u.TeV, 4)
+    actual = SkyCube.empty_like(reference=image, energies=energies)
+
+    desired = SkyCube.empty(nxpix=11, nypix=7, enumbins=4, mode='edges',
+                            emin=1, emax=100, eunit='TeV')
+    SkyCube.assert_allclose(actual, desired)
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -50,7 +50,7 @@ class SkyImage(object):
     _AxisIndex = namedtuple('AxisIndex', ['x', 'y'])
     _ax_idx = _AxisIndex(x=1, y=0)
 
-    def __init__(self, name=None, data=None, wcs=None, unit=u.Unit(''), meta=None):
+    def __init__(self, name=None, data=None, wcs=None, unit='', meta=None):
         # TODO: validate inputs
         self.name = name
         self.data = data
@@ -61,7 +61,7 @@ class SkyImage(object):
         else:
             self.meta = OrderedDict(meta)
 
-        self.unit = unit
+        self.unit = u.Unit(unit)
 
     @property
     def center_pix(self):
@@ -127,7 +127,7 @@ class SkyImage(object):
             # Validate unit string
             unit = u.Unit(header['BUNIT'], format='fits').to_string()
         except (KeyError, ValueError):
-            unit = None
+            unit = ''
 
         meta = OrderedDict(header)
 
@@ -152,7 +152,7 @@ class SkyImage(object):
     @classmethod
     def empty(cls, name=None, nxpix=200, nypix=200, binsz=0.02, xref=0, yref=0,
               fill=0, proj='CAR', coordsys='GAL', xrefpix=None, yrefpix=None,
-              dtype='float64', unit=None, meta=None):
+              dtype='float64', unit='', meta=None):
         """
         Create an empty image from scratch.
 
@@ -189,7 +189,7 @@ class SkyImage(object):
             Coordinate system reference pixel for y axis. Default is None.
         dtype : str, optional
             Data type, default is float32
-        unit : str
+        unit : str or `~astropy.units.Unit`
             Data unit.
         meta : `~collections.OrderedDict`
             Meta data attached to the image.
@@ -206,7 +206,7 @@ class SkyImage(object):
         return cls(name=name, data=data, wcs=wcs, unit=unit, meta=header)
 
     @classmethod
-    def empty_like(cls, image, name=None, unit=None, fill=0, meta=None):
+    def empty_like(cls, image, name=None, unit='', fill=0, meta=None):
         """
         Create an empty image like the given image.
 

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -384,10 +384,10 @@ class ImageProfileEstimator(object):
         result['x_min'] = x_edges[:-1]
         result['x_max'] = x_edges[1:]
         result['x_ref'] = (x_edges[:-1] + x_edges[1:]) / 2
-        result['profile'] = profile * u.Unit(image.unit)
+        result['profile'] = profile * image.unit
 
         if profile_err is not None:
-            result['profile_err'] = profile_err * u.Unit(image.unit)
+            result['profile_err'] = profile_err * image.unit
 
         result.meta['PROFILE_TYPE'] = p['axis']
         return ImageProfile(result)

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -159,7 +159,7 @@ class TestSkyImagePoisson:
         refstring += "Name: None\n"
         refstring += "Data shape: (200, 200)\n"
         refstring += "Data type: >i4\n"
-        refstring += "Data unit: None\n"
+        refstring += "Data unit: \n"
         refstring += "Data mean: 1.022e+00\n"
         refstring += "WCS type: ['GLON-CAR', 'GLAT-CAR']\n"
         assert str(self.image) == refstring


### PR DESCRIPTION
This PR addresses issue #905. A `SkyCube` object can now be created from a reference image and an energy specification as well. See docstring examples.