### PR TITLE
Move mask_region to WcsGeom

### DIFF
--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -31,8 +31,7 @@ def on_region():
 @pytest.fixture
 def obs_list():
     """Example observation list for testing."""
-    DATA_DIR = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
-    datastore = DataStore.from_dir(DATA_DIR)
+    datastore = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
     obs_ids = [23523, 23526]
     return datastore.obs_list(obs_ids)
 

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -4,7 +4,7 @@ import pytest
 from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
 from ...utils.testing import requires_data, requires_dependency, assert_quantity_allclose
-from ...maps import WcsNDMap
+from ...maps import WcsNDMap, WcsGeom
 from ...data import DataStore
 from ..reflected import ReflectedRegionsFinder, ReflectedRegionsBackgroundEstimator
 
@@ -14,8 +14,9 @@ def mask():
     """Example mask for testing."""
     pos = SkyCoord(83.63, 22.01, unit='deg', frame='icrs')
     exclusion_region = CircleSkyRegion(pos, Angle(0.3, 'deg'))
-    template_map = WcsNDMap.create(skydir=pos, binsz=0.02, width=10.)
-    return template_map.make_region_mask(exclusion_region, inside=False)
+    geom = WcsGeom.create(skydir=pos, binsz=0.02, width=10.)
+    mask = geom.region_mask([exclusion_region], inside=False)
+    return WcsNDMap(geom, data=mask)
 
 
 @pytest.fixture

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -200,26 +200,25 @@ def test_geom_repr():
                           coordsys='GAL', proj='AIT')
     assert geom.__class__.__name__ in repr(geom)
 
+
 def test_geom_refpix():
     refpix = (400, 300)
     geom = WcsGeom.create(skydir=(0, 0), npix=(800, 600),
                           refpix=refpix, binsz=0.1, coordsys='GAL')
     assert_allclose(geom.wcs.wcs.crpix, refpix)
 
+
 def test_region_mask():
     from regions import CircleSkyRegion
-    geom = WcsGeom.create(npix=(3, 3), binsz=2,
-                          proj='CAR', coordsys='GAL')
+    geom = WcsGeom.create(npix=(3, 3), binsz=2, proj='CAR')
 
-    region = CircleSkyRegion(SkyCoord(0, 0, unit='deg', frame='galactic'),
-                             1.0 * u.deg)
+    r1 = CircleSkyRegion(SkyCoord(0, 0, unit='deg'), 1 * u.deg)
+    r2 = CircleSkyRegion(SkyCoord(20, 20, unit='deg'), 1 * u.deg)
+    regions = [r1, r2]
 
-    region_out = CircleSkyRegion(SkyCoord(20, 20, unit='deg', frame='galactic'),
-                             1.0 * u.deg)
-
-    mask = geom.region_mask([region, region_out], inside=True)
+    mask = geom.region_mask(regions)  # default inside=True
     assert mask.dtype == bool
     assert np.sum(mask) == 1
 
-    mask = geom.region_mask([region, region_out], inside=False)
+    mask = geom.region_mask(regions, inside=False)
     assert np.sum(mask) == 8

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -200,9 +200,23 @@ def test_geom_repr():
                           coordsys='GAL', proj='AIT')
     assert geom.__class__.__name__ in repr(geom)
 
-
 def test_geom_refpix():
     refpix = (400, 300)
     geom = WcsGeom.create(skydir=(0, 0), npix=(800, 600),
                           refpix=refpix, binsz=0.1, coordsys='GAL')
     assert_allclose(geom.wcs.wcs.crpix, refpix)
+
+def test_region_mask():
+    from regions import CircleSkyRegion
+    geom = WcsGeom.create(npix=(3, 3), binsz=2,
+                          proj='CAR', coordsys='GAL')
+
+    region = CircleSkyRegion(SkyCoord(0, 0, unit='deg', frame='galactic'),
+                             1.0 * u.deg)
+
+    mask = geom.region_mask([region], inside=True)
+    assert mask.dtype == bool
+    assert np.sum(mask) == 1
+
+    mask = geom.region_mask([region], inside=False)
+    assert np.sum(mask) == 8

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -214,9 +214,12 @@ def test_region_mask():
     region = CircleSkyRegion(SkyCoord(0, 0, unit='deg', frame='galactic'),
                              1.0 * u.deg)
 
