### PR TITLE
EnergyDispersion2D.peek error

### DIFF
--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -1,14 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
-import pytest
 from astropy.coordinates import Angle
-from ...utils.testing import requires_dependency, requires_data
-from ...datasets import FermiGalacticCenter
+from ...utils.testing import requires_dependency, mpl_savefig_check
 from ...image import SkyImage
 from ..profile import compute_binning, ImageProfile, ImageProfileEstimator
 
@@ -124,3 +123,4 @@ class TestImageProfile(object):
     @requires_dependency('matplotlib')
     def test_peek(self):
         self.profile.peek()
+        mpl_savefig_check()

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -886,7 +886,7 @@ class EnergyDispersion2D(object):
 
         x = e_true.value
         y = migra.value
-        z = self.data.evaluate(offset=offset, e_true=e_true, migra=migra)
+        z = self.data.evaluate(offset=offset, e_true=e_true, migra=migra).value
 
         caxes = ax.pcolormesh(x, y, z.T, **kwargs)
 

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -8,6 +8,7 @@ import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EnergyDispersion2D
+from ...utils.testing import mpl_savefig_check
 from ...utils.fits import table_to_fits_table
 
 
@@ -65,14 +66,17 @@ class TestEnergyDispersion:
     @requires_dependency('matplotlib')
     def test_plot_matrix(self):
         self.edisp.plot_matrix()
+        mpl_savefig_check()
 
     @requires_dependency('matplotlib')
     def test_plot_bias(self):
         self.edisp.plot_bias()
+        mpl_savefig_check()
 
     @requires_dependency('matplotlib')
     def test_peek(self):
         self.edisp.peek()
+        mpl_savefig_check()
 
 
 @requires_dependency('scipy')
@@ -137,10 +141,6 @@ class TestEnergyDispersion2D:
         desired = self.edisp.get_response(offset, e_val, e_reco)
         assert_equal(actual, desired)
 
-    @requires_dependency('matplotlib')
-    def test_peek(self):
-        self.edisp.peek()
-
     def test_write(self):
         energy_lo = np.logspace(0, 1, 11)[:-1] * u.TeV
         energy_hi = np.logspace(0, 1, 11)[1:] * u.TeV
@@ -159,3 +159,18 @@ class TestEnergyDispersion2D:
         hdu = table_to_fits_table(edisp.to_table())
         assert_equal(hdu.data['ENERG_LO'][0], edisp.data.axis('e_true').lo.value)
         assert hdu.header['TUNIT1'] == edisp.data.axis('e_true').lo.unit
+
+    @requires_dependency('matplotlib')
+    def test_plot_migration(self):
+        self.edisp.plot_migration()
+        mpl_savefig_check()
+
+    @requires_dependency('matplotlib')
+    def test_plot_migration(self):
+        self.edisp.plot_bias()
+        mpl_savefig_check()
+
+    @requires_dependency('matplotlib')
+    def test_peek(self):
+        self.edisp.peek()
+        mpl_savefig_check()

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -2,10 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.table import Table
-from astropy.units import Quantity
-from astropy.coordinates import Angle
-from ...utils.energy import Energy
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
 from ...utils.scripts import make_path
 from ...irf import PSF3D
 
@@ -51,3 +48,5 @@ class TestPSF3D:
     @requires_dependency('matplotlib')
     def test_peek(self):
         self.psf.peek()
+        mpl_savefig_check()
+

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -1,66 +1,56 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing.utils import assert_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
-from astropy.units import Quantity
-import pytest
-from astropy.coordinates import Angle
+from astropy import units as u
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EnergyDependentMultiGaussPSF
-from ...datasets import gammapy_extra
-
-ENERGIES = Quantity([1, 10, 25], 'TeV')
 
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_EnergyDependentMultiGaussPSF():
-    filename = get_pkg_data_filename('data/psf_info.txt')
-    info_str = open(filename, 'r').read()
+class TestEnergyDependentMultiGaussPSF:
 
