### PR TITLE
Add HAWC 2FHL catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ _build
 
 # Pytest
 .cache
+v
 
 # Packages/installer info
 *.egg

--- a/gammapy/catalog/__init__.py
+++ b/gammapy/catalog/__init__.py
@@ -4,6 +4,7 @@ Source catalogs and objects.
 """
 from .core import *
 from .fermi import *
+from .hawc import *
 from .hess import *
 from .gammacat import *
 from .registry import *

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -1,0 +1,159 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+HAWC catalogs (https://www.hawc-observatory.org)
+"""
+
+from .core import SourceCatalog, SourceCatalogObject
+from ..utils.scripts import make_path
+from astropy.table import Table
+import astropy.units as u
+import numpy as np
+from ..spectrum.models import PowerLaw
+
+
+class SourceCatalogObject2HWC(SourceCatalogObject):
+    """One source from the HAWC 2FHL catalog.
+
+    Catalog is represented by `~gammapy.catalog.SourceCatalog2HWC`.
+    """
+
+    _source_name_key = 'source_name'
+    _source_index_key = 'catalog_row_index'
+
+    def __str__(self):
+        return self.info()
+
+    def info(self, info='all'):
+        """Summary info string.
+
+        Parameters
+        ----------
+        info : {'all', 'basic', 'position', 'spectrum}
+            Comma separated list of options
+        """
+
+        if info == 'all':
+            info = 'basic,position,spectrum'
+
+        ss = ''
+        ops = info.split(',')
+        if 'basic' in ops:
+            ss += self._info_basic()
+        if 'position' in ops:
+            ss += self._info_position()
+        if 'spectrum' in ops:
+            ss += self._info_spectrum()
+
+        return ss
+
+    def _info_basic(self):
+        """Print basic info."""
+        d = self.data
+        ss = '\n*** Basic info ***\n\n'
+        ss += 'Catalog row index (zero-based) : {}\n'.format(d['catalog_row_index'])
+        ss += '{:<15s} : {}\n'.format('Source name:', d['source_name'])
+
+        return ss
+
+    def _info_position(self):
+        """Print position info."""
+        d = self.data
+        ss = '\n*** Position info ***\n\n'
+        ss += 'Measurement:\n'
+        ss += '{:20s} : {:.3f}\n'.format('RA', d['ra'])
+        ss += '{:20s} : {:.3f}\n'.format('DEC', d['dec'])
+        ss += '{:20s} : {:.3f}\n'.format('GLON', d['glon'])
+        ss += '{:20s} : {:.3f}\n'.format('GLAT', d['glat'])
+        ss += '{:20s} : {:.3f}\n'.format('Position error', d['pos_err'])
+
+        return ss
+
+    def _info_spectrum(self):
+        """Print spectral info."""
+        d = self.data
+        ss = '\n*** Spectral info ***\n\n'
+
+        ss += 'Spectrum 1:\n'
+        args1 = 'Flux at 7 TeV', d['spec0_dnde'].value, d['spec0_dnde_err'].value, 'cm-2 s-1 TeV-1'
+        ss += '{:20s} : {:.3} +- {:.3} {}\n'.format(*args1)
+        args2 = 'Spectral index', d['spec0_index'], d['spec0_index_err']
+        ss += '{:20s} : {:.3f} +- {:.3f}\n'.format(*args2)
+        ss += '{:20s} : {:1}\n\n'.format('Test radius', d['spec0_radius'])
+
+        if(np.isnan(d['spec1_dnde'])):
+            ss += 'No second spectrum available for this source'
+        else:
+            ss += 'Spectrum 2:\n'
+            args3 = 'Flux at 7 TeV', d['spec1_dnde'].value, d['spec1_dnde_err'].value, 'cm-2 s-1 TeV-1'
+            ss += '{:20s} : {:.3} +- {:.3} {}\n'.format(*args3)
+            args4 = 'Spectral index', d['spec1_index'], d['spec1_index_err']
+            ss += '{:20s} : {:.3f} +- {:.3f}\n'.format(*args4)
+            ss += '{:20s} : {:1}'.format('Test radius', d['spec1_radius'])
+
+        return ss
+
+    @property
+    def n_spectra(self):
+        """Number of measured spectra (1 or 2)."""
+
+        return 1 if np.isnan(self.data['spec1_dnde']) else 2
+
+    def _get_spec_pars(self, id):
+        pars, errs = {}, {}
+        data = self.data
+        label = 'spec{}_'.format(id)
+
+        pars['amplitude'] = data[label + 'dnde']
+        errs['amplitude'] = data[label + 'dnde_err']
+        pars['index'] = data[label + 'index'] * u.Unit('')
+        errs['index'] = data[label + 'index_err'] * u.Unit('')
+        pars['reference'] = 7 * u.TeV
+
+        return [pars, errs]
+
+    def spectral_model(self):
+        """Returns a list of `~gammapy.spectrum.models.SpectralModel`
+        objects. Either with one or with two entries depending on the
+        source in the catalog.
+        """
+
+        models = []
+
+        model1 = PowerLaw(**(self._get_spec_pars(0)[0]))
+        model1.parameters.set_parameter_errors(self._get_spec_pars(0)[1])
+        models = [model1]
+
+        if(self.n_spectra == 2):
+            model2 = PowerLaw(**(self._get_spec_pars(1)[0]))
+            model2.parameters.set_parameter_errors(self._get_spec_pars(1)[1])
+            models.append(model2)
+
+        return models
+
+
+class SourceCatalog2HWC(SourceCatalog):
+    """ HAWC 2FHL catalog
+
+    One source is represented by `~gammapy.catalog.SourceCatalogObjectGammaCat`
+
+    See: http://adsabs.harvard.edu/abs/2017ApJ...843...40A
+
+    References
+    -----------
+    .. [1] Abeysekara et al, "The 2HWC HAWC Observatory Gamma Ray Catalog",
+     `Link <https://arxiv.org/abs/1702.02992>_
+    """
+
+    name = '2hwc'
+    description = 'Second HWC FHL catalog from the HAWC observatory'
+    source_object_class = SourceCatalogObject2HWC
+
+    def __init__(self, filename='$GAMMAPY_EXTRA/datasets/catalogs/2HWC.ecsv'):
+        filename = str(make_path(filename))
+        table = Table.read(filename, format='ascii.ecsv')
+
+        source_name_key = 'source_name'
+
+        super(SourceCatalog2HWC, self).__init__(
+            table=table,
+            source_name_key=source_name_key)

