### PR TITLE
Add printout for 3FHL and gamma-cat sources

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -186,11 +186,13 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         if spec_type == 'LogParabola':
             ss += '{:<45s} : {} +- {}\n'.format('beta', d['beta'], d['Unc_beta'])
         if spec_type in ['PLExpCutoff', 'PlSuperExpCutoff']:
-            ss += '{:<45s} : {:.0f} +- {:.0f} MeV\n'.format('Cutoff energy', d['Cutoff'], d['Unc_Cutoff'])
+            fmt = '{:<45s} : {:.0f} +- {:.0f} {}\n'
+            args = ('Cutoff energy', d['Cutoff'].value, d['Unc_Cutoff'].value, d['Cutoff'].unit)
+            ss += fmt.format(*args)
         if spec_type == 'PLSuperExpCutoff':
             ss += '{:<45s} : {} +- {}\n'.format('Exponential index', d['Exp_Index'], d['Unc_Exp_Index'])
 
-        ss += '{:<45s} : {:.0f} MeV\n'.format('Pivot energy', d['Pivot_Energy'])
+        ss += '{:<45s} : {:.0f} {}\n'.format('Pivot energy', d['Pivot_Energy'].value, d['Pivot_Energy'].unit)
 
         ss += '{:<45s} : {:.3f}\n'.format('Power law index', d['PowerLaw_Index'])
 
@@ -198,16 +200,19 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         args = ('Spectral index', d['Spectral_Index'], d['Unc_Spectral_Index'])
         ss += fmt.format(*args)
 
-        fmt = '{:<45s} : {:.3} +- {:.3} cm^-2 MeV^-1 s^-1\n'
-        args = ('Flux Density at pivot energy', d['Flux_Density'], d['Unc_Flux_Density'])
+        unit = 'cm-2 MeV-1 s-1'
+        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
+        args = ('Flux Density at pivot energy', d['Flux_Density'].value, d['Unc_Flux_Density'].value, unit)
         ss += fmt.format(*args)
 
-        fmt = '{:<45s} : {:.3} +- {:.3} cm^-2 s^-1\n'
-        args = ('Integral flux (1 - 100 GeV)', d['Flux1000'], d['Unc_Flux1000'])
+        unit = 'cm-2 s-1'
+        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
+        args = ('Integral flux (1 - 100 GeV)', d['Flux1000'].value, d['Unc_Flux1000'].value, unit)
         ss += fmt.format(*args)
 
-        fmt = '{:<45s} : {:.3} +- {:.3} erg cm^-2 s^-1\n'
-        args = ('Energy flux (100 MeV - 100 GeV)', d['Energy_Flux100'], d['Unc_Energy_Flux100'])
+        unit = 'erg cm-2 s-1'
+        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
+        args = ('Energy flux (100 MeV - 100 GeV)', d['Energy_Flux100'].value, d['Unc_Energy_Flux100'].value, unit)
         ss += fmt.format(*args)
 
         return ss
@@ -216,41 +221,11 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         """Print spectral points."""
         d = self.data
         ss = '\n*** Spectral points ***\n\n'
-        ss += '{:<15} {:<35} {:<25} {:<20}\n'.format('Energy range', 'Integral flux', 'Energy flux',
-                                                     'Sqrt Test Statistic')
-        flux_table = {
-            '100-300 MeV': [
-                '{:.3} +- {:.3} cm^-2 s^-1'.format(d['Flux100_300'], d['Unc_Flux100_300'][1]),
-                '{:.3} erg cm^-2 s^-1'.format(d['nuFnu100_300']),
-                '{:.1f}'.format(d['Sqrt_TS100_300'])
-            ],
-            '0.3-1 GeV': [
-                '{:.3} +- {:.3} cm^-2 s^-1'.format(d['Flux300_1000'], d['Unc_Flux300_1000'][1]),
-                '{:.3} erg cm^-2 s^-1'.format(d['nuFnu300_1000']),
-                '{:.1f}'.format(d['Sqrt_TS300_1000'])
-            ],
-            '1-3 GeV': [
-                '{:.3} +- {:.3} cm^-2 s^-1'.format(d['Flux1000_3000'], d['Unc_Flux1000_3000'][1]),
-                '{:.3} erg cm^-2 s^-1'.format(d['nuFnu1000_3000']),
-                '{:.1f}'.format(d['Sqrt_TS1000_3000'])
-            ],
-            '3-10 GeV': [
-                '{:.3} +- {:.3} cm^-2 s^-1'.format(d['Flux3000_10000'], d['Unc_Flux3000_10000'][1]),
-                '{:.3} erg cm^-2 s^-1'.format(d['nuFnu3000_10000']),
-                '{:.1f}'.format(d['Sqrt_TS3000_10000'])
-            ],
-            '10-100 GeV': [
-                '{:.3} +- {:.3} cm^-2 s^-1'.format(d['Flux10000_100000'], d['Unc_Flux10000_100000'][1]),
-                '{:.3} erg cm^-2 s^-1'.format(d['nuFnu10000_100000']),
-                '{:.1f}'.format(d['Sqrt_TS10000_100000'])
-            ]
-        }
-        for k, v in flux_table.items():
-            flux, dist, sqrt = v
-            ss += '{:<15} {:<35} {:<25} {:<20}\n'.format(k, flux, dist, sqrt)
-        ss += '\n'
 
-        return ss
+        t = self._flux_points_table_formatted
+
+        ss += '\n'.join(t.pformat(max_width=-1))
+        return ss + '\n'
 
     def _info_lightcurve(self):
         """Print lightcurve info."""
@@ -258,7 +233,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         ss = '\n*** Lightcurve info ***\n\n'
         ss += 'Lightcurve measured in the energy band: 100 MeV - 100 GeV\n\n'
 
-        ss += '{:<40s} : {:.3f}\n'.format('Variability index', d['Variability_Index'])
+        ss += '{:<15s} : {:.3f}\n'.format('Variability index', d['Variability_Index'])
 
         if d['Signif_Peak'] == np.nan:
             ss += '{:<40s} : {:.3f}\n'.format('Significance peak (100 MeV - 100 GeV)', d['Signif_Peak'])
@@ -320,6 +295,24 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         return model
 
     @property
+    def _flux_points_table_formatted(self):
+        """Returns formatted version of self.flux_points.table"""
+        table = self.flux_points.table.copy()
+
+        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn', 'eflux_errp', 'flux_ul', 'eflux_ul',
+                     'dnde']
+
+        table['sqrt_TS'].format = '.1f'
+
+        table['e_ref'].format = '.1f'
+
+        for _ in flux_cols:
+            table[_].format = '.3'
+
+        return table
+
+
+    @property
     def flux_points(self):
         """Flux points (`~gammapy.spectrum.FluxPoints`)."""
         table = Table()
@@ -353,12 +346,20 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         eflux_ul = compute_flux_points_ul(table['eflux'], table['eflux_errp'])
         table['eflux_ul'][is_ul] = eflux_ul[is_ul]
 
+        # Square root of test statistic
+        ts = self._get_ts_values()
+        table['sqrt_TS'] = ts
+
         table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
         return FluxPoints(table)
 
     def _get_flux_values(self, prefix, unit='cm-2 s-1'):
         values = [self.data[prefix + _] for _ in self._ebounds_suffix]
         return u.Quantity(values, unit)
+
+    def _get_ts_values(self, prefix='Sqrt_TS'):
+        values = [self.data[prefix + _] for _ in self._ebounds_suffix]
+        return u.Quantity(values)
 
     @property
     def lightcurve(self):
