### PR TITLE
Generalise instrument response classes

### DIFF
--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -12,5 +12,4 @@ from .psf_analytical import *
 from .psf_king import *
 from .energy_dispersion import *
 from .irf_stack import *
-
-from .instrument_response import InstrumentResponse
+from .instrument_response import *

--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -13,3 +13,4 @@ from .psf_king import *
 from .energy_dispersion import *
 from .irf_stack import *
 
+from .instrument_response import InstrumentResponse

--- a/gammapy/irf/instrument_response.py
+++ b/gammapy/irf/instrument_response.py
@@ -25,6 +25,7 @@ class InstrumentResponse(object):
     Examples
     -------
     Read and evaluate the effective area from a FITS file.
+    >>> from gammapy.irf import InstrumentResponse
     >>> irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
     >>> point = {'THETA': 3.5*u.deg, 'ENERG': 1*u.TeV}
     >>> interpolated_result = irf.evaluate(point)

--- a/gammapy/irf/instrument_response.py
+++ b/gammapy/irf/instrument_response.py
@@ -1,0 +1,131 @@
+from astropy.table import Table
+from gammapy.utils.nddata import BinnedDataAxis,  NDDataArray
+import numpy as np
+
+
+
+class InstrumentResponse(object):
+    '''
+    Class with an NDDataArray containing an instrument response.
+    ...
+
+    Attributes
+    ----------
+    names :  list of str
+        Names of the axes of the NDDataArray
+    data: NDDataArray
+        The data array containing the insturment response
+
+    Methods
+    -------
+    evaluate(point={'axis_name' : value})
+        Evaulate the data and fixed point
+
+
+    Examples
+    -------
+    Read and evaluate the effective area from a FITS file.
+    >>> irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
+    >>> point = {'THETA': 3.5*u.deg, 'ENERG': 1*u.TeV}
+    >>> interpolated_result = irf.evaluate(point)
+
+    '''
+
+    def __init__(self, axes, data):
+        self.data = NDDataArray(axes=axes, data=data)
+        self.names = [ax.name for ax in axes]
+
+    def evaluate(self, point):
+        '''
+        Evaluate the instrument response at the given point.
+
+        Parameters
+        -----------
+        point: a dict containing the coordinates where you want to evaluate the response
+
+        Returns
+        -----------
+        A number with an associated unit.
+
+
+        Examples
+        --------
+        Evaluate instrument response at a point
+
+        >>> point = {'DETX': 3.5*u.deg, 'DETY': 3.5*u.deg, 'ENERG': 1*u.TeV}
+        >>> irf.evaluate(point)
+
+        '''
+        return self.data.evaluate(**point)
+
+    @classmethod
+    def from_fits(cls, path, extension='EFFECTIVE AREA', names=None, interpolation_modes=None):
+        '''
+        Read the instrument respone froma fits file given.
+
+        Parameters
+        -----------
+        path: string
+            path to a fits file containing the instrument response
+
+        extension: string
+            name of the HDU in the fits file which contains the instrument response
+
+        names:list of strings
+            Per default the column names of the bintable in the FITS file are used for axis names.
+
+        interpolation_modes: list of strings
+            TODO: No clue what that does for an NDDataArray
+
+        Examples
+        -----------
+        >>> irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
+        '''
+        table = Table.read(path, hdu=extension)
+        return cls.from_table(table, names)
+
+
+    @classmethod
+    def from_table(cls, table, names=None, interpolation_modes=None):
+        '''
+        Read the instrument respone from an astropy table
+
+        Parameters
+        -----------
+        table: astropy.table.Table
+            the table contianing the instrument response
+
+        names:list of strings
+            Per default the column names of the table are used for axis names.
+
+        interpolation_modes: list of strings
+            TODO: No clue what that does for an NDDataArray
+
+        Examples
+        -----------
+        >>> table = Table.read(path)
+        >>> irf = InstrumentResponse.from_table(table)
+        '''
+        number_of_columns = len(table.colnames)
+
+        if not interpolation_modes:
+            interpolation_modes = ['linear', ] * (number_of_columns - 1)
+
+        # read table data that srores n-dimensional data in ogip convention
+        bounds = table.colnames[:-1]
+        low_bounds = bounds[::2]
+        high_bounds = bounds[1::2]
+
+        data = table[table.colnames[-1]].quantity[0].T
+
+        if not names:
+            names = [n.replace('_LO', '') for n in low_bounds]
+
+        axes = []
+        for colname_low, colname_high, name, mode in zip(low_bounds, high_bounds, names, interpolation_modes):
+            low = np.ravel(table[colname_low]).quantity
+            high = np.ravel(table[colname_high]).quantity
+
+            axes.append(BinnedDataAxis(low, high, interpolation_mode=mode, name=name))
+
+        return cls(axes=axes, data=data)

