### PR TITLE
Add meta maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -130,13 +130,16 @@ class Map(object):
             Map object
         """
         with fits.open(filename) as hdulist:
-            if map_type == 'auto':
-                map_type = cls._get_map_type(hdulist, hdu)
+            map_out = cls.from_hdu_list(hdulist, hdu, hdu_bands, map_type)
 
-            cls_out = cls._get_map_cls(map_type)
-            map_out = cls_out.from_hdulist(hdulist, hdu=hdu,
-                                           hdu_bands=hdu_bands)
+        return map_out
 
+    @classmethod
+    def from_hdu_list(cls, hdulist, hdu=None, hdu_bands=None, map_type='auto'):
+        if map_type == 'auto':
+            map_type = cls._get_map_type(hdulist, hdu)
+        cls_out = cls._get_map_cls(map_type)
+        map_out = cls_out.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands)
         return map_out
 
     @staticmethod

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
+import json
 import numpy as np
 from collections import OrderedDict
 from ..extern import six
@@ -86,6 +87,8 @@ class Map(object):
             Data type, default is ``float32``
         unit : str or `~astropy.units.Unit`
             Data unit.
+        meta : `~collections.OrderedDict`
+            Dictionary to store meta data.
 
         Returns
         -------
@@ -141,6 +144,15 @@ class Map(object):
         cls_out = cls._get_map_cls(map_type)
         map_out = cls_out.from_hdulist(hdulist, hdu=hdu, hdu_bands=hdu_bands)
         return map_out
+
+    @staticmethod
+    def _get_meta_from_header(header):
+        """Load meta data from a FITS header."""
+        if 'META' in header:
+            meta = json.loads(header['META'], object_pairs_hook=OrderedDict)
+        else:
+            meta = {}
+        return meta
 
     @staticmethod
     def _get_map_type(hdu_list, hdu_name):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
 import numpy as np
+from collections import OrderedDict
 from ..extern import six
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
@@ -29,11 +30,17 @@ class Map(object):
         Geometry
     data : `~numpy.ndarray`
         Data array
+    meta : `~collections.OrderedDict`
+        Dictionary to store meta data.
     """
 
-    def __init__(self, geom, data):
+    def __init__(self, geom, data, meta=None):
         self._geom = geom
         self._data = data
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
 
     @property
     def data(self):
@@ -203,6 +210,8 @@ class Map(object):
             This option is only compatible with the 'gadf' format.
         """
         hdulist = self.to_hdulist(**kwargs)
+        header=hdulist[0].header
+        header.update(self.meta)
         overwrite = kwargs.get('overwrite', True)
         hdulist.writeto(filename, overwrite=overwrite)
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -96,7 +96,6 @@ class Map(object):
         from .wcsmap import WcsMap
 
         map_type = kwargs.setdefault('map_type', 'wcs')
-
         if 'wcs' in map_type.lower():
             return WcsMap.create(**kwargs)
         elif 'hpx' in map_type.lower():
@@ -210,8 +209,6 @@ class Map(object):
             This option is only compatible with the 'gadf' format.
         """
         hdulist = self.to_hdulist(**kwargs)
-        header=hdulist[0].header
-        header.update(self.meta)
         overwrite = kwargs.get('overwrite', True)
         hdulist.writeto(filename, overwrite=overwrite)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -265,7 +265,6 @@ def pix_to_coord(edges, pix, interp='lin'):
     """Convert pixel coordinates to grid coordinates using the chosen
     interpolation scheme."""
     from scipy.interpolate import interp1d
-
     if interp == 'log':
         fn0 = np.log
         fn1 = np.exp

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
+import json
 import numpy as np
-from collections import OrderedDict
 from astropy.io import fits
 from .base import Map
 from .hpx import HpxGeom, HpxConv
@@ -121,13 +121,11 @@ class HpxMap(Map):
         # extname_bands = kwargs.get('extname_bands', self.geom.conv.bands_hdu)
         extname_bands = kwargs.get('extname_bands', 'BANDS')
         hdu = self.make_hdu(**kwargs)
-        header = hdu.header
-        header.update(self.meta)
+        hdu.header['META'] = json.dumps(self.meta)
         hdulist = [fits.PrimaryHDU(), hdu]
 
         if self.geom.axes:
             hdulist += [self.geom.make_bands_hdu(extname=extname_bands)]
