### PR TITLE
Improvements and Bug Fixes for I/O methods in gammapy.maps

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -103,8 +103,6 @@ def find_and_read_bands(hdu, header=None):
         for i in range(5):
             if 'AXCOLS%i' % i in hdu.header:
                 axis_cols += [hdu.header['AXCOLS%i' % i].split(',')]
-            else:
-                break
 
     for i, cols in enumerate(axis_cols):
 
@@ -975,14 +973,14 @@ class MapGeom(object):
         for i, ax in enumerate(self.axes):
 
             if ax.name == 'energy' and ax.node_type == 'edge':
-                header['AXCOLS%i' % i] = 'E_MIN,E_MAX'
+                header['AXCOLS%i' % (i + 1)] = 'E_MIN,E_MAX'
             elif ax.name == 'energy' and ax.node_type == 'center':
-                header['AXCOLS%i' % i] = 'ENERGY'
+                header['AXCOLS%i' % (i + 1)] = 'ENERGY'
             elif ax.node_type == 'edge':
-                header['AXCOLS%i' % i] = '{}_MIN,{}_MAX'.format(ax.name.upper(),
-                                                                ax.name.upper())
+                header['AXCOLS%i' % (i + 1)] = '{}_MIN,{}_MAX'.format(ax.name.upper(),
+                                                                      ax.name.upper())
             elif ax.node_type == 'center':
-                header['AXCOLS%i' % i] = ax.name.upper()
+                header['AXCOLS%i' % (i + 1)] = ax.name.upper()
             else:
                 raise ValueError('Invalid node type '
                                  '{}'.format(ax.node_type))

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1073,13 +1073,11 @@ class HpxGeom(MapGeom):
         """"Build and return FITS header for this HEALPIX map."""
 
         header = fits.Header()
-        print(kwargs)
         conv = kwargs.get('conv', HPX_FITS_CONVENTIONS['gadf'])
 
         # FIXME: For some sparse maps we may want to allow EXPLICIT
         # with an empty region string
         indxschm = kwargs.get('indxschm', None)
-        #'EXPLICIT' if self._region else 'IMPLICIT')
 
         if indxschm is None:
             if self._region is None:

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -49,30 +49,30 @@ class HpxConv(object):
         return '{}{}'.format(self.colstring, indx)
 
     @classmethod
-    def create(cls, convname='GADF'):
+    def create(cls, convname='gadf'):
         return copy.deepcopy(HPX_FITS_CONVENTIONS[convname])
 
 
 # Various conventions for storing HEALPIX maps in FITS files
 HPX_FITS_CONVENTIONS = OrderedDict()
