### PR TITLE
Correcting exposure unit in MapMaker

### DIFF
--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -409,13 +409,12 @@ class MapMaker(object):
         )
 
         self._add_cutouts(cutout_slices, count_obs_map, expo_obs_map, background_obs_map)
-        #self.exclusion_map.unit = expo_obs_map.unit
-        #self.background_map.unit = background_obs_map.unit
-        #self.count_map.unit = count_obs_map.unit
+
+
 
 
     def _add_cutouts(self, cutout_slices, count_obs_map, expo_obs_map, acceptance_obs_map):
         """Add current cutout to global maps."""
         self.count_map.data[cutout_slices] += count_obs_map.data
-        self.exposure_map.data[cutout_slices] += expo_obs_map.data
+        self.exposure_map.data[cutout_slices] += (expo_obs_map.data * expo_obs_map.unit).to("m2 s")
         self.background_map.data[cutout_slices] += acceptance_obs_map.data

--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -158,7 +158,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max
     # We check if exposure is a 3D array in case there is a single bin in energy
     # TODO: call np.atleast_3d ?
     if len(exposure.shape) < 3:
-        exposure = np.expand_dims(exposure, 0)
+        exposure = np.expand_dims(exposure, 0) * exposure.unit
 
     # Put exposure outside offset max to zero
     # This might be more generaly dealt with a mask map
@@ -360,7 +360,7 @@ class MapMaker(object):
         self.count_map = WcsNDMap(self.ref_geom)
 
         data = np.zeros_like(self.count_map.data)
-        self.exposure_map = WcsNDMap(self.ref_geom, data)
+        self.exposure_map = WcsNDMap(self.ref_geom, data, unit="m2 s")
 
         data = np.zeros_like(self.count_map.data)
         self.background_map = WcsNDMap(self.ref_geom, data)
@@ -409,6 +409,10 @@ class MapMaker(object):
         )
 
         self._add_cutouts(cutout_slices, count_obs_map, expo_obs_map, background_obs_map)
+        #self.exclusion_map.unit = expo_obs_map.unit
+        #self.background_map.unit = background_obs_map.unit
+        #self.count_map.unit = count_obs_map.unit
+
 
     def _add_cutouts(self, cutout_slices, count_obs_map, expo_obs_map, acceptance_obs_map):
         """Add current cutout to global maps."""

--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-#import astropy.units as u
 from astropy.coordinates import SkyCoord, Angle
 from astropy.nddata import Cutout2D
 from astropy.nddata.utils import PartialOverlapError
@@ -158,7 +157,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max
     # We check if exposure is a 3D array in case there is a single bin in energy
     # TODO: call np.atleast_3d ?
     if len(exposure.shape) < 3:
-        exposure = np.expand_dims(exposure, 0) * exposure.unit
+        exposure = np.expand_dims(exposure.value, 0) * exposure.unit
 
     # Put exposure outside offset max to zero
     # This might be more generaly dealt with a mask map
@@ -416,5 +415,5 @@ class MapMaker(object):
     def _add_cutouts(self, cutout_slices, count_obs_map, expo_obs_map, acceptance_obs_map):
         """Add current cutout to global maps."""
         self.count_map.data[cutout_slices] += count_obs_map.data
-        self.exposure_map.data[cutout_slices] += (expo_obs_map.data * expo_obs_map.unit).to("m2 s").value
+        self.exposure_map.data[cutout_slices] += expo_obs_map.quantity.to(self.exposure_map.unit).value
         self.background_map.data[cutout_slices] += acceptance_obs_map.data

--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-# import astropy.units as u
+#import astropy.units as u
 from astropy.coordinates import SkyCoord, Angle
 from astropy.nddata import Cutout2D
 from astropy.nddata.utils import PartialOverlapError
@@ -416,5 +416,5 @@ class MapMaker(object):
     def _add_cutouts(self, cutout_slices, count_obs_map, expo_obs_map, acceptance_obs_map):
         """Add current cutout to global maps."""
         self.count_map.data[cutout_slices] += count_obs_map.data
-        self.exposure_map.data[cutout_slices] += (expo_obs_map.data * expo_obs_map.unit).to("m2 s")
+        self.exposure_map.data[cutout_slices] += (expo_obs_map.data * expo_obs_map.unit).to("m2 s").value
         self.background_map.data[cutout_slices] += acceptance_obs_map.data

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -3,13 +3,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+import astropy.units as u
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
 from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data
 from ...irf import EffectiveAreaTable2D, Background3D
 from ...maps import WcsNDMap, WcsGeom, MapAxis
-from ..new import make_separation_map, make_map_exposure_true_energy, make_map_hadron_acceptance
+from ..new import make_separation_map, make_map_exposure_true_energy, make_map_hadron_acceptance, MapMaker
+from ...data import DataStore
 
 pytest.importorskip('scipy')
 
@@ -88,3 +90,19 @@ def test_make_map_fov_background(bkg_3d, counts_cube):
     # pos = SkyCoord(85.6, 23, unit='deg')
     # val = bkg_cube.lookup(pos, energy=1 * u.TeV)
     # assert_allclose(val, 0)
+
+@requires_data('gammapy-extra')
+def test_MapMaker():
+    ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
+    obs = ds.obs(111140)
+    pos_SagA = SkyCoord(266.41681663, -29.00782497, unit="deg", frame="icrs")
+    energy_axis = MapAxis.from_edges([0.1,0.5,1.5,3.0,10.],name='energy',unit='TeV',interp='log')
+    geom = WcsGeom.create(binsz=0.1*u.deg, skydir=pos_SagA, width=15.0, axes=[energy_axis])
+    mmaker = MapMaker(geom, 4.0 * u.deg)
+    mmaker.process_obs(obs)
+
+    assert mmaker.exposure_map.unit == "m2 s"
+    assert_quantity_allclose(mmaker.count_map.data.sum, 51152.0)
+
+
+

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -102,7 +102,7 @@ def test_MapMaker():
     mmaker.process_obs(obs)
 
     assert mmaker.exposure_map.unit == "m2 s"
-    assert_quantity_allclose(mmaker.count_map.data.sum, 51152.0)
+    assert_quantity_allclose(mmaker.count_map.data.sum(), 51152.0)
 
 
 


### PR DESCRIPTION
This PR is to address the issue #1436
The MapMaker class now puts a correct unit on the exposure map.
Also, `make_map_exposure_true_energy` did not take the unit properly for case there is a single bin in energy, because `np.expand_dims` did not return an unit. This is also corrected.