### PR TITLE
Replace links from NBViewer to local documentation folder

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -935,20 +935,8 @@ Link to a notebook in gammapy-extra from the docs
 Jupyter notebooks stored in ``gammpy-extra`` are copied to the ``notebooks`` folder
 during the process of Sphinx building documentation. They are converted to HTML files
 using `nb_sphinx <http://nbsphinx.readthedocs.io/>`__ Sphinx extension that provides
-a source parser for .ipynb files.
-
-From docstrings and high-level docs in Gammapy you can link to these *fixed-text*
-formatted versions of the notebooks providing its filename with .html file extension
-and the relative path to the ``notebooks`` folder. This folder is created at the root of the ``docs`` folder in the process of documentation building.
-
-Example: `First steps with Gammapy <../notebooks/first_steps.html>`__
-
-Sphinx directive to generate that link::
-
-    `First steps with Gammapy <../notebooks/first_steps.html>`__
-
-If you want to link to notebooks rendered on the external
-**NBViewer platform** you can use the ``gp-extra-notebook``
+a source parser for .ipynb files. From docstrings and high-level docs in Gammapy you
+can link to these *fixed-text* formatted versions using the ``gp-extra-notebook``
 Sphinx role providing **only the filename**.
 
 Example: :gp-extra-notebook:`image_analysis`
@@ -958,6 +946,15 @@ Sphinx directive to generate that link::
       :gp-extra-notebook:`image_analysis`
 
 More info on Sphinx roles is `here <http://www.sphinx-doc.org/en/stable/markup/inline.html>`__
+
+Alternatively you can also link to the notebooks providing its filename with .html file extension and the relative path to the ``notebooks`` folder. This folder is created at the root of the ``docs`` folder in the process of documentation building.
+
+Example: `First steps with Gammapy <../notebooks/first_steps.html>`__
+
+Sphinx directive to generate that link::
+
+    `First steps with Gammapy <../notebooks/first_steps.html>`__
+
 
 Include images from gammapy-extra into the docs
 -----------------------------------------------

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -65,13 +65,13 @@ class ExtraImage(Image):
 
 def notebook_role(name, rawtext, notebook, lineno, inliner, options={}, content=[]):
     """Link to a notebook on gammapy-extra"""
-    if HAS_GP_EXTRA:
-        available_notebooks = read_yaml('$GAMMAPY_EXTRA/notebooks/notebooks.yaml')
-        exists = notebook in [_['name'] for _ in available_notebooks]
-    else:
-        exists = True
 
-    if not exists:
+    # check if file exists in local notebooks folder
+    nbfolder = Path('notebooks')
+    nbfilename = notebook + '.ipynb'
+    nbfile = nbfolder / nbfilename
+
+    if not nbfile.is_file():
         msg = inliner.reporter.error(
             'Unknown notebook {}'.format(notebook),
             line=lineno,

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -79,15 +79,20 @@ def notebook_role(name, rawtext, notebook, lineno, inliner, options={}, content=
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]
     else:
+        refuri = inliner.document.settings._source
         app = inliner.document.settings.env.app
-        node = make_link_node(rawtext, app, notebook, options)
+        node = make_link_node(rawtext, app, refuri, notebook, options)
         return [node], []
 
 
-def make_link_node(rawtext, app, notebook, options):
+def make_link_node(rawtext, app, refuri, notebook, options):
     # base = 'https://github.com/gammapy/gammapy-extra/tree/master/notebooks/'
-    base = 'https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/notebooks/'
-    full_name = notebook + '.ipynb'
+    # base = 'https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/notebooks/'
+
+    relpath = refuri.split('gammapy/docs/')[1]
+    foldersplit = relpath.split('/')
+    base = '../' * (len(foldersplit) - 1) + 'notebooks/'
+    full_name = notebook + '.html'
     ref = base + full_name
     roles.set_classes(options)
     node = nodes.reference(rawtext, full_name, refuri=ref, **options)


### PR DESCRIPTION
This PR fixes issue #1283 
* Modif on definition of ``gp-extra-notebook``Sphinx role to make relative links to ``notebooks`` folder, instead of the old absolute links to NBViewer platform.
* Modif documentation accordingly.
* Check if pointed notebooks files are present in local ``notebooks`` folder.