### PR TITLE
Add get image convenience methods to maps

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -193,4 +193,3 @@ Please help make these better, or write new, better ones!
 - `Fermi Vela model <notebooks/fermi_vela_model.html>`__ (Fermi Vela model) | *fermi_vela_model.ipynb*
 - `Simulating and analysing sources and diffuse emission <notebooks/source_diffuse_estimation.html>`__ | *source_diffuse_estimation.ipynb*
 - `Time analysis with Gammapy <notebooks/time_analysis.html>`__ (not written yet) | *time_analysis.ipynb*
->>>>>>> add link to example notebook

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -499,7 +499,7 @@ class Map(object):
         """
         pass
 
-    def get_image_by_coord(self, coords):
+    def get_image_by_coord(self, coords, copy=True):
         """Return spatial map at the given axis coordinates.
 
         Parameters
@@ -565,9 +565,10 @@ class Map(object):
 
         coords = MapCoord(coords_)
         idx = self.geom.coord_to_idx(coords)
-        return self.get_image_by_idx(idx[2:])
+        idx = idx[-len(self.geom.axes):]
+        return self.get_image_by_idx(idx, copy=copy)
 
-    def get_image_by_pix(self, pix):
+    def get_image_by_pix(self, pix, copy=True):
         """Return spatial map at the given axis pixel coordinates
 
         Parameters
@@ -582,11 +583,12 @@ class Map(object):
         map_out : '~Map'
             Map with spatial dimensions only.
         """
-        pix = (np.nan, np.nan) + pix
+        pix = (np.nan, ) * (self.data.ndim - len(self.geom.axes)) + pix
         idx = self.geom.pix_to_idx(pix)
-        return self.get_image_by_idx(idx[2:])
+        idx = idx[-len(self.geom.axes):]
+        return self.get_image_by_idx(idx, copy=copy)
 
-    def get_image_by_idx(self, idx):
+    def get_image_by_idx(self, idx, copy=True):
         """Return spatial map at the given axis pixel indices.
 
         Parameters
@@ -605,8 +607,8 @@ class Map(object):
                              " non spatial dimensions")
         geom = self.geom.to_image()
         map_out = self.__class__(geom=geom)
-        idx += (None, None)
-        data_out = self.data[idx].copy()
+        idx = (slice(None), ) * (self.data.ndim - len(self.geom.axes)) + idx
+        data_out = self.data.T[idx].copy() if copy else self.data.T[idx]
         map_out.data = np.squeeze(data_out)
         return map_out
 
@@ -645,7 +647,7 @@ class Map(object):
             Tuple of pixel index arrays for each dimension of the map.
             Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
-            Pixel indices can be either float or integer type. 
+            Pixel indices can be either float or integer type.
 
         Returns
         ----------

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -457,7 +457,7 @@ class Map(object):
 
     @abc.abstractmethod
     def downsample(self, factor, preserve_counts=True):
-        """Downsample the spatial dimension of the map by a given factor. 
+        """Downsample the spatial dimension of the map by a given factor.
 
         Parameters
         ----------
@@ -477,7 +477,7 @@ class Map(object):
 
     @abc.abstractmethod
     def upsample(self, factor, order=0, preserve_counts=True):
-        """Upsample the spatial dimension of the map by a given factor. 
+        """Upsample the spatial dimension of the map by a given factor.
 
         Parameters
         ----------
@@ -497,6 +497,69 @@ class Map(object):
 
         """
         pass
