### PR TITLE
Always open FITS files with memmap=False

### DIFF
--- a/gammapy/background/fov_cube.py
+++ b/gammapy/background/fov_cube.py
@@ -375,15 +375,15 @@ class FOVCube(object):
         """
         filename = make_path(filename)
         scheme_dict = cls.define_scheme(scheme)
-        hdu_list = fits.open(str(filename))
 
-        if format == 'table':
-            hdu = hdu_list[hdu]
-            return cls.from_fits_table(hdu, scheme)
-        elif format == 'image':
-            return cls.from_fits_image(hdu_list['PRIMARY'], hdu_list['EBOUNDS'], scheme)
-        else:
-            raise ValueError("Invalid format {}.".format(format))
+        with fits.open(str(filename), memmap=False) as hdu_list:
+            if format == 'table':
+                hdu = hdu_list[hdu]
+                return cls.from_fits_table(hdu, scheme)
+            elif format == 'image':
+                return cls.from_fits_image(hdu_list['PRIMARY'], hdu_list['EBOUNDS'], scheme)
+            else:
+                raise ValueError("Invalid format {}.".format(format))
 
     def to_table(self):
         """Convert cube to astropy table format.

--- a/gammapy/cube/core.py
+++ b/gammapy/cube/core.py
@@ -152,7 +152,8 @@ class SkyCube(MapBase):
             data = Quantity(data, '1 / (cm2 MeV s sr)')
             name = 'flux'
         elif format == 'fermi-counts':
-            energy = EnergyBounds.from_ebounds(fits.open(filename)['EBOUNDS'])
+            with fits.open(filename, memmap=False) as hdu_list:
+                energy = EnergyBounds.from_ebounds(hdu_list['EBOUNDS'])
             energy_axis = LogEnergyAxis(energy, mode='edges')
             data = Quantity(data, 'count')
             name = 'counts'

--- a/gammapy/cube/tests/test_core.py
+++ b/gammapy/cube/tests/test_core.py
@@ -83,8 +83,8 @@ class TestSkyCube(object):
         filename = str(tmpdir / 'sky_cube.fits')
         self.sky_cube.write(filename, format='fermi-background')
 
-        hdu_list = fits.open(filename)
-        assert hdu_list[1].name == 'ENERGIES'
+        with fits.open(filename, memmap=False) as hdu_list:
+            assert hdu_list[1].name == 'ENERGIES'
 
         sky_cube = SkyCube.read(filename, format='fermi-background')
         assert sky_cube.data.shape == (30, 21, 61)

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -63,7 +63,8 @@ class HDULocation(object):
 
     def get_hdu(self):
         """Get HDU."""
-        hdu_list = fits.open(str(self.path(abs_path=True)))
+        filename = str(self.path(abs_path=True))
+        hdu_list = fits.open(filename, memmap=False)
         return hdu_list[self.hdu_name]
 
     def load(self):

--- a/gammapy/image/lists.py
+++ b/gammapy/image/lists.py
@@ -113,13 +113,10 @@ class SkyImageList(UserList):
         return cls(images)
 
     @classmethod
-    def read(cls, filename, **kwargs):
-        """Write to FITS file.
-
-        ``kwargs`` are passed to `astropy.io.fits.open`.
-        """
+    def read(cls, filename):
+        """Read from FITS file."""
         filename = make_path(filename)
-        with fits.open(str(filename), **kwargs) as hdu_list:
+        with fits.open(str(filename), memmap=False) as hdu_list:
             images = cls.from_hdu_list(hdu_list)
         return images
 

--- a/gammapy/image/tests/test_core.py
+++ b/gammapy/image/tests/test_core.py
@@ -109,9 +109,9 @@ class TestSkyImagePoisson:
         self.image = SkyImage.read(f)
 
     def test_read_hdu(self):
-        f = load_poisson_stats_image(return_filenames=True)
-        hdulist = fits.open(f)
-        image = SkyImage.from_image_hdu(hdulist[0])
+        filename = load_poisson_stats_image(return_filenames=True)
+        with fits.open(filename, memmap=False) as hdu_list:
+            image = SkyImage.from_image_hdu(hdu_list[0])
         assert_equal(image.data, self.image.data)
 
     def test_io(self, tmpdir):

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -112,7 +112,7 @@ class Background3D(object):
     def read(cls, filename, hdu='BACKGROUND'):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename)) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             bkg = cls.from_hdulist(hdulist, hdu=hdu)
 
         return bkg
