### PR TITLE
Introduce map clone method

### DIFF
--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -215,7 +215,7 @@ def make_map_background_fov(acceptance_map, counts_map, exclusion_mask):
 
     norm_bkg = norm_factor * acceptance_map.data.T
 
-    return acceptance_map.clone(data=norm_bkg.T)
+    return acceptance_map.copy(data=norm_bkg.T)
 
 
 class MapMaker(object):

--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -23,14 +23,14 @@ def make_map_separation(geom, position):
     """Compute distance of pixels to a given position for the input reference WCSGeom.
 
     Result is returned as a 2D WcsNDmap
-    
+
     Parameters
     ----------
     geom : `~gammapy.maps.WcsGeom`
         Reference geometry
     position : `~astropy.coordinates.SkyCoord`
         Reference position
-    
+
     Returns
     -------
     separation : `~gammapy.maps.Map`
@@ -63,7 +63,7 @@ def make_map_counts(events, ref_geom, pointing, offset_max):
         Pointing direction
     offset_max : `~astropy.coordinates.Angle`
         Maximum field of view offset.
-    
+
     Returns
     -------
     cntmap : `~gammapy.maps.WcsNDMap`
@@ -215,7 +215,7 @@ def make_map_background_fov(acceptance_map, counts_map, exclusion_mask):
 
     norm_bkg = norm_factor * acceptance_map.data.T
 
-    return WcsNDMap(acceptance_map.geom, data=norm_bkg.T)
+    return acceptance_map.clone(data=norm_bkg.T)
 
 
 class MapMaker(object):
@@ -240,11 +240,9 @@ class MapMaker(object):
         # We instantiate the end products of the MakeMaps class
         self.count_map = WcsNDMap(self.ref_geom)
 
-        data = np.zeros_like(self.count_map.data)
-        self.exposure_map = WcsNDMap(self.ref_geom, data, unit="m2 s")
+        self.exposure_map = WcsNDMap(self.ref_geom, unit="m2 s")
 
-        data = np.zeros_like(self.count_map.data)
-        self.background_map = WcsNDMap(self.ref_geom, data)
+        self.background_map = WcsNDMap(self.ref_geom)
 
         # We will need this general exclusion mask for the analysis
         self.exclusion_map = WcsNDMap(self.ref_geom)

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -152,9 +152,7 @@ class KernelBackgroundEstimator(object):
         mask = (significance.data < self.parameters['significance_threshold']) | np.isnan(significance.data)
         mask = binary_erosion(mask, structure, border_value=1)
 
-        exclusion = Map.from_geom(counts.geom)
-        exclusion.data = mask.astype('float')
-        return exclusion
+        return counts.clone(data=mask.astype('float'))
 
     def _estimate_background(self, counts, exclusion):
         """

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-# TODO: use `Map.clone` or `Map.copy` once available
+# TODO: use `Map.copy` or `Map.copy` once available
 # instead of the awkward way with `Map.from_geom` and adjusting map data after.
 class KernelBackgroundEstimator(object):
     """Estimate background and exclusion mask iteratively.
@@ -152,7 +152,7 @@ class KernelBackgroundEstimator(object):
         mask = (significance.data < self.parameters['significance_threshold']) | np.isnan(significance.data)
         mask = binary_erosion(mask, structure, border_value=1)
 
-        return counts.clone(data=mask.astype('float'))
+        return counts.copy(data=mask.astype('float'))
 
     def _estimate_background(self, counts, exclusion):
         """

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -55,10 +55,10 @@ def compute_lima_image(counts, background, kernel, exposure=None):
 
     # TODO: we should make coopies of the geom to make them independent objects
     images = {
-        'significance': counts.clone(data=significance_conv),
-        'counts': counts.clone(data=counts_conv),
-        'background': counts.clone(data=background_conv),
-        'excess': counts.clone(data=excess_conv),
+        'significance': counts.copy(data=significance_conv),
+        'counts': counts.copy(data=counts_conv),
+        'background': counts.copy(data=background_conv),
+        'excess': counts.copy(data=excess_conv),
     }
 
     # TODO: should we be doing this here?
