### PR TITLE
Improve catalog source str and tests

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -180,7 +180,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         ss += fmt.format(*args)
         ss += '{:<45s} : {:.1f}\n'.format('Significance curvature', d['Signif_Curve'])
 
-        if spec_type == 'LogParabola':
+        if spec_type == 'PowerLaw':
+            pass
+        elif spec_type == 'LogParabola':
             ss += '{:<45s} : {} +- {}\n'.format('beta', d['beta'], d['Unc_beta'])
         elif spec_type in ['PLExpCutoff', 'PlSuperExpCutoff']:
             fmt = '{:<45s} : {:.0f} +- {:.0f} {}\n'
@@ -218,9 +220,9 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
     def _info_spectral_points(self):
         """Print spectral points."""
-        d = self.data
         ss = '\n*** Spectral points ***\n\n'
-        ss += '\n'.join(self._flux_points_table_formatted.pformat(max_width=-1))
+        lines = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
+        ss += '\n'.join(lines)
 
         return ss + '\n'
 
@@ -744,8 +746,8 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _info_spectral_points(self):
         """Print spectral points."""
         ss = '\n*** Spectral points ***\n\n'
-        ss += '\n'.join(self._flux_points_table_formatted.pformat(max_width=-1))
-
+        lines = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
+        ss += '\n'.join(lines)
         return ss + '\n'
 
     def _info_other(self):

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -25,8 +25,8 @@ __all__ = [
     'SourceCatalogGammaCat',
     'SourceCatalogObjectGammaCat',
     'GammaCatDataCollection',
-    'GammaCatResource',  # TODO: public or not?
-    'GammaCatResourceIndex',  # TODO: public or not?
+    'GammaCatResource',
+    'GammaCatResourceIndex',
 ]
 
 log = logging.getLogger(__name__)
@@ -163,106 +163,63 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += '{:<15s} : {:.3f}\n'.format('Significance', d['significance'])
         ss += '{:<15s} : {:.3f}\n'.format('Livetime', d['livetime'])
 
-        spec = d['spec_type']
-        str = ''
-        if spec == 'pl2':
-            str = '(integral power law)'
-        ss += '\n{:<15s} : {} {}\n'.format('Spectrum type', spec, str)
+        spec_type = d['spec_type']
+        ss += '\n{:<15s} : {}\n'.format('Spectrum type', spec_type)
 
         # Spectral model parameters
-        if spec == 'pl':
-            unit = 'cm-2 s-1 TeV-1'
-            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
-            args = ('norm', d['spec_pl_norm'].value, d['spec_pl_norm_err'].value, unit)
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
-            args = ('', d['spec_pl_norm'].value, d['spec_pl_norm_err_sys'].value, unit)
-            ss += fmt.format(*args)
-
-            fmt = '{:<15s} : {:.3} +- {:.3} (statistical)\n'
-            args = ('index', d['spec_pl_index'], d['spec_pl_index_err'])
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} (systematic)\n'
-            args = ('', d['spec_pl_index'], d['spec_pl_index_err_sys'])
-            ss += fmt.format(*args)
-
+        if spec_type == 'pl':
+            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (syst) {}\n'.format(
+                'norm', d['spec_pl_norm'].value, d['spec_pl_norm_err'].value,
+                d['spec_pl_norm_err_sys'].value, 'cm-2 s-1 TeV-1')
+            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (sys)\n'.format(
+                'index', d['spec_pl_index'], d['spec_pl_index_err'],
+                d['spec_pl_index_err_sys'])
             ss += '{:<15s} : {:.3}\n'.format('reference', d['spec_pl_e_ref'])
 
-        elif spec == 'pl2':
-            unit = 'cm-2 s-1'
-            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
-            args = ('flux', d['spec_pl2_flux'].value, d['spec_pl2_flux_err'].value, unit)
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
-            args = ('', d['spec_pl2_flux'].value, d['spec_pl2_flux_err_sys'].value, unit)
-            ss += fmt.format(*args)
-
-            fmt = '{:<15s} : {:.3} +- {:.3} (statistical)\n'
-            args = ('index', d['spec_pl2_index'], d['spec_pl2_index_err'])
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} (systematic)\n'
-            args = ('', d['spec_pl2_index'], d['spec_pl2_index_err_sys'])
-            ss += fmt.format(*args)
-
+        elif spec_type == 'pl2':
+            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (sys) {}\n'.format(
+                'flux', d['spec_pl2_flux'].value, d['spec_pl2_flux_err'].value,
+                d['spec_pl2_flux_err_sys'].value, 'cm-2 s-1')
+            ss += '{:<15s} : {:.3} +- {:.3} (stat)\n'.format(
+                'index', d['spec_pl2_index'], d['spec_pl2_index_err'],
+                d['spec_pl2_index_err_sys'])
             ss += '{:<15s} : {:.3}\n'.format('e_min', d['spec_pl2_e_min'])
             ss += '{:<15s} : {:.3}\n'.format('e_max', d['spec_pl2_e_max'])
 
-        elif spec == 'ecpl':
-            unit = 'cm-2 s-1 TeV-1'
-            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
-            args = ('norm', d['spec_ecpl_norm'].value, d['spec_ecpl_norm_err'].value, unit)
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
-            args = ('', d['spec_ecpl_norm'].value, d['spec_ecpl_norm_err_sys'].value, unit)
-            ss += fmt.format(*args)
-
-            fmt = '{:<15s} : {:.3} +- {:.3} (statistical)\n'
-            args = ('index', d['spec_ecpl_index'], d['spec_ecpl_index_err'])
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} (systematic)\n'
-            args = ('', d['spec_ecpl_index'], d['spec_ecpl_index_err_sys'])
-            ss += fmt.format(*args)
-
-            unit = 'TeV'
-            fmt = '{:<15s} : {:.3} +- {:.3} {} (statistical)\n'
-            args = ('e_cut', d['spec_ecpl_e_cut'].value, d['spec_ecpl_e_cut_err'].value, unit)
-            ss += fmt.format(*args)
-            fmt = '{:<15s}   {:.3} +- {:.3} {} (systematic)\n'
-            args = ('', d['spec_ecpl_e_cut'].value, d['spec_ecpl_e_cut_err_sys'].value, unit)
-            ss += fmt.format(*args)
-
+        elif spec_type == 'ecpl':
+            ss += '{:<15s} : {:.3g} +- {:.3g} (stat) +- {:.03g} (sys) {}\n'.format(
+                'norm', d['spec_ecpl_norm'].value, d['spec_ecpl_norm_err'].value,
+                d['spec_ecpl_norm_err_sys'].value, 'cm-2 s-1 TeV-1')
+            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (sys)\n'.format(
+                'index', d['spec_ecpl_index'], d['spec_ecpl_index_err'],
+                d['spec_ecpl_index_err_sys'])
+            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (stat) {}\n'.format(
+                'e_cut', d['spec_ecpl_e_cut'].value, d['spec_ecpl_e_cut_err'].value,
+                d['spec_ecpl_e_cut_err_sys'].value, 'TeV')
             ss += '{:<15s} : {:.3}\n'.format('reference', d['spec_ecpl_e_ref'])
 
         else:
             # raise ValueError('Spectral model printout not implemented: {}'.format(spec))
             ss += '\nSpectral model printout not yet implemented.\n'
 
