### PR TITLE
Minor code cleanup  in gammapy.maps

### DIFF
--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -21,7 +21,7 @@ an all-sky 2D HEALPix image:
 
 .. code:: python
 
-   from gammapy.maps import HpxGeom
+   from gammapy.maps import HpxGeom, HpxMapND, HpxMap
    # Create a HEALPix geometry of NSIDE=16
    geom = HpxGeom(16, coordsys='GAL')
    m = HpxMapND(geom)

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -188,7 +188,7 @@ given operation across a grid of coordinate values.
 
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
-   coords = np.linspace(-5.0,5.0,11)
+   coords = np.linspace(-4.0,4.0,9)
 
    # Equivalent calls for accessing value at pixel (49,49)
    vals = m.get_by_idx( (49,49) )
@@ -200,7 +200,7 @@ given operation across a grid of coordinate values.
    # Retrieve map values on a 2D grid of latitude/longitude points
    vals = m.get_by_coords( (coords[None,:], coords[:,None]) )
    # Set map values along slice at longitude=0.0 to twice their existing value
-   m.set_by_coords((0.0, coords), 2.0*m.get_by_coords(0.0, coords))
+   m.set_by_coords((0.0, coords), 2.0*m.get_by_coords((0.0, coords)))
 
 The ``set`` and ``fill`` methods can both be used to set pixel values.
 The following demonstrates how one can set pixel values:

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -365,8 +365,9 @@ objects that can be used to further tweak/customize the image.
 
    import matplotlib.pyplot as plt
    from gammapy.maps import MapBase
+   from gammapy.maps.utils import fill_poisson
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
-   m.fill_poisson(1.0)
+   fill_poisson(m, mu=1.0, random_state=0)
    fig, ax, im = m.plot(cmap='magma')
    plt.colorbar(im)
 

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -106,6 +106,7 @@ Fermi-LAT PSF:
 
 .. code:: python
 
+   import numpy as np
    from gammapy.maps import MapBase, MapAxis
    from astropy.coordinates import SkyCoord
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
@@ -276,6 +277,7 @@ one can use this method to fill a map with a 2D Gaussian:
 
 .. code:: python
 
+   import numpy as np
    from astropy.coordinates import SkyCoord
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.05, map_type='wcs', width=10.0)
@@ -364,7 +366,7 @@ objects that can be used to further tweak/customize the image.
    import matplotlib.pyplot as plt
    from gammapy.maps import MapBase
    m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
-   m.fill_by_poisson(1.0)
+   m.fill_poisson(1.0)
    fig, ax, im = m.plot(cmap='magma')
    plt.colorbar(im)
 

--- a/gammapy/maps/__init__.py
+++ b/gammapy/maps/__init__.py
@@ -17,3 +17,4 @@ from .hpxmap import *
 from .wcs import *
 from .wcsnd import *
 from .wcsmap import *
+from .sparse import *

--- a/gammapy/maps/_sparse.pyx
+++ b/gammapy/maps/_sparse.pyx
@@ -12,7 +12,6 @@ ctypedef fused float_t:
     np.float32_t
     np.float64_t
 