@@ -210,7 +210,7 @@ class Background2D(object):
     def read(cls, filename, hdu='BACKGROUND'):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename)) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             bkg = cls.from_hdulist(hdulist, hdu=hdu)
         
         return bkg

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -180,10 +180,10 @@ class EffectiveAreaTable(object):
         return cls.from_table(Table.read(hdulist[hdu]))
 
     @classmethod
-    def read(cls, filename, hdu='SPECRESP', **kwargs):
+    def read(cls, filename, hdu='SPECRESP'):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename), **kwargs) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             try:
                 aeff = cls.from_hdulist(hdulist, hdu=hdu)
             except KeyError:
@@ -408,7 +408,7 @@ class EffectiveAreaTable2D(object):
     def read(cls, filename, hdu='EFFECTIVE AREA'):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename)) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             aeff = cls.from_hdulist(hdulist, hdu=hdu)
 
         return aeff

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -202,7 +202,7 @@ class EnergyDispersion(object):
                    data=pdf_matrix)
 
     @classmethod
-    def read(cls, filename, hdu1='MATRIX', hdu2='EBOUNDS', **kwargs):
+    def read(cls, filename, hdu1='MATRIX', hdu2='EBOUNDS'):
         """Read from file.
 
         Parameters
@@ -215,7 +215,7 @@ class EnergyDispersion(object):
             HDU containing the energy axis information, default, EBOUNDS
         """
         filename = make_path(filename)
-        with fits.open(str(filename), **kwargs) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             edisp = cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
         return edisp
@@ -695,7 +695,7 @@ class EnergyDispersion2D(object):
             File name
         """
         filename = make_path(filename)
-        with fits.open(str(filename)) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             edisp = cls.from_hdulist(hdulist, hdu)
 
         return edisp

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -99,7 +99,7 @@ class EnergyDependentMultiGaussPSF(object):
             File name
         """
         filename = make_path(filename)
-        with fits.open(str(filename)) as hdulist:
+        with fits.open(str(filename), memmap=False) as hdulist:
             psf = cls.from_fits(hdulist[hdu])
 
         return psf

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -494,7 +494,7 @@ class EnergyDependentTablePSF(object):
         filename : str
             File name
         """
-        with fits.open(filename) as hdulist:
+        with fits.open(filename, memmap=False) as hdulist:
             psf = cls.from_fits(hdulist)
 
         return psf

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -31,13 +31,12 @@ class TestEnergyDependentMultiGaussPSF:
         psf.write(filename)
 
         # Verify checksum
-        hdu_list = fits.open(filename)
-
-        # TODO: replace this assert with something else.
-        # For unknown reasons this verify_checksum fails non-deterministically
-        # see e.g. https://travis-ci.org/gammapy/gammapy/jobs/31056341#L1162
-        # assert hdu_list[1].verify_checksum() == 1
-        assert len(hdu_list) == 2
+        with fits.open(filename) as hdu_list:
+            # TODO: replace this assert with something else.
+            # For unknown reasons this verify_checksum fails non-deterministically
+            # see e.g. https://travis-ci.org/gammapy/gammapy/jobs/31056341#L1162
+            # assert hdu_list[1].verify_checksum() == 1
+            assert len(hdu_list) == 2
 
     def test_to_table_psf(self, psf):
         energy = 1 * u.TeV

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -162,7 +162,7 @@ class Map(object):
             Map object
         """
         filename = str(make_path(filename))
-        with fits.open(filename) as hdulist:
+        with fits.open(filename, memmap=False) as hdulist:
             map_out = cls.from_hdu_list(hdulist, hdu, hdu_bands, map_type)
 
         return map_out

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -917,7 +917,7 @@ class MapGeom(object):
             Geometry object.
         """
         filename = str(make_path(filename))
-        with fits.open(filename) as hdulist:
+        with fits.open(filename, memmap=False) as hdulist:
             geom = cls.from_hdulist(hdulist, **kwargs)
         return geom
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1445,9 +1445,8 @@ class HpxGeom(MapGeom):
         overwrite : bool
             Overwrite existing file?
         """
