### PR TITLE
Add flux upper limit computation to TSImageEstimator

### DIFF
--- a/gammapy/detect/_test_statistics_cython.pyx
+++ b/gammapy/detect/_test_statistics_cython.pyx
@@ -97,8 +97,8 @@ def _amplitude_bounds_cython(np.ndarray[np.float_t, ndim=2] counts,
     cdef unsigned int i, j, ni, nj
     ni = counts.shape[1]
     nj = counts.shape[0]
-    for j in range(ni):
-        for i in range(nj):
+    for j in range(nj):
+        for i in range(ni):
             if counts[j, i] > 0:
                 s_counts += counts[j, i]
                 if model[j, i] > 0:

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -25,7 +25,7 @@ def test_compute_ts_map():
     ts_estimator = TSImageEstimator(method='leastsq iter')
     result = ts_estimator.run(images, kernel=kernel)
 
-    for name, order in zip(['ts', 'flux', 'flux_err', 'niter'], [2, 5, 5, 0]):
+    for name, order in zip(['ts', 'flux', 'flux_err', 'flux_ul', 'niter'], [2, 5, 5, 5, 0]):
         result[name].data = np.nan_to_num(result[name].data)
         result[name] = result[name].upsample(2, order=order)
 
@@ -34,3 +34,4 @@ def test_compute_ts_map():
     assert_allclose(3, result['niter'].data[99, 99])
     assert_allclose(1.0227934338735763e-09, result['flux'].data[99, 99], rtol=1e-3)
     assert_allclose(3.842162268386843e-11, result['flux_err'].data[99, 99], rtol=1e-3)
+    assert_allclose(1.0996355030292762e-09, result['flux_ul'].data[99, 99], rtol=1e-3)


### PR DESCRIPTION
This PR adds flux upper limit computation to the `TSImageEstimator` class and fix a few minor issues, related to rectangular source model kernels.