### PR TITLE
Fix gamma_rate in SpectrumObervation.stats_in_range

### DIFF
--- a/gammapy/data/obs_stats.py
+++ b/gammapy/data/obs_stats.py
@@ -52,12 +52,14 @@ class ObservationStats(Stats):
         self.obs_id = obs_id
         self.livetime = livetime
         if alpha is not None:
+            self.a_on = alpha
+            self.a_off = 1
             self.alpha_obs = alpha
         elif a_off > 0:
             self.alpha_obs = a_on / a_off
         else:
             self.alpha_obs = 0
-        self.gamma_rate = gamma_rate or n_on / livetime
+        self.gamma_rate = gamma_rate or self.excess / livetime
         self.bg_rate = bg_rate or self.alpha_obs * n_off / livetime
 
     @classmethod

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -30,8 +30,8 @@ class SpectrumStats(ObservationStats):
     """
 
     def __init__(self, **kwargs):
-        self.energy_min = kwargs.pop('energy_min', None)
-        self.energy_max = kwargs.pop('energy_max', None)
+        self.energy_min = kwargs.pop('energy_min', Quantity(0, 'TeV'))
+        self.energy_max = kwargs.pop('energy_max', Quantity(0, 'TeV'))
         super(SpectrumStats, self).__init__(**kwargs)
 
     def __str__(self):
@@ -313,6 +313,7 @@ class SpectrumObservation(object):
         stats_list = [self.stats(ii) for ii in idx]
         stacked_stats = SpectrumStats.stack(stats_list)
         stacked_stats.livetime = self.livetime
+        stacked_stats.gamma_rate = stacked_stats.excess / stacked_stats.livetime
         stacked_stats.obs_id = self.obs_id
         stacked_stats.energy_min = self.e_reco[bin_min]
         stacked_stats.energy_max = self.e_reco[bin_max + 1]


### PR DESCRIPTION
Fixes #1428 

The problem was that in a ``SpectrumObservation`` the total stats are computed by stacking the stats in the individual bins. In this stacking process the livetimes are added. For the use case of stacking bins this is obviously wrong, so the livetime is reset manually at the end of the process. The ``gamma_rate`` however was not reset. This is quick fix. One could think about making ``ObservationStats`` more fail save by adding properties and so on but IMO it's not necessary.