### PR TITLE
Small modeling / XML cleanup

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -530,7 +530,7 @@ class PowerLaw(SpectralModel):
         self.parameters = ParameterList([
             Parameter('index', index),
             Parameter('amplitude', amplitude),
-            Parameter('reference', reference, parmin=0, frozen=True)
+            Parameter('reference', reference, min=0, frozen=True)
         ])
 
     @staticmethod
@@ -1152,7 +1152,7 @@ class TableModel(SpectralModel):
     def __init__(self, energy, values, scale=1, scale_logy=True, meta=None):
         from scipy.interpolate import interp1d
         self.parameters = ParameterList([
-            Parameter('scale', scale, parmin=0, unit='')
+            Parameter('scale', scale, min=0, unit='')
         ])
         self.energy = energy
         self.values = values
@@ -1519,10 +1519,10 @@ class AbsorbedSpectralModel(SpectralModel):
             param_list.append(param)
 
         # Add parameter to the list
-        param_min = self.absorption.data.axes[0].lo[0]
-        param_max = self.absorption.data.axes[0].lo[-1]
+        min_ = self.absorption.data.axes[0].lo[0]
+        max_ = self.absorption.data.axes[0].lo[-1]
         par = Parameter(parameter_name, parameter,
-                        parmin=param_min, parmax=param_max,
+                        min=min_, max=max_,
                         frozen=True)
         param_list.append(par)
 

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -83,7 +83,7 @@ def make_minuit_par_kwargs(parameters):
         kwargs[par.name] = par.value
         if par.frozen:
             kwargs['fix_{}'.format(par.name)] = True
-        limits = par.parmin, par.parmax
+        limits = par.min, par.max
         limits = np.where(np.isnan(limits), None, limits)
         kwargs['limit_{}'.format(par.name)] = limits
 

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -38,7 +38,7 @@ def test_iminuit():
     assert minuit.list_of_fixed_param() == ['x']
 
     # Test limits
-    pars_in['y'].parmin = 4
+    pars_in['y'].min = 4
     pars_out, minuit = fit_iminuit(function=f, parameters=pars_in)
     states = minuit.get_param_states()
     assert not states[0]['has_limits']

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -28,13 +28,11 @@ class Parameter(object):
     unit : str, optional
         Unit of the parameter (if value is given as float)
     parmin : float, optional
-        Parameter value minimum. Used as minimum boundary value
-        in a model fit
+        Minimum parameter value allowed in fit
     parmax : float, optional
-        Parameter value maximum. Used as minimum boundary value
-        in a model fit
+        Maximum parameter value allowed in fit
     frozen : bool, optional
-        Whether the parameter is free to be varied in a model fit
+        Is the parameter frozen in a fit?
     """
 
     def __init__(self, name, value, unit='', parmin=None, parmax=None, frozen=False):
@@ -52,8 +50,7 @@ class Parameter(object):
 
     @property
     def quantity(self):
-        retval = self.value * u.Unit(self.unit)
-        return retval
+        return self.value * u.Unit(self.unit)
 
     @quantity.setter
     def quantity(self, par):
@@ -64,16 +61,17 @@ class Parameter(object):
     def __str__(self):
         ss = 'Parameter(name={name!r}, value={value!r}, unit={unit!r}, '
         ss += 'min={parmin!r}, max={parmax!r}, frozen={frozen!r})'
-
         return ss.format(**self.__dict__)
 
     def to_dict(self):
-        return dict(name=self.name,
-                    value=float(self.value),
-                    unit=str(self.unit),
-                    frozen=self.frozen,
-                    min=float(self.parmin),
-                    max=float(self.parmax))
+        return dict(
+            name=self.name,
+            value=float(self.value),
+            unit=str(self.unit),
+            min=float(self.parmin),
+            max=float(self.parmax),
+            frozen=self.frozen,
+        )
 
     def to_sherpa(self, modelname='Default'):
         """Convert to sherpa parameter"""
@@ -99,8 +97,8 @@ class ParameterList(object):
     parameters : list of `Parameter`
         List of parameters
     covariance : `~numpy.ndarray`
-        Parameters covariance matrix. Order of values as specified by
-        `parameters`.
+        Parameters covariance matrix.
+        Order of values as specified by `parameters`.
     """
 
     def __init__(self, parameters, covariance=None):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -27,15 +27,15 @@ class Parameter(object):
         Value of the parameter
     unit : str, optional
         Unit of the parameter (if value is given as float)