@@ -567,7 +568,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
             Comma separated list of options
         """
         if info == 'all':
-            info = 'basic,position,spectral'
+            info = 'basic,position,spectral,other'
 
         ss = ''
         ops = info.split(',')
@@ -578,6 +579,9 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         if 'spectral' in ops:
             ss += self._info_spectral_fit()
             ss += self._info_spectral_points()
+        if 'other' in ops:
+            ss += self._info_other()
+
         return ss
 
     def _info_basic(self):
@@ -594,9 +598,12 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
         keys = ['ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM']
         associations = get_nonentry_keys(keys)
-        ss += '{:<30s} : {}\n'.format('Associations', associations)
+        ss += '{:<16s} : {}\n'.format('Associations', associations)
+        ss += '{:<16s} : {:.3f}\n'.format('ASSOC_PROB_BAY', d['ASSOC_PROB_BAY'])
+        ss += '{:<16s} : {:.3f}\n'.format('ASSOC_PROB_LR', d['ASSOC_PROB_LR'])
 
-        ss += '{:<30s} : {}\n'.format('Class', d['CLASS'])
+
+        ss += '{:<16s} : {}\n'.format('Class', d['CLASS'])
 
         tevcat_flag = d['TEVCAT_FLAG']
         if tevcat_flag == 'N':
@@ -607,7 +614,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
             tevcat_message = 'Extended TeV source (diameter > 40 arcmins)'
         else:
             tevcat_message = 'N/A'
-        ss += '{:<30s} : {}\n'.format('TeVCat flag', tevcat_message)
+        ss += '{:<16s} : {}\n'.format('TeVCat flag', tevcat_message)
 
         return ss
 
@@ -620,6 +627,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         ss += '{:<20s} : {:.3f}\n'.format('GLON', d['GLON'])
         ss += '{:<20s} : {:.3f}\n'.format('GLAT', d['GLAT'])
 
+        # TODO: All sources are non-elliptical; just give one number for radius?
         ss += '\n'
         ss += '{:<20s} : {:.4f}\n'.format('Semimajor (95%)', d['Conf_95_SemiMajor'])
         ss += '{:<20s} : {:.4f}\n'.format('Semiminor (95%)', d['Conf_95_SemiMinor'])
@@ -629,43 +637,49 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         return ss;
 
     def _info_spectral_fit(self):
-        """Print spectral data."""
+        """Print model data."""
         d = self.data
-        ss = '\n*** Spectral info ***\n\n'
-
-        ss += '{:<45s} : {}\n'.format('Spectrum type', d['SpectrumType'])
+        ss = '\n*** Model info ***\n\n'
 
         fmt = '{:<45s} : {:.3f}\n'
         args = ('Detection significance (10 GeV - 2 TeV)', d['Signif_Avg'])
         ss += fmt.format(*args)
 
-        ss += '{:<45s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])
+        ss += '{:<45s} : {:.1f}\n\n'.format('Npred', d['Npred'])
+
+
+        ss += '{:<32s} : {}\n'.format('Spectrum type', d['SpectrumType'])
+
+        ss += '{:<32s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])
+
+        fmt = '{:<32s} : {:.3f} +- {:.3f}\n'
+        args = ('Spectral index', d['Spectral_Index'], d['Unc_Spectral_Index'])
+        ss += fmt.format(*args)
 
         spec_type = d['SpectrumType'].strip()
         if spec_type == 'LogParabola':
-            ss += '{:<45s} : {:.3f} +- {:.3f}\n'.format('alpha', d['Spectral_Index'], d['Unc_Spectral_Index'])
-            ss += '{:<45s} : {:.3f} +- {:.3f}\n'.format('beta', d['beta'], d['Unc_beta'])
-        if spec_type == 'PowerLaw':
-            fmt = '{:<45s} : {:.3f} +- {:.3f}\n'
-            args = ('Spectral index', d['Spectral_Index'], d['Unc_Spectral_Index'])
-            ss += fmt.format(*args)
+            # ss += '{:<32s} : {:.3f} +- {:.3f}\n'.format('alpha', d['Spectral_Index'], d['Unc_Spectral_Index'])
+            ss += '{:<32s} : {:.3f} +- {:.3f}\n'.format('beta', d['beta'], d['Unc_beta'])
 
-        ss += '{:<45s} : {:.0f} {}\n'.format('Pivot energy', d['Pivot_Energy'].value, d['Pivot_Energy'].unit)
+        ss += '{:<32s} : {:.0f} {}\n'.format('Pivot energy', d['Pivot_Energy'].value, d['Pivot_Energy'].unit)
 
-        fmt = '{:<45s} : {:.3f} +- {:.3f}\n'
+        fmt = '{:<32s} : {:.3f} +- {:.3f}\n'
         args = ('Power Law index', d['PowerLaw_Index'], d['Unc_PowerLaw_Index'], d['Unc_PowerLaw_Index'])
         ss += fmt.format(*args)
 
-        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
-        args = ('Flux Density at pivot energy', d['Flux_Density'].value, d['Unc_Flux_Density'].value, d['Flux_Density'].unit)
+        unit = 'cm-2 GeV-1 s-1'
+        fmt = '{:<32s} : {:.3} +- {:.3} {}\n'
+        args = ('Flux Density at pivot energy', d['Flux_Density'].value, d['Unc_Flux_Density'].value, unit)
         ss += fmt.format(*args)
 
-        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
-        args = ('Integral flux (10 GeV - 1 TeV)', d['Flux'].value, d['Unc_Flux'].value, d['Flux'].unit)
+        unit = 'cm-2 s-1'
+        fmt = '{:<32s} : {:.3} +- {:.3} {}\n'
+        args = ('Integral flux (10 GeV - 1 TeV)', d['Flux'].value, d['Unc_Flux'].value, unit)
         ss += fmt.format(*args)
 
-        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
-        args = ('Energy flux (10 GeV - TeV)', d['Energy_Flux'].value, d['Unc_Energy_Flux'].value, d['Energy_Flux'].unit)
+        unit = 'erg cm-2 s-1'
+        fmt = '{:<32s} : {:.3} +- {:.3} {}\n'
+        args = ('Energy flux (10 GeV - TeV)', d['Energy_Flux'].value, d['Unc_Energy_Flux'].value, unit)
         ss += fmt.format(*args)
 
         return ss
@@ -677,8 +691,32 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         t = self._flux_points_table_formatted
 
         ss += '\n'.join(t.pformat(max_width=-1))
-        #TODO: Print all of the columns, rather than just a few with the "..." in between.
         return ss + '\n'
+
+    def _info_other(self):
+        """Print other info."""
+        d = self.data
+        ss = '\n*** Other info ***\n\n'
+
+        ss += '{:<16s} : {:.3f} {}\n'.format('HEP Energy', d['HEP_Energy'].value, d['HEP_Energy'].unit)
+        ss += '{:<16s} : {:.3f}\n'.format('HEP Probability', d['HEP_Prob'])
+
+        bayes = d['Variability_BayesBlocks']
+        str = bayes
+        if bayes == 1:
+            str = 'Not variable'
+        elif bayes == -1:
+            str = 'Could not be tested'
+        ss += '{:<30s} : {}\n'.format('Variability - Bayesian Blocks', str)
+
+        ss += '{:<16s} : {:.3f}\n'.format('Redshift', d['Redshift'])
+        ss += '{:<16s} : {:.3f} {}\n'.format('NuPeak_obs', d['NuPeak_obs'].value, d['NuPeak_obs'].unit)
+
+
+
+        return ss
+
+
 
     @property
     def spectral_model(self):

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -65,6 +65,17 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     be consistent with previous catalogs.
     """
 
