### PR TITLE
Consistently use mode='constant' in convolutions of RingBackgroundEstimator

### DIFF
--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -328,7 +328,7 @@ class RingBackgroundEstimator(object):
 
         exposure_on_excluded = SkyImage(data=exposure_on.data * exclusion.data, wcs=wcs)
 
-        result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='reflect',
+        result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='constant',
                                                                use_fft=p['use_fft_convolution'])
 
         with np.errstate(divide='ignore'):

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -93,10 +93,10 @@ class TestIACTBasicImageEstimator:
     def test_run(self):
         images = OrderedDict()
         images['counts'] = dict(sum=2222.0)
-        images['background'] = dict(sum=1827.9166666666665)
+        images['background'] = dict(sum=1885.083333333333)
         images['exposure'] = dict(sum=83036669325.30281)
-        images['excess'] = dict(sum=394.0833333333333)
-        images['flux'] = dict(sum=8.477134335825048e-07)
+        images['excess'] = dict(sum=336.91666666666674)
+        images['flux'] = dict(sum=5.250525628586507e-07)
         images['psf'] = dict(sum=1.)
         results = self.estimator.run(self.observations)
 


### PR DESCRIPTION
Commit 6d614a1c86e01f109f5b9d229beed58fe9265606 has set the `mode` keyword of `scipy.ndimage.convolve` to `'constant'` for the computation of the background counts, but not for the exposure. This leads to wrong results and should be fixed by this PR.