### PR TITLE
Add light curve computation

### DIFF
--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -4,11 +4,15 @@ Lightcurve and elementary temporal functions
 """
 from astropy.table import QTable
 from astropy.units import Quantity
+from astropy.time import Time
 import astropy.units as u
 import numpy as np
 
+from ..spectrum.utils import calculate_predicted_counts
+
 __all__ = [
     'LightCurve',
+    'LightCurveFactory',
 ]
 
 
@@ -112,3 +116,249 @@ class LightCurve(QTable):
         fvar_err = sigxserr / (2 * fvar)
 
         return fvar, fvar_err
+
+
+class LightCurveFactory(object):
+    """
+    Class producing light curve
+
+    Parameters
+    ----------
+    spectral_extraction: `~gammapy.spectrum.SpectrumExtraction`
+       class storing statistics, IRF and event lists
+    """
+
+    def __init__(self, spectral_extraction):
+        self.obs_list = spectral_extraction.obs
+        self.obs_spec = spectral_extraction.observations
+        self.off_evt_list = self._get_off_evt_list(spectral_extraction)
+        self.on_evt_list = self._get_on_evt_list(spectral_extraction)
+
+        
+    def _get_off_evt_list(self, spectral_extraction):
+        """
+        Returns list of OFF events for each observations
+        """
+        off_evt_list = []
+        for bg in spectral_extraction.background:
+            off_evt_list.append(bg.off_events)
+        return off_evt_list
+
+    
+    def _get_on_evt_list(self, spectral_extraction):
+        """
+        Returns list of OFF events for each observations
+        """
+        on_region = spectral_extraction.target.on_region
+        on_evt_list = []
+        for obs in spectral_extraction.obs:
+            idx = on_region.contains(obs.events.radec)
+            on_evt_list.append(obs.events.select_row_subset(idx))
+            
+        return on_evt_list
+    
+            
+    def _get_time_intervals(self, t_start, t_stop, time_binning_type):
+        """
+        Compute time intervals needed for a light curve
+
+        Parameters
+        ----------
+        time_start: `~astropy.units.Quantity`
+            start time to integrate events
+        time_stop: `~astropy.units.Quantity`
+            start time to integrate events
+        time_binning_type: `str`
+            type of time binning (e.g. obs, minute, hour, night, day, month, user)
+        """
+
+        dt = None
+        n_dt = None
+        intervals = []
+        if time_binning_type == 'obs':
+            n_dt = len(self.obs_list)
+            for obs in self.obs_list:
+                # for now use time of first and last evt to define the interval
+                # intervals.append([obs.tstart, obs.tstop])
+                intervals.append([obs.events.time[0], obs.events.time[-1]])
+        else:
+            raise NotImplementedError
+
+        return intervals
+
+    
+    def light_curve(self, t_start, t_stop, t_binning_type,
+                    spectral_model, energy_range, binning=None):
+        """
+        Function returning light curve for given parameters
+        
+        Parameters
+        ----------
+        t_start: `~astropy.units.Quantity`
+            start time to integrate events
+        t_stop: `~astropy.units.Quantity`
+            start time to integrate events
+        t_binning_type: `str`
+            type of time binning (e.g. obs, minute, hour, night, day, month, user)
+        spectral_model: `~gammapy.spectrum.models.SpectralModel`
+            spectral model
+        energy_range: `~astropy.units.Quantity`
+            true energy range to evaluate integrated flux (true energy)
+        binning: `~astropy.units.Quantity` 
+            bining 
+        """
+
+        # create time intervals
+        if binning == 'user':
+            t_intervals = binning
+        else:
+            t_intervals = self._get_time_intervals(t_start,
+                                                   t_stop,
+                                                   t_binning_type)
+
+        lc_flux = []
+        lc_flux_err = []
+        lc_tmin = []
+        lc_tmax = []
+            
+        # Loop on time intervals
+        for t_bin in t_intervals:
+            interval_tmin, interval_tmax = t_bin[0], t_bin[1]
+
+            interval_livetime = 0
+            interval_alpha_mean = 0.
+            interval_alpha_mean_backup = 0.
+
+            interval_measured_excess = 0
+            interval_predicted_excess = 0
+            interval_off = 0
+            interval_on = 0
+            
+            # Loop on observations
+            for t_index, obs in enumerate(self.obs_list):
+
+                spec = self.obs_spec[t_index]
+
+                obs_on = 0
+                obs_off = 0
+                obs_measured_excess = 0
+                obs_predicted_excess = 0
+                
+                # discard observations not matching the time interval
+                obs_start = obs.events.time[0]
+                obs_stop = obs.events.time[-1]
+                if ( (interval_tmin < obs_start and interval_tmax < obs_start)
+                     or interval_tmin > obs_stop ):
+                    continue
+
+                # print('## t_index={}, obs={}'.format(t_index, obs.obs_id))
+                
+                # get ON and OFF evt list
+                off_evt = self.off_evt_list[t_index]
+                on_evt = self.on_evt_list[t_index]
+                
+                # Loop on energy bins
+                for e_index in range(len(spec.e_reco)-1):
+                    emin = spec.e_reco[e_index]
+                    emax = spec.e_reco[e_index+1]
+
+                    # discard bins not matching the energy threshold
+                    if emin < spec.lo_threshold or emax > spec.hi_threshold:
+                        continue
+
+                    # Loop on ON evts (time and energy)
+                    on = on_evt.select_energy([emin, emax])
+                    on = on.select_time([interval_tmin, interval_tmax])
+                    # print('on={}'.format(len(on.table)))
+                    obs_on += len(on.table)
+
+                    # Loop on OFF evts
+                    off = off_evt.select_energy([emin, emax])
+                    off = off.select_time([interval_tmin, interval_tmax])
+                    # print('off={}'.format(len(off.table)))
+                    obs_off += len(off.table)
+                    
+                # compute effective livetime (for the interval)
+                livetime_to_add = 0.
+                # interval included in obs
+                if interval_tmin >= obs_start and interval_tmax <= obs_stop:
+                    livetime_to_add = (interval_tmax - interval_tmin).to('s')
+                # interval min above tstart from obs
+                elif interval_tmin >= obs_start and interval_tmax >= obs_stop:
+                    livetime_to_add = (obs_stop - interval_tmin).to('s')
+                # interval min below tstart from obs
+                elif interval_tmin <= obs_start and interval_tmax <= obs_stop:
+                    livetime_to_add = (interval_tmax - obs_start).to('s')
+                # obs included in interval
+                elif interval_tmin <= obs_start and interval_tmax >= obs_stop:
+                    livetime_to_add = (obs_stop - obs_start).to('s')
+                else:
+                    pass
+
+                # Take into account dead time
+                livetime_to_add *= (1. - obs.observation_dead_time_fraction)
+                
+                # Compute excess
+                obs_measured_excess = obs_on - spec.alpha * obs_off
+
+                # Compute expected excess
+                # We use the effective livetime and the right energy threshold
+                e_idx = np.where(np.logical_and(spec.e_reco>=spec.lo_threshold,
+                                                spec.e_reco<=spec.hi_threshold))
+                counts_predicted_excess = calculate_predicted_counts(livetime=livetime_to_add,
+                                                                     aeff=spec.aeff,
+                                                                     edisp=spec.edisp,
+                                                                     model=spectral_model,
+                                                                     e_reco=spec.e_reco[e_idx])
+                obs_predicted_excess = np.sum(counts_predicted_excess.data.data)
+                obs_predicted_excess /= obs.observation_live_time_duration.to('s').value
+                obs_predicted_excess *= livetime_to_add.value
+
+                # compute effective normalisation between ON/OFF (for the interval)
+                interval_livetime += livetime_to_add
+                interval_alpha_mean += spec.alpha * obs_off
+                interval_alpha_mean_backup += spec.alpha * livetime_to_add
+                interval_measured_excess += obs_measured_excess
+                interval_predicted_excess += obs_predicted_excess
+                interval_on += obs_on
+                interval_off += obs_off
+                
+            # Fill time interval information
+            int_flux = spectral_model.integral(energy_range[0], energy_range[1])
+            if interval_off > 0.:
+                interval_alpha_mean /= interval_off
+            if interval_livetime > 0.:
+                interval_alpha_mean_backup /= interval_livetime
+
+            if interval_alpha_mean == 0.:  # use backup if necessary
+                interval_alpha_mean = interval_alpha_mean_backup
+
+            interval_flux = interval_measured_excess / interval_predicted_excess.value
+            interval_flux *= int_flux
+            interval_flux_error = int_flux / interval_measured_excess
+            # Gaussian errors, ToDo: should be improved
+            interval_flux_error *= np.sqrt(interval_on + interval_alpha_mean**2 * interval_off)
+
+            print('### start:{}, stop:{}'.format(interval_tmin, interval_tmax))
+            print('LIVETIME={}'.format(interval_livetime))
+            print('ALPHA={}'.format(interval_alpha_mean))
+            print('ON={}'.format(interval_on))
+            print('OFF={}'.format(interval_off))
+            print('EXCESS={}'.format(interval_measured_excess))
+            print('EXP. EXCESS={}'.format(interval_predicted_excess))
+            print('FLUX={}'.format(interval_flux))
+            print('FLUX_ERR={}'.format(interval_flux_error))
+
+            lc_flux.append(interval_flux.value)
+            lc_flux_err.append(interval_flux_error.value)
+            lc_tmin.append(interval_tmin.value)
+            lc_tmax.append(interval_tmax.value)
+            
+        # Fill light curve data 
+        lc = LightCurve()
+        lc['FLUX'] = lc_flux * u.Unit('1 / (s cm2)')
+        lc['FLUX_ERR'] = lc_flux_err * u.Unit('1 / (s cm2)')
+        lc['TIME_MIN'] = Time(lc_tmin, format='mjd')
+        lc['TIME_MAX'] = Time(lc_tmax, format='mjd')
+        
+        return lc

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -314,17 +314,6 @@ class LightCurveEstimator(object):
                                                 n_off=interval_off,
                                                 alpha=interval_alpha_mean)
             
-
-            print('### start:{}, stop:{}'.format(interval_tmin, interval_tmax))
-            print('LIVETIME={}'.format(interval_livetime))
-            print('ALPHA={}'.format(interval_alpha_mean))
-            print('ON={}'.format(interval_on))
-            print('OFF={}'.format(interval_off))
-            print('EXCESS={}'.format(interval_measured_excess))
-            print('EXP. EXCESS={}'.format(interval_predicted_excess))
-            print('FLUX={}'.format(interval_flux))
-            print('FLUX_ERR={}'.format(interval_flux_error))
-
             lc_flux.append(interval_flux.value)
             lc_flux_err.append(interval_flux_error.value)
             lc_tmin.append(interval_tmin.value)

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -46,16 +46,16 @@ class LightCurve(QTable):
         import matplotlib.pyplot as plt
         ax = plt.gca() if ax is None else ax
 
-        tstart = self['TIME_MIN'].to('s')
-        tstop = self['TIME_MAX'].to('s')
-        time = (tstart + tstop) / 2.0
+        tstart = self['TIME_MIN']
+        tstop = self['TIME_MAX']
+        time = (tstart.value + tstop.value) / 2.0
         flux = self['FLUX'].to('cm-2 s-1')
         errors = self['FLUX_ERR'].to('cm-2 s-1')
 
-        ax.errorbar(time.value, flux.value,
+        ax.errorbar(time, flux.value,
                     yerr=errors.value, linestyle="None")
         ax.scatter(time, flux)
-        ax.set_xlabel("Time (secs)")
+        ax.set_xlabel("Time (MJD)")
         ax.set_ylabel("Flux ($cm^{-2} sec^{-1}$)")
 
         return ax
@@ -68,8 +68,8 @@ class LightCurve(QTable):
         """
         lc = cls()
 
