### PR TITLE
Remove some usage of SkyImage

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -262,25 +262,6 @@ class SourceCatalog(object):
         """Source positions (`~astropy.coordinates.SkyCoord`)."""
         return skycoord_from_table(self.table)
 
-    def select_image_region(self, image):
-        """
-        Select all source within an image
-
-        Parameters
-        ----------
-        image : `~gammapy.image.SkyImage`
-            Sky image
-
-        Returns
-        -------
-        catalog : `SourceCatalog`
-            Source catalog selection.
-        """
-        catalog = self.copy()
-        selection = image.contains(self.positions)
-        catalog.table = catalog.table[selection]
-        return catalog
-
     def copy(self):
         """Copy catalog"""
         return deepcopy(self)

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -8,7 +8,6 @@ from astropy.table import Table, Column
 from astropy.units import Quantity
 from ...utils.testing import assert_quantity_allclose
 from ..core import SourceCatalog
-from ...image import SkyImage
 
 
 def make_test_catalog():
@@ -71,13 +70,6 @@ class TestSourceCatalog:
     def test_positions(self):
         positions = self.cat.positions
         assert len(positions) == 3
-
-    def test_select_image_region(self):
-        reference = SkyImage.empty(xref=42.2, yref=1, nxpix=5, nypix=5,
-                                   coordsys='CEL')
-        selection = self.cat.select_image_region(reference)
-
-        assert len(selection.table) == 1
 
 
 class TestSourceCatalogObject:

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -9,7 +9,6 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy.table import Table
 from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data, requires_dependency
-from ...image import SkyImage
 from ...spectrum.models import PowerLaw, ExponentialCutoffPowerLaw
 from ..hess import SourceCatalogHGPS, SourceCatalogLargeScaleHGPS
 
@@ -45,33 +44,6 @@ class TestSourceCatalogHGPS:
         # Thus we expect `HGPSC 084` at row 83
         c = cat.gaussian_component(83)
         assert c.name == 'HGPSC 084'
-
-    @staticmethod
-    @requires_dependency('scipy')
-    @pytest.mark.parametrize('source_name', ['HESS J1837-069', 'HESS J1809-193', 'HESS J1841-055'])
-    def test_large_scale_component(cat, source_name):
-        # This test compares the flux values from the LS model within source
-        # regions with ones listed in the catalog, agreement is <1%
-        ls_model = cat.large_scale_component
-
-        source = cat[source_name]
-        rspec = source.data['RSpec']
-        npix = int(2.5 * rspec.value / 0.02)
-
-        image = SkyImage.empty(
-            xref=source.position.galactic.l.deg,
-            yref=source.position.galactic.b.deg,
-            nxpix=npix,
-            nypix=npix,
-        )
-        coordinates = image.coordinates()
-        image.data = ls_model.evaluate(coordinates)
-        image.data *= image.solid_angle()
-
-        mask = coordinates.separation(source.position) < rspec
-        flux_ls = image.data[mask].sum()
-
-        assert_quantity_allclose(flux_ls, source.data['Flux_Map_RSpec_LS'], rtol=1E-2)
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -730,36 +730,15 @@ class EventListLAT(EventListBase):
     >>> events = EventListLAT.read(filename)
     """
 
-    def plot_image(self, center, size):
-        """A quick look function to generate a count skymap with all the photons
-        within a certain square (rectangle).
-
-        Fermi-LAT eventlist could encompass large fraction of the sky,
-        this way we can restirct the skymap to a squared (rectangular)
-        region of interest (ROI)
-
-        We evaluate the number of pixel of the skymap such that we have a
-        bin size 0.1 deg, this is what is suggested by default in fermipy
-        http://fermipy.readthedocs.io/en/latest/config.html
-
-        Parameters
-        -----------
-        center : `~astropy.coordinates.SkyCoord`
-            Sky circle center
-        size : `~astropy.coordinates.Quantity`
-            size of the square defining our ROI
-        """
-        from ..image import SkyImage
-        binsz = Quantity(0.1, 'deg')
-        nxpix = int(size[0] / binsz)
-        nypix = int(size[1] / binsz)
-        counts_image = SkyImage.empty(
-            nxpix=nxpix, nypix=nypix, binsz=binsz.value,
-            xref=center.icrs.ra.deg, yref=center.icrs.dec.deg,
-            coordsys='CEL', proj='TAN',
+    def plot_image(self):
+        """Quick look counts map sky plot."""
+        from ..maps import WcsNDMap
+        m = WcsNDMap.create(
+            npix=(360, 180), binsz=1.0, proj='AIT', coordsys='GAL',
         )
-        counts_image.fill_events(self)
-        counts_image.show()
+        coord = self.radec
+        m.fill_by_coord(coord)
+        m.plot(stretch='sqrt')
 
 
 class EventListDataset(object):

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing import assert_allclose
-from astropy.coordinates import Angle, SkyCoord
 import pytest
-from regions import CircleSkyRegion
+from numpy.testing import assert_allclose
+from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_dependency, requires_data
-from ...data import EventList, EventListDataset, EventListDatasetChecker
-from ...datasets import gammapy_extra
+from ...data import EventList, EventListLAT, EventListDataset, EventListDatasetChecker
 
 
 @requires_data('gammapy-extra')
@@ -49,15 +47,19 @@ class TestEventListHESS:
 class TestEventListFermi:
     def setup(self):
         filename = '$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz'
-        self.events = EventList.read(filename)
+        self.events = EventListLAT.read(filename)
 
     def test_basics(self):
         assert 'EventList' in str(self.events)
 
+    @requires_dependency('matplotlib')
+    def test_plot_image(self):
+        self.events.plot_image()
+
 
 @requires_data('gammapy-extra')
 def test_EventListDataset():
-    filename = gammapy_extra.filename('test_datasets/unbundled/hess/run_0023037_hard_eventlist.fits.gz')
+    filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/hess/run_0023037_hard_eventlist.fits.gz'
     dset = EventListDataset.read(filename)
     assert 'Event list dataset info' in str(dset)
 
@@ -69,7 +71,7 @@ def test_EventListDataset():
 @pytest.mark.xfail
 @requires_data('gammapy-extra')
 def test_EventListDatasetChecker():
-    filename = gammapy_extra.filename('test_datasets/unbundled/hess/run_0023037_hard_eventlist.fits.gz')
+    filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/hess/run_0023037_hard_eventlist.fits.gz'
     dset = EventListDataset.read(filename)
     checker = EventListDatasetChecker(dset)
     checker.run('all')


### PR DESCRIPTION
This PR removes some usage in Gammapy of the deprecated SkyImage, especially rewrites EventListLAT.plot_image to use gammapy.maps.
The test for the HGPS catalog really was more of a HGPS internal check than a gammapy.catalog unit test, so I think it's OK to delete.