### PR TITLE
Finish integration of Jupyter notebooks with Sphinx docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,15 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject nbsphinx ipython'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa regions reproject nbsphinx ipython'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils regions reproject nbsphinx ipython'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject nbsphinx ipython'
-        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy regions reproject nbsphinx ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject nbsphinx ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy libgfortran runipy regions reproject nbsphinx ipython'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject pandoc ipython'
+        - CONDA_DOCS_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils pygments aplpy regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml scikit-image scikit-learn pandas naima photutils aplpy libgfortran runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='uncertainties'
+        - PIP_DEPENDENCIES='uncertainties nbsphinx==0.2.17'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,8 @@ recursive-include dev *
 prune build
 prune docs/_build
 prune docs/api
+prune docs/notebooks
+prune docs/_static/notebooks
 
 recursive-include astropy_helpers *
 exclude astropy_helpers/.git

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build dist docs/_build docs/api docs/notebooks htmlcov MANIFEST gammapy.egg-info .coverage .cache
+	rm -rf build dist docs/_build docs/api docs/notebooks _static/notebooks htmlcov MANIFEST gammapy.egg-info .coverage .cache
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find gammapy -name '*.c' -exec rm {} \;

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo ''
 
 clean:
-	rm -rf build dist docs/_build docs/api docs/notebooks _static/notebooks htmlcov MANIFEST gammapy.egg-info .coverage .cache
+	rm -rf build dist docs/_build docs/api docs/notebooks docs/_static/notebooks htmlcov MANIFEST gammapy.egg-info .coverage .cache
 	find . -name "*.pyc" -exec rm {} \;
 	find . -name "*.so" -exec rm {} \;
 	find gammapy -name '*.c' -exec rm {} \;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,10 +28,6 @@
 import datetime
 import os
 import sys
-from shutil import copytree, rmtree
-import re
-import nbformat
-from nbformat.v4 import new_markdown_cell
 
 try:
     import astropy_helpers
@@ -197,60 +193,9 @@ if on_rtd:
 from gammapy.utils.docs import gammapy_sphinx_ext_activate
 gammapy_sphinx_ext_activate()
 
-# ---
-# notebooks
-# make relative links
-DOWNLOAD_CELL = """
-<div class='admonition note'>
-[Download notebook](../_static/notebooks/nbfilename.ipynb)
-
-This is a *fixed-text* formatted version of a Jupyter notebook. """
-if on_rtd:
-    DOWNLOAD_CELL += """
-    You may download the whole HTML documentation for this version of gammapy
-    using the link at the bottom of this page and execute the notebooks
-    in your local desktop inside the `_static/notebooks/` folder.
-    """
-DOWNLOAD_CELL += """</div>"""
-
-url_docs = setup_cfg.get('url_docs')
-
-def modif_links(folder):
-    for filename in os.listdir(folder):
-        filepath = os.path.join(folder, filename)
-        if os.path.isfile(filepath) and filepath[-6:] == '.ipynb':
-            if folder=='notebooks':
-                strcell = DOWNLOAD_CELL.replace('nbfilename.ipynb', filename)
-                nb = nbformat.read(filepath, as_version=nbformat.NO_CONVERT)
-                nb.cells.insert(0, new_markdown_cell(strcell))
-                nbformat.write(nb, filepath)
-            with open(filepath, "r") as f:
-                txt = f.read()
-            if folder=='notebooks':
-                txt = re.sub(url_docs+'(.*?)html(\)|#)',r'..\1rst\2', txt, flags=re.M|re.I)
-            if folder=='_static/notebooks':
-                txt = re.sub(url_docs+'(.*?)html(\)|#)',r'..\/..\1html\2', txt, flags=re.M|re.I)
-            with open(filepath, "w") as f:
-                f.write(txt)
-
-# remove existing notebooks if rebuilding
-if eval(setup_cfg.get('rebuild_notebooks')):
-    rmtree('notebooks', ignore_errors=True)
-    rmtree('_static/notebooks', ignore_errors=True)
-
-# copy and build notebooks if empty
-if os.environ.get('GAMMAPY_EXTRA') and not os.path.isdir("notebooks"):
-    gammapy_extra_notebooks_folder = os.environ['GAMMAPY_EXTRA'] + '/notebooks'
-    if os.path.isdir(gammapy_extra_notebooks_folder):
-        ignorefiles = lambda d, files: [f for f in files
-            if os.path.isfile(os.path.join(d, f)) and f[-6:] != '.ipynb' and f[-4:] != '.png']
-        copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
-        copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
-        os.system('jupyter nbconvert --to script _static/notebooks/*.ipynb')
-        modif_links('notebooks')
-        modif_links('_static/notebooks')
-
-# ---
+# integration of notebooks from gamapy-extra repo
+from gammapy.utils.docs import gammapy_sphinx_notebooks
+gammapy_sphinx_notebooks(setup_cfg)
 
 html_style = 'gammapy.css'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,11 @@ exclude_patterns.append('**.ipynb_checkpoints')
 extensions.append('nbsphinx')
 extensions.append('IPython.sphinxext.ipython_console_highlighting')
 extensions.append('sphinx.ext.mathjax')
