### PR TITLE
Add a PSFKernel to perform PSF convolution on Maps

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -11,3 +11,4 @@ from .cube_pipe import *
 from .basic_cube import *
 from .fit import *
 from .new import *
+from .psf_kernel import *

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -220,8 +220,8 @@ class PSFKernel(object):
         return cls(table_psf_to_kernel_map(table_psf, geom))
 
     def write(self, *args, **kwargs):
-        psf_kernel_map = self.to_map()
-        psf_kernel_map.write(*args, **kwargs)
+        """Write the Map object which contains the PSF kernel to file."""
+        self.psf_kernel_map.write(*args, **kwargs)
 
     def apply(self, map):
         """Apply the kernel to an input Map.
@@ -240,5 +240,5 @@ class PSFKernel(object):
         # TODO : check that the MapGeom are consistent
         convolved_map = Map.from_geom(geom=map.geom, unit=map.unit, meta=map.meta)
         for img, idx in map.iter_by_image():
-            convolved_map.data[idx] = convolve_fft(img, self.to_map().data[idx])
+            convolved_map.data[idx] = convolve_fft(img, self.psf_kernel_map.data[idx])
         return convolved_map

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -126,6 +126,28 @@ class PSFKernel(object):
     ----------
     psf_kernel_map : `~gammapy.maps.Map`
         PSF kernel stored in a Map
+
+    Examples
+    --------
+
+    .. code:: python
+
+        import numpy as np
+        from gammapy.maps import WcsGeom, MapAxis
+        from astropy import units as u
+
+        # Define energy axis
+        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy')
+
+        # Create WcsGeom
+        geom = WcsGeom.create(binsz=0.02*u.deg, width=10.0*u.deg, axes=[energy_axis])
+
+        # Extract EnergyDependentTablePSF from PSF IRF (here a PSF3D)
+        table_psf = psf.to_energy_dependent_table_psf(theta=0.5*u.deg)
+
+        psf_kernel = PSFKernel.from_table_psf(table_psf,geom, max_radius=1*u.deg)
+
+        some_map_convolved = psf_kernel.apply(some_map)
     """
 
     def __init__(self, psf_kernel_map):
@@ -142,7 +164,7 @@ class PSFKernel(object):
         return cls.from_map(psf_kernel_map)
 
     @classmethod
-    def from_table_psf(cls, table_psf, geom, max_radius=None, normalize=True, factor=4):
+    def from_table_psf(cls, table_psf, geom, max_radius=None, factor=4):
         """Create a PSF kernel from a TablePSF or an EnergyDependentTablePSF on a given MapGeom.
         If the MapGeom is not an image, the same kernel will be present on all axes.
 
@@ -165,6 +187,7 @@ class PSFKernel(object):
         kernel : `~gammapy.cube.PSFKernel`
             the kernel Map with reduced geometry according to the max_radius
         """
+        # TODO : use PSF containment radius if max_radius is None
         if max_radius is not None:
             geom = _make_kernel_geom(geom, max_radius)
 
@@ -192,8 +215,6 @@ class PSFKernel(object):
             Gaussian width. Assume degrees if float input
         max_radius : `~astropy.coordinates.Angle` or float
             Desired kernel map size. Implicit unit is degree.
-        normalize : bool
-            normalize the PSF kernel (per energy)
         factor : int
             the oversample factor to compute the PSF
 

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -96,7 +96,7 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
         the oversample factor to compute the PSF
     """
     # Find energy axis in geom
-    energy_axis = geom.get_axes_by_type('energy')[0]
+    energy_axis = geom.get_axis_by_type('energy')
     energy_idx = geom.axes.index(energy_axis)
     energy_unit = u.Unit(energy_axis.unit)
 

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -66,7 +66,7 @@ def table_psf_to_kernel_map(table_psf, geom, factor=4):
     kernel_map, rads = _compute_kernel_separations(geom, factor)
 
     vals = table_psf.evaluate(rad=rads)
-    norm = np.sum(vals).value
+    norm = vals.sum().value
 
     # loop over images and fill map
     for img, idx in kernel_map.iter_by_image():
@@ -106,7 +106,7 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
     for img, idx in kernel_map.iter_by_image():
         energy = energy_axis.center[idx[energy_idx]] * energy_unit
         vals = table_psf.evaluate(energy=energy, rad=rads).reshape(img.shape)
-        img += vals.value / np.sum(vals).value
+        img += vals.value / vals.sum().value
 
     # downsample the psf kernel map. Take the average
     kernel_map = kernel_map.downsample(factor, preserve_counts=True)
@@ -160,8 +160,8 @@ class PSFKernel(object):
     def read(cls, *args, **kwargs):
         """Read kernel Map from file."""
 
-        psf_kernel_map = WcsNDMap.read(*args, **kwargs)
-        return cls.from_map(psf_kernel_map)
+        psf_kernel_map = Map.read(*args, **kwargs)
+        return cls(psf_kernel_map)
 
     @classmethod
     def from_table_psf(cls, table_psf, geom, max_radius=None, factor=4):
@@ -198,8 +198,7 @@ class PSFKernel(object):
             return cls(energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor))
 
     @classmethod
-    def from_gauss(cls, geom, sigma, max_radius=None, containment_fraction=0.99,
-                   normalize=True, factor=4):
+    def from_gauss(cls, geom, sigma, max_radius=None, containment_fraction=0.99, factor=4):
         """Create Gaussian PSF.
 
         This is used for testing and examples.
