### PR TITLE
Improve MapCoord interface

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -132,16 +132,16 @@ representation.  Three types of accessor methods are provided:
 
 * ``get`` : Return the value of the map at the pixel containing the
   given coordinate (`~Map.get_by_idx`, `~Map.get_by_pix`,
-  `~Map.get_by_coords`).  With the ``interp`` argument,
-  `~Map.get_by_pix` and `~Map.get_by_coords` also support
+  `~Map.get_by_coord`).  With the ``interp`` argument,
+  `~Map.get_by_pix` and `~Map.get_by_coord` also support
   interpolation of map values between pixels (see `Interpolation`_).
 * ``set`` : Set the value of the map at the pixel containing the
   given coordinate (`~Map.set_by_idx`, `~Map.set_by_pix`,
-  `~Map.set_by_coords`).
+  `~Map.set_by_coord`).
 * ``fill`` : Increment the value of the map at the pixel containing
   the given coordinate with a unit weight or the value in the optional
   ``weights`` argument (`~Map.fill_by_idx`,
-  `~Map.fill_by_pix`, `~Map.fill_by_coords`).
+  `~Map.fill_by_pix`, `~Map.fill_by_coord`).
 
 All accessor methods accept as their first argument a
 coordinate tuple containing scalars, lists, or numpy arrays with one
@@ -174,7 +174,7 @@ systems:
 
    vals = m.get_by_idx( ([49,50],[49,50]) )
    vals = m.get_by_pix( ([49.0,50.0],[49.0,50.0]) )
-   vals = m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]) )
+   vals = m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]) )
 
 Coordinate arguments obey normal numpy broadcasting rules.  The
 coordinate tuple may contain any combination of scalars, lists or
@@ -196,11 +196,11 @@ given operation across a grid of coordinate values.
    vals = m.get_by_idx( (np.array([49]),np.array([49])) )
 
    # Retrieve map values along latitude at fixed longitude=0.0
-   vals = m.get_by_coords( (0.0, coords) )
+   vals = m.get_by_coord( (0.0, coords) )
    # Retrieve map values on a 2D grid of latitude/longitude points
-   vals = m.get_by_coords( (coords[None,:], coords[:,None]) )
+   vals = m.get_by_coord( (coords[None,:], coords[:,None]) )
    # Set map values along slice at longitude=0.0 to twice their existing value
-   m.set_by_coords((0.0, coords), 2.0*m.get_by_coords((0.0, coords)))
+   m.set_by_coord((0.0, coords), 2.0*m.get_by_coord((0.0, coords)))
 
 The ``set`` and ``fill`` methods can both be used to set pixel values.
 The following demonstrates how one can set pixel values:
@@ -210,13 +210,13 @@ The following demonstrates how one can set pixel values:
    from gammapy.maps import Map
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-   m.set_by_coords( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
-   m.fill_by_coords( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
+   m.set_by_coord( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
+   m.fill_by_coord( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
 
 Interpolation
 -------------
 
-Maps support interpolation via the `~Map.get_by_coords` and
+Maps support interpolation via the `~Map.get_by_coord` and
 `~Map.get_by_pix` methods.  Currently the following interpolation
 methods are supported:
 
@@ -237,8 +237,8 @@ maps.
    from gammapy.maps import Map
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-   m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
-   m.get_by_coords( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
+   m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
+   m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
 
 
 Projection
@@ -285,7 +285,7 @@ one can use this method to fill a map with a 2D Gaussian:
        skydir = SkyCoord(coords[0],coords[1], unit='deg')
        sep = skydir.separation(m.geom.center_skydir).deg
        new_val = np.exp(-sep**2/2.0)
-       m.set_by_coords(coords, new_val)
+       m.set_by_coord(coords, new_val)
 
 For maps with non-spatial dimensions the `~Map.iter_by_image`
 method can be used to loop over image slices:
@@ -393,7 +393,7 @@ This example shows how to fill a counts cube from an FT1 file:
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
    m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
                        coordsys='CEL', axes=[energy_axis])
-   m.fill_by_coords((h['EVENTS'].data.field('RA'),
+   m.fill_by_coord((h['EVENTS'].data.field('RA'),
                      h['EVENTS'].data.field('DEC'),
                      h['EVENTS'].data.field('ENERGY')))
    m.write('ccube.fits', conv='fgst-ccube')

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -220,7 +220,7 @@ The following demonstrates how one can set pixel values:
    m.fill_by_coord( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
 
 Interface with `~MapCoord` and `~astropy.coordinates.SkyCoord`
--------------------------------------------------------------
+--------------------------------------------------------------
 
 The ``coord`` accessor methods accept `dict`, `~MapCoord`, and
 `~astropy.coordinates.SkyCoord` arguments in addition to the standard
@@ -232,7 +232,8 @@ coordinate system of the map.
 
 .. code:: python
 
-   from astropy.coordinates.SkyCoord
+   import numpy as np
+   from astropy.coordinates import SkyCoord
    from gammapy.maps import Map, MapCoord, MapAxis
 
    lon = np.array([0.0,1.0])
@@ -279,7 +280,8 @@ argument:
 
 .. code:: python
 
-   from astropy.coordinates.SkyCoord
+   import numpy as np
+   from astropy.coordinates import SkyCoord
    from gammapy.maps import MapCoord
 
    lon = np.array([0.0,1.0])
@@ -335,8 +337,7 @@ Spatial axes must be named ``lon`` and ``lat``.  `~MapCoord` objects
 created with named axes do not need to have the same axis ordering as
 the map geometry.  However the name of the axis must match the name of
 the corresponding map geometry axis.
-  
-   
+
    
 Interpolation
 -------------
@@ -393,7 +394,7 @@ Iterating on a Map
 ------------------
 
 Iterating over a map can be performed with the
-`~Map.iter_by_coords` and `~Map.iter_by_pix` methods.  These
+`~Map.iter_by_coord` and `~Map.iter_by_pix` methods.  These
 return an iterator that traverses the map returning (value,
 coordinate) pairs with map and pixel coordinates, respectively.  The
 optional ``buffersize`` argument can be used to split the iteration
@@ -406,11 +407,11 @@ one can use this method to fill a map with a 2D Gaussian:
    from astropy.coordinates import SkyCoord
    from gammapy.maps import Map
    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
-   for val, coords in m.iter_by_coords(buffersize=10000):
-       skydir = SkyCoord(coords[0],coords[1], unit='deg')
+   for val, coord in m.iter_by_coord(buffersize=10000):
+       skydir = SkyCoord(coord[0],coord[1], unit='deg')
        sep = skydir.separation(m.geom.center_skydir).deg
        new_val = np.exp(-sep**2/2.0)
-       m.set_by_coord(coords, new_val)
+       m.set_by_coord(coord, new_val)
 
 For maps with non-spatial dimensions the `~Map.iter_by_image`
 method can be used to loop over image slices:
@@ -422,7 +423,7 @@ method can be used to loop over image slices:
    from gammapy.maps import Map
    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
    for img, idx in m.iter_by_image():
-       img = convolve(img, Gaussian2DKernel(stddev=2.0) )
+       img = convolve(img, Gaussian2DKernel(x_stddev=2.0) )
 
 
 FITS I/O

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -128,13 +128,13 @@ Get, Set, and Fill Methods
 All map objects have a set of accessor methods provided through the
 abstract `~Map` class.  These methods can be used to access or
 update the contents of the map irrespective of its underlying
-representation.  Three types of accessor methods are provided:
+representation.  Four types of accessor methods are provided:
 
 * ``get`` : Return the value of the map at the pixel containing the
   given coordinate (`~Map.get_by_idx`, `~Map.get_by_pix`,
-  `~Map.get_by_coord`).  With the ``interp`` argument,
-  `~Map.get_by_pix` and `~Map.get_by_coord` also support
-  interpolation of map values between pixels (see `Interpolation`_).
+  `~Map.get_by_coord`).  
+* ``interp`` : Interpolate or extrapolate the value of the map at an arbitrary
+  coordinate (see also `Interpolation`_).  T  
 * ``set`` : Set the value of the map at the pixel containing the
   given coordinate (`~Map.set_by_idx`, `~Map.set_by_pix`,
   `~Map.set_by_coord`).
@@ -143,12 +143,15 @@ representation.  Three types of accessor methods are provided:
   ``weights`` argument (`~Map.fill_by_idx`,
   `~Map.fill_by_pix`, `~Map.fill_by_coord`).
 
-All accessor methods accept as their first argument a
-coordinate tuple containing scalars, lists, or numpy arrays with one
-tuple element for each dimension of the map.  By convention the first
-two elements in the coordinate tuple correspond to longitude and
-latitude followed by one element for each non-spatial dimension.  Map
-coordinates can be expressed in one of three coordinate systems:
+Accessor methods accept as their first argument a coordinate tuple
+containing scalars, lists, or numpy arrays with one tuple element for
+each dimension of the map.  ``coord`` methods optionally support a
+`dict` or `~MapCoord` argument.
+
+When using tuple input the first two elements in the tuple
+should be longitude and latitude followed by one element for each
+non-spatial dimension.  Map coordinates can be expressed in one of
+three coordinate systems:
 
 * ``idx`` : Pixel indices.  These are explicit (integer) pixel indices into the map.
 * ``pix`` : Coordinates in pixel space.  Pixel coordinates are continuous defined
@@ -216,8 +219,8 @@ The following demonstrates how one can set pixel values:
 Interpolation
 -------------
 
-Maps support interpolation via the `~Map.get_by_coord` and
-`~Map.get_by_pix` methods.  Currently the following interpolation
+Maps support interpolation via the `~Map.interp_by_coord` and
+`~Map.interp_by_pix` methods.  Currently the following interpolation
 methods are supported:
 
 * ``nearest`` : Return value of nearest pixel (no interpolation).
@@ -237,8 +240,8 @@ maps.
    from gammapy.maps import Map
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-   m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
-   m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
+   m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
+   m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
 
 
 Projection

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -436,7 +436,7 @@ Maps can be written to and read from a FITS file with the
 
    from gammapy.maps import Map
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   m.write('file.fits', extname='IMAGE')
+   m.write('file.fits', hdu='IMAGE')
    m = Map.read('file.fits', hdu='IMAGE')
 
 If ``map_type`` argument is not given when calling `~Map.read` a
@@ -452,7 +452,7 @@ scheme.
 
    from gammapy.maps import Map
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   m.write('file.fits', extname='IMAGE', sparse=True)
+   m.write('file.fits', hdu='IMAGE', sparse=True)
    m = Map.read('file.fits', hdu='IMAGE', map_type='wcs')
 
 Sparse maps have the same ``read`` and ``write`` methods with the
@@ -462,7 +462,7 @@ exception that they will be written to a sparse format by default:
 
    from gammapy.maps import Map
    m = Map.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
-   m.write('file.fits', extname='IMAGE')
+   m.write('file.fits', hdu='IMAGE')
    m = Map.read('file.fits', hdu='IMAGE', map_type='hpx-sparse')
 
 By default files will be written to the *gamma-astro-data-format*

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -70,6 +70,7 @@ representation of the data.
 
    from gammapy.maps import Map
    from astropy.coordinates import SkyCoord
+
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
 
    # Create a WCS Map
@@ -86,6 +87,7 @@ dimensions with the ``axes`` parameter:
 
    from gammapy.maps import Map, MapAxis
    from astropy.coordinates import SkyCoord
+
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
 
@@ -109,6 +111,7 @@ Fermi-LAT PSF:
    import numpy as np
    from gammapy.maps import Map, MapAxis
    from astropy.coordinates import SkyCoord
+
    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
 
@@ -176,6 +179,7 @@ systems:
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
    vals = m.get_by_idx( ([49,50],[49,50]) )
@@ -193,13 +197,14 @@ given operation across a grid of coordinate values.
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   coords = np.linspace(-4.0,4.0,9)
+   coords = np.linspace(-4.0, 4.0, 9)
 
    # Equivalent calls for accessing value at pixel (49,49)
    vals = m.get_by_idx( (49,49) )
    vals = m.get_by_idx( ([49],[49]) )
-   vals = m.get_by_idx( (np.array([49]),np.array([49])) )
+   vals = m.get_by_idx( (np.array([49]), np.array([49])) )
 
    # Retrieve map values along latitude at fixed longitude=0.0
    vals = m.get_by_coord( (0.0, coords) )
@@ -214,6 +219,7 @@ The following demonstrates how one can set pixel values:
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
    m.set_by_coord( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
@@ -236,10 +242,10 @@ coordinate system of the map.
    from astropy.coordinates import SkyCoord
    from gammapy.maps import Map, MapCoord, MapAxis
 
-   lon = np.array([0.0,1.0])
-   lat = np.array([1.0,2.0])
-   energy = np.array([100., 1000.])
-   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', name='energy')
+   lon = [0, 1]
+   lat = [1, 2]
+   energy = [100, 1000]
+   energy_axis = MapAxis.from_bounds(100, 1E5, 12, interp='log', name='energy')
    
    skycoord = SkyCoord(lon, lat, unit='deg', frame='galactic')   
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
@@ -261,7 +267,7 @@ object without reference to the axis ordering of the map geometry:
    
 
 However when using the named axis interface the axis name string
-(e.g. as given by `~MapAxis.name`) must match the name given in the
+(e.g. as given by `MapAxis.name`) must match the name given in the
 method argument.  The two spatial axes must always be named ``lon``
 and ``lat``.
 
@@ -270,12 +276,12 @@ and ``lat``.
 MapCoord
 --------
 
-`~MapCoord` is an N-dimensional coordinate object that stores both
+`MapCoord` is an N-dimensional coordinate object that stores both
 spatial and non-spatial coordinates and is accepted by all ``coord``
 methods.  A `~MapCoord` can be created with or without explicitly
-named axes with `~MapCoord.create`.  Axes of a `~MapCoord` can be
-accessed by index, name, or attribute.  A `~MapCoord` without explicit
-axis names can be created by calling `~MapCoord.create` with a `tuple`
+named axes with `MapCoord.create`.  Axes of a `MapCoord` can be
+accessed by index, name, or attribute.  A `MapCoord` without explicit
+axis names can be created by calling `MapCoord.create` with a `tuple`
 argument:
 
 .. code:: python
@@ -284,32 +290,31 @@ argument:
    from astropy.coordinates import SkyCoord
    from gammapy.maps import MapCoord
 
-   lon = np.array([0.0,1.0])
-   lat = np.array([1.0,2.0])
-   energy = np.array([100., 1000.])
+   lon = [0.0, 1.0]
+   lat = [1.0, 2.0]
+   energy = [100, 1000]
    skycoord = SkyCoord(lon, lat, unit='deg', frame='galactic')   
 
    # Create a MapCoord from a tuple (no explicit axis names)
    c = MapCoord.create((lon, lat, energy))
    print(c[0], c['lon'], c.lon)
    print(c[1], c['lat'], c.lat)
-   print(c[2], c['axis0'], c.axis0)
+   print(c[2], c['axis0'])
 
    # Create a MapCoord from a tuple + SkyCoord (no explicit axis names)
    c = MapCoord.create((skycoord, energy))
    print(c[0], c['lon'], c.lon)
    print(c[1], c['lat'], c.lat)
-   print(c[2], c['axis0'], c.axis0)
+   print(c[2], c['axis0'])
 
 The first two elements of the tuple argument must contain longitude
 and latitude.  Non-spatial axes are assigned a default name
 ``axis{I}`` where ``{I}`` is the index of the non-spatial dimension.
-`~MapCoord` objects created without named axes must have the same axis
+`MapCoord` objects created without named axes must have the same axis
 ordering as the map geometry.
 
-
-A `~MapCoord` with named axes can be created by calling
-`~MapCoord.create` with a `dict` or `~collections.OrderedDict`:
+A `MapCoord` with named axes can be created by calling
+`MapCoord.create` with a `dict` or `~collections.OrderedDict`:
 
 .. code:: python
    
@@ -317,12 +322,12 @@ A `~MapCoord` with named axes can be created by calling
    c = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
    print(c[0], c['lon'], c.lon)
    print(c[1], c['lat'], c.lat)
-   print(c[2], c['energy'], c.energy)
+   print(c[2], c['energy'])
 
    # Create a MapCoord from an OrderedDict
    from collections import OrderedDict
    c = MapCoord.create(OrderedDict([('energy',energy), ('lon',lon), ('lat', lat)]))
-   print(c[0], c['energy'], c.energy)
+   print(c[0], c['energy'])
    print(c[1], c['lon'], c.lon)
    print(c[2], c['lat'], c.lat)
    
@@ -330,15 +335,13 @@ A `~MapCoord` with named axes can be created by calling
    c = MapCoord.create(dict(skycoord=skycoord, energy=energy))
    print(c[0], c['lon'], c.lon)
    print(c[1], c['lat'], c.lat)
-   print(c[2], c['energy'], c.energy)
+   print(c[2], c['energy'])
 
-
-Spatial axes must be named ``lon`` and ``lat``.  `~MapCoord` objects
+Spatial axes must be named ``lon`` and ``lat``.  `MapCoord` objects
 created with named axes do not need to have the same axis ordering as
 the map geometry.  However the name of the axis must match the name of
 the corresponding map geometry axis.
 
-   
 Interpolation
 -------------
 
@@ -361,11 +364,11 @@ maps.
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
    m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
    m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
-
 
 Projection
 ----------
@@ -380,6 +383,7 @@ over to the projected map.
 .. code:: python
 
    from gammapy.maps import WcsNDMap, HpxGeom
+
    m = WcsNDMap.read('gll_iem_v06.fits')
    geom = HpxGeom.create(nside=8, coordsys='GAL')
    # Convert LAT standard IEM to HPX (nside=8)
@@ -406,6 +410,7 @@ one can use this method to fill a map with a 2D Gaussian:
    import numpy as np
    from astropy.coordinates import SkyCoord
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
    for val, coord in m.iter_by_coord(buffersize=10000):
        skydir = SkyCoord(coord[0],coord[1], unit='deg')
@@ -421,10 +426,10 @@ method can be used to loop over image slices:
    from astropy.coordinates import SkyCoord
    from astropy.convolution import Gaussian2DKernel, convolve
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
    for img, idx in m.iter_by_image():
        img = convolve(img, Gaussian2DKernel(x_stddev=2.0) )
-
 
 FITS I/O
 --------
@@ -435,6 +440,7 @@ Maps can be written to and read from a FITS file with the
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', hdu='IMAGE')
    m = Map.read('file.fits', hdu='IMAGE')
@@ -451,6 +457,7 @@ scheme.
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    m.write('file.fits', hdu='IMAGE', sparse=True)
    m = Map.read('file.fits', hdu='IMAGE', map_type='wcs')
@@ -461,6 +468,7 @@ exception that they will be written to a sparse format by default:
 .. code:: python
 
    from gammapy.maps import Map
+
    m = Map.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
    m.write('file.fits', hdu='IMAGE')
    m = Map.read('file.fits', hdu='IMAGE', map_type='hpx-sparse')
@@ -478,6 +486,7 @@ the GADF format:
 .. code:: python
 
    from gammapy.maps import Map, MapAxis
+
    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
                       axes=[energy_axis])
@@ -496,6 +505,7 @@ objects that can be used to further tweak/customize the image.
    import matplotlib.pyplot as plt
    from gammapy.maps import Map
    from gammapy.maps.utils import fill_poisson
+
    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
    fill_poisson(m, mu=1.0, random_state=0)
    fig, ax, im = m.plot(cmap='magma')
@@ -520,8 +530,8 @@ This example shows how to fill a counts cube from an FT1 file:
    m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
                        coordsys='CEL', axes=[energy_axis])
    m.fill_by_coord((h['EVENTS'].data.field('RA'),
-                     h['EVENTS'].data.field('DEC'),
-                     h['EVENTS'].data.field('ENERGY')))
+                    h['EVENTS'].data.field('DEC'),
+                    h['EVENTS'].data.field('ENERGY')))
    m.write('ccube.fits', conv='fgst-ccube')
 
 Generating a Cutout of a Model Cube
@@ -533,6 +543,7 @@ diffuse model cube using the `~Map.reproject` method:
 .. code:: python
 
    from gammapy.maps import WcsGeom, WcsNDMap
+
    m = WcsNDMap.read('gll_iem_v06.fits')
    geom = WcsGeom(binsz=0.125, skydir=(45.0,30.0), coordsys='GAL', proj='AIT')
    m_proj = m.reproject(geom)

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -264,6 +264,8 @@ However when using the named axis interface the axis name string
 method argument.  The two spatial axes must always be named ``lon``
 and ``lat``.
 
+.. _mapcoord:
+
 MapCoord
 --------
 

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -638,10 +638,10 @@ def reproject_exposure(exposure, ref_cube):
 
     ref_image = ref_cube.sky_image_ref
     geom = ref_image.to_wcs_nd_map().geom
-    coords = geom.get_coords()
+    coords = geom.get_coord()
     for idx, energy in enumerate(ref_cube.energies().value):
         coords_hpx = coords[0], coords[1], energy
-        vals = exposure.get_by_coords(coords_hpx, interp='linear')
+        vals = exposure.get_by_coord(coords_hpx, interp='linear')
         exposure_cube.data[idx] = vals.reshape(ref_image.data.shape)
 
     exposure_cube.data = exposure_cube.data * u.Unit('cm2 s')

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -618,7 +618,7 @@ def reproject_exposure(exposure, ref_cube):
     """Helper function to reproject exposure to a reference cube.
 
     TODO: this is a temp solution, as long as we use HpxNDMap objects for exposure
-    and SkyCube objects otherwise. This should be changed to use WCSMapND
+    and SkyCube objects otherwise. This should be changed to use WcsNDMap
     instead of SkyCube in the future.
 
     Parameters
@@ -641,7 +641,7 @@ def reproject_exposure(exposure, ref_cube):
     coords = geom.get_coord()
     for idx, energy in enumerate(ref_cube.energies().value):
         coords_hpx = coords[0], coords[1], energy
-        vals = exposure.get_by_coord(coords_hpx, interp='linear')
+        vals = exposure.interp_by_coord(coords_hpx, interp='linear')
         exposure_cube.data[idx] = vals.reshape(ref_image.data.shape)
 
     exposure_cube.data = exposure_cube.data * u.Unit('cm2 s')

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -491,10 +491,10 @@ class Map(object):
            outside of map.
         """
         if interp is None:
-            coords = MapCoords.create(coords)
+            coords = MapCoords.create(coords, coordsys=self.geom.coordsys)
             msk = self.geom.contains(coords)
             vals = np.empty(coords.shape, dtype=self.data.dtype)
-            coords = tuple([c[msk] for c in coords])
+            coords = coords.mask(msk)
             idx = self.geom.coord_to_pix(coords)
             vals[msk] = self.get_by_idx(idx)
             vals[~msk] = np.nan

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -340,9 +340,9 @@ class Map(object):
         # TODO: Check whether geometries are aligned and if so sum the
         # data vectors directly
         idx = map_in.geom.get_idx()
-        coords = map_in.geom.get_coords()
+        coords = map_in.geom.get_coord()
         vals = map_in.get_by_idx(idx)
-        self.fill_by_coords(coords, vals)
+        self.fill_by_coord(coords, vals)
 
     def reproject(self, geom, order=1, mode='interp'):
         """Reproject this map to a different geometry.
@@ -463,7 +463,7 @@ class Map(object):
         """
         pass
 
-    def get_by_coords(self, coords):
+    def get_by_coord(self, coords):
         """Return map values at the given map coordinates.
 
         Parameters
@@ -567,7 +567,7 @@ class Map(object):
         """
         pass
 
-    def fill_by_coords(self, coords, weights=None):
+    def fill_by_coord(self, coords, weights=None):
         """Fill pixels at the given map coordinates with values in `weights`
         vector.
 
@@ -624,7 +624,7 @@ class Map(object):
         """
         pass
 
-    def set_by_coords(self, coords, vals):
+    def set_by_coord(self, coords, vals):
         """Set pixels at the given map coordinates to the values in `vals`
         vector.
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -484,7 +484,7 @@ class Map(object):
         msk = self.geom.contains(coords)
         vals = np.empty(coords.shape, dtype=self.data.dtype)
         coords = coords.mask(msk)
-        idx = self.geom.coord_to_pix(coords)
+        idx = self.geom.coord_to_idx(coords)
         vals[msk] = self.get_by_idx(idx)
         vals[~msk] = np.nan
         return vals

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -302,7 +302,7 @@ class Map(object):
         pass
 
     @abc.abstractmethod
-    def iter_by_coords(self, buffersize=1):
+    def iter_by_coord(self, buffersize=1):
         """Iterate over elements of the map returning a tuple with values and
         map coordinates.
 
@@ -538,7 +538,7 @@ class Map(object):
         pass
 
     @abc.abstractmethod
-    def interp_by_coords(self, coords, interp=None):
+    def interp_by_coord(self, coords, interp=None):
         """Interpolate map values at the given map coordinates.
 
         Parameters

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -483,7 +483,7 @@ class Map(object):
         coords = MapCoord.create(coords, coordsys=self.geom.coordsys)
         msk = self.geom.contains(coords)
         vals = np.empty(coords.shape, dtype=self.data.dtype)
-        coords = coords.mask(msk)
+        coords = coords.apply_mask(msk)
         idx = self.geom.coord_to_idx(coords)
         vals[msk] = self.get_by_idx(idx)
         vals[~msk] = np.nan

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from ..extern import six
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
-from .geom import pix_tuple_to_idx, MapCoords
+from .geom import pix_tuple_to_idx, MapCoord
 
 __all__ = [
     'Map',
@@ -468,8 +468,8 @@ class Map(object):
 
         Parameters
         ----------
-        coords : tuple or `~gammapy.maps.MapCoords`
-            `~gammapy.maps.MapCoords` object or tuple of
+        coords : tuple or `~gammapy.maps.MapCoord`
+            `~gammapy.maps.MapCoord` object or tuple of
             coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
@@ -480,7 +480,7 @@ class Map(object):
            Values of pixels in the map.  np.nan used to flag coords
            outside of map.
         """
-        coords = MapCoords.create(coords, coordsys=self.geom.coordsys)
+        coords = MapCoord.create(coords, coordsys=self.geom.coordsys)
         msk = self.geom.contains(coords)
         vals = np.empty(coords.shape, dtype=self.data.dtype)
         coords = coords.mask(msk)
@@ -543,8 +543,8 @@ class Map(object):
 
         Parameters
         ----------
-        coords : tuple or `~gammapy.maps.MapCoords`
-            `~gammapy.maps.MapCoords` object or tuple of
+        coords : tuple or `~gammapy.maps.MapCoord`
+            `~gammapy.maps.MapCoord` object or tuple of
             coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
@@ -573,8 +573,8 @@ class Map(object):
 
         Parameters
         ----------
-        coords : tuple or `~gammapy.maps.MapCoords`
-            `~gammapy.maps.MapCoords` object or tuple of
+        coords : tuple or `~gammapy.maps.MapCoord`
+            `~gammapy.maps.MapCoord` object or tuple of
             coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
@@ -630,8 +630,8 @@ class Map(object):
 
         Parameters
         ----------
-        coords : tuple or `~gammapy.maps.MapCoords`
-            `~gammapy.maps.MapCoords` object or tuple of
+        coords : tuple or `~gammapy.maps.MapCoord`
+            `~gammapy.maps.MapCoord` object or tuple of
             coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -243,11 +243,11 @@ class Map(object):
         ----------
         filename : str
             Output file name.
-        extname : str
+        hdu : str
             Set the name of the image extension.  By default this will
             be set to SKYMAP (for BINTABLE HDU) or PRIMARY (for IMAGE
             HDU).
-        extname_bands : str
+        hdu_bands : str
             Set the name of the bands table extension.  By default this will
             be set to BANDS.
         conv : str        

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -562,8 +562,36 @@ class Map(object):
         Returns
         -------
         vals : `~numpy.ndarray`
-           Values of pixels in the flattened map.
-           np.nan used to flag coords outside of map
+            Interpolated pixel values.
+        """
+        pass
+
+    @abc.abstractmethod
+    def interp_by_pix(self, pix, interp=None):
+        """Interpolate map values at the given pixel coordinates.
+
+        Parameters
+        ----------
+        pix : tuple
+            Tuple of pixel coordinate arrays for each dimension of the
+            map.  Tuple should be ordered as (p_lon, p_lat, p_0, ...,
+            p_n) where p_i are pixel coordinates for non-spatial
+            dimensions of the map.
+
+        interp : {None, 'nearest', 'linear', 'cubic', 0, 1, 2, 3}
+            Method to interpolate data values.  By default no
+            interpolation is performed and the return value will be
+            the amplitude of the pixel encompassing the given
+            coordinate.  Integer values can be used in lieu of strings
+            to choose the interpolation method of the given order
+            (0='nearest', 1='linear', 2='quadratic', 3='cubic').  Note
+            that only 'nearest' and 'linear' methods are supported for
+            all map types.
+
+        Returns
+        -------
+        vals : `~numpy.ndarray`
+            Interpolated pixel values.
         """
         pass
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -463,7 +463,7 @@ class Map(object):
         """
         pass
 
-    def get_by_coords(self, coords, interp=None):
+    def get_by_coords(self, coords):
         """Return map values at the given map coordinates.
 
         Parameters
@@ -474,36 +474,22 @@ class Map(object):
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
 
-        interp : {None, 'nearest', 'linear', 'cubic', 0, 1, 2, 3}
-            Method to interpolate data values.  By default no
-            interpolation is performed and the return value will be
-            the amplitude of the pixel encompassing the given
-            coordinate.  Integer values can be used in lieu of strings
-            to choose the interpolation method of the given order
-            (0='nearest', 1='linear', 2='quadratic', 3='cubic').  Note
-            that only 'nearest' and 'linear' methods are supported for
-            all map types.
-
         Returns
         -------
         vals : `~numpy.ndarray`
            Values of pixels in the map.  np.nan used to flag coords
            outside of map.
         """
-        if interp is None:
-            coords = MapCoords.create(coords, coordsys=self.geom.coordsys)
-            msk = self.geom.contains(coords)
-            vals = np.empty(coords.shape, dtype=self.data.dtype)
-            coords = coords.mask(msk)
-            idx = self.geom.coord_to_pix(coords)
-            vals[msk] = self.get_by_idx(idx)
-            vals[~msk] = np.nan
-        else:
-            vals = self.interp_by_coords(coords, interp=interp)
-
+        coords = MapCoords.create(coords, coordsys=self.geom.coordsys)
+        msk = self.geom.contains(coords)
+        vals = np.empty(coords.shape, dtype=self.data.dtype)
+        coords = coords.mask(msk)
+        idx = self.geom.coord_to_pix(coords)
+        vals[msk] = self.get_by_idx(idx)
+        vals[~msk] = np.nan
         return vals
 
-    def get_by_pix(self, pix, interp=None):
+    def get_by_pix(self, pix):
         """Return map values at the given pixel coordinates.
 
         Parameters
@@ -514,16 +500,6 @@ class Map(object):
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
             Pixel indices can be either float or integer type. 
 
-        interp : {None, 'nearest', 'linear', 'cubic', 0, 1, 2, 3}
-            Method to interpolate data values.  By default no
-            interpolation is performed and the return value will be
-            the amplitude of the pixel encompassing the given
-            coordinate.  Integer values can be used in lieu of strings
-            to choose the interpolation method of the given order
-            (0='nearest', 1='linear', 2='quadratic', 3='cubic').  Note
-            that only 'nearest' and 'linear' methods are supported for
-            all map types.
-
         Returns
         ----------
         vals : `~numpy.ndarray`
@@ -532,19 +508,14 @@ class Map(object):
         """
         # FIXME: Support local indexing here?
         # FIXME: Support slicing?
-
-        if interp is None:
-            pix = [np.array(p, copy=False, ndmin=1) for p in pix]
-            pix = np.broadcast_arrays(*pix)
-            msk = self.geom.contains_pix(pix)
-            vals = np.empty(pix[0].shape, dtype=self.data.dtype)
-            pix = tuple([p[msk] for p in pix])
-            idx = self.geom.pix_to_idx(pix)
-            vals[msk] = self.get_by_idx(idx)
-            vals[~msk] = np.nan
-        else:
-            vals = self.interp_by_pix(pix, interp=interp)
-
+        pix = [np.array(p, copy=False, ndmin=1) for p in pix]
+        pix = np.broadcast_arrays(*pix)
+        msk = self.geom.contains_pix(pix)
+        vals = np.empty(pix[0].shape, dtype=self.data.dtype)
+        pix = tuple([p[msk] for p in pix])
+        idx = self.geom.pix_to_idx(pix)
+        vals[msk] = self.get_by_idx(idx)
+        vals[~msk] = np.nan
         return vals
 
     @abc.abstractmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -598,8 +598,8 @@ class MapCoord(object):
 
     Parameters
     ----------
-    data : tuple of `~numpy.ndarray`
-        Tuple of coordinate values.
+    data : `~collections.OrderedDict` of `~numpy.ndarray`
+        Dictionary of coordinate arrays.
     coordsys : {'CEL', 'GAL', None}    
         Spatial coordinate system.  If None then the coordinate system
         will be set to the native coordinate system of the geometry.
@@ -638,10 +638,12 @@ class MapCoord(object):
 
     @property
     def ndim(self):
+        """Number of dimensions."""
         return len(self._data)
 
     @property
     def shape(self):
+        """Coordinate array shape."""
         return self[0].shape
 
     @property
@@ -650,10 +652,12 @@ class MapCoord(object):
 
     @property
     def lon(self):
+        """Longitude coordinate in degrees."""
         return self._data['lon']
 
     @property
     def lat(self):
+        """Latitude coordinate in degrees."""
         return self._data['lat']
 
     @property
@@ -667,12 +671,19 @@ class MapCoord(object):
 
     @classmethod
     def from_lonlat(cls, coords, coordsys=None, copy=False):
-        """Create from vectors of longitude and latitude in degrees.
+        """Create a `~MapCoord` from a tuple of coordinate vectors.  The first
+        two elements of the tuple should be longitude and latitude in
+        degrees.
 
         Parameters
         ----------
         coords : tuple
             Tuple of `~numpy.ndarray`.
+
+        Returns
+        -------
+        coord : `~MapCoord`
+            A coordinates object.
         """
 
         if isinstance(coords, (list, tuple)):
@@ -760,16 +771,34 @@ class MapCoord(object):
 
     @classmethod
     def create(cls, data, coordsys=None, copy=False):
-        """Create a new `~MapCoord` object.
+        """Create a new `~MapCoord` object.  This method can be used to create
+        either unnamed (with tuple input) or named (via dict input)
+        axes.
 
         Parameters
         ----------
-        data : tuple
-            Coordinate tuple.        
+        data : `tuple`, `dict`, or `~MapCoord`
+            Object containing coordinate arrays.  
         coordsys : {'CEL', 'GAL', None}, optional
             Set the coordinate system for longitude and latitude.  If
-            None then longitude and latitude will be assumed to be in
-            the coordinate system native to the map.
+            None longitude and latitude will be assumed to be in
+            the coordinate system native to a given map geometry.
+        copy : bool
+            Make copies of the input coordinate arrays.  If False this
+            object will store views.
+
+        Examples
+        --------
+        >>> from astropy.coordinates import SkyCoord
+        >>> from gammapy.maps import MapCoord
+        >>> lon, lat = np.array([1.0,2.0]), np.array([2.0,3.0])
+        >>> energy = np.array([1000.])
+        >>> c = MapCoord.create((lon,lat))
+        >>> c = MapCoord.create((SkyCoord(lon,lat,unit='deg'),))
+        >>> c = MapCoord.create((lon,lat,energy))
+        >>> c = MapCoord.create(dict(lon=lon,lat=lat))
+        >>> c = MapCoord.create(dict(lon=lon,lat=lat,energy=energy))
+
         """
         if isinstance(data, cls):
             if data.coordsys is None or coordsys == data.coordsys:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -596,6 +596,8 @@ class MapCoord(object):
     Contains coordinates for 2 spatial dimensions and an arbitrary
     number of additional non-spatial dimensions.
 
+    For further information see :ref:`mapcoord`.
+
     Parameters
     ----------
     data : `~collections.OrderedDict` of `~numpy.ndarray`
@@ -606,10 +608,15 @@ class MapCoord(object):
     copy : bool
         Make copies of the input arrays.  If False then this object will store views.
     match_by_name : bool
-        Match coordinates to axes by name.  If false coordinates will be matched by index.
+        Match coordinates to axes by name.  If false coordinates will
+        be matched by index.
     """
 
     def __init__(self, data, coordsys=None, copy=False, match_by_name=True):
+
+        if 'lon' not in data or 'lat' not in data:
+            raise ValueError(
+                "data dictionary must contain axes named 'lon' and 'lat'.")
 
         self._data = OrderedDict([(k, np.array(v, ndmin=1, copy=copy))
                                   for k, v in data.items()])
@@ -798,7 +805,7 @@ class MapCoord(object):
         >>> c = MapCoord.create((lon,lat,energy))
         >>> c = MapCoord.create(dict(lon=lon,lat=lat))
         >>> c = MapCoord.create(dict(lon=lon,lat=lat,energy=energy))
-
+        >>> c = MapCoord.create(dict(skycoord=skycoord,energy=energy))
         """
         if isinstance(data, cls):
             if data.coordsys is None or coordsys == data.coordsys:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -948,7 +948,7 @@ class MapGeom(object):
         pass
 
     @abc.abstractmethod
-    def get_coords(self, idx=None, flat=False):
+    def get_coord(self, idx=None, flat=False):
         """Get the coordinate array for this geometry.
 
         Returns a coordinate array with the same shape as the data

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -623,12 +623,14 @@ class MapCoord(object):
         if isinstance(key, six.string_types):
             return self._data[key]
         else:
-            return self._data.values()[key]
+            return list(self._data.values())[key]
 
     def __iter__(self):
         return iter(self._data.values())
 
     def __getattr__(self, key):
+        if key.startswith('_'):
+            raise AttributeError(key)
         try:
             return self[key]
         except KeyError:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -802,10 +802,10 @@ class MapCoord(object):
                 return data.to_coordsys(coordsys)
         elif isinstance(data, dict):
             return cls._from_dict(data, coordsys=coordsys, copy=copy)
-        elif isinstance(data, tuple) or isinstance(data, list):
+        elif isinstance(data, (list, tuple)):
             return cls._from_tuple(data, coordsys=coordsys, copy=copy)
         elif isinstance(data, SkyCoord):
-            return cls._from_skycoord(data, coordsys=coordsys, copy=copy)
+            return cls._from_skycoord((data,), coordsys=coordsys, copy=copy)
         else:
             raise Exception('Unsupported input type.')
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -663,6 +663,13 @@ class MapCoord(object):
         return self._coordsys
 
     @property
+    def match_by_name(self):
+        """Boolean flag indicating whether axis lookup should be performed by
+        name (True) or index (False).
+        """
+        return self._match_by_name
+
+    @property
     def skycoord(self):
         return SkyCoord(self.lon, self.lat, unit='deg',
                         frame=coordsys_to_frame(self.coordsys))
@@ -728,9 +735,9 @@ class MapCoord(object):
     def _from_tuple(cls, coords, coordsys=None, copy=False):
         """Create from tuple of coordinate vectors."""
         if (isinstance(coords[0], (list, np.ndarray)) or np.isscalar(coords[0])):
-            return cls._from_lonlat(coords, coordsys=coordsys)
+            return cls._from_lonlat(coords, coordsys=coordsys, copy=copy)
         elif isinstance(coords[0], SkyCoord):
-            return cls._from_skycoord(coords, coordsys=coordsys)
+            return cls._from_skycoord(coords, coordsys=coordsys, copy=copy)
         else:
             raise Exception('Unsupported input type.')
 
@@ -1172,7 +1179,7 @@ class MapGeom(object):
         if self.ndim != coord.ndim:
             raise ValueError
 
-        if not coord._match_by_name:
+        if not coord.match_by_name:
             return tuple(coord._data.values())
 
         coord_tuple = [coord.lon, coord.lat]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -784,10 +784,11 @@ class MapCoord(object):
         --------
         >>> from astropy.coordinates import SkyCoord
         >>> from gammapy.maps import MapCoord
-        >>> lon, lat = np.array([1.0,2.0]), np.array([2.0,3.0])
-        >>> energy = np.array([1000.])
+        >>> lon, lat = [1, 2], [2, 3]
+        >>> skycoord = SkyCoord(lon, lat, unit='deg')
+        >>> energy = [1000]
         >>> c = MapCoord.create((lon,lat))
-        >>> c = MapCoord.create((SkyCoord(lon,lat,unit='deg'),))
+        >>> c = MapCoord.create((skycoord,))
         >>> c = MapCoord.create((lon,lat,energy))
         >>> c = MapCoord.create(dict(lon=lon,lat=lat))
         >>> c = MapCoord.create(dict(lon=lon,lat=lat,energy=energy))

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -808,7 +808,7 @@ class MapCoord(object):
             data['lat'] = lat
             return self.__class__(data, coordsys=coordsys)
 
-    def mask(self, msk):
+    def apply_mask(self, msk):
         """Return a masked copy of this coordinate object.
 
         Parameters
@@ -819,7 +819,7 @@ class MapCoord(object):
         Returns
         -------
         coords : `~MapCoord`
-            A masked coordinates object.        
+            A coordinates object.
         """
         data = OrderedDict([(k, v[msk]) for k, v in self._data.items()])
         return self.__class__(data, self.coordsys)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -634,14 +634,6 @@ class MapCoord(object):
     def __iter__(self):
         return iter(self._data.values())
 
-    def __getattr__(self, key):
-        if key.startswith('_'):
-            raise AttributeError(key)
-        try:
-            return self[key]
-        except KeyError:
-            raise AttributeError(key)
-
     @property
     def ndim(self):
         """Number of dimensions."""
@@ -784,6 +776,7 @@ class MapCoord(object):
         --------
         >>> from astropy.coordinates import SkyCoord
         >>> from gammapy.maps import MapCoord
+
         >>> lon, lat = [1, 2], [2, 3]
         >>> skycoord = SkyCoord(lon, lat, unit='deg')
         >>> energy = [1000]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -13,7 +13,7 @@ from astropy.coordinates import SkyCoord
 from .utils import find_hdu, find_bands_hdu
 
 __all__ = [
-    'MapCoords',
+    'MapCoord',
     'MapGeom',
     'MapAxis',
 ]
@@ -590,7 +590,7 @@ class MapAxis(object):
                        node_type=self._node_type, unit=self._unit)
 
 
-class MapCoords(object):
+class MapCoord(object):
     """Represents a sequence of n-dimensional map coordinates.
 
     Contains coordinates for 2 spatial dimensions and an arbitrary
@@ -705,7 +705,7 @@ class MapCoords(object):
             Coordinate tuple with first element of type
             `~astropy.coordinates.SkyCoord`.        
         coordsys : {'CEL', 'GAL', None}
-            Spatial coordinate system of output `~MapCoords` object.
+            Spatial coordinate system of output `~MapCoord` object.
             If None the coordinate system will be set to the frame of
             the `~astropy.coordinates.SkyCoord` object.        
         """
@@ -758,7 +758,7 @@ class MapCoords(object):
 
     @classmethod
     def create(cls, data, coordsys=None, copy=False):
-        """Create a new `~MapCoords` object.
+        """Create a new `~MapCoord` object.
 
         Parameters
         ----------
@@ -793,7 +793,7 @@ class MapCoords(object):
 
         Returns
         -------
-        coords : `~MapCoords`
+        coords : `~MapCoord`
             A coordinates object.
         """
         if coordsys == self.coordsys:
@@ -816,7 +816,7 @@ class MapCoords(object):
 
         Returns
         -------
-        coords : `~MapCoords`
+        coords : `~MapCoord`
             A masked coordinates object.        
         """
         data = OrderedDict([(k, v[msk]) for k, v in self._data.items()])
@@ -982,7 +982,7 @@ class MapGeom(object):
         ----------
         coords : tuple
             Coordinate values in each dimension of the map.  This can
-            either be a tuple of numpy arrays or a MapCoords object.
+            either be a tuple of numpy arrays or a MapCoord object.
             If passed as a tuple then the ordering should be
             (longitude, latitude, c_0, ..., c_N) where c_i is the
             coordinate vector for axis i.
@@ -999,9 +999,9 @@ class MapGeom(object):
 
         Parameters
         ----------
-        coords : tuple or `~MapCoords`
+        coords : tuple or `~MapCoord`
             Coordinate values in each dimension of the map.  This can
-            either be a tuple of numpy arrays or a MapCoords object.
+            either be a tuple of numpy arrays or a MapCoord object.
             If passed as a tuple then the ordering should be
             (longitude, latitude, c_0, ..., c_N) where c_i is the
             coordinate vector for axis i.
@@ -1063,7 +1063,7 @@ class MapGeom(object):
 
         Parameters
         ----------
-        coords : tuple or `~gammapy.maps.MapCoords`
+        coords : tuple or `~gammapy.maps.MapCoord`
             Tuple of map coordinates.
 
         Returns

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -626,7 +626,6 @@ class MapCoord(object):
         self._match_by_name = match_by_name
 
     def __getitem__(self, key):
-
         if isinstance(key, six.string_types):
             return self._data[key]
         else:
@@ -692,7 +691,6 @@ class MapCoord(object):
         coord : `~MapCoord`
             A coordinates object.
         """
-
         if isinstance(coords, (list, tuple)):
             coords_dict = OrderedDict([('lon', coords[0]),
                                        ('lat', coords[1])])

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -825,12 +825,12 @@ class MapCoord(object):
             return self.__class__(data, coordsys=coordsys,
                                   match_by_name=self._match_by_name)
 
-    def apply_mask(self, msk):
+    def apply_mask(self, mask):
         """Return a masked copy of this coordinate object.
 
         Parameters
         ----------
-        msk : `~numpy.ndarray`
+        mask : `~numpy.ndarray`
             Boolean mask.
 
         Returns
@@ -838,7 +838,7 @@ class MapCoord(object):
         coords : `~MapCoord`
             A coordinates object.
         """
-        data = OrderedDict([(k, v[msk]) for k, v in self._data.items()])
+        data = OrderedDict([(k, v[mask]) for k, v in self._data.items()])
         return self.__class__(data, self.coordsys,
                               match_by_name=self._match_by_name)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -620,7 +620,7 @@ class MapCoord(object):
 
     def __getitem__(self, key):
 
-        if isinstance(key, basestring):
+        if isinstance(key, six.string_types):
             return self._data[key]
         else:
             return self._data.values()[key]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -845,7 +845,8 @@ class MapCoord(object):
             A coordinates object.
         """
         data = OrderedDict([(k, v[msk]) for k, v in self._data.items()])
-        return self.__class__(data, self.coordsys)
+        return self.__class__(data, self.coordsys,
+                              match_by_name=self._match_by_name)
 
 
 class MapGeomMeta(InheritDocstrings, abc.ABCMeta):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -830,7 +830,8 @@ class MapCoord(object):
             data = copy.deepcopy(self._data)
             data['lon'] = lon
             data['lat'] = lat
-            return self.__class__(data, coordsys=coordsys)
+            return self.__class__(data, coordsys=coordsys,
+                                  match_by_name=self._match_by_name)
 
     def apply_mask(self, msk):
         """Return a masked copy of this coordinate object.

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -39,7 +39,7 @@ class HpxConv(object):
         self.convname = convname
         self.colstring = kwargs.get('colstring', 'CHANNEL')
         self.firstcol = kwargs.get('firstcol', 1)
-        self.extname = kwargs.get('extname', 'SKYMAP')
+        self.hduname = kwargs.get('hduname', 'SKYMAP')
         self.bands_hdu = kwargs.get('bands_hdu', 'EBOUNDS')
         self.quantity_type = kwargs.get('quantity_type', 'integral')
         self.coordsys = kwargs.get('coordsys', 'COORDSYS')
@@ -58,20 +58,20 @@ HPX_FITS_CONVENTIONS[None] = HpxConv('gadf', bands_hdu='BANDS')
 HPX_FITS_CONVENTIONS['gadf'] = HpxConv('gadf', bands_hdu='BANDS')
 HPX_FITS_CONVENTIONS['fgst-ccube'] = HpxConv('fgst-ccube')
 HPX_FITS_CONVENTIONS['fgst-ltcube'] = HpxConv(
-    'fgst-ltcube', colstring='COSBINS', extname='EXPOSURE', bands_hdu='CTHETABOUNDS')
+    'fgst-ltcube', colstring='COSBINS', hduname='EXPOSURE', bands_hdu='CTHETABOUNDS')
 HPX_FITS_CONVENTIONS['fgst-bexpcube'] = HpxConv(
-    'fgst-bexpcube', colstring='ENERGY', extname='HPXEXPOSURES', bands_hdu='ENERGIES')
+    'fgst-bexpcube', colstring='ENERGY', hduname='HPXEXPOSURES', bands_hdu='ENERGIES')
 HPX_FITS_CONVENTIONS['fgst-srcmap'] = HpxConv(
-    'fgst-srcmap', extname=None, quantity_type='differential')
+    'fgst-srcmap', hduname=None, quantity_type='differential')
 HPX_FITS_CONVENTIONS['fgst-template'] = HpxConv(
     'fgst-template', colstring='ENERGY', bands_hdu='ENERGIES')
 HPX_FITS_CONVENTIONS['fgst-srcmap-sparse'] = HpxConv(
-    'fgst-srcmap-sparse', colstring=None, extname=None, quantity_type='differential')
+    'fgst-srcmap-sparse', colstring=None, hduname=None, quantity_type='differential')
 HPX_FITS_CONVENTIONS['galprop'] = HpxConv(
-    'galprop', colstring='Bin', extname='SKYMAP2',
+    'galprop', colstring='Bin', hduname='SKYMAP2',
     bands_hdu='ENERGIES', quantity_type='differential', coordsys='COORDTYPE')
 HPX_FITS_CONVENTIONS['galprop2'] = HpxConv(
-    'galprop', colstring='Bin', extname='SKYMAP2',
+    'galprop', colstring='Bin', hduname='SKYMAP2',
     bands_hdu='ENERGIES', quantity_type='differential')
 
 
