### PR TITLE
Add `.slice_by_idx()` methods to gammapy maps

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -127,13 +127,13 @@ Fermi-LAT PSF:
 
 Indexing and Slicing
 --------------------
-All map objects feature a `slice_by_idx()` method, which can be used to slice and
+All map objects feature a `~Map.slice_by_idx()` method, which can be used to slice and
 index non-spatial axes of the map to create arbitrary sub-maps. The method accepts
-a `dict` specifying the axes name and correspoding integer index or regular `slice`
-object. When indexing an axis with an integer the corresponding axes is dropped
+a `dict` specifying the axes name and correspoding integer index or `slice`
+objects. When indexing an axis with an integer the corresponding axes is dropped
 from the returned sub-map. To keep the axes (with length 1) in the returned sub-map
 use a slice object of length one. This behaviour is equivalent to regular numpy
-array indexing. The follwing example demonstrates the use of `slice_by_idx()`
+array indexing. The follwing example demonstrates the use of `~Map.slice_by_idx()`
 on a map with a time and energy axes:
 
 .. code:: python
@@ -159,7 +159,8 @@ on a map with a time and energy axes:
    # slice first three images of the energy axis at a fixed time
    m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': 0})
 
-
+   # slice first three images of the energy axis as well as time axis
+   m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': slice(0, 3)})
 
 Accessor Methods
 ----------------

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -125,6 +125,42 @@ Fermi-LAT PSF:
    m_hpx = Map.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
                           axes=[energy_axis])
 
+Indexing and Slicing
+--------------------
+All map objects feature a `slice_by_idx()` method, which can be used to slice and
+index non-spatial axes of the map to create arbitrary sub-maps. The method accepts
+a `dict` specifying the axes name and correspoding integer index or regular `slice`
+object. When indexing an axis with an integer the corresponding axes is dropped
+from the returned sub-map. To keep the axes (with length 1) in the returned sub-map
+use a slice object of length one. This behaviour is equivalent to regular numpy
+array indexing. The follwing example demonstrates the use of `slice_by_idx()`
+on a map with a time and energy axes:
+
+.. code:: python
+
+   import numpy as np
+   from gammapy.maps import Map, MapAxis
+   from astropy.coordinates import SkyCoord
+
+   position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
+   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', unit='GeV')
+   time_axis = MapAxis.from_bounds(0., 12, 12, interp='lin', unit='h')
+
+   # Create a WCS Map
+   m_wcs = Map.create(binsz=0.02, map_type='wcs', skydir=position, width=10.0,
+                          axes=[energy_axis, time_axis])
+
+   # index first image plane of the energy axes and third from the time axis
+   m_wcs.slice_by_idx({'energy': 0, 'time': 2})
+
+   # index first image plane of the energy axes and keep time axis unchanged
+   m_wcs.slice_by_idx({'energy': 0})
+
+   # slice first three images of the energy axis at a fixed time
+   m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': 0})
+
+
+
 Accessor Methods
 ----------------
 

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -125,15 +125,19 @@ Fermi-LAT PSF:
    m_hpx = Map.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
                           axes=[energy_axis])
 
+
+.. _mapslicing:
+
 Indexing and Slicing
 --------------------
-All map objects feature a `~Map.slice_by_idx()` method, which can be used to slice and
-index non-spatial axes of the map to create arbitrary sub-maps. The method accepts
-a `dict` specifying the axes name and correspoding integer index or `slice`
+
+All map objects feature a `~Map.slice_by_idx()` method, which can be used to slice
+and index non-spatial axes of the map to create arbitrary sub-maps. The method
+accepts a `dict` specifying the axes name and correspoding integer index or `slice`
 objects. When indexing an axis with an integer the corresponding axes is dropped
 from the returned sub-map. To keep the axes (with length 1) in the returned sub-map
-use a slice object of length one. This behaviour is equivalent to regular numpy
-array indexing. The follwing example demonstrates the use of `~Map.slice_by_idx()`
+use a `slice` object of length one. This behaviour is equivalent to regular numpy
+array indexing. The following example demonstrates the use of `~Map.slice_by_idx()`
 on a map with a time and energy axes:
 
 .. code:: python
@@ -426,10 +430,6 @@ over to the projected map.
    # Convert LAT standard IEM to HPX (nside=8)
    m_proj = m.project(geom)
    m_proj.write('gll_iem_v06_hpx_nside8.fits')
-
-
-Slicing Methods
----------------
 
 Iterating on a Map
 ------------------

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -499,33 +499,34 @@ class Map(object):
         """
         pass
 
-    def slice_by_idx(self, slices, drop_axes=False, copy=True):
+    def slice_by_idx(self, slices, copy=False):
         """Slice sub map from map object.
 
         Parameters
         ----------
