### PR TITLE
Added MAGIC Crab spectra to crab.py

### DIFF
--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -25,8 +25,8 @@ hegra = {'amplitude': 2.83e-11 * u.Unit('1 / (cm2 s TeV)'),
          'reference': 1 * u.TeV}
 
 # MAGIC publication: JHEAP 5-6 (2015), 30-38
-# note that in the paper the beta of the LogParabola is given as negative (pag.32)
-# but it is positive in gammapy notation
+# note that in the paper the beta of the LogParabola is given as negative in  
+# Table 1 (pag. 33), but it is positive in gammapy notation (see formula pag. 32)
 magic_lp ={'amplitude': 3.23e-11 * u.Unit('1 / (cm2 s TeV)'),
 		   'alpha': 2.47,
 		   'beta': 0.24,

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy import units as u
-from .models import PowerLaw, ExponentialCutoffPowerLaw, SpectralModel
+from .models import PowerLaw, LogParabola, ExponentialCutoffPowerLaw, SpectralModel
 from ..utils.modeling import ParameterList, Parameter
 
 __all__ = [
@@ -23,6 +23,19 @@ hess_ecpl = {'amplitude': 3.76e-11 * u.Unit('1 / (cm2 s TeV)'),
 hegra = {'amplitude': 2.83e-11 * u.Unit('1 / (cm2 s TeV)'),
          'index': 2.62,
          'reference': 1 * u.TeV}
+
+# MAGIC publication: JHEAP 5-6 (2015), 30-38
+# note that in the paper the beta of the LogParabola is given as negative (pag.32)
+# but it is positive in gammapy notation
+magic_lp ={'amplitude': 3.23e-11 * u.Unit('1 / (cm2 s TeV)'),
+		   'alpha': 2.47,
+		   'beta': 0.24,
+		   'reference': 1 * u.TeV}
+
+magic_ecpl = {'amplitude': 3.80e-11 * u.Unit('1 / (cm2 s TeV)'),
+             'index': 2.21,
+             'lambda_': 1 / (6. * u.TeV),
+             'reference': 1 * u.TeV}
 
 
 class MeyerCrabModel(SpectralModel):
@@ -58,10 +71,11 @@ class CrabSpectrum(object):
     * 'meyer', http://adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
     * 'hegra', http://adsabs.harvard.edu/abs/2000ApJ...539..317A
     * 'hess_pl' and 'hess_ecpl': http://adsabs.harvard.edu/abs/2006A%26A...457..899A
+	* 'magic_lp' and 'magic_ecpl': http://www.sciencedirect.com/science/article/pii/S2214404815000038?via%3Dihub
 
-    Parameters
+	Parameters
     ----------
-    reference : {'meyer', 'hegra', 'hess_pl', 'hess_ecpl'}
+    reference : {'meyer', 'hegra', 'hess_pl', 'hess_ecpl', 'magic_lp', 'magic_ecpl'}
         Which reference to use for the spectral model.
 
     Examples
@@ -96,7 +110,7 @@ class CrabSpectrum(object):
     """
 
     references = [
-        'meyer', 'hegra', 'hess_pl', 'hess_ecpl',
+        'meyer', 'hegra', 'hess_pl', 'hess_ecpl', 'magic_lp', 'magic_ecpl'
     ]
     """Available references (see class docstring)."""
 
@@ -110,6 +124,10 @@ class CrabSpectrum(object):
             model = PowerLaw(**hess_pl)
         elif reference == 'hess_ecpl':
             model = ExponentialCutoffPowerLaw(**hess_ecpl)
+        elif reference == 'magic_lp':
+            model = LogParabola(**magic_lp)
+        elif reference == 'magic_ecpl':
+            model = ExponentialCutoffPowerLaw(**magic_ecpl)
         else:
             fmt = 'Invalid reference: {!r}. Choices: {!r}'
             raise ValueError(fmt.format(reference, self.references))

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -26,7 +26,7 @@ hegra = {'amplitude': 2.83e-11 * u.Unit('1 / (cm2 s TeV)'),
 
 # MAGIC publication: JHEAP 5-6 (2015), 30-38
 # note that in the paper the beta of the LogParabola is given as negative in  
-# Table 1 (pag. 33), but it is positive in gammapy notation (see formula pag. 32)
+# Table 1 (pag. 33), but should be positive to match gammapy LogParabola def
 magic_lp ={'amplitude': 3.23e-11 * u.Unit('1 / (cm2 s TeV)'),
 		   'alpha': 2.47,
 		   'beta': 0.24,
@@ -68,12 +68,12 @@ class CrabSpectrum(object):
 
     The following references are available:
 
-    * 'meyer', http://adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
-    * 'hegra', http://adsabs.harvard.edu/abs/2000ApJ...539..317A
-    * 'hess_pl' and 'hess_ecpl': http://adsabs.harvard.edu/abs/2006A%26A...457..899A
-	* 'magic_lp' and 'magic_ecpl': http://www.sciencedirect.com/science/article/pii/S2214404815000038?via%3Dihub
+ 	* 'meyer', http://adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
+  	* 'hegra', http://adsabs.harvard.edu/abs/2000ApJ...539..317A
+ 	* 'hess_pl' and 'hess_ecpl': http://adsabs.harvard.edu/abs/2006A%26A...457..899A
+    * 'magic_lp' and 'magic_ecpl': http://www.sciencedirect.com/science/article/pii/S2214404815000038?via%3Dihub
 
-	Parameters
+    Parameters
     ----------
     reference : {'meyer', 'hegra', 'hess_pl', 'hess_ecpl', 'magic_lp', 'magic_ecpl'}
         Which reference to use for the spectral model.

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -26,7 +26,7 @@ hegra = {'amplitude': 2.83e-11 * u.Unit('1 / (cm2 s TeV)'),
 
 # MAGIC publication: JHEAP 5-6 (2015), 30-38
 # note that in the paper the beta of the LogParabola is given as negative in  
-# Table 1 (pag. 33), but should be positive to match gammapy LogParabola def
+# Table 1 (pag. 33), but should be positive to match gammapy LogParabola expression
 magic_lp ={'amplitude': 3.23e-11 * u.Unit('1 / (cm2 s TeV)'),
 		   'alpha': 2.47,
 		   'beta': 0.24,
@@ -68,9 +68,9 @@ class CrabSpectrum(object):
 
     The following references are available:
 
- 	* 'meyer', http://adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
-  	* 'hegra', http://adsabs.harvard.edu/abs/2000ApJ...539..317A
- 	* 'hess_pl' and 'hess_ecpl': http://adsabs.harvard.edu/abs/2006A%26A...457..899A
+    * 'meyer', http://adsabs.harvard.edu/abs/2010A%26A...523A...2M, Appendix D
+    * 'hegra', http://adsabs.harvard.edu/abs/2000ApJ...539..317A
+    * 'hess_pl' and 'hess_ecpl': http://adsabs.harvard.edu/abs/2006A%26A...457..899A
     * 'magic_lp' and 'magic_ecpl': http://www.sciencedirect.com/science/article/pii/S2214404815000038?via%3Dihub
 
     Parameters

--- a/gammapy/spectrum/tests/test_crab.py
+++ b/gammapy/spectrum/tests/test_crab.py
@@ -29,7 +29,20 @@ CRAB_SPECTRA = [
         dnde=u.Quantity(6.23714253e-12, 'cm-2 s-1 TeV-1'),
         flux=u.Quantity(2.267957713046026e-11, 'cm-2 s-1'),
         index=2.529860258102417,
-    )
+    ),
+	dict(
+		name='magic_lp',
+		dnde=u.Quantity(5.19493945966e-12, 'cm-2 s-1 TeV-1'),
+		flux=u.Quantity(1.8787105528004794e-11, 'cm-2 s-1'),
+		index=2.802713046670476,
+	),
+	dict(
+		name='magic_ecpl',
+		dnde=u.Quantity(5.88494595619e-12, 'cm-2 s-1 TeV-1'),
+		flux=u.Quantity(2.070767119534948e-11, 'cm-2 s-1'),
+		index=2.5433349999859405,
+	),
+
 ]
 
 


### PR DESCRIPTION
Hi I took the liberty to add the latest Crab spectra measured by MAGIC in `gammapy/spectrum/crab.py`. The reference is 
http://adsabs.harvard.edu/abs/2015JHEAp...5...30A

I didn't modify `gammapy/spectrum/tests/test_crab.py` because it is not clear to me how the numbers hardcoded at the beginning of the macro in `CRAB_SPECTRA` for the `assert_quantity_allclose` test are calculated. Could you modify it accordingly or explaining how to do, before merging?

Thanks