--- a/gammapy/catalog/registry.py
+++ b/gammapy/catalog/registry.py
@@ -53,6 +53,9 @@ class SourceCatalogRegistry(object):
         from .fermi import SourceCatalog3FHL
         source_catalogs.register('3fhl', SourceCatalog3FHL)
 
+        from .hawc import SourceCatalog2HWC
+        source_catalogs.register('2hwc', SourceCatalog2HWC)
+
         return source_catalogs
 
     @property

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -1,48 +1,47 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
+import pytest
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
-import pytest
-from ..hawc import SourceCatalog2HWC
 from ...utils.testing import requires_data, requires_dependency
+from ..hawc import SourceCatalog2HWC
 
 
 @pytest.fixture(scope='session')
-def hwc2_fhl():
+def hawc_2hwc():
     return SourceCatalog2HWC()
 
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog2HWC:
-    def test_source_table(self, hwc2_fhl):
-        assert hwc2_fhl.name == '2hwc'
-        assert len(hwc2_fhl.table) == 40
+    def test_source_table(self, hawc_2hwc):
+        assert hawc_2hwc.name == '2hwc'
+        assert len(hawc_2hwc.table) == 40
 
 
 @requires_data('gammapy-extra')
 class TestSourceCatalogObject2HWC:
-    def test_data(self, hwc2_fhl):
-        source = hwc2_fhl[0]
+    def test_data(self, hawc_2hwc):
+        source = hawc_2hwc[0]
 
         assert source.data['source_name'] == '2HWC J0534+220'
 
     @requires_dependency('uncertainties')
-    def test_spectra(self, hwc2_fhl):
-        source0 = hwc2_fhl[0]
-        source1 = hwc2_fhl[1]
+    def test_spectra(self, hawc_2hwc):
+        source0 = hawc_2hwc[0]
+        source1 = hawc_2hwc[1]
 
