### PR TITLE
Add evaluate method to the background 3D

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -134,15 +134,15 @@ class Background3D(object):
         """Convert to `~astropy.io.fits.BinTable`."""
         return fits.BinTableHDU(self.to_table(), name=name)
 
-    def evaluate(self, det_x, det_y, energy_reco, method=None, **kwargs):
+    def evaluate(self, detx, dety, energy_reco, method=None, **kwargs):
         """
         Evaluate the `Background3D` at a given FOV coordinate and energy. The coordinates det_x, det_y and erngy_reco
         should have the same dimension that match the numbers of point you want to evaluate
         Parameters
         ----------
-        det_x : `~astropy.coordinates.Angle`
+        detx : `~astropy.coordinates.Angle`
                 FOV coordinate X-axis binning. Same dimension than det_y and energy_reco
-        det_y: `~astropy.coordinates.Angle`
+        dety: `~astropy.coordinates.Angle`
                 FOV coordinate Y-axis binning. Same dimension than det_x and energy_reco
         energy_reco : `~astropy.units.Quantity`
                 energy on which you want to interpolate. Same dimension than det_x and det_y
@@ -155,7 +155,7 @@ class Background3D(object):
         array : `~astropy.units.Quantity`
             Interpolated values, axis order is the same as for the NDData array
         """
-        points=dict(detx=det_x, dety=det_y, energy=energy_reco)
+        points = dict(detx=detx, dety=dety, energy=energy_reco)
         array = self.data.evaluate_at_coord(points=points, method=method, **kwargs)
         return array
 
@@ -237,7 +237,7 @@ class Background2D(object):
         filename = make_path(filename)
         with fits.open(str(filename), memmap=False) as hdulist:
             bkg = cls.from_hdulist(hdulist, hdu=hdu)
-        
+
         return bkg
 
     def to_table(self):

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -150,6 +150,7 @@ class Background3D(object):
             Interpolation method
         kwargs : dict
             option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
+            
         Returns
         -------
         array : `~astropy.units.Quantity`

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -134,6 +134,31 @@ class Background3D(object):
         """Convert to `~astropy.io.fits.BinTable`."""
         return fits.BinTableHDU(self.to_table(), name=name)
 
