### PR TITLE
Refactor gammapy.maps methods for calculating index and coordinate arrays

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -187,11 +187,14 @@ def pix_tuple_to_idx(pix, copy=False):
     """
     idx = []
     for i, p in enumerate(pix):
-        p = np.array(p, copy=copy)
+        p = np.array(p, copy=copy, ndmin=1)
         if np.issubdtype(p.dtype, np.integer):
             idx += [p]
         else:
-            idx += [np.rint(p).astype(int)]
+            #idx += [np.rint(p).astype(int)]
+            p_idx = np.rint(p).astype(int)
+            p_idx[~np.isfinite(p)] = -1
+            idx += [p_idx]
     return tuple(idx)
 
 
@@ -745,7 +748,7 @@ class MapGeom(object):
         pass
 
     @abc.abstractmethod
-    def get_idx(self, idx=None, local=False):
+    def get_idx(self, idx=None, local=False, flat=False):
         """Get tuple of pixel indices for this geometry.
 
         Returns all pixels in the geometry by default. Pixel indices
@@ -765,6 +768,10 @@ class MapGeom(object):
             indices run from 0 to the number of pixels in a given
             image plane.
 
+        flat : bool, optional
+            Return a flattened array containing only indices for
+            pixels contained in the geometry.
+
         Returns
         -------
         idx : tuple
@@ -774,10 +781,11 @@ class MapGeom(object):
         pass
 
     @abc.abstractmethod
-    def get_coords(self, idx=None):
-        """Get the coordinates of all the pixels in this geometry.
+    def get_coords(self, idx=None, flat=False):
+        """Get the coordinate array for this geometry.
 
-        Returns coordinates for all pixels in the geometry by default.
+        Returns a coordinate array with the same shape as the data
+        array.  Pixels outside the geometry are set to NaN.
         Coordinates for a single image plane can be accessed by
         setting ``idx`` to the index tuple of a plane.
 
@@ -789,11 +797,16 @@ class MapGeom(object):
             plane with this index will be returned.  If none then
             coordinates for all pixels will be returned.
 
+        flat : bool, optional
+            Return a flattened array containing only coordinates for
+            pixels contained in the geometry.
+
         Returns
         -------
         coords : tuple
             Tuple of coordinate vectors with one vector for each
             dimension.
