### PR TITLE
Change from healpy to astropy-healpix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,8 @@ install:
           export QT_API=pyqt;
       fi
 
+    - pip install git+https://github.com/gammapy/gammapy.git#egg=gammapy
+
 script:
     - $MAIN_CMD $SETUP_CMD
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -164,7 +164,7 @@ def get_nside_from_pixel_size(pixsz):
     nside : `~numpy.ndarray`
         NSIDE parameter.
     """
-    import healpy as hp
+    from astropy_healpix import healpy as hp
     pixsz = np.array(pixsz, ndmin=1)
     nside = 2 ** np.linspace(1, 14, 14, dtype=int)
     nside_pixsz = np.degrees(hp.nside2resol(nside))
@@ -267,7 +267,7 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
     npix : tuple
         tuple(nx,ny) with the shape of the WCS grid
     """
-    import healpy as hp
+    from astropy_healpix import healpy as hp
     npix = wcs.npix
 
     # FIXME: Calculation of WCS pixel centers should be moved into a
@@ -282,10 +282,10 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
     ipix = -1 * np.ones((len(hpx.nside), int(npix[0] * npix[1])), int)
     m = mask[None, :] * np.ones_like(ipix, dtype=bool)
 
-    ipix[m] = hp.pixelfunc.ang2pix(hpx.nside[..., None],
-                                   sky_crds[:, 1][mask][None, ...],
-                                   sky_crds[:, 0][mask][None, ...],
-                                   hpx.nest).flatten()
+    ipix[m] = hp.ang2pix(hpx.nside[..., None],
+                         sky_crds[:, 1][mask][None, ...],
+                         sky_crds[:, 0][mask][None, ...],
+                         hpx.nest).flatten()
 
     # Here we are counting the number of HEALPIX pixels each WCS pixel
     # points to and getting a multiplicative factor that tells use how
@@ -308,7 +308,7 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
 def match_hpx_pixel(nside, nest, nside_pix, ipix_ring):
     """TODO
     """
-    import healpy as hp
+    from astropy_healpix import healpy as hp
     ipix_in = np.arange(12 * nside * nside)
     vecs = hp.pix2vec(nside, ipix_in, nest)
     pix_match = hp.vec2pix(nside_pix, vecs[0], vecs[1], vecs[2]) == ipix_ring
@@ -588,7 +588,7 @@ class HpxGeom(MapGeom):
         return retval
 
     def coord_to_pix(self, coords):
-        import healpy as hp
+        from astropy_healpix import healpy as hp
         c = MapCoords.create(coords)
         phi = np.radians(c.lon)
         theta = np.pi / 2. - np.radians(c.lat)
@@ -616,7 +616,7 @@ class HpxGeom(MapGeom):
         return pix
 
     def pix_to_coord(self, pix):
-        import healpy as hp
+        from astropy_healpix import healpy as hp
         if self.axes:
 
             bins = []
@@ -1182,7 +1182,7 @@ class HpxGeom(MapGeom):
         ilist : `~numpy.ndarray`
             List of pixel indices.
         """
-        import healpy as hp
+        from astropy_healpix import healpy as hp
         tokens = parse_hpxregion(region)
 
         if tokens[0] == 'DISK':
@@ -1221,7 +1221,7 @@ class HpxGeom(MapGeom):
         coordsys : {'CEL', 'GAL'}
             Coordinate system
         """
-        import healpy as hp
+        from astropy_healpix import healpy as hp
         frame = coordsys_to_frame(coordsys)
 
         if region is None or isinstance(region, tuple):

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -278,7 +278,7 @@ class HpxMapND(HpxMap):
 
     def _get_interp_weights(self, coords, idxs):
 
-        import healpy as hp
+        from astropy_healpix import healpy as hp
 
         c = MapCoords.create(coords)
         coords_ctr = list(coords[:2])
@@ -298,8 +298,8 @@ class HpxMapND(HpxMap):
         else:
             nside = self.hpx.nside
 
-        pix, wts = hp.pixelfunc.get_interp_weights(nside, theta,
-                                                   phi, nest=self.hpx.nest)
+        pix, wts = hp.get_interp_weights(nside, theta,
+                                         phi, nest=self.hpx.nest)
 
         if self.hpx.nside.size > 1:
             pix_local = [self.hpx.global_to_local([pix] + list(idxs))[0]]
@@ -313,7 +313,7 @@ class HpxMapND(HpxMap):
 
     def _interp_by_coords(self, coords, interp):
         """Linearly interpolate map values."""
