### PR TITLE
Revert "Handling binsz and width units in Map.create"

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -106,13 +106,8 @@ class Map(object):
         map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse'}
             Map type.  Selects the class that will be used to
             instantiate the map.
-        binsz : float or tuple `~astropy.units.Unit`
-            Pixel size.  A tuple will be interpreted
-            as parameters for longitude and latitude axes.
-            If no astropy.units are given, assuming degrees.
-        width : float or tuple `~astropy.units.Unit`
-            Width of the map.  A tuple will be interpreted
-            as parameters for longitude and latitude axes.
+        binsz : float or `~numpy.ndarray`
+            Pixel size in degrees.
         skydir : `~astropy.coordinates.SkyCoord`
             Coordinate of map center.
         axes : list
@@ -132,11 +127,6 @@ class Map(object):
         """
         from .hpxmap import HpxMap
         from .wcsmap import WcsMap
-
-        if 'binsz' in kwargs:
-            kwargs['binsz'] = Quantity(kwargs['binsz'],'deg').value
-        if 'width' in kwargs:
-            kwargs['width'] = Quantity(kwargs['width'],'deg').value
 
         map_type = kwargs.setdefault('map_type', 'wcs')
         if 'wcs' in map_type.lower():

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1160,9 +1160,9 @@ class HpxGeom(MapGeom):
         nside : int or `~numpy.ndarray`
             HEALPix NSIDE parameter.  This parameter sets the size of
             the spatial pixels in the map.
-        binsz : float or `~numpy.ndarray` or `~astropy.units.Unit`
-            Approximate pixel size. If no astropy.units are given, assuming degrees.
-            An NSIDE will be chosen that correponds to a pixel size closest to this
+        binsz : float or `~numpy.ndarray`
+            Approximate pixel size in degrees.  An NSIDE will be
+            chosen that correponds to a pixel size closest to this
             value.  This option is superseded by nside.
         nest : bool
             True for HEALPIX "NESTED" indexing scheme, False for "RING" scheme
@@ -1174,10 +1174,10 @@ class HpxGeom(MapGeom):
             coordinate system of the map.
         region  : str
             HPX region string.  Allows for partial-sky maps.
-        width : float or `~astropy.units.Unit`
-            Diameter of the map. If no astropy.units are given, assuming degrees.
-            If set the map will encompass all pixels within a circular region
-            centered on ``skydir``.
+        width : float
+            Diameter of the map in degrees.  If set the map will
+            encompass all pixels within a circular region centered on
+            ``skydir``.
         axes : list
             List of axes for non-spatial dimensions.
         conv : str
@@ -1199,11 +1199,6 @@ class HpxGeom(MapGeom):
         """
         if nside is None and binsz is None:
             raise ValueError('Either nside or binsz must be defined.')
-
-        if width is not None:
-            width = Quantity(width,'deg').value
-        if binsz is not None:
-            binsz = Quantity(binsz,'deg').value
 
         if nside is None and binsz is not None:
             nside = get_nside_from_pix_size(binsz)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import assert_equal
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit, Quantity
-from astropy import units as u
 from ..base import Map
 from ..geom import MapAxis
 from ..wcs import WcsGeom
@@ -24,8 +23,6 @@ map_axes = [
 ]
 
 mapbase_args = [
-    (0.1*u.deg, 10.0*u.deg, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
-    (0.1*u.deg, 10.0*u.deg, 'hpx', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
     (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), None, ''),
     (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), map_axes[:1], ''),
     (0.1, 10.0, 'wcs', SkyCoord(0.0, 30.0, unit='deg'), map_axes, 'm^2'),
@@ -45,26 +42,12 @@ def test_map_create(binsz, width, map_type, skydir, axes, unit):
                    skydir=skydir, axes=axes, unit=unit)
     assert m.unit == unit
 
-def test_map_create_size():
-    m = Map.create(binsz=6*u.arcmin, width=600*u.arcmin, map_type='wcs')
-    assert(m.data.shape == (100,100))
-
-    m = Map.create(binsz=0.1*u.deg, width=10*u.deg, map_type='wcs')
-    assert(m.data.shape == (100,100))
 
 def test_map_from_geom():
     geom = WcsGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
     assert isinstance(m, WcsNDMap)
     assert m.geom.is_image
-
-    geom = WcsGeom.create(binsz=1.0)
-    m = Map.from_geom(geom)
-    assert isinstance(m, WcsNDMap)
-
-    geom = WcsGeom.create(binsz=6*u.arcmin, width=600*u.arcmin)
-    m = Map.from_geom(geom)
-    assert(m.data.shape == (100,100))
 
     geom = HpxGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)
@@ -101,9 +84,6 @@ def test_map_get_image_by_pix(binsz, width, map_type, skydir, axes, unit):
     m_vals = m.get_by_pix(idx + pix)
     assert_equal(m_image.data, m_vals)
 
-    geom = HpxGeom.create(binsz=1.0*u.deg, width=10.0*u.deg)
-    m = Map.from_geom(geom)
-    assert isinstance(m, HpxNDMap)
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])
 def test_map_meta_read_write(map_type):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -8,7 +8,6 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy.coordinates.angle_utilities import angular_separation
 import astropy.units as u
-from astropy.units import Quantity, Unit
 from regions import SkyRegion
 from ..image.utils import make_header
 from ..utils.scripts import make_path
@@ -226,16 +225,16 @@ class WcsGeom(MapGeom):
             non-spatial dimensions, list input can be used to define a
             different map width in each image plane.  This option
             supersedes width.
-        width : float or tuple or list `~astropy.units.Unit`
-            Width of the map. If no astropy.units are given, assuming degrees.
-            A tuple will be interpreted as parameters for longitude and latitude axes.
-            For maps with non-spatial dimensions, list input can be used to
+        width : float or tuple or list
+            Width of the map in degrees.  A tuple will be interpreted
+            as parameters for longitude and latitude axes.  For maps
+            with non-spatial dimensions, list input can be used to
             define a different map width in each image plane.
-        binsz : float or tuple or list `~astropy.units.Unit`
-            Map pixel size.  If no astropy.units are given, assuming degrees.
-            A tuple will be interpreted as parameters for longitude and latitude axes.
-            For maps with non-spatial dimensions, list input can be used to
-            define a different map width in each image plane.
+        binsz : float or tuple or list
+            Map pixel size in degrees.  A tuple will be interpreted
+            as parameters for longitude and latitude axes.  For maps
+            with non-spatial dimensions, list input can be used to
+            define a different bin size in each image plane.
         skydir : tuple or `~astropy.coordinates.SkyCoord`
             Sky position of map center.  Can be either a SkyCoord
             object or a tuple of longitude and latitude in deg in the
@@ -277,11 +276,6 @@ class WcsGeom(MapGeom):
         else:
             raise ValueError(
                 'Invalid type for skydir: {}'.format(type(skydir)))
-
-
-        if width is not None:
-            width = Quantity(width,'deg').value
-        binsz = Quantity(binsz,'deg').value
 
         shape = max([get_shape(t) for t in [npix, binsz, width]])
         binsz = cast_to_shape(binsz, shape, float)


### PR DESCRIPTION
Reverts gammapy/gammapy#1439, because of failing tests, that can not easily be resolved.