### PR TITLE
Migrate image measure and profile to maps

### DIFF
--- a/docs/image/colormap_example.py
+++ b/docs/image/colormap_example.py
@@ -5,30 +5,26 @@ import matplotlib.pyplot as plt
 from gammapy.image import colormap_hess, colormap_milagro
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.visualization import LinearStretch
-from gammapy.image import SkyImage
+from gammapy.maps import Map
 
 filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz'
-image = SkyImage.read(filename, hdu='SQRT_TS')
+image = Map.read(filename, hdu='SQRT_TS')
 
 # Plot with the HESS and Milagro colormap
 vmin, vmax, vtransition = -5, 15, 5
-plt.figure(figsize=(12, 6))
+fig = plt.figure(figsize=(15.5, 6))
 
 normalize = ImageNormalize(vmin=vmin, vmax=vmax, stretch=LinearStretch())
 transition = normalize(vtransition)
 
-plt.subplot(121)
+ax = fig.add_subplot(121, projection=image.geom.wcs)
 cmap = colormap_hess(transition=transition)
-plt.imshow(image, cmap=cmap, norm=normalize)
-plt.axis('off')
-plt.colorbar(shrink=0.7)
+image.plot(ax=ax, cmap=cmap, norm=normalize, add_cbar=True)
 plt.title('HESS-style colormap')
 
-plt.subplot(122)
+ax = fig.add_subplot(122, projection=image.geom.wcs)
 cmap = colormap_milagro(transition=transition)
-plt.imshow(image, cmap=cmap, norm=normalize)
-plt.axis('off')
-plt.colorbar(shrink=0.7)
+image.plot(ax=ax, cmap=cmap, norm=normalize, add_cbar=True)
 plt.title('MILAGRO-style colormap')
 
 plt.tight_layout()

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -9,8 +9,8 @@ from ...maps import Map
 from ...detect import TSMapEstimator
 
 
-@pytest.fixture
-def input_maps(scope='session'):
+@pytest.fixture(scope='session')
+def input_maps():
     filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/input_all.fits.gz'
     maps = {}
     maps['counts'] = Map.read(filename, hdu='counts')

--- a/gammapy/image/models/tests/test_gauss.py
+++ b/gammapy/image/models/tests/test_gauss.py
@@ -5,7 +5,8 @@ from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution import discretize_model
 from ....utils.testing import requires_dependency
-from ....image import measure_image_moments, SkyImage
+from ....maps import WcsNDMap
+from ....image import measure_image_moments
 from ..gauss import Gauss2DPDF, MultiGauss2D, gaussian_sum_moments
 
 BINSZ = 0.02
@@ -133,7 +134,7 @@ def test_gaussian_sum_moments():
     F_2_image = discretize_model(f_2, (0, 201), (0, 201))
     F_3_image = discretize_model(f_3, (0, 201), (0, 201))
 
-    image = SkyImage.empty(nxpix=201, nypix=201)
+    image = WcsNDMap.create(npix=(201, 201), binsz=0.02)
     image.data = F_1_image + F_2_image + F_3_image
     moments_num = measure_image_moments(image)
 
@@ -144,7 +145,7 @@ def test_gaussian_sum_moments():
     cov_matrix = np.zeros((12, 12))
     F = [F_1, F_2, F_3]
     sigma = np.array([sigma_1, sigma_2, sigma_3]) * BINSZ
-    x, y = image.wcs.wcs_pix2world([x_1, x_2, x_3], [y_1, y_2, y_3], 0)
+    x, y = image.geom.wcs.wcs_pix2world([x_1, x_2, x_3], [y_1, y_2, y_3], 0)
     x = np.where(x > 180, x - 360, x)
 
     moments_ana, uncertainties = gaussian_sum_moments(F, sigma, x, y, cov_matrix, shift=0)

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -79,14 +79,13 @@ class ImageProfileEstimator(object):
     .. code:: python
 
         import matplotlib.pyplot as plt
-        from gammapy.datasets import FermiGalacticCenter
-        from gammapy.image import ImageProfile, ImageProfileEstimator
-        from gammapy.image import SkyImage
+        from gammapy.image import ImageProfileEstimator
+        from gammapy.maps import Map
         from astropy import units as u
 
         # load example data
-        fermi_cts = SkyImage.from_image_hdu(FermiGalacticCenter.counts())
-        fermi_cts.unit = u.count
+        filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/fermi/fermi_counts.fits.gz'
+        fermi_cts = Map.read(filename)
 
         # set up profile estimator and run
         p = ImageProfileEstimator(axis='lon', method='sum')
