### PR TITLE
Add functions and class to work with PSFs with gammapy.maps 

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -12,3 +12,4 @@ from .basic_cube import *
 from .fit import *
 from .new import *
 from .psf_kernel import *
+from .psf_map import *

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -109,10 +109,10 @@ class PSFMap(object):
     def __init__(self, psf_map):
         # Check the presence of an energy axis
         if psf_map.geom.axes[1].type is not 'energy':
-            raise (ValueError, "Incorrect energy axis position in input Map")
+            raise ValueError("Incorrect energy axis position in input Map")
 
         if not u.Unit(psf_map.geom.axes[0].unit).is_equivalent('deg'):
-            raise (ValueError, "Incorrect rad axis position in input Map")
+            raise ValueError("Incorrect rad axis position in input Map")
 
         self._psf_map = psf_map
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -43,11 +43,11 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
     rad = Angle(rad_axis.center, unit=rad_axis.unit)
 
     # Check axes positions
-    if ref_geom.axes_names.index(rad_axis.name) != 0:
-        raise ValueError("Incorrect theta axis position in input MapGeom")
+#    if ref_geom.axes_names.index(rad_axis.name) != 0:
+#        raise ValueError("Incorrect theta axis position in input MapGeom")
 
-    if ref_geom.axes_names.index(energy_axis.name) != 1:
-        raise ValueError("Incorrect energy axis position in input MapGeom")
+#    if ref_geom.axes_names.index(energy_axis.name) != 1:
+#        raise ValueError("Incorrect energy axis position in input MapGeom")
 
     # Compute separations with pointing position
     separations = pointing.separation(ref_geom.to_image().get_coord().skycoord)
@@ -86,11 +86,11 @@ class PSFMap(object):
         from astropy import units as u
         from astropy.coordinates import SkyCoord
 
-        # Define energy axis
-        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy')
-        # Define rad axis
+        # Define energy axis. Note that the name is fixed.
+        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy_true')
+        # Define rad axis. Again note the axis name
         rads = np.linspace(0., 0.5, 100) * u.deg
-        rad_axis = MapAxis.from_edges(rads, unit='deg', name='rad')
+        rad_axis = MapAxis.from_edges(rads, unit='deg', name='theta')
 
         # Define parameters
         pointing = SkyCoord(0., 0., unit='deg')
@@ -117,10 +117,10 @@ class PSFMap(object):
 
     def __init__(self, psf_map):
         # Check the presence of an energy axis
-        if psf_map.geom.axes[1].name != 'energy_true':
+        if psf_map.geom.axes[1].name.upper() != 'ENERGY_TRUE':
             raise ValueError("Incorrect energy axis position in input Map")
 
-        if psf_map.geom.axes[0].name is not 'theta':
+        if psf_map.geom.axes[0].name.upper() != 'THETA':
             raise ValueError("Incorrect theta axis position in input Map")
 
         self._psf_map = psf_map

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -79,11 +79,15 @@ class PSFMap(object):
         return self._psf_map
 
     @classmethod
-    def from_file(cls, filename, **kwargs):
+    def read(cls, filename, **kwargs):
         """ Read a psf_map from file and create a PSFMap object"""
 
         psfmap = Map.read(filename, **kwargs)
         return cls(psfmap)