-    mask = geom.region_mask([region], inside=True)
+    region_out = CircleSkyRegion(SkyCoord(20, 20, unit='deg', frame='galactic'),
+                             1.0 * u.deg)
+
+    mask = geom.region_mask([region, region_out], inside=True)
     assert mask.dtype == bool
     assert np.sum(mask) == 1
 
-    mask = geom.region_mask([region], inside=False)
+    mask = geom.region_mask([region, region_out], inside=False)
     assert np.sum(mask) == 8

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -393,22 +393,6 @@ def test_coadd_unit():
     assert_allclose(m1.data, 1.0001)
 
 
-def test_make_region_mask():
-    from regions import CircleSkyRegion
-    geom = WcsGeom.create(npix=(3, 3), binsz=2,
-                          proj='CAR', coordsys='GAL')
-    m = WcsNDMap(geom)
-    region = CircleSkyRegion(SkyCoord(0, 0, unit='deg', frame='galactic'),
-                             1.0 * u.deg)
-    maskmap = m.make_region_mask(region)
-
-    assert maskmap.data.dtype == bool
-    assert np.sum(maskmap.data) == 1
-
-    maskmap = m.make_region_mask(region, inside=False)
-    assert np.sum(maskmap.data) == 8
-
-
 @requires_dependency('scipy')
 @pytest.mark.parametrize('kernel', ['gauss', 'box', 'disk'])
 def test_smooth(kernel):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -758,7 +758,8 @@ class WcsGeom(MapGeom):
         regions : list of  `~regions.PixelRegion` or `~regions.SkyRegion` objects
             A list of regions on the sky (defined in pixel or sky coordinates).
         inside : bool
-          Output array is set to True inside the input region if inside is set to True and False outside and conversely.
+            Default ``inside=True`` sets pixels in the region to True.
+            For ``inside=False``, pixels in the region are False.
 
         Returns
         -------
@@ -797,7 +798,6 @@ class WcsGeom(MapGeom):
         mask = np.zeros(idx[0].shape, dtype=bool)
 
         for region in regions:
-            # TODO : if Pixel Compound regions are taken into account, rather convert to PixelRegion
             if isinstance(region, SkyRegion):
                 region = region.to_pixel(self.wcs)
             mask += region.contains(pixcoord)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -751,8 +751,6 @@ class WcsGeom(MapGeom):
     def region_mask(self, regions, inside=False):
         """Create a mask from a given list of regions
 
-        TODO: implement list of region for each axis
-
         Parameters
         ----------
         regions : list of  `~regions.PixelRegion` or `~regions.SkyRegion` objects

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -763,10 +763,11 @@ class WcsGeom(MapGeom):
         Returns
         -------
         mask_map : `~numpy.ndarray` of boolean type
-            the mask map
+            the mask array
 
         Example
         -------
+
         Example building a mask and storing it in a `~gammapy.maps.WcsNDMap' ::
             from regions import CircleSkyRegion
             from astropy.coordinates import SkyCoord, Angle
@@ -799,7 +800,7 @@ class WcsGeom(MapGeom):
             # TODO : if Pixel Compound regions are taken into account, rather convert to PixelRegion
             if isinstance(region, SkyRegion):
                 region = region.to_pixel(self.wcs)
-            mask = np.logical_or(mask, region.contains(pixcoord))
+            mask += region.contains(pixcoord)
 
         if inside is False:
             np.logical_not(mask, out=mask)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -748,40 +748,46 @@ class WcsGeom(MapGeom):
         coord = self.to_image().get_coord()
         return center.separation(coord.skycoord)
 
-    def region_mask(self, regions, inside=False):
+    def region_mask(self, regions, inside=True):
         """Create a mask from a given list of regions
 
         Parameters
         ----------
