### PR TITLE
Bug Fixes and Improvements to HPX to WCS Methods

### DIFF
--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1549,9 +1549,10 @@ class HpxGeom(MapGeom):
             HEALPIX geometry will be copied to the WCS geometry.
         proj : str
             Projection type of WCS geometry.
-        oversample : int
-            Factor by which the WCS pixel size will be chosen to
-            oversample the HEALPIX map.
+        oversample : float
+           Oversampling factor for WCS geometry.  This will be the
+           approximate ratio of the width of a HPX pixel to a WCS
+           pixel.
 
         Returns
         -------
@@ -1778,6 +1779,21 @@ class HpxToWcsMapping(object):
 
     @classmethod
     def create(cls, hpx, wcs):
+        """Create an object that maps pixels from HEALPix geometry ``hpx`` to
+        WCS geometry ``wcs``.
+
+        Parameters
+        ----------
+        hpx : `~HpxGeom`
+            HEALPix geometry object.
+        wcs : `~gammapy.maps.WcsGeom`
+            WCS geometry object.
+
+        Returns
+        -------
+        hpx2wcs : `~HpxToWcsMapping`
+
+        """
         ipix, mult_val, npix = make_hpx_to_wcs_mapping(hpx, wcs)
         return cls(hpx, wcs, ipix, mult_val, npix)
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -18,6 +18,7 @@ from .geom import find_and_read_bands, make_axes
 # HPX_FITS_CONVENTIONS, HpxConv
 __all__ = [
     'HpxGeom',
+    'HpxToWcsMapping'
 ]
 
 # This is an approximation of the size of HEALPIX pixels (in degrees)

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -163,7 +163,8 @@ class HpxMap(Map):
         return fits.HDUList(hdu_list)
 
     @abc.abstractmethod
-    def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
+    def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2,
+               hpx2wcs=None):
         """Make a WCS object and convert HEALPIX data into WCS projection.
 
         Parameters
@@ -174,11 +175,22 @@ class HpxMap(Map):
             HEALPix one.
         normalize : bool
             True -> preserve integral by splitting HEALPIX values between bins
+        proj  : str
+           WCS-projection
+        oversample : float
+           Oversampling factor for WCS map.  This will be the
+           approximate ratio of the width of a HPX pixel to a WCS
+           pixel.
+        hpx2wcs : `~HpxToWcsMapping`
+            Set the HPX to WCS mapping object that will be used to
+            generate the WCS map.  If none then a new mapping will be
+            generated based on ``proj`` and ``oversample`` arguments.
 
         Returns
         -------
         map_out : `~gammapy.maps.WcsMap`
             WCS map object.
+
         """
         pass
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -163,7 +163,7 @@ class HpxMap(Map):
         return fits.HDUList(hdu_list)
 
     @abc.abstractmethod
-    def to_wcs(self, sum_bands=False, normalize=True):
+    def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2):
         """Make a WCS object and convert HEALPIX data into WCS projection.
 
         Parameters
@@ -177,10 +177,8 @@ class HpxMap(Map):
 
         Returns
         -------
-        wcs : `~astropy.wcs.WCS`
-            WCS object
-        data : `~numpy.ndarray`
-            Reprojected data
+        map_out : `~gammapy.maps.WcsMap`
+            WCS map object.
         """
         pass
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -494,7 +494,8 @@ class HpxNDMap(HpxMap):
 
         return map_out
 
