### PR TITLE
Add map geom pixel solid angle computation

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1298,14 +1298,8 @@ class MapGeom(object):
 
     @abc.abstractmethod
     def solid_angle(self):
-        """
-        Returns
-        -------
-        omega : `~astropy.units.Quantity`
-                Solid angle (in `sr`).
-        """
+        """Solid angle (`~astropy.units.Quantity` in ``sr``)."""
         pass
-
 
     def _fill_header_from_axes(self, header):
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1296,6 +1296,17 @@ class MapGeom(object):
         """
         pass
 
+    @abc.abstractmethod
+    def solid_angle(self):
+        """
+        Returns
+        -------
+        omega : `~astropy.units.Quantity`
+                Solid angle (in `sr`).
+        """
+        pass
+
+
     def _fill_header_from_axes(self, header):
 
         for i, ax in enumerate(self.axes):

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -9,6 +9,7 @@ from ..extern import six
 from ..extern.six.moves import range
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
+from astropy.units import Quantity
 from .wcs import WcsGeom
 from .geom import MapGeom, MapCoord, pix_tuple_to_idx
 from .geom import coordsys_to_frame, skycoord_to_lonlat
@@ -1711,6 +1712,17 @@ class HpxGeom(MapGeom):
             lat = skydir.b.deg
 
         return self.pix_to_coord((lat, lon))
+
+    def solid_angle(self):
+        """
+        Returns
+        -------
+        omega : `~astropy.units.Quantity`
+                Solid angle (in `sr`). Here we return a simple float since all pixels have the same solid angle.
+        """
+        import healpy as hp
+        return Quantity(hp.nside2pixarea(self.nside),'sr')
+
 
 
 class HpxToWcsMapping(object):

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1714,15 +1714,13 @@ class HpxGeom(MapGeom):
         return self.pix_to_coord((lat, lon))
 
     def solid_angle(self):
-        """
-        Returns
-        -------
-        omega : `~astropy.units.Quantity`
-                Solid angle (in `sr`). Here we return an array with same dimensionality as self.nside since all pixels have the same solid angle.
+        """Solid angle array (`~astropy.units.Quantity` in ``sr``).
+
+        The array has the same dimensionality as ``map.nside``
+        since all pixels have the same solid angle.
         """
         import healpy as hp
-        return Quantity(hp.nside2pixarea(self.nside),'sr')
-
+        return Quantity(hp.nside2pixarea(self.nside), 'sr')
 
 
 class HpxToWcsMapping(object):
@@ -1874,8 +1872,8 @@ class HpxToWcsMapping(object):
             wcs_data[wcs_slice] = hpx_data[hpx_slice]
 
         if fill_nan:
-            valid = np.swapaxes(self._valid.reshape(shape),-1,-2)
-            valid = valid*np.ones_like(wcs_data, dtype=bool)
+            valid = np.swapaxes(self._valid.reshape(shape), -1, -2)
+            valid = valid * np.ones_like(wcs_data, dtype=bool)
             wcs_data[~valid] = np.nan
         return wcs_data
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1718,7 +1718,7 @@ class HpxGeom(MapGeom):
         Returns
         -------
         omega : `~astropy.units.Quantity`
