### PR TITLE
Improve utility methods for HPX maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -335,7 +335,7 @@ class Map(object):
             return self._reproject_wcs(geom, mode=mode, order=order)
 
     @abc.abstractmethod
-    def pad(self, pad_width, mode='edge', cval=0, order=1):
+    def pad(self, pad_width, mode='constant', cval=0, order=1):
         """Pad the spatial dimension of the map by extending the edge of the
         map by the given number of pixels.
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -287,8 +287,8 @@ class Map(object):
         pass
 
     def coadd(self, map_in):
-        """Fill this map with the contents of another map.  This method can be
-        used to sum maps containing integral quantities (e.g. counts)
+        """Add the contents of ``map_in`` to this map.  This method can be
+        used to combine maps containing integral quantities (e.g. counts)
         or differential quantities if the maps have the same binning.
 
         Parameters

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -335,20 +335,23 @@ class Map(object):
             return self._reproject_wcs(geom, mode=mode, order=order)
 
     @abc.abstractmethod
-    def pad(self, pad_width, mode='edge', cval=0):
+    def pad(self, pad_width, mode='edge', cval=0, order=1):
         """Pad the spatial dimension of the map by extending the edge of the
         map by the given number of pixels.
 
         Parameters
         ----------
         pad_width : {sequence, array_like, int}
-            Number of values padded to the edges of each axis, passed to `numpy.pad`
+            Number of pixels padded to the edges of each axis.
         mode : {'edge', 'constant', 'interp'}
             Padding mode.  'edge' pads with the closest edge value.
             'constant' pads with a constant value. 'interp' pads with
             an extrapolated value.
         cval : float
             Padding value when mode='consant'.
+        order : int
+            Order of interpolation when mode='constant' (0 =
+            nearest-neighbor, 1 = linear, 2 = quadratic, 3 = cubic).
 
         Returns
         -------
@@ -360,18 +363,20 @@ class Map(object):
 
     @abc.abstractmethod
     def crop(self, crop_width):
-        """Crop the spatial dimension of the map.
+        """Crop the spatial dimension of the map by removing a number of
+        pixels from the edge of the map.
 
         Parameters
         ----------
         crop_width : {sequence, array_like, int}
-            Number of values cropped from the edges of each axis.
+            Number of pixels cropped from the edges of each axis.
             Defined analogously to `pad_with` from `~numpy.pad`.
 
         Returns
         -------
         map : `~Map`
             Cropped map.
+
         """
         pass
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -426,6 +426,15 @@ def get_superpixels(idx, nside_subpix, nside_superpix, nest=True):
     nside_superpix : int or `~numpy.ndarray`
         NSIDE of superpixel.
 
+    nest : bool
+        If True, assume NESTED pixel ordering, otherwise, RING pixel
+        ordering.
+
+    Returns
+    -------
+    idx_super : `~numpy.ndarray`
+        Indices of HEALpix pixels of nside ``nside_superpix`` that
+        contain pixel indices ``idx`` of nside ``nside_subpix``.
     """
 
     import healpy as hp
@@ -473,14 +482,14 @@ def get_subpixels(idx, nside_superpix, nside_subpix, nest=True):
         NSIDE of subpixel.
 
     nest : bool
-        If True, assume NESTED pixel ordering, otherwise, RING pixel ordering.
+        If True, assume NESTED pixel ordering, otherwise, RING pixel
+        ordering.
 
     Returns
     -------
-    subidx : `~numpy.ndarray`
+    idx_sub : `~numpy.ndarray`
         Indices of HEALpix pixels of nside ``nside_subpix`` contained
-        within pixel ``pix`` of nside ``nside_superpix``.
-
+        within pixel indices ``idx`` of nside ``nside_superpix``.
     """
     import healpy as hp
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -557,7 +557,7 @@ class HpxGeom(MapGeom):
         idx_global = unravel_hpx_index(self._ipix[idx], self._maxpix)
         return idx_global[:1] + tuple(idx_local[1:])
 
-    def global_to_local(self, idx_global):
+    def global_to_local(self, idx_global, ravel=False):
         """Compute a global (all-sky) index from a local (partial-sky)
         index.
 
