### PR TITLE
Add gamma-cat resource and resource index classes

### DIFF
--- a/docs/catalog/gammacat.rst
+++ b/docs/catalog/gammacat.rst
@@ -1,0 +1,61 @@
+.. include:: ../references.txt
+
+.. _gammacat:
+
+*********
+gamma-cat
+*********
+
+``gamma-cat`` (https://github.com/gammapy/gamma-cat) is an
+open data collection and source catalog for TeV gamma-ray astronomy.
+
+As explained further in the ``gamma-cat`` docs, it provides two data products:
+
+1. the full data collection
+2. a source catalog with part of the data
+
+Catalog
+-------
+
+The gamma-cat catalog is available here:
+
+* ``$GAMMA_CAT/docs/data/gammacat.fits.gz`` -- latest version
+* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz``
+  - a stable version copied to the ``gammapy-extra`` repo,
+  used for the ``gammapy.catalog.gammacat`` tests.
+
+To work with the gamma-cat catalog from Gammapy,
+pick a version and create a `~gammapy.catalog.SourceCatalogGammaCat`::
+
+    from gammapy.catalog import SourceCatalogGammaCat
+    filename = '$GAMMA_CAT/docs/data/gammacat.fits.gz'
+    filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz'
+    cat = SourceCatalogGammaCat(filename)
+
+TODO: add examples how to use it and links to notebooks.
+
+Data collection
+---------------
+
+The gamma-cat data collection consists of a bunch of files in JSON and ECSV format, and there's a single
+JSON index file summarising all available data and containing pointers to the other files.
+(we plan to make a bundled version with all info in one JSON file soon)
+
+It is available here:
+
+* ``$GAMMA_CAT/docs/data/gammacat-datasets.json`` -- latest version
+* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat-datasets.json``
+  - a stable version copied to the ``gammapy-extra`` repo,
+  used for the ``gammapy.catalog.gammacat`` tests.
+
+To work with the gamma-cat data collection from Gammapy,
+pick a version and create a `~gammapy.catalog.GammaCatDataCollection` class.
+
+::
+
+    from gammapy.catalog import GammaCatDataCollection
+    filename = '$GAMMA_CAT/docs/data/gammacat-datasets.json'
+    filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat-datasets.json'
+    gammacat = GammaCatDataCollection.from_index(filename)
+
+TODO: add examples how to use it and links to notebooks.

--- a/docs/catalog/index.rst
+++ b/docs/catalog/index.rst
@@ -151,6 +151,13 @@ We also started to implement a local web app: ``gammapy-catalog-browse``.
 It isn't working well at the moment, and probably now that we started http://gamma-sky.net we'll probably remove it.
 But if anyone is interested to fix and improve ``gammapy-catalog-browse``, we could also keep it.
 
+Content
+=======
+
+.. toctree::
+   :maxdepth: 1
+
+   gammacat
 
 Reference/API
 =============

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -2,13 +2,13 @@
 """
 Gammacat open TeV source catalog.
 
-Meow!!!!
-
 https://github.com/gammapy/gamma-cat
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 import logging
 import numpy as np
+from astropy.extern import six
 from astropy.tests.helper import ignore_warnings
 from astropy import units as u
 from astropy.table import Table
@@ -24,6 +24,9 @@ from .core import SourceCatalog, SourceCatalogObject
 __all__ = [
     'SourceCatalogGammaCat',
     'SourceCatalogObjectGammaCat',
+    'GammaCatDataCollection',
+    'GammaCatResource',  # TODO: public or not?
+    'GammaCatResourceIndex',  # TODO: public or not?
 ]
 
 log = logging.getLogger(__name__)
@@ -275,3 +278,200 @@ class SourceCatalogGammaCat(SourceCatalog):
             source_list.append(source_model)
 
         return SourceLibrary(source_list=source_list)
+
+
+class GammaCatDataCollection(object):
+    """Data store for gamma-cat.
+
+    Gives access to all data from https://github.com/gammapy/gamma-cat .
+
+    Holds a `GammaCatResourceIndex` to locate resources,
+    but also more info about gamma-cat, as well as methods to create
+    Gammapy objects (spectral models, flux points, lightcurves) from the datasets.
+    """
+
+    def __init__(self, data_index):
+        self.data_index = data_index
+
+    @classmethod
+    def from_index_file(cls, filename='$GAMMA_CAT/docs/data/gammacat-datasets.json'):
+        """Create from index file."""
+        filename = str(make_path(filename))
+        # TODO: make a list of `GammaCatResource`, as well as a dict by ``resource_id`` for lookup!
+        data_index = load_json(filename)
+        return cls(data_index=data_index)
+
+    def info(self):
+        """Print some info."""
+        ss = 'version = {}'.format(self.data_index['info']['version'])
+        return ss
+
+
+class GammaCatResource(object):
+    """Reference for a single resource in gamma-cat. 
+    
+    This can be considered an implementation detail,
+    used to assign ``global_id`` and to load resources.
+
+    TODO: explain how ``global_id``, ``type`` and ``location`` work.
+    Uses the Python ``hash`` function on the tuple ``(source_id, reference_id, file_id)``
+
+    Parameters
+    ----------
+    source_id : int
+        Gamma-cat source ID
+    reference_id : str
+        Gamma-cat reference ID (usually the ADS paper bibcode)
+    file_id : int
+        File ID (a counter for cases with multiple measurements per reference / source)
+        (use integer -1 if missing)
+    type : str
+        Resource type (use string 'none' if missing)
+    location : str
+        Resource location (use string 'none' if missing)
+    
+    Examples
+    --------
+    >>> from gammapy.catalog.gammacat import GammaCatResource
+    >>> resource = GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2)
+    >>> resource
+    GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2, global_id='42-2010A&A...516A..62A-2', location=None)
+    """
+    _NA_FILL = dict(file_id=-1, type='none', location='none')
+
+    def __init__(self, source_id, reference_id, file_id=-1, type='none', location='none'):
+        self.source_id = int(source_id)
+        self.reference_id = six.text_type(reference_id)
+        self.file_id = int(file_id)
+        self.type = six.text_type(type)
+        self.location = six.text_type(location)
+
+    @property
+    def global_id(self):
+        """Globally unique (within gamma-cat) resource ID (str).
+
+        (see class docstring for explanation and example).
+        """
+        return '|'.join((str(self.source_id), self.reference_id, str(self.file_id), self.type))
+
+    def __repr__(self):
+        fmt = '{}(source_id={!r}, reference_id={!r}, file_id={!r}, type={!r}, location={!r})'
+        return fmt.format(self.__class__.__name__, self.source_id, str(self.reference_id),
+                          self.file_id, str(self.type), str(self.location))
+
+    def __eq__(self, other):
+        return (
+            self.source_id == other.source_id and
+            self.reference_id == other.reference_id and
+            self.file_id == other.file_id and
+            self.type == other.type and
+            self.location == other.location
+        )
+
+    def to_dict(self):
+        """Convert to `collections.OrderedDict`."""
+        data = OrderedDict()
+        data['source_id'] = self.source_id
+        data['reference_id'] = self.reference_id
+        data['file_id'] = self.file_id
+        data['type'] = self.type
+        data['location'] = self.location
+        return data
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create from dict."""
+        return cls(
+            source_id=data['source_id'],
+            reference_id=data['reference_id'],
+            file_id=data.get('file_id', cls._NA_FILL['file_id']),
+            type=data.get('type', cls._NA_FILL['type']),
+            location=data.get('location', cls._NA_FILL['location'])
+        )
+
+
+class GammaCatResourceIndex(object):
+    """Resource index for gamma-cat.
+
+    Parameters
+    ----------
+    resources : list
+        List of `GammaCatResource` objects
+    """
+
+    def __init__(self, resources):
+        self.resources = resources
+
+    def __repr__(self):
+        return '{}(n_resources={})'.format(self.__class__.__name__, len(self.resources))
+
+    def __eq__(self, other):
+        if len(self.resources) != len(other.resources):
+            return False
+        return all(a == b for (a, b) in zip(self.resources, other.resources))
+
+    @property
+    def unique_source_ids(self):
+        """Sorted list of unique source IDs (`list(int)`)."""
+        return sorted(set([resource.source_id for resource in self.resources]))
+
+    @property
+    def unique_reference_ids(self):
+        """Sorted list of unique source IDs (`list(str)`)."""
+        return sorted(set([resource.reference_id for resource in self.resources]))
+
+    @property
+    def global_ids(self):
+        """List of global resource IDs (`list(str)`).
+        
+        In original order, not sorted.
+        """
+        return [resource.global_id for resource in self.resources]
+
+    def to_list(self):
+        """Convert to list of dict."""
+        return [resource.to_dict() for resource in self.resources]
+
+    @classmethod
+    def from_list(cls, data):
+        """Create from list of dicts."""
+        return cls([GammaCatResource.from_dict(_) for _ in data])
+
+    def to_table(self):
+        """Convert to `~astropy.table.Table`."""
+        rows = self.to_list()
+        return Table(rows=rows, names=list(rows[0].keys()))
+
+    @classmethod
+    def from_table(cls, table):
+        resources = []
+        for row in table:
+            data = OrderedDict((k, row[k]) for k in table.colnames)
+            resources.append(GammaCatResource.from_dict(data))
+        return cls(resources=resources)
+
+    def to_pandas(self):
+        """Convert to `pandas.DataFrame`."""
+        # This is inefficient. Could implement direct conversion if needed.
+        table = self.to_table()
+        return table.to_pandas()
+
+    @classmethod
+    def from_pandas(cls, dataframe):
+        """Create from `pandas.DataFrame`."""
+        table = Table.from_pandas(dataframe)
+        return cls.from_table(table)
+
+    def query(self, *args, **kwargs):
+        """Query to select subset of resources.
+        
+        Calls `pandas.DataFrame.query` and passes arguments to that method.
+        
+        Examples
+        --------
+        >>> resource_index = GammaCatResourceIndex(...)
+        >>> resource_index2 = resource_index.query('type == "sed" and source_id == 42')
+        """
+        df = self.to_pandas()
+        df2 = df.query(*args, **kwargs)
+        return self.from_pandas(df2)

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -335,7 +335,7 @@ class GammaCatResource(object):
     >>> from gammapy.catalog.gammacat import GammaCatResource
     >>> resource = GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2)
     >>> resource
