### PR TITLE
make_base_catalog_galactic not passing random_state

### DIFF
--- a/docs/astro/source/plot_snr_brightness_evolution.py
+++ b/docs/astro/source/plot_snr_brightness_evolution.py
@@ -4,20 +4,20 @@ import matplotlib.pyplot as plt
 from astropy.units import Quantity
 from gammapy.astro.source import SNR
 
-densities = Quantity([1, 0.1], 'cm^-3')
+densities = Quantity([1, 0.1], 'cm-3')
 
 t = Quantity(np.logspace(0, 5, 100), 'yr')
 
 for density in densities:
     snr = SNR(n_ISM=density)
     F = snr.luminosity_tev(t) / (4 * np.pi * Quantity(1, 'kpc') ** 2)
-    plt.plot(t.value, F.to('ph s^-1 cm^-2').value, label='n_ISM = {0}'.format(density.value))
+    plt.plot(t.value, F.to('cm-2 s-1').value, label='n_ISM = {0}'.format(density.value))
     plt.vlines(snr.sedov_taylor_begin.to('yr').value, 1E-13, 1E-10, linestyle='--')
     plt.vlines(snr.sedov_taylor_end.to('yr').value, 1E-13, 1E-10, linestyle='--')
 plt.xlim(1E2, 1E5)
 plt.ylim(1E-13, 1E-10)
 plt.xlabel('time [years]')
-plt.ylabel('flux @ 1kpc [ph s^-1 cm ^-2]')
+plt.ylabel('flux @ 1kpc [s^-1 cm^-2]')
 plt.legend(loc=4)
 plt.loglog()
 plt.show()

--- a/docs/tutorials/catalog/simulated_image_demo.py
+++ b/docs/tutorials/catalog/simulated_image_demo.py
@@ -17,25 +17,17 @@ psf_file = FermiGalacticCenter.filenames()['psf']
 psf = EnergyDependentTablePSF.read(psf_file)
 
 # Simulation Parameters
-
-# source density at the sun (sources kpc^-1)
-rho_sun = 3
-# number of sources
 n_sources = int(5e2)
-# Spatial distribution using Lorimer (2006) model
-rad_dis = 'L06'
-# Velocity dispersion
-vel_dis = 'F06B'
-# Includes spiral arms
-spiralarms = True
-# Creates table
-table = population.make_base_catalog_galactic(n_sources=n_sources, rad_dis=rad_dis,
-                                              vel_dis=vel_dis, max_age=1e6,
-                                              spiralarms=spiralarms, random_state=0)
 
-# Minimum source luminosity (ph s^-1)
+table = population.make_base_catalog_galactic(
+    n_sources=n_sources, rad_dis='L06',
+    vel_dis='F06B', max_age=1e6,
+    spiralarms=True, random_state=0,
+)
+
+# Minimum source luminosity (s^-1)
 luminosity_min = 4e34
-# Maximum source luminosity (ph s^-1)
+# Maximum source luminosity (s^-1)
 luminosity_max = 4e37
 # Luminosity function differential power-law index
 luminosity_index = 1.5
@@ -47,7 +39,7 @@ table['luminosity'] = luminosity
 
 # Adds parameters to table: distance, glon, glat, flux, angular_extension
 table = population.add_observed_parameters(table)
-table.meta['Energy Bins'] = np.array([10, 500]) * u.GeV
+table.meta['Energy Bins'] = [10, 500] * u.GeV
 # Create image
 image = catalog_image(reference, psf, catalog='simulation', source_type='point',
                       total_flux=True, sim_table=table)
