### PR TITLE
Notebooks update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,11 +56,11 @@ MANIFEST
 # notebooks
 *.ipynb
 *.ipynb_checkpoints
+docs/_static/notebooks
 
 gammapy/gammapy.cfg
 
 docs/_generated
-docs/notebooks
 docs/api
 .coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ MANIFEST
 *.ipynb
 *.ipynb_checkpoints
 docs/_static/notebooks
+docs/notebooks
 
 gammapy/gammapy.cfg
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,5 +232,8 @@ suppress_warnings = [
     'ref.citation'
 ]
 
+# remove docs/notebooks folder
+from gammapy.utils.docs import remove_notebooks
+remove_notebooks()
 
 # nitpicky = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,11 @@ except ImportError:
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 
+# Load utils docs functions
+from gammapy.utils.docs import gammapy_sphinx_ext_activate
+from gammapy.utils.docs import gammapy_sphinx_notebooks
+from gammapy.utils.docs import remove_notebooks
+
 # Get configuration information from setup.cfg
 try:
     from ConfigParser import ConfigParser
@@ -174,11 +179,9 @@ htmlhelp_basename = project + 'doc'
 # Static files to copy after template files
 html_static_path = ['_static']
 
-from gammapy.utils.docs import gammapy_sphinx_ext_activate
 gammapy_sphinx_ext_activate()
 
 # integration of notebooks from gamapy-extra repo
-from gammapy.utils.docs import gammapy_sphinx_notebooks
 gammapy_sphinx_notebooks(setup_cfg)
 
 html_style = 'gammapy.css'
@@ -233,7 +236,6 @@ suppress_warnings = [
 ]
 
 # remove docs/notebooks folder
-from gammapy.utils.docs import remove_notebooks
 remove_notebooks()
 
 # nitpicky = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,6 @@ from astropy_helpers.sphinx.conf import *
 # Load utils docs functions
 from gammapy.utils.docs import gammapy_sphinx_ext_activate
 from gammapy.utils.docs import gammapy_sphinx_notebooks
-from gammapy.utils.docs import remove_notebooks
 
 # Get configuration information from setup.cfg
 try:
@@ -234,8 +233,5 @@ automodsumm_inherited_members = True
 suppress_warnings = [
     'ref.citation'
 ]
-
-# remove docs/notebooks folder
-remove_notebooks()
 
 # nitpicky = True

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -27,7 +27,7 @@ The equivalent of ``make clean`` is:
 
 .. code-block:: bash
 
-    $ rm -r build docs/_build docs/api htmlcov docs/_static/notebooks
+    $ rm -r build docs/_build docs/api htmlcov docs/notebooks docs/_static/notebooks
 
 These folders only contain generated files and are always safe to delete!
 Most of the time you don't have to delete them, but if you e.g. remove or rename files or functions / classes,
@@ -41,7 +41,8 @@ on travis-ci or for other developers.
 * The  ``docs/_build`` folder is where ``python setup.py build_docs`` generates the HTML and other Sphinx
   documentation output files.
 * The ``htmlcov`` folder is where ``python setup.py test --coverage`` generates the HTML coverage report.
-* The ``docs/_static/notebooks`` folder is where raw .ipynb files and .py scripts versions of Jupyter notebooks are stored.
+* The ``docs/notebooks`` folder is where the source Jupyter notebooks are placed before conversion into Sphinx formatted HTML documents.
+* The ``docs/_static/notebooks`` folder is where raw .ipynb files and .py scripts versions of Jupyter notebooks are placed so they may be downloaded from links in the documentation.
 
 If you use ``python setup.py build_ext --inplace``, then files are generated in the ``gammapy`` source folder.
 Usually that's not a problem, but if you want to clean up those generated files, you can use
@@ -800,11 +801,10 @@ This should work::
 You need a bunch or LaTeX stuff, specifically ``texlive-fonts-extra`` is needed.
 
 Jupyter notebooks present in the ``gammapy-extra`` repository are by default copied
-to a temporal ``docs/notebooks`` folder as well as to a permanent
-``docs/_static/notebooks`` folder during the process of generating HTML docs.
-This triggers its conversion to Sphinx formatted HTML files and .py
-scripts. The Sphinx formatted versions of the notebooks provide access to
-the raw .ipynb Jupyter files and .py script versions stored in ``docs/_static/notebooks`` folder.
+to the ``docs/notebooks`` and ``docs/_static/notebooks`` folders during
+the process of generating HTML docs. This triggers its conversion to  Sphinx
+formatted HTML files and .py scripts. The Sphinx formatted versions of the notebooks provide access to the raw .ipynb Jupyter files and .py script versions stored in ``docs/_static/notebooks`` folder.
+
 
 Documentation guidelines
 ------------------------
