### PR TITLE
Minor code and docstring cleanup

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -944,10 +944,10 @@ for some classes in Gammapy (e.g. classes that inherit the ``info`` method from
 ``astropy.table.Table``.
 
 
-Validating H.E.S.S. Fits exporters
+Validating H.E.S.S. FITS exporters
 ----------------------------------
 
-The H.E.S.S. experiment has 3 independent analysis chains, which all have exporters to the :ref:`gadf:iact-irfs` format.
+The H.E.S.S. experiment has 3 independent analysis chains, which all have exporters to the :ref:`gadf:main-page` format.
 The Gammapy tests contain a mechanism to track changes in these exporters.
 
 

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -15,7 +15,7 @@ Introduction
 * Energy dispersion (EDISP)
 * Point spread function (PSF)
 
-Most of the formats defined at :ref:`gadf:iact-irfs` are supported.  Otherwise,
+Most of the formats defined at :ref:`gadf:iact-irf` are supported.  Otherwise,
 at the moment, there is very little support for Fermi-LAT or other instruments.
 
 Most users will not use `gammapy.irf` directly, but will instead use IRFs as

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -2,13 +2,13 @@
 """Source catalog and object base classes.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ..utils.array import _is_int
 from collections import OrderedDict
 import sys
 from pprint import pprint
 from astropy.extern import six
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
+from ..utils.array import _is_int
 
 __all__ = [
     'SourceCatalog',
@@ -73,13 +73,13 @@ class SourceCatalog(object):
     base class for the other source catalog classes.
 
     This is a thin wrapper around `~astropy.table.Table`,
-    which is stored in the `catalog.table` attribute.
+    which is stored in the ``catalog.table`` attribute.
 
     Parameters
     ----------
     table : `~astropy.table.Table`
         Table with catalog data.
-    source_name_key : str ('Source_Name')
+    source_name_key : str
         Column with source name information
     source_name_alias : tuple of str
         Columns with source name aliases. This will allow accessing the source

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -547,7 +547,7 @@ class SkyCube(MapBase):
             Any valid ds9 command line option can be passed.
             See http://ds9.si.edu/doc/ref/command.html for details.
         **kwargs : dict
-            Keyword arguments passed to `~matplotlib.pyplot.imshow`.
+            Keyword arguments passed to `matplotlib.pyplot.imshow`.
         """
         import matplotlib.pyplot as plt
         from ipywidgets import interact
@@ -569,6 +569,8 @@ class SkyCube(MapBase):
             return interact(show_image, idx=(0, max_, 1))
         elif viewer == 'ds9':
             raise NotImplementedError
+        else:
+            raise ValueError('Invalid viewer: {}'.format(viewer))
 
     def plot_rgb(self, ax=None, fig=None, **kwargs):
         """
@@ -664,7 +666,7 @@ class SkyCube(MapBase):
 
         Parameters
         ----------
-        reference : `~astropy.io.fits.Header`, `SkyImage` or `SkyCube`
+        reference : `~astropy.io.fits.Header`, `~gamampy.image.SkyImage` or `SkyCube`
             Reference wcs specification to reproject the data on.
         mode : {'interp', 'exact'}
             Interpolation mode.

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -388,7 +388,7 @@ class SkyCube(MapBase):
         Returns
         -------
         (position, energy) : tuple
-            Tuple of (`~astropy.coordinates.SkyCoord`, `~astropy.unit.Quantity`).
+            Tuple of (`~astropy.coordinates.SkyCoord`, `~astropy.units.Quantity`).
         """
         position = self.sky_image_ref.wcs_pixel_to_skycoord(x, y)
         energy = self.energy_axis.wcs_pix2world(z)
@@ -583,7 +583,7 @@ class SkyCube(MapBase):
 
         Returns
         -------
-        ax : `~astropy.visualization.wcsaxes.WCSAxes`, optional
+        ax : `~astropy.visualization.wcsaxes.WCSAxes`
             WCS axis object
         """
         import matplotlib.pyplot as plt
@@ -597,12 +597,15 @@ class SkyCube(MapBase):
         kwargs['origin'] = kwargs.get('origin', 'lower')
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
 
-        if not self.data.shape[0] == 3:
+        ne = self.data.shape[0]
+        if ne != 3:
             raise ValueError("Energy axes must be length 3, but is {}".format(ne))
+
         data_rgb = []
         for idx in range(3):
             data_rgb.append(self.data[idx, :, :])
-        caxes = ax.imshow(np.dstack(data_rgb), **kwargs)
+
+        ax.imshow(np.dstack(data_rgb), **kwargs)
 
         try:
             ax.coords['glon'].set_axislabel('Galactic Longitude')
@@ -610,11 +613,10 @@ class SkyCube(MapBase):
         except KeyError:
             ax.coords['ra'].set_axislabel('Right Ascension')
             ax.coords['dec'].set_axislabel('Declination')
-        except AttributeError:
-            log.info("Can't set coordinate axes. No WCS information available.")
 
         # without this the axis limits are changed when calling scatter
         ax.autoscale(enable=False)
+
         return ax
 
     def sky_image_integral(self, emin, emax, nbins=10, per_decade=False, interpolation='linear'):

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -666,7 +666,7 @@ class SkyCube(MapBase):
 
         Parameters
         ----------
-        reference : `~astropy.io.fits.Header`, `~gamampy.image.SkyImage` or `SkyCube`
+        reference : `~astropy.io.fits.Header`, `~gammapy.image.SkyImage` or `SkyCube`
             Reference wcs specification to reproject the data on.
         mode : {'interp', 'exact'}
             Interpolation mode.

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -11,7 +11,7 @@ from ..stats import significance
 from ..irf import TablePSF
 from ..background import fill_acceptance_image
 from ..cube import SkyCube
-from .exposure import exposure_cube
+from .exposure import make_exposure_cube
 
 __all__ = ['SingleObsCubeMaker', 'StackedObsCubeMaker']
 
@@ -37,7 +37,7 @@ class SingleObsCubeMaker(object):
         Reference Cube for images in reco energy
     empty_exposure_cube : `~gammapy.cube.SkyCube`
         Reference Cube for exposure in true energy
-    offset_band : `astropy.coordinates.Angle`
+    offset_band : `~astropy.coordinates.Angle`
         Offset band selection
     exclusion_mask : `~gammapy.cube.SkyCube`
         Exclusion mask
@@ -130,13 +130,15 @@ class SingleObsCubeMaker(object):
 
     def make_exposure_cube(self):
         """
-        Compute the exposure cube
+        Compute the exposure cube.
         """
-        self.exposure_cube = exposure_cube(pointing=self.obs_center,
-                                           livetime=self.livetime,
-                                           aeff2d=self.aeff,
-                                           ref_cube=self.exposure_cube,
-                                           offset_max=self.offset_band[1])
+        self.exposure_cube = make_exposure_cube(
+            pointing=self.obs_center,
+            livetime=self.livetime,
+            aeff=self.aeff,
+            ref_cube=self.exposure_cube,
+            offset_max=self.offset_band[1],
+        )
 
     def make_significance_cube(self, radius):
         """Make the significance cube from the counts and bkg cubes.
@@ -184,10 +186,10 @@ class StackedObsCubeMaker(object):
         Required columns: OBS_ID
     exclusion_mask : `~gammapy.cube.SkyCube`
         Exclusion mask
-    save_bkg_scale: bool
+    save_bkg_scale : bool
         True if you want to save the normalisation of the bkg for each run
-        in a `Table` table_bkg_norm with two columns:
-         "OBS_ID" and "bkg_scale"
+        in a table table_bkg_norm with two columns:
+        "OBS_ID" and "bkg_scale"
     """
 
     def __init__(self, empty_cube_images, empty_exposure_cube=None,
@@ -277,14 +279,14 @@ class StackedObsCubeMaker(object):
     # Define a method for the mean psf from a list of observation
     def make_mean_psf_cube(self, ref_cube, spectral_index=2.3):
         """
-        Compute the mean psf for a set of observation for different energy bands
+        Compute the mean psf for a set of observation for different energy bands.
 
         Parameters
         ----------
         ref_cube : `~gammapy.cube.SkyCube`
             Reference sky cube to evaluate PSF on.
-        spectral_index: float
-            Assumed spectral index to compute mean psf in energy band.
+        spectral_index : float
+            Assumed spectral index to compute mean PSF in energy band.
 
         Returns
         -------

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -42,11 +42,12 @@ class SingleObsCubeMaker(object):
     exclusion_mask : `~gammapy.cube.SkyCube`
         Exclusion mask
     save_bkg_scale: bool
-        True if you want to save the normalisation of the bkg computed outside the exclusion region in a Table
+        True if you want to save the normalisation of the bkg
+        computed outside the exclusion region in a Table
     """
 
-    def __init__(self, obs, empty_cube_images, empty_exposure_cube, offset_band, exclusion_mask=None,
-                 save_bkg_scale=True):
+    def __init__(self, obs, empty_cube_images, empty_exposure_cube,
+                 offset_band, exclusion_mask=None, save_bkg_scale=True):
         self.energy_reco = empty_cube_images.energies(mode="edges")
         self.offset_band = offset_band
         self.counts_cube = SkyCube.empty_like(empty_cube_images)
@@ -85,9 +86,9 @@ class SingleObsCubeMaker(object):
             If true, apply the scaling factor from the number of counts
             outside the exclusion region to the bkg image
         """
-        for i_E in range(len(self.energy_reco) - 1):
+        for idx_energy in range(len(self.energy_reco) - 1):
             energy_band = Energy(
-                [self.energy_reco[i_E].value, self.energy_reco[i_E + 1].value],
+                [self.energy_reco[idx_energy].value, self.energy_reco[idx_energy + 1].value],
                 self.energy_reco.unit)
             table = self.bkg.acceptance_curve_in_energy_band(
                 energy_band=energy_band)
@@ -96,9 +97,12 @@ class SingleObsCubeMaker(object):
                                             table["offset"],
                                             table["Acceptance"],
                                             self.offset_band[1])