@@ -239,7 +238,7 @@ class PSFKernel(object):
 
         table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
 
-        return cls(table_psf_to_kernel_map(table_psf, geom))
+        return cls(table_psf_to_kernel_map(table_psf, geom, factor))
 
     def write(self, *args, **kwargs):
         """Write the Map object which contains the PSF kernel to file."""

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -11,8 +11,6 @@ from ..image.models.gauss import Gauss2DPDF
 from ..irf import TablePSF
 
 __all__ = [
-   'table_psf_to_kernel_map',
-    'energy_dependent_table_psf_to_kernel_map',
     'PSFKernel',
 ]
 
@@ -48,6 +46,7 @@ def _compute_kernel_separations(geom, factor):
 
 def table_psf_to_kernel_map(table_psf, geom, factor=4):
     """Compute a PSF kernel on a given MapGeom.
+
     If the MapGeom is not an image, the same kernel will be present on all axes.
 
     The PSF is estimated by oversampling defined by a given factor.
@@ -160,12 +159,14 @@ class PSFKernel(object):
     @classmethod
     def read(cls, *args, **kwargs):
         """Read kernel Map from file."""
+
         psf_kernel_map = WcsNDMap.read(*args, **kwargs)
         return cls.from_map(psf_kernel_map)
 
     @classmethod
     def from_table_psf(cls, table_psf, geom, max_radius=None, factor=4):
         """Create a PSF kernel from a TablePSF or an EnergyDependentTablePSF on a given MapGeom.
+
         If the MapGeom is not an image, the same kernel will be present on all axes.
 
         The PSF is estimated by oversampling defined by a given factor.

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -131,6 +131,10 @@ class PSFKernel(object):
     def __init__(self, psf_kernel_map):
         self._psf_kernel_map = psf_kernel_map
 
+    @property
+    def psf_kernel_map(self):
+        return self._psf_kernel_map
+
     @classmethod
     def read(cls, *args, **kwargs):
         """Read kernel Map from file."""
@@ -214,9 +218,6 @@ class PSFKernel(object):
         table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
 
         return cls(table_psf_to_kernel_map(table_psf, geom))
