### PR TITLE
Integrate tutorial notebooks in Sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ distribute-*.tar.gz
 htmlcov
 MANIFEST
 
+# notebooks
 *.ipynb
 *.ipynb_checkpoints
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,13 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject nbsphinx'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa regions reproject'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils regions reproject'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject'
-        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy regions reproject'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject'
-        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy libgfortran runipy regions reproject'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject nbsphinx ipython'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa regions reproject nbsphinx ipython'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils regions reproject nbsphinx ipython'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject nbsphinx ipython'
+        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy regions reproject nbsphinx ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject nbsphinx ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy libgfortran runipy regions reproject nbsphinx ipython'
 
         - PIP_DEPENDENCIES='uncertainties'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject nbsphinx'
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa regions reproject'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils regions reproject'
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject'

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build dist docs/_build docs/api htmlcov MANIFEST gammapy.egg-info .coverage .cache
+	rm -rf build dist docs/_build docs/api docs/notebooks htmlcov MANIFEST gammapy.egg-info .coverage .cache
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find gammapy -name '*.c' -exec rm {} \;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@
 import datetime
 import os
 import sys
+from distutils.dir_util import copy_tree
 
 try:
     import astropy_helpers
@@ -81,19 +82,13 @@ intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/'
 exclude_patterns.append('_templates')
 exclude_patterns.append('**.ipynb_checkpoints')
 
+
 #
 # -- nbsphinx settings
-#exclude_patterns.append('notebooks')
 extensions.append('nbsphinx')
 extensions.append('IPython.sphinxext.ipython_console_highlighting')
 extensions.append('sphinx.ext.mathjax')
 nbsphinx_execute = 'never'
-
-# patch to solve error in :code directive
-#from docutils.parsers.rst import directives
-#from docutils.parsers.rst.directives.body import CodeBlock
-#directives.register_directive('code', CodeBlock)
-#
 # --
 
 # This is added to the end of RST files - a good place to put substitutions to
@@ -194,6 +189,12 @@ if on_rtd:
 from gammapy.utils.docs import gammapy_sphinx_ext_activate
 gammapy_sphinx_ext_activate()
 
+# copy notebooks
+if os.environ['GAMMAPY_EXTRA']:
+    gammapy_extra_notebooks_folder = os.environ['GAMMAPY_EXTRA'] + '/notebooks'
+    if os.path.isdir(gammapy_extra_notebooks_folder):
+        copy_tree(gammapy_extra_notebooks_folder, 'notebooks')
+
 html_style = 'gammapy.css'
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -226,8 +227,6 @@ if eval(setup_cfg.get('edit_on_github')):
     edit_on_github_doc_root = "docs"
 
 
-
-
 github_issues_url = 'https://github.com/gammapy/gammapy/issues/'
 
 # -- Other options --
@@ -235,6 +234,7 @@ github_issues_url = 'https://github.com/gammapy/gammapy/issues/'
 # http://sphinx-automodapi.readthedocs.io/en/latest/automodapi.html
 # show inherited members for classes
 automodsumm_inherited_members = True
+
 
 # In `about.rst` and `references.rst` we are giving lists of citations
 # (e.g. papers using Gammapy) that partly aren't referenced from anywhere

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,22 @@ intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')
+exclude_patterns.append('**.ipynb_checkpoints')
+
+#
+# -- nbsphinx settings
+#exclude_patterns.append('notebooks')
+extensions.append('nbsphinx')
+extensions.append('IPython.sphinxext.ipython_console_highlighting')
+extensions.append('sphinx.ext.mathjax')
+nbsphinx_execute = 'never'
+
+# patch to solve error in :code directive
+#from docutils.parsers.rst import directives
+#from docutils.parsers.rst.directives.body import CodeBlock
+#directives.register_directive('code', CodeBlock)
+#
+# --
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
@@ -208,6 +224,9 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
+
+
+
 
 github_issues_url = 'https://github.com/gammapy/gammapy/issues/'
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,3 +19,4 @@ dependencies:
   - sphinx
   - pyyaml
   - nbsphinx
+  - ipython

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - aplpy
   - sphinx
   - pyyaml
+  - nbsphinx

