### PR TITLE
Force download files in Sphinx static notebooks

### DIFF
--- a/docs/_static/linksdl.js
+++ b/docs/_static/linksdl.js
@@ -1,0 +1,12 @@
+/*
+ * linksdl.js
+ * ~~~~~~~~~~~
+ *
+ * javascript code to enable download links of notebooks and scripts *.py
+ *
+ */
+
+$(document).ready(function() {
+  document.getElementsByClassName("last")[0].children[1].setAttribute("download", "")
+  document.getElementsByClassName("last")[0].children[2].setAttribute("download", "")
+});

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -132,10 +132,8 @@ them in your local `_static/notebooks/` folder. You can also contribute with you
 own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 
 **Source files:**
-<br/><br/>
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
 [{py_filename}](../_static/notebooks/{txt_filename})
-*(right-click and select "save as")*
 </div>
 """
 

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -117,7 +117,8 @@ def modif_nb_links(folder, url_docs, git_commit):
     """
 
     DOWNLOAD_CELL = """
-<div class='admonition note'>
+<script type="text/javascript" src="../_static/linksdl.js"></script>
+<div class='alert alert-info'>
 **This is a fixed-text formatted version of a Jupyter notebook.**
 
 Try online on Binder
@@ -131,6 +132,7 @@ them in your local `_static/notebooks/` folder. You can also contribute with you
 own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 
 **Source files:**
+<br/><br/>
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
 [{py_filename}](../_static/notebooks/{txt_filename})
 *(right-click and select "save as")*

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -133,7 +133,7 @@ own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-ext
 
 **Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
-[{py_filename}](../_static/notebooks/{txt_filename})
+[{py_filename}](../_static/notebooks/{py_filename})
 </div>
 """
 
@@ -142,8 +142,7 @@ own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-ext
         if os.path.isfile(filepath) and filepath[-6:] == '.ipynb':
             if folder == 'notebooks':
                 py_filename = filename.replace('ipynb', 'py')
-                txt_filename = filename.replace('ipynb', 'txt')
-                ctx = dict(nb_filename=filename, py_filename=py_filename, txt_filename=txt_filename,
+                ctx = dict(nb_filename=filename, py_filename=py_filename,
                            git_commit=git_commit)
                 strcell = DOWNLOAD_CELL.format(**ctx)
                 nb = nbformat.read(filepath, as_version=nbformat.NO_CONVERT)
@@ -177,7 +176,7 @@ def convert_nb_to_script(path):
     exporter = PythonExporter()
     source, meta = exporter.from_notebook_node(nb)
 
-    path = path.with_suffix('.txt')
+    path = path.with_suffix('.py')
     log.info('Writing {}'.format(path))
     path.write_text(source, encoding='utf-8')
 


### PR DESCRIPTION
This PR makes use of javascript code to add ``download``attribute to the links built in Sphinx static notebooks. This enables automatic download of *.ipynb source notebooks and *.py converted files. Moreover, the source python files have no longer .txt extension.

It addresses issues discussed in #1223 