### PR TITLE
Add required dependency to scipy for test_containment_radius_map

### DIFF
--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -82,7 +82,7 @@ def test_psfmap(tmpdir):
 
     assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)
 
-
+@requires_dependency('scipy')
 def test_containment_radius_map(tmpdir):
     psf = fake_psf3d(0.15 * u.deg)
     pointing = SkyCoord(0, 0, unit='deg')


### PR DESCRIPTION
This is a very small change to ensure that tests do not fail in travis CI when scipy is not available. 
test_psf_map.py