### PR TITLE
Change test with assert_quantity_allclose to explicit unit checks

### DIFF
--- a/gammapy/astro/source/tests/test_pulsar.py
+++ b/gammapy/astro/source/tests/test_pulsar.py
@@ -4,8 +4,7 @@ from numpy.testing import assert_allclose
 import numpy as np
 from astropy.units import Quantity
 from astropy.table import Table
-from astropy.tests.helper import assert_quantity_allclose
-from ....utils.testing import requires_dependency
+from ....utils.testing import requires_dependency, assert_quantity_allclose
 from ...source import Pulsar, SimplePulsar
 
 pulsar = Pulsar()

--- a/gammapy/background/tests/test_energy_offset_array.py
+++ b/gammapy/background/tests/test_energy_offset_array.py
@@ -3,11 +3,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_equal
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.table import Table
 from astropy.coordinates import Angle
 from ...data import DataStore, EventList
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, assert_quantity_allclose
 from ...utils.energy import EnergyBounds, Energy
 from ..energy_offset_array import EnergyOffsetArray
 from ..fov_cube import FOVCube
@@ -116,7 +115,7 @@ def test_evaluate_at_energy():
     e_eval = energy[0]
     interpol_param = dict(method='nearest', bounds_error=False)
     table_energy = array.evaluate_at_energy(e_eval, interpol_param)
-    assert_quantity_allclose(table_energy["offset"], array.offset_bin_center)
+    assert_quantity_allclose(table_energy["offset"].quantity, array.offset_bin_center)
     # Offset bin for the first event is 23
     assert_equal(table_energy["value"][23], 1)
 
@@ -127,7 +126,7 @@ def test_evaluate_at_offset():
     off_eval = offset[0]
     interpol_param = dict(method='nearest', bounds_error=False)
     table_offset = array.evaluate_at_offset(off_eval, interpol_param)
-    assert_quantity_allclose(table_offset["energy"], array.energy.log_centers)
+    assert_quantity_allclose(table_offset["energy"].quantity, array.energy.log_centers)
     # Energy bin for the first event is 2
     assert_equal(table_offset["value"][2], 1)
 
@@ -149,7 +148,7 @@ def test_acceptance_curve_in_energy_band():
     bins = 100
     interpol_param = dict(method='nearest', bounds_error=False)
     table_energy = array.acceptance_curve_in_energy_band(energ_range, bins, interpol_param)
