### PR TITLE
Improve map read method

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -116,20 +116,23 @@ class MapBase(object):
         map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
             Map type.  Selects the class that will be used to
             instantiate the map.  The map type should be consistent
-            the format of the input file.  If map_type is 'auto' then an
-            appropriate map type will be inferred from the input file.
+            with the format of the input file.  If map_type is 'auto'
+            then an appropriate map type will be inferred from the
+            input file.
 
         Returns
         -------
         map_out : `~MapBase`
             Map object
+
         """
         with fits.open(filename) as hdulist:
             if map_type == 'auto':
                 map_type = cls._get_map_type(hdulist, hdu)
 
             cls_out = cls._get_map_cls(map_type)
-            map_out = cls_out.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands)
+            map_out = cls_out.from_hdulist(hdulist, hdu=hdu,
+                                           hdu_bands=hdu_bands)
 
         return map_out
 
@@ -174,8 +177,6 @@ class MapBase(object):
             return HpxMapSparse
         else:
             raise ValueError('Unrecognized map type: {!r}'.format(map_type))
-
-
 
     def write(self, filename, **kwargs):
         """Write to a FITS file.

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -31,7 +31,7 @@ class HpxMap(MapBase):
         self._hpx2wcs = None
 
     @classmethod
-    def create(cls, nside=None, binsz=None, nest=True, map_type=None, coordsys='CEL',
+    def create(cls, nside=None, binsz=None, nest=True, map_type='hpx', coordsys='CEL',
                data=None, skydir=None, width=None, dtype='float32',
                region=None, axes=None, conv='gadf'):
         """Factory method to create an empty HEALPix map.
@@ -75,12 +75,12 @@ class HpxMap(MapBase):
             return HpxMapND(hpx, dtype=dtype)
         elif cls.__name__ == 'HpxMapSparse':
             return HpxMapSparse(hpx, dtype=dtype)
-        elif map_type in [None, 'hpx', 'HpxMapND']:
+        elif map_type == 'hpx':
             return HpxMapND(hpx, dtype=dtype)
-        elif map_type in ['hpx-sparse', 'HpxMapSparse']:
+        elif map_type == 'hpx-sparse':
             return HpxMapSparse(hpx, dtype=dtype)
         else:
-            raise ValueError('Unregnized Map type: {}'.format(map_type))
+            raise ValueError('Unrecognized map type: {}'.format(map_type))
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -53,9 +53,9 @@ class HpxMap(MapBase):
             Sky position of map center.  Can be either a SkyCoord
             object or a tuple of longitude and latitude in deg in the
             coordinate system of the map.
-        map_type : str
-            Internal map representation.  Valid types are `HpxMapND`/`hpx` and
-            `HpxMapSparse`/`hpx-sparse`.
+        map_type : {'hpx', 'hpx-sparse'}
+            Map type.  Selects the class that will be used to
+            instantiate the map.
         width : float
             Diameter of the map in degrees.  If None then an all-sky
             geometry will be created.

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -5,7 +5,9 @@ import numpy as np
 from numpy.testing import assert_allclose
 from ..utils import fill_poisson
 from ..geom import MapAxis
+from ..base import MapBase
 from ..hpx import HpxGeom
+from ..hpxmap import HpxMap
 from ..hpxnd import HpxMapND
 from ..hpxsparse import HpxMapSparse
 
@@ -75,6 +77,7 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
 
     m2 = HpxMapND.read(filename)
     m3 = HpxMapSparse.read(filename)
+    m4 = MapBase.read(filename, map_type='hpx')
     if sparse:
         msk = np.isfinite(m2.data[...])
     else:
@@ -82,11 +85,15 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
 
     assert_allclose(m.data[...][msk], m2.data[...][msk])
     assert_allclose(m.data[...][msk], m3.data[...][msk])
+    assert_allclose(m.data[...][msk], m4.data[...][msk])
+
     m.write(filename, sparse=True)
     m2 = HpxMapND.read(filename)
-    m3 = HpxMapND.read(filename)
+    m3 = HpxMap.read(filename, map_type='hpx')
+    m4 = MapBase.read(filename, map_type='hpx')
     assert_allclose(m.data[...][msk], m2.data[...][msk])
     assert_allclose(m.data[...][msk], m3.data[...][msk])
+    assert_allclose(m.data[...][msk], m4.data[...][msk])
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -7,8 +7,10 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..utils import fill_poisson
 from ..geom import MapAxis
+from ..base import MapBase
 from ..wcs import WcsGeom
 from ..hpx import HpxGeom
+from ..wcsmap import WcsMap
 from ..wcsnd import WcsMapND
 
 pytest.importorskip('scipy')
@@ -63,10 +65,19 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     fill_poisson(m0, mu=0.5)
     m0.write(filename)
     m1 = WcsMapND.read(filename)
+    m2 = MapBase.read(filename)
+    m3 = MapBase.read(filename, map_type='wcs')
     assert_allclose(m0.data, m1.data)
+    assert_allclose(m0.data, m2.data)
+    assert_allclose(m0.data, m3.data)
+
     m0.write(filename_sparse, sparse=True)
     m1 = WcsMapND.read(filename_sparse)
+    m2 = MapBase.read(filename)
+    m3 = MapBase.read(filename, map_type='wcs')
     assert_allclose(m0.data, m1.data)
+    assert_allclose(m0.data, m2.data)
+    assert_allclose(m0.data, m3.data)
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -133,3 +133,33 @@ def find_bintable_hdu(hdulist):
             return hdu
 
     raise AttributeError('No BinTable HDU found.')
+
+
+def get_map_type(hdu, map_type=None):
+    """Infer map type from a FITS HDU.
+
+    Parameters
+    ----------
+    hdu :  `~astropy.io.fits.ImageHDU` or  `~astropy.io.fits.BinTableHDU`
+        The HDU containing the map data.
+
+    map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse'}
+        Map representation.  If none then the representation will be
+        inferred from the FITS header.
+
+    """
+
+    # Infer pixel type from file
+    pix_type = 'wcs'
+    if 'PIXTYPE' in hdu.header and hdu.header['PIXTYPE'] == 'HEALPIX':
+        pix_type = 'hpx'
+
+    # if map type is not specified then default to non-sparse map for
+    # the appropriate pixelization
+    if map_type is None:
+        return pix_type
+    else:
+        if (('wcs' in map_type and pix_type != 'wcs') or
+                ('hpx' in map_type and pix_type != 'hpx')):
+            raise Exception('Mismatch between requested map type and file.')
+        return map_type

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -24,7 +24,7 @@ class WcsMap(MapBase):
     """
 
     @classmethod
-    def create(cls, map_type=None, npix=None, binsz=0.1, width=None,
+    def create(cls, map_type='wcs', npix=None, binsz=0.1, width=None,
                proj='CAR', coordsys='CEL', refpix=None,
                axes=None, skydir=None, dtype='float32', conv='gadf'):
         """Factory method to create an empty WCS map.
@@ -82,12 +82,12 @@ class WcsMap(MapBase):
                               coordsys=coordsys, refpix=refpix, axes=axes,
                               conv=conv)
 
-        if map_type in [None, 'wcs', 'WcsMapND']:
+        if map_type == 'wcs':
             return WcsMapND(geom, dtype=dtype)
-        elif map_type in ['wcs-sparse', 'WcsMapSparse']:
+        elif map_type == 'wcs-sparse':
             raise NotImplementedError
         else:
-            raise ValueError('Unregnized Map type: {}'.format(map_type))
+            raise ValueError('Unrecognized map type: {}'.format(map_type))
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -31,9 +31,9 @@ class WcsMap(MapBase):
 
         Parameters
         ----------
-        map_type : str
-            Internal map representation.  Valid types are `WcsMapND`/`wcs` and
-            `WcsMapSparse`/`wcs-sparse`.
+        map_type : {'wcs', 'wcs-sparse'}
+            Map type.  Selects the class that will be used to
+            instantiate the map.
         npix : int or tuple or list
             Width of the map in pixels. A tuple will be interpreted as
             parameters for longitude and latitude axes.  For maps with


### PR DESCRIPTION
This PR addresses #1242 by rewriting `MapBase.read` to allow it to work when called from a base class.  Here are the ways the `read` method can be called:
* When called from any of the non-base classes (WcsMapND, HpxMapND, HpxMapSparse) the method will instantiate an object of that class.  This was the existing behavior of this method.
* When called from an abstract base class (MapBase, WcsMap, or HpxMap) it will instantiate a non-sparse map appropriate to the format of the file (WcsMapND if the file is WCS format or HpxMapND for a HPX file).
* When called from an abstract base class with the `map_type` argument it will try to instantiate a map of that type.  If that map type is inconsistent with the file format then an exception is thrown.