### PR TITLE
Adding PhaseCurve class for periodic system

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -117,3 +117,7 @@ Reference/API
 .. automodapi:: gammapy.time
     :no-inheritance-diagram:
     :include-all-objects:
+
+.. automodapi:: gammapy.time.models
+    :no-inheritance-diagram:
+    :include-all-objects:

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+import logging
+import numpy as np
+from ..utils.modeling import Parameter, ParameterList
+
+__all__ = [
+    'PhaseCurve',
+]
+
+log = logging.getLogger(__name__)
+
+
+class PhaseCurve(object):
+
+ """
+ This is to calculate phase of a periodic system and to provide the normalization
+ factor for the phase using circular interpolation. The required data for interpolation
+ is given as an astropy table
+
+# TODO: 1. Checking table values if the phases are in increasing order
+        2. Check normalization constant to set maximum values
+
+ Parameters
+ ----------
+ table = A table of 'PHASE' vs 'NORM' should be given
+ reference: The MJD value where phase is considered as 0.
+ phase0: phase at the reference MJD
+ f0:1st order derivative of the function phi with time
+ f1:2nd order derivative of the function phi with time
+ f2:3rd order derivative of the function phi with time
+ phase as function of time is computed using
+ Φ(t)=Φ0+f0(t−t0)+(1/2)f1(t−t0)^2+(1/6)f2(t−t0)^3
+
+
+ Returns
+ --------
+ Phase corresponding to the time provided as input
+ It also calculates the normalization constant for that phase
+
+ Examples
+ --------
+ This shows how to get the phase and the normalization constant
+
+    phase_curve = PhaseCurve(table,reference,phase0,f0,f1,f2)
+    phase = phase_curve.phase(time)
+    norm_const = phase_curve.evaluate(time)
+
+"""
+
+
+      
+ def __init__(self,table,reference,phase0,f0,f1,f2):
+
+    self.table = table
+    self.parameters = ParameterList([
+    Parameter('reference', reference),
+    Parameter('phase0', phase0),
+    Parameter('f0', f0),
+    Parameter('f1', f1),
+    Parameter('f2', f2)])
+     
+
+ def phase(self,time):
+    """ To assign the phase to the time """
+    c1 = 0.5
+    c2 = 1.0/6.0
+    pars = self.parameters
+    reference = pars['reference'].value
+    phase0    = pars['phase0'].value
+    f0        = pars['f0'].value
+    f1        = pars['f1'].value
+    f2        = pars['f2'].value
+
+    t = time - reference
+
+    phase = phase0 + t * (f0 + t * (c1 * f1 +  c2 * f2 * t))
+          
+    phase = np.remainder(phase,1)
+    return phase
+     
+ def evaluate(self,time):
+    """
+    To calculate the normalization constant for
+    the phase calculated from the given time
+    """
+    phase = self.phase(time)
+    tbdata = self.table
+    phase_col = tbdata['PHASE']
+    norm_col  = tbdata['NORM']
+
+    x_values = phase_col
+    f_values = norm_col
+
+    f_norm = np.interp(x = phase,xp= x_values,fp = f_values, period = 1)
+    return f_norm
+

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -22,16 +22,16 @@ class PhaseCurve(object):
     and / or ``f2 !=0``.
 
     The "phase curve", i.e. multiplicative flux factor for a given phase is given
-    by a `~astropy.table.Table` of nodes ``(PHASE, NORM)``, using linear interpolation
+    by a `~astropy.table.Table` of nodes ``(phase, norm)``, using linear interpolation
     and circular behaviour, where ``norm(phase=0) == norm(phase=1)``.
 
     Parameters
     ----------
     table : `~astropy.table.Table`
         A table of 'PHASE' vs 'NORM' should be given
-    reference : float
+    time_0 : float
         The MJD value where phase is considered as 0.
-    phase0 : float
+    phase_0 : float
         Phase at the reference MJD
     f0, f2, f2 : float
         Derivatives of the function phi with time of order 1, 2, 3
@@ -45,21 +45,22 @@ class PhaseCurve(object):
         from gammapy.time.models import PhaseCurve
         filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
         table = Table.read(str(filename))
-        phase_curve = PhaseCurve(table, reference=43366.275, phase0=0.0, f0=0.5, f1=0.0, f2=0.0)
+        phase_curve = PhaseCurve(table, time_0=43366.275, phase_0=0.0, f0=0.5, f1=0.0, f2=0.0)
 
     Use it to compute a phase and evaluate the phase curve model for a given time:
 
     >>> phase_curve.phase(time=46300.0)
     0.8624999999992724
