### PR TITLE
Maps I/O Cleanup and Improvements

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -51,7 +51,7 @@ class Map(object):
     @data.setter
     def data(self, val):
         if val.shape != self.data.shape:
-            raise Exception('Wrong shape.')
+            raise ValueError('Wrong shape.')
         self._data = val
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -935,7 +935,7 @@ class MapGeom(object):
 
         return cls.from_header(hdu.header, hdu_bands)
 
-    def make_bands_hdu(self, hdu=None, conv=None):
+    def make_bands_hdu(self, hdu=None, hdu_skymap=None, conv=None):
         conv = self.conv if conv is None else conv
         header = fits.Header()
         self._fill_header_from_axes(header)
@@ -951,7 +951,10 @@ class MapGeom(object):
             hdu = 'ENERGIES'
             axis_names = ['energy']
         elif hdu is None and conv == 'gadf':
-            hdu = 'BANDS'
+            if hdu_skymap:
+                hdu = '{}_{}'.format(hdu_skymap, 'BANDS')
+            else:
+                hdu = 'BANDS'
 
         cols = make_axes_cols(self.axes, axis_names)
         cols += self._make_bands_cols()

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -935,8 +935,31 @@ class MapGeom(object):
 
         return cls.from_header(hdu.header, hdu_bands)
 
+    def make_bands_hdu(self, hdu=None, conv=None):
+        conv = self.conv if conv is None else conv
+        header = fits.Header()
+        self._fill_header_from_axes(header)
+        axis_names = None
+
+        # FIXME: Check whether convention is compatible with
+        # dimensionality of geometry
+
+        if conv == 'fgst-ccube':
+            hdu = 'EBOUNDS'
+            axis_names = ['energy']
+        elif conv == 'fgst-template':
+            hdu = 'ENERGIES'
+            axis_names = ['energy']
+        elif hdu is None and conv == 'gadf':
+            hdu = 'BANDS'
+
+        cols = make_axes_cols(self.axes, axis_names)
+        cols += self._make_bands_cols()
+        hdu_out = fits.BinTableHDU.from_columns(cols, header, name=hdu)
+        return hdu_out
+
     @abc.abstractmethod
-    def make_bands_hdu(self):
+    def _make_bands_cols(self):
         pass
 
     @abc.abstractmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -739,7 +739,7 @@ class MapCoord(object):
         elif isinstance(coords[0], SkyCoord):
             return cls._from_skycoord(coords, coordsys=coordsys, copy=copy)
         else:
-            raise Exception('Unsupported input type.')
+            raise TypeError('Type not supported: {}'.format(type(coords)))
 
     @classmethod
     def _from_dict(cls, coords, coordsys=None, copy=False):

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -929,7 +929,12 @@ class HpxGeom(MapGeom):
 
     @property
     def conv(self):
+        """Name of default FITS convention associated with this geometry."""
         return self._conv
+
+    @property
+    def hpx_conv(self):
+        return HPX_FITS_CONVENTIONS[self.conv]
 
     @property
     def coordsys(self):
@@ -1314,7 +1319,7 @@ class HpxGeom(MapGeom):
                 region = None
 
         return cls(nside, nest, coordsys=coordsys, region=region,
-                   axes=axes, conv=conv)
+                   axes=axes, conv=convname)
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):
@@ -1347,7 +1352,7 @@ class HpxGeom(MapGeom):
         """"Build and return FITS header for this HEALPIX map."""
 
         header = fits.Header()
-        conv = kwargs.get('conv', HPX_FITS_CONVENTIONS['gadf'])
+        conv = kwargs.get('conv', HPX_FITS_CONVENTIONS[self.conv])
 
         # FIXME: For some sparse maps we may want to allow EXPLICIT
         # with an empty region string
@@ -1361,10 +1366,9 @@ class HpxGeom(MapGeom):
             else:
                 indxschm = 'LOCAL'
 
-        # FIXME: Set TELESCOP and INSTRUME from convention type
-
-        header["TELESCOP"] = "GLAST"
-        header["INSTRUME"] = "LAT"
+        if 'FGST' in conv.convname.upper():
+            header["TELESCOP"] = "GLAST"
+            header["INSTRUME"] = "LAT"
         header[conv.coordsys] = self.coordsys
         header["PIXTYPE"] = "HEALPIX"
         header["ORDERING"] = self.ordering

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -11,16 +11,13 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from .wcs import WcsGeom
 from .geom import MapGeom, MapCoord, pix_tuple_to_idx