--- a/docs/image/sky_image.rst
+++ b/docs/image/sky_image.rst
@@ -18,7 +18,7 @@ Getting started
 
 Most easily a `~gammapy.image.SkyImage` can be created from a fits file:
 
-.. code::
+.. code:: python
 
     from gammapy.image import SkyImage
 
@@ -29,7 +29,7 @@ Alternatively an empty image can be created from the scratch, by specifying the
 WCS information (see `~gammapy.image.SkyImage.empty` for a detailed description of
 the parameters):
 
-.. code::
+.. code:: python
 
     image_empty = SkyImage.empty('empty')
 
@@ -37,13 +37,13 @@ Where the optional string ``'empty'`` specifies the name of the image.
 
 Some basic info on the image is shown when calling:
 
-.. code::
+.. code:: python
 
     image.info()
 
 To lookup the value of the data at a certain sky position one can do:
 
-.. code::
+.. code:: python
 
     from astropy.coordinates import SkyCoord
     position = SkyCoord(0, 0, frame='galactic', unit='deg')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,15 @@ General documentation
   development/index
   changelog
 
+.. _gammapy_notebooks:
+
+IPython notebooks
+---------------------
+.. toctree::
+  :maxdepth: 1
+
+  notebooks
+
 .. _gammapy_toolbox:
 
 The Gammapy toolbox
@@ -53,7 +62,7 @@ The Gammapy toolbox
 
 .. toctree::
   :maxdepth: 1
- 
+
   scripts/index
   astro/index
   background/index

--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -19,7 +19,7 @@ of non-spatial axes (e.g. energy).  By default a HEALPix geometry will
 encompass the full sky.  The following example shows how to create
 an all-sky 2D HEALPix image:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import HpxGeom
    # Create a HEALPix geometry of NSIDE=16
@@ -33,7 +33,7 @@ Partial-sky maps can be created by passing a ``region`` argument to
 the map geometry constructor or by setting the ``width`` argument to
 the `~gammapy.maps.HpxMap.create` factory method:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import HpxGeom, HpxMap, HpxMapND
    from astropy.coordinates import SkyCoord
@@ -42,13 +42,13 @@ the `~gammapy.maps.HpxMap.create` factory method:
    geom = HpxGeom(16, region='DISK(0.0,5.0,10.0)', coordsys='GAL')
    m = HpxMapND(geom)
 
-   # Equivalent factory method call  
+   # Equivalent factory method call
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
    m = HpxMap.create(nside=16, skydir=position, width=20.0)
 
 
 
-   
+
 
 Sparse Maps
 -----------

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -13,7 +13,7 @@ Data Structures for Images and Cubes (`gammapy.maps`)
     The code in `gammapy.maps` is currently in an
     experimental/development state. Method and class names may change
     in the future.
-                   
+
 Introduction
 ============
 
@@ -66,7 +66,7 @@ facilitate creating an empty map object from scratch.  The
 (WCS or HPX) and whether the map internally uses a sparse
 representation of the data.
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase
    from astropy.coordinates import SkyCoord
@@ -77,18 +77,18 @@ representation of the data.
 
    # Create a HPX Map
    m_hpx = MapBase.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0)
-   
+
 Higher dimensional map objects (cubes and hypercubes) can be
 constructed by passing a list of `~MapAxis` objects for non-spatial
 dimensions with the ``axes`` parameter:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase, MapAxis
    from astropy.coordinates import SkyCoord
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
-   
+
    # Create a WCS Map
    m_wcs = MapBase.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0,
                           axes=[energy_axis])
@@ -104,7 +104,7 @@ non-spatial dimensions of the map.  The following example demonstrates
 creating an energy cube with a pixel size proportional to the
 Fermi-LAT PSF:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase, MapAxis
    from astropy.coordinates import SkyCoord
@@ -149,7 +149,7 @@ two elements in the coordinate tuple correspond to longitude and
 latitude followed by one element for each non-spatial dimension.  Map
 coordinates can be expressed in one of three coordinate systems:
 
-* ``idx`` : Pixel indices.  These are explicit (integer) pixel indices into the map.  
+* ``idx`` : Pixel indices.  These are explicit (integer) pixel indices into the map.
 * ``pix`` : Coordinates in pixel space.  Pixel coordinates are continuous defined
   on the interval [0,N-1] where N is the number of pixels along a
   given map dimension with pixel centers at integer values.  For
