### PR TITLE
Improve modeling parameter handling

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -100,9 +100,13 @@ class SkyModel(object):
     """
 
     def __init__(self, spatial_model, spectral_model, name='SkyModel'):
+        self.name = name
         self._spatial_model = spatial_model
         self._spectral_model = spectral_model
-        self.name = name
+        self._parameters = ParameterList(
+            spatial_model.parameters.parameters +
+            spectral_model.parameters.parameters
+        )
 
     @property
     def spatial_model(self):
@@ -117,10 +121,7 @@ class SkyModel(object):
     @property
     def parameters(self):
         """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
-        return ParameterList(
-            self.spatial_model.parameters.parameters +
-            self.spectral_model.parameters.parameters
-        )
+        return self._parameters
 
     @parameters.setter
     def parameters(self, parameters):
@@ -254,6 +255,11 @@ class SumSkyModel(object):
 
     def __init__(self, components):
         self.components = components
+        pars = []
+        for model in self.components:
+            for p in model.parameters.parameters:
+                pars.append(p)
+        self._parameters = ParameterList(pars)
 
     @property
     def parameters(self):
@@ -261,11 +267,7 @@ class SumSkyModel(object):
 
         Currently no way to distinguish spectral and spatial.
         """
-        pars = []
-        for model in self.components:
-            for p in model.parameters.parameters:
-                pars.append(p)
-        return ParameterList(pars)
+        return self._parameters
 
     @parameters.setter
     def parameters(self, parameters):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -21,24 +21,6 @@ from .. import (
 
 
 @pytest.fixture(scope='session')
-def sky_model():
-    spatial_model = SkyGaussian(
-        lon_0='0.2 deg',
-        lat_0='0.1 deg',
-        sigma='0.2 deg',
-    )
-    spectral_model = PowerLaw(
-        index=3,
-        amplitude='1e-11 cm-2 s-1 TeV-1',
-        reference='1 TeV',
-    )
-    return SkyModel(
-        spatial_model=spatial_model,
-        spectral_model=spectral_model,
-    )
-
-
-@pytest.fixture(scope='session')
 def geom():
     axis = MapAxis.from_edges(np.logspace(-1., 1., 3), name="energy", unit=u.TeV)
     return WcsGeom.create(skydir=(0, 0), binsz=0.02, width=(2, 2),
@@ -89,15 +71,38 @@ def psf(geom):
     return psf_kernel
 
 
-@pytest.fixture(scope='session')
-def counts(sky_model, exposure, psf, edisp):
+@pytest.fixture
+def sky_model():
+    spatial_model = SkyGaussian(
+        lon_0='0.2 deg',
+        lat_0='0.1 deg',
+        sigma='0.2 deg',
+    )
+    spectral_model = PowerLaw(
+        index=3,
+        amplitude='1e-11 cm-2 s-1 TeV-1',
+        reference='1 TeV',
+    )
+    return SkyModel(
+        spatial_model=spatial_model,
+        spectral_model=spectral_model,
+    )
+
+
+@pytest.fixture
+def counts(sky_model, exposure, background, psf, edisp):
     evaluator = MapEvaluator(
         sky_model=sky_model,
         exposure=exposure,
+        background=background,
         psf=psf,
         edisp=edisp,
     )
     npred = evaluator.compute_npred()
+    # PSF kernel apply with FFT convolve did give negative npred previously
+    # TODO: resolve this somehow
+    assert np.min(npred) >= 0
+
     return WcsNDMap(exposure.geom, npred)
 
 
@@ -105,38 +110,41 @@ def counts(sky_model, exposure, psf, edisp):
 @requires_dependency('iminuit')
 @requires_data('gammapy-extra')
 def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
-    input_model = sky_model.copy()
+    sky_model.parameters['lon_0'].value = 0.5
+    sky_model.parameters['lat_0'].value = 0.5
+    sky_model.parameters['index'].value = 2
+    sky_model.parameters['sigma'].frozen = True
 
-    input_model.parameters['lon_0'].value = 0.5
-    input_model.parameters['index'].value = 2
-    input_model.parameters['lat_0'].value = 0.5
-    input_model.parameters['sigma'].frozen = True
-
-    input_model.parameters.set_parameter_errors({
-        'lon_0': '0.1 deg',
-        'index': '0.1',
-        'amplitude': '1e-12 cm-2 s-1 TeV-1',
+    sky_model.parameters.set_parameter_errors({
+        'lon_0': '0.01 deg',
+        'lat_0': '0.01 deg',
+        'sigma': '0.02 deg',
+        'index': 0.1,
+        'amplitude': '1e-13 cm-2 s-1 TeV-1',
     })
 
     fit = MapFit(
-        model=input_model,
+        model=sky_model,
         counts=counts,
         exposure=exposure,
-        psf=psf,
         background=background,
+        psf=psf,
         edisp=edisp,
     )
     fit.fit()
+    pars = fit.model.parameters
 
-    assert_allclose(fit.model.parameters['index'].value,
-                    sky_model.parameters['index'].value,
-                    rtol=1e-2)
-    assert_allclose(fit.model.parameters['amplitude'].value,
-                    sky_model.parameters['amplitude'].value,
-                    rtol=1e-2)
-    assert_allclose(fit.model.parameters['lon_0'].value,
-                    sky_model.parameters['lon_0'].value,
-                    rtol=1e-2)
+    assert sky_model.parameters['lon_0'] is fit.model.parameters['lon_0']
+    assert sky_model.parameters['lon_0'] is sky_model.spatial_model.parameters['lon_0']
+
+    assert_allclose(pars['lon_0'].value, 0.2, rtol=1e-2)
+    assert_allclose(pars.error('lon_0'), 0.005895, rtol=1e-2)
+
+    assert_allclose(pars['index'].value, 3, rtol=1e-2)
+    assert_allclose(pars.error('index'), 0.05614, rtol=1e-2)
+
+    assert_allclose(pars['amplitude'].value, 1e-11, rtol=1e-2)
+    assert_allclose(pars.error('amplitude'), 3.936e-13, rtol=1e-2)
 
     stat = np.sum(fit.stat, dtype='float64')
     stat_expected = 3840.0605649268496

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -99,10 +99,6 @@ def counts(sky_model, exposure, background, psf, edisp):
         edisp=edisp,
     )
     npred = evaluator.compute_npred()
-    # PSF kernel apply with FFT convolve did give negative npred previously
-    # TODO: resolve this somehow
-    assert np.min(npred) >= 0
-
     return WcsNDMap(exposure.geom, npred)
 
 

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -55,17 +55,14 @@ class MeyerCrabModel(SpectralModel):
 
     See 2010A%26A...523A...2M, Appendix D.
     """