@@ -932,13 +932,14 @@ that will be used to access the same version of the notebook in Gammapy Binder.
 Link to a notebook in gammapy-extra from the docs
 -------------------------------------------------
 
-Jupyter notebooks stored in ``gammpy-extra`` are copied to thew ``notebooks`` folder
+Jupyter notebooks stored in ``gammpy-extra`` are copied to the ``notebooks`` folder
 during the process of Sphinx building documentation. They are converted to HTML files
 using `nb_sphinx <http://nbsphinx.readthedocs.io/>`__ Sphinx extension that provides
 a source parser for .ipynb files.
 
 From docstrings and high-level docs in Gammapy you can link to these *fixed-text*
-formatted version of the notebooks providing its filename with .html file extension in a relative path to a temporal ``notebooks`` folder that is created at the root of the ``docs`` folder in the process of documentation building.
+formatted versions of the notebooks providing its filename with .html file extension
+and the relative path to the ``notebooks`` folder. This folder is created at the root of the ``docs`` folder in the process of documentation building.
 
 Example: `First steps with Gammapy <../notebooks/first_steps.html>`__
 

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -27,7 +27,7 @@ The equivalent of ``make clean`` is:
 
 .. code-block:: bash
 
-    $ rm -r build docs/_build docs/api htmlcov docs/notebooks docs/_static/notebooks
+    $ rm -r build docs/_build docs/api htmlcov docs/_static/notebooks
 
 These folders only contain generated files and are always safe to delete!
 Most of the time you don't have to delete them, but if you e.g. remove or rename files or functions / classes,
@@ -41,7 +41,7 @@ on travis-ci or for other developers.
 * The  ``docs/_build`` folder is where ``python setup.py build_docs`` generates the HTML and other Sphinx
   documentation output files.
 * The ``htmlcov`` folder is where ``python setup.py test --coverage`` generates the HTML coverage report.
-* The ``docs/notebooks`` and ``docs/_static/notebooks`` folders are where *fixed* and *live* versions of Jupyter notebooks files are stored.
+* The ``docs/_static/notebooks`` folder is where raw .ipynb files and .py scripts versions of Jupyter notebooks are stored.
 
 If you use ``python setup.py build_ext --inplace``, then files are generated in the ``gammapy`` source folder.
 Usually that's not a problem, but if you want to clean up those generated files, you can use
@@ -800,12 +800,11 @@ This should work::
 You need a bunch or LaTeX stuff, specifically ``texlive-fonts-extra`` is needed.
 
 Jupyter notebooks present in the ``gammapy-extra`` repository are by default copied
-to the ``docs/notebooks`` and ``docs/_static/notebooks`` tree-folder structure during
-the process of generating HTML docs. This triggers its conversion to *fixed-text*
-Sphinx formatted documentation files and at the same time provides access to raw
-.ipynb Jupyter notebooks for the same version of the gammapy documentation. This
-behaviour may be modified in the  `setup.cfg` configuration file changing the
-value of `clean_notebooks` boolean.
+to a temporal ``docs/notebooks`` folder as well as to a permanent
+``docs/_static/notebooks`` folder during the process of generating HTML docs.
+This triggers its conversion to Sphinx formatted HTML files and .py
+scripts. The Sphinx formatted versions of the notebooks provide access to
+the raw .ipynb Jupyter files and .py script versions stored in ``docs/_static/notebooks`` folder.
 
 Documentation guidelines
 ------------------------
@@ -938,8 +937,8 @@ during the process of Sphinx building documentation. They are converted to HTML 
 using `nb_sphinx <http://nbsphinx.readthedocs.io/>`__ Sphinx extension that provides
 a source parser for .ipynb files.
 
-From docstrings and high-level docs in Gammapy, you can link to these *fixed-text*
-formatted version of the notebooks **providing the relative path to** ``notebooks`` **folder and .html file extension**:
+From docstrings and high-level docs in Gammapy you can link to these *fixed-text*
+formatted version of the notebooks providing its filename with .html file extension in a relative path to a temporal ``notebooks`` folder that is created at the root of the ``docs`` folder in the process of documentation building.
 
 Example: `First steps with Gammapy <../notebooks/first_steps.html>`__
 