-nbsphinx_execute = 'never'
+if eval(setup_cfg.get('execute_notebooks')):
+    nbsphinx_execute = 'always'
+else:
+    nbsphinx_execute = 'never'
+
 # --
 
 # This is added to the end of RST files - a good place to put substitutions to

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,10 +88,7 @@ exclude_patterns.append('**.ipynb_checkpoints')
 extensions.append('nbsphinx')
 extensions.append('IPython.sphinxext.ipython_console_highlighting')
 extensions.append('sphinx.ext.mathjax')
-if eval(setup_cfg.get('execute_notebooks')):
-    nbsphinx_execute = 'always'
-else:
-    nbsphinx_execute = 'never'
+nbsphinx_execute = setup_cfg['execute_notebooks']
 
 # --
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@
 import datetime
 import os
 import sys
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 try:
     import astropy_helpers
@@ -80,6 +80,7 @@ intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')
+exclude_patterns.append('_static')
 exclude_patterns.append('**.ipynb_checkpoints')
 
 
@@ -190,10 +191,13 @@ from gammapy.utils.docs import gammapy_sphinx_ext_activate
 gammapy_sphinx_ext_activate()
 
 # copy notebooks
-if os.environ['GAMMAPY_EXTRA']:
+if os.environ.get('GAMMAPY_EXTRA'):
     gammapy_extra_notebooks_folder = os.environ['GAMMAPY_EXTRA'] + '/notebooks'
     if os.path.isdir(gammapy_extra_notebooks_folder):
-        copy_tree(gammapy_extra_notebooks_folder, 'notebooks')
+        ignorefiles = lambda d, files: [f for f in files
+            if os.path.isfile(os.path.join(d, f)) and f[-6:] != '.ipynb' and f[-4:] != '.png']
+        copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
+        copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
 
 html_style = 'gammapy.css'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@
 import datetime
 import os
 import sys
-from shutil import copytree
+from shutil import copytree, rmtree
 
 try:
     import astropy_helpers
@@ -191,6 +191,10 @@ from gammapy.utils.docs import gammapy_sphinx_ext_activate
 gammapy_sphinx_ext_activate()
 
 # copy notebooks
+if eval(setup_cfg.get('rebuild_notebooks')):
+    rmtree('notebooks', ignore_errors=True)
+    rmtree('_static/notebooks', ignore_errors=True)
+
 if os.environ.get('GAMMAPY_EXTRA'):
     gammapy_extra_notebooks_folder = os.environ['GAMMAPY_EXTRA'] + '/notebooks'
     if os.path.isdir(gammapy_extra_notebooks_folder):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -246,6 +246,7 @@ if os.environ.get('GAMMAPY_EXTRA') and not os.path.isdir("notebooks"):
             if os.path.isfile(os.path.join(d, f)) and f[-6:] != '.ipynb' and f[-4:] != '.png']
         copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
         copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
+        os.system('jupyter nbconvert --to script _static/notebooks/*.ipynb')
         modif_links('notebooks')
         modif_links('_static/notebooks')
 

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -25,7 +25,7 @@ The functions have a naming pattern (following the `sklearn.datasets` lead):
           And there is a separate section describing the :ref:`dataformats`
           that are commonly used in gamma-ray astronomy.
 
-.. _gammapy-extra:
+.. _gammapyextra:
 
 gammapy-extra
 =============

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -50,7 +50,7 @@ The equivalent of ``make clean`` is:
 
 .. code-block:: bash
 
-    $ rm -r build docs/_build docs/api htmlcov
+    $ rm -r build docs/_build docs/api htmlcov docs/notebooks docs/_static/notebooks
 
 These folders only contain generated files and are always safe to delete!
 Most of the time you don't have to delete them, but if you e.g. remove or rename files or functions / classes,
@@ -64,6 +64,7 @@ on travis-ci or for other developers.
 * The  ``docs/_build`` folder is where ``python setup.py build_docs`` generates the HTML and other Sphinx
   documentation output files.
 * The ``htmlcov`` folder is where ``python setup.py test --coverage`` generates the HTML coverage report.
