### PR TITLE
Add Fermi catalog 3FHL and 3FGL source class selection

### DIFF
--- a/gammapy/background/models.py
+++ b/gammapy/background/models.py
@@ -163,27 +163,8 @@ class GaussianBand2D(object):
     spline_kwargs : dict
         Keyword arguments passed to `~scipy.interpolate.UnivariateSpline`
     """
-    boundary_left = {'GLON': 75,
-                     'GLAT': 0,
-                     'GLAT_Err': 0,
-                     'Surface_Brightness': 0,
-                     'Surface_Brightness_Err': 0,
-                     'Width': 0,
-                     'Width_Err': 0}
-
-    boundary_right = {'GLON': 240,
-                     'GLAT': 0,
-                     'GLAT_Err': 0,
-                     'Surface_Brightness': 0,
-                     'Surface_Brightness_Err': 0,
-                     'Width': 0,
-                     'Width_Err': 0}
-
     def __init__(self, table, spline_kwargs=DEFAULT_SPLINE_KWARGS):
         from scipy.interpolate import UnivariateSpline
-
-        table.insert_row(index=0, vals=self.boundary_right)
-        table.add_row(vals=self.boundary_left)
 
         self.table = table
         glon = Angle(self.table['GLON']).wrap_at('180d')

--- a/gammapy/background/models.py
+++ b/gammapy/background/models.py
@@ -163,9 +163,27 @@ class GaussianBand2D(object):
     spline_kwargs : dict
         Keyword arguments passed to `~scipy.interpolate.UnivariateSpline`
     """
+    boundary_left = {'GLON': 75,
+                     'GLAT': 0,
+                     'GLAT_Err': 0,
+                     'Surface_Brightness': 0,
+                     'Surface_Brightness_Err': 0,
+                     'Width': 0,
+                     'Width_Err': 0}
+
+    boundary_right = {'GLON': 240,
+                     'GLAT': 0,
+                     'GLAT_Err': 0,
+                     'Surface_Brightness': 0,
+                     'Surface_Brightness_Err': 0,
+                     'Width': 0,
+                     'Width_Err': 0}
 
     def __init__(self, table, spline_kwargs=DEFAULT_SPLINE_KWARGS):
         from scipy.interpolate import UnivariateSpline
+
+        table.insert_row(index=0, vals=self.boundary_right)
+        table.add_row(vals=self.boundary_left)
 
         self.table = table
         glon = Angle(self.table['GLON']).wrap_at('180d')

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -37,10 +37,6 @@ __all__ = [
 ]
 
 
-FERMI_GALACTIC = []
-FERMI_EXTRA_GALACTIC = []
-
-
 def compute_flux_points_ul(quantity, quantity_errp):
     """Compute UL value for fermi flux points.
 
@@ -898,13 +894,13 @@ class SourceCatalog3FGL(SourceCatalog):
     name = '3fgl'
     description = 'LAT 4-year point source catalog'
     source_object_class = SourceCatalogObject3FGL
-    source_classes = {'galactic': ['psr', 'pwn', 'snr', 'spp',  'glc'],
-                      'extra-galactic': ['css', 'bll', 'fsrq', 'agn', 'nlsy1',
+    source_categories = {'galactic': ['psr', 'pwn', 'snr', 'spp',  'glc'],
+                         'extra-galactic': ['css', 'bll', 'fsrq', 'agn', 'nlsy1',
                                          'rdg', 'sey', 'bcu', 'gal', 'sbg', 'ssrq'],
-                      'GALACTIC': ['PSR', 'PWN',  'SNR', 'HMB', 'BIN', 'NOV', 'SFR'],
-                      'EXTRA-GALACTIC': ['CSS', 'BLL', 'FSRQ', 'AGN', 'NLSY1',
-                                         'RDG', 'SEY', 'BCU', 'GAL', 'SBG', 'SSRQ']
-                      }
+                         'GALACTIC': ['PSR', 'PWN',  'SNR', 'HMB', 'BIN', 'NOV', 'SFR'],
+                         'EXTRA-GALACTIC': ['CSS', 'BLL', 'FSRQ', 'AGN', 'NLSY1',
+                                         'RDG', 'SEY', 'BCU', 'GAL', 'SBG', 'SSRQ'],
+                         'unassociated': ['']}
 
     def __init__(self, filename='$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psc_v16.fit.gz'):
         filename = str(make_path(filename))
@@ -925,51 +921,70 @@ class SourceCatalog3FGL(SourceCatalog):
 
         self.extended_sources_table = Table.read(filename, hdu='ExtendedSources')
 
-    def select_source_class(self, source_class):
+    def is_source_class(self, source_class):
         """
