### PR TITLE
Various improvements and bug fixes for IACTBasicImageEstimator

### DIFF
--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -318,6 +318,7 @@ class RingBackgroundEstimator(object):
         counts_excluded = SkyImage(data=counts.data * exclusion.data, wcs=wcs)
         result['off'] = counts_excluded.convolve(ring.array, mode='reflect',
                                                  use_fft=p['use_fft_convolution'])
+        result['off'].data = result['off'].data.astype(int)
 
         exposure_on_excluded = SkyImage(data=exposure_on.data * exclusion.data, wcs=wcs)
         result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='reflect',

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -238,6 +238,8 @@ class RingBackgroundEstimator(object):
         Inner ring radius
     width : `~astropy.units.Quantity`
         Ring width.
+    use_fft_convolution : bool
+        Use fft convolution.
 
 
     Examples
@@ -263,8 +265,8 @@ class RingBackgroundEstimator(object):
     gammapy.detect.KernelBackgroundEstimator, AdaptiveRingBackgroundEstimator
     """
 
-    def __init__(self, r_in, width):
-        self.parameters = dict(r_in=r_in, width=width)
+    def __init__(self, r_in, width, use_fft_convolution=False):
+        self.parameters = dict(r_in=r_in, width=width, use_fft_convolution=use_fft_convolution)
 
     def kernel(self, image):
         """Ring kernel.
@@ -304,6 +306,7 @@ class RingBackgroundEstimator(object):
         result : `SkyImageList`
             Result sky images
         """
+        p = self.parameters
         required = ['counts', 'exposure_on', 'exclusion']
         images.check_required(required)
         counts, exposure_on, exclusion = [images[_] for _ in required]
@@ -313,12 +316,23 @@ class RingBackgroundEstimator(object):
         ring = self.kernel(counts)
 
         counts_excluded = SkyImage(data=counts.data * exclusion.data, wcs=wcs)
-        result['off'] = counts_excluded.convolve(ring.array, mode='reflect')
+        result['off'] = counts_excluded.convolve(ring.array, mode='reflect',
+                                                 use_fft=p['use_fft_convolution'])
 
         exposure_on_excluded = SkyImage(data=exposure_on.data * exclusion.data, wcs=wcs)
-        result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='reflect')
+        result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='reflect',
+                                                               use_fft=p['use_fft_convolution'])
 
-        result['alpha'] = SkyImage(data=exposure_on.data / result['exposure_off'].data, wcs=wcs)
+        with np.errstate(divide='ignore'):
+            # set pixels, where ring is too small to NaN
+            not_has_off_exposure = ~(result['exposure_off'].data > 0)
+            result['exposure_off'].data[not_has_off_exposure] = np.nan
+
+            result['alpha'] = SkyImage(data=exposure_on.data / result['exposure_off'].data, wcs=wcs)
+
+            not_has_exposure = ~(exposure_on.data > 0)
+            result['alpha'].data[not_has_exposure] = 0
+
         result['background'] = SkyImage(data=result['alpha'].data * result['off'].data, wcs=wcs)
         return result
 

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -129,6 +129,7 @@ class IACTBasicImageEstimator(BasicImageEstimator):
                  background_estimator=None, exclusion_mask=None):
         self.parameters = OrderedDict(emin=emin, emax=emax, offset_max=offset_max)
         self.reference = reference
+        self.reference.data = np.zeros(reference.data.shape)
         self.background_estimator = background_estimator
         self.exclusion_mask = exclusion_mask
 
@@ -137,20 +138,29 @@ class IACTBasicImageEstimator(BasicImageEstimator):
 
         self.spectral_model = spectral_model
 
-    def _get_ref_cube(self, enumbins=11):
+    def _get_ref_cube(self, observation,  enumbins=11):
         from ..cube import SkyCube
         from ..spectrum import LogEnergyAxis
 
         p = self.parameters
 
-        wcs = self.reference.wcs.deepcopy()
-        shape = (enumbins,) + self.reference.data.shape
+        cutout = self._cutout_observation(self.reference, observation)
+
+        wcs = cutout.wcs.deepcopy()
+        shape = (enumbins,) + cutout.data.shape
         data = np.zeros(shape)
 
         energy = Energy.equal_log_spacing(p['emin'], p['emax'], enumbins, 'TeV')
         energy_axis = LogEnergyAxis(energy, mode='center')
 
         return SkyCube(data=data, wcs=wcs, energy_axis=energy_axis)
+
+    def _cutout_observation(self, image, observation, margin=0.5 * u.deg):
+        p = self.parameters
+        position = observation.pointing_radec
+        size = 2 * (p['offset_max'] + margin)
+        cutout = image.cutout(position=position, size=size)
+        return cutout
 
     def _exposure_cube(self, observation):
         """
@@ -168,7 +178,7 @@ class IACTBasicImageEstimator(BasicImageEstimator):
             pointing=observation.pointing_radec,
             aeff=observation.aeff,
             offset_max=p['offset_max'],
