### PR TITLE
Fix CTA obs sim and add test for OGIP spec I/O

### DIFF
--- a/gammapy/scripts/cta_utils.py
+++ b/gammapy/scripts/cta_utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import astropy.units as u
 from ..spectrum import SpectrumObservation
@@ -132,22 +132,21 @@ class CTAObservationSimulation(object):
 
         on_counts += bkg_counts  # evts in ON region
 
-        meta = dict(EXPOSURE=livetime.to('s').value)
-
         on_vector = PHACountsSpectrum(
             data=on_counts,
             backscal=1,
             energy_lo=reco_energy.lo,
             energy_hi=reco_energy.hi,
-            meta=meta,
         )
 
+        on_vector.livetime = livetime
         off_vector = PHACountsSpectrum(energy_lo=reco_energy.lo,
                                        energy_hi=reco_energy.hi,
                                        data=off_counts,
                                        backscal=1. / alpha,
                                        is_bkg=True,
                                        )
+        off_vector.livetime = livetime
 
         obs = SpectrumObservation(on_vector=on_vector,
                                   off_vector=off_vector,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -293,22 +293,20 @@ class TestSpectralFit:
         actual = read_result.model.evaluate_error(1 * u.TeV)
         assert_quantity_allclose(actual, desired)
 
+    def test_sherpa_fit(self, tmpdir):
+        # this is to make sure that the written PHA files work with sherpa
+        import sherpa.astro.ui as sau
+        from sherpa.models import PowLaw1D
 
-@requires_dependency('sherpa')
-@requires_data('gammapy-extra')
-def test_sherpa_fit(tmpdir):
-    # this is to make sure that the written PHA files work with sherpa
-    import sherpa.astro.ui as sau
-    from sherpa.models import PowLaw1D
-
-    filename = gammapy_extra.filename("datasets/hess-crab4_pha/pha_obs23592.fits")
-    sau.load_pha(filename)
-    sau.set_stat('wstat')
-    model = PowLaw1D('powlaw1d.default')
-    model.ref = 1e9
-    model.ampl = 1
-    model.gamma = 2
-    sau.set_model(model * 1e-20)
-    sau.fit()
-    assert_allclose(model.pars[0].val, 2.0033101181778026)
-    assert_allclose(model.pars[2].val, 2.2991681244938498)
+        self.obs_list.write(tmpdir, use_sherpa=True)
+        filename = tmpdir / 'pha_obs23523.fits'
+        sau.load_pha(str(filename))
+        sau.set_stat('wstat')
+        model = PowLaw1D('powlaw1d.default')
+        model.ref = 1e9
+        model.ampl = 1
+        model.gamma = 2
+        sau.set_model(model * 1e-20)
+        sau.fit()
+        assert_allclose(model.pars[0].val, 2.0881699260935838)
+        assert_allclose(model.pars[2].val, 1.6234222129479836)


### PR DESCRIPTION
in #1028 @cdeil noted correctly
> [some test] reads files from gammapy-extra, I guess it could be broken, and one would only see that when reproducing the files with latest Gammapy

This PR updates the regression test to always write files to ``tmpdir`` with the newest version of gammapy. Everything works fine though, this does not (yet) resolve #1028 

cc @jjlk 