-        ss += '\n{:<20s} : {:.3}\n'.format('energy range min', d['spec_erange_min'])
-        ss += '{:<20s} : {:.3}\n'.format('energy range max', d['spec_erange_max'])
+        ss += '\n{:<20s} : ({:.3}, {:.3}) TeV\n'.format(
+            'Energy range', d['spec_erange_min'].value, d['spec_erange_max'].value)
         ss += '{:<20s} : {:.3}\n'.format('theta', d['spec_theta'])
 
         ss += '\n\nDerived fluxes:\n'
 
-        unit = 'cm-2 s-1 TeV-1'
-        fmt = '{:<30s} : {:.3} +- {:.3} {} (statistical)\n'
-        args = ('Spectral model norm (1 TeV)', d['spec_dnde_1TeV'].value, d['spec_dnde_1TeV_err'].value, unit)
-        ss += fmt.format(*args)
-
-        unit = 'cm-2 s-1'
-        fmt = '{:<30s} : {:.3} +- {:.3} {} (statistical)\n'
-        args = ('Integrated flux (<1 TeV)', d['spec_flux_1TeV'].value, d['spec_flux_1TeV_err'].value, unit)
-        ss += fmt.format(*args)
-
-        unit = '(crab units)'
-        fmt = '{:<30s} : {:.3} +- {:.3} {}\n'
-        args = ('Integrated flux (<1 TeV)', d['spec_flux_1TeV_crab'], d['spec_flux_1TeV_crab_err'], unit)
-        ss += fmt.format(*args)
-
-        unit = 'erg cm-2 s-1'
-        fmt = '{:<30s} : {:.3} +- {:.3} {} (statistical)\n'
-        args = (
-        'Integrated flux (1-10 TeV)', d['spec_eflux_1TeV_10TeV'].value, d['spec_eflux_1TeV_10TeV_err'].value, unit)
-        ss += fmt.format(*args)
+        ss += '{:<30s} : {:.3} +- {:.3} (stat) {}\n'.format(
+            'Spectral model norm (1 TeV)', d['spec_dnde_1TeV'].value,
+            d['spec_dnde_1TeV_err'].value, 'cm-2 s-1 TeV-1')
+        ss += '{:<30s} : {:.3} +- {:.3} (stat) {}\n'.format(
+            'Integrated flux (>1 TeV)', d['spec_flux_1TeV'].value,
+            d['spec_flux_1TeV_err'].value, 'cm-2 s-1')
+        ss += '{:<30s} : {:.3f} +- {:.3f} {}\n'.format(
+            'Integrated flux (>1 TeV)', d['spec_flux_1TeV_crab'],
+            d['spec_flux_1TeV_crab_err'], '(% Crab)')
+        ss += '{:<30s} : {:.3} +- {:.3} (stat) {}\n'.format(
+            'Integrated flux (1-10 TeV)', d['spec_eflux_1TeV_10TeV'].value,
+            d['spec_eflux_1TeV_10TeV_err'].value, 'erg cm-2 s-1')
 
         return ss
 
@@ -581,20 +538,20 @@ class GammaCatResource(object):
 
     def __eq__(self, other):
         return (
-            self.source_id == other.source_id and
-            self.reference_id == other.reference_id and
-            self.file_id == other.file_id and
-            self.type == other.type and
-            self.location == other.location
+                self.source_id == other.source_id and
+                self.reference_id == other.reference_id and
+                self.file_id == other.file_id and
+                self.type == other.type and
+                self.location == other.location
         )
 
     def __lt__(self, other):
         return (
-            self.source_id < other.source_id or
-            self.reference_id < other.reference_id or
-            self.file_id < other.file_id or
-            self.type < other.type or
-            self.location < other.location
+                self.source_id < other.source_id or
+                self.reference_id < other.reference_id or
+                self.file_id < other.file_id or
+                self.type < other.type or
+                self.location < other.location
         )
 
     def to_dict(self):

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -232,8 +232,8 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += '{:<25s} : {}\n\n'.format('Number of upper limits', d['sed_n_ul'])
 
         try:
-            txt = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
-            ss += '\n'.join(txt)
+            lines = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
+            ss += '\n'.join(lines)
         except NoDataAvailableError:
             ss += '\nNo spectral points available for this source.'
 
@@ -243,7 +243,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
     def spectral_model(self):
         """Source spectral model (`~gammapy.spectrum.models.SpectralModel`).
 
-        TODO: how to handle systematic errors? (ignored at the moment)
+        Parameter errors are statistical errors only.
         """
         data = self.data
         spec_type = data['spec_type']
@@ -338,10 +338,10 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
     def _flux_points_table_formatted(self):
         """Returns formatted version of self.flux_points.table"""
         table = self.flux_points.table.copy()
-        table['e_ref'].format = '.1f'
+        table['e_ref'].format = '.3f'
         flux_cols = ['dnde', 'dnde_errn', 'dnde_errp', 'dnde_err']
-        for _ in flux_cols:
-            if _ in table: table[_].format = '.3'
+        for _ in set(table.colnames) & set(flux_cols):
+            table[_].format = '.3e'
         return table
 
     @property

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -168,7 +168,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
         # Spectral model parameters
         if spec_type == 'pl':
