### PR TITLE
Fix Fermi-LAT catalog flux points column names

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -305,8 +305,8 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn',
-                     'eflux_errp', 'flux_ul', 'eflux_ul', 'dnde']
+        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'e2dnde', 'e2dnde_errn',
+                     'e2dnde_errp', 'flux_ul', 'e2dnde_ul', 'dnde']
         table['sqrt_TS'].format = '.1f'
         table['e_ref'].format = '.1f'
         for _ in flux_cols:
@@ -331,9 +331,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         table['flux_errp'] = flux_err[:, 1]
 
         nuFnu = self._get_flux_values('nuFnu', 'erg cm-2 s-1')
-        table['eflux'] = nuFnu
-        table['eflux_errn'] = np.abs(nuFnu * flux_err[:, 0] / flux)
-        table['eflux_errp'] = nuFnu * flux_err[:, 1] / flux
+        table['e2dnde'] = nuFnu
+        table['e2dnde_errn'] = np.abs(nuFnu * flux_err[:, 0] / flux)
+        table['e2dnde_errp'] = nuFnu * flux_err[:, 1] / flux
 
         is_ul = np.isnan(table['flux_errn'])
         table['is_ul'] = is_ul
@@ -344,9 +344,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         table['flux_ul'][is_ul] = flux_ul[is_ul]
 
         # handle upper limits
-        table['eflux_ul'] = np.nan * nuFnu.unit
-        eflux_ul = compute_flux_points_ul(table['eflux'], table['eflux_errp'])
-        table['eflux_ul'][is_ul] = eflux_ul[is_ul]
+        table['e2dnde_ul'] = np.nan * nuFnu.unit
+        e2dnde_ul = compute_flux_points_ul(table['e2dnde'], table['e2dnde_errp'])
+        table['e2dnde_ul'][is_ul] = e2dnde_ul[is_ul]
 
         # Square root of test statistic
         table['sqrt_TS'] = [self.data['Sqrt_TS' + _] for _ in self._ebounds_suffix]
@@ -754,8 +754,8 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'eflux', 'eflux_errn',
-                     'eflux_errp', 'flux_ul', 'eflux_ul', 'dnde']
+        flux_cols = ['flux', 'flux_errn', 'flux_errp', 'e2dnde', 'e2dnde_errn',
+                     'e2dnde_errp', 'flux_ul', 'e2dnde_ul', 'dnde']
         table['sqrt_ts'].format = '.1f'
         table['e_ref'].format = '.1f'
         for _ in flux_cols:
@@ -781,9 +781,9 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         table['flux_errn'] = np.abs(flux_err[:, 0])
         table['flux_errp'] = flux_err[:, 1]
 
-        table['eflux'] = e2dnde
-        table['eflux_errn'] = np.abs(e2dnde * flux_err[:, 0] / flux)
-        table['eflux_errp'] = e2dnde * flux_err[:, 1] / flux
+        table['e2dnde'] = e2dnde
+        table['e2dnde_errn'] = np.abs(e2dnde * flux_err[:, 0] / flux)
+        table['e2dnde_errp'] = e2dnde * flux_err[:, 1] / flux
 
         is_ul = np.isnan(table['flux_errn'])
         table['is_ul'] = is_ul
@@ -793,9 +793,9 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         flux_ul = compute_flux_points_ul(table['flux'], table['flux_errp'])
         table['flux_ul'][is_ul] = flux_ul[is_ul]
 
-        table['eflux_ul'] = np.nan * e2dnde.unit
-        eflux_ul = compute_flux_points_ul(table['eflux'], table['eflux_errp'])
-        table['eflux_ul'][is_ul] = eflux_ul[is_ul]
+        table['e2dnde_ul'] = np.nan * e2dnde.unit
+        e2dnde_ul = compute_flux_points_ul(table['e2dnde'], table['e2dnde_errp'])
+        table['e2dnde_ul'][is_ul] = e2dnde_ul[is_ul]
 
         # Square root of test statistic
         table['sqrt_ts'] = self.data['Sqrt_TS_Band']

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -508,7 +508,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         table['dnde_errn'] = self.data['Flux_Points_Flux_Err_Lo'][mask]
         table['dnde_errp'] = self.data['Flux_Points_Flux_Err_Hi'][mask]
         table['dnde_ul'] = self.data['Flux_Points_Flux_UL'][mask]