+
+    def get_image_by_coord(self, coords):
+        """Return spatial map at the given axis coordinates.
+
+        Parameters
+        ----------
+        coords : tuple or `~gammapy.maps.MapCoord`
+            `~gammapy.maps.MapCoord` object or tuple of coordinate arrays for
+            each non-spatial dimension of the map. Tuple should be ordered as
+            (x_0, ..., x_n) where x_i are coordinates for non-spatial dimensions
+            of the map.
+
+        Returns
+        -------
+        map_out : '~Map'
+            Map with spatial dimensions only.
+        """
+        if isinstance(coords, tuple):
+            coords = (np.nan, np.nan) + coords
+        idx = self.geom.coord_to_idx(coords)
+        return self.get_image_by_idx(idx[2:])
+
+    def get_image_by_pix(self, pix):
+        """Return spatial map at the given axis pixel coordinates
+
+        Parameters
+        ----------
+        pix : tuple
+            Tuple of pixel index arrays for each non-spatial dimension of the map.
+            Tuple should be ordered as (I_0, ..., I_n). Pixel indices can be
+            either float or integer type.
+
+        Returns
+        -------
+        map_out : '~Map'
+            Map with spatial dimensions only.
+        """
+        idx = self.geom.pix_to_idx(pix)
+        return self.get_image_by_idx(idx)
+
+    def get_image_by_idx(self, idx):
+        """Return spatial map at the given axis pixel indices.
+
+        Parameters
+        ----------
+        idx : tuple
+            Tuple of index arrays for each non spatial dimension of the map.
+            Tuple should be ordered as (I_0, ..., I_n).
+
+        Returns
+        -------
+        map_out : '~Map'
+            Map with spatial dimensions only.
+        """
+        if len(idx) != len(self.geom.axes):
+            raise ValueError("Tuple length must be equal to number of"
+                             " non spatial dimensions")
+        geom = self.geom.to_image()
+        map_out = self.__class__(geom=geom)
+        idx += (None, None)
+        data_out = self.data[idx].copy()
+        map_out.data = np.squeeze(data_out)
+        return map_out
 
     def get_by_coord(self, coords):
         """Return map values at the given map coordinates.

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -534,8 +534,9 @@ class Map(object):
         map_out : '~Map'
             Map with spatial dimensions only.
         """
+        pix = (np.nan, np.nan) + pix
         idx = self.geom.pix_to_idx(pix)
-        return self.get_image_by_idx(idx)
+        return self.get_image_by_idx(idx[2:])
 
     def get_image_by_idx(self, idx):
         """Return spatial map at the given axis pixel indices.

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -180,7 +180,7 @@ class Map(object):
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
 
-        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}        
+        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
             Map type.  Selects the class that will be used to
             instantiate the map.  The map type should be consistent
             with the geometry.  If map_type is 'auto' then an
@@ -285,7 +285,7 @@ class Map(object):
         hdu_bands : str
             Set the name of the bands table extension.  By default this will
             be set to BANDS.
-        conv : str        
+        conv : str
             FITS format convention.  By default files will be written
             to the gamma-astro-data-formats (GADF) format.  This
             option can be used to write files that are compliant with
@@ -293,8 +293,8 @@ class Map(object):
             Fermi Science Tools).  Supported conventions are 'gadf',
             'fgst-ccube', 'fgst-ltcube', 'fgst-bexpcube',
             'fgst-template', 'fgst-srcmap', 'fgst-srcmap-sparse',
-            'galprop', and 'galprop2'.            
-        sparse : bool        
+            'galprop', and 'galprop2'.
+        sparse : bool
             Sparsify the map by dropping pixels with zero amplitude.
             This option is only compatible with the 'gadf' format.
         """
@@ -514,40 +514,46 @@ class Map(object):
         Examples
         --------
 
-            import numpy as np
-            from gammapy.maps import Map, MapAxis
-            from astropy.coordinates import SkyCoord
-            from astropy import units as u
+        .. code:: python
 
-            # Define map axes
-            energy_axis = MapAxis.from_edges(
-                np.logspace(-1., 1., 4), unit='TeV', name='energy',
-            )
+                import numpy as np
+                from gammapy.maps import Map, MapAxis
+                from astropy.coordinates import SkyCoord
+                from astropy import units as u
 
-            time_axis = MapAxis.from_edges(
-                np.linspace(0., 10, 20), unit='h', name='time',
-            )
+                # Define map axes
+                energy_axis = MapAxis.from_edges(
+                    np.logspace(-1., 1., 4), unit='TeV', name='energy',
+                )
 
