### PR TITLE
Add function to compute background cube

### DIFF
--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -333,9 +333,23 @@ class SkyCube(MapBase):
 
     @property
     def energy_width(self):
-        """Energy bin width vector (Quantity)"""
+        """Energy bin width vector (`~astropy.units.Quantity`)"""
         ebounds = self.energies(mode='edges')
         return ebounds[1:] - ebounds[:-1]
+
+    @property
+    def bin_size(self):
+        """Sky cube element bin size (`~astropy.units.Quantity`)
+
+        This is a convenience method which computes this::
+
+            cube.energy_width * cube.sky_image_ref.solid_angle()
+
+        Units could be "TeV" (or whatever ``energy_width`` returns) times "sr"
+        """
+        solid_angle = self.sky_image_ref.solid_angle()
+        de = self.energy_width
+        return solid_angle * de[:, np.newaxis, np.newaxis]
 
     def cutout(self, position, size):
         """Cut out rectangular piece of a cube.

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -58,10 +58,16 @@ def make_background_cube(pointing,
     """Calculate background predicted counts cube.
 
     This function evaluates the background rate model on
-    a sky cube, and then multiplies with
+    a sky cube, and then multiplies with the cube bin size,
+    computed via `gammapy.cube.SkyCube.bin_size`, resulting
+    in a cube with values that contain predicted background
+    counts per bin.
 
-    TODO: clarify if it should be livetime or obstime:
-    https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/issues/97
+    Note that this method isn't very precise if the energy
+    bins are large. In that case you might consider implementing
+    a more precise method that integrates over energy (e.g. by
+    choosing a finer energy binning here and then to group
+    energy bins).
 
     Parameters
     ----------
