### PR TITLE
Remove SkyImage.plot_norm() method

### DIFF
--- a/docs/irf/plot_fermi_psf.py
+++ b/docs/irf/plot_fermi_psf.py
@@ -1,6 +1,7 @@
 """Plot Fermi PSF."""
 import matplotlib.pyplot as plt
 from astropy import units as u
+from astropy.visualization import simple_norm
 from gammapy.datasets import FermiGalacticCenter
 from gammapy.irf import EnergyDependentTablePSF
 from gammapy.image import SkyImage
@@ -17,7 +18,7 @@ energies = [1] * u.GeV
 for energy in energies:
     psf = fermi_psf.table_psf_at_energy(energy=energy)
     image_psf.data = psf.kernel(image_psf)
-    norm = image_psf.plot_norm('log')
+    norm = simple_norm(image_psf.data, stretch='log')
     image_psf.plot(fig=fig, add_cbar=True, norm=norm)
 
 plt.show()

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -297,7 +297,7 @@ class StackedObsCubeMaker(object):
         for i_E, E in enumerate(energy_bins[0:-1]):
             energy_band = Energy([energy_bins[i_E].value, energy_bins[i_E + 1].value], energy_bins.unit)
             energy = EnergyBounds.equal_log_spacing(energy_band[0].value, energy_band[1].value, 100, energy_band.unit)
-            psf_energydependent = obslist.make_psf(center, energy, theta=None)
+            psf_energydependent = obslist.make_mean_psf(center, energy, theta=None)
             try:
                 psf_table = psf_energydependent.table_psf_in_energy_band(energy_band, spectral_index=spectral_index)
             except:

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -901,52 +901,6 @@ class SkyImage(object):
         ax.autoscale(enable=False)
         return fig, ax, cbar
 
-    def plot_norm(self, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
-                  max_cut=None, min_percent=None, max_percent=None,
-                  percent=None, clip=True):
-        """Create a matplotlib norm object for plotting.
-
-        This is a copy of this function that will be available in Astropy 1.3:
-        `astropy.visualization.mpl_normalize.simple_norm`
-
-        See the parameter description there!
-
-        Examples
-        --------
-        >>> image = SkyImage()
-        >>> norm = image.plot_norm(stretch='sqrt', max_percent=99)
-        >>> image.plot(norm=norm)
-        """
-        import astropy.visualization as v
-        from astropy.visualization.mpl_normalize import ImageNormalize
-
-        if percent is not None:
-            interval = v.PercentileInterval(percent)
-        elif min_percent is not None or max_percent is not None:
-            interval = v.AsymmetricPercentileInterval(min_percent or 0.,
-                                                      max_percent or 100.)
-        elif min_cut is not None or max_cut is not None:
-            interval = v.ManualInterval(min_cut, max_cut)
-        else:
-            interval = v.MinMaxInterval()
-
-        if stretch == 'linear':
-            stretch = v.LinearStretch()
-        elif stretch == 'sqrt':
-            stretch = v.SqrtStretch()
-        elif stretch == 'power':
-            stretch = v.PowerStretch(power)
-        elif stretch == 'log':
-            stretch = v.LogStretch()
-        elif stretch == 'asinh':
-            stretch = v.AsinhStretch(asinh_a)
-        else:
-            raise ValueError('Unknown stretch: {0}.'.format(stretch))
-
-        vmin, vmax = interval.get_limits(self.data)
-
-        return ImageNormalize(vmin=vmin, vmax=vmax, stretch=stretch, clip=clip)
-
     def info(self):
         """
         Print summary info about the image.


### PR DESCRIPTION
This PR removes the `SkyImage.plot_norm()` method and replaces all it's uses with Astropy's `simple_norm()`.