### PR TITLE
Add sqrt stretch to image plot

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -877,7 +877,7 @@ class SkyImage(MapBase):
             raise ValueError("Invalid image viewer option, choose either"
                              " 'mpl' or 'ds9'.")
 
-    def plot(self, ax=None, fig=None, add_cbar=False, **kwargs):
+    def plot(self, ax=None, fig=None, add_cbar=False, stretch='linear', **kwargs):
         """
         Plot image on matplotlib WCS axes.
 
@@ -887,7 +887,8 @@ class SkyImage(MapBase):
             WCS axis object to plot on.
         fig : `~matplotlib.figure.Figure`, optional
             Figure
-
+        stretch : str, optional
+            Scaling for image ('linear', 'sqrt', 'log')
         Returns
         -------
         fig : `~matplotlib.figure.Figure`, optional
@@ -898,6 +899,7 @@ class SkyImage(MapBase):
             Colorbar object (if ``add_cbar=True`` was set)
         """
         import matplotlib.pyplot as plt
+        from astropy.visualization import simple_norm
 
         if fig is None:
             fig = plt.gcf()
@@ -913,7 +915,9 @@ class SkyImage(MapBase):
             data = self.data.value
         except AttributeError:
             data = self.data
-        caxes = ax.imshow(data, **kwargs)
+
+        norm = simple_norm(data, stretch)
+        caxes = ax.imshow(data, norm=norm, **kwargs)
 
         if add_cbar:
             unit = self.unit or 'A.U.'

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -890,10 +890,6 @@ class SkyImage(MapBase):
         stretch : str, optional
             Scaling for image ('linear', 'sqrt', 'log').
             Similar to normalize and stretch functions in ds9.
-            Uses astropy.visualization ImageNormalize object e.g. :
-            from astropy.visualization import simple_norm
-            norm = simple_norm(image, 'sqrt')
-            plt.imshow(image, norm = norm)
             See http://docs.astropy.org/en/stable/visualization/normalization.html
         Returns
         -------
@@ -903,6 +899,17 @@ class SkyImage(MapBase):
             WCS axis object
         cbar : ?
             Colorbar object (if ``add_cbar=True`` was set)
+        Examples
+        --------
+        >>> from astropy.visualization import simple_norm
+        >>> from gammapy.image import SkyImage
+        >>> filename = '$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_vela.fits.gz'
+        >>> image = SkyImage.read(filename, hdu=2)
+        >>> norm = simple_norm(image, 'sqrt')
+        >>> plt.imshow(image, norm = norm)
+        >>> plt.show()
+        >>> #Equivalent to :
+        >>> image.plot(stretch='sqrt')
         """
         import matplotlib.pyplot as plt
         from astropy.visualization import simple_norm

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -888,7 +888,13 @@ class SkyImage(MapBase):
         fig : `~matplotlib.figure.Figure`, optional
             Figure
         stretch : str, optional
-            Scaling for image ('linear', 'sqrt', 'log')
+            Scaling for image ('linear', 'sqrt', 'log').
+            Similar to normalize and stretch functions in ds9.
+            Uses astropy.visualization ImageNormalize object e.g. :
+            from astropy.visualization import simple_norm
+            norm = simple_norm(image, 'sqrt')
+            plt.imshow(image, norm = norm)
+            See http://docs.astropy.org/en/stable/visualization/normalization.html
         Returns
         -------
         fig : `~matplotlib.figure.Figure`, optional
@@ -901,6 +907,12 @@ class SkyImage(MapBase):
         import matplotlib.pyplot as plt
         from astropy.visualization import simple_norm
 
+        # TODO: make skyimage.data a quantity
+        try:
+            data = self.data.value
+        except AttributeError:
+            data = self.data
+
         if fig is None:
             fig = plt.gcf()
 
@@ -910,14 +922,10 @@ class SkyImage(MapBase):
         kwargs['origin'] = kwargs.get('origin', 'lower')
         kwargs['cmap'] = kwargs.get('cmap', 'afmhot')
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
-        # TODO: make skyimage.data a quantity
-        try:
-            data = self.data.value
-        except AttributeError:
-            data = self.data
-
         norm = simple_norm(data, stretch)
-        caxes = ax.imshow(data, norm=norm, **kwargs)
+        kwargs.setdefault('norm', norm)
+
+        caxes = ax.imshow(data, **kwargs)
 
         if add_cbar:
             unit = self.unit or 'A.U.'


### PR DESCRIPTION
Using from astropy.visualization import simple_norm 
to be able to plot sqrt, linear or log images in the image.plot function