-    >>> phase_curve.evaluate(time=46300.0)
+    >>> phase_curve.evaluate_at_phase(0.8624999999992724)
+    >>> phase_curve.evaluate_at_time(46300.0)
     0.05
     """
 
-    def __init__(self, table, reference, phase0, f0, f1, f2):
+    def __init__(self, table, time_0, phase_0, f0, f1, f2):
         self.table = table
         self.parameters = ParameterList([
-            Parameter('reference', reference),
-            Parameter('phase0', phase0),
+            Parameter('time_0', time_0),
+            Parameter('phase_0', phase_0),
             Parameter('f0', f0),
             Parameter('f1', f1),
             Parameter('f2', f2)]
@@ -77,32 +78,36 @@ class PhaseCurve(object):
         phase : array_like
         """
         pars = self.parameters
-        reference = pars['reference'].value
-        phase0 = pars['phase0'].value
+        time_0 = pars['time_0'].value
+        phase_0 = pars['phase_0'].value
         f0 = pars['f0'].value
         f1 = pars['f1'].value
         f2 = pars['f2'].value
 
-        t = time - reference
-
-        c1 = 0.5
-        c2 = 1.0 / 6.0
-        phase = phase0 + t * (f0 + t * (c1 * f1 + c2 * f2 * t))
-
+        t = time - time_0
+        phase = self._evaluate_phase(t, phase_0, f0, f1, f2)
         return np.remainder(phase, 1)
 
-    def evaluate(self, time):
-        """Evaluate model for a given time.
+    @staticmethod
+    def _evaluate_phase(t, phase_0, f0, f1, f2):
+        return phase_0 + t * (f0 + t * (f1 / 2 + f2 / 6 * t))
+
+    def evaluate_norm_at_time(self, time):
+        """Evaluate for a given time.
 
         Parameters
         ----------
         time : array_like
+            Time since the ``reference`` time.
 
         Returns
         -------
         norm : array_like
         """
-        x = self.phase(time)
+        phase = self.phase(time)
+        return self.evaluate_norm_at_phase(phase)
+
+    def evaluate_norm_at_phase(self, phase):
         xp = self.table['PHASE']
         fp = self.table['NORM']
-        return np.interp(x=x, xp=xp, fp=fp, period=1)
+        return np.interp(x=phase, xp=xp, fp=fp, period=1)

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -9,31 +9,50 @@ __all__ = [
 
 
 class PhaseCurve(object):
-    """PhaseCurve class.
+    """Temporal phase curve model.
     
-    This is to calculate phase of a periodic system and to provide the 
-    normalization factor for the phase using circular interpolation. 
-    The required data for interpolation is given as an astropy table
+    Phase for a given time is computed as
+
+    .. math::
+
+        \phi(t) = \phi0 + f0(t−t0) + (1/2)f1(t−t0)^2 + (1/6)f2(t−t0)^3
+
+    Strictly periodic sources such as gamma-ray binaries have ``f1=0`` and ``f2=0``.
+    Sources like some pulsars where the period spins up or down have ``f1!=0``
+    and / or ``f2 !=0``.
+
+    The "phase curve", i.e. multiplicative flux factor for a given phase is given
+    by a `~astropy.table.Table` of nodes ``(PHASE, NORM)``, using linear interpolation
+    and circular behaviour, where ``norm(phase=0) == norm(phase=1)``.
 
     Parameters
     ----------
-    table = A table of 'PHASE' vs 'NORM' should be given
-    reference: The MJD value where phase is considered as 0.
-    phase0: phase at the reference MJD
-    f0:1st order derivative of the function phi with time
-    f1:2nd order derivative of the function phi with time
-    f2:3rd order derivative of the function phi with time
-    phase as function of time is computed using
-    Φ(t)=Φ0+f0(t−t0)+(1/2)f1(t−t0)^2+(1/6)f2(t−t0)^3
-
+    table : `~astropy.table.Table`
+        A table of 'PHASE' vs 'NORM' should be given
+    reference : float
+        The MJD value where phase is considered as 0.
+    phase0 : float
+        Phase at the reference MJD
+    f0, f2, f2 : float
+        Derivatives of the function phi with time of order 1, 2, 3
 
     Examples
     --------
-    This shows how to get the phase and the normalization constant
+    Create an example phase curve object::
 
-    phase_curve = PhaseCurve(table,reference,phase0,f0,f1,f2)
-    phase = phase_curve.phase(time)
-    norm_const = phase_curve.evaluate(time)
+        from astropy.table import Table
+        from gammapy.utils.scripts import make_path
+        from gammapy.time.models import PhaseCurve
+        filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
+        table = Table.read(str(filename))
+        phase_curve = PhaseCurve(table, reference=43366.275, phase0=0.0, f0=0.5, f1=0.0, f2=0.0)
+
+    Use it to compute a phase and evaluate the phase curve model for a given time:
+
+    >>> phase_curve.phase(time=46300.0)
+    0.8624999999992724
+    >>> phase_curve.evaluate(time=46300.0)
+    0.05
     """
 
     def __init__(self, table, reference, phase0, f0, f1, f2):
