### PR TITLE
Add sherpa fitting backend prototype

### DIFF
--- a/gammapy/utils/fitting/__init__.py
+++ b/gammapy/utils/fitting/__init__.py
@@ -1,3 +1,4 @@
 """Fitting utility functions.
 """
 from .iminuit import *
+from .sherpa import *

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -7,3 +7,47 @@ SHERPA_OPTMETHODS['levmar'] = LevMar()
 SHERPA_OPTMETHODS['simplex'] = NelderMead()
 SHERPA_OPTMETHODS['moncar'] = MonCar()
 SHERPA_OPTMETHODS['gridsearch'] = GridSearch()
+
+
+def fit_sherpa(parameters, function, optimizer='simplex'):
+    """Sherpa optimization wrapper method.
+
+    Parameters
+    ----------
+    parameters : `~gammapy.utils.modeling.ParameterList`
+        Parameter list with starting values.
+    function : callable
+        Likelihood function
+    optimizer : {'levmar', 'simplex', 'moncar', 'gridsearch'}
+        Which optimizer to use for the fit. See
+        http://cxc.cfa.harvard.edu/sherpa/methods/index.html
+        for details on the different options available.
+
+    Returns
+    -------
+    parameters : `~gammapy.utils.modeling.ParameterList`
+        Parameter list with best-fit values
+    """
+    optimizer = SHERPA_OPTMETHODS[optimizer]
+
+    pars = [par.value for par in parameters.parameters]
+    parmins = [par.min for par in parameters.parameters]
+    parmaxes = [par.max for par in parameters.parameters]
+
+    def statfunc(values):
+        parameters.update_values_from_tuple(values)
+        return function(parameters)
+
+    result = optimizer.fit(
+        statfunc=statfunc,
+        pars=pars,
+        parmins=parmins,
+        parmaxes=parmaxes
+    )
+
+    pars_best_fit = result[1]
+
+    for par, value in zip(parameters, pars_best_fit):
+        par.value = value
+
+    return result

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -1,12 +1,38 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
-from sherpa.optmethods import LevMar, NelderMead, MonCar, GridSearch
 
-SHERPA_OPTMETHODS = OrderedDict()
-SHERPA_OPTMETHODS['levmar'] = LevMar()
-SHERPA_OPTMETHODS['simplex'] = NelderMead()
-SHERPA_OPTMETHODS['moncar'] = MonCar()
-SHERPA_OPTMETHODS['gridsearch'] = GridSearch()
+__all__ = [
+    'fit_sherpa',
+]
+
+
+def get_sherpa_optimiser(name):
+    from sherpa.optmethods import LevMar, NelderMead, MonCar, GridSearch
+    return {
+        'levmar': LevMar,
+        'simplex': NelderMead,
+        'moncar': MonCar,
+        'gridsearch': GridSearch,
+    }[name]()
+
+
+class SherpaFunction(object):
+    """Wrapper for Sherpa
+
+    Parameters
+    ----------
+    parameters : `~gammapy.utils.modeling.ParameterList`
+        Parameters with starting values
+    function : callable
+        Likelihood function
+    """
+
+    def __init__(self, function, parameters):
+        self.function = function
+        self.parameters = parameters
+
+    def fcn(self, values):
+        self.parameters.update_values_from_tuple(values)
+        return self.function(self.parameters)
 
 
 def fit_sherpa(parameters, function, optimizer='simplex'):
@@ -28,26 +54,32 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
     parameters : `~gammapy.utils.modeling.ParameterList`
         Parameter list with best-fit values
     """
-    optimizer = SHERPA_OPTMETHODS[optimizer]
+    optimizer = get_sherpa_optimiser(optimizer)
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]
     parmaxes = [par.max for par in parameters.parameters]
 
-    def statfunc(values):
-        parameters.update_values_from_tuple(values)
-        return function(parameters)
+    statfunc = SherpaFunction(function, parameters)
 
     result = optimizer.fit(
-        statfunc=statfunc,
+        statfunc=statfunc.fcn,
         pars=pars,
         parmins=parmins,
-        parmaxes=parmaxes
+        parmaxes=parmaxes,
     )
 
-    pars_best_fit = result[1]
+    result = {
+        'success': result[0],
+        'values': result[1],
+        'statval': result[2],
+        'message': result[3],
+        'info': result[4],  # that's a dict, content varies based on optimiser
+    }
 
-    for par, value in zip(parameters, pars_best_fit):
-        par.value = value
+    result['nfev'] = result['info']['nfev']
+
+    # Copy final results into the parameters object
+    parameters.update_values_from_tuple(result['values'])
 
     return result

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -14,20 +14,21 @@ def fcn(parameters):
     return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2, 0
 
 
+# TODO: levmar doesn't work yet; needs array of statval as return in likelihood
+# optimiser='gridsearch' would require very low tolerance asserts, not added for now
+
 @requires_dependency('sherpa')
-@pytest.mark.parametrize('optimizer', ['gridsearch', 'moncar', 'levmar', 'simplex'])
+@pytest.mark.parametrize('optimizer', ['moncar', 'simplex'])
 def test_sherpa(optimizer):
     pars = ParameterList(
         [Parameter('x', 2.2), Parameter('y', 3.4), Parameter('z', 4.5)]
     )
 
-    result = fit_sherpa(function=fcn, parameters=pars)
-    success, pars_best_fit, statval, message, info = result
+    result = fit_sherpa(function=fcn, parameters=pars, optimizer=optimizer)
 
-    assert success
-    assert message == 'Optimization terminated successfully'
-    assert 'nfev' in info
-    assert_allclose(statval, 0, atol=1e-2)
+    assert result['success']
+    assert result['nfev'] > 10
+    assert_allclose(result['statval'], 0, atol=1e-2)
     assert_allclose(pars['x'].value, 2, rtol=1e-2)
     assert_allclose(pars['y'].value, 3, rtol=1e-2)
     assert_allclose(pars['z'].value, 4, rtol=1e-2)

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -1,9 +1,33 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+from numpy.testing import assert_allclose
 from ...testing import requires_dependency
+from ...modeling import Parameter, ParameterList
+from ..sherpa import fit_sherpa
+
+
+def fcn(parameters):
+    x = parameters['x'].value
+    y = parameters['y'].value
+    z = parameters['z'].value
+    return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2, 0
 
 
 @requires_dependency('sherpa')
-def test_sherpa_wrapper():
-    from ..sherpa import SHERPA_OPTMETHODS
-    assert 'levmar' in SHERPA_OPTMETHODS
+@pytest.mark.parametrize('optimizer', ['gridsearch', 'moncar', 'levmar', 'simplex'])
+def test_sherpa(optimizer):
+    pars = ParameterList(
+        [Parameter('x', 2.2), Parameter('y', 3.4), Parameter('z', 4.5)]
+    )
+
+    result = fit_sherpa(function=fcn, parameters=pars)
+    success, pars_best_fit, statval, message, info = result
+
+    assert success
+    assert message == 'Optimization terminated successfully'
+    assert 'nfev' in info
+    assert_allclose(statval, 0, atol=1e-2)
+    assert_allclose(pars['x'].value, 2, rtol=1e-2)
+    assert_allclose(pars['y'].value, 3, rtol=1e-2)
+    assert_allclose(pars['z'].value, 4, rtol=1e-2)


### PR DESCRIPTION
This PR adds a prototype fitting backend for sherpa. It mainly implements `fit_sherpa` with the same API as `fit_minuit`. One minor problem we have to solve is that the fit statistics function for sherpa is expected to return a tuple `(total_stat, stat_per_bin)`, while the minuit optimizer just needs `total_stat`. 
