### PR TITLE
Bugfix for `setup.py build_docs`

### DIFF
--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -32,7 +32,7 @@ import nbformat
 from nbformat.v4 import new_markdown_cell
 from nbconvert.exporters import PythonExporter
 
-from ..extern.pathlib import Path, PurePosixPath
+from ..extern.pathlib import Path
 
 try:
     gammapy_extra_path = Path(os.environ['GAMMAPY_EXTRA'])
@@ -91,7 +91,7 @@ def make_link_node(rawtext, app, refuri, notebook, options):
     # base = 'https://github.com/gammapy/gammapy-extra/tree/master/notebooks/'
     # base = 'https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/notebooks/'
 
-    relpath = refuri.split(str(Path(PurePosixPath("gammapy/docs/"))))[1]
+    relpath = refuri.split(str(Path("gammapy/docs/")))[1]
     foldersplit = relpath.split('/')
     base = '../' * (len(foldersplit) - 1) + 'notebooks/'
     full_name = notebook + '.html'

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -32,7 +32,7 @@ import nbformat
 from nbformat.v4 import new_markdown_cell
 from nbconvert.exporters import PythonExporter
 
-from ..extern.pathlib import Path
+from ..extern.pathlib import Path, PurePosixPath
 
 try:
     gammapy_extra_path = Path(os.environ['GAMMAPY_EXTRA'])
@@ -91,7 +91,7 @@ def make_link_node(rawtext, app, refuri, notebook, options):
     # base = 'https://github.com/gammapy/gammapy-extra/tree/master/notebooks/'
     # base = 'https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/notebooks/'
 
-    relpath = refuri.split('gammapy/docs/')[1]
+    relpath = refuri.split(str(Path(PurePosixPath("gammapy/docs/"))))[1]
     foldersplit = relpath.split('/')
     base = '../' * (len(foldersplit) - 1) + 'notebooks/'
     full_name = notebook + '.html'


### PR DESCRIPTION
This PR is a bugfix for the `setup.py build_docs`-command, fixing follwoing error message:

```
File \gammapy\build\lib.win-amd64-3.5\gammapy\utils\docs.py, line 94, in make_link_node

relpath = refuri.split('gammapy/docs/')[1]

IndexError: list index out of range
```

changed `make_link_node` to work with both Windows and Linux by using `PurePosixPath` from `pathlib`