@@ -43,22 +62,20 @@ class PhaseCurve(object):
             Parameter('phase0', phase0),
             Parameter('f0', f0),
             Parameter('f1', f1),
-            Parameter('f2', f2)])
+            Parameter('f2', f2)]
+        )
 
     def phase(self, time):
-        """ Calculate phase 
+        """Evaluate phase for a given time.
         
         Parameters
         ----------
-        time: array_like
+        time : array_like
         
         Returns
-        ---------
-        phase: array_like
+        -------
+        phase : array_like
         """
-
-        c1 = 0.5
-        c2 = 1.0 / 6.0
         pars = self.parameters
         reference = pars['reference'].value
         phase0 = pars['phase0'].value
@@ -68,27 +85,24 @@ class PhaseCurve(object):
 
         t = time - reference
 
+        c1 = 0.5
+        c2 = 1.0 / 6.0
         phase = phase0 + t * (f0 + t * (c1 * f1 + c2 * f2 * t))
 
-        phase = np.remainder(phase, 1)
-        return phase
+        return np.remainder(phase, 1)
 
     def evaluate(self, time):
-        """
-        To calculate the normalization constant for
-        the phase calculated from the given time
-            
+        """Evaluate model for a given time.
+
+        Parameters
+        ----------
+        time : array_like
+
         Returns
         -------
-        normalization constant: array_like
+        norm : array_like
         """
-        phase = self.phase(time)
-        tbdata = self.table
-        phase_col = tbdata['PHASE']
-        norm_col = tbdata['NORM']
-
-        x_values = phase_col
-        f_values = norm_col
-
-        f_norm = np.interp(x=phase, xp=x_values, fp=f_values, period=1)
-        return f_norm
+        x = self.phase(time)
+        xp = self.table['PHASE']
+        fp = self.table['NORM']
+        return np.interp(x=x, xp=xp, fp=fp, period=1)

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -11,86 +11,99 @@ log = logging.getLogger(__name__)
 
 
 class PhaseCurve(object):
+    """PhaseCurve class.
+    
+    This is to calculate phase of a periodic system and to provide the 
+    normalization factor for the phase using circular interpolation. 
+    The required data for interpolation is given as an astropy table
 
- """
- This is to calculate phase of a periodic system and to provide the normalization
- factor for the phase using circular interpolation. The required data for interpolation
- is given as an astropy table
+    # TODO: 1. Checking table values if the phases are in increasing order
+            2. Check normalization constant to set maximum values
 
-# TODO: 1. Checking table values if the phases are in increasing order
-        2. Check normalization constant to set maximum values
-
- Parameters
- ----------
- table = A table of 'PHASE' vs 'NORM' should be given
- reference: The MJD value where phase is considered as 0.
- phase0: phase at the reference MJD
- f0:1st order derivative of the function phi with time
- f1:2nd order derivative of the function phi with time
- f2:3rd order derivative of the function phi with time
- phase as function of time is computed using
- Φ(t)=Φ0+f0(t−t0)+(1/2)f1(t−t0)^2+(1/6)f2(t−t0)^3
+    Parameters
+    ----------
+    table = A table of 'PHASE' vs 'NORM' should be given
+    reference: The MJD value where phase is considered as 0.
+    phase0: phase at the reference MJD
+    f0:1st order derivative of the function phi with time
+    f1:2nd order derivative of the function phi with time
+    f2:3rd order derivative of the function phi with time
+    phase as function of time is computed using
+    Φ(t)=Φ0+f0(t−t0)+(1/2)f1(t−t0)^2+(1/6)f2(t−t0)^3
 
 
- Returns
- --------
- Phase corresponding to the time provided as input
- It also calculates the normalization constant for that phase
+    Returns
+    --------
+    Phase corresponding to the time provided as input
+    It also calculates the normalization constant for that phase
 
