### PR TITLE
Improve Gammapy installation docs a bit

### DIFF
--- a/dev/sherpa/stats/xspec_stats.py
+++ b/dev/sherpa/stats/xspec_stats.py
@@ -1,7 +1,7 @@
 """XSPEC statistics tests.
 
 Here you find a direct implementation of the formulae at
-http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
+https://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
 
 Then I'll try to translate to the notation I use in gammapy.stats
 and get some test cases.

--- a/docs/dataformats/file_formats.rst
+++ b/docs/dataformats/file_formats.rst
@@ -1,4 +1,4 @@
-.. include:: ../../references.txt
+.. include:: ../references.txt
 
 .. _dataformats_file_formats:
 
@@ -23,7 +23,7 @@ Introduction
 
 In Gammapy we use existing file formats by `Fermi-LAT`_ and `CTA`_ where available.
 
-This increases inter-operability with the `Fermi science tools`_
+This increases inter-operability with the `Fermi ScienceTools`_
 and `ctools`_ as well as mind share with users of those tools.
 
 We also introduce new file formats for things that should be easy to store and exchange,

--- a/docs/dataformats/file_formats.rst
+++ b/docs/dataformats/file_formats.rst
@@ -1,3 +1,5 @@
+.. include:: ../../references.txt
+
 .. _dataformats_file_formats:
 
 File formats
@@ -19,15 +21,10 @@ where no suitable standardised format exists.
 Introduction
 ------------
 
-In Gammapy we use existing file formats by
-`Fermi-LAT <http://fermi.gsfc.nasa.gov/>`__ and
-`CTA <https://www.cta-observatory.org/>`__ where available.
+In Gammapy we use existing file formats by `Fermi-LAT`_ and `CTA`_ where available.
 
-This increases inter-operability with the
-`Fermi science tools <http://fermi.gsfc.nasa.gov/ssc/data/>`__
-and the
-`CTA science tools <http://cta.irap.omp.eu/ctools/>`__
-as well as mind share with users of those tools.
+This increases inter-operability with the `Fermi science tools`_
+and `ctools`_ as well as mind share with users of those tools.
 
 We also introduce new file formats for things that should be easy to store and exchange,
 but no well-defined format exists. E.g. we could define a Gaussian PSF in XML format as
@@ -122,8 +119,7 @@ Almost all entries in the above table are debatable ... here's some caveats:
   E.g. I put FITS as "no" for tree data (a.k.a. structured or hierarchical data such as
   in the JSON example above) even though people have found ways to encode such information
   in FITS headers or data extensions.
-* The schema supports is best (very common, well-understood, good tools) for
-  `XML schema <http://en.wikipedia.org/wiki/XML_schema>`__,
+* The schema supports is best (very common, well-understood, good tools) for `XML schema`_,
   but there's some schema support for the other formats as well.
   This will be discussed in the section `Validation`_ below.
 
@@ -132,7 +128,7 @@ Here's a short description of each format with references if you want to learn m
 INI
 +++
 
-**INI** files (see `Wikipedia <http://en.wikipedia.org/wiki/INI_file>`__)
+**INI** files (see `Wikipedia <https://en.wikipedia.org/wiki/INI_file>`__)
 are the most easy to write and edit for humans and can contain ``#`` comments
 and are thus a good for configuration files.
 file extensions of ``.ini``, ``.conf`` and ``.cfg`` are common.
@@ -150,13 +146,13 @@ Unfortunately INI files are not standardised, so there's only conventions and to
 CSV
 +++
 
-**CSV** files (see `Wikipedia <http://en.wikipedia.org/wiki/Comma-separated_values>`__),
+**CSV** files (see `Wikipedia <https://en.wikipedia.org/wiki/Comma-separated_values>`__),
 store tables as comma-separated values (or tab or whitespace separated),
 sometimes with the column names in the first row, sometimes with ``#`` comments.
 The good thing is that you can import and export data in CSV format from all spreadsheet
-programs (e.g. `Microsoft Excel <http://en.wikipedia.org/wiki/Microsoft_Excel>`__,
-`Apple Keynote <http://en.wikipedia.org/wiki/Keynote_(presentation_software)>`__ or
-`LibreOffice Calc <http://en.wikipedia.org/wiki/LibreOffice_Calc>`__)
+programs (e.g. `Microsoft Excel <https://en.wikipedia.org/wiki/Microsoft_Excel>`__,
+`Apple Keynote <https://en.wikipedia.org/wiki/Keynote_(presentation_software)>`__ or
+`LibreOffice Calc <https://en.wikipedia.org/wiki/LibreOffice_Calc>`__)
 as well as astronomy table programs such as e.g.
 `TOPCAT <http://www.star.bris.ac.uk/~mbt/topcat/>`__.
 Since it's a simple text format it's easy to read or edit in any text editor or
@@ -204,21 +200,20 @@ TODO: describe
 FITS
 ++++
 
-**FITS** files (see `Wikipedia <http://en.wikipedia.org/wiki/FITS>`__)
+**FITS** files (see `Wikipedia <https://en.wikipedia.org/wiki/FITS>`__)
 
 TODO: describe
 
 ROOT
 ++++
 
-**ROOT** files (see `Wikipedia <http://en.wikipedia.org/wiki/ROOT>`__)
-This is a binary serialisation format (see `TFile <http://root.cern.ch/root/html/TFile.html>`__)
+**ROOT** files (see `Wikipedia <https://en.wikipedia.org/wiki/ROOT>`__)
+This is a binary serialisation format (see `TFile <https://root.cern.ch/root/html/TFile.html>`__)
 that is very common for low-level data in high-energy physics and astronomy and for
 computing and storing instrument response functions.
-If only ROOT built-in objects like simple `TTree <http://root.cern.ch/root/html/TTree.html>`__ and
-`Histogram <http://root.cern.ch/root/html/TH1.html>`__  objects are stored it is
-possible to exchange those files and read them from C++, Python (via
-`PyROOT <http://root.cern.ch/drupal/content/pyroot>`__ or  `rootpy <http://www.rootpy.org/>`__).
+If only ROOT built-in objects like simple `TTree <https://root.cern.ch/root/html/TTree.html>`__ and
+`Histogram <https://root.cern.ch/root/html/TH1.html>`__  objects are stored it is
+possible to exchange those files and read them from C++, Python (via `PyROOT`_ or `rootpy`_).
 Access to your own serialised C++ objects is only possible if you distribute ROOT and
 a C++ library ... but storing data this way is anyways a bad idea
 (see e.g. `here <https://www.youtube.com/watch?v=7KnfGDajDQw>`__).
@@ -230,13 +225,13 @@ Other
 
 Other file formats that are very useful but not commonly used in gamma-ray astronomy (yet):
 
-* **HDF5** files (see `Wikipedia <http://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5>`__).
+* **HDF5** files (see `Wikipedia <https://en.wikipedia.org/wiki/Hierarchical_Data_Format#HDF5>`__).
   Advantages over FITS: much faster for some applications,
   more flexible metadata, more widespread use (not astro specific),
   some tools for schema validation.
 * There's a bunch of efficient and flexible binary data serialization formats, e.g.
   `Google Protobuf <https://code.google.com/p/protobuf/>`__ or
-  `MessagePack <http://msgpack.org/>`__ or `BSON <http://bsonspec.org/>`__.
+  `MessagePack <https://msgpack.org/>`__ or `BSON <https://bsonspec.org/>`__.
 
 TODO: describe that most of these formats are only being considered for low-level data
 for CTA, e.g. shower image I/O can be much more efficient that with FITS variable-length columns.
@@ -246,7 +241,7 @@ for CTA, e.g. shower image I/O can be much more efficient that with FITS variabl
   pickled. (Do we care at all for Gammapy or is our policy that we don't support pickling
   Gammapy objects?)
 
-* `SQLite <http://sqlite.org/>`__ gives you a `SQL <http://en.wikipedia.org/wiki/SQL>`__
+* `SQLite <https://sqlite.org/>`__ gives you a `SQL <https://en.wikipedia.org/wiki/SQL>`__
   database in memory or a simple file (no server, no configuration).
   TODO: describe how it can be useful for pipeline processing (async I/O and easy select)
 
@@ -275,7 +270,7 @@ output with incorrect structure or content, so this is not only an issue for use
 Checking the structure (and where possible content) is the responsibility of
 the tool author and can be done either by writing a schema or code.
 If you don't know what a schema is, please take a few minutes to read about it
-`here <http://spacetelescope.github.io/understanding-json-schema/about.html>`__
+`here <https://spacetelescope.github.io/understanding-json-schema/about.html>`__
 using JSON as an example, I won't try to explain it here.
 
 Existing Tools

--- a/docs/dataformats/source_models.rst
+++ b/docs/dataformats/source_models.rst
@@ -12,7 +12,7 @@ GammaLib / ctools uses an "model definition" XML format described
 `here <http://gammalib.sourceforge.net/user_manual/modules/model.html#overview>`__
 
 The Fermi ``gtlike`` tool uses the same format (the implemented models are a bit different) described
-`here <http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html>`__
+`here <https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html>`__
 
 The same format is used by ``ctlike`` and ``gtlike`` to report the model fit results,
 which has the serious draw-back that useful information like the fit covariance matrix, asymmetric errors

--- a/docs/dataformats/target_lists.rst
+++ b/docs/dataformats/target_lists.rst
@@ -13,7 +13,7 @@ varying other parameters.
 CSV format
 ----------
 
-We use the `CSV <http://en.wikipedia.org/wiki/Comma-separated_values>`_ (comma-separated values) format for target lists.
+We use the `CSV <https://en.wikipedia.org/wiki/Comma-separated_values>`_ (comma-separated values) format for target lists.
 
 A target list must have at least a column called ``Number`` with unique entries:
 

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -174,7 +174,7 @@ To check all internal and external links use this `linkchecker <https://github.c
 
 .. code-block:: bash
 
-   $ pip install linkchecker
+   $ python -m pip install linkchecker
    $ linkchecker --check-extern docs/_build/html/index.html
 
 Because Sphinx doesn't warn about some broken internal links for some reason,

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -160,28 +160,12 @@ Here's to commands to check for and fix this (see `here <http://stackoverflow.co
 Check HTML links
 ----------------
 
-There's two ways to check the docs for broken links.
-
-
-This will check external links (not nice because you have to install first):
+To check for broken external links from the Sphinx documentation:
 
 .. code-block:: bash
 
    $ python setup.py install
    $ cd docs; make linkcheck
-
-To check all internal and external links use this `linkchecker <https://github.com/wummel/linkchecker>`__:
-
-.. code-block:: bash
-
-   $ python -m pip install linkchecker
-   $ linkchecker --check-extern docs/_build/html/index.html
-
-Because Sphinx doesn't warn about some broken internal links for some reason,
-we run ``linkchecker docs/_build/html/index.html`` on travis-ci,
-but not with the ``--check-extern`` option as that would probably fail
-randomly quite often whenever one of the external websites is down.
-
 
 Other codes
 -----------

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -279,18 +279,15 @@ In Gammapy we use on ``overwrite`` bool option for `gammapy.scripts` and functio
 write to files.
 
 Why not use ``clobber`` instead?
-After all the
-`FTOOLS <http://heasarc.gsfc.nasa.gov/ftools/ftools_menu.html>`__
-always use ``clobber``.
+After all the `FTOOLS`_ always use ``clobber``.
 
 The reason is that ``overwrite`` is clear to everyone, but ``clobber`` is defined by the dictionary
 (e.g. see `here <http://dictionary.reference.com/browse/clobber>`__)
 as "to batter severely; strike heavily. to defeat decisively. to denounce or criticize vigorously."
 and isn't intuitively clear to new users.
 
-Astropy uses both ``clobber`` and ``overwrite`` in various places at the moment.
-For Gammapy we can re-visit this decision before the 1.0 release, but for now,
-please be consistent and use ``overwrite``.
+Astropy has started the process of changing their APIs to consistently use ``overwrite``
+and deprecated the use of ``clobber``. So we do the same in Gammapy.
 
 Pixel coordinate convention
 ---------------------------

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -66,7 +66,7 @@ Make release
 
 Steps for the day of the release:
 
-#. Mention release in the :ref:`gammapy_news` section.
+#. Mention release on the front page and on the news page of the Gammapy webpage.
 #. Follow the instructions how to release an Astropy affiliated package
    `here <http://docs.astropy.org/en/latest/development/affiliated-packages.html#releasing-an-affiliated-package>`__.
 #. Check that the tarball and description (which is from ``LONG_DESCRIPTION.rst``) on PyPI is OK.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,6 @@
     :width: 400px
 
 |
-
 .. _gammapy_welcome:
 
 What is Gammapy?
@@ -13,6 +12,7 @@ What is Gammapy?
 Gammapy is a community-developed, open-source Python package for gamma-ray astronomy.
 It is a prototype for the `CTA`_ science tools.
 
+* Gammapy webpage: http://gammapy.org/
 * Read the `Gammapy documentation`_.
 * Ask questions on the `Gammapy mailing list`_.
 * Request features, report bugs or contribute on the `Gammapy GitHub page`_.
@@ -80,27 +80,3 @@ The Gammapy toolbox
   time/index
   utils/index
   maps/index
-
-.. _gammapy_news:
-
-News
-----
-
-To get notifications for Gammapy releases, join the `Gammapy mailing list`_.
-
-* April 28, 2017 --- Gammapy **0.6** release. See changelog: :ref:`gammapy_0p6_release`
-* February 2017 --- `Gammapy workshop in Paris <https://github.com/gammapy/gammapy-meetings/blob/master/2017-02_Paris.md>`__
-* November 22, 2016 --- Gammapy **0.5** release. See changelog: :ref:`gammapy_0p5_release`
-* July 2016 --- `Gammapy poster at Gamma 2016`_
-* June 2016 --- `First Gammapy coding sprint`_ at MPIK, Heidelberg
-* June 2016 --- Gammapy is used to build `gamma-sky.net`_
-* May - August 2016 --- `Olga Vorokh GSoC 2016 on image analysis and source detection`_
-* May 2016 --- `First Gammapy presentation at a CTA meeting`_
-* April 20, 2016 --- Gammapy **0.4** release. See changelog: :ref:`gammapy_0p4_release`
-* April 7, 2016 --- Gammapy presentation at the `April 2016 IACT data meeting`_
-* November 16 - 20, 2015 --- `Python for gamma-ray astronomy 2015`_ workshop at MPIK, Heidelberg
-* August 13, 2015 --- Gammapy **0.3** release. See changelog: :ref:`gammapy_0p3_release`
-* August 2015 --- `Gammapy poster and proceeding at ICRC 2015`_
-* May - August 2015 --- `Manuel Paz Arribas GSoC 2015 on observation handling and cube background modeling`_
-* April 13, 2015 --- Gammapy **0.2** release. See changelog: :ref:`gammapy_0p2_release`
-* August 25, 2014 --- Gammapy **0.1** release. See changelog: :ref:`gammapy_0p1_release`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@
     :width: 400px
 
 |
+
 .. _gammapy_welcome:
 
 What is Gammapy?

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -23,7 +23,7 @@ functionality available:
         scikit-image scikit-learn h5py pandas \
         aplpy photutils reproject
 
-    pip install iminuit
+    python -m pip install iminuit
 
 Sherpa is the only Gammapy dependency that's not yet available on Python 3, so if you want
 to use Sherpa for modeling / fitting, install Anaconda Python 2 and

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -10,7 +10,7 @@ and then run these commands:
 .. code-block:: bash
 
     conda config --add channels conda-forge --add channels sherpa
-    conda install gammapy naima \
+    conda install gammapy naima sherpa \
         scipy matplotlib ipython-notebook \
         cython click
 
@@ -19,18 +19,7 @@ functionality available:
 
 .. code-block:: bash
 
-    conda install \
-        scikit-image scikit-learn h5py pandas \
-        aplpy photutils reproject
-
-    python -m pip install iminuit
-
-Sherpa is the only Gammapy dependency that's not yet available on Python 3, so if you want
-to use Sherpa for modeling / fitting, install Anaconda Python 2 and
-
-.. code-block:: bash
-
-    conda install sherpa
+    conda install scikit-image aplpy photutils reproject iminuit
 
 To update to the latest version:
 

--- a/docs/install/dependencies.rst
+++ b/docs/install/dependencies.rst
@@ -48,7 +48,6 @@ Allowed optional dependencies:
 * `GammaLib`_ and `ctools`_ for simulating data and likelihood fitting
 * `ROOT`_ and `rootpy`_ conversion helper functions (still has some Python 3 issues)
 * `uncertainties`_ for linear error propagation
-* `gwcs`_ for generalised world coordinate transformations
 * `astroplan`_ for observation planning and scheduling
 * `iminuit`_ for fitting by optimization
 * `emcee`_ for fitting by MCMC sampling

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -28,7 +28,7 @@ You can install the latest stable version of Gammapy with conda::
 
 or with pip::
 
-    pip install gammapy
+    python -m pip install gammapy
 
 or with Macports (a package manager for Mac OS)::
 
@@ -44,7 +44,7 @@ To install the development version of Gammapy::
 
     git clone https://github.com/gammapy/gammapy.git
     cd gammapy
-    pip install .
+    python -m pip install .
 
 of if you're using conda, you can install the development version like this::
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -40,30 +40,33 @@ install it with e.g. ``apt-get`` or ``yum``.
 Development version
 -------------------
 
-To install the development version of Gammapy::
+You can install the development version of Gammapy like this::
 
-    git clone https://github.com/gammapy/gammapy.git
-    cd gammapy
-    python -m pip install .
+    python -m pip install --user git+https://github.com/gammapy/gammapy.git
 
-of if you're using conda, you can install the development version like this::
+This will ``git clone`` the Gammapy repository from Github into a temp folder
+and then build and install Gammapy from there.
 
-    git clone https://github.com/gammapy/gammapy.git
-    cd gammapy
-    conda env create -f environment-dev.yml
-    source activate gammapy-dev
+If there are any errors related to Cython, Numpy or Astropy, you should install
+those first and try again::
+
+    conda install -c cython numpy astropy click regions
+    python -m pip install --user git+https://github.com/gammapy/gammapy.git
+
+How to get set up for Gammapy development is described here: :ref:`dev_setup`
 
 Verify
 ------
 
-To verify that Gammapy is installed and available, type this::
+To verify that Gammapy is installed and available,
+and to check it's version and where it's located, type this::
 
     $ python
 
     >>> import gammapy
     >>> print(gammapy.__version__)
+    >>> print(gammapy.__path__)
 
-To find out
 
 Need help?
 ==========
@@ -74,6 +77,11 @@ It's a binary package manager (so generally installation is fast), and allows yo
 install any software in your home folder (without needing ``sudo``) and works the
 same on Linux, Mac OS and Windows. Many Gammapy users and developers use conda
 and are happy with it.
+
+There is a nice blog post `Installing Python Packages from a Jupyter Notebook`_ that
+explains how to install Python packages in general with ``pip`` and ``conda``,
+specifically from inisde Jupyter notebooks, but also in general it's a good introduction
+how Python package installation with ``pip`` and ``conda`` work.
 
 If you have any questions or issues, don't hesitate to ask on the `Gammapy mailing list`_!
 

--- a/docs/install/macports.rst
+++ b/docs/install/macports.rst
@@ -12,7 +12,7 @@ To install Gammapy and it's core dependencies:
 
 .. code-block:: bash
 
-    sudo port install py35-gammapy
+    sudo port install py36-gammapy
 
 The commands to update Gammapy and it's dependencies to the latest stable versions are:
 
@@ -52,7 +52,7 @@ Macports also has a convenience command ``port select`` built in to select a giv
 
 .. code-block:: bash
 
-    sudo port select python python35
+    sudo port select python python36
 
 This will create a symbolic link ``/opt/local/bin/python -> /opt/local/bin/python3.5`` and means that
 now if you execute ``python``, you will get the Macports Python 3.5.
@@ -73,10 +73,10 @@ Here's some examples for some scientific computing and astronomy packages:
 .. code-block:: bash
 
     sudo port install \
-        py35-pip py35-pytest \
-        py35-scipy py35-matplotlib py35-scikit-image py35-scikit-learn \
-        py35-pandas py35-emcee py35-h5py py35-ipython py35-uncertainties \
-        py35-healpy py35-cython
+        py36-pip py36-pytest \
+        py36-scipy py36-matplotlib py36-scikit-image py36-scikit-learn \
+        py36-pandas py36-emcee py36-h5py py36-ipython py36-uncertainties \
+        py36-healpy py36-cython
 
 To search which software is available in Macports (searches package name and description):
 
@@ -115,7 +115,7 @@ There's a few things worth pointing out about how we execute ``pip`` to install 
   the ``site-packages`` folder where Macports installs packages.
   This will usually work, but can then cause problems later on when you try to upgrade or add packages
   via ``sudo port install``. Macports updates work so well because it is very well organised and e.g. keeps
-  manifests of all files installed (you can list them with ``port contents py35-gammapy``). So basically,
+  manifests of all files installed (you can list them with ``port contents py36-gammapy``). So basically,
   to not mess with this, you should never touch files in ``/opt/local`` except through ``port`` commands.
   The ``--user`` option of ``pip`` means "install in my user site-packages folder", which at this time
   on macOS is ``/Users/<username>/Library/Python/3.5/lib/python/site-packages`` and is by default on the
@@ -126,7 +126,7 @@ To uninstall Python packages:
 .. code-block:: bash
 
     sudo port uninstall <packagename>
-    pip uninstall <packagename>
+    python -m pip uninstall <packagename>
 
 To check where a given package you're using is installed:
 

--- a/docs/install/other.rst
+++ b/docs/install/other.rst
@@ -44,7 +44,7 @@ The following packages have to be installed with pip:
 
 .. code-block:: bash
 
-    pip3 install --user \
+    python3 -m pip install --user \
         gammapy naima photutils reproject gwcs astroplan \
         iminuit emcee healpy
 
@@ -95,7 +95,7 @@ and then
 
 .. code-block:: bash
 
-   $ pip install ipython astropy gammapy
+   $ python -m pip install ipython astropy gammapy
 
 If this doesn't work (which is not uncommon, this is known to fail to compile the C
 extensions of Astropy on some platforms), ask your Python-installation-savvy co-worker

--- a/docs/install/other.rst
+++ b/docs/install/other.rst
@@ -6,11 +6,8 @@ Other package managers
 ======================
 
 Besides conda, Gammapy and some of the optional dependencies (Sherpa, Astropy-affiliated packages)
-as not yet available in other package managers (such as
-e.g. `apt-get <https://en.wikipedia.org/wiki/Advanced_Packaging_Tool>`__
-or `yum <https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified>`__ on Linux
-or `Macports <https://www.macports.org/>`__
-or `homebrew <http://brew.sh/>`__ on Mac.
+are not yet available in other package managers, such as e.g. `apt-get`_ or `yum`_ on Linux
+or `Macports`_ or `Homebrew`_ on Mac.
 
 So installing Gammapy this way is not recommended at this time.
 (The recommended method is conda as mentioned above).
@@ -28,8 +25,7 @@ available in those distributions and versions are updated.
 apt-get
 -------
 
-`apt-get <https://en.wikipedia.org/wiki/Advanced_Packaging_Tool>`__ is a popular package manager on Linux,
-e.g. on Debian or Ubuntu.
+On Ubuntu or Debian Linux, you can use `apt-get`_ and `pip`_ to install Gammapy and it's dependencies.
 
 The following packages are available:
 
@@ -46,22 +42,14 @@ The following packages have to be installed with pip:
 
     python3 -m pip install --user \
         gammapy naima photutils reproject gwcs astroplan \
-        iminuit emcee healpy
+        iminuit emcee healpy sherpa
 
-Sherpa currently doesn't work on Python 3.
-You could try to use Python 2 and pip-installing Sherpa (don't know if that works).
-
-A Debian package for Sherpa is in preparation: https://github.com/sherpa/sherpa/issues/75
-
-A Debian package for Gammapy is in preparation: https://github.com/gammapy/gammapy/issues/324
-
-As far as I can see there's no HEALPIX or healpy package.
+Another option to install software on Debian (and any system) is to use conda.
 
 yum
 ---
 
-`yum <https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified>`__ is a popular package manager on Linux,
-e.g. on Scientific linux or Red Hat Linux.
+`yum`_ is a popular package manager on Linux, e.g. on Scientific linux or Red Hat Linux.
 
 If you are a ``yum`` user, please contribute the equivalent commands
 (see e.g. the Macports section below).
@@ -69,17 +57,20 @@ If you are a ``yum`` user, please contribute the equivalent commands
 Homebrew
 --------
 
-`Homebrew <http://brew.sh/>`_ is a popular package manager on Mac.
+`Homebrew`_ is a popular package manager on Mac.
 
-If you are a ``brew`` user, please contribute the equivalent commands
-(see e.g. the Macports section above).
+Gammapy currently isn't packaged with Homebrew. It should be possible to install
+Python / pip / Numpy / Astropy with ``brew`` and then to install Gammapy with ``pip``.
 
+If you're a ``brew`` user, please let us know if it works and what the exact commands are.
+
+Note that we have some Gammapy developers and users on Mac that use Macports.
+For this you can find detailed instructions here: :ref:`install-macports`
 
 Fermi ScienceTools
 ------------------
 
-The `Fermi ScienceTools <http://fermi.gsfc.nasa.gov/ssc/data/analysis/software/>`__
-ships with it's own Python 2.7 interpreter.
+The `Fermi ScienceTools`_ ships with it's own Python 2.7 interpreter.
 
 If you want to use Astropy or Gammapy with that Python, you have to install it using
 that Python interpreter, other existing Python interpreters or installed packages
@@ -89,9 +80,7 @@ Fermi ScienceTools version ``v10r0p5`` (released Jun 24, 2015) includes
 Python 2.7.8, Numpy 1.9.1, Scipy 0.14.0, matplotlib 1.1.1, PyFITS 3.1.2.
 Unfortunately pip, ipython or Astropy are not included.
 
-So first in stall `pip`_ (see
-`instructions <https://pip.pypa.io/en/latest/installing.html#install-pip>`__),
-and then
+So first in stall `pip`_ (see `pip install instructions`_), and then
 
 .. code-block:: bash
 

--- a/docs/install/other.rst
+++ b/docs/install/other.rst
@@ -41,7 +41,7 @@ The following packages have to be installed with pip:
 .. code-block:: bash
 
     python3 -m pip install --user \
-        gammapy naima photutils reproject gwcs astroplan \
+        gammapy naima photutils reproject \
         iminuit emcee healpy sherpa
 
 Another option to install software on Debian (and any system) is to use conda.

--- a/docs/install/pip.rst
+++ b/docs/install/pip.rst
@@ -14,18 +14,18 @@ To install the latest Gammapy **stable** version (see `Gammapy page on PyPI`_) u
 
 .. code-block:: bash
 
-   $ pip install gammapy
+   $ python -m pip install gammapy
 
 To install the current Gammapy **development** version using `pip`_:
 
 .. code-block:: bash
 
-   $ pip install git+https://github.com/gammapy/gammapy.git#egg=gammapy
+   $ python -m pip install git+https://github.com/gammapy/gammapy.git#egg=gammapy
 
 If that doesn't work because the download from PyPI or Github is blocked by your network,
 but you have some other means of copying files onto that machine,
 you can get the tarball (``.tar.gz`` file) from PyPI or ``.zip`` file from Github, and then
-``pip install <filename>``.
+``python -m pip install <filename>``.
 
 .. _install-setuppy:
 

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -40,7 +40,7 @@ where :math:`F`, :math:`R`, :math:`t_{obs}` and :math:`N` are the following quan
 * Expected observed counts model :math:`N(p', E')` (unit: :math:`sr^{-1} TeV^{-1}`)
 
 If you'd like to learn more about instrument response functions, have a look at the descriptions for
-`Fermi <http://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_LAT_IRFs/index.html>`__,
+`Fermi <https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_LAT_IRFs/index.html>`__,
 for `TeV data analysis <http://inspirehep.net/record/1122589>`__
 and for `GammaLib <http://gammalib.sourceforge.net/user_manual/modules/obs.html#handling-the-instrument-response>`__.
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -63,7 +63,7 @@ Software references:
 .. [Knoedlseder2012] `Knödlseder et at. (2012) <http://adsabs.harvard.edu/abs/2012ASPC..461...65K>`_
    "GammaLib: A New Framework for the Analysis of Astronomical Gamma-Ray Data"
    
-.. [FSSC2013] `Fermi LAT Collaboration (2013) <http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/overview.html>`_
+.. [FSSC2013] `Fermi LAT Collaboration (2013) <https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/overview.html>`_
    "Science Tools: LAT Data Analysis Tools"
 
 .. [Mayer2015] `Michael Mayer (2015) <https://publishup.uni-potsdam.de/frontdoor/index/index/docId/7150>`_

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -15,7 +15,6 @@
 .. _reproject: http://reproject.readthedocs.io
 .. _photutils: http://photutils.readthedocs.io
 .. _astroplan: http://astroplan.readthedocs.io
-.. _gwcs: http://gwcs.readthedocs.io
 .. _iminuit: https://github.com/iminuit/iminuit
 .. _probfit: https://github.com/iminuit/probfit
 .. _h5py: http://www.h5py.org/

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -106,3 +106,4 @@
 
 .. _Gammapy tutorial notebooks on nbviewer: https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/index.ipynb
 .. _nbsphinx: http://nbsphinx.readthedocs.io
+.. _Installing Python Packages from a Jupyter Notebook: http://jakevdp.github.io/blog/2017/12/05/installing-python-packages-from-jupyter/

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -9,7 +9,6 @@
 .. _ctools: http://cta.irap.omp.eu/ctools
 .. _3ML: https://threeml.stanford.edu/
 .. _Numpy: http://www.numpy.org/
-.. _Astropy: http://www.astropy.org/
 .. _affiliated package: http://www.astropy.org/affiliated/index.html
 .. _regions: http://astropy-regions.readthedocs.io
 .. _reproject: http://reproject.readthedocs.io

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -81,7 +81,7 @@
 .. _gamma-sky.net: http://gamma-sky.net/
 .. _Gammapy binder: http://mybinder.org/repo/gammapy/gammapy-extra
 
-.. _Gammapy mailing list: http://groups.google.com/group/gammapy
+.. _Gammapy mailing list: https://groups.google.com/forum/#!forum/gammapy
 .. _Gammapy Github page: https://github.com/gammapy/gammapy
 .. _Gammapy documentation: http://docs.gammapy.org/
 .. _Gammapy project summary on Open HUB: https://www.openhub.net/p/gammapy

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -9,7 +9,7 @@
 .. _ctools: http://cta.irap.omp.eu/ctools
 .. _3ML: https://threeml.stanford.edu/
 .. _Numpy: http://www.numpy.org/
-.. _Astropy: http://astropy.org
+.. _Astropy: http://www.astropy.org/
 .. _affiliated package: http://www.astropy.org/affiliated/index.html
 .. _regions: http://astropy-regions.readthedocs.io
 .. _reproject: http://reproject.readthedocs.io
@@ -21,6 +21,7 @@
 .. _h5py: http://www.h5py.org/
 .. _naima: https://github.com/zblz/naima
 .. _ROOT: https://root.cern.ch/drupal/
+.. _PyROOT: https://root.cern.ch/drupal/content/pyroot
 .. _rootpy: http://www.rootpy.org/
 .. _Sherpa: http://cxc.cfa.harvard.edu/sherpa/
 .. _CIAO: http://cxc.cfa.harvard.edu/ciao/
@@ -29,6 +30,7 @@
 .. _matplotlib: http://matplotlib.org
 .. _pandas: http://pandas.pydata.org
 .. _pip: https://pip.pypa.io/en/stable/
+.. _pip install instructions: https://pip.pypa.io/en/latest/installing.html#install-pip
 .. _conda: http://conda.pydata.org/
 .. _PyFACT: http://adsabs.harvard.edu/abs/2012AIPC.1505..789R
 .. _healpy: https://healpy.readthedocs.io/en/latest/
@@ -48,18 +50,19 @@
 .. _pointlike: https://github.com/tburnett/Fermi-LAT
 .. _NaN: https://en.wikipedia.org/wiki/NaN
 
-.. _MPIK Heidelberg: http://www.mpi-hd.mpg.de/mpi/en/start/
+.. _MPIK Heidelberg: https://www.mpi-hd.mpg.de/mpi/en/start/
 .. _APC Paris: http://www.apc.univ-paris7.fr/
 .. _Paris Observatory: https://www.obspm.fr
 
 .. _Python for gamma-ray astronomy 2015: http://gammapy.github.io/PyGamma15/
 
 .. _CTA: https://www.cta-observatory.org/
-.. _H.E.S.S.: http://www.mpi-hd.mpg.de/hfm/HESS/
-.. _HAWC: http://www.hawc-observatory.org/
-.. _VERITAS: http://veritas.sao.arizona.edu/
+.. _H.E.S.S.: https://www.mpi-hd.mpg.de/hfm/HESS/
+.. _HAWC: https://www.hawc-observatory.org/
+.. _VERITAS: https://veritas.sao.arizona.edu/
 .. _MAGIC: https://magic.mpp.mpg.de/
-.. _Fermi-LAT: http://fermi.gsfc.nasa.gov/
+.. _Fermi-LAT: https://fermi.gsfc.nasa.gov/
+.. _Fermi ScienceTools: https://fermi.gsfc.nasa.gov/ssc/data/analysis/software/
 .. _FermiPy: https://github.com/fermiPy/fermipy
 .. _gadf: http://gamma-astro-data-formats.readthedocs.io/
 
@@ -92,18 +95,29 @@
 .. _Slack: https://slack.com
 .. _PyPI: https://pypi.python.org
 
-.. _scientific Python stack: http://www.scipy.org/about.html
+.. _scientific Python stack: https://www.scipy.org/about.html
 
 .. _ctobssim: http://cta.irap.omp.eu/ctools-devel/reference_manual/ctobssim.html
-.. _gtpsf: http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/help/gtpsf.txt
+.. _gtpsf: https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/help/gtpsf.txt
 .. _rsync: https://en.wikipedia.org/wiki/Rsync
 
 .. _PHA: https://heasarc.gsfc.nasa.gov/docs/heasarc/ofwg/docs/spectra/ogip_92_007/node5.html
-.. _ARF: http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc4
-.. _RMF: http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.1
+.. _ARF: https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc4
+.. _RMF: https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.1
 
 .. _Github clone URL help article: https://help.github.com/articles/which-remote-url-should-i-use/
 
 .. _Gammapy tutorial notebooks on nbviewer: https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/index.ipynb
 .. _nbsphinx: http://nbsphinx.readthedocs.io
 .. _Installing Python Packages from a Jupyter Notebook: http://jakevdp.github.io/blog/2017/12/05/installing-python-packages-from-jupyter/
+
+.. _apt-get: https://en.wikipedia.org/wiki/Advanced_Packaging_Tool
+.. _yum: https://en.wikipedia.org/wiki/Yellowdog_Updater,_Modified
+.. _Macports: https://www.macports.org/
+.. _Homebrew: https://brew.sh/
+.. _Fermi-LAT time systems in a nutshell: https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html
+.. _FTOOLS: https://heasarc.gsfc.nasa.gov/ftools/ftools_menu.html
+.. _XSpec: https://heasarc.gsfc.nasa.gov/xanadu/xspec/
+.. _XSpec manual statistics page: https://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
+.. _Sherpa statistics page: https://cxc.cfa.harvard.edu/sherpa/statistics
+.. _XML schema: https://en.wikipedia.org/wiki/XML_schema

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -83,7 +83,7 @@ This means that to be able to use the tools you have to install Gammapy:
 
 .. code-block:: bash
 
-    $ pip install --user .
+    $ python -m pip install --user .
 
 
 This will install the ``gammapy-*`` wrappers in a ``bin`` folder that you need to add to your ``$PATH``,
@@ -94,7 +94,7 @@ Gammapy and the tools and don't have to re-install after every change.
 
 .. code-block:: bash
 
-    $ pip install --user --editable .
+    $ python -m pip install --user --editable .
 
 
 Most of the command line tools are implemented in the `gammapy.scripts` sub-package as thin wrappers

--- a/docs/stats/fit_statistics.rst
+++ b/docs/stats/fit_statistics.rst
@@ -1,3 +1,5 @@
+.. include:: ../references.txt
+
 .. _fit-statistics:
 
 Fit statistics
@@ -7,9 +9,7 @@ Introduction
 ------------
 
 This page describes common fit statistics used in gamma-ray astronomy.
-Results were tested against results from the
-`Sherpa <http://cxc.harvard.edu/sherpa/>`_ and
-`XSpec <https://heasarc.gsfc.nasa.gov/xanadu/xspec/>`_
+Results were tested against results from the `Sherpa`_ and `XSpec`_
 X-ray analysis packages.
 
 .. Likelihood defined per bin -> take sum
@@ -286,10 +286,8 @@ scenarios
 Notes
 ^^^^^
 
-All above formulae are equivalent to what is given on the 
-`XSpec manual statistics page
-<http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
-with the substitutions
+All above formulae are equivalent to what is given on the
+`XSpec manual statistics page`_ with the substitutions:
 
 .. math::
 
@@ -300,7 +298,6 @@ with the substitutions
 
 Further references
 ------------------
-* `Sherpa statistics page <http://cxc.cfa.harvard.edu/sherpa/statistics>`_ 
-* `XSpec manual statistics page
-  <http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
- 
+
+* `Sherpa statistics page`_
+* `XSpec manual statistics page`_

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -1,3 +1,5 @@
+.. include:: ../references.txt
+
 .. _utils:
 
 *************************************************
@@ -79,8 +81,8 @@ This is done automatically by `astropy.coordinates.AltAz` when the
 no need for explicit time scale transformations in Gammapy
 (although if you do want to explicitly compute it, it's easy, see `here <http://docs.astropy.org/en/latest/time/index.html#sidereal-time>`__).
 
-The "Time Systems in a nutshell" section `here <http://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html>`__
-gives a good, brief explanation of the differences between the relevant time scales ``UT1``, ``UTC`` and ``TT``.
+The `Fermi-LAT time systems in a nutshell`_ page gives a good, brief explanation of the differences
+between the relevant time scales ``UT1``, ``UTC`` and ``TT``.
 
 .. _MET_definition:
 
@@ -90,9 +92,7 @@ Mission elapsed times (MET)
 [MET]_ time references are times representing UTC seconds after a
 specific origin. Each experiment may have a different MET origin
 that should be included in the header of the corresponding data
-files. For more details see `Cicerone: Data - Time in Fermi Data Analysis
-<http://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/
-Time_in_ScienceTools.html>`_.
+files. For more details see `Fermi-LAT time systems in a nutshell`_.
 
 It's not clear yet how to best implement METs in Gammapy, it's one
 of the tasks here:

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -617,8 +617,8 @@ class DataStoreObservation(object):
 
         Dead-time is defined as the time during the observation
         where the detector didn't record events:
-        http://en.wikipedia.org/wiki/Dead_time
-        http://adsabs.harvard.edu/abs/2004APh....22..285F
+        https://en.wikipedia.org/wiki/Dead_time
+        https://adsabs.harvard.edu/abs/2004APh....22..285F
 
         The dead-time fraction is used in the live-time computation,
         which in turn is used in the exposure and flux computation.

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -225,8 +225,8 @@ class EventList(object):
 
         Dead-time is defined as the time during the observation
         where the detector didn't record events:
-        http://en.wikipedia.org/wiki/Dead_time
-        http://adsabs.harvard.edu/abs/2004APh....22..285F
+        https://en.wikipedia.org/wiki/Dead_time
+        https://adsabs.harvard.edu/abs/2004APh....22..285F
 
         The dead-time fraction is used in the live-time computation,
         which in turn is used in the exposure and flux computation.

--- a/gammapy/data/observers.py
+++ b/gammapy/data/observers.py
@@ -23,23 +23,23 @@ Not that with ``EarthLocation`` the orientation of angles is as follows:
 Available observatories (alphabetical order):
 
 - ``cta_south`` and ``cta_north`` for CTA, see
-  `Website <http://www.cta-observatory.org/>`__ and
-  `Wikipedia <http://en.wikipedia.org/wiki/Cherenkov_Telescope_Array>`__
+  `Website <https://www.cta-observatory.org/>`__ and
+  `Wikipedia <https://en.wikipedia.org/wiki/Cherenkov_Telescope_Array>`__
 - ``hawc`` for HAWC, see
   `Website <https://www.hawc-observatory.org/>`__ and
-  `Wikipedia <http://en.wikipedia.org/wiki/High_Altitude_Water_Cherenkov_Experiment>`__
-- ``hegra`` for HEGRA, see `Wikipedia <http://en.wikipedia.org/wiki/HEGRA>`__
+  `Wikipedia <https://en.wikipedia.org/wiki/High_Altitude_Water_Cherenkov_Experiment>`__
+- ``hegra`` for HEGRA, see `Wikipedia <https://en.wikipedia.org/wiki/HEGRA>`__
 - ``hess`` for HESS, see
   `Website <https://www.mpi-hd.mpg.de/hfm/HESS/>`__ and
-  `Wikipedia <http://en.wikipedia.org/wiki/HESS>`__
+  `Wikipedia <https://en.wikipedia.org/wiki/HESS>`__
 - ``magic`` for MAGIC, see
   `Website <https://wwwmagic.mpp.mpg.de/>`__ and
-  `Wikipedia <http://en.wikipedia.org/wiki/MAGIC_(telescope)>`__
+  `Wikipedia <https://en.wikipedia.org/wiki/MAGIC_(telescope)>`__
 - ``milagro`` for MILAGRO, see
-  `Wikipedia <http://en.wikipedia.org/wiki/Milagro_(experiment)>`__)
+  `Wikipedia <https://en.wikipedia.org/wiki/Milagro_(experiment)>`__)
 - ``veritas`` for VERITAS, see
-  `Website <http://veritas.sao.arizona.edu/>`__ and `Wikipedia <http://en.wikipedia.org/wiki/VERITAS>`__
-- ``whipple`` for WHIPPLE, see `Wikipedia <http://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory>`__
+  `Website <https://veritas.sao.arizona.edu/>`__ and `Wikipedia <https://en.wikipedia.org/wiki/VERITAS>`__
+- ``whipple`` for WHIPPLE, see `Wikipedia <https://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory>`__
 
 Examples
 --------
@@ -61,7 +61,7 @@ observatory_locations['cta_south'] = EarthLocation(lon='-70d18m58.84s', lat='-24
 # lon=-17.891571d, lat=28.762158d, height=2147m
 observatory_locations['cta_north'] = EarthLocation(lon='-17d53m31.218s', lat='28d45m43.7904s', height='2147m')
 
-# HAWC location taken from http://arxiv.org/pdf/1108.6034v2.pdf
+# HAWC location taken from https://arxiv.org/pdf/1108.6034v2.pdf
 observatory_locations['hawc'] = EarthLocation(lon='-97d18m34s', lat='18d59m48s', height='4100m')
 
 # https://en.wikipedia.org/wiki/HEGRA
@@ -77,5 +77,5 @@ observatory_locations['milagro'] = EarthLocation(lon='-106.67625d', lat='35.8783
 observatory_locations['veritas'] = EarthLocation(lon='-110d57m07.77s', lat='31d40m30.21s', height='1268m')
 
 # WHIPPLE coordinates taken from the Observatory Wikipedia page:
-# http://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory
+# https://en.wikipedia.org/wiki/Fred_Lawrence_Whipple_Observatory
 observatory_locations['whipple'] = EarthLocation(lon='-110d52m42s', lat='31d40m52s', height='2606m')

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -225,8 +225,8 @@ class SkyImage(MapBase):
         """
         Create an empty image from scratch.
 