@@ -70,7 +76,7 @@ def make_background_cube(pointing,
     obstime : `~astropy.units.Quantity`
         Observation time
     bkg : `~gammapy.irf.Background3D`
-        Effective area table
+        Background rate model
     ref_cube : `~gammapy.cube.SkyCube`
         Reference cube used to define geometry
     offset_max : `~astropy.coordinates.Angle`
@@ -79,7 +85,7 @@ def make_background_cube(pointing,
     Returns
     -------
     background : `~gammapy.cube.SkyCube`
-        Background cube (3D)
+        Background predicted counts sky cube
     """
     coordinates = ref_cube.sky_image_ref.coordinates()
     offset = coordinates.separation(pointing)

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -12,7 +12,7 @@ def make_exposure_cube(pointing,
                        livetime,
                        aeff,
                        ref_cube,
-                       offset_max=None,
+                       offset_max,
                        ):
     """Calculate exposure cube.
 
@@ -53,7 +53,7 @@ def make_background_cube(pointing,
                          obstime,
                          bkg,
                          ref_cube,
-                         offset_max=None,
+                         offset_max,
                          ):
     """Calculate background predicted counts cube.
 

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -196,6 +196,14 @@ class TestSkyCubeInterpolation(object):
         integral = self.sky_cube.sky_image_integral(emin, emax)
         assert_quantity_allclose(integral.data, self.pwl.integral(emin, emax))
 
+    def test_bin_size(self):
+        bin_size = self.sky_cube.bin_size
+        assert bin_size.shape == (4, 3, 3)
+        assert bin_size.unit == 'TeV sr'
+
+        assert_allclose(bin_size.value[0, 0, 0], 2.6346694056569e-07)
+        assert_allclose(bin_size.value.sum(), 0.00010856564234889744)
+
     @requires_dependency('reproject')
     def test_reproject(self):
         emin = 1 * u.TeV

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -1,36 +1,75 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
+from numpy.testing import assert_allclose
+from astropy import units as u
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
-from ...irf import EffectiveAreaTable2D
-from .. import make_exposure_cube
+from ...irf import EffectiveAreaTable2D, Background3D
+from .. import make_exposure_cube, make_background_cube
 from .. import SkyCube
+
+
+@pytest.fixture(scope='session')
+def bkg_3d():
+    filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    return Background3D.read(filename, hdu='BACKGROUND')
+
+
+@pytest.fixture(scope='session')
+def aeff():
+    aeff_filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz'
+    return EffectiveAreaTable2D.read(aeff_filename, hdu='AEFF_2D')
+
+
+@pytest.fixture(scope='session')
+def counts_cube():
+    ccube_filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
+    return SkyCube.read(ccube_filename, format='fermi-counts')
 
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_exposure_cube():
-    aeff_filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz'
-    ccube_filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
-
+def test_exposure_cube(aeff, counts_cube):
     pointing = SkyCoord(83.633, 21.514, unit='deg')
     livetime = Quantity(1581.17, 's')
-    aeff = EffectiveAreaTable2D.read(aeff_filename, hdu='AEFF_2D')
-    count_cube = SkyCube.read(ccube_filename, format='fermi-counts')
     offset_max = Angle(2.2, 'deg')
 
     exp_cube = make_exposure_cube(
-        pointing, livetime, aeff, count_cube, offset_max=offset_max,
+        pointing, livetime, aeff, counts_cube, offset_max=offset_max,
     )
     exp_ref = Quantity(4.7e8, 'm2 s')
     coordinates = exp_cube.sky_image_ref.coordinates()
     offset = coordinates.separation(pointing)
 
-    assert np.shape(exp_cube.data)[1:] == np.shape(count_cube.data)[1:]
-    assert np.shape(exp_cube.data)[0] == np.shape(count_cube.data)[0]
-    assert exp_cube.wcs == count_cube.wcs
+    assert np.shape(exp_cube.data)[1:] == np.shape(counts_cube.data)[1:]
+    assert np.shape(exp_cube.data)[0] == np.shape(counts_cube.data)[0]
+    assert exp_cube.wcs == counts_cube.wcs
     assert_quantity_allclose(np.nanmax(exp_cube.data), exp_ref, rtol=100)
     assert exp_cube.data.unit == exp_ref.unit
     assert exp_cube.data[:, offset > offset_max].sum() == 0
+
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_background_cube(bkg_3d, counts_cube):
+    pointing = SkyCoord(83.633, 21.514, unit='deg')
+    livetime = Quantity(1581.17, 's')
+    offset_max = Angle(2.2, 'deg')
+
+    bkg_cube = make_background_cube(
+        pointing, livetime, bkg_3d, counts_cube, offset_max=offset_max,
+    )
+
+    assert bkg_cube.data.shape == (15, 120, 200)
+    assert bkg_cube.data.unit == ''
+
+    assert_allclose(bkg_cube.data[0, 0, 0], 0.014835371179768773)
+    assert_allclose(bkg_cube.data.sum(), 1359.1700828673065)
+
+    # Check that `offset_max` is working properly
+    pos = SkyCoord(85.6, 23, unit='deg')
+    val = bkg_cube.lookup(pos, energy=1 * u.TeV)
+    assert_allclose(val, 0)

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -111,12 +111,10 @@ def compute_npred_cube_simple(flux_cube, exposure_cube):
     """
     _validate_inputs(flux_cube, exposure_cube)
 
-    solid_angle = exposure_cube.sky_image_ref.solid_angle()
-    # TODO: is this OK? Exposure cube has no `ebounds`, only `ecenter`, but npred needs `ebounds`, no?
-    de = exposure_cube.energy_width
+    bin_size = exposure_cube.bin_size
     flux = flux_cube.data
     exposure = exposure_cube.data
-    npred = flux * exposure * solid_angle * de[:, np.newaxis, np.newaxis]
+    npred = flux * exposure * bin_size
 
     npred_cube = SkyCube.empty_like(exposure_cube)
     npred_cube.data = npred.to('')

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -100,8 +100,8 @@ class HDULocation(object):
             from ..background import EnergyOffsetArray
             return EnergyOffsetArray.read(filename, hdu=hdu_name, data_name='bkg')
         elif hdu_class == 'bkg_3d':
-            from ..background import FOVCube
-            return FOVCube.read(filename, hdu=hdu_name)
+            from ..irf import Background3D
+            return Background3D.read(filename, hdu=hdu_name)
         else:
             raise ValueError('Invalid hdu_class: {}'.format(hdu_class))
 


### PR DESCRIPTION
This PR adds a helper function `make_background_cube`, which fills a background cube model into a SkyCube. We also add a `bin_size` property to `SkyCube`, which gives the sky cube cell bin size, i.e. energy width times solid angle. This is continuing the work started in #1162 where the `gammapy.irf.Background3D` class was added.

We plan to change to `gammapy.maps` for these functions and cube analysis soon, but while that is still under development we continue with `SkyCube` for now.

The goal for the next days is to get a CTA GPS background model image using these background models.

Pair coding with @robertazanin .

cc @adonath @bkhelifi 