@@ -1225,10 +1225,10 @@ class HpxGeom(MapGeom):
             pass
 
         # Try based on the EXTNAME keyword
-        extname = header.get('EXTNAME', None)
-        if extname == 'HPXEXPOSURES':
+        hduname = header.get('EXTNAME', None)
+        if hduname == 'HPXEXPOSURES':
             return 'fgst-bexpcube'
-        elif extname == 'SKYMAP2':
+        elif hduname == 'SKYMAP2':
             if 'COORDTYPE' in header.keys():
                 return 'galprop'
             else:
@@ -1248,7 +1248,7 @@ class HpxGeom(MapGeom):
         elif colname == 'Bin0':
             return 'galprop'
         elif colname == 'CHANNEL1' or colname == 'CHANNEL0':
-            if extname == 'SKYMAP':
+            if hduname == 'SKYMAP':
                 return 'fgst-ccube'
             else:
                 return 'fgst-srcmap'
@@ -1383,22 +1383,22 @@ class HpxGeom(MapGeom):
 
         return header
 
-    def make_bands_hdu(self, extname='BANDS'):
+    def make_bands_hdu(self, hdu='BANDS'):
 
         header = fits.Header()
         self._fill_header_from_axes(header)
         cols = make_axes_cols(self.axes)
         if self.nside.size > 1:
             cols += [fits.Column('NSIDE', 'I', array=np.ravel(self.nside)), ]