--- a/gammapy/irf/instrument_response.py
+++ b/gammapy/irf/instrument_response.py
@@ -118,6 +118,11 @@ class InstrumentResponse(object):
 
         data = table[table.colnames[-1]].quantity[0].T
 
+        # we need to check this unit specifically because ctools writes weird units into fits tables and astropy goes haywire
+        if data.unit == '1/s/MeV/sr':
+            import astropy.units as u
+            data = data.value * u.Unit('1/(s MeV sr)')
+
         if not names:
             names = [n.replace('_LO', '') for n in low_bounds]
 

--- a/gammapy/irf/instrument_response.py
+++ b/gammapy/irf/instrument_response.py
@@ -1,19 +1,23 @@
-from astropy.table import Table
-from gammapy.utils.nddata import BinnedDataAxis,  NDDataArray
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from astropy.table import Table
+from ..utils.scripts import make_path
+from ..utils.nddata import BinnedDataAxis, NDDataArray
 
+__all__ = [
+    'InstrumentResponse',
+]
 
 
 class InstrumentResponse(object):
-    '''
-    Class with an NDDataArray containing an instrument response.
-    ...
+    """Class with an NDDataArray containing an instrument response.
 
     Attributes
     ----------
     names :  list of str
         Names of the axes of the NDDataArray
-    data: NDDataArray
+    data : NDDataArray
         The data array containing the insturment response
 
     Methods
@@ -29,16 +33,29 @@ class InstrumentResponse(object):
     >>> irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
     >>> point = {'THETA': 3.5*u.deg, 'ENERG': 1*u.TeV}
     >>> interpolated_result = irf.evaluate(point)
+    """
+    names = None
+    interpolation_modes = None
 
-    '''
+    def __init__(self, data):
+        self._data = data
 
-    def __init__(self, axes, data):
-        self.data = NDDataArray(axes=axes, data=data)
-        self.names = [ax.name for ax in axes]
+    def __repr__(self):
+        return repr(self._data)
 
-    def evaluate(self, point):
-        '''
-        Evaluate the instrument response at the given point.
+    @classmethod
+    def make_class(cls, config):
+        class MyClass(cls):
+            pass
+
+        return MyClass
+
+    @property
+    def axis_names(self):
+        return self._data.axes.names
+
+    def evaluate(self, **kwargs):
+        """Evaluate the instrument response at the given point.
 
         Parameters
         -----------
@@ -48,90 +65,73 @@ class InstrumentResponse(object):
         -----------
         A number with an associated unit.
 
-
         Examples
         --------
         Evaluate instrument response at a point
 
         >>> point = {'DETX': 3.5*u.deg, 'DETY': 3.5*u.deg, 'ENERG': 1*u.TeV}
         >>> irf.evaluate(point)
-
-        '''
-        return self.data.evaluate(**point)
+        """
+        return self._data.evaluate(**kwargs)
 
     @classmethod
-    def from_fits(cls, path, extension='EFFECTIVE AREA', names=None, interpolation_modes=None):
-        '''
-        Read the instrument respone froma fits file given.
+    def read(cls, filename, hdu):
+        """Read from file."""
+        filename = make_path(filename)
+        table = Table.read(str(filename), hdu=hdu)
+        return cls.from_table(table)
+
+    @classmethod
+    def from_table(cls, table):
+        """
+        Read the instrument response from an astropy table
 
         Parameters
         -----------
-        path: string
-            path to a fits file containing the instrument response
-
-        extension: string
-            name of the HDU in the fits file which contains the instrument response
-
-        names:list of strings
-            Per default the column names of the bintable in the FITS file are used for axis names.
-
-        interpolation_modes: list of strings
-            TODO: No clue what that does for an NDDataArray
+        table : astropy.table.Table
+            the table containing the instrument response
 
         Examples
-        -----------
-        >>> irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
-        '''
-        table = Table.read(path, hdu=extension)
-        return cls.from_table(table, names)
-
-
-    @classmethod
-    def from_table(cls, table, names=None, interpolation_modes=None):
-        '''
-        Read the instrument respone from an astropy table
-
-        Parameters
-        -----------
-        table: astropy.table.Table
-            the table contianing the instrument response
-
-        names:list of strings
-            Per default the column names of the table are used for axis names.
-
-        interpolation_modes: list of strings
-            TODO: No clue what that does for an NDDataArray
-
-        Examples
-        -----------
+        --------
         >>> table = Table.read(path)
         >>> irf = InstrumentResponse.from_table(table)
