### PR TITLE
FITS Table string related fails with Astropy dev

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -9,8 +9,8 @@ from pprint import pprint
 import numpy as np
 from ..extern import six
 from astropy.utils import lazyproperty
-from astropy.units import Quantity
 from ..utils.array import _is_int
+from ..utils.table import table_row_to_dict
 from .utils import skycoord_from_table
 
 __all__ = [
@@ -229,13 +229,13 @@ class SourceCatalog(object):
         source : `SourceCatalogObject`
             Source object
         """
-        data = self._make_source_dict(self.table, index)
+        data = table_row_to_dict(self.table[index])
         data[self._source_index_key] = index
 
         try:
             name_extended = data['Extended_Source_Name'].strip()
             idx = self._lookup_extended_source_idx[name_extended]
-            data_extended = self._make_source_dict(self.extended_sources_table, idx)
+            data_extended = table_row_to_dict(self.extended_sources_table[idx])
         except KeyError:
             data_extended = None
 
@@ -247,28 +247,6 @@ class SourceCatalog(object):
         names = [_.strip() for _ in self.extended_sources_table['Source_Name']]
         idx = range(len(names))
         return dict(zip(names, idx))
-
-    @staticmethod
-    def _make_source_dict(table, idx):
-        """Make one source data dict.
-
-        Parameters
-        ----------
-        idx : int
-            Row index
-
-        Returns
-        -------
-        data : `~collections.OrderedDict`
-            Source data
-        """
-        data = OrderedDict()
-        for name, col in table.columns.items():
-            val = col[idx]
-            if col.unit:
-                val = val * col.unit
-            data[name] = val
-        return data
 
     @property
     def _data_python_list(self):

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -263,17 +263,11 @@ class SourceCatalog(object):
             Source data
         """
         data = OrderedDict()
-        for colname in table.colnames:
-            col = table[colname]
-
-            if isinstance(col, Quantity):
-                val = col[idx]
-            else:
-                val = col.data[idx]
-                if col.unit:
-                    val = Quantity(val, col.unit)
-
-            data[colname] = val
+        for name, col in table.columns.items():
+            val = col[idx]
+            if col.unit:
+                val = val * col.unit
+            data[name] = val
         return data
 
     @property

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
-from astropy.table import QTable, Table
+from astropy.table import Table, Column
 from astropy.time import Time
 from astropy.tests.helper import ignore_warnings
 from astropy.modeling.models import Gaussian2D, Disk2D
@@ -428,13 +428,13 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         n_points = len(flux)
         time_step = (time_end - time_start) / n_points
         time_bounds = time_start + np.arange(n_points + 1) * time_step
-        table = QTable()
-        table['TIME_MIN'] = time_bounds[:-1]
-        table['TIME_MAX'] = time_bounds[1:]
-        table['FLUX'] = flux
-        table['FLUX_ERR'] = flux_err
-        lc = LightCurve(table)
-        return lc
+        table = Table([
+            Column(time_bounds[:-1], 'TIME_MIN'),
+            Column(time_bounds[1:], 'TIME_MAX'),
+            Column(flux, 'FLUX'),
+            Column(flux_err, 'FLUX_ERR'),
+        ])
+        return LightCurve(table)
 
 
 class SourceCatalogObject1FHL(SourceCatalogObject):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -71,6 +71,10 @@ class TestSourceCatalogGammaCat:
         for name in names:
             assert str(gammacat[name]) == str(gammacat['W28'])
 
+    # TODO: remove this xfail once the issue in Astropy has been fixed
+    # https://github.com/astropy/astropy/issues/6862#issuecomment-348811300
+    # https://github.com/gammapy/gammapy/pull/1228
+    @pytest.mark.xfail
     def test_sort_table(self):
         name = 'HESS J1848-018'
         sort_keys = ['ra', 'dec', 'reference_id']

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -166,7 +166,7 @@ class SpectrumEnergyGroups(UserList):
         ])
 
     def to_total_table(self):
-        """Table with one energy bin per row (`~astropy.table.QTable`).
+        """Table with one energy bin per row (`~astropy.table.Table`).
 
         Columns:
 
@@ -181,7 +181,7 @@ class SpectrumEnergyGroups(UserList):
         return table_vstack(tables)
 
     def to_group_table(self):
-        """Table with one energy group per row (`~astropy.table.QTable`).
+        """Table with one energy group per row (`~astropy.table.Table`).
 
         Columns:
 

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -21,7 +21,7 @@ from ..extern.six.moves import UserList
 from astropy.units import Quantity
 from astropy.table import Table
 from astropy.table import vstack as table_vstack
