### PR TITLE
PIG 3 - Plan for dropping Python 2.7 support

### DIFF
--- a/docs/development/pigs/pig-003.rst
+++ b/docs/development/pigs/pig-003.rst
@@ -1,0 +1,95 @@
+.. include:: ../../references.txt
+
+.. _pig-003:
+
+********************************************
+PIG 3 - Plan for dropping Python 2.7 support
+********************************************
+
+* Author: Christoph Deil & Matthew Wood
+* Created: Feb 1, 2018
+* Status: draft
+* Discussion: `GH 1278`_
+
+Abstract
+========
+
+This PIG proposes a plan for dropping Python 2.7 support in Gammapy.
+The motivation to post it now is to inform users and developers early
+and transparently that this is coming and that they should update to
+Python 3 now. If you are stuck on Python 2.7 for some reason, or need
+help to update, please let us know. The only blocker we are aware of is
+that the Fermi Science Tools don't support Python 3 yet, so we plan
+to keep Python 2 support for now, no definite schedule for dropping
+Python 2.7 in Gammapy is in place at the moment. Comments on this PIG
+to discuss are welcome now, and then once that blocker is resolved,
+we plan to update it with a concrete proposal / timeline.
+
+Introduction
+============
+
+Python 3 was introduced 10 years ago. The transition from Python 2
+to Python 3 has been long and painful, and is still ongoing.
+In Gammapy, like most other Python packages,
+we currently support Python 2.7 as well as Python 3.
+But now things are changing at a more rapid pace, Python itself
+will drop support for the 2.7 branch (even security fixes) in 2020,
+Numpy in 2019 (see `Numpy statement`_). Astropy dropped Python 2
+support recently (see `Astropy statement`_), Jupyter already in 2017.
+The `ctapipe`_ project was Python 3 only from the start.
+
+That leaves the question what we should do in Gammapy.
+
+It is not hard to keep Python 2.7 support, but even if it's not large,
+there is a real cost. It is mostly complexity and extra testing needed,
+i.e. a burden for developers. E.g. understanding bytes / strings in Python
+2 and Python 3 is non-trivial, but here are also many small improvements
+in Python 3 (e.g. the super call when subclassing), none of which is is
+a must-have, but they add up to Python 3 as an overall simpler and better
+language. The main motivation to drop Python 2.7 support however is that
+it will become harder and harder to support over the years as everyone
+else drops support for it. So let's assume that as Gammapy developers,
+we want to drop Python 2.7 support, and to only support Python 3.5 or later.
+
+Is there any reason why someone should still use Gammapy with Python 2?
+
+Most Gammapy developers and users are already using Python 3. Anyone on
+Linux, Mac  or Windows can install and use Gammapy with Python 3.6 with
+conda. Using the system Python to install a scientific Python stack and
+Gammapy isn't a good idea anyways, the system Python is to run your
+operating system and should be left alone.
+
+The only blocker we are aware of where updating to Python 3 isn't possible
+is the Fermi ScienceTools Python. It is using Python 2.7, Python 3 isn't
+supported. It is unclear if and when Python 3 support will be added
+to the Fermi ScienceTools. A major reason that Matthew developed gammapy.maps was to
+use it in combination with the Fermi ST and in Fermipy. This isn't the case
+yet, but it is planned, and we want to support this. Keeping only gammapy.maps
+Python 2 compatible or putting a copy in ``fermipy.extern`` is possible, but
+not a nicely maintainable solution.
+
+Proposal
+========
+
+We propose to re-evaluate the timescale to drop Python 2.7 support later in 2018.
+
+As stated in the abstract, the reason to post this PIG now was to make
+the eventual goal clear (Gammapy becomes Python 3 only), and to have an
+open and transparent discussion and process to get there.
+
+Let us know what you think, especially if you are using Gammapy with Python 2.7
+and prefer to not update, or if you can't for some reason!
+
+Decision
+========
+
+As mentioned above, this PIG is not ready for a decision.
+It was just opened to have the goal defined, to explain the blocker
+and to have a place to discuss.
+
+
+.. _GH 1278: https://github.com/gammapy/gammapy/pull/1278
+.. _Numpy statement: https://github.com/numpy/numpy/blob/master/doc/neps/dropping-python2.7-proposal.rst
+.. _Astropy statement: https://github.com/astropy/astropy-APEs/blob/master/APE10.rst
+.. _Python 3 statement: http://www.python3statement.org/
+.. _ctapipe: https://github.com/cta-observatory/ctapipe

