### PR TITLE
Updates for Fermipy Integration

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -138,6 +138,46 @@ class Map(object):
         return map_out
 
     @classmethod
+    def from_geom(cls, geom, meta=None, map_type='auto'):
+        """Generate an empty map from a `~Geom` instance.
+
+        Parameters
+        ----------
+        geom : `~MapGeom`
+            Map geometry.
+
+        meta : `~collections.OrderedDict`
+            Dictionary to store meta data.
+
+        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}        
+            Map type.  Selects the class that will be used to
+            instantiate the map.  The map type should be consistent
+            with the geometry.  If map_type is 'auto' then an
+            appropriate map type will be inferred from type of
+            ``geom``.
+
+        Returns
+        -------
+        map_out : `~Map`
+            Map object
+
+        """
+        if map_type == 'auto':
+
+            from .hpx import HpxGeom
+            from .wcs import WcsGeom
+            if isinstance(geom, HpxGeom):
+                map_type = 'hpx'
+            elif isinstance(geom, WcsGeom):
+                map_type = 'wcs'
+            else:
+                raise ValueError('Unrecognized geom type.')
+
+        cls_out = cls._get_map_cls(map_type)
+        map_out = cls_out(geom, meta=meta)
+        return map_out
+
+    @classmethod
     def from_hdu_list(cls, hdulist, hdu=None, hdu_bands=None, map_type='auto'):
         if map_type == 'auto':
             map_type = cls._get_map_type(hdulist, hdu)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -4,7 +4,12 @@ import pytest
 from astropy.coordinates import SkyCoord
 from collections import OrderedDict
 from ..base import Map
-from ..geom import MapAxis
+from ..geom import MapGeom, MapAxis
+from ..wcs import WcsGeom
+from ..wcsnd import WcsNDMap
+from ..hpx import HpxGeom
+from ..hpxnd import HpxNDMap
+
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
@@ -30,9 +35,18 @@ mapbase_args = [
 
 @pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes'),
                          mapbase_args)
-def test_mapbase_create(binsz, width, map_type, skydir, axes):
+def test_map_create(binsz, width, map_type, skydir, axes):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes)
+
+
+def test_map_from_geom():
+    geom = WcsGeom.create(binsz=1.0, width=10.0)
+    m = Map.from_geom(geom)
+    assert(isinstance(m, WcsNDMap))
+    geom = HpxGeom.create(binsz=1.0, width=10.0)
+    m = Map.from_geom(geom)
+    assert(isinstance(m, HpxNDMap))
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -55,11 +55,16 @@ class WcsGeom(MapGeom):
         Number of pixels in each spatial dimension
     cdelt : tuple
         Pixel size in each image plane.  If none then a constant pixel size will be used.
+    crpix : tuple
+        Reference pixel coordinate in each image plane.  
     axes : list
         Axes for non-spatial dimensions
+    conv : {'gadf', 'fgst-ccube', 'fgst-template'}    
+        Serialization format convention.  This sets the default format
+        that will be used when writing this geometry to a file.
     """
 
-    def __init__(self, wcs, npix, cdelt=None, axes=None, conv='gadf'):
+    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, conv='gadf'):
         self._wcs = wcs
         self._coordsys = get_coordsys(wcs)
         self._projection = get_projection(wcs)
@@ -79,8 +84,9 @@ class WcsGeom(MapGeom):
         self._npix = cast_to_shape(npix, wcs_shape, int)
         self._cdelt = cast_to_shape(cdelt, wcs_shape, float)
         # By convention CRPIX is indexed from 1
-        self._crpix = (1.0 + (self._npix[0] - 1.0) / 2.,
-                       1.0 + (self._npix[1] - 1.0) / 2.)
+        if crpix is None:
+            self._crpix = (1.0 + (self._npix[0] - 1.0) / 2.,
+                           1.0 + (self._npix[1] - 1.0) / 2.)
         self._width = (self._cdelt[0] * self._npix[0],
                        self._cdelt[1] * self._npix[1])
 


### PR DESCRIPTION
This PR makes a few small updates to `gammapy.maps` to support replacing sky map classes in the fermipy package with their equivalents in `gammapy.maps`:
* Add `crpix` argument to `HpxGeom` constructor.  This is needed for creating cutout geometries.  For the moment I'm constructing these manually in fermipy but eventually we could use this when we implement the `cutout` method.
* Add `from_geom` factory method to `Map` base class.  This method creates an empty map object given a geometry (either HPX or WCS).  This is helpful in code where you may be dealing with either HPX or WCS map objects.

Note that the migration is still a WIP on the fermipy side so I may use this branch to stage a few more updates (although I don't expect any of them to be major).