### PR TITLE
Improve background map making

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -7,15 +7,11 @@ from ..maps import WcsNDMap
 
 __all__ = [
     'make_map_background_irf',
-    'make_map_background_fov',
 ]
 
 
 def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1):
     """Compute background map from background IRFs.
-
-    TODO: Call a method on bkg that returns integral over energy bin directly
-    Related: https://github.com/gammapy/gammapy/pull/1342
 
     Parameters
     ----------
@@ -28,32 +24,29 @@ def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1)
     geom : `~gammapy.maps.WcsGeom`
         Reference geometry
     n_integration_bins : int
-        Number of bins used to integrate on each energy range
+        Number of bins per energy bin in integration
 
     Returns
     -------
     background : `~gammapy.maps.WcsNDMap`
         Background predicted counts sky cube in reco energy
     """
-    # Compute the expected background
-    # TODO: properly transform FOV to sky coordinates
-    # For now we assume the background is radially symmetric
-
     energy_axis = geom.axes[0]
-    # Compute offsets of all pixels
+    ebounds = energy_axis.edges * energy_axis.unit
+
+    # Compute FOV coordinates; at the moment assume symmetric background model
+    # TODO: implement FOV coordinates properly
     map_coord = geom.get_coord()
-    # Retrieve energies from map coordinates
-    energy_reco = map_coord[energy_axis.name] * energy_axis.unit
-    # TODO: go from SkyCoord to FOV coordinates. Here assume symmetric geometry for fov_lon, fov_lat
-    # Compute offset at all the pixels and energy of the Map
     fov_lon = map_coord.skycoord.separation(pointing)
     fov_lat = Angle(np.zeros_like(fov_lon), fov_lon.unit)
+
     data_int = Quantity(np.zeros_like(fov_lat.value), "s^-1 sr^-1")
-    for ie, (e_lo, e_hi) in enumerate(zip(energy_axis.edges[0:-1], energy_axis.edges[1:])):
+
+    for ie, (e_lo, e_hi) in enumerate(zip(ebounds[:-1], ebounds[1:])):
         data_int[ie, :, :] = bkg.integrate_on_energy_range(
             fov_lon=fov_lon[0, :, :],
             fov_lat=fov_lat[0, :, :],
-            energy_range=[e_lo * energy_axis.unit, e_hi * energy_axis.unit],
+            energy_range=[e_lo, e_hi],
             n_integration_bins=n_integration_bins,
         )
 
@@ -63,14 +56,12 @@ def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1)
     return WcsNDMap(geom, data=data)
 
 
-def make_map_background_fov(acceptance_map, counts_map, exclusion_mask=None):
-    """Build Normalized background map from a given acceptance map and counts map.
+def _fov_background_norm(acceptance_map, counts_map, exclusion_mask=None):
+    """Compute FOV background norm
 
     This operation is normally performed on single observation maps.
     An exclusion map is used to avoid using regions with significant gamma-ray emission.
     All maps are assumed to follow the same WcsGeom.
-
-    TODO: A model map could be used instead of an exclusion mask.
 
     Parameters
     ----------
@@ -83,8 +74,8 @@ def make_map_background_fov(acceptance_map, counts_map, exclusion_mask=None):
 
     Returns
     -------
-    norm_bkg_map : `~gammapy.maps.WcsNDMap`
-        Normalized background
+    norm_factor : array
+        Background normalisation factor as function of energy (1D vector)
     """
     if exclusion_mask is None:
         mask = np.ones_like(counts_map, dtype=bool)
@@ -96,11 +87,6 @@ def make_map_background_fov(acceptance_map, counts_map, exclusion_mask=None):
     integ_acceptance = np.sum(acceptance_map.data * mask, axis=(1, 2))
     integ_counts = np.sum(counts_map.data * mask, axis=(1, 2))
 
-    # TODO: Here we need to add a function rebin energy axis to have minimal statistics for the normalization
-
-    # Normalize background
     norm_factor = integ_counts / integ_acceptance
 
-    norm_bkg = norm_factor * acceptance_map.data.T
-
-    return acceptance_map.copy(data=norm_bkg.T)
+    return norm_factor

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -161,13 +161,16 @@ class MapMakerObs(object):
         if self.fov_mask is not None:
             background.data[..., self.fov_mask] = 0
 
-        background_scale = _fov_background_norm(
-            acceptance_map=background,
-            counts_map=counts,
-            exclusion_mask=self.exclusion_mask,
-        )
-        if self.fov_mask is not None:
-            background.data *= background_scale[:, None, None]
+        # TODO: decide what background modeling options to support
+        # This is not well tested or documented at the moment,
+        # so for now take this out
+        # background_scale = _fov_background_norm(
+        #     acceptance_map=background,
+        #     counts_map=counts,
+        #     exclusion_mask=self.exclusion_mask,
+        # )
+        # if self.fov_mask is not None:
+        #     background.data *= background_scale[:, None, None]
 
         return {
             'counts': counts,

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -34,7 +34,7 @@ def geom(ebounds):
         'mode': 'trim',
         'counts': 34366,
         'exposure': 3.99815e+11,
-        'background': 34366,
+        'background': 187528.89,
     },
     {
         # Test single energy bin
@@ -42,7 +42,7 @@ def geom(ebounds):
         'mode': 'trim',
         'counts': 34366,
         'exposure': 1.16866e+11,
-        'background': 34366,
+        'background': 1988492.8,
     },
     {
         # Test strict mode
@@ -50,7 +50,7 @@ def geom(ebounds):
         'mode': 'strict',
         'counts': 21981,
         'exposure': 2.592941e+11,
-        'background': 21981,
+        'background': 121457.695,
     },
 ])
 def test_map_maker(pars, obs_list):


### PR DESCRIPTION
This PR changes the background map computation a bit.

At first I thought that the `integrate_over_energy` method on the background IRF had a bug, but then I convinced myself that it's OK using a simple test case where I know what answer to expect.

Now I'd like to remove the make_map_background_fov scaling, because it isn't properly documented or tested. It was applied by default in the new MapMaker, and because there was no option to pass an exclusion mask, people were getting incorrect results (I think). We can bring that back, and also ring background estimation, but only with proper documentation.

I still have to make the change and check that background cubes are OK without that scaling. I already tried that locally and got hugely different values in the background npred cubes. Work in progress ...

cc @registerrier @AtreyeeS @JouvinLea 