-            # Define map center
-            skydir = SkyCoord(0, 0, frame='galactic', unit='deg')
+                time_axis = MapAxis.from_edges(
+                    np.linspace(0., 10, 20), unit='h', name='time',
+                )
 
-            # Create map
-            m_wcs = Map.create(
-                map_type='wcs',
-                binsz=0.02,
-                skydir=skydir,
-                width=10.0,
-                axes=[energy_axis, time_axis],
-            )
+                # Define map center
+                skydir = SkyCoord(0, 0, frame='galactic', unit='deg')
 
-        >>> # Get image by coord tuple
-        >>> image = m_wcs.get_image_by_coord(('500 GeV', '1 h'))
+                # Create map
+                m_wcs = Map.create(
+                    map_type='wcs',
+                    binsz=0.02,
+                    skydir=skydir,
+                    width=10.0,
+                    axes=[energy_axis, time_axis],
+                )
 
-        >>> # Get image by coord dict with strings
-        >>> image = m_wcs.get_image_by_coord({'energy': '500 GeV', 'time': '1 h'})
+            # Get image by coord tuple
+            image = m_wcs.get_image_by_coord(('500 GeV', '1 h'))
 
-        >>> # Get image by coord dict with quantities
-        >>> image = m_wcs.get_image_by_coord({'energy': 0.5 * u.TeV, 'time': 1 * u.h})
+            # Get image by coord dict with strings
+            image = m_wcs.get_image_by_coord({'energy': '500 GeV', 'time': '1 h'})
+
+            # Get image by coord dict with quantities
+            image = m_wcs.get_image_by_coord({'energy': 0.5 * u.TeV, 'time': 1 * u.h})
+
+        See Also
+        --------
+        get_image_by_idx, get_image_by_pix
 
         Returns
         -------
@@ -577,6 +583,10 @@ class Map(object):
         copy : bool
             Whether to make a copy of the data.
 
+        See Also
+        --------
+        get_image_by_coord, get_image_by_idx
+
         Returns
         -------
         map_out : '~Map'
@@ -595,6 +605,10 @@ class Map(object):
             Tuple should be ordered as (I_0, ..., I_n).
         copy : bool
             Whether to make a copy of the data.
+
+        See Also
+        --------
+        get_image_by_coord, get_image_by_pix
 
         Returns
         -------
@@ -631,9 +645,8 @@ class Map(object):
            Values of pixels in the map.  np.nan used to flag coords
            outside of map.
         """
-        coords = MapCoord.create(coords, coordsys=self.geom.coordsys)       
+        coords = MapCoord.create(coords, coordsys=self.geom.coordsys)
         msk = self.geom.contains(coords)
-        print(msk)
         vals = np.empty(coords.shape, dtype=self.data.dtype)
         coords = coords.apply_mask(msk)
         idx = self.geom.coord_to_idx(coords)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -745,11 +745,11 @@ class MapCoord(object):
         ----------
         coords : tuple
             Coordinate tuple with first element of type
-            `~astropy.coordinates.SkyCoord`.        
+            `~astropy.coordinates.SkyCoord`.
         coordsys : {'CEL', 'GAL', None}
             Spatial coordinate system of output `~MapCoord` object.
             If None the coordinate system will be set to the frame of
-            the `~astropy.coordinates.SkyCoord` object.        
+            the `~astropy.coordinates.SkyCoord` object.
         """
         skycoord = coords[0]
         if skycoord.frame.name in ['icrs', 'fk5']:
@@ -1306,7 +1306,7 @@ class MapGeom(object):
 
     @abc.abstractmethod
     def upsample(self, factor):
-        """Upsample the spatial dimension of the geometry by a given factor. 
+        """Upsample the spatial dimension of the geometry by a given factor.
 
         Parameters
         ----------
@@ -1342,3 +1342,11 @@ class MapGeom(object):
             else:
                 raise ValueError('Invalid node type '
                                  '{}'.format(ax.node_type))