-        table['is_ul'] = self.data['Flux_Points_Flux_Is_UL'][mask]
+        table['is_ul'] = self.data['Flux_Points_Flux_Is_UL'][mask].astype('bool')
 
         return FluxPoints(table)
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -265,6 +265,28 @@ class FluxPoints(object):
         table.meta['SED_TYPE'] = 'dnde'
         return FluxPoints(table)
 
+    @staticmethod
+    def _e_ref_lafferty(model, e_min, e_max):
+        """Helper for `to_sed_type`.
+
+        Compute e_ref that the value at e_ref corresponds
+        to the mean value between e_min and e_max.
+        """
+        flux = model.integral(e_min, e_max)
+        dnde_mean = flux / (e_max - e_min)
+        return model.inverse(dnde_mean)
+
+    @staticmethod
+    def _dnde_from_flux(flux, model, e_ref, e_min, e_max):
+        """Helper for `to_sed_type`.
+
+        Compute dnde under the assumption that flux equals expected
+        flux from model.
+        """
+        flux_model = model.integral(e_min, e_max, intervals=True)
+        dnde_model = model(e_ref)
+        return dnde_model * (flux / flux_model)
+
     @property
     def sed_type(self):
         """SED type (str).
@@ -392,28 +414,6 @@ class FluxPoints(object):
             Upper bound of energy bin.
         """
         return self.table['e_max'].quantity
-
-    @staticmethod
-    def _e_ref_lafferty(model, e_min, e_max):
-        """Helper for `to_sed_type`.
-
-        Compute e_ref that the value at e_ref corresponds
-        to the mean value between e_min and e_max.
-        """
-        flux = model.integral(e_min, e_max)
-        dnde_mean = flux / (e_max - e_min)
-        return model.inverse(dnde_mean)
-
-    @staticmethod
-    def _dnde_from_flux(flux, model, e_ref, e_min, e_max):
-        """Helper for `to_sed_type`.
-
-        Compute dnde under the assumption that flux equals expected
-        flux from model.
-        """
-        flux_model = model.integral(e_min, e_max)
-        dnde_model = model(e_ref)
-        return dnde_model * (flux / flux_model)
 
     def plot(self, ax=None, sed_type=None, energy_unit='TeV', flux_unit=None,
              energy_power=0, **kwargs):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -602,7 +602,7 @@ class PowerLaw2(SpectralModel):
         bottom = emax ** (-index + 1) - emin ** (-index + 1)
         return amplitude * (top / bottom) * np.power(energy, -index)
 
-    def integral(self, emin, emax):
+    def integral(self, emin, emax, **kwargs):
         r"""Integrate power law analytically.
 
         .. math::

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -33,7 +33,7 @@ class LWTestModel(SpectralModel):
     def evaluate(x):
         return 1e4 * np.exp(-6 * x)
 
-    def integral(self, xmin, xmax):
+    def integral(self, xmin, xmax, **kwargs):
         return - 1. / 6 * 1e4 * (np.exp(-6 * xmax) - np.exp(-6 * xmin))
 
     def inverse(self, y):
@@ -47,7 +47,7 @@ class XSqrTestModel(SpectralModel):
     def evaluate(x):
         return x ** 2
 
-    def integral(self, xmin, xmax):
+    def integral(self, xmin, xmax, **kwargs):
         return 1. / 3 * (xmax ** 3 - xmin ** 2)
 
     def inverse(self, y):
@@ -61,7 +61,7 @@ class ExpTestModel(SpectralModel):
     def evaluate(x):
         return np.exp(x * u.Unit('1 / TeV'))
 
-    def integral(self, xmin, xmax):
+    def integral(self, xmin, xmax, **kwargs):
         return np.exp(xmax * u.Unit('1 / TeV')) - np.exp(xmin * u.Unit('1 / TeV'))
 
     def inverse(self, y):


### PR DESCRIPTION
This PR fixes the column names in the `.flux_points` property for Fermi-LAT sources. Additionally it fixes a bug in `Flux_points.to_sed_type()`, that was related to spectral model, that use numerical integration to compute integral fluxes. I also added a regression test.