+
+    def write(self, *args, **kwargs):
+        """Write the Map object containing the PSF Library map."""
+        self.psf_map.write(*args, **kwargs)
 
     def get_energy_dependent_table_psf(self, position):
         """ Returns EnergyDependentTable PSF at a given position

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -144,6 +144,30 @@ class PSFMap():
         # Beware. Need to revert rad and energies to follow the TablePSF scheme.
         return EnergyDependentTablePSF(energy=self.energies,rad=self.rad,psf_value=psf_values.T)
 
+    def get_psf_kernel(self, position, npix, pixel_size, normalize=True, factor=5):
+        """Returns a PSF kernel at the given position.
+        The PSF is returned in the form a WcsNDMap defined by the input MapGeom.
+
+        Parameters
+        ----------
+        position : `~astropy.coordinates.SkyCoord`
+            the target position. Should be a single coordinate
+        npix : int
+            number of pixels
+        pixel_size: float or `~astropy.coordinates.Angle`
+            angular size of a pixel. Default unit in degree.
+        normalize : bool
+            normalize PSF per energy bin.
+        factor : int
+            oversampling factor to compute the PSF
+        Returns
+        -------
+        kernel : `~gammapy.cube.WcsNDMapPSFKernel`
+            the resulting kernel
+        """
+        table_psf = self.get_energy_dependent_table_psf(position)
+        return table_psf_to_kernel_array(table_psf, npix, pixel_size, normalize, factor)
+
     def containment_radius_map(self, fraction = 0.68):
         """Returns the containement radius map.
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
-from gammapy.irf import EnergyDependentTablePSF, PSF3D
-from gammapy.maps import WcsGeom, WcsNDMap, MapAxis, Map
+from ..irf import EnergyDependentTablePSF
+from ..maps import Map
+from ..cube import PSFKernel
 
 __all__ = [
     'make_psf_map',

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -4,7 +4,6 @@ from gammapy.irf import EnergyDependentTablePSF, PSF3D
 from gammapy.maps import WcsGeom, WcsNDMap, MapAxis, Map
 
 __all__ = [
-    'make_psf3d',
     'make_psf_map',
     'PSFMap'
 ]

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -44,7 +44,10 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
     valid = np.where(separations < max_offset)
 
     # Compute PSF values
-    psf_values = np.transpose(psf.evaluate(offset=separations[valid], energy=energy, rad=rad), axes=(2, 0, 1))
+    psf_values = psf.evaluate(offset=separations[valid], energy=energy, rad=rad)
+    # Re-order axes to be consistent with expected geometry
+    psf_values = np.transpose(psf_values, axes=(2, 0, 1))
+    # Create Map and fill relevant entries
     psfmap = Map.from_geom(ref_geom, unit='sr-1')
     psfmap.data[:, :, valid[0], valid[1]] += psf_values.to(psfmap.unit).value
     return psfmap
@@ -73,7 +76,6 @@ class PSFMap():
 
         self.energies = self._geom.axes[1].center * self._geom.axes[1].unit
         self.rad = self._geom.axes[0].center * self._geom.axes[0].unit
-
 
     @property
     def psfmap(self):
@@ -157,3 +159,4 @@ class PSFMap():
         """
 
         raise NotImplementedError
+    

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -1,0 +1,145 @@
+import numpy as np
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+from gammapy.irf import EnergyDependentTablePSF, PSF3D
+from gammapy.maps import WcsGeom, WcsNDMap, MapAxis, Map
+
+def make_psf3d(psf_analytical, rad):
+    """ Creates a PSF3D from an analytical PSF.
+
+    Parameters
+    ----------
+    psf_analytical : `~gammapy.irf.EnergyDependentMultiGaussPSF`
+        the analytical PSF to be transformed to PSF3D
+    rad : `~astropy.unit.Quantity` or `~astropy.coordinates.Angle`
+        the array of position errors (rad) on which the PSF3D will be defined
+
+    Return
+    ------
+    psf3d : `~gammapy.irf.PSF3D`
+        the PSF3D. It will be defined on the same energy and offset values than the input psf.
+    """
+    offsets = psf_analytical.theta
+    energy = psf_analytical.energy
+    energy_lo = psf_analytical.energy_lo
+    energy_hi = psf_analytical.energy_hi
+    rad_lo = rad[:-1]
+    rad_hi = rad[1:]
+
+    psf_values = np.zeros((rad_lo.shape[0],offsets.shape[0],energy_lo.shape[0]))*u.Unit('sr-1')
+
+    for i,offset in enumerate(offsets):
+        psftable = psf_analytical.to_energy_dependent_table_psf(offset)
+        psf_values[:,i,:] = psftable.evaluate(energy,0.5*(rad_lo+rad_hi)).T
+
+    return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values,
+                 psf_analytical.energy_thresh_lo, psf_analytical.energy_thresh_hi)
+
+
+def make_psf_map(psf, pointing, ref_geom, max_offset):
+    """Make a psf map for a single observation
+
+    Expected axes : rad and true energy in this specific order
+
+    Parameters
+    ----------
+    psf : `~gammapy.irf.PSF3D`
+        the PSF IRF
+    pointing : `~astropy.coordinates.SkyCoord`
+        the pointing direction
+    ref_geom : `~gammapy.maps.MapGeom`
+        the map geom to be used. It provides the target geometry.
+        rad and true energy axes should be given in this specific order.
+    max_offset : `~astropy.coordinates.Angle`
+        maximum offset w.r.t. fov center
+
+    Returns
+    -------
+    psfmap : `~gammapy.maps.Map`
+        the resulting PSF map
+    """
+    # retrieve energies. This should be properly tested
+    energy = ref_geom.axes[1].center * ref_geom.axes[1].unit
+
+    # retrieve rad from psf IRF directly (this might be given as an argument instead)
+    rad = ref_geom.axes[0].center * ref_geom.axes[0].unit
+
+    # Compute separations with pointing position
+    separations = pointing.separation(ref_geom.to_image().get_coord().skycoord)
+    valid = np.where(separations < max_offset)
+
+    # Compute PSF values
+    psf_values = np.transpose(psf.evaluate(offset=separations[valid], energy=energy, rad=rad), axes=(2, 0, 1))
+    psfmap = Map.from_geom(ref_geom, unit='sr-1')
+    psfmap.data[:, :, valid[0], valid[1]] += psf_values.to(psfmap.unit).value
+    return psfmap
+
+
+class PSFMap():
+    """Class containing the Map of PSFs and allowing to interact with it.
+
+    Parameters
+    ----------
+    psf_map : `~gammapy.maps.Map`
+        the input PSF Map. Should be a Map with 2 non spatial axes.
+        rad and true energy axes should be given in this specific order.
+
+    """
+    def __init__(self, psf_map):
+        # Check the presence of an energy axis
+        if psf_map.geom.axes[1].type is not 'energy':
+            raise(ValueError,"Incorrect energy axis position in input Map")
+
+        if not u.Unit(psf_map.geom.axes[0].unit).is_equivalent('deg'):
+            raise(ValueError,"Incorrect rad axis position in input Map")
+
+        self._psfmap = psf_map
+        self.geom = psf_map.geom
+
+        self.energies = self.geom.axes[1].center * self.geom.axes[1].unit
+        self.rad = self.geom.axes[0].center * self.geom.axes[0].unit
+
+
+    @property
+    def psfmap(self):
+        """the PSFMap itself (~gammapy.maps.Map)"""
+        return self._psfmap
+
+    @classmethod
+    def from_file(cls, filename, **kwargs):
+        """ Read a psf_map from file and create a PSFMap object"""
+
+        psf_map.read(filename, **kwargs)
+        return cls(psf_map)
+
+    def get_energy_dependent_table_psf(self, position):
+        """ Returns EnergyDependentTable PSF at a given position
+
+        Parameters
+     ----------
+        position : `~astropy.coordinates.SkyCoord`
+            the target position. Should be a single coordinates
+
+        Returns
+        -------
+        psf_table : `~gammapy.irf.EnergyDependentTablePSF`
+            the table PSF
+        """
+        if position.size != 1:
+            raise ValueError("EnergyDependentTablePSF can be extracted at one single position only.")
+
+        # axes ordering fixed. Could be changed.
+        pix_ener = np.arange(self.geom.axes[1].nbin)
+        pix_rad = np.arange(self.geom.axes[0].nbin)
+
+        # Convert position to pixels
+        pix_lon, pix_lat = self.geom.to_image().coord_to_pix(position)
+
+        # Build the pixels tuple
+        pix = np.meshgrid(pix_lon, pix_lat,pix_rad,pix_ener)
+
+        # Interpolate in the PSF map. Squeeze to remove dimensions of length 1
+        psf_values = np.squeeze(self.interp_by_pix(pix)*u.Unit(self._psf_map.unit))
+
+        # Beware. Need to revert rad and energies to follow the TablePSF scheme.
+        return EnergyDependentTablePSF(energy=self.energies,rad=self.rad,psf_value=psf_values.T)

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -105,13 +105,14 @@ class PSFMap(object):
         psf_library.write('psf_map.fits')
 
     """
+
     def __init__(self, psf_map):
         # Check the presence of an energy axis
         if psf_map.geom.axes[1].type is not 'energy':
-            raise(ValueError,"Incorrect energy axis position in input Map")
+            raise (ValueError, "Incorrect energy axis position in input Map")
 
         if not u.Unit(psf_map.geom.axes[0].unit).is_equivalent('deg'):
-            raise(ValueError,"Incorrect rad axis position in input Map")
+            raise (ValueError, "Incorrect rad axis position in input Map")
 
         self._psf_map = psf_map
 
@@ -155,16 +156,16 @@ class PSFMap(object):
         pix_lon, pix_lat = self.psf_map.geom.to_image().coord_to_pix(position)
 
         # Build the pixels tuple
-        pix = np.meshgrid(pix_lon, pix_lat,pix_rad,pix_ener)
+        pix = np.meshgrid(pix_lon, pix_lat, pix_rad, pix_ener)
 
         # Interpolate in the PSF map. Squeeze to remove dimensions of length 1
-        psf_values = np.squeeze(self.psf_map.interp_by_pix(pix)*u.Unit(self.psf_map.unit))
+        psf_values = np.squeeze(self.psf_map.interp_by_pix(pix) * u.Unit(self.psf_map.unit))
 
         energies = self.psf_map.geom.axes[1].center * self.psf_map.geom.axes[1].unit
         rad = self.psf_map.geom.axes[0].center * self.psf_map.geom.axes[0].unit
 
         # Beware. Need to revert rad and energies to follow the TablePSF scheme.
-        return EnergyDependentTablePSF(energy=energies,rad=rad,psf_value=psf_values.T)
+        return EnergyDependentTablePSF(energy=energies, rad=rad, psf_value=psf_values.T)
 
     def get_psf_kernel(self, position, geom, max_radius=None, factor=4):
         """Returns a PSF kernel at the given position.
@@ -190,7 +191,7 @@ class PSFMap(object):
         table_psf = self.get_energy_dependent_table_psf(position)
         return PSFKernel.from_table_psf(table_psf, geom, max_radius, factor)
 
-    def containment_radius_map(self, fraction = 0.68):
+    def containment_radius_map(self, fraction=0.68):
         """Returns the containement radius map.
 
         Parameters

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -9,37 +9,6 @@ __all__ = [
     'PSFMap'
 ]
 
-def make_psf3d(psf_analytical, rad):
-    """ Creates a PSF3D from an analytical PSF.
-
-    Parameters
-    ----------
-    psf_analytical : `~gammapy.irf.EnergyDependentMultiGaussPSF`
-        the analytical PSF to be transformed to PSF3D
-    rad : `~astropy.unit.Quantity` or `~astropy.coordinates.Angle`
-        the array of position errors (rad) on which the PSF3D will be defined
-
-    Return
-    ------
-    psf3d : `~gammapy.irf.PSF3D`
-        the PSF3D. It will be defined on the same energy and offset values than the input psf.
-    """
-    offsets = psf_analytical.theta
-    energy = psf_analytical.energy
-    energy_lo = psf_analytical.energy_lo
-    energy_hi = psf_analytical.energy_hi
-    rad_lo = rad[:-1]
-    rad_hi = rad[1:]
-
-    psf_values = np.zeros((rad_lo.shape[0],offsets.shape[0],energy_lo.shape[0]))*u.Unit('sr-1')
-
-    for i,offset in enumerate(offsets):
-        psftable = psf_analytical.to_energy_dependent_table_psf(offset)
-        psf_values[:,i,:] = psftable.evaluate(energy,0.5*(rad_lo+rad_hi)).T
-
-    return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values,
-                 psf_analytical.energy_thresh_lo, psf_analytical.energy_thresh_hi)
-
 
 def make_psf_map(psf, pointing, ref_geom, max_offset):
     """Make a psf map for a single observation

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -143,3 +143,18 @@ class PSFMap():
 
         # Beware. Need to revert rad and energies to follow the TablePSF scheme.
         return EnergyDependentTablePSF(energy=self.energies,rad=self.rad,psf_value=psf_values.T)
+
+    def containment_radius_map(self, fraction = 0.68):
+        """Returns the containement radius map.
+
+        Parameters
+        ----------
+        fraction : float
+            the containment fraction (a positive number <=1). Default 0.68.
+        Returns
+        -------
+        containment_radius_map : `~gammapy.maps.Map`
+            a 3D map giving the containment radius at each energy and each position of the initial psf_map
+        """
+
+        raise NotImplementedError

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -146,7 +146,7 @@ class PSFMap(object):
             the resulting kernel
         """
         table_psf = self.get_energy_dependent_table_psf(position)