-
 
         return fits.HDUList(hdulist)
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -120,13 +120,15 @@ class HpxMap(Map):
         extname = kwargs.get('extname', 'SKYMAP')
         # extname_bands = kwargs.get('extname_bands', self.geom.conv.bands_hdu)
         extname_bands = kwargs.get('extname_bands', 'BANDS')
-        hdulist = [fits.PrimaryHDU(), self.make_hdu(**kwargs)]
+        hdu = self.make_hdu(**kwargs)
+        header = hdu.header
+        header.update(self.meta)
+        hdulist = [fits.PrimaryHDU(), hdu]
 
         if self.geom.axes:
             hdulist += [self.geom.make_bands_hdu(extname=extname_bands)]
 
-        header = hdulist[0].header
-        header.update(self.meta)
+
         return fits.HDUList(hdulist)
 
     @abc.abstractmethod

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -65,6 +65,13 @@ class HpxMap(Map):
         conv : str, optional
             FITS format convention ('fgst-ccube', 'fgst-template',
             'gadf').  Default is 'gadf'.
+        meta : `~collections.OrderedDict`
+            Dictionary to store meta data.
+
+        Returns
+        -------
+        map : `~HpxMap`
+            A HPX map object.
         """
         from .hpxnd import HpxNDMap
         from .hpxsparse import HpxSparseMap
@@ -200,7 +207,7 @@ class HpxMap(Map):
         extname_bands = kwargs.get('extname_bands', conv.bands_hdu)
 
         sparse = kwargs.get('sparse', True if isinstance(self, HpxSparseMap)
-        else False)
+                            else False)
         header = self.geom.make_header()
 
         if self.geom.axes:

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -23,7 +23,7 @@ class HpxMap(Map):
         Data array.
     """
 
-    def __init__(self, geom, data):
+    def __init__(self, geom, data, meta=None):
         super(HpxMap, self).__init__(geom, data)
         self._wcs2d = None
         self._hpx2wcs = None
@@ -79,6 +79,10 @@ class HpxMap(Map):
             return HpxSparseMap(hpx, dtype=dtype)
         else:
             raise ValueError('Unrecognized map type: {}'.format(map_type))
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):
@@ -121,6 +125,9 @@ class HpxMap(Map):
 
         if self.geom.axes:
             hdulist += [self.geom.make_bands_hdu(extname=extname_bands)]
+
+        header=hdulist[0].header
+        header.update(self.meta)
         return fits.HDUList(hdulist)
 
     @abc.abstractmethod

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
+from collections import OrderedDict
 from .utils import unpack_seq
 from .geom import MapCoords, pix_tuple_to_idx, coord_to_idx
 from .hpxmap import HpxMap
@@ -28,9 +29,11 @@ class HpxNDMap(HpxMap):
     data : `~numpy.ndarray`
         HEALPIX data array.
         If none then an empty array will be allocated.
