### PR TITLE
Implement methods for WCS maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -278,7 +278,7 @@ class Map(object):
         """
         # TODO: Check whether geometries are aligned and if so sum the
         # data vectors directly
-        idx = map_in.geom.get_pixels()
+        idx = map_in.geom.get_idx()
         coords = map_in.geom.get_coords()
         vals = map_in.get_by_idx(idx)
         self.fill_by_coords(coords, vals)
@@ -314,7 +314,7 @@ class Map(object):
             return self._reproject_wcs(geom, mode=mode, order=order)
 
     @abc.abstractmethod
-    def pad(self, pad_width):
+    def pad(self, pad_width, mode='edge', cval=0):
         """Pad the spatial dimension of the map by extending the edge of the
         map by the given number of pixels.
 
@@ -322,11 +322,18 @@ class Map(object):
         ----------
         pad_width : {sequence, array_like, int}
             Number of values padded to the edges of each axis, passed to `numpy.pad`
+        mode : {'edge', 'constant', 'interp'}
+            Padding mode.  'edge' pads with the closest edge value.
+            'constant' pads with a constant value. 'interp' pads with
+            an extrapolated value.
+        cval : float
+            Padding value when mode='consant'.
 
         Returns
         -------
         map : `~Map`
             Padded map.
+
         """
         pass
 
@@ -348,13 +355,17 @@ class Map(object):
         pass
 
     @abc.abstractmethod
-    def downsample(self, factor):
+    def downsample(self, factor, preserve_counts=True):
         """Downsample the spatial dimension of the map by a given factor. 
 
         Parameters
         ----------
         factor : int
             Downsampling factor.
+        preserve_counts : bool
+            Preserve the integral over each bin.  This should be true
+            if the map is an integral quantity (e.g. counts) and false if
+            the map is a differential quantity (e.g. intensity).
 
         Returns
         -------
@@ -364,18 +375,25 @@ class Map(object):
         pass
 
     @abc.abstractmethod
-    def upsample(self, factor):
+    def upsample(self, factor, order=0, preserve_counts=True):
         """Upsample the spatial dimension of the map by a given factor. 
 
         Parameters
         ----------
         factor : int
             Upsampling factor.
+        order : int
+            Order of the interpolation used for upsampling.
+        preserve_counts : bool
+            Preserve the integral over each bin.  This should be true
+            if the map is an integral quantity (e.g. counts) and false if
+            the map is a differential quantity (e.g. intensity).
 
         Returns
         -------
         map : `~Map`
             Upsampled map.
+
         """
         pass
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -265,6 +265,24 @@ class Map(object):
         """Reduce to a 2D image by summing over non-spatial dimensions."""
         pass
 
+    def coadd(self, map_in):
+        """Fill this map with the contents of another map.  This method can be
+        used to sum maps containing integral quantities (e.g. counts)
+        or differential quantities if the maps have the same binning.
+
+        Parameters
+        ----------
+        map_in : `~MapBase`
+            Input map.
+
+        """
+        # TODO: Check whether geometries are aligned and if so sum the
+        # data vectors directly
+        idx = map_in.geom.get_pixels()
+        coords = map_in.geom.get_coords()
+        vals = map_in.get_by_idx(idx)
+        self.fill_by_coords(coords, vals)
+
     def reproject(self, geom, order=1, mode='interp'):
         """Reproject this map to a different geometry.
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -272,7 +272,7 @@ class Map(object):
 
         Parameters
         ----------
-        map_in : `~MapBase`
+        map_in : `~Map`
             Input map.
 
         """

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -628,7 +628,8 @@ class MapCoords(object):
             return cls.from_lonlat(skydir.l.deg, skydir.b.deg, *args,
                                    coordsys='GAL', **kwargs)
         else:
-            raise ValueError('Unrecognized coordinate frame: {}'.format(skydir.frame.name))
+            raise ValueError(
+                'Unrecognized coordinate frame: {}'.format(skydir.frame.name))
 
     @classmethod
     def from_tuple(cls, coords, **kwargs):