- Examples
- --------
- This shows how to get the phase and the normalization constant
+    Examples
+    --------
+    This shows how to get the phase and the normalization constant
 
     phase_curve = PhaseCurve(table,reference,phase0,f0,f1,f2)
     phase = phase_curve.phase(time)
     norm_const = phase_curve.evaluate(time)
-
-"""
+    """
 
 
       
- def __init__(self,table,reference,phase0,f0,f1,f2):
+    def __init__(self,table,reference,phase0,f0,f1,f2):
 
-    self.table = table
-    self.parameters = ParameterList([
-    Parameter('reference', reference),
-    Parameter('phase0', phase0),
-    Parameter('f0', f0),
-    Parameter('f1', f1),
-    Parameter('f2', f2)])
+        self.table = table
+        self.parameters = ParameterList([
+        Parameter('reference', reference),
+        Parameter('phase0', phase0),
+        Parameter('f0', f0),
+        Parameter('f1', f1),
+        Parameter('f2', f2)])
      
 
- def phase(self,time):
-    """ To assign the phase to the time """
-    c1 = 0.5
-    c2 = 1.0/6.0
-    pars = self.parameters
-    reference = pars['reference'].value
-    phase0    = pars['phase0'].value
-    f0        = pars['f0'].value
-    f1        = pars['f1'].value
-    f2        = pars['f2'].value
+    def phase(self,time):
+        """ Calculate phase 
+        
+        Parameters
+        ----------
+        time: array_like
+        
+        Returns
+        ---------
+        phase: array_like
+        """
+        
+        c1 = 0.5
+        c2 = 1.0/6.0
+        pars = self.parameters
+        reference = pars['reference'].value
+        phase0    = pars['phase0'].value
+        f0        = pars['f0'].value
+        f1        = pars['f1'].value
+        f2        = pars['f2'].value
 
-    t = time - reference
+        t = time - reference
 
-    phase = phase0 + t * (f0 + t * (c1 * f1 +  c2 * f2 * t))
+        phase = phase0 + t * (f0 + t * (c1 * f1 +  c2 * f2 * t))
           
-    phase = np.remainder(phase,1)
-    return phase
+        phase = np.remainder(phase,1)
+        return phase
      
- def evaluate(self,time):
-    """
-    To calculate the normalization constant for
-    the phase calculated from the given time
-    """
-    phase = self.phase(time)
-    tbdata = self.table
-    phase_col = tbdata['PHASE']
-    norm_col  = tbdata['NORM']
+    def evaluate(self,time):
+        """
+        To calculate the normalization constant for
+        the phase calculated from the given time
+            
+        Returns
+        -------
+        normalization constant: array_like
+        """
+        phase = self.phase(time)
+        tbdata = self.table
+        phase_col = tbdata['PHASE']
+        norm_col  = tbdata['NORM']
 
-    x_values = phase_col
-    f_values = norm_col
+        x_values = phase_col
+        f_values = norm_col
 
-    f_norm = np.interp(x = phase,xp= x_values,fp = f_values, period = 1)
-    return f_norm
+        f_norm = np.interp(x = phase,xp= x_values,fp = f_values, period = 1)
+        return f_norm
 

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -1,13 +1,11 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import logging
 import numpy as np
 from ..utils.modeling import Parameter, ParameterList
 
 __all__ = [
     'PhaseCurve',
 ]
-
-log = logging.getLogger(__name__)
 
 
 class PhaseCurve(object):
@@ -16,9 +14,6 @@ class PhaseCurve(object):
     This is to calculate phase of a periodic system and to provide the 
     normalization factor for the phase using circular interpolation. 
     The required data for interpolation is given as an astropy table
-
-    # TODO: 1. Checking table values if the phases are in increasing order
-            2. Check normalization constant to set maximum values
 
     Parameters
     ----------
@@ -32,11 +27,6 @@ class PhaseCurve(object):
     Φ(t)=Φ0+f0(t−t0)+(1/2)f1(t−t0)^2+(1/6)f2(t−t0)^3
 
 
