### PR TITLE
Add gammapy.irf.Background3D

### DIFF
--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -3,6 +3,7 @@
 Instrument response functions (IRFs).
 """
 from .effective_area import *
+from .background import *
 from .psf_core import *
 from .psf_table import *
 from .psf_3d import *

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -30,17 +30,18 @@ class Background3D(object):
 
     Examples
     --------
-    Create `~gammapy.irf.EffectiveAreaTable2D` from scratch
+    Here's an example you can use to learn about this class:
 
     >>> from gammapy.irf import Background3D
     >>> filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
-    >>> bkg_3d = Background3D.read(filename)
-    >>> print(bkg_3d.data)
+    >>> bkg_3d = Background3D.read(filename, hdu='BACKGROUND')
+    >>> print(bkg_3d)
+    Background3D
     NDDataArray summary info
     energy         : size =    21, min =  0.016 TeV, max = 158.489 TeV
     detx           : size =    12, min = -5.500 deg, max =  5.500 deg
     dety           : size =    12, min = -5.500 deg, max =  5.500 deg
-    Data           : size =  3024, min =  0.000 1/s/MeV/sr, max =  0.269 1/s/MeV/sr
+    Data           : size =  3024, min =  0.000 1 / (MeV s sr), max =  0.269 1 / (MeV s sr)
     """
     default_interp_kwargs = dict(bounds_error=False, fill_value=None)
     """Default Interpolation kwargs for `~NDDataArray`. Extrapolate."""
@@ -65,6 +66,11 @@ class Background3D(object):
         self.data = NDDataArray(axes=axes, data=data,
                                 interp_kwargs=interp_kwargs)
         self.meta = OrderedDict(meta) if meta else OrderedDict()
+
+    def __str__(self):
+        ss = self.__class__.__name__
+        ss += '\n{}'.format(self.data)
+        return ss
 
     @classmethod
     def from_table(cls, table):

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -1,0 +1,110 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
+from astropy.io import fits
+import astropy.units as u
+from ..utils.nddata import NDDataArray, BinnedDataAxis
+from ..utils.scripts import make_path
+from ..utils.fits import fits_table_to_table
+
+__all__ = [
+    'Background3D',
+]
+
+
+class Background3D(object):
+    """Background 3D.
+
+    Data format specification: :ref:`gadf:bkg_3d`
+
+    Parameters
+    -----------
+    energy_lo, energy_hi : `~astropy.units.Quantity`
+        Energy binning
+    detx_lo, detx_hi : `~astropy.units.Quantity`
+        FOV coordinate X-axis binning
+    dety_lo, dety_hi : `~astropy.units.Quantity`
+        FOV coordinate Y-axis binning
+    data : `~astropy.units.Quantity`
+        Background rate (usually: ``s^-1 MeV^-1 sr^-1``)
+
+    Examples
+    --------
+    Create `~gammapy.irf.EffectiveAreaTable2D` from scratch
+
+    >>> from gammapy.irf import Background3D
+    >>> filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    >>> bkg_3d = Background3D.read(filename)
+    >>> print(bkg_3d.data)
+    NDDataArray summary info
+    energy         : size =    21, min =  0.016 TeV, max = 158.489 TeV
+    detx           : size =    12, min = -5.500 deg, max =  5.500 deg
+    dety           : size =    12, min = -5.500 deg, max =  5.500 deg
+    Data           : size =  3024, min =  0.000 1/s/MeV/sr, max =  0.269 1/s/MeV/sr
+    """
+    default_interp_kwargs = dict(bounds_error=False, fill_value=None)
+    """Default Interpolation kwargs for `~NDDataArray`. Extrapolate."""
+
+    def __init__(self, energy_lo, energy_hi,
+                 detx_lo, detx_hi, dety_lo, dety_hi,
+                 data, meta=None, interp_kwargs=None):
+
+        if interp_kwargs is None:
+            interp_kwargs = self.default_interp_kwargs
+        axes = [
+            BinnedDataAxis(
+                energy_lo, energy_hi,
+                interpolation_mode='log', name='energy'),
+            BinnedDataAxis(
+                detx_lo, detx_hi,
+                interpolation_mode='linear', name='detx'),
+            BinnedDataAxis(
+                dety_lo, dety_hi,
+                interpolation_mode='linear', name='dety'),
+        ]
+        self.data = NDDataArray(axes=axes, data=data,
+                                interp_kwargs=interp_kwargs)
+        self.meta = OrderedDict(meta) if meta else OrderedDict()
+
+    @classmethod
+    def from_table(cls, table):
+        """Read from `~astropy.table.Table`."""
+        # Spec says key should be "BKG", but there are files around
+        # (e.g. CTA 1DC) that use "BGD". For now we support both
+        if 'BKG' in table.colnames:
+            bkg_name = 'BKG'
+        elif 'BGD' in table.colnames:
+            bkg_name = 'BGD'
+        else:
+            raise ValueError('Invalid column names. Need "BKG" or "BGD".')
+
+        # Currently some files (e.g. CTA 1DC) contain unit in the FITS file
+        # '1/s/MeV/sr', which is invalid ( try: astropy.unit.Unit('1/s/MeV/sr')
+        # This should be corrected.
+        # For now, we hard-code the unit here:
+        data_unit = u.Unit('s-1 MeV-1 sr-1')
+
+        return cls(
+            energy_lo=table['ENERG_LO'].quantity[0],
+            energy_hi=table['ENERG_HI'].quantity[0],
+            detx_lo=table['DETX_LO'].quantity[0],
+            detx_hi=table['DETX_HI'].quantity[0],
+            dety_lo=table['DETY_LO'].quantity[0],
+            dety_hi=table['DETY_HI'].quantity[0],
+            data=table[bkg_name].data[0] * data_unit,
+            meta=table.meta,
+        )
+
+    @classmethod
+    def from_hdulist(cls, hdulist, hdu='BACKGROUND'):
+        """Create from `~astropy.io.fits.HDUList`."""
+        fits_table = hdulist[hdu]
+        table = fits_table_to_table(fits_table)
+        return cls.from_table(table)
+
+    @classmethod
+    def read(cls, filename, hdu='BACKGROUND'):
+        """Read from file."""
+        filename = make_path(filename)
+        hdulist = fits.open(str(filename))
+        return cls.from_hdulist(hdulist, hdu=hdu)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -24,14 +24,10 @@ class EnergyDispersion(object):
 
     Parameters
     ----------
