### PR TITLE
Rename classes in gammapy.maps

### DIFF
--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -4,9 +4,9 @@ HEALPix-based Maps
 ==================
 
 This page provides examples and documentation specific to the HEALPix
-map classes (`~gammapy.maps.HpxMapND` and
+map classes (`~gammapy.maps.HpxNDMap` and
 `~gammapy.maps.HpxMapSparse`).  All HEALPix classes inherit from
-`~gammapy.maps.MapBase` which provides generic interface methods that can be be
+`~gammapy.maps.Map` which provides generic interface methods that can be be
 used to access or update the contents of a map without reference to
 its pixelization scheme.
 
@@ -21,10 +21,10 @@ an all-sky 2D HEALPix image:
 
 .. code:: python
 
-   from gammapy.maps import HpxGeom, HpxMapND, HpxMap
+   from gammapy.maps import HpxGeom, HpxNDMap, HpxMap
    # Create a HEALPix geometry of NSIDE=16
    geom = HpxGeom(16, coordsys='GAL')
-   m = HpxMapND(geom)
+   m = HpxNDMap(geom)
 
    # Equivalent factory method call
    m = HpxMap.create(nside=16, coordsys='GAL')
@@ -35,12 +35,12 @@ the `~gammapy.maps.HpxMap.create` factory method:
 
 .. code:: python
 
-   from gammapy.maps import HpxGeom, HpxMap, HpxMapND
+   from gammapy.maps import HpxGeom, HpxMap, HpxNDMap
    from astropy.coordinates import SkyCoord
 
    # Create a partial-sky HEALPix geometry of NSIDE=16
    geom = HpxGeom(16, region='DISK(0.0,5.0,10.0)', coordsys='GAL')
-   m = HpxMapND(geom)
+   m = HpxNDMap(geom)
 
    # Equivalent factory method call
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')

--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -5,7 +5,7 @@ HEALPix-based Maps
 
 This page provides examples and documentation specific to the HEALPix
 map classes (`~gammapy.maps.HpxNDMap` and
-`~gammapy.maps.HpxMapSparse`).  All HEALPix classes inherit from
+`~gammapy.maps.HpxSparseMap`).  All HEALPix classes inherit from
 `~gammapy.maps.Map` which provides generic interface methods that can be be
 used to access or update the contents of a map without reference to
 its pixelization scheme.
@@ -47,13 +47,10 @@ the `~gammapy.maps.HpxMap.create` factory method:
    m = HpxMap.create(nside=16, skydir=position, width=20.0)
 
 
-
-
-
 Sparse Maps
 -----------
 
-The `~gammapy.maps.HpxMapSparse` class is a memory-efficient
+The `~gammapy.maps.HpxSparseMap` class is a memory-efficient
 implementation of a HEALPix map that uses a sparse data structure to
 store map values.  Sparse maps can be useful when working with maps
 that have many empty pixels (e.g. a low-statistics counts map).

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -33,11 +33,11 @@ pixelization schemes are supported:
 
 `gammapy.maps` is organized around two data structures:
 *geometry* classes inheriting from `~MapGeom` and *map* classes
-inheriting from `~MapBase`.  A geometry defines the map
+inheriting from `~Map`.  A geometry defines the map
 boundaries, pixelization scheme, and provides methods for converting
 to/from map and pixel coordinates.  A map owns a `~MapGeom`
-instance as well as a data structure containing map values.  Where
-possible it is recommended to use the abstract `~MapBase` interface
+instance as well as a data array containing map values.  Where
+possible it is recommended to use the abstract `~Map` interface
 for accessing or updating the contents of a map as this allows
 algorithms to be used interchangeably with different map
 representations.  The following reviews methods of the abstract
@@ -49,18 +49,18 @@ Getting Started
 ===============
 
 All map objects have an abstract inteface provided through the methods
-of the `~MapBase`.  These methods can be used for accessing and
+of the `~Map`.  These methods can be used for accessing and
 manipulating the contents of a map without reference to the underlying
 data representation (e.g. whether a map uses WCS or HEALPix
 pixelization).  For applications which do depend on the specific
 representation one can also work directly with the classes derived
-from `~MapBase`.  In the following we review some of the basic methods
+from `~Map`.  In the following we review some of the basic methods
 for working with map objects.
 
 Constructing with Factory Methods
 ---------------------------------
 
-The `~MapBase` class provides a `~MapBase.create` factory method to
+The `~Map` class provides a `~Map.create` factory method to
 facilitate creating an empty map object from scratch.  The
 ``map_type`` argument can be used to control the pixelization scheme
 (WCS or HPX) and whether the map internally uses a sparse
@@ -68,15 +68,15 @@ representation of the data.
 
 .. code:: python
 
-   from gammapy.maps import MapBase
+   from gammapy.maps import Map
    from astropy.coordinates import SkyCoord
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
 
    # Create a WCS Map
-   m_wcs = MapBase.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0)
+   m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0)
 
    # Create a HPX Map
-   m_hpx = MapBase.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0)
+   m_hpx = Map.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0)
 
 Higher dimensional map objects (cubes and hypercubes) can be
 constructed by passing a list of `~MapAxis` objects for non-spatial
@@ -84,17 +84,17 @@ dimensions with the ``axes`` parameter:
 
 .. code:: python
 
-   from gammapy.maps import MapBase, MapAxis
+   from gammapy.maps import Map, MapAxis
    from astropy.coordinates import SkyCoord
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
 
    # Create a WCS Map
-   m_wcs = MapBase.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0,
+   m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0,
                           axes=[energy_axis])
 
    # Create a HPX Map
