### PR TITLE
Fix flux point computation for non-power-law models

### DIFF
--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -741,7 +741,8 @@ class FluxPointEstimator(object):
         try:
             result = brentq(ts_diff, amplitude_min, amplitude_max,
                             maxiter=100, rtol=1e-2)
-            return 1E-12 * result * u.Unit(fit.model.parameters['amplitude'].unit)
+            fit.model.parameters['amplitude'].value = result * 1E-12
+            return fit.model(fit.model.parameters['reference'].quantity)
         except (RuntimeError, ValueError):
             # Where the root finding fails NaN is set as amplitude
             log.debug('Flux point upper limit computation failed.')

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -11,7 +11,7 @@ from ...catalog.fermi import SourceCatalog3FGL
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.modeling import ParameterList
 from ...spectrum import SpectrumResult, SpectrumFit
-from ...spectrum.models import PowerLaw, SpectralModel
+from ...spectrum.models import PowerLaw, SpectralModel, ExponentialCutoffPowerLaw
 from ..flux_point import FluxPoints
 from ..flux_point import FluxPointProfiles
 from ..flux_point import FluxPointFitter
@@ -154,7 +154,7 @@ def test_compute_flux_points_dnde_exp(method):
 @requires_dependency('sherpa')
 @requires_dependency('matplotlib')
 @requires_dependency('scipy')
-@pytest.mark.parametrize('config', ['pl'])
+@pytest.mark.parametrize('config', ['pl', 'ecpl'])
 def test_flux_points(config):
     if config == 'pl':
         config = dict(
@@ -172,6 +172,24 @@ def test_flux_points(config):
             dnde_ul=3.7998e-11 * u.Unit('cm-2 s-1 TeV-1'),
             res=-0.1126,
             res_err=0.1536,
+        )
+    elif config == 'ecpl':
+        config = dict(
+            model=ExponentialCutoffPowerLaw(
+                index=Quantity(2, ''),
+                amplitude=Quantity(1e-11, 'm-2 s-1 TeV-1'),
+                reference=Quantity(1, 'TeV'),
+                lambda_= Quantity(0.1, 'TeV-1')
+            ),
+            obs=obs(),
+            seg=seg(obs()),
+            dnde=2.7465e-11 * u.Unit('cm-2 s-1 TeV-1'),
+            dnde_err=4.7555e-12 * u.Unit('cm-2 s-1 TeV-1'),
+            dnde_errn=4.5333e-12 * u.Unit('cm-2 s-1 TeV-1'),
+            dnde_errp=5.0050e-12 * u.Unit('cm-2 s-1 TeV-1'),
+            dnde_ul=3.7998e-11 * u.Unit('cm-2 s-1 TeV-1'),
+            res=-0.057955,
+            res_err=0.1634,
         )
 
     tester = FluxPointTester(config)


### PR DESCRIPTION
This PR fixes the issue raised in #1219. The code computed the asymmetric errors for the amplitude of the model, assuming that the parameter value is equal to value when the model is evaluated at the reference energy. This is not the case for an `ExponentialCutoffPowerLaw`. The code was adapted to handle this correctly. 

@facero This is what the fixed RXJ 1713 flux points look like:
![rxj_1713_flux_points_fixed](https://user-images.githubusercontent.com/3715928/33218151-9ece830a-d13b-11e7-9fcd-e5cba93fd265.png)
