### PR TITLE
Make DataStoreObservation properties less lazy

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -538,32 +538,32 @@ class DataStoreObservation(object):
         location = self.location(hdu_type=hdu_type, hdu_class=hdu_class)
         return location.load()
 
-    @lazyproperty
+    @property
     def events(self):
         """Load `gammapy.data.EventList` object (lazy property)."""
         return self.load(hdu_type='events')
 
-    @lazyproperty
+    @property
     def gti(self):
         """Load `gammapy.data.GTI` object (lazy property)."""
         return self.load(hdu_type='gti')
 
-    @lazyproperty
+    @property
     def aeff(self):
         """Load effective area object (lazy property)."""
         return self.load(hdu_type='aeff')
 
-    @lazyproperty
+    @property
     def edisp(self):
         """Load energy dispersion object (lazy property)."""
         return self.load(hdu_type='edisp')
 
-    @lazyproperty
+    @property
     def psf(self):
         """Load point spread function object (lazy property)."""
         return self.load(hdu_type='psf')
 
-    @lazyproperty
+    @property
     def bkg(self):
         """Load background object (lazy property)."""
         return self.load(hdu_type='bkg')

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -308,11 +308,6 @@ class IACTBasicImageEstimator(BasicImageEstimator):
                 flux = self.flux(SkyImageList([counts, background, exposure]))
                 result['flux'].paste(flux)
 
-            # TODO: this is needed, otherwise the memory runs full, check why this
-            # happens and what the correct way is to handle this, e.g. implement
-            # a generator method for observation lists
-            del observation.events
-
         if 'psf' in which:
             result['psf'] = self.psf(observations)
         return result


### PR DESCRIPTION
This PR should fix the immediate problem mentioned in #1213, i.e. avoid memory consumption from growing endlessly as more observations are processed. In principle this could mean performance regressions that this change leads to events or IRFs being read from disk more than once. In practice I don't think we do this anywhere, i.e. this change is good.

All tests pass for me locally. Otherwise I didn't test this at all, i.e. I didn't check if it actually solves the memory issue. @adonath - assigning to you.