-                Solid angle (in `sr`). Here we return a simple float since all pixels have the same solid angle.
+                Solid angle (in `sr`). Here we return an array with same dimensionality as self.nside since all pixels have the same solid angle.
         """
         import healpy as hp
         return Quantity(hp.nside2pixarea(self.nside),'sr')

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -69,7 +69,7 @@ def test_ravel_hpx_index():
 
 
 def make_test_nside(nside, nside0, nside1):
-    npix = 12 * nside**2
+    npix = 12 * nside ** 2
     nside_test = np.concatenate((nside0 * np.ones(npix // 2, dtype=int),
                                  nside1 * np.ones(npix // 2, dtype=int)))
     return nside_test
@@ -79,10 +79,9 @@ def make_test_nside(nside, nside0, nside1):
                          [(4, 2, True), (8, 2, True), (8, make_test_nside(8, 4, 2), True),
                           (4, 2, False), (8, 2, False), (8, make_test_nside(8, 4, 2), False), ])
 def test_get_superpixels(nside_subpix, nside_superpix, nest):
-
     import healpy as hp
 
-    npix = 12 * nside_subpix**2
+    npix = 12 * nside_subpix ** 2
     subpix = np.arange(npix)
     ang_subpix = hp.pix2ang(nside_subpix, subpix, nest=nest)
     superpix = get_superpixels(subpix, nside_subpix, nside_superpix, nest=nest)
@@ -107,7 +106,7 @@ def test_get_superpixels(nside_subpix, nside_superpix, nest):
 def test_get_subpixels(nside_superpix, nside_subpix, nest):
     import healpy as hp
 
-    npix = 12 * nside_superpix**2
+    npix = 12 * nside_superpix ** 2
     superpix = np.arange(npix)
     subpix = get_subpixels(superpix, nside_superpix, nside_subpix, nest=nest)
     ang1 = hp.pix2ang(nside_subpix, subpix, nest=nest)
@@ -532,3 +531,14 @@ def test_hpxgeom_downsample(nside, nested, coordsys, region, axes):
     assert_allclose(geom.nside, 2 * geom_down.nside)
     coords = geom.get_coord(flat=True)
     assert np.all(geom_down.contains(coords))
+
+
+def test_hpxgeom_solid_angle():
+    geom = HpxGeom.create(nside=8, coordsys='GAL',
+                          axes=[MapAxis.from_edges([0, 2, 3])])
+
+    solid_angle = geom.solid_angle()
+    print(float(solid_angle.value))
+
+    assert solid_angle.shape == (1,)
+    assert_allclose(solid_angle.value, 0.016362461737446838)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
+import astropy.units as u
 from ..wcs import WcsGeom
 from ..geom import MapAxis
 
@@ -121,3 +122,19 @@ def test_wcsgeom_contains(npix, binsz, coordsys, proj, skydir, axes):
     if not geom.is_allsky:
         coords = [0.0, 0.0] + [ax.center[0] for ax in geom.axes]
         assert_allclose(geom.contains(coords), np.zeros((1,), dtype=bool))
+
+def test_wcsgeom_solid_angle():
+    binsz=1.0
+    npix=100
+
+    # Test using cartesian geometry
+    geom = WcsGeom.create(skydir=(0, 0), npix=(npix, npix), binsz=binsz, coordsys='GAL',proj='CAR')
+
+    solid_array = geom.solid_angle()
+
+    # Test bin size at b=0
+    solid_lat0 = binsz*np.pi/180 * (np.sin(binsz * np.pi / 180.)) * u.sr
+    assert_allclose(solid_array[50,50],solid_lat0, rtol=1e-4)
+    # Test bin size at b=50 deg
+    solid_lat50 = binsz*np.pi / 180 * (np.sin(50*binsz * np.pi / 180.)-np.sin(49*binsz * np.pi / 180.)) * u.sr
+    assert_allclose(solid_array[99,50],solid_lat50, rtol=1e-4)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -127,14 +127,20 @@ def test_wcsgeom_solid_angle():
     binsz=1.0
     npix=100
 
+    # create dummy axes
+    axis1 = MapAxis.from_edges(np.arange(0,4))
+    axis2 = MapAxis.from_edges(np.arange(10,20))
     # Test using cartesian geometry
-    geom = WcsGeom.create(skydir=(0, 0), npix=(npix, npix), binsz=binsz, coordsys='GAL',proj='CAR')
+    geom = WcsGeom.create(skydir=(0, 0), npix=(npix, npix), binsz=binsz, coordsys='GAL',proj='CAR',axes=[axis1,axis2])
 
     solid_array = geom.solid_angle()
 
+    # Check array size
+    assert solid_array.shape == (9,3,100,100)
+
     # Test bin size at b=0
     solid_lat0 = binsz*np.pi/180 * (np.sin(binsz * np.pi / 180.)) * u.sr
-    assert_allclose(solid_array[50,50],solid_lat0, rtol=1e-4)
+    assert_allclose(solid_array[0,0,50,50],solid_lat0, rtol=1e-4)
     # Test bin size at b=50 deg
     solid_lat50 = binsz*np.pi / 180 * (np.sin(50*binsz * np.pi / 180.)-np.sin(49*binsz * np.pi / 180.)) * u.sr
-    assert_allclose(solid_array[99,50],solid_lat50, rtol=1e-4)
+    assert_allclose(solid_array[0,0,99,50],solid_lat50, rtol=1e-4)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -597,18 +597,9 @@ class WcsGeom(MapGeom):
         raise NotImplementedError
 
     def solid_angle(self):
+        """ Returns solid angle array (in `sr`) as `~astropy.units.Quantity`
         """
-        Returns
-        -------
-        omega : `~astropy.units.Quantity`
-                Solid angle array (in `sr`)
-        """
-#        It could be faster to do simply
-#        nx, ny = self.npix
-#        X, Y = np.mgrid[0:nx[0]+1:1, 0:ny[0]+1:1]+0.5
-#        lon, lat = self._wcs.all_pix2world(X, Y, 1)
-#       And the resize the map
-
+        # TODO: Improve by exposing a mode 'edge' for get_coord
         # Note that edge is applied only to spatial coordinates in the following call
         pix = self._get_pix_coords(mode='edge')
         # Note also that pix_to_coord is already called in _get_pix_coords. This should be made more efficient.

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -402,8 +402,8 @@ class WcsGeom(MapGeom):
         npix = copy.deepcopy(self.npix)
 
         if mode == 'edge':