@@ -113,11 +113,11 @@ def compute_lima_on_off_image(n_on, n_off, a_on, a_off, kernel, exposure=None):
     significance_conv = significance_on_off(n_on_conv, n_off.data, alpha_conv, method='lima')
 
     images = {
-        'significance': n_on.clone(data=significance_conv),
-        'n_on': n_on.clone(data=n_on_conv),
-        'background': n_on.clone(data=background_conv),
-        'excess': n_on.clone(data=excess_conv),
-        'alpha': n_on.clone(data=alpha_conv),
+        'significance': n_on.copy(data=significance_conv),
+        'n_on': n_on.copy(data=n_on_conv),
+        'background': n_on.copy(data=background_conv),
+        'excess': n_on.copy(data=excess_conv),
+        'alpha': n_on.copy(data=alpha_conv),
     }
 
     # TODO: should we be doing this here?
@@ -137,4 +137,4 @@ def _add_other_images(images, exposure, kernel, conv_opt):
     exposure_conv = convolve(exposure.data, kernel.array, **conv_opt)
     flux = images['excess'].data / exposure_conv
     # TODO: we should make coopies of the geom to make them independent objects
-    images['flux'] = images['excess'].clone(data=flux)
+    images['flux'] = images['excess'].copy(data=flux)

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -55,10 +55,10 @@ def compute_lima_image(counts, background, kernel, exposure=None):
 
     # TODO: we should make coopies of the geom to make them independent objects
     images = {
-        'significance': WcsNDMap(counts.geom, significance_conv),
-        'counts': WcsNDMap(counts.geom, counts_conv),
-        'background': WcsNDMap(counts.geom, background_conv),
-        'excess': WcsNDMap(counts.geom, excess_conv),
+        'significance': counts.clone(data=significance_conv),
+        'counts': counts.clone(data=counts_conv),
+        'background': counts.clone(data=background_conv),
+        'excess': counts.clone(data=excess_conv),
     }
 
     # TODO: should we be doing this here?
@@ -113,11 +113,11 @@ def compute_lima_on_off_image(n_on, n_off, a_on, a_off, kernel, exposure=None):
     significance_conv = significance_on_off(n_on_conv, n_off.data, alpha_conv, method='lima')
 
     images = {
-        'significance': WcsNDMap(n_on.geom, data=significance_conv),
-        'n_on': WcsNDMap(n_on.geom, data=n_on_conv),
-        'background': WcsNDMap(n_on.geom, data=background_conv),
-        'excess': WcsNDMap(n_on.geom, data=excess_conv),
-        'alpha': WcsNDMap(n_on.geom, data=alpha_conv),
+        'significance': n_on.clone(data=significance_conv),
+        'n_on': n_on.clone(data=n_on_conv),
+        'background': n_on.clone(data=background_conv),
+        'excess': n_on.clone(data=excess_conv),
+        'alpha': n_on.clone(data=alpha_conv),
     }
 
     # TODO: should we be doing this here?
@@ -136,5 +136,5 @@ def _add_other_images(images, exposure, kernel, conv_opt):
     kernel.normalize('integral')
     exposure_conv = convolve(exposure.data, kernel.array, **conv_opt)
     flux = images['excess'].data / exposure_conv
-    # TODO: we should make coopies of the geom to make them independent objects 
-    images['flux'] = WcsNDMap(images['excess'].geom, flux)
+    # TODO: we should make coopies of the geom to make them independent objects
+    images['flux'] = images['excess'].clone(data=flux)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
+import copy
+import inspect
 import json
 import numpy as np
 from collections import OrderedDict
