### PR TITLE
Changed point source model

### DIFF
--- a/gammapy/image/models/tests/test_models.py
+++ b/gammapy/image/models/tests/test_models.py
@@ -19,7 +19,7 @@ def test_sky_point_source():
         lat_0='45 deg',
     )
     lon = [1, 1.1] * u.deg
-    lat = 45 * u.deg
+    lat = [45, 45.2] * u.deg
     val = model(lon, lat)
     assert val.unit == 'sr-1'
     assert_allclose(val.value, [1, 0])

--- a/gammapy/image/models/tests/test_models.py
+++ b/gammapy/image/models/tests/test_models.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
+import numpy as np
 import astropy.units as u
 from ....utils.testing import requires_dependency, requires_data
 from ..new import (
@@ -15,14 +16,13 @@ from ..new import (
 
 def test_sky_point_source():
     model = SkyPointSource(
-        lon_0='1 deg',
-        lat_0='45 deg',
+        lon_0 = '2.5 deg',
+        lat_0 = '2.5 deg'
     )
-    lon = [1, 1.1] * u.deg
-    lat = [45, 45.2] * u.deg
+    lat, lon = np.mgrid[0:6, 0:6] * u.deg
     val = model(lon, lat)
     assert val.unit == 'sr-1'
-    assert_allclose(val.value, [1, 0])
+    assert_allclose(val.sum().value, 1.0)
 
 
 def test_sky_gaussian():


### PR DESCRIPTION
This PR is wrt to issue #1399.
The points source spectral model now puts weighted values at four neighbouring pixels.

This will probably fail for HEALPix maps.