+    def info(self, info='all'):
+        """Print info.
+
+        Parameters
+        ----------
+        info : {'all', 'basic', 'position', 'spectral', 'lightcurve'}
+            Comma separated list of options
+        """
+        ss = self.__str__(info=info)
+        print(ss)
+
     def __str__(self, info='all'):
         """Summary info string.
 
@@ -93,9 +104,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         """Print basic info."""
         d = self.data
         ss = '\n*** Basic info ***\n\n'
-        ss += '{:<30s} : {}\n'.format('Source', d['Source_Name'])
-        ss += '{:<30s} : {}\n'.format('Catalog row index (zero-based)', d['catalog_row_index'])
-        ss += '{:<30s} : {}\n'.format('Extended name', d['Extended_Source_Name'])
+        ss += 'Catalog row index (zero-based) : {}\n'.format(d['catalog_row_index'])
+        ss += '{:<20s} : {}\n'.format('Source name', d['Source_Name'])
+        ss += '{:<20s} : {}\n'.format('Extended name', d['Extended_Source_Name'])
 
         def get_nonentry_keys(keys):
             vals = [d[_].strip() for _ in keys]
@@ -103,13 +114,13 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
         keys = ['ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM1', 'ASSOC_GAM2', 'ASSOC_GAM3']
         associations = get_nonentry_keys(keys)
-        ss += '{:<30s} : {}\n'.format('Associations', associations)
+        ss += '{:<20s} : {}\n'.format('Associations', associations)
 
         keys = ['0FGL_Name', '1FGL_Name', '2FGL_Name', '1FHL_Name']
         other_names = get_nonentry_keys(keys)
-        ss += '{:<30s} : {}\n'.format('Other names', other_names)
+        ss += '{:<20s} : {}\n'.format('Other names', other_names)
 
-        ss += '{:<30s} : {}\n'.format('Class', d['CLASS1'])
+        ss += '{:<20s} : {}\n'.format('Class', d['CLASS1'])
 
         tevcat_flag = d['TEVCAT_FLAG']
         if tevcat_flag == 'N':
@@ -559,6 +570,17 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     _ebounds = EnergyBounds([10, 20, 50, 150, 500, 2000], 'GeV')
 
 
+    def info(self, info='all'):
+        """Print info.
+
+        Parameters
+        ----------
+        info : {'all', 'basic', 'position', 'spectral'}
+            Comma separated list of options
+        """
+        ss = self.__str__(info=info)
+        print(ss)
+
     def __str__(self, info='all'):
         """Summary info string.
 
@@ -588,9 +610,9 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         """Print basic info."""
         d = self.data
         ss = '\n*** Basic info ***\n\n'
-        ss += '{:<30s} : {}\n'.format('Source', d['Source_Name'])
-        ss += '{:<30s} : {}\n'.format('Catalog row index (zero-based)', d['catalog_row_index'])
-        ss += '{:<30s} : {}\n'.format('Extended name', d['Extended_Source_Name'])
+        ss += 'Catalog row index (zero-based) : {}\n'.format(d['catalog_row_index'])
+        ss += '{:<20s} : {}\n'.format('Source name', d['Source_Name'])
+        ss += '{:<20s} : {}\n'.format('Extended name', d['Extended_Source_Name'])
 
         def get_nonentry_keys(keys):
             vals = [d[_].strip() for _ in keys]
@@ -641,11 +663,11 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         d = self.data
         ss = '\n*** Model info ***\n\n'
 
-        fmt = '{:<45s} : {:.3f}\n'
-        args = ('Detection significance (10 GeV - 2 TeV)', d['Signif_Avg'])
+        fmt = '{:<32s} : {:.3f}\n'
+        args = ('Significance (10 GeV - 2 TeV)', d['Signif_Avg'])
         ss += fmt.format(*args)
 
-        ss += '{:<45s} : {:.1f}\n\n'.format('Npred', d['Npred'])
+        ss += '{:<32s} : {:.1f}\n\n'.format('Npred', d['Npred'])
 
 
         ss += '{:<32s} : {}\n'.format('Spectrum type', d['SpectrumType'])

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -152,19 +152,19 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         """Print position info."""
         d = self.data
         ss = '\n*** Position info ***\n\n'