+    meta : `~collections.OrderedDict`
+        Dictionary to store meta data.
     """
 
-    def __init__(self, geom, data=None, dtype='float32'):
+    def __init__(self, geom, data=None, dtype='float32', meta=None):
 
         shape = tuple([np.max(geom.npix)] + [ax.nbin for ax in geom.axes])
         if data is None:
@@ -45,8 +48,12 @@ class HpxNDMap(HpxMap):
         elif data.shape != shape[::-1]:
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
 
-        super(HpxNDMap, self).__init__(geom, data)
+        super(HpxNDMap, self).__init__(geom, data, self.meta)
         self._wcs2d = None
         self._hpx2wcs = None
 
@@ -66,8 +73,7 @@ class HpxNDMap(HpxMap):
         shape_data = shape + tuple([np.max(hpx.npix)])
 
         # TODO: Should we support extracting slices?
-
-        map_out = cls(hpx)
+        map_out = cls(hpx, meta=hdu.header)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -73,7 +73,7 @@ class HpxNDMap(HpxMap):
         shape_data = shape + tuple([np.max(hpx.npix)])
 
         # TODO: Should we support extracting slices?
-        map_out = cls(hpx, meta=hdu.header)
+        map_out = cls(hpx)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -70,14 +70,8 @@ class HpxNDMap(HpxMap):
 
         # TODO: Should we support extracting slices?
 
-        # TODO: implement map META read support
-        # probably should introduce a method in the base class
-        # and call it via super, no?
-        if 'META' in hdu.header:
-            meta = json.load(hdu.header['META'])
-        else:
-            meta = {}
-        map_out = cls(hpx, None, meta)
+        meta = cls._get_meta_from_header(hdu.header)
+        map_out = cls(hpx, None, meta=meta)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import json
 import numpy as np
 from astropy.io import fits
-from collections import OrderedDict
 from .utils import unpack_seq
 from .geom import MapCoords, pix_tuple_to_idx, coord_to_idx
 from .hpxmap import HpxMap
@@ -69,7 +69,15 @@ class HpxNDMap(HpxMap):
         shape_data = shape + tuple([np.max(hpx.npix)])
 
         # TODO: Should we support extracting slices?
-        map_out = cls(hpx)
+
+        # TODO: implement map META read support
+        # probably should introduce a method in the base class
+        # and call it via super, no?
+        if 'META' in hdu.header:
+            meta = json.load(hdu.header['META'])
+        else:
+            meta = {}
+        map_out = cls(hpx, None, meta)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -48,12 +48,8 @@ class HpxNDMap(HpxMap):
         elif data.shape != shape[::-1]:
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
-        if meta is None:
-            self.meta = OrderedDict()
-        else:
-            self.meta = OrderedDict(meta)
 
-        super(HpxNDMap, self).__init__(geom, data, self.meta)
+        super(HpxNDMap, self).__init__(geom, data, meta)
         self._wcs2d = None
         self._hpx2wcs = None
 

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -36,12 +36,7 @@ class HpxSparseMap(HpxMap):
         elif isinstance(data, np.ndarray):
             data = SparseArray.from_array(data)
 
-        if meta is None:
-            self.meta = OrderedDict()
-        else:
-            self.meta = OrderedDict(meta)
-
-        super(HpxSparseMap, self).__init__(geom, data, self.meta)
+        super(HpxSparseMap, self).__init__(geom, data, meta)
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
+from collections import OrderedDict
 from .sparse import SparseArray
 from .geom import pix_tuple_to_idx
 from .hpxmap import HpxMap
@@ -24,16 +25,23 @@ class HpxSparseMap(HpxMap):
         HEALPIX geometry object.
     data : `~numpy.ndarray`
         HEALPIX data array.
+    meta : `~collections.OrderedDict`
+        Dictionary to store meta data.
     """
 
-    def __init__(self, geom, data=None, dtype='float32'):
+    def __init__(self, geom, data=None, dtype='float32', meta=None):
         if data is None:
             shape = tuple([np.max(geom.npix)] + [ax.nbin for ax in geom.axes])
             data = SparseArray(shape[::-1], dtype=dtype)
         elif isinstance(data, np.ndarray):
             data = SparseArray.from_array(data)
 
-        super(HpxSparseMap, self).__init__(geom, data)
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
+
+        super(HpxSparseMap, self).__init__(geom, data, self.meta)
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):
@@ -52,7 +60,7 @@ class HpxSparseMap(HpxMap):
 
         # TODO: Should we support extracting slices?
 
-        map_out = cls(hpx)
+        map_out = cls(hpx, meta=hdu.header)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -60,7 +60,7 @@ class HpxSparseMap(HpxMap):
 
         # TODO: Should we support extracting slices?
 
-        map_out = cls(hpx, meta=hdu.header)
+        map_out = cls(hpx)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -54,8 +54,8 @@ class HpxSparseMap(HpxMap):
         shape_data = shape + tuple([np.max(hpx.npix)])
 
         # TODO: Should we support extracting slices?
-
-        map_out = cls(hpx)
+        meta = cls._get_meta_from_header(hdu.header)
+        map_out = cls(hpx, meta=meta)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -11,35 +11,11 @@ pytest.importorskip('healpy')
 pytest.importorskip('numpy', '1.12.0')
 
 
-def make_test_map(map_type, meta):
-    """
-    Make empty maps
-
-    Parameters
-    ----------
-    map_type: str
-        Define wcs or hpx
-    meta : `~collections.OrderedDict`
-        Dictionary to store meta data.
-
-    Returns
-    -------
-    m: `~gammapy.maps.Map`
-
-    """
-    map_axes = [
-        MapAxis.from_bounds(1.0, 10.0, 3, interp='log'),
-        MapAxis.from_bounds(0.1, 1.0, 4, interp='log'),
-    ]
-    m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
-                   skydir=SkyCoord(0.0, 30.0, unit='deg'), axes=map_axes, meta=meta)
-    return m
-
-
 map_axes = [
     MapAxis.from_bounds(1.0, 10.0, 3, interp='log'),
     MapAxis.from_bounds(0.1, 1.0, 4, interp='log'),
 ]