-            bkg_image = Quantity(bkg_hdu.data, table[
-                "Acceptance"].unit) * self.bkg_cube.sky_image_ref.solid_angle() * self.livetime
-            self.bkg_cube.data[i_E, :, :] = bkg_image.decompose().value
+            bkg_image = (
+                Quantity(bkg_hdu.data, table["Acceptance"].unit) *
+                self.bkg_cube.sky_image_ref.solid_angle() *
+                self.livetime
+            )
+            self.bkg_cube.data[idx_energy, :, :] = bkg_image.decompose().value
 
         if bkg_norm:
             scale = self.background_norm_factor()
@@ -107,24 +111,18 @@ class SingleObsCubeMaker(object):
                 self.table_bkg_scale.add_row([self.obs_id, scale])
 
     def background_norm_factor(self):
-        """Determine the scaling factor to apply to the background images on the whole reco energy range.
+        """Determine the scaling factor to apply to the background
+        images on the whole reco energy range.
 
-        Compares the events in the counts cube and the bkg cube outside the exclusion regions.
-
-        Parameters
-        ----------
-        counts : `~gammapy.cube.SkyCube`
-            counts images cube
-        bkg : `~gammapy.cube.SkyCube`
-            bkg images cube
+        Compares the events in the counts cube and the bkg cube
+        outside the exclusion regions.
 
         Returns
         -------
         scale : float
             scaling factor between the counts and the bkg images outside the exclusion region.
         """
-        counts_sum = np.sum(
-            self.counts_cube.data * self.cube_exclusion_mask.data)
+        counts_sum = np.sum(self.counts_cube.data * self.cube_exclusion_mask.data)
         bkg_sum = np.sum(self.bkg_cube.data * self.cube_exclusion_mask.data)
         scale = counts_sum / bkg_sum
 
@@ -163,7 +161,8 @@ class SingleObsCubeMaker(object):
 class StackedObsCubeMaker(object):
     """Compute stacked cubes for many observations.
 