+* The ``docs/notebooks`` and ``docs/_static/notebooks`` folders are where *fixed* and *live* versions of Jupyter notebooks files are stored.
 
 If you use ``python setup.py build_ext --inplace``, then files are generated in the ``gammapy`` source folder.
 Usually that's not a problem, but if you want to clean up those generated files, you can use
@@ -528,6 +529,14 @@ You need a bunch or LaTeX stuff, specifically ``texlive-fonts-extra`` is needed.
 The PDF is also generated on Read the Docs and available online here:
 https://media.readthedocs.org/pdf/gammapy/latest/gammapy.pdf
 
+Jupyter notebooks present in the `gammapy-extra` repository are by default copied
+to the `docs/notebooks` and `docs/_static/notebooks` tree-folder structure during
+the process of generating HTML docs. This triggers its conversion to *fixed-text*
+Sphinx formatted documentation files and at the same time provides access to raw
+.ipynb Jupyter notebooks for the same version of the gammapy documentation. This
+behaviour may be modified in the  `setup.cfg` configuration file changing the
+value of `rebuild_notebooks` boolean.
+
 Documentation guidelines
 ------------------------
 
@@ -827,7 +836,7 @@ In Gammapy, we use interpolation a lot, e.g. to evaluate instrument response fun
 data grids, or to reproject diffuse models on data grids.
 
 Note: For some use cases that require interpolation the
-`~gammapy.utils.nddata.NDDataArray` base class might be useful. 
+`~gammapy.utils.nddata.NDDataArray` base class might be useful.
 
 The default interpolator we use is `scipy.interpolate.RegularGridInterpolator` because it's fast and robust
 (more fancy interpolation schemes can lead to unstable response in some cases, so more careful checking
@@ -959,7 +968,7 @@ and have an coherent I/O interface, mainly in `~gammapy.irf`.
 A usage example can be found in :gp-extra-notebooks:``nddata_demo``.
 
 Also, consult :ref:`interpolation-extrapolation` if you are not sure how to
-setup your interpolator. 
+setup your interpolator.
 
 
 Write a test for an IPython notebook

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -535,7 +535,7 @@ the process of generating HTML docs. This triggers its conversion to *fixed-text
 Sphinx formatted documentation files and at the same time provides access to raw
 .ipynb Jupyter notebooks for the same version of the gammapy documentation. This
 behaviour may be modified in the  `setup.cfg` configuration file changing the
-value of `rebuild_notebooks` boolean.
+value of `clean_notebooks` boolean.
 
 Documentation guidelines
 ------------------------

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,5 +19,6 @@ dependencies:
   - sphinx
   - pyyaml
   - ipython
+  - pandoc
   - pip:
     - nbsphinx==0.2.17

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,5 +18,6 @@ dependencies:
   - aplpy
   - sphinx
   - pyyaml
-  - nbsphinx
   - ipython
+  - pip:
+    - nbsphinx==0.2.17

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -41,7 +41,7 @@ To check if the Gammapy command line tools have been installed and are available
     $ gammapy-info --version
 
 The Gammapy tutorials use some example datasets that are stored in the ``gammapy-extra`` repository on Github.
-So please go follow the instructions at :ref:`gammapy-extra` to fetch those, then come back here.
+So please go follow the instructions at :ref:`gammapyextra` to fetch those, then come back here.
 
 To check if ``gammapy-extra`` is available and the ``GAMMAPY_EXTRA`` shell environment variable set, use this command::
 
@@ -157,4 +157,3 @@ If you'd like to continue with tutorials to learn Gammapy, go here: :ref:`tutori
 To learn about some specific functionality that could be useful for your work,
 start browsing the "Getting Started" section of Gammapy sub-package that
 might be of interest to you (e.g. `gammapy.data`, `gammapy.catalog`, `gammapy.spectrum`, ...).
-

--- a/docs/install/dependencies.rst
+++ b/docs/install/dependencies.rst
@@ -54,4 +54,4 @@ Allowed optional dependencies:
 * `emcee`_ for fitting by MCMC sampling
 * `h5py`_ for `HDF5 <http://en.wikipedia.org/wiki/Hierarchical_Data_Format>`__ data handling
 * `healpy`_ for `HEALPIX <http://healpix.jpl.nasa.gov/>`__ data handling
-
+* `nbsphinx`_ for transformation of Jupyter notebooks into fixed-text documentation 

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -8,8 +8,8 @@ Gammapy tutorial notebooks
 What is this?
 -------------
 
--  This is an overview of tutorial `Jupyter <http://jupyter.org/>`
-   notebooks for `Gammapy <http://gammapy.org>`, a Python package for
+-  This is an overview of tutorial `Jupyter <http://jupyter.org/>`__
+   notebooks for `Gammapy <http://gammapy.org>`__, a Python package for
    gamma-ray astronomy.
 -  The notebooks complement the Gammapy Sphinx-based documentation at
    http://docs.gammapy.org
@@ -25,8 +25,10 @@ install Gammapy and get the ``gammapy-extra`` repository. This is
 described in `Gammapy tutorial
 setup <notebooks/tutorial_setup.html>`__.
 
-You may also download the whole HTML documentation for this version of gammapy
-and execute the notebooks in your local desktop inside the `_static/notebooks/` folder.
+You can also download for each version of *gammapy* a
+`HTMLZip pack <http://readthedocs.org/projects/gammapy/downloads/>`__
+containing the whole documentation and full collection of notebooks, so you can execute
+them in your local desktop inside the `_static/notebooks/` folder.
 
 The basics
 ----------
@@ -54,46 +56,46 @@ Notebooks
 If you're new to Astro (haven't used ``Table``, ``SkyCoord`` and
 ``Time`` much), start here:
 