-            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (syst) {}\n'.format(
+            ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (sys) {}\n'.format(
                 'norm', d['spec_pl_norm'].value, d['spec_pl_norm_err'].value,
                 d['spec_pl_norm_err_sys'].value, 'cm-2 s-1 TeV-1')
             ss += '{:<15s} : {:.3} +- {:.3} (stat) +- {:.3} (sys)\n'.format(
@@ -232,7 +232,8 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += '{:<25s} : {}\n\n'.format('Number of upper limits', d['sed_n_ul'])
 
         try:
-            ss += '\n'.join(self._flux_points_table_formatted.pformat(max_width=-1))
+            txt = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
+            ss += '\n'.join(txt)
         except NoDataAvailableError:
             ss += '\nNo spectral points available for this source.'
 

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -5,7 +5,8 @@ Gammacat open TeV source catalog.
 https://github.com/gammapy/gamma-cat
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
+import functools
 import logging
 import numpy as np
 from ..extern import six
@@ -485,6 +486,7 @@ class GammaCatDataCollection(object):
         return ss
 
 
+@functools.total_ordering
 class GammaCatResource(object):
     """Reference for a single resource in gamma-cat.
 
@@ -538,22 +540,15 @@ class GammaCatResource(object):
                           self.file_id, str(self.type), str(self.location))
 
     def __eq__(self, other):
-        return (
-                self.source_id == other.source_id and
-                self.reference_id == other.reference_id and
-                self.file_id == other.file_id and
-                self.type == other.type and
-                self.location == other.location
-        )
+        return self.to_namedtuple() == other.to_namedtuple()
 
     def __lt__(self, other):
-        return (
-                self.source_id < other.source_id or
-                self.reference_id < other.reference_id or
-                self.file_id < other.file_id or
-                self.type < other.type or
-                self.location < other.location
-        )
+        return self.to_namedtuple() < other.to_namedtuple()
+
+    def to_namedtuple(self):
+        """Convert to `collections.namedtuple`."""
+        d = self.to_dict()
+        return namedtuple('GammaCatResourceNamedTuple', d.keys())(**d)
 
     def to_dict(self):
         """Convert to `collections.OrderedDict`."""

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -348,7 +348,8 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             flux_points[_].format = '.3e'
 
         # convert table to string
-        ss += '\n\t'.join(flux_points.pformat(-1))
+        lines = flux_points.pformat(max_width=-1, max_lines=-1)
+        ss += '\n'.join(lines)
         return ss + '\n'
 
     def _info_components(self):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -86,6 +86,12 @@ class TestFermi3FGLObject:
         assert 'Detection significance (100 MeV - 300 GeV)    : 30.670' in ss
         assert 'Integral flux (1 - 100 GeV)                   : 1.57e-07 +- 1.08e-09 cm-2 s-1' in ss
 
+    @pytest.mark.parametrize('ref', SOURCES_3FGL, ids=lambda _: _['name'])
+    def test_str_all(self, ref):
+        ss = str(self.cat[ref['idx']])
+        # TODO: put better assert on content. Maybe like for gamma-cat?
+        assert 'Source name' in ss
+
     def test_data_python_dict(self):
         data = self.source._data_python_dict
         assert type(data['RAJ2000']) == float

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -191,6 +191,8 @@ class TestGammaCatResource:
     def test_lt(self):
         resource = GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=2)
 
+        assert not resource < resource
+
         assert resource < GammaCatResource(source_id=43, reference_id='2010A&A...516A..62A', file_id=2)
         assert resource < GammaCatResource(source_id=42, reference_id='2010A&A...516A..62B', file_id=2)
         assert resource < GammaCatResource(source_id=42, reference_id='2010A&A...516A..62A', file_id=3)

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -12,7 +12,6 @@ from ..gammacat import GammaCatResource, GammaCatResourceIndex
 SOURCES = [
     {
         'name': 'Vela X',
-
         'spec_type': 'ecpl',
         'dnde_1TeV': 1.36e-11 * u.Unit('cm-2 s-1 TeV-1'),
         'dnde_1TeV_err': 7.531e-13 * u.Unit('cm-2 s-1 TeV-1'),
@@ -20,12 +19,10 @@ SOURCES = [
         'flux_1TeV_err': 1.973e-12 * u.Unit('cm-2 s-1'),
         'eflux_1_10TeV': 9.265778680255336e-11 * u.Unit('erg cm-2 s-1'),
         'eflux_1_10TeV_err': 9.590978299538194e-12 * u.Unit('erg cm-2 s-1'),
-
         'n_flux_points': 24,
     },
     {
         'name': 'HESS J1848-018',
-
         'spec_type': 'pl',
         'dnde_1TeV': 3.7e-12 * u.Unit('cm-2 s-1 TeV-1'),
         'dnde_1TeV_err': 4e-13 * u.Unit('cm-2 s-1 TeV-1'),
@@ -33,12 +30,10 @@ SOURCES = [
         'flux_1TeV_err': 3.187e-13 * u.Unit('cm-2 s-1'),
         'eflux_1_10TeV': 6.235650344765057e-12 * u.Unit('erg cm-2 s-1'),
         'eflux_1_10TeV_err': 1.2210315515569183e-12 * u.Unit('erg cm-2 s-1'),
-
         'n_flux_points': 11,
     },
     {
         'name': 'HESS J1813-178',
-
         'spec_type': 'pl2',
         'dnde_1TeV': 2.678e-12 * u.Unit('cm-2 s-1 TeV-1'),
         'dnde_1TeV_err': 2.55e-13 * u.Unit('cm-2 s-1 TeV-1'),
@@ -46,7 +41,6 @@ SOURCES = [
         'flux_1TeV_err': 3.692e-13 * u.Unit('cm-2 s-1'),
         'eflux_1_10TeV': 8.923614018939419e-12 * u.Unit('erg cm-2 s-1'),
         'eflux_1_10TeV_err': 1.4613807070890267e-12 * u.Unit('erg cm-2 s-1'),
-
         'n_flux_points': 13,
     },
 ]
@@ -101,9 +95,8 @@ class TestSourceCatalogObjectGammaCat:
 
     @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
     def test_str(self, gammacat, ref):
-        ss = gammacat[ref['name']]._info_spectral_fit()
-        print(ss)
-        assert ss == STRING_REPRESENTATION[ref['name']]
+        ss = str(gammacat[ref['name']])
+        assert ss == SOURCES_STR[ref['name']]
 
     def test_data_python_dict(self, gammacat):
         source = gammacat[0]
@@ -282,8 +275,54 @@ class TestGammaCatResourceIndex:
         assert resource_index.resources[0].global_id == '42|2010A&A...516A..62A|2|sed'
 
 
-STRING_REPRESENTATION = {
+SOURCES_STR = {
     'Vela X': """
+*** Basic info ***
+
+Catalog row index (zero-based) : 36
+Common name     : Vela X
+Other names     : HESS J0835-455
+Location        : gal
+Class           : pwn
+
+TeVCat ID       : 86
+TeVCat 2 ID     : yVoFOS
+TeVCat name     : TeV J0835-456
+
+TGeVCat ID      : 37
+TGeVCat name    : TeV J0835-4536
+
+Discoverer      : hess
+Discovery date  : 2006-03
+Seen by         : hess
+Reference       : 2012A&A...548A..38A
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 128.287 deg
+DEC                  : -45.190 deg
+GLON                 : 263.332 deg
+GLAT                 : -3.106 deg
+
+Measurement:
+RA                   : 128.750 deg
+DEC                  : -45.600 deg
+GLON                 : 263.856 deg
+GLAT                 : -3.089 deg
+Position error       : nan deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.480 deg
+Sigma error               : 0.030 deg
+Sigma2                    : 0.360 deg
+Sigma2 error              : 0.030 deg
+Position angle            : 41.000 deg
+Position angle error      : 7.000 deg
+Position angle frame      : radec
+
 *** Spectral info ***
 
 Significance    : 27.900
@@ -304,8 +343,88 @@ Spectral model norm (1 TeV)    : 1.36e-11 +- 7.53e-13 (stat) cm-2 s-1 TeV-1
 Integrated flux (>1 TeV)       : 2.1e-11 +- 1.97e-12 (stat) cm-2 s-1
 Integrated flux (>1 TeV)       : 101.425 +- 9.511 (% Crab)
 Integrated flux (1-10 TeV)     : 9.27e-11 +- 9.59e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2012A&A...548A..38A
+Number of spectral points : 24
+Number of upper limits    : 0
+
+e_ref       dnde         dnde_errn       dnde_errp   
+ TeV  1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+----- --------------- --------------- ---------------
+  0.7       1.055e-11       3.284e-12        3.28e-12
+  0.9       1.304e-11        2.13e-12        2.13e-12
+  1.1       9.211e-12       1.401e-12       1.399e-12
+  1.3       8.515e-12        9.58e-13        9.61e-13
+  1.5       5.378e-12        7.07e-13        7.09e-13
+  1.9       4.455e-12        5.05e-13        5.07e-13
+  2.3       3.754e-12         3.3e-13        3.34e-13
+  2.8       2.418e-12        2.68e-13         2.7e-13
+  3.4       1.605e-12         1.8e-13        1.83e-13
+  4.1       1.445e-12        1.26e-13        1.29e-13
+  5.0        9.24e-13        9.49e-14         9.7e-14
+  6.0       7.348e-13        6.47e-14        6.71e-14
+  7.3       3.863e-13        4.54e-14         4.7e-14
+  8.8       3.579e-13        3.57e-14        3.75e-14
+ 10.6       1.696e-13        2.49e-14        2.59e-14
+ 12.9       1.549e-13        2.06e-14        2.16e-14
+ 15.6       6.695e-14       1.134e-14        1.23e-14
+ 18.9       2.105e-14      1.3904e-14        1.32e-14
+ 22.6       3.279e-14        6.83e-15        7.51e-15
+ 26.9       3.026e-14        5.91e-15        6.66e-15
+ 31.6       1.861e-14        4.38e-15        5.12e-15
+ 37.0       5.653e-15       2.169e-15       2.917e-15
+ 43.1       3.479e-15       1.641e-15        2.41e-15
+ 52.4       1.002e-15       8.327e-16       1.615e-15
 """,
     'HESS J1813-178': """
+*** Basic info ***
+
+Catalog row index (zero-based) : 118
+Common name     : HESS J1813-178
+Other names     : HESS J1813-178,G12.82-0.02,PSR J1813-1749,CXOU J181335.1-174957,IGR J18135-1751,W33
+Location        : gal
+Class           : pwn
+
+TeVCat ID       : 114
+TeVCat 2 ID     : Unhlxa
+TeVCat name     : TeV J1813-178
+
+TGeVCat ID      : 116
+TGeVCat name    : TeV J1813-1750
+
+Discoverer      : hess
+Discovery date  : 2005-03
+Seen by         : hess,magic
+Reference       : 2006ApJ...636..777A
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 273.363 deg
+DEC                  : -17.849 deg
+GLON                 : 12.787 deg
+GLAT                 : 0.000 deg
+
+Measurement:
+RA                   : 273.408 deg
+DEC                  : -17.842 deg
+GLON                 : 12.813 deg
+GLAT                 : -0.034 deg
+Position error       : 0.005 deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.036 deg
+Sigma error               : 0.006 deg
+Sigma2                    : nan deg
+Sigma2 error              : nan deg
+Position angle            : nan deg
+Position angle error      : nan deg
+Position angle frame      : 
+
 *** Spectral info ***
 
 Significance    : 13.500
@@ -326,8 +445,77 @@ Spectral model norm (1 TeV)    : 2.68e-12 +- 2.55e-13 (stat) cm-2 s-1 TeV-1
 Integrated flux (>1 TeV)       : 2.46e-12 +- 3.69e-13 (stat) cm-2 s-1
 Integrated flux (>1 TeV)       : 11.844 +- 1.780 (% Crab)
 Integrated flux (1-10 TeV)     : 8.92e-12 +- 1.46e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2006ApJ...636..777A
+Number of spectral points : 13
+Number of upper limits    : 0
+
+e_ref       dnde         dnde_errn       dnde_errp   
+ TeV  1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+----- --------------- --------------- ---------------
+  0.3     2.73577e-11     5.69046e-12     5.97149e-12
+  0.4      1.5539e-11     3.35562e-12     3.55928e-12
+  0.6     8.14211e-12     1.60278e-12     1.71637e-12
+  0.8     4.56709e-12     9.31895e-13      1.0075e-12
+  1.0     2.66915e-12     5.58626e-13     6.10985e-13
+  1.4     1.51816e-12     3.37844e-13     3.72122e-13
+  1.8      7.9658e-13     2.16613e-13     2.42646e-13
+  2.5     3.56979e-13     1.13516e-13     1.29469e-13
+  3.2     3.32097e-13     8.75657e-14     1.01182e-13
+  4.4     1.93378e-13     5.76383e-14     6.85693e-14
+  5.6     4.46083e-14     2.12963e-14      2.8445e-14
+ 10.8     1.31758e-14     6.05638e-15     1.08496e-14
+ 22.1     1.37179e-14     6.12777e-15     1.17835e-14
 """,
     'HESS J1848-018': """
+*** Basic info ***
+
+Catalog row index (zero-based) : 134
+Common name     : HESS J1848-018
+Other names     : HESS J1848-018,1HWC J1849-017c,WR121a,W43
+Location        : gal
+Class           : unid
+
+TeVCat ID       : 187
+TeVCat 2 ID     : hcE3Ou
+TeVCat name     : TeV J1848-017
+
+TGeVCat ID      : 128
+TGeVCat name    : TeV J1848-0147
+
+Discoverer      : hess
+Discovery date  : 2008-07
+Seen by         : hess
+Reference       : 2008AIPC.1085..372C
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 282.120 deg
+DEC                  : -1.792 deg
+GLON                 : 31.000 deg
+GLAT                 : -0.159 deg
+
+Measurement:
+RA                   : 282.121 deg
+DEC                  : -1.792 deg
+GLON                 : 31.000 deg
+GLAT                 : -0.160 deg
+Position error       : nan deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.320 deg
+Sigma error               : 0.020 deg
+Sigma2                    : nan deg
+Sigma2 error              : nan deg
+Position angle            : nan deg
+Position angle error      : nan deg
+Position angle frame      : 
+
 *** Spectral info ***
 
 Significance    : 9.000
@@ -347,5 +535,26 @@ Spectral model norm (1 TeV)    : 3.7e-12 +- 4e-13 (stat) cm-2 s-1 TeV-1
 Integrated flux (>1 TeV)       : 2.06e-12 +- 3.19e-13 (stat) cm-2 s-1
 Integrated flux (>1 TeV)       : 9.909 +- 1.536 (% Crab)
 Integrated flux (1-10 TeV)     : 6.24e-12 +- 1.22e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2008AIPC.1085..372C
+Number of spectral points : 11
+Number of upper limits    : 0
+
+e_ref       dnde         dnde_errn       dnde_errp   
+ TeV  1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+----- --------------- --------------- ---------------
+  0.6     9.94175e-12     3.30083e-12     3.26451e-12
+  0.9     6.81516e-12     1.04206e-12     1.02928e-12
+  1.3     1.70718e-12     3.88868e-13     3.82595e-13
+  1.9     5.02674e-13     1.56604e-13     1.53321e-13
+  2.8     3.26588e-13     7.52648e-14     7.32347e-14
+  4.0     8.18333e-14     3.60923e-14     3.50318e-14
+  5.9      2.9794e-14      1.9812e-14     1.92094e-14
+  8.6      4.0217e-15     9.06779e-15     8.72854e-15
+ 12.7    -6.64708e-15     3.78572e-15     3.67482e-15
+ 18.5     3.73541e-15     2.00875e-15     1.78617e-15
+ 27.2    -5.31736e-16      9.2363e-16     8.56839e-16
 """
 }

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -20,6 +20,8 @@ SOURCES = [
         'eflux_1_10TeV': 9.265778680255336e-11 * u.Unit('erg cm-2 s-1'),
         'eflux_1_10TeV_err': 9.590978299538194e-12 * u.Unit('erg cm-2 s-1'),
         'n_flux_points': 24,
+        'is_pointlike': False,
+        'spatial_model': 'Gaussian2D',
     },
     {
         'name': 'HESS J1848-018',
@@ -31,6 +33,8 @@ SOURCES = [
         'eflux_1_10TeV': 6.235650344765057e-12 * u.Unit('erg cm-2 s-1'),
         'eflux_1_10TeV_err': 1.2210315515569183e-12 * u.Unit('erg cm-2 s-1'),
         'n_flux_points': 11,
+        'is_pointlike': False,
+        'spatial_model': 'Gaussian2D',
     },
     {
         'name': 'HESS J1813-178',
@@ -42,6 +46,8 @@ SOURCES = [
         'eflux_1_10TeV': 8.923614018939419e-12 * u.Unit('erg cm-2 s-1'),
         'eflux_1_10TeV_err': 1.4613807070890267e-12 * u.Unit('erg cm-2 s-1'),
         'n_flux_points': 13,
+        'is_pointlike': False,
+        'spatial_model': 'Gaussian2D',
     },
 ]
 
@@ -96,6 +102,7 @@ class TestSourceCatalogObjectGammaCat:
     @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
     def test_str(self, gammacat, ref):
         ss = str(gammacat[ref['name']])
+        print(ss)
         assert ss == SOURCES_STR[ref['name']]
 
     def test_data_python_dict(self, gammacat):
@@ -151,6 +158,19 @@ class TestSourceCatalogObjectGammaCat:
         flux_points = source.flux_points
 
         assert len(flux_points.table) == ref['n_flux_points']
+
+    @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
+    def test_spatial_model(self, gammacat, ref):
+        source = gammacat[ref['name']]
+
+        spatial_model = source.spatial_model()
+
+        # print(spatial_model); 1 /0
+        # TODO: put better asserts on model properties
+        # TODO: add a point and shell source -> separate list of sources for morphology test parametrization?
+        assert spatial_model.__class__.__name__ == ref['spatial_model']
+
+        assert source.is_pointlike == ref['is_pointlike']
 
 
 class TestGammaCatResource:
@@ -275,8 +295,9 @@ class TestGammaCatResourceIndex:
         assert resource_index.resources[0].global_id == '42|2010A&A...516A..62A|2|sed'
 
 
-SOURCES_STR = {
-    'Vela X': """
+SOURCES_STR = {}
+
+SOURCES_STR['Vela X'] = """
 *** Basic info ***
 
 Catalog row index (zero-based) : 36
@@ -350,35 +371,125 @@ SED reference id          : 2012A&A...548A..38A
 Number of spectral points : 24
 Number of upper limits    : 0
 
-e_ref       dnde         dnde_errn       dnde_errp   
- TeV  1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
------ --------------- --------------- ---------------
-  0.7       1.055e-11       3.284e-12        3.28e-12
-  0.9       1.304e-11        2.13e-12        2.13e-12
-  1.1       9.211e-12       1.401e-12       1.399e-12
-  1.3       8.515e-12        9.58e-13        9.61e-13
-  1.5       5.378e-12        7.07e-13        7.09e-13
-  1.9       4.455e-12        5.05e-13        5.07e-13
-  2.3       3.754e-12         3.3e-13        3.34e-13
-  2.8       2.418e-12        2.68e-13         2.7e-13
-  3.4       1.605e-12         1.8e-13        1.83e-13
-  4.1       1.445e-12        1.26e-13        1.29e-13
-  5.0        9.24e-13        9.49e-14         9.7e-14
-  6.0       7.348e-13        6.47e-14        6.71e-14
-  7.3       3.863e-13        4.54e-14         4.7e-14
-  8.8       3.579e-13        3.57e-14        3.75e-14
- 10.6       1.696e-13        2.49e-14        2.59e-14
- 12.9       1.549e-13        2.06e-14        2.16e-14
- 15.6       6.695e-14       1.134e-14        1.23e-14
- 18.9       2.105e-14      1.3904e-14        1.32e-14
- 22.6       3.279e-14        6.83e-15        7.51e-15
- 26.9       3.026e-14        5.91e-15        6.66e-15
- 31.6       1.861e-14        4.38e-15        5.12e-15
- 37.0       5.653e-15       2.169e-15       2.917e-15
- 43.1       3.479e-15       1.641e-15        2.41e-15
- 52.4       1.002e-15       8.327e-16       1.615e-15
-""",
-    'HESS J1813-178': """
+e_ref        dnde         dnde_errn       dnde_errp   
+ TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+------ --------------- --------------- ---------------
+ 0.719       1.055e-11       3.284e-12       3.280e-12
+ 0.868       1.304e-11       2.130e-12       2.130e-12
+ 1.051       9.211e-12       1.401e-12       1.399e-12
+ 1.274       8.515e-12       9.580e-13       9.610e-13
+ 1.546       5.378e-12       7.070e-13       7.090e-13
+ 1.877       4.455e-12       5.050e-13       5.070e-13
+ 2.275       3.754e-12       3.300e-13       3.340e-13
+ 2.759       2.418e-12       2.680e-13       2.700e-13
+ 3.352       1.605e-12       1.800e-13       1.830e-13
+ 4.078       1.445e-12       1.260e-13       1.290e-13
+ 4.956       9.240e-13       9.490e-14       9.700e-14
+ 6.008       7.348e-13       6.470e-14       6.710e-14
+ 7.271       3.863e-13       4.540e-14       4.700e-14
+ 8.795       3.579e-13       3.570e-14       3.750e-14
+10.650       1.696e-13       2.490e-14       2.590e-14
+12.910       1.549e-13       2.060e-14       2.160e-14
+15.650       6.695e-14       1.134e-14       1.230e-14
+18.880       2.105e-14       1.390e-14       1.320e-14
+22.620       3.279e-14       6.830e-15       7.510e-15
+26.870       3.026e-14       5.910e-15       6.660e-15
+31.610       1.861e-14       4.380e-15       5.120e-15
+36.970       5.653e-15       2.169e-15       2.917e-15
+43.080       3.479e-15       1.641e-15       2.410e-15
+52.370       1.002e-15       8.327e-16       1.615e-15
+"""
+
+SOURCES_STR['HESS J1848-018'] = """
+*** Basic info ***
+
+Catalog row index (zero-based) : 134
+Common name     : HESS J1848-018
+Other names     : HESS J1848-018,1HWC J1849-017c,WR121a,W43
+Location        : gal
+Class           : unid
+
+TeVCat ID       : 187
+TeVCat 2 ID     : hcE3Ou
+TeVCat name     : TeV J1848-017
+
+TGeVCat ID      : 128
+TGeVCat name    : TeV J1848-0147
+
+Discoverer      : hess
+Discovery date  : 2008-07
+Seen by         : hess
+Reference       : 2008AIPC.1085..372C
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 282.120 deg
+DEC                  : -1.792 deg
+GLON                 : 31.000 deg
+GLAT                 : -0.159 deg
+
+Measurement:
+RA                   : 282.121 deg
+DEC                  : -1.792 deg
+GLON                 : 31.000 deg
+GLAT                 : -0.160 deg
+Position error       : nan deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.320 deg
+Sigma error               : 0.020 deg
+Sigma2                    : nan deg
+Sigma2 error              : nan deg
+Position angle            : nan deg
+Position angle error      : nan deg
+Position angle frame      : 
+
+*** Spectral info ***
+
+Significance    : 9.000
+Livetime        : 50.000 h
+
+Spectrum type   : pl
+norm            : 3.7e-12 +- 4e-13 (stat) +- 7e-13 (sys) cm-2 s-1 TeV-1
+index           : 2.8 +- 0.2 (stat) +- 0.2 (sys)
+reference       : 1.0 TeV
+
+Energy range         : (0.9, 12.0) TeV
+theta                : 0.2 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 3.7e-12 +- 4e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.06e-12 +- 3.19e-13 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 9.909 +- 1.536 (% Crab)
+Integrated flux (1-10 TeV)     : 6.24e-12 +- 1.22e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2008AIPC.1085..372C
+Number of spectral points : 11
+Number of upper limits    : 0
+
+e_ref        dnde         dnde_errn       dnde_errp   
+ TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+------ --------------- --------------- ---------------
+ 0.624       9.942e-12       3.301e-12       3.265e-12
+ 0.878       6.815e-12       1.042e-12       1.029e-12
+ 1.284       1.707e-12       3.889e-13       3.826e-13
+ 1.881       5.027e-13       1.566e-13       1.533e-13
+ 2.754       3.266e-13       7.526e-14       7.323e-14
+ 4.033       8.183e-14       3.609e-14       3.503e-14
+ 5.905       2.979e-14       1.981e-14       1.921e-14
+ 8.648       4.022e-15       9.068e-15       8.729e-15
+12.663      -6.647e-15       3.786e-15       3.675e-15
+18.542       3.735e-15       2.009e-15       1.786e-15
+27.173      -5.317e-16       9.236e-16       8.568e-16
+"""
+
+SOURCES_STR['HESS J1813-178'] = """
 *** Basic info ***
 
 Catalog row index (zero-based) : 118
@@ -452,109 +563,20 @@ SED reference id          : 2006ApJ...636..777A
 Number of spectral points : 13
 Number of upper limits    : 0
 
-e_ref       dnde         dnde_errn       dnde_errp   
- TeV  1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
------ --------------- --------------- ---------------
-  0.3     2.73577e-11     5.69046e-12     5.97149e-12
-  0.4      1.5539e-11     3.35562e-12     3.55928e-12
-  0.6     8.14211e-12     1.60278e-12     1.71637e-12
-  0.8     4.56709e-12     9.31895e-13      1.0075e-12
-  1.0     2.66915e-12     5.58626e-13     6.10985e-13
-  1.4     1.51816e-12     3.37844e-13     3.72122e-13
-  1.8      7.9658e-13     2.16613e-13     2.42646e-13
-  2.5     3.56979e-13     1.13516e-13     1.29469e-13
-  3.2     3.32097e-13     8.75657e-14     1.01182e-13
-  4.4     1.93378e-13     5.76383e-14     6.85693e-14
-  5.6     4.46083e-14     2.12963e-14      2.8445e-14
- 10.8     1.31758e-14     6.05638e-15     1.08496e-14
- 22.1     1.37179e-14     6.12777e-15     1.17835e-14
-""",
-    'HESS J1848-018': """
-*** Basic info ***
-
-Catalog row index (zero-based) : 134
-Common name     : HESS J1848-018
-Other names     : HESS J1848-018,1HWC J1849-017c,WR121a,W43
-Location        : gal
-Class           : unid
-
-TeVCat ID       : 187
-TeVCat 2 ID     : hcE3Ou
-TeVCat name     : TeV J1848-017
-
-TGeVCat ID      : 128
-TGeVCat name    : TeV J1848-0147
-
-Discoverer      : hess
-Discovery date  : 2008-07
-Seen by         : hess
-Reference       : 2008AIPC.1085..372C
-
-*** Position info ***
-
-SIMBAD:
-RA                   : 282.120 deg
-DEC                  : -1.792 deg
-GLON                 : 31.000 deg
-GLAT                 : -0.159 deg
-
-Measurement:
-RA                   : 282.121 deg
-DEC                  : -1.792 deg
-GLON                 : 31.000 deg
-GLAT                 : -0.160 deg
-Position error       : nan deg
-
-*** Morphology info ***
-
-Morphology model type     : gauss
-Sigma                     : 0.320 deg
-Sigma error               : 0.020 deg
-Sigma2                    : nan deg
-Sigma2 error              : nan deg
-Position angle            : nan deg
-Position angle error      : nan deg
-Position angle frame      : 
-
-*** Spectral info ***
-
-Significance    : 9.000
-Livetime        : 50.000 h
-
-Spectrum type   : pl
-norm            : 3.7e-12 +- 4e-13 (stat) +- 7e-13 (syst) cm-2 s-1 TeV-1
-index           : 2.8 +- 0.2 (stat) +- 0.2 (sys)
-reference       : 1.0 TeV
-
-Energy range         : (0.9, 12.0) TeV
-theta                : 0.2 deg
-
-
-Derived fluxes:
-Spectral model norm (1 TeV)    : 3.7e-12 +- 4e-13 (stat) cm-2 s-1 TeV-1
-Integrated flux (>1 TeV)       : 2.06e-12 +- 3.19e-13 (stat) cm-2 s-1
-Integrated flux (>1 TeV)       : 9.909 +- 1.536 (% Crab)
-Integrated flux (1-10 TeV)     : 6.24e-12 +- 1.22e-12 (stat) erg cm-2 s-1
-
-*** Spectral points ***
-
-SED reference id          : 2008AIPC.1085..372C
-Number of spectral points : 11
-Number of upper limits    : 0
-
-e_ref       dnde         dnde_errn       dnde_errp   
- TeV  1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
------ --------------- --------------- ---------------
-  0.6     9.94175e-12     3.30083e-12     3.26451e-12
-  0.9     6.81516e-12     1.04206e-12     1.02928e-12
-  1.3     1.70718e-12     3.88868e-13     3.82595e-13
-  1.9     5.02674e-13     1.56604e-13     1.53321e-13
-  2.8     3.26588e-13     7.52648e-14     7.32347e-14
-  4.0     8.18333e-14     3.60923e-14     3.50318e-14
-  5.9      2.9794e-14      1.9812e-14     1.92094e-14
-  8.6      4.0217e-15     9.06779e-15     8.72854e-15
- 12.7    -6.64708e-15     3.78572e-15     3.67482e-15
- 18.5     3.73541e-15     2.00875e-15     1.78617e-15
- 27.2    -5.31736e-16      9.2363e-16     8.56839e-16
+e_ref        dnde         dnde_errn       dnde_errp   
+ TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+------ --------------- --------------- ---------------
+ 0.323       2.736e-11       5.690e-12       5.971e-12
+ 0.427       1.554e-11       3.356e-12       3.559e-12
+ 0.574       8.142e-12       1.603e-12       1.716e-12
+ 0.777       4.567e-12       9.319e-13       1.007e-12
+ 1.023       2.669e-12       5.586e-13       6.110e-13
+ 1.373       1.518e-12       3.378e-13       3.721e-13
+ 1.841       7.966e-13       2.166e-13       2.426e-13
+ 2.476       3.570e-13       1.135e-13       1.295e-13
+ 3.159       3.321e-13       8.757e-14       1.012e-13
+ 4.414       1.934e-13       5.764e-14       6.857e-14
+ 5.560       4.461e-14       2.130e-14       2.844e-14
+10.765       1.318e-14       6.056e-15       1.085e-14
+22.052       1.372e-14       6.128e-15       1.178e-14
 """
-}

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -13,6 +13,7 @@ SOURCES = [
     {
         'name': 'Vela X',
 
+        'spec_type': 'ecpl',
         'dnde_1TeV': 1.36e-11 * u.Unit('cm-2 s-1 TeV-1'),
         'dnde_1TeV_err': 7.531e-13 * u.Unit('cm-2 s-1 TeV-1'),
         'flux_1TeV': 2.104e-11 * u.Unit('cm-2 s-1'),
@@ -25,6 +26,7 @@ SOURCES = [
     {
         'name': 'HESS J1848-018',
 
+        'spec_type': 'pl',
         'dnde_1TeV': 3.7e-12 * u.Unit('cm-2 s-1 TeV-1'),
         'dnde_1TeV_err': 4e-13 * u.Unit('cm-2 s-1 TeV-1'),
         'flux_1TeV': 2.056e-12 * u.Unit('cm-2 s-1'),
@@ -37,6 +39,7 @@ SOURCES = [
     {
         'name': 'HESS J1813-178',
 
+        'spec_type': 'pl2',
         'dnde_1TeV': 2.678e-12 * u.Unit('cm-2 s-1 TeV-1'),
         'dnde_1TeV_err': 2.55e-13 * u.Unit('cm-2 s-1 TeV-1'),
         'flux_1TeV': 2.457e-12 * u.Unit('cm-2 s-1'),
@@ -96,13 +99,11 @@ class TestSourceCatalogObjectGammaCat:
         assert source.data['common_name'] == 'CTA 1'
         assert_quantity_allclose(source.data['dec'], 72.782997 * u.deg)
 
-    def test_str(self, gammacat):
-        source = gammacat[0]
-        ss = str(source) # CTA 1
-        assert 'Common name     : CTA 1' in ss
-        assert 'RA                   : 1.650 deg' in ss
-        assert 'norm            : 9.1e-14 +- 1.3e-14 cm-2 s-1 TeV-1 (statistical)' in ss
-        assert 'Integrated flux (<1 TeV)       : 8.5e-13 +- 1.3e-13 cm-2 s-1 (statistical)' in ss
+    @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
+    def test_str(self, gammacat, ref):
+        ss = gammacat[ref['name']]._info_spectral_fit()
+        print(ss)
+        assert ss == STRING_REPRESENTATION[ref['name']]
 
     def test_data_python_dict(self, gammacat):
         source = gammacat[0]
@@ -117,6 +118,8 @@ class TestSourceCatalogObjectGammaCat:
     def test_spectral_model(self, gammacat, ref):
         source = gammacat[ref['name']]
         spectral_model = source.spectral_model
+
+        assert source.data['spec_type'] == ref['spec_type']
 
         e_min, e_max, e_inf = [1, 10, 1e10] * u.TeV
 
@@ -277,3 +280,72 @@ class TestGammaCatResourceIndex:
         resource_index = self.resource_index.query('type == "sed" and source_id == 42')
         assert len(resource_index.resources) == 1
         assert resource_index.resources[0].global_id == '42|2010A&A...516A..62A|2|sed'
+
+
+STRING_REPRESENTATION = {
+    'Vela X': """
+*** Spectral info ***
+
+Significance    : 27.900
+Livetime        : 53.100 h
+
+Spectrum type   : ecpl
+norm            : 1.46e-11 +- 8e-13 (stat) +- 3e-12 (sys) cm-2 s-1 TeV-1
+index           : 1.32 +- 0.06 (stat) +- 0.12 (sys)
+e_cut           : 14.0 +- 1.6 (stat) +- 2.6 (stat) TeV
+reference       : 1.0 TeV
+
+Energy range         : (0.75, nan) TeV
+theta                : 1.2 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 1.36e-11 +- 7.53e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.1e-11 +- 1.97e-12 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 101.425 +- 9.511 (% Crab)
+Integrated flux (1-10 TeV)     : 9.27e-11 +- 9.59e-12 (stat) erg cm-2 s-1
+""",
+    'HESS J1813-178': """
+*** Spectral info ***
+
+Significance    : 13.500
+Livetime        : 9.700 h
+
+Spectrum type   : pl2
+flux            : 1.42e-11 +- 1.1e-12 (stat) +- 3e-13 (sys) cm-2 s-1
+index           : 2.09 +- 0.08 (stat)
+e_min           : 0.2 TeV
+e_max           : nan TeV
+
+Energy range         : (nan, nan) TeV
+theta                : 0.15 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 2.68e-12 +- 2.55e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.46e-12 +- 3.69e-13 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 11.844 +- 1.780 (% Crab)
+Integrated flux (1-10 TeV)     : 8.92e-12 +- 1.46e-12 (stat) erg cm-2 s-1
+""",
+    'HESS J1848-018': """
+*** Spectral info ***
+
+Significance    : 9.000
+Livetime        : 50.000 h
+
+Spectrum type   : pl
+norm            : 3.7e-12 +- 4e-13 (stat) +- 7e-13 (syst) cm-2 s-1 TeV-1
+index           : 2.8 +- 0.2 (stat) +- 0.2 (sys)
+reference       : 1.0 TeV
+
+Energy range         : (0.9, 12.0) TeV
+theta                : 0.2 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 3.7e-12 +- 4e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.06e-12 +- 3.19e-13 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 9.909 +- 1.536 (% Crab)
+Integrated flux (1-10 TeV)     : 6.24e-12 +- 1.22e-12 (stat) erg cm-2 s-1
+"""
+}


### PR DESCRIPTION
This PR improves catalog source str and tests for:

- [x] gamma-cat
- [x] 3FGL (completely broken?)

As far as I can see, just asserting on the whole string is best, i.e. a full test, reference output under version control, simple to implement. The main drawback is that we have so much text in the test file. For now I've put it at the end of the test file, which I think is a good compromise between keeping it simple and close to the test (same file), and avoiding it being very distracting when reading the test file.