-
-    def to_map(self):
-        return self._psf_kernel_map
 
     def write(self, *args, **kwargs):
         psf_kernel_map = self.to_map()

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -1,0 +1,309 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.coordinates import Angle
+from astropy.coordinates.angle_utilities import angular_separation
+import astropy.units as u
+from astropy.units import Quantity
+from astropy.convolution import convolve_fft
+from ..maps import Map, WcsGeom
+from ..image.models.gauss import Gauss2DPDF
+from ..irf import TablePSF
+
+__all__ = [
+   'table_psf_to_kernel_map',
+    'energy_dependent_table_psf_to_kernel_map',
+    'PSFKernel',
+]
+
+
+def table_psf_to_kernel_map(table_psf, geom, normalize=True, factor=4):
+    """Compute a PSF kernel on a given MapGeom.
+    If the MapGeom is not an image, the same kernel will be present on all axes.
+
+    The PSF is estimated by oversampling defined by a given factor.
+
+    Parameters
+    ----------
+    table_psf : `~gammapy.irf.TablePSF`
+        the input table PSF
+    geom : `~gammapy.maps.MapGeom`
+        the target geometry. The PSF kernel will be centered on the spatial center.
+    normalize : bool
+        normalize the PSF kernel (per energy)
+    factor : int
+        the oversample factor to compute the PSF
+    """
+    # First upsample spatial geom
+    upsampled_image_geom = geom.to_image().upsample(factor)
+
+    # get center coordinate
+    center_coord = upsampled_image_geom.center_coord * u.deg
+
+    # get coordinates
+    map_c = upsampled_image_geom.get_coord()
+
+    # get solid angles
+    solid_angles = upsampled_image_geom.solid_angle()
+
+    # compute distances to map center
+    rads = angular_separation(center_coord[0], center_coord[1], map_c.lon * u.deg, map_c.lat * u.deg)
+
+    vals = table_psf.evaluate(rad=rads).reshape(solid_angles.shape) * solid_angles
+
+    if normalize:
+        vals /= np.sum(vals)
+
+    # Create map
+    kernel_map = Map.from_geom(geom=upsampled_image_geom.to_cube(axes=geom.axes),
+                               unit='')
+
+    # loop over images and fill map
+    for img, idx in kernel_map.iter_by_image():
+        img += vals.value
+
+    # downsample the psf kernel map. Take the average
+    kernel_map = kernel_map.downsample(factor, preserve_counts=False)
+
+    return kernel_map
+
+
+def energy_dependent_table_psf_to_kernel_map(table_psf, geom, normalize=True, factor=4):
+    """Compute an energy dependent PSF kernel on a given MapGeom.
+
+    The PSF is estimated by oversampling defined by a given factor.
+
+    Parameters
+    ----------
+    table_psf : `~gammapy.irf.EnergyDependentTablePSF`
+        the input table PSF
+    geom : `~gammapy.maps.MapGeom`
+        the target geometry. The PSF kernel will be centered on the spatial centre.
+        the geometry axes should contain an energy MapAxis.
+    normalize : bool
+        normalize the PSF kernel (per energy)
+    factor : int
+        the oversample factor to compute the PSF
+    """
+    # Find energy axis in geom
+    energy_idx = -1
+    for i, axis in enumerate(geom.axes):
+        if axis.type is 'energy':
+            energy_idx = i
+
+    if energy_idx == -1:
+        raise ValueError("No energy axis in target geometry for PSFKernel")
+
+    energy_unit = u.Unit(geom.axes[energy_idx].unit)
+
+    # TODO: change the logic to support non-regular geometry. This would allow energy dependent sizes for the kernel.
+    if geom.is_regular is False:
+        raise ValueError("Non regular geometries non supported yet.")
+
+    # First upsample spatial geom
+    upsampled_image_geom = geom.to_image().upsample(factor)
+
+    # get center coordinate
+    center_coord = upsampled_image_geom.center_coord * u.deg
+
+    # get coordinates
+    map_c = upsampled_image_geom.get_coord()
+
+    # get solid angles
+    solid_angles = upsampled_image_geom.solid_angle()
+
+    # compute distances to map center
+    rads = angular_separation(center_coord[0], center_coord[1], map_c.lon * u.deg, map_c.lat * u.deg)
+
+    # Create map
+    kernel_map = Map.from_geom(geom=upsampled_image_geom.to_cube(axes=geom.axes),
+                               unit='')
+
+    # loop over images
+    for img, idx in kernel_map.iter_by_image():
+        energy = geom.axes[energy_idx].center[idx[energy_idx]] * energy_unit
+        vals = table_psf.evaluate(energy=energy, rad=rads).reshape(img.shape) * solid_angles
+        img += vals.value
+
+    # downsample the psf kernel map. Take the average
+    kernel_map = kernel_map.downsample(factor, preserve_counts=False)
+
+    if normalize:
+        # normalize each image in map
+        for img, idx in kernel_map.iter_by_image():
+            norm = np.sum(img)
+            img /= norm
+
+    return kernel_map
+
+
+class PSFKernel(object):
+    """PSF kernel for `~gammapy.maps.Map`.
+
+    This is a container class to store a PSF kernel
+    that can be used to convolve `~gammapy.maps.WcsNDMap` objects.
+    It is usually computed from an EnergyDependentTablePSF
+
+    Parameters
+    ----------
+    psf_kernel_map : `~gammapy.maps.Map`
+        PSF kernel stored in a Map
+    """
+
+    def __init__(self, psf_kernel_map):
+        self._psf_kernel_map = psf_kernel_map
+
+    @classmethod
+    def from_map(cls, psf_kernel_map):
+        return cls(psf_kernel_map)
+
+    @classmethod
+    def read(cls, *args, **kwargs):
+        """Read kernel Map from file."""
+        psf_kernel_map = WcsNDMap.read(*args, **kwargs)
+        return cls.from_map(psf_kernel_map)
+
+    @classmethod
+    def from_energy_dependent_table_psf(cls, table_psf, geom, max_radius=None, normalize=True, factor=4):
+        """Create a PSF kernel from an EnergyDependentTablePSF on a given MapGeom.
+
+        The PSF is estimated by oversampling defined by a given factor.
+
+        Parameters
+        ----------
+        table_psf : `~gammapy.irf.EnergyDependentTablePSF`
+            the input table PSF
+        geom : `~gammapy.maps.WcsGeom`
+            the target geometry. The PSF kernel will be centered on the central pixel.
+            the geometry axes should contain an energy MapAxis.
+        max_radius : `~astropy.coordinates.Angle` or float
+            the maximum radius of the PSF kernel. If float assume unit is degree.
+        normalize : bool
+            normalize the PSF kernel (per energy)
+        factor : int
+            the oversample factor to compute the PSF
+        """
+        if max_radius is not None:
+            # Create a new geom accordingly
+            center = geom.center_coord[:2]
+            binsz = Quantity(np.abs(geom.wcs.wcs.cdelt[0]), 'deg')
+            max_radius = Quantity(max_radius, 'deg')
+            npix = 2 * int(max_radius / binsz) + 1
+            geom = WcsGeom.create(skydir=center, binsz=binsz, npix=npix, proj=geom.projection,
+                                  coordsys=geom.coordsys, axes=geom.axes)
+        return cls(energy_dependent_table_psf_to_kernel_map(table_psf, geom, normalize, factor))
+
+    @classmethod
+    def from_table_psf(cls, table_psf, geom, max_radius=None, normalize=True, factor=4):
+        """Create a PSF kernel from an TablePSF on a given MapGeom.
+        If the MapGeom is not an image, the same kernel will be present on all axes.
+
+        The PSF is estimated by oversampling defined by a given factor.
+
+        Parameters
+        ----------
+        table_psf : `~gammapy.irf.TablePSF`
+            the input table PSF
+        geom : `~gammapy.maps.WcsGeom`
+            the target geometry. The PSF kernel will be centered on the central pixel.
+            the geometry axes should contain an energy MapAxis.
+        max_radius : `~astropy.coordinates.Angle` or float
+            the maximum radius of the PSF kernel. If float, we assume unit is degree.
+        normalize : bool
+            normalize the PSF kernel (per energy)
+        factor : int
+            the oversample factor to compute the PSF
+
+        Returns
+        -------
+        kernel : `~gammapy.cube.PSFKernel`
+            the kernel Map with reduced geometry according to the max_radius
+        """
+        if max_radius is not None:
+            # Create a new geom accordingly
+            center = geom.center_coord[:2]
+            binsz = Quantity(np.abs(geom.wcs.wcs.cdelt[0]), 'deg')
+            max_radius = Quantity(max_radius, 'deg')
+            npix = 2 * int(max_radius / binsz) + 1
+            geom = WcsGeom.create(skydir=center, binsz=binsz, npix=npix, proj=geom.projection,
+                                  coordsys=geom.coordsys, axes=geom.axes)
+        return cls(table_psf_to_kernel_map(table_psf, geom, normalize, factor))
+
+    @classmethod
+    def from_gauss(cls, geom, sigma, max_radius=None, containment_fraction=0.99,
+                   normalize=True, factor=4):
+        """Create Gaussian PSF.
+
+        This is used for testing and examples.
+        The map geometry parameters (pixel size, energy bins) are taken from `geom`.
+        The Gaussian width ``sigma`` is a scalar,
+
+        TODO : support array input if it should vary along the energy axis.
+
+        Parameters
+        ----------
+        geom : `~gammapy.map.WcsGeom`
+            Map geometry
+        sigma : `~astropy.coordinates.Angle` or float
+            Gaussian width. Assume degrees if float input
+        max_radius : `~astropy.coordinates.Angle` or float
+            Desired kernel map size. Implicit unit is degree.
+        normalize : bool
+            normalize the PSF kernel (per energy)
+        factor : int
+            the oversample factor to compute the PSF
+
+        Returns
+        -------
+        kernel : `~gammapy.cube.PSFKernel`
+            the kernel Map with reduced geometry according to the max_radius
+        """
+        sigma = Angle(sigma, 'deg')
+        if len(sigma) > 1:
+            raise ValueError("Array values for sigma are not supported yet.")
+
+        if max_radius is None:
+            max_radius = Gauss2DPDF(sigma.to('deg').value).containment_radius(
+                containment_fraction=containment_fraction)
+
+        max_radius = Angle(max_radius, 'deg')
+
+        # Create a new geom according to given input
+        center = geom.center_coord[:2]
+        binsz = Quantity(np.abs(geom.wcs.wcs.cdelt[0]), 'deg')
+        npix = 2 * int(max_radius / binsz) + 1
+        geom = WcsGeom.create(skydir=center, binsz=binsz, npix=npix, proj=geom.projection,
+                              coordsys=geom.coordsys, axes=geom.axes)
+
+        rad = Angle(np.linspace(0., max_radius, 200), 'deg')
+
+        table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
+
+        return cls(table_psf_to_kernel_map(table_psf, geom))
+
+    def to_map(self):
+        return self._psf_kernel_map
+
+    def write(self, *args, **kwargs):
+        psf_kernel_map = self.to_map()
+        psf_kernel_map.write(*args, **kwargs)
+
+    def apply(self, map):
+        """Apply the kernel to an input Map.
+
+        Parameters
+        ----------
+        map : `~gammapy.maps.WcsNDMap`
+            the model map to be convolved with the PSFKernel.
+            It should have the same MapGeom than the current PSFKernel.
+
+        Returns
+        -------
+        convolved_map : `~gammapy.maps.Map`
+            the convolved map
+        """
+        # TODO : check that the MapGeom are consistent
+        convolved_map = Map.from_geom(geom=map.geom, unit=map.unit, meta=map.meta)
+        for img, idx in map.iter_by_image():
+            convolved_map.data[idx] = convolve_fft(img, self.to_map().data[idx])
+        return convolved_map

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -4,7 +4,6 @@ import numpy as np
 from astropy.coordinates import Angle
 from astropy.coordinates.angle_utilities import angular_separation
 import astropy.units as u