@@ -95,7 +94,6 @@ class ImageProfileEstimator(object):
         # smooth profile and plot
         smoothed = profile.smooth(kernel='gauss')
         smoothed.peek()
-
         plt.show()
 
     """

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -4,30 +4,28 @@ import numpy as np
 import pytest
 from astropy import units as u
 from astropy.modeling.models import Gaussian2D
-from astropy.coordinates import SkyCoord, Angle
-from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency
-from ...image import (measure_containment_radius,
-                      measure_image_moments,
-                      measure_containment,
-                      measure_curve_of_growth,
-                      _wrapped_coordinates)
-from ...image.models import SkyGaussian
+from astropy.coordinates import SkyCoord
+from ...utils.testing import assert_quantity_allclose, requires_dependency
 from ...maps import WcsGeom, WcsNDMap
-
-BINSZ = 0.02
+from ...image import (
+    measure_containment_radius,
+    measure_image_moments,
+    measure_containment,
+    measure_curve_of_growth,
+)
 
 
 @pytest.fixture(scope='session')
 def gaussian_image():
     """Generate gaussian test image.
     """
-    geom = WcsGeom.create(npix=(201, 201), binsz=BINSZ, coordsys='GAL')
+    binsz = 0.02
     sigma = 0.2
-    gauss = Gaussian2D(1. / (2 * np.pi * (sigma / BINSZ) ** 2), 0, 0, sigma, sigma)
-    coordinates = geom.get_coord().skycoord
-    l, b = coordinates.data.lon.wrap_at('180d')
-    b = coordinates.data.lat
+    geom = WcsGeom.create(npix=(201, 201), binsz=binsz, coordsys='GAL')
+    gauss = Gaussian2D(1. / (2 * np.pi * (sigma / binsz) ** 2), 0, 0, sigma, sigma)
+    coord = geom.get_coord().skycoord
+    l = coord.data.lon.wrap_at('180d')
+    b = coord.data.lat
     data = gauss(l.degree, b.degree)
     return WcsNDMap(geom=geom, data=data, unit='cm-2 s-1')
 
@@ -43,7 +41,7 @@ def test_measure_image_moments(gaussian_image):
         0.2 * u.deg,
         0.2 * u.deg,
         0.2 * u.deg
-        ]
+    ]
 
     for val, ref in zip(moments, reference):
         assert_quantity_allclose(val, ref, atol=1e-12 * val.unit)

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -10,22 +10,23 @@ from ...utils.testing import requires_dependency
 from ...image import (measure_containment_radius,
                       measure_image_moments,
                       measure_containment,
-                      measure_curve_of_growth)
+                      measure_curve_of_growth,
+                      _wrapped_coordinates)
 from ...image.models import SkyGaussian
 from ...maps import WcsGeom, WcsNDMap
 
 BINSZ = 0.02
 
 
-@pytest.fixture
-def gaussian_image(scope='session'):
+@pytest.fixture(scope='session')
+def gaussian_image():
     """Generate gaussian test image.
     """
     geom = WcsGeom.create(npix=(201, 201), binsz=BINSZ, coordsys='GAL')
     sigma = 0.2
     gauss = Gaussian2D(1. / (2 * np.pi * (sigma / BINSZ) ** 2), 0, 0, sigma, sigma)
     coordinates = geom.get_coord().skycoord
-    l = coordinates.data.lon.wrap_at('180d')
+    l, b = coordinates.data.lon.wrap_at('180d')
     b = coordinates.data.lat
     data = gauss(l.degree, b.degree)
     return WcsNDMap(geom=geom, data=data, unit='cm-2 s-1')

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -2,56 +2,58 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import pytest
-from astropy.units import Quantity
+from astropy import units as u
 from astropy.modeling.models import Gaussian2D
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, Angle
 from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency
 from ...image import (measure_containment_radius,
                       measure_image_moments,
                       measure_containment,
-                      measure_curve_of_growth, SkyImage)
+                      measure_curve_of_growth)
+from ...image.models import SkyGaussian
+from ...maps import WcsGeom, WcsNDMap
 
 BINSZ = 0.02
 
 
-
 @pytest.fixture
-def gaussian_image():
+def gaussian_image(scope='session'):
+    """Generate gaussian test image.
     """
-    Generate some greyscale image to run the detection on.
-    """
-    image = SkyImage.empty(nxpix=201, nypix=201, binsz=0.02)
-    coordinates = image.coordinates()
-    l = coordinates.data.lon.wrap_at("180d")
-    b = coordinates.data.lat
+    geom = WcsGeom.create(npix=(201, 201), binsz=BINSZ, coordsys='GAL')
     sigma = 0.2
