### PR TITLE
Add regression test for model array evaluation

### DIFF
--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -191,6 +191,11 @@ def test_models(spectrum):
 
     assert '' in str(model)
 
+    # check that an array evaluation works (otherwise e.g. plotting raises an error)
+    e_array = [2, 10, 20] * u.TeV
+    val = model(e_array)
+    assert_quantity_allclose(val[0], spectrum['val_at_2TeV'])
+
 
 @requires_dependency('matplotlib')
 @requires_dependency('sherpa')


### PR DESCRIPTION
@Ozi1Kenobi reported offline that some of the spectral models cannot be plotted (error is raised)
I assume this has to do with array evaluation of models, thus this PR

* [x] Add a regression test to make sure array evaluation works for all models
* [ ] Check if all models are actually tested
* [ ] Fix broken models