-from astropy.units import Quantity
 from astropy.convolution import convolve_fft
 from ..maps import Map, WcsGeom
 from ..image.models.gauss import Gauss2DPDF
@@ -19,9 +18,9 @@ def _make_kernel_geom(geom, max_radius):
     # Create a new geom object with an odd number of pixel and a maximum size
     # This is useful for PSF kernel creation.
     center = geom.center_coord[:2]
-    binsz = Quantity(np.abs(geom.wcs.wcs.cdelt[0]), 'deg')
-    max_radius = Quantity(max_radius, 'deg')
-    npix = 2 * int(max_radius / binsz) + 1
+    binsz = Angle(np.abs(geom.wcs.wcs.cdelt[0]), 'deg')
+    max_radius = Angle(max_radius)
+    npix = 2 * int(max_radius.deg / binsz.deg) + 1
     return WcsGeom.create(skydir=center, binsz=binsz, npix=npix, proj=geom.projection,
                           coordsys=geom.coordsys, axes=geom.axes)
 
@@ -63,21 +62,16 @@ def table_psf_to_kernel_map(table_psf, geom, factor=4):
     factor : int
         the oversample factor to compute the PSF
     """
-
     # prepare map and compute distances to map center
     kernel_map, rads = _compute_kernel_separations(geom, factor)
 
-    vals = table_psf.evaluate(rad=rads)
-    norm = vals.sum().value
+    vals = table_psf.evaluate(rad=rads).value
+    norm = vals.sum()
 
-    # loop over images and fill map
     for img, idx in kernel_map.iter_by_image():
-        img += vals.reshape(img.shape).value / norm
+        img += vals.reshape(img.shape) / norm
 
-    # downsample the psf kernel map. Take the average
-    kernel_map = kernel_map.downsample(factor, preserve_counts=True)
-
-    return kernel_map
+    return kernel_map.downsample(factor, preserve_counts=True)
 
 
 def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
@@ -110,10 +104,7 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
         vals = table_psf.evaluate(energy=energy, rad=rads).reshape(img.shape)
         img += vals.value / vals.sum().value
 
-    # downsample the psf kernel map. Take the average
-    kernel_map = kernel_map.downsample(factor, preserve_counts=True)
-
-    return kernel_map
+    return kernel_map.downsample(factor, preserve_counts=True)
 
 
 class PSFKernel(object):
@@ -121,7 +112,7 @@ class PSFKernel(object):
 
     This is a container class to store a PSF kernel
     that can be used to convolve `~gammapy.maps.WcsNDMap` objects.
-    It is usually computed from an EnergyDependentTablePSF
+    It is usually computed from an `~gammapy.irf.EnergyDependentTablePSF`.
 
     Parameters
     ----------
@@ -166,12 +157,12 @@ class PSFKernel(object):
 
     @property
     def psf_kernel_map(self):
+        """The map object holding the kernel (`~gammapy.maps.Map`)"""
         return self._psf_kernel_map
 
     @classmethod
     def read(cls, *args, **kwargs):
         """Read kernel Map from file."""
-
         psf_kernel_map = Map.read(*args, **kwargs)
         return cls(psf_kernel_map)
 
@@ -185,13 +176,13 @@ class PSFKernel(object):
 
         Parameters
         ----------
-        table_psf : `~gammapy.irf.TablePSF` or ~gammapy.irf.EnergyDependentTablePSF`
+        table_psf : `~gammapy.irf.TablePSF` or `~gammapy.irf.EnergyDependentTablePSF`
             the input table PSF
         geom : `~gammapy.maps.WcsGeom`
             the target geometry. The PSF kernel will be centered on the central pixel.
             the geometry axes should contain an energy MapAxis.
-        max_radius : `~astropy.coordinates.Angle` or float
-            the maximum radius of the PSF kernel. If float, we assume unit is degree.
+        max_radius : `~astropy.coordinates.Angle`
+            the maximum radius of the PSF kernel.
         factor : int
             the oversample factor to compute the PSF
 
@@ -223,10 +214,10 @@ class PSFKernel(object):
         ----------
         geom : `~gammapy.map.WcsGeom`
             Map geometry
-        sigma : `~astropy.coordinates.Angle` or float
-            Gaussian width. Assume degrees if float input
-        max_radius : `~astropy.coordinates.Angle` or float
-            Desired kernel map size. Implicit unit is degree.
+        sigma : `~astropy.coordinates.Angle`
+            Gaussian width.
+        max_radius : `~astropy.coordinates.Angle`
+            Desired kernel map size.
         factor : int
             the oversample factor to compute the PSF
 
@@ -235,18 +226,18 @@ class PSFKernel(object):
         kernel : `~gammapy.cube.PSFKernel`
             the kernel Map with reduced geometry according to the max_radius
         """