-        regions : list of  `~regions.PixelRegion` or `~regions.SkyRegion` objects
-            A list of regions on the sky (defined in pixel or sky coordinates).
+        regions : list of  `~regions.Region`
+            Python list of regions (pixel or sky regions accepted)
         inside : bool
-            Default ``inside=True`` sets pixels in the region to True.
+            For ``inside=True``, pixels in the region to True (the default).
             For ``inside=False``, pixels in the region are False.
 
         Returns
         -------
         mask_map : `~numpy.ndarray` of boolean type
-            the mask array
+            Boolean region mask
 
-        Example
-        -------
+        Examples
+        --------
+        Make an exclusion mask for a circular region:
 
-        Example building a mask and storing it in a `~gammapy.maps.WcsNDMap' ::
             from regions import CircleSkyRegion
             from astropy.coordinates import SkyCoord, Angle
             from gammapy.maps import WcsNDMap, WcsGeom
 
-            pos = SkyCoord(0.,0., unit='deg')
+            pos = SkyCoord(0, 0, unit='deg')
             geom = WcsGeom.create(skydir=pos, npix=100, binsz=0.1)
 
-            pos_region = SkyCoord(3.,3., unit='deg')
-            excluded_region = CircleSkyRegion(pos_region, Angle(0.5, 'deg'))
+            region = CircleSkyRegion(
+                SkyCoord(3, 2, unit='deg'),
+                Angle(1, 'deg'),
+            )
+            mask = geom.region_mask([region], inside=False)
 
-            # We want to exclude points inside excluded_region
-            mask = geom.region_mask([excluded_region], inside=False)
+        Note how we made a list with a single region,
+        since this method expects a list of regions.
 
-            # Now we create a map
+        The return ``mask`` is a boolean Numpy array.
+        If you want a map object (e.g. for storing in FITS or plotting),
+        this is how you can make the map::
+
             mask_map = WcsNDMap(geom=geom, data=mask)
             mask_map.plot()
         """

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -767,7 +767,23 @@ class WcsGeom(MapGeom):
 
         Example
         -------
+        Example building a mask and storing it in a `~gammapy.maps.WcsNDMap' ::
+            from regions import CircleSkyRegion
+            from astropy.coordinates import SkyCoord, Angle
+            from gammapy.maps import WcsNDMap, WcsGeom
 
+            pos = SkyCoord(0.,0., unit='deg')
+            geom = WcsGeom.create(skydir=pos, npix=100, binsz=0.1)
+
+            pos_region = SkyCoord(3.,3., unit='deg')
+            excluded_region = CircleSkyRegion(pos_region, Angle(0.5, 'deg'))
+
+            # We want to exclude points inside excluded_region
+            mask = geom.region_mask([excluded_region], inside=False)
+
+            # Now we create a map
+            mask_map = WcsNDMap(geom=geom, data=mask)
+            mask_map.plot()
         """
         from regions import PixCoord
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -596,28 +596,6 @@ class WcsNDMap(WcsMap):
 
             plt.show()
 
-    def make_region_mask(self, region, inside=True):
-        """Create a mask of a given region
-
-        TODO: implement list of region for each axis
-
-        Parameters
-        ----------
-        region :  `~regions.PixelRegion` or `~regions.SkyRegion` object
-            A region on the sky could be defined in pixel or sky coordinates.
-        inside : bool
-          Output map is True inside the input region if inside is set to True and False outside and conversely.
-
-        Returns
-        -------
-        mask_map : `~gammapy.maps.WcsNDMap`
-            the mask map
-        """
-        mask = self.geom.get_region_mask_array(region)
-        if inside is False:
-            np.logical_not(mask, out=mask)
-        # TODO : update meta table to include something about the region used for mask creation?
-        return self._init_copy(data=mask.astype('bool'))
 
     def smooth(self, radius, kernel='gauss', **kwargs):
         """


### PR DESCRIPTION
This PR moves the mask creation to `WcsGeom`. It now takes a list of regions and return a boolean array. `WcsGeom.get_region_mask_array` has been removed since it becomes useless.

An example docstring is given and tests for reflected background have been updated.