-        lc['TIME_MIN'] = [1, 4, 7, 9] * u.s
-        lc['TIME_MAX'] = [1, 4, 7, 9] * u.s
+        lc['TIME_MIN'] = Time([1, 4, 7, 9], format='mjd')
+        lc['TIME_MAX'] = Time([1, 4, 7, 9], format='mjd')
         lc['FLUX'] = Quantity([1, 4, 7, 9], 'cm^-2 s^-1')
         lc['FLUX_ERR'] = Quantity([0.1, 0.4, 0.7, 0.9], 'cm^-2 s^-1')
 

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -2,6 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
 from astropy.tests.helper import assert_quantity_allclose, pytest
+from regions import CircleSkyRegion
+from astropy.time import Time
+import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data
 from ..lightcurve import LightCurve, LightCurveEstimator
 from numpy.testing import assert_allclose
@@ -10,9 +13,7 @@ from ...spectrum import SpectrumExtraction
 from ...spectrum.models import PowerLaw
 from ...data import Target, DataStore
 from ...image import SkyMask
-from regions import CircleSkyRegion
-from astropy.time import Time
-import astropy.units as u
+from ...utils.energy import EnergyBounds
 
 def test_lightcurve():
     lc = LightCurve.simulate_example()
@@ -60,11 +61,14 @@ def spec_extraction():
         method='reflected',
         exclusion=exclusion_mask,
     )
