### PR TITLE
Add get_mapcoord to gammapy.maps.Geom 

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -223,7 +223,7 @@ class Map(object):
         if 'META' in header:
             meta = json.loads(header['META'], object_pairs_hook=OrderedDict)
         else:
-            meta = {}
+            meta = OrderedDict()
         return meta
 
     @staticmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1063,6 +1063,17 @@ class MapGeom(object):
         """
         pass
 
+    def get_mapcoord(self):
+        """Returns a MapCoord for this `~gammapy.maps.Geom` object.
+        """
+        coord_tuple = self.get_coord()
+        cdict = dict(lon=coord_tuple[0], lat=coord_tuple[1])
+        for i,axis in enumerate(self.axes):
+            cdict.update({axis.name:coord_tuple[i+2]})
+
+        return MapCoord.create(cdict, coordsys=self.coordsys)
+
+
     def coord_to_idx(self, coords, clip=False):
         """Convert map coordinates to pixel indices.
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -620,10 +620,11 @@ class MapCoord(object):
         Spatial coordinate system.  If None then the coordinate system
         will be set to the native coordinate system of the geometry.
     copy : bool
-        Make copies of the input arrays.  If False then this object will store views.
+        Make copies of the input arrays?
+        If False then this object will store views.
     match_by_name : bool
-        Match coordinates to axes by name.  If false coordinates will
-        be matched by index.
+        Match coordinates to axes by name?
+        If false coordinates will be matched by index.
     """
 
     def __init__(self, data, coordsys=None, copy=False, match_by_name=True):
@@ -690,9 +691,9 @@ class MapCoord(object):
 
     @classmethod
     def _from_lonlat(cls, coords, coordsys=None, copy=False):
-        """Create a `~MapCoord` from a tuple of coordinate vectors.  The first
-        two elements of the tuple should be longitude and latitude in
-        degrees.
+        """Create a `~MapCoord` from a tuple of coordinate vectors.
+
+        The first two elements of the tuple should be longitude and latitude in degrees.
 
         Parameters
         ----------
@@ -777,9 +778,10 @@ class MapCoord(object):
 
     @classmethod
     def create(cls, data, coordsys=None, copy=False):
-        """Create a new `~MapCoord` object.  This method can be used to create
-        either unnamed (with tuple input) or named (via dict input)
-        axes.
+        """Create a new `~MapCoord` object.
+
+        This method can be used to create either unnamed (with tuple input)
+        or named (via dict input) axes.
 
         Parameters
         ----------

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1063,16 +1063,6 @@ class MapGeom(object):
         """
         pass
 
-    def get_mapcoord(self):
-        """Returns a MapCoord for this `~gammapy.maps.Geom` object.
-        """
-        coord_tuple = self.get_coord()
-        cdict = dict(lon=coord_tuple[0], lat=coord_tuple[1])
-        for i,axis in enumerate(self.axes):
-            cdict.update({axis.name:coord_tuple[i+2]})
-
-        return MapCoord.create(cdict, coordsys=self.coordsys)
-
 
     def coord_to_idx(self, coords, clip=False):
         """Convert map coordinates to pixel indices.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -632,8 +632,10 @@ class MapCoord(object):
         if 'lon' not in data or 'lat' not in data:
             raise ValueError("data dictionary must contain axes named 'lon' and 'lat'.")
 
-        self._data = OrderedDict([(k, np.array(v, ndmin=1, copy=copy))
-                                  for k, v in data.items()])
+        self._data = OrderedDict([
+            (k, np.array(v, ndmin=1, copy=copy))
+            for k, v in data.items()
+        ])
         vals = np.broadcast_arrays(*self._data.values())
         self._data = OrderedDict(zip(self._data.keys(), vals))
         self._coordsys = coordsys
@@ -1064,7 +1066,6 @@ class MapGeom(object):
             Tuple of pixel coordinates in image and band dimensions.
         """
         pass
