### PR TITLE
Remove old cruft from gammapy.datasets

### DIFF
--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -4,10 +4,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
 import warnings
-from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
-from astropy.utils.data import download_file
 from astropy.utils import lazyproperty
 from .core import gammapy_extra
 from ..data import EventList
@@ -22,29 +20,7 @@ __all__ = [
     'FermiLATDataset',
     'FermiGalacticCenter',
     'FermiVelaRegion',
-    'fetch_fermi_diffuse_background_model',
-    'load_lat_psf_performance',
 ]
-
-
-def fetch_fermi_diffuse_background_model(filename='gll_iem_v02.fit'):
-    """Fetch Fermi diffuse background model.
-
-    Parameters
-    ----------
-    filename : str
-        Diffuse model file name
-
-    Returns
-    -------
-    filename : str
-        Full local path name
-    """
-    BASE_URL = 'http://fermi.gsfc.nasa.gov/ssc/data/analysis/software/aux/'
-
-    url = BASE_URL + filename
-    filename = download_file(url, cache=True)
-    return filename
 
 
 class FermiGalacticCenter(object):
@@ -190,51 +166,6 @@ class FermiVelaRegion(object):
         """Livetime cube (`~astropy.io.fits.HDUList`)."""
         filename = FermiVelaRegion.filenames()['livetime_cube']
         return fits.open(filename)
-
-
-def load_lat_psf_performance(performance_file):
-    """Loads Fermi-LAT TOTAL PSF performance data.
-
-    These points are extracted by hand from:
-
-    * `PSF_P7REP_SOURCE_V15 <http://www.slac.stanford.edu/exp/glast/groups/canda/archive/p7rep_v15/lat_Performance_files/cPsfEnergy_P7REP_SOURCE_V15.png>`_
-    * `PSF_P7SOURCEV6 <http://www.slac.stanford.edu/exp/glast/groups/canda/archive/pass7v6/lat_Performance_files/cPsfEnergy_P7SOURCE_V6.png>`_
-
-    As such, a 10% error in the values should be assumed.
-
-    Parameters
-    ----------
-    performance_file : str
-        Specify which PSF performance file to return.
-
-        * ``P7REP_SOURCE_V15_68`` P7REP_SOURCE_V15, 68% containment
-        * ``P7REP_SOURCE_V15_95`` P7REP_SOURCE_V15, 95% containment
-        * ``P7SOURCEV6_68`` P7SOURCEV6, 68% containment
-        * ``P7SOURCEV6_95`` P7SOURCEV6, 95% containment
-
-    Returns
-    -------
-    table : `~astropy.table.Table`
-        Table of psf size (deg) for selected containment radius and IRF at
-        energies (MeV).
-    """
-    filename = gammapy_extra.filename('test_datasets/unbundled/fermi//fermi_irf_data.fits')
-    hdus = fits.open(filename)
-
-    perf_files = OrderedDict()
-    perf_files['P7REP_SOURCE_V15_68'] = hdus[1]
-    perf_files['P7REP_SOURCE_V15_95'] = hdus[4]
-    perf_files['P7SOURCEV6_68'] = hdus[3]
-    perf_files['P7SOURCEV6_95'] = hdus[2]
-    hdu = perf_files[performance_file]
-    table = Table(hdu.data)
-    table.rename_column('col1', 'energy')
-    table.rename_column('col2', 'containment_angle')
-
-    table['energy'].unit = 'MeV'
-    table['containment_angle'].unit = 'deg'
-
-    return table
 
 
 class FermiLATDataset(object):

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -19,7 +19,6 @@ from ..catalog.gammacat import NoDataAvailableError
 __all__ = [
     'FermiLATDataset',
     'FermiGalacticCenter',
-    'FermiVelaRegion',
 ]
 
 
@@ -69,103 +68,6 @@ class FermiGalacticCenter(object):
         from ..cube import SkyCube
         filename = FermiGalacticCenter.filenames()['exposure_cube']
         return SkyCube.read(filename, format='fermi-exposure')