-    GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2, global_id='42-2010A&A...516A..62A-2', location=None)
+    GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2, type='none', location='none')
     """
     _NA_FILL = dict(file_id=-1, type='none', location='none')
 
@@ -444,6 +444,7 @@ class GammaCatResourceIndex(object):
 
     @classmethod
     def from_table(cls, table):
+        """Create from `~astropy.table.Table`."""
         resources = []
         for row in table:
             data = OrderedDict((k, row[k]) for k in table.colnames)

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -50,7 +50,7 @@ SOURCES = [
 
 @pytest.fixture(scope='session')
 def gammacat():
-    filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat.fits.gz'
+    filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz'
     return SourceCatalogGammaCat(filename=filename)
 
 
@@ -120,17 +120,17 @@ class TestSourceCatalogObjectGammaCat:
 
         e_min, e_max, e_inf = [1, 10, 1e10] * u.TeV
 
-        dnde_1TeV = spectral_model.evaluate_error(e_min)
-        flux_1TeV = spectral_model.integral_error(emin=e_min, emax=e_inf)
-        eflux_1_10TeV = spectral_model.energy_flux_error(emin=e_min, emax=e_max).to('erg cm-2 s-1')
+        dnde_1TeV, dnde_1TeV_err = spectral_model.evaluate_error(e_min)
+        flux_1TeV, flux_1TeV_err = spectral_model.integral_error(emin=e_min, emax=e_inf)
+        eflux_1_10TeV, eflux_1_10TeV_err = spectral_model.energy_flux_error(emin=e_min, emax=e_max).to('erg cm-2 s-1')
 
-        assert_quantity_allclose(dnde_1TeV[0], ref['dnde_1TeV'], rtol=1e-3)
-        assert_quantity_allclose(flux_1TeV[0], ref['flux_1TeV'], rtol=1e-3)
-        assert_quantity_allclose(eflux_1_10TeV[0], ref['eflux_1_10TeV'], rtol=1e-3)
+        assert_quantity_allclose(dnde_1TeV, ref['dnde_1TeV'], rtol=1e-3)
+        assert_quantity_allclose(flux_1TeV, ref['flux_1TeV'], rtol=1e-3)
+        assert_quantity_allclose(eflux_1_10TeV, ref['eflux_1_10TeV'], rtol=1e-3)
 
-        assert_quantity_allclose(dnde_1TeV[1], ref['dnde_1TeV_err'], rtol=1e-3)
-        assert_quantity_allclose(flux_1TeV[1], ref['flux_1TeV_err'], rtol=1e-3)
-        assert_quantity_allclose(eflux_1_10TeV[1], ref['eflux_1_10TeV_err'], rtol=1e-3)
+        assert_quantity_allclose(dnde_1TeV_err, ref['dnde_1TeV_err'], rtol=1e-3)
+        assert_quantity_allclose(flux_1TeV_err, ref['flux_1TeV_err'], rtol=1e-3)
+        assert_quantity_allclose(eflux_1_10TeV_err, ref['eflux_1_10TeV_err'], rtol=1e-3)
 
     @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
     def test_flux_points(self, gammacat, ref):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -6,6 +6,7 @@ from astropy.tests.helper import assert_quantity_allclose, pytest
 from astropy import units as u
 from ...utils.testing import requires_data, requires_dependency
 from ..gammacat import SourceCatalogGammaCat
+from ..gammacat import GammaCatResource, GammaCatResourceIndex
 
 SOURCES = [
     {
@@ -138,3 +139,108 @@ class TestSourceCatalogObjectGammaCat:
         flux_points = source.flux_points
 
         assert len(flux_points.table) == ref['n_flux_points']
+
+
+class TestGammaCatResource:
+    def setup(self):
+        self.resource = GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2)
+        self.global_id = '42|2010A&A...516A..62A|2|none'
+
+    def test_global_id(self):
+        assert self.resource.global_id == self.global_id
+
+    def test_eq(self):
+        resource1 = self.resource
+        resource2 = GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A')
+
+        assert resource1 == resource1
+        assert resource1 != resource2
+
+    def test_repr(self):
+        expected = ("GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', "
+                    "file_id=2, type='none', location='none')")
+        assert repr(self.resource) == expected
+
+    def test_to_dict(self):
+        expected = OrderedDict([
+            ('source_id', 42), ('reference_id', '2010A&A...516A..62A'),
+            ('file_id', 2), ('type', 'none'), ('location', 'none'),
+        ])
+        assert self.resource.to_dict() == expected
+
+    def test_dict_roundtrip(self):
+        actual = GammaCatResource.from_dict(self.resource.to_dict())
+        assert actual == self.resource
+
+
+class TestGammaCatResourceIndex:
+    def setup(self):
+        self.resource_index = GammaCatResourceIndex([
+            GammaCatResource(source_id=99, reference_id='2014ApJ...780..168A'),
+            GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2, type='sed'),
+            GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=1),
+        ])
+
+    def test_repr(self):
+        assert repr(self.resource_index) == 'GammaCatResourceIndex(n_resources=3)'
+
+    def test_eq(self):
+        resource_index1 = self.resource_index
+        resource_index2 = GammaCatResourceIndex(resource_index1.resources[:-1])
+
+        assert resource_index1 == resource_index1
+        assert resource_index1 != resource_index2
+
+    def test_unique_source_ids(self):
+        expected = [42, 99]
+        assert self.resource_index.unique_source_ids == expected
+
+    def test_unique_reference_ids(self):
+        expected = ['2010A&A...516A..62A', '2014ApJ...780..168A']
+        assert self.resource_index.unique_reference_ids == expected
+
+    def test_global_ids(self):
+        expected = [
+            '99|2014ApJ...780..168A|-1|none',
+            '42|2010A&A...516A..62A|2|sed',
+            '42|2010A&A...516A..62A|1|none',
+        ]
+        assert self.resource_index.global_ids == expected
+
+    def test_to_list(self):
+        result = self.resource_index.to_list()
+        assert isinstance(result, list)
+        assert len(result) == 3
+
+    def test_list_roundtrip(self):
+        data = self.resource_index.to_list()
+        actual = GammaCatResourceIndex.from_list(data)
+        assert actual == self.resource_index
+
+    def test_to_table(self):
+        table = self.resource_index.to_table()
+        assert len(table) == 3
+        assert table.colnames == ['source_id', 'reference_id', 'file_id', 'type', 'location']
+
+    def test_table_roundtrip(self):
+        table = self.resource_index.to_table()
+        actual = GammaCatResourceIndex.from_table(table)
+        assert actual == self.resource_index
+
+    @requires_dependency('pandas')
+    def test_to_pandas(self):
+        df = self.resource_index.to_pandas()
+        df2 = df.query('source_id == 42')
+        assert len(df2) == 2
+
+    @requires_dependency('pandas')
+    def test_pandas_roundtrip(self):
+        df = self.resource_index.to_pandas()
+        actual = GammaCatResourceIndex.from_pandas(df)
+        assert actual == self.resource_index
+
+    @requires_dependency('pandas')
+    def test_query(self):
+        resource_index = self.resource_index.query('type == "sed" and source_id == 42')
+        assert len(resource_index.resources) == 1
+        assert resource_index.resources[0].global_id == '42|2010A&A...516A..62A|2|sed'


### PR DESCRIPTION
This pull request adds `GammaCatResource` and `GammaCatResourceIndex` class, that are supposed to be the basis for representing and selecting resources in `gamma-cat` (such as SED, lightcurve, basic source info, dataset info). It also adds a separate docs page for gammacat, and I moved the catalog file into a `gammacat` sub-folder in the gamma-extra repo.

I want to start using this in the `gammacat` scripts soon, so I'll probably merge this tonight and then do a follow-up pull request implementing the `GammaCatDatasetCollection` class that will be the main end-user interface to gamma-cat tomorrow.

The gamma-cat catalog and source object classes remain completely separate, nothing changed there.