### PR TITLE
A minor modification in the PhaseCurve class

### DIFF
--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -84,7 +84,7 @@ class PhaseCurve(object):
         f1 = pars['f1'].value
         f2 = pars['f2'].value
 
-        t = time - time_0
+        t = (time - time_0)*86400.0
         phase = self._evaluate_phase(t, phase_0, f0, f1, f2)
         return np.remainder(phase, 1)
 

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -11,22 +11,22 @@ from ..models import PhaseCurve
 def phase_curve():
     filename = make_path('$GAMMAPY_EXTRA/test_datasets/phasecurve_LSI_DC.fits')
     table = Table.read(str(filename))
-    return PhaseCurve(table, time_0=43366.275, phase_0=0.0, f0=0.5, f1=0.0, f2=0.0)
+    return PhaseCurve(table, time_0=43366.275, phase_0=0.0, f0=4.367575e-7, f1=0.0, f2=0.0)
 
 
 @requires_data('gammapy-extra')
 def test_phasecurve_phase(phase_curve):
     time = 46300.0
     phase = phase_curve.phase(time)
-    assert_allclose(phase, 0.8624999999992724)
+    assert_allclose(phase, 0.7066006737999402)
 
 
 @requires_data('gammapy-extra')
 def test_phasecurve_evaluate(phase_curve):
     time = 46300.0
     value = phase_curve.evaluate_norm_at_time(time)
-    assert_allclose(value, 0.05)
+    assert_allclose(value, 0.49059393580053845)
 
     phase = phase_curve.phase(time)
     value = phase_curve.evaluate_norm_at_phase(phase)
-    assert_allclose(value, 0.05)
+    assert_allclose(value, 0.49059393580053845)


### PR DESCRIPTION
In the previous PR, the values of the `f0,f1,f2` were arbitrary. This time the values are used directly from the XML model file of 1DC, and the values correctly represent the binary. The units of `f0, f1, f2` are `s^-1, s^-2, s^-3`, respectively. Hence, a modification is required in a method of the `models.py` file.  