### PR TITLE
Make the FluxPointEstimator work on multiple observations

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -130,6 +130,9 @@ class SpectrumFit(object):
         true_range = []
         for binrange, obs in zip(self.bins_in_fit_range, self.obs_list):
             idx = np.where(binrange)[0]
+            if len(idx) == 0:
+                true_range.append(None)
+                continue
             e_min = obs.e_reco[idx[0]]
             e_max = obs.e_reco[idx[-1] + 1]
             fit_range = u.Quantity((e_min, e_max))
@@ -150,7 +153,6 @@ class SpectrumFit(object):
                 idx_lo = np.where(energy * (1 + precision) < self.fit_range[0])[0]
                 valid_range[idx_lo] = 1
 
-                
                 idx_hi = np.where(energy[:-1] * (1 - precision) > self.fit_range[1])[0]
                 if len(idx_hi) != 0:
                     idx_hi = np.insert(idx_hi, 0, idx_hi[0] - 1)
@@ -406,7 +408,6 @@ class SpectrumFit(object):
 
         model = self.model.copy()
         if self.background_model is not None:
-
             bkg_model = self.background_model.copy()
         else:
             bkg_model = None

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -806,7 +806,7 @@ class FluxPointEstimator(object):
         # compute TS value for all observations
         stat_best_fit = np.sum([res.statval for res in fit.result])
 
-        dnde, dnde_err = res.model.evaluate_error(energy_ref)
+        dnde, dnde_err = fit.result[0].model.evaluate_error(energy_ref)
         sqrt_ts = self.compute_flux_point_sqrt_ts(fit, stat_best_fit=stat_best_fit)
 
         dnde_ul = self.compute_flux_point_ul(fit, stat_best_fit=stat_best_fit)


### PR DESCRIPTION
These are some small fixes to make it possible to run the `FluxPointEstimator` on a `SpectrumObservationList` (rather than a single `SpectrumObservation`).

The most important point is that the computation of upper limits needs to be fixed, since that relied on there being only a single entry in the `result` attribute of the fit.

The changes in gammapy/spectrum/fit.py are necessary to catch cases in which one of the observations in the list has no "safe" bins within the energy bounds specified by the `FluxPointEstimator`.