-
-
-class FermiVelaRegion(object):
-    """Fermi high-energy data for the Vela region.
-
-    For details, see
-    `README file for FermiVelaRegion
-    <https://github.com/gammapy/gammapy-extra/blob/master/datasets/vela_region/README.rst>`_.
-    """
-
-    @staticmethod
-    def filenames():
-        """Dictionary of available file names."""
-        base_dir = gammapy_extra.dir / 'datasets/vela_region'
-
-        result = OrderedDict()
-        result['counts_cube'] = str(base_dir / 'counts_vela.fits')
-        result['exposure_cube'] = str(base_dir / 'exposure_vela.fits')
-        result['background_image'] = str(base_dir / 'background_vela.fits')
-        result['total_image'] = str(base_dir / 'total_vela.fits')
-        result['diffuse_model'] = str(base_dir / 'gll_iem_v05_rev1_cutout.fits')
-        result['events'] = str(base_dir / 'events_vela.fits')
-        result['psf'] = str(base_dir / 'psf_vela.fits')
-        result['livetime_cube'] = str(base_dir / 'livetime_vela.fits')
-        return result
-
-    @staticmethod
-    def counts_cube():
-        """Counts cube information (`~astropy.io.fits.HDUList`).
-
-        The HDU list contains:
-
-        * Counts cube `~astropy.io.fits.PrimaryHDU`.
-        * Energy bins `~astropy.io.fits.BinTableHDU`.
-        * MET bins `~astropy.io.fits.BinTableHDU`.
-        """
-        filename = FermiVelaRegion.filenames()['counts_cube']
-        return fits.open(filename)
-
-    @staticmethod
-    def psf():
-        """Point spread function (`~gammapy.irf.EnergyDependentTablePSF`)"""
-        from ..irf import EnergyDependentTablePSF
-        filename = FermiVelaRegion.filenames()['psf']
-        return EnergyDependentTablePSF.read(filename)
-
-    @staticmethod
-    def diffuse_model():
-        """Diffuse model (`~gammapy.data.SkyCube`)"""
-        from ..cube import SkyCube
-        filename = FermiVelaRegion.filenames()['diffuse_model']
-        return SkyCube.read(filename, format='fermi-background')
-
-    @staticmethod
-    def background_image():
-        """Predicted background counts image (`~gammapy.image.SkyImage`).
-
-        Based on the Fermi Diffuse model (see class docstring).
-        """
-        from ..image import SkyImage
-        filename = FermiVelaRegion.filenames()['background_image']
-        return SkyImage.read(filename)
-
-    @staticmethod
-    def predicted_image():
-        """Predicted total counts image (`~astropy.io.fits.PrimaryHDU`).
-
-        Based on the Fermi diffuse model (see class docstring) and
-        Vela Point source model.
-        """
-        filename = FermiVelaRegion.filenames()['total_image']
-        return fits.open(filename)[0]
-
-    @staticmethod
-    def events():
-        """Events list information (`~astropy.io.fits.HDUList`)
-
-        The HDU list contains:
-
-        - ``EVENTS`` table HDU
-        - ``GTI`` table HDU
-        """
-        filename = FermiVelaRegion.filenames()['events']
-        return fits.open(filename)
-
-    @staticmethod
-    def exposure_cube():
-        """Exposure cube (`~gammapy.data.SkyCube`)."""
-        from ..cube import SkyCube
-        filename = FermiVelaRegion.filenames()['exposure_cube']
-        return SkyCube.read(filename, format='fermi-exposure')
-
-    @staticmethod
-    def livetime_cube():
-        """Livetime cube (`~astropy.io.fits.HDUList`)."""
-        filename = FermiVelaRegion.filenames()['livetime_cube']
-        return fits.open(filename)
 
 
 class FermiLATDataset(object):

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -10,7 +10,6 @@ from ...datasets import (
     FermiLATDataset,
     FermiGalacticCenter,
     FermiVelaRegion,
-    load_lat_psf_performance,
 )
 
 
@@ -101,27 +100,6 @@ class TestFermiVelaRegion:
         assert livetime_list[4].data.shape == (17276,)
 
 
