### PR TITLE
SkyModel parameter sync with components

### DIFF
--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -188,15 +188,14 @@ class TestSourceCatalogObjectHGPS:
     @staticmethod
     def test_sky_model_gaussian2(cat):
         model = cat['HESS J1843-033'].sky_model
-        p = model.parameters
 
-        p = model[0].parameters
+        p = model.components[0].parameters
         assert_allclose(p['amplitude'].value, 1.343344814726255e-12)
         assert_allclose(p['lon_0'].value, 29.047216415405273)
         assert_allclose(p['lat_0'].value, 0.24389676749706268)
         assert_allclose(p['sigma'].value, 0.12499100714921951)
 
-        p = model[1].parameters
+        p = model.components[1].parameters
         assert_allclose(p['amplitude'].value, 1.5390372353277226e-12)
         assert_allclose(p['lon_0'].value, 28.77037811279297)
         assert_allclose(p['lat_0'].value, -0.0727819949388504)
@@ -209,9 +208,9 @@ class TestSourceCatalogObjectHGPS:
     @staticmethod
     def test_sky_model_gaussian3(cat):
         model = cat['HESS J1825-137'].sky_model
-        assert_allclose(model[0].parameters['amplitude'].value, 5.022436459778401e-12)
-        assert_allclose(model[1].parameters['amplitude'].value, 1.1829840926291801e-11)
-        assert_allclose(model[2].parameters['amplitude'].value, 1.5557788347539403e-12)
+        assert_allclose(model.components[0].parameters['amplitude'].value, 5.022436459778401e-12)
+        assert_allclose(model.components[1].parameters['amplitude'].value, 1.1829840926291801e-11)
+        assert_allclose(model.components[2].parameters['amplitude'].value, 1.5557788347539403e-12)
 
     @staticmethod
     def test_sky_model_gaussian_extern(cat):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -96,4 +96,5 @@ class MapFit(object):
         parameters, minuit = fit_iminuit(parameters=self.model.parameters,
                                          function=self.total_stat,
                                          opts_minuit=opts_minuit)
+        self.model.parameters = parameters
         self._minuit = minuit

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -103,10 +103,6 @@ class SkyModel(object):
         self._spatial_model = spatial_model
         self._spectral_model = spectral_model
         self.name = name
-        self._parameters = ParameterList(
-            self.spatial_model.parameters.parameters +
-            self.spectral_model.parameters.parameters
-        )
 
     @property
     def spatial_model(self):
