### PR TITLE
Add and improve "edges" mode for map pix coordinates

### DIFF
--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -241,14 +241,14 @@ class TestSkyModelMapEvaluator:
         out = evaluator.compute_dnde()
         assert out.shape == (2, 4, 5)
         assert out.unit == 'cm-2 s-1 TeV-1 deg-2'
-        assert_allclose(out.value.mean(), 7.460919e-14)
+        assert_allclose(out.value.mean(), 7.460919e-14, rtol=1e-5)
 
     @staticmethod
     def test_compute_flux(evaluator):
         out = evaluator.compute_flux()
         assert out.shape == (2, 4, 5)
         assert out.unit == 'cm-2 s-1'
-        assert_allclose(out.value.mean(), 1.828206748668197e-14)
+        assert_allclose(out.value.mean(), 1.828206748668197e-14, rtol=1e-5)
 
     @staticmethod
     def test_apply_psf(evaluator):
@@ -256,17 +256,17 @@ class TestSkyModelMapEvaluator:
         npred = evaluator.apply_exposure(flux)
         out = evaluator.apply_psf(npred)
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.mean(), 1.2574065e-08)
+        assert_allclose(out.data.mean(), 1.2574065e-08, rtol=1e-5)
 
     @staticmethod
     def test_apply_edisp(evaluator):
         flux = evaluator.compute_flux()
         out = evaluator.apply_edisp(flux.value)
         assert out.shape == (2, 4, 5)
-        assert_allclose(out.mean(), 1.828206748668197e-14)
+        assert_allclose(out.mean(), 1.828206748668197e-14, rtol=1e-5)
 
     @staticmethod
     def test_compute_npred(evaluator):
         out = evaluator.compute_npred()
         assert out.shape == (2, 4, 5)
-        assert_allclose(out.sum(), 45.02963e-07)
+        assert_allclose(out.sum(), 45.02963e-07, rtol=1e-5)

--- a/gammapy/cube/tests/test_new.py
+++ b/gammapy/cube/tests/test_new.py
@@ -83,8 +83,8 @@ def test_make_map_fov_background(bkg_3d, counts_cube):
     )
 
     assert m.data.shape == (15, 120, 200)
-    assert_allclose(m.data[0, 0, 0], 0.013959366925415072)
-    assert_allclose(m.data.sum(), 1356.2551841113177)
+    assert_allclose(m.data[0, 0, 0], 0.013959, rtol=1e-4)
+    assert_allclose(m.data.sum(), 1356.2551, rtol=1e-5)
 
     # TODO: Check that `offset_max` is working properly
     # pos = SkyCoord(85.6, 23, unit='deg')

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -156,22 +156,22 @@ def test_wcsgeom_solid_angle_ait():
 
 def test_wcsgeom_get_coord():
     geom = WcsGeom.create(skydir=(0, 0), npix=(4, 3), binsz=1,
-                          coordsys='GAL', proj='CAR', axes=axes1)
+                          coordsys='GAL', proj='CAR')
     coord = geom.get_coord(mode='edges')
-    assert_allclose(coord.lon[0, 0, 0], 2)
-    assert_allclose(coord.lat[0, 0, 0], -1.5)
+    assert_allclose(coord.lon[0, 0], 2)
+    assert_allclose(coord.lat[0, 0], -1.5)
 
 
 def test_wcsgeom_get_pix_coords():
     geom = WcsGeom.create(skydir=(0, 0), npix=(4, 3), binsz=1,
                           coordsys='GAL', proj='CAR', axes=axes1)
-    idx_center = geom._get_pix_coords(mode='center')
+    idx_center = geom.get_pix(mode='center')
 
     for idx in idx_center:
         assert idx.shape == (2, 3, 4)
         assert_allclose(idx[0, 0, 0], 0)
 
-    idx_edge = geom._get_pix_coords(mode='edges')
+    idx_edge = geom.get_pix(mode='edges')
     for idx, desired in zip(idx_edge, [-0.5, -0.5, 0]):
         assert idx.shape == (2, 4, 5)
         assert_allclose(idx[0, 0, 0], desired)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from ..wcs import WcsGeom
@@ -137,16 +138,11 @@ def test_wcsgeom_solid_angle():
     # Check array size
     assert solid_angle.shape == (2, npix, npix)
 
