### PR TITLE
Add new options for applying energy thresholds

### DIFF
--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -119,7 +119,7 @@ class EnergyDispersion(object):
         """
         return self.data.data.value
 
-    def pdf_in_safe_range(self, lo_threshold, hi_threshold):
+    def pdf_in_safe_range(self, lo_threshold, hi_threshold, axis=1):
         """PDF matrix with bins outside threshold set to 0.
 
         Parameters
@@ -128,11 +128,22 @@ class EnergyDispersion(object):
             Low reco energy threshold
         hi_threshold : `~astropy.units.Quantity`
             High reco energy threshold
+        axis : int
+            Axis along which to apply thresholds.
+                0 - true energy
+                1 - reconstructed energy
         """
         data = self.pdf_matrix.copy()
-        idx = np.where((self.e_reco.lo < lo_threshold) |
-                       (self.e_reco.hi > hi_threshold))
-        data[:, idx] = 0
+        if axis == 0:
+            idx = np.where((self.e_true.lo < lo_threshold) |
+                           (self.e_true.hi > hi_threshold))
+            data[idx, :] = 0
+        elif axis == 1:
+            idx = np.where((self.e_reco.lo < lo_threshold) |
+                           (self.e_reco.hi > hi_threshold))
+            data[:, idx] = 0
+        else:
+            raise ValueError("`axis` must be either 0 (true energy) or 1 (reconstructed energy)")
         return data
 
     @classmethod

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from copy import deepcopy
 from collections import OrderedDict
 import numpy as np
 from astropy.io import fits
@@ -548,6 +549,9 @@ class EnergyDispersion(object):
         self.plot_bias(ax=axes[0])
         self.plot_matrix(ax=axes[1])
         plt.tight_layout()
+
+    def copy(self):
+        return deepcopy(self)
 
 
 class EnergyDispersion2D(object):

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -49,15 +49,19 @@ class IRFStacker(object):
         list of low energy threshold, optional for effective area mean computation
     list_high_threshold : list
         list of high energy threshold, optional for effective area mean computation
+    threshold_axis : string, {'e_reco', 'e_true'}
+        axis along which to apply energy thresholds
     """
 
     def __init__(self, list_aeff, list_livetime, list_edisp=None,
-                 list_low_threshold=None, list_high_threshold=None):
+                 list_low_threshold=None, list_high_threshold=None,
+                 threshold_axis='e_reco'):
         self.list_aeff = list_aeff
         self.list_livetime = Quantity(list_livetime)
         self.list_edisp = list_edisp
         self.list_low_threshold = list_low_threshold
         self.list_high_threshold = list_high_threshold
+        self.thresh_axis = threshold_axis == 'e_reco'
         self.stacked_aeff = None
         self.stacked_edisp = None
 
@@ -97,7 +101,8 @@ class IRFStacker(object):
             aefft_current = aeff_data * self.list_livetime[i]
             aefft += aefft_current
             edisp_data = edisp.pdf_in_safe_range(self.list_low_threshold[i],
-                                                 self.list_high_threshold[i])
+                                                 self.list_high_threshold[i],
+                                                 self.thresh_axis)
 
             aefftedisp += edisp_data.transpose() * aefft_current
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -583,12 +583,15 @@ class FluxPointEstimator(object):
         Energy groups (usually output of `~gammapy.spectrum.SpectrumEnergyGroupMaker`)
     model : `~gammapy.spectrum.models.SpectralModel`
         Global model (usually output of `~gammapy.spectrum.SpectrumFit`)
+    apply_thresholds : bool, default: True
+        Apply energy thresholds of individual observations
     """
 
-    def __init__(self, obs, groups, model):
+    def __init__(self, obs, groups, model, apply_thresholds=True):
         self.obs = obs
         self.groups = groups
         self.model = model
+        self.apply_thresholds = apply_thresholds
         self.flux_points = None
 
     def __str__(self):
@@ -787,7 +790,7 @@ class FluxPointEstimator(object):
         # Set reference and remove min amplitude
         model.parameters['reference'].value = energy_ref.to('TeV').value
 
-        fit = SpectrumFit(self.obs, model)
+        fit = SpectrumFit(self.obs, model, apply_thresholds=self.apply_thresholds)
 
         # TODO: Notice channels contained in energy_group
         fit.fit_range = energy_min, energy_max

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -579,9 +579,16 @@ class SpectrumObservationList(UserList):
         """Off `~gammapy.spectrum.PHACountsSpectrumList`"""
         return PHACountsSpectrumList([o.off_vector for o in self])
 
-    def stack(self):
-        """Return stacked `~gammapy.spectrum.SpectrumObservation`"""
-        stacker = SpectrumObservationStacker(obs_list=self)
+    def stack(self, threshold_axis='e_reco'):
+        """Return stacked `~gammapy.spectrum.SpectrumObservation`
+
+        Parameters
+        ----------
+        threshold_axis : string, {'e_reco', 'e_true'}
+            axis along which to apply energy thresholds
+        """
+        stacker = SpectrumObservationStacker(obs_list=self,
+                                             threshold_axis=threshold_axis)
         stacker.run()
         return stacker.stacked_obs
 
@@ -737,6 +744,8 @@ class SpectrumObservationStacker(object):
     ----------
     obs_list : `~gammapy.spectrum.SpectrumObservationList`
         Observations to stack
+    threshold_axis : string, {'e_reco', 'e_true'}
+        Axis along which to apply energy thresholds
 
     Examples
     --------
@@ -760,8 +769,9 @@ class SpectrumObservationStacker(object):
     energy range: 681292069.06 keV - 87992254356.91 keV
     """
 
-    def __init__(self, obs_list):
+    def __init__(self, obs_list, threshold_axis='e_reco'):
         self.obs_list = SpectrumObservationList(obs_list)
+        self.threshold_axis = threshold_axis
         self.stacked_on_vector = None
         self.stacked_off_vector = None
         self.stacked_aeff = None
@@ -884,6 +894,7 @@ class SpectrumObservationStacker(object):
             list_edisp=[obs.edisp for obs in self.obs_list],
             list_low_threshold=[obs.lo_threshold for obs in self.obs_list],
             list_high_threshold=[obs.hi_threshold for obs in self.obs_list],
+            threshold_axis=self.threshold_axis,
         )
         irf_stacker.stack_edisp()
         self.stacked_edisp = irf_stacker.stacked_edisp


### PR DESCRIPTION
After some discussion in #1263, it became apparent that when predicting counts for some model, Gammapy applies energy thresholds of observations in reconstructed energy space (i.e. after having applied the energy dispersion matrix). It would also be possible to apply the thresholds in true energy space though, in fact, that is what the HESS-HAP software package does.

This PR adds options that allow
1) to apply the energy thresholds in true energy space (i.e. before applying the energy dispersion matrix) for the predicted counts
2) not to convolve the fit range with the energy thresholds of the observations

The default behavior is unchanged, but it is convenient to have the option to run the fit in a different way.