@@ -159,18 +159,18 @@ coordinates can be expressed in one of three coordinate systems:
 * ``coord`` : Sky (spherical) coordinates.  The tuple should contain longitude and
   latitude in degrees followed by one coordinate array for each
   non-spatial dimension.
-  
+
 The coordinate system accepted by a given accessor method can be
 inferred from the suffix of the method name
 (e.g. `~MapBase.get_by_idx`).  The following demonstrates how one can
 access the same pixels of a WCS map using each of the three coordinate
 systems:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
-   
+
    vals = m.get_by_idx( ([49,50],[49,50]) )
    vals = m.get_by_pix( ([49.0,50.0],[49.0,50.0]) )
    vals = m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]) )
@@ -183,17 +183,17 @@ operation along a slice of the map at a fixed value along that
 dimension.  Multi-dimensional arguments can be use to broadcast a
 given operation across a grid of coordinate values.
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
    coords = np.linspace(-5.0,5.0,11)
-   
+
    # Equivalent calls for accessing value at pixel (49,49)
    vals = m.get_by_idx( (49,49) )
    vals = m.get_by_idx( ([49],[49]) )
    vals = m.get_by_idx( (np.array([49]),np.array([49])) )
-   
+
    # Retrieve map values along latitude at fixed longitude=0.0
    vals = m.get_by_coords( (0.0, coords) )
    # Retrieve map values on a 2D grid of latitude/longitude points
@@ -204,14 +204,14 @@ given operation across a grid of coordinate values.
 The ``set`` and ``fill`` methods can both be used to set pixel values.
 The following demonstrates how one can set pixel values:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
-   
+
    m.set_by_coords( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
    m.fill_by_coords( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
-   
+
 Interpolation
 -------------
 
@@ -231,7 +231,7 @@ the same geometry in every image plane).  ``linear`` and higher order
 interpolation by pixel coordinates is only supported for WCS-based
 maps.
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
@@ -250,7 +250,7 @@ HPX map types.  If the projection geometry lacks non-spatial
 dimensions then the non-spatial dimensions of the original map will be copied
 over to the projected map.
 
-.. code::
+.. code:: python
 
    from gammapy.maps import WcsMapND, HpxGeom
    m = WcsMapND.read('gll_iem_v06.fits')
@@ -259,7 +259,7 @@ over to the projected map.
    m_proj = m.project(geom)
    m_proj.write('gll_iem_v06_hpx_nside8.fits')
 
-   
+
 Slicing Methods
 ---------------
 
@@ -270,11 +270,11 @@ Iterating over a map can be performed with the
 `~MapBase.iter_by_coords` and `~MapBase.iter_by_pix` methods.  These
 return an iterator that traverses the map returning (value,
 coordinate) pairs with map and pixel coordinates, respectively.  The
-optional ``buffersize`` argument can be used to split the iteration 
+optional ``buffersize`` argument can be used to split the iteration
 into chunks of a given size.  The following example illustrates how
 one can use this method to fill a map with a 2D Gaussian:
 
-.. code::
+.. code:: python
 
    from astropy.coordinates import SkyCoord
    from gammapy.maps import MapBase
@@ -288,7 +288,7 @@ one can use this method to fill a map with a 2D Gaussian:
 For maps with non-spatial dimensions the `~MapBase.iter_by_image`
 method can be used to loop over image slices:
 
-.. code::
+.. code:: python
 
    from astropy.coordinates import SkyCoord
    from astropy.convolution import Gaussian2DKernel, convolve
@@ -304,7 +304,7 @@ FITS I/O
 Maps can be written to and read from a FITS file with the
 `~MapBase.write` and ``read`` methods:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase, WcsMapND
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
@@ -316,7 +316,7 @@ Maps can be serialized to a sparse data format by calling
 pixels in the map to a data table appropriate to the pixelization
 scheme.
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase, WcsMapND
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
@@ -326,7 +326,7 @@ scheme.
 Sparse maps have the same ``read`` and ``write`` methods with the
 exception that they will be written to a sparse format by default:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase, HpxMapSparse
    m = MapBase.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
@@ -343,7 +343,7 @@ backward compatibility with software using other formats, the ``conv``
 keyword option is provided to write a file using a format other than
 the GADF format:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import MapBase, MapAxis
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
@@ -351,7 +351,7 @@ the GADF format:
                       axes=[energy_axis])
    # Write a counts cube in a format compatible with the Fermi Science Tools
    m.write('ccube.fits', conv='fgst-ccube')
