### PR TITLE
Update 3D fitting example script

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+import copy
 import astropy.units as u
 from astropy.utils import lazyproperty
+from ..utils.modeling import ParameterList
 
 __all__ = [
     'SkyModel',
@@ -28,6 +30,29 @@ class SkyModel(object):
     def __init__(self, spatial_model, spectral_model):
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
+
+    @property
+    def n_spatial(self):
+        """Number of spatial parameters"""
+        return len(self.spatial_model.parameters.parameters)
+
+    @property
+    def n_spectral(self):
+        """Number of spectral parameters"""
+        return len(self.spectral_model.parameters.parameters)
+
+    # TODO: Think about how to deal with covariance matrix
+    @property
+    def parameters(self):
+        val = self.spatial_model.parameters.parameters + self.spectral_model.parameters.parameters
+        return ParameterList(val)
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """Update parameters
+        """
+        self.spatial_model.parameters.parameters = parameters.parameters[:self.n_spatial]
+        self.spectral_model.parameters.parameters = parameters.parameters[self.n_spatial:]
 
     def __repr__(self):
         fmt = '{}(spatial_model={!r}, spectral_model={!r})'
@@ -66,6 +91,10 @@ class SkyModel(object):
         val = val_spatial * val_spectral
 
         return val.to('cm-2 s-1 TeV-1 deg-2')
+
+    def copy(self):
+        """A deep copy"""
+        return copy.deepcopy(self)
 
 
 class SkyModelMapEvaluator(object):

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -40,8 +40,8 @@ def fit_minuit(parameters, function):
     minuit_kwargs = make_minuit_kwargs(parameters)
 
     minuit = Minuit(minuit_func.fcn,
-               forced_parameters=parameters.names,
-               **minuit_kwargs)
+                    forced_parameters=parameters.names,
+                    **minuit_kwargs)
 
     minuit.migrad()
     return parameters, minuit
@@ -76,5 +76,8 @@ def make_minuit_kwargs(parameters):
         kwargs[par.name] = par.value
         if par.frozen:
             kwargs['fix_{}'.format(par.name)] = True
+        limits = par.parmin, par.parmax
+        limits = np.where(np.isnan(limits), None, limits)
+        kwargs['limit_{}'.format(par.name)] = limits
 
     return kwargs

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -31,3 +31,19 @@ def test_iminuit():
     assert_allclose(minuit.values['x'], 2, rtol=1e-2)
     assert_allclose(minuit.values['y'], 3, rtol=1e-2)
     assert_allclose(minuit.values['z'], 4, rtol=1e-2)
+
+    # Test freeze
+    pars_in['x'].frozen = True
+    pars_out, minuit = fit_minuit(function=f, parameters=pars_in)
+    assert minuit.list_of_fixed_param() == ['x']
+
+    # Test limits
+    pars_in['y'].parmin = 4
+    pars_out, minuit = fit_minuit(function=f, parameters=pars_in)
+    states = minuit.get_param_states()
+    assert not states[0]['has_limits']
+    assert not states[2]['has_limits']
+
+    assert states[1]['has_limits']
+    assert states[1]['lower_limit'] == 4
+    assert states[1]['upper_limit'] == 0


### PR DESCRIPTION
This PR modifies the example script for 3D fitting to use with iminuit backend added in #1335 
The fit converges but is quite slow and requires some tweaking of the input parameters. Most annoyingly I had to play a lot with the minimum of the ``amplitude`` parameter to keep the fit from setting ``amplitude=0``. I guess adapting the minuit stepsize could already help, I will look into this.

```
INFO: Starting values
ParameterList
Parameter(name='lon_0', value=0.0, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='lat_0', value=0.0, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='sigma', value=1.0, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='index', value=2, unit='', min=nan, max=nan, frozen=False)
Parameter(name='amplitude', value=1e-10, unit='1 / (cm2 s TeV)', min=1e-12, max=nan, frozen=False)
Parameter(name='reference', value=1.0, unit='TeV', min=nan, max=nan, frozen=True)

Covariance: 
None [__main__]
INFO: Best fit values
ParameterList
Parameter(name='lon_0', value=0.19999767344948793, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='lat_0', value=0.0999974320886449, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='sigma', value=0.19999884967532772, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='index', value=3.000575227144423, unit='', min=nan, max=nan, frozen=False)
Parameter(name='amplitude', value=1.0008549544693324e-11, unit='1 / (cm2 s TeV)', min=1e-12, max=nan, frozen=False)
Parameter(name='reference', value=1.0, unit='TeV', min=nan, max=nan, frozen=True)

Covariance: 
None [__main__]
INFO: True values
ParameterList
Parameter(name='lon_0', value=0.2, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='lat_0', value=0.1, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='sigma', value=0.2, unit='deg', min=nan, max=nan, frozen=False)
Parameter(name='index', value=3, unit='', min=nan, max=nan, frozen=False)
Parameter(name='amplitude', value=1e-11, unit='1 / (cm2 s TeV)', min=nan, max=nan, frozen=False)
Parameter(name='reference', value=1.0, unit='TeV', min=nan, max=nan, frozen=True)

Covariance: 
None [__main__]

real    0m19.183s
user    0m18.992s
sys     0m0.185s
```