@@ -121,7 +117,10 @@ class SkyModel(object):
     @property
     def parameters(self):
         """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
-        return self._parameters
+        return ParameterList(
+            self.spatial_model.parameters.parameters +
+            self.spectral_model.parameters.parameters
+        )
 
     @parameters.setter
     def parameters(self, parameters):
@@ -267,6 +266,14 @@ class SumSkyModel(object):
             for p in model.parameters.parameters:
                 pars.append(p)
         return ParameterList(pars)
+
+    @parameters.setter
+    def parameters(self, parameters):
+        idx = 0
+        for component in self.components:
+            n_par = len(component.parameters.parameters)
+            component.parameters.parameters = parameters.parameters[idx:idx+n_par]
+            idx += n_par
 
     def evaluate(self, lon, lat, energy):
         out = self.components[0].evaluate(lon, lat, energy)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ...irf import EffectiveAreaTable2D, EnergyDependentMultiGaussPSF
 from ...irf.energy_dispersion import EnergyDispersion
@@ -129,15 +128,15 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
     )
     fit.fit()
 
-    assert_quantity_allclose(fit.model.parameters['index'].quantity,
-                             sky_model.parameters['index'].quantity,
-                             rtol=1e-2)
-    assert_quantity_allclose(fit.model.parameters['amplitude'].quantity,
-                             sky_model.parameters['amplitude'].quantity,
-                             rtol=1e-2)
-    assert_quantity_allclose(fit.model.parameters['lon_0'].quantity,
-                             sky_model.parameters['lon_0'].quantity,
-                             rtol=1e-2)
+    assert_allclose(fit.model.parameters['index'].value,
+                    sky_model.parameters['index'].value,
+                    rtol=1e-2)
+    assert_allclose(fit.model.parameters['amplitude'].value,
+                    sky_model.parameters['amplitude'].value,
+                    rtol=1e-2)
+    assert_allclose(fit.model.parameters['lon_0'].value,
+                    sky_model.parameters['lon_0'].value,
+                    rtol=1e-2)
 
     stat = np.sum(fit.stat, dtype='float64')
     stat_expected = 3840.0605649268496

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -142,6 +142,11 @@ class TestCompoundSkyModel:
         # Check that model parameters are references to the parts
         assert compound_model.parameters['lon_0'] is compound_model.model1.parameters['lon_0']
 
+        # Check that parameter assignment works
+        assert compound_model.parameters.parameters[-1].value == 1
+        compound_model.parameters = compound_model.parameters.copy()
+        assert compound_model.parameters.parameters[-1].value == 1
+
     @staticmethod
     def test_evaluate(compound_model):
         lon = 3 * u.deg * np.ones(shape=(3, 4))
@@ -169,6 +174,11 @@ class TestSumSkyModel:
 
         # Check that model parameters are references to the parts
         assert sum_model.parameters['lon_0'] is sum_model.components[0].parameters['lon_0']
+
+        # Check that parameter assignment works
+        assert sum_model.parameters.parameters[-1].value == 1
+        sum_model.parameters = sum_model.parameters.copy()
+        assert sum_model.parameters.parameters[-1].value == 1
 
     @staticmethod
     def test_evaluate(sum_model):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -12,9 +12,10 @@ from ...image.models import SkyGaussian
 from ...spectrum.models import PowerLaw
 from ..models import (
     SkyModel,
-    MapEvaluator,
     SourceLibrary,
     CompoundSkyModel,
+    SumSkyModel,
+    MapEvaluator,
 )
 
 
@@ -71,8 +72,20 @@ class TestSourceLibrary:
         self.source_library = SourceLibrary([sky_model(), sky_model()])
 
     def test_to_compound_model(self):
-        compound = self.source_library.to_compound_model()
-        assert isinstance(compound, CompoundSkyModel)
+        model = self.source_library.to_compound_model()
+        assert isinstance(model, CompoundSkyModel)
+        pars = model.parameters.parameters
+        assert len(pars) == 12
+        assert pars[0].name == 'lon_0'
+        assert pars[-1].name == 'reference'
+
+    def test_to_sum_model(self):
+        model = self.source_library.to_sum_model()
+        assert isinstance(model, SumSkyModel)
+        pars = model.parameters.parameters
+        assert len(pars) == 12
+        assert pars[0].name == 'lon_0'
+        assert pars[-1].name == 'reference'
 
 
 class TestSkyModel:
@@ -86,9 +99,7 @@ class TestSkyModel:
 
     @staticmethod
     def test_parameters(sky_model):
-        # Check that the total model parameters are references
-        # to the spatial and spectral parameters, not copies
-        # see https://github.com/gammapy/gammapy/issues/1556
+        # Check that model parameters are references to the spatial and spectral parts
         assert sky_model.parameters['lon_0'] is sky_model.spatial_model.parameters['lon_0']
         assert sky_model.parameters['amplitude'] is sky_model.spectral_model.parameters['amplitude']
 
@@ -119,17 +130,55 @@ class TestSkyModel:
 class TestCompoundSkyModel:
 
     @staticmethod
-    def test_add(sky_model):
-        compound_model = sky_model + sky_model
+    @pytest.fixture()
+    def compound_model(sky_model):
+        return sky_model + sky_model
+
+    @staticmethod
+    def test_parameters(compound_model):
         parnames = ['lon_0', 'lat_0', 'sigma', 'index', 'amplitude', 'reference'] * 2
         assert compound_model.parameters.names == parnames
 
+        # Check that model parameters are references to the parts
+        assert compound_model.parameters['lon_0'] is compound_model.model1.parameters['lon_0']
+
+    @staticmethod
+    def test_evaluate(compound_model):
         lon = 3 * u.deg * np.ones(shape=(3, 4))
         lat = 4 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
 
         q = compound_model.evaluate(lon, lat, energy)
 
+        assert q.unit == 'cm-2 s-1 TeV-1 deg-2'
+        assert q.shape == (5, 3, 4)
+        assert_allclose(q.value, 3.536776513153229e-13)
+
+
+class TestSumSkyModel:
+
+    @staticmethod
+    @pytest.fixture()
+    def sum_model(sky_model):
+        return SumSkyModel([sky_model, sky_model])
+
+    @staticmethod
+    def test_parameters(sum_model):
+        parnames = ['lon_0', 'lat_0', 'sigma', 'index', 'amplitude', 'reference'] * 2
+        assert sum_model.parameters.names == parnames
+
+        # Check that model parameters are references to the parts
+        assert sum_model.parameters['lon_0'] is sum_model.components[0].parameters['lon_0']
+
+    @staticmethod
+    def test_evaluate(sum_model):
+        lon = 3 * u.deg * np.ones(shape=(3, 4))
+        lat = 4 * u.deg * np.ones(shape=(3, 4))
+        energy = [1, 1, 1, 1, 1] * u.TeV
+
+        q = sum_model.evaluate(lon, lat, energy)
+
+        assert q.unit == 'cm-2 s-1 TeV-1 deg-2'
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value, 3.536776513153229e-13)
 
@@ -190,7 +239,6 @@ class TestSkyModelMapEvaluator:
         assert out.shape == (2, 4, 5)
         assert out.unit == 'cm-2 s-1'
         assert_allclose(out.value.mean(), 1.828206748668197e-14)
-
 
     @staticmethod
     def test_apply_psf(evaluator):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -85,6 +85,14 @@ class TestSkyModel:
         assert 'SkyModel' in str(sky_model)
 
     @staticmethod
+    def test_parameters(sky_model):
+        # Check that the total model parameters are references
+        # to the spatial and spectral parameters, not copies
+        # see https://github.com/gammapy/gammapy/issues/1556
+        assert sky_model.parameters['lon_0'] is sky_model.spatial_model.parameters['lon_0']
+        assert sky_model.parameters['amplitude'] is sky_model.spectral_model.parameters['amplitude']
+
+    @staticmethod
     def test_evaluate_scalar(sky_model):
         lon = 3 * u.deg
         lat = 4 * u.deg

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -13,11 +13,6 @@ __all__ = [
 def fit_iminuit(parameters, function, opts_minuit=None):
     """iminuit optimization
 
