### PR TITLE
More uniform naming with idx and pix in gammapy.maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -32,8 +32,8 @@ class MapBase(object):
     """
 
     def __init__(self, geom, data):
-        self._data = data
         self._geom = geom
+        self._data = data
 
     @property
     def data(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -745,7 +745,7 @@ class MapGeom(object):
         pass
 
     @abc.abstractmethod
-    def get_pixels(self, idx=None, local=False):
+    def get_idx(self, idx=None, local=False):
         """Get tuple of pixel indices for this geometry.
 
         Returns all pixels in the geometry by default. Pixel indices
@@ -767,7 +767,7 @@ class MapGeom(object):
 
         Returns
         -------
-        pix : tuple
+        idx : tuple
             Tuple of pixel index vectors with one vector for each
             dimension.
         """

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -282,10 +282,12 @@ def make_hpx_to_wcs_mapping(hpx, wcs):
     ipix = -1 * np.ones((len(hpx.nside), int(npix[0] * npix[1])), int)
     m = mask[None, :] * np.ones_like(ipix, dtype=bool)
 
-    ipix[m] = hp.pixelfunc.ang2pix(hpx.nside[..., None],
-                                   sky_crds[:, 1][mask][None, ...],
-                                   sky_crds[:, 0][mask][None, ...],
-                                   hpx.nest).flatten()
+    ipix[m] = hp.ang2pix(
+        hpx.nside[..., None],
+        sky_crds[:, 1][mask][None, ...],
+        sky_crds[:, 0][mask][None, ...],
+         hpx.nest,
+    ).flatten()
 
     # Here we are counting the number of HEALPIX pixels each WCS pixel
     # points to and getting a multiplicative factor that tells use how

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -26,7 +26,7 @@ class HpxMap(MapBase):
     """
 
     def __init__(self, geom, data):
-        MapBase.__init__(self, geom, data)
+        super(HpxMap, self).__init__(geom, data)
         self._wcs2d = None
         self._hpx2wcs = None
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -293,8 +293,8 @@ class HpxMapND(HpxMap):
         else:
             nside = self.geom.nside
 
-        pix, wts = hp.pixelfunc.get_interp_weights(nside, theta,
-                                                   phi, nest=self.geom.nest)
+        pix, wts = hp.get_interp_weights(nside, theta,
+                                         phi, nest=self.geom.nest)
 
         if self.geom.nside.size > 1:
             pix_local = [self.geom.global_to_local([pix] + list(idxs))[0]]
@@ -523,7 +523,7 @@ class HpxMapND(HpxMap):
         pix = self.geom.get_pixels()
         vtx = hp.boundaries(self.geom.nside, pix[0],
                             nest=self.geom.nest, step=step)
-        theta, phi = hp.pixelfunc.vec2ang(np.rollaxis(vtx, 2))
+        theta, phi = hp.vec2ang(np.rollaxis(vtx, 2))
         theta = theta.reshape((4 * step, -1)).T
         phi = phi.reshape((4 * step, -1)).T
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -46,7 +46,7 @@ class HpxMapND(HpxMap):
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
 
-        HpxMap.__init__(self, geom, data)
+        super(HpxMapND, self).__init__(geom, data)
         self._wcs2d = None
         self._hpx2wcs = None
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -34,7 +34,7 @@ class HpxMapSparse(HpxMap):
         elif isinstance(data, np.ndarray):
             data = SparseArray.from_array(data)
 