-        ss += '{:<20s} : {:.3f} deg\n'.format('RA', d['RAJ2000'])
-        ss += '{:<20s} : {:.3f} deg\n'.format('DEC', d['DEJ2000'])
-        ss += '{:<20s} : {:.3f} deg\n'.format('GLON', d['GLON'])
-        ss += '{:<20s} : {:.3f} deg\n'.format('GLAT', d['GLAT'])
+        ss += '{:<20s} : {:.3f}\n'.format('RA', d['RAJ2000'])
+        ss += '{:<20s} : {:.3f}\n'.format('DEC', d['DEJ2000'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLON', d['GLON'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLAT', d['GLAT'])
 
         ss += '\n'
-        ss += '{:<20s} : {:.4f} deg\n'.format('Semimajor (68%)', d['Conf_68_SemiMajor'])
-        ss += '{:<20s} : {:.4f} deg\n'.format('Semiminor (68%)', d['Conf_68_SemiMinor'])
-        ss += '{:<20s} : {:.2f} deg\n'.format('Position angle (68%)', d['Conf_68_PosAng'])
+        ss += '{:<20s} : {:.4f}\n'.format('Semimajor (68%)', d['Conf_68_SemiMajor'])
+        ss += '{:<20s} : {:.4f}\n'.format('Semiminor (68%)', d['Conf_68_SemiMinor'])
+        ss += '{:<20s} : {:.2f}\n'.format('Position angle (68%)', d['Conf_68_PosAng'])
 
-        ss += '{:<20s} : {:.4f} deg\n'.format('Semimajor (95%)', d['Conf_95_SemiMajor'])
-        ss += '{:<20s} : {:.4f} deg\n'.format('Semiminor (95%)', d['Conf_95_SemiMinor'])
-        ss += '{:<20s} : {:.2f} deg\n'.format('Position angle (95%)', d['Conf_95_PosAng'])
+        ss += '{:<20s} : {:.4f}\n'.format('Semimajor (95%)', d['Conf_95_SemiMajor'])
+        ss += '{:<20s} : {:.4f}\n'.format('Semiminor (95%)', d['Conf_95_SemiMinor'])
+        ss += '{:<20s} : {:.2f}\n'.format('Position angle (95%)', d['Conf_95_PosAng'])
         ss += '{:<20s} : {:.0f}\n'.format('ROI number', d['ROI_num'])
 
         return ss
@@ -213,6 +213,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         return ss
 
     def _info_spectral_points(self):
+        """Print spectral points."""
         d = self.data
         ss = '\n*** Spectral points ***\n\n'
         ss += '{:<15} {:<35} {:<25} {:<20}\n'.format('Energy range', 'Integral flux', 'Energy flux',
@@ -556,21 +557,128 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
     _ebounds = EnergyBounds([10, 20, 50, 150, 500, 2000], 'GeV')
 
-    def __str__(self):
-        """Print summary info."""
+
+    def __str__(self, info='all'):
+        """Summary info string.
+
+        Parameters
+        ----------
+        info : {'all', 'basic', 'position', 'spectral'}
+            Comma separated list of options
+        """
+        if info == 'all':
+            info = 'basic,position,spectral'
+
+        ss = ''
+        ops = info.split(',')
+        if 'basic' in ops:
+            ss += self._info_basic()
+        if 'position' in ops:
+            ss += self._info_position()
+        if 'spectral' in ops:
+            ss += self._info_spectral_fit()
+            ss += self._info_spectral_points()
+        return ss
+
+    def _info_basic(self):
+        """Print basic info."""
         d = self.data
+        ss = '\n*** Basic info ***\n\n'
+        ss += '{:<30s} : {}\n'.format('Source', d['Source_Name'])
+        ss += '{:<30s} : {}\n'.format('Catalog row index (zero-based)', d['catalog_row_index'])
+        ss += '{:<30s} : {}\n'.format('Extended name', d['Extended_Source_Name'])
 
-        ss = 'Source: {}\n'.format(d['Source_Name'])
-        ss += '\n'
+        def get_nonentry_keys(keys):
+            vals = [d[_].strip() for _ in keys]
+            return ', '.join([_ for _ in vals if _ != ''])
 
-        ss += 'RA (J2000)  : {}\n'.format(d['RAJ2000'])
-        ss += 'Dec (J2000) : {}\n'.format(d['DEJ2000'])
-        ss += 'GLON        : {}\n'.format(d['GLON'])
-        ss += 'GLAT        : {}\n'.format(d['GLAT'])
-        ss += '\n'
-        ss += 'Detection significance : {}\n'.format(d['Signif_Avg'])
+        keys = ['ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM']
+        associations = get_nonentry_keys(keys)
+        ss += '{:<30s} : {}\n'.format('Associations', associations)
+
+        ss += '{:<30s} : {}\n'.format('Class', d['CLASS'])
+
+        tevcat_flag = d['TEVCAT_FLAG']
+        if tevcat_flag == 'N':
+            tevcat_message = 'No TeV association'
+        elif tevcat_flag == 'P':
+            tevcat_message = 'Small TeV source'
+        elif tevcat_flag == 'E':
+            tevcat_message = 'Extended TeV source (diameter > 40 arcmins)'
+        else:
+            tevcat_message = 'N/A'
+        ss += '{:<30s} : {}\n'.format('TeVCat flag', tevcat_message)
 
         return ss
+
+    def _info_position(self):
+        """Print position info."""
+        d = self.data
+        ss = '\n*** Position info ***\n\n'
+        ss += '{:<20s} : {:.3f}\n'.format('RA', d['RAJ2000'])
+        ss += '{:<20s} : {:.3f}\n'.format('DEC', d['DEJ2000'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLON', d['GLON'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLAT', d['GLAT'])
+
+        ss += '\n'
+        ss += '{:<20s} : {:.4f}\n'.format('Semimajor (95%)', d['Conf_95_SemiMajor'])
+        ss += '{:<20s} : {:.4f}\n'.format('Semiminor (95%)', d['Conf_95_SemiMinor'])
+        ss += '{:<20s} : {:.2f}\n'.format('Position angle (95%)', d['Conf_95_PosAng'])
+        ss += '{:<20s} : {:.0f}\n'.format('ROI number', d['ROI_num'])
+
+        return ss;
+
+    def _info_spectral_fit(self):
+        """Print spectral data."""
+        d = self.data
+        ss = '\n*** Spectral info ***\n\n'
+
+        ss += '{:<45s} : {}\n'.format('Spectrum type', d['SpectrumType'])
+
+        fmt = '{:<45s} : {:.3f}\n'
+        args = ('Detection significance (10 GeV - 2 TeV)', d['Signif_Avg'])
+        ss += fmt.format(*args)
+
+        ss += '{:<45s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])
+
+        spec_type = d['SpectrumType'].strip()
+        if spec_type == 'LogParabola':
+            ss += '{:<45s} : {:.3f} +- {:.3f}\n'.format('alpha', d['Spectral_Index'], d['Unc_Spectral_Index'])
+            ss += '{:<45s} : {:.3f} +- {:.3f}\n'.format('beta', d['beta'], d['Unc_beta'])
+        if spec_type == 'PowerLaw':
+            fmt = '{:<45s} : {:.3f} +- {:.3f}\n'
+            args = ('Spectral index', d['Spectral_Index'], d['Unc_Spectral_Index'])
+            ss += fmt.format(*args)
+
+        ss += '{:<45s} : {:.0f} {}\n'.format('Pivot energy', d['Pivot_Energy'].value, d['Pivot_Energy'].unit)
+
+        fmt = '{:<45s} : {:.3f} +- {:.3f}\n'
+        args = ('Power Law index', d['PowerLaw_Index'], d['Unc_PowerLaw_Index'], d['Unc_PowerLaw_Index'])
+        ss += fmt.format(*args)
+
+        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
+        args = ('Flux Density at pivot energy', d['Flux_Density'].value, d['Unc_Flux_Density'].value, d['Flux_Density'].unit)
+        ss += fmt.format(*args)
+
+        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
+        args = ('Integral flux (10 GeV - 1 TeV)', d['Flux'].value, d['Unc_Flux'].value, d['Flux'].unit)
+        ss += fmt.format(*args)
+
+        fmt = '{:<45s} : {:.3} +- {:.3} {}\n'
+        args = ('Energy flux (10 GeV - TeV)', d['Energy_Flux'].value, d['Unc_Energy_Flux'].value, d['Energy_Flux'].unit)
+        ss += fmt.format(*args)
+
+        return ss
+
+    def _info_spectral_points(self):
+        """Print spectral points."""
+        ss = '\n*** Spectral points ***\n\n'
+
+        t = self._flux_points_table_formatted
+
+        ss += '\n'.join(t.pformat(max_width=-1))
+        #TODO: Print all of the columns, rather than just a few with the "..." in between.
+        return ss + '\n'
 
     @property
     def spectral_model(self):
@@ -597,6 +705,23 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
         model.parameters.set_parameter_errors(errs)
         return model
+
+    @property
+    def _flux_points_table_formatted(self):
+        """Returns formatted version of self.flux_points.table"""
+        table = self.flux_points.table.copy()
+
+        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn', 'eflux_errp', 'flux_ul', 'eflux_ul',
+                     'dnde']
+
+        table['sqrt_TS'].format = '.1f'
+
+        table['e_ref'].format = '.1f'
+
+        for _ in flux_cols:
+            table[_].format = '.3'
+
+        return table
 
     @property
     def flux_points(self):
@@ -632,9 +757,15 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         eflux_ul = compute_flux_points_ul(table['eflux'], table['eflux_errp'])
         table['eflux_ul'][is_ul] = eflux_ul[is_ul]
 
+        # Square root of test statistic
+        ts = self.data['Sqrt_TS_Band']
+        table['sqrt_TS'] = ts
+
+
         # TODO: remove this computation here.
         # # Instead provide a method on the FluxPoints class like `to_dnde()` or something.
         table['dnde'] = (e2dnde * e_ref ** -2).to('cm-2 s-1 TeV-1')
+
         return FluxPoints(table)
 
     def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -131,7 +131,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
             tevcat_message = 'Extended TeV source (diameter > 40 arcmins)'
         else:
             tevcat_message = 'N/A'
-        ss += '{:<30s} : {}\n'.format('TeVCat flag', tevcat_message)
+        ss += '{:<20s} : {}\n'.format('TeVCat flag', tevcat_message)
 
         flag_message = {
             0: 'None',
@@ -155,7 +155,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
             12: 'Highly curved spectrum; LogParabola beta fixed to 1 or PLExpCutoff Spectral Index fixed to 0 (see '
                 'Section 3.3 in catalog paper).'
         }
-        ss += '{:<30s} : {}\n'.format('Other flags', flag_message.get(d['Flags'], 'N/A'))
+        ss += '{:<20s} : {}\n'.format('Other flags', flag_message.get(d['Flags'], 'N/A'))
 
         return ss
 
@@ -172,7 +172,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         ss += '{:<20s} : {:.4f}\n'.format('Semimajor (68%)', d['Conf_68_SemiMajor'])
         ss += '{:<20s} : {:.4f}\n'.format('Semiminor (68%)', d['Conf_68_SemiMinor'])
         ss += '{:<20s} : {:.2f}\n'.format('Position angle (68%)', d['Conf_68_PosAng'])
-
         ss += '{:<20s} : {:.4f}\n'.format('Semimajor (95%)', d['Conf_95_SemiMajor'])
         ss += '{:<20s} : {:.4f}\n'.format('Semiminor (95%)', d['Conf_95_SemiMinor'])
         ss += '{:<20s} : {:.2f}\n'.format('Position angle (95%)', d['Conf_95_PosAng'])
@@ -186,11 +185,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         ss = '\n*** Spectral info ***\n\n'
 
         ss += '{:<45s} : {}\n'.format('Spectrum type', d['SpectrumType'])
-
         fmt = '{:<45s} : {:.3f}\n'
         args = ('Detection significance (100 MeV - 300 GeV)', d['Signif_Avg'])
         ss += fmt.format(*args)
-
         ss += '{:<45s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])
 
         spec_type = d['SpectrumType'].strip()
@@ -232,10 +229,8 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         """Print spectral points."""
         d = self.data
         ss = '\n*** Spectral points ***\n\n'
+        ss += '\n'.join(self._flux_points_table_formatted.pformat(max_width=-1))
 
-        t = self._flux_points_table_formatted
-
-        ss += '\n'.join(t.pformat(max_width=-1))
         return ss + '\n'
 
     def _info_lightcurve(self):
@@ -309,14 +304,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-
-        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn', 'eflux_errp', 'flux_ul', 'eflux_ul',
-                     'dnde']
-
+        flux_cols = ['flux','flux_errn','flux_errp','eflux','eflux_errn','eflux_errp','flux_ul','eflux_ul','dnde']
         table['sqrt_TS'].format = '.1f'
-
         table['e_ref'].format = '.1f'
-
         for _ in flux_cols:
             table[_].format = '.3'
 
@@ -370,7 +360,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
     def _get_ts_values(self, prefix='Sqrt_TS'):
         values = [self.data[prefix + _] for _ in self._ebounds_suffix]
-        return u.Quantity(values)
+        return values
 
     @property
     def lightcurve(self):
@@ -617,16 +607,13 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         def get_nonentry_keys(keys):
             vals = [d[_].strip() for _ in keys]
             return ', '.join([_ for _ in vals if _ != ''])
-
         keys = ['ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM']
         associations = get_nonentry_keys(keys)
         ss += '{:<16s} : {}\n'.format('Associations', associations)
         ss += '{:<16s} : {:.3f}\n'.format('ASSOC_PROB_BAY', d['ASSOC_PROB_BAY'])
         ss += '{:<16s} : {:.3f}\n'.format('ASSOC_PROB_LR', d['ASSOC_PROB_LR'])
 
-
         ss += '{:<16s} : {}\n'.format('Class', d['CLASS'])
-
         tevcat_flag = d['TEVCAT_FLAG']
         if tevcat_flag == 'N':
             tevcat_message = 'No TeV association'
@@ -666,14 +653,10 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         fmt = '{:<32s} : {:.3f}\n'
         args = ('Significance (10 GeV - 2 TeV)', d['Signif_Avg'])
         ss += fmt.format(*args)
-
         ss += '{:<32s} : {:.1f}\n\n'.format('Npred', d['Npred'])
 
-
         ss += '{:<32s} : {}\n'.format('Spectrum type', d['SpectrumType'])
-
         ss += '{:<32s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])
-
         fmt = '{:<32s} : {:.3f} +- {:.3f}\n'
         args = ('Spectral index', d['Spectral_Index'], d['Unc_Spectral_Index'])
         ss += fmt.format(*args)
@@ -709,36 +692,26 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _info_spectral_points(self):
         """Print spectral points."""
         ss = '\n*** Spectral points ***\n\n'
+        ss += '\n'.join(self._flux_points_table_formatted.pformat(max_width=-1))
 
-        t = self._flux_points_table_formatted
-
-        ss += '\n'.join(t.pformat(max_width=-1))
         return ss + '\n'
 
     def _info_other(self):
         """Print other info."""
         d = self.data
         ss = '\n*** Other info ***\n\n'
-
         ss += '{:<16s} : {:.3f} {}\n'.format('HEP Energy', d['HEP_Energy'].value, d['HEP_Energy'].unit)
         ss += '{:<16s} : {:.3f}\n'.format('HEP Probability', d['HEP_Prob'])
-
-        bayes = d['Variability_BayesBlocks']
-        str = bayes
-        if bayes == 1:
-            str = 'Not variable'
-        elif bayes == -1:
-            str = 'Could not be tested'
-        ss += '{:<30s} : {}\n'.format('Variability - Bayesian Blocks', str)
-
+        msg = d['Variability_BayesBlocks']
+        if msg == 1:
+            msg = 'Not variable'
+        elif msg == -1:
+            msg = 'Could not be tested'
+        ss += '{:<30s} : {}\n'.format('Variability - Bayesian Blocks', msg)
         ss += '{:<16s} : {:.3f}\n'.format('Redshift', d['Redshift'])
-        ss += '{:<16s} : {:.3f} {}\n'.format('NuPeak_obs', d['NuPeak_obs'].value, d['NuPeak_obs'].unit)
-
-
+        ss += '{:<16s} : {:.3} {}\n'.format('NuPeak_obs', d['NuPeak_obs'].value, d['NuPeak_obs'].unit)
 
         return ss
-
-
 
     @property
     def spectral_model(self):
@@ -770,14 +743,9 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-
-        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn', 'eflux_errp', 'flux_ul', 'eflux_ul',
-                     'dnde']
-
-        table['sqrt_TS'].format = '.1f'
-
+        flux_cols = ['flux','flux_errn','flux_errp','eflux','eflux_errn','eflux_errp','flux_ul','eflux_ul','dnde']
+        table['sqrt_ts'].format = '.1f'
         table['e_ref'].format = '.1f'