@@ -894,6 +896,34 @@ class Map(object):
             Values vector. Pixels at `idx` will be set to these values.
         """
         pass
+
+    def clone(self, **kwargs):
+        """Clone map instance and overwrite given attributes.
+
+        Parameters
+        ----------
+
+
+        Returns
+        --------
+
+        """
+        init_args = inspect.getargspec(self.__init__).args
+        init_args.remove('self')
+        init_args.remove('dtype')
+
+        for attr in init_args:
+            if attr not in kwargs:
+                value = getattr(self, attr)
+                if attr == 'data' and 'dtype' in kwargs:
+                    value = value.astype(kwargs['dtype'], copy=True)
+                else:
+                    value = copy.deepcopy(value)
+
+                kwargs[attr] = value
+
+        return self.__class__(**kwargs)
+
 
     def __repr__(self):
         str_ = self.__class__.__name__

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -902,15 +902,20 @@ class Map(object):
 
         Parameters
         ----------
-
+        **kwargs : dict
+            Keyword arguments to overwrite in the map constructor.
 
         Returns
         --------
-
+        clone : `Map`
+            Cloned Map.
         """
         init_args = inspect.getargspec(self.__init__).args
         init_args.remove('self')
         init_args.remove('dtype')
+
+        if 'geom' in kwargs and 'data' not in kwargs:
+            raise ValueError("Can't clone and overwrite geometry if the data is not overwritten too.")
 
         for attr in init_args:
             if attr not in kwargs:
@@ -921,7 +926,6 @@ class Map(object):
                     value = copy.deepcopy(value)
 
                 kwargs[attr] = value
-
         return self.__class__(**kwargs)
 
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -886,6 +886,10 @@ class MapCoord(object):
         return self.__class__(data, self.coordsys,
                               match_by_name=self._match_by_name)
 
+    def copy(self):
+        """Copy geom object."""
+        return copy.deepcopy(self)
+
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import abc
 import copy
+import inspect
 import re
 from collections import OrderedDict
 import numpy as np
@@ -1219,9 +1220,7 @@ class MapGeom(object):
                 axes.append(ax_sliced)
                 # in the case where isinstance(ax_slice, int) the axes is dropped
 
-        kwargs = self._copy_init_kwargs
-        kwargs['axes'] = axes
-        return self.__class__(**kwargs)
+        return self._init_copy(axes=axes)
 
     @abc.abstractmethod
     def to_image(self):
@@ -1418,3 +1417,15 @@ class MapGeom(object):
             if axis.type == type:
                 return axis
         raise ValueError("Cannot find type {}".format(type))
+
+    def _init_copy(self, **kwargs):
+        """Init map instance by copying missing init arguments from self.
+        """
+        argnames = inspect.getargspec(self.__init__).args
+        argnames.remove('self')
+
+        for arg in argnames:
+            value = getattr(self, '_' + arg)
+            kwargs.setdefault(arg, copy.deepcopy(value))
+
+        return self.__class__(**kwargs)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -586,6 +586,7 @@ class HpxGeom(MapGeom):
         self._coordsys = coordsys
         self._maxpix = 12 * self._nside * self._nside
         self._maxpix = self._maxpix * np.ones(self._shape, dtype=int)
+        self._sparse = sparse
 
         self._ipix = None
         self._rmap = None
@@ -604,14 +605,6 @@ class HpxGeom(MapGeom):
         self._center_coord = tuple([lon, lat] +
                                    [ax.pix_to_coord((float(ax.nbin) - 1.0) / 2.) for ax in self.axes])
         self._center_pix = self.coord_to_pix(self._center_coord)