-        return PSFKernel.from_table_psf(table_psf, geom, factor)
+        return PSFKernel.from_table_psf(table_psf, geom, max_radius, factor)
 
     def containment_radius_map(self, fraction = 0.68):
         """Returns the containement radius map.

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -1,3 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
 from gammapy.irf import EnergyDependentTablePSF, PSF3D
@@ -127,7 +129,7 @@ class PSFMap():
             the target position. Should be a single coordinate
         npix : int
             number of pixels
-        pixel_size: float or `~astropy.coordinates.Angle`
+        pixel_size : float or `~astropy.coordinates.Angle`
             angular size of a pixel. Default unit in degree.
         normalize : bool
             normalize PSF per energy bin.

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -42,13 +42,6 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
     rad_axis = ref_geom.get_axis_by_name('theta')
     rad = Angle(rad_axis.center, unit=rad_axis.unit)
 
-    # Check axes positions
-#    if ref_geom.axes_names.index(rad_axis.name) != 0:
-#        raise ValueError("Incorrect theta axis position in input MapGeom")
-
-#    if ref_geom.axes_names.index(energy_axis.name) != 1:
-#        raise ValueError("Incorrect energy axis position in input MapGeom")
-
     # Compute separations with pointing position
     separations = pointing.separation(ref_geom.to_image().get_coord().skycoord)
     valid = np.where(separations < max_offset)
@@ -62,6 +55,7 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
     # Create Map and fill relevant entries
     psfmap = Map.from_geom(ref_geom, unit='sr-1')
     psfmap.data[:, :, valid[0], valid[1]] += psf_values.to(psfmap.unit).value
+
     return PSFMap(psfmap)
 
 
@@ -116,7 +110,6 @@ class PSFMap(object):
     """
 
     def __init__(self, psf_map):
