### PR TITLE
Development in gammapy.maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1,15 +1,28 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import abc
+from astropy.extern import six
+from astropy.utils.misc import InheritDocstrings
 
 __all__ = [
     'MapBase',
 ]
 
 
-class MapBase(object):
-    """Abstract map class.
+class MapMeta(InheritDocstrings, abc.ABCMeta):
+    pass
 
-    This can represent either WCS or HEALPIX-based maps in 2 or 3 dimensions.
+
+@six.add_metaclass(MapMeta)
+class MapBase(object):
+    """Abstract map class.  This can represent WCS- or HEALPIX-based maps
+    with 2 spatial dimensions and N non-spatial dimensions.
+
+    Parameters
+    ----------
+    geom : `~gammapy.maps.geom.MapGeom`
+
+    data : `~numpy.ndarray`
     """
 
     def __init__(self, geom, data):
@@ -18,6 +31,7 @@ class MapBase(object):
 
     @property
     def data(self):
+        """Array of data values."""
         return self._data
 
     @property
@@ -30,14 +44,48 @@ class MapBase(object):
             raise Exception('Wrong shape.')
         self._counts = val
 
+    @abc.abstractmethod
     def sum_over_axes(self):
-        """Reduce a counts cube to a counts map by summing over the energy planes."""
+        """Reduce to a 2D image by dropping non-spatial dimensions."""
         pass
 
-    def get_by_coord(self, coord, interp=None):
-        """Return the map values corresponding to a set of map coordinates."""
+    @abc.abstractmethod
+    def get_by_coords(self, coords, interp=None):
+        """Return map values at the given map coordinates.
+
+        Parameters
+        ----------
+        coords : tuple or `~gammapy.maps.geom.MapCoords`
+            `~gammapy.maps.geom.MapCoords` object or tuple of
+            coordinate arrays for each dimension of the map.  Tuple
+            should be ordered as (lon, lat, x_0, ..., x_n) where x_i
+            are coordinates for non-spatial dimensions of the map.
+
+        Returns
+        -------
+        vals : `~numpy.ndarray`
+           Values of pixels in the flattened map.
+           np.nan used to flag coords outside of map
+
+        """
         pass
 
+    @abc.abstractmethod
     def get_by_pix(self, pix, interp=None):
-        """Return the map values corresponding to a set of pixel coordinates."""
+        """Return map values at the given pixel coordinates.
+
+        Parameters
+        ----------
+        pix : tuple
+            Tuple of pixel index arrays for each dimension of the map.
+            Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
+            for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
+
+        Returns
+        ----------
+        vals : `~numpy.ndarray`
+           Values of pixels in the flattened map
+           np.nan used to flag coords outside of map
+
+        """
         pass

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -42,7 +42,7 @@ class MapBase(object):
     def data(self, val):
         if val.shape != self.data.shape:
             raise Exception('Wrong shape.')
-        self._counts = val
+        self._data = val
 
     @abc.abstractmethod
     def sum_over_axes(self):

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1200,12 +1200,13 @@ class HpxToWcsMapping(object):
         from fermipy.skymap import Map
         index_map = Map.read(filename)
         mult_map = Map.read(filename, hdu=1)
-        ff = fits.open(filename)
-        hpx = HPXGeom.from_header(ff[0])
-        mapping_data = dict(ipix=index_map.counts,
-                            mult_val=mult_map.counts,
-                            npix=mult_map.counts.shape)
-        return cls(hpx, index_map.wcs, mapping_data)
+
+        with fits.open(filename) as ff:
+            hpx = HPXGeom.from_header(ff[0])
+            ipix=index_map.counts
+            mult_val=mult_map.counts
+            npix=mult_map.counts.shape
+        return cls(hpx, index_map.wcs, ipix, mult_val, npix)
 
     def fill_wcs_map_from_hpx_data(self, hpx_data, wcs_data, normalize=True):
         """Fill the WCS map from the hpx data using the pre-calculated mappings.

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -102,9 +102,10 @@ class HpxMap(MapBase):
             Map object
 
         """
-        hdulist = fits.open(filename)
-        return cls.from_hdulist(hdulist, **kwargs)
-
+        with fits.open(filename) as hdulist:
+            hpx_map = cls.from_hdulist(hdulist, **kwargs)
+        return hpx_map
+            
     @classmethod
     def from_hdulist(cls, hdulist, **kwargs):
         """Make a HpxMap object from a FITS HDUList.

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -246,7 +246,7 @@ class HpxMap(object):
         Parameters
         ----------
         coords : tuple
