### PR TITLE
Resolving issue  #1459

### DIFF
--- a/gammapy/cube/new.py
+++ b/gammapy/cube/new.py
@@ -330,9 +330,9 @@ class MapMaker(object):
             self._add_cutouts(cs, count, exp, back)
 
         maps = {
-            'counts': self.counts_map,
-            'background': self.background_map,
-            'exposure': self.exposure_map
+            'counts_map': self.counts_map,
+            'background_map': self.background_map,
+            'exposure_map': self.exposure_map
                 }
         return maps
 


### PR DESCRIPTION
This PR is to address issue  #1459.
I have also added a new function `create_list()` which will process a list of observations and return lists of counts, background and exposure maps.
I think this is useful when the user wants to analyse each run individually (or maybe do some grouping later...)

I guess that the names `run` and `create_list` may not be very nice.
Shall change them if required.

I still have a function`process_obs` to keep compatibility with the old `MapMaker`. Maybe this can be removed in the later versions?

@mackaiver : Do you like the present implementation?

There will be some merge conflicts with @leajouvin PR #1558 , so @cdeil and @registerrier , please merge either one so that the other can be edited...