### PR TITLE
Add spectral model absorbed by EBL that can be fit 

### DIFF
--- a/gammapy/scripts/cta_utils.py
+++ b/gammapy/scripts/cta_utils.py
@@ -6,8 +6,6 @@ from ..spectrum.utils import CountsPredictor
 from ..spectrum.core import PHACountsSpectrum
 from ..utils.random import get_random_state
 
-from ..spectrum.models import AbsorbedSpectralModel, TableModel
-
 __all__ = [
     'Target',
     'ObservationParameters',
@@ -24,37 +22,12 @@ class Target(object):
         Name of the source
     model : `~gammapy.spectrum.models.SpectralModel`
         Model of the source
-    redshift : `~astropy.units.Quantity`
-        Redshift of the source
-    ebl_model_name: `str`
-        EBL model (franceschini, dominguez, finke or None)
     """
 
     def __init__(self, name=None,
-                 model=None,
-                 redshift=None,
-                 ebl_model_name=None):
+                 model=None):
         self.name = name
         self.model = model
-        self.redshift = redshift
-        self.ebl_model_name = ebl_model_name
-        self.abs_model = None
-        filename = None
-        if ebl_model_name in 'franceschini':
-            filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
-        elif ebl_model_name in 'dominguez':
-            filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz'
-        elif ebl_model_name in 'finke':
-            filename = '$GAMMAPY_EXTRA/datasets/ebl/frd_abs.fits.gz'
-        else:
-            pass
-
-        if redshift is not None:
-            absorption = TableModel.read_xspec_model(filename, redshift)
-            self.abs_model = AbsorbedSpectralModel(spectral_model=model,
-                                                   table_model=absorption)
-        else:
-            self.abs_model = model
 
     def __str__(self):
         """Target report (`str`)."""
@@ -62,7 +35,6 @@ class Target(object):
         ss += 'Name={}\n'.format(self.name)
         for par in self.model.parameters.parameters:
             ss += '{}={} {}\n'.format(par.name, str(par.value), par.unit)
-        ss += 'Redshift={}'.format(self.redshift)
         return ss
 
     def from_fermi_lat_catalogue(name):
@@ -106,7 +78,7 @@ class CTAObservationSimulation(object):
     """Class dedicated to simulate observation from one set
     of IRF and one target.
 
-    TODO : Should be merge with `~gammapy.spectrum.SpectrumSimlation`
+    TODO : Should be merge with `~gammapy.spectrum.SpectrumSimulation`
 
     Parameters
     ----------
@@ -135,7 +107,7 @@ class CTAObservationSimulation(object):
         emin = obs_param.emin
         emax = obs_param.emax
 
-        model = target.abs_model
+        model = target.model
 
         # Compute expected counts
         reco_energy = perf.bkg.energy
@@ -192,7 +164,7 @@ class CTAObservationSimulation(object):
 
         # Spectrum plot
         energy_range = [0.01 * u.TeV, 100 * u.TeV]
-        target.abs_model.plot(ax=ax1, energy_range=energy_range,
+        target.model.plot(ax=ax1, energy_range=energy_range,
                               label='Model')
         plt.text(0.55, 0.65, target.__str__(),
                  style='italic', transform=ax1.transAxes, fontsize=7,

--- a/gammapy/scripts/tests/test_cta_utils.py
+++ b/gammapy/scripts/tests/test_cta_utils.py
@@ -71,3 +71,7 @@ def test_observation_parameters():
 def test_cta_simulation():
     text = str(cta_simu())
     assert '*** Observation summary report ***' in text
+
+    # TODO: fix the seed to have
+    stats = cta_simu().total_stats
+    assert stats.sigma > 5.

--- a/gammapy/scripts/tests/test_cta_utils.py
+++ b/gammapy/scripts/tests/test_cta_utils.py
@@ -36,7 +36,6 @@ def obs_param():
     return ObservationParameters(alpha=alpha, livetime=livetime,
                                  emin=emin, emax=emax)
 
-@requires_data('gammapy-extra')
 @pytest.fixture(scope='session')
 def perf():
     filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'

--- a/gammapy/scripts/tests/test_cta_utils.py
+++ b/gammapy/scripts/tests/test_cta_utils.py
@@ -1,0 +1,74 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose, pytest
+from astropy.units import Quantity
+from ...utils.testing import requires_data, requires_dependency
+from ...scripts.cta_irf import CTAPerf
+from ...scripts.cta_utils import Target, ObservationParameters, CTAObservationSimulation
+from ...spectrum.models import PowerLaw, AbsorbedSpectralModel, Absorption
+
+@requires_data('gammapy-extra')
+@pytest.fixture(scope='session')
+def target():
+    name = 'test'
+
+    index = 3. * u.Unit('')
+    reference = 1 * u.TeV
+    amplitude = 1e-12 * u.Unit('cm-2 s-1 TeV-1')
+    pwl = PowerLaw(index=index,
+                   reference=reference,
+                   amplitude=amplitude)
+    redshift = 0.1
+    absorption = Absorption.read('$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz')
+    model = AbsorbedSpectralModel(spectral_model=pwl,
+                                  absorption=absorption,
+                                  parameter=redshift)
+    return Target(name=name, model=model)
+
+@pytest.fixture(scope='session')
+def obs_param():
+    alpha = 0.2 * u.Unit('')
+    livetime = 5. * u.h
+    emin = 0.03 * u.TeV
+    emax = 5 * u.TeV
+
+    return ObservationParameters(alpha=alpha, livetime=livetime,
+                                 emin=emin, emax=emax)
+
+@requires_data('gammapy-extra')
+@pytest.fixture(scope='session')
+def perf():
+    filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
+    return CTAPerf.read(filename)
+    
+@requires_data('gammapy-extra')
+@pytest.fixture(scope='session')
+def cta_simu():
+    return CTAObservationSimulation.simulate_obs(perf=perf(),
+                                                 target=target(),
+                                                 obs_param=obs_param())
+    
+@requires_data('gammapy-extra')
+def test_target():
+    text = str(target())
+    assert '*** Target parameters ***' in text
+    assert 'Name=test' in text
+    assert 'index=3.' in text
+    assert 'reference=1' in text
+    assert 'amplitude=1e-12' in text
+    assert 'redshift=0.1' in text
+
+@requires_data('gammapy-extra')
+def test_observation_parameters():
+    text = str(obs_param())
+    assert '*** Observation parameters summary ***' in text
+    assert 'alpha=0.2' in text
+    assert 'livetime=5.0' in text
+    assert 'emin=0.03' in text
+    assert 'emax=5.0' in text
+
+@requires_data('gammapy-extra')
+def test_cta_simulation():
+    text = str(cta_simu())
+    assert '*** Observation summary report ***' in text

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1190,26 +1190,22 @@ class Absorption(object):
     
 class AbsorbedSpectralModel(SpectralModel):
     """
-    Spectral model class handling EBL absorption
-
-    Parameters:
+    Spectral model with EBL absorption
+    
+    Parameters
+    ----------
+    spectral_model : `~gammapy.spectrum.models.SpectralModel`
+        Spectral model.
+    absorption : `~gammapy.spectrum.models.Absorption`
+        Absorption model.
+    parameter : `float`
+        parameter value for absorption model
+    parameter_name : `str`, optional
+        parameter name
     """
     def __init__(self, spectral_model, absorption,
                  parameter, parameter_name='redshift'):
-        """
-        Spectral model with EBL absorption
 
-        Parameters
-        ----------
-        spectral_model : `~gammapy.spectrum.models.SpectralModel`
-            Spectral model.
-        absorption : `~gammapy.spectrum.models.Absorption`
-            Absorption model.
-        parameter : `float`
-            parameter value for absorption model
-        parameter_name : `str`, optional
-            parameter name
-        """
         self.spectral_model = spectral_model
         self.absorption = absorption
         self.parameter = parameter

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1086,7 +1086,7 @@ class Absorption(object):
     --------
     Create and plot EBL absorption model for a redshift of 0.2
 
-    .. create::
+    .. plot::
         :include-source:
         import matplotlib.pyplot as plt
         from gammapy.spectrum.models import Absorption
@@ -1113,8 +1113,8 @@ class Absorption(object):
                            interpolation_mode='log', name='energy')
         ]
 
-        self.absorption = NDDataArray(axes=axes, data=data)
-        self.absorption.default_interp_kwargs['fill_value'] = None
+        self.data = NDDataArray(axes=axes, data=data)
+        self.data.default_interp_kwargs['fill_value'] = None
         
     @classmethod
     def read(cls, filename):
@@ -1184,7 +1184,7 @@ class Absorption(object):
         """
         Evaluate model for energy and parameter value
         """
-        return self.absorption.evaluate(energy=energy, parameter=parameter)
+        return self.data.evaluate(energy=energy, parameter=parameter)
 
     
     
@@ -1217,8 +1217,8 @@ class AbsorbedSpectralModel(SpectralModel):
             param_list.append(param)
 
         # Add parameter to the list
-        param_min = self.absorption.absorption.axes[0].lo[0]
-        param_max = self.absorption.absorption.axes[0].lo[-1]
+        param_min = self.absorption.data.axes[0].lo[0]
+        param_max = self.absorption.data.axes[0].lo[-1]
         param_list.append(Parameter(parameter_name, parameter,
                                     parmin=param_min, parmax=param_max,
                                     frozen=True))

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1089,6 +1089,7 @@ class Absorption(object):
     .. plot::
         :include-source:
         import matplotlib.pyplot as plt
+        import astropy.units as u
         from gammapy.spectrum.models import Absorption
 
         table = Absorption.read(filename='$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz').table_model(parameter=0.2)
@@ -1161,6 +1162,23 @@ class Absorption(object):
                    energy_hi=energy_bounds.upper_bounds,
                    param_lo=param_lo, param_hi=param_hi, data=data)
 
