### PR TITLE
Less optional dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython iminuit'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils pygments sherpa libgfortran regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran runipy regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image pandas naima photutils sherpa libgfortran regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image pandas naima photutils sherpa regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image pandas naima photutils regions reproject pandoc ipython iminuit'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image pandas naima photutils pygments sherpa libgfortran regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image pandas naima photutils sherpa libgfortran runipy regions reproject pandoc ipython'
 
         - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython iminuit'
-        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils pygments sherpa libgfortran regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy h5py matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran runipy regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils regions reproject pandoc ipython iminuit'
+        - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils pygments sherpa libgfortran regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties scikit-image scikit-learn pandas naima photutils sherpa libgfortran runipy regions reproject pandoc ipython'
 
         - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,12 +64,12 @@ plot_html_show_source_link = False
 # We currently want to link to the latest development version of the astropy docs,
 # so we override the `intersphinx_mapping` entry pointing to the stable docs version
 # that is listed in `astropy/sphinx/conf.py`.
+intersphinx_mapping.pop('h5py', None)
 intersphinx_mapping['matplotlib'] = ('https://matplotlib.org/', None)
 intersphinx_mapping['astropy'] = ('http://docs.astropy.org/en/latest/', None)
 intersphinx_mapping['regions'] = ('http://astropy-regions.readthedocs.io/en/latest/', None)
 intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/', None)
 intersphinx_mapping['uncertainties'] = ('http://pythonhosted.org/uncertainties/', None)
-intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
 intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
 intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/', None)
 intersphinx_mapping['naima'] = ('http://naima.readthedocs.io/en/latest/', None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,14 +67,14 @@ plot_html_show_source_link = False
 intersphinx_mapping.pop('h5py', None)
 intersphinx_mapping['matplotlib'] = ('https://matplotlib.org/', None)
 intersphinx_mapping['astropy'] = ('http://docs.astropy.org/en/latest/', None)
-intersphinx_mapping['regions'] = ('http://astropy-regions.readthedocs.io/en/latest/', None)
-intersphinx_mapping['reproject'] = ('http://reproject.readthedocs.io/en/latest/', None)
-intersphinx_mapping['uncertainties'] = ('http://pythonhosted.org/uncertainties/', None)
-intersphinx_mapping['skimage'] = ('http://scikit-image.org/docs/stable/', None)
-intersphinx_mapping['photutils'] = ('http://photutils.readthedocs.io/en/latest/', None)
-intersphinx_mapping['naima'] = ('http://naima.readthedocs.io/en/latest/', None)
-intersphinx_mapping['gadf'] = ('http://gamma-astro-data-formats.readthedocs.io/en/latest/', None)
-intersphinx_mapping['iminuit'] = ('http://iminuit.readthedocs.io/en/latest/', None)
+intersphinx_mapping['regions'] = ('https://astropy-regions.readthedocs.io/en/latest/', None)
+intersphinx_mapping['reproject'] = ('https://reproject.readthedocs.io/en/latest/', None)
+intersphinx_mapping['uncertainties'] = ('https://pythonhosted.org/uncertainties/', None)
+intersphinx_mapping['skimage'] = ('https://scikit-image.org/docs/stable/', None)
+intersphinx_mapping['photutils'] = ('https://photutils.readthedocs.io/en/latest/', None)
+intersphinx_mapping['naima'] = ('https://naima.readthedocs.io/en/latest/', None)
+intersphinx_mapping['gadf'] = ('https://gamma-astro-data-formats.readthedocs.io/en/latest/', None)
+intersphinx_mapping['iminuit'] = ('https://iminuit.readthedocs.io/en/latest/', None)
 
 
 # List of patterns, relative to source directory, that match files and

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -14,7 +14,7 @@ Introduction
 `gammapy.datasets` contains function to easily access datasets that are
 relevant for gamma-ray astronomy.
 
-The functions have a naming pattern (following the `sklearn.datasets` lead):
+The functions have a naming pattern (following scikit-learn lead):
 
 * ``load_*`` functions load datasets that are distributed with Gammapy (bundled in the repo)
 * ``fetch_*`` functions fetch datasets from the web (either from ``gammapy-extra`` or other sites)

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -437,7 +437,7 @@ Another option is to pass an integer seed to every function that generates rando
 
 This pattern was inspired by the way
 `scikit-learn handles random numbers <http://scikit-learn.org/stable/developers/#random-numbers>`__.
-We have changed the ``None`` option of `sklearn.utils.check_random_state` to ``'global-rng'``,
+We have changed the ``None`` option of ``sklearn.utils.check_random_state`` to ``'global-rng'``,
 because we felt that this meaning for ``None`` was confusing given that `numpy.random.RandomState`
 uses a different meaning (for which we use the option ``'global-rng'``).
 

--- a/docs/install/dependencies.rst
+++ b/docs/install/dependencies.rst
@@ -42,13 +42,8 @@ Currently optional dependencies that are being considered as core dependencies:
 Allowed optional dependencies:
 
 * `matplotlib`_ for plotting
-* `pandas`_ CSV read / write; DataFrame
-* `scikit-learn`_ for some data analysis tasks
-* `GammaLib`_ and `ctools`_ for simulating data and likelihood fitting
 * `uncertainties`_ for linear error propagation
-* `astroplan`_ for observation planning and scheduling
 * `iminuit`_ for fitting by optimization
 * `emcee`_ for fitting by MCMC sampling
-* `h5py`_ for `HDF5 <http://en.wikipedia.org/wiki/Hierarchical_Data_Format>`__ data handling
-* `healpy`_ for `HEALPIX <http://healpix.jpl.nasa.gov/>`__ data handling
+* `healpy`_ for `HEALPIX`_ data handling
 * `nbsphinx`_ for transformation of Jupyter notebooks into fixed-text documentation

--- a/docs/install/macports.rst
+++ b/docs/install/macports.rst
@@ -75,7 +75,7 @@ Here's some examples for some scientific computing and astronomy packages:
     sudo port install \
         py36-pip py36-pytest \
         py36-scipy py36-matplotlib py36-scikit-image \
-        py36-pandas py36-emcee py36-ipython py36-uncertainties \
+        py36-emcee py36-ipython py36-uncertainties \
         py36-healpy py36-cython
 
 To search which software is available in Macports (searches package name and description):

--- a/docs/install/macports.rst
+++ b/docs/install/macports.rst
@@ -74,7 +74,7 @@ Here's some examples for some scientific computing and astronomy packages:
 
     sudo port install \
         py36-pip py36-pytest \
-        py36-scipy py36-matplotlib py36-scikit-image py36-scikit-learn \
+        py36-scipy py36-matplotlib py36-scikit-image \
         py36-pandas py36-emcee py36-ipython py36-uncertainties \
         py36-healpy py36-cython
 

--- a/docs/install/macports.rst
+++ b/docs/install/macports.rst
@@ -75,7 +75,7 @@ Here's some examples for some scientific computing and astronomy packages:
     sudo port install \
         py36-pip py36-pytest \
         py36-scipy py36-matplotlib py36-scikit-image py36-scikit-learn \
-        py36-pandas py36-emcee py36-h5py py36-ipython py36-uncertainties \
+        py36-pandas py36-emcee py36-ipython py36-uncertainties \
         py36-healpy py36-cython
 
 To search which software is available in Macports (searches package name and description):

--- a/docs/install/other.rst
+++ b/docs/install/other.rst
@@ -32,7 +32,7 @@ The following packages are available:
 .. code-block:: bash
 
     sudo apt-get install \
-        python3-pip python3-scipy python3-matplotlib python3-skimage python3-sklearn \
+        python3-pip python3-scipy python3-matplotlib python3-skimage \
         python3-yaml ipython3-notebook python3-uncertainties \
         python3-astropy python3-click
 

--- a/docs/install/other.rst
+++ b/docs/install/other.rst
@@ -33,7 +33,7 @@ The following packages are available:
 
     sudo apt-get install \
         python3-pip python3-scipy python3-matplotlib python3-skimage python3-sklearn \
-        python3-pandas python3-h5py python3-yaml ipython3-notebook python3-uncertainties \
+        python3-yaml ipython3-notebook python3-uncertainties \
         python3-astropy python3-click
 
 The following packages have to be installed with pip:

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -32,6 +32,7 @@
 .. _conda: http://conda.pydata.org/
 .. _PyFACT: http://adsabs.harvard.edu/abs/2012AIPC.1505..789R
 .. _healpy: https://healpy.readthedocs.io/en/latest/
+.. _HEALPix: https://en.wikipedia.org/wiki/HEALPix
 .. _PyYAML: https://pypi.org/project/PyYAML/
 .. _emcee: http://dan.iel.fm/emcee/current/
 .. _ctapipe: https://github.com/cta-observatory/ctapipe

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -17,8 +17,6 @@ TESTED_VERSIONS[packagename] = version.version
 # Declare for which packages version numbers should be displayed
 # when running the tests
 PYTEST_HEADER_MODULES['cython'] = 'cython'
-PYTEST_HEADER_MODULES['skimage'] = 'skimage'
-PYTEST_HEADER_MODULES['sklearn'] = 'sklearn'
 PYTEST_HEADER_MODULES['uncertainties'] = 'uncertainties'
 PYTEST_HEADER_MODULES['iminuit'] = 'iminuit'
 PYTEST_HEADER_MODULES['astropy'] = 'astropy'

--- a/gammapy/datasets/fermi.py
+++ b/gammapy/datasets/fermi.py
@@ -84,7 +84,7 @@ class FermiLATDataset(object):
         path = make_path(filename)
         self._path = path.parents[0].resolve()
         with path.open() as fh:
-            self.config = yaml.load(fh)
+            self.config = yaml.safe_load(fh)
 
     @property
     def name(self):

--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -26,7 +26,6 @@ GAMMAPY_DEPENDENCIES = [
     'pytest',
     'sphinx',
 
-    'pandas',
     'healpy',
     'regions',
     'iminuit',

--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -27,7 +27,6 @@ GAMMAPY_DEPENDENCIES = [
     'sphinx',
 
     'pandas',
-    'h5py',
     'healpy',
     'regions',
     'iminuit',


### PR DESCRIPTION
In Gammapy so far we were mentioning `h5py`, `pandas` and `scikit-learn` as allowed optional dependencies, and also to users in the install section, but we weren't using them.

Especially in the interest of CTA ST application, but also generally for users, it's important to reduce the number of dependencies, so here I'm doing that.

I don't think `h5py`, `pandas` and `scikit-learn` should be disallowed for Gammapy necessarily, but let's only introduce and mention them if they are used in a substantial way.

For scikit-image, it needs a bit of work, I'll do that separately. See #1494 .