### PR TITLE
Change clobber to overwrite everywhere

### DIFF
--- a/gammapy/background/off_data_background_maker.py
+++ b/gammapy/background/off_data_background_maker.py
@@ -210,7 +210,7 @@ class OffDataBackgroundMaker(object):
 
         if modeltype == "3D":
             if str(ngroup) in self.models3D.keys():
-                self.models3D[str(ngroup)].write(str(filename), format='table', clobber=True)
+                self.models3D[str(ngroup)].write(str(filename), format='table', overwrite=True)
             else:
                 log.info("No run in the group {}".format(ngroup))
         if modeltype == "2D":

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -379,7 +379,7 @@ class DataStore(object):
 
         return file_available
 
-    def copy_obs(self, obs_id, outdir, hdu_class=None, verbose=False, clobber=False):
+    def copy_obs(self, obs_id, outdir, hdu_class=None, verbose=False, overwrite=False):
         """Create a new `~gammapy.data.DataStore` containing a subset of observations.
 
         Parameters
@@ -392,7 +392,7 @@ class DataStore(object):
             see :attr:`gammapy.data.HDUIndexTable.VALID_HDU_CLASS`
         verbose : bool
             Print copied files
-        clobber : bool
+        overwrite : bool
             Overwrite
         """
         # TODO : Does rsync give any benefits here?
@@ -417,13 +417,13 @@ class DataStore(object):
             targetdir = outdir / loc.file_dir
             targetdir.mkdir(exist_ok=True, parents=True)
             cmd = ['cp', '-v'] if verbose else ['cp']
-            if not clobber:
+            if not overwrite:
                 cmd += ['-n']
             cmd += [str(loc.path()), str(targetdir)]
             subprocess.call(cmd)
 
-        subhdutable.write(str(outdir / self.DEFAULT_HDU_TABLE), format='fits', overwrite=clobber)
-        subobstable.write(str(outdir / self.DEFAULT_OBS_TABLE), format='fits', overwrite=clobber)
+        subhdutable.write(str(outdir / self.DEFAULT_HDU_TABLE), format='fits', overwrite=overwrite)
+        subobstable.write(str(outdir / self.DEFAULT_OBS_TABLE), format='fits', overwrite=overwrite)
 
     def data_summary(self, obs_id=None, summed=False):
         """Create a summary `~astropy.table.Table` with HDU size information.

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -102,7 +102,7 @@ def test_datastore_subset(tmpdir, data_manager):
     storedir = tmpdir / 'substore'
     data_store.copy_obs(selected_obs, storedir)
     obs_id = [23523, 23592]
-    data_store.copy_obs(obs_id, storedir, clobber=True)
+    data_store.copy_obs(obs_id, storedir, overwrite=True)
 
     substore = DataStore.from_dir(storedir)
 

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -764,4 +764,4 @@ class CWTData(object):
         hdu_list.append(fits.ImageHDU(data=self._approx, header=header, name='approx'))
         hdu_list.append(fits.ImageHDU(data=self._transform_2d, header=header, name='transform_2d'))
         hdu_list.append(fits.ImageHDU(data=self._approx_bkg, header=header, name='approx_bkg'))
-        hdu_list.writeto(filename, clobber=overwrite)
+        hdu_list.writeto(filename, overwrite=overwrite)

--- a/gammapy/detect/iterfind.py
+++ b/gammapy/detect/iterfind.py
@@ -115,14 +115,14 @@ class IterativeSourceDetector(object):
                 for name in ['background']:
                     filename = '{}/{}.fits'.format(debug_folder, name)
                     log.info('Writing {}'.format(filename))
-                    fits.writeto(filename, self.iter_images[name], clobber=self.overwrite)
+                    fits.writeto(filename, self.iter_images[name], overwrite=self.overwrite)
 
                 # Save per iteration and scale images
                 for name in ['significance']:
                     for scale in self.scales:
                         filename = '{}/{}_{}.fits'.format(debug_folder, name, scale)
                         log.info('Writing {}'.format(filename))
-                        fits.writeto(filename, self.iter_images[name][scale], clobber=self.overwrite)
+                        fits.writeto(filename, self.iter_images[name][scale], overwrite=self.overwrite)
 
             self.find_peaks()
             # TODO: debug output to JSON here and for later steps

--- a/gammapy/image/tests/test_lists.py
+++ b/gammapy/image/tests/test_lists.py
@@ -14,9 +14,9 @@ class TestSkyImageList:
     @staticmethod
     def assert_read_write_roundtrips(filename, images, check_wcs=True):
         images.write(filename)
-        # Make sure clobber works as expected by writing again.
+        # Make sure overwrite works as expected by writing again.
         # Before there was a bug where this appended and duplicated HDUs
-        images.write(filename, clobber=True)
+        images.write(filename, overwrite=True)
         images2 = SkyImageList.read(filename)
         SkyImageList.assert_allclose(images, images2, check_wcs=check_wcs)
         return images2

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1425,7 +1425,7 @@ class HpxGeom(MapGeom):
             cols, self.make_header(), name=extname)
         return hdu
 
-    def write(self, data, outfile, extname='SKYMAP', clobber=True):
+    def write(self, data, outfile, extname='SKYMAP', overwrite=True):
         """Write input data to a FITS file.
 
         Parameters
@@ -1436,7 +1436,7 @@ class HpxGeom(MapGeom):
             The name of the output file
         extname :
             The HDU extension name