-
-    @property
-    def _copy_init_kwargs(self):
-        """Get kwargs to init an instance with the same parameters."""
-        kwargs = {}
-        for arg in ['nside', 'nest', 'coordsys', 'region', 'axes', 'conv']:
-            kwargs[arg] = getattr(self, '_' + arg)
-        return kwargs
 
     def _create_lookup(self, region):
         """Create local-to-global pixel lookup table."""

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -204,17 +204,10 @@ class HpxNDMap(HpxMap):
         map_out : `~HpxNDMap`
             Summed map.
         """
-        hpx_out = self.geom.to_image()
-        map_out = self.__class__(hpx_out)
-
-        if self.geom.nside.size > 1:
-            vals = self.get_by_idx(self.geom.get_idx(flat=True))
-            map_out.fill_by_coord(self.geom.get_coord(flat=True)[:2], vals)
-        else:
-            axis = tuple(range(self.data.ndim - 1))
-            map_out.data = np.sum(self.data, axis=axis)
-
-        return map_out
+        geom = self.geom.to_image()
+        axis = tuple(range(self.data.ndim - 1))
+        data = np.nansum(self.data, axis=axis)
+        return self.clone(geom=geom, data=data)
 
     def _reproject_wcs(self, geom, order=1, mode='interp'):
 
@@ -257,7 +250,7 @@ class HpxNDMap(HpxMap):
 
     def pad(self, pad_width, mode='constant', cval=0.0, order=1):
         geom = self.geom.pad(pad_width)
-        map_out = self.__class__(geom, meta=copy.deepcopy(self.meta), unit=self.unit)
+        map_out = self.clone(geom=geom, data=None)
         map_out.coadd(self)
         coords = geom.get_coord(flat=True)
         m = self.geom.contains(coords)
@@ -278,31 +271,28 @@ class HpxNDMap(HpxMap):
 
     def crop(self, crop_width):
         geom = self.geom.crop(crop_width)
-        map_out = self.__class__(geom, meta=copy.deepcopy(self.meta), unit=self.unit)
+        map_out = self.clone(geom=geom, data=None)
         map_out.coadd(self)
         return map_out
 
     def upsample(self, factor, preserve_counts=True):
-
-        map_out = self.__class__(self.geom.upsample(factor),
-                                 meta=copy.deepcopy(self.meta), unit=self.unit)
-        coords = map_out.geom.get_coord(flat=True)
-        vals = self.get_by_coord(coords)
-        m = np.isfinite(vals)
-        map_out.fill_by_coord([c[m] for c in coords], vals[m])
+        geom = self.geom.upsample(factor)
+        coords = geom.get_coord()
+        data = self.get_by_coord(coords)
 
         if preserve_counts:
-            map_out.data /= factor ** 2
+            data /= factor ** 2
 
-        return map_out
+        return self.clone(geom=geom, data=data)
 
     def downsample(self, factor, preserve_counts=True):
+        geom = self.geom.downsample(factor)
+        coords = self.geom.get_coord()
+        vals = self.get_by_coord(coords)
 
-        map_out = self.__class__(self.geom.downsample(factor),
-                                 meta=copy.deepcopy(self.meta), unit=self.unit)
-        idx = self.geom.get_idx(flat=True)
-        coords = self.geom.pix_to_coord(idx)
-        vals = self.get_by_idx(idx)
+        # if we provide data=None the data is not cloned by rather created from
+        # the altered geometry
+        map_out = self.clone(geom=geom, data=None)
         map_out.fill_by_coord(coords, vals)
 
         if not preserve_counts:
@@ -462,7 +452,7 @@ class HpxNDMap(HpxMap):
     def to_swapped(self):
         import healpy as hp
         hpx_out = self.geom.to_swapped()
-        map_out = self.__class__(hpx_out, meta=copy.deepcopy(self.meta), unit=self.unit)
+        map_out = self.clone(geom=hpx_out, data=None)
         idx = self.geom.get_idx(flat=True)
         vals = self.get_by_idx(idx)
         if self.geom.nside.size > 1:
@@ -485,7 +475,7 @@ class HpxNDMap(HpxMap):
         import healpy as hp
         order = nside_to_order(nside)
         new_hpx = self.geom.to_ud_graded(order)
-        map_out = self.__class__(new_hpx, meta=copy.deepcopy(self.meta), unit=self.unit)
+        map_out = self.clone(geom=new_hpx, data=None)
 
         if np.all(order <= self.geom.order):
             # Downsample

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -207,7 +207,7 @@ class HpxNDMap(HpxMap):
         geom = self.geom.to_image()
         axis = tuple(range(self.data.ndim - 1))
         data = np.nansum(self.data, axis=axis)
-        return self.clone(geom=geom, data=data)
+        return self._init_copy(geom=geom, data=data)
 
     def _reproject_wcs(self, geom, order=1, mode='interp'):
 
@@ -250,7 +250,7 @@ class HpxNDMap(HpxMap):
 
     def pad(self, pad_width, mode='constant', cval=0.0, order=1):
         geom = self.geom.pad(pad_width)
-        map_out = self.clone(geom=geom, data=None)
+        map_out = self._init_copy(geom=geom, data=None)
         map_out.coadd(self)
         coords = geom.get_coord(flat=True)
         m = self.geom.contains(coords)
@@ -271,7 +271,7 @@ class HpxNDMap(HpxMap):
 
     def crop(self, crop_width):
         geom = self.geom.crop(crop_width)
-        map_out = self.clone(geom=geom, data=None)
+        map_out = self._init_copy(geom=geom, data=None)
         map_out.coadd(self)
         return map_out
 
@@ -283,16 +283,14 @@ class HpxNDMap(HpxMap):
         if preserve_counts:
             data /= factor ** 2
 
-        return self.clone(geom=geom, data=data)
+        return self._init_copy(geom=geom, data=data)
 
     def downsample(self, factor, preserve_counts=True):
         geom = self.geom.downsample(factor)
         coords = self.geom.get_coord()
         vals = self.get_by_coord(coords)
 
-        # if we provide data=None the data is not cloned by rather created from
-        # the altered geometry
-        map_out = self.clone(geom=geom, data=None)
+        map_out = self._init_copy(geom=geom, data=None)
         map_out.fill_by_coord(coords, vals)
 
         if not preserve_counts:
@@ -452,7 +450,7 @@ class HpxNDMap(HpxMap):
     def to_swapped(self):
         import healpy as hp
         hpx_out = self.geom.to_swapped()
-        map_out = self.clone(geom=hpx_out, data=None)
+        map_out = self._init_copy(geom=hpx_out, data=None)
         idx = self.geom.get_idx(flat=True)
         vals = self.get_by_idx(idx)
         if self.geom.nside.size > 1:
@@ -475,7 +473,7 @@ class HpxNDMap(HpxMap):
         import healpy as hp
         order = nside_to_order(nside)
         new_hpx = self.geom.to_ud_graded(order)
-        map_out = self.clone(geom=new_hpx, data=None)
+        map_out = self._init_copy(geom=new_hpx, data=None)
 
         if np.all(order <= self.geom.order):
             # Downsample

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -45,24 +45,24 @@ def test_map_create(binsz, width, map_type, skydir, axes, unit):
 
 @pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes', 'unit'),
                          mapbase_args_with_axes)
-def test_map_clone(binsz, width, map_type, skydir, axes, unit):
+def test_map_copy(binsz, width, map_type, skydir, axes, unit):
     m = Map.create(binsz=binsz, width=width, map_type=map_type,
                    skydir=skydir, axes=axes, unit=unit)
 
-    m_clone = m.clone()
-    assert repr(m) == repr(m_clone)
+    m_copy = m.copy()
+    assert repr(m) == repr(m_copy)
 
-    m_clone = m.clone(unit='cm-2 s-1')
-    assert m_clone.unit == 'cm-2 s-1'
+    m_copy = m.copy(unit='cm-2 s-1')
+    assert m_copy.unit == 'cm-2 s-1'
+    assert m_copy.unit is not m.unit
 
-    m_clone = m.clone(meta=OrderedDict([('is_clone', True)]))
-    assert m_clone.meta['is_clone']
+    m_copy = m.copy(meta=OrderedDict([('is_copy', True)]))
+    assert m_copy.meta['is_copy']
+    assert m_copy.meta is not m.meta
 
-    m_clone = m.clone(dtype=np.int)
-    assert m_clone.data.dtype == np.int
-
-    m_clone = m.clone(data=42 * np.ones(m.data.shape))
-    assert m_clone.data[(0,) * m_clone.data.ndim] == 42
+    m_copy = m.copy(data=42 * np.ones(m.data.shape))
+    assert m_copy.data[(0,) * m_copy.data.ndim] == 42
+    assert m_copy.data is not m.data
 
 
 def test_map_from_geom():

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -43,6 +43,28 @@ def test_map_create(binsz, width, map_type, skydir, axes, unit):
     assert m.unit == unit
 
 
+@pytest.mark.parametrize(('binsz', 'width', 'map_type', 'skydir', 'axes', 'unit'),
+                         mapbase_args_with_axes)
+def test_map_clone(binsz, width, map_type, skydir, axes, unit):
+    m = Map.create(binsz=binsz, width=width, map_type=map_type,
+                   skydir=skydir, axes=axes, unit=unit)
+
+    m_clone = m.clone()
+    assert repr(m) == repr(m_clone)
+
+    m_clone = m.clone(unit='cm-2 s-1')
+    assert m_clone.unit == 'cm-2 s-1'
+
+    m_clone = m.clone(meta=OrderedDict([('is_clone', True)]))
+    assert m_clone.meta['is_clone']
+
+    m_clone = m.clone(dtype=np.int)
+    assert m_clone.data.dtype == np.int
+
+    m_clone = m.clone(data=42 * np.ones(m.data.shape))
+    assert m_clone.data[(0,) * m_clone.data.ndim] == 42
+
+
 def test_map_from_geom():
     geom = WcsGeom.create(binsz=1.0, width=10.0)
     m = Map.from_geom(geom)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -107,14 +107,6 @@ class WcsGeom(MapGeom):
                                                   self.wcs)
 
     @property
-    def _copy_init_kwargs(self):
-        """Get kwargs to init an instance with the same parameters."""
-        kwargs = {}
-        for arg in ['wcs', 'npix', 'cdelt', 'crpix', 'axes', 'conv']:
-            kwargs[arg] = getattr(self, '_' + arg)
-        return kwargs
-
-    @property
     def wcs(self):
         """WCS projection object."""
         return self._wcs

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -242,7 +242,7 @@ class WcsNDMap(WcsMap):
                       kind=kind, fill_value=fill_value)
         data_interp = fn(float(pix))
         geom = self.geom.to_image()
-        return self.__class__(geom, data_interp)
+        return self.clone(data=data, geom=geom)
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
@@ -282,18 +282,11 @@ class WcsNDMap(WcsMap):
                                     buffersize=buffersize))
 
     def sum_over_axes(self):
-        if self.geom.ndim == 2:
-            return copy.deepcopy(self)
-
-        map_out = self.__class__(self.geom.to_image())
-        if not self.geom.is_regular:
-            vals = self.get_by_idx(self.geom.get_idx())
-            map_out.fill_by_coord(self.geom.get_coord()[:2], vals)
-        else:
-            axis = tuple(range(self.data.ndim - 2))
-            map_out.data = np.sum(self.data, axis=axis)
-
-        return map_out
+        axis = tuple(range(self.data.ndim - 2))
+        data = np.nansum(self.data, axis=axis)
+        geom = self.geom.to_image()
+        # TODO: summing over the axis can change the unit, handle this correctly
+        return self.clone(geom=geom, data=data)
 
     def _reproject_wcs(self, geom, mode='interp', order=1):
         from reproject import reproject_interp, reproject_exact
@@ -392,14 +385,13 @@ class WcsNDMap(WcsMap):
         geometries but should be more efficient when working with
         large maps.
         """
