### PR TITLE
Add sparse map prototype

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -309,9 +309,9 @@ Maps can be written to and read from a FITS file with the
    from gammapy.maps import MapBase, WcsMapND
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', extname='IMAGE')
-   m = WcsMapND.read('file.fits', extname='IMAGE')
+   m = WcsMapND.read('file.fits', hdu='IMAGE')
 
-Images can be serialized to a sparse data format by calling
+Maps can be serialized to a sparse data format by calling
 `~MapBase.write` with ``sparse=True``.  This will write all non-zero
 pixels in the map to a data table appropriate to the pixelization
 scheme.
@@ -321,7 +321,17 @@ scheme.
    from gammapy.maps import MapBase, WcsMapND
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', extname='IMAGE', sparse=True)
-   m = WcsMapND.read('file.fits', extname='IMAGE')
+   m = WcsMapND.read('file.fits', hdu='IMAGE')
+
+Sparse maps have the same ``read`` and ``write`` methods with the
+exception that they will be written to a sparse format by default:
+
+.. code::
+
+   from gammapy.maps import MapBase, HpxMapSparse
+   m = MapBase.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
+   m.write('file.fits', extname='IMAGE')
+   m = HpxMapSparse.read('file.fits', hdu='IMAGE')
 
 By default files will be written to the *gamma-astro-data-format*
 specification for sky maps (see `here

--- a/gammapy/maps/_sparse.pyx
+++ b/gammapy/maps/_sparse.pyx
@@ -4,16 +4,22 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+ctypedef fused int_t:
+    np.int32_t
+    np.int64_t
+
+ctypedef fused float_t:
+    np.float32_t
+    np.float64_t
+
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def binary_search(np.ndarray[np.int64_t, ndim=1] arr_in, np.int64_t idx,
-                  np.int64_t ilo, np.int64_t ihi):
+def binary_search(np.ndarray[int_t, ndim=1] arr_in, int_t idx,
+                  int_t ilo, int_t ihi):
     """Perform a binary search for an element ``idx`` in a sorted integer
     array ``arr_in``.  The search is restricted to the range between
-    ``ilo`` and ``ihi``.  This will return the index of the matching
-    element or the index at which ``idx`` would be inserted to
-    maintain sorted order.
+    ``ilo`` and ``ihi``.
 
     Parameters
     ----------
@@ -21,12 +27,18 @@ def binary_search(np.ndarray[np.int64_t, ndim=1] arr_in, np.int64_t idx,
         Sorted array of integers.
 
     idx : int
-        Value to be searched for.
+        Value to be searched for in ``arr_in``.
+
+    Returns
+    -------
+    idx_out: int
+        Index of matching element or the index at which ``idx`` would
+        be inserted to maintain sorted order.
 
     """
-    
-    cdef int mid = 0
-    cdef int midval = 0
+
+    cdef int_t mid = 0
+    cdef int_t midval = 0
 
     while(ilo < ihi):
         mid = (ilo + ihi) // 2
@@ -44,30 +56,8 @@ def binary_search(np.ndarray[np.int64_t, ndim=1] arr_in, np.int64_t idx,
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def binary_search2(np.ndarray[np.int64_t, ndim=1] arr_in, np.int64_t idx,
-                   np.int64_t ilo, np.int64_t ihi):
-
-    cdef int mid = 0
-    cdef int midval = 0
-
-    while(ilo < ihi):
-        mid = (ilo + ihi) // 2
-        midval = arr_in[mid]
-
-        if midval < idx:
-            ilo = mid + 1
-        elif midval > idx:
-            ihi = mid
-        else:
-            return mid, 1
-
-    return ilo, 0
-
-
-@cython.cdivision(True)
-@cython.boundscheck(False)
-def find_in_array(np.ndarray[np.int64_t, ndim=1] idx0,
-                  np.ndarray[np.int64_t, ndim=1] idx1):
+def find_in_array(np.ndarray[int_t, ndim=1] idx0,
+                  np.ndarray[int_t, ndim=1] idx1):
     """Find the values in ``idx0`` contained in ``idx1``.
 
     Parameters
@@ -93,12 +83,12 @@ def find_in_array(np.ndarray[np.int64_t, ndim=1] idx0,
     cdef int ni = idx0.shape[0]
     cdef int nj = idx1.shape[0]
 
-    cdef np.ndarray[np.int64_t, ndim= 1] idx_sort = np.argsort(idx0)
+    cdef np.ndarray[int_t, ndim = 1] idx_sort = np.argsort(idx0)
     cdef int i = 0
     cdef int ii = 0
-    cdef np.int64_t j = binary_search(idx1, idx0[idx_sort[0]], 0, nj)
-    cdef np.ndarray[np.int64_t, ndim = 1] out = np.zeros([ni], dtype=np.int64)
-    cdef np.ndarray[np.uint8_t, ndim = 1] msk = np.zeros([ni], dtype=np.uint8)
+    cdef int_t j = binary_search(idx1, idx0[idx_sort[0]], 0, nj)
+    cdef np.ndarray[int_t, ndim= 1] out = np.zeros([ni], dtype=idx0.dtype)
+    cdef np.ndarray[np.uint8_t, ndim= 1] msk = np.zeros([ni], dtype=np.uint8)
 
     while(i < ni and j < nj):
 
@@ -120,11 +110,11 @@ def find_in_array(np.ndarray[np.int64_t, ndim=1] idx0,
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def merge_sparse_arrays(np.ndarray[np.int64_t, ndim=1] idx0,
-                        np.ndarray[np.float64_t, ndim=1] val0,
-                        np.ndarray[np.int64_t, ndim=1] idx1,
-                        np.ndarray[np.float64_t, ndim=1] val1,
-                        np.int64_t fill=False
+def merge_sparse_arrays(np.ndarray[int_t, ndim=1] idx0,
+                        np.ndarray[float_t, ndim=1] val0,
+                        np.ndarray[int_t, ndim=1] idx1,
+                        np.ndarray[float_t, ndim=1] val1,
+                        bint fill=False
                         ):
     """Merge two sparse arrays represented as index/value pairs into a
     single sparse array.  Values in the first array (``idx0``,
@@ -133,16 +123,16 @@ def merge_sparse_arrays(np.ndarray[np.int64_t, ndim=1] idx0,
 
     Parameters
     ----------
-    idx0 : `numpy.ndarray`
+    idx0 : `~numpy.ndarray`
         Array of indices of first sparse array.
 
-    val0 : `numpy.ndarray`
+    val0 : `~numpy.ndarray`
         Array of values of first sparse array.
 
-    idx1 : `numpy.ndarray`
+    idx1 : `~numpy.ndarray`
         Array of indices for second sparse array. 
 
-    val1 : `numpy.ndarray`
+    val1 : `~numpy.ndarray`
         Array of values for second sparse array. 
 
     fill : bool
@@ -153,10 +143,10 @@ def merge_sparse_arrays(np.ndarray[np.int64_t, ndim=1] idx0,
 
     Returns
     -------
-    idx : `numpy.ndarray`
+    idx : `~numpy.ndarray`
         Array of indices for merged sparse array.
 
-    vals : `numpy.ndarray`
+    vals : `~numpy.ndarray`
         Array of values for merged sparse array.
 
     """
@@ -171,9 +161,10 @@ def merge_sparse_arrays(np.ndarray[np.int64_t, ndim=1] idx0,
     idx0 = idx0[isort]
     val0 = val0[isort]
 
-    cdef np.ndarray[np.int64_t, ndim= 1] idx = np.sort(np.unique(np.concatenate((idx0, idx1))))
+    cdef np.ndarray[int_t, ndim = 1] idx = np.sort(np.unique(np.concatenate((idx0, idx1))))
     cdef int n = idx.size
-    cdef np.ndarray[np.float64_t, ndim = 1] vals = np.zeros(n, dtype=np.float64)
+    cdef np.ndarray[float_t, ndim= 1] vals = np.zeros(n, dtype=val0.dtype)
+
     while(k < n):
 
         while(j < nj):

--- a/gammapy/maps/_sparse.pyx
+++ b/gammapy/maps/_sparse.pyx
@@ -7,7 +7,8 @@ cimport cython
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def binary_search(np.ndarray[np.int_t, ndim=1] arr_in, np.int_t idx, np.int_t ilo, np.int_t ihi):
+def binary_search(np.ndarray[np.int64_t, ndim=1] arr_in, np.int64_t idx,
+                  np.int64_t ilo, np.int64_t ihi):
     """Perform a binary search for an element ``idx`` in a sorted integer
     array ``arr_in``.  The search is restricted to the range between
     ``ilo`` and ``ihi``.  This will return the index of the matching
@@ -43,7 +44,8 @@ def binary_search(np.ndarray[np.int_t, ndim=1] arr_in, np.int_t idx, np.int_t il
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def binary_search2(np.ndarray[np.int_t, ndim=1] arr_in, np.int_t idx, np.int_t ilo, np.int_t ihi):
+def binary_search2(np.ndarray[np.int64_t, ndim=1] arr_in, np.int64_t idx,
+                   np.int64_t ilo, np.int64_t ihi):
 
     cdef int mid = 0
     cdef int midval = 0
@@ -64,8 +66,8 @@ def binary_search2(np.ndarray[np.int_t, ndim=1] arr_in, np.int_t idx, np.int_t i
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def find_in_array(np.ndarray[np.int_t, ndim=1] idx0,
-                  np.ndarray[np.int_t, ndim=1] idx1):
+def find_in_array(np.ndarray[np.int64_t, ndim=1] idx0,
+                  np.ndarray[np.int64_t, ndim=1] idx1):
     """Find the values in ``idx0`` contained in ``idx1``.
 
     Parameters
@@ -91,38 +93,38 @@ def find_in_array(np.ndarray[np.int_t, ndim=1] idx0,
     cdef int ni = idx0.shape[0]
     cdef int nj = idx1.shape[0]
 
-    cdef np.ndarray[np.int_t, ndim= 1] idx_sort = np.argsort(idx0)
-    cdef int i_ = 0
-    cdef int ii_ = 0
-    cdef int j_ = binary_search(idx1, idx0[idx_sort[0]], 0, nj)
-    cdef np.ndarray[np.int_t, ndim = 1] out = np.zeros([ni], dtype=int)
+    cdef np.ndarray[np.int64_t, ndim= 1] idx_sort = np.argsort(idx0)
+    cdef int i = 0
+    cdef int ii = 0
+    cdef np.int64_t j = binary_search(idx1, idx0[idx_sort[0]], 0, nj)
+    cdef np.ndarray[np.int64_t, ndim = 1] out = np.zeros([ni], dtype=np.int64)
     cdef np.ndarray[np.uint8_t, ndim = 1] msk = np.zeros([ni], dtype=np.uint8)
 
-    while(i_ < ni and j_ < nj):
+    while(i < ni and j < nj):
 
-        ii_ = idx_sort[i_]
+        ii = idx_sort[i]
 
         # Current element is less
-        if idx0[ii_] < idx1[j_]:
-            out[ii_] = j_
-            i_ += 1
-        elif idx0[ii_] > idx1[j_]:
-            j_ += 1
+        if idx0[ii] < idx1[j]:
+            out[ii] = j
+            i += 1
+        elif idx0[ii] > idx1[j]:
+            j += 1
         else:
-            out[ii_] = j_
-            msk[ii_] = True
-            i_ += 1
+            out[ii] = j
+            msk[ii] = True
+            i += 1
 
     return out, msk.astype(bool)
 
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
-def merge_sparse_arrays(np.ndarray[np.int_t, ndim=1] idx0,
-                        np.ndarray[np.float_t, ndim=1] val0,
-                        np.ndarray[np.int_t, ndim=1] idx1,
-                        np.ndarray[np.float_t, ndim=1] val1,
-                        np.int_t fill=False
+def merge_sparse_arrays(np.ndarray[np.int64_t, ndim=1] idx0,
+                        np.ndarray[np.float64_t, ndim=1] val0,
+                        np.ndarray[np.int64_t, ndim=1] idx1,
+                        np.ndarray[np.float64_t, ndim=1] val1,
+                        np.int64_t fill=False
                         ):
     """Merge two sparse arrays represented as index/value pairs into a
     single sparse array.  Values in the first array (``idx0``,
@@ -169,9 +171,9 @@ def merge_sparse_arrays(np.ndarray[np.int_t, ndim=1] idx0,
     idx0 = idx0[isort]
     val0 = val0[isort]
 
-    cdef np.ndarray[np.int_t, ndim= 1] idx = np.sort(np.unique(np.concatenate((idx0, idx1))))
+    cdef np.ndarray[np.int64_t, ndim= 1] idx = np.sort(np.unique(np.concatenate((idx0, idx1))))
     cdef int n = idx.size
-    cdef np.ndarray[np.float_t, ndim = 1] vals = np.zeros(n, dtype=float)
+    cdef np.ndarray[np.float64_t, ndim = 1] vals = np.zeros(n, dtype=np.float64)
     while(k < n):
 
         while(j < nj):

--- a/gammapy/maps/_sparse.pyx
+++ b/gammapy/maps/_sparse.pyx
@@ -1,0 +1,205 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+cimport numpy as np
+cimport cython
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+def binary_search(np.ndarray[np.int_t, ndim=1] arr_in, np.int_t idx, np.int_t ilo, np.int_t ihi):
+    """Perform a binary search for an element ``idx`` in a sorted integer
+    array ``arr_in``.  The search is restricted to the range between
+    ``ilo`` and ``ihi``.  This will return the index of the matching
+    element or the index at which ``idx`` would be inserted to
+    maintain sorted order.
+
+    Parameters
+    ----------
+    arr_in : `~numpy.ndarray`
+        Sorted array of integers.
+
+    idx : int
+        Value to be searched for.
+
+    """
+    
+    cdef int mid = 0
+    cdef int midval = 0
+
+    while(ilo < ihi):
+        mid = (ilo + ihi) // 2
+        midval = arr_in[mid]
+
+        if midval < idx:
+            ilo = mid + 1
+        elif midval > idx:
+            ihi = mid
+        else:
+            return mid
+
+    return ilo
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+def binary_search2(np.ndarray[np.int_t, ndim=1] arr_in, np.int_t idx, np.int_t ilo, np.int_t ihi):
+
+    cdef int mid = 0
+    cdef int midval = 0
+
+    while(ilo < ihi):
+        mid = (ilo + ihi) // 2
+        midval = arr_in[mid]
+
+        if midval < idx:
+            ilo = mid + 1
+        elif midval > idx:
+            ihi = mid
+        else:
+            return mid, 1
+
+    return ilo, 0
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+def find_in_array(np.ndarray[np.int_t, ndim=1] idx0,
+                  np.ndarray[np.int_t, ndim=1] idx1):
+    """Find the values in ``idx0`` contained in ``idx1``.
+
+    Parameters
+    ----------
+    idx0 : `~np.ndarray`
+        Array of unsorted input values.
+
+    idx1 : `~np.ndarray`
+        Array of sorted values to be searched. 
+
+    Returns
+    -------
+    idx : `~np.ndarray`
+        Array of indices with length of ``idx0`` with the position of
+        the given element in ``idx1``.
+
+    msk : `~np.ndarray`
+        Boolean mask with length of ``idx0`` indicating whether a
+        given value was found in ``idx1``.
+
+    """
+
+    cdef int ni = idx0.shape[0]
+    cdef int nj = idx1.shape[0]
+
+    cdef np.ndarray[np.int_t, ndim= 1] idx_sort = np.argsort(idx0)
+    cdef int i_ = 0
+    cdef int ii_ = 0
+    cdef int j_ = binary_search(idx1, idx0[idx_sort[0]], 0, nj)
+    cdef np.ndarray[np.int_t, ndim = 1] out = np.zeros([ni], dtype=int)
+    cdef np.ndarray[np.uint8_t, ndim = 1] msk = np.zeros([ni], dtype=np.uint8)
+
+    while(i_ < ni and j_ < nj):
+
+        ii_ = idx_sort[i_]
+
+        # Current element is less
+        if idx0[ii_] < idx1[j_]:
+            out[ii_] = j_
+            i_ += 1
+        elif idx0[ii_] > idx1[j_]:
+            j_ += 1
+        else:
+            out[ii_] = j_
+            msk[ii_] = True
+            i_ += 1
+
+    return out, msk.astype(bool)
+
+
+@cython.cdivision(True)
+@cython.boundscheck(False)
+def merge_sparse_arrays(np.ndarray[np.int_t, ndim=1] idx0,
+                        np.ndarray[np.float_t, ndim=1] val0,
+                        np.ndarray[np.int_t, ndim=1] idx1,
+                        np.ndarray[np.float_t, ndim=1] val1,
+                        np.int_t fill=False
+                        ):
+    """Merge two sparse arrays represented as index/value pairs into a
+    single sparse array.  Values in the first array (``idx0``,
+    ``val0``) will supersede those in the second array.  Indices in
+    the second array should be presorted.
+
+    Parameters
+    ----------
+    idx0 : `numpy.ndarray`
+        Array of indices of first sparse array.
+
+    val0 : `numpy.ndarray`
+        Array of values of first sparse array.
+
+    idx1 : `numpy.ndarray`
+        Array of indices for second sparse array. 
+
+    val1 : `numpy.ndarray`
+        Array of values for second sparse array. 
+
+    fill : bool
+        Flag to switch between update and fill mode.  When fill is
+        True the values in the first array will be added to the second
+        array.  When fill is False values in the second array will be
+        updated to the values in the first array.
+
+    Returns
+    -------
+    idx : `numpy.ndarray`
+        Array of indices for merged sparse array.
+
+    vals : `numpy.ndarray`
+        Array of values for merged sparse array.
+
+    """
+
+    cdef int ni = idx0.shape[0]
+    cdef int nj = idx1.shape[0]
+    cdef int i = 0
+    cdef int j = 0
+    cdef int k = 0
+
+    isort = np.argsort(idx0)
+    idx0 = idx0[isort]
+    val0 = val0[isort]
+
+    cdef np.ndarray[np.int_t, ndim= 1] idx = np.sort(np.unique(np.concatenate((idx0, idx1))))
+    cdef int n = idx.size
+    cdef np.ndarray[np.float_t, ndim = 1] vals = np.zeros(n, dtype=float)
+    while(k < n):
+
+        while(j < nj):
+
+            if(idx1[j] > idx[k]):
+                break
+            elif(idx1[j] == idx[k]):
+
+                if fill:
+                    vals[k] += val1[j]
+                else:
+                    vals[k] = val1[j]
+
+            j += 1
+
+        while(i < ni):
+
+            if(idx0[i] > idx[k]):
+                break
+            elif(idx0[i] == idx[k]):
+
+                if fill:
+                    vals[k] += val0[i]
+                else:
+                    vals[k] = val0[i]
+
+            i += 1
+
+        k += 1
+
+    return idx, vals

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from astropy.io import fits
 from .utils import unpack_seq
 from .geom import MapCoords, pix_tuple_to_idx, coord_to_idx
 from .hpxmap import HpxMap
@@ -368,9 +369,7 @@ class HpxMapND(HpxMap):
         idx_local = (self.hpx[idx[0]],) + tuple(idx[1:])
         self.data.T[idx_local] = vals
 
-    def make_cols(self, header, conv):
-
-        from astropy.io import fits
+    def _make_cols(self, header, conv):
 
         shape = self.data.shape
         cols = []

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -86,7 +86,6 @@ class HpxMapND(HpxMap):
                 if c.find(hpx.conv.colstring) == 0:
                     cnames.append(c)
             nbin = len(cnames)
-            data = np.ndarray(shape_data)
             if len(cnames) == 1:
                 map_out.data = hdu.data.field(cnames[0])
             else:

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -220,6 +220,6 @@ class HpxMap(MapBase):
             cols.append(fits.Column('PIX', 'J',
                                     array=np.arange(data.shape[-1])))
 
-        cols += self.make_cols(header, conv)
+        cols += self._make_cols(header, conv)
         hdu = fits.BinTableHDU.from_columns(cols, header=header, name=extname)
         return hdu

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -193,6 +193,8 @@ class HpxMap(MapBase):
         # FIXME: Should this be a method of HpxMapND?
         # FIXME: Should we assign extname in this method?
 
+        from .hpxsparse import HpxMapSparse
+
         conv = kwargs.get('conv', HpxConv.create('GADF'))
 
         data = self.data
@@ -201,7 +203,8 @@ class HpxMap(MapBase):
         extname_bands = kwargs.get('extname_bands', conv.bands_hdu)
         extname_bands = conv.bands_hdu
 
-        sparse = kwargs.get('sparse', False)
+        sparse = kwargs.get('sparse', True if isinstance(self, HpxMapSparse)
+                            else False)
         header = self.hpx.make_header()
 
         if self.geom.axes:
@@ -217,31 +220,6 @@ class HpxMap(MapBase):
             cols.append(fits.Column('PIX', 'J',
                                     array=np.arange(data.shape[-1])))
 
-        if header['INDXSCHM'] == 'SPARSE':
-
-            data = data.copy()
-            data[~np.isfinite(data)] = 0
-            nonzero = np.where(data > 0)
-            pix = self.geom.local_to_global(nonzero[::-1])[0]
-            if len(shape) == 1:
-                cols.append(fits.Column('PIX', 'J', array=pix))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=data[nonzero].astype(float)))
-
-            else:
-                channel = np.ravel_multi_index(nonzero[:-1], shape[:-1])
-                cols.append(fits.Column('PIX', 'J', array=pix))
-                cols.append(fits.Column('CHANNEL', 'I', array=channel))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=data[nonzero].astype(float)))
-
-        elif len(shape) == 1:
-            cols.append(fits.Column(conv.colname(indx=conv.firstcol),
-                                    'E', array=data.astype(float)))
-        else:
-            for i, idx in enumerate(np.ndindex(shape[:-1])):
-                cols.append(fits.Column(conv.colname(indx=i + conv.firstcol), 'E',
-                                        array=data[idx].astype(float)))
-
+        cols += self.make_cols(header, conv)
         hdu = fits.BinTableHDU.from_columns(cols, header=header, name=extname)
         return hdu

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -74,7 +74,11 @@ class HpxMap(MapBase):
         hpx = HpxGeom.create(nside=nside, binsz=binsz,
                              nest=nest, coordsys=coordsys, region=region,
                              conv=None, axes=axes, skydir=skydir, width=width)
-        if map_type in [None, 'hpx', 'HpxMapND']:
+        if cls.__name__ == 'HpxMapND':
+            return HpxMapND(hpx, dtype=dtype)
+        elif cls.__name__ == 'HpxMapSparse':
+            return HpxMapSparse(hpx, dtype=dtype)
+        elif map_type in [None, 'hpx', 'HpxMapND']:
             return HpxMapND(hpx, dtype=dtype)
         elif map_type in ['hpx-sparse', 'HpxMapSparse']:
             return HpxMapSparse(hpx, dtype=dtype)

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from .utils import swap_byte_order
 from .sparse import SparseArray
 from .geom import pix_tuple_to_idx
 from .hpxmap import HpxMap
@@ -57,10 +58,10 @@ class HpxMapSparse(HpxMap):
         colnames = hdu.columns.names
         cnames = []
         if hdu.header['INDXSCHM'] == 'SPARSE':
-            pix = hdu.data.field('PIX').byteswap().newbyteorder()
-            vals = hdu.data.field('VALUE').byteswap().newbyteorder()
+            pix = swap_byte_order(hdu.data.field('PIX'))
+            vals = swap_byte_order(hdu.data.field('VALUE'))
             if 'CHANNEL' in hdu.data.columns.names:
-                chan = hdu.data.field('CHANNEL')
+                chan = swap_byte_order(hdu.data.field('CHANNEL'))
                 chan = np.unravel_index(chan, shape)
                 idx = chan + (pix,)
             else:

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -59,10 +59,10 @@ class HpxMapSparse(HpxMap):
         colnames = hdu.columns.names
         cnames = []
         if hdu.header['INDXSCHM'] == 'SPARSE':
-            pix = swap_byte_order(hdu.data.field('PIX'))
-            vals = swap_byte_order(hdu.data.field('VALUE'))
+            pix = hdu.data.field('PIX')
+            vals = hdu.data.field('VALUE')
             if 'CHANNEL' in hdu.data.columns.names:
-                chan = swap_byte_order(hdu.data.field('CHANNEL'))
+                chan = hdu.data.field('CHANNEL')
                 chan = np.unravel_index(chan, shape)
                 idx = chan + (pix,)
             else:

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from astropy.io import fits
 from .utils import swap_byte_order
 from .sparse import SparseArray
 from .geom import pix_tuple_to_idx
@@ -115,9 +116,8 @@ class HpxMapSparse(HpxMap):
         idx = self.hpx.global_to_local(idx)
         self.data[idx[::-1]] = vals
 
-    def make_cols(self, header, conv):
+    def _make_cols(self, header, conv):
 
-        from astropy.io import fits
         shape = self.data.shape
         cols = []
         if header['INDXSCHM'] == 'SPARSE':

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -57,8 +57,8 @@ class HpxMapSparse(HpxMap):
         colnames = hdu.columns.names
         cnames = []
         if hdu.header['INDXSCHM'] == 'SPARSE':
-            pix = hdu.data.field('PIX')
-            vals = hdu.data.field('VALUE')
+            pix = hdu.data.field('PIX').byteswap().newbyteorder()
+            vals = hdu.data.field('VALUE').byteswap().newbyteorder()
             if 'CHANNEL' in hdu.data.columns.names:
                 chan = hdu.data.field('CHANNEL')
                 chan = np.unravel_index(chan, shape)

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -50,8 +50,20 @@ class SparseArray(object):
             self._idx = idx
             self._data = data
         else:
-            self._idx = np.zeros(0, dtype=int)
+            self._idx = np.zeros(0, dtype=np.int64)
             self._data = np.zeros(0, dtype=dtype)
+
+    def __getitem__(self, slices):
+
+        idx = slices_to_idxs(slices, self.shape, self.ndim)
+        idx = np.broadcast_arrays(*idx)
+        return self.get(idx)
+
+    def __setitem__(self, slices, vals):
+
+        idx = slices_to_idxs(slices, self.shape, self.ndim)
+        idx = np.broadcast_arrays(*idx)
+        return self.set(idx, vals)
 
     @property
     def size(self):
@@ -144,7 +156,7 @@ class SparseArray(object):
     def sum(self, axis=None, dtype=None, out=None, keepdims=False, **unused_kwargs):
 
         # FIXME: Figure out how to correctly support np.apply_over_axes
-        
+
         if axis is None:
             return np.sum(self._data)
         else:
@@ -155,15 +167,3 @@ class SparseArray(object):
                 del shape[axis]
             out = SparseArray(shape)
             return out
-
-    def __getitem__(self, slices):
-
-        idx = slices_to_idxs(slices, self.shape, self.ndim)
-        idx = np.broadcast_arrays(*idx)
-        return self.get(idx)
-
-    def __setitem__(self, slices, vals):
-
-        idx = slices_to_idxs(slices, self.shape, self.ndim)
-        idx = np.broadcast_arrays(*idx)
-        return self.set(idx, vals)

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -130,6 +130,7 @@ class SparseArray(object):
 
         vals = np.array(vals, ndmin=1)
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
+        idx_flat_in = np.asanyarray(idx_flat_in, dtype=np.int64)
         idx, data = merge_sparse_arrays(idx_flat_in, vals,
                                         self.idx, self.data,
                                         fill=fill)
@@ -145,6 +146,7 @@ class SparseArray(object):
         shape_out = idx_in[0].shape
         size_out = idx_in[0].size
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
+        idx_flat_in = np.asanyarray(idx_flat_in, dtype=np.int64)
 
         # Get broadcasted shape?
 

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -186,8 +186,7 @@ class SparseArray(object):
 
         vals = np.array(vals, ndmin=1)
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
-        idx_flat_in = np.asanyarray(idx_flat_in, dtype=np.int64)
-        vals = np.asanyarray(vals, dtype=np.float64)
+        vals = np.asanyarray(vals, dtype=self.data.dtype)
         idx, data = merge_sparse_arrays(idx_flat_in, vals,
                                         self.idx, self.data,
                                         fill=fill)
@@ -206,10 +205,6 @@ class SparseArray(object):
 
         shape_out = idx_in[0].shape
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
-        idx_flat_in = np.asanyarray(idx_flat_in, dtype=np.int64)
-
-        # Get broadcasted shape?
-
         idx, msk = find_in_array(idx_flat_in, self.idx)
         val_out = np.full(shape_out, self._fill_value)
         val_out.flat[np.flatnonzero(msk_in)[msk]] = self._data[idx[msk]]

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -12,6 +12,9 @@ def slices_to_idxs(slices, shape, ndim):
     elif not isinstance(slices, tuple):
         slices = tuple([slices])
 
+    if len(slices) < ndim:
+        slices = tuple(list(slices) + [slice(None)] * (ndim - len(slices)))
+
     #nslice = min(1, sum([not isinstance(s, slice) for s in slices]))
     #nslice += sum([isinstance(s, slice) for s in slices])
     nslice = len(slices)
@@ -184,10 +187,15 @@ class SparseArray(object):
         vals = np.array(vals, ndmin=1)
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
         idx_flat_in = np.asanyarray(idx_flat_in, dtype=np.int64)
+        vals = np.asanyarray(vals, dtype=np.float64)
         idx, data = merge_sparse_arrays(idx_flat_in, vals,
                                         self.idx, self.data,
                                         fill=fill)
 
+        # Remove elements equal to fill value
+        msk = data != self._fill_value
+        idx = idx[msk]
+        data = data[msk]
         self._idx = idx
         self._data = data
         #idx, msk = find_in_array(idx_flat_in, self.idx)

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -40,6 +40,54 @@ class SparseArray(object):
     structure for sparse n-dimensional arrays such that only non-zero
     data values are allocated in memory.  Supports numpy conventions
     for indexing and slicing logic.
+
+    Parameters
+    ----------
+    shape : tuple of ints
+        Shape of array.
+
+    idx : `~numpy.ndarray`, optional
+        Flattened index vector that initializes the array.  If none
+        then an empty array will be created.
+
+    data : `~numpy.ndarray`, optional
+        Flattened data vector that initializes the array.  If none
+        then an empty array will be created.
+
+    dtype : data-type, optional
+        Type of data vector.
+
+    fill_value : scalar, optional
+        Value assigned to array elements that are not allocated in
+        memory.
+
+    Examples
+    --------
+
+    A SparseArray is created in the same way as `~numpy.ndarray` by
+    passing the array shape to the constructor with an optional
+    argument for the array type:
+
+    >>> import numpy as np
+    >>> from gammapy.maps.sparse import SparseArray
+    >>> v = SparseArray((10,20), dtype=float)
+
+    Alternatively you can create a new SparseArray from an
+    `~numpy.ndarray` with `~SparseArray.from_array`:
+
+    >>> x = np.ndarray((10,20))
+    >>> v = SparseArray.from_array(x)
+
+    SparseArray follows numpy indexing and slicing conventions for
+    setting/getting array elements.  The primary difference with
+    respect to the behavior of `~numpy.ndarray` is that indexing
+    always returns a copy rather than a view.
+
+    >>> v[0,0] = 1.0
+    >>> print(v[0,0])
+    >>> v[:,0] = 1.0
+    >>> print(v[:,0])
+
     """
 
     def __init__(self, shape, idx=None, data=None, dtype=float, fill_value=0.0):
@@ -91,8 +139,8 @@ class SparseArray(object):
         return len(self._shape)
 
     @classmethod
-    def from_array(cls, data, min_value=0):
-        """Create from a numpy array.
+    def from_array(cls, data, min_value=0.0):
+        """Create a `~SparseArray` from a numpy array.
 
         Parameters
         ----------
@@ -101,6 +149,11 @@ class SparseArray(object):
 
         min_value : float
             Threshold for sparsifying the data vector.
+
+        Returns
+        -------
+        out : `~SparseArray`
+            Output sparse array.
         """
         shape = data.shape
         idx = np.where(data > min_value)
@@ -151,7 +204,7 @@ class SparseArray(object):
         # Get broadcasted shape?
 
         idx, msk = find_in_array(idx_flat_in, self.idx)
-        val_out = np.zeros(shape_out)
+        val_out = np.full(shape_out, self._fill_value)
         val_out.flat[np.flatnonzero(msk_in)[msk]] = self._data[idx[msk]]
         return np.squeeze(val_out)
 

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -197,7 +197,6 @@ class SparseArray(object):
         """Get array values at indices ``idx_in``."""
 
         shape_out = idx_in[0].shape
-        size_out = idx_in[0].size
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
         idx_flat_in = np.asanyarray(idx_flat_in, dtype=np.int64)
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -72,15 +72,19 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     m.write(filename)
 
     m2 = HpxMapND.read(filename)
+    m3 = HpxMapSparse.read(filename)
     if sparse:
         msk = np.isfinite(m2.data[...])
     else:
         msk = np.ones_like(m2.data[...], dtype=bool)
 
     assert_allclose(m.data[...][msk], m2.data[...][msk])
+    assert_allclose(m.data[...][msk], m3.data[...][msk])
     m.write(filename, sparse=True)
     m2 = HpxMapND.read(filename)
+    m3 = HpxMapND.read(filename)
     assert_allclose(m.data[...][msk], m2.data[...][msk])
+    assert_allclose(m.data[...][msk], m3.data[...][msk])
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),

--- a/gammapy/maps/tests/test_hpxsparse.py
+++ b/gammapy/maps/tests/test_hpxsparse.py
@@ -24,7 +24,7 @@ hpx_test_geoms = [
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
-def test_hpxcube_init(nside, nested, coordsys, region, axes):
+def test_hpxsparse_init(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
     m = HpxMapSparse(geom)
     # TODO: Test initialization w/ data array

--- a/gammapy/maps/tests/test_sparse.py
+++ b/gammapy/maps/tests/test_sparse.py
@@ -32,6 +32,8 @@ def test_sparse_getitem():
     data = np.random.poisson(np.ones(shape)).astype(float)
     v = SparseArray.from_array(data)
     assert_allclose(v[...], data[...])
+    assert_allclose(v[:], data[:])
+    assert_allclose(v[:, :], data[:, :])
     assert_allclose(v[:, :, :], data[:, :, :])
     assert_allclose(v[1, 3, 10], data[1, 3, 10])
     assert_allclose(v[:, 3, 10], data[:, 3, 10])

--- a/gammapy/maps/tests/test_sparse.py
+++ b/gammapy/maps/tests/test_sparse.py
@@ -1,0 +1,53 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from ..sparse import SparseArray
+
+test_params = [
+    (8,),
+    (8, 16),
+    (8, 16, 32),
+]
+
+
+@pytest.mark.parametrize(('shape'), test_params)
+def test_sparse_init(shape):
+
+    v = SparseArray(shape)
+    assert(v.shape == shape)
+    assert(v.size == 0)
+
+    data = np.ones(shape)
+    v = SparseArray.from_array(data)
+    assert_allclose(v[...], data)
+
+
+def test_sparse_getitem():
+
+    shape = (8, 16, 32)
+
+    data = np.random.poisson(np.ones(shape)).astype(float)
+    v = SparseArray.from_array(data)
+    assert_allclose(v[...], data[...])
+    assert_allclose(v[:, :, :], data[:, :, :])
+    assert_allclose(v[1, 3, 10], data[1, 3, 10])
+    assert_allclose(v[:, 3, 10], data[:, 3, 10])
+    assert_allclose(v[1, :, 10], data[1, :, 10])
+    assert_allclose(v[1, 3, :], data[1, 3, :])
+    assert_allclose(v[1, np.arange(4), :], data[1, np.arange(4), :])
+    assert_allclose(v[np.arange(4), np.arange(4), :],
+                    data[np.arange(4), np.arange(4), :])
+    assert_allclose(v[:, np.arange(4), np.arange(4)],
+                    data[:, np.arange(4), np.arange(4)])
+
+
+@pytest.mark.parametrize(('shape'), test_params)
+def test_sparse_setitem(shape):
+
+    data = np.random.poisson(np.ones(shape)).astype(float)
+    v = SparseArray(shape)
+    idx = np.where(data > 0)
+    v[idx] = data[idx]
+    assert_allclose(v[...], data)

--- a/gammapy/maps/tests/test_sparse.py
+++ b/gammapy/maps/tests/test_sparse.py
@@ -76,12 +76,18 @@ def test_sparse_setitem(shape):
     assert_allclose(v[...], data)
 
 
-def test_merge_sparse_arrays():
+@pytest.mark.parametrize(('dtype_idx','dtype_val'),
+                         [(np.int64, np.float64),
+                          (np.int32, np.float64),
+                          (np.int32, np.float32),
+                          (np.int32, np.float64),
+                         ])
+def test_merge_sparse_arrays(dtype_idx, dtype_val):
 
-    idx0 = np.array([0, 0, 1, 4], dtype=np.int64)
-    val0 = np.array([1.0, 2.0, 3.0, 7.0], dtype=np.float64)
-    idx1 = np.array([0, 1, 2], dtype=np.int64)
-    val1 = np.array([1.0, 1.0, 1.0], dtype=np.float64)
+    idx0 = np.array([0, 0, 1, 4], dtype=dtype_idx)
+    val0 = np.array([1.0, 2.0, 3.0, 7.0], dtype=dtype_val)
+    idx1 = np.array([0, 1, 2], dtype=dtype_idx)
+    val1 = np.array([1.0, 1.0, 1.0], dtype=dtype_val)
     idx, val = merge_sparse_arrays(idx0, val0, idx1, val1)
     assert_allclose(idx, np.unique(np.concatenate((idx0, idx1))))
     assert_allclose(val, np.array([2.0, 3.0, 1.0, 7.0]))

--- a/gammapy/maps/tests/test_sparse.py
+++ b/gammapy/maps/tests/test_sparse.py
@@ -78,10 +78,10 @@ def test_sparse_setitem(shape):
 
 def test_merge_sparse_arrays():
 
-    idx0 = np.array([0, 0, 1, 4])
-    val0 = np.array([1.0, 2.0, 3.0, 7.0])
-    idx1 = np.array([0, 1, 2])
-    val1 = np.array([1.0, 1.0, 1.0])
+    idx0 = np.array([0, 0, 1, 4], dtype=np.int64)
+    val0 = np.array([1.0, 2.0, 3.0, 7.0], dtype=np.float64)
+    idx1 = np.array([0, 1, 2], dtype=np.int64)
+    val1 = np.array([1.0, 1.0, 1.0], dtype=np.float64)
     idx, val = merge_sparse_arrays(idx0, val0, idx1, val1)
     assert_allclose(idx, np.unique(np.concatenate((idx0, idx1))))
     assert_allclose(val, np.array([2.0, 3.0, 1.0, 7.0]))

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -3,6 +3,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy.io import fits
 
 
+def swap_byte_order(arr_in):
+    """Swap the byte order of a numpy array to the native one.
+
+    Parameters
+    ----------
+    arr_in : `~numpy.ndarray`
+        Input array.
+
+    Returns
+    -------
+    arr_out : `~numpy.ndarray`
+        Array with native byte order.
+    """
+
+    if arr_in.dtype.byteorder not in ('=', '|'):
+        return arr_in.byteswap().newbyteorder()
+
+    return arr_in
+
+
 def interp_to_order(interp):
     """Convert interpolation string to order."""
 


### PR DESCRIPTION
This PR provides a proof of concept for implementing sparse maps with a custom sparse array class.  `SparseArray` is a sparse data structure for ND arrays that partially mimics the interface of `numpy.ndarray`.  It uses cython functions in `gammapy.maps._sparse` to efficiently lookup and update array values.  Note that the current implementation is not efficient for certain use cases for instance setting an element will always trigger a reallocation of the full array in memory.  However I think those use cases are probably not so important for the usage patterns we'll typically have for gamma-ray analysis where maps are normally allocated in a single pass at the start of the analysis.  To demonstrate how this could be used for the sparse map classes I've updated `HpxMapSparse` to use  `SparseArray` in lieu of `scipy.sparse` and added some tests for the get/set methods.

Currently `SparseArray` only supports a small subset of the functionality of `numpy.ndarray` and does not support the numpy `ufunc` interface.  I also considered the option of making `SparseArray` a sub-class of `numpy.ndarray` which would probably be the cleaner approach for making something that can be used interchangeably with `numpy.ndarray`.  However it looked like this would require a much deeper understanding of the numpy internals and didn't seem to be critical for getting a working prototype.

To the extent that we could eventually fully reproduce the  `numpy.ndarray` interface we could consider doing away with the current class hierarchy with separate classes for sparse and non-sparse maps.  In this case we would just have a switch statement in the map constructor that would allocate the data vector as a `numpy.ndarray` or `SparseArray`.  From the standpoint of long-term code maintenance this would be my preferred option but while we're still prototyping different solutions we should probably keep the current design. 