### PR TITLE
Fix spiralarm=False case in make_base_catalog_galactic

### DIFF
--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -232,7 +232,8 @@ def make_base_catalog_galactic(n_sources, rad_dis='YK04', vel_dis='H05',
     table = Table()
     table['age'] = Column(age, unit='yr', description='Age of the source')
     table['n_ISM'] = Column(n_ISM, unit='cm-3', description='Interstellar medium density')
-    table['spiralarm'] = Column(spiralarm, description='Which spiralarm?')
+    if spiralarms:
+        table['spiralarm'] = Column(spiralarm, description='Which spiralarm?')
 
     table['x_birth'] = Column(x, unit='kpc', description='Galactocentric x coordinate at birth')
     table['y_birth'] = Column(y, unit='kpc', description='Galactocentric y coordinate at birth')


### PR DESCRIPTION
This PR fixes the issue reported in #1020 .

added an if statement to check if the “spiralarms” option is True. If
it is not, this column is unnecessary in the table