### PR TITLE
Improving LightCurve.plot(), partially resolving #1230

### DIFF
--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -42,6 +42,7 @@ def lc():
         Column([1e-11, 3e-11], 'flux', unit='cm-2 s-1'),
         Column([0.1e-11, 0.3e-11], 'flux_err', unit='cm-2 s-1'),
         Column([np.nan, 3.6e-11], 'flux_ul', unit='cm-2 s-1'),
+        Column([False, True], 'is_ul'),
     ])
 
     return LightCurve(table=table)


### PR DESCRIPTION
Hi,
I took up issue #1230 and improved a bit the plot method of the LightCurve class.
It can handle upper limits now looking for a `is_ul` and `flux_ul` column in the table.
I also added two options: `time_format` and `flux_unit`:

- `flux_unit` is the same as in the plot method of the FluxPoints class (in general the two methods are more alike now)

- with `time_format` one can choose 'iso' now. This results in MPL dates on the x-axis which are fairly easy to format by the user.

I still want to update the notebook example in gammapy-extra (light_curve.ipynb) to make the user aware of the `time_format` option.
Ciao,
David