### PR TITLE
Change 3D model evaluation from SkyCube to Map

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -2,30 +2,20 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
-from .core import SkyCube
+from astropy.utils import lazyproperty
 
 __all__ = [
-    'CombinedModel3D',
+    'SkyModel',
+    'SkyModelMapEvaluator',
 ]
 
 
-class CombinedModel3D(object):
-    """Combine spatial and spectral model into a 3D model.
+class SkyModel(object):
+    """Sky model component.
 
-    TODO: give move infos and an example how spatial models
-    must be normalised to integrate to 1 and caveats about
-    binning effects, i.e. how too small bins or very small
-    sources will lead to incorrect spectral results!
+    This model represents a factorised sky model.
 
-    At the moment this model has no built-in integration.
-    I.e. it's left up to callers to:
-
-    * integrate over energy bins
-    * integrate over spatial pixels
-
-    TODO: This is a prototype, and the evaluation scheme might change!
-    Feedback on what you'd like to do and whether this class is working
-    for you or not is highly welcome!!!
+    TODO: add possibility to have a temporal model component also.
 
     Parameters
     ----------
@@ -33,59 +23,6 @@ class CombinedModel3D(object):
         Spatial model (must be normalised to integrate to 1)
     spectral_model : `~gammapy.spectrum.models.SpectralModel`
         Spectral model
-
-    Examples
-    --------
-    Create a `CombinedModel3D`, i.e. one that factors into a spatial
-    and position-independent spectral part::
-
-        import astropy.units as u
-        from gammapy.image.models import Shell2D
-        from gammapy.spectrum.models import PowerLaw
-        from gammapy.cube.models import CombinedModel3D
-
-        spatial_model = Shell2D(
-            amplitude=1, x_0=3, y_0=4, r_in=5, width=6, normed=True,
-        )
-        spectral_model = PowerLaw(
-            index=2, amplitude=1 * u.Unit('cm-2 s-1 TeV-1'), reference=1 * u.Unit('TeV'),
-        )
-        model = CombinedModel3D(spatial_model, spectral_model)
-
-    Look at the model you created::
-
-        >>> model
-        CombinedModel3D(spatial_model=<Shell2D(amplitude=1.0, x_0=3.0, y_0=4.0, r_in=5.0, width=6.0)>, spectral_model=PowerLaw())
-        >>> print(model.spectral_model)
-        PowerLaw
-
-        Parameters:
-
-               name     value   error       unit      min  max  frozen
-            --------- --------- ----- --------------- ---- ---- ------
-                index 2.000e+00   nan                    0 None  False
-            amplitude 1.000e+00   nan 1 / (cm2 s TeV)    0 None  False
-            reference 1.000e+00   nan             TeV None None   True
-
-        >>> print(model.spatial_model)
-        Model: Shell2D
-        Inputs: ('x', 'y')
-        Outputs: ('z',)
-        Model set size: 1
-        Parameters:
-            amplitude x_0 y_0 r_in width
-            --------- --- --- ---- -----
-                  1.0 3.0 4.0  5.0   6.0
-
-    Evaluate the model at a given point::
-
-        >>> import astropy.units as u
-        >>> model.evaluate(lon=0.1 * u.deg, lat=0.2 * u.deg, energy='1 TeV')
-        <Quantity [[[ 0.00334177]]] 1 / (cm2 deg2 s TeV)>
-
-    Evaluate the model on a sky cube::
-
-        >>> # TODO: add example.
     """
 
     def __init__(self, spatial_model, spectral_model):
@@ -94,20 +31,20 @@ class CombinedModel3D(object):
 
     def __repr__(self):
         fmt = '{}(spatial_model={!r}, spectral_model={!r})'
-        return fmt.format(self.__class__.__name__, self.spatial_model, self.spectral_model)
+        return fmt.format(self.__class__.__name__,
+                          self.spatial_model, self.spectral_model)
 
-    # TODO: decide on coordinate order and make it uniform within Gammapy
-    # see SkyCube.lookup(skycoord, energy)
-    # see sherpy_.CombinedModel3D(e_lo, e_hi, x, y)
+    def __str__(self):
+        ss = '{}\n\n'.format(self.__class__.__name__)
+        ss += 'spatial_model = {}\n\n'.format(self.spatial_model)
+        ss += 'spectral_model = {}\n'.format(self.spectral_model)
+        return ss
+
     def evaluate(self, lon, lat, energy):
         """Evaluate the model at given points.
 
         Return differential surface brightness cube.
-        At the moment in units: ``cm-2 s-1 TeV-1 sr-1``
-
-        TODO: currently spatial models don't support units,
-        and we have hard-coded in this evaluate the assumption
-        that they return their result in unit ``deg-2``
+        At the moment in units: ``cm-2 s-1 TeV-1 deg-2``
 
         Parameters
         ----------
