### PR TITLE
Fix add_pwn_parameters in astro simulate.py

### DIFF
--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -69,10 +69,7 @@ class PWN(object):
             t = Quantity(t, 'yr')
             r_pwn = self._radius_free_expansion(t).to('cm').value
             r_shock = self.snr.radius_reverse_shock(t).to('cm').value
-            # Calling float here is an attempt to fix
-            # https://travis-ci.org/gammapy/gammapy/jobs/358305453#L3824
-            # by forcing a scalar return value in this function
-            return float(r_pwn - r_shock)
+            return r_pwn - r_shock
 
         # 4e3 years is a typical value that works for fsolve
         return Quantity(fsolve(time_coll, 4e3), 'yr')
@@ -131,6 +128,7 @@ class PWN(object):
             t = self.age
         else:
             raise ValueError('Need time variable or age attribute.')
+
         return np.sqrt(2 * const.mu0 * self.eta_B * self.pulsar.energy_integrated(t) /
                        (4. / 3 * np.pi * self.radius(t) ** 3))
 


### PR DESCRIPTION
There was a fail in Gammapy master CI in add_pwn_parameters in astro simulate.py :
https://travis-ci.org/gammapy/gammapy/jobs/358305444#L3768

I'm not sure why it appeared now. Guess: this was always was a bug, but now `scipy` got more strict and raised an error.

I tried to fix it via 92faa796995f1b9c4bc789f973c79a8a592cb47a , but that change was no good.
See https://ci.appveyor.com/project/cdeil/gammapy/build/1.0.3202/job/gplqdto8b6i6k68o

This PR should fix it (at least results look OK for me locally, but I never saw the original issue from CI linked to above). Let's see ...