-            TODO
+            Tuple of coordinate vectors for each dimension of the map.
 
         Returns
         -------
@@ -257,13 +257,14 @@ class HpxMap(object):
         pass
 
     @abc.abstractmethod
-    def get_by_pix(self, coords, interp=None):
+    def get_by_pix(self, pix, interp=None):
         """Return map values at the given pixel coordinates.
 
         Parameters
         ----------
-        coords : tuple
-            TODO
+        pix : tuple
+            Tuple of pixel index vectors for each dimension of the map.
+
         Returns
         ----------
         vals : `~numpy.ndarray`

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.io import fits
+from astropy.coordinates import SkyCoord
 from ..hpx import HPXGeom, get_pixel_size_from_nside, nside_to_order
 from ..hpx import make_hpx_to_wcs_mapping, unravel_hpx_index, ravel_hpx_index
 
@@ -145,10 +146,60 @@ def test_hpx_get_region_size():
     assert_allclose(HPXGeom.get_region_size('DISK(110.,75.,2.)'), 2.0)
 
 
+def test_hpx_get_ref_dir():
+
+    refdir = HPXGeom.get_ref_dir('DISK(110.,75.,2.)', 'GAL')
+    assert_allclose(refdir.l.deg, 110.)
+    assert_allclose(refdir.b.deg, 75.)
+
+    refdir = HPXGeom.get_ref_dir(None, 'GAL')
+    assert_allclose(refdir.l.deg, 0.)
+    assert_allclose(refdir.b.deg, 0.)
+
+
 def test_hpx_make_wcs():
     hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)')
     wcs = hpx.make_wcs()
     assert_allclose(wcs.wcs.wcs.crval, np.array([110., 75.]))
+
+
+def test_hpx_get_coords():
+
+    ax0 = np.linspace(0., 3., 4)
+
+    # 2D all-sky
+    hpx = HPXGeom(16, False, 'GAL')
+    c = hpx.get_coords()
+    assert_allclose(c[0][:3], np.array([87.075819,  87.075819,  87.075819]))
+    assert_allclose(c[1][:3], np.array([45.,  135.,  225.]))
+
+    # 3D all-sky
+    hpx = HPXGeom(16, False, 'GAL', axes=[ax0])
+    c = hpx.get_coords()
+    assert_allclose(c[0][:3], np.array([87.075819,  87.075819,  87.075819]))
+    assert_allclose(c[1][:3], np.array([45.,  135.,  225.]))
+    assert_allclose(c[2][:3], np.array([0.5, 0.5, 0.5]))
+
+    # 2D partial-sky
+    hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)')
+    c = hpx.get_coords()
+    assert_allclose(c[0][:3], np.array([76.813533,  76.813533,  76.07742]))
+    assert_allclose(c[1][:3], np.array([107.5,  112.5,  106.57894737]))
+
+    # 3D partial-sky
+    hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)', axes=[ax0])
+    c = hpx.get_coords()
+    assert_allclose(c[0][:3], np.array([76.813533,  76.813533,  76.07742]))
+    assert_allclose(c[1][:3], np.array([107.5,  112.5,  106.57894737]))
+    assert_allclose(c[2][:3], np.array([0.5, 0.5, 0.5]))
+
+    # 3D partial-sky w/ variable bin size
+    hpx = HPXGeom([16, 32, 64], False, 'GAL',
+                  region='DISK(110.,75.,2.)', axes=[ax0])
+    c = hpx.get_coords()
+    assert_allclose(c[0][:3], np.array([75.340734,  75.340734,  75.340734]))
+    assert_allclose(c[1][:3], np.array([117.,  103.5,  112.5]))
+    assert_allclose(c[2][:3], np.array([0.5,  1.5,  1.5]))
 
 
 def test_make_hpx_to_wcs_mapping():
@@ -164,7 +215,8 @@ def test_make_hpx_to_wcs_mapping():
                     np.array([0.5, 0.2, 0.2, 0.2, 0.5, 0.2, 0.2, 0.25,
                               0.2, 0.2, 0.25, 0.25, 0.2, 0.2, 0.2, 0.25]))
 
-    hpx = HPXGeom([8, 16], False, 'GAL', region='DISK(110.,75.,2.)', axes=[ax0])
+    hpx = HPXGeom([8, 16], False, 'GAL',
+                  region='DISK(110.,75.,2.)', axes=[ax0])
     hpx2wcs = make_hpx_to_wcs_mapping(hpx, wcs)
     assert_allclose(hpx2wcs[0],
                     np.array([[15, 6, 6, 6, 15, 6, 6, 6,

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -170,35 +170,35 @@ def test_hpx_get_coords():
     # 2D all-sky
     hpx = HPXGeom(16, False, 'GAL')
     c = hpx.get_coords()
-    assert_allclose(c[0][:3], np.array([87.075819,  87.075819,  87.075819]))
-    assert_allclose(c[1][:3], np.array([45.,  135.,  225.]))
+    assert_allclose(c[0][:3], np.array([45.,  135.,  225.]))
+    assert_allclose(c[1][:3], np.array([87.075819,  87.075819,  87.075819]))
 
     # 3D all-sky
     hpx = HPXGeom(16, False, 'GAL', axes=[ax0])
     c = hpx.get_coords()
-    assert_allclose(c[0][:3], np.array([87.075819,  87.075819,  87.075819]))
-    assert_allclose(c[1][:3], np.array([45.,  135.,  225.]))
+    assert_allclose(c[0][:3], np.array([45.,  135.,  225.]))
+    assert_allclose(c[1][:3], np.array([87.075819,  87.075819,  87.075819]))
     assert_allclose(c[2][:3], np.array([0.5, 0.5, 0.5]))
 
     # 2D partial-sky
     hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)')
     c = hpx.get_coords()
-    assert_allclose(c[0][:3], np.array([76.813533,  76.813533,  76.07742]))
-    assert_allclose(c[1][:3], np.array([107.5,  112.5,  106.57894737]))
+    assert_allclose(c[0][:3], np.array([107.5,  112.5,  106.57894737]))
+    assert_allclose(c[1][:3], np.array([76.813533,  76.813533,  76.07742]))
 
     # 3D partial-sky
     hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)', axes=[ax0])
     c = hpx.get_coords()
-    assert_allclose(c[0][:3], np.array([76.813533,  76.813533,  76.07742]))
-    assert_allclose(c[1][:3], np.array([107.5,  112.5,  106.57894737]))
+    assert_allclose(c[0][:3], np.array([107.5,  112.5,  106.57894737]))
+    assert_allclose(c[1][:3], np.array([76.813533,  76.813533,  76.07742]))
     assert_allclose(c[2][:3], np.array([0.5, 0.5, 0.5]))
 
     # 3D partial-sky w/ variable bin size
     hpx = HPXGeom([16, 32, 64], False, 'GAL',
                   region='DISK(110.,75.,2.)', axes=[ax0])
     c = hpx.get_coords()
-    assert_allclose(c[0][:3], np.array([75.340734,  75.340734,  75.340734]))
-    assert_allclose(c[1][:3], np.array([117.,  103.5,  112.5]))
+    assert_allclose(c[0][:3], np.array([117.,  103.5,  112.5]))
+    assert_allclose(c[1][:3], np.array([75.340734,  75.340734,  75.340734]))
     assert_allclose(c[2][:3], np.array([0.5,  1.5,  1.5]))
 
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -158,7 +158,14 @@ def test_hpx_get_ref_dir():
 
 
 def test_hpx_make_wcs():
+
+    ax0 = np.linspace(0., 3., 4)
+    
     hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)')
+    wcs = hpx.make_wcs()
+    assert_allclose(wcs.wcs.wcs.crval, np.array([110., 75.]))
+
+    hpx = HPXGeom(64, False, 'GAL', region='DISK(110.,75.,2.)', axes=[ax0])
     wcs = hpx.make_wcs()
     assert_allclose(wcs.wcs.wcs.crval, np.array([110., 75.]))
 

--- a/gammapy/maps/tests/test_hpxcube.py
+++ b/gammapy/maps/tests/test_hpxcube.py
@@ -1,0 +1,72 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.tests.helper import pytest
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
+from ..geom import MapAxis
+from ..hpx import HPXGeom
+from ..hpxcube import HpxCube
+
+pytest.importorskip('healpy')
+
+
+def make_test_cubes():
+
+    data = np.random.uniform(0, 1, 3072)
+    m0 = HpxCube(HPXGeom(16, False, 'GAL'), data)
+    m1 = HpxCube(HPXGeom(16, False, 'GAL', axes=[np.linspace(0., 3., 4)]))
+    m2 = HpxCube(HPXGeom(16, False, 'GAL', region='DISK(110.,75.,10.)',
+                         axes=[np.linspace(0., 3., 4)]))
+    m3 = HpxCube(HPXGeom(16, False, 'GAL', region='DISK(110.,75.,10.)',
+                         axes=[np.linspace(0., 3., 4), np.linspace(0., 2., 3)]))
+    return m0, m1, m2, m3
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         [(8, False, 'GAL', None, None),
+                          (8, False, 'GAL', None, [
+                           MapAxis(np.logspace(0., 3., 4))]),
+                          (8, False, 'GAL', 'DISK(110.,75.,10.)',
+                           [MapAxis(np.logspace(0., 3., 4))]),
+                          (8, False, 'GAL', 'DISK(110.,75.,10.)',
+                           [MapAxis(np.logspace(0., 3., 4), name='axis0'),
+                            MapAxis(np.logspace(0., 2., 3))])
+                          ])
+def test_hpxcube_init(nside, nested, coordsys, region, axes):
+
+    shape = []
+    if axes:
+        shape = [ax.nbin for ax in axes]
+    geom = HPXGeom(nside, nested, coordsys, region=region, axes=axes)
+    shape += [np.unique(geom.npix)]
+    data = np.random.uniform(0, 1, shape)
+    m = HpxCube(geom)
+    assert(m.data.shape == data.shape)
+    m = HpxCube(geom, data)
+    assert_allclose(m.data, data)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         [(8, False, 'GAL', None, None),
+                          (8, False, 'GAL', None, [
+                           MapAxis(np.logspace(0., 3., 4))]),
+                          (8, False, 'GAL', 'DISK(110.,75.,10.)',
+                           [MapAxis(np.logspace(0., 3., 4))]),
+                          (8, False, 'GAL', 'DISK(110.,75.,10.)',
+                           [MapAxis(np.logspace(0., 3., 4), name='axis0'),
+                            MapAxis(np.logspace(0., 2., 3))])
+                          ])
+def test_hpxcube_read_write(tmpdir, nside, nested, coordsys, region, axes):
+
+    filename = str(tmpdir / 'skycube.fits')
+    m = HpxCube(HPXGeom(nside, nested, coordsys, region=region, axes=axes))
+    data = np.random.poisson(0.1, m.data.shape)
+    m.data[...] = data
+    m.write(filename)
+    m2 = HpxCube.read(filename)
+    assert_allclose(m.data, m2.data)
+    m.write(filename, sparse=True)
+    m2 = HpxCube.read(filename)
+    assert_allclose(m.data, m2.data)

--- a/gammapy/maps/tests/test_hpxcube.py
+++ b/gammapy/maps/tests/test_hpxcube.py
@@ -27,7 +27,7 @@ hpx_test_geoms = [(8, False, 'GAL', None, None),
 def test_hpxcube_init(nside, nested, coordsys, region, axes):
 
     geom = HPXGeom(nside, nested, coordsys, region=region, axes=axes)
-    shape = [np.unique(geom.npix)]
+    shape = [int(np.unique(geom.npix))]
     if axes:
         shape += [ax.nbin for ax in axes]
     shape = shape[::-1]

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -72,14 +72,19 @@ class WCSGeom(MapGeom):
         """TODO."""
         return self._npix
 
+    @property
+    def axes(self):
+        """List of non-spatial axes."""
+        return self._axes
+
     @classmethod
-    def from_skydir(cls, skydir, cdelt, npix, coordsys='CEL', projection='AIT'):
+    def from_skydir(cls, skydir, cdelt, npix, coordsys='CEL', projection='AIT', axes=None):
         """TODO."""
         npix = np.array(npix, ndmin=1)
         crpix = npix / 2. + 0.5
         wcs = create_wcs(skydir, coordsys, projection,
                          cdelt, crpix)
-        return cls(wcs, npix)
+        return cls(wcs, npix, axes)
 
     @classmethod
     def create(cls, nxpix=100, nypix=100, binsz=0.1, xref=0, yref=0,
@@ -131,7 +136,7 @@ class WCSGeom(MapGeom):
 
 
 def create_wcs(skydir, coordsys='CEL', projection='AIT',
-               cdelt=1.0, crpix=1., naxis=2, energies=None):
+               cdelt=1.0, crpix=1., axes=None):
     """Create a WCS object.
 
     Parameters
