### PR TITLE
Add _init_meta to PHACountsSpectrum

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -607,7 +607,10 @@ class DataStoreObservation(object):
         Computed as ``t_live = t_observation * (1 - f_dead)``
         where ``f_dead`` is the dead-time fraction.
         """
-        return Quantity(self.obs_info['LIVETIME'], 'second')
+        if not isinstance(self.obs_info, Quantity):
+            log.warn("No unit given for livetime, assume 'second'")
+            self.obs_info['LIVETIME'] = Quantity(self.obs_info['LIVETIME'], 'second')
+        return self.obs_info['LIVETIME']
 
     @lazyproperty
     def observation_dead_time_fraction(self):

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -582,7 +582,6 @@ class PHACountsSpectrumList(list):
         meta['hduclas4'] = 'TYPE:II'
         meta['ancrfile'] = 'arf.fits'
         meta['respfile'] = 'rmf.fits'
-        meta.pop('OBS_ID')
 
         data = [spec_num, channel, counts, quality, backscal]
         names = ['SPEC_NUM', 'CHANNEL', 'COUNTS', 'QUALITY', 'BACKSCAL']
@@ -619,9 +618,9 @@ class PHACountsSpectrumList(list):
             kwargs['data'] = row['COUNTS']
             kwargs['backscal'] = row['BACKSCAL']
             kwargs['quality'] = row['QUALITY']
-            spec = PHACountsSpectrum(meta=dict(hdulist[1].header),
-                                     **kwargs)
-            spec.obs_id = row['SPEC_NUM']
+            kwargs['livetime'] = hdulist[1].header['EXPOSURE'] * u.s
+            kwargs['obs_id'] = row['SPEC_NUM']
+            spec = PHACountsSpectrum( **kwargs)
             speclist.append(spec)
 
         return speclist

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from copy import deepcopy
 from collections import OrderedDict
 import numpy as np
+import logging
 from astropy.table import Table
 from astropy.io import fits
 import astropy.units as u
@@ -22,6 +23,8 @@ __all__ = [
     'PHACountsSpectrum',
     'PHACountsSpectrumList',
 ]
+
+log = logging.getLogger('__name__')
 
 
 class CountsSpectrum(object):
@@ -282,12 +285,19 @@ class PHACountsSpectrum(CountsSpectrum):
         Area scaling factor
     is_bkg : bool, optional
         Background or soure spectrum, default: False
+    obs_id : int
+        Observation identifier, optional
+    livetime : `~astropy.units.Quantity`, optional
+        Observation livetime
+    offset : `~astropy.units.Quantity`, optional
+        Field of view offset
     meta : dict, optional
-        Meta information, TODO: add link where possible meta info is listed
+        Meta information
     """
 
     def __init__(self, energy_lo, energy_hi, data=None, quality=None,
-                 backscal=None, areascal=None, is_bkg=False, meta=None):
+                 backscal=None, areascal=None, is_bkg=False, obs_id=None,
+                 livetime=None, offset=None, meta=None):
         super(PHACountsSpectrum, self).__init__(energy_lo, energy_hi, data)
         if quality is None:
             quality = np.zeros(self.energy.nbins, dtype='i2')
@@ -299,10 +309,11 @@ class PHACountsSpectrum(CountsSpectrum):
             areascal = np.ones(self.energy.nbins)
         self.areascal = areascal
         self.is_bkg = is_bkg
-        self.meta = meta or OrderedDict()
-        self.meta.setdefault('CREATOR', 'Gammapy {}'.format(version.version))
-        self.meta.setdefault('OBS_ID', 0)
-
+        self.obs_id = obs_id
+        self.livetime = livetime
+        self.offset = offset
+        self.meta = meta or dict()
+        
     @property
     def quality(self):
         """Bins in safe energy range (1 = bad, 0 = good)"""
@@ -331,26 +342,6 @@ class PHACountsSpectrum(CountsSpectrum):
     def bkgfile(self):
         """Background PHA files associated with the observations"""
         return self.phafile.replace('pha', 'bkg')