-        kw = {}
+        kwargs = {}
         if mode == 'constant':
-            kw['constant_values'] = cval
+            kwargs['constant_values'] = cval
 
         pad_width = [(t, t) for t in pad_width]
-        data = np.pad(self.data, pad_width[::-1], mode, **kw)
-        map_out = self.__class__(geom, data, meta=copy.deepcopy(self.meta), unit=self.unit)
-        return map_out
+        data = np.pad(self.data, pad_width[::-1], mode)
+        return self.clone(geom=geom, data=data)
 
     def _pad_coadd(self, geom, pad_width, mode, cval, order):
         """Pad a map manually by coadding the original map with the new
@@ -407,7 +399,7 @@ class WcsNDMap(WcsMap):
         idx_in = self.geom.get_idx(flat=True)
         idx_in = tuple([t + w for t, w in zip(idx_in, pad_width)])[::-1]
         idx_out = geom.get_idx(flat=True)[::-1]
-        map_out = self.__class__(geom, meta=copy.deepcopy(self.meta), unit=self.unit)
+        map_out = self.clone(geom=geom, data=None)
         map_out.coadd(self)
         if mode == 'constant':
             pad_msk = np.zeros_like(map_out.data, dtype=bool)
@@ -437,11 +429,11 @@ class WcsNDMap(WcsMap):
             for ax in self.geom.axes:
                 slices += [slice(None)]
             data = self.data[slices[::-1]]
-            map_out = self.__class__(geom, data, meta=copy.deepcopy(self.meta), unit=self.unit)
+            map_out = self.clone(geom=geom, data=data)
         else:
             # FIXME: This could be done more efficiently by
             # constructing the appropriate slices for each image plane
-            map_out = self.__class__(geom, meta=copy.deepcopy(self.meta), unit=self.unit)
+            map_out = self.clone(geom=geom, data=None)
             map_out.coadd(self)
 
         return map_out
@@ -455,7 +447,7 @@ class WcsNDMap(WcsMap):
         data = map_coordinates(self.data.T, pix, order=order, mode='nearest')
         if preserve_counts:
             data /= factor ** 2
-        return self.__class__(geom, data, meta=copy.deepcopy(self.meta), unit=self.unit)
+        return self.clone(data=data, geom=geom)
 
     def downsample(self, factor, preserve_counts=True):
         from skimage.measure import block_reduce
@@ -464,7 +456,7 @@ class WcsNDMap(WcsMap):
         data = block_reduce(self.data, block_size[::-1], np.nansum)
         if not preserve_counts:
             data /= factor ** 2
-        return self.__class__(geom, data, meta=copy.deepcopy(self.meta), unit=self.unit)
+        return self.clone(data=data, geom=geom)
 
     def plot(self, ax=None, fig=None, add_cbar=False, stretch='linear', **kwargs):
         """
