### PR TITLE
Add routine to DataStore that performs sanity checks on observations

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -24,6 +24,8 @@ __all__ = [
     'ObservationList',
 ]
 
+format = "%(levelname)8s %(filename)s:%(lineno)s - %(funcName)s --- %(message)s"
+logging.basicConfig(level=logging.INFO, format=format)
 log = logging.getLogger(__name__)
 
 
@@ -283,6 +285,29 @@ class DataStore(object):
             things.append(thing)
 
         return things
+
+    def check_observations(self):
+        """Check all observations regarding their values in events, aeff, edisp, psf
+        """
+
+        # Loop over all obs_ids in obs_table
+        log.info('Checking all runs listed in the obs_table')
+        for obs_id in self.obs_table['OBS_ID']:
+            # Check that events table is not empty
+            if len(self.obs(obs_id).events.table) == 0:
+                log.warning('Events table is empty in run: {}'.format(obs_id))
+            # Check that thresholds are meaningful for aeff
+            if self.obs(obs_id).aeff.meta['LO_THRES'] >= self.obs(obs_id).aeff.meta['HI_THRES']:
+                log.warning('LO_THRES >= HI_THRES for aeff in run: {}'.format(obs_id))
+            # Check that maximum value of aeff is greater than zero
+            if np.max(self.obs(obs_id).aeff.data.data) <= 0:
+                log.warning('EFFAREA_MAX <= 0 for aeff in run: {}'.format(obs_id))
+            # Check that maximum value of edisp matrix is greater than zero"
+            if np.max(self.obs(obs_id).edisp.data.data) <= 0:
+                log.warning('MATRIX_MAX <= 0 for edisp in run: {}'.format(obs_id))
+            # Check that thresholds are meaningful for psf
+            if self.obs(obs_id).psf.energy_thresh_lo >= self.obs(obs_id).psf.energy_thresh_hi:
+                log.warning('LO_THRES greater than HI_THRES for psf in run: {}'.format(obs_id))
 
     def check_integrity(self, logger=None):
         """Check integrity, i.e. whether index and observation table match.

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -213,6 +213,7 @@ def test_make_mean_edisp(tmpdir):
     assert_equal(i, i2)
 
 
+@requires_dependency('yaml')
 @requires_data('gammapy-extra')
 def test_check_observations(data_manager):
     data_store = data_manager['hess-crab4-hd-hap-prod2']

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -211,3 +211,10 @@ def test_make_mean_edisp(tmpdir):
     i = np.where(rmf.data.evaluate(e_reco=Energy(40, "TeV")) != 0)[0]
     i2 = np.where(rmf2.data.evaluate(e_reco=Energy(40, "TeV")) != 0)[0]
     assert_equal(i, i2)
+
+
+@requires_data('gammapy-extra')
+def test_check_observations(data_manager):
+    data_store = data_manager['hess-crab4-hd-hap-prod2']
+    result = data_store.check_observations()
+    assert len(result) == 0


### PR DESCRIPTION
This simple routine performs some sanity checks on the events and IRF files of the observations in the DataStore.