@@ -566,6 +566,9 @@ class HpxGeom(MapGeom):
         idx_global : tuple
             A tuple of pixel indices with global HEALPix pixel
             indices.
+
+        ravel : bool
+            Return a raveled index.
 
         Returns
         -------
@@ -596,7 +599,10 @@ class HpxGeom(MapGeom):
         for i, t in enumerate(idx_local):
             idx_local[i][m] = -1
 
-        return idx_local
+        if not ravel:
+            return idx_local
+        else:
+            return ravel_hpx_index(idx_local, self.npix)
 
     def __getitem__(self, idx_global):
         """This implements the global-to-local index lookup.
@@ -629,25 +635,7 @@ class HpxGeom(MapGeom):
             idx_global = unravel_hpx_index(np.array(idx_global, ndmin=1),
                                            self._maxpix)
 
-        if self.nside.size == 1:
-            idx = np.array(idx_global[0], ndmin=1)
-        else:
-            idx = ravel_hpx_index(idx_global, self._maxpix)
-
-        if self._rmap is not None:
-            retval = np.empty((idx.size), 'i')
-            retval.fill(-1)
-            m = np.in1d(idx.flat, self._ipix)
-            retval[m] = np.searchsorted(self._ipix, idx.flat[m])
-            retval = retval.reshape(idx.shape)
-        else:
-            retval = idx
-
-        if self.nside.size == 1:
-            retval = ravel_hpx_index([retval] + list(idx_global[1:]),
-                                     self.npix)
-
-        return retval
+        return self.global_to_local(idx_global, ravel=True)
 
     def coord_to_pix(self, coords):
         import healpy as hp

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -622,6 +622,7 @@ class HpxGeom(MapGeom):
 
         elif isinstance(region, tuple):
 
+            region = [np.asarray(t) for t in region]
             m = np.any(np.stack([t >= 0 for t in region]), axis=0)
             region = [t[m] for t in region]
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -159,8 +159,13 @@ class HpxMap(Map):
         pass
 
     @abc.abstractmethod
-    def to_swapped_scheme(self):
+    def to_swapped(self):
         """Return a new map with the opposite scheme (ring or nested).
+
+        Returns
+        -------
+        map : `~HpxMap`
+            Map object.
         """
         pass
 
@@ -176,6 +181,11 @@ class HpxMap(Map):
         preserve_counts : bool
             Choose whether to preserve counts (total amplitude) or
             intensity (amplitude per unit solid angle).
+
+        Returns
+        -------
+        map : `~HpxMap`
+            Map object.
         """
         pass
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import copy
 import json
 import numpy as np
 from astropy.io import fits
@@ -244,7 +245,7 @@ class HpxNDMap(HpxMap):
 
     def pad(self, pad_width, mode='constant', cval=0.0, order=1):
         geom = self.geom.pad(pad_width)
-        map_out = self.__class__(geom)
+        map_out = self.__class__(geom, meta=copy.deepcopy(self.meta))
         map_out.coadd(self)
         coords = geom.get_coords(flat=True)
         m = self.geom.contains(coords)
@@ -265,13 +266,14 @@ class HpxNDMap(HpxMap):
 
     def crop(self, crop_width):
         geom = self.geom.crop(crop_width)
-        map_out = self.__class__(geom)
+        map_out = self.__class__(geom, meta=copy.deepcopy(self.meta))
         map_out.coadd(self)
         return map_out
 
     def upsample(self, factor, preserve_counts=True):
 
-        map_out = self.__class__(self.geom.upsample(factor))
+        map_out = self.__class__(self.geom.upsample(factor),
+                                 meta=copy.deepcopy(self.meta))
         coords = map_out.geom.get_coords(flat=True)
         vals = self.get_by_coords(coords)
         m = np.isfinite(vals)
@@ -284,7 +286,8 @@ class HpxNDMap(HpxMap):
 
     def downsample(self, factor, preserve_counts=True):
 
-        map_out = self.__class__(self.geom.downsample(factor))
+        map_out = self.__class__(self.geom.downsample(factor),
+                                 meta=copy.deepcopy(self.meta))
         idx = self.geom.get_idx(flat=True)
         coords = self.geom.pix_to_coord(idx)
         vals = self.get_by_idx(idx)