-        Select all sources of a given source class.
+        Check if source belongs to a given source class.
 
         The classes are described in Table 3 of the 3FGL paper:
 
         http://adsabs.harvard.edu/abs/2015arXiv150102003T
 
-        There are a few extra selections available:
+        Parameters
+        ----------
+        source_class : str
+            Source class designator as defined in Table 3. There are a few extra
+            selections available:
 
-        - `'ALL'`: all identified objects
-        - `'all'`: all objects with associations
-        - `'galactic'`: all sources with an associated galactic object
-        - `'GALACTIC'`: all identified galactic sources
-        - `'extra-galactic'`: all sources with an associated extra-galactic object
-        - `'EXTRA-GALACTIC'`: all identified extra-galactic sources
-        - `'unassociated'`: all unassociated objects
+            - `'ALL'`: all identified objects
+            - `'all'`: all objects with associations
+            - `'galactic'`: all sources with an associated galactic object
+            - `'GALACTIC'`: all identified galactic sources
+            - `'extra-galactic'`: all sources with an associated extra-galactic object
+            - `'EXTRA-GALACTIC'`: all identified extra-galactic sources
+            - `'unassociated'`: all unassociated objects
+
+        Returns
+        -------
+        selection : `~numpy.ndarray`
+            Selection mask.
+        """
+        source_class_info = np.array([_.strip() for _ in self.table['CLASS1']])
+
+        if source_class in self.source_categories:
+            category = set(self.source_categories[source_class])
+        elif source_class == 'ALL':
+            category = set(self.source_categories['EXTRA-GALACTIC']
+                            + self.source_categories['GALACTIC'])
+        elif source_class == 'all':
+            category = set(self.source_categories['extra-galactic']
+                            + self.source_categories['galactic'])
+        elif source_class in np.unique(source_class_info):
+            category = set(source_class)
+        else:
+            raise ValueError("'{}' ist not a valid source class.".format(source_class))
+
+        selection = np.array([ _ in category for _ in source_class_info])
+        return selection
+
+
+    def select_source_class(self, source_class):
+        """
+        Select all sources of a given source class.
+
+        See `SourceCatalog3FHL.is_source_class` for further documentation
 
         Parameters
         ----------
         source_class : str
             Source class designator.
