### PR TITLE
Also ignore inf values in norm computation for SkyImage plots

### DIFF
--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -942,7 +942,7 @@ class SkyImage(MapBase):
         kwargs['origin'] = kwargs.get('origin', 'lower')
         kwargs['cmap'] = kwargs.get('cmap', 'afmhot')
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
-        norm = simple_norm(data[~np.isnan(data)], stretch)
+        norm = simple_norm(data[(~np.isnan(data))&(~np.isinf(data))], stretch)
         kwargs.setdefault('norm', norm)
 
         caxes = ax.imshow(data, **kwargs)

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -942,7 +942,7 @@ class SkyImage(MapBase):
         kwargs['origin'] = kwargs.get('origin', 'lower')
         kwargs['cmap'] = kwargs.get('cmap', 'afmhot')
         kwargs['interpolation'] = kwargs.get('interpolation', 'None')
-        norm = simple_norm(data[(~np.isnan(data))&(~np.isinf(data))], stretch)
+        norm = simple_norm(data[np.isfinite(data)], stretch)
         kwargs.setdefault('norm', norm)
 
         caxes = ax.imshow(data, **kwargs)


### PR DESCRIPTION
Very simple fix, similar to #1163, also ignore inf values.