+
+    @property
+    def is_image(self):
+        """Whether the geom is equivalent to an image without extra dimensions."""
+        if self.axes is None:
+            return True
+        is_image = len(self.axes) == 0
+        return is_image

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -635,7 +635,7 @@ class MapCoord(object):
     ----------
     data : `~collections.OrderedDict` of `~numpy.ndarray`
         Dictionary of coordinate arrays.
-    coordsys : {'CEL', 'GAL', None}    
+    coordsys : {'CEL', 'GAL', None}
         Spatial coordinate system.  If None then the coordinate system
         will be set to the native coordinate system of the geometry.
     copy : bool

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -47,10 +47,12 @@ def test_map_from_geom():
     geom = WcsGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
     assert isinstance(m, WcsNDMap)
+    assert m.geom.is_image
 
     geom = HpxGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
     assert isinstance(m, HpxNDMap)
+    assert m.geom.is_image
 
 
 @pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes', 'unit'),
@@ -66,7 +68,7 @@ def test_map_get_image_by_coord(binsz, width, map_type, skydir, axes, unit):
     im_geom = m.geom.to_image()
     skycoord = im_geom.get_coord().skycoord
     m_vals = m.get_by_coord((skycoord,) + coords)
-    assert_equal(m_image.data, m_vals.data)
+    assert_equal(m_image.data, m_vals)
 
 
 @pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes', 'unit'),
@@ -80,7 +82,7 @@ def test_map_get_image_by_pix(binsz, width, map_type, skydir, axes, unit):
     im_geom = m.geom.to_image()
     idx = im_geom.get_idx()
     m_vals = m.get_by_pix(idx + pix)
-    assert_equal(m_image.data, m_vals.data)
+    assert_equal(m_image.data, m_vals)
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -58,15 +58,15 @@ def test_map_from_geom():
 def test_map_get_image_by_coord(binsz, width, map_type, skydir, axes, unit):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes, unit=unit)
-    coords = (1.234,) * len(m.geom.axes)
-    m_im_tuple = m.get_image_by_coord(coords)
+    m.data = np.arange(m.data.size, dtype=float).reshape(m.data.shape)
 
-    coords_dict = {}
-    for value, axes in zip(coords, m.geom.axes):
-        coords_dict[axes.name] = value * Unit(axes.unit)
+    coords = (3.456, 0.1234)[:len(m.geom.axes)]
+    m_image = m.get_image_by_coord(coords)
 
-    m_im_dict = m.get_image_by_coord(coords_dict)
-    assert_equal(m_im_tuple.data, m_im_dict.data)
+    im_geom = m.geom.to_image()
+    skycoord = im_geom.get_coord().skycoord
+    m_vals = m.get_by_coord((skycoord,) + coords)
+    assert_equal(m_image.data, m_vals.data)
 
 
 @pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes', 'unit'),
@@ -74,8 +74,13 @@ def test_map_get_image_by_coord(binsz, width, map_type, skydir, axes, unit):
 def test_map_get_image_by_pix(binsz, width, map_type, skydir, axes, unit):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes, unit=unit)
-    pix = (0.1234,) * len(m.geom.axes)
-    m_im = m.get_image_by_pix(pix)
+    pix = (1.2345, 0.1234)[:len(m.geom.axes)]
+    m_image = m.get_image_by_pix(pix)
+
+    im_geom = m.geom.to_image()
+    idx = im_geom.get_idx()
+    m_vals = m.get_by_pix(idx + pix)
+    assert_equal(m_image.data, m_vals.data)
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -236,33 +236,6 @@ def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
-def test_wcsndmap_get_image_by_coord(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
-                          proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsNDMap(geom)
-    coords = (1.234,) * len(m.geom.axes)
-    m_im_tuple = m.get_image_by_coord(coords)
-
-    coords_dict = {}
-    for value, axes in zip(coords, m.geom.axes):
-        coords_dict[axes.name] = value * u.Unit(axes.unit)
-
-    m_im_dict = m.get_image_by_coord(coords_dict)
-    assert_allclose(m_im_tuple.data, m_im_dict.data)
-
-
-@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
-                         wcs_test_geoms)
-def test_wcsndmap_get_image_by_pix(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
-                          proj=proj, coordsys=coordsys, axes=axes)
-    m = WcsNDMap(geom)
-    pix = (0.1234,) * len(m.geom.axes)
-    m_im = m.get_image_by_pix(pix)
-
-
-@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
-                         wcs_test_geoms)
 def test_wcsndmap_interp_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -241,7 +241,14 @@ def test_wcsndmap_get_image_by_coord(npix, binsz, coordsys, proj, skydir, axes):
                           proj=proj, coordsys=coordsys, axes=axes)
     m = WcsNDMap(geom)
     coords = (1.234,) * len(m.geom.axes)
