### PR TITLE
Split MapMakerObs from MapMaker

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -63,7 +63,7 @@ def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1)
     return WcsNDMap(geom, data=data)
 
 
-def make_map_background_fov(acceptance_map, counts_map, exclusion_mask):
+def make_map_background_fov(acceptance_map, counts_map, exclusion_mask=None):
     """Build Normalized background map from a given acceptance map and counts map.
 
     This operation is normally performed on single observation maps.
@@ -86,8 +86,11 @@ def make_map_background_fov(acceptance_map, counts_map, exclusion_mask):
     norm_bkg_map : `~gammapy.maps.WcsNDMap`
         Normalized background
     """
-    # We resize the mask
-    mask = np.resize(np.squeeze(exclusion_mask.data), acceptance_map.data.shape)
+    if exclusion_mask is None:
+        mask = np.ones_like(counts_map, dtype=bool)
+    else:
+        # We resize the mask
+        mask = np.resize(np.squeeze(exclusion_mask.data), acceptance_map.data.shape)
 
     # We multiply the data with the mask to obtain normalization factors in each energy bin
     integ_acceptance = np.sum(acceptance_map.data * mask, axis=(1, 2))

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -1,33 +1,57 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ..maps import Map
 
 __all__ = [
     'fill_map_counts',
-    'make_map_counts',
 ]
 
 
-def fill_map_counts(count_map, events):
+def fill_map_counts(counts_map, events):
     """Fill events into a counts map.
 
     The energy of the events is used for a non-spatial axis homogeneous to energy.
-    The other non-spatial axis names should have an entry in the column names of the ``EventList``
+    The other non-spatial axis names should have an entry in the column names of the event list.
 
     Parameters
     ----------
-    count_map : `~gammapy.maps.Map`
+    counts_map : `~gammapy.maps.Map`
         Map object, will be filled by this function.
     events : `~gammapy.data.EventList`
         Event list
-    """
-    geom = count_map.geom
 
+    Examples
+    --------
+    To make a counts map, create an empty map with a geometry of your choice
+    and then fill it using this function::
+
+        from gammapy.maps import Map
+        from gammapy.data import EventList
+        from gammapy.cube import fill_map_counts
+        events = EventList.read('$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits')
+        counts = Map.create(coordsys='GAL', skydir=(0, 0), binsz=0.1, npix=(120, 100))
+        fill_map_counts(counts, events)
+        counts.plot()
+
+    If you have a given map already, and want to make a counts image
+    with the same geometry (not using the pixel data from the original map), do this:
+
+        from gammapy.maps import Map
+        from gammapy.data import EventList
+        from gammapy.cube import fill_map_counts
+        events = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
+        reference_map = Map.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_gc.fits.gz')
+        counts = Map.from_geom(reference_map.geom)
+        fill_map_counts(counts, events)
+        counts.smooth(3).plot()
+
+    It works for IACT and Fermi-LAT events, for WCS or HEALPix map geometries,
+    and also for extra axes. Especially energy axes are automatically handled correctly.
+    """
     # Make a coordinate dictionary; skycoord is always added
     coord_dict = dict(skycoord=events.radec)
 
     # Now add one coordinate for each extra map axis
-    for axis in geom.axes:
+    for axis in counts_map.geom.axes:
         if axis.type == 'energy':
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict[axis.name] = events.energy.to(axis.unit)
@@ -41,24 +65,4 @@ def fill_map_counts(count_map, events):
             else:
                 raise ValueError("Cannot find MapGeom axis {!r} in EventList".format(axis.name))
 
-    count_map.fill_by_coord(coord_dict)
-
-
-def make_map_counts(events, geom):
-    """Make a counts map for a given geometry.
-
-    Parameters
-    ----------
-    events : `~gammapy.data.EventList`
-        Event list
-    geom : `~gammapy.maps.Geom`
-        Map geometry
-
-    Returns
-    -------
-    counts_map : `~gammapy.maps.Map`
-        Counts map
-    """
-    counts_map = Map.from_geom(geom)
-    fill_map_counts(counts_map, events)
-    return counts_map
+    counts_map.fill_by_coord(coord_dict)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -61,14 +61,14 @@ def test_map_maker(pars, obs_list):
     )
     maps = maker.run(obs_list)
 
-    counts = maps['counts_map']
+    counts = maps['counts']
     assert counts.unit == ""
     assert_allclose(counts.data.sum(), pars['counts'], rtol=1e-5)
 
-    exposure = maps['exposure_map']
+    exposure = maps['exposure']
     assert exposure.unit == "m2 s"
     assert_allclose(exposure.data.sum(), pars['exposure'], rtol=1e-5)
 
-    background = maps['background_map']
+    background = maps['background']
     assert background.unit == ""
     assert_allclose(background.data.sum(), pars['background'], rtol=1e-5)


### PR DESCRIPTION
This PR split out the per-obs processing from the MapMaker into a separate class MapMakerObs.

The tests show that the result is the same as before.

It also does some other cleanup, e.g. it now stores the maps directly in a dict `maker.maps`, instead of in addition having `maker.counts_map` etc. I think this is better, because previously users had two places to access results, and now there's only one. I.e. a smaller surface that's easier to describe and test.

I also change to call `fill_map_counts` , and remove the `make_map_counts` now as discussed: https://github.com/gammapy/gammapy/issues/1620#issuecomment-409876581

@registerrier - OK?