### PR TITLE
Add a PSF map kernel class

### DIFF
--- a/examples/example_fermi_psf.py
+++ b/examples/example_fermi_psf.py
@@ -19,6 +19,7 @@ fermi_psf = EnergyDependentTablePSF.read(filename)
 # psf = fermi_psf.table_psf_at_energy(energy=energy)
 psf = fermi_psf.table_psf_in_energy_band(energy_band=energy_band, spectral_index=2.5)
 psf.normalize()
+import IPython; IPython.embed()
 kernel = psf.kernel(pixel_size=pixel_size, offset_max=offset_max)
 kernel_image = kernel.value
 

--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -11,3 +11,4 @@ from .cube_pipe import *
 from .basic_cube import *
 from .fit import *
 from .new import *
+from .psf import *

--- a/gammapy/cube/psf.py
+++ b/gammapy/cube/psf.py
@@ -1,0 +1,113 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.convolution.utils import discretize_oversample_2D
+from astropy.coordinates import Angle
+from ..image.models import Gauss2DPDF
+from ..irf import TablePSF
+from ..maps import WcsNDMap
+
+__all__ = [
+    'WcsNDMapPSFKernel',
+]
+
+
+class WcsNDMapPSFKernel(object):
+    """PSF kernel for `~gammapy.maps.WcsNDMap`.
+
+    This is a container class to store a PSF kernel
+    that can be used to convolve `~gammapy.maps.WcsNDMap` objects.
+    It is usually computed for a given sky position as the
+    mean PSF for a list of observations.
+
+    It is very preliminary, for now the goal is just to get the
+    case of 3D maps with an energy axis working.
+
+    For now, we store the PSF itself in a `~gammapy.maps.WcsNDMap`
+    object. That should be considered an implementation detail
+    that we might or might not keep later. For now it saves us the
+    trouble of developing code for extra axes and FITS I/O.
+
+    Parameters
+    ----------
+    psf_map : `~gammapy.maps.WcsNDMap`
+        PSF data
+    """
+
+    def __init__(self, psf_map):
+        self._psf_map = psf_map
+
+    @classmethod
+    def from_map(cls, psf_map):
+        return cls(psf_map)
+
+    @classmethod
+    def read(cls, *args, **kwargs):
+        psf_map = WcsNDMap.read(*args, **kwargs)
+        return cls.from_map(psf_map)
+
+    @classmethod
+    def from_gauss(cls, geom, sigma, rad_max=None, containment_fraction=0.99):
+        """Create Gaussian PSF.
+
+        This is used for testing and examples.
+
+        The map geometry parameters (pixel size, energy bins)
+        are taken from `geom`.
+
+        The Gaussian width ``sigma`` can be a scalar,
+        or an array if it should vary along the energy axis.
+
+        Parameters
+        ----------
+        geom : `~gammapy.map.WcsGeom`
+            Map geometry
+        sigma : `~astropy.coordinates.Angle`
+            Gaussian width
+        rad_max : `~astropy.coordinates.Angle`
+            Desired kernel width
+        """
+        sigma = Angle(sigma)
+        if rad_max is None:
+            rad_max = Gauss2DPDF(sigma.to('deg').value).containment_radius(
+                containment_fraction=containment_fraction
+            )
+        rad_max = Angle(rad_max)
+        pixel_size = np.abs(geom.wcs.wcs.cdelt)
+        psf = TablePSF.from_shape(shape='gauss', width=sigma)
+        npix = int(rad_max.radian / pixel_size.radian)
+        data = table_psf_to_kernel_array(psf, npix)
+
+        m = WcsNDMap.from_geom(geom)
+        m.data = data
+
+        return cls.from_map(m)
+
+    def to_map(self):
+        return self._psf_map
+
+    def write(self, *args, **kwargs):
+        psf_map = self.to_map()
+        psf_map.write(*args, **kwargs)
+
+
+def table_psf_to_kernel_array(psf, npix, pixel_size, normalize=True, factor=5):
+    """Compute oversampled
+
+    Parameters
+    ----------
+    TODO
+    """
+    def f(x, y):
+        rad = np.sqrt(x * x + y * y) * pixel_size
+        return psf.evaluate(rad)
+
+    pix_range = (-npix, npix + 1)
+
+    kernel = discretize_oversample_2D(
+        f, x_range=pix_range, y_range=pix_range, factor=factor
+    )
+    if normalize:
+        kernel = kernel / kernel.sum()
+
+    return kernel

--- a/gammapy/cube/tests/test_psf.py
+++ b/gammapy/cube/tests/test_psf.py
@@ -1,0 +1,29 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+import astropy.units as u
+from ...maps import MapAxis, WcsGeom, Map
+from ..psf import WcsNDMapPSFKernel
+
+
+@pytest.fixture(scope='session')
+def geom():
+    axis = MapAxis.from_edges(np.logspace(-1, 1, 3), unit=u.TeV)
+    return WcsGeom.create(skydir=(0, 0), npix=(5, 4), coordsys='GAL', axes=[axis])
+
+
+@pytest.fixture(scope='session')
+def exposure(geom):
+    m = Map.from_geom(geom)
+    m.quantity = np.ones((2, 4, 5)) * u.Quantity('100 m2 s')
+    return m
+
+
+@pytest.fixture(scope='session')
+def psf(geom):
+    return WcsNDMapPSFKernel.from_gauss(geom, sigma='0.3 deg')
+
+
+def test_psf_kernel_create(psf):
+    assert psf.data


### PR DESCRIPTION
This PR adds a PSF map kernel class.

It's work in progress, no need to review at this point; I just wanted to mention it to you @joleroi @registerrier that I started implementing this, to avoid overlap if you're also working on Gammapy this week.