### PR TITLE
Fix bug in map .fits.gz write (change map data transpose)

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -88,9 +88,8 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom0 = WcsGeom.create(npix=npix, binsz=binsz,
                            proj=proj, coordsys=coordsys, axes=axes)
 
-    shape = (np.max(geom0.npix[0]), np.max(geom0.npix[1]))
     hdu_bands = geom0.make_bands_hdu(hdu='BANDS')
-    hdu_prim = fits.PrimaryHDU(np.zeros(shape).T)
+    hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.make_header())
 
     filename = str(tmpdir / 'wcsgeom.fits')

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from ..utils import fill_poisson
@@ -108,6 +108,41 @@ def test_wcsndmap_read_write_fgst(tmpdir):
 
     m2 = Map.read(filename)
     assert m2.geom.conv == 'fgst-template'
+
+
+def test_wcs_nd_map_data_transpose_issue(tmpdir):
+    # Regression test for https://github.com/gammapy/gammapy/issues/1346
+
+    # Our test case: a little map with WCS shape (3, 2), i.e. numpy array shape (2, 3)
+    data = np.array([[0, 1, 2], [3, 0, 5]])
+    geom = WcsGeom.create(npix=(3, 2))
+
+    # Data should be unmodified after init
+    m = WcsNDMap(data=data, geom=geom)
+    assert_equal(m.data, data)
+
+    # Data should be unmodified if initialised like this
+    m = WcsNDMap(geom=geom)
+    # and then filled via an in-place Numpy array operation
+    m.data += data
+    assert_equal(m.data, data)
+    # This is done e.g. in `m.interp_image` or probably also other operations,
+    # sometimes they operate on `m.data` in-place.
+
+    # Data should be unmodified after write / read to normal image format
+    filename = str(tmpdir / 'normal.fits.gz')
+    m.write(filename)
+    assert_equal(Map.read(filename).data, data)
+
+    # Data should be unmodified after write / read to sparse image format
+    filename = str(tmpdir / 'sparse.fits.gz')
+    m.write(filename)
+    assert_equal(Map.read(filename).data, data)
+
+    # TODO: I wasn't able to trigger the issue without I/O yet. Remove?
+    # hdu_list = m.to_hdulist(sparse=True)
+    # m2 = Map.from_hdu_list(hdu_list)
+    # assert_equal(m2.data, data)
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -114,7 +114,7 @@ def test_wcs_nd_map_data_transpose_issue(tmpdir):
     # Regression test for https://github.com/gammapy/gammapy/issues/1346
 
     # Our test case: a little map with WCS shape (3, 2), i.e. numpy array shape (2, 3)
-    data = np.array([[0, 1, 2], [3, 0, 5]])
+    data = np.array([[0, 1, 2], [np.nan, np.inf, -np.inf]])
     geom = WcsGeom.create(npix=(3, 2))
 
     # Data should be unmodified after init
@@ -138,11 +138,6 @@ def test_wcs_nd_map_data_transpose_issue(tmpdir):
     filename = str(tmpdir / 'sparse.fits.gz')
     m.write(filename)
     assert_equal(Map.read(filename).data, data)
-
-    # TODO: I wasn't able to trigger the issue without I/O yet. Remove?
-    # hdu_list = m.to_hdulist(sparse=True)
-    # m2 = Map.from_hdu_list(hdu_list)
-    # assert_equal(m2.data, data)
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -149,8 +149,7 @@ class WcsMap(Map):
             hdu = 'PRIMARY' if hdu is None else hdu.upper()
 
         if sparse and hdu == 'PRIMARY':
