### PR TITLE
Remove offset_max from map make functions

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-def make_map_background_irf(pointing, livetime, bkg, geom, offset_max, n_integration_bins=1):
+def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1):
     """Compute background map from background IRFs.
 
     TODO: Call a method on bkg that returns integral over energy bin directly
@@ -27,8 +27,6 @@ def make_map_background_irf(pointing, livetime, bkg, geom, offset_max, n_integra
         Background rate model
     geom : `~gammapy.maps.WcsGeom`
         Reference geometry
-    offset_max : `~astropy.coordinates.Angle`
-        Maximum field of view offset
     n_integration_bins : int
             Number of bins used to integrate on each energy range
 
@@ -61,11 +59,6 @@ def make_map_background_irf(pointing, livetime, bkg, geom, offset_max, n_integra
 
     d_omega = geom.solid_angle()
     data = (data_int * d_omega * livetime).to('').value
-
-    # Put exposure outside offset max to zero
-    # This might be more generaly dealt with a mask map
-    offset = np.sqrt(fov_lon ** 2 + fov_lat ** 2)
-    data[:, offset[0, :, :] >= offset_max] = 0
 
     return WcsNDMap(geom, data=data)
 

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ..maps import WcsNDMap
+from ..maps import Map
 
 __all__ = [
     'fill_map_counts',
@@ -44,33 +44,21 @@ def fill_map_counts(count_map, event_list):
     count_map.fill_by_coord(coord_dict)
 
 
-def make_map_counts(events, geom, pointing, offset_max):
-    """Build a WcsNDMap (space - energy) with events from an EventList.
-
-    The energy of the events is used for the non-spatial axis.
+def make_map_counts(events, geom):
+    """Make a counts map for a given geometry.
 
     Parameters
     ----------
     events : `~gammapy.data.EventList`
         Event list
-    geom : `~gammapy.maps.WcsGeom`
-        Reference WcsGeom object used to define geometry (space - energy)
-    pointing : `~astropy.coordinates.SkyCoord`
-        Pointing direction
-    offset_max : `~astropy.coordinates.Angle`
-        Maximum field of view offset.
+    geom : `~gammapy.maps.Geom`
+        Map geometry
 
     Returns
     -------
-    cntmap : `~gammapy.maps.WcsNDMap`
-        Count cube (3D) in true energy bins
+    counts_map : `~gammapy.maps.Map`
+        Counts map
     """
-    counts_map = WcsNDMap(geom)
+    counts_map = Map.from_geom(geom)
     fill_map_counts(counts_map, events)
-
-    # Compute and apply FOV offset mask
-    offset = geom.separation(pointing)
-    offset_mask = offset >= offset_max
-    counts_map.data[:, offset_mask] = 0
-
     return counts_map

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -8,8 +8,11 @@ __all__ = [
 ]
 
 
-def make_map_exposure_true_energy(pointing, livetime, aeff, geom, offset_max):
-    """Compute exposure WcsNDMap in true energy (i.e. not convolved by Edisp).
+def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
+    """Compute exposure map.
+
+     This map has a true energy axis, the exposure is not combined
+     with energy dispersion.
 
     Parameters
     ----------
@@ -21,8 +24,6 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, offset_max):
         Effective area table
     geom : `~gammapy.maps.WcsGeom`
         Reference WcsGeom object used to define geometry (space - energy)
-    offset_max : `~astropy.coordinates.Angle`
-        Maximum field of view offset.
 
     Returns
     -------
@@ -43,10 +44,6 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom, offset_max):
     # TODO: call np.atleast_3d ?
     if len(exposure.shape) < 3:
         exposure = np.expand_dims(exposure.value, 0) * exposure.unit
-
-    # Put exposure outside offset max to zero
-    # This might be more generaly dealt with a mask map
-    exposure[:, offset >= offset_max] = 0
 
     data = exposure.to('m2 s')
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -83,7 +83,7 @@ class MapMaker(object):
 
         acceptance_obs_map = make_map_background_irf(
             obs.pointing_radec, obs.observation_live_time_duration,
-            obs.bkg, cutout_geom, self.offset_max,
+            obs.bkg, cutout_geom
         )
         acceptance_obs_map.data[:, offset_mask] = 0
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -72,9 +72,7 @@ class MapMaker(object):
         offset = exclusion_mask_cutout.geom.separation(obs.pointing_radec)
         offset_mask = offset >= self.offset_max
 
