### PR TITLE
Improve HESS HGPS catalog source class

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -43,13 +43,13 @@ class SourceCatalogObject(object):
 
     @property
     def name(self):
-        """Source name"""
+        """Source name (str)"""
         name = self.data[self._source_name_key]
         return name.strip()
 
     @property
     def index(self):
-        """Row index of source in catalog"""
+        """Row index of source in catalog (int)"""
         return self.data[self._source_index_key]
 
     def pprint(self, file=None):
@@ -90,9 +90,7 @@ class SourceCatalogObject(object):
 
     @property
     def position(self):
-        """
-        `~astropy.coordinates.SkyCoord`
-        """
+        """Source position (`~astropy.coordinates.SkyCoord`)."""
         return skycoord_from_table(self.data)
 
 
@@ -261,9 +259,7 @@ class SourceCatalog(object):
 
     @property
     def positions(self):
-        """
-        `~astropy.coordinates.SkyCoord`
-        """
+        """Source positions (`~astropy.coordinates.SkyCoord`)."""
         return skycoord_from_table(self.table)
 
     def select_image_region(self, image):

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -1,12 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """HESS Galactic plane survey (HGPS) catalog.
-
-(Not released yet.)
-
-TODO:
-- [ ] Load HGPS maps
-- [ ] Source object should contain info on components and associations
-- [ ] Links to SNRCat
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
@@ -18,6 +11,7 @@ from astropy.coordinates import Angle
 from astropy.modeling.models import Gaussian2D
 from ..extern.pathlib import Path
 from ..utils.scripts import make_path
+from ..utils.table import table_row_to_dict
 from ..spectrum import FluxPoints
 from ..spectrum.models import PowerLaw, ExponentialCutoffPowerLaw
 from ..image.models import Delta2D, Shell2D
@@ -27,6 +21,7 @@ from .core import SourceCatalog, SourceCatalogObject
 __all__ = [
     'SourceCatalogHGPS',
     'SourceCatalogObjectHGPS',
+    'SourceCatalogObjectHGPSComponent',
 ]
 
 # Flux factor, used for printing
@@ -39,14 +34,21 @@ FLUX_TO_CRAB = 100 / 2.26e-11
 FLUX_TO_CRAB_DIFF = 100 / 3.5060459323111307e-11
 
 
-class HGPSGaussComponent(object):
+class SourceCatalogObjectHGPSComponent(object):
     """One Gaussian component from the HGPS catalog.
+
+    See also
+    --------
+    SourceCatalogHGPS, SourceCatalogObjectHGPS
     """
-    _source_name_key = 'Source_Name'
+    _source_name_key = 'Component_ID'
     _source_index_key = 'catalog_row_index'
 
     def __init__(self, data):
         self.data = OrderedDict(data)
+
+    def __repr__(self):
+        return 'SourceCatalogObjectHGPSComponent({!r})'.format(self.name)
 
     def __str__(self):
         """Pretty-print source data"""
@@ -64,20 +66,18 @@ class HGPSGaussComponent(object):
 
     @property
     def name(self):
-        """Source name"""
+        """Source name (str)"""
         name = self.data[self._source_name_key]
         return name.strip()
 
     @property
     def index(self):
-        """Row index of source in catalog"""
+        """Row index of source in table (int)"""
         return self.data[self._source_index_key]
 
     @property
     def spatial_model(self):
-        """
-        Component spatial model.
-        """
+        """Component spatial model (`~astropy.modeling.models.Gaussian2D`)."""
         d = self.data
         # At the moment spatial models are normalised by deg^2
         amplitude = d['Flux_Map'].value / (2 * np.pi * d['Size'].value ** 2)
@@ -94,7 +94,11 @@ class HGPSGaussComponent(object):
 
 
 class SourceCatalogObjectHGPS(SourceCatalogObject):
-    """One object from the HGPS catalog."""
+    """One object from the HGPS catalog.
+
+    The catalog is represented by `SourceCatalogHGPS`.
+    Examples are given there.
+    """
 
     def __str__(self):
         return self.info()
@@ -104,11 +108,11 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
         Parameters
         ----------
-        info : {'all', 'basic', 'map', 'spec', 'flux_points', 'components', 'associations'}
+        info : {'all', 'basic', 'map', 'spec', 'flux_points', 'components', 'associations', 'id'}
             Comma separated list of options
         """
         if info == 'all':