-    source = Gaussian2D(1. / (2 * np.pi * (sigma / BINSZ) ** 2), 0, 0, sigma, sigma)
-    image.data += source(l.degree, b.degree)
-    image.data = Quantity(image.data, 'cm-2 s-1')
-    return image
+    gauss = Gaussian2D(1. / (2 * np.pi * (sigma / BINSZ) ** 2), 0, 0, sigma, sigma)
+    coordinates = geom.get_coord().skycoord
+    l = coordinates.data.lon.wrap_at('180d')
+    b = coordinates.data.lat
+    data = gauss(l.degree, b.degree)
+    return WcsNDMap(geom=geom, data=data, unit='cm-2 s-1')
 
 
 def test_measure_image_moments(gaussian_image):
     """Test measure_image_moments function"""
     moments = measure_image_moments(gaussian_image)
-    reference = [Quantity(1, 'cm-2 s-1'),
-                 Quantity(0, 'deg'),
-                 Quantity(0, 'deg'),
-                 Quantity(0.2, 'deg'),
-                 Quantity(0.2, 'deg'),
-                 Quantity(0.2, 'deg')]
+
+    reference = [
+        1 * u.Unit('cm-2 s-1'),
+        0 * u.deg,
+        0 * u.deg,
+        0.2 * u.deg,
+        0.2 * u.deg,
+        0.2 * u.deg
+        ]
 
     for val, ref in zip(moments, reference):
-        assert_quantity_allclose(val, ref, atol=Quantity(1e-12, val.unit))
+        assert_quantity_allclose(val, ref, atol=1e-12 * val.unit)
 
 
 def test_measure_containment(gaussian_image):
     """Test measure_containment function"""
     position = SkyCoord(0, 0, frame='galactic', unit='deg')
-    radius = Quantity(0.2 * np.sqrt(2 * np.log(5)), 'deg')
+    radius = u.Quantity(0.2 * np.sqrt(2 * np.log(5)), 'deg')
     frac = measure_containment(gaussian_image, position, radius)
-    ref = Quantity(0.8, 'cm-2 s-1')
+    ref = u.Quantity(0.8, 'cm-2 s-1')
     assert_quantity_allclose(frac, ref, rtol=0.01)
 
 
@@ -60,15 +62,15 @@ def test_measure_containment_radius(gaussian_image):
     """Test measure_containment_radius function"""
     position = SkyCoord(0, 0, frame='galactic', unit='deg')
     rad = measure_containment_radius(gaussian_image, position, 0.8)
-    ref = Quantity(0.2 * np.sqrt(2 * np.log(5)), 'deg')
+    ref = 0.2 * np.sqrt(2 * np.log(5)) * u.deg
     assert_quantity_allclose(rad, ref, rtol=0.01)
 
 
 def test_measure_curve_of_growth(gaussian_image):
     """Test measure_curve_of_growth function"""
     position = SkyCoord(0, 0, frame='galactic', unit='deg')
-    radius_max = Quantity(0.6, 'deg')
+    radius_max = 0.6 * u.deg
     radius, containment = measure_curve_of_growth(gaussian_image, position, radius_max)
-    sigma = Quantity(0.2, 'deg')
-    containment_ana = Quantity(1 - np.exp(-0.5 * (radius / sigma) ** 2).value, 'cm-2 s-1')
+    sigma = 0.2 * u.deg
+    containment_ana = u.Quantity(1 - np.exp(-0.5 * (radius / sigma) ** 2).value, 'cm-2 s-1')
     assert_quantity_allclose(containment, containment_ana, rtol=0.1)

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -5,12 +5,11 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from astropy import units as u
-from astropy.coordinates import Angle
+from astropy.coordinates import Angle, SkyCoord
 from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, mpl_savefig_check
-from ...image import SkyImage
+from ...maps import WcsNDMap, WcsGeom
 from ..profile import compute_binning, ImageProfile, ImageProfileEstimator
-from ..profile import radial_profile, radial_profile_label_image
 
 
 @requires_dependency('pandas')
@@ -24,119 +23,112 @@ def test_compute_binning():
     assert_allclose(bin_edges, [1, 2, 2.66666667, 4])
 
 