-
 @cython.cdivision(True)
 @cython.boundscheck(False)
 def binary_search(np.ndarray[int_t, ndim=1] arr_in, int_t idx,
@@ -25,7 +24,6 @@ def binary_search(np.ndarray[int_t, ndim=1] arr_in, int_t idx,
     ----------
     arr_in : `~numpy.ndarray`
         Sorted array of integers.
-
     idx : int
         Value to be searched for in ``arr_in``.
 
@@ -34,13 +32,11 @@ def binary_search(np.ndarray[int_t, ndim=1] arr_in, int_t idx,
     idx_out: int
         Index of matching element or the index at which ``idx`` would
         be inserted to maintain sorted order.
-
     """
-
     cdef int_t mid = 0
     cdef int_t midval = 0
 
-    while(ilo < ihi):
+    while ilo < ihi:
         mid = (ilo + ihi) // 2
         midval = arr_in[mid]
 
@@ -53,7 +49,6 @@ def binary_search(np.ndarray[int_t, ndim=1] arr_in, int_t idx,
 
     return ilo
 
-
 @cython.cdivision(True)
 @cython.boundscheck(False)
 def find_in_array(np.ndarray[int_t, ndim=1] idx0,
@@ -64,22 +59,18 @@ def find_in_array(np.ndarray[int_t, ndim=1] idx0,
     ----------
     idx0 : `~np.ndarray`
         Array of unsorted input values.
-
     idx1 : `~np.ndarray`
         Array of sorted values to be searched. 
 
     Returns
     -------
-    idx : `~np.ndarray`
+    idx : `~numpy.ndarray`
         Array of indices with length of ``idx0`` with the position of
         the given element in ``idx1``.
-
-    msk : `~np.ndarray`
+    msk : `~numpy.ndarray`
         Boolean mask with length of ``idx0`` indicating whether a
         given value was found in ``idx1``.
-
     """
-
     cdef int ni = idx0.shape[0]
     cdef int nj = idx1.shape[0]
 
@@ -90,7 +81,7 @@ def find_in_array(np.ndarray[int_t, ndim=1] idx0,
     cdef np.ndarray[int_t, ndim= 1] out = np.zeros([ni], dtype=idx0.dtype)
     cdef np.ndarray[np.uint8_t, ndim= 1] msk = np.zeros([ni], dtype=np.uint8)
 
-    while(i < ni and j < nj):
+    while i < ni and j < nj:
 
         ii = idx_sort[i]
 
@@ -107,7 +98,6 @@ def find_in_array(np.ndarray[int_t, ndim=1] idx0,
 
     return out, msk.astype(bool)
 
-
 @cython.cdivision(True)
 @cython.boundscheck(False)
 def merge_sparse_arrays(np.ndarray[int_t, ndim=1] idx0,
@@ -117,24 +107,21 @@ def merge_sparse_arrays(np.ndarray[int_t, ndim=1] idx0,
                         bint fill=False
                         ):
     """Merge two sparse arrays represented as index/value pairs into a
-    single sparse array.  Values in the first array (``idx0``,
-    ``val0``) will supersede those in the second array.  Indices in
-    the second array should be presorted.
+    single sparse array.
+
+    Values in the first array (``idx0``, ``val0``) will supersede those
+    in the second array. Indices in the second array should be presorted.
 
     Parameters
     ----------
     idx0 : `~numpy.ndarray`
         Array of indices of first sparse array.
-
     val0 : `~numpy.ndarray`
         Array of values of first sparse array.
-
     idx1 : `~numpy.ndarray`
-        Array of indices for second sparse array. 
-
+        Array of indices for second sparse array.
     val1 : `~numpy.ndarray`
-        Array of values for second sparse array. 
-
+        Array of values for second sparse array.
     fill : bool
         Flag to switch between update and fill mode.  When fill is
         True the values in the first array will be added to the second
@@ -145,12 +132,9 @@ def merge_sparse_arrays(np.ndarray[int_t, ndim=1] idx0,
     -------
     idx : `~numpy.ndarray`
         Array of indices for merged sparse array.
-
     vals : `~numpy.ndarray`
         Array of values for merged sparse array.
-
     """
-
     cdef int ni = idx0.shape[0]
     cdef int nj = idx1.shape[0]
     cdef int i = 0
@@ -165,13 +149,13 @@ def merge_sparse_arrays(np.ndarray[int_t, ndim=1] idx0,
     cdef int n = idx.size
     cdef np.ndarray[float_t, ndim= 1] vals = np.zeros(n, dtype=val0.dtype)
 
-    while(k < n):
+    while k < n:
 
-        while(j < nj):
+        while j < nj:
 
-            if(idx1[j] > idx[k]):
+            if idx1[j] > idx[k]:
                 break
-            elif(idx1[j] == idx[k]):
+            elif idx1[j] == idx[k]:
 
                 if fill:
                     vals[k] += val1[j]
@@ -180,11 +164,11 @@ def merge_sparse_arrays(np.ndarray[int_t, ndim=1] idx0,
 
             j += 1
 
-        while(i < ni):
+        while i < ni:
 
-            if(idx0[i] > idx[k]):
+            if idx0[i] > idx[k]:
                 break
-            elif(idx0[i] == idx[k]):
+            elif idx0[i] == idx[k]:
 
                 if fill:
                     vals[k] += val0[i]

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -529,9 +529,3 @@ class MapBase(object):
             Values vector. Pixels at `idx` will be set to these values.
         """
         pass
-
-    def fill_poisson(self, mu):
-
-        pix = self.geom.get_pixels()
-        mu = np.random.poisson(mu, len(pix[0]))
-        self.fill_by_idx(pix, mu)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -25,9 +25,10 @@ class MapBase(object):
 
     Parameters
     ----------
-    geom : `~gammapy.maps.geom.MapGeom`
-
+    geom : `~gammapy.maps.MapGeom`
+        Geometry
     data : `~numpy.ndarray`
+        Data array
     """
 
     def __init__(self, geom, data):
@@ -36,12 +37,8 @@ class MapBase(object):
 
     @property
     def data(self):
-        """Array of data values."""
+        """Data array (`~numpy.ndarray`)"""
         return self._data
-
-    @property
-    def geom(self):
-        return self._geom
 
     @data.setter
     def data(self, val):
@@ -49,9 +46,16 @@ class MapBase(object):
             raise Exception('Wrong shape.')
         self._data = val
 
+    @property
+    def geom(self):
+        """Map geometry (`~gammapy.maps.MapGeom`)"""
+        return self._geom
+
     @classmethod
     def create(cls, **kwargs):
-        """Create an empty map object.  This method accepts generic options
+        """Create an empty map object.
+
+        This method accepts generic options
         listed below as well as options for `~HpxMap` and `~WcsMap`
         objects (see `~HpxMap.create` and `~WcsMap.create` for WCS-
         and HPX-specific options).
@@ -61,24 +65,18 @@ class MapBase(object):
         coordsys : str
             Coordinate system, either Galactic ('GAL') or Equatorial
             ('CEL').
-
         map_type : str
             Internal map representation.  Valid types are `wcs`,
-            `wcs-sparse`,`hpx`, and `hpx-sparse`.
-
+            `wcs-sparse`, `hpx`, and `hpx-sparse`.
         binsz : float or `~numpy.ndarray`
             Pixel size in degrees.
-
         skydir : `~astropy.coordinates.SkyCoord`
             Coordinate of map center.
-
         axes : list
             List of `~MapAxis` objects for each non-spatial dimension.
             If None then the map will be a 2D image.
-
         dtype : str
-            Data type, default is float32
-
+            Data type, default is ``float32``
         unit : str or `~astropy.units.Unit`
             Data unit.
 
@@ -86,9 +84,7 @@ class MapBase(object):
         -------
         map : `~MapBase`
             Empty map object.
-
         """
-
         from .hpxmap import HpxMap
         from .wcsmap import WcsMap
 
@@ -120,7 +116,6 @@ class MapBase(object):
         -------
         map_out : `~MapBase`
             Map object
-
         """
         with fits.open(filename) as hdulist:
             map_out = cls.from_hdulist(hdulist, **kwargs)
@@ -168,7 +163,6 @@ class MapBase(object):
             Array of image plane values.
         idx : tuple
             Index of image plane.
-
         """
         pass
 
@@ -185,7 +179,7 @@ class MapBase(object):
 
         Returns
         -------
-        val : `~np.ndarray`
+        val : `~numpy.ndarray`
             Map values.
         pix : tuple
             Tuple of pixel coordinates.
@@ -205,7 +199,7 @@ class MapBase(object):
 
         Returns
         -------
-        val : `~np.ndarray`
+        val : `~numpy.ndarray`
             Map values.
         coords : tuple
             Tuple of map coordinates.
@@ -224,11 +218,9 @@ class MapBase(object):
         ----------
         geom : `~MapGeom`
             Geometry of projection.
-
         mode : str
             Method for reprojection.  'interp' method interpolates at pixel
             centers.  'exact' method integrates over intersection of pixels.
-
         order : int or str
             Order of interpolating polynomial (0 = nearest-neighbor, 1 =
             linear, 2 = quadratic, 3 = cubic).
@@ -237,7 +229,6 @@ class MapBase(object):
         -------
         map : `~MapBase`
             Reprojected map.
-
         """
         if geom.ndim == 2 and self.geom.ndim > 2:
             geom = geom.to_cube(self.geom.axes)
@@ -297,7 +288,6 @@ class MapBase(object):
         -------
         map : `~MapBase`
             Downsampled map.
-
         """
         pass
 
@@ -314,7 +304,6 @@ class MapBase(object):
         -------
         map : `~MapBase`
             Upsampled map.
-
         """
         pass
 
@@ -344,7 +333,6 @@ class MapBase(object):
         vals : `~numpy.ndarray`
            Values of pixels in the map.  np.nan used to flag coords
            outside of map.
-
         """
         if interp is None or interp == 'nearest':
             idx = self.geom.coord_to_pix(coords)
@@ -379,7 +367,6 @@ class MapBase(object):
         vals : `~numpy.ndarray`
            Array of pixel values.  np.nan used to flag coordinates
            outside of map
-
         """
         pass
 
@@ -399,7 +386,6 @@ class MapBase(object):
         vals : `~numpy.ndarray`
            Array of pixel values.
            np.nan used to flag coordinate outside of map
-
         """
         pass
 
@@ -430,7 +416,6 @@ class MapBase(object):
         vals : `~numpy.ndarray`
            Values of pixels in the flattened map.
            np.nan used to flag coords outside of map
-
         """
         pass
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -29,9 +29,9 @@ def make_axes(axes_in, conv):
             ax = MapAxis(ax)
 
         if conv in ['fgst-ccube', 'fgst-template']:
-            ax.set_name('energy')
+            ax.name = 'energy'
         elif ax.name == '':
-            ax.set_name('axis%i' % i)
+            ax.name = 'axis%i' % i
 
         axes_out += [ax]
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -163,7 +163,8 @@ def skydir_to_lonlat(skydir, coordsys=None):
     elif skydir.frame.name in ['galactic']:
         return skydir.l.deg, skydir.b.deg
     else:
-        raise ValueError('Unrecognized SkyCoord frame: {}'.format(skydir.frame.name))
+        raise ValueError(
+            'Unrecognized SkyCoord frame: {}'.format(skydir.frame.name))
 
 
 def pix_tuple_to_idx(pix):
@@ -359,6 +360,10 @@ class MapAxis(object):
         """Name of the axis."""
         return self._name
 
+    @name.setter
+    def name(self, val):
+        self._name = val
+
     @property
     def edges(self):
         """Return array of bin edges."""
@@ -470,9 +475,6 @@ class MapAxis(object):
             raise ValueError('Edges array must have at least two elements.')
 
         return cls(edges, node_type='edge', **kwargs)
-
-    def set_name(self, name):
-        self._name = name
 
     def pix_to_coord(self, pix):
         """Transform from pixel to axis coordinates.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -45,13 +45,14 @@ def make_axes_cols(axes, axis_names=None):
     ----------
     axes : list of `~MapAxis`
 
-    colnames : list of str
+    axis_names : list of str
 
     """
 
-    colname = {'energy': ['ENERGY', 'E_MIN', 'E_MAX'],
-               'time': ['TIME', 'T_MIN', 'T_MAX'],
-               }
+    colname = {
+        'energy': ['ENERGY', 'E_MIN', 'E_MAX'],
+        'time': ['TIME', 'T_MIN', 'T_MAX'],
+    }
 
     if axis_names is None:
         axis_names = [ax.name for ax in axes]
@@ -79,14 +80,15 @@ def find_and_read_bands(hdu, header=None):
 
     Parameters
     ----------
-    hdu : `~astropy.fits.BinTableHDU`
+    hdu : `~astropy.io.fits.BinTableHDU`
         The BANDS table HDU.
+    header : `~astropy.io.fits.Header`
+        TODO
 
     Returns
     -------
     axes : list of `~MapAxis`
         List of axis objects.
-
     """
     if hdu is None:
         return []
@@ -147,8 +149,7 @@ def coordsys_to_frame(coordsys):
     elif coordsys in ['GAL', 'G']:
         return 'galactic'
     else:
-        raise ValueError('Unrecognized coordinate system: {}',
-                         coordsys)
+        raise ValueError('Unrecognized coordinate system: {}'.format(coordsys))
 
 
 def skydir_to_lonlat(skydir, coordsys=None):
@@ -158,12 +159,11 @@ def skydir_to_lonlat(skydir, coordsys=None):
         skydir = skydir.transform_to('galactic')
 
     if skydir.frame.name in ['icrs', 'fk5']:
-        return (skydir.ra.deg, skydir.dec.deg)
+        return skydir.ra.deg, skydir.dec.deg
     elif skydir.frame.name in ['galactic']:
-        return (skydir.l.deg, skydir.b.deg)
+        return skydir.l.deg, skydir.b.deg
     else:
-        raise ValueError('Unrecognized SkyCoord frame: {}',
-                         skydir.frame.name)
+        raise ValueError('Unrecognized SkyCoord frame: {}'.format(skydir.frame.name))
 
 
 def pix_tuple_to_idx(pix):
@@ -198,7 +198,6 @@ def axes_pix_to_coord(axes, pix):
     pix : tuple
         Tuple of pixel coordinates.
     """
-
     coords = []
     for ax, t in zip(axes, pix):
         coords += [ax.pix_to_coord(t)]
@@ -219,6 +218,7 @@ def coord_to_idx(edges, x, bounded=False):
         ibin[x > edges[-1]] = len(edges) - 1
     else:
         ibin[x > edges[-1]] = -1
+
     return ibin
 
 
@@ -242,9 +242,11 @@ def coord_to_pix(edges, coord, interp='lin'):
     else:
         raise ValueError('Invalid interp: {}'.format(interp))
 
-    interp_fn = interp1d(fn(edges),
-                         np.arange(len(edges)).astype(float),
-                         fill_value='extrapolate')
+    interp_fn = interp1d(
+        fn(edges),
+        np.arange(len(edges)).astype(float),
+        fill_value='extrapolate',
+    )
 
     return interp_fn(fn(coord))
 
@@ -271,15 +273,19 @@ def pix_to_coord(edges, pix, interp='lin'):
     else:
         raise ValueError('Invalid interp: {}'.format(interp))
 
-    interp_fn = interp1d(np.arange(len(edges)).astype(float),
-                         fn0(edges),
-                         fill_value='extrapolate')
+    interp_fn = interp1d(
+        np.arange(len(edges)).astype(float),
+        fn0(edges),
+        fill_value='extrapolate',
+    )
 
     return fn1(interp_fn(pix))
 
 
 class MapAxis(object):
-    """Class representing an axis of a map.  Provides methods for
+    """Class representing an axis of a map.
+
+    Provides methods for
     transforming to/from axis and pixel coordinates.  An axis is
     defined by a sequence of node values that lie at the center of
     each bin.  The pixel coordinate at each node is equal to its index
@@ -295,6 +301,8 @@ class MapAxis(object):
     interp : str
         Interpolation method used to transform between axis and pixel
         coordinates.  Valid options are 'log', 'lin', and 'sqrt'.
+    name : str
+        Axis name
     node_type : str
         Flag indicating whether coordinate nodes correspond to pixel
         edges (node_type = 'edge') or pixel centers (node_type =
@@ -305,7 +313,6 @@ class MapAxis(object):
         counts histogram).
     unit : str
         String specifying the data units.
-
     """
 
     # TODO: Add methods to faciliate FITS I/O.
@@ -393,12 +400,10 @@ class MapAxis(object):
             Upper bound of last axis bin.
         nbin : int
             Number of bins.
-        interp : str
+        interp : {'lin', 'log', 'sqrt'}
             Interpolation method used to transform between axis and pixel
-            coordinates.  Valid options are `log`, `lin`, and `sqrt`.
-
+            coordinates.  Default: 'lin'.
         """
-
         interp = kwargs.setdefault('interp', 'lin')
         node_type = kwargs.setdefault('node_type', 'edge')
 
@@ -435,9 +440,9 @@ class MapAxis(object):
         ----------
         nodes : `~numpy.ndarray`
             Axis nodes (bin center).
-        interp : str
+        interp : {'lin', 'log', 'sqrt'}
             Interpolation method used to transform between axis and pixel
-            coordinates.  Valid options are `log`, `lin`, and `sqrt`.
+            coordinates.  Default: 'lin'.
         """
         nodes = np.array(nodes, ndmin=1)
         if len(nodes) < 1:
@@ -457,9 +462,9 @@ class MapAxis(object):
         ----------
         edges : `~numpy.ndarray`
             Axis bin edges.
-        interp : str
+        interp : {'lin', 'log', 'sqrt'}
             Interpolation method used to transform between axis and pixel
-            coordinates.  Valid options are `log`, `lin`, and `sqrt`.
+            coordinates.  Default: 'lin'.
         """
         if len(edges) < 2:
             raise ValueError('Edges array must have at least two elements.')
@@ -517,7 +522,6 @@ class MapAxis(object):
         -------
         idx : `~numpy.ndarray`
             Array of bin indices.
-
         """
         return coord_to_idx(self.edges, coord, bounded)
 
@@ -637,19 +641,23 @@ class MapGeomMeta(InheritDocstrings, abc.ABCMeta):
 class MapGeom(object):
     """Base class for WCS and HEALPix geometries."""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def allsky(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def center_coord(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def center_pix(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def center_skydir(self):
         pass
 
@@ -716,10 +724,11 @@ class MapGeom(object):
 
     @abc.abstractmethod
     def get_pixels(self, idx=None, local=False):
-        """Get tuple of pixel indices for this geometry.  Returns all pixels
-        in the geometry by default.  Pixel indices for a single image
-        plane can be accessed by setting ``idx`` to the index tuple of
-        a plane.
+        """Get tuple of pixel indices for this geometry.
+
+        Returns all pixels in the geometry by default. Pixel indices
+        for a single image plane can be accessed by setting ``idx``
+        to the index tuple of a plane.
 
         Parameters
         ----------
@@ -744,8 +753,9 @@ class MapGeom(object):
 
     @abc.abstractmethod
     def get_coords(self, idx=None):
-        """Get the coordinates of all the pixels in this geometry.  Returns
-        coordinates for all pixels in the geometry by default.
+        """Get the coordinates of all the pixels in this geometry.
+
+        Returns coordinates for all pixels in the geometry by default.
         Coordinates for a single image plane can be accessed by
         setting ``idx`` to the index tuple of a plane.
 
@@ -762,7 +772,6 @@ class MapGeom(object):
         coords : tuple
             Tuple of coordinate vectors with one vector for each
             dimension.
-
         """
         pass
 
@@ -843,8 +852,7 @@ class MapGeom(object):
 
     @abc.abstractmethod
     def contains(self, coords):
-        """
-        Check if a given coordinate is contained in the map.
+        """Check if a given coordinate is contained in the map.
 
         Parameters
         ----------
@@ -889,7 +897,6 @@ class MapGeom(object):
         -------
         geom : `~MapGeom`
             Image geometry.
-
         """
         pass
 
@@ -909,7 +916,6 @@ class MapGeom(object):
         -------
         geom : `~MapGeom`
             Map geometry.
-
         """
         pass
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -699,10 +699,12 @@ class HpxGeom(MapGeom):
 
     @property
     def ndim(self):
+        """Number of dimensions (int)."""
         return len(self._axes) + 2
 
     @property
     def ordering(self):
+        """HEALPix ordering ('NESTED' or 'RING')."""
         if self._nest:
             return 'NESTED'
         return 'RING'
@@ -721,6 +723,7 @@ class HpxGeom(MapGeom):
 
     @property
     def nest(self):
+        """Is HEALPix order nested? (bool)."""
         return self._nest
 
     @property

--- a/gammapy/maps/hpxcube.py
+++ b/gammapy/maps/hpxcube.py
@@ -28,7 +28,6 @@ class HpxMapND(HpxMap):
     data : `~numpy.ndarray`
         HEALPIX data array.
         If none then an empty array will be allocated.
-
     """
 
     def __init__(self, hpx, data=None, dtype='float32'):
@@ -487,9 +486,7 @@ class HpxMapND(HpxMap):
 
         im : `~matplotlib.image.AxesImage` or `~matplotlib.collections.PatchCollection`
             Image object.
-
         """
-
         if method == 'raster':
             m = self.to_wcs(sum_bands=True,
                             normalize=normalize,
@@ -510,9 +507,7 @@ class HpxMapND(HpxMap):
         step : int
             Set the number vertices that will be computed for each
             pixel in multiples of 4.
-
         """
-
         # FIXME: At the moment this only works for all-sky maps if the
         # projection is centered at (0,0)
 
@@ -555,7 +550,7 @@ class HpxMapND(HpxMap):
             dist = np.max(np.abs(pix[0][0] - pix[0]))
 
             # Split pixels that wrap around the edges of the projection
-            if(dist > wcs.npix[0] / 1.5):
+            if (dist > wcs.npix[0] / 1.5):
 
                 lon, lat = np.degrees(x), np.degrees(np.pi / 2. - y)
                 lon0 = lon - 1E-4

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -105,7 +105,6 @@ class HpxMap(MapBase):
         hpx_map : `HpxMap`
             Map object
         """
-
         if hdu is None:
             hdu = find_bintable_hdu(hdulist)
         else:
@@ -149,7 +148,6 @@ class HpxMap(MapBase):
             WCS object
         data : `~numpy.ndarray`
             Reprojected data
-
         """
         pass
 
@@ -171,7 +169,6 @@ class HpxMap(MapBase):
         preserve_counts : bool
             Choose whether to preserve counts (total amplitude) or
             intensity (amplitude per unit solid angle).
-
         """
         pass
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -21,7 +21,7 @@ class HpxMapSparse(HpxMap):
 
     Parameters
     ----------
-    hpx : `~gammapy.maps.hpx.HpxGeom`
+    hpx : `~gammapy.maps.HpxGeom`
         HEALPIX geometry object.
     data : `~numpy.ndarray`
         HEALPIX data array.

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -28,10 +28,9 @@ class HpxMapSparse(HpxMap):
     """
 
     def __init__(self, hpx, data=None, dtype='float32'):
-
         if data is None:
             shape = tuple([np.max(hpx.npix)] + [ax.nbin for ax in hpx.axes])
-            data = SparseArray(shape[::-1])
+            data = SparseArray(shape[::-1], dtype=dtype)
         elif isinstance(data, np.ndarray):
             data = SparseArray.from_array(data)
 
@@ -82,14 +81,12 @@ class HpxMapSparse(HpxMap):
         return map_out
 
     def get_by_pix(self, pix, interp=None):
-
         if interp is None:
             return self.get_by_idx(pix)
         else:
             raise NotImplementedError
 
     def get_by_idx(self, idx):
-
         # Convert to local pixel indices
         idx = pix_tuple_to_idx(idx)
         idx = self.hpx.global_to_local(idx)
@@ -99,7 +96,6 @@ class HpxMapSparse(HpxMap):
         raise NotImplementedError
 
     def fill_by_idx(self, idx, weights=None):
-
         idx = pix_tuple_to_idx(idx)
         if weights is None:
             weights = np.ones(idx[0].shape)
@@ -117,7 +113,6 @@ class HpxMapSparse(HpxMap):
         self.data[idx[::-1]] = vals
 
     def _make_cols(self, header, conv):
-
         shape = self.data.shape
         cols = []
         if header['INDXSCHM'] == 'SPARSE':

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -14,7 +14,6 @@ def _get_input_pixels_celestial(wcs_in, wcs_out, shape_out):
     Get the pixel coordinates of the pixels in an array of shape ``shape_out``
     in the input WCS.
     """
-
     from reproject.wcs_utils import convert_world_coordinates
 
     # TODO: for now assuming that coordinates are spherical, not
@@ -37,7 +36,6 @@ def _get_input_pixels_celestial(wcs_in, wcs_out, shape_out):
 
 def reproject_car_to_hpx(input_data, coord_system_out,
                          nside, order=1, nested=False):
-
     import healpy as hp
     from scipy.ndimage import map_coordinates
     from reproject.wcs_utils import convert_world_coordinates
@@ -54,8 +52,10 @@ def reproject_car_to_hpx(input_data, coord_system_out,
     # Convert between celestial coordinates
     coord_system_out = parse_coord_system(coord_system_out)
     with np.errstate(invalid='ignore'):
-        lon_in, lat_in = convert_world_coordinates(lon_out, lat_out,
-                                                   (coord_system_out, u.deg, u.deg), wcs_in)
+        lon_in, lat_in = convert_world_coordinates(
+            lon_out, lat_out,
+            (coord_system_out, u.deg, u.deg), wcs_in,
+        )
 
     # Look up pixels in input system
     yinds, xinds = wcs_in.wcs_world2pix(lon_in, lat_in, 0)

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -76,7 +76,7 @@ class SparseArray(object):
     Alternatively you can create a new SparseArray from an
     `~numpy.ndarray` with `~SparseArray.from_array`:
 
-    >>> x = np.ndarray((10,20))
+    >>> x = np.ones((10,20))
     >>> v = SparseArray.from_array(x)
 
     SparseArray follows numpy indexing and slicing conventions for

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -6,7 +6,6 @@ from ._sparse import find_in_array, merge_sparse_arrays
 
 
 def slices_to_idxs(slices, shape, ndim):
-
     if slices == Ellipsis:
         slices = tuple([slice(None)] * ndim)
     elif not isinstance(slices, tuple):
@@ -15,8 +14,8 @@ def slices_to_idxs(slices, shape, ndim):
     if len(slices) < ndim:
         slices = tuple(list(slices) + [slice(None)] * (ndim - len(slices)))
 
-    #nslice = min(1, sum([not isinstance(s, slice) for s in slices]))
-    #nslice += sum([isinstance(s, slice) for s in slices])
+    # nslice = min(1, sum([not isinstance(s, slice) for s in slices]))
+    # nslice += sum([isinstance(s, slice) for s in slices])
     nslice = len(slices)
     idim = None
     idx = []
@@ -48,25 +47,20 @@ class SparseArray(object):
     ----------
     shape : tuple of ints
         Shape of array.
-
     idx : `~numpy.ndarray`, optional
         Flattened index vector that initializes the array.  If none
         then an empty array will be created.
-
     data : `~numpy.ndarray`, optional
         Flattened data vector that initializes the array.  If none
         then an empty array will be created.
-
     dtype : data-type, optional
         Type of data vector.
-
     fill_value : scalar, optional
         Value assigned to array elements that are not allocated in
         memory.
 
     Examples
     --------
-
     A SparseArray is created in the same way as `~numpy.ndarray` by
     passing the array shape to the constructor with an optional
     argument for the array type:
@@ -90,11 +84,9 @@ class SparseArray(object):
     >>> print(v[0,0])
     >>> v[:,0] = 1.0
     >>> print(v[:,0])
-
     """
 
     def __init__(self, shape, idx=None, data=None, dtype=float, fill_value=0.0):
-
         self._shape = tuple(shape)
         self._fill_value = fill_value
         if idx is not None:
@@ -105,13 +97,11 @@ class SparseArray(object):
             self._data = np.zeros(0, dtype=dtype)
 
     def __getitem__(self, slices):
-
         idx = slices_to_idxs(slices, self.shape, self.ndim)
         idx = np.broadcast_arrays(*idx)
         return self.get(idx)
 
     def __setitem__(self, slices, vals):
-
         idx = slices_to_idxs(slices, self.shape, self.ndim)
         idx = np.broadcast_arrays(*idx)
         return self.set(idx, vals)
@@ -149,7 +139,6 @@ class SparseArray(object):
         ----------
         data : `numpy.ndarray`
             Input data array.
-
         min_value : float
             Threshold for sparsifying the data vector.
 
@@ -176,7 +165,6 @@ class SparseArray(object):
 
     def set(self, idx_in, vals, fill=False):
         """Set array values at indices ``idx_in``."""
-
         o = np.broadcast_arrays(vals, *idx_in)
         vals = np.ravel(o[0])
 
@@ -197,12 +185,11 @@ class SparseArray(object):
         data = data[msk]
         self._idx = idx
         self._data = data
-        #idx, msk = find_in_array(idx_flat_in, self.idx)
-        #self._data[idx[msk]] = vals[msk]
+        # idx, msk = find_in_array(idx_flat_in, self.idx)
+        # self._data[idx[msk]] = vals[msk]
 
     def get(self, idx_in):
         """Get array values at indices ``idx_in``."""
-
         shape_out = idx_in[0].shape
         idx_flat_in, msk_in = self._to_flat_index(idx_in)
         idx, msk = find_in_array(idx_flat_in, self.idx)
@@ -211,7 +198,6 @@ class SparseArray(object):
         return np.squeeze(val_out)
 
     def sum(self, axis=None, dtype=None, out=None, keepdims=False, **unused_kwargs):
-
         # FIXME: Figure out how to correctly support np.apply_over_axes
 
         if axis is None:

--- a/gammapy/maps/sparse.py
+++ b/gammapy/maps/sparse.py
@@ -1,8 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import copy
 import numpy as np
 from ._sparse import find_in_array, merge_sparse_arrays
+
+__all__ = [
+    'SparseArray',
+]
 
 
 def slices_to_idxs(slices, shape, ndim):
@@ -38,10 +41,11 @@ def slices_to_idxs(slices, shape, ndim):
 
 
 class SparseArray(object):
-    """Sparse N-dimensional array object.  This class implements a data
-    structure for sparse n-dimensional arrays such that only non-zero
-    data values are allocated in memory.  Supports numpy conventions
-    for indexing and slicing logic.
+    """Sparse N-dimensional array object.
+
+    This class implements a data structure for sparse n-dimensional
+    arrays such that only non-zero data values are allocated in memory.
+    Supports numpy conventions for indexing and slicing logic.
 
     Parameters
     ----------
@@ -123,12 +127,12 @@ class SparseArray(object):
 
     @property
     def shape(self):
-        """Return the array shape."""
+        """Array shape."""
         return self._shape
 
     @property
     def ndim(self):
-        """Return the array dimension."""
+        """Array number of dimensions (int)."""
         return len(self._shape)
 
     @classmethod

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -168,7 +168,6 @@ def test_hpxgeom_to_slice(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxgeom_get_pixels(nside, nested, coordsys, region, axes):
-
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
     pix = geom.get_pixels(local=False)
     pix_local = geom.get_pixels(local=True)
@@ -347,13 +346,11 @@ def test_hpxgeom_contains(nside, nested, coordsys, region, axes):
         coords[0].shape, dtype=bool))
 
     if axes is not None:
-
         coords = [c[0] for c in coords[:2]] + \
-            [ax.edges[-1] + 1.0 for ax in axes]
+                 [ax.edges[-1] + 1.0 for ax in axes]
         assert_allclose(geom.contains(coords), np.zeros((1,), dtype=bool))
 
     if geom.region is not None:
-
         coords = [0.0, 0.0] + [ax.center[0] for ax in geom.axes]
         assert_allclose(geom.contains(coords), np.zeros((1,), dtype=bool))
 
@@ -433,4 +430,4 @@ def test_hpxgeom_read_write(tmpdir, nside, nested, coordsys, region, axes):
     assert_allclose(geom0.nside, geom1.nside)
     assert_allclose(geom0.npix, geom1.npix)
     assert_allclose(geom0.nest, geom1.nest)
-    assert(geom0.coordsys == geom1.coordsys)
+    assert geom0.coordsys == geom1.coordsys

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+from ..utils import fill_poisson
 from ..geom import MapAxis
 from ..hpx import HpxGeom
 from ..hpxcube import HpxMapND
@@ -67,7 +68,7 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     filename = str(tmpdir / 'skycube.fits')
 
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    m.fill_poisson(0.5)
+    fill_poisson(m, 0.5)
     m.write(filename)
 
     m2 = HpxMapND.read(filename)
@@ -154,7 +155,7 @@ def test_hpxmap_to_wcs(nside, nested, coordsys, region, axes):
 def test_hpxmap_swap_scheme(nside, nested, coordsys, region, axes):
     m = HpxMapND(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    m.fill_poisson(1.0)
+    fill_poisson(m, 1.0)
     m2 = m.to_swapped_scheme()
     coords = m.hpx.get_coords()
     assert_allclose(m.get_by_coords(coords), m2.get_by_coords(coords))

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -68,7 +68,7 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     filename = str(tmpdir / 'skycube.fits')
 
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    fill_poisson(m, 0.5)
+    fill_poisson(m, mu=0.5, random_state=0)
     m.write(filename)
 
     m2 = HpxMapND.read(filename)
@@ -155,7 +155,7 @@ def test_hpxmap_to_wcs(nside, nested, coordsys, region, axes):
 def test_hpxmap_swap_scheme(nside, nested, coordsys, region, axes):
     m = HpxMapND(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    fill_poisson(m, 1.0)
+    fill_poisson(m, mu=1.0, random_state=0)
     m2 = m.to_swapped_scheme()
     coords = m.hpx.get_coords()
     assert_allclose(m.get_by_coords(coords), m2.get_by_coords(coords))

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -29,7 +29,6 @@ hpx_test_geoms_sparse += [tuple(list(t) + [False]) for t in hpx_test_geoms]
 
 
 def create_map(nside, nested, coordsys, region, axes, sparse):
-
     if sparse:
         m = HpxMapSparse(HpxGeom(nside=nside, nest=nested,
                                  coordsys=coordsys, region=region, axes=axes))
@@ -90,7 +89,6 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)
 def test_hpxmap_set_get_by_pix(nside, nested, coordsys, region, axes, sparse):
-
     m = create_map(nside, nested, coordsys, region, axes, sparse)
     coords = m.hpx.get_coords()
     pix = m.hpx.get_pixels()
@@ -122,7 +120,6 @@ def test_hpxmap_get_by_coords_interp(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)
 def test_hpxmap_fill_by_coords(nside, nested, coordsys, region, axes, sparse):
-
     m = create_map(nside, nested, coordsys, region, axes, sparse)
     coords = m.hpx.get_coords()
     m.fill_by_coords(coords, coords[1])

--- a/gammapy/maps/tests/test_sparse.py
+++ b/gammapy/maps/tests/test_sparse.py
@@ -15,10 +15,9 @@ test_params = [
 
 @pytest.mark.parametrize(('shape'), test_params)
 def test_sparse_init(shape):
-
     v = SparseArray(shape)
-    assert(v.shape == shape)
-    assert(v.size == 0)
+    assert (v.shape == shape)
+    assert (v.size == 0)
 
     data = np.ones(shape)
     v = SparseArray.from_array(data)
@@ -26,7 +25,6 @@ def test_sparse_init(shape):
 
 
 def test_sparse_getitem():
-
     shape = (8, 16, 32)
 
     data = np.random.poisson(np.ones(shape)).astype(float)
@@ -48,7 +46,6 @@ def test_sparse_getitem():
 
 @pytest.mark.parametrize(('shape'), test_params)
 def test_sparse_setitem(shape):
-
     data = np.random.poisson(np.ones(shape)).astype(float)
     v = SparseArray(shape)
     idx = np.where(data > 0)
@@ -76,14 +73,13 @@ def test_sparse_setitem(shape):
     assert_allclose(v[...], data)
 
 
-@pytest.mark.parametrize(('dtype_idx','dtype_val'),
+@pytest.mark.parametrize(('dtype_idx', 'dtype_val'),
                          [(np.int64, np.float64),
                           (np.int32, np.float64),
                           (np.int32, np.float32),
                           (np.int32, np.float64),
-                         ])
+                          ])
 def test_merge_sparse_arrays(dtype_idx, dtype_val):
-
     idx0 = np.array([0, 0, 1, 4], dtype=dtype_idx)
     val0 = np.array([1.0, 2.0, 3.0, 7.0], dtype=dtype_val)
     idx1 = np.array([0, 1, 2], dtype=dtype_idx)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -85,4 +85,4 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom1 = WcsGeom.from_header(hdulist[0].header, hdulist['BANDS'])
 
     assert_allclose(geom0.npix, geom1.npix)
-    assert(geom0.coordsys == geom1.coordsys)
+    assert (geom0.coordsys == geom1.coordsys)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
+from ..utils import fill_poisson
 from ..geom import MapAxis
 from ..wcs import WcsGeom
 from ..hpx import HpxGeom
@@ -45,7 +46,8 @@ def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m0 = WcsMapND(geom)
-    m0.fill_poisson(0.5)
+    coords = m0.geom.get_coords()
+    m0.set_by_coords(coords, coords[1])
     m1 = WcsMapND(geom, m0.data)
     assert_allclose(m0.data, m1.data)
 
@@ -58,7 +60,7 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     filename = str(tmpdir / 'skycube.fits')
     filename_sparse = str(tmpdir / 'skycube_sparse.fits')
     m0 = WcsMapND(geom)
-    m0.fill_poisson(0.5)
+    fill_poisson(m0, 0.5)
     m0.write(filename)
     m1 = WcsMapND.read(filename)
     assert_allclose(m0.data, m1.data)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -10,7 +10,6 @@ from ..wcs import WcsGeom
 from ..hpx import HpxGeom
 from ..wcsnd import WcsMapND
 
-
 pytest.importorskip('scipy')
 pytest.importorskip('reproject')
 
@@ -54,7 +53,6 @@ def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
-
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     filename = str(tmpdir / 'skycube.fits')
@@ -132,8 +130,7 @@ def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
         pytest.xfail('Bug in reproject version <= 0.3.1')
 
     if geom.ndim > 3 or geom.npix[0].size > 1:
-        pytest.xfail(
-            "> 3 dimensions or multi-resolution geometries not supported")
+        pytest.xfail("> 3 dimensions or multi-resolution geometries not supported")
 
     geom0 = WcsGeom.create(npix=npix, binsz=binsz, proj=proj,
                            skydir=skydir, coordsys=coordsys, axes=axes)
@@ -145,7 +142,6 @@ def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
 
 
 def test_wcsmapnd_reproject_allsky_car():
-
     geom = WcsGeom.create(binsz=10.0, proj='CAR', coordsys='CEL')
     m = WcsMapND(geom)
     coords = m.geom.get_coords()

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -60,7 +60,7 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     filename = str(tmpdir / 'skycube.fits')
     filename_sparse = str(tmpdir / 'skycube_sparse.fits')
     m0 = WcsMapND(geom)
-    fill_poisson(m0, 0.5)
+    fill_poisson(m0, mu=0.5)
     m0.write(filename)
     m1 = WcsMapND.read(filename)
     assert_allclose(m0.data, m1.data)

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,6 +1,25 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from astropy.io import fits
+
+
+def fill_poisson(map_in, mu):
+    """Fill a map object with a poisson random variable.
+
+    Parameters
+    ----------
+    map_in : `~gammapy.maps.MapBase`
+        Input map.
+
+    mu : scalar or `~numpy.ndarray`
+        Expectation value.
+
+    """
+
+    pix = map_in.geom.get_pixels()
+    mu = np.random.poisson(mu, len(pix[0]))
+    map_in.fill_by_idx(pix, mu)
 
 
 def swap_byte_order(arr_in):
@@ -69,12 +88,12 @@ def find_bands_hdu(hdulist, hdu):
     has_cube_data = False
 
     if (isinstance(hdu, (fits.ImageHDU, fits.PrimaryHDU)) and
-                hdu.header.get('NAXIS', None) == 3):
+            hdu.header.get('NAXIS', None) == 3):
         has_cube_data = True
     elif isinstance(hdu, fits.BinTableHDU):
 
         if (hdu.header.get('INDXSCHM', '') == 'IMPLICIT' and
-                    len(hdu.columns) > 1):
+                len(hdu.columns) > 1):
             has_cube_data = True
 
     if has_cube_data:

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -16,7 +16,6 @@ def swap_byte_order(arr_in):
     arr_out : `~numpy.ndarray`
         Array with native byte order.
     """
-
     if arr_in.dtype.byteorder not in ('=', '|'):
         return arr_in.byteswap().newbyteorder()
 
@@ -25,15 +24,16 @@ def swap_byte_order(arr_in):
 
 def interp_to_order(interp):
     """Convert interpolation string to order."""
-
     if isinstance(interp, int):
         return interp
 
-    order_map = {None: 0,
-                 'nearest': 0,
-                 'linear': 1,
-                 'quadratic': 2,
-                 'cubic': 3}
+    order_map = {
+        None: 0,
+        'nearest': 0,
+        'linear': 1,
+        'quadratic': 2,
+        'cubic': 3,
+    }
     return order_map.get(interp, None)
 
 
@@ -47,13 +47,10 @@ def unpack_seq(seq, n=1):
     ----------
     seq : list or tuple
         Input sequence to be unpacked.
-
     n : int
         Number of elements of ``seq`` to unpack.  Remaining elements
         are put into a single tuple.
-
     """
-
     for row in seq:
         yield [e for e in row[:n]] + [row[n:]]
 
@@ -72,12 +69,12 @@ def find_bands_hdu(hdulist, hdu):
     has_cube_data = False
 
     if (isinstance(hdu, (fits.ImageHDU, fits.PrimaryHDU)) and
-            hdu.header.get('NAXIS', None) == 3):
+                hdu.header.get('NAXIS', None) == 3):
         has_cube_data = True
     elif isinstance(hdu, fits.BinTableHDU):
 
         if (hdu.header.get('INDXSCHM', '') == 'IMPLICIT' and
-                len(hdu.columns) > 1):
+                    len(hdu.columns) > 1):
             has_cube_data = True
 
     if has_cube_data:
@@ -91,7 +88,6 @@ def find_bands_hdu(hdulist, hdu):
 
 def find_hdu(hdulist):
     """Find the first non-empty HDU."""
-
     for hdu in hdulist:
         if hdu.data is not None:
             return hdu
@@ -100,7 +96,6 @@ def find_hdu(hdulist):
 
 
 def find_image_hdu(hdulist):
-
     for hdu in hdulist:
         if hdu.data is not None and isinstance(hdu, fits.ImageHDU):
             return hdu
@@ -109,7 +104,6 @@ def find_image_hdu(hdulist):
 
 
 def find_bintable_hdu(hdulist):
-
     for hdu in hdulist:
         if hdu.data is not None and isinstance(hdu, fits.BinTableHDU):
             return hdu

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,24 +1,29 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numpy as np
 from astropy.io import fits
+from ..utils.random import get_random_state
 
 
-def fill_poisson(map_in, mu):
+def fill_poisson(map_in, mu, random_state='random-seed'):
     """Fill a map object with a poisson random variable.
+
+    This can be useful for testing, to make a simulated counts image.
+    E.g. filling with ``mu=0.5`` fills the map so that many pixels
+    have value 0 or 1, and a few more "counts".
 
     Parameters
     ----------
     map_in : `~gammapy.maps.MapBase`
-        Input map.
-
+        Input map
     mu : scalar or `~numpy.ndarray`
-        Expectation value.
-
+        Expectation value
+    random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+        Defines random number generator initialisation.
+        Passed to `~gammapy.utils.random.get_random_state`.
     """
-
+    random_state = get_random_state(random_state)
     pix = map_in.geom.get_pixels()
-    mu = np.random.poisson(mu, len(pix[0]))
+    mu = random_state.poisson(mu, len(pix[0]))
     map_in.fill_by_idx(pix, mu)
 
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -191,7 +191,9 @@ class WcsGeom(MapGeom):
     @classmethod
     def create(cls, npix=None, binsz=0.5, proj='CAR', coordsys='CEL', refpix=None,
                axes=None, skydir=None, width=None, conv=None):
-        """Create a WCS geometry object.  Pixelization of the map is set with
+        """Create a WCS geometry object.
+
+        Pixelization of the map is set with
         ``binsz`` and one of either ``npix`` or ``width`` arguments.
         For maps with non-spatial dimensions a different pixelization
         can be used for each image plane by passing a list or array
@@ -247,7 +249,6 @@ class WcsGeom(MapGeom):
         >>> geom = WcsGeom.create(npix=[100,200], binsz=[0.1,0.05], axes=[axis])
         >>> geom = WcsGeom.create(width=[5.0,8.0], binsz=[0.1,0.05], axes=[axis])
         >>> geom = WcsGeom.create(npix=([100,200],[100,200]), binsz=0.1, axes=[axis])
-
         """
         if skydir is None:
             xref, yref = (0.0, 0.0)
@@ -337,7 +338,6 @@ class WcsGeom(MapGeom):
         return cls(wcs, npix, cdelt=cdelt, axes=axes, conv=conv)
 
     def make_bands_hdu(self, extname=None, conv=None):
-
         conv = self._conv if conv is None else conv
         header = self.make_header(conv)
         axis_names = None
@@ -452,12 +452,10 @@ class WcsGeom(MapGeom):
 #        return tuple([np.ravel(np.broadcast_to(t,shape)[m]) for t in pix])
 
     def get_coords(self, idx=None):
-
         pix = self.get_pixels(idx=idx)
         return self.pix_to_coord(pix)
 
     def coord_to_pix(self, coords):
-
         c = MapCoords.create(coords)
 
         # Variable Bin Size
@@ -478,7 +476,6 @@ class WcsGeom(MapGeom):
         return pix
 
     def pix_to_coord(self, pix):
-
         # Variable Bin Size
         if self.axes and self.npix[0].size > 1:
             idxs = pix_tuple_to_idx([pix[2 + i] for i, ax
@@ -549,7 +546,6 @@ def create_wcs(skydir, coordsys='CEL', projection='AIT',
     axes : list
         List of non-spatial axes
     """
-
     naxis = 2
     if axes is not None:
         naxis += len(axes)
@@ -672,20 +668,15 @@ def pix2world(wcs, cdelt, crpix, pix):
     ----------
     wcs : `astropy.wcs.WCS`
         WCS transform object.
-
     cdelt : tuple
         Tuple of X/Y pixel size in deg.  Each element should have the
         same length as ``pix``.
-
     crpix : tuple
         Tuple of reference pixel parameters in X and Y dimensions.  Each
         element should have the same length as ``pix``.
-
     pix : tuple
         Tuple of pixel coordinates.
-
     """
-
     pix_ratio = [np.abs(wcs.wcs.cdelt[0] / cdelt[0]),
                  np.abs(wcs.wcs.cdelt[1] / cdelt[1])]
     pix = ((pix[0] - (crpix[0] - 1.0)) / pix_ratio[0] + wcs.wcs.crpix[0] - 1.0,
@@ -785,7 +776,7 @@ def wcs_to_coords(w, shape):
     elif w.naxis == 3:
         z, y, x = wcs_to_axes(w, shape)
     else:
-        raise Exception('WCS naxis must be 2 or 3. Got: {}'.format(w.naxis))
+        raise ValueError('WCS naxis must be 2 or 3. Got: {}'.format(w.naxis))
 
     x = 0.5 * (x[1:] + x[:-1])
     y = 0.5 * (y[1:] + y[:-1])

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -19,7 +19,6 @@ class WcsMap(MapBase):
     ----------
     geom : `~gammapy.maps.WcsGeom`
         A WCS geometry object.
-
     data : `~numpy.ndarray`
         Data array.
     """
@@ -126,7 +125,12 @@ class WcsMap(MapBase):
 
     def to_hdulist(self, extname=None, extname_bands=None, sparse=False,
                    conv=None):
+        """Convert to `~astropy.io.fits.HDUList`.
 
+        Parameters
+        ----------
+        TODO
+        """
         if sparse:
             extname = 'SKYMAP' if extname is None else extname.upper()
         else:
@@ -151,6 +155,7 @@ class WcsMap(MapBase):
 
         if self.geom.axes:
             hdulist += [bands_hdu]
+
         return fits.HDUList(hdulist)
 
     def make_hdu(self, extname='SKYMAP', extname_bands=None, sparse=False,

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -17,10 +17,11 @@ __all__ = [
 
 class WcsMapND(WcsMap):
     """Representation of a N+2D map using WCS with two spatial dimensions
-    and N non-spatial dimensions.  This class uses an ND numpy array
-    to store map values.  For maps with non-spatial dimensions and
-    variable pixel size it will allocate an array with dimensions
-    commensurate with the largest image plane.
+    and N non-spatial dimensions.
+
+    This class uses an ND numpy array to store map values. For maps with
+    non-spatial dimensions and variable pixel size it will allocate an
+    array with dimensions commensurate with the largest image plane.
 
     Parameters
     ----------
@@ -33,7 +34,6 @@ class WcsMapND(WcsMap):
     """
 
     def __init__(self, wcs, data=None, dtype='float32'):
-
         # TODO: Figure out how to mask pixels for integer data types
 
         shape = tuple([np.max(wcs.npix[0]), np.max(wcs.npix[1])] +
@@ -47,7 +47,6 @@ class WcsMapND(WcsMap):
         WcsMap.__init__(self, wcs, data)
 
     def _init_data(self, geom, shape, dtype):
-
         # Check whether corners of each image plane are valid
         coords = []
         if not geom.regular:
@@ -137,9 +136,7 @@ class WcsMapND(WcsMap):
 
     def interp_by_pix(self, pix, interp=None):
         """Interpolate map values at the given pixel coordinates.
-
         """
-
         if not self.geom.regular:
             raise ValueError('Pixel-based interpolation not supported for '
                              'non-regular geometries.')
@@ -155,7 +152,6 @@ class WcsMapND(WcsMap):
             raise ValueError('Invalid interpolation order: {}'.format(order))
 
     def _interp_by_pix_linear_grid(self, pix):
-
         # TODO: Cache interpolator
 
         from scipy.interpolate import RegularGridInterpolator
@@ -178,7 +174,6 @@ class WcsMapND(WcsMap):
         return map_coordinates(self.data.T, pix, order=order, mode='nearest')
 
     def _interp_by_coords_griddata(self, coords, interp=None):
-
         order = interp_to_order(interp)
         method_lookup = {1: 'linear', 3: 'cubic'}
         method = method_lookup.get(order, None)
@@ -197,7 +192,6 @@ class WcsMapND(WcsMap):
         return vals
 
     def interp_image(self, coords, order=1):
-
         if self.geom.ndim == 2:
             raise ValueError('Operation only supported for maps with one or more '
                              'non-spatial dimensions.')
@@ -208,7 +202,6 @@ class WcsMapND(WcsMap):
 
     def _interp_image_cube(self, coords, order=1):
         """Interpolate an image plane of a cube."""
-
         # TODO: consider re-writing to support maps with > 3 dimensions
 
         from scipy.interpolate import interp1d
@@ -269,7 +262,6 @@ class WcsMapND(WcsMap):
                                     buffersize=buffersize))
 
     def sum_over_axes(self):
-
         if self.geom.ndim == 2:
             return copy.deepcopy(self)
 
@@ -285,7 +277,6 @@ class WcsMapND(WcsMap):
         return map_out
 
     def _reproject_wcs(self, geom, mode='interp', order=1):
-
         from reproject import reproject_interp, reproject_exact
 
         map_out = WcsMapND(geom)
@@ -331,7 +322,6 @@ class WcsMapND(WcsMap):
         return map_out
 
     def _reproject_hpx(self, geom, mode='interp', order=1):
-
         from reproject import reproject_from_healpix, reproject_to_healpix
         from .hpxcube import HpxMapND
 
@@ -385,7 +375,6 @@ class WcsMapND(WcsMap):
         ----------
         norm : str
             Set the normalization scheme of the color map.
-
         idx : tuple
             Set the image slice to plot if this map has non-spatial
             dimensions.
@@ -394,15 +383,11 @@ class WcsMapND(WcsMap):
         -------
         fig : `~matplotlib.figure.Figure`
             Figure object.
-
         ax : `~astropy.visualization.wcsaxes.WCSAxes`
             WCS axis object
-
         im : `~matplotlib.image.AxesImage`
             Image object.
-
         """
-
         import matplotlib.pyplot as plt
         import matplotlib.colors as colors
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -233,6 +233,7 @@ class WcsMapND(WcsMap):
         msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
         idx = [t[msk] for t in idx]
         if weights is not None:
+            weights = np.asarray(weights)
             weights = weights[msk]
         idx = np.ravel_multi_index(idx, self.data.T.shape)
         idx, idx_inv = np.unique(idx, return_inverse=True)


### PR DESCRIPTION
This PR contains some minor code cleanup (mostly whitespace) in gammapy.maps.
It's just superficial stuff that I wanted to do separately from actual changes we're discussing like #1180 .

Two of the high-level docs examples about http://docs.gammapy.org/en/latest/maps/index.html#get-set-and-fill-methods raise an error for me:
* https://gist.github.com/cdeil/1e97aa0b0ddd9462dca43b78cdd57e32
* https://gist.github.com/cdeil/e2ac95d957a8a37b3912fd4f9c0face9

@woodmd - Can you please fix those? (push a commit here if you like)

I have two more small suggestions:

Use a property setter instead of a `set_name` method here?
http://docs.gammapy.org/en/latest/api/gammapy.maps.MapAxis.html#gammapy.maps.MapAxis.set_name

Get rid of the `fill_poisson` method here?http://docs.gammapy.org/en/latest/_modules/gammapy/maps/base.html#MapBase.fill_poisson
It looks out of place among all the other things in the base class.
(I think tests shouldn't use random data anyways unless there is a good reason for that, and the one use in the docs (see http://docs.gammapy.org/en/latest/maps/index.html#visualization) could be replaced with some real data example (like in other parts of the Gammapy docs: http://docs.gammapy.org/en/latest/notebooks/first_steps.html#Sky-images), or by showing the 3 lines of code to do such a random data filling from the outside, in that docs example.
