### PR TITLE
Add field-of-view coordinate transformations

### DIFF
--- a/gammapy/utils/coordinates/__init__.py
+++ b/gammapy/utils/coordinates/__init__.py
@@ -2,3 +2,4 @@
 """
 from .celestial import *
 from .other import *
+from .fov import *

--- a/gammapy/utils/coordinates/fov.py
+++ b/gammapy/utils/coordinates/fov.py
@@ -1,0 +1,109 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+
+__all__ = [
+    'fov_to_sky',
+    'sky_to_fov'
+]
+
+def fov_to_sky(lon, lat, lon_pnt, lat_pnt):
+    """Make a transformation from field-of-view coordinates to sky coordinates.
+
+    Parameters
+    ----------
+    lon : array_like
+        Field-of-view longitude coordinate to be transformed, in degrees
+    lat : array_like
+        Field-of-view latitude coordinate to be transformed, in degrees
+    lon_pnt : array_like
+        Longitude coordinate of the pointing position, in degrees
+    lat_pnt : array_like
+        Latitude coordinate of the pointing position, in degrees
+
+    Returns
+    -------
+    lon_t : array_like
+        Sky longitude coordinate, in degrees
+    lat_t : array_like
+        Sky latitude coordinate, in degrees
+    """
+
+    # compute cartesian coordinates
+    x = np.cos(np.deg2rad(lat))*np.cos(np.deg2rad(lon))
+    y = np.cos(np.deg2rad(lat))*np.sin(np.deg2rad(lon))
+    z = np.sin(np.deg2rad(lat))
+
+    # make sure vector is properly normalised
+    assert np.allclose(x**2+y**2+z**2, 1)
+
+    # switch coordinates due to axis convention
+    x_ = -z
+    y_ = y
+    z_ = x
+
+    # transform
+    lat_pnt = np.deg2rad(90 - lat_pnt)
+    lon_pnt = -np.deg2rad(lon_pnt)
+    x_t = x_*np.cos(lat_pnt)*np.cos(lon_pnt) - y_*np.sin(lon_pnt) + z_*np.sin(lat_pnt)*np.cos(lon_pnt)
+    y_t = x_*np.sin(lon_pnt)*np.cos(lat_pnt) + y_*np.cos(lon_pnt) + z_*np.sin(lon_pnt)*np.sin(lat_pnt)
+    z_t = -x_*np.sin(lat_pnt) + z_*np.cos(lat_pnt)
+
+    # compute new lon, lat
+    lon_t = -np.rad2deg(np.arctan2(y_t,x_t))
+    lat_t = np.rad2deg(np.arcsin(z_t))
+
+    # shift lon by 360 degrees if negative
+    lon_t = np.where(lon_t < 0, lon_t + 360, lon_t)
+
+    return lon_t, lat_t
+
+def sky_to_fov(lon, lat, lon_pnt, lat_pnt):
+    """Make a transformation from sky coordinates to field-of-view coordinates.
+
+    Parameters
+    ----------
+    lon : array_like
+        Sky longitude coordinate to be transformed, in degrees
+    lat : array_like
+        Sky latitude coordinate to be transformed, in degrees
+    lon_pnt : array_like
+        Longitude coordinate of the pointing position, in degrees
+    lat_pnt : array_like
+        Latitude coordinate of the pointing position, in degrees
+
+    Returns
+    -------
+    lon_t : array_like
+        Field-of-view longitude coordinate, in degrees
+    lat_t : array_like
+        Field-of-view latitude coordinate, in degrees
+    """
+
+    lon_ = -lon
+
+    # compute cartesian coordinates
+    x = np.cos(np.deg2rad(lat))*np.cos(np.deg2rad(lon_))
+    y = np.cos(np.deg2rad(lat))*np.sin(np.deg2rad(lon_))
+    z = np.sin(np.deg2rad(lat))
+
+    # make sure vector is properly normalised
+    assert np.allclose(x**2+y**2+z**2, 1)
+
+    # transform
+    lat_pnt = np.deg2rad(90 - lat_pnt)
+    lon_pnt = -np.deg2rad(lon_pnt)
+    x_t = x*np.cos(lat_pnt)*np.cos(lon_pnt) + y*np.sin(lon_pnt)*np.cos(lat_pnt) - z*np.sin(lat_pnt)
+    y_t = -x*np.sin(lon_pnt) + y*np.cos(lon_pnt)
+    z_t = x*np.sin(lat_pnt)*np.cos(lon_pnt) + y*np.sin(lat_pnt)*np.sin(lon_pnt) + z*np.cos(lat_pnt)
+
+    # switch coordinates due to axis convention
+    x_ = z_t
+    y_ = y_t
+    z_ = -x_t
+
+    # compute new lon, lat
+    lon_t = np.rad2deg(np.arctan2(y_,x_))
+    lat_t = np.rad2deg(np.arcsin(z_))
+
+    return lon_t, lat_t

--- a/gammapy/utils/coordinates/tests/test_fov.py
+++ b/gammapy/utils/coordinates/tests/test_fov.py
@@ -1,0 +1,53 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from numpy.testing import assert_allclose
+from ..fov import fov_to_sky, sky_to_fov
+
+def test_fov_to_sky():
+    # test some simple cases
+    az,alt = fov_to_sky(1, 1, 0, 0)
+    assert_allclose(az, 359)
+    assert_allclose(alt, 1)
+
+    az,alt = fov_to_sky(-1, 1, 180, 0)
+    assert_allclose(az, 181)
+    assert_allclose(alt, 1)
+
+    az,alt = fov_to_sky(1, 0, 0, 60)
+    assert_allclose(az, 358, rtol=1e-3)
+    assert_allclose(alt, 59.985, rtol=1e-3)
+
+    # these are cross-checked with the
+    # transformation as implemented in H.E.S.S.
+    fov_altaz_lon = np.array([0.7145614, 0.86603433, -0.05409698, 2.10295248])
+    fov_altaz_lat = np.array([-1.60829115, -1.19643974, 0.45800984, 3.26844192])
+    az_pointing = np.array([52.42056255, 52.24706061, 52.06655505, 51.86795724])
+    alt_pointing = np.array([51.11908203, 51.23454751, 51.35376141, 51.48385814])
+    az,alt = fov_to_sky(fov_altaz_lon, fov_altaz_lat, az_pointing, alt_pointing)
+    assert_allclose(az, np.array([51.320575, 50.899125, 52.154053, 48.233023]))
+    assert_allclose(alt, np.array([49.505451, 50.030165, 51.811739, 54.700102]))
+
+def test_sky_to_fov():
+    # test some simple cases
+    lon,lat = sky_to_fov(1, 1, 0, 0)
+    assert_allclose(lon, -1)
+    assert_allclose(lat, 1)
+
+    lon,lat = sky_to_fov(269, 0, 270, 0)
+    assert_allclose(lon, 1)
+    assert_allclose(lat, 0, atol=1e-7)
+
+    lon,lat = sky_to_fov(1, 60, 0, 60)
+    assert_allclose(lon, -0.5, rtol=1e-3)
+    assert_allclose(lat, 0.003779, rtol=1e-3)
+
+    # these are cross-checked with the
+    # transformation as implemented in H.E.S.S.
+    az = np.array([51.320575, 50.899125, 52.154053, 48.233023])
+    alt = np.array([49.505451, 50.030165, 51.811739, 54.700102])
+    az_pointing = np.array([52.42056255, 52.24706061, 52.06655505, 51.86795724])
+    alt_pointing = np.array([51.11908203, 51.23454751, 51.35376141, 51.48385814])
+    lon,lat = sky_to_fov(az, alt, az_pointing, alt_pointing)
+    assert_allclose(lon, np.array([0.7145614, 0.86603433, -0.05409698, 2.10295248]), rtol=1e-5)
+    assert_allclose(lat, np.array([-1.60829115, -1.19643974, 0.45800984, 3.26844192]), rtol=1e-5)


### PR DESCRIPTION
This PR adds transformations from sky coordinates to field-of-view coordinates and vice versa. This is required e.g. for non-radially-symmetric background maps.

Things that could likely be improved:
- Use astropy Angle for input and output coordinates?
- Possibly, SkyOffsetFrame from astropy already provides the same transformation

A test has been added, so it's easy to work on these points and make sure the results are still correct.