-   
+
 Visualization
 -------------
 
@@ -359,7 +359,7 @@ All map objects provide a `~MapBase.plot` method for generating a
 visualization of a map.  This method returns figure, axes, and image
 objects that can be used to further tweak/customize the image.
 
-.. code::
+.. code:: python
 
    import matplotlib.pyplot as plt
    from gammapy.maps import MapBase
@@ -377,7 +377,7 @@ Creating a Counts Cube from an FT1 File
 
 This example shows how to fill a counts cube from an FT1 file:
 
-.. code::
+.. code:: python
 
    from astropy.io import fits
    from gammapy.maps import WcsGeom, WcsMapND, MapAxis
@@ -390,14 +390,14 @@ This example shows how to fill a counts cube from an FT1 file:
                      h['EVENTS'].data.field('DEC'),
                      h['EVENTS'].data.field('ENERGY')))
    m.write('ccube.fits', conv='fgst-ccube')
-   
+
 Generating a Cutout of a Model Cube
 -----------------------------------
 
 This example shows how to extract a cut-out of LAT galactic
 diffuse model cube using the `~MapBase.reproject` method:
 
-.. code::
+.. code:: python
 
    from gammapy.maps import WcsGeom, WcsMapND
    m = WcsMapND.read('gll_iem_v06.fits')
@@ -405,7 +405,7 @@ diffuse model cube using the `~MapBase.reproject` method:
    m_proj = m.reproject(geom)
    m_proj.write('cutout.fits', conv='fgst-template')
 
-   
+
 Using `gammapy.maps`
 ====================
 

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -5,14 +5,14 @@ Gammapy tutorial notebooks
 What is this?
 -------------
 