-    m_im = m.get_image_by_coord(coords)
+    m_im_tuple = m.get_image_by_coord(coords)
+
+    coords_dict = {}
+    for value, axes in zip(coords, m.geom.axes):
+        coords_dict[axes.name] = value * u.Unit(axes.unit)
+
+    m_im_dict = m.get_image_by_coord(coords_dict)
+    assert_allclose(m_im_tuple.data, m_im_dict.data)
 
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -236,6 +236,26 @@ def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
 
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
+def test_wcsndmap_get_image_by_coord(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsNDMap(geom)
+    coords = (1.234,) * len(m.geom.axes)
+    m_im = m.get_image_by_coord(coords)
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
+def test_wcsndmap_get_image_by_pix(npix, binsz, coordsys, proj, skydir, axes):
+    geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
+                          proj=proj, coordsys=coordsys, axes=axes)
+    m = WcsNDMap(geom)
+    pix = (0.1234,) * len(m.geom.axes)
+    m_im = m.get_image_by_pix(pix)
+
+
+@pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
+                         wcs_test_geoms)
 def test_wcsndmap_interp_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(npix=npix, binsz=binsz, skydir=skydir,
                           proj=proj, coordsys=coordsys, axes=axes)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -61,10 +61,10 @@ class WcsGeom(MapGeom):
     cdelt : tuple
         Pixel size in each image plane.  If none then a constant pixel size will be used.
     crpix : tuple
-        Reference pixel coordinate in each image plane.  
+        Reference pixel coordinate in each image plane.
     axes : list
         Axes for non-spatial dimensions
-    conv : {'gadf', 'fgst-ccube', 'fgst-template'}    
+    conv : {'gadf', 'fgst-ccube', 'fgst-template'}
         Serialization format convention.  This sets the default format
         that will be used when writing this geometry to a file.
     """
@@ -541,8 +541,6 @@ class WcsGeom(MapGeom):
                 else:
                     np.clip(idxs[i], 0, self.axes[i - 2].nbin - 1, out=idxs[i])
             else:
-                # TODO: indices out of range are set to -1 here. Maybe the behaviour
-                # should be changed to raise an IndexError instead?
                 if i < 2:
                     np.putmask(idxs[i], (idx < 0) | (idx >= npix[i]), -1)
                 else:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -541,11 +541,13 @@ class WcsGeom(MapGeom):
                 else:
                     np.clip(idxs[i], 0, self.axes[i - 2].nbin - 1, out=idxs[i])
             else:
+                # TODO: indices out of range are set to -1 here. Maybe the behaviour
+                # should be changed to raise an IndexError instead?
                 if i < 2:
                     np.putmask(idxs[i], (idx < 0) | (idx >= npix[i]), -1)
                 else:
                     np.putmask(idxs[i], (idx < 0) | (
-                            idx >= self.axes[i - 2].nbin), -1)
+                               idx >= self.axes[i - 2].nbin), -1)
 
         return idxs
 


### PR DESCRIPTION
This PR adds `.get_image_by_coord()`, `.get_image_by_pix()` and `.get_image_by_idx()` convenience methods to the `Map` class. Those methods allow the user to easily access images by only giving the coordinates of the non-spatial axes and getting back again a `Map` object with only 2 dimensions. This is a special case of more general slicing (see #1329) method, but as it is very common to work with images, it's probably well justified to add a convenience method for this case.  