+
 
 mapbase_args = [
     (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), None),
@@ -65,7 +41,8 @@ def test_map_meta_read_write(map_type):
         ('user', 'test'),
     ])
 
-    m = make_test_map(map_type=map_type, meta=meta)
+    m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
+                   skydir=SkyCoord(0.0, 30.0, unit='deg'), meta=meta)
 
     hdulist = m.to_hdulist(extname='COUNTS')
     header = hdulist['COUNTS'].header

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -60,18 +60,17 @@ def test_mapbase_create(binsz, width, map_type, skydir, axes):
 
 def test_write():
     meta = OrderedDict()
-    meta["name"] = "counts"
+    meta["user"] = "test"
     m_wcs = make_test_map(map_type="wcs", meta=meta)
     m_hpx = make_test_map(map_type="hpx", meta=meta)
     m_hpx_sparse = make_test_map(map_type="hpx-sparse", meta=meta)
-    hdulist_wcs = m_wcs.to_hdulist()
-    hdulist_hpx = m_hpx.to_hdulist()
-    hdulist_hpx_sparse = m_hpx_sparse.to_hdulist()
-    header_wcs = hdulist_wcs[0].header
-    header_hpx = hdulist_hpx[0].header
-    header_hpx_sparse = hdulist_hpx_sparse[0].header
-    assert "name" in header_wcs
-    assert "name" in header_hpx
-    assert "name" in header_hpx_sparse
-    
+    hdulist_wcs = m_wcs.to_hdulist(extname='COUNTS')
+    hdulist_hpx = m_hpx.to_hdulist(extname='COUNTS')
+    hdulist_hpx_sparse = m_hpx_sparse.to_hdulist(extname='COUNTS')
+    header_wcs = hdulist_wcs['COUNTS'].header
+    header_hpx = hdulist_hpx['COUNTS'].header
+    header_hpx_sparse = hdulist_hpx_sparse['COUNTS'].header
+    assert "user" in header_wcs
+    assert "user" in header_hpx
+    assert "user" in header_hpx_sparse
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -2,11 +2,38 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from astropy.coordinates import SkyCoord
+from collections import OrderedDict
 from ..base import Map
 from ..geom import MapAxis
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
+
+
+def make_test_map(map_type, meta):
+    """
+    Make empty maps
+
+    Parameters
+    ----------
+    map_type: str
+        Define wcs or hpx
+    meta : `~collections.OrderedDict`
+        Dictionary to store meta data.
+
+    Returns
+    -------
+    m: `~gammapy.maps.Map`
+
+    """
+    map_axes = [
+        MapAxis.from_bounds(1.0, 10.0, 3, interp='log'),
+        MapAxis.from_bounds(0.1, 1.0, 4, interp='log'),
+    ]
+    m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
+                   skydir=SkyCoord(0.0, 30.0, unit='deg'), axes=map_axes, meta=meta)
+    return m
+
 
 map_axes = [
     MapAxis.from_bounds(1.0, 10.0, 3, interp='log'),
@@ -29,3 +56,22 @@ mapbase_args = [
 def test_mapbase_create(binsz, width, map_type, skydir, axes):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes)
+
+
+def test_write():
+    meta = OrderedDict()
+    meta["name"] = "counts"
+    m_wcs = make_test_map(map_type="wcs", meta=meta)
+    m_hpx = make_test_map(map_type="hpx", meta=meta)
+    m_hpx_sparse = make_test_map(map_type="hpx-sparse", meta=meta)
+    hdulist_wcs = m_wcs.to_hdulist()
+    hdulist_hpx = m_hpx.to_hdulist()
+    hdulist_hpx_sparse = m_hpx_sparse.to_hdulist()
+    header_wcs = hdulist_wcs[0].header
+    header_hpx = hdulist_hpx[0].header
+    header_hpx_sparse = hdulist_hpx_sparse[0].header
+    assert "name" in header_wcs
+    assert "name" in header_hpx
+    assert "name" in header_hpx_sparse
+    
+

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -58,19 +58,18 @@ def test_mapbase_create(binsz, width, map_type, skydir, axes):
                    skydir=skydir, axes=axes)
 
 
