### PR TITLE
Add __repr__ methods to Maps and related classes

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -742,7 +742,6 @@ class Map(object):
         pass
 
     def __repr__(self):
-        """String representation of the Map object"""
         str_ = self.__class__.__name__
         str_ += "\n\n"
         geom = self.geom.__class__.__name__[:3]

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -741,3 +741,15 @@ class Map(object):
         """
         pass
 
+    def __repr__(self):
+        """String representation of the Map object"""
+        str_ = self.__class__.__name__
+        str_ += "\n\n"
+        geom = self.geom.__class__.__name__[:3]
+        str_ += "\tgeom      : {} \n ".format(geom)
+        str_ += "\tunit      : {} \n".format(self.unit)
+        str_ += "\tdata shape: {}\n".format(self.data.shape)
+        str_ += "\tdata mean : {:.1e} {}\n".format(np.nanmean(self.data), self.unit)
+        str_ += "\tdata min  : {:.1e} {}\n".format(np.nanmin(self.data), self.unit)
+        str_ += "\tdata max  : {:.1e} {}\n".format(np.nanmax(self.data), self.unit)
+        return str_

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -609,8 +609,7 @@ class MapAxis(object):
         return MapAxis(nodes, interp=self._interp, name=self._name,
                        node_type=self._node_type, unit=self._unit)
 
-    def __str__(self):
-        """String representation of the MapAxis object"""
+    def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
         str_ += "\tname     : {}\n".format(self.name)
@@ -620,6 +619,7 @@ class MapAxis(object):
         str_ += "\tnode type: {}\n".format(self.node_type)
         str_ += "\tedge min : {:.1e} {}\n".format(self.edges.min(), self.unit)
         str_ += "\tedge max : {:.1e} {}\n".format(self.edges.max(), self.unit)
+        str_ += "\tinterp   : {}\n".format(self._interp)
         return str_
 
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -609,6 +609,19 @@ class MapAxis(object):
         return MapAxis(nodes, interp=self._interp, name=self._name,
                        node_type=self._node_type, unit=self._unit)
 
+    def __str__(self):
+        """String representation of the MapAxis object"""
+        str_ = self.__class__.__name__
+        str_ += "\n\n"
+        str_ += "\tname     : {}\n".format(self.name)
+        str_ += "\ttype     : {}\n".format(self.type)
+        str_ += "\tunit     : {}\n".format(self.unit)
+        str_ += "\tnbins    : {}\n".format(self.nbin)
+        str_ += "\tnode type: {}\n".format(self.node_type)
+        str_ += "\tedge min : {:.1e} {}\n".format(self.edges.min(), self.unit)
+        str_ += "\tedge max : {:.1e} {}\n".format(self.edges.max(), self.unit)
+        return str_
+
 
 class MapCoord(object):
     """Represents a sequence of n-dimensional map coordinates.

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1732,7 +1732,6 @@ class HpxGeom(MapGeom):
         return Quantity(hp.nside2pixarea(self.nside), 'sr')
 
     def __repr__(self):
-        """String representation of the MapAxis object"""
         str_ = self.__class__.__name__
         str_ += "\n\n"
         str_ += "\tnpix      : {npix[0][0]} pix\n".format(npix=self.npix)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1734,7 +1734,7 @@ class HpxGeom(MapGeom):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        str_ += "\tnpix      : {npix[0][0]} pix\n".format(npix=self.npix)
+        str_ += "\tnpix      : {npix[0]} pix\n".format(npix=self.npix)
         str_ += "\tnside     : {nside[0]}\n".format(nside=self.nside)
         str_ += "\tnested    : {}\n".format(self.nest)
         str_ += "\tcoordsys  : {}\n".format(self.coordsys)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1731,6 +1731,23 @@ class HpxGeom(MapGeom):
         import healpy as hp
         return Quantity(hp.nside2pixarea(self.nside), 'sr')
 
