### PR TITLE
Improve map making test cases

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -28,7 +28,7 @@ def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1)
     geom : `~gammapy.maps.WcsGeom`
         Reference geometry
     n_integration_bins : int
-            Number of bins used to integrate on each energy range
+        Number of bins used to integrate on each energy range
 
     Returns
     -------

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -2,14 +2,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from numpy.testing import assert_allclose
-from astropy.units import Quantity
-from astropy.coordinates import SkyCoord, Angle
+from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_data
-from ...maps import Map
+from ...maps import WcsGeom, HpxGeom, MapAxis
 from ...irf import Background3D
 from ..background import make_map_background_irf
 
 pytest.importorskip('scipy')
+pytest.importorskip('healpy')
 
 
 @pytest.fixture(scope='session')
@@ -18,21 +18,44 @@ def bkg_3d():
     return Background3D.read(filename, hdu='BACKGROUND')
 
 
-@pytest.fixture(scope='session')
-def counts_cube():
-    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hess_events_simulated_023523_cntcube.fits'
-    return Map.read(filename)
+def geom(map_type, ebounds):
+    axis = MapAxis.from_edges(ebounds, name="energy", unit='TeV', interp='log')
+    if map_type == 'wcs':
+        return WcsGeom.create(npix=(4, 3), binsz=2, axes=[axis])
+    elif map_type == 'hpx':
+        return HpxGeom(256, axes=[axis])
+    else:
+        raise ValueError()
 
 
 @requires_data('gammapy-extra')
-def test_make_map_fov_background(bkg_3d, counts_cube):
-    pointing = SkyCoord(83.633, 21.514, unit='deg')
-    livetime = Quantity(1581.17, 's')
-
+@pytest.mark.parametrize("pars", [
+    {
+        'geom': geom(map_type='wcs', ebounds=[0.1, 1, 10]),
+        'shape': (2, 3, 4),
+        'sum': 4760.562826,
+    },
+    {
+        'geom': geom(map_type='wcs', ebounds=[0.1, 10]),
+        'shape': (1, 3, 4),
+        'sum': 49620.735907,
+    },
+    # TODO: make this work for HPX
+    # 'HpxGeom' object has no attribute 'separation'
+    # {
+    #     'geom': geom(map_type='hpx', ebounds=[0.1, 1, 10]),
+    #     'shape': '???',
+    #     'sum': '???',
+    # },
+])
+def test_make_map_background_irf(bkg_3d, pars):
     m = make_map_background_irf(
-        pointing, livetime, bkg_3d, counts_cube.geom
+        pointing=SkyCoord(2, 1, unit='deg'),
+        livetime='42 s',
+        bkg=bkg_3d,
+        geom=pars['geom'],
     )
 
-    assert m.data.shape == (15, 120, 200)
-    assert_allclose(m.data[0, 0, 0], 0.013959, rtol=1e-4)
-    assert_allclose(m.data.sum(), 1408.573698, rtol=1e-5)
+    assert m.data.shape == pars['shape']
+    assert m.unit == ''
+    assert_allclose(m.data.sum(), pars['sum'], rtol=1e-5)

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -14,8 +14,8 @@ pytest.importorskip('healpy')
 
 @pytest.fixture(scope='session')
 def aeff():
-    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz'
-    return EffectiveAreaTable2D.read(filename, hdu='AEFF_2D')
+    filename = '$GAMMAPY_EXTRA/datasets/cta-1dc//caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
+    return EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
 
 
 def geom(map_type, ebounds):
@@ -33,12 +33,12 @@ def geom(map_type, ebounds):
     {
         'geom': geom(map_type='wcs', ebounds=[0.1, 1, 10]),
         'shape': (2, 3, 4),
-        'sum': 54448477.348027,
+        'sum': 8.103974e+08,
     },
     {
         'geom': geom(map_type='wcs', ebounds=[0.1, 10]),
         'shape': (1, 3, 4),
-        'sum': 31219048.597406,
+        'sum': 2.387916e+08,
     },
     # TODO: make this work for HPX
     # 'HpxGeom' object has no attribute 'separation'
@@ -51,9 +51,11 @@ def geom(map_type, ebounds):
 def test_make_map_exposure_true_energy(aeff, pars):
     m = make_map_exposure_true_energy(
         pointing=SkyCoord(2, 1, unit='deg'),
-        livetime='42 s', aeff=aeff, geom=pars['geom'],
+        livetime='42 s',
+        aeff=aeff,
+        geom=pars['geom'],
     )
 
     assert m.data.shape == pars['shape']
     assert m.unit == 'm2 s'
-    assert_allclose(m.data.sum(), pars['sum'])
+    assert_allclose(m.data.sum(), pars['sum'], rtol=1e-5)


### PR DESCRIPTION
This PR improves the map making test cases in gammapy.cube to use the CTA DC1 IRFs instead of old ones from HESS.

I now use the same geom as in the MapMaker, so next I'll refactor MapMaker so that it can only compute an exposure, and should get the same result as from the function.

Merging now.