-from .geom import coordsys_to_frame, skycoord_to_lonlat, make_axes_cols
+from .geom import coordsys_to_frame, skycoord_to_lonlat
 from .geom import find_and_read_bands, make_axes
 
-# TODO: What should be part of the public API?
+# Not sure if we should expose this in the docs or not:
+# HPX_FITS_CONVENTIONS, HpxConv
 __all__ = [
-    # 'HpxConv',
-    # 'HPX_FITS_CONVENTIONS',
-    # 'HPX_ORDER_TO_PIXSIZE',
     'HpxGeom',
-    # 'HpxToWcsMapping',
 ]
 
 # This is an approximation of the size of HEALPIX pixels (in degrees)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1388,15 +1388,11 @@ class HpxGeom(MapGeom):
 
         return header
 
-    def make_bands_hdu(self, hdu='BANDS'):
-
-        header = fits.Header()
-        self._fill_header_from_axes(header)
-        cols = make_axes_cols(self.axes)
+    def _make_bands_cols(self):
+        cols = []
         if self.nside.size > 1:
             cols += [fits.Column('NSIDE', 'I', array=np.ravel(self.nside)), ]
-        hdu = fits.BinTableHDU.from_columns(cols, header, name=hdu)
-        return hdu
+        return cols
 
     def make_ebounds_hdu(self, hdu='EBOUNDS'):
         """Make a FITS HDU with the energy bin boundaries.

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -145,14 +145,21 @@ class HpxMap(Map):
         hdu_list : `~astropy.io.fits.HDUList`
         """
 
+        hdu_bands_out = None
+        if self.geom.axes:
+            hdu_bands_out = self.geom.make_bands_hdu(hdu=hdu_bands, hdu_skymap=hdu,
+                                                     conv=conv)
+            hdu_bands = hdu_bands_out.name
+        else:
+            hdu_bands = None
+
         hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse,
                                 conv=conv)
-        hdu_bands = hdu_out.header.get('BANDSHDU', None)
         hdu_out.header['META'] = json.dumps(self.meta)
         hdu_list = [fits.PrimaryHDU(), hdu_out]
 
         if self.geom.axes:
-            hdu_list += [self.geom.make_bands_hdu(hdu=hdu_bands, conv=conv)]
+            hdu_list += [hdu_bands_out]
 
         return fits.HDUList(hdu_list)
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -152,7 +152,7 @@ class HpxMap(Map):
         hdu_list = [fits.PrimaryHDU(), hdu_out]
 
         if self.geom.axes:
-            hdu_list += [self.geom.make_bands_hdu(hdu=hdu_bands)]
+            hdu_list += [self.geom.make_bands_hdu(hdu=hdu_bands, conv=conv)]
 
         return fits.HDUList(hdu_list)
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -240,7 +240,6 @@ class HpxMap(Map):
 
         data = self.data
         shape = data.shape
-        print(hduname, convname, hduname_bands)
         header = self.geom.make_header(conv=conv)
 
         if self.geom.axes:

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
-import json
 import numpy as np
 from astropy.io import fits
 from .utils import unpack_seq

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -90,7 +90,7 @@ class HpxNDMap(HpxMap):
             map_out.set_by_idx(idx[::-1], vals)
         else:
             for c in colnames:
-                if c.find(hpx.conv.colstring) == 0:
+                if c.find(hpx.hpx_conv.colstring) == 0:
                     cnames.append(c)
             nbin = len(cnames)
             if len(cnames) == 1:

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.io import fits
-from collections import OrderedDict
 from .sparse import SparseArray
 from .geom import pix_tuple_to_idx
 from .hpxmap import HpxMap