-    
+    e_reco = EnergyBounds.equal_log_spacing(0.2, 100, 50, unit='TeV') # fine binning
+    e_true = EnergyBounds.equal_log_spacing(0.05, 100, 200, unit='TeV')
     extraction = SpectrumExtraction(target=target,
                                     obs=obs_list,
                                     background=bkg_estimation,
-                                    containment_correction=True)
+                                    containment_correction=True,
+                                    e_reco=e_reco,
+                                    e_true=e_true)
     extraction.estimate_background(extraction.background)
     extraction.define_energy_threshold('area_max', percent=10.0)
     return extraction
@@ -80,7 +84,6 @@ def test_lightcurve_estimator():
     intervals = []
     for obs in spec_extract.obs:
         intervals.append([obs.events.time[0], obs.events.time[-1]])
-    energy_range = [0.5, 10] * u.TeV
     model = PowerLaw(index=2.3 * u.Unit(''),
                      amplitude=3.4e-11 * u.Unit('1 / (cm2 s TeV)'),
                      reference=1 * u.TeV)
@@ -88,13 +91,22 @@ def test_lightcurve_estimator():
     # build the light curve
     lc = lc_factory.light_curve(time_intervals=intervals,
                                 spectral_model=model,
-                                energy_range=energy_range)
+                                energy_range=[0.5, 100] * u.TeV)
 
     # Test number of intervals
     assert_quantity_allclose(len(lc), 2)
     # Test flux values for the first and the last interval