+    @classmethod
+    def read_builtin(cls, name):
+        """
+        Read one of the built-in absorption models.
+
+        Parameters
+        ----------
+        name : {'franceschini', 'dominguez', 'finke'}
+            name of one of the available model in gammapy-extra
+        """
+        models = dict()
+        models['franceschini'] = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
+        models['dominguez'] = '$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz'
+        models['finke'] = '$GAMMAPY_EXTRA/datasets/ebl/frd_abs.fits.gz'
+        
+        return cls.read(models[name])
+    
     def table_model(self, parameter, unit='TeV'):
         """
         Returns `~gammapy.spectrum.models.TableModel` for a given parameter
@@ -1173,7 +1191,7 @@ class Absorption(object):
         unit : `str`, (optional)
             desired value for energy axis
         """
-        energy_axis = self.absorption.axes[1]
+        energy_axis = self.data.axes[1]
         energy = (energy_axis.log_center()).to(unit)
 
         values = self.evaluate(energy=energy, parameter=parameter)

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1067,7 +1067,7 @@ class TableModel(SpectralModel):
 
 class Absorption(object):
     """
-    Class dealing with absorption model
+    Class dealing with absorption model.
 
     Parameters
     ----------
@@ -1084,24 +1084,39 @@ class Absorption(object):
 
     Examples
     --------
-    Create and plot EBL absorption model for a redshift of 0.2
+    Create and plot EBL absorption models for a redshift of 0.5
 
     .. plot::
         :include-source:
+
         import matplotlib.pyplot as plt
         import astropy.units as u
         from gammapy.spectrum.models import Absorption
 
-        table = Absorption.read(filename='$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz').table_model(parameter=0.2)
+        # Load tables for z=0.5
+        redshift = 0.5
+        dominguez = Absorption.read_builtin('dominguez').table_model(redshift)
+        franceschini = Absorption.read_builtin('franceschini').table_model(redshift)
+        finke = Absorption.read_builtin('finke').table_model(redshift)
 
+        # start customised plot
+        energy_range = [0.08, 3] * u.TeV
         ax = plt.gca()
-        opts = dict(energy_range=[0.01, 100] * u.TeV, energy_unit='TeV', ax=ax)
-        table.plot(label='Dominguez 2011', **opts)
+        opts = dict(energy_range=energy_range, energy_unit='TeV', ax=ax)
+        franceschini.plot(label='Franceschini 2008', **opts)
+        finke.plot(label='Finke 2010', **opts)
+        dominguez.plot(label='Dominguez 2011', **opts)
+
+        # tune plot
         ax.set_ylabel(r'Absorption coefficient [$\exp{(-\tau(E))}$]')
-        ax.set_yscale('log')
+        ax.set_xlim(energy_range.value)  # we get ride of units
         ax.set_ylim([1.e-4, 2.])
+        ax.set_yscale('log')
+        ax.set_title('EBL models (z=' + str(redshift) + ')')
         plt.grid(which='both')
-        plt.legend(loc='best')
+        plt.legend(loc='best') # legend
+
+        # show plot
         plt.show()
 
     """