@@ -121,49 +58,136 @@ class CombinedModel3D(object):
         value : `~astropy.units.Quantity`
             Model value at the given point.
         """
-        # Evaluate the spatial and spectral models
-        # TODO: change spatial models to work with quantities,
-        # so that these explicit unit conversions become unnecessary.
-        a = self.spatial_model(lon.to('deg').value, lat.to('deg').value) * u.Unit('deg-2')
-        b = self.spectral_model(energy)
+        val_spatial = self.spatial_model(lon, lat)
 
-        # TODO: make this more general to support all possible use cases (in an efficient way).
-        # is this a good pattern?
-        # shape = SkyCube.compute_shape(lon, lat, energy)
-        # val = a.reshape(tuple(shape)) * b.reshape(tuple(shape))
+        val_spectral = self.spectral_model(energy)
+        val_spectral = np.atleast_1d(val_spectral)[:, np.newaxis, np.newaxis]
 
-        # For now, we only support the case of scalar or 1-dim energy
-        # where the following broadcasting works:
-        val = a * np.atleast_1d(b)[:, np.newaxis, np.newaxis]
+        val = val_spatial * val_spectral
 
-        return val
+        return val.to('cm-2 s-1 TeV-1 deg-2')
 
-    def evaluate_cube(self, ref_cube):
-        """Evaluate the model on coordinates given by a reference sky cube.
 
-        Parameters
-        ----------
-        ref_cube : `~gammapy.cube.SkyCube`
-            Reference sky cube
+class SkyModelMapEvaluator(object):
+    """Sky model evaluation on maps.
+
+    This is a first attempt to compute flux as well as predicted counts maps.
+
+    The basic idea is that this evaluator is created once at the start
+    of the analysis, and pre-computes some things.
+    It it then evaluated many times during likelihood fit when model parameters
+    change, re-using pre-computed quantities each time.
+    At the moment it does some things, e.g. cache and re-use energy and coordinate grids,
+    but overall it is not an efficient implementation yet.
+
+    For now, we only make it work for 3D WCS maps with an energy axis.
+    No HPX, no other axes, those can be added later here or via new
+    separate model evaluator classes.
+
+    We should discuss how to organise the model and IRF evaluation code,
+    and things like integrations and convolutions in a good way.
+
+    Parameters
+    ----------
+    sky_model : `~gammapy.cube.models.SkyModel`
+        Sky model
+    exposure : `~gammapy.maps.Map`
+        Exposure map
+    psf : TODO
+        PSF or PSF kernel
+    """
+
+    def __init__(self, sky_model=None, exposure=None, psf=None):
+        self.sky_model = sky_model
+        self.exposure = exposure
+        self.psf = psf
+
+    @lazyproperty
+    def geom(self):
+        return self.exposure.geom
+
+    @lazyproperty
+    def geom_image(self):
+        return self.geom.to_image()
+
+    @lazyproperty
+    def energy_center(self):
+        """Energy axis bin centers (`~astropy.units.Quantity`)"""
+        energy_axis = self.geom.axes[0]
+        energy = energy_axis.center * energy_axis.unit
+        return energy
+
+    @lazyproperty
+    def energy_edges(self):
+        """Energy axis bin edges (`~astropy.units.Quantity`)"""
+        energy_axis = self.geom.axes[0]
+        energy = energy_axis.edges * energy_axis.unit
+        return energy
+
+    @lazyproperty
+    def energy_bin_width(self):
+        """Energy axis bin widths (`astropy.units.Quantity`)"""
+        return np.diff(self.energy_edges)
+
+    @lazyproperty
+    def lon_lat(self):
+        """Spatial coordinate pixel centers.
+
+        Returns ``lon, lat`` tuple of `~astropy.units.Quantity`.
+        """
+        lon, lat = self.geom_image.get_coord()
+        return lon * u.deg, lat * u.deg
+
+    @lazyproperty
+    def lon(self):
+        return self.lon_lat[0]
+
+    @lazyproperty
+    def lat(self):
+        return self.lon_lat[1]
+
+    @lazyproperty
+    def solid_angle(self):
+        """Solid angle per pixel"""
+        return self.geom.solid_angle()
+
+    @lazyproperty
+    def bin_volume(self):
+        """Map pixel bin volume (solid angle times energy bin width)."""
+        omega = self.solid_angle
+        de = self.energy_bin_width
+        de = de[:, np.newaxis, np.newaxis]
+        return omega * de
+
+    def compute_dnde(self):
+        """Compute model differential flux at map pixel centers.
 
         Returns
         -------
-        model_cube : `~gammapy.cube.SkyCube`
+        model_map : `~gammapy.map.Map`
             Sky cube with data filled with evaluated model values.
-            Units: ``cm-2 s-1 TeV-1 sr-1``
+            Units: ``cm-2 s-1 TeV-1 deg-2``
         """
-        # Extract grid of coordinates (lon, lat, energy) from the cube
-        coords = ref_cube.sky_image_ref.coordinates()
-        lon = coords.data.lon
-        lat = coords.data.lat
-        energy = ref_cube.energies(mode='center')
+        coord = (self.lon, self.lat, self.energy_center)
+        dnde = self.sky_model.evaluate(*coord)
+        return dnde
 