--- a/docs/development/pigs/pig-003.rst
+++ b/docs/development/pigs/pig-003.rst
@@ -14,82 +14,132 @@ PIG 3 - Plan for dropping Python 2.7 support
 Abstract
 ========
 
-This PIG proposes a plan for dropping Python 2.7 support in Gammapy.
-The motivation to post it now is to inform users and developers early
-and transparently that this is coming and that they should update to
-Python 3 now. If you are stuck on Python 2.7 for some reason, or need
-help to update, please let us know. The only blocker we are aware of is
-that the Fermi Science Tools don't support Python 3 yet, so we plan
-to keep Python 2 support for now, no definite schedule for dropping
-Python 2.7 in Gammapy is in place at the moment. Comments on this PIG
-to discuss are welcome now, and then once that blocker is resolved,
-we plan to update it with a concrete proposal / timeline.
+We propose to drop Python 2.7 support in Gammapy v0.11 in March 2019.
 
-Introduction
-============
+All earlier Gammapy versions, up to Gammapy v0.10, support Python 2.7 and of
+course will remain available indefinitely.
 
-Python 3 was introduced 10 years ago. The transition from Python 2
-to Python 3 has been long and painful, and is still ongoing.
-In Gammapy, like most other Python packages,
-we currently support Python 2.7 as well as Python 3.
-But now things are changing at a more rapid pace, Python itself
-will drop support for the 2.7 branch (even security fixes) in 2020,
-Numpy in 2019 (see `Numpy statement`_). Astropy dropped Python 2
-support recently (see `Astropy statement`_), Jupyter already in 2017.
-The `ctapipe`_ project was Python 3 only from the start.
+Use surveys in 2018 have shown that most Gammapy users are already on Python 3.
+Gammapy v0.8 shipped with a recommended conda environment based on Python 3.6
+that works on Linux, Mac and Windows and can be installed by anyone, also on
+older machines.
 
-That leaves the question what we should do in Gammapy.
+To support Fermipy, which uses gammapy.maps and still requires Python 2.7, as
+well as other users on Python 2.7 (if any), we will backport bug-fixes and make
+patch releases in the Gammapy v0.10.x branch as needed, throughout 2019.
 
-It is not hard to keep Python 2.7 support, but even if it's not large,
-there is a real cost. It is mostly complexity and extra testing needed,
-i.e. a burden for developers. E.g. understanding bytes / strings in Python
-2 and Python 3 is non-trivial, but here are also many small improvements
-in Python 3 (e.g. the super call when subclassing), none of which is is
-a must-have, but they add up to Python 3 as an overall simpler and better
-language. The main motivation to drop Python 2.7 support however is that
-it will become harder and harder to support over the years as everyone
-else drops support for it. So let's assume that as Gammapy developers,
-we want to drop Python 2.7 support, and to only support Python 3.5 or later.
+This change will reduce the effort spent on Gammapy testing and packaging in
+2019, and also will simplify life for Gammapy developers a bit and make a few
+new features of the Python 3 language available for Gammapy.
 
-Is there any reason why someone should still use Gammapy with Python 2?
+Support for Python 3 will remain as-is (Python 3.5 or later) for now, whether to
+require Python 3.6 or later for Gammapy v1.0 in fall 2019 or later will be
+discussed separately.
 
-Most Gammapy developers and users are already using Python 3. Anyone on
-Linux, Mac  or Windows can install and use Gammapy with Python 3.6 with
-conda. Using the system Python to install a scientific Python stack and
-Gammapy isn't a good idea anyways, the system Python is to run your
-operating system and should be left alone.
+User perspective
+================
 
