### PR TITLE
Source catalog object converter to JSON-serializable dict

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import sys
 from copy import deepcopy
 from pprint import pprint
+import numpy as np
 from astropy.extern import six
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
@@ -58,10 +59,28 @@ class SourceCatalogObject(object):
 
         pprint(self.data, stream=file)
 
-        # TODO: add methods to serialise to JSON and YAML
-        # and also to quickly pretty-print output in that format for interactive use.
-        # Maybe even add HTML output for IPython repr?
-        # Or at to_table method?
+    @property
+    def _data_python_dict(self):
+        """Convert ``data`` into a Python dict that only contains
+        Python data types, i.e. is readily JSON or YAML serialisable.
+        Quantity unit information is stripped.
+
+        This is mainly used at the moment to pass the data to
+        the gamma-sky.net webpage.
+        """
+        out = OrderedDict()
+        for key, value in self.data.items():
+            if isinstance(value, int):
+                out_val = value
+            else:
+                # This works because almost all values in ``data``
+                # are Numpy objects, and ``tolist`` works for Numpy
+                # arrays and scalars.
+                out_val = np.asarray(value).tolist()
+
+            out[key] = out_val
+
+        return out
 
     def info(self):
         """
@@ -246,6 +265,17 @@ class SourceCatalog(object):
 
             data[colname] = val
         return data
+
+    @property
+    def _data_python_list(self):
+        """Convert catalog into a Python list that only contains
+        Python data types, i.e. is readily JSON or YAML serialisable.
+        Quantity unit information is stripped.
+
+        This is mainly used at the moment to pass the data to
+        the gamma-sky.net webpage.
+        """
+        return [source._data_python_dict for source in self]
 
     def info(self):
         """Print info string."""

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -69,6 +69,14 @@ class TestFermi3FGLObject:
         assert 'Detection significance (100 MeV - 300 GeV)    : 30.670' in ss
         assert 'Integral flux (1 - 100 GeV)                   : 1.57e-07 +- 1.08e-09 cm-2 s-1' in ss
 
+    def test_data_python_dict(self):
+        data = self.source._data_python_dict
+        assert type(data['RAJ2000']) == float
+        assert data['RAJ2000'] == 83.63719940185547
+        assert type(data['Unc_Flux100_300']) == list
+        assert type(data['Unc_Flux100_300'][0]) == float
+        assert_allclose(data['Unc_Flux100_300'][0], -1.44535601265261e-08)
+
     @pytest.mark.parametrize('index, model_type, desired, desired_err', MODEL_TEST_DATA_3FGL)
     def test_spectral_model(self, index, model_type, desired, desired_err):
         energy = u.Quantity(1, 'GeV')
@@ -209,6 +217,14 @@ class TestFermi3FHLObject:
         assert 'Significance (10 GeV - 2 TeV)    : 7.974' in ss
         assert 'Integral flux (10 GeV - 1 TeV)   : 1.46e-10 +- 2.57e-11 cm-2 s-1' in ss
         assert 'Model form       : Disk' in ss
+
+    def test_data_python_dict(self):
+        data = self.source._data_python_dict
+        assert type(data['RAJ2000']) == float
+        assert data['RAJ2000'] == 83.63483428955078
+        assert type(data['Flux_Band']) == list
+        assert type(data['Flux_Band'][0]) == float
+        assert_allclose(data['Flux_Band'][0], 5.1698894054652555e-09)
 
     @pytest.mark.parametrize('index, model_type, desired', MODEL_TEST_DATA_3FHL)
     def test_spectral_model(self, index, model_type, desired):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -104,6 +104,15 @@ class TestSourceCatalogObjectGammaCat:
         assert 'norm            : 9.1e-14 +- 1.3e-14 cm-2 s-1 TeV-1 (statistical)' in ss
         assert 'Integrated flux (<1 TeV)       : 8.5e-13 +- 1.3e-13 cm-2 s-1 (statistical)' in ss
 
+    def test_data_python_dict(self, gammacat):
+        source = gammacat[0]
+        data = source._data_python_dict
+        assert type(data['ra']) == float
+        assert data['ra'] == 1.649999976158142
+        assert type(data['sed_e_min']) == list
+        assert type(data['sed_e_min'][0]) == float
+        assert_allclose(data['sed_e_min'][0], 0.5600000023841858)
+
     @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
     def test_spectral_model(self, gammacat, ref):
         source = gammacat[ref['name']]


### PR DESCRIPTION
@cdeil - This is the PR for the `_data_python_dict` and `_data_python_list` source/catalog object properties that we worked on. I've implemented tests in the latest PR for 3FGL and 3FHL source catalog objects. Let me know if anything else is needed.

(I'm now transitioning to work on gamma-sky.net.)