-    The input `~gammapy.utils.modeling.ParameterList` is copied internally
-    before the fit and will thus not be modified. The best-fit parameter values
-    are contained in the output `~gammapy.utils.modeling.ParameterList` or the
-    `~iminuit.Minuit` object.
-
     Parameters
     ----------
     parameters : `~gammapy.utils.modeling.ParameterList`
@@ -36,7 +31,6 @@ def fit_iminuit(parameters, function, opts_minuit=None):
     """
     from iminuit import Minuit
 
-    parameters = parameters.copy()
     minuit_func = MinuitFunction(function, parameters)
 
     if opts_minuit is None:
@@ -48,6 +42,7 @@ def fit_iminuit(parameters, function, opts_minuit=None):
                     **opts_minuit)
 
     minuit.migrad()
+
     return parameters, minuit
 
 
@@ -66,11 +61,10 @@ class MinuitFunction(object):
         self.function = function
         self.parameters = parameters
 
-    def fcn(self, *p):
-        for parval, par in zip(p, self.parameters.parameters):
-            par.value = parval
-        val = self.function(self.parameters)
-        return val
+    def fcn(self, *values):
+        for value, parameter in zip(values, self.parameters.parameters):
+            parameter.value = value
+        return self.function(self.parameters)
 
 
 def make_minuit_par_kwargs(parameters):
@@ -78,7 +72,7 @@ def make_minuit_par_kwargs(parameters):
 
     See: http://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit
     """
-    kwargs = dict()
+    kwargs = {}
     for par in parameters.parameters:
         kwargs[par.name] = par.value
         if par.frozen:

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -20,9 +20,8 @@ def test_iminuit():
 
     pars_out, minuit = fit_iminuit(function=f, parameters=pars_in)
 
-    assert_allclose(pars_in['x'].value, 2.1, rtol=1e-2)
-    assert_allclose(pars_in['y'].value, 3.1, rtol=1e-2)
-    assert_allclose(pars_in['z'].value, 4.1, rtol=1e-2)
+    # Input and output parameters are the same objects
+    assert pars_in['x'] is pars_out['x']
 
     assert_allclose(pars_out['x'].value, 2, rtol=1e-2)
     assert_allclose(pars_out['y'].value, 3, rtol=1e-2)


### PR DESCRIPTION
I tried to update [analysis_3d.ipynb](https://github.com/gammapy/gammapy-extra/blob/master/notebooks/analysis_3d.ipynb) just now to add a `SkyModel` fit, and noticed a few issues.

There doesn't seem to be a way to get a `SkyModel` with fitted parameters back, e.g. `print(fit.model)` shows the start values even though the fit ran and `fit.model.parameters` actually contains the result.

The core of the problem is that `SkyModel` makes a new `ParameterList` that is not synced with the one from the components.
Minimal example:
```
from gammapy.image.models import SkyGaussian
from gammapy.spectrum.models import PowerLaw
from gammapy.cube.models import SkyModel
spatial_model = SkyGaussian(lon_0='0 deg', lat_0='0 deg', sigma='1 deg')
spectral_model = PowerLaw()
model = SkyModel(spatial_model, spectral_model)
model.spatial_model.parameters.parameters[0].value = 42
print(model.parameters['lon_0'])  # changed value: 42 deg
print(model.spatial_model.parameters['lon_0']) # initial value: 0 deg
```

There's also doesn't seem to be an API yet on `ParameterList` to set parameter values, one has to reach into the `parameter_list.parameters` internals:
https://github.com/gammapy/gammapy/blob/142ad8496675964bdf21f1d66d333c9b0d94e444/gammapy/utils/fitting/iminuit.py#L70

I will try to make this better today and in the next days, but @joleroi or @adonath - if you have time to help and pair-code on this with me, it would be very helpful.