### PR TITLE
Introduces a minuit_kwargs argument for the fit_iminuit function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/'
 intersphinx_mapping['aplpy'] = ('http://aplpy.readthedocs.io/en/latest/', None)
 intersphinx_mapping['naima'] = ('http://naima.readthedocs.io/en/latest/', None)
 intersphinx_mapping['gadf'] = ('http://gamma-astro-data-formats.readthedocs.io/en/latest/', None)
+intersphinx_mapping['iminuit'] = ('http://iminuit.readthedocs.io/en/latest/', None)
 
 
 # List of patterns, relative to source directory, that match files and

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -85,8 +85,16 @@ class MapFit(object):
         self.compute_stat()
         return np.sum(self.stat, dtype=np.float64)
 
-    def fit(self):
-        """Run the fit"""
+    def fit(self, minuit_kwargs={}):
+        """Run the fit
+
+        Parameters
+        ----------
+        minuit_kwargs : `dict`
+            *Builtin Keyword Arguments* that are passed on to the `Minuit` constructor of iminuit.
+            See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+        """
         parameters, minuit = fit_iminuit(parameters=self.model.parameters,
-                                         function=self.total_stat)
+                                         function=self.total_stat,
+                                         minuit_kwargs=minuit_kwargs)
         self._minuit = minuit

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -85,16 +85,15 @@ class MapFit(object):
         self.compute_stat()
         return np.sum(self.stat, dtype=np.float64)
 
-    def fit(self, minuit_kwargs={}):
+    def fit(self, opts_minuit=None):
         """Run the fit
 
         Parameters
         ----------
-        minuit_kwargs : `dict`
-            *Builtin Keyword Arguments* that are passed on to the `Minuit` constructor of iminuit.
-            See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+        opts_minuit : dict (optional)
+            Options passed to `iminuit.Minuit` constructor
         """
         parameters, minuit = fit_iminuit(parameters=self.model.parameters,
                                          function=self.total_stat,
-                                         minuit_kwargs=minuit_kwargs)
+                                         opts_minuit=opts_minuit)
         self._minuit = minuit

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -402,19 +402,18 @@ class SpectrumFit(object):
 
         return ax
 
-    def fit(self, minuit_kwargs={}):
+    def fit(self, opts_minuit=None):
         """Run the fit
 
         Parameters
         ----------
-        minuit_kwargs : `dict`
-            *Builtin Keyword Arguments* that are passed on to the `Minuit` constructor of iminuit.
-            See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+        opts_minuit : dict (optional)
+            Options passed to `iminuit.Minuit` constructor
         """
         if self.method == 'sherpa':
             self._fit_sherpa()
         elif self.method == 'iminuit':
-            self._fit_iminuit(minuit_kwargs)
+            self._fit_iminuit(opts_minuit)
         else:
             raise NotImplementedError('method: {}'.format(self.method))
 
@@ -453,11 +452,11 @@ class SpectrumFit(object):
         log.debug(fitresult)
         self._make_fit_result(self._model.parameters)
 
-    def _fit_iminuit(self, minuit_kwargs):
+    def _fit_iminuit(self, opts_minuit):
         """Iminuit minimization"""
         parameters, minuit = fit_iminuit(parameters=self._model.parameters,
                                          function=self.total_stat,
-                                         minuit_kwargs=minuit_kwargs)
+                                         opts_minuit=opts_minuit)
         self._iminuit_fit = minuit
         log.debug(minuit)
         self._make_fit_result(parameters)

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -402,12 +402,19 @@ class SpectrumFit(object):
 
         return ax
 
-    def fit(self):
-        """Run the fit."""
+    def fit(self, minuit_kwargs={}):
+        """Run the fit
+
+        Parameters
+        ----------
+        minuit_kwargs : `dict`
+            *Builtin Keyword Arguments* that are passed on to the `Minuit` constructor of iminuit.
+            See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+        """
         if self.method == 'sherpa':
             self._fit_sherpa()
         elif self.method == 'iminuit':
