### PR TITLE
Small fix to prepare the switch to the new obs classes

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -157,7 +157,7 @@ class SpectrumExtraction(object):
             backscal=bkg.a_on,
             offset=offset,
             livetime=obs.observation_live_time_duration,
-            obs_id=obs.obs_info['OBS_ID'])
+            obs_id=obs.obs_id)
 
         self._off_vector = self._on_vector.copy()
         self._off_vector.is_bkg = True


### PR DESCRIPTION
This is just a small fix to prepare the switch to the new obs classes.
The new classes will not have the `obs_info` attribute anymore, which is hardly used outside of DataStoreObservation. I only found this occurrence.