### PR TITLE
Added skydir_to_pix method to WcsGeom

### DIFF
--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -475,6 +475,27 @@ class WcsGeom(MapGeom):
             coords = tuple([c[np.isfinite(c)] for c in coords])
         return coords
 
+    def skydir_to_pix(self, skydir):
+        """
+        Convert SkyCoord to pixels in the MapGeom
+
+        Parameters:
+        ___________
+
+        skydir : `~astropy.coordinates.SkyCoord`
+                 input coordinate
+
+        Returns
+        _______
+        tuple of pixels
+        """
+        if self.coordsys == 'CEL':
+            return self.coord_to_pix(skydir.fk5)
+        elif  self.coordsys == 'GAL':
+            return self.coord_to_pix(skydir.galactic)
+        else:
+            raise ValueError('Unrecognized WCS coordinate system.')
+
     def coord_to_pix(self, coords):
         c = MapCoords.create(coords)
         if c.size == 0:


### PR DESCRIPTION
WcsGeom.coord_to_pix(skycoord) does not work if skycoord is a `~astropy.coordinates.SkyCoord` and its coordsys is different from that of the WcsGeom. It implicitly assumes that the SkyCoord is in the same coordinate system as the WcsGeom.

This PR is supposed to solve this issue by adding a specific skydive_to_pix method to WcsGeom. It ensures that the coordsys of the SkyCoord and the WcsGeom are consistent.