### PR TITLE
Fix SkyImage plot norm computation for images with nan values

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -929,7 +929,7 @@ class SkyImage(MapBase):
         kwargs['origin'] = kwargs.get('origin', 'lower')
         kwargs['cmap'] = kwargs.get('cmap', 'afmhot')
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
-        norm = simple_norm(data, stretch)
+        norm = simple_norm(data[~np.isnan(data)], stretch)
         kwargs.setdefault('norm', norm)
 
         caxes = ax.imshow(data, **kwargs)


### PR DESCRIPTION
The norm computation fails in case there are nan values in the image. Ignoring these values gives more sensible results.