### PR TITLE
Rewrite ASmooth to use gammapy.maps

### DIFF
--- a/gammapy/image/asmooth.py
+++ b/gammapy/image/asmooth.py
@@ -5,37 +5,18 @@ Implementation of adaptive smoothing algorithms.
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import numpy as np
+from astropy.coordinates import Angle
 from astropy.convolution import Gaussian2DKernel, Tophat2DKernel
 from ..stats import significance
+from ..maps import WcsNDMap
 from .utils import scale_cube
-from . import SkyImage, SkyImageList
 
-__all__ = ['ASmooth', 'asmooth_scales']
+__all__ = ['ASmooth']
 
 
-# TODO: move to gammapy.stats.significance
 def _significance_asmooth(counts, background):
-    """
-    Significance according to formula (5) in asmooth paper.
-
-    Parameters
-    ----------
-    counts : ndarray
-        Counts data array
-    background : ndarray
-        Background data array.
-    """
+    """Significance according to formula (5) in asmooth paper."""
     return (counts - background) / np.sqrt(counts + background)
-
-
-def asmooth_scales(n_scales, factor=np.sqrt(2), kernel=Gaussian2DKernel):
-    """Create list of Gaussian widths."""
-    if kernel == Gaussian2DKernel:
-        sigma_0 = 1. / np.sqrt(9 * np.pi)
-    elif kernel == Tophat2DKernel:
-        sigma_0 = 1. / np.sqrt(np.pi)
-
-    return sigma_0 * factor ** np.arange(n_scales)
 
 
 class ASmooth(object):
@@ -65,14 +46,14 @@ class ASmooth(object):
         self.parameters = OrderedDict(kernel=kernel, method=method,
                                       threshold=threshold, scales=scales)
 
-    def kernels(self, image):
+    def kernels(self, pixel_scale):
         """
         Ring kernels according to the specified method.
 
         Parameters
         ----------
-        image : `~gammapy.image.SkyImage`
-            Sky image specifying the WCS information.
+        pixel_scale : `~astropy.coordinates.Angle`
+            Sky image pixel scale
 
         Returns
         -------
@@ -80,8 +61,7 @@ class ASmooth(object):
             List of `~astropy.convolution.Kernel`
         """
         p = self.parameters
-        pix_per_deg = image.wcs_pixel_scale()[0]
-        scales = p['scales'].to('deg') / pix_per_deg
+        scales = p['scales'].to('deg') / Angle(pixel_scale).deg
 
         kernels = []
         for scale in scales.value:
@@ -92,78 +72,79 @@ class ASmooth(object):
 
         return kernels
 
-    def _significance_cube(self, cubes):
-        p = self.parameters
-        if p['method'] == 'lima':
+    @staticmethod
+    def _significance_cube(cubes, method):
+        if method in {'lima', 'simple'}:
             scube = significance(cubes['counts'], cubes['background'], method='lima')
-        elif p['method'] == 'simple':
-            scube = significance(cubes['counts'], cubes['background'], method='simple')
-        elif p['method'] == 'asmooth':
+        elif method == 'asmooth':
             scube = _significance_asmooth(cubes['counts'], cubes['background'])
-        elif p['method'] == 'ts':
-            raise NotImplementedError
+        elif method == 'ts':
+            raise NotImplementedError()
         else:
             raise ValueError("Not a valid significance estimation method."
                              " Choose one of the following: 'lima', 'simple',"
                              " 'asmooth' or 'ts'")
         return scube
 
-    def run(self, images):
+    def run(self, counts, background=None, exposure=None):
         """
         Run image smoothing.
 
         Parameters
         ----------
-        images : `SkyImageList`
-            List of input sky images.
+        counts : `~gammapy.maps.WCSNDMap`
+            Counts map
+        background : `~gammapy.maps.WCSNDMap`
+            Background map
+        exposure : `~gammapy.maps.WCSNDMap`
+            Exposure map
 
         Returns
         -------
-        smoothed : `SkyImageList`
-            List of smoothed sky images containing:
+        images : dict of `~gammapy.maps.WCSNDMap`
+            Smoothed images; keys are:
                 * 'counts'
                 * 'background'
                 * 'flux' (optional)
                 * 'scales'
                 * 'significance'.
         """
-        images.check_required(['counts'])
-        wcs = images['counts'].wcs.copy()
-
-        kernels = self.kernels(images['counts'])
+        pixel_scale = counts.geom.pixel_scales.mean()
+        kernels = self.kernels(pixel_scale)
 
         cubes = {}
-        cubes['counts'] = scale_cube(images['counts'].data, kernels)
+        cubes['counts'] = scale_cube(counts.data, kernels)
 
-        if 'background' in images.names:
-            cubes['background'] = scale_cube(images['background'].data, kernels)
+        if background is not None:
+            cubes['background'] = scale_cube(background.data, kernels)
         else:
             # TODO: Estimate background with asmooth method
             raise ValueError('Background estimation required.')
 
-        if 'exposure' in images.names:
-            flux = ((images['counts'].data - images['background'].data) /
-                    images['exposure'].data)
+        if exposure is not None:
+            flux = (counts.data - background.data) / exposure.data
             cubes['flux'] = scale_cube(flux, kernels)
 
-        cubes['significance'] = self._significance_cube(cubes)
+        cubes['significance'] = self._significance_cube(cubes, method=self.parameters['method'])
 
         smoothed = self._reduce_cubes(cubes, kernels)
-        result = SkyImageList()
+
+        result = {}
+
         for key in ['counts', 'background', 'scale', 'significance']:
             data = smoothed[key]
 
             # set remaining pixels with significance < threshold to mean value
             if key in ['counts', 'background']:
                 mask = np.isnan(data)
-                data[mask] = np.mean(images[key].data[mask])
-            result[key] = SkyImage(data=data, wcs=wcs)
+                data[mask] = np.mean(locals()[key].data[mask])
+            result[key] = WcsNDMap(counts.geom, data)
 
-        if 'exposure' in images.names:
+        if exposure is not None:
             data = smoothed['flux']
             mask = np.isnan(data)
             data[mask] = np.mean(flux[mask])
-            result['flux'] = SkyImage(data=data, wcs=wcs)
+            result['flux'] = WcsNDMap(counts.geom, data)
 
         return result
 
@@ -202,3 +183,13 @@ class ASmooth(object):
                 smoothed['flux'][mask] = cubes['flux'][slice_][mask] / norm
 
         return smoothed
+
+    @staticmethod
+    def make_scales(n_scales, factor=np.sqrt(2), kernel=Gaussian2DKernel):
+        """Create list of Gaussian widths."""
+        if kernel == Gaussian2DKernel:
+            sigma_0 = 1. / np.sqrt(9 * np.pi)
+        elif kernel == Tophat2DKernel:
+            sigma_0 = 1. / np.sqrt(np.pi)
+
+        return sigma_0 * factor ** np.arange(n_scales)


### PR DESCRIPTION
This PR rewrites `ASmooth` to use gammapy.maps.
The functionality is kept, all tests pass; I hope I didn't break anything.
Merging now.

@adonath - Test coverage for this isn't great, you might want to do a follow-up PR here to adjust the API a bit and improve test coverage for this in the coming weeks (i.e. before Gammapy v1.0 in the fall).