@@ -146,11 +151,14 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
         TODO
     crpix : float or (float,float)
         In the first case the same value is used for x and y axes
-    naxis : {2, 3}
-       Number of dimensions of the projection.
-    energies : array-like
-       Array of energies that defines the third dimension if naxis=3.
+    axes : list
+        List of non-spatial axes
     """
+
+    naxis = 2
+    if axes is not None:
+        naxis += len(axes)
+
     w = WCS(naxis=naxis)
 
     if coordsys == 'CEL':
@@ -176,12 +184,13 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
     w.wcs.cdelt[1] = cdelt
 
     w = WCS(w.to_header())
-    if naxis == 3 and energies is not None:
-        w.wcs.crpix[2] = 1
-        w.wcs.crval[2] = energies[0]
-        w.wcs.cdelt[2] = energies[1] - energies[0]
-        w.wcs.ctype[2] = 'Energy'
-        w.wcs.cunit[2] = 'MeV'
+    # FIXME: Figure out what to do here
+    # if naxis == 3 and energies is not None:
+    #    w.wcs.crpix[2] = 1
+    #    w.wcs.crval[2] = energies[0]
+    #    w.wcs.cdelt[2] = energies[1] - energies[0]
+    #    w.wcs.ctype[2] = 'Energy'
+    #    w.wcs.cunit[2] = 'MeV'
 
     return w
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -364,8 +364,9 @@ def wcs_to_coords(w, shape):
 
 
 def get_map_skydir(filename, maphdu=0):
-    hdulist = fits.open(filename)
-    wcs = WCS(hdulist[maphdu].header)
+
+    with fits.open(filename) as hdulist:
+        wcs = WCS(hdulist[maphdu].header)
     return wcs_to_skydir(wcs)
 
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -1,0 +1,58 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.wcs import WCS
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
+from ..image.utils import make_header
+from .base import MapBase
+from .wcs import WCSGeom, create_wcs
+
+__all__ = [
+    'WcsMap', 'WcsMapND'
+]
+
+
+class WcsMap(MapBase):
+
+    def __init__(self, wcs, data=None):
+        MapBase.__init__(self, wcs, data)
+
+
+class WcsMapND(WcsMap):
+
+    def __init__(self, wcs, data=None):
+        WcsMap.__init__(self, wcs, data)
+
+    @classmethod
+    def from_skydir(cls, skydir, cdelt, npix, coordsys='CEL', projection='AIT', axes=None):
+        wcs = WCSGeom.from_skydir(skydir, cdelt, npix, coordsys, projection,
+                                  axes)
+        return cls(wcs, np.zeros(npix).T)
+
+    @classmethod
+    def from_lonlat(cls, lon, lat, cdelt, npix, coordsys='CEL', projection='AIT', axes=None):
+        skydir = SkyCoord(lon, lat, unit='deg')
+        return cls.from_skydir(skydir, cdelt, npix, coordsys, projection, axes)
+
+    def get_by_coords(self, coords, interp=None):
+        raise NotImplementedError
+
+    def get_by_pix(self, pix, interp=None):
+        raise NotImplementedError
+
+    def sum_over_axes(self):
+        raise NotImplementedError
+
+    def plot(self, ax=None):
+
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            fig = plt.figure()
+            ax = fig.add_subplot(111, projection=self.geom.wcs)
+
+        im = ax.imshow(self.data, interpolation='nearest', cmap='magma',
+                       origin='lower')
+        ax.coords.grid(color='w', linestyle=':', linewidth=0.5)
+        return im


### PR DESCRIPTION
This PR contains changes related to ongoing development in `gammapy.maps`.  All of the code here is in an experimental/development state so it's possible that method and class names may change in the future.  The intention was to give everyone an opportunity to review and give feedback on the current class/interface design.  A quick summary of the updates included here:

* Fills out more of the class hierarchy.  WCS and HPX maps now both inherit from a `MapBase` class that defines abstract methods for accessing the contents of a map.  My plan is to have two concrete instances each for WCS and HPX -- one for non-sparse maps (`HpxMapND` and `WcsMapND`) and one for sparse maps  (`HpxMapSparse` and `WcsMapSparse`).  Both can represent maps of arbitrary dimensionality (i.e. 2 +N).
* Implemented I/O routines for `HpxMapND`.  These support reading/writing maps to FITS according to the format conventions documented [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/skymaps/healpix/index.html).  There are still a few aspects of the format that need to be worked out -- mostly pertaining to how axes can be extracted from the BANDS table in an automated way.
* Added stubs for some of the WCS classes mainly for testing the hpx to wcs conversion methods.

There's obviously still a lot of work to be done but I plan to continue working on this over the next few months.  Once I'm satisfied that these classes have everything we need in fermipy I would start working on copying over functionality from SkyImage and SkyCube.