-        # Check the presence of an energy axis
         if psf_map.geom.axes[1].name.upper() != 'ENERGY_TRUE':
             raise ValueError("Incorrect energy axis position in input Map")
 
@@ -147,8 +140,7 @@ class PSFMap(object):
 
     @classmethod
     def read(cls, filename, **kwargs):
-        """ Read a psf_map from file and create a PSFMap object"""
-
+        """Read a psf_map from file and create a PSFMap object"""
         psfmap = Map.read(filename, **kwargs)
         return cls(psfmap)
 
@@ -216,7 +208,7 @@ class PSFMap(object):
         return PSFKernel.from_table_psf(table_psf, geom, max_radius, factor)
 
     def containment_radius_map(self, fraction=0.68):
-        """Returns the containement radius map.
+        """Returns the containment radius map.
 
         Parameters
         ----------
@@ -228,5 +220,4 @@ class PSFMap(object):
         containment_radius_map : `~gammapy.maps.Map`
             a 3D map giving the containment radius at each energy and each position of the initial psf_map
         """
-
         raise NotImplementedError

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -6,9 +6,9 @@ import astropy.units as u
 from astropy.units import Unit
 from astropy.coordinates import SkyCoord
 from ...irf import PSF3D
-from ...maps import WcsNDMap, MapAxis, WcsGeom
+from ...maps import MapAxis, WcsGeom
 from ...cube import PSFMap, make_psf_map
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency
 
 
 def fake_psf3d(sigma=0.15 * u.deg):
@@ -74,6 +74,11 @@ def test_psfmap(tmpdir):
                     psf.containment_radius(1 * u.TeV, 0 * u.deg, 0.9), rtol=1e-3)
     assert_allclose(table_psf.containment_radius(1 * u.TeV, 0.5)[0],
                     psf.containment_radius(1 * u.TeV, 0 * u.deg, 0.5), rtol=1e-3)
+
+    # create PSFKernel
+    kern_geom = WcsGeom.create(binsz=0.02, width=5., axes=[energy_axis])
+    psfkernel = psfmap.get_psf_kernel(SkyCoord(1, 1, unit='deg'), kern_geom, max_radius=1*u.deg)
+    assert_allclose(psfkernel.psf_kernel_map.data.sum(axis=(1,2)),1.0)
 
     # test read/write
     filename = str(tmpdir / "psfmap.fits")

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -20,7 +20,6 @@ def fake_psf3d(sigma=0.15 * u.deg):
     rad = np.linspace(0, 1., 101) * u.deg
     rad_lo = rad[:-1]
     rad_hi = rad[1:]
-    #    rad = 0.5*(rad_lo + rad_hi)
 
     O, R, E = np.meshgrid(offsets, rad, energy)
 
@@ -32,6 +31,7 @@ def fake_psf3d(sigma=0.15 * u.deg):
     return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values)
 
 
+@requires_dependency('scipy')
 def test_make_psf_map():
     psf = fake_psf3d(0.3 * u.deg)
 
@@ -43,14 +43,9 @@ def test_make_psf_map():
 
     psfmap = make_psf_map(psf, pointing, geom, 3 * u.deg)
 
-    # check axes ordering
     assert psfmap.psf_map.geom.axes[0] == rad_axis
     assert psfmap.psf_map.geom.axes[1] == energy_axis
-
-    # Check unit
-    assert psfmap._psf_map.unit == Unit('sr-1')
-
-    # check size
+    assert psfmap.psf_map.unit == Unit('sr-1')
     assert psfmap.data.shape == (4, 50, 25, 25)
 
 
@@ -77,8 +72,8 @@ def test_psfmap(tmpdir):
 
     # create PSFKernel
     kern_geom = WcsGeom.create(binsz=0.02, width=5., axes=[energy_axis])
-    psfkernel = psfmap.get_psf_kernel(SkyCoord(1, 1, unit='deg'), kern_geom, max_radius=1*u.deg)
-    assert_allclose(psfkernel.psf_kernel_map.data.sum(axis=(1,2)),1.0)
+    psfkernel = psfmap.get_psf_kernel(SkyCoord(1, 1, unit='deg'), kern_geom, max_radius=1 * u.deg)
+    assert_allclose(psfkernel.psf_kernel_map.data.sum(axis=(1, 2)), 1.0)
 
     # test read/write
     filename = str(tmpdir / "psfmap.fits")

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from numpy.testing import assert_allclose
 import astropy.units as u
+from astropy.units import Unit
 from astropy.coordinates import SkyCoord
 from ...irf import PSF3D
 from ...maps import WcsNDMap, MapAxis, WcsGeom
@@ -9,7 +11,7 @@ from ...cube import PSFMap, make_psf_map
 
 
 def fake_psf3d(sigma = 0.15 * u.deg):
-    offsets = np.array((0.,1.))*u.deg
+    offsets = np.array((0.,1., 2., 3.))*u.deg
     energy = np.logspace(-1,1,5)*u.TeV
     energy_lo = energy[:-1]
     energy_hi = energy[1:]
@@ -17,27 +19,42 @@ def fake_psf3d(sigma = 0.15 * u.deg):
     rad = np.linspace(0,1.,101)*u.deg
     rad_lo = rad[:-1]
     rad_hi = rad[1:]
-    rad = 0.5*(rad_lo + rad_hi)
+#    rad = 0.5*(rad_lo + rad_hi)
 
     O, R, E = np.meshgrid(offsets, rad, energy)
 
-    gaus = np.exp(-0.5*R**2/sigma**2)
-    psf_values = gaus/(gaus.sum(0)[0])*u.Unit('sr-1')
+    Rmid = 0.5*(R[:-1]+R[1:])
+    gaus = np.exp(-0.5*Rmid**2/sigma**2)
+    drad=2*np.pi*(np.cos(R[:-1])-np.cos(R[1:]))*u.Unit('sr')
+    psf_values = gaus/((gaus*drad).sum(0)[0])
 
     return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values)
 
 
 
 def test_make_psf_map():
-    psf = fake_psf3d()
+    psf = fake_psf3d(0.3*u.deg)
 
     pointing = SkyCoord(0,0,unit='deg')
-    axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.],unit='TeV')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.],unit='TeV')
     rad_axis = MapAxis(nodes=np.linspace(0.,1.,50),unit='deg')
 
-    geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis,axis])
+    geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis,energy_axis])
 
-    psfmap = make_psf_map(psf, pointing, geom, 3*u.deg)
+    psfmap = PSFMap(make_psf_map(psf, pointing, geom, 3*u.deg))
 
-    pmap = PSFMap(psfmap)
-    # need to assert something...
+    # check axes ordering
+    assert psfmap.psf_map.geom.axes[0] == rad_axis
+    assert psfmap.psf_map.geom.axes[1] == energy_axis
+
+    # Check unit
+    assert psfmap.psf_map.unit == Unit('sr-1')
+
+    # Extract EnergyDependentTablePSF
+    table_psf = psfmap.get_energy_dependent_table_psf(SkyCoord(1, 1, unit='deg'))
+
+    # Check that containment radius is consistent between psf_table and psf3d
+    assert_allclose(table_psf.containment_radius(1*u.TeV, 0.9)[0],
+                    psf.containment_radius(1*u.TeV, 0*u.deg, 0.9),rtol=1e-3)
+    assert_allclose(table_psf.containment_radius(1*u.TeV, 0.5)[0],
+                    psf.containment_radius(1*u.TeV, 0*u.deg, 0.5),rtol=1e-3)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -8,53 +8,75 @@ from astropy.coordinates import SkyCoord
 from ...irf import PSF3D
 from ...maps import WcsNDMap, MapAxis, WcsGeom
 from ...cube import PSFMap, make_psf_map
+from ...utils.testing import requires_dependency, requires_data
 
 
-def fake_psf3d(sigma = 0.15 * u.deg):
-    offsets = np.array((0.,1., 2., 3.))*u.deg
-    energy = np.logspace(-1,1,5)*u.TeV
+def fake_psf3d(sigma=0.15 * u.deg):
+    offsets = np.array((0., 1., 2., 3.)) * u.deg
+    energy = np.logspace(-1, 1, 5) * u.TeV
     energy_lo = energy[:-1]
     energy_hi = energy[1:]
-    energy = np.sqrt(energy_lo*energy_hi)
-    rad = np.linspace(0,1.,101)*u.deg
+    energy = np.sqrt(energy_lo * energy_hi)
+    rad = np.linspace(0, 1., 101) * u.deg
     rad_lo = rad[:-1]
     rad_hi = rad[1:]
-#    rad = 0.5*(rad_lo + rad_hi)
+    #    rad = 0.5*(rad_lo + rad_hi)
 
     O, R, E = np.meshgrid(offsets, rad, energy)
 
-    Rmid = 0.5*(R[:-1]+R[1:])
-    gaus = np.exp(-0.5*Rmid**2/sigma**2)
-    drad=2*np.pi*(np.cos(R[:-1])-np.cos(R[1:]))*u.Unit('sr')
-    psf_values = gaus/((gaus*drad).sum(0)[0])
+    Rmid = 0.5 * (R[:-1] + R[1:])
+    gaus = np.exp(-0.5 * Rmid ** 2 / sigma ** 2)
+    drad = 2 * np.pi * (np.cos(R[:-1]) - np.cos(R[1:])) * u.Unit('sr')
+    psf_values = gaus / ((gaus * drad).sum(0)[0])
 
     return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values)
 
 
-
 def test_make_psf_map():
-    psf = fake_psf3d(0.3*u.deg)
+    psf = fake_psf3d(0.3 * u.deg)
 
-    pointing = SkyCoord(0,0,unit='deg')
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.],unit='TeV')
-    rad_axis = MapAxis(nodes=np.linspace(0.,1.,50),unit='deg')
+    pointing = SkyCoord(0, 0, unit='deg')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV')
+    rad_axis = MapAxis(nodes=np.linspace(0., 1., 51), unit='deg')
 
-    geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis,energy_axis])
+    geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis])
 
-    psfmap = PSFMap(make_psf_map(psf, pointing, geom, 3*u.deg))
+    psf_map = make_psf_map(psf, pointing, geom, 3 * u.deg)
 
     # check axes ordering
-    assert psfmap.psf_map.geom.axes[0] == rad_axis
-    assert psfmap.psf_map.geom.axes[1] == energy_axis
+    assert psf_map.geom.axes[0] == rad_axis
+    assert psf_map.geom.axes[1] == energy_axis
 
     # Check unit
-    assert psfmap.psf_map.unit == Unit('sr-1')
+    assert psf_map.unit == Unit('sr-1')
+
+    # check size
+    assert psf_map.data.shape == (4,50,25,25)
+
+@requires_dependency('scipy')
+def test_psfmap(tmpdir):
+    psf = fake_psf3d(0.15 * u.deg)
+
+    pointing = SkyCoord(0, 0, unit='deg')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV')
+    rad_axis = MapAxis(nodes=np.linspace(0., 0.6, 50), unit='deg')
+
+    geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis])
+
+    psfmap = PSFMap(make_psf_map(psf, pointing, geom, 3 * u.deg))
 
     # Extract EnergyDependentTablePSF
     table_psf = psfmap.get_energy_dependent_table_psf(SkyCoord(1, 1, unit='deg'))
 
     # Check that containment radius is consistent between psf_table and psf3d
-    assert_allclose(table_psf.containment_radius(1*u.TeV, 0.9)[0],
-                    psf.containment_radius(1*u.TeV, 0*u.deg, 0.9),rtol=1e-3)
-    assert_allclose(table_psf.containment_radius(1*u.TeV, 0.5)[0],
-                    psf.containment_radius(1*u.TeV, 0*u.deg, 0.5),rtol=1e-3)
+    assert_allclose(table_psf.containment_radius(1 * u.TeV, 0.9)[0],
+                    psf.containment_radius(1 * u.TeV, 0 * u.deg, 0.9), rtol=1e-3)
+    assert_allclose(table_psf.containment_radius(1 * u.TeV, 0.5)[0],
+                    psf.containment_radius(1 * u.TeV, 0 * u.deg, 0.5), rtol=1e-3)
+
+    # test read/write
+    filename = str(tmpdir / "psfmap.fits")
+    psfmap.write(filename, overwrite=True)
+    new_psfmap = PSFMap.read(filename)
+
+    assert_allclose(psfmap.psf_map.data, new_psfmap.psf_map.data)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -1,3 +1,5 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -51,7 +51,8 @@ def test_make_psf_map():
     assert psf_map.unit == Unit('sr-1')
 
     # check size
-    assert psf_map.data.shape == (4,50,25,25)
+    assert psf_map.data.shape == (4, 50, 25, 25)
+
 
 @requires_dependency('scipy')
 def test_psfmap(tmpdir):

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -1,0 +1,41 @@
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from ...irf import PSF3D
+from ...maps import WcsNDMap, MapAxis, WcsGeom
+from ...cube import PSFMap, make_psf_map
+
+
+def fake_psf3d(sigma = 0.15 * u.deg):
+    offsets = np.array((0.,1.))*u.deg
+    energy = np.logspace(-1,1,5)*u.TeV
+    energy_lo = energy[:-1]
+    energy_hi = energy[1:]
+    energy = np.sqrt(energy_lo*energy_hi)
+    rad = np.linspace(0,1.,101)*u.deg
+    rad_lo = rad[:-1]
+    rad_hi = rad[1:]
+    rad = 0.5*(rad_lo + rad_hi)
+
+    O, R, E = np.meshgrid(offsets, rad, energy)
+
+    gaus = np.exp(-0.5*R**2/sigma**2)
+    psf_values = gaus/(gaus.sum(0)[0])*u.Unit('sr-1')
+
+    return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values)
+
+
+
+def test_make_psf_map():
+    psf = fake_psf3d()
+
+    pointing = SkyCoord(0,0,unit='deg')
+    axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.],unit='TeV')
+    rad_axis = MapAxis(nodes=np.linspace(0.,1.,50),unit='deg')
+
+    geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis,axis])
+
+    psfmap = make_psf_map(psf, pointing, geom, 3*u.deg)
+
+    pmap = PSFMap(psfmap)
+    # need to assert something...

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -79,4 +79,4 @@ def test_psfmap(tmpdir):
     psfmap.write(filename, overwrite=True)
     new_psfmap = PSFMap.read(filename)
 
-    assert_allclose(psfmap.psf_map.data, new_psfmap.psf_map.data)
+    assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -36,22 +36,22 @@ def test_make_psf_map():
     psf = fake_psf3d(0.3 * u.deg)
 
     pointing = SkyCoord(0, 0, unit='deg')
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV')
-    rad_axis = MapAxis(nodes=np.linspace(0., 1., 51), unit='deg')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV', name='energy_true')
+    rad_axis = MapAxis(nodes=np.linspace(0., 1., 51), unit='deg', name='theta')
 
     geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis])
 
-    psf_map = make_psf_map(psf, pointing, geom, 3 * u.deg)
+    psfmap = make_psf_map(psf, pointing, geom, 3 * u.deg)
 
     # check axes ordering
-    assert psf_map.geom.axes[0] == rad_axis
-    assert psf_map.geom.axes[1] == energy_axis
+    assert psfmap.psf_map.geom.axes[0] == rad_axis
+    assert psfmap.psf_map.geom.axes[1] == energy_axis
 
     # Check unit
-    assert psf_map.unit == Unit('sr-1')
+    assert psfmap._psf_map.unit == Unit('sr-1')
 
     # check size
-    assert psf_map.data.shape == (4, 50, 25, 25)
+    assert psfmap.data.shape == (4, 50, 25, 25)
 
 
 @requires_dependency('scipy')
@@ -59,12 +59,12 @@ def test_psfmap(tmpdir):
     psf = fake_psf3d(0.15 * u.deg)
 
     pointing = SkyCoord(0, 0, unit='deg')
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV')
-    rad_axis = MapAxis(nodes=np.linspace(0., 0.6, 50), unit='deg')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV', name='energy_true')
+    rad_axis = MapAxis(nodes=np.linspace(0., 0.6, 50), unit='deg', name='theta')
 
     geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis])
 
-    psfmap = PSFMap(make_psf_map(psf, pointing, geom, 3 * u.deg))
+    psfmap = make_psf_map(psf, pointing, geom, 3 * u.deg)
 
     # Extract EnergyDependentTablePSF
     table_psf = psfmap.get_energy_dependent_table_psf(SkyCoord(1, 1, unit='deg'))

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -4,13 +4,13 @@ import numpy as np
 import logging
 from astropy.io import fits
 from astropy.table import Table
-from astropy.units import Quantity
+from astropy.units import Quantity, Unit
 from astropy.coordinates import Angle
 from ..extern.validator import validate_physical_type
 from ..utils.array import array_stats_str
 from ..utils.energy import Energy, EnergyBounds
 from ..utils.scripts import make_path
-from ..irf import HESSMultiGaussPSF
+from ..irf import HESSMultiGaussPSF,PSF3D
 from . import EnergyDependentTablePSF
 
 __all__ = ['EnergyDependentMultiGaussPSF']
@@ -414,7 +414,7 @@ class EnergyDependentMultiGaussPSF(object):
         return EnergyDependentTablePSF(energy=energies, rad=rad,
                                        exposure=exposure, psf_value=psf_value)
 
-    def to_psf3D(self, rad):
+    def to_psf3d(self, rad):
         """ Creates a PSF3D from an analytical PSF.
 
         Parameters
