### PR TITLE
Change convolution method in FermiLATBasicImageEstimator.background

### DIFF
--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -471,7 +471,7 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
         # convolve with PSF kernel
         psf_mean = psf.table_psf_in_energy_band(energy_band, spectrum=self.spectral_model)
         kernel = psf_mean.kernel(npred_total)
-        npred_total = npred_total.convolve(kernel)
+        npred_total = npred_total.convolve(kernel, use_fft=True)
         return npred_total
 
     def exposure(self, dataset):


### PR DESCRIPTION
I ran into a problem with the ``FermiLATBasicImageEstimator`` and a custom made ``FermiLATDataset``:

The [convolution of the background model with the PSF kernel](https://github.com/gammapy/gammapy/blob/master/gammapy/image/basic.py#L478) raised a ``MemoryError``, even on the MPIK cluster. I guess this is a problem in ``scipy.ndimage.convolve``, see e.g. [this post](https://www.reddit.com/r/Python/comments/hfavk/memory_problems_when_i_shouldnt_have_any/) (interestingly the example presented there runs on my machine, but that's not the point)

I guess @adonath is/was aware of this problem and added the [use_fft](https://github.com/gammapy/gammapy/blob/master/gammapy/image/core.py#L1158) option, to use ``scipy.signal.fftconvolve``. It's however not possible to use this from the ``FermiLATBasicImageEstimator``.

Is it acceptable to make ``use_fft=True`` the default
* in general
* in the ``FermiLATBasicImageEstimator`` as suggested in this PR
?