-    The computed cubes are stored in a `~gammapy.cube.SkyCube` with the following name:
+    The computed cubes are stored in a `~gammapy.cube.SkyCube`
+    with the following name:
 
     * ``counts_cube`` : Counts
     * ``bkg_cube`` : Background model
@@ -186,11 +185,13 @@ class StackedObsCubeMaker(object):
     exclusion_mask : `~gammapy.cube.SkyCube`
         Exclusion mask
     save_bkg_scale: bool
-        True if you want to save the normalisation of the bkg for each run in a `Table` table_bkg_norm with two columns:
+        True if you want to save the normalisation of the bkg for each run
+        in a `Table` table_bkg_norm with two columns:
          "OBS_ID" and "bkg_scale"
     """
 
-    def __init__(self, empty_cube_images, empty_exposure_cube=None, offset_band=None, data_store=None, obs_table=None,
+    def __init__(self, empty_cube_images, empty_exposure_cube=None,
+                 offset_band=None, data_store=None, obs_table=None,
                  exclusion_mask=None, save_bkg_scale=True):
 
         self.empty_cube_images = empty_cube_images
@@ -217,7 +218,8 @@ class StackedObsCubeMaker(object):
             self.table_bkg_scale = Table(names=["OBS_ID", "bkg_scale"])
 
     def make_cubes(self, make_background_image=False, bkg_norm=True, radius=10):
-        """Compute the total counts, bkg, exposure, excess and significance cubes for a set of observation.
+        """Compute the total counts, bkg, exposure, excess and
+        significance cubes for a set of observation.
 
         Parameters
         ----------
@@ -239,6 +241,7 @@ class StackedObsCubeMaker(object):
                                              save_bkg_scale=self.save_bkg_scale)
             cube_images.make_counts_cube()
             self.counts_cube.data += cube_images.counts_cube.data
+
             if make_background_image:
                 cube_images.make_bkg_cube(bkg_norm)
                 if self.save_bkg_scale:
@@ -247,6 +250,7 @@ class StackedObsCubeMaker(object):
                 cube_images.make_exposure_cube()
                 self.bkg_cube.data += cube_images.bkg_cube.data
                 self.exposure_cube.data += cube_images.exposure_cube.data.to("m2 s")
+
         if make_background_image:
             self.make_significance_cube(radius)
             self.make_excess_cube()
@@ -293,19 +297,25 @@ class StackedObsCubeMaker(object):
         header = ref_cube.sky_image_ref.to_image_hdu().header
         energy_bins = ref_cube.energies()
         center = ref_cube.sky_image_ref.center
-        for i_E, E in enumerate(energy_bins[0:-1]):
-            energy_band = Energy([energy_bins[i_E].value, energy_bins[i_E + 1].value], energy_bins.unit)
+
+        for idx_energy, E in enumerate(energy_bins[0:-1]):
+            energy_band = Energy([energy_bins[idx_energy].value, energy_bins[idx_energy + 1].value], energy_bins.unit)
             energy = EnergyBounds.equal_log_spacing(energy_band[0].value, energy_band[1].value, 100, energy_band.unit)
             psf_energydependent = obslist.make_mean_psf(center, energy, theta=None)
             try:
-                psf_table = psf_energydependent.table_psf_in_energy_band(energy_band, spectral_index=spectral_index)
+                psf_table = psf_energydependent.table_psf_in_energy_band(
+                    energy_band, spectral_index=spectral_index)
             except:
                 rad = psf_energydependent.rad
-                dp_domega = u.Quantity(np.zeros(len(psf_energydependent.rad)), u.sr ** -1)
+                dp_domega = u.Quantity(np.zeros(len(psf_energydependent.rad)), 'sr-1')
                 psf_table = TablePSF(rad, dp_domega)
 
-            data = fill_acceptance_image(header, center, psf_table._rad.to("deg"),
-                                         psf_table._dp_domega, psf_table._rad.to("deg")[-1]).data
-            ref_cube.data[i_E, :, :] = data / data.sum()
+            image = fill_acceptance_image(
+                header, center,
+                psf_table._rad.to("deg"),
+                psf_table._dp_domega,
+                psf_table._rad.to("deg")[-1],
+            )
+            ref_cube.data[idx_energy, :, :] = image.data / image.data.sum()
 
         return ref_cube

--- a/gammapy/cube/cube_pipe.py
+++ b/gammapy/cube/cube_pipe.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class SingleObsCubeMaker(object):
-    """Compute '~gammapy.cube.SkyCube' images for one observation.
+    """Compute `~gammapy.cube.SkyCube` images for one observation.
 
     The computed cubes are stored in a `~gammapy.cube.SkyCube` with the following name:
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -68,4 +68,4 @@ def make_exposure_cube_obs(obs, ref_cube=None):
     if not ref_cube:
         ref_cube = obs.ref_cube
 
-    return exposure_cube(obs.pointing, obs.livetime, obs.irfs.aeff2d, ref_cube)
+    return make_exposure_cube(obs.pointing, obs.livetime, obs.irfs.aeff2d, ref_cube)

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -3,16 +3,16 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from .core import SkyCube
 
 __all__ = [
-    'exposure_cube'
+    'make_exposure_cube'
 ]
 
 
-def exposure_cube(pointing,
-                  livetime,
-                  aeff2d,
-                  ref_cube,
-                  offset_max=None,
-                  ):
+def make_exposure_cube(pointing,
+                       livetime,
+                       aeff,
+                       ref_cube,
+                       offset_max=None,
+                       ):
     """Calculate exposure cube.
 
     Parameters
