### PR TITLE
Fix SpectrumObservationStacker

### DIFF
--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -689,16 +689,20 @@ class SpectrumObservationStacker(object):
         """Stack `~gammapy.spectrum.PHACountsSpectrum`
 
         Bins outside the safe energy range are set to 0, attributes
-        are set to None.
+        are set to None. The quality vector of the observations are combined
+        with a logical or, such that the low (high) threshold of the stacked
+        obs is the minimum low (maximum high) threshold of the observation list
+        to be stacked.
         """
         template = counts_spectrum_list[0].copy()
         energy = template.energy
         stacked_data = np.zeros(energy.nbins)
-        stacked_quality = np.zeros(energy.nbins)
+        stacked_quality = np.ones(energy.nbins)
         for spec in counts_spectrum_list:
             stacked_data += spec.counts_in_safe_range
-            stacked_quality = np.logical_or(stacked_quality,
-                                            spec.quality)
+            temp = np.logical_and(stacked_quality,
+                                  spec.quality)
+            stacked_quality = np.array(temp, dtype=int)
 
         stacked_spectrum = PHACountsSpectrum(data=stacked_data,
                                              energy_lo=energy.lo,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -296,9 +296,9 @@ class TestSpectralFit:
         fit = SpectrumFit(obs_list, self.pwl)
         fit.fit()
         pars = fit.model.parameters
-        assert_quantity_allclose(pars['index'].value, 2.249406693574462) 
+        assert_quantity_allclose(pars['index'].value, 2.2134741433676934) 
         assert_quantity_allclose(pars['amplitude'].quantity,
-                                 2.4978415475815918e-11 * u.Unit('cm-2 s-1 TeV-1'))
+                                 2.3750588665654947e-11 * u.Unit('cm-2 s-1 TeV-1'))
 
     def test_run(self, tmpdir):
         fit = SpectrumFit(self.obs_list, self.pwl)

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -143,6 +143,8 @@ class TestSpectrumObservationStacker:
 
         # Change threshold to make stuff more interesting
         self.obs_list.obs(23523).lo_threshold = 1.2 * u.TeV
+        self.obs_list.obs(23592).hi_threshold = 20 * u.TeV
+        self.obs_list.obs(23523).hi_threshold = 50 * u.TeV
         self.obs_stacker = SpectrumObservationStacker(self.obs_list)
         self.obs_stacker.run()
 
@@ -153,6 +155,15 @@ class TestSpectrumObservationStacker:
         summed_counts = counts1 + counts2
         stacked_counts = self.obs_stacker.stacked_obs.total_stats.n_on
         assert summed_counts == stacked_counts
+
+    def test_thresholds(self):
+        actual = self.obs_stacker.stacked_obs.lo_threshold
+        desired = 599484250.319 * u.keV
+        assert_quantity_allclose(actual, desired)
+
+        actual = self.obs_stacker.stacked_obs.hi_threshold
+        desired = 46415888336.1 * u.keV
+        assert_quantity_allclose(actual, desired)
 
     def test_verify_npred(self):
         """Veryfing npred is preserved during the stacking"""


### PR DESCRIPTION
This fixes a bug reported by @JouvinLea via slack. The quality vector of the stacked spectrum observation was filled incorrectly (it only contained bins that where within the safe thresholds for *all* observations).

This PR fixes this and adds a test. This is very nice since now the stacked and the joint fit give exactly the same results in the unit tests :fireworks: 