-    e_true_lo : `~astropy.units.Quantity`
-        Lower bin edges of true energy axis
-    e_true_hi : `~astropy.units.Quantity`
-        Upper bin edges of true energy axis
-    e_reco_lo : `~astropy.units.Quantity`
-        Lower bin edges of reconstruced energy axis
-    e_reco_hi : `~astropy.units.Quantity`
-        Upper bin edges of reconstruced energy axis
+    e_true_lo, e_true_hi : `~astropy.units.Quantity`
+        True energy axis binning
+    e_reco_lo, e_reco_hi : `~astropy.units.Quantity`
+        Reconstruced energy axis binning
     data : array_like
         2-dim energy dispersion matrix
 
@@ -39,6 +35,7 @@ class EnergyDispersion(object):
     --------
     Create a Gaussian energy dispersion matrix::
 
+        import numpy as np
         import astropy.units as u
         from gammapy.irf import EnergyDispersion
         energy = np.logspace(0, 1, 101) * u.TeV
@@ -78,7 +75,6 @@ class EnergyDispersion(object):
     def __str__(self):
         ss = self.__class__.__name__
         ss += '\n{}'.format(self.data)
-
         return ss
 
     def apply(self, data):
@@ -550,20 +546,14 @@ class EnergyDispersion2D(object):
 
     Parameters
     ----------
-    e_true_lo : `~astropy.units.Quantity`
-        True energy axis lower bounds
-    e_true_hi : `~astropy.units.Quantity`
-        True energy axis upper bounds
-    migra_lo : `~numpy.ndarray`, list
-        Migration axis lower bounds
-    migra_hi : `~numpy.ndarray`, list
-        Migration axis upper bounds
-    offset_lo : `~astropy.coordinates.Angle`
-        Offset axis lower bounds
-    offset_hi : `~astropy.coordinates.Angle`
-        Offset axis upper bounds
+    e_true_lo, e_true_hi : `~astropy.units.Quantity`
+        True energy axis binning
+    migra_lo, migra_hi : `~numpy.ndarray`
+        Energy migration axis binning
+    offset_lo, offset_hi : `~astropy.coordinates.Angle`
+        Field of view offset axis binning
     data : `~numpy.ndarray`