-        slices : tuple
-            Tuple of integers or `slice` objects. Contains one
-            element for each non-spatial dimension.
-        drop_axes : bool
-            Drop axes for which the slice reduces the size of that
-            dimension to one.
+        slices : dict
+            Dict of axes names and integers or `slice` object pairs. Contains one
+            element for each non-spatial dimension. For integer indexing the
+            correspoding axes is dropped from the map. Axes not specified in the
+            dict are kept unchanged.
         copy : bool
             Whether to make a copy of the data.
+
+        Examples
+        --------
+
+        .. code::
+
+            from gammapy.maps import Map
 
         Returns
         -------
         map_out : '~Map'
             Sliced map object.
         """
-        if len(slices) != len(self.geom.axes):
-            raise ValueError("tuple length must be equal to the number of"
-                             " non spatial dimensions.")
-        geom = self.geom.slice_by_idx(slices, drop_axes=drop_axes)
+        geom = self.geom.slice_by_idx(slices)
+        slices = tuple([slices.get(ax.name, slice(None)) for ax in self.geom.axes])
         data = self.data[slices[::-1]]
-
-        if drop_axes:
-            data = np.squeeze(data)
 
         if copy:
             data = data.copy()

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -502,6 +502,8 @@ class Map(object):
     def slice_by_idx(self, slices, copy=False):
         """Slice sub map from map object.
 
+        For usage examples, see :ref:`mapslicing`.
+
         Parameters
         ----------
         slices : dict

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -499,6 +499,38 @@ class Map(object):
         """
         pass
 
+    def slice(self, slices, drop_axis=False, copy=True):
+        """Slice sub map from map object.
+
+        Parameters
+        ----------
+        slices : tuple
+            Tuple of integers or `slice` objects. Contains one
+            element for each non-spatial dimension.
+        drop_axes : bool
+            Drop axes for which the slice reduces the size of that
+            dimension to one.
+        copy : bool
+            Whether to make a copy of the data.
+
+        Returns
+        -------
+        map_out : '~Map'
+            Sliced map object.
+        """
+        if len(slices) != len(self.geom.axes):
+            raise ValueError("tuple length must be equal to the number of"
+                             " non spatial dimensions.")
+        geom = self.geom.slice(slices, drop_axis=drop_axis)
+        data = self.data[slices[::-1]]
+
+        if drop_axis:
+            data = np.squeeze(data)
+
+        if copy:
+            data = data.copy()
+        return self.__class__(geom=geom, data=data, unit=self.unit, meta=self.meta)
+
     def get_image_by_coord(self, coords, copy=True):
         """Return spatial map at the given axis coordinates.
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -512,13 +512,6 @@ class Map(object):
         copy : bool
             Whether to make a copy of the data.
 
-        Examples
-        --------
-
-        .. code::
-
-            from gammapy.maps import Map
-
         Returns
         -------
         map_out : '~Map'

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -499,7 +499,7 @@ class Map(object):
         """
         pass
 
-    def slice(self, slices, drop_axis=False, copy=True):
+    def slice_by_idx(self, slices, drop_axes=False, copy=True):
         """Slice sub map from map object.
 
         Parameters
@@ -521,10 +521,10 @@ class Map(object):
         if len(slices) != len(self.geom.axes):
             raise ValueError("tuple length must be equal to the number of"
                              " non spatial dimensions.")
-        geom = self.geom.slice(slices, drop_axis=drop_axis)
+        geom = self.geom.slice_by_idx(slices, drop_axes=drop_axes)
         data = self.data[slices[::-1]]
 
-        if drop_axis:
+        if drop_axes:
             data = np.squeeze(data)
 
         if copy:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -807,7 +807,7 @@ class MapCoord(object):
         Parameters
         ----------
         data : `tuple`, `dict`, `~MapCoord` or `~astropy.coordinates.SkyCoord`
-            Object containing coordinate arrays.  
+            Object containing coordinate arrays.
         coordsys : {'CEL', 'GAL', None}, optional
             Set the coordinate system for longitude and latitude.  If
             None longitude and latitude will be assumed to be in
@@ -1181,8 +1181,7 @@ class MapGeom(object):
         idx = self.pix_to_idx(pix)
         return np.all(np.stack([t != -1 for t in idx]), axis=0)
 
-    @abc.abstractmethod
-    def to_slice(self, slices, drop_axes=True):
+    def slice_by_idx(self, slices, drop_axes=True):
         """Create a new geometry by cutting in the non-spatial dimensions of
         this geometry.
 
@@ -1201,7 +1200,12 @@ class MapGeom(object):
         geom : `~MapGeom`
             Sliced geometry.
         """