--  `Astropy introduction for Gammapy users <notebooks/astropy_introduction.html>`__
+-  `Astropy introduction for Gammapy users <notebooks/astropy_introduction.html>`__  | *astropy_introduction.ipynb*
 -  `Astropy Hands On (1st ASTERICS-OBELICS International School) <https://github.com/Asterics2020-Obelics/School2017/blob/master/astropy/astropy_hands_on.ipynb>`__
 
 For a quick introduction to Gammapy, go here:
 
--  `First steps with Gammapy <notebooks/first_steps.html>`__
+-  `First steps with Gammapy <notebooks/first_steps.html>`__  | *first_steps.ipynb*
 
 Interested to do a first analysis of simulated CTA data?
 
--  `CTA first data challenge (1DC) with Gammapy <notebooks/cta_1dc_introduction.html>`__
--  `CTA data analysis with Gammapy <notebooks/cta_data_analysis.html>`__
+-  `CTA first data challenge (1DC) with Gammapy <notebooks/cta_1dc_introduction.html>`__ | *cta_1dc_introduction.ipynb*
+-  `CTA data analysis with Gammapy <notebooks/cta_data_analysis.html>`__ | *cta_data_analysis.ipynb*
 
 To learn how to work with gamma-ray data with Gammapy:
 
--  `IACT DL3 data with Gammapy <notebooks/data_iact.html>`__ (H.E.S.S data example)
--  `Fermi-LAT data with Gammapy <notebooks/data_fermi_lat.html>`__ (Fermi-LAT data example)
+-  `IACT DL3 data with Gammapy <notebooks/data_iact.html>`__ (H.E.S.S data example) | *data_iact.ipynb*
+-  `Fermi-LAT data with Gammapy <notebooks/data_fermi_lat.html>`__ (Fermi-LAT data example) | *data_fermi_lat.ipynb*
 
 2-dimensional sky image analysis:
 
--  `Image analysis with Gammapy (run pipeline) <notebooks/image_pipe.html>`__ (H.E.S.S. data example)
--  `Image analysis with Gammapy (individual steps) <notebooks/image_analysis.html>`__ (H.E.S.S. data example)
--  `Source detection with Gammapy <notebooks/detect_ts.html>`__ (Fermi-LAT data example)
+-  `Image analysis with Gammapy (run pipeline) <notebooks/image_pipe.html>`__ (H.E.S.S. data example) | *image_pipe.ipynb*
+-  `Image analysis with Gammapy (individual steps) <notebooks/image_analysis.html>`__ (H.E.S.S. data example) | *image_analysis.ipynb*
+-  `Source detection with Gammapy <notebooks/detect_ts.html>`__ (Fermi-LAT data example) | *detect_ts.ipynb*
 
 1-dimensional spectral analysis:
 
