### PR TITLE
Extend options for energy thresholds

### DIFF
--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -372,8 +372,8 @@ class EnergyDispersion(object):
         """Get mean log reconstructed energy."""
         # Reconstructed energy is 1st moment of PDF
         pdf = self.data.evaluate(e_true=e_true)
-        norm = np.sum(pdf)
-        temp = np.sum(pdf * self.e_reco._interp_nodes())
+        norm = np.sum(pdf, axis=1)
+        temp = np.sum(pdf * self.e_reco._interp_nodes(), axis=1)
         return temp / norm
 
     def _extent(self):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -372,8 +372,8 @@ class EnergyDispersion(object):
         """Get mean log reconstructed energy."""
         # Reconstructed energy is 1st moment of PDF
         pdf = self.data.evaluate(e_true=e_true)
-        norm = np.sum(pdf, axis=1)
-        temp = np.sum(pdf * self.e_reco._interp_nodes(), axis=1)
+        norm = np.sum(pdf, axis=pdf.ndim-1)
+        temp = np.sum(pdf * self.e_reco._interp_nodes(), axis=pdf.ndim-1)
         return temp / norm
 
     def _extent(self):

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -390,6 +390,10 @@ class PHACountsSpectrum(CountsSpectrum):
             idx = np.insert(idx, 0, idx[0] - 1)
         self.quality[idx] = 1
 
+    def reset_thresholds(self):
+        """Reset energy thresholds (i.e. declare all energy bins valid)"""
+        self.quality = np.zeros_like(self.quality)
+
     def rebin(self, parameter):
         """Rebin.
 

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -233,40 +233,15 @@ class SpectrumExtraction(object):
         self._on_vector.areascal = areascal
         self._off_vector.areascal = areascal
 
-    def define_energy_threshold(self, method_lo_threshold='area_max', **kwargs):
-        """Compute and set the safe energy threshold.
+    def compute_energy_threshold(self, **kwargs):
+        """Compute and set the safe energy threshold for all observations.
 
-        Set the high and low energy threshold for each observation based on a
-        chosen method.
-
-        Available methods for setting the low energy threshold:
-
-        * area_max : Set energy threshold at x percent of the maximum effective
-          area (x given as kwargs['percent'])
-
-        Available methods for setting the high energy threshold:
-
-        * TBD
-
-        Parameters
-        ----------
-        method_lo_threshold : {'area_max'}
-            Method for defining the low energy threshold
+        See `SpectrumObservation.compute_energy_threshold` for full
+        documentation about the options.
         """
-        # TODO: This should be a method on SpectrumObservation
-        # TODO: define method for the high energy threshold
 
-        # It is important to update the low and high threshold for ON and OFF
-        # vector, otherwise Sherpa will not understand the files
         for obs in self.observations:
-            if method_lo_threshold == 'area_max':
-                aeff_thres = kwargs['percent'] / 100 * obs.aeff.max_area
-                thres = obs.aeff.find_energy(aeff_thres)
-                obs.on_vector.lo_threshold = thres
-                obs.off_vector.lo_threshold = thres
-            else:
-                raise ValueError('Undefine method for low threshold: {}'.format(
-                    method_lo_threshold))
+            obs.compute_energy_threshold(**kwargs)
 
     def write(self, outdir, ogipdir='ogip_data', use_sherpa=False):
         """Write results to disk.

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -144,6 +144,66 @@ class SpectrumObservation(object):
         if self.off_vector is not None:
             self.off_vector.hi_threshold = threshold
 
+    def reset_thresholds(self):
+        """Reset energy thresholds (i.e. declare all energy bins valid)"""
+        self.on_vector.reset_thresholds()
+        if self.off_vector is not None:
+            self.off_vector.reset_thresholds()
+
+    def compute_energy_threshold(self, method_lo='area_max', method_hi='area_max', reset=False, **kwargs):
+        """Compute and set the safe energy threshold.
+
+        Set the high and low energy threshold for each observation based on a
+        chosen method.
+
+        Available methods for setting the low energy threshold:
+
+        * area_max : Set energy threshold at x percent of the maximum effective
+          area (x given as kwargs['area_percent_lo'])
+
+        Available methods for setting the high energy threshold:
+
+        * area_max : Set energy threshold at x percent of the maximum effective
+          area (x given as kwargs['area_percent_hi'])
+
+        Parameters
+        ----------
+        method_lo : {'area_max'}
+            Method for defining the low energy threshold
+
+        method_hi : {'area_max'}
+            Method for defining the high energy threshold
+
+        reset : bool
+            Reset existing energy thresholds before setting the new ones
+            (default is `False`)
+        """
+
+        if reset:
+            self.reset_thresholds()
+
+        # It is important to update the low and high threshold for ON and OFF
+        # vector, otherwise Sherpa will not understand the files
+        if method_lo == 'area_max':
+            aeff_thres = kwargs['area_percent_lo'] / 100 * self.aeff.max_area
+            thres = self.aeff.find_energy(aeff_thres)
+            self.on_vector.lo_threshold = thres
+            if self.off_vector is not None:
+                self.off_vector.lo_threshold = thres
+        else:
+            raise ValueError('Undefine method for low threshold: {}'.format(
+                method_lo))
+
+        if method_hi == 'area_max':
+            aeff_thres = kwargs['area_percent_hi'] / 100 * self.aeff.max_area
+            thres = self.aeff.find_energy(aeff_thres, reverse=True)
+            self.on_vector.hi_threshold = thres
+            if self.off_vector is not None:
+                self.off_vector.hi_threshold = thres
+        else:
+            raise ValueError('Undefined method for high threshold: {}'.format(
+                method_hi))
+
     @property
     def background_vector(self):
         """Background `~gammapy.spectrum.CountsSpectrum`.


### PR DESCRIPTION
This PR adds more options to define energy thresholds for `SpectrumObservation` objects. For now, I only added the possibility to define the `hi_threshold` in the same way as is possible for the `lo_threshold`. I will probably add more if I find the time, but this could be merged already.

Note that I also added options to reset the energy thresholds.