### PR TITLE
Minor cleanup of new maps code

### DIFF
--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -14,7 +14,7 @@ def geom():
 
 @pytest.fixture(scope="session")
 def jfact():
-    jfactory = JFactory(ref_geom=geom(), profile=profiles.NFWProfile(), distance=8 * u.kpc)
+    jfactory = JFactory(geom=geom(), profile=profiles.NFWProfile(), distance=8 * u.kpc)
     return jfactory.compute_jfactor()
 
 

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -20,7 +20,7 @@ class JFactory(object):
 
     Parameters
     ----------
-    ref_geom : `~gammapy.maps.WcsGeom`
+    geom : `~gammapy.maps.WcsGeom`
         Reference geometry
     profile : `~gammapy.astro.darkmatter.profiles.DMProfile`
         Dark matter profile
@@ -28,8 +28,8 @@ class JFactory(object):
         Distance to convert angular scale of the map
     """
 
-    def __init__(self, ref_geom, profile, distance):
-        self.ref_geom = ref_geom
+    def __init__(self, geom, profile, distance):
+        self.geom = geom
         self.profile = profile
         self.distance = distance
 
@@ -42,7 +42,7 @@ class JFactory(object):
 
         TODO: Needs to be implemented more efficiently
         """
-        separation = self.ref_geom.separation(self.ref_geom.center_skydir)
+        separation = self.geom.separation(self.geom.center_skydir)
         rmin = separation.rad * self.distance
         rmax = self.distance
         val = [self.profile.integral(_, rmax) for _ in rmin.flatten()]
@@ -59,7 +59,7 @@ class JFactory(object):
 
         """
         diff_jfact = self.compute_differential_jfactor()
-        jfact = diff_jfact * self.ref_geom.to_image().solid_angle()
+        jfact = diff_jfact * self.geom.to_image().solid_angle()
         return jfact
 
 

--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max, n_integration_bins=1):
+def make_map_background_irf(pointing, livetime, bkg, geom, offset_max, n_integration_bins=1):
     """Compute background map from background IRFs.
 
     TODO: Call a method on bkg that returns integral over energy bin directly
@@ -25,7 +25,7 @@ def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max, n_int
         Observation livetime
     bkg : `~gammapy.irf.Background3D`
         Background rate model
-    ref_geom : `~gammapy.maps.WcsGeom`
+    geom : `~gammapy.maps.WcsGeom`
         Reference geometry
     offset_max : `~astropy.coordinates.Angle`
         Maximum field of view offset
@@ -41,9 +41,9 @@ def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max, n_int
     # TODO: properly transform FOV to sky coordinates
     # For now we assume the background is radially symmetric
 
-    energy_axis = ref_geom.axes[0]
+    energy_axis = geom.axes[0]
     # Compute offsets of all pixels
-    map_coord = ref_geom.get_coord()
+    map_coord = geom.get_coord()
     # Retrieve energies from map coordinates
     energy_reco = map_coord[energy_axis.name] * energy_axis.unit
     # TODO: go from SkyCoord to FOV coordinates. Here assume symmetric geometry for fov_lon, fov_lat
@@ -59,7 +59,7 @@ def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max, n_int
             n_integration_bins=n_integration_bins,
         )
 
-    d_omega = ref_geom.solid_angle()
+    d_omega = geom.solid_angle()
     data = (data_int * d_omega * livetime).to('').value
 
     # Put exposure outside offset max to zero
