### PR TITLE
Add Fermi-LAT 3FHL spatial models

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -642,6 +642,28 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         table['dnde'] = (e2dnde * e_ref ** -2).to('cm-2 s-1 TeV-1')
         return FluxPoints(table)
 
+    def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
+        """
+        Source spatial model.
+        """
+        d = self.data
+        flux = self.spectral_model.integral(emin, emax)
+
+        pars = {}
+        pars['amplitude'] = flux.to('cm-2 s-1').value
+        glon = Angle(d['GLON']).wrap_at('180d')
+        glat = Angle(d['GLAT']).wrap_at('180d')
+
+        pointlike = self.data['Extended_Source_Name'].strip() == ''
+
+        if pointlike:
+            pars['x_0'] = glon.value
+            pars['y_0'] = glat.value
+            return Delta2D(**pars)
+        else:
+            raise NotImplementedError('Only spatial model: {!r}'.format(''))
+
+
 
 class SourceCatalog3FGL(SourceCatalog):
     """Fermi-LAT 3FGL source catalog.

--- a/gammapy/catalog/utils.py
+++ b/gammapy/catalog/utils.py
@@ -259,8 +259,7 @@ def skycoord_from_table(table):
     else:
         raise KeyError('No column GLON / GLAT or RA / DEC or RAJ2000 / DEJ2000 found.')
 
-    unit = table[lon].unit if table[lon].unit else 'deg'
-
+    unit = table[lon].unit.to_string() if table[lon].unit else 'deg'
     skycoord = SkyCoord(table[lon], table[lat], unit=unit, frame=frame)
 
     return skycoord

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -17,16 +17,13 @@ from .lists import SkyImageList
 
 __all__ = [
     'CatalogImageEstimator',
-    'catalog_image',
-    'catalog_table',
 ]
 
 
 BBOX_DELTA2D_PIX = 5
 
 class CatalogImageEstimator(object):
-    """
-    Compute model image for given energy band from a catalog.
+    """Compute model image for given energy band from a catalog.
 
     Sources are only filled when their center lies within the image boundaries.
 
@@ -64,8 +61,7 @@ class CatalogImageEstimator(object):
         self.parameters = OrderedDict(emin=emin, emax=emax)
 
     def flux(self, catalog):
-        """
-        Compute flux image from catalog.
+        """Compute flux image from catalog.
 
         Sources are only filled when their center lies within the image boundaries.
 
@@ -88,20 +84,23 @@ class CatalogImageEstimator(object):
         for source in selection:
             try:
                 spatial_model = source.spatial_model(emin=p['emin'], emax=p['emax'])
+            #TODO: remove this error handling and add selection to SourceCatalog
+            # class
             except (NotImplementedError, NoDataAvailableError):
                 continue
 
             if source.pointlike:
                 # use 5 pixel bbox for point-like models
                 size = BBOX_DELTA2D_PIX * image.wcs_pixel_scale().to('deg')
-                solid_angle = 1.
             else:
                 height, width = np.diff(spatial_model.bounding_box)
                 size = (float(height) * u.deg, float(width) * u.deg)
 
             cutout = image.cutout(source.position, size=size)
 
-            if not source.pointlike:
+            if source.pointlike:
+                solid_angle = 1.
+            else:
                 solid_angle = cutout.solid_angle().to('deg2').value
 
             # evaluate model on smaller image and paste
@@ -113,8 +112,7 @@ class CatalogImageEstimator(object):
         return image
 
     def run(self, catalog, which='flux'):
-        """
-        Run catalog image estimator.
+        """Run catalog image estimator.
 
         Parameters
         ----------
@@ -128,6 +126,8 @@ class CatalogImageEstimator(object):
         """
         result = SkyImageList()
 
+        #TODO: add input image list and computed derived quantities such as
+        # excess, psf convolution etc.
         if 'flux' in which:
             result['flux'] = self.flux(catalog)
 

