### PR TITLE
Fix computation of PSF containment radii for PSF3D.

### DIFF
--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -302,6 +302,7 @@ class PSF3D(object):
                     # Not sure what type exactly or how to catch it.
                     radius[e, t] = np.nan
                     continue
+                psf.normalize()
                 r = psf.containment_radius(fraction)
                 radius[e, t] = r.value
                 unit = r.unit


### PR DESCRIPTION
The computation of containment radii for the `PSF3D` class is wrong. The cdf of the `TablePSF` class created in the process is not normalized.

This PR constitutes the most simple and straightforward fix. One could also think about changing the `TablePSF` class such that the cdf is always normalized, but I'd prefer to make this simple fix first.