@@ -549,7 +541,7 @@ class WcsNDMap(WcsMap):
         if inside is False:
             np.logical_not(mask, out=mask)
         # TODO : update meta table to include something about the region used for mask creation?
-        return WcsNDMap(geom=self.geom, data=mask, meta=self.meta)
+        return self.clone(data=mask, dtype='bool')
 
     def smooth(self, radius, kernel='gauss', **kwargs):
         """
@@ -598,9 +590,7 @@ class WcsNDMap(WcsMap):
         else:
             raise ValueError('Invalid option kernel = {}'.format(kernel))
 
-        image = copy.copy(self)
-        image.data = data
-        return image
+        return self.clone(data=data)
 
     def make_cutout(self, position, width, mode="strict", copy=True):
         """
@@ -641,4 +631,4 @@ class WcsNDMap(WcsMap):
         if copy:
             data = data.copy()
 
-        return WcsNDMap(geom, data, meta=self.meta, unit=self.unit), cutout_slices
+        return self.clone(geom=geom, data=data), cutout_slices

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -617,9 +617,9 @@ class WcsNDMap(WcsMap):
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
 
         copy : bool, optional
-               If False (default), then the cutout data will be a view into the original data  array. 
+               If False (default), then the cutout data will be a view into the original data  array.
                If True, then the cutout data will hold a copy of the original data array.
-        
+
         Returns
         -------
         cutout : `~gammapy.maps.WcsNDMap`


### PR DESCRIPTION
This PR introduces the `Map.clone()` method to simplify creating new maps from existing ones. This PR addresses #1547.   