@@ -67,7 +67,7 @@ def make_map_background_irf(pointing, livetime, bkg, ref_geom, offset_max, n_int
     offset = np.sqrt(fov_lon ** 2 + fov_lat ** 2)
     data[:, offset[0, :, :] >= offset_max] = 0
 
-    return WcsNDMap(ref_geom, data=data)
+    return WcsNDMap(geom, data=data)
 
 
 def make_map_background_fov(acceptance_map, counts_map, exclusion_mask):

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -44,7 +44,7 @@ def fill_map_counts(count_map, event_list):
     count_map.fill_by_coord(coord_dict)
 
 
-def make_map_counts(events, ref_geom, pointing, offset_max):
+def make_map_counts(events, geom, pointing, offset_max):
     """Build a WcsNDMap (space - energy) with events from an EventList.
 
     The energy of the events is used for the non-spatial axis.
@@ -53,7 +53,7 @@ def make_map_counts(events, ref_geom, pointing, offset_max):
     ----------
     events : `~gammapy.data.EventList`
         Event list
-    ref_geom : `~gammapy.maps.WcsGeom`
+    geom : `~gammapy.maps.WcsGeom`
         Reference WcsGeom object used to define geometry (space - energy)
     pointing : `~astropy.coordinates.SkyCoord`
         Pointing direction
@@ -65,11 +65,11 @@ def make_map_counts(events, ref_geom, pointing, offset_max):
     cntmap : `~gammapy.maps.WcsNDMap`
         Count cube (3D) in true energy bins
     """
-    counts_map = WcsNDMap(ref_geom)
+    counts_map = WcsNDMap(geom)
     fill_map_counts(counts_map, events)
 
     # Compute and apply FOV offset mask
-    offset = ref_geom.separation(pointing)
+    offset = geom.separation(pointing)
     offset_mask = offset >= offset_max
     counts_map.data[:, offset_mask] = 0
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 
-def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max):
+def make_map_exposure_true_energy(pointing, livetime, aeff, geom, offset_max):
     """Compute exposure WcsNDMap in true energy (i.e. not convolved by Edisp).
 
     Parameters
@@ -19,7 +19,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max
         Livetime
     aeff : `~gammapy.irf.EffectiveAreaTable2D`
         Effective area table
-    ref_geom : `~gammapy.maps.WcsGeom`
+    geom : `~gammapy.maps.WcsGeom`
         Reference WcsGeom object used to define geometry (space - energy)
     offset_max : `~astropy.coordinates.Angle`
         Maximum field of view offset.
@@ -29,12 +29,12 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max
     expmap : `~gammapy.maps.WcsNDMap`
         Exposure cube (3D) in true energy bins
     """
-    offset = ref_geom.separation(pointing)
+    offset = geom.separation(pointing)
 
     # Retrieve energies from WcsNDMap
     # Note this would require a log_center from the geometry
     # Or even better edges, but WcsNDmap does not really allows it.
-    energy = ref_geom.axes[0].center * ref_geom.axes[0].unit
+    energy = geom.axes[0].center * geom.axes[0].unit
 
     exposure = aeff.data.evaluate(offset=offset, energy=energy)
     exposure *= livetime
@@ -50,4 +50,4 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, ref_geom, offset_max
 
     data = exposure.to('m2 s')
 
-    return WcsNDMap(ref_geom, data)
+    return WcsNDMap(geom, data)

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
+from astropy.utils.console import ProgressBar
 from astropy.nddata.utils import PartialOverlapError
+from astropy.coordinates import Angle
 from ..maps import WcsNDMap
 from .counts import make_map_counts
 from .exposure import make_map_exposure_true_energy
@@ -30,7 +32,7 @@ class MapMaker(object):
     """
 
     def __init__(self, ref_geom, offset_max, cutout_mode="trim"):
-        self.offset_max = offset_max
+        self.offset_max = Angle(offset_max)
         self.ref_geom = ref_geom
 
         # We instantiate the end products of the MakeMaps class
@@ -45,7 +47,7 @@ class MapMaker(object):
         self.exclusion_map.data += 1
 
         self.cutout_mode = cutout_mode
-        self.maps={}
+        self.maps = {}
 
     def process_obs(self, obs):
         """Process one observation and add it to the cutout image
@@ -87,7 +89,6 @@ class MapMaker(object):
 
         self._add_cutouts(cutout_slices, counts_obs_map, expo_obs_map, background_obs_map)
 
