### PR TITLE
Change the way of integrating the background rate in MapMaker

### DIFF
--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -126,7 +126,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max
     return WcsNDMap(ref_geom, data)
 
 
-def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max):
+def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max, n_integration_bins=1):
     """Compute background map from background IRFs.
 
     TODO: Call a method on bkg that returns integral over energy bin directly
@@ -144,6 +144,8 @@ def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max):
         Reference geometry
     offset_max : `~astropy.coordinates.Angle`
         Maximum field of view offset
+    n_integration_bins : int
+            Number of bins used to integrate on each energy range
 
     Returns
     -------
@@ -168,7 +170,7 @@ def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max):
         data_int[ie, :, :] = bkg.integrate_on_energy_range(
             fov_lon=fov_lon[0, :, :],
             fov_lat=fov_lat[0, :, :],
-            energy_range=[e_lo * energy_axis.unit, e_hi * energy_axis.unit], n_integration_bins=1)
+            energy_range=[e_lo * energy_axis.unit, e_hi * energy_axis.unit], n_integration_bins=n_integration_bins)
 
     d_omega = ref_geom.solid_angle()
     data = (data_int * d_omega * livetime).to('').value

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -83,8 +83,8 @@ def test_make_map_fov_background(bkg_3d, counts_cube):
     )
 
     assert m.data.shape == (15, 120, 200)
-    assert_allclose(m.data[0, 0, 0], 0.013759879207779322)
-    assert_allclose(m.data.sum(), 1301.0242859188463)
+    assert_allclose(m.data[0, 0, 0], 0.013959366925415072)
+    assert_allclose(m.data.sum(), 1356.2551841113177)
 
     # TODO: Check that `offset_max` is working properly
     # pos = SkyCoord(85.6, 23, unit='deg')
@@ -94,11 +94,11 @@ def test_make_map_fov_background(bkg_3d, counts_cube):
 
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("mode, expected", [("trim", 107214.0), ("strict", 53486.0)])
-def test_MapMaker(mode,expected):
+def test_MapMaker(mode, expected):
     ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
     pos_SagA = SkyCoord(266.41681663, -29.00782497, unit="deg", frame="icrs")
-    energy_axis = MapAxis.from_edges([0.1,0.5,1.5,3.0,10.],name='energy',unit='TeV',interp='log')
-    geom = WcsGeom.create(binsz=0.1*u.deg, skydir=pos_SagA, width=15.0, axes=[energy_axis])
+    energy_axis = MapAxis.from_edges([0.1, 0.5, 1.5, 3.0, 10.], name='energy', unit='TeV', interp='log')
+    geom = WcsGeom.create(binsz=0.1 * u.deg, skydir=pos_SagA, width=15.0, axes=[energy_axis])
     mmaker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
     obs = [110380, 111140]
 
@@ -112,5 +112,4 @@ def test_MapMaker(mode,expected):
     maps = maker.run(obslist)
     assert maps['exposure_map'].unit == "m2 s"
     assert_quantity_allclose(maps['counts_map'].data.sum(), expected)
-
 


### PR DESCRIPTION
- use now the new method integration of background 2D and background3D based on the trapezoidal integration.
- we saw that f we do a trapezoidal integration compare to the rectangular one, the value of the test implemented for the integration doesn't change that much

**Questions that remain:**
- How many integration steps do we put by default? For the moment this is one but it has to be changed. Do we fix it or do we let it as a parameter of the MapMaker method?
- The test is not easy to understand and thus it is not easy to see that the integration is really working. For the moment there is only a test for background3D but not background 2D in the MapMaker. This is maybe just something we have to remember to improve but I must admit that I will not have time to improve this before leaving in holiday.