-        PDF matrix
+        Energy dispersion probability density
 
     Examples
     --------
@@ -619,7 +609,6 @@ class EnergyDispersion2D(object):
     def __str__(self):
         ss = self.__class__.__name__
         ss += '\n{}'.format(self.data)
-
         return ss
 
     @property

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import astropy.units as u
+from numpy.testing import assert_allclose
+from ..background import Background3D
+
+
+@pytest.fixture(scope='session')
+def bkg_3d():
+    filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    return Background3D.read(filename, hdu='BACKGROUND')
+
+
+def test_background_3d_basics(bkg_3d):
+    assert 'NDDataArray summary info' in str(bkg_3d.data)
+
+    axis = bkg_3d.data.axis('energy')
+    assert axis.nbins == 21
+    assert axis.unit == 'TeV'
+
+    axis = bkg_3d.data.axis('detx')
+    assert axis.nbins == 12
+    assert axis.unit == 'deg'
+
+    axis = bkg_3d.data.axis('dety')
+    assert axis.nbins == 12
+    assert axis.unit == 'deg'
+
+    data = bkg_3d.data.data
+    assert data.shape == (21, 12, 12)
+    assert data.unit == u.Unit('s-1 MeV-1 sr-1')
+
+
+def test_background_3d_evalutate(bkg_3d):
+    bkg_rate = bkg_3d.data.evaluate(energy='1 TeV', detx='0.2 deg', dety='0.5 deg')
+    assert_allclose(bkg_rate.value, 0.00013652553025167435)
+    bkg_rate.unit == '1/s/MeV/sr'

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import astropy.units as u
 from numpy.testing import assert_allclose
+from ...utils.testing import requires_dependency, requires_data
 from ..background import Background3D
 
 
@@ -12,6 +13,8 @@ def bkg_3d():
     return Background3D.read(filename, hdu='BACKGROUND')
 
 
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
 def test_background_3d_basics(bkg_3d):
     assert 'NDDataArray summary info' in str(bkg_3d.data)
 
@@ -32,7 +35,9 @@ def test_background_3d_basics(bkg_3d):
     assert data.unit == u.Unit('s-1 MeV-1 sr-1')
 
 
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
 def test_background_3d_evalutate(bkg_3d):
     bkg_rate = bkg_3d.data.evaluate(energy='1 TeV', detx='0.2 deg', dety='0.5 deg')
     assert_allclose(bkg_rate.value, 0.00013652553025167435)
-    bkg_rate.unit == '1/s/MeV/sr'
+    bkg_rate.unit == u.Unit('s-1 MeV-1 sr-1')

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -357,8 +357,8 @@ class SpectrumResult(object):
             points_err = np.sqrt(points_err[0] * points_err[1])
 
         model_val = self.model(e_ref)
-        residuals = ((points - model_val) / model_val).to('')
-        residuals_err = (points_err / model_val).to('')
+        residuals = ((points - model_val) / model_val).to('').value
+        residuals_err = (points_err / model_val).to('').value
 
         return residuals, residuals_err
 


### PR DESCRIPTION
This PR adds a `gammapy.irf.Background3D` class that can read the `mkg_3d` format:

http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/full_enclosure/bkg/index.html#bkg-3d

A test case (and some minor workarounds for units issues) with a CTA 1DC response file are included.

This is just a first step (pair coding with @robertazanin), the next steps would be to add a `make_background_cube` function in a similar way to and next to [gammapy.cube.make_exposure_cube](http://docs.gammapy.org/en/latest/api/gammapy.cube.make_exposure_cube.html) and to update the 3D simulation / analysis example in `examples/3d` in a follow-up PR.

Reviewing the old `gammapy.background.FOVCube` class, copying over the useful methods and adding tests to this replacement `gammapy.irf.Background3D` should be done, but probably no-one has time to do it now.