-    assert_allclose(lc['FLUX'][0].value, 5.678899701403769e-11, rtol=1e-2)
-    assert_allclose(lc['FLUX'][-1].value, 6.047638325123559e-11, rtol=1e-2)
+    assert_allclose(lc['FLUX'][0].value, 5.70852574714e-11, rtol=1e-2)
+    assert_allclose(lc['FLUX'][-1].value, 6.16718031281e-11 , rtol=1e-2)
     # Test flux error values for the first and the last interval
-    assert_allclose(lc['FLUX_ERR'][0].value, 5.5262147103422505e-12, rtol=1e-2)
-    assert_allclose(lc['FLUX_ERR'][-1].value, 5.776966170949116e-12, rtol=1e-2)
+    assert_allclose(lc['FLUX_ERR'][0].value, 5.43450927144e-12, rtol=1e-2)
+    assert_allclose(lc['FLUX_ERR'][-1].value, 5.91581572415e-12, rtol=1e-2)
+
+    # same but with threshold equal to 2 TeV
+    lc = lc_factory.light_curve(time_intervals=intervals,
+                                spectral_model=model,
+                                energy_range=[2, 100] * u.TeV)
+
+    # Test flux values for the first and the last interval
+    assert_allclose(lc['FLUX'][0].value, 1.02122885108e-11, rtol=1e-2)
+    assert_allclose(lc['FLUX_ERR'][0].value, 1.43055726983e-12, rtol=1e-2)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -1,11 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
-from astropy.tests.helper import assert_quantity_allclose
-from ...utils.testing import requires_dependency
-from ..lightcurve import LightCurve
+from astropy.tests.helper import assert_quantity_allclose, pytest
+from ...utils.testing import requires_dependency, requires_data
+from ..lightcurve import LightCurve, LightCurveFactory
 from numpy.testing import assert_allclose