-        sigma = Angle(sigma, 'deg')
+        sigma = Angle(sigma)
 
         if max_radius is None:
-            max_radius = Gauss2DPDF(sigma.to('deg').value).containment_radius(
-                containment_fraction=containment_fraction)
+            max_radius = Gauss2DPDF(sigma.deg).containment_radius(
+                containment_fraction=containment_fraction) * u.deg
 
-        max_radius = Angle(max_radius, 'deg')
+        max_radius = Angle(max_radius)
 
         # Create a new geom according to given input
         geom = _make_kernel_geom(geom, max_radius)
 
-        rad = Angle(np.linspace(0., max_radius, 200), 'deg')
+        rad = Angle(np.linspace(0., max_radius.deg, 200), 'deg')
 
         table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
 

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -12,6 +12,7 @@ from ...irf import TablePSF, EnergyDependentTablePSF
 
 # TODO : add proper test with EnergyDependentTablePSF
 
+@requires_dependency('scipy')
 def test_table_psf_to_kernel_map():
     sigma = 0.5 * u.deg
     binsz = 0.1 * u.deg
@@ -29,7 +30,7 @@ def test_table_psf_to_kernel_map():
     # absolute tolerance at 0.5 because of even number of pixel here
     assert_allclose(ind, geom.center_pix, atol=0.5)
 
