### PR TITLE
Add units to gammapy.maps

### DIFF
--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -3,14 +3,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy import units as u
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ...irf import EffectiveAreaTable2D, Background3D
 from ...maps import WcsNDMap, WcsGeom, MapAxis
 from ..new import make_separation_map, make_map_exposure_true_energy, make_map_hadron_acceptance
+
+pytest.importorskip('scipy')
 
 
 @pytest.fixture(scope='session')
@@ -54,7 +55,6 @@ def test_separation_map():
     assert_allclose(m.data[0, 0], 0.7106291438079875)
 
 
-@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_make_map_exposure_true_energy(aeff, counts_cube):
     pointing = SkyCoord(83.633, 21.514, unit='deg')
@@ -70,7 +70,6 @@ def test_make_map_exposure_true_energy(aeff, counts_cube):
     assert_quantity_allclose(np.nanmax(m.data), 4.7e8, rtol=100)
 
 
-@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_make_map_fov_background(bkg_3d, counts_cube):
     pointing = SkyCoord(83.633, 21.514, unit='deg')

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -41,16 +41,16 @@ class Map(object):
     def __init__(self, geom, data, meta=None, unit=None):
         self._geom = geom
         if isinstance(data,Quantity):
-            self.unit = Quantity.unit.to_string()
+            self._unit = Quantity.unit.to_string()
             self._data = data.value
         else:
             self._data = data
             if unit is None:
-                self.unit = ''
+                self._unit = ''
             elif isinstance(unit,Unit):
-                self.unit = unit.to_string()
+                self._unit = unit.to_string()
             else:
-                self.unit = unit
+                self._unit = unit
 
         if meta is None:
             self.meta = OrderedDict()
@@ -65,7 +65,12 @@ class Map(object):
     @property
     def quantity(self):
         """Return data as a quantity"""
-        return self._data * Unit(self.unit)
+        return self._data * Unit(self._unit)
+
+    @property
+    def unit(self):
+        """Return map unit as `~astropy.unit.Unit`"""
+        return Unit(self._unit)
 
     @data.setter
     def data(self, val):
@@ -80,7 +85,7 @@ class Map(object):
 
         val = Quantity(val)
         self._data = val.value
-        self.unit = val.unit.to_string()
+        self._unit = val.unit.to_string()
 
     @property
     def geom(self):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -169,7 +169,7 @@ class Map(object):
         return map_out
 
     @classmethod
-    def from_geom(cls, geom, meta=None, map_type='auto', unit=None):
+    def from_geom(cls, geom, meta=None, map_type='auto', unit=''):
         """Generate an empty map from a `~Geom` instance.
 
         Parameters

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -34,20 +34,18 @@ class Map(object):
         Data array
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
-    unit : str or `~astropy.unit.Unit`
+    unit : str or `~astropy.units.Unit`
         The map unit if data is a `~numpy.ndarray`. Default is dimensionless
     """
 
-    def __init__(self, geom, data, meta=None, unit=None):
+    def __init__(self, geom, data, meta=None, unit=''):
         self._geom = geom
         if isinstance(data,Quantity):
             self._unit = Quantity.unit.to_string()
             self._data = data.value
         else:
             self._data = data
-            if unit is None:
-                self._unit = ''
-            elif isinstance(unit,Unit):
+            if isinstance(unit,Unit):
                 self._unit = unit.to_string()
             else:
                 self._unit = unit
@@ -69,7 +67,7 @@ class Map(object):
 
     @property
     def unit(self):
-        """Return map unit as `~astropy.unit.Unit`"""
+        """Return map unit as `~astropy.units.Unit`"""
         return Unit(self._unit)
 
     @data.setter
@@ -372,11 +370,14 @@ class Map(object):
             Input map.
 
         """
+        if not self.unit.is_equivalent(map_in.unit):
+            raise ValueError("Incompatible units, Map.coadd")
+
         # TODO: Check whether geometries are aligned and if so sum the
         # data vectors directly
         idx = map_in.geom.get_idx()
         coords = map_in.geom.get_coord()
-        vals = map_in.get_by_idx(idx)
+        vals = Quantity(map_in.get_by_idx(idx),map_in.unit)
         self.fill_by_coord(coords, vals)
 
     def reproject(self, geom, order=1, mode='interp'):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -35,20 +35,17 @@ class Map(object):
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
     unit : str or `~astropy.units.Unit`
-        The map unit if data is a `~numpy.ndarray`. Default is dimensionless
+        Data unit
     """
 
     def __init__(self, geom, data, meta=None, unit=''):
         self._geom = geom