-    filename = gammapy_extra.filename('test_datasets/unbundled/irfs/psf.fits')
-    psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
-    assert psf.info() == info_str
+    @pytest.fixture(scope='session')
+    def psf(self):
+        filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/irfs/psf.fits'
+        return EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
 
+    def test_info(self, psf):
+        filename = get_pkg_data_filename('data/psf_info.txt')
+        info_str = open(filename, 'r').read()
 
-@requires_data('gammapy-extra')
-def test_EnergyDependentMultiGaussPSF_write(tmpdir):
-    filename = gammapy_extra.filename('test_datasets/unbundled/irfs/psf.fits')
-    psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
+        assert psf.info() == info_str
 
-    # Write it back to disk
-    filename = str(tmpdir / 'multigauss_psf_test.fits')
-    psf.write(filename)
+    def test_write(self, tmpdir, psf):
+        # Write it back to disk
+        filename = str(tmpdir / 'multigauss_psf_test.fits')
+        psf.write(filename)
 
-    # Verify checksum
-    hdu_list = fits.open(filename)
+        # Verify checksum
+        hdu_list = fits.open(filename)
 
-    # TODO: replace this assert with something else.
-    # For unknown reasons this verify_checksum fails non-deterministically
-    # see e.g. https://travis-ci.org/gammapy/gammapy/jobs/31056341#L1162
-    # assert hdu_list[1].verify_checksum() == 1
-    assert len(hdu_list) == 2
+        # TODO: replace this assert with something else.
+        # For unknown reasons this verify_checksum fails non-deterministically
+        # see e.g. https://travis-ci.org/gammapy/gammapy/jobs/31056341#L1162
+        # assert hdu_list[1].verify_checksum() == 1
+        assert len(hdu_list) == 2
 
+    def test_to_table_psf(self, psf):
+        energy = 1 * u.TeV
+        theta = 0 * u.deg
 
-@requires_dependency('scipy')
-@requires_data('gammapy-extra')
-@pytest.mark.parametrize(('energy'), ENERGIES)
-def test_to_table_psf(energy):
-    filename = gammapy_extra.filename('datasets/hess-crab4-hd-hap-prod2/run023400-023599/'
-                                      'run023523/hess_psf_3gauss_023523.fits.gz')
-    psf = EnergyDependentMultiGaussPSF.read(filename, hdu='PSF_2D_GAUSS')
-    theta = Angle(0, 'deg')
+        table_psf = psf.to_energy_dependent_table_psf(theta)
+        interpol_param = dict(method='nearest', bounds_error=False)
+        table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
+        psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
 
-    table_psf = psf.to_energy_dependent_table_psf(theta)
-    interpol_param = dict(method='nearest', bounds_error=False)
-    table_psf_at_energy = table_psf.table_psf_at_energy(energy, interpol_param)
-    psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
+        containment = np.linspace(0, 0.95, 10)
+        desired = [psf_at_energy.containment_radius(_) for _ in containment]
+        actual = table_psf_at_energy.containment_radius(containment)
 
-    containment = np.linspace(0, 0.95, 10)
-    desired = [psf_at_energy.containment_radius(_) for _ in containment]
-    actual = table_psf_at_energy.containment_radius(containment)
-
-    # TODO: try to improve precision, so that rtol can be lowered
-    assert_allclose(desired, actual.degree, rtol=0.03)
+        # TODO: try to improve precision, so that rtol can be lowered
+        assert_allclose(desired, actual.degree, rtol=0.03)

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check
 from ...scripts import CTAIrf, CTAPerf
 
 
@@ -47,3 +47,4 @@ def test_point_like_perf():
     filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
     cta_perf = CTAPerf.read(filename)
     cta_perf.peek()
