### PR TITLE
Fix Binder links for JupyterLab

### DIFF
--- a/docs/_static/linksdl.js
+++ b/docs/_static/linksdl.js
@@ -9,6 +9,7 @@
 
 document.onreadystatechange = function () {
     if (document.readyState == "interactive") {
+         document.getElementsByClassName("last")[0].children[0].children[0].setAttribute("target", "_blank")
          document.getElementsByClassName("last")[0].children[2].children[1].setAttribute("download", "")
          document.getElementsByClassName("last")[0].children[2].children[2].setAttribute("download", "")
      }

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -128,7 +128,8 @@ def modif_nb_links(folder, url_docs, git_commit):
 <div class='alert alert-info'>
 **This is a fixed-text formatted version of a Jupyter notebook.**
 
-- Try online [![Binder](https://mybinder.org/badge.svg)](https://beta.mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?filepath={nb_filename})
+- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?urlpath=lab)
+ and then double-click on **{nb_filename}** file.
 - You can also contribute with your own notebooks in this 
 [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 - **Source files:**


### PR DESCRIPTION
This PR addresses issue #1409 

- Links to Binder open in a JupyterLab working session.
- JupyterLab-Binder launches in a new tab, keeping the docs tab open aside.