-        if isinstance(data,Quantity):
-            self._unit = Quantity.unit.to_string()
+        if isinstance(data, Quantity):
             self._data = data.value
+            self._unit = data.unit.to_string()
         else:
             self._data = data
-            if isinstance(unit,Unit):
-                self._unit = unit.to_string()
-            else:
-                self._unit = unit
+            self._unit = Unit(unit).to_string()
 
         if meta is None:
             self.meta = OrderedDict()
@@ -62,12 +59,12 @@ class Map(object):
 
     @property
     def quantity(self):
-        """Return data as a quantity"""
+        """Map data times unit (`~astropy.units.Quantity`)"""
         return self._data * Unit(self._unit)
 
     @property
     def unit(self):
-        """Return map unit as `~astropy.units.Unit`"""
+        """Map unit (`~astropy.units.Unit`)"""
         return Unit(self._unit)
 
     @data.setter
@@ -368,16 +365,15 @@ class Map(object):
         ----------
         map_in : `~Map`
             Input map.
-
         """
         if not self.unit.is_equivalent(map_in.unit):
-            raise ValueError("Incompatible units, Map.coadd")
+            raise ValueError("Incompatible units")
 
         # TODO: Check whether geometries are aligned and if so sum the
         # data vectors directly
         idx = map_in.geom.get_idx()
         coords = map_in.geom.get_coord()
-        vals = Quantity(map_in.get_by_idx(idx),map_in.unit)
+        vals = Quantity(map_in.get_by_idx(idx), map_in.unit)
         self.fill_by_coord(coords, vals)
 
     def reproject(self, geom, order=1, mode='interp'):

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -26,15 +26,15 @@ class HpxMap(Map):
         Dictionary to store meta data.
     """
 
-    def __init__(self, geom, data, meta=None):
-        super(HpxMap, self).__init__(geom, data, meta)
+    def __init__(self, geom, data, meta=None, unit=None):
+        super(HpxMap, self).__init__(geom, data, meta, unit)
         self._wcs2d = None
         self._hpx2wcs = None
 
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, map_type='hpx', coordsys='CEL',
                data=None, skydir=None, width=None, dtype='float32',
-               region=None, axes=None, conv='gadf', meta=None):
+               region=None, axes=None, conv='gadf', meta=None, unit=None):
         """Factory method to create an empty HEALPix map.
 
         Parameters
@@ -67,6 +67,8 @@ class HpxMap(Map):
             writing this map to a file.  Default is 'gadf'.            
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
+        unit : `~astropy.units.Unit`
+            The map unit
 
         Returns
         -------
@@ -80,13 +82,13 @@ class HpxMap(Map):
                              nest=nest, coordsys=coordsys, region=region,
                              conv=conv, axes=axes, skydir=skydir, width=width)
         if cls.__name__ == 'HpxNDMap':
-            return HpxNDMap(hpx, dtype=dtype, meta=meta)
+            return HpxNDMap(hpx, dtype=dtype, meta=meta, unit=unit)
         elif cls.__name__ == 'HpxSparseMap':
-            return HpxSparseMap(hpx, dtype=dtype, meta=meta)
+            return HpxSparseMap(hpx, dtype=dtype, meta=meta, unit=unit)
         elif map_type == 'hpx':
-            return HpxNDMap(hpx, dtype=dtype, meta=meta)
+            return HpxNDMap(hpx, dtype=dtype, meta=meta, unit=unit)
         elif map_type == 'hpx-sparse':
-            return HpxSparseMap(hpx, dtype=dtype, meta=meta)
+            return HpxSparseMap(hpx, dtype=dtype, meta=meta, unit=unit)
         else:
             raise ValueError('Unrecognized map type: {}'.format(map_type))
 
@@ -155,6 +157,9 @@ class HpxMap(Map):
         hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse,
                                 conv=conv)
         hdu_out.header['META'] = json.dumps(self.meta)
+        # add unit in header
+        hdu_out.header['UNIT'] = self.unit
+
         hdu_list = [fits.PrimaryHDU(), hdu_out]
 
         if self.geom.axes:

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -24,9 +24,11 @@ class HpxMap(Map):
         Data array.
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
+    unit : `~astropy.units.Unit`
+        The map unit
     """
 