+    coefficients = np.array([-0.00449161, 0, 0.0473174, -0.179475, -0.53616, -10.2708])
 
     def __init__(self):
-        coefficients = np.array([-0.00449161, 0, 0.0473174, -0.179475,
-                                 -0.53616, -10.2708])
-        self.parameters = ParameterList([
-            Parameter('coefficients', coefficients)
-        ])
+        self.parameters = ParameterList([])
 
     @staticmethod
-    def evaluate(energy, coefficients):
-        polynomial = np.poly1d(coefficients)
+    def evaluate(energy):
+        polynomial = np.poly1d(MeyerCrabModel.coefficients)
         log_energy = np.log10(energy.to('TeV').value)
         log_flux = polynomial(log_energy)
         flux = np.power(10, log_flux) * u.Unit('erg / (cm2 s)')

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -232,9 +232,7 @@ class TestSpectralFit:
                                  2.0082864582748925e-7 * u.Unit('m-2 s-1 TeV-1'),
                                  rtol=1e-2)
         assert_allclose(result.npred_src[60], 0.5642179482961884)
-
-        with pytest.raises(ValueError):
-            self.fit.result[0].to_table()
+        self.fit.result[0].to_table()
 
     def test_basic_errors(self):
         self.fit.fit()

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -77,9 +77,9 @@ def make_minuit_par_kwargs(parameters):
         kwargs[par.name] = par.value
         if par.frozen:
             kwargs['fix_{}'.format(par.name)] = True
