### PR TITLE
Implement CatalogImageEstimator class

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -6,11 +6,14 @@ from collections import OrderedDict
 import sys
 from copy import deepcopy
 from pprint import pprint
+import numpy as np
 from astropy.extern import six
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
+from astropy.table import Table, Row
 from ..utils.array import _is_int
+from .utils import skycoord_from_table
 
 __all__ = [
     'SourceCatalog',
@@ -67,14 +70,12 @@ class SourceCatalogObject(object):
         """
         print(self)
 
-    @property    
+    @property
     def position(self):
-        try:
-            l, b = self.data['GLON'], self.data['GLAT']
-        except KeyError:
-            l, b = self.data['glon'], self.data['glat']
-        position = SkyCoord(l, b, frame='galactic')
-        return position
+        """
+        `~astropy.coordinates.SkyCoord`
+        """
+        return skycoord_from_table(self.data)
 
 
 class SourceCatalog(object):
@@ -243,17 +244,12 @@ class SourceCatalog(object):
         ss += ' with {} objects.'.format(len(self.table))
         return ss
 
-    @property    
+    @property
     def positions(self):
         """
         `~astropy.coordinates.SkyCoord`
         """
-        try:
-            l, b = self.table['GLON'], self.table['GLAT']
-        except KeyError:
-            l, b = self.table['glon'], self.table['glat']
-        position = SkyCoord(l, b, frame='galactic')
-        return position
+        return skycoord_from_table(self.table)
 
     def select_image_region(self, image):
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -201,6 +201,13 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
         return FluxPoints(table)
 
+    @property
+    def pointlike(self):
+        """
+        Source is pointlike.
+        """
+        return self.data['morph_type'] == 'point'
+
 
 class SourceCatalogGammaCat(SourceCatalog):
     """Gammacat open TeV source catalog.

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -19,7 +19,7 @@ from ..utils.modeling import SourceModel, SourceLibrary
 from ..utils.scripts import make_path
 from ..spectrum import FluxPoints
 from ..spectrum.models import PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw
-from ..image.models import Shell2D
+from ..image.models import Shell2D, Delta2D
 from .core import SourceCatalog, SourceCatalogObject
 
 __all__ = [

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -148,14 +148,10 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             pars['width'] = 0.2 * d['morph_sigma'].value
             return Shell2D(**pars)
         elif morph_type == 'point':
-            DEFAULT_POINT_EXTENSION = Angle('0.05 deg')
             pars['amplitude'] = flux.to('cm-2 s-1').value
-            pars['x_mean'] = glon.value
-            pars['y_mean'] = glat.value
-            pars['x_stddev'] = DEFAULT_POINT_EXTENSION
-            pars['y_stddev'] = DEFAULT_POINT_EXTENSION
-            # TODO: make Delta2D work and use it here.
-            return Gaussian2D(**pars)
+            pars['x_0'] = glon.value
+            pars['y_0'] = glat.value
+            return Delta2D(**pars)
         elif morph_type == 'none':
             raise NoDataAvailableError('No spatial model available: {}'.format(self.name))
         else:

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -7,6 +7,7 @@ from astropy.tests.helper import pytest, assert_quantity_allclose
 from astropy.table import Table, Column
 from astropy.units import Quantity
 from ..core import SourceCatalog
+from ...image import SkyImage
 
 
 def make_test_catalog():
@@ -65,6 +66,17 @@ class TestSourceCatalog:
 
         with pytest.raises(ValueError):
             self.cat[int]
+
+    def test_positions(self):
+        positions = self.cat.positions
+        assert len(positions) == 3
+
+    def test_select_image_region(self):
+        reference = SkyImage.empty(xref=42.2, yref=1, nxpix=5, nypix=5,
+                                   coordsys='CEL')
+        selection = self.cat.select_image_region(reference)
+
+        assert len(selection.table) == 1
 
 
 class TestSourceCatalogObject:

--- a/gammapy/catalog/utils.py
+++ b/gammapy/catalog/utils.py
@@ -243,13 +243,18 @@ def skycoord_from_table(table):
     TODO: I'm not sure if it's a good idea to use this because it's not always clear
     which positions are taken.
     """
-    if set(['RAJ2000', 'DEJ2000']).issubset(table.colnames):
+    try:
+        keys = table.colnames
+    except AttributeError:
+        keys = table.keys()
+
+    if set(['RAJ2000', 'DEJ2000']).issubset(keys):
         lon, lat, frame = 'RAJ2000', 'DEJ2000', 'icrs'
-    elif set(['RA', 'DEC']).issubset(table.colnames):
+    elif set(['RA', 'DEC']).issubset(keys):
         lon, lat, frame = 'RA', 'DEC', 'icrs'
-    elif set(['GLON', 'GLAT']).issubset(table.colnames):
+    elif set(['GLON', 'GLAT']).issubset(keys):
         lon, lat, frame = 'GLON', 'GLAT', 'galactic'
-    elif set(['glon', 'glat']).issubset(table.colnames):
+    elif set(['glon', 'glat']).issubset(keys):
         lon, lat, frame = 'glon', 'glat', 'galactic'
     else:
         raise KeyError('No column GLON / GLAT or RA / DEC or RAJ2000 / DEJ2000 found.')

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -2,16 +2,132 @@
 """Make an image from a source catalog, or simulated catalog, e.g 1FHL 2FGL etc
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
+
 import numpy as np
 from astropy.wcs import WCS
 from astropy.units import Quantity
+from astropy import units as u
 from astropy.table import Table
+
+from .models import Delta2D
+from .core import SkyImage
+from .lists import SkyImageList
 
 
 __all__ = [
+    'CatalogImageEstimator',
     'catalog_image',
     'catalog_table',
 ]
+
+
+BBOX_DELTA2D_PIX = 5
+
+class CatalogImageEstimator(object):
+    """
+    Compute model image for given energy band from a catalog.
+
+    Sources are only filled when their center lies within the image boundaries.
+
+    Parameters
+    ----------
+    reference : `~gammapy.image.SkyImage`
+        Reference sky image.
+    emin : `~astropy.units.Quantity`
+        Lower bound of energy range.
+    emax : `~astropy.units.Quantity`
+        Upper bound of energy range.
+
+    Examples
+    --------
+
+    from astropy import units as u
+    from gammapy.image import SkyImage, CatalogImageEstimator
+    from gammapy.catalog import SourceCatalogGammaCat
+
+    reference = SkyImage.empty(xref=265, yref=-1.5, nxpix=201,
+                               nypix=201, binsz=0.04)
+
+    image_estimator = CatalogImageEstimator(reference=reference,
+                                            emin=1 * u.TeV,
+                                            emax=10 * u.TeV)
+
+    catalog = SourceCatalogGammaCat()
+    result = image_estimator.run(catalog)
+    result['flux'].show()
+
+    """
+
+    def __init__(self, reference, emin, emax):
+        self.reference = reference
+        self.parameters = OrderedDict(emin=emin, emax=emax)
+
+    def flux(self, catalog):
+        """
+        Compute flux image from catalog.
+
+        Sources are only filled when their center lies within the image boundaries.
+
+        Parameters
+        ----------
+        catalog : `~gammapy.catalog.SourceCatalog`
+            Source catalog instance.
+
+        Returns
+        -------
+        image :  `~gammapy.image.SkyImage`
+            Flux sky image.
+        """
+        from ..catalog.gammacat import NoDataAvailableError
+        p = self.parameters
+        image = SkyImage.empty_like(self.reference)
+
+        selection = catalog.select_image_region(image)
+
+        for source in selection:
+            try:
+                spatial_model = source.spatial_model(emin=p['emin'], emax=p['emax'])
+            except (NotImplementedError, NoDataAvailableError):
+                continue
+
+            if isinstance(spatial_model, Delta2D):
+                # use 5 pixel bbox for point-like models
+                size = BBOX_DELTA2D_PIX * image.wcs_pixel_scale().to('deg')
+            else:
+                height, width = np.diff(spatial_model.bounding_box)
+                size = (float(height) * u.deg, float(width) * u.deg)
+
+            cutout = image.cutout(source.position, size=size)
+
+            # evaluate model on smaller image and paste
+            c = cutout.coordinates()
+            l, b = c.galactic.l.wrap_at('180d'), c.galactic.b
+            cutout.data = spatial_model(l.deg, b.deg)
+            image.paste(cutout)
+
+        return image
+
+    def run(self, catalog, which='flux'):
+        """
+        Run catalog image estimator.
+
+        Parameters
+        ----------
+        catalog : `~gammapy.catalog.SourceCatalog`
+            Source catalog instance.
+
+        Returns
+        -------
+        sky_images : `~gammapy.image.SkyImageList`
+            List of sky images
+        """
+        result = SkyImageList()
+
+        if 'flux' in which:
+            result['flux'] = self.flux(catalog)
+
+        return result
 
 
 def _extended_image(catalog, reference_cube):

--- a/gammapy/image/models/models.py
+++ b/gammapy/image/models/models.py
@@ -329,44 +329,9 @@ class Delta2D(Fittable2DModel):
         return x_val * y_val * amplitude
 
 
-class Template2D(Fittable2DModel):
-    """
-    Two dimensional table model .
-
-    Parameters
-    ----------
-    amplitude : float
-        Amplitude of the template model.
-
-    See Also
-    --------
-    Shell2D, Sphere2D, astropy.modeling.models.Gaussian2D
-
-    """
-    amplitude = Parameter('amplitude')
-
-    def __init__(self, x, y, data, amplitude=1, **constraints):
-
-        x_axis = DataAxis(x, name='x')
-        y_axis = DataAxis(y, name='y')
-
-        self._interpolator = NDDataArray(axes=[x_axis, y_axis], data=data)
-        super(Table2D, self).__init__(amplitude=amplitude, **constraints)
-
-    @classmethod
-    def read(filename):
-
-        return cls(x, y, data)
-
-    def evaluate(self, x, y, amplitude):
-        values = self._interpolator.evaluate(x=x, y=y)
-        return amplitude * values
-
-
 morph_types = OrderedDict()
 """Available morphology types."""
 morph_types['delta2d'] = Delta2D
 morph_types['gauss2d'] = Gaussian2D
 morph_types['shell2d'] = Shell2D
 morph_types['sphere2d'] = Sphere2D
-morph_types['template2d'] = Template2D

--- a/gammapy/image/models/models.py
+++ b/gammapy/image/models/models.py
@@ -321,8 +321,10 @@ class Delta2D(Fittable2DModel):
         Two dimensional delta model function using a local rectangular pixel
         approximation.
         """
-        x_diff = np.abs((x - x_0) / np.gradient(x, axis=1))
-        y_diff = np.abs((y - y_0) / np.gradient(y, axis=0))
+        _, grad_x = np.gradient(x)
+        grad_y, _ = np.gradient(y)
+        x_diff = np.abs((x - x_0) / grad_x)
+        y_diff = np.abs((y - y_0) / grad_y)
 
         x_val = np.select([x_diff < 1], [1 - x_diff], 0)
         y_val = np.select([y_diff < 1], [1 - y_diff], 0)


### PR DESCRIPTION
This PR implements a `CatalogImageEstimator` class to compute model images from catalogs.
Right now this only works with `SourceCatalogGammaCat`, in later PRs I will add support for the Fermi-LAT catalogs. 