--  This is an overview of tutorial `Jupyter <http://jupyter.org/>`__
-   notebooks for `Gammapy <http://gammapy.org>`__, a Python package for
+-  This is an overview of tutorial `Jupyter <http://jupyter.org/>`
+   notebooks for `Gammapy <http://gammapy.org>`, a Python package for
    gamma-ray astronomy.
 -  The notebooks complement the Gammapy Sphinx-based documentation at
    http://docs.gammapy.org
 -  You can read a static HTML version of these notebooks (i.e. code
    can't be executed) online
-   `here <http://nbviewer.ipython.org/github/gammapy/gammapy-extra/tree/master/notebooks/>`__.
+   `here <http://nbviewer.ipython.org/github/gammapy/gammapy-extra/tree/master/notebooks/>`.
 -  The notebooks and example datasets are available at
    https://github.com/gammapy/gammapy-extra
 
@@ -23,7 +23,7 @@ If you want to execute the notebooks locally, to play around with the
 examples, or to try to do one of the exercises, you have to first
 install Gammapy and get the ``gammapy-extra`` repository. This is
 described in `Gammapy tutorial
-setup <notebooks/tutorial_setup.ipynb>`__.
+setup <notebooks/tutorial_setup.html>`__.
 
 The basics
 ----------
@@ -57,62 +57,62 @@ If you're new to Astro (haven't used ``Table``, ``SkyCoord`` and
 ``Time`` much), start here:
 
 -  `Astropy introduction for Gammapy
-   users <notebooks/astropy_introduction.ipynb>`__
+   users <notebooks/astropy_introduction.html>`__
 -  `Astropy Hands On (1st ASTERICS-OBELICS International
    School) <https://github.com/Asterics2020-Obelics/School2017/blob/master/astropy/astropy_hands_on.ipynb>`__
 
 For a quick introduction to Gammapy, go here:
 
--  `First steps with Gammapy <notebooks/first_steps.ipynb>`__
+-  `First steps with Gammapy <notebooks/first_steps.html>`__
 
 Interested to do a first analysis of simulated CTA data?
 
 -  `CTA first data challenge (1DC) with
-   Gammapy <notebooks/cta_1dc_introduction.ipynb>`__
+   Gammapy <notebooks/cta_1dc_introduction.html>`__
 -  `CTA data analysis with
-   Gammapy <notebooks/cta_data_analysis.ipynb>`__
+   Gammapy <notebooks/cta_data_analysis.html>`__
 
 To learn how to work with gamma-ray data with Gammapy:
 
--  `IACT DL3 data with Gammapy <notebooks/data_iact.ipynb>`__ (H.E.S.S.
+-  `IACT DL3 data with Gammapy <notebooks/data_iact.html>`__ (H.E.S.S.
    data example)
--  `Fermi-LAT data with Gammapy <notebooks/data_fermi_lat.ipynb>`__
+-  `Fermi-LAT data with Gammapy <notebooks/data_fermi_lat.html>`__
    (Fermi-LAT data example)
 
 2-dimensional sky image analysis:
 
 -  `Image analysis with Gammapy (run
-   pipeline) <notebooks/image_pipe.ipynb>`__ (H.E.S.S. data example)
+   pipeline) <notebooks/image_pipe.html>`__ (H.E.S.S. data example)
 -  `Image analysis with Gammapy (individual
-   steps) <notebooks/image_analysis.ipynb>`__ (H.E.S.S. data example)
--  `Source detection with Gammapy <notebooks/detect_ts.ipynb>`__
+   steps) <notebooks/image_analysis.html>`__ (H.E.S.S. data example)
+-  `Source detection with Gammapy <notebooks/detect_ts.html>`__
    (Fermi-LAT data example)
 
 1-dimensional spectral analysis:
 
--  `Spectral models in Gammapy <notebooks/spectrum_models.ipynb>`__
+-  `Spectral models in Gammapy <notebooks/spectrum_models.html>`__
 -  `Spectral analysis with Gammapy (run
-   pipeline) <notebooks/spectrum_pipe.ipynb>`__ (H.E.S.S. data example)
+   pipeline) <notebooks/spectrum_pipe.html>`__ (H.E.S.S. data example)
 -  `Spectral analysis with Gammapy (individual
-   steps) <notebooks/spectrum_analysis.ipynb>`__ (H.E.S.S. data example)
--  `Spectrum simulation and fitting <notebooks/cta_simulation.ipynb>`__
+   steps) <notebooks/spectrum_analysis.html>`__ (H.E.S.S. data example)
+-  `Spectrum simulation and fitting <notebooks/cta_simulation.html>`__
    (CTA data example with AGN / EBL)
 -  `Flux point fitting with
-   Gammapy <notebooks/sed_fitting_gammacat_fermi.ipynb>`__
--  `Light curve estimation with Gammapy <notebooks/light_curve.ipynb>`__
+   Gammapy <notebooks/sed_fitting_gammacat_fermi.html>`__
+-  `Light curve estimation with Gammapy <notebooks/light_curve.html>`__
    (H.E.S.S. fake data example TBC)
 
 3-dimensional cube analysis:
 
 -  `Cube analysis with Gammapy (part
-   1) <notebooks/cube_analysis_part1.ipynb>`__ - compute cubes and mean
+   1) <notebooks/cube_analysis_part1.html>`__ - compute cubes and mean
    PSF / EDISP
 -  `Cube analysis with Gammapy (part
-   2) <notebooks/cube_analysis_part2.ipynb>`__ - likelihood fit
+   2) <notebooks/cube_analysis_part2.html>`__ - likelihood fit
 
 Time-related analysis:
 
--  `Time analysis with Gammapy <notebooks/time_analysis.ipynb>`__ (not
+-  `Time analysis with Gammapy <notebooks/time_analysis.html>`__ (not
    written yet)
 
 Extra topics
@@ -127,13 +127,13 @@ something that could be interesting for your work (or contribute to
 Gammapy if something is missing!).
 
 -  `Template background model production with
-   Gammapy <notebooks/background_model.ipynb>`__
+   Gammapy <notebooks/background_model.html>`__
 -  `Continuous wavelet transform on gamma-ray
-   images <notebooks/cwt.ipynb>`__
+   images <notebooks/cwt.html>`__
 -  `Interpolation using the NDDataArray
-   class <notebooks/nddata_demo.ipynb>`__
+   class <notebooks/nddata_demo.html>`__
 -  `Rapid introduction on using numpy, scipy,
-   matplotlib <notebooks/using_numpy.ipynb>`__
+   matplotlib <notebooks/using_numpy.html>`__
 
 Work in progress
 ~~~~~~~~~~~~~~~~
@@ -146,12 +146,20 @@ Please help make these better, or write new, better ones!
 -  TODO: simulate Fermi and CTA sky with Gammapy
 
 -  `Astrophysical source population modeling with