-        hdu = fits.BinTableHDU.from_columns(cols, header, name=extname)
+        hdu = fits.BinTableHDU.from_columns(cols, header, name=hdu)
         return hdu
 
-    def make_ebounds_hdu(self, extname='EBOUNDS'):
+    def make_ebounds_hdu(self, hdu='EBOUNDS'):
         """Make a FITS HDU with the energy bin boundaries.
 
         Parameters
         ----------
-        extname : str
+        hdu : str
             The HDU extension name
         """
         # TODO: Assert if the number of axes is wrong?
@@ -1409,25 +1409,25 @@ class HpxGeom(MapGeom):
         cols = [fits.Column('CHANNEL', 'I', array=np.arange(1, self._axes[0].nbin)),
                 fits.Column('E_MIN', '1E', unit='keV', array=1000 * emin),
                 fits.Column('E_MAX', '1E', unit='keV', array=1000 * emax)]
-        hdu = fits.BinTableHDU.from_columns(
-            cols, self.make_header(), name=extname)
-        return hdu
+        hdu_out = fits.BinTableHDU.from_columns(cols, self.make_header(),
+                                                name=hdu)
+        return hdu_out
 
-    def make_energies_hdu(self, extname='ENERGIES'):
+    def make_energies_hdu(self, hdu='ENERGIES'):
         """Make a FITS HDU with the energy bin centers.
 
         Parameters
         ----------
-        extname : str
+        hdu : str
             The HDU extension name
         """
         ectr = np.sqrt(self._axes[0][1:] * self._axes[0][:-1])
         cols = [fits.Column('ENERGY', '1E', unit='MeV', array=ectr)]
-        hdu = fits.BinTableHDU.from_columns(
-            cols, self.make_header(), name=extname)
-        return hdu
+        hdu_out = fits.BinTableHDU.from_columns(
+            cols, self.make_header(), name=hdu)
+        return hdu_out
 
-    def write(self, data, outfile, extname='SKYMAP', overwrite=True):
+    def write(self, data, outfile, hdu='SKYMAP', overwrite=True):
         """Write input data to a FITS file.
 
         Parameters
@@ -1436,13 +1436,13 @@ class HpxGeom(MapGeom):
             The data being stored
         outfile : str
             The name of the output file
-        extname :
+        hdu : str
             The HDU extension name
         overwrite : bool
             True -> overwrite existing files
         """
         hdu_prim = fits.PrimaryHDU()
-        hdu_hpx = self.make_hdu(data, extname=extname)
+        hdu_hpx = self.make_hdu(data, hdu=hdu)
         hl = [hdu_prim, hdu_hpx]
 
         if self.conv.bands_hdu == 'EBOUNDS':

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -10,7 +10,7 @@ from ..extern.six.moves import range
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from .wcs import WcsGeom
-from .geom import MapGeom, MapCoords, pix_tuple_to_idx
+from .geom import MapGeom, MapCoord, pix_tuple_to_idx
 from .geom import coordsys_to_frame, skycoord_to_lonlat, make_axes_cols
 from .geom import find_and_read_bands, make_axes
 
@@ -756,7 +756,7 @@ class HpxGeom(MapGeom):
 
     def coord_to_pix(self, coords):
         import healpy as hp
-        coords = MapCoords.create(coords, coordsys=self.coordsys)
+        coords = MapCoord.create(coords, coordsys=self.coordsys)
         phi = np.radians(coords.lon)
         theta = np.pi / 2. - np.radians(coords.lat)
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -755,7 +755,7 @@ class HpxGeom(MapGeom):
 
     def coord_to_pix(self, coords):
         import healpy as hp
