### PR TITLE
Fix ring background estimation

### DIFF
--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -213,6 +213,12 @@ class AdaptiveRingBackgroundEstimator(object):
 
         exposure_off, off = self._reduce_cubes(cubes)
         alpha = images['exposure_on'].data / exposure_off
+        not_has_exposure = ~(images['exposure_on'].data > 0)
+
+        # set data outside fov to zero
+        for data in [alpha, off, exposure_off]:
+            data[not_has_exposure] = 0
+
         background = alpha * off
 
         result = SkyImageList()
@@ -316,11 +322,12 @@ class RingBackgroundEstimator(object):
         ring = self.kernel(counts)
 
         counts_excluded = SkyImage(data=counts.data * exclusion.data, wcs=wcs)
-        result['off'] = counts_excluded.convolve(ring.array, mode='reflect',
+        result['off'] = counts_excluded.convolve(ring.array, mode='constant',
                                                  use_fft=p['use_fft_convolution'])
         result['off'].data = result['off'].data.astype(int)
 
         exposure_on_excluded = SkyImage(data=exposure_on.data * exclusion.data, wcs=wcs)
+
         result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='reflect',
                                                                use_fft=p['use_fft_convolution'])
 

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -247,8 +247,12 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         """
         input_images = SkyImageList()
         input_images['counts'] = counts
+
+        #TODO: instead of using a constant exposure, the acceptance model should
+        # be taken into account
         exposure_on = exposure.copy()
         exposure_on.name = 'exposure_on'
+        exposure_on.data = (exposure_on.data > 0).astype(float)
         input_images['exposure_on'] = exposure_on
         input_images['exclusion'] = self._cutout_observation(self.exclusion_mask, observation)
         return self.background_estimator.run(input_images)

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -97,10 +97,10 @@ class TestIACTBasicImageEstimator:
     def test_run(self):
         images = OrderedDict()
         images['counts'] = dict(sum=2222.0)
-        images['background'] = dict(sum=1855.654807821552)
+        images['background'] = dict(sum=1827.9166666666665)
         images['exposure'] = dict(sum=83036669325.30281)
-        images['excess'] = dict(sum=366.34519217844803)
-        images['flux'] = dict(sum=8.143944483402417e-07)
+        images['excess'] = dict(sum=394.0833333333333)
+        images['flux'] = dict(sum=8.477134335825048e-07)
         images['psf'] = dict(sum=1.)
         results = self.estimator.run(self.observations)
 


### PR DESCRIPTION
This PR partly fixes the ring background estimation, when used with the `IACTBasicImageEstimator`, by assuming constant `on_exposure` instead of the gamma exposure. This still isn't correct, but gets rid of the prominent artefacts at high offsets. It also fixes the `AdaptiveRingBackgroundEstimator` to only fill all maps within the FoV.