-            raise ValueError(
-                'Sparse maps cannot be written to the PRIMARY HDU.')
+            raise ValueError('Sparse maps cannot be written to the PRIMARY HDU.')
 
         if self.geom.axes:
             hdu_bands_out = self.geom.make_bands_hdu(hdu=hdu_bands,
@@ -194,62 +193,75 @@ class WcsMap(Map):
         hdu : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
             HDU containing the map data.
         """
-        data = self.data
-        shape = data.shape
         header = self.geom.make_header()
 
         if hdu_bands is not None:
             header['BANDSHDU'] = hdu_bands
 
-        cols = []
         if sparse:
-
-            if len(shape) == 2:
-                data_flat = np.ravel(data)
-                data_flat[~np.isfinite(data_flat)] = 0
-                nonzero = np.where(data_flat > 0)
-                array = nonzero[0]
-                cols.append(fits.Column('PIX', 'J', array=array))
-                array = data_flat[nonzero].astype(float)
-                cols.append(fits.Column('VALUE', 'E', array=array))
-            elif self.geom.npix[0].size == 1:
-                data_flat = np.ravel(data).reshape(
-                    shape[:-2] + (shape[-1] * shape[-2],))
-                data_flat[~np.isfinite(data_flat)] = 0
-                nonzero = np.where(data_flat > 0)
-                channel = np.ravel_multi_index(nonzero[:-1], shape[:-2])
-                cols.append(fits.Column('PIX', 'J', array=nonzero[-1]))
-                cols.append(fits.Column('CHANNEL', 'I', array=channel))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=data_flat[nonzero].astype(float)))
-            else:
-
-                data_flat = []
-                channel = []
-                pix = []
-                for i, _ in np.ndenumerate(self.geom.npix[0]):
-                    data_i = np.ravel(data[i[::-1]])
-                    data_i[~np.isfinite(data_i)] = 0
-                    pix_i = np.where(data_i > 0)
-                    data_i = data_i[pix_i]
-                    data_flat += [data_i]
-                    pix += pix_i
-                    channel += [np.ones(data_i.size, dtype=int) *
-                                np.ravel_multi_index(i[::-1], shape[:-2])]
-
-                data_flat = np.concatenate(data_flat)
-                pix = np.concatenate(pix)
-                channel = np.concatenate(channel)
-                cols.append(fits.Column('PIX', 'J', array=pix))
-                cols.append(fits.Column('CHANNEL', 'I', array=channel))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=data_flat.astype(float)))
-
-            hdu_out = fits.BinTableHDU.from_columns(cols, header=header,
-                                                    name=hdu)
+            hdu_out = self._make_hdu_sparse(self.data, self.geom.npix, hdu, header)
         elif hdu == 'PRIMARY':
-            hdu_out = fits.PrimaryHDU(data, header=header)
+            hdu_out = fits.PrimaryHDU(self.data, header=header)
         else:
-            hdu_out = fits.ImageHDU(data, header=header, name=hdu)
+            hdu_out = fits.ImageHDU(self.data, header=header, name=hdu)
 
         return hdu_out
+
+    @staticmethod
+    def _make_hdu_sparse(data, npix, hdu, header):
+        shape = data.shape
+
+        # We make a copy, because below we modify `data` to handle non-finite entries
+        # TODO: The code below could probably be simplified to use expressions
+        # that create new arrays instead of in-place modifications
+        # But first: do we want / need the non-finite entry handling at all and always cast to 64-bit float?
+        data = data.copy()
+
+        if len(shape) == 2:
+            data_flat = np.ravel(data)
+            data_flat[~np.isfinite(data_flat)] = 0
+            nonzero = np.where(data_flat > 0)
+            value = data_flat[nonzero].astype(float)
+
+            cols = [
+                fits.Column('PIX', 'J', array=nonzero[0]),
+                fits.Column('VALUE', 'E', array=value),
+            ]
+        elif npix[0].size == 1:
+            shape_flat = shape[:-2] + (shape[-1] * shape[-2],)
+            data_flat = np.ravel(data).reshape(shape_flat)
+            data_flat[~np.isfinite(data_flat)] = 0
+            nonzero = np.where(data_flat > 0)
+            channel = np.ravel_multi_index(nonzero[:-1], shape[:-2])
+            value = data_flat[nonzero].astype(float)
+
+            cols = [
+                fits.Column('PIX', 'J', array=nonzero[-1]),
+                fits.Column('CHANNEL', 'I', array=channel),
+                fits.Column('VALUE', 'E', array=value),
+            ]
+        else:
+            data_flat = []
+            channel = []
+            pix = []
+            for i, _ in np.ndenumerate(npix[0]):
+                data_i = np.ravel(data[i[::-1]])
+                data_i[~np.isfinite(data_i)] = 0
+                pix_i = np.where(data_i > 0)
+                data_i = data_i[pix_i]
+                data_flat += [data_i]
+                pix += pix_i
+                channel += [np.ones(data_i.size, dtype=int) *
+                            np.ravel_multi_index(i[::-1], shape[:-2])]
+
+            pix = np.concatenate(pix)
+            channel = np.concatenate(channel)
+            value = np.concatenate(data_flat).astype(float)
+
+            cols = [
+                fits.Column('PIX', 'J', array=pix),
+                fits.Column('CHANNEL', 'I', array=channel),
+                fits.Column('VALUE', 'E', array=value),
+            ]
+
+        return fits.BinTableHDU.from_columns(cols, header=header, name=hdu)

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -208,9 +208,10 @@ class WcsMap(Map):
                 data_flat = np.ravel(data)
                 data_flat[~np.isfinite(data_flat)] = 0
                 nonzero = np.where(data_flat > 0)
-                cols.append(fits.Column('PIX', 'J', array=nonzero[0]))
-                cols.append(fits.Column('VALUE', 'E',
-                                        array=data_flat[nonzero].astype(float)))
+                array = nonzero[0]
+                cols.append(fits.Column('PIX', 'J', array=array))
+                array = data_flat[nonzero].astype(float)
+                cols.append(fits.Column('VALUE', 'E', array=array))
             elif self.geom.npix[0].size == 1:
                 data_flat = np.ravel(data).reshape(
                     shape[:-2] + (shape[-1] * shape[-2],))
@@ -235,6 +236,7 @@ class WcsMap(Map):
                     pix += pix_i
                     channel += [np.ones(data_i.size, dtype=int) *
                                 np.ravel_multi_index(i[::-1], shape[:-2])]
+
                 data_flat = np.concatenate(data_flat)
                 pix = np.concatenate(pix)
                 channel = np.concatenate(channel)
@@ -249,4 +251,5 @@ class WcsMap(Map):
             hdu_out = fits.PrimaryHDU(data, header=header)
         else:
             hdu_out = fits.ImageHDU(data, header=header, name=hdu)
+
         return hdu_out

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -45,14 +45,15 @@ class WcsNDMap(WcsMap):
         shape_np = shape[::-1]
 
         if data is None:
-            data = self._init_data(geom, shape_np, dtype)
+            data = self._make_default_data(geom, shape_np, dtype)
         elif data.shape != shape_np:
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape_np, data.shape))
 
         super(WcsNDMap, self).__init__(geom, data, meta)
 
-    def _init_data(self, geom, shape_np, dtype):
+    @staticmethod
+    def _make_default_data(geom, shape_np, dtype):
         # Check whether corners of each image plane are valid
         coords = []
         if not geom.is_regular:
@@ -72,7 +73,7 @@ class WcsNDMap(WcsMap):
             if geom.is_regular:
                 data = np.zeros(shape_np, dtype=dtype)
             else:
-                data = np.nan * np.ones(shape_np, dtype=dtype)
+                data = np.full(shape_np, np.nan, dtype=dtype)
                 for idx in np.ndindex(geom.shape):
                     data[idx,
                          slice(geom.npix[0][idx]),

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -151,9 +151,10 @@ class WcsNDMap(WcsMap):
     def _interp_by_pix_linear_grid(self, pix, order=1):
         # TODO: Cache interpolator
         method_lookup = {0: 'nearest', 1: 'linear'}
-        method = method_lookup.get(order, None)
-        if method is None:
-            raise ValueError('Invalid interpolation method: {}'.format(interp))
+        try:
+            method = method_lookup[order]
+        except KeyError:
+            raise ValueError('Invalid interpolation order: {}'.format(order))
 
         from scipy.interpolate import RegularGridInterpolator
         grid_pix = [np.arange(n, dtype=float) for n in self.data.shape[::-1]]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -39,21 +39,23 @@ class WcsNDMap(WcsMap):
     def __init__(self, geom, data=None, dtype='float32', meta=None):
         # TODO: Figure out how to mask pixels for integer data types
 
+        # Shape in WCS or FITS order is `shape`, in Numpy axis order is `shape_np`
         shape = tuple([np.max(geom.npix[0]), np.max(geom.npix[1])] +
                       [ax.nbin for ax in geom.axes])
+        shape_np = shape[::-1]
+
         if data is None:
-            data = self._init_data(geom, shape, dtype)
-        elif data.shape != shape[::-1]:
+            data = self._init_data(geom, shape_np, dtype)
+        elif data.shape != shape_np:
             raise ValueError('Wrong shape for input data array. Expected {} '
-                             'but got {}'.format(shape, data.shape))
+                             'but got {}'.format(shape_np, data.shape))
 
         super(WcsNDMap, self).__init__(geom, data, meta)
 
-    def _init_data(self, geom, shape, dtype):
+    def _init_data(self, geom, shape_np, dtype):
         # Check whether corners of each image plane are valid
         coords = []
         if not geom.is_regular:
-
             for idx in np.ndindex(geom.shape):
                 pix = (np.array([0.0, float(geom.npix[0][idx] - 1)]),
                        np.array([0.0, float(geom.npix[1][idx] - 1)]))
@@ -61,24 +63,22 @@ class WcsNDMap(WcsMap):
                 coords += geom.pix_to_coord(pix)
 
         else:
-
             pix = (np.array([0.0, float(geom.npix[0] - 1)]),
                    np.array([0.0, float(geom.npix[1] - 1)]))
             pix += tuple([np.array(2 * [0.0]) for i in range(geom.ndim - 2)])
             coords += geom.pix_to_coord(pix)
 
         if np.all(np.isfinite(np.vstack(coords))):
-
             if geom.is_regular:
-                data = np.zeros(shape, dtype=dtype).T
+                data = np.zeros(shape_np, dtype=dtype)
             else:
-                data = np.nan * np.ones(shape, dtype=dtype).T
+                data = np.nan * np.ones(shape_np, dtype=dtype)
                 for idx in np.ndindex(geom.shape):
                     data[idx,
                          slice(geom.npix[0][idx]),
                          slice(geom.npix[1][idx])] = 0.0
         else:
-            data = np.full(shape, np.nan, dtype=dtype).T
+            data = np.full(shape_np, np.nan, dtype=dtype)
             idx = geom.get_idx()
             m = np.all(np.stack([t != -1 for t in idx]), axis=0)
             data[m] = 0.0
@@ -123,7 +123,7 @@ class WcsNDMap(WcsMap):
 
     def get_by_idx(self, idx):
         idx = pix_tuple_to_idx(idx)
-        return self._data.T[idx]
+        return self.data.T[idx]
 
     def interp_by_coord(self, coords, interp=None):
 


### PR DESCRIPTION
I think I've found a bug in WCSMapND write.

The image orientation is incorrect in this example:
https://nbviewer.jupyter.org/gist/cdeil/2feb9e784d128d43867a707c0ca23092

At first I thought it's a bug in reproject, but maybe it's just in write and I was always looking at incorrectly images from DS9.

@woodmd - You're busy with new things, right?
If so, I'll have a look at this tomorrow and try to debug / fix it.