### PR TITLE
Emit a warning when there are multiple types of IRFs present

### DIFF
--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import numpy as np
+import logging
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils import lazyproperty
@@ -12,6 +13,7 @@ __all__ = [
     'HDUIndexTable',
 ]
 
+log = logging.getLogger(__name__)
 
 class HDULocation(object):
     """HDU localisation and loading.
@@ -172,9 +174,11 @@ class HDUIndexTable(Table):
             raise IndexError('No HDU found matching: OBS_ID = {}, HDU_TYPE = {}, HDU_CLASS = {}'
                              ''.format(obs_id, hdu_type, hdu_class))
         else:
-            # For now we just pick the first valid entry.
-            # TODO: should we emit a warning
             idx = idx[0]
+            log.warn('Found multiple HDU matching: OBS_ID = {}, HDU_TYPE = {}, HDU_CLASS = {}.'
+                     ''.format(obs_id, hdu_type, hdu_class) +
+                     ' Returning the first entry, which has HDU_TYPE = {} and HDU_CLASS = {}'
+                     ''.format(self[idx]['HDU_TYPE'], self[idx]['HDU_CLASS']))
 
         return self.location_info(idx)
 


### PR DESCRIPTION
When multiple entries for the same IRF are encountered in the HDU_INDEX, emit a warning (and return the first one).