--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -22,6 +22,7 @@ __all__ = [
 
 BBOX_DELTA2D_PIX = 5
 
+
 class CatalogImageEstimator(object):
     """Compute model image for given energy band from a catalog.
 

--- a/gammapy/image/models/models.py
+++ b/gammapy/image/models/models.py
@@ -46,7 +46,7 @@ class Shell2D(Fittable2DModel):
 
     See Also
     --------
-    Sphere2D, Delta2D, astropy.modeling.models.Gaussian2D
+    Sphere2D, Delta2D, `~astropy.modeling.models.Gaussian2D`
 
     Notes
     -----
@@ -184,7 +184,7 @@ class Sphere2D(Fittable2DModel):
 
     See Also
     --------
-    Shell2D, Delta2D, astropy.modeling.models.Gaussian2D
+    Shell2D, Delta2D, `~astropy.modeling.models.Gaussian2D`
 
     Notes
     -----
@@ -293,7 +293,7 @@ class Delta2D(Fittable2DModel):
 
     See Also
     --------
-    Shell2D, Sphere2D, astropy.modeling.models.Gaussian2D
+    Shell2D, Sphere2D, `~astropy.modeling.models.Gaussian2D`
 
     Notes
     -----
@@ -345,7 +345,7 @@ class Template2D(Fittable2DModel):
 
     See Also
     --------
-    Shell2D, Sphere2D, astropy.modeling.models.Gaussian2D
+    Shell2D, Sphere2D, `~astropy.modeling.models.Gaussian2D`
 
     """
     amplitude = Parameter('amplitude')
@@ -364,6 +364,7 @@ class Template2D(Fittable2DModel):
         x = np.arange(self.image.data.shape[1])
 
         data_normed = self.image.data / self.image.data.sum()
+        data_normed /= self.image.solid_angle()
 
         f = RegularGridInterpolator((y, x), data_normed, fill_value=0,
                                     bounds_error=False)
@@ -394,6 +395,16 @@ class Template2D(Fittable2DModel):
         values = self._interpolate_data(y_pix, x_pix)
         return amplitude * values
 
+    @property
+    def bounding_box(self):
+        footprint = self.image.footprint()
+        width = footprint['width'].deg
+        height = footprint['height'].deg
+        center = footprint['center']
+        x_0 = center.data.lon.wrap_at('180d').deg
+        y_0 = center.data.lat.deg
+        return ((y_0 - height / 2, y_0 + height / 2),
+                (x_0 - width, x_0 + height / 2))
 
 morph_types = OrderedDict()
 """Available morphology types."""

--- a/gammapy/image/models/models.py
+++ b/gammapy/image/models/models.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import numpy as np
 from astropy.modeling import Parameter, ModelDefinitionError, Fittable2DModel
 from astropy.modeling.models import Gaussian2D
+from ..core import SkyImage
 
 __all__ = [
     'morph_types',
@@ -331,9 +332,52 @@ class Delta2D(Fittable2DModel):
         return x_val * y_val * amplitude
 
 
+class Template2D(Fittable2DModel):
+    """
+    Two dimensional table model .
+
+    Parameters
+    ----------
+    amplitude : float
+        Amplitude of the template model.
+
+    See Also
+    --------
+    Shell2D, Sphere2D, astropy.modeling.models.Gaussian2D
+
+    """
+    amplitude = Parameter('amplitude')
+
+    def __init__(self, x, y, data, amplitude=1., **constraints):
+
+        x_axis = DataAxis(x, name='x')
+        y_axis = DataAxis(y, name='y')
+
+        self._interpolator = NDDataArray(axes=[x_axis, y_axis], data=data)
+        super(Table2D, self).__init__(amplitude=amplitude, **constraints)
+
+    @classmethod
+    def read(cls, filename):
+        """
+        Read spatial template model from fits image.
+        """
+        template = SkyImage.read(filename)
+
+        coords = template.coordinates()
+        x = coords.
+        y =
+
+        return cls(x, y, template.data)
+
+    def evaluate(self, x, y, amplitude):
+        values = self._interpolator.evaluate(x=x, y=y)
+        return amplitude * values
+
+
 morph_types = OrderedDict()
 """Available morphology types."""
 morph_types['delta2d'] = Delta2D
 morph_types['gauss2d'] = Gaussian2D
 morph_types['shell2d'] = Shell2D
 morph_types['sphere2d'] = Sphere2D
+morph_types['template2d'] = Template2D

--- a/gammapy/image/models/tests/test_shapes.py
+++ b/gammapy/image/models/tests/test_shapes.py
@@ -5,8 +5,8 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.modeling.models import Gaussian2D
 from astropy.modeling.tests.test_models import Fittable2DModelTester
-from ..models import Sphere2D, Shell2D, Delta2D
-from ....utils.testing import requires_dependency
+from ..models import Sphere2D, Shell2D, Delta2D, Template2D
+from ....utils.testing import requires_dependency, requires_data
 
 models_2D = {
 
@@ -81,6 +81,15 @@ def test_delta2d_against_gauss(x_0, y_0):
     values_convolved = gaussian_filter(values, width, mode='constant')
     values_gauss = gauss(x, y)
     assert_allclose(values_convolved, values_gauss, atol=1E-4)
+
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_template2d():
+    filename = ('$GAMMAPY_EXTRA/datasets/catalogs/fermi/Extended_archive_v17'
+                '/Templates/HESSJ1841-055.fits')
+    template = Template2D.read(filename)
+    assert_allclose(template(26.7, 0), 1.1553735159851262)
 
 
 @pytest.mark.parametrize(('model_class', 'test_parameters'), list(models_2D.items()))

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -113,4 +113,4 @@ class TestCatalogImageEstimator(object):
         assert len(selection.table) == 7
 
         desired = selection.table['Flux'].sum()
-        assert_allclose(actual, desired, rtol=1E-1)
+        assert_allclose(actual, desired, rtol=1E-2)

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -73,22 +73,44 @@ def test_catalog_table():
 
 
 class TestCatalogImageEstimator(object):
-    def setup(self):
-        self.reference = SkyImage.empty(xref=18.0, yref=-0.6, nypix=41,
-                                        nxpix=41, binsz=0.1)
-        self.estimator = CatalogImageEstimator(reference=self.reference,
-                                               emin=1 * u.TeV,
-                                               emax=1E4 * u.TeV)
     @requires_data('gammapy-extra')
     def test_flux_gammacat(self):
         from ...catalog import SourceCatalogGammaCat
+        reference = SkyImage.empty(xref=18.0, yref=-0.6, nypix=41,
+                                   nxpix=41, binsz=0.1)
+
         catalog = SourceCatalogGammaCat()
-        result = self.estimator.run(catalog)
+        estimator = CatalogImageEstimator(reference=reference,
+                                          emin=1 * u.TeV,
+                                          emax=1E4 * u.TeV)
+
+        result = estimator.run(catalog)
 
         actual = result['flux'].data.sum()
-        selection = catalog.select_image_region(self.reference)
+        selection = catalog.select_image_region(reference)
 
         assert len(selection.table) == 3
 
         desired = selection.table['spec_flux_above_1TeV'].sum()
         assert_allclose(actual, desired, rtol=1E-3)
+
+    @requires_data('gammapy-extra')
+    def test_flux_3FHL(self):
+        from ...catalog import SourceCatalog3FHL
+        reference = SkyImage.empty(xref=18.0, yref=-0.6, nypix=81,
+                                   nxpix=81, binsz=0.1)
+
+        catalog = SourceCatalog3FHL()
+        estimator = CatalogImageEstimator(reference=reference,
+                                          emin=10 * u.GeV,
+                                          emax=1000 * u.GeV)
+
+        result = estimator.run(catalog)
+
+        actual = result['flux'].data.sum()
+        selection = catalog.select_image_region(reference)
+
+        assert len(selection.table) == 7
+
+        desired = selection.table['Flux'].sum()
+        assert_allclose(actual, desired, rtol=1E-1)


### PR DESCRIPTION
This PR adds the `.spatial_model` attribute to `SourceCatalogObject3FHL`. The corresponding extended sources template archive is added in  https://github.com/gammapy/gammapy-extra/pull/78.