### PR TITLE
Improve Table FITS I/O in gammapy.utils.fits

### DIFF
--- a/examples/example_write_irf.py
+++ b/examples/example_write_irf.py
@@ -8,14 +8,14 @@ import astropy.units as u
 from gammapy.irf import EffectiveAreaTable2D, EnergyDispersion2D, Background3D
 from collections import OrderedDict
 from astropy.io import fits
-from gammapy.utils.fits import table_to_fits_table
 
-
-provenance = OrderedDict([('ORIGIN', 'IRAP'),
-                          ('DATE', '2017-09-27T12:02:24'),
-                          ('TELESCOP', 'CTA'),
-                          ('INSTRUME', 'PROD3B'),
-                          ('ETC', 'ETC')])
+provenance = OrderedDict([
+    ('ORIGIN', 'IRAP'),
+    ('DATE', '2017-09-27T12:02:24'),
+    ('TELESCOP', 'CTA'),
+    ('INSTRUME', 'PROD3B'),
+    ('ETC', 'ETC'),
+])
 
 # Set up some example data
 energy = np.logspace(0, 1, 11) * u.TeV
@@ -24,19 +24,18 @@ energy_hi = energy[1:]
 offset = np.linspace(0, 1, 4) * u.deg
 offset_lo = offset[:-1]
 offset_hi = offset[1:]
-migra = np.linspace(0,3,4)
+migra = np.linspace(0, 3, 4)
 migra_lo = migra[:-1]
 migra_hi = migra[1:]
-detx = np.linspace(-6,6,11) * u.deg
+detx = np.linspace(-6, 6, 11) * u.deg
 detx_lo = detx[:-1]
 detx_hi = detx[1:]
-dety = np.linspace(-6,6,11) * u.deg
+dety = np.linspace(-6, 6, 11) * u.deg
 dety_lo = dety[:-1]
 dety_hi = dety[1:]
-aeff_data = np.ones(shape=(10,3))*u.cm*u.cm
+aeff_data = np.ones(shape=(10, 3)) * u.cm * u.cm
 edisp_data = np.ones(shape=(10, 3, 3))
