### PR TITLE
Improve unit handling in gammapy.catalog

### DIFF
--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -170,10 +170,16 @@ Reference/API
 .. automodapi:: gammapy.utils.energy
     :no-inheritance-diagram:
 
+.. automodapi:: gammapy.utils.units
+    :no-inheritance-diagram:
+
 .. automodapi:: gammapy.utils.mpl_style
     :no-inheritance-diagram:
 
 .. automodapi:: gammapy.utils.coordinates
+    :no-inheritance-diagram:
+
+.. automodapi:: gammapy.utils.table
     :no-inheritance-diagram:
 
 .. automodapi:: gammapy.utils.fits

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Table helper utilities.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from .units import standardise_unit
+
+__all__ = [
+    'table_standardise',
+]
+
+
+def table_standardise(table):
+    """TODO
+    """
+    for column in table.columns.values():
+        if column.unit:
+            column.unit = standardise_unit(column.unit)

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -1,0 +1,20 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import astropy.units as u
+from astropy.table import Table, Column
+from ..table import table_standardise
+
+
+def test_table_standardise():
+    table = Table()
+    table['a'] = Column([1], unit='ph cm-2 s-1')
+    table['b'] = Column([1], unit='ct cm-2 s-1')
+    table['c'] = Column([1], unit='cm-2 s-1')
+    table['d'] = Column([1])
+
+    table_standardise(table)
+
+    assert table['a'].unit == u.Unit('cm-2 s-1')
+    assert table['b'].unit == u.Unit('cm-2 s-1')
+    assert table['c'].unit == u.Unit('cm-2 s-1')
+    assert table['d'].unit is None

--- a/gammapy/utils/tests/test_units.py
+++ b/gammapy/utils/tests/test_units.py
@@ -1,0 +1,10 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import astropy.units as u
+from ..units import standardise_unit
+
+
+def test_standardise_unit():
+    assert standardise_unit('ph cm-2 s-1') == u.Unit('cm-2 s-1')
+    assert standardise_unit('ct cm-2 s-1') == u.Unit('cm-2 s-1')
+    assert standardise_unit('cm-2 s-1') == u.Unit('cm-2 s-1')

--- a/gammapy/utils/units.py
+++ b/gammapy/utils/units.py
@@ -37,8 +37,10 @@ def standardise_unit(unit):
     Unit("1 / (cm2 s)")
     """
     unit = u.Unit(unit)
+    bases, powers = [], []
     for base, power in zip(unit.bases, unit.powers):
-        if base == u.Unit('ph') or base == u.Unit('ct'):
-            unit = unit / (base ** power)
+        if str(base) not in {'ph', 'ct'}:
+            bases.append(base)
+            powers.append(power)
 
-    return unit
+    return u.CompositeUnit(scale=unit.scale, bases=bases, powers=powers)

--- a/gammapy/utils/units.py
+++ b/gammapy/utils/units.py
@@ -1,0 +1,44 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Units and Quantity related helper functions"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import astropy.units as u
+
+__all__ = [
+    'standardise_unit',
+]
+
+
+def standardise_unit(unit):
+    """Standardise unit.
+    
+    Changes applied by this function:
+
+    * Drop "photon" == "ph" from the unit
+    * Drop "count" == "ct" from the unit
+
+    Parameters
+    ----------
+    unit : `~astropy.units.Unit` or str
+        Any old unit
+
+    Returns
+    -------
+    unit : `~astropy.units.Unit`
+        Shiny new, standardised unit
+
+    Examples
+    --------
+    >>> from gammapy.utils.units import standardise_unit
+    >>> standardise_unit('ph cm-2 s-1')
+    Unit("1 / (cm2 s)")
+    >>> standardise_unit('ct cm-2 s-1')
+    Unit("1 / (cm2 s)")
+    >>> standardise_unit('cm-2 s-1')
+    Unit("1 / (cm2 s)")
+    """
+    unit = u.Unit(unit)
+    for base, power in zip(unit.bases, unit.powers):
+        if base == u.Unit('ph') or base == u.Unit('ct'):
+            unit = unit / (base ** power)
+
+    return unit


### PR DESCRIPTION
This pull request:
- [x] Introduces `gammapy.utils.units` and `gammapy.utils.table` with helper functions to standardise units (get rid of "photon" and "counts").
- [x] Cleans up unit handling in gamma.catalog (reading units from the FITS file where given, instead of dropping it on read and then adding units back later via code)