### PR TITLE
Change testing of notebooks to testipynb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima photutils pygments sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima photutils sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme'
+        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme testipynb'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -44,4 +44,4 @@ dependencies:
     - sphinx-click
     - pydocstyle
     - black
-    - runipy
+    - testipynb

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -4,32 +4,27 @@ Test if IPython notebooks work.
 """
 import os
 import sys
-import subprocess
+import testipynb
+import unittest
 import logging
 from pkg_resources import working_set
 from pprint import pprint
+from gammapy.extern.pathlib import Path
 import yaml
 
 logging.basicConfig(level=logging.INFO)
-
-status_codes = dict(
-    success=0,
-    error_nb_failed=1,
-    error_no_gammapy_extra=2,
-)
 
 if 'GAMMAPY_EXTRA' not in os.environ:
     logging.info('GAMMAPY_EXTRA environment variable not set.')
     logging.info('Running notebook tests requires gammapy-extra.')
     logging.info('Exiting now.')
-    sys.exit(status_codes['error_no_gammapy_extra'])
-
-status_code = status_codes['success']
+    sys.exit()
 
 
 def get_notebooks():
     """Read `notebooks.yaml` info."""
-    filename = os.environ['GAMMAPY_EXTRA'] + '/notebooks/notebooks.yaml'
+    filename = str(
+        Path(os.environ['GAMMAPY_EXTRA']) / 'notebooks' / 'notebooks.yaml')
     logging.info('')
     with open(filename) as fh:
         notebooks = yaml.safe_load(fh)
@@ -45,54 +40,55 @@ def requirement_missing(notebook):
         try:
             working_set.require(package)
         except Exception as ex:
-            logging.warning('Skipping notebook {} because dependency {} is missing.'.format(notebook['name'], package))
+            logging.warning('Skipping notebook {} because dependency {} is missing.'.format(
+                notebook['name'], package))
             return True
 
     return False
 
 
-notebooks = get_notebooks()
-pprint(notebooks)
+class TestNotebooks(unittest.TestCase):
 
-logging.info('Python executable: {}'.format(sys.executable))
-logging.info('Python version: {}'.format(sys.version))
-logging.info('Testing IPython notebooks ...')
+    def test_notebooks(self):
 
-for notebook in notebooks:
+        logging.info('Python executable: {}'.format(sys.executable))
+        logging.info('Python version: {}'.format(sys.version))
+        logging.info('Testing IPython notebooks...')
 
-    if not notebook['test']:
-        logging.info('Skipping notebook {} because test=false.'.format(notebook['name']))
-        continue
+        dirnbs = Path(os.environ['GAMMAPY_EXTRA']) / 'notebooks'
+        nbfiles = [f.name for f in dirnbs.iterdir() if
+                   f.name.endswith('.ipynb')]
+        notebooks = get_notebooks()
+        pprint(notebooks)
+        ignorelist = []
+        yamllist = []
 
-    if requirement_missing(notebook):
-        continue
+        for notebook in notebooks:
 
-    # For testing how `subprocess.Popen` works:
-    # cmd = 'pwd && echo "hi" && asdf'
+            notebookfile = notebook['name']
+            yamllist.append(notebookfile)
 
-    cmd = 'pwd; '
-    cmd += 'echo $GAMMAPY_EXTRA; '
-    # cmd += 'export GAMMAPY_EXTRA={}; '.format(os.environ['GAMMAPY_EXTRA'])
-    # cmd += 'cd $GAMMAPY_EXTRA/notebooks; '
-    cmd += sys.executable + ' -m runipy.main {}.ipynb'.format(notebook['name'])
-    logging.info('Executing: {}'.format(cmd))
-    proc = subprocess.Popen(
-        cmd,
-        shell=True,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env=os.environ.copy(),
-        cwd=os.environ['GAMMAPY_EXTRA'] + '/notebooks',
-    )
-    stdout, stderr = proc.communicate()
-    logging.info('Exit status code: {}'.format(proc.returncode))
-    logging.info('stdout:\n{}'.format(stdout.decode('utf8')))
-    logging.info('stderr:\n{}'.format(stderr.decode('utf8')))
+            if not notebook['test']:
+                logging.info(
+                    'Skipping notebook {} because test=false.'.format(notebook['name']))
+                ignorelist.append(notebookfile)
+                continue
 
-    if proc.returncode != status_codes['success']:
-        status_code = status_codes['error_nb_failed']
+            if requirement_missing(notebook):
+                logging.info('Skipping notebook {} because requirement is missing.'.format(
+                    notebook['name']))
+                ignorelist.append(notebookfile)
+                continue
 
-logging.info('... finished testing IPython notebooks.')
-logging.info('Total exit status code of test_notebook.py is: {}'.format(status_code))
-sys.exit(status_code)
+        for nbfile in nbfiles:
+            nbname = nbfile.replace('.ipynb', '')
+            if nbname not in yamllist:
+                ignorelist.append(nbname)
+
+        testnb = testipynb.TestNotebooks(
+            directory=str(dirnbs), ignore=ignorelist)
+        self.assertTrue(testnb.run_tests())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR uses `testipynb` https://github.com/opengeophysics/testipynb for unit testing of notebooks in `test_notebooks.py`script. 

In unit-tests assertions `testipynb` relies on `nbconvert` (which we already use in the doc generation process) to run the notebooks. 

Tracebacks are cleaner and input/output cells of the notebooks are not shown.

Using `testipynb` I catch a fail on `nddata_demo.ipynb` notebook. This is not the case when running the present version of `test_notebooks.py`script. 

