### PR TITLE
Fix 3-lines display and download attr in NBs alert boxes

### DIFF
--- a/docs/_static/linksdl.js
+++ b/docs/_static/linksdl.js
@@ -9,7 +9,7 @@
 
 document.onreadystatechange = function () {
     if (document.readyState == "interactive") {
-         document.getElementsByClassName("line")[2].children[1].setAttribute("download", "")
-         document.getElementsByClassName("line")[2].children[2].setAttribute("download", "")
+         document.getElementsByClassName("last")[0].children[2].children[1].setAttribute("download", "")
+         document.getElementsByClassName("last")[0].children[2].children[2].setAttribute("download", "")
      }
 }

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -128,10 +128,10 @@ def modif_nb_links(folder, url_docs, git_commit):
 <div class='alert alert-info'>
 **This is a fixed-text formatted version of a Jupyter notebook.**
 
-Try online [![Binder](https://mybinder.org/badge.svg)](https://beta.mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?filepath={nb_filename})  
-You can also contribute with your own notebooks in this
-[GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).  
-**Source files:**
+- Try online [![Binder](https://mybinder.org/badge.svg)](https://beta.mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?filepath={nb_filename})
+- You can also contribute with your own notebooks in this 
+[GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
+- **Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
 [{py_filename}](../_static/notebooks/{py_filename})
 </div>


### PR DESCRIPTION
This PR addresses Issue https://github.com/gammapy/gammapy/pull/1360#issuecomment-381625386

Makes alert boxes in notebooks appear as a three-lines display, and consequently fixes the addition of attribute "download" to the linked files, so they can be properly downloaded with all browsers.
