### PR TITLE
Change gammapy image bin to gammapy.maps; add back TS map test

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -99,8 +99,6 @@ Functions that return more than a single value shouldn't return a list
 or dictionary of values but rather a Python Bunch result object. A Bunch
 is similar to a dict, except that it allows attribute access to the result
 values. The approach is the same as e.g. the use of `~scipy.optimize.OptimizeResult`.
-An example of how Bunches are used in gammapy is given by the `~gammapy.image.SkyImageList`
-class.
 
 .. _dev-python2and3:
 

--- a/gammapy/scripts/image_bin.py
+++ b/gammapy/scripts/image_bin.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import click
-import numpy as np
 from ..data import EventList
-from ..image import SkyImage
+from ..maps import Map
+from ..cube import fill_map_counts
 
 log = logging.getLogger(__name__)
 
@@ -25,10 +25,10 @@ def cli_image_bin(event_file, reference_file, out_file, overwrite):
     events = EventList.read(event_file)
 
     log.info('Reading {}'.format(reference_file))
-    image = SkyImage.read(reference_file)
+    m_ref = Map.read(reference_file)
 
-    image.data = np.zeros_like(image.data, dtype='int32')
-    image.fill_events(events)
+    counts_map = Map.from_geom(m_ref.geom)
+    fill_map_counts(counts_map, events)
 
     log.info('Writing {}'.format(out_file))
-    image.write(out_file, overwrite=overwrite)
+    counts_map.write(out_file, overwrite=overwrite)

--- a/gammapy/scripts/tests/test_image_bin.py
+++ b/gammapy/scripts/tests/test_image_bin.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
 from ...utils.testing import requires_data, run_cli
-from ...image import SkyImage
+from ...maps import Map
+from ...utils.testing import assert_wcs_allclose
 from ..main import cli
 
 
@@ -16,6 +18,7 @@ def test_bin_image_main(tmpdir):
     args = ['image', 'bin', event_file, reference_file, out_file]
     run_cli(cli, args)
 
-    actual = SkyImage.read(out_file)
-    expected = SkyImage.read(reference_file)
-    SkyImage.assert_allclose(actual, expected)
+    actual = Map.read(out_file)
+    expected = Map.read(reference_file)
+    assert_allclose(actual.data, expected.data)
+    assert_wcs_allclose(actual.geom.wcs, expected.geom.wcs)

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -244,9 +244,6 @@ class SmartHDUList(object):
     >>> hdus.get_hdu(2)  # by index
     >>> hdus.get_hdu(hdu_type='image')  # first image (skip primary if empty)
     >>> hdus.get_hdu(hdu_type='table')  # first table
-
-    TODO: add more conveniences, e.g. to create HDU lists from lists of Gammapy
-    objects that can be serialised to FITS (e.g. SkyImage, SkyCube, EventList, ...)
     """
 
     def __init__(self, hdu_list):


### PR DESCRIPTION
This PR rewrites `gammapy image bin` to use `gammapy.maps` instead of SkyImage.
It also adds back a test from `gammapy image ts` that I removed in #1524, as a test in `gammapy.detect`.

The TS map code will be pretty difficult to migrate to gammapy.maps, because it's pretty complex (return Python list of SkyImageList, doing Kernel computation coupled to the old multi-Gauss representation) and doesn't have good test coverage.

I'll first do other things, but @adonath - we should talk what to do here.