-    def plot(self, ax=None, idx=None, normalize=False, proj='AIT', oversample=4, method='raster'):
+    def plot(self, ax=None, idx=None, normalize=False, proj='AIT', oversample=4, method='raster',
+             **kwargs):
         """Quickplot method.
 
         This will generate a visualization of the map by converting to
@@ -517,7 +518,8 @@ class HpxNDMap(HpxMap):
         idx : tuple
             Set the image slice to plot if this map has non-spatial
             dimensions.
-
+        **kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.imshow`.            
         Returns
         -------
         fig : `~matplotlib.figure.Figure`
@@ -533,7 +535,7 @@ class HpxNDMap(HpxMap):
             m = self.to_wcs(sum_bands=True,
                             normalize=normalize,
                             proj=proj, oversample=oversample)
-            return m.plot(ax)
+            return m.plot(ax, **kwargs)
         elif method == 'poly':
             return self._plot_poly(proj=proj, ax=ax)
         else:

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -146,17 +146,13 @@ class HpxNDMap(HpxMap):
             hpx_data = np.squeeze(hpx_data)
             wcs_shape = tuple([t.flat[0] for t in hpx2wcs.npix])
             wcs_data = np.zeros(wcs_shape).T
-            wcs = self.geom.make_wcs(proj=proj,
-                                     oversample=oversample,
-                                     drop_axes=True)
+            wcs = hpx2wcs.wcs.to_image()
         else:
             hpx_data = self.data
             wcs_shape = tuple([t.flat[0] for t in
                                hpx2wcs.npix]) + self.geom._shape
             wcs_data = np.zeros(wcs_shape).T
-            wcs = self.geom.make_wcs(proj=proj,
-                                     oversample=oversample,
-                                     drop_axes=False)
+            wcs = hpx2wcs.wcs.to_cube(self.geom.axes)
 
         # FIXME: Should reimplement instantiating map first and fill data array
         hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize)

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -122,7 +122,7 @@ class HpxNDMap(HpxMap):
         self._wcs2d = self.geom.make_wcs(proj=proj, oversample=oversample,
                                          drop_axes=True)
         self._hpx2wcs = HpxToWcsMapping.create(self.geom, self._wcs2d)
-        return self._hpx2wcs 
+        return self._hpx2wcs
 
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2,
                hpx2wcs=None):
@@ -158,7 +158,7 @@ class HpxNDMap(HpxMap):
                                      oversample=oversample,
                                      drop_axes=False)
 
-        # FIXME: Should reimplement instantiating map first and fill data array            
+        # FIXME: Should reimplement instantiating map first and fill data array
         hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize)
         return WcsNDMap(wcs, wcs_data)
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -286,3 +286,6 @@ def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
     coords = m.geom.get_coord(flat=True)
     m.fill_by_coord(coords, coords[0])
     msum = m.sum_over_axes()
+
+    if m.geom.is_regular:
+        assert_allclose(np.nansum(m.data), np.nansum(msum.data))

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -240,6 +240,9 @@ def test_wcsndmap_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes):
     m.fill_by_coord(coords, coords[0])
     msum = m.sum_over_axes()
 
+    if m.geom.is_regular:
+        assert_allclose(np.nansum(m.data), np.nansum(msum.data))
+
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -268,7 +268,7 @@ class WcsNDMap(WcsMap):
             return copy.deepcopy(self)
 
         map_out = self.__class__(self.geom.to_image())
-        if self.geom.is_regular:
+        if not self.geom.is_regular:
             vals = self.get_by_idx(self.geom.get_idx())
             map_out.fill_by_coord(self.geom.get_coord()[:2], vals)
         else:
@@ -459,6 +459,8 @@ class WcsNDMap(WcsMap):
         idx : tuple
             Set the image slice to plot if this map has non-spatial
             dimensions.
+        **kwargs : dict
+            Keyword arguments passed to `~matplotlib.pyplot.imshow`.   
 
         Returns
         -------

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -272,9 +272,8 @@ class WcsNDMap(WcsMap):
             vals = self.get_by_idx(self.geom.get_idx())
             map_out.fill_by_coord(self.geom.get_coord()[:2], vals)
         else:
-            data = np.apply_over_axes(np.sum, self.data,
-                                      axes=np.arange(self.data.ndim - 2))
-            map_out.data = np.squeeze(data)
+            axis = tuple(np.arange(self.data.ndim - 2).tolist())
+            map_out.data = np.sum(self.data, axis=axis)
 
         return map_out
 


### PR DESCRIPTION
This PR includes some miscellaneous bug fixes and cleanup that I implemented as part of the fermipy integration work.  I hope this will be the final set of changes for the upcoming gammapy release.
* Fix bug in `WcsNDMap.sum_over_axes`.  This was causing a huge inefficiency when dealing with large maps.
* Improve implementation and docstring for `HpxNDMap.to_wcs`.  This method now accepts an optional `hpx2wcs` parameter that lets one reuse an existing HPX mapping.  
* Pass through kwargs for imshow in `HpxNDMap.plot`.