### PR TITLE
Updating astropy-helpers to 2.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,9 @@ matrix:
     include:
 
         # MacOS X tests
-#        - os: osx
-#          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OSX
+        - os: osx
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OSX
 
         - os: osx
           env: PYTHON_VERSION=3.5 SETUP_CMD='test'
@@ -82,9 +82,9 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
         # Build docs
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
-#               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
+               CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
         - os: linux
           env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
@@ -99,8 +99,8 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
 
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
+        - os: linux
+          env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
 
 
         # Test with Astropy dev and LTS versions
@@ -126,8 +126,8 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.10 SETUP_CMD='test -V'
 
@@ -136,9 +136,9 @@ matrix:
           env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-notebooks'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
 
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 MAIN_CMD='make' SETUP_CMD='test-notebooks'
-#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
+        - os: linux
+          env: PYTHON_VERSION=2.7 MAIN_CMD='make' SETUP_CMD='test-notebooks'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
 
     # You can move builds that temporarily fail because of some non-Gammapy here.
     # Please add a link to a GH issue that tracks the upstream issue.
@@ -148,9 +148,9 @@ matrix:
           env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-notebooks'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
 
-#        - os: linux
-#          env: PYTHON_VERSION=2.7 MAIN_CMD='make' SETUP_CMD='test-notebooks'
-#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
+        - os: linux
+          env: PYTHON_VERSION=2.7 MAIN_CMD='make' SETUP_CMD='test-notebooks'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
 
 
 install:

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -142,7 +142,6 @@ import pkg_resources
 
 from setuptools import Distribution
 from setuptools.package_index import PackageIndex
-from setuptools.sandbox import run_setup
 
 from distutils import log
 from distutils.debug import DEBUG
@@ -486,9 +485,10 @@ class _Bootstrapper(object):
             # setup.py exists we can generate it
             setup_py = os.path.join(path, 'setup.py')
             if os.path.isfile(setup_py):
-                with _silence():
-                    run_setup(os.path.join(path, 'setup.py'),
-                              ['egg_info'])
+                # We use subprocess instead of run_setup from setuptools to
+                # avoid segmentation faults - see the following for more details:
+                # https://github.com/cython/cython/issues/2104
+                sp.check_output([sys.executable, 'setup.py', 'egg_info'], cwd=path)
 
                 for dist in pkg_resources.find_distributions(path, True):
                     # There should be only one...
@@ -530,12 +530,25 @@ class _Bootstrapper(object):
 
         attrs = {'setup_requires': [req]}
 
+        # NOTE: we need to parse the config file (e.g. setup.cfg) to make sure
+        # it honours the options set in the [easy_install] section, and we need
+        # to explicitly fetch the requirement eggs as setup_requires does not
+        # get honored in recent versions of setuptools:
+        # https://github.com/pypa/setuptools/issues/1273
+
         try:
-            if DEBUG:
-                _Distribution(attrs=attrs)
-            else:
-                with _silence():
-                    _Distribution(attrs=attrs)
+
+            context = _verbose if DEBUG else _silence
+            with context():
+                dist = _Distribution(attrs=attrs)
+                try:
+                    dist.parse_config_files(ignore_option_errors=True)
+                    dist.fetch_build_eggs(req)
+                except TypeError:
+                    # On older versions of setuptools, ignore_option_errors
+                    # doesn't exist, and the above two lines are not needed
+                    # so we can just continue
+                    pass
 
             # If the setup_requires succeeded it will have added the new dist to
             # the main working_set
@@ -870,6 +883,10 @@ class _DummyFile(object):
     def flush(self):
         pass
 
+
+@contextlib.contextmanager
+def _verbose():
+    yield
 
 @contextlib.contextmanager
 def _silence():

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,9 @@ environment:
       ASTROPY_USE_SYSTEM_PYTEST: 1
 
   matrix:
-#      - PYTHON_VERSION: "2.7"
-#        ASTROPY_VERSION: "stable"
-#        NUMPY_VERSION: "stable"
+      - PYTHON_VERSION: "2.7"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
       - PYTHON_VERSION: "3.5"
         ASTROPY_VERSION: "stable"


### PR DESCRIPTION
~DO NOT MERGE YET~

~This is to test the top of the 2.0.x branch of the helpers to see whether it indeed fixes #1248~

This now has the actual 2.0.3 release of the helpers and can be merged when tests pass.