### PR TITLE
Fix overwrite kwarg handling in Map to_hdulist

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -268,13 +268,15 @@ class Map(object):
         else:
             raise ValueError('Unrecognized map type: {!r}'.format(map_type))
 
-    def write(self, filename, **kwargs):
+    def write(self, filename, overwrite=True, **kwargs):
         """Write to a FITS file.
 
         Parameters
         ----------
         filename : str
             Output file name.
+        overwrite : bool
+            Overwrite existing file?
         hdu : str
             Set the name of the image extension.  By default this will
             be set to SKYMAP (for BINTABLE HDU) or PRIMARY (for IMAGE
@@ -296,7 +298,6 @@ class Map(object):
             This option is only compatible with the 'gadf' format.
         """
         hdulist = self.to_hdulist(**kwargs)
-        overwrite = kwargs.get('overwrite', True)
         hdulist.writeto(filename, overwrite=overwrite)
 
     @abc.abstractmethod

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1443,7 +1443,7 @@ class HpxGeom(MapGeom):
         hdu : str
             The HDU extension name
         overwrite : bool
-            True -> overwrite existing files
+            Overwrite existing file?
         """
         hdu_prim = fits.PrimaryHDU()
         hdu_hpx = self.make_hdu(data, hdu=hdu)
@@ -1782,8 +1782,17 @@ class HpxToWcsMapping(object):
         HEALPIX region"""
         return self._valid
 
-    def write(self, fitsfile, overwrite=True):
-        """Write this mapping to a FITS file, to avoid having to recompute it
+    def write(self, filename, overwrite=True):
+        """Write this mapping to a FITS file.
+
+        This can be useful to avoid having to recompute it.
+
+        Parameters
+        ----------
+        filename : str
+            FITS file name
+        overwrite : bool
+            Overwrite existing file?
         """
         from .wcsnd import WcsNDMap
         hpx_header = self._hpx.make_header()
@@ -1801,7 +1810,7 @@ class HpxToWcsMapping(object):
         #    mult_hdu.header[key] = hpx_header[key]
 
         hdulist = index_map.to_hdulist()
-        hdulist.writeto(fitsfile, overwrite=overwrite)
+        hdulist.writeto(filename, overwrite=overwrite)
 
     @classmethod
     def create(cls, hpx, wcs):


### PR DESCRIPTION
The handling of the overwrite kwarg doesn't work properly
```
>>> from gammapy.maps import Map
>>> m = Map.create()
>>> m.write('map.fits', overwrite=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/deil/code/gammapy/gammapy/maps/base.py", line 298, in write
    hdulist = self.to_hdulist(**kwargs)
TypeError: to_hdulist() got an unexpected keyword argument 'overwrite'
```
the problem is here:
https://github.com/gammapy/gammapy/blob/a05ffd906a8943fcbde71a38a98c826bcd37ecdb/gammapy/maps/base.py#L298-L300

I also suggest to change the default to `overwrite=False`, to be consistent with e.g. all Astropy functions / methods that write to files. @woodmd - OK?
```
$ ack overwrite gammapy/maps/

gammapy/maps/hpx.py
1434:    def write(self, data, outfile, hdu='SKYMAP', overwrite=True):
1445:        overwrite : bool
1446:            True -> overwrite existing files
1461:        hdulist.writeto(outfile, overwrite=overwrite)
1785:    def write(self, fitsfile, overwrite=True):
1804:        hdulist.writeto(fitsfile, overwrite=overwrite)

gammapy/maps/base.py
299:        overwrite = kwargs.get('overwrite', True)
300:        hdulist.writeto(filename, overwrite=overwrite)
```
