### PR TITLE
Bug fixes for HPX maps

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -182,7 +182,7 @@ def pix_tuple_to_idx(pix):
         if np.issubdtype(p.dtype, np.integer):
             idx += [p]
         else:
-            idx += [(0.5 + p).astype(int)]
+            idx += [np.rint(p).astype(int)]
     return tuple(idx)
 
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -650,7 +650,7 @@ class HpxGeom(MapGeom):
         idx = list(pix_tuple_to_idx(pix))
         idx_local = self.global_to_local(idx)
         for i, _ in enumerate(idx):
-            idx[i][idx_local[i] < 0] = -1
+            idx[i][(idx_local[i] < 0) | (idx[i] < 0)] = -1
             if i > 0:
                 idx[i][idx[i] > self.axes[i - 1].nbin - 1] = -1
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -996,7 +996,7 @@ class HpxGeom(MapGeom):
             raise Exception('ORDERING != RING | NESTED')
 
         if hdu_bands is not None and 'NSIDE' in hdu_bands.columns.names:
-            nside = hdu_bands.data.field('NSIDE').reshape(shape)
+            nside = hdu_bands.data.field('NSIDE').reshape(shape).astype(int)
         elif 'NSIDE' in header:
             nside = header['NSIDE']
         elif 'ORDER' in header:

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -351,6 +351,8 @@ class HpxMapND(HpxMap):
     def fill_by_idx(self, idx, weights=None):
 
         idx = pix_tuple_to_idx(idx)
+        msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
+        idx = [t[msk] for t in idx]
         idx_local = list(self.hpx.global_to_local(idx))
         msk = idx_local[0] >= 0
         idx_local = [t[msk] for t in idx_local]


### PR DESCRIPTION
This PR makes a few small bug fixes to `HpxMapND`:

- Fixes indexing error that was occuring when evaluating coordinates outside the map.
- Casts NSIDE to int when reading from FITS BANDS table to avoid overflow.