-HPX_FITS_CONVENTIONS[None] = HpxConv('GADF', bands_hdu='BANDS')
-HPX_FITS_CONVENTIONS['GADF'] = HpxConv('GADF', bands_hdu='BANDS')
-HPX_FITS_CONVENTIONS['FGST_CCUBE'] = HpxConv('FGST_CCUBE')
-HPX_FITS_CONVENTIONS['FGST_LTCUBE'] = HpxConv(
-    'FGST_LTCUBE', colstring='COSBINS', extname='EXPOSURE', bands_hdu='CTHETABOUNDS')
-HPX_FITS_CONVENTIONS['FGST_BEXPCUBE'] = HpxConv(
-    'FGST_BEXPCUBE', colstring='ENERGY', extname='HPXEXPOSURES', bands_hdu='ENERGIES')
-HPX_FITS_CONVENTIONS['FGST_SRCMAP'] = HpxConv(
-    'FGST_SRCMAP', extname=None, quantity_type='differential')
-HPX_FITS_CONVENTIONS['FGST_TEMPLATE'] = HpxConv(
-    'FGST_TEMPLATE', colstring='ENERGY', bands_hdu='ENERGIES')
-HPX_FITS_CONVENTIONS['FGST_SRCMAP_SPARSE'] = HpxConv(
-    'FGST_SRCMAP_SPARSE', colstring=None, extname=None, quantity_type='differential')
-HPX_FITS_CONVENTIONS['GALPROP'] = HpxConv(
-    'GALPROP', colstring='Bin', extname='SKYMAP2',
+HPX_FITS_CONVENTIONS[None] = HpxConv('gadf', bands_hdu='BANDS')
+HPX_FITS_CONVENTIONS['gadf'] = HpxConv('gadf', bands_hdu='BANDS')
+HPX_FITS_CONVENTIONS['fgst-ccube'] = HpxConv('fgst-ccube')
+HPX_FITS_CONVENTIONS['fgst-ltcube'] = HpxConv(
+    'fgst-ltcube', colstring='COSBINS', extname='EXPOSURE', bands_hdu='CTHETABOUNDS')
+HPX_FITS_CONVENTIONS['fgst-bexpcube'] = HpxConv(
+    'fgst-bexpcube', colstring='ENERGY', extname='HPXEXPOSURES', bands_hdu='ENERGIES')
+HPX_FITS_CONVENTIONS['fgst-srcmap'] = HpxConv(
+    'fgst-srcmap', extname=None, quantity_type='differential')
+HPX_FITS_CONVENTIONS['fgst-template'] = HpxConv(
+    'fgst-template', colstring='ENERGY', bands_hdu='ENERGIES')
+HPX_FITS_CONVENTIONS['fgst-srcmap-sparse'] = HpxConv(
+    'fgst-srcmap-sparse', colstring=None, extname=None, quantity_type='differential')
+HPX_FITS_CONVENTIONS['galprop'] = HpxConv(
+    'galprop', colstring='Bin', extname='SKYMAP2',
     bands_hdu='ENERGIES', quantity_type='differential', coordsys='COORDTYPE')
-HPX_FITS_CONVENTIONS['GALPROP2'] = HpxConv(
-    'GALPROP', colstring='Bin', extname='SKYMAP2',
+HPX_FITS_CONVENTIONS['galprop2'] = HpxConv(
+    'galprop', colstring='Bin', extname='SKYMAP2',
     bands_hdu='ENERGIES', quantity_type='differential')
 
 
@@ -403,7 +403,7 @@ class HpxGeom(MapGeom):
     """
 
     def __init__(self, nside, nest=True, coordsys='CEL', region=None,
-                 axes=None, conv='GADF', sparse=False):
+                 axes=None, conv='gadf', sparse=False):
 
         # FIXME: Figure out what to do when sparse=True
         # FIXME: Require NSIDE to be power of two when nest=True
@@ -870,7 +870,7 @@ class HpxGeom(MapGeom):
 
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, coordsys='CEL', region=None,
-               axes=None, conv='GADF', skydir=None, width=None):
+               axes=None, conv='gadf', skydir=None, width=None):
         """Create an HpxGeom object.
 
         Parameters
@@ -947,19 +947,19 @@ class HpxGeom(MapGeom):
         # Hopefully the file contains the HPX_CONV keyword specifying
         # the convention used
         try:
-            return header['HPX_CONV']
+            return header['HPX_CONV'].lower()
         except KeyError:
             pass
 
         # Try based on the EXTNAME keyword
         extname = header.get('EXTNAME', None)
         if extname == 'HPXEXPOSURES':
-            return 'FGST_BEXPCUBE'
+            return 'fgst-bexpcube'
         elif extname == 'SKYMAP2':
             if 'COORDTYPE' in header.keys():
-                return 'GALPROP'
+                return 'galprop'
             else:
-                return 'GALPROP2'
+                return 'galprop2'
 
         # Check the name of the first column
         colname = header['TTYPE1']
@@ -967,18 +967,18 @@ class HpxGeom(MapGeom):
             colname = header['TTYPE2']
 
         if colname == 'KEY':
-            return 'FGST_SRCMAP_SPARSE'
+            return 'fgst-srcmap-sparse'
         elif colname == 'ENERGY1':
-            return 'FGST_TEMPLATE'
+            return 'fgst-template'
         elif colname == 'COSBINS':
-            return 'FGST_LTCUBE'
+            return 'fgst-ltcube'
         elif colname == 'Bin0':
-            return 'GALPROP'
+            return 'galprop'
         elif colname == 'CHANNEL1' or colname == 'CHANNEL0':
             if extname == 'SKYMAP':
-                return 'FGST_CCUBE'
+                return 'fgst-ccube'
             else:
-                return 'FGST_SRCMAP'
+                return 'fgst-srcmap'
         else:
             raise ValueError('Could not identify HEALPIX convention')
 
@@ -1073,18 +1073,18 @@ class HpxGeom(MapGeom):
         """"Build and return FITS header for this HEALPIX map."""
 
         header = fits.Header()
-
-        conv = kwargs.get('conv', HPX_FITS_CONVENTIONS['GADF'])
+        print(kwargs)
+        conv = kwargs.get('conv', HPX_FITS_CONVENTIONS['gadf'])
 
         # FIXME: For some sparse maps we may want to allow EXPLICIT
         # with an empty region string
-        indxschm = kwargs.get('indxschm',
-                              'EXPLICIT' if self._region else 'IMPLICIT')
+        indxschm = kwargs.get('indxschm', None)
+        #'EXPLICIT' if self._region else 'IMPLICIT')
 
         if indxschm is None:
             if self._region is None:
                 indxschm = 'IMPLICIT'
-            elif self.nside.size == 1:
+            elif self.is_regular == 1:
                 indxschm = 'EXPLICIT'
             else:
                 indxschm = 'LOCAL'
@@ -1101,9 +1101,7 @@ class HpxGeom(MapGeom):
         header["NSIDE"] = np.max(self._nside)
         header["FIRSTPIX"] = 0
         header["LASTPIX"] = np.max(self._maxpix) - 1
-        header["HPX_CONV"] = conv.convname
-
-        self._fill_header_from_axes(header)
+        header["HPX_CONV"] = conv.convname.upper()
 
         if self.coordsys == 'CEL':
             header['EQUINOX'] = (2000.0,
@@ -1116,7 +1114,8 @@ class HpxGeom(MapGeom):
 
     def make_bands_hdu(self, extname='BANDS'):
 
-        header = self.make_header()
+        header = fits.Header()
+        self._fill_header_from_axes(header)
         cols = make_axes_cols(self.axes)
         if self.nside.size > 1:
             cols += [fits.Column('NSIDE', 'I', array=np.ravel(self.nside)), ]

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -33,7 +33,7 @@ class HpxMap(MapBase):
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, map_type=None, coordsys='CEL',
                data=None, skydir=None, width=None, dtype='float32',
-               region=None, axes=None):
+               region=None, axes=None, conv='gadf'):
         """Factory method to create an empty HEALPix map.
 
         Parameters
@@ -61,13 +61,16 @@ class HpxMap(MapBase):
             geometry will be created.
         axes : list
             List of `~MapAxis` objects for each non-spatial dimension.
+        conv : str, optional
+            FITS format convention ('fgst-ccube', 'fgst-template',
+            'gadf').  Default is 'gadf'.
         """
         from .hpxnd import HpxMapND
         from .hpxsparse import HpxMapSparse
 
         hpx = HpxGeom.create(nside=nside, binsz=binsz,
                              nest=nest, coordsys=coordsys, region=region,
-                             conv=None, axes=axes, skydir=skydir, width=width)
+                             conv=conv, axes=axes, skydir=skydir, width=width)
         if cls.__name__ == 'HpxMapND':
             return HpxMapND(hpx, dtype=dtype)
         elif cls.__name__ == 'HpxMapSparse':
