### PR TITLE
Fix a bug in SpectrumStacker

### DIFF
--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -813,7 +813,6 @@ class SpectrumObservationStacker(object):
         energy = template.energy
         stacked_data = np.zeros(energy.nbins)
         stacked_quality = np.ones(energy.nbins)
-
         for spec in counts_spectrum_list:
             stacked_data += spec.counts_in_safe_range.value
             temp = np.logical_and(stacked_quality,
@@ -839,7 +838,7 @@ class SpectrumObservationStacker(object):
             bkscal_on_data = obs.on_vector._backscal_array.copy()
             bkscal_off_data = obs.off_vector._backscal_array.copy()
             bkscal_off += (bkscal_on_data / bkscal_off_data) * obs.off_vector.counts_in_safe_range.value
-            alpha_sum += obs.alpha * obs.off_vector.counts_in_safe_range.sum()
+            alpha_sum += (obs.alpha * obs.off_vector.counts_in_safe_range).sum()
 
         stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
         alpha_average = alpha_sum / self.stacked_off_vector.counts_in_safe_range.sum()

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -859,6 +859,7 @@ class SpectrumObservationStacker(object):
         self.stacked_bkscal_on = bkscal_on
         self.stacked_bkscal_off = stacked_bkscal_off
 
+    
 
         
     def setup_counts_vectors(self):

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -834,9 +834,7 @@ class SpectrumObservationStacker(object):
         bkscal_on = np.ones(nbins)
         bkscal_off = np.zeros(nbins)
         
-        #AL 06.02.2018:calculate the averaged alpha value
         alpha_sum=0.0
-        off_sum=0.0
         
         for obs in self.obs_list:
             bkscal_on_data = obs.on_vector._backscal_array.copy()
@@ -844,52 +842,24 @@ class SpectrumObservationStacker(object):
             bkscal_off_data = obs.off_vector._backscal_array.copy()
             bkscal_off += (bkscal_on_data / bkscal_off_data) * obs.off_vector.counts_in_safe_range.value
 
-            obs_off_sum =0
-            obs_bins = obs.off_vector.bins_in_safe_range
-            for obs_eb in obs_bins:
-              obs_off_sum += obs.off_vector.data.data.value[obs_eb]
-            alpha_sum += obs.alpha * obs_off_sum
-           
+            alpha_sum += obs.alpha * obs.off_vector.counts_in_safe_range.sum()
             
         stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
-
-        off_bins = self.stacked_off_vector.bins_in_safe_range
-        for Eb in off_bins:
-            off_sum += self.stacked_off_vector.data.data.value[Eb]
-        alpha_average = alpha_sum / off_sum
+        alpha_average = alpha_sum / self.stacked_off_vector.counts_in_safe_range.sum()
        
         
         # there should be no nan values in backscal_on or backscal_off
         # this leads to problems when fitting the data
-        #AL 06.02.2018 replace -1 by 1 for on_vector and -1 by averaged_alpha for off_vector
+        # use 1 for backscale of on_vector and 1 / alpha_average for backscale of off_vector
         alpha_correction = 1
         idx = np.where(self.stacked_off_vector.data.data == 0)[0]
         bkscal_on[idx] = alpha_correction
-        stacked_bkscal_off[idx] = alpha_correction * ( 1 / alpha_average )
+        stacked_bkscal_off[idx] = alpha_correction / alpha_average
 
         self.stacked_bkscal_on = bkscal_on
         self.stacked_bkscal_off = stacked_bkscal_off
 
- # AL: 06.02.2018 : old stack_backscale makes bias
- #   def stack_backscal(self):
- #       """Stack ``backscal`` for on and off vector."""
- #       nbins = self.obs_list[0].e_reco.nbins
- #       bkscal_on = np.ones(nbins)
- #       bkscal_off = np.zeros(nbins)
- #
- #       for obs in self.obs_list:
- #           bkscal_on_data = obs.on_vector._backscal_array.copy()
- #            bkscal_off_data = obs.off_vector._backscal_array.copy()
- #           bkscal_off += (bkscal_on_data / bkscal_off_data) * obs.off_vector.counts_in_safe_range.value
- #       stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
-  #      # there should be no nan values in backscal_on or backscal_off
-  #      # this leads to problems when fitting the data
-  #      alpha_correction = - 1
-  #      idx = np.where(self.stacked_off_vector.data.data == 0)[0]
-  #      bkscal_on[idx] = alpha_correction
-  #      stacked_bkscal_off[idx] = alpha_correction
-  #      self.stacked_bkscal_on = bkscal_on
-  #      self.stacked_bkscal_off = stacked_bkscal_off
+
         
     def setup_counts_vectors(self):
         """Add correct attributes to stacked counts vectors."""

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -245,7 +245,7 @@ class SpectrumObservation(object):
                                    (e[[idx - 1, idx]].value))
         else:
             if idx == e.size - 1:
-                energy = self.e_true[idx+1].value
+                energy = self.e_true[idx + 1].value
             else:
                 energy = np.interp(bias_value,
                                    (bias[[idx, idx + 1]].value),
@@ -827,41 +827,36 @@ class SpectrumObservationStacker(object):
             quality=stacked_quality,
         )
 
-    #modif AL : correct bug on alpha
     def stack_backscal(self):
         """Stack ``backscal`` for on and off vector."""
         nbins = self.obs_list[0].e_reco.nbins
         bkscal_on = np.ones(nbins)
         bkscal_off = np.zeros(nbins)
-        
-        alpha_sum=0.0
-        
+
+        alpha_sum = 0.0
+
         for obs in self.obs_list:
             bkscal_on_data = obs.on_vector._backscal_array.copy()
-
             bkscal_off_data = obs.off_vector._backscal_array.copy()
             bkscal_off += (bkscal_on_data / bkscal_off_data) * obs.off_vector.counts_in_safe_range.value
-
             alpha_sum += obs.alpha * obs.off_vector.counts_in_safe_range.sum()
-            
+
         stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
         alpha_average = alpha_sum / self.stacked_off_vector.counts_in_safe_range.sum()
-       
-        
+
         # there should be no nan values in backscal_on or backscal_off
         # this leads to problems when fitting the data
         # use 1 for backscale of on_vector and 1 / alpha_average for backscale of off_vector
         alpha_correction = 1
         idx = np.where(self.stacked_off_vector.data.data == 0)[0]
         bkscal_on[idx] = alpha_correction
+        # For the bins where the stacked OFF counts equal 0, the alpha value is performed by weighting on the total
+        # OFF counts of each run
         stacked_bkscal_off[idx] = alpha_correction / alpha_average
 
         self.stacked_bkscal_on = bkscal_on
         self.stacked_bkscal_off = stacked_bkscal_off
 
-    
-
-        
     def setup_counts_vectors(self):
         """Add correct attributes to stacked counts vectors."""
         total_livetime = self.obs_list.total_livetime
@@ -907,4 +902,3 @@ class SpectrumObservationStacker(object):
             aeff=self.stacked_aeff,
             edisp=self.stacked_edisp,
         )
-

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -234,9 +234,9 @@ class TestSpectrumObservationStacker:
         obs_list = make_observation_list()
         obs_stacker = SpectrumObservationStacker(obs_list)
         obs_stacker.run()
-        assert obs_stacker.stacked_obs.alpha[0] == 1.25 / 4.
-        # When the OFF stack observation counts=0, averaging the alpha on the total OFF counts for each run.
-        assert obs_stacker.stacked_obs.alpha[1] == 2.5 / 8.
+        assert_allclose(obs_stacker.stacked_obs.alpha[0], 1.25 / 4.)
+        # When the OFF stack observation counts=0, the alpha is averaged on the total OFF counts for each run.
+        assert_allclose(obs_stacker.stacked_obs.alpha[1], 2.5 / 8.)
 
 
 @requires_dependency('scipy')

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -90,60 +90,45 @@ def test_spectrum_observation_3():
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
 
+
 @requires_dependency('scipy')
 @requires_dependency('sherpa')
 @requires_data('gammapy-extra')
 def make_observation_list():
-    """obs without IRF"""
-    nbin=10
-    energy = np.logspace(-1, 1, nbin+1) * u.TeV
+    """obs with dummy IRF"""
+    nbin = 3
+    energy = np.logspace(-1, 1, nbin + 1) * u.TeV
     livetime = 2 * u.h
-    data=np.arange(nbin)
-    data1=data
-    data2=data
-    data3=data
-    data1[0]=0
-    data1[1]=0
-    data1[2]=0
-    data1[nbin-1]=0
-    data2[0]=0
-    data1[1]=0
-    data2[nbin-1]=0
-    data3[0]=0
-    data3[nbin-1]=0
-
-
+    data_on = np.arange(nbin)
+    dataoff_1 = np.ones(3)
+    dataoff_2 = np.ones(3) * 3
+    dataoff_1[1] = 0
+    dataoff_2[1] = 0
     on_vector = PHACountsSpectrum(energy_lo=energy[:-1],
                                   energy_hi=energy[1:],
-                                  data=data,
-                                  backscal=1) 
-    off_vector1 = PHACountsSpectrum(energy_lo=energy[:-1],
-                                  energy_hi=energy[1:],
-                                  data=data1,
-                                  backscal=10)
-    off_vector2 = PHACountsSpectrum(energy_lo=energy[:-1],
-                                  energy_hi=energy[1:],
-                                  data=data2,
+                                  data=data_on,
                                   backscal=1)