-            info = 'basic,associations,map,spec,flux_points,components'
+            info = 'basic,associations,id,map,spec,flux_points,components'
 
         ss = ''
         ops = info.split(',')
@@ -120,10 +124,12 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             ss += self._info_spec()
         if 'flux_points' in ops:
             ss += self._info_flux_points()
-        if 'components' in ops:
+        if 'components' in ops and hasattr(self, 'components'):
             ss += self._info_components()
         if 'associations' in ops:
             ss += self._info_associations()
+        if 'id' in ops and hasattr(self, 'identification_info'):
+            ss += self._info_id()
         return ss
 
     def _info_basic(self):
@@ -142,9 +148,14 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
     def _info_associations(self):
         ss = '\n*** Source associations info ***\n\n'
-        associations = ', '.join(self.associations)
-        ss += 'List of associated objects: {}\n'.format(associations)
-        return ss
+        lines = self.associations.pformat(max_width=-1, max_lines=-1)
+        ss += '\n'.join(lines)
+        return ss + '\n'
+
+    def _info_id(self):
+        ss = '\n*** Source identification info ***\n\n'
+        ss += '\n'.join('{}: {}'.format(k, v) for k, v in self.identification_info.items())
+        return ss + '\n'
 
     def _info_map(self):
         """Print info from map analysis."""
@@ -257,7 +268,6 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         ss += '{:<20s} : ({:.3f} +/- {:.3f}) x 10^-12 erg cm^-2 s^-1\n'.format(
             'Best-fit model energy flux(1 to 10 TeV)', val / FF, err / FF)
 
-        # TODO: can we just use the Gammapy model classes here instead of duplicating the code?
         ss += self._info_spec_pl()
         ss += self._info_spec_ecpl()
 
@@ -325,7 +335,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         d = self.data
         ss = '\n*** Flux points info ***\n\n'
         ss += 'Number of flux points: {}\n'.format(d['N_Flux_Points'])
-        ss += 'Flux points table: \n\n\t'
+        ss += 'Flux points table: \n\n'
 
         flux_points = self.flux_points.table.copy()
 
@@ -340,16 +350,12 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         for _ in flux_cols:
             flux_points[_].format = '.3e'
 
-        # convert table to string
         lines = flux_points.pformat(max_width=-1, max_lines=-1)
         ss += '\n'.join(lines)
         return ss + '\n'
 
     def _info_components(self):
         """Print info about the components."""
-        if not hasattr(self, 'components'):
-            return ''
-
         ss = '\n*** Gaussian component info ***\n\n'
         ss += 'Number of components: {}\n'.format(len(self.components))
         ss += '{:<20s} : {}\n\n'.format('Spatial components', self.data['Components'])
@@ -379,30 +385,13 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
     def spectral_model(self):
         """Spectral model (`~gammapy.spectrum.models.SpectralModel`).
 
-        One of the following models:
+        One of the following models (given by ``Spectral_Model`` in the catalog):
 
-        - ``Spectral_Model="PL"`` : `~gammapy.spectrum.models.PowerLaw`
-        - ``Spectral_Model="ECPL"`` : `~gammapy.spectrum.models.ExponentialCutoffPowerLaw`
+        - ``PL`` : `~gammapy.spectrum.models.PowerLaw`
+        - ``ECPL`` : `~gammapy.spectrum.models.ExponentialCutoffPowerLaw`
         """
         data = self.data
         spec_type = data['Spectral_Model'].strip()
-        return self._spectral_model(spec_type)
-
-    def _spectral_model(self, spec_type):
-        """
-        Create spectral model from source parameters.
-
-        Parameters
-        ----------
-        spec_type : str
-            Spectral model type either 'PL' or 'ECPL'.
-
-        Returns
-        -------
-        model : `~gammapy.spectrum.models.SpectralModel`
-            Spectral model instance.
-        """
-        data = self.data
 
         pars, errs = {}, {}
 
@@ -429,8 +418,14 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         return model
 
     def spatial_model(self, emin=1 * u.TeV, emax=1E5 * u.TeV):