-    def __init__(self, geom, data, meta=None, unit=None):
+    def __init__(self, geom, data, meta=None, unit=''):
         super(HpxMap, self).__init__(geom, data, meta, unit)
         self._wcs2d = None
         self._hpx2wcs = None

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -157,8 +157,7 @@ class HpxMap(Map):
         hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse,
                                 conv=conv)
         hdu_out.header['META'] = json.dumps(self.meta)
-        # add unit in header
-        hdu_out.header['UNIT'] = self.unit
+        hdu_out.header['UNIT'] = self._unit
 
         hdu_list = [fits.PrimaryHDU(), hdu_out]
 

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -34,7 +34,7 @@ class HpxMap(Map):
     @classmethod
     def create(cls, nside=None, binsz=None, nest=True, map_type='hpx', coordsys='CEL',
                data=None, skydir=None, width=None, dtype='float32',
-               region=None, axes=None, conv='gadf', meta=None, unit=None):
+               region=None, axes=None, conv='gadf', meta=None, unit=''):
         """Factory method to create an empty HEALPix map.
 
         Parameters
@@ -67,7 +67,7 @@ class HpxMap(Map):
             writing this map to a file.  Default is 'gadf'.            
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
-        unit : `~astropy.units.Unit`
+        unit : str or `~astropy.units.Unit`
             The map unit
 
         Returns

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -32,9 +32,11 @@ class HpxNDMap(HpxMap):
         If none then an empty array will be allocated.
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
+    unit : `~astropy.units.Unit`
+        The map unit
     """
 
-    def __init__(self, geom, data=None, dtype='float32', meta=None):
+    def __init__(self, geom, data=None, dtype='float32', meta=None, unit=None):
 
         shape = tuple([np.max(geom.npix)] + [ax.nbin for ax in geom.axes])
         shape_np = shape[::-1]
@@ -45,7 +47,7 @@ class HpxNDMap(HpxMap):
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape_np, data.shape))
 
-        super(HpxNDMap, self).__init__(geom, data, meta)
+        super(HpxNDMap, self).__init__(geom, data, meta, unit)
         self._wcs2d = None
         self._hpx2wcs = None
 
@@ -78,7 +80,12 @@ class HpxNDMap(HpxMap):
         # TODO: Should we support extracting slices?
 
         meta = cls._get_meta_from_header(hdu.header)
-        map_out = cls(hpx, None, meta=meta)
+
+        if 'UNIT' in hdu.header:
+            unit = hdu.header['UNIT']
+        else:
+            unit = None
+        map_out = cls(hpx, None, meta=meta, unit=unit)
 
         colnames = hdu.columns.names
         cnames = []

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -81,10 +81,7 @@ class HpxNDMap(HpxMap):
 
         meta = cls._get_meta_from_header(hdu.header)
 
-        if 'UNIT' in hdu.header:
-            unit = hdu.header['UNIT']
-        else:
-            unit = None
+        unit = hdu.header.get('UNIT', None)
         map_out = cls(hpx, None, meta=meta, unit=unit)
 
         colnames = hdu.columns.names

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -416,15 +416,7 @@ class HpxNDMap(HpxMap):
         idx_local = [t[msk] for t in idx_local]
         if weights is not None:
             if isinstance(weights, Quantity):
-                if self.unit.is_equivalent(weights.unit):
-                    weights = np.asarray(weights.to(self.unit).value, dtype=self.data.dtype)
-                else:
-                    raise ValueError("fill_by_idx : Incompatible unit for weights")
-            elif self.unit.is_equivalent(''):
-                weights = np.asarray(weights, dtype=self.data.dtype)
-            else:
-                raise ValueError("fill_by_idx : Incompatible unit for weights")
-
+                weights = weights.to(self.unit).value
             weights = weights[msk]
 
         idx_local = np.ravel_multi_index(idx_local, self.data.T.shape)

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -82,7 +82,7 @@ class HpxNDMap(HpxMap):
 
         meta = cls._get_meta_from_header(hdu.header)
 