+
+        Returns
+        -------
+        selection : `SourceCatalog3FHL`
+            Subset of the 3FHL catalog containing only the selected source class.
         """
         catalog = self.copy()
-        source_class_column = np.char.strip(catalog.table['CLASS1'])
-        source_classes_id = list(self.source_classes['EXTRA-GALACTIC']
-                               + self.source_classes['GALACTIC'])
-        source_classes_assoc = list(self.source_classes['extra-galactic']
-                                  + self.source_classes['galactic'])
-
-        source_classes_all = source_classes_id + source_classes_assoc
-
-        if source_class in self.source_classes:
-            selection = np.in1d(source_class_column, self.source_classes[source_class])
-        elif source_class == 'ALL':
-            selection = np.in1d(source_class_column, source_classes_id)
-        elif source_class == 'all':
-            selection = np.in1d(source_class_column, source_classes_assoc)
-        elif source_class == 'unassociated':
-            selection = (source_class_column == '')
-        elif source_class in source_classes_all:
-            selection = (source_class_column == source_class)
-        else:
-            raise ValueError("'{}' ist not a valid source class.".format(source_class))
-
+        selection = self.is_source_class(source_class)
         catalog.table = catalog.table[selection]
         return catalog
 
@@ -1039,11 +1054,11 @@ class SourceCatalog3FHL(SourceCatalog):
     name = '3fhl'
     description = 'LAT third high-energy source catalog'
     source_object_class = SourceCatalogObject3FHL
-    source_classes = {'galactic': ['glc', 'hmb', 'psr', 'pwn',  'sfr', 'snr', 'spp'],
-                      'extra-galactic': ['agn', 'bcu', 'bll', 'fsrq', 'rdg', 'sbg'],
-                      'GALACTIC': ['BIN', 'HMB',  'PSR', 'PWN', 'SFR', 'SNR'],
-                      'EXTRA-GALACTIC': ['BLL', 'FSRQ', 'NLSY1', 'RDG']
-                      }
+    source_categories = {'galactic': ['glc', 'hmb', 'psr', 'pwn',  'sfr', 'snr', 'spp'],
+                         'extra-galactic': ['agn', 'bcu', 'bll', 'fsrq', 'rdg', 'sbg'],
+                         'GALACTIC': ['BIN', 'HMB',  'PSR', 'PWN', 'SFR', 'SNR'],
+                         'EXTRA-GALACTIC': ['BLL', 'FSRQ', 'NLSY1', 'RDG'],
+                         'unassociated': ['']}
 
     def __init__(self, filename='$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v13.fit.gz'):
         filename = str(make_path(filename))
@@ -1064,52 +1079,68 @@ class SourceCatalog3FHL(SourceCatalog):
         self.rois = Table.read(filename, hdu='ROIs')
         self.energy_bounds_table = Table.read(filename, hdu='EnergyBounds')
 
+    def is_source_class(self, source_class):
+        """
+        Check if source belongs to a given source class.
+
+        The classes are described in Table 3 of the 3FGL paper:
+
+        http://adsabs.harvard.edu/abs/2015arXiv150102003T
+
+        Parameters
+        ----------
+        source_class : str
+            Source class designator as defined in Table 3. There are a few extra
+            selections available:
+
+            - `'ALL'`: all identified objects
+            - `'all'`: all objects with associations
+            - `'galactic'`: all sources with an associated galactic object
+            - `'GALACTIC'`: all identified galactic sources
+            - `'extra-galactic'`: all sources with an associated extra-galactic object
+            - `'EXTRA-GALACTIC'`: all identified extra-galactic sources
+            - `'unassociated'`: all unassociated objects
+
+        Returns
+        -------
+        selection : `~numpy.ndarray`
+            Selection mask.
+        """
+        source_class_info = np.array([_.strip() for _ in self.table['CLASS']])
+
+        if source_class in self.source_categories:
+            category = set(self.source_categories[source_class])
+        elif source_class == 'ALL':
+            category = set(self.source_categories['EXTRA-GALACTIC']
+                            + self.source_categories['GALACTIC'])
+        elif source_class == 'all':
+            category = set(self.source_categories['extra-galactic']
+                            + self.source_categories['galactic'])
+        elif source_class in np.unique(source_class_info):
+            category = set(source_class)
+        else:
+            raise ValueError("'{}' ist not a valid source class.".format(source_class))
+
+        selection = np.array([ _ in category for _ in source_class_info])
+        return selection
+
     def select_source_class(self, source_class):
         """
         Select all sources of a given source class.
 
-        The classes are described in Table 2 of the 3FHL paper:
-
-        http://adsabs.harvard.edu/abs/2017arXiv170200664T
-
-        There are a few extra selections available:
-
-        - `'all'`: all objects with associations
-        - `'ALL'`: all identified objects
-        - `'galactic'`: all sources with an associated galactic object
-        - `'GALACTIC'`: all identified galactic sources
-        - `'extra-galactic'`: all sources with an associated extra-galactic object
-        - `'EXTRA-GALACTIC'`: all identified extra-galactic sources
-        - `'unassociated'`: all unassociated objects
+        See `SourceCatalog3FHL.is_source_class` for further documentation
 
         Parameters
         ----------
         source_class : str
             Source class designator.
+
+        Returns
+        -------
+        selection : `SourceCatalog3FHL`
+            Subset of the 3FHL catalog containing only the selected source class.
         """
         catalog = self.copy()
-        source_class_column = np.char.strip(catalog.table['CLASS'])
-
-        source_classes_id = list(self.source_classes['EXTRA-GALACTIC']
-                               + self.source_classes['GALACTIC'])
-        source_classes_assoc = list(self.source_classes['extra-galactic']
-                                  + self.source_classes['galactic'])
-        source_classes_all = source_classes_id + source_classes_assoc
-
-        if source_class in self.source_classes:
-            selection = np.in1d(source_class_column, self.source_classes[source_class])
-        elif source_class == 'ALL':
-            selection = np.in1d(source_class_column, source_classes_id)
-        elif source_class == 'all':
-            selection = np.in1d(source_class_column, source_classes_assoc)
-        elif source_class == 'unassociated':
-            selection = (source_class_column == '')
-        elif source_class in source_classes_all:
-            selection = (source_class_column == source_class)
-        elif source_class == 'unknown':
-            selection = (source_class_column == 'unknown')
-        else:
-            raise ValueError("'{}' ist not a valid source class.".format(source_class))
-
+        selection = self.is_source_class(source_class)
         catalog.table = catalog.table[selection]
         return catalog

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -37,6 +37,10 @@ __all__ = [
 ]
 
 
+FERMI_GALACTIC = []
+FERMI_EXTRA_GALACTIC = []
+
+
 def compute_flux_points_ul(quantity, quantity_errp):
     """Compute UL value for fermi flux points.
 