@@ -970,6 +971,74 @@ class MapGeom(object):
         -------
         geom : `~MapGeom`
             Map geometry.
+        """
+        pass
+
+    @abc.abstractmethod
+    def pad(self, pad_width):
+        """
+        Pad the geometry at the edges.
+
+        Parameters
+        ----------
+        pad_width : {sequence, array_like, int}
+            Number of values padded to the edges of each axis.
+
+        Returns
+        -------
+        geom : `~MapGeom`
+            Padded geometry.
+        """
+        pass
+
+    @abc.abstractmethod
+    def crop(self, crop_width):
+        """
+        Crop the geometry at the edges.
+
+        Parameters
+        ----------
+        crop_width : {sequence, array_like, int}
+            Number of values cropped from the edges of each axis.
+
+        Returns
+        -------
+        geom : `~MapGeom`
+            Cropped geometry.
+        """
+        pass
+
+    @abc.abstractmethod
+    def downsample(self, factor):
+        """Downsample the spatial dimension of the geometry by a given factor.
+
+        Parameters
+        ----------
+        factor : int
+            Downsampling factor.
+
+        Returns
+        -------
+        geom : `~MapGeom`
+            Downsampled geometry.
+
+        """
+        pass
+
+    @abc.abstractmethod
+    def upsample(self, factor):
+        """Upsample the spatial dimension of the geometry by a given factor. 
+
+        Parameters
+        ----------
+        factor : int
+            Upsampling factor.
+
+        Returns
+        -------
+        geom : `~MapGeom`
+            Upsampled geometry.
+
         """
         pass
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -228,6 +228,7 @@ def coord_to_idx(edges, x, clip=False):
     else:
         ibin[x > edges[-1]] = -1
 
+    ibin[~np.isfinite(x)] = -1
     return ibin
 
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -875,6 +875,18 @@ class HpxGeom(MapGeom):
         return self.__class__(np.max(self.nside), self.nest, coordsys=self.coordsys,
                               region=self.region, conv=self.conv, axes=axes)
 
+    def pad(self, pad_width):
+        raise NotImplementedError
+
+    def crop(self, crop_width):
+        raise NotImplementedError
+
+    def upsample(self, factor):
+        raise NotImplementedError
+
+    def downsample(self, factor):
+        raise NotImplementedError
+
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, coordsys='CEL', region=None,
                axes=None, conv='gadf', skydir=None, width=None):

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -238,10 +238,16 @@ class HpxNDMap(HpxMap):
         return map_out
 
     def pad(self, pad_width):
-        raise NotImplementedError
+        geom = self.geom.pad(pad_width)
+        map_out = self.__class__(geom)
+        map_out.coadd(self)
+        return map_out
 
     def crop(self, crop_width):
-        raise NotImplementedError
+        geom = self.geom.crop(crop_width)
+        map_out = self.__class__(geom)
+        map_out.coadd(self)
+        return map_out
 
     def upsample(self, factor):
         raise NotImplementedError
@@ -391,23 +397,19 @@ class HpxNDMap(HpxMap):
         import healpy as hp
         hpx_out = self.geom.to_swapped()
         map_out = self.__class__(hpx_out)
-        idx = list(self.geom.get_idx())
+        idx = self.geom.get_idx(flat=True)
         vals = self.get_by_idx(idx)
-        msk = vals > 0
-        idx = [t[msk] for t in idx]
-        vals = vals[msk]
-
         if self.geom.nside.size > 1:
             nside = self.geom.nside[idx[1:]]
         else:
             nside = self.geom.nside
 
         if self.geom.nest:
-            idx_new = tuple([hp.nest2ring(nside, idx[0])] + idx[1:])
+            idx_new = tuple([hp.nest2ring(nside, idx[0])]) + idx[1:]
         else:
-            idx_new = tuple([hp.ring2nest(nside, idx[0])] + idx[1:])
+            idx_new = tuple([hp.ring2nest(nside, idx[0])]) + idx[1:]
 
-        map_out.set_by_pix(idx_new, vals)
+        map_out.set_by_idx(idx_new, vals)
         return map_out
 
     def to_ud_graded(self, nside, preserve_counts=False):

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -28,4 +28,4 @@ mapbase_args = [
                          mapbase_args)
 def test_mapbase_create(binsz, width, map_type, skydir, axes):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
-                       skydir=skydir, axes=axes)
+                   skydir=skydir, axes=axes)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -7,6 +7,7 @@ from astropy.io import fits
 from ..geom import MapAxis
 from ..hpx import HpxGeom, get_pix_size_from_nside, nside_to_order, lonlat_to_colat
 from ..hpx import make_hpx_to_wcs_mapping, unravel_hpx_index, ravel_hpx_index
+from ..hpx import get_hpxregion_dir, get_hpxregion_size
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
@@ -152,7 +153,7 @@ def test_hpxgeom_to_slice(nside, nested, coordsys, region, axes):
 
     # Test slicing with explicit geometry
     geom = HpxGeom(nside, nested, coordsys, region=tuple(
-        [t[::10] for t in idx]), axes=axes)
+        [t[::3] for t in idx]), axes=axes)
     geom_slice = geom.to_slice(slices)
     assert_allclose(geom_slice.ndim, 2)
     assert_allclose(geom_slice.npix, np.squeeze(geom.npix[slices]))
@@ -280,16 +281,16 @@ def test_hpx_get_pix_size_from_nside():
                     np.array([32.0, 16.0, 8.0]))
 
 
-def test_hpx_get_region_size():
-    assert_allclose(HpxGeom.get_region_size('DISK(110.,75.,2.)'), 2.0)
+def test_hpx_get_hpxregion_size():
+    assert_allclose(get_hpxregion_size('DISK(110.,75.,2.)'), 2.0)
 
 
-def test_hpxgeom_get_ref_dir():
-    refdir = HpxGeom.get_ref_dir('DISK(110.,75.,2.)', 'GAL')
+def test_hpxgeom_get_hpxregion_dir():
+    refdir = get_hpxregion_dir('DISK(110.,75.,2.)', 'GAL')
     assert_allclose(refdir.l.deg, 110.)
     assert_allclose(refdir.b.deg, 75.)
 
-    refdir = HpxGeom.get_ref_dir(None, 'GAL')
+    refdir = get_hpxregion_dir(None, 'GAL')
     assert_allclose(refdir.l.deg, 0.)
     assert_allclose(refdir.b.deg, 0.)
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -17,17 +17,21 @@ pytest.importorskip('numpy', '1.12.0')
 
 axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
 
-hpx_test_geoms = [
+hpx_test_allsky_geoms = [
     (8, False, 'GAL', None, None),
     (8, False, 'GAL', None, axes1),
-    ([4, 8], False, 'GAL', None, axes1),
-    ([4, 8], False, 'GAL', 'DISK(110.,75.,10.)', axes1),
+    ([4, 8], False, 'GAL', None, axes1)]
+
+hpx_test_partialsky_geoms = [
+    ([4, 8], False, 'GAL', 'DISK(110.,75.,30.)', axes1),
     (8, False, 'GAL', 'DISK(110.,75.,10.)',
      [MapAxis(np.logspace(0., 3., 4))]),
     (8, False, 'GAL', 'DISK(110.,75.,10.)',
      [MapAxis(np.logspace(0., 3., 4), name='axis0'),
       MapAxis(np.logspace(0., 2., 3), name='axis1')])
 ]
+
+hpx_test_geoms = hpx_test_allsky_geoms + hpx_test_partialsky_geoms
 
 hpx_test_geoms_sparse = [tuple(list(t) + [True]) for t in hpx_test_geoms]
 hpx_test_geoms_sparse += [tuple(list(t) + [False]) for t in hpx_test_geoms]
@@ -176,6 +180,22 @@ def test_hpxmap_ud_grade(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     m.to_ud_graded(4)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_partialsky_geoms)
+def test_hpxmap_pad(nside, nested, coordsys, region, axes):
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.pad(1)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_partialsky_geoms)
+def test_hpxmap_crop(nside, nested, coordsys, region, axes):
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.crop(1)
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -44,7 +44,7 @@ wcs_test_geoms = wcs_allsky_test_geoms + wcs_partialsky_test_geoms
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_init(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m0 = WcsNDMap(geom)
@@ -56,7 +56,7 @@ def test_wcsmapnd_init(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     filename = str(tmpdir / 'skycube.fits')
@@ -82,7 +82,7 @@ def test_wcsmapnd_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -94,7 +94,7 @@ def test_wcsmapnd_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -110,7 +110,7 @@ def test_wcsmapnd_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_fill_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_fill_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -122,7 +122,21 @@ def test_wcsmapnd_fill_by_coords(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m0 = WcsNDMap(geom)
+    m1 = WcsNDMap(geom.upsample(2))
+    coords = m0.geom.get_coords()
+    m1.fill_by_coords(tuple([np.concatenate((t, t)) for t in coords]),
+                      np.concatenate((coords[1], coords[1])))
+    m0.coadd(m1)
+    assert_allclose(np.nansum(m0.data), np.nansum(m1.data), rtol=1E-4)
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsndmap_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -137,7 +151,7 @@ def test_wcsmapnd_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_iter(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_iter(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -151,7 +165,7 @@ def test_wcsmapnd_iter(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -162,7 +176,7 @@ def test_wcsmapnd_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_reproject(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, proj=proj,
                           skydir=skydir, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
@@ -183,7 +197,7 @@ def test_wcsmapnd_reproject(npix, binsz, coordsys, proj, skydir, axes):
     # TODO : Reproject to a different spatial geometry
 
 
-def test_wcsmapnd_reproject_allsky_car():
+def test_wcsndmap_reproject_allsky_car():
     geom = WcsGeom.create(binsz=10.0, proj='CAR', coordsys='CEL')
     m = WcsNDMap(geom)
     coords = m.geom.get_coords()
@@ -202,3 +216,44 @@ def test_wcsmapnd_reproject_allsky_car():
     m = (coords1[0] > 10.0) & (coords1[0] < 350.0)
     assert_allclose(m1.get_by_coords((coords1[0][m], coords1[1][m])),
                     coords1[0][m])
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsndmap_pad(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsNDMap(geom)
+    m.pad(1, mode='constant')
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsndmap_crop(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsNDMap(geom)
+    m.crop(1)
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsndmap_downsample(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsNDMap(geom)
+    # Check whether we can downsample
+    if (np.all(np.mod(geom.npix[0], 2) == 0) and
+            np.all(np.mod(geom.npix[1], 2) == 0)):
+        m2 = m.downsample(2, preserve_counts=True)
+        assert_allclose(np.nansum(m.data), np.nansum(m2.data))
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsndmap_upsample(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsNDMap(geom)
+    m2 = m.upsample(2, order=0, preserve_counts=True)
+    assert_allclose(np.nansum(m.data), np.nansum(m2.data))

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -364,8 +364,12 @@ class WcsGeom(MapGeom):
 
     def make_header(self):
         header = self.wcs.to_header()
-        header['WCSSHAPE'] = '({},{})'.format(np.max(self.npix[0]),
-                                              np.max(self.npix[1]))
+        self._fill_header_from_axes(header)
+        shape = '{},{}'.format(np.max(self.npix[0]),
+                               np.max(self.npix[1]))
+        for ax in self.axes:
+            shape += ',{}'.format(ax.nbin)
+        header['WCSSHAPE'] = '({})'.format(shape)
         return header
 
     def distance_to_edge(self, skydir):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -6,6 +6,7 @@ from astropy.wcs import WCS
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..image.utils import make_header
+from ..utils.wcs import get_resampled_wcs
 from .geom import MapGeom, MapCoords, pix_tuple_to_idx, skydir_to_lonlat
 from .geom import get_shape, make_axes_cols, make_axes
 from .geom import find_and_read_bands
@@ -554,6 +555,47 @@ class WcsGeom(MapGeom):
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
         axes = copy.deepcopy(self.axes) + axes
         return self.__class__(self._wcs.deepcopy(), npix, cdelt=cdelt, axes=axes)
+
+    def pad(self, pad_width):
+        if np.isscalar(pad_width):
+            pad_width = (pad_width, pad_width)
+        npix = (self.npix[0] + 2 * pad_width[0],
+                self.npix[1] + 2 * pad_width[1])
+        wcs = self._wcs.deepcopy()
+        wcs.wcs.crpix += np.array(pad_width)
+        return self.__class__(wcs, npix, cdelt=copy.deepcopy(self._cdelt),
+                              axes=copy.deepcopy(self.axes))
+
+    def crop(self, crop_width):
+        if np.isscalar(crop_width):
+            crop_width = (crop_width, crop_width)
+        npix = (self.npix[0] - 2 * crop_width[0],
+                self.npix[1] - 2 * crop_width[1])
+        wcs = self._wcs.deepcopy()
+        wcs.wcs.crpix -= np.array(crop_width)
+        return self.__class__(wcs, npix, cdelt=copy.deepcopy(self._cdelt),
+                              axes=copy.deepcopy(self.axes))
+
+    def downsample(self, factor):
+
+        if (not np.all(np.mod(self.npix[0], factor) == 0) or
+                not np.all(np.mod(self.npix[1], factor) == 0)):
+            raise ValueError('Data shape is not divisible by {} in all axes.'
+                             ' Pad image prior to downsampling to correct'
+                             ' shape.'.format(factor))
+
+        npix = (self.npix[0] / factor, self.npix[1] / factor)
+        cdelt = (self._cdelt[0] * factor, self._cdelt[1] * factor)
+        wcs = get_resampled_wcs(self.wcs, factor, True)
+        return self.__class__(wcs, npix, cdelt=cdelt,
+                              axes=copy.deepcopy(self.axes))
+
+    def upsample(self, factor):
+        npix = (self.npix[0] * factor, self.npix[1] * factor)
+        cdelt = (self._cdelt[0] / factor, self._cdelt[1] / factor)
+        wcs = get_resampled_wcs(self.wcs, factor, False)
+        return self.__class__(wcs, npix, cdelt=cdelt,
+                              axes=copy.deepcopy(self.axes))
 
     def to_slice(self, slices):
         raise NotImplementedError

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -278,7 +278,7 @@ class WcsGeom(MapGeom):
         # FIXME: Need to propagate refpix
 
         header = make_header(npix[0].flat[0], npix[1].flat[0],
-                             binsz[0].flat[0], xref, yref,
+                             binsz[0].flat[0], float(xref), float(yref),
                              proj, coordsys, refpix, refpix)
         wcs = WCS(header)
         return cls(wcs, npix, cdelt=binsz, axes=axes, conv=conv)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -231,11 +231,11 @@ class WcsNDMap(WcsMap):
         msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
         idx = [t[msk] for t in idx]
         if weights is not None:
-            weights = np.asarray(weights)
+            weights = np.asarray(weights, dtype=self.data.dtype)
             weights = weights[msk]
         idx = np.ravel_multi_index(idx, self.data.T.shape)
         idx, idx_inv = np.unique(idx, return_inverse=True)
-        weights = np.bincount(idx_inv, weights=weights)
+        weights = np.bincount(idx_inv, weights=weights).astype(self.data.dtype)
         self.data.T.flat[idx] += weights
 
     def set_by_idx(self, idx, vals):
@@ -265,7 +265,7 @@ class WcsNDMap(WcsMap):
             return copy.deepcopy(self)
 
         map_out = self.__class__(self.geom.to_image())
-        if self.geom.npix[0].size > 1:
+        if self.geom.is_regular:
             vals = self.get_by_idx(self.geom.get_idx())
             map_out.fill_by_coords(self.geom.get_coords()[:2], vals)
         else:

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -355,17 +355,77 @@ class WcsNDMap(WcsMap):
 
         return map_out
 
-    def pad(self, pad_width):
-        raise NotImplementedError
+    def pad(self, pad_width, mode='edge', cval=0):
+
+        if np.isscalar(pad_width):
+            pad_width = (pad_width, pad_width)
+            pad_width += (0,) * (self.geom.ndim - 2)
+
+        geom = self.geom.pad(pad_width[:2])
+        if self.geom.is_regular and mode != 'interp':
+            kw = {}
+            if mode == 'constant':
+                kw['constant_values'] = cval
+
+            pad_width = [(t, t) for t in pad_width]
+            data = np.pad(self.data, pad_width[::-1], mode, **kw)
+            map_out = self.__class__(geom, data)
+        else:
+            idx_in = self.geom.get_idx(flat=True)
+            idx_in = tuple([t + w for t, w in zip(idx_in, pad_width)])[::-1]
+            idx_out = geom.get_idx(flat=True)[::-1]
+            map_out = self.__class__(geom)
+
+            pad_msk = np.zeros_like(map_out.data, dtype=bool)
+            pad_msk[idx_out] = True
+            pad_msk[idx_in] = False
+            map_out.coadd(self)
+            if mode == 'constant':
+                map_out.data[pad_msk] = cval
+            else:
+                raise NotImplementedError
+
+        return map_out
 
     def crop(self, crop_width):
-        raise NotImplementedError
 
-    def upsample(self, factor):
-        raise NotImplementedError
+        if np.isscalar(crop_width):
+            crop_width = (crop_width, crop_width)
+        geom = self.geom.crop(crop_width)
+        if self.geom.is_regular:
+            slices = [slice(crop_width[0], int(self.geom.npix[0] - crop_width[0])),
+                      slice(crop_width[1], int(self.geom.npix[1] - crop_width[1]))]
+            for ax in self.geom.axes:
+                slices += [slice(None)]
+            data = self.data[slices[::-1]]
+            map_out = self.__class__(geom, data)
+        else:
+            # FIXME: This could be done more efficiently by
+            # constructing the appropriate slices for each image plane
+            map_out = self.__class__(geom)
+            map_out.coadd(self)
 
-    def downsample(self, factor):
-        raise NotImplementedError
+        return map_out
+
+    def upsample(self, factor, order=0, preserve_counts=True):
+        from scipy.ndimage import map_coordinates
+        geom = self.geom.upsample(factor)
+        idx = geom.get_idx()
+        pix = ((idx[0] - 0.5 * (factor - 1)) / factor,
+               (idx[1] - 0.5 * (factor - 1)) / factor,) + idx[2:]
+        data = map_coordinates(self.data.T, pix, order=order, mode='nearest')
+        if preserve_counts:
+            data /= factor**2
+        return self.__class__(geom, data)
+
+    def downsample(self, factor, preserve_counts=True):
+        from skimage.measure import block_reduce
+        geom = self.geom.downsample(factor)
+        block_size = tuple([factor, factor] + [1] * (self.geom.ndim - 2))
+        data = block_reduce(self.data, block_size[::-1], np.nansum)
+        if not preserve_counts:
+            data /= factor**2
+        return self.__class__(geom, data)
 
     def plot(self, ax=None, idx=None, **kwargs):
         """Quickplot method.


### PR DESCRIPTION
This PR implements some methods for `WcsGeom` and `WcsNDMap` that are inspired by methods of the same name in `SkyImage`:
* `crop`/`pad` : Decrease/increase the size of a geometry/map by the given number of pixels.
* `downsample`/`upsample` : Decrease/increase the resolution of a geometry/map by the given factor.

These methods operate only in the spatial dimension of the map.  We could consider extending the methods to operate on non-spatial dimensions but this is probably a less common use case.  Some parts of the current implementation are still missing -- namely support for all padding modes.  `pad` and `crop` are also restricted to be symmetric (i.e. the same number of pixels added on either side of the image).  

This PR also includes a new `coadd` method to `Map` which fills the contents of one map with another.  For maps with the same WCS or HPX projection this method can be used to stack counts maps together even if they have different pixel sizes.  Presently this method operates on the map in-place but we could also consider having it return a copy of the co-added map.

 