### PR TITLE
Fix energy bias computation

### DIFF
--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -365,7 +365,7 @@ class EnergyDispersion(object):
         """
         mean = self._get_mean(e_true)
         e_reco = (10 ** mean) * self.e_reco.unit
-        bias = (e_true - e_reco) / e_true
+        bias = (e_reco - e_true) / e_true
         return bias
 
     def _get_mean(self, e_true):


### PR DESCRIPTION
Hi

there is a small mistake in the bias calculation for the energy dispersion, `e_reco` and `e_true` were inverted in the function `EnergyDispersion.get_bias()` w.r.t the definition http://docs.gammapy.org/en/latest/api/gammapy.irf.EnergyDispersion.html

Thanks 