### PR TITLE
Add function to compute counts maps

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -8,3 +8,4 @@ from .exposure import *
 from .utils import *
 from .models import *
 from .cube_pipe import *
+from .basic_cube import *

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -4,27 +4,22 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ..maps import WcsNDMap
 
-def make_map_counts(event_list, valid_ref_map):
-    """Build a ``WcsNDMap` with events from an EventList.
+def fill_map_counts(event_list, ndmap):
+    """Fill a ``WcsNDMap` with events from an EventList.
 
-    The energy of the events is used for a non-spatial axis homogeneous to energy.
-    The other non-spatial axis names should have an entry in the colum names of the ``EventList``
+     The energy of the events is used for a non-spatial axis homogeneous to energy.
+     The other non-spatial axis names should have an entry in the colum names of the ``EventList``
 
-    Parameters
-    ----------
-    event_list : `~gammapy.data.EventList`
-            the input event list
-    valid_ref_map : `~gammapy.maps.WcsNDMap`
-        Map containing the valid pixels
-
-    Returns
-    -------
-    cntmap : `~gammapy.maps.WcsNDMap`
-        Count cube (3D) in true energy bins
-    """
+     Parameters
+     ----------
+     event_list : `~gammapy.data.EventList`
+             the input event list
+     nd_map : `~gammapy.maps.WcsNDMap`
+         Target map
+     """
     # The list will contain the event table entries to be fed into the WcsNDMap
     tmp = list()
-    ref_geom = valid_ref_map.geom
+    ref_geom = ndmap.geom
     # Convert events coordinates
     if ref_geom.coordsys == 'GAL':
         galactic_coords = event_list.galactic
@@ -51,12 +46,31 @@ def make_map_counts(event_list, valid_ref_map):
         else:
             raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
 
+    # Fill it
+    ndmap.fill_by_coords(tmp)
+
+
+def make_map_counts(event_list, ref_geom):
+    """Build a ``WcsNDMap` with events from an EventList.
+
+    The energy of the events is used for a non-spatial axis homogeneous to energy.
+    The other non-spatial axis names should have an entry in the colum names of the ``EventList``
+
+    Parameters
+    ----------
+    event_list : `~gammapy.data.EventList`
+            the input event list
+    ref_geom : `~gammapy.maps.WcsGeom`
+
+
+    Returns
+    -------
+    cntmap : `~gammapy.maps.WcsNDMap`
+        Count cube (3D) in true energy bins
+    """
     # Create map
     cntmap = WcsNDMap(ref_geom)
     # Fill it
-    cntmap.fill_by_coords(tmp)
-
-    # Put counts outside validity region to zero
-    cntmap.data *= valid_ref_map.data
+    fill_map_counts(event_list,cntmap)
 
     return cntmap

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -34,11 +34,11 @@ def fill_map_counts(event_list, ndmap):
         # TODO: add proper extraction for time
         else:
             # We look for other axes name in the table column names (case insensitive)
-            try:
-                # Here we implicitly assume that there is only one column with the same name
-                column_name = next(_ for _ in event_list.table.colnames if _.upper() == axis.name.upper())
+            colnames = [_.upper() for _ in event_list.table.colnames]
+            if axis.name.upper() in colnames:
+                column_name = event_list.table.colnames[colnames.index(axis.name.upper())]
                 coord_dict.update({axis.name: event_list.table[column_name].to(axis.unit)})
-            except StopIteration:
+            else:
                 raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
     # Fill it
     ndmap.fill_by_coord(coord_dict)

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -43,33 +43,3 @@ def fill_map_counts(count_map, event_list):
                 raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
     # Fill it
     count_map.fill_by_coord(coord_dict)
-
-
-def make_map_counts(event_list, geom, meta=None):
-    """Build a ``WcsNDMap` with events from an EventList.
-
-    The energy of the events is used for a non-spatial axis homogeneous to energy.
-    The other non-spatial axis names should have an entry in the colum names of the ``EventList``
-
-    Parameters
-    ----------
-    event_list : `~gammapy.data.EventList`
-            the input event list
-    geom : `~gammapy.maps.WcsGeom`
-            the reference geometry
-    meta : `~collections.OrderedDict`
-            Dictionnary of meta information to keep with the map
-
-    Returns
-    -------
-    cntmap : `~gammapy.maps.WcsNDMap`
-        Count cube (3D) in true energy bins
-    """
-    # Create map
-    cntmap = WcsNDMap(geom,meta=meta)
-    # Fill it
-    fill_map_counts(event_list, cntmap)
-    # Add MAPTYPE keyword to identify the nature of the map
-    cntmap.meta['MAPTYPE']='COUNTS'
-
-    return cntmap

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Functions to perform basic functions for map and cube analysis.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+from ..maps import WcsNDMap
+
+def make_map_counts(evts, valid_ref_map):
+    """
+    Build a ``WcsNDMap` with events from an EventList.
+    The energy of the events is used for a non-spatial axis homogeneous to energy.
+    The other non-spatial axis names should have an entry in the colum names of the ``EventList``
+
+    Parameters
+    __________
+
+    evts : `~gammapy.data.EventList`
+            the input event list
+    valid_ref_map : `~gammapy.maps.WcsNDMap`
+        Map containing the valid pixels
+
+    Returns
+    -------
+    cntmap : `~gammapy.maps.WcsNDMap`
+        Count cube (3D) in true energy bins
+
+    """
+    # The list will contain the event table entries to be fed into the WcsNDMap
+    tmp = list()
+    ref_geom = valid_ref_map.geom
+    # Convert events coordinates
+    if ref_geom.coordsys == 'GAL':
+        tmp.append(evts.galactic.l)
+        tmp.append(evts.galactic.b)
+    elif ref_geom.coordsys == 'CEL':
+        tmp.append(evts.radec.ra)
+        tmp.append(evts.radec.dec)
+    else:
+        # should raise an error here. The map is not correct.
+        raise ValueError("Incorrect coordsys of input map.")
+
+    for i, axis in enumerate(ref_geom.axes):
+        if axis.unit.is_equivalent("eV"):
+            # This axis is the energy
+            tmp.append(evts.energy.to(axis.unit))
+        elif axis.name.upper() in evts.table.colnames:
+            # Here we assume that colanmes are all capital
+            tmp.append(evts.table[axis.name.upper()].to(axis.unit))
+        elif axis.name.lower() in evts.table.colnames:
+            # Here we assume that colanmes are not capital
+            tmp.append(evts.table[axis.name.lower()].to(axis.unit))
+        else:
+            raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
+
+    # Create map
+    cntmap = WcsNDMap(ref_geom)
+    # Fill it
+    cntmap.fill_by_coords(tmp)
+
+    # Put counts outside validity region to zero
+    cntmap.data *= valid_ref_map.data
+
+    return cntmap

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -20,20 +20,20 @@ def fill_map_counts(event_list, ndmap):
      """
     # The list will contain the event table entries to be fed into the WcsNDMap
     coord_dict = dict()