@@ -434,7 +434,7 @@ class EnergyDependentMultiGaussPSF(object):
         rad_lo = rad[:-1]
         rad_hi = rad[1:]
 
-        psf_values = np.zeros((rad_lo.shape[0], offsets.shape[0], energy_lo.shape[0])) * u.Unit('sr-1')
+        psf_values = np.zeros((rad_lo.shape[0], offsets.shape[0], energy_lo.shape[0])) * Unit('sr-1')
 
         for i, offset in enumerate(offsets):
             psftable = self.to_energy_dependent_table_psf(offset)

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -419,11 +419,11 @@ class EnergyDependentMultiGaussPSF(object):
 
         Parameters
         ----------
-        rad : `~astropy.unit.Quantity` or `~astropy.coordinates.Angle`
+        rad : `~astropy.units.Quantity` or `~astropy.coordinates.Angle`
             the array of position errors (rad) on which the PSF3D will be defined
 
-        Return
-        ------
+        Returns
+        -------
         psf3d : `~gammapy.irf.PSF3D`
             the PSF3D. It will be defined on the same energy and offset values than the input psf.
         """

--- a/gammapy/irf/psf_analytical.py
+++ b/gammapy/irf/psf_analytical.py
@@ -414,7 +414,7 @@ class EnergyDependentMultiGaussPSF(object):
         return EnergyDependentTablePSF(energy=energies, rad=rad,
                                        exposure=exposure, psf_value=psf_value)
 
-    def to_psf3D(self):
+    def to_psf3D(self, rad):
         """ Creates a PSF3D from an analytical PSF.
 
         Parameters

