### PR TITLE
Fix Fermi catalog flux points upper limit

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -42,6 +42,13 @@ __all__ = [
 ]
 
 
+def compute_flux_points_ul(quantity, quantity_errp):
+    """Compute UL value for fermi flux points.
+
+    See https://arxiv.org/pdf/1501.02003.pdf (page 30)
+    """
+    return 2 * quantity_errp + quantity
+
 class SourceCatalogObject3FGL(SourceCatalogObject):
     """One source from the Fermi-LAT 3FGL catalog.
 
@@ -337,17 +344,13 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
         # handle upper limits
         table['flux_ul'] = np.nan * flux_err.unit
-        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
-
-        for column in ['flux', 'flux_errp', 'flux_errn']:
-            table[column][is_ul] = np.nan
+        flux_ul = compute_flux_points_ul(table['flux'], table['flux_errp'])
+        table['flux_ul'][is_ul] = flux_ul[is_ul]
 
         # handle upper limits
         table['eflux_ul'] = np.nan * nuFnu.unit
-        table['eflux_ul'][is_ul] = table['eflux_errp'][is_ul]
-
-        for column in ['eflux', 'eflux_errp', 'eflux_errn']:
-            table[column][is_ul] = np.nan
+        eflux_ul = compute_flux_points_ul(table['eflux'], table['eflux_errp'])
+        table['eflux_ul'][is_ul] = eflux_ul[is_ul]
 
         table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
         return FluxPoints(table)
@@ -445,10 +448,8 @@ class SourceCatalogObject1FHL(SourceCatalogObject):
         is_ul = np.isnan(table['flux_errn'])
         table['is_ul'] = is_ul
         table['flux_ul'] = np.nan * flux_err.unit
-        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
-
-        for column in ['flux', 'flux_errp', 'flux_errn']:
-            table[column][is_ul] = np.nan
+        flux_ul = compute_flux_points_ul(table['flux'], table['flux_errp'])
+        table['flux_ul'][is_ul] = flux_ul[is_ul]
 
         flux_points = FluxPoints(table)
 
@@ -520,10 +521,8 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         is_ul = np.isnan(table['flux_errn'])
         table['is_ul'] = is_ul
         table['flux_ul'] = np.nan * flux_err.unit
-        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
-
-        for column in ['flux', 'flux_errp', 'flux_errn']:
-            table[column][is_ul] = np.nan
+        flux_ul = compute_flux_points_ul(table['flux'], table['flux_errp'])
+        table['flux_ul'][is_ul] = flux_ul[is_ul]
 
         flux_points = FluxPoints(table)
 
@@ -626,16 +625,12 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
         # handle upper limits
         table['flux_ul'] = np.nan * flux_err.unit
-        table['flux_ul'][is_ul] = table['flux_errp'][is_ul]
-
-        for column in ['flux', 'flux_errp', 'flux_errn']:
-            table[column][is_ul] = np.nan
+        flux_ul = compute_flux_points_ul(table['flux'], table['flux_errp'])
+        table['flux_ul'][is_ul] = flux_ul[is_ul]
 
         table['eflux_ul'] = np.nan * e2dnde.unit
-        table['eflux_ul'][is_ul] = table['eflux_errp'][is_ul]
-
-        for column in ['eflux', 'eflux_errp', 'eflux_errn']:
-            table[column][is_ul] = np.nan
+        eflux_ul = compute_flux_points_ul(table['eflux'], table['eflux_errp'])
+        table['eflux_ul'][is_ul] = eflux_ul[is_ul]
 
         # TODO: remove this computation here.
         # # Instead provide a method on the FluxPoints class like `to_dnde()` or something.

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -91,6 +91,13 @@ class TestFermi3FGLObject:
         desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06, 1.308784e-08]
         assert_allclose(flux_points.table['dnde'].data, desired, rtol=1e-5)
 
+    def test_flux_points_ul(self):
+        source = self.cat['3FGL J0000.2-3738']
+        flux_points = source.flux_points
+
+        desired = [4.096391e-09, 6.680059e-10, np.nan, np.nan, np.nan]
+        assert_allclose(flux_points.table['flux_ul'].data, desired, rtol=1e-5)
+
     def test_lightcurve(self):
         lc = self.source.lightcurve
         assert len(lc) == 48
@@ -131,11 +138,11 @@ class TestFermi1FHLObject:
         src = self.cat['1FHL J0153.1+7515']
         flux_points = src.flux_points
         actual = flux_points.table['flux']
-        desired = [5.523017e-11, np.nan, np.nan] * u.Unit('cm-2 s-1')
+        desired = [5.523017e-11, 0, 0] * u.Unit('cm-2 s-1')
         assert_quantity_allclose(actual, desired)
 
         actual = flux_points.table['flux_ul']
-        desired = [np.nan, 2.081589e-11, 1.299698e-11] * u.Unit('cm-2 s-1')
+        desired = [np.nan, 4.163177e-11, 2.599397e-11] * u.Unit('cm-2 s-1')
         assert_quantity_allclose(actual, desired, rtol=1e-5)
 
 
@@ -162,12 +169,12 @@ class TestFermi2FHLObject:
         src = self.cat['PKS 2155-304']
         flux_points = src.flux_points
         actual = flux_points.table['flux']
-        desired = [2.866363e-10, 6.118736e-11, np.nan] * u.Unit('cm-2 s-1')
+        desired = [2.866363e-10, 6.118736e-11, 3.257970e-16] * u.Unit('cm-2 s-1')
         assert_quantity_allclose(actual, desired)
 
         actual = flux_points.table['flux_ul']
-        desired = [np.nan, np.nan, 6.470300e-12] * u.Unit('cm-2 s-1')
-        assert_quantity_allclose(actual, desired)
+        desired = [np.nan, np.nan, 1.294092e-11] * u.Unit('cm-2 s-1')
+        assert_quantity_allclose(actual, desired, rtol=1E-3)
 
 
 @requires_data('gammapy-extra')


### PR DESCRIPTION
This PR fixes the Fermi-LAT flux points upper limit computation. When plotting Fermi-LAT spectra and flux points I noticed, that the flux upper limits where not compatible with the ones I computed myself.
I found that the `flux_ul` and `eflux_ul` columns were not filled correctly in the catalog object `.flux_points` property. 

The `flux_errp` column in the Fermi catalogs is set to `flux_errp = 0.5 * (flux_ul - flux)` (see [here](https://arxiv.org/pdf/1501.02003.pdf), page 30). So the upper limit column has to be computed from that.

**Before:**
![3fgl_j0000 2m3738_before](https://cloud.githubusercontent.com/assets/3715928/26119395/5d9377e8-3a6d-11e7-81b3-b9cad57bf8e3.png)

**After:**
![3fgl_j0000 2m3738_after](https://cloud.githubusercontent.com/assets/3715928/26119408/64444ffe-3a6d-11e7-9022-8da9ad1a6cfb.png)

**Reference:**
![3fgl_j0000d2m3738_spec](https://cloud.githubusercontent.com/assets/3715928/26119420/6e0c5bda-3a6d-11e7-940b-41a59955d0df.png)

In addition I removed that the `flux` column is set to `NaN`, where a flux ul are present, because the information is actually filled in the catalogs and can be useful for flux point fitting. 


  