-
 
     def coord_to_idx(self, coords, clip=False):
         """Convert map coordinates to pixel indices.

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1687,7 +1687,13 @@ class HpxGeom(MapGeom):
 
     def get_coord(self, idx=None, flat=False):
         pix = self.get_idx(idx=idx, flat=flat)
-        return self.pix_to_coord(pix)
+        coords = self.pix_to_coord(pix)
+        cdict = OrderedDict(lon=coords[0], lat=coords[1])
+        for i,axis in enumerate(self.axes):
+            cdict.update({axis.name:coords[i+2]})
+
+        return MapCoord.create(cdict, coordsys=self.coordsys)
+ #       return self.pix_to_coord(pix)
 
     def contains(self, coords):
         idx = self.coord_to_idx(coords)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1688,12 +1688,15 @@ class HpxGeom(MapGeom):
     def get_coord(self, idx=None, flat=False):
         pix = self.get_idx(idx=idx, flat=flat)
         coords = self.pix_to_coord(pix)
-        cdict = OrderedDict(lon=coords[0], lat=coords[1])
-        for i,axis in enumerate(self.axes):
-            cdict.update({axis.name:coords[i+2]})
+        cdict = OrderedDict([
+            ('lon', coords[0]),
+            ('lat', coords[1]),
+        ])
+
+        for i, axis in enumerate(self.axes):
+            cdict[axis.name] = coords[i + 2]
 
         return MapCoord.create(cdict, coordsys=self.coordsys)
- #       return self.pix_to_coord(pix)
 
     def contains(self, coords):
         idx = self.coord_to_idx(coords)

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -163,10 +163,10 @@ def test_hpxmap_set_get_by_coord(nside, nested, coordsys, region, axes, sparse):
                       frame=coordsys_to_frame(m.geom.coordsys))
     skydir_cel = skydir.transform_to('icrs')
     skydir_gal = skydir.transform_to('galactic')
-    m.set_by_coord((skydir_gal,) + coords[2:], coords[0])
+    m.set_by_coord((skydir_gal,) + tuple(coords[2:]), coords[0])
     assert_allclose(coords[0], m.get_by_coord(coords))
-    assert_allclose(m.get_by_coord((skydir_cel,) + coords[2:]),
-                    m.get_by_coord((skydir_gal,) + coords[2:]))
+    assert_allclose(m.get_by_coord((skydir_cel,) + tuple(coords[2:])),
+                    m.get_by_coord((skydir_gal,) + tuple(coords[2:])))
 
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -175,10 +175,11 @@ def test_wcsndmap_set_get_by_coord(npix, binsz, coordsys, proj, skydir, axes):
                       frame=coordsys_to_frame(geom.coordsys))
     skydir_cel = skydir.transform_to('icrs')
     skydir_gal = skydir.transform_to('galactic')
-    m.set_by_coord((skydir_gal,) + coords[2:], coords[0])
+
+    m.set_by_coord((skydir_gal,) + tuple(coords[2:]), coords[0])
     assert_allclose(coords[0], m.get_by_coord(coords))
-    assert_allclose(m.get_by_coord((skydir_cel,) + coords[2:]),
-                    m.get_by_coord((skydir_gal,) + coords[2:]))
+    assert_allclose(m.get_by_coord((skydir_cel,) + tuple(coords[2:])),
+                    m.get_by_coord((skydir_gal,) + tuple(coords[2:])))
 
     # Test with MapCoord
     m = WcsNDMap(geom)
@@ -211,8 +212,8 @@ def test_wcsndmap_fill_by_coord(npix, binsz, coordsys, proj, skydir, axes):
                       frame=coordsys_to_frame(geom.coordsys))
     skydir_cel = skydir.transform_to('icrs')
     skydir_gal = skydir.transform_to('galactic')
-    fill_coords_cel = (skydir_cel,) + coords[2:]
-    fill_coords_gal = (skydir_gal,) + coords[2:]
+    fill_coords_cel = (skydir_cel,) + tuple(coords[2:])
+    fill_coords_gal = (skydir_gal,) + tuple(coords[2:])
     m.fill_by_coord(fill_coords_cel, coords[1])
     m.fill_by_coord(fill_coords_gal, coords[1])
     assert_allclose(m.get_by_coord(coords), 2.0 * coords[1])

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -470,9 +470,12 @@ class WcsGeom(MapGeom):
         if flat:
             coords = tuple([c[np.isfinite(c)] for c in coords])
 
-        cdict = OrderedDict(lon=coords[0], lat=coords[1])
-        for i,axis in enumerate(self.axes):
-            cdict.update({axis.name:coords[i+2]})
+        cdict = OrderedDict([
+            ('lon', coords[0]),
+            ('lat', coords[1]),
+        ])
+        for i, axis in enumerate(self.axes):
+            cdict[axis.name] = coords[i + 2]
 
         return MapCoord.create(cdict, coordsys=self.coordsys)
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import numpy as np
+from collections import OrderedDict
 from astropy.wcs import WCS
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
@@ -468,7 +469,13 @@ class WcsGeom(MapGeom):
         coords = self.pix_to_coord(pix)
         if flat:
             coords = tuple([c[np.isfinite(c)] for c in coords])
-        return coords
+
+        cdict = OrderedDict(lon=coords[0], lat=coords[1])
+        for i,axis in enumerate(self.axes):
+            cdict.update({axis.name:coords[i+2]})
+
+        return MapCoord.create(cdict, coordsys=self.coordsys)
+
 
     def coord_to_pix(self, coords):
         coords = MapCoord.create(coords, coordsys=self.coordsys)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -189,14 +189,16 @@ class WcsNDMap(WcsMap):
             raise ValueError('Invalid interpolation method: {}'.format(interp))
 
         from scipy.interpolate import griddata
-        grid_coords = self.geom.get_coord(flat=True)
+        grid_coords = tuple(self.geom.get_coord(flat=True))
         data = self.data[np.isfinite(self.data)]
-        vals = griddata(grid_coords, data, coords, method=method)
+        vals = griddata(grid_coords, data, tuple(coords), method=method)
+
         m = ~np.isfinite(vals)
         if np.any(m):
             vals_fill = griddata(grid_coords, data, tuple([c[m] for c in coords]),
                                  method='nearest')
             vals[m] = vals_fill
+
         return vals
 
     def interp_image(self, coords, order=1):


### PR DESCRIPTION
At the moment `~gammapy.maps.Geom`has only a `get_coord()`methods that yields a tuple of arrays. 
It is desirable to have a MapCoord containing all coordinates contained in a Geom object.
This PR adds a `get_mapcoord()` method to do so.