+@pytest.fixture(scope='session')
+def checkerboard_image():
+    nxpix, nypix = 10, 6
+
+    # set up data as a checkerboard of 0.5 and 1.5, so that the mean and sum
+    # are not compeletely trivial to compute
+    data = 1.5 * np.ones((nypix, nxpix))
+    data[slice(0, nypix + 1, 2), slice(0, nxpix + 1, 2)] = 0.5
+    data[slice(1, nypix + 1, 2), slice(1, nxpix + 1, 2)] = 0.5
+
+    geom = WcsGeom.create(npix=(nxpix, nypix), coordsys='GAL', binsz=0.02)
+    return WcsNDMap(geom=geom, data=data, unit='cm-2 s-1')
+
+
+@pytest.fixture(scope='session')
+def cosine_profile():
+    table = Table()
+    table['x_ref'] = np.linspace(-90, 90, 11) * u.deg
+    table['profile'] = np.cos(table['x_ref'].to('rad')) * u.Unit('cm-2 s-1')
+    table['profile_err'] = 0.1 * table['profile']
+    return ImageProfile(table)
+
+
 @requires_dependency('scipy')
 class TestImageProfileEstimator(object):
-
-    def setup(self):
-        unit = u.Unit('cm-2 s-1')
-        nxpix, nypix = 10, 6
-
-        # set up data as a checkerboard of 0.5 and 1.5, so that the mean and sum
-        # are not compeletely trivial to compute
-        data = 1.5 * np.ones((nypix, nxpix))
-        data[slice(0, nypix + 1, 2), slice(0, nxpix + 1, 2)] = 0.5
-        data[slice(1, nypix + 1, 2), slice(1, nxpix + 1, 2)] = 0.5
-
-        self.image = SkyImage.empty(nxpix=nxpix, nypix=nypix, unit=unit)
-        self.image.data = data
-        self.image_err = SkyImage.empty(nxpix=nxpix, nypix=nypix, unit=unit)
-        self.image_err.data = 0.1 * data
-
-    def test_lat_profile_sum(self):
+    def test_lat_profile_sum(self, checkerboard_image):
         p = ImageProfileEstimator(axis='lat', method='sum')
-        profile = p.run(self.image)
+        profile = p.run(checkerboard_image)
 
         desired = 10 * np.ones(6) * u.Unit('cm-2 s-1')
         assert_quantity_allclose(profile.profile, desired)
 
-    def test_lon_profile_sum(self):
+    def test_lon_profile_sum(self, checkerboard_image):
         p = ImageProfileEstimator(axis='lon', method='sum')
-        profile = p.run(self.image)
+        profile = p.run(checkerboard_image)
 
         desired = 6 * np.ones(10) * u.Unit('cm-2 s-1')
         assert_quantity_allclose(profile.profile, desired)
 
-    def test_lat_profile_mean(self):
+    def test_radial_profile_sum(self, checkerboard_image):
+        center = SkyCoord(0, 0, unit='deg', frame='galactic')
+        p = ImageProfileEstimator(axis='radial', method='sum', center=center)
+        profile = p.run(checkerboard_image)
+
+        desired = [4., 8., 20., 12., 12.] * u.Unit('cm-2 s-1')
+        assert_quantity_allclose(profile.profile, desired)
+
+    def test_lat_profile_mean(self, checkerboard_image):
         p = ImageProfileEstimator(axis='lat', method='mean')
-        profile = p.run(self.image)
+        profile = p.run(checkerboard_image)
 
         desired = np.ones(6) * u.Unit('cm-2 s-1')
         assert_quantity_allclose(profile.profile, desired)
 
-    def test_lon_profile_mean(self):
+    def test_lon_profile_mean(self, checkerboard_image):
         p = ImageProfileEstimator(axis='lon', method='mean')
-        profile = p.run(self.image)
+        profile = p.run(checkerboard_image)
 
         desired = np.ones(10) * u.Unit('cm-2 s-1')
         assert_quantity_allclose(profile.profile, desired)
 
-    def test_x_edges_lat(self):
+    def test_x_edges_lat(self, checkerboard_image):
         x_edges = Angle(np.linspace(-0.06, 0.06, 4), 'deg')
 
         p = ImageProfileEstimator(x_edges=x_edges, axis='lat', method='sum')
-        profile = p.run(self.image)
+        profile = p.run(checkerboard_image)
 
         desired = 20 * np.ones(3) * u.Unit('cm-2 s-1')
         assert_quantity_allclose(profile.profile, desired)
 
-    def test_x_edges_lon(self):
+    def test_x_edges_lon(self, checkerboard_image):
         x_edges = Angle(np.linspace(-0.1, 0.1, 6), 'deg')
 
         p = ImageProfileEstimator(x_edges=x_edges, axis='lon', method='sum')
-        profile = p.run(self.image)
+        profile = p.run(checkerboard_image)
 
         desired = 12 * np.ones(5) * u.Unit('cm-2 s-1')
         assert_quantity_allclose(profile.profile, desired)
 
 
 class TestImageProfile(object):
