### PR TITLE
Background added to model evaluator

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -29,11 +29,12 @@ class SkyModelMapFit(object):
         PSF kernel
     """
 
-    def __init__(self, model, counts, exposure, psf=None):
+    def __init__(self, model, counts, exposure, psf=None, background=None):
         self.model = model
         self.counts = counts
         self.exposure = exposure
         self.psf = psf
+        self.background = background
 
         self._npred = None
         self._stat = None
@@ -60,7 +61,8 @@ class SkyModelMapFit(object):
         """Initialize SkyModelEvaluator"""
         self.evaluator = SkyModelMapEvaluator(sky_model=self.model,
                                               exposure=self.exposure,
-                                              psf=self.psf)
+                                              psf=self.psf,
+                                              background=self.background)
 
     def compute_npred(self):
         """Compute predicted counts"""

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -27,6 +27,8 @@ class SkyModelMapFit(object):
         Exposure cube
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel
+    background : `~gammapy.maps.WcsNDMap`
+        Background Cube
     """
 
     def __init__(self, model, counts, exposure, psf=None, background=None):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -191,12 +191,15 @@ class SkyModelMapEvaluator(object):
         Exposure map
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel
+    background : `~gammapy.maps.Map`
+        background map
     """
 
-    def __init__(self, sky_model=None, exposure=None, psf=None):
+    def __init__(self, sky_model=None, exposure=None, psf=None, background=None):
         self.sky_model = sky_model
         self.exposure = exposure
         self.psf = psf
+        self.background = background
 
     @lazyproperty
     def geom(self):
@@ -299,5 +302,9 @@ class SkyModelMapEvaluator(object):
         npred = self.apply_aeff(flux)
         if self.psf is not None:
             npred = self.apply_psf(npred)
-        return npred.data
+        if self.background:
+            return npred.data + self.background.data
+        else:
+            return npred.data
+
 

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -303,8 +303,7 @@ class SkyModelMapEvaluator(object):
         if self.psf is not None:
             npred = self.apply_psf(npred)
         if self.background:
-            return npred.data + self.background.data
-        else:
-            return npred.data
+            npred.data += self.background.data
+        return npred.data
 
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -84,7 +84,7 @@ def psf(geom):
 def counts(sky_model, exposure, psf):
     evaluator = SkyModelMapEvaluator(sky_model=sky_model,
                                      exposure=exposure,
-                                     psf=psf,
+                                     psf=psf
                                      )
     npred = evaluator.compute_npred()
     return WcsNDMap(exposure.geom, npred)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -84,8 +84,7 @@ def psf(geom):
 def counts(sky_model, exposure, psf):
     evaluator = SkyModelMapEvaluator(sky_model=sky_model,
                                      exposure=exposure,
-                                     psf=psf
-                                     )
+                                     psf=psf)
     npred = evaluator.compute_npred()
     return WcsNDMap(exposure.geom, npred)
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -65,7 +65,7 @@ def exposure(geom):
 @pytest.fixture(scope='session')
 def background(geom):
     m = Map.from_geom(geom)
-    m.quantity = np.ones((9, 150, 400))*1e-5
+    m.quantity = np.ones(m.data.shape)*1e-5
     return m
 
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -85,7 +85,7 @@ def counts(sky_model, exposure, psf):
     evaluator = SkyModelMapEvaluator(sky_model=sky_model,
                                      exposure=exposure,
                                      psf=psf,
-                                     background=background)
+                                     )
     npred = evaluator.compute_npred()
     return WcsNDMap(exposure.geom, npred)
 
@@ -93,7 +93,7 @@ def counts(sky_model, exposure, psf):
 @requires_dependency('scipy')
 @requires_dependency('iminuit')
 @requires_data('gammapy-extra')
-def test_cube_fit(sky_model, counts, exposure, psf):
+def test_cube_fit(sky_model, counts, exposure, psf, background):
     input_model = sky_model.copy()
 
     input_model.parameters['lon_0'].value = 0
@@ -110,7 +110,8 @@ def test_cube_fit(sky_model, counts, exposure, psf):
     fit = SkyModelMapFit(model=input_model,
                          counts=counts,
                          exposure=exposure,
-                         psf=psf)
+                         psf=psf,
+                         background=background)
     fit.fit()
 
     assert_quantity_allclose(fit.model.parameters['index'].quantity,

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -131,12 +131,11 @@ class TestSkyModelMapEvaluator:
     def test_compute_npred(self):
         out = self.evaluator.compute_npred()
         assert out.shape == (2, 4, 5)
-        npred_expected = 7.312826994672788e-07
-        assert_allclose(out.sum(), npred_expected)
+        assert_allclose(out.sum(), 7.312826994672788e-07)
 
-        evaluator_bkg = SkyModelMapEvaluator(sky_model(), exposure(geom()), background=background(geom()))
+    def test_compute_npred_withbkg(self, sky_model, exposure, background):
+        evaluator_bkg = SkyModelMapEvaluator(sky_model, exposure, background=background)
         out_bkg = evaluator_bkg.compute_npred()
-        npred_back_expected = npred_expected + 40.0e-7
-        assert_allclose(out_bkg.sum(), npred_back_expected)
+        assert_allclose(out_bkg.sum(), 47.312826994672788e-07)
 
 

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -23,6 +23,12 @@ def exposure(geom):
     m.quantity = np.ones((2, 4, 5)) * u.Quantity('100 m2 s')
     return m
 
+@pytest.fixture(scope='session')
+def background(geom):
+    m = Map.from_geom(geom)
+    m.quantity = np.ones((2, 4, 5))*1e-7
+    return m
+
 
 @pytest.fixture(scope='session')
 def sky_model():
@@ -125,4 +131,12 @@ class TestSkyModelMapEvaluator:
     def test_compute_npred(self):
         out = self.evaluator.compute_npred()
         assert out.shape == (2, 4, 5)
-        assert_allclose(out.sum(), 7.312826994672788e-07)
+        npred_expected = 7.312826994672788e-07
+        assert_allclose(out.sum(), npred_expected)
+
+        evaluator_bkg = SkyModelMapEvaluator(sky_model(), exposure(geom()), background=background(geom()))
+        out_bkg = evaluator_bkg.compute_npred()
+        npred_back_expected = npred_expected + 40.0e-7
+        assert_allclose(out_bkg.sum(), npred_back_expected)
+
+


### PR DESCRIPTION
The SkyModelEvaluator now adds background to the npred.

The fit stats value needed to be changed in the test (also mentioned in @mackaiver PR #1466 )

