### PR TITLE
Change IRF extrapolation behaviour

### DIFF
--- a/gammapy/scripts/tests/test_cta_sensitivity.py
+++ b/gammapy/scripts/tests/test_cta_sensitivity.py
@@ -26,13 +26,13 @@ def test_cta_sensitivity():
     # Assert on relevant values in three energy bins
     # TODO: add asserts on other quantities: excess, exposure
     assert_allclose(table['ENERGY'][0], 0.015848932787775993)
-    assert_allclose(table['FLUX'][0], 1.2234342551880124e-10)
+    assert_allclose(table['FLUX'][0], 1.265689381204479e-10)
 
     assert_allclose(table['ENERGY'][9], 1)
-    assert_allclose(table['FLUX'][9], 4.28759401411e-13)
+    assert_allclose(table['FLUX'][9], 4.2875940141105596e-13)
 
     assert_allclose(table['ENERGY'][20], 158.4893035888672)
-    assert_allclose(table['FLUX'][20], 9.04770579058e-12)
+    assert_allclose(table['FLUX'][20], 9.048305001092968e-12)
 
 
 # TODO: fix this test

--- a/gammapy/scripts/tests/test_cta_utils.py
+++ b/gammapy/scripts/tests/test_cta_utils.py
@@ -84,4 +84,4 @@ def test_cta_simulation():
     assert '*** Observation summary report ***' in text
 
     stats = cta_simu().total_stats
-    assert_allclose(stats.sigma, 36.51439765644547)
+    assert_allclose(stats.sigma, 36.404120931670384)

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.tests.helper import assert_quantity_allclose
+from numpy.testing import assert_allclose
 import astropy.units as u
 from ...utils.energy import EnergyBounds
 from ...utils.testing import requires_dependency, requires_data
@@ -37,9 +37,9 @@ def test_spectrum_analysis_iact(tmpdir):
     analysis.run()
     flux_points = analysis.flux_point_estimator.flux_points
 
-    print(flux_points)
-    print(flux_points.table)
+    assert len(flux_points.table) == 4
 
-    actual = flux_points.table['dnde'].quantity[0]
-    desired = 7.987394752616973e-12 * u.Unit('cm-2 s-1 TeV-1')
-    assert_quantity_allclose(actual, desired)
+    dnde = flux_points.table['dnde'].quantity
+    dnde.unit == 'cm-2 s-1 TeV-1'
+    assert_allclose(dnde[0].value, 7.986780772924239e-12)
+    assert_allclose(dnde[-1].value, 8.527066331239763e-15)

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -50,6 +50,14 @@ class NDDataArray(object):
 
         self._regular_grid_interp = None
 
+    def __str__(self):
+        """String representation"""
+        ss = 'NDDataArray summary info\n'
+        for axis in self.axes:
+            ss += array_stats_str(axis.nodes, axis.name)
+        ss += array_stats_str(self.data, 'Data')
+        return ss
+
     @property
     def axes(self):
         """Array holding the axes in correct order"""
@@ -101,14 +109,6 @@ class NDDataArray(object):
     def dim(self):
         """Dimension (number of axes)"""
         return len(self.axes)
-
-    def __str__(self):
-        """String representation"""
-        ss = 'NDDataArray summary info\n'
-        for axis in self.axes:
-            ss += array_stats_str(axis.nodes, axis.name)
-        ss += array_stats_str(self.data, 'Data')
-        return ss
 
     def find_node(self, **kwargs):
         """Find next node

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -160,16 +160,20 @@ class NDDataArray(object):
             raise ValueError("Input given for unknown axis: {}".format(kwargs))
 
         if method is None:
-            return self._eval_regular_grid_interp(
-                values) * self.data.unit
+            out = self._eval_regular_grid_interp(values)
         elif method == 'linear':
-            return self._eval_regular_grid_interp(
-                values, method='linear') * self.data.unit
+            out = self._eval_regular_grid_interp(values, method='linear')
         elif method == 'nearest':
-            return self._eval_regular_grid_interp(
-                values, method='nearest') * self.data.unit
+            out = self._eval_regular_grid_interp(values, method='nearest')
         else:
             raise ValueError('Interpolator {} not available'.format(method))
+
+        # Clip interpolated values to be non-negative
+        np.clip(out, 0, None, out=out)
+        # Attach units to the output
+        out = out * self.data.unit
+
+        return out
 
     def _eval_regular_grid_interp(self, values, **kwargs):
         """Evaluate linear interpolator


### PR DESCRIPTION
Last week @bkhelifi reported that CTA DC-1 AGN spectrum analysis failed miserably.

The core of the issue was identified by @registerrier to lie in negative effective area and energy dispersion from the evaluate method in our IRF classes:
* https://github.com/gammasky/cta-dc/blob/master/data/aeff-interpolation.ipynb
* https://github.com/gammasky/cta-dc/blob/master/data/edisp_extrapolation.ipynb

As demonstrated there, what we currently do is to place the interpolation nodes at the bin centers, i.e. at 0.5, 1.5, 2.5, ... deg in FOV offset, and thus since the AGN were placed at offset = 0.0 deg, we extrapolate the IRF values from the nodes at 0.5 and 1.5 deg, and this can lead to negative EDISP and predicted counts and analysis.
 
This can be fixed in several ways, e.g. by padding with an extra row of interpolation nodes at offset = 0 deg with the same values as at 0.5 deg on IRF read, or by implementing a custom IRF interpolator that has axis-specific behaviour and knows about energy and offset axes and how to extend.

However, the simplest solution is to clip the IRF values to >= 0, i.e. to replace negative values with zero. Doing that is also exactly what Gammalib / ctools does (linear extrapolation followed by clipping to >=0), so at least for CTA DC-1 where simulation was done by ctools, it means that we should be able to analyse the data and get pretty good results. I think there will still be issues from IRF and sampling noise when doing analysis, but that remains to be seen / studies in the coming weeks, it's not clear at the moment.

So I plan to make a pull request shortly where I introduce the clip to >= 0 shortly, applying it to all IRFs (AEFF, EDISP, BKG, table PSF)

cc @jjlk 