-            ref_cube=self._get_ref_cube(),
+            ref_cube=self._get_ref_cube(observation),
         )
 
     def _exposure(self, observation):
@@ -225,11 +235,12 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         # TODO: check if a lower offset bound different from zero is needed.
         events = events.select_offset((Angle(0, 'deg'), p['offset_max']))
 
-        counts = self._get_empty_skyimage('counts')
+        counts = self._cutout_observation(self.reference, observation)
+        counts.name = 'counts'
         counts.fill_events(events)
         return counts
 
-    def _background(self, counts, exposure):
+    def _background(self, counts, exposure, observation):
         """
         Estimate background image for one observation.
 
@@ -242,7 +253,7 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         exposure_on = exposure.copy()
         exposure_on.name = 'exposure_on'
         input_images['exposure_on'] = exposure_on
-        input_images['exclusion'] = self.exclusion_mask
+        input_images['exclusion'] = self._cutout_observation(self.exclusion_mask, observation)
         return self.background_estimator.run(input_images)
 
     def run(self, observations, which='all'):
@@ -270,28 +281,28 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         for observation in observations:
             if 'counts' in which:
                 counts = self._counts(observation)
-                result['counts'].data += counts.data
+                result['counts'].paste(counts)
 
             if 'exposure' in which:
                 exposure = self._exposure(observation)
-                result['exposure'].data += exposure.data
+                result['exposure'].paste(exposure)
 
             if 'background' in which:
-                background = self._background(counts, exposure)['background']
+                background = self._background(counts, exposure, observation)['background']
 
                 # TODO: check why fixing nan is needed here
                 background.data = np.nan_to_num(background.data)
 
                 # TODO: included stacked alpha and on/off exposure images
-                result['background'].data += background.data
+                result['background'].paste(background)
 
             if 'excess' in which:
                 excess = self.excess(SkyImageList([counts, background]))
-                result['excess'].data += excess.data
+                result['excess'].paste(excess)
 
             if 'flux' in which:
                 flux = self.flux(SkyImageList([counts, background, exposure]))
-                result['flux'].data += flux.data
+                result['flux'].paste(flux)
 
         if 'psf' in which:
             result['psf'] = self.psf(observations)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -512,7 +512,7 @@ class SkyImage(MapBase):
         else:
             raise ValueError('Invalid method: {}'.format(method))
 
-    def cutout(self, position, size):
+    def cutout(self, position, size, copy=True):
         """
         Cut out rectangular piece of a image.
 
@@ -551,7 +551,7 @@ class SkyImage(MapBase):
             Cut out image.
         """
         cutout = Cutout2D(
-            self.data, position=position, wcs=self.wcs, size=size, copy=True,
+            self.data, position=position, wcs=self.wcs, size=size, copy=copy,
         )
         return self.__class__(
             name=self.name, data=cutout.data,
@@ -1136,7 +1136,7 @@ class SkyImage(MapBase):
         else:
             raise ValueError('One image has `wcs==None` and the other does not.')
 
-    def convolve(self, kernel, **kwargs):
+    def convolve(self, kernel, use_fft=False, **kwargs):
         """
         Convolve sky image with kernel.
 
@@ -1148,7 +1148,12 @@ class SkyImage(MapBase):
             Further keyword arguments passed to `~scipy.ndimage.convolve`.
         """
         from scipy.ndimage import convolve
-        data = convolve(self.data, kernel, **kwargs)
+        from scipy.signal import fftconvolve
+
+        if use_fft:
+            data = fftconvolve(self.data, kernel, mode='same')
+        else:
+            data = convolve(self.data, kernel, **kwargs)
         wcs = self.wcs.deepcopy() if self.wcs else None
         return self.__class__(name=self.name, data=data, wcs=wcs)
 

--- a/gammapy/image/plotting.py
+++ b/gammapy/image/plotting.py
@@ -2,7 +2,10 @@
 """Helper functions and functions for plotting gamma-ray images.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 import numpy as np