-    ref_geom = ndmap.geom
+    geom = ndmap.geom
 
     # Add sky coordinates to dictionary
     coord_dict.update(skycoord=event_list.radec)
 
     # Now check the other axes and find corresponding entries in the EventList
     # energy and time are specific types
-    # TODO: add proper extraction for time
-    for i, axis in enumerate(ref_geom.axes):
+    for i, axis in enumerate(geom.axes):
         if axis.type == 'energy':
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict.update({axis.name: event_list.energy.to(axis.unit)})
-        # We look for other axes name in the table column names (case insensitive)
+        # TODO: add proper extraction for time
         else:
+            # We look for other axes name in the table column names (case insensitive)
             try:
                 # Here we implicitly assume that there is only one column with the same name
                 column_name = next(_ for _ in event_list.table.colnames if _.upper() == axis.name.upper())
@@ -44,7 +44,7 @@ def fill_map_counts(event_list, ndmap):
     ndmap.fill_by_coord(coord_dict)
 
 
-def make_map_counts(event_list, ref_geom, meta=None):
+def make_map_counts(event_list, geom, meta=None):
     """Build a ``WcsNDMap` with events from an EventList.
 
     The energy of the events is used for a non-spatial axis homogeneous to energy.
@@ -54,7 +54,7 @@ def make_map_counts(event_list, ref_geom, meta=None):
     ----------
     event_list : `~gammapy.data.EventList`
             the input event list
-    ref_geom : `~gammapy.maps.WcsGeom`
+    geom : `~gammapy.maps.WcsGeom`
             the reference geometry
     meta : `~collections.OrderedDict`
             Dictionnary of meta information to keep with the map
@@ -65,10 +65,10 @@ def make_map_counts(event_list, ref_geom, meta=None):
         Count cube (3D) in true energy bins
     """
     # Create map
