### PR TITLE
Changed the default parameter for RegularGridInterpolator

### DIFF
--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -177,7 +177,7 @@ class WcsNDMap(WcsMap):
         else:
             data = self.data.T
 
-        fn = RegularGridInterpolator(grid_pix, data, fill_value=None,
+        fn = RegularGridInterpolator(grid_pix, data, fill_value=0,
                                      bounds_error=False, method=method)
         return fn(tuple(pix))
 


### PR DESCRIPTION
this avoids the strange effect to have a cross around the spatial
template. With fill_value=None, the default is to extrapolate on the
spatial template pixels values