### PR TITLE
Better test case for MapMaker

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -32,6 +32,9 @@ class MapMaker(object):
     """
 
     def __init__(self, geom, offset_max, cutout_mode="trim"):
+        if geom.is_image:
+            raise ValueError('MapMaker only works with geom with an energy axis')
+
         self.geom = geom
         self.offset_max = Angle(offset_max)
 

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -19,31 +19,36 @@ def obs_list():
     return data_store.obs_list(obs_id)
 
 
-@pytest.fixture(scope='session')
 def geom():
-    skydir = SkyCoord(266.41681663, -29.00782497, unit="deg")
-    energy_axis = MapAxis.from_edges([0.1, 0.5, 1.5, 3.0, 10.],
-                                     name='energy', unit='TeV', interp='log')
-    return WcsGeom.create(binsz=0.1 * u.deg, skydir=skydir, width=15.0, axes=[energy_axis])
+    skydir = SkyCoord(0, -1, unit="deg", frame='galactic')
+    energy_axis = MapAxis.from_edges([0.1, 1, 10], name='energy', unit='TeV', interp='log')
+    return WcsGeom.create(binsz=0.5 * u.deg, skydir=skydir, width=(10, 5),
+                          coordsys='GAL', axes=[energy_axis])
 
 
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("pars", [
     {
+        'geom': geom(),
         'mode': 'trim',
-        'counts': 107214,
-        'exposure': 9.582158e+13,
-        'background': 107214.016,
+        'counts': 34366,
+        'exposure': 3.99815e+11,
+        'background': 34366,
     },
     {
+        'geom': geom(),
         'mode': 'strict',
-        'counts': 53486,
-        'exposure': 4.794064e+13,
-        'background': 53486,
+        'counts': 21981,
+        'exposure': 2.592941e+11,
+        'background': 21981,
     },
 ])
-def test_map_maker(pars, obs_list, geom):
-    maker = MapMaker(geom, '6 deg', cutout_mode=pars['mode'])
+def test_map_maker(pars, obs_list):
+    maker = MapMaker(
+        geom=pars['geom'],
+        offset_max='2 deg',
+        cutout_mode=pars['mode'],
+    )
     maps = maker.run(obs_list)
 
     counts = maps['counts_map']

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -19,9 +19,9 @@ def obs_list():
     return data_store.obs_list(obs_id)
 
 
-def geom():
+def geom(ebounds):
     skydir = SkyCoord(0, -1, unit="deg", frame='galactic')
-    energy_axis = MapAxis.from_edges([0.1, 1, 10], name='energy', unit='TeV', interp='log')
+    energy_axis = MapAxis.from_edges(ebounds, name='energy', unit='TeV', interp='log')
     return WcsGeom.create(binsz=0.5 * u.deg, skydir=skydir, width=(10, 5),
                           coordsys='GAL', axes=[energy_axis])
 
@@ -29,14 +29,24 @@ def geom():
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("pars", [
     {
-        'geom': geom(),
+        # Default, normal test case
+        'geom': geom(ebounds=[0.1, 1, 10]),
         'mode': 'trim',
         'counts': 34366,
         'exposure': 3.99815e+11,
         'background': 34366,
     },
     {
-        'geom': geom(),
+        # Test single energy bin
+        'geom': geom(ebounds=[0.1, 10]),
+        'mode': 'trim',
+        'counts': 34366,
+        'exposure': 1.16866e+11,
+        'background': 34366,
+    },
+    {
+        # Test strict mode
+        'geom': geom(ebounds=[0.1, 1, 10]),
         'mode': 'strict',
         'counts': 21981,
         'exposure': 2.592941e+11,


### PR DESCRIPTION
This PR changes the MapMaker test case to something a bit simpler, where it's clear that one run is fully contained and the second isn't from this image: http://docs.gammapy.org/dev/notebooks/cta_data_analysis.html#Extraction

I chose big pixels and large energy bins, which means it's fast and we will notice any changes in binning effects in the result numbers that are asserted on.

I also added a geom input validation to give a good error if a user tries to run on an image without a third axis. This fixes #1609 .

Merging this now.