-    Returns
-    --------
-    Phase corresponding to the time provided as input
-    It also calculates the normalization constant for that phase
-
     Examples
     --------
     This shows how to get the phase and the normalization constant
@@ -46,20 +36,16 @@ class PhaseCurve(object):
     norm_const = phase_curve.evaluate(time)
     """
 
-
-      
-    def __init__(self,table,reference,phase0,f0,f1,f2):
-
+    def __init__(self, table, reference, phase0, f0, f1, f2):
         self.table = table
         self.parameters = ParameterList([
-        Parameter('reference', reference),
-        Parameter('phase0', phase0),
-        Parameter('f0', f0),
-        Parameter('f1', f1),
-        Parameter('f2', f2)])
-     
+            Parameter('reference', reference),
+            Parameter('phase0', phase0),
+            Parameter('f0', f0),
+            Parameter('f1', f1),
+            Parameter('f2', f2)])
 
-    def phase(self,time):
+    def phase(self, time):
         """ Calculate phase 
         
         Parameters
@@ -70,24 +56,24 @@ class PhaseCurve(object):
         ---------
         phase: array_like
         """
-        
+
         c1 = 0.5
-        c2 = 1.0/6.0
+        c2 = 1.0 / 6.0
         pars = self.parameters
         reference = pars['reference'].value
-        phase0    = pars['phase0'].value
-        f0        = pars['f0'].value
-        f1        = pars['f1'].value
-        f2        = pars['f2'].value
+        phase0 = pars['phase0'].value
+        f0 = pars['f0'].value
+        f1 = pars['f1'].value
+        f2 = pars['f2'].value
 
         t = time - reference
 
-        phase = phase0 + t * (f0 + t * (c1 * f1 +  c2 * f2 * t))
-          
-        phase = np.remainder(phase,1)
+        phase = phase0 + t * (f0 + t * (c1 * f1 + c2 * f2 * t))
+
+        phase = np.remainder(phase, 1)
         return phase
-     
-    def evaluate(self,time):
+
+    def evaluate(self, time):
         """
         To calculate the normalization constant for
         the phase calculated from the given time
@@ -99,11 +85,10 @@ class PhaseCurve(object):
         phase = self.phase(time)
         tbdata = self.table
         phase_col = tbdata['PHASE']
-        norm_col  = tbdata['NORM']
+        norm_col = tbdata['NORM']
 
         x_values = phase_col
         f_values = norm_col
 
-        f_norm = np.interp(x = phase,xp= x_values,fp = f_values, period = 1)
+        f_norm = np.interp(x=phase, xp=x_values, fp=f_values, period=1)
         return f_norm
-

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -1,0 +1,26 @@
+from astropy.table import Table
+import pytest
+from numpy.testing import assert_allclose
+from gammapy.time.models import PhaseCurve
+from gammapy.utils.testing import requires_data
+from gammapy.utils.scripts import make_path
+
+
+
+@pytest.fixture(scope='session')
+def phase():
+    filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
+    print(filename)
+    table = Table.read(str(filename))
+    return PhaseCurve(table,reference=43366.275,phase0 = 0.0,f0 = 0.5,f1 = 0.0,f2 = 0.0
+)
+
+# To check the value of the phase
+def test_phasecurve_phase(phase):
+    time = 46300.0
+    assert_allclose(phase.phase(time),0.86,rtol=0.01)
+
+# To check the value of the normalization constant
+def test_phasecurve_norm(phase):
+    time = 46300.0
+    assert_allclose(phase.evaluate(time),0.05,rtol=0.01)

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -1,27 +1,26 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.table import Table
-import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from gammapy.time.models import PhaseCurve
-from gammapy.utils.testing import requires_data
-from gammapy.utils.scripts import make_path
-
+from ..models import PhaseCurve
+from ...utils.scripts import make_path
 
 
 @pytest.fixture(scope='session')
 def phase_curve():
     filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
-    print(filename)
     table = Table.read(str(filename))
-    return PhaseCurve(table,reference=43366.275,phase0 = 0.0,f0 = 0.5,f1 = 0.0,f2 = 0.0
-)
+    return PhaseCurve(table, reference=43366.275, phase0=0.0, f0=0.5, f1=0.0, f2=0.0
+                      )
+
 
 # To check the value of the phase
 def test_phasecurve_phase(phase_curve):
     time = 46300.0