-    parmin : float, optional
+    min : float, optional
         Minimum parameter value allowed in fit
-    parmax : float, optional
+    max : float, optional
         Maximum parameter value allowed in fit
     frozen : bool, optional
         Is the parameter frozen in a fit?
     """
 
-    def __init__(self, name, value, unit='', parmin=None, parmax=None, frozen=False):
+    def __init__(self, name, value, unit='', min=None, max=None, frozen=False):
         self.name = name
 
         if isinstance(value, u.Quantity) or isinstance(value, six.string_types):
@@ -44,8 +44,8 @@ class Parameter(object):
             self.value = value
             self.unit = unit
 
-        self.parmin = parmin or np.nan
-        self.parmax = parmax or np.nan
+        self.min = min or np.nan
+        self.max = max or np.nan
         self.frozen = frozen
 
     @property
@@ -58,9 +58,9 @@ class Parameter(object):
         self.value = par.value
         self.unit = str(par.unit)
 
-    def __str__(self):
+    def __repr__(self):
         ss = 'Parameter(name={name!r}, value={value!r}, unit={unit!r}, '
-        ss += 'min={parmin!r}, max={parmax!r}, frozen={frozen!r})'
+        ss += 'min={min!r}, max={max!r}, frozen={frozen!r})'
         return ss.format(**self.__dict__)
 
     def to_dict(self):
@@ -68,8 +68,8 @@ class Parameter(object):
             name=self.name,
             value=float(self.value),
             unit=str(self.unit),
-            min=float(self.parmin),
-            max=float(self.parmax),
+            min=float(self.min),
+            max=float(self.max),
             frozen=self.frozen,
         )
 
@@ -77,12 +77,12 @@ class Parameter(object):
         """Convert to sherpa parameter"""
         from sherpa.models import Parameter
 
-        parmin = np.finfo(np.float32).min if np.isnan(self.parmin) else self.parmin
-        parmax = np.finfo(np.float32).max if np.isnan(self.parmax) else self.parmax
+        min_ = np.finfo(np.float32).min if np.isnan(self.min) else self.min
+        max_ = np.finfo(np.float32).max if np.isnan(self.max) else self.max
 
         par = Parameter(modelname=modelname, name=self.name,
                         val=self.value, units=self.unit,
-                        min=parmin, max=parmax,
+                        min=min_, max=max_,
                         frozen=self.frozen)
         return par
 
@@ -161,8 +161,8 @@ class ParameterList(object):
             pars.append(Parameter(name=par['name'],
                                   value=float(par['value']),
                                   unit=par['unit'],
-                                  parmin=float(par['min']),
-                                  parmax=float(par['max']),
+                                  min=float(par['min']),
+                                  max=float(par['max']),
                                   frozen=par['frozen']))
             try:
                 covariance = np.array(val['covariance'])

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -28,20 +28,20 @@ def test_complex():
     pars1 = model1.parameters
     assert pars1['index'].value == 2.1
     assert pars1['index'].unit == ''
-    assert pars1['index'].parmax is None
-    assert pars1['index'].parmin is None
+    assert pars1['index'].max is None
+    assert pars1['index'].min is None
     assert pars1['index'].frozen is False
 
     assert pars1['lon_0'].value == 0.5
     assert pars1['lon_0'].unit == 'deg'
-    assert pars1['lon_0'].parmax == 360
-    assert pars1['lon_0'].parmin == -360
+    assert pars1['lon_0'].max == 360
+    assert pars1['lon_0'].min == -360
     assert pars1['lon_0'].frozen is True
 
     assert pars1['lat_0'].value == 1.0
     assert pars1['lat_0'].unit == 'deg'
-    assert pars1['lat_0'].parmax == 90
-    assert pars1['lat_0'].parmin == -90
+    assert pars1['lat_0'].max == 90
+    assert pars1['lat_0'].min == -90
     assert pars1['lat_0'].frozen is True
 
     model2 = sourcelib.skymodels[2]
@@ -52,12 +52,12 @@ def test_complex():
     assert pars2['sigma'].unit == 'deg'
     assert pars2['lambda_'].value == 0.01
     assert pars2['lambda_'].unit == 'MeV-1'
-    assert pars2['lambda_'].parmin is None
-    assert pars2['lambda_'].parmax is None
+    assert pars2['lambda_'].min is None
+    assert pars2['lambda_'].max is None
     assert pars2['index'].value == 2.2
     assert pars2['index'].unit == ''
-    assert pars2['index'].parmax is None
-    assert pars2['index'].parmin is None
+    assert pars2['index'].max is None
+    assert pars2['index'].min is None
 
     model3 = sourcelib.skymodels[3]
     assert isinstance(model3.spatial_model, spatial.SkyDisk)

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -139,15 +139,11 @@ model_registry['spectral']['Constant'] = model_registry['spectral']['ConstantVal
 
 
 class UnknownModelError(ValueError):
-    """
-    Error when encountering unknown model types.
-    """
+    """Error when encountering unknown models."""
 
 
 class UnknownParameterError(ValueError):
-    """
-    Error when encountering unknown model types.
-    """
+    """Error when encountering unknown parameters."""
 
 
 def xml_to_source_library(xml):
@@ -218,16 +214,16 @@ def xml_to_model(xml, which):
         # one to the gammapy model definition
         if type_ == 'PowerLaw':
             model.parameters['index'].value *= -1
-            model.parameters['index'].parmin = None
-            model.parameters['index'].parmax = None
+            model.parameters['index'].min = None
+            model.parameters['index'].max = None
         if type_ == 'ExponentialCutoffPowerLaw':
             model.parameters['lambda_'].value = 1 / model.parameters['lambda_'].value
             model.parameters['lambda_'].unit = model.parameters['lambda_'].unit + '-1'
-            model.parameters['lambda_'].parmin = None
-            model.parameters['lambda_'].parmax = None
+            model.parameters['lambda_'].min = None
+            model.parameters['lambda_'].max = None
             model.parameters['index'].value *= -1
-            model.parameters['index'].parmin = None
-            model.parameters['index'].parmax = None
+            model.parameters['index'].min = None
+            model.parameters['index'].max = None
     return model
 
 
@@ -246,16 +242,16 @@ def xml_to_parameter_list(xml, which, type_):
             raise UnknownParameterError(msg.format(par['@name'], which, type_))
 
         value = float(par['@value']) * float(par['@scale'])
-        parmin = float(par['@min']) if '@min' in par.keys() else None
-        parmax = float(par['@max']) if '@max' in par.keys() else None
+        min_ = float(par['@min']) if '@min' in par.keys() else None
+        max_ = float(par['@max']) if '@max' in par.keys() else None
         frozen = bool(1 - int(par['@free']))
 
         parameters.append(Parameter(
             name=name,
             value=value,
             unit=unit,
-            parmin=parmin,
-            parmax=parmax,
+            min=min_,
+            max=max_,
             frozen=frozen,
         ))
 
@@ -340,11 +336,9 @@ def parameter_list_to_xml(parameters, which):
             raise UnknownParameterError(msg)
 
         xml += indent
-        xml += val.format(int(not par.frozen),
-                          par.parmax,
-                          par.parmin,
-                          xml_par,
-                          par.quantity.to(unit).value)
+        free = int(not par.frozen)
+        value = par.quantity.to(unit).value
+        xml += val.format(free, par.max, par.min, xml_par, value)
         xml += '\n'
 
     return xml

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -8,17 +8,15 @@ For XML model format definitions, see here:
 * http://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+import logging
+import numpy as np
+import astropy.units as u
 from ...extern import xmltodict
-from ...cube.models import SourceLibrary, SkyModel
 from ..modeling import Parameter, ParameterList
 from ...maps import Map
-import numpy as np
-import logging
-import astropy.units as u
-import gammapy.image.models as spatial
-import gammapy.spectrum.models as spectral
-from astropy.coordinates import SkyCoord
-import astropy.units as u
+from ...image import models as spatial
+from ...spectrum import models as spectral
+from ...cube.models import SourceLibrary, SkyModel
 
 log = logging.getLogger(__name__)
 
@@ -247,10 +245,10 @@ def xml_to_parameter_list(xml, which, type_):
             msg = "Parameter '{}' not registered for {} model {}"
             raise UnknownParameterError(msg.format(par['@name'], which, type_))
 
-        value = float(par['@value']) * float(par['@scale']) 
+        value = float(par['@value']) * float(par['@scale'])
         parmin = float(par['@min']) if '@min' in par.keys() else None
         parmax = float(par['@max']) if '@max' in par.keys() else None
-        frozen=bool(1 - int(par['@free']))
+        frozen = bool(1 - int(par['@free']))
 
         parameters.append(Parameter(
             name=name,

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -10,6 +10,6 @@ def test_parameter():
     assert par.name == 'spam'
     assert par.value == 42
     assert par.unit == 'deg'
-    assert par.parmin is np.nan
-    assert par.parmax is np.nan
+    assert par.min is np.nan
+    assert par.max is np.nan
     assert par.frozen is False

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -1,49 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing import assert_allclose
-from ..testing import requires_data
-from ..modeling import Parameter
 import pytest
+import numpy as np
+from ..modeling import Parameter
 
 
-@pytest.mark.xfail(reason='to XML need to be rewritten')
 def test_parameter():
-    data = dict(name='spam', val=99., unit='ham')
-    par = Parameter.from_dict(data)
-    xml = par.to_xml()
-    assert xml == '        <parameter name="spam" value="99.0" unit="ham"/>'
-
-
-@pytest.mark.xfail(reason='XML serialization currently rewritten')
-@requires_data('gammapy-extra')
-def test_source_library_old_xml_file():
-    filename = '$GAMMAPY_EXTRA/test_datasets/models/shell.xml'
-    sources = SourceLibrary.read(filename)
-
-    assert len(sources.source_list) == 2
-
-    source = sources.source_list[0]
-    assert source.source_name == 'CrabShell'
-    assert_allclose(source.spectral_model.parameters['Index'].value, 2.48)
-
-    xml = sources.to_xml()
-    assert 'sources' in xml
-
-
-@pytest.mark.xfail(reason='XML serialization currently rewritten')
-@requires_data('gammapy-extra')
-def test_source_library_new_xml_file():
-    filename = '$GAMMAPY_EXTRA/test_datasets/models/ctadc_skymodel_gps_sources_bright.xml'
-    sources = SourceLibrary.read(filename)
-
-    assert len(sources.source_list) == 47
-
-    source = sources.source_list[0]
-    assert source.source_name == 'HESS J0632+057'
-    assert_allclose(source.spectral_model.parameters['Index'].value, -2.5299999713897705)
-
-    xml = sources.to_xml()
-    assert 'sources' in xml
-
-    # TODO: add more asserts for other spectral & spatial models
-    # (or split those out into separate XML strings or files for better unit testing)
+    par = Parameter('spam', 42, 'deg')
+    assert par.name == 'spam'
+    assert par.value == 42
+    assert par.unit == 'deg'
+    assert par.parmin is np.nan
+    assert par.parmax is np.nan
+    assert par.frozen is False


### PR DESCRIPTION
This PR changes the Parameter attributes `parmin` and `parmax` to `min` and `max`.
It's shorter, and both Astropy and Sherpa and others use those attribute name on the Parameter class.

I also moved the XML I/O tests to the right place.

I wanted to fix those, but the XML serialisation isn't so easy to fix.
Writing is completely broken, and most of the read tests are `xfail`.