-        hdu_prim = fits.PrimaryHDU()
         hdu_hpx = self.make_hdu(data, hdu=hdu)
-        hl = [hdu_prim, hdu_hpx]
+        hdu_list = fits.HDUList([fits.PrimaryHDU(), hdu_hpx])
 
         if self.conv.bands_hdu == 'EBOUNDS':
             hdu_energy = self.make_ebounds_hdu()
@@ -1455,10 +1454,9 @@ class HpxGeom(MapGeom):
             hdu_energy = self.make_energies_hdu()
 
         if hdu_energy is not None:
-            hl.append(hdu_energy)
+            hdu_list.append(hdu_energy)
 
-        hdulist = fits.HDUList(hl)
-        hdulist.writeto(outfile, overwrite=overwrite)
+        hdu_list.writeto(outfile, overwrite=overwrite)
 
     @staticmethod
     def get_index_list(nside, nest, region):
@@ -1848,8 +1846,8 @@ class HpxToWcsMapping(object):
         filename = str(make_path(filename))
         index_map = WcsNDMap.read(filename)
         mult_map = WcsNDMap.read(filename, hdu=1)
-        with fits.open(filename) as ff:
-            hpx = HpxGeom.from_header(ff[0])
+        with fits.open(filename, memmap=False) as hdu_list:
+            hpx = HpxGeom.from_header(hdu_list[0])
             ipix = index_map.data
             mult_val = mult_map.data
             npix = mult_map.counts.shape

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -161,12 +161,12 @@ class HpxMap(Map):
         hdu_out.header['META'] = json.dumps(self.meta)
         hdu_out.header['UNIT'] = self._unit
 
-        hdu_list = [fits.PrimaryHDU(), hdu_out]
+        hdu_list = fits.HDUList([fits.PrimaryHDU(), hdu_out])
 
         if self.geom.axes:
-            hdu_list += [hdu_bands_out]
+            hdu_list.append(hdu_bands_out)
 
