### PR TITLE
minor change in off_data_background_maker

### DIFF
--- a/gammapy/background/off_data_background_maker.py
+++ b/gammapy/background/off_data_background_maker.py
@@ -344,10 +344,9 @@ class OffDataBackgroundMaker(object):
         """
         index_table_bkg = self.make_bkg_index_table(data_store, modeltype, out_dir_background_model,
                                                     filename_obs_group_table, smooth)
-        if modeltype=="3D":
-            index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_3d")[0].tolist()
-        else
-            index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_2d")[0].tolist()
+
+        hdu_class = 'bkg_3d' if modeltype == "3D" else 'bkg_2d'
+        index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == hdu_class)[0]
         data_store.hdu_table.remove_rows(index_bkg)
         index_table_new = vstack([data_store.hdu_table, index_table_bkg])
         return index_table_new

--- a/gammapy/background/off_data_background_maker.py
+++ b/gammapy/background/off_data_background_maker.py
@@ -346,5 +346,7 @@ class OffDataBackgroundMaker(object):
                                                     filename_obs_group_table, smooth)
         index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_3d")[0].tolist()
         data_store.hdu_table.remove_rows(index_bkg)
+        index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_2d")[0].tolist()
+        data_store.hdu_table.remove_rows(index_bkg)
         index_table_new = vstack([data_store.hdu_table, index_table_bkg])
         return index_table_new

--- a/gammapy/background/off_data_background_maker.py
+++ b/gammapy/background/off_data_background_maker.py
@@ -344,9 +344,10 @@ class OffDataBackgroundMaker(object):
         """
         index_table_bkg = self.make_bkg_index_table(data_store, modeltype, out_dir_background_model,
                                                     filename_obs_group_table, smooth)
-        index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_3d")[0].tolist()
-        data_store.hdu_table.remove_rows(index_bkg)
-        index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_2d")[0].tolist()
+        if modeltype=="3D":
+            index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_3d")[0].tolist()
+        else
+            index_bkg = np.where(data_store.hdu_table["HDU_CLASS"] == "bkg_2d")[0].tolist()
         data_store.hdu_table.remove_rows(index_bkg)
         index_table_new = vstack([data_store.hdu_table, index_table_bkg])
         return index_table_new


### PR DESCRIPTION
A very minor change in writing the hdu table in the off_data_background_maker.

This is useful if the user wants to re-make the background models (eg: with different zenith angle bins/muon efficiency bins/etc) following the tutorial https://github.com/gammapy/gammapy-extra/blob/master/notebooks/background_model.ipynb

Currently, a link to the background model is appended at the end of the hdu table. If the table already contains links to some pre-computed background model, it picks up the old ones instead of the new ones.

Now, the old links are deleted and new ones added.