-        c = MapCoords.create(coords)
+        c = MapCoords.create(coords, coordsys=self.coordsys)
         phi = np.radians(c.lon)
         theta = np.pi / 2. - np.radians(c.lat)
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -340,6 +340,7 @@ def get_hpxregion_dir(region, coordsys):
     coordsys : {'CEL', 'GAL'}
         Coordinate system
     """
+    import healpy as hp
     frame = coordsys_to_frame(coordsys)
     if region is None:
         return SkyCoord(0., 0., frame=frame, unit='deg')

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1670,7 +1670,7 @@ class HpxGeom(MapGeom):
 
         return pix
 
-    def get_coords(self, idx=None, flat=False):
+    def get_coord(self, idx=None, flat=False):
         pix = self.get_idx(idx=idx, flat=flat)
         return self.pix_to_coord(pix)
 
@@ -1680,7 +1680,7 @@ class HpxGeom(MapGeom):
 
     def get_skydirs(self):
         """Get the sky coordinates of all the pixels in this geometry. """
-        coords = self.get_coords()
+        coords = self.get_coord()
         frame = 'galactic' if self.coordsys == 'GAL' else 'icrs'
         return SkyCoord(coords[0], coords[1], unit='deg', frame=frame)
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 from astropy.io import fits
 from .utils import unpack_seq
-from .geom import MapCoords, pix_tuple_to_idx, coord_to_idx
+from .geom import MapCoord, pix_tuple_to_idx, coord_to_idx
 from .utils import interp_to_order
 from .hpxmap import HpxMap
 from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order
@@ -320,7 +320,7 @@ class HpxNDMap(HpxMap):
 
         import healpy as hp
 
-        c = MapCoords.create(coords)
+        c = MapCoord.create(coords)
         coords_ctr = list(coords[:2])
         coords_ctr += [ax.pix_to_coord(t)
                        for ax, t in zip(self.geom.axes, idxs)]
@@ -358,7 +358,7 @@ class HpxNDMap(HpxMap):
 
     def _interp_by_coords(self, coords, order):
         """Linearly interpolate map values."""
-        c = MapCoords.create(coords)
+        c = MapCoord.create(coords)
         idx_ax = self.geom.coord_to_idx(c, clip=True)[1:]
         pix, wts = self._get_interp_weights(coords, idx_ax)
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -178,7 +178,7 @@ class HpxNDMap(HpxMap):
                                     buffersize=buffersize))
 
     def iter_by_coords(self, buffersize=1):
-        coords = list(self.geom.get_coords(flat=True))
+        coords = list(self.geom.get_coord(flat=True))
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + coords,
                                     flags=['external_loop', 'buffered'],
@@ -197,7 +197,7 @@ class HpxNDMap(HpxMap):
 
         if self.geom.nside.size > 1:
             vals = self.get_by_idx(self.geom.get_idx(flat=True))
-            map_out.fill_by_coords(self.geom.get_coords(flat=True)[:2], vals)
+            map_out.fill_by_coord(self.geom.get_coord(flat=True)[:2], vals)
         else:
             axes = np.arange(self.data.ndim - 1).tolist()
             data = np.apply_over_axes(np.sum, self.data, axes=axes)
@@ -247,18 +247,18 @@ class HpxNDMap(HpxMap):
         geom = self.geom.pad(pad_width)
         map_out = self.__class__(geom, meta=copy.deepcopy(self.meta))
         map_out.coadd(self)
-        coords = geom.get_coords(flat=True)
+        coords = geom.get_coord(flat=True)
         m = self.geom.contains(coords)
         coords = tuple([c[~m] for c in coords])
 
         if mode == 'constant':
-            map_out.set_by_coords(coords, cval)
+            map_out.set_by_coord(coords, cval)
         elif mode in ['edge', 'interp']:
             # FIXME: These modes don't work at present because
             # interp_by_coords doesn't support extrapolation
             vals = self.interp_by_coords(coords, interp=0 if mode == 'edge'
                                          else order)
-            map_out.set_by_coords(coords, vals)
+            map_out.set_by_coord(coords, vals)
         else:
             raise ValueError('Unrecognized pad mode: {}'.format(mode))
 
@@ -274,10 +274,10 @@ class HpxNDMap(HpxMap):
 
         map_out = self.__class__(self.geom.upsample(factor),
                                  meta=copy.deepcopy(self.meta))
-        coords = map_out.geom.get_coords(flat=True)
-        vals = self.get_by_coords(coords)
+        coords = map_out.geom.get_coord(flat=True)
+        vals = self.get_by_coord(coords)
         m = np.isfinite(vals)
-        map_out.fill_by_coords([c[m] for c in coords], vals[m])
+        map_out.fill_by_coord([c[m] for c in coords], vals[m])
 
         if preserve_counts:
             map_out.data /= factor**2
@@ -291,7 +291,7 @@ class HpxNDMap(HpxMap):
         idx = self.geom.get_idx(flat=True)
         coords = self.geom.pix_to_coord(idx)
         vals = self.get_by_idx(idx)
-        map_out.fill_by_coords(coords, vals)
+        map_out.fill_by_coord(coords, vals)
 
         if not preserve_counts:
             map_out.data /= factor**2
@@ -478,14 +478,14 @@ class HpxNDMap(HpxMap):
             idx = self.geom.get_idx(flat=True)
             coords = self.geom.pix_to_coord(idx)
             vals = self.get_by_idx(idx)
-            map_out.fill_by_coords(coords, vals)
+            map_out.fill_by_coord(coords, vals)
         else:
             # Upsample
             idx = new_hpx.get_idx(flat=True)
             coords = new_hpx.pix_to_coord(idx)
-            vals = self.get_by_coords(coords)
+            vals = self.get_by_coord(coords)
             m = np.isfinite(vals)
-            map_out.fill_by_coords([c[m] for c in coords], vals[m])
+            map_out.fill_by_coord([c[m] for c in coords], vals[m])
 
         if not preserve_counts:
             fact = (2 ** order) ** 2 / (2 ** self.geom.order) ** 2

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -177,7 +177,7 @@ class HpxNDMap(HpxMap):
                                     flags=['external_loop', 'buffered'],
                                     buffersize=buffersize))
 
-    def iter_by_coords(self, buffersize=1):
+    def iter_by_coord(self, buffersize=1):
         coords = list(self.geom.get_coord(flat=True))
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + coords,
@@ -255,8 +255,8 @@ class HpxNDMap(HpxMap):
             map_out.set_by_coord(coords, cval)
         elif mode in ['edge', 'interp']:
             # FIXME: These modes don't work at present because
-            # interp_by_coords doesn't support extrapolation
-            vals = self.interp_by_coords(coords, interp=0 if mode == 'edge'
+            # interp_by_coord doesn't support extrapolation
+            vals = self.interp_by_coord(coords, interp=0 if mode == 'edge'
                                          else order)
             map_out.set_by_coord(coords, vals)
         else:
@@ -298,11 +298,11 @@ class HpxNDMap(HpxMap):
 
         return map_out
 
-    def interp_by_coords(self, coords, interp=1):
+    def interp_by_coord(self, coords, interp=1):
 
         order = interp_to_order(interp)
         if order == 1:
-            return self._interp_by_coords(coords, order)
+            return self._interp_by_coord(coords, order)
         else:
             raise ValueError('Invalid interpolation order: {}'.format(order))
 
@@ -356,7 +356,7 @@ class HpxNDMap(HpxMap):
         pix_local += [np.broadcast_to(t, pix_local[0].shape) for t in idxs]
         return pix_local, wts
 
-    def _interp_by_coords(self, coords, order):
+    def _interp_by_coord(self, coords, order):
         """Linearly interpolate map values."""
         c = MapCoord.create(coords)
         idx_ax = self.geom.coord_to_idx(c, clip=True)[1:]

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -257,7 +257,7 @@ class HpxNDMap(HpxMap):
             # FIXME: These modes don't work at present because
             # interp_by_coord doesn't support extrapolation
             vals = self.interp_by_coord(coords, interp=0 if mode == 'edge'
-                                         else order)
+                                        else order)
             map_out.set_by_coord(coords, vals)
         else:
             raise ValueError('Unrecognized pad mode: {}'.format(mode))

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -98,6 +98,9 @@ class HpxSparseMap(HpxMap):
     def interp_by_coord(self, coords, interp=None):
         raise NotImplementedError
 
+    def interp_by_pix(self, pix, interp=None):
+        raise NotImplementedError
+
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
         if weights is None:

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -95,7 +95,7 @@ class HpxSparseMap(HpxMap):
         idx = self.geom.global_to_local(idx)
         return self.data[idx[::-1]]
 
-    def interp_by_coords(self, coords, interp=None):
+    def interp_by_coord(self, coords, interp=None):
         raise NotImplementedError
 
     def fill_by_idx(self, idx, weights=None):
@@ -148,7 +148,7 @@ class HpxSparseMap(HpxMap):
     def iter_by_pix(self):
         raise NotImplementedError
 
-    def iter_by_coords(self):
+    def iter_by_coord(self):
         raise NotImplementedError
 
     def sum_over_axes(self):

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -58,7 +58,7 @@ def test_map_meta_read_write(map_type):
     m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
                    skydir=SkyCoord(0.0, 30.0, unit='deg'), meta=meta)
 
-    hdulist = m.to_hdulist(extname='COUNTS')
+    hdulist = m.to_hdulist(hdu='COUNTS')
     header = hdulist['COUNTS'].header
 
     assert header['META'] == '{"user": "test"}'

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -107,6 +107,6 @@ def test_mapcoords_create():
 
     # 2D Vector w/ SkyCoord
     lon, lat = np.array([0.0, 1.0]), np.array([2.0, 3.0])
-    coords = MapCoords.create((SkyCoord(lon, lat, unit='deg')))
+    coords = MapCoords.create((SkyCoord(lon, lat, unit='deg'),))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -94,7 +94,6 @@ def test_mapaxis_slice(nodes, interp, node_type):
 
 
 def test_mapcoords_create():
-
     # From existing MapCoord
     coords_cel = MapCoord.create((0.0, 1.0), coordsys='CEL')
     coords_gal = MapCoord.create(coords_cel, coordsys='GAL')
@@ -107,16 +106,16 @@ def test_mapcoords_create():
     assert_allclose(coords.lat, 1.0)
     assert_allclose(coords[0], 0.0)
     assert_allclose(coords[1], 1.0)
-    assert(coords.coordsys == None)
-    assert(coords.ndim == 2)
+    assert coords.coordsys is None
+    assert coords.ndim == 2
 
     # 3D Tuple of scalars
     coords = MapCoord.create((0.0, 1.0, 2.0))
     assert_allclose(coords[0], 0.0)
     assert_allclose(coords[1], 1.0)
     assert_allclose(coords[2], 2.0)
-    assert(coords.coordsys == None)
-    assert(coords.ndim == 3)
+    assert coords.coordsys is None
+    assert coords.ndim == 3
 
     # 2D Tuple w/ NaN coordinates
     coords = MapCoord.create((np.nan, np.nan))
@@ -135,45 +134,45 @@ def test_mapcoords_create():
     coords = MapCoord.create((skycoord_cel,))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert(coords.coordsys == 'CEL')
-    assert(coords.ndim == 2)
+    assert coords.coordsys == 'CEL'
+    assert coords.ndim == 2
     coords = MapCoord.create((skycoord_gal,))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert(coords.coordsys == 'GAL')
-    assert(coords.ndim == 2)
+    assert coords.coordsys == 'GAL'
+    assert coords.ndim == 2
 
     # SkyCoord
     coords = MapCoord.create(skycoord_cel)
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert(coords.coordsys == 'CEL')
-    assert(coords.ndim == 2)
+    assert coords.coordsys == 'CEL'
+    assert coords.ndim == 2
     coords = MapCoord.create(skycoord_gal)
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert(coords.coordsys == 'GAL')
-    assert(coords.ndim == 2)
+    assert coords.coordsys == 'GAL'
+    assert coords.ndim == 2
 
     # 2D Dict w/ vectors
     coords = MapCoord.create(dict(lon=lon, lat=lat))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert(coords.ndim == 2)
+    assert coords.ndim == 2
 
     # 3D Dict w/ vectors
     coords = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords.energy, energy)
-    assert(coords.ndim == 3)
+    assert coords.ndim == 3
 
     # 3D Dict w/ SkyCoord
     coords = MapCoord.create(dict(skycoord=skycoord_cel, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords.energy, energy)
-    assert(coords.ndim == 3)
+    assert coords.ndim == 3
 
     # 3D OrderedDict w/ vectors
     coords = MapCoord.create(OrderedDict([('energy', energy),
@@ -184,11 +183,10 @@ def test_mapcoords_create():
     assert_allclose(coords[0], energy)
     assert_allclose(coords[1], lat)
     assert_allclose(coords[2], lon)
-    assert(coords.ndim == 3)
+    assert coords.ndim == 3
 
 
 def test_mapcoords_to_coordsys():
-
     lon, lat = np.array([0.0, 1.0]), np.array([2.0, 3.0])
     energy = np.array([100., 1000.])
     skycoord_cel = SkyCoord(lon, lat, unit='deg', frame='icrs')
@@ -196,13 +194,13 @@ def test_mapcoords_to_coordsys():
 
     coords = MapCoord.create(
         dict(lon=lon, lat=lat, energy=energy), coordsys='CEL')
-    assert(coords.coordsys == 'CEL')
+    assert coords.coordsys == 'CEL'
     assert_allclose(coords.skycoord.transform_to(
         'icrs').ra.deg, skycoord_cel.ra.deg)
     assert_allclose(coords.skycoord.transform_to(
         'icrs').dec.deg, skycoord_cel.dec.deg)
     coords = coords.to_coordsys('GAL')
-    assert(coords.coordsys == 'GAL')
+    assert coords.coordsys == 'GAL'
     assert_allclose(coords.skycoord.transform_to(
         'galactic').l.deg, skycoord_cel.galactic.l.deg)
     assert_allclose(coords.skycoord.transform_to(
@@ -210,13 +208,13 @@ def test_mapcoords_to_coordsys():
 
     coords = MapCoord.create(
         dict(lon=lon, lat=lat, energy=energy), coordsys='GAL')
-    assert(coords.coordsys == 'GAL')
+    assert coords.coordsys == 'GAL'
     assert_allclose(coords.skycoord.transform_to(
         'galactic').l.deg, skycoord_gal.l.deg)
     assert_allclose(coords.skycoord.transform_to(
         'galactic').b.deg, skycoord_gal.b.deg)
     coords = coords.to_coordsys('CEL')
-    assert(coords.coordsys == 'CEL')
+    assert coords.coordsys == 'CEL'
     assert_allclose(coords.skycoord.transform_to(
         'icrs').ra.deg, skycoord_gal.icrs.ra.deg)
     assert_allclose(coords.skycoord.transform_to(

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -164,14 +164,14 @@ def test_mapcoords_create():
     coords = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert_allclose(coords.energy, energy)
+    assert_allclose(coords['energy'], energy)
     assert coords.ndim == 3
 
     # 3D Dict w/ SkyCoord
     coords = MapCoord.create(dict(skycoord=skycoord_cel, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert_allclose(coords.energy, energy)
+    assert_allclose(coords['energy'], energy)
     assert coords.ndim == 3
 
     # 3D OrderedDict w/ vectors
@@ -179,7 +179,7 @@ def test_mapcoords_create():
                                           ('lat', lat), ('lon', lon)]))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
-    assert_allclose(coords.energy, energy)
+    assert_allclose(coords['energy'], energy)
     assert_allclose(coords[0], energy)
     assert_allclose(coords[1], lat)
     assert_allclose(coords[2], lon)

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
-from ..geom import MapAxis, MapCoords
+from ..geom import MapAxis, MapCoord
 
 pytest.importorskip('scipy')
 
@@ -95,7 +95,7 @@ def test_mapaxis_slice(nodes, interp, node_type):
 
 def test_mapcoords_create():
     # 2D Tuple of scalars
-    coords = MapCoords.create((0.0, 1.0))
+    coords = MapCoord.create((0.0, 1.0))
     assert_allclose(coords.lon, 0.0)
     assert_allclose(coords.lat, 1.0)
     assert_allclose(coords[0], 0.0)
@@ -104,7 +104,7 @@ def test_mapcoords_create():
     assert(coords.ndim == 2)
 
     # 3D Tuple of scalars
-    coords = MapCoords.create((0.0, 1.0, 2.0))
+    coords = MapCoord.create((0.0, 1.0, 2.0))
     assert_allclose(coords[0], 0.0)
     assert_allclose(coords[1], 1.0)
     assert_allclose(coords[2], 2.0)
@@ -112,11 +112,11 @@ def test_mapcoords_create():
     assert(coords.ndim == 3)
 
     # 2D Tuple w/ NaN coordinates
-    coords = MapCoords.create((np.nan, np.nan))
+    coords = MapCoord.create((np.nan, np.nan))
 
     # 2D Tuple w/ NaN coordinates
     lon, lat = np.array([np.nan, 1.0]), np.array([np.nan, 3.0])
-    coords = MapCoords.create((lon, lat))
+    coords = MapCoord.create((lon, lat))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
 
@@ -125,39 +125,39 @@ def test_mapcoords_create():
     energy = np.array([100., 1000.])
     skycoord_cel = SkyCoord(lon, lat, unit='deg', frame='icrs')
     skycoord_gal = SkyCoord(lon, lat, unit='deg', frame='galactic')
-    coords = MapCoords.create((skycoord_cel,))
+    coords = MapCoord.create((skycoord_cel,))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert(coords.coordsys == 'CEL')
     assert(coords.ndim == 2)
-    coords = MapCoords.create((skycoord_gal,))
+    coords = MapCoord.create((skycoord_gal,))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert(coords.coordsys == 'GAL')
     assert(coords.ndim == 2)
 
     # 2D Dict w/ vectors
-    coords = MapCoords.create(dict(lon=lon, lat=lat))
+    coords = MapCoord.create(dict(lon=lon, lat=lat))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert(coords.ndim == 2)
 
     # 3D Dict w/ vectors
-    coords = MapCoords.create(dict(lon=lon, lat=lat, energy=energy))
+    coords = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords.energy, energy)
     assert(coords.ndim == 3)
 
     # 3D Dict w/ SkyCoord
-    coords = MapCoords.create(dict(skycoord=skycoord_cel, energy=energy))
+    coords = MapCoord.create(dict(skycoord=skycoord_cel, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords.energy, energy)
     assert(coords.ndim == 3)
 
     # 3D OrderedDict w/ vectors
-    coords = MapCoords.create(OrderedDict([('energy', energy),
+    coords = MapCoord.create(OrderedDict([('energy', energy),
                                            ('lat', lat), ('lon', lon)]))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
@@ -175,7 +175,7 @@ def test_mapcoords_to_coordsys():
     skycoord_cel = SkyCoord(lon, lat, unit='deg', frame='icrs')
     skycoord_gal = SkyCoord(lon, lat, unit='deg', frame='galactic')
 
-    coords = MapCoords.create(
+    coords = MapCoord.create(
         dict(lon=lon, lat=lat, energy=energy), coordsys='CEL')
     assert(coords.coordsys == 'CEL')
     assert_allclose(coords.skycoord.transform_to(
@@ -189,7 +189,7 @@ def test_mapcoords_to_coordsys():
     assert_allclose(coords.skycoord.transform_to(
         'galactic').b.deg, skycoord_cel.galactic.b.deg)
 
-    coords = MapCoords.create(
+    coords = MapCoord.create(
         dict(lon=lon, lat=lat, energy=energy), coordsys='GAL')
     assert(coords.coordsys == 'GAL')
     assert_allclose(coords.skycoord.transform_to(

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -94,6 +94,13 @@ def test_mapaxis_slice(nodes, interp, node_type):
 
 
 def test_mapcoords_create():
+
+    # From existing MapCoord
+    coords_cel = MapCoord.create((0.0, 1.0), coordsys='CEL')
+    coords_gal = MapCoord.create(coords_cel, coordsys='GAL')
+    assert_allclose(coords_gal.lon, coords_cel.skycoord.galactic.l.deg)
+    assert_allclose(coords_gal.lat, coords_cel.skycoord.galactic.b.deg)
+
     # 2D Tuple of scalars
     coords = MapCoord.create((0.0, 1.0))
     assert_allclose(coords.lon, 0.0)
@@ -136,6 +143,18 @@ def test_mapcoords_create():
     assert(coords.coordsys == 'GAL')
     assert(coords.ndim == 2)
 
+    # SkyCoord
+    coords = MapCoord.create(skycoord_cel)
+    assert_allclose(coords.lon, lon)
+    assert_allclose(coords.lat, lat)
+    assert(coords.coordsys == 'CEL')
+    assert(coords.ndim == 2)
+    coords = MapCoord.create(skycoord_gal)
+    assert_allclose(coords.lon, lon)
+    assert_allclose(coords.lat, lat)
+    assert(coords.coordsys == 'GAL')
+    assert(coords.ndim == 2)
+
     # 2D Dict w/ vectors
     coords = MapCoord.create(dict(lon=lon, lat=lat))
     assert_allclose(coords.lon, lon)
@@ -158,7 +177,7 @@ def test_mapcoords_create():
 
     # 3D OrderedDict w/ vectors
     coords = MapCoord.create(OrderedDict([('energy', energy),
-                                           ('lat', lat), ('lon', lon)]))
+                                          ('lat', lat), ('lon', lon)]))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords.energy, energy)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -481,7 +481,7 @@ def test_hpxgeom_from_header():
                          hpx_test_geoms)
 def test_hpxgeom_read_write(tmpdir, nside, nested, coordsys, region, axes):
     geom0 = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
-    hdu_bands = geom0.make_bands_hdu(extname='BANDS')
+    hdu_bands = geom0.make_bands_hdu(hdu='BANDS')
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.make_header())
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -364,31 +364,31 @@ def test_hpxgeom_make_wcs():
     assert_allclose(wcs.wcs.wcs.crval, np.array([110., 75.]))
 
 
-def test_hpxgeom_get_coords():
+def test_hpxgeom_get_coord():
     ax0 = np.linspace(0., 3., 4)
 
     # 2D all-sky
     hpx = HpxGeom(16, False, 'GAL')
-    c = hpx.get_coords()
+    c = hpx.get_coord()
     assert_allclose(c[0][:3], np.array([45., 135., 225.]))
     assert_allclose(c[1][:3], np.array([87.075819, 87.075819, 87.075819]))
 
     # 3D all-sky
     hpx = HpxGeom(16, False, 'GAL', axes=[ax0])
-    c = hpx.get_coords()
+    c = hpx.get_coord()
     assert_allclose(c[0][0, :3], np.array([45., 135., 225.]))
     assert_allclose(c[1][0, :3], np.array([87.075819, 87.075819, 87.075819]))
     assert_allclose(c[2][0, :3], np.array([0.5, 0.5, 0.5]))
 
     # 2D partial-sky
     hpx = HpxGeom(64, False, 'GAL', region='DISK(110.,75.,2.)')
-    c = hpx.get_coords()
+    c = hpx.get_coord()
     assert_allclose(c[0][:3], np.array([107.5, 112.5, 106.57894737]))
     assert_allclose(c[1][:3], np.array([76.813533, 76.813533, 76.07742]))
 
     # 3D partial-sky
     hpx = HpxGeom(64, False, 'GAL', region='DISK(110.,75.,2.)', axes=[ax0])
-    c = hpx.get_coords()
+    c = hpx.get_coord()
     assert_allclose(c[0][0, :3], np.array([107.5, 112.5, 106.57894737]))
     assert_allclose(c[1][0, :3], np.array([76.813533, 76.813533, 76.07742]))
     assert_allclose(c[2][0, :3], np.array([0.5, 0.5, 0.5]))
@@ -396,7 +396,7 @@ def test_hpxgeom_get_coords():
     # 3D partial-sky w/ variable bin size
     hpx = HpxGeom([16, 32, 64], False, 'GAL',
                   region='DISK(110.,75.,2.)', axes=[ax0])
-    c = hpx.get_coords(flat=True)
+    c = hpx.get_coord(flat=True)
     assert_allclose(c[0][:3], np.array([117., 103.5, 112.5]))
     assert_allclose(c[1][:3], np.array([75.340734, 75.340734, 75.340734]))
     assert_allclose(c[2][:3], np.array([0.5, 1.5, 1.5]))
@@ -406,7 +406,7 @@ def test_hpxgeom_get_coords():
                          hpx_test_geoms)
 def test_hpxgeom_contains(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
-    coords = geom.get_coords(flat=True)
+    coords = geom.get_coord(flat=True)
     assert_allclose(geom.contains(coords),
                     np.ones_like(coords[0], dtype=bool))
 
@@ -507,7 +507,7 @@ def test_hpxgeom_upsample(nside, nested, coordsys, region, axes):
     geom_up = geom.upsample(2)
     assert_allclose(2 * geom.nside, geom_up.nside)
     assert_allclose(4 * geom.npix, geom_up.npix)
-    coords = geom_up.get_coords(flat=True)
+    coords = geom_up.get_coord(flat=True)
     assert(np.all(geom.contains(coords)))
 
     # RING
@@ -515,7 +515,7 @@ def test_hpxgeom_upsample(nside, nested, coordsys, region, axes):
     geom_up = geom.upsample(2)
     assert_allclose(2 * geom.nside, geom_up.nside)
     assert_allclose(4 * geom.npix, geom_up.npix)
-    coords = geom_up.get_coords(flat=True)
+    coords = geom_up.get_coord(flat=True)
     assert(np.all(geom.contains(coords)))
 
 
@@ -527,12 +527,12 @@ def test_hpxgeom_downsample(nside, nested, coordsys, region, axes):
     geom = HpxGeom(nside, True, coordsys, region=region, axes=axes)
     geom_down = geom.downsample(2)
     assert_allclose(geom.nside, 2 * geom_down.nside)
-    coords = geom.get_coords(flat=True)
+    coords = geom.get_coord(flat=True)
     assert(np.all(geom_down.contains(coords)))
 
     # RING
     geom = HpxGeom(nside, False, coordsys, region=region, axes=axes)
     geom_down = geom.downsample(2)
     assert_allclose(geom.nside, 2 * geom_down.nside)
-    coords = geom.get_coords(flat=True)
+    coords = geom.get_coord(flat=True)
     assert(np.all(geom_down.contains(coords)))

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -134,13 +134,13 @@ def test_hpxmap_set_get_by_coord(nside, nested, coordsys, region, axes, sparse):
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
-def test_hpxmap_interp_by_coords(nside, nested, coordsys, region, axes):
+def test_hpxmap_interp_by_coord(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     coords = m.geom.get_coord(flat=True)
     m.set_by_coord(coords, coords[1])
     assert_allclose(m.get_by_coord(coords),
-                    m.interp_by_coords(coords, interp='linear'))
+                    m.interp_by_coord(coords, interp='linear'))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
@@ -162,7 +162,7 @@ def test_hpxmap_iter(nside, nested, coordsys, region, axes):
     m.fill_by_coord(coords, coords[0])
     for vals, pix in m.iter_by_pix(buffersize=100):
         assert_allclose(vals, m.get_by_pix(pix))
-    for vals, coords in m.iter_by_coords(buffersize=100):
+    for vals, coords in m.iter_by_coord(buffersize=100):
         assert_allclose(vals, m.get_by_coord(coords))
 
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -105,7 +105,7 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
                          hpx_test_geoms_sparse)
 def test_hpxmap_set_get_by_pix(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords(flat=True)
+    coords = m.geom.get_coord(flat=True)
     idx = m.geom.get_idx(flat=True)
     m.set_by_pix(idx, coords[0])
     assert_allclose(coords[0], m.get_by_pix(idx))
@@ -113,23 +113,23 @@ def test_hpxmap_set_get_by_pix(nside, nested, coordsys, region, axes, sparse):
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)
-def test_hpxmap_set_get_by_coords(nside, nested, coordsys, region, axes, sparse):
+def test_hpxmap_set_get_by_coord(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords(flat=True)
-    m.set_by_coords(coords, coords[0])
-    assert_allclose(coords[0], m.get_by_coords(coords))
+    coords = m.geom.get_coord(flat=True)
+    m.set_by_coord(coords, coords[0])
+    assert_allclose(coords[0], m.get_by_coord(coords))
 
     # Test with SkyCoords
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords(flat=True)
+    coords = m.geom.get_coord(flat=True)
     skydir = SkyCoord(coords[0], coords[1], unit='deg',
                       frame=coordsys_to_frame(m.geom.coordsys))
     skydir_cel = skydir.transform_to('icrs')
     skydir_gal = skydir.transform_to('galactic')
-    m.set_by_coords((skydir_gal,) + coords[2:], coords[0])
-    assert_allclose(coords[0], m.get_by_coords(coords))
-    assert_allclose(m.get_by_coords((skydir_cel,) + coords[2:]),
-                    m.get_by_coords((skydir_gal,) + coords[2:]))
+    m.set_by_coord((skydir_gal,) + coords[2:], coords[0])
+    assert_allclose(coords[0], m.get_by_coord(coords))
+    assert_allclose(m.get_by_coord((skydir_cel,) + coords[2:]),
+                    m.get_by_coord((skydir_gal,) + coords[2:]))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
@@ -137,20 +137,20 @@ def test_hpxmap_set_get_by_coords(nside, nested, coordsys, region, axes, sparse)
 def test_hpxmap_interp_by_coords(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    coords = m.geom.get_coords(flat=True)
-    m.set_by_coords(coords, coords[1])
-    assert_allclose(m.get_by_coords(coords),
+    coords = m.geom.get_coord(flat=True)
+    m.set_by_coord(coords, coords[1])
+    assert_allclose(m.get_by_coord(coords),
                     m.interp_by_coords(coords, interp='linear'))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)
-def test_hpxmap_fill_by_coords(nside, nested, coordsys, region, axes, sparse):
+def test_hpxmap_fill_by_coord(nside, nested, coordsys, region, axes, sparse):
     m = create_map(nside, nested, coordsys, region, axes, sparse)
-    coords = m.geom.get_coords(flat=True)
-    m.fill_by_coords(coords, coords[1])
-    m.fill_by_coords(coords, coords[1])
-    assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])
+    coords = m.geom.get_coord(flat=True)
+    m.fill_by_coord(coords, coords[1])
+    m.fill_by_coord(coords, coords[1])
+    assert_allclose(m.get_by_coord(coords), 2.0 * coords[1])
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
@@ -158,12 +158,12 @@ def test_hpxmap_fill_by_coords(nside, nested, coordsys, region, axes, sparse):
 def test_hpxmap_iter(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    coords = m.geom.get_coords(flat=True)
-    m.fill_by_coords(coords, coords[0])
+    coords = m.geom.get_coord(flat=True)
+    m.fill_by_coord(coords, coords[0])
     for vals, pix in m.iter_by_pix(buffersize=100):
         assert_allclose(vals, m.get_by_pix(pix))
     for vals, coords in m.iter_by_coords(buffersize=100):
-        assert_allclose(vals, m.get_by_coords(coords))
+        assert_allclose(vals, m.get_by_coord(coords))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
@@ -182,8 +182,8 @@ def test_hpxmap_swap_scheme(nside, nested, coordsys, region, axes):
                          coordsys=coordsys, region=region, axes=axes))
     fill_poisson(m, mu=1.0, random_state=0)
     m2 = m.to_swapped()
-    coords = m.geom.get_coords(flat=True)
-    assert_allclose(m.get_by_coords(coords), m2.get_by_coords(coords))
+    coords = m.geom.get_coord(flat=True)
+    assert_allclose(m.get_by_coord(coords), m2.get_by_coord(coords))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
@@ -202,13 +202,13 @@ def test_hpxmap_pad(nside, nested, coordsys, region, axes):
     m.set_by_pix(m.geom.get_idx(flat=True), 1.0)
     cval = 2.2
     m_pad = m.pad(1, mode='constant', cval=cval)
-    coords_pad = m_pad.geom.get_coords(flat=True)
+    coords_pad = m_pad.geom.get_coord(flat=True)
     msk = m.geom.contains(coords_pad)
     coords_out = tuple([c[~msk] for c in coords_pad])
-    assert_allclose(m_pad.get_by_coords(coords_out),
+    assert_allclose(m_pad.get_by_coord(coords_out),
                     cval * np.ones_like(coords_out[0]))
     coords_in = tuple([c[msk] for c in coords_pad])
-    assert_allclose(m_pad.get_by_coords(coords_in),
+    assert_allclose(m_pad.get_by_coord(coords_in),
                     np.ones_like(coords_in[0]))
 
 
@@ -247,6 +247,6 @@ def test_hpxmap_downsample(nside, nested, coordsys, region, axes):
 def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
-    coords = m.geom.get_coords(flat=True)
-    m.fill_by_coords(coords, coords[0])
+    coords = m.geom.get_coord(flat=True)
+    m.fill_by_coord(coords, coords[0])
     msum = m.sum_over_axes()

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -134,13 +134,13 @@ def test_hpxmap_set_get_by_coords(nside, nested, coordsys, region, axes, sparse)
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
-def test_hpxmap_get_by_coords_interp(nside, nested, coordsys, region, axes):
+def test_hpxmap_interp_by_coords(nside, nested, coordsys, region, axes):
     m = HpxNDMap(HpxGeom(nside=nside, nest=nested,
                          coordsys=coordsys, region=region, axes=axes))
     coords = m.geom.get_coords(flat=True)
     m.set_by_coords(coords, coords[1])
     assert_allclose(m.get_by_coords(coords),
-                    m.get_by_coords(coords, interp='linear'))
+                    m.interp_by_coords(coords, interp='linear'))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -90,7 +90,7 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
                            proj=proj, coordsys=coordsys, axes=axes)
 
     shape = (np.max(geom0.npix[0]), np.max(geom0.npix[1]))
-    hdu_bands = geom0.make_bands_hdu(extname='BANDS')
+    hdu_bands = geom0.make_bands_hdu(hdu='BANDS')
     hdu_prim = fits.PrimaryHDU(np.zeros(shape).T)
     hdu_prim.header.update(geom0.make_header())
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -10,8 +10,8 @@ from ..geom import MapAxis
 
 pytest.importorskip('scipy')
 
-axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
-axes2 = [MapAxis(np.logspace(0., 3., 3), interp='log'),
+axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log', name='energy')]
+axes2 = [MapAxis(np.logspace(0., 3., 3), interp='log', name='energy'),
          MapAxis(np.logspace(1., 3., 4), interp='lin')]
 skydir = SkyCoord(110., 75.0, unit='deg', frame='icrs')
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -60,7 +60,7 @@ def test_wcsgeom_get_pix(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsgeom_test_pix_to_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    assert_allclose(geom.get_coords()[0],
+    assert_allclose(geom.get_coord()[0],
                     geom.pix_to_coord(geom.get_idx())[0])
 
 
@@ -70,7 +70,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     assert_allclose(geom.get_idx()[0],
-                    geom.coord_to_idx(geom.get_coords())[0])
+                    geom.coord_to_idx(geom.get_coord())[0])
 
     if not geom.is_allsky:
         coords = geom.center_coord[:2] + \
@@ -110,7 +110,7 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsgeom_contains(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
-    coords = geom.get_coords()
+    coords = geom.get_coord()
     coords = [c[np.isfinite(c)] for c in coords]
     assert_allclose(geom.contains(coords),
                     np.ones(coords[0].shape, dtype=bool))

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..utils import fill_poisson
-from ..geom import MapAxis, coordsys_to_frame
+from ..geom import MapAxis, MapCoords, coordsys_to_frame
 from ..base import Map
 from ..wcs import WcsGeom
 from ..hpx import HpxGeom
@@ -118,6 +118,17 @@ def test_wcsndmap_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(coords[0], m.get_by_coords(coords))
     assert_allclose(m.get_by_coords((skydir_cel,) + coords[2:]),
                     m.get_by_coords((skydir_gal,) + coords[2:]))
+
+    # Test with MapCoords
+    m = WcsNDMap(geom)
+    coords = m.geom.get_coords()
+    coords_dict = dict(lon=coords[0], lat=coords[1])
+    if axes:
+        for i, ax in enumerate(axes):
+            coords_dict[ax.name] = coords[i + 2]
+    map_coords = MapCoords.create(coords_dict, coordsys=coordsys)
+    m.set_by_coords(map_coords, coords[0])
+    assert_allclose(coords[0], m.get_by_coords(map_coords))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -168,11 +168,11 @@ def test_wcsndmap_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     m = WcsNDMap(geom)
     coords = m.geom.get_coords(flat=True)
     m.set_by_coords(coords, coords[1])
-    assert_allclose(coords[1], m.get_by_coords(coords, interp='nearest'))
-    assert_allclose(coords[1], m.get_by_coords(coords, interp='linear'))
-    assert_allclose(coords[1], m.get_by_coords(coords, interp=1))
+    assert_allclose(coords[1], m.interp_by_coords(coords, interp='nearest'))
+    assert_allclose(coords[1], m.interp_by_coords(coords, interp='linear'))
+    assert_allclose(coords[1], m.interp_by_coords(coords, interp=1))
     if geom.is_regular and not geom.is_allsky:
-        assert_allclose(coords[1], m.get_by_coords(coords, interp='cubic'))
+        assert_allclose(coords[1], m.interp_by_coords(coords, interp='cubic'))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..utils import fill_poisson
-from ..geom import MapAxis, MapCoords, coordsys_to_frame
+from ..geom import MapAxis, MapCoord, coordsys_to_frame
 from ..base import Map
 from ..wcs import WcsGeom
 from ..hpx import HpxGeom
@@ -119,14 +119,14 @@ def test_wcsndmap_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(m.get_by_coords((skydir_cel,) + coords[2:]),
                     m.get_by_coords((skydir_gal,) + coords[2:]))
 
-    # Test with MapCoords
+    # Test with MapCoord
     m = WcsNDMap(geom)
     coords = m.geom.get_coords()
     coords_dict = dict(lon=coords[0], lat=coords[1])
     if axes:
         for i, ax in enumerate(axes):
             coords_dict[ax.name] = coords[i + 2]
-    map_coords = MapCoords.create(coords_dict, coordsys=coordsys)
+    map_coords = MapCoord.create(coords_dict, coordsys=coordsys)
     m.set_by_coords(map_coords, coords[0])
     assert_allclose(coords[0], m.get_by_coords(map_coords))
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -173,17 +173,17 @@ def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsndmap_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_interp_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
     coords = m.geom.get_coord(flat=True)
     m.set_by_coord(coords, coords[1])
-    assert_allclose(coords[1], m.interp_by_coords(coords, interp='nearest'))
-    assert_allclose(coords[1], m.interp_by_coords(coords, interp='linear'))
-    assert_allclose(coords[1], m.interp_by_coords(coords, interp=1))
+    assert_allclose(coords[1], m.interp_by_coord(coords, interp='nearest'))
+    assert_allclose(coords[1], m.interp_by_coord(coords, interp='linear'))
+    assert_allclose(coords[1], m.interp_by_coord(coords, interp=1))
     if geom.is_regular and not geom.is_allsky:
-        assert_allclose(coords[1], m.interp_by_coords(coords, interp='cubic'))
+        assert_allclose(coords[1], m.interp_by_coord(coords, interp='cubic'))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
@@ -196,7 +196,7 @@ def test_wcsndmap_iter(npix, binsz, coordsys, proj, skydir, axes):
     m.fill_by_coord(coords, coords[0])
     for vals, pix in m.iter_by_pix(buffersize=100):
         assert_allclose(vals, m.get_by_pix(pix))
-    for vals, coords in m.iter_by_coords(buffersize=100):
+    for vals, coords in m.iter_by_coord(buffersize=100):
         assert_allclose(vals, m.get_by_coord(coords))
 
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -48,8 +48,8 @@ def test_wcsndmap_init(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m0 = WcsNDMap(geom)
-    coords = m0.geom.get_coords()
-    m0.set_by_coords(coords, coords[1])
+    coords = m0.geom.get_coord()
+    m0.set_by_coord(coords, coords[1])
     m1 = WcsNDMap(geom, m0.data)
     assert_allclose(m0.data, m1.data)
 
@@ -86,7 +86,7 @@ def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coord()
     pix = m.geom.get_idx()
     m.set_by_pix(pix, coords[0])
     assert_allclose(coords[0], m.get_by_pix(pix))
@@ -94,67 +94,67 @@ def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsndmap_set_get_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_set_get_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
-    m.set_by_coords(coords, coords[0])
-    assert_allclose(coords[0], m.get_by_coords(coords))
+    coords = m.geom.get_coord()
+    m.set_by_coord(coords, coords[0])
+    assert_allclose(coords[0], m.get_by_coord(coords))
 
     if not geom.is_allsky:
         coords[1][...] = 0.0
         assert_allclose(
-            np.nan * np.ones(coords[0].shape), m.get_by_coords(coords))
+            np.nan * np.ones(coords[0].shape), m.get_by_coord(coords))
 
     # Test with SkyCoords
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coord()
     skydir = SkyCoord(coords[0], coords[1], unit='deg',
                       frame=coordsys_to_frame(geom.coordsys))
     skydir_cel = skydir.transform_to('icrs')
     skydir_gal = skydir.transform_to('galactic')
-    m.set_by_coords((skydir_gal,) + coords[2:], coords[0])
-    assert_allclose(coords[0], m.get_by_coords(coords))
-    assert_allclose(m.get_by_coords((skydir_cel,) + coords[2:]),
-                    m.get_by_coords((skydir_gal,) + coords[2:]))
+    m.set_by_coord((skydir_gal,) + coords[2:], coords[0])
+    assert_allclose(coords[0], m.get_by_coord(coords))
+    assert_allclose(m.get_by_coord((skydir_cel,) + coords[2:]),
+                    m.get_by_coord((skydir_gal,) + coords[2:]))
 
     # Test with MapCoord
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coord()
     coords_dict = dict(lon=coords[0], lat=coords[1])
     if axes:
         for i, ax in enumerate(axes):
             coords_dict[ax.name] = coords[i + 2]
     map_coords = MapCoord.create(coords_dict, coordsys=coordsys)
-    m.set_by_coords(map_coords, coords[0])
-    assert_allclose(coords[0], m.get_by_coords(map_coords))
+    m.set_by_coord(map_coords, coords[0])
+    assert_allclose(coords[0], m.get_by_coord(map_coords))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsndmap_fill_by_coords(npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsndmap_fill_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coord()
     fill_coords = tuple([np.concatenate((t, t)) for t in coords])
     fill_vals = fill_coords[1]
-    m.fill_by_coords(fill_coords, fill_vals)
-    assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])
+    m.fill_by_coord(fill_coords, fill_vals)
+    assert_allclose(m.get_by_coord(coords), 2.0 * coords[1])
 
     # Test with SkyCoords
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
+    coords = m.geom.get_coord()
     skydir = SkyCoord(coords[0], coords[1], unit='deg',
                       frame=coordsys_to_frame(geom.coordsys))
     skydir_cel = skydir.transform_to('icrs')
     skydir_gal = skydir.transform_to('galactic')
     fill_coords_cel = (skydir_cel,) + coords[2:]
     fill_coords_gal = (skydir_gal,) + coords[2:]
-    m.fill_by_coords(fill_coords_cel, coords[1])
-    m.fill_by_coords(fill_coords_gal, coords[1])
-    assert_allclose(m.get_by_coords(coords), 2.0 * coords[1])
+    m.fill_by_coord(fill_coords_cel, coords[1])
+    m.fill_by_coord(fill_coords_gal, coords[1])
+    assert_allclose(m.get_by_coord(coords), 2.0 * coords[1])
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
@@ -164,8 +164,8 @@ def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
                           proj=proj, coordsys=coordsys, axes=axes)
     m0 = WcsNDMap(geom)
     m1 = WcsNDMap(geom.upsample(2))
-    coords = m0.geom.get_coords()
-    m1.fill_by_coords(tuple([np.concatenate((t, t)) for t in coords]),
+    coords = m0.geom.get_coord()
+    m1.fill_by_coord(tuple([np.concatenate((t, t)) for t in coords]),
                       np.concatenate((coords[1], coords[1])))
     m0.coadd(m1)
     assert_allclose(np.nansum(m0.data), np.nansum(m1.data), rtol=1E-4)
@@ -177,8 +177,8 @@ def test_wcsndmap_interp_by_coords(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords(flat=True)
-    m.set_by_coords(coords, coords[1])
+    coords = m.geom.get_coord(flat=True)
+    m.set_by_coord(coords, coords[1])
     assert_allclose(coords[1], m.interp_by_coords(coords, interp='nearest'))
     assert_allclose(coords[1], m.interp_by_coords(coords, interp='linear'))
     assert_allclose(coords[1], m.interp_by_coords(coords, interp=1))
@@ -192,12 +192,12 @@ def test_wcsndmap_iter(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
-    m.fill_by_coords(coords, coords[0])
+    coords = m.geom.get_coord()
+    m.fill_by_coord(coords, coords[0])
     for vals, pix in m.iter_by_pix(buffersize=100):
         assert_allclose(vals, m.get_by_pix(pix))
     for vals, coords in m.iter_by_coords(buffersize=100):
-        assert_allclose(vals, m.get_by_coords(coords))
+        assert_allclose(vals, m.get_by_coord(coords))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
@@ -206,8 +206,8 @@ def test_wcsndmap_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
-    m.fill_by_coords(coords, coords[0])
+    coords = m.geom.get_coord()
+    m.fill_by_coord(coords, coords[0])
     msum = m.sum_over_axes()
 
 
@@ -237,21 +237,21 @@ def test_wcsndmap_reproject(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsndmap_reproject_allsky_car():
     geom = WcsGeom.create(binsz=10.0, proj='CAR', coordsys='CEL')
     m = WcsNDMap(geom)
-    coords = m.geom.get_coords()
-    m.set_by_coords(coords, coords[0])
+    coords = m.geom.get_coord()
+    m.set_by_coord(coords, coords[0])
 
     geom0 = WcsGeom.create(binsz=1.0, proj='CAR', coordsys='CEL',
                            skydir=(180.0, 0.0), width=30.0)
     m0 = m.reproject(geom0, order=1)
-    coords0 = m0.geom.get_coords()
-    assert_allclose(m0.get_by_coords(coords0), coords0[0])
+    coords0 = m0.geom.get_coord()
+    assert_allclose(m0.get_by_coord(coords0), coords0[0])
 
     geom1 = HpxGeom.create(binsz=5.0, coordsys='CEL')
     m1 = m.reproject(geom1, order=1)
-    coords1 = m1.geom.get_coords()
+    coords1 = m1.geom.get_coord()
 
     m = (coords1[0] > 10.0) & (coords1[0] < 350.0)
-    assert_allclose(m1.get_by_coords((coords1[0][m], coords1[1][m])),
+    assert_allclose(m1.get_by_coord((coords1[0][m], coords1[1][m])),
                     coords1[0][m])
 
 
@@ -263,10 +263,10 @@ def test_wcsndmap_pad(npix, binsz, coordsys, proj, skydir, axes):
     m = WcsNDMap(geom)
     m2 = m.pad(1, mode='constant', cval=2.2)
     if not geom.is_allsky:
-        coords = m2.geom.get_coords()
+        coords = m2.geom.get_coord()
         msk = m2.geom.contains(coords)
         coords = tuple([c[~msk] for c in coords])
-        assert_allclose(m2.get_by_coords(coords), 2.2)
+        assert_allclose(m2.get_by_coord(coords), 2.2)
     m.pad(1, mode='edge')
     m.pad(1, mode='interp')
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -166,7 +166,7 @@ def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
     m1 = WcsNDMap(geom.upsample(2))
     coords = m0.geom.get_coord()
     m1.fill_by_coord(tuple([np.concatenate((t, t)) for t in coords]),
-                      np.concatenate((coords[1], coords[1])))
+                     np.concatenate((coords[1], coords[1])))
     m0.coadd(m1)
     assert_allclose(np.nansum(m0.data), np.nansum(m1.data), rtol=1E-4)
 

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -84,7 +84,7 @@ def find_bands_hdu(hdulist, hdu):
 
     Returns
     -------
-    extname : str
+    hduname : str
         Extension name of the BANDS HDU.  None if no BANDS HDU was found.
     """
     if 'BANDSHDU' in hdu.header:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -7,7 +7,7 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..image.utils import make_header
 from ..utils.wcs import get_resampled_wcs