-    # Note: test is valid for small enough bin sizes since
-    # WcsGeom.solid_angle() approximates the true solid angle value
-
     # Test at b = 0 deg
-    solid_lat0 = binsz.to('rad').value * (np.sin(binsz)) * u.sr
-    assert_allclose(solid_angle[0, 5, 5], solid_lat0, rtol=1e-3)
+    assert_quantity_allclose(solid_angle[0, 5, 5], 0.0003046 * u.sr, rtol=1e-3)
 
     # Test at b = 5 deg
-    solid_lat5 = binsz.to('rad').value * (np.sin(5 * binsz) - np.sin(4 * binsz.to('rad').value)) * u.sr
-    assert_allclose(solid_angle[0, 9, 5], solid_lat5, rtol=1e-3)
+    assert_quantity_allclose(solid_angle[0, 9, 5], 0.0003038  * u.sr, rtol=1e-3)
 
 
 def test_wcsgeom_solid_angle_ait():

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -157,6 +157,27 @@ def test_wcsgeom_solid_angle_ait():
     solid_angle = ait_geom.solid_angle()
     assert np.isnan(solid_angle[0, 0])
 
+def test_wcsgeom_get_coord():
+    geom = WcsGeom.create(skydir=(0, 0), npix=(4, 3), binsz=1,
+                              coordsys='GAL', proj='CAR')
+    coords = geom.get_coord()
+
+
+def test_wcsgeom_get_idx():
+    geom = WcsGeom.create(skydir=(0, 0), npix=(4, 3), binsz=1,
+                          coordsys='GAL', proj='CAR', axes=axes1)
+    idx_center = geom.get_idx()
+
+    for idx in idx_center:
+        assert idx.shape == (2, 3, 4)
+        assert_allclose(idx[0, 0, 0], 0)
+
+    idx_edge = geom._get_pix_coords(mode='edges')
+    for idx, desired in zip(idx_edge, [-0.5, -0.5, 0]):
+        assert idx.shape == (2, 4, 5)
+        assert_allclose(idx[0, 0, 0], desired)
+
+
 
 def test_geom_repr():
     geom = WcsGeom.create(skydir=(0, 0), npix=(10, 4), binsz=50,

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -153,16 +153,19 @@ def test_wcsgeom_solid_angle_ait():
     solid_angle = ait_geom.solid_angle()
     assert np.isnan(solid_angle[0, 0])
 
+
 def test_wcsgeom_get_coord():
     geom = WcsGeom.create(skydir=(0, 0), npix=(4, 3), binsz=1,
-                              coordsys='GAL', proj='CAR')
-    coords = geom.get_coord()
+                          coordsys='GAL', proj='CAR', axes=axes1)
+    coord = geom.get_coord(mode='edges')
+    assert_allclose(coord.lon[0, 0, 0], 2)
+    assert_allclose(coord.lat[0, 0, 0], -1.5)
 
 
-def test_wcsgeom_get_idx():
+def test_wcsgeom_get_pix_coords():
     geom = WcsGeom.create(skydir=(0, 0), npix=(4, 3), binsz=1,
                           coordsys='GAL', proj='CAR', axes=axes1)
-    idx_center = geom.get_idx()
+    idx_center = geom._get_pix_coords(mode='center')
 
     for idx in idx_center:
         assert idx.shape == (2, 3, 4)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -545,17 +545,26 @@ class WcsGeom(MapGeom):
         return pix
 
     def get_coord(self, idx=None, flat=False, mode='center'):
+        """Get map coordinates from the geometry.
+
+        Paramters
+        ---------
+        mode : {'center', 'edges'}
+            Get center or edge coordinates for the spatial axes.
+
+        Returns
+        -------
+        coord : `~MapCoord`
+            Map coordinate object.
+        """
         pix = self._get_pix_coords(idx=idx, mode=mode)
         coords = self.pix_to_coord(pix)
+
         if flat:
             coords = tuple([c[np.isfinite(c)] for c in coords])
 
