### PR TITLE
Fixes/addresses #1481, left a TODO for the `error_method` implementation

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -45,13 +45,14 @@ class SpectrumFit(object):
         Background model to be used in cash fits
     method : {'sherpa', 'iminuit'}
         Optimization backend for the fit
-    err_method : {'sherpa', 'iminuit'}
-        Optimization backend for error estimation
+    error_method : {'covar', 'conf', 'HESSE', 'MINOS'}
+        Method of the error estimation depending on the backend.
+        TODO: Not implemented yet. For now 'covar'/'HESSE' are used by default.
     """
 
     def __init__(self, obs_list, model, stat='wstat', forward_folded=True,
                  fit_range=None, background_model=None,
-                 method='sherpa', err_method='sherpa'):
+                 method='sherpa', error_method=None):
         self.obs_list = obs_list
         self._model = model
         self.stat = stat
@@ -59,7 +60,7 @@ class SpectrumFit(object):
         self.fit_range = fit_range
         self._background_model = background_model
         self.method = method
-        self.err_method = err_method
+        self.error_method = error_method
 
         self._predicted_counts = None
         self._statval = None
@@ -80,7 +81,7 @@ class SpectrumFit(object):
         if self.background_model is not None:
             ss += '\nBackground model {}'.format(self.background_model)
         ss += '\nBackend {}'.format(self.method)
-        ss += '\nError Backend {}'.format(self.err_method)
+        ss += '\nError Method {}'.format(self.error_method)
 
         return ss
 
@@ -498,12 +499,12 @@ class SpectrumFit(object):
 
     def est_errors(self):
         """Estimate parameter errors."""
-        if self.err_method == 'sherpa':
+        if self.method == 'sherpa':
             self._est_errors_sherpa()
-        elif self.err_method == 'iminuit':
+        elif self.method == 'iminuit':
             self._est_errors_iminuit()
         else:
-            raise NotImplementedError('{}'.format(self.err_method))
+            raise NotImplementedError('{}'.format(self.method))
 
         for res in self.result:
             res.covar_axis = self.covar_axis


### PR DESCRIPTION
When choosing a different `method` and `err_method`, the current code fails:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-19-003331b1746c> in <module>()
      3 stacked_fit = SpectrumFit(obs_list=stacked_obs, model=model, method='iminuit', err_method='sherpa')
      4 stacked_fit.fit()
----> 5 stacked_fit.est_errors()
      6 
      7 

/media/david/Data/Programs/gammapy-code/gammapy/gammapy/spectrum/fit.py in est_errors(self)
    500         """Estimate parameter errors."""
    501         if self.err_method == 'sherpa':
--> 502             self._est_errors_sherpa()
    503         elif self.err_method == 'iminuit':
    504             self._est_errors_iminuit()

/media/david/Data/Programs/gammapy-code/gammapy/gammapy/spectrum/fit.py in _est_errors_sherpa(self)
    533     def _est_errors_sherpa(self):
    534         """Wrapper around Sherpa error estimator."""
--> 535         covar = self._sherpa_fit.est_errors()
    536         self.covar_axis = [par.split('.')[-1] for par in covar.parnames]
    537         self.covariance = copy.deepcopy(covar.extra_output)

AttributeError: 'SpectrumFit' object has no attribute '_sherpa_fit'
```
This PR fixes the fail described in #1481 and leaves a TODO for the proper implementation of an `error_method`.