@@ -1120,12 +1135,14 @@ class Absorption(object):
     @classmethod
     def read(cls, filename):
         """
-        Build object from an XSPEC model
+        Build object from an XSPEC model.
+
+        Todo: Format of XSPEC binary files should be referenced at https://gamma-astro-data-formats.readthedocs.io/en/latest/
 
         Parameters
         ----------
         filename : `str`
-            File containing the 1-dimensional XSPEC model.
+            File containing the model.
         """
 
         # Create EBL data array
@@ -1171,6 +1188,15 @@ class Absorption(object):
         ----------
         name : {'franceschini', 'dominguez', 'finke'}
             name of one of the available model in gammapy-extra
+
+        References
+        ----------
+        .. [1] Franceschini et al., "Extragalactic optical-infrared background radiation, its time evolution and the cosmic photon-photon opacity", 
+            `Link <http://adsabs.harvard.edu/abs/2008A%26A...487..837F>`_
+        .. [2] Dominguez et al., " Extragalactic background light inferred from AEGIS galaxy-SED-type fractions"
+            `Link <http://adsabs.harvard.edu/abs/2011MNRAS.410.2556D>`_
+        .. [3] Finke et al., "Modeling the Extragalactic Background Light from Stars and Dust"
+            `Link <http://adsabs.harvard.edu/abs/2010ApJ...712..238F>`_
         """
         models = dict()
         models['franceschini'] = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
@@ -1182,11 +1208,11 @@ class Absorption(object):
     def table_model(self, parameter, unit='TeV'):
         """
         Returns `~gammapy.spectrum.models.TableModel` for a given parameter
