### PR TITLE
Fix IACTBasicImageEstimator psf method

### DIFF
--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -234,7 +234,10 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         coordinates = psf_image.coordinates()
         offset = coordinates.separation(psf_image.center)
         psf_image.data = psf_mean.evaluate(offset)
+
         psf_image.data /= psf_image.data.sum()
+        psf_image.unit = psf_image.data.unit
+        psf_image.data = psf_image.data.value
         return psf_image
 
     def _counts(self, observation):

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -224,10 +224,8 @@ class IACTBasicImageEstimator(BasicImageEstimator):
             rad_max = Angle(rad_max)
 
         psfkern = psf_mean.kernel(refskyim, rad_max)
-        print ('psfkern.sum() =', psfkern.sum())
         psfunit = psfkern.unit
         psfdata = psfkern.value
-        print ('psfdata.sum() =', psfdata.sum())
 
         psfhead = refskyim.wcs.to_header()
         radnpix = int(np.shape(psfdata)[0] / 2)
@@ -236,11 +234,6 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         psfwcs = WCS(psfhead)
 
         psf_image = SkyImage('psf', data=psfdata, wcs=psfwcs, unit=psfunit)
-
-        print('psf_image.data.sum() =', '%.8f' % psf_image.data.sum())
-        psf_image.data /= psf_image.data.sum()
-        print('psf_image.data.sum() =', '%.8f' % psf_image.data.sum())
-
         return psf_image
 
     def _counts(self, observation):

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -203,6 +203,11 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         ----------
         observations : `~gammapy.data.ObservationList`
             List of observations
+        containment_fraction : float (0.99)
+            Minimum PSF containment fraction included in kernel image.
+        rad_max : `~astropy.coordinates.Angle` (None)
+            If specified, passed to `~gammapy.irf.TablePSF.kernel`;
+            containment_fraction is then ignored.
 
         Returns
         -------


### PR DESCRIPTION
Changed psf() method to return image with odd number of pixels and
PSF centered in the middle of the central pixel.
PSF image FOV set to 99% containment radius.
PSF sky position is that for which the PSF is computed (center of
the reference image by default for now).