### PR TITLE
Update pytest config to pytest 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
+[tool:pytest]
+minversion = 3.0
 norecursedirs = build docs/_build
 #doctest_plus = enabled
 addopts = -p no:warnings


### PR DESCRIPTION
In reflection to the discussion in #1057 

Note, that the version limitation is not strictly required, but if pytest version is <3.0, the config block is not recognized in it's current form, and that can lead to rather misleading behaviour (e.g. https://github.com/astropy/astropy/issues/5695)

pytest 3.0 was released about 10 months ago (2016-08-18), so probably it should be fine for your next release 