### PR TITLE
Fix test failures in gammapy.maps

### DIFF
--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -10,6 +10,7 @@ from ..hpx import make_hpx_to_wcs_mapping, unravel_hpx_index, ravel_hpx_index
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
+pytest.importorskip('numpy', '1.12.0')
 
 hpx_allsky_test_geoms = [
     # 2D All-sky
@@ -174,8 +175,10 @@ def test_hpxgeom_get_pix(nside, nested, coordsys, region, axes):
     assert_allclose(idx, geom.local_to_global(idx_local))
 
     if axes is not None:
-        idx_img = geom.get_idx(local=False, idx=tuple([1] * len(axes)), flat=True)
-        idx_img_local = geom.get_idx(local=True, idx=tuple([1] * len(axes)), flat=True)
+        idx_img = geom.get_idx(
+            local=False, idx=tuple([1] * len(axes)), flat=True)
+        idx_img_local = geom.get_idx(
+            local=True, idx=tuple([1] * len(axes)), flat=True)
         assert_allclose(idx_img, geom.local_to_global(idx_img_local))
 
 
@@ -311,9 +314,9 @@ def test_hpxgeom_get_coords():
     # 3D all-sky
     hpx = HpxGeom(16, False, 'GAL', axes=[ax0])
     c = hpx.get_coords()
-    assert_allclose(c[0][0,:3], np.array([45., 135., 225.]))
-    assert_allclose(c[1][0,:3], np.array([87.075819, 87.075819, 87.075819]))
-    assert_allclose(c[2][0,:3], np.array([0.5, 0.5, 0.5]))
+    assert_allclose(c[0][0, :3], np.array([45., 135., 225.]))
+    assert_allclose(c[1][0, :3], np.array([87.075819, 87.075819, 87.075819]))
+    assert_allclose(c[2][0, :3], np.array([0.5, 0.5, 0.5]))
 
     # 2D partial-sky
     hpx = HpxGeom(64, False, 'GAL', region='DISK(110.,75.,2.)')
@@ -324,9 +327,9 @@ def test_hpxgeom_get_coords():
     # 3D partial-sky
     hpx = HpxGeom(64, False, 'GAL', region='DISK(110.,75.,2.)', axes=[ax0])
     c = hpx.get_coords()
-    assert_allclose(c[0][0,:3], np.array([107.5, 112.5, 106.57894737]))
-    assert_allclose(c[1][0,:3], np.array([76.813533, 76.813533, 76.07742]))
-    assert_allclose(c[2][0,:3], np.array([0.5, 0.5, 0.5]))
+    assert_allclose(c[0][0, :3], np.array([107.5, 112.5, 106.57894737]))
+    assert_allclose(c[1][0, :3], np.array([76.813533, 76.813533, 76.07742]))
+    assert_allclose(c[2][0, :3], np.array([0.5, 0.5, 0.5]))
 
     # 3D partial-sky w/ variable bin size
     hpx = HpxGeom([16, 32, 64], False, 'GAL',

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -11,6 +11,7 @@ from ..hpxsparse import HpxMapSparse
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
+pytest.importorskip('numpy', '1.12.0')
 
 axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -27,8 +27,8 @@ wcs_allsky_test_geoms = [
 wcs_partialsky_test_geoms = [
     (10, 0.1, 'GAL', 'AIT', skydir, None),
     (10, 0.1, 'GAL', 'AIT', skydir, axes1),
-    (10, [0.1,0.2], 'GAL', 'AIT', skydir, axes1),
-    ]
+    (10, [0.1, 0.2], 'GAL', 'AIT', skydir, axes1),
+]
 
 wcs_test_geoms = wcs_allsky_test_geoms + wcs_partialsky_test_geoms
 


### PR DESCRIPTION
This PR adds a `pytest.importorskip` statement in some `gammapy.maps` tests to require numpy 1.12 or later.  These tests were failing due to a bug in numpy which was fixed in this release.  Resolves #1193.