@@ -186,13 +189,12 @@ class HpxMap(MapBase):
 
         from .hpxsparse import HpxMapSparse
 
-        conv = kwargs.get('conv', HpxConv.create('GADF'))
+        conv = kwargs.get('conv', HpxConv.create('gadf'))
 
         data = self.data
         shape = data.shape
         extname = kwargs.get('extname', conv.extname)
         extname_bands = kwargs.get('extname_bands', conv.bands_hdu)
-        extname_bands = conv.bands_hdu
 
         sparse = kwargs.get('sparse', True if isinstance(self, HpxMapSparse)
                             else False)

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -80,6 +80,7 @@ class HpxMapND(HpxMap):
                 idx = chan + (pix,)
             else:
                 idx = (pix,)
+
             map_out.set_by_idx(idx[::-1], vals)
         else:
             for c in colnames:
@@ -347,12 +348,16 @@ class HpxMapND(HpxMap):
 
         idx = pix_tuple_to_idx(idx)
         msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
+        if weights is not None:
+            weights = weights[msk]
         idx = [t[msk] for t in idx]
+
         idx_local = list(self.geom.global_to_local(idx))
         msk = idx_local[0] >= 0
         idx_local = [t[msk] for t in idx_local]
         if weights is not None:
             weights = weights[msk]