-    cntmap = WcsNDMap(ref_geom,meta=meta)
+    cntmap = WcsNDMap(geom,meta=meta)
     # Fill it
     fill_map_counts(event_list, cntmap)
     # Add MAPTYPE keyword to identify the nature of the map
-    cntmap.meta['MAPTYPE']='COUNTS_MAP'
+    cntmap.meta['MAPTYPE']='COUNTS'
 
     return cntmap

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ..maps import WcsNDMap
 
+
 def fill_map_counts(event_list, ndmap):
     """Fill a ``WcsNDMap` with events from an EventList.
 
@@ -61,7 +62,7 @@ def make_map_counts(event_list, ref_geom):
     event_list : `~gammapy.data.EventList`
             the input event list
     ref_geom : `~gammapy.maps.WcsGeom`
-
+            the reference geometry
 
     Returns
     -------
@@ -71,6 +72,6 @@ def make_map_counts(event_list, ref_geom):
     # Create map
     cntmap = WcsNDMap(ref_geom)
     # Fill it
-    fill_map_counts(event_list,cntmap)
+    fill_map_counts(event_list, cntmap)
 
     return cntmap

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -2,36 +2,35 @@
 """Functions to perform basic functions for map and cube analysis.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ..maps import WcsNDMap
 
 __all__ = [
-    'fill_map_counts'
+    'fill_map_counts',
 ]
 
+
 def fill_map_counts(count_map, event_list):
-    """Fill a ``WcsMap` with events from an EventList.
+    """Fill events into a counts map.
 
-     The energy of the events is used for a non-spatial axis homogeneous to energy.
-     The other non-spatial axis names should have an entry in the colum names of the ``EventList``
+    The energy of the events is used for a non-spatial axis homogeneous to energy.
+    The other non-spatial axis names should have an entry in the column names of the ``EventList``
 
-     Parameters
-     ----------
-     count_map : `~gammapy.maps.Map`
-         Target map
-     event_list : `~gammapy.data.EventList`
-             the input event list
-     """
+    Parameters
+    ----------
+    count_map : `~gammapy.maps.Map`
+        Map object, will be filled by this function.
+    event_list : `~gammapy.data.EventList`
+        Event list
+    """
     geom = count_map.geom
 
-    # Add sky coordinates to dictionary
-    coord_dict=dict(skycoord=event_list.radec)
+    # Make a coordinate dictionary; skycoord is always added
+    coord_dict = dict(skycoord=event_list.radec)
 
-    # Now check the other axes and find corresponding entries in the EventList
-    # energy and time are specific types
+    # Now add one coordinate for each extra map axis
     for axis in geom.axes:
         if axis.type == 'energy':
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
-            coord_dict.update({axis.name: event_list.energy.to(axis.unit)})
+            coord_dict[axis.name] = event_list.energy.to(axis.unit)
         # TODO: add proper extraction for time
         else:
             # We look for other axes name in the table column names (case insensitive)
@@ -40,6 +39,6 @@ def fill_map_counts(count_map, event_list):
                 column_name = event_list.table.colnames[colnames.index(axis.name.upper())]
                 coord_dict.update({axis.name: event_list.table[column_name].to(axis.unit)})
             else:
-                raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
-    # Fill it
+                raise ValueError("Cannot find MapGeom axis {!r} in EventList".format(axis.name))
+
     count_map.fill_by_coord(coord_dict)

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -19,32 +19,30 @@ def fill_map_counts(event_list, ndmap):
          Target map
      """
     # The list will contain the event table entries to be fed into the WcsNDMap
-    tmp = list()
+    tmp = dict()
     ref_geom = ndmap.geom
-    # Convert events coordinates
-    if ref_geom.coordsys == 'GAL':
-        tmp.append(event_list.galactic)
-    elif ref_geom.coordsys == 'CEL':
-        tmp.append(event_list.radec)
-    else:
-        # should raise an error here. The map is not correct.
-        raise ValueError("Incorrect coordsys of input map.")
 
+    # Add sky coordinates to dictionary
+    tmp.update(skycoord=event_list.radec)
+
+    # No check the other axes and find corresponding entries in the EventList
+    # energy and time are specific types
+    # TODO: add proper extraction for time
     for i, axis in enumerate(ref_geom.axes):
-        if axis.unit.is_equivalent("eV"):
+        if axis.type == 'energy':
             # This axis is the energy
-            tmp.append(event_list.energy.to(axis.unit))
+            tmp.update({axis.name: event_list.energy.to(axis.unit)})
         elif axis.name.upper() in event_list.table.colnames:
             # Here we assume that colnames are all capital
-            tmp.append(event_list.table[axis.name.upper()].to(axis.unit))
+            tmp.update({axis.name: event_list.table[axis.name.upper()].to(axis.unit)})
         elif axis.name.lower() in event_list.table.colnames:
             # Here we assume that colnames are all lower cases
-            tmp.append(event_list.table[axis.name.lower()].to(axis.unit))
+            tmp.update({axis.name: event_list.table[axis.name.lower()].to(axis.unit)})
         else:
             raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
 
     # Fill it
-    ndmap.fill_by_coords(tmp)
+    ndmap.fill_by_coord(tmp)
 
 
 def make_map_counts(event_list, ref_geom):

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -4,16 +4,15 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ..maps import WcsNDMap
 
-def make_map_counts(evts, valid_ref_map):
-    """
-    Build a ``WcsNDMap` with events from an EventList.
+def make_map_counts(event_list, valid_ref_map):
+    """Build a ``WcsNDMap` with events from an EventList.
+
     The energy of the events is used for a non-spatial axis homogeneous to energy.
     The other non-spatial axis names should have an entry in the colum names of the ``EventList``
 
     Parameters