-        unit = hdu.header.get('UNIT', None)
+        unit = hdu.header.get('UNIT', '')
         map_out = cls(hpx, None, meta=meta, unit=unit)
 
         colnames = hdu.columns.names

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -26,16 +26,18 @@ class HpxSparseMap(HpxMap):
         HEALPIX data array.
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
+    unit : `~astropy.units.Unit`
+        The map unit
     """
 
-    def __init__(self, geom, data=None, dtype='float32', meta=None):
+    def __init__(self, geom, data=None, dtype='float32', meta=None, unit=None):
         if data is None:
             shape = tuple([np.max(geom.npix)] + [ax.nbin for ax in geom.axes])
             data = SparseArray(shape[::-1], dtype=dtype)
         elif isinstance(data, np.ndarray):
             data = SparseArray.from_array(data)
 
-        super(HpxSparseMap, self).__init__(geom, data, meta)
+        super(HpxSparseMap, self).__init__(geom, data, meta, unit)
 
     @classmethod
     def from_hdu(cls, hdu, hdu_bands=None):

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -30,7 +30,7 @@ class HpxSparseMap(HpxMap):
         The map unit
     """
 
-    def __init__(self, geom, data=None, dtype='float32', meta=None, unit=None):
+    def __init__(self, geom, data=None, dtype='float32', meta=None, unit=''):
         if data is None:
             shape = tuple([np.max(geom.npix)] + [ax.nbin for ax in geom.axes])
             data = SparseArray(shape[::-1], dtype=dtype)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
+from collections import OrderedDict
+import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit, Quantity
-import numpy as np
-from collections import OrderedDict
 from ..base import Map
 from ..geom import MapAxis
 from ..wcs import WcsGeom
@@ -16,12 +16,10 @@ pytest.importorskip('scipy')
 pytest.importorskip('healpy')
 pytest.importorskip('numpy', '1.12.0')
 
-
 map_axes = [
     MapAxis.from_bounds(1.0, 10.0, 3, interp='log'),
     MapAxis.from_bounds(0.1, 1.0, 4, interp='log'),
 ]
-
 
 mapbase_args = [
     (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
@@ -68,37 +66,36 @@ def test_map_meta_read_write(map_type):
     m2 = Map.from_hdu_list(hdulist)
     assert m2.meta == meta
 
+
 unit_args = [
-    ('wcs','s'),
-    ('wcs',''),
-    ('wcs',Unit('sr')),
-    ('hpx','m^2')
+    ('wcs', 's'),
+    ('wcs', ''),
+    ('wcs', Unit('sr')),
+    ('hpx', 'm^2')
 ]
 
-@pytest.mark.parametrize(('map_type','unit'),
-                         unit_args)
+
+@pytest.mark.parametrize(('map_type', 'unit'), unit_args)
 def test_map_quantity(map_type, unit):
-    m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
-                   skydir=SkyCoord(0.0, 30.0, unit='deg'), unit=unit)
+    m = Map.create(binsz=0.1, width=10.0, map_type=map_type, unit=unit)
 
     # This is to test if default constructor with no unit performs as expected
     if unit is None:
         unit = ''
     assert m.quantity.unit == Unit(unit)
 
-    m.quantity = Quantity(np.ones_like(m.data),'m2')
+    m.quantity = Quantity(np.ones_like(m.data), 'm2')
     assert m.unit == 'm2'
 
-@pytest.mark.parametrize(('map_type','unit'),
-                         unit_args)
-def test_map_unit_read_write(map_type, unit):
-    m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
-                   skydir=SkyCoord(0.0, 30.0, unit='deg'), unit=unit)
 
-    hdulist = m.to_hdulist(hdu='COUNTS')
-    header = hdulist['COUNTS'].header
+@pytest.mark.parametrize(('map_type', 'unit'), unit_args)
+def test_map_unit_read_write(map_type, unit):
+    m = Map.create(binsz=0.1, width=10.0, map_type=map_type, unit=unit)
+
+    hdu_list = m.to_hdulist(hdu='COUNTS')
+    header = hdu_list['COUNTS'].header
 
     assert Unit(header['UNIT']) == Unit(unit)
 