-
         for _ in flux_cols:
             table[_].format = '.3'
 
@@ -818,9 +786,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         table['eflux_ul'][is_ul] = eflux_ul[is_ul]
 
         # Square root of test statistic
-        ts = self.data['Sqrt_TS_Band']
-        table['sqrt_TS'] = ts
-
+        table['sqrt_ts'] = self.data['Sqrt_TS_Band']
 
         # TODO: remove this computation here.
         # # Instead provide a method on the FluxPoints class like `to_dnde()` or something.

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -49,6 +49,7 @@ def compute_flux_points_ul(quantity, quantity_errp):
     """
     return 2 * quantity_errp + quantity
 
+
 class SourceCatalogObject3FGL(SourceCatalogObject):
     """One source from the Fermi-LAT 3FGL catalog.
 
@@ -304,14 +305,14 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-        flux_cols = ['flux','flux_errn','flux_errp','eflux','eflux_errn','eflux_errp','flux_ul','eflux_ul','dnde']
+        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn',
+                     'eflux_errp', 'flux_ul', 'eflux_ul', 'dnde']
         table['sqrt_TS'].format = '.1f'
         table['e_ref'].format = '.1f'
         for _ in flux_cols:
             table[_].format = '.3'
 
         return table
-
 
     @property
     def flux_points(self):
@@ -348,8 +349,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         table['eflux_ul'][is_ul] = eflux_ul[is_ul]
 
         # Square root of test statistic
-        ts = self._get_ts_values()
-        table['sqrt_TS'] = ts
+        table['sqrt_TS'] = [self.data['Sqrt_TS' + _] for _ in self._ebounds_suffix]
 
         table['dnde'] = (nuFnu * e_ref ** -2).to('TeV-1 cm-2 s-1')
         return FluxPoints(table)
@@ -357,10 +357,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     def _get_flux_values(self, prefix, unit='cm-2 s-1'):
         values = [self.data[prefix + _] for _ in self._ebounds_suffix]
         return u.Quantity(values, unit)
-
-    def _get_ts_values(self, prefix='Sqrt_TS'):
-        values = [self.data[prefix + _] for _ in self._ebounds_suffix]
-        return values
 
     @property
     def lightcurve(self):
@@ -559,7 +555,6 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
     _ebounds = EnergyBounds([10, 20, 50, 150, 500, 2000], 'GeV')
 
