### PR TITLE
Fix gp-extra-image Sphinx directive on Windows

### DIFF
--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -19,8 +19,8 @@ and [LiMa1983]_.
 Computation of TS images
 ========================
 
-.. gp-extra-image:: fermi_ts_image.png
-    :scale: 100%
+.. gp-extra-image:: detect/fermi_ts_image.png
+    :width: 100%
 
 Test statistics image computed using `~gammapy.detect.TSImageEstimator` for an
 example Fermi dataset.

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -1004,7 +1004,7 @@ instead of the usual Sphinx ``image`` directive like this:
 
 .. code-block:: rst
 
-    .. gp-extra-image:: fermi_ts_image.png
+    .. gp-extra-image:: detect/fermi_ts_image.png
         :scale: 100%
 
 More info on the image directive is `here <http://www.sphinx-doc.org/en/stable/rest.html#images>`__

--- a/docs/time/period.rst
+++ b/docs/time/period.rst
@@ -37,20 +37,16 @@ An example of detecting a period is shown in the figure below.
 The light curve is from the X-ray binary LS 5039 observed with H.E.S.S. at energies above 0.1 TeV in 2005 [1]_.
 The Lomb-Scargle reveals the period of :math:`(3.907 \pm 0.001)` days in agreement with [1]_ and [2]_.
 
-.. gp-extra-image:: lomb_scargle_long.png
-    :width: 100 %
-    :alt: alternate text
-    :align: left
+.. gp-extra-image:: time/lomb_scargle_long.png
+    :width: 100%
 
 The periodogram shows fluctuations for small periods and a smoothed behaviour for longer periods that are
 due to sampling effects and aliasing.
 If this is the case, `max_period` can be defined to limit the period range for the analysis.
 This way, the resoultion can be increased with equal computation time.
 
-.. gp-extra-image:: lomb_scargle_short.png
-    :width: 100 %
-    :alt: alternate text
-    :align: left
+.. gp-extra-image:: time/lomb_scargle_short.png
+    :width: 100%
 
 The periodogram has many spurious peaks, which are due to several factors:
 

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -34,17 +34,16 @@ class ExtraImage(Image):
     """Directive to add optional images from gammapy-extra"""
 
     def run(self):
+        filename = self.arguments[0]
+
         if HAS_GP_EXTRA:
-            path = gammapy_extra_path / 'figures'
-            filename = self.arguments[0]
-            current_source = self.state_machine.document.current_source
-            module = current_source.split('/')[-2]
-            new_filename = path / module / filename
-            if not new_filename.is_file():
-                msg = 'Error in {} directive: File not found: {}'.format(self.name, new_filename)
+            path = gammapy_extra_path / 'figures' / filename
+            if not path.is_file():
+                msg = 'Error in {} directive: File not found: {}'.format(self.name, path)
                 raise self.error(msg)
-            self.arguments[0] = '/' + str(new_filename)
+            self.arguments[0] = '/' + str(path)
         else:
+            self.warning('GAMMAPY_EXTRA not available. Missing image: {}'.format(self.name, filename))
             self.options['alt'] = self.argument[1]
 
         return super(ExtraImage, self).run()

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -41,10 +41,13 @@ class ExtraImage(Image):
             if not path.is_file():
                 msg = 'Error in {} directive: File not found: {}'.format(self.name, path)
                 raise self.error(msg)
-            self.arguments[0] = '/' + str(path)
+            # Usually Sphinx doesn't support absolute paths
+            # But passing a POSIX string of the absolute path
+            # with an extra "/" at the start seems to do the trick
+            self.arguments[0] = '/' + path.absolute().as_posix()
         else:
             self.warning('GAMMAPY_EXTRA not available. Missing image: {}'.format(self.name, filename))
-            self.options['alt'] = self.argument[1]
+            self.options['alt'] = self.arguments[1]
 
         return super(ExtraImage, self).run()
 


### PR DESCRIPTION
@wegenmat reported on Slack that `python setup.py build_docs` doesn't work on Windows.

This makes sense because we used `current_source.split('/')[-2]` and on Windows the path separator is `\`, not `/`.

This PR tries to fix this; the simplest solution was to use `Path` objects, and I also got rid of trying to compute the module name and sub-folder automatically. @joleroi - OK?

---

There is still the weird `self.arguments[0] = '/' + str(path)` at the end, where I don't know why the `/` is needed, and it'll probably not work on Windows. @wegenmat - Can you please try it out and find a working solution on Windows? (preferably calling a method or property on the path object in a way that works both on Windows and Linux)