-def test_write():
-    meta = OrderedDict()
-    meta["user"] = "test"
-    m_wcs = make_test_map(map_type="wcs", meta=meta)
-    m_hpx = make_test_map(map_type="hpx", meta=meta)
-    m_hpx_sparse = make_test_map(map_type="hpx-sparse", meta=meta)
-    hdulist_wcs = m_wcs.to_hdulist(extname='COUNTS')
-    hdulist_hpx = m_hpx.to_hdulist(extname='COUNTS')
-    hdulist_hpx_sparse = m_hpx_sparse.to_hdulist(extname='COUNTS')
-    header_wcs = hdulist_wcs['COUNTS'].header
-    header_hpx = hdulist_hpx['COUNTS'].header
-    header_hpx_sparse = hdulist_hpx_sparse['COUNTS'].header
-    assert "user" in header_wcs
-    assert "user" in header_hpx
-    assert "user" in header_hpx_sparse
+@pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])
+def test_map_meta_read_write(map_type):
+    meta = OrderedDict([
+        ('user', 'test'),
+    ])
 
+    m = make_test_map(map_type=map_type, meta=meta)
+
+    hdulist = m.to_hdulist(extname='COUNTS')
+    header = hdulist['COUNTS'].header
+
+    assert header['META'] == '{"user": "test"}'
+
+    m2 = Map.from_hdu_list(hdulist)
+    assert m2.meta == meta

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -8,6 +8,7 @@ from ..geom import MapAxis
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
+pytest.importorskip('numpy', '1.12.0')
 
 
 def make_test_map(map_type, meta):

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -11,7 +11,7 @@ from ..hpx import get_hpxregion_dir, get_hpxregion_size
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
-pytest.importorskip('numpy', '1.12.0')
+pytest.importorskip('numpy', '1.13.0')
 
 hpx_allsky_test_geoms = [
     # 2D All-sky

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -147,18 +147,16 @@ class WcsMap(Map):
         hdu = self.make_hdu(extname=extname, extname_bands=extname_bands,
                             sparse=sparse, conv=conv)
 
+        header = hdu.header
+        header.update(self.meta)
         if extname == 'PRIMARY':
             hdulist = [hdu]
         else:
             hdulist = [fits.PrimaryHDU(), hdu]
 
-        header = hdulist[0].header
-        header.update(self.meta)
         if self.geom.axes:
             hdulist += [bands_hdu]
 
-        header = hdulist[0].header
-        header.update(self.meta)
 
         return fits.HDUList(hdulist)
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -25,7 +25,7 @@ class WcsMap(Map):
     @classmethod
     def create(cls, map_type='wcs', npix=None, binsz=0.1, width=None,
                proj='CAR', coordsys='CEL', refpix=None,
-               axes=None, skydir=None, dtype='float32', conv='gadf'):
+               axes=None, skydir=None, dtype='float32', conv='gadf', meta=None):
         """Factory method to create an empty WCS map.
 
         Parameters
@@ -87,6 +87,10 @@ class WcsMap(Map):
             raise NotImplementedError
         else:
             raise ValueError('Unrecognized map type: {}'.format(map_type))
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):
@@ -149,6 +153,8 @@ class WcsMap(Map):
         else:
             hdulist = [fits.PrimaryHDU(), hdu]
 
+        header=hdulist[0].header
+        header.update(self.meta)
         if self.geom.axes:
             hdulist += [bands_hdu]
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
+from collections import OrderedDict
 from .base import Map
 from .wcs import WcsGeom
 from .utils import find_hdu, find_bands_hdu
@@ -67,6 +68,8 @@ class WcsMap(Map):
         conv : str, optional
             FITS format convention ('fgst-ccube', 'fgst-template',
             'gadf').  Default is 'gadf'.
+        meta : `~collections.OrderedDict`
+            Dictionary to store meta data.
 
         Returns
         -------
@@ -82,15 +85,11 @@ class WcsMap(Map):
                               conv=conv)
 
         if map_type == 'wcs':
-            return WcsNDMap(geom, dtype=dtype)
+            return WcsNDMap(geom, dtype=dtype, meta=meta)
         elif map_type == 'wcs-sparse':
             raise NotImplementedError
         else:
             raise ValueError('Unrecognized map type: {}'.format(map_type))
-        if meta is None:
-            self.meta = OrderedDict()
-        else:
-            self.meta = OrderedDict(meta)
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):
@@ -153,10 +152,13 @@ class WcsMap(Map):
         else:
             hdulist = [fits.PrimaryHDU(), hdu]
 
-        header=hdulist[0].header
+        header = hdulist[0].header
         header.update(self.meta)
         if self.geom.axes:
             hdulist += [bands_hdu]
+
+        header = hdulist[0].header
+        header.update(self.meta)
 
         return fits.HDUList(hdulist)
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import json
 import numpy as np
 from astropy.io import fits
-from collections import OrderedDict
 from .base import Map
 from .wcs import WcsGeom
 from .utils import find_hdu, find_bands_hdu
@@ -147,8 +147,8 @@ class WcsMap(Map):
         hdu = self.make_hdu(extname=extname, extname_bands=extname_bands,
                             sparse=sparse, conv=conv)
 
-        header = hdu.header
-        header.update(self.meta)
+        hdu.header['META'] = json.dumps(self.meta)
+
         if extname == 'PRIMARY':
             hdulist = [hdu]
         else:
@@ -156,7 +156,6 @@ class WcsMap(Map):
 
         if self.geom.axes:
             hdulist += [bands_hdu]
-
 
         return fits.HDUList(hdulist)
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -101,7 +101,8 @@ class WcsNDMap(WcsMap):
         shape_wcs = tuple([np.max(geom.npix[0]),
                            np.max(geom.npix[1])])
         shape_data = shape_wcs + shape
-        map_out = cls(geom)
+        meta = cls._get_meta_from_header(hdu.header)
+        map_out = cls(geom, meta=meta)
 
         # TODO: Should we support extracting slices?
         if isinstance(hdu, fits.BinTableHDU):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -105,7 +105,7 @@ class WcsNDMap(WcsMap):
         shape_wcs = tuple([np.max(geom.npix[0]),
                            np.max(geom.npix[1])])
         shape_data = shape_wcs + shape
-        map_out = cls(geom, meta=hdu.header)
+        map_out = cls(geom)
 
         # TODO: Should we support extracting slices?
         if isinstance(hdu, fits.BinTableHDU):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import numpy as np
 from astropy.io import fits
+from collections import OrderedDict
 from .utils import unpack_seq
 from .geom import pix_tuple_to_idx, axes_pix_to_coord
 from .utils import interp_to_order
@@ -31,9 +32,11 @@ class WcsNDMap(WcsMap):
         Data array. If none then an empty array will be allocated.
     dtype : str, optional
         Data type, default is float32
+    meta : `~collections.OrderedDict`
+        Dictionary to store meta data.
     """
 
