### PR TITLE
Fix map write for custom axis name

### DIFF
--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -17,7 +17,7 @@ from ..wcsnd import WcsNDMap
 pytest.importorskip('scipy')
 pytest.importorskip('reproject')
 
-axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log')]
+axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log', name='spam')]
 axes2 = [MapAxis(np.logspace(0., 3., 3), interp='log'),
          MapAxis(np.logspace(1., 3., 4), interp='lin')]
 skydir = SkyCoord(110., 75.0, unit='deg', frame='icrs')


### PR DESCRIPTION
This PR fixes issue #1429 reported by @registerrier .

The key change is to use
```
s = 'AXIS%i' % i if name == '' else name
colnames = [s, s + '_MIN', s + '_MAX']
```
in `make_axes_cols` so that if the axis has a `name`, that name is used for the `colnames`.

The change in the test to add an axis `name='spam'` revealed the issue and now serves as a regression test:
```
axes1 = [MapAxis(np.logspace(0., 3., 3), interp='log', name='spam')]
```

@registerrier @woodmd - Please review.