### PR TITLE
Add WCS map cutout method

### DIFF
--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -405,3 +405,13 @@ def test_smooth(kernel):
     smoothed = m.smooth(0.2 * u.deg, kernel)
     actual = smoothed.data.sum()
     assert_allclose(actual, desired)
+
+def test_make_cutout():
+    geom = WcsGeom.create(npix=(10, 10), binsz=1,
+                          proj='CAR', coordsys='GAL')
+    m = WcsNDMap(geom, data=np.ones((10, 10)), unit='m2')
+    pos=SkyCoord(0, 0, unit='deg', frame='galactic')
+    cutout=m.make_cutout(position=pos,radius=3.0*u.deg,margin=0.1*u.deg)
+    actual=cutout.data.sum()
+    assert_allclose(actual,9.0)
+

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -369,22 +369,25 @@ def test_wcsndmap_upsample(npix, binsz, coordsys, proj, skydir, axes):
     m2 = m.upsample(2, order=0, preserve_counts=True)
     assert_allclose(np.nansum(m.data), np.nansum(m2.data))
 
+
 def test_coadd_unit():
-    geom = WcsGeom.create(npix=(10,10), binsz=1,
+    geom = WcsGeom.create(npix=(10, 10), binsz=1,
                           proj='CAR', coordsys='GAL')
-    m1 = WcsNDMap(geom, data=np.ones((10,10)), unit='m2')
-    m2 = WcsNDMap(geom, data=np.ones((10,10)), unit='cm2')
+    m1 = WcsNDMap(geom, data=np.ones((10, 10)), unit='m2')
+    m2 = WcsNDMap(geom, data=np.ones((10, 10)), unit='cm2')
 
     m1.coadd(m2)
 
     assert_allclose(m1.data, 1.0001)
 
+
 def test_make_region_mask():
     from regions import CircleSkyRegion
-    geom = WcsGeom.create(npix=(3,3), binsz=2,
+    geom = WcsGeom.create(npix=(3, 3), binsz=2,
                           proj='CAR', coordsys='GAL')
     m = WcsNDMap(geom)
-    region = CircleSkyRegion(SkyCoord(0, 0, unit='deg', frame='galactic'), 1.0*u.deg)
+    region = CircleSkyRegion(SkyCoord(0, 0, unit='deg', frame='galactic'),
+                             1.0 * u.deg)
     maskmap = m.make_region_mask(region)
 
     assert maskmap.data.dtype == bool
@@ -406,14 +409,13 @@ def test_smooth(kernel):
     actual = smoothed.data.sum()
     assert_allclose(actual, desired)
 
-def test_make_cutout():
 
-    geom = WcsGeom.create(npix=(10, 10), binsz=1,
+def test_make_cutout():
+    pos = SkyCoord(0, 0, unit='deg', frame='galactic')
+    geom = WcsGeom.create(npix=(10, 10), binsz=1, skydir=pos,
                           proj='CAR', coordsys='GAL', axes=axes2)
     m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
-    pos = SkyCoord(0, 0, unit='deg', frame='galactic')
-    cutout = m.make_cutout(position=pos,width=(2.0,3.0)*u.deg)
+    cutout = m.make_cutout(position=pos, width=(2.0, 3.0) * u.deg)
     actual = cutout.data.sum()
-    assert_allclose(actual,36.0)
+    assert_allclose(actual, 36.0)
     assert_allclose(cutout.geom.shape, m.geom.shape)
-

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -412,7 +412,7 @@ def test_make_cutout():
                           proj='CAR', coordsys='GAL', axes=axes2)
     m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
     pos = SkyCoord(0, 0, unit='deg', frame='galactic')
-    cutout = m.make_cutout(position=pos,width=(2.0,3.0)*u.deg,margin=(0.1,0.2)*u.deg)
+    cutout = m.make_cutout(position=pos,width=(2.0,3.0)*u.deg)
     actual = cutout.data.sum()
     assert_allclose(actual,36.0)
     assert_allclose(cutout.geom.shape, m.geom.shape)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -412,7 +412,7 @@ def test_make_cutout():
                           proj='CAR', coordsys='GAL', axes=axes2)
     m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
     pos = SkyCoord(0, 0, unit='deg', frame='galactic')
-    cutout = m.make_cutout(position=pos,radius=3.0*u.deg,margin=0.1*u.deg)
+    cutout = m.make_cutout(position=pos,radius=(2.0,3.0)*u.deg,margin=(0.1,0.2)*u.deg)
     actual = cutout.data.sum()
-    assert_allclose(actual,54.0)
+    assert_allclose(actual,36.0)
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -407,11 +407,12 @@ def test_smooth(kernel):
     assert_allclose(actual, desired)
 
 def test_make_cutout():
+
     geom = WcsGeom.create(npix=(10, 10), binsz=1,
-                          proj='CAR', coordsys='GAL')
-    m = WcsNDMap(geom, data=np.ones((10, 10)), unit='m2')
-    pos=SkyCoord(0, 0, unit='deg', frame='galactic')
-    cutout=m.make_cutout(position=pos,radius=3.0*u.deg,margin=0.1*u.deg)
-    actual=cutout.data.sum()
-    assert_allclose(actual,9.0)
+                          proj='CAR', coordsys='GAL', axes=axes2)
+    m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
+    pos = SkyCoord(0, 0, unit='deg', frame='galactic')
+    cutout = m.make_cutout(position=pos,radius=3.0*u.deg,margin=0.1*u.deg)
+    actual = cutout.data.sum()
+    assert_allclose(actual,54.0)
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -412,7 +412,8 @@ def test_make_cutout():
                           proj='CAR', coordsys='GAL', axes=axes2)
     m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
     pos = SkyCoord(0, 0, unit='deg', frame='galactic')