-            npix[0][0] += 1
-            npix[1][0] += 1
+            for pix_num in npix[:2]:
+                pix_num += 1
 
         if self.axes and not self.is_regular:
 
@@ -598,6 +598,9 @@ class WcsGeom(MapGeom):
 
     def solid_angle(self):
         """ Returns solid angle array (in `sr`) as `~astropy.units.Quantity`
+
+            The array has the same dimension as the WcsGeom object.
+            To return solid angles for the spatial dimensions only use: WcsGeom.to_image().solid_angle()
         """
         # TODO: Improve by exposing a mode 'edge' for get_coord
         # Note that edge is applied only to spatial coordinates in the following call

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -429,7 +429,7 @@ class WcsGeom(MapGeom):
                     s_img = (slice(0, npix0), slice(0, npix1),) + idx_img
                 else:
                     s_img = (slice(0, npix0), slice(0, npix1),) + \
-                        (0,) * len(self.axes)
+                            (0,) * len(self.axes)
 
                 pix2[0][s_img] = pix_img[0]
                 pix2[1][s_img] = pix_img[1]
@@ -457,10 +457,10 @@ class WcsGeom(MapGeom):
             pix[i][~m] = np.nan
         return pix
 
-#        shape = np.broadcast(*coords).shape
-#        m = [np.isfinite(c) for c in coords]
-#        m = np.broadcast_to(np.prod(m),shape)
-#        return tuple([np.ravel(np.broadcast_to(t,shape)[m]) for t in pix])
+    #        shape = np.broadcast(*coords).shape
+    #        m = [np.isfinite(c) for c in coords]
+    #        m = np.broadcast_to(np.prod(m),shape)
+    #        return tuple([np.ravel(np.broadcast_to(t,shape)[m]) for t in pix])
 
     def get_coord(self, idx=None, flat=False):
         pix = self._get_pix_coords(idx=idx)
@@ -533,7 +533,7 @@ class WcsGeom(MapGeom):
                     np.putmask(idxs[i], (idx < 0) | (idx >= npix[i]), -1)
                 else:
                     np.putmask(idxs[i], (idx < 0) | (
-                        idx >= self.axes[i - 2].nbin), -1)
+                            idx >= self.axes[i - 2].nbin), -1)
 
         return idxs
 
@@ -597,31 +597,31 @@ class WcsGeom(MapGeom):
         raise NotImplementedError
 
     def solid_angle(self):
-        """ Returns solid angle array (in `sr`) as `~astropy.units.Quantity`
+        """Solid angle array (`~astropy.units.Quantity` in ``sr``).
 
-            The array has the same dimension as the WcsGeom object.
-            To return solid angles for the spatial dimensions only use: WcsGeom.to_image().solid_angle()
+        The array has the same dimension as the WcsGeom object.
+        To return solid angles for the spatial dimensions only use: WcsGeom.to_image().solid_angle()
         """
         # TODO: Improve by exposing a mode 'edge' for get_coord
         # Note that edge is applied only to spatial coordinates in the following call
+        # Note also that pix_to_coord is already called in _get_pix_coords.
+        # This should be made more efficient.
         pix = self._get_pix_coords(mode='edge')
-        # Note also that pix_to_coord is already called in _get_pix_coords. This should be made more efficient.
-        coords = self.pix_to_coord(pix)
-        lon=coords[0] * np.pi/180.
-        lat=coords[1] * np.pi/180.
+        coord = self.pix_to_coord(pix)
+        lon = coord[0] * np.pi / 180.
+        lat = coord[1] * np.pi / 180.
 
         # Compute solid angle using the approximation that it's
         # the product between angular separation of pixel corners.
         # First index is "y", second index is "x"
-        ylo_xlo = lon[...,:-1,:-1], lat[...,:-1, :-1]
-        ylo_xhi = lon[...,:-1, 1:], lat[...,:-1, 1:]
-        yhi_xlo = lon[...,1:, :-1], lat[...,1:, :-1]
+        ylo_xlo = lon[..., :-1, :-1], lat[..., :-1, :-1]
+        ylo_xhi = lon[..., :-1, 1:], lat[..., :-1, 1:]
+        yhi_xlo = lon[..., 1:, :-1], lat[..., 1:, :-1]
 
         dx = angular_separation(*(ylo_xlo + ylo_xhi))
         dy = angular_separation(*(ylo_xlo + yhi_xlo))
-        omega = u.Quantity(dx * dy, 'sr')
 
-        return omega
+        return u.Quantity(dx * dy, 'sr')
 
 
 def create_wcs(skydir, coordsys='CEL', projection='AIT',


### PR DESCRIPTION
This adds a Geom.solid_angle() method to compute the solid angles of the map pixels.
For healpix geometry this simply returns a 1 element Quantity. 
For Wcs Geom it returns a Quantity array with the same dimension as the Geom itself.