### PR TITLE
Interpolation and reprojection in gammapy.maps

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -133,7 +133,7 @@ representation.  Three types of accessor methods are provided:
   given coordinate (`~MapBase.get_by_idx`, `~MapBase.get_by_pix`,
   `~MapBase.get_by_coords`).  With the ``interp`` argument,
   `~MapBase.get_by_pix` and `~MapBase.get_by_coords` also support
-  interpolation of map values between pixels.
+  interpolation of map values between pixels (see `Interpolation`_).
 * ``set`` : Set the value of the map at the pixel containing the
   given coordinate (`~MapBase.set_by_idx`, `~MapBase.set_by_pix`,
   `~MapBase.set_by_coords`).
@@ -212,7 +212,52 @@ The following demonstrates how one can set pixel values:
    m.set_by_coords( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
    m.fill_by_coords( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
    
+Interpolation
+-------------
 
+Maps support interpolation via the `~MapBase.get_by_coords` and
+`~MapBase.get_by_pix` methods.  Currently the following interpolation
+methods are supported:
+
+* ``nearest`` : Return value of nearest pixel (no interpolation).
+* ``linear`` : Interpolation with first order polynomial.  This is the
+  only interpolation method that is supported for all map types.
+* ``quadratic`` : Interpolation with second order polynomial.
+* ``cubic`` : Interpolation with third order polynomial.
+
+Note that ``quadratic`` and ``cubic`` interpolation are currently only
+supported for WCS-based maps with regular geometry (e.g. 2D or ND with
+the same geometry in every image plane).  ``linear`` and higher order
+interpolation by pixel coordinates is only supported for WCS-based
+maps.
+
+.. code::
+
+   from gammapy.maps import MapBase
+   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+
+   m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
+   m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
+
+
+Projection
+----------
+
+The `~MapBase.reproject` method can be used to project a map onto a
+different geometry.  This can be used to convert between different WCS
+projections, extract a cut-out of a map, or to convert between WCS and
+HPX map types.  If the projection geometry lacks non-spatial
+dimensions then the non-spatial dimensions of the original map will be copied
+over to the projected map.
+
+.. code::
+
+   from gammapy.maps import WcsMapND, HpxGeom
+   m = WcsMapND.read('gll_iem_v06.fits')
+   geom = HpxGeom.create(nside=8, coordsys='GAL')
+   # Convert LAT standard IEM to HPX (nside=8)
+   m_proj = m.project(geom)
+   m_proj.write('gll_iem_v06_hpx_nside8.fits')
 
    
 Slicing Methods

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -329,19 +329,24 @@ class MapBase(object):
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
 
-        interp : {None, 'linear', 'nearest'}
-            Interpolate data values. None corresponds to 'nearest',
-            but might have advantages in performance, because no
-            interpolator is set up.
+        interp : {None, 'nearest', 'linear', 'cubic', 0, 1, 2, 3}
+            Method to interpolate data values.  By default no
+            interpolation is performed and the return value will be
+            the amplitude of the pixel encompassing the given
+            coordinate.  Integer values can be used in lieu of strings
+            to choose the interpolation method of the given order
+            (0='nearest', 1='linear', 2='quadratic', 3='cubic').  Note
+            that only 'nearest' and 'linear' methods are supported for
+            all map types.
 
         Returns
         -------
         vals : `~numpy.ndarray`
-           Values of pixels in the flattened map.
-           np.nan used to flag coords outside of map
+           Values of pixels in the map.  np.nan used to flag coords
+           outside of map.
 
         """
-        if interp is None:
+        if interp is None or interp == 'nearest':
             idx = self.geom.coord_to_pix(coords)
             return self.get_by_idx(idx)
         else:
@@ -359,16 +364,21 @@ class MapBase(object):
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
             Pixel indices can be either float or integer type. 
 
-        interp : {None, 'linear', 'nearest'}
-            Interpolate data values. None corresponds to 'nearest',
-            but might have advantages in performance, because no
-            interpolator is set up.
+        interp : {None, 'nearest', 'linear', 'cubic', 0, 1, 2, 3}
+            Method to interpolate data values.  By default no
+            interpolation is performed and the return value will be
+            the amplitude of the pixel encompassing the given
+            coordinate.  Integer values can be used in lieu of strings
+            to choose the interpolation method of the given order
+            (0='nearest', 1='linear', 2='quadratic', 3='cubic').  Note
+            that only 'nearest' and 'linear' methods are supported for
+            all map types.
 
         Returns
         ----------
         vals : `~numpy.ndarray`
-           Array of pixel values.
-           np.nan used to flag coordinates outside of map
+           Array of pixel values.  np.nan used to flag coordinates
+           outside of map
 
         """
         pass
@@ -405,10 +415,15 @@ class MapBase(object):
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
 
-        interp : {None, 'linear', 'nearest'}
-            Interpolate data values. None corresponds to 'nearest',
-            but might have advantages in performance, because no
-            interpolator is set up.
+        interp : {None, 'nearest', 'linear', 'cubic', 0, 1, 2, 3}
+            Method to interpolate data values.  By default no
+            interpolation is performed and the return value will be
+            the amplitude of the pixel encompassing the given
+            coordinate.  Integer values can be used in lieu of strings
+            to choose the interpolation method of the given order
+            (0='nearest', 1='linear', 2='quadratic', 3='cubic').  Note
+            that only 'nearest' and 'linear' methods are supported for
+            all map types.
 
         Returns
         -------

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -140,13 +140,18 @@ class MapBase(object):
         extname_bands : str
             Set the name of the bands table extension.  By default this will
             be set to BANDS.
-        hpxconv : str
-            Format convention for HEALPix maps.  This option can be used to
-            write files that are compliant with non-standard HEALPix
-            conventions.
-        sparse : bool
+        conv : str        
+            FITS format convention.  By default files will be written
+            to the gamma-astro-data-formats (GADF) format.  This
+            option can be used to write files that are compliant with
+            format conventions required by specific software (e.g. the
+            Fermi Science Tools).  Supported conventions are 'gadf',
+            'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
+            'fgst-template', 'fgst-srcmap', 'fgst-srcmap-sparse',
+            'galprop', and 'galprop2'.            
+        sparse : bool        
             Sparsify the map by dropping pixels with zero amplitude.
-
+            This option is only compatible with the 'gadf' format.
         """
         hdulist = self.to_hdulist(**kwargs)
         overwrite = kwargs.get('overwrite', True)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -826,12 +826,12 @@ class HpxGeom(MapGeom):
                               region=self.region, axes=self.axes, conv=self.conv)
 
     def to_image(self):
-        return self.__class__(np.max(self.nside), not self.nest, coordsys=self.coordsys,
+        return self.__class__(np.max(self.nside), self.nest, coordsys=self.coordsys,
                               region=self.region, conv=self.conv)
 
     def to_cube(self, axes):
         axes = copy.deepcopy(self.axes) + axes
-        return self.__class__(np.max(self.nside), not self.nest, coordsys=self.coordsys,
+        return self.__class__(np.max(self.nside), self.nest, coordsys=self.coordsys,
                               region=self.region, conv=self.conv, axes=axes)
 
     @classmethod
@@ -940,7 +940,7 @@ class HpxGeom(MapGeom):
             return 'FGST_LTCUBE'
         elif colname == 'Bin0':
             return 'GALPROP'
-        elif colname == 'CHANNEL1':
+        elif colname == 'CHANNEL1' or colname == 'CHANNEL0':
             if extname == 'SKYMAP':
                 return 'FGST_CCUBE'
             else:

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -759,6 +759,18 @@ class HpxGeom(MapGeom):
             return False
 
     @property
+    def regular(self):
+        """Flag identifying whether this geometry is regular in non-spatial
+        dimensions.  False for multi-resolution or irregular
+        geometries.  If true all image planes have the same pixel
+        geometry.
+        """
+        if self.nside.size > 1:
+            return False
+        else:
+            return True
+
+    @property
     def center_coord(self):
         """Map coordinate of the center of the geometry.
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -83,6 +83,21 @@ def test_wcsmapnd_fill_by_coords(tmpdir, npix, binsz, coordsys, proj, skydir, ax
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
+def test_wcsmapnd_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsMapND(geom)
+    coords = m.geom.get_coords()
+    m.set_by_coords(coords, coords[1])
+    assert_allclose(coords[1], m.get_by_coords(coords, interp='nearest'))
+    assert_allclose(coords[1], m.get_by_coords(coords, interp='linear'))
+    assert_allclose(coords[1], m.get_by_coords(coords, interp=1))
+    if geom.regular and not geom.allsky:
+        assert_allclose(coords[1], m.get_by_coords(coords, interp='cubic'))
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
 def test_wcsmapnd_iter(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -3,6 +3,20 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy.io import fits
 
 
+def interp_to_order(interp):
+    """Convert interpolation string to order."""
+
+    if isinstance(interp, int):
+        return interp
+
+    order_map = {None: 0,
+                 'nearest': 0,
+                 'linear': 1,
+                 'quadratic': 2,
+                 'cubic': 3}
+    return order_map.get(interp, None)
+
+
 def unpack_seq(seq, n=1):
     """Utility to unpack the first N values of a tuple or list.  Remaining
     values are put into a single list which is the last element of the

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -117,6 +117,18 @@ class WcsGeom(MapGeom):
             return False
 
     @property
+    def regular(self):
+        """Flag identifying whether this geometry is regular in non-spatial
+        dimensions.  False for multi-resolution or irregular
+        geometries.  If true all image planes have the same pixel
+        geometry.
+        """
+        if self.npix[0].size > 1:
+            return False
+        else:
+            return True
+
+    @property
     def width(self):
         """Tuple with image dimension in deg in longitude and latitude."""
         return self._width


### PR DESCRIPTION
This PR implements support for interpolation in `WcsMapND` and partial support for HPX->WCS reprojection.  Also includes some miscellaneous improvements and bug fixes to HPX I/O methods.