-    m2 = Map.from_hdu_list(hdulist)
-    assert Unit(m2.unit) == Unit(unit)
+    m2 = Map.from_hdu_list(hdu_list)
+    assert m2.unit == unit

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from astropy.coordinates import SkyCoord
-from astropy.units import Unit
+from astropy.units import Unit, Quantity
+import numpy as np
 from collections import OrderedDict
 from ..base import Map
 from ..geom import MapAxis
@@ -73,6 +74,21 @@ unit_args = [
     ('wcs',Unit('sr')),
     ('hpx','m^2')
 ]
+
+@pytest.mark.parametrize(('map_type','unit'),
+                         unit_args)
+def test_map_quantity(map_type, unit):
+    m = Map.create(binsz=0.1, width=10.0, map_type=map_type,
+                   skydir=SkyCoord(0.0, 30.0, unit='deg'), unit=unit)
+
+    # This is to test if default constructor with no unit performs as expected
+    if unit is None:
+        unit = ''
+    assert m.quantity.unit == Unit(unit)
+
+    m.quantity = Quantity(np.ones_like(m.data),'m2')
+    assert m.unit == 'm2'
+
 @pytest.mark.parametrize(('map_type','unit'),
                          unit_args)
 def test_map_unit_read_write(map_type, unit):

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -24,13 +24,13 @@ map_axes = [
 
 
 mapbase_args = [
-    (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), None, None),
-    (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), map_axes[:1], None),
+    (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
+    (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), map_axes[:1], ''),
     (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), map_axes, 'm^2'),
