### PR TITLE
Auto-format docs RST pages

### DIFF
--- a/docs/astro/darkmatter/index.rst
+++ b/docs/astro/darkmatter/index.rst
@@ -27,7 +27,7 @@ analyses.
 There are many other packages out there that implement functionality for dark
 matter analysis, their capabilities are summarized in the following
 
-GammaLib 
+GammaLib
 --------
 
 The `GammaLib 1.3 release`_ contains radial profile spatial models, including
@@ -57,7 +57,7 @@ serialization format
     <parameter free="0" max="360" min="-360" name="RA" scale="1.0" value="128.8272"/>
     <parameter free="0" max="90" min="-90" name="DEC" scale="1.0" value="-45.1762"/>
     </spatialModel>
-    </source> 
+    </source>
 
 The `DMFitFunction`_ is only a spectral model and the spatial component is
 set using a point source. A spatial template can obviously be used. Utilities
@@ -100,7 +100,7 @@ particle model. GamLike can somehow be use to reproduce HESS results (Section
 6.2.2. of the DarkBit paper). But I don't fully understand how.
 
 
-  
+
 Getting Started
 ===============
 
@@ -118,7 +118,7 @@ Reference/API
     :include-all-objects:
 
 
-.. _GammaLib 1.3 release: http://cta.irap.omp.eu/gammalib-devel/admin/release_history/1.3.html 
+.. _GammaLib 1.3 release: http://cta.irap.omp.eu/gammalib-devel/admin/release_history/1.3.html
 .. _Feature request #1520:  https://cta-redmine.irap.omp.eu/issues/1520
 .. _Cirelli et al. 2011: http://iopscience.iop.org/article/10.1088/1475-7516/2011/03/051/pdf
 .. _Cirelli 2014: http://www.marcocirelli.net/otherworks/HDR.pdf
@@ -143,7 +143,7 @@ Reference/API
 
 .. _GAMBIT: https://gambit.hepforge.org/
 
-.. _DarkBit: https://link.springer.com/article/10.1140%2Fepjc%2Fs10052-017-5155-4 
+.. _DarkBit: https://link.springer.com/article/10.1140%2Fepjc%2Fs10052-017-5155-4
 
 
 

--- a/docs/astro/index.rst
+++ b/docs/astro/index.rst
@@ -16,9 +16,8 @@ This module contains utility functions for some astrophysical scenarios:
 * `gammapy.astro.darkmatter` for dark matter spatial and spectral models
 
 The `gammapy.astro` module is in a prototyping phase and its scope and future
-are currently beeing discussed. It is likely that some of the functionality
-will be removed or split out into a separate package at some point.
-
+are currently beeing discussed. It is likely that some of the functionality will
+be removed or split out into a separate package at some point.
 
 Getting Started
 ===============
@@ -27,8 +26,9 @@ The ``gammapy.astro`` namespace is empty. Use these import statements:
 
 .. code-block:: python
 
-   from gammapy.astro import source
-   from gammapy.astro import population
+    from gammapy.astro import source
+    from gammapy.astro import population
+    from gammapy.astro import darkmatter
 
 Please refer to the Getting Started section of each module for a further
 introduction
@@ -37,8 +37,8 @@ Sub-packages
 ============
 
 .. toctree::
-  :maxdepth: 1
+    :maxdepth: 1
 
-  source/index
-  population/index
-  darkmatter/index
+    source/index
+    population/index
+    darkmatter/index

--- a/docs/astro/population/index.rst
+++ b/docs/astro/population/index.rst
@@ -50,14 +50,15 @@ surface density of pulsars and related objects used in literature:
 
 .. plot:: astro/population/plot_radial_distributions.py
 
-TODO: add illustration of Galactocentric z-distribution model and combined
-(r, z) distribution for the Besancon model.
+TODO: add illustration of Galactocentric z-distribution model and combined (r,
+z) distribution for the Besancon model.
 
 Spiral arm models
 -----------------
 
 Two spiral arm models of the Milky way are available:
-(`~gammapy.astro.population.ValleeSpiral` and `gammapy.astro.population.FaucherSpiral`)
+`~gammapy.astro.population.ValleeSpiral` and
+`gammapy.astro.population.FaucherSpiral`
 
 .. plot:: astro/population/plot_spiral_arm_models.py
 

--- a/docs/astro/population/plot_spiral_arm_models.py
+++ b/docs/astro/population/plot_spiral_arm_models.py
@@ -4,7 +4,6 @@ import matplotlib.pyplot as plt
 from astropy.units import Quantity
 from gammapy.astro.population.spatial import ValleeSpiral, FaucherSpiral
 
-
 fig = plt.figure(figsize=(7, 8))
 rect = [0.12, 0.12, 0.85, 0.85]
 ax_cartesian = fig.add_axes(rect)

--- a/docs/astro/source/index.rst
+++ b/docs/astro/source/index.rst
@@ -9,7 +9,8 @@ Astrophysical source models (`gammapy.astro.source`)
 Introduction
 ============
 
-The `gammapy.astro.source` module contains classes of source models, which can be used for population synthesis of galactic gamma-ray sources.
+The `gammapy.astro.source` module contains classes of source models, which can
+be used for population synthesis of galactic gamma-ray sources.
 
 Getting Started
 ===============
@@ -22,11 +23,11 @@ Using `gammapy.astro.source`
 The following source models are available:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   snr
-   pwn
-   pulsar
+    snr
+    pwn
+    pulsar
 
 Reference/API
 =============

--- a/docs/background/index.rst
+++ b/docs/background/index.rst
@@ -9,30 +9,29 @@ Background estimation (``background``)
 Introduction
 ============
 
-`gammapy.background` contains methods to estimate and model background for specral,
-image based and cube analyses.
+`gammapy.background` contains methods to estimate and model background for
+specral, image based and cube analyses.
 
-Most of the methods implemented are described in [Berge2007]_.
-Section 7.3 "Background subtraction"
-and Section 7.4 "Acceptance determination and predicted background"
-in [Naurois2012]_ describe mostly the same methods as [Berge2007]_,
+Most of the methods implemented are described in [Berge2007]_. Section 7.3
+"Background subtraction" and Section 7.4 "Acceptance determination and predicted
+background" in [Naurois2012]_ describe mostly the same methods as [Berge2007]_,
 except for the "2D acceptance model" described in Section 7.4.3.
 
 Getting Started
 ===============
 
-
-* TODO: example how to read and use a 2D and A 3D background model
+TODO: example how to read and use a 2D and A 3D background model
 
 Using `gammapy.background`
 --------------------------
 
-If you'd like to learn more about using `gammapy.background`, read the following sub-pages:
+If you'd like to learn more about using `gammapy.background`, read the following
+sub-pages:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   reflected
+    reflected
 
 Reference/API
 =============

--- a/docs/background/make_reflected_regions.py
+++ b/docs/background/make_reflected_regions.py
@@ -6,11 +6,9 @@ from regions import CircleSkyRegion
 from gammapy.maps import WcsNDMap
 from gammapy.background import ReflectedRegionsFinder
 
-exclusion_mask = WcsNDMap.create(
-    npix=(801, 701), binsz=0.01, skydir=(83.633, 23.014),
-)
-
 # Exclude a rectangular region
+exclusion_mask = WcsNDMap.create(npix=(801, 701), binsz=0.01, skydir=(83.6, 23.0))
+
 coords = exclusion_mask.geom.get_coord().skycoord
 mask = (Angle('23d') < coords.dec) & (coords.dec < Angle('24d'))
 exclusion_mask.data = np.invert(mask)

--- a/docs/background/reflected.rst
+++ b/docs/background/reflected.rst
@@ -8,11 +8,10 @@ Reflected regions
 
 .. currentmodule:: gammapy.background
 
-
 Details on the reflected regions method can be found in [Berge2007]_
 
-The following example illustrates how to create reflected regions
-for a given circular on region and exclusion mask.
+The following example illustrates how to create reflected regions for a given
+circular on region and exclusion mask.
 
 .. plot:: background/make_reflected_regions.py
-   :include-source:
+    :include-source:

--- a/docs/catalog/gammacat.rst
+++ b/docs/catalog/gammacat.rst
@@ -6,8 +6,8 @@
 gamma-cat
 *********
 