-from .geom import MapGeom, MapCoords, pix_tuple_to_idx, skycoord_to_lonlat
+from .geom import MapGeom, MapCoord, pix_tuple_to_idx, skycoord_to_lonlat
 from .geom import get_shape, make_axes_cols, make_axes
 from .geom import find_and_read_bands
 
@@ -481,7 +481,7 @@ class WcsGeom(MapGeom):
         return coords
 
     def coord_to_pix(self, coords):
-        coords = MapCoords.create(coords, coordsys=self.coordsys)
+        coords = MapCoord.create(coords, coordsys=self.coordsys)
         if coords.size == 0:
             return tuple([np.array([]) for i in range(coords.ndim)])
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -66,7 +66,7 @@ class WcsGeom(MapGeom):
 
     def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, conv='gadf'):
         self._wcs = wcs
-        self._coordsys = get_coordsys(wcs)
+        self._coordsys = get_coordys(wcs)
         self._projection = get_projection(wcs)
         self._conv = conv
         self._axes = make_axes(axes, conv)
@@ -473,7 +473,7 @@ class WcsGeom(MapGeom):
 #        m = np.broadcast_to(np.prod(m),shape)
 #        return tuple([np.ravel(np.broadcast_to(t,shape)[m]) for t in pix])
 
-    def get_coords(self, idx=None, flat=False):
+    def get_coord(self, idx=None, flat=False):
         pix = self._get_pix_coords(idx=idx)
         coords = self.pix_to_coord(pix)
         if flat:
