### PR TITLE
Change TablePSF.kernel input from containment fraction to radius

### DIFF
--- a/gammapy/cube/tests/test_utils.py
+++ b/gammapy/cube/tests/test_utils.py
@@ -47,7 +47,7 @@ def test_compute_npred_cube():
 
     # Convolve with Energy-dependent Fermi LAT PSF
     psf = fermi_vela.psf()
-    kernels = psf.kernels(npred_cube)
+    kernels = psf.kernels(npred_cube, rad_max=2 * u.deg)
     convolved_npred_cube = npred_cube.convolve(kernels)
 
     actual = convolved_npred_cube.data.value.sum()

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -44,7 +44,8 @@ class TestKernelBackgroundEstimator(object):
         psf = FermiGalacticCenter.psf()
         erange = [10, 500] * u.GeV
         psf = psf.table_psf_in_energy_band(erange)
-        kernel_array = psf.kernel(images['counts'])
+        rad_max = psf.containment_radius(0.99)
+        kernel_array = psf.kernel(images['counts'], rad_max=rad_max)
 
         images['counts'] = images['counts'].convolve(kernel_array, mode='constant')
         return images

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -336,6 +336,8 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
         Upper bound of energy range.
     spectral_model : `~gammapy.spectrum.models.SpectralModel`
         Spectral model assumption to compute mean exposure and psf images.
+    rad_max : `~astropy.coordinates.Angle`
+        PSF kernel size, passed to :func:`gammapy.irf.TablePSF.kernel`
 
     Examples
     --------
@@ -361,11 +363,13 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
         result['counts'].show()
     """
 
-    def __init__(self, reference, emin, emax, spectral_model=None):
+    def __init__(self, reference, emin, emax, spectral_model=None,
+                 rad_max=1 * u.deg):
         self.parameters = OrderedDict(emin=emin, emax=emax)
         self.reference = reference
         if spectral_model is None:
             self.spectral_model = self._default_spectral_model
+        self.rad_max = rad_max
 
     def counts(self, dataset):
         """

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -478,7 +478,7 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
 
         # convolve with PSF kernel
         psf_mean = psf.table_psf_in_energy_band(energy_band, spectrum=self.spectral_model)
-        kernel = psf_mean.kernel(npred_total)
+        kernel = psf_mean.kernel(npred_total, rad_max=self.rad_max)
         npred_total = npred_total.convolve(kernel)
         return npred_total
 

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -365,11 +365,10 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
 
     def __init__(self, reference, emin, emax, spectral_model=None,
                  rad_max=1 * u.deg):
-        self.parameters = OrderedDict(emin=emin, emax=emax)
+        self.parameters = OrderedDict(emin=emin, emax=emax, rad_max=rad_max)
         self.reference = reference
         if spectral_model is None:
             self.spectral_model = self._default_spectral_model
-        self.rad_max = rad_max
 
     def counts(self, dataset):
         """
@@ -478,7 +477,8 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
 
         # convolve with PSF kernel
         psf_mean = psf.table_psf_in_energy_band(energy_band, spectrum=self.spectral_model)
-        kernel = psf_mean.kernel(npred_total, rad_max=self.rad_max)
+        kernel = psf_mean.kernel(npred_total,
+                                 rad_max=self.parameters['rad_max'])
         npred_total = npred_total.convolve(kernel)
         return npred_total
 

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -520,12 +520,13 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
         exposure.name = 'exposure'
         return exposure.reproject(self.reference)
 
-    def _psf_image(self, dataset, nxpix=101, nypix=101, binsz=0.02):
+    def _psf_image(self, dataset, binsz=0.02):
         """
         Compute fermi PSF image.
         """
         p = self.parameters
-        psf_image = SkyImage.empty(nxpix=nxpix, nypix=nypix, binsz=binsz)
+        npix = p['rad_max'].deg / binsz
+        psf_image = SkyImage.empty(nxpix=npix, nypix=npix, binsz=binsz)
 
         psf = dataset.psf
         erange = u.Quantity((p['emin'], p['emax']))

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -174,6 +174,7 @@ class TablePSF(object):
             Kernel 2D image of Quantities
         """
         from ..cube import SkyCube
+        rad_max = Angle(rad_max)
 
         if isinstance(reference, SkyCube):
             reference = reference.sky_image_ref

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -151,7 +151,7 @@ class TablePSF(object):
         rad = center.separation(point)
         return self.evaluate(rad)
 
-    def kernel(self, reference, containment=0.99, normalize=True,
+    def kernel(self, reference, rad_max, normalize=True,
                discretize_model_kwargs=dict(factor=10)):
         """
         Make a 2-dimensional kernel image.
@@ -163,8 +163,8 @@ class TablePSF(object):
         ----------
         reference : `~gammapy.image.SkyImage` or `~gammapy.cube.SkyCube`
             Reference sky image or sky cube defining the spatial grid.
-        containment : float
-            Minimal containment fraction of the kernel image.
+        rad_max : `~astropy.coordinates.Angle`
+            Radial size of the kernel
         normalize : bool
             Whether to normalize the kernel.
 
@@ -174,7 +174,6 @@ class TablePSF(object):
             Kernel 2D image of Quantities
         """
         from ..cube import SkyCube
-        rad_max = self.containment_radius(containment)
 
         if isinstance(reference, SkyCube):
             reference = reference.sky_image_ref
@@ -586,7 +585,8 @@ class EnergyDependentTablePSF(object):
             energy_band = Quantity([emin, emax])
             try:
                 psf = self.table_psf_in_energy_band(energy_band, **kwargs)
-                kernel = psf.kernel(cube.sky_image_ref)
+                rad_max = psf.containment_radius(0.99)
+                kernel = psf.kernel(cube.sky_image_ref, rad_max=rad_max)
             except ValueError:
                 kernel = np.nan * np.ones((1, 1))  # Dummy, means "no kernel available"
             kernels.append(kernel)

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -112,7 +112,8 @@ def test_EnergyDependentTablePSF():
     psf_band = psf.table_psf_in_energy_band(energy_band)
 
     ref = SkyImage.empty(binsz=0.1)
-    actual = psf_band.kernel(ref, normalize=True).value.sum()
+    rad_max = psf_band.containment_radius(0.99)
+    actual = psf_band.kernel(ref, normalize=True, rad_max=rad_max).value.sum()
     assert_allclose(actual, desired)
 
 


### PR DESCRIPTION
Follow up on #1171 , expecially https://github.com/gammapy/gammapy/pull/1171#issuecomment-337863691

This PR changes in input of ``TablePSF.kernel`` from ``containment_radius`` to ``rad_max``. This is more generic, one can always get ``rad_max`` from ``TablePSF.containment_radius`` in one line before calling ``kernel``.

The improvement is that instabilities in ``TablePSF.containment_radius`` can be avoided, by defining an a priori kernel size