-        HpxMap.__init__(self, geom, data)
+        super(HpxMapSparse, self).__init__(geom, data)
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 
-def _get_input_pixels_celestial(wcs_in, wcs_out, shape_out):
+def _get_input_pix_celestial(wcs_in, wcs_out, shape_out):
     """
     Get the pixel coordinates of the pixels in an array of shape ``shape_out``
     in the input WCS.
@@ -83,9 +83,9 @@ def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
     array_new = np.zeros(shape_out)
     slice_out = array_new
 
-    xp_in, yp_in = _get_input_pixels_celestial(wcs_in.celestial,
-                                               wcs_out.celestial,
-                                               slice_out.shape)
+    xp_in, yp_in = _get_input_pix_celestial(wcs_in.celestial,
+                                            wcs_out.celestial,
+                                            slice_out.shape)
     coordinates = np.array([yp_in.ravel(), xp_in.ravel()])
 
     jmin, imin = np.floor(np.nanmin(coordinates, axis=1)).astype(int) - 1

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from ..geom import MapAxis
-from ..hpx import HpxGeom, get_pixel_size_from_nside, nside_to_order, lonlat_to_colat
+from ..hpx import HpxGeom, get_pix_size_from_nside, nside_to_order, lonlat_to_colat
 from ..hpx import make_hpx_to_wcs_mapping, unravel_hpx_index, ravel_hpx_index
 
 pytest.importorskip('scipy')
@@ -122,14 +122,14 @@ def test_hpx_global_to_local():
 def test_hpxgeom_init_with_pix(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
 
-    pix0 = geom.get_pixels()
-    pix1 = tuple([t[::10] for t in pix0])
-    geom = HpxGeom(nside, nested, coordsys, region=pix0, axes=axes)
-    assert_allclose(pix0, geom.get_pixels())
-    assert_allclose(len(pix0[0]), np.sum(geom.npix))
-    geom = HpxGeom(nside, nested, coordsys, region=pix1, axes=axes)
-    assert_allclose(pix1, geom.get_pixels())
-    assert_allclose(len(pix1[0]), np.sum(geom.npix))
+    idx0 = geom.get_idx()
+    idx1 = tuple([t[::10] for t in idx0])
+    geom = HpxGeom(nside, nested, coordsys, region=idx0, axes=axes)
+    assert_allclose(idx0, geom.get_idx())
+    assert_allclose(len(idx0[0]), np.sum(geom.npix))
+    geom = HpxGeom(nside, nested, coordsys, region=idx1, axes=axes)
+    assert_allclose(idx1, geom.get_idx())
+    assert_allclose(len(idx1[0]), np.sum(geom.npix))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
@@ -141,42 +141,42 @@ def test_hpxgeom_to_slice(nside, nested, coordsys, region, axes):
     assert_allclose(geom_slice.ndim, 2)
     assert_allclose(geom_slice.npix, np.squeeze(geom.npix[slices]))
 
-    pix = geom.get_pixels()
-    pix_slice = geom_slice.get_pixels()
+    idx = geom.get_idx()
+    idx_slice = geom_slice.get_idx()
     if geom.ndim > 2:
-        m = np.all([np.in1d(t, [1]) for t in pix[1:]], axis=0)
-        assert_allclose(pix_slice, (pix[0][m],))
+        m = np.all([np.in1d(t, [1]) for t in idx[1:]], axis=0)
+        assert_allclose(idx_slice, (idx[0][m],))
     else:
-        assert_allclose(pix_slice, pix)
+        assert_allclose(idx_slice, idx)
 
     # Test slicing with explicit geometry
     geom = HpxGeom(nside, nested, coordsys, region=tuple(
-        [t[::10] for t in pix]), axes=axes)
+        [t[::10] for t in idx]), axes=axes)
     geom_slice = geom.to_slice(slices)
     assert_allclose(geom_slice.ndim, 2)
     assert_allclose(geom_slice.npix, np.squeeze(geom.npix[slices]))
 
-    pix = geom.get_pixels()
-    pix_slice = geom_slice.get_pixels()
+    idx = geom.get_idx()
+    idx_slice = geom_slice.get_idx()
     if geom.ndim > 2:
-        m = np.all([np.in1d(t, [1]) for t in pix[1:]], axis=0)
-        assert_allclose(pix_slice, (pix[0][m],))
+        m = np.all([np.in1d(t, [1]) for t in idx[1:]], axis=0)
+        assert_allclose(idx_slice, (idx[0][m],))
     else:
-        assert_allclose(pix_slice, pix)
+        assert_allclose(idx_slice, idx)
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
-def test_hpxgeom_get_pixels(nside, nested, coordsys, region, axes):
+def test_hpxgeom_get_pix(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
-    pix = geom.get_pixels(local=False)
-    pix_local = geom.get_pixels(local=True)
-    assert_allclose(pix, geom.local_to_global(pix_local))
+    idx = geom.get_idx(local=False)
+    idx_local = geom.get_idx(local=True)
+    assert_allclose(idx, geom.local_to_global(idx_local))
 
     if axes is not None:
-        pix_img = geom.get_pixels(local=False, idx=tuple([1] * len(axes)))
-        pix_img_local = geom.get_pixels(local=True, idx=tuple([1] * len(axes)))
-        assert_allclose(pix_img, geom.local_to_global(pix_img_local))
+        idx_img = geom.get_idx(local=False, idx=tuple([1] * len(axes)))
+        idx_img_local = geom.get_idx(local=True, idx=tuple([1] * len(axes)))
+        assert_allclose(idx_img, geom.local_to_global(idx_img_local))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
@@ -268,8 +268,8 @@ def test_hpx_nside_to_order():
                     order.reshape((2, 5)))
 
 
-def test_hpx_get_pixel_size_from_nside():
-    assert_allclose(get_pixel_size_from_nside(np.array([1, 2, 4])),
+def test_hpx_get_pix_size_from_nside():
+    assert_allclose(get_pix_size_from_nside(np.array([1, 2, 4])),
                     np.array([32.0, 16.0, 8.0]))
 
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -92,9 +92,9 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
 def test_hpxmap_set_get_by_pix(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
     coords = m.geom.get_coords()
-    pix = m.geom.get_pixels()
-    m.set_by_pix(pix, coords[0])
-    assert_allclose(coords[0], m.get_by_pix(pix))
+    idx = m.geom.get_idx()
+    m.set_by_pix(idx, coords[0])
+    assert_allclose(coords[0], m.get_by_pix(idx))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -42,13 +42,13 @@ def test_wcsgeom_init(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsgeom_get_pixels(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsgeom_get_pix(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    pix = geom.get_pixels()
+    pix = geom.get_idx()
     if axes is not None:
         idx = tuple([1] * len(axes))
-        pix_img = geom.get_pixels(idx=idx)
+        pix_img = geom.get_idx(idx=idx)
         m = np.all(np.stack([x == y for x, y in zip(idx, pix[2:])]), axis=0)
         assert_allclose(pix[0][m], pix_img[0])
         assert_allclose(pix[1][m], pix_img[1])
@@ -60,7 +60,7 @@ def test_wcsgeom_test_pix_to_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     assert_allclose(geom.get_coords()[0],
-                    geom.pix_to_coord(geom.get_pixels())[0])
+                    geom.pix_to_coord(geom.get_idx())[0])
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
@@ -68,7 +68,7 @@ def test_wcsgeom_test_pix_to_coord(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
-    assert_allclose(geom.get_pixels()[0],
+    assert_allclose(geom.get_idx()[0],
                     geom.coord_to_idx(geom.get_coords())[0])
 
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -76,7 +76,7 @@ def test_wcsmapnd_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsMapND(geom)
     coords = m.geom.get_coords()
-    pix = m.geom.get_pixels()
+    pix = m.geom.get_idx()
     m.set_by_pix(pix, coords[0])
     assert_allclose(coords[0], m.get_by_pix(pix))
 

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -22,9 +22,9 @@ def fill_poisson(map_in, mu, random_state='random-seed'):
         Passed to `~gammapy.utils.random.get_random_state`.
     """
     random_state = get_random_state(random_state)