-    (0.1, 10.0, 'hpx', SkyCoord(0.0, 30.0, unit='deg'), None, None),
-    (0.1, 10.0, 'hpx', SkyCoord(0.0, 30.0, unit='deg'), map_axes[:1], None),
+    (0.1, 10.0, 'hpx', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
+    (0.1, 10.0, 'hpx', SkyCoord(0.0, 30.0, unit='deg'), map_axes[:1], ''),
     (0.1, 10.0, 'hpx', SkyCoord(0.0, 30.0, unit='deg'), map_axes, 's^2'),
-    (0.1, 10.0, 'hpx-sparse', SkyCoord(0.0, 30.0, unit='deg'), None, None),
+    (0.1, 10.0, 'hpx-sparse', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
 ]
 
 
@@ -70,7 +70,7 @@ def test_map_meta_read_write(map_type):
 
 unit_args = [
     ('wcs','s'),
-    ('wcs',None),
+    ('wcs',''),
     ('wcs',Unit('sr')),
     ('hpx','m^2')
 ]
@@ -98,9 +98,6 @@ def test_map_unit_read_write(map_type, unit):
     hdulist = m.to_hdulist(hdu='COUNTS')
     header = hdulist['COUNTS'].header
 
-    # This is to test if default constructor with no unit performs as expected
-    if unit is None:
-        unit = ''
     assert Unit(header['UNIT']) == Unit(unit)
 
     m2 = Map.from_hdu_list(hdulist)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -291,17 +291,20 @@ def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
     if m.geom.is_regular:
         assert_allclose(np.nansum(m.data), np.nansum(msum.data))
 
+
 def test_coadd_unit():
     geom = HpxGeom.create(nside=128)
-    m1 = HpxNDMap(geom , unit='m2')
+    m1 = HpxNDMap(geom, unit='m2')
     m2 = HpxNDMap(geom, unit='cm2')
 
     idx = geom.get_idx()
 
-    m1.fill_by_idx(idx,weights=Quantity(np.ones_like(idx[0]),unit='cm2'))
+    weights = Quantity(np.ones_like(idx[0]), unit='cm2')
+    m1.fill_by_idx(idx, weights=weights)
     assert_allclose(m1.data, 0.0001)
 
-    m1.fill_by_idx(idx, weights=Quantity(np.ones_like(idx[0]), unit='m2'))
+    weights = Quantity(np.ones_like(idx[0]), unit='m2')
+    m1.fill_by_idx(idx, weights=weights)
     m1.coadd(m2)
 
     assert_allclose(m1.data, 1.0001)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
+from astropy.units import Quantity
 from ..utils import fill_poisson
 from ..geom import MapAxis, coordsys_to_frame
 from ..base import Map
@@ -289,3 +290,18 @@ def test_hpxmap_sum_over_axes(nside, nested, coordsys, region, axes):
 
     if m.geom.is_regular:
         assert_allclose(np.nansum(m.data), np.nansum(msum.data))
+
+def test_coadd_unit():
+    geom = HpxGeom.create(nside=128)
+    m1 = HpxNDMap(geom , unit='m2')
+    m2 = HpxNDMap(geom, unit='cm2')
+
+    idx = geom.get_idx()
+
+    m1.fill_by_idx(idx,weights=Quantity(np.ones_like(idx[0]),unit='cm2'))
+    assert_allclose(m1.data, 0.0001)
+
+    m1.fill_by_idx(idx, weights=Quantity(np.ones_like(idx[0]), unit='m2'))
+    m1.coadd(m2)
+
+    assert_allclose(m1.data, 1.0001)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -366,3 +366,14 @@ def test_wcsndmap_upsample(npix, binsz, coordsys, proj, skydir, axes):
     m = WcsNDMap(geom)
     m2 = m.upsample(2, order=0, preserve_counts=True)
     assert_allclose(np.nansum(m.data), np.nansum(m2.data))
+
+def test_coadd_unit():
+    geom = WcsGeom.create(npix=(10,10), binsz=1,
+                          proj='CAR', coordsys='GAL')
+    m1 = WcsNDMap(geom, data=np.ones((10,10)), unit='m2')
+    m2 = WcsNDMap(geom, data=np.ones((10,10)), unit='cm2')
+
+    m1.coadd(m2)
+
+    assert_allclose(m1.data, 1.0001)
+

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -166,8 +166,7 @@ class WcsMap(Map):
 
         hdu_out.header['META'] = json.dumps(self.meta)
 
-        # Save unit in header
-        hdu_out.header['UNIT'] = self.unit
+        hdu_out.header['UNIT'] = self._unit
 
         if hdu == 'PRIMARY':
             hdulist = [hdu_out]

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -26,7 +26,7 @@ class WcsMap(Map):
     @classmethod
     def create(cls, map_type='wcs', npix=None, binsz=0.1, width=None,
                proj='CAR', coordsys='CEL', refpix=None,
-               axes=None, skydir=None, dtype='float32', conv='gadf', meta=None, unit=None):
+               axes=None, skydir=None, dtype='float32', conv='gadf', meta=None, unit=''):
         """Factory method to create an empty WCS map.
 
         Parameters
@@ -69,7 +69,7 @@ class WcsMap(Map):
             FITS format convention.  Default is 'gadf'.
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
-        unit : `~astropy.units.Unit`
+        unit : str or `~astropy.units.Unit`
             The unit of the map
 
         Returns

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -26,7 +26,7 @@ class WcsMap(Map):
     @classmethod
     def create(cls, map_type='wcs', npix=None, binsz=0.1, width=None,
                proj='CAR', coordsys='CEL', refpix=None,
-               axes=None, skydir=None, dtype='float32', conv='gadf', meta=None):
+               axes=None, skydir=None, dtype='float32', conv='gadf', meta=None, unit=None):
         """Factory method to create an empty WCS map.
 
         Parameters
@@ -69,6 +69,8 @@ class WcsMap(Map):
             FITS format convention.  Default is 'gadf'.
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
+        unit : `~astropy.units.Unit`
+            The unit of the map
 
         Returns
         -------
@@ -84,7 +86,7 @@ class WcsMap(Map):
                               conv=conv)
 
         if map_type == 'wcs':
-            return WcsNDMap(geom, dtype=dtype, meta=meta)
+            return WcsNDMap(geom, dtype=dtype, meta=meta, unit=unit)
         elif map_type == 'wcs-sparse':
             raise NotImplementedError
         else:
@@ -163,6 +165,9 @@ class WcsMap(Map):
                                 sparse=sparse, conv=conv)
 
         hdu_out.header['META'] = json.dumps(self.meta)
+
+        # Save unit in header
+        hdu_out.header['UNIT'] = self.unit
 
         if hdu == 'PRIMARY':
             hdulist = [hdu_out]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -105,11 +105,7 @@ class WcsNDMap(WcsMap):
                            np.max(geom.npix[1])])
         meta = cls._get_meta_from_header(hdu.header)
 