-
     def info(self, info='all'):
         """Print info.
 
@@ -607,6 +602,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         def get_nonentry_keys(keys):
             vals = [d[_].strip() for _ in keys]
             return ', '.join([_ for _ in vals if _ != ''])
+
         keys = ['ASSOC1', 'ASSOC2', 'ASSOC_TEV', 'ASSOC_GAM']
         associations = get_nonentry_keys(keys)
         ss += '{:<16s} : {}\n'.format('Associations', associations)
@@ -614,6 +610,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         ss += '{:<16s} : {:.3f}\n'.format('ASSOC_PROB_LR', d['ASSOC_PROB_LR'])
 
         ss += '{:<16s} : {}\n'.format('Class', d['CLASS'])
+
         tevcat_flag = d['TEVCAT_FLAG']
         if tevcat_flag == 'N':
             tevcat_message = 'No TeV association'
@@ -643,7 +640,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         ss += '{:<20s} : {:.2f}\n'.format('Position angle (95%)', d['Conf_95_PosAng'])
         ss += '{:<20s} : {:.0f}\n'.format('ROI number', d['ROI_num'])
 
-        return ss;
+        return ss
 
     def _info_spectral_fit(self):
         """Print model data."""
@@ -702,12 +699,16 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         ss = '\n*** Other info ***\n\n'
         ss += '{:<16s} : {:.3f} {}\n'.format('HEP Energy', d['HEP_Energy'].value, d['HEP_Energy'].unit)
         ss += '{:<16s} : {:.3f}\n'.format('HEP Probability', d['HEP_Prob'])
+
+        # This is the number of Bayesian blocks for most sources,
+        # except -1 means "could not be tested"
         msg = d['Variability_BayesBlocks']
         if msg == 1:
-            msg = 'Not variable'
+            msg = '1 (not variable)'
         elif msg == -1:
             msg = 'Could not be tested'
-        ss += '{:<30s} : {}\n'.format('Variability - Bayesian Blocks', msg)
+        ss += '{:<16s} : {}\n'.format('Bayesian Blocks', msg)
+
         ss += '{:<16s} : {:.3f}\n'.format('Redshift', d['Redshift'])
         ss += '{:<16s} : {:.3} {}\n'.format('NuPeak_obs', d['NuPeak_obs'].value, d['NuPeak_obs'].unit)
 
@@ -743,7 +744,8 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-        flux_cols = ['flux','flux_errn','flux_errp','eflux','eflux_errn','eflux_errp','flux_ul','eflux_ul','dnde']
+        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn',
+                     'eflux_errp', 'flux_ul', 'eflux_ul', 'dnde']
         table['sqrt_ts'].format = '.1f'
         table['e_ref'].format = '.1f'
         for _ in flux_cols:

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -622,6 +622,11 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
             tevcat_message = 'N/A'
         ss += '{:<16s} : {}\n'.format('TeVCat flag', tevcat_message)
 
+        fmt = '\n{:<32s} : {:.3f}\n'
+        args = ('Significance (10 GeV - 2 TeV)', d['Signif_Avg'])
+        ss += fmt.format(*args)
+        ss += '{:<32s} : {:.1f}\n'.format('Npred', d['Npred'])
+
         return ss
 
     def _info_position(self):
@@ -647,10 +652,15 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         d = self.data
         ss = '\n*** Model info ***\n\n'
 
-        fmt = '{:<32s} : {:.3f}\n'
-        args = ('Significance (10 GeV - 2 TeV)', d['Signif_Avg'])
-        ss += fmt.format(*args)
-        ss += '{:<32s} : {:.1f}\n\n'.format('Npred', d['Npred'])
+        if not self.is_pointlike:
+            e = self.data_extended
+            ss += 'Extended source information:\n'
+            ss += '{:<16s} : {}\n'.format('Model form', e['Model_Form'])
+            ss += '{:<16s} : {:.4f}\n'.format('Model semimajor', e['Model_SemiMajor'])
+            ss += '{:<16s} : {:.4f}\n'.format('Model semiminor', e['Model_SemiMinor'])
+            ss += '{:<16s} : {:.4f}\n'.format('Position angle', e['Model_PosAng'])
+            ss += '{:<16s} : {}\n'.format('Spatial function', e['Spatial_Function'])
+            ss += '{:<16s} : {}\n\n'.format('Spatial filename', e['Spatial_Filename'])
 
         ss += '{:<32s} : {}\n'.format('Spectrum type', d['SpectrumType'])
         ss += '{:<32s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -54,25 +54,246 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
     _source_name_key = 'common_name'
     _source_index_key = 'catalog_row_index'
 
-    def __str__(self):
-        """Print default summary info string"""
-        d = self.data
+    def info(self, info='all'):
+        """Print info.
 
