### PR TITLE
Add `e_peak` property to some spectral models

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -995,7 +995,7 @@ def _is_galactic(source_class):
         return 'galactic'
     elif source_class in egal_classes:
         return 'extra-galactic'
-    elif source_class == '':
+    elif (source_class == '') or (source_class == 'unknown'):
         return 'unknown'
     else:
         raise ValueError('Unknown source class: {}'.format(source_class))

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -735,24 +735,23 @@ class ExponentialCutoffPowerLaw(SpectralModel):
 
     @property
     def e_peak(self):
-        """Peak energy of the spectral model.
+        r"""Spectral energy distribution peak energy (`~astropy.utils.Quantity`).
 
-        Given by:
+        This is the peak in E^2 x dN/dE and is given by:
 
         .. math::
 
-            E_{Peak} = \Gamma / \lambda
+            E_{Peak} = (2 - \Gamma) / \lambda
 
-        Returns
-        -------
-        e_peak : `~astropy.units.Quantity`
-            Peak energy of the spectrum.
         """
         p = self.parameters
         reference = p['reference'].quantity
         index = p['index'].quantity
         lambda_ = p['lambda_'].quantity
-        return index / lambda_
+        if index >= 2:
+            return np.nan * reference.unit
+        else:
+            return (2 - index) / lambda_
 
 
 class ExponentialCutoffPowerLaw3FGL(SpectralModel):
@@ -891,24 +890,20 @@ class LogParabola(SpectralModel):
 
     @property
     def e_peak(self):
-        """Peak energy of the spectral model.
+        r"""Spectral energy distribution peak energy (`~astropy.utils.Quantity`).
 
-        Given by:
+        This is the peak in E^2 x dN/dE and is given by:
 
         .. math::
 
-            E_{Peak} = E_{0} \exp{- \alpha / (2 * \beta)}
+            E_{Peak} = E_{0} \exp{ (2 - \alpha) / (2 * \beta)}
 
-        Returns
-        -------
-        e_peak : `~astropy.units.Quantity`
-            Peak energy of the spectrum.
         """
         p = self.parameters
         reference = p['reference'].quantity
         alpha = p['alpha'].quantity
         beta = p['beta'].quantity
-        return reference * np.exp(-alpha / (2 * beta))
+        return reference * np.exp((2 - alpha) / (2 * beta))
 
 
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -733,6 +733,27 @@ class ExponentialCutoffPowerLaw(SpectralModel):
 
         return model
 
+    @property
+    def e_peak(self):
+        """Peak energy of the spectral model.
+
+        Given by:
+
+        .. math::
+
+            E_{Peak} = \Gamma / \lambda
+
+        Returns
+        -------
+        e_peak : `~astropy.units.Quantity`
+            Peak energy of the spectrum.
+        """
+        p = self.parameters
+        reference = p['reference'].quantity
+        index = p['index'].quantity
+        lambda_ = p['lambda_'].quantity
+        return index / lambda_
+
 
 class ExponentialCutoffPowerLaw3FGL(SpectralModel):
     r"""Spectral exponential cutoff power-law model used for 3FGL.
@@ -867,6 +888,28 @@ class LogParabola(SpectralModel):
             xx = energy / reference
             exponent = -alpha - beta * log(xx)
         return amplitude * np.power(xx, exponent)
+
+    @property
+    def e_peak(self):
+        """Peak energy of the spectral model.
+
+        Given by:
+
+        .. math::
+
+            E_{Peak} = E_{0} \exp{- \alpha / (2 * \beta)}
+
+        Returns
+        -------
+        e_peak : `~astropy.units.Quantity`
+            Peak energy of the spectrum.
+        """
+        p = self.parameters
+        reference = p['reference'].quantity
+        alpha = p['alpha'].quantity
+        beta = p['beta'].quantity
+        return reference * np.exp(-alpha / (2 * beta))
+
 
 
 class TableModel(SpectralModel):

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -76,6 +76,7 @@ TEST_MODELS = [
         val_at_2TeV=u.Quantity(0.6650160161581361, 'cm-2 s-1 TeV-1'),
         integral_1_10TeV=u.Quantity(2.3556579120286796, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(4.83209019773561, 'TeV cm-2 s-1'),
+        e_peak=23 * u.TeV
     ),
 
     dict(
@@ -103,7 +104,8 @@ TEST_MODELS = [
 
         val_at_2TeV=u.Quantity(0.6387956571420305, 'cm-2 s-1 TeV-1'),
         integral_1_10TeV=u.Quantity(2.255689748270628, 'cm-2 s-1'),
-        eflux_1_10TeV=u.Quantity(3.9586515834989267, 'TeV cm-2 s-1')
+        eflux_1_10TeV=u.Quantity(3.9586515834989267, 'TeV cm-2 s-1'),
+        e_peak=0.1 * u.TeV
     ),
 ]
 
@@ -137,6 +139,9 @@ def test_models(spectrum):
                              spectrum['integral_1_10TeV'])
     assert_quantity_allclose(model.energy_flux(emin=emin, emax=emax),
                              spectrum['eflux_1_10TeV'])
+
+    if 'e_peak' in spectrum:
+        assert_quantity_allclose(model.e_peak, spectrum['e_peak'], rtol=1E-2)
 
     # inverse for TableModel is not implemented
     if not isinstance(model, TableModel):

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -67,16 +67,16 @@ TEST_MODELS = [
     dict(
         name='ecpl',
         model=ExponentialCutoffPowerLaw(
-            index=2.3 * u.Unit(''),
+            index=1.6 * u.Unit(''),
             amplitude=4 / u.cm ** 2 / u.s / u.TeV,
             reference=1 * u.TeV,
             lambda_=0.1 / u.TeV
         ),
 
-        val_at_2TeV=u.Quantity(0.6650160161581361, 'cm-2 s-1 TeV-1'),
-        integral_1_10TeV=u.Quantity(2.3556579120286796, 'cm-2 s-1'),
-        eflux_1_10TeV=u.Quantity(4.83209019773561, 'TeV cm-2 s-1'),
-        e_peak=23 * u.TeV
+        val_at_2TeV=u.Quantity(1.080321705479446, 'cm-2 s-1 TeV-1'),
+        integral_1_10TeV=u.Quantity(3.765838739678921, 'cm-2 s-1'),
+        eflux_1_10TeV=u.Quantity(9.901735870666526, 'TeV cm-2 s-1'),
+        e_peak=4 * u.TeV
     ),
 
     dict(
@@ -105,7 +105,7 @@ TEST_MODELS = [
         val_at_2TeV=u.Quantity(0.6387956571420305, 'cm-2 s-1 TeV-1'),
         integral_1_10TeV=u.Quantity(2.255689748270628, 'cm-2 s-1'),
         eflux_1_10TeV=u.Quantity(3.9586515834989267, 'TeV cm-2 s-1'),
-        e_peak=0.1 * u.TeV
+        e_peak=0.74082 * u.TeV
     ),
 ]
 


### PR DESCRIPTION
This PR adds a `e_peak` property to the `LogParabola` and `ExponentialCutoffPowerLaw` spectral models. It computes the peak energy of the spectral model and returns it as a quantity.