-from ..utils.fits import table_from_row_data
+from ..utils.table import table_from_row_data
 from ..data import ObservationStats
 
 __all__ = [

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -7,8 +7,7 @@ from astropy.table import Table, vstack
 from astropy import units as u
 from astropy.io.registry import IORegistryError
 from ..utils.scripts import make_path
-from ..utils.fits import table_from_row_data
-from ..utils.table import table_standardise_units_copy
+from ..utils.table import table_standardise_units_copy, table_from_row_data
 from .models import PowerLaw
 from .powerlaw import power_law_integral_flux
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -7,7 +7,7 @@ from ..extern.six.moves import UserList
 from ..extern.pathlib import Path
 from ..utils.scripts import make_path
 from ..utils.energy import EnergyBounds
-from ..utils.fits import table_from_row_data
+from ..utils.table import table_from_row_data
 from ..data import ObservationStats
 from ..irf import EffectiveAreaTable, EnergyDispersion
 from ..irf import IRFStacker

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -118,7 +118,7 @@ class SpectrumObservationTester:
     def test_stats_table(self):
         table = self.obs.stats_table()
         assert table['n_on'].sum() == self.vals['total_on']
-        assert_quantity_allclose(table['livetime'].max(), self.vals['livetime'])
+        assert_quantity_allclose(table['livetime'].quantity.max(), self.vals['livetime'])
 
     def test_total_stats(self):
         excess = self.obs.total_stats.excess

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -294,7 +294,6 @@ def table_to_fits_table(table, name=None):
     header = fits.Header()
     header.update(table.meta)
 
-
     hdu = fits.BinTableHDU(data, header, name=name)
 
     # Copy over column meta-data
@@ -325,7 +324,7 @@ def table_to_fits_table(table, name=None):
     return hdu
 
 
-def fits_table_to_table(tbhdu):
+def fits_table_to_table(hdu):
     """Convert astropy table to binary table FITS format.
 
     This is a generic method to convert a `~astropy.io.fits.BinTableHDU`
@@ -346,13 +345,13 @@ def fits_table_to_table(tbhdu):
     table : `~astropy.table.Table`
         astropy table containing the desired columns
     """
-    data = tbhdu.data
-    header = tbhdu.header
+    data = hdu.data
+    header = hdu.header
     table = Table(data, meta=header)
 
     # Copy over column meta-data
-    for idx, colname in enumerate(tbhdu.columns.names):
-        table[colname].unit = tbhdu.columns[colname].unit
+    for idx, colname in enumerate(hdu.columns.names):
+        table[colname].unit = hdu.columns[colname].unit
         description = table.meta.pop('TCOMM' + str(idx + 1), None)
         table[colname].meta['description'] = description
         ucd = table.meta.pop('TUCD' + str(idx + 1), None)

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -4,15 +4,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import numpy as np
-from astropy.units import Quantity
 from astropy.io import fits
-from astropy.table import Table, QTable
+from astropy.table import Table
 from .scripts import make_path
 from .energy import EnergyBounds
 
 __all__ = [
     'SmartHDUList',
-    'table_from_row_data',
     'table_to_fits_table',
     'fits_table_to_table',
     'energy_axis_to_ebounds',
@@ -220,45 +218,6 @@ def fits_header_to_meta_dict(header):
     meta.pop('HISTORY', None)
 
     return meta
-
-
-# TODO: remove type = 'qtable' to avoid issues?
-# see https://github.com/astropy/astropy/issues/6098
-# see https://github.com/gammapy/gammapy/issues/980
-def table_from_row_data(rows, type='qtable', **kwargs):
-    """Helper function to create table objects from row data.
-
-    - Works with quantities.
-    - Preserves order of keys if OrderedDicts are used.
-
-    Parameters
-    ----------
-    rows : list
-        List of row data (each row a dict or OrderedDict)
-    type : {'table', 'qtable'}
-        Type of table to create
-    """
-    # Creating `QTable` from list of row data with `Quantity` objects
-    # doesn't work. So we're reformatting to list of column `Quantity`
-    # objects here.
-    # table = QTable(rows=rows)
-
-    if type == 'table':
-        cls = Table
-    elif type == 'qtable':
-        cls = QTable
-    else:
-        raise ValueError('Invalid type: {}'.format(type))
-
-    table = cls(**kwargs)
-    colnames = list(rows[0].keys())
-    for name in colnames:
-        coldata = [_[name] for _ in rows]
-        if isinstance(rows[0][name], Quantity):
-            coldata = Quantity(coldata, unit=rows[0][name].unit)
-        table[name] = coldata
-
-    return table
 
 
 def table_to_fits_table(table, name=None):

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -2,12 +2,15 @@
 """Table helper utilities.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 from astropy.table import Table
+from astropy.units import Quantity
 from .units import standardise_unit
 
 __all__ = [
     'table_standardise_units_copy',
     'table_standardise_units_inplace',
+    'table_row_to_dict',
 ]
 
 
@@ -41,3 +44,27 @@ def table_standardise_units_inplace(table):
             column.unit = standardise_unit(column.unit)
 
     return table
+
+
+def table_row_to_dict(row, make_quantity=True):
+    """Make one source data dict.
+
+    Parameters
+    ----------
+    row : `~astropy.table.Row`
+        Row
+    make_quantity : bool
+        Make quantity values for columns with units
+
+    Returns
+    -------
+    data : `~collections.OrderedDict`
+        Row data
+    """
+    data = OrderedDict()
+    for name, col in row.columns.items():
+        val = row[name]
+        if make_quantity and col.unit:
+            val = Quantity(val, unit=col.unit)
+        data[name] = val
+    return data

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -22,7 +22,7 @@ def table_standardise_units_copy(table):
 
     Parameters
     ----------
-    table : `~astropy.table.Table` or `~astropy.table.QTable`
+    table : `~astropy.table.Table`
         Input table (won't be modified)
 
     Returns
@@ -31,7 +31,6 @@ def table_standardise_units_copy(table):
         Copy of the input table with standardised column units
     """
     # Note: we could add an `inplace` option (or variant of this function)
-    # for `Table`, but not for `QTable`.
     # See https://github.com/astropy/astropy/issues/6098
     table = Table(table)
     return table_standardise_units_inplace(table)

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -71,10 +71,7 @@ def table_row_to_dict(row, make_quantity=True):
     return data
 
 
-# TODO: remove type = 'qtable' to avoid issues?
-# see https://github.com/astropy/astropy/issues/6098
-# see https://github.com/gammapy/gammapy/issues/980
-def table_from_row_data(rows, type='qtable', **kwargs):
+def table_from_row_data(rows, **kwargs):
     """Helper function to create table objects from row data.
 
     - Works with quantities.
@@ -84,22 +81,8 @@ def table_from_row_data(rows, type='qtable', **kwargs):
     ----------
     rows : list
         List of row data (each row a dict or OrderedDict)
-    type : {'table', 'qtable'}
-        Type of table to create
     """
-    # Creating `QTable` from list of row data with `Quantity` objects
-    # doesn't work. So we're reformatting to list of column `Quantity`
-    # objects here.
-    # table = QTable(rows=rows)
-
-    if type == 'table':
-        cls = Table
-    elif type == 'qtable':
-        cls = QTable
-    else:
-        raise ValueError('Invalid type: {}'.format(type))
-
-    table = cls(**kwargs)
+    table = Table(**kwargs)
     colnames = list(rows[0].keys())
     for name in colnames:
         coldata = [_[name] for _ in rows]

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
+from collections import OrderedDict
 import astropy.units as u
 from astropy.table import Table, QTable, Column
-from ..table import table_standardise_units_copy
+from ..table import table_standardise_units_copy, table_row_to_dict
 
 
 @pytest.mark.parametrize('table_class', [Table, QTable])
@@ -20,3 +21,22 @@ def test_table_standardise_units(table_class):
     assert table['b'].unit == u.Unit('cm-2 s-1')
     assert table['c'].unit == u.Unit('cm-2 s-1')
     assert table['d'].unit is None
+
+
+@pytest.fixture()
+def table():
+    return Table([
+        Column([1, 2], 'col_a'),
+        Column([1, 2] * u.m, 'col_c'),
+        Column(['x', 'yy'], 'col_d'),
+    ])
+
+
+def test_table_row_to_dict(table):
+    actual = table_row_to_dict(table[1])
+    expected = OrderedDict([
+        ('col_a', 2),
+        ('col_c', 2 * u.m),
+        ('col_d', 'yy'),
+    ])
+    assert actual == expected

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -4,7 +4,7 @@ import pytest
 from collections import OrderedDict
 import astropy.units as u
 from astropy.table import Table, QTable, Column
-from ..table import table_standardise_units_copy, table_row_to_dict
+from ..table import table_standardise_units_copy, table_row_to_dict, table_from_row_data
 
 
 @pytest.mark.parametrize('table_class', [Table, QTable])

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -4,17 +4,17 @@ import pytest
 from collections import OrderedDict
 from numpy.testing import assert_allclose
 import astropy.units as u
-from astropy.table import Table, QTable, Column
+from astropy.table import Table, Column
 from ..table import table_standardise_units_copy, table_row_to_dict, table_from_row_data
 
 
-@pytest.mark.parametrize('table_class', [Table, QTable])
-def test_table_standardise_units(table_class):
-    table = table_class()
-    table['a'] = Column([1], unit='ph cm-2 s-1')
-    table['b'] = Column([1], unit='ct cm-2 s-1')
-    table['c'] = Column([1], unit='cm-2 s-1')
-    table['d'] = Column([1])
+def test_table_standardise_units():
+    table = Table([
+        Column([1], 'a', unit='ph cm-2 s-1'),
+        Column([1], 'b', unit='ct cm-2 s-1'),
+        Column([1], 'c', unit='cm-2 s-1'),
+        Column([1], 'd'),
+    ])
 
     table = table_standardise_units_copy(table)
 

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from collections import OrderedDict
+from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table, QTable, Column
 from ..table import table_standardise_units_copy, table_row_to_dict, table_from_row_data
@@ -26,17 +27,28 @@ def test_table_standardise_units(table_class):
 @pytest.fixture()
 def table():
     return Table([
-        Column([1, 2], 'col_a'),
-        Column([1, 2] * u.m, 'col_c'),
-        Column(['x', 'yy'], 'col_d'),
+        Column([1, 2], 'a'),
+        Column([1, 2] * u.m, 'b'),
+        Column(['x', 'yy'], 'c'),
     ])
 
 
 def test_table_row_to_dict(table):
     actual = table_row_to_dict(table[1])
     expected = OrderedDict([
-        ('col_a', 2),
-        ('col_c', 2 * u.m),
-        ('col_d', 'yy'),
+        ('a', 2),
+        ('b', 2 * u.m),
+        ('c', 'yy'),
     ])
     assert actual == expected
+
+
+def test_table_from_row_data():
+    rows = [
+        dict(a=1, b=1 * u.m, c='x'),
+        dict(a=2, b=2 * u.km, c='yy'),
+    ]
+    table = table_from_row_data(rows)
+    assert isinstance(table, Table)
+    assert table['b'].unit == 'm'
+    assert_allclose(table['b'].data, [1, 2000])


### PR DESCRIPTION
In Gammapy we are testing against the Astropy dev version, and this started to fail:
https://travis-ci.org/gammapy/gammapy/jobs/310116908#L3261

I think the cause is this FITS Table related change by @astrofrog that was merged yesterday: 
https://github.com/astropy/astropy/pull/6821

From a quick look, I think all the fails in `gammapy.catalog` originate from here, where we extract a FITS table row data into a dict that's independent from the table object:
https://github.com/gammapy/gammapy/blob/48d7ae1b9228078e9059ea391e0cd730e46dff0f/gammapy/catalog/core.py#L252

Before the change by @astrofrog FITS string column data came back as `str`, now as `bytes` (I only tested on Python 3 so far), and then our code fails later when we compare `str` with `bytes` (and previously worked because we compared `str` with `str`).

Here's an isolated test case: old behaviour:
```
>>> import astropy
>>> astropy.__version__
'2.0.2'
>>> from astropy.table import Table
>>> t = Table.read('https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz')
Downloading https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz
|==============================================================================================================| 205k/205k (100.00%)         0s
WARNING: hdu= was not specified but multiple tables are present, reading in first available table (hdu=1) [astropy.io.fits.connect]
WARNING: UnitsWarning: 'photon/cm**2/s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
WARNING: UnitsWarning: 'erg/cm**2/s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
>>> t['Source_Name'].data.dtype
dtype('<U18')
>>> t['Source_Name'].data[0]
'2FHL J0008.1+4709'
>>> type(t['Source_Name'].data[0])
<class 'numpy.str_'>
```
New behaviour:
```
>>> import astropy
>>> astropy.__version__
'3.0.dev20763'
>>> from astropy.table import Table
>>> t = Table.read('https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz')
Downloading https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz
|==============================================================================================================| 205k/205k (100.00%)         0s
WARNING: hdu= was not specified but multiple tables are present, reading in first available table (hdu=1) [astropy.io.fits.connect]
WARNING: UnitsWarning: 'photon/cm**2/s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
WARNING: UnitsWarning: 'erg/cm**2/s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
>>> t['Source_Name'].data.dtype
dtype('S18')
>>> t['Source_Name'].data[0]
b'2FHL J0008.1+4709'
>>> type(t['Source_Name'].data[0])
<class 'numpy.bytes_'>
```

In both cases, this gives a `str`:
```
>>> type(t['Source_Name'][0])
<class 'numpy.str_'>
```

Actually given https://github.com/astropy/astropy/pull/6821/files#diff-db23dcd814354c954091a9b90dbfd92aR253 this makes sense:

> When reading in FITS tables with ``Table.read``, string columns are now represented using Numpy byte (dtype ``S``) arrays rather than Numpy unicode arrays (dtype ``U``). The ``Column`` class then ensures the bytes are automatically converted to string as needed. [#6821]

@astrofrog So basically, this is an intentional change in Astropy, and we should update our code in Gammapy to no longer rely on `column.data` being a `str` for FITS string columns, no?

Concretely for the method `_make_source_dict` I linked to above I think that means we need an `isinstance` or `try` for string columns?