-    off_vector3 = PHACountsSpectrum(energy_lo=energy[:-1],
-                                  energy_hi=energy[1:],
-                                  data=data3,
-                                  backscal=5)
-       
+    off_vector1 = PHACountsSpectrum(energy_lo=energy[:-1],
+                                    energy_hi=energy[1:],
+                                    data=dataoff_1,
+                                    backscal=2)
+    off_vector2 = PHACountsSpectrum(energy_lo=energy[:-1],
+                                    energy_hi=energy[1:],
+                                    data=dataoff_2,
+                                    backscal=4)
     aeff = EffectiveAreaTable(energy_lo=energy[:-1],
                               energy_hi=energy[1:],
-                              data=np.ones(10) * 1e5 * u.m ** 2)
+                              data=np.ones(nbin) * 1e5 * u.m ** 2)
     edisp = EnergyDispersion.from_gauss(e_true=energy, e_reco=energy,
                                         sigma=0.2, bias=0)
     on_vector.livetime = livetime
     on_vector.obs_id = 2
-    obs1 = SpectrumObservation(on_vector=on_vector,off_vector=off_vector1,aeff=aeff,edisp=edisp)
-    obs2 = SpectrumObservation(on_vector=on_vector,off_vector=off_vector2,aeff=aeff,edisp=edisp)
-    obs3 = SpectrumObservation(on_vector=on_vector,off_vector=off_vector3,aeff=aeff,edisp=edisp)
+    obs1 = SpectrumObservation(on_vector=on_vector, off_vector=off_vector1, aeff=aeff, edisp=edisp)
+    obs2 = SpectrumObservation(on_vector=on_vector, off_vector=off_vector2, aeff=aeff, edisp=edisp)
 
-    obs_list=[obs1,obs2,obs3]
+    obs_list = [obs1, obs2]
     return obs_list
-  
+
 
 class SpectrumObservationTester:
     def __init__(self, obs, vals):
@@ -244,23 +229,16 @@ class TestSpectrumObservationStacker:
 
         assert_allclose(npred_stacked.data.data, npred_summed)
 
-        
     def test_stack_backscal(self):
         """Verify backscal stacking """
-        obs_list=make_observation_list()
+        obs_list = make_observation_list()
         obs_stacker = SpectrumObservationStacker(obs_list)
         obs_stacker.run()
-        alpha_sum=0.0
-        off_sum=0.0
-        for obs in obs_list:
-            alpha_sum += obs.alpha * obs.off_vector.counts_in_safe_range.sum()
-            off_sum += obs.off_vector.counts_in_safe_range.sum()
-        alpha_average = alpha_sum / off_sum 
-        idx = np.where(obs_stacker.stacked_obs.off_vector.data.data == 0)[0]
-        desired_alpha=np.ones(idx.shape)* alpha_average.value
-        assert obs_stacker.stacked_obs.alpha[idx].all() == desired_alpha.all()
-       
-        
+        assert obs_stacker.stacked_obs.alpha[0] == 1.25 / 4.
+        # When the OFF stack observation counts=0, averaging the alpha on the total OFF counts for each run.
+        assert obs_stacker.stacked_obs.alpha[1] == 2.5 / 8.
+
+
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 class TestSpectrumObservationList:

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -4,10 +4,10 @@ import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose
-from ..utils.testing import requires_dependency, requires_data, mpl_savefig_check
-from ..utils.scripts import make_path
-from ..irf import EffectiveAreaTable, EnergyDispersion
-from ..spectrum import (
+from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
+from ...utils.scripts import make_path
+from ...irf import EffectiveAreaTable, EnergyDispersion
+from .. import (
     PHACountsSpectrum,
     SpectrumObservation,
     SpectrumObservationList,


### PR DESCRIPTION
This pull request is aked in order to fix a bug in spectrum/observation.py : in the stacking function, the alpha table was filled with 1 if NOFF=0. We now calculate the average alpha and fill the alpha table with this value when NOFF=0. 
The bug appears fixed after several tests on MC and data. 
There is a test (test_stack_backscal) in tests/test_observation.py 
