### PR TITLE
Add Background2D class

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -156,9 +156,9 @@ class Background3D(object):
         Parameters
         ----------
         fov_offset : `~astropy.coordinates.Angle`
-            offset in the FOV
+            offset in the FOV. Same shape than fov_phi`
         fov_phi: `~astropy.coordinates.Angle`
-            azimuth angle in the FOV.
+            azimuth angle in the FOV. Same shape than `fov_offset`
         energy_reco : `~astropy.units.Quantity`
             Vector of energy (1D) on which the model is evaluated
         method : str {'linear', 'nearest'}, optional
@@ -201,9 +201,9 @@ class Background3D(object):
         energy_bins : int
             Number of energy bins used for the integration
         fov_offset : `~astropy.coordinates.Angle`
-            offset in the FOV
+            offset in the FOV. Same shape than `fov_phi`
         fov_phi: `~astropy.coordinates.Angle`
-            azimuth angle in the FOV.
+            azimuth angle in the FOV. Same shape than `fov_offset`
         method : str {'linear', 'nearest'}, optional
             Interpolation method
         kwargs : dict
@@ -217,12 +217,11 @@ class Background3D(object):
         dim_E=len(tab_energy_band)-1
         if fov_offset is None:
             shape_bkg= (dim_E,len(self.data.axis('detx').nodes),len(self.data.axis('dety').nodes))
+        elif fov_phi is None:
+            shape_bkg= (dim_E,len(self.data.axis('detx').nodes),len(self.data.axis('dety').nodes))
         else:
             shape_bkg= tuple([dim_E]) + fov_offset.shape + fov_offset.shape
-        #    self.axis[].data
         bkg_integrated = u.Quantity(np.zeros(shape_bkg),"1 / (s sr)")
-
-        bkg_integrated = np.zeros(tab_energy_band.shape + fov_offset.shape)
         for i_e, (e_min, e_max) in enumerate(zip(tab_energy_band[0:-1], tab_energy_band[1:])):
             energy_edges = EnergyBounds.equal_log_spacing(e_min, e_max, energy_bins)
             energy_bins = energy_edges.log_centers
@@ -405,7 +404,6 @@ class Background2D(object):
             shape_bkg= (dim_E,len(self.data.axis('offset').nodes))
         else:
             shape_bkg= tuple([dim_E]) + fov_offset.shape
-        #    self.axis[].data
         bkg_integrated = u.Quantity(np.zeros(shape_bkg),"1 / (s sr)")
 
         for i_e, (e_min, e_max) in enumerate(zip(tab_energy_band[0:-1], tab_energy_band[1:])):
@@ -419,6 +417,5 @@ class Background2D(object):
             elif len(fov_offset.shape) == 1:
                 bkg_integrated[i_e, :] = np.sum(bkg_evaluated.T * energy_edges.bands, axis=1).T
             else:
-                #import IPython; IPython.embed()
                 bkg_integrated[i_e, :, :] = np.sum(bkg_evaluated.T * energy_edges.bands, axis=2).T
         return bkg_integrated

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -4,16 +4,12 @@ import pytest
 import astropy.units as u
 from numpy.testing import assert_allclose, assert_equal
 import numpy as np
-from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
 from ..background import Background3D, Background2D
 from ...utils.fits import table_to_fits_table
-from ...data import EventList
 from ...utils.energy import EnergyBounds, Energy
-from ...background import EnergyOffsetArray
-
 
 
 @pytest.fixture(scope='session')
@@ -60,33 +56,49 @@ def test_background_3d_write(bkg_3d):
 
 
 def make_test_array():
+    # Create a dummy `Background2D`
+    # Make Axes
+    nE_bins = 100
     ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
     offset = Angle(np.linspace(0, 2.5, 100), "deg")
-    array = EnergyOffsetArray(ebounds, offset)
-
-    # Define an EventList with three events
-    table = Table()
-    table['RA'] = [0.6, 0, 2] * u.deg
-    table['DEC'] = [0, 1.5, 0] * u.deg
-    table['ENERGY'] = [0.12, 22, 55] * u.TeV
-    table.meta['RA_PNT'] = 0
-    table.meta['DEC_PNT'] = 0
-    events = EventList(table)
-    array.fill_events([events])
+    data = np.zeros((nE_bins, len(offset) - 1))
+    # Make dummy data
+    data[2, 23] = 1
+    data[78, 59] = 1
     data_unit = u.Unit('s-1 MeV-1 sr-1')
     bkg_2d = Background2D(energy_lo=ebounds[0:-1], energy_hi=ebounds[1:],
-                 offset_lo=offset[0:-1], offset_hi=offset[1:],
-                          data=array.data.value*data_unit)
-    return bkg_2d, events.offset, events.energy
+                          offset_lo=offset[0:-1], offset_hi=offset[1:],
+                          data=data * data_unit)
+    return bkg_2d
 
 
+def make_test_cube():
+    # Create a dummy `Background2D`
+    # Make Axes
+    nE_bins = 100
+    ebounds = EnergyBounds.equal_log_spacing(0.1, 100, nE_bins, 'TeV')
+    offset = Angle(np.linspace(0, 2.5, 100), "deg")
+    bins = 2 * len(offset)
+    coordx_edges = Angle(np.linspace(-offset.max().value, offset.max().value, bins + 1), "deg")
+    coordy_edges = Angle(np.linspace(-offset.max().value, offset.max().value, bins + 1), "deg")
+    data = np.zeros((nE_bins, bins, bins))
+    # Make dummy data
+    data[3, 10, 152] = 1
+    data[20, 108, 52] = 1
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+    bkg_3d = Background3D(energy_lo=ebounds[0:-1], energy_hi=ebounds[1:], detx_lo=coordx_edges[0:-1],
+                          detx_hi=coordx_edges[1:], dety_lo=coordy_edges[0:-1], dety_hi=coordy_edges[1:],
+                          data=data * data_unit)
+    return bkg_3d
 
-def test_background2D_read_write(tmpdir):
-    bkg_2d_1, events_offset, events_energy=make_test_array()
-    #hdu_list=bkg_2d_1.to_hdulist(name='BACKGROUND')
-    #bkg_2d_2=Background2D.from_hdulist(hdulist=hdu_list, hdu='BACKGROUND')
-    bkg_2d_1.write(tmpdir+"/bkg2d.fits")
-    bkg_2d_2=Background2D.read(tmpdir+"/bkg2d.fits")
+
+def test_background2d_read_write(tmpdir):
+    bkg_2d_1 = make_test_array()
+    # hdu_list=bkg_2d_1.to_hdulist(name='BACKGROUND')
+    # bkg_2d_2=Background2D.from_hdulist(hdulist=hdu_list, hdu='BACKGROUND')
+    filename = str(tmpdir / "bkg2d.fits")
+    bkg_2d_1.write(filename)
+    bkg_2d_2 = Background2D.read(filename)
 
     axis = bkg_2d_2.data.axis('energy')
     assert axis.nbins == 100
@@ -96,86 +108,16 @@ def test_background2D_read_write(tmpdir):
     assert axis.nbins == 99
     assert axis.unit == 'deg'
 
-
     data = bkg_2d_2.data.data
     assert data.shape == (100, 99)
     assert data.unit == u.Unit('s-1 MeV-1 sr-1')
 
 
-
-def test_background2D_evaluate():
-    bkg_2d, events_offset, events_energy  = make_test_array()
-    method='nearest'
-    data_unit = u.Unit('s-1 MeV-1 sr-1')
-    #With some values
-    for off, e_reco in zip(events_offset, events_energy):
-        res = bkg_2d.evaluate(fov_offset= off, energy_reco=e_reco, method=method)
-        assert_quantity_allclose(res, 1*data_unit)
-    #at the default one
-    res = bkg_2d.evaluate(method=method)
-    assert_quantity_allclose(res, bkg_2d.data.data)
-    #at 2D in spatial: La premiere colone du tableau contient le bon offset
-    offset_2d=np.meshgrid(events_offset,events_offset)[0]
-    res = bkg_2d.evaluate(fov_offset= offset_2d, energy_reco= events_energy[0], method=method)
-    assert_quantity_allclose(res[:,0], 1*data_unit)
-    assert_quantity_allclose(res[:,1], 0*data_unit)
-    assert_quantity_allclose(res[:,2], 0*data_unit)
-
-
-def test_background2D_integrate_on_energy_band():
-    """
-    I define an energy range on witch I want to compute the acceptance curve that has the same boundaries as the
-    energyoffsetarray.energy one and I take a Nbin for this range equal to the number of bin of the
-    energyoffsetarray.energy one. This way, the interpolator will evaluate at energies that are the same as the one
-    that define the RegularGridInterpolator. With the method="nearest" you are sure to get 1 for the energybin where
-    are located the three events that define the energyoffsetarray. Since in this method we integrate over the energy
-    and multiply by the solid angle, I check if for the offset of the three events (bin [23, 59, 79]), we get in the
-    table["Acceptance"] what we expect by multiplying 1 by the solid angle and the energy bin width where is situated
-    the event (bin [2, 78, 91]).
-    """
-    bkg_2d, events_offset, events_energy  = make_test_array()
-    energy_range = Energy([0.1, 100], 'TeV')
-    bins = 100
-    method='nearest'
-    bkg_integrate=bkg_2d.integrate_on_energy_range(tab_energy_band=energy_range, energy_bins=bins, method=method)
-    data_unit = u.Unit('s-1 MeV-1 sr-1')
-    axis_energy_band=(bkg_2d.data.axes[0].bins[1:]-bkg_2d.data.axes[0].bins[:-1]).to('MeV')
-    assert_quantity_allclose(bkg_integrate[0,23],
-                             1* data_unit * axis_energy_band[2])
-    assert_quantity_allclose(bkg_integrate[0,59],
-                             1 * data_unit * axis_energy_band[78])
-    assert_quantity_allclose(bkg_integrate[0,79],
-                             1 * data_unit * axis_energy_band[91])
-
-    #at 2D in spatial
-    offset_2d=np.meshgrid(events_offset,events_offset)[0]
-    res = bkg_2d.integrate_on_energy_range(fov_offset= offset_2d, tab_energy_band=energy_range, energy_bins=bins, method=method)
-    assert_quantity_allclose(res[0,:,0], 1* data_unit * axis_energy_band[2])
-    assert_quantity_allclose(res[0,:,1], 1 * data_unit * axis_energy_band[78])
-    assert_quantity_allclose(res[0,:,2], 1 * data_unit * axis_energy_band[91])
-
-
-def make_test_cube():
-    nE_bins=100
-    ebounds = EnergyBounds.equal_log_spacing(0.1, 100, nE_bins, 'TeV')
-    offset = Angle(np.linspace(0, 2.5, 100), "deg")
-
-    bins = 2 * len(offset)
-    coordx_edges = Angle(np.linspace(-offset.max().value, offset.max().value, bins+1), "deg")
-    coordy_edges = Angle(np.linspace(-offset.max().value, offset.max().value, bins+1), "deg")
-    data=np.zeros((nE_bins,bins,bins))
-    #events at energy bin=[0.123,0.132] TeV, 0.12735031 TeV
-    data[3,104,152]=1
-    #events at energy bin=[0.398,0.426] TeV, 0.41209752 TeV
-    data[20,108,172]=1
-    data_unit = u.Unit('s-1 MeV-1 sr-1')
-    bkg_3d=Background3D(energy_lo=ebounds[0:-1], energy_hi=ebounds[1:],detx_lo=coordx_edges[0:-1], detx_hi=coordx_edges[1:], dety_lo=coordy_edges[0:-1], dety_hi=coordy_edges[1:],data=data*data_unit)
-    return bkg_3d
-
-def test_background3D_read_write(tmpdir):
-    bkg_3d_1=make_test_cube()
-    bkg_3d_1.write(tmpdir+"/bkg3d.fits")
-    bkg_3d_2=Background3D.read(tmpdir+"/bkg3d.fits")
+def test_background3d_read_write(tmpdir):
+    bkg_3d_1 = make_test_cube()
+    filename = str(tmpdir / "bkg3d.fits")
+    bkg_3d_1.write(filename)
+    bkg_3d_2 = Background3D.read(filename)
 
     axis = bkg_3d_2.data.axis('energy')
     assert axis.nbins == 100
@@ -189,77 +131,97 @@ def test_background3D_read_write(tmpdir):
     assert axis.nbins == 200
     assert axis.unit == 'deg'
 
-
     data = bkg_3d_2.data.data
     assert data.shape == (100, 200, 200)
     assert data.unit == u.Unit('s-1 MeV-1 sr-1')
 
-def test_background3D_evaluate():
-    bkg_3d = make_test_cube()
-    method='nearest'
+
+def test_background2d_evaluate():
+    bkg_2d = make_test_array()
+    method = 'nearest'
     data_unit = u.Unit('s-1 MeV-1 sr-1')
 
-    det_x=Angle(np.array([bkg_3d.data.axis("detx").nodes[104].value,bkg_3d.data.axis("detx").nodes[108].value]),"deg")
-    det_y=Angle(np.array([bkg_3d.data.axis("detx").nodes[152].value,bkg_3d.data.axis("dety").nodes[172].value]),"deg")
-    energy_tab=[bkg_3d.data.axis("energy").nodes[3],bkg_3d.data.axis("energy").nodes[20]]
-    offset_tab=np.sqrt(det_x**2+det_y**2)
-    phi_tab=np.arctan(det_y/det_x)
-    #at the default one
-    res = bkg_3d.evaluate(method=method)
-    assert_quantity_allclose(res, bkg_3d.data.data)
-    #at 2D in spatial
-    res = bkg_3d.evaluate(fov_offset= offset_tab,fov_phi= phi_tab, energy_reco= bkg_3d.data.axis("energy").nodes[3], method=method)
-    assert_quantity_allclose(res[0,0], 1*data_unit)
-    assert_quantity_allclose(res[0,1], 0*data_unit)
-    assert_quantity_allclose(res[1,0], 0*data_unit)
-    assert_quantity_allclose(res[1,1], 0*data_unit)
-    res = bkg_3d.evaluate(fov_offset= offset_tab,fov_phi= phi_tab, energy_reco= bkg_3d.data.axis("energy").nodes[20], method=method)
-    assert_quantity_allclose(res[0,0], 0*data_unit)
-    assert_quantity_allclose(res[0,1], 0*data_unit)
-    assert_quantity_allclose(res[1,0], 0*data_unit)
-    assert_quantity_allclose(res[1,1], 1*data_unit)
+    # Define the offset and energy for which bkg_2d contains 1. With the "nearest" method used for the interpolation
+    # we check that it is giving 1.
+    offset_tab = Angle([bkg_2d.data.axis("offset").nodes[23].value, bkg_2d.data.axis("offset").nodes[59].value], "deg")
+    energy_tab = u.Quantity([bkg_2d.data.axis("energy").nodes.value[2], bkg_2d.data.axis("energy").nodes.value[78]],
+                            bkg_2d.data.axis("energy").nodes.unit)
+    # With some values
+    for off, e_reco in zip(offset_tab, energy_tab):
+        res = bkg_2d.evaluate(fov_offset=off, energy_reco=e_reco, method=method)
+        assert_quantity_allclose(res, 1 * data_unit)
+    # Interoplate at the energy and offset bin of the bgk_2d axes
+    off = bkg_2d.data.axis('offset').nodes
+    e_reco = bkg_2d.data.axis('energy').nodes
+    res = bkg_2d.evaluate(fov_offset=off, energy_reco=e_reco, method=method)
+    assert_quantity_allclose(res, bkg_2d.data.data)
+    # Test that evaluate works for a 2D offset array. The bkg_2d data contains 1 for first column of the offset 2D array
+    # and energy_tab[0].
+    offset_2d = np.meshgrid(offset_tab, energy_tab)[0]
+    res = bkg_2d.evaluate(fov_offset=offset_2d, energy_reco=energy_tab[0], method=method)
+    assert_quantity_allclose(res[:, 0], 1 * data_unit)
+    assert_quantity_allclose(res[:, 1], 0 * data_unit)
 
-def test_background3D_integrate_on_energy_band():
-    """
-    I define an energy range on witch I want to compute the acceptance curve that has the same boundaries as the
-    energyoffsetarray.energy one and I take a Nbin for this range equal to the number of bin of the
-    energyoffsetarray.energy one. This way, the interpolator will evaluate at energies that are the same as the one
-    that define the RegularGridInterpolator. With the method="nearest" you are sure to get 1 for the energybin where
-    are located the three events that define the energyoffsetarray. Since in this method we integrate over the energy
-    and multiply by the solid angle, I check if for the offset of the three events (bin [23, 59, 79]), we get in the
-    table["Acceptance"] what we expect by multiplying 1 by the solid angle and the energy bin width where is situated
-    the event (bin [2, 78, 91]).
-    """
+
+def test_background3d_evaluate():
     bkg_3d = make_test_cube()
-    method='nearest'
+    method = 'nearest'
     data_unit = u.Unit('s-1 MeV-1 sr-1')
 
-    det_x=Angle(np.array([bkg_3d.data.axis("detx").nodes[104].value,bkg_3d.data.axis("detx").nodes[108].value]),"deg")
-    det_y=Angle(np.array([bkg_3d.data.axis("detx").nodes[152].value,bkg_3d.data.axis("dety").nodes[172].value]),"deg")
-    energy_tab=[bkg_3d.data.axis("energy").nodes[3],bkg_3d.data.axis("energy").nodes[20]]
-    offset_tab=np.sqrt(det_x**2+det_y**2)
-    phi_tab=np.arctan(det_y/det_x)
+    # at 2D in spatial
+    # Define the detx,dety and energy for which bkg_2d contains 1. With the "nearest" method used for the interpolation
+    # we check that it is giving 1.
+    det_x = Angle(np.array([bkg_3d.data.axis("detx").nodes[10].value, bkg_3d.data.axis("detx").nodes[108].value]),
+                  "deg")
+    det_y = Angle(np.array([bkg_3d.data.axis("detx").nodes[152].value, bkg_3d.data.axis("dety").nodes[52].value]),
+                  "deg")
+    energy_tab = [bkg_3d.data.axis("energy").nodes[3], bkg_3d.data.axis("energy").nodes[20]]
+    offset_tab = np.sqrt(det_x ** 2 + det_y ** 2)
+    phi_tab = np.arctan(det_y / det_x)
+    phi_tab.value[np.where(det_x.value < 0)] = phi_tab.value[np.where(det_x.value < 0)] + np.pi
+    # For the energy.nodes[3], only the the coordinates (0,0) of the (off,phi) array contains 1
+    res = bkg_3d.evaluate(fov_offset=offset_tab, fov_phi=phi_tab, energy_reco=energy_tab[0], method=method)
+    assert_quantity_allclose(res[0, 0], 1 * data_unit)
+    assert_quantity_allclose(res[0, 1], 0 * data_unit)
+    assert_quantity_allclose(res[1, 0], 0 * data_unit)
+    assert_quantity_allclose(res[1, 1], 0 * data_unit)
+    # For the energy.nodes[20], only the the coordinates (0,0) of the (off,phi) array contains 1
+    res = bkg_3d.evaluate(fov_offset=offset_tab, fov_phi=phi_tab, energy_reco=energy_tab[1], method=method)
+    assert_quantity_allclose(res[0, 0], 0 * data_unit)
+    assert_quantity_allclose(res[0, 1], 0 * data_unit)
+    assert_quantity_allclose(res[1, 0], 0 * data_unit)
+    assert_quantity_allclose(res[1, 1], 1 * data_unit)
 
+
+def test_background2d_integrate_on_energy_band():
+    """
+    We define an energy range on witch we want to compute the integral background rate that has the same boundaries as the
+    energy axis of the Background2D one. The number of bins used for the integration on this range is the same than the
+    energy axis of the Background2D. This way, the interpolator will evaluate at energies that are the same as the one
+    that define the RegularGridInterpolator. With the method="nearest",we are sure to get 1 for the energybin where
+    are located the "1" value of the dummy Background2D data (see function make_test_cube() above). I check if for the
+    (offset) of these "1" value (23) and (59), we get what we expect by multiplying 1 by the energy bin width
+    (bin 2 for (offset)=(23) and bin 78 for (offset)=(59)).
+    """
+    bkg_2d = make_test_array()
     energy_range = Energy([0.1, 100], 'TeV')
     bins = 100
-    method='nearest'
-    import IPython; IPython.embed()
-    bkg_integrate=bkg_3d.integrate_on_energy_range(tab_energy_band=energy_range, energy_bins=bins, method=method)
+    method = 'nearest'
+    off = bkg_2d.data.axis('offset').nodes
+    bkg_integrate = bkg_2d.integrate_on_energy_range(tab_energy_band=energy_range, energy_bins=bins, fov_offset=off,
+                                                     method=method)
     data_unit = u.Unit('s-1 MeV-1 sr-1')
-    axis_energy_band=(bkg_2d.data.axes[0].bins[1:]-bkg_2d.data.axes[0].bins[:-1]).to('MeV')
-    assert_quantity_allclose(bkg_integrate[0,104,152],
-                             1* data_unit * axis_energy_band[2])
-    assert_quantity_allclose(bkg_integrate[0,108,172],
+    axis_energy_band = (bkg_2d.data.axes[0].bins[1:] - bkg_2d.data.axes[0].bins[:-1]).to('MeV')
+    assert_quantity_allclose(bkg_integrate[23],
+                             1 * data_unit * axis_energy_band[2])
+    assert_quantity_allclose(bkg_integrate[59],
                              1 * data_unit * axis_energy_band[78])
-    bkg_integrate=bkg_3d.integrate_on_energy_range(fov_offset= offset_tab,fov_phi= phi_tab, tab_energy_band=energy_range, energy_bins=bins, method=method)
-
-    """
-    #at 2D in spatial
-    offset_2d=np.meshgrid(events_offset,events_offset)[0]
-    res = bkg_2d.integrate_on_energy_range(fov_offset= offset_2d, tab_energy_band=energy_range, energy_bins=bins, method=method)
-    assert_quantity_allclose(res[0,:,0], 1* data_unit * axis_energy_band[2])
-    assert_quantity_allclose(res[0,:,1], 1 * data_unit * axis_energy_band[78])
-    assert_quantity_allclose(res[0,:,2], 1 * data_unit * axis_energy_band[91])
-    """
-
-
+    # at 2D in spatial
+    offset_tab = Angle([bkg_2d.data.axis("offset").nodes[23].value, bkg_2d.data.axis("offset").nodes[59].value], "deg")
+    energy_tab = u.Quantity([bkg_2d.data.axis("energy").nodes.value[2], bkg_2d.data.axis("energy").nodes.value[78]],
+                            bkg_2d.data.axis("energy").nodes.unit)
+    offset_2d = np.meshgrid(offset_tab, energy_tab)[0]
+    res = bkg_2d.integrate_on_energy_range(fov_offset=offset_2d, tab_energy_band=energy_range, energy_bins=bins,
+                                           method=method)
+    assert_quantity_allclose(res[:, 0], 1 * data_unit * axis_energy_band[2])
+    assert_quantity_allclose(res[:, 1], 1 * data_unit * axis_energy_band[78])

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -3,9 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import astropy.units as u
 from numpy.testing import assert_allclose, assert_equal
+import numpy as np
+from astropy.table import Table
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
-from ..background import Background3D
+from ..background import Background3D, Background2D
 from ...utils.fits import table_to_fits_table
+from ...data import EventList
+from ...utils.energy import EnergyBounds, Energy
+from ...background import EnergyOffsetArray
+
 
 
 @pytest.fixture(scope='session')
@@ -49,3 +57,81 @@ def test_background_3d_write(bkg_3d):
     hdu = table_to_fits_table(bkg_3d.to_table())
     assert_equal(hdu.data['DETX_LO'][0], bkg_3d.data.axis('detx').lo.value)
     assert hdu.header['TUNIT1'] == bkg_3d.data.axis('detx').lo.unit
+
+
+def make_test_array():
+    ebounds = EnergyBounds.equal_log_spacing(0.1, 100, 100, 'TeV')
+    offset = Angle(np.linspace(0, 2.5, 100), "deg")
+    array = EnergyOffsetArray(ebounds, offset)
+
+    # Define an EventList with three events
+    table = Table()
+    table['RA'] = [0.6, 0, 2] * u.deg
+    table['DEC'] = [0, 1.5, 0] * u.deg
+    table['ENERGY'] = [0.12, 22, 55] * u.TeV
+    table.meta['RA_PNT'] = 0
+    table.meta['DEC_PNT'] = 0
+    events = EventList(table)
+    array.fill_events([events])
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+    bkg_2d = Background2D(energy_lo=ebounds[0:-1], energy_hi=ebounds[1:],
+                 offset_lo=offset[0:-1], offset_hi=offset[1:],
+                          data=array.data.value*data_unit)
+    return bkg_2d, events.offset, events.energy
+
+def test_background2D_read_write(tmpdir):
+    bkg_2d_1, events_offset, events_energy=make_test_array()
+    #hdu_list=bkg_2d_1.to_hdulist(name='BACKGROUND')
+    #bkg_2d_2=Background2D.from_hdulist(hdulist=hdu_list, hdu='BACKGROUND')
+    bkg_2d_1.write(tmpdir+"/bkg2d.fits")
+    bkg_2d_2=Background2D.read(tmpdir+"/bkg2d.fits")
+
+    axis = bkg_2d_2.data.axis('energy')
+    assert axis.nbins == 100
+    assert axis.unit == 'TeV'
+
+    axis = bkg_2d_2.data.axis('offset')
+    assert axis.nbins == 99
+    assert axis.unit == 'deg'
+
+
+    data = bkg_2d_2.data.data
+    assert data.shape == (100, 99)
+    assert data.unit == u.Unit('s-1 MeV-1 sr-1')
+
+
+
+def test_background2D_evaluate():
+    bkg_2d, events_offset, events_energy  = make_test_array()
+    method='nearest'
+    for off, e_reco in zip(events_offset, events_energy):
+        res = bkg_2d.evaluate(fov_offset= off, energy_reco=e_reco, method=method)
+        data_unit = u.Unit('s-1 MeV-1 sr-1')
+        assert_quantity_allclose(res, 1*data_unit)
+
+
+def test_background2D_integrate_on_energy_band():
+    """
+    I define an energy range on witch I want to compute the acceptance curve that has the same boundaries as the
+    energyoffsetarray.energy one and I take a Nbin for this range equal to the number of bin of the
+    energyoffsetarray.energy one. This way, the interpolator will evaluate at energies that are the same as the one
+    that define the RegularGridInterpolator. With the method="nearest" you are sure to get 1 for the energybin where
+    are located the three events that define the energyoffsetarray. Since in this method we integrate over the energy
+    and multiply by the solid angle, I check if for the offset of the three events (bin [23, 59, 79]), we get in the
+    table["Acceptance"] what we expect by multiplying 1 by the solid angle and the energy bin width where is situated
+    the event (bin [2, 78, 91]).
+    """
+    bkg_2d, events_offset, events_energy  = make_test_array()
+    energy_range = Energy([0.1, 100], 'TeV')
+    bins = 100
+    method='nearest'
+    bkg_integrate=bkg_2d.integrate_on_energy_range(tab_energy_band=energy_range, energy_bins=bins, method=method)
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+    assert_quantity_allclose(bkg_integrate[23],
+                             1* data_unit * bkg_2d.data.axes[0].bins[2].to('MeV'))
+    assert_quantity_allclose(bkg_integrate[59],
+                             1 * data_unit * bkg_2d.data.axes[0].bins[78].to('MeV'))
+    assert_quantity_allclose(bkg_integrate[79],
+                             1 * data_unit * bkg_2d.data.axes[0].bins[91].to('MeV'))
+
+

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -79,6 +79,8 @@ def make_test_array():
                           data=array.data.value*data_unit)
     return bkg_2d, events.offset, events.energy
 
+
+
 def test_background2D_read_write(tmpdir):
     bkg_2d_1, events_offset, events_energy=make_test_array()
     #hdu_list=bkg_2d_1.to_hdulist(name='BACKGROUND')
@@ -104,10 +106,20 @@ def test_background2D_read_write(tmpdir):
 def test_background2D_evaluate():
     bkg_2d, events_offset, events_energy  = make_test_array()
     method='nearest'
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+    #With some values
     for off, e_reco in zip(events_offset, events_energy):
         res = bkg_2d.evaluate(fov_offset= off, energy_reco=e_reco, method=method)
-        data_unit = u.Unit('s-1 MeV-1 sr-1')
         assert_quantity_allclose(res, 1*data_unit)
+    #at the default one
+    res = bkg_2d.evaluate(method=method)
+    assert_quantity_allclose(res, bkg_2d.data.data)
+    #at 2D in spatial: La premiere colone du tableau contient le bon offset
+    offset_2d=np.meshgrid(events_offset,events_offset)[0]
+    res = bkg_2d.evaluate(fov_offset= offset_2d, energy_reco= events_energy[0], method=method)
+    assert_quantity_allclose(res[:,0], 1*data_unit)
+    assert_quantity_allclose(res[:,1], 0*data_unit)
+    assert_quantity_allclose(res[:,2], 0*data_unit)
 
 
 def test_background2D_integrate_on_energy_band():
@@ -127,11 +139,127 @@ def test_background2D_integrate_on_energy_band():
     method='nearest'
     bkg_integrate=bkg_2d.integrate_on_energy_range(tab_energy_band=energy_range, energy_bins=bins, method=method)
     data_unit = u.Unit('s-1 MeV-1 sr-1')
-    assert_quantity_allclose(bkg_integrate[23],
-                             1* data_unit * bkg_2d.data.axes[0].bins[2].to('MeV'))
-    assert_quantity_allclose(bkg_integrate[59],
-                             1 * data_unit * bkg_2d.data.axes[0].bins[78].to('MeV'))
-    assert_quantity_allclose(bkg_integrate[79],
-                             1 * data_unit * bkg_2d.data.axes[0].bins[91].to('MeV'))
+    axis_energy_band=(bkg_2d.data.axes[0].bins[1:]-bkg_2d.data.axes[0].bins[:-1]).to('MeV')
+    assert_quantity_allclose(bkg_integrate[0,23],
+                             1* data_unit * axis_energy_band[2])
+    assert_quantity_allclose(bkg_integrate[0,59],
+                             1 * data_unit * axis_energy_band[78])
+    assert_quantity_allclose(bkg_integrate[0,79],
+                             1 * data_unit * axis_energy_band[91])
+
+    #at 2D in spatial
+    offset_2d=np.meshgrid(events_offset,events_offset)[0]
+    res = bkg_2d.integrate_on_energy_range(fov_offset= offset_2d, tab_energy_band=energy_range, energy_bins=bins, method=method)
+    assert_quantity_allclose(res[0,:,0], 1* data_unit * axis_energy_band[2])
+    assert_quantity_allclose(res[0,:,1], 1 * data_unit * axis_energy_band[78])
+    assert_quantity_allclose(res[0,:,2], 1 * data_unit * axis_energy_band[91])
+
+
+def make_test_cube():
+    nE_bins=100
+    ebounds = EnergyBounds.equal_log_spacing(0.1, 100, nE_bins, 'TeV')
+    offset = Angle(np.linspace(0, 2.5, 100), "deg")
+
+    bins = 2 * len(offset)
+    coordx_edges = Angle(np.linspace(-offset.max().value, offset.max().value, bins+1), "deg")
+    coordy_edges = Angle(np.linspace(-offset.max().value, offset.max().value, bins+1), "deg")
+    data=np.zeros((nE_bins,bins,bins))
+    #events at energy bin=[0.123,0.132] TeV, 0.12735031 TeV
+    data[3,104,152]=1
+    #events at energy bin=[0.398,0.426] TeV, 0.41209752 TeV
+    data[20,108,172]=1
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+    bkg_3d=Background3D(energy_lo=ebounds[0:-1], energy_hi=ebounds[1:],detx_lo=coordx_edges[0:-1], detx_hi=coordx_edges[1:], dety_lo=coordy_edges[0:-1], dety_hi=coordy_edges[1:],data=data*data_unit)
+    return bkg_3d
+
+def test_background3D_read_write(tmpdir):
+    bkg_3d_1=make_test_cube()
+    bkg_3d_1.write(tmpdir+"/bkg3d.fits")
+    bkg_3d_2=Background3D.read(tmpdir+"/bkg3d.fits")
+
+    axis = bkg_3d_2.data.axis('energy')
+    assert axis.nbins == 100
+    assert axis.unit == 'TeV'
+
+    axis = bkg_3d_2.data.axis('detx')
+    assert axis.nbins == 200
+    assert axis.unit == 'deg'
+
+    axis = bkg_3d_2.data.axis('dety')
+    assert axis.nbins == 200
+    assert axis.unit == 'deg'
+
+
+    data = bkg_3d_2.data.data
+    assert data.shape == (100, 200, 200)
+    assert data.unit == u.Unit('s-1 MeV-1 sr-1')
+
+def test_background3D_evaluate():
+    bkg_3d = make_test_cube()
+    method='nearest'
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+
+    det_x=Angle(np.array([bkg_3d.data.axis("detx").nodes[104].value,bkg_3d.data.axis("detx").nodes[108].value]),"deg")
+    det_y=Angle(np.array([bkg_3d.data.axis("detx").nodes[152].value,bkg_3d.data.axis("dety").nodes[172].value]),"deg")
+    energy_tab=[bkg_3d.data.axis("energy").nodes[3],bkg_3d.data.axis("energy").nodes[20]]
+    offset_tab=np.sqrt(det_x**2+det_y**2)
+    phi_tab=np.arctan(det_y/det_x)
+    #at the default one
+    res = bkg_3d.evaluate(method=method)
+    assert_quantity_allclose(res, bkg_3d.data.data)
+    #at 2D in spatial
+    res = bkg_3d.evaluate(fov_offset= offset_tab,fov_phi= phi_tab, energy_reco= bkg_3d.data.axis("energy").nodes[3], method=method)
+    assert_quantity_allclose(res[0,0], 1*data_unit)
+    assert_quantity_allclose(res[0,1], 0*data_unit)
+    assert_quantity_allclose(res[1,0], 0*data_unit)
+    assert_quantity_allclose(res[1,1], 0*data_unit)
+    res = bkg_3d.evaluate(fov_offset= offset_tab,fov_phi= phi_tab, energy_reco= bkg_3d.data.axis("energy").nodes[20], method=method)
+    assert_quantity_allclose(res[0,0], 0*data_unit)
+    assert_quantity_allclose(res[0,1], 0*data_unit)
+    assert_quantity_allclose(res[1,0], 0*data_unit)
+    assert_quantity_allclose(res[1,1], 1*data_unit)
+
+def test_background3D_integrate_on_energy_band():
+    """
+    I define an energy range on witch I want to compute the acceptance curve that has the same boundaries as the
+    energyoffsetarray.energy one and I take a Nbin for this range equal to the number of bin of the
+    energyoffsetarray.energy one. This way, the interpolator will evaluate at energies that are the same as the one
+    that define the RegularGridInterpolator. With the method="nearest" you are sure to get 1 for the energybin where
+    are located the three events that define the energyoffsetarray. Since in this method we integrate over the energy
+    and multiply by the solid angle, I check if for the offset of the three events (bin [23, 59, 79]), we get in the
+    table["Acceptance"] what we expect by multiplying 1 by the solid angle and the energy bin width where is situated
+    the event (bin [2, 78, 91]).
+    """
+    bkg_3d = make_test_cube()
+    method='nearest'
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+
+    det_x=Angle(np.array([bkg_3d.data.axis("detx").nodes[104].value,bkg_3d.data.axis("detx").nodes[108].value]),"deg")
+    det_y=Angle(np.array([bkg_3d.data.axis("detx").nodes[152].value,bkg_3d.data.axis("dety").nodes[172].value]),"deg")
+    energy_tab=[bkg_3d.data.axis("energy").nodes[3],bkg_3d.data.axis("energy").nodes[20]]
+    offset_tab=np.sqrt(det_x**2+det_y**2)
+    phi_tab=np.arctan(det_y/det_x)
+
+    energy_range = Energy([0.1, 100], 'TeV')
+    bins = 100
+    method='nearest'
+    import IPython; IPython.embed()
+    bkg_integrate=bkg_3d.integrate_on_energy_range(tab_energy_band=energy_range, energy_bins=bins, method=method)
+    data_unit = u.Unit('s-1 MeV-1 sr-1')
+    axis_energy_band=(bkg_2d.data.axes[0].bins[1:]-bkg_2d.data.axes[0].bins[:-1]).to('MeV')
+    assert_quantity_allclose(bkg_integrate[0,104,152],
+                             1* data_unit * axis_energy_band[2])
+    assert_quantity_allclose(bkg_integrate[0,108,172],
+                             1 * data_unit * axis_energy_band[78])
+    bkg_integrate=bkg_3d.integrate_on_energy_range(fov_offset= offset_tab,fov_phi= phi_tab, tab_energy_band=energy_range, energy_bins=bins, method=method)
+
+    """
+    #at 2D in spatial
+    offset_2d=np.meshgrid(events_offset,events_offset)[0]
+    res = bkg_2d.integrate_on_energy_range(fov_offset= offset_2d, tab_energy_band=energy_range, energy_bins=bins, method=method)
+    assert_quantity_allclose(res[0,:,0], 1* data_unit * axis_energy_band[2])
+    assert_quantity_allclose(res[0,:,1], 1 * data_unit * axis_energy_band[78])
+    assert_quantity_allclose(res[0,:,2], 1 * data_unit * axis_energy_band[91])
+    """
 
 

--- a/gammapy/irf/tests/test_irf_write.py
+++ b/gammapy/irf/tests/test_irf_write.py
@@ -63,11 +63,11 @@ class TestIRFWrite:
 
         assert self.aeff.to_fits().header['EXTNAME'] == 'EFFECTIVE AREA'
         assert self.edisp.to_fits().header['EXTNAME'] == 'ENERGY DISPERSION'
-        assert self.bkg.to_fits().header['EXTNAME'] == 'BACKGROUND'
+        assert self.bkg.to_hdulist()[1].header['EXTNAME'] == 'BACKGROUND'
 
         assert self.aeff.to_fits(name='TEST').header['EXTNAME'] == 'TEST'
         assert self.edisp.to_fits(name='TEST').header['EXTNAME'] == 'TEST'
-        assert self.bkg.to_fits(name='TEST').header['EXTNAME'] == 'TEST'
+        assert self.bkg.to_hdulist(name='TEST')[1].header['EXTNAME'] == 'TEST'
         assert_equal(self.aeff.to_fits().data[self.aeff.to_fits().header['TTYPE1']][0]
                      * u.Unit(self.aeff.to_fits().header['TUNIT1']),
                      self.aeff.data.axes[0].lo)
@@ -82,11 +82,11 @@ class TestIRFWrite:
                      * u.Unit(self.edisp.to_fits().header['TUNIT7']),
                      self.edisp.data.data)
 
-        assert_equal(self.bkg.to_fits().data[self.bkg.to_fits().header['TTYPE1']][0]
-                     * u.Unit(self.bkg.to_fits().header['TUNIT1']),
+        assert_equal(self.bkg.to_hdulist()[1].data[self.bkg.to_hdulist()[1].header['TTYPE1']][0]
+                     * u.Unit(self.bkg.to_hdulist()[1].header['TUNIT1']),
                      self.bkg.data.axes[1].lo)
-        assert_equal(self.bkg.to_fits().data[self.bkg.to_fits().header['TTYPE7']][0]
-                     * u.Unit(self.bkg.to_fits().header['TUNIT7']),
+        assert_equal(self.bkg.to_hdulist()[1].data[self.bkg.to_hdulist()[1].header['TTYPE7']][0]
+                     * u.Unit(self.bkg.to_hdulist()[1].header['TUNIT7']),
                      self.bkg.data.data)
 
     def test_writeread(self, tmpdir):
@@ -94,7 +94,7 @@ class TestIRFWrite:
         prim_hdu = fits.PrimaryHDU()
         hdu_aeff = self.aeff.to_fits()
         hdu_edisp = self.edisp.to_fits()
-        hdu_bkg = self.bkg.to_fits()
+        hdu_bkg = self.bkg.to_hdulist()[1]
         fits.HDUList([prim_hdu, hdu_aeff, hdu_edisp, hdu_bkg]).writeto(filename)
         read_aeff = EffectiveAreaTable2D.read(filename=filename, hdu='EFFECTIVE AREA')
         read_edisp = EnergyDispersion2D.read(filename=filename, hdu='ENERGY DISPERSION')


### PR DESCRIPTION
This PR concern the addition of a `Background2D`class with the same API as the Background 3D since we could have 2D modelisation of the background in (energy,offset).
It also add an evaluate methode and an integrate method to compute the background rate per steradian over an energy range. We use fov_offset and fov_phi in both classes in order for the user to not have to know which type of background he is using when he want to evaluate on a grid coordinate for example. Of course for the Background2D`, fov_phi is not used. For the `Background3D`, I encountered issues for the evaluate method report in this issue (https://github.com/gammapy/gammapy/issues/1308#issuecomment-365696674) since the fov_offset and fov_phi are not independant...