@@ -822,7 +822,7 @@ def get_projection(wcs):
     return wcs.wcs.ctype[0][5:]
 
 
-def get_coordsys(wcs):
+def get_coordys(wcs):
     if 'RA' in wcs.wcs.ctype[0]:
         return 'CEL'
     elif 'GLON' in wcs.wcs.ctype[0]:
@@ -884,7 +884,7 @@ def get_map_skydir(filename, maphdu=0):
 def wcs_to_skydir(wcs):
     lon = wcs.wcs.crval[0]
     lat = wcs.wcs.crval[1]
-    coordsys = get_coordsys(wcs)
+    coordsys = get_coordys(wcs)
     if coordsys == 'GAL':
         return SkyCoord(lon, lat, unit='deg', frame='galactic').transform_to('icrs')
     else:
@@ -892,7 +892,7 @@ def wcs_to_skydir(wcs):
 
 
 def is_galactic(wcs):
-    coordsys = get_coordsys(wcs)
+    coordsys = get_coordys(wcs)
     if coordsys == 'GAL':
         return True
     elif coordsys == 'CEL':

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -336,7 +336,7 @@ class WcsGeom(MapGeom):
 
         return cls(wcs, npix, cdelt=cdelt, axes=axes, conv=conv)
 
-    def make_bands_hdu(self, extname=None, conv=None):
+    def make_bands_hdu(self, hdu=None, conv=None):
         conv = self._conv if conv is None else conv
         header = fits.Header()
         self._fill_header_from_axes(header)