-
     def _add_cutouts(self, cutout_slices, counts_obs_map, expo_obs_map, acceptance_obs_map):
         """Add current cutout to global maps."""
         self.counts_map.data[cutout_slices] += counts_obs_map.data
@@ -108,15 +109,12 @@ class MapMaker(object):
         -----------
         maps: dict of stacked counts, background and exposure maps.
         """
-
-        from astropy.utils.console import ProgressBar
-
         for obs in ProgressBar(obs_list):
             self.process_obs(obs)
+
         self.maps = {
             'counts_map': self.counts_map,
             'background_map': self.background_map,
             'exposure_map': self.exposure_map
-                }
+        }
         return self.maps
-

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -21,7 +21,7 @@ class MapMaker(object):
 
     Parameters
     ----------
-    ref_geom : `~gammapy.maps.WcsGeom`
+    geom : `~gammapy.maps.WcsGeom`
         Reference image geometry
     offset_max : `~astropy.coordinates.Angle`
         Maximum offset angle
@@ -31,19 +31,19 @@ class MapMaker(object):
         unless you want only fully contained observations to be added to the map
     """
 
-    def __init__(self, ref_geom, offset_max, cutout_mode="trim"):
+    def __init__(self, geom, offset_max, cutout_mode="trim"):
         self.offset_max = Angle(offset_max)
-        self.ref_geom = ref_geom
+        self.geom = geom
 
         # We instantiate the end products of the MakeMaps class
-        self.counts_map = WcsNDMap(self.ref_geom)
+        self.counts_map = WcsNDMap(self.geom)
 
-        self.exposure_map = WcsNDMap(self.ref_geom, unit="m2 s")
+        self.exposure_map = WcsNDMap(self.geom, unit="m2 s")
 
-        self.background_map = WcsNDMap(self.ref_geom)
+        self.background_map = WcsNDMap(self.geom)
 
         # We will need this general exclusion mask for the analysis
-        self.exclusion_map = WcsNDMap(self.ref_geom)
+        self.exclusion_map = WcsNDMap(self.geom)
         self.exclusion_map.data += 1
 
         self.cutout_mode = cutout_mode

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-def make_psf_map(psf, pointing, ref_geom, max_offset):
+def make_psf_map(psf, pointing, geom, max_offset):
     """Make a psf map for a single observation
 
     Expected axes : rad and true energy in this specific order
@@ -25,7 +25,7 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
         the PSF IRF
     pointing : `~astropy.coordinates.SkyCoord`
         the pointing direction
-    ref_geom : `~gammapy.maps.MapGeom`
+    geom : `~gammapy.maps.MapGeom`
         the map geom to be used. It provides the target geometry.
         rad and true energy axes should be given in this specific order.
     max_offset : `~astropy.coordinates.Angle`
@@ -36,14 +36,14 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
     psfmap : `~gammapy.cube.PSFMap`
         the resulting PSF map
     """
-    energy_axis = ref_geom.get_axis_by_name('energy_true')
+    energy_axis = geom.get_axis_by_name('energy_true')
     energy = energy_axis.center * energy_axis.unit
 
-    rad_axis = ref_geom.get_axis_by_name('theta')
+    rad_axis = geom.get_axis_by_name('theta')
     rad = Angle(rad_axis.center, unit=rad_axis.unit)
 
     # Compute separations with pointing position
-    separations = pointing.separation(ref_geom.to_image().get_coord().skycoord)
+    separations = pointing.separation(geom.to_image().get_coord().skycoord)
     valid = np.where(separations < max_offset)
 
     # Compute PSF values
@@ -53,7 +53,7 @@ def make_psf_map(psf, pointing, ref_geom, max_offset):
     psf_values = np.transpose(psf_values, axes=(2, 0, 1))
 
     # Create Map and fill relevant entries