-        data = self.evaluate(lon, lat, energy)
+    def compute_flux(self):
+        """Compute model integral flux over map pixel volumes.
 
-        # TODO: Fix this so that explicit unit conversion here become unnecessary
-        # The problem at the moment is that here we have quantities with
-        # a unit scale != 1, and `.write('cube.fits')` errors out for a SkyCube with such a Quantity.
-        # This is a temp quick fix:
-        data = data.to('cm-2 s-1 TeV-1 sr-1')
+        For now, we simply multiply dnde with bin volume.
+        """
+        dnde = self.compute_dnde()
+        volume = self.bin_volume
+        flux = dnde * volume
+        return flux.to('cm-2 s-1')
 
-        return SkyCube(data=data, wcs=ref_cube.wcs, energy_axis=ref_cube.energy_axis)
+    def compute_npred(self):
+        """Evaluate model predicted counts.
+
+        For now, we simply multiply flux with exposure.
+        """
+        flux = self.compute_flux()
+        exposure = self.exposure.quantity
+        npred = flux * exposure
+        return npred.to('').value

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -18,12 +18,11 @@ from .. import SkyCube
 
 
 def make_test_spectral_model():
-    emin, emax = 1 * u.TeV, 100 * u.TeV,
     return PowerLaw2(
-        amplitude=1e-12 * u.Unit('1 / (s sr cm2)'),
+        amplitude='1e-12 cm-2 s-1 sr-1',
         index=2,
-        emin=emin,
-        emax=emax,
+        emin='1 TeV',
+        emax='100 TeV',
     )
 
 

--- a/gammapy/cube/utils.py
+++ b/gammapy/cube/utils.py
@@ -9,10 +9,11 @@ from .core import SkyCube
 
 __all__ = [
     'compute_npred_cube',
-    'compute_npred_cube_simple',
 ]
 
 
+# TODO: remove this!
+# If useful, add to the new SkyModelMapEvaluator
 def compute_npred_cube(flux_cube, exposure_cube, ebounds,
                        integral_resolution=10):
     """Compute predicted counts cube.
@@ -32,10 +33,6 @@ def compute_npred_cube(flux_cube, exposure_cube, ebounds,
     -------
     npred_cube : `SkyCube`
         Predicted counts cube with energy bounds as given by the input ``ebounds``.
-
-    See also
-    --------
-    compute_npred_cube_simple
 
     Examples
     --------
@@ -60,8 +57,6 @@ def compute_npred_cube(flux_cube, exposure_cube, ebounds,
         kernels = psf.kernels(npred_cube)
         npred_cube_convolved = npred_cube.convolve(kernels)
     """
-    _validate_inputs(flux_cube, exposure_cube)
-
     # Make an empty cube with the requested energy binning
     sky_geom = exposure_cube.sky_image_ref
     energies = EnergyBounds(ebounds)
@@ -81,48 +76,3 @@ def compute_npred_cube(flux_cube, exposure_cube, ebounds,
         npred_cube.data[idx] = npred.to('')
 
     return npred_cube
-
-
-def compute_npred_cube_simple(flux_cube, exposure_cube):
-    """Compute predicted counts cube (using a simple method).
-
-    * Simply multiplies flux and exposure and pixel solid angle and energy bin width.
-    * No spatial reprojection, or interpolation or integration in energy.
-    * This is very fast, but can be inaccurate (e.g. for very large energy bins.)
-    * If you want a more fancy method, call `compute_npred_cube` instead.
-
-    Output cube energy bounds will be the same as for the exposure cube. 
-
-    Parameters
-    ----------
-    flux_cube : `SkyCube`
-        Differential flux cube
-    exposure_cube : `SkyCube`
-        Exposure cube
-
-    Returns
-    -------
-    npred_cube : `SkyCube`
-        Predicted counts cube
-
-    See also
-    --------
-    compute_npred_cube
-    """
-    _validate_inputs(flux_cube, exposure_cube)
-
-    bin_size = exposure_cube.bin_size
-    flux = flux_cube.data
-    exposure = exposure_cube.data
-    npred = flux * exposure * bin_size
-
-    npred_cube = SkyCube.empty_like(exposure_cube)
-    npred_cube.data = npred.to('')
-    return npred_cube
-
-
-def _validate_inputs(flux_cube, exposure_cube):
-    if flux_cube.data.shape[1:] != exposure_cube.data.shape[1:]:
-        raise ValueError('flux_cube and exposure cube must have the same shape!\n'
-                         'flux_cube: {0}\nexposure_cube: {1}'
-                         ''.format(flux_cube.data.shape[1:], exposure_cube.data.shape[1:]))


### PR DESCRIPTION
This PR changes the 3D model evaluation from SkyCube to Map.

@joleroi @registerrier  - I'm just starting to work on this now, but I wanted to open the PR early to avoid conflicts of us editing the same code. I will try to keep my edits limited to the five files that I started to edit here. That should avoid overlap e.g. with #1377 or @registerrier with any edits e.g. in `new.py` or `test_new.py` if you have time to work on those.