### PR TITLE
Make gammapy.spectrum.powerlaw private

### DIFF
--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -89,6 +89,3 @@ Reference/API
 
 .. automodapi:: gammapy.spectrum.models
     :no-inheritance-diagram:
-
-.. automodapi:: gammapy.spectrum.powerlaw
-    :no-inheritance-diagram:


### PR DESCRIPTION
This pull request makes the `gammapy.spectrum.powerlaw` module private, by removing it's mention in the public API docs.

At first, I wanted to remove it completely, but then I decided to keep them for now.
I've updated the module docstring to explain why.