### PR TITLE
Fix options for threshold computation in SpectrumObservation, fix tests

### DIFF
--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -150,7 +150,7 @@ class SpectrumObservation(object):
         if self.off_vector is not None:
             self.off_vector.reset_thresholds()
 
-    def compute_energy_threshold(self, method_lo='area_max', method_hi='area_max', reset=False, **kwargs):
+    def compute_energy_threshold(self, method_lo=None, method_hi=None, reset=False, **kwargs):
         """Compute and set the safe energy threshold.
 
         Set the high and low energy threshold for each observation based on a
@@ -192,32 +192,34 @@ class SpectrumObservation(object):
         # vector, otherwise Sherpa will not understand the files
 
         # Low threshold
-        if method_lo == 'area_max':
-            aeff_thres = kwargs['area_percent_lo'] / 100 * self.aeff.max_area
-            thres_lo = self.aeff.find_energy(aeff_thres)
-        elif method_lo == 'energy_bias':
-            thres_lo = self._find_bias_energy(kwargs['bias_percent_lo'] / 100)
-        else:
-            raise ValueError('Undefine method for low threshold: {}'.format(
-                method_lo))
+        if method_lo is not None:
+            if method_lo == 'area_max':
+                aeff_thres = kwargs['area_percent_lo'] / 100 * self.aeff.max_area
+                thres_lo = self.aeff.find_energy(aeff_thres)
+            elif method_lo == 'energy_bias':
+                thres_lo = self._find_bias_energy(kwargs['bias_percent_lo'] / 100)
+            else:
+                raise ValueError('Undefine method for low threshold: {}'.format(
+                    method_lo))
 
-        self.on_vector.lo_threshold = thres_lo
-        if self.off_vector is not None:
-            self.off_vector.lo_threshold = thres_lo
+            self.on_vector.lo_threshold = thres_lo
+            if self.off_vector is not None:
+                self.off_vector.lo_threshold = thres_lo
 
         # High threshold
-        if method_hi == 'area_max':
-            aeff_thres = kwargs['area_percent_hi'] / 100 * self.aeff.max_area
-            thres_hi = self.aeff.find_energy(aeff_thres, reverse=True)
-        elif method_hi == 'energy_bias':
-            thres_hi = self._find_bias_energy(kwargs['bias_percent_hi'] / 100, reverse=True)
-        else:
-            raise ValueError('Undefined method for high threshold: {}'.format(
-                method_hi))
+        if method_hi is not None:
+            if method_hi == 'area_max':
+                aeff_thres = kwargs['area_percent_hi'] / 100 * self.aeff.max_area
+                thres_hi = self.aeff.find_energy(aeff_thres, reverse=True)
+            elif method_hi == 'energy_bias':
+                thres_hi = self._find_bias_energy(kwargs['bias_percent_hi'] / 100, reverse=True)
+            else:
+                raise ValueError('Undefined method for high threshold: {}'.format(
+                    method_hi))
 
-        self.on_vector.hi_threshold = thres_hi
-        if self.off_vector is not None:
-            self.off_vector.hi_threshold = thres_hi
+            self.on_vector.hi_threshold = thres_hi
+            if self.off_vector is not None:
+                self.off_vector.hi_threshold = thres_hi
 
     def _find_bias_energy(self, bias_value, reverse=False):
         """Helper function to interpolate between bias values to retrieve an energy"""

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -105,8 +105,8 @@ class TestSpectrumExtraction:
         desired = extraction.observations[0].aeff.data.data.value
         assert_allclose(actual, desired)
 
-    def test_define_energy_threshold(self, extraction):
+    def test_compute_energy_threshold(self, extraction):
         # TODO: Find better API for this
-        extraction.define_energy_threshold(method_lo_threshold="area_max", percent=10)
+        extraction.compute_energy_threshold(method_lo="area_max", area_percent_lo=10)
         actual = extraction.observations[0].lo_threshold
         assert_quantity_allclose(actual, 0.6812920690579611 * u.TeV, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -106,7 +106,6 @@ class TestSpectrumExtraction:
         assert_allclose(actual, desired)
 
     def test_compute_energy_threshold(self, extraction):
-        # TODO: Find better API for this
         extraction.compute_energy_threshold(method_lo="area_max", area_percent_lo=10)
         actual = extraction.observations[0].lo_threshold
         assert_quantity_allclose(actual, 0.6812920690579611 * u.TeV, rtol=1e-3)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -79,7 +79,7 @@ def spec_extraction():
                                     e_reco=e_reco,
                                     e_true=e_true)
     extraction.run()
-    extraction.define_energy_threshold('area_max', percent=10.0)
+    extraction.compute_energy_threshold(method_lo='area_max', area_percent_lo=10.0)
     return extraction
 
 


### PR DESCRIPTION
This PR introduces more sane defaults for the method options in `SpectrumObservation.compute_energy_threshold`, in particular it allows to set a method to `None` to not apply a threshold at the lower or upper end.

Also, fixing some tests that use this method.