### PR TITLE
Enable rate models in SpectrumSimulation

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -207,11 +207,12 @@ class SpectrumFit(object):
         """
         predictor = CountsPredictor(model=model)
         if forward_folded:
-            predictor.livetime = obs.livetime
             predictor.aeff = obs.aeff
             predictor.edisp = obs.edisp
         else:
             predictor.e_true = obs.e_reco
+
+        predictor.livetime = obs.livetime
 
         predictor.run()
         counts = predictor.npred.data.data
@@ -320,6 +321,10 @@ class SpectrumFit(object):
             raise ValueError('IRFs required for forward folded fit')
         if self.stat == 'wstat' and self.obs_list[0].off_vector is None:
             raise ValueError('Off vector required for WStat fit')
+        try:
+            test_obs.livetime
+        except KeyError:
+            raise ValueError('No observation livetime given')
 
     def likelihood_1d(self, model, parname, parvals):
         """Compute likelihood profile.

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -45,7 +45,7 @@ class SpectrumFit(object):
     def __init__(self, obs_list, model, stat='wstat', forward_folded=True,
                  fit_range=None, background_model=None,
                  method='sherpa', err_method='sherpa'):
-        self.obs_list = self._convert_obs_list(obs_list)
+        self.obs_list = obs_list
         self.model = model
         self.stat = stat
         self.forward_folded = forward_folded
@@ -77,15 +77,18 @@ class SpectrumFit(object):
 
         return ss
 
-    @staticmethod
-    def _convert_obs_list(obs_list):
-        """Helper function to accept different inputs for obs_list."""
+    @property
+    def obs_list(self):
+        return self._obs_list
+
+    @obs_list.setter
+    def obs_list(self, obs_list):
         if isinstance(obs_list, SpectrumObservation):
-            obs_list = SpectrumObservationList([obs_list])
+            obs_list  = SpectrumObservationList([obs_list])
         if not isinstance(obs_list, SpectrumObservationList):
             raise ValueError('Invalid input {} for parameter obs_list'.format(
                 type(obs_list)))
-        return obs_list
+        self._obs_list = obs_list
 
     @property
     def bins_in_fit_range(self):

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -27,22 +27,25 @@ class SpectrumSimulation(object):
         Livetime
     source_model : `~gammapy.spectrum.models.SpectralModel`
         Source model
-    aeff : `~gammapy.irf.EffectiveAreaTable`
+    aeff : `~gammapy.irf.EffectiveAreaTable`, optional
         Effective Area
     edisp : `~gammapy.irf.EnergyDispersion`, optional
         Energy Dispersion
+    e_true : `~astropy.units.Quantity`, optional
+        Desired energy axis of the prediced counts vector if no IRFs are given
     background_model : `~gammapy.spectrum.models.SpectralModel`, optional
         Background model
     alpha : float, optional
         Exposure ratio between source and background
     """
 
-    def __init__(self, livetime, source_model, aeff, edisp=None,
-                 background_model=None, alpha=None):
+    def __init__(self, livetime, source_model, aeff=None, edisp=None,
+                 e_true=None, background_model=None, alpha=None):
         self.livetime = livetime
         self.source_model = source_model
         self.aeff = aeff
         self.edisp = edisp
+        self.e_true = e_true
         self.background_model = background_model
         self.alpha = alpha
 
@@ -60,6 +63,7 @@ class SpectrumSimulation(object):
         predictor = CountsPredictor(livetime=self.livetime,
                                     aeff=self.aeff,
                                     edisp=self.edisp,
+                                    e_true=self.e_true,
                                     model=self.source_model)
         predictor.run()
         return predictor.npred
@@ -73,6 +77,7 @@ class SpectrumSimulation(object):
         predictor = CountsPredictor(livetime=self.livetime,
                                     aeff=self.aeff,
                                     edisp=self.edisp,
+                                    e_true=self.e_true,
                                     model=self.background_model)
         predictor.run()
         return predictor.npred
@@ -83,7 +88,10 @@ class SpectrumSimulation(object):
         if self.edisp is not None:
             temp = self.edisp.e_reco.bins
         else:
-            temp = self.aeff.energy.bins
+            if self.aeff is not None:
+                temp = self.aeff.energy.bins
+            else:
+                temp = self.e_true
         return EnergyBounds(temp)
 
     def run(self, seed):

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -40,6 +40,8 @@ class TestFit:
                                      energy_hi=binning[1:],
                                      data=source_counts,
                                      backscal=1)
+        # Currently it's necessary to specify a lifetime
+        self.src.livetime = 1 * u.s
 
         npred_bkg = self.bkg_model.integral(binning[:-1], binning[1:])
 

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -3,6 +3,7 @@ import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency
+from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EffectiveAreaTable
 from .. import SpectrumExtraction, SpectrumSimulation
 from ..models import PowerLaw
@@ -71,3 +72,14 @@ class TestSpectrumSimulation:
         assert_allclose(np.sum(sim.npred_source.data.data.value),
                         167.467572145, rtol=0.01)
 
+    def test_without_aeff(self):
+        e_true = EnergyBounds.equal_log_spacing(1, 10, 5, u.TeV)
+        rate_model = self.source_model.copy()
+        rate_model.parameters['amplitude'].unit = u.Unit('TeV-1 s-1')
+        rate_model.parameters['amplitude'].value = 1
+        sim = SpectrumSimulation(source_model=rate_model,
+                                 livetime=4*u.h,
+                                 e_true=e_true 
+                                )
+        sim.simulate_obs(seed=23, obs_id=23)
+        assert sim.obs.on_vector.total_counts == 10509 * u.ct

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -174,10 +174,12 @@ class CountsPredictor(object):
     def apply_aeff(self):
         if self.aeff is not None:
             cts = self.true_flux * self.aeff.data.data
-            if cts.unit.is_equivalent('s-1'):
-                cts *= self.livetime
         else:
             cts = self.true_flux
+
+        # Multiply with livetime if not already contained in aeff or model
+        if cts.unit.is_equivalent('s-1'):
+            cts *= self.livetime
 
         self.true_counts = cts.to('')
 


### PR DESCRIPTION
As discussed in #1330 the ``SpectrumSimulation`` class should be able to handle rate models. This PR adds this options. It is still not possible however, to have different kinds of models for source and background. This should be very easy to implement, however. I'll leave it for another PR. I don't think a review is needed but if someone want to give his 2 cents, you're welcome.