@@ -51,7 +50,6 @@ class HpxSparseMap(HpxMap):
         """
         hpx = HpxGeom.from_header(hdu.header, hdu_bands)
         shape = tuple([ax.nbin for ax in hpx.axes[::-1]])
-        shape_data = shape + tuple([np.max(hpx.npix)])
 
         # TODO: Should we support extracting slices?
         meta = cls._get_meta_from_header(hdu.header)
@@ -73,8 +71,9 @@ class HpxSparseMap(HpxMap):
             for c in colnames:
                 if c.find(hpx.conv.colstring) == 0:
                     cnames.append(c)
-            nbin = len(cnames)
+
             if len(cnames) == 1:
+                # Use [...] to force dense array indexing
                 map_out.data[...] = hdu.data.field(cnames[0])
             else:
                 for i, cname in enumerate(cnames):
@@ -126,24 +125,28 @@ class HpxSparseMap(HpxMap):
             pix = self.geom.local_to_global(idx[::-1])[0]
             if len(shape) == 1:
                 cols.append(fits.Column('PIX', 'J', array=pix))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=self.data.data.astype(float)))
-
+                array = self.data.data.astype(float)
+                cols.append(fits.Column('VALUE', 'E', array=array))
             else:
                 channel = np.ravel_multi_index(idx[:-1], shape[:-1])
                 cols.append(fits.Column('PIX', 'J', array=pix))
                 cols.append(fits.Column('CHANNEL', 'I', array=channel))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=self.data.data.astype(float)))
+                array = self.data.data.astype(float)
+                cols.append(fits.Column('VALUE', 'E', array=array))
 
         elif len(shape) == 1:
-            cols.append(fits.Column(conv.colname(indx=conv.firstcol),
-                                    'E', array=self.data[...].astype(float)))
+            name = conv.colname(indx=conv.firstcol)
+            # Use [...] to instantiate a dense array
+            array = self.data[...].astype(float)
+            cols.append(fits.Column(name, 'E', array=array))
         else:
             # FIXME: We should be filling undefined pixels here with NaN
             for i, idx in enumerate(np.ndindex(shape[:-1])):
-                cols.append(fits.Column(conv.colname(indx=i + conv.firstcol), 'E',
-                                        array=self.data[...][idx].astype(float)))
+                name = conv.colname(indx=i + conv.firstcol)
+                # Use [...] to instantiate a dense array
+                array = self.data[...][idx].astype(float)
+                cols.append(fits.Column(name, 'E', array=array))
+
         return cols
 
     def iter_by_image(self):

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -138,11 +138,12 @@ class HpxSparseMap(HpxMap):
 
         elif len(shape) == 1:
             cols.append(fits.Column(conv.colname(indx=conv.firstcol),
-                                    'E', array=self.data.data.astype(float)))
+                                    'E', array=self.data[...].astype(float)))
         else:
+            # FIXME: We should be filling undefined pixels here with NaN
             for i, idx in enumerate(np.ndindex(shape[:-1])):
                 cols.append(fits.Column(conv.colname(indx=i + conv.firstcol), 'E',
-                                        array=self.data[idx].astype(float)))
+                                        array=self.data[...][idx].astype(float)))
         return cols
 
     def iter_by_image(self):

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -43,10 +43,10 @@ def test_map_create(binsz, width, map_type, skydir, axes):
 def test_map_from_geom():
     geom = WcsGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
-    assert(isinstance(m, WcsNDMap))
+    assert isinstance(m, WcsNDMap)
     geom = HpxGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
-    assert(isinstance(m, HpxNDMap))
+    assert isinstance(m, HpxNDMap)
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -4,7 +4,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 from collections import OrderedDict
 from ..base import Map
-from ..geom import MapGeom, MapAxis
+from ..geom import MapAxis
 from ..wcs import WcsGeom
 from ..wcsnd import WcsNDMap
 from ..hpx import HpxGeom
@@ -44,6 +44,7 @@ def test_map_from_geom():
     geom = WcsGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
     assert isinstance(m, WcsNDMap)
+
     geom = HpxGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
     assert isinstance(m, HpxNDMap)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -105,7 +105,6 @@ def test_get_superpixels(nside_subpix, nside_superpix, nest):
                          [(2, 4, True), (2, 8, True),
                           (2, 4, False), (2, 8, False)])
 def test_get_subpixels(nside_superpix, nside_subpix, nest):
-
     import healpy as hp
 
     npix = 12 * nside_superpix**2
@@ -113,16 +112,16 @@ def test_get_subpixels(nside_superpix, nside_subpix, nest):
     subpix = get_subpixels(superpix, nside_superpix, nside_subpix, nest=nest)
     ang1 = hp.pix2ang(nside_subpix, subpix, nest=nest)
     pix1 = hp.ang2pix(nside_superpix, *ang1, nest=nest)
-    assert(np.all(superpix[..., None] == pix1))
+    assert np.all(superpix[..., None] == pix1)
 
     superpix = superpix.reshape((12, -1))
     subpix = get_subpixels(superpix, nside_superpix, nside_subpix, nest=nest)
     ang1 = hp.pix2ang(nside_subpix, subpix, nest=nest)
     pix1 = hp.ang2pix(nside_superpix, *ang1, nest=nest)
-    assert(np.all(superpix[..., None] == pix1))
+    assert np.all(superpix[..., None] == pix1)
 
     pix1 = get_superpixels(subpix, nside_subpix, nside_superpix, nest=nest)
-    assert(np.all(superpix[..., None] == pix1))
+    assert np.all(superpix[..., None] == pix1)
 
 
 def test_hpx_global_to_local():
@@ -273,8 +272,7 @@ def test_hpxgeom_coord_to_idx(nside, nested, coordsys, region, axes):
         assert_allclose(np.full_like(coords[0], -1, dtype=int), idx[0])
 
     idx = geom.coord_to_idx(coords, clip=True)
-    assert(np.all(np.not_equal(np.full_like(
-        coords[0], -1, dtype=int), idx[0])))
+    assert np.all(np.not_equal(np.full_like(coords[0], -1, dtype=int), idx[0]))
 
 
 def test_hpxgeom_coord_to_pix():
@@ -501,14 +499,13 @@ def test_hpxgeom_read_write(tmpdir, nside, nested, coordsys, region, axes):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxgeom_upsample(nside, nested, coordsys, region, axes):
-
     # NESTED
     geom = HpxGeom(nside, True, coordsys, region=region, axes=axes)
     geom_up = geom.upsample(2)
     assert_allclose(2 * geom.nside, geom_up.nside)
     assert_allclose(4 * geom.npix, geom_up.npix)
     coords = geom_up.get_coord(flat=True)
-    assert(np.all(geom.contains(coords)))
+    assert np.all(geom.contains(coords))
 
     # RING
     geom = HpxGeom(nside, False, coordsys, region=region, axes=axes)
@@ -516,23 +513,22 @@ def test_hpxgeom_upsample(nside, nested, coordsys, region, axes):
     assert_allclose(2 * geom.nside, geom_up.nside)
     assert_allclose(4 * geom.npix, geom_up.npix)
     coords = geom_up.get_coord(flat=True)
-    assert(np.all(geom.contains(coords)))
+    assert np.all(geom.contains(coords))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)
 def test_hpxgeom_downsample(nside, nested, coordsys, region, axes):
-
     # NESTED
     geom = HpxGeom(nside, True, coordsys, region=region, axes=axes)
     geom_down = geom.downsample(2)
     assert_allclose(geom.nside, 2 * geom_down.nside)
     coords = geom.get_coord(flat=True)
-    assert(np.all(geom_down.contains(coords)))
+    assert np.all(geom_down.contains(coords))
 
     # RING
     geom = HpxGeom(nside, False, coordsys, region=region, axes=axes)
     geom_down = geom.downsample(2)
     assert_allclose(geom.nside, 2 * geom_down.nside)
     coords = geom.get_coord(flat=True)
-    assert(np.all(geom_down.contains(coords)))
+    assert np.all(geom_down.contains(coords))

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -129,7 +129,7 @@ def test_hpxmap_read_write_fgst(tmpdir):
 
     m2 = Map.read(filename)
     assert(m2.geom.conv == 'fgst-template')
-    
+
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -117,24 +117,24 @@ def test_hpxmap_read_write_fgst(tmpdir):
     m = create_map(8, False, 'GAL', None, [axis], False)
     m.write(filename, conv='fgst-ccube')
     h = fits.open(filename)
-    assert('SKYMAP' in h)
-    assert('EBOUNDS' in h)
-    assert(h['SKYMAP'].header['HPX_CONV'] == 'FGST-CCUBE')
-    assert(h['SKYMAP'].header['TTYPE1'] == 'CHANNEL1')
+    assert 'SKYMAP' in h
+    assert 'EBOUNDS' in h
+    assert h['SKYMAP'].header['HPX_CONV'] == 'FGST-CCUBE'
+    assert h['SKYMAP'].header['TTYPE1'] == 'CHANNEL1'
 
     m2 = Map.read(filename)
-    assert(m2.geom.conv == 'fgst-ccube')
+    assert m2.geom.conv == 'fgst-ccube'
 
     # Test Model Cube
     m.write(filename, conv='fgst-template')
     h = fits.open(filename)
-    assert('SKYMAP' in h)
-    assert('ENERGIES' in h)
-    assert(h['SKYMAP'].header['HPX_CONV'] == 'FGST-TEMPLATE')
-    assert(h['SKYMAP'].header['TTYPE1'] == 'ENERGY1')
+    assert 'SKYMAP' in h
+    assert 'ENERGIES' in h
+    assert h['SKYMAP'].header['HPX_CONV'] == 'FGST-TEMPLATE'
+    assert h['SKYMAP'].header['TTYPE1'] == 'ENERGY1'
 
     m2 = Map.read(filename)
-    assert(m2.geom.conv == 'fgst-template')
+    assert m2.geom.conv == 'fgst-template'
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -101,6 +101,12 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     assert_allclose(m.data[...][msk], m3.data[...][msk])
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
+    # Specify alternate HDU name for IMAGE and BANDS table
+    m.write(filename, hdu='IMAGE', hdu_bands='TEST')
+    m2 = HpxNDMap.read(filename)
+    m3 = Map.read(filename)
+    m4 = Map.read(filename, map_type='hpx')
+
 
 def test_hpxmap_read_write_fgst(tmpdir):
     filename = str(tmpdir / 'skycube.fits')

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..utils import fill_poisson
 from ..geom import MapAxis, coordsys_to_frame
@@ -78,7 +79,7 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
 
     m = create_map(nside, nested, coordsys, region, axes, sparse)
     fill_poisson(m, mu=0.5, random_state=0)
-    m.write(filename)
+    m.write(filename, sparse=sparse)
 
     m2 = HpxNDMap.read(filename)
     m3 = HpxSparseMap.read(filename)
@@ -100,6 +101,35 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     assert_allclose(m.data[...][msk], m3.data[...][msk])
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
+
+def test_hpxmap_read_write_fgst(tmpdir):
+    filename = str(tmpdir / 'skycube.fits')
+
+    axis = MapAxis.from_bounds(100., 1000., 4, name='energy', unit='MeV')
+
+    # Test Counts Cube
+    m = create_map(8, False, 'GAL', None, [axis], False)
+    m.write(filename, conv='fgst-ccube')
+    h = fits.open(filename)
+    assert('SKYMAP' in h)
+    assert('EBOUNDS' in h)
+    assert(h['SKYMAP'].header['HPX_CONV'] == 'FGST-CCUBE')
+    assert(h['SKYMAP'].header['TTYPE1'] == 'CHANNEL1')
+
+    m2 = Map.read(filename)
+    assert(m2.geom.conv == 'fgst-ccube')
+
+    # Test Model Cube
+    m.write(filename, conv='fgst-template')
+    h = fits.open(filename)
+    assert('SKYMAP' in h)
+    assert('ENERGIES' in h)
+    assert(h['SKYMAP'].header['HPX_CONV'] == 'FGST-TEMPLATE')
+    assert(h['SKYMAP'].header['TTYPE1'] == 'ENERGY1')
+
+    m2 = Map.read(filename)
+    assert(m2.geom.conv == 'fgst-template')
+    
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -79,8 +79,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
         idx = geom.coord_to_idx(coords)
         assert_allclose(np.full_like(coords[0], -1, dtype=int), idx[0])
         idx = geom.coord_to_idx(coords, clip=True)
-        assert(np.all(np.not_equal(np.full_like(
-            coords[0], -1, dtype=int), idx[0])))
+        assert np.all(np.not_equal(np.full_like(coords[0], -1, dtype=int), idx[0]))
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -97,18 +97,18 @@ def test_wcsndmap_read_write_fgst(tmpdir):
     m = WcsNDMap(geom)
     m.write(filename, conv='fgst-ccube')
     h = fits.open(filename)
-    assert('EBOUNDS' in h)
+    assert 'EBOUNDS' in h
 
     m2 = Map.read(filename)
-    assert(m2.geom.conv == 'fgst-ccube')
+    assert m2.geom.conv == 'fgst-ccube'
 
     # Test Model Cube
     m.write(filename, conv='fgst-template')
     h = fits.open(filename)
-    assert('ENERGIES' in h)
+    assert 'ENERGIES' in h
 
     m2 = Map.read(filename)
-    assert(m2.geom.conv == 'fgst-template')
+    assert m2.geom.conv == 'fgst-template'
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -10,7 +10,6 @@ from ..geom import MapAxis, MapCoord, coordsys_to_frame
 from ..base import Map
 from ..wcs import WcsGeom
 from ..hpx import HpxGeom
-from ..wcsmap import WcsMap
 from ..wcsnd import WcsNDMap
 
 pytest.importorskip('scipy')

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -79,6 +79,12 @@ def test_wcsndmap_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(m0.data, m2.data)
     assert_allclose(m0.data, m3.data)
 
+    # Specify alternate HDU name for IMAGE and BANDS table
+    m0.write(filename, hdu='IMAGE', hdu_bands='TEST')
+    m1 = WcsNDMap.read(filename)
+    m2 = Map.read(filename)
+    m3 = Map.read(filename, map_type='wcs')
+
 
 def test_wcsndmap_read_write_fgst(tmpdir):
     filename = str(tmpdir / 'skycube.fits')

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -80,6 +80,31 @@ def test_wcsndmap_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(m0.data, m3.data)
 
 
+def test_wcsndmap_read_write_fgst(tmpdir):
+    filename = str(tmpdir / 'skycube.fits')
+
+    axis = MapAxis.from_bounds(100., 1000., 4, name='energy', unit='MeV')
+    geom = WcsGeom.create(npix=10, binsz=1.0,
+                          proj='AIT', coordsys='GAL', axes=[axis])
+
+    # Test Counts Cube
+    m = WcsNDMap(geom)
+    m.write(filename, conv='fgst-ccube')
+    h = fits.open(filename)
+    assert('EBOUNDS' in h)
+
+    m2 = Map.read(filename)
+    assert(m2.geom.conv == 'fgst-ccube')
+
+    # Test Model Cube
+    m.write(filename, conv='fgst-template')
+    h = fits.open(filename)
+    assert('ENERGIES' in h)
+
+    m2 = Map.read(filename)
+    assert(m2.geom.conv == 'fgst-template')
+
+
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -79,8 +79,14 @@ def unpack_seq(seq, n=1):
         yield [e for e in row[:n]] + [row[n:]]
 
 
-def find_bands_hdu(hdulist, hdu):
+def find_bands_hdu(hdu_list, hdu):
     """Discover the extension name of the BANDS HDU.
