### PR TITLE
Remove parmin and parmax for some XML models

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -46,7 +46,18 @@ class SourceLibrary(object):
 
     @classmethod
     def read(cls, filename):
-        """Read SourceLibrary from XML file"""
+        """Read SourceLibrary from XML file
+
+        The XML definition of some models is uncompatible with the models
+        currently implemented in gammapy. Therefore the following modifications
+        happen to the XML model definition
+
+        * PowerLaw: The spectral index is negative in XML but positive in
+          gammapy. Parameter limits are ignored
+
+        * ExponentialCutoffPowerLaw: The cutoff energy is transferred to
+          lambda = 1 / cutof energy on read
+        """
         path = make_path(filename)
         xml = path.read_text()
         return cls.from_xml(xml)

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -27,8 +27,8 @@ def test_complex():
     pars1 = model1.parameters
     assert pars1['index'].value == 2.1
     assert pars1['index'].unit == ''
-    assert pars1['index'].parmax == 1.0
-    assert pars1['index'].parmin == 5.0
+    assert pars1['index'].parmax == None
+    assert pars1['index'].parmin == None
     assert pars1['index'].frozen == False
 
     assert pars1['lon_0'].value == 0.5
@@ -51,12 +51,12 @@ def test_complex():
     assert pars2['sigma'].unit == 'deg'
     assert pars2['lambda_'].value == 0.01
     assert pars2['lambda_'].unit == 'MeV-1'
-    assert pars2['lambda_'].parmin == 100
-    assert pars2['lambda_'].parmax == 0.001
+    assert pars2['lambda_'].parmin == None
+    assert pars2['lambda_'].parmax == None
     assert pars2['index'].value == 2.2
     assert pars2['index'].unit == ''
-    assert pars2['index'].parmax == 1.0
-    assert pars2['index'].parmin == 5.0
+    assert pars2['index'].parmax == None
+    assert pars2['index'].parmin == None
 
     model3 = sourcelib.skymodels[3]
     assert isinstance(model3.spatial_model, spatial.SkyDisk)

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -220,16 +220,16 @@ def xml_to_model(xml, which):
         # one to the gammapy model definition
         if type_ == 'PowerLaw':
             model.parameters['index'].value *= -1
-            model.parameters['index'].parmin *= -1
-            model.parameters['index'].parmax *= -1
+            model.parameters['index'].parmin = None
+            model.parameters['index'].parmax = None
         if type_ == 'ExponentialCutoffPowerLaw':
             model.parameters['lambda_'].value = 1 / model.parameters['lambda_'].value
             model.parameters['lambda_'].unit = model.parameters['lambda_'].unit + '-1'
-            model.parameters['lambda_'].parmin = 1 / model.parameters['lambda_'].parmin
-            model.parameters['lambda_'].parmax = 1 / model.parameters['lambda_'].parmax
+            model.parameters['lambda_'].parmin = None
+            model.parameters['lambda_'].parmax = None
             model.parameters['index'].value *= -1
-            model.parameters['index'].parmin *= -1
-            model.parameters['index'].parmax *= -1
+            model.parameters['index'].parmin = None
+            model.parameters['index'].parmax = None
     return model
 
 


### PR DESCRIPTION
For the (exponential cutoff) power law the XML serialization foresees a negative spectral index whereas the gammapy models accept only a positive one. The short term fix was to invert the sign of the index on read. This would also require changing the sign of ``parmin`` and ``parmax`` and swapping them. Since they're both optional this can lead to a rather complicated if .. else monster. So this PR set ``parmin`` and ``parmax`` to ``None`` for the aforementioned models on read to avoid further confusion.

cc @facero 