-        pass
+        axes = []
+        for ax, ax_slice in zip(self.axes, slices):
+            axes.append(ax.slice(ax_slice))
+        kwargs = self._copy_init_kwargs
+        kwargs['axes'] = axes
+        return self.__class__(**kwargs)
 
     @abc.abstractmethod
     def to_image(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1181,19 +1181,17 @@ class MapGeom(object):
         idx = self.pix_to_idx(pix)
         return np.all(np.stack([t != -1 for t in idx]), axis=0)
 
-    def slice_by_idx(self, slices, drop_axes=True):
+    def slice_by_idx(self, slices):
         """Create a new geometry by cutting in the non-spatial dimensions of
         this geometry.
 
         Parameters
         ----------
-        slices : tuple
-            Tuple of integers or `slice` objects.  Contains one
-            element for each non-spatial dimension.
-
-        drop_axes : bool
-            Drop axes for which the slice reduces the size of that
-            dimension to one.
+        slices : dict
+            Dict of axes names and integers or `slice` object pairs. Contains one
+            element for each non-spatial dimension. For integer indexing the
+            correspoding axes is dropped from the map. Axes not specified in the
+            dict are kept unchanged.
 
         Returns
         -------
@@ -1201,12 +1199,12 @@ class MapGeom(object):
             Sliced geometry.
         """
         axes = []
-        for ax, ax_slice in zip(self.axes, slices):
-            ax_sliced = ax.slice(ax_slice)
-            if ax_sliced.nbin == 1 and drop_axes:
-                continue
-            else:
+        for ax in self.axes:
+            ax_slice = slices.get(ax.name, slice(None))
+            if isinstance(ax_slice, slice):
+                ax_sliced = ax.slice(ax_slice)
                 axes.append(ax_sliced)
+            # in the case where isinstance(ax_slice, int) the axes is dropped
 
         kwargs = self._copy_init_kwargs
         kwargs['axes'] = axes

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1204,7 +1204,7 @@ class MapGeom(object):
             if isinstance(ax_slice, slice):
                 ax_sliced = ax.slice(ax_slice)
                 axes.append(ax_sliced)
-            # in the case where isinstance(ax_slice, int) the axes is dropped
+                # in the case where isinstance(ax_slice, int) the axes is dropped
 
         kwargs = self._copy_init_kwargs
         kwargs['axes'] = axes

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1202,7 +1202,12 @@ class MapGeom(object):
         """
         axes = []
         for ax, ax_slice in zip(self.axes, slices):
-            axes.append(ax.slice(ax_slice))
+            ax_sliced = ax.slice(ax_slice)
+            if ax_sliced.nbin == 1 and drop_axes:
+                continue
+            else:
+                axes.append(ax_sliced)
+
         kwargs = self._copy_init_kwargs
         kwargs['axes'] = axes
         return self.__class__(**kwargs)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -589,6 +589,7 @@ class HpxGeom(MapGeom):
 
         self._ipix = None
         self._rmap = None
+        self._region = region
         self._create_lookup(region)
 
         if self._ipix is not None:
@@ -603,6 +604,14 @@ class HpxGeom(MapGeom):
         self._center_coord = tuple([lon, lat] +
                                    [ax.pix_to_coord((float(ax.nbin) - 1.0) / 2.) for ax in self.axes])
         self._center_pix = self.coord_to_pix(self._center_coord)
+
+    @property
+    def _copy_init_kwargs(self):
+        """Get kwargs to init an instance with the same parameters."""
+        kwargs = {}
+        for arg in ['nside', 'nest', 'coordsys', 'region', 'axes', 'conv']:
+            kwargs[arg] = getattr(self, '_' + arg)
+        return kwargs
 
     def _create_lookup(self, region):
         """Create local-to-global pixel lookup table."""

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -90,8 +90,10 @@ def test_map_get_image_by_pix(binsz, width, map_type, skydir, axes, unit):
 def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes, unit=unit)
-    m.data = np.arange(m.data.size, dtype=float).reshape(m.data.shape)
+    data = np.arange(m.data.size, dtype=float)
+    m.data = data.reshape(m.data.shape)
 
+    # Test none slicing
     sliced = m.slice_by_idx({})
     assert_equal(m.geom.shape, sliced.geom.shape)
 
@@ -101,15 +103,15 @@ def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
     assert not sliced.geom.is_image
     slices = tuple([slices[ax.name] for ax in m.geom.axes])
     assert_equal(m.data[slices[::-1]], sliced.data)
-    # assert sliced.data.base is m.data
+    assert sliced.data.base is data
 
     slices = {'energy': 0,
               'time': 1}
-    sliced = m.slice_by_idx(slices)
+    sliced = m.slice_by_idx(slices, copy=True)
     assert sliced.geom.is_image
     slices = tuple([slices[ax.name] for ax in m.geom.axes])
     assert_equal(m.data[slices[::-1]], sliced.data)
-    # assert sliced.data.base is m.data
+    assert sliced.data.base is not data
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -85,6 +85,28 @@ def test_map_get_image_by_pix(binsz, width, map_type, skydir, axes, unit):
     assert_equal(m_image.data, m_vals)
 
 
+@pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes', 'unit'),
+                         mapbase_args_with_axes)
+def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
+    m = Map.create(binsz=binsz, width=width, map_type=map_type,
+                   skydir=skydir, axes=axes, unit=unit)
+    m.data = np.arange(m.data.size, dtype=float).reshape(m.data.shape)
+
+    slices = (slice(None, None), slice(None, None))[:len(m.geom.axes)]
+    sliced = m.slice_by_idx(slices)
+    assert_equal(m.geom.shape, sliced.geom.shape)
+
+    slices = (slice(0, 1), slice(0, 2))[:len(m.geom.axes)]
+    sliced = m.slice_by_idx(slices)
+    assert not sliced.geom.is_image
+    assert_equal(m.data[slices[::-1]], sliced.data)
+
+    slices = (0, 1)[:len(m.geom.axes)]
+    sliced = m.slice_by_idx(slices, drop_axes=True)
+    assert sliced.geom.is_image
+    assert_equal(m.data[slices[::-1]], sliced.data)
+
+
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])
 def test_map_meta_read_write(map_type):
     meta = OrderedDict([

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -18,8 +18,8 @@ pytest.importorskip('healpy')
 pytest.importorskip('numpy', '1.12.0')
 
 map_axes = [
-    MapAxis.from_bounds(1.0, 10.0, 3, interp='log'),
-    MapAxis.from_bounds(0.1, 1.0, 4, interp='log'),
+    MapAxis.from_bounds(1.0, 10.0, 3, interp='log', name='energy'),
+    MapAxis.from_bounds(0.1, 1.0, 4, interp='log', name='time'),
 ]
 
 mapbase_args = [
@@ -92,19 +92,24 @@ def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
                    skydir=skydir, axes=axes, unit=unit)
     m.data = np.arange(m.data.size, dtype=float).reshape(m.data.shape)
 
-    slices = (slice(None, None), slice(None, None))[:len(m.geom.axes)]
-    sliced = m.slice_by_idx(slices)
+    sliced = m.slice_by_idx({})
     assert_equal(m.geom.shape, sliced.geom.shape)
 
-    slices = (slice(0, 1), slice(0, 2))[:len(m.geom.axes)]
+    slices = {'energy': slice(0, 1),
+              'time': slice(0, 2)}
     sliced = m.slice_by_idx(slices)
     assert not sliced.geom.is_image
+    slices = tuple([slices[ax.name] for ax in m.geom.axes])
     assert_equal(m.data[slices[::-1]], sliced.data)
+    # assert sliced.data.base is m.data
 
-    slices = (0, 1)[:len(m.geom.axes)]
-    sliced = m.slice_by_idx(slices, drop_axes=True)
+    slices = {'energy': 0,
+              'time': 1}
+    sliced = m.slice_by_idx(slices)
     assert sliced.geom.is_image
+    slices = tuple([slices[ax.name] for ax in m.geom.axes])
     assert_equal(m.data[slices[::-1]], sliced.data)
+    # assert sliced.data.base is m.data
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -224,7 +224,7 @@ class WcsGeom(MapGeom):
         it is projected onto the plane of intermediate world coordinates.
 
         Returns
-        ------
+        -------
         angle: `~astropy.coordinates.Angle`
         """
         return Angle(astropy.wcs.utils.proj_plane_pixel_scales(self.wcs), 'deg')

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -107,6 +107,14 @@ class WcsGeom(MapGeom):
                                                   self.wcs)
 
     @property
+    def _copy_init_kwargs(self):
+        """Get kwargs to init an instance with the same parameters."""
+        kwargs = {}
+        for arg in ['wcs', 'npix', 'cdelt', 'crpix', 'axes', 'conv']:
+            kwargs[arg] = getattr(self, '_' + arg)
+        return kwargs
+
+    @property
     def wcs(self):
         """WCS projection object."""
         return self._wcs


### PR DESCRIPTION
This PR adds `.slice_by_idx()` methods to the `MapGeom` and `Map` classes. I'm opening this PR early to get some feedback on the implementation and API, before I continue with  `.slice_by_coord()`. Does the `drop_axes` keyword makes sense to you (this was introduced by @woodmd in `Map.to_slice()`) or shall we rather implement a `Map.drop_axis()` method? I introduced a hidden `_copy_init_kwargs` property to `WcsGeom` and `HpxGeom` to easily create a new `WcsGeom` and `HpxGeom` object with the same specification. Or shall we rather introduce a `WcsGeom.copy()` method?