-    assert_quantity_allclose(table_energy["offset"], array.offset_bin_center)
+    assert_quantity_allclose(table_energy["offset"].quantity, array.offset_bin_center)
     assert_quantity_allclose(table_energy["Acceptance"][23] * table_energy["Acceptance"].unit,
                              1 * array.energy.bands[2].to('MeV'))
     assert_quantity_allclose(table_energy["Acceptance"][59] * table_energy["Acceptance"].unit,

--- a/gammapy/background/tests/test_fov_cube.py
+++ b/gammapy/background/tests/test_fov_cube.py
@@ -1,12 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
 from astropy.units import Quantity
 from astropy.coordinates import Angle
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, assert_quantity_allclose
 from ...datasets import make_test_bg_cube_model
 from ...data import DataStore
 from ..fov_cube import FOVCube

--- a/gammapy/background/tests/test_models.py
+++ b/gammapy/background/tests/test_models.py
@@ -1,15 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
 from astropy.table import Table
 import astropy.units as u
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
-from regions import CircleSkyRegion
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, assert_quantity_allclose
 from ...utils.energy import EnergyBounds
 from ...data import ObservationTable, DataStore, EventList
 from ...background.models import _compute_pie_fraction, _select_events_outside_pie

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data, requires_dependency, assert_quantity_allclose
 from ...image import SkyImage
 from ...data import DataStore
 from ..reflected import ReflectedRegionsFinder, ReflectedRegionsBackgroundEstimator

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 from collections import OrderedDict
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
-
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.table import Table, Column
 from astropy.units import Quantity
+from ...utils.testing import assert_quantity_allclose
 from ..core import SourceCatalog
 from ...image import SkyImage
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -4,11 +4,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
+from ...utils.testing import requires_data, requires_dependency
 from ..fermi import SourceCatalog3FGL, SourceCatalog2FHL, SourceCatalog1FHL, SourceCatalog3FHL
 from ...spectrum.models import (PowerLaw, LogParabola, ExponentialCutoffPowerLaw3FGL,
                                 PLSuperExpCutoff3FGL)
-from ...utils.testing import requires_data, requires_dependency
 
 SOURCES_3FGL = [
     dict(

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -2,10 +2,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
 from astropy import units as u
 from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import assert_quantity_allclose
 from ..gammacat import SourceCatalogGammaCat
 from ..gammacat import GammaCatResource, GammaCatResourceIndex
 

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import Counter
 import pytest
 from numpy.testing.utils import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 from astropy import units as u
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ...image import SkyImage
 from ...spectrum.models import PowerLaw, ExponentialCutoffPowerLaw

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import textwrap
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from regions import CircleSkyRegion
 from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import assert_quantity_allclose
 from ...utils.energy import Energy, EnergyBounds
 from ...image import SkyImage
 from ...data import EventList

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EffectiveAreaTable2D, Background3D
 from .. import make_exposure_cube, make_background_cube

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data
 from ...irf import EffectiveAreaTable2D, Background3D
 from ...maps import WcsNDMap, WcsGeom, MapAxis

--- a/gammapy/cube/tests/test_utils.py
+++ b/gammapy/cube/tests/test_utils.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import assert_quantity_allclose
 from ...datasets import FermiVelaRegion
-from .. import compute_npred_cube
+from ..utils import compute_npred_cube
 from ..core import SkyCube
 from .test_core import make_test_sky_cube
 

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.units import Quantity
@@ -10,7 +9,7 @@ import astropy.units as u
 from astropy.time import Time
 from ...data import DataStore, DataManager, ObservationList
 from ...utils.testing import data_manager, requires_data, requires_dependency
-from ...utils.testing import assert_time_allclose, assert_skycoord_allclose
+from ...utils.testing import assert_quantity_allclose, assert_time_allclose, assert_skycoord_allclose
 from ...utils.energy import Energy
 from ...datasets import gammapy_extra
 from ...utils.energy import EnergyBounds

--- a/gammapy/data/tests/test_observationlist.py
+++ b/gammapy/data/tests/test_observationlist.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import Angle
 from astropy.coordinates import SkyCoord
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.energy import EnergyBounds, Energy
 from ...data import DataStore, ObservationList

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -2,11 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing.utils import assert_allclose
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
 from astropy.units import Quantity
 from astropy.coordinates import Angle
-
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...datasets import (
     FermiLATDataset,

--- a/gammapy/datasets/tests/test_make.py
+++ b/gammapy/datasets/tests/test_make.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
-import numpy as np
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
+import numpy as np
 from astropy.coordinates import Angle
 from astropy.units import Quantity
+from ...utils.testing import assert_quantity_allclose
 from ...datasets import (make_test_psf, make_test_observation_table,
                          make_test_bg_cube_model, make_test_dataset)
 from ...data import DataStore

--- a/gammapy/image/models/tests/test_models.py
+++ b/gammapy/image/models/tests/test_models.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
+from ....utils.testing import assert_quantity_allclose
 from ....utils.testing import requires_dependency, requires_data
 from ..new import (
     SkyGaussian2D, SkyPointSource, SkyDisk2D, SkyShell2D, SkyTemplate2D,

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.table import Table
@@ -7,10 +8,9 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy.io import fits
 from astropy import units as u
 from astropy.units import Quantity
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
 from astropy.wcs import WcsError
 from regions import PixCoord, CirclePixelRegion, CircleSkyRegion
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...data import DataStore, EventList
 from ...datasets import load_poisson_stats_image

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.units import Quantity
 from astropy.modeling.models import Gaussian2D
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency
 from ...image import (measure_labeled_regions,
                       measure_containment_radius,

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -5,8 +5,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import Angle
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, mpl_savefig_check
 from ...image import SkyImage
 from ..profile import compute_binning, ImageProfile, ImageProfileEstimator

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose, assert_equal
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
 

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data, data_manager
 
 productions = [

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
-from astropy.units import Quantity
 from astropy.coordinates import Angle
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data
 from ...irf import PSFKing
 

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -2,11 +2,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
 from astropy.units import Quantity
 from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import assert_quantity_allclose
 from ...datasets import gammapy_extra
 from ...datasets import FermiGalacticCenter
 from ...irf import TablePSF, EnergyDependentTablePSF

--- a/gammapy/scripts/tests/test_cta_irf.py
+++ b/gammapy/scripts/tests/test_cta_irf.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
 from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check
+from ...utils.testing import assert_quantity_allclose
 from ..cta_irf import CTAIrf, CTAPerf
 
 

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 from numpy.testing import assert_allclose
 import numpy as np
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency
 from ...utils.energy import EnergyBounds
 from .. import CountsSpectrum, PHACountsSpectrum

--- a/gammapy/spectrum/tests/test_cosmic_ray.py
+++ b/gammapy/spectrum/tests/test_cosmic_ray.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...spectrum import cosmic_ray_flux
 
 

--- a/gammapy/spectrum/tests/test_crab.py
+++ b/gammapy/spectrum/tests/test_crab.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
+import astropy.units as u
+from ...utils.testing import assert_quantity_allclose
 from ...spectrum import CrabSpectrum
 
 CRAB_SPECTRA = [

--- a/gammapy/spectrum/tests/test_diffuse.py
+++ b/gammapy/spectrum/tests/test_diffuse.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...spectrum import diffuse_gamma_ray_flux
 
 

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ..core import PHACountsSpectrum
 from ..observation import SpectrumObservation, SpectrumObservationList

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...spectrum import SpectrumExtraction, SpectrumObservation
 from ...background.tests.test_reflected import bkg_estimator, obs_list

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
 import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.random import get_random_state
 from ...irf import EffectiveAreaTable

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
 from astropy.table import Table
 import astropy.units as u
 from ...catalog.fermi import SourceCatalog3FGL
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, assert_quantity_allclose
 from ...utils.modeling import ParameterList
 from ..results import SpectrumResult
 from ..fit import SpectrumFit
@@ -274,11 +273,11 @@ class FluxPointTester:
 
         actual = result.flux_point_residuals[0][0]
         desired = self.config['res']
-        assert_quantity_allclose(actual, desired, rtol=self.rtol)
+        assert_allclose(actual, desired, rtol=self.rtol)
 
         actual = result.flux_point_residuals[1][0]
         desired = self.config['res_err']
-        assert_quantity_allclose(actual, desired, rtol=self.rtol)
+        assert_allclose(actual, desired, rtol=self.rtol)
 
         result.plot(energy_range=[1, 10] * u.TeV)
 
@@ -289,7 +288,7 @@ class TestFluxPointProfiles:
         filename = '$GAMMAPY_EXTRA/datasets/spectrum/llsed_hights.fits'
         self.sed = FluxPointProfiles.read(filename)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(run=False)
     @requires_dependency('matplotlib')
     def test_plot(self):
         self.sed.plot()

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -1,16 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import astropy.units as u
-from gammapy.utils.energy import EnergyBounds
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
+import astropy.units as u
+from ...utils.energy import EnergyBounds
+from ...utils.testing import assert_quantity_allclose
+from ...utils.testing import requires_dependency, requires_data
+from ...scripts import CTAPerf
 from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
                       ExponentialCutoffPowerLaw3FGL, LogParabola,
                       TableModel, AbsorbedSpectralModel, Absorption)
-from ...utils.testing import requires_dependency, requires_data
-from ...scripts import CTAPerf
-from gammapy.scripts.cta_utils import CTAObservationSimulation, Target, ObservationParameters
-from gammapy.spectrum import SpectrumObservationList, SpectrumFit
+from ...scripts.cta_utils import CTAObservationSimulation, Target, ObservationParameters
+from ...spectrum import SpectrumObservationList, SpectrumFit
 
 
 def table_model():

--- a/gammapy/spectrum/tests/test_obs_group.py
+++ b/gammapy/spectrum/tests/test_obs_group.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from astropy.tests.helper import assert_quantity_allclose
 import pytest
 from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import assert_quantity_allclose
 from ...data import ObservationTable
 from ...datasets import gammapy_extra
 from ..obs_group import group_obs_table, SpectrumObservationGrouping

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
 from ...utils.scripts import make_path
 from ...irf import EffectiveAreaTable, EnergyDispersion

--- a/gammapy/spectrum/tests/test_powerlaw.py
+++ b/gammapy/spectrum/tests/test_powerlaw.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
+from ...utils.testing import assert_quantity_allclose
 from ..powerlaw import (
     power_law_pivot_energy,
     power_law_energy_flux,

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from astropy.tests.helper import assert_quantity_allclose
 import astropy.units as u
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 from ..models import PowerLaw
 from .. import SpectrumObservation, SpectrumFitResult

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose
-import pytest
+from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency
 from ...irf import EffectiveAreaTable, EnergyDispersion
 from ...spectrum import LogEnergyAxis, integrate_spectrum, CountsPredictor

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -7,11 +7,10 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy.time import Time
 import astropy.units as u
 from astropy.table import Table, Column
-from astropy.tests.helper import assert_quantity_allclose
 from regions import CircleSkyRegion
-from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check, assert_time_allclose
+from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check
+from ...utils.testing import assert_quantity_allclose
 from ...utils.energy import EnergyBounds
-from ...utils.time import time_ref_to_dict, time_relative_to_ref
 from ...data import Target, DataStore
 from ...spectrum import SpectrumExtraction
 from ...spectrum.models import PowerLaw

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import os
 import pytest
+import numpy as np
+import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
@@ -13,6 +15,7 @@ from ..datasets import gammapy_extra
 __all__ = [
     'requires_dependency',
     'requires_data',
+    'assert_quantity_allclose',
     'assert_wcs_allclose',
     'assert_skycoord_allclose',
     'assert_time_allclose',
@@ -185,3 +188,42 @@ def mpl_savefig_check():
     import matplotlib.pyplot as plt
     from io import BytesIO
     plt.savefig(BytesIO(), format='png')
+
+
+def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, **kwargs):
+    # TODO: change this later to explicitly check units are the same!
+    # assert actual.unit == desired.unit
+    args = _unquantify_allclose_arguments(actual, desired, rtol, atol)
+    assert_allclose(*args, **kwargs)
+
+
+def _unquantify_allclose_arguments(actual, desired, rtol, atol):
+    actual = u.Quantity(actual, subok=True, copy=False)
+
+    desired = u.Quantity(desired, subok=True, copy=False)
+    try:
+        desired = desired.to(actual.unit)
+    except u.UnitsError:
+        raise u.UnitsError("Units for 'desired' ({0}) and 'actual' ({1}) "
+                           "are not convertible"
+                           .format(desired.unit, actual.unit))
+
+    if atol is None:
+        # by default, we assume an absolute tolerance of 0
+        atol = u.Quantity(0)
+    else:
+        atol = u.Quantity(atol, subok=True, copy=False)
+        try:
+            atol = atol.to(actual.unit)
+        except u.UnitsError:
+            raise u.UnitsError("Units for 'atol' ({0}) and 'actual' ({1}) "
+                               "are not convertible"
+                               .format(atol.unit, actual.unit))
+
+    rtol = u.Quantity(rtol, subok=True, copy=False)
+    try:
+        rtol = rtol.to(u.dimensionless_unscaled)
+    except Exception:
+        raise u.UnitsError("`rtol` should be dimensionless")
+
+    return actual.value, desired.value, rtol.value, atol.value

--- a/gammapy/utils/tests/test_random.py
+++ b/gammapy/utils/tests/test_random.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ..random import sample_sphere, sample_powerlaw, sample_sphere_distance
 
 

--- a/gammapy/utils/tests/test_wcs.py
+++ b/gammapy/utils/tests/test_wcs.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.coordinates import Angle
-from astropy.tests.helper import assert_quantity_allclose
+from ...utils.testing import assert_quantity_allclose
 from ...utils.wcs import (linear_wcs_to_arrays,
                           linear_arrays_to_wcs)
 


### PR DESCRIPTION
A change in Astropy master from yesterday (https://github.com/astropy/astropy/pull/7252#issuecomment-381882939) broke some of our tests (https://travis-ci.org/gammapy/gammapy/jobs/367497442#L3786)

The error message is now no longer useful if the quantities are different:
```
>>> from astropy.tests.helper import assert_quantity_allclose
>>> import astropy.units as u
>>> assert_quantity_allclose(42 * u.m, 44 * u.m)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/Library/Python/3.6/lib/python/site-packages/astropy/tests/helper.py", line 466, in assert_quantity_allclose
    assert _quantity_allclose(actual, desired, rtol=rtol, atol=atol, **kwargs)
AssertionError
```

But I never liked `assert_quantity_allclose` anyways, because it passes if quantity value and unit change, but the quantity is the same:
```
>>> assert_quantity_allclose(42 * u.m, 4200 * u.cm)
```
Units shouldn't change without good reason and code changes, so I prefer to explicitly check value and unit, using `numpy.testing.assert_allclose` for the data and a separate assert statement for the unit. It's one extra line, and we could introduce our own helper function for that. But for now, I'll just change to have these two lines.