-    pix = map_in.geom.get_pixels()
-    mu = random_state.poisson(mu, len(pix[0]))
-    map_in.fill_by_idx(pix, mu)
+    idx = map_in.geom.get_idx()
+    mu = random_state.poisson(mu, len(idx[0]))
+    map_in.fill_by_idx(idx, mu)
 
 
 def swap_byte_order(arr_in):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -392,7 +392,7 @@ class WcsGeom(MapGeom):
     def get_image_wcs(self, idx):
         raise NotImplementedError
 
-    def get_pixels(self, idx=None, local=False):
+    def get_idx(self, idx=None, local=False):
         return pix_tuple_to_idx(self._get_pix_coords(idx=idx,
                                                      mode='center'))
 
@@ -452,7 +452,7 @@ class WcsGeom(MapGeom):
 #        return tuple([np.ravel(np.broadcast_to(t,shape)[m]) for t in pix])
 
     def get_coords(self, idx=None):
-        pix = self.get_pixels(idx=idx)
+        pix = self.get_idx(idx=idx)
         return self.pix_to_coord(pix)
 
     def coord_to_pix(self, coords):

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -23,9 +23,6 @@ class WcsMap(MapBase):
         Data array.
     """
 
-    def __init__(self, geom, data=None):
-        MapBase.__init__(self, geom, data)
-
     @classmethod
     def create(cls, map_type=None, npix=None, binsz=0.1, width=None,
                proj='CAR', coordsys='CEL', refpix=None,

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -76,8 +76,8 @@ class WcsMapND(WcsMap):
                          slice(geom.npix[1][idx])] = 0.0
         else:
             data = np.nan * np.ones(shape, dtype=dtype).T
-            pix = geom.get_pixels()
-            data[pix[::-1]] = 0.0
+            idx = geom.get_idx()
+            data[idx[::-1]] = 0.0
 
         return data
 
@@ -246,7 +246,7 @@ class WcsMapND(WcsMap):
             yield self.data[idx[::-1]], idx
 
     def iter_by_pix(self, buffersize=1):
-        pix = list(self.geom.get_pixels())
+        pix = list(self.geom.get_idx())
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + pix,
                                     flags=['external_loop', 'buffered'],
@@ -265,7 +265,7 @@ class WcsMapND(WcsMap):
 
         map_out = self.__class__(self.geom.to_image())
         if self.geom.npix[0].size > 1:
-            vals = self.get_by_idx(self.geom.get_pixels())
+            vals = self.get_by_idx(self.geom.get_idx())
             map_out.fill_by_coords(self.geom.get_coords()[:2], vals)
         else:
             data = np.apply_over_axes(np.sum, self.data,

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -44,7 +44,7 @@ class WcsMapND(WcsMap):
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
 
-        WcsMap.__init__(self, geom, data)
+        super(WcsMapND, self).__init__(geom, data)
 
     def _init_data(self, geom, shape, dtype):
         # Check whether corners of each image plane are valid


### PR DESCRIPTION
This PR contains some small cleanup already discussed with @woodmd  on Slack for gammapy.maps. The main change is some renames "pixel" -> "pix"  (consistenly use "pix") and a rename of "get_pix" -> "get_idx" (more consistently use "idx" for integer indices that can be used to index into Numpy arrays, and reserve "pix" for cases where float pixel coordinates can happen).

@woodmd - Please review, and if you have time - please directly fix any remaining cases or if I messed up some case, please revert. Note that this is mostly the result of "rename" and multi-file "replace" in PyCharm, the diff really needs to be reviewed.

One thing I noticed is `skydir_to_pix`, which ends with `pix_to_coord`. Is this a bug? Should this method be renamed, e.g. to `skycoord_to_coord`?