### PR TITLE
Implement I/O methods for gammapy.maps

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -278,6 +278,25 @@ scheme.
    m.write('file.fits', extname='IMAGE', sparse=True)
    m = WcsMapND.read('file.fits', extname='IMAGE')
 
+By default files will be written to the *gamma-astro-data-format*
+specification for sky maps (see `here
+<http://gamma-astro-data-formats.readthedocs.io/en/latest/skymaps/index.html>`_).
+The GADF format offers a number of enhancements over existing map
+formats such as support for writing multi-resolution maps, sparse
+maps, and cubes with different geometries to the same file.  For
+backward compatibility with software using other formats, the ``conv``
+keyword option is provided to write a file using a format other than
+the GADF format:
+
+.. code::
+
+   from gammapy.maps import MapBase, MapAxis
+   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0,
+                      axes=[energy_axis])
+   # Write a counts cube in a format compatible with the Fermi Science Tools
+   m.write('ccube.fits', conv='fgst-ccube')
+   
 Visualization
 -------------
 

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -84,7 +84,30 @@ dimensions with the ``axes`` parameter:
    m_hpx = MapBase.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0,
                           axes=[energy_axis])
 
-   
+Multi-resolution maps (maps with a different pixel size or geometry in
+each image plane) can be constructed by passing a vector argument for
+any of the geometry parameters.  This vector must have the same shape as the
+non-spatial dimensions of the map.  The following example demonstrates
+creating an energy cube with a pixel size proportional to the
+Fermi-LAT PSF:
+
+.. code::
+
+   from gammapy.maps import MapBase, MapAxis
+   from astropy.coordinates import SkyCoord
+   position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
+   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+
+   binsz = np.sqrt((3.0*(energy_axis.center/100.)**-0.8)**2 + 0.1**2)
+
+   # Create a WCS Map
+   m_wcs = MapBase.create(binsz=binsz, map_type='wcs', skydir=position, width=10.0,
+                          axes=[energy_axis])
+
+   # Create a HPX Map
+   m_hpx = MapBase.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
+                          axes=[energy_axis])
+
 Get, Set, and Fill Methods
 --------------------------
 

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -176,6 +176,25 @@ Slicing Methods
 Iterating on a Map
 ------------------
 
+Iterating over a map can be performed with the
+`~MapBase.iter_by_coords` and `~MapBase.iter_by_pix` methods.  These
+return an iterator that traverses the map returning (value,
+coordinate) pairs with map and pixel coordinates, respectively.  The
+optional ``buffersize`` argument can be used to split the iteration 
+into chunks of a given size.  The following example illustrates how
+one can use this method to fill a map with a 2D Gaussian:
+
+.. code::
+
+   from astropy.coordinates import SkyCoord
+   from gammapy.maps import MapBase
+   m = MapBase.create(binsz=0.05, map_type='wcs', width=10.0)
+   for val, coords in m.iter_by_coords(buffersize=10000):
+       skydir = SkyCoord(coords[0],coords[1], unit='deg')
+       sep = skydir.separation(m.geom.center_skydir).deg
+       new_val = np.exp(-sep**2/2.0)
+       m.set_by_coords(coords, new_val)
+
 File I/O
 --------
 
@@ -184,10 +203,10 @@ and ``read`` methods.
 
 .. code::
 
-   from gammapy.maps import MapBase
+   from gammapy.maps import MapBase, WcsMapND
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', extname='IMAGE')
-   m = MapBase.read('test.fits', extname='IMAGE')
+   m = WcsMapND.read('test.fits', extname='IMAGE')
 
 Images can be serialized to a sparse data format by passing
 ``sparse=True``.  This will write the file to a sparse data table
@@ -195,10 +214,10 @@ appropriate to the pixelization scheme.
 
 .. code::
 
-   from gammapy.maps import MapBase
+   from gammapy.maps import MapBase, WcsMapND
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', extname='IMAGE', sparse=True)
-   m = MapBase.read('test.fits', extname='IMAGE')
+   m = WcsMapND.read('test.fits', extname='IMAGE')
 
 Using `gammapy.maps`
 ====================

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -33,7 +33,6 @@ class MapBase(object):
     def __init__(self, geom, data):
         self._data = data
         self._geom = geom
-        self._iter = None
 
     @property
     def data(self):
@@ -153,21 +152,45 @@ class MapBase(object):
         overwrite = kwargs.get('overwrite', True)
         hdulist.writeto(filename, overwrite=overwrite)
 
-    def __iter__(self):
-        return self
+    @abc.abstractmethod
+    def iter_by_pix(self, buffersize=1):
+        """Iterate over elements of the map returning a tuple with values and
+        pixel coordinates.
 
-    def __next__(self):
+        Parameters
+        ----------
+        buffersize : int
+            Set the size of the buffer.  The map will be returned in
+            chunks of the given size.
 
-        if self._iter is None:
-            self._iter = np.ndenumerate(self.data)
+        Returns
+        -------
+        val : ~np.ndarray
+            Map values.
+        pix : tuple
+            Tuple of pixel coordinates.
+        """
+        pass
 
-        try:
-            return next(self._iter)
-        except StopIteration:
-            self._iter = None
-            raise
+    @abc.abstractmethod
+    def iter_by_coords(self, buffersize=1):
+        """Iterate over elements of the map returning a tuple with values and
+        map coordinates.
 
-    next = __next__
+        Parameters
+        ----------
+        buffersize : int
+            Set the size of the buffer.  The map will be returned in
+            chunks of the given size.
+
+        Returns
+        -------
+        val : ~np.ndarray
+            Map values.
+        coords : tuple
+            Tuple of map coordinates.
+        """
+        pass
 
     @abc.abstractmethod
     def sum_over_axes(self):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -197,6 +197,23 @@ class MapBase(object):
         """Reduce to a 2D image by summing over non-spatial dimensions."""
         pass
 
+    @abc.abstractmethod
+    def reproject(self, geom):
+        """Reproject this map to a different geometry.
+
+        Parameters
+        ----------
+        geom : `~MapGeom`
+            Geometry of projection.
+
+        Returns
+        -------
+        map : `~MapBase`
+            Reprojected map.
+
+        """
+        pass
+
     def get_by_coords(self, coords, interp=None):
         """Return map values at the given map coordinates.
 
@@ -314,8 +331,8 @@ class MapBase(object):
             Weights vector. If None then a unit weight will be assumed
             for each element in `coords`.
         """
-        pix = self.geom.coord_to_pix(coords)
-        self.fill_by_idx(pix, weights)
+        idx = self.geom.coord_to_idx(coords)
+        self.fill_by_idx(idx, weights)
 
     def fill_by_pix(self, pix, weights=None):
         """Fill pixels at the given pixel coordinates with values in `weights`

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -118,13 +118,13 @@ class MapBase(object):
 
         Returns
         -------
-        out_map : `~MapBase`
+        map_out : `~MapBase`
             Map object
 
         """
         with fits.open(filename) as hdulist:
-            out_map = cls.from_hdulist(hdulist, **kwargs)
-        return out_map
+            map_out = cls.from_hdulist(hdulist, **kwargs)
+        return map_out
 
     def write(self, filename, **kwargs):
         """Write to a FITS file.

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -385,3 +385,9 @@ class MapBase(object):
             Values vector. Pixels at `idx` will be set to these values.
         """
         pass
+
+    def fill_poisson(self, mu):
+
+        pix = self.geom.get_pixels()
+        mu = np.random.poisson(mu,len(pix[0]))
+        self.fill_by_idx(pix,mu)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -159,7 +159,7 @@ class MapBase(object):
 
         Returns
         -------
-        val : ~np.ndarray
+        val : `~np.ndarray`
             Array of image plane values.
         idx : tuple
             Index of image plane.
@@ -180,7 +180,7 @@ class MapBase(object):
 
         Returns
         -------
-        val : ~np.ndarray
+        val : `~np.ndarray`
             Map values.
         pix : tuple
             Tuple of pixel coordinates.
@@ -200,7 +200,7 @@ class MapBase(object):
 
         Returns
         -------
-        val : ~np.ndarray
+        val : `~np.ndarray`
             Map values.
         coords : tuple
             Tuple of map coordinates.

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -213,13 +213,17 @@ class MapBase(object):
         pass
 
     @abc.abstractmethod
-    def reproject(self, geom):
+    def reproject(self, geom, order=1):
         """Reproject this map to a different geometry.
 
         Parameters
         ----------
         geom : `~MapGeom`
             Geometry of projection.
+
+        order : int or str
+            Order of interpolating polynomial (0 = nearest-neighbor, 1 =
+            linear, 2 = quadratic, 3 = cubic).
 
         Returns
         -------

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -214,6 +214,74 @@ class MapBase(object):
         """
         pass
 
+    @abc.abstractmethod
+    def pad(self, pad_width):
+        """Pad the spatial dimension of the map by extending the edge of the
+        map by the given number of pixels.
+
+        Parameters
+        ----------
+        pad_width : {sequence, array_like, int}
+            Number of values padded to the edges of each axis, passed to `numpy.pad`
+
+        Returns
+        -------
+        map : `~MapBase`
+            Padded map.
+        """
+        pass
+
+    @abc.abstractmethod
+    def crop(self, crop_width):
+        """Crop the spatial dimension of the map.
+
+        Parameters
+        ----------
+        crop_width : {sequence, array_like, int}
+            Number of values cropped from the edges of each axis.
+            Defined analogously to `pad_with` from `~numpy.pad`.
+
+        Returns
+        -------
+        map : `~MapBase`
+            Cropped map.
+        """
+        pass
+
+    @abc.abstractmethod
+    def downsample(self, factor):
+        """Downsample the spatial dimension of the map by a given factor. 
+
+        Parameters
+        ----------
+        factor : int
+            Downsampling factor.
+
+        Returns
+        -------
+        map : `~MapBase`
+            Downsampled map.
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def upsample(self, factor):
+        """Upsample the spatial dimension of the map by a given factor. 
+
+        Parameters
+        ----------
+        factor : int
+            Upsampling factor.
+
+        Returns
+        -------
+        map : `~MapBase`
+            Upsampled map.
+
+        """
+        pass
+
     def get_by_coords(self, coords, interp=None):
         """Return map values at the given map coordinates.
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -389,5 +389,5 @@ class MapBase(object):
     def fill_poisson(self, mu):
 
         pix = self.geom.get_pixels()
-        mu = np.random.poisson(mu,len(pix[0]))
-        self.fill_by_idx(pix,mu)
+        mu = np.random.poisson(mu, len(pix[0]))
+        self.fill_by_idx(pix, mu)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -153,6 +153,21 @@ class MapBase(object):
         hdulist.writeto(filename, overwrite=overwrite)
 
     @abc.abstractmethod
+    def iter_by_image(self):
+        """Iterate over image planes of the map returning a tuple with the image
+        array and image plane index.
+
+        Returns
+        -------
+        val : ~np.ndarray
+            Array of image plane values.
+        idx : tuple
+            Index of image plane.
+
+        """
+        pass
+
+    @abc.abstractmethod
     def iter_by_pix(self, buffersize=1):
         """Iterate over elements of the map returning a tuple with values and
         pixel coordinates.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -683,6 +683,19 @@ class MapGeom(object):
         """
         pass
 