-        return fits.HDUList(hdu_list)
+        return hdu_list
 
     @abc.abstractmethod
     def to_wcs(self, sum_bands=False, normalize=True, proj='AIT', oversample=2,

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -117,22 +117,22 @@ def test_hpxmap_read_write_fgst(tmpdir):
     # Test Counts Cube
     m = create_map(8, False, 'GAL', None, [axis], False)
     m.write(filename, conv='fgst-ccube')
-    h = fits.open(filename)
-    assert 'SKYMAP' in h
-    assert 'EBOUNDS' in h
-    assert h['SKYMAP'].header['HPX_CONV'] == 'FGST-CCUBE'
-    assert h['SKYMAP'].header['TTYPE1'] == 'CHANNEL1'
+    with fits.open(filename) as h:
+        assert 'SKYMAP' in h
+        assert 'EBOUNDS' in h
+        assert h['SKYMAP'].header['HPX_CONV'] == 'FGST-CCUBE'
+        assert h['SKYMAP'].header['TTYPE1'] == 'CHANNEL1'
 
     m2 = Map.read(filename)
     assert m2.geom.conv == 'fgst-ccube'
 
     # Test Model Cube
     m.write(filename, conv='fgst-template')
-    h = fits.open(filename)
-    assert 'SKYMAP' in h
-    assert 'ENERGIES' in h
-    assert h['SKYMAP'].header['HPX_CONV'] == 'FGST-TEMPLATE'
-    assert h['SKYMAP'].header['TTYPE1'] == 'ENERGY1'
+    with fits.open(filename) as h:
+        assert 'SKYMAP' in h
+        assert 'ENERGIES' in h
+        assert h['SKYMAP'].header['HPX_CONV'] == 'FGST-TEMPLATE'
+        assert h['SKYMAP'].header['TTYPE1'] == 'ENERGY1'
 
     m2 = Map.read(filename)
     assert m2.geom.conv == 'fgst-template'

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -97,8 +97,8 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
     hdulist.writeto(filename, overwrite=True)
 
-    hdulist = fits.open(filename)
-    geom1 = WcsGeom.from_header(hdulist[0].header, hdulist['BANDS'])
+    with fits.open(filename) as hdulist:
+        geom1 = WcsGeom.from_header(hdulist[0].header, hdulist['BANDS'])
 
     assert_allclose(geom0.npix, geom1.npix)
     assert (geom0.coordsys == geom1.coordsys)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -96,16 +96,16 @@ def test_wcsndmap_read_write_fgst(tmpdir):
     # Test Counts Cube
     m = WcsNDMap(geom)
     m.write(filename, conv='fgst-ccube')
-    h = fits.open(filename)
-    assert 'EBOUNDS' in h
+    with fits.open(filename) as h:
+        assert 'EBOUNDS' in h
 
     m2 = Map.read(filename)
     assert m2.geom.conv == 'fgst-ccube'
 
     # Test Model Cube
     m.write(filename, conv='fgst-template')
-    h = fits.open(filename)
-    assert 'ENERGIES' in h
+    with fits.open(filename) as h:
+        assert 'ENERGIES' in h
 
     m2 = Map.read(filename)
     assert m2.geom.conv == 'fgst-template'

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -904,8 +904,8 @@ def wcs_to_coords(w, shape):
 
 def get_map_skydir(filename, maphdu=0):
     filename = str(make_path(filename))
-    with fits.open(filename) as hdulist:
-        wcs = WCS(hdulist[maphdu].header)
+    with fits.open(filename, memmap=False) as hdu_list:
+        wcs = WCS(hdu_list[maphdu].header)
     return wcs_to_skydir(wcs)
 
 

--- a/gammapy/scripts/cta_irf.py
+++ b/gammapy/scripts/cta_irf.py
@@ -81,7 +81,6 @@ class CTAIrf(object):
         edisp = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
         psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
 
-        table = fits.open(filename)['SENSITIVITY']
         sensi = SensitivityTable.read(filename, hdu='SENSITIVITY')
 
         return cls(
@@ -133,15 +132,10 @@ class BgRateTable(object):
         return cls.from_table(table)
 
     @classmethod
-    def read(cls, filename, hdu='BACKGROUND', **kwargs):
+    def read(cls, filename, hdu='BACKGROUND'):
         filename = make_path(filename)
-        hdulist = fits.open(str(filename), **kwargs)
-        try:
+        with fits.open(str(filename), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu=hdu)
-        except KeyError:
-            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
-            msg += '\n Available {}'.format([_.name for _ in hdulist])
-            raise ValueError(msg)
 
     def plot(self, ax=None, energy=None, **kwargs):
         """Plot background rate.
@@ -216,15 +210,10 @@ class Psf68Table(object):
         return cls.from_table(table)
 
     @classmethod
-    def read(cls, filename, hdu='POINT SPREAD FUNCTION', **kwargs):
+    def read(cls, filename, hdu='POINT SPREAD FUNCTION'):
         filename = make_path(filename)
-        hdulist = fits.open(str(filename), **kwargs)
-        try:
+        with fits.open(str(filename), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu=hdu)
-        except KeyError:
-            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
-            msg += '\n Available {}'.format([_.name for _ in hdulist])
-            raise ValueError(msg)
 
     def plot(self, ax=None, energy=None, **kwargs):
         """Plot point spread function.
@@ -299,15 +288,10 @@ class SensitivityTable(object):
         return cls.from_table(table)
 
     @classmethod
-    def read(cls, filename, hdu='SENSITVITY', **kwargs):
+    def read(cls, filename, hdu='SENSITVITY'):
         filename = make_path(filename)
-        hdulist = fits.open(str(filename), **kwargs)
-        try:
+        with fits.open(str(filename), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu=hdu)
-        except KeyError:
-            msg = 'File {} contains no HDU "{}"'.format(filename, hdu)
-            msg += '\n Available {}'.format([_.name for _ in hdulist])
-            raise ValueError(msg)
 
     def plot(self, ax=None, energy=None, **kwargs):
         """Plot sensitivity.
@@ -395,12 +379,12 @@ class CTAPerf(object):
         """
         filename = str(make_path(filename))
 
-        hdulist = fits.open(filename)
-        aeff = EffectiveAreaTable.from_hdulist(hdulist=hdulist)
-        edisp = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
-        bkg = BgRateTable.from_hdulist(hdulist=hdulist)
-        psf = Psf68Table.from_hdulist(hdulist=hdulist)
-        sens = SensitivityTable.from_hdulist(hdulist=hdulist)
+        with fits.open(filename, memmap=False) as hdulist:
+            aeff = EffectiveAreaTable.from_hdulist(hdulist=hdulist)
+            edisp = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
+            bkg = BgRateTable.from_hdulist(hdulist=hdulist)
+            psf = Psf68Table.from_hdulist(hdulist=hdulist)
+            sens = SensitivityTable.from_hdulist(hdulist=hdulist)
 
         # Create rmf with appropriate dimensions (e_reco->bkg, e_true->area)
         e_reco_min = bkg.energy.lo[0]

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -77,19 +77,11 @@ class CountsSpectrum(object):
                    energy_hi=ebounds.upper_bounds)
 
     @classmethod
-    def read(cls, filename, hdu1='COUNTS', hdu2='EBOUNDS', **kwargs):
+    def read(cls, filename, hdu1='COUNTS', hdu2='EBOUNDS'):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename), **kwargs) as hdulist:
-            try:
-                spec = cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
-            except KeyError:
-                msg = 'File {} does not contain HDUs "{}"'.format(
-                    filename, [hdu1, hdu2])
-                msg += '\n Available {}'.format([_.name for _ in hdulist])
-                raise ValueError(msg)
-
-        return spec
+        with fits.open(str(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
     def to_table(self):
         """Convert to `~astropy.table.Table`.
@@ -493,19 +485,11 @@ class PHACountsSpectrum(CountsSpectrum):
         return cls(**kwargs)
 
     @classmethod
-    def read(cls, filename, hdu1='SPECTRUM', hdu2='EBOUNDS', **kwargs):
+    def read(cls, filename, hdu1='SPECTRUM', hdu2='EBOUNDS'):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename), **kwargs) as hdulist:
-            try:
-                spec = cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
-            except KeyError:
-                msg = 'File {} does not contain HDUs "{}"'.format(
-                    filename, [hdu1, hdu2])
-                msg += '\n Available {}'.format([_.name for _ in hdulist])
-                raise ValueError(msg)
-
-        return spec
+        with fits.open(str(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
     def to_sherpa(self, name):
         """Convert to `sherpa.astro.data.DataPHA`.
@@ -599,9 +583,8 @@ class PHACountsSpectrumList(list):
     def read(cls, filename):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename)) as hdulist:
-            speclist = cls.from_hdulist(hdulist)
-        return speclist
+        with fits.open(str(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist)
 
     @classmethod
     def from_hdulist(cls, hdulist):

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -265,7 +265,8 @@ class SmartHDUList(object):
             Filename
         """
         filename = str(make_path(filename))
-        hdu_list = fits.open(filename, **kwargs)
+        memmap = kwargs.pop('memmap', False)
+        hdu_list = fits.open(filename, memmap=memmap, **kwargs)
         return cls(hdu_list)
 
     def write(self, filename, **kwargs):
@@ -360,31 +361,6 @@ class SmartHDUList(object):
         index = self.get_hdu_index(hdu=hdu, hdu_type=hdu_type)
         hdu = self.hdu_list[index]
         return hdu
-
-
-def split_filename_hduname(location):
-    """Get one HDU for a given location.
-
-    location should be either a ``file_name`` or a file
-    and HDU name in the format ``file_name[hdu_name]``.
-
-    Parameters
-    ----------
-    TODO
-
-    Returns
-    -------
-    TODO
-    """
-    # TODO: Test all cases and give good exceptions / error messages
-    if '[' in location:
-        tokens = location.split('[')
-        file_name = tokens[0]
-        hdu_name = tokens[1][:-1]  # split off ']' at the end
-        return fits.open(file_name)[hdu_name]
-    else:
-        file_name = location
-        return fits.open(file_name)[0]
 
 
 def fits_header_to_meta_dict(header):


### PR DESCRIPTION
This PR changes all read methods in Gammapy to use `with fits.open(filename, memmap=False)`.

See discussion in #1055 and https://github.com/astropy/astropy/issues/7440 .

I plan to merge if CI passes.

But comments are still welcome of course. Especially @woodmd or anyone, if you know of cases where `memmap=True` should definitely be used (e.g. for maps) for performance reasons. My understanding is that the performance difference should be small for most of our use cases, and thus given that `memmap=False` leads to predictable behaviour of FITS files always being closed at the end of `read` methods, just putting `memmap=False` everywhere is somehow the simple & safe default to put for now.