-    def setup(self):
-        table = Table()
-        table['x_ref'] = np.linspace(-90, 90, 11) * u.deg
-        table['profile'] = np.cos(table['x_ref'].to('rad')) * u.Unit('cm-2 s-1')
-        table['profile_err'] = 0.1 * table['profile']
-        self.profile = ImageProfile(table)
-
-    def test_normalize(self):
-        normalized = self.profile.normalize(mode='integral')
+    def test_normalize(self, cosine_profile):
+        normalized = cosine_profile.normalize(mode='integral')
         profile = normalized.profile
         assert_quantity_allclose(profile.sum(), 1 * u.Unit('cm-2 s-1'))
 
-        normalized = self.profile.normalize(mode='peak')
+        normalized = cosine_profile.normalize(mode='peak')
         profile = normalized.profile
         assert_quantity_allclose(profile.max(), 1 * u.Unit('cm-2 s-1'))
 
-    def test_profile_x_edges(self):
-        assert_quantity_allclose(self.profile.x_ref.sum(), 0 * u.deg)
+    def test_profile_x_edges(self, cosine_profile):
+        assert_quantity_allclose(cosine_profile.x_ref.sum(), 0 * u.deg)
 
     @requires_dependency('scipy')
     @pytest.mark.parametrize('kernel', ['gauss', 'box'])
-    def test_smooth(self, kernel):
+    def test_smooth(self, cosine_profile, kernel):
         # smoothing should preserve the mean
-        desired_mean = self.profile.profile.mean()
-        smoothed = self.profile.smooth(kernel, radius=3)
+        desired_mean = cosine_profile.profile.mean()
+        smoothed = cosine_profile.smooth(kernel, radius=3)
 
         assert_quantity_allclose(smoothed.profile.mean(), desired_mean)
 
         # smoothing should decrease errors
-        assert smoothed.profile_err.mean() < self.profile.profile_err.mean()
+        assert smoothed.profile_err.mean() < cosine_profile.profile_err.mean()
 
     @requires_dependency('matplotlib')
-    def test_peek(self):
-        self.profile.peek()
+    def test_peek(self, cosine_profile):
+        cosine_profile.peek()
         mpl_savefig_check()
-
-
-@requires_dependency('scipy')
-def test_radial_profile():
-    image = SkyImage.empty()
-    image.data.fill(1)
-    center = image.center
-    radius = Angle([0.1, 0.2, 0.4, 0.5, 1.0], 'deg')
-
-    labels = radial_profile_label_image(image, center, radius)
-    assert labels.data.max() == 5
-
-    profile = radial_profile(image, center, radius)
-    assert len(profile) == 4
-    assert_allclose(profile['MEAN'], 1)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -480,8 +480,8 @@ class WcsGeom(MapGeom):
     def get_pix(self, idx=None, mode='center'):
         """Get map pix coordinates from the geometry.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         mode : {'center', 'edges'}
             Get center or edge pix coordinates for the spatial axes.
 
@@ -558,22 +558,17 @@ class WcsGeom(MapGeom):
     def get_coord(self, idx=None, flat=False, mode='center'):
         """Get map coordinates from the geometry.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         mode : {'center', 'edges'}
             Get center or edge coordinates for the spatial axes.
 
-<<<<<<< HEAD
         Returns
         -------
         coord : `~MapCoord`
             Map coordinate object.
         """
         pix = self.get_pix(idx=idx, mode=mode)
-=======
-    def get_coord(self, idx=None, flat=False, mode='center'):
-        pix = self._get_pix_coords(idx=idx, mode=mode)
->>>>>>> Migrate gammapy.image.profile to maps and clean up
         coords = self.pix_to_coord(pix)
 
         if flat:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -563,12 +563,17 @@ class WcsGeom(MapGeom):
         mode : {'center', 'edges'}
             Get center or edge coordinates for the spatial axes.
 
+<<<<<<< HEAD
         Returns
         -------
         coord : `~MapCoord`
             Map coordinate object.
         """
         pix = self.get_pix(idx=idx, mode=mode)
+=======
+    def get_coord(self, idx=None, flat=False, mode='center'):
+        pix = self._get_pix_coords(idx=idx, mode=mode)
+>>>>>>> Migrate gammapy.image.profile to maps and clean up
         coords = self.pix_to_coord(pix)
 
         if flat:


### PR DESCRIPTION
This PR migrates `gammapy.image.measure` and `gammapy.image.profile` to `gammapy.maps` and makes a general clean up. The `radial_profile` and related methods have been remove, instead a `radial` option has been added to the `ImageProfileEstimator`. 