### PR TITLE
Improve make_exposure_map tests

### DIFF
--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -23,12 +23,12 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
     aeff : `~gammapy.irf.EffectiveAreaTable2D`
         Effective area
     geom : `~gammapy.maps.WcsGeom`
-        Reference WcsGeom object used to define geometry (space - energy)
+        Map geometry (must have an energy axis)
 
     Returns
     -------
-    expmap : `~gammapy.maps.WcsNDMap`
-        Exposure cube (3D) in true energy bins
+    map : `~gammapy.maps.WcsNDMap`
+        Exposure map
     """
     offset = geom.separation(pointing)
     energy = geom.axes[0].center * geom.axes[0].unit

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_data
@@ -19,23 +18,35 @@ def aeff():
     return EffectiveAreaTable2D.read(filename, hdu='AEFF_2D')
 
 
-def geom(ebounds):
+def geom(map_type, ebounds):
     axis = MapAxis.from_edges(ebounds, name="energy", unit='TeV')
-    return WcsGeom.create(npix=(4, 3), binsz=2, axes=[axis])
+    if map_type == 'wcs':
+        return WcsGeom.create(npix=(4, 3), binsz=2, axes=[axis])
+    elif map_type == 'hpx':
+        return HpxGeom(256, axes=[axis])
+    else:
+        raise ValueError()
 
 
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("pars", [
     {
-        'geom': geom(ebounds=[0.1, 1, 10]),
+        'geom': geom(map_type='wcs', ebounds=[0.1, 1, 10]),
         'shape': (2, 3, 4),
         'sum': 85420535.474238,
     },
     {
-        'geom': geom(ebounds=[0.1, 10]),
+        'geom': geom(map_type='wcs', ebounds=[0.1, 10]),
         'shape': (1, 3, 4),
         'sum': 66133814.978884,
     },
+    # TODO: make this work for HPX
+    # 'HpxGeom' object has no attribute 'separation'
+    # {
+    #     'geom': geom(map_type='hpx', ebounds=[0.1, 1, 10]),
+    #     'shape': (1, 3, 4),
+    #     'sum': 66133814.978884,
+    # },
 ])
 def test_make_map_exposure_true_energy(aeff, pars):
     m = make_map_exposure_true_energy(


### PR DESCRIPTION
This PR is a little improvement to the make_exposure_map tests.

It uses a custom geom instead of reading a counts cube to get a geom from disk.

It also parametrises the test to have one that shows that it works with a single energy bin.

I also wanted to add a test showing that it works for HPX, but didn't succeed. For that, the `separation` method has to be added there first, and the coord interface for IRF evaluation improved.

Merging this now.