### PR TITLE
Fix refpix argument handling in WcsGeom.create

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -199,3 +199,10 @@ def test_geom_repr():
     geom = WcsGeom.create(skydir=(0, 0), npix=(10, 4), binsz=50,
                           coordsys='GAL', proj='AIT')
     assert geom.__class__.__name__ in repr(geom)
+
+
+def test_geom_refpix():
+    refpix = (400, 300)
+    geom = WcsGeom.create(skydir=(0, 0), npix=(800, 600),
+                          refpix=refpix, binsz=0.1, coordsys='GAL')
+    assert_allclose(geom.wcs.wcs.crpix, refpix)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -373,12 +373,19 @@ class WcsGeom(MapGeom):
         else:
             npix = cast_to_shape(npix, shape, int)
 
-        # FIXME: Need to propagate refpix
+        if refpix is None:
+            refpix = (None, None)
 
         header = _make_image_header(
-            npix[0].flat[0], npix[1].flat[0],
-            binsz[0].flat[0], float(xref), float(yref),
-            proj, coordsys, refpix, refpix,
+            nxpix=npix[0].flat[0],
+            nypix=npix[1].flat[0],
+            binsz=binsz[0].flat[0],
+            xref=float(xref),
+            yref=float(yref),
+            proj=proj,
+            coordsys=coordsys,
+            xrefpix=refpix[0],
+            yrefpix=refpix[1],
         )
         wcs = WCS(header)
         return cls(wcs, npix, cdelt=binsz, axes=axes, conv=conv)


### PR DESCRIPTION
This PR fixes #1607. Note that there was a [comment in the code](https://github.com/gammapy/gammapy/blob/master/gammapy/maps/wcs.py#L376), that this should be addressed. So it was a known bug. I also added a regression test. 