-        src0_mod0 = source0.spectral_model()[0]
-        src1_mod0 = source1.spectral_model()[0]
-        src1_mod1 = source1.spectral_model()[1]
+        src0_mod0 = source0.spectral_models[0]
+        src1_mod0 = source1.spectral_models[0]
+        src1_mod1 = source1.spectral_models[1]
 
         dnde_7TeV_src0, dnde_7TeV_src0_err = src0_mod0.evaluate_error(7 * u.TeV)
         dnde_7TeV_src1_mod0, dnde_7TeV_src1_mod0_err = src1_mod0.evaluate_error(7 * u.TeV)
         dnde_7TeV_src1_mod1, dnde_7TeV_src1_mod1_err = src1_mod1.evaluate_error(7 * u.TeV)
 
-        assert_quantity_allclose(dnde_7TeV_src0, source0['dnde_spec0'], rtol=1e-3)
-        assert_quantity_allclose(dnde_7TeV_src1_mod0, source1['dnde_spec0'], rtol=1e-3)
-        assert_quantity_allclose(dnde_7TeV_src1_mod1, source1['dnde_spec1'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src0, source0.data['spec0_dnde'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod0, source1.data['spec0_dnde'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod1, source1.data['spec1_dnde'], rtol=1e-3)
 
-        assert_quantity_allclose(dnde_7TeV_src0_err, source0['dnde_spec0_err'], rtol=1e-3)
-        assert_quantity_allclose(dnde_7TeV_src1_mod0_err, source1['dnde_spec0_err'], rtol=1e-3)
-        assert_quantity_allclose(dnde_7TeV_src1_mod1_err, source1['dnde_spec1_err'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src0_err, source0.data['spec0_dnde_err'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod0_err, source1.data['spec0_dnde_err'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod1_err, source1.data['spec1_dnde_err'], rtol=1e-3)

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+import pytest
+from ..hawc import SourceCatalog2HWC
+from ...utils.testing import requires_data, requires_dependency
+
+
+@pytest.fixture(scope='session')
+def hwc2_fhl():
+    return SourceCatalog2HWC()
+
+
+@requires_data('gammapy-extra')
+class TestSourceCatalog2HWC:
+    def test_source_table(self, hwc2_fhl):
+        assert hwc2_fhl.name == '2hwc'
+        assert len(hwc2_fhl.table) == 40
+
+
+@requires_data('gammapy-extra')
+class TestSourceCatalogObject2HWC:
+    def test_data(self, hwc2_fhl):
+        source = hwc2_fhl[0]
+
+        assert source.data['source_name'] == '2HWC J0534+220'
+
+    @requires_dependency('uncertainties')
+    def test_spectra(self, hwc2_fhl):
+        source0 = hwc2_fhl[0]
+        source1 = hwc2_fhl[1]
+
+        src0_mod0 = source0.spectral_model()[0]
+        src1_mod0 = source1.spectral_model()[0]
+        src1_mod1 = source1.spectral_model()[1]
+
+        dnde_7TeV_src0, dnde_7TeV_src0_err = src0_mod0.evaluate_error(7 * u.TeV)
+        dnde_7TeV_src1_mod0, dnde_7TeV_src1_mod0_err = src1_mod0.evaluate_error(7 * u.TeV)
+        dnde_7TeV_src1_mod1, dnde_7TeV_src1_mod1_err = src1_mod1.evaluate_error(7 * u.TeV)
+
+        assert_quantity_allclose(dnde_7TeV_src0, source0['dnde_spec0'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod0, source1['dnde_spec0'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod1, source1['dnde_spec1'], rtol=1e-3)
+
+        assert_quantity_allclose(dnde_7TeV_src0_err, source0['dnde_spec0_err'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod0_err, source1['dnde_spec0_err'], rtol=1e-3)
+        assert_quantity_allclose(dnde_7TeV_src1_mod1_err, source1['dnde_spec1_err'], rtol=1e-3)


### PR DESCRIPTION
I was geared to the existing files for e.g. gamma cat, fermi and hess.
But some things where not clear to me how to transform them to hwc2, e.g. the description of the catalog. There, I added some TODOs.
@cdeil Please have a look at them and tell me what to do at these points. (We can do it via Skype if you want) 

---

EDIT by @cdeil - this is a PR implementing #887