### PR TITLE
Fix PHA filename for stacked observation

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -320,22 +320,26 @@ class PHACountsSpectrum(CountsSpectrum):
 
     @property
     def phafile(self):
-        """PHA file associated with the observations"""
-        return 'pha_obs{}.fits'.format(self.obs_id)
+        """PHA file associated with the observation"""
+        if isinstance(self.obs_id, list):
+            filename = 'pha_stacked.fits'
+        else:
+            filename = 'pha_obs{}.fits'.format(self.obs_id)
+        return filename
 
     @property
     def arffile(self):
-        """ARF associated with the observations"""
+        """ARF associated with the observation"""
         return self.phafile.replace('pha', 'arf')
 
     @property
     def rmffile(self):
-        """RMF associated with the observations"""
+        """RMF associated with the observation"""
         return self.phafile.replace('pha', 'rmf')
 
     @property
     def bkgfile(self):
-        """Background PHA files associated with the observations"""
+        """Background PHA files associated with the observation"""
         return self.phafile.replace('pha', 'bkg')
 
     @property

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -196,6 +196,7 @@ class TestSpectrumObservationStacker:
 
     def test_basic(self):
         assert 'Stacker' in str(self.obs_stacker)
+        assert 'stacked' in str(self.obs_stacker.stacked_obs.on_vector.phafile)
         counts1 = self.obs_list[0].total_stats_safe_range.n_on
         counts2 = self.obs_list[1].total_stats_safe_range.n_on
         summed_counts = counts1 + counts2


### PR DESCRIPTION
A stacked observation has a ``list`` of observation ids stored as ``obs_id``. This lead to funny PHAfilenames.