### PR TITLE
Change to default overwrite=False in gammapy.maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -268,7 +268,7 @@ class Map(object):
         else:
             raise ValueError('Unrecognized map type: {!r}'.format(map_type))
 
-    def write(self, filename, overwrite=True, **kwargs):
+    def write(self, filename, overwrite=False, **kwargs):
         """Write to a FITS file.
 
         Parameters

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1431,7 +1431,7 @@ class HpxGeom(MapGeom):
             cols, self.make_header(), name=hdu)
         return hdu_out
 
-    def write(self, data, outfile, hdu='SKYMAP', overwrite=True):
+    def write(self, data, outfile, hdu='SKYMAP', overwrite=False):
         """Write input data to a FITS file.
 
         Parameters
@@ -1789,7 +1789,7 @@ class HpxToWcsMapping(object):
         HEALPIX region"""
         return self._valid
 
-    def write(self, filename, overwrite=True):
+    def write(self, filename, overwrite=False):
         """Write this mapping to a FITS file.
 
         This can be useful to avoid having to recompute it.

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -76,11 +76,11 @@ def test_hpxmap_create(nside, nested, coordsys, region, axes, sparse):
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)
 def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse):
-    filename = str(tmpdir / 'skycube.fits')
+    filename = str(tmpdir / 'map.fits')
 
     m = create_map(nside, nested, coordsys, region, axes, sparse)
     fill_poisson(m, mu=0.5, random_state=0)
-    m.write(filename, sparse=sparse)
+    m.write(filename, sparse=sparse, overwrite=True)
 
     m2 = HpxNDMap.read(filename)
     m3 = HpxSparseMap.read(filename)
@@ -94,7 +94,7 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     assert_allclose(m.data[...][msk], m3.data[...][msk])
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
-    m.write(filename, sparse=True)
+    m.write(filename, sparse=True, overwrite=True)
     m2 = HpxNDMap.read(filename)
     m3 = HpxMap.read(filename, map_type='hpx')
     m4 = Map.read(filename, map_type='hpx')
@@ -103,20 +103,20 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
     # Specify alternate HDU name for IMAGE and BANDS table
-    m.write(filename, hdu='IMAGE', hdu_bands='TEST')
+    m.write(filename, hdu='IMAGE', hdu_bands='TEST', overwrite=True)
     m2 = HpxNDMap.read(filename)
     m3 = Map.read(filename)
     m4 = Map.read(filename, map_type='hpx')
 
 
 def test_hpxmap_read_write_fgst(tmpdir):
-    filename = str(tmpdir / 'skycube.fits')
+    filename = str(tmpdir / 'map.fits')
 
     axis = MapAxis.from_bounds(100., 1000., 4, name='energy', unit='MeV')
 
     # Test Counts Cube
     m = create_map(8, False, 'GAL', None, [axis], False)
-    m.write(filename, conv='fgst-ccube')
+    m.write(filename, conv='fgst-ccube', overwrite=True)
     with fits.open(filename) as h:
         assert 'SKYMAP' in h
         assert 'EBOUNDS' in h
@@ -127,7 +127,7 @@ def test_hpxmap_read_write_fgst(tmpdir):
     assert m2.geom.conv == 'fgst-ccube'
 
     # Test Model Cube
-    m.write(filename, conv='fgst-template')
+    m.write(filename, conv='fgst-template', overwrite=True)
     with fits.open(filename) as h:
         assert 'SKYMAP' in h
         assert 'ENERGIES' in h

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -59,11 +59,11 @@ def test_wcsndmap_init(npix, binsz, coordsys, proj, skydir, axes):
 def test_wcsndmap_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz,
                           proj=proj, coordsys=coordsys, axes=axes)
-    filename = str(tmpdir / 'skycube.fits')
-    filename_sparse = str(tmpdir / 'skycube_sparse.fits')
+    filename = str(tmpdir / 'map.fits')
+
     m0 = WcsNDMap(geom)
     fill_poisson(m0, mu=0.5)
-    m0.write(filename)
+    m0.write(filename, overwrite=True)
     m1 = WcsNDMap.read(filename)
     m2 = Map.read(filename)
     m3 = Map.read(filename, map_type='wcs')
@@ -71,8 +71,8 @@ def test_wcsndmap_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(m0.data, m2.data)
     assert_allclose(m0.data, m3.data)
 
-    m0.write(filename_sparse, sparse=True)
-    m1 = WcsNDMap.read(filename_sparse)
+    m0.write(filename, sparse=True, overwrite=True)
+    m1 = WcsNDMap.read(filename)
     m2 = Map.read(filename)
     m3 = Map.read(filename, map_type='wcs')
     assert_allclose(m0.data, m1.data)
@@ -80,14 +80,14 @@ def test_wcsndmap_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(m0.data, m3.data)
 
     # Specify alternate HDU name for IMAGE and BANDS table
-    m0.write(filename, hdu='IMAGE', hdu_bands='TEST')
+    m0.write(filename, hdu='IMAGE', hdu_bands='TEST', overwrite=True)
     m1 = WcsNDMap.read(filename)
     m2 = Map.read(filename)
     m3 = Map.read(filename, map_type='wcs')
 
 
 def test_wcsndmap_read_write_fgst(tmpdir):
-    filename = str(tmpdir / 'skycube.fits')
+    filename = str(tmpdir / 'map.fits')
 
     axis = MapAxis.from_bounds(100., 1000., 4, name='energy', unit='MeV')
     geom = WcsGeom.create(npix=10, binsz=1.0,
@@ -95,7 +95,7 @@ def test_wcsndmap_read_write_fgst(tmpdir):
 
     # Test Counts Cube
     m = WcsNDMap(geom)
-    m.write(filename, conv='fgst-ccube')
+    m.write(filename, conv='fgst-ccube', overwrite=True)
     with fits.open(filename) as h:
         assert 'EBOUNDS' in h
 
@@ -103,7 +103,7 @@ def test_wcsndmap_read_write_fgst(tmpdir):
     assert m2.geom.conv == 'fgst-ccube'
 
     # Test Model Cube
-    m.write(filename, conv='fgst-template')
+    m.write(filename, conv='fgst-template', overwrite=True)
     with fits.open(filename) as h:
         assert 'ENERGIES' in h
 


### PR DESCRIPTION
This PR changes to default `overwrite=False` in `map.write` calls.
This change was discussed here: #1396
