### PR TITLE
Remove tevcat mask

### DIFF
--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -12,8 +12,10 @@ from ..reflected import ReflectedRegionsFinder, ReflectedRegionsBackgroundEstima
 @pytest.fixture
 def mask():
     """Example mask for testing."""
-    filename = '$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits'
-    return WcsNDMap.read(filename, hdu='EXCLUSION')
+    pos = SkyCoord(83.63, 22.01, unit='deg', frame='icrs')
+    exclusion_region = CircleSkyRegion(pos, Angle(0.3, 'deg'))
+    template_map = WcsNDMap.create(skydir=pos, binsz=0.02, width=10.)
+    return template_map.make_region_mask(exclusion_region, inside=False)
 
 
 @pytest.fixture

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -8,8 +8,6 @@ from regions import CircleSkyRegion
 from ...data import DataStore, ObservationList, ObservationStats
 from ...utils.testing import requires_data, requires_dependency
 from ...background import ReflectedRegionsBackgroundEstimator
-from ...maps import WcsNDMap
-
 
 @pytest.fixture(scope='session')
 def obs_list():
@@ -26,24 +24,17 @@ def on_region():
 
 
 @pytest.fixture(scope='session')
-def mask():
-    return WcsNDMap.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
-
-
-@pytest.fixture(scope='session')
-def stats(on_region, obs_list, mask):
+def stats(on_region, obs_list):
     obs = obs_list[0]
     bge = ReflectedRegionsBackgroundEstimator(on_region=on_region,
-                                              exclusion_mask=mask,
                                               obs_list=obs)
     bg = bge.process(obs)
     return ObservationStats.from_obs(obs, bg)
 
 
 @pytest.fixture(scope='session')
-def stats_stacked(on_region, obs_list, mask):
+def stats_stacked(on_region, obs_list):
     bge = ReflectedRegionsBackgroundEstimator(on_region=on_region,
-                                              exclusion_mask=mask,
                                               obs_list=obs_list)
     bge.run()
 

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -9,7 +9,6 @@ from ...data import DataStore, ObservationTableSummary, ObservationSummary
 from ...data import ObservationStats
 from ...utils.testing import requires_data, requires_dependency
 from ...background import ReflectedRegionsBackgroundEstimator
-from ...maps import WcsNDMap
 
 
 @requires_data('gammapy-extra')
@@ -58,15 +57,12 @@ class TestObservationSummary:
         on_size = 0.3 * u.deg
         on_region = CircleSkyRegion(pos, on_size)
 
-        exclusion_mask = WcsNDMap.read('$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits')
-
         obs_stats_list = []
         for obs_id in obs_ids:
             obs = datastore.obs(obs_id)
             bkg = ReflectedRegionsBackgroundEstimator(
                 on_region=on_region,
                 obs_list=[obs],
-                exclusion_mask=exclusion_mask,
             )
             bkg.run()
             bg_estimate = bkg.result[0]

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -36,13 +36,13 @@ def extraction():
 class TestSpectrumExtraction:
     @pytest.mark.parametrize("pars, results", [
         (dict(containment_correction=False), dict(n_on=172,
-                                                  sigma=24.98,
+                                                  sigma=24.56,
                                                   aeff=549861.8 * u.m ** 2,
                                                   edisp=0.2595896944765074,
                                                   containment=1,
                                                   )),
         (dict(containment_correction=True), dict(n_on=172,
-                                                 sigma=24.98,
+                                                 sigma=24.56,
                                                  aeff=412731.8 * u.m ** 2,
                                                  edisp=0.2595896944765074,
                                                  containment=0.7645777148101338,

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -16,7 +16,6 @@ from ...data import DataStore
 from ...spectrum import SpectrumExtraction
 from ...spectrum.models import PowerLaw
 from ...background import ReflectedRegionsBackgroundEstimator
-from ...maps import WcsNDMap
 from ..lightcurve import LightCurve, LightCurveEstimator
 
 
@@ -159,15 +158,8 @@ def spec_extraction():
     on_region_radius = Angle('0.11 deg')
     on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)
 
-    exclusion_file = '$GAMMAPY_EXTRA/datasets/exclusion_masks/tevcat_exclusion.fits'
-    allsky_mask = WcsNDMap.read(exclusion_file)
-    exclusion_mask = allsky_mask.make_cutout(
-        position=on_region.center,
-        width=Angle('6 deg'),
-    )[0]
     bkg_estimator = ReflectedRegionsBackgroundEstimator(on_region=on_region,
-                                                        obs_list=obs_list,
-                                                        exclusion_mask=exclusion_mask)
+                                                        obs_list=obs_list)
     bkg_estimator.run()
 
     e_reco = EnergyBounds.equal_log_spacing(0.2, 100, 50, unit='TeV')  # fine binning
@@ -263,7 +255,7 @@ def test_lightcurve_adaptative_interval_maker():
         separators=separator)
     assert_allclose(table['significance'] >= 3, True)
     assert_allclose(table['t_start'][5].value, 53343.92371392407, rtol=1e-10)
-    assert_allclose(table['alpha'][5], 0.09090909, rtol=1e-5)
+    assert_allclose(table['alpha'][5], 0.0833333, rtol=1e-5)
     assert_allclose(len(table), 71)
     assert_allclose(table['t_start'][0].value, 53343.92096938292, rtol=1e-10)
     assert_allclose(table['t_stop'][70].value, 53343.97229090575, rtol=1e-10)


### PR DESCRIPTION
TeVCat mask has been removed from tests and a specific mask is created to test the reflected background estimator.