+    mpl_savefig_check()

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
 from ...utils.scripts import make_path
 from ...irf import EffectiveAreaTable, EnergyDispersion
 from ...spectrum import (
@@ -139,6 +139,7 @@ class SpectrumObservationTester:
     @requires_dependency('matplotlib')
     def test_peek(self):
         self.obs.peek()
+        mpl_savefig_check()
 
 
 @requires_dependency('scipy')

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -154,3 +154,18 @@ def assert_time_allclose(actual, desired):
     assert_allclose(actual.value, desired.value)
     assert actual.scale == desired.scale
     assert actual.format == desired.format
+
+
+def mpl_savefig_check():
+    """Call matplotlib savefig for the current figure.
+
+    This will trigger a render of the Figure, which can sometimes
+    raise errors if there is a problem; i.e. we call this at the
+    end of every plotting test for now.
+
+    This is writing to an in-memory byte buffer, i.e. is faster
+    than writing to disk.
+    """
+    import matplotlib.pyplot as plt
+    from io import BytesIO
+    plt.savefig(BytesIO(), format='png')


### PR DESCRIPTION
This works:
```
>>> from gammapy.irf import EnergyDispersion2D
>>> edisp = EnergyDispersion2D.read('$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits', hdu='ENERGY DISPERSION')
>>> edisp.peek()
2017-11-06 13:07:33.608 Python[67430:13212907] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to (null)
/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/colors.py:1238: UserWarning: Power-law scaling on negative values is ill-defined, clamping to 0.
  warnings.warn("Power-law scaling on negative values is "
/Users/deil/Library/Python/3.6/lib/python/site-packages/astropy/units/quantity.py:635: RuntimeWarning: invalid value encountered in true_divide
  result = super().__array_ufunc__(function, method, *arrays, **kwargs)
```
But if plotting with an interactive backend it fails like this:
```
>>> import matplotlib.pyplot as plt
>>> plt.ion()
>>> edisp.peek()
>>> /opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/colors.py:1199: RuntimeWarning: invalid value encountered in power
  np.power(resdat, gamma, resdat)
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/backends/backend_macosx.py", line 105, in _draw
    self.figure.draw(renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/figure.py", line 1295, in draw
    renderer, self, artists, self.suppressComposite)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/image.py", line 138, in _draw_list_compositing_images
    a.draw(renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/axes/_base.py", line 2399, in draw
    mimage._draw_list_compositing_images(renderer, self, artists)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/image.py", line 138, in _draw_list_compositing_images
    a.draw(renderer)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/artist.py", line 55, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/collections.py", line 1873, in draw
    self.update_scalarmappable()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/collections.py", line 742, in update_scalarmappable
    self._facecolors = self.to_rgba(self._A, self._alpha)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/cm.py", line 275, in to_rgba
    x = self.norm(x)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/matplotlib/colors.py", line 1200, in __call__
    resdat /= (vmax - vmin) ** gamma
  File "/Users/deil/Library/Python/3.6/lib/python/site-packages/astropy/units/quantity.py", line 644, in __array_ufunc__
    return self._result_as_quantity(result, unit, out)
  File "/Users/deil/Library/Python/3.6/lib/python/site-packages/astropy/units/quantity.py", line 683, in _result_as_quantity
    out._set_unit(unit)
AttributeError: 'numpy.ndarray' object has no attribute '_set_unit'
```

I don't know what exactly the issue is, but probably we're passing a Quantity object to matplotlib, and that sometimes works and sometimes doesn't. So the change here would be to check and make sure we're passing a numpy array. And in addition we should check that there is a test covering this, and if yes, maybe find a way to also run tests in interactive mode so that such issues show up.

Note that at the moment, I added this to force non-interactive backend when running the tests, because otherwise on Mac windows pop up for the default interactive backend while running the tests:
https://github.com/gammapy/gammapy/blob/01b7b21ca5eff780a60360e28b6050a4591d0bec/gammapy/conftest.py#L54
Hmmm ....