-        """
-        Source spatial model.
+        """Spatial model (`~gammapy.image.models.SpatialModel`).
+
+        One of the following models (given by ``Spatial_Model`` in the catalog):
+
+        - ``Point-Like`` or has a size upper limit : `~gammapy.image.models.Delta2D`
+        - ``Shell``: `~gammapy.image.models.Shell2D`
+        - ``Gaussian``: `gammapy.image.models.Gaussian2D`
+        - ``2-Gaussian`` or ``3-Gaussian``: composite model (using ``+`` with Gaussians)
         """
         d = self.data
         flux = self.spectral_model.integral(emin, emax)
@@ -467,7 +462,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             except AttributeError:
                 # there is one external source (HESS J1801-233) where there is no
                 # component info available, so we create it here locally
-                models = [HGPSGaussComponent(d).spatial_model]
+                models = [SourceCatalogObjectHGPSComponent(d).spatial_model]
 
             for model in models:
                 # weight total flux according to relative amplitude
@@ -497,7 +492,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
     @property
     def is_pointlike(self):
-        """Source is pointlike"""
+        """Source is pointlike? (bool)"""
         d = self.data
         has_size_ul = np.isfinite(d['Size_UL'])
         pointlike = d['Spatial_Model'] == 'Point-Like'
@@ -526,11 +521,41 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 class SourceCatalogHGPS(SourceCatalog):
     """HESS Galactic plane survey (HGPS) source catalog.
 
-    Note: this catalog isn't publicly available yet.
-    H.E.S.S. members have access and can use this.
+    Reference: https://www.mpi-hd.mpg.de/hfm/HESS/hgps/
+
+    One source is represented by `SourceCatalogObjectHGPS`.
+
+    Examples
+    --------
+    Load the catalog data:
+
+    >>> from gammapy.catalog import SourceCatalogHGPS
+    >>> filename = 'hgps_catalog_v1.fits.gz'
+    >>> cat = SourceCatalogHGPS(filename)
+
+    Access a source by name:
+
+    >>> source = cat['HESS J1843-033']
+    >>> print(source)
+
+    Access source spectral data and plot it:
+
+    >>> source.spectral_model.plot(source.energy_range)
+    >>> source.spectral_model.plot_error(source.energy_range)
+    >>> source.flux_points.plot()
+
+    Gaussian component information can be accessed as well,
+    either via the source, or via the catalog:
+
+    >>> source.components
+    >>> cat.gaussian_component(83)
     """
     name = 'hgps'
+    """Source catalog name (str)."""
+
     description = 'H.E.S.S. Galactic plane survey (HGPS) source catalog'
+    """Source catalog description (str)."""
+
     source_object_class = SourceCatalogObjectHGPS
 
     def __init__(self, filename=None, hdu='HGPS_SOURCES'):
@@ -546,51 +571,70 @@ class SourceCatalogHGPS(SourceCatalog):
             source_name_alias=source_name_alias,
         )
 
-        self.components = Table.read(filename, hdu='HGPS_GAUSS_COMPONENTS')
-        self.associations = Table.read(filename, hdu='HGPS_ASSOCIATIONS')
-        self.identifications = Table.read(filename, hdu='HGPS_IDENTIFICATIONS')
-        self._large_scale_component = Table.read(filename, hdu='HGPS_LARGE_SCALE_COMPONENT')
+        self._table_components = Table.read(filename, hdu='HGPS_GAUSS_COMPONENTS')
+        self._table_associations = Table.read(filename, hdu='HGPS_ASSOCIATIONS')
+        self._table_identifications = Table.read(filename, hdu='HGPS_IDENTIFICATIONS')
+        self._table_large_scale_component = Table.read(filename, hdu='HGPS_LARGE_SCALE_COMPONENT')
+
+    @property
+    def table_components(self):
+        """Gaussian component table (`~astropy.table.Table`)"""
+        return self._table_components
+
+    @property
+    def table_associations(self):
+        """Source association table (`~astropy.table.Table`)"""
+        return self._table_associations
+
+    @property
+    def table_identifications(self):
+        """Source identification table (`~astropy.table.Table`)"""
+        return self._table_identifications
+
+    @property
+    def table_large_scale_component(self):
+        """Large scale component table (`~astropy.table.Table`)"""
+        return self._table_large_scale_component
 
     @property
     def large_scale_component(self):
-        """Large sclae component model (`~gammapy.background.models.GaussianBand2D`).
+        """Large scale component model (`~gammapy.background.models.GaussianBand2D`).
         """
-        table = self._large_scale_component
+        table = self.table_large_scale_component
         return GaussianBand2D(table, spline_kwargs=dict(k=3, s=0, ext=0))
 
     def _make_source_object(self, index):
