### PR TITLE
Introduce spectral models default parameters

### DIFF
--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -310,7 +310,7 @@ class FermiLATDataset(object):
 
         try:
             cube = SkyCube.read(filename, format='fermi-counts')
-        except ValueError:
+        except (ValueError, KeyError):
             from ..cube.healpix import SkyCubeHealpix
             cube = SkyCubeHealpix.read(filename, format='fermi-counts')
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -718,7 +718,6 @@ class FluxPointEstimator(object):
 
         # Set reference and remove min amplitude
         model.parameters['reference'].value = energy_ref.to('TeV').value
-        model.parameters['amplitude'].parmin = None
 
         fit = SpectrumFit(self.obs, model)
         erange = energy_group.energy_range

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -398,11 +398,12 @@ class PowerLaw(SpectralModel):
         :math:`E_0`
     """
 
-    def __init__(self, index, amplitude, reference):
+    def __init__(self, index=2., amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
+                 reference=1 * u.TeV):
         self.parameters = ParameterList([
-            Parameter('index', index, parmin=0),
-            Parameter('amplitude', amplitude, parmin=0),
-            Parameter('reference', reference, frozen=True)
+            Parameter('index', index),
+            Parameter('amplitude', amplitude),
+            Parameter('reference', reference, parmin=0, frozen=True)
         ])
 
     @staticmethod
@@ -587,12 +588,13 @@ class PowerLaw2(SpectralModel):
         Upper energy limit :math:`E_{0, max}`.
     """
 
-    def __init__(self, amplitude, index, emin, emax):
+    def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1'), index=2,
+                 emin=0.1 * u.TeV, emax=100 * u.TeV):
         self.parameters = ParameterList([
-            Parameter('amplitude', amplitude, parmin=0),
-            Parameter('index', index, parmin=0),
-            Parameter('emin', emin),
-            Parameter('emax', emax)
+            Parameter('amplitude', amplitude),
+            Parameter('index', index),
+            Parameter('emin', emin, frozen=True),
+            Parameter('emax', emax, frozen=True)
         ])
 
     @staticmethod
@@ -694,12 +696,13 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         :math:`\lambda`
     """
 
-    def __init__(self, index, amplitude, reference, lambda_):
+    def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
+                 reference=1 * u.TeV, lambda_=0.1 / u.TeV):
         self.parameters = ParameterList([
-            Parameter('index', index, parmin=0),
-            Parameter('amplitude', amplitude, parmin=0),
+            Parameter('index', index),
+            Parameter('amplitude', amplitude),
             Parameter('reference', reference, frozen=True),
-            Parameter('lambda_', lambda_, parmin=0)
+            Parameter('lambda_', lambda_)
         ])
 
     @staticmethod
@@ -756,11 +759,12 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         :math:`E_{C}`
     """
 
-    def __init__(self, index, amplitude, reference, ecut):
+    def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
+                 reference=1 * u.TeV, ecut=10 * u.TeV):
         self.parameters = ParameterList([
-            Parameter('index', index, parmin=0),
-            Parameter('amplitude', amplitude, parmin=0),
-            Parameter('reference', reference, frozen=0),
+            Parameter('index', index),
+            Parameter('amplitude', amplitude),
+            Parameter('reference', reference, frozen=True),
             Parameter('ecut', ecut)
         ])
 
@@ -800,14 +804,15 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         :math:`E_{C}`
     """
 
-    def __init__(self, index_1, index_2, amplitude, reference, ecut):
+    def __init__(self, index_1=1.5, index_2=2, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
+                 reference=1 * u.TeV, ecut=10 * u.TeV):
         # TODO: order or parameters is different from argument list / docstring. Make uniform!
         self.parameters = ParameterList([
-            Parameter('amplitude', amplitude, parmin=0),
-            Parameter('reference', reference, frozen=0),
+            Parameter('amplitude', amplitude),
+            Parameter('reference', reference, frozen=True),
             Parameter('ecut', ecut),
-            Parameter('index_1', index_1, parmin=0),
-            Parameter('index_2', index_2, parmin=0),
+            Parameter('index_1', index_1),
+            Parameter('index_2', index_2),
         ])
 
     @staticmethod
@@ -845,9 +850,10 @@ class LogParabola(SpectralModel):
         :math:`\beta`
     """
 
