### PR TITLE
Improve iminuit fitting interface a little bit

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -93,8 +93,7 @@ class MapFit(object):
         opts_minuit : dict (optional)
             Options passed to `iminuit.Minuit` constructor
         """
-        parameters, minuit = fit_iminuit(parameters=self.model.parameters,
-                                         function=self.total_stat,
-                                         opts_minuit=opts_minuit)
-        self.model.parameters = parameters
+        minuit = fit_iminuit(parameters=self.model.parameters,
+                             function=self.total_stat,
+                             opts_minuit=opts_minuit)
         self._minuit = minuit

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -130,6 +130,7 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
     fit.fit()
     pars = fit.model.parameters
 
+    assert sky_model is fit.model
     assert sky_model.parameters['lon_0'] is fit.model.parameters['lon_0']
     assert sky_model.parameters['lon_0'] is sky_model.spatial_model.parameters['lon_0']
 

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -454,12 +454,12 @@ class SpectrumFit(object):
 
     def _fit_iminuit(self, opts_minuit):
         """Iminuit minimization"""
-        parameters, minuit = fit_iminuit(parameters=self._model.parameters,
-                                         function=self.total_stat,
-                                         opts_minuit=opts_minuit)
+        minuit = fit_iminuit(parameters=self._model.parameters,
+                             function=self.total_stat,
+                             opts_minuit=opts_minuit)
         self._iminuit_fit = minuit
         log.debug(minuit)
-        self._make_fit_result(parameters)
+        self._make_fit_result(self._model.parameters)
 
     def _make_fit_result(self, parameters):
         """Bundle fit results into `~gammapy.spectrum.SpectrumFitResult`.

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -231,7 +231,7 @@ class TestSpectralFit:
         assert_quantity_allclose(pars['amplitude'].quantity,
                                  2.0082864582748925e-7 * u.Unit('m-2 s-1 TeV-1'),
                                  rtol=1e-2)
-        assert_allclose(result.npred_src[60], 0.5642179482961884)
+        assert_allclose(result.npred_src[60], 0.5638139014342695)
         self.fit.result[0].to_table()
 
     def test_basic_errors(self):

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -45,9 +45,12 @@ def fit_iminuit(parameters, function, opts_minuit=None):
                     **opts_minuit)
 
     minuit.migrad()
+
+    # Copy final results into the parameters object
+    parameters.update_values_from_tuple(minuit.args)
     parameters.covariance = _get_covar(minuit)
 
-    return parameters, minuit
+    return minuit
 
 
 class MinuitFunction(object):
@@ -66,8 +69,7 @@ class MinuitFunction(object):
         self.parameters = parameters
 
     def fcn(self, *values):
-        for value, parameter in zip(values, self.parameters.parameters):
-            parameter.value = value
+        self.parameters.update_values_from_tuple(values)
         return self.function(self.parameters)
 
 

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -344,3 +344,8 @@ class ParameterList(object):
     def copy(self):
         """A deep copy"""
         return copy.deepcopy(self)
+
+    def update_values_from_tuple(self, values):
+        """Update parameter values from a tuple of values."""
+        for value, parameter in zip(values, self.parameters):
+            parameter.value = value


### PR DESCRIPTION
This PR improves the iminuit fitting interface a little bit, after discussions with @adonath and @joleroi .

- Copy best-fit parameter values into `parameters` object at the end of `fit_iminuit`
- Very small adjustment in reference value in spectrum fit with iminuit as a result of that
- No longer return `parameters` object from `fit_iminuit`, not needed

@joleroi @adonath - Note that there's still a double-update of parameter values during likelihood evaluation, once in the likelihood function on the first line in MapFit, once in the Minuit wrapper function.

I'm really having a hard time to decide on the likelihood callback interface, and who updates the parameter values. @adonath and @joleroi - I'd suggest you merge this and then continue as you like for today, and then we re-discuss this question also with @registerrier tomorrow.