### PR TITLE
Testing sphinx 1.6+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ env:
         - MAIN_CMD='python setup.py'
 
         - ASTROPY_USE_SYSTEM_PYTEST=1
+        - SPHINX_VERSION='>1.6'
 
     matrix:
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'


### PR DESCRIPTION
The sphinx version is currently limited by ``ci-helpers``, so I expect to see warnings here in the docs building jobs due to the new version. I don't plan to lift that version limitation in the next month or two, so this PR has some time to get sorted out.

Anyone with commit rights can push changes directly to this branch until the tests pass.