### PR TITLE
Remove old FoVBackgroundEstimator

### DIFF
--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -15,7 +15,6 @@ __all__ = [
     'ring_r_out',
     'ring_area_factor',
     'ring_alpha',
-    'FoVBackgroundEstimator',
 ]
 
 
@@ -412,50 +411,3 @@ def ring_alpha(theta, r_in, r_out):
         Outer ring radius
     """
     return 1. / ring_area_factor(theta, r_in, r_out)
-
-
-class FoVBackgroundEstimator(object):
-    """Basic class to perform FoV background estimation.
-
-    Parameters
-    ----------
-    norm : bool
-        flag to normalize the background from the count image outside exclusion regions
-
-    """
-    def __init__(self,norm=True):
-        self.norm=norm
-
-    def run(self, images):
-        """Run FoV background algorithm.
-
-        Required sky images: {required}
-
-        Parameters
-        ----------
-        images : `SkyImageList`
-            Input sky images.
-
-        Returns
-        -------
-        result : `SkyImageList`
-            Result sky images
-        """
-
-        required = ['counts', 'exposure_on', 'exclusion']
-        images.check_required(required)
-        counts, exposure_on, exclusion = [images[_] for _ in required]
-        wcs = counts.wcs.copy()
-
-        if self.norm:
-            counts_excluded = np.sum(counts.data * exclusion.data)
-            acceptance_excluded = np.sum(exposure_on.data * exclusion.data)
-            #print(counts_excluded, acceptance_excluded, counts_excluded / acceptance_excluded)
-            norm = counts_excluded / acceptance_excluded
-        else:
-            norm=1
-        result = SkyImageList()
-        result['background'] = SkyImage(data=norm * exposure_on.data, wcs=wcs)
-        result['background'].meta['NORM'] = norm
-        return result
-


### PR DESCRIPTION
I found an old, unused and untested `FoVBackgroundEstimator` in `gammapy/background/ring.py`.
This PR deletes it.

This method has been rewritten already in `gammapy.cube.make_map_fov_background` with `gammapy.maps`.

@adonath or @registerrier - Maybe this was planned to be used with the IACTBasicImageEstimator pipeline class? In this case we might want to add something back, but it hast to be `gammapy.maps` based and with the new `MapMaker`.
