### PR TITLE
Fix PSF3D.to_energy_dependent_table_psf

### DIFF
--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -1,52 +1,93 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.table import Table
+import pytest
+from numpy.testing import assert_allclose
+from astropy import units as u
 from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
-from ...utils.scripts import make_path
 from ...irf import PSF3D
+
+pytest.importorskip('scipy')
+
+
+@pytest.fixture(scope='session')
+def psf_3d():
+    filename = '$GAMMAPY_EXTRA/test_datasets/psf_table_023523.fits.gz'
+    return PSF3D.read(filename)
 
 
 @requires_data('gammapy-extra')
-@requires_dependency('scipy')
-class TestPSF3D:
-    def setup(self):
-        filename = '$GAMMAPY_EXTRA/test_datasets/psf_table_023523.fits.gz'
-        self.psf = PSF3D.read(filename)
-        filename = str(make_path(filename))
-        self.table = Table.read(filename, 'PSF_2D_TABLE')
+def test_psf_3d_basics(psf_3d):
+    assert_allclose(psf_3d.rad_lo[-1].value, 0.6704476475715637)
+    assert psf_3d.rad_lo.shape == (900,)
+    assert psf_3d.rad_lo.unit == 'deg'
 
-    def test_read(self):
-        table = self.table
-        energy_lo = table["ENERG_LO"].quantity[0]
-        energy_hi = table["ENERG_HI"].quantity[0]
-        offset_lo = table["THETA_LO"].quantity[0]
-        offset_hi = table["THETA_HI"].quantity[0]
-        rad_lo = table["RAD_LO"].quantity[0]
-        rad_hi = table["RAD_HI"].quantity[0]
-        psf_value = table["RPSF"].quantity[0]
+    assert_allclose(psf_3d.energy_lo[0].value, 0.02)
+    assert psf_3d.energy_lo.shape == (18,)
+    assert psf_3d.energy_lo.unit == 'TeV'
 
-        assert_quantity_allclose(self.psf.energy_lo, energy_lo)
-        assert_quantity_allclose(self.psf.energy_hi, energy_hi)
-        assert_quantity_allclose(self.psf.offset, offset_lo)
-        assert_quantity_allclose(self.psf.offset, offset_hi)
-        assert_quantity_allclose(self.psf.rad_lo, rad_lo)
-        assert_quantity_allclose(self.psf.rad_hi, rad_hi)
-        assert_quantity_allclose(self.psf.psf_value, psf_value)
+    assert psf_3d.psf_value.shape == (900, 6, 18)
+    assert psf_3d.psf_value.unit == 'sr-1'
 
-    def test_write(self, tmpdir):
-        filename = str(tmpdir / 'psf.fits')
-        self.psf.write(filename)
-        psf2 = PSF3D.read(filename)
-        assert_quantity_allclose(self.psf.energy_lo, psf2.energy_lo)
-        assert_quantity_allclose(self.psf.energy_hi, psf2.energy_hi)
-        assert_quantity_allclose(self.psf.offset, psf2.offset)
-        assert_quantity_allclose(self.psf.rad_lo, psf2.rad_lo)
-        assert_quantity_allclose(self.psf.rad_hi, psf2.rad_hi)
-        assert_quantity_allclose(self.psf.psf_value, psf2.psf_value)
+    assert_allclose(psf_3d.energy_thresh_lo.value, 0.1)
+    assert psf_3d.energy_lo.unit == 'TeV'
 
-    @requires_dependency('matplotlib')
-    def test_peek(self):
-        self.psf.peek()
-        mpl_savefig_check()
+    assert 'PSF3D' in psf_3d.info()
 
