### PR TITLE
Modified fill_map_counts to deal with columns without units

### DIFF
--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.units import Quantity
 
 __all__ = [
     'fill_map_counts',
@@ -61,7 +62,7 @@ def fill_map_counts(counts_map, events):
             colnames = [_.upper() for _ in events.table.colnames]
             if axis.name.upper() in colnames:
                 column_name = events.table.colnames[colnames.index(axis.name.upper())]
-                coord_dict.update({axis.name: events.table[column_name].to(axis.unit)})
+                coord_dict.update({axis.name: Quantity(events.table[column_name]).to(axis.unit)})
             else:
                 raise ValueError("Cannot find MapGeom axis {!r} in EventList".format(axis.name))
 

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -52,6 +52,8 @@ def fill_map_counts(counts_map, events):
     coord_dict = dict(skycoord=events.radec)
 
     # Now add one coordinate for each extra map axis
+    cols = {k.upper(): v for k, v in events.table.columns.items()}
+
     for axis in counts_map.geom.axes:
         if axis.type == 'energy':
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
@@ -61,8 +63,7 @@ def fill_map_counts(counts_map, events):
             # We look for other axes name in the table column names (case insensitive)
             colnames = [_.upper() for _ in events.table.colnames]
             if axis.name.upper() in colnames:
-                column_name = events.table.colnames[colnames.index(axis.name.upper())]
-                coord_dict.update({axis.name: Quantity(events.table[column_name]).to(axis.unit)})
+                coord_dict[axis.name] = Quantity(cols[axis.name.upper()]).to(axis.unit)
             else:
                 raise ValueError("Cannot find MapGeom axis {!r} in EventList".format(axis.name))
 

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -61,10 +61,9 @@ def fill_map_counts(counts_map, events):
         # TODO: add proper extraction for time
         else:
             # We look for other axes name in the table column names (case insensitive)
-            colnames = [_.upper() for _ in events.table.colnames]
-            if axis.name.upper() in colnames:
+            try:
                 coord_dict[axis.name] = Quantity(cols[axis.name.upper()]).to(axis.unit)
-            else:
-                raise ValueError("Cannot find MapGeom axis {!r} in EventList".format(axis.name))
+            except KeyError:
+                raise KeyError("No column {} found in EventList".format(axis.name))
 
     counts_map.fill_by_coord(coord_dict)

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -64,6 +64,6 @@ def fill_map_counts(counts_map, events):
             try:
                 coord_dict[axis.name] = Quantity(cols[axis.name.upper()]).to(axis.unit)
             except KeyError:
-                raise KeyError("No column {} found in EventList".format(axis.name))
+                raise KeyError("Column not found in event list: {!r}".format(axis.name))
 
     counts_map.fill_by_coord(coord_dict)

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -64,7 +64,7 @@ def test_fill_map_counts_hpx(events):
 
     axis_det = MapAxis([-2, 1, 5], node_type='edge', name='detx', unit='deg')
     # This test to check entries without units in eventlist table do not fail
-    axis_evt = MapAxis(np.linspace(1,130000,100), node_type='edge', name='event_id', unit='')
+    axis_evt = MapAxis((0,100000,150000), node_type='edge', name='event_id', unit='')
 
     geom = HpxGeom(256, coordsys='GAL', axes=[axis_evt, axis_det])
 

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -62,11 +62,16 @@ def test_fill_map_counts(geom_opts, events):
 def test_fill_map_counts_hpx(events):
     # This tests healpix maps fill with non standard non spatial axis
 
-    axis = MapAxis([-2, 1, 5], node_type='edge', name='detx', unit='deg')
-    geom = HpxGeom(256, coordsys='GAL', axes=[axis])
+    axis_det = MapAxis([-2, 1, 5], node_type='edge', name='detx', unit='deg')
+    # This test to check entries without units in eventlist table do not fail
+    axis_evt = MapAxis(np.linspace(1,130000,100), node_type='edge', name='event_id', unit='')
+
+    geom = HpxGeom(256, coordsys='GAL', axes=[axis_evt, axis_det])
+
     m = Map.from_geom(geom)
 
     fill_map_counts(m, events)
 
     assert m.data[0].sum() == 66697
     assert m.data[1].sum() == 29410
+

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -64,7 +64,7 @@ def test_fill_map_counts_hpx(events):
 
     axis_det = MapAxis([-2, 1, 5], node_type='edge', name='detx', unit='deg')
     # This test to check entries without units in eventlist table do not fail
-    axis_evt = MapAxis((0,100000,150000), node_type='edge', name='event_id', unit='')
+    axis_evt = MapAxis((0, 100000, 150000), node_type='edge', name='event_id')
 
     geom = HpxGeom(256, coordsys='GAL', axes=[axis_evt, axis_det])
 
@@ -75,11 +75,10 @@ def test_fill_map_counts_hpx(events):
     assert m.data[0].sum() == 66697
     assert m.data[1].sum() == 29410
 
+
 @requires_data('gammapy-extra')
 def test_fill_map_counts_keyerror(events):
-    axis = MapAxis([0, 1, 2], node_type='edge', name='nokey', unit='')
+    axis = MapAxis([0, 1, 2], node_type='edge', name='nokey')
     cntmap = WcsNDMap.create(binsz=0.1, npix=10, axes=[axis])
     with pytest.raises(KeyError):
         fill_map_counts(cntmap, events)
-
-

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data
-from ...maps import MapAxis, WcsGeom, HpxGeom, Map
+from ...maps import MapAxis, WcsGeom, HpxGeom, Map, WcsNDMap
 from ...data import EventList
 from ..counts import fill_map_counts
 
@@ -74,4 +74,12 @@ def test_fill_map_counts_hpx(events):
 
     assert m.data[0].sum() == 66697
     assert m.data[1].sum() == 29410
+
+@requires_data('gammapy-extra')
+def test_fill_map_counts_keyerror(events):
+    axis = MapAxis([0, 1, 2], node_type='edge', name='nokey', unit='')
+    cntmap = WcsNDMap.create(binsz=0.1, npix=10, axes=[axis])
+    with pytest.raises(KeyError):
+        fill_map_counts(cntmap, events)
+
 


### PR DESCRIPTION
In case it is not done already, this is a PR to deal with issue #1620 . 
`fill_map_counts` can now deal with dimensionless columns in the `EventList`.