--  `Spectral models in Gammapy <notebooks/spectrum_models.html>`__
--  `Spectral analysis with Gammapy (run pipeline) <notebooks/spectrum_pipe.html>`__ (H.E.S.S. data example)
--  `Spectral analysis with Gammapy (individual steps) <notebooks/spectrum_analysis.html>`__ (H.E.S.S. data example)
--  `Spectrum simulation and fitting <notebooks/cta_simulation.html>`__ (CTA data example with AGN / EBL)
--  `Flux point fitting with Gammapy <notebooks/sed_fitting_gammacat_fermi.html>`__
+-  `Spectral models in Gammapy <notebooks/spectrum_models.html>`__ | *spectrum_models.ipynb*
+-  `Spectral analysis with Gammapy (run pipeline) <notebooks/spectrum_pipe.html>`__ (H.E.S.S. data example) | *spectrum_pipe.ipynb*
+-  `Spectral analysis with Gammapy (individual steps) <notebooks/spectrum_analysis.html>`__ (H.E.S.S. data example) | *spectrum_analysis.ipynb*
+-  `Spectrum simulation and fitting <notebooks/cta_simulation.html>`__ (CTA data example with AGN / EBL) | *cta_simulation.ipynb*
+-  `Flux point fitting with Gammapy <notebooks/sed_fitting_gammacat_fermi.html>`__ | *sed_fitting_gammacat_fermi.ipynb*
 
 3-dimensional cube analysis:
 
--  `Cube analysis with Gammapy (part 1) <notebooks/cube_analysis_part1.html>`__ - compute cubes and mean PSF / EDISP
--  `Cube analysis with Gammapy (part 2) <notebooks/cube_analysis_part2.html>`__ - likelihood fit
+-  `Cube analysis with Gammapy (part 1) <notebooks/cube_analysis_part1.html>`__ (compute cubes and mean PSF / EDISP) | *cube_analysis_part1.ipynb*
+-  `Cube analysis with Gammapy (part 2) <notebooks/cube_analysis_part2.html>`__ (likelihood fit) | *cube_analysis_part2.ipynb*
 
 Time-related analysis:
 
--  `Light curve estimation with Gammapy <notebooks/light_curve.html>`__
--  `Time analysis with Gammapy <notebooks/time_analysis.html>`__ (not written yet)
+-  `Light curve estimation with Gammapy <notebooks/light_curve.html>`__ | *light_curve.ipynb*
+-  `Time analysis with Gammapy <notebooks/time_analysis.html>`__ (not written yet) | *time_analysis.ipynb*
 
 Extra topics
 ~~~~~~~~~~~~
@@ -105,10 +107,10 @@ through all of them, but maybe browse the list and see if there's
 something that could be interesting for your work (or contribute to
 Gammapy if something is missing!).
 
--  `Template background model production with Gammapy <notebooks/background_model.html>`__
--  `Continuous wavelet transform on gamma-ray images <notebooks/cwt.html>`__
--  `Interpolation using the NDDataArray class <notebooks/nddata_demo.html>`__
--  `Rapid introduction on using numpy, scipy, matplotlib <notebooks/using_numpy.html>`__
+-  `Template background model production with Gammapy <notebooks/background_model.html>`__ | *background_model.ipynb*
+-  `Continuous wavelet transform on gamma-ray images <notebooks/cwt.html>`__ | *cwt.ipynb*
+-  `Interpolation using the NDDataArray class <notebooks/nddata_demo.html>`__ | *nddata_demo.ipynb*
+-  `Rapid introduction on using numpy, scipy, matplotlib <notebooks/using_numpy.html>`__ | *using_numpy.ipynb*
 
 Work in progress
 ~~~~~~~~~~~~~~~~
@@ -120,11 +122,11 @@ Please help make these better, or write new, better ones!
 -  TODO: joint Fermi-IACT analysis with Gammpy
 -  TODO: simulate Fermi and CTA sky with Gammapy
 
--  `Astrophysical source population modeling with Gammapy <notebooks/source_population_model.html>`__
--  `Source catalogs <notebooks/source_catalogs.html>`__ : Working with gamma-ray source catalogs
--  `Diffuse model computation <notebooks/diffuse_model_computation.html>`__ : Diffuse model computation
--  `Fermi Vela model <notebooks/fermi_vela_model.html>`__ : Fermi Vela model
--  `Simulating and analysing sources and diffuse emission <notebooks/source_diffuse_estimation.html>`__
+-  `Astrophysical source population modeling with Gammapy <notebooks/source_population_model.html>`__ | *source_population_model.ipynb*
+-  `Source catalogs <notebooks/source_catalogs.html>`__ (working with gamma-ray source catalogs) | *source_catalogs.ipynb*
+-  `Diffuse model computation <notebooks/diffuse_model_computation.html>`__ (diffuse model computation) | *diffuse_model_computation.ipynb*
+-  `Fermi Vela model <notebooks/fermi_vela_model.html>`__ (Fermi Vela model) | *fermi_vela_model.ipynb*
+-  `Simulating and analysing sources and diffuse emission <notebooks/source_diffuse_estimation.html>`__ | *source_diffuse_estimation.ipynb*
 
 List of notebooks
 ~~~~~~~~~~~~~~~~~~

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -13,9 +13,6 @@ What is this?
    gamma-ray astronomy.
 -  The notebooks complement the Gammapy Sphinx-based documentation at
    http://docs.gammapy.org
