### PR TITLE
Add missing __future__ imports

### DIFF
--- a/gammapy/__main__.py
+++ b/gammapy/__main__.py
@@ -7,6 +7,7 @@ This is what's executed when you run:
 
 See https://docs.python.org/3/library/__main__.html
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 from .scripts.main import cli
 

--- a/gammapy/background/tests/test_off_data_background_maker.py
+++ b/gammapy/background/tests/test_off_data_background_maker.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.table import Table
 import numpy as np
 from ...utils.testing import requires_dependency, requires_data

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """HAWC catalogs (https://www.hawc-observatory.org)."""
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.table import Table
 import astropy.units as u

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u

--- a/gammapy/cube/tests/test_basic_cube.py
+++ b/gammapy/cube/tests/test_basic_cube.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
 from astropy.coordinates import SkyCoord

--- a/gammapy/image/radial_profile.py
+++ b/gammapy/image/radial_profile.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.table import Table
 from .core import SkyImage

--- a/gammapy/scripts/cta_utils.py
+++ b/gammapy/scripts/cta_utils.py
@@ -1,4 +1,5 @@
-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
 from ..spectrum import SpectrumObservation

--- a/gammapy/scripts/tests/test_cta_sensitivity.py
+++ b/gammapy/scripts/tests/test_cta_sensitivity.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from numpy.testing import assert_allclose, assert_almost_equal
+import astropy.units as u
 from gammapy.utils.testing import requires_data, requires_dependency
 from gammapy.stats import significance_on_off
-import astropy.units as u
 from ..cta_irf import CTAPerf
 from ..cta_sensitivity import SensitivityEstimator
 

--- a/gammapy/tests/setup_package.py
+++ b/gammapy/tests/setup_package.py
@@ -1,3 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+
 def get_package_data():
     files = ['coveragerc']
     return {'gammapy.tests': files}

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import numpy as np
 import astropy.units as u

--- a/gammapy/time/period.py
+++ b/gammapy/time/period.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import numpy as np
 from astropy.stats import LombScargle

--- a/gammapy/time/plot_periodogram.py
+++ b/gammapy/time/plot_periodogram.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
 __all__ = [

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.table import Table
+from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from numpy.testing import assert_allclose
+from astropy.table import Table
 from ...utils.scripts import make_path
 from ...utils.testing import requires_data
 from ..models import PhaseCurve

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/gammapy/time/tests/test_plot_periodogram.py
+++ b/gammapy/time/tests/test_plot_periodogram.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from ..period import lomb_scargle
 from ...utils.testing import requires_dependency

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -15,6 +15,7 @@ Here's some good resources with working examples:
 - https://github.com/sphinx-doc/sphinx/blob/master/sphinx/directives/other.py
 - https://github.com/bokeh/bokeh/tree/master/bokeh/sphinxext
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 import re
 from shutil import copytree, rmtree
@@ -30,7 +31,6 @@ import nbformat
 from nbformat.v4 import new_markdown_cell
 from nbconvert.exporters import PythonExporter
 
-from .scripts import read_yaml
 from ..extern.pathlib import Path
 
 try:


### PR DESCRIPTION
This PR adds the `__future__` import line a few files in Gammapy that were missing it.

I used this command to find those files
```
$ ack --type=python -L '__future__' gammapy | egrep -v __init__ | egrep -v extern | egrep -v setup_package.py
gammapy/conftest.py
gammapy/_astropy_init.py
gammapy/cython_version.py
```
I'll leave those files alone.

This was triggered by the following issue:
https://travis-ci.org/gammapy/gammapy/jobs/362003602#L3686
where
```
gammapy/time/tests/test_lightcurve.py::test_lightcurve_interval_maker 
```
stalled in Python 2 builds; presumably because division on Python 2 is int division by default, and then the while loop in `lightcurve_interval_maker` was an endless loop (I didn't try to track this down or improve the code there to be safe against this issue in this PR).

I didn't add it to the `setup_package.py` files, because that results in this error on Python 2:
https://ci.appveyor.com/project/cdeil/gammapy/build/1.0.3225/job/k7lg3fbb9j03t0g6#L214