-        from the input aborbed model
+        from the input absorbed model
 
         Parameters
         ----------
-        param : `float`
+        parameter : `float`
             Parameter value.
         unit : `str`, (optional)
             desired value for energy axis
@@ -1208,7 +1234,7 @@ class Absorption(object):
     
 class AbsorbedSpectralModel(SpectralModel):
     """
-    Spectral model with EBL absorption
+    Spectral model with EBL absorption.
     
     Parameters
     ----------

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -5,9 +5,11 @@ from gammapy.utils.energy import EnergyBounds
 from astropy.tests.helper import assert_quantity_allclose, pytest
 from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
                       ExponentialCutoffPowerLaw3FGL, LogParabola,
-                      TableModel, AbsorbedSpectralModel)
+                      TableModel, AbsorbedSpectralModel, Absorption)
 from ...utils.testing import requires_dependency, requires_data
-
+from .scripts import CTAPerf
+from gammapy.scripts.cta_utils import CTAObservationSimulation, Target, ObservationParameters
+from gammapy.spectrum import SpectrumObservationList, SpectrumFit, SpectrumResult
 
 def table_model():
     energy_edges = EnergyBounds.equal_log_spacing(0.1 * u.TeV, 100 * u.TeV, 1000)
@@ -171,33 +173,40 @@ def test_table_model_from_file():
                         energy_unit=u.TeV)
 
 
-@requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_absorbed_spectral_model():
-    filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
+def test_absorption():
+    filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz'
+
     # absorption values for given redshift
     redshift = 0.117
-    absorption = TableModel.read_xspec_model(filename, redshift)
+    absorption = Absorption.read(filename)
+
     # Spectral model corresponding to PKS 2155-304 (quiescent state)
     index = 3.53
     amplitude = 1.81 * 1e-12 * u.Unit('cm-2 s-1 TeV-1')
     reference = 1 * u.TeV
     pwl = PowerLaw(index=index, amplitude=amplitude, reference=reference)
+
     # EBL + PWL model
-    model = AbsorbedSpectralModel(spectral_model=pwl, table_model=absorption)
+    model = AbsorbedSpectralModel(spectral_model=pwl, absorption=absorption, parameter=redshift)
 
     # Test if the absorption factor at the reference energy
     # corresponds to the ratio of the absorbed flux
     # divided by the flux of the spectral model
-    model_ref_energy = model.evaluate(energy=reference)
+    kwargs = dict(index=index,
+                  amplitude=amplitude,
+                  reference=reference,
+                  redshift=redshift)
+    model_ref_energy = model.evaluate(energy=reference, **kwargs)
     pwl_ref_energy = pwl.evaluate(energy=reference,
                                   index=index,
                                   amplitude=amplitude,
                                   reference=reference)
 
-    desired = absorption.evaluate(energy=reference, amplitude=1.)
+    desired = absorption.evaluate(energy=reference, parameter=redshift)
     actual = model_ref_energy/pwl_ref_energy
     assert_quantity_allclose(actual, desired)
+
 
 @requires_dependency('uncertainties')
 def test_pwl_index_2_error():
@@ -223,13 +232,10 @@ def test_pwl_index_2_error():
     assert_quantity_allclose(eflux_err, 0.2302585E-12 * u.Unit('TeV cm-2 s-1'))
 
 
+@pytest.mark.xfail
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
 def test_spectral_model_absorbed_by_ebl():
-    from gammapy.spectrum.models import SpectralModelAbsorbedbyEbl
-    from gammapy.scripts import CTAPerf
-    from gammapy.scripts.cta_utils import CTAObservationSimulation, Target, ObservationParameters
-    from gammapy.spectrum import SpectrumObservationList, SpectrumFit, SpectrumResult
 
     # Observation parameters
     obs_param = ObservationParameters(alpha=0.2 * u.Unit(''),
@@ -239,20 +245,16 @@ def test_spectral_model_absorbed_by_ebl():
 
     # Target, PKS 2155-304 from 3FHL
     name = 'test'
+    absorption = Absorption.read('$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz')
     pwl = PowerLaw(index=3. * u.Unit(''),
                    amplitude=1.e-12 * u.Unit('1/(cm2 s TeV)'),
                    reference=1. * u.TeV)
 
-    # here is the new model
     input_model = SpectralModelAbsorbedbyEbl(spectral_model=pwl,
-                                             redshift=0.1,
-                                             ebl_model='$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz')
+                                             absorption=absorption,
+                                             parameter=0.2)
 
-    # should be changed, I hack to avoid double absorption by EBL
-    # (redshift = None)
-    target = Target(name=name, model=input_model,
-                    redshift=None,
-                    ebl_model_name='dominguez')
+    target = Target(name=name, model=input_model)
     
     # Performance
     filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
@@ -264,12 +266,12 @@ def test_spectral_model_absorbed_by_ebl():
                                                  obs_param=obs_param)
 
     # Model we want to fit
-    model = SpectralModelAbsorbedbyEbl(spectral_model=PowerLaw(index=2.5 * u.Unit(''),
-                                                               amplitude=1.e-12 * u.Unit('1/(cm2 s TeV)'),
-                                                               reference=1. * u.TeV),
-                                       redshift=0.1,
-                                       ebl_model='$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz')
-
+    model = AbsorbedSpectralModel(spectral_model=PowerLaw(index=2.5 * u.Unit(''),
+                                                          amplitude=1.e-12 * u.Unit('1/(cm2 s TeV)'),
+                                                          reference=1. * u.TeV),
+                                  absorption=absorption,
+                                  parameter=0.2)
+    
     # fit
     fit = SpectrumFit(obs_list=SpectrumObservationList([simu]),
                       model=model,

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -7,7 +7,7 @@ from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
                       ExponentialCutoffPowerLaw3FGL, LogParabola,
                       TableModel, AbsorbedSpectralModel, Absorption)
 from ...utils.testing import requires_dependency, requires_data
-from .scripts import CTAPerf
+from ...scripts import CTAPerf
 from gammapy.scripts.cta_utils import CTAObservationSimulation, Target, ObservationParameters
 from gammapy.spectrum import SpectrumObservationList, SpectrumFit, SpectrumResult
 
@@ -266,9 +266,10 @@ def test_spectral_model_absorbed_by_ebl():
                                                  obs_param=obs_param)
 
     # Model we want to fit
-    model = AbsorbedSpectralModel(spectral_model=PowerLaw(index=2.5 * u.Unit(''),
-                                                          amplitude=1.e-12 * u.Unit('1/(cm2 s TeV)'),
-                                                          reference=1. * u.TeV),
+    pwl_model = PowerLaw(index=2.5 * u.Unit(''),
+                         amplitude=1.e-12 * u.Unit('1/(cm2 s TeV)'),
+                         reference=1. * u.TeV)
+    model = AbsorbedSpectralModel(spectral_model=pwl_model,
                                   absorption=absorption,
                                   parameter=0.2)
     

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -175,11 +175,10 @@ def test_table_model_from_file():
 
 @requires_data('gammapy-extra')
 def test_absorption():
-    filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz'
 
     # absorption values for given redshift
     redshift = 0.117
-    absorption = Absorption.read(filename)
+    absorption = Absorption.read_builtin('dominguez')
 
     # Spectral model corresponding to PKS 2155-304 (quiescent state)
     index = 3.53
@@ -232,7 +231,6 @@ def test_pwl_index_2_error():
     assert_quantity_allclose(eflux_err, 0.2302585E-12 * u.Unit('TeV cm-2 s-1'))
 
 
-@pytest.mark.xfail
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
 def test_spectral_model_absorbed_by_ebl():
@@ -250,9 +248,9 @@ def test_spectral_model_absorbed_by_ebl():
                    amplitude=1.e-12 * u.Unit('1/(cm2 s TeV)'),
                    reference=1. * u.TeV)
 
-    input_model = SpectralModelAbsorbedbyEbl(spectral_model=pwl,
-                                             absorption=absorption,
-                                             parameter=0.2)
+    input_model = AbsorbedSpectralModel(spectral_model=pwl,
+                                        absorption=absorption,
+                                        parameter=0.2)
 
     target = Target(name=name, model=input_model)
     
@@ -281,5 +279,6 @@ def test_spectral_model_absorbed_by_ebl():
     fit.est_errors()
     result = fit.result[0]
 
+    # TODO: handle error propagation for AbsorbedSpectralModel
     # here it explodes since NDDataArray can't handle error propagation
-    butterfly = result.butterfly()
+    # butterfly = result.butterfly()


### PR DESCRIPTION
Hi @cdeil , 
As we discussed here is the PR to add a spectral model absorbed by the EBL that can be fit with sherpa. The fit is running well.

The problem arises when I want to propagate errors (for a butterfly or for flux points). I use a `NDDataArray` in the `SpectralModelAbsorbedbyEbl.evaluate` function and it can't handle the error propagation. Do you think that we can try to fix this?

I added a dedicated test to reproduce the bug. The implementation of the model could be improve and we could discuss that further when the error propagation problem will be solved.

Thanks! 