-        ss = 'Source: {}\n'.format(d['common_name'])
-        ss += 'source_id: {}\n'.format(d['source_id'])
-        ss += 'reference_id: {}\n'.format(d['reference_id'])
-        ss += '\n'
+        Parameters
+        ----------
+        info : {'all', 'basic', 'position', 'model', 'reference'}
+            Comma separated list of options
+        """
+        ss = self.__str__(info=info)
+        print(ss)
 
-        ss += 'RA          : {:.2f}\n'.format(d['ra'])
-        ss += 'DEC         : {:.2f}\n'.format(d['dec'])
-        ss += 'GLON        : {:.2f}\n'.format(d['glon'])
-        ss += 'GLAT        : {:.2f}\n'.format(d['glat'])
-        ss += '\n'
+    def __str__(self, info='all'):
+        """Info string.
+
+        Parameters
+        ----------
+        info : {'all', 'basic', 'position, 'model', 'reference'}
+            Comma separated list of options
+        """
+
+        if info == 'all':
+            info = 'basic,position,model,reference'
+
+        ss = ''
+        ops = info.split(',')
+        if 'basic' in ops:
+            ss += self._info_basic()
+        if 'position' in ops:
+            ss += self._info_position()
+        if 'model' in ops:
+            ss += self._info_morph()
+            ss += self._info_spectral_fit()
+            ss += self._info_spectral_points()
+        if 'reference' in ops:
+            ss += self._info_reference()
         return ss
 
-    def info(self):
-        """Print summary info."""
-        print(self)
+    def _info_basic(self):
+        """Print basic info."""
+        d = self.data
+        ss = '\n*** Basic info ***\n\n'
+        ss += 'Catalog row index (zero-based) : {}\n'.format(d['catalog_row_index'])
+        ss += '{:<15s} : {}\n'.format('Common name', d['common_name'])
+        # ss += '{:<15s} : {}\n'.format('Gamma names', d['gamma_names'])
+        # ss += '{:<15s} : {}\n'.format('Fermi names', d['fermi_names'])
+        # ss += '{:<15s} : {}\n'.format('Other names', d['other_names'])
+
+        def get_nonentry_keys(keys):
+            vals = [d[_].strip() for _ in keys]
+            return ','.join([_ for _ in vals if _ != ''])
+
+        keys = ['gamma_names', 'fermi_names', 'other_names']
+        other_names = get_nonentry_keys(keys)
+        ss += '{:<15s} : {}\n'.format('Other names', other_names)
+        ss += '{:<15s} : {}\n'.format('Location', d['where'])
+        ss += '{:<15s} : {}\n'.format('Class', d['classes'])
+
+        ss += '\n{:<15s} : {}\n'.format('TeVCat ID', d['tevcat_id'])
+        ss += '{:<15s} : {}\n'.format('TeVCat 2 ID', d['tevcat2_id'])
+        ss += '{:<15s} : {}\n'.format('TeVCat name', d['tevcat_name'])
+
+        ss += '\n{:<15s} : {}\n'.format('TGeVCat ID', d['tgevcat_id'])
+        ss += '{:<15s} : {}\n'.format('TGeVCat name', d['tgevcat_name'])
+
+        return ss
+
+    def _info_position(self):
+        """Print position info."""
+        d = self.data
+        ss = '\n*** Position info ***\n\n'
+
+        ss += 'SIMBAD:\n'
+        ss += '{:<20s} : {:.3f}\n'.format('RA', d['ra'])
+        ss += '{:<20s} : {:.3f}\n'.format('DEC', d['dec'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLON', d['glon'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLAT', d['glat'])
+
+        ss += '\nMeasurement:\n'
+        ss += '{:<20s} : {:.3f}\n'.format('RA', d['pos_ra'])
+        ss += '{:<20s} : {:.3f}\n'.format('DEC', d['pos_dec'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLON', d['pos_glon'])
+        ss += '{:<20s} : {:.3f}\n'.format('GLAT', d['pos_glat'])
+        ss += '{:<20s} : {:.3f}\n'.format('Position error', d['pos_err'])
+
+        return ss
+
+    def _info_morph(self):
+        """Print morphology info."""
+        ss = '\n*** Morphology info ***\n\n'
+        d = self.data
+        ss += '{:<25s} : {}\n'.format('Morphology model type', d['morph_type'])
+        ss += '{:<25s} : {:.3f}\n'.format('Sigma', d['morph_sigma'])
+        ss += '{:<25s} : {:.3f}\n'.format('Sigma error', d['morph_sigma_err'])
+        ss += '{:<25s} : {:.3f}\n'.format('Sigma2', d['morph_sigma2'])
+        ss += '{:<25s} : {:.3f}\n'.format('Sigma2 error', d['morph_sigma2_err'])
+        # Call these major/minor axis instead?
+        # Signify (gauss) for Sigma above?
+
+        ss += '{:<25s} : {:.3f}\n'.format('Position angle', d['morph_pa'])
+        ss += '{:<25s} : {:.3f}\n'.format('Position angle error', d['morph_pa_err'])
+        ss += '{:<25s} : {}\n'.format('Position angle frame', d['morph_pa_frame'])
+
+        return ss
+
+
+    def _info_spectral_fit(self):
+        """Print spectral info."""
+        d = self.data
+        ss = '\n*** Spectral info ***\n\n'
+        ss += '{:<32s} : {:.3f}\n'.format('Significance (*energy range*)', d['significance'])
+        ss += '{:<32s} : {:.3f}\n'.format('Livetime', d['livetime'])
+
+        spec = d['spec_type']
+        str = ''
+        if(spec == 'pl2'):
+            str = '(integral power law)'
+        ss += '\n{:<15s} : {} {}\n'.format('Spectrum type', spec, str)
+
+        # Spectral model parameters
+        if(spec == 'pl'):
+
+            unit = 'cm-2 s-1 TeV-1'
+            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
+            args = ('norm', d['spec_pl_norm'].value, d['spec_pl_norm_err'].value, unit)
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
+            args = ('', d['spec_pl_norm'].value, d['spec_pl_norm_err_sys'].value, unit)
+            ss += fmt.format(*args)
+
+            fmt = '{:<15s} : {:.3} +- {:.3} (statistical)\n'
+            args = ('index', d['spec_pl_index'], d['spec_pl_index_err'])
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} (systematic)\n'
+            args = ('', d['spec_pl_index'], d['spec_pl_index_err_sys'])
+            ss += fmt.format(*args)
+
+            ss += '{:<15s} : {:.3}\n'.format('reference', d['spec_pl_e_ref'])
+
+        if(spec == 'pl2'):
+
+            unit = 'cm-2 s-1'
+            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
+            args = ('flux', d['spec_pl2_flux'].value, d['spec_pl2_flux_err'].value, unit)
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
+            args = ('', d['spec_pl2_flux'].value, d['spec_pl2_flux_err_sys'].value, unit)
+            ss += fmt.format(*args)
+
+            fmt = '{:<15s} : {:.3} +- {:.3} (statistical)\n'
+            args = ('index', d['spec_pl2_index'], d['spec_pl2_index_err'])
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} (systematic)\n'
+            args = ('', d['spec_pl2_index'], d['spec_pl2_index_err_sys'])
+            ss += fmt.format(*args)
+
+            ss += '{:<15s} : {:.3}\n'.format('e_min', d['spec_pl2_e_min'])
+            ss += '{:<15s} : {:.3}\n'.format('e_max', d['spec_pl2_e_max'])
+
+        if(spec == 'ecpl'):
+
+            unit = 'cm-2 s-1 TeV-1'
+            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
+            args = ('norm', d['spec_ecpl_norm'].value, d['spec_ecpl_norm_err'].value, unit)
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
+            args = ('', d['spec_ecpl_norm'].value, d['spec_ecpl_norm_err_sys'].value, unit)
+            ss += fmt.format(*args)
+
+            fmt = '{:<15s} : {:.3} +- {:.3} (statistical)\n'
+            args = ('index', d['spec_ecpl_index'], d['spec_ecpl_index_err'])
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} (systematic)\n'
+            args = ('', d['spec_ecpl_index'], d['spec_ecpl_index_err_sys'])
+            ss += fmt.format(*args)
+
+            unit = 'TeV'
+            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
+            args = ('e_cut', d['spec_ecpl_e_cut'].value, d['spec_ecpl_e_cut_err'].value, unit)
+            ss += fmt.format(*args)
+            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
+            args = ('', d['spec_ecpl_e_cut'].value, d['spec_ecpl_e_cut_err_sys'].value, unit)
+            ss += fmt.format(*args)
+
+            ss += '{:<15s} : {:.3}\n'.format('reference', d['spec_ecpl_e_ref'])
+
+        ss += '\n{:<20s} : {:.3}\n'.format('energy range min', d['spec_erange_min'])
+        ss += '{:<20s} : {:.3}\n'.format('energy range max', d['spec_erange_max'])
+        ss += '{:<20s} : {:.3}\n'.format('theta', d['spec_theta'])
+
+        ss = '\n\nDerived fluxes:\n'
+
+        unit = 'cm-2 s-1 TeV-1'
+        fmt = '{:<30s} : {:.3} +- {:.3} {} (statistical)\n'
+        args = ('Spectral model norm (1 TeV)', d['spec_dnde_1TeV'].value, d['spec_dnde_1TeV_err'].value, unit)
+        ss += fmt.format(*args)
+
+        unit = 'cm-2 s-1'
+        fmt = '{:<30s} : {:.3} +- {:.3} {} (statistical)\n'
+        args = ('Integrated flux (<1 TeV)', d['spec_flux_1TeV'].value, d['spec_flux_1TeV_err'].value, unit)
+        ss += fmt.format(*args)
+
+        unit = '(crab units)'
+        fmt = '{:<30s} : {:.3} +- {:.3} {}\n'
+        args = ('Integrated flux (<1 TeV)', d['spec_flux_1TeV_crab'], d['spec_flux_1TeV_crab_err'], unit)
+        ss += fmt.format(*args)
+
+        unit = 'erg cm-2 s-1'
+        fmt = '{:<30s} : {:.3} +- {:.3} {} (statistical)\n'
+        args = ('Integrated flux (1-10 TeV)', d['spec_eflux_1TeV_10TeV'].value, d['spec_eflux_1TeV_10TeV_err'].value, unit)
+        ss += fmt.format(*args)
+
+        return ss
+
+
+    def _info_spectral_points(self):
+        """Print spectral points info."""
+        d = self.data
+        ss = '\n*** Spectral points ***\n'
+        ss += '{:<20s} : {}\n'.format('SED reference id', d['sed_reference_id'])
+        ss += '{:<20s} : {}\n'.format('# spectral points', d['sed_n_points'])
+        ss += '{:<20s} : {}\n\n'.format('# upper limits', d['sed_n_ul'])
+
+        t = self._flux_points_table_formatted
+
+        ss += '\n'.join(t.pformat(max_width=-1))
+        return ss + '\n'
+
+
+    def _info_reference(self):
+        """Print reference info."""
+        d = self.data
+        ss = '\n*** Reference info ***\n\n'
+        ss += '{:<20s} : {}\n'.format('Discoverer', d['discoverer'])
+        ss += '{:<20s} : {}\n'.format('Discovery date', d['discovery_date'])
+        ss += '{:<20s} : {}\n'.format('Seen by', d['seen_by'])
+        ss += '{:<20s} : {}\n'.format('Reference', d['reference_id'])
+
+        return ss
+
+
 
     @property
     def spectral_model(self):
@@ -168,6 +389,19 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         m['source_id'] = d['source_id']
         m['common_name'] = d['common_name']
         m['reference_id'] = d['reference_id']
+
+    @property
+    def _flux_points_table_formatted(self):
+        """Returns formatted version of self.flux_points.table"""
+        table = self.flux_points.table.copy()
+
+        table['e_ref'].format = '.1f'
+
+        flux_cols = ['dnde', 'dnde_errn', 'dnde_errp']
+        for _ in flux_cols:
+            table[_].format = '.3'
+
+        return table
 
     @property
     def flux_points(self):

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -123,7 +123,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             Comma separated list of options
         """
         if info == 'all':
-            info = 'basic,map,spec,flux_points,components,associations'
+            info = 'basic,associations,map,spec,flux_points,components'
 
         ss = ''
         ops = info.split(',')
@@ -153,6 +153,12 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         ss += '{:<20s} : {}\n'.format('Identified object', d['Identified_Object'])
         ss += '{:<20s} : {}\n'.format('Gamma-Cat id', d['Gamma_Cat_Source_ID'])
         ss += '\n'
+        return ss
+
+    def _info_associations(self):
+        ss = '\n*** Source associations info ***\n\n'
+        associations = ', '.join(self.associations)
+        ss += 'List of associated objects: {}\n'.format(associations)
         return ss
 
     def _info_map(self):
@@ -365,12 +371,6 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             # Call __str__ directly to
             ss += component.__str__()
             ss += '\n\n'
-        return ss
-
-    def _info_associations(self):
-        ss = '\n*** Source associations info ***\n\n'
-        associations = ', '.join(self.associations)
-        ss += 'List of associated objects: {}\n'.format(associations)
         return ss
 
     @property

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -202,11 +202,13 @@ class TestFermi3FHLObject:
         self.source.pprint()
 
     def test_str(self):
-        ss = str(self.source)
-        assert '3FHL J0534.5+2201' in ss  # Source name
-        assert '83.635 deg' in ss # RA
-        assert 'Significance (10 GeV - 2 TeV)    : 168.641' in ss
-        assert 'Integral flux (10 GeV - 1 TeV)   : 8.66e-09 +- 1.71e-10 cm-2 s-1' in ss
+        source = self.cat['3FHL J2301.9+5855e'] # Picking an extended source
+        ss = str(source)
+        assert 'Source name          : 3FHL J2301.9+5855e' in ss
+        assert 'RA                   : 345.494 deg' in ss
+        assert 'Significance (10 GeV - 2 TeV)    : 7.974' in ss
+        assert 'Integral flux (10 GeV - 1 TeV)   : 1.46e-10 +- 2.57e-11 cm-2 s-1' in ss
+        assert 'Model form       : Disk' in ss
 
     @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FHL)
     def test_spectral_model(self, index, model_type, desired):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -205,7 +205,7 @@ class TestFermi3FHLObject:
         ss = str(self.source)
         assert '3FHL J0534.5+2201' in ss  # Source name
         assert '83.635 deg' in ss # RA