-        # Read unit
-        if 'UNIT' in hdu.header:
-            unit = hdu.header['UNIT']
-        else:
-            unit = None
+        unit = hdu.header.get('UNIT', None)
 
         map_out = cls(geom, meta=meta, unit=unit)
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -243,15 +243,7 @@ class WcsNDMap(WcsMap):
 
         if weights is not None:
             if isinstance(weights, Quantity):
-                if self.unit.is_equivalent(weights.unit):
-                    weights = np.asarray(weights.to(self.unit).value, dtype=self.data.dtype)
-                else:
-                    raise ValueError("Incompatible unit for weights")
-            elif self.unit.is_equivalent(''):
-                weights = np.asarray(weights, dtype=self.data.dtype)
-            else:
-                raise ValueError("Incompatible unit for weights")
-
+                weights = weights.to(self.unit).value
             weights = weights[msk]
 
         idx = np.ravel_multi_index(idx, self.data.T.shape)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -105,7 +105,7 @@ class WcsNDMap(WcsMap):
                            np.max(geom.npix[1])])
         meta = cls._get_meta_from_header(hdu.header)
 
-        unit = hdu.header.get('UNIT', None)
+        unit = hdu.header.get('UNIT', '')
 
         map_out = cls(geom, meta=meta, unit=unit)
 
@@ -246,11 +246,11 @@ class WcsNDMap(WcsMap):
                 if self.unit.is_equivalent(weights.unit):
                     weights = np.asarray(weights.to(self.unit).value, dtype=self.data.dtype)
                 else:
-                    raise ValueError("fill_by_idx : Incompatible unit for weights")
+                    raise ValueError("Incompatible unit for weights")
             elif self.unit.is_equivalent(''):
                 weights = np.asarray(weights, dtype=self.data.dtype)
             else:
-                raise ValueError("fill_by_idx : Incompatible unit for weights")
+                raise ValueError("Incompatible unit for weights")
 
             weights = weights[msk]
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -34,9 +34,11 @@ class WcsNDMap(WcsMap):
         Data type, default is float32
     meta : `~collections.OrderedDict`
         Dictionary to store meta data.
+    unit : `~astropy.units.Unit`
+        The map unit
     """
 
-    def __init__(self, geom, data=None, dtype='float32', meta=None):
+    def __init__(self, geom, data=None, dtype='float32', meta=None, unit=None):
         # TODO: Figure out how to mask pixels for integer data types
 
         # Shape in WCS or FITS order is `shape`, in Numpy axis order is `shape_np`
@@ -50,7 +52,7 @@ class WcsNDMap(WcsMap):
             raise ValueError('Wrong shape for input data array. Expected {} '
                              'but got {}'.format(shape_np, data.shape))
 
-        super(WcsNDMap, self).__init__(geom, data, meta)
+        super(WcsNDMap, self).__init__(geom, data, meta, unit)
 
     @staticmethod
     def _make_default_data(geom, shape_np, dtype):
@@ -102,7 +104,14 @@ class WcsNDMap(WcsMap):
         shape_wcs = tuple([np.max(geom.npix[0]),
                            np.max(geom.npix[1])])
         meta = cls._get_meta_from_header(hdu.header)
-        map_out = cls(geom, meta=meta)
+
+        # Read unit
+        if 'UNIT' in hdu.header:
+            unit = hdu.header['UNIT']
+        else:
+            unit = None
+
+        map_out = cls(geom, meta=meta, unit=unit)
 
         # TODO: Should we support extracting slices?
         if isinstance(hdu, fits.BinTableHDU):


### PR DESCRIPTION
This is a first commit to add units to map. This contains:
- addition of `Map.unit` as a string in the constructor and in the relevant `Map.create`methods
- addition of `Map.quantity`property and setter
- addition of `Map.unit` in the header exported and imported respectively in `Map.to_hdu()` and in `Map.from_hdu()`
- Tests for creation and hdu read/write

Still need to add unit in `Map.fill_map_idx`.

Note that the `Map.quantity` setter forces the unit so one can change the unit with `Map.quantity = some_quantity`. If this is not wanted one can add a check on the unit consistency. Or even remove the setter.
 
EDIT : this PR implements #1206 