-
+@requires_dependency('scipy')
 def test_psf_kernel_from_gauss():
     sigma = 0.5 * u.deg
     binsz = 0.1 * u.deg
@@ -43,7 +44,7 @@ def test_psf_kernel_from_gauss():
     # Is there an odd number of pixels
     assert_allclose(np.array(kernel.psf_kernel_map.geom.npix) % 2, 1)
 
-
+@requires_dependency('scipy')
 def test_psf_kernel_convolve():
     sigma = 0.5 * u.deg
     binsz = 0.05 * u.deg

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+import astropy.units as u
+from astropy.coordinates import Angle
+from ...maps import WcsNDMap, MapAxis, WcsGeom
+from .. import PSFKernel, table_psf_to_kernel_map
+from ...irf import TablePSF, EnergyDependentTablePSF
+
+
+def test_table_psf_to_kernel_map():
+    sigma = 0.5 * u.deg
+    binsz = 0.1 * u.deg
+    geom = WcsGeom.create(binsz=binsz, npix=150)
+
+    rad = Angle(np.linspace(0., 3 * sigma, 100), 'deg')
+    table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
+    kernel = table_psf_to_kernel_map(table_psf, geom, normalize=True)
+
+    # Is normalization OK?
+    assert_allclose(kernel.data.sum(), 1.0, atol=1e-5)
+
+    # maximum at the center of map?
+    ind = np.unravel_index(np.argmax(kernel.data, axis=None), kernel.data.shape)
+    # absolute tolerance at 0.5 because of even number of pixel here
+    assert_allclose(ind, geom.center_pix, atol=0.5)
+
+
+def test_psf_kernel_from_gauss():
+    sigma = 0.5 * u.deg
+    binsz = 0.1 * u.deg
+    geom = WcsGeom.create(binsz=binsz, npix=150, axes=[MapAxis((0, 1, 2))])
+
+    kernel = PSFKernel.from_gauss(geom, sigma)
+
+    # Check that both maps are identical
+    assert_allclose(kernel.to_map().data[0], kernel.to_map().data[1])
+
+    # Is there an odd number of pixels
+    assert_allclose(np.array(kernel.to_map().geom.npix) % 2, 1)
+
+
+def test_psf_kernel_convolve():
+    sigma = 0.5 * u.deg
+    binsz = 0.05 * u.deg
+
+    testmap = WcsNDMap.create(binsz=binsz, width=5 * u.deg)
+    testmap.fill_by_coord(([1], [1]), weights=np.array([2]))
+
+    kernel = PSFKernel.from_gauss(testmap.geom, sigma)
+
+    conv_map = kernel.apply(testmap)
+
+    # Is convolved map normalization OK
+    assert_allclose(conv_map.data.sum(), 2.0, atol=1e-3)
+
+    # Are the maxima at the same position?
+    index_conv = np.unravel_index(np.argmax(conv_map.data, axis=None), conv_map.data.shape)
+    index_test = np.unravel_index(np.argmax(testmap.data, axis=None), testmap.data.shape)
+    assert_allclose(index_conv, index_test)

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle
+from ...utils.testing import requires_dependency
 from ...maps import WcsNDMap, MapAxis, WcsGeom
 from .. import PSFKernel
 from ..psf_kernel import table_psf_to_kernel_map

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -45,6 +45,11 @@ def test_psf_kernel_from_gauss():
     # Is there an odd number of pixels
     assert_allclose(np.array(kernel.psf_kernel_map.geom.npix) % 2, 1)
 