@@ -445,7 +448,7 @@ class HpxNDMap(HpxMap):
     def to_swapped(self):
         import healpy as hp
         hpx_out = self.geom.to_swapped()
-        map_out = self.__class__(hpx_out)
+        map_out = self.__class__(hpx_out, meta=copy.deepcopy(self.meta))
         idx = self.geom.get_idx(flat=True)
         vals = self.get_by_idx(idx)
         if self.geom.nside.size > 1:
@@ -468,7 +471,7 @@ class HpxNDMap(HpxMap):
         import healpy as hp
         order = nside_to_order(nside)
         new_hpx = self.geom.to_ud_graded(order)
-        map_out = self.__class__(new_hpx)
+        map_out = self.__class__(new_hpx, meta=copy.deepcopy(self.meta))
 
         if np.all(order <= self.geom.order):
             # Downsample

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -169,7 +169,7 @@ class HpxSparseMap(HpxMap):
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
         raise NotImplementedError
 
-    def to_swapped_scheme(self):
+    def to_swapped(self):
         raise NotImplementedError
 
     def to_ud_graded(self):

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -199,6 +199,22 @@ def test_hpxmap_crop(nside, nested, coordsys, region, axes):
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_partialsky_geoms)
+def test_hpxmap_upsample(nside, nested, coordsys, region, axes):
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.upsample(2)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
+                         hpx_test_partialsky_geoms)
+def test_hpxmap_crop(nside, nested, coordsys, region, axes):
+    m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
+                         coordsys=coordsys, region=region, axes=axes))
+    m.downsample(2)
+
+
+@pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -119,13 +119,13 @@ def test_hpxmap_set_get_by_coords(nside, nested, coordsys, region, axes, sparse)
     assert_allclose(coords[0], m.get_by_coords(coords))
 
 