@@ -58,7 +50,7 @@ fig.show_colorscale(interpolation='bicubic', cmap='afmhot', stretch='log', vmin=
 fig.tick_labels.set_xformat('ddd')
 fig.tick_labels.set_yformat('dd')
 ticks = np.logspace(30, 35, 6)
-fig.add_colorbar(ticks=ticks, axis_label_text='Flux (ph s^-1)')
+fig.add_colorbar(ticks=ticks, axis_label_text='Flux (s^-1)')
 fig.colorbar._colorbar_axes.set_yticklabels(['{:.0e}'.format(_) for _ in ticks])
 plt.tight_layout()
 plt.show()

--- a/docs/tutorials/catalog/source_image_demo.py
+++ b/docs/tutorials/catalog/source_image_demo.py
@@ -22,7 +22,7 @@ fig.show_colorscale(interpolation='bicubic', cmap='afmhot', stretch='log', vmin=
 fig.tick_labels.set_xformat('ddd')
 fig.tick_labels.set_yformat('dd')
 ticks = np.logspace(-12, -8, 5)
-fig.add_colorbar(ticks=ticks, axis_label_text='Flux (ph s^-1 cm^-2 TeV^-1)')
+fig.add_colorbar(ticks=ticks, axis_label_text='Flux (cm^-2 s^-1 TeV^-1)')
 fig.colorbar._colorbar_axes.set_yticklabels(['{:.0e}'.format(_) for _ in ticks])
 plt.tight_layout()
 plt.show()

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy import degrees, pi, arctan, exp
+from astropy.extern import six
 from astropy.table import Table, Column
 from astropy.units import Quantity
 from astropy.coordinates import SkyCoord, spherical_to_cartesian
@@ -183,10 +184,10 @@ def make_base_catalog_galactic(n_sources, rad_dis='YK04', vel_dis='H05',
     """
     random_state = get_random_state(random_state)
 
-    if isinstance(rad_dis, str):
+    if isinstance(rad_dis, six.string_types):
         rad_dis = radial_distributions[rad_dis]
 
-    if isinstance(vel_dis, str):
+    if isinstance(vel_dis, six.string_types):
         vel_dis = velocity_distributions[vel_dis]
 
     # Draw r and z values from the given distribution

--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -493,8 +493,8 @@ class FaucherSpiral(LogSpiral):
         spiralarm = self.spiralarms[N]  # List that contains in wich spiralarm a postion lies
 
         if blur:  # Apply blurring model according to Faucher
-            radius, theta = self._blur(radius, theta)
-            radius, theta = self._gc_correction(radius, theta)
+            radius, theta = self._blur(radius, theta, random_state=random_state)
+            radius, theta = self._gc_correction(radius, theta, random_state=random_state)
         return radius, theta, spiralarm
 
 

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from ....utils.testing import requires_dependency
 from ...population import (
@@ -88,3 +89,31 @@ def test_add_par_obs(example_table):
     table = add_observed_source_parameters(table)
     assert len(table) == len(example_table)
     assert has_columns(table, ['ext_in_SNR'])
+
+
+def test_make_base_catalog_galactic():
+    """Test that make_base_catalog_galactic uses random_state correctly.
+    
+    Calling with a given seed should always give the same output.
+
+    Regression test for https://github.com/gammapy/gammapy/issues/959
+    """
+    table = make_base_catalog_galactic(n_sources=1, random_state=0)
+    d = table[0]
+    # print(list(zip(d.colnames, d.as_void())))
+
+    assert_allclose(d['x_birth'], -7.7244510367459904)
+    assert_allclose(d['y_birth'], -0.3878120924926074)
+    assert_allclose(d['z_birth'], 0.028117277025426112)
+    assert_allclose(d['x'], -7.7244510367459904)
+    assert_allclose(d['y'], -0.3878120924926074)
+    assert_allclose(d['z'], 0.028117277025426112)
+    assert_allclose(d['vx'], -341.28926571465314)
+    assert_allclose(d['vy'], 48.211461842444507)
+    assert_allclose(d['vz'], 298.79950689388124)
+
+    assert_allclose(d['age'], -0.056712977317443181)
+    assert_allclose(d['n_ISM'], 1.0)
+    assert d['spiralarm'] == 'Crux Scutum'
+    assert d['morph_type'] == 'shell2d'
+    assert_allclose(d['v_abs'], 456.16209099952528)

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -10,7 +10,7 @@ __all__ = [
     'SimplePulsar',
 ]
 
-DEFAULT_I = Quantity(1e45, 'g cm^2')
+DEFAULT_I = Quantity(1e45, 'g cm2')
 """Pulsar default moment of inertia"""
 
 DEFAULT_R = Quantity(1e6, 'cm')

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -37,7 +37,7 @@ class SNR(object):
     """
 
     def __init__(self, e_sn=Quantity(1e51, 'erg'), theta=Quantity(0.1),
-                 n_ISM=Quantity(1, 'cm^-3'), m_ejecta=const.M_sun,
+                 n_ISM=Quantity(1, 'cm-3'), m_ejecta=const.M_sun,
                  t_stop=Quantity(1e6, 'K'), age=None, morphology='Shell2D',
                  spectral_index=2.1):
         self.e_sn = e_sn
@@ -167,12 +167,12 @@ class SNR(object):
         # Flux in 1 k distance according to Drury formula 9
         term_0 = energy_min / Quantity(1, 'TeV')
         term_1 = self.e_sn / Quantity(1e51, 'erg')
-        term_2 = self.rho_ISM / (Quantity(1, 'cm^-3') * const.m_p)
+        term_2 = self.rho_ISM / (Quantity(1, 'cm-3') * const.m_p)
         L = self.theta * term_0 ** (1 - self.spectral_index) * term_1 * term_2
 
         # Corresponding luminosity
         L = np.select([t <= self.sedov_taylor_begin, t <= self.sedov_taylor_end], [0, L])
-        return Quantity(1.0768E34, 'ph s^-1') * L
+        return Quantity(1.0768E34, 's-1') * L
 
     @lazyproperty
     def sedov_taylor_begin(self):
@@ -196,7 +196,7 @@ class SNR(object):
         """
         term1 = (self.e_sn / Quantity(1e51, 'erg')) ** (-1. / 2)
         term2 = (self.m_ejecta / const.M_sun) ** (5. / 6)
-        term3 = (self.rho_ISM / (Quantity(1, 'cm^-3') * const.m_p)) ** (-1. / 3)
+        term3 = (self.rho_ISM / (Quantity(1, 'cm-3') * const.m_p)) ** (-1. / 3)
         return Quantity(200, 'yr') * term1 * term2 * term3
 
     @lazyproperty

--- a/gammapy/image/models/model.py
+++ b/gammapy/image/models/model.py
@@ -5,6 +5,7 @@ At the moment you can have any number of Gaussians.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from astropy.extern import six
 from astropy.io import fits
 from astropy.stats import gaussian_fwhm_to_sigma
 from ...utils.random import get_random_state
@@ -65,7 +66,7 @@ class MorphModelImageCreator(object):
         if psf_file is not None:
             self.psf_file = psf_file
         if background is not None:
-            if isinstance(background, str):
+            if isinstance(background, six.string_types):
                 self.background = fits.getdata(background)
             elif isinstance(background, (int, float)):
                 self.background = np.ones_like(self.exposure)
@@ -192,7 +193,7 @@ class GaussCatalog(dict):
         if isinstance(source, dict):
             # Assume source is a dict with correct format
             self.pars = source
-        elif isinstance(source, str):
+        elif isinstance(source, six.string_types):
             # Assume it is a JSON filename
             fh = open(source)
             self.pars = json.load(fh)

--- a/gammapy/image/models/models.py
+++ b/gammapy/image/models/models.py
@@ -308,10 +308,9 @@ class Delta2D(Fittable2DModel):
         return np.select([np.logical_and(x_mask, y_mask)], [amplitude])
 
 
-morph_types = OrderedDict(
-    delta2d=Delta2D,
-    gauss2d=Gaussian2D,
-    shell2d=Shell2D,
-    sphere2d=Sphere2D,
-)
+morph_types = OrderedDict()
 """Available morphology types."""
+morph_types['delta2d'] = Delta2D
+morph_types['gauss2d'] = Gaussian2D
+morph_types['shell2d'] = Shell2D
+morph_types['sphere2d'] = Sphere2D

--- a/gammapy/utils/distributions/utils.py
+++ b/gammapy/utils/distributions/utils.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Helper functions to work with distributions."""
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ...utils.random import get_random_state
 from ...utils.distributions import GeneralRandom
 
 __all__ = ['normalize', 'density', 'draw', 'pdf']
@@ -35,11 +37,12 @@ def density(func):
     return f
 
 
-def draw(low, high, size, dist, *args, **kwargs):
+def draw(low, high, size, dist, random_state='random-seed', *args, **kwargs):
     """Allows drawing of random numbers from any distribution."""
+    random_state = get_random_state(random_state)
+
     def f(x):
         return dist(x, *args, **kwargs)
 
     d = GeneralRandom(f, low, high)
-    array = d.draw(size)
-    return array
+    return d.draw(size, random_state=random_state)


### PR DESCRIPTION
This is a reminder issue for myself.

The random number generator or seed is not passed to the `draw` calls in `make_base_catalog_galactic`. So it's currently not possible to choose a seed and get fixed output.

To reproduce:
```
>>> from gammapy.astro.population import make_base_catalog_galactic
>>> make_base_catalog_galactic(n_sources=3, random_state=0)['x']
<Column name='x' dtype='float64' unit='kpc' description='Galactocentric x coordinate' length=3>
-2.09043015232
0.918387463769
-2.55585540526
>>> make_base_catalog_galactic(n_sources=3, random_state=0)['x']
<Column name='x' dtype='float64' unit='kpc' description='Galactocentric x coordinate' length=3>
4.58641203329
2.21176273182
5.33941725739
```

The output should be the same in both calls (because the seed is the same), but it's not.