-``gamma-cat`` (https://github.com/gammapy/gamma-cat) is an
-open data collection and source catalog for TeV gamma-ray astronomy.
+``gamma-cat`` (https://github.com/gammapy/gamma-cat) is an open data collection
+and source catalog for TeV gamma-ray astronomy.
 
 As explained further in the ``gamma-cat`` docs, it provides two data products:
 
@@ -19,13 +19,13 @@ Catalog
 
 The gamma-cat catalog is available here:
 
-* ``$GAMMA_CAT/docs/data/gammacat.fits.gz`` -- latest version
-* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz``
-  - a stable version copied to the ``gammapy-extra`` repo,
-  used for the ``gammapy.catalog.gammacat`` tests.
+* ``$GAMMA_CAT/docs/data/gammacat.fits.gz``: latest version
+* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz``:
+  a stable version copied to the ``gammapy-extra`` repo, used for the
+  ``gammapy.catalog.gammacat`` tests.
 
-To work with the gamma-cat catalog from Gammapy,
-pick a version and create a `~gammapy.catalog.SourceCatalogGammaCat`::
+To work with the gamma-cat catalog from Gammapy, pick a version and create a
+`~gammapy.catalog.SourceCatalogGammaCat`::
 
     from gammapy.catalog import SourceCatalogGammaCat
     filename = '$GAMMA_CAT/docs/data/gammacat.fits.gz'
@@ -43,15 +43,13 @@ JSON index file summarising all available data and containing pointers to the ot
 
 It is available here:
 
-* ``$GAMMA_CAT/docs/data/gammacat-datasets.json`` -- latest version
-* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat-datasets.json``
-  - a stable version copied to the ``gammapy-extra`` repo,
-  used for the ``gammapy.catalog.gammacat`` tests.
+* ``$GAMMA_CAT/docs/data/gammacat-datasets.json``: latest version
+* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat-datasets.json``:
+  a stable version copied to the ``gammapy-extra`` repo, used for the
+  ``gammapy.catalog.gammacat`` tests.
 
-To work with the gamma-cat data collection from Gammapy,
-pick a version and create a `~gammapy.catalog.GammaCatDataCollection` class.
-
-::
+To work with the gamma-cat data collection from Gammapy, pick a version and
+create a `~gammapy.catalog.GammaCatDataCollection` class::
 
     from gammapy.catalog import GammaCatDataCollection
     filename = '$GAMMA_CAT/docs/data/gammacat-datasets.json'

--- a/docs/catalog/index.rst
+++ b/docs/catalog/index.rst
@@ -12,7 +12,8 @@ Introduction
 `gammapy.catalog` provides utilities to work with source catalogs in general,
 and catalogs relevant for gamma-ray astronomy specifically.
 
-If you just want to browse catalog information, you can visit http://gamma-sky.net .
+If you just want to browse catalog information, you can visit
+http://gamma-sky.net .
 
 Available catalogs
 ------------------
@@ -31,35 +32,39 @@ Support for the following catalogs is available::
          2hwc               2HWC catalog from the HAWC observatory      40
 
 More catalogs can be added to ``gammapy.catalog``, and users can also add
-support for their favourite catalog in their Python script or package,
-by following the examples how the built-in catalogs are implemented.
+support for their favourite catalog in their Python script or package, by
+following the examples how the built-in catalogs are implemented.
 
 How it works
 ------------
 
-This section provides some information how ``gammapy.catalog`` works. In principle,
-to use it, you don't have to know how it's implemented, and just follow the examples
-in the sections below. In practice, if you want to work with catalogs via ``gammapy.catalog``
-or directly, it really helps if you spend a little time and learn about Astropy tables.
+This section provides some information how ``gammapy.catalog`` works. In
+principle, to use it, you don't have to know how it's implemented, and just
+follow the examples in the sections below. In practice, if you want to work with
+catalogs via ``gammapy.catalog`` or directly, it really helps if you spend a
+little time and learn about Astropy tables.
 
-Catalog data is stored as an `astropy.table.Table` object, with the information for
-each source in a `astropy.table.Row`. In ``gammapy.catalog`` we have implemented
-a base class `gammapy.catalog.SourceCatalog` that stores the `astropy.table.Table`
-in the ``table`` attribute, and a base `gammapy.catalog.SourceCatalogObject` class
-that can extract the `astropy.table.Row` data into a Python dictionary in the ``data`` attribute
-and then provides conveniences to work with the data for a given source.
+Catalog data is stored as an `astropy.table.Table` object, with the information
+for each source in a `astropy.table.Row`. In ``gammapy.catalog`` we have
+implemented a base class `gammapy.catalog.SourceCatalog` that stores the
+`astropy.table.Table` in the ``table`` attribute, and a base
+`gammapy.catalog.SourceCatalogObject` class that can extract the
+`astropy.table.Row` data into a Python dictionary in the ``data`` attribute and
+then provides conveniences to work with the data for a given source.
 
-For every given concrete catalog, two classes ("catalog" and "source/object") are needed.
-E.g. for the Fermi-LAT 3FGL catalog, there are the `gammapy.catalog.SourceCatalog3FGL`
-and the `gammapy.catalog.SourceCatalogObject3FGL` classes.
+For every given concrete catalog, two classes ("catalog" and "source/object")
+are needed. E.g. for the Fermi-LAT 3FGL catalog, there are the
+`gammapy.catalog.SourceCatalog3FGL` and the
+`gammapy.catalog.SourceCatalogObject3FGL` classes.
 
-The ``SourceCatalog`` class mostly handles data file loading, as well as source access by integer
-row index or source name. The ``SourceCatalogObject`` class implements in ``__str__`` a
-pretty-printed version of ``source.data``, so that you can ``print(source)``, as well as
-factory methods to create Gammapy objects such as `gammapy.spectrum.models.SpectralModel`
-or ``gammapy.image.models.SpatialModel`` or `gammapy.spectrum.FluxPoints` representing
-spatial and spectral models, or spectral points, which you can then print or plot
-or use for simulation and analysis.
+The ``SourceCatalog`` class mostly handles data file loading, as well as source
+access by integer row index or source name. The ``SourceCatalogObject`` class
+implements in ``__str__`` a pretty-printed version of ``source.data``, so that
+you can ``print(source)``, as well as factory methods to create Gammapy objects
+such as `gammapy.spectrum.models.SpectralModel` or
+``gammapy.image.models.SpatialModel`` or `gammapy.spectrum.FluxPoints`
+representing spatial and spectral models, or spectral points, which you can then
+print or plot or use for simulation and analysis.
 
 Getting Started
 ===============
@@ -79,16 +84,18 @@ You can access ``source_catalogs`` like a dict, i.e. load catalogs by name::
     >>> catalog = source_catalogs['3fgl']
     >>> catalog.table # To access the underlying astropy.table.Table
 
-Note that importing ``source_catalogs`` did not load catalogs from disk,
-they are lazy-loaded on access via ``[name]`` and then cached for the duration
-of your Python session.
+Note that importing ``source_catalogs`` did not load catalogs from disk, they
+are lazy-loaded on access via ``[name]`` and then cached for the duration of
+your Python session.
 
-You can get an object representing one source of interest by source name or by row index::
+You can get an object representing one source of interest by source name or by
+row index::
 
     >>> source = catalog['3FGL J0004.7-4740']  # access by source name
     >>> source = catalog[15]  # access by row index
 
-The ``source`` object contains all of the information in the ``data`` attribute::
+The ``source`` object contains all of the information in the ``data``
+attribute::
 
     >>> source.data['RAJ2000']
     1.1806999
@@ -97,8 +104,8 @@ The ``source`` object contains all of the information in the ``data`` attribute:
     >>> source.pprint()
     # print all info on this source in a readable format
 
-TODO: continue here describing how to access spectra, finder charts, ...
-once that's implemented.
+TODO: continue here describing how to access spectra, finder charts, ... once
+that's implemented.
 
 Using `gammapy.catalog`
 =======================
@@ -112,9 +119,9 @@ For more advanced use cases please go to the tutorial notebooks:
 The following pages describe ``gammapy.catalog`` in more detail:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   gammacat
+    gammacat
 
 Reference/API
 =============

--- a/docs/cube/index.rst
+++ b/docs/cube/index.rst
@@ -12,11 +12,11 @@ Introduction
 ============
 
 The `gammapy.cube` sub-package contains functions and classes to make maps
-(counts, exposure, background), as well as to compute an effective PSF
-and energy dispersion for a given set of observations.
+(counts, exposure, background), as well as to compute an effective PSF and
+energy dispersion for a given set of observations.
 
-It also contains classes that represent cube models (sky maps with an energy axis),
-and classes to evaluate and fit those models to data.
+It also contains classes that represent cube models (sky maps with an energy
+axis), and classes to evaluate and fit those models to data.
 
 Getting Started
 ===============

--- a/docs/datasets/index.rst
+++ b/docs/datasets/index.rst
@@ -11,8 +11,8 @@ Dataset access (``datasets``)
 Introduction
 ============
 
-`gammapy.datasets` contains function to easily access datasets that are
-relevant for gamma-ray astronomy.
+`gammapy.datasets` contains function to easily access datasets that are relevant
+for gamma-ray astronomy.
 
 The functions have a naming pattern (following scikit-learn lead):
 
@@ -20,22 +20,24 @@ The functions have a naming pattern (following scikit-learn lead):
 * ``fetch_*`` functions fetch datasets from the web (either from ``gammapy-extra`` or other sites)
 * ``make_*`` functions create datasets programatically (sometimes involving a random number generator)
 
-.. note:: The `gammapy.datasets` sub-package shouldn't be confused with the `gammapy.data`
-          sub-package, which contains classes representing gamma-ray data.
-          And there is a separate section describing the :ref:`dataformats`
-          that are commonly used in gamma-ray astronomy.
+.. note::
+    The `gammapy.datasets` sub-package shouldn't be confused with the
+    `gammapy.data` sub-package, which contains classes representing gamma-ray
+    data. And there is a separate section describing the :ref:`dataformats` that
+    are commonly used in gamma-ray astronomy.
 
 .. _gammapyextra:
 
 gammapy-extra
 =============
 
-To keep the Gammapy code repository at https://github.com/gammapy/gammapy small and clean,
-we are putting sample data files and IPython notebooks in an extra repository
-at https://github.com/gammapy/gammapy-extra/ .
+To keep the Gammapy code repository at https://github.com/gammapy/gammapy small
+and clean, we are putting sample data files and IPython notebooks in an extra
+repository at https://github.com/gammapy/gammapy-extra/ .
 
-To get the repository, ``git clone`` it to a location of your choosing using a git protocol of your choosing
-(try HTTPS or see the `Github clone URL help article`_ if you're not sure which you want).
+To get the repository, ``git clone`` it to a location of your choosing using a
+git protocol of your choosing (try HTTPS or see the `Github clone URL help
+article`_ if you're not sure which you want).
 
 .. code-block:: bash
 
@@ -49,31 +51,30 @@ If you don't have git, you can also fetch the latest version as a zip file:
     wget https://github.com/gammapy/gammapy-extra/archive/master.zip
     unzip master.zip # will result in a `gammapy-extra-master` folder
 
-The Gammapy tests, docs generator, examples and tutorials will access files from the ``gammapy-extra``
-repo using the `gammapy.datasets.gammapy_extra` object.
+The Gammapy tests, docs generator, examples and tutorials will access files from
+the ``gammapy-extra`` repo using the `gammapy.datasets.gammapy_extra` object.
 
-For this to work, you have to set the ``GAMMAPY_EXTRA`` shell environment variable to point to that folder.
-We suggest you put this in you ``.bashrc`` or ``.profile``
+For this to work, you have to set the ``GAMMAPY_EXTRA`` shell environment
+variable to point to that folder. We suggest you put this in you ``.bashrc`` or
+``.profile``
 
 .. code-block:: bash
 
     export GAMMAPY_EXTRA=/path/on/your/machine/to/gammapy-extra
 
-After you've done this, open up a new terminal (or ``source .profile``) and check if ``gammapy-extra`` is found:
+After you've done this, open up a new terminal (or ``source .profile``) and
+check if ``gammapy-extra`` is found:
 
 .. code-block:: bash
 
     # TODO: make this print some info about gammapy-extra (including a version!!!)
     gammapy info
 
-Example usage:
-
-.. code-block:: python
+Example usage:::
 
     >>> from gammapy.datasets import gammapy_extra
     >>> gammapy_extra.filename('logo/gammapy_banner.png')
     '/Users/deil/code/gammapy-extra/logo/gammapy_banner.png'
-
 
 .. _gammapy-cat:
 
@@ -81,49 +82,48 @@ Gamma-cat
 ===========
 
 Gamma-cat is an open catalog for TeV gamma-ray sources. It is maintained as an
-open git repository and hosted on github. To get the data you can use the
-`git clone` command:
+open git repository and hosted on github. To get the data you can use the ``git
+clone`` command:
 
 .. code-block:: bash
 
-  git clone https://github.com/gammapy/gamma-cat.git
-  git clone git@github.com:gammapy/gamma-cat.git
+    git clone https://github.com/gammapy/gamma-cat.git
+    git clone git@github.com:gammapy/gamma-cat.git
 
 If you don't have git, you can also fetch the latest version as a zip file as well:
 
 .. code-block:: bash
 
-    wget https://github.com/gammapy/gamma-cat/archive/master.zip
-    unzip master.zip # will result in a `gamma-cat-master` folder
+    wget https://github.com/gammapy/gamma-cat/archive/master.zip unzip
+    master.zip # will result in a `gamma-cat-master` folder
 
-
-The `~gammapy.catalog.SourceCatalogGammaCat` and `~gammapy.catalog.SourceCatalogObjectGammaCat`
-classes need to know where the gamma-cat repository is located on your machine.
-For this reason the ``GAMMA_CAT`` shell environment variable has to be set using:
+The `~gammapy.catalog.SourceCatalogGammaCat` and
+`~gammapy.catalog.SourceCatalogObjectGammaCat` classes need to know where the
+gamma-cat repository is located on your machine. For this reason the
+``GAMMA_CAT`` shell environment variable has to be set using:
 
 .. code-block:: bash
 
     export GAMMAPY_CAT=/path/on/your/machine/to/gamma-cat
 
-
 Getting Started
 ===============
 
-Example how to load a dataset that is distributed with the code
-in the ``gammapy`` repo (i.e. will be available even if you're offline)
+Example how to load a dataset that is distributed with the code in the
+``gammapy`` repo (i.e. will be available even if you're offline)
 
 .. code-block:: python
 
-   >>> from gammapy.datasets import load_crab_flux_points
-   >>> flux_points = load_crab_flux_points()
+    >>> from gammapy.datasets import load_crab_flux_points
+    >>> flux_points = load_crab_flux_points()
 
-Example how to fetch a dataset from the web (i.e. will download to
-the Astropy cache and need internet access on first call):
+Example how to fetch a dataset from the web (i.e. will download to the Astropy
+cache and need internet access on first call):
 
 .. code-block:: python
 
-   >>> from gammapy.datasets import fetch_fermi_diffuse_background_model
-   >>> catalog = fetch_fermi_diffuse_background_model()
+    >>> from gammapy.datasets import fetch_fermi_diffuse_background_model
+    >>> catalog = fetch_fermi_diffuse_background_model()
 
 TODO: explain how the Astropy cache works and make it configurable for Gammapy.
 
@@ -131,8 +131,8 @@ Example how to make a dataset (from scratch, no file is loaded):
 
 .. code-block:: python
 
-   >>> from gammapy.datasets import make_test_psf
-   >>> psf = make_test_psf(energy_bins=20)
+    >>> from gammapy.datasets import make_test_psf
+    >>> psf = make_test_psf(energy_bins=20)
 
 Using `gammapy.datasets`
 ========================

--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -11,16 +11,16 @@ Source detection tools (``detect``)
 Introduction
 ============
 
-The `gammapy.detect` submodule includes low level functions to compute significance
-and test statistics images as well as some high level source detection method
-prototypes.
+The `gammapy.detect` submodule includes low level functions to compute
+significance and test statistics images as well as some high level source
+detection method prototypes.
 
-Detailed description of the methods can be found in [Stewart2009]_
-and [LiMa1983]_.
+Detailed description of the methods can be found in [Stewart2009]_ and
+[LiMa1983]_.
 
-Note that in Gammapy maps are stored as Numpy arrays, which implies that
-it's very easy to use `scikit-image`_ or `photutils`_ or other packages
-that have advanced image analysis and source detection methods readily available.
+Note that in Gammapy maps are stored as Numpy arrays, which implies that it's
+very easy to use `scikit-image`_ or `photutils`_ or other packages that have
+advanced image analysis and source detection methods readily available.
 
 Computation of TS images
 ========================
@@ -31,23 +31,25 @@ Computation of TS images
 Test statistics image computed using `~gammapy.detect.TSMapEstimator` for an
 example Fermi dataset.
 
-The `gammapy.detect` module includes a high performance `~gammapy.detect.TSMapEstimator` class to
-compute test statistics (TS) images for gamma-ray survey data. The implementation is based on the method
-described in [Stewart2009]_.
+The `gammapy.detect` module includes a high performance
+`~gammapy.detect.TSMapEstimator` class to compute test statistics (TS) images
+for gamma-ray survey data. The implementation is based on the method described
+in [Stewart2009]_.
 
-Assuming a certain source morphology, which can be defined by any `astropy.convolution.Kernel2D`
-instance, the amplitude of the morphology model is fitted at every pixel of the input data using a
-Poisson maximum likelihood procedure. As input data a counts, background and exposure images have to be provided.
-Based on the best fit flux amplitude, the change in TS, compared to the null hypothesis is computed
-using `~gammapy.stats.cash` statistics.
+Assuming a certain source morphology, which can be defined by any
+`astropy.convolution.Kernel2D` instance, the amplitude of the morphology model
+is fitted at every pixel of the input data using a Poisson maximum likelihood
+procedure. As input data a counts, background and exposure images have to be
+provided. Based on the best fit flux amplitude, the change in TS, compared to
+the null hypothesis is computed using `~gammapy.stats.cash` statistics.
 
-To optimize the performance of the code, the fitting procedure is simplified by finding roots
-of the derivative of the fit statistics with respect to the flux amplitude. This approach is
-described in detail in Appendix A of [Stewart2009]_. To further improve the performance,
-Pythons's `multiprocessing` facility is used.
+To optimize the performance of the code, the fitting procedure is simplified by
+finding roots of the derivative of the fit statistics with respect to the flux
+amplitude. This approach is described in detail in Appendix A of [Stewart2009]_.
+To further improve the performance, Pythons's `multiprocessing` facility is
+used.
 
-In the following the computation of a TS image for prepared Fermi survey data, which is provided in
-`gammapy-extra <https://github.com/gammapy/gammapy-extra/tree/master/datasets/fermi_survey>`_, shall be demonstrated:
+The following example shows how to compute a TS image for Fermi-LAT survey data:
 
 .. code-block:: python
 
@@ -65,8 +67,8 @@ In the following the computation of a TS image for prepared Fermi survey data, w
     ts_estimator = TSMapEstimator()
     result = ts_estimator.run(maps, kernel)
 
-The function returns an `~OrderedDict` object, that bundles all resulting maps.
-E.g. here's how to find the largest TS value:
+The function returns an dictionary, that bundles all resulting maps. E.g. here's
+how to find the largest TS value:
 
 .. code-block:: python
 
@@ -92,9 +94,8 @@ dataset as above, the corresponding images can be computed using the
     kernel = Tophat2DKernel(5)
     result = compute_lima_image(counts, background, kernel)
 
-The function returns a dictionary, that bundles all resulting
-images such as significance, flux and correlated counts and excess images.
-
+The function returns a dictionary, that bundles all resulting images such as
+significance, flux and correlated counts and excess images.
 
 Reference/API
 =============

--- a/docs/development/dataformats.rst
+++ b/docs/development/dataformats.rst
@@ -7,16 +7,15 @@ Data Formats
 ************
 
 .. note:: Since November 2015 there is the :ref:`gadf:main-page` project.
-    This page contains extra information about which formats we support
-    in Gammapy and which class corresponds to which format.
+    This page contains extra information about which formats we support in
+    Gammapy and which class corresponds to which format.
 
 .. note:: In :ref:`datasets` you find example gamma-ray datasets,
           some in the formats described here.
 
-Where available and useful existing standards are used, e.g.
-for spectral data the X-ray community has developed the ``PHA``, ``ARF`` and ``RMF``
-file formats and they have developed powerful tools to work with data in that format.
-
+Where available and useful existing standards are used, e.g. for spectral data
+the X-ray community has developed the ``PHA``, ``ARF`` and ``RMF`` file formats
+and they have developed powerful tools to work with data in that format.
 
 .. _dataformats_overview:
 

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -9,52 +9,58 @@ How to contribute to Gammapy?
 What is this?
 =============
 
-**This page is an overview of how to make a change or addition to the Gammapy code, tests or documentation.**
-**It's partly an introduction to the process, partly a guide to some technical aspects.**
+**This page is an overview of how to make a change or addition to the Gammapy
+code, tests or documentation. It's partly an introduction to the process, partly
+a guide to some technical aspects.**
 
-It is *not* a tutorial introduction explaining all the tools (git, Github, Sphinx, pytest)
-or code (Python, Numpy, Scipy, Astropy) in detail. In the Gammapy docs, we don't have such a tutorial
-introduction written up, but we're happy to point out other tutorials or help you get started
-at any skill level anytime if you ask.
+It is *not* a tutorial introduction explaining all the tools (git, Github,
+Sphinx, pytest) or code (Python, Numpy, Scipy, Astropy) in detail. In the
+Gammapy docs, we don't have such a tutorial introduction written up, but we're
+happy to point out other tutorials or help you get started at any skill level
+anytime if you ask.
 
-Before attempting to make a contribution, you should *use* Gammapy a little bit at least:
+Before attempting to make a contribution, you should *use* Gammapy a little bit
+at least:
 
 * Install Gammapy
 * Execute one or two of the tutorial notebooks for Gammapy and do the exercises there.
 * Ask questions or complain about issues on the Gammapy mailing list or issue tracker
 
 We'd like to note that there are many ways to contribute to the Gammapy project.
-For example if you mention it to a colleague or suggest it to a student,
-or if you use it and acknowledge Gammapy in a presentation, poster or publication,
-or if you report an issue on the mailing list, those are contributions we value.
-The rest of this page though is concerned only with the process and technical steps
-how to contribute a code or documentation change via a **pull request** against the Gammapy repository.
+For example if you mention it to a colleague or suggest it to a student, or if
+you use it and acknowledge Gammapy in a presentation, poster or publication, or
+if you report an issue on the mailing list, those are contributions we value.
+The rest of this page though is concerned only with the process and technical
+steps how to contribute a code or documentation change via a **pull request**
+against the Gammapy repository.
 
-So let's assume you've used Gammapy for a while, and now you'd like to fix or add something
-to the Gammapy code, tests or docs. Here's the steps and commands to do it ...
+So let's assume you've used Gammapy for a while, and now you'd like to fix or
+add something to the Gammapy code, tests or docs. Here's the steps and commands
+to do it ...
 
 Get in touch early
 ==================
 
-**Usually the first step, before doing any work, is to get in touch with the Gammapy developers!**
+**Usually the first step, before doing any work, is to get in touch with the
+Gammapy developers!**
 
-Especially if you're new to the project, and don't have an overview of ongoing activities,
-there's a risk that your work will be in vain if you don't talk to us early.
-E.g. it could happen that someone else is currently working on similar functionality,
-or that you've found a code or documentation bug and are willing to fix it,
-but it then turns out that this was for some part of Gammapy that we wanted to
-re-write or remove soon anyways.
+Especially if you're new to the project, and don't have an overview of ongoing
+activities, there's a risk that your work will be in vain if you don't talk to
+us early. E.g. it could happen that someone else is currently working on similar
+functionality, or that you've found a code or documentation bug and are willing
+to fix it, but it then turns out that this was for some part of Gammapy that we
+wanted to re-write or remove soon anyways.
 
-Also, it's usually more fun if you get a *mentor* or *reviewer* early in the process,
-so that you have someone to bug with questions and issues that come up while executing
-the steps outlined below.
+Also, it's usually more fun if you get a *mentor* or *reviewer* early in the
+process, so that you have someone to bug with questions and issues that come up
+while executing the steps outlined below.
 
-After you've done a few contributions to Gammapy and know about the status of ongoing work,
-the best way to proceed is to file an issue or pull request on Github at the stage where
-you want feedback or review. Sometimes you're not sure how to best do something, and you
-start by discussing it on the mailing list or in a Github issue. Sometimes you know how
-you'd like to do it, and you just code or write it up and make a pull request when it's
-basically finished.
+After you've done a few contributions to Gammapy and know about the status of
+ongoing work, the best way to proceed is to file an issue or pull request on
+Github at the stage where you want feedback or review. Sometimes you're not sure
+how to best do something, and you start by discussing it on the mailing list or
+in a Github issue. Sometimes you know how you'd like to do it, and you just code
+or write it up and make a pull request when it's basically finished.
 
 In any case, please keep the following point also in mind ...
 
@@ -79,25 +85,28 @@ using git branches.
 
 So how large should one pull request be?
 
-Our experience in Gammapy (and others confirm, see e.g. `here <https://alexgaynor.net/2015/dec/29/shrinking-code-review/>`__)
-is that smaller is better. Working on a pull request for an hour or maximum a day,
-and having a diff of a few to maximum a few 100 lines to review and discuss is pleasant.
+Our experience in Gammapy (and others confirm, see e.g. `here
+<https://alexgaynor.net/2015/dec/29/shrinking-code-review/>`__) is that smaller
+is better. Working on a pull request for an hour or maximum a day, and having a
+diff of a few to maximum a few 100 lines to review and discuss is pleasant.
 
-A pull request that drags on for more than a few days, or that contains a diff or 1000 lines,
-is almost always painful and inefficient for the person making it, but even more so for the
-person reviewing it.
+A pull request that drags on for more than a few days, or that contains a diff
+or 1000 lines, is almost always painful and inefficient for the person making
+it, but even more so for the person reviewing it.
 
-The worst case is if you start a bit pull request, put in a lot of hours, but then don't have
-time to "finish" it, and it's sitting there for a week or a month without getting merged.
-Then it's either blocking others that want to work on the same part of the code or docs,
-or they do it, and then you have merge conflicts to resolve when you come back to it.
-And coming back to a large pull request after a long time always means a large investment
-of time for the reviewer, because they probably have to re-read the previous discussion,
-and look through the large diff again.
+The worst case is if you start a bit pull request, put in a lot of hours, but
+then don't have time to "finish" it, and it's sitting there for a week or a
+month without getting merged. Then it's either blocking others that want to work
+on the same part of the code or docs, or they do it, and then you have merge
+conflicts to resolve when you come back to it. And coming back to a large pull
+request after a long time always means a large investment of time for the
+reviewer, because they probably have to re-read the previous discussion, and
+look through the large diff again.
 
-So pull requests that are small, e.g. one bug fix with the addition of one regression test,
-or one new function or class or file, or one documentation example, and that get reviewed and merged quickly
-(ideally the same day, certainly the same week), are best.
+So pull requests that are small, e.g. one bug fix with the addition of one
+regression test, or one new function or class or file, or one documentation
+example, and that get reviewed and merged quickly (ideally the same day,
+certainly the same week), are best.
 
 .. _dev_setup:
 
@@ -106,15 +115,18 @@ Get set up
 
 .. warning::
 
-    The rest of this page isn't written yet.
-    It's almost identical to https://cta-observatory.github.io/ctapipe/getting_started/index.html
-    so for now, see there.
-    Also, we shouldn't duplicate content from http://astropy.readthedocs.io/en/latest/#developer-documentation
-    but link there instead.
+    The rest of this page isn't written yet. It's almost identical to
+    https://cta-observatory.github.io/ctapipe/getting_started/index.html so for
+    now, see there. Also, we shouldn't duplicate content from
+    http://astropy.readthedocs.io/en/latest/#developer-documentation but link
+    there instead.
 
-The first steps are basically identical to https://cta-observatory.github.io/ctapipe/getting_started/index.html (until step 4, excluding 5)
-and http://astropy.readthedocs.io/en/latest/development/workflow/get_devel_version.html (up to *Create your own private workspace*).
-The following is a quick summary of commands to set up an environment for Gammapy development:
+The first steps are basically identical to
+https://cta-observatory.github.io/ctapipe/getting_started/index.html (until step
+4, excluding 5) and
+http://astropy.readthedocs.io/en/latest/development/workflow/get_devel_version.html
+(up to *Create your own private workspace*). The following is a quick summary of
+commands to set up an environment for Gammapy development:
 
 .. code-block:: bash
 
@@ -130,13 +142,12 @@ The following is a quick summary of commands to set up an environment for Gammap
     git remote rename origin [your-user-name]
 
 It is also common to stick with the name ``origin`` for your repository and to
-use ``upstream`` for the respository you forked from.
-In any case, you can use ``$ git remote -v`` to list all your configured
-remotes.
+use ``upstream`` for the respository you forked from. In any case, you can use
+``$ git remote -v`` to list all your configured remotes.
 
 When developing gammapy you never want to work on the ``master`` branch, but
-always on a dedicated feature branch.
-To create and switch the branch you are working on (see also :ref:`dev_working_example`):
+always on a dedicated feature branch. To create and switch the branch you are
+working on (see also :ref:`dev_working_example`):
 
 .. code-block:: bash
 
@@ -149,11 +160,13 @@ To *activate* your development version (branch) of Gammapy in your environment:
 
     pip install -e .
 
-This build is necessary to compile the few Cython code (``*.pyx``). If you skip this
-step, some imports depending on Cython code will fail. This is described in more
-details here: :ref:`setup_cython`. If you want to revert the build see :ref:`make_clean`.
+This build is necessary to compile the few Cython code (``*.pyx``). If you skip
+this step, some imports depending on Cython code will fail. This is described in
+more details here: :ref:`setup_cython`. If you want remove the generated files
+run ``make clean``.
 
-For the development it is also convenient to fork and set up the :ref:`dev_gammapy-extra`:
+For the development it is also convenient to fork and set up the
+:ref:`dev_gammapy-extra`:
 
 .. code-block:: bash
 
@@ -161,7 +174,6 @@ For the development it is also convenient to fork and set up the :ref:`dev_gamma
     cd code
     git clone https://github.com/[your-github-username]/gammapy-extra.git
     export GAMMAPY_EXTRA=$PWD/gammapy-extra
-
 
 * install dependencies
 * git clone dev version

--- a/docs/development/pigs/index.rst
+++ b/docs/development/pigs/index.rst
@@ -6,13 +6,13 @@
 PIGs
 ****
 
-PIGs (proposals for improvement of Gammapy) are short documents proposing a major
-addition or change to Gammapy. See :ref:`pig-001` for further information.
+PIGs (proposals for improvement of Gammapy) are short documents proposing a
+major addition or change to Gammapy. See :ref:`pig-001` for further information.
 
-Below is a list of merged PIGs, i.e. the ones that are finalised,
-with status "accepted" or "rejected" or "withdrawn".
-The ones with "draft" status, i.e. that are under discussion,
-can be found on Github as `pull requests with the "pig" label`_ .
+Below is a list of merged PIGs, i.e. the ones that are finalised, with status
+"accepted" or "rejected" or "withdrawn". The ones with "draft" status, i.e. that
+are under discussion, can be found on Github as `pull requests with the "pig"
+label`_ .
 
 .. toctree::
     :maxdepth: 1

--- a/docs/development/pigs/pig-001.rst
+++ b/docs/development/pigs/pig-001.rst
@@ -15,42 +15,42 @@ PIG 1 - PIG purpose and guidelines
 Abstract
 ========
 
-PIG stands for "proposal for improvement of Gammapy". This is PIG 1,
-describing the purpose of using PIGs as well as giving some guidelines
-on how PIGs are authored, discussed and reviewed.
+PIG stands for "proposal for improvement of Gammapy". This is PIG 1, describing
+the purpose of using PIGs as well as giving some guidelines on how PIGs are
+authored, discussed and reviewed.
 
 What is a PIG?
 ==============
 
-This article is about the design document . For other uses, see `Pig (disambiguation)`_
+This article is about the design document . For other uses, see `Pig
+(disambiguation)`_
 
-Proposals for improvement of Gammapy (PIGs) are short documents proposing a major
-addition or change to Gammapy.
+Proposals for improvement of Gammapy (PIGs) are short documents proposing a
+major addition or change to Gammapy.
 
-PIGs are like `APEs`_, `PEPs`_, `NEPs`_ and `JEPs`_, just for Gammapy.
-Using such enhancement proposals is common for large and long-term
-open-source Python projects.
+PIGs are like `APEs`_, `PEPs`_, `NEPs`_ and `JEPs`_, just for Gammapy. Using
+such enhancement proposals is common for large and long-term open-source Python
+projects.
 
-The primary goal of PIGs is to have an open
-and structured way of working on Gammapy, forcing the person making the
-change to think it through and motivate the proposal before taking action,
-and for others to have a chance to review and comment on the proposal. The PIGs will also
-serve as a record of major design decisions taken in Gammapy, which can
-be useful in the future when things are re-discussed or new proposals to
-do things differently arrive.
+The primary goal of PIGs is to have an open and structured way of working on
+Gammapy, forcing the person making the change to think it through and motivate
+the proposal before taking action, and for others to have a chance to review and
+comment on the proposal. The PIGs will also serve as a record of major design
+decisions taken in Gammapy, which can be useful in the future when things are
+re-discussed or new proposals to do things differently arrive.
 
 We expect that we will not use PIGs very often, but we think they can be useful
 e.g. in the following cases:
 
 * Outline design for something that requires significant work,
-  e.g. on topics like "Modeling in Gammapy" or "High-level user interface in Gammapy".
-  These PIGs can be rather long, i.e. more than one page, explaining the
-  design in detail and even explaining which alternatives were
-  considered and why the proposed solution was preferred.
-* Have a conscious decision and make sure all interested parties
-  are aware for things that might be controversial and have long-term
-  effects for Gammapy, e.g. when to drop Python 2 support or defining
-  a release cycle for Gammapy. These PIGs can usually be very short, a page or less.
+  e.g. on topics like "Modeling in Gammapy" or "High-level user interface in
+  Gammapy". These PIGs can be rather long, i.e. more than one page, explaining
+  the design in detail and even explaining which alternatives were considered
+  and why the proposed solution was preferred.
+* Have a conscious decision and make sure all interested parties are aware for
+  things that might be controversial and have long-term effects for Gammapy,
+  e.g. when to drop Python 2 support or defining a release cycle for Gammapy.
+  These PIGs can usually be very short, a page or less.
 
 Writing a PIG
 =============
@@ -60,78 +60,79 @@ Anyone is welcome to write a PIG!
 PIGs are written as RST files in the ``docs/development/pigs`` folder in the
 main Gammapy repository, and submitted as pull requests.
 
-Most discussions concerning Gammapy will happen by talking to each other directly
-(calls or face-to-face), or online on the mailing list or Github.
-If you're not sure if you should write a PIG, please don't! Instead bring the
-topic up in discussions first with other Gammapy developers, or on the mailing list,
-to get some initial feedback. This will let you figure out if writing a PIG
-will be helpful or not to realise your proposal.
+Most discussions concerning Gammapy will happen by talking to each other
+directly (calls or face-to-face), or online on the mailing list or Github. If
+you're not sure if you should write a PIG, please don't! Instead bring the topic
+up in discussions first with other Gammapy developers, or on the mailing list,
+to get some initial feedback. This will let you figure out if writing a PIG will
+be helpful or not to realise your proposal.
 
-When starting to write a PIG, we suggest you copy & paste & update the header
-at the top of this file, i.e. the title, bullet list with "Author" etc, up to
-the ``Abstract`` section. A PIG must have a number. If you're not sure what
-the next free number is, put ``X`` and filename ``pig-XXX.rst`` as placeholders,
-make the pull request, and we'll let you know what number to put.
+When starting to write a PIG, we suggest you copy & paste & update the header at
+the top of this file, i.e. the title, bullet list with "Author" etc, up to the
+``Abstract`` section. A PIG must have a number. If you're not sure what the next
+free number is, put ``X`` and filename ``pig-XXX.rst`` as placeholders, make the
+pull request, and we'll let you know what number to put.
 
-Please make your proposal clearly and keep the initial proposal short.
-If more information is needed, people that will review it will ask for it.
+Please make your proposal clearly and keep the initial proposal short. If more
+information is needed, people that will review it will ask for it.
 
 In term of content, we don't require a formal structure for a PIG. We do suggest
-that you start with an "Abstract" explaining the proposal in one or a few sentences,
-followed by a section motivating the change or addition. Then usually there will be
-a detailed description, and at the end or interspersed there will often be some
-comments about alternative options that have been discussed and explanation why
-proposed one was favoured. Usually a short "Decision" section will be added
-at the end of the document after discussion by the reviewers.
+that you start with an "Abstract" explaining the proposal in one or a few
+sentences, followed by a section motivating the change or addition. Then usually
+there will be a detailed description, and at the end or interspersed there will
+often be some comments about alternative options that have been discussed and
+explanation why proposed one was favoured. Usually a short "Decision" section
+will be added at the end of the document after discussion by the reviewers.
 
-If you're not sure how to structure your proposal, you could have a look at
-at the `APE template`_ or some well-written APEs_ or PEPs_.
-`APE 5`_, `APE 7`_ and `APE 13`_ are examples of "design documents",
-outlining major changes / extensions to existing code in Astropy.
-`APE 2`_ and `APE 10`_ are examples of "process" proposals, outlining a release cycle for
-Astropy and a timeline for dropping Python 2 support.
-`PEP 389`_ is a good example proposing an improvement in the Python standard library,
-in that case by adding a new module ``argparse``, leaving the existing ``optparse``
-alone for backward-compatibility reasons. In Gammapy many PIGs will also be about
-implementing better solutions and a major question will be whether to change and improve
-the existing implementation, or whether to just put a new one, and in that case what
-the plan concerning the old code is. `PEP 481`_ is an example of a "process" PEP,
-proposing to move CPython development to git and Github. For Gammapy, we might also have
-"process" PIGs in the future, e.g. concerning release cycle or package distribution
-or support for users and other projects relying on Gammapy. It's good to think these
-things through and write them down to make sure it's clear how things work and what
-the plan for the future is.
+If you're not sure how to structure your proposal, you could have a look at at
+the `APE template`_ or some well-written APEs_ or PEPs_. `APE 5`_, `APE 7`_ and
+`APE 13`_ are examples of "design documents", outlining major changes /
+extensions to existing code in Astropy. `APE 2`_ and `APE 10`_ are examples of
+"process" proposals, outlining a release cycle for Astropy and a timeline for
+dropping Python 2 support. `PEP 389`_ is a good example proposing an improvement
+in the Python standard library, in that case by adding a new module
+``argparse``, leaving the existing ``optparse`` alone for backward-compatibility
+reasons. In Gammapy many PIGs will also be about implementing better solutions
+and a major question will be whether to change and improve the existing
+implementation, or whether to just put a new one, and in that case what the plan
+concerning the old code is. `PEP 481`_ is an example of a "process" PEP,
+proposing to move CPython development to git and Github. For Gammapy, we might
+also have "process" PIGs in the future, e.g. concerning release cycle or package
+distribution or support for users and other projects relying on Gammapy. It's
+good to think these things through and write them down to make sure it's clear
+how things work and what the plan for the future is.
 
 Writing a PIG doesn't mean you have to implement it. That said, we expect that
 most PIGs will propose something that requires developments where someone has
 the intention to implement it within the near future (say within the next year).
-But it's not required, e.g. if you have a great idea or vision for Gammapy
-that requires a lot of development, without the manpower to execute the idea,
-writing a PIG could be a nice way to share this idea in some detail, with the
-hope that in collaboration with others it can eventually be realised.
+But it's not required, e.g. if you have a great idea or vision for Gammapy that
+requires a lot of development, without the manpower to execute the idea, writing
+a PIG could be a nice way to share this idea in some detail, with the hope that
+in collaboration with others it can eventually be realised.
 
 PIG review
 ==========
 
 PIG review happens on the pull request on Github.
 
-When a PIG is put up, an announcement with a link to the pull request should
-be sent both to the Gammapy mailing list and the Gammapy coordinator list.
+When a PIG is put up, an announcement with a link to the pull request should be
+sent both to the Gammapy mailing list and the Gammapy coordinator list.
 
-Anyone is welcome to review it and is encouraged to share their thoughts
-in the discussion!
+Anyone is welcome to review it and is encouraged to share their thoughts in the
+discussion!
 
-Please note that Github hides inline comments after they have been edited,
-so we suggest that you use inline comments for minor points like spelling mistakes only.
-Put your main feedback as normal comments in the "Conversation" tab,
-so that for someone reading the discussion later they will see your comment directly.
+Please note that Github hides inline comments after they have been edited, so we
+suggest that you use inline comments for minor points like spelling mistakes
+only. Put your main feedback as normal comments in the "Conversation" tab, so
+that for someone reading the discussion later they will see your comment
+directly.
 
-The final decision on any PIG is made by the Gammapy coordination committee.
-We expect that in most cases, the people participating in the PIG review will
-reach a consensus and the coordination committee will follow the outcome
-of the public discussion. But in unusual cases where disagreement remains,
-the coordination committee will talk to the people involved in the discussion
-with the goal to reach consensus or compromise, and then make the final decision.
+The final decision on any PIG is made by the Gammapy coordination committee. We
+expect that in most cases, the people participating in the PIG review will reach
+a consensus and the coordination committee will follow the outcome of the public
+discussion. But in unusual cases where disagreement remains, the coordination
+committee will talk to the people involved in the discussion with the goal to
+reach consensus or compromise, and then make the final decision.
 
 PIG status
 ==========
@@ -143,48 +144,51 @@ PIGs can have a status of:
 * "accepted" - accepted by the coordination committee
 * "rejected" - rejected by the coordination committee
 
-When a PIG is put up for discussion as a pull request, it should have a status of
-"draft". Then once the discussion and review is done, the status will change to
-one of "withdrawn", "accepted" or "rejected". The reviewers should add a section
-"Decision" with a sentence or paragraph summarising the discussion and
+When a PIG is put up for discussion as a pull request, it should have a status
+of "draft". Then once the discussion and review is done, the status will change
+to one of "withdrawn", "accepted" or "rejected". The reviewers should add a
+section "Decision" with a sentence or paragraph summarising the discussion and
 decision on this PIG. Then in any case, the PIG should be merged, even if it's
 status is "withdrawn" or "rejected".
 
 Final remarks
 =============
 
-This PIG leaves some points open.
-This is intentional. We want to keep the process flexible
-and first gain some experience. The goal of PIGs is to help the Gammapy developer
-team to be more efficient, not to have a rigid or bureaucratic process.
+This PIG leaves some points open. This is intentional. We want to keep the
+process flexible and first gain some experience. The goal of PIGs is to help the
+Gammapy developer team to be more efficient, not to have a rigid or bureaucratic
+process.
 
 Specifically the following points remain flexible:
 
 * When to merge a PIG? There can be cases where the PIG is merged quickly,
   as an outline or design document, even if the actual implementation hasn't
   been done yet. There can be other cases where the PIG pull request remains
-  open for a long time, because the proposal is too vague or requires prototyping
-  to be evaluated properly. Note that this is normal, e.g. Python PEPs_ are usually
-  only accepted once all development is done and a full implementation exists.
+  open for a long time, because the proposal is too vague or requires
+  prototyping to be evaluated properly. Note that this is normal, e.g. Python
+  PEPs_ are usually only accepted once all development is done and a full
+  implementation exists.
 * Allow edits of existing PIGs? We don't say if PIGs are supposed to be fixed
-  or live documents. We expect that some will remain fixed, while others will
-  be edited after being merged. E.g. for this PIG 1 we expect that over the years
+  or live documents. We expect that some will remain fixed, while others will be
+  edited after being merged. E.g. for this PIG 1 we expect that over the years
   as we gain experience with the PIG process and see what works well and what
-  doesn't, that edits will be made with clarifications or even changes.
-  Whether to edit an existing PIG or whether to write a new follow-up PIG will
-  be discussed on a case by case basis.
+  doesn't, that edits will be made with clarifications or even changes. Whether
+  to edit an existing PIG or whether to write a new follow-up PIG will be
+  discussed on a case by case basis.
 * What to do if the coordination committee doesn't agree on some PIG?
   For now, we leave this question to the future. We expect that this scenario
-  might arise, it's normal that opinions on technical solutions or importance
-  of use cases or projects to support with Gammapy differ. We also expect
-  that Gammapy coordination committee members will be friendly people that
-  can collaborate and find a solution or at least compromise that works for everyone.
+  might arise, it's normal that opinions on technical solutions or importance of
+  use cases or projects to support with Gammapy differ. We also expect that
+  Gammapy coordination committee members will be friendly people that can
+  collaborate and find a solution or at least compromise that works for
+  everyone.
 
 Decision
 ========
 
-This PIG was discussed extensively in `GH 1239`_, resulting in several improvements and additions.
-Everyone thought it was one honking good idea - let's do more of those!
+This PIG was discussed extensively in `GH 1239`_, resulting in several
+improvements and additions. Everyone thought it was one honking good idea -
+let's do more of those!
 
 .. _Pig (disambiguation): https://en.wikipedia.org/wiki/Pig_(disambiguation)
 .. _PEPs: https://www.python.org/dev/peps/pep-0001/

--- a/docs/development/pigs/pig-002.rst
+++ b/docs/development/pigs/pig-002.rst
@@ -19,40 +19,46 @@ The case of image and cube analysis
 Abstract
 ========
 
-This PIG discusses the general structure of the low level analysis subpackages of gammapy.
-Low level analysis is based on the gammapy building blocks from ``gammapy.data``, ``gammapy.irf``
-and ``gammapy.maps``. Low level analysis implements all the individual steps required to perform
-data reduction for IACT from DL3 inputs (event lists and IRFs) to DL4 data (spectra, maps and cubes)
-and their associated reduced IRFs. Low-level analysis should be structured in a very modular way to allow
-easy implementation of high-level analysis classes and scripts. 
+This PIG discusses the general structure of the low level analysis subpackages
+of gammapy. Low level analysis is based on the gammapy building blocks from
+``gammapy.data``, ``gammapy.irf`` and ``gammapy.maps``. Low level analysis
+implements all the individual steps required to perform data reduction for IACT
+from DL3 inputs (event lists and IRFs) to DL4 data (spectra, maps and cubes) and
+their associated reduced IRFs. Low-level analysis should be structured in a very
+modular way to allow easy implementation of high-level analysis classes and
+scripts.
 
 
 General code style guidelines
 =============================
 
-Functions or methods should be no longer than few tens of lines of code. Above that it is better to
-use multiple functions to make testing easier and allow more modular usage. One line functions
-are usually not needed unless this is a very complex line.
+Functions or methods should be no longer than few tens of lines of code. Above
+that it is better to use multiple functions to make testing easier and allow
+more modular usage. One line functions are usually not needed unless this is a
+very complex line.
 
-Similarly, classes should have 3-10 methods. 2 methods classes (e.g. only ``__init__`` and ``__call__``)
-should usually be functions. Above 10-20 methodes, the class should  be split into
-several classes/functions.
+Similarly, classes should have 3-10 methods. 2 methods classes (e.g. only
+``__init__`` and ``__call__``) should usually be functions. Above 10-20
+methodes, the class should  be split into several classes/functions.
 
-It is important to keep the number of functions and classes needed by the user to a reasonnable level.
-Modularity is therefore very important, since it allows to easily implement high level interfaces
-that orchestrates the common analysis patterns.
+It is important to keep the number of functions and classes needed by the user
+to a reasonnable level. Modularity is therefore very important, since it allows
+to easily implement high level interfaces that orchestrates the common analysis
+patterns.
 
-Algorithms and data should be clearly separated. The naming scheme used should allow easy identification of the
-nature of a piece of code. For instance, functions creating maps and or cube should be named make_map_xxx. 
+Algorithms and data should be clearly separated. The naming scheme used should
+allow easy identification of the nature of a piece of code. For instance,
+functions creating maps and or cube should be named make_map_xxx.
 
 Data analysis subpackages in gammapy
 ====================================
 
-Low level analysis produces reduced datasets and IRFs from the general event lists and multidimensional IRFs of
-each observation or GTI.  The building blocks on which it relies are coded in gammapy.data
-(``EventList``, ``DataStore``, ``DataStoreObservation`` etc), in gammapy.maps (in particular ``WcsNDMap`` used
-both for images and cubes), in gammapy.irf (e.g. ``EffectiveAreaTable2D``, ``EnergyDispersion2D``,
-``EnergyDependentTablePSF``, etc). 
+Low level analysis produces reduced datasets and IRFs from the general event
+lists and multidimensional IRFs of each observation or GTI.  The building blocks
+on which it relies are coded in gammapy.data (``EventList``, ``DataStore``,
+``DataStoreObservation`` etc), in gammapy.maps (in particular ``WcsNDMap`` used
+both for images and cubes), in gammapy.irf (e.g. ``EffectiveAreaTable2D``,
+``EnergyDispersion2D``, ``EnergyDependentTablePSF``, etc).
 
 Analysis subpackages are:
 
@@ -64,42 +70,57 @@ Analysis subpackages are:
 Low level map and cube analysis
 ===============================
 
-The low-level analysis cube package deals with the production of all maps/cubes and PSF kernels required
-to perform 2D and 3D modeling and fitting. This includes counts, exposure, acceptance and normalized background
-maps and cubes. These reduced data and IRFs are stored using the ``gammapy.maps.WcsNDMap`` class which describes
-multidimensional maps with their World Coordinate System (WCS) description and a set of non-spatial axis.
-The default map structure for most of the typical analysis will be 3 dimensional maps with an energy axis (with a
+The low-level analysis cube package deals with the production of all maps/cubes
+and PSF kernels required to perform 2D and 3D modeling and fitting. This
+includes counts, exposure, acceptance and normalized background maps and cubes.
+These reduced data and IRFs are stored using the ``gammapy.maps.WcsNDMap`` class
+which describes multidimensional maps with their World Coordinate System (WCS)
+description and a set of non-spatial axis. The default map structure for most of
+the typical analysis will be 3 dimensional maps with an energy axis (with a
 single bin for 2D images).
 
-The low level analysis is performed on an observation per observation (or GTI) basis. This is required by the response
-and background rapid variations. Therefore, all basic functions operate on a single ``EventList`` or set of IRFs
-(i.e. ``EffectiveAreaTable2D``, ``EnergyDispersion2D``, ``EnergyDependentTablePSF``). The iterative production of the individual
-reduced datasets and IRFs and their combination is realized by the higher level class. The individual observation products
-can be serialized, mostly for analysis debugging purposes or to avoid reprocessing large databases when new data are added.
+The low level analysis is performed on an observation per observation (or GTI)
+basis. This is required by the response and background rapid variations.
+Therefore, all basic functions operate on a single ``EventList`` or set of IRFs
+(i.e. ``EffectiveAreaTable2D``, ``EnergyDispersion2D``,
+``EnergyDependentTablePSF``). The iterative production of the individual reduced
+datasets and IRFs and their combination is realized by the higher level class.
+The individual observation products can be serialized, mostly for analysis
+debugging purposes or to avoid reprocessing large databases when new data are
+added.
 
-Depending on the type of analysis, different reduced IRFs are to be produced. The main difference lies in the type of energy
-considered: reconstructed or true (i.e. incident) energy. Counts, hadronic acceptance and background always use reconstructed
-(i.e. measured) energy. Exposure and PSF kernels will be defined in reconstructed energy for 2D analysis whereas they will be
-defined in true energies for 3D analysis with their own energy binning. A reduced energy dispersion will then be produced
-to convert from true to reconstructed energies and used later to predict counts. 
- 
-The maker functions and the products have to clearly state  what type of energy they are using to avoid any confusion.
-The serialization has to include a way to clearly differentiate the products. Some metadata, probably in the form
-of an ``OrderedDict`` as in the case of ``astropy.table.Table`` could be used to do so.
+Depending on the type of analysis, different reduced IRFs are to be produced.
+The main difference lies in the type of energy considered: reconstructed or true
+(i.e. incident) energy. Counts, hadronic acceptance and background always use
+reconstructed (i.e. measured) energy. Exposure and PSF kernels will be defined
+in reconstructed energy for 2D analysis whereas they will be defined in true
+energies for 3D analysis with their own energy binning. A reduced energy
+dispersion will then be produced to convert from true to reconstructed energies
+and used later to predict counts.
 
-In order to perform likelihood analysis of maps and cubes, as well as to apply *ON-OFF* significance estimation techniques
-it is important to have integers values for counts and OFF maps produced by ring background estimation techniques (on an
-observation per observation basis). Therefore, we want to avoid reprojecting individual maps onto a global mosaic.
+The maker functions and the products have to clearly state  what type of energy
+they are using to avoid any confusion. The serialization has to include a way to
+clearly differentiate the products. Some metadata, probably in the form of an
+``OrderedDict`` as in the case of ``astropy.table.Table`` could be used to do
+so.
 
-The approach should be to define the general geometry of the target mosaic map and to perform cutouts for each observation.
-This can be done using for instance ``astropy.Cutout2D``. The index range of the cutout in the general mosaic map
+In order to perform likelihood analysis of maps and cubes, as well as to apply
+*ON-OFF* significance estimation techniques it is important to have integers
+values for counts and OFF maps produced by ring background estimation techniques
+(on an observation per observation basis). Therefore, we want to avoid
+reprojecting individual maps onto a global mosaic.
+
+The approach should be to define the general geometry of the target mosaic map
+and to perform cutouts for each observation. This can be done using for instance
+``astropy.Cutout2D``. The index range of the cutout in the general mosaic map
 should be kept for easy summation. This step is performed with:
 
 ``make_map_cutout``
     * *takes* a ``WcsNDMap`` and a maximum offset angle ``Angle`` or ``Quantity``
-    * *returns* the ``WcsGeom`` of the cutout and its ``slice`` 
+    * *returns* the ``WcsGeom`` of the cutout and its ``slice``
 
-For individual observations/gti, the general arguments of all maker functions are:
+For individual observations/gti, the general arguments of all maker functions
+are:
 
 * Reference image and energy range. ``gammapy.maps.MapGeom``
 * Maximum offset angle. ``astropy.coordinates.Angle``
@@ -114,7 +135,7 @@ The various maker functions are then:
     * *returns* an exposure map/cube in true energy
 ``make_map_exposure_reco_energy``
     * *takes* a pointing direction, an ``EffectiveAreaTable2D``, an ``EnergyDispersion2D`` and a livetime
-    * *returns* an exposure map/cube in reco energy  
+    * *returns* an exposure map/cube in reco energy
 ``make_map_hadron_acceptance``
     * *takes* a pointing direction, a ``Background3D`` and a livetime
     * *returns* an hadronic acceptance map, i.e. a predicted background map/cube.
@@ -125,42 +146,49 @@ The various maker functions are then:
 ``make_map_ring_background``
     * *takes* maps/cube (``WcsNDMap``) of observed counts and hadron acceptance/predicted background and exclusion map. It also takes a ``gammapy.background.AdaptiveRingBackgroundEstimator`` or a ``gammapy.background.RingBackgroundEstimator``
     * *returns* the map of background normalized on the observed counts with a ring filter (excluding regions with significant gamma-ray emission). The background estimator object also contains the *OFF* map and the *ON* and *OFF* exposure maps.
-    * Most likely this technique is not meant to be used for too small energy bands, so that energy grouping is probably not relevant here. 
+    * Most likely this technique is not meant to be used for too small energy bands, so that energy grouping is probably not relevant here.
 
-The general processing can then be performed by general classes or scripts, possibly config file driven.
-It should be sufficiently modular to allow for users to do their own scripts
-  
+The general processing can then be performed by general classes or scripts,
+possibly config file driven. It should be sufficiently modular to allow for
+users to do their own scripts
+
 
 Existing code
 =============
 
-Currently, maps and cubes rely on the ``SkyImage`` and ``SkyCube`` classes. There are various scripts and classes existing
-currently in gammapy to produce maps and cubes (mostly developped by @adonath and @ljouvin).Image  processing can be performed
-with ``SingleObsImageMaker`` and ``StackedObsImageMaker``, while cube processing can be performed with
-``SingleObsCubeMaker`` and ``StackedObsCubeMaker``. For images, one can also use the ``IACTBasicImageEstimator``.
-All this code relies on high level class which perform all the analysis sequentially (exposure, background, count maps
-etc). This approach is not modular and creates a lot of code duplication. Some cube-related analysis is required for images
-creating some cross-dependencies. 
+Currently, maps and cubes rely on the ``SkyImage`` and ``SkyCube`` classes.
+There are various scripts and classes existing currently in gammapy to produce
+maps and cubes (mostly developped by @adonath and @ljouvin).Image  processing
+can be performed with ``SingleObsImageMaker`` and ``StackedObsImageMaker``,
+while cube processing can be performed with ``SingleObsCubeMaker`` and
+``StackedObsCubeMaker``. For images, one can also use the
+``IACTBasicImageEstimator``. All this code relies on high level class which
+perform all the analysis sequentially (exposure, background, count maps etc).
+This approach is not modular and creates a lot of code duplication. Some
+cube-related analysis is required for images creating some cross-dependencies.
 
-The proposed scheme should be much more modular and allow user to use gammapy as a library to compose their own scripts
-and classes if needed. It should limit code duplication. In particular, it uses the more general ``gammapy.maps`` which
-allows to get rid of the cross dependencies of the image and cube package we have now. 
+The proposed scheme should be much more modular and allow user to use gammapy as
+a library to compose their own scripts and classes if needed. It should limit
+code duplication. In particular, it uses the more general ``gammapy.maps`` which
+allows to get rid of the cross dependencies of the image and cube package we
+have now.
 
-The existing code will remain in gammapy for the moment, with possibly some bugs fixed. The new code is largely
-independent so that the new development should bot break user scripts.
+The existing code will remain in gammapy for the moment, with possibly some bugs
+fixed. The new code is largely independent so that the new development should
+bot break user scripts.
 
 Decision
 ========
 
 This PIG was extensively discussed on Github, as well as in Gammapy weekly calls
-and at the Feb 2018 and July 2018 Gammapy meetings.
-Doing this move to new analysis code based on gammapy.maps was never controversial,
-bug API and implementation discussions were ongoing.
+and at the Feb 2018 and July 2018 Gammapy meetings. Doing this move to new
+analysis code based on gammapy.maps was never controversial, bug API and
+implementation discussions were ongoing.
 
 On July 27, 2018, Regis and Christoph noticed that the description in this PIG
 had been mostly implemented in Gammapy master already, and that further progress
 would come from individual improvements, not a rewrite / update of this PIG with
-a complete design. So we decided to merge this PIG with status "approved" to have it on the record
-as part of the design and evolution process for Gammapy.
+a complete design. So we decided to merge this PIG with status "approved" to
+have it on the record as part of the design and evolution process for Gammapy.
 
 .. _GH 1277: https://github.com/gammapy/gammapy/pull/1277

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -19,9 +19,10 @@ We have structured the procedure in three phases:
 #. "Post release" -- on the day when announcing the release
    (ideally only two or three days after making the release)
 
-The purpose of writing the procedure down explicitly is to make it easy for anyone to make a release
-(as opposed to one or a few people with secret knowledge how to do it).
-It's also good to not have to remember this stuff, and to avoid errors or forgotten steps.
+The purpose of writing the procedure down explicitly is to make it easy for
+anyone to make a release (as opposed to one or a few people with secret
+knowledge how to do it). It's also good to not have to remember this stuff, and
+to avoid errors or forgotten steps.
 
 Note that we currently don't do bugfix releases, i.e. making a release is always simple in the sense
 that you just need to create a branch off of ``master``.
@@ -37,17 +38,17 @@ Steps to prepare for the release (e.g. a week before) to check that things are i
 
 #. Check the issue (example: https://github.com/gammapy/gammapy/issues/302 )
    and milestone (example: https://github.com/gammapy/gammapy/milestones/0.3 )
-   for the release.
-   Try to get developers to finish up their PRs, try to help fix bugs,
-   and postpone non-critical issues to the next release.
+   for the release. Try to get developers to finish up their PRs, try to help
+   fix bugs, and postpone non-critical issues to the next release.
 #. Follow the instructions `here <http://docs.astropy.org/en/latest/development/affiliated-packages.html#updating-to-the-latest-template-files>`__
-   to check that the astropy-helpers sub-module in Gammapy is pointing to the latest stable astropy-helpers release
-   and whether there have been any fixes / changes to the Astropy
-   `package-template <https://github.com/astropy/package-template/blob/master/TEMPLATE_CHANGES.md>`__
-   since the last Gammapy release that should be copied over.
-   In Gammapy we are using the method that's described in the section "managing the template files manually"
-   that's described.
-   If there are any updates to be done, you should do them via a PR so that travis-ci testing can run.
+   to check that the astropy-helpers sub-module in Gammapy is pointing to the
+   latest stable astropy-helpers release and whether there have been any fixes /
+   changes to the Astropy `package-template
+   <https://github.com/astropy/package-template/blob/master/TEMPLATE_CHANGES.md>`__
+   since the last Gammapy release that should be copied over. In Gammapy we are
+   using the method that's described in the section "managing the template files
+   manually" that's described. If there are any updates to be done, you should
+   do them via a PR so that travis-ci testing can run.
 #. Do these extra checks and clean up any warnings / errors that come up::
 
        make trailing-spaces
@@ -88,7 +89,8 @@ Post release
 Steps for the day to announce the release:
 
 #. Send release announcement to the Gammapy mailing list and on Gammapy Slack
-   (using the version you drafted in https://github.com/gammapy/gammapy/tree/master/dev/notes ).
+   (using the version you drafted in
+   https://github.com/gammapy/gammapy/tree/master/dev/notes ).
 #. If it's a big release with important new features or fixes,
    also send the release announcement to the following mailing lists
    (decide on a case by case basis, if it's relevant to the group of people):
@@ -102,8 +104,8 @@ Steps for the day to announce the release:
    while making the release (ideally try to script / automate the task or check,
    e.g. as a ``make release-check-xyz`` target.
 #. Open a milestone and issue for the next release (and possibly also a milestone for the
-   release after, so that low-priority issues can already be moved there)
-   Find a release manager for the next release, assign the release issue to her / him,
-   and ideally put a tentative date (to help developers plan their time for the coming
-   weeks and months).
+   release after, so that low-priority issues can already be moved there) Find a
+   release manager for the next release, assign the release issue to her / him,
+   and ideally put a tentative date (to help developers plan their time for the
+   coming weeks and months).
 #. Start working on the next release. :-)

--- a/docs/development/setup.rst
+++ b/docs/development/setup.rst
@@ -6,13 +6,14 @@
 Gammapy project setup
 =====================
 
-This page gives an overview of the technical infrastructure we have set up to develop and maintain Gammapy.
+This page gives an overview of the technical infrastructure we have set up to
+develop and maintain Gammapy.
 
-If you just want to make contribution to the Gammapy code or documentation,
-you don't need to know about most of the things mentioned on this page!
+If you just want to make contribution to the Gammapy code or documentation, you
+don't need to know about most of the things mentioned on this page!
 
-But for Gammapy maintainers it's helpful to have a reference that explains
-what we have and how things work.
+But for Gammapy maintainers it's helpful to have a reference that explains what
+we have and how things work.
 
 gammapy repository
 ==================
@@ -24,19 +25,19 @@ This section explains the content of the main repository for Gammapy:
 Package and docs
 ----------------
 
-The two main folders of interest for developers are the ``gammapy`` folder
-and the ``docs`` folder. In ``gammapy`` you find the Gammapy package, i.e.
-all code, but also tests are included there in sub-folders called ``tests``.
-The ``docs`` folder contains the documentation pages in restructured text (RST)
-format. The Sphinx documentation generator is used to convert those RST files
-to the HTML documentation.
+The two main folders of interest for developers are the ``gammapy`` folder and
+the ``docs`` folder. In ``gammapy`` you find the Gammapy package, i.e. all code,
+but also tests are included there in sub-folders called ``tests``. The ``docs``
+folder contains the documentation pages in restructured text (RST) format. The
+Sphinx documentation generator is used to convert those RST files to the HTML
+documentation.
 
 Jupyter notebooks present in the ``gammapy-extra`` GitHub repository are also
 part of the documentation. They are copied to a ``docs/notebooks`` folder during
-the process of documentation building and converted to the Sphinx-formatted HTML files
-present in the :ref:`tutorials` section. Raw Jupyter notebooks files and .py scripts
-versions are placed in the ``docs/_static/notebooks`` folder generated during the
-documentation building process.
+the process of documentation building and converted to the Sphinx-formatted HTML
+files present in the :ref:`tutorials` section. Raw Jupyter notebooks files and
+.py scripts versions are placed in the ``docs/_static/notebooks`` folder
+generated during the documentation building process.
 
 In the repository you will find a bunch of other files and folders. We will explain
 some of them here, but not all. Just ignore the rest.
@@ -46,34 +47,41 @@ some of them here, but not all. Just ignore the rest.
 Build
 -----
 
-The ``setup.py`` and ``Makefile`` contain code to build and install Gammapy,
-as well as to run the tests and build the documentation, see :ref:`dev_intro`.
+The ``setup.py`` and ``Makefile`` contain code to build and install Gammapy, as
+well as to run the tests and build the documentation, see :ref:`dev_intro`.
 
-The ``environment-dev.yml`` file contains the conda environment specification that
-allows one to quickly set up a conda environment for Gammapy development, see :ref:`dev_setup`.
+The ``environment-dev.yml`` file contains the conda environment specification
+that allows one to quickly set up a conda environment for Gammapy development,
+see :ref:`dev_setup`.
 
-The ``astropy_helpers`` folder is a git submodule pointing to https://github.com/astropy/astropy-helpers
-It is used from ``setup.py`` (also using ``ah_bootstrap.py``) and provides helpers related to
-Python build, installation and packaging, including a robust way to build C and Cython code from ``setup.py``,
-as well as pytest extensions for testing and Sphinx extensions for the documentation build.
-If you look into those Python files, you will find that they are highly complex, and full of workarounds
-for old versions of Python, setuptools, Sphinx etc. Note that this is not code that we develop and maintain
-in Gammapy. Gammapy was started from https://github.com/astropy/package-template and there are besides the
-``astropy_helpers`` folder a number of files (like ``ah_bootstrap.py``, but also ``ez_setup.py`` or
-``gamampy/_astropy_init.py``) that are needed, but should be ignored. The Astropy team has set up a bot
-that from time to time makes pull requests to update the affiliated packages (including Gammapy) as new
-versions of ``astropy_helpers`` and the extra files are released.
+The ``astropy_helpers`` folder is a git submodule pointing to
+https://github.com/astropy/astropy-helpers It is used from ``setup.py`` (also
+using ``ah_bootstrap.py``) and provides helpers related to Python build,
+installation and packaging, including a robust way to build C and Cython code
+from ``setup.py``, as well as pytest extensions for testing and Sphinx
+extensions for the documentation build. If you look into those Python files, you
+will find that they are highly complex, and full of workarounds for old versions
+of Python, setuptools, Sphinx etc. Note that this is not code that we develop
+and maintain in Gammapy. Gammapy was started from
+https://github.com/astropy/package-template and there are besides the
+``astropy_helpers`` folder a number of files (like ``ah_bootstrap.py``, but also
+``ez_setup.py`` or ``gamampy/_astropy_init.py``) that are needed, but should be
+ignored. The Astropy team has set up a bot that from time to time makes pull
+requests to update the affiliated packages (including Gammapy) as new versions
+of ``astropy_helpers`` and the extra files are released.
 
 Version
 -------
 
-One more thing worth pointing out is how versioning for Gammapy works. Getting a correct version number
-in all cases (stable or dev version, installed package or in-place build in the source folder, ...) is
-surprisingly complex for Python packages. For Gammapy, the version is computed at build time,
-by ``setup.py`` calling into the ``get_git_devstr`` helper function, and writing it to the auto-generated
-file ``gammapy/version.py``. This file is then part of the Gammapy package, and is imported via
-``gammapy/_astropy_init.py`` from ``gammapy/__init__.py``. This means that one can simply do this
-and always get the right version for Gammapy::
+One more thing worth pointing out is how versioning for Gammapy works. Getting a
+correct version number in all cases (stable or dev version, installed package or
+in-place build in the source folder, ...) is surprisingly complex for Python
+packages. For Gammapy, the version is computed at build time, by ``setup.py``
+calling into the ``get_git_devstr`` helper function, and writing it to the
+auto-generated file ``gammapy/version.py``. This file is then part of the
+Gammapy package, and is imported via ``gammapy/_astropy_init.py`` from
+``gammapy/__init__.py``. This means that one can simply do this and always get
+the right version for Gammapy::
 
     >>> import gammapy
     >>> gammapy.__version__
@@ -84,42 +92,49 @@ and always get the right version for Gammapy::
 Cython
 ------
 
-We also have some Cython code in Gammapy, at the time of this writing less than 1% in these two files:
+We also have some Cython code in Gammapy, at the time of this writing less than
+1% in these two files:
 
 * ``gammapy/detect/_test_statistics_cython.pyx``
 * ``gammapy/maps/_sparse.pyx``
 
-and again as part of the Astropy package template there is the ``gammapy/_compiler.c`` file
-to help ``setup.py`` figure out information about the C compiler at build time.
-These are the files that are compiled by Cython and your C compiler when you build the Gammapy package,
-as explained in :ref:`dev_intro`.
+and again as part of the Astropy package template there is the
+``gammapy/_compiler.c`` file to help ``setup.py`` figure out information about
+the C compiler at build time. These are the files that are compiled by Cython
+and your C compiler when you build the Gammapy package, as explained in
+:ref:`dev_intro`.
 
 Other
 -----
 
-There are two more folders in the ``gammapy`` repo: ``examples`` and ``dev``. We started with the
-``examples`` folder with the idea to have Gammapy usage examples there and have them be part of
-the user documentation. But this is not the case at the moment, rather ``examples`` is a collection
-of scripts that have mostly been used by developers to develop and debug Gammapy code.
-Most can probably just be deleted, some should be moved to user documentation (not clear where,
-could move all content to notebooks) or automated tests. The idea for the ``dev`` folder was
-to just have a place for scripts and checks and notes by Gammapy developers. Like for ``examples``,
-it's mostly outdated cruft and should probably be cleaned out.
+There are two more folders in the ``gammapy`` repo: ``examples`` and ``dev``. We
+started with the ``examples`` folder with the idea to have Gammapy usage
+examples there and have them be part of the user documentation. But this is not
+the case at the moment, rather ``examples`` is a collection of scripts that have
+mostly been used by developers to develop and debug Gammapy code. Most can
+probably just be deleted, some should be moved to user documentation (not clear
+where, could move all content to notebooks) or automated tests. The idea for the
+``dev`` folder was to just have a place for scripts and checks and notes by
+Gammapy developers. Like for ``examples``, it's mostly outdated cruft and should
+probably be cleaned out.
 
-The files ``.travis.yml``, ``appveyor.yml``, ``readthedocs.yml`` and ``environment-rtd.yml`` are the configuration files
-for the continuous integration (CI) and documentation build / hosting cloud services we use.
-They are described in sections further down on this page.
+The files ``.travis.yml``, ``appveyor.yml``, ``readthedocs.yml`` and
+``environment-rtd.yml`` are the configuration files for the continuous
+integration (CI) and documentation build / hosting cloud services we use. They
+are described in sections further down on this page.
 
-Finally, there are some folders that are generated and filled by various build steps:
+Finally, there are some folders that are generated and filled by various build
+steps:
 
 * ``build`` contains the Gammapy package if you run ``python setup.py build``.
-  If you run ``python setup.py install``, first the build is run and files placed there,
-  and after that files are copied from the ``build`` folder to your ``site-packages``.
+  If you run ``python setup.py install``, first the build is run and files
+  placed there, and after that files are copied from the ``build`` folder to
+  your ``site-packages``.
 * ``docs/_build`` contains the generated documentation, especially ``docs/_build/html`` the HTML version.
 * ``htmlcov`` and ``.coverage`` is where the test coverage report is stored.
 * ``v`` is a folder Pytest uses for caching information about failing tests across test runs.
-  This is what makes it possible to execute tests e.g. with the ``--lf`` option and just run
-  the tests that "last failed".
+  This is what makes it possible to execute tests e.g. with the ``--lf`` option
+  and just run the tests that "last failed".
 * ``dist`` contains the Gammapy distribution if you run ``python setup.py sdist``
 
 .. _dev_gammapy-extra:
@@ -127,57 +142,68 @@ Finally, there are some folders that are generated and filled by various build s
 gammapy-extra repository
 ========================
 
-For Gammapy we have a second repository for example data files, Jupyter notebooks and a few other things:
+For Gammapy we have a second repository for example data files, Jupyter
+notebooks and a few other things:
 
     https://github.com/gammapy/gammapy-extra
 
 Jupyter notebooks
 -----------------
 
-The ``notebooks`` folder contains Jupyter notebooks that are part of the user documentation for Gammapy.
-We do have automated testing for notebooks set up (just check that they run and don't raise an exception),
-via the ``test_notebooks.py`` script in the ``gammapy`` repo, which looks at
-``gammapy-extra/notebooks/notebooks.yaml`` for which notebooks to test or not to test.
+The ``notebooks`` folder contains Jupyter notebooks that are part of the user
+documentation for Gammapy. We do have automated testing for notebooks set up
+(just check that they run and don't raise an exception), via the
+``test_notebooks.py`` script in the ``gammapy`` repo, which looks at
+``gammapy-extra/notebooks/notebooks.yaml`` for which notebooks to test or not to
+test.
 
-The ``index.ipynb`` file is just a placeholder, the notebook index was moved to ``docs/tutorials.rst``
-in the ``gammapy`` repo and is now visible at http://docs.gammapy.org/en/latest/tutorials.html
-It can be removed after a while (say in January 2018).
+The ``index.ipynb`` file is just a placeholder, the notebook index was moved to
+``docs/tutorials.rst`` in the ``gammapy`` repo and is now visible at
+http://docs.gammapy.org/en/latest/tutorials.html It can be removed after a while
+(say in January 2018).
 
 The ``Dockerfile`` is used for Binder, see below.
 
 Example data
 ------------
 
-The ``datasets`` and ``test_dataset`` folders contain example datasets that are used by the Gammapy
-documentation and tests. Note that here is a lot of old cruft, because Gammapy was developed since
-2013 in parallel with the development of data formats for gamma-ray astronomy (see below).
+The ``datasets`` and ``test_dataset`` folders contain example datasets that are
+used by the Gammapy documentation and tests. Note that here is a lot of old
+cruft, because Gammapy was developed since 2013 in parallel with the development
+of data formats for gamma-ray astronomy (see below).
 
-Many old files in those folders can just be deleted; in some cases where documentation or tests
-access the old files, they should be changed to access newer files or generate test datasets from scratch.
-Doing this "cleanup" and improvement of curated example datasets will be an ongoing task in Gammapy
-for the coming years, that has to proceed in parallel with code, test and documentation improvements.
+Many old files in those folders can just be deleted; in some cases where
+documentation or tests access the old files, they should be changed to access
+newer files or generate test datasets from scratch. Doing this "cleanup" and
+improvement of curated example datasets will be an ongoing task in Gammapy for
+the coming years, that has to proceed in parallel with code, test and
+documentation improvements.
 
 Other
 -----
 
-* The ``figures`` folder contains images that we show in the documentation (or in presentations or publications),
-  for cases where the analysis and image takes a while to compute (i.e. something we don't want to do all the time
-  during the Gammapy documentation build). In each case, there should be a Python script to generate the image.
-* The ``experiments`` and ``checks`` folders contain Python scripts and notebooks with, well, experiments and
-  checks by Gammapy developers. Some are still work in progress and of interest, most could probably be deleted.
+* The ``figures`` folder contains images that we show in the documentation (or
+  in presentations or publications), for cases where the analysis and image
+  takes a while to compute (i.e. something we don't want to do all the time
+  during the Gammapy documentation build). In each case, there should be a
+  Python script to generate the image.
+* The ``experiments`` and ``checks`` folders contain Python scripts and
+  notebooks with, well, experiments and checks by Gammapy developers. Some are
+  still work in progress and of interest, most could probably be deleted.
 * The ``logo`` folder contains the Gammapy logo and banner in a few different variants.
-* The ``posters`` and ``presentations`` folders contain a few Gammapy posters and presentations,
-  for cases where the poster or presentation isn't available somewhere else on the web.
-  It's hugely incomplete and probably not very useful as-is, and we should discuss if this is useful at all,
-  and if yes, how we want to maintain it.
+* The ``posters`` and ``presentations`` folders contain a few Gammapy posters
+  and presentations, for cases where the poster or presentation isn't available
+  somewhere else on the web. It's hugely incomplete and probably not very useful
+  as-is, and we should discuss if this is useful at all, and if yes, how we want
+  to maintain it.
 
 Versioning
 ----------
 
-At this time, the ``gammapy`` and ``gammapy-extra`` repositories aren't version-coupled,
-and we don't have a good solution for how to handle example data files yet.
-What we do now is tell users to download ``gammapy-extra`` locally, which isn't nice,
-but it's hard to implement something better.
+At this time, the ``gammapy`` and ``gammapy-extra`` repositories aren't
+version-coupled, and we don't have a good solution for how to handle example
+data files yet. What we do now is tell users to download ``gammapy-extra``
+locally, which isn't nice, but it's hard to implement something better.
 
 Other repositories
 ==================
@@ -205,12 +231,13 @@ In addition we have Binder set up to allow users to try Gammapy in the browser.
 gammapy.org
 -----------
 
-http://gammapy.org/ is a small landing page for the Gammapy project.
-The page shown there a static webpage served via Github pages.
+http://gammapy.org/ is a small landing page for the Gammapy project. The page
+shown there a static webpage served via Github pages.
 
-To update it, edit the HTML and CSS files this repo: https://github.com/gammapy/gammapy-webpage
-and then make a pull request against the default branch for that repo, called ``gh-pages``.
-Once it's merged, the webpage at http://gammapy.org/ usually updates within less than a minute.
+To update it, edit the HTML and CSS files this repo:
+https://github.com/gammapy/gammapy-webpage and then make a pull request against
+the default branch for that repo, called ``gh-pages``. Once it's merged, the
+webpage at http://gammapy.org/ usually updates within less than a minute.
 
 docs.gammapy.org
 ----------------
@@ -223,9 +250,10 @@ TODO: describe how to update.
 Gammapy Binder
 --------------
 
-We have set up https://mybinder.org/ for Gammapy, which allows users to execute the tutorial
-Jupyter notebooks in the web browser, without having to install software or download data
-to their local machine. This can be useful for people to get started, and for tutorials.
+We have set up https://mybinder.org/ for Gammapy, which allows users to execute
+the tutorial Jupyter notebooks in the web browser, without having to install
+software or download data to their local machine. This can be useful for people
+to get started, and for tutorials.
 
 TODO: describe a bit how it works.
 
@@ -235,12 +263,13 @@ Continuous integration
 * Windows CI: https://ci.appveyor.com/project/cdeil/gammapy/branch/master
 * Mac and Linux CI: https://travis-ci.org/gammapy/gammapy
 
-We also have a Jenkins server set up at MPIK (at https://www.mpi-hd.mpg.de/gamma-jenkins )
-that is running on Ubuntu. We could use it to e.g. run more extensive CI builds
-such as e.g. making nightly or weekly test releases and running an extensive
-set of "science verification" tests that might involve larger datasets or be slow.
-It could also be used for performance tests, to check for regressions in CPU or memory usage.
-If anyone is interested in setting this up for Gammapy, please get in touch.
+We also have a Jenkins server set up at MPIK (at
+https://www.mpi-hd.mpg.de/gamma-jenkins ) that is running on Ubuntu. We could
+use it to e.g. run more extensive CI builds such as e.g. making nightly or
+weekly test releases and running an extensive set of "science verification"
+tests that might involve larger datasets or be slow. It could also be used for
+performance tests, to check for regressions in CPU or memory usage. If anyone is
+interested in setting this up for Gammapy, please get in touch.
 
 Code quality
 ============
@@ -251,16 +280,18 @@ Code quality
 Releases
 ========
 
-At this time, making a Gammapy release is a sequence of steps to execute in the command line
-and on some webpages, that is fully documented in this checklist: :ref:`dev-release`.
-It is difficult to automate this procedure more, but it is already pretty straightforward and quick to do.
-If all goes well, making a release takes about 1 hour of human time and one or two days of real time,
-with the building of the conda binary packages being the slowest step, something we wait for before
-announcing a new release to users (because many use conda and will try to update as soon as they get
-the announcement email).
+At this time, making a Gammapy release is a sequence of steps to execute in the
+command line and on some webpages, that is fully documented in this checklist:
+:ref:`dev-release`. It is difficult to automate this procedure more, but it is
+already pretty straightforward and quick to do. If all goes well, making a
+release takes about 1 hour of human time and one or two days of real time, with
+the building of the conda binary packages being the slowest step, something we
+wait for before announcing a new release to users (because many use conda and
+will try to update as soon as they get the announcement email).
 
 * Source distribution releases: https://pypi.org/project/gammapy/
-* Binary conda packages for Linux, Mac and Windows: https://github.com/conda-forge/gammapy-feedstock
+* Binary conda packages for Linux, Mac and Windows:
+  https://github.com/conda-forge/gammapy-feedstock
 
 Data formats
 ============

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -12,20 +12,21 @@ Reading through this page will just take you a few minutes.
 But we hope that you'll get curious and start executing the examples yourself,
 using Gammapy to analyse (simulated) H.E.S.S. and real Fermi-LAT data.
 
-If you're new to Python for gamma-ray astronomy and would like to learn the basics, we recommend
-you go to the `Scipy Lecture Notes`_ or the `Practical Python for Astronomers Tutorial`_.
+If you're new to Python for gamma-ray astronomy and would like to learn the
+basics, we recommend you go to the `Scipy Lecture Notes`_ or the `Practical
+Python for Astronomers Tutorial`_.
 
 Gammapy as a Python package and set of science tools
 ----------------------------------------------------
 
-Gammapy is a Python package, consisting of functions and classes, that you can use
-as a flexible and extensible toolbox to implement and execute exactly the analysis you want.
+Gammapy is a Python package, consisting of functions and classes, that you can
+use as a flexible and extensible toolbox to implement and execute exactly the
+analysis you want.
 
-On top of that, Gammapy provides some command line tools (sometimes driven by a config file),
-and in the future we plan on adding web apps with a graphical user interface.
-To use those no Python programming skills are required, you'll just have to specify which
-data to analyse, with which method and parameters.
-
+On top of that, Gammapy provides some command line tools (sometimes driven by a
+config file), and in the future we plan on adding web apps with a graphical user
+interface. To use those no Python programming skills are required, you'll just
+have to specify which data to analyse, with which method and parameters.
 
 Getting set up
 --------------
@@ -34,16 +35,19 @@ First, make sure you have Gammapy installed (see :ref:`install`).
 
 You can use this command to make sure the Python package is available::
 
-   $ python -c 'import gammapy'
+    $ python -c 'import gammapy'
 
-To check if the Gammapy command line tool has been installed and are available on your PATH, use this command::
+To check if the Gammapy command line tool has been installed and are available
+on your PATH, use this command::
 
     $ gammapy --version
 
-The Gammapy tutorials use some example datasets that are stored in the ``gammapy-extra`` repository on Github.
-So please go follow the instructions at :ref:`gammapyextra` to fetch those, then come back here.
+The Gammapy tutorials use some example datasets that are stored in the
+``gammapy-extra`` repository on Github. So please go follow the instructions at
+:ref:`gammapyextra` to fetch those, then come back here.
 
-To check if ``gammapy-extra`` is available and the ``GAMMAPY_EXTRA`` shell environment variable set, use this command::
+To check if ``gammapy-extra`` is available and the ``GAMMAPY_EXTRA`` shell
+environment variable set, use this command::
 
     $ echo $GAMMAPY_EXTRA
     $ ls $GAMMAPY_EXTRA/logo/gammapy_banner.png
@@ -54,86 +58,91 @@ Need help?
 If you have any questions or issues with installation, setup or Gammapy usage,
 lease use the `Gammapy mailing list`_!
 
-Gammapy is a very young project, we know there are many missing features and issues.
-Please have some patience, and let us know what you want to do, so that we can set priorities.
-
+Gammapy is a very young project, we know there are many missing features and
+issues. Please have some patience, and let us know what you want to do, so that
+we can set priorities.
 
 Using Gammapy as a Python package
 ---------------------------------
 
 Here's a few very simple examples how to use Gammapy as a Python package.
 
-What's the statistical significance when 10 events have been observed with a known background level of 4.2
-according to [LiMa1983]_?
+What's the statistical significance when 10 events have been observed with a
+known background level of 4.2 according to [LiMa1983]_?
 
-Getting the answer from Gammapy is easy. You import and call the `gammapy.stats.significance` function:
-
-.. code-block:: python
-
-   >>> from gammapy.stats import significance
-   >>> significance(n_observed=10, mu_background=4.2, method='lima')
-   2.3979181291475453
-
-As another example, here's how you can create `gammapy.data.DataStore` and `gammapy.data.EventList`
-objects and start exploring some properties of the (simulated) H.E.S.S. event data:
+Getting the answer from Gammapy is easy. You import and call the
+`gammapy.stats.significance` function:
 
 .. code-block:: python
 
-   >>> from gammapy.data import DataStore
-   >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
-   >>> events = data_store.obs(obs_id=23523).events
-   >>> len(events)
-   1527
-   >>> events.energy.mean()
-   <Quantity 3.585395097732544 TeV>
+    >>> from gammapy.stats import significance
+    >>> significance(n_observed=10, mu_background=4.2, method='lima')
+    2.3979181291475453
 
+As another example, here's how you can create `gammapy.data.DataStore` and
+`gammapy.data.EventList` objects and start exploring some properties of the
+(simulated) H.E.S.S. event data:
+
+.. code-block:: python
+
+    >>> from gammapy.data import DataStore
+    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    >>> events = data_store.obs(obs_id=23523).events
+    >>> len(events)
+    1527
+    >>> events.energy.mean()
+    <Quantity 3.585395097732544 TeV>
 
 How do you find something in Gammapy?
 
-Often using the full-text search field is the quickest and simplest way.
-As you get to know the package, you'll learn the names of the different sub-packages that are available,
-like `gammapy.stats` or `gammapy.data`, and what functionality they contain.
+Often using the full-text search field is the quickest and simplest way. As you
+get to know the package, you'll learn the names of the different sub-packages
+that are available, like `gammapy.stats` or `gammapy.data`, and what
+functionality they contain.
 
 Another good way is tutorials, IPython and Jupyter notebooks ...
 
 Using Gammapy from the Jupyter notebooks
 ----------------------------------------
 
-In the last section you've seen how to use Gammapy as a Python package.
-To become good at using it, you have to learn the Gammapy API (application programming interface).
-One way to do this is to read documentation. A more interactive (and arguably more fun)
-way is to play with Gammapy code and gamma-ray data in Jupyter notebooks.
+In the last section you've seen how to use Gammapy as a Python package. To
+become good at using it, you have to learn the Gammapy API (application
+programming interface). One way to do this is to read documentation. A more
+interactive (and arguably more fun) way is to play with Gammapy code and
+gamma-ray data in Jupyter notebooks.
 
-Jupyter notebooks are documents that combine code input and text and graphical output,
-and are wonderful tools to learn and explore (both programming and the data),
-and finally to share results with your colleagues.
+Jupyter notebooks are documents that combine code input and text and graphical
+output, and are wonderful tools to learn and explore (both programming and the
+data), and finally to share results with your colleagues.
 
-So now is a good time to have a look here: :ref:`tutorials`.
-Try executing the cells locally on your machine as you read through the text and code.
-
+So now is a good time to have a look here: :ref:`tutorials`. Try executing the
+cells locally on your machine as you read through the text and code.
 
 Using Gammapy via command line tools
 ------------------------------------
 
-The ``gammapy`` command line tool lets you execute some very common analysis tasks
-directly from the command line. Try this::
+The ``gammapy`` command line tool lets you execute some very common analysis
+tasks directly from the command line. Try this::
 
     $ gammapy --help
     $ gammapy --version
 
-Further information about the ``gammapy`` command line interface is here: :ref:`scripts`
+Further information about the ``gammapy`` command line interface is here:
+:ref:`scripts`
 
 That page also includes information how the ``gammapy`` command line tool works
 and what to do if it doesn't work (likely you have to add the ``bin`` directory
 where Gammapy is installed to your ``PATH`` shell environment variable). It even
-has a section with a tutorial how to write your own command line tools if this is
-something you want.
+has a section with a tutorial how to write your own command line tools if this
+is something you want.
 
 What next?
 ----------
 
-If you'd like to continue with tutorials to learn Gammapy, go here: :ref:`tutorials`.
+If you'd like to continue with tutorials to learn Gammapy, go here:
+:ref:`tutorials`.
 
 To learn about some specific functionality that could be useful for your work,
-start browsing the "Getting Started" section of Gammapy sub-package that
-might be of interest to you (e.g. `gammapy.data`, `gammapy.catalog`, `gammapy.spectrum`, ...).
+start browsing the "Getting Started" section of Gammapy sub-package that might
+be of interest to you (e.g. `gammapy.data`, `gammapy.catalog`,
+`gammapy.spectrum`, ...).

--- a/docs/image/colormap_example.py
+++ b/docs/image/colormap_example.py
@@ -2,9 +2,9 @@
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from gammapy.image import colormap_hess, colormap_milagro
 from astropy.visualization.mpl_normalize import ImageNormalize
 from astropy.visualization import LinearStretch
+from gammapy.image import colormap_hess, colormap_milagro
 from gammapy.maps import Map
 
 filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/poisson_stats_image/expected_ts_0.000.fits.gz'

--- a/docs/image/index.rst
+++ b/docs/image/index.rst
@@ -14,14 +14,13 @@ Introduction
 `gammapy.image` contains functions and classes for image based analysis.
 `gammapy.image.models` contains image models that can be evaluated and fitted.
 
-
 Getting Started
 ===============
 
-The functions and classes in `gammapy.image` take `gammapy.maps` objects as input
-and output. Currently they only work on WCS-based 2D images.
-For some, we will improve them to also work on HPX-based images and on maps
-with extra axes, such as e.g. an energy axis.
+The functions and classes in `gammapy.image` take `gammapy.maps` objects as
+input and output. Currently they only work on WCS-based 2D images. For some, we
+will improve them to also work on HPX-based images and on maps with extra axes,
+such as e.g. an energy axis.
 
 .. plot::
     :include-source:
@@ -31,8 +30,8 @@ with extra axes, such as e.g. an energy axis.
     image = Map.read(filename, hdu=2)
     image.plot()
 
-TODO: Show some gammapy.image functionality, e.g. evaluating a model image or making a profile.
-
+TODO: Show some gammapy.image functionality, e.g. evaluating a model image or
+making a profile.
 
 Using `gammapy.image`
 =====================
@@ -46,11 +45,10 @@ Using `gammapy.image`
 Documentation pages with more detailed information:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   models
-   plotting
-
+    models
+    plotting
 
 Reference/API
 =============

--- a/docs/image/models.rst
+++ b/docs/image/models.rst
@@ -9,11 +9,8 @@ Morphology models (`gammapy.image.models`)
 Introduction
 ============
 
-`gammapy.image.models` contains implementations of common morphology models.
-
-TODO: explain about `astropy.modeling` and ``sherpa`` models.
-
-TODO: write me
+`gammapy.image.models` contains implementations of common 2-dimensional spatial
+models.
 
 Getting Started
 ===============

--- a/docs/image/plotting.rst
+++ b/docs/image/plotting.rst
@@ -10,7 +10,8 @@ Colormaps
 ---------
 
 The following example shows how to plot images using colormaps that are commonly
-used in gamma-ray astronomy (`~gammapy.image.colormap_hess` and `~gammapy.image.colormap_milagro`).
+used in gamma-ray astronomy (`~gammapy.image.colormap_hess` and
+`~gammapy.image.colormap_milagro`).
 
 .. plot:: image/colormap_example.py
 
@@ -18,6 +19,7 @@ Multi-panel Galactic plane survey image plots
 ---------------------------------------------
 
 The following example shows how to plot a very wide Galactic plane survey image
-by splitting it into multiple panels using the `~gammapy.image.MapPanelPlotter` class.
+by splitting it into multiple panels using the `~gammapy.image.MapPanelPlotter`
+class.
 
 .. plot:: image/survey_example.py

--- a/docs/image/survey_example.py
+++ b/docs/image/survey_example.py
@@ -1,15 +1,13 @@
 """Plot a Galactic plane survey image in two panels."""
-from astropy.coordinates import Angle
 import matplotlib.pyplot as plt
-from gammapy.image import MapPanelPlotter
+from astropy.coordinates import Angle
 from gammapy.maps import Map
-
+from gammapy.image import MapPanelPlotter
 
 filename = '$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz'
 survey_map = Map.read(filename, hdu='counts')
 survey_map.data = survey_map.data.astype('float')
 smoothed_map = survey_map.smooth(radius=Angle(0.2, unit='deg'))
-
 
 fig = plt.figure(figsize=(15, 8))
 xlim = Angle([70, 262], unit='deg')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,57 +6,58 @@
 |
 
 
-Gammapy is a community-developed, open-source Python package for gamma-ray astronomy.
-It is a prototype for the `CTA`_ science tools.
-This page ( http://docs.gammapy.org ) contains the Gammapy documentation.
-The Gammapy webpage ( http://gammapy.org ) contains information about Gammapy,
-including news and contact information if you have any questions, want to report
-and issue or request a feature, or need help with anything Gammapy-related.
+Gammapy is a community-developed, open-source Python package for gamma-ray
+astronomy. It is a prototype for the `CTA`_ science tools. This page (
+http://docs.gammapy.org ) contains the Gammapy documentation. The Gammapy
+webpage ( http://gammapy.org ) contains information about Gammapy, including
+news and contact information if you have any questions, want to report and issue
+or request a feature, or need help with anything Gammapy-related.
 
 .. _gammapy_intro:
 
 Getting started
 ---------------
 
-Gammapy works with Python 2 and 3, on Linux, Mac OS X and (partly) Windows.
-See :ref:`install` for information how to get started and the :ref:`tutorials`
-to start to learn how to use Gammapy.
+Gammapy works with Python 2 and 3, on Linux, Mac OS X and (partly) Windows. See
+:ref:`install` for information how to get started and the :ref:`tutorials` to
+start to learn how to use Gammapy.
 
 .. toctree::
-  :maxdepth: 1
+    :maxdepth: 1
 
-  install/index
-  getting-started
-  tutorials
+    install/index
+    getting-started
+    tutorials
 
 .. _gammapy_package:
 
 Gammapy package
 ---------------
 
-As mentioned in the :ref:`getting-started`, the Gammapy package is structured as a
-series of sub-packages. We recommend that you start to learn Gammapy via the :ref:`tutorials`,
-and then consult the following pages for further information about each sub-package.
-Those pages also contain very detailed reference documentation for every function and class in Gammapy.
+As mentioned in the :ref:`getting-started`, the Gammapy package is structured as
+a series of sub-packages. We recommend that you start to learn Gammapy via the
+:ref:`tutorials`, and then consult the following pages for further information
+about each sub-package. Those pages also contain very detailed reference
+documentation for every function and class in Gammapy.
 
 .. toctree::
-  :maxdepth: 1
+    :maxdepth: 1
 
-  astro/index
-  background/index
-  catalog/index
-  cube/index
-  data/index
-  datasets/index
-  detect/index
-  image/index
-  irf/index
-  spectrum/index
-  stats/index
-  time/index
-  utils/index
-  maps/index
-  scripts/index
+    astro/index
+    background/index
+    catalog/index
+    cube/index
+    data/index
+    datasets/index
+    detect/index
+    image/index
+    irf/index
+    spectrum/index
+    stats/index
+    time/index
+    utils/index
+    maps/index
+    scripts/index
 
 .. _gammapy_dev:
 
@@ -64,14 +65,13 @@ Developer documentation
 -----------------------
 
 The Gammapy webpage contains information about the `Gammapy project and team`_
-as well as information about `Gammapy contact and communication channels`_.
-Most development takes place on the `Gammapy GitHub page`_.
+as well as information about `Gammapy contact and communication channels`_. Most
+development takes place on the `Gammapy GitHub page`_.
 
 .. toctree::
-  :maxdepth: 1
+    :maxdepth: 1
 
-  development/index
-
+    development/index
 
 .. _Gammapy project and team: http://gammapy.org/team.html
 .. _Gammapy contact and communication channels: http://gammapy.org/contact.html
@@ -79,7 +79,7 @@ Most development takes place on the `Gammapy GitHub page`_.
 References and Changelog
 ------------------------
 .. toctree::
-  :maxdepth: 1
+    :maxdepth: 1
 
-  references
-  changelog
+    references
+    changelog

--- a/docs/install/check.rst
+++ b/docs/install/check.rst
@@ -6,27 +6,26 @@ Check Gammapy installation
 How to run checks
 -----------------
 
-To check if Gammapy is correctly installed, start up python or ipython,
-import Gammapy and run the unit tests::
+To check if Gammapy is correctly installed, start up python or ipython, import
+Gammapy and run the unit tests::
 
-   $ python -c 'import gammapy; gammapy.test()'
+    $ python -c 'import gammapy; gammapy.test()'
 
 To check if the Gammapy command line tools are on your ``$PATH`` try this::
 
-   $ gammapy info --tools
+    $ gammapy info --tools
 
 To check which dependencies of Gammapy you have installed::
 
-   $ gammapy info --dependencies
+    $ gammapy info --dependencies
 
 .. _install-issues:
 
 Common issues
 -------------
 
-If you have an issue with Gammapy installation or usage, please check
-this list. If your issue is not adressed, please send an email to the
-mailing list.
+If you have an issue with Gammapy installation or usage, please check this list.
+If your issue is not adressed, please send an email to the mailing list.
 
 - Q: I get an error mentioning something (e.g. Astropy) isn't available,
   but I did install it.

--- a/docs/install/conda.rst
+++ b/docs/install/conda.rst
@@ -4,8 +4,8 @@ Installation with conda
 =======================
 
 To install the latest Gammapy **stable** version as well as the most common
-optional dependencies for Gammapy, first install `Anaconda <http://continuum.io/downloads>`__
-and then run these commands:
+optional dependencies for Gammapy, first install `Anaconda
+<http://continuum.io/downloads>`__ and then run these commands:
 
 .. code-block:: bash
 
@@ -14,8 +14,8 @@ and then run these commands:
         scipy matplotlib ipython-notebook \
         cython click
 
-We strongly recommend that you install the optional dependencies of Gammapy to have the full
-functionality available:
+We strongly recommend that you install the optional dependencies of Gammapy to
+have the full functionality available:
 
 .. code-block:: bash
 
@@ -28,5 +28,6 @@ To update to the latest version:
     conda update --all
     conda update gammapy
 
-Overall ``conda`` is a great cross-platform package manager, you can quickly learn how to use
-it by reading the docs `here <http://conda.pydata.org/docs/>`__.
+Overall ``conda`` is a great cross-platform package manager, you can quickly
+learn how to use it by reading the docs `here
+<http://conda.pydata.org/docs/>`__.

--- a/docs/install/dependencies.rst
+++ b/docs/install/dependencies.rst
@@ -5,19 +5,20 @@
 Dependencies
 ============
 
-.. note:: The philosophy of Gammapy is to build on the existing scientific Python stack.
-   This means that you need to install those dependencies to use Gammapy.
+The philosophy of Gammapy is to build on the existing scientific Python stack.
+This means that you need to install those dependencies to use Gammapy.
 
-   We are aware that too many dependencies is an issue for deployment and maintenance.
-   That's why currently Gammapy only has two core dependencies --- Numpy and Astropy.
-   We are considering making Sherpa, Scipy, scikit-image, photutils, reproject and naima
-   core dependencies.
+We are aware that too many dependencies is an issue for deployment and
+maintenance. That's why currently Gammapy only has two core dependencies ---
+Numpy and Astropy. We are considering making Sherpa, Scipy, scikit-image,
+photutils, reproject and naima core dependencies.
 
-   In addition there are about a dozen optional dependencies that are OK to import
-   from Gammapy because they are potentially useful (not all of those are
-   actually currently imported).
+In addition there are about a dozen optional dependencies that are OK to import
+from Gammapy because they are potentially useful (not all of those are actually
+currently imported).
 
-   Before the Gammapy 1.0 release we will re-evaluate and clarify the Gammapy dependencies.
+Before the Gammapy 1.0 release we will re-evaluate and clarify the Gammapy
+dependencies.
 
 The required core dependencies of Gammapy are:
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -6,15 +6,18 @@
 Installation
 ************
 
-* Gammapy works with legacy Python (version 2.7) as well as Python 3 (version 3.5 or above).
-* The core dependencies are Numpy and Astropy, as well as for now the regions package
-  (until it is merged into Astropy core).
-* The main optional dependencies are PyYAML, Scipy, healpy, uncertainties and Sherpa
-  (only imported when used).
+* Gammapy works with legacy Python (version 2.7) as well as Python 3 (version
+  3.5 or above).
+* The core dependencies are Numpy and Astropy, as well as for now the regions
+  package (until it is merged into Astropy core).
+* The main optional dependencies are PyYAML, Scipy, healpy, uncertainties and
+  Sherpa (only imported when used).
 * Linux and Mac OS are fully supported.
-* Windows is fully supported by Gammapy, but not by Sherpa (which is used as a backend for
-  modeling and fitting in Gammapy), so on Windows only part of the Gammapy functionality is available.
-* You can always check what the latest stable release of Gammapy is here: https://pypi.org/project/gammapy
+* Windows is fully supported by Gammapy, but not by Sherpa (which is used as a
+  backend for modeling and fitting in Gammapy), so on Windows only part of the
+  Gammapy functionality is available.
+* You can always check what the latest stable release of Gammapy is here:
+  https://pypi.org/project/gammapy
 
 Quick install guide
 ===================
@@ -34,8 +37,8 @@ or with Macports (a package manager for Mac OS)::
 
     sudo port install gammapy
 
-Gammapy is not yet available in the Linux distributions, i.e. at this time you can't
-install it with e.g. ``apt-get`` or ``yum``.
+Gammapy is not yet available in the Linux distributions, i.e. at this time you
+can't install it with e.g. ``apt-get`` or ``yum``.
 
 Development version
 -------------------
@@ -58,8 +61,8 @@ How to get set up for Gammapy development is described here: :ref:`dev_setup`
 Verify
 ------
 
-To verify that Gammapy is installed and available,
-and to check it's version and where it's located, type this::
+To verify that Gammapy is installed and available, and to check it's version and
+where it's located, type this::
 
     $ python
 
@@ -67,29 +70,30 @@ and to check it's version and where it's located, type this::
     >>> print(gammapy.__version__)
     >>> print(gammapy.__path__)
 
-
 Need help?
 ==========
 
-If you're not sure how to best install Gammapy on your machine (e.g. whether to use
-conda or pip or Macports ...), we recommend that you give conda a try first.
-It's a binary package manager (so generally installation is fast), and allows you to
-install any software in your home folder (without needing ``sudo``) and works the
-same on Linux, Mac OS and Windows. Many Gammapy users and developers use conda
-and are happy with it.
+If you're not sure how to best install Gammapy on your machine (e.g. whether to
+use conda or pip or Macports ...), we recommend that you give conda a try first.
+It's a binary package manager (so generally installation is fast), and allows
+you to install any software in your home folder (without needing ``sudo``) and
+works the same on Linux, Mac OS and Windows. Many Gammapy users and developers
+use conda and are happy with it.
 
-There is a nice blog post `Installing Python Packages from a Jupyter Notebook`_ that
-explains how to install Python packages in general with ``pip`` and ``conda``,
-specifically from inisde Jupyter notebooks, but also in general it's a good introduction
-how Python package installation with ``pip`` and ``conda`` work.
+There is a nice blog post `Installing Python Packages from a Jupyter Notebook`_
+that explains how to install Python packages in general with ``pip`` and
+``conda``, specifically from inisde Jupyter notebooks, but also in general it's
+a good introduction how Python package installation with ``pip`` and ``conda``
+work.
 
-If you have any questions or issues, don't hesitate to ask on the `Gammapy mailing list`_!
+If you have any questions or issues, don't hesitate to ask on the `Gammapy
+mailing list`_!
 
 Detailed information
 ====================
 
-Once you've made your choice how to install Gammapy, you can find detailed information
-on the following sub-pages:
+Once you've made your choice how to install Gammapy, you can find detailed
+information on the following sub-pages:
 
 .. toctree::
     :maxdepth: 1
@@ -101,6 +105,6 @@ on the following sub-pages:
     check
     dependencies
 
-
-If you'd like to make a code contribution to Gammapy, please see the developer documentation
-for information how to get set up (e.g. to code, run tests, generate docs locally).
+If you'd like to make a code contribution to Gammapy, please see the developer
+documentation for information how to get set up (e.g. to code, run tests,
+generate docs locally).

--- a/docs/install/macports.rst
+++ b/docs/install/macports.rst
@@ -14,16 +14,18 @@ To install Gammapy and it's core dependencies:
 
     sudo port install py36-gammapy
 
-The commands to update Gammapy and it's dependencies to the latest stable versions are:
+The commands to update Gammapy and it's dependencies to the latest stable
+versions are:
 
 .. code-block:: bash
 
     sudo port selfupdate
     sudo port upgrade outdated
 
-The rest of this section is a quick crash course about Macports, to explain the most common
-commands and how to set up and check things. There's not really anything Gammapy-specific
-here, but we thought it might be useful to summarise this information for Macports users here.
+The rest of this section is a quick crash course about Macports, to explain the
+most common commands and how to set up and check things. There's not really
+anything Gammapy-specific here, but we thought it might be useful to summarise
+this information for Macports users here.
 
 To check that Gammapy is installed, and which version you have:
 
@@ -32,31 +34,36 @@ To check that Gammapy is installed, and which version you have:
     port installed '*gammapy'
     /opt/local/bin/python3.5 -c 'import gammapy; print(gammapy.__version__)'
 
-Macports supports several versions of Python, so you can choose the one you want.
-Parallel installation of multiple Python versions works well, but is only really useful for developers.
-So if you want Python 2.7 or Python 3.6, you would have to adapt the commands given in this section
-to use that version number instead. If you're not sure which version to use, at this time (January 2017)
-we recommend you choose Python 3.5 (because Python 3 is the future, and 3.6 was just released and there
-are still a few minor issues being ironed out).
+Macports supports several versions of Python, so you can choose the one you
+want. Parallel installation of multiple Python versions works well, but is only
+really useful for developers. So if you want Python 2.7 or Python 3.6, you would
+have to adapt the commands given in this section to use that version number
+instead. If you're not sure which version to use, at this time (January 2017) we
+recommend you choose Python 3.5 (because Python 3 is the future, and 3.6 was
+just released and there are still a few minor issues being ironed out).
 
-Usually if you're using Macports, you will add this line to your ``~/.profile`` file:
+Usually if you're using Macports, you will add this line to your ``~/.profile``
+file:
 
 .. code-block:: bash
 
     export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
 
-This means that you can just execute Python via ``python3.5`` and will get the Macports Python
-(and not some other Python, like e.g. the system Python in ``/usr/bin`` or an Anaconda Python in ``$HOME``).
+This means that you can just execute Python via ``python3.5`` and will get the
+Macports Python (and not some other Python, like e.g. the system Python in
+``/usr/bin`` or an Anaconda Python in ``$HOME``).
 
-Macports also has a convenience command ``port select`` built in to select a given Python version:
+Macports also has a convenience command ``port select`` built in to select a
+given Python version:
 
 .. code-block:: bash
 
     sudo port select python python36
 
-This will create a symbolic link ``/opt/local/bin/python -> /opt/local/bin/python3.5`` and means that
-now if you execute ``python``, you will get the Macports Python 3.5.
-If you're not sure what your configuration is, you can use these commands to find out:
+This will create a symbolic link ``/opt/local/bin/python ->
+/opt/local/bin/python3.5`` and means that now if you execute ``python``, you
+will get the Macports Python 3.5. If you're not sure what your configuration is,
+you can use these commands to find out:
 
 .. code-block:: bash
 
@@ -65,10 +72,12 @@ If you're not sure what your configuration is, you can use these commands to fin
     ls -l `which python`
     python --version
 
-From here on out, we assume that you've done this setup and ``python`` is the correct Python you want to use.
+From here on out, we assume that you've done this setup and ``python`` is the
+correct Python you want to use.
 
-Many other software, including several optional dependencies of Gammapy, is available via Macports.
-Here's some examples for some scientific computing and astronomy packages:
+Many other software, including several optional dependencies of Gammapy, is
+available via Macports. Here's some examples for some scientific computing and
+astronomy packages:
 
 .. code-block:: bash
 
@@ -78,19 +87,22 @@ Here's some examples for some scientific computing and astronomy packages:
         py36-emcee py36-ipython py36-uncertainties \
         py36-healpy py36-cython
 
-To search which software is available in Macports (searches package name and description):
+To search which software is available in Macports (searches package name and
+description):
 
 .. code-block:: bash
 
     port search <name>
 
-There are about 100,000 Python packages on `PyPI`_. Many of those aren't re-packaged and available in Macports,
-and some are outdated (although usually Macports packages are updated within days or weeks of the release
-of new package versions).
+There are about 100,000 Python packages on `PyPI`_. Many of those aren't
+re-packaged and available in Macports, and some are outdated (although usually
+Macports packages are updated within days or weeks of the release of new package
+versions).
 
-Using the Macports Python as the basis, you can use the Macports pip to install more Python packages.
-The default should be to use Macports and to only pip install what's not available there,
-because then updates usually just work (see commands above), whereas with pip it's usually a more manual process.
+Using the Macports Python as the basis, you can use the Macports pip to install
+more Python packages. The default should be to use Macports and to only pip
+install what's not available there, because then updates usually just work (see
+commands above), whereas with pip it's usually a more manual process.
 
 .. code-block:: bash
 
@@ -98,28 +110,33 @@ because then updates usually just work (see commands above), whereas with pip it
         naima photutils reproject astroplan iminuit
 
 
-There's a few things worth pointing out about how we execute ``pip`` to install packages:
+There's a few things worth pointing out about how we execute ``pip`` to install
+packages:
 
 * Instead of using the command line tool ``pip``, we're executing via ``python -m pip``.
-  This is because users frequently accidentally execute the wrong pip (e.g. from system Python or Anaconda)
-  that happens to be on their ``$PATH`` and then either the install fails, or it succeeds but then
-  trying to import the package fails because it's in a ``site-packages`` folder that's unrelated
-  to the ``python`` they are using.
+  This is because users frequently accidentally execute the wrong pip (e.g. from
+  system Python or Anaconda) that happens to be on their ``$PATH`` and then
+  either the install fails, or it succeeds but then trying to import the package
+  fails because it's in a ``site-packages`` folder that's unrelated to the
+  ``python`` they are using.
 * The ``--no-deps`` option instructs ``pip`` to not recursively fetch and install all dependencies.
-  Of course, auto-installing all dependencies can be convenient, but it also often happens that
-  this leads to the installation of many packages (e.g. Numpy, Scipy, ....) and is not what you want.
-  So being explicit about which packages to install is the safer thing to do here.
+  Of course, auto-installing all dependencies can be convenient, but it also
+  often happens that this leads to the installation of many packages (e.g.
+  Numpy, Scipy, ....) and is not what you want. So being explicit about which
+  packages to install is the safer thing to do here.
 * We're not using ``sudo`` here and we are using the ``--user`` option. Using ``sudo python -m pip install``
   would result in the installation of packages in
   ``opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages``,
-  the ``site-packages`` folder where Macports installs packages.
-  This will usually work, but can then cause problems later on when you try to upgrade or add packages
-  via ``sudo port install``. Macports updates work so well because it is very well organised and e.g. keeps
-  manifests of all files installed (you can list them with ``port contents py36-gammapy``). So basically,
-  to not mess with this, you should never touch files in ``/opt/local`` except through ``port`` commands.
-  The ``--user`` option of ``pip`` means "install in my user site-packages folder", which at this time
-  on macOS is ``/Users/<username>/Library/Python/3.5/lib/python/site-packages`` and is by default on the
-  list of folders searched by Python to find packages to import.
+  the ``site-packages`` folder where Macports installs packages. This will
+  usually work, but can then cause problems later on when you try to upgrade or
+  add packages via ``sudo port install``. Macports updates work so well because
+  it is very well organised and e.g. keeps manifests of all files installed (you
+  can list them with ``port contents py36-gammapy``). So basically, to not mess
+  with this, you should never touch files in ``/opt/local`` except through
+  ``port`` commands. The ``--user`` option of ``pip`` means "install in my user
+  site-packages folder", which at this time on macOS is
+  ``/Users/<username>/Library/Python/3.5/lib/python/site-packages`` and is by
+  default on the list of folders searched by Python to find packages to import.
 
 To uninstall Python packages:
 

--- a/docs/install/other.rst
+++ b/docs/install/other.rst
@@ -5,27 +5,28 @@
 Other package managers
 ======================
 
-Besides conda, Gammapy and some of the optional dependencies (Sherpa, Astropy-affiliated packages)
-are not yet available in other package managers, such as e.g. `apt-get`_ or `yum`_ on Linux
-or `Macports`_ or `Homebrew`_ on Mac.
+Besides conda, Gammapy and some of the optional dependencies (Sherpa,
+Astropy-affiliated packages) are not yet available in other package managers,
+such as e.g. `apt-get`_ or `yum`_ on Linux or `Macports`_ or `Homebrew`_ on Mac.
 
-So installing Gammapy this way is not recommended at this time.
-(The recommended method is conda as mentioned above).
+So installing Gammapy this way is not recommended at this time. (The recommended
+method is conda as mentioned above).
 
-Still, it's possible and common on systems where users have root access
-to install some of the dependencies using those package managers, and then
-to use `pip`_ to do the rest of the installation.
+Still, it's possible and common on systems where users have root access to
+install some of the dependencies using those package managers, and then to use
+`pip`_ to do the rest of the installation.
 
-So as a convenience, here we show the commands to install those packages that are available,
-so that you don't have to look up the package names.
+So as a convenience, here we show the commands to install those packages that
+are available, so that you don't have to look up the package names.
 
-We do hope this situation will improve in the future as more astronomy packages become
-available in those distributions and versions are updated.
+We do hope this situation will improve in the future as more astronomy packages
+become available in those distributions and versions are updated.
 
 apt-get
 -------
 
-On Ubuntu or Debian Linux, you can use `apt-get`_ and `pip`_ to install Gammapy and it's dependencies.
+On Ubuntu or Debian Linux, you can use `apt-get`_ and `pip`_ to install Gammapy
+and it's dependencies.
 
 The following packages are available:
 
@@ -51,8 +52,8 @@ yum
 
 `yum`_ is a popular package manager on Linux, e.g. on Scientific linux or Red Hat Linux.
 
-If you are a ``yum`` user, please contribute the equivalent commands
-(see e.g. the Macports section below).
+If you are a ``yum`` user, please contribute the equivalent commands (see e.g.
+the Macports section below).
 
 Homebrew
 --------
@@ -60,9 +61,11 @@ Homebrew
 `Homebrew`_ is a popular package manager on Mac.
 
 Gammapy currently isn't packaged with Homebrew. It should be possible to install
-Python / pip / Numpy / Astropy with ``brew`` and then to install Gammapy with ``pip``.
+Python / pip / Numpy / Astropy with ``brew`` and then to install Gammapy with
+``pip``.
 
-If you're a ``brew`` user, please let us know if it works and what the exact commands are.
+If you're a ``brew`` user, please let us know if it works and what the exact
+commands are.
 
 Note that we have some Gammapy developers and users on Mac that use Macports.
 For this you can find detailed instructions here: :ref:`install-macports`
@@ -72,13 +75,13 @@ Fermi ScienceTools
 
 The `Fermi ScienceTools`_ ships with it's own Python 2.7 interpreter.
 
-If you want to use Astropy or Gammapy with that Python, you have to install it using
-that Python interpreter, other existing Python interpreters or installed packages
-can't be used (when they have C extensions, like Astropy does).
+If you want to use Astropy or Gammapy with that Python, you have to install it
+using that Python interpreter, other existing Python interpreters or installed
+packages can't be used (when they have C extensions, like Astropy does).
 
-Fermi ScienceTools version ``v10r0p5`` (released Jun 24, 2015) includes
-Python 2.7.8, Numpy 1.9.1, Scipy 0.14.0, matplotlib 1.1.1, PyFITS 3.1.2.
-Unfortunately pip, ipython or Astropy are not included.
+Fermi ScienceTools version ``v10r0p5`` (released Jun 24, 2015) includes Python
+2.7.8, Numpy 1.9.1, Scipy 0.14.0, matplotlib 1.1.1, PyFITS 3.1.2. Unfortunately
+pip, ipython or Astropy are not included.
 
 So first in stall `pip`_ (see `pip install instructions`_), and then
 
@@ -86,6 +89,6 @@ So first in stall `pip`_ (see `pip install instructions`_), and then
 
    $ python -m pip install ipython astropy gammapy
 
-If this doesn't work (which is not uncommon, this is known to fail to compile the C
-extensions of Astropy on some platforms), ask your Python-installation-savvy co-worker
-or on the Astropy or Gammapy mailing list.
+If this doesn't work (which is not uncommon, this is known to fail to compile
+the C extensions of Astropy on some platforms), ask your
+Python-installation-savvy co-worker or on the Astropy or Gammapy mailing list.

--- a/docs/install/pip.rst
+++ b/docs/install/pip.rst
@@ -10,7 +10,8 @@ Installation with pip or setup.py
 pip
 ---
 
-To install the latest Gammapy **stable** version (see `Gammapy page on PyPI`_) using `pip`_:
+To install the latest Gammapy **stable** version (see `Gammapy page on PyPI`_)
+using `pip`_:
 
 .. code-block:: bash
 
@@ -22,10 +23,10 @@ To install the current Gammapy **development** version using `pip`_:
 
    $ python -m pip install git+https://github.com/gammapy/gammapy.git#egg=gammapy
 
-If that doesn't work because the download from PyPI or Github is blocked by your network,
-but you have some other means of copying files onto that machine,
-you can get the tarball (``.tar.gz`` file) from PyPI or ``.zip`` file from Github, and then
-``python -m pip install <filename>``.
+If that doesn't work because the download from PyPI or Github is blocked by your
+network, but you have some other means of copying files onto that machine, you
+can get the tarball (``.tar.gz`` file) from PyPI or ``.zip`` file from Github,
+and then ``python -m pip install <filename>``.
 
 .. _install-setuppy:
 
@@ -54,7 +55,7 @@ Also you have easy access to the Python scripts from the tutorials and examples:
    $ cd docs/tutorials
    $ cd examples
 
-If you want to contribute to Gammapy, but are not familiar with Python or
-git or Astropy yet, please have a look at the
-`Astropy developer documentation <http://docs.astropy.org/en/latest/#developer-documentation>`__.
+If you want to contribute to Gammapy, but are not familiar with Python or git or
+Astropy yet, please have a look at the `Astropy developer documentation
+<http://docs.astropy.org/en/latest/#developer-documentation>`__.
 

--- a/docs/irf/index.rst
+++ b/docs/irf/index.rst
@@ -19,8 +19,8 @@ Most of the formats defined at :ref:`gadf:iact-irf` are supported.  Otherwise,
 at the moment, there is very little support for Fermi-LAT or other instruments.
 
 Most users will not use `gammapy.irf` directly, but will instead use IRFs as
-part of their spectrum, image or cube analysis to compute exposure and
-effective EDISP and PSF for a given dataset.
+part of their spectrum, image or cube analysis to compute exposure and effective
+EDISP and PSF for a given dataset.
 
 Most (at some point maybe all) classes in `gammapy.irf` have an
 `gammapy.utils.nddata.NDDataArray` as data attribute to support interpolation.
@@ -28,8 +28,8 @@ Most (at some point maybe all) classes in `gammapy.irf` have an
 Getting Started
 ===============
 
-see :gp-extra-notebook:`cta_1dc_introduction` for an example how to access IACT IRFs.
-
+See :gp-extra-notebook:`cta_1dc_introduction` for an example how to access IACT
+IRFs.
 
 Effective area
 ==============
@@ -57,8 +57,8 @@ Energy Dispersion
 The `~gammapy.irf.EnergyDispersion` class represents an energy migration matrix
 (finite probabilities per pixel) with ``y=log(energy_reco)``.
 
-The `~gammapy.irf.EnergyDispersion2D` class represents a probability
-density with ``y=energy_reco/energy_true`` that can also have a FOV offset dependence.
+The `~gammapy.irf.EnergyDispersion2D` class represents a probability density
+with ``y=energy_reco/energy_true`` that can also have a FOV offset dependence.
 
 .. plot:: irf/plot_edisp.py
 
@@ -66,14 +66,15 @@ density with ``y=energy_reco/energy_true`` that can also have a FOV offset depen
 Using `gammapy.irf`
 ===================
 
-If you'd like to learn more about using `gammapy.irf`, read the following sub-pages:
+If you'd like to learn more about using `gammapy.irf`, read the following
+sub-pages:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   theory
-   aeff
-   edisp
+    theory
+    aeff
+    edisp
 
 Reference/API
 =============

--- a/docs/irf/plot_edisp.py
+++ b/docs/irf/plot_edisp.py
@@ -1,7 +1,7 @@
 """Plot energy dispersion example."""
+import numpy as np
 import matplotlib.pyplot as plt
 import astropy.units as u
-import numpy as np
 from gammapy.irf import EnergyDispersion
 
 ebounds = np.logspace(-1, 2, 101) * u.TeV

--- a/docs/irf/theory.rst
+++ b/docs/irf/theory.rst
@@ -5,17 +5,18 @@ IRF Theory
 
 TODO: do a detailed writeup of how IRFs are implemented and used in Gammapy.
 
-For high-level gamma-ray data analysis (measuring morphology and spectra of sources)
-a canonical detector model is used, where the gamma-ray detection process is simplified
-as being fully characterized by the following three "instrument response functions":
+For high-level gamma-ray data analysis (measuring morphology and spectra of
+sources) a canonical detector model is used, where the gamma-ray detection
+process is simplified as being fully characterized by the following three
+"instrument response functions":
 
 * Effective area :math:`A(p, E)` (unit: :math:`m^2`)
 * Point spread function :math:`PSF(p'|p, E)` (unit: :math:`sr^{-1}`)
 * Energy dispersion :math:`D(E'|p, E)` (unit: :math:`TeV^{-1}`)
 
-The effective area represents the gamma-ray detection efficiency,
-the PSF the angular resolution and the energy dispersion the energy resolution
-of the instrument.
+The effective area represents the gamma-ray detection efficiency, the PSF the
+angular resolution and the energy dispersion the energy resolution of the
+instrument.
 
 The full instrument response is given by
 
@@ -23,8 +24,8 @@ The full instrument response is given by
 
    R(p', E'|p, E) = A(p, E) \times PSF(p'|p, E) \times D(E'|p, E),
 
-where :math:`p` and :math:`E` are the true gamma-ray position and energy
-and :math:`p'` and :math:`E'` are the reconstructed gamma-ray position and energy.
+where :math:`p` and :math:`E` are the true gamma-ray position and energy and
+:math:`p'` and :math:`E'` are the reconstructed gamma-ray position and energy.
 
 The instrument function relates sky flux models to expected observed counts distributions via
 
@@ -32,16 +33,19 @@ The instrument function relates sky flux models to expected observed counts dist
 
    N(p', E') = t_{obs} \int_E \int_\Omega R(p', E'|p, E) \times F(p, E) dp dE,
 
-where :math:`F`, :math:`R`, :math:`t_{obs}` and :math:`N` are the following quantities:
+where :math:`F`, :math:`R`, :math:`t_{obs}` and :math:`N` are the following
+quantities:
 
 * Sky flux model :math:`F(p, E)` (unit: :math:`m^{-2} s^{-1} TeV^{-1} sr^{-1}`)
 * Instrument response :math:`R(p', E'|p, E)` (unit: :math:`m^2 TeV^{-1} sr^{-1}`)
 * Observation time: :math:`t_{obs}` (unit: :math:`s`)
 * Expected observed counts model :math:`N(p', E')` (unit: :math:`sr^{-1} TeV^{-1}`)
 
-If you'd like to learn more about instrument response functions, have a look at the descriptions for
-`Fermi <https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_LAT_IRFs/index.html>`__,
-for `TeV data analysis <http://inspirehep.net/record/1122589>`__
-and for `GammaLib <http://gammalib.sourceforge.net/user_manual/modules/obs.html#handling-the-instrument-response>`__.
+If you'd like to learn more about instrument response functions, have a look at
+the descriptions for `Fermi
+<https://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_LAT_IRFs/index.html>`__,
+for `TeV data analysis <http://inspirehep.net/record/1122589>`__ and for
+`GammaLib
+<http://gammalib.sourceforge.net/user_manual/modules/obs.html#handling-the-instrument-response>`__.
 
 TODO: add an overview of what is / isn't available in Gammapy.

--- a/docs/maps/hpxmap.rst
+++ b/docs/maps/hpxmap.rst
@@ -3,21 +3,19 @@
 HEALPix-based Maps
 ==================
 
-This page provides examples and documentation specific to the HEALPix
-map classes (`~gammapy.maps.HpxNDMap` and
-`~gammapy.maps.HpxSparseMap`).  All HEALPix classes inherit from
-`~gammapy.maps.Map` which provides generic interface methods that can be be
-used to access or update the contents of a map without reference to
-its pixelization scheme.
+This page provides examples and documentation specific to the HEALPix map
+classes (`~gammapy.maps.HpxNDMap` and `~gammapy.maps.HpxSparseMap`).  All
+HEALPix classes inherit from `~gammapy.maps.Map` which provides generic
+interface methods that can be be used to access or update the contents of a map
+without reference to its pixelization scheme.
 
 HEALPix Geometry
 ----------------
 
-The `~gammapy.maps.HpxGeom` class encapsulates the geometry of a
-HEALPix map: the pixel size (NSIDE), coordinate system, and definition
-of non-spatial axes (e.g. energy).  By default a HEALPix geometry will
-encompass the full sky.  The following example shows how to create
-an all-sky 2D HEALPix image:
+The `~gammapy.maps.HpxGeom` class encapsulates the geometry of a HEALPix map:
+the pixel size (NSIDE), coordinate system, and definition of non-spatial axes
+(e.g. energy).  By default a HEALPix geometry will encompass the full sky.  The
+following example shows how to create an all-sky 2D HEALPix image:
 
 .. code:: python
 
@@ -29,9 +27,9 @@ an all-sky 2D HEALPix image:
     # Equivalent factory method call
     m = HpxMap.create(nside=16, coordsys='GAL')
 
-Partial-sky maps can be created by passing a ``region`` argument to
-the map geometry constructor or by setting the ``width`` argument to
-the `~gammapy.maps.HpxMap.create` factory method:
+Partial-sky maps can be created by passing a ``region`` argument to the map
+geometry constructor or by setting the ``width`` argument to the
+`~gammapy.maps.HpxMap.create` factory method:
 
 .. code:: python
 
@@ -46,11 +44,10 @@ the `~gammapy.maps.HpxMap.create` factory method:
     position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
     m = HpxMap.create(nside=16, skydir=position, width=20.0)
 
-
 Sparse Maps
 -----------
 
-The `~gammapy.maps.HpxSparseMap` class is a memory-efficient
-implementation of a HEALPix map that uses a sparse data structure to
-store map values.  Sparse maps can be useful when working with maps
-that have many empty pixels (e.g. a low-statistics counts map).
+The `~gammapy.maps.HpxSparseMap` class is a memory-efficient implementation of a
+HEALPix map that uses a sparse data structure to store map values.  Sparse maps
+can be useful when working with maps that have many empty pixels (e.g. a
+low-statistics counts map).

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -11,378 +11,358 @@ Structures for images / cubes (``maps``)
 Introduction
 ============
 
-`gammapy.maps` contains classes for representing pixelized data
-structures with at least two spatial dimensions representing
-coordinates on a sphere (e.g. an image in celestial coordinates).  These classes
-support an arbitrary number of non-spatial dimensions and can
-represent images (2D), cubes (3D), or hypercubes (4+D).  Two
-pixelization schemes are supported:
+`gammapy.maps` contains classes for representing pixelized data structures with
+at least two spatial dimensions representing coordinates on a sphere (e.g. an
+image in celestial coordinates).  These classes support an arbitrary number of
+non-spatial dimensions and can represent images (2D), cubes (3D), or hypercubes
+(4+D).  Two pixelization schemes are supported:
 
 * WCS : Projection onto a 2D cartesian grid following the conventions
-  of the World Coordinate System (WCS).  Pixels are square in
-  projected coordinates and as such are not equal area in spherical
-  coordinates.
+  of the World Coordinate System (WCS).  Pixels are square in projected
+  coordinates and as such are not equal area in spherical coordinates.
 * HEALPix : Hierarchical Equal Area Iso Latitude pixelation of the
-  sphere.  Pixels are equal area but have irregular shapes.
+  sphere. Pixels are equal area but have irregular shapes.
 
-`gammapy.maps` is organized around two data structures:
-*geometry* classes inheriting from `~MapGeom` and *map* classes
-inheriting from `~Map`.  A geometry defines the map
-boundaries, pixelization scheme, and provides methods for converting
-to/from map and pixel coordinates.  A map owns a `~MapGeom`
-instance as well as a data array containing map values.  Where
-possible it is recommended to use the abstract `~Map` interface
-for accessing or updating the contents of a map as this allows
-algorithms to be used interchangeably with different map
-representations.  The following reviews methods of the abstract
-map interface.  Documentation specific to WCS- and HEALPix-based maps is
-provided in :doc:`hpxmap` and :doc:`wcsmap`.
+`gammapy.maps` is organized around two data structures: *geometry* classes
+inheriting from `~MapGeom` and *map* classes inheriting from `~Map`. A geometry
+defines the map boundaries, pixelization scheme, and provides methods for
+converting to/from map and pixel coordinates. A map owns a `~MapGeom` instance
+as well as a data array containing map values. Where possible it is recommended
+to use the abstract `~Map` interface for accessing or updating the contents of a
+map as this allows algorithms to be used interchangeably with different map
+representations. The following reviews methods of the abstract map interface.
+Documentation specific to WCS- and HEALPix-based maps is provided in
+:doc:`hpxmap` and :doc:`wcsmap`.
 
 
 Getting Started
 ===============
 
-All map objects have an abstract inteface provided through the methods
-of the `~Map`.  These methods can be used for accessing and
-manipulating the contents of a map without reference to the underlying
-data representation (e.g. whether a map uses WCS or HEALPix
-pixelization).  For applications which do depend on the specific
-representation one can also work directly with the classes derived
-from `~Map`.  In the following we review some of the basic methods
-for working with map objects.
+All map objects have an abstract inteface provided through the methods of the
+`~Map`. These methods can be used for accessing and manipulating the contents of
+a map without reference to the underlying data representation (e.g. whether a
+map uses WCS or HEALPix pixelization). For applications which do depend on the
+specific representation one can also work directly with the classes derived from
+`~Map`. In the following we review some of the basic methods for working with
+map objects.
 
 Constructing with Factory Methods
 ---------------------------------
 
-The `~Map` class provides a `~Map.create` factory method to
-facilitate creating an empty map object from scratch.  The
-``map_type`` argument can be used to control the pixelization scheme
-(WCS or HPX) and whether the map internally uses a sparse
-representation of the data.
+The `~Map` class provides a `~Map.create` factory method to facilitate creating
+an empty map object from scratch. The ``map_type`` argument can be used to
+control the pixelization scheme (WCS or HPX) and whether the map internally uses
+a sparse representation of the data.
 
 .. code:: python
 
-   from gammapy.maps import Map
-   from astropy.coordinates import SkyCoord
+    from gammapy.maps import Map
+    from astropy.coordinates import SkyCoord
 
-   position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
+    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
 
-   # Create a WCS Map
-   m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0)
+    # Create a WCS Map
+    m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0)
 
-   # Create a HPX Map
-   m_hpx = Map.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0)
+    # Create a HPX Map
+    m_hpx = Map.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0)
 
-Higher dimensional map objects (cubes and hypercubes) can be
-constructed by passing a list of `~MapAxis` objects for non-spatial
-dimensions with the ``axes`` parameter:
-
-.. code:: python
-
-   from gammapy.maps import Map, MapAxis
-   from astropy.coordinates import SkyCoord
-
-   position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
-   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
-
-   # Create a WCS Map
-   m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0,
-                          axes=[energy_axis])
-
-   # Create a HPX Map
-   m_hpx = Map.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0,
-                          axes=[energy_axis])
-
-Multi-resolution maps (maps with a different pixel size or geometry in
-each image plane) can be constructed by passing a vector argument for
-any of the geometry parameters.  This vector must have the same shape as the
-non-spatial dimensions of the map.  The following example demonstrates
-creating an energy cube with a pixel size proportional to the
-Fermi-LAT PSF:
+Higher dimensional map objects (cubes and hypercubes) can be constructed by
+passing a list of `~MapAxis` objects for non-spatial dimensions with the
+``axes`` parameter:
 
 .. code:: python
 
-   import numpy as np
-   from gammapy.maps import Map, MapAxis
-   from astropy.coordinates import SkyCoord
+    from gammapy.maps import Map, MapAxis
+    from astropy.coordinates import SkyCoord
 
-   position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
-   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
 
-   binsz = np.sqrt((3.0*(energy_axis.center/100.)**-0.8)**2 + 0.1**2)
-
-   # Create a WCS Map
-   m_wcs = Map.create(binsz=binsz, map_type='wcs', skydir=position, width=10.0,
+    # Create a WCS Map
+    m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0,
                           axes=[energy_axis])
 
-   # Create a HPX Map
-   m_hpx = Map.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
+    # Create a HPX Map
+    m_hpx = Map.create(binsz=0.1, map_type='hpx', skydir=position, width=10.0,
                           axes=[energy_axis])
 
+Multi-resolution maps (maps with a different pixel size or geometry in each
+image plane) can be constructed by passing a vector argument for any of the
+geometry parameters. This vector must have the same shape as the non-spatial
+dimensions of the map. The following example demonstrates creating an energy
+cube with a pixel size proportional to the Fermi-LAT PSF:
+
+.. code:: python
+
+    import numpy as np
+    from gammapy.maps import Map, MapAxis
+    from astropy.coordinates import SkyCoord
+
+    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+
+    binsz = np.sqrt((3.0*(energy_axis.center/100.)**-0.8)**2 + 0.1**2)
+
+    # Create a WCS Map
+    m_wcs = Map.create(binsz=binsz, map_type='wcs', skydir=position, width=10.0,
+                          axes=[energy_axis])
+
+    # Create a HPX Map
+    m_hpx = Map.create(binsz=binsz, map_type='hpx', skydir=position, width=10.0,
+                          axes=[energy_axis])
 
 .. _mapslicing:
 
 Indexing and Slicing
 --------------------
 
-All map objects feature a `~Map.slice_by_idx()` method, which can be used to slice
-and index non-spatial axes of the map to create arbitrary sub-maps. The method
-accepts a `dict` specifying the axes name and correspoding integer index or `slice`
-objects. When indexing an axis with an integer the corresponding axes is dropped
-from the returned sub-map. To keep the axes (with length 1) in the returned sub-map
-use a `slice` object of length one. This behaviour is equivalent to regular numpy
-array indexing. The following example demonstrates the use of `~Map.slice_by_idx()`
-on a map with a time and energy axes:
+All map objects feature a `~Map.slice_by_idx()` method, which can be used to
+slice and index non-spatial axes of the map to create arbitrary sub-maps. The
+method accepts a `dict` specifying the axes name and correspoding integer index
+or `slice` objects. When indexing an axis with an integer the corresponding axes
+is dropped from the returned sub-map. To keep the axes (with length 1) in the
+returned sub-map use a `slice` object of length one. This behaviour is
+equivalent to regular numpy array indexing. The following example demonstrates
+the use of `~Map.slice_by_idx()` on a map with a time and energy axes:
 
 .. code:: python
 
-   import numpy as np
-   from gammapy.maps import Map, MapAxis
-   from astropy.coordinates import SkyCoord
+    import numpy as np
+    from gammapy.maps import Map, MapAxis
+    from astropy.coordinates import SkyCoord
 
-   position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
-   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', unit='GeV')
-   time_axis = MapAxis.from_bounds(0., 12, 12, interp='lin', unit='h')
+    position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', unit='GeV')
+    time_axis = MapAxis.from_bounds(0., 12, 12, interp='lin', unit='h')
 
-   # Create a WCS Map
-   m_wcs = Map.create(binsz=0.02, map_type='wcs', skydir=position, width=10.0,
+    # Create a WCS Map
+    m_wcs = Map.create(binsz=0.02, map_type='wcs', skydir=position, width=10.0,
                           axes=[energy_axis, time_axis])
 
-   # index first image plane of the energy axes and third from the time axis
-   m_wcs.slice_by_idx({'energy': 0, 'time': 2})
+    # index first image plane of the energy axes and third from the time axis
+    m_wcs.slice_by_idx({'energy': 0, 'time': 2})
 
-   # index first image plane of the energy axes and keep time axis unchanged
-   m_wcs.slice_by_idx({'energy': 0})
+    # index first image plane of the energy axes and keep time axis unchanged
+    m_wcs.slice_by_idx({'energy': 0})
 
-   # slice first three images of the energy axis at a fixed time
-   m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': 0})
+    # slice first three images of the energy axis at a fixed time
+    m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': 0})
 
-   # slice first three images of the energy axis as well as time axis
-   m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': slice(0, 3)})
+    # slice first three images of the energy axis as well as time axis
+    m_wcs.slice_by_idx({'energy': slice(0, 3), 'time': slice(0, 3)})
 
 Accessor Methods
 ----------------
 
-All map objects have a set of accessor methods provided through the
-abstract `~Map` class.  These methods can be used to access or
-update the contents of the map irrespective of its underlying
-representation.  Four types of accessor methods are provided:
+All map objects have a set of accessor methods provided through the abstract
+`~Map` class. These methods can be used to access or update the contents of the
+map irrespective of its underlying representation. Four types of accessor
+methods are provided:
 
 * ``get`` : Return the value of the map at the pixel containing the
-  given coordinate (`~Map.get_by_idx`, `~Map.get_by_pix`,
-  `~Map.get_by_coord`).
+  given coordinate (`~Map.get_by_idx`, `~Map.get_by_pix`, `~Map.get_by_coord`).
 * ``interp`` : Interpolate or extrapolate the value of the map at an arbitrary
   coordinate (see also `Interpolation`_).
 * ``set`` : Set the value of the map at the pixel containing the
-  given coordinate (`~Map.set_by_idx`, `~Map.set_by_pix`,
-  `~Map.set_by_coord`).
+  given coordinate (`~Map.set_by_idx`, `~Map.set_by_pix`, `~Map.set_by_coord`).
 * ``fill`` : Increment the value of the map at the pixel containing
   the given coordinate with a unit weight or the value in the optional
-  ``weights`` argument (`~Map.fill_by_idx`,
-  `~Map.fill_by_pix`, `~Map.fill_by_coord`).
+  ``weights`` argument (`~Map.fill_by_idx`, `~Map.fill_by_pix`,
+  `~Map.fill_by_coord`).
 
-Accessor methods accept as their first argument a coordinate tuple
-containing scalars, lists, or numpy arrays with one tuple element for
-each dimension of the map.  ``coord`` methods optionally support a
-`dict` or `~MapCoord` argument.
+Accessor methods accept as their first argument a coordinate tuple containing
+scalars, lists, or numpy arrays with one tuple element for each dimension of the
+map. ``coord`` methods optionally support a `dict` or `~MapCoord` argument.
 
-When using tuple input the first two elements in the tuple
-should be longitude and latitude followed by one element for each
-non-spatial dimension.  Map coordinates can be expressed in one of
+When using tuple input the first two elements in the tuple should be longitude
+and latitude followed by one element for each non-spatial dimension. Map
+coordinates can be expressed in one of three coordinate systems:
+
+* ``idx`` : Pixel indices.  These are explicit (integer) pixel indices into the
+  map.
+* ``pix`` : Coordinates in pixel space.  Pixel coordinates are continuous defined
+  on the interval [0,N-1] where N is the number of pixels along a given map
+  dimension with pixel centers at integer values.  For methods that reference a
+  discrete pixel, pixel coordinates wil be rounded to the nearest pixel index
+  and passed to the corresponding ``idx`` method.
+* ``coord`` : The true map coordinates including angles on the sky (longitude
+  and latitude).  This coordinate system supports three coordinate
+  representations: `tuple`, `dict`, and `~MapCoord`.  The tuple representation
+  should contain longitude and latitude in degrees followed by one coordinate
+  array for each non-spatial dimension.
+
+The coordinate system accepted by a given accessor method can be inferred from
+the suffix of the method name (e.g. `~Map.get_by_idx`).  The following
+demonstrates how one can access the same pixels of a WCS map using each of the
 three coordinate systems:
 
-* ``idx`` : Pixel indices.  These are explicit (integer) pixel indices into the map.
-* ``pix`` : Coordinates in pixel space.  Pixel coordinates are continuous defined
-  on the interval [0,N-1] where N is the number of pixels along a
-  given map dimension with pixel centers at integer values.  For
-  methods that reference a discrete pixel, pixel coordinates wil be
-  rounded to the nearest pixel index and passed to the corresponding
-  ``idx`` method.
-* ``coord`` : The true map coordinates including angles on the sky
-  (longitude and latitude).  This coordinate system supports three
-  coordinate representations: `tuple`, `dict`, and `~MapCoord`.  The
-  tuple representation should contain longitude and latitude in
-  degrees followed by one coordinate array for each non-spatial
-  dimension.
+.. code:: python
 
-The coordinate system accepted by a given accessor method can be
-inferred from the suffix of the method name
-(e.g. `~Map.get_by_idx`).  The following demonstrates how one can
-access the same pixels of a WCS map using each of the three coordinate
-systems:
+    from gammapy.maps import Map
+
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+
+    vals = m.get_by_idx( ([49,50],[49,50]) )
+    vals = m.get_by_pix( ([49.0,50.0],[49.0,50.0]) )
+    vals = m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]) )
+
+Coordinate arguments obey normal numpy broadcasting rules.  The coordinate tuple
+may contain any combination of scalars, lists or numpy arrays as long as they
+have compatible shapes.  For instance a combination of scalar and vector
+arguments can be used to perform an operation along a slice of the map at a
+fixed value along that dimension. Multi-dimensional arguments can be use to
+broadcast a given operation across a grid of coordinate values.
 
 .. code:: python
 
-   from gammapy.maps import Map
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    coords = np.linspace(-4.0, 4.0, 9)
 
-   vals = m.get_by_idx( ([49,50],[49,50]) )
-   vals = m.get_by_pix( ([49.0,50.0],[49.0,50.0]) )
-   vals = m.get_by_coord( ([-0.05,-0.05],[0.05,0.05]) )
+    # Equivalent calls for accessing value at pixel (49,49)
+    vals = m.get_by_idx( (49,49) )
+    vals = m.get_by_idx( ([49],[49]) )
+    vals = m.get_by_idx( (np.array([49]), np.array([49])) )
 
-Coordinate arguments obey normal numpy broadcasting rules.  The
-coordinate tuple may contain any combination of scalars, lists or
-numpy arrays as long as they have compatible shapes.  For instance a
-combination of scalar and vector arguments can be used to perform an
-operation along a slice of the map at a fixed value along that
-dimension.  Multi-dimensional arguments can be use to broadcast a
-given operation across a grid of coordinate values.
+    # Retrieve map values along latitude at fixed longitude=0.0
+    vals = m.get_by_coord( (0.0, coords) )
+    # Retrieve map values on a 2D grid of latitude/longitude points
+    vals = m.get_by_coord( (coords[None,:], coords[:,None]) )
+    # Set map values along slice at longitude=0.0 to twice their existing value
+    m.set_by_coord((0.0, coords), 2.0*m.get_by_coord((0.0, coords)))
 
-.. code:: python
-
-   from gammapy.maps import Map
-
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   coords = np.linspace(-4.0, 4.0, 9)
-
-   # Equivalent calls for accessing value at pixel (49,49)
-   vals = m.get_by_idx( (49,49) )
-   vals = m.get_by_idx( ([49],[49]) )
-   vals = m.get_by_idx( (np.array([49]), np.array([49])) )
-
-   # Retrieve map values along latitude at fixed longitude=0.0
-   vals = m.get_by_coord( (0.0, coords) )
-   # Retrieve map values on a 2D grid of latitude/longitude points
-   vals = m.get_by_coord( (coords[None,:], coords[:,None]) )
-   # Set map values along slice at longitude=0.0 to twice their existing value
-   m.set_by_coord((0.0, coords), 2.0*m.get_by_coord((0.0, coords)))
-
-The ``set`` and ``fill`` methods can both be used to set pixel values.
-The following demonstrates how one can set pixel values:
+The ``set`` and ``fill`` methods can both be used to set pixel values. The
+following demonstrates how one can set pixel values:
 
 .. code:: python
 
-   from gammapy.maps import Map
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-   m.set_by_coord( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
-   m.fill_by_coord( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
+    m.set_by_coord( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
+    m.fill_by_coord( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
 
 Interface with `~MapCoord` and `~astropy.coordinates.SkyCoord`
 --------------------------------------------------------------
 
 The ``coord`` accessor methods accept `dict`, `~MapCoord`, and
-`~astropy.coordinates.SkyCoord` arguments in addition to the standard
-`tuple` of `~numpy.ndarray` argument.  When using a `tuple` argument a
-`~astropy.coordinates.SkyCoord` can be used instead of longitude and
-latitude arrays.  The coordinate frame of the
-`~astropy.coordinates.SkyCoord` will be transformed to match the
-coordinate system of the map.
+`~astropy.coordinates.SkyCoord` arguments in addition to the standard `tuple` of
+`~numpy.ndarray` argument.  When using a `tuple` argument a
+`~astropy.coordinates.SkyCoord` can be used instead of longitude and latitude
+arrays.  The coordinate frame of the `~astropy.coordinates.SkyCoord` will be
+transformed to match the coordinate system of the map.
 
 .. code:: python
 
-   import numpy as np
-   from astropy.coordinates import SkyCoord
-   from gammapy.maps import Map, MapCoord, MapAxis
+    import numpy as np
+    from astropy.coordinates import SkyCoord
+    from gammapy.maps import Map, MapCoord, MapAxis
 
-   lon = [0, 1]
-   lat = [1, 2]
-   energy = [100, 1000]
-   energy_axis = MapAxis.from_bounds(100, 1E5, 12, interp='log', name='energy')
+    lon = [0, 1]
+    lat = [1, 2]
+    energy = [100, 1000]
+    energy_axis = MapAxis.from_bounds(100, 1E5, 12, interp='log', name='energy')
 
-   skycoord = SkyCoord(lon, lat, unit='deg', frame='galactic')
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
+    skycoord = SkyCoord(lon, lat, unit='deg', frame='galactic')
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
                   coordsys='GAL', axes=[energy_axis])
 
-   m.set_by_coord( (skycoord, energy), [0.5, 1.5] )
-   m.get_by_coord( (skycoord, energy) )
+    m.set_by_coord( (skycoord, energy), [0.5, 1.5] )
+    m.get_by_coord( (skycoord, energy) )
 
-A `~MapCoord` or `dict` argument can be used to interact with a map
-object without reference to the axis ordering of the map geometry:
+A `~MapCoord` or `dict` argument can be used to interact with a map object
+without reference to the axis ordering of the map geometry:
 
 .. code:: python
 
-   coord = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
-   m.set_by_coord( coord, [0.5, 1.5] )
-   m.get_by_coord( coord, )
-   m.set_by_coord( dict(lon=lon, lat=lat, energy=energy), [0.5, 1.5] )
-   m.get_by_coord( dict(lon=lon, lat=lat, energy=energy) )
+    coord = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
+    m.set_by_coord( coord, [0.5, 1.5] )
+    m.get_by_coord( coord, )
+    m.set_by_coord( dict(lon=lon, lat=lat, energy=energy), [0.5, 1.5] )
+    m.get_by_coord( dict(lon=lon, lat=lat, energy=energy) )
 
-
-However when using the named axis interface the axis name string
-(e.g. as given by `MapAxis.name`) must match the name given in the
-method argument.  The two spatial axes must always be named ``lon``
-and ``lat``.
+However when using the named axis interface the axis name string (e.g. as given
+by `MapAxis.name`) must match the name given in the method argument.  The two
+spatial axes must always be named ``lon`` and ``lat``.
 
 .. _mapcoord:
 
 MapCoord
 --------
 
-`MapCoord` is an N-dimensional coordinate object that stores both
-spatial and non-spatial coordinates and is accepted by all ``coord``
-methods.  A `~MapCoord` can be created with or without explicitly
-named axes with `MapCoord.create`.  Axes of a `MapCoord` can be
-accessed by index, name, or attribute.  A `MapCoord` without explicit
-axis names can be created by calling `MapCoord.create` with a `tuple`
-argument:
+`MapCoord` is an N-dimensional coordinate object that stores both spatial and
+non-spatial coordinates and is accepted by all ``coord`` methods. A `~MapCoord`
+can be created with or without explicitly named axes with `MapCoord.create`.
+Axes of a `MapCoord` can be accessed by index, name, or attribute.  A `MapCoord`
+without explicit axis names can be created by calling `MapCoord.create` with a
+`tuple` argument:
 
 .. code:: python
 
-   import numpy as np
-   from astropy.coordinates import SkyCoord
-   from gammapy.maps import MapCoord
+    import numpy as np
+    from astropy.coordinates import SkyCoord
+    from gammapy.maps import MapCoord
 
-   lon = [0.0, 1.0]
-   lat = [1.0, 2.0]
-   energy = [100, 1000]
-   skycoord = SkyCoord(lon, lat, unit='deg', frame='galactic')
+    lon = [0.0, 1.0]
+    lat = [1.0, 2.0]
+    energy = [100, 1000]
+    skycoord = SkyCoord(lon, lat, unit='deg', frame='galactic')
 
-   # Create a MapCoord from a tuple (no explicit axis names)
-   c = MapCoord.create((lon, lat, energy))
-   print(c[0], c['lon'], c.lon)
-   print(c[1], c['lat'], c.lat)
-   print(c[2], c['axis0'])
+    # Create a MapCoord from a tuple (no explicit axis names)
+    c = MapCoord.create((lon, lat, energy))
+    print(c[0], c['lon'], c.lon)
+    print(c[1], c['lat'], c.lat)
+    print(c[2], c['axis0'])
 
-   # Create a MapCoord from a tuple + SkyCoord (no explicit axis names)
-   c = MapCoord.create((skycoord, energy))
-   print(c[0], c['lon'], c.lon)
-   print(c[1], c['lat'], c.lat)
-   print(c[2], c['axis0'])
+    # Create a MapCoord from a tuple + SkyCoord (no explicit axis names)
+    c = MapCoord.create((skycoord, energy))
+    print(c[0], c['lon'], c.lon)
+    print(c[1], c['lat'], c.lat)
+    print(c[2], c['axis0'])
 
-The first two elements of the tuple argument must contain longitude
-and latitude.  Non-spatial axes are assigned a default name
-``axis{I}`` where ``{I}`` is the index of the non-spatial dimension.
-`MapCoord` objects created without named axes must have the same axis
-ordering as the map geometry.
+The first two elements of the tuple argument must contain longitude and
+latitude.  Non-spatial axes are assigned a default name ``axis{I}`` where
+``{I}`` is the index of the non-spatial dimension. `MapCoord` objects created
+without named axes must have the same axis ordering as the map geometry.
 
-A `MapCoord` with named axes can be created by calling
-`MapCoord.create` with a `dict` or `~collections.OrderedDict`:
+A `MapCoord` with named axes can be created by calling `MapCoord.create` with a
+`dict` or `~collections.OrderedDict`:
 
 .. code:: python
 
-   # Create a MapCoord from a dict
-   c = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
-   print(c[0], c['lon'], c.lon)
-   print(c[1], c['lat'], c.lat)
-   print(c[2], c['energy'])
+    # Create a MapCoord from a dict
+    c = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
+    print(c[0], c['lon'], c.lon)
+    print(c[1], c['lat'], c.lat)
+    print(c[2], c['energy'])
 
-   # Create a MapCoord from an OrderedDict
-   from collections import OrderedDict
-   c = MapCoord.create(OrderedDict([('energy',energy), ('lon',lon), ('lat', lat)]))
-   print(c[0], c['energy'])
-   print(c[1], c['lon'], c.lon)
-   print(c[2], c['lat'], c.lat)
+    # Create a MapCoord from an OrderedDict
+    from collections import OrderedDict
+    c = MapCoord.create(OrderedDict([('energy',energy), ('lon',lon), ('lat', lat)]))
+    print(c[0], c['energy'])
+    print(c[1], c['lon'], c.lon)
+    print(c[2], c['lat'], c.lat)
 
-   # Create a MapCoord from a dict + SkyCoord
-   c = MapCoord.create(dict(skycoord=skycoord, energy=energy))
-   print(c[0], c['lon'], c.lon)
-   print(c[1], c['lat'], c.lat)
-   print(c[2], c['energy'])
+    # Create a MapCoord from a dict + SkyCoord
+    c = MapCoord.create(dict(skycoord=skycoord, energy=energy))
+    print(c[0], c['lon'], c.lon)
+    print(c[1], c['lat'], c.lat)
+    print(c[2], c['energy'])
 
-Spatial axes must be named ``lon`` and ``lat``.  `MapCoord` objects
-created with named axes do not need to have the same axis ordering as
-the map geometry.  However the name of the axis must match the name of
-the corresponding map geometry axis.
+Spatial axes must be named ``lon`` and ``lat``. `MapCoord` objects created with
+named axes do not need to have the same axis ordering as the map geometry.
+However the name of the axis must match the name of the corresponding map
+geometry axis.
 
 Interpolation
 -------------
 
 Maps support interpolation via the `~Map.interp_by_coord` and
-`~Map.interp_by_pix` methods.  Currently the following interpolation
-methods are supported:
+`~Map.interp_by_pix` methods.  Currently the following interpolation methods are
+supported:
 
 * ``nearest`` : Return value of nearest pixel (no interpolation).
 * ``linear`` : Interpolation with first order polynomial.  This is the
@@ -390,157 +370,151 @@ methods are supported:
 * ``quadratic`` : Interpolation with second order polynomial.
 * ``cubic`` : Interpolation with third order polynomial.
 
-Note that ``quadratic`` and ``cubic`` interpolation are currently only
-supported for WCS-based maps with regular geometry (e.g. 2D or ND with
-the same geometry in every image plane).  ``linear`` and higher order
-interpolation by pixel coordinates is only supported for WCS-based
-maps.
+Note that ``quadratic`` and ``cubic`` interpolation are currently only supported
+for WCS-based maps with regular geometry (e.g. 2D or ND with the same geometry
+in every image plane). ``linear`` and higher order interpolation by pixel
+coordinates is only supported for WCS-based maps.
 
 .. code:: python
 
-   from gammapy.maps import Map
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-   m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
-   m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
+    m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
+    m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
 
 Projection
 ----------
 
-The `~Map.reproject` method can be used to project a map onto a
-different geometry.  This can be used to convert between different WCS
-projections, extract a cut-out of a map, or to convert between WCS and
-HPX map types.  If the projection geometry lacks non-spatial
-dimensions then the non-spatial dimensions of the original map will be copied
-over to the projected map.
+The `~Map.reproject` method can be used to project a map onto a different
+geometry.  This can be used to convert between different WCS projections,
+extract a cut-out of a map, or to convert between WCS and HPX map types.  If the
+projection geometry lacks non-spatial dimensions then the non-spatial dimensions
+of the original map will be copied over to the projected map.
 
 .. code:: python
 
-   from gammapy.maps import WcsNDMap, HpxGeom
+    from gammapy.maps import WcsNDMap, HpxGeom
 
-   m = WcsNDMap.read('gll_iem_v06.fits')
-   geom = HpxGeom.create(nside=8, coordsys='GAL')
-   # Convert LAT standard IEM to HPX (nside=8)
-   m_proj = m.project(geom)
-   m_proj.write('gll_iem_v06_hpx_nside8.fits')
+    m = WcsNDMap.read('gll_iem_v06.fits')
+    geom = HpxGeom.create(nside=8, coordsys='GAL')
+    # Convert LAT standard IEM to HPX (nside=8)
+    m_proj = m.project(geom)
+    m_proj.write('gll_iem_v06_hpx_nside8.fits')
 
 Iterating on a Map
 ------------------
 
-Iterating over a map can be performed with the
-`~Map.iter_by_coord` and `~Map.iter_by_pix` methods.  These
-return an iterator that traverses the map returning (value,
-coordinate) pairs with map and pixel coordinates, respectively.  The
-optional ``buffersize`` argument can be used to split the iteration
-into chunks of a given size.  The following example illustrates how
+Iterating over a map can be performed with the `~Map.iter_by_coord` and
+`~Map.iter_by_pix` methods.  These return an iterator that traverses the map
+returning (value, coordinate) pairs with map and pixel coordinates,
+respectively.  The optional ``buffersize`` argument can be used to split the
+iteration into chunks of a given size.  The following example illustrates how
 one can use this method to fill a map with a 2D Gaussian:
 
 .. code:: python
 
-   import numpy as np
-   from astropy.coordinates import SkyCoord
-   from gammapy.maps import Map
+    import numpy as np
+    from astropy.coordinates import SkyCoord
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
-   for val, coord in m.iter_by_coord(buffersize=10000):
-       skydir = SkyCoord(coord[0],coord[1], unit='deg')
-       sep = skydir.separation(m.geom.center_skydir).deg
-       new_val = np.exp(-sep**2/2.0)
-       m.set_by_coord(coord, new_val)
+    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
+    for val, coord in m.iter_by_coord(buffersize=10000):
+        skydir = SkyCoord(coord[0],coord[1], unit='deg')
+        sep = skydir.separation(m.geom.center_skydir).deg
+        new_val = np.exp(-sep**2/2.0)
+        m.set_by_coord(coord, new_val)
 
-For maps with non-spatial dimensions the `~Map.iter_by_image`
-method can be used to loop over image slices:
+For maps with non-spatial dimensions the `~Map.iter_by_image` method can be used
+to loop over image slices:
 
 .. code:: python
 
-   from astropy.coordinates import SkyCoord
-   from astropy.convolution import Gaussian2DKernel, convolve
-   from gammapy.maps import Map
+    from astropy.coordinates import SkyCoord
+    from astropy.convolution import Gaussian2DKernel, convolve
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
-   for img, idx in m.iter_by_image():
-       img = convolve(img, Gaussian2DKernel(x_stddev=2.0) )
+    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
+    for img, idx in m.iter_by_image():
+        img = convolve(img, Gaussian2DKernel(x_stddev=2.0) )
 
 FITS I/O
 --------
 
-Maps can be written to and read from a FITS file with the
-`~Map.write` and `~Map.read` methods:
+Maps can be written to and read from a FITS file with the `~Map.write` and
+`~Map.read` methods:
 
 .. code:: python
 
-   from gammapy.maps import Map
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   m.write('file.fits', hdu='IMAGE')
-   m = Map.read('file.fits', hdu='IMAGE')
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    m.write('file.fits', hdu='IMAGE')
+    m = Map.read('file.fits', hdu='IMAGE')
 
-If ``map_type`` argument is not given when calling `~Map.read` a
-non-sparse map object will be instantiated with the pixelization of
-the input HDU.
+If ``map_type`` argument is not given when calling `~Map.read` a non-sparse map
+object will be instantiated with the pixelization of the input HDU.
 
-Maps can be serialized to a sparse data format by calling
-`~Map.write` with ``sparse=True``.  This will write all non-zero
-pixels in the map to a data table appropriate to the pixelization
-scheme.
+Maps can be serialized to a sparse data format by calling `~Map.write` with
+``sparse=True``. This will write all non-zero pixels in the map to a data table
+appropriate to the pixelization scheme.
 
 .. code:: python
 
-   from gammapy.maps import Map
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   m.write('file.fits', hdu='IMAGE', sparse=True)
-   m = Map.read('file.fits', hdu='IMAGE', map_type='wcs')
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    m.write('file.fits', hdu='IMAGE', sparse=True)
+    m = Map.read('file.fits', hdu='IMAGE', map_type='wcs')
 
-Sparse maps have the same ``read`` and ``write`` methods with the
-exception that they will be written to a sparse format by default:
+Sparse maps have the same ``read`` and ``write`` methods with the exception that
+they will be written to a sparse format by default:
 
 .. code:: python
 
-   from gammapy.maps import Map
+    from gammapy.maps import Map
 
-   m = Map.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
-   m.write('file.fits', hdu='IMAGE')
-   m = Map.read('file.fits', hdu='IMAGE', map_type='hpx-sparse')
+    m = Map.create(binsz=0.1, map_type='hpx-sparse', width=10.0)
+    m.write('file.fits', hdu='IMAGE')
+    m = Map.read('file.fits', hdu='IMAGE', map_type='hpx-sparse')
 
-By default files will be written to the *gamma-astro-data-format*
-specification for sky maps (see `here
+By default files will be written to the *gamma-astro-data-format* specification
+for sky maps (see `here
 <http://gamma-astro-data-formats.readthedocs.io/en/latest/skymaps/index.html>`_).
-The GADF format offers a number of enhancements over existing map
-formats such as support for writing multi-resolution maps, sparse
-maps, and cubes with different geometries to the same file.  For
-backward compatibility with software using other formats, the ``conv``
-keyword option is provided to write a file using a format other than
-the GADF format:
+The GADF format offers a number of enhancements over existing map formats such
+as support for writing multi-resolution maps, sparse maps, and cubes with
+different geometries to the same file.  For backward compatibility with software
+using other formats, the ``conv`` keyword option is provided to write a file
+using a format other than the GADF format:
 
 .. code:: python
 
-   from gammapy.maps import Map, MapAxis
+    from gammapy.maps import Map, MapAxis
 
-   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
                       axes=[energy_axis])
-   # Write a counts cube in a format compatible with the Fermi Science Tools
-   m.write('ccube.fits', conv='fgst-ccube')
+    # Write a counts cube in a format compatible with the Fermi Science Tools
+    m.write('ccube.fits', conv='fgst-ccube')
 
 Visualization
 -------------
 
-All map objects provide a `~Map.plot` method for generating a
-visualization of a map.  This method returns figure, axes, and image
-objects that can be used to further tweak/customize the image.
+All map objects provide a `~Map.plot` method for generating a visualization of a
+map.  This method returns figure, axes, and image objects that can be used to
+further tweak/customize the image.
 
 .. code:: python
 
-   import matplotlib.pyplot as plt
-   from gammapy.maps import Map
-   from gammapy.maps.utils import fill_poisson
+    import matplotlib.pyplot as plt
+    from gammapy.maps import Map
+    from gammapy.maps.utils import fill_poisson
 
-   m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
-   fill_poisson(m, mu=1.0, random_state=0)
-   fig, ax, im = m.plot(cmap='magma')
-   plt.colorbar(im)
+    m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
+    fill_poisson(m, mu=1.0, random_state=0)
+    fig, ax, im = m.plot(cmap='magma')
+    plt.colorbar(im)
 
 
 Examples
@@ -553,32 +527,32 @@ This example shows how to fill a counts cube from an FT1 file:
 
 .. code:: python
 
-   from astropy.io import fits
-   from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
+    from astropy.io import fits
+    from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
 
-   h = fits.open('ft1.fits')
-   energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
-   m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
-                       coordsys='CEL', axes=[energy_axis])
-   m.fill_by_coord((h['EVENTS'].data.field('RA'),
+    h = fits.open('ft1.fits')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+    m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
+                        coordsys='CEL', axes=[energy_axis])
+    m.fill_by_coord((h['EVENTS'].data.field('RA'),
                     h['EVENTS'].data.field('DEC'),
                     h['EVENTS'].data.field('ENERGY')))
-   m.write('ccube.fits', conv='fgst-ccube')
+    m.write('ccube.fits', conv='fgst-ccube')
 
 Generating a Cutout of a Model Cube
 -----------------------------------
 
-This example shows how to extract a cut-out of LAT galactic
-diffuse model cube using the `~Map.reproject` method:
+This example shows how to extract a cut-out of LAT galactic diffuse model cube
+using the `~Map.reproject` method:
 
 .. code:: python
 
-   from gammapy.maps import WcsGeom, WcsNDMap
+    from gammapy.maps import WcsGeom, WcsNDMap
 
-   m = WcsNDMap.read('gll_iem_v06.fits')
-   geom = WcsGeom(binsz=0.125, skydir=(45.0,30.0), coordsys='GAL', proj='AIT')
-   m_proj = m.reproject(geom)
-   m_proj.write('cutout.fits', conv='fgst-template')
+    m = WcsNDMap.read('gll_iem_v06.fits')
+    geom = WcsGeom(binsz=0.125, skydir=(45.0,30.0), coordsys='GAL', proj='AIT')
+    m_proj = m.reproject(geom)
+    m_proj.write('cutout.fits', conv='fgst-template')
 
 
 Using `gammapy.maps`
@@ -588,15 +562,14 @@ Using `gammapy.maps`
 
 * :gp-extra-notebook:`data_fermi_lat`
 
-More detailed documentation on the WCS and HPX classes in
-`gammapy.maps` can be found in the following sub-pages:
+More detailed documentation on the WCS and HPX classes in `gammapy.maps` can be
+found in the following sub-pages:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   hpxmap
-   wcsmap
-
+    hpxmap
+    wcsmap
 
 Reference/API
 =============

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -30,7 +30,7 @@ The best reference to TeV data analysis is Chapter 7 of Mathieu de Naurois's hab
 
 .. [Feldman1998] `Feldman & Cousins (1998) <http://adsabs.harvard.edu/abs/1998PhRvD..57.3873F>`_,
    "Unified approach to the classical statistical analysis of small signals"
-   
+
 .. [Lafferty1994] `Lafferty & Wyatt (1994) <http://adsabs.harvard.edu/abs/1995NIMPA.355..541L>`_,
    "Where to stick your data points: The treatment of measurements within wide bins"
 
@@ -62,13 +62,12 @@ Software references:
 
 .. [Knoedlseder2012] `Knödlseder et at. (2012) <http://adsabs.harvard.edu/abs/2012ASPC..461...65K>`_
    "GammaLib: A New Framework for the Analysis of Astronomical Gamma-Ray Data"
-   
+
 .. [FSSC2013] `Fermi LAT Collaboration (2013) <https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/overview.html>`_
    "Science Tools: LAT Data Analysis Tools"
 
 .. [Mayer2015] `Michael Mayer (2015) <https://publishup.uni-potsdam.de/frontdoor/index/index/docId/7150>`_
    "Pulsar wind nebulae at high energies"
-
 
 .. _glossary:
 

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -22,19 +22,20 @@ Command line tools (``scripts``)
 Introduction
 ============
 
-Currently, Gammapy is first and foremost a Python package. This means that
-to use it you have to write a Python script or Jupyter notebook, where
-you import the functions and classes needed for a given analysis, and then
-call them, passing parameters to configure the analysis.
+Currently, Gammapy is first and foremost a Python package. This means that to
+use it you have to write a Python script or Jupyter notebook, where you import
+the functions and classes needed for a given analysis, and then call them,
+passing parameters to configure the analysis.
 
-That said, for some very commonly used and easy to configure analysis tasks
-we have implemented a **command line interface (CLI)**. It is automatically
+That said, for some very commonly used and easy to configure analysis tasks we
+have implemented a **command line interface (CLI)**. It is automatically
 installed together with the Gammapy python package.
 
 Execute
 -------
 
-To execute the Gammapy CLI, type the command ``gammapy`` at your terminal shell (not in Python)::
+To execute the Gammapy CLI, type the command ``gammapy`` at your terminal shell
+(not in Python)::
 
     $ gammapy --help
 
@@ -42,7 +43,8 @@ or equivalently, just type this::
 
     $ gammapy
 
-Either way, the command should print some help text to the console and then exit:
+Either way, the command should print some help text to the console and then
+exit:
 
 .. code-block:: text
 
@@ -66,12 +68,12 @@ Either way, the command should print some help text to the console and then exit
       image  Analysis - 2D images
       info   Display information about Gammapy
 
-All CLI functionality for Gammapy is implemented as sub-commands of the
-main ``gammapy`` command. If a command has sub-commands, they are listed
-in the help output. E.g. the help output from ``gammapy`` above shows
-that there is a sub-command called ``gammapy image``. Actually, ``gammapy image``
-itself isn't a command that does something, but another command group
-that is used to group sub-commands:
+All CLI functionality for Gammapy is implemented as sub-commands of the main
+``gammapy`` command. If a command has sub-commands, they are listed in the help
+output. E.g. the help output from ``gammapy`` above shows that there is a
+sub-command called ``gammapy image``. Actually, ``gammapy image`` itself isn't a
+command that does something, but another command group that is used to group
+sub-commands:
 
 .. code-block:: text
 
@@ -114,22 +116,23 @@ Use ``--help`` to see the help text and available options:
       --overwrite  Overwrite existing files?
       -h, --help   Show this message and exit.
 
-So now you know how the Gammapy CLI is structured and how to discover
-all available sub-commands, arguments and options.
+So now you know how the Gammapy CLI is structured and how to discover all
+available sub-commands, arguments and options.
 
 Command not found
 -----------------
 
-Usually tools that install Gammapy (e.g. setuptools via ``python setup.py install``
-or ``pip`` or package managers like ``conda``) will put the ``gammapy`` command
-line tool in a directory that is on your ``PATH``, and if you type ``gammapy``
-the command is found and executed.
+Usually tools that install Gammapy (e.g. setuptools via ``python setup.py
+install`` or ``pip`` or package managers like ``conda``) will put the
+``gammapy`` command line tool in a directory that is on your ``PATH``, and if
+you type ``gammapy`` the command is found and executed.
 
 However, due to the large number of supported systems (Linux, Mac OS, Windows)
-and different ways to install Python packages like Gammapy (e.g. system install, user install,
-virtual environments, conda environments) and environments to launch command line tools
-like ``gammapy`` (e.g. bash, csh, Windows command prompt, Jupyter, ...) it is not unheard of
-that users have trouble running ``gammapy`` after installing it.
+and different ways to install Python packages like Gammapy (e.g. system install,
+user install, virtual environments, conda environments) and environments to
+launch command line tools like ``gammapy`` (e.g. bash, csh, Windows command
+prompt, Jupyter, ...) it is not unheard of that users have trouble running
+``gammapy`` after installing it.
 
 This usually looks like this::
 
@@ -137,44 +140,45 @@ This usually looks like this::
     -bash: gammapy: command not found
 
 If you just installed Gammapy, search the install log for the message
-"Installing gammapy script" to see where ``gammapy`` was installed, and
-check that this location is on your PATH::
+"Installing gammapy script" to see where ``gammapy`` was installed, and check
+that this location is on your PATH::
 
     echo $PATH
 
-If you don't manage to figure out where the ``gammapy`` command line tool is installed,
-you can try calling it like this instead::
+If you don't manage to figure out where the ``gammapy`` command line tool is
+installed, you can try calling it like this instead::
 
     $ python -m gammapy
 
-This also has the advantage that it avoids issues where users have multiple versions
-of Python and Gammapy installed and accidentally launch one they don't want because
-it comes first on their ``PATH``. For the same reason these days the recommended way
-to use e.g. ``pip`` is via ``python -m pip``.
+This also has the advantage that it avoids issues where users have multiple
+versions of Python and Gammapy installed and accidentally launch one they don't
+want because it comes first on their ``PATH``. For the same reason these days
+the recommended way to use e.g. ``pip`` is via ``python -m pip``.
 
-If this still doesn't work, check if you are using the right Python and
-have Gammapy installed::
+If this still doesn't work, check if you are using the right Python and have
+Gammapy installed::
 
     $ which python
     $ python -c 'import gammapy'
 
-To see more information about your shell environment, these commands might be helpful::
+To see more information about your shell environment, these commands might be
+helpful::
 
     $ python -m site
     $ python -m gammapy info
     $ echo $PATH
     $ conda info -a # if you're using conda
 
-If you're still stuck or have any question, feel free to ask for help with installation issues
-on the Gammapy mailing list of Slack any time!
+If you're still stuck or have any question, feel free to ask for help with
+installation issues on the Gammapy mailing list of Slack any time!
 
 Example
 -------
 
-Here's one example what you can do with the Gammapy CLI: use the ``gammapy image bin``
-command to create a counts image from a Fermi-LAT event list as well as a FITS image
-that serves as a reference geometry (projection, center, binning) for the counts image
-we're creating.
+Here's one example what you can do with the Gammapy CLI: use the ``gammapy image
+bin`` command to create a counts image from a Fermi-LAT event list as well as a
+FITS image that serves as a reference geometry (projection, center, binning) for
+the counts image we're creating.
 
 .. code-block:: text
 
@@ -198,8 +202,8 @@ we're creating.
     INFO:gammapy.scripts.image_bin:Reading /Users/deil/code/gammapy-extra/datasets/fermi_survey/all.fits.gz
     INFO:gammapy.scripts.image_bin:Writing out.fits
 
-If you have the FTOOLS_ installed or other tools that can work with the files that Gammapy
-supports, you can of course use them together::
+If you have the FTOOLS_ installed or other tools that can work with the files
+that Gammapy supports, you can of course use them together::
 
     $ ftlist $GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz H
 
@@ -225,9 +229,10 @@ Reference
 Here is auto-generated documentation for all available sub-commands, arguments
 and options of the ``gammapy`` command line interface (CLI).
 
-It's not very readable at the moment. With the current formatting it's a bit hard
-to tell where documentation for a new sub-command starts and what level of subcommand
-one is looking at for a given heading. Maybe change to one page per sub-command?
+It's not very readable at the moment. With the current formatting it's a bit
+hard to tell where documentation for a new sub-command starts and what level of
+subcommand one is looking at for a given heading. Maybe change to one page per
+sub-command?
 
 .. click:: gammapy.scripts.main:cli
    :prog: gammapy
@@ -238,14 +243,14 @@ one is looking at for a given heading. Maybe change to one page per sub-command?
 Implementation
 ==============
 
-Currently, the command line interface (CLI) of Gammapy is implemented using `click`_
-to define sub-commands, arguments and options, as well as calling the right function
-that implements a given sub-command.
+Currently, the command line interface (CLI) of Gammapy is implemented using
+`click`_ to define sub-commands, arguments and options, as well as calling the
+right function that implements a given sub-command.
 
-We have chosen to implement all functionality via a single command line tool called
-``gammapy``, with each task as a subcommand. The ``gammapy`` command line tool uses
-the `setuptools console_scripts entry point`_ method to automatically create command
-line tools when Gammapy is installed.
+We have chosen to implement all functionality via a single command line tool
+called ``gammapy``, with each task as a subcommand. The ``gammapy`` command line
+tool uses the `setuptools console_scripts entry point`_ method to automatically
+create command line tools when Gammapy is installed.
 
 This means that to be able to use the tools you have to install Gammapy.
 Although, from the source folder you can still execute it without installing via
@@ -254,19 +259,19 @@ Although, from the source folder you can still execute it without installing via
 
     $ python -m gammapy
 
-which executes ``gammapy/__main__.py`` as a script as explained
-`here <https://docs.python.org/3/library/__main__.html>`__.
+which executes ``gammapy/__main__.py`` as a script as explained `here
+<https://docs.python.org/3/library/__main__.html>`__.
 
-Another way to install the ``gammapy`` command line tool once, but to have
-it point at the Gammapy git source folder while you're hacking on Gammapy is to use
+Another way to install the ``gammapy`` command line tool once, but to have it
+point at the Gammapy git source folder while you're hacking on Gammapy is to use
 
 .. code-block:: bash
 
     $ python -m pip install --editable .
 
-
-Either ``gammapy`` or ``python -m gammapy`` call the ``gammapy.scripts.main.cli`` function,
-which is a ``click.Group`` object. If you want you can also import and execute it yourself::
+Either ``gammapy`` or ``python -m gammapy`` call the
+``gammapy.scripts.main.cli`` function, which is a ``click.Group`` object. If you
+want you can also import and execute it yourself::
 
     >>> from gammapy.scripts.main import cli
     >>> type(cli)
@@ -275,16 +280,18 @@ which is a ``click.Group`` object. If you want you can also import and execute i
     >>> cli(['--version'])
     >>> cli(['image', 'bin', '--help'])
 
-This is what we do to test the CLI, we import ``gammapy.scripts.main.cli`` and run it via
-``gammapy.utils.testing.run_cli`` and check the return code and sometimes console output
-or generated files. Note that this means that all tests run in a single Python process,
-we don't "shell out" and create a subprocess that calls ``gammapy`` from a sub-shell.
+This is what we do to test the CLI, we import ``gammapy.scripts.main.cli`` and
+run it via ``gammapy.utils.testing.run_cli`` and check the return code and
+sometimes console output or generated files. Note that this means that all tests
+run in a single Python process, we don't "shell out" and create a subprocess
+that calls ``gammapy`` from a sub-shell.
 
 This is also how the auto-generated CLI documentation in the :ref:`scripts_ref`
-section above was generated: we use the `sphinx-click`_ Sphinx extension that imports and
-inspects ``gammapy.scripts.main.cli`` to find out about all the available sub-commands
-and help text / arguments / options. The ``click.Group`` object exposes all information
-as attributes and methods. To just give one example::
+section above was generated: we use the `sphinx-click`_ Sphinx extension that
+imports and inspects ``gammapy.scripts.main.cli`` to find out about all the
+available sub-commands and help text / arguments / options. The ``click.Group``
+object exposes all information as attributes and methods. To just give one
+example::
 
     >>> from gammapy.scripts.main import cli
     >>> cli.commands
@@ -292,14 +299,16 @@ as attributes and methods. To just give one example::
      'image': <click.core.Group at 0x112102e10>,
      'info': <click.core.Command at 0x1120bb278>}
 
-If you're new to Python command line tools or Click, probably setuptools entry points
-and click groups seem very complex. And they are, compared to the rest of Gammapy which
-is just `def` and `class` statements to make functions and classes, i.e. "normal" Python code.
-Just know that to use and even work on the Gammapy CLI you don't have to understand how
-it works under the hood, but if you want to, it's actually not that complex.
+If you're new to Python command line tools or Click, probably setuptools entry
+points and click groups seem very complex. And they are, compared to the rest of
+Gammapy which is just `def` and `class` statements to make functions and
+classes, i.e. "normal" Python code. Just know that to use and even work on the
+Gammapy CLI you don't have to understand how it works under the hood, but if you
+want to, it's actually not that complex.
 
-A good path to learn is to start by reading `gammapy/__main__.py`_ and `gammapy/scripts/main.py`_
-and then to look at an example of how a sub-command in Gammapy is implemented and tested,
+A good path to learn is to start by reading `gammapy/__main__.py`_ and
+`gammapy/scripts/main.py`_ and then to look at an example of how a sub-command
+in Gammapy is implemented and tested,
 e.g. `gammapy/scripts/image_bin.py`_ and `gammapy/scripts/tests/test_image_bin.py`_.
 
 Note how sub-commands are ``click.Command`` objects::
@@ -308,14 +317,15 @@ Note how sub-commands are ``click.Command`` objects::
     >>> type(cli_image_bin)
     click.core.Command
 
-that are independent and how the main ``cli`` is created via ``cli.add_command`` calls in
-`gammapy/scripts/main.py`.
+that are independent and how the main ``cli`` is created via ``cli.add_command``
+calls in `gammapy/scripts/main.py`.
 
-Now you have a basic understanding how things work and should be able to work on Gammapy CLI
-(e.g. add more functionality to the CLI interface). If you're curious to learn how it
-works in detail, we suggest you read the `click`_ docs and play with the Gammapy ``cli``
-object in IPython like we did above when looking at ``cli.commands``, or read and play with
-the standalone example in the :ref:`scripts_user_cli` section below.
+Now you have a basic understanding how things work and should be able to work on
+Gammapy CLI (e.g. add more functionality to the CLI interface). If you're
+curious to learn how it works in detail, we suggest you read the `click`_ docs
+and play with the Gammapy ``cli`` object in IPython like we did above when
+looking at ``cli.commands``, or read and play with the standalone example in the
+:ref:`scripts_user_cli` section below.
 
 .. _gammapy/__main__.py: https://github.com/gammapy/gammapy/blob/master/gammapy/__main__.py
 .. _gammapy/scripts/main.py: https://github.com/gammapy/gammapy/blob/master/gammapy/scripts/main.py
@@ -327,8 +337,8 @@ the standalone example in the :ref:`scripts_user_cli` section below.
 Limitations
 ===========
 
-The current `click`_-based Gammapy CLI is pretty nice, it is very simple to add commands
-and also documenting and testing them is pretty nice.
+The current `click`_-based Gammapy CLI is pretty nice, it is very simple to add
+commands and also documenting and testing them is pretty nice.
 
 However, the current implementation has some issues and limitations. We describe
 them in this section, and then in the next one discuss more generally the plan
@@ -347,8 +357,8 @@ and options for the Gammapy high-level (CLI or non-CLI) interface.
   in very different ways, and there is duplication and not a nice transition
   and re-use between the two ways.
 
-More technical issues that can certainly be fixed if we want to stick
-with the current click-based CLI:
+More technical issues that can certainly be fixed if we want to stick with the
+current click-based CLI:
 
 * ``gammapy`` always imports all code from all sub-commands, which drags in
   large fraction of ``astropy`` and ``gammapy`` whether it is used or not.
@@ -370,11 +380,12 @@ with the current click-based CLI:
 Plan
 ====
 
-There is no concrete plan yet concerning the high-level user interface for Gammapy.
-Feedback from users and developers on the mailing list is highly welcome!
-What do you want?
+There is no concrete plan yet concerning the high-level user interface for
+Gammapy. Feedback from users and developers on the mailing list is highly
+welcome! What do you want?
 
-Some options we are considering to build the high-level end-user interface for Gammapy:
+Some options we are considering to build the high-level end-user interface for
+Gammapy:
 
 1. Collection of command line tools. Examples: FTOOLs_, `Fermi ScienceTools`_, `ctools`_
 2. Config-file driven analysis. Examples: `FermiPy`_, or the H.E.S.S.-internal HAP
@@ -384,43 +395,47 @@ Some options we are considering to build the high-level end-user interface for G
    config files or a CLI using a single implementation. Examples: `ctapipe`_, `fact-tools`_,
    `python-fire`_
 
-Options 1 and 2 are nice and simple, and they are user-friendly interfaces, and they
-would allow us to have a stable high-level interface while being able to continue to
-improve the Gammapy package without breaking user scripts over the coming years.
+Options 1 and 2 are nice and simple, and they are user-friendly interfaces, and
+they would allow us to have a stable high-level interface while being able to
+continue to improve the Gammapy package without breaking user scripts over the
+coming years.
 
-Their drawback is that they create a second way to use Gammapy, with some users learning
-and using the more flexible and powerful Python package, and some the simpler to use,
-but less flexible high-level interface. And note that eventually this second interface
-will grow into a config file with 100 options (that's what we have in HAP) or into
-10s of CLI tools with in total again 100s of options (see the ctools). However, the Fermi
-Science tools CLI and Fermipy config interface are examples where the interface size
-remains at a reasonable level (for users to learn and for developers to implement and maintain)
-while still exposing everything that most users need.
+Their drawback is that they create a second way to use Gammapy, with some users
+learning and using the more flexible and powerful Python package, and some the
+simpler to use, but less flexible high-level interface. And note that eventually
+this second interface will grow into a config file with 100 options (that's what
+we have in HAP) or into 10s of CLI tools with in total again 100s of options
+(see the ctools). However, the Fermi Science tools CLI and Fermipy config
+interface are examples where the interface size remains at a reasonable level
+(for users to learn and for developers to implement and maintain) while still
+exposing everything that most users need.
 
-Options 3 and 4 are similar, in either case the analysis functionality that is available
-in Gammapy would be written once. Option 3 is what we have now in the Gammapy Python package.
-Changing to option 4 would mean adding some boilerplate code everywhere (e.g. Python decorators
-or sub-classing from "tool" base classes like what ctapipe is developing)
-or relying on the dynamic and inspection features of the Python language offers (see e.g.
-python-fire), to make it possible to configure and drive analyses not just via Python
-code, but via some configuration coming either from configuration files (YAML or XML)
-or command line options.
+Options 3 and 4 are similar, in either case the analysis functionality that is
+available in Gammapy would be written once. Option 3 is what we have now in the
+Gammapy Python package. Changing to option 4 would mean adding some boilerplate
+code everywhere (e.g. Python decorators or sub-classing from "tool" base classes
+like what ctapipe is developing) or relying on the dynamic and inspection
+features of the Python language offers (see e.g. python-fire), to make it
+possible to configure and drive analyses not just via Python code, but via some
+configuration coming either from configuration files (YAML or XML) or command
+line options.
 
 So what should we do for Gammapy?
 
-I would suggest we continue with the prototyping of the CLI interface as well
-as of a config-file based interface (`gammapy.scripts.SpectrumAnalysisIACT` is a starting point).
-Pull requests that improve and extend what we have are welcome any time!
+I would suggest we continue with the prototyping of the CLI interface as well as
+of a config-file based interface (`gammapy.scripts.SpectrumAnalysisIACT` is a
+starting point). Pull requests that improve and extend what we have are welcome
+any time!
 
 In parallel, we continue to learn and evaluate solutions others have developed.
 In `python-cli-examples`_ I have started an exploration and evaluation of Python
 CLI packages, namely `click`_, but also `cliff`_ and `traitlets`_, and I might
-take a closer look also at `cement`_ and `python-fire`_ there.
-We should also look in detail at what other projects like LSST, JWST, Fermi, ctapipe,
-and others do concerning configuration and interface of their science tools.
-Later in 2018 we will need a comprehensive proposal for code organisation and
-high-level interface for Gammapy. Suggestions or even contributions are welcome any time!
-
+take a closer look also at `cement`_ and `python-fire`_ there. We should also
+look in detail at what other projects like LSST, JWST, Fermi, ctapipe, and
+others do concerning configuration and interface of their science tools. Later
+in 2018 we will need a comprehensive proposal for code organisation and
+high-level interface for Gammapy. Suggestions or even contributions are welcome
+any time!
 
 .. _fact-tools: https://pos.sissa.it/236/865/
 .. _cement: http://builtoncement.com/
@@ -437,20 +452,20 @@ Write your own CLI
 
 This section explains how to write your own command line interface (CLI).
 
-We will focus on the command line aspect, and use a very simple example
-where we just call `gammapy.stats.significance`.
+We will focus on the command line aspect, and use a very simple example where we
+just call `gammapy.stats.significance`.
 
-From the interactive Python or IPython prompt or from a Jupyter notebook
-you just import the functionality you need and call it, like this:
+From the interactive Python or IPython prompt or from a Jupyter notebook you
+just import the functionality you need and call it, like this:
 
    >>> from gammapy.stats import significance
    >>> significance(n_observed=10, mu_background=4.2, method='lima')
    2.3979181291475453
 
-If you imagine that the actual computation involves many lines of code
-(and not just a one-line function call), and that you need to do this
-computation frequently, you will probably write a Python script that
-looks something like this:
+If you imagine that the actual computation involves many lines of code (and not
+just a one-line function call), and that you need to do this computation
+frequently, you will probably write a Python script that looks something like
+this:
 
 .. code-block:: python
 
@@ -465,32 +480,34 @@ looks something like this:
     print(s)
 
 We have introduced variables that hold the parameters for the analysis and put
-them before the computation. Let's say this script is in a file called ``significance.py``,
-then to use it you put the parameters you like and then execute it via::
+them before the computation. Let's say this script is in a file called
+``significance.py``, then to use it you put the parameters you like and then
+execute it via::
 
     $ python significance.py
 
-If you want, you can also put the line ``#!/usr/bin/env python`` at the top of the
-script, make it executable via ``chmod +x significance.py`` and then you'll be able
-to execute it via ``./significance.py`` if you prefer to execute it like this.
-This works on Linux and Mac OS, but not on Windows.
-It is also possible to omit the ``.py`` extension from the filename, i.e. to simply
-call the file ``significance``. Either way has some advantages and disadvantages,
-it's a matter of taste. Omitting the ``.py`` is nice because users calling the tool
-usually don't care that it's a Python script, and it's shorter. But omitting the ``.py`` also
-means that some advanced users that open up the file in an editor have a harder time
-(because the editor might not recognise it as a Python file and syntax highlight appropriately),
-or more importantly that importing functions of classes from that script from other Python
-files or Jupyter notebooks is not easily possible, leading some people to rename it or
-copy & paste from it. We're explaining these details, because if you work with colleagues
-and share scripts, you'll encounter the ``#!/usr/bin/env python`` and scripts with and without
-``.py`` and will need to know how to work with them.
+If you want, you can also put the line ``#!/usr/bin/env python`` at the top of
+the script, make it executable via ``chmod +x significance.py`` and then you'll
+be able to execute it via ``./significance.py`` if you prefer to execute it like
+this. This works on Linux and Mac OS, but not on Windows. It is also possible to
+omit the ``.py`` extension from the filename, i.e. to simply call the file
+``significance``. Either way has some advantages and disadvantages, it's a
+matter of taste. Omitting the ``.py`` is nice because users calling the tool
+usually don't care that it's a Python script, and it's shorter. But omitting the
+``.py`` also means that some advanced users that open up the file in an editor
+have a harder time (because the editor might not recognise it as a Python file
+and syntax highlight appropriately), or more importantly that importing
+functions of classes from that script from other Python files or Jupyter
+notebooks is not easily possible, leading some people to rename it or copy &
+paste from it. We're explaining these details, because if you work with
+colleagues and share scripts, you'll encounter the ``#!/usr/bin/env python`` and
+scripts with and without ``.py`` and will need to know how to work with them.
 
-Writing and using such scripts is perfectly fine and a common way to run science analyses.
-However, if you use it very frequently it might become annoying to have to open up and
-edit the ``significance.py`` file every time to use it. In that case, you can change your
-script into a command line interface that allows you to set analysis parameters without
-having to edit the file, like this::
+Writing and using such scripts is perfectly fine and a common way to run science
+analyses. However, if you use it very frequently it might become annoying to
+have to open up and edit the ``significance.py`` file every time to use it. In
+that case, you can change your script into a command line interface that allows
+you to set analysis parameters without having to edit the file, like this::
 
     $ python significance.py --help
     Usage: significance.py [OPTIONS] N_OBSERVED MU_BACKGROUND
@@ -510,36 +527,39 @@ having to edit the file, like this::
     $ python significance.py 10 4.2 --method simple
     2.83011021
 
-In Python, there are several ways to do command line argument parsing and to create
-command line interfaces. Of course you're free to do whatever you like, but if
-you're not sure what to use to build your own CLIs, we suggest you give `click`_
-a try. Here is how you'd rewrite your ``significance.py`` as a click CLI:
+In Python, there are several ways to do command line argument parsing and to
+create command line interfaces. Of course you're free to do whatever you like,
+but if you're not sure what to use to build your own CLIs, we suggest you give
+`click`_ a try. Here is how you'd rewrite your ``significance.py`` as a click
+CLI:
 
 .. literalinclude:: significance.py
 
 As mentioned above in the :ref:`scripts_implementation`, we use `click`_ in
-Gammapy itself. We also use `click`_ frequently for our own projects if we choose to add
-a CLI (no matter if Gammapy is used or not). Putting the CLI in a file called ``make.py``
-makes it easy to go back to a project after a while and to remember or quickly figure out
-again how it works (as opposed to just having a bunch of Python scripts or Jupyter notebooks
-where it's harder to remember where to edit parameters and which ones to run in which order).
-One example is the `gamma-cat make.py`_.
+Gammapy itself. We also use `click`_ frequently for our own projects if we
+choose to add a CLI (no matter if Gammapy is used or not). Putting the CLI in a
+file called ``make.py`` makes it easy to go back to a project after a while and
+to remember or quickly figure out again how it works (as opposed to just having
+a bunch of Python scripts or Jupyter notebooks where it's harder to remember
+where to edit parameters and which ones to run in which order). One example is
+the `gamma-cat make.py`_.
 
 .. _gamma-cat make.py: https://github.com/gammapy/gamma-cat/blob/master/make.py
 .. _gamma-sky.net make.py: https://github.com/gammapy/gamma-sky/blob/master/make.py
 
-If you find that you don't like `click`_, another popular alternative to create CLIs is
-`argparse`_ from the Python standard library. To learn argparse, either read the official
-documentation, or the `PYMOTW argparse`_ tutorial. For basic use cases ``argparse`` is
-similar to ``click``, the main difference being that ``click`` uses decorators
-(``@command``, ``@argument``, ``@option``) attached to a callback function to execute,
-whereas ``argparse`` uses classes and method calls to create a parser object, and then
-you have to call ``parse_args`` yourself and also pass the ``args`` to the code or function
-to execute yourself. So for basic use cases, but also for more advanced use cases where
-you define a CLI with sub-commands, ``argparse`` can be used just as well, it's just
-a little harder to learn and use than ``click`` (of course that's a matter of opinion).
-Another advantage of choosing Click is that once you've learned it, you'll be able to
-quickly read and understand, or even contribute to the Gammapy CLI.
+If you find that you don't like `click`_, another popular alternative to create
+CLIs is `argparse`_ from the Python standard library. To learn argparse, either
+read the official documentation, or the `PYMOTW argparse`_ tutorial. For basic
+use cases ``argparse`` is similar to ``click``, the main difference being that
+``click`` uses decorators (``@command``, ``@argument``, ``@option``) attached to
+a callback function to execute, whereas ``argparse`` uses classes and method
+calls to create a parser object, and then you have to call ``parse_args``
+yourself and also pass the ``args`` to the code or function to execute yourself.
+So for basic use cases, but also for more advanced use cases where you define a
+CLI with sub-commands, ``argparse`` can be used just as well, it's just a little
+harder to learn and use than ``click`` (of course that's a matter of opinion).
+Another advantage of choosing Click is that once you've learned it, you'll be
+able to quickly read and understand, or even contribute to the Gammapy CLI.
 
 .. _argparse: https://docs.python.org/3/library/argparse.html
 .. _PYMOTW argparse: https://pymotw.com/3/argparse/index.html
@@ -547,10 +567,10 @@ quickly read and understand, or even contribute to the Gammapy CLI.
 Reference/API
 =============
 
-Besides the CLI interface, the `gammapy.scripts` package currently contains a bunch of things
-that will probably all be removed or rewritten and integrated in other sub-packages of Gammapy,
-leaving ``scripts`` just as the high-level command line script interface for Gammapy.
-
+Besides the CLI interface, the `gammapy.scripts` package currently contains a
+bunch of things that will probably all be removed or rewritten and integrated in
+other sub-packages of Gammapy, leaving ``scripts`` just as the high-level
+command line script interface for Gammapy.
 
 .. automodapi:: gammapy.scripts
     :no-inheritance-diagram:

--- a/docs/scripts/significance.py
+++ b/docs/scripts/significance.py
@@ -1,3 +1,4 @@
+"""Example how to write a command line tool with Click"""
 import click
 from gammapy.stats import significance
 

--- a/docs/spectrum/fitting.rst
+++ b/docs/spectrum/fitting.rst
@@ -10,7 +10,8 @@ Spectral Fitting
 
 In the following you will see how to fit spectral data in OGIP format. The
 format is described at :ref:`gadf:ogip`. An example dataset is available in the
-`gammapy-extra repo <https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-crab4_pha>`_. For a description of the available fit statstics see :ref:`fit-statistics`.
+``gammapy-extra`` repo. For a description of the available fit statstics see
+:ref:`fit-statistics`.
 
 Getting Started
 ===============
@@ -38,22 +39,21 @@ simulated crab runs using the `~gammapy.spectrum.SpectrumFit` class.
     fit = SpectrumFit(obs_list=obs_list, model=model)
     fit.statistic = 'WStat'
     fit.fit()
-    
+
 You can check the fit results by looking at
 `~gammapy.spectrum.SpectrumFitResult` that is attached to the
 `~gammapy.spectrum.SpectrumFit` for each observation.
-
 
 .. code-block:: python
 
     >>> print(fit.global_result)
 
-    Fit result info 
-    --------------- 
+    Fit result info
+    ---------------
     Best Fit Model: PowerLaw
     index : 2.12+/-0.05
     reference : 1e+09
-    amplitude : (2.08+/-0.00)e-20 
+    amplitude : (2.08+/-0.00)e-20
     --> Units: keV, cm, s
 
     Statistic: 103.596 (wstat)
@@ -87,7 +87,7 @@ example dataset used above. It makes use of the Sherpa `datastack module
     ds.load_pha(phalist)
 
     model = PowLaw1D('powlaw1d.default')
-    model.ampl = 1 
+    model.ampl = 1
     model.ref = 1e9
     model.gamma = 2
 
@@ -103,7 +103,7 @@ example dataset used above. It makes use of the Sherpa `datastack module
 
 This should give the following output
 
-.. code-block:: python
+.. code-block:: text
 
     Datasets              = 1, 2
     Method                = levmar
@@ -115,8 +115,8 @@ This should give the following output
     Probability [Q-value] = 0.0392206
     Reduced statistic     = 1.29494
     Change in statistic   = 114.79
-    powlaw1d.default.gamma   2.11641     
-    powlaw1d.default.ampl   2.08095     
+    powlaw1d.default.gamma   2.11641
+    powlaw1d.default.ampl   2.08095
     Datasets              = 1, 2
     Confidence Method     = covariance
     Iterative Fit Method  = None

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -16,10 +16,10 @@ spectral analysis. This includes also simulation tools.
 
 The basic of 1D spectral analysis are explained in `this
 <https://github.com/gammapy/PyGamma15/tree/gh-pages/talks/analysis-classical>`__
-talk. A good reference for the forward-folding on-off likelihood fitting
-methods is Section 7.5 "Spectra and Light Curves" in [Naurois2012]_, in
-publications usually the reference [Piron2001]_ is used.  A standard reference
-for the unfolding method is [Albert2007]_.
+talk. A good reference for the forward-folding on-off likelihood fitting methods
+is Section 7.5 "Spectra and Light Curves" in [Naurois2012]_, in publications
+usually the reference [Piron2001]_ is used.  A standard reference for the
+unfolding method is [Albert2007]_.
 
 Getting Started
 ===============
@@ -65,22 +65,22 @@ It will print the following output to the console:
     Statistic: 46.051 (wstat)
     Fit Range: [  5.99484250e+08   1.00000000e+11] keV
 
-
-
 Using `gammapy.spectrum`
 ========================
 
 For more advanced use cases please go to the tutorial notebooks:
 
-* :gp-extra-notebook:`spectrum_simulation` - simulate and fit 1D spectra using pre-defined or a user-defined model.
-* :gp-extra-notebook:`spectrum_analysis` - spectral analysis starting from event lists and field-of-view IRFs.
+* :gp-extra-notebook:`spectrum_simulation` - simulate and fit 1D spectra using
+  pre-defined or a user-defined model.
+* :gp-extra-notebook:`spectrum_analysis` - spectral analysis starting from event
+  lists and field-of-view IRFs.
 
 The following pages describe ``gammapy.spectrum`` in more detail:
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   fitting
+    fitting
 
 Reference/API
 =============

--- a/docs/stats/feldman_cousins.rst
+++ b/docs/stats/feldman_cousins.rst
@@ -3,61 +3,61 @@
 Feldman and Cousins Confidence Intervals
 ========================================
 
-Feldman and Cousins solved the problem on how to choose confidence intervals
-in a unified way (that is without basing the choice on the data)
-[Feldman1998]_. The functions ``gammapy.stats.fc_*`` give you access to a
-numerical solution to the Feldman Cousins algorithm. It can be used for any type
-of statistical distribution and is not limited to a Poisson process with
-background or a Gaussian with a boundary at the origin.
+Feldman and Cousins solved the problem on how to choose confidence intervals in
+a unified way (that is without basing the choice on the data) [Feldman1998]_.
+The functions ``gammapy.stats.fc_*`` give you access to a numerical solution to
+the Feldman Cousins algorithm. It can be used for any type of statistical
+distribution and is not limited to a Poisson process with background or a
+Gaussian with a boundary at the origin.
 
-The basic ingredient to `~gammapy.stats.fc_construct_acceptance_intervals_pdfs` is a matrix of
-:math:`P(X|\\mu)` (see e.g. equation (3.1) and (3.2) in [Feldman1998]_). Every row is a
-probability density function (PDF) of x and the columns are built up by varying
-the signal strength :math:`\\mu`. The other parameter is the desired confidence level
-(C.L.). The function will return another matrix of acceptance intervals where 1
-means the point is part of the acceptance interval and 0 means it is outside.
-This can be easily converted to upper and lower limits (`~gammapy.stats.fc_get_limits`),
-which simply connect the outside 1s for different :math:`\\mu` values. An upper or lower limit
-is obtained by drawing a vertical line at the measured value and calculating the
+The basic ingredient to `~gammapy.stats.fc_construct_acceptance_intervals_pdfs`
+is a matrix of :math:`P(X|\\mu)` (see e.g. equation (3.1) and (3.2) in
+[Feldman1998]_). Every row is a probability density function (PDF) of x and the
+columns are built up by varying the signal strength :math:`\\mu`. The other
+parameter is the desired confidence level (C.L.). The function will return
+another matrix of acceptance intervals where 1 means the point is part of the
+acceptance interval and 0 means it is outside. This can be easily converted to
+upper and lower limits (`~gammapy.stats.fc_get_limits`), which simply connect
+the outside 1s for different :math:`\\mu` values. An upper or lower limit is
+obtained by drawing a vertical line at the measured value and calculating the
 intersection (`~gammapy.stats.fc_find_limit`).
 
 Examples
 --------
 
-Assume you have a Poisson background with known mean 3.0. We generate the
-matrix of :math:`P(X|\\mu)` like this
+Assume you have a Poisson background with known mean 3.0. We generate the matrix
+of :math:`P(X|\\mu)` like this
 
 .. code-block:: python
 
-   import gammapy.stats as gstats
-   import numpy as np
-   from scipy import stats
+    import gammapy.stats as gstats
+    import numpy as np
+    from scipy import stats
 
-   x_bins = np.arange(0, 50)
-   mu_bins = np.linspace(0, 15, 15 / 0.005 + 1, endpoint=True)
-   matrix = [stats.poisson(mu + 3.0).pmf(x_bins) for mu in mu_bins]
+    x_bins = np.arange(0, 50)
+    mu_bins = np.linspace(0, 15, 15 / 0.005 + 1, endpoint=True)
+    matrix = [stats.poisson(mu + 3.0).pmf(x_bins) for mu in mu_bins]
 
 Now we generate the 90% acceptance intervals and construct the lower and upper
 limit from them:
 
 .. code-block:: python
 
-   acceptance_intervals = gstats.fc_construct_acceptance_intervals_pdfs(matrix, 0.9)
-
-   LowerLimitNum, UpperLimitNum, _ = gstats.fc_get_limits(mu_bins, x_bins, acceptance_intervals)
+    acceptance_intervals = gstats.fc_construct_acceptance_intervals_pdfs(matrix, 0.9)
+    LowerLimitNum, UpperLimitNum, _ = gstats.fc_get_limits(mu_bins, x_bins, acceptance_intervals)
 
 Let's say you measured x = 1, then the 90% upper limit would be:
 
 .. code-block:: python
 
-   >>> gstats.fc_find_limit(1, UpperLimitNum, mu_bins)
-   1.875
+    >>> gstats.fc_find_limit(1, UpperLimitNum, mu_bins)
+    1.875
 
 The following plot shows the confidence belt based on the Feldman and Cousins
-principle for a 90% confidence level for the unknown Poisson signal mean :math:`\\mu`.
-It is a reproduction of Fig. 7 from [Feldman1998]_. It should be noted that the
-plot in the paper is inconsistent with Table IV from the same paper: the lower
-limit is off by one bin to the left.
+principle for a 90% confidence level for the unknown Poisson signal mean
+:math:`\\mu`. It is a reproduction of Fig. 7 from [Feldman1998]_. It should be
+noted that the plot in the paper is inconsistent with Table IV from the same
+paper: the lower limit is off by one bin to the left.
 
 .. plot:: stats/plot_fc_poisson.py
 
@@ -79,65 +79,69 @@ lines is not simply connected. These artefacts are corrected with
 
 .. code-block:: python
 
-   >>> gstats.fc_fix_limits(LowerLimitNum, UpperLimitNum)
+    >>> gstats.fc_fix_limits(LowerLimitNum, UpperLimitNum)
 
 The following script in the ``examples`` directory demonstrates the problem:
-:download:`example_fc_demonstrate_artefact.py <../../examples/example_fc_demonstrate_artefact.py>`
+:download:`example_fc_demonstrate_artefact.py
+<../../examples/example_fc_demonstrate_artefact.py>`
 
 For mu = 0.745 the 90% acceptance interval is [0,8] and for mu = 0.750 it is
 [1,8]. A lot of the fast algorithms that do not compute the full confidence belt
 will come to the conclusion that the 90% confidence interval is [0, 0.745] and
 thus the upper limit when zero is measured should be 0.745 (one example is
-``TFeldmanCousins`` that comes with ``ROOT``, but is has the additional bug of making
-the confidence interval one mu bin to big, thus reporting 0.75 as upper limit).
+``TFeldmanCousins`` that comes with ``ROOT``, but is has the additional bug of
+making the confidence interval one mu bin to big, thus reporting 0.75 as upper
+limit).
 
-For mu = 1.035 the 90% acceptance interval is [0,8] again and only starting
-mu = 1.060 will 0 no longer be in the 90% acceptance interval. Thus the correct
-upper limit according to the procedure described in [Feldman1998]_ should be
-1.055, which is also the value given in the paper (rounded to 1.06).
+For mu = 1.035 the 90% acceptance interval is [0,8] again and only starting mu =
+1.060 will 0 no longer be in the 90% acceptance interval. Thus the correct upper
+limit according to the procedure described in [Feldman1998]_ should be 1.055,
+which is also the value given in the paper (rounded to 1.06).
 
 Sensitivity
 -----------
 
 [Feldman1998]_ also defines experimental sensitivity as the average upper limit
 that would be obtained by an ensemble of experiments with the expected
-background and no true signal. It can be calculated using `~gammapy.stats.fc_find_average_upper_limit`.
+background and no true signal. It can be calculated using
+`~gammapy.stats.fc_find_average_upper_limit`.
 
 .. code-block:: python
 
-   >>> gstats.fc_find_average_upper_limit(x_bins, matrix, UpperLimitNum, mu_bins)
-   4.41
+    >>> gstats.fc_find_average_upper_limit(x_bins, matrix, UpperLimitNum, mu_bins)
+    4.41
 
 General Case
 ------------
 
-In the more general case, one may not know the underlying PDF of :math:`P(X|\\mu)`. One
-way would be to generate :math:`P(X|\\mu)` from Monte Carlo simulation. With a dictionary
-of mu values and lists of X values from Monte Carlo one can use `~gammapy.stats.fc_construct_acceptance_intervals`
-to construct the confidence belts.
+In the more general case, one may not know the underlying PDF of
+:math:`P(X|\\mu)`. One way would be to generate :math:`P(X|\\mu)` from Monte
+Carlo simulation. With a dictionary of mu values and lists of X values from
+Monte Carlo one can use `~gammapy.stats.fc_construct_acceptance_intervals` to
+construct the confidence belts.
 
 Here is an example, where the X values are generated from Monte Carlo (seed is
 fixed here, so the result is known):
 
 .. code-block:: python
 
-   import gammapy.stats as gstats
-   import numpy as np
-   from scipy import stats
+    import gammapy.stats as gstats
+    import numpy as np
+    from scipy import stats
 
-   x_bins = np.linspace(-10, 10, 100, endpoint=True)
-   mu_bins = np.linspace(0, 8, 8 / 0.05 + 1, endpoint=True)
+    x_bins = np.linspace(-10, 10, 100, endpoint=True)
+    mu_bins = np.linspace(0, 8, 8 / 0.05 + 1, endpoint=True)
 
-   np.random.seed(seed=1)
+    np.random.seed(seed=1)
 
-   distribution_dict = dict((mu, [stats.norm.rvs(loc=mu, scale=1, size=5000)]) for mu in mu_bins)
+    distribution_dict = dict((mu, [stats.norm.rvs(loc=mu, scale=1, size=5000)]) for mu in mu_bins)
 
-   acceptance_intervals = gstats.fc_construct_acceptance_intervals(distribution_dict, x_bins, 0.6827)
+    acceptance_intervals = gstats.fc_construct_acceptance_intervals(distribution_dict, x_bins, 0.6827)
 
-   LowerLimitNum, UpperLimitNum, _ = gstats.fc_get_limits(mu_bins, x_bins, acceptance_intervals)
+    LowerLimitNum, UpperLimitNum, _ = gstats.fc_get_limits(mu_bins, x_bins, acceptance_intervals)
 
-   mu_upper_limit = gstats.fc_find_limit(1.7, UpperLimitNum, mu_bins)
-   # mu_upper_limit == 2.7
+    mu_upper_limit = gstats.fc_find_limit(1.7, UpperLimitNum, mu_bins)
+    # mu_upper_limit == 2.7
 
 Verification
 ------------
@@ -145,5 +149,7 @@ Verification
 To verify that the numerical solution is working, the example plots can also be
 produced using the analytical solution. They look consistent. The scripts for
 the analytical solution are given in the ``examples`` directory:
-:download:`example_fc_poisson_analytical.py <../../examples/example_fc_poisson_analytical.py>`
-:download:`example_fc_gauss_analytical.py <../../examples/example_fc_gauss_analytical.py>`
+:download:`example_fc_poisson_analytical.py
+<../../examples/example_fc_poisson_analytical.py>`
+:download:`example_fc_gauss_analytical.py
+<../../examples/example_fc_gauss_analytical.py>`

--- a/docs/stats/fit_statistics.rst
+++ b/docs/stats/fit_statistics.rst
@@ -8,20 +8,16 @@ Fit statistics
 Introduction
 ------------
 
-This page describes common fit statistics used in gamma-ray astronomy.
-Results were tested against results from the `Sherpa`_ and `XSpec`_
-X-ray analysis packages.
-
-.. Likelihood defined per bin -> take sum
-.. Stat = -2 log (L)
-.. Code example
+This page describes common fit statistics used in gamma-ray astronomy. Results
+were tested against results from the `Sherpa`_ and `XSpec`_ X-ray analysis
+packages.
 
 All functions compute per-bin statistics. If you want the summed statistics for
 all bins, call sum on the output array yourself. Here's an example for the
-`~gammapy.stats.cash` statistic:: 
+`~gammapy.stats.cash` statistic::
 
     >>> from gammapy.stats import cash
-    >>> data = [3, 5, 9] 
+    >>> data = [3, 5, 9]
     >>> model = [3.3, 6.8, 9.2]
     >>> cash(data, model)
     array([ -0.56353481,  -5.56922612, -21.54566271])
@@ -30,19 +26,22 @@ all bins, call sum on the output array yourself. Here's an example for the
 
 Gaussian data
 -------------
+
 TODO
 
 Poisson data
 ------------
+
 TODO
 
 .. _wstat:
 
 Poisson data with background measurement
 ----------------------------------------
-If you not only have a  measurement of counts  :math:`n_{\mathrm{on}}` in the signal region,
-but also a measurement :math:`n_{\mathrm{off}}` in a background region you can write down the
-likelihood formula as 
+
+If you not only have a  measurement of counts  :math:`n_{\mathrm{on}}` in the
+signal region, but also a measurement :math:`n_{\mathrm{off}}` in a background
+region you can write down the likelihood formula as
 
 .. math::
 
@@ -53,11 +52,11 @@ likelihood formula as
     \frac{(\mu_{\mathrm{bkg}})^{n_{\mathrm{off}}}}{n_{\mathrm{off}}
     !}\exp{(-\mu_{\mathrm{bkg}})},
 
-where :math:`\mu_{\mathrm{sig}}` is the number of expected counts in the signal regions,
-and :math:`\mu_{\mathrm{bkg}}` is the number of expected counts in the background
-region, as defined in the :ref:`stats-introduction`. By taking two time the
-negative log likelihood and neglecting model independent and thus constant
-terms, we define the **WStat**.
+where :math:`\mu_{\mathrm{sig}}` is the number of expected counts in the signal
+regions, and :math:`\mu_{\mathrm{bkg}}` is the number of expected counts in the
+background region, as defined in the :ref:`stats-introduction`. By taking two
+time the negative log likelihood and neglecting model independent and thus
+constant terms, we define the **WStat**.
 
 .. math::
 
@@ -78,17 +77,17 @@ Profile Likelihood
 ^^^^^^^^^^^^^^^^^^
 
 Most of the times you probably won't have a model in order to get
-:math:`\mu_{\mathrm{bkg}}`. The strategy in this case is to treat :math:`\mu_{\mathrm{bkg}}` as
-so-called nuisance parameter, i.e. a free parameter that is of no physical
-interest.  Of course you don't want an additional free parameter for each bin
-during a fit. Therefore one calculates an estimator for :math:`\mu_{\mathrm{bkg}}` by
-analytically minimizing the likelihood function. This is called 'profile
-likelihood'.
+:math:`\mu_{\mathrm{bkg}}`. The strategy in this case is to treat
+:math:`\mu_{\mathrm{bkg}}` as so-called nuisance parameter, i.e. a free
+parameter that is of no physical interest.  Of course you don't want an
+additional free parameter for each bin during a fit. Therefore one calculates an
+estimator for :math:`\mu_{\mathrm{bkg}}` by analytically minimizing the
+likelihood function. This is called 'profile likelihood'.
 
 .. math::
     \frac{\mathrm d \log L}{\mathrm d \mu_{\mathrm{bkg}}} = 0
-    
-This yields a quadratic equation for :math:`\mu_{\mathrm{bkg}}` 
+
+This yields a quadratic equation for :math:`\mu_{\mathrm{bkg}}`
 
 .. math::
     \frac{\alpha\,n_{\mathrm{on}}}{\mu_{\mathrm{sig}}+\alpha
@@ -108,12 +107,11 @@ where
     C = \alpha(n_{\mathrm{on}} + n_{\mathrm{off}}) - (\alpha+1)\mu_{\mathrm{sig}} \\
     D^2 = C^2 + 4 (\alpha+1)\alpha n_{\mathrm{off}} \mu_{\mathrm{sig}}
 
-
 Goodness of fit
 ^^^^^^^^^^^^^^^
 
-The best-fit value of the WStat as defined now contains no information about
-the goodness of the fit. We consider the likelihood of the data
+The best-fit value of the WStat as defined now contains no information about the
+goodness of the fit. We consider the likelihood of the data
 :math:`n_{\mathrm{on}}` and :math:`n_{\mathrm{off}}` under the expectation of
 :math:`n_{\mathrm{on}}` and :math:`n_{\mathrm{off}}`,
 
@@ -145,7 +143,6 @@ Intuitively, this log-likelihood ratio should asymptotically behave like a
 chi-square with ``m-n`` degrees of freedom, where ``m`` is the number of
 measurements and ``n`` the number of model parameters.
 
-
 Final result
 ^^^^^^^^^^^^
 
@@ -157,14 +154,13 @@ Final result
     \log{(n_{\mathrm{on}})}}) - n_{\mathrm{off}} (\log{(\mu_{\mathrm{bkg}})} -
     \log{(n_{\mathrm{off}})})\big)
 
-
 Special cases
 ^^^^^^^^^^^^^
 
 The above formula is undefined if :math:`n_{\mathrm{on}}` or
 :math:`n_{\mathrm{off}}` are equal to zero, because of the :math:`n\log{{n}}`
-terms, that were introduced by adding the goodness of fit terms.
-These cases are treated as follows.
+terms, that were introduced by adding the goodness of fit terms. These cases are
+treated as follows.
 
 If :math:`n_{\mathrm{on}} = 0` the likelihood formulae read
 
@@ -208,14 +204,13 @@ When inserting this into the WStat we find the simplified expression.
 
     W = 2\big(\mu_{\mathrm{sig}} + n_{\mathrm{off}} \log{(1 + \alpha)}\big)
 
-
 If :math:`n_{\mathrm{off}} = 0` Wstat becomes
 
 .. math::
 
     W = 2 \big(\mu_{\mathrm{sig}} + (1 + \alpha)\mu_{\mathrm{bkg}} -
     n_{\mathrm{on}} - n_{\mathrm{on}} (\log{(\mu_{\mathrm{sig}} + \alpha
-    \mu_{\mathrm{bkg}}) - \log{(n_{\mathrm{on}})}}) 
+    \mu_{\mathrm{bkg}}) - \log{(n_{\mathrm{on}})}})
 
 and
 
@@ -227,9 +222,9 @@ and
 For :math:`\mu_{\mathrm{sig}} > n_{\mathrm{on}} (\frac{\alpha}{1 + \alpha})`,
 :math:`\mu_{\mathrm{bkg}}` becomes negative which is unphysical.
 
-Therefore we distinct two cases. The physical one where 
+Therefore we distinct two cases. The physical one where
 
-:math:`\mu_{\mathrm{sig}} < n_{\mathrm{on}} (\frac{\alpha}{1 + \alpha})`. 
+:math:`\mu_{\mathrm{sig}} < n_{\mathrm{on}} (\frac{\alpha}{1 + \alpha})`.
 
 is straightforward and gives
 
@@ -252,7 +247,7 @@ Example
 The following table gives an overview over values that WStat takes in different
 scenarios
 
-    >>> from gammapy.stats import wstat    
+    >>> from gammapy.stats import wstat
     >>> from astropy.table import Table
     >>> table = Table()
     >>> table['mu_sig'] = [0.1, 0.1, 1.4, 0.2, 0.1, 5.2, 6.2, 4.1, 6.4, 4.9, 10.2,
@@ -286,15 +281,14 @@ scenarios
 Notes
 ^^^^^
 
-All above formulae are equivalent to what is given on the
-`XSpec manual statistics page`_ with the substitutions:
+All above formulae are equivalent to what is given on the `XSpec manual
+statistics page`_ with the substitutions:
 
 .. math::
 
     \mu_{\mathrm{sig}} = t_s \cdot m_i \\
     \mu_{\mathrm{bkg}} = t_b \cdot m_b \\
     \alpha = t_s / t_b  \\
-
 
 Further references
 ------------------

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -11,15 +11,15 @@ Statistics tools (``stats``)
 Introduction
 ============
 
-`gammapy.stats` holds statistical estimators,
-fit statistics and algorithms commonly used in gamma-ray astronomy.
+`gammapy.stats` holds statistical estimators, fit statistics and algorithms
+commonly used in gamma-ray astronomy.
 
-It is mostly concerned with the evaluation of one or several observations
-that count events in a given region and time window, i.e. with
-Poisson-distributed counts measurements.
+It is mostly concerned with the evaluation of one or several observations that
+count events in a given region and time window, i.e. with Poisson-distributed
+counts measurements.
 
-For on-off methods we will use the following variable names
-following the notation in [Cousins2007]_:
+For on-off methods we will use the following variable names following the
+notation in [Cousins2007]_:
 
 ================= ====================================================
 Variable          Definition
@@ -40,28 +40,25 @@ The following formulae show how an on-off measurement :math:`(n_{on}, n_{off})`
 is related to the quantities in the above table:
 
 .. math::
-
     n_{on} \sim Pois(\mu_{on})\text{ with }\mu_{on} = \mu_s + \mu_b
-
     n_{off} \sim Pois(\mu_{off})\text{ with }\mu_{off} = \mu_b / \alpha\text{ with }\alpha = a_{on} / a_{off}
 
 With the background estimate in the on region
 
 .. math::
-
    n_{bkg} = \alpha\ n_{off},
 
 the maximum likelihood estimate of a signal excess is
 
 .. math::
-   n_{excess} = n_{on} - n_{bkg}.
+    n_{excess} = n_{on} - n_{bkg}.
 
-When the background is known and there is only an "on" region (sometimes also called "source region"),
-we use the variable names ``n_on``, ``mu_on``, ``mu_sig`` and ``mu_bkg``.
+When the background is known and there is only an "on" region (sometimes also
+called "source region"), we use the variable names ``n_on``, ``mu_on``,
+``mu_sig`` and ``mu_bkg``.
 
-
-These are references describing the available methods:
-[LiMa1983]_, [Cash1979]_, [Stewart2009]_, [Rolke2005]_, [Feldman1998]_, [Cousins2007]_.
+These are references describing the available methods: [LiMa1983]_, [Cash1979]_,
+[Stewart2009]_, [Rolke2005]_, [Feldman1998]_, [Cousins2007]_.
 
 Getting Started
 ===============
@@ -74,35 +71,35 @@ you suspect a source might be present and :math:`n_{off} = 97` counts in a
 background control region where you assume no source is present and that is
 :math:`a_{off}/a_{on}=10` times larger than the on-region.
 
-Here's how you compute the statistical significance of your detection
-with the Li \& Ma formula:
+Here's how you compute the statistical significance of your detection with the
+Li \& Ma formula:
 
 .. code-block:: python
 
-   >>> from gammapy.stats import significance_on_off
-   >>> significance_on_off(n_on=18, n_off=97, alpha=1. / 10, method='lima')
-   2.2421704424844875
+    >>> from gammapy.stats import significance_on_off
+    >>> significance_on_off(n_on=18, n_off=97, alpha=1. / 10, method='lima')
+    2.2421704424844875
 
 Confidence Intervals
 --------------------
 
 Assume you measured 6 counts in a Poissonian counting experiment with an
-expected background :math:`b = 3`. Here's how you compute the 90% upper limit
-on the signal strength :math:`\\mu`:
+expected background :math:`b = 3`. Here's how you compute the 90% upper limit on
+the signal strength :math:`\\mu`:
 
 .. code-block:: python
 
-   import numpy as np
-   from scipy import stats
-   import gammapy.stats as gstats
+    import numpy as np
+    from scipy import stats
+    import gammapy.stats as gstats
 
-   x_bins = np.arange(0, 100)
-   mu_bins = np.linspace(0, 50, 50 / 0.005 + 1, endpoint=True)
+    x_bins = np.arange(0, 100)
+    mu_bins = np.linspace(0, 50, 50 / 0.005 + 1, endpoint=True)
 
-   matrix = [stats.poisson(mu + 3).pmf(x_bins) for mu in mu_bins]
-   acceptance_intervals = gstats.fc_construct_acceptance_intervals_pdfs(matrix, 0.9)
-   LowerLimitNum, UpperLimitNum, _ = gstats.fc_get_limits(mu_bins, x_bins, acceptance_intervals)
-   mu_upper_limit = gstats.fc_find_limit(6, UpperLimitNum, mu_bins)
+    matrix = [stats.poisson(mu + 3).pmf(x_bins) for mu in mu_bins]
+    acceptance_intervals = gstats.fc_construct_acceptance_intervals_pdfs(matrix, 0.9)
+    LowerLimitNum, UpperLimitNum, _ = gstats.fc_get_limits(mu_bins, x_bins, acceptance_intervals)
+    mu_upper_limit = gstats.fc_find_limit(6, UpperLimitNum, mu_bins)
 
 The result is ``mu_upper_limit == 8.465``.
 
@@ -110,10 +107,10 @@ Using `gammapy.stats`
 =====================
 
 .. toctree::
-   :maxdepth: 1
+    :maxdepth: 1
 
-   feldman_cousins
-   fit_statistics
+    feldman_cousins
+    fit_statistics
 
 Reference/API
 =============

--- a/docs/stats/plot_fc_gauss.py
+++ b/docs/stats/plot_fc_gauss.py
@@ -1,6 +1,8 @@
-"""Compute numerical solution for Gaussian with a
-   boundary at the origin. Produces Fig. 10 from
-   the Feldman Cousins paper."""
+"""
+Compute numerical solution for Gaussian with a boundary at the origin.
+
+Produces Fig. 10 from the Feldman & Cousins paper.
+"""
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.stats import norm

--- a/docs/stats/plot_fc_poisson.py
+++ b/docs/stats/plot_fc_poisson.py
@@ -1,10 +1,11 @@
-"""Compute numerical solution for Poisson with
-   background. Produces Fig. 7 from the Feldman
-   Cousins paper."""
+"""
+Compute numerical solution for Poisson with background.
+
+Produces Fig. 7 from the Feldman & Cousins paper.
+"""
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.stats import poisson
-
 from gammapy.stats import (
     fc_construct_acceptance_intervals_pdfs,
     fc_get_limits,

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -9,13 +9,9 @@ Time analysis (``time``)
 Introduction
 ============
 
-`gammapy.time` contains methods for timing analysis.
-
-There is also `gammapy.utils.time`, which contains low-level helper functions
-for time conversions e.g. following the
-
-At the moment there isn't a lot of functionality yet ... contributions welcome!
-
+`gammapy.time` contains methods for time-based analysis, e.g. from AGN, binaries
+or pulsars. There is also `gammapy.utils.time`, which contains low-level helper
+functions for time conversions e.g. following the
 
 Getting Started
 ===============
@@ -27,38 +23,37 @@ Lightcurve
 
 This section introduces the `~gammapy.time.LightCurve` class.
 
-Read a table that contains a lightcurve:
+Read a table that contains a lightcurve::
 
->>> from astropy.table import Table
->>> url = 'https://github.com/gammapy/gamma-cat/raw/master/input/data/2006/2006A%2526A...460..743A/tev-000119-lc.ecsv'
->>> table = Table.read(url, format='ascii.ecsv')
+    >>> from astropy.table import Table
+    >>> url = 'https://github.com/gammapy/gamma-cat/raw/master/input/data/2006/2006A%2526A...460..743A/tev-000119-lc.ecsv'
+    >>> table = Table.read(url, format='ascii.ecsv')
 
 Create a ``LightCurve`` object:
 
->>> from gammapy.time import LightCurve
->>> lc = LightCurve(table)
+    >>> from gammapy.time import LightCurve
+    >>> lc = LightCurve(table)
 
-``LightCurve`` is a simple container that stores the LC table,
-and provices a few conveniences, like creating time objects
-and a quick-look plot:
+``LightCurve`` is a simple container that stores the LC table, and provices a
+few conveniences, like creating time objects and a quick-look plot:
 
->>> lc.time[:2].iso
-['2004-05-23 01:47:08.160' '2004-05-23 02:17:31.200']
->>> lc.plot()
+    >>> lc.time[:2].iso
+    ['2004-05-23 01:47:08.160' '2004-05-23 02:17:31.200']
+    >>> lc.plot()
 
 .. _time-variability:
 
 Variability test
 ----------------
 
-The `~gammapy.time.exptest` function can be used to compute the significance
-of variability (compared to the null hypothesis of constant rate)
-for a list of event time differences.
+The `~gammapy.time.exptest` function can be used to compute the significance of
+variability (compared to the null hypothesis of constant rate) for a list of
+event time differences.
 
-Here's an example how to use the `~gammapy.time.random_times` helper
-function to simulate a `~astropy.time.TimeDelta` array for a given constant rate
-and use `~gammapy.time.exptest` to assess the level of variability (0.11 sigma in this case,
-not variable):
+Here's an example how to use the `~gammapy.time.random_times` helper function to
+simulate a `~astropy.time.TimeDelta` array for a given constant rate and use
+`~gammapy.time.exptest` to assess the level of variability (0.11 sigma in this
+case, not variable):
 
 .. code-block:: python
 
@@ -69,7 +64,6 @@ not variable):
     >>> mr = exptest(time_delta)
     >>> print(mr)
     0.11395763079
-
 
 See ``examples/example_exptest.py`` for a longer example.
 
@@ -82,14 +76,13 @@ TODO: apply this to the 2FHL events and check which sources are variable as a ni
     events = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz ', hdu='EVENTS')
     # TODO: cone select events for 2FHL catalog sources, compute mr for each and print 10 most variable sources
 
-
 Other codes
 ===========
 
-Where possible we shouldn't duplicate timing analysis functionality
-that's already available elsewhere. In some cases it's enough to refer
-gamma-ray astronomers to other packages, sometimes a convenience wrapper for
-our data formats or units might make sense.
+Where possible we shouldn't duplicate timing analysis functionality that's
+already available elsewhere. In some cases it's enough to refer gamma-ray
+astronomers to other packages, sometimes a convenience wrapper for our data
+formats or units might make sense.
 
 Some references (please add what you find useful
 
@@ -106,6 +99,7 @@ Some references (please add what you find useful
 
 Content
 =======
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/time/period.rst
+++ b/docs/time/period.rst
@@ -8,33 +8,38 @@ Period detection and plotting
 Introduction
 ============
 
-`~gammapy.time` provides methods for period detection in time series,
-i.e. light curves of :math:`\gamma`-ray sources.
-The period detection is implemented in the scope of the Lomb-Scargle periodogram,
-a method that detects periods in unevenly sampled time series typical for :math:`\gamma`-ray observations.
-We refer to the `astropy.stats.LombScargle`-class and documentation within
-for an introduction to the Lomb-Scargle algorithm, interpretation and usage [1]_.
+`~gammapy.time` provides methods for period detection in time series, i.e. light
+curves of :math:`\gamma`-ray sources. The period detection is implemented in the
+scope of the Lomb-Scargle periodogram, a method that detects periods in unevenly
+sampled time series typical for :math:`\gamma`-ray observations. We refer to the
+`astropy.stats.LombScargle`-class and documentation within for an introduction
+to the Lomb-Scargle algorithm, interpretation and usage [1]_.
 
-With `~gammapy.time.robust_periodogram`, the analysis is extended to a more general case where
-the unevenly sampled time series is contaminated by outliers, i.e. due to the source's high states.
-This robust periodogram includes the naive Lomb-Scargle implementation as a special case.
+With `~gammapy.time.robust_periodogram`, the analysis is extended to a more
+general case where the unevenly sampled time series is contaminated by outliers,
+i.e. due to the source's high states. This robust periodogram includes the naive
+Lomb-Scargle implementation as a special case.
 
-`~gammapy.time.robust_periodogram` returns the periodogram of the input.
-This is done by fitting a single sinusoidal model to the light curve and
-computing a normalised :math:`\chi^2`-statistic for each period of interest.
-The Lomb-Scargle algorithm uses a naive least square regression and thus, is sensitive to outliers in the light curve.
-Contrary, `~gammapy.time.robust_periodogram` uses different loss functions that account for outliers [2]_.
-The location of the highest periodogram peak is assumed to be the period of an intrinsic periodic behaviour.
+`~gammapy.time.robust_periodogram` returns the periodogram of the input. This is
+done by fitting a single sinusoidal model to the light curve and computing a
+normalised :math:`\chi^2`-statistic for each period of interest. The
+Lomb-Scargle algorithm uses a naive least square regression and thus, is
+sensitive to outliers in the light curve. Contrary,
+`~gammapy.time.robust_periodogram` uses different loss functions that account
+for outliers [2]_. The location of the highest periodogram peak is assumed to be
+the period of an intrinsic periodic behaviour.
 
-The result's significance can be estimated in terms of a false alarm probability (FAP)
-with the respective function of the `astropy.stats.LombScargle`-class.
-It computes the probability of the highest periodogram peak being observed by chance
-if the underlying light curve would consist of Gaussian white-noise only.
+The result's significance can be estimated in terms of a false alarm probability
+(FAP) with the respective function of the `astropy.stats.LombScargle`-class. It
+computes the probability of the highest periodogram peak being observed by
+chance if the underlying light curve would consist of Gaussian white-noise only.
 
-Both, periodogram and light curve can be plotted with `~gammapy.time.plot_periodogram`.
+Both, periodogram and light curve can be plotted with
+`~gammapy.time.plot_periodogram`.
 
-See the `astropy`-docs for more details about the Lomb-Scargle periodogram and its false alarm probability [1]_.
-The loss functions for the robust periodogram are provided by `scipy.optimize.least_squares` [2]_.
+See the `astropy`-docs for more details about the Lomb-Scargle periodogram and
+its false alarm probability [1]_. The loss functions for the robust periodogram
+are provided by `scipy.optimize.least_squares` [2]_.
 
 Getting Started
 ===============
@@ -42,8 +47,9 @@ Getting Started
 Basic Usage
 -----------
 
-`~gammapy.time.robust_periodogram` takes a light curve with data format ``time`` and ``flux`` as input.
-It returns the period grid, the periodogram peaks and the location of the highest periodogram peak.
+`~gammapy.time.robust_periodogram` takes a light curve with data format ``time``
+and ``flux`` as input. It returns the period grid, the periodogram peaks and the
+location of the highest periodogram peak.
 
 .. code-block:: python
 
@@ -55,13 +61,15 @@ It returns the period grid, the periodogram peaks and the location of the highes
     >>> periodogram['best_period']
     0.99
 
-The returned period diverges from the true period of :math:`P = 1`,
-since this period is not contained in the linear period grid automatically computed by `~gammapy.time.robust_periodogram`.
+The returned period diverges from the true period of :math:`P = 1`, since this
+period is not contained in the linear period grid automatically computed by
+`~gammapy.time.robust_periodogram`.
 
 Period Grid
 -----------
 
-The checked periods can be specified optionally by forwarding an array ``periods``.
+The checked periods can be specified optionally by forwarding an array
+``periods``.
 
 .. code-block:: python
 
@@ -70,7 +78,8 @@ The checked periods can be specified optionally by forwarding an array ``periods
     >>> periodogram['best_period']
     1.0
 
-If not given, a linear grid will be computed limited by the length of the light curve and the Nyquist frequency.
+If not given, a linear grid will be computed limited by the length of the light
+curve and the Nyquist frequency.
 
 Measurement Uncertainties
 -------------------------
@@ -89,19 +98,20 @@ They can be forwarded as an array ``flux_err``.
 Loss Function and Loss Scale
 ----------------------------
 
-To obtain a robust periodogram, loss function ``loss`` and loss scale parameter ``scale`` need to be given.
+To obtain a robust periodogram, loss function ``loss`` and loss scale parameter
+``scale`` need to be given.
 
 .. code-block:: python
 
     >>> periodogram = robust_periodogram(time, flux, loss='huber', scale=1)
 
-For available parameters, see [2]_.
-The choice of ``loss`` and ``scale`` depends on the data set and needs to be optimised by the user.
+For available parameters, see [2]_. The choice of ``loss`` and ``scale`` depends
+on the data set and needs to be optimised by the user.
 
-If the loss function ``linear`` is used, `~gammapy.time.robust_periodogram`
-is performed with an ordinary linear least square regression.
-It is then identical to `astropy.stats.LombScargle` and ``scale`` can be set arbitrarily.
-This is the default setting.
+If the loss function ``linear`` is used, `~gammapy.time.robust_periodogram` is
+performed with an ordinary linear least square regression. It is then identical
+to `astropy.stats.LombScargle` and ``scale`` can be set arbitrarily. This is the
+default setting.
 
 .. code-block:: python
 
@@ -112,15 +122,17 @@ This is the default setting.
     >>> np.isclose(periodogram['power'], LSP).all() == True
     True
 
-Also, if ``scale`` is set to infinity, this results in the Lomb-Scargle periodogram for any ``loss``.
-Default settings are recommended if no outliers are expected in the light curve.
+Also, if ``scale`` is set to infinity, this results in the Lomb-Scargle
+periodogram for any ``loss``. Default settings are recommended if no outliers
+are expected in the light curve.
 
 False Alarm Probabilities
 -------------------------
 
-For the determination of peak significance in terms of a false alarm probability, see [1]_ and [7]_.
-Methods for the false alarm probability can be chosen from ``methods`` [3]_.
-The respective modul can be called, for example with the ``Baluev``-method:
+For the determination of peak significance in terms of a false alarm
+probability, see [1]_ and [7]_. Methods for the false alarm probability can be
+chosen from ``methods`` [3]_. The respective modul can be called, for example
+with the ``Baluev``-method:
 
 .. code-block:: python
 
@@ -134,14 +146,16 @@ The respective modul can be called, for example with the ``Baluev``-method:
     >>> fap
     0.0
 
-If other loss functions than ``linear`` are used, using the ``Bootstrap``-method is not recommended,
-because it internally calls `astropy.stats.LombScargle` (linear least square regression) which is not identical to non-linear robust periodogram.
+If other loss functions than ``linear`` are used, using the ``Bootstrap``-method
+is not recommended, because it internally calls `astropy.stats.LombScargle`
+(linear least square regression) which is not identical to non-linear robust
+periodogram.
 
 Plotting
 --------
 
-For plotting, `~gammapy.time.plot_periodogram` can be used.
-It takes the output of `~gammapy.time.robust_periodogram` as input.
+For plotting, `~gammapy.time.plot_periodogram` can be used. It takes the output
+of `~gammapy.time.robust_periodogram` as input.
 
 .. code-block:: python
 
@@ -156,17 +170,18 @@ It takes the output of `~gammapy.time.robust_periodogram` as input.
 Example
 =======
 
-An example of detecting a period with `~gammapy.time.robust_periodogram` is shown in the figure below.
-The code can be found under [4]_.
-The light curve of the X-ray binary LS 5039 is used, observed  in 2005 with H.E.S.S.
-at energies above :math:`0.1 \mathrm{TeV}` [4]_.
-The robust periodogram reveals the period of :math:`P = (3.907 \pm 0.001) \mathrm{d}` in agreement with [5]_ and [6]_.
+An example of detecting a period with `~gammapy.time.robust_periodogram` is
+shown in the figure below. The code can be found under [4]_. The light curve of
+the X-ray binary LS 5039 is used, observed  in 2005 with H.E.S.S. at energies
+above :math:`0.1 \mathrm{TeV}` [4]_. The robust periodogram reveals the period
+of :math:`P = (3.907 \pm 0.001) \mathrm{d}` in agreement with [5]_ and [6]_.
 
 .. gp-extra-image:: time/example_robust_periodogram.png
     :width: 100%
 
-The maximum FAP of the highest periodogram peak is estimated to :math:`4.06e^{-19}` with the :math:`\texttt{Baluev}`-method.
-The other methods return following FAP:
+The maximum FAP of the highest periodogram peak is estimated to
+:math:`4.06e^{-19}` with the :math:`\texttt{Baluev}`-method. The other methods
+return following FAP:
 
 ===========   ===================
 method        FAP
@@ -178,10 +193,11 @@ method        FAP
 `bootstrap`   :math:`0.0`
 ===========   ===================
 
-The plot of the light curve shows no evidence for outliers.
-Thus, :math:`\texttt{linear}` is used as ``loss`` with an arbitrary ``scale`` of :math:`1`.
-As periods, a linear grid is forwarded that is limited by :math:`10 \mathrm{d}` to decrease computation time
-in favour for a higher resolution of :math:`0.001 \mathrm{d}`.
+The plot of the light curve shows no evidence for outliers. Thus,
+:math:`\texttt{linear}` is used as ``loss`` with an arbitrary ``scale`` of
+:math:`1`. As periods, a linear grid is forwarded that is limited by :math:`10
+\mathrm{d}` to decrease computation time in favour for a higher resolution of
+:math:`0.001 \mathrm{d}`.
 
 The periodogram has many spurious peaks, which are due to several factors:
 
@@ -195,9 +211,10 @@ The periodogram has many spurious peaks, which are due to several factors:
    .. gp-extra-image:: time/example_spectral_window_function.png
        :width: 100%
 
-   It shows a prominent peak around one day that arises from the nightly observation cycle.
-   Aliases in the light curve's periodogram, :math:`P_{{alias}}`, are expected to appear at :math:`f_{{true}} + n f_{{window}}`.
-   In terms of periods
+   It shows a prominent peak around one day that arises from the nightly
+   observation cycle. Aliases in the light curve's periodogram,
+   :math:`P_{{alias}}`, are expected to appear at :math:`f_{{true}} + n
+   f_{{window}}`. In terms of periods
 
    .. math::
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -21,7 +21,8 @@ Set up
 
 The Gammapy installation instructions are here: :ref:`install`
 
-One quick way to get set up, that works the same on Linux, Mac and Windows is this:
+One quick way to get set up, that works the same on Linux, Mac and Windows is
+this:
 
 * Install Anaconda or Miniconda (see https://www.anaconda.com/download/ )
 * Get the following repository that contains the Gammapy tutorial notebooks::
@@ -51,23 +52,25 @@ If you have any questions, ask for help. See http://gammapy.org/contact.html
 Execute tutorials online
 ------------------------
 
-If you want, you can execute latest version of the collection of notebooks on-line
-accessing the `Gammapy Binder <http://mybinder.org/repo/gammapy/gammapy-extra>`__ space.
+If you want, you can execute latest version of the collection of notebooks
+on-line accessing the `Gammapy Binder
+<http://mybinder.org/repo/gammapy/gammapy-extra>`__ space.
 
 Click the "launch binder" link here, or at the top of each notebook below:
 
 .. image:: http://mybinder.org/badge.svg
     :target: http://mybinder.org/repo/gammapy/gammapy-extra
 
-Note that this is a free, temporary notebook server. You cannot upload your data or save
-your work there. For that, install Gammapy on your machine and work there.
+Note that this is a free, temporary notebook server. You cannot upload your data
+or save your work there. For that, install Gammapy on your machine and work
+there.
 
 The basics
 ----------
 
-Gammapy is a Python package built on Numpy and Astropy, and the
-tutorials are Jupyter notebooks. If you're already familar with those,
-you can skip to the next section and start learning about Gammapy.
+Gammapy is a Python package built on Numpy and Astropy, and the tutorials are
+Jupyter notebooks. If you're already familar with those, you can skip to the
+next section and start learning about Gammapy.
 
 To learn the basics, here are a few good resources.
 
@@ -157,13 +160,13 @@ To learn how to work with gamma-ray data with Gammapy:
 Extra topics
 ------------
 .. toctree::
-   :hidden:
+    :hidden:
 
-   notebooks/hgps.ipynb
-   notebooks/source_population_model.ipynb
-   notebooks/background_model.ipynb
-   notebooks/cwt.ipynb
-   notebooks/astro_dark_matter.ipynb
+    notebooks/hgps.ipynb
+    notebooks/source_population_model.ipynb
+    notebooks/background_model.ipynb
+    notebooks/cwt.ipynb
+    notebooks/astro_dark_matter.ipynb
 
 These notebooks contain examples on some more specialised functionality in Gammapy.
 
@@ -177,9 +180,9 @@ Work in progress
 ----------------
 
 .. toctree::
-   :hidden:
+    :hidden:
 
-   notebooks/source_population_model.ipynb
+    notebooks/source_population_model.ipynb
 
 The following notebooks are work in progress or broken.
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -9,22 +9,20 @@ Utility functions / classes (``utils``)
 Introduction
 ============
 
-``gammapy.utils`` is a collection of utility functions that are used in many places
-or don't fit in one of the other packages.
+``gammapy.utils`` is a collection of utility functions that are used in many
+places or don't fit in one of the other packages.
 
-Since the various sub-modules of ``gammapy.utils`` are mostly unrelated,
-they are not imported into the top-level namespace.
-Here are some examples of how to import functionality from the ``gammapy.utils``
-sub-modules:
+Since the various sub-modules of ``gammapy.utils`` are mostly unrelated, they
+are not imported into the top-level namespace. Here are some examples of how to
+import functionality from the ``gammapy.utils`` sub-modules:
 
 .. code-block:: python
 
-   from gammapy.utils.random import sample_sphere
-   sample_sphere(size=10)
+    from gammapy.utils.random import sample_sphere
+    sample_sphere(size=10)
 
-   from gammapy.utils import random
-   random.sample_sphere(size=10)
-
+    from gammapy.utils import random
+    random.sample_sphere(size=10)
 
 .. _time_handling:
 
@@ -49,18 +47,19 @@ Gammapy these are also the recommended format and time scale.
 
 .. warning::
 
-   Actually what's written here is not true.
-   In CTA it hasn't been decided if times will be in ``utc`` or ``tt`` (terrestial time) format.
+   Actually what's written here is not true. In CTA it hasn't been decided if
+   times will be in ``utc`` or ``tt`` (terrestial time) format.
 
    Here's a reminder that this needs to be settled / updated:
    https://github.com/gammapy/gammapy/issues/284
 
 
-When other time formats are needed it's easy to convert, see the
-:ref:`time format section and table in the Astropy docs <astropy:time-format>`.
+When other time formats are needed it's easy to convert, see the :ref:`time
+format section and table in the Astropy docs <astropy:time-format>`.
 
-E.g. sometimes in astronomy the modified Julian date ``mjd`` is used and for passing times to matplotlib
-for plotting the ``plot_date`` format should be used:
+E.g. sometimes in astronomy the modified Julian date ``mjd`` is used and for
+passing times to matplotlib for plotting the ``plot_date`` format should be
+used:
 
 .. code-block:: python
 
@@ -71,43 +70,44 @@ for plotting the ``plot_date`` format should be used:
     >>> time.plot_date
     array([ 729755.00000143,  733773.        ])
 
-Converting to other time scales is also easy, see the
-:ref:`time scale section, diagram and table in the Astropy docs <astropy:time-scale>`.
+Converting to other time scales is also easy, see the :ref:`time scale section,
+diagram and table in the Astropy docs <astropy:time-scale>`.
 
 E.g. when converting celestial (RA/DEC) to horizontal (ALT/AZ) coordinates, the
-`sidereal time <https://en.wikipedia.org/wiki/Sidereal_time>`__ is needed.
-This is done automatically by `astropy.coordinates.AltAz` when the
-`astropy.coordinates.AltAz.obstime` is set with a `~astropy.time.Time` object in any scale,
-no need for explicit time scale transformations in Gammapy
-(although if you do want to explicitly compute it, it's easy, see `here <http://docs.astropy.org/en/latest/time/index.html#sidereal-time>`__).
+`sidereal time <https://en.wikipedia.org/wiki/Sidereal_time>`__ is needed. This
+is done automatically by `astropy.coordinates.AltAz` when the
+`astropy.coordinates.AltAz.obstime` is set with a `~astropy.time.Time` object in
+any scale, no need for explicit time scale transformations in Gammapy (although
+if you do want to explicitly compute it, it's easy, see `here
+<http://docs.astropy.org/en/latest/time/index.html#sidereal-time>`__).
 
-The `Fermi-LAT time systems in a nutshell`_ page gives a good, brief explanation of the differences
-between the relevant time scales ``UT1``, ``UTC`` and ``TT``.
+The `Fermi-LAT time systems in a nutshell`_ page gives a good, brief explanation
+of the differences between the relevant time scales ``UT1``, ``UTC`` and ``TT``.
 
 .. _MET_definition:
 
 Mission elapsed times (MET)
 ---------------------------
 
-[MET]_ time references are times representing UTC seconds after a
-specific origin. Each experiment may have a different MET origin
-that should be included in the header of the corresponding data
-files. For more details see `Fermi-LAT time systems in a nutshell`_.
+[MET]_ time references are times representing UTC seconds after a specific
+origin. Each experiment may have a different MET origin that should be included
+in the header of the corresponding data files. For more details see `Fermi-LAT
+time systems in a nutshell`_.
 
-It's not clear yet how to best implement METs in Gammapy, it's one
-of the tasks here:
-https://github.com/gammapy/gammapy/issues/284
+It's not clear yet how to best implement METs in Gammapy, it's one of the tasks
+here: https://github.com/gammapy/gammapy/issues/284
 
-For now, we use the `gammapy.time.time_ref_from_dict`, `gammapy.time.time_relative_to_ref`
-and `gammapy.time.absolute_time` functions to convert MET floats to `~astropy.time.Time`
-objects via the reference times stored in FITS headers.
+For now, we use the `gammapy.time.time_ref_from_dict`,
+`gammapy.time.time_relative_to_ref` and `gammapy.time.absolute_time` functions
+to convert MET floats to `~astropy.time.Time` objects via the reference times
+stored in FITS headers.
 
 Time differences
 ----------------
 
-TODO: discuss when to use `~astropy.time.TimeDelta` or `~astropy.units.Quantity` or [MET]_ floats and
-where one needs to convert between those and what to watch out for.
-
+TODO: discuss when to use `~astropy.time.TimeDelta` or `~astropy.units.Quantity`
+or [MET]_ floats and where one needs to convert between those and what to watch
+out for.
 
 .. _energy_handling_gammapy:
 
@@ -147,8 +147,8 @@ same functionality plus some convenience functions for fits I/O
 EnergyBounds
 ------------
 
-The EnergyBounds class is a subclass of Energy. Additional functions are available
-e.g. to compute the bin centers
+The EnergyBounds class is a subclass of Energy. Additional functions are
+available e.g. to compute the bin centers
 
 .. code-block:: python
 
@@ -162,7 +162,6 @@ e.g. to compute the bin centers
     >>> center
     <Energy [ 1.15478198, 1.53992653, 2.05352503, 2.73841963, 3.65174127,
               4.86967525, 6.49381632, 8.65964323] GeV>
-
 
 Reference/API
 =============


### PR DESCRIPTION
This PR auto-formats all RST (and the few PY) files in the docs folder.

- Hard-wrap text at 80 chars line length
- Indent consistently with 4 spaces (was a mix of 2, 3, 4 before)
- One blank line between between sections and paragraphs, never zero, or 2+

This is a one-time cleanup. We don't have to be super-strict in preserving this style in RST pages moving forward, especially since it's not technically easy to do without annoying contributors.

I plan to do something similar for the code also, before tagging the v0.8 release: #1423