### PR TITLE
Include module-level variables in API docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,7 @@ See the complete `Gammapy 0.7 merged pull requests list on Github <https://githu
 - [#1014] Introduce TSImageEstimator class (Axel Donath)
 - [#1013] Add Fermi-LAT 3FHL spatial models (Axel Donath)
 - [#845] Add background model component to SpectrumFit (Johannes King)
+- [#111] Include module-level variables in API docs (Christoph Deil)
 
 .. _gammapy_0p6_release:
 

--- a/docs/astro/population/index.rst
+++ b/docs/astro/population/index.rst
@@ -74,3 +74,4 @@ Reference/API
 
 .. automodapi:: gammapy.astro.population
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/astro/source/index.rst
+++ b/docs/astro/source/index.rst
@@ -33,3 +33,4 @@ Reference/API
 
 .. automodapi:: gammapy.astro.source
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/background/index.rst
+++ b/docs/background/index.rst
@@ -44,3 +44,4 @@ Reference/API
 
 .. automodapi:: gammapy.background
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/catalog/index.rst
+++ b/docs/catalog/index.rst
@@ -114,3 +114,4 @@ Reference/API
 
 .. automodapi:: gammapy.catalog
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,8 @@ conf = ConfigParser()
 conf.read([os.path.join(os.path.dirname(__file__), '..', 'setup.cfg')])
 setup_cfg = dict(conf.items('metadata'))
 
+plot_html_show_source_link = False
+
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/cube/index.rst
+++ b/docs/cube/index.rst
@@ -50,3 +50,4 @@ Reference/API
 
 .. automodapi:: gammapy.cube
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -55,3 +55,4 @@ Reference/API
 
 .. automodapi:: gammapy.data
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -147,4 +147,4 @@ Reference/API
 
 .. automodapi:: gammapy.datasets
     :no-inheritance-diagram:
-
+    :include-all-objects:

--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -149,3 +149,4 @@ Reference/API
 
 .. automodapi:: gammapy.detect
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/image/index.rst
+++ b/docs/image/index.rst
@@ -56,7 +56,9 @@ Reference/API
 
 .. automodapi:: gammapy.image
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.image.models
     :no-inheritance-diagram:
+    :include-all-objects:
 

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -49,3 +49,4 @@ Reference/API
 
 .. automodapi:: gammapy.irf
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -369,6 +369,4 @@ Reference/API
 
 .. automodapi:: gammapy.maps
     :no-inheritance-diagram:
-
-
-
+    :include-all-objects:

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -111,3 +111,4 @@ Reference/API
 
 .. automodapi:: gammapy.scripts
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -85,6 +85,8 @@ Reference/API
 
 .. automodapi:: gammapy.spectrum
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.spectrum.models
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -120,3 +120,4 @@ Reference/API
 
 .. automodapi:: gammapy.stats
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -115,4 +115,4 @@ Reference/API
 
 .. automodapi:: gammapy.time
     :no-inheritance-diagram:
-
+    :include-all-objects:

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -169,42 +169,56 @@ Reference/API
 
 .. automodapi:: gammapy.utils.energy
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.units
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.coordinates
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.table
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.fits
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.root
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.random
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.distributions
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.scripts
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.testing
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.wcs
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.nddata
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.time
     :no-inheritance-diagram:
+    :include-all-objects:
 
 .. automodapi:: gammapy.utils.modeling
     :no-inheritance-diagram:
+    :include-all-objects:

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -13,8 +13,8 @@ from ...utils.coordinates import D_SUN_TO_GALACTIC_CENTER
 from ...utils.distributions import draw, pdf
 from ...utils.random import sample_sphere, sample_sphere_distance, get_random_state
 from ..source import SNR, SNRTrueloveMcKee, PWN, Pulsar
-from ..population import Exponential, FaucherSpiral, RMIN, RMAX, ZMIN, ZMAX, radial_distributions
-from ..population import VMIN, VMAX, velocity_distributions
+from ..population.spatial import Exponential, FaucherSpiral, RMIN, RMAX, ZMIN, ZMAX, radial_distributions
+from ..population.velocity import VMIN, VMAX, velocity_distributions
 
 __all__ = [
     'make_catalog_random_positions_cube',

--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -1,13 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Galactic radial source distribution probability density functions.
-
-Attributes
-----------
-radial_distributions : `~collections.OrderedDict`
-    Dictionary of available spatial distributions.
-
-    Useful for automatic processing.
-"""
+"""Galactic radial source distribution probability density functions."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import numpy as np
@@ -29,8 +21,6 @@ __all__ = [
     'FaucherSpiral',
     'ValleeSpiral',
     'radial_distributions',
-    'RMIN', 'RMAX',
-    'ZMIN', 'ZMAX',
 ]
 
 # Simulation range used for random number drawing
@@ -512,14 +502,8 @@ class ValleeSpiral(LogSpiral):
         self.bar = dict(x=Quantity([x_0, x_1]), y=Quantity([y_0, y_1]))
 
 
-# TODO: this is not picked up in the HTML docs ... don't know why.
-# http://sphinx-doc.org/latest/ext/example_numpy.html
-# For now I add it in the module-level docstring in an `Attributes` section.
 radial_distributions = OrderedDict()
-"""Dictionary of available spatial distributions.
-
-Useful for automatic processing.
-"""
+radial_distributions.__doc__ = """Radial distribution (dict mapping names to classes)."""
 radial_distributions['CB98'] = CaseBattacharya1998
 radial_distributions['F06'] = FaucherKaspi2006
 radial_distributions['L06'] = Lorimer2006

--- a/gammapy/astro/population/tests/test_spatial.py
+++ b/gammapy/astro/population/tests/test_spatial.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import pytest
 from astropy.modeling.tests.test_models import Fittable1DModelTester
-from ...population import (FaucherKaspi2006, Lorimer2006,
-                           YusifovKucuk2004, YusifovKucuk2004B,
-                           Paczynski1990, CaseBattacharya1998,
-                           RMIN, RMAX, ZMIN, ZMAX, Exponential)
+from ..spatial import (FaucherKaspi2006, Lorimer2006,
+                       YusifovKucuk2004, YusifovKucuk2004B,
+                       Paczynski1990, CaseBattacharya1998,
+                       RMIN, RMAX, ZMIN, ZMAX, Exponential)
 from .test_velocity import velocity_models_1D
 
 radial_models_1D = {

--- a/gammapy/astro/population/tests/test_velocity.py
+++ b/gammapy/astro/population/tests/test_velocity.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ...population import (FaucherKaspi2006VelocityMaxwellian,
-                           Paczynski1990Velocity,
-                           FaucherKaspi2006VelocityBimodal, VMAX, VMIN)
+from ..velocity import (FaucherKaspi2006VelocityMaxwellian,
+                        Paczynski1990Velocity,
+                        FaucherKaspi2006VelocityBimodal, VMAX, VMIN)
 
 velocity_models_1D = {
 

--- a/gammapy/astro/population/velocity.py
+++ b/gammapy/astro/population/velocity.py
@@ -11,7 +11,6 @@ __all__ = [
     'FaucherKaspi2006VelocityBimodal',
     'Paczynski1990Velocity',
     'velocity_distributions',
-    'VMIN', 'VMAX',
 ]
 
 # Simulation range used for random number drawing
@@ -119,10 +118,7 @@ class Paczynski1990Velocity(Fittable1DModel):
 
 
 velocity_distributions = OrderedDict()
-"""Dictionary of available distributions.
-
-Useful for automatic processing.
-"""
+velocity_distributions.__doc__ = """Velocity distributions (dict mapping names to classes)."""
 velocity_distributions['H05'] = FaucherKaspi2006VelocityMaxwellian
 velocity_distributions['F06B'] = FaucherKaspi2006VelocityBimodal
 velocity_distributions['F06P'] = Paczynski1990Velocity

--- a/gammapy/data/observers.py
+++ b/gammapy/data/observers.py
@@ -1,71 +1,81 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Location of gamma-ray observatories.
-
-TODO: Define observers and convenience functions to convert celestial
-SkyCoords to the horizontal altitude-azimuth system.
-Or show how to do that in the docs.
-"""
+"""Location of gamma-ray observatories."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.units import Quantity
-from astropy.coordinates import Angle, EarthLocation
-from ..extern.bunch import Bunch
+from collections import OrderedDict
+from astropy.coordinates import EarthLocation
 
 __all__ = [
     'observatory_locations',
 ]
 
 
-def _obs_loc(lon, lat, height):
-    return EarthLocation(
-        lon=Angle(lon, unit='deg'),
-        lat=Angle(lat, unit='deg'),
-        height=Quantity(height, 'm'),
-    )
+observatory_locations = OrderedDict()
+observatory_locations.__doc__ = """Gamma-ray observatory locations (`~collections.OrderedDict`).
 
+This is an `~collections.OrderedDict` with string keys 
+nd values of type `~astropy.coordinates.EarthLocation`.
 
-# TODO: make this appear in the Sphinx docs!
-# https://github.com/gammapy/gammapy/issues/111
-# https://github.com/astropy/astropy-helpers/issues/117
-"""Cherenkov telescope observatory Earth locations.
+Not that with ``EarthLocation`` the orientation of angles is as follows:
+
+- longitude is east for positive values and west for negative values
+- latitude is north for positive values and south for negative values 
 
 Available observatories (alphabetical order):
-- CTA (`Website <http://www.cta-observatory.org/>`__, `Wikipedia <http://en.wikipedia.org/wiki/Cherenkov_Telescope_Array>`__):
-  Several candidate sites are listed here:
-  CTA_South_Aar, CTA_South_Armazones, CTA_South_Leoncito, CTA_North_Teide, CTA_North_Meteor_Crater
-- HAWC (`Website <>`__, `Wikipedia <http://en.wikipedia.org/wiki/High_Altitude_Water_Cherenkov_Experiment>`__)
-- HEGRA (`Wikipedia <http://en.wikipedia.org/wiki/HEGRA>`__)
-- HESS (`Website <https://www.mpi-hd.mpg.de/hfm/HESS/>`__, `Wikipedia <http://en.wikipedia.org/wiki/HESS>`__)
-- MAGIC (`Website <https://wwwmagic.mpp.mpg.de/>`__, `Wikipedia <http://en.wikipedia.org/wiki/MAGIC_(telescope)>`__)
-- MILAGRO (`Website <>`__, `Wikipedia <http://en.wikipedia.org/wiki/Milagro_(experiment)>`__)
-- VERITAS (`Website <http://veritas.sao.arizona.edu/>`__, `Wikipedia <http://en.wikipedia.org/wiki/VERITAS>`__)
-- WHIPPLE (`Wikipedia <http://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory>`__)
+
+- ``cta_south`` and ``cta_north`` for CTA, see
+  `Website <http://www.cta-observatory.org/>`__ and
+  `Wikipedia <http://en.wikipedia.org/wiki/Cherenkov_Telescope_Array>`__
+- ``hawc`` for HAWC, see
+  `Website <https://www.hawc-observatory.org/>`__ and
+  `Wikipedia <http://en.wikipedia.org/wiki/High_Altitude_Water_Cherenkov_Experiment>`__
+- ``hegra`` for HEGRA, see `Wikipedia <http://en.wikipedia.org/wiki/HEGRA>`__
+- ``hess`` for HESS, see
+  `Website <https://www.mpi-hd.mpg.de/hfm/HESS/>`__ and
+  `Wikipedia <http://en.wikipedia.org/wiki/HESS>`__
+- ``magic`` for MAGIC, see
+  `Website <https://wwwmagic.mpp.mpg.de/>`__ and
+  `Wikipedia <http://en.wikipedia.org/wiki/MAGIC_(telescope)>`__
+- ``milagro`` for MILAGRO, see
+  `Wikipedia <http://en.wikipedia.org/wiki/Milagro_(experiment)>`__)
+- ``veritas`` for VERITAS, see
+  `Website <http://veritas.sao.arizona.edu/>`__ and `Wikipedia <http://en.wikipedia.org/wiki/VERITAS>`__
+- ``whipple`` for WHIPPLE, see `Wikipedia <http://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory>`__
 
 Examples
 --------
 
