### PR TITLE
Add 3FGL spatial models

### DIFF
--- a/gammapy/image/catalog.py
+++ b/gammapy/image/catalog.py
@@ -35,7 +35,7 @@ class CatalogImageEstimator(object):
     Examples
     --------
 
-    ::
+    Here is an example how to compute a flux image from a catalog:
 
         from astropy import units as u
         from gammapy.image import SkyImage, CatalogImageEstimator

--- a/gammapy/image/tests/test_catalog.py
+++ b/gammapy/image/tests/test_catalog.py
@@ -11,7 +11,8 @@ from ...irf import EnergyDependentTablePSF
 from ...cube import SkyCube
 from ...datasets import FermiGalacticCenter
 from ...spectrum import LogEnergyAxis
-from ...catalog import SourceCatalog3FHL, SourceCatalogGammaCat, SourceCatalogHGPS
+from ...catalog import (SourceCatalog3FHL, SourceCatalogGammaCat, SourceCatalogHGPS,
+                        SourceCatalog3FGL)
 
 
 def test_extended_image():
@@ -117,6 +118,25 @@ class TestCatalogImageEstimator(object):
         desired = selection.table['Flux'].sum()
         assert_allclose(actual, desired, rtol=1E-2)
 
+    @requires_data('gammapy-extra')
+    def test_flux_3FGL(self):
+        reference = SkyImage.empty(xref=18.0, yref=-0.6, nypix=81,
+                                   nxpix=81, binsz=0.1)
+
+        catalog = SourceCatalog3FGL()
+        estimator = CatalogImageEstimator(reference=reference,
+                                          emin=1 * u.GeV,
+                                          emax=100 * u.GeV)
+
+        result = estimator.run(catalog)
+
+        actual = result['flux'].data.sum()
+        selection = catalog.select_image_region(reference)
+
+        assert len(selection.table) == 18
+
+        desired = selection.table['Flux1000'].sum()
+        assert_allclose(actual, desired, rtol=1E-2)
 
     @requires_data('hgps')
     def test_flux_hgps(self):


### PR DESCRIPTION
This PR add the `.spatial_model` attribute to the `SourceCatalogObject3FGL` class. Corresponding PR adding the source templates is here: https://github.com/gammapy/gammapy-extra/pull/81  