-        Uses the same parameter names as the Fermi tool gtbin
-        (see http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/help/gtbin.txt).
+        Uses the same parameter names as the Fermi tool ``gtbin``
+        (see https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/help/gtbin.txt).
 
         If no reference pixel position is given it is assumed to be
         at the center of the image.

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -242,8 +242,7 @@ class EnergyDispersion(object):
         Notes
         -----
         For more info on the RMF FITS file format see:
-        http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/summary/cal_gen_92_002_summary.html
-
+        https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/summary/cal_gen_92_002_summary.html
         """
         # Cannot use table_to_fits here due to variable length array
         # http://docs.astropy.org/en/v1.0.4/io/fits/usage/unfamiliar.html
@@ -276,7 +275,7 @@ class EnergyDispersion(object):
         """Convert to `~astropy.table.Table`.
 
         The output table is in the OGIP RMF format.
-        http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#Tab:1
+        https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#Tab:1
         """
         rows = self.pdf_matrix.shape[0]
         n_grp = []

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -687,7 +687,7 @@ class PowerLaw(SpectralModel):
 class PowerLaw2(SpectralModel):
     r"""Spectral power-law model with integral as amplitude parameter.
 
-    See also: http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html
+    See also: https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html
 
     .. math::
 

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -140,7 +140,7 @@ def wstat(n_on, n_off, alpha, mu_sig, mu_bkg=None, extra_terms=True):
     * `Habilitation M. de Naurois, p. 141
       <http://inspirehep.net/record/1122589/files/these_short.pdf>`_
     * `XSPEC page on Poisson data with Poisson background
-      <http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
+      <https://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html>`_
     """
     # Note: This is equivalent to what's defined on the XSPEC page under the
     # following assumptions
@@ -212,18 +212,17 @@ def get_wstat_gof_terms(n_on, n_off):
 def lstat():
     r"""L statistic, for Poisson data with Poisson background (Bayesian).
 