-        import healpy as hp
+        from astropy_healpix import healpy as hp
 
         c = MapCoords.create(coords)
         pix, wts = self._get_interp_weights(coords,
@@ -371,7 +371,7 @@ class HpxMapND(HpxMap):
 
     def to_swapped_scheme(self):
 
-        import healpy as hp
+        from astropy_healpix import healpy as hp
         hpx_out = self.hpx.to_swapped()
         map_out = self.__class__(hpx_out)
         idx = list(self.hpx.get_pixels())
@@ -401,7 +401,7 @@ class HpxMapND(HpxMap):
         # FIXME: For higher order maps we may want the option to split
         # the pixel amplitude among all subpixels
 
-        import healpy as hp
+        from astropy_healpix import healpy as hp
         order = nside_to_order(nside)
         new_hpx = self.hpx.ud_graded_hpx(order)
         map_out = self.__class__(new_hpx)
@@ -491,7 +491,7 @@ class HpxMapND(HpxMap):
         import matplotlib.pyplot as plt
         from matplotlib.patches import Polygon
         from matplotlib.collections import PatchCollection
-        import healpy as hp
+        from astropy_healpix import healpy as hp
 
         wcs = self.geom.make_wcs(proj=proj, oversample=1)
         if ax is None:
@@ -502,7 +502,7 @@ class HpxMapND(HpxMap):
         pix = self.geom.get_pixels()
         vtx = hp.boundaries(self.geom.nside, pix[0],
                             nest=self.geom.nest, step=step)
-        theta, phi = hp.pixelfunc.vec2ang(np.rollaxis(vtx, 2))
+        theta, phi = hp.vec2ang(np.rollaxis(vtx, 2))
         theta = theta.reshape((4 * step, -1)).T
         phi = phi.reshape((4 * step, -1)).T
 

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -38,7 +38,7 @@ def _get_input_pixels_celestial(wcs_in, wcs_out, shape_out):
 def reproject_car_to_hpx(input_data, coord_system_out,
                          nside, order=1, nested=False):
 
-    import healpy as hp
+    from astropy_healpix import healpy as hp
     from scipy.ndimage import map_coordinates
     from reproject.wcs_utils import convert_world_coordinates
     from reproject.healpix.utils import parse_coord_system

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -183,7 +183,7 @@ def test_hpxgeom_get_pixels(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxgeom_coord_to_idx(nside, nested, coordsys, region, axes):
-    import healpy as hp
+    from astropy_healpix import healpy as hp
 
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
     lon = np.array([112.5, 135., 105.])


### PR DESCRIPTION
Astropy is growing a HEALPix package. At the moment it's under development as a separate package at http://astropy-healpix.readthedocs.io but the idea is to propose it for inclusion in the Astropy core package as `astropy.healpix` once it's stable and polished. The [hips](https://hips.readthedocs.io) and [reproject](http://reproject.readthedocs.io/) packages were already switched over from `healpy` to `astropy-healpix`, and I propose we do the same with Gammapy.

One major advantage over `healpy` is that it's easy to install and works on Windows; once merged in Astropy core it's one less extra dependency for Gammapy. Another one is that it's BSD-licensed just like Astropy, Gammapy, ... whereas the HEALPix C++ library and `healpy` are GPL-licensed and thus importing them in Astropy or Reproject or Gammapy is a legal gray zone (there have been long debates over the past years in which case it is and isn't legal to import a GPL package from a BSD package, in the end opinions differ and who is "right" is never clear at the end, because that would be for a judge to decide and as far as I know there is no known case yet where this decision was forced). Finally, another small plus in my opinion: the astropy-healpix API is using Astropy Angle, SkyCoord and Frame objects like we already do in many places in Gammapy, whereas healpy is using co-latitude in radians which often trips up people new to sky coordinates.

The disadvantages of changing to `astropy.healpix` I see are that it's a factor of ~ 4 slower in the main operation pix2ang and ang2pix for large pixel arrays (see [here](http://astropy-healpix.readthedocs.io/en/latest/performance.html)). This is likely due to the underlying C implementation of pix2ang and ang2pix which is done in a different, slower way in astropy-healpix compared to the HEALPix C++ library. On the other hand, `astropy-healpix` can now use multi-core and then be faster if you have more than 4 CPU cores. My understanding is that speed here doesn't matter much for Gammapy though, because pix2ang and ang2pix only is called as a setup step at the start once, not during likelihood fitting. For a million pixels, pix2ang takes ~ 0.15 seconds, i.e. HEALPix computations are unlikely to dominate compute time for any application we have in Gammapy. The other disadvantage I see is that there's a little bit of development work needed now in the coming weeks to make `astropy-healpix` complete for what we need in Gammapy, and possibly, should we decide to move some non-gamma-ray specific parts of `gammapy.maps` to `astropy-healpix`, quite some development effort for the coming weeks.

This PR is a first attempt to make the switch for Gammapy by just changing to `from astropy_healpix import healpy as hp` as described as migration strategy here: http://astropy-healpix.readthedocs.io/en/latest/healpy_compat.html#migrate
I'm not proposing this be merged now, this is just for discussion and to see which pieces are missing in astropy-healpix and to develop those in the coming days.

This is what I get locally at the moment for `python -m pytest -v gammapy/maps`:
https://gist.github.com/cdeil/754b76dc7f22511a5504fbbe74dccd62
I'll have a look now and see if some or all of those can be resolved easily.

@woodmd and anyone interested in the topic - Thoughts?

If we go this way (and really in any case), increasing the coverage of `gammapy.maps` to a have a test executing one test case for each major function / method that does some computation would be helpful.

To make a coverage report locally:
```
python setup.py test -V -t gammapy/maps --coverage
open htmlcov/index.html
```
and we also have coveralls that shows which functions / methods currently aren't covered:
* [hpxsparse.py](https://coveralls.io/builds/13730985/source?filename=gammapy%2Fmaps%2Fhpxsparse.py)
* [hpxcube.py](https://coveralls.io/builds/13730985/source?filename=gammapy%2Fmaps%2Fhpxcube.py)
* [hpx.py](https://coveralls.io/builds/13730985/source?filename=gammapy%2Fmaps%2Fhpx.py)
* [hpxmap.py](https://coveralls.io/builds/13730985/source?filename=gammapy%2Fmaps%2Fhpxmap.py)

cc @astrofrog 