-        limits = par.min, par.max
-        limits = np.where(np.isnan(limits), None, limits)
-        kwargs['limit_{}'.format(par.name)] = limits
+        min_ = None if np.isnan(par.min) else par.min
+        max_ = None if np.isnan(par.max) else par.max
+        kwargs['limit_{}'.format(par.name)] = (min_, max_)
 
         if parameters.covariance is not None:
             err = parameters.error(par.name)

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -99,9 +99,10 @@ def _get_covar(minuit):
     but we still want to support v1.2
     """
     n = len(minuit.parameters)
-    m = np.empty((n, n))
+    m = np.zeros((n, n))
     print(minuit.covariance)
     for i1, k1 in enumerate(minuit.parameters):
         for i2, k2 in enumerate(minuit.parameters):
-            m[i1, i2] = minuit.covariance[(k1, k2)]
+            if set([k1, k2]).issubset(minuit.list_of_vary_param()):
+                m[i1, i2] = minuit.covariance[(k1, k2)]
     return m

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 
-
 __all__ = [
     'fit_iminuit',
 ]
@@ -42,6 +41,7 @@ def fit_iminuit(parameters, function, opts_minuit=None):
                     **opts_minuit)
 
     minuit.migrad()
+    parameters.covariance = _get_covar(minuit)
 
     return parameters, minuit
 
@@ -81,12 +81,27 @@ def make_minuit_par_kwargs(parameters):
         max_ = None if np.isnan(par.max) else par.max
         kwargs['limit_{}'.format(par.name)] = (min_, max_)
 
-        if parameters.covariance is not None:
-            err = parameters.error(par.name)
-            if err != '0':
-                kwargs['error_{}'.format(par.name)] = err
+        if parameters.covariance is None:
+            kwargs['error_{}'.format(par.name)] = 1
+        else:
+            kwargs['error_{}'.format(par.name)] = parameters.error(par.name)
 
         # TODO: Check if we need 0.5 or 1
         kwargs['errordef'] = 1
 
     return kwargs
+
+
+def _get_covar(minuit):
+    """Get full covar matrix as Numpy array.
+
+    This was added as `minuit.np_covariance` in `iminuit` in v1.3,
+    but we still want to support v1.2
+    """
+    n = len(minuit.parameters)
+    m = np.empty((n, n))
+    print(minuit.covariance)
+    for i1, k1 in enumerate(minuit.parameters):
+        for i2, k2 in enumerate(minuit.parameters):
+            m[i1, i2] = minuit.covariance[(k1, k2)]
+    return m

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -6,19 +6,20 @@ from ...testing import requires_dependency
 from .. import fit_iminuit
 
 
+def fcn(parameters):
+    x = parameters['x'].value
+    y = parameters['y'].value
+    z = parameters['z'].value
+    return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
+
+
 @requires_dependency('iminuit')
 def test_iminuit():
-    def f(parameters):
-        x = parameters['x'].value
-        y = parameters['y'].value
-        z = parameters['z'].value
-        return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
-
     pars_in = ParameterList(
         [Parameter('x', 2.1), Parameter('y', 3.1), Parameter('z', 4.1)]
     )
 
-    pars_out, minuit = fit_iminuit(function=f, parameters=pars_in)
+    pars_out, minuit = fit_iminuit(function=fcn, parameters=pars_in)
 
     # Input and output parameters are the same objects
     assert pars_in['x'] is pars_out['x']
@@ -33,12 +34,12 @@ def test_iminuit():
 
     # Test freeze
     pars_in['x'].frozen = True
-    pars_out, minuit = fit_iminuit(function=f, parameters=pars_in)
+    pars_out, minuit = fit_iminuit(function=fcn, parameters=pars_in)
     assert minuit.list_of_fixed_param() == ['x']
 
     # Test limits
     pars_in['y'].min = 4
-    pars_out, minuit = fit_iminuit(function=f, parameters=pars_in)
+    pars_out, minuit = fit_iminuit(function=fcn, parameters=pars_in)
     states = minuit.get_param_states()
     assert not states[0]['has_limits']
     assert not states[2]['has_limits']
@@ -49,6 +50,6 @@ def test_iminuit():
 
     # Test stepsize via covariance matrix
     pars_in.set_parameter_errors({'x': '0.2', 'y': '0.1'})
-    pars_out, minuit = fit_iminuit(function=f, parameters=pars_in)
+    pars_out, minuit = fit_iminuit(function=fcn, parameters=pars_in)
 
     assert minuit.migrad_ok()

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -289,11 +289,12 @@ class ParameterList(object):
         errors : dict of `~astropy.units.Quantity`
             Dict of parameter errors.
         """
