### PR TITLE
Apply FOV mask to all maps in ring background estimator

### DIFF
--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -332,14 +332,16 @@ class RingBackgroundEstimator(object):
         result['exposure_off'] = exposure_on_excluded.convolve(ring.array, mode='constant',
                                                                use_fft=p['use_fft_convolution'])
 
-        with np.errstate(divide='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore'):
             # set pixels, where ring is too small to NaN
             not_has_off_exposure = ~(result['exposure_off'].data > 0)
             result['exposure_off'].data[not_has_off_exposure] = np.nan
 
-            result['alpha'] = SkyImage(data=exposure_on.data / result['exposure_off'].data, wcs=wcs)
-
             not_has_exposure = ~(exposure_on.data > 0)
+            result['off'].data[not_has_exposure] = 0
+            result['exposure_off'].data[not_has_exposure] = 0
+
+            result['alpha'] = SkyImage(data=exposure_on.data / result['exposure_off'].data, wcs=wcs)
             result['alpha'].data[not_has_exposure] = 0
 
         result['background'] = SkyImage(data=result['alpha'].data * result['off'].data, wcs=wcs)

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -46,6 +46,10 @@ class TestRingBackgroundEstimator:
         assert_allclose(result['exposure_off'].data[in_fov].mean(), 305.1268970794541)
         assert_allclose(result['off'].data[in_fov].mean(), 610.2537941589082)
 
+        assert_allclose(result['off'].data[~in_fov], 0.)
+        assert_allclose(result['exposure_off'].data[~in_fov], 0.)
+        assert_allclose(result['alpha'].data[~in_fov], 0.)
+
 
 @requires_dependency('scipy')
 class TestAdaptiveRingBackgroundEstimator:

--- a/gammapy/image/basic.py
+++ b/gammapy/image/basic.py
@@ -13,7 +13,6 @@ from .core import SkyImage
 from .lists import SkyImageList
 from ..irf.background import Background3D
 
