### PR TITLE
Modified MapMaker to allow partially contained observations

### DIFF
--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -304,7 +304,7 @@ class MapMaker(object):
     offset_max : `~astropy.coordinates.Angle`
         Maximum offset angle
     cutout_mode : {'trim', 'strict'}, optional
-            Options for making cutouts, see :func: '~gammapy.maps.WcsNDMap.make_cutout'
+            Options for making cutouts, see :func: `~gammapy.maps.WcsNDMap.make_cutout`
              Should be left to the default value 'trim'
             unless you want only fully contained observations to be added to the map
     """

--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -303,8 +303,9 @@ class MapMaker(object):
         Reference image geometry
     offset_max : `~astropy.coordinates.Angle`
         Maximum offset angle
-    cutout_mode : {'trim', 'partial', 'strict'}, optional
-            Options for making cutouts. Should be left to the default value 'trim'
+    cutout_mode : {'trim', 'strict'}, optional
+            Options for making cutouts, see :func: '~gammapy.maps.WcsNDMap.make_cutout'
+             Should be left to the default value 'trim'
             unless you want only fully contained observations to be added to the map
     """
 

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -92,17 +92,17 @@ def test_make_map_fov_background(bkg_3d, counts_cube):
     # assert_allclose(val, 0)
 
 @requires_data('gammapy-extra')
-def test_MapMaker():
+@pytest.mark.parametrize("mode, expected", [("trim", 160530.0), ("strict", 53486.0)])
+def test_MapMaker(mode,expected):
     ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
-    obs = ds.obs(111140)
     pos_SagA = SkyCoord(266.41681663, -29.00782497, unit="deg", frame="icrs")
     energy_axis = MapAxis.from_edges([0.1,0.5,1.5,3.0,10.],name='energy',unit='TeV',interp='log')
     geom = WcsGeom.create(binsz=0.1*u.deg, skydir=pos_SagA, width=15.0, axes=[energy_axis])
-    mmaker = MapMaker(geom, 4.0 * u.deg)
-    mmaker.process_obs(obs)
-
+    mmaker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
+    for obsid in ds.obs_table['OBS_ID']:
+        mmaker.process_obs(ds.obs(obsid))
     assert mmaker.exposure_map.unit == "m2 s"
-    assert_quantity_allclose(mmaker.count_map.data.sum(), 51152.0)
+    assert_quantity_allclose(mmaker.count_map.data.sum(), expected)
 
 
 

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -92,14 +92,15 @@ def test_make_map_fov_background(bkg_3d, counts_cube):
     # assert_allclose(val, 0)
 
 @requires_data('gammapy-extra')
-@pytest.mark.parametrize("mode, expected", [("trim", 160530.0), ("strict", 53486.0)])
+@pytest.mark.parametrize("mode, expected", [("trim", 107214.0), ("strict", 53486.0)])
 def test_MapMaker(mode,expected):
     ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
     pos_SagA = SkyCoord(266.41681663, -29.00782497, unit="deg", frame="icrs")
     energy_axis = MapAxis.from_edges([0.1,0.5,1.5,3.0,10.],name='energy',unit='TeV',interp='log')
     geom = WcsGeom.create(binsz=0.1*u.deg, skydir=pos_SagA, width=15.0, axes=[energy_axis])
     mmaker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
-    for obsid in ds.obs_table['OBS_ID']:
+    obs = [110380, 111140]
+    for obsid in obs:
         mmaker.process_obs(ds.obs(obsid))
     assert mmaker.exposure_map.unit == "m2 s"
     assert_quantity_allclose(mmaker.count_map.data.sum(), expected)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -416,7 +416,7 @@ def test_make_cutout():
     geom = WcsGeom.create(npix=(10, 10), binsz=1, skydir=pos,
                           proj='CAR', coordsys='GAL', axes=axes2)
     m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
-    cutout = m.make_cutout(position=pos, width=(2.0, 3.0) * u.deg)
+    cutout, _ = m.make_cutout(position=pos, width=(2.0, 3.0) * u.deg)
     actual = cutout.data.sum()
     assert_allclose(actual, 36.0)
     assert_allclose(cutout.geom.shape, m.geom.shape)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -624,6 +624,7 @@ class WcsNDMap(WcsMap):
         -------
         cutout : `~gammapy.maps.WcsNDMap`
             The cutout map itself
+        cutout_slices : Tuple of slice objects (with dimension 1 less than that of the non-spatial axes of the map)
         """
 
         idx = (0,) * len(self.geom.axes)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -640,4 +640,4 @@ class WcsNDMap(WcsMap):
         if copy:
             data = data.copy()
 
-        return WcsNDMap(geom, data, meta=self.meta, unit=self.unit)
+        return WcsNDMap(geom, data, meta=self.meta, unit=self.unit), cutout_slices


### PR DESCRIPTION
During DC1 analysis, @robertazanin, @facero and @bkhelifi reported that they would prefer to make the maps with partially contained observations.
This PR allows that, and cleans up the code to access `make_cutout` from `WcsNDMap` instead of from `cubes/new.py`.
Also, the test for `MapMaker` is changed to check for multiple observations. 