@@ -21,32 +21,34 @@ def exposure_cube(pointing,
         Pointing direction
     livetime : `~astropy.units.Quantity`
         Livetime
-    aeff2d : `~gammapy.irf.EffectiveAreaTable2D`
+    aeff : `~gammapy.irf.EffectiveAreaTable2D`
         Effective area table
-    ref_cube : `~gammapy.data.SkyCube`
+    ref_cube : `~gammapy.cube.SkyCube`
         Reference cube used to define geometry
     offset_max : `~astropy.coordinates.Angle`
         Maximum field of view offset.
 
     Returns
     -------
-    expcube : `~gammapy.data.SkyCube`
+    expcube : `~gammapy.cube.SkyCube`
         Exposure cube (3D)
     """
     coordinates = ref_cube.sky_image_ref.coordinates()
     offset = coordinates.separation(pointing)
-
     energy = ref_cube.energies()
-    exposure = aeff2d.data.evaluate(offset=offset, energy=energy)
+
+    exposure = aeff.data.evaluate(offset=offset, energy=energy)
     exposure *= livetime
     exposure[:, offset >= offset_max] = 0
-    expcube = SkyCube(data=exposure,
-                      wcs=ref_cube.wcs,
-                      energy_axis=ref_cube.energy_axis)
-    return expcube
+
+    return SkyCube(
+        data=exposure,
+        wcs=ref_cube.wcs,
+        energy_axis=ref_cube.energy_axis,
+    )
 
 
-def obs_exposure_cube(obs, ref_cube=None):
+def make_exposure_cube_obs(obs, ref_cube=None):
     """Make exposure cube for a given observation.
 
     Parameters

--- a/gammapy/cube/healpix.py
+++ b/gammapy/cube/healpix.py
@@ -1,22 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-
 from astropy.io import fits
 from astropy.table import Table
 from astropy import units as u
-
-from .core import SkyCube
 from ..image.healpix import SkyImageHealpix, WCSHealpix
 from ..spectrum.utils import LogEnergyAxis
 from ..utils.energy import EnergyBounds
 from ..utils.scripts import make_path
+from .core import SkyCube
 
 __all__ = ['SkyCubeHealpix']
 
 
 class SkyCubeHealpix(object):
     """
-    Sky cube object with healpix pixelisation.
+    Sky cube object with HEALPIX pixelisation.
 
     First axis is energy axis.
     """
@@ -116,6 +114,7 @@ class SkyCubeHealpix(object):
 
         data = u.Quantity(np.stack(out, axis=0), self.data.unit)
         wcs = image_out.wcs.copy()
+
         return SkyCube(name=self.name, data=data, wcs=wcs, meta=self.meta,
                        energy_axis=self.energy_axis)
 
@@ -137,6 +136,9 @@ class SkyCubeHealpix(object):
             z = np.arange(self.data.shape[0])
         elif mode == 'edges':
             z = np.arange(self.data.shape[0] + 1) - 0.5
+        else:
+            raise ValueError('Invalid mode: {}'.format(mode))
+
         return self.energy_axis.wcs_pix2world(z)
 
     def __str__(self):

--- a/gammapy/cube/tests/test_cube_pipe.py
+++ b/gammapy/cube/tests/test_cube_pipe.py
@@ -37,9 +37,10 @@ def make_empty_cube(image_size, energy, center, data_unit=None):
     def_image["coordsys"] = 'GAL'
     def_image["unit"] = data_unit
     e_min, e_max, nbins = energy
-    empty_cube = SkyCube.empty(emin=e_min.value, emax=e_max.value, enumbins=nbins, eunit=e_min.unit, mode='edges',
-                               **def_image)
-    return empty_cube
+    return SkyCube.empty(
+        emin=e_min.value, emax=e_max.value, enumbins=nbins, eunit=e_min.unit,
+        mode='edges', **def_image
+    )
 
 
 # Temp xfail for this: https://github.com/gammapy/gammapy/pull/899#issuecomment-281001655

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -5,7 +5,7 @@ from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EffectiveAreaTable2D
-from .. import exposure_cube
+from .. import make_exposure_cube
 from .. import SkyCube
 
 
@@ -17,11 +17,13 @@ def test_exposure_cube():
 
     pointing = SkyCoord(83.633, 21.514, unit='deg')
     livetime = Quantity(1581.17, 's')
-    aeff2d = EffectiveAreaTable2D.read(aeff_filename, hdu='AEFF_2D')
+    aeff = EffectiveAreaTable2D.read(aeff_filename, hdu='AEFF_2D')
     count_cube = SkyCube.read(ccube_filename, format='fermi-counts')
     offset_max = Angle(2.2, 'deg')
-    exp_cube = exposure_cube(pointing, livetime, aeff2d, count_cube,
-                             offset_max=offset_max)
+
+    exp_cube = make_exposure_cube(
+        pointing, livetime, aeff, count_cube, offset_max=offset_max,
+    )
     exp_ref = Quantity(4.7e8, 'm2 s')
     coordinates = exp_cube.sky_image_ref.coordinates()
     offset = coordinates.separation(pointing)

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -3,12 +3,10 @@
 Cube analysis utility functions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numpy as np
 from astropy import units as u
-from ..image import SkyImage
-from .core import SkyCube
-from ..spectrum import LogEnergyAxis
 from ..utils.energy import EnergyBounds
+from ..spectrum import LogEnergyAxis
+from .core import SkyCube
 
 __all__ = [
     'compute_npred_cube',
@@ -54,4 +52,5 @@ def compute_npred_cube(flux_cube, exposure_cube, energy_bins,
         data.append(npred)
 
     data = u.Quantity(data, '')
+
     return SkyCube(data=data, wcs=wcs, energy_axis=energy_axis)

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -62,7 +62,7 @@ class CWT(object):
 
     Parameters
     ----------
-    kernels : '~gammapy.detect.CWTKernels'
+    kernels : `~gammapy.detect.CWTKernels`
         Kernels for the algorithm.
     max_iter : int, optional (default 10)
         The maximum number of iterations of the CWT algorithm.
@@ -311,12 +311,12 @@ class CWTKernels(object):
         First scale used.
     step_scale : float
         Base scaling factor.
-    scales : '~numpy.ndarray'
+    scales : `~numpy.ndarray`
         Grid of scales.
     kern_base : dict
         Dictionary of scale powers as keys and 2D kernel arrays.
         (mexican hat) as values
-    kern_approx : '~numpy.ndarray'
+    kern_approx : `~numpy.ndarray`
         2D Gaussian kernel array from maximum scale.
 
     Examples
@@ -493,7 +493,7 @@ class CWTData(object):
     @property
     def support_2d(self):
         """
-        2D '~gammapy.cube.SkyCube' cube exclusion mask. Created from support_3d
+        2D `~gammapy.cube.SkyCube` cube exclusion mask. Created from support_3d
         by OR-operation per 0 axis.
         """
         support_2d = (self._support.sum(0) > 0)
@@ -536,13 +536,13 @@ class CWTData(object):
     @property
     def support_3d(self):
         """
-        3D '~gammapy.cube.SkyCube' cube exclusion mask. Primordial initialized by zero array.
+        3D `~gammapy.cube.SkyCube` cube exclusion mask. Primordial initialized by zero array.
         """
         return SkyImage(name='support_3d', data=self._support, wcs=self._wcs)
 
     @property
     def max_scale_image(self):
-        """Compute the maximum scale image as '~gammapy.image.SkyImage'."""
+        """Compute the maximum scale image as `~gammapy.image.SkyImage`."""
         # Previous version:
         # idx_scale_max = np.argmax(self._transform_3d, axis=0)
         # return kernels.scales[idx_scale_max] * (self._support.sum(0) > 0)
@@ -570,21 +570,23 @@ class CWTData(object):
 
         Returns
         -------
-        images : '~collections.OrderedDict'
+        images : `~collections.OrderedDict`
             Dictionary with keys {'counts', 'background', 'model', 'approx',
-            'approx_bkg', 'transform_2d', 'maximal', 'support_2d'} and 2D `~numpy.ndarray` images as values.
+            'approx_bkg', 'transform_2d', 'maximal', 'support_2d'}
+            and 2D `~numpy.ndarray` images as values.
         """
-        images = OrderedDict(counts=self.counts,
-                             background=self.background,
-                             model=self.model,
-                             approx=self.approx,
-                             approx_bkg=self.approx_bkg,
-                             transform_2d=self.transform_2d,
-                             model_plus_approx=self.model_plus_approx,
-                             residual=self.residual,
-                             maximal=self.max_scale_image,
-                             support_2d=self.support_2d)
-        return images
+        return OrderedDict(
+            counts=self.counts,
+            background=self.background,
+            model=self.model,
+            approx=self.approx,
+            approx_bkg=self.approx_bkg,
+            transform_2d=self.transform_2d,
+            model_plus_approx=self.model_plus_approx,
+            residual=self.residual,
+            maximal=self.max_scale_image,
+            support_2d=self.support_2d,
+        )
 
     def cubes(self):
         """
@@ -592,14 +594,15 @@ class CWTData(object):
 
         Returns
         -------
-        cubes : '~collections.OrderedDict'
+        cubes : `~collections.OrderedDict`
             Dictionary with keys {'transform_3d', 'error', 'support_3d'} and 3D
             `~numpy.ndarray` cubes as values.
         """
-        cubes = OrderedDict(transform_3d=self.transform_3d,
-                            error=self.error,
-                            support=self.support_3d)
-        return cubes
+        return OrderedDict(
+            transform_3d=self.transform_3d,
+            error=self.error,
+            support=self.support_3d,
+        )
 
     def _metrics_info(self, data, name):
         """
@@ -644,7 +647,7 @@ class CWTData(object):
 
         Returns
         -------
-        table : `~astropy.Table`
+        table : `~astropy.table.Table`
             Information about the object.
         """
         if name not in self.images():

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -233,7 +233,6 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         ----------
         TODO
         """
-        p = self.parameters
         input_images = SkyImageList()
         input_images['counts'] = counts
         exposure_on = exposure.copy()

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -3,7 +3,6 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from astropy.coordinates import Angle
 from astropy.wcs import WCS
 from astropy.units import Quantity
 from astropy.table import Table

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import OrderedDict
 import numpy as np
 from astropy.table import Table
-from astropy.units import Quantity
 from astropy import units as u
-
 from .core import SkyImage
 
 __all__ = [
@@ -51,6 +49,7 @@ def compute_binning(data, n_bins, method='equal width', eps=1e-10):
         bin_edges = np.percentile(data, quantiles)
     else:
         raise ValueError('Invalid option: method = {0}'.format(method))
+
     bin_edges[-1] += eps
     return bin_edges
 

--- a/gammapy/image/tests/test_asmooth.py
+++ b/gammapy/image/tests/test_asmooth.py
@@ -2,12 +2,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
-
 import astropy.units as u
 from astropy.convolution import Gaussian2DKernel
-
 from ...utils.testing import requires_data, requires_dependency
-from .. import SkyImage, ASmooth, SkyImageList, asmooth_scales
+from .. import ASmooth, SkyImageList, asmooth_scales
 
 
 @requires_dependency('scipy')
@@ -23,10 +21,12 @@ def test_asmooth():
     asmooth = ASmooth(kernel=kernel, scales=scales[6:], method='lima', threshold=4)
     smoothed = asmooth.run(images)
 
-    desired = {'counts': 0.02089332998318483,
-               'background': 0.022048139647973686,
-               'scale': np.nan,
-               'significance': np.nan}
+    desired = {
+        'counts': 0.02089332998318483,
+        'background': 0.022048139647973686,
+        'scale': np.nan,
+        'significance': np.nan,
+    }
 
     for name in smoothed.names:
         actual = smoothed[name].data[100, 100]

--- a/gammapy/image/tests/test_utils.py
+++ b/gammapy/image/tests/test_utils.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from numpy.testing import assert_equal, assert_allclose
+from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.wcs import WCS
 from ...utils.testing import requires_dependency, requires_data

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -17,7 +17,7 @@ __all__ = [
 
 
 class EffectiveAreaTable(object):
-    """Effective Area Table
+    """Effective area table.
 
     TODO: Document
 
@@ -67,6 +67,7 @@ class EffectiveAreaTable(object):
     >>> print(ener)
     0.185368478744 TeV
     """
+
     def __init__(self, energy_lo, energy_hi, data, meta=None):
         axes = [BinnedDataAxis(energy_lo, energy_hi,
                                interpolation_mode='log', name='energy')]
@@ -79,7 +80,7 @@ class EffectiveAreaTable(object):
         return self.data.axis('energy')
 
     def plot(self, ax=None, energy=None, show_energy=None, **kwargs):
-        """Plot effective area
+        """Plot effective area.
 
         Parameters
         ----------
@@ -94,7 +95,6 @@ class EffectiveAreaTable(object):
         -------
         ax : `~matplotlib.axes.Axes`
             Axis
-
         """
         import matplotlib.pyplot as plt
         ax = plt.gca() if ax is None else ax
@@ -119,7 +119,7 @@ class EffectiveAreaTable(object):
 
     @classmethod
     def from_parametrization(cls, energy, instrument='HESS'):
-        """Get parametrized effective area
+        """Get parametrized effective area.
 
         Parametrizations of the effective areas of different Cherenkov
         telescopes taken from Appendix B of Abramowski et al. (2010), see
@@ -160,7 +160,7 @@ class EffectiveAreaTable(object):
         data = value * u.cm ** 2
 
         return cls(energy_lo=energy.lower_bounds,
-                   energy_hi = energy.upper_bounds, data=data)
+                   energy_hi=energy.upper_bounds, data=data)
 
     @classmethod
     def from_table(cls, table):
@@ -191,9 +191,9 @@ class EffectiveAreaTable(object):
             raise ValueError(msg)
 
     def to_table(self):
-        """Convert to `~astropy.table.Table`
+        """Convert to `~astropy.table.Table`.
 
-        http://gamma-astro-data-formats.readthedocs.io/en/latest/ogip/index.html#arf-file
+        Data format specification: :ref:`gadf:ogip-arf`
         """
         ener_lo = self.energy.lo
         ener_hi = self.energy.hi
@@ -213,12 +213,12 @@ class EffectiveAreaTable(object):
         self.to_hdulist().writeto(str(filename), **kwargs)
 
     def evaluate_fill_nan(self, **kwargs):
-        """Modified evalute function
+        """Modified evaluate function.
 
         Calls :func:`gammapy.utils.nddata.NDDataArray.evaluate` and replaces
         possible nan values. Below the finite range the effective area is set
         to zero and above to value of the last valid note. This is needed since
-        other Sofwares, e.g. sherpa, don't like nan values in FITS files. Make
+        other codes, e.g. sherpa, don't like nan values in FITS files. Make
         sure that the replacement happens outside of the energy range, where
         the `~gammapy.irf.EffectiveAreaTable` is used.
         """
@@ -272,17 +272,17 @@ class EffectiveAreaTable(object):
 
         table = self.to_table()
         kwargs = dict(
-            name = name,
-            energ_lo = table['ENERG_LO'].quantity.to('keV').value,
-            energ_hi = table['ENERG_HI'].quantity.to('keV').value,
-            specresp = table['SPECRESP'].quantity.to('cm2').value,
+            name=name,
+            energ_lo=table['ENERG_LO'].quantity.to('keV').value,
+            energ_hi=table['ENERG_HI'].quantity.to('keV').value,
+            specresp=table['SPECRESP'].quantity.to('cm2').value,
         )
 
         return DataARF(**kwargs)
 
 
 class EffectiveAreaTable2D(object):
-    """2D Effective Area Table
+    """2D effective area table.
 
     Parameters
     -----------
@@ -296,10 +296,6 @@ class EffectiveAreaTable2D(object):
         Upper bin edges of offset axis
     data : `~astropy.units.Quantity`
         Effective area
-    low_threshold : `~astropy.units.Quantity`, optional
-        Low energy threshold
-    high_threshold : `~astropy.units.Quantity`, optional
-        High energy threshold
 
     Examples
     --------
@@ -359,21 +355,20 @@ class EffectiveAreaTable2D(object):
 
     @classmethod
     def from_table(cls, table):
-        """This is a reader for the format specified at
-        http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/effective_area/index.html#aeff-2d-format
+        """Read from table.
+        
+        Data format specification: :ref:`gadf:aeff_2d`
         """
-        energy_col = 'ENERG'
-        offset_col = 'THETA'
-        data_col = 'EFFAREA'
-
-        energy_lo = table['{}_LO'.format(energy_col)].quantity[0]
-        energy_hi = table['{}_HI'.format(energy_col)].quantity[0]
-        o_lo = table['{}_LO'.format(offset_col)].quantity[0]
-        o_hi = table['{}_HI'.format(offset_col)].quantity[0]
-        data = table['{}'.format(data_col)].quantity[0].transpose()
-        return cls(offset_lo=o_lo, offset_hi=o_hi,
-                   energy_lo=energy_lo, energy_hi=energy_hi,
-                   data=data, meta=table.meta)
+        energy_lo = table['ENERG_LO'].quantity[0]
+        energy_hi = table['ENERG_HI'].quantity[0]
+        offset_lo = table['THETA_LO'].quantity[0]
+        offset_hi = table['THETA_HI'].quantity[0]
+        data = table['EFFAREA'].quantity[0].transpose()
+        return cls(
+            energy_lo=energy_lo, energy_hi=energy_hi,
+            offset_lo=offset_lo, offset_hi=offset_hi,
+            data=data, meta=table.meta,
+        )
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu='EFFECTIVE AREA'):

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -235,7 +235,7 @@ class EffectiveAreaTable(object):
         return cleaned_data.max()
 
     def find_energy(self, aeff):
-        """Find energy for given effective area
+        """Find energy for given effective area.
 
         A linear interpolation is performed between the two nodes closest to
         the desired effective area value.
@@ -244,13 +244,13 @@ class EffectiveAreaTable(object):
 
         Parameters
         ----------
-        aeff: `~astropy.units.Quantity`
+        aeff : `~astropy.units.Quantity`
             Effective area value
 
         Returns
         -------
-        energy: `~astropy.units.Quantity`
-            Energy corresponing to aeff
+        energy : `~astropy.units.Quantity`
+            Energy corresponding to aeff
         """
         idx = np.where(self.data.data > aeff)[0][0]
 

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class IRFStacker(object):
     r"""
-    Stack instrument response functions
+    Stack instrument response functions.
 
     Compute mean effective area and the mean energy dispersion for a given for a
     given list of instrument response functions. Results are stored as
@@ -39,15 +39,15 @@ class IRFStacker(object):
 
     Parameters
     ----------
-    list_aeff: list
+    list_aeff : list
         list of `~gammapy.irf.EffectiveAreaTable`
-    list_livetime: list
+    list_livetime : list
         list of `~astropy.units.Quantity` (livetime)
-    list_edisp: list
+    list_edisp : list
         list of `~gammapy.irf.EnergyDispersion`
-    list_low_threshold: list
+    list_low_threshold : list
         list of low energy threshold, optional for effective area mean computation
-    list_high_threshold: list
+    list_high_threshold : list
         list of high energy threshold, optional for effective area mean computation
     """
 
@@ -63,7 +63,7 @@ class IRFStacker(object):
 
     def stack_aeff(self):
         """
-        Compute mean effective area
+        Compute mean effective area (`~gammapy.irf.EffectiveAreaTable`).
         """
         nbins = self.list_aeff[0].energy.nbins
         aefft = Quantity(np.zeros(nbins), 'cm2 s')
@@ -83,7 +83,7 @@ class IRFStacker(object):
 
     def stack_edisp(self):
         """
-        Compute mean energy dispersion
+        Compute mean energy dispersion (`~gammapy.irf.EnergyDispersion`).
         """
         reco_bins = self.list_edisp[0].e_reco.nbins
         true_bins = self.list_edisp[0].e_true.nbins

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -233,7 +233,7 @@ class PSF3D(object):
         Returns
         -------
         table_psf : `~gammapy.irf.EnergyDependentTablePSF`
-            Instance of `EnergyDependentTablePSF`.
+            Energy-dependent PSF
         """
         energies = self.energy_logcenter()
 

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -19,7 +19,7 @@ __all__ = [
 class PSF3D(object):
     """PSF with axes: energy, offset, rad.
     
-    Data format specification: :ref:`gadf:psf-table`.
+    Data format specification: :ref:`gadf:psf_table`
 
     Parameters
     ----------
@@ -138,7 +138,7 @@ class PSF3D(object):
 
     def to_fits(self):
         """
-        Convert psf table data to FITS hdu list.
+        Convert PSF table data to FITS HDU list.
 
         Returns
         -------
@@ -173,7 +173,7 @@ class PSF3D(object):
 
     def evaluate(self, energy=None, offset=None, rad=None,
                  interp_kwargs=None):
-        """Interpolate the value of the `EnergyOffsetArray` at a given offset and Energy.
+        """Interpolate the value of the `EnergyOffsetArray` at a given offset and energy.
 
         Parameters
         ----------
@@ -235,15 +235,15 @@ class PSF3D(object):
         table_psf : `~gammapy.irf.EnergyDependentTablePSF`
             Energy-dependent PSF
         """
-        energies = self.energy_logcenter()
-
-        # Defaults
         theta = theta or Angle(0, 'deg')
+        energies = self.energy_logcenter()
         rad = self.rad_center()
         psf_value = self.evaluate(offset=theta).squeeze().T
 
-        return EnergyDependentTablePSF(energy=energies, rad=rad,
-                                       exposure=exposure, psf_value=psf_value)
+        return EnergyDependentTablePSF(
+            energy=energies, rad=rad,
+            exposure=exposure, psf_value=psf_value,
+        )
 
     def to_table_psf(self, energy, theta=None, interp_kwargs=None, **kwargs):
         """Evaluate the `EnergyOffsetArray` at one given energy.
@@ -262,8 +262,6 @@ class PSF3D(object):
         table : `~astropy.table.Table`
             Table with two columns: offset, value
         """
-
-        # Defaults
         theta = theta or Angle(0, 'deg')
 
         psf_value = self.evaluate(energy, theta, interp_kwargs=interp_kwargs).squeeze()
@@ -288,8 +286,6 @@ class PSF3D(object):
         radius : `~astropy.units.Quantity`
             Containment radius in deg
         """
-
-        # Defaults
         if theta is None:
             theta = Angle(0, 'deg')
         if energy.ndim == 0:
@@ -316,7 +312,7 @@ class PSF3D(object):
         return Quantity(radius.squeeze(), unit)
 
     def plot_containment_vs_energy(self, fractions=[0.68, 0.95],
-                                   thetas=Angle([0, 1], 'deg'), ax=None, **kwargs):
+                                   thetas=Angle([0, 1], 'deg'), ax=None):
         """Plot containment fraction as a function of energy.
         """
         import matplotlib.pyplot as plt
@@ -394,8 +390,8 @@ class PSF3D(object):
             self._plot_safe_energy_range(ax)
 
         if add_cbar:
-            label = 'Containment radius R{0:.0f} ({1})'.format(100 * fraction,
-                                                               containment.unit)
+            label = ('Containment radius R{0:.0f} ({1})'
+                     ''.format(100 * fraction, containment.unit))
             cbar = ax.figure.colorbar(caxes, ax=ax, label=label)
 
         return ax

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -227,7 +227,7 @@ class PSFKing(object):
         Returns
         -------
         table_psf : `~gammapy.irf.EnergyDependentTablePSF`
-            Instance of `EnergyDependentTablePSF`.
+            Energy-dependent PSF
         """
         # self.energy is already the logcenter
         energies = self.energy

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 class PSFKing(object):
-    """King profile analytical PSF depending on energy and theta.
+    """King profile analytical PSF depending on energy and offset.
 
     This PSF parametrisation and FITS data format is described here: :ref:`gadf:psf_king`.
 
@@ -116,7 +116,7 @@ class PSFKing(object):
 
     def to_fits(self):
         """
-        Convert psf table data to FITS hdu list.
+        Convert PSF table data to FITS HDU list.
 
         Returns
         -------
@@ -149,7 +149,9 @@ class PSFKing(object):
 
     @staticmethod
     def evaluate_direct(r, gamma, sigma):
-        """Evaluate formula from here: :ref:`gadf:psf_king`.
+        """Evaluate the PSF model.
+        
+        Formula is given here: :ref:`gadf:psf_king`.
 
         Parameters
         ----------
@@ -162,8 +164,8 @@ class PSFKing(object):
 
         Returns
         -------
-        king function : `~astropy.units.Quantity`
-            formula from here: :ref:`gadf:psf_king`
+        psf_value : `~astropy.units.Quantity`
+            PSF value
         """
         r2 = r * r
         sigma2 = sigma * sigma

--- a/gammapy/scripts/image_pipe.py
+++ b/gammapy/scripts/image_pipe.py
@@ -168,7 +168,7 @@ class SingleObsImageMaker(object):
             True if you want that the total excess / exposure gives the integrated flux
         """
         from scipy.interpolate import interp1d
-        # TODO: should be re-implemented using the exposure_cube function
+        # TODO: should be re-implemented using the make_exposure_cube function
         table = self.make_1d_expected_counts(spectral_index, for_integral_flux)
         exposure = SkyImage.empty_like(self.empty_image, unit=table["npred"].unit)
 

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 class CountsSpectrum(object):
-    """Generic counts spectrum
+    """Generic counts spectrum.
 
     Parameters
     ----------
@@ -100,9 +100,9 @@ class CountsSpectrum(object):
             raise ValueError(msg)
 
     def to_table(self):
-        """Convert to `~astropy.table.Table`
+        """Convert to `~astropy.table.Table`.
 
-        http://gamma-astro-data-formats.readthedocs.io/en/latest/ogip/index.html
+        Data format specification: :ref:`gadf:ogip-pha`
         """
         channel = np.arange(self.energy.nbins, dtype=np.int16)
         counts = np.array(self.data.data.value, dtype=np.int32)

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -228,8 +228,9 @@ class NDDataArray(object):
 class DataAxis(object):
     """Data axis to be used with NDDataArray
 
-    Axis values are interpreted as nodes. For binned data see
-    `~gammapy.utils.ndddata.BinnedDataAxis`.
+    Axis values are interpreted as nodes.
+    
+    For binned data see `~gammapy.utils.nddata.BinnedDataAxis`.
 
     Parameters
     ----------

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -148,7 +148,7 @@ def sample_sphere_distance(distance_min=0, distance_max=1, size=None,
     distance_min, distance_max : float, optional
         Distance range in which to sample
     size : int or tuple of ints, optional
-        Output shape. Default: one sample. Passed to `~numpy.random.uniform`.
+        Output shape. Default: one sample. Passed to `numpy.random.uniform`.
     random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
         Defines random number generator initialisation.
         Passed to `~gammapy.utils.random.get_random_state`.


### PR DESCRIPTION
This PR does some minor code and docstring cleanup.

The only substantial change is renaming the function `exposure_cube` to `make_exposure_cube`.

I don't have a unified naming scheme for Gammapy in mind yet, but this was being used like this:
```python
from gammapy.cube import exposure_cube as make_exposure_cube

exposure_cube = make_exposure_cube(...)
```
Maybe we should go all-in with avoiding nouns for functions...