### PR TITLE
Add Minuit backend to SpectrumFit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython iminuit'
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject pandoc ipython'
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -222,3 +222,7 @@ Reference/API
 .. automodapi:: gammapy.utils.modeling
     :no-inheritance-diagram:
     :include-all-objects:
+
+.. automodapi:: gammapy.utils.fitting
+    :no-inheritance-diagram:
+    :include-all-objects:

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -462,9 +462,10 @@ class SpectrumFit(object):
 
     def _fit_iminuit(self):
         """Iminuit minimization"""
-        bf_parameters = fit_minuit(parameters=self.model.parameters,
+        parameters, minuit = fit_minuit(parameters=self.model.parameters,
                                    function=self.total_stat)
-        self._make_fit_result(bf_parameters)
+        log.debug(minuit)
+        self._make_fit_result(parameters)
 
     def _make_fit_result(self, parameters):
         """Bundle fit results into `~gammapy.spectrum.SpectrumFitResult`.

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -4,6 +4,7 @@ import copy
 import numpy as np
 import astropy.units as u
 from ..utils.scripts import make_path
+from ..utils.fitting import fit_minuit
 from .. import stats
 from .utils import CountsPredictor
 from . import SpectrumObservationList, SpectrumObservation
@@ -461,7 +462,6 @@ class SpectrumFit(object):
 
     def _fit_iminuit(self):
         """Iminuit minimization"""
-        from gammapy.utils.fitting import fit_minuit
         bf_parameters = fit_minuit(parameters=self.model.parameters,
                                    function=self.total_stat)
         self._make_fit_result(bf_parameters)

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -731,10 +731,10 @@ class FluxPointEstimator(object):
             amplitude_min = amplitude
 
         def ts_diff(x):
-            fit.model.parameters['amplitude'].value = x * 1E-12
-            fit.predict_counts()
-            fit.calc_statval()
-            return (stat_best_fit + delta_ts) - fit.total_stat
+            pars = fit.model.parameters
+            pars['amplitude'].value = x * 1E-12
+            stat = fit.total_stat(pars)
+            return (stat_best_fit + delta_ts) - stat
 
         try:
             result = brentq(ts_diff, amplitude_min, amplitude_max,
@@ -767,12 +767,11 @@ class FluxPointEstimator(object):
         """
         # store best fit amplitude, set amplitude of fit model to zero
         amplitude = fit.result[0].model.parameters['amplitude'].value
-        fit.model.parameters['amplitude'].value = 0
 
         # determine TS value for amplitude zero
-        fit.predict_counts()
-        fit.calc_statval()
-        stat_null = fit.total_stat
+        pars = fit.model.parameters
+        pars['amplitude'].value = 0
+        stat_null = fit.total_stat(pars)
 
         # set amplitude of fit model to best fit amplitude
         fit.model.parameters['amplitude'].value = amplitude

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -464,6 +464,12 @@ class CompoundSpectralModel(SpectralModel):
         val = self.model1.parameters.parameters + self.model2.parameters.parameters
         return ParameterList(val)
 
+    @parameters.setter
+    def parameters(self, parameters):
+        idx = len(self.model1.parameters.parameters)
+        self.model1.parameters.parameters = parameters.parameters[:idx]
+        self.model2.parameters.parameters = parameters.parameters[idx:]
+
     def __str__(self):
         ss = self.__class__.__name__
         ss += '\n    Component 1 : {}'.format(self.model1)

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -459,6 +459,7 @@ class CompoundSpectralModel(SpectralModel):
         self.model2 = model2
         self.operator = operator
 
+    # TODO: Think about how to deal with covariance matrix
     @property
     def parameters(self):
         val = self.model1.parameters.parameters + self.model2.parameters.parameters

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -171,6 +171,7 @@ class TestFit:
 
 
 @requires_dependency('sherpa')
+@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 class TestSpectralFit:
     """Test fitter in astrophysical scenario"""

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -206,6 +206,21 @@ class TestSpectralFit:
         with pytest.raises(ValueError):
             self.fit.result[0].to_table()
 
+    def test_basic_results_iminuit(self):
+        self.fit.method = 'iminuit'
+        self.fit.fit()
+        result = self.fit.result[0]
+        assert_allclose(result.statval, 32.838716584005645, rtol=1e-4)
+        pars = result.model.parameters
+        assert_quantity_allclose(pars['index'].value, 2.2542312883476465, rtol=1e-2)
+        assert_quantity_allclose(pars['amplitude'].quantity,
+                                 2.0082864582748925e-7 * u.Unit('m-2 s-1 TeV-1'),
+                                 rtol=1e-2)
+        assert_allclose(result.npred_src[60], 0.5642179482961884)
+
+        with pytest.raises(ValueError):
+            self.fit.result[0].to_table()
+
     def test_basic_errors(self):
         self.fit.fit()
         self.fit.est_errors()

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -204,6 +204,7 @@ class TestSpectralFit:
                                  2.0082864582748925e-7 * u.Unit('m-2 s-1 TeV-1'))
         assert_allclose(result.npred_src[60], 0.563822994375907)
 