-    def __init__(self, amplitude, reference, alpha, beta):
+    def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'), reference=1 * u.TeV,
+                 alpha=2, beta=1):
         self.parameters = ParameterList([
-            Parameter('amplitude', amplitude, parmin=0),
+            Parameter('amplitude', amplitude),
             Parameter('reference', reference, frozen=True),
             Parameter('alpha', alpha),
             Parameter('beta', beta)

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -396,6 +396,22 @@ class PowerLaw(SpectralModel):
         :math:`Phi_0`
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+
+
+    Examples
+    --------
+    This is a example plot of the default `PowerLaw` model:
+
+    .. plot::
+        :include-source:
+
+        from astropy import units as u
+        from gammapy.spectrum.models import PowerLaw
+
+        pwl = PowerLaw()
+        pwl.plot(energy_range=[0.1, 100] * u.TeV)
+        plt.show()
+
     """
 
     def __init__(self, index=2., amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
@@ -586,6 +602,20 @@ class PowerLaw2(SpectralModel):
         Lower energy limit :math:`E_{0, min}`.
     emax : `~astropy.units.Quantity`
         Upper energy limit :math:`E_{0, max}`.
+
+    Examples
+    --------
+    This is an example plot of the default `PowerLaw2` model:
+
+    .. plot::
+        :include-source:
+
+        from astropy import units as u
+        from gammapy.spectrum.models import PowerLaw2
+
+        pwl2 = PowerLaw2()
+        pwl2.plot(energy_range=[0.1, 100] * u.TeV)
+        plt.show()
     """
 
     def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1'), index=2,
@@ -694,6 +724,20 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         :math:`E_0`
     lambda : `~astropy.units.Quantity`
         :math:`\lambda`
+
+    Examples
+    --------
+    This is an example plot of the default `ExponentialCutoffPowerLaw` model:
+
+    .. plot::
+        :include-source:
+
+        from astropy import units as u
+        from gammapy.spectrum.models import ExponentialCutoffPowerLaw
+
+        ecpl = ExponentialCutoffPowerLaw()
+        ecpl.plot(energy_range=[0.1, 100] * u.TeV)
+        plt.show()
     """
 
     def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
@@ -757,6 +801,20 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         :math:`E_0`
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
+
+    Examples
+    --------
+    This is an example plot of the default `ExponentialCutoffPowerLaw3FGL` model:
+
+    .. plot::
+        :include-source:
+
+        from astropy import units as u
+        from gammapy.spectrum.models import ExponentialCutoffPowerLaw3FGL
+
+        ecpl_3fgl = ExponentialCutoffPowerLaw3FGL()
+        ecpl_3fgl.plot(energy_range=[0.1, 100] * u.TeV)
+        plt.show()
     """
 
     def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
@@ -802,6 +860,20 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         :math:`E_0`
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
+
+    Examples
+    --------
+    This is an example plot of the default `PLSuperExpCutoff3FGL` model:
+
+    .. plot::
+        :include-source:
+
+        from astropy import units as u
+        from gammapy.spectrum.models import PLSuperExpCutoff3FGL
+
+        secpl_3fgl = PLSuperExpCutoff3FGL()
+        secpl_3fgl.plot(energy_range=[0.1, 100] * u.TeV)
+        plt.show()
     """
 
     def __init__(self, index_1=1.5, index_2=2, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
@@ -848,9 +920,23 @@ class LogParabola(SpectralModel):
         :math:`\alpha`
     beta : `~astropy.units.Quantity`
         :math:`\beta`
+
+    Examples
+    --------
+    This is an example plot of the default `LogParabola` model:
+
+    .. plot::
+        :include-source:
+
+        from astropy import units as u
+        from gammapy.spectrum.models import LogParabola
+
+        log_parabola = LogParabola()
+        log_parabola.plot(energy_range=[0.1, 100] * u.TeV)
+        plt.show()
     """
 
-    def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'), reference=1 * u.TeV,
+    def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'), reference=10 * u.TeV,
                  alpha=2, beta=1):
         self.parameters = ParameterList([
             Parameter('amplitude', amplitude),

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -231,7 +231,9 @@ class ParameterList(object):
         """
         names = ['name', 'value', 'error', 'unit', 'min', 'max', 'frozen']
         formats = {'value': '.3e',
-                   'error': '.3e', }
+                   'error': '.3e',
+                   'min': '.3e',
+                   'max': '.3e'}
         table = Table(self.to_list_of_dict(), names=names)
 
         for name in formats:

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -91,8 +91,8 @@ class Parameter(object):
             self.value = value
             self.unit = unit
 
-        self.parmin = parmin or np.finfo(np.float32).min
-        self.parmax = parmax or np.finfo(np.float32).max
+        self.parmin = parmin or np.nan
+        self.parmax = parmax or np.nan
         self.frozen = frozen
 
     @property
@@ -153,11 +153,14 @@ class Parameter(object):
     def to_sherpa(self, modelname='Default'):
         """Convert to sherpa parameter"""
         from sherpa.models import Parameter
+
+        parmin = np.finfo(np.float32).min if np.isnan(self.parmin) else self.parmin
+        parmax = np.finfo(np.float32).max if np.isnan(self.parmax) else self.parmax
+
         par = Parameter(modelname=modelname, name=self.name,
                         val=self.value, units=self.unit,
-                        min=self.parmin, max=self.parmax,
+                        min=parmin, max=parmax,
                         frozen=self.frozen)
-
         return par
 
 

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -91,8 +91,8 @@ class Parameter(object):
             self.value = value
             self.unit = unit
 
-        self.parmin = parmin
-        self.parmax = parmax
+        self.parmin = parmin or np.finfo(np.float32).min
+        self.parmax = parmax or np.finfo(np.float32).max
         self.frozen = frozen
 
     @property


### PR DESCRIPTION
This PR addresses https://github.com/gammapy/gammapy/issues/992 and introduces default values for the spectral model parameters.

Once question I have is, whether we prefer strings as defaults (as suggested by @cdeil in https://github.com/gammapy/gammapy/issues/992).

A little bit tricky was the choice for parameter min / max default values. I've tried make the choice as general as possible and removed some of the previous default settings (OK with you @joleroi?). 

The PR also adds example plots for the spectral models.