-    def __init__(self, geom, data=None, dtype='float32'):
+    def __init__(self, geom, data=None, dtype='float32', meta=None):
         # TODO: Figure out how to mask pixels for integer data types
 
         shape = tuple([np.max(geom.npix[0]), np.max(geom.npix[1])] +
@@ -43,8 +46,12 @@ class WcsNDMap(WcsMap):
         elif data.shape != shape[::-1]:
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
+        if meta is None:
+            self.meta = OrderedDict()
+        else:
+            self.meta = OrderedDict(meta)
 
-        super(WcsNDMap, self).__init__(geom, data)
+        super(WcsNDMap, self).__init__(geom, data, self.meta)
 
     def _init_data(self, geom, shape, dtype):
         # Check whether corners of each image plane are valid
@@ -98,7 +105,7 @@ class WcsNDMap(WcsMap):
         shape_wcs = tuple([np.max(geom.npix[0]),
                            np.max(geom.npix[1])])
         shape_data = shape_wcs + shape
-        map_out = cls(geom)
+        map_out = cls(geom, meta=hdu.header)
 
         # TODO: Should we support extracting slices?
         if isinstance(hdu, fits.BinTableHDU):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -46,12 +46,8 @@ class WcsNDMap(WcsMap):
         elif data.shape != shape[::-1]:
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape, data.shape))
-        if meta is None:
-            self.meta = OrderedDict()
-        else:
-            self.meta = OrderedDict(meta)
 
-        super(WcsNDMap, self).__init__(geom, data, self.meta)
+        super(WcsNDMap, self).__init__(geom, data, meta)
 
     def _init_data(self, geom, shape, dtype):
         # Check whether corners of each image plane are valid


### PR DESCRIPTION
Add meta attribut to the Map class.
For the moment I only added the possibilty to write the meta attribut.
For the read options, it's a little more complicated because for example you don't want just read the header and put it as the meta attribut since the header could contain the wcs info that is already present in the MAP object.