+
+    Parameters
+    ----------
+    hdu_list : `~astropy.io.fits.HDUList`
+
+    hdu : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
 
     Returns
     -------
@@ -97,14 +103,14 @@ def find_bands_hdu(hdulist, hdu):
         has_cube_data = True
     elif isinstance(hdu, fits.BinTableHDU):
 
-        if (hdu.header.get('INDXSCHM', '') in ['IMPLICIT', ''] and
-                len(hdu.columns) > 1):
+        if (hdu.header.get('INDXSCHM', '') in ['EXPLICIT', 'IMPLICIT', '']
+                and len(hdu.columns) > 1):
             has_cube_data = True
 
     if has_cube_data:
-        if 'EBOUNDS' in hdulist:
+        if 'EBOUNDS' in hdu_list:
             return 'EBOUNDS'
-        elif 'ENERGIES' in hdulist:
+        elif 'ENERGIES' in hdu_list:
             return 'ENERGIES'
 
     return None

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -665,7 +665,7 @@ def wcs_add_energy_axis(wcs, energies):
         Array of energies
     """
     if wcs.naxis != 2:
-        raise Exception('WCS naxis must be 2. Got: {}'.format(wcs.naxis))
+        raise ValueError('WCS naxis must be 2. Got: {}'.format(wcs.naxis))
 
     w = WCS(naxis=3)
     w.wcs.crpix[0] = wcs.wcs.crpix[0]

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -8,7 +8,7 @@ from astropy.coordinates import SkyCoord
 from ..image.utils import make_header
 from ..utils.wcs import get_resampled_wcs
 from .geom import MapGeom, MapCoord, pix_tuple_to_idx, skycoord_to_lonlat
-from .geom import get_shape, make_axes_cols, make_axes
+from .geom import get_shape, make_axes
 from .geom import find_and_read_bands
 
 __all__ = [

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -154,8 +154,11 @@ class WcsMap(Map):
 
         if self.geom.axes:
             hdu_bands_out = self.geom.make_bands_hdu(hdu=hdu_bands,
+                                                     hdu_skymap=hdu,
                                                      conv=conv)
             hdu_bands = hdu_bands_out.name
+        else:
+            hdu_bands = None
 
         hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands,
                                 sparse=sparse, conv=conv)

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -92,12 +92,12 @@ class WcsMap(Map):
             raise ValueError('Unrecognized map type: {}'.format(map_type))
 
     @classmethod
-    def from_hdulist(cls, hdulist, hdu=None, hdu_bands=None):
+    def from_hdulist(cls, hdu_list, hdu=None, hdu_bands=None):
         """Make a WcsMap object from a FITS HDUList.
 
         Parameters
         ----------
