### PR TITLE
Bug fix in gammapy.maps interpolation

### DIFF
--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -660,16 +660,24 @@ class HpxGeom(MapGeom):
 
         return coords
 
-    def pix_to_idx(self, pix):
+    def pix_to_idx(self, pix, clip=False):
 
-        # FIXME: Correctly apply bounds on non-spatial pixel
-        # coordinates
+        # FIXME: Look for better method to clip HPX indices
         idx = list(pix_tuple_to_idx(pix, copy=True))
         idx_local = self.global_to_local(idx)
         for i, _ in enumerate(idx):
-            idx[i][(idx_local[i] < 0) | (idx[i] < 0)] = -1
-            if i > 0:
-                idx[i][idx[i] > self.axes[i - 1].nbin - 1] = -1
+
+            if clip:
+                if i > 0:
+                    np.clip(idx[i], 0, self.axes[i - 1].nbin - 1, out=idx[i])
+                else:
+                    np.clip(idx[i], 0, None, out=idx[i])
+            else:
+                if i > 0:
+                    np.putmask(idx[i],
+                               (idx[i] < 0) | (idx[i] >= self.axes[i - 1].nbin), -1)
+                else:
+                    np.putmask(idx[i], (idx_local[i] < 0) | (idx[i] < 0), -1)
 
         return tuple(idx)
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -312,8 +312,8 @@ class HpxMapND(HpxMap):
         import healpy as hp
 
         c = MapCoords.create(coords)
-        pix, wts = self._get_interp_weights(coords,
-                                            self.geom.coord_to_idx(c)[1:])
+        idx_ax = self.geom.coord_to_idx(c, clip=True)[1:]
+        pix, wts = self._get_interp_weights(coords, idx_ax)
 
         if self.geom.ndim == 2:
             return np.sum(self.data.T[pix] * wts, axis=0)
@@ -327,7 +327,7 @@ class HpxMapND(HpxMap):
             for j, ax in enumerate(self.geom.axes):
 
                 idx = coord_to_idx(ax.center[:-1],
-                                   c[2 + j], bounded=True)  # [None, ...]
+                                   c[2 + j], clip=True)  # [None, ...]
 
                 w = ax.center[idx + 1] - ax.center[idx]
                 if (i & (1 << j)):

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -204,6 +204,7 @@ def test_hpxgeom_coord_to_idx(nside, nested, coordsys, region, axes):
     for i, z in enumerate(zidx):
         assert_allclose(z, idx[i + 1])
 
+    # Test w/ coords outside the geometry
     lon = np.array([0.0, 5.0, 10.0])
     lat = np.array([75.3, 75.3, 74.6])
     coords = make_test_coords(geom, lon, lat)
@@ -211,8 +212,11 @@ def test_hpxgeom_coord_to_idx(nside, nested, coordsys, region, axes):
 
     idx = geom.coord_to_idx(coords)
     if geom.region is not None:
-        assert_allclose(-1 * np.ones(len(coords[0]), dtype=int),
-                        idx[0])
+        assert_allclose(np.full_like(coords[0], -1, dtype=int), idx[0])
+
+    idx = geom.coord_to_idx(coords, clip=True)
+    assert(np.all(np.not_equal(np.full_like(
+        coords[0], -1, dtype=int), idx[0])))
 
 
 def test_hpxgeom_coord_to_pix():
@@ -346,7 +350,7 @@ def test_hpxgeom_contains(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
     coords = geom.get_coords(flat=True)
     assert_allclose(geom.contains(coords),
-                    np.ones(coords[0].shape, dtype=bool))
+                    np.ones_like(coords[0], dtype=bool))
 
     if axes is not None:
         coords = [c[0] for c in coords[:2]] + \

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -72,6 +72,16 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(geom.get_idx()[0],
                     geom.coord_to_idx(geom.get_coords())[0])
 
+    if not geom.is_allsky:
+        coords = geom.center_coord[:2] + \
+            tuple([ax.center[0] for ax in geom.axes])
+        coords[0][...] += 2.0 * np.max(geom.width[0])
+        idx = geom.coord_to_idx(coords)
+        assert_allclose(np.full_like(coords[0], -1, dtype=int), idx[0])
+        idx = geom.coord_to_idx(coords, clip=True)
+        assert(np.all(np.not_equal(np.full_like(
+            coords[0], -1, dtype=int), idx[0])))
+
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)


### PR DESCRIPTION
This PR fixes an indexing bug that was breaking interpolation on a `HpxMapND` when the argument included coordinates outside the map.  To facilitate getting a valid index when interpolating on points outside a geometry I added a `clip` option to `MapGeom.coord_to_idx` and `MapGeom.pix_to_idx` which returns the closest index to the given coordinate (for consistency I also renamed this option for `MapAxis` methods).  

Note that for HEALPix maps it's not obvious what the `clip` option should do for spatial indices since healpix pixels are not contiguous on the sky.  Ideally one would identify the healpix pixel in the geometry that is closest to the given coordinate but I think this might be too computationally expensive.  For now the method is just clipping the spatial index to 0.  I've left a FIXME comment for now but we should probably revisit this in a future PR.