### PR TITLE
Change np.squeeze calls to pass a tuple of int

### DIFF
--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -206,9 +206,8 @@ class HpxNDMap(HpxMap):
             vals = self.get_by_idx(self.geom.get_idx(flat=True))
             map_out.fill_by_coord(self.geom.get_coord(flat=True)[:2], vals)
         else:
-            axes = np.arange(self.data.ndim - 1).tolist()
-            data = np.apply_over_axes(np.sum, self.data, axes=axes)
-            map_out.data = np.squeeze(data, axis=axes)
+            axis = tuple(range(self.data.ndim - 1))
+            map_out.data = np.sum(self.data, axis=axis)
 
         return map_out
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -274,7 +274,7 @@ class WcsNDMap(WcsMap):
             vals = self.get_by_idx(self.geom.get_idx())
             map_out.fill_by_coord(self.geom.get_coord()[:2], vals)
         else:
-            axis = tuple(np.arange(self.data.ndim - 2).tolist())
+            axis = tuple(range(self.data.ndim - 2))
             map_out.data = np.sum(self.data, axis=axis)
 
         return map_out


### PR DESCRIPTION
Yesterday a change to `numpy.squeeze` landed that caused this error in Gammapy master:
https://travis-ci.org/gammapy/gammapy/jobs/363544680#L3839

The problem is that we're passing a list of int to `numpy.squeeze` and it seems they now require tuple of int instead. That seems weird, I've left a comment here:
https://github.com/numpy/numpy/pull/10826#issuecomment-379498908

However, probable we should just change to tuple of int. The docs of [numpy.squeeze](https://docs.scipy.org/doc/numpy/reference/generated/numpy.squeeze.html) as well as [numpy.apply_over_axes](https://docs.scipy.org/doc/numpy/reference/generated/numpy.apply_over_axes.html) and [numpy.sum](https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html) that we call with list of int currently for `axis` or `axes` all say "tuple of int" should be passed. So I've made that change in this PR. Let's see if that works with Numpy dev and all other versions we text in CI.