-    assert_allclose(phase_curve.phase(time),0.86,rtol=0.01)
+    assert_allclose(phase_curve.phase(time), 0.86, rtol=0.01)
+
 
 # To check the value of the normalization constant
 def test_phasecurve_norm(phase_curve):
     time = 46300.0
-    assert_allclose(phase_curve.evaluate(time),0.05,rtol=0.01)
+    assert_allclose(phase_curve.evaluate(time), 0.05, rtol=0.01)

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -1,4 +1,5 @@
 from astropy.table import Table
+import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from gammapy.time.models import PhaseCurve
@@ -8,7 +9,7 @@ from gammapy.utils.scripts import make_path
 
 
 @pytest.fixture(scope='session')
-def phase():
+def phase_curve():
     filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
     print(filename)
     table = Table.read(str(filename))
@@ -16,11 +17,11 @@ def phase():
 )
 
 # To check the value of the phase
-def test_phasecurve_phase(phase):
+def test_phasecurve_phase(phase_curve):
     time = 46300.0
-    assert_allclose(phase.phase(time),0.86,rtol=0.01)
+    assert_allclose(phase_curve.phase(time),0.86,rtol=0.01)
 
 # To check the value of the normalization constant
-def test_phasecurve_norm(phase):
+def test_phasecurve_norm(phase_curve):
     time = 46300.0
-    assert_allclose(phase.evaluate(time),0.05,rtol=0.01)
+    assert_allclose(phase_curve.evaluate(time),0.05,rtol=0.01)

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -2,25 +2,27 @@
 from astropy.table import Table
 import pytest
 from numpy.testing import assert_allclose
-from ..models import PhaseCurve
 from ...utils.scripts import make_path
+from ...utils.testing import requires_data
+from ..models import PhaseCurve
 
 
 @pytest.fixture(scope='session')
 def phase_curve():
     filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
     table = Table.read(str(filename))
-    return PhaseCurve(table, reference=43366.275, phase0=0.0, f0=0.5, f1=0.0, f2=0.0
-                      )
+    return PhaseCurve(table, reference=43366.275, phase0=0.0, f0=0.5, f1=0.0, f2=0.0)
 
 
-# To check the value of the phase
+@requires_data('gammapy-extra')
 def test_phasecurve_phase(phase_curve):
     time = 46300.0
-    assert_allclose(phase_curve.phase(time), 0.86, rtol=0.01)
+    phase = phase_curve.phase(time)
+    assert_allclose(phase, 0.86, rtol=0.01)
 
 
-# To check the value of the normalization constant
+@requires_data('gammapy-extra')
 def test_phasecurve_norm(phase_curve):
     time = 46300.0
-    assert_allclose(phase_curve.evaluate(time), 0.05, rtol=0.01)
+    value = phase_curve.evaluate(time)
+    assert_allclose(value, 0.05, rtol=0.01)

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -11,18 +11,22 @@ from ..models import PhaseCurve
 def phase_curve():
     filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
     table = Table.read(str(filename))
-    return PhaseCurve(table, reference=43366.275, phase0=0.0, f0=0.5, f1=0.0, f2=0.0)
+    return PhaseCurve(table, time_0=43366.275, phase_0=0.0, f0=0.5, f1=0.0, f2=0.0)
 
 
 @requires_data('gammapy-extra')
 def test_phasecurve_phase(phase_curve):
     time = 46300.0
     phase = phase_curve.phase(time)
-    assert_allclose(phase, 0.86, rtol=0.01)
+    assert_allclose(phase, 0.8624999999992724)
 
 
 @requires_data('gammapy-extra')
-def test_phasecurve_norm(phase_curve):
+def test_phasecurve_evaluate(phase_curve):
     time = 46300.0
-    value = phase_curve.evaluate(time)
-    assert_allclose(value, 0.05, rtol=0.01)
+    value = phase_curve.evaluate_norm_at_time(time)
+    assert_allclose(value, 0.05)
+
+    phase = phase_curve.phase(time)
+    value = phase_curve.evaluate_norm_at_phase(phase)
+    assert_allclose(value, 0.05)


### PR DESCRIPTION
This PR adds `PhaseCurve` class for calculating the phase of a periodic system at a given time. It also calculates the normalization factor at that phase of the system by ring interpolation using a given table of `phase` vs `normalization factor`. 