--  You can read a static HTML version of these notebooks (i.e. code
-   can't be executed) online
-   `here <http://nbviewer.ipython.org/github/gammapy/gammapy-extra/tree/master/notebooks/>`.
 -  The notebooks and example datasets are available at
    https://github.com/gammapy/gammapy-extra
 
@@ -27,6 +24,9 @@ examples, or to try to do one of the exercises, you have to first
 install Gammapy and get the ``gammapy-extra`` repository. This is
 described in `Gammapy tutorial
 setup <notebooks/tutorial_setup.html>`__.
+
+You may also download the whole HTML documentation for this version of gammapy
+and execute the notebooks in your local desktop inside the `_static/notebooks/` folder.
 
 The basics
 ----------

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -105,3 +105,4 @@
 .. _Github clone URL help article: https://help.github.com/articles/which-remote-url-should-i-use/
 
 .. _Gammapy tutorial notebooks on nbviewer: https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/index.ipynb
+.. _nbsphinx: http://nbsphinx.readthedocs.io

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -144,7 +144,7 @@ def gammapy_sphinx_notebooks(setup_cfg):
     url_docs = setup_cfg.get('url_docs')
 
     # remove existing notebooks if rebuilding
-    if eval(setup_cfg.get('rebuild_notebooks')):
+    if bool(setup_cfg.get('clean_notebooks')):
         print('*** Cleaning notebooks')
         rmtree('notebooks', ignore_errors=True)
         rmtree('_static/notebooks', ignore_errors=True)

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -110,18 +110,17 @@ def modif_nb_links(folder, url_docs):
 
     DOWNLOAD_CELL = """
 <div class='admonition note'>
-This is a *fixed-text* formatted version of a Jupyter notebook.
+**This is a fixed-text formatted version of a Jupyter notebook.**
 
 You can download for each version of *gammapy* a
 [HTMLZip pack](http://readthedocs.org/projects/gammapy/downloads/) containing
-the whole documentation and full collection of notebooks, so you can execute
-them in your local _static/notebooks/ folder. You can also contribute with
-your own notebooks in this
-[GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
+the whole HTML documentation and full collection of notebooks, so you can execute
+them in your local `_static/notebooks/` folder. You can also contribute with your
+own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 
-**Download source files:**
+**Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
-[{py_filename}](../_static/notebooks/{py_filename})
+[{py_filename}](../_static/notebooks/{txt_filename})
 </div>"""
 
     for filename in os.listdir(folder):
@@ -129,7 +128,8 @@ your own notebooks in this
         if os.path.isfile(filepath) and filepath[-6:] == '.ipynb':
             if folder=='notebooks':
                 py_filename = filename.replace('ipynb', 'py')
-                ctx = dict(nb_filename=filename, py_filename=py_filename)
+                txt_filename = filename.replace('ipynb', 'txt')
+                ctx = dict(nb_filename=filename, py_filename=py_filename, txt_filename=txt_filename)
                 strcell = DOWNLOAD_CELL.format(**ctx)
                 nb = nbformat.read(filepath, as_version=nbformat.NO_CONVERT)
                 nb.cells.insert(0, new_markdown_cell(strcell))
@@ -142,6 +142,15 @@ your own notebooks in this
                 txt = re.sub(url_docs+'(.*?)html(\)|#)',r'..\/..\1html\2', txt, flags=re.M|re.I)
             with open(filepath, "w") as f:
                 f.write(txt)
+
+def replace_extension(folder):
+    """
+    Replaces extension of .py files so they can be served for download
+    """
+
+    for filename in os.listdir(folder):
+        txtfilename = filename.replace('.py', '.txt')
+        os.rename(os.path.join(folder, filename), os.path.join(folder, txtfilename))
 
 def gammapy_sphinx_notebooks(setup_cfg):
     """
@@ -166,5 +175,6 @@ def gammapy_sphinx_notebooks(setup_cfg):
             copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
             copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
             os.system('jupyter nbconvert --to script _static/notebooks/*.ipynb')
+            replace_extension('_static/notebooks')
             modif_nb_links('notebooks', url_docs)
             modif_nb_links('_static/notebooks', url_docs)

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -18,6 +18,7 @@ Here's some good resources with working examples:
 import os
 import re
 import nbformat
+from sphinx.util import logging
 from nbformat.v4 import new_markdown_cell
 from shutil import copytree, rmtree
 from docutils.parsers.rst.directives.images import Image
@@ -33,6 +34,7 @@ try:
 except KeyError:
     HAS_GP_EXTRA = False
 
+logger = logging.getLogger('__name__')
 
 class ExtraImage(Image):
     """Directive to add optional images from gammapy-extra"""
@@ -88,14 +90,15 @@ def make_link_node(rawtext, app, notebook, options):
 
 
 def gammapy_sphinx_ext_activate():
+
     if HAS_GP_EXTRA:
-        print('*** Found GAMMAPY_EXTRA = {}'.format(gammapy_extra_path))
-        print('*** Nice!')
+        logger.info('*** Found GAMMAPY_EXTRA = {}'.format(gammapy_extra_path))
+        logger.info('*** Nice!')
     else:
-        print('*** gammapy-extra *not* found.')
-        print('*** Set the GAMMAPY_EXTRA environment variable!')
-        print('*** Docs build will be incomplete.')
-        print('*** Notebook links will not be verified.')
+        logger.info('*** gammapy-extra *not* found.')
+        logger.info('*** Set the GAMMAPY_EXTRA environment variable!')
+        logger.info('*** Docs build will be incomplete.')
+        logger.info('*** Notebook links will not be verified.')
 
     # Register our directives and roles with Sphinx
     register_directive('gp-extra-image', ExtraImage)
@@ -121,6 +124,7 @@ own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-ext
 **Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
 [{py_filename}](../_static/notebooks/{txt_filename})
+*(right-click and select "save as")*
 </div>"""
 
     for filename in os.listdir(folder):
@@ -157,11 +161,11 @@ def gammapy_sphinx_notebooks(setup_cfg):
     Manages the processes for the building of sphinx formatted notebooks
     """
 
-    url_docs = setup_cfg.get('url_docs')
+    url_docs = setup_cfg['url_docs']
 
     # remove existing notebooks if rebuilding
-    if bool(setup_cfg.get('clean_notebooks')):
-        print('*** Cleaning notebooks')
+    if bool(setup_cfg['clean_notebooks']):
+        logger.info('*** Cleaning notebooks')
         rmtree('notebooks', ignore_errors=True)
         rmtree('_static/notebooks', ignore_errors=True)
 
@@ -171,7 +175,7 @@ def gammapy_sphinx_notebooks(setup_cfg):
         if os.path.isdir(gammapy_extra_notebooks_folder):
             ignorefiles = lambda d, files: [f for f in files
                 if os.path.isfile(os.path.join(d, f)) and f[-6:] != '.ipynb' and f[-4:] != '.png']
-            print('*** Converting notebooks to scripts')
+            logger.info('*** Converting notebooks to scripts')
             copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
             copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
             os.system('jupyter nbconvert --to script _static/notebooks/*.ipynb')

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -110,25 +110,31 @@ def modif_nb_links(folder, url_docs):
 
     DOWNLOAD_CELL = """
 <div class='admonition note'>
-[Download notebook](../_static/notebooks/{nb_filename})
-
 This is a *fixed-text* formatted version of a Jupyter notebook.
 
-You may download the whole HTML documentation for this version of gammapy
-using the link at the bottom of this page and execute the notebooks
-in your local desktop inside the `_static/notebooks/` folder.
+You can download for each version of *gammapy* a
+[HTMLZip pack](http://readthedocs.org/projects/gammapy/downloads/) containing
+the whole documentation and full collection of notebooks, so you can execute
+them in your local _static/notebooks/ folder. You can also contribute with
+your own notebooks in this
+[GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
+
+**Download source files:**
+[{nb_filename}](../_static/notebooks/{nb_filename}) |
+[{py_filename}](../_static/notebooks/{py_filename})
 </div>"""
 
     for filename in os.listdir(folder):
         filepath = os.path.join(folder, filename)
         if os.path.isfile(filepath) and filepath[-6:] == '.ipynb':
             if folder=='notebooks':
-                ctx = dict(nb_filename=filename)
+                py_filename = filename.replace('ipynb', 'py')
+                ctx = dict(nb_filename=filename, py_filename=py_filename)
                 strcell = DOWNLOAD_CELL.format(**ctx)
                 nb = nbformat.read(filepath, as_version=nbformat.NO_CONVERT)
                 nb.cells.insert(0, new_markdown_cell(strcell))
                 nbformat.write(nb, filepath)
-            with open(filepath, "r") as f:
+            with open(filepath) as f:
                 txt = f.read()
             if folder=='notebooks':
                 txt = re.sub(url_docs+'(.*?)html(\)|#)',r'..\1rst\2', txt, flags=re.M|re.I)
@@ -156,8 +162,9 @@ def gammapy_sphinx_notebooks(setup_cfg):
         if os.path.isdir(gammapy_extra_notebooks_folder):
             ignorefiles = lambda d, files: [f for f in files
                 if os.path.isfile(os.path.join(d, f)) and f[-6:] != '.ipynb' and f[-4:] != '.png']
-            print('*** Building sphinx formatted notebooks')
+            print('*** Converting notebooks to scripts')
             copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
             copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
+            os.system('jupyter nbconvert --to script _static/notebooks/*.ipynb')
             modif_nb_links('notebooks', url_docs)
             modif_nb_links('_static/notebooks', url_docs)

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -110,7 +110,7 @@ def modif_nb_links(folder, url_docs):
 
     DOWNLOAD_CELL = """
 <div class='admonition note'>
-[Download notebook](../_static/notebooks/nbfilename.ipynb)
+[Download notebook](../_static/notebooks/{nb_filename})
 
 This is a *fixed-text* formatted version of a Jupyter notebook.
 
@@ -123,7 +123,8 @@ in your local desktop inside the `_static/notebooks/` folder.
         filepath = os.path.join(folder, filename)
         if os.path.isfile(filepath) and filepath[-6:] == '.ipynb':
             if folder=='notebooks':
-                strcell = DOWNLOAD_CELL.replace('nbfilename.ipynb', filename)
+                ctx = dict(nb_filename=filename)
+                strcell = DOWNLOAD_CELL.format(**ctx)
                 nb = nbformat.read(filepath, as_version=nbformat.NO_CONVERT)
                 nb.cells.insert(0, new_markdown_cell(strcell))
                 nbformat.write(nb, filepath)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ edit_on_github = False
 github_project = gammapy/gammapy
 url_docs = http://docs.gammapy.org/en/latest
 rebuild_notebooks = True
-execute_notebooks = False
+execute_notebooks = never
+#execute_notebooks = always
 
 [entry_points]
 gammapy-info = gammapy.scripts.info:print_info_main

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,8 @@ edit_on_github = False
 github_project = gammapy/gammapy
 url_docs = http://docs.gammapy.org/en/latest
 clean_notebooks = True
+# configure whether to run nbsphinx; see http://nbsphinx.readthedocs.io/en/stable/never-execute.html
 execute_notebooks = never
-#execute_notebooks = always
 
 [entry_points]
 gammapy-info = gammapy.scripts.info:print_info_main

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ url = https://github.com/gammapy/gammapy
 edit_on_github = False
 github_project = gammapy/gammapy
 rebuild_notebooks = True
+execute_notebooks = False
 
 [entry_points]
 gammapy-info = gammapy.scripts.info:print_info_main

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ url = https://github.com/gammapy/gammapy
 edit_on_github = False
 github_project = gammapy/gammapy
 url_docs = http://docs.gammapy.org/en/latest
-rebuild_notebooks = True
+clean_notebooks = True
 execute_notebooks = never
 #execute_notebooks = always
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ license = BSD
 url = https://github.com/gammapy/gammapy
 edit_on_github = False
 github_project = gammapy/gammapy
+rebuild_notebooks = True
 
 [entry_points]
 gammapy-info = gammapy.scripts.info:print_info_main

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ license = BSD
 url = https://github.com/gammapy/gammapy
 edit_on_github = False
 github_project = gammapy/gammapy
+url_docs = http://docs.gammapy.org/en/latest
 rebuild_notebooks = True
 execute_notebooks = False
 


### PR DESCRIPTION
$ `setup.py build_docs` 

- added flag execute_notebooks = False in `setup.cfg` sets no execution of notebooks during the docs building process
- added  flag rebuild_notebooks = True in `setup.cfg` sets always replace notebooks from  $GAMMAPY_EXTRA and rebuild
- copies notebooks from $GAMMAPY_EXTRA to `_static/notebooks` folder, so RST files,  ipynb notebooks, and sphinx formatted notebooks live in the same version/tag
- links added in *fixed-text* sphinx formatted notebooks for downloading *live* *.ipynb notebooks
- transforms absolute links from notebooks to http://docs.gammapy.org website into relative links to RST files, so RST files,  ipynb notebooks, and sphinx formatted notebooks live in the same version/tag
- added some documentation related with these modifs

previous work:
https://github.com/gammapy/gammapy/pull/1176

see generated doc:
http://www.iaa.es/~jer/gammapydocs/notebooks/first_steps.html


