### PR TITLE
Change SpectrumExtract to not write in the run method

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -75,23 +75,14 @@ class SpectrumExtraction(object):
         self._aeff = None
         self._edisp = None
 
-    def run(self, outdir=None, use_sherpa=False):
+    def run(self):
         """Run all steps.
-
-        Parameters
-        ----------
-        outdir : Path, str
-            directory to write results files to (if given)
-        use_sherpa : bool, optional
-            Write Sherpa compliant files, default: False
         """
         log.info('Running {}'.format(self))
         for obs, bkg in zip(self.obs_list, self.bkg_estimate):
             if not self._alpha_ok(obs, bkg):
                 continue
             self.observations.append(self.process(obs, bkg))
-        if outdir is not None:
-            self.write(outdir, use_sherpa=use_sherpa)
 
     def _alpha_ok(self, obs, bkg):
         """Check if observation fulfills alpha criterion"""
@@ -248,7 +239,7 @@ class SpectrumExtraction(object):
         for obs in self.observations:
             obs.compute_energy_threshold(**kwargs)
 
-    def write(self, outdir, ogipdir='ogip_data', use_sherpa=False):
+    def write(self, outdir, ogipdir='ogip_data', use_sherpa=False, overwrite=False):
         """Write results to disk.
 
         Parameters
@@ -258,11 +249,13 @@ class SpectrumExtraction(object):
         ogipdir : str, optional
             Folder name for OGIP data, default: 'ogip_data'
         use_sherpa : bool, optional
-            Write Sherpa compliant files, default: False
+            Write Sherpa compliant files?
+        overwrite : bool
+            Overwrite existing files?
         """
         outdir = make_path(outdir)
         log.info("Writing OGIP files to {}".format(outdir / ogipdir))
         outdir.mkdir(exist_ok=True, parents=True)
-        self.observations.write(outdir / ogipdir, use_sherpa=use_sherpa)
+        self.observations.write(outdir / ogipdir, use_sherpa=use_sherpa, overwrite=overwrite)
 
         # TODO : add more debug plots etc. here

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -411,7 +411,7 @@ class SpectrumObservation(object):
                    off_vector=off_vector,
                    edisp=energy_dispersion)
 
-    def write(self, outdir=None, use_sherpa=False, overwrite=True):
+    def write(self, outdir=None, use_sherpa=False, overwrite=False):
         """Write OGIP files.
 
         If you want to use the written files with Sherpa you have to set the
@@ -424,8 +424,8 @@ class SpectrumObservation(object):
             output directory, default: pwd
         use_sherpa : bool, optional
             Write Sherpa compliant files, default: False
-        overwrite : bool, optional
-            Overwrite, default: True
+        overwrite : bool
+            Overwrite existing files?
         """
         outdir = Path.cwd() if outdir is None else Path(outdir)
         outdir.mkdir(exist_ok=True, parents=True)

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -84,7 +84,8 @@ class TestSpectrumExtraction:
 
     def test_run(self, tmpdir, extraction):
         """Test the run method and check if files are written correctly"""
-        extraction.run(outdir=tmpdir)
+        extraction.run()
+        extraction.write(outdir=tmpdir, overwrite=True)
         testobs = SpectrumObservation.read(tmpdir / 'ogip_data' / 'pha_obs23523.fits')
         assert_quantity_allclose(testobs.aeff.data.data,
                                  extraction.observations[0].aeff.data.data)
@@ -98,7 +99,8 @@ class TestSpectrumExtraction:
         """Same as above for files to be used with sherpa"""
         import sherpa.astro.ui as sau
 
-        extraction.run(outdir=tmpdir, use_sherpa=True)
+        extraction.run()
+        extraction.write(outdir=tmpdir, use_sherpa=True, overwrite=True)
         sau.load_pha(str(tmpdir / 'ogip_data' / 'pha_obs23523.fits'))
         arf = sau.get_arf()
 


### PR DESCRIPTION
This PR changes `SpectrumExtract` to not call `write` at the end of the `run` method.
The change was triggered by #1396 because this was one of the cases where I found a default of `overwrite=True`.

This might break some users scripts.

If you have code like this with Gammapy <= 0.7,
```
extract.run(<write parameters>)
```
with Gammapy >= 0.8 you have to change to
```
extract.run()
extract.write(<write parameters>)
```

I think this is better, as far as I know we have write `separate` from methods that run computations everywhere else in Gammapy at the moment except in this one case, so this is more modular and more consistent overall IMO.

@joleroi - OK?