+
+@requires_data('gammapy-extra')
+def test_psf_3d_evaluate(psf_3d):
+    q = psf_3d.evaluate(energy='1 TeV', offset='0.3 deg', rad='0.1 deg')
+    assert_allclose(q.value, 21417.213824)
+    # TODO: is this the shape we want here?
+    assert q.shape == (1, 1, 1)
+    assert q.unit == 'sr-1'
+
+
+@requires_data('gammapy-extra')
+def test_to_energy_dependent_table_psf(psf_3d):
+    psf = psf_3d.to_energy_dependent_table_psf()
+    assert psf.psf_value.shape == (18, 900)
+    radius = psf.table_psf_at_energy('1 TeV').containment_radius(0.68).deg
+    assert_allclose(radius, 0.171445, atol=1e-4)
+
+
+@requires_data('gammapy-extra')
+def test_psf_3d_containment_radius(psf_3d):
+    q = psf_3d.containment_radius(energy='1 TeV')
+    assert_allclose(q.value, 0.171445, rtol=1e-3)
+    assert q.isscalar
+    assert q.unit == 'deg'
+
+    q = psf_3d.containment_radius(energy=[1, 3] * u.TeV)
+    assert_allclose(q.value, [0.171445, 0.157455], rtol=1e-3)
+    assert q.shape == (2,)
+
+
+@requires_data('gammapy-extra')
+def test_psf_3d_write(psf_3d, tmpdir):
+    filename = str(tmpdir / 'temp.fits')
+    psf_3d.write(filename)
+    psf_3d = PSF3D.read(filename)
+
+    assert_allclose(psf_3d.energy_lo[0].value, 0.02)
+
+
+@requires_data('gammapy-extra')
+@requires_dependency('matplotlib')
+def test_psf_3d_plot_vs_rad(psf_3d):
+    psf_3d.plot_psf_vs_rad()
+    mpl_savefig_check()
+
+
+@requires_data('gammapy-extra')
+@requires_dependency('matplotlib')
+def test_psf_3d_plot_containment(psf_3d):
+    psf_3d.plot_containment(show_safe_energy=True)
+    mpl_savefig_check()
+
+
+@requires_data('gammapy-extra')
+@requires_dependency('matplotlib')
+def test_psf_3d_peek(psf_3d):
+    psf_3d.peek()
+    mpl_savefig_check()

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -9,7 +9,7 @@ from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import gammapy_extra
 from ...datasets import FermiGalacticCenter
-from ...irf import TablePSF, EnergyDependentTablePSF, EnergyDependentMultiGaussPSF
+from ...irf import TablePSF, EnergyDependentTablePSF
 from ...image import SkyImage
 
 
@@ -115,25 +115,6 @@ def test_EnergyDependentTablePSF():
     rad_max = psf_band.containment_radius(0.99)
     actual = psf_band.kernel(ref, normalize=True, rad_max=rad_max).value.sum()
     assert_allclose(actual, desired)
-
-
-@requires_dependency('scipy')
-@requires_data('gammapy-extra')
-def test_psf_cta_1dc():
-    filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
-    psf_irf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
-
-    # Check that PSF is filled with 0 for energy / offset where no PSF info is given.
-    # This is needed so that stacked PSF computation doesn't error out,
-    # trying to interpolate for observations / energies where this occurs.
-    psf = psf_irf.to_energy_dependent_table_psf('4.5 deg')
-    psf = psf.table_psf_at_energy('0.05 TeV')
-    assert_allclose(psf.evaluate(rad='0.03 deg').value, 0)
-
-    # Check that evaluation works for an energy / offset where an energy is available
-    psf = psf_irf.to_energy_dependent_table_psf('2 deg')
-    psf = psf.table_psf_at_energy('1 TeV')
-    assert_allclose(psf.containment_radius(0.68).deg, 0.053728, atol=1e-4)
 
 
 @requires_data('gammapy-extra')


### PR DESCRIPTION
The `PSF3D.to_energy_dependent_table_psf` method is broken, i.e. it's not possible to do PSF containment correction in spectral analysis for the HESS data (cc @lmohrmann)

```
apply_containment_correction
    psf = obs.psf.to_energy_dependent_table_psf(theta=offset)
  File "/Users/deil/code/gammapy/gammapy/irf/psf_3d.py", line 239, in to_energy_dependent_table_psf
    psf_value = self.evaluate(offset=theta).quantity[0].T
  File "/Users/deil/Library/Python/3.6/lib/python/site-packages/astropy/units/quantity.py", line 988, in __getattr__
    attr))
AttributeError: 'Quantity' object has no 'quantity' member
```

I plan to make a PR to fix this and to generally improve that class and test coverage tonight.