-   m_hpx = MapBase.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0,
+   m_hpx = Map.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0,
                           axes=[energy_axis])
 
 Multi-resolution maps (maps with a different pixel size or geometry in
@@ -107,7 +107,7 @@ Fermi-LAT PSF:
 .. code:: python
 
    import numpy as np
-   from gammapy.maps import MapBase, MapAxis
+   from gammapy.maps import Map, MapAxis
    from astropy.coordinates import SkyCoord
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
@@ -115,33 +115,33 @@ Fermi-LAT PSF:
    binsz = np.sqrt((3.0*(energy_axis.center/100.)**-0.8)**2 + 0.1**2)
 
    # Create a WCS Map
-   m_wcs = MapBase.create(binsz=binsz, map_type='wcs', skydir=position, width=10.0,
+   m_wcs = Map.create(binsz=binsz, map_type='wcs', skydir=position, width=10.0,
                           axes=[energy_axis])
 
    # Create a HPX Map
-   m_hpx = MapBase.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
+   m_hpx = Map.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
                           axes=[energy_axis])
 
 Get, Set, and Fill Methods
 --------------------------
 
 All map objects have a set of accessor methods provided through the
-abstract `~MapBase` class.  These methods can be used to access or
+abstract `~Map` class.  These methods can be used to access or
 update the contents of the map irrespective of its underlying
 representation.  Three types of accessor methods are provided:
 
 * ``get`` : Return the value of the map at the pixel containing the
-  given coordinate (`~MapBase.get_by_idx`, `~MapBase.get_by_pix`,
-  `~MapBase.get_by_coords`).  With the ``interp`` argument,
-  `~MapBase.get_by_pix` and `~MapBase.get_by_coords` also support
+  given coordinate (`~Map.get_by_idx`, `~Map.get_by_pix`,
+  `~Map.get_by_coords`).  With the ``interp`` argument,
+  `~Map.get_by_pix` and `~Map.get_by_coords` also support
   interpolation of map values between pixels (see `Interpolation`_).
 * ``set`` : Set the value of the map at the pixel containing the
-  given coordinate (`~MapBase.set_by_idx`, `~MapBase.set_by_pix`,
-  `~MapBase.set_by_coords`).
+  given coordinate (`~Map.set_by_idx`, `~Map.set_by_pix`,
+  `~Map.set_by_coords`).
 * ``fill`` : Increment the value of the map at the pixel containing
   the given coordinate with a unit weight or the value in the optional
-  ``weights`` argument (`~MapBase.fill_by_idx`,
-  `~MapBase.fill_by_pix`, `~MapBase.fill_by_coords`).
+  ``weights`` argument (`~Map.fill_by_idx`,
+  `~Map.fill_by_pix`, `~Map.fill_by_coords`).
 
 All accessor methods accept as their first argument a
 coordinate tuple containing scalars, lists, or numpy arrays with one
@@ -163,14 +163,14 @@ coordinates can be expressed in one of three coordinate systems:
 
 The coordinate system accepted by a given accessor method can be
 inferred from the suffix of the method name
-(e.g. `~MapBase.get_by_idx`).  The following demonstrates how one can
+(e.g. `~Map.get_by_idx`).  The following demonstrates how one can
 access the same pixels of a WCS map using each of the three coordinate
 systems:
 
 .. code:: python
 
-   from gammapy.maps import MapBase
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
    vals = m.get_by_idx( ([49,50],[49,50]) )
    vals = m.get_by_pix( ([49.0,50.0],[49.0,50.0]) )
@@ -186,8 +186,8 @@ given operation across a grid of coordinate values.
 
 .. code:: python
 
-   from gammapy.maps import MapBase
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    coords = np.linspace(-4.0,4.0,9)
 
    # Equivalent calls for accessing value at pixel (49,49)
@@ -207,8 +207,8 @@ The following demonstrates how one can set pixel values:
 
 .. code:: python
 
-   from gammapy.maps import MapBase
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
    m.set_by_coords( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
    m.fill_by_coords( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
@@ -216,8 +216,8 @@ The following demonstrates how one can set pixel values:
 Interpolation
 -------------
 
-Maps support interpolation via the `~MapBase.get_by_coords` and
-`~MapBase.get_by_pix` methods.  Currently the following interpolation
+Maps support interpolation via the `~Map.get_by_coords` and
+`~Map.get_by_pix` methods.  Currently the following interpolation
 methods are supported:
 
 * ``nearest`` : Return value of nearest pixel (no interpolation).
@@ -234,8 +234,8 @@ maps.
 
 .. code:: python
 
-   from gammapy.maps import MapBase
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
    m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
    m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
@@ -244,7 +244,7 @@ maps.
 Projection
 ----------
 
-The `~MapBase.reproject` method can be used to project a map onto a
+The `~Map.reproject` method can be used to project a map onto a
 different geometry.  This can be used to convert between different WCS
 projections, extract a cut-out of a map, or to convert between WCS and
 HPX map types.  If the projection geometry lacks non-spatial
@@ -253,8 +253,8 @@ over to the projected map.
 
 .. code:: python
 
-   from gammapy.maps import WcsMapND, HpxGeom
-   m = WcsMapND.read('gll_iem_v06.fits')
+   from gammapy.maps import WcsNDMap, HpxGeom
+   m = WcsNDMap.read('gll_iem_v06.fits')
    geom = HpxGeom.create(nside=8, coordsys='GAL')
    # Convert LAT standard IEM to HPX (nside=8)
    m_proj = m.project(geom)
@@ -268,7 +268,7 @@ Iterating on a Map
 ------------------
 
 Iterating over a map can be performed with the
-`~MapBase.iter_by_coords` and `~MapBase.iter_by_pix` methods.  These
+`~Map.iter_by_coords` and `~Map.iter_by_pix` methods.  These
 return an iterator that traverses the map returning (value,
 coordinate) pairs with map and pixel coordinates, respectively.  The
 optional ``buffersize`` argument can be used to split the iteration
@@ -279,23 +279,23 @@ one can use this method to fill a map with a 2D Gaussian:
 
    import numpy as np
    from astropy.coordinates import SkyCoord
-   from gammapy.maps import MapBase
-   m = MapBase.create(binsz=0.05, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
    for val, coords in m.iter_by_coords(buffersize=10000):
        skydir = SkyCoord(coords[0],coords[1], unit='deg')
        sep = skydir.separation(m.geom.center_skydir).deg
        new_val = np.exp(-sep**2/2.0)
        m.set_by_coords(coords, new_val)
 
-For maps with non-spatial dimensions the `~MapBase.iter_by_image`
+For maps with non-spatial dimensions the `~Map.iter_by_image`
 method can be used to loop over image slices:
 
 .. code:: python
 
    from astropy.coordinates import SkyCoord
    from astropy.convolution import Gaussian2DKernel, convolve
-   from gammapy.maps import MapBase
-   m = MapBase.create(binsz=0.05, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
    for img, idx in m.iter_by_image():
        img = convolve(img, Gaussian2DKernel(stddev=2.0) )
 
@@ -304,36 +304,40 @@ FITS I/O
 --------
 
 Maps can be written to and read from a FITS file with the
-`~MapBase.write` and ``read`` methods:
+`~Map.write` and `~Map.read` methods:
 
 .. code:: python
 
-   from gammapy.maps import MapBase, WcsMapND
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', extname='IMAGE')
-   m = WcsMapND.read('file.fits', hdu='IMAGE')
+   m = Map.read('file.fits', hdu='IMAGE')
 
+If ``map_type`` argument is not given when calling `~Map.read` a
+non-sparse map object will be instantiated with the pixelization of
+the input HDU.
+   
 Maps can be serialized to a sparse data format by calling
-`~MapBase.write` with ``sparse=True``.  This will write all non-zero
+`~Map.write` with ``sparse=True``.  This will write all non-zero
 pixels in the map to a data table appropriate to the pixelization
 scheme.
 
 .. code:: python
 
-   from gammapy.maps import MapBase, WcsMapND
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', extname='IMAGE', sparse=True)
-   m = WcsMapND.read('file.fits', hdu='IMAGE')
+   m = Map.read('file.fits', hdu='IMAGE', map_type='wcs')
 
 Sparse maps have the same ``read`` and ``write`` methods with the
 exception that they will be written to a sparse format by default:
 
 .. code:: python
 
-   from gammapy.maps import MapBase, HpxMapSparse
-   m = MapBase.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
+   from gammapy.maps import Map
+   m = Map.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
    m.write('file.fits', extname='IMAGE')
-   m = HpxMapSparse.read('file.fits', hdu='IMAGE')
+   m = Map.read('file.fits', hdu='IMAGE', map_type='hpx-sparse')
 
 By default files will be written to the *gamma-astro-data-format*
 specification for sky maps (see `here
@@ -347,9 +351,9 @@ the GADF format:
 
 .. code:: python
 
-   from gammapy.maps import MapBase, MapAxis
+   from gammapy.maps import Map, MapAxis
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0,
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
                       axes=[energy_axis])
    # Write a counts cube in a format compatible with the Fermi Science Tools
    m.write('ccube.fits', conv='fgst-ccube')
@@ -357,16 +361,16 @@ the GADF format:
 Visualization
 -------------
 
-All map objects provide a `~MapBase.plot` method for generating a
+All map objects provide a `~Map.plot` method for generating a
 visualization of a map.  This method returns figure, axes, and image
 objects that can be used to further tweak/customize the image.
 
 .. code:: python
 
    import matplotlib.pyplot as plt
-   from gammapy.maps import MapBase
+   from gammapy.maps import Map
    from gammapy.maps.utils import fill_poisson
-   m = MapBase.create(binsz=0.1, map_type='wcs', width=10.0)
+   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    fill_poisson(m, mu=1.0, random_state=0)
    fig, ax, im = m.plot(cmap='magma')
    plt.colorbar(im)
@@ -383,11 +387,11 @@ This example shows how to fill a counts cube from an FT1 file:
 .. code:: python
 
    from astropy.io import fits
-   from gammapy.maps import WcsGeom, WcsMapND, MapAxis
+   from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
 
    h = fits.open('ft1.fits')
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
-   m = WcsMapND.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
+   m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
                        coordsys='CEL', axes=[energy_axis])
    m.fill_by_coords((h['EVENTS'].data.field('RA'),
                      h['EVENTS'].data.field('DEC'),
@@ -398,12 +402,12 @@ Generating a Cutout of a Model Cube
 -----------------------------------
 
 This example shows how to extract a cut-out of LAT galactic
-diffuse model cube using the `~MapBase.reproject` method:
+diffuse model cube using the `~Map.reproject` method:
 
 .. code:: python
 
-   from gammapy.maps import WcsGeom, WcsMapND
-   m = WcsMapND.read('gll_iem_v06.fits')
+   from gammapy.maps import WcsGeom, WcsNDMap
+   m = WcsNDMap.read('gll_iem_v06.fits')
    geom = WcsGeom(binsz=0.125, skydir=(45.0,30.0), coordsys='GAL', proj='AIT')
    m_proj = m.reproject(geom)
    m_proj.write('cutout.fits', conv='fgst-template')
@@ -430,5 +434,4 @@ Reference/API
 =============
 
 .. automodapi:: gammapy.maps
-    :no-inheritance-diagram:
     :include-all-objects:

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -881,7 +881,7 @@ class SkyCube(MapBase):
         assert_allclose(cube1.energies(), cube2.energies())
         assert_wcs_allclose(cube1.wcs, cube2.wcs)
 
-    def to_wcs_map_nd(self, energy_axis_mode='center'):
+    def to_wcs_nd_map(self, energy_axis_mode='center'):
         """Convert to a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.
@@ -914,7 +914,7 @@ class SkyCube(MapBase):
         return WcsNDMap(geom=geom, data=data)
 
     @classmethod
-    def from_wcs_map_nd(cls, wcs_map_nd):
+    def from_wcs_nd_map(cls, wcs_map_nd):
         """Create from a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -882,14 +882,14 @@ class SkyCube(MapBase):
         assert_wcs_allclose(cube1.wcs, cube2.wcs)
 
     def to_wcs_map_nd(self, energy_axis_mode='center'):
-        """Convert to a `gammapy.maps.WcsMapND`.
+        """Convert to a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.
 
         This is meant to help migrate code using `SkyCube`
         over to the new maps classes.
         """
-        from gammapy.maps import WcsMapND, WcsGeom, MapAxis
+        from gammapy.maps import WcsNDMap, WcsGeom, MapAxis
 
         if energy_axis_mode == 'center':
             energy = self.energies(mode='center')
@@ -911,11 +911,11 @@ class SkyCube(MapBase):
         data = np.asarray(self.data)
         # unit = getattr(self.data, 'unit', None)
 
-        return WcsMapND(geom=geom, data=data)
+        return WcsNDMap(geom=geom, data=data)
 
     @classmethod
     def from_wcs_map_nd(cls, wcs_map_nd):
-        """Create from a `gammapy.maps.WcsMapND`.
+        """Create from a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.
 

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -256,6 +256,6 @@ def test_conversion_wcs_map_nd():
     # TODO: add unit back once it's properly supported
     cube.data = cube.data.value
 
-    map = cube.to_wcs_map_nd()
-    cube2 = SkyCube.from_wcs_map_nd(map)
+    map = cube.to_wcs_nd_map()
+    cube2 = SkyCube.from_wcs_nd_map(map)
     SkyCube.assert_allclose(cube, cube2)

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -12,7 +12,7 @@ from astropy.utils import lazyproperty
 from .core import gammapy_extra
 from ..data import EventList
 from ..cube import SkyCube
-from ..maps import HpxMapND
+from ..maps import HpxNDMap
 from ..irf import EnergyDependentTablePSF
 from ..utils.scripts import make_path
 from ..spectrum.models import TableModel
@@ -280,7 +280,7 @@ class FermiLATDataset(object):
 
         Returns
         -------
-        cube : `~gammapy.cube.SkyCube` or `~gammapy.maps.HpxMapND`
+        cube : `~gammapy.cube.SkyCube` or `~gammapy.maps.HpxNDMap`
             Exposure cube.
         """
         filename = self.filenames['exposure']
@@ -289,7 +289,7 @@ class FermiLATDataset(object):
                 warnings.simplefilter("ignore")
                 cube = SkyCube.read(filename, format='fermi-exposure')
         except (ValueError, KeyError):
-            cube = HpxMapND.read(filename)
+            cube = HpxNDMap.read(filename)
 
         return cube
 
@@ -299,7 +299,7 @@ class FermiLATDataset(object):
 
         Returns
         -------
-        cube : `~gammapy.cube.SkyCube` or `~gammapy.maps.HpxMapND`
+        cube : `~gammapy.cube.SkyCube` or `~gammapy.maps.HpxNDMap`
             Counts cube
         """
         try:
@@ -310,7 +310,7 @@ class FermiLATDataset(object):
         try:
             cube = SkyCube.read(filename, format='fermi-counts')
         except (ValueError, KeyError):
-            cube = HpxMapND.read(filename)
+            cube = HpxNDMap.read(filename)
 
         return cube
 

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -608,7 +608,7 @@ def reproject_exposure(exposure, ref_cube):
     exposure_cube = SkyCube.empty_like(ref_cube)
 
     ref_image = ref_cube.sky_image_ref
-    geom = ref_image.to_wcs_map_nd().geom
+    geom = ref_image.to_wcs_nd_map().geom
     coords = geom.get_coords()
     for idx, energy in enumerate(ref_cube.energies().value):
         coords_hpx = coords[0], coords[1], energy

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -588,13 +588,13 @@ class FermiLATBasicImageEstimator(BasicImageEstimator):
 def reproject_exposure(exposure, ref_cube):
     """Helper function to reproject exposure to a reference cube.
 
-    TODO: this is a temp solution, as long as we use HpxMapND objects for exposure
+    TODO: this is a temp solution, as long as we use HpxNDMap objects for exposure
     and SkyCube objects otherwise. This should be changed to use WCSMapND
     instead of SkyCube in the future.
 
     Parameters
     ----------
-    exposure : `~gammapy.maps.HpxMapND`
+    exposure : `~gammapy.maps.HpxNDMap`
         Exposure cube from gtexmpcube2
     ref_cube : `~gammapy.cube.SkyCube`
         Reference cube to reproject to

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -143,9 +143,9 @@ class SkyImage(MapBase):
         filename : str
             Name of the FITS file.
         *args : list
-            Arguments passed to `~astropy.fits.ImageHDU.writeto`.
+            Arguments passed to `~astropy.io.fits.ImageHDU.writeto`.
         **kwargs : dict
-            Keyword arguments passed to `~astropy.fits.ImageHDU.writeto`.
+            Keyword arguments passed to `~astropy.io.fits.ImageHDU.writeto`.
         """
         filename = str(make_path(filename))
         hdu = self.to_image_hdu()

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1322,25 +1322,25 @@ class SkyImage(MapBase):
         return SkyImage(data=distance, wcs=self.wcs)
 
     def to_wcs_map_nd(self):
-        """Convert to a `gammapy.maps.WcsMapND`.
+        """Convert to a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.
 
         This is meant to help migrate code using `SkyImage`
         over to the new maps classes.
         """
-        from gammapy.maps import WcsMapND, WcsGeom
+        from gammapy.maps import WcsNDMap, WcsGeom
 
         # Axis order in SkyImage: lat, lon
         npix = (self.data.shape[1], self.data.shape[0])
 
         geom = WcsGeom(wcs=self.wcs, npix=npix)
 
-        return WcsMapND(geom=geom, data=self.data)
+        return WcsNDMap(geom=geom, data=self.data)
 
     @classmethod
     def from_wcs_map_nd(cls, wcs_map_nd):
-        """Create from a `gammapy.maps.WcsMapND`.
+        """Create from a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.
 

--- a/gammapy/image/core.py
+++ b/gammapy/image/core.py
@@ -1321,7 +1321,7 @@ class SkyImage(MapBase):
 
         return SkyImage(data=distance, wcs=self.wcs)
 
-    def to_wcs_map_nd(self):
+    def to_wcs_nd_map(self):
         """Convert to a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.
@@ -1339,7 +1339,7 @@ class SkyImage(MapBase):
         return WcsNDMap(geom=geom, data=self.data)
 
     @classmethod
-    def from_wcs_map_nd(cls, wcs_map_nd):
+    def from_wcs_nd_map(cls, wcs_map_nd):
         """Create from a `gammapy.maps.WcsNDMap`.
 
         There is no copy of the ``data`` or ``wcs`` object, this conversion is cheap.

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -471,8 +471,8 @@ def test_conversion_wcs_map_nd():
     """Check conversion SkyCube <-> WCSMapNd"""
     image = SkyImage.empty(nxpix=3, nypix=2, unit='cm', name='axel')
 
-    map = image.to_wcs_map_nd()
-    image2 = SkyImage.from_wcs_map_nd(map)
+    map = image.to_wcs_nd_map()
+    image2 = SkyImage.from_wcs_nd_map(map)
 
     # Note: WCSMapNd doesn't store name or unit at the moment
     SkyImage.assert_allclose(image, image2, check_name=False, check_unit=False)

--- a/gammapy/maps/_sparse.pyx
+++ b/gammapy/maps/_sparse.pyx
@@ -57,9 +57,9 @@ def find_in_array(np.ndarray[int_t, ndim=1] idx0,
 
     Parameters
     ----------
-    idx0 : `~np.ndarray`
+    idx0 : `~numpy.ndarray`
         Array of unsorted input values.
-    idx1 : `~np.ndarray`
+    idx1 : `~numpy.ndarray`
         Array of sorted values to be searched. 
 
     Returns

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -5,7 +5,6 @@ import numpy as np
 from ..extern import six
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
-from .utils import find_hdu
 from .geom import pix_tuple_to_idx, MapCoords
 
 __all__ = [
@@ -85,7 +84,6 @@ class Map(object):
         -------
         map : `~Map`
             Empty map object.
-
         """
         from .hpxmap import HpxMap
         from .wcsmap import WcsMap
@@ -124,7 +122,6 @@ class Map(object):
         -------
         map_out : `~Map`
             Map object
-
         """
         with fits.open(filename) as hdulist:
             if map_type == 'auto':
@@ -216,7 +213,7 @@ class Map(object):
 
         Returns
         -------
-        val : `~np.ndarray`
+        val : `~numpy.ndarray`
             Array of image plane values.
         idx : tuple
             Index of image plane.

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -9,7 +9,7 @@ from .utils import find_hdu
 from .geom import pix_tuple_to_idx, MapCoords
 
 __all__ = [
-    'MapBase',
+    'Map',
 ]
 
 
@@ -18,7 +18,7 @@ class MapMeta(InheritDocstrings, abc.ABCMeta):
 
 
 @six.add_metaclass(MapMeta)
-class MapBase(object):
+class Map(object):
     """Abstract map class.
 
     This can represent WCS- or HEALPIX-based maps
@@ -83,7 +83,7 @@ class MapBase(object):
 
         Returns
         -------
-        map : `~MapBase`
+        map : `~Map`
             Empty map object.
 
         """
@@ -122,7 +122,7 @@ class MapBase(object):
 
         Returns
         -------
-        map_out : `~MapBase`
+        map_out : `~Map`
             Map object
 
         """
@@ -165,16 +165,16 @@ class MapBase(object):
         but that's non-trivial to implement without avoiding circular imports.
         """
         if map_type == 'wcs':
-            from .wcsnd import WcsMapND
-            return WcsMapND
+            from .wcsnd import WcsNDMap
+            return WcsNDMap
         elif map_type == 'wcs-sparse':
             raise NotImplementedError()
         elif map_type == 'hpx':
-            from .hpxnd import HpxMapND
-            return HpxMapND
+            from .hpxnd import HpxNDMap
+            return HpxNDMap
         elif map_type == 'hpx-sparse':
-            from .hpxsparse import HpxMapSparse
-            return HpxMapSparse
+            from .hpxsparse import HpxSparseMap
+            return HpxSparseMap
         else:
             raise ValueError('Unrecognized map type: {!r}'.format(map_type))
 
@@ -284,7 +284,7 @@ class MapBase(object):
 
         Returns
         -------
-        map : `~MapBase`
+        map : `~Map`
             Reprojected map.
         """
         if geom.ndim == 2 and self.geom.ndim > 2:
@@ -310,7 +310,7 @@ class MapBase(object):
 
         Returns
         -------
-        map : `~MapBase`
+        map : `~Map`
             Padded map.
         """
         pass
@@ -327,7 +327,7 @@ class MapBase(object):
 
         Returns
         -------
-        map : `~MapBase`
+        map : `~Map`
             Cropped map.
         """
         pass
@@ -343,7 +343,7 @@ class MapBase(object):
 
         Returns
         -------
-        map : `~MapBase`
+        map : `~Map`
             Downsampled map.
         """
         pass
@@ -359,7 +359,7 @@ class MapBase(object):
 
         Returns
         -------
-        map : `~MapBase`
+        map : `~Map`
             Upsampled map.
         """
         pass

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -48,7 +48,6 @@ def make_axes_cols(axes, axis_names=None):
     axis_names : list of str
 
     """
-
     colname = {
         'energy': ['ENERGY', 'E_MIN', 'E_MAX'],
         'time': ['TIME', 'T_MIN', 'T_MAX'],
@@ -167,8 +166,9 @@ def skydir_to_lonlat(skydir, coordsys=None):
 
 def pix_tuple_to_idx(pix, copy=False):
     """Convert a tuple of pixel coordinate arrays to a tuple of pixel
-    indices.  Pixel coordinates are rounded to the closest integer
-    value.
+    indices.
+
+    Pixel coordinates are rounded to the closest integer value.
 
     Parameters
     ----------
@@ -189,7 +189,6 @@ def pix_tuple_to_idx(pix, copy=False):
         if np.issubdtype(p.dtype, np.integer):
             idx += [p]
         else:
-            #idx += [np.rint(p).astype(int)]
             p_idx = np.rint(p).astype(int)
             p_idx[~np.isfinite(p)] = -1
             idx += [p_idx]
@@ -400,8 +399,9 @@ class MapAxis(object):
 
     @classmethod
     def from_bounds(cls, lo_bnd, hi_bnd, nbin, **kwargs):
-        """Generate an axis object from a lower/upper bound and number of
-        bins.  If node_type = 'edge' then bounds correspond to the
+        """Generate an axis object from a lower/upper bound and number of bins.
+
+        If node_type = 'edge' then bounds correspond to the
         lower and upper bound of the first and last bin.  If node_type
         = 'center' then bounds correspond to the centers of the first
         and last bin.
@@ -544,7 +544,6 @@ class MapAxis(object):
         coord : `~numpy.ndarray`
             Array of axis coordinate values.
         """
-
         return (coord_to_idx(self.center[:-1], coord, clip=True),
                 coord_to_idx(self.center[:-1], coord, clip=True) + 1,)
 
@@ -804,7 +803,6 @@ class MapGeom(object):
         coords : tuple
             Tuple of coordinate vectors with one vector for each
             dimension.
-
         """
         pass
 
@@ -850,7 +848,6 @@ class MapGeom(object):
             Tuple of pixel indices in image and band dimensions.
             Elements set to -1 correspond to coordinates outside the
             map.
-
         """
         pix = self.coord_to_pix(coords)
         return self.pix_to_idx(pix, clip=clip)
@@ -903,7 +900,7 @@ class MapGeom(object):
 
         Returns
         -------
-        containment : `~np.ndarray`
+        containment : `~numpy.ndarray`
             Bool array.
         """
         pass
@@ -913,12 +910,12 @@ class MapGeom(object):
 
         Parameters
         ----------
-        coords : tuple
+        pix : tuple
             Tuple of pixel coordinates.
 
         Returns
         -------
-        containment : `~np.ndarray`
+        containment : `~numpy.ndarray`
             Bool array.
         """
         idx = self.pix_to_idx(pix)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1518,10 +1518,10 @@ class HpxToWcsMapping(object):
     def write(self, fitsfile, clobber=True):
         """Write this mapping to a FITS file, to avoid having to recompute it
         """
-        from .wcsnd import WcsMapND
+        from .wcsnd import WcsNDMap
         hpx_header = self._hpx.make_header()
-        index_map = WcsMapND(self.ipix, self.wcs)
-        mult_map = WcsMapND(self.mult_val, self.wcs)
+        index_map = WcsNDMap(self.ipix, self.wcs)
+        mult_map = WcsNDMap(self.mult_val, self.wcs)
 
         # TODO: Figure out where to write HPX header information
 
@@ -1544,9 +1544,9 @@ class HpxToWcsMapping(object):
     @classmethod
     def read(cls, filename):
         """Read a FITS file and use it to make a mapping."""
-        from .wcsnd import WcsMapND
-        index_map = WcsMapND.read(filename)
-        mult_map = WcsMapND.read(filename, hdu=1)
+        from .wcsnd import WcsNDMap
+        index_map = WcsNDMap.read(filename)
+        mult_map = WcsNDMap.read(filename, hdu=1)
         with fits.open(filename) as ff:
             hpx = HpxGeom.from_header(ff[0])
             ipix = index_map.data

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -8,10 +8,9 @@ import numpy as np
 from ..extern import six
 from ..extern.six.moves import range
 from astropy.io import fits
-from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
 from .wcs import WcsGeom
-from .geom import MapGeom, MapCoords, MapAxis, bin_to_val, pix_tuple_to_idx
+from .geom import MapGeom, MapCoords, pix_tuple_to_idx
 from .geom import coordsys_to_frame, skydir_to_lonlat, make_axes_cols
 from .geom import find_and_read_bands, make_axes
 
@@ -836,13 +835,13 @@ class HpxGeom(MapGeom):
         return self.get_idx()
 
     def ud_graded_hpx(self, order):
-        """Upgrade or downgroad the resolution of this geometry to the given
+        """Upgrade or downgrade the resolution of this geometry to the given
         order.
 
         Returns
         -------
         geom : `~HpxGeom`
-            A HEALPix geoemtry object.
+            A HEALPix geometry object.
         """
         if np.any(self.order < 0):
             raise ValueError(
@@ -860,7 +859,7 @@ class HpxGeom(MapGeom):
         Returns
         -------
         geom : `~HpxGeom`
-            A HEALPix geoemtry object.
+            A HEALPix geometry object.
         """
         # FIXME: Pass ipix as argument
 
@@ -916,16 +915,13 @@ class HpxGeom(MapGeom):
 
         Examples
         --------
-        >>> from gammapy.maps import HpxGeom
-        >>> from gammapy.maps import MapAxis
+        >>> from gammapy.maps import HpxGeom, MapAxis
         >>> axis = MapAxis.from_bounds(0,1,2)
         >>> geom = HpxGeom.create(nside=16)
         >>> geom = HpxGeom.create(binsz=0.1, width=10.0)
         >>> geom = HpxGeom.create(nside=64, width=10.0, axes=[axis])
         >>> geom = HpxGeom.create(nside=[32,64], width=10.0, axes=[axis])
-
         """
-
         if nside is None and binsz is None:
             raise ValueError('Either nside or binsz must be defined.')
 
@@ -998,7 +994,7 @@ class HpxGeom(MapGeom):
         ----------
         header : `~astropy.io.fits.Header`
             The FITS header
-        hdu_bands : `~astropy.fits.BinTableHDU` 
+        hdu_bands : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU.
         pix : tuple
             List of pixel index vectors defining the pixels
@@ -1314,7 +1310,6 @@ class HpxGeom(MapGeom):
         wcs : `~gammapy.maps.WcsGeom`
             WCS geometry
         """
-
         skydir = self.get_ref_dir(self._region, self.coordsys)
         binsz = np.min(get_pix_size_from_nside(self.nside)) / oversample
         width = (2.0 * self.get_region_size(self._region) +
@@ -1334,7 +1329,6 @@ class HpxGeom(MapGeom):
         return geom
 
     def get_idx(self, idx=None, local=False, flat=False):
-
         if idx is not None and np.any(np.array(idx) >= np.array(self._shape)):
             raise ValueError('Image index out of range: {}'.format(idx))
 
@@ -1430,7 +1424,6 @@ class HpxGeom(MapGeom):
         return self.pix_to_coord(pix)
 
     def contains(self, coords):
-
         idx = self.coord_to_idx(coords)
         return np.all(np.stack([t != -1 for t in idx]), axis=0)
 
@@ -1442,7 +1435,6 @@ class HpxGeom(MapGeom):
 
     def skydir_to_pix(self, skydir):
         """Return the pixel index of a SkyCoord object."""
-
         # FIXME: What should this method do for maps with non-spatial
         # dimensions
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -4,7 +4,7 @@ import abc
 import re
 import numpy as np
 from astropy.io import fits
-from .base import MapBase
+from .base import Map
 from .hpx import HpxGeom, HpxConv
 from .geom import MapAxis, find_and_read_bands
 from .utils import find_bintable_hdu, find_bands_hdu
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-class HpxMap(MapBase):
+class HpxMap(Map):
     """Base class for HEALPIX map classes.
 
     Parameters
@@ -65,20 +65,20 @@ class HpxMap(MapBase):
             FITS format convention ('fgst-ccube', 'fgst-template',
             'gadf').  Default is 'gadf'.
         """
-        from .hpxnd import HpxMapND
-        from .hpxsparse import HpxMapSparse
+        from .hpxnd import HpxNDMap
+        from .hpxsparse import HpxSparseMap
 
         hpx = HpxGeom.create(nside=nside, binsz=binsz,
                              nest=nest, coordsys=coordsys, region=region,
                              conv=conv, axes=axes, skydir=skydir, width=width)
-        if cls.__name__ == 'HpxMapND':
-            return HpxMapND(hpx, dtype=dtype)
-        elif cls.__name__ == 'HpxMapSparse':
-            return HpxMapSparse(hpx, dtype=dtype)
+        if cls.__name__ == 'HpxNDMap':
+            return HpxNDMap(hpx, dtype=dtype)
+        elif cls.__name__ == 'HpxSparseMap':
+            return HpxSparseMap(hpx, dtype=dtype)
         elif map_type == 'hpx':
-            return HpxMapND(hpx, dtype=dtype)
+            return HpxNDMap(hpx, dtype=dtype)
         elif map_type == 'hpx-sparse':
-            return HpxMapSparse(hpx, dtype=dtype)
+            return HpxSparseMap(hpx, dtype=dtype)
         else:
             raise ValueError('Unrecognized map type: {}'.format(map_type))
 
@@ -184,10 +184,10 @@ class HpxMap(MapBase):
             Set INDXSCHM to SPARSE and sparsify the map by only
             writing pixels with non-zero amplitude.
         """
-        # FIXME: Should this be a method of HpxMapND?
+        # FIXME: Should this be a method of HpxNDMap?
         # FIXME: Should we assign extname in this method?
 
-        from .hpxsparse import HpxMapSparse
+        from .hpxsparse import HpxSparseMap
 
         conv = kwargs.get('conv', HpxConv.create('gadf'))
 
@@ -196,7 +196,7 @@ class HpxMap(MapBase):
         extname = kwargs.get('extname', conv.extname)
         extname_bands = kwargs.get('extname_bands', conv.bands_hdu)
 
-        sparse = kwargs.get('sparse', True if isinstance(self, HpxMapSparse)
+        sparse = kwargs.get('sparse', True if isinstance(self, HpxSparseMap)
                             else False)
         header = self.geom.make_header()
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
-import re
 import numpy as np
 from astropy.io import fits
 from .base import Map
 from .hpx import HpxGeom, HpxConv
-from .geom import MapAxis, find_and_read_bands
 from .utils import find_bintable_hdu, find_bands_hdu
 
 __all__ = [
@@ -116,7 +114,6 @@ class HpxMap(Map):
         return cls.from_hdu(hdu, hdu_bands)
 
     def to_hdulist(self, **kwargs):
-
         extname = kwargs.get('extname', 'SKYMAP')
         # extname_bands = kwargs.get('extname_bands', self.geom.conv.bands_hdu)
         extname_bands = kwargs.get('extname_bands', 'BANDS')

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -8,11 +8,11 @@ from .hpxmap import HpxMap
 from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order
 
 __all__ = [
-    'HpxMapND',
+    'HpxNDMap',
 ]
 
 
-class HpxMapND(HpxMap):
+class HpxNDMap(HpxMap):
     """Representation of a N+2D map using HEALPix with two spatial
     dimensions and N non-spatial dimensions.
 
@@ -46,13 +46,13 @@ class HpxMapND(HpxMap):
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
 
-        super(HpxMapND, self).__init__(geom, data)
+        super(HpxNDMap, self).__init__(geom, data)
         self._wcs2d = None
         self._hpx2wcs = None
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):
-        """Make a HpxMapND object from a FITS HDU.
+        """Make a HpxNDMap object from a FITS HDU.
 
         Parameters
         ----------
@@ -125,7 +125,7 @@ class HpxMapND(HpxMap):
 
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
 
-        from .wcsnd import WcsMapND
+        from .wcsnd import WcsNDMap
 
         if sum_bands and self.geom.nside.size > 1:
             map_sum = self.sum_over_axes()
@@ -158,7 +158,7 @@ class HpxMapND(HpxMap):
         # FIXME: Should reimplement instantiating map first and fill data array
 
         self._hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize)
-        return WcsMapND(wcs, wcs_data)
+        return WcsNDMap(wcs, wcs_data)
 
     def get_pixel_skydirs(self):
         """Get a list of sky coordinates for the centers of every pixel. """
@@ -187,7 +187,7 @@ class HpxMapND(HpxMap):
 
         Returns
         -------
-        map_out : `~HpxMapND`
+        map_out : `~HpxNDMap`
             Summed map.
         """
 
@@ -207,9 +207,9 @@ class HpxMapND(HpxMap):
     def _reproject_wcs(self, geom, order=1, mode='interp'):
 
         from reproject import reproject_from_healpix
-        from .wcsnd import WcsMapND
+        from .wcsnd import WcsNDMap
 
-        map_out = WcsMapND(geom)
+        map_out = WcsNDMap(geom)
         coordsys = 'galactic' if geom.coordsys == 'GAL' else 'icrs'
         axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
                           zip(geom.axes, self.geom.axes)])
@@ -234,7 +234,7 @@ class HpxMapND(HpxMap):
 
     def _reproject_hpx(self, geom, order=1, mode='interp'):
 
-        map_out = HpxMapND(geom)
+        map_out = HpxNDMap(geom)
         axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
                           zip(geom.axes, self.geom.axes)])
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -56,9 +56,9 @@ class HpxNDMap(HpxMap):
 
         Parameters
         ----------
-        hdu : `~astropy.fits.BinTableHDU`
+        hdu : `~astropy.io.fits.BinTableHDU`
             The FITS HDU
-        hdu_bands  : `~astropy.fits.BinTableHDU`
+        hdu_bands  : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU
         """
         hpx = HpxGeom.from_header(hdu.header, hdu_bands)
@@ -190,7 +190,6 @@ class HpxNDMap(HpxMap):
         map_out : `~HpxNDMap`
             Summed map.
         """
-
         hpx_out = self.geom.to_image()
         map_out = self.__class__(hpx_out)
 
@@ -233,7 +232,6 @@ class HpxNDMap(HpxMap):
         return map_out
 
     def _reproject_hpx(self, geom, order=1, mode='interp'):
-
         map_out = HpxNDMap(geom)
         axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
                           zip(geom.axes, self.geom.axes)])
@@ -256,7 +254,6 @@ class HpxNDMap(HpxMap):
         raise NotImplementedError
 
     def interp_by_coords(self, coords, interp=None):
-
         if interp == 'linear':
             return self._interp_by_coords(coords, interp)
         else:
@@ -309,8 +306,6 @@ class HpxNDMap(HpxMap):
 
     def _interp_by_coords(self, coords, interp):
         """Linearly interpolate map values."""
-        import healpy as hp
-
         c = MapCoords.create(coords)
         idx_ax = self.geom.coord_to_idx(c, clip=True)[1:]
         pix, wts = self._get_interp_weights(coords, idx_ax)
@@ -330,7 +325,7 @@ class HpxNDMap(HpxMap):
                                    c[2 + j], clip=True)  # [None, ...]
 
                 w = ax.center[idx + 1] - ax.center[idx]
-                if (i & (1 << j)):
+                if i & (1 << j):
                     wt *= (c[2 + j] - ax.center[idx]) / w
                     pix_i += [1 + idx]
                 else:
@@ -345,7 +340,6 @@ class HpxNDMap(HpxMap):
         return val
 
     def fill_by_idx(self, idx, weights=None):
-
         idx = pix_tuple_to_idx(idx)
         msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
         if weights is not None:
@@ -364,13 +358,11 @@ class HpxNDMap(HpxMap):
         self.data.T.flat[idx_local] += weights
 
     def set_by_idx(self, idx, vals):
-
         idx = pix_tuple_to_idx(idx)
         idx_local = self.geom.global_to_local(idx)
         self.data.T[idx_local] = vals
 
     def _make_cols(self, header, conv):
-
         shape = self.data.shape
         cols = []
         if header['INDXSCHM'] == 'SPARSE':
@@ -400,7 +392,6 @@ class HpxNDMap(HpxMap):
         return cols
 
     def to_swapped_scheme(self):
-
         import healpy as hp
         hpx_out = self.geom.to_swapped()
         map_out = self.__class__(hpx_out)
@@ -424,7 +415,6 @@ class HpxNDMap(HpxMap):
         return map_out
 
     def to_ud_graded(self, nside, preserve_counts=False):
-
         # FIXME: For partial sky maps we should ensure that a higher
         # order map fully encompasses the lower order map
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -2,11 +2,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
-from .utils import swap_byte_order
 from .sparse import SparseArray
 from .geom import pix_tuple_to_idx
 from .hpxmap import HpxMap
-from .hpx import HpxGeom, ravel_hpx_index
+from .hpx import HpxGeom
 
 __all__ = [
     'HpxSparseMap',
@@ -38,13 +37,13 @@ class HpxSparseMap(HpxMap):
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):
-        """Make a HpxNDMap object from a FITS HDU.
+        """Create from a FITS HDU.
 
         Parameters
         ----------
-        hdu : `~astropy.fits.BinTableHDU`
+        hdu : `~astropy.io.fits.BinTableHDU`
             The FITS HDU
-        hdu_bands  : `~astropy.fits.BinTableHDU`
+        hdu_bands  : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU
         """
         hpx = HpxGeom.from_header(hdu.header, hdu_bands)
@@ -78,6 +77,7 @@ class HpxSparseMap(HpxMap):
                 for i, cname in enumerate(cnames):
                     idx = np.unravel_index(i, shape)
                     map_out.data[idx + (slice(None),)] = hdu.data.field(cname)
+
         return map_out
 
     def get_by_pix(self, pix, interp=None):

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -9,11 +9,11 @@ from .hpxmap import HpxMap
 from .hpx import HpxGeom, ravel_hpx_index
 
 __all__ = [
-    'HpxMapSparse',
+    'HpxSparseMap',
 ]
 
 
-class HpxMapSparse(HpxMap):
+class HpxSparseMap(HpxMap):
     """Representation of a N+2D map using HEALPIX with two spatial
     dimensions and N non-spatial dimensions.
 
@@ -34,11 +34,11 @@ class HpxMapSparse(HpxMap):
         elif isinstance(data, np.ndarray):
             data = SparseArray.from_array(data)
 
-        super(HpxMapSparse, self).__init__(geom, data)
+        super(HpxSparseMap, self).__init__(geom, data)
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):
-        """Make a HpxMapND object from a FITS HDU.
+        """Make a HpxNDMap object from a FITS HDU.
 
         Parameters
         ----------

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -72,6 +72,7 @@ def reproject_car_to_hpx(input_data, coord_system_out,
 
 def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
     """Reproject an all-sky CAR projection to another WCS projection.
+
     This method performs special handling of the projection edges to
     ensure that the interpolation of the CAR projection is correctly
     wrapped in longitude.

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from astropy.coordinates import SkyCoord
-from ..base import MapBase
+from ..base import Map
 from ..geom import MapAxis
 
 pytest.importorskip('scipy')
@@ -27,5 +27,5 @@ mapbase_args = [
 @pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes'),
                          mapbase_args)
 def test_mapbase_create(binsz, width, map_type, skydir, axes):
-    m = MapBase.create(binsz=binsz, width=width, map_type=map_type,
+    m = Map.create(binsz=binsz, width=width, map_type=map_type,
                        skydir=skydir, axes=axes)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -5,11 +5,11 @@ import numpy as np
 from numpy.testing import assert_allclose
 from ..utils import fill_poisson
 from ..geom import MapAxis
-from ..base import MapBase
+from ..base import Map
 from ..hpx import HpxGeom
 from ..hpxmap import HpxMap
-from ..hpxnd import HpxMapND
-from ..hpxsparse import HpxMapSparse
+from ..hpxnd import HpxNDMap
+from ..hpxsparse import HpxSparseMap
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
@@ -35,10 +35,10 @@ hpx_test_geoms_sparse += [tuple(list(t) + [False]) for t in hpx_test_geoms]
 
 def create_map(nside, nested, coordsys, region, axes, sparse):
     if sparse:
-        m = HpxMapSparse(HpxGeom(nside=nside, nest=nested,
+        m = HpxSparseMap(HpxGeom(nside=nside, nest=nested,
                                  coordsys=coordsys, region=region, axes=axes))
     else:
-        m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+        m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                              coordsys=coordsys, region=region, axes=axes))
 
     return m
@@ -54,9 +54,9 @@ def test_hpxmap_init(nside, nested, coordsys, region, axes):
         shape += [ax.nbin for ax in axes]
     shape = shape[::-1]
     data = np.random.uniform(0, 1, shape)
-    m = HpxMapND(geom)
+    m = HpxNDMap(geom)
     assert m.data.shape == data.shape
-    m = HpxMapND(geom, data)
+    m = HpxNDMap(geom, data)
     assert_allclose(m.data, data)
 
 
@@ -75,9 +75,9 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     fill_poisson(m, mu=0.5, random_state=0)
     m.write(filename)
 
-    m2 = HpxMapND.read(filename)
-    m3 = HpxMapSparse.read(filename)
-    m4 = MapBase.read(filename, map_type='hpx')
+    m2 = HpxNDMap.read(filename)
+    m3 = HpxSparseMap.read(filename)
+    m4 = Map.read(filename, map_type='hpx')
     if sparse:
         msk = np.isfinite(m2.data[...])
     else:
@@ -88,9 +88,9 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
     m.write(filename, sparse=True)
-    m2 = HpxMapND.read(filename)
+    m2 = HpxNDMap.read(filename)
     m3 = HpxMap.read(filename, map_type='hpx')
-    m4 = MapBase.read(filename, map_type='hpx')
+    m4 = Map.read(filename, map_type='hpx')
     assert_allclose(m.data[...][msk], m2.data[...][msk])
     assert_allclose(m.data[...][msk], m3.data[...][msk])
     assert_allclose(m.data[...][msk], m4.data[...][msk])
@@ -119,7 +119,7 @@ def test_hpxmap_set_get_by_coords(nside, nested, coordsys, region, axes, sparse)
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_get_by_coords_interp(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     coords = m.geom.get_coords()
     m.set_by_coords(coords, coords[1])
@@ -140,7 +140,7 @@ def test_hpxmap_fill_by_coords(nside, nested, coordsys, region, axes, sparse):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_iter(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     coords = m.geom.get_coords(flat=True)
     m.fill_by_coords(coords, coords[0])
@@ -153,7 +153,7 @@ def test_hpxmap_iter(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_to_wcs(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     m_wcs = m.to_wcs(sum_bands=False, oversample=2, normalize=False)
     m_wcs = m.to_wcs(sum_bands=True, oversample=2, normalize=False)
@@ -162,7 +162,7 @@ def test_hpxmap_to_wcs(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_swap_scheme(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     fill_poisson(m, mu=1.0, random_state=0)
     m2 = m.to_swapped_scheme()
@@ -173,7 +173,7 @@ def test_hpxmap_swap_scheme(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_ud_grade(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     m.to_ud_graded(4)
 
@@ -181,7 +181,7 @@ def test_hpxmap_ud_grade(nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
-    m = HpxMapND(HpxGeom(nside=nside, nest=nested,
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     coords = m.geom.get_coords(flat=True)
     m.fill_by_coords(coords, coords[0])

--- a/gammapy/maps/tests/test_hpxsparse.py
+++ b/gammapy/maps/tests/test_hpxsparse.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from ..geom import MapAxis
 from ..hpx import HpxGeom
-from ..hpxsparse import HpxMapSparse
+from ..hpxsparse import HpxSparseMap
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
@@ -26,5 +26,5 @@ hpx_test_geoms = [
                          hpx_test_geoms)
 def test_hpxsparse_init(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
-    m = HpxMapSparse(geom)
+    m = HpxSparseMap(geom)
     # TODO: Test initialization w/ data array

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -7,11 +7,11 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..utils import fill_poisson
 from ..geom import MapAxis
-from ..base import MapBase
+from ..base import Map
 from ..wcs import WcsGeom
 from ..hpx import HpxGeom
 from ..wcsmap import WcsMap
-from ..wcsnd import WcsMapND
+from ..wcsnd import WcsNDMap
 
 pytest.importorskip('scipy')
 pytest.importorskip('reproject')
@@ -47,10 +47,10 @@ wcs_test_geoms = wcs_allsky_test_geoms + wcs_partialsky_test_geoms
 def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m0 = WcsMapND(geom)
+    m0 = WcsNDMap(geom)
     coords = m0.geom.get_coords()
     m0.set_by_coords(coords, coords[1])
-    m1 = WcsMapND(geom, m0.data)
+    m1 = WcsNDMap(geom, m0.data)
     assert_allclose(m0.data, m1.data)
 
 
@@ -61,20 +61,20 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
                           proj=proj, coordsys=coordsys, axes=axes)
     filename = str(tmpdir / 'skycube.fits')
     filename_sparse = str(tmpdir / 'skycube_sparse.fits')
-    m0 = WcsMapND(geom)
+    m0 = WcsNDMap(geom)
     fill_poisson(m0, mu=0.5)
     m0.write(filename)
-    m1 = WcsMapND.read(filename)
-    m2 = MapBase.read(filename)
-    m3 = MapBase.read(filename, map_type='wcs')
+    m1 = WcsNDMap.read(filename)
+    m2 = Map.read(filename)
+    m3 = Map.read(filename, map_type='wcs')
     assert_allclose(m0.data, m1.data)
     assert_allclose(m0.data, m2.data)
     assert_allclose(m0.data, m3.data)
 
     m0.write(filename_sparse, sparse=True)
-    m1 = WcsMapND.read(filename_sparse)
-    m2 = MapBase.read(filename)
-    m3 = MapBase.read(filename, map_type='wcs')
+    m1 = WcsNDMap.read(filename_sparse)
+    m2 = Map.read(filename)
+    m3 = Map.read(filename, map_type='wcs')
     assert_allclose(m0.data, m1.data)
     assert_allclose(m0.data, m2.data)
     assert_allclose(m0.data, m3.data)
@@ -85,7 +85,7 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     pix = m.geom.get_idx()
     m.set_by_pix(pix, coords[0])
@@ -97,7 +97,7 @@ def test_wcsmapnd_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     m.set_by_coords(coords, coords[0])
     assert_allclose(coords[0], m.get_by_coords(coords))
@@ -113,7 +113,7 @@ def test_wcsmapnd_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_fill_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     m.fill_by_coords(tuple([np.concatenate((t, t)) for t in coords]),
                      np.concatenate((coords[1], coords[1])))
@@ -125,7 +125,7 @@ def test_wcsmapnd_fill_by_coords(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords(flat=True)
     m.set_by_coords(coords, coords[1])
     assert_allclose(coords[1], m.get_by_coords(coords, interp='nearest'))
@@ -140,7 +140,7 @@ def test_wcsmapnd_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_iter(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     m.fill_by_coords(coords, coords[0])
     for vals, pix in m.iter_by_pix(buffersize=100):
@@ -154,7 +154,7 @@ def test_wcsmapnd_iter(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     m.fill_by_coords(coords, coords[0])
     msum = m.sum_over_axes()
@@ -165,7 +165,7 @@ def test_wcsmapnd_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj,
                           skydir=skydir, coordsys=coordsys, axes=axes)
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
 
     if geom.projection == 'AIT' and geom.is_allsky:
         pytest.xfail('Bug in reproject version <= 0.3.1')
@@ -185,7 +185,7 @@ def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
 
 def test_wcsmapnd_reproject_allsky_car():
     geom = WcsGeom.create(binsz=10.0, proj='CAR', coordsys='CEL')
-    m = WcsMapND(geom)
+    m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     m.set_by_coords(coords, coords[0])
 

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -13,7 +13,7 @@ def fill_poisson(map_in, mu, random_state='random-seed'):
 
     Parameters
     ----------
-    map_in : `~gammapy.maps.MapBase`
+    map_in : `~gammapy.maps.Map`
         Input map
     mu : scalar or `~numpy.ndarray`
         Expectation value

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -290,7 +290,7 @@ class WcsGeom(MapGeom):
         ----------
         header : `~astropy.io.fits.Header`
             The FITS header
-        hdu_bands : `~astropy.fits.BinTableHDU` 
+        hdu_bands : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU.
         conv : str
             Override FITS format convention.

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.io import fits
 from .geom import find_and_read_bands
-from .base import MapBase
+from .base import Map
 from .wcs import WcsGeom
 from .utils import find_hdu, find_bands_hdu
 
@@ -12,7 +12,7 @@ __all__ = [
 ]
 
 
-class WcsMap(MapBase):
+class WcsMap(Map):
     """Base class for WCS map classes.
 
     Parameters
@@ -74,7 +74,7 @@ class WcsMap(MapBase):
         map : `~WcsMap`
             A WCS map object.
         """
-        from .wcsnd import WcsMapND
+        from .wcsnd import WcsNDMap
         # from .wcssparse import WcsMapSparse
 
         geom = WcsGeom.create(npix=npix, binsz=binsz, width=width,
@@ -83,7 +83,7 @@ class WcsMap(MapBase):
                               conv=conv)
 
         if map_type == 'wcs':
-            return WcsMapND(geom, dtype=dtype)
+            return WcsNDMap(geom, dtype=dtype)
         elif map_type == 'wcs-sparse':
             raise NotImplementedError
         else:

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
-from .geom import find_and_read_bands
 from .base import Map
 from .wcs import WcsGeom
 from .utils import find_hdu, find_bands_hdu

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -11,11 +11,11 @@ from .wcsmap import WcsMap
 from .reproject import reproject_car_to_hpx, reproject_car_to_wcs
 
 __all__ = [
-    'WcsMapND',
+    'WcsNDMap',
 ]
 
 
-class WcsMapND(WcsMap):
+class WcsNDMap(WcsMap):
     """Representation of a N+2D map using WCS with two spatial dimensions
     and N non-spatial dimensions.
 
@@ -44,7 +44,7 @@ class WcsMapND(WcsMap):
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
 
-        super(WcsMapND, self).__init__(geom, data)
+        super(WcsNDMap, self).__init__(geom, data)
 
     def _init_data(self, geom, shape, dtype):
         # Check whether corners of each image plane are valid
@@ -84,7 +84,7 @@ class WcsMapND(WcsMap):
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):
-        """Make a WcsMapND object from a FITS HDU.
+        """Make a WcsNDMap object from a FITS HDU.
 
         Parameters
         ----------
@@ -278,7 +278,7 @@ class WcsMapND(WcsMap):
     def _reproject_wcs(self, geom, mode='interp', order=1):
         from reproject import reproject_interp, reproject_exact
 
-        map_out = WcsMapND(geom)
+        map_out = WcsNDMap(geom)
         axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
                           zip(geom.axes, self.geom.axes)])
 
@@ -322,9 +322,9 @@ class WcsMapND(WcsMap):
 
     def _reproject_hpx(self, geom, mode='interp', order=1):
         from reproject import reproject_from_healpix, reproject_to_healpix
-        from .hpxnd import HpxMapND
+        from .hpxnd import HpxNDMap
 
-        map_out = HpxMapND(geom)
+        map_out = HpxNDMap(geom)
         coordsys = 'galactic' if geom.coordsys == 'GAL' else 'icrs'
         axes_eq = np.all([ax0 == ax1 for ax0, ax1 in
                           zip(geom.axes, self.geom.axes)])

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -88,9 +88,9 @@ class WcsNDMap(WcsMap):
 
         Parameters
         ----------
-        hdu : `~astropy.fits.BinTableHDU` or `~astropy.fits.ImageHDU`
+        hdu : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
             The map FITS HDU.
-        hdu_bands : `~astropy.fits.BinTableHDU`
+        hdu_bands : `~astropy.io.fits.BinTableHDU`
             The BANDS table HDU.
         """
         geom = WcsGeom.from_header(hdu.header, hdu_bands)


### PR DESCRIPTION
This PR implements the changes to the class names in `gammapy.maps` proposed by @cdeil (see #1242 for further discussion):
* `MapBase` -> `Map`
* `WcsMapND` -> `WcsNDMap` 
* `HpxMapND` -> `HpxNDMap` 
* `HpxMapSparse` -> `HpxSparseMap` 