-        """Make one source object.
-
-        Parameters
-        ----------
-        index : int
-            Row index
-
-        Returns
-        -------
-        source : `SourceCatalogObject`
-            Source object
-        """
+        """Make `SourceCatalogObject` for given row index"""
         source = super(SourceCatalogHGPS, self)._make_source_object(index)
-        if hasattr(self, 'components'):
-            if source.data['Components'] != '':
-                self._attach_component_info(source)
-        if hasattr(self, 'associations'):
-            self._attach_association_info(source)
-        # TODO: implement or remove:
-        # if source.data['Source_Class'] != 'Unid':
-        #    self._attach_identification_info(source)
+
+        if source.data['Components'] != '':
+            self._attach_component_info(source)
+
+        self._attach_association_info(source)
+
+        if source.data['Source_Class'] != 'Unid':
+            self._attach_identification_info(source)
+
         return source
 
     def _attach_component_info(self, source):
         source.components = []
-        lookup = SourceCatalog(self.components, source_name_key='Component_ID')
+        lookup = SourceCatalog(self.table_components, source_name_key='Component_ID')
         for name in source.data['Components'].split(', '):
-            component = HGPSGaussComponent(data=lookup[name].data)
+            component = SourceCatalogObjectHGPSComponent(data=lookup[name].data)
             source.components.append(component)
 
     def _attach_association_info(self, source):
-        source.associations = []
-        _ = source.data['Source_Name'] == self.associations['Source_Name']
+        t = self.table_associations
+        mask = source.data['Source_Name'] == t['Source_Name']
+        source.associations = t[mask]
 
-        source.associations = list(self.associations['Association_Name'][_])
+    def _attach_identification_info(self, source):
+        t = self._table_identifications
+        idx = np.nonzero(source.name == t['Source_Name'])[0][0]
+        source.identification_info = table_row_to_dict(t[idx])
+
+    def gaussian_component(self, row_idx):
+        """Gaussian component (`SourceCatalogObjectHGPSComponent`)."""
+        data = table_row_to_dict(self.table_components[row_idx])
+        return SourceCatalogObjectHGPSComponent(data=data)

--- a/gammapy/image/models/shapes.py
+++ b/gammapy/image/models/shapes.py
@@ -6,21 +6,36 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import OrderedDict
 import numpy as np
 from astropy.modeling import Parameter, ModelDefinitionError, Fittable2DModel
-from astropy.modeling.models import Gaussian2D
+from astropy.modeling.models import Gaussian2D as AstropyGaussian2D
 from astropy.utils import lazyproperty
 from astropy.coordinates import SkyCoord
 from ..core import SkyImage
 
 __all__ = [
     'morph_types',
+    'SpatialModel',
     'Delta2D',
-    # TODO: we need our own model, so that we can add in stuff like XML I/O
-    # Copy over the Astropy version and use that throughout Gammapy
-    # 'Gaussian2D',
+    'Gaussian2D',
     'Shell2D',
     'Sphere2D',
     'Template2D',
 ]
+
+
+class SpatialModel(object):
+    """Spatial model base class.
+
+    TODO: implement properly. At the moment this is just a placeholder
+    """
+
+
+class Gaussian2D(AstropyGaussian2D):
+    """Two-dimensional Gaussian model.
+
+    TODO: implement properly. At the moment this is just an empty subclass of the Astropy model.
+    """
+    # TODO: we need our own model, so that we can add in stuff like XML I/O
+    # Copy over the Astropy version and use that throughout Gammapy
 
 
 class Delta2D(Fittable2DModel):


### PR DESCRIPTION
I just now did some small updates to the HESS HGPS catalog code in a69d05b902edf16d520ae0116a4d59c73d54323c and e6e3a39c614bdbbddffd054f1374d32967bd4199 .

This is a reminder issue for further improvements that should be done at some point:

- [x] In `SourceCatalogHGPS._make_source_object` the `hasattr` lines for `components` and `associations` can be removed, those should always be available. I think the `hasattr` in `SourceCatalogObjectHGPS._info_components` can also be removed, if we simply put empty lists if there are no components.
- [x] There's also a TODO concerning `_attach_identification_info` that should be implemented or removed.
- [x] Source object should contain info on components and associations
- [x] There should be a unit test for HGPSGaussComponent (name and index properties are currently not covered, str is executed, but no assert on content)
- [x] The 2-Gauss case in spatial model is not covered
- [x] The spatial model tests only assert on amplitude, not other properties
- [x] give access to powerlaw spectrum for all sources
