### PR TITLE
Migrate gammapy.detect to Maps

### DIFF
--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -28,10 +28,10 @@ Computation of TS images
 .. gp-extra-image:: detect/fermi_ts_image.png
     :width: 100%
 
-Test statistics image computed using `~gammapy.detect.TSImageEstimator` for an
+Test statistics image computed using `~gammapy.detect.TSMapEstimator` for an
 example Fermi dataset.
 
-The `gammapy.detect` module includes a high performance `~gammapy.detect.TSImageEstimator` class to
+The `gammapy.detect` module includes a high performance `~gammapy.detect.TSMapEstimator` class to
 compute test statistics (TS) images for gamma-ray survey data. The implementation is based on the method
 described in [Stewart2009]_.
 
@@ -52,57 +52,26 @@ In the following the computation of a TS image for prepared Fermi survey data, w
 .. code-block:: python
 
     from astropy.convolution import Gaussian2DKernel
-    from gammapy.image import SkyImageList
-    from gammapy.detect import TSImageEstimator
-    images = SkyImageList.read('$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz')
+    from gammapy.detect import TSMapEstimator
+    from gammapy.maps import Map
+
+    filename = '$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz'
+    maps = {}
+    maps['counts'] = Map.read(filename, hdu='counts')
+    maps['exposure'] = Map.read(filename, hdu='exposure')
+    maps['background'] = Map.read(filename, hdu='background')
+
     kernel = Gaussian2DKernel(5)
-    ts_estimator = TSImageEstimator()
-    result = ts_estimator.run(images, kernel)
+    ts_estimator = TSMapEstimator()
+    result = ts_estimator.run(maps, kernel)
 
-The function returns a `~gammapy.image.SkyImageList` object, that bundles all relevant
-data. E.g. the time needed for the TS image computation can be checked by:
-
-.. code-block:: python
-
-	result.meta['runtime']
-
-The TS `~gammapy.image.SkyImage` itself can be accessed from the `~gammapy.image.SkyImageList` object.
+The function returns an `~OrderedDict` object, that bundles all resulting maps.
 E.g. here's how to find the largest TS value:
 
 .. code-block:: python
 
     import numpy as np
 	np.nanmax(result['ts'].data)
-
-Command line tool
------------------
-
-Gammapy also provides a command line tool ``gammapy image ts`` for TS image computation, which can be run
-on the Fermi example dataset by:
-
-.. code-block:: bash
-
-    $ cd $GAMMAPY_EXTRA/datasets/fermi_survey
-    $ gammapy image ts all.fits.gz ts_image_0.00.fits --scales 0
-
-The command line tool additionally requires a psf json file, where the psf shape
-is defined by the parameters of a triple Gaussian model. See also
-`gammapy.irf.multi_gauss_psf_kernel`. By default the command line tool uses
-a Gaussian source kernel, where the width in degree can be defined by the
-``--scale`` parameter. Multiple scales can be selected by passing a list to the
-``scales`` parameter.  When setting ``--scale 0`` only the psf is used as source
-model, which is the preferred setting to detect point sources. When using scales
-that are larger than five times the binning of the data, the data is sampled down
-and later sampled up again to speed up the performance. See
-`~gammapy.image.downsample_2N` and `~gammapy.image.upsample_2N` for details.
-
-Furthermore it is possible to compute residual TS images. Using the following options:
-
-.. code-block:: bash
-
-	$ gammapy image ts all.fits.gz residual_ts_image_0.00.fits --scales 0 --residual --model model.fits.gz
-
-When ``--residual`` is set an excess model must be provided using the ``--model`` option.
 
 
 Computation of Li & Ma significance images

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -28,14 +28,6 @@ log = logging.getLogger(__name__)
 FLUX_FACTOR = 1e-12
 MAX_NITER = 20
 RTOL = 1e-3
-UPSAMPLING_ARGS = {
-    'ts' : {'order': 1, 'preserve_counts': False},
-    'sqrt_ts': {'order': 1, 'preserve_counts': False},
-    'flux': {'order': 1, 'preserve_counts': False},
-    'flux_ul': {'order': 1, 'preserve_counts': False},
-    'flux_err': {'order': 1, 'preserve_counts': False},
-    'niter': {'order': 0, 'preserve_counts': False},
-    }
 
 
 def _extract_array(array, shape, position):
@@ -355,10 +347,11 @@ class TSMapEstimator(object):
 
         if downsampling_factor:
             for name in which:
+                order = 0 if name == 'niter' else 1
                 result[name] = result[name].upsample(
                     factor=downsampling_factor,
-                    preserve_counts=UPSAMPLING_ARGS[name]['preserve_counts'],
-                    order=UPSAMPLING_ARGS[name]['order']
+                    preserve_counts=False,
+                    order=order
                     )
                 result[name] = result[name].crop(crop_width=pad_width)
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -2,6 +2,7 @@
 """Functions to compute TS images."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
+import contextlib
 from time import time
 import warnings
 from collections import OrderedDict
@@ -333,7 +334,7 @@ class TSMapEstimator(object):
         x, y = np.where(mask.data)
         positions = list(zip(x, y))
 
-        with Pool(processes=p['n_jobs']) as pool:
+        with contextlib.closing(Pool(processes=p['n_jobs'])) as pool:
             log.info('Using {} jobs to compute TS map.'.format(p['n_jobs']))
             results = pool.map(wrap, positions)
 

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -7,7 +7,7 @@ from astropy.convolution import Gaussian2DKernel
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.scripts import make_path
 from ...maps.utils import read_fits_hdus
-from ...detect import TSMapEstimator, compute_ts_image_multiscale
+from ...detect import TSMapEstimator
 
 
 @requires_dependency('scipy')
@@ -23,39 +23,29 @@ def test_compute_ts_map():
     ts_estimator = TSMapEstimator(method='leastsq iter', n_jobs=4)
     result = ts_estimator.run(maps, kernel=kernel)
 
-    assert_allclose(1714.2325, result['ts'].data[99, 99], rtol=1e-3)
-    assert_allclose([[99], [99]], np.where(result['ts'].data == np.nanmax(result['ts'].data)))
+    assert_allclose(1714.23, result['ts'].data[99, 99], rtol=1e-2)
     assert_allclose(3, result['niter'].data[99, 99])
-    assert_allclose(1.02596e-09, result['flux'].data[99, 99], rtol=1e-3)
-    assert_allclose(3.846415e-11, result['flux_err'].data[99, 99], rtol=1e-3)
-    assert_allclose(1.102886e-09, result['flux_ul'].data[99, 99], rtol=1e-3)
+    assert_allclose(1.02e-09, result['flux'].data[99, 99], rtol=1e-2)
+    assert_allclose(3.84e-11, result['flux_err'].data[99, 99], rtol=1e-2)
+    assert_allclose(1.10e-09, result['flux_ul'].data[99, 99], rtol=1e-2)
 
 
 @requires_dependency('scipy')
 @requires_dependency('skimage')
 @requires_data('gammapy-extra')
-@pytest.mark.parametrize('scale', ['0.000', '0.050', '0.100', '0.200'])
-def test_compute_ts_image_multiscale(tmpdir, scale):
-    path = make_path('$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image')
-    filename = path / 'input_all.fits.gz'
-    maps_in = read_fits_hdus(filename)
+def test_compute_ts_map_downsampled():
+    """Minimal test of compute_ts_image"""
+    filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/input_all.fits.gz'
+    maps = read_fits_hdus(filename)
 
-    psf_parameters = {
-        "psf1": {"fwhm": 7.0644601350928475, "ampl": 1},
-        "psf2": {"fwhm": 1e-05, "ampl": 0},
-        "psf3": {"fwhm": 1e-05, "ampl": 0},
-    }
+    kernel = Gaussian2DKernel(2.5)
 
-    maps_out = compute_ts_image_multiscale(
-        maps_in, psf_parameters, [float(scale)],
-    )
-    # Function returns a Python list of `SkyImageList`. TODO: simplify
-    maps_out = maps_out[0]
+    ts_estimator = TSMapEstimator(method='root brentq', n_jobs=4)
+    result = ts_estimator.run(maps, kernel=kernel, downsampling_factor=2)
 
-    maps_ref = read_fits_hdus(path / 'expected_ts_{}.fits.gz'.format(scale))
+    assert_allclose(1675.28, result['ts'].data[99, 99], rtol=1e-2)
+    assert_allclose(7, result['niter'].data[99, 99])
+    assert_allclose(1.02e-09, result['flux'].data[99, 99], rtol=1e-2)
+    assert_allclose(3.84e-11, result['flux_err'].data[99, 99], rtol=1e-2)
+    assert_allclose(1.10e-09, result['flux_ul'].data[99, 99], rtol=1e-2)
 
-    opts = dict(rtol=1e-2, atol=1e-5, equal_nan=True)
-    assert_allclose(maps_out['ts'].data, maps_ref['ts'].data, **opts)
-    assert_allclose(maps_out['sqrt_ts'].data, maps_ref['sqrt_ts'].data, **opts)
-    assert_allclose(maps_out['flux'].data, maps_ref['amplitude'].data, **opts)
-    assert 'niter' in maps_out

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -6,8 +6,8 @@ from numpy.testing.utils import assert_allclose
 from astropy.convolution import Gaussian2DKernel
 from ...utils.testing import requires_dependency, requires_data
 from ...utils.scripts import make_path
-from ...image import SkyImageList
-from ...detect import TSImageEstimator, compute_ts_image_multiscale
+from ...maps.utils import read_fits_hdus
+from ...detect import TSMapEstimator, compute_ts_image_multiscale
 
 
 @requires_dependency('scipy')
@@ -16,27 +16,19 @@ from ...detect import TSImageEstimator, compute_ts_image_multiscale
 def test_compute_ts_map():
     """Minimal test of compute_ts_image"""
     filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/input_all.fits.gz'
-    images = SkyImageList.read(filename)
+    maps = read_fits_hdus(filename)
 
-    kernel = Gaussian2DKernel(2.5)
+    kernel = Gaussian2DKernel(5)
 
-    images['counts'] = images['counts'].downsample(2, np.nansum)
-    images['background'] = images['background'].downsample(2, np.nansum)
-    images['exposure'] = images['exposure'].downsample(2, np.mean)
+    ts_estimator = TSMapEstimator(method='leastsq iter', n_jobs=4)
+    result = ts_estimator.run(maps, kernel=kernel)
 
-    ts_estimator = TSImageEstimator(method='leastsq iter')
-    result = ts_estimator.run(images, kernel=kernel)
-
-    for name, order in zip(['ts', 'flux', 'flux_err', 'flux_ul', 'niter'], [2, 5, 5, 5, 0]):
-        result[name].data = np.nan_to_num(result[name].data)
-        result[name] = result[name].upsample(2, order=order)
-
-    assert_allclose(1705.840212274973, result['ts'].data[99, 99], rtol=1e-3)
-    assert_allclose([[99], [99]], np.where(result['ts'].data == result['ts'].data.max()))
+    assert_allclose(1714.2325, result['ts'].data[99, 99], rtol=1e-3)
+    assert_allclose([[99], [99]], np.where(result['ts'].data == np.nanmax(result['ts'].data)))
     assert_allclose(3, result['niter'].data[99, 99])
-    assert_allclose(1.0227934338735763e-09, result['flux'].data[99, 99], rtol=1e-3)
-    assert_allclose(3.842162268386843e-11, result['flux_err'].data[99, 99], rtol=1e-3)
-    assert_allclose(1.0996355030292762e-09, result['flux_ul'].data[99, 99], rtol=1e-3)
+    assert_allclose(1.02596e-09, result['flux'].data[99, 99], rtol=1e-3)
+    assert_allclose(3.846415e-11, result['flux_err'].data[99, 99], rtol=1e-3)
+    assert_allclose(1.102886e-09, result['flux_ul'].data[99, 99], rtol=1e-3)
 
 
 @requires_dependency('scipy')
@@ -45,7 +37,8 @@ def test_compute_ts_map():
 @pytest.mark.parametrize('scale', ['0.000', '0.050', '0.100', '0.200'])
 def test_compute_ts_image_multiscale(tmpdir, scale):
     path = make_path('$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image')
-    images_in = SkyImageList.read(path / 'input_all.fits.gz')
+    filename = path / 'input_all.fits.gz'
+    maps_in = read_fits_hdus(filename)
 
     psf_parameters = {
         "psf1": {"fwhm": 7.0644601350928475, "ampl": 1},
@@ -53,16 +46,16 @@ def test_compute_ts_image_multiscale(tmpdir, scale):
         "psf3": {"fwhm": 1e-05, "ampl": 0},
     }
 
-    images_out = compute_ts_image_multiscale(
-        images_in, psf_parameters, [float(scale)],
+    maps_out = compute_ts_image_multiscale(
+        maps_in, psf_parameters, [float(scale)],
     )
     # Function returns a Python list of `SkyImageList`. TODO: simplify
-    images_out = images_out[0]
+    maps_out = maps_out[0]
 
-    images_ref = SkyImageList.read(path / 'expected_ts_{}.fits.gz'.format(scale))
+    maps_ref = read_fits_hdus(path / 'expected_ts_{}.fits.gz'.format(scale))
 
     opts = dict(rtol=1e-2, atol=1e-5, equal_nan=True)
-    assert_allclose(images_out['ts'].data, images_ref['ts'].data, **opts)
-    assert_allclose(images_out['sqrt_ts'].data, images_ref['sqrt_ts'].data, **opts)
-    assert_allclose(images_out['flux'].data, images_ref['amplitude'].data, **opts)
-    assert 'niter' in images_out.names
+    assert_allclose(maps_out['ts'].data, maps_ref['ts'].data, **opts)
+    assert_allclose(maps_out['sqrt_ts'].data, maps_ref['sqrt_ts'].data, **opts)
+    assert_allclose(maps_out['flux'].data, maps_ref['amplitude'].data, **opts)
+    assert 'niter' in maps_out

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -10,7 +10,7 @@ from ...detect import TSMapEstimator
 
 
 @pytest.fixture
-def input_maps():
+def input_maps(scope='session'):
     filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/input_all.fits.gz'
     maps = {}
     maps['counts'] = Map.read(filename, hdu='counts')
@@ -29,12 +29,11 @@ def test_compute_ts_map(input_maps):
     ts_estimator = TSMapEstimator(method='leastsq iter', n_jobs=4)
     result = ts_estimator.run(input_maps, kernel=kernel)
 
-    assert_allclose(1714.23, result['ts'].data[99, 99], rtol=1e-2)
-    assert_allclose(3, result['niter'].data[99, 99])
-    assert_allclose(1.02e-09, result['flux'].data[99, 99], rtol=1e-2)
-    assert_allclose(3.84e-11, result['flux_err'].data[99, 99], rtol=1e-2)
-    assert_allclose(1.10e-09, result['flux_ul'].data[99, 99], rtol=1e-2)
-
+    assert_allclose(result['ts'].data[99, 99], 1714.23, rtol=1e-2)
+    assert_allclose(result['niter'].data[99, 99], 3)
+    assert_allclose(result['flux'].data[99, 99], 1.02e-09, rtol=1e-2)
+    assert_allclose(result['flux_err'].data[99, 99], 3.84e-11, rtol=1e-2)
+    assert_allclose(result['flux_ul'].data[99, 99], 1.10e-09, rtol=1e-2)
 
 @requires_dependency('scipy')
 @requires_dependency('skimage')
@@ -46,9 +45,9 @@ def test_compute_ts_map_downsampled(input_maps):
     ts_estimator = TSMapEstimator(method='root brentq', n_jobs=4)
     result = ts_estimator.run(input_maps, kernel=kernel, downsampling_factor=2)
 
-    assert_allclose(1675.28, result['ts'].data[99, 99], rtol=1e-2)
-    assert_allclose(7, result['niter'].data[99, 99])
-    assert_allclose(1.02e-09, result['flux'].data[99, 99], rtol=1e-2)
-    assert_allclose(3.84e-11, result['flux_err'].data[99, 99], rtol=1e-2)
-    assert_allclose(1.10e-09, result['flux_ul'].data[99, 99], rtol=1e-2)
+    assert_allclose(result['ts'].data[99, 99], 1675.28, rtol=1e-2)
+    assert_allclose(result['niter'].data[99, 99], 7)
+    assert_allclose(result['flux'].data[99, 99], 1.02e-09, rtol=1e-2)
+    assert_allclose(result['flux_err'].data[99, 99], 3.84e-11, rtol=1e-2)
+    assert_allclose(result['flux_ul'].data[99, 99], 1.10e-09, rtol=1e-2)
 

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from collections import OrderedDict
 from astropy.io import fits
 from ..utils.random import get_random_state
+from ..utils.scripts import make_path
 
 
 def fill_poisson(map_in, mu, random_state='random-seed'):
@@ -139,3 +141,16 @@ def find_bintable_hdu(hdulist):
             return hdu
 
     raise AttributeError('No BinTable HDU found.')
+
+
+def read_fits_hdus(filename):
+    """Read fits file with mutiple image hdus and return an `OrderedDict`
+    of `Map` objects.
+    """
+    from .wcsnd import WcsNDMap
+    maps = OrderedDict()
+
+    for hdu in fits.open(str(make_path(filename))):
+        maps[hdu.name] = WcsNDMap.from_hdu(hdu)
+
+    return maps

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 from astropy.io import fits
 from ..utils.random import get_random_state
-from ..utils.scripts import make_path
 
 
 def fill_poisson(map_in, mu, random_state='random-seed'):

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -141,16 +141,3 @@ def find_bintable_hdu(hdulist):
             return hdu
 
     raise AttributeError('No BinTable HDU found.')
-
-
-def read_fits_hdus(filename):
-    """Read fits file with mutiple image hdus and return an `OrderedDict`
-    of `Map` objects.
-    """
-    from .wcsnd import WcsNDMap
-    maps = OrderedDict()
-
-    for hdu in fits.open(str(make_path(filename))):
-        maps[hdu.name] = WcsNDMap.from_hdu(hdu)
-
-    return maps


### PR DESCRIPTION
This PR migrates `gammapy.detect` to `Maps` and also does a substantial clean up, especially removing the multiscale ts map helper functions, which are only useful for few user. The functionality was still kept by introducing a `downsampling_factor` argument in the `TSMapEstimator.run()` method.