+    # Test read and write
+    kernel.write('test_kernel.fits', overwrite=True)
+    newkernel = PSFKernel.read('test_kernel.fits')
+    assert_allclose(kernel.psf_kernel_map.data, newkernel.psf_kernel_map.data)
+
 @requires_dependency('scipy')
 def test_psf_kernel_convolve():
     sigma = 0.5 * u.deg
@@ -67,3 +72,4 @@ def test_psf_kernel_convolve():
 
     # Is the maximum in the convolved map at the right position?
     assert conv_map.get_by_coord([1,1]) == np.max(conv_map.data)
+

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -36,10 +36,10 @@ def test_psf_kernel_from_gauss():
     kernel = PSFKernel.from_gauss(geom, sigma)
 
     # Check that both maps are identical
-    assert_allclose(kernel.to_map().data[0], kernel.to_map().data[1])
+    assert_allclose(kernel.psf_kernel_map.data[0], kernel.psf_kernel_map.data[1])
 
     # Is there an odd number of pixels
-    assert_allclose(np.array(kernel.to_map().geom.npix) % 2, 1)
+    assert_allclose(np.array(kernel.psf_kernel_map.geom.npix) % 2, 1)
 
 
 def test_psf_kernel_convolve():

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -17,7 +17,7 @@ def test_table_psf_to_kernel_map():
 
     rad = Angle(np.linspace(0., 3 * sigma, 100), 'deg')
     table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