-@pytest.mark.xfail(reason="Bug in healpy <= 0.10.3")
+#@pytest.mark.xfail(reason="Bug in healpy <= 0.10.3")
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxmap_get_by_coords_interp(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coords(flat=True)
     m.set_by_coords(coords, coords[1])
     assert_allclose(m.get_by_coords(coords),
                     m.get_by_coords(coords, interp='linear'))

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -208,7 +208,7 @@ def test_hpxmap_upsample(nside, nested, coordsys, region, axes):
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_partialsky_geoms)
-def test_hpxmap_crop(nside, nested, coordsys, region, axes):
+def test_hpxmap_downsample(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     m.downsample(2)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -224,7 +224,14 @@ def test_wcsndmap_pad(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    m.pad(1, mode='constant')
+    m2 = m.pad(1, mode='constant', cval=2.2)
+    if not geom.is_allsky:
+        coords = m2.geom.get_coords()
+        msk = m2.geom.contains(coords)
+        coords = tuple([c[~msk] for c in coords])
+        assert_allclose(m2.get_by_coords(coords), 2.2)
+    m.pad(1, mode='edge')
+    m.pad(1, mode='interp')
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -359,7 +359,7 @@ class WcsNDMap(WcsMap):
 
         return map_out
 
-    def pad(self, pad_width, mode='edge', cval=0, order=1):
+    def pad(self, pad_width, mode='constant', cval=0, order=1):
 
         if np.isscalar(pad_width):
             pad_width = (pad_width, pad_width)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -371,8 +371,6 @@ class WcsNDMap(WcsMap):
         else:
             return self._pad_coadd(geom, pad_width, mode, cval, order)
 
-        return map_out
-
     def _pad_np(self, geom, pad_width, mode, cval):
         """Pad a map with `~np.pad`.  This method only works for regular
         geometries but should be more efficient when working with
@@ -384,7 +382,7 @@ class WcsNDMap(WcsMap):
 
         pad_width = [(t, t) for t in pad_width]
         data = np.pad(self.data, pad_width[::-1], mode, **kw)
-        map_out = self.__class__(geom, data)
+        map_out = self.__class__(geom, data, meta=copy.deepcopy(self.meta))
         return map_out
 
     def _pad_coadd(self, geom, pad_width, mode, cval, order):
@@ -393,7 +391,7 @@ class WcsNDMap(WcsMap):
         idx_in = self.geom.get_idx(flat=True)
         idx_in = tuple([t + w for t, w in zip(idx_in, pad_width)])[::-1]
         idx_out = geom.get_idx(flat=True)[::-1]
-        map_out = self.__class__(geom)
+        map_out = self.__class__(geom, meta=copy.deepcopy(self.meta))
         map_out.coadd(self)
         if mode == 'constant':
             pad_msk = np.zeros_like(map_out.data, dtype=bool)
@@ -423,11 +421,11 @@ class WcsNDMap(WcsMap):
             for ax in self.geom.axes:
                 slices += [slice(None)]
             data = self.data[slices[::-1]]
-            map_out = self.__class__(geom, data)
+            map_out = self.__class__(geom, data, meta=copy.deepcopy(self.meta))
         else:
             # FIXME: This could be done more efficiently by
             # constructing the appropriate slices for each image plane
-            map_out = self.__class__(geom)
+            map_out = self.__class__(geom, meta=copy.deepcopy(self.meta))
             map_out.coadd(self)
 
         return map_out
@@ -441,7 +439,7 @@ class WcsNDMap(WcsMap):
         data = map_coordinates(self.data.T, pix, order=order, mode='nearest')
         if preserve_counts:
             data /= factor**2
-        return self.__class__(geom, data)
+        return self.__class__(geom, data, meta=copy.deepcopy(self.meta))
 
     def downsample(self, factor, preserve_counts=True):
         from skimage.measure import block_reduce
@@ -450,7 +448,7 @@ class WcsNDMap(WcsMap):
         data = block_reduce(self.data, block_size[::-1], np.nansum)
         if not preserve_counts:
             data /= factor**2
-        return self.__class__(geom, data)
+        return self.__class__(geom, data, meta=copy.deepcopy(self.meta))
 
     def plot(self, ax=None, idx=None, **kwargs):
         """Quickplot method.


### PR DESCRIPTION
This is a followup to #1281 that addresses some feedback from that PR and also improves some of the utility methods for HPX maps:
* Implements `downsample` and `upsample` methods for `HpxNDMap`.  
* Splits implementation of `WcsNDMap.pad` into several private methods.
* Fully implements `edge` and `interp` modes for `WcsNDMap.pad`.
* Support non-regular geometry in `HpxNDMap.interp_by_coords`.
* Implements `constant` mode for `HpxNDMap.pad`.  `edge` and `interp` are still on the TODO list.  Unfortunately `interp` will be challenging to implement given that the healpy interpolation methods don't support extrapolation. 

Note that currently `HpxNDMap.downsample` and `HpxNDMap.upsample` do not preserve the geometric footprint of the map (i.e. a downsampled/upsampled map will have a slightly larger/smaller footprint depending on the location of the map origin) whereas the equivalent methods for `WcsNDMap` do preserve the footprint.  We could consider adding an option that preserves the footprint but this means that the geometry itself would switch to the `explicit` type and would no longer be a simple function of sky coordinates.  Presently in `HpxGeom` we support three geometry types:
* `disk` : All pixels of a given nside with centers contained within a circular region of radius R.
* `disk_inc` : All pixels of a given nside that intersect a circular region of radius R.
* `explicit` : An explicit list of pixels.  

There are some advantages to maps with a purely geometrical description -- in particular the `explicit` map type largely negates the memory savings of a sparse map.  There are also some circumstances where it might be useful to constitute a map geometry without having to read the whole map table itself.  One solution for encoding a geometrical description of down/up sampled maps might be to expand the disk geometry types to include an optional down/up sampling parameter in addition to the disk origin and radius.  Eventually it would be nice to support a `moc` geometry type which would have the flexibility of the `explicit` type without the memory cost.  However this would require some substantial changes to the format spec (e.g. an additional HDU to store the footprint pixels).

I'm not sure if it's critical that we figure out the best approach for the downsample/upsample methods in this PR but I just wanted to raise these points to make sure people are aware of the issues around this.