### PR TITLE
Fix a bug in EnergyBounds class

### DIFF
--- a/gammapy/background/fov_cube.py
+++ b/gammapy/background/fov_cube.py
@@ -627,7 +627,7 @@ class FOVCube(object):
 
         # find energy bin containing the specified energy
         energy_bin = self.energy_edges.find_energy_bin(energy)
-        energy_bin_edges = self.energy_edges.bin(energy_bin)
+        energy_bin_edges = self.energy_edges[[energy_bin, energy_bin + 1]]
 
         # get data for the plot
         data = self.data[energy_bin]

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -285,16 +285,6 @@ class EnergyBounds(Energy):
         high = hdu.data['ENERG_HI']
         return cls.from_lower_and_upper_bounds(low, high, unit)
 
-    def bin(self, i):
-        """Return energy bin edges (zero-based numbering).
-
-        Parameters
-        ----------
-        i : int
-            Energy bin
-        """
-        return self[[i, i + 1]]
-
     def find_energy_bin(self, energy):
         """Find the bins that contain the specified energy values.
 

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -293,7 +293,7 @@ class EnergyBounds(Energy):
         i : int
             Energy bin
         """
-        return self[[i, i + 2]]
+        return self[[i, i + 1]]
 
     def find_energy_bin(self, energy):
         """Find the bins that contain the specified energy values.


### PR DESCRIPTION
This seems like a bug in the EnergyBounds class to me:
```python
In [1]: from gammapy.utils.energy import EnergyBounds

In [2]: eb = EnergyBounds.equal_log_spacing(0.1, 10.0, 20, unit='TeV')

In [3]: eb
Out[3]: 
<EnergyBounds [  0.1       ,  0.12589254,  0.15848932,  0.19952623,
                 0.25118864,  0.31622777,  0.39810717,  0.50118723,
                 0.63095734,  0.79432823,  1.        ,  1.25892541,
                 1.58489319,  1.99526231,  2.51188643,  3.16227766,
                 3.98107171,  5.01187234,  6.30957344,  7.94328235, 10.        ] TeV>

In [4]: eb.bin(2)
Out[4]: <EnergyBounds [ 0.15848932, 0.25118864] TeV>
```

With the fix, I get:
```python
In [4]: eb.bin(2)
Out[4]: <EnergyBounds [ 0.15848932, 0.19952623] TeV>
```