### PR TITLE
Hide SpectrumFit.model

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -31,7 +31,8 @@ class SpectrumFit(object):
     obs_list : `~gammapy.spectrum.SpectrumObservationList`, `~gammapy.spectrum.SpectrumObservation`
         Observation(s) to fit
     model : `~gammapy.spectrum.models.SpectralModel`
-        Source model. Should return counts if ``forward_folded`` is False and a flux otherwise
+        Source model with initial parameter values. Should return counts if
+        ``forward_folded`` is False and a flux otherwise
     stat : {'wstat', 'cash'}
         Fit statistic
     forward_folded : bool, default: True
@@ -72,7 +73,7 @@ class SpectrumFit(object):
 
     def __str__(self):
         ss = self.__class__.__name__
-        ss += '\nSource model {}'.format(self.model)
+        ss += '\nSource model {}'.format(self._model.__class__.__name__)
         ss += '\nStat {}'.format(self.stat)
         ss += '\nForward Folded {}'.format(self.forward_folded)
         ss += '\nFit range {}'.format(self.fit_range)
@@ -94,20 +95,6 @@ class SpectrumFit(object):
         etc.
         """
         return self._result
-
-    @property
-    def model(self):
-        """Source model
-
-        The model parameters change every time the likelihood is evaluated. In
-        order to access the best-fit model parameters, use
-        :func:`gammapy.spectrum.SpectrumFit.result`
-        """
-        return self._model
-
-    @model.setter
-    def model(self, model):
-        self._model = model
 
     @property
     def background_model(self):
@@ -224,7 +211,7 @@ class SpectrumFit(object):
         predicted_counts = []
         for obs in self.obs_list:
             mu_sig = self._predict_counts_helper(obs,
-                                                 self.model,
+                                                 self._model,
                                                  self.forward_folded)
             mu_bkg = None
             if self.background_model is not None:
@@ -351,7 +338,7 @@ class SpectrumFit(object):
         parameters : `~gammapy.utils.fitting.ParameterList`
             Model parameters
         """
-        self.model.parameters = parameters
+        self._model.parameters = parameters
         self.predict_counts()
         self.calc_statval()
         total_stat = np.sum([np.sum(v) for v in self.statval], dtype=np.float64)
@@ -382,9 +369,7 @@ class SpectrumFit(object):
 
     def likelihood_1d(self, model, parname, parvals):
         """Compute likelihood profile.
-
-        TODO: Replace by something more generic
-
+    
         Parameters
         ----------
         model : `~gammapy.spectrum.models.SpectralModel`
@@ -397,8 +382,8 @@ class SpectrumFit(object):
         likelihood = []
         self._model = model
         for val in parvals:
-            self.model.parameters[parname].value = val
-            stat = self.total_stat(self.model.parameters)
+            self._model.parameters[parname].value = val
+            stat = self.total_stat(self._model.parameters)
             likelihood.append(stat)
         return np.array(likelihood)
 
@@ -458,11 +443,11 @@ class SpectrumFit(object):
                                NelderMead())
         fitresult = self._sherpa_fit.fit()
         log.debug(fitresult)
-        self._make_fit_result(self.model.parameters)
+        self._make_fit_result(self._model.parameters)
 
     def _fit_iminuit(self):
         """Iminuit minimization"""
-        parameters, minuit = fit_minuit(parameters=self.model.parameters,
+        parameters, minuit = fit_minuit(parameters=self._model.parameters,
                                         function=self.total_stat)
         self._iminuit_fit = minuit
         log.debug(minuit)
@@ -480,7 +465,7 @@ class SpectrumFit(object):
 
         # run again with best fit parameters
         self.total_stat(parameters)
-        model = self.model.copy()
+        model = self._model.copy()
 
         if self.background_model is not None:
             bkg_model = self.background_model.copy()
@@ -531,7 +516,7 @@ class SpectrumFit(object):
         cov = self._iminuit_fit.covariance
 
         #create tuples of combinations
-        d = self.model.parameters.to_dict()
+        d = self._model.parameters.to_dict()
         parameter_names = [l['name'] for l in d['parameters'] if l['frozen'] == False]
         self.covar_axis = parameter_names
         parameter_combinations = list(product(parameter_names, repeat=2))

--- a/gammapy/spectrum/sherpa_utils.py
+++ b/gammapy/spectrum/sherpa_utils.py
@@ -28,7 +28,7 @@ class SherpaModel(ArithmeticModel):
 
         sherpa_name = 'sherpa_model'
         par_list = list()
-        for par in self.fit.model.parameters.parameters:
+        for par in self.fit._model.parameters.parameters:
             sherpa_par = par.to_sherpa(modelname='source')
             # setattr(self, name, sherpa_par)
             par_list.append(sherpa_par)
@@ -46,13 +46,13 @@ class SherpaModel(ArithmeticModel):
     @modelCacher1d
     def calc(self, p, x, xhi=None):
         # Adjust model parameters
-        n_src = len(self.fit.model.parameters.parameters)
+        n_src = len(self.fit._model.parameters.parameters)
         for idx, par in enumerate(p):
             # Special case background model
             if idx >= n_src:
                 self.fit.background_model.parameters.parameters[idx - n_src].value = par
             else:
-                self.fit.model.parameters.parameters[idx].value = par
+                self.fit._model.parameters.parameters[idx].value = par
 
         self.fit.predict_counts()
         # Return ones since sherpa does some check on the shape

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -245,9 +245,9 @@ class TestSpectralFit:
         self.fit.result[0].to_table()
 
     def test_compound(self):
-        self.fit.model = self.fit.model * 2
-        self.fit.fit()
-        result = self.fit.result[0]
+        fit = SpectrumFit(self.obs_list[0], self.pwl * 2)
+        fit.fit()
+        result = fit.result[0]
         pars = result.model.parameters
         assert_quantity_allclose(pars['index'].value, 2.2542315426423283)
         # amplitude should come out roughly * 0.5


### PR DESCRIPTION
this is a reaction to offline discussion with @cdeil and #1483. For now ``SpectrumFit._model`` is hidden, to avoid confusion with its changing state. 

In the long term we should obviously have a coherent API and decide how to treat inputs.