--- a/gammapy/irf/tests/test_psf_analytical.py
+++ b/gammapy/irf/tests/test_psf_analytical.py
@@ -6,6 +6,7 @@ from numpy.testing.utils import assert_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
 from astropy import units as u
+from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data
 from ...irf import EnergyDependentMultiGaussPSF
 
@@ -54,6 +55,19 @@ class TestEnergyDependentMultiGaussPSF:
         # TODO: try to improve precision, so that rtol can be lowered
         assert_allclose(desired, actual.degree, rtol=0.03)
 
+    def test_to_psf3d(self, psf):
+        rads = np.linspace(0.,1.0,301)*u.deg
+        psf_3d = psf.to_psf3d(rads)
+        assert psf_3d.rad_lo.shape == (300,)
+        assert psf_3d.rad_lo.unit == 'deg'
+
+        theta=0.5*u.deg
+        energy = 0.5*u.TeV
+
+        containment = np.linspace(0.1, 0.95, 10)
+        desired = np.array([psf.containment_radius(energy,theta,_).value for _ in containment])
+        actual = np.array([psf_3d.containment_radius(energy,theta,_).value for _ in containment])
+        assert_allclose(np.squeeze(desired),actual,rtol=0.01)
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')


### PR DESCRIPTION
This PR adds a function to project a `gammapy.irf.PSF3D` on a `gammapy.map`. 
It also adds a class to work with the resulting Map to extract an `gammapy.irf.EnergyDependentTablePSF` at any position or to produce a PSF kernel following the implementation of PR #1388.
The complete computation of a PSFMap for a collection of observation has to be performed on a higher level maker class. This will be added in a coming PR.