-The only blocker we are aware of where updating to Python 3 isn't possible
-is the Fermi ScienceTools Python. It is using Python 2.7, Python 3 isn't
-supported. It is unclear if and when Python 3 support will be added
-to the Fermi ScienceTools. A major reason that Matthew developed gammapy.maps was to
-use it in combination with the Fermi ST and in Fermipy. This isn't the case
-yet, but it is planned, and we want to support this. Keeping only gammapy.maps
-Python 2 compatible or putting a copy in ``fermipy.extern`` is possible, but
-not a nicely maintainable solution.
+Most Gammapy users are already using Python 3.
 
-Proposal
-========
+We did a "Gammapy installation questionnaire" on the Gammapy mailing list and
+Gammapy Slack in Feb 2018 which resulted in only 12 responses. Only 2 people
+were still using Python 2.7, only one person suggested to keep Python 2.7
+support for a while longer, until January 2019.
 
-We propose to re-evaluate the timescale to drop Python 2.7 support later in 2018.
+In CTA, a "CTA first data challenge user survey" was done in August 2018, which
+yielded 50 responses. There 40% said they were still using Python 2.7. The
+question why, or if / when they would be happy to switch to Python 3 wasn't
+asked.
 
-As stated in the abstract, the reason to post this PIG now was to make
-the eventual goal clear (Gammapy becomes Python 3 only), and to have an
-open and transparent discussion and process to get there.
+Based on these two questionnaires, and talking to Gammapy users in 2018, it
+became clear that the only good reason to keep using Gammapy with Python 2.7 is
+when using Fermipy, which uses gammapy.maps and the Fermi science tools, which
+at this time don't support Python 3 yet, and the timeline for Python 3 support
+there isn't clear.
 
-Let us know what you think, especially if you are using Gammapy with Python 2.7
-and prefer to not update, or if you can't for some reason!
+Based on discussions with the Fermipy maintainers, as mentioned in the abstract
+already, the suggested solution here would be that Fermipy puts ``gammapy<0.11``
+in their ``setup.py`` which will mean that users will get the latest Python 2
+compatible version. Probably even that isn't needed, because the ``setup.py`` in
+Gammapy v0.11 and later will declare that it only supports Python 3 or later, so
+``pip`` or ``conda`` would always pick the latest Python 2.7 compatible version
+automatically.
+
+If other Gammapy users need support, please contact us. We can either help you
+update your scripts to run on Python 3 (preferred, usually trivial changes) or
+backport fixes to older Gammapy versions that still support Python 2.7 (if
+really needed).
+
+Maintainer and developer perspective
+====================================
+
+This change will have a big positive impact on Gammapy maintenance and
+development. It is an important step to allow for developments in 2019 towards
+the Gammapy 1.0 release that is planned for fall 2019 (see `PIG 5 - Gammapy 1.0
+Roadmap`_).
+
+Python 3 was introduced 10 years ago. The transition from Python 2 to Python 3
+has been long and painful, and is still ongoing, but it is coming to an end.
+Most scientific Python projects have already dropped Python 2.7 support or are
+doing it now  (see `Python 3 statement`_).
+
+Astropy and the ``astropy-helpers`` that we use have already dropped Python 2
+support (see `Astropy statement`_). Jupyter that we extensively use for the
+documentation has dropped Python 2 support as well. While these projects are
+still maintaining long-term-support (LST) branches for the last Python 2
+compatible versions, it is getting harder and harder to keep the Python 2 builds
+(especially the Sphinx documentation build) and tests in continuous integration
+(CI) working. Dropping Python 2 support in Gammapy means less maintainer time
+spent on this moving forward.
+
+There are also new developments that are slowed down by keeping Python 2
+support. E.g. we want to continue and finish the development of
+``astropy-healpix`` and ``astropy-regions`` to the point where it can be moved
+into the Astropy core package. This should happen before Gammapy v1.0 and then
+we should use ``astropy-healpix`` instead of ``healpy`` in Gammapy (see `GH 1167
+for Gammapy`_). Given that Astropy core doesn't support Python 2 any more, it
+makes sense to directly develop those packages with this target, i.e. Python 3
+only. Keeping support for Python 2 there does cause some extra work in
+development (see `GH 111 for astropy-healpix`_) and also for packaging. Finally,
+we want to collaborate with `ctapipe`_ in Gammapy, and they only supported
+Python 3 from the start and are using Python 3 only features.
+
+So to summarise: the extra maintenance effort to keep supporting Python 2.7 in
+Gammapy in 2019 would be significant and also slow down the work on
+``astropy-healpix`` and ``astropy-regions``. Moving to Python 3 only make life
+better for all Gammapy maintainers and developers.
+
+Detailed plan
+=============
+
+There are two ways to execute this. When dropping Python 2 support from the git
+master branch, one can either remove the Python 2 shims directly, or keep them
+in place and do as few code changes as possible for the time period where one
+has to backport bug-fixes to the Python 2 compatible branch to avoid the amount
+of git and manual edits needed. Many big and stable projects like e.g. Numpy
+that have several stable branches that are supported sometimes for years, and
+thus do a lot of backporting, don't do the cleanup directly.
+
+However, for Gammapy, we propose to do the cleanup directly in the master branch
+following the v0.10 release.
+
+The motivation for this is that in 2019 we will have to re-organise the Gammapy
+sub-packages and move and edit most files as we work towards Gammapy v1.0 in
+fall 2019 (see `PIG 5 - Gammapy 1.0 Roadmap`). So it seems unlikely that ``git
+cherry-pick`` would work at all to backport bugfixes. Instead, the strategy
+would be to manually re-apply important bug fixes (mostly to ``gammapy.maps``,
+hopefully not many) in the ``v0.10.x`` branch.
 
 Decision
 ========
 
