### PR TITLE
fix cube_pipe test

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -301,13 +301,13 @@ class SkyCube(object):
                 raise ValueError("'energies' must be instance of Energy or EnergyBounds, "
                                  "but {} was given.".format(type(energies)))
             energy_axis = LogEnergyAxis(energies, mode=mode)
-            data = np.ones_like(reference.data)
+            data = np.ones_like(reference.data.value)
             data = data * np.ones(enumbins).reshape((-1, 1, 1))
 
         elif isinstance(reference, SkyCube):
             unit = reference.data.unit
             energy_axis = reference.energy_axis
-            data = np.ones_like(reference.data)
+            data = np.ones_like(reference.data.value)
 
         else:
             raise ValueError("'reference' must be instance of SkyImage or SkyCube")
@@ -407,7 +407,6 @@ class SkyCube(object):
         ehi = energies[1:]
         n_ebins = len(elo)
         if dstype == 'Data3DInt':
-
             coordinates = self.sky_image_ref.coordinates(mode="edges")
             ra = coordinates.data.lon.degree
             dec = coordinates.data.lat.degree
@@ -418,8 +417,8 @@ class SkyCube(object):
             elo_cube = elo.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra[0:-1, 0:-1]) * u.TeV
             return Data3DInt('', elo_cube.ravel(), ra_cube_lo.ravel(), dec_cube_lo.ravel(), ehi_cube.ravel(),
-                                 ra_cube_hi.ravel(), dec_cube_hi.ravel(), self.data.value.ravel(),
-                                 self.data.value.ravel().shape)
+                             ra_cube_hi.ravel(), dec_cube_hi.ravel(), self.data.value.ravel(),
+                             self.data.value.ravel().shape)
 
         if dstype == 'Data3D':
             coordinates = self.sky_image_ref.coordinates()
@@ -430,8 +429,8 @@ class SkyCube(object):
             elo_cube = elo.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
             ehi_cube = ehi.reshape(n_ebins, 1, 1) * np.ones_like(ra) * u.TeV
             return Data3D('', elo_cube.ravel(), ehi_cube.ravel(), ra_cube.ravel(),
-                              dec_cube.ravel(), self.data.value.ravel(),
-                              self.data.value.ravel().shape)
+                          dec_cube.ravel(), self.data.value.ravel(),
+                          self.data.value.ravel().shape)
 
         else:
             raise ValueError('Invalid sherpa data type.')

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -247,7 +247,7 @@ class SkyCube(object):
         return cls(data=data, wcs=image.wcs, energy_axis=energy_axis)
 
     @classmethod
-    def empty_like(cls, reference, energies=None, fill=0):
+    def empty_like(cls, reference, energies=None, unit='', fill=0):
         """
         Create an empty sky cube with the same WCS and energy specification
         as given reference.
@@ -258,6 +258,8 @@ class SkyCube(object):
             Reference sky cube or image.
         energies : `~gammapy.utils.energy.Energy` or `~gammapy.utils.energy.EnergyBounds` (optional)
             Reference energies, mandatory when a `~gammapy.image.SkyImage` is passed.
+        unit : str
+            String specifying the data units.
         fill : float
             Value to fill the data array with.
 
@@ -290,7 +292,6 @@ class SkyCube(object):
         wcs = reference.wcs.copy()
 
         if isinstance(reference, SkyImage):
-            unit = reference.unit
             if type(energies) == Energy:
                 mode = 'center'
                 enumbins = len(energies)
@@ -301,11 +302,10 @@ class SkyCube(object):
                 raise ValueError("'energies' must be instance of Energy or EnergyBounds, "
                                  "but {} was given.".format(type(energies)))
             energy_axis = LogEnergyAxis(energies, mode=mode)
-            data = np.ones_like(reference.data.value)
+            data = np.ones_like(reference.data)
             data = data * np.ones(enumbins).reshape((-1, 1, 1))
 
         elif isinstance(reference, SkyCube):
-            unit = reference.data.unit
             energy_axis = reference.energy_axis
             data = np.ones_like(reference.data.value)
 

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -53,7 +53,7 @@ class SingleObsCubeMaker(object):
         self.bkg_cube = SkyCube.empty_like(empty_cube_images)
         self.significance_cube = SkyCube.empty_like(empty_cube_images)
         self.excess_cube = SkyCube.empty_like(empty_cube_images)
-        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube, unit='m2 s')
+        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube)
 
         self.obs_id = obs.obs_id
         events = obs.events
@@ -203,7 +203,7 @@ class StackedObsCubeMaker(object):
         self.bkg_cube = SkyCube.empty_like(empty_cube_images)
         self.significance_cube = SkyCube.empty_like(empty_cube_images)
         self.excess_cube = SkyCube.empty_like(empty_cube_images)
-        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube, unit='m2 s')
+        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube)
 
         self.data_store = data_store
         self.obs_table = obs_table
@@ -270,8 +270,7 @@ class StackedObsCubeMaker(object):
         """Compute excess cube between counts and bkg cube."""
         self.excess_cube.data = self.counts_cube.data - self.bkg_cube.data
 
-
-    #Define a method for the mean psf from a list of observation
+    # Define a method for the mean psf from a list of observation
     def make_mean_psf_cube(self, ref_cube, spectral_index=2.3):
         """
         Compute the mean psf for a set of observation for different energy bands

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -53,7 +53,7 @@ class SingleObsCubeMaker(object):
         self.bkg_cube = SkyCube.empty_like(empty_cube_images)
         self.significance_cube = SkyCube.empty_like(empty_cube_images)
         self.excess_cube = SkyCube.empty_like(empty_cube_images)
-        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube)
+        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube, unit="m2 s")
 
         self.obs_id = obs.obs_id
         events = obs.events
@@ -203,7 +203,7 @@ class StackedObsCubeMaker(object):
         self.bkg_cube = SkyCube.empty_like(empty_cube_images)
         self.significance_cube = SkyCube.empty_like(empty_cube_images)
         self.excess_cube = SkyCube.empty_like(empty_cube_images)
-        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube)
+        self.exposure_cube = SkyCube.empty_like(empty_exposure_cube, unit="m2 s")
 
         self.data_store = data_store
         self.obs_table = obs_table


### PR DESCRIPTION
@cdeil @adonath 
The cube pipe class was broken. Since there was an xfail on the test, nobody noticed ....
I fixed the issue with the exposure unit and I fix the test. I have to change the ```empy_like``` method of the ```SkyCube```class but I think there was a mistake. Indeed when you were creating the Skycube at the end if the data have unit you multiply again by u.unit so there was an issue for the exposure because it was in m4s-2 when you were calling empty_like....

I had to change the value for the total exposure in the test, this is not a big change but I don't know exactly why....