-    cutout = m.make_cutout(position=pos,radius=(2.0,3.0)*u.deg,margin=(0.1,0.2)*u.deg)
+    cutout = m.make_cutout(position=pos,width=(2.0,3.0)*u.deg,margin=(0.1,0.2)*u.deg)
     actual = cutout.data.sum()
     assert_allclose(actual,36.0)
+    assert_allclose(cutout.geom.shape, m.geom.shape)
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -602,7 +602,7 @@ class WcsNDMap(WcsMap):
         image.data = data
         return image
 
-    def make_cutout(self, position, width, mode="strict"):
+    def make_cutout(self, position, width, mode="strict", copy=True):
         """
         Create a cutout of a WcsNDMap around a given position.
 
@@ -616,6 +616,10 @@ class WcsNDMap(WcsMap):
         mode : {'trim', 'partial', 'strict'}
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
 
+        copy : bool, optional
+               If False (default), then the cutout data will be a view into the original data  array. 
+               If True, then the cutout data will hold a copy of the original data array.
+        
         Returns
         -------
         cutout : `~gammapy.maps.WcsNDMap`
@@ -625,7 +629,7 @@ class WcsNDMap(WcsMap):
         idx = (0,) * len(self.geom.axes)
 
         cutout2d = Cutout2D(data=self.data[idx], wcs=self.geom.wcs,
-                            position=position, size=width, mode=mode)
+                            position=position, size=width, mode=mode, copy=copy)
 
         # Create the slices with the non-spatial axis
         cutout_slices = Ellipsis, cutout2d.slices_original[0], cutout2d.slices_original[1]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -602,7 +602,7 @@ class WcsNDMap(WcsMap):
         image.data = data
         return image
 
-    def make_cutout(self, position, width, margin=None, mode="strict"):
+    def make_cutout(self, position, width, mode="strict"):
         """
         Create a cutout of a WcsNDMap around a given direction.
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -629,12 +629,15 @@ class WcsNDMap(WcsMap):
         idx = (0,) * len(self.geom.axes)
 
         cutout2d = Cutout2D(data=self.data[idx], wcs=self.geom.wcs,
-                            position=position, size=width, mode=mode, copy=copy)
+                            position=position, size=width, mode=mode)
 
         # Create the slices with the non-spatial axis
         cutout_slices = Ellipsis, cutout2d.slices_original[0], cutout2d.slices_original[1]
 
         geom = WcsGeom(cutout2d.wcs, cutout2d.shape[::-1], axes=self.geom.axes)
         data = self.data[cutout_slices]
+        
+        if copy:
+            data=data.copy()
 
         return WcsNDMap(geom, data, meta=self.meta, unit=self.unit)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -633,8 +633,8 @@ class WcsNDMap(WcsMap):
                 position=position, size=width, mode=mode)
 
         # Create the slices with the non-spatial axis
-
         cutout_slices = Ellipsis, cutout2d.slices_original[0], cutout2d.slices_original[1]
+
         geom = WcsGeom(cutout2d.wcs, cutout2d.shape[::-1], axes=self.geom.axes)
         data = self.data[cutout_slices]
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -604,21 +604,17 @@ class WcsNDMap(WcsMap):
 
     def make_cutout(self, position, width, mode="strict"):
         """
-        Create a cutout of a WcsNDMap around a given direction.
+        Create a cutout of a WcsNDMap around a given position.
 
         Parameters
         ----------
-
         position : `~astropy.coordinates.SkyCoord`
-            Center position of the cutout box
+            Center position of the cutout region.
         width : tuple of `~astropy.coordinates.Angle`
-            Angular sizes of the box in (lon,lat)
-            If only one value is passed, a square region is extracted
-        margin : `~astropy.coordinates.Angle`, optional
-            Additional safety margin. If specified must be same length as radius
+            Angular sizes of the region in (lon, lat). If only one value is passed,
+            a square region is extracted. For more options see also `~astropy.nddata.utils.Cutout2D`.
         mode : {'trim', 'partial', 'strict'}
-            Mode option for Cutout2D, `~astropy.nddata.utils.Cutout2D`
-            for details, see http://docs.astropy.org/en/stable/api/astropy.nddata.Cutout2D.html
+            Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
 
         Returns
         -------
@@ -626,11 +622,10 @@ class WcsNDMap(WcsMap):
             The cutout map itself
         """
 
-
-        idx = (0,)*(self.data.ndim - 2)
+        idx = (0,) * len(self.geom.axes)
 
         cutout2d = Cutout2D(data=self.data[idx], wcs=self.geom.wcs,
-                position=position, size=width, mode=mode)
+                            position=position, size=width, mode=mode)
 
         # Create the slices with the non-spatial axis
         cutout_slices = Ellipsis, cutout2d.slices_original[0], cutout2d.slices_original[1]
@@ -639,4 +634,3 @@ class WcsNDMap(WcsMap):
         data = self.data[cutout_slices]
 
         return WcsNDMap(geom, data, meta=self.meta, unit=self.unit)
-    


### PR DESCRIPTION
Hello,

I added a make_cutout() following the one in SkyCube.
This makes only a spatial cutout on all axis of the cube.

But in practise, I think the users will want to be able to make cutouts on all other axes as well, no?
I mean, maybe something like
`cutout=cmap.make_cutout(position=pos,radius=rad, energy=(1,3)*u.TeV, time=(t1,t2) )`

Or can cutout remain only for spatial cuts, and then other axes extracted as needed?