-        '''
-        number_of_columns = len(table.colnames)
-
-        if not interpolation_modes:
-            interpolation_modes = ['linear', ] * (number_of_columns - 1)
-
-        # read table data that srores n-dimensional data in ogip convention
+        """
+        # read table data that stores n-dimensional data in ogip convention
         bounds = table.colnames[:-1]
         low_bounds = bounds[::2]
         high_bounds = bounds[1::2]
 
         data = table[table.colnames[-1]].quantity[0].T
 
-        # we need to check this unit specifically because ctools writes weird units into fits tables and astropy goes haywire
+        # we need to check this unit specifically because ctools writes weird units
+        # into fits tables and astropy goes haywire
         if data.unit == '1/s/MeV/sr':
             import astropy.units as u
             data = data.value * u.Unit('1/(s MeV sr)')
 
-        if not names:
+        if not cls.names:
             names = [n.replace('_LO', '') for n in low_bounds]
 
+        if not cls.interpolation_modes:
+            interpolation_modes = ['linear'] * len(names)
+
         axes = []
-        for colname_low, colname_high, name, mode in zip(low_bounds, high_bounds, names, interpolation_modes):
+        for colname_low, colname_high, name, mode in zip(low_bounds, high_bounds, cls.names, cls.interpolation_modes):
             low = np.ravel(table[colname_low]).quantity
             high = np.ravel(table[colname_high]).quantity
+            axis = BinnedDataAxis(low, high, interpolation_mode=mode, name=name)
+            axes.append(axis)
 
-            axes.append(BinnedDataAxis(low, high, interpolation_mode=mode, name=name))
+        return cls(NDDataArray(axes=axes, data=data))
 
-        return cls(axes=axes, data=data)
+
+class Background3D(InstrumentResponse):
+    """Background 3D IRF.
+
+    Data format specification: :ref:`gadf:bkg_3d`
+
+    This is a prototype, let's see if it can replace
+    `gammapy.irf.background.Background3D`
+    """
+    names = ['detx', 'dety', 'energy']
+    interpolation_modes = ['linear', 'linear', 'log']

--- a/gammapy/irf/tests/test_instrument_response.py
+++ b/gammapy/irf/tests/test_instrument_response.py
@@ -1,0 +1,42 @@
+from ...irf.instrument_response import InstrumentResponse
+from astropy.utils.data import get_pkg_data_filename
+import astropy.units as u
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
+def test_reading_fits(path):
+    path = get_pkg_data_filename(path)
+    irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
+    assert len(irf.names) > 0
+
+@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
+def test_reading_aeff(path):
+    path = get_pkg_data_filename(path)
+    irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
+
+    assert 'ENERG' in irf.names
+    assert 'THETA' in irf.names
+
+    point = {'THETA': 3.5*u.deg, 'ENERG': 1*u.TeV}
+
+    interpolated_result = irf.evaluate(point)
+    assert not np.isnan(interpolated_result)
+
+    assert interpolated_result.si.unit == u.m**2
+
+
+@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
+def test_reading_edisp(path):
+    path = get_pkg_data_filename(path)
+    irf = InstrumentResponse.from_fits(path, extension='ENERGY DISPERSION')
+
+    assert 'ETRUE' in irf.names
+    assert 'THETA' in irf.names
+    assert 'MIGRA' in irf.names
+
+    point = {'THETA': 3.5*u.deg, 'ETRUE': 1*u.TeV, 'MIGRA': 2}
+
+    interpolated_result = irf.evaluate(point)
+    assert not np.isnan(interpolated_result)

--- a/gammapy/irf/tests/test_instrument_response.py
+++ b/gammapy/irf/tests/test_instrument_response.py
@@ -1,58 +1,65 @@
-from ...irf.instrument_response import InstrumentResponse
-from astropy.utils.data import get_pkg_data_filename
-import astropy.units as u
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-import pytest
+from numpy.testing import assert_allclose
+import astropy.units as u
+from ..instrument_response import InstrumentResponse, Background3D
 
 
-@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
-def test_reading_fits(path):
-    path = get_pkg_data_filename(path)
-    irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
-    assert len(irf.names) > 0
+def test_reading_aeff():
+    path = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+    irf = InstrumentResponse.read(path, hdu='EFFECTIVE AREA')
 
-@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
-def test_reading_aeff(path):
-    path = get_pkg_data_filename(path)
-    irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
+    assert irf.names == ['energy', 'theta']
 
-    assert 'ENERG' in irf.names
-    assert 'THETA' in irf.names
-
-    point = {'THETA': 3.5*u.deg, 'ENERG': 1*u.TeV}
+    point = {'theta': 3.5 * u.deg, 'energy': 1 * u.TeV}
 
     interpolated_result = irf.evaluate(point)
     assert not np.isnan(interpolated_result)
 
-    assert interpolated_result.si.unit == u.m**2
+    assert interpolated_result.si.unit == u.m ** 2
 
 
-@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
-def test_reading_edisp(path):
-    path = get_pkg_data_filename(path)
-    irf = InstrumentResponse.from_fits(path, extension='ENERGY DISPERSION')
+def test_reading_edisp():
+    path = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+    irf = InstrumentResponse.read(path, hdu='ENERGY DISPERSION')
 
     assert 'ETRUE' in irf.names
     assert 'THETA' in irf.names
     assert 'MIGRA' in irf.names
 
-    point = {'THETA': 3.5*u.deg, 'ETRUE': 1*u.TeV, 'MIGRA': 2}
+    point = {'THETA': 3.5 * u.deg, 'ETRUE': 1 * u.TeV, 'MIGRA': 2}
 
     interpolated_result = irf.evaluate(point)
     assert not np.isnan(interpolated_result)
 
 
-@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
-def test_reading_background(path):
-    path = get_pkg_data_filename(path)
-    irf = InstrumentResponse.from_fits(path, extension='BACKGROUND')
+def test_reading_background():
+    path = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+    irf = InstrumentResponse.read(path, hdu='BACKGROUND')
 
     assert 'DETX' in irf.names
     assert 'DETY' in irf.names
     assert 'ENERG' in irf.names
 
-    point = {'DETX': 3.5*u.deg, 'DETY': 3.5*u.deg, 'ENERG': 1*u.TeV,}
+    point = {'DETX': 3.5 * u.deg, 'DETY': 3.5 * u.deg, 'ENERG': 1 * u.TeV, }
 
     interpolated_result = irf.evaluate(point)
     assert not np.isnan(interpolated_result)
     assert interpolated_result.unit == u.Unit('1/(MeV * sr * s)')
+
+
+def test_reading_background_with_subclass():
+    path = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+    irf = Background3D.read(path, hdu='BACKGROUND')
+    assert irf.names == ['detx', 'dety', 'energy']
+
+    point = {'detx': 3.5 * u.deg, 'dety': 3.5 * u.deg, 'energy': 1 * u.TeV, }
+
+    interpolated_result = irf.evaluate(**point)
+    assert not np.isnan(interpolated_result)
+    assert interpolated_result.unit == u.Unit('1/(MeV * sr * s)')
+
+    bkg_rate = irf.evaluate(energy='1 TeV', detx='0.2 deg', dety='0.5 deg')
+    assert_allclose(bkg_rate.value, 0.00013352689711418575)
+    assert bkg_rate.unit == u.Unit('s-1 MeV-1 sr-1')

--- a/gammapy/irf/tests/test_instrument_response.py
+++ b/gammapy/irf/tests/test_instrument_response.py
@@ -40,3 +40,19 @@ def test_reading_edisp(path):
 
     interpolated_result = irf.evaluate(point)
     assert not np.isnan(interpolated_result)
+
+
+@pytest.mark.parametrize('path', ['data/1dc_irf.fits', 'data/prod3b_irf.fits'])
+def test_reading_background(path):
+    path = get_pkg_data_filename(path)
+    irf = InstrumentResponse.from_fits(path, extension='BACKGROUND')
+
+    assert 'DETX' in irf.names
+    assert 'DETY' in irf.names
+    assert 'ENERG' in irf.names
+
+    point = {'DETX': 3.5*u.deg, 'DETY': 3.5*u.deg, 'ENERG': 1*u.TeV,}
+
+    interpolated_result = irf.evaluate(point)
+    assert not np.isnan(interpolated_result)
+    assert interpolated_result.unit == u.Unit('1/(MeV * sr * s)')

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -58,6 +58,9 @@ class NDDataArray(object):
         ss += array_stats_str(self.data, 'Data')
         return ss
 
+    def __repr__(self):
+        return str(self)
+
     @property
     def axes(self):
         """Array holding the axes in correct order"""
@@ -364,7 +367,7 @@ class BinnedDataAxis(DataAxis):
         Upper bin edges
     name : str, optional
         Axis name, default: 'Default'
-    interpolation_mode : str {'linear', 'log'}
+    interpolation_mode : {'linear', 'log'}
         Interpolation behaviour, default: 'linear'
     """
 


### PR DESCRIPTION
This replaces all the code in the irf subpackage except for the PSF related stuff. 
Use like this.
```
from gammapy.irf import InstrumentResponse
irf = InstrumentResponse.from_fits(path, extension='EFFECTIVE AREA')
point = {'THETA': 3.5*u.deg, 'ENERG': 1*u.TeV}
interpolated_result = irf.evaluate(point)
```