+
         """
         pass
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -195,7 +195,7 @@ class HpxMap(MapBase):
         extname_bands = conv.bands_hdu
 
         sparse = kwargs.get('sparse', True if isinstance(self, HpxMapSparse)
-        else False)
+                            else False)
         header = self.geom.make_header()
 
         if self.geom.axes:

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -119,7 +119,7 @@ class HpxMapND(HpxMap):
         self._wcs_proj = proj
         self._wcs_oversample = oversample
         self._wcs2d = self.geom.make_wcs(proj=proj, oversample=oversample,
-                                        drop_axes=True)
+                                         drop_axes=True)
         self._hpx2wcs = HpxToWcsMapping.create(self.geom, self._wcs2d)
 
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
@@ -143,16 +143,16 @@ class HpxMapND(HpxMap):
             wcs_shape = tuple([t.flat[0] for t in self._hpx2wcs.npix])
             wcs_data = np.zeros(wcs_shape).T
             wcs = self.geom.make_wcs(proj=proj,
-                                    oversample=oversample,
-                                    drop_axes=True)
+                                     oversample=oversample,
+                                     drop_axes=True)
         else:
             hpx_data = self.data
             wcs_shape = tuple([t.flat[0] for t in
                                self._hpx2wcs.npix]) + self.geom._shape
             wcs_data = np.zeros(wcs_shape).T
             wcs = self.geom.make_wcs(proj=proj,
-                                    oversample=oversample,
-                                    drop_axes=False)
+                                     oversample=oversample,
+                                     drop_axes=False)
 
         # FIXME: Should reimplement instantiating map first and fill data array
 
@@ -168,14 +168,14 @@ class HpxMapND(HpxMap):
             yield self.data[idx[::-1]], idx
 
     def iter_by_pix(self, buffersize=1):
-        idx = list(self.geom.get_idx())
+        idx = list(self.geom.get_idx(flat=True))
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + idx,
                                     flags=['external_loop', 'buffered'],
                                     buffersize=buffersize))
 
     def iter_by_coords(self, buffersize=1):
-        coords = list(self.geom.get_coords())
+        coords = list(self.geom.get_coords(flat=True))
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + coords,
                                     flags=['external_loop', 'buffered'],
@@ -194,8 +194,8 @@ class HpxMapND(HpxMap):
         map_out = self.__class__(hpx_out)
 
         if self.geom.nside.size > 1:
-            vals = self.get_by_idx(self.geom.get_idx())
-            map_out.fill_by_coords(self.geom.get_coords()[:2], vals)
+            vals = self.get_by_idx(self.geom.get_idx(flat=True))
+            map_out.fill_by_coords(self.geom.get_coords(flat=True)[:2], vals)
         else:
             axes = np.arange(self.data.ndim - 1).tolist()
             data = np.apply_over_axes(np.sum, self.data, axes=axes)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -91,8 +91,8 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
                          hpx_test_geoms_sparse)
 def test_hpxmap_set_get_by_pix(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords()
-    idx = m.geom.get_idx()
+    coords = m.geom.get_coords(flat=True)
+    idx = m.geom.get_idx(flat=True)
     m.set_by_pix(idx, coords[0])
     assert_allclose(coords[0], m.get_by_pix(idx))
 
@@ -101,7 +101,7 @@ def test_hpxmap_set_get_by_pix(nside, nested, coordsys, region, axes, sparse):
                          hpx_test_geoms_sparse)
 def test_hpxmap_set_get_by_coords(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     m.set_by_coords(coords, coords[0])
     assert_allclose(coords[0], m.get_by_coords(coords))
 
@@ -122,7 +122,7 @@ def test_hpxmap_get_by_coords_interp(nside, nested, coordsys, region, axes):
                          hpx_test_geoms_sparse)
 def test_hpxmap_fill_by_coords(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     m.fill_by_coords(coords, coords[1])
     m.fill_by_coords(coords, coords[1])
     assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])
@@ -133,7 +133,7 @@ def test_hpxmap_fill_by_coords(nside, nested, coordsys, region, axes, sparse):
 def test_hpxmap_iter(nside, nested, coordsys, region, axes):
     m = HpxMapND(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     m.fill_by_coords(coords, coords[0])
     for vals, pix in m.iter_by_pix(buffersize=100):
         assert_allclose(vals, m.get_by_pix(pix))
@@ -157,7 +157,7 @@ def test_hpxmap_swap_scheme(nside, nested, coordsys, region, axes):
                          coordsys=coordsys, region=region, axes=axes))
     fill_poisson(m, mu=1.0, random_state=0)
     m2 = m.to_swapped_scheme()
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     assert_allclose(m.get_by_coords(coords), m2.get_by_coords(coords))
 
 
@@ -174,6 +174,6 @@ def test_hpxmap_ud_grade(nside, nested, coordsys, region, axes):
 def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
     m = HpxMapND(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     m.fill_by_coords(coords, coords[0])
     msum = m.sum_over_axes()

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -50,8 +50,9 @@ def test_wcsgeom_get_pix(npix, binsz, coordsys, proj, skydir, axes):
         idx = tuple([1] * len(axes))
         pix_img = geom.get_idx(idx=idx)
         m = np.all(np.stack([x == y for x, y in zip(idx, pix[2:])]), axis=0)
-        assert_allclose(pix[0][m], pix_img[0])
-        assert_allclose(pix[1][m], pix_img[1])
+        m2 = pix_img[0] != -1
+        assert_allclose(pix[0][m], np.ravel(pix_img[0][m2]))
+        assert_allclose(pix[1][m], np.ravel(pix_img[1][m2]))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
@@ -100,6 +101,7 @@ def test_wcsgeom_contains(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     coords = geom.get_coords()
+    coords = [c[np.isfinite(c)] for c in coords]
     assert_allclose(geom.contains(coords),
                     np.ones(coords[0].shape, dtype=bool))
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -115,7 +115,7 @@ def test_wcsmapnd_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsMapND(geom)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     m.set_by_coords(coords, coords[1])
     assert_allclose(coords[1], m.get_by_coords(coords, interp='nearest'))
     assert_allclose(coords[1], m.get_by_coords(coords, interp='linear'))

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -22,8 +22,8 @@ def fill_poisson(map_in, mu, random_state='random-seed'):
         Passed to `~gammapy.utils.random.get_random_state`.
     """
     random_state = get_random_state(random_state)
-    idx = map_in.geom.get_idx()
-    mu = random_state.poisson(mu, len(idx[0]))
+    idx = map_in.geom.get_idx(flat=True)
+    mu = random_state.poisson(mu, idx[0].shape)
     map_in.fill_by_idx(idx, mu)
 
 


### PR DESCRIPTION
This PR is a rewrite of the `get_coords()` and `get_idx()` methods of the HPX and WCS geometry classes that changes the return value to a multi-dimensional array.  Previously these methods returned flattened arrays with pixels outside the geometry masked.  The disadvantage of this design is that it made it difficult to easily retrieve coordinates or indices by slice (e.g. getting coordinates for an image plane or along the non-spatial dimensions at a given image pixel).

The new implementation returns a multi-dimensional array for each coordinate with the same shape as the data member.  Pixels outside the geometry are set to NaN (for coords) or -1 (for indices).  I believe this implementation will be more intuitive for users as it means there will be a one-to-one mapping of the data array to the arrays returned by these methods.  This will also facilitate implementing slice-based operations on the data.  Both methods can still return  flattened/masked arrays by calling with `flat=True`.

Note that I plan to make a follow-up PR that updates all set/get methods to gracefully handle NaN inputs.
