### PR TITLE
Add first draft of LightCurve model class

### DIFF
--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -4,8 +4,8 @@ import pytest
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from ...utils.scripts import make_path
-from ...utils.testing import requires_data
-from ..models import PhaseCurve
+from ...utils.testing import requires_data, requires_dependency
+from ..models import PhaseCurve, LightCurve
 
 
 @pytest.fixture(scope='session')
@@ -31,3 +31,31 @@ def test_phasecurve_evaluate(phase_curve):
     phase = phase_curve.phase(time)
     value = phase_curve.evaluate_norm_at_phase(phase)
     assert_allclose(value, 0.49059393580053845)
+
+
+# TODO: add light-curve test case from scratch
+# only use the FITS one for I/O (or not at all)
+@pytest.fixture(scope='session')
+def light_curve():
+    path = '$GAMMAPY_EXTRA/test_datasets/models/light_curve/lightcrv_PKSB1222+216.fits'
+    return LightCurve.read(path)
+
+
+@requires_data('gammapy-extra')
+def test_light_curve_str(light_curve):
+    ss = str(light_curve)
+    assert 'LightCurve' in ss
+
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_light_curve_evaluate_norm_at_time(light_curve):
+    val = light_curve.evaluate_norm_at_time(46300)
+    assert_allclose(val, 0.021192223042749835)
+
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_light_curve_mean_norm_in_time_interval(light_curve):
+    val = light_curve.mean_norm_in_time_interval(46300, 46301)
+    assert_allclose(val, 0.021192284384617066)


### PR DESCRIPTION
This PR adds a first draft of a LightCurve model class.

The scope / timescale here is very limited. It's just to add something to help compute mean per-run fluxes for the LC for this CTA DC-1 check, which is needed ASAP:
https://github.com/gammasky/cta-analyses/tree/master/dc-1-checks/agn_j1224

I've left "TODO" comments in the docstrings about things we need to discuss / improve.

@bkhelifi @cboisson @jlenain @labsaha - If one of you has suggestions on this today, let me know and I'll implement them tonight. Otherwise I'll just merge this in as a very preliminary first version, and we can discuss and improve it in the coming weeks.