### PR TITLE
Bump Numpy install_requires from 1.8 to 1.10 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
     # Older versions could work, but are unsupported.
     # To find out if everything works run the Gammapy tests.
     install_requires=[
-      'numpy>=1.8',
+      'numpy>=1.10',
       'astropy>=1.3',
       'regions',
       'click',


### PR DESCRIPTION
I'm proposing to adjust our `install_requires` in `setup.py` for Numpy from 1.8 to 1.10.

Numpy 1.10 was released in October 2015:  https://pypi.org/project/numpy/1.10.0/

This is triggered by https://github.com/gammapy/gammapy/issues/1366#issuecomment-380071390

Probably most things work on older Numpy, but we don't test for that in CI, so we don't really know.

@dimauromattia @woodmd - Do you know if some Fermipy users are stuck on Numpy < 1.10? Or is this change OK for you? Maybe you could even do the same change to Numpy >= 1.10 in the Fermipy setup.py?