### PR TITLE
Remove references to RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,22 +174,6 @@ htmlhelp_basename = project + 'doc'
 # Static files to copy after template files
 html_static_path = ['_static']
 
-# download gammapy-extra for read the docs build
-on_rtd = os.environ.get('READTHEDOCS') == 'False'
-if on_rtd:
-    from zipfile import ZipFile
-    from astropy.extern.six.moves import urllib
-    from tempfile import mktemp
-
-    filename = mktemp('gammapy-extra-master.zip')
-    url = 'https://github.com/gammapy/gammapy-extra/archive/master.zip'
-    name, hdrs = urllib.request.urlretrieve(url, filename)
-    gp_extra_zip = ZipFile(filename)
-    path = os.path.dirname(filename)
-    gp_extra_zip.extractall(path)
-    gp_extra_zip.close()
-    os.environ['GAMMAPY_EXTRA'] = os.path.join(path, 'gammapy-extra-master')
-
 from gammapy.utils.docs import gammapy_sphinx_ext_activate
 gammapy_sphinx_ext_activate()
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,7 +175,7 @@ htmlhelp_basename = project + 'doc'
 html_static_path = ['_static']
 
 # download gammapy-extra for read the docs build
-on_rtd = os.environ.get('READTHEDOCS') == 'True'
+on_rtd = os.environ.get('READTHEDOCS') == 'False'
 if on_rtd:
     from zipfile import ZipFile
     from astropy.extern.six.moves import urllib

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -799,9 +799,6 @@ This should work::
 
 You need a bunch or LaTeX stuff, specifically ``texlive-fonts-extra`` is needed.
 
-The PDF is also generated on Read the Docs and available online here:
-https://media.readthedocs.org/pdf/gammapy/latest/gammapy.pdf
-
 Jupyter notebooks present in the ``gammapy-extra`` repository are by default copied
 to the ``docs/notebooks`` and ``docs/_static/notebooks`` tree-folder structure during
 the process of generating HTML docs. This triggers its conversion to *fixed-text*
@@ -977,24 +974,3 @@ instead of the usual Sphinx ``image`` directive like this:
         :scale: 100%
 
 More info on the image directive is `here <http://www.sphinx-doc.org/en/stable/rest.html#images>`__
-
-.. _dev-wipe_rtd:
-
-Wipe readthedocs
-----------------
-
-After things (classes, methods, functions) are removed, the Sphinx API docs often show these old items.
-If you notice this, you have to "wipe" the Gammapy install on Readthedocs and start a fresh build.
-If you don't have permissions on Readthedocs, file a Github issue or mention this on the mailing list.
-
-The wipe procedure is described `here <http://read-the-docs.readthedocs.io/en/latest/builds.html#deleting-a-stale-or-broken-build-environment>`__.
-
-The steps are:
-
-* log in `here <https://readthedocs.org/accounts/login/>`__
-* hit this URL and click the "wipe" button to wipe the existing install:
-
-   https://readthedocs.org/wipe/gammapy/latest/
-* go `here <https://readthedocs.org/projects/gammapy/>`__ and clicking the "Build" button.
-* go `here <https://readthedocs.org/builds/gammapy/>`__ and check if the build succeeded
-* re-check the output docs page where you had previously seen something outdated.

--- a/docs/development/setup.rst
+++ b/docs/development/setup.rst
@@ -29,7 +29,7 @@ and the ``docs`` folder. In ``gammapy`` you find the Gammapy package, i.e.
 all code, but also tests are included there in sub-folders called ``tests``.
 The ``docs`` folder contains the documentation pages in restructured text (RST)
 format. The Sphinx documentation generator is used to convert those RST files
-to the HTML documentation at https://gammapy.readthedocs.io/ .
+to the HTML documentation.
 
 In the repository you will find a bunch of other files and folders. We will explain
 some of them here, but not all. Just ignore the rest.
@@ -205,13 +205,7 @@ docs.gammapy.org
 http://docs.gammapy.org/ contains most of the documentation for Gammapy,
 including information about Gammapy, the changelog, tutorials, ...
 
-The docs.gammapy.org URL serves the content from https://gammapy.readthedocs.io
-ReadTheDocs (RTD) is a free cloud service to build and host documentation.
-
-To update the content, edit the RST files in the ``docs`` folder of the main
-``gammapy`` repo and make a pull request. Once it's merged, a docs build on
-the RTD servers will start, and if it succeeds, the updated documentation
-will appear at https://gammapy.readthedocs.io/en/latest/ about 10 minutes later.
+TODO: describe how to update.
 
 Gammapy Binder
 --------------
@@ -262,4 +256,3 @@ Data formats should be defined here, and then linked to from the Gammapy docs:
 
 * https://github.com/open-gamma-ray-astro/gamma-astro-data-formats
 * http://gamma-astro-data-formats.readthedocs.io
-

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -25,11 +25,6 @@ install Gammapy and get the ``gammapy-extra`` repository. This is
 described in `Gammapy tutorial
 setup <notebooks/tutorial_setup.html>`__.
 
-You can also download **for each version of Gammapy** a
-`HTMLZip pack <http://readthedocs.org/projects/gammapy/downloads/>`__
-containing the whole documentation and full collection of notebooks, so you can execute
-them in your local desktop inside the `_static/notebooks/` folder.
-
 Alternatively you may execute latest version of the collection of notebooks on-line
 accessing the `Gammapy Binder <http://mybinder.org/repo/gammapy/gammapy-extra>`__ space.
 

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -125,11 +125,8 @@ Try online on Binder
 
 [![Binder](https://mybinder.org/badge.svg)](https://beta.mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?filepath={nb_filename})
 
-Alternatively you can download for each version of Gammapy a
-[HTMLZip pack](http://readthedocs.org/projects/gammapy/downloads/) containing
-the whole HTML documentation and full collection of notebooks, so you can execute
-them in your local `_static/notebooks/` folder. You can also contribute with your
-own notebooks in this [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
+ You can also contribute with your own notebooks in this
+ [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 
 **Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |


### PR DESCRIPTION
References to Read the Docs have been removed from:

- documentation RST files
- fixed-notebooks info green boxes

RTD flags set to False in config scripts.