### PR TITLE
Add easy access to parameter errors

### DIFF
--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -197,10 +197,8 @@ class TestSpectralFit:
         self.fit.fit()
         self.fit.est_errors()
         result = self.fit.result[0]
-        par_errors = result.model.parameters._ufloats
-        assert_allclose(par_errors['index'].s, 0.09787747219456712)
-        assert_allclose(par_errors['amplitude'].s, 2.1992645712596426e-12)
-
+        assert_allclose(result.model.parameters.error('index'), 0.09787747219456712)
+        assert_allclose(result.model.parameters.error('amplitude'), 2.1992645712596426e-12)
         self.fit.result[0].to_table()
 
     def test_areascal(self):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -216,12 +216,12 @@ class ParameterList(object):
 
     def to_list_of_dict(self):
         result = []
-        for i, parameter in enumerate(self.parameters):
+        for parameter in self.parameters:
             vals = parameter.to_dict()
             if self.covariance is None:
                 vals['error'] = np.nan
             else:
-                vals['error'] = np.sqrt(self.covariance[i, i])
+                vals['error'] = self.error(parameter.name)
             result.append(vals)
         return result
 
@@ -349,6 +349,25 @@ class ParameterList(object):
                 covariance_new[i_new, j_new] = covariance[i, j]
 
         self.covariance = covariance_new
+
+    # TODO: this is a temporary solution until we have a better way
+    # to handle covariance matrices via a class
+    def error(self, parname):
+        """
+        Return error on a given parameter
+
+        Parameters
+        ----------
+        parname : str
+            Parameter
+        """
+        if self.covariance is None:
+            raise ValueError('Covariance matrix not set.')
+
+        for i, parameter in enumerate(self.parameters):
+            if parameter.name == parname:
+                return np.sqrt(self.covariance[i, i])
+        raise ValueError('Could not find parameter {}'.format(parname))
 
 
 class SourceLibrary(object):


### PR DESCRIPTION
At the moment there's no simple possibility to access the errors of model parameters, except via fiddling with the covariance matrix oder the hidden ``_ufloats`` parameter.

This PR add a function ``error`` to ``ParameterList`` to over come this, of course it's just a temporary solution until we have a proper covariance matrix class.

cc @Ozi1Kenobi