### PR TITLE
Fix data_fits_name for "bg_cube" scheme in FOVCube

### DIFF
--- a/gammapy/background/fov_cube.py
+++ b/gammapy/background/fov_cube.py
@@ -174,7 +174,7 @@ class FOVCube(object):
             scheme_dict['coordx_fits_name'] = 'DETX'
             scheme_dict['coordy_fits_name'] = 'DETY'
             scheme_dict['energy_fits_name'] = 'ENERG'
-            scheme_dict['data_fits_name'] = 'Bgd'
+            scheme_dict['data_fits_name'] = 'BKG'
             scheme_dict['coordx_plot_name'] = 'DET X'
             scheme_dict['coordy_plot_name'] = 'DET Y'
             scheme_dict['energy_plot_name'] = 'E'


### PR DESCRIPTION
This is a small fix to bring this class in line with the specs, see http://gamma-astro-data-formats.readthedocs.io/en/latest/irfs/full_enclosure/bkg/index.html#bkg-3d.