-    psfmap = Map.from_geom(ref_geom, unit='sr-1')
+    psfmap = Map.from_geom(geom, unit='sr-1')
     psfmap.data[:, :, valid[0], valid[1]] += psf_values.to(psfmap.unit).value
 
     return PSFMap(psfmap)

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 from astropy.units import Quantity
 from astropy.coordinates import SkyCoord, Angle
 from ...utils.testing import requires_data
-from ...maps import WcsNDMap
+from ...maps import Map
 from ...irf import Background3D
 from ..background import make_map_background_irf
 
@@ -20,12 +20,8 @@ def bkg_3d():
 
 @pytest.fixture(scope='session')
 def counts_cube():
-    import os
-    filename = os.path.join(
-        os.environ['GAMMAPY_EXTRA'],
-        'datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
-    )
-    return WcsNDMap.read(filename)
+    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
+    return Map.read(filename)
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -6,7 +6,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data
 from ...maps import MapAxis, WcsGeom, HpxGeom, Map
-from ...data import DataStore, EventList
+from ...data import EventList
 from ..counts import fill_map_counts
 
 
@@ -32,9 +32,9 @@ geom_cta_time = {'binsz': 0.02, 'coordsys': 'GAL', 'width': 15 * u.deg,
 # TODO: change the test event list to something that's created from scratch,
 # using values so that it's possible to make simple assert statements on the
 # map data in the tests below, i.e. have pixels that should receive 0, 1 or 2 counts
-def make_test_event_list():
-    ds = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/')
-    return ds.obs(110380).events
+@pytest.fixture(scope='session')
+def events():
+    return EventList.read('$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits')
 
 
 @pytest.fixture(scope='session')
@@ -44,8 +44,7 @@ def evt_2fhl():
 
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize('geom_opts', [geom_cta, geom_cta_time])
-def test_fill_map_counts(geom_opts):
-    events = make_test_event_list()
+def test_fill_map_counts(geom_opts, events):
     geom = WcsGeom.create(**geom_opts)
     cntmap = Map.from_geom(geom)
 

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -30,7 +30,7 @@ def test_make_map_exposure_true_energy(aeff, counts_cube):
         pointing=SkyCoord(83.633, 21.514, unit='deg'),
         livetime='1581.17 s',
         aeff=aeff,
-        ref_geom=counts_cube.geom,
+        geom=counts_cube.geom,
         offset_max=Angle('2.2 deg'),
     )
 

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from astropy.coordinates import SkyCoord, Angle
 from ...utils.testing import requires_data, assert_quantity_allclose
-from ...maps import WcsNDMap
+from ...maps import Map
 from ...irf import EffectiveAreaTable2D
 from ..exposure import make_map_exposure_true_energy
 
@@ -19,26 +19,19 @@ def aeff():
 
 @pytest.fixture(scope='session')
 def counts_cube():
-    import os
-    filename = os.path.join(
-        os.environ['GAMMAPY_EXTRA'],
-        'datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
-    )
-    return WcsNDMap.read(filename)
+    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
+    return Map.read(filename)
 
 
 @requires_data('gammapy-extra')
 def test_make_map_exposure_true_energy(aeff, counts_cube):
-    pointing = SkyCoord(83.633, 21.514, unit='deg')
-    # livetime = Quantity(1581.17, 's')
-    offset_max = Angle(2.2, 'deg')
 
     m = make_map_exposure_true_energy(
-        pointing,
-        '1581.17 s',
-        aeff,
-        counts_cube.geom,
-        offset_max,
+        pointing=SkyCoord(83.633, 21.514, unit='deg'),
+        livetime='1581.17 s',
+        aeff=aeff,
+        ref_geom=counts_cube.geom,
+        offset_max=Angle('2.2 deg'),
     )
 
     assert m.data.shape == (15, 120, 200)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -32,13 +32,11 @@ def exposure(geom):
     filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     aeff = EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
 
-    pointing = SkyCoord(1, 0.5, unit='deg', frame='galactic')
-    livetime = 1 * u.hour
     offset_max = 3 * u.deg
 
     exposure_map = make_map_exposure_true_energy(
-        pointing=pointing,
-        livetime=livetime,
+        pointing=SkyCoord(1, 0.5, unit='deg', frame='galactic'),
+        livetime='1 hour',
         aeff=aeff,
         ref_geom=geom,
         offset_max=offset_max,

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -38,7 +38,7 @@ def exposure(geom):
         pointing=SkyCoord(1, 0.5, unit='deg', frame='galactic'),
         livetime='1 hour',
         aeff=aeff,
-        ref_geom=geom,
+        geom=geom,
         offset_max=offset_max,
     )
     return exposure_map

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -11,24 +11,33 @@ from ..make import MapMaker
 pytest.importorskip('scipy')
 
 
+@pytest.fixture(scope='session')
+def data_store():
+    return DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
+
+
+@pytest.fixture(scope='session')
+def geom():
+    skydir = SkyCoord(266.41681663, -29.00782497, unit="deg")
+    energy_axis = MapAxis.from_edges([0.1, 0.5, 1.5, 3.0, 10.],
+                                     name='energy', unit='TeV', interp='log')
+    return WcsGeom.create(binsz=0.1 * u.deg, skydir=skydir, width=15.0, axes=[energy_axis])
+
+
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("mode, expected", [("trim", 107214.0), ("strict", 53486.0)])
-def test_MapMaker(mode, expected):
-    ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
-    pos_SagA = SkyCoord(266.41681663, -29.00782497, unit="deg", frame="icrs")
-    energy_axis = MapAxis.from_edges([0.1, 0.5, 1.5, 3.0, 10.], name='energy', unit='TeV', interp='log')
-    geom = WcsGeom.create(binsz=0.1 * u.deg, skydir=pos_SagA, width=15.0, axes=[energy_axis])
+def test_map_maker(mode, expected, data_store, geom):
     mmaker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
     obs = [110380, 111140]
 
     for obsid in obs:
-        mmaker.process_obs(ds.obs(obsid))
+        mmaker.process_obs(data_store.obs(obsid))
 
     assert mmaker.exposure_map.unit == "m2 s"
     assert_quantity_allclose(mmaker.counts_map.data.sum(), expected)
 
     maker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
-    obslist = ds.obs_list(obs)
+    obslist = data_store.obs_list(obs)
     maps = maker.run(obslist)
 
     assert maps['exposure_map'].unit == "m2 s"

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -27,7 +27,7 @@ def geom():
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("mode, expected", [("trim", 107214.0), ("strict", 53486.0)])
 def test_map_maker(mode, expected, data_store, geom):
-    mmaker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
+    mmaker = MapMaker(geom, '6 deg', cutout_mode=mode)
     obs = [110380, 111140]
 
     for obsid in obs:
@@ -36,7 +36,7 @@ def test_map_maker(mode, expected, data_store, geom):
     assert mmaker.exposure_map.unit == "m2 s"
     assert_quantity_allclose(mmaker.counts_map.data.sum(), expected)
 
-    maker = MapMaker(geom, 6.0 * u.deg, cutout_mode=mode)
+    maker = MapMaker(geom, '6 deg', cutout_mode=mode)
     obslist = data_store.obs_list(obs)
     maps = maker.run(obslist)
 


### PR DESCRIPTION
This PR does some minor cleanup of the new maps code.

It contains three commits that should be easy to review each.

I'm merging this now, because I don't think there's anything controversial here, and I'd like to start a PR with real changes to the map making functions, and there the diff should be easy to review.

One change I made was to put "geom" consistently as argument name for functions that take a geometry as input, removing the "_ref" in some cases. I think the "_ref" was a relict of us previously having to pass around "image_ref" and "cube_ref" objects, to indicate that only the geometry, not the pixel data should be used. Now, we can just say make_some_map(geom) and it's IMO clear that one is asking for a map with that geom, no "_ref" needed. We already had this in places, now it's consistent throughout Gammapy.

@registerrier - Feel free to make suggestions any tonight or tomorrow if you think something should be done differently.