-        assert 'Detection significance (10 GeV - 2 TeV)       : 168.641' in ss
+        assert 'Significance (10 GeV - 2 TeV)    : 168.641' in ss
         assert 'Integral flux (10 GeV - 1 TeV)   : 8.66e-09 +- 1.71e-10 cm-2 s-1' in ss
 
     @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FHL)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -64,8 +64,8 @@ class TestFermi3FGLObject:
 
     def test_str(self):
         ss = str(self.source)
-        assert '3FGL J0534.5+2201' in ss  # Source name
-        assert '83.637 deg' in ss  # RA
+        assert 'Source name          : 3FGL J0534.5+2201' in ss
+        assert 'RA                   : 83.637 deg' in ss
         assert 'Detection significance (100 MeV - 300 GeV)    : 30.670' in ss
         assert 'Integral flux (1 - 100 GeV)                   : 1.57e-07 +- 1.08e-09 cm-2 s-1' in ss
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -66,6 +66,8 @@ class TestFermi3FGLObject:
         ss = str(self.source)
         assert '3FGL J0534.5+2201' in ss  # Source name
         assert '83.637 deg' in ss  # RA
+        assert 'Detection significance (100 MeV - 300 GeV)    : 30.670' in ss
+        assert 'Integral flux (1 - 100 GeV)                   : 1.57e-07 +- 1.08e-09 cm-2 s-1' in ss
 
     @pytest.mark.parametrize('index, model_type, desired, desired_err', MODEL_TEST_DATA_3FGL)
     def test_spectral_model(self, index, model_type, desired, desired_err):
@@ -201,8 +203,10 @@ class TestFermi3FHLObject:
 
     def test_str(self):
         ss = str(self.source)
-        assert 'Source: 3FHL J0534.5+2201' in ss
-        assert 'RA (J2000)  : 83.63' in ss
+        assert '3FHL J0534.5+2201' in ss  # Source name
+        assert '83.635 deg' in ss # RA
+        assert 'Detection significance (10 GeV - 2 TeV)       : 168.641' in ss
+        assert 'Integral flux (10 GeV - 1 TeV)   : 8.66e-09 +- 1.71e-10 cm-2 s-1' in ss
 
     @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FHL)
     def test_spectral_model(self, index, model_type, desired):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -74,10 +74,8 @@ class TestSourceCatalogGammaCat:
         for sort_key in sort_keys:
             # this test modifies the catalog, so we make a copy
             cat = gammacat()
-            before = str(cat[name])
             cat.table.sort(sort_key)
-            after = str(cat[name])
-            assert before == after
+            assert cat[name].name == name
 
     def test_to_source_library(self, gammacat):
         sources = gammacat.to_source_library()
@@ -97,6 +95,14 @@ class TestSourceCatalogObjectGammaCat:
         assert isinstance(source.data, OrderedDict)
         assert source.data['common_name'] == 'CTA 1'
         assert_quantity_allclose(source.data['dec'], 72.782997 * u.deg)
+
+    def test_str(self, gammacat):
+        source = gammacat[0]
+        ss = str(source) # CTA 1
+        assert 'Common name     : CTA 1' in ss
+        assert 'RA                   : 1.650 deg' in ss
+        assert 'norm            : 9.1e-14 +- 1.3e-14 cm-2 s-1 TeV-1 (statistical)' in ss
+        assert 'Integrated flux (<1 TeV)       : 8.5e-13 +- 1.3e-13 cm-2 s-1 (statistical)' in ss
 
     @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
     def test_spectral_model(self, gammacat, ref):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -81,7 +81,7 @@ class TestSourceCatalogGammaCat:
         sources = gammacat.to_source_library()
         source = sources.source_list[0]
 
-        assert len(sources.source_list) == 72
+        assert len(sources.source_list) == 74
         assert source.source_name == 'CTA 1'
         assert_allclose(source.spectral_model.parameters['Index'].value, -2.2)
 


### PR DESCRIPTION
@adonath @cdeil - This PR mainly focuses on the `__str__()` method for `SourceCatalogObject3FHL`, but here is everything it accomplishes:

* Create full print-out for `SourceCatalogObject3FHL`

* Add new property, `_flux_points_table_formatted`, to 3FHL and 3FGL source objects - essentially just a cleaner version of `flux_points.table`. It allows people to easily dump a clean + formatted astropy table to JSON, etc.

* Minor fixes to print-outs for 3FGL and HGPS sources (e.g. add `_flux_points_table_formatted` to print string)

* Add `sqrt_TS` column to `flux_points.table` for 3FHL and 3FGL source objects

I haven't really done anything with the tests for `SourceCatalogObject3FHL` and `SourceCatalogObject3FGL` yet - let me know what can be done for them.