### PR TITLE
Clean up PSF axis names: use "rad"

### DIFF
--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -1,10 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-import numpy as np
-from astropy.coordinates import SkyCoord, Angle
+from __future__ import absolute_import, division, print_function, unicode_literals
 from .core import SkyCube
-from ..utils.energy import EnergyBounds
 
 __all__ = [
     'exposure_cube'

--- a/gammapy/cube/tests/test_cube_pipe.py
+++ b/gammapy/cube/tests/test_cube_pipe.py
@@ -11,8 +11,8 @@ from ...utils.testing import requires_dependency, requires_data, pytest
 from ...utils.energy import Energy
 from ...data import DataStore
 from ...image import SkyImage
-from .. import StackedObsCubeMaker
 from ...background import OffDataBackgroundMaker
+from .. import StackedObsCubeMaker
 from .. import SkyCube
 
 

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EffectiveAreaTable2D
-from ...datasets import gammapy_extra
 from .. import exposure_cube
 from .. import SkyCube
 
@@ -15,10 +12,8 @@ from .. import SkyCube
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_exposure_cube():
-    aeff_filename = gammapy_extra.filename(
-        'datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz')
-    ccube_filename = gammapy_extra.filename(
-        'datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits')
+    aeff_filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz'
+    ccube_filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
 
     pointing = SkyCoord(83.633, 21.514, unit='deg')
     livetime = Quantity(1581.17, 's')

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -121,25 +121,25 @@ def test_data_summary(data_manager):
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("pars,result", [
-    (dict(energy=None, theta=None),
-     dict(energy_shape=18, theta_shape=300, psf_energy=2.5178505859375 * u.TeV,
-          psf_theta=0.05 * u.deg,
+    (dict(energy=None, rad=None),
+     dict(energy_shape=18, rad_shape=300, psf_energy=2.5178505859375 * u.TeV,
+          psf_rad=0.05 * u.deg,
           psf_exposure=Quantity(6878545291473.34, "cm2 s"),
           psf_value=Quantity(1837.4367332530592, "1/sr"))),
-    (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"), theta=None),
-     dict(energy_shape=101, theta_shape=300,
-          psf_energy=1.2589254117941673 * u.TeV, psf_theta=0.05 * u.deg,
+    (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"), rad=None),
+     dict(energy_shape=101, rad_shape=300,
+          psf_energy=1.2589254117941673 * u.TeV, psf_rad=0.05 * u.deg,
           psf_exposure=Quantity(4622187644084.735, "cm2 s"),
           psf_value=Quantity(1682.8135627097995, "1/sr"))),
-    (dict(energy=None, theta=Angle(np.arange(0, 2, 0.002), 'deg')),
-     dict(energy_shape=18, theta_shape=1000,
-          psf_energy=2.5178505859375 * u.TeV, psf_theta=0.02 * u.deg,
+    (dict(energy=None, rad=Angle(np.arange(0, 2, 0.002), 'deg')),
+     dict(energy_shape=18, rad_shape=1000,
+          psf_energy=2.5178505859375 * u.TeV, psf_rad=0.02 * u.deg,
           psf_exposure=Quantity(6878545291473.34, "cm2 s"),
           psf_value=Quantity(20455.914082287516, "1/sr"))),
     (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"),
-          theta=Angle(np.arange(0, 2, 0.002), 'deg')),
-     dict(energy_shape=101, theta_shape=1000,
-          psf_energy=1.2589254117941673 * u.TeV, psf_theta=0.02 * u.deg,
+          rad=Angle(np.arange(0, 2, 0.002), 'deg')),
+     dict(energy_shape=101, rad_shape=1000,
+          psf_energy=1.2589254117941673 * u.TeV, psf_rad=0.02 * u.deg,
           psf_exposure=Quantity(4622187644084.735, "cm2 s"),
           psf_value=Quantity(25016.103907407552, "1/sr"))),
 ])
@@ -149,16 +149,15 @@ def test_make_psf(pars, result):
     data_store = DataStore.from_dir(store)
 
     obs1 = data_store.obs(23523)
-    psf = obs1.make_psf(position=position, energy=pars["energy"],
-                        theta=pars["theta"])
+    psf = obs1.make_psf(position=position, energy=pars["energy"], rad=pars["rad"])
 
-    assert_allclose(psf.offset.shape, result["theta_shape"])
+    assert_allclose(psf.rad.shape, result["rad_shape"])
     assert_allclose(psf.energy.shape, result["energy_shape"])
     assert_allclose(psf.exposure.shape, result["energy_shape"])
     assert_allclose(psf.psf_value.shape, (result["energy_shape"],
-                                          result["theta_shape"]))
+                                          result["rad_shape"]))
 
-    assert_quantity_allclose(psf.offset[10], result["psf_theta"])
+    assert_quantity_allclose(psf.rad[10], result["psf_rad"])
     assert_quantity_allclose(psf.energy[10], result["psf_energy"])
     assert_quantity_allclose(psf.exposure[10], result["psf_exposure"])
     assert_quantity_allclose(psf.psf_value[10, 50], result["psf_value"])

--- a/gammapy/data/tests/test_observationlist.py
+++ b/gammapy/data/tests/test_observationlist.py
@@ -18,8 +18,8 @@ def test_make_psftable():
     energy = EnergyBounds.equal_log_spacing(1, 10, 100, "TeV")
     energy_band = Energy([energy[0].value, energy[-1].value], energy.unit)
 
-    psf1 = obs1.make_psf(position=position, energy=energy, theta=None)
-    psf2 = obs2.make_psf(position=position, energy=energy, theta=None)
+    psf1 = obs1.make_psf(position=position, energy=energy, rad=None)
+    psf2 = obs2.make_psf(position=position, energy=energy, rad=None)
     psf1_int = psf1.table_psf_in_energy_band(energy_band, spectral_index=2.3)
     psf2_int = psf2.table_psf_in_energy_band(energy_band, spectral_index=2.3)
     obslist = ObservationList([obs1, obs2])

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -5,7 +5,7 @@ import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
 from ..extern.bunch import Bunch
-from ..utils.nddata import NDDataArray, DataAxis, BinnedDataAxis
+from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.energy import EnergyBounds
 from ..utils.scripts import make_path
 from ..utils.fits import fits_table_to_table, table_to_fits_table

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -6,9 +6,8 @@ from astropy.coordinates import Angle
 from astropy.units import Quantity
 from astropy.table import Table
 from ..utils.energy import EnergyBounds, Energy
-from ..utils.array import array_stats_str
 from ..utils.scripts import make_path
-from ..utils.nddata import NDDataArray, BinnedDataAxis, DataAxis
+from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.fits import energy_axis_to_ebounds, fits_table_to_table
 
 __all__ = [

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -48,9 +48,7 @@ class IRFStacker(object):
     list_low_threshold: list
         list of low energy threshold, optional for effective area mean computation
     list_high_threshold: list
-        list of high energy threshold, optional for effecitve area mean computation
-
-
+        list of high energy threshold, optional for effective area mean computation
     """
 
     def __init__(self, list_aeff, list_livetime, list_edisp=None,

--- a/gammapy/irf/psf_core.py
+++ b/gammapy/irf/psf_core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Utility funtions for reading / writing PSF parameters to JSON files.
+"""Utility functions for reading / writing PSF parameters to JSON files.
 
 From the documentaion of load_psf():
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import pytest, assert_quantity_allclose
-from ...datasets import gammapy_extra
+from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data, data_manager
 from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
 
@@ -12,9 +11,8 @@ from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
 @requires_dependency('scipy')
 @requires_dependency('matplotlib')
 @requires_data('gammapy-extra')
-def test_EffectiveAreaTable2D(tmpdir):
-    filename = gammapy_extra.filename(
-        'datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz')
+def test_EffectiveAreaTable2D():
+    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz'
     aeff = EffectiveAreaTable2D.read(filename, hdu='AEFF_2D')
 
     assert aeff.energy.nbins == 73
@@ -28,9 +26,7 @@ def test_EffectiveAreaTable2D(tmpdir):
     assert_quantity_allclose(aeff.high_threshold, 99.083 * u.TeV, rtol=1e-3)
     assert_quantity_allclose(aeff.low_threshold, 0.603 * u.TeV, rtol=1e-3)
 
-    test_e = 14 * u.TeV
-    test_o = 0.2 * u.deg
-    test_val = aeff.data.evaluate(energy=test_e, offset=test_o)
+    test_val = aeff.data.evaluate(energy='14 TeV', offset='0.2 deg')
     assert_allclose(test_val.value, 740929.645, atol=1e-2)
 
     aeff.plot()
@@ -43,22 +39,20 @@ def test_EffectiveAreaTable2D(tmpdir):
     effareafrom2d = aeff.to_effective_area_table(offset, e_axis)
 
     energy = np.sqrt(e_axis[:-1] * e_axis[1:])
-    area = aeff.data.evaluate(offset=offset, energy=energy)
+    area = aeff.data.evaluate(energy=energy, offset=offset)
     effarea1d = EffectiveAreaTable(energy_lo=e_axis[:-1],
                                    energy_hi=e_axis[1:],
                                    data=area)
 
-    test_energy = 2.34 * u.TeV
-    actual = effareafrom2d.data.evaluate(energy=test_energy)
-    desired = effarea1d.data.evaluate(energy=test_energy)
+    actual = effareafrom2d.data.evaluate(energy='2.34 TeV')
+    desired = effarea1d.data.evaluate(energy='2.34 TeV')
     assert_equal(actual, desired)
 
     # Test ARF export #2
     offset = 1.2 * u.deg
-    effareafrom2dv2 = aeff.to_effective_area_table(offset=offset)
-    actual = effareafrom2dv2.data.data
+    actual = aeff.to_effective_area_table(offset=offset).data.data
     desired = aeff.data.evaluate(offset=offset)
-    assert_equal(actual, desired)
+    assert_equal(actual.value, desired.value)
 
 
 @requires_dependency('scipy')
@@ -75,7 +69,6 @@ def test_EffectiveAreaTable(tmpdir, data_manager):
 
     filename = str(tmpdir / 'effarea_test.fits')
     arf.write(filename)
-
     arf2 = EffectiveAreaTable.read(filename)
 
     assert_quantity_allclose(arf.data.evaluate(), arf2.data.evaluate())
@@ -103,7 +96,7 @@ def test_EffectiveAreaTable(tmpdir, data_manager):
     assert vals[-1] == 3
 
 
-def test_EffectiveAreaTableParametrization():
+def test_EffectiveAreaTable_from_parametrization():
     # Log center of this is 100 GeV
     energy = [80, 125] * u.GeV
     area_ref = 1.65469579e+07 * u.cm * u.cm

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -1,33 +1,30 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.tests.helper import pytest, assert_quantity_allclose
-from ...datasets.core import GammapyExtraNotFoundError
-from ...utils.scripts import make_path
 from ...utils.testing import requires_dependency, requires_data, data_manager
-from ...irf import EffectiveAreaTable2D, EnergyDispersion2D
+
 
 def get_tested_prods():
     prods = list()
     prods.append(dict(
-        prod = 'hap-hd-prod2',
-        datastore = 'hess-crab4-hd-hap-prod2',
-        test_obs = 23523,
-        aeff_ref = 267252.7018649852 * u.m**2,
-        psf_type = 'psf_3gauss',
-        psf_ref = 106.31031643387723 / u.sr,
-        edisp_ref = 2.059754779846907)
+        prod='hap-hd-prod2',
+        datastore='hess-crab4-hd-hap-prod2',
+        test_obs=23523,
+        aeff_ref=267252.7018649852 * u.m ** 2,
+        psf_type='psf_3gauss',
+        psf_ref=106.31031643387723 / u.sr,
+        edisp_ref=2.059754779846907)
     )
     prods.append(dict(
-        prod = 'pa-release1',
-        datastore = 'hess-crab4-pa',
-        test_obs = 23523,
-        aeff_ref = 207835.97395833334 * u.m**2,
-        psf_type = 'psf_king',
-        psf_ref = 51.0044923171571 / u.sr,
-        edisp_ref = 2.783763964427291)
+        prod='pa-release1',
+        datastore='hess-crab4-pa',
+        test_obs=23523,
+        aeff_ref=207835.97395833334 * u.m ** 2,
+        psf_type='psf_king',
+        psf_ref=51.0044923171571 / u.sr,
+        edisp_ref=2.783763964427291)
     )
     return prods
 
@@ -38,8 +35,8 @@ class FitsProductionTester:
         dm = data_manager()
         self.ds = dm[prod['datastore']]
         self.ref_energy = 1 * u.TeV
-        self.ref_theta = 0.25 * u.deg
-        self.ref_offset = np.arange(0, 2, 0.1) * u.deg
+        self.ref_offset = 0.25 * u.deg
+        self.ref_rad = np.arange(0, 2, 0.1) * u.deg
         self.ref_migra = 0.95
         self.obs = self.ds.obs(prod['test_obs'])
 
@@ -50,24 +47,23 @@ class FitsProductionTester:
 
     def test_aeff(self):
         aeff = self.obs.load(hdu_type='aeff', hdu_class='aeff_2d')
-        actual = aeff.data.evaluate(energy=self.ref_energy, offset=self.ref_theta)
+        actual = aeff.data.evaluate(energy=self.ref_energy, offset=self.ref_offset)
         desired = self.ref_dict['aeff_ref']
         assert_quantity_allclose(actual, desired)
 
     def test_edisp(self):
         edisp = self.obs.load(hdu_type='edisp', hdu_class='edisp_2d')
-        actual = edisp.data.evaluate(e_true=self.ref_energy,
-                                offset=self.ref_theta,
-                                migra=self.ref_migra)
+        actual = edisp.data.evaluate(e_true=self.ref_energy, offset=self.ref_offset, migra=self.ref_migra)
         desired = self.ref_dict['edisp_ref']
         assert_quantity_allclose(actual, desired)
 
     def test_psf(self):
         psf = self.obs.load(hdu_type='psf', hdu_class=self.ref_dict['psf_type'])
-        table_psf = psf.to_energy_dependent_table_psf(offset=self.ref_offset, theta=self.ref_theta)
+        table_psf = psf.to_energy_dependent_table_psf(rad=self.ref_rad, theta=self.ref_offset)
         actual = table_psf.evaluate(energy=self.ref_energy)
         desired = self.ref_dict['psf_ref']
         assert_quantity_allclose(actual[0][4], desired)
+
 
 @pytest.mark.parametrize('prod', get_tested_prods())
 @requires_dependency('yaml')

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -6,7 +6,7 @@ from astropy.units import Quantity
 from astropy.coordinates import Angle
 from ...utils.energy import Energy
 from ...utils.testing import requires_dependency, requires_data
-from ...datasets import gammapy_extra
+from ...utils.scripts import make_path
 from ...irf import PSF3D
 
 
@@ -14,27 +14,28 @@ from ...irf import PSF3D
 @requires_dependency('scipy')
 class TestPSF3D:
     def setup(self):
-        filename = str(gammapy_extra.dir) + '/test_datasets/psf_table_023523.fits.gz'
+        filename = '$GAMMAPY_EXTRA/test_datasets/psf_table_023523.fits.gz'
         self.psf = PSF3D.read(filename)
+        filename = str(make_path(filename))
         self.table = Table.read(filename, 'PSF_2D_TABLE')
 
     def test_read(self):
         table = self.table
-        elo = Energy(table["ENERG_LO"].squeeze(), unit=table["ENERG_LO"].unit)
-        ehi = Energy(table["ENERG_HI"].squeeze(), unit=table["ENERG_HI"].unit)
-        offlo = Angle(table["THETA_LO"].squeeze(), unit=table["THETA_LO"].unit)
-        offhi = Angle(table["THETA_HI"].squeeze(), unit=table["THETA_HI"].unit)
-        radlo = Angle(table["RAD_LO"].squeeze(), unit=table["RAD_LO"].unit)
-        radhi = Angle(table["RAD_HI"].squeeze(), unit=table["RAD_HI"].unit)
-        rpsf = Quantity(table["RPSF"].squeeze(), unit=table["RPSF"].unit)
+        energy_lo = Energy(table["ENERG_LO"].squeeze(), unit=table["ENERG_LO"].unit)
+        energy_hi = Energy(table["ENERG_HI"].squeeze(), unit=table["ENERG_HI"].unit)
+        offset_lo = Angle(table["THETA_LO"].squeeze(), unit=table["THETA_LO"].unit)
+        offset_hi = Angle(table["THETA_HI"].squeeze(), unit=table["THETA_HI"].unit)
+        rad_lo = Angle(table["RAD_LO"].squeeze(), unit=table["RAD_LO"].unit)
+        rad_hi = Angle(table["RAD_HI"].squeeze(), unit=table["RAD_HI"].unit)
+        psf_value = Quantity(table["RPSF"].squeeze(), unit=table["RPSF"].unit)
 
-        assert_quantity_allclose(self.psf.energy_lo, elo)
-        assert_quantity_allclose(self.psf.energy_hi, ehi)
-        assert_quantity_allclose(self.psf.offset, offlo)
-        assert_quantity_allclose(self.psf.offset, offhi)
-        assert_quantity_allclose(self.psf.rad_lo, radlo)
-        assert_quantity_allclose(self.psf.rad_hi, radhi)
-        assert_quantity_allclose(self.psf.psf_value, rpsf)
+        assert_quantity_allclose(self.psf.energy_lo, energy_lo)
+        assert_quantity_allclose(self.psf.energy_hi, energy_hi)
+        assert_quantity_allclose(self.psf.offset, offset_lo)
+        assert_quantity_allclose(self.psf.offset, offset_hi)
+        assert_quantity_allclose(self.psf.rad_lo, rad_lo)
+        assert_quantity_allclose(self.psf.rad_hi, rad_hi)
+        assert_quantity_allclose(self.psf.psf_value, psf_value)
 
     def test_write(self, tmpdir):
         filename = str(tmpdir / 'psf.fits')

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -16,11 +16,8 @@ def psf_king():
 
 @requires_data('gammapy-extra')
 def test_psf_king_evaluate(psf_king):
-    energy = Quantity(1, "TeV")
-    off1 = Angle(0, "deg")
-    off2 = Angle(1, "deg")
-    param_off1 = psf_king.evaluate(energy, off1)
-    param_off2 = psf_king.evaluate(energy, off2)
+    param_off1 = psf_king.evaluate(energy='1 TeV', offset='0 deg')
+    param_off2 = psf_king.evaluate('1 TeV', '1 deg')
 
     assert_quantity_allclose(param_off1["gamma"], psf_king.gamma[0, 8])
     assert_quantity_allclose(param_off2["gamma"], psf_king.gamma[2, 8])
@@ -45,9 +42,9 @@ def test_psf_king_to_table(psf_king):
     assert_quantity_allclose(psf_king_table_off2.psf_value[8, 200], value_off2)
 
     # Test that the integral value is close to one
-    bin_off = (psf_king_table_off1.offset[1] - psf_king_table_off1.offset[0])
-    integral = np.sum(psf_king_table_off1.psf_value[8] * 2 * np.pi * psf_king_table_off1.offset * bin_off)
-    assert_quantity_allclose(integral, 1, rtol=1e-1)
+    bin_off = (psf_king_table_off1.rad[1] - psf_king_table_off1.rad[0])
+    integral = np.sum(psf_king_table_off1.psf_value[8] * 2 * np.pi * psf_king_table_off1.rad * bin_off)
+    assert_quantity_allclose(integral, 1, atol=0.03)
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/scripts/image_pipe.py
+++ b/gammapy/scripts/image_pipe.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import logging
 import numpy as np
 from astropy.units import Quantity
 from astropy.table import QTable, Table
@@ -12,8 +11,6 @@ from ..background import fill_acceptance_image
 from ..image import SkyImage, SkyImageList
 
 __all__ = ['SingleObsImageMaker', 'StackedObsImageMaker']
-
-log = logging.getLogger(__name__)
 
 
 class SingleObsImageMaker(object):
@@ -80,9 +77,6 @@ class SingleObsImageMaker(object):
 
         if len(self.events.table) > self.ncounts_min:
             self.images['counts'].fill_events(self.events)
-        else:
-            log.warn('Too few counts, there is only {} events and you requested a minimal counts number of {}'.
-                     format(len(self.events), self.ncounts_min))
 
     def bkg_image(self, bkg_norm=True):
         """

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.tests.helper import assert_quantity_allclose, pytest
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
 from ...utils.testing import requires_data, requires_dependency
 from ...scripts import CTAIrf, CTAPerf

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utils to create scripts and command-line tools"""
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import argparse
 from collections import OrderedDict
@@ -9,7 +8,6 @@ import importlib
 import os
 import glob
 import logging
-import shutil
 from os.path import expandvars
 from ..extern.pathlib import Path
 


### PR DESCRIPTION
This PR is a small step towards  addressing #776. I tried to limit the scope so that I can get it done and the diff remains reviewable. @joleroi - Do you have time to review or should I look over the diff?

The main change here is to use "rad" consistently for the PSF axis name of the offset wrt the source position. For me, this was the worst / most confusing problem. The inconsistency with the FOV offset axis (sometimes called "offset", sometimes "theta") and other issues pointed out in #776 is left for a future PR.

This can break user scripts, especially due to the axis name / attribute change in the `TablePSF` and `EnergyDependentTablePSF` classes.

Note that "rad" is recommended by the spec (see http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/irf_axes/index.html) and used for most PSFs, except for the existing format with gtpsf where they use THETA in the FITS file: http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/full_enclosure/psf/psf_gtpsf/index.html