@@ -346,13 +346,13 @@ class WcsGeom(MapGeom):
         # dimensionality of geometry
 
         if conv == 'fgst-ccube':
-            extname = 'EBOUNDS'
+            hdu = 'EBOUNDS'
             axis_names = ['energy']
         elif conv == 'fgst-template':
-            extname = 'ENERGIES'
+            hdu = 'ENERGIES'
             axis_names = ['energy']
-        elif extname is None and conv == 'gadf':
-            extname = 'BANDS'
+        elif hdu is None and conv == 'gadf':
+            hdu = 'BANDS'
 
         cols = make_axes_cols(self.axes, axis_names)
         if not self.is_regular:
@@ -366,8 +366,8 @@ class WcsGeom(MapGeom):
                                  array=np.vstack((np.ravel(self._crpix[0]),
                                                   np.ravel(self._crpix[1]))).T), ]
 
-        hdu = fits.BinTableHDU.from_columns(cols, header, name=extname)
-        return hdu
+        hdu_out = fits.BinTableHDU.from_columns(cols, header, name=hdu)
+        return hdu_out
 
     def make_header(self):
         header = self.wcs.to_header()

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -481,7 +481,7 @@ class WcsGeom(MapGeom):
         return coords
 
     def coord_to_pix(self, coords):
-        c = MapCoords.create(coords)
+        c = MapCoords.create(coords, coordsys=self.coordsys)
         if c.size == 0:
             return tuple([np.array([]) for i in range(c.ndim)])
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -126,13 +126,13 @@ class WcsNDMap(WcsMap):
         idx = pix_tuple_to_idx(idx)
         return self._data.T[idx]
 
-    def interp_by_coords(self, coords, interp=None):
+    def interp_by_coord(self, coords, interp=None):
 
         if self.geom.is_regular:
             pix = self.geom.coord_to_pix(coords)
             return self.interp_by_pix(pix, interp=interp)
         else:
-            return self._interp_by_coords_griddata(coords, interp=interp)
+            return self._interp_by_coord_griddata(coords, interp=interp)
 
     def interp_by_pix(self, pix, interp=None):
         """Interpolate map values at the given pixel coordinates.
@@ -175,7 +175,7 @@ class WcsNDMap(WcsMap):
                      if not isinstance(x, np.ndarray) or x.ndim == 0 else x for x in pix])
         return map_coordinates(self.data.T, pix, order=order, mode='nearest')
 
-    def _interp_by_coords_griddata(self, coords, interp=None):
+    def _interp_by_coord_griddata(self, coords, interp=None):
         order = interp_to_order(interp)
         method_lookup = {0: 'nearest', 1: 'linear', 3: 'cubic'}
         method = method_lookup.get(order, None)
@@ -257,7 +257,7 @@ class WcsNDMap(WcsMap):
                                     flags=['external_loop', 'buffered'],
                                     buffersize=buffersize))
 
-    def iter_by_coords(self, buffersize=1):
+    def iter_by_coord(self, buffersize=1):
         coords = list(self.geom.get_coord(flat=True))
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + coords,
@@ -402,7 +402,7 @@ class WcsNDMap(WcsMap):
             coords = geom.pix_to_coord(idx_out[::-1])
             m = self.geom.contains(coords)
             coords = tuple([c[~m] for c in coords])
-            vals = self.interp_by_coords(coords, interp=0 if mode == 'edge'
+            vals = self.interp_by_coord(coords, interp=0 if mode == 'edge'
                                          else order)
             map_out.set_by_coord(coords, vals)
         else:

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -183,7 +183,7 @@ class WcsNDMap(WcsMap):
             raise ValueError('Invalid interpolation method: {}'.format(interp))
 
         from scipy.interpolate import griddata
-        grid_coords = self.geom.get_coords(flat=True)
+        grid_coords = self.geom.get_coord(flat=True)
         data = self.data[np.isfinite(self.data)]
         vals = griddata(grid_coords, data, coords, method=method)
         m = ~np.isfinite(vals)
@@ -258,7 +258,7 @@ class WcsNDMap(WcsMap):
                                     buffersize=buffersize))
 
     def iter_by_coords(self, buffersize=1):
-        coords = list(self.geom.get_coords(flat=True))
+        coords = list(self.geom.get_coord(flat=True))
         vals = self.data[np.isfinite(self.data)]
         return unpack_seq(np.nditer([vals] + coords,
                                     flags=['external_loop', 'buffered'],
@@ -271,7 +271,7 @@ class WcsNDMap(WcsMap):
         map_out = self.__class__(self.geom.to_image())
         if self.geom.is_regular:
             vals = self.get_by_idx(self.geom.get_idx())
-            map_out.fill_by_coords(self.geom.get_coords()[:2], vals)
+            map_out.fill_by_coord(self.geom.get_coord()[:2], vals)
         else:
             data = np.apply_over_axes(np.sum, self.data,
                                       axes=np.arange(self.data.ndim - 2))
@@ -404,7 +404,7 @@ class WcsNDMap(WcsMap):
             coords = tuple([c[~m] for c in coords])
             vals = self.interp_by_coords(coords, interp=0 if mode == 'edge'
                                          else order)
-            map_out.set_by_coords(coords, vals)
+            map_out.set_by_coord(coords, vals)
         else:
             raise ValueError('Unrecognized pad mode: {}'.format(mode))
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -403,7 +403,7 @@ class WcsNDMap(WcsMap):
             m = self.geom.contains(coords)
             coords = tuple([c[~m] for c in coords])
             vals = self.interp_by_coord(coords, interp=0 if mode == 'edge'
-                                         else order)
+                                        else order)
             map_out.set_by_coord(coords, vals)
         else:
             raise ValueError('Unrecognized pad mode: {}'.format(mode))


### PR DESCRIPTION
This PR refactors the `MapCoord` class and improves the interface for interacting with map objects via `MapCoord` objects (e.g. with `get_by_coords` or `set_by_coords`).  Specifically it addresses some of the ideas and points raised in #1251.  Some additional iteration will probably be required to figure out how to integrate this into a unified scheme for coordinate handling in gammapy but I think these changes to `MapCoord` could be a good starting point for that development.

A short summary of some the changes in this PR:

* Renamed `MapCoords` to `MapCoord`.
* `MapCoord` objects support labeled axes and use an `OrderedDict` internally to store coordinate values.  Using `OrderedDict`as the internal data structure means that we have the option to preserve the axis ordering such as when converting from a coordinate tuple.  `__getitem__` accepts either integer or string-based axis indexing (e.g. either `coord[0]` or `coord['lon']`).  Attribute-based access is also supported (`coord.lon`).  
* Added support to `by_coords` methods for dict input in addition to tuple and `MapCoord`.  Where the internal logic of the map/geometry classes depends on the axis ordering a `MapGeom.coord_to_tuple` method is used to extract a coordinate tuple from a `MapCoord` object with an axis ordering matched to the geometry.  Note that when using dict or MapCoord input this requires a strict match between the axis name of the map and coordinate object (`energy` would not match `reco_energy` for instance).  We might consider whether it might be better to match on the `type` property proposed in #1317.
* `by_coords` methods now correctly handle celestial/galactic coordinate transformations when working with `SkyCoord` objects.  For the tuple-based access pattern the `SkyCoord` replaces the longitude and latitude arrays.  For dict-based access the `SkyCoord` should be passed with key `skycoord`.  Here's an example:
```
from gammapy.maps import WcsND, MapAxis
from astropy.coordinates import SkyCoord

axes=[MapAxis.from_bounds(100.,10000.,3,name='energy')]
m = WcsNDMap.create(npix=10,skydir=(0.0,0.0), axes=axes)

skycoord, energy = SkyCoord(0.0,0.0,unit='deg'), 1000.
# Access by tuple
m.get_by_coords((skycoord,energy))
# Access by dict
m.get_by_coords(dict(skycoord=skycoord,energy=energy))
```
* Drop `interp` option for `get_by_coords`.  This was just dispatching to `interp_by_coords` so it seemed better just to have users call this method explicitly.