-    kernel = table_psf_to_kernel_map(table_psf, geom, normalize=True)
+    kernel = table_psf_to_kernel_map(table_psf, geom)
 
     # Is normalization OK?
     assert_allclose(kernel.data.sum(), 1.0, atol=1e-5)

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -19,7 +19,7 @@ def test_table_psf_to_kernel_map():
     binsz = 0.1 * u.deg
     geom = WcsGeom.create(binsz=binsz, npix=150)
 
-    rad = Angle(np.linspace(0., 3 * sigma, 100), 'deg')
+    rad = Angle(np.linspace(0., 3 * sigma.to('deg').value, 100), 'deg')
     table_psf = TablePSF.from_shape(shape='gauss', width=sigma, rad=rad)
     kernel = table_psf_to_kernel_map(table_psf, geom)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1366,3 +1366,55 @@ class MapGeom(object):
             return True
         is_image = len(self.axes) == 0
         return is_image
+
+    @property
+    def axes_names(self):
+        """Returns list of axes names"""
+        return [_.name for _ in self.axes]
+
+    def get_axis_by_name(self, name):
+        """Return axis with corresponding name or type.
+
+        Parameters
+        ----------
+        name : str
+           the name of the requested axis
+
+        Returns
+        -------
+        axis : `~gammapy.maps.MapAxis`
+            the corresponding axis
+
+        """
+
+        # TODO : we implictly assume all axes have different names. This should be enforced at MapGeom creation.
+        for i, axis in enumerate(self.axes):
+            if axis.name.upper() == name.upper():
+                return axis
+        raise ValueError("Cannot find axis named {}".format(name))
+
+    def get_axes_by_type(self, type):
+        """Returns a tuple containing axes of a given type.
+
+        Parameters
+        ----------
+        type : str in {'energy', 'time', 'any'}
+           the name of the requested type of axis
+
+        Returns
+        -------
+        axes : list of `~gammapy.maps.MapAxis`
+            the corresponding list of axis
+        """
+        valid_types = ('energy', 'time', 'any')
+        if type not in valid_types:
+            raise ValueError("Invalid axis type {}. Should be {}.".format(type, valid_types))
+        axes_list=[]
+        for i, axis in enumerate(self.axes):
+            if axis.type == type:
+                axes_list.append(axis)
+
+        if len(axes_list) ==0:
+            raise ValueError("Cannot find type {}".format(type))
+
+        return axes_list

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1373,7 +1373,7 @@ class MapGeom(object):
         return [_.name for _ in self.axes]
 
     def get_axis_by_name(self, name):
-        """Return axis with corresponding name or type.
+        """Return axis with corresponding name
 
         Parameters
         ----------
@@ -1393,8 +1393,8 @@ class MapGeom(object):
                 return axis
         raise ValueError("Cannot find axis named {}".format(name))
 
-    def get_axes_by_type(self, type):
-        """Returns a tuple containing axes of a given type.
+    def get_axis_by_type(self, type):
+        """Returns axis of given type.
 
         Parameters
         ----------
@@ -1403,18 +1403,14 @@ class MapGeom(object):
 
         Returns
         -------
-        axes : list of `~gammapy.maps.MapAxis`
-            the corresponding list of axis
+        axes : `~gammapy.maps.MapAxis`
+            the corresponding  axis
         """
         valid_types = ('energy', 'time', 'any')
         if type not in valid_types:
             raise ValueError("Invalid axis type {}. Should be {}.".format(type, valid_types))
-        axes_list=[]
+
         for i, axis in enumerate(self.axes):
             if axis.type == type:
-                axes_list.append(axis)
-
-        if len(axes_list) ==0:
-            raise ValueError("Cannot find type {}".format(type))
-
-        return axes_list
+                return axis
+        raise ValueError("Cannot find type {}".format(type))


### PR DESCRIPTION
This is a first commit to discuss.

Two function that take a TablePSF or an EnergyDependentTablePSF as well as a MapGeom are provided and are used to build the PSF kernel map.

The creators on PSFKernel ensure that there is an odd number of pixels for convolution.

The `PSFKernel.apply()`method is performing the PSF kernel convolution on a Map that has the same geometry.

A number of tests are present already and should be completed.