-        hdulist :  `~astropy.io.fits.HDUList`
+        hdu_list :  `~astropy.io.fits.HDUList`
             HDU list containing HDUs for map data and bands.
         hdu : str
             Name or index of the HDU with the map data.
@@ -110,15 +110,15 @@ class WcsMap(Map):
             Map object
         """
         if hdu is None:
-            hdu = find_hdu(hdulist)
+            hdu = find_hdu(hdu_list)
         else:
-            hdu = hdulist[hdu]
+            hdu = hdu_list[hdu]
 
         if hdu_bands is None:
-            hdu_bands = find_bands_hdu(hdulist, hdu)
+            hdu_bands = find_bands_hdu(hdu_list, hdu)
 
         if hdu_bands is not None:
-            hdu_bands = hdulist[hdu_bands]
+            hdu_bands = hdu_list[hdu_bands]
 
         return cls.from_hdu(hdu, hdu_bands)
 
@@ -128,7 +128,14 @@ class WcsMap(Map):
 
         Parameters
         ----------
-        TODO
+        hdu : str
+            Name or index of the HDU with the map data.
+        hdu_bands : str
+            Name or index of the HDU with the BANDS table.
+
+        Returns
+        -------
+        hdu_list : `~astropy.io.fits.HDUList`
         """
         if sparse:
             hdu = 'SKYMAP' if hdu is None else hdu.upper()

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -65,9 +65,8 @@ class WcsMap(Map):
             be chosen to be center of the map.
         dtype : str, optional
             Data type, default is float32