+
         idx_local = np.ravel_multi_index(idx_local, self.data.T.shape)
         idx_local, idx_inv = np.unique(idx_local, return_inverse=True)
         weights = np.bincount(idx_inv, weights=weights)
@@ -361,7 +366,7 @@ class HpxMapND(HpxMap):
     def set_by_idx(self, idx, vals):
 
         idx = pix_tuple_to_idx(idx)
-        idx_local = (self.geom[idx[0]],) + tuple(idx[1:])
+        idx_local = self.geom.global_to_local(idx)
         self.data.T[idx_local] = vals
 
     def _make_cols(self, header, conv):

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -19,6 +19,7 @@ hpx_test_geoms = [
     (8, False, 'GAL', None, None),
     (8, False, 'GAL', None, axes1),
     ([4, 8], False, 'GAL', None, axes1),
+    ([4, 8], False, 'GAL', 'DISK(110.,75.,10.)', axes1),
     (8, False, 'GAL', 'DISK(110.,75.,10.)',
      [MapAxis(np.logspace(0., 3., 4))]),
     (8, False, 'GAL', 'DISK(110.,75.,10.)',

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -190,7 +190,7 @@ class WcsGeom(MapGeom):
 
     @classmethod
     def create(cls, npix=None, binsz=0.5, proj='CAR', coordsys='CEL', refpix=None,
-               axes=None, skydir=None, width=None, conv=None):
+               axes=None, skydir=None, width=None, conv='gadf'):
         """Create a WCS geometry object.
 
         Pixelization of the map is set with
@@ -316,8 +316,6 @@ class WcsGeom(MapGeom):
             elif hdu_bands.name == 'ENERGIES':
                 conv = 'fgst-template'
 
-        # FIXME: Propagate CRPIX
-
         if hdu_bands is not None and 'NPIX' in hdu_bands.columns.names:
             npix = hdu_bands.data.field('NPIX').reshape(shape + (2,))
             npix = (npix[..., 0], npix[..., 1])
@@ -339,7 +337,8 @@ class WcsGeom(MapGeom):
 
     def make_bands_hdu(self, extname=None, conv=None):
         conv = self._conv if conv is None else conv
-        header = self.make_header(conv)
+        header = fits.Header()
+        self._fill_header_from_axes(header)
         axis_names = None
 
         # FIXME: Check whether convention is compatible with
@@ -371,7 +370,6 @@ class WcsGeom(MapGeom):
 
     def make_header(self, conv=None):
         header = self.wcs.to_header()
-        self._fill_header_from_axes(header)
         header['WCSSHAPE'] = '({},{})'.format(np.max(self.npix[0]),
                                               np.max(self.npix[1]))
         return header

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -26,7 +26,7 @@ class WcsMap(MapBase):
     @classmethod
     def create(cls, map_type=None, npix=None, binsz=0.1, width=None,
                proj='CAR', coordsys='CEL', refpix=None,
-               axes=None, skydir=None, dtype='float32', conv=None):
+               axes=None, skydir=None, dtype='float32', conv='gadf'):
         """Factory method to create an empty WCS map.
 
         Parameters


### PR DESCRIPTION
This PR includes miscellaneous cleanup and bug fixes for I/O methods in `gammapy.maps`:
* Switch to 1-based indexing for `AXCOLS` header keyword.
* Eliminate duplication of header keywords in BANDS and map HDUs.
* Fix a bug in `HpxMapND.fill_by_idx` and add a test case for multi-resolution, partial-sky maps.
* Make `gadf` the default format convention for factory methods.
* Use lower-case consistently for all format convention names.