-
-    @property
-    def obs_id(self):
-        return self.meta['OBS_ID']
-
-    @obs_id.setter
-    def obs_id(self, val):
-        self.meta['OBS_ID'] = val
-
-    @property
-    def livetime(self):
-        return self.meta['EXPOSURE'] * u.s
-
-    @livetime.setter
-    def livetime(self, val):
-        self.meta['EXPOSURE'] = val.to('s').value
-
-    @property
-    def offset(self):
-        return self.meta['OFFSET'] * u.deg
 
     @property
     def bins_in_safe_range(self):
@@ -449,6 +440,8 @@ class PHACountsSpectrum(CountsSpectrum):
         meta['hduclas4'] = 'TYPE:1'
         meta['lo_thres'] = self.lo_threshold.to("TeV").value
         meta['hi_thres'] = self.hi_threshold.to("TeV").value
+        meta['exposure'] = self.livetime.to('s').value
+        meta['obs_id'] = self.obs_id
 
         if not self.is_bkg:
             if self.rmffile is not None:
@@ -483,6 +476,7 @@ class PHACountsSpectrum(CountsSpectrum):
             areascal = counts_table['AREASCAL'].data
         if 'BACKSCAL' in counts_table.colnames:
             backscal = counts_table['BACKSCAL'].data
+
         kwargs = dict(
             data=counts_table['COUNTS'],
             backscal=backscal,
@@ -490,7 +484,8 @@ class PHACountsSpectrum(CountsSpectrum):
             energy_hi=emax,
             quality=quality,
             areascal=areascal,
-            meta=counts_table.meta
+            livetime = counts_table.meta['EXPOSURE'] * u.s,
+            obs_id = counts_table.meta['OBS_ID']
         )
         if hdulist[1].header['HDUCLAS2'] == 'BKG':
             kwargs['is_bkg'] = True

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -157,20 +157,17 @@ class SpectrumExtraction(object):
             Background estimate
         """
         log.info('Update observation meta info')
-        # Copy over existing meta information
-        meta = OrderedDict(obs.obs_info)
+
         offset = obs.pointing_radec.separation(bkg.on_region.center)
         log.info('Offset : {}\n'.format(offset))
-        meta['OFFSET'] = offset.deg
-
-        # LIVETIME is called EXPOSURE in the OGIP standard
-        meta['EXPOSURE'] = meta.pop('LIVETIME')
 
         self._on_vector = PHACountsSpectrum(
             energy_lo=self.e_reco[:-1],
             energy_hi=self.e_reco[1:],
             backscal=bkg.a_on,
-            meta=meta, )
+            offset=offset,
+            livetime = obs.observation_live_time_duration,
+            obs_id=obs.obs_info['OBS_ID'])
 
         self._off_vector = self._on_vector.copy()
         self._off_vector.is_bkg = True

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -863,8 +863,8 @@ class SpectrumObservationStacker(object):
         self.stacked_off_vector.livetime = total_livetime
         self.stacked_on_vector.backscal = self.stacked_bkscal_on
         self.stacked_off_vector.backscal = self.stacked_bkscal_off
-        self.stacked_on_vector.meta['OBS_ID'] = self.obs_list.obs_id
-        self.stacked_off_vector.meta['OBS_ID'] = self.obs_list.obs_id
+        self.stacked_on_vector.obs_id = self.obs_list.obs_id
+        self.stacked_off_vector.obs_id = self.obs_list.obs_id
 
     def stack_aeff(self):
         """Stack effective areas (weighted by livetime).

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -184,7 +184,7 @@ class TestSpectrumEnergyGroupMaker:
             energy_lo=pha_ebounds[:-1],
             energy_hi=pha_ebounds[1:],
             data=np.zeros(len(pha_ebounds) - 1),
-            meta=dict(EXPOSURE=99)
+            livetime=99 * u.s
         )
         return SpectrumObservation(on_vector=on_vector)
 


### PR DESCRIPTION
The meta info in ``SpectrumExtraction`` was taken from the ``obs_list`` instead of the header of the ``EVENTS`` extension

OUTDATED, see below