### PR TITLE
Simpler names for map evaluator and fit?

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from .models import SkyModelMapEvaluator
+from .models import MapEvaluator
 from ..stats import cash
 from ..utils.fitting import fit_iminuit
 
@@ -44,7 +44,7 @@ class SkyModelMapFit(object):
         self._stat = None
         self._minuit = None
 
-        self.evaluator = SkyModelMapEvaluator(
+        self.evaluator = MapEvaluator(
             sky_model=self.model,
             exposure=self.exposure,
             background=self.background,

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -6,11 +6,11 @@ from ..stats import cash
 from ..utils.fitting import fit_iminuit
 
 __all__ = [
-    'SkyModelMapFit',
+    'MapFit',
 ]
 
 
-class SkyModelMapFit(object):
+class MapFit(object):
     """Perform sky model likelihood fit on maps.
 
     This is the first go at such a class. It's geared to the

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -13,7 +13,7 @@ __all__ = [
     'SourceLibrary',
     'SkyModel',
     'CompoundSkyModel',
-    'SkyModelMapEvaluator',
+    'MapEvaluator',
 ]
 
 
@@ -255,7 +255,7 @@ class CompoundSkyModel(object):
         return self.operator(val1, val2)
 
 
-class SkyModelMapEvaluator(object):
+class MapEvaluator(object):
     """Sky model evaluation on maps.
 
     This is a first attempt to compute flux as well as predicted counts maps.

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -15,7 +15,7 @@ from ...spectrum.models import PowerLaw
 from .. import (
     SkyModel,
     MapEvaluator,
-    SkyModelMapFit,
+    MapFit,
     make_map_exposure_true_energy,
     PSFKernel,
 )
@@ -119,7 +119,7 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
         'amplitude': '1e-12 cm-2 s-1 TeV-1',
     })
 
-    fit = SkyModelMapFit(
+    fit = MapFit(
         model=input_model,
         counts=counts,
         exposure=exposure,

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -14,7 +14,7 @@ from ...image.models import SkyGaussian
 from ...spectrum.models import PowerLaw
 from .. import (
     SkyModel,
-    SkyModelMapEvaluator,
+    MapEvaluator,
     SkyModelMapFit,
     make_map_exposure_true_energy,
     PSFKernel,
@@ -92,7 +92,7 @@ def psf(geom):
 
 @pytest.fixture(scope='session')
 def counts(sky_model, exposure, psf, edisp):
-    evaluator = SkyModelMapEvaluator(
+    evaluator = MapEvaluator(
         sky_model=sky_model,
         exposure=exposure,
         psf=psf,

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -12,7 +12,7 @@ from ...image.models import SkyGaussian
 from ...spectrum.models import PowerLaw
 from ..models import (
     SkyModel,
-    SkyModelMapEvaluator,
+    MapEvaluator,
     SourceLibrary,
     CompoundSkyModel,
 )
@@ -63,7 +63,7 @@ def psf(geom):
 
 @pytest.fixture(scope='session')
 def evaluator(sky_model, exposure, background, psf, edisp):
-    return SkyModelMapEvaluator(sky_model, exposure, background, psf=psf, edisp=edisp)
+    return MapEvaluator(sky_model, exposure, background, psf=psf, edisp=edisp)
 
 
 class TestSourceLibrary:


### PR DESCRIPTION
In #1536 I did a few small renames for the map functions towards more consistency.
I think we should consider a few more renames to go towards a simple and consistent API this week, before making the v0.8 release, especially for the new things that were never shipped in a stable release yet.

This is one change I'd like to make:
* SkyModelMapEvaluator -> MapEvaluator
* SkyModelMapFit -> MapFit

The reasoning is just that it's simpler / shorter to remember and type, and that the fit and evaluator also deals e.g. with background models, which we'll probably call `BackgroundModel...` and not `SkyModel...`.

`MapFit` is also analogous to the existing [gammapy.spectrum.SpectrumFit](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumFit.html) for 1D analysis.
The counterpart for 1D to `MapEvaluator` is [gammapy.spectrum.CountsPredictor](http://docs.gammapy.org/dev/api/gammapy.spectrum.CountsPredictor.html), but I don't particularly like that name, I'd rather change to `gammapy.spectrum.SpectrumEvaluator`. We could also defer renames / re-location of classes to v0.9, and just do a bit of cleanup for the things that were added since v0.7 now.

@AtreyeeS @joleroi @registerrier @adonath @facero  - Thoughts? Votes?