-    __________
-
-    evts : `~gammapy.data.EventList`
+    ----------
+    event_list : `~gammapy.data.EventList`
             the input event list
     valid_ref_map : `~gammapy.maps.WcsNDMap`
         Map containing the valid pixels
@@ -22,18 +21,19 @@ def make_map_counts(evts, valid_ref_map):
     -------
     cntmap : `~gammapy.maps.WcsNDMap`
         Count cube (3D) in true energy bins
-
     """
     # The list will contain the event table entries to be fed into the WcsNDMap
     tmp = list()
     ref_geom = valid_ref_map.geom
     # Convert events coordinates
     if ref_geom.coordsys == 'GAL':
-        tmp.append(evts.galactic.l)
-        tmp.append(evts.galactic.b)
+        galactic_coords = event_list.galactic
+        tmp.append(galactic_coords.l)
+        tmp.append(galactic_coords.b)
     elif ref_geom.coordsys == 'CEL':
-        tmp.append(evts.radec.ra)
-        tmp.append(evts.radec.dec)
+        radec_coords = event_list.radec
+        tmp.append(radec_coords.ra)
+        tmp.append(radec_coords.dec)
     else:
         # should raise an error here. The map is not correct.
         raise ValueError("Incorrect coordsys of input map.")
@@ -41,13 +41,13 @@ def make_map_counts(evts, valid_ref_map):
     for i, axis in enumerate(ref_geom.axes):
         if axis.unit.is_equivalent("eV"):
             # This axis is the energy
-            tmp.append(evts.energy.to(axis.unit))
-        elif axis.name.upper() in evts.table.colnames:
-            # Here we assume that colanmes are all capital
-            tmp.append(evts.table[axis.name.upper()].to(axis.unit))
-        elif axis.name.lower() in evts.table.colnames:
-            # Here we assume that colanmes are not capital
-            tmp.append(evts.table[axis.name.lower()].to(axis.unit))
+            tmp.append(event_list.energy.to(axis.unit))
+        elif axis.name.upper() in event_list.table.colnames:
+            # Here we assume that colnames are all capital
+            tmp.append(event_list.table[axis.name.upper()].to(axis.unit))
+        elif axis.name.lower() in event_list.table.colnames:
+            # Here we assume that colnames are all lower cases
+            tmp.append(event_list.table[axis.name.lower()].to(axis.unit))
         else:
             raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
 

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -23,13 +23,9 @@ def fill_map_counts(event_list, ndmap):
     ref_geom = ndmap.geom
     # Convert events coordinates
     if ref_geom.coordsys == 'GAL':
-        galactic_coords = event_list.galactic
-        tmp.append(galactic_coords.l)
-        tmp.append(galactic_coords.b)
+        tmp.append(event_list.galactic)
     elif ref_geom.coordsys == 'CEL':
-        radec_coords = event_list.radec
-        tmp.append(radec_coords.ra)
-        tmp.append(radec_coords.dec)
+        tmp.append(event_list.radec)
     else:
         # should raise an error here. The map is not correct.
         raise ValueError("Incorrect coordsys of input map.")

--- a/gammapy/cube/basic_cube.py
+++ b/gammapy/cube/basic_cube.py
@@ -4,8 +4,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from ..maps import WcsNDMap
 
+__all__ = [
+    'fill_map_counts'
+]
 
-def fill_map_counts(event_list, ndmap):
+def fill_map_counts(count_map, event_list):
     """Fill a ``WcsMap` with events from an EventList.
 
      The energy of the events is used for a non-spatial axis homogeneous to energy.
@@ -13,21 +16,19 @@ def fill_map_counts(event_list, ndmap):
 
      Parameters
      ----------
+     count_map : `~gammapy.maps.Map`
+         Target map
      event_list : `~gammapy.data.EventList`
              the input event list
-     ndmap : `~gammapy.maps.Map`
-         Target map
      """
-    # The list will contain the event table entries to be fed into the WcsNDMap
-    coord_dict = dict()
-    geom = ndmap.geom
+    geom = count_map.geom
 
     # Add sky coordinates to dictionary
-    coord_dict.update(skycoord=event_list.radec)
+    coord_dict=dict(skycoord=event_list.radec)
 
     # Now check the other axes and find corresponding entries in the EventList
     # energy and time are specific types
-    for i, axis in enumerate(geom.axes):
+    for axis in geom.axes:
         if axis.type == 'energy':
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict.update({axis.name: event_list.energy.to(axis.unit)})
@@ -41,7 +42,7 @@ def fill_map_counts(event_list, ndmap):
             else:
                 raise ValueError("Cannot find MapGeom axis {} in EventList", axis.name)
     # Fill it
-    ndmap.fill_by_coord(coord_dict)
+    count_map.fill_by_coord(coord_dict)
 
 
 def make_map_counts(event_list, geom, meta=None):

--- a/gammapy/cube/tests/test_basic_cube.py
+++ b/gammapy/cube/tests/test_basic_cube.py
@@ -11,24 +11,25 @@ from ...cube.basic_cube import make_map_counts
 t0_1DC = 664504199. * u.s
 
 energy_reco = np.logspace(-1., 1.5, 10) * u.TeV
-times = np.linspace(t0_1DC.value, t0_1DC.value+1900., 10)*u.s
+times = np.linspace(t0_1DC.value, t0_1DC.value + 1900., 10) * u.s
 
 axis_energy_reco = MapAxis(energy_reco.value, interp='log', node_type='edge',
-                           name='energy_reco', unit = energy_reco.unit)
-axis_time = MapAxis(times, node_type='edge', name='time',unit = times.unit)
+                           name='energy_reco', unit=energy_reco.unit)
+axis_time = MapAxis(times, node_type='edge', name='time', unit=times.unit)
 
 cta_1dc_store = "$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/"
 cta_1dc_runs = [110380]
 
-pos_cta = SkyCoord(0.0, 0.0, frame='galactic',unit='deg')
+pos_cta = SkyCoord(0.0, 0.0, frame='galactic', unit='deg')
 
-geom_cta = {'binsz':0.02, 'coordsys':'GAL', 'width' : 15*u.deg,
-            'skydir' : pos_cta, 'axes' : [axis_energy_reco]}
-geom_cta_time = {'binsz':0.02, 'coordsys':'GAL', 'width' : 15*u.deg,
-                 'skydir' : pos_cta, 'axes' : [axis_energy_reco, axis_time]}
+geom_cta = {'binsz': 0.02, 'coordsys': 'GAL', 'width': 15 * u.deg,
+            'skydir': pos_cta, 'axes': [axis_energy_reco]}
+geom_cta_time = {'binsz': 0.02, 'coordsys': 'GAL', 'width': 15 * u.deg,
+                 'skydir': pos_cta, 'axes': [axis_energy_reco, axis_time]}
 
-@pytest.mark.parametrize("ds_path,run_list,geom",[(cta_1dc_store,cta_1dc_runs, geom_cta),
-                                                  (cta_1dc_store,cta_1dc_runs, geom_cta_time)])
+
+@pytest.mark.parametrize("ds_path,run_list,geom", [(cta_1dc_store, cta_1dc_runs, geom_cta),
+                                                   (cta_1dc_store, cta_1dc_runs, geom_cta_time)])
 def test_counts_map_maker(ds_path, run_list, geom):
     # TODO: change the test event list to something that's created from scratch,
     # using values so that it's possible to make simple assert statements on the
@@ -57,8 +58,8 @@ def test_counts_map_maker(ds_path, run_list, geom):
             valid = np.logical_and(events.energy.value >= axis.edges[0], valid)
             valid = np.logical_and(events.energy.value <= axis.edges[-1], valid)
         else:
-            valid = np.logical_and(events.table[axis.name.upper()]>=axis.edges[0],valid)
-            valid = np.logical_and(events.table[axis.name.upper()]<=axis.edges[-1],valid)
+            valid = np.logical_and(events.table[axis.name.upper()] >= axis.edges[0], valid)
+            valid = np.logical_and(events.table[axis.name.upper()] <= axis.edges[-1], valid)
 
     nevt = valid.sum()
     assert nmap == nevt

--- a/gammapy/cube/tests/test_basic_cube.py
+++ b/gammapy/cube/tests/test_basic_cube.py
@@ -44,13 +44,9 @@ def test_counts_map_maker(ds_path, run_list, geom):
 
     # Build WcsGeom
     wcsgeom = WcsGeom.create(**geom)
-    # Build mask WcsNDMap
-    mask = WcsNDMap(wcsgeom)
-    # Fill it with ones
-    mask.data += 1.
 
     # Extract count map
-    cntmap = make_map_counts(events, mask)
+    cntmap = make_map_counts(events, wcsgeom)
 
     # Number of entries in the map
     nmap = cntmap.data.sum()

--- a/gammapy/cube/tests/test_basic_cube.py
+++ b/gammapy/cube/tests/test_basic_cube.py
@@ -48,7 +48,7 @@ def test_fill_map_counts(ds_path, run_list, geom):
 
     # Extract count map
     cntmap = Map.from_geom(wcsgeom)
-    fill_map_counts(cntmap,events)
+    fill_map_counts(cntmap, events)
 
     # Number of entries in the map
     nmap = cntmap.data.sum()
@@ -66,21 +66,22 @@ def test_fill_map_counts(ds_path, run_list, geom):
     assert nmap == nevt
 
 
-def test_fill_map_counts_fermi():
+def test_fill_map_counts_hpx():
     # This tests healpix maps fill with non standard non spatial axis
-    angles = np.array((0,45,180))*u.deg
-    axis_zen = MapAxis(angles, node_type='edge', name='zenith_angle', unit=u.deg)
 
     evt_2fhl = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
-    hpxgeom = HpxGeom(256,coordsys='GAL',axes=[axis_zen])
+
+    axis_zen = MapAxis([0, 45, 180], node_type='edge', name='zenith_angle', unit=u.deg)
+    hpxgeom = HpxGeom(256, coordsys='GAL', axes=[axis_zen])
     map_2fhl = Map.from_geom(hpxgeom)
-    fill_map_counts(map_2fhl,evt_2fhl)
+
+    fill_map_counts(map_2fhl, evt_2fhl)
 
     nmap_l = np.sum(map_2fhl.data[0])
     nmap_h = np.sum(map_2fhl.data[1])
 
-    nevt_l = np.sum(evt_2fhl.table['ZENITH_ANGLE']<45)
-    nevt_h = np.sum(evt_2fhl.table['ZENITH_ANGLE']>45)
+    nevt_l = np.sum(evt_2fhl.table['ZENITH_ANGLE'] < 45)
+    nevt_h = np.sum(evt_2fhl.table['ZENITH_ANGLE'] > 45)
 
     assert nmap_l == nevt_l
     assert nmap_h == nevt_h

--- a/gammapy/cube/tests/test_basic_cube.py
+++ b/gammapy/cube/tests/test_basic_cube.py
@@ -1,0 +1,79 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+from ...maps import MapAxis, WcsGeom, WcsNDMap
+from ...data import DataStore
+from ...cube.basic_cube import make_map_counts
+
+# initial time of run 110380 from cta 1DC
+t0_1DC = 664504199. * u.s
+
+energy_true = np.logspace(-2., 2., 30) * u.TeV
+energy_reco = np.logspace(-1., 1.5, 10) * u.TeV
+times = np.linspace(t0_1DC.value, t0_1DC.value+1900., 10)*u.s
+
+axis_energy_true = MapAxis(energy_true.value, interp='log', node_type='edge',
+                           name='energy_true', unit = energy_true.unit)
+axis_energy_reco = MapAxis(energy_reco.value, interp='log', node_type='edge',
+                           name='energy_reco', unit = energy_reco.unit)
+axis_time = MapAxis(times, node_type='edge', name='time',unit = times.unit)
+
+cta_1dc_store = "$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/"
+cta_1dc_runs = [110380]
+
+hess_crab_store = "$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/"
+hess_crab_runs = [23523]
+
+pos_crab = SkyCoord(83.633212, 22.01446, frame='icrs',unit='deg').galactic
+pos_cta = SkyCoord(0.0, 0.0, frame='galactic',unit='deg')
+
+geom_cta = {'binsz':0.02, 'coordsys':'GAL', 'width' : 15*u.deg,
+            'skydir' : pos_cta, 'axes' : [axis_energy_reco]}
+geom_cta_time = {'binsz':0.02, 'coordsys':'GAL', 'width' : 15*u.deg,
+                 'skydir' : pos_cta, 'axes' : [axis_energy_reco, axis_time]}
+
+geom_hess_true = {'binsz':0.02, 'coordsys':'GAL', 'width' : 10*u.deg,
+                  'skydir' : pos_crab, 'axes' : [axis_energy_true]}
+
+geom_hess_reco = {'binsz':0.02, 'coordsys':'GAL', 'width' : 10*u.deg,
+                  'skydir' : pos_crab, 'axes' : [axis_energy_reco]}
+
+@pytest.mark.parametrize("ds_path,run_list,geom",[(cta_1dc_store,cta_1dc_runs, geom_cta),
+                                                  (cta_1dc_store,cta_1dc_runs, geom_cta_time),
+                                                  (hess_crab_store,hess_crab_runs,geom_hess_reco)])
+def test_counts_map_maker(ds_path, run_list, geom):
+    # Get datastore
+    ds = DataStore.from_dir(ds_path)
+    run = run_list[0]
+
+    # Get observation
+    obs = ds.obs(run)
+    evts = obs.events
+
+    # Build WcsGeom
+    wcsgeom = WcsGeom.create(**geom)
+    # Build mask WcsNDMap
+    mask = WcsNDMap(wcsgeom)
+    # Fill it with ones
+    mask.data += 1.
+
+    # Extract count map
+    cntmap = make_map_counts(evts, mask)
+
+    # Number of entries in the map
+    nmap = cntmap.data.sum()
+    # number of events
+    valid = np.ones_like(evts.energy.value)
+    for axis in geom['axes']:
+        if axis.name == 'energy_reco':
+            valid = np.logical_and(evts.energy.value >= axis.edges[0], valid)
+            valid = np.logical_and(evts.energy.value <= axis.edges[-1], valid)
+        else:
+            valid = np.logical_and(evts.table[axis.name.upper()]>=axis.edges[0],valid)
+            valid = np.logical_and(evts.table[axis.name.upper()]<=axis.edges[-1],valid)
+
+    nevt = valid.sum()
+    print(nevt,nmap)
+    assert nmap == nevt

--- a/gammapy/cube/tests/test_basic_cube.py
+++ b/gammapy/cube/tests/test_basic_cube.py
@@ -3,22 +3,22 @@ import pytest
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
+from ...utils.testing import requires_dependency, requires_data
 from ...maps import MapAxis, WcsGeom, HpxGeom, Map
 from ...data import DataStore, EventList
 from ...cube.basic_cube import fill_map_counts
 
+
+pytest.importorskip('scipy')
+
+# TODO: move these two cases to different test functions?
+# Would allow to change the asserts in `test_fill_map_counts` to something much more specific / useful, no?
+axis_energy_reco = MapAxis(np.logspace(-1., 1.5, 10), interp='log', node_type='edge',
+                           name='energy_reco', unit='TeV')
+
 # initial time of run 110380 from cta 1DC
-t0_1DC = 664504199. * u.s
-
-energy_reco = np.logspace(-1., 1.5, 10) * u.TeV
-times = np.linspace(t0_1DC.value, t0_1DC.value + 1900., 10) * u.s
-
-axis_energy_reco = MapAxis(energy_reco.value, interp='log', node_type='edge',
-                           name='energy_reco', unit=energy_reco.unit)
-axis_time = MapAxis(times, node_type='edge', name='time', unit=times.unit)
-
-cta_1dc_store = "$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/"
-cta_1dc_runs = [110380]
+times = np.linspace(664504199, 664504199 + 1900., 10)
+axis_time = MapAxis(times, node_type='edge', name='time', unit='s')
 
 pos_cta = SkyCoord(0.0, 0.0, frame='galactic', unit='deg')
 
@@ -28,33 +28,33 @@ geom_cta_time = {'binsz': 0.02, 'coordsys': 'GAL', 'width': 15 * u.deg,
                  'skydir': pos_cta, 'axes': [axis_energy_reco, axis_time]}
 
 
-@pytest.mark.parametrize("ds_path,run_list,geom", [(cta_1dc_store, cta_1dc_runs, geom_cta),
-                                                   (cta_1dc_store, cta_1dc_runs, geom_cta_time)])
-def test_fill_map_counts(ds_path, run_list, geom):
-    # TODO: change the test event list to something that's created from scratch,
-    # using values so that it's possible to make simple assert statements on the
-    # map data in the tests below, i.e. have pixels that should receive 0, 1 or 2 counts
+# TODO: change the test event list to something that's created from scratch,
+# using values so that it's possible to make simple assert statements on the
+# map data in the tests below, i.e. have pixels that should receive 0, 1 or 2 counts
+def make_test_event_list():
+    ds = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/')
+    return ds.obs(110380).events
 
-    # Get datastore
-    ds = DataStore.from_dir(ds_path)
-    run = run_list[0]
 
-    # Get observation
-    obs = ds.obs(run)
-    events = obs.events
+@pytest.fixture(scope='session')
+def evt_2fhl():
+    return EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
 
-    # Build WcsGeom
-    wcsgeom = WcsGeom.create(**geom)
 
-    # Extract count map
-    cntmap = Map.from_geom(wcsgeom)
+@requires_data('gammapy-extra')
+@pytest.mark.parametrize('geom_opts', [geom_cta, geom_cta_time])
+def test_fill_map_counts(geom_opts):
+    events = make_test_event_list()
+    geom = WcsGeom.create(**geom_opts)
+    cntmap = Map.from_geom(geom)
+
     fill_map_counts(cntmap, events)
 
     # Number of entries in the map
     nmap = cntmap.data.sum()
     # number of events
     valid = np.ones_like(events.energy.value)
-    for axis in geom['axes']:
+    for axis in geom.axes:
         if axis.name == 'energy_reco':
             valid = np.logical_and(events.energy.value >= axis.edges[0], valid)
             valid = np.logical_and(events.energy.value <= axis.edges[-1], valid)
@@ -66,19 +66,19 @@ def test_fill_map_counts(ds_path, run_list, geom):
     assert nmap == nevt
 
 
-def test_fill_map_counts_hpx():
+@requires_data('gammapy-extra')
+@requires_dependency('healpy')
+def test_fill_map_counts_hpx(evt_2fhl):
     # This tests healpix maps fill with non standard non spatial axis
 
-    evt_2fhl = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
-
     axis_zen = MapAxis([0, 45, 180], node_type='edge', name='zenith_angle', unit=u.deg)
-    hpxgeom = HpxGeom(256, coordsys='GAL', axes=[axis_zen])
-    map_2fhl = Map.from_geom(hpxgeom)
+    geom = HpxGeom(256, coordsys='GAL', axes=[axis_zen])
+    m = Map.from_geom(geom)
 
-    fill_map_counts(map_2fhl, evt_2fhl)
+    fill_map_counts(m, evt_2fhl)
 
-    nmap_l = np.sum(map_2fhl.data[0])
-    nmap_h = np.sum(map_2fhl.data[1])
+    nmap_l = np.sum(m.data[0])
+    nmap_h = np.sum(m.data[1])
 
     nevt_l = np.sum(evt_2fhl.table['ZENITH_ANGLE'] < 45)
     nevt_h = np.sum(evt_2fhl.table['ZENITH_ANGLE'] > 45)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -355,6 +355,14 @@ class MapAxis(object):
         self._node_type = node_type
         self._unit = u.Unit('' if unit is None else unit)
 
+        # Set axis type from its unit
+        if self._unit.is_equivalent("eV"):
+            self._type = 'energy'
+        elif self._unit.is_equivalent("s"):
+            self._type = 'time'
+        else:
+            self._type = 'any'
+
         # Set pixel coordinate of first node
         if node_type == 'edge':
             self._pix_offset = -0.5
@@ -416,6 +424,11 @@ class MapAxis(object):
     def unit(self):
         """Return coordinate axis unit."""
         return self._unit
+
+    @property
+    def type(self):
+        """Return coordinate axis type."""
+        return self._type
 
     @classmethod
     def from_bounds(cls, lo_bnd, hi_bnd, nbin, **kwargs):


### PR DESCRIPTION
This PR is a follow up of some [comments (https://github.com/gammapy/gammapy/pull/1314#pullrequestreview-97012013)
made during the review of PR #1314.

This introduces a ``MapAxis.type`` which is selected depending on the ``MapAxis.unit``. 
Checking on the unit might be ugly, but it ensures consistency between axis type and the unit used.

Only 2 types are defined for now: ``energy``and ``time``. The rest is ``any``.

As far as I understand spatial axes are not MapAxis in maps. 

Would that be OK? 