+
+from astropy.coordinates import Angle
 
 __all__ = [
     'colormap_hess',
@@ -15,6 +18,107 @@ __all__ = [
 ]
 
 __doctest_requires__ = {('colormap_hess', 'colormap_milagro'): ['matplotlib']}
+
+
+class SkyImagePanelPlotter(object):
+    """
+    Sky image panel plotter class
+
+    Given a `~matplotlib.pyplot.Figure` object this class creates axes objects
+    using `~matplotlib.gridspec.GridSpec` and plots a given sky image onto these.
+
+    Parameters
+    ----------
+    figure : `~matplotlib.pyplot.figure.`
+        Figure instance.
+    xlim : `~astropy.coordinates.Angle`
+        Angle object specifying the longitude limits.
+    ylim : `~astropy.coordinates.Angle`
+        Angle object specifying the latitude limits.
+    npanels : int
+        Number of panels.
+    **kwargs : dict
+        Keyword arguments passed to `~matplotlib.gridspec.GridSpec`.
+    """
+
+    def __init__(self, figure, xlim, ylim, npanels=4, **kwargs):
+        from matplotlib.gridspec import GridSpec
+
+        self.figure = figure
+        self.parameters = OrderedDict(xlim=xlim, ylim=ylim, npanels=npanels)
+        self.grid_spec = GridSpec(nrows=npanels, ncols=1, **kwargs)
+
+    def _get_ax_extend(self, ax, panel):
+        """Get width and height of the axis in world coordinates"""
+        p = self.parameters
+
+        # compute aspect ratio of the axis
+        aspect = ax.bbox.width / ax.bbox.height
+
+        # compute width and height in world coordinates
+        height = np.abs(p['ylim'].diff())
+        width = aspect * height
+
+        left, bottom = p['xlim'][0].wrap_at('180d'), p['ylim'][0]
+
+        width_all = np.abs(p['xlim'].wrap_at('180d').diff())
+        xoverlap = ((p['npanels'] * width) - width_all) / (p['npanels'] - 1.)
+        if xoverlap < 0:
+            raise ValueError('No overlap between panels. Please reduce figure '
+                             'height or increase vertical space between the panels.')
+
+        left = left - panel * (width - xoverlap)
+        return left[0], bottom, width, height
+
+    def _set_ax_fov(self, ax, panel):
+        left, bottom, width, height = self._get_ax_extend(ax, panel)
+
+        # set fov
+        xlim = Angle([left, left - width])
+        ylim = Angle([bottom, bottom + height])
+        xlim_pix, ylim_pix = ax.wcs.wcs_world2pix(xlim.deg, ylim.deg, 1)
+
+        ax.set_xlim(*xlim_pix)
+        ax.set_ylim(*ylim_pix)
+        return ax
+
+    def plot_panel(self, skyimage, panel=1, panel_fov=None, **kwargs):
+        """
+        Plot sky image on one panel.
+
+        Parameters
+        ----------
+        skyimage : `~gammapy.image.SkyImage`
+            Sky image to plot.
+        panel : int
+            Which panel to plot on (counted from top).
+        """
+        if panel_fov is None:
+            panel_fov = panel
+        spec = self.grid_spec[panel]
+        ax = self.figure.add_subplot(spec, projection=skyimage.wcs)
+        try:
+            ax = skyimage.plot(ax=ax, **kwargs)[1]
+        except AttributeError:
+            ax = skyimage.plot_rgb(ax=ax, **kwargs)
+        ax = self._set_ax_fov(ax, panel_fov)
+        return ax
+
+    def plot(self, skyimage, **kwargs):
+        """
+        Plot sky image on all panels.
+
+        Parameters
+        ----------
+        skyimage : `~gammapy.image.SkyImage`
+            Sky image to plot.
+        """
+        p = self.parameters
+        axes = []
+        for panel in range(p['npanels']):
+            ax = self.plot_panel(skyimage, panel=panel, **kwargs)
+            axes.append(ax)
+        return axes
 
 
 def colormap_hess(transition=0.5, width=0.1):

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -82,7 +82,7 @@ class TestIACTBasicImageEstimator:
         width = 0.2 * u.deg
         kwargs['background_estimator'] = RingBackgroundEstimator(r_in=r_in, width=width)
 
-        # Defien exclusion mask
+        # Define exclusion mask
         center = SkyCoord(83.633083, 22.0145, frame='icrs', unit='deg')
         circle = CircleSkyRegion(center, radius=Angle(0.2, 'deg'))
         kwargs['exclusion_mask'] = kwargs['reference'].region_mask(circle)
@@ -96,11 +96,11 @@ class TestIACTBasicImageEstimator:
 
     def test_run(self):
         images = OrderedDict()
-        images['counts'] = dict(sum=2620.0)
-        images['background'] = dict(sum=1994.79254434631)
+        images['counts'] = dict(sum=2222.0)
+        images['background'] = dict(sum=1855.654807821552)
         images['exposure'] = dict(sum=83036669325.30281)
-        images['excess'] = dict(sum=625.2074556536902)
-        images['flux'] = dict(sum=2.524971454563909e-07)
+        images['excess'] = dict(sum=366.34519217844803)
+        images['flux'] = dict(sum=8.143944483402417e-07)
         images['psf'] = dict(sum=1.)
         results = self.estimator.run(self.observations)
 


### PR DESCRIPTION
This PR includes various improvements (mainly performance improvements for large scale images) and bug fixes for the `IACTBasicImageEstimator` class. I don't have time to add more tests and docs or make any changes to this PR,  so I would suggest to just merge it. It might be important in case someone wants to debug e.g. the artefacts at high offset angles during the coding sprint.

It also includes an `SkyImagePanelPlotter` class, which is a better (simpler and using wcsaxes and quantities) implementation of the `GalacticPlaneSurveyPanelPlot` class. I've hidden it from the public docs right now, but will make it public in another, later clean up PR, that adds tests and usage examples.