### PR TITLE
Fix energy bias computation

### DIFF
--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -372,8 +372,8 @@ class EnergyDispersion(object):
         """Get mean log reconstructed energy."""
         # Reconstructed energy is 1st moment of PDF
         pdf = self.data.evaluate(e_true=e_true)
-        norm = np.sum(pdf)
-        temp = np.sum(pdf * self.e_reco._interp_nodes())
+        norm = np.sum(pdf, axis=1)
+        temp = np.sum(pdf * self.e_reco._interp_nodes(), axis=1)
         return temp / norm
 
     def _extent(self):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -372,8 +372,8 @@ class EnergyDispersion(object):
         """Get mean log reconstructed energy."""
         # Reconstructed energy is 1st moment of PDF
         pdf = self.data.evaluate(e_true=e_true)
-        norm = np.sum(pdf, axis=1)
-        temp = np.sum(pdf * self.e_reco._interp_nodes(), axis=1)
+        norm = np.sum(pdf, axis=pdf.ndim-1)
+        temp = np.sum(pdf * self.e_reco._interp_nodes(), axis=pdf.ndim-1)
         return temp / norm
 
     def _extent(self):


### PR DESCRIPTION
The energy bias computation in `energy_dispersion.EnergyDispersion` is broken. It computes the average log reconstructed energy over all bins of the pdf rather than column-wise. I think this PR should fix this bug, but it would be nice if someone would confirm this (the result can easily be plotted using `plot_bias()`).