+        # TODO: at the moment to_table only works if covariance matrix is set
         with pytest.raises(ValueError):
             self.fit.result[0].to_table()
 

--- a/gammapy/utils/fitting/__init__.py
+++ b/gammapy/utils/fitting/__init__.py
@@ -1,0 +1,3 @@
+"""Fitting utility functions.
+"""
+from .iminuit import *

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -14,24 +14,37 @@ __all__ = [
 def fit_minuit(parameters, function):
     """iminuit optimization
 
+    The input `~gammapy.utils.modeling.ParameterList` is copied internally
+    before the fit and will thus not be modified. The best-fit parameter values
+    are contained in the output `~gammapy.utils.modeling.ParameterList` or the
+    `~iminuit.Minuit` object.
+
     Parameters
     ----------
     parameters : `~gammapy.utils.modeling.ParameterList`
         Parameters with starting values
     function : callable
         Likelihood function
+
+    Returns
+    -------
+    parameters : `~gammapy.utils.modeling.ParameterList`
+        Parameters with best-fit values
+    minuit : `~iminuit.Minuit`
+        Minuit object
     """
     from iminuit import Minuit
 
+    parameters = parameters.copy()
     minuit_func = MinuitFunction(function, parameters)
     minuit_kwargs = make_minuit_kwargs(parameters)
 
-    m = Minuit(minuit_func.fcn,
+    minuit = Minuit(minuit_func.fcn,
                forced_parameters=parameters.names,
                **minuit_kwargs)
 
-    m.migrad()
-    return parameters
+    minuit.migrad()
+    return parameters, minuit
 
 
 class MinuitFunction(object):

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -61,5 +61,7 @@ def make_minuit_kwargs(parameters):
     kwargs = dict()
     for par in parameters.parameters:
         kwargs[par.name] = par.value
+        if par.frozen:
+            kwargs['fix_{}'.format(par.name)] = True
 
     return kwargs

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -1,0 +1,65 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""iminuit fitting functions.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from ..modeling import ParameterList, Parameter
+
+
+__all__ = [
+    'fit_minuit',
+]
+
+
+def fit_minuit(parameters, function):
+    """iminuit optimization
+
+    Parameters
+    ----------
+    parameters : `~gammapy.utils.modelling.ParameterList`
+        Parameters with starting values
+    function : callable
+        Likelihood function
+    """
+    from iminuit import Minuit
+
+    minuit_func = MinuitFunction(function, parameters)
+    minuit_kwargs = make_minuit_kwargs(parameters)
+
+    m = Minuit(minuit_func.fcn,
+               forced_parameters=parameters.names,
+               **minuit_kwargs)
+
+    m.migrad()
+    return parameters
+
+
+class MinuitFunction(object):
+    """Wrapper for iminuit
+
+    Parameters
+    ----------
+    parameters : `~gammapy.utils.modelling.ParameterList`
+        Parameters with starting values
+    function : callable
+        Likelihood function
+    """
+
+    def __init__(self, function, parameters):
+        self.function = function
+        self.parameters = parameters
+
+    def fcn(self, *p):
+        for parval, par in zip(p, self.parameters.parameters):
+            par.value = parval
+        val = self.function(self.parameters)
+        return val
+
+
+def make_minuit_kwargs(parameters):
+    """Create kwargs for iminuit"""
+    kwargs = dict()
+    for par in parameters.parameters:
+        kwargs[par.name] = par.value
+
+    return kwargs

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -16,7 +16,7 @@ def fit_minuit(parameters, function):
 
     Parameters
     ----------
-    parameters : `~gammapy.utils.modelling.ParameterList`
+    parameters : `~gammapy.utils.modeling.ParameterList`
         Parameters with starting values
     function : callable
         Likelihood function
@@ -39,7 +39,7 @@ class MinuitFunction(object):
 
     Parameters
     ----------
-    parameters : `~gammapy.utils.modelling.ParameterList`
+    parameters : `~gammapy.utils.modeling.ParameterList`
         Parameters with starting values
     function : callable
         Likelihood function

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -2,9 +2,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
 from ...modeling import ParameterList, Parameter
+from ...testing import requires_dependency
 from .. import fit_minuit
 
 
+@requires_dependency('iminuit')  
 def test_iminuit():
     def f(parameters):
         x = parameters['x'].value
@@ -12,12 +14,12 @@ def test_iminuit():
         z = parameters['z'].value
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
-    p = ParameterList(
+    p_in = ParameterList(
         [Parameter('x', 2.1), Parameter('y', 3.1), Parameter('z', 4.1)]
     )
 
-    bf_pars = fit_minuit(function=f, parameters=p)
+    p_out = fit_minuit(function=f, parameters=p_in)
 
-    assert_allclose(bf_pars['x'].value, 2, rtol=1e-2)
-    assert_allclose(bf_pars['y'].value, 3, rtol=1e-2)
-    assert_allclose(bf_pars['z'].value, 4, rtol=1e-2)
+    assert_allclose(p_out['x'].value, 2, rtol=1e-2)
+    assert_allclose(p_out['y'].value, 3, rtol=1e-2)
+    assert_allclose(p_out['z'].value, 4, rtol=1e-2)

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -1,0 +1,23 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from ...modeling import ParameterList, Parameter
+from .. import fit_minuit
+
+
+def test_iminuit():
+    def f(parameters):
+        x = parameters['x'].value
+        y = parameters['y'].value
+        z = parameters['z'].value
+        return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
+
+    p = ParameterList(
+        [Parameter('x', 2.1), Parameter('y', 3.1), Parameter('z', 4.1)]
+    )
+
+    bf_pars = fit_minuit(function=f, parameters=p)
+
+    assert_allclose(bf_pars['x'].value, 2, rtol=1e-2)
+    assert_allclose(bf_pars['y'].value, 3, rtol=1e-2)
+    assert_allclose(bf_pars['z'].value, 4, rtol=1e-2)

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -14,12 +14,20 @@ def test_iminuit():
         z = parameters['z'].value
         return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
-    p_in = ParameterList(
+    pars_in = ParameterList(
         [Parameter('x', 2.1), Parameter('y', 3.1), Parameter('z', 4.1)]
     )
 
-    p_out = fit_minuit(function=f, parameters=p_in)
+    pars_out, minuit = fit_minuit(function=f, parameters=pars_in)
 
-    assert_allclose(p_out['x'].value, 2, rtol=1e-2)
-    assert_allclose(p_out['y'].value, 3, rtol=1e-2)
-    assert_allclose(p_out['z'].value, 4, rtol=1e-2)
+    assert_allclose(pars_in['x'].value, 2.1, rtol=1e-2)
+    assert_allclose(pars_in['y'].value, 3.1, rtol=1e-2)
+    assert_allclose(pars_in['z'].value, 4.1, rtol=1e-2)
+
+    assert_allclose(pars_out['x'].value, 2, rtol=1e-2)
+    assert_allclose(pars_out['y'].value, 3, rtol=1e-2)
+    assert_allclose(pars_out['z'].value, 4, rtol=1e-2)
+
+    assert_allclose(minuit.values['x'], 2, rtol=1e-2)
+    assert_allclose(minuit.values['y'], 3, rtol=1e-2)
+    assert_allclose(minuit.values['z'], 4, rtol=1e-2)

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -27,6 +27,7 @@ For XML model format definitions, see here:
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
 import numpy as np
+import copy
 from ..extern import six
 from astropy import units as u
 from astropy.table import Table, Column, vstack
@@ -376,6 +377,10 @@ class ParameterList(object):
             if parameter.name == parname:
                 return np.sqrt(self.covariance[i, i])
         raise ValueError('Could not find parameter {}'.format(parname))
+
+    def copy(self):
+        """A deep copy"""
+        return copy.deepcopy(self)
 
 
 class SourceLibrary(object):


### PR DESCRIPTION
This PR adds a Minuit backend to the ``SpectrumFit`` class. The implementation is quite crude, but for a simple test case it gives the same results as the sherpa backend within 1%

If there's someone who knows how to use ``iminuit`` properly, especially in combination with the ``exec`` function, help is very welcome. I can ask more precise question if someone is willing to give feedback.