-
 __all__ = [
     'BasicImageEstimator',
     'IACTBasicImageEstimator',
@@ -200,7 +199,7 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         exposure.data = np.nan_to_num(exposure.data.value)
         return exposure
 
-    def psf(self, observations, containment_fraction = 0.99, rad_max = None):
+    def psf(self, observations, containment_fraction=0.99, rad_max=None):
         """Mean point spread function kernel image.
 
         Parameters
@@ -220,7 +219,7 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         """
         p = self.parameters
 
-        refskyim  = self.reference
+        refskyim = self.reference
         refskypos = refskyim.center
         mean_psf = observations.make_mean_psf(refskypos)
 
@@ -280,7 +279,7 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         acceptance.name = 'exposure_on'
 
         offsets = observation.pointing_radec.separation(acceptance.coordinates())
-        
+
         # This is a somewhat dirty approach to deal with the different background IRFs
         try:
             if isinstance(observation.bkg, Background3D):
@@ -292,10 +291,10 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         # If no background is found, assume flat acceptance.
         # This will provide very bad results for FoV background without norm.
         except IndexError:
-            integrated_bkg = np.ones_like(counts.data)/u.s/u.sr
-            
+            integrated_bkg = np.ones_like(counts.data) / u.s / u.sr
+
         # Reshape the array to fit the SkyImage
-        acceptance.data = np.reshape(integrated_bkg,offsets.shape)
+        acceptance.data = np.reshape(integrated_bkg, offsets.shape)
         acceptance.data *= acceptance.solid_angle() * observation.observation_live_time_duration
         acceptance.data = acceptance.data.to('').value
         return acceptance
@@ -330,7 +329,6 @@ class IACTBasicImageEstimator(BasicImageEstimator):
         input_images['exclusion'] = self._cutout_observation(self.exclusion_mask, observation)
 
         return self.background_estimator.run(input_images)
-
 
     def run(self, observations, which='all'):
         """
@@ -699,4 +697,3 @@ def reproject_exposure(exposure, ref_cube):
     exposure_cube.data = exposure_cube.data * u.Unit('cm2 s')
 
     return exposure_cube
-

--- a/gammapy/image/tests/test_basic.py
+++ b/gammapy/image/tests/test_basic.py
@@ -14,6 +14,7 @@ from ...data import DataStore
 from ...datasets import FermiLATDataset
 from ...utils.testing import requires_dependency, requires_data
 
+
 @requires_data('fermi-lat')
 @requires_dependency('healpy')
 @requires_dependency('scipy')
@@ -57,48 +58,44 @@ class TestIACTBasicImageEstimator:
 
     def setup(self):
         from regions import CircleSkyRegion
-        kwargs = {}
 
-        # Define energy range
-        kwargs['emin'] = 1 * u.TeV
-        kwargs['emax'] = 10 * u.TeV
+        reference = SkyImage.empty(
+            nxpix=21, nypix=21, binsz=0.5,
+            xref=83.633083, yref=22.0145,
+            coordsys='CEL', proj='CAR',
+        )
 
-        # Define reference image
-        wcs_spec = {'nxpix': 21,
-                    'nypix': 21,
-                    'xref': 83.633083,
-                    'yref': 22.0145,
-                    'coordsys': 'CEL',
-                    'proj': 'CAR',
-                    'binsz': 0.5}
-        kwargs['reference'] = SkyImage.empty(**wcs_spec)
-
-        # Define background estimator
-        r_in = 0.3 * u.deg
-        width = 0.2 * u.deg
-        kwargs['background_estimator'] = RingBackgroundEstimator(r_in=r_in, width=width)
-
-        # Define exclusion mask
         center = SkyCoord(83.633083, 22.0145, frame='icrs', unit='deg')
         circle = CircleSkyRegion(center, radius=Angle(0.2, 'deg'))
-        kwargs['exclusion_mask'] = kwargs['reference'].region_mask(circle)
-        kwargs['exclusion_mask'].data = ~kwargs['exclusion_mask'].data
+        exclusion_mask = reference.region_mask(circle)
+        exclusion_mask.data = ~exclusion_mask.data
 
-        self.estimator = IACTBasicImageEstimator(**kwargs)
+        background_estimator = RingBackgroundEstimator(r_in=0.3 * u.deg, width=0.2 * u.deg)
+
+        self.estimator = IACTBasicImageEstimator(
+            emin=1 * u.TeV,
+            emax=10 * u.TeV,
+            reference=reference,
+            exclusion_mask=exclusion_mask,
+            background_estimator=background_estimator,
+        )
 
         # setup data store and get list of observations
         data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
         self.observations = data_store.obs_list([23523, 23526, 23559, 23592])
 
     def test_run(self):
-        images = OrderedDict()
-        images['counts'] = dict(sum=2222.0)
-        images['background'] = dict(sum=1885.083333333333)
-        images['exposure'] = dict(sum=83036669325.30281)
-        images['excess'] = dict(sum=336.91666666666674)
-        images['flux'] = dict(sum=5.250525628586507e-07)
-        images['psf'] = dict(sum=1.)
-        results = self.estimator.run(self.observations)
+        images = self.estimator.run(self.observations)
 
-        for name in results.names:
-            assert_allclose(results[name].data.sum(), images[name]['sum'], rtol=1e-3)
+        assert_allclose(images['counts'].data.sum(), 2222)
+        assert_allclose(images['background'].data.sum(), 1885.083333333333, rtol=1e-3)
+        assert_allclose(images['exposure'].data.sum(), 83036669325.30281, rtol=1e-3)
+        assert_allclose(images['excess'].data.sum(), 336.91666666666674, rtol=1e-3)
+        assert_allclose(images['flux'].data.sum(), 5.250525628586507e-07, rtol=1e-3)
+        assert_allclose(images['psf'].data.sum(), 1, rtol=1e-3)
+
+        # TODO: there should be asserts as well on lower-level maps, like the `n_off` map
+        # Unfortunately it's not really possible, because the following line
+        # background = self._background(counts, exposure, observation)['background']
+        # is in `IACTBasicImageEstimator.run`, i.e. the lower-level maps are never stored
+        # or exposed to the caller.


### PR DESCRIPTION
With this PR, the OFF counts and exposure as computed by the `RingBackgroundEstimator` are set to zero where the ON exposure is zero. This is in agreement with the `AdaptiveRingBackgroundEstimator`, where this is done as well.

I've also modified the test such that this is checked.