### PR TITLE
Introducing new observation container class

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import numpy as np
+from collections import OrderedDict
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
@@ -13,11 +14,113 @@ from ..utils.table import table_row_to_dict
 from ..utils.time import time_ref_from_dict
 
 __all__ = [
+    'ObservationCTA',
     'DataStoreObservation',
     'ObservationList',
 ]
 
 log = logging.getLogger(__name__)
+
+
+class ObservationCTA(object):
+    """Container class for an CTA observation
+
+    Parameters follow loosely the "Required columns" here:
+    http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/obs_index/index.html#required-columns
+
+    Parameters
+    ----------
+    obs_id : int
+        Observation ID
+    gti : `~gammapy.data.GTI`
+        Good Time Intervals
+    events : `~gammapy.data.EventList`
+        Event list
+    aeff : `~gammapy.irf.EffectiveAreaTable2D`
+        Effective area
+    edisp : `~gammapy.irf.EnergyDispersion2D`
+        Energy dispersion
+    psf : `~gammapy.irf.PSF3D` or `~gammapy.irf.EnergyDependentMultiGaussPSF` or `~gammapy.irf.PSFKing`
+        Tabled Point Spread Function
+    bkg : `~gammapy.irf.Background2D` or `~gammapy.irf.Background3D`
+        Background rate
+    pointing_radec : `~astropy.coordinates.SkyCoord`
+        Pointing RA / DEC sky coordinates
+    pointing_altaz : `~astropy.coordinates.SkyCoord`
+        Pointing ALT / AZ sky coordinates
+    pointing_zen : `~astropy.coordinates.SkyCoord`
+        Pointing zenith angle sky
+    observation_time_duration : `~astropy.units.Quantity`
+        Observation time duration in seconds
+
+        The wall time, including dead-time.
+    observation_live_time_duration : `~astropy.units.Quantity`
+        Live-time duration in seconds
+
+        The dead-time-corrected observation time.
+
+        Computed as ``t_live = t_observation * (1 - f_dead)``
+        where ``f_dead`` is the dead-time fraction.
+    observation_dead_time_fraction : `float`
+        Dead-time fraction
+
+        Defined as dead-time over observation time.
+
+        Dead-time is defined as the time during the observation
+        where the detector did not record events:
+        https://en.wikipedia.org/wiki/Dead_time
+        https://adsabs.harvard.edu/abs/2004APh....22..285F
+
+        The dead-time fraction is used in the live-time computation,
+        which in turn is used in the exposure and flux computation.
+    tstart : `~astropy.units.Quantity`
+        Observation start time
+    tstop : `~astropy.units.Quantity`
+        Observation stop time
+    target_radec : `~astropy.coordinates.SkyCoord`
+        Target RA / DEC sky coordinates
+    observatory_earth_location : `~astropy.coordinates.EarthLocation`
+        Observatory location
+    meta : `~collections.OrderedDict`
+        Dictionary to store metadata
+
+    """
+    def __init__(self, obs_id=None, gti=None, events=None, aeff=None, edisp=None, psf=None, bkg=None,
+                 pointing_radec=None, pointing_altaz=None, pointing_zen=None, observation_time_duration=None,
+                 observation_live_time_duration=None, observation_dead_time_fraction=None, tstart=None, tstop=None,
+                 target_radec=None, observatory_earth_location=None, meta=None):
+        self.obs_id = obs_id
+        self.gti = gti
+        self.events = events
+        self.aeff = aeff
+        self.edisp = edisp
+        self.psf = psf
+        self.bkg = bkg
+        self.pointing_radec = pointing_radec
+        self.pointing_altaz = pointing_altaz
+        self.pointing_zen = pointing_zen
+        self.observation_time_duration = observation_time_duration
+        self.observation_live_time_duration = observation_live_time_duration
+        self.observation_dead_time_fraction = observation_dead_time_fraction
+        self.tstart = tstart
+        self.tstop = tstop
+        self.target_radec = target_radec
+        self.observatory_earth_location = observatory_earth_location
+        if not meta:
+            meta = OrderedDict()
+        self.meta = meta
+
+    def __str__(self):
+        """Generate summary info string."""
+        ss = 'Info for OBS_ID = {}\n'.format(self.obs_id)
+        ss += '- Start time: {:.2f}\n'.format(self.tstart.mjd if self.tstart else 'None')
+        ss += '- Pointing pos: RA {:.2f} / Dec {:.2f}\n'.format(
+            self.pointing_radec.ra if self.pointing_radec else 'None',
+            self.pointing_radec.dec if self.pointing_radec else 'None')
+        ss += '- Observation duration: {}\n'.format(self.observation_time_duration)
+        ss += '- Dead-time fraction: {:5.3f} %\n'.format(100 * self.observation_dead_time_fraction)
+
+        return ss
 
 
 class DataStoreObservation(object):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -46,14 +46,6 @@ class ObservationCTA(object):
         Background rate
     pointing_radec : `~astropy.coordinates.SkyCoord`
         Pointing RA / DEC sky coordinates