-   Gammapy <notebooks/source_population_model.ipynb>`__
--  `notebooks/source\_catalogs.ipynb <notebooks/source_catalogs.ipynb>`__
+   Gammapy <notebooks/source_population_model.html>`__
+-  `Source catalogs <notebooks/source_catalogs.html>`__
    : Working with gamma-ray source catalogs
--  `notebooks/diffuse\_model\_computation.ipynb <notebooks/diffuse_model_computation.ipynb>`__
+-  `Diffuse model computation <notebooks/diffuse_model_computation.html>`__
    : Diffuse model computation
--  `notebooks/fermi\_vela\_model.ipynb <notebooks/fermi_vela_model.ipynb>`__
+-  `Fermi Vela model <notebooks/fermi_vela_model.html>`__
    : Fermi Vela model
 -  `Simulating and analysing sources and diffuse
-   emission <notebooks/source_diffuse_estimation.ipynb>`__
+   emission <notebooks/source_diffuse_estimation.html>`__
+
+List of notebooks
+~~~~~~~~~~~~~~~~~~
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   notebooks/*

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -1,0 +1,157 @@
+
+Gammapy tutorial notebooks
+==========================
+
+What is this?
+-------------
+
+-  This is an overview of tutorial `Jupyter <http://jupyter.org/>`__
+   notebooks for `Gammapy <http://gammapy.org>`__, a Python package for
+   gamma-ray astronomy.
+-  The notebooks complement the Gammapy Sphinx-based documentation at
+   http://docs.gammapy.org
+-  You can read a static HTML version of these notebooks (i.e. code
+   can't be executed) online
+   `here <http://nbviewer.ipython.org/github/gammapy/gammapy-extra/tree/master/notebooks/>`__.
+-  The notebooks and example datasets are available at
+   https://github.com/gammapy/gammapy-extra
+
+Set up
+------
+
+If you want to execute the notebooks locally, to play around with the
+examples, or to try to do one of the exercises, you have to first
+install Gammapy and get the ``gammapy-extra`` repository. This is
+described in `Gammapy tutorial
+setup <notebooks/tutorial_setup.ipynb>`__.
+
+The basics
+----------
+
+Gammapy is a Python package built on Numpy and Astropy, and the
+tutorials are Jupyter notebooks. If you're already familar with those,
+you can skip to the next section and start learning about Gammapy.
+
+If you're new to Python or scientific Python, we can recommmend the
+following resources:
+
+-  `A Whirlwind tour of
+   Python <http://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/Index.ipynb>`__
+   (learn Python)
+-  `Python data science
+   handbook <http://nbviewer.jupyter.org/github/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/Index.ipynb>`__
+   (learn IPython, Numpy, matplotlib)
+-  `Scipy lectures <http://www.scipy-lectures.org/>`__ (another intro to
+   scientific Python)
+
+If you're new to Astropy, here's some good resources:
+
+-  http://www.astropy.org/astropy-tutorials
+-  http://astropy.readthedocs.io
+-  https://python4astronomers.github.io/
+
+Notebooks
+---------
+
+If you're new to Astro (haven't used ``Table``, ``SkyCoord`` and
+``Time`` much), start here:
+
+-  `Astropy introduction for Gammapy
+   users <notebooks/astropy_introduction.ipynb>`__
+-  `Astropy Hands On (1st ASTERICS-OBELICS International
+   School) <https://github.com/Asterics2020-Obelics/School2017/blob/master/astropy/astropy_hands_on.ipynb>`__
+
+For a quick introduction to Gammapy, go here:
+
+-  `First steps with Gammapy <notebooks/first_steps.ipynb>`__
+
+Interested to do a first analysis of simulated CTA data?
+
+-  `CTA first data challenge (1DC) with
+   Gammapy <notebooks/cta_1dc_introduction.ipynb>`__
+-  `CTA data analysis with
+   Gammapy <notebooks/cta_data_analysis.ipynb>`__
+
+To learn how to work with gamma-ray data with Gammapy:
+
+-  `IACT DL3 data with Gammapy <notebooks/data_iact.ipynb>`__ (H.E.S.S.
+   data example)
+-  `Fermi-LAT data with Gammapy <notebooks/data_fermi_lat.ipynb>`__
+   (Fermi-LAT data example)
+
+2-dimensional sky image analysis:
+
+-  `Image analysis with Gammapy (run
+   pipeline) <notebooks/image_pipe.ipynb>`__ (H.E.S.S. data example)
+-  `Image analysis with Gammapy (individual
+   steps) <notebooks/image_analysis.ipynb>`__ (H.E.S.S. data example)
+-  `Source detection with Gammapy <notebooks/detect_ts.ipynb>`__
+   (Fermi-LAT data example)
+
+1-dimensional spectral analysis:
+
+-  `Spectral models in Gammapy <notebooks/spectrum_models.ipynb>`__
+-  `Spectral analysis with Gammapy (run
+   pipeline) <notebooks/spectrum_pipe.ipynb>`__ (H.E.S.S. data example)
+-  `Spectral analysis with Gammapy (individual
+   steps) <notebooks/spectrum_analysis.ipynb>`__ (H.E.S.S. data example)
+-  `Spectrum simulation and fitting <notebooks/cta_simulation.ipynb>`__
+   (CTA data example with AGN / EBL)
+-  `Flux point fitting with
+   Gammapy <notebooks/sed_fitting_gammacat_fermi.ipynb>`__
+-  `Light curve estimation with Gammapy <notebooks/light_curve.ipynb>`__
+   (H.E.S.S. fake data example TBC)
+
+3-dimensional cube analysis:
+
+-  `Cube analysis with Gammapy (part
+   1) <notebooks/cube_analysis_part1.ipynb>`__ - compute cubes and mean
+   PSF / EDISP
+-  `Cube analysis with Gammapy (part
+   2) <notebooks/cube_analysis_part2.ipynb>`__ - likelihood fit
+
+Time-related analysis:
+
+-  `Time analysis with Gammapy <notebooks/time_analysis.ipynb>`__ (not
+   written yet)
+
+Extra topics
+~~~~~~~~~~~~
+
+These notebooks contain examples on some more specialised functionality
+in Gammapy.
+
+Most users will not need them. It doesn't make much sense that you read
+through all of them, but maybe browse the list and see if there's
+something that could be interesting for your work (or contribute to
+Gammapy if something is missing!).
+
+-  `Template background model production with
+   Gammapy <notebooks/background_model.ipynb>`__
+-  `Continuous wavelet transform on gamma-ray
+   images <notebooks/cwt.ipynb>`__
+-  `Interpolation using the NDDataArray
+   class <notebooks/nddata_demo.ipynb>`__
+-  `Rapid introduction on using numpy, scipy,
+   matplotlib <notebooks/using_numpy.ipynb>`__
+
+Work in progress
+~~~~~~~~~~~~~~~~
+
+The following notebooks are work in progress or broken.
+
+Please help make these better, or write new, better ones!
+
+-  TODO: joint Fermi-IACT analysis with Gammpy
+-  TODO: simulate Fermi and CTA sky with Gammapy
+
+-  `Astrophysical source population modeling with
+   Gammapy <notebooks/source_population_model.ipynb>`__
+-  `notebooks/source\_catalogs.ipynb <notebooks/source_catalogs.ipynb>`__
+   : Working with gamma-ray source catalogs
+-  `notebooks/diffuse\_model\_computation.ipynb <notebooks/diffuse_model_computation.ipynb>`__
+   : Diffuse model computation
+-  `notebooks/fermi\_vela\_model.ipynb <notebooks/fermi_vela_model.ipynb>`__
+   : Fermi Vela model
+-  `Simulating and analysing sources and diffuse
+   emission <notebooks/source_diffuse_estimation.ipynb>`__

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -46,7 +46,7 @@ class AdaptiveRingBackgroundEstimator(object):
     --------
     Here's an example how to use the `AdaptiveRingBackgroundEstimator`:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.background import AdaptiveRingBackgroundEstimator