-        conv : str, optional
-            FITS format convention ('fgst-ccube', 'fgst-template',
-            'gadf').  Default is 'gadf'.
+        conv : {'fgst-ccube','fgst-template','gadf'}, optional
+            FITS format convention.  Default is 'gadf'.
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
 
@@ -132,10 +131,17 @@ class WcsMap(Map):
             Name or index of the HDU with the map data.
         hdu_bands : str
             Name or index of the HDU with the BANDS table.
+        sparse : bool
+            Sparsify the map by only writing pixels with non-zero
+            amplitude.
+        conv : {'fgst-ccube','fgst-template','gadf',None}, optional
+            FITS format convention.  If None this will be set to the
+            default convention of the map.
 
         Returns
         -------
         hdu_list : `~astropy.io.fits.HDUList`
+
         """
         if sparse:
             hdu = 'SKYMAP' if hdu is None else hdu.upper()

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -100,7 +100,6 @@ class WcsNDMap(WcsMap):
         shape = tuple([ax.nbin for ax in geom.axes])
         shape_wcs = tuple([np.max(geom.npix[0]),
                            np.max(geom.npix[1])])
-        shape_data = shape_wcs + shape
         meta = cls._get_meta_from_header(hdu.header)
         map_out = cls(geom, meta=meta)
 
@@ -325,7 +324,7 @@ class WcsNDMap(WcsMap):
         return map_out
 
     def _reproject_hpx(self, geom, mode='interp', order=1):
-        from reproject import reproject_from_healpix, reproject_to_healpix
+        from reproject import reproject_to_healpix
         from .hpxnd import HpxNDMap
 
         map_out = HpxNDMap(geom)


### PR DESCRIPTION
This PR implements some bug fixes and other miscellaneous improvements related to I/O in `gammapy.maps`:
* Fix bug in handling of `conv`option when writing HPX maps.
* Eliminated some duplication in HPX/WCS code for building BANDS HDU.  Most of the logic is now collected into a single `MapGeom.make_bands_hdu` method.
* Added some tests exercising the `conv`, `hdu`, and `hdu_bands` options.
* Introduced a mechanism for setting the BANDS table extension name automatically from the skymap table name.  When `hdu_bands=None` the BANDS table will be set `{SKYMAP_EXTNAME}_BANDS`.  

