### PR TITLE
Update CTA IRF files for tests

### DIFF
--- a/examples/3D/example_3d_simulate.py
+++ b/examples/3D/example_3d_simulate.py
@@ -20,7 +20,7 @@ from configuration import get_model_gammapy, make_ref_cube
 
 
 def get_irfs(config):
-    filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
 
     offset = Angle(config['selection']['offset_fov'] * u.deg)
 

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -14,7 +14,7 @@ from .. import SkyCube
 
 @pytest.fixture(scope='session')
 def bkg_3d():
-    filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     return Background3D.read(filename, hdu='BACKGROUND')
 
 
@@ -66,8 +66,9 @@ def test_background_cube(bkg_3d, counts_cube):
     assert bkg_cube.data.shape == (15, 120, 200)
     assert bkg_cube.data.unit == ''
 
-    assert_allclose(bkg_cube.data[0, 0, 0], 0.014835371179768773)
-    assert_allclose(bkg_cube.data.sum(), 1359.1700828673065)
+    print(bkg_cube.data.sum())
+    assert_allclose(bkg_cube.data[0, 0, 0], 0.013959329891790048)
+    assert_allclose(bkg_cube.data.sum(), 1315.7910319477235)
 
     # Check that `offset_max` is working properly
     pos = SkyCoord(85.6, 23, unit='deg')

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -35,15 +35,15 @@ class Background3D(object):
     Here's an example you can use to learn about this class:
 
     >>> from gammapy.irf import Background3D
-    >>> filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    >>> filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     >>> bkg_3d = Background3D.read(filename, hdu='BACKGROUND')
     >>> print(bkg_3d)
     Background3D
     NDDataArray summary info
     energy         : size =    21, min =  0.016 TeV, max = 158.489 TeV
-    detx           : size =    12, min = -5.500 deg, max =  5.500 deg
-    dety           : size =    12, min = -5.500 deg, max =  5.500 deg
-    Data           : size =  3024, min =  0.000 1 / (MeV s sr), max =  0.269 1 / (MeV s sr)
+    detx           : size =    36, min = -5.833 deg, max =  5.833 deg
+    dety           : size =    36, min = -5.833 deg, max =  5.833 deg
+    Data           : size = 27216, min =  0.000 1 / (MeV s sr), max =  0.421 1 / (MeV s sr)
     """
     default_interp_kwargs = dict(bounds_error=False, fill_value=None)
     """Default Interpolation kwargs for `~NDDataArray`. Extrapolate."""

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -327,15 +327,14 @@ class EffectiveAreaTable2D(object):
     Here's an example you can use to learn about this class:
 
     >>> from gammapy.irf import EffectiveAreaTable2D
-    >>> filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    >>> filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     >>> aeff = EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
     >>> print(aeff)
     EffectiveAreaTable2D
     NDDataArray summary info
-    energy         : size =    21, min =  0.016 TeV, max = 158.489 TeV
+    energy         : size =    42, min =  0.014 TeV, max = 177.828 TeV
     offset         : size =     6, min =  0.500 deg, max =  5.500 deg
-    Data           : size =   126, min =  0.000 m2, max = 4263992.500 m2
-
+    Data           : size =   252, min =  0.000 m2, max = 5371581.000 m2
 
     Here's another one, created from scratch, without reading a file:
 

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -10,7 +10,7 @@ from ...utils.fits import table_to_fits_table
 
 @pytest.fixture(scope='session')
 def bkg_3d():
-    filename = '$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits'
+    filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     return Background3D.read(filename, hdu='BACKGROUND')
 
 
@@ -24,27 +24,28 @@ def test_background_3d_basics(bkg_3d):
     assert axis.unit == 'TeV'
 
     axis = bkg_3d.data.axis('detx')
-    assert axis.nbins == 12
+    assert axis.nbins == 36
     assert axis.unit == 'deg'
 
     axis = bkg_3d.data.axis('dety')
-    assert axis.nbins == 12
+    assert axis.nbins == 36
     assert axis.unit == 'deg'
 
     data = bkg_3d.data.data
-    assert data.shape == (21, 12, 12)
+    assert data.shape == (21, 36, 36)
     assert data.unit == u.Unit('s-1 MeV-1 sr-1')
 
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_background_3d_evalutate(bkg_3d):
+def test_background_3d_evaluate(bkg_3d):
     bkg_rate = bkg_3d.data.evaluate(energy='1 TeV', detx='0.2 deg', dety='0.5 deg')
-    assert_allclose(bkg_rate.value, 0.00013652553025167435)
+    assert_allclose(bkg_rate.value, 0.00013352689711418575)
     assert bkg_rate.unit == u.Unit('s-1 MeV-1 sr-1')
 
+
 @requires_data('gammapy-extra')
-def test_background3d_write(bkg_3d):
-    hdu =  table_to_fits_table(bkg_3d.to_table())
+def test_background_3d_write(bkg_3d):
+    hdu = table_to_fits_table(bkg_3d.to_table())
     assert_equal(hdu.data['DETX_LO'][0], bkg_3d.data.axis('detx').lo.value)
     assert hdu.header['TUNIT1'] == bkg_3d.data.axis('detx').lo.unit

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -120,7 +120,7 @@ def test_EnergyDependentTablePSF():
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_psf_cta_1dc():
-    filename = "$GAMMAPY_EXTRA/test_datasets/cta_1dc/caldb/data/cta/prod3b/bcf/South_z20_50h/irf_file.fits"
+    filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     psf_irf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
 
     # Check that PSF is filled with 0 for energy / offset where no PSF info is given.
@@ -133,7 +133,7 @@ def test_psf_cta_1dc():
     # Check that evaluation works for an energy / offset where an energy is available
     psf = psf_irf.to_energy_dependent_table_psf('2 deg')
     psf = psf.table_psf_at_energy('1 TeV')
-    assert_allclose(psf.containment_radius(0.68).deg, 0.05175066714958721)
+    assert_allclose(psf.containment_radius(0.68).deg, 0.053728, atol=1e-4)
 
 
 @requires_data('gammapy-extra')


### PR DESCRIPTION
This PR updates the CTA IRF test files. It's a follow-up to https://github.com/gammapy/gammapy-extra/pull/98 with the corresponding changes in the Gammapy repo. The changes in reference numbers are very small, as expected. Tests pass for me locally.

I'm merging this now, because `master` is broken anyways (I already removed the old files in gammapy-extra) and I have to go. If there's an issue, I'll fix tonight.