@@ -252,7 +252,7 @@ class RingBackgroundEstimator(object):
     --------
     Here's an example how to use the `RingBackgroundEstimator`:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.background import RingBackgroundEstimator

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -342,7 +342,7 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
     This example shows how to compute a set of basic images for the galactic
     center region using a prepared 2FHL dataset:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.image import SkyImage, FermiLATBasicImageEstimator

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -216,7 +216,7 @@ class ImageProfileEstimator(object):
     This example shows how to compute a counts profile for the Fermi galactic
     center region:
 
-    .. code::
+    .. code:: python
 
         import matplotlib.pyplot as plt
         from gammapy.datasets import FermiGalacticCenter

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -70,7 +70,7 @@ class FluxPoints(object):
     The `FluxPoints` object is most easily created by reading a file with
     flux points given in one of the formats documented above:
 
-    .. code::
+    .. code:: python
 
         from gammapy.spectrum import FluxPoints
         filename = '$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/flux_points.fits'
@@ -81,7 +81,7 @@ class FluxPoints(object):
     `astropy.table.Table`, which contains the required columns, such as `'e_ref'`
     and `'dnde'`:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from astropy.table import Table
@@ -101,7 +101,7 @@ class FluxPoints(object):
     If you have flux points in a different data format, the format can be changed
     by renamimg the table columns and adding meta data:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from astropy.table import Table

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -431,7 +431,7 @@ class ConstantModel(SpectralModel):
 
     .. math::
 
