### PR TITLE
Add flux point fitter class

### DIFF
--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -405,6 +405,17 @@ class FluxPoints(object):
         """
         Drop upper limit flux points.
 
+        Examples
+        --------
+
+        from gammapy.spectrum import FluxPoints
+
+        filename = '$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/flux_points.fits'
+        flux_points = FluxPoints.read(filename)
+
+        print(flux_points)
+        print(flux_points.drop_ul())
+
         Returns
         -------
         flux_points : `FluxPoints`

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -440,7 +440,8 @@ class FluxPoints(object):
             table = _.table
             for colname in reference.colnames:
                 column = reference[colname]
-                table[colname] = table[colname].quantity.to(column.unit)
+                if column.unit:
+                    table[colname] = table[colname].quantity.to(column.unit)
             tables.append(table[reference.colnames])
         table_stacked = vstack(tables)
         table_stacked.meta['SED_TYPE'] = reference.meta['SED_TYPE']

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -408,7 +408,7 @@ class FluxPoints(object):
         Returns
         -------
         flux_points : `FluxPoints`
-            Flux points without upper limit points.
+            Flux points with upper limit points removed.
         """
         table = self.table.copy()
         table_drop_ul = table[~self._is_ul]
@@ -417,12 +417,16 @@ class FluxPoints(object):
     @classmethod
     def stack(cls, flux_points):
         """
-        Stack a list of flux points
+        Create a new `FluxPoints` object by stacking a list of existing
+        flux points.
+
+        The first `FluxPoints` object in the list is taken as a reference to infer
+        column names and units for the stacked object.
 
         Parameters
         ----------
         flux_points : list of `FluxPoints` objects
-            List of flux point to stack.
+            List of flux points to stack.
 
         Returns
         -------
@@ -778,6 +782,9 @@ class FluxPointsFitter(object):
             self.stat = chi2_flux_points
         elif stat == 'chi2assym':
             self.stat = chi2_flux_points_assym
+        else:
+            raise ValueError("'{stat}' is not a valid fit statistic, please choose"
+                             " either 'chi2' or 'chi2assym'")
 
         if not ul_handling == 'ignore':
             raise NotImplementedError('No handling of upper limits implemented.')

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -51,7 +51,15 @@ class SpectralModel(object):
     def __str__(self):
         """String representation"""
         ss = self.__class__.__name__
-        ss += '\n{}'.format(self.parameters)
+        ss += '\n\nParameters: \n\n\t'
+
+        table = self.parameters.to_table()
+        ss += '\n\t'.join(table.pformat())
+
+        if self.parameters.covariance is not None:
+            ss += '\n\nCovariance: \n\n\t'
+            covar = self.parameters.covariance_to_table()
+            ss += '\n\t'.join(covar.pformat())
         return ss
 
     def _parse_uarray(self, uarray):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -835,14 +835,14 @@ class LogParabola(SpectralModel):
 
     .. math::
 
-        f(x) = A \left( \frac{E}{E_0} \right) ^ {
+        \phi(E) = \phi_0 \left( \frac{E}{E_0} \right) ^ {
           - \alpha - \beta \log{ \left( \frac{E}{E_0} \right) }
         }
 
     Parameters
     ----------
     amplitude : `~astropy.units.Quantity`
-        :math:`Phi_0`
+        :math:`\phi_0`
     reference : `~astropy.units.Quantity`
         :math:`E_0`
     alpha : `~astropy.units.Quantity`

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -312,7 +312,7 @@ class TestFluxPoints:
 
     def test_drop_ul(self, flux_points):
         flux_points = flux_points.drop_ul()
-        assert not np.any(flux_points._is_ul())
+        assert not np.any(flux_points._is_ul)
 
     def test_stack(self, flux_points):
         stacked = FluxPoints.stack([flux_points, flux_points])
@@ -354,3 +354,5 @@ class TestFluxPointsFitter:
         amplitude = result['best_fit_model'].parameters['amplitude']
         assert_quantity_allclose(index.quantity, 2.216 * u.Unit(''), rtol=1E-3)
         assert_quantity_allclose(amplitude.quantity, 2.149E-13 * u.Unit('cm-2 s-1 TeV-1'), rtol=1E-3)
+        assert_allclose(result['statval'], 27.183618, rtol=1E-3)
+        assert_allclose(result['dof'], 22)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -254,7 +254,7 @@ class TestSEDLikelihoodProfile:
         ax = self.sed.plot()
 
 
-@pytest.fixture(params=FLUX_POINTS_FILES)
+@pytest.fixture(params=FLUX_POINTS_FILES, scope='session')
 def flux_points(request):
     path = '$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/' + request.param
     return FluxPoints.read(path)
@@ -310,6 +310,15 @@ class TestFluxPoints:
         actual = FluxPoints.read(filename)
         assert str(flux_points) == str(actual)
 
+    def test_drop_ul(self, flux_points):
+        flux_points = flux_points.drop_ul()
+        assert not np.any(flux_points._is_ul())
+
+    def test_stack(self, flux_points):
+        stacked = FluxPoints.stack([flux_points, flux_points])
+        assert len(stacked.table) == 2 * len(flux_points.table)
+        assert stacked.sed_type == flux_points.sed_type
+
 
 @requires_data('gammapy-extra')
 def test_compute_flux_points_dnde():
@@ -338,8 +347,8 @@ class TestFluxPointsFitter:
 
     def test_fit_pwl(self):
         fitter = FluxPointsFitter()
-        model = PowerLaw(2.2 * u.Unit(''), 1E-12 * u.Unit('cm-2 s-1 TeV-1'), 1 * u.TeV)
-        result = fitter.run([self.flux_points], model)
+        model = PowerLaw(2.3 * u.Unit(''), 1E-12 * u.Unit('cm-2 s-1 TeV-1'), 1 * u.TeV)
+        result = fitter.run(self.flux_points, model)
 
         index = result['best_fit_model'].parameters['index']
         amplitude = result['best_fit_model'].parameters['amplitude']

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -247,6 +247,22 @@ class ParameterList(object):
             upars[par.name] = upar
         return upars
 
+    @property
+    def free(self):
+        """
+        Return list of free parameters names.
+        """
+        free_pars = [par.name for par in self.parameters if not par.frozen]
+        return free_pars
+
+    @property
+    def frozen(self):
+        """
+        Return list of frozen parameters names.
+        """
+        frozen_pars = [par.name for par in self.parameters if par.frozen]
+        return frozen_pars
+
     # TODO: this is a temporary solution until we have a better way
     # to handle covariance matrices via a class
     def set_parameter_errors(self, errors):

--- a/gammapy/utils/sherpa.py
+++ b/gammapy/utils/sherpa.py
@@ -45,7 +45,9 @@ class SherpaStatWrapper(Likelihood):
             part._update_pars()
             gp_models.append(part.gp_model)
         gp_datasets = [_.gp_data for _ in data.datasets]
-        return self.gp_stat(gp_datasets, gp_models)
+        # right now we only pass the first dataset and model
+        # but in general we'd like pass all
+        return self.gp_stat(gp_datasets[0], gp_models[0])
 
     def calc_stat_error(self):
         staterr = np.array([np.nan])

--- a/gammapy/utils/sherpa.py
+++ b/gammapy/utils/sherpa.py
@@ -22,7 +22,7 @@ SHERPA_OPTMETHODS = {'simplex': NelderMead(),
 class SherpaDataWrapper(Data):
     def __init__(self, gp_data, name='GPData'):
         # sherpa does some magic here: it sets class attributes from constructor
-        # arguments so `gp-data` will be available later on the instance.
+        # arguments so `gp_data` will be available later on the instance.
         self._data_dummy = np.empty_like(gp_data.e_ref)
         BaseData.__init__(self)
 
@@ -77,7 +77,9 @@ class SherpaModelWrapper(ArithmeticModel):
 
     def _update_pars(self):
         for par in self.pars:
-            self.gp_model.parameters[par.name] = u.Quantity(par.val, par.units)
+            gp_par = self.gp_model.parameters[par.name]
+            gp_par.value = par.val
+            gp_par.unit = par.units
 
     def calc(self, pars, *args):
         return np.empty_like(args[0])


### PR DESCRIPTION
This PR adds a `FluxPointFitter` class to fit a common model to a given set of flux points. A demo notebook is shown [here](https://github.com/adonath/gammapy-extra/blob/add_flux_point_fitter_notebook/notebooks/sed_fitting_gammacat_fermi.ipynb).

TODO:
- [x] Rework flux point upper limit handling
- [x] Improve test (add asserts on more values of the result dict)
- [x] Wait for #978 to be merged and rebase