### PR TITLE
Change KernelBackgroundEstimator to use gammapy.maps

### DIFF
--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 from astropy.coordinates import Angle
 from astropy.convolution import Tophat2DKernel, CustomKernel
-from ..image import SkyImage, SkyImageList
+from ..maps import Map
 from .lima import compute_lima_image
 
 log = logging.getLogger(__name__)
@@ -14,6 +14,8 @@ __all__ = [
 ]
 
 
+# TODO: use `Map.clone` or `Map.copy` once available
+# instead of the awkward way with `Map.from_geom` and adjusting map data after.
 class KernelBackgroundEstimator(object):
     """Estimate background and exclusion mask iteratively.
 
@@ -40,7 +42,6 @@ class KernelBackgroundEstimator(object):
         Radius by which mask is dilated with each iteration.
     keep_record : bool
         Keep record of intermediate results while the algorithm runs?
-        Default False.
 
     See Also
     --------
@@ -49,7 +50,8 @@ class KernelBackgroundEstimator(object):
     """
 
     def __init__(self, kernel_src, kernel_bkg,
-                 significance_threshold=5, mask_dilation_radius='0.02 deg',
+                 significance_threshold=5,
+                 mask_dilation_radius='0.02 deg',
                  keep_record=False):
 
         self.parameters = {
@@ -67,8 +69,8 @@ class KernelBackgroundEstimator(object):
 
         Parameters
         ----------
-        images : `~gammapy.image.SkyImageList`
-            Input sky images.
+        images : dict
+            Input sky images: counts, background, exclusion
         niter_min : int
             Minimum number of iterations, to prevent early termination of the
             algorithm.
@@ -79,31 +81,33 @@ class KernelBackgroundEstimator(object):
 
         Returns
         -------
-        images : `~gammapy.image.SkyImageList`
-            List of sky images containing 'background', 'exclusion' mask and
-            'significance' images.
+        images : dict
+            Sky images: background, exclusion, significance
         """
-        images.check_required(['counts'])
-        p = self.parameters
-
         # initial mask, if not present
-        if 'exclusion' not in images.names:
-            images['exclusion'] = SkyImage.empty_like(images['counts'], fill=1)
+        if 'exclusion' not in images:
+            exclusion = Map.from_geom(images['counts'].geom)
+            exclusion += 1
+            images['exclusion'] = exclusion
 
         # initial background estimate, if not present
-        if 'background' not in images.names:
-            log.info('Estimating initial background.')
-            images['background'] = self._estimate_background(images['counts'],
-                                                             images['exclusion'])
+        if 'background' not in images:
+            images['background'] = self._estimate_background(
+                images['counts'],
+                images['exclusion'],
+            )
 
-        images['significance'] = self._estimate_significance(images['counts'],
-                                                             images['background'])
+        images['significance'] = self._estimate_significance(
+            images['counts'],
+            images['background'],
+        )
+
         self.images_stack.append(images)
 
         for idx in range(niter_max):
-            result = self._run_iteration(images)
+            result = self.run_iteration(images)
 
-            if p['keep_record']:
+            if self.parameters['keep_record']:
                 self.images_stack.append(result)
 
             if self._is_converged(result, images) and (idx >= niter_min):
@@ -113,52 +117,56 @@ class KernelBackgroundEstimator(object):
 
         return result
 
-    def _run_iteration(self, images):
+    def run_iteration(self, images):
         """Run one iteration.
 
         Parameters
         ----------
-        images : `gammapy.image.SkyImageList`
+        images : dict
             Input sky images
         """
-        images.check_required(['counts', 'exclusion', 'background'])
-
         significance = self._estimate_significance(images['counts'], images['background'])
         exclusion = self._estimate_exclusion(images['counts'], significance)
         background = self._estimate_background(images['counts'], exclusion)
 
-        return SkyImageList([images['counts'], background, exclusion, significance])
+        return {
+            'counts': images['counts'],
+            'background': background,
+            'exclusion': exclusion,
+            'significance': significance,
+        }
 
     def _estimate_significance(self, counts, background):
         kernel = CustomKernel(self.kernel_src)
-        images_lima = compute_lima_image(counts.to_wcs_nd_map(), background.to_wcs_nd_map(), kernel=kernel)
-        return SkyImage.from_wcs_nd_map(images_lima['significance'])
+        images = compute_lima_image(counts, background, kernel=kernel)
+        return images['significance']
 
     def _estimate_exclusion(self, counts, significance):
         from scipy.ndimage import binary_erosion
-        wcs = counts.wcs.copy()
-        p = self.parameters
-        radius = p['mask_dilation_radius'].to('deg').value
-        scale = counts.wcs_pixel_scale()[0].value
+        radius = self.parameters['mask_dilation_radius'].deg
+        scale = counts.geom.pixel_scales.mean().deg
         mask_dilation_radius_pix = radius / scale
+
         structure = np.array(Tophat2DKernel(mask_dilation_radius_pix))
 
-        mask = (significance.data < p['significance_threshold']) | np.isnan(significance)
+        mask = (significance.data < self.parameters['significance_threshold']) | np.isnan(significance.data)
         mask = binary_erosion(mask, structure, border_value=1)
-        return SkyImage(name='exclusion', data=mask.astype('float'), wcs=wcs)
+
+        exclusion = Map.from_geom(counts.geom)
+        exclusion.data = mask.astype('float')
+        return exclusion
 
     def _estimate_background(self, counts, exclusion):
         """
         Estimate background by convolving the excluded counts image with
         the background kernel and renormalizing the image.
         """
-        wcs = counts.wcs.copy()
-
-        # recompute background estimate
-        counts_excluded = SkyImage(data=counts.data * exclusion.data, wcs=wcs)
-        data = counts_excluded.convolve(self.kernel_bkg, mode='constant')
-        norm = exclusion.convolve(self.kernel_bkg, mode='constant')
-        return SkyImage(name='background', data=data.data / norm.data, wcs=wcs)
+        from scipy.ndimage import convolve
+        vals = convolve(counts.data * exclusion.data, self.kernel_bkg, mode='constant')
+        norm = convolve(exclusion.data, self.kernel_bkg, mode='constant')
+        bkg = Map.from_geom(counts.geom)
+        bkg.data = vals / norm
+        return bkg
 
     @staticmethod
     def _is_converged(result, result_previous):

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -1,89 +1,60 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-import astropy.units as u
-from ...utils.testing import requires_dependency, requires_data
-from ...irf import EnergyDependentTablePSF
+from ...utils.testing import requires_data
 from ...image import SkyImage, SkyImageList
 from ..kernel import KernelBackgroundEstimator
 
+pytest.importorskip('scipy')
 
-@requires_dependency('scipy')
+
+@pytest.fixture(scope='session')
+def images():
+    """A simple test case for the algorithm."""
+    counts = SkyImage.empty(name='counts', nxpix=10, nypix=10, binsz=1, fill=42.)
+    counts.data[4][4] = 1000
+
+    background = SkyImage.empty_like(counts, fill=42., name='background')
+    exclusion = SkyImage.empty_like(counts, name='exclusion', fill=1.)
+    return SkyImageList([counts, background, exclusion])
+
+
+@pytest.fixture()
+def kbe():
+    source_kernel = np.ones((1, 3))
+    background_kernel = np.ones((5, 3))
+    return KernelBackgroundEstimator(
+        kernel_src=source_kernel,
+        kernel_bkg=background_kernel,
+        significance_threshold=4,
+        mask_dilation_radius='1 deg',
+        keep_record=True,
+    )
+
+
 @requires_data('gammapy-extra')
-class TestKernelBackgroundEstimator(object):
-    def setup(self):
-        source_kernel = np.ones((1, 3))
-        background_kernel = np.ones((5, 3))
-        self.kbe = KernelBackgroundEstimator(
-            kernel_src=source_kernel,
-            kernel_bkg=background_kernel,
-            significance_threshold=4,
-            mask_dilation_radius='1 deg',
-            keep_record=True,
-        )
+def test_run_iteration(kbe, images):
+    # Call the _run_iteration code as this is what is explicitly being tested
+    result = kbe._run_iteration(images)
+    mask, background = result['exclusion'].data, result['background'].data
 
-    def _images_point(self):
-        """
-        Test images for a point source
-        """
-        counts = SkyImage.empty(name='counts', nxpix=10, nypix=10, binsz=1, fill=42.)
-        counts.data[4][4] = 1000
+    # Check mask
+    idx = [(4, 3), (4, 4), (4, 5), (3, 4), (5, 4)]
+    i, j = zip(*idx)
+    assert_allclose(mask[i, j], 0)
+    assert_allclose((1. - mask).sum(), 11)
 
-        background = SkyImage.empty_like(counts, fill=42., name='background')
-        exclusion = SkyImage.empty_like(counts, name='exclusion', fill=1.)
-        return SkyImageList([counts, background, exclusion])
+    # Check background, should be 42 uniformly
+    assert_allclose(background, 42 * np.ones((10, 10)))
 
-    def _images_psf(self):
-        # Initial counts required by one of the tests.
-        images = self._images_point()
 
-        filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/fermi/psf.fits'
-        psf = EnergyDependentTablePSF.read(filename)
-        erange = [10, 500] * u.GeV
-        psf = psf.table_psf_in_energy_band(erange)
-        rad_max = psf.containment_radius(0.99)
-        kernel_array = psf.kernel(images['counts'], rad_max=rad_max)
+@requires_data('gammapy-extra')
+def test_run(kbe, images):
+    result = kbe.run(images)
+    mask, background = result['exclusion'].data, result['background'].data
 
-        images['counts'] = images['counts'].convolve(kernel_array, mode='constant')
-        return images
-
-    def test_run_iteration_point(self):
-        """Asserts that mask and background are as expected according to input."""
-
-        images = self._images_point()
-
-        # Call the _run_iteration code as this is what is explicitly being tested
-        result = self.kbe._run_iteration(images)
-        mask, background = result['exclusion'].data, result['background'].data
-
-        # Check mask
-        idx = [(4, 3), (4, 4), (4, 5), (3, 4), (5, 4)]
-        i, j = zip(*idx)
-        assert_allclose(mask[i, j], 0)
-        assert_allclose((1. - mask).sum(), 11)
-
-        # Check background, should be 42 uniformly
-        assert_allclose(background, 42 * np.ones((10, 10)))
-
-    def test_run_iteration_blob(self):
-        """Asserts that mask and background are as expected according to input."""
-
-        images = self._images_psf()
-
-        # Call the run_iteration code as this is what is explicitly being tested
-        result = self.kbe._run_iteration(images)
-        background = result['background'].data
-
-        # Check background, should be 42 uniformly within 10%
-        assert_allclose(background, 42 * np.ones((10, 10)), rtol=0.1)
-
-    def test_run(self):
-        """Tests run script."""
-        images = self._images_point()
-        result = self.kbe.run(images)
-        mask, background = result['exclusion'].data, result['background'].data
-
-        assert_allclose(mask.sum(), 89)
-        assert_allclose(background, 42 * np.ones((10, 10)))
-        assert len(self.kbe.images_stack) == 4
+    assert_allclose(mask.sum(), 89)
+    assert_allclose(background, 42 * np.ones((10, 10)))
+    assert len(kbe.images_stack) == 4


### PR DESCRIPTION
This PR is a continuation of #1535 , now changing the `gammapy.detect.KernelBackgroundEstimator` to use gammapy.maps.

I also removed the second test case images, because it turns out they didn't test anything additionally, but just used a Fermi-LAT energy dependent PSF in a complex way to make a source kernel, but then didn't have any asserts on the results.

IMO the code still isn't great, I've left a TODO that once Map.clone is there it should be updated; and the tests should also be improved, e.g. with a source at the edge or not passing in an input background  (the line that isn't covered). But those things can be done in a future PR. Merging this now.