@@ -902,7 +906,6 @@ class SourceCatalog3FGL(SourceCatalog):
                                          'RDG', 'SEY', 'BCU', 'GAL', 'SBG', 'SSRQ']
                       }
 
-
     def __init__(self, filename='$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psc_v16.fit.gz'):
         filename = str(make_path(filename))
 
@@ -921,7 +924,6 @@ class SourceCatalog3FGL(SourceCatalog):
         )
 
         self.extended_sources_table = Table.read(filename, hdu='ExtendedSources')
-
 
     def select_source_class(self, source_class):
         """
@@ -948,7 +950,6 @@ class SourceCatalog3FGL(SourceCatalog):
         """
         catalog = self.copy()
         source_class_column = np.char.strip(catalog.table['CLASS1'])
-
         source_classes_id = list(self.source_classes['EXTRA-GALACTIC']
                                + self.source_classes['GALACTIC'])
         source_classes_assoc = list(self.source_classes['extra-galactic']

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -419,7 +419,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         model.parameters.set_parameter_errors(errs)
         return model
 
-    def spatial_model(self, emin=1 * u.TeV, emax=10 * u.TeV):
+    def spatial_model(self, emin=1 * u.TeV, emax=1E5 * u.TeV):
         """
         Source spatial model.
         """
@@ -453,17 +453,9 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             try:
                 models = [component.spatial_model for component in self.components]
             except AttributeError:
-                amplitude = d['Flux_Map'].to('cm-2 s-1').value
-                pars = {}
-                glon = Angle(d['GLON']).wrap_at('180d')
-                glat = Angle(d['GLAT']).wrap_at('180d')
-
-                pars['x_mean'] = glon.value
-                pars['y_mean'] = glat.value
-                pars['x_stddev'] = d['Size'].to('deg').value
-                pars['y_stddev'] = d['Size'].to('deg').value
-                pars['amplitude'] = amplitude * 1 / (2 * np.pi * pars['x_stddev'] ** 2)
-                return Gaussian2D(**pars)
+                # there is one external source (HESS J1801-233) where there is no
+                # component info available, so we create it here locally
+                models = [HGPSGaussComponent(d).spatial_model]
 
             for model in models:
                 # weight total flux according to relative amplitude

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -450,7 +450,20 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
         elif spatial_model in ['Gaussian', '2-Gaussian', '3-Gaussian']:
             amplitude_total = d['Flux_Map'].to('cm-2 s-1').value
-            models = [component.spatial_model for component in self.components]
+            try:
+                models = [component.spatial_model for component in self.components]
+            except AttributeError:
+                amplitude = d['Flux_Map'].to('cm-2 s-1').value
+                pars = {}
+                glon = Angle(d['GLON']).wrap_at('180d')
+                glat = Angle(d['GLAT']).wrap_at('180d')
+
+                pars['x_mean'] = glon.value
+                pars['y_mean'] = glat.value
+                pars['x_stddev'] = d['Size'].to('deg').value
+                pars['y_stddev'] = d['Size'].to('deg').value
+                pars['amplitude'] = amplitude * 1 / (2 * np.pi * pars['x_stddev'] ** 2)
+                return Gaussian2D(**pars)
 
             for model in models:
                 # weight total flux according to relative amplitude

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -554,7 +554,7 @@ class SourceCatalogHGPS(SourceCatalog):
         """Large sclae component model (`~gammapy.background.models.GaussianBand2D`).
         """
         table = self._large_scale_component
-        return GaussianBand2D(table, spline_kwargs=dict(k=3, s=0))
+        return GaussianBand2D(table, spline_kwargs=dict(k=3, s=0, ext=0))
 
     def _make_source_object(self, index):
         """Make one source object.

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -270,6 +270,9 @@ class TestSourceCatalog3FGL:
         selection = self.cat.select_source_class('unassociated')
         assert len(selection.table) == 1010
 
+        selection = self.cat.select_source_class('ALL')
+        assert len(selection.table) == 239
+
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog1FHL:
@@ -329,3 +332,6 @@ class TestSourceCatalog3FHL:
 
         selection = self.cat.select_source_class('unassociated')
         assert len(selection.table) == 177
+
+        selection = self.cat.select_source_class('ALL')
+        assert len(selection.table) == 135

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -260,6 +260,16 @@ class TestSourceCatalog3FGL:
         table = self.cat.extended_sources_table
         assert len(table) == 25
 
+    def test_select_source_classes(self):
+        selection = self.cat.select_source_class('galactic')
+        assert len(selection.table) == 101
+
+        selection = self.cat.select_source_class('extra-galactic')
+        assert len(selection.table) == 1684
+
+        selection = self.cat.select_source_class('unassociated')
+        assert len(selection.table) == 1010
+
 
 @requires_data('gammapy-extra')
 class TestSourceCatalog1FHL:
@@ -309,3 +319,13 @@ class TestSourceCatalog3FHL:
     def test_extended_sources(self):
         table = self.cat.extended_sources_table
         assert len(table) == 55
+
+    def test_select_source_classes(self):
+        selection = self.cat.select_source_class('galactic')
+        assert len(selection.table) == 44
+
+        selection = self.cat.select_source_class('extra-galactic')
+        assert len(selection.table) == 1177
+
+        selection = self.cat.select_source_class('unassociated')
+        assert len(selection.table) == 177

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -49,6 +49,11 @@ class TestSourceCatalogHGPS:
 
         assert_quantity_allclose(flux_ls, source.data['Flux_Map_RSpec_LS'], rtol=1E-2)
 
+    def test_hessj1801_spatial_model(self):
+        # special test for the only extern source with a gaussian morphology
+        source = self.cat['HESS J1801-233']
+        assert_allclose(source.spatial_model().amplitude, 2.488E-12, rtol=1E-3)
+
 
 @requires_data('hgps')
 class TestSourceCatalogObjectHGPS:

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -505,6 +505,8 @@ class PowerLaw(SpectralModel):
     --------
     This is how to plot the default `PowerLaw` model:
 
+    .. code::
+
         from astropy import units as u
         from gammapy.spectrum.models import PowerLaw
 
@@ -707,6 +709,8 @@ class PowerLaw2(SpectralModel):
     --------
     This is how to plot the default `PowerLaw2` model:
 
+    .. code::
+
         from astropy import units as u
         from gammapy.spectrum.models import PowerLaw2
 
@@ -826,6 +830,8 @@ class ExponentialCutoffPowerLaw(SpectralModel):
     --------
     This is how to plot the default `ExponentialCutoffPowerLaw` model:
 
+    .. code::
+
         from astropy import units as u
         from gammapy.spectrum.models import ExponentialCutoffPowerLaw
 
@@ -920,6 +926,8 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
     --------
     This is how to plot the default `ExponentialCutoffPowerLaw3FGL` model:
 
+    .. code::
+
         from astropy import units as u
         from gammapy.spectrum.models import ExponentialCutoffPowerLaw3FGL
 
@@ -975,6 +983,8 @@ class PLSuperExpCutoff3FGL(SpectralModel):
     Examples
     --------
     This is how to plot the default `PLSuperExpCutoff3FGL` model:
+
+    .. code::
 
         from astropy import units as u
         from gammapy.spectrum.models import PLSuperExpCutoff3FGL
@@ -1032,6 +1042,8 @@ class LogParabola(SpectralModel):
     Examples
     --------
     This is how to plot the default `LogParabola` model:
+
+    .. code::
 
         from astropy import units as u
         from gammapy.spectrum.models import LogParabola


### PR DESCRIPTION
This PR adds a `.select_source_class()` method to the `SourceCatalog3FHL` and `SourceCatalog3FGL` classes.  This allows users to simply and conveniently select sub-classes of sources and still keep the original table e.g.:
```python
from gammapy.catalog import SourceCatalog3FHL
fermi_3fhl = SourceCatalog3FHL()
fermi_galactic = fermi_3fhl.select_source_class('galactic')
fermi_extra_galactic = fermi_3fhl.select_source_class('extra-galactic')
```

What I don't like at the moment is the amount of code duplication between the Fermi-LAT catalog classes. I guess at some point we should introduce a `SourceCatalogFermi` base class... 