-        \phi(E) = k 
+        \phi(E) = k
 
     Parameters
     ----------
@@ -446,7 +446,7 @@ class ConstantModel(SpectralModel):
     @staticmethod
     def evaluate(energy, const):
         """Evaluate the model (static function)."""
-        return const 
+        return const
 
 
 class CompoundSpectralModel(SpectralModel):
@@ -505,7 +505,7 @@ class PowerLaw(SpectralModel):
     --------
     This is how to plot the default `PowerLaw` model:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.spectrum.models import PowerLaw
@@ -709,7 +709,7 @@ class PowerLaw2(SpectralModel):
     --------
     This is how to plot the default `PowerLaw2` model:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.spectrum.models import PowerLaw2
@@ -830,7 +830,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
     --------
     This is how to plot the default `ExponentialCutoffPowerLaw` model:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.spectrum.models import ExponentialCutoffPowerLaw
@@ -926,7 +926,7 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
     --------
     This is how to plot the default `ExponentialCutoffPowerLaw3FGL` model:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.spectrum.models import ExponentialCutoffPowerLaw3FGL
@@ -984,7 +984,7 @@ class PLSuperExpCutoff3FGL(SpectralModel):
     --------
     This is how to plot the default `PLSuperExpCutoff3FGL` model:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.spectrum.models import PLSuperExpCutoff3FGL
@@ -1053,7 +1053,7 @@ class LogParabola(SpectralModel):
     --------
     This is how to plot the default `LogParabola` model:
 
-    .. code::
+    .. code:: python
 
         from astropy import units as u
         from gammapy.spectrum.models import LogParabola


### PR DESCRIPTION
Main modifs are: 
* .gitignore to track  the *.ipynb files in `docs/folder` (these will be copied from GAMMAPY-EXTRA later on)
* conf.py Sphinx config file in `docs` to make `nbconfig` work nicely
* some *.rst files in `docs`and some *.py files in `gammany`source code folder to replace directive `.. code::` by `..code :: python`and make code inclusion in docs working. 
* You also need to re-install gammany with these new source files.

Remember you need to install `nbsphinx`:
conda install -c conda-forge nbsphinx

And that's all for the moment.
Just type `python setup.py build-docs` and this mixed interlinked doc of *rst files and notebooks is generated in one shot. We still have some warnings due to orphans *.ipynb files, but this does not prevent their conversion.

This is the firs step, still work in progress..

TODO
---
- [x] Create notebooks.rst with `toctree::` directive

Scriptting
- [x] Copy notebooks from $GAMMAPY_EXTRA
- [ ] Add footer cell with link to $GAMMAPY_EXTRA notebooks
- [ ] Flag only-notebooks
- [ ] Flag exec-noteboooks 
- [ ] Launch sphinx-build
- [ ] Param URL of published docs
- [ ] Regexp to modify HTML notebooks links from absolute to relative
- [ ] Add footer cell in $GAMMAPY_EXTRA notebooks with Param URL link pointing to the individual published HTML notebook

---
- [ ] Push manually to GitHub GAMMAPY-EXTRA

