### PR TITLE
Improve table unit standardisation and flux points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build dist docs/_build docs/api htmlcov MANIFEST gammapy.egg-info .coverage
+	rm -rf build dist docs/_build docs/api htmlcov MANIFEST gammapy.egg-info .coverage .cache
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find gammapy -name '*.c' -exec rm {} \;

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -14,7 +14,7 @@ from astropy.modeling.models import Gaussian2D, Disk2D
 from astropy.coordinates import Angle
 from ..utils.scripts import make_path
 from ..utils.energy import EnergyBounds
-from ..utils.table import table_standardise
+from ..utils.table import table_standardise_units_inplace
 from ..image import SkyImage
 from ..image.models import Delta2D, Template2D
 from ..spectrum import FluxPoints, compute_flux_points_dnde
@@ -699,7 +699,7 @@ class SourceCatalog3FGL(SourceCatalog):
 
         with ignore_warnings():  # ignore FITS units warnings
             table = Table.read(filename, hdu='LAT_Point_Source_Catalog')
-        table_standardise(table)
+        table_standardise_units_inplace(table)
 
         source_name_key = 'Source_Name'
         source_name_alias = ('Extended_Source_Name', '0FGL_Name', '1FGL_Name',
@@ -728,7 +728,7 @@ class SourceCatalog1FHL(SourceCatalog):
 
         with ignore_warnings():  # ignore FITS units warnings
             table = Table.read(filename, hdu='LAT_Point_Source_Catalog')
-        table_standardise(table)
+        table_standardise_units_inplace(table)
 
         source_name_key = 'Source_Name'
         source_name_alias = ('ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM')
@@ -755,7 +755,7 @@ class SourceCatalog2FHL(SourceCatalog):
 
         with ignore_warnings():  # ignore FITS units warnings
             table = Table.read(filename, hdu='2FHL Source Catalog')
-        table_standardise(table)
+        table_standardise_units_inplace(table)
 
         source_name_key = 'Source_Name'
         source_name_alias = ('ASSOC', '3FGL_Name', '1FHL_Name', 'TeVCat_Name')
@@ -784,7 +784,7 @@ class SourceCatalog3FHL(SourceCatalog):
 
         with ignore_warnings():  # ignore FITS units warnings
             table = Table.read(filename, hdu='LAT_Point_Source_Catalog')
-        table_standardise(table)
+        table_standardise_units_inplace(table)
 
         source_name_key = 'Source_Name'
         source_name_alias = ('ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM')

--- a/gammapy/image/radial_profile.py
+++ b/gammapy/image/radial_profile.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from astropy.table import QTable
+from astropy.table import Table
 from .core import SkyImage
 
 __all__ = [
@@ -30,7 +30,7 @@ def radial_profile(image, center, radius):
 
     Returns
     -------
-    table : `~astropy.table.QTable`
+    table : `~astropy.table.Table`
 
         Table with the following fields that define the binning:
 
@@ -145,7 +145,7 @@ def _radial_profile_measure(image, labels, index):
     image = image.data
     labels = labels.data
 
-    table = QTable()
+    table = Table()
     table['N_PIX'] = ndimage.sum(np.ones_like(image), labels, index=index)
     table['SUM'] = ndimage.sum(image, labels, index=index)
     table['MEAN'] = table['SUM'] / table['N_PIX']

--- a/gammapy/scripts/image_pipe.py
+++ b/gammapy/scripts/image_pipe.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.units import Quantity
-from astropy.table import QTable, Table
+from astropy.table import Table
 from astropy.coordinates import Angle
 from astropy.convolution import Tophat2DKernel
 from ..utils.energy import EnergyBounds
@@ -115,7 +115,7 @@ class SingleObsImageMaker(object):
 
         Returns
         -------
-        table : `astropy.table.QTable`
+        table : `astropy.table.Table`
             Two columns: offset in the FOV "theta" and expected counts "npred"
         """
         energy = EnergyBounds.equal_log_spacing(self.energy_band[0].value, self.energy_band[1].value, 100,
@@ -133,7 +133,7 @@ class SingleObsImageMaker(object):
             norm = np.sum(spectrum * energy_band)
             npred /= norm
 
-        table = QTable()
+        table = Table()
         table['theta'] = offset
         table['npred'] = npred
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -246,12 +246,11 @@ class TestSEDLikelihoodProfile:
         self.sed = SEDLikelihoodProfile.read(filename)
 
     def test_basics(self):
-        # print(self.sed)
         assert 'SEDLikelihoodProfile' in str(self.sed)
 
     @requires_dependency('matplotlib')
     def test_plot(self):
-        ax = self.sed.plot()
+        self.sed.plot()
 
 
 @pytest.fixture(params=FLUX_POINTS_FILES, scope='session')
@@ -263,12 +262,10 @@ def flux_points(request):
 @requires_dependency('yaml')
 @requires_data('gammapy-extra')
 class TestFluxPoints:
+
     @requires_dependency('matplotlib')
     def test_plot(self, flux_points):
-        import matplotlib.pyplot as plt
-        ax = plt.gca()
-        flux_points.plot(ax=ax)
-        flux_points.peek()
+        flux_points.plot()
 
     def test_info(self, flux_points):
         info = str(flux_points)

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -222,6 +222,9 @@ def fits_header_to_meta_dict(header):
     return meta
 
 
+# TODO: remove type = 'qtable' to avoid issues?
+# see https://github.com/astropy/astropy/issues/6098
+# see https://github.com/gammapy/gammapy/issues/980
 def table_from_row_data(rows, type='qtable', **kwargs):
     """Helper function to create table objects from row data.
 

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -2,16 +2,42 @@
 """Table helper utilities.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.table import Table
 from .units import standardise_unit
 
 __all__ = [
-    'table_standardise',
+    'table_standardise_units_copy',
+    'table_standardise_units_inplace',
 ]
 
 
-def table_standardise(table):
-    """TODO
+def table_standardise_units_copy(table):
+    """Standardise units for all columns in a table in a copy.
+    
+    Calls `~gammapy.utils.units.standardise_unit`.
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table` or `~astropy.table.QTable`
+        Input table (won't be modified)
+
+    Returns
+    -------
+    table : `~astropy.table.Table`
+        Copy of the input table with standardised column units
+    """
+    # Note: we could add an `inplace` option (or variant of this function)
+    # for `Table`, but not for `QTable`.
+    # See https://github.com/astropy/astropy/issues/6098
+    table = Table(table)
+    return table_standardise_units_inplace(table)
+
+
+def table_standardise_units_inplace(table):
+    """Standardise units for all columns in a table in place.
     """
     for column in table.columns.values():
         if column.unit:
             column.unit = standardise_unit(column.unit)
+
+    return table

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -1,18 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.tests.helper import pytest
 import astropy.units as u
-from astropy.table import Table, Column
-from ..table import table_standardise
+from astropy.table import Table, QTable, Column
+from ..table import table_standardise_units_copy
 
 
-def test_table_standardise():
-    table = Table()
+@pytest.mark.parametrize('table_class', [Table, QTable])
+def test_table_standardise_units(table_class):
+    table = table_class()
     table['a'] = Column([1], unit='ph cm-2 s-1')
     table['b'] = Column([1], unit='ct cm-2 s-1')
     table['c'] = Column([1], unit='cm-2 s-1')
     table['d'] = Column([1])
 
-    table_standardise(table)
+    table = table_standardise_units_copy(table)
 
     assert table['a'].unit == u.Unit('cm-2 s-1')
     assert table['b'].unit == u.Unit('cm-2 s-1')


### PR DESCRIPTION
I wanted to do a pull request that fixes `FluxPoints.plot` to work for the case where asymmetric errors are given (they currently don't show up). But then I got sidetracked when I wanted to replace the unit standardisation code in `FluxPoints.__init__` with the version in `gammapy.utils`, and ran into weird behaviour for `QTable` objects which get generated in the flux points tests.

Astropy issue concerning the `QTable` issues is here: https://github.com/astropy/astropy/issues/6098

This pull request:
- [x] Changes the table column unit standardisation so that it can work for QTable
- [x] Call the new function from `FluxPoints.__init__`
- [x] Change from `QTable` to `Table` in two places in Gammapy where it's not really needed. (will leave a comment in #980).
- [x] Misc cleanup of `FluxPoint` class. Remove `peek` method because it was the same as `plot`. I'm -1 on adding a duplicate method just to have `peek` everywhere, users will be confused when to call `plot` or `peek`.

The `FluxPoints.plot` method is unchanged here, it just appears in the diff because I moved it to the end of the class code (like where the plotting code is for most classes in Gammapy). I'll make a follow-up PR tomorrow to actually refactor `FluxPoints.plot` (it's currently super long and hard to read and test) and fix the plotting of spectra with asymmetric errors (like we have cases in `gammacat-status`).