-        counts_obs_map = make_map_counts(
-            obs.events, cutout_geom, obs.pointing_radec, self.offset_max,
-        )
+        counts_obs_map = make_map_counts(obs.events, cutout_geom)
         counts_obs_map.data[:, offset_mask] = 0
 
         expo_obs_map = make_map_exposure_true_energy(

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -77,7 +77,7 @@ class MapMaker(object):
 
         expo_obs_map = make_map_exposure_true_energy(
             obs.pointing_radec, obs.observation_live_time_duration,
-            obs.aeff, cutout_geom, self.offset_max,
+            obs.aeff, cutout_geom
         )
         expo_obs_map.data[:, offset_mask] = 0
 

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -28,17 +28,11 @@ def counts_cube():
 def test_make_map_fov_background(bkg_3d, counts_cube):
     pointing = SkyCoord(83.633, 21.514, unit='deg')
     livetime = Quantity(1581.17, 's')
-    offset_max = Angle(2.2, 'deg')
 
     m = make_map_background_irf(
-        pointing, livetime, bkg_3d, counts_cube.geom, offset_max,
+        pointing, livetime, bkg_3d, counts_cube.geom
     )
 
     assert m.data.shape == (15, 120, 200)
     assert_allclose(m.data[0, 0, 0], 0.013959, rtol=1e-4)
-    assert_allclose(m.data.sum(), 1356.2551, rtol=1e-5)
-
-    # TODO: Check that `offset_max` is working properly
-    # pos = SkyCoord(85.6, 23, unit='deg')
-    # val = bkg_cube.lookup(pos, energy=1 * u.TeV)
-    # assert_allclose(val, 0)
+    assert_allclose(m.data.sum(), 1408.573698, rtol=1e-5)

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
-from astropy.coordinates import SkyCoord, Angle
+from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_data, assert_quantity_allclose
 from ...maps import Map
 from ...irf import EffectiveAreaTable2D
@@ -31,7 +31,6 @@ def test_make_map_exposure_true_energy(aeff, counts_cube):
         livetime='1581.17 s',
         aeff=aeff,
         geom=counts_cube.geom,
-        offset_max=Angle('2.2 deg'),
     )
 
     assert m.data.shape == (15, 120, 200)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -32,14 +32,11 @@ def exposure(geom):
     filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
     aeff = EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
 
-    offset_max = 3 * u.deg
-
     exposure_map = make_map_exposure_true_energy(
         pointing=SkyCoord(1, 0.5, unit='deg', frame='galactic'),
         livetime='1 hour',
         aeff=aeff,
         geom=geom,
-        offset_max=offset_max,
     )
     return exposure_map
 

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
+from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from ...utils.testing import assert_quantity_allclose, requires_data
+from ...utils.testing import requires_data
 from ...data import DataStore
 from ...maps import WcsGeom, MapAxis
 from ..make import MapMaker
@@ -12,8 +13,10 @@ pytest.importorskip('scipy')
 
 
 @pytest.fixture(scope='session')
-def data_store():
-    return DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
+def obs_list():
+    data_store = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/")
+    obs_id = [110380, 111140]
+    return data_store.obs_list(obs_id)
 
 
 @pytest.fixture(scope='session')
@@ -25,20 +28,32 @@ def geom():
 
 
 @requires_data('gammapy-extra')
-@pytest.mark.parametrize("mode, expected", [("trim", 107214.0), ("strict", 53486.0)])
-def test_map_maker(mode, expected, data_store, geom):
-    mmaker = MapMaker(geom, '6 deg', cutout_mode=mode)
-    obs = [110380, 111140]
+@pytest.mark.parametrize("pars", [
+    {
+        'mode': 'trim',
+        'counts': 107214,
+        'exposure': 9.582158e+13,
+        'background': 107214.016,
+    },
+    {
+        'mode': 'strict',
+        'counts': 53486,
+        'exposure': 4.794064e+13,
+        'background': 53486,
+    },
+])
+def test_map_maker(pars, obs_list, geom):
+    maker = MapMaker(geom, '6 deg', cutout_mode=pars['mode'])
+    maps = maker.run(obs_list)
 
-    for obsid in obs:
-        mmaker.process_obs(data_store.obs(obsid))
+    counts = maps['counts_map']
+    assert counts.unit == ""
+    assert_allclose(counts.data.sum(), pars['counts'], rtol=1e-5)
 
-    assert mmaker.exposure_map.unit == "m2 s"
-    assert_quantity_allclose(mmaker.counts_map.data.sum(), expected)
+    exposure = maps['exposure_map']
+    assert exposure.unit == "m2 s"
+    assert_allclose(exposure.data.sum(), pars['exposure'], rtol=1e-5)
 
-    maker = MapMaker(geom, '6 deg', cutout_mode=mode)
-    obslist = data_store.obs_list(obs)
-    maps = maker.run(obslist)
-
-    assert maps['exposure_map'].unit == "m2 s"
-    assert_quantity_allclose(maps['counts_map'].data.sum(), expected)
+    background = maps['background_map']
+    assert background.unit == ""
+    assert_allclose(background.data.sum(), pars['background'], rtol=1e-5)


### PR DESCRIPTION
This PR removes the offset_max argument from the functions that make maps.
Instead the mask is computed once and applied to each map in the MapMaker.

@registerrier - OK?

(I'd like to merge this, and continue the work on MapMaker in follow-up PRs)