-bkg_data = np.ones(shape=(10,10,10)) / u.MeV / u.s / u.sr
-
+bkg_data = np.ones(shape=(10, 10, 10)) / u.MeV / u.s / u.sr
 
 # Create IRF Class objects with data
 aeff = EffectiveAreaTable2D(energy_lo=energy_lo, energy_hi=energy_hi,
@@ -64,14 +63,14 @@ table_edisp.meta.update(provenance)
 table_bkg.meta.update(provenance)
 
 # Convert to fits HDU objects
-hdu_aeff = table_to_fits_table(table_aeff, name='EFFECTIVE AREA')
-hdu_edisp = table_to_fits_table(table_edisp, name='ENERGY DISPERSION')
-hdu_bkg = table_to_fits_table(table_bkg, name='BACKGROUND')
-prim_hdu = fits.PrimaryHDU()
+hdu_aeff = fits.BinTableHDU(table_aeff, name='EFFECTIVE AREA')
+hdu_edisp = fits.BinTableHDU(table_edisp, name='ENERGY DISPERSION')
+hdu_bkg = fits.BinTableHDU(table_bkg, name='BACKGROUND')
 
 # Alternatively, HDU can be obtained directly:
 # hdu_aeff = aeff.to_fits(name='EFFECTIVE AREA')
 # ...
 
+hdu_list = fits.HDUList([fits.PrimaryHDU(), hdu_aeff, hdu_edisp, hdu_bkg])
 
-fits.HDUList([prim_hdu, hdu_aeff, hdu_edisp, hdu_bkg]).writeto('irf_test.fits')
+hdu_list.writeto('irf_test.fits')

--- a/gammapy/background/fov_cube.py
+++ b/gammapy/background/fov_cube.py
@@ -10,7 +10,6 @@ from astropy.io import fits
 from astropy.wcs import WCS
 from ..utils.scripts import make_path
 from ..utils.wcs import linear_wcs_to_arrays, linear_arrays_to_wcs
-from ..utils.fits import table_to_fits_table
 from ..utils.energy import Energy, EnergyBounds
 
 __all__ = [
@@ -428,7 +427,7 @@ class FOVCube(object):
         tbhdu : `~astropy.io.fits.BinTableHDU`
             Table containing the cube.
         """
-        return table_to_fits_table(self.to_table())
+        return fits.BinTableHDU(self.to_table())
 
     def to_fits_image(self):
         """Convert cube to image FITS format.
@@ -456,16 +455,15 @@ class FOVCube(object):
         # get energy values as a table HDU, via an astropy table
         energy_table = Table()
         energy_table['ENERGY'] = self.energy_edges
-        energy_table.meta['name'] = 'EBOUNDS'
+        energy_hdu = fits.BinTableHDU(energy_table, name='EBOUNDS')
+
         # TODO: this function should be reviewed/re-written, when
         # the following PR is completed:
         # https://github.com/gammapy/gammapy/pull/290
         # as suggested in:
         # https://github.com/gammapy/gammapy/pull/299#discussion_r35044977
 
-        enhdu = table_to_fits_table(energy_table)
-
-        hdu_list = fits.HDUList([imhdu, enhdu])
+        hdu_list = fits.HDUList([imhdu, energy_hdu])
 
         return hdu_list
 

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -11,7 +11,7 @@ from astropy.wcs import WCS
 from astropy.utils import lazyproperty
 from ..utils.scripts import make_path
 from ..utils.energy import EnergyBounds, Energy
-from ..utils.fits import SmartHDUList, fits_header_to_meta_dict, table_to_fits_table
+from ..utils.fits import SmartHDUList, fits_header_to_meta_dict
 from ..image.core import SkyImage, MapBase
 from ..spectrum import LogEnergyAxis
 from ..spectrum.utils import _trapz_loglog
@@ -756,23 +756,18 @@ class SkyCube(MapBase):
 
         if format == 'fermi-counts':
             energies = self.energies(mode='edges')
-            # for BinTableHDU's the data must be added via a Table object
             energy_table = Table()
             energy_table['E_MIN'] = energies[:-1]
             energy_table['E_MAX'] = energies[1:]
-            energy_table.meta['name'] = 'EBOUNDS'
-            energy_hdu = table_to_fits_table(energy_table)
+            energy_hdu = fits.BinTableHDU(energy_table, name='EBOUNDS')
         elif format in ['fermi-exposure', 'fermi-background']:
-            # for BinTableHDU's the data must be added via a Table object
             energy_table = Table()
             energy_table['Energy'] = self.energies()
-            energy_table.meta['name'] = 'ENERGIES'
-            energy_hdu = table_to_fits_table(energy_table)
+            energy_hdu = fits.BinTableHDU(energy_table, name='ENERGIES')
         else:
             raise ValueError('Not a valid cube fits format')
 
-        hdu_list = fits.HDUList([image_hdu, energy_hdu])
-        return hdu_list
+        return fits.HDUList([image_hdu, energy_hdu])
 
     def to_images(self):
         """Convert to `~gammapy.cube.SkyCubeImages`."""

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from regions import CircleSkyRegion
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.energy import Energy, EnergyBounds
@@ -82,6 +83,9 @@ class TestSkyCube(object):
     def test_read_write(self, tmpdir):
         filename = str(tmpdir / 'sky_cube.fits')
         self.sky_cube.write(filename, format='fermi-background')
+
+        hdu_list = fits.open(filename)
+        assert hdu_list[1].name == 'ENERGIES'
 
         sky_cube = SkyCube.read(filename, format='fermi-background')
         assert sky_cube.data.shape == (30, 21, 61)

--- a/gammapy/datasets/make.py
+++ b/gammapy/datasets/make.py
@@ -7,11 +7,11 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.time import Time, TimeDelta
 from astropy.coordinates import SkyCoord, AltAz, Angle
+from astropy.io import fits
 from astropy.table import Table
 from ..extern.pathlib import Path
 from ..utils.random import sample_sphere, sample_powerlaw, get_random_state
 from ..utils.time import time_ref_from_dict, time_relative_to_ref
-from ..utils.fits import table_to_fits_table
 
 __all__ = [
     'make_test_psf',
@@ -523,11 +523,12 @@ def make_test_dataset(outdir, overwrite=False,
 
     # loop over observations
     for obs_id in observation_table['OBS_ID']:
-        event_list, aeff_hdu = make_test_eventlist(observation_table=observation_table,
-                                                   obs_id=obs_id,
-                                                   sigma=sigma,
-                                                   spectral_index=spectral_index,
-                                                   random_state=random_state)
+        event_list = make_test_eventlist(observation_table=observation_table,
+                                         obs_id=obs_id,
+                                         sigma=sigma,
+                                         spectral_index=spectral_index,
+                                         random_state=random_state)
+        aeff_hdu = _make_test_aeff()
 
         # save event list and effective area table to disk
         outfile = data_store.filename(obs_id, filetype='events')
@@ -653,7 +654,11 @@ def make_test_eventlist(observation_table,
     event_list.meta['LIVETIME'] = livetime.to('second').value
     event_list.meta['EUNIT'] = str(energy.unit)
 
-    # effective area table
+    return event_list
+
+
+# TODO: remove?
+def _make_test_aeff():
     aeff_table = Table()
 
     # fill threshold, for now, a default 100 GeV will be set
@@ -662,8 +667,4 @@ def make_test_eventlist(observation_table,
     aeff_table.meta['LO_THRES'] = energy_threshold.value
     aeff_table.meta['name'] = 'EFFECTIVE AREA'
 
-    # convert to BinTableHDU and add necessary comment for the units
-    aeff_hdu = table_to_fits_table(aeff_table)
-    aeff_hdu.header.comments['LO_THRES'] = '[' + str(energy_threshold.unit) + ']'
-
-    return event_list, aeff_hdu
+    return fits.BinTableHDU(aeff_table)

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
+import numpy as np
 from astropy.table import Table
 from astropy.io import fits
 import astropy.units as u
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.scripts import make_path
-from ..utils.fits import fits_table_to_table, table_to_fits_table
-import numpy as np
 
 __all__ = [
     'Background3D',
@@ -107,9 +106,7 @@ class Background3D(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='BACKGROUND'):
         """Create from `~astropy.io.fits.HDUList`."""
-        fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
-        return cls.from_table(table)
+        return cls.from_table(Table.read(hdulist[hdu]))
 
     @classmethod
     def read(cls, filename, hdu='BACKGROUND'):
@@ -133,7 +130,7 @@ class Background3D(object):
 
     def to_fits(self, name='BACKGROUND'):
         """Convert to `~astropy.io.fits.BinTable`."""
-        return table_to_fits_table(self.to_table(), name)
+        return fits.BinTableHDU(self.to_table(), name=name)
 
 
 class Background2D(object):
@@ -205,9 +202,7 @@ class Background2D(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='BACKGROUND'):
         """Create from `~astropy.io.fits.HDUList`."""
-        fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
-        return cls.from_table(table)
+        return cls.from_table(Table.read(hdulist[hdu]))
 
     @classmethod
     def read(cls, filename, hdu='BACKGROUND'):
@@ -230,7 +225,7 @@ class Background2D(object):
 
     def to_fits(self, name='BACKGROUND'):
         """Convert to `~astropy.io.fits.BinTable`."""
-        return table_to_fits_table(self.to_table(), name)
+        return fits.BinTableHDU(self.to_table(), name=name)
 
     def evaluate(self, fov_offset, fov_phi=None, energy_reco=None, **kwargs):
         """

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -8,7 +8,6 @@ from astropy.table import Table
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.energy import EnergyBounds
 from ..utils.scripts import make_path
-from ..utils.fits import fits_table_to_table, table_to_fits_table
 
 __all__ = [
     'EffectiveAreaTable',
@@ -178,9 +177,7 @@ class EffectiveAreaTable(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='SPECRESP'):
         """Create from `~astropy.io.fits.HDUList`."""
-        fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
-        return cls.from_table(table)
+        return cls.from_table(Table.read(hdulist[hdu]))
 
     @classmethod
     def read(cls, filename, hdu='SPECRESP', **kwargs):
@@ -211,11 +208,12 @@ class EffectiveAreaTable(object):
         table['SPECRESP'] = self.evaluate_fill_nan()
         return table
 
-    def to_hdulist(self):
+    def to_hdulist(self, name=None):
         """Convert to `~astropy.io.fits.HDUList`."""
-        hdu = table_to_fits_table(self.to_table())
-        prim_hdu = fits.PrimaryHDU()
-        return fits.HDUList([prim_hdu, hdu])
+        return fits.HDUList([
+            fits.PrimaryHDU(),
+            fits.BinTableHDU(self.to_table(), name=name),
+        ])
 
     def write(self, filename, **kwargs):
         """Write to file."""
@@ -402,9 +400,7 @@ class EffectiveAreaTable2D(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='EFFECTIVE AREA'):
         """Create from `~astropy.io.fits.HDUList`."""
-        fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
-        return cls.from_table(table)
+        return cls.from_table(Table.read(hdulist[hdu]))
 
     @classmethod
     def read(cls, filename, hdu='EFFECTIVE AREA'):
@@ -576,4 +572,4 @@ class EffectiveAreaTable2D(object):
 
     def to_fits(self, name='EFFECTIVE AREA'):
         """Convert to `~astropy.io.fits.BinTable`."""
-        return table_to_fits_table(self.to_table(), name)
+        return fits.BinTableHDU(self.to_table(), name=name)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -9,8 +9,7 @@ from astropy.table import Table
 from ..utils.energy import EnergyBounds, Energy
 from ..utils.scripts import make_path
 from ..utils.nddata import NDDataArray, BinnedDataAxis
-from ..utils.fits import energy_axis_to_ebounds, fits_table_to_table
-from ..utils.fits import fits_table_to_table, table_to_fits_table
+from ..utils.fits import energy_axis_to_ebounds
 
 __all__ = [
     'EnergyDispersion',
@@ -217,12 +216,7 @@ class EnergyDispersion(object):
         """
         filename = make_path(filename)
         hdulist = fits.open(str(filename), **kwargs)
-        try:
-            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
-        except KeyError:
-            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
-            msg += '\n Available {}'.format([_.name for _ in hdulist])
-            raise ValueError(msg)
+        return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
     def to_hdulist(self, **kwargs):
         """Convert RMF to FITS HDU list format.
@@ -687,9 +681,7 @@ class EnergyDispersion2D(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='edisp_2d'):
         """Create from `~astropy.io.fits.HDUList`."""
-        hdu = hdulist[hdu]
-        table = fits_table_to_table(hdu)
-        return cls.from_table(table)
+        return cls.from_table(Table.read(hdulist[hdu]))
 
     @classmethod
     def read(cls, filename, hdu='edisp_2d'):
@@ -932,4 +924,4 @@ class EnergyDispersion2D(object):
 
     def to_fits(self, name='ENERGY DISPERSION'):
         """Convert to `~astropy.io.fits.BinTable`."""
-        return table_to_fits_table(self.to_table(), name)
+        return fits.BinTableHDU(self.to_table(), name=name)

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -6,7 +6,6 @@ from astropy.io import fits
 from astropy.units import Quantity
 from astropy.coordinates import Angle
 from ..utils.array import array_stats_str
-from ..utils.fits import table_to_fits_table
 from ..utils.energy import Energy
 from ..utils.scripts import make_path
 from .psf_table import TablePSF, EnergyDependentTablePSF
@@ -152,7 +151,7 @@ class PSF3D(object):
             table[name_] = [data_]
             table[name_].unit = unit_
 
-        hdu = table_to_fits_table(table)
+        hdu = fits.BinTableHDU(table)
         hdu.header['LO_THRES'] = self.energy_thresh_lo.value
         hdu.header['HI_THRES'] = self.energy_thresh_hi.value
 

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -9,7 +9,6 @@ from astropy.coordinates import Angle
 from ..extern.validator import validate_physical_type
 from ..utils.array import array_stats_str
 from ..utils.energy import Energy, EnergyBounds
-from ..utils.fits import table_to_fits_table
 from ..utils.scripts import make_path
 from ..irf import HESSMultiGaussPSF
 from . import EnergyDependentTablePSF
@@ -165,7 +164,7 @@ class EnergyDependentMultiGaussPSF(object):
             table[name_].unit = unit_
 
         # Create hdu and hdu list
-        hdu = table_to_fits_table(table)
+        hdu = fits.BinTableHDU(table)
         hdu.header['LO_THRES'] = self.energy_thresh_lo.value
         hdu.header['HI_THRES'] = self.energy_thresh_hi.value
 

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -9,7 +9,6 @@ from astropy.io import fits
 from ..utils.scripts import make_path
 from ..utils.array import array_stats_str
 from ..utils.energy import Energy, EnergyBounds
-from ..utils.fits import table_to_fits_table
 from . import EnergyDependentTablePSF
 
 __all__ = ['PSFKing']
@@ -132,7 +131,7 @@ class PSFKing(object):
             table[name_] = [data_]
             table[name_].unit = unit_
 
-        hdu = table_to_fits_table(table)
+        hdu = fits.BinTableHDU(table)
         hdu.header['LO_THRES'] = self.energy_thresh_lo.value
         hdu.header['HI_THRES'] = self.energy_thresh_hi.value
 

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -1,14 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import assert_quantity_allclose
-from astropy.coordinates import Angle
+import astropy.units as u
+from astropy.io import fits
 from ...utils.testing import requires_dependency, requires_data
 from ..background import Background3D, Background2D
-from ...utils.fits import table_to_fits_table
 
 
 @pytest.fixture(scope='session')
@@ -49,7 +47,7 @@ def test_background_3d_evaluate(bkg_3d):
 
 @requires_data('gammapy-extra')
 def test_background_3d_write(bkg_3d):
-    hdu = table_to_fits_table(bkg_3d.to_table())
+    hdu = fits.BinTableHDU(bkg_3d.to_table())
     assert_equal(hdu.data['DETX_LO'][0], bkg_3d.data.axis('detx').lo.value)
     assert hdu.header['TUNIT1'] == bkg_3d.data.axis('detx').lo.unit
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_allclose, assert_equal
 from astropy.tests.helper import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
-from ...utils.fits import table_to_fits_table
 
 
 @pytest.fixture(scope='session')
@@ -132,6 +131,6 @@ def test_EffectiveAreaTable2d_write():
     aeff = EffectiveAreaTable2D(energy_lo=energy_lo,energy_hi=energy_hi,
                                 offset_lo=offset_lo, offset_hi=offset_hi,
                                 data=data)
-    hdu = table_to_fits_table(aeff.to_table())
+    hdu = aeff.to_fits()
     assert_equal(hdu.data['ENERG_LO'][0], aeff.data.axis('energy').lo.value)
     assert hdu.header['TUNIT1'] == aeff.data.axis('energy').lo.unit

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -9,7 +9,6 @@ from ...utils.testing import requires_dependency, requires_data
 from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EnergyDispersion2D
 from ...utils.testing import mpl_savefig_check
-from ...utils.fits import table_to_fits_table
 
 
 @requires_dependency('scipy')
@@ -156,7 +155,7 @@ class TestEnergyDispersion2D:
                                    offset_lo=offset_lo, offset_hi=offset_hi,
                                    data=data)
 
-        hdu = table_to_fits_table(edisp.to_table())
+        hdu = edisp.to_fits()
         assert_equal(hdu.data['ENERG_LO'][0], edisp.data.axis('e_true').lo.value)
         assert hdu.header['TUNIT1'] == edisp.data.axis('e_true').lo.unit
 

--- a/gammapy/irf/tests/test_irf_write.py
+++ b/gammapy/irf/tests/test_irf_write.py
@@ -1,17 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-import pytest
 import numpy as np
 import astropy.units as u
-from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data
-from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
-from ...utils.fits import table_to_fits_table
-from ...irf import EnergyDispersion, EnergyDispersion2D
-from ..background import Background3D
-from ...utils.fits import table_to_fits_table
 from astropy.io import fits
-
+from numpy.testing import assert_equal
+from ..effective_area import EffectiveAreaTable2D
+from ..energy_dispersion import EnergyDispersion2D
+from ..background import Background3D
 
 
 class TestIRFWrite:
@@ -91,14 +85,18 @@ class TestIRFWrite:
 
     def test_writeread(self, tmpdir):
         filename = str(tmpdir / 'testirf.fits')
-        prim_hdu = fits.PrimaryHDU()
-        hdu_aeff = self.aeff.to_fits()
-        hdu_edisp = self.edisp.to_fits()
-        hdu_bkg = self.bkg.to_fits()
-        fits.HDUList([prim_hdu, hdu_aeff, hdu_edisp, hdu_bkg]).writeto(filename)
+        fits.HDUList([
+            fits.PrimaryHDU(),
+            self.aeff.to_fits(),
+            self.edisp.to_fits(),
+            self.bkg.to_fits(),
+        ]).writeto(filename)
+
         read_aeff = EffectiveAreaTable2D.read(filename=filename, hdu='EFFECTIVE AREA')
-        read_edisp = EnergyDispersion2D.read(filename=filename, hdu='ENERGY DISPERSION')
-        read_bkg = Background3D.read(filename=filename, hdu='BACKGROUND')
         assert_equal(read_aeff.data.data, self.aeff_data)
+
+        read_edisp = EnergyDispersion2D.read(filename=filename, hdu='ENERGY DISPERSION')
         assert_equal(read_edisp.data.data, self.edisp_data)
+
+        read_bkg = Background3D.read(filename=filename, hdu='BACKGROUND')
         assert_equal(read_bkg.data.data, self.bkg_data)

--- a/gammapy/scripts/cta_irf.py
+++ b/gammapy/scripts/cta_irf.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.io import fits
-from ..utils.fits import fits_table_to_table
+from astropy.table import Table
 from ..utils.scripts import make_path
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.energy import EnergyBounds
@@ -129,7 +129,7 @@ class BgRateTable(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='BACKGROUND'):
         fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
+        table = Table.read(fits_table)
         return cls.from_table(table)
 
     @classmethod
@@ -212,7 +212,7 @@ class Psf68Table(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='POINT SPREAD FUNCTION'):
         fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
+        table = Table.read(fits_table)
         return cls.from_table(table)
 
     @classmethod
@@ -295,7 +295,7 @@ class SensitivityTable(object):
     @classmethod
     def from_hdulist(cls, hdulist, hdu='SENSITIVITY'):
         fits_table = hdulist[hdu]
-        table = fits_table_to_table(fits_table)
+        table = Table.read(fits_table)
         return cls.from_table(table)
 
     @classmethod

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -12,22 +12,12 @@ FITS tables
 
 In Gammapy we use the nice `astropy.table.Table` class a lot to represent all
 kinds of data (e.g. event lists, spectral points, light curves, source catalogs).
-The most common format to store tables is FITS. Unfortunately, the FITS table
-format is complicated (other words that come to mind are "horrible" or "bad"),
-and on top of that the FITS serialisation support in Astropy is incomplete.
-
-Because it's such an important and common topic, in this section we first show
-examples of Table FITS I/O in Astropy, and then present the relevant helper
-functions in `gammapy.utils.fits` and `gammapy.utils.table`.
-Of course, long-term, some of these utilities should be moved from Gammapy
-to Astropy, for the cases (all?) that are not gamma-ray astronomy specific.
+The most common format to store tables is FITS. In this section we show examples
+and mention some limitations of Table FITS I/O.
 
 Also, note that if you have the choice, you might want to use a better format
 than FITS to store tables. All of these are nice and have very good support
 in Astropy: ``ECSV``, ``HDF5``, ``ASDF``.
-
-Astropy
-+++++++
 
 In Astropy, there is the `~astropy.table.Table` class with a nice data model
 and API. Let's make an example table object that has some metadata on the
@@ -120,11 +110,10 @@ OrderedDict([('VERSION', 42),
                '  __serialized_columns__: {}',
                '--END-ASTROPY-SERIALIZED-COLUMNS--'])])
 
-Side note: possible bug: calling ``table.write`` adds
-``table.meta['comments']``, i.e. modified ``table.meta``.
-I don't think this is good behaviour, write shouldn't modify the object.
-Also, it seems that calling write repeatedly appends the same info
-to ``table.meta['comments']`` multiple times.
+
+TODO: we'll have to see how to handle this, i.e. if we want that
+behaviour or not, and how to get consistent output accross Astropy versions.
+See https://github.com/astropy/astropy/issues/7364
 
 Let's make sure for the following examples we have a clean ``table.meta``
 like we did at the start:
@@ -141,14 +130,9 @@ i.e. if you don't pass extra options, this is equivalent to
 
 >>> hdu = fits.table_to_hdu(table)
 
-Somewhat surprisingly, ``Table(hdu)`` doesn't work and there is no
-``hdu_to_table`` function; instead you have to call ``Table.read``
-if you want to convert in the other direction:
-
->>> table2 = Table.read(hdu)
-
 However, in this case, the column metadata that is serialised is
-doesn't include the column ``description``:
+doesn't include the column ``description``.
+TODO: how to get consistent behaviour and FITS headers?
 
 >>> hdu.header
 XTENSION= 'BINTABLE'           / binary table extension
@@ -168,6 +152,11 @@ TUNIT2  = 'm       '
 TTYPE3  = 'c       '
 TFORM3  = '2A      '
 
+Somewhat surprisingly, ``Table(hdu)`` doesn't work and there is no
+``hdu_to_table`` function; instead you have to call ``Table.read``
+if you want to convert in the other direction:
+
+>>> table2 = Table.read(hdu)
 >>> table2.info()
 <Table length=2>
 name dtype unit
@@ -182,40 +171,25 @@ to one FITS file. There is support in the ``Table`` API to read any HDU
 from a FITS file with multiple HDUs via the ``hdu`` option to ``Table.read``;
 you can pass an integer HDU index or an HDU extension name string
 (see :ref:`astropy:table_io_fits`).
+
 For writing (or if you prefer also for reading) multiple tables, you should
 use the in-memory conversion to HDU objects and the `~astropy.io.fits.HDUList`
 like this::
 
     hdu_list = fits.HDUList([
         fits.PrimaryHDU(),
-        fits.BinTableHDU(table),
-        fits.BinTableHDU(table),
+        fits.BinTableHDU(table, name='spam'),
+        fits.BinTableHDU(table, name='ham'),
     ])
     hdu_list.info()
     hdu_list.writeto('tables.fits')
 
-TODO: give examples how to control FITS extension names.
-
-TODO: give examples of things that don't work with Astropy, such as
-having complex meta (e.g. Quantity or ...) or having extra column metadata,
-especially the ``TDISP`` and ``TUCD`` that we use.
-But really, it looks like Astropy 3.0 is pretty good already, so we can make
-a note here that this is only support oder versions of Astropy for now.
 
 For further information on Astropy, see the Astropy docs at
 :ref:`astropy:astropy-table` and :ref:`astropy:table_io_fits`.
 
-Gammapy
-+++++++
-
-In Gammapy, we have two helper functions `gammapy.utils.fits.table_to_fits_table`
-and `gammapy.utils.fits.fits_table_to_table`.
-
-tbd: explain how they are different from the Astropy versions.
-
-TODO: I just now saw that TDISP support is being added in Astropy:
-https://github.com/astropy/astropy/pull/7226
-
+We will have to see if / what we need here in `gammapy.utils.fits`
+as a stable and nice interface on top of what Astropy provides.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict

--- a/gammapy/utils/tests/test_fits.py
+++ b/gammapy/utils/tests/test_fits.py
@@ -3,11 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import pytest
 from astropy.io import fits
-import astropy.units as u
 from astropy.table import Table, Column
-from ..fits import (
-    SmartHDUList, fits_table_to_table, table_to_fits_table,
-)
+from ..fits import SmartHDUList
 
 
 def make_test_hdu_list():
@@ -125,24 +122,3 @@ def test_table_fits_io_astropy(table):
     assert table2['b'].unit == 'm'
     # Note: description doesn't come back in older versions of Astropy
     # that we still support, so we're not asserting on that here for now.
-
-
-# TODO: I'm thinking maybe we should remove that Gammapy utils function ...
-def _test_table_fits_io_gammapy(table):
-    """Test table FITS I/O helper functions in Gammapy.
-    """
-    # Check Table -> BinTableHDU
-    hdu = table_to_fits_table(table)
-    assert hdu.header['TTYPE2'] == 'b'
-    assert hdu.header['TFORM2'] == 'K'
-    assert hdu.header['TUNIT2'] == 'm'
-    print(repr(hdu.header))  # ; 1/0
-
-    # Check BinTableHDU -> Table
-    table2 = fits_table_to_table(hdu)
-    assert isinstance(table2.meta, dict)
-    print(table2.meta)
-    assert table2.meta == {'VERSION': 42, 'TUCD2': 'spam'}
-    # assert table2['b'].unit == 'm'
-    assert table2['b'].description == 'Velocity'
-    assert table2['b'].meta['ucd'] == 'spam'

--- a/gammapy/utils/tests/test_fits.py
+++ b/gammapy/utils/tests/test_fits.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import pytest
 from astropy.io import fits
+import astropy.units as u
+from astropy.table import Table, Column
 from ..fits import (
-    SmartHDUList,
+    SmartHDUList, fits_table_to_table, table_to_fits_table,
 )
 
 
@@ -16,6 +18,18 @@ def make_test_hdu_list():
         fits.BinTableHDU(name='TABLE2'),
         fits.ImageHDU(name='IMAGE2', data=np.zeros(shape=(4, 5))),
     ])
+
+
+# TODO: merge this fixture with the one in `test_table.py`.
+# Need to move to conftest or can import?
+@pytest.fixture()
+def table():
+    t = Table(meta={'version': 42})
+    t['a'] = np.array([1, 2], dtype=np.int32)
+    t['b'] = Column(np.array([1, 2], dtype=np.int64), unit='m', description='Velocity')
+    t['b'].meta['ucd'] = 'spam'
+    t['c'] = Column(['x', 'yy'], 'c')
+    return t
 
 
 class TestSmartHDUList:
@@ -83,3 +97,52 @@ class TestSmartHDUList:
         self.hdus.write(filename)
         hdus2 = SmartHDUList.open(filename)
         assert self.hdus.names == hdus2.names
+
+
+def test_table_fits_io_astropy(table):
+    """Test `astropy.table.Table` FITS I/O in Astropy.
+
+    Having these tests in Gammapy is to check / ensure that the features
+    we rely on work properly for all Astropy versions we support in CI
+    (currently Astropy 1.3 and up)
+
+    This is useful, because Table FITS I/O was pretty shaky for a while
+    and incrementally improved over time.
+
+    These are the same examples that we have in the docstring
+    at the top of `gammapy/utils/fits.py`.
+    """
+    # Check Table -> BinTableHDU
+    hdu = fits.BinTableHDU(table)
+    assert hdu.header['TTYPE2'] == 'b'
+    assert hdu.header['TFORM2'] == 'K'
+    assert hdu.header['TUNIT2'] == 'm'
+
+    # Check BinTableHDU -> Table
+    table2 = Table.read(hdu)
+    assert isinstance(table2.meta, dict)
+    assert table2.meta == {'VERSION': 42}
+    assert table2['b'].unit == 'm'
+    # Note: description doesn't come back in older versions of Astropy
+    # that we still support, so we're not asserting on that here for now.
+
+
+# TODO: I'm thinking maybe we should remove that Gammapy utils function ...
+def _test_table_fits_io_gammapy(table):
+    """Test table FITS I/O helper functions in Gammapy.
+    """
+    # Check Table -> BinTableHDU
+    hdu = table_to_fits_table(table)
+    assert hdu.header['TTYPE2'] == 'b'
+    assert hdu.header['TFORM2'] == 'K'
+    assert hdu.header['TUNIT2'] == 'm'
+    print(repr(hdu.header))  # ; 1/0
+
+    # Check BinTableHDU -> Table
+    table2 = fits_table_to_table(hdu)
+    assert isinstance(table2.meta, dict)
+    print(table2.meta)
+    assert table2.meta == {'VERSION': 42, 'TUCD2': 'spam'}
+    # assert table2['b'].unit == 'm'
+    assert table2['b'].description == 'Velocity'
+    assert table2['b'].meta['ucd'] == 'spam'


### PR DESCRIPTION
I've started to improve the Table FITS I/O in `gammapy.utils.fits` by improving the utility functions there, adding some docs, and adding some tests.

This is work in progress, it's complicated by the fact that Astropy Table FITS I/O changed over the past years, and we want things to work the same across all Astropy versions we support (currently 1.3 to 3.0). I'm still trying to figure things out myself, no need for review at this point.