-    Reference: http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
-
+    Reference: https://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
     """
-    pass
+    raise NotImplementedError
 
 
 def pgstat():
     r"""PG statistic, for Poisson data with Gaussian background.
 
-    Reference: http://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
+    Reference: https://heasarc.nasa.gov/xanadu/xspec/manual/XSappendixStatistics.html
     """
-    pass
+    raise NotImplementedError
 
 
 def chi2(N_S, B, S, sigma2):

--- a/gammapy/stats/significance.py
+++ b/gammapy/stats/significance.py
@@ -81,11 +81,11 @@ def convert_likelihood(to, probability=None, significance=None,
     Note that the `~gammapy.stats.cash` statistic already contains the factor 2,
     i.e. you should compute ``TS`` as ``TS = cash_alt - cash_null``.
 
-    - http://en.wikipedia.org/wiki/Chi-squared_distribution
+    - https://en.wikipedia.org/wiki/Chi-squared_distribution
     - http://docs.scipy.org/doc/scipy-dev/reference/generated/scipy.stats.chi2.html
-    - http://en.wikipedia.org/wiki/Likelihood-ratio_test#Wilks.27s_theorem
-    - http://adsabs.harvard.edu/abs/1979ApJ...228..939C
-    - http://adsabs.harvard.edu/abs/2009A%26A...495..989S
+    - https://en.wikipedia.org/wiki/Likelihood-ratio_test
+    - https://adsabs.harvard.edu/abs/1979ApJ...228..939C
+    - https://adsabs.harvard.edu/abs/2009A%26A...495..989S
 
     **Physical limits**
 

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -320,10 +320,9 @@ def fits_table_to_table(hdu):
 
 
 def energy_axis_to_ebounds(energy):
-    """Convert `~gammapy.utils.energy.EnergyBounds` to OGIP ``EBOUNDS`` extension
+    """Convert `~gammapy.utils.energy.EnergyBounds` to OGIP ``EBOUNDS`` extension.
 
-    see
-    http://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.2
+    See https://heasarc.gsfc.nasa.gov/docs/heasarc/caldb/docs/memos/cal_gen_92_002/cal_gen_92_002.html#tth_sEc3.2
     """
     energy = EnergyBounds(energy)
     table = Table()

--- a/gammapy/utils/root/__init__.py
+++ b/gammapy/utils/root/__init__.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utility functions to work with ROOT and rootpy.
 
-* ROOT: http://root.cern.ch
-* rootpy: http://rootpy.org
+* ROOT: https://root.cern.ch
+* rootpy: http://www.rootpy.org/
 """
 from .convert import *

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,6 @@ setup(
           'scikit-image>=0.10',
           'photutils',
           'reproject',
-          'gwcs',
           'astroplan',
           'uncertainties>=2.4',
           'naima',


### PR DESCRIPTION
Here I improve the Gammapy installation docs a bit, using `python -m pip` everywhere and adding a link to http://jakevdp.github.io/blog/2017/12/05/installing-python-packages-from-jupyter/ as well as a few other small (hopefully) improvements.

I also removed the recommendation to use `linkchecker` when making a Gammapy - it doesn't work with Python 3, is unmaintained and it's forks or competing Python projects are all not great. It's also not really needed; the Sphinx `linkcheck` is already available for anyone working on the Sphinx docs and works well.

cc @adonath 