+    def evaluate(self, det_x, det_y, energy_reco, method=None, **kwargs):
+        """
+        Evaluate the `Background3D` at a given FOV coordinate and energy. The coordinates det_x, det_y and erngy_reco
+        should have the same dimension that match the numbers of point you want to evaluate
+        Parameters
+        ----------
+        det_x : `~astropy.coordinates.Angle`
+                FOV coordinate X-axis binning. Same dimension than det_y and energy_reco
+        det_y: `~astropy.coordinates.Angle`
+                FOV coordinate Y-axis binning. Same dimension than det_x and energy_reco
+        energy_reco : `~astropy.units.Quantity`
+                energy on which you want to interpolate. Same dimension than det_x and det_y
+        method : str {'linear', 'nearest'}, optional
+            Interpolation method
+        kwargs : dict
+            option for interpolation for `~scipy.interpolate.RegularGridInterpolator`
+        Returns
+        -------
+        array : `~astropy.units.Quantity`
+            Interpolated values, axis order is the same as for the NDData array
+        """
+        points=dict(detx=det_x, dety=det_y, energy=energy_reco)
+        array = self.data.evaluate_at_coord(points=points, method=method, **kwargs)
+        return array
+
 
 class Background2D(object):
     """Background 2D.

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -14,6 +14,20 @@ def bkg_3d():
     filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     return Background3D.read(filename, hdu='BACKGROUND')
 
+@pytest.fixture(scope='session')
+def bkg_3d_simple():
+    """A simple Background2D test case"""
+    energy = [0.1, 10, 1000] * u.TeV
+    det_x = [0, 1, 2, 3] * u.deg
+    det_y = [0, 1, 2, 3] * u.deg
+    data = np.zeros((2, 3, 3)) * u.Unit('s-1 MeV-1 sr-1')
+    data.value[1, 0, 0] = 2
+    data.value[1, 1, 1] = 4
+    return Background3D(
+        energy_lo=energy[:-1], energy_hi=energy[1:],
+        detx_lo=det_x[:-1], detx_hi=det_x[1:], dety_lo=det_y[:-1], dety_hi=det_y[1:],
+        data=data
+    )
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
@@ -33,8 +47,6 @@ def test_background_3d_basics(bkg_3d):
     assert axis.unit == 'deg'
 
     data = bkg_3d.data.data
-    assert data.shape == (21, 36, 36)
-    assert data.unit == u.Unit('s-1 MeV-1 sr-1')
 
 
 @requires_dependency('scipy')
@@ -51,6 +63,71 @@ def test_background_3d_write(bkg_3d):
     assert_equal(hdu.data['DETX_LO'][0], bkg_3d.data.axis('detx').lo.value)
     assert hdu.header['TUNIT1'] == bkg_3d.data.axis('detx').lo.unit
 
+    assert data.shape == (21, 36, 36)
+    assert data.unit == u.Unit('s-1 MeV-1 sr-1')
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_background_3d_basics2(bkg_3d_simple):
+    assert 'NDDataArray summary info' in str(bkg_3d_simple.data)
+
+    axis = bkg_3d_simple.data.axis('energy')
+    assert axis.nbins == 2
+    assert axis.unit == 'TeV'
+
+    axis = bkg_3d_simple.data.axis('detx')
+    assert axis.nbins == 3
+    assert axis.unit == 'deg'
+
+    axis = bkg_3d_simple.data.axis('dety')
+    assert axis.nbins == 3
+    assert axis.unit == 'deg'
+
+    data = bkg_3d_simple.data.data
+    assert data.shape == (2, 3, 3)
+    assert data.unit == u.Unit('s-1 MeV-1 sr-1')
+
+def test_background_3d_read_write(tmpdir, bkg_3d_simple):
+    filename = str(tmpdir / "bkg3d.fits")
+    bkg_3d_simple.to_fits().writeto(filename)
+
+    bkg_3d = Background3D.read(filename)
+
+    axis = bkg_3d.data.axis('energy')
+    assert axis.nbins == 2
+    assert axis.unit == 'TeV'
+
+    axis = bkg_3d.data.axis('detx')
+    assert axis.nbins == 3
+    assert axis.unit == 'deg'
+
+    axis = bkg_3d.data.axis('dety')
+    assert axis.nbins == 3
+    assert axis.unit == 'deg'
+
+    data = bkg_3d.data.data
+    assert data.shape == (2, 3, 3)
+    assert data.unit == 's-1 MeV-1 sr-1'
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_background_3d_evaluate_2(bkg_3d_simple):
+    # Evaluate at log center between nodes in energy
+    bkg_rate = bkg_3d_simple.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 1 * u.TeV)
+    assert_allclose(res.value, 0)
+    assert res.shape == (2,)
+    assert res.unit == 's-1 MeV-1 sr-1'
+
+    res = bkg_3d_simple.evaluate(fov_offset=[1, 0.5] * u.deg, energy_reco=100 * u.TeV)
+    assert_allclose(res.value, [3, 2])
+
+    res = bkg_3d_simple.evaluate(fov_offset=[1, 0.5] * u.deg, energy_reco=[1, 100] * u.TeV)
+    assert_allclose(res.value, [[0, 0], [3, 2]])
+    assert res.shape == (2, 2)
+
+    res = bkg_3d_simple.evaluate(fov_offset=1 * u.deg, energy_reco=[1, 100] * u.TeV)
+    assert_allclose(res.value, [0, 3])
+    assert res.shape == (2,)
 
 @pytest.fixture(scope='session')
 def bkg_2d():

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -73,18 +73,20 @@ def test_background_3d_read_write(tmpdir, bkg_3d):
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_background_3d_evaluate(bkg_3d):
-    # Evaluate at log center between nodes in energy
-    res = bkg_3d.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 1 * u.TeV)
+    # Evaluate at nodes in energy
+    res = bkg_3d.evaluate(detx=np.array([1, 0.5]) * u.deg, dety=np.array([1, 0.5]) * u.deg,
+                          energy_reco=np.ones(2) * 1 * u.TeV)
     assert_allclose(res.value, 0)
     assert res.shape == (2,)
     assert res.unit == 's-1 MeV-1 sr-1'
 
-    res = bkg_3d.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 100 * u.TeV)
+    res = bkg_3d.evaluate(detx=np.array([1, 0.5]) * u.deg, dety=np.array([1, 0.5]) * u.deg,
+                          energy_reco=np.ones(2) * 100 * u.TeV)
     assert_allclose(res.value, [1.5, 2])
 
-    detx= np.array(([1, 0.5], [1, 0.5])) * u.deg
-    dety= np.array(([1, 0.5],[1, 0.5])) * u.deg
-    energy_reco= np.array(([1, 1],[100, 100])) * u.TeV
+    detx = np.array(([1, 0.5], [1, 0.5])) * u.deg
+    dety = np.array(([1, 0.5], [1, 0.5])) * u.deg
+    energy_reco = np.array(([1, 1], [100, 100])) * u.TeV
     res = bkg_3d.evaluate(detx=detx, dety=dety, energy_reco=energy_reco)
     assert_allclose(res.value, [[0, 0], [1.5, 2]])
     assert res.shape == (2, 2)

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -70,26 +70,24 @@ def test_background_3d_read_write(tmpdir, bkg_3d):
     assert data.unit == 's-1 MeV-1 sr-1'
 
 
-"""
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-def test_background_3d_evaluate_2(bkg_3d_simple):
+def test_background_3d_evaluate(bkg_3d):
     # Evaluate at log center between nodes in energy
-    res = bkg_3d_simple.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 1 * u.TeV)
+    res = bkg_3d.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 1 * u.TeV)
     assert_allclose(res.value, 0)
     assert res.shape == (2,)
     assert res.unit == 's-1 MeV-1 sr-1'
 
-    res = bkg_3d_simple.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 100 * u.TeV)
-    assert_allclose(res.value, [3, 2])
+    res = bkg_3d.evaluate(detx=np.array([1,0.5]) * u.deg, dety=np.array([1,0.5]) * u.deg, energy_reco=np.ones(2) * 100 * u.TeV)
+    assert_allclose(res.value, [1.5, 2])
 
     detx= np.array(([1, 0.5], [1, 0.5])) * u.deg
     dety= np.array(([1, 0.5],[1, 0.5])) * u.deg
     energy_reco= np.array(([1, 1],[100, 100])) * u.TeV
-    res = bkg_3d_simple.evaluate(detx=detx, dety=dety, energy_reco=energy_reco)
-    assert_allclose(res.value, [[0, 0], [3, 2]])
+    res = bkg_3d.evaluate(detx=detx, dety=dety, energy_reco=energy_reco)
+    assert_allclose(res.value, [[0, 0], [1.5, 2]])
     assert res.shape == (2, 2)
-"""
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
- The evaluate method is based on the new evaluate method in NDdata array from a set of coordinates.
- Clean a bit the test of background 3D with a more simple test