### PR TITLE
Change conda install instructions to conda-forge channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
 
         - PIP_DEPENDENCIES='uncertainties'
 
-        - CONDA_CHANNELS='conda-forge astropy sherpa openastronomy'
+        - CONDA_CHANNELS='conda-forge sherpa'
 
         - FETCH_GAMMAPY_EXTRA=true
         - FETCH_GAMMA_CAT=true

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -77,7 +77,7 @@ Steps for the day of the release:
    https://readthedocs.org/projects/gammapy/builds/
 #. Draft the release announcement as a new file in https://github.com/gammapy/gammapy/tree/master/dev/notes
    (usually by copy & pasting the announcement from the last release)
-#. Update the Gammapy conda package at https://github.com/astropy/conda-channel-astropy/
+#. Update the Gammapy conda-forge package at https://github.com/conda-forge/gammapy-feedstock
 #. Update Gammapy Macports package at https://github.com/macports/macports-ports
 #. Encourage the Gammapy developers to try out the new stable version (update and run tests)
    via the Github issue for the release and wait a day or two for feedback.

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -9,7 +9,7 @@ and then run these commands:
 
 .. code-block:: bash
 
-    conda config --add channels astropy --add channels sherpa
+    conda config --add channels conda-forge --add channels sherpa
     conda install gammapy naima \
         scipy matplotlib ipython-notebook \
         cython click

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -24,16 +24,15 @@ Stable version
 
 You can install the latest stable version of Gammapy with conda::
 
-  conda install -c astropy gammapy
+    conda install -c conda-forge gammapy
 
 or with pip::
 
-  pip install gammapy
+    pip install gammapy
 
 or with Macports (a package manager for Mac OS)::
 
-  sudo port install gammapy
-
+    sudo port install gammapy
 
 Gammapy is not yet available in the Linux distributions, i.e. at this time you can't
 install it with e.g. ``apt-get`` or ``yum``.
@@ -43,16 +42,16 @@ Development version
 
 To install the development version of Gammapy::
 
-  git clone https://github.com/gammapy/gammapy.git
-  cd gammapy
-  pip install .
+    git clone https://github.com/gammapy/gammapy.git
+    cd gammapy
+    pip install .
 
 of if you're using conda, you can install the development version like this::
 
-  git clone https://github.com/gammapy/gammapy.git
-  cd gammapy
-  conda install -f environment.yml
-  source activate gammapy-dev
+    git clone https://github.com/gammapy/gammapy.git
+    cd gammapy
+    conda install -f environment.yml
+    source activate gammapy-dev
 
 Verify
 ------
@@ -85,14 +84,14 @@ Once you've made your choice how to install Gammapy, you can find detailed infor
 on the following sub-pages:
 
 .. toctree::
-  :maxdepth: 1
+    :maxdepth: 1
 
-  conda
-  pip
-  macports
-  other
-  check
-  dependencies
+    conda
+    pip
+    macports
+    other
+    check
+    dependencies
 
 
 If you'd like to make a code contribution to Gammapy, please see the developer documentation

--- a/gammapy-conda-install.sh
+++ b/gammapy-conda-install.sh
@@ -32,7 +32,7 @@ bash miniconda.sh -b -p $INSTALL_DIR
 export PATH="$INSTALL_DIR/bin:$PATH"
 conda config --set always_yes yes --set changeps1 no
 
-conda config --add channels astropy
+conda config --add channels conda-forge
 conda config --add channels sherpa
 
 conda update -q conda
@@ -40,7 +40,7 @@ conda update -q conda
 
 # Finally ... install Gammapy and the most useful dependencies
 conda install gammapy naima \
-    scipy matplotlib ipython-notebook
+    iminuit scipy matplotlib ipython-notebook
 # Disk space now: 200 MB
 
 # Nice to have extras
@@ -50,6 +50,5 @@ conda install \
 # Disk space now: 747 MB
 
 pip install reproject
-pip install iminuit
 
 conda install sherpa


### PR DESCRIPTION
The Astropy conda packagers recently moved Gammapy and all the other conda packages previously maintained by the Astropy team to conda-forge.

In the past years, conda-forge has emerged as the most popular / well-organised solution for conda packaging / build / distribution. To quote from  https://conda-forge.org/
> A community led collection of recipes, build infrastructure and distributions for the conda package manager.

Here's the conda-forge package for Gammapy:

* https://github.com/conda-forge/gammapy-feedstock
* https://anaconda.org/conda-forge/gammapy

I think this is the long-term conda solution for Gammapy as an open source project for the coming years (irrespective if others like CTA start building or distributing conda packages).

This PR updates the Gammapy docs to use `conda-forge`, getting rid of mentions of the `astropy` or `openastronomy` channels. (but doesn't do other improvements, like improving our install docs or merging the content from https://github.com/gammapy/gammapy-extra/blob/master/notebooks/tutorial_setup.ipynb into the existing Sphinx install docs).