-            self._fit_iminuit()
+            self._fit_iminuit(minuit_kwargs)
         else:
             raise NotImplementedError('method: {}'.format(self.method))
 
@@ -446,10 +453,11 @@ class SpectrumFit(object):
         log.debug(fitresult)
         self._make_fit_result(self._model.parameters)
 
-    def _fit_iminuit(self):
+    def _fit_iminuit(self, minuit_kwargs):
         """Iminuit minimization"""
         parameters, minuit = fit_iminuit(parameters=self._model.parameters,
-                                         function=self.total_stat)
+                                         function=self.total_stat,
+                                         minuit_kwargs=minuit_kwargs)
         self._iminuit_fit = minuit
         log.debug(minuit)
         self._make_fit_result(parameters)

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-def fit_iminuit(parameters, function):
+def fit_iminuit(parameters, function, minuit_kwargs={}):
     """iminuit optimization
 
     The input `~gammapy.utils.modeling.ParameterList` is copied internally
@@ -25,6 +25,9 @@ def fit_iminuit(parameters, function):
         Parameters with starting values
     function : callable
         Likelihood function
+    minuit_kwargs : `dict`
+        *Builtin Keyword Arguments* that are passed on to the `Minuit` constructor.
+        See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
 
     Returns
     -------
@@ -37,7 +40,7 @@ def fit_iminuit(parameters, function):
 
     parameters = parameters.copy()
     minuit_func = MinuitFunction(function, parameters)
-    minuit_kwargs = make_minuit_kwargs(parameters)
+    minuit_kwargs.update(make_minuit_par_kwargs(parameters))
 
     minuit = Minuit(minuit_func.fcn,
                     forced_parameters=parameters.names,
@@ -69,8 +72,11 @@ class MinuitFunction(object):
         return val
 
 
-def make_minuit_kwargs(parameters):
-    """Create kwargs for iminuit"""
+def make_minuit_par_kwargs(parameters):
+    """Create *Parameter Keyword Arguments* for the `Minuit` constructor.
+
+    See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+    """
     kwargs = dict()
     for par in parameters.parameters:
         kwargs[par.name] = par.value

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -3,7 +3,6 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from ..modeling import ParameterList, Parameter
 
 
 __all__ = [
@@ -11,7 +10,7 @@ __all__ = [
 ]
 
 
-def fit_iminuit(parameters, function, minuit_kwargs={}):
+def fit_iminuit(parameters, function, opts_minuit=None):
     """iminuit optimization
 
     The input `~gammapy.utils.modeling.ParameterList` is copied internally
@@ -25,9 +24,8 @@ def fit_iminuit(parameters, function, minuit_kwargs={}):
         Parameters with starting values
     function : callable
         Likelihood function
-    minuit_kwargs : `dict`
-        *Builtin Keyword Arguments* that are passed on to the `Minuit` constructor.
-        See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
+    opts_minuit : dict (optional)
+        Options passed to `iminuit.Minuit` constructor
 
     Returns
     -------
@@ -40,11 +38,14 @@ def fit_iminuit(parameters, function, minuit_kwargs={}):
 
     parameters = parameters.copy()
     minuit_func = MinuitFunction(function, parameters)
-    minuit_kwargs.update(make_minuit_par_kwargs(parameters))
+
+    if opts_minuit is None:
+        opts_minuit = {}
+    opts_minuit.update(make_minuit_par_kwargs(parameters))
 
     minuit = Minuit(minuit_func.fcn,
                     forced_parameters=parameters.names,
-                    **minuit_kwargs)
+                    **opts_minuit)
 
     minuit.migrad()
     return parameters, minuit


### PR DESCRIPTION
This PR gives a solution to #1542 

I introduced a new parameter to the `gammapy.utils.fitting.fit_iminuit` function, which allows the user to pass on kwargs to the `Minuit` constructor of iminuit. I exposed this option to the `fit` method of the `MapFit` and `SpectrumFit` class. For example:
```python
MapFit.fit(minuit_kwargs={'print_level': 0})
```