-from gammapy.data import observatory_locations
-observatory_locations['HESS']
-observatory_locations.HESS
-list(observatory_locations.keys())
+>>> from gammapy.data import observatory_locations
+>>> observatory_locations['hess']
+>>> list(observatory_locations.keys())
 """
-# Locations / height info mostly taken from Wikipedia unless noted differently
-observatory_locations = Bunch()
-# The selection of CTA candidate sites is somewhat random ... there's other candidate sites I think
-# http://en.wikipedia.org/wiki/Cherenkov_Telescope_Array#Site_Selection
-observatory_locations['CTA_South_Aar'] = _obs_loc(lon='16.44d', lat='-26.69d', height=1650)
-observatory_locations['CTA_South_Armazones'] = _obs_loc(lon='-70.24d', lat='-24.58d', height=2500)
-observatory_locations['CTA_South_Armazones_2K'] = _obs_loc(lon='-70.31d', lat='-24.69d', height=2100)
-observatory_locations['CTA_South_Leoncito'] = _obs_loc(lon='-69.27d', lat='31.72d', height=2640)
-observatory_locations['CTA_North_Teide'] = _obs_loc(lon='-16.54d', lat='28.28d', height=2290)
-observatory_locations['CTA_North_Meteor_Crator'] = _obs_loc(lon='-111.03d', lat='35.04d', height=1680)
+
+# Values from https://www.cta-observatory.org/about/array-locations/chile/
+# Latitude: 24d41m0.34s South, Longitude: 70d18m58.84s West, Height: not given
+# Email from Gernot Maier on Sep 8, 2017, stating what they use in the CTA MC group:
+# lon=-70.31634499364885d, lat=-24.68342915473787d, height=2150m
+observatory_locations['cta_south'] = EarthLocation(lon='-70d18m58.84s', lat='-24d41m0.34s', height='2150m')
+
+# Values from https://www.cta-observatory.org/about/array-locations/la-palma/
+# Latitude: 28d45m43.7904s North, Longitude: 17d53m31.218s West, Height: 2200 m
+# Email from Gernot Maier on Sep 8, 2017, stating what they use in the CTA MC group for MST-1:
+# lon=-17.891571d, lat=28.762158d, height=2147m
+observatory_locations['cta_north'] = EarthLocation(lon='-17d53m31.218s', lat='28d45m43.7904s', height='2147m')
+
 # HAWC location taken from http://arxiv.org/pdf/1108.6034v2.pdf
-observatory_locations['HAWC'] = _obs_loc(lon='-97d18m34s', lat='18d59m48s', height=4100)
-observatory_locations['HEGRA'] = _obs_loc(lon='28d45m42s', lat='17d53m27s', height=3)
+observatory_locations['hawc'] = EarthLocation(lon='-97d18m34s', lat='18d59m48s', height='4100m')
+
+# https://en.wikipedia.org/wiki/HEGRA
+observatory_locations['hegra'] = EarthLocation(lon='28d45m42s', lat='17d53m27s', height='2200m')
+
 # Precision position of HESS from the HESS software (slightly different from Wikipedia)
-observatory_locations['HESS'] = _obs_loc(lon='16d30m00.8s', lat='-23d16m18.4s', height=1835)
-observatory_locations['MAGIC'] = _obs_loc(lon='-17d53m24s', lat='28d45m43s', height=2200)
-observatory_locations['MILAGRO'] = _obs_loc(lon='-106.67625d', lat='35.87835d', height=2530)
-observatory_locations['VERITAS'] = _obs_loc(lon='-110d57m07.77s', lat='31d40m30.21s', height=1268)
+observatory_locations['hess'] = EarthLocation(lon='16d30m00.8s', lat='-23d16m18.4s', height='1835m')
+
+observatory_locations['magic'] = EarthLocation(lon='-17d53m24s', lat='28d45m43s', height='2200m')
+
+observatory_locations['milagro'] = EarthLocation(lon='-106.67625d', lat='35.87835d', height='2530m')
+
+observatory_locations['veritas'] = EarthLocation(lon='-110d57m07.77s', lat='31d40m30.21s', height='1268m')
+
 # WHIPPLE coordinates taken from the Observatory Wikipedia page:
 # http://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory
-observatory_locations['WHIPPLE'] = _obs_loc(lon='-110d52m42s', lat='31d40m52s', height=2606)
+observatory_locations['whipple'] = EarthLocation(lon='-110d52m42s', lat='31d40m52s', height='2606m')

--- a/gammapy/data/tests/test_observers.py
+++ b/gammapy/data/tests/test_observers.py
@@ -5,13 +5,10 @@ from astropy.coordinates import Angle
 from ...data import observatory_locations
 
 
-def test_ObservatoryLocations():
-    # Check if attribute and key access works
-    # and if all fields are set correctly for one example
-    location = observatory_locations.HESS
+def test_observatory_locations():
+    # Check one example
+    location = observatory_locations['hess']
     assert_allclose(location.longitude.deg, Angle('16d30m00.8s').deg)
-
-    location = observatory_locations['HESS']
     assert_allclose(location.latitude.deg, Angle('-23d16m18.4s').deg)
-
-    assert_allclose(location.height.to('meter').value, 1835)
+    assert_allclose(location.height.value, 1835)
+    assert str(location.height.unit) == 'm'

--- a/gammapy/datasets/make.py
+++ b/gammapy/datasets/make.py
@@ -75,7 +75,7 @@ def make_test_psf(energy_bins=15, theta_bins=12):
                                         )
 
 
-def make_test_observation_table(observatory_name='HESS', n_obs=10,
+def make_test_observation_table(observatory_name='hess', n_obs=10,
                                 az_range=Angle([0, 360], 'deg'),
                                 alt_range=Angle([45, 90], 'deg'),
                                 date_range=(Time('2010-01-01'),
@@ -431,7 +431,7 @@ def make_test_bg_cube_model(detx_range=Angle([-10., 10.], 'deg'),
 
 
 def make_test_dataset(outdir, overwrite=False,
-                      observatory_name='HESS', n_obs=10,
+                      observatory_name='hess', n_obs=10,
                       az_range=Angle([0, 360], 'deg'),
                       alt_range=Angle([45, 90], 'deg'),
                       date_range=(Time('2010-01-01'),
@@ -512,8 +512,8 @@ def make_test_dataset(outdir, overwrite=False,
 
     # create data store for the organization of the files
     # using H.E.S.S.-like dir/file naming scheme
-    if observatory_name == 'HESS':
-        scheme = 'HESS'
+    if observatory_name == 'hess':
+        scheme = 'hess'
     else:
         s_error = "Warning! Storage scheme for {}".format(observatory_name)
         s_error += "not implemented. Only H.E.S.S. scheme is available."

--- a/gammapy/datasets/tests/test_make.py
+++ b/gammapy/datasets/tests/test_make.py
@@ -22,7 +22,7 @@ def test_make_test_psf_fits_table():
 
 
 def test_make_test_observation_table():
-    observatory_name = 'HESS'
+    observatory_name = 'hess'
     n_obs = 10
     random_state = np.random.RandomState(seed=0)
     obs_table = make_test_observation_table(observatory_name=observatory_name,

--- a/gammapy/image/models/shapes.py
+++ b/gammapy/image/models/shapes.py
@@ -402,8 +402,9 @@ class Template2D(Fittable2DModel):
                 (x_0 - width, x_0 + height / 2))
 
 
+# TODO: change this to a model registry
 morph_types = OrderedDict()
-"""Available morphology types."""
+morph_types.__doc__ = """Spatial model registry (`~collections.OrderedDict`)."""
 morph_types['delta2d'] = Delta2D
 morph_types['gauss2d'] = Gaussian2D
 morph_types['shell2d'] = Shell2D

--- a/gammapy/scripts/data_show.py
+++ b/gammapy/scripts/data_show.py
@@ -32,10 +32,6 @@ def data_show_main(filename, filetype, do_plot):
 
     Use the `gammapy-data-browser` to browse / check lots of files.
     """
-    if do_plot:
-        import matplotlib.pyplot as plt
-        plt.style.use('fivethirtyeight')
-
     if filetype == 'events':
         show_events(filename, do_plot)
     elif filetype == 'aeff':

--- a/gammapy/utils/coordinates/other.py
+++ b/gammapy/utils/coordinates/other.py
@@ -10,6 +10,7 @@ __all__ = [
     'motion_since_birth', 'polar', 'D_SUN_TO_GALACTIC_CENTER',
 ]
 
+# TODO: replace this with the default from the Galactocentric frame in astropy.coordinates
 D_SUN_TO_GALACTIC_CENTER = Quantity(8.5, 'kpc')
 
 


### PR DESCRIPTION
The constants in `gammapy.utils.const` should appear in the API docs.

E.g. `fwhm_to_sigma` is there:

```
from gammapy.utils.const import fwhm_to_sigma
```

But it's not in the API docs: [search result](https://gammapy.readthedocs.org/en/latest/search.html?q=fwhm_to_sigma)