-        cdict = OrderedDict([
-            ('lon', coords[0]),
-            ('lat', coords[1]),
-        ])
-        for i, axis in enumerate(self.axes):
-            cdict[axis.name] = coords[i + 2]
+        axes_names = ['lon', 'lat'] + [ax.name for ax in self.axes]
+        cdict = OrderedDict(zip(axes_names, coords))
 
         return MapCoord.create(cdict, coordsys=self.coordsys)
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -471,14 +471,25 @@ class WcsGeom(MapGeom):
     def get_image_wcs(self, idx):
         raise NotImplementedError
 
-    def get_idx(self, idx=None, local=False, flat=False):
-        pix = self._get_pix_coords(idx=idx, mode='center')
+    def get_idx(self, idx=None, flat=False):
+        pix = self.get_pix(idx=idx, mode='center')
         if flat:
             pix = tuple([p[np.isfinite(p)] for p in pix])
         return pix_tuple_to_idx(pix)
 
-    def _get_pix_coords(self, idx=None, mode='center'):
+    def get_pix(self, idx=None, mode='center'):
+        """Get map pix coordinates from the geometry.
 
+        Paramters
+        ---------
+        mode : {'center', 'edges'}
+            Get center or edge pix coordinates for the spatial axes.
+
+        Returns
+        -------
+        coord : tuple
+            Map pix coordinate tuple.
+        """
         # FIXME: Figure out if there is some way to employ open/sparse
         # vectors
 
@@ -557,7 +568,7 @@ class WcsGeom(MapGeom):
         coord : `~MapCoord`
             Map coordinate object.
         """
-        pix = self._get_pix_coords(idx=idx, mode=mode)
+        pix = self.get_pix(idx=idx, mode=mode)
         coords = self.pix_to_coord(pix)
 
         if flat:
@@ -698,10 +709,6 @@ class WcsGeom(MapGeom):
         The array has the same dimension as the WcsGeom object.
         To return solid angles for the spatial dimensions only use: WcsGeom.to_image().solid_angle()
         """
-        # TODO: Improve by exposing a mode 'edge' for get_coord
-        # Note that edge is applied only to spatial coordinates in the following call
-        # Note also that pix_to_coord is already called in _get_pix_coords.
-        # This should be made more efficient.
         coord = self.get_coord(mode='edges')
         lon = coord.lon * np.pi / 180.
         lat = coord.lat * np.pi / 180.

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -683,9 +683,6 @@ class WcsGeom(MapGeom):
         return self.__class__(wcs, npix, cdelt=cdelt,
                               axes=copy.deepcopy(self.axes))
 
-    def to_slice(self, slices):
-        raise NotImplementedError
-
     def solid_angle(self):
         """Solid angle array (`~astropy.units.Quantity` in ``sr``).
 
@@ -697,18 +694,20 @@ class WcsGeom(MapGeom):
         # Note also that pix_to_coord is already called in _get_pix_coords.
         # This should be made more efficient.
         coord = self.get_coord(mode='edges')
+        lon = coord.lon * np.pi / 180.
+        lat = coord.lat * np.pi / 180.
 
         # Compute solid angle using the approximation that it's
         # the product between angular separation of pixel corners.
         # First index is "y", second index is "x"
-        ylo_xlo = coord.lon[..., :-1, :-1], coord.lat[..., :-1, :-1]
-        ylo_xhi = coord.lon[..., :-1, 1:], coord.lat[..., :-1, 1:]
-        yhi_xlo = coord.lon[..., 1:, :-1], coord.lat[..., 1:, :-1]
+        ylo_xlo = lon[..., :-1, :-1], lat[..., :-1, :-1]
+        ylo_xhi = lon[..., :-1, 1:], lat[..., :-1, 1:]
+        yhi_xlo = lon[..., 1:, :-1], lat[..., 1:, :-1]
 
         dx = angular_separation(*(ylo_xlo + ylo_xhi))
         dy = angular_separation(*(ylo_xlo + yhi_xlo))
 
-        return u.Quantity(dx * dy, 'deg2').to('sr')
+        return u.Quantity(dx * dy, 'sr')
 
     def get_region_mask_array(self, region):
         """Return mask of pixels inside region in the the form of boolean array


### PR DESCRIPTION
This PR adds the `mode='edges'` option to `WcsGeom.get_coord()`. Note that I had to slightly change the  implementation of `WcsGeom.solif_angle()`, which causes the tiny changes in the cube model and fitting tests. 