### PR TITLE
Fix PSF evaluate error at low energy and high offset

### DIFF
--- a/gammapy/image/models/gauss.py
+++ b/gammapy/image/models/gauss.py
@@ -150,8 +150,8 @@ class MultiGauss2D(object):
     def __init__(self, sigmas, norms=None):
         # If no norms are given, you have a PDF.
         sigmas = np.asarray(sigmas, dtype=np.float64)
-
         self.components = [Gauss2DPDF(sigma) for sigma in sigmas]
+
         if norms is None:
             self.norms = np.ones(len(self.components))
         else:
@@ -251,7 +251,9 @@ class MultiGauss2D(object):
         norm_multigauss : `~gammapy.image.models.MultiGauss2D`
            normalized function
         """
-        self.norms /= self.integral
+        sum = self.integral
+        if sum!=0:
+            self.norms /= sum
         return self
 
     def containment_fraction(self, theta):

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -403,7 +403,7 @@ class EnergyDependentMultiGaussPSF(object):
         else:
             rad = Angle(np.arange(0, 1.5, 0.005), 'deg')
 
-        psf_value = Quantity(np.empty((energies.size, rad.size)), 'deg^-2')
+        psf_value = Quantity(np.zeros((energies.size, rad.size)), 'deg^-2')
 
         for idx, energy in enumerate(energies):
             psf_gauss = self.psf_at_energy_and_theta(energy, theta)

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -777,6 +777,7 @@ class EnergyDependentTablePSF(object):
         """
         psf_values = self.psf_value[energy_index, :].flatten().copy()
         where_are_NaNs = np.isnan(psf_values)
+        # When the PSF Table is not filled (with nan), the psf estimation at a given energy crashes
         psf_values[where_are_NaNs] = 0
         return psf_values
 

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -638,7 +638,6 @@ class EnergyDependentTablePSF(object):
             energy_min = self.energy[idx]
             energy_max = self.energy[idx + 1]
             exposure = self.exposure[idx]
-
             flux = spectrum(energy_min)
             weights[idx] = (exposure * flux * (energy_max - energy_min)).value
 
@@ -777,6 +776,8 @@ class EnergyDependentTablePSF(object):
             PSF value array
         """
         psf_values = self.psf_value[energy_index, :].flatten().copy()
+        where_are_NaNs = np.isnan(psf_values)
+        psf_values[where_are_NaNs] = 0
         return psf_values
 
     def _get_1d_table_psf(self, energy_index, **kwargs):

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -115,13 +115,25 @@ def test_EnergyDependentTablePSF():
     actual = psf_band.kernel(ref, normalize=True).value.sum()
     assert_allclose(actual, desired)
 
+
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_PSFLowEnergy():
+def test_psf_cta_1dc():
     filename = "$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits"
-    psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
-    psf = psf.to_energy_dependent_table_psf('4.5 deg')
-    psf.table_psf_at_energy('0.05 TeV')
+    psf_irf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
+
+    # Check that PSF is filled with 0 for energy / offset where no PSF info is given.
+    # This is needed so that stacked PSF computation doesn't error out,
+    # trying to interpolate for observations / energies where this occurs.
+    psf = psf_irf.to_energy_dependent_table_psf('4.5 deg')
+    psf = psf.table_psf_at_energy('0.05 TeV')
+    assert_allclose(psf.evaluate(rad='0.03 deg').value, 0)
+
+    # Check that evaluation works for an energy / offset where an energy is available
+    psf = psf_irf.to_energy_dependent_table_psf('2 deg')
+    psf = psf.table_psf_at_energy('1 TeV')
+    assert_allclose(psf.containment_radius(0.68).deg, 0.05175066714958721)
+
 
 @requires_data('gammapy-extra')
 @requires_dependency('matplotlib')

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -9,7 +9,7 @@ from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import gammapy_extra
 from ...datasets import FermiGalacticCenter
-from ...irf import TablePSF, EnergyDependentTablePSF
+from ...irf import TablePSF, EnergyDependentTablePSF, EnergyDependentMultiGaussPSF
 from ...image import SkyImage
 
 
@@ -115,6 +115,13 @@ def test_EnergyDependentTablePSF():
     actual = psf_band.kernel(ref, normalize=True).value.sum()
     assert_allclose(actual, desired)
 
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_PSFLowEnergy():
+    filename = "$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits"
+    psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
+    psf = psf.to_energy_dependent_table_psf('4.5 deg')
+    psf.table_psf_at_energy('0.05 TeV')
 
 @requires_data('gammapy-extra')
 @requires_dependency('matplotlib')


### PR DESCRIPTION
From tests made by Yves and Fabio, the PSF machinery crashed when one scan the space parameters where the PSF is not defined, e.g. at very low energy at large offset.
I propose fixes at the level of constructors at low level..