-        clobber : bool
+        overwrite : bool
             True -> overwrite existing files
         """
         hdu_prim = fits.PrimaryHDU()
@@ -1452,7 +1452,7 @@ class HpxGeom(MapGeom):
             hl.append(hdu_energy)
 
         hdulist = fits.HDUList(hl)
-        hdulist.writeto(outfile, clobber=clobber)
+        hdulist.writeto(outfile, overwrite=overwrite)
 
     @staticmethod
     def get_index_list(nside, nest, region):
@@ -1756,7 +1756,7 @@ class HpxToWcsMapping(object):
         HEALPIX region"""
         return self._valid
 
-    def write(self, fitsfile, clobber=True):
+    def write(self, fitsfile, overwrite=True):
         """Write this mapping to a FITS file, to avoid having to recompute it
         """
         from .wcsnd import WcsNDMap
@@ -1775,7 +1775,7 @@ class HpxToWcsMapping(object):
         #    mult_hdu.header[key] = hpx_header[key]
 
         hdulist = index_map.to_hdulist()
-        hdulist.writeto(fitsfile, clobber=clobber)
+        hdulist.writeto(fitsfile, overwrite=overwrite)
 
     @classmethod
     def create(cls, hpx, wcs):

--- a/gammapy/scripts/cube_background.py
+++ b/gammapy/scripts/cube_background.py
@@ -298,4 +298,4 @@ def stack_observations(indir, outdir, overwrite, method='default'):
             filename = 'bg_cube_model_group{}_{}.fits.gz'.format(group, format)
             filename = Path(outdir) / filename
             log.info("Writing {}".format(filename))
-            bg_cube_model.write(str(filename), format=format, clobber=overwrite)
+            bg_cube_model.write(str(filename), format=format, overwrite=overwrite)

--- a/gammapy/scripts/image_pipe_example.yaml
+++ b/gammapy/scripts/image_pipe_example.yaml
@@ -2,7 +2,7 @@
 
 general:
   outdir: crab
-  clobber: false
+  overwrite: false
 
 source:
   lon: 83.6332124

--- a/gammapy/scripts/image_ts.py
+++ b/gammapy/scripts/image_ts.py
@@ -83,9 +83,9 @@ def cli_image_ts(input_file, output_file, psf, model, scales, downsample, residu
             fn = Path(folder) / filename_
 
             log.info('Writing {}'.format(fn))
-            result.write(str(fn), clobber=overwrite)
+            result.write(str(fn), overwrite=overwrite)
     elif results:
         log.info('Writing {}'.format(output_file))
-        results[0].write(output_file, clobber=overwrite)
+        results[0].write(output_file, overwrite=overwrite)
     else:
         log.info("No results to write to file: all scales have failed")

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -458,12 +458,12 @@ class SpectrumObservation(object):
                 # TODO: Make NDData notice change of axis
                 self.edisp.data.data = self.edisp.data.data
 
-        self.on_vector.write(outdir / phafile, clobber=overwrite)
-        self.aeff.write(outdir / arffile, clobber=overwrite)
+        self.on_vector.write(outdir / phafile, overwrite=overwrite)
+        self.aeff.write(outdir / arffile, overwrite=overwrite)
         if self.off_vector is not None:
-            self.off_vector.write(outdir / bkgfile, clobber=overwrite)
+            self.off_vector.write(outdir / bkgfile, overwrite=overwrite)
         if self.edisp is not None:
-            self.edisp.write(str(outdir / rmffile), clobber=overwrite)
+            self.edisp.write(str(outdir / rmffile), overwrite=overwrite)
 
     def peek(self, figsize=(10, 10)):
         """Quick-look summary plots."""

--- a/gammapy/utils/root/tests/test_convert.py
+++ b/gammapy/utils/root/tests/test_convert.py
@@ -72,4 +72,4 @@ def test_TH2_to_FITS():
     pprint(f.header2classic())
     filename = 'TH2_to_FITS.fits'
     print('Writing {}'.format(filename))
-    f.writetofits(filename, clobber=True)
+    f.writetofits(filename, overwrite=True)


### PR DESCRIPTION
This PR changes the `clobber` parameter in some `write` methods to `overwrite` everywhere in Gammapy. It was already the case in most places, but recently a `clobber` slipped in again in `gammapy.maps` (cc @woodmd)


This change to use `overwrite` consistently was done in Astropy since Astropy 1.3 (see e.g. https://github.com/astropy/astropy/pull/5171 or https://github.com/astropy/astropy/issues/5438), and using it now e.g. in `astropy.io.fits` will emit warnings:
```
>>> from astropy.io import fits
>>> h = fits.HDUList()
>>> h.writeto('asdf.fits', clobber=True)
WARNING: AstropyDeprecationWarning: "clobber" was deprecated in version 2.0 and will be removed in a future version. Use argument "overwrite" instead. [warnings]
WARNING: There is nothing to write. [astropy.io.fits.hdu.hdulist]
```

This `overwrite` will fail for Astropy 1.2 or earlier, but already half a year ago for the Gammapy 0.6 release we stated that only Astropy 1.3 or later is supported and tested by CI for Gammapy (see http://docs.gammapy.org/dev/changelog.html#april-28-2017).

@woodmd - OK for you / Fermi to require Astropy 1.3 or later and this change in gammapy.maps?

I also saw that you have `overwrite=True` by default, whereas I think all write methods in Astropy and elsewhere in Gammapy have `overwrite=False` by default. Consistency is good, so we should probably change to `overwrite=False` as default also in `gammapy.maps`, no? I'm not 100% sure on this point, given that at least for me the more frequent use is to write scripts and run them multiple times, always putting `overwrite=True` in `write` calls. @woodmd @registerrier - Please comment what you prefer here, and if it's not uniform we can discuss tonight in the `gammapy.maps` call and make a decision.