-As mentioned above, this PIG is not ready for a decision.
-It was just opened to have the goal defined, to explain the blocker
-and to have a place to discuss.
-
+tbd
 
 .. _GH 1278: https://github.com/gammapy/gammapy/pull/1278
-.. _Numpy statement: https://github.com/numpy/numpy/blob/master/doc/neps/dropping-python2.7-proposal.rst
+.. _Numpy statement: https://docs.scipy.org/doc/numpy-1.14.1/neps/dropping-python2.7-proposal.html
 .. _Astropy statement: https://github.com/astropy/astropy-APEs/blob/master/APE10.rst
 .. _Python 3 statement: http://www.python3statement.org/
 .. _ctapipe: https://github.com/cta-observatory/ctapipe
+.. _PIG 5 - Gammapy 1.0 Roadmap: https://github.com/gammapy/gammapy/pull/1841
+.. _GH 111 for astropy-healpix: https://github.com/astropy/astropy-healpix/issues/111
+.. _GH 1167 for Gammapy: https://github.com/gammapy/gammapy/pull/1167

--- a/docs/development/pigs/pig-003.rst
+++ b/docs/development/pigs/pig-003.rst
@@ -19,7 +19,7 @@ We propose to drop Python 2.7 support in Gammapy v0.11 in March 2019.
 All earlier Gammapy versions, up to Gammapy v0.10, support Python 2.7 and of
 course will remain available indefinitely.
 
-Use surveys in 2018 have shown that most Gammapy users are already on Python 3.
+User surveys in 2018 have shown that most Gammapy users are already on Python 3.
 Gammapy v0.8 shipped with a recommended conda environment based on Python 3.6
 that works on Linux, Mac and Windows and can be installed by anyone, also on
 older machines.


### PR DESCRIPTION
This PIG is a proposal that we should drop Python 2.7 support with Gammapy and users and developers are encouraged to update to Python 3 now. No timescale is proposed yet, this is just to mention the goal and have a place for discussion on this question.

* Let us know if you need help to update to Python 3!
* Let us know if you can't update for some reason, and need continued Python 2.7 support from future Gammapy releases.

cc @woodmd and @eacharles from Fermipy.