### PR TITLE
Improvement of the way to select energy bins to make the fit

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -170,8 +170,6 @@ class SpectrumFit(object):
                 valid_range_hi[idx_hi] = 0  # every bin edges below threshold is accepted
 
                 valid_range = np.logical_and(1-valid_range_lo, 1-valid_range_hi)
-                
-            print('valid: {}'.format(valid_range))
 
             # Take into account quality 
             try:
@@ -180,7 +178,6 @@ class SpectrumFit(object):
                 quality = np.ones(obs.e_reco.nbins)
 
             convolved = np.logical_and(quality, valid_range)
-            print('convolved: {}'.format(convolved))
             self._bins_in_fit_range.append(convolved)
 
     def predict_counts(self):

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -142,15 +142,16 @@ class SpectrumFit(object):
         for obs in self.obs_list:
             # Take into account fit range
             energy = obs.e_reco            
-            thresh_lo = np.full(len(energy.lower_bounds),
-                                self.fit_range[0]) * u.Unit((self.fit_range[0].unit))
-            thresh_hi = np.full(len(energy.upper_bounds),
-                                self.fit_range[1]) * u.Unit((self.fit_range[1].unit))
             valid_range_lo = np.ones(energy.nbins)
             valid_range_hi = np.ones(energy.nbins)
             valid_range = np.zeros(energy.nbins)
 
             if self.fit_range is not None:
+
+                thresh_lo = np.full(len(energy.lower_bounds),
+                                    self.fit_range[0]) * u.Unit((self.fit_range[0].unit))
+                thresh_hi = np.full(len(energy.upper_bounds),
+                                    self.fit_range[1]) * u.Unit((self.fit_range[1].unit))
                 
                 # conditions for low threshold
                 cond1 = energy.lower_bounds > self.fit_range[0]


### PR DESCRIPTION
Hi @cdeil, @joleroi , @bkhelifi ,
I had some trouble with the energy range of the fit. So I change/improve a bit the philosophy of the function which does that (`SpectrumFit._apply_fit_range`).

The trouble I had appeared when i wanted to give by hand the definitions of the reconstructed energy bins and the energy range of the fit: 
```
In [11]: fit_range = [0.3, 2.] * u.TeV

In [12]: e_reco = np.logspace(np.log10(fit_range[0].value),
    ...:                      np.log10(fit_range[1].value),10).tolist() * u.TeV

In [13]: fit_range[0]
Out[13]: <Quantity 0.3 TeV>

In [14]: e_reco[0]
Out[14]: <Quantity 0.29999999999999993 TeV>
```
My first bin was systematically removed and it was a problem of float precision.

I added a second condition using `np.isclose` function.

What do you think?