-        values = []
+        diag = []
         for par in self.parameters:
-            quantity = errors.get(par.name, 0 * u.Unit(par.unit))
-            values.append(u.Quantity(quantity, par.unit).value)
-        self.covariance = np.diag(values) ** 2
+            error = errors.get(par.name, 0)
+            error = u.Quantity(error, par.unit).value
+            diag.append(error)
+        self.covariance = np.diag(diag) ** 2
 
     # TODO: this is a temporary solution until we have a better way
     # to handle covariance matrices via a class

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -22,20 +22,21 @@ class Parameter(object):
     Parameters
     ----------
     name : str
-        Name of the parameter
+        Name
     value : float or `~astropy.units.Quantity`
-        Value of the parameter
+        Value
     unit : str, optional
-        Unit of the parameter (if value is given as float)
+        Unit
     min : float, optional
-        Minimum parameter value allowed in fit
+        Minimum (sometimes used in fitting)
     max : float, optional
-        Maximum parameter value allowed in fit
+        Maximum (sometimes used in fitting)
     frozen : bool, optional
-        Is the parameter frozen in a fit?
+        Frozen? (used in fitting)
     """
+    __slots__ = ['_name', '_value', '_unit', '_min', '_max', '_frozen']
 
-    def __init__(self, name, value, unit='', min=None, max=None, frozen=False):
+    def __init__(self, name, value, unit='', min=np.nan, max=np.nan, frozen=False):
         self.name = name
 
         if isinstance(value, u.Quantity) or isinstance(value, six.string_types):
@@ -44,9 +45,57 @@ class Parameter(object):
             self.value = value
             self.unit = unit
 
-        self.min = min or np.nan
-        self.max = max or np.nan
+        self.min = min
+        self.max = max
         self.frozen = frozen
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, val):
+        self._name = str(val)
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, val):
+        self._value = float(val)
+
+    @property
+    def unit(self):
+        return self._unit
+
+    @unit.setter
+    def unit(self, val):
+        self._unit = str(val)
+
+    @property
+    def min(self):
+        return self._min
+
+    @min.setter
+    def min(self, val):
+        self._min = float(val)
+
+    @property
+    def max(self):
+        return self._max
+
+    @max.setter
+    def max(self, val):
+        self._max = float(val)
+
+    @property
+    def frozen(self):
+        return self._frozen
+
+    @frozen.setter
+    def frozen(self, val):
+        self._frozen = bool(val)
 
     @property
     def quantity(self):
@@ -61,30 +110,32 @@ class Parameter(object):
     def __repr__(self):
         ss = 'Parameter(name={name!r}, value={value!r}, unit={unit!r}, '
         ss += 'min={min!r}, max={max!r}, frozen={frozen!r})'
-        return ss.format(**self.__dict__)
+        return ss.format(**self.to_dict())
 
     def to_dict(self):
         return dict(
             name=self.name,
-            value=float(self.value),
-            unit=str(self.unit),
-            min=float(self.min),
-            max=float(self.max),
+            value=self.value,
+            unit=self.unit,
+            min=self.min,
+            max=self.max,
             frozen=self.frozen,
         )
 
     def to_sherpa(self, modelname='Default'):
         """Convert to sherpa parameter"""
         from sherpa.models import Parameter
-
         min_ = np.finfo(np.float32).min if np.isnan(self.min) else self.min
         max_ = np.finfo(np.float32).max if np.isnan(self.max) else self.max
-
-        par = Parameter(modelname=modelname, name=self.name,
-                        val=self.value, units=self.unit,
-                        min=min_, max=max_,
-                        frozen=self.frozen)
-        return par
+        return Parameter(
+            modelname=modelname,
+            name=self.name,
+            val=self.value,
+            units=self.unit,
+            min=min_,
+            max=max_,
+            frozen=self.frozen,
+        )
 
 
 class ParameterList(object):

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -214,16 +214,17 @@ def xml_to_model(xml, which):
         # one to the gammapy model definition
         if type_ == 'PowerLaw':
             model.parameters['index'].value *= -1
-            model.parameters['index'].min = None
-            model.parameters['index'].max = None
+            model.parameters['index'].min = np.nan
+            model.parameters['index'].max = np.nan
         if type_ == 'ExponentialCutoffPowerLaw':
             model.parameters['lambda_'].value = 1 / model.parameters['lambda_'].value
             model.parameters['lambda_'].unit = model.parameters['lambda_'].unit + '-1'
-            model.parameters['lambda_'].min = None
-            model.parameters['lambda_'].max = None
+            model.parameters['lambda_'].min = np.nan
+            model.parameters['lambda_'].max = np.nan
             model.parameters['index'].value *= -1
-            model.parameters['index'].min = None
-            model.parameters['index'].max = None
+            model.parameters['index'].min = np.nan
+            model.parameters['index'].max = np.nan
+
     return model
 
 
@@ -242,8 +243,8 @@ def xml_to_parameter_list(xml, which, type_):
             raise UnknownParameterError(msg.format(par['@name'], which, type_))
 
         value = float(par['@value']) * float(par['@scale'])
-        min_ = float(par['@min']) if '@min' in par.keys() else None
-        max_ = float(par['@max']) if '@max' in par.keys() else None
+        min_ = float(par.get('@min', 'nan'))
+        max_ = float(par.get('@max', 'nan'))
         frozen = bool(1 - int(par['@free']))
 
         parameters.append(Parameter(

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
-from ..modeling import Parameter
+from numpy.testing import assert_allclose
+from ..modeling import Parameter, ParameterList
 
 
 def test_parameter_init():
@@ -18,3 +19,16 @@ def test_parameter_init():
 def test_parameter_repr():
     par = Parameter('spam', 42, 'deg')
     assert repr(par).startswith('Parameter(name=')
+
+
+def test_parameter_list():
+    pars = ParameterList([
+        Parameter('spam', 42, 'deg'),
+        Parameter('ham', 99, 'TeV'),
+    ])
+    # This applies a unit transformation
+    pars.set_parameter_errors({
+        'ham': '10000 GeV',
+    })
+    assert_allclose(pars.covariance, [[1, 0], [0, 100]])
+    assert_allclose(pars.error('ham'), 10)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -30,5 +30,6 @@ def test_parameter_list():
     pars.set_parameter_errors({
         'ham': '10000 GeV',
     })
-    assert_allclose(pars.covariance, [[1, 0], [0, 100]])
+    assert_allclose(pars.covariance, [[0, 0], [0, 100]])
+    assert_allclose(pars.error('spam'), 0)
     assert_allclose(pars.error('ham'), 10)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..modeling import Parameter
 
 
-def test_parameter():
+def test_parameter_init():
     par = Parameter('spam', 42, 'deg')
     assert par.name == 'spam'
     assert par.value == 42
@@ -13,3 +13,8 @@ def test_parameter():
     assert par.min is np.nan
     assert par.max is np.nan
     assert par.frozen is False
+
+
+def test_parameter_repr():
+    par = Parameter('spam', 42, 'deg')
+    assert repr(par).startswith('Parameter(name=')


### PR DESCRIPTION
This PR improves the parameter handling in modeling and fitting.

It locks down the `Parameter` class, using slots and properties. All of those typos / misuses now give an error, but previously passed silently:
```
par.parmin = 42  # the attribute is called `min`, not `parmin`
par.value = '42'  # must pass float
par.min = None # we now consistently use `nan` for no bounds, previously we had a mix of None and nan
```
Sherpa does the same thing, locking down the `Parameter` class because users interact so much with it and mistype.

The MapFit test currently fails. I found a few bugs in the iminuit interface, but still don't get good results. Not sure if it ever worked before ... I'll add another commit here later today once it's working.