-
+from astropy.coordinates import SkyCoord, Angle
+from ...spectrum import SpectrumExtraction
+from ...spectrum.models import PowerLaw
+from ...data import Target, DataStore
+from ...image import SkyMask
+from regions import CircleSkyRegion
+from astropy.time import Time
+import astropy.units as u
 
 def test_lightcurve():
     lc = LightCurve.simulate_example()
@@ -28,3 +35,61 @@ def test_lightcurve_fvar():
 def test_lightcurve_plot():
     lc = LightCurve.simulate_example()
     lc.plot()
+
+
+@requires_data('gammapy-extra')
+@pytest.fixture(scope='session')
+def spec_extraction():
+    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    obs_ids = [23523, 23526, 23559, 23592]
+    obs_list = data_store.obs_list(obs_ids)
+    
+    target_position = SkyCoord(ra=83.63308,
+                               dec=22.01450,
+                               unit='deg',
+                               frame='icrs')
+    on_region_radius = Angle('0.11 deg')
+    on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)
+    target = Target(on_region=on_region, name='Crab', tag='ana_crab')
+
+    exclusion_file = '$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits'
+    allsky_mask = SkyMask.read(exclusion_file)
+    exclusion_mask = allsky_mask.cutout(
+        position=target.on_region.center,
+        size=Angle('6 deg'),
+    )
+    bkg_estimation = dict(
+        method='reflected',
+        exclusion=exclusion_mask,
+    )
+    
+    extraction = SpectrumExtraction(target=target,
+                                    obs=obs_list,
+                                    background=bkg_estimation,
+                                    containment_correction=True)
+    extraction.estimate_background(extraction.background)
+    extraction.define_energy_threshold('area_max', percent=10.0)
+    return extraction
+
+@requires_data('gammapy-extra')
+def test_lightcurvefactory():
+
+    lc_factory = LightCurveFactory(spec_extraction())
+
+    # param
+    t_start = Time(100.0, format='mjd')
+    t_stop = Time(100000.0, format='mjd')
+    energy_range = [0.5, 10] * u.TeV
+    model = PowerLaw(index=2.3 * u.Unit(''),
+                     amplitude=3.4e-11 * u.Unit('1 / (cm2 s TeV)'),
+                     reference=1 * u.TeV)
+
+    # build the light curve
+    lc = lc_factory.light_curve(t_start=t_start,
+                                t_stop=t_stop,
+                                t_binning_type='obs',
+                                spectral_model=model,
+                                energy_range=energy_range)
+
+    # ToDo, add real test when results are checked
+    assert_quantity_allclose(len(lc), 4)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -70,7 +70,8 @@ def spec_extraction():
     return extraction
 
 @requires_data('gammapy-extra')
-def test_lightcurvefactory():
+@requires_dependency('scipy')
+def test_lightcurve_estimator():
 
     spec_extract = spec_extraction()
     lc_factory = LightCurveEstimator(spec_extract)


### PR DESCRIPTION
Hi @cdeil, 
As we discussed, here is a first attempt to deal with light curves. Implementation follows closely what has been done in the the H.E.S.S. publication: http://adsabs.harvard.edu/abs/2010A%26A...520A..83H.

This PR: 
 - add a `LightCurveFactory` class
 - modify `LightCurve.plot` and `LightCurve.simulate` functions (I replaced seconds by MJD values)
 - add a small test (only checking the length of the output LightCurve object since values might change after checking that the results are okés)
++

PS: forgot to say that there is room for improvements, different time bining definitions (only run bye run, or user defined binning are implemented) and optimisation of the code, I guess I'm doing too much loops =)