--- a/docs/development/setup.rst
+++ b/docs/development/setup.rst
@@ -31,6 +31,13 @@ The ``docs`` folder contains the documentation pages in restructured text (RST)
 format. The Sphinx documentation generator is used to convert those RST files
 to the HTML documentation.
 
+Jupyter notebooks present in the ``gammapy-extra`` GitHub repository are also
+part of the documentation. They are copied to a temporal ``docs/notebooks`` folder during
+the process of documentation building and converted to the Sphinx-formatted HTML files
+present in the :ref:`tutorials` section. Raw Jupyter notebooks files and .py scripts
+versions are stored in the ``docs/_static/notebooks`` folder generated during the
+documentation building process.
+
 In the repository you will find a bunch of other files and folders. We will explain
 some of them here, but not all. Just ignore the rest.
 

--- a/docs/development/setup.rst
+++ b/docs/development/setup.rst
@@ -32,10 +32,10 @@ format. The Sphinx documentation generator is used to convert those RST files
 to the HTML documentation.
 
 Jupyter notebooks present in the ``gammapy-extra`` GitHub repository are also
-part of the documentation. They are copied to a temporal ``docs/notebooks`` folder during
+part of the documentation. They are copied to a ``docs/notebooks`` folder during
 the process of documentation building and converted to the Sphinx-formatted HTML files
 present in the :ref:`tutorials` section. Raw Jupyter notebooks files and .py scripts
-versions are stored in the ``docs/_static/notebooks`` folder generated during the
+versions are placed in the ``docs/_static/notebooks`` folder generated during the
 documentation building process.
 
 In the repository you will find a bunch of other files and folders. We will explain

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -186,10 +186,7 @@ def gammapy_sphinx_notebooks(setup_cfg):
     git_commit = setup_cfg['git_commit']
 
     # remove existing notebooks if rebuilding
-    if bool(setup_cfg['clean_notebooks']):
-        log.info('*** Cleaning notebooks')
-        rmtree('notebooks', ignore_errors=True)
-        rmtree('_static/notebooks', ignore_errors=True)
+    rmtree('_static/notebooks', ignore_errors=True)
 
     # copy and build notebooks if empty
     if os.environ.get('GAMMAPY_EXTRA') and not os.path.isdir("notebooks"):

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -198,16 +198,10 @@ def gammapy_sphinx_notebooks(setup_cfg):
             ]
             log.info('*** Converting notebooks to scripts')
             copytree(gammapy_extra_notebooks_folder, 'notebooks', ignore=ignorefiles)
-            copytree(gammapy_extra_notebooks_folder, '_static/notebooks')
+            copytree(gammapy_extra_notebooks_folder, '_static/notebooks', ignore=ignorefiles)
 
             for path in Path('_static/notebooks').glob('*.ipynb'):
                 convert_nb_to_script(path)
 
             modif_nb_links('notebooks', url_docs, git_commit)
             modif_nb_links('_static/notebooks', url_docs, git_commit)
-
-
-def remove_notebooks():
-    """Removes folder docs/notebooks after the building process"""
-
-    rmtree('notebooks', ignore_errors=True)

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -208,3 +208,9 @@ def gammapy_sphinx_notebooks(setup_cfg):
 
             modif_nb_links('notebooks', url_docs, git_commit)
             modif_nb_links('_static/notebooks', url_docs, git_commit)
+
+
+def remove_notebooks():
+    """Removes folder docs/notebooks after the building process"""
+
+    rmtree('notebooks', ignore_errors=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ url = https://github.com/gammapy/gammapy
 edit_on_github = False
 github_project = gammapy/gammapy
 url_docs = http://docs.gammapy.org/en/latest
-clean_notebooks = True
+
 # configure whether to run nbsphinx; see http://nbsphinx.readthedocs.io/en/stable/never-execute.html
 execute_notebooks = never
 # configure version of notebooks in Binder


### PR DESCRIPTION
This PR addresses issue #1270 

* Makes `docs/notebooks` a temporal folder living only during the building doc process
* Avoids copying FITS files from notebooks folder in `GAMMAPY_EXTRA`
* Updates documentation and `.gitignore` accordingly 

After documentation building process only one notebooks folder exists,  containing raw .ipynb files and .py converted files -> `docs/_static/notebooks`