### PR TITLE
Add new SpatialModel base class

### DIFF
--- a/gammapy/image/models/__init__.py
+++ b/gammapy/image/models/__init__.py
@@ -5,3 +5,4 @@ Morphology models.
 from .gauss import *
 from .shapes import *
 from .theta import *
+from .new import *

--- a/gammapy/image/models/new.py
+++ b/gammapy/image/models/new.py
@@ -1,0 +1,83 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Morphological models for astrophysical gamma-ray sources - new implementation
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ...utils.modeling import Parameter, ParameterList
+import numpy as np
+
+__all__ = [
+    'SkySpatialModel',
+    'SkyGaussian2D',
+]
+
+
+class SkySpatialModel(object):
+    """SkySpatial model base class.
+    """
+
+    def __repr__(self):
+        fmt = '{}()'
+        return fmt.format(self.__class__.__name__)
+
+    def __str__(self):
+        ss = self.__class__.__name__
+        ss += '\n\nParameters: \n\n\t'
+
+        table = self.parameters.to_table()
+        ss += '\n\t'.join(table.pformat())
+
+        if self.parameters.covariance is not None:
+            ss += '\n\nCovariance: \n\n\t'
+            covar = self.parameters.covariance_to_table()
+            ss += '\n\t'.join(covar.pformat())
+        return ss
+
+    def __call__(self, lon, lat):
+        """Call evaluate method of derived classes"""
+        kwargs = dict()
+        for par in self.parameters.parameters:
+            kwargs[par.name] = par.quantity
+
+        return self.evaluate(lon, lat, **kwargs)
+
+    def copy(self):
+        """A deep copy."""
+        return copy.deepcopy(self)
+
+
+class SkyGaussian2D(SkySpatialModel):
+    r"""Two-dimensional symmetric Gaussian model.
+
+    .. math::
+
+        \phi(x, y) = \phi_0 \cdot \exp{\left(-\frac{1}{2\sigma^2}
+            \left((x-x_0)^2+(y-y_0)^2\right)\right)}
+
+    Parameters
+    ----------
+    amplitude : `~astropy.units.Quantity`
+        :math:`\phi_0`
+    lon_mean : `~astropy.units.Quantity`
+        :math:`x_0`
+    lat_mean : `~astropy.units.Quantity`
+        :math:`y_0`
+    sigma : `~astropy.units.Quantity`
+        :math:`\sigma`
+    """
+
+    def __init__(self, amplitude, lon_mean, lat_mean, sigma):
+        self.parameters = ParameterList([
+            Parameter('amplitude', amplitude),
+            Parameter('lon_mean', lon_mean),
+            Parameter('lat_mean', lat_mean),
+            Parameter('sigma', sigma)
+        ])
+
+    @staticmethod
+    def evaluate(lon, lat, amplitude, lon_mean, lat_mean, sigma):
+        """Evaluate the model (static function)."""
+        exp_ = (lon - lon_mean) ** 2 + (lat - lat_mean) ** 2
+        val = amplitude * np.exp((- 1 / (2 * sigma ** 2)) * exp_)
+        return val

--- a/gammapy/image/models/tests/test_models.py
+++ b/gammapy/image/models/tests/test_models.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from ..new import SkyGaussian2D
+from astropy.tests.helper import assert_quantity_allclose
+import pytest
+import astropy.units as u
+
+TEST_MODELS = [
+    dict(
+        name='skygaussian2d',
+        model=SkyGaussian2D(
+            amplitude=1,
+            lon_mean=0 * u.deg,
+            lat_mean=0 * u.deg,
+            sigma=1 * u.deg,
+        ),
+        test_val=0.36787944117144233,
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "spatial", TEST_MODELS, ids=[_['name'] for _ in TEST_MODELS]
+)
+def test_models(spatial):
+    model = spatial['model']
+    lon = 1 * u.deg
+    lat = 1 * u.deg
+    value = model(lon, lat)
+    assert_quantity_allclose(value, spatial['test_val'])

--- a/gammapy/image/models/tests/test_models.py
+++ b/gammapy/image/models/tests/test_models.py
@@ -10,12 +10,11 @@ TEST_MODELS = [
     dict(
         name='skygaussian2d',
         model=SkyGaussian2D(
-            amplitude=1,
-            lon_mean=0 * u.deg,
-            lat_mean=0 * u.deg,
+            lon_mean=359 * u.deg,
+            lat_mean=88 * u.deg,
             sigma=1 * u.deg,
         ),
-        test_val=0.36787944117144233,
+        test_val=0.0964148382898712 / u.deg ** 2,
     )
 ]
 
@@ -26,6 +25,6 @@ TEST_MODELS = [
 def test_models(spatial):
     model = spatial['model']
     lon = 1 * u.deg
-    lat = 1 * u.deg
+    lat = 89 * u.deg
     value = model(lon, lat)
     assert_quantity_allclose(value, spatial['test_val'])

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -503,7 +503,7 @@ class PowerLaw(SpectralModel):
     index : `~astropy.units.Quantity`
         :math:`\Gamma`
     amplitude : `~astropy.units.Quantity`
-        :math:`Phi_0`
+        :math:`\phi_0`
     reference : `~astropy.units.Quantity`
         :math:`E_0`
 


### PR DESCRIPTION
Introduce SpatialModels based on ``Parameter`` and ``ParameterList`` to be used in a cube fit. For now the model names begin with ``Sky`` in order to avoid naming conflicts with older implementations.