### PR TITLE
Remove aplpy dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ env:
         - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython iminuit'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils pygments aplpy sherpa libgfortran regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils aplpy sherpa libgfortran runipy regions reproject pandoc ipython'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils pygments sherpa libgfortran regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran runipy regions reproject pandoc ipython'
 
         - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme'
 

--- a/dev/docker/commands.sh
+++ b/dev/docker/commands.sh
@@ -43,7 +43,6 @@ if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL uncertainties; fi
 if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL git+http://github.com/astrofrog/reproject.git#egg=reproject; fi
 if [[ $SETUP_CMD == build_docs* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib scipy; fi
 if [[ $SETUP_CMD == build_docs* ]]; then $PIP_INSTALL linkchecker; fi
-if [[ $SETUP_CMD == build_docs* ]]; then $PIP_INSTALL aplpy; fi
 if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
 python setup.py $SETUP_CMD
 if [[ $SETUP_CMD == build_docs* ]]; then linkchecker docs/_build/html; fi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,6 @@ intersphinx_mapping['uncertainties'] = ('http://pythonhosted.org/uncertainties/'
 intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
 intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/', None)
-intersphinx_mapping['aplpy'] = ('http://aplpy.readthedocs.io/en/latest/', None)
 intersphinx_mapping['naima'] = ('http://naima.readthedocs.io/en/latest/', None)
 intersphinx_mapping['gadf'] = ('http://gamma-astro-data-formats.readthedocs.io/en/latest/', None)
 intersphinx_mapping['iminuit'] = ('http://iminuit.readthedocs.io/en/latest/', None)

--- a/docs/image/plotting.rst
+++ b/docs/image/plotting.rst
@@ -18,6 +18,6 @@ Multi-panel Galactic plane survey image plots
 ---------------------------------------------
 
 The following example shows how to plot a very wide Galactic plane survey image
-by splitting it into multiple panels using the `~gammapy.image.GalacticPlaneSurveyPanelPlot` class.
+by splitting it into multiple panels using the `~gammapy.image.MapPanelPlotter` class.
 
 .. plot:: image/survey_example.py

--- a/docs/image/survey_example.py
+++ b/docs/image/survey_example.py
@@ -1,17 +1,20 @@
 """Plot a Galactic plane survey image in two panels."""
-from aplpy import FITSFigure
-from gammapy.datasets import FermiGalacticCenter
-from gammapy.image import GalacticPlaneSurveyPanelPlot
+from astropy.coordinates import Angle
+import matplotlib.pyplot as plt
+from gammapy.image import MapPanelPlotter
+from gammapy.maps import Map
 
 
-class GPSFermiPlot(GalacticPlaneSurveyPanelPlot):
-    def main(self, figure, subplot):
-        filename = FermiGalacticCenter.filenames()['counts']
-        self.fits_figure = FITSFigure(filename, hdu=1, figure=figure, subplot=subplot)
-        self.fits_figure.show_colorscale(vmin=1, vmax=10, cmap='afmhot')
-        self.fits_figure.ticks.set_xspacing(2)
+filename = '$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz'
+survey_map = Map.read(filename, hdu='counts')
+survey_map.data = survey_map.data.astype('float')
+smoothed_map = survey_map.smooth(radius=Angle(0.2, unit='deg'))
 
 
-plot = GPSFermiPlot(npanels=3, center=(0, 0), fov=(30, 3))
-plot.draw_panels('all')
-plot.figure.savefig('survey_example.png')
+fig = plt.figure(figsize=(15, 8))
+xlim = Angle([70, 262], unit='deg')
+ylim = Angle([-4, 4], unit='deg')
+plotter = MapPanelPlotter(figure=fig, xlim=xlim, ylim=ylim, npanels=4, top=0.98,
+                          bottom=0.07, right=0.98, left=0.05, hspace=0.15)
+axes = plotter.plot(smoothed_map, cmap='inferno', stretch='log', vmax=50)
+plt.savefig('survey_example.png')

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -19,7 +19,7 @@ functionality available:
 
 .. code-block:: bash
 
-    conda install scikit-image aplpy photutils reproject iminuit
+    conda install scikit-image photutils reproject iminuit
 
 To update to the latest version:
 

--- a/docs/install/dependencies.rst
+++ b/docs/install/dependencies.rst
@@ -42,7 +42,6 @@ Currently optional dependencies that are being considered as core dependencies:
 Allowed optional dependencies:
 
 * `matplotlib`_ for plotting
-* `aplpy`_ for sky image plotting (provides a high-level API)
 * `pandas`_ CSV read / write; DataFrame
 * `scikit-learn`_ for some data analysis tasks
 * `GammaLib`_ and `ctools`_ for simulating data and likelihood fitting
@@ -52,4 +51,4 @@ Allowed optional dependencies:
 * `emcee`_ for fitting by MCMC sampling
 * `h5py`_ for `HDF5 <http://en.wikipedia.org/wiki/Hierarchical_Data_Format>`__ data handling
 * `healpy`_ for `HEALPIX <http://healpix.jpl.nasa.gov/>`__ data handling
-* `nbsphinx`_ for transformation of Jupyter notebooks into fixed-text documentation 
+* `nbsphinx`_ for transformation of Jupyter notebooks into fixed-text documentation

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -1,12 +1,8 @@
-# TODO: this can probably be removed as soon as this is merged
-# https://github.com/aplpy/aplpy/pull/189
-# py:obj aplpy.FITSFigure
-
 # This is needed for `astropy.io.fits.HDUList` sub-classes
 # TODO: resolve correctly
 py:class astropy.io.fits.hdu.hdulist.HDUList
 
-# For some reason links for astropy.io.fits don't work 
+# For some reason links for astropy.io.fits don't work
 # TODO: resolve correctly
 #py:obj astropy.io.fits.BinTableHDU
 #py:obj astropy.io.fits.ImageHDU

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,7 +36,6 @@ dependencies:
   - pytest
   - pytest-cov
   - sphinx
-  - aplpy
   - pandoc
   - pylint
   - flake8

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -29,7 +29,6 @@ PYTEST_HEADER_MODULES['gammapy'] = 'gammapy'
 PYTEST_HEADER_MODULES['naima'] = 'naima'
 PYTEST_HEADER_MODULES['reproject'] = 'reproject'
 PYTEST_HEADER_MODULES['photutils'] = 'photutils'
-PYTEST_HEADER_MODULES['aplpy'] = 'aplpy'
 
 
 def pytest_configure(config):

--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -27,7 +27,6 @@ GAMMAPY_DEPENDENCIES = [
     'sphinx',
 
     'pandas',
-    'aplpy',
     'h5py',
     'healpy',
     'regions',

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,6 @@ setup(
       ],
       plotting=[
           'matplotlib>=1.5',
-          'aplpy>=0.9',
       ],
     ),
     author=AUTHOR,


### PR DESCRIPTION
This PR removes the aplpy dependency from Gammapy and adapts the survey plotting example to use the `MapPanelPlotter` class.