+    @abc.abstractmethod
+    def to_image(self):
+        """Create a 2D geometry by dropping all non-spatial dimensions of this
+        geometry.
+
+        Returns
+        -------
+        geom : `~MapGeom`
+            Image geometry.
+
+        """
+        pass
+
     def _fill_header_from_axes(self, header):
 
         for i, ax in enumerate(self.axes):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -286,6 +286,20 @@ class MapAxis(object):
         pix = np.arange(nbin + 1, dtype=float) - 0.5
         self._bin_edges = self.pix_to_coord(pix)
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (np.allclose(self._nodes, other._nodes) and
+                    self._node_type == other._node_type and
+                    self._interp == other._interp and
+                    self._quantity_type == other._quantity_type and
+                    self._unit == other._unit)
+        return NotImplemented
+
+    def __ne__(self, other):
+        if isinstance(other, self.__class__):
+            return not self.__eq__(other)
+        return NotImplemented
+
     @property
     def name(self):
         """Name of the axis."""

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -156,7 +156,7 @@ def coord_to_idx(edges, x, bounded=False):
 
     if bounded:
         ibin[x < edges[0]] = 0
-        ibin[x < edges[0]] = len(edges) - 1
+        ibin[x > edges[-1]] = len(edges) - 1
     else:
         ibin[x > edges[-1]] = -1
     return ibin
@@ -415,14 +415,29 @@ class MapAxis(object):
         coord : `~numpy.ndarray`
             Array of axis coordinate values.
         bounded : bool
-
+            Choose whether to clip the index to the valid range of the
+            axis.  If false then indices for values outside the axis
+            range will be set -1.
 
         Returns
         -------
         idx : `~numpy.ndarray`
             Array of bin indices.
+
         """
         return coord_to_idx(self.edges, coord, bounded)
+
+    def coord_to_idx_interp(self, coord):
+        """Compute indices of two nearest bins to the given coordinate.
+
+        Parameters
+        ----------
+        coord : `~numpy.ndarray`
+            Array of axis coordinate values.
+        """
+
+        return (coord_to_idx(self.center[:-1], coord, bounded=True),
+                coord_to_idx(self.center[:-1], coord, bounded=True) + 1,)
 
     def slice(self, idx):
         """Create a new axis object by extracting a slice from this axis.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -715,26 +715,54 @@ class MapGeom(object):
         pass
 
     @abc.abstractmethod
-    def get_pixels(self):
-        """Get pixel indices for all pixels in this geometry.
+    def get_pixels(self, idx=None, local=False):
+        """Get tuple of pixel indices for this geometry.  Returns all pixels
+        in the geometry by default.  Pixel indices for a single image
+        plane can be accessed by setting ``idx`` to the index tuple of
+        a plane.
+
+        Parameters
+        ----------
+        idx : tuple, optional
+            A tuple of indices with one index for each non-spatial
+            dimension.  If defined only pixels for the image plane with
+            this index will be returned.  If none then all pixels
+            will be returned.
+
+        local : bool
+            Flag to return local or global pixel indices.  Local
+            indices run from 0 to the number of pixels in a given
+            image plane.
 
         Returns
         -------
         pix : tuple
-            Tuple of pixel index vectors with one element for each
+            Tuple of pixel index vectors with one vector for each
             dimension.
         """
         pass
 
     @abc.abstractmethod
-    def get_coords(self):
-        """Get the coordinates of all the pixels in this geometry.
+    def get_coords(self, idx=None):
+        """Get the coordinates of all the pixels in this geometry.  Returns
+        coordinates for all pixels in the geometry by default.
+        Coordinates for a single image plane can be accessed by
+        setting ``idx`` to the index tuple of a plane.
+
+        Parameters
+        ----------
+        idx : tuple, optional
+            A tuple of indices with one index for each non-spatial
+            dimension.  If defined only coordinates for the image
+            plane with this index will be returned.  If none then
+            coordinates for all pixels will be returned.
 
         Returns
         -------
         coords : tuple
-            Tuple of coordinate vectors with one element for each
+            Tuple of coordinate vectors with one vector for each
             dimension.
+
         """
         pass
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -146,6 +146,26 @@ def pix_tuple_to_idx(pix):
     return tuple(idx)
 
 
+def axes_pix_to_coord(axes, pix):
+    """Perform pixel to axis coordinates for a list of `~MapAxis`
+    objects.
+
+    Parameters
+    ----------
+    axes : list
+        List of `~MapAxis`.
+
+    pix : tuple
+        Tuple of pixel coordinates.
+    """
+
+    coords = []
+    for ax, t in zip(axes, pix):
+        coords += [ax.pix_to_coord(t)]
+
+    return coords
+
+
 def coord_to_idx(edges, x, bounded=False):
     """Convert axis coordinates ``x`` to bin indices.
 
@@ -168,7 +188,7 @@ def bin_to_val(edges, bins):
 
 
 def coord_to_pix(edges, coord, interp='lin'):
-    """Convert grid coordinates to pixel coordinates using the chosen
+    """Convert axis coordinates to pixel coordinates using the chosen
     interpolation scheme."""
     from scipy.interpolate import interp1d
 
@@ -545,6 +565,10 @@ class MapGeom(object):
     """Base class for WCS and HEALPix geometries."""
 
     @abc.abstractproperty
+    def allsky(self):
+        pass
+
+    @abc.abstractproperty
     def center_coord(self):
         pass
 
@@ -707,6 +731,26 @@ class MapGeom(object):
         -------
         geom : `~MapGeom`
             Image geometry.
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def to_cube(self, axes):
+        """Create a new geometry by appending a list of non-spatial axes to
+        the present geometry.  This will result in a new geometry with
+        N+M dimensions where N is the number of current dimensions and
+        M is the number of axes in the list.
+
+        Parameters
+        ----------
+        axes : list
+            Axes that will be appended to this geometry.
+
+        Returns
+        -------
+        geom : `~MapGeom`
+            Map geometry.
 
         """
         pass

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -703,7 +703,7 @@ class MapGeom(object):
             hdu = hdulist[hdu]
 
         if hdu_bands is None:
-            hdu_bands = find_bands_hdu(hdu)
+            hdu_bands = find_bands_hdu(hdulist, hdu)
 
         if hdu_bands is not None:
             hdu_bands = hdulist[hdu_bands]

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -13,7 +13,7 @@ from astropy.coordinates import SkyCoord
 from .wcs import WcsGeom
 from .geom import MapGeom, MapCoords, MapAxis, bin_to_val, pix_tuple_to_idx
 from .geom import coordsys_to_frame, skydir_to_lonlat, make_axes_cols