-    pointing_altaz : `~astropy.coordinates.SkyCoord`
-        Pointing ALT / AZ sky coordinates
-    pointing_zen : `~astropy.coordinates.SkyCoord`
-        Pointing zenith angle sky
-    observation_time_duration : `~astropy.units.Quantity`
-        Observation time duration in seconds
-
-        The wall time, including dead-time.
     observation_live_time_duration : `~astropy.units.Quantity`
         Live-time duration in seconds
 
@@ -73,22 +65,13 @@ class ObservationCTA(object):
 
         The dead-time fraction is used in the live-time computation,
         which in turn is used in the exposure and flux computation.
-    tstart : `~astropy.units.Quantity`
-        Observation start time
-    tstop : `~astropy.units.Quantity`
-        Observation stop time
-    target_radec : `~astropy.coordinates.SkyCoord`
-        Target RA / DEC sky coordinates
-    observatory_earth_location : `~astropy.coordinates.EarthLocation`
-        Observatory location
     meta : `~collections.OrderedDict`
         Dictionary to store metadata
 
     """
     def __init__(self, obs_id=None, gti=None, events=None, aeff=None, edisp=None, psf=None, bkg=None,
-                 pointing_radec=None, pointing_altaz=None, pointing_zen=None, observation_time_duration=None,
-                 observation_live_time_duration=None, observation_dead_time_fraction=None, tstart=None, tstop=None,
-                 target_radec=None, observatory_earth_location=None, meta=None):
+                 pointing_radec=None, observation_live_time_duration=None, observation_dead_time_fraction=None,
+                 meta=None):
         self.obs_id = obs_id
         self.gti = gti
         self.events = events
@@ -97,15 +80,8 @@ class ObservationCTA(object):
         self.psf = psf
         self.bkg = bkg
         self.pointing_radec = pointing_radec
-        self.pointing_altaz = pointing_altaz
-        self.pointing_zen = pointing_zen
-        self.observation_time_duration = observation_time_duration
         self.observation_live_time_duration = observation_live_time_duration
         self.observation_dead_time_fraction = observation_dead_time_fraction
-        self.tstart = tstart
-        self.tstop = tstop
-        self.target_radec = target_radec
-        self.observatory_earth_location = observatory_earth_location
         if not meta:
             meta = OrderedDict()
         self.meta = meta
@@ -113,11 +89,11 @@ class ObservationCTA(object):
     def __str__(self):
         """Generate summary info string."""
         ss = 'Info for OBS_ID = {}\n'.format(self.obs_id)
-        ss += '- Start time: {:.2f}\n'.format(self.tstart.mjd if self.tstart else 'None')
+        ss += '- Start time: {:.2f}\n'.format(np.atleast_1d(self.gti.time_start.fits)[0] if self.gti else 'None')
         ss += '- Pointing pos: RA {:.2f} / Dec {:.2f}\n'.format(
             self.pointing_radec.ra if self.pointing_radec else 'None',
             self.pointing_radec.dec if self.pointing_radec else 'None')
-        ss += '- Observation duration: {}\n'.format(self.observation_time_duration)
+        ss += '- Observation duration: {}\n'.format(self.gti.time_sum if self.gti else 'None')
         ss += '- Dead-time fraction: {:5.3f} %\n'.format(100 * self.observation_dead_time_fraction)
 
         return ss


### PR DESCRIPTION
This PR introduces a new observation container class: `ObservationCTA` (we want to keep the name `Observation` free for a possible more generic observation container class in the future that supports other instruments, Fermi/Hawc, as well).

The main goal is to break the dependency of the observation container on the `DataStore` object. Like this we can create an observation from scratch (programmatically) and we are more flexible for other input formats (for example, the xml format of ctools, http://cta.irap.omp.eu/ctools/users/tutorials/howto/iact/analysis.html?highlight=xml#observation-definition-xml-file).

For this we basically copy the old `DataStoreObservation` replacing all its properties/lazyproperties with class attributes, that are taken on init.

Regarding the name, `ObservationIACT` vs `ObservationCTA`: 
@cdeil had a slight preference towards CTA. Personally i do not have a favorite, other opinions are more than welcome.

Follow-up PRs are planed: 
* introduce a method that creates an `ObservationCTA` from a `DataStore` object
* make `DataStoreObservation` a child class of `ObservaionCTA` to avoid code duplication, maybe make `DataStoreObservation` a light version of the current implementation 
* rename `DataStoreObservation` to either `DataStoreObservationCTA` or `DataStoreObservationIACT` for consistency

Looking forward to your thoughts @cdeil @registerrier @adonath and all