### PR TITLE
Addition of metadata to SkyImage created with empty and empty_like

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -259,6 +259,7 @@ class SkyImage(MapBase):
                              proj, coordsys, xrefpix, yrefpix)
         data = fill * np.ones((nypix, nxpix), dtype=dtype)
         wcs = WCS(header)
+        header.update(meta)
         return cls(name=name, data=data, wcs=wcs, unit=unit, meta=header)
 
     @classmethod
@@ -290,7 +291,9 @@ class SkyImage(MapBase):
 
         data = fill * np.ones_like(image.data)
 
-        return cls(name, data, wcs, unit, meta=wcs.to_header())
+        header = wcs.to_header()
+        header.update(meta)
+        return cls(name, data, wcs, unit, meta=header)
 
     def fill_events(self, events, weights=None):
         """Fill events (modifies ``data`` attribute).

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -308,7 +308,7 @@ class TestSkyImage:
         self.image = SkyImage.empty(
             nxpix=10, nypix=5, binsz=0.2,
             xref=self.center.l.deg, yref=self.center.b.deg,
-            proj='TAN', coordsys='GAL',
+            proj='TAN', coordsys='GAL', meta={'TEST': 42},
         )
         self.image.data = np.arange(50, dtype=float).reshape((5, 10))
 
@@ -337,6 +337,9 @@ class TestSkyImage:
         smoothed = self.image.smooth(kernel, 0.2 * u.deg)
         actual = smoothed.data.sum()
         assert_allclose(actual, desired)
+
+    def test_meta(self):
+        assert self.image.meta['TEST'] == 42
 
 
 def test_image_pad():


### PR DESCRIPTION
meta keyword was left unused in SkyImage.empty and empty_like which prevented proper propagation of metadata to SkyImages.
This PR is a small patch to properly update the header Dict with the meta argument.