-@requires_data('gammapy-extra')
-def test_load_lat_psf_performance():
-    """Tests loading of each file by asserting first value is correct."""
-
-    table_p7rep_68 = load_lat_psf_performance('P7REP_SOURCE_V15_68')
-    assert table_p7rep_68['energy'][0] == 29.65100879793481
-    assert table_p7rep_68['containment_angle'][0] == 11.723606254043286
-
-    table_p7rep_95 = load_lat_psf_performance('P7REP_SOURCE_V15_95')
-    assert table_p7rep_95['energy'][0] == 29.989807922064667
-    assert table_p7rep_95['containment_angle'][0] == 24.31544392270023
-
-    table_p7_68 = load_lat_psf_performance('P7SOURCEV6_68')
-    assert table_p7_68['energy'][0] == 31.9853049046
-    assert table_p7_68['containment_angle'][0] == 14.7338699328
-
-    table_p7_95 = load_lat_psf_performance('P7SOURCEV6_95')
-    assert table_p7_95['energy'][0] == 31.6227766017
-    assert table_p7_95['containment_angle'][0] == 38.3847234362
-
-
 @requires_data('fermi-lat')
 @requires_dependency('healpy')
 @requires_dependency('yaml')
@@ -143,7 +121,6 @@ class TestFermiLATDataset:
         assert_allclose(counts.data.sum(), 60275)
 
     def test_psf(self):
-        psf = self.data_2fhl.psf
         actual = self.data_2fhl.psf.integral(100 * u.GeV, 0 * u.deg, 2 * u.deg)
         desired = 1.00048
         assert_allclose(actual, desired, rtol=1e-4)

--- a/gammapy/datasets/tests/test_fermi.py
+++ b/gammapy/datasets/tests/test_fermi.py
@@ -9,7 +9,6 @@ from ...utils.testing import requires_dependency, requires_data
 from ...datasets import (
     FermiLATDataset,
     FermiGalacticCenter,
-    FermiVelaRegion,
 )
 
 
@@ -44,60 +43,6 @@ class TestFermiGalacticCenter:
         exposure_cube = FermiGalacticCenter.exposure_cube()
         assert exposure_cube.data.shape == (21, 11, 31)
         assert_quantity_allclose(exposure_cube.energies()[0], Quantity(50, 'MeV'))
-
-
-@requires_data('gammapy-extra')
-class TestFermiVelaRegion:
-    def test_filenames(self):
-        filenames = FermiVelaRegion.filenames()
-        assert isinstance(filenames, dict)
-
-    def test_counts_cube(self):
-        counts = FermiVelaRegion.counts_cube()[0]
-        assert counts.data.shape == (20, 50, 50)
-        assert counts.data.sum() == 1551
-
-    @requires_dependency('scipy')
-    def test_psf(self):
-        psf = FermiVelaRegion.psf()
-        energy = Quantity(110, 'GeV')
-        fraction = 0.68
-        interpol_param = dict(method='nearest', bounds_error=False)
-        angle = psf.containment_radius(energy, fraction, interpol_param)
-        assert_quantity_allclose(angle, Angle(0.13185321269896136, 'deg'), rtol=1e-1)
-
-    @requires_dependency('scipy')
-    def test_diffuse_model(self):
-        diffuse_model = FermiVelaRegion.diffuse_model()
-        assert diffuse_model.data.shape == (30, 161, 161)
-
-    def test_background_image(self):
-        background = FermiVelaRegion.background_image()
-        assert background.data.shape == (50, 50)
-        assert background.data.sum(), 264.54391
-
-    def test_predicted_image(self):
-        background = FermiVelaRegion.predicted_image()
-        assert background.data.shape == (50, 50)
-        assert background.data.sum(), 322.12299
-
-    def test_events(self):
-        events_list = FermiVelaRegion.events()
-        assert events_list['EVENTS'].data.shape == (2042,)
-
-    @requires_dependency('scipy')
-    def test_exposure_cube(self):
-        exposure_cube = FermiVelaRegion.exposure_cube()
-        assert exposure_cube.data.shape == (21, 50, 50)
-        assert exposure_cube.data.value.sum(), 4.978616e+15
-        assert_quantity_allclose(exposure_cube.energies()[0], Quantity(10000, 'MeV'))
-
-    def test_livetime(self):
-        livetime_list = FermiVelaRegion.livetime_cube()
-        assert livetime_list[1].data.shape == (12288,)
-        assert livetime_list[2].data.shape == (12288,)
-        assert livetime_list[3].data.shape == (4,)
-        assert livetime_list[4].data.shape == (17276,)
 
 
 @requires_data('fermi-lat')


### PR DESCRIPTION
This PR removes some old and unused code to fetch and load Fermi-LAT example dataset from gammapy.datasets. Note that there are still two classes left; those are used by other tests, and what to do about them will need some discussion (see also #1237 by @adonath ).