-from .geom import find_and_read_bands
+from .geom import find_and_read_bands, make_axes
 
 # TODO: What should be part of the public API?
 __all__ = [
@@ -404,14 +404,7 @@ class HpxGeom(MapGeom):
         # FIXME: Require NSIDE to be power of two when nest=True
 
         self._nside = np.array(nside, ndmin=1)
-        self._axes = axes if axes is not None else []
-
-        for i, ax in enumerate(self.axes):
-            if isinstance(ax, np.ndarray):
-                self.axes[i] = MapAxis(ax)
-            if self.axes[i].name == '':
-                self.axes[i].set_name('axis%i' % i)
-
+        self._axes = make_axes(axes, conv)
         self._shape = tuple([ax.nbin for ax in self._axes])
         if self.nside.size > 1 and self.nside.shape != self._shape:
             raise Exception('Wrong dimensionality for nside.  nside must '

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -728,9 +728,22 @@ class HpxGeom(MapGeom):
         return self._coordsys
 
     @property
+    def projection(self):
+        """Map projection."""
+        return 'HPX'
+
+    @property
     def region(self):
         """Region string."""
         return self._region
+
+    @property
+    def allsky(self):
+        """Flag for all-sky maps."""
+        if self._region is None:
+            return True
+        else:
+            return False
 
     @property
     def center_coord(self):
@@ -802,6 +815,11 @@ class HpxGeom(MapGeom):
     def to_image(self):
         return self.__class__(np.max(self.nside), not self.nest, coordsys=self.coordsys,
                               region=self.region, conv=self.conv)
+
+    def to_cube(self, axes):
+        axes = copy.deepcopy(self.axes) + axes
+        return self.__class__(np.max(self.nside), not self.nest, coordsys=self.coordsys,
+                              region=self.region, conv=self.conv, axes=axes)
 
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, coordsys='CEL', region=None,

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -55,6 +55,7 @@ class HpxConv(object):
 
 # Various conventions for storing HEALPIX maps in FITS files
 HPX_FITS_CONVENTIONS = OrderedDict()
+HPX_FITS_CONVENTIONS[None] = HpxConv('GADF', bands_hdu='BANDS')
 HPX_FITS_CONVENTIONS['GADF'] = HpxConv('GADF', bands_hdu='BANDS')
 HPX_FITS_CONVENTIONS['FGST_CCUBE'] = HpxConv('FGST_CCUBE')
 HPX_FITS_CONVENTIONS['FGST_LTCUBE'] = HpxConv(
@@ -397,7 +398,7 @@ class HpxGeom(MapGeom):
     """
 
     def __init__(self, nside, nest=True, coordsys='CEL', region=None,
-                 axes=None, conv=HpxConv('FGST_CCUBE'), sparse=False):
+                 axes=None, conv='GADF', sparse=False):
 
         # FIXME: Figure out what to do when sparse=True
         # FIXME: Require NSIDE to be power of two when nest=True
@@ -815,7 +816,7 @@ class HpxGeom(MapGeom):
 
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, coordsys='CEL', region=None,
-               axes=None, conv=HpxConv('FGST_CCUBE'), skydir=None, width=None):
+               axes=None, conv='GADF', skydir=None, width=None):
         """Create an HpxGeom object.
 
         Parameters
@@ -836,14 +837,31 @@ class HpxGeom(MapGeom):
             object or a tuple of longitude and latitude in deg in the
             coordinate system of the map.
         region  : str
-            Allows for partial-sky mappings
+            HPX region string.  Allows for partial-sky maps.
+        width : float
+            Diameter of the map in degrees.  If set the map will
+            encompass all pixels within a circular region centered on
+            ``skydir``.
         axes : list
-            List of axes for non-spatial dimensions
+            List of axes for non-spatial dimensions.
+        conv : str
+            Convention for FITS file format.
 
         Returns
         -------
         geom : `~HpxGeom`
-            A HEALPix geoemtry object.
+            A HEALPix geometry object.
+
+        Examples
+        --------
+        >>> from gammapy.maps import HpxGeom
+        >>> from gammapy.maps import MapAxis
+        >>> axis = MapAxis.from_bounds(0,1,2)
+        >>> geom = HpxGeom.create(nside=16)
+        >>> geom = HpxGeom.create(binsz=0.1, width=10.0)
+        >>> geom = HpxGeom.create(nside=64, width=10.0, axes=[axis])
+        >>> geom = HpxGeom.create(nside=[32,64], width=10.0, axes=[axis])
+
         """
 
         if nside is None and binsz is None:

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -10,7 +10,7 @@ from astropy.extern.six.moves import range
 from astropy.io import fits
 from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
-from .wcs import WCSGeom
+from .wcs import WcsGeom
 from .geom import MapGeom, MapCoords, MapAxis, bin_to_val, pix_tuple_to_idx
 from .geom import coordsys_to_frame, skydir_to_lonlat, make_axes_cols
 from .geom import find_and_read_bands
@@ -251,7 +251,7 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
     ----------
     hpx : `~gammapy.maps.hpx.HpxGeom`
        The HEALPIX geometry
-    wcs : `~gammapy.maps.wcs.WCSGeom`
+    wcs : `~gammapy.maps.wcs.WcsGeom`
        The WCS geometry
 
     Returns
@@ -267,7 +267,7 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
     npix = wcs.npix
 
     # FIXME: Calculation of WCS pixel centers should be moved into a
-    # method of WCSGeom
+    # method of WcsGeom
     pix_crds = np.dstack(np.meshgrid(np.arange(npix[0]), np.arange(npix[1])))
     pix_crds = pix_crds.swapaxes(0, 1).reshape((-1, 2))
     sky_crds = wcs.wcs.wcs_pix2world(pix_crds, 0)
@@ -1234,7 +1234,7 @@ class HpxGeom(MapGeom):
 
         Returns
         -------
-        wcs : `~gammapy.maps.wcs.WCSGeom`
+        wcs : `~gammapy.maps.wcs.WcsGeom`
             WCS geometry
         """
 
@@ -1251,7 +1251,7 @@ class HpxGeom(MapGeom):
         else:
             axes = copy.deepcopy(self.axes)
 
-        geom = WCSGeom.create(width=width, binsz=binsz, coordsys=self.coordsys,
+        geom = WcsGeom.create(width=width, binsz=binsz, coordsys=self.coordsys,
                               axes=axes, skydir=skydir)
 
         return geom
@@ -1353,7 +1353,7 @@ class HpxToWcsMapping(object):
     ----------
     hpx : `~HpxGeom`
         HEALPix geometry object.
-    wcs : `~gammapy.maps.wcs.WCSGeom`
+    wcs : `~gammapy.maps.wcs.WcsGeom`
         WCS geometry object.
     """
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -799,14 +799,7 @@ class HpxGeom(MapGeom):
         return self.__class__(self.nside, not self.nest, coordsys=self.coordsys,
                               region=self.region, axes=self.axes, conv=self.conv)
 
-    def copy_and_drop_axes(self):
-        """Make a copy of the spatial component of this geometry.
-
-        Returns
-        -------
-        geom : `~HpxGeom`
-            A HEALPix geoemtry object.
-        """
+    def to_image(self):
         return self.__class__(np.max(self.nside), not self.nest, coordsys=self.coordsys,
                               region=self.region, conv=self.conv)
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -873,7 +873,7 @@ class HpxGeom(MapGeom):
         if skydir is None:
             lonlat = (0.0, 0.0)
         elif isinstance(skydir, tuple):
-            pass
+            lonlat = skydir
         elif isinstance(skydir, SkyCoord):
             lonlat = skydir_to_lonlat(skydir, coordsys=coordsys)
         else:
@@ -1261,8 +1261,8 @@ class HpxGeom(MapGeom):
         width = (2.0 * self.get_region_size(self._region) +
                  np.max(get_pixel_size_from_nside(self.nside)))
 
-        if width > 45.:
-            width = (180., 90.0)
+        if width > 90.:
+            width = (min(360., width), min(180.0, width))
 
         if drop_axes:
             axes = None
@@ -1270,7 +1270,7 @@ class HpxGeom(MapGeom):
             axes = copy.deepcopy(self.axes)
 
         geom = WcsGeom.create(width=width, binsz=binsz, coordsys=self.coordsys,
-                              axes=axes, skydir=skydir)
+                              axes=axes, skydir=skydir, proj=proj)
 
         return geom
 

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -196,6 +196,18 @@ class HpxMapND(HpxMap):
     def reproject(self, geom):
         raise NotImplementedError
 
+    def pad(self, pad_width):
+        raise NotImplementedError
+
+    def crop(self, crop_width):
+        raise NotImplementedError
+
+    def upsample(self, factor):
+        raise NotImplementedError
+
+    def downsample(self, factor):
+        raise NotImplementedError
+
     def interp_by_coords(self, coords, interp=None):
 
         if interp == 'linear':

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -197,8 +197,27 @@ class HpxMapND(HpxMap):
 
         return map_out
 
-    def reproject(self, geom):
-        raise NotImplementedError
+    def _reproject_wcs(self, geom, order=1, mode='interp'):
+
+        map_out = WcsMapND(geom)
+        axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
+                          zip(geom.axes, self.geom.axes)])
+
+        for vals, idx in map_out.iter_by_image():
+            pass
+
+        return map_out
+
+    def _reproject_hpx(self, geom, order=1, mode='interp'):
+
+        map_out = HpxMapND(geom)
+        axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
+                          zip(geom.axes, self.geom.axes)])
+
+        for vals, idx in map_out.iter_by_image():
+            pass
+
+        return map_out
 
     def pad(self, pad_width):
         raise NotImplementedError

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from .utils import unpack_seq
 from .geom import MapCoords, pix_tuple_to_idx, coord_to_idx
 from .hpxmap import HpxMap
 from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order
@@ -161,6 +162,20 @@ class HpxMapND(HpxMap):
     def get_pixel_skydirs(self):
         """Get a list of sky coordinates for the centers of every pixel. """
         return self._hpx.get_skydirs()
+
+    def iter_by_pix(self, buffersize=1):
+        pix = list(self.geom.get_pixels())
+        vals = self.data[np.isfinite(self.data)]
+        return unpack_seq(np.nditer([vals] + pix,
+                                    flags=['external_loop', 'buffered'],
+                                    buffersize=buffersize))
+
+    def iter_by_coords(self, buffersize=1):
+        coords = list(self.geom.get_coords())
+        vals = self.data[np.isfinite(self.data)]
+        return unpack_seq(np.nditer([vals] + coords,
+                                    flags=['external_loop', 'buffered'],
+                                    buffersize=buffersize))
 
     def sum_over_axes(self):
         """Sum over all non-spatial dimensions."""

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -51,18 +51,18 @@ class HpxMapND(HpxMap):
         self._hpx2wcs = None
 
     @classmethod
-    def from_hdu(cls, hdu, axes):
+    def from_hdu(cls, hdu, hdu_bands=None):
         """Make a HpxMapND object from a FITS HDU.
 
         Parameters
         ----------
         hdu : `~astropy.fits.BinTableHDU`
             The FITS HDU
-        axes : list
-            List of axes for non-spatial dimensions.
+        hdu_bands  : `~astropy.fits.BinTableHDU`
+            The BANDS table HDU
         """
-        hpx = HpxGeom.from_header(hdu.header, axes)
-        shape = tuple([ax.nbin for ax in axes[::-1]])
+        hpx = HpxGeom.from_header(hdu.header, hdu_bands)
+        shape = tuple([ax.nbin for ax in hpx.axes[::-1]])
         shape_data = shape + tuple(np.unique(hpx.npix))
 
         # FIXME: We need to assert here if the file is incompatible

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -163,6 +163,10 @@ class HpxMapND(HpxMap):
         """Get a list of sky coordinates for the centers of every pixel. """
         return self._hpx.get_skydirs()
 
+    def iter_by_image(self):
+        for idx in np.ndindex(self.geom.shape):
+            yield self.data[idx[::-1]], idx
+
     def iter_by_pix(self, buffersize=1):
         pix = list(self.geom.get_pixels())
         vals = self.data[np.isfinite(self.data)]

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -180,18 +180,21 @@ class HpxMapND(HpxMap):
     def sum_over_axes(self):
         """Sum over all non-spatial dimensions."""
 
-        hpx_out = self.hpx.copy_and_drop_axes()
+        hpx_out = self.hpx.to_image()
         map_out = self.__class__(hpx_out)
 
         if self.hpx.nside.size > 1:
             vals = self.get_by_idx(self.hpx.get_pixels())
             map_out.fill_by_coords(self.hpx.get_coords()[:2], vals)
         else:
-            data = np.apply_over_axes(np.sum, self.data,
-                                      axes=np.arange(self.data.ndim - 1))
-            map_out.data = data
+            axes = np.arange(self.data.ndim - 1).tolist()
+            data = np.apply_over_axes(np.sum, self.data, axes=axes)
+            map_out.data = np.squeeze(data, axis=axes)
 
         return map_out
+
+    def reproject(self, geom):
+        raise NotImplementedError
 
     def interp_by_coords(self, coords, interp=None):
 

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -132,7 +132,7 @@ class HpxMapND(HpxMap):
                                   oversample=oversample)
 
         # FIXME: Check whether the old mapping is still valid and reuse it
-        self.make_wcs_mapping(oversample=oversample)
+        self.make_wcs_mapping(oversample=oversample, proj=proj)
 
         # FIXME: Need a function to extract a valid shape from npix property
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -5,54 +5,12 @@ import re
 import numpy as np
 from astropy.io import fits
 from .base import MapBase
-from .hpx import HpxGeom
-from .geom import MapAxis
+from .hpx import HpxGeom, HpxConv
+from .geom import MapAxis, find_and_read_bands
 
 __all__ = [
     'HpxMap',
 ]
-
-
-def find_and_read_bands(hdulist, extname=None):
-    """Read and returns the energy bin edges.
-
-    This works for both the CASE where the energies are in the ENERGIES HDU
-    and the case where they are in the EBOUND HDU
-    """
-    axes = []
-    axis_cols = []
-    if extname is not None and extname in hdulist:
-        hdu = hdulist[extname]
-        for i in range(5):
-            if 'AXCOLS%i' % i in hdu.header:
-                axis_cols += [hdu.header['AXCOLS%i' % i].split(',')]
-            else:
-                break
-    elif 'ENERGIES' in hdulist:
-        hdu = hdulist['ENERGIES']
-        axis_cols = [['ENERGY']]
-    elif 'EBOUNDS' in hdulist:
-        hdu = hdulist['EBOUNDS']
-        axis_cols = [['E_MIN', 'E_MAX']]
-
-    for i, cols in enumerate(axis_cols):
-
-        if 'ENERGY' in cols or 'E_MIN' in cols:
-            name = 'energy'
-        elif re.search('(.+)_MIN', cols[0]):
-            name = re.search('(.+)_MIN', cols[0]).group(1)
-        else:
-            name = cols[0]
-
-        if len(cols) == 2:
-            xmin = np.unique(hdu.data.field(cols[0]))  # / 1E3
-            xmax = np.unique(hdu.data.field(cols[1]))  # / 1E3
-            axes += [MapAxis(np.append(xmin, xmax[-1]), name=name)]
-        else:
-            x = np.unique(hdu.data.field(cols[0]))
-            axes += [MapAxis.from_nodes(x, name=name)]
-
-    return axes
 
 
 class HpxMap(MapBase):
@@ -115,34 +73,12 @@ class HpxMap(MapBase):
         hpx = HpxGeom.create(nside=nside, binsz=binsz,
                              nest=nest, coordsys=coordsys, region=region,
                              conv=None, axes=axes, skydir=skydir, width=width)
-        if map_type in [None,'hpx','HpxMapND']:
+        if map_type in [None, 'hpx', 'HpxMapND']:
             return HpxMapND(hpx, dtype=dtype)
-        elif map_type in ['hpx-sparse','HpxMapSparse']:
+        elif map_type in ['hpx-sparse', 'HpxMapSparse']:
             return HpxMapSparse(hpx, dtype=dtype)
         else:
             raise ValueError('Unregnized Map type: {}'.format(map_type))
-
-    @classmethod
-    def read(cls, filename, **kwargs):
-        """Read from a FITS file.
-
-        Parameters
-        ----------
-        filename : str
-            Name of the FITS file.
-        hdu : str
-            Name or index of the HDU with the map data.
-        hdu_bands : str
-            Name or index of the HDU with the BANDS table.
-
-        Returns
-        -------
-        hpx_map : `~HpxMap`
-            Map object
-        """
-        with fits.open(filename) as hdulist:
-            hpx_map = cls.from_hdulist(hdulist, **kwargs)
-        return hpx_map
 
     @classmethod
     def from_hdulist(cls, hdulist, **kwargs):
@@ -169,41 +105,21 @@ class HpxMap(MapBase):
         if 'BANDSHDU' in hdu.header and extname_bands is None:
             extname_bands = hdu.header['BANDSHDU']
 
-        axes = find_and_read_bands(hdulist, extname=extname_bands)
-        return cls.from_hdu(hdu, axes)
+        hdu_bands = None
+        if extname_bands is not None:
+            hdu_bands = hdulist[extname_bands]
 
-    def write(self, filename, **kwargs):
-        """Write to a FITS file.
-
-        Parameters
-        ----------
-        filename : str
-            Output file name.
-        extname : str
-            Set the name of the image extension.  By default this will
-            be set to SKYMAP.
-        extname_bands : str
-            Set the name of the binning extension.  By default this will
-            be set to BANDS.
-        hpxconv : str
-            HEALPix format convention.  This option can be used to
-            write files that are compliant with non-standard HEALPix
-            conventions.
-        sparse : bool
-            Sparsify the map by dropping pixels with zero amplitude.
-
-        """
-        hdulist = self.to_hdulist(**kwargs)
-        overwrite = kwargs.get('overwrite', True)
-        hdulist.writeto(filename, overwrite=overwrite)
+        return cls.from_hdu(hdu, hdu_bands)
 
     def to_hdulist(self, **kwargs):
 
         extname = kwargs.get('extname', 'SKYMAP')
-        extname_bands = kwargs.get('extname_bands', self.hpx.conv.bands_hdu)
+        #extname_bands = kwargs.get('extname_bands', self.hpx.conv.bands_hdu)
+        extname_bands = kwargs.get('extname_bands', 'BANDS')
         hdulist = [fits.PrimaryHDU(), self.make_hdu(**kwargs)]
-        if self.hpx.axes:
-            hdulist += [self.hpx.make_bands_hdu(extname=extname_bands)]
+
+        if self.geom.axes:
+            hdulist += [self.geom.make_bands_hdu(extname=extname_bands)]
         return fits.HDUList(hdulist)
 
     @abc.abstractmethod
@@ -259,15 +175,20 @@ class HpxMap(MapBase):
         # FIXME: Should this be a method of HpxMapND?
         # FIXME: Should we assign extname in this method?
 
+        conv = kwargs.get('conv', HpxConv.create('GADF'))
+
         data = self.data
         shape = data.shape
-        extname = kwargs.get('extname', self.hpx.conv.extname)
-        extname_bands = kwargs.get('extname_bands', self.hpx.conv.bands_hdu)
-        convname = kwargs.get('convname', self.hpx.conv.convname)
+        extname = kwargs.get('extname', conv.extname)
+        extname_bands = kwargs.get('extname_bands', conv.bands_hdu)
+        #convname = kwargs.get('convname', self.hpx.conv.convname)
+        extname_bands = conv.bands_hdu
+
         sparse = kwargs.get('sparse', False)
         header = self.hpx.make_header()
-        conv = self.hpx.conv
-        header['BANDSHDU'] = extname_bands
+
+        if self.geom.axes:
+            header['BANDSHDU'] = extname_bands
 
         if sparse:
             header['INDXSCHM'] = 'SPARSE'

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -84,9 +84,6 @@ class HpxMapSparse(HpxMap):
     def sum_over_axes(self):
         raise NotImplementedError
 
-    def reproject(self, geom):
-        raise NotImplementedError
-
     def pad(self, pad_width):
         raise NotImplementedError
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -81,6 +81,9 @@ class HpxMapSparse(HpxMap):
     def sum_over_axes(self):
         raise NotImplementedError
 
+    def reproject(self, geom):
+        raise NotImplementedError
+
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
         raise NotImplementedError
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -84,6 +84,18 @@ class HpxMapSparse(HpxMap):
     def reproject(self, geom):
         raise NotImplementedError
 
+    def pad(self, pad_width):
+        raise NotImplementedError
+
+    def crop(self, crop_width):
+        raise NotImplementedError
+
+    def upsample(self, factor):
+        raise NotImplementedError
+
+    def downsample(self, factor):
+        raise NotImplementedError
+
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
         raise NotImplementedError
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -72,6 +72,9 @@ class HpxMapSparse(HpxMap):
         idx = ravel_hpx_index(idx, self.hpx.npix)
         self.data[0, idx] = vals
 
+    def iter_by_image(self):
+        raise NotImplementedError
+
     def iter_by_pix(self):
         raise NotImplementedError
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -72,6 +72,12 @@ class HpxMapSparse(HpxMap):
         idx = ravel_hpx_index(idx, self.hpx.npix)
         self.data[0, idx] = vals
 
+    def iter_by_pix(self):
+        raise NotImplementedError
+
+    def iter_by_coords(self):
+        raise NotImplementedError
+
     def sum_over_axes(self):
         raise NotImplementedError
 

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -1,0 +1,123 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+import astropy.units as u
+
+__all__ = [
+    'reproject_car_to_hpx',
+    'reproject_car_to_wcs',
+]
+
+
+def _get_input_pixels_celestial(wcs_in, wcs_out, shape_out):
+    """
+    Get the pixel coordinates of the pixels in an array of shape ``shape_out``
+    in the input WCS.
+    """
+
+    from reproject.wcs_utils import convert_world_coordinates
+
+    # TODO: for now assuming that coordinates are spherical, not
+    # necessarily the case. Also assuming something about the order of the
+    # arguments.
+
+    # Generate pixel coordinates of output image
+    xp_out, yp_out = np.indices(shape_out, dtype=float)[::-1]
+
+    # Convert output pixel coordinates to pixel coordinates in original image
+    # (using pixel centers).
+    xw_out, yw_out = wcs_out.wcs_pix2world(xp_out, yp_out, 0)
+
+    xw_in, yw_in = convert_world_coordinates(xw_out, yw_out, wcs_out, wcs_in)
+
+    xp_in, yp_in = wcs_in.wcs_world2pix(xw_in, yw_in, 0)
+
+    return xp_in, yp_in
+
+
+def reproject_car_to_hpx(input_data, coord_system_out,
+                         nside, order=1, nested=False):
+
+    import healpy as hp
+    from scipy.ndimage import map_coordinates
+    from reproject.wcs_utils import convert_world_coordinates
+    from reproject.healpix.utils import parse_coord_system
+
+    data, wcs_in = input_data
+
+    npix = hp.nside2npix(nside)
+
+    theta, phi = hp.pix2ang(nside, np.arange(npix), nested)
+    lon_out = np.degrees(phi)
+    lat_out = 90. - np.degrees(theta)
+
+    # Convert between celestial coordinates
+    coord_system_out = parse_coord_system(coord_system_out)
+    with np.errstate(invalid='ignore'):
+        lon_in, lat_in = convert_world_coordinates(lon_out, lat_out,
+                                                   (coord_system_out, u.deg, u.deg), wcs_in)
+
+    # Look up pixels in input system
+    yinds, xinds = wcs_in.wcs_world2pix(lon_in, lat_in, 0)
+
+    # Interpolate
+    data = np.pad(data, 3, mode='wrap')
+
+    healpix_data = map_coordinates(data, [xinds + 3, yinds + 3],
+                                   order=order,
+                                   mode='wrap', cval=np.nan)
+
+    return healpix_data, (~np.isnan(healpix_data)).astype(float)
+
+
+def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
+    """Reproject an all-sky CAR projection to another WCS projection.
+    This method performs special handling of the projection edges to
+    ensure that the interpolation of the CAR projection is correctly
+    wrapped in longitude.
+    """
+    from scipy.ndimage import map_coordinates
+
+    slice_in, wcs_in = input_data
+
+    array_new = np.zeros(shape_out)
+    slice_out = array_new
+
+    xp_in, yp_in = _get_input_pixels_celestial(wcs_in.celestial,
+                                               wcs_out.celestial,
+                                               slice_out.shape)
+    coordinates = np.array([yp_in.ravel(), xp_in.ravel()])
+
+    jmin, imin = np.floor(np.nanmin(coordinates, axis=1)).astype(int) - 1
+    jmax, imax = np.ceil(np.nanmax(coordinates, axis=1)).astype(int) + 1
+
+    ny, nx = slice_in.shape
+
+    if imin >= nx or imax < 0 or jmin >= ny or jmax < 0:
+        return array_new * np.nan, array_new.astype(float)
+
+    subset = None
+    # Now, we check whether there is any point in defining a subset
+    if 0 and (imin > 0 or imax < nx or jmin > 0 or jmax < ny):
+        subset = (slice(max(jmin, 0), min(jmax, ny)),
+                  slice(max(imin, 0), min(imax, nx)))
+        if imin > 0:
+            coordinates[1] -= imin
+        if jmin > 0:
+            coordinates[0] -= jmin
+
+    if subset is not None:
+        slice_in = slice_in[subset]
+
+    # Pad by 3 pixels to ensure that cubic interpolation works
+    slice_in = np.pad(slice_in, 3, mode='wrap')
+
+    # Make sure image is floating point. We do this only now because
+    # we want to avoid converting the whole input array if possible
+    slice_in = np.asarray(slice_in, dtype=float)
+    slice_out[:, :] = map_coordinates(slice_in,
+                                      coordinates + 3,
+                                      order=order, cval=np.nan,
+                                      mode='wrap').reshape(slice_out.shape)
+
+    return array_new, (~np.isnan(array_new)).astype(float)

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -96,19 +96,6 @@ def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
     if imin >= nx or imax < 0 or jmin >= ny or jmax < 0:
         return array_new * np.nan, array_new.astype(float)
 
-    subset = None
-    # Now, we check whether there is any point in defining a subset
-    if 0 and (imin > 0 or imax < nx or jmin > 0 or jmax < ny):
-        subset = (slice(max(jmin, 0), min(jmax, ny)),
-                  slice(max(imin, 0), min(imax, nx)))
-        if imin > 0:
-            coordinates[1] -= imin
-        if jmin > 0:
-            coordinates[0] -= jmin
-
-    if subset is not None:
-        slice_in = slice_in[subset]
-
     # Pad by 3 pixels to ensure that cubic interpolation works
     slice_in = np.pad(slice_in, 3, mode='wrap')
 
@@ -118,6 +105,6 @@ def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
     slice_out[:, :] = map_coordinates(slice_in,
                                       coordinates + 3,
                                       order=order, cval=np.nan,
-                                      mode='wrap').reshape(slice_out.shape)
+                                      mode='constant').reshape(slice_out.shape)
 
     return array_new, (~np.isnan(array_new)).astype(float)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -321,6 +321,26 @@ def test_hpxgeom_get_coords():
     assert_allclose(c[2][:3], np.array([0.5, 1.5, 1.5]))
 
 
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_geoms)
+def test_hpxgeom_contains(nside, nested, coordsys, region, axes):
+    geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
+    coords = geom.get_coords()
+    assert_allclose(geom.contains(coords), np.ones(
+        coords[0].shape, dtype=bool))
+
+    if axes is not None:
+
+        coords = [c[0] for c in coords[:2]] + \
+            [ax.edges[-1] + 1.0 for ax in axes]
+        assert_allclose(geom.contains(coords), np.zeros((1,), dtype=bool))
+
+    if geom.region is not None:
+
+        coords = [0.0, 0.0] + [ax.center[0] for ax in geom.axes]
+        assert_allclose(geom.contains(coords), np.zeros((1,), dtype=bool))
+
+
 def test_make_hpx_to_wcs_mapping():
     ax0 = np.linspace(0., 1., 3)
     hpx = HpxGeom(16, False, 'GAL', region='DISK(110.,75.,2.)')

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -16,6 +16,8 @@ hpx_allsky_test_geoms = [
     (8, False, 'GAL', None, None),
     # 3D All-sky
     (8, False, 'GAL', None, [MapAxis(np.logspace(0., 3., 4))]),
+    # 3D All-sky w/ variable pixel size
+    ([2, 4, 8], False, 'GAL', None, [MapAxis(np.logspace(0., 3., 4))]),
     # 4D All-sky
     (8, False, 'GAL', None, [MapAxis(np.logspace(0., 3., 3), name='axis0'),
                              MapAxis(np.logspace(0., 2., 4), name='axis1')]),
@@ -26,10 +28,10 @@ hpx_partialsky_test_geoms = [
     (8, False, 'GAL', 'DISK(110.,75.,10.)', None),
     # 3D Partial-sky
     (8, False, 'GAL', 'DISK(110.,75.,10.)', [MapAxis(np.logspace(0., 3., 4))]),
-    # 3D Partial-sky w/ variable bin size
+    # 3D Partial-sky w/ variable pixel size
     ([8, 16, 32], False, 'GAL', 'DISK(110.,75.,10.)',
      [MapAxis(np.logspace(0., 3., 4))]),
-    # 4D Partial-sky w/ variable bin size
+    # 4D Partial-sky w/ variable pixel size
     ([[8, 16, 32], [8, 8, 16]], False, 'GAL', 'DISK(110.,75.,10.)',
      [MapAxis(np.logspace(0., 3., 3), name='axis0'),
       MapAxis(np.logspace(0., 2., 4), name='axis1')])
@@ -161,6 +163,21 @@ def test_hpxgeom_to_slice(nside, nested, coordsys, region, axes):
         assert_allclose(pix_slice, (pix[0][m],))
     else:
         assert_allclose(pix_slice, pix)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_geoms)
+def test_hpxgeom_get_pixels(nside, nested, coordsys, region, axes):
+
+    geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
+    pix = geom.get_pixels(local=False)
+    pix_local = geom.get_pixels(local=True)
+    assert_allclose(pix, geom.local_to_global(pix_local))
+
+    if axes is not None:
+        pix_img = geom.get_pixels(local=False, idx=tuple([1] * len(axes)))
+        pix_img_local = geom.get_pixels(local=True, idx=tuple([1] * len(axes)))
+        assert_allclose(pix_img, geom.local_to_global(pix_img_local))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),

--- a/gammapy/maps/tests/test_hpxcube.py
+++ b/gammapy/maps/tests/test_hpxcube.py
@@ -108,6 +108,19 @@ def test_hpxcube_fill_by_coords(nside, nested, coordsys, region, axes):
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
+def test_hpxcube_iter(nside, nested, coordsys, region, axes):
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    coords = m.geom.get_coords()
+    m.fill_by_coords(coords, coords[0])
+    for vals, pix in m.iter_by_pix(buffersize=100):
+        assert_allclose(vals, m.get_by_pix(pix))
+    for vals, coords in m.iter_by_coords(buffersize=100):
+        assert_allclose(vals, m.get_by_coords(coords))
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_geoms)
 def test_hpxcube_to_wcs(nside, nested, coordsys, region, axes):
     m = HpxMapND(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))

--- a/gammapy/maps/tests/test_hpxcube.py
+++ b/gammapy/maps/tests/test_hpxcube.py
@@ -145,3 +145,13 @@ def test_hpxcube_ud_grade(nside, nested, coordsys, region, axes):
     m = HpxMapND(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     m.to_ud_graded(4)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_geoms)
+def test_hpxcube_sum_over_axes(nside, nested, coordsys, region, axes):
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    coords = m.geom.get_coords()
+    m.fill_by_coords(coords, coords[0])
+    msum = m.sum_over_axes()

--- a/gammapy/maps/tests/test_hpxcube.py
+++ b/gammapy/maps/tests/test_hpxcube.py
@@ -10,9 +10,12 @@ from ..hpxcube import HpxMapND
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
 
+axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
+
 hpx_test_geoms = [
     (8, False, 'GAL', None, None),
-    (8, False, 'GAL', None, [MapAxis(np.logspace(0., 3., 4))]),
+    (8, False, 'GAL', None, axes1),
+    ([4, 8], False, 'GAL', None, axes1),
     (8, False, 'GAL', 'DISK(110.,75.,10.)',
      [MapAxis(np.logspace(0., 3., 4))]),
     (8, False, 'GAL', 'DISK(110.,75.,10.)',
@@ -24,8 +27,9 @@ hpx_test_geoms = [
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxcube_init(nside, nested, coordsys, region, axes):
-    geom = HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes)
-    shape = [int(np.unique(geom.npix))]
+    geom = HpxGeom(nside=nside, nest=nested,
+                   coordsys=coordsys, region=region, axes=axes)
+    shape = [int(np.max(geom.npix))]
     if axes:
         shape += [ax.nbin for ax in axes]
     shape = shape[::-1]
@@ -47,9 +51,9 @@ def test_hpxcube_create(nside, nested, coordsys, region, axes):
                          hpx_test_geoms)
 def test_hpxcube_read_write(tmpdir, nside, nested, coordsys, region, axes):
     filename = str(tmpdir / 'skycube.fits')
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
-    data = np.random.poisson(0.1, m.data.shape)
-    m.data[...] = data
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.fill_poisson(0.5)
     m.write(filename)
     m2 = HpxMapND.read(filename)
     assert_allclose(m.data, m2.data)
@@ -60,57 +64,53 @@ def test_hpxcube_read_write(tmpdir, nside, nested, coordsys, region, axes):
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
-def test_hpxcube_get_by_pix(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
-    data = np.linspace(0, m.data.size - 1.0, m.data.size).reshape(m.data.shape)
-    m.data[...] = data
+def test_hpxcube_set_get_by_pix(nside, nested, coordsys, region, axes):
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    coords = m.hpx.get_coords()
     pix = m.hpx.get_pixels()
-    assert_allclose(np.ravel(m.data), m.get_by_pix(pix))
+    m.set_by_pix(pix, coords[0])
+    assert_allclose(coords[0], m.get_by_pix(pix))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
-def test_hpxcube_get_by_coords(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
-    data = np.linspace(0, m.data.size - 1.0, m.data.size).reshape(m.data.shape)
-    m.data[...] = data
+def test_hpxcube_set_get_by_coords(nside, nested, coordsys, region, axes):
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
     coords = m.hpx.get_coords()
-    assert_allclose(np.ravel(m.data), m.get_by_coords(coords))
+    m.set_by_coords(coords, coords[0])
+    assert_allclose(coords[0], m.get_by_coords(coords))
 
 
 @pytest.mark.xfail(reason="Bug in healpy <= 0.10.3")
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxcube_get_by_coords_interp(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
     coords = m.hpx.get_coords()
-    m.data[...] = coords[1].reshape(m.data.shape)
-    assert_allclose(np.ravel(m.data), m.get_by_coords(coords, interp='linear'))
+    m.set_by_coords(coords, coords[1])
+    assert_allclose(m.get_by_coords(coords),
+                    m.get_by_coords(coords, interp='linear'))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxcube_fill_by_coords(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
     coords = m.hpx.get_coords()
     m.fill_by_coords(coords, coords[1])
     m.fill_by_coords(coords, coords[1])
-    assert_allclose(np.ravel(m.data), 2.0 * coords[1])
-
-
-@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
-                         hpx_test_geoms)
-def test_hpxcube_set_by_coords(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
-    coords = m.hpx.get_coords()
-    m.set_by_coords(coords, coords[1])
-    assert_allclose(np.ravel(m.data), coords[1])
+    assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxcube_to_wcs(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
     m_wcs = m.to_wcs(sum_bands=False, oversample=2, normalize=False)
     m_wcs = m.to_wcs(sum_bands=True, oversample=2, normalize=False)
 
@@ -118,8 +118,9 @@ def test_hpxcube_to_wcs(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxcube_swap_scheme(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
-    m.data[...] = np.random.poisson(1.0, m.data.shape)
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.fill_poisson(1.0)
     m2 = m.to_swapped_scheme()
     coords = m.hpx.get_coords()
     assert_allclose(m.get_by_coords(coords), m2.get_by_coords(coords))
@@ -128,5 +129,6 @@ def test_hpxcube_swap_scheme(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxcube_ud_grade(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes))
-    m.to_ud_graded(m.hpx.order - 1)
+    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.to_ud_graded(4)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -30,14 +30,28 @@ wcs_test_geoms = wcs_allsky_test_geoms
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsgeom_init(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WcsGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
+def test_wcsgeom_get_pixels(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    pix = geom.get_pixels()
+    if axes is not None:
+        idx = tuple([1] * len(axes))
+        pix_img = geom.get_pixels(idx=idx)
+        m = np.all(np.stack([x == y for x, y in zip(idx, pix[2:])]), axis=0)
+        assert_allclose(pix[0][m], pix_img[0])
+        assert_allclose(pix[1][m], pix_img[1])
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
 def test_wcsgeom_test_pix_to_coord(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WcsGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     assert_allclose(geom.get_coords()[0],
                     geom.pix_to_coord(geom.get_pixels())[0])
@@ -56,9 +70,9 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
                          wcs_test_geoms)
 def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom0 = WcsGeom.create(npix=npix, binsz=binsz,
-                          proj=proj, coordsys=coordsys, axes=axes)
+                           proj=proj, coordsys=coordsys, axes=axes)
 
-    shape = (np.max(geom0.npix[0]),np.max(geom0.npix[1]))
+    shape = (np.max(geom0.npix[0]), np.max(geom0.npix[1]))
     hdu_bands = geom0.make_bands_hdu(extname='BANDS')
     hdu_prim = fits.PrimaryHDU(np.zeros(shape).T)
     hdu_prim.header.update(geom0.make_header())

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
-from ..wcs import WCSGeom
+from ..wcs import WcsGeom
 from ..geom import MapAxis
 
 pytest.importorskip('scipy')
@@ -30,14 +30,14 @@ wcs_test_geoms = wcs_allsky_test_geoms
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsgeom_init(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WCSGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsgeom_test_pix_to_coord(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WCSGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     assert_allclose(geom.get_coords()[0],
                     geom.pix_to_coord(geom.get_pixels())[0])
@@ -46,7 +46,7 @@ def test_wcsgeom_test_pix_to_coord(npix, binsz, coordsys, proj, skydir, axes):
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WCSGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     assert_allclose(geom.get_pixels()[0],
                     geom.coord_to_idx(geom.get_coords())[0])
@@ -55,7 +55,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
-    geom0 = WCSGeom.create(npix=npix, binsz=binsz,
+    geom0 = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
 
     shape = (np.max(geom0.npix[0]),np.max(geom0.npix[1]))
@@ -68,7 +68,7 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     hdulist.writeto(filename, overwrite=True)
 
     hdulist = fits.open(filename)
-    geom1 = WCSGeom.from_header(hdulist[0].header, hdulist['BANDS'])
+    geom1 = WcsGeom.from_header(hdulist[0].header, hdulist['BANDS'])
 
     assert_allclose(geom0.npix, geom1.npix)
     assert(geom0.coordsys == geom1.coordsys)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -64,3 +64,15 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     m0.write(filename, sparse=True)
     m1 = WcsMapND.read(filename)
     assert_allclose(m0.data, m1.data)
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsmapnd_fill_by_coords(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
+    geom = WCSGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsMapND(geom)
+    coords = m.geom.get_coords()
+    m.fill_by_coords(tuple([np.concatenate((t, t)) for t in coords]),
+                     np.concatenate((coords[1], coords[1])))
+    assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -12,6 +12,7 @@ from ..wcsnd import WcsMapND
 
 
 pytest.importorskip('scipy')
+pytest.importorskip('reproject')
 
 axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
 axes2 = [MapAxis(np.logspace(0., 3., 3), interp='log'),
@@ -111,6 +112,9 @@ def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj,
                           skydir=skydir, coordsys=coordsys, axes=axes)
     m = WcsMapND(geom)
+
+    if geom.projection == 'AIT' and geom.allsky:
+        pytest.xfail('Bug in reproject version <= 0.3.1')
 
     if geom.ndim > 3 or geom.npix[0].size > 1:
         pytest.xfail(

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -76,3 +76,17 @@ def test_wcsmapnd_fill_by_coords(tmpdir, npix, binsz, coordsys, proj, skydir, ax
     m.fill_by_coords(tuple([np.concatenate((t, t)) for t in coords]),
                      np.concatenate((coords[1], coords[1])))
     assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsmapnd_iter(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsMapND(geom)
+    coords = m.geom.get_coords()
+    m.fill_by_coords(coords, coords[0])
+    for vals, pix in m.iter_by_pix(buffersize=100):
+        assert_allclose(vals, m.get_by_pix(pix))
+    for vals, coords in m.iter_by_coords(buffersize=100):
+        assert_allclose(vals, m.get_by_coords(coords))

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -57,13 +57,14 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     filename = str(tmpdir / 'skycube.fits')
+    filename_sparse = str(tmpdir / 'skycube_sparse.fits')
     m0 = WcsMapND(geom)
     m0.fill_poisson(0.5)
     m0.write(filename)
     m1 = WcsMapND.read(filename)
     assert_allclose(m0.data, m1.data)
-    m0.write(filename, sparse=True)
-    m1 = WcsMapND.read(filename)
+    m0.write(filename_sparse, sparse=True)
+    m1 = WcsMapND.read(filename_sparse)
     assert_allclose(m0.data, m1.data)
 
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -1,0 +1,66 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
+from ..geom import MapAxis
+from ..wcs import WCSGeom
+from ..wcsnd import WcsMapND
+
+
+pytest.importorskip('scipy')
+
+axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
+axes2 = [MapAxis(np.logspace(0., 3., 3), interp='log'),
+         MapAxis(np.logspace(1., 3., 4), interp='lin')]
+skydir = SkyCoord(110., 75.0, unit='deg', frame='icrs')
+
+wcs_allsky_test_geoms = [
+    (None, 10.0, 'GAL', 'AIT', skydir, None),
+    (None, 10.0, 'GAL', 'AIT', skydir, axes1),
+    (None, [10.0, 20.0], 'GAL', 'AIT', skydir, axes1),
+    (None, 10.0, 'GAL', 'AIT', skydir, axes2),
+    (None, [[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]],
+     'GAL', 'AIT', skydir, axes2),
+]
+
+wcs_partialsky_test_geoms = [
+    (10, 1.0, 'GAL', 'AIT', skydir, None),
+    (10, 1.0, 'GAL', 'AIT', skydir, axes1),
+    (10, [1.0, 2.0], 'GAL', 'AIT', skydir, axes1),
+    (10, 1.0, 'GAL', 'AIT', skydir, axes2),
+    (10, [[1.0, 2.0, 3.0], [1.0, 2.0, 3.0]],
+     'GAL', 'AIT', skydir, axes2),
+]
+
+wcs_test_geoms = wcs_allsky_test_geoms + wcs_partialsky_test_geoms
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WCSGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m0 = WcsMapND(geom)
+    m0.fill_poisson(0.5)
+    m1 = WcsMapND(geom, m0.data)
+    assert_allclose(m0.data, m1.data)
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
+
+    geom = WCSGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    filename = str(tmpdir / 'skycube.fits')
+    m0 = WcsMapND(geom)
+    m0.fill_poisson(0.5)
+    m0.write(filename)
+    m1 = WcsMapND.read(filename)
+    assert_allclose(m0.data, m1.data)
+    m0.write(filename, sparse=True)
+    m1 = WcsMapND.read(filename)
+    assert_allclose(m0.data, m1.data)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -90,3 +90,14 @@ def test_wcsmapnd_iter(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
         assert_allclose(vals, m.get_by_pix(pix))
     for vals, coords in m.iter_by_coords(buffersize=100):
         assert_allclose(vals, m.get_by_coords(coords))
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsmapnd_sum_over_axes(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsMapND(geom)
+    coords = m.geom.get_coords()
+    m.fill_by_coords(coords, coords[0])
+    msum = m.sum_over_axes()

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..geom import MapAxis
-from ..wcs import WCSGeom
+from ..wcs import WcsGeom
 from ..wcsnd import WcsMapND
 
 
@@ -41,7 +41,7 @@ wcs_test_geoms = wcs_allsky_test_geoms + wcs_partialsky_test_geoms
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WCSGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m0 = WcsMapND(geom)
     m0.fill_poisson(0.5)
@@ -53,7 +53,7 @@ def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
                          wcs_test_geoms)
 def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
 
-    geom = WCSGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     filename = str(tmpdir / 'skycube.fits')
     m0 = WcsMapND(geom)
@@ -69,7 +69,7 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsmapnd_fill_by_coords(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
-    geom = WCSGeom.create(npix=npix, binsz=binsz,
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsMapND(geom)
     coords = m.geom.get_coords()

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.io import fits
 
 
 def unpack_seq(seq, n=1):
@@ -21,3 +22,62 @@ def unpack_seq(seq, n=1):
 
     for row in seq:
         yield [e for e in row[:n]] + [row[n:]]
+
+
+def find_bands_hdu(hdu):
+    """Discover the extension name of the BANDS HDU.
+
+    Returns
+    -------
+    extname : str
+        Extension name of the BANDS HDU.  None if no BANDS HDU was found.
+    """
+    if 'BANDSHDU' in hdu.header:
+        return hdu.header['BANDSHDU']
+
+    has_cube_data = False
+
+    if (isinstance(hdu, (fits.ImageHDU, fits.PrimaryHDU)) and
+            hdu.header.get('NAXIS', None) == 3):
+        has_cube_data = True
+    elif isinstance(hdu, fits.BinTableHDU):
+
+        if (hdu.header.get('INDXSCHM', '') == 'IMPLICIT' and
+                len(hdu.columns) > 1):
+            has_cube_data = True
+
+    if has_cube_data:
+        if 'EBOUNDS' in hdulist:
+            return 'EBOUNDS'
+        elif 'ENERGIES' in hdulist:
+            return 'ENERGIES'
+
+    return None
+
+
+def find_hdu(hdulist):
+    """Find the first non-empty HDU."""
+
+    for hdu in hdulist:
+        if hdu.data is not None:
+            return hdu
+
+    raise AttributeError('No Image or BinTable HDU found.')
+
+
+def find_image_hdu(hdulist):
+
+    for hdu in hdulist:
+        if hdu.data is not None and isinstance(hdu, fits.ImageHDU):
+            return hdu
+
+    raise AttributeError('No Image HDU found.')
+
+
+def find_bintable_hdu(hdulist):
+
+    for hdu in hdulist:
+        if hdu.data is not None and isinstance(hdu, fits.BinTableHDU):
+            return hdu
+
+    raise AttributeError('No BinTable HDU found.')

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,0 +1,23 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
+def unpack_seq(seq, n=1):
+    """Utility to unpack the first N values of a tuple or list.  Remaining
+    values are put into a single list which is the last element of the
+    return value.  This partially simulates the extended unpacking
+    functionality available in Python 3.
+
+    Parameters
+    ----------
+    seq : list or tuple
+        Input sequence to be unpacked.
+
+    n : int
+        Number of elements of ``seq`` to unpack.  Remaining elements
+        are put into a single tuple.
+
+    """
+
+    for row in seq:
+        yield [e for e in row[:n]] + [row[n:]]

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -24,7 +24,7 @@ def unpack_seq(seq, n=1):
         yield [e for e in row[:n]] + [row[n:]]
 
 
-def find_bands_hdu(hdu):
+def find_bands_hdu(hdulist, hdu):
     """Discover the extension name of the BANDS HDU.
 
     Returns

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -330,6 +330,9 @@ class WcsGeom(MapGeom):
         header = self.make_header(conv)
         axis_names = None
 
+        # FIXME: Check whether convention is compatible with
+        # dimensionality of geometry
+
         if conv == 'fgst-ccube':
             extname = 'EBOUNDS'
             axis_names = ['energy']

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -127,6 +127,11 @@ class WcsGeom(MapGeom):
         return self._axes
 
     @property
+    def shape(self):
+        """Shape of non-spatial axes."""
+        return self._shape
+
+    @property
     def ndim(self):
         return len(self._axes) + 2
 
@@ -431,7 +436,7 @@ class WcsGeom(MapGeom):
             if i < 2:
                 idxs[i][(idx < 0) | (idx >= npix[i])] = -1
             else:
-                idxs[i][(idx < 0) | (idx >= self.axes[i-2].nbin)] = -1
+                idxs[i][(idx < 0) | (idx >= self.axes[i - 2].nbin)] = -1
         return idxs
 
     def contains(self, coords):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -10,7 +10,7 @@ from .geom import MapGeom, MapCoords, pix_tuple_to_idx, skydir_to_lonlat
 from .geom import MapAxis, get_shape, make_axes_cols, find_and_read_bands
 
 __all__ = [
-    'WCSGeom',
+    'WcsGeom',
 ]
 
 
@@ -37,7 +37,7 @@ def cast_to_shape(param, shape, dtype):
     return tuple(param)
 
 
-class WCSGeom(MapGeom):
+class WcsGeom(MapGeom):
     """Geometry class for WCS maps.
 
     This class encapsulates both the WCS transformation object and the
@@ -200,12 +200,12 @@ class WCSGeom(MapGeom):
 
         Returns
         -------
-        geom : `~WCSGeom`
+        geom : `~WcsGeom`
             A WCS geometry object.
 
         Examples
         --------
-        >>> from gammapy.maps import WCSGeom
+        >>> from gammapy.maps import WcsGeom
         >>> from gammapy.maps import MapAxis
         >>> axis = MapAxis.from_bounds(0,1,2)
         >>> geom = SkyImage.create(npix=(100,100), binsz=0.1)
@@ -259,7 +259,7 @@ class WCSGeom(MapGeom):
 
         Returns
         -------
-        wcs : `~WCSGeom`
+        wcs : `~WcsGeom`
             WCS geometry object.
         """
         wcs = WCS(header)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -341,19 +341,21 @@ class WcsGeom(MapGeom):
 
                 ntot = npix[0][i] * npix[1][i]
                 o = np.unravel_index(np.arange(ntot, dtype=int),
-                                     (npix[0][i], npix[1][i]))
+                                     (npix[0][i], npix[1][i]), order='F')
                 pix[0] = np.concatenate((pix[0], o[0].astype(float)))
                 pix[1] = np.concatenate((pix[1], o[1].astype(float)))
+                idx = np.unravel_index(np.ravel_multi_index(i, npix[0].shape),
+                                       npix[0].shape, order='F')
                 for j in range(len(self.axes)):
                     pix[2 + j] = np.concatenate((pix[2 + j],
-                                                 i[j] * np.ones(ntot, dtype=float)))
+                                                 idx[j] * np.ones(ntot, dtype=float)))
 
         else:
             pix = [np.arange(npix[0], dtype=float),
                    np.arange(npix[1], dtype=float)]
             for i, ax in enumerate(self.axes):
                 pix += [np.arange(ax.nbin, dtype=float)]
-            pix = np.meshgrid(*pix, indexing='ij')
+            pix = np.meshgrid(*pix[::-1], indexing='ij')[::-1]
 
         if mode == 'edges':
             for i in range(len(pix)):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -178,7 +178,7 @@ class WcsGeom(MapGeom):
             Width of the map in degrees.  A tuple will be interpreted
             as parameters for longitude and latitude axes.  For maps
             with non-spatial dimensions, list input can be used to
-            define a different map width in each image plane.  
+            define a different map width in each image plane.
         binsz : float or tuple or list
             Map pixel size in degrees.  A tuple will be interpreted
             as parameters for longitude and latitude axes.  For maps
@@ -195,8 +195,8 @@ class WcsGeom(MapGeom):
         proj : string, optional
             Any valid WCS projection type. Default is 'CAR' (cartesian).
         refpix : tuple
-            Reference pixel of the projection.  If None then this will
-            be chosen to be center of the map.
+            Reference pixel of the projection.  If None this will be
+            set to the center of the map.
 
         Returns
         -------
@@ -208,10 +208,10 @@ class WcsGeom(MapGeom):
         >>> from gammapy.maps import WcsGeom
         >>> from gammapy.maps import MapAxis
         >>> axis = MapAxis.from_bounds(0,1,2)
-        >>> geom = SkyImage.create(npix=(100,100), binsz=0.1)
-        >>> geom = SkyImage.create(npix=[100,200], binsz=[0.1,0.05], axes=[axis])
-        >>> geom = SkyImage.create(width=[5.0,8.0], binsz=[0.1,0.05], axes=[axis])
-        >>> geom = SkyImage.create(npix=([100,200],[100,200]), binsz=0.1, axes=[axis])
+        >>> geom = WcsGeom.create(npix=(100,100), binsz=0.1)
+        >>> geom = WcsGeom.create(npix=[100,200], binsz=[0.1,0.05], axes=[axis])
+        >>> geom = WcsGeom.create(width=[5.0,8.0], binsz=[0.1,0.05], axes=[axis])
+        >>> geom = WcsGeom.create(npix=([100,200],[100,200]), binsz=0.1, axes=[axis])
 
         """
         if skydir is None:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -399,21 +399,22 @@ class WcsGeom(MapGeom):
 
             pix = [np.array([], dtype=float)
                    for i in range(2 + len(self.axes))]
-            for i, t in np.ndenumerate(npix[0]):
+            for idx_img in np.ndindex(self.shape[::-1]):
 
-                if idx is not None and i != idx:
+                idx_img = idx_img[::-1]
+                if idx is not None and idx_img != idx:
                     continue
 
-                ntot = npix[0][i] * npix[1][i]
+                npix0, npix1 = npix[0][idx_img], npix[1][idx_img]
+                ntot = npix0 * npix1
                 pix_img = np.unravel_index(np.arange(ntot, dtype=int),
-                                           (npix[0][i], npix[1][i]), order='F')
+                                           (npix0, npix1), order='F')
                 pix[0] = np.concatenate((pix[0], pix_img[0].astype(float)))
                 pix[1] = np.concatenate((pix[1], pix_img[1].astype(float)))
-                idx_img = np.unravel_index(np.ravel_multi_index(i, npix[0].shape, order='F'),
-                                           npix[0].shape, order='F')
                 for j in range(len(self.axes)):
                     pix[2 + j] = np.concatenate((pix[2 + j],
-                                                 idx_img[j] * np.ones(ntot, dtype=float)))
+                                                 idx_img[j] *
+                                                 np.ones(ntot, dtype=float)))
 
         else:
             pix = [np.arange(npix[0], dtype=float),

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.io import fits
 from .geom import find_and_read_bands
 from .base import MapBase
-from .wcs import WCSGeom
+from .wcs import WcsGeom
 
 __all__ = [
     'WcsMap',
@@ -43,7 +43,7 @@ class WcsMap(MapBase):
 
     Parameters
     ----------
-    geom : `~gammapy.maps.WCSGeom`
+    geom : `~gammapy.maps.WcsGeom`
         A WCS geometry object.
 
     data : `~numpy.ndarray`
@@ -104,7 +104,7 @@ class WcsMap(MapBase):
         from .wcsnd import WcsMapND
         # from .wcssparse import WcsMapSparse
 
-        geom = WCSGeom.create(npix=npix, binsz=binsz, width=width,
+        geom = WcsGeom.create(npix=npix, binsz=binsz, width=width,
                               proj=proj, skydir=skydir,
                               coordsys=coordsys, refpix=refpix, axes=axes)
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -5,37 +5,11 @@ from astropy.io import fits
 from .geom import find_and_read_bands
 from .base import MapBase
 from .wcs import WcsGeom
+from .utils import find_hdu, find_bands_hdu
 
 __all__ = [
     'WcsMap',
 ]
-
-
-def find_hdu(hdulist):
-
-    for hdu in hdulist:
-        if hdu.data is not None:
-            return hdu
-
-    raise AttributeError('No Image HDU found.')
-
-
-def find_image_hdu(hdulist):
-
-    for hdu in hdulist:
-        if hdu.data is not None and isinstance(hdu, fits.ImageHDU):
-            return hdu
-
-    raise AttributeError('No Image HDU found.')
-
-
-def find_bintable_hdu(hdulist):
-
-    for hdu in hdulist:
-        if hdu.data is not None and isinstance(hdu, fits.BinTableHDU):
-            return hdu
-
-    raise AttributeError('No BinTable HDU found.')
 
 
 class WcsMap(MapBase):
@@ -142,14 +116,8 @@ class WcsMap(MapBase):
         else:
             hdu = hdulist[hdu]
 
-        if 'BANDSHDU' in hdu.header and hdu_bands is None:
-            hdu_bands = hdu.header['BANDSHDU']
-        elif hdu.header.get('NAXIS', None) == 3 and hdu_bands is None:
-
-            if 'EBOUNDS' in hdulist:
-                hdu_bands = 'EBOUNDS'
-            elif 'ENERGIES' in hdulist:
-                hdu_bands = 'ENERGIES'
+        if hdu_bands is None:
+            hdu_bands = find_bands_hdu(hdu)
 
         if hdu_bands is not None:
             hdu_bands = hdulist[hdu_bands]

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -116,7 +116,7 @@ class WcsMap(MapBase):
             raise ValueError('Unregnized Map type: {}'.format(map_type))
 
     @classmethod
-    def from_hdulist(cls, hdulist, **kwargs):
+    def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):
         """Make a WcsMap object from a FITS HDUList.
 
         Parameters
@@ -133,18 +133,22 @@ class WcsMap(MapBase):
         wcs_map : `WcsMap`
             Map object
         """
-        extname = kwargs.get('hdu', None)
-        if extname is None:
+        if hdu is None:
             hdu = find_hdu(hdulist)
         else:
-            hdu = hdulist[extname]
-        extname_bands = kwargs.get('hdu_bands', None)
-        if 'BANDSHDU' in hdu.header and extname_bands is None:
-            extname_bands = hdu.header['BANDSHDU']
+            hdu = hdulist[hdu]
 
-        hdu_bands = None
-        if extname_bands is not None:
-            hdu_bands = hdulist[extname_bands]
+        if 'BANDSHDU' in hdu.header and hdu_bands is None:
+            hdu_bands = hdu.header['BANDSHDU']
+        elif hdu.header.get('NAXIS', None) == 3 and hdu_bands is None:
+
+            if 'EBOUNDS' in hdulist:
+                hdu_bands = 'EBOUNDS'
+            elif 'ENERGIES' in hdulist:
+                hdu_bands = 'ENERGIES'
+
+        if hdu_bands is not None:
+            hdu_bands = hdulist[hdu_bands]
 
         return cls.from_hdu(hdu, hdu_bands)
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -117,7 +117,7 @@ class WcsMap(MapBase):
             hdu = hdulist[hdu]
 
         if hdu_bands is None:
-            hdu_bands = find_bands_hdu(hdu)
+            hdu_bands = find_bands_hdu(hdulist, hdu)
 
         if hdu_bands is not None:
             hdu_bands = hdulist[hdu_bands]

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.io import fits
+from .geom import find_and_read_bands
 from .base import MapBase
 from .wcs import WCSGeom
 
@@ -9,6 +12,17 @@ __all__ = [
 
 
 class WcsMap(MapBase):
+    """Base class for WCS map classes.
+
+    Parameters
+    ----------
+    geom : `~gammapy.maps.WCSGeom`
+        A WCS geometry object.
+
+    data : `~numpy.ndarray`
+        Data array.
+    """
+
     def __init__(self, geom, data=None):
         MapBase.__init__(self, geom, data)
 
@@ -73,3 +87,94 @@ class WcsMap(MapBase):
             raise NotImplementedError
         else:
             raise ValueError('Unregnized Map type: {}'.format(map_type))
+
+    @classmethod
+    def from_hdulist(cls, hdulist, **kwargs):
+        """Make a WcsMap object from a FITS HDUList.
+
+        Parameters
+        ----------
+        hdulist :  `~astropy.io.fits.HDUList`
+            HDU list containing HDUs for map data and bands.
+        hdu : str
+            Name or index of the HDU with the map data.
+        hdu_bands : str
+            Name or index of the HDU with the BANDS table.
+
+        Returns
+        -------
+        wcs_map : `WcsMap`
+            Map object
+        """
+        extname = kwargs.get('hdu', 'PRIMARY')
+
+        hdu = hdulist[extname]
+        extname_bands = kwargs.get('hdu_bands', None)
+        if 'BANDSHDU' in hdu.header and extname_bands is None:
+            extname_bands = hdu.header['BANDSHDU']
+
+        hdu_bands = None
+        if extname_bands is not None:
+            hdu_bands = hdulist[extname_bands]
+
+        return cls.from_hdu(hdu, hdu_bands)
+
+    def to_hdulist(self, **kwargs):
+
+        extname = kwargs.get('extname', 'SKYMAP')
+        extname_bands = kwargs.get('extname_bands', 'BANDS')
+        sparse = kwargs.get('sparse', False)
+
+        if sparse:
+            hdulist = [fits.PrimaryHDU(), self.make_hdu(**kwargs)]
+        else:
+            kwargs['primary'] = True
+            hdulist = [self.make_hdu(**kwargs)]
+
+        if self.geom.axes:
+            hdulist += [self.geom.make_bands_hdu(extname=extname_bands)]
+        return fits.HDUList(hdulist)
+
+    def make_hdu(self, extname='SKYMAP', extname_bands='BANDS', sparse=False,
+                 primary=False):
+        """Make a FITS HDU with input data.
+
+        Parameters
+        ----------
+        extname : str
+            The HDU extension name.
+        extname_bands : str
+            The HDU extension name for BANDS table.
+        sparse : bool
+            Set INDXSCHM to SPARSE and sparsify the map by only
+            writing pixels with non-zero amplitude.
+        primary : bool
+            Specify whether to make a primary or image HDU.
+        """
+        data = self.data
+        shape = data.shape
+        header = self.geom.wcs.to_header()
+
+        if self.geom.axes:
+            header['BANDSHDU'] = extname_bands
+
+        cols = []
+        if sparse:
+            nonzero = data.nonzero()
+            if len(shape) == 1:
+                cols.append(fits.Column('PIX', 'J', array=nonzero[0]))
+                cols.append(fits.Column('VALUE', 'E',
+                                        array=data[nonzero].astype(float)))
+            else:
+                channel = np.ravel_multi_index(nonzero[:-1], shape[:-1])
+                cols.append(fits.Column('PIX', 'J', array=nonzero[-1]))
+                cols.append(fits.Column('CHANNEL', 'I', array=channel))
+                cols.append(fits.Column('VALUE', 'E',
+                                        array=data[nonzero].astype(float)))
+            hdu = fits.BinTableHDU.from_columns(cols, header=header,
+                                                name=extname)
+        elif primary:
+            hdu = fits.PrimaryHDU(data, header=header)
+        else:
+            hdu = fits.ImageHDU(data, header=header, name=extname)
+        return hdu

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -51,9 +51,9 @@ class WcsMapND(WcsMap):
 
         Parameters
         ----------
-        hdu : `~astropy.fits.BinTableHDU` or `~astropy.fits.ImageHDU` 
+        hdu : `~astropy.fits.BinTableHDU` or `~astropy.fits.ImageHDU`
             The map FITS HDU.
-        hdu_bands : `~astropy.fits.BinTableHDU` 
+        hdu_bands : `~astropy.fits.BinTableHDU`
             The BANDS table HDU.
         """
         geom = WcsGeom.from_header(hdu.header, hdu_bands)
@@ -129,14 +129,21 @@ class WcsMapND(WcsMap):
     def sum_over_axes(self):
         raise NotImplementedError
 
-    def plot(self, ax=None):
+    def plot(self, ax=None, pix_slice=None, **kwargs):
         import matplotlib.pyplot as plt
 
         if ax is None:
             fig = plt.gcf()
             ax = fig.add_subplot(111, projection=self.geom.wcs)
 
-        im = ax.imshow(self.data, interpolation='nearest', cmap='magma',
-                       origin='lower')
+        if pix_slice is not None:
+            slices = (slice(None), slice(None)) + pix_slice
+            data = self.data[slices[::-1]]
+        else:
+            data = self.data
+
+        kwargs.setdefault('interpolation', 'nearest')
+        kwargs.setdefault('origin', 'lower')
+        im = ax.imshow(data, **kwargs)
         ax.coords.grid(color='w', linestyle=':', linewidth=0.5)
         return im

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
+from .utils import unpack_seq
 from .geom import pix_tuple_to_idx
 from .wcsmap import WcsGeom
 from .wcsmap import WcsMap
@@ -110,6 +111,20 @@ class WcsMapND(WcsMap):
     def set_by_idx(self, idx, vals):
         idx = pix_tuple_to_idx(idx)
         self.data.T[idx] = vals
+
+    def iter_by_pix(self, buffersize=1):
+        pix = list(self.geom.get_pixels())
+        vals = self.data[np.isfinite(self.data)]
+        return unpack_seq(np.nditer([vals] + pix,
+                                    flags=['external_loop', 'buffered'],
+                                    buffersize=buffersize))
+
+    def iter_by_coords(self, buffersize=1):
+        coords = list(self.geom.get_coords())
+        vals = self.data[np.isfinite(self.data)]
+        return unpack_seq(np.nditer([vals] + coords,
+                                    flags=['external_loop', 'buffered'],
+                                    buffersize=buffersize))
 
     def sum_over_axes(self):
         raise NotImplementedError

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -146,6 +146,18 @@ class WcsMapND(WcsMap):
     def reproject(self, geom):
         raise NotImplementedError
 
+    def pad(self, pad_width):
+        raise NotImplementedError
+
+    def crop(self, crop_width):
+        raise NotImplementedError
+
+    def upsample(self, factor):
+        raise NotImplementedError
+
+    def downsample(self, factor):
+        raise NotImplementedError
+
     def plot(self, ax=None, pix_slice=None, **kwargs):
         import matplotlib.pyplot as plt
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -323,6 +323,30 @@ class WcsMapND(WcsMap):
         raise NotImplementedError
 
     def plot(self, ax=None, idx=None, **kwargs):
+        """Quickplot method.
+
+        Parameters
+        ----------
+        norm : str
+            Set the normalization scheme of the color map.
+
+        idx : tuple
+            Set the image slice to plot if this map has non-spatial
+            dimensions.
+
+        Returns
+        -------
+        fig : `~matplotlib.figure.Figure`
+            Figure object.
+
+        ax : `~astropy.visualization.wcsaxes.WCSAxes`
+            WCS axis object
+
+        im : `~matplotlib.image.AxesImage`
+            Image object.
+
+        """
+
         import matplotlib.pyplot as plt
         import matplotlib.colors as colors
 
@@ -347,4 +371,4 @@ class WcsMapND(WcsMap):
 
         im = ax.imshow(data, **kwargs)
         ax.coords.grid(color='w', linestyle=':', linewidth=0.5)
-        return im
+        return fig, ax, im

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -88,7 +88,7 @@ class WcsMapND(WcsMap):
 
     def get_by_idx(self, idx):
         idx = pix_tuple_to_idx(idx)
-        return self._data[idx]
+        return self._data.T[idx]
 
     def interp_by_coords(self, coords, interp=None):
         if interp == 'linear':
@@ -98,9 +98,14 @@ class WcsMapND(WcsMap):
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
-        if weights is None:
-            weights = np.ones(idx[0].shape)
-        self.data.T[idx] += weights
+        msk = idx[0] >= 0
+        idx = [t[msk] for t in idx]
+        if weights is not None:
+            weights = weights[msk]
+        idx = np.ravel_multi_index(idx, self.data.T.shape)
+        idx, idx_inv = np.unique(idx, return_inverse=True)
+        weights = np.bincount(idx_inv, weights=weights)
+        self.data.T.flat[idx] += weights
 
     def set_by_idx(self, idx, vals):
         idx = pix_tuple_to_idx(idx)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.io import fits
 from .geom import pix_tuple_to_idx
-from .wcsmap import WCSGeom
+from .wcsmap import WcsGeom
 from .wcsmap import WcsMap
 
 __all__ = [
@@ -20,7 +20,7 @@ class WcsMapND(WcsMap):
 
     Parameters
     ----------
-    wcs : `~gammapy.maps.wcs.WCSGeom`
+    wcs : `~gammapy.maps.wcs.WcsGeom`
         WCS geometry object.
     data : `~numpy.ndarray`
         Data array. If none then an empty array will be allocated.
@@ -55,7 +55,7 @@ class WcsMapND(WcsMap):
         hdu_bands : `~astropy.fits.BinTableHDU` 
             The BANDS table HDU.
         """
-        geom = WCSGeom.from_header(hdu.header, hdu_bands)
+        geom = WcsGeom.from_header(hdu.header, hdu_bands)
         shape = tuple([ax.nbin for ax in geom.axes])
         shape_wcs = tuple([np.max(geom.npix[0]),
                            np.max(geom.npix[1])])

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -213,21 +213,6 @@ class WcsMapND(WcsMap):
 
         return map_out
 
-    def reproject(self, geom, mode='interp', order=1):
-
-        from .hpx import HpxGeom
-
-        if geom.ndim == 2 and self.geom.ndim > 2:
-            geom = geom.to_cube(self.geom.axes)
-        elif geom.ndim != self.geom.ndim:
-            raise ValueError('Projection geometry must be 2D or have the '
-                             'same number of dimensions as the map.')
-
-        if geom.projection == 'HPX':
-            return self._reproject_hpx(geom, order=order)
-        else:
-            return self._reproject_wcs(geom, mode=mode, order=order)
-
     def _reproject_wcs(self, geom, mode='interp', order=1):
 
         from reproject import reproject_interp, reproject_exact
@@ -274,7 +259,7 @@ class WcsMapND(WcsMap):
 
         return map_out
 
-    def _reproject_hpx(self, geom, order=1):
+    def _reproject_hpx(self, geom, mode='interp', order=1):
 
         from reproject import reproject_from_healpix, reproject_to_healpix
         from .hpxcube import HpxMapND


### PR DESCRIPTION
This PR fleshes out more of the FITS I/O related functionality in `gammapy.maps` and adds some new features to `HpxMapND`:
* Implement `read` and `write` methods for `WcsMapND` and `HpxMapND`.  
* Maps can be written to a sparse format by calling `write` with `sparse=True`.  This writes a BINTABLE with one row per pixel.  The format for HPX maps is documented on the [gamma-astro-data-formats page](http://gamma-astro-data-formats.readthedocs.io/en/latest/skymaps/healpix/index.html).  WCS maps use a similar convention which I will try to document in the next few weeks.  `WcsMapND.read` and `HpxMapND.read` can instantiate a map from a FITS HDU in either the sparse or non-sparse format.
* Support for instantiating `HpxMapND` with a multi-resolution geometry (i.e. different pixel size in each image plane).  This is implemented by allocating an array with an image dimension with size equal to the largest image plane in the map and filling array elements outside the geometry in a given image plane with guard values.  It's not particularly memory efficient but it should be useful for testing multi-resolution maps until the sparse map classes are fully implemented.