### PR TITLE
Improve reflected background region finder

### DIFF
--- a/docs/background/make_reflected_regions.py
+++ b/docs/background/make_reflected_regions.py
@@ -18,6 +18,7 @@ radius = Angle(0.3, 'deg')
 on_region = CircleSkyRegion(pos, radius)
 center = SkyCoord(83.633, 24, unit='deg')
 
+# One can impose a minimal distance between ON region and first reflected regions
 finder = ReflectedRegionsFinder(
     region=on_region,
     center=center,
@@ -25,5 +26,34 @@ finder = ReflectedRegionsFinder(
     min_distance_input='0.2 rad',
 )
 finder.run()
-finder.plot()
+
+fig1=plt.figure(1)
+finder.plot(fig=fig1)
+
+# One can impose a minimal distance between two adjacent regions
+finder = ReflectedRegionsFinder(
+    region=on_region,
+    center=center,
+    exclusion_mask=exclusion_mask,
+    min_distance_input='0.2 rad',
+    min_distance='0.1 rad'
+)
+finder.run()
+fig2=plt.figure(2)
+finder.plot(fig=fig2)
+
+# One can impose a maximal number of regions to be extracted
+finder = ReflectedRegionsFinder(
+    region=on_region,
+    center=center,
+    exclusion_mask=exclusion_mask,
+    min_distance_input='0.2 rad',
+    max_region_number=5,
+    min_distance='0.1 rad'
+)
+finder.run()
+fig3 = plt.figure(3)
+finder.plot(fig=fig3)
+
+
 plt.show()

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -80,7 +80,7 @@ class ReflectedRegionsFinder(object):
     center : `~astropy.coordinates.SkyCoord`
         Rotation point
     angle_increment : `~astropy.coordinates.Angle`, optional
-        Rotation angle for each step
+        Rotation angle applied when a region falls in an excluded region.
     min_distance : `~astropy.coordinates.Angle`, optional
         Minimal distance between to reflected regions
     min_distance_input : `~astropy.coordinates.Angle`, optional
@@ -111,7 +111,12 @@ class ReflectedRegionsFinder(object):
                  min_distance_input='0.1 rad', exclusion_mask=None):
         self.region = region
         self.center = center
-        self.angle_increment = Angle(angle_increment)
+
+        if angle_increment < Angle(1,'deg'):
+            self.angle_increment = Angle(angle_increment)
+        else:
+            raise ValueError("ReflectedRegionsFinder: the angle_increment parameter is too small.")
+
         self.min_distance = Angle(min_distance)
         self.min_distance_input = Angle(min_distance_input)
         self.exclusion_mask = exclusion_mask

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -115,9 +115,8 @@ class ReflectedRegionsFinder(object):
         self.region = region
         self.center = center
 
-        if angle_increment > Angle(1,'deg'):
-            self.angle_increment = Angle(angle_increment)
-        else:
+        self.angle_increment = Angle(angle_increment)
+        if self.angle_increment < Angle(1,'deg'):
             raise ValueError("ReflectedRegionsFinder: the angle_increment parameter is too small.")
 
         self.min_distance = Angle(min_distance)

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -14,8 +14,8 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
-def _compute_distance_image(mask_map):
 
+def _compute_distance_image(mask_map):
     """Distance to nearest exclusion region.
 
     Compute distance image, i.e. the Euclidean (=Cartesian 2D)
@@ -110,13 +110,13 @@ class ReflectedRegionsFinder(object):
 
     def __init__(self, region, center,
                  angle_increment='0.1 rad', min_distance='0 rad',
-                 min_distance_input='0.1 rad', max_region_number=None,
+                 min_distance_input='0.1 rad', max_region_number=10000,
                  exclusion_mask=None):
         self.region = region
         self.center = center
 
         self.angle_increment = Angle(angle_increment)
-        if self.angle_increment < Angle(1,'deg'):
+        if self.angle_increment < Angle(1, 'deg'):
             raise ValueError("ReflectedRegionsFinder: the angle_increment parameter is too small.")
 
         self.min_distance = Angle(min_distance)
@@ -193,13 +193,12 @@ class ReflectedRegionsFinder(object):
                 log.debug('Placing reflected region\n{}'.format(refl_region))
                 reflected_regions.append(refl_region)
                 curr_angle = curr_angle + self._min_ang
+                if self.max_region_number <= len(reflected_regions):
+                    break
             else:
                 curr_angle = curr_angle + self.angle_increment
 
         log.debug('Found {} reflected regions'.format(len(reflected_regions)))
-        if self.max_region_number is not None:
-            nreg = min(len(reflected_regions),self.max_region_number)
-            reflected_regions = reflected_regions[:nreg]
         self.reflected_regions = reflected_regions
 
     def plot(self, fig=None, ax=None):

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -85,6 +85,8 @@ class ReflectedRegionsFinder(object):
         Minimal distance between to reflected regions
     min_distance_input : `~astropy.coordinates.Angle`, optional
         Minimal distance from input region
+    max_region_number : int, optional
+        Maximum number of regions to use
     exclusion_mask : `~gammapy.maps.WcsNDMap`, optional
         Exclusion mask
 
@@ -108,11 +110,12 @@ class ReflectedRegionsFinder(object):
 
     def __init__(self, region, center,
                  angle_increment='0.1 rad', min_distance='0 rad',
-                 min_distance_input='0.1 rad', exclusion_mask=None):
+                 min_distance_input='0.1 rad', max_region_number=None,
+                 exclusion_mask=None):
         self.region = region
         self.center = center
 
-        if angle_increment < Angle(1,'deg'):
+        if angle_increment > Angle(1,'deg'):
             self.angle_increment = Angle(angle_increment)
         else:
             raise ValueError("ReflectedRegionsFinder: the angle_increment parameter is too small.")
@@ -120,7 +123,7 @@ class ReflectedRegionsFinder(object):
         self.min_distance = Angle(min_distance)
         self.min_distance_input = Angle(min_distance_input)
         self.exclusion_mask = exclusion_mask
-
+        self.max_region_number = max_region_number
         self.reflected_regions = None
 
     def run(self):
@@ -195,6 +198,9 @@ class ReflectedRegionsFinder(object):
                 curr_angle = curr_angle + self.angle_increment
 
         log.debug('Found {} reflected regions'.format(len(reflected_regions)))
+        if self.max_region_number is not None:
+            nreg = min(len(reflected_regions),self.max_region_number)
+            reflected_regions = reflected_regions[:nreg]
         self.reflected_regions = reflected_regions
 
     def plot(self, fig=None, ax=None):

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -63,6 +63,12 @@ def test_find_reflected_regions(mask, on_region):
     assert len(regions) == 16
     assert_quantity_allclose(regions[3].center.icrs.ra, Angle('83.674 deg'), rtol=1e-2)
 
+    # Test with maximum number of regions
+    fregions.max_region_number = 5
+    fregions.run()
+    regions = fregions.reflected_regions
+    assert len(regions) == 5
+
 
 @pytest.fixture
 def bkg_estimator():


### PR DESCRIPTION
this PR proposes a solution to issue #1449 by adding an optional parameter to take only the first `max_region_number` regions that come out of the algorithm. 

The PR also corrects a bug that could allow the user to create an infinite loop by passing an `increment_angle` equal to 0. 