+    def __repr__(self):
+        """String representation of the MapAxis object"""
+        str_ = self.__class__.__name__
+        str_ += "\n\n"
+        str_ += "\tnpix      : {npix[0][0]} pix\n".format(npix=self.npix)
+        str_ += "\tnside     : {nside[0]}\n".format(nside=self.nside)
+        str_ += "\tnested    : {}\n".format(self.nest)
+        str_ += "\tcoordsys  : {}\n".format(self.coordsys)
+        str_ += "\tprojection: {}\n".format(self.projection)
+        lon, lat = self.center_skydir.data.lon.deg, self.center_skydir.data.lat.deg
+        str_ += "\tcenter    : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
+        str_ += "\tndim      : {}\n".format(self.ndim)
+        axes = [_.name for _ in self.axes]
+        str_ += "\taxes      : {}\n".format(", ".join(axes))
+        return str_
+
+
 
 class HpxToWcsMapping(object):
     """Stores the indices need to convert from HEALPIX to WCS.

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -37,6 +37,7 @@ mapbase_args = [
 def test_map_create(binsz, width, map_type, skydir, axes, unit):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes, unit=unit)
+    assert m.unit == unit
 
 
 def test_map_from_geom():
@@ -99,3 +100,10 @@ def test_map_unit_read_write(map_type, unit):
 
     m2 = Map.from_hdu_list(hdu_list)
     assert m2.unit == unit
+
+
+@pytest.mark.parametrize(('map_type', 'unit'), unit_args)
+def test_map_repr(map_type, unit):
+    m = Map.create(binsz=0.1, width=10.0, map_type=map_type, unit=unit)
+    assert unit in repr(m)
+    assert m.__class__.__name__ in repr(m)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -105,5 +105,4 @@ def test_map_unit_read_write(map_type, unit):
 @pytest.mark.parametrize(('map_type', 'unit'), unit_args)
 def test_map_repr(map_type, unit):
     m = Map.create(binsz=0.1, width=10.0, map_type=map_type, unit=unit)
-    assert unit in repr(m)
     assert m.__class__.__name__ in repr(m)

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -221,3 +221,8 @@ def test_mapcoords_to_coordsys():
     assert_allclose(coords.skycoord.transform_to(
         'icrs').dec.deg, skycoord_gal.icrs.dec.deg)
 
+
+def test_mapaxis_repr():
+    axis = MapAxis([1, 2, 3], name='test')
+    assert axis.__class__.__name__ in repr(axis)
+    assert 'test' in repr(axis)

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -225,4 +225,3 @@ def test_mapcoords_to_coordsys():
 def test_mapaxis_repr():
     axis = MapAxis([1, 2, 3], name='test')
     assert axis.__class__.__name__ in repr(axis)
-    assert 'test' in repr(axis)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -545,6 +545,6 @@ def test_hpxgeom_solid_angle():
 
 
 def test_geom_repr():
-    geom = HpxGeom(nside=12)
+    geom = HpxGeom(nside=8)
     assert geom.__class__.__name__ in repr(geom)
     assert 'nside' in repr(geom)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -542,3 +542,9 @@ def test_hpxgeom_solid_angle():
 
     assert solid_angle.shape == (1,)
     assert_allclose(solid_angle.value, 0.016362461737446838)
+
+
+def test_geom_repr():
+    geom = HpxGeom(nside=12)
+    assert geom.__class__.__name__ in repr(geom)
+    assert 'nside' in repr(geom)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -156,3 +156,10 @@ def test_wcsgeom_solid_angle_ait():
                               coordsys='GAL', proj='AIT')
     solid_angle = ait_geom.solid_angle()
     assert np.isnan(solid_angle[0, 0])
+
+
+def test_geom_repr():
+    geom = WcsGeom.create(skydir=(0, 0), npix=(10, 4), binsz=50,
+                          coordsys='GAL', proj='AIT')
+    assert geom.__class__.__name__ in repr(geom)
+    assert 'npix' in repr(geom)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -162,4 +162,3 @@ def test_geom_repr():
     geom = WcsGeom.create(skydir=(0, 0), npix=(10, 4), binsz=50,
                           coordsys='GAL', proj='AIT')
     assert geom.__class__.__name__ in repr(geom)
-    assert 'npix' in repr(geom)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -663,7 +663,6 @@ class WcsGeom(MapGeom):
         return region.contains(pixcoord)
 
     def __repr__(self):
-        """String representation of the MapAxis object"""
         str_ = self.__class__.__name__
         str_ += "\n\n"
         str_ += "\tnpix      : {npix[0][0]} x {npix[1][0]} pix\n".format(npix=self.npix)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -659,8 +659,24 @@ class WcsGeom(MapGeom):
         if not self.is_regular:
             raise NotImplementedError("Region mask is not working yet with multiresolution maps")
         idx = self.get_idx()
-        pixcoord = PixCoord(idx[0],idx[1])
+        pixcoord = PixCoord(idx[0], idx[1])
         return region.contains(pixcoord)
+
+    def __repr__(self):
+        """String representation of the MapAxis object"""
+        str_ = self.__class__.__name__
+        str_ += "\n\n"
+        str_ += "\tnpix      : {npix[0][0]} x {npix[1][0]} pix\n".format(npix=self.npix)
+        str_ += "\tcoordsys  : {}\n".format(self.coordsys)
+        str_ += "\tprojection: {}\n".format(self.projection)
+        lon, lat = self.center_skydir.data.lon.deg, self.center_skydir.data.lat.deg
+        str_ += "\tcenter    : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
+        str_ += ("\twidth     : {width[0][0]:.1f} x {width[1][0]:.1f} "
+                 "deg\n".format(width=self.width))
+        str_ += "\tndim      : {}\n".format(self.ndim)
+        axes = [_.name for _ in self.axes]
+        str_ += "\taxes      : {}\n".format(", ".join(axes))
+        return str_
 
 
 def create_wcs(skydir, coordsys='CEL', projection='AIT',

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -4,7 +4,6 @@ import copy
 import numpy as np
 from astropy.io import fits
 from astropy.units import Quantity
-from collections import OrderedDict
 from .utils import unpack_seq
 from .geom import pix_tuple_to_idx, axes_pix_to_coord
 from .utils import interp_to_order
@@ -15,6 +14,7 @@ from .reproject import reproject_car_to_hpx, reproject_car_to_wcs
 __all__ = [
     'WcsNDMap',
 ]
+
 
 class WcsNDMap(WcsMap):
     """Representation of a N+2D map using WCS with two spatial dimensions
@@ -471,7 +471,7 @@ class WcsNDMap(WcsMap):
             Set the image slice to plot if this map has non-spatial dimensions.
             For maps with exactly one non-spatial dimension idx can be an int
         **kwargs : dict
-            Keyword arguments passed to `~matplotlib.pyplot.imshow`.   
+            Keyword arguments passed to `~matplotlib.pyplot.imshow`.
 
         Returns
         -------
@@ -509,7 +509,6 @@ class WcsNDMap(WcsMap):
         ax.coords.grid(color='w', linestyle=':', linewidth=0.5)
         return fig, ax, im
 
-
     def make_region_mask(self, region, inside=True):
         """Create a mask of a given region
 
@@ -529,6 +528,6 @@ class WcsNDMap(WcsMap):
         """
         mask = self.geom.get_region_mask_array(region)
         if inside is False:
-            np.logical_not(mask,out=mask)
+            np.logical_not(mask, out=mask)
         # TODO : update meta table to include something about the region used for mask creation?
         return WcsNDMap(geom=self.geom, data=mask, meta=self.meta)


### PR DESCRIPTION
This PR adds `__repr__` methods to the Maps, MapsGeom and MapAxis classes. 