### PR TITLE
WIP: Introduce modelname attribute for Parameter

### DIFF
--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -31,10 +31,11 @@ lat_0_1 = 0.1
 lat_0_2 = 0.6
 
 spatial_model_1 = SkyGaussian(
-    lon_0=lon_0_1 * u.deg, lat_0=lat_0_1 * u.deg, sigma="0.3 deg", name="gauss1"
+    lon_0=lon_0_1 * u.deg, lat_0=lat_0_1 * u.deg, sigma="0.3 deg"
 )
 spatial_model_2 = SkyGaussian(
-    lon_0=lon_0_2 * u.deg, lat_0=lat_0_2 * u.deg, sigma="0.2 deg", name="gauss2"
+    lon_0=lon_0_2 * u.deg, lat_0=lat_0_2 * u.deg, sigma="0.2 deg",
+    name="roberta"
 )
 
 spectral_model_1 = PowerLaw(
@@ -42,7 +43,7 @@ spectral_model_1 = PowerLaw(
 )
 
 spectral_model_2 = PowerLaw(
-    index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV", name="pl2"
+    index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV", name="roberta"
 )
 
 sky_model_1 = SkyModel(spatial_model=spatial_model_1, spectral_model=spectral_model_1)
@@ -93,12 +94,14 @@ counts_map.sum_over_axes().plot()
 plt.clf()
 
 compound_model.parameters.set_parameter_errors({
-    'gauss1.sigma'  : 0.1 * u.deg,
+    'gaussian.sigma'  : 0.1 * u.deg,
     'pl1.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
-    'pl2.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
+    'roberta.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
 })
 
 fit = MapFit(model=compound_model, counts=counts_map, exposure=exposure_map)
 print(compound_model.parameters)
+
+import IPython; IPython.embed()
 
 fit.fit()

--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -1,0 +1,104 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord, Angle
+from gammapy.irf import (
+    EffectiveAreaTable2D,
+    EnergyDispersion2D,
+    EnergyDependentMultiGaussPSF,
+    Background3D,
+)
+from gammapy.maps import WcsGeom, MapAxis, WcsNDMap, Map
+from gammapy.spectrum.models import PowerLaw
+from gammapy.image.models import SkyGaussian
+from gammapy.utils.random import get_random_state
+from gammapy.cube import (
+    make_map_exposure_true_energy,
+    SkyModel,
+    MapFit,
+    MapEvaluator,
+    SourceLibrary,
+    PSFKernel,
+)
+
+filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+aeff = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
+
+# Define sky model to simulate the data
+lon_0_1 = 0.2
+lon_0_2 = 0.4
+lat_0_1 = 0.1
+lat_0_2 = 0.6
+
+spatial_model_1 = SkyGaussian(
+    lon_0=lon_0_1 * u.deg, lat_0=lat_0_1 * u.deg, sigma="0.3 deg", name="gauss1"
+)
+spatial_model_2 = SkyGaussian(
+    lon_0=lon_0_2 * u.deg, lat_0=lat_0_2 * u.deg, sigma="0.2 deg", name="gauss2"
+)
+
+spectral_model_1 = PowerLaw(
+    index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV", name="pl1"
+)
+
+spectral_model_2 = PowerLaw(
+    index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV", name="pl2"
+)
+
+sky_model_1 = SkyModel(spatial_model=spatial_model_1, spectral_model=spectral_model_1)
+
+sky_model_2 = SkyModel(spatial_model=spatial_model_2, spectral_model=spectral_model_2)
+
+compound_model = sky_model_1 + sky_model_2
+
+# Define map geometry
+axis = MapAxis.from_edges(np.logspace(-1., 1., 10), unit="TeV")
+geom = WcsGeom.create(
+    skydir=(0, 0), binsz=0.02, width=(2, 2), coordsys="GAL", axes=[axis]
+)
+
+
+# Define some observation parameters
+# we are not simulating many pointings / observations
+pointing = SkyCoord(0.2, 0.5, unit="deg", frame="galactic")
+livetime = 20 * u.hour
+
+exposure_map = make_map_exposure_true_energy(
+    pointing=pointing, livetime=livetime, aeff=aeff, geom=geom
+)
+
+evaluator = MapEvaluator(sky_model=compound_model, exposure=exposure_map)
+
+
+npred = evaluator.compute_npred()
+npred_map = WcsNDMap(geom, npred)
+
+fig, ax, cbar = npred_map.sum_over_axes().plot(add_cbar=True)
+ax.scatter(
+    [lon_0_1, lon_0_2, pointing.galactic.l.degree],
+    [lat_0_1, lat_0_2, pointing.galactic.b.degree],
+    transform=ax.get_transform("galactic"),
+    marker="+",
+    color="cyan",
+)
+# plt.show()
+plt.clf()
+
+rng = get_random_state(42)
+counts = rng.poisson(npred)
+counts_map = WcsNDMap(geom, counts)
+
+counts_map.sum_over_axes().plot()
+# plt.show()
+plt.clf()
+
+compound_model.parameters.set_parameter_errors({
+    'gauss1.sigma'  : 0.1 * u.deg,
+    'pl1.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
+    'pl2.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
+})
+
+fit = MapFit(model=compound_model, counts=counts_map, exposure=exposure_map)
+print(compound_model.parameters)
+
+fit.fit()

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -29,6 +29,10 @@ class DMProfile(object):
     DISTANCE_GC = 8.33 * u.kpc
     """Distance to the Galactic Center as given in reference 2"""
 
+    @property
+    def name(self):
+        return self._name
+
     def __call__(self, radius):
         """Call evaluate method of derived classes"""
         kwargs = dict()
@@ -40,7 +44,7 @@ class DMProfile(object):
     def scale_to_local_density(self):
         """Scale to local density"""
         scale = (self.LOCAL_DENSITY / self(self.DISTANCE_GC)).to('').value
-        self.parameters['rho_s'].value *= scale
+        self.parameters[self.name + '.rho_s'].value *= scale
 
     def _eval_squared(self, radius):
         """Helper function to return squared density"""
@@ -88,11 +92,12 @@ class NFWProfile(DMProfile):
     DEFAULT_SCALE_RADIUS = 24.42 * u.kpc
     """Default scale radius as given in reference 2"""
 
-    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
+    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3'), name='nfw'):
+        self._name = name
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
         self.parameters = ParameterList([
-            Parameter('r_s', u.Quantity(r_s)),
-            Parameter('rho_s', u.Quantity(rho_s))
+            Parameter(name, 'r_s', u.Quantity(r_s)),
+            Parameter(name, 'rho_s', u.Quantity(rho_s))
         ])
 
     @staticmethod
@@ -129,14 +134,16 @@ class EinastoProfile(DMProfile):
     DEFAULT_ALPHA = 0.17
     """Default scale radius as given in reference 2"""
 
-    def __init__(self, r_s=None, alpha=None, rho_s=1 * u.Unit('GeV / cm3')):
+    def __init__(self, r_s=None, alpha=None, rho_s=1 * u.Unit('GeV / cm3'),
+                 name='einasto'):
+        self._name = name
         alpha = self.DEFAULT_ALPHA if alpha is None else alpha
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
         self.parameters = ParameterList([
-            Parameter('r_s', u.Quantity(r_s)),
-            Parameter('alpha', u.Quantity(alpha)),
-            Parameter('rho_s', u.Quantity(rho_s))
+            Parameter(name, 'r_s', u.Quantity(r_s)),
+            Parameter(name, 'alpha', u.Quantity(alpha)),
+            Parameter(name, 'rho_s', u.Quantity(rho_s))
         ])
 
     @staticmethod
@@ -166,12 +173,13 @@ class IsothermalProfile(DMProfile):
     DEFAULT_SCALE_RADIUS = 4.38 * u.kpc
     """Default scale radius as given in reference 2"""
 
-    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
+    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3'), name='isothermal'):
+        self._name = name
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
         self.parameters = ParameterList([
-            Parameter('r_s', u.Quantity(r_s)),
-            Parameter('rho_s', u.Quantity(rho_s))
+            Parameter(name, 'r_s', u.Quantity(r_s)),
+            Parameter(name, 'rho_s', u.Quantity(rho_s))
         ])
 
     @staticmethod
@@ -200,12 +208,13 @@ class BurkertProfile(DMProfile):
     DEFAULT_SCALE_RADIUS = 12.67 * u.kpc
     """Default scale radius as given in reference 2"""
 
-    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
+    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3'), name='burkert'):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
-
+        
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('r_s', u.Quantity(r_s)),
-            Parameter('rho_s', u.Quantity(rho_s))
+            Parameter(name, 'r_s', u.Quantity(r_s)),
+            Parameter(name, 'rho_s', u.Quantity(rho_s))
         ])
 
     @staticmethod
@@ -235,12 +244,13 @@ class MooreProfile(DMProfile):
     DEFAULT_SCALE_RADIUS = 30.28 * u.kpc
     """Default scale radius as given in reference 2"""
 
-    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
+    def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3'), name='moore'):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('r_s', u.Quantity(r_s)),
-            Parameter('rho_s', u.Quantity(rho_s))
+            Parameter(name, 'r_s', u.Quantity(r_s)),
+            Parameter(name, 'rho_s', u.Quantity(rho_s))
         ])
 
     @staticmethod

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -258,24 +258,26 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
         pars, errs = {}, {}
         pars['amplitude'] = self.data['Flux_Density']
-        errs['amplitude'] = self.data['Unc_Flux_Density']
         pars['reference'] = self.data['Pivot_Energy']
 
         if spec_type == 'PowerLaw':
             pars['index'] = self.data['Spectral_Index'] * u.dimensionless_unscaled
-            errs['index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+            errs['powerlaw.index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+            errs['powerlaw.amplitude'] = self.data['Unc_Flux_Density']
             model = PowerLaw(**pars)
         elif spec_type == 'PLExpCutoff':
             pars['index'] = self.data['Spectral_Index'] * u.dimensionless_unscaled
             pars['ecut'] = self.data['Cutoff']
-            errs['index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
-            errs['ecut'] = self.data['Unc_Cutoff']
+            errs['expcutoffpowerlaw3fgl.index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+            errs['expcutoffpowerlaw3fgl.ecut'] = self.data['Unc_Cutoff']
+            errs['expcutoffpowerlaw3fgl.amplitude'] = self.data['Unc_Flux_Density']
             model = ExponentialCutoffPowerLaw3FGL(**pars)
         elif spec_type == 'LogParabola':
             pars['alpha'] = self.data['Spectral_Index'] * u.dimensionless_unscaled
             pars['beta'] = self.data['beta'] * u.dimensionless_unscaled
-            errs['alpha'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
-            errs['beta'] = self.data['Unc_beta'] * u.dimensionless_unscaled
+            errs['logpar.alpha'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+            errs['logpar.beta'] = self.data['Unc_beta'] * u.dimensionless_unscaled
+            errs['logpar.amplitude'] = self.data['Unc_Flux_Density']
             model = LogParabola(**pars)
         elif spec_type == "PLSuperExpCutoff":
             # TODO: why convert to GeV here? Remove?
@@ -283,9 +285,10 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
             pars['index_1'] = self.data['Spectral_Index'] * u.dimensionless_unscaled
             pars['index_2'] = self.data['Exp_Index'] * u.dimensionless_unscaled
             pars['ecut'] = self.data['Cutoff'].to('GeV')
-            errs['index_1'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
-            errs['index_2'] = self.data['Unc_Exp_Index'] * u.dimensionless_unscaled
-            errs['ecut'] = self.data['Unc_Cutoff'].to('GeV')
+            errs['plsuperexpcutoff3fgl.index_1'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+            errs['plsuperexpcutoff3fgl.index_2'] = self.data['Unc_Exp_Index'] * u.dimensionless_unscaled
+            errs['plsuperexpcutoff3fgl.ecut'] = self.data['Unc_Cutoff'].to('GeV')
+            errs['plsuperexpcutoff3fgl.amplitude'] = self.data['Unc_Flux_Density']
             model = PLSuperExpCutoff3FGL(**pars)
         else:
             raise ValueError('No spec_type: {}. Please report this issue.'.format(spec_type))
@@ -516,8 +519,8 @@ class SourceCatalogObject1FHL(SourceCatalogObject):
         pars['amplitude'] = self.data['Flux']
         pars['emin'], pars['emax'] = self.energy_range
         pars['index'] = self.data['Spectral_Index'] * u.dimensionless_unscaled
-        errs['amplitude'] = self.data['Unc_Flux']
-        errs['index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+        errs['powerlaw2.amplitude'] = self.data['Unc_Flux']
+        errs['powerlaw2.index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
         model = PowerLaw2(**pars)
         model.parameters.set_parameter_errors(errs)
         return model
@@ -593,8 +596,8 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         pars['emin'], pars['emax'] = self.energy_range
         pars['index'] = self.data['Spectral_Index'] * u.dimensionless_unscaled
 
-        errs['amplitude'] = self.data['Unc_Flux50']
-        errs['index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
+        errs['powerlaw2.amplitude'] = self.data['Unc_Flux50']
+        errs['powerlaw2.index'] = self.data['Unc_Spectral_Index'] * u.dimensionless_unscaled
 
         model = PowerLaw2(**pars)
         model.parameters.set_parameter_errors(errs)
@@ -789,18 +792,19 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
         pars, errs = {}, {}
         pars['amplitude'] = d['Flux_Density']
-        errs['amplitude'] = d['Unc_Flux_Density']
         pars['reference'] = d['Pivot_Energy']
 
         if spec_type == 'PowerLaw':
             pars['index'] = d['PowerLaw_Index'] * u.dimensionless_unscaled
-            errs['index'] = d['Unc_PowerLaw_Index'] * u.dimensionless_unscaled
+            errs['powerlaw.index'] = d['Unc_PowerLaw_Index'] * u.dimensionless_unscaled
+            errs['powerlaw.amplitude'] = d['Unc_Flux_Density']
             model = PowerLaw(**pars)
         elif spec_type == 'LogParabola':
             pars['alpha'] = d['Spectral_Index'] * u.dimensionless_unscaled
             pars['beta'] = d['beta'] * u.dimensionless_unscaled
-            errs['alpha'] = d['Unc_Spectral_Index'] * u.dimensionless_unscaled
-            errs['beta'] = d['Unc_beta'] * u.dimensionless_unscaled
+            errs['logpar.alpha'] = d['Unc_Spectral_Index'] * u.dimensionless_unscaled
+            errs['logpar.beta'] = d['Unc_beta'] * u.dimensionless_unscaled
+            errs['logpar.amplitude'] = d['Unc_Flux_Density']
             model = LogParabola(**pars)
         else:
             raise ValueError('No spec_type: {}. Please report this issue.'.format(spec_type))

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -105,9 +105,9 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
         label = 'spec{}_'.format(idx)
 
         pars['amplitude'] = data[label + 'dnde']
-        errs['amplitude'] = data[label + 'dnde_err']
+        errs['powerlaw.amplitude'] = data[label + 'dnde_err']
         pars['index'] = data[label + 'index'] * u.Unit('')
-        errs['index'] = data[label + 'index_err'] * u.Unit('')
+        errs['powerlaw.index'] = data[label + 'index_err'] * u.Unit('')
         pars['reference'] = 7 * u.TeV
 
         model = PowerLaw(**pars)

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -85,11 +85,11 @@ class SourceCatalogObjectHGPSComponent(object):
             lat_0=d['GLAT'],
             sigma=d['Size'],
         )
-        model.parameters.set_parameter_errors(dict(
-            lon_0=d['GLON_Err'],
-            lat_0=d['GLAT_Err'],
-            sigma=d['Size_Err'],
-        ))
+        model.parameters.set_parameter_errors({
+            'gaussian.lon_0' : d['GLON_Err'],
+            'gaussian.lat_0' : d['GLAT_Err'],
+            'gaussian.sigma' : d['Size_Err'],
+        })
         return model
 
     @property
@@ -102,9 +102,9 @@ class SourceCatalogObjectHGPSComponent(object):
             emin='1 TeV',
             emax='1e5 TeV',
         )
-        model.parameters.set_parameter_errors(dict(
-            amplitude=d['Flux_Map_Err'],
-        ))
+        model.parameters.set_parameter_errors({
+            'powerlaw2.amplitude' : d['Flux_Map_Err'],
+        })
         return model
 
     @property
@@ -440,17 +440,17 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             pars['index'] = data['Index_Spec_PL']
             pars['amplitude'] = data['Flux_Spec_PL_Diff_Pivot']
             pars['reference'] = data['Energy_Spec_PL_Pivot']
-            errs['amplitude'] = data['Flux_Spec_PL_Diff_Pivot_Err']
-            errs['index'] = data['Index_Spec_PL_Err'] * u.dimensionless_unscaled
+            errs['powerlaw.amplitude'] = data['Flux_Spec_PL_Diff_Pivot_Err']
+            errs['powerlaw.index'] = data['Index_Spec_PL_Err'] * u.dimensionless_unscaled
             model = PowerLaw(**pars)
         elif spec_type == 'ecpl':
             pars['index'] = data['Index_Spec_ECPL']
             pars['amplitude'] = data['Flux_Spec_ECPL_Diff_Pivot']
             pars['reference'] = data['Energy_Spec_ECPL_Pivot']
             pars['lambda_'] = data['Lambda_Spec_ECPL']
-            errs['index'] = data['Index_Spec_ECPL_Err'] * u.dimensionless_unscaled
-            errs['amplitude'] = data['Flux_Spec_ECPL_Diff_Pivot_Err']
-            errs['lambda_'] = data['Lambda_Spec_ECPL_Err']
+            errs['expcutoffpowerlaw.index'] = data['Index_Spec_ECPL_Err'] * u.dimensionless_unscaled
+            errs['expcutoffpowerlaw.amplitude'] = data['Flux_Spec_ECPL_Diff_Pivot_Err']
+            errs['expcutoffpowerlaw.lambda_'] = data['Lambda_Spec_ECPL_Err']
             model = ExponentialCutoffPowerLaw(**pars)
         else:
             raise ValueError('Invalid spectral model: {}'.format(spec_type))

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -121,9 +121,9 @@ class TestSourceCatalogObjectHGPS:
 
         assert isinstance(model, PowerLaw)
         pars = model.parameters
-        assert_allclose(pars['amplitude'].value, 9.140179932365378e-13)
-        assert_allclose(pars['index'].value, 2.1513476371765137)
-        assert_allclose(pars['reference'].value, 1.867810606956482)
+        assert_allclose(pars['powerlaw.amplitude'].value, 9.140179932365378e-13)
+        assert_allclose(pars['powerlaw.index'].value, 2.1513476371765137)
+        assert_allclose(pars['powerlaw.reference'].value, 1.867810606956482)
 
         val, err = model.integral_error(1 * u.TeV, 1e5 * u.TeV).value
         assert_allclose(val, source.data['Flux_Spec_Int_1TeV'].value, rtol=0.01)
@@ -138,10 +138,10 @@ class TestSourceCatalogObjectHGPS:
         assert isinstance(model, ExponentialCutoffPowerLaw)
 
         pars = model.parameters
-        assert_allclose(pars['amplitude'].value, 6.408420542586617e-12)
-        assert_allclose(pars['index'].value, 1.3543991614920847)
-        assert_allclose(pars['reference'].value, 1.696938754239)
-        assert_allclose(pars['lambda_'].value, 0.081517637)
+        assert_allclose(pars['expcutoffpowerlaw.amplitude'].value, 6.408420542586617e-12)
+        assert_allclose(pars['expcutoffpowerlaw.index'].value, 1.3543991614920847)
+        assert_allclose(pars['expcutoffpowerlaw.reference'].value, 1.696938754239)
+        assert_allclose(pars['expcutoffpowerlaw.lambda_'].value, 0.081517637)
 
         val, err = model.integral_error(1 * u.TeV, 1e5 * u.TeV).value
         assert_allclose(val, source.data['Flux_Spec_Int_1TeV'].value, rtol=0.01)
@@ -151,9 +151,9 @@ class TestSourceCatalogObjectHGPS:
         assert isinstance(model, PowerLaw)
 
         pars = model.parameters
-        assert_allclose(pars['amplitude'].value, 1.833056926733856e-12)
-        assert_allclose(pars['index'].value, 1.8913707)
-        assert_allclose(pars['reference'].value, 3.0176312923431396)
+        assert_allclose(pars['powerlaw.amplitude'].value, 1.833056926733856e-12)
+        assert_allclose(pars['powerlaw.index'].value, 1.8913707)
+        assert_allclose(pars['powerlaw.reference'].value, 3.0176312923431396)
 
         val, err = model.integral_error(1 * u.TeV, 1e5 * u.TeV).value
         assert_allclose(val, source.data['Flux_Spec_PL_Int_1TeV'].value, rtol=0.01)
@@ -168,18 +168,18 @@ class TestSourceCatalogObjectHGPS:
     def test_sky_model_point(cat):
         model = cat['HESS J1826-148'].sky_model
         p = model.parameters
-        assert_allclose(p['amplitude'].value, 9.815771242691063e-13)
-        assert_allclose(p['lon_0'].value, 16.882482528686523)
-        assert_allclose(p['lat_0'].value, -1.2889292240142822)
+        assert_allclose(p['powerlaw.amplitude'].value, 9.815771242691063e-13)
+        assert_allclose(p['pointsource.lon_0'].value, 16.882482528686523)
+        assert_allclose(p['pointsource.lat_0'].value, -1.2889292240142822)
 
     @staticmethod
     def test_sky_model_gaussian(cat):
         model = cat['HESS J1119-614'].sky_model
         p = model.parameters
-        assert_allclose(p['amplitude'].value, 7.959899015960725e-13)
-        assert_allclose(p['lon_0'].value, 292.1280822753906)
-        assert_allclose(p['lat_0'].value, -0.5332353711128235)
-        assert_allclose(p['sigma'].value, 0.09785966575145721)
+        assert_allclose(p['powerlaw.amplitude'].value, 7.959899015960725e-13)
+        assert_allclose(p['gaussian.lon_0'].value, 292.1280822753906)
+        assert_allclose(p['gaussian.lat_0'].value, -0.5332353711128235)
+        assert_allclose(p['gaussian.sigma'].value, 0.09785966575145721)
 
         # TODO: bring back the bounding box in the new model classes
         # bbox = model.bounding_box
@@ -190,16 +190,16 @@ class TestSourceCatalogObjectHGPS:
         model = cat['HESS J1843-033'].sky_model
 
         p = model.components[0].parameters
-        assert_allclose(p['amplitude'].value, 1.343344814726255e-12)
-        assert_allclose(p['lon_0'].value, 29.047216415405273)
-        assert_allclose(p['lat_0'].value, 0.24389676749706268)
-        assert_allclose(p['sigma'].value, 0.12499100714921951)
+        assert_allclose(p['powerlaw2.amplitude'].value, 1.343344814726255e-12)
+        assert_allclose(p['gaussian.lon_0'].value, 29.047216415405273)
+        assert_allclose(p['gaussian.lat_0'].value, 0.24389676749706268)
+        assert_allclose(p['gaussian.sigma'].value, 0.12499100714921951)
 
         p = model.components[1].parameters
-        assert_allclose(p['amplitude'].value, 1.5390372353277226e-12)
-        assert_allclose(p['lon_0'].value, 28.77037811279297)
-        assert_allclose(p['lat_0'].value, -0.0727819949388504)
-        assert_allclose(p['sigma'].value, 0.2294706553220749)
+        assert_allclose(p['powerlaw2.amplitude'].value, 1.5390372353277226e-12)
+        assert_allclose(p['gaussian.lon_0'].value, 28.77037811279297)
+        assert_allclose(p['gaussian.lat_0'].value, -0.0727819949388504)
+        assert_allclose(p['gaussian.sigma'].value, 0.2294706553220749)
 
         # TODO: bounding boxes need to be re-added to the new model classes
         # bbox = model.bounding_box
@@ -208,29 +208,29 @@ class TestSourceCatalogObjectHGPS:
     @staticmethod
     def test_sky_model_gaussian3(cat):
         model = cat['HESS J1825-137'].sky_model
-        assert_allclose(model.components[0].parameters['amplitude'].value, 5.022436459778401e-12)
-        assert_allclose(model.components[1].parameters['amplitude'].value, 1.1829840926291801e-11)
-        assert_allclose(model.components[2].parameters['amplitude'].value, 1.5557788347539403e-12)
+        assert_allclose(model.components[0].parameters['powerlaw2.amplitude'].value, 5.022436459778401e-12)
+        assert_allclose(model.components[1].parameters['powerlaw2.amplitude'].value, 1.1829840926291801e-11)
+        assert_allclose(model.components[2].parameters['powerlaw2.amplitude'].value, 1.5557788347539403e-12)
 
     @staticmethod
     def test_sky_model_gaussian_extern(cat):
         # special test for the only extern source with a gaussian morphology
         model = cat['HESS J1801-233'].sky_model
         p = model.parameters
-        assert_allclose(p['amplitude'].value, 7.499999970031479e-13)
-        assert_allclose(p['lon_0'].value, 6.656888961791992)
-        assert_allclose(p['lat_0'].value, -0.267688125371933)
-        assert_allclose(p['sigma'].value, 0.17)
+        assert_allclose(p['powerlaw.amplitude'].value, 7.499999970031479e-13)
+        assert_allclose(p['gaussian.lon_0'].value, 6.656888961791992)
+        assert_allclose(p['gaussian.lat_0'].value, -0.267688125371933)
+        assert_allclose(p['gaussian.sigma'].value, 0.17)
 
     @staticmethod
     def test_sky_model_shell(cat):
         model = cat['Vela Junior'].sky_model
         p = model.parameters
-        assert_allclose(p['amplitude'].value, 3.2163001428830995e-11)
-        assert_allclose(p['lon_0'].value, 266.2873840332031)
-        assert_allclose(p['lat_0'].value, -1.243260383605957)
-        assert_allclose(p['radius'].value, 0.95)
-        assert_allclose(p['width'].value, 0.05)
+        assert_allclose(p['expcutoffpowerlaw.amplitude'].value, 3.2163001428830995e-11)
+        assert_allclose(p['shell.lon_0'].value, 266.2873840332031)
+        assert_allclose(p['shell.lat_0'].value, -1.243260383605957)
+        assert_allclose(p['shell.radius'].value, 0.95)
+        assert_allclose(p['shell.width'].value, 0.05)
 
 
 @requires_data('gammapy-extra')
@@ -260,19 +260,19 @@ class TestSourceCatalogObjectHGPSComponent:
     def test_spatial_model(component):
         model = component.spatial_model
         p = model.parameters
-        assert_allclose(p['lon_0'].value, 28.77037811279297)
-        assert_allclose(p.error('lon_0'), 0.058748625218868256)
-        assert_allclose(p['lat_0'].value, -0.0727819949388504)
-        assert_allclose(p.error('lat_0'), 0.06880396604537964)
-        assert_allclose(p['sigma'].value, 0.2294706553220749)
-        assert_allclose(p.error('sigma'), 0.04618723690509796)
+        assert_allclose(p['gaussian.lon_0'].value, 28.77037811279297)
+        assert_allclose(p.error('gaussian.lon_0'), 0.058748625218868256)
+        assert_allclose(p['gaussian.lat_0'].value, -0.0727819949388504)
+        assert_allclose(p.error('gaussian.lat_0'), 0.06880396604537964)
+        assert_allclose(p['gaussian.sigma'].value, 0.2294706553220749)
+        assert_allclose(p.error('gaussian.sigma'), 0.04618723690509796)
 
     @staticmethod
     def test_spectral_model(component):
         model = component.spectral_model
         p = model.parameters
-        assert_allclose(p['amplitude'].value, 1.5390372353277226e-12)
-        assert_allclose(p.error('amplitude'), 4.721826770727466e-13)
+        assert_allclose(p['powerlaw2.amplitude'].value, 1.5390372353277226e-12)
+        assert_allclose(p.error('powerlaw2.amplitude'), 4.721826770727466e-13)
 
     @staticmethod
     def test_sky_model(component):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -125,6 +125,7 @@ class SkyModel(object):
 
     @parameters.setter
     def parameters(self, parameters):
+        self._parameters = parameters
         idx = len(self.spatial_model.parameters.parameters)
         self._spatial_model.parameters.parameters = parameters.parameters[:idx]
         self._spectral_model.parameters.parameters = parameters.parameters[idx:]
@@ -193,18 +194,19 @@ class CompoundSkyModel(object):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
+        self._parameters = ParameterList(
+            model1.parameters.parameters +
+            model2.parameters.parameters
+        )
 
-    # TODO: Think about how to deal with covariance matrix
     @property
     def parameters(self):
         """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
-        return ParameterList(
-            self.model1.parameters.parameters +
-            self.model2.parameters.parameters
-        )
+        return self._parameters
 
     @parameters.setter
     def parameters(self, parameters):
+        self._parameters = parameters
         idx = len(self.model1.parameters.parameters)
         self.model1.parameters.parameters = parameters.parameters[:idx]
         self.model2.parameters.parameters = parameters.parameters[idx:]

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -101,17 +101,17 @@ def counts(sky_model, exposure, background, psf, edisp):
 @requires_dependency('iminuit')
 @requires_data('gammapy-extra')
 def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
-    sky_model.parameters['lon_0'].value = 0.5
-    sky_model.parameters['lat_0'].value = 0.5
-    sky_model.parameters['index'].value = 2
-    sky_model.parameters['sigma'].frozen = True
+    sky_model.parameters['gaussian.lon_0'].value = 0.5
+    sky_model.parameters['gaussian.lat_0'].value = 0.5
+    sky_model.parameters['powerlaw.index'].value = 2
+    sky_model.parameters['gaussian.sigma'].frozen = True
 
     sky_model.parameters.set_parameter_errors({
-        'lon_0': '0.01 deg',
-        'lat_0': '0.01 deg',
-        'sigma': '0.02 deg',
-        'index': 0.1,
-        'amplitude': '1e-13 cm-2 s-1 TeV-1',
+        'gaussian.lon_0': '0.01 deg',
+        'gaussian.lat_0': '0.01 deg',
+        'gaussian.sigma': '0.02 deg',
+        'powerlaw.index': 0.1,
+        'powerlaw.amplitude': '1e-13 cm-2 s-1 TeV-1',
     })
 
     fit = MapFit(
@@ -126,17 +126,17 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
     pars = fit.model.parameters
 
     assert sky_model is fit.model
-    assert sky_model.parameters['lon_0'] is fit.model.parameters['lon_0']
-    assert sky_model.parameters['lon_0'] is sky_model.spatial_model.parameters['lon_0']
+    assert sky_model.parameters['gaussian.lon_0'] is fit.model.parameters['gaussian.lon_0']
+    assert sky_model.parameters['gaussian.lon_0'] is sky_model.spatial_model.parameters['gaussian.lon_0']
 
-    assert_allclose(pars['lon_0'].value, 0.2, rtol=1e-2)
-    assert_allclose(pars.error('lon_0'), 0.005895, rtol=1e-2)
+    assert_allclose(pars['gaussian.lon_0'].value, 0.2, rtol=1e-2)
+    assert_allclose(pars.error('gaussian.lon_0'), 0.005895, rtol=1e-2)
 
-    assert_allclose(pars['index'].value, 3, rtol=1e-2)
-    assert_allclose(pars.error('index'), 0.05614, rtol=1e-2)
+    assert_allclose(pars['powerlaw.index'].value, 3, rtol=1e-2)
+    assert_allclose(pars.error('powerlaw.index'), 0.05614, rtol=1e-2)
 
-    assert_allclose(pars['amplitude'].value, 1e-11, rtol=1e-2)
-    assert_allclose(pars.error('amplitude'), 3.936e-13, rtol=1e-2)
+    assert_allclose(pars['powerlaw.amplitude'].value, 1e-11, rtol=1e-2)
+    assert_allclose(pars.error('powerlaw.amplitude'), 3.936e-13, rtol=1e-2)
 
     stat = np.sum(fit.stat, dtype='float64')
     stat_expected = 3840.0605649268496

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -100,8 +100,8 @@ class TestSkyModel:
     @staticmethod
     def test_parameters(sky_model):
         # Check that model parameters are references to the spatial and spectral parts
-        assert sky_model.parameters['lon_0'] is sky_model.spatial_model.parameters['lon_0']
-        assert sky_model.parameters['amplitude'] is sky_model.spectral_model.parameters['amplitude']
+        assert sky_model.parameters['gaussian.lon_0'] is sky_model.spatial_model.parameters['gaussian.lon_0']
+        assert sky_model.parameters['powerlaw.amplitude'] is sky_model.spectral_model.parameters['powerlaw.amplitude']
 
     @staticmethod
     def test_evaluate_scalar(sky_model):
@@ -136,11 +136,11 @@ class TestCompoundSkyModel:
 
     @staticmethod
     def test_parameters(compound_model):
-        parnames = ['lon_0', 'lat_0', 'sigma', 'index', 'amplitude', 'reference'] * 2
-        assert compound_model.parameters.names == parnames
+        assert compound_model.parameters.parameters[0].fullname == 'gaussian.lon_0'
+        assert compound_model.parameters.parameters[-1].fullname == 'powerlaw.reference'
 
         # Check that model parameters are references to the parts
-        assert compound_model.parameters['lon_0'] is compound_model.model1.parameters['lon_0']
+        assert compound_model.parameters['gaussian.lon_0'] is compound_model.model1.parameters['gaussian.lon_0']
 
         # Check that parameter assignment works
         assert compound_model.parameters.parameters[-1].value == 1
@@ -169,11 +169,11 @@ class TestSumSkyModel:
 
     @staticmethod
     def test_parameters(sum_model):
-        parnames = ['lon_0', 'lat_0', 'sigma', 'index', 'amplitude', 'reference'] * 2
-        assert sum_model.parameters.names == parnames
+        assert sum_model.parameters.parameters[0].fullname == 'gaussian.lon_0'
+        assert sum_model.parameters.parameters[-1].fullname == 'powerlaw.reference'
 
         # Check that model parameters are references to the parts
-        assert sum_model.parameters['lon_0'] is sum_model.components[0].parameters['lon_0']
+        assert sum_model.parameters['gaussian.lon_0'] is sum_model.components[0].parameters['gaussian.lon_0']
 
         # Check that parameter assignment works
         assert sum_model.parameters.parameters[-1].value == 1

--- a/gammapy/image/models/new.py
+++ b/gammapy/image/models/new.py
@@ -28,6 +28,10 @@ __all__ = [
 class SkySpatialModel(object):
     """SkySpatial model base class.
     """
+    @property
+    def name(self):
+        return self._name
+
     def __str__(self):
         ss = self.__class__.__name__
         ss += '\n\nParameters: \n\n\t'
@@ -69,12 +73,16 @@ class SkyPointSource(SkySpatialModel):
         :math:`lon_0`
     lat_0 : `~astropy.coordinates.Latitude`
         :math:`lat_0`
+    name : str
+        model name
     """
 
-    def __init__(self, lon_0, lat_0):
+
+    def __init__(self, lon_0, lat_0, name='pointsource'):
+        self._name = str(name)
         self.parameters = ParameterList([
-            Parameter('lon_0', Longitude(lon_0)),
-            Parameter('lat_0', Latitude(lat_0))
+            Parameter(name, 'lon_0', Longitude(lon_0)),
+            Parameter(name, 'lat_0', Latitude(lat_0))
         ])
 
     @staticmethod
@@ -113,12 +121,12 @@ class SkyGaussian(SkySpatialModel):
         :math:`lat_0`
     sigma : `~astropy.coordinates.Angle`
         :math:`\sigma`
+    name : str
+        model name
     """
 
-    def __init__(self, lon_0, lat_0, sigma, name=None):
-        if name is None:
-            name = self.__class__.__name__
-        self.name = name
+    def __init__(self, lon_0, lat_0, sigma, name='gaussian'):
+        self._name = str(name)
         self.parameters = ParameterList([
             Parameter(name, 'lon_0', Longitude(lon_0)),
             Parameter(name, 'lat_0', Latitude(lat_0)),
@@ -160,13 +168,16 @@ class SkyDisk(SkySpatialModel):
         :math:`lat_0`
     r_0 : `~astropy.coordinates.Angle`
         :math:`r_0`
+    name : str
+        model name
     """
 
-    def __init__(self, lon_0, lat_0, r_0):
+    def __init__(self, lon_0, lat_0, r_0, name='disk'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('lon_0', Longitude(lon_0)),
-            Parameter('lat_0', Latitude(lat_0)),
-            Parameter('r_0', Angle(r_0))
+            Parameter(name, 'lon_0', Longitude(lon_0)),
+            Parameter(name, 'lat_0', Latitude(lat_0)),
+            Parameter(name, 'r_0', Angle(r_0))
         ])
 
     @staticmethod
@@ -211,14 +222,17 @@ class SkyShell(SkySpatialModel):
         Inner radius, :math:`r_{in}`
     width : `~astropy.coordinates.Angle`
         Shell width
+    name : str
+        model name
     """
 
-    def __init__(self, lon_0, lat_0, radius, width):
+    def __init__(self, lon_0, lat_0, radius, width, name='shell'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('lon_0', Longitude(lon_0)),
-            Parameter('lat_0', Latitude(lat_0)),
-            Parameter('radius', Angle(radius)),
-            Parameter('width', Angle(width))
+            Parameter(name, 'lon_0', Longitude(lon_0)),
+            Parameter(name, 'lat_0', Latitude(lat_0)),
+            Parameter(name, 'radius', Angle(radius)),
+            Parameter(name, 'width', Angle(width))
         ])
 
     @staticmethod
@@ -246,11 +260,14 @@ class SkyDiffuseConstant(SkySpatialModel):
     ----------
     value : `~astropy.units.Quantity`
         Value
+    name : str
+        model name
     """
 
-    def __init__(self, value=1):
+    def __init__(self, value=1, name='constant'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('value', value),
+            Parameter(name, 'value', value),
         ])
 
     @staticmethod
@@ -274,12 +291,15 @@ class SkyDiffuseMap(SkySpatialModel):
         Norm parameter (multiplied with map values)
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialization
+    name : str
+        model name
     """
 
-    def __init__(self, map, norm=1, meta=None):
+    def __init__(self, map, norm=1, meta=None, name='map'):
+        self._name = str(name)
         self._map = map
         self.parameters = ParameterList([
-            Parameter('norm', norm),
+            Parameter(name, 'norm', norm),
         ])
         self.meta = dict() if meta is None else meta
 

--- a/gammapy/image/models/new.py
+++ b/gammapy/image/models/new.py
@@ -28,7 +28,6 @@ __all__ = [
 class SkySpatialModel(object):
     """SkySpatial model base class.
     """
-
     def __str__(self):
         ss = self.__class__.__name__
         ss += '\n\nParameters: \n\n\t'
@@ -116,11 +115,14 @@ class SkyGaussian(SkySpatialModel):
         :math:`\sigma`
     """
 
-    def __init__(self, lon_0, lat_0, sigma):
+    def __init__(self, lon_0, lat_0, sigma, name=None):
+        if name is None:
+            name = self.__class__.__name__
+        self.name = name
         self.parameters = ParameterList([
-            Parameter('lon_0', Longitude(lon_0)),
-            Parameter('lat_0', Latitude(lat_0)),
-            Parameter('sigma', Angle(sigma))
+            Parameter(name, 'lon_0', Longitude(lon_0)),
+            Parameter(name, 'lat_0', Latitude(lat_0)),
+            Parameter(name, 'sigma', Angle(sigma))
         ])
 
     @staticmethod

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -17,7 +17,7 @@ def get_config():
         reference=1 * u.TeV,
     )
     model.parameters.set_parameter_errors({
-        'amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1')
+        'powerlaw.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1')
     })
     fp_binning = EnergyBounds.equal_log_spacing(1, 50, 4, 'TeV')
     return dict(

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -430,7 +430,7 @@ class SpectrumFit(object):
 
         # create tuples of combinations
         d = self._model.parameters.to_dict()
-        parameter_names = [l['name'] for l in d['parameters'] if not l['frozen']]
+        parameter_names = [l['modelname'] + '.' + l['name'] for l in d['parameters'] if not l['frozen']]
         self.covar_axis = parameter_names
         parameter_combinations = list(product(parameter_names, repeat=2))
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -694,8 +694,8 @@ class FluxPointEstimator(object):
         model = fit.result[0].model.copy()
         # this is a prototype for fast flux point upper limit
         # calculation using brentq
-        amplitude = model.parameters['amplitude'].value / 1E-12
-        amplitude_err = model.parameters.error('amplitude') / 1E-12
+        amplitude = model.parameters[model.name + '.amplitude'].value / 1E-12
+        amplitude_err = model.parameters.error(model.name + '.amplitude') / 1E-12
 
         if negative:
             amplitude_max = amplitude
@@ -705,19 +705,19 @@ class FluxPointEstimator(object):
             amplitude_min = amplitude
 
         def ts_diff(x):
-            model.parameters['amplitude'].value = x * 1E-12
+            model.parameters[model.name + '.amplitude'].value = x * 1E-12
             stat = fit.total_stat(model.parameters)
             return (stat_best_fit + delta_ts) - stat
 
         try:
             result = brentq(ts_diff, amplitude_min, amplitude_max,
                             maxiter=100, rtol=1e-2)
-            model.parameters['amplitude'].value = result * 1E-12
-            return model(model.parameters['reference'].quantity)
+            model.parameters[model.name + '.amplitude'].value = result * 1E-12
+            return model(model.parameters[model.name + '.reference'].quantity)
         except (RuntimeError, ValueError):
             # Where the root finding fails NaN is set as amplitude
             log.debug('Flux point upper limit computation failed.')
-            return np.nan * u.Unit(fit.model.parameters['amplitude'].unit)
+            return np.nan * u.Unit(fit.model.parameters[model.name + '.amplitude'].unit)
 
     def compute_flux_point_sqrt_ts(self, fit, stat_best_fit):
         """
@@ -740,14 +740,14 @@ class FluxPointEstimator(object):
         """
         model = fit.result[0].model.copy()
         # store best fit amplitude, set amplitude of fit model to zero
-        amplitude = model.parameters['amplitude'].value
+        amplitude = model.parameters[model.name + '.amplitude'].value
 
         # determine TS value for amplitude zero
-        model.parameters['amplitude'].value = 0
+        model.parameters[model.name + '.amplitude'].value = 0
         stat_null = fit.total_stat(model.parameters)
 
         # set amplitude of fit model to best fit amplitude
-        model.parameters['amplitude'].value = amplitude
+        model.parameters[model.name + '.amplitude'].value = amplitude
 
         # compute sqrt TS
         ts = np.abs(stat_null - stat_best_fit)
@@ -760,7 +760,7 @@ class FluxPointEstimator(object):
         energy_max = energy_group.energy_max
 
         # Set reference and remove min amplitude
-        model.parameters['reference'].value = energy_ref.to('TeV').value
+        model.parameters[model.name + '.reference'].value = energy_ref.to('TeV').value
 
         fit = SpectrumFit(self.obs, model)
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -37,6 +37,10 @@ class SpectralModel(object):
     See for example return pardict of
     `~gammapy.spectrum.models.PowerLaw`.
     """
+    @property
+    def name(self):
+        return self._name
+
     def __repr__(self):
         fmt = '{}()'
         return fmt.format(self.__class__.__name__)
@@ -103,9 +107,9 @@ class SpectralModel(object):
 
     def _convert_energy(self, energy):
         try:
-            energy = energy.to(self.parameters['reference'].unit)
+            energy = energy.to(self.parameters[self.name + '.reference'].unit)
         except IndexError:
-            energy = energy.to(self.parameters['emin'].unit)
+            energy = energy.to(self.parameters[self.name + '.emin'].unit)
         return energy
 
     def evaluate_error(self, energy):
@@ -431,10 +435,13 @@ class ConstantModel(SpectralModel):
     ----------
     const : `~astropy.units.Quantity`
         :math:`k`
+    name : str
+        model name
     """
-    def __init__(self, const):
+    def __init__(self, const, name='constant'):
+        self._name = str(name)
         self.parameters = ParameterList([
-            Parameter('const', const)
+            Parameter(name, 'const', const)
         ])
 
     @staticmethod
@@ -500,6 +507,8 @@ class PowerLaw(SpectralModel):
         :math:`\phi_0`
     reference : `~astropy.units.Quantity`
         :math:`E_0`
+    name : str
+        model name
 
 
     Examples
@@ -518,10 +527,8 @@ class PowerLaw(SpectralModel):
     """
 
     def __init__(self, index=2., amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
-                 reference=1 * u.TeV, name=None):
-        if name is None:
-            name = self.__class__.__name__
-        self.name = name
+                 reference=1 * u.TeV, name='powerlaw'):
+        self._name = str(name)
         self.parameters = ParameterList([
             Parameter(name, 'index', index),
             Parameter(name, 'amplitude', amplitude),
@@ -550,17 +557,20 @@ class PowerLaw(SpectralModel):
         # kwargs are passed to this function but not used
         # this is to get a consistent API with SpectralModel.integral()
         pars = self.parameters
+        index = pars.parameters[0]
+        amplitude = pars.parameters[1]
+        reference = pars.parameters[2] 
 
-        if np.isclose(pars['index'].value, 1):
+        if np.isclose(index.value, 1):
             e_unit = emin.unit
-            prefactor = pars['amplitude'].quantity * pars['reference'].quantity.to(e_unit)
+            prefactor = amplitude.quantity * reference.quantity.to(e_unit)
             upper = np.log(emax.to(e_unit).value)
             lower = np.log(emin.value)
         else:
-            val = -1 * pars['index'].value + 1
-            prefactor = pars['amplitude'].quantity * pars['reference'].quantity / val
-            upper = np.power((emax / pars['reference'].quantity), val)
-            lower = np.power((emin / pars['reference'].quantity), val)
+            val = -1 * index.value + 1
+            prefactor = amplitude.quantity * reference.quantity / val
+            upper = np.power((emax / reference.quantity), val)
+            lower = np.power((emin / reference.quantity), val)
 
         return prefactor * (upper - lower)
 
@@ -613,17 +623,20 @@ class PowerLaw(SpectralModel):
             Lower and upper bound of integration range.
         """
         pars = self.parameters
-        val = -1 * pars['index'].value + 2
+        index = pars.parameters[0]
+        amplitude = pars.parameters[1]
+        reference = pars.parameters[2] 
+        val = -1 * index.value + 2
 
         if np.isclose(val, 0):
             # see https://www.wolframalpha.com/input/?i=a+*+x+*+(x%2Fb)+%5E+(-2)
             # for reference
-            temp = pars['amplitude'].quantity * pars['reference'].quantity ** 2
+            temp = amplitude.quantity * reference.quantity ** 2
             return temp * np.log(emax / emin)
         else:
-            prefactor = pars['amplitude'].quantity * pars['reference'].quantity ** 2 / val
-            upper = (emax / pars['reference'].quantity) ** val
-            lower = (emin / pars['reference'].quantity) ** val
+            prefactor = amplitude.quantity * reference.quantity ** 2 / val
+            upper = (emax / reference.quantity) ** val
+            lower = (emin / reference.quantity) ** val
             return prefactor * (upper - lower)
 
     def energy_flux_error(self, emin, emax, **kwargs):
@@ -669,8 +682,12 @@ class PowerLaw(SpectralModel):
             Function value of the spectral model.
         """
         p = self.parameters
-        base = value / p['amplitude'].quantity
-        return p['reference'].quantity * np.power(base, - 1. / p['index'].value)
+        index = p.parameters[0]
+        amplitude = p.parameters[1]
+        reference = p.parameters[2]
+
+        base = value / amplitude.quantity
+        return reference.quantity * np.power(base, - 1. / index.value)
 
 
 class PowerLaw2(SpectralModel):
@@ -693,6 +710,8 @@ class PowerLaw2(SpectralModel):
         Lower energy limit :math:`E_{0, min}`.
     emax : `~astropy.units.Quantity`
         Upper energy limit :math:`E_{0, max}`.
+    name : str
+        model name
 
     Examples
     --------
@@ -709,12 +728,13 @@ class PowerLaw2(SpectralModel):
     """
 
     def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1'), index=2,
-                 emin=0.1 * u.TeV, emax=100 * u.TeV):
+                 emin=0.1 * u.TeV, emax=100 * u.TeV, name='powerlaw2'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('amplitude', amplitude),
-            Parameter('index', index),
-            Parameter('emin', emin, frozen=True),
-            Parameter('emax', emax, frozen=True)
+            Parameter(name, 'amplitude', amplitude),
+            Parameter(name, 'index', index),
+            Parameter(name, 'emin', emin, frozen=True),
+            Parameter(name, 'emax', emax, frozen=True)
         ])
 
     @staticmethod
@@ -741,16 +761,20 @@ class PowerLaw2(SpectralModel):
             Lower and upper bound of integration range.
         """
         pars = self.parameters
+        amplitude = pars.parameters[0]
+        index = pars.parameters[1]
+        emin_ = pars.parameters[2]
+        emax_ = pars.parameters[3]
 
-        temp1 = np.power(emax, -pars['index'].value + 1)
-        temp2 = np.power(emin, -pars['index'].value + 1)
+        temp1 = np.power(emax, -index.value + 1)
+        temp2 = np.power(emin, -index.value + 1)
         top = temp1 - temp2
 
-        temp1 = np.power(pars['emax'].quantity, -pars['index'].value + 1)
-        temp2 = np.power(pars['emin'].quantity, -pars['index'].value + 1)
+        temp1 = np.power(emax_.quantity, -index.value + 1)
+        temp2 = np.power(emin_.quantity, -index.value + 1)
         bottom = temp1 - temp2
 
-        return pars['amplitude'].quantity * top / bottom
+        return amplitude.quantity * top / bottom
 
     def integral_error(self, emin, emax, **kwargs):
         r"""Integrate power law analytically with error propagation.
@@ -791,11 +815,14 @@ class PowerLaw2(SpectralModel):
             Function value of the spectral model.
         """
         p = self.parameters
-        index = p['index'].value
+        amplitude = p.parameters[0]
+        index = p.parameters[1].value
+        emin = p.parameters[2]
+        emax = p.parameters[3]
         top = -index + 1
-        bottom = (p['emax'].quantity.to('TeV').value ** (-index + 1) -
-                  p['emin'].quantity.to('TeV').value ** (-index + 1))
-        term = (bottom / top) * (value / p['amplitude'].quantity).to('1 / TeV')
+        bottom = (emax.quantity.to('TeV').value ** (-index + 1) -
+                  emin.quantity.to('TeV').value ** (-index + 1))
+        term = (bottom / top) * (value / amplitude.quantity).to('1 / TeV')
         return np.power(term.value, -1. / index) * u.TeV
 
 
@@ -816,6 +843,8 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         :math:`E_0`
     lambda_ : `~astropy.units.Quantity`
         :math:`\lambda`
+    name : str
+        model name
 
     Examples
     --------
@@ -832,12 +861,14 @@ class ExponentialCutoffPowerLaw(SpectralModel):
     """
 
     def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
-                 reference=1 * u.TeV, lambda_=0.1 / u.TeV):
+                 reference=1 * u.TeV, lambda_=0.1 / u.TeV,
+                 name='expcutoffpowerlaw'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('index', index),
-            Parameter('amplitude', amplitude),
-            Parameter('reference', reference, frozen=True),
-            Parameter('lambda_', lambda_)
+            Parameter(name, 'index', index),
+            Parameter(name, 'amplitude', amplitude),
+            Parameter(name, 'reference', reference, frozen=True),
+            Parameter(name, 'lambda_', lambda_)
         ])
 
     @staticmethod
@@ -863,9 +894,9 @@ class ExponentialCutoffPowerLaw(SpectralModel):
 
         """
         p = self.parameters
-        reference = p['reference'].quantity
-        index = p['index'].quantity
-        lambda_ = p['lambda_'].quantity
+        index = p.parameters[0].quantity
+        reference = p.parameters[2].quantity
+        lambda_ = p.parameters[3].quantity
         if index >= 2:
             return np.nan * reference.unit
         else:
@@ -892,6 +923,8 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         :math:`E_0`
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
+    name : str
+        model name
 
     Examples
     --------
@@ -908,12 +941,13 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
     """
 
     def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
-                 reference=1 * u.TeV, ecut=10 * u.TeV):
+                 reference=1 * u.TeV, ecut=10 * u.TeV, name='expcutoffpowerlaw3fgl'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('index', index),
-            Parameter('amplitude', amplitude),
-            Parameter('reference', reference, frozen=True),
-            Parameter('ecut', ecut)
+            Parameter(name, 'index', index),
+            Parameter(name, 'amplitude', amplitude),
+            Parameter(name, 'reference', reference, frozen=True),
+            Parameter(name, 'ecut', ecut)
         ])
 
     @staticmethod
@@ -950,6 +984,8 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         :math:`E_0`
     ecut : `~astropy.units.Quantity`
         :math:`E_{C}`
+    name : str
+        model name
 
     Examples
     --------
@@ -966,14 +1002,15 @@ class PLSuperExpCutoff3FGL(SpectralModel):
     """
 
     def __init__(self, index_1=1.5, index_2=2, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
-                 reference=1 * u.TeV, ecut=10 * u.TeV):
+                 reference=1 * u.TeV, ecut=10 * u.TeV, name='plsuperexpcutoff3fgl'):
         # TODO: order or parameters is different from argument list / docstring. Make uniform!
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('amplitude', amplitude),
-            Parameter('reference', reference, frozen=True),
-            Parameter('ecut', ecut),
-            Parameter('index_1', index_1),
-            Parameter('index_2', index_2),
+            Parameter(name, 'amplitude', amplitude),
+            Parameter(name, 'reference', reference, frozen=True),
+            Parameter(name, 'ecut', ecut),
+            Parameter(name, 'index_1', index_1),
+            Parameter(name, 'index_2', index_2),
         ])
 
     @staticmethod
@@ -1019,6 +1056,8 @@ class LogParabola(SpectralModel):
         :math:`\alpha`
     beta : `~astropy.units.Quantity`
         :math:`\beta`
+    name : str
+        model name
 
     Examples
     --------
@@ -1035,12 +1074,13 @@ class LogParabola(SpectralModel):
     """
 
     def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'), reference=10 * u.TeV,
-                 alpha=2, beta=1):
+                 alpha=2, beta=1, name='logpar'):
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('amplitude', amplitude),
-            Parameter('reference', reference, frozen=True),
-            Parameter('alpha', alpha),
-            Parameter('beta', beta)
+            Parameter(name, 'amplitude', amplitude),
+            Parameter(name, 'reference', reference, frozen=True),
+            Parameter(name, 'alpha', alpha),
+            Parameter(name, 'beta', beta)
         ])
 
     @classmethod
@@ -1077,9 +1117,9 @@ class LogParabola(SpectralModel):
 
         """
         p = self.parameters
-        reference = p['reference'].quantity
-        alpha = p['alpha'].quantity
-        beta = p['beta'].quantity
+        reference = p.parameters[1].quantity
+        alpha = p.parameters[2].quantity
+        beta = p.parameters[3].quantity
         return reference * np.exp((2 - alpha) / (2 * beta))
 
 
@@ -1107,12 +1147,16 @@ class TableModel(SpectralModel):
         interpolation can be done linearly or in logarithm
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialization
+    name : str
+        model name
     """
 
-    def __init__(self, energy, values, scale=1, scale_logy=True, meta=None):
+    def __init__(self, energy, values, scale=1, scale_logy=True, meta=None,
+                 name='tablemodel'):
         from scipy.interpolate import interp1d
+        self._name = name
         self.parameters = ParameterList([
-            Parameter('scale', scale, min=0, unit='')
+            Parameter(name, 'scale', scale, min=0, unit='')
         ])
         self.energy = energy
         self.values = values
@@ -1281,7 +1325,7 @@ class TableModel(SpectralModel):
         emin, emax = energy_range
         energy = EnergyBounds.equal_log_spacing(emin, emax, n_points, energy_unit)
 
-        y = self.interpy(np.log10(energy.to('eV').value)) * self.parameters['scale'].quantity
+        y = self.interpy(np.log10(energy.to('eV').value)) * self.parameters[self.name + '.scale'].quantity
         if self.scale_logy:
             y = np.power(10, y)
 
@@ -1467,7 +1511,8 @@ class AbsorbedSpectralModel(SpectralModel):
     """
 
     def __init__(self, spectral_model, absorption,
-                 parameter, parameter_name='redshift'):
+                 parameter, parameter_name='redshift', name='absorbed'):
+        self._name = name
         self.spectral_model = spectral_model
         self.absorption = absorption
         self.parameter = parameter
@@ -1481,7 +1526,7 @@ class AbsorbedSpectralModel(SpectralModel):
         # Add parameter to the list
         min_ = self.absorption.data.axes[0].lo[0]
         max_ = self.absorption.data.axes[0].lo[-1]
-        par = Parameter(parameter_name, parameter,
+        par = Parameter(name, parameter_name, parameter,
                         min=min_, max=max_,
                         frozen=True)
         param_list.append(par)

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -37,7 +37,6 @@ class SpectralModel(object):
     See for example return pardict of
     `~gammapy.spectrum.models.PowerLaw`.
     """
-
     def __repr__(self):
         fmt = '{}()'
         return fmt.format(self.__class__.__name__)
@@ -519,11 +518,14 @@ class PowerLaw(SpectralModel):
     """
 
     def __init__(self, index=2., amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
-                 reference=1 * u.TeV):
+                 reference=1 * u.TeV, name=None):
+        if name is None:
+            name = self.__class__.__name__
+        self.name = name
         self.parameters = ParameterList([
-            Parameter('index', index),
-            Parameter('amplitude', amplitude),
-            Parameter('reference', reference, min=0, frozen=True)
+            Parameter(name, 'index', index),
+            Parameter(name, 'amplitude', amplitude),
+            Parameter(name, 'reference', reference, min=0, frozen=True)
         ])
 
     @staticmethod

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -145,7 +145,8 @@ class SpectrumFitResult(object):
         """
         t = Table()
         t['model'] = [self.model.__class__.__name__]
-        for par_name, value in self.model.parameters._ufloats.items():
+        for par_name, value in zip(self.model.parameters.names,
+                                   self.model.parameters._ufloats.values()):
             val = value.n
             err = value.s
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -69,12 +69,12 @@ class TestFit:
         fit.calc_statval()
         assert_allclose(np.sum(fit.statval[0]), -107346.5291, rtol=1e-5)
 
-        self.source_model.parameters['index'].value = 1.12
+        self.source_model.parameters['powerlaw.index'].value = 1.12
         fit.fit()
         # These values are check with sherpa fits, do not change
         pars = fit.result[0].model.parameters
-        assert_allclose(pars['index'].value, 1.995525, rtol=1e-3)
-        assert_allclose(pars['amplitude'].value, 100245.9, rtol=1e-3)
+        assert_allclose(pars['powerlaw.index'].value, 1.995525, rtol=1e-3)
+        assert_allclose(pars['powerlaw.amplitude'].value, 100245.9, rtol=1e-3)
 
     def test_wstat(self):
         """WStat with on source and background spectrum"""
@@ -88,8 +88,8 @@ class TestFit:
                           stat='wstat', forward_folded=False)
         fit.fit()
         pars = fit.result[0].model.parameters
-        assert_allclose(pars['index'].value, 1.997342, rtol=1e-3)
-        assert_allclose(pars['amplitude'].value, 100245.187067, rtol=1e-3)
+        assert_allclose(pars['powerlaw.index'].value, 1.997342, rtol=1e-3)
+        assert_allclose(pars['powerlaw.amplitude'].value, 100245.187067, rtol=1e-3)
         assert_allclose(fit.result[0].statval, 30.022316, rtol=1e-3)
 
     def test_joint(self):
@@ -101,7 +101,7 @@ class TestFit:
                           model=self.source_model, forward_folded=False)
         fit.fit()
         pars = fit.result[0].model.parameters
-        assert_allclose(pars['index'].value, 1.996456, rtol=1e-3)
+        assert_allclose(pars['powerlaw.index'].value, 1.996456, rtol=1e-3)
 
     def test_fit_range(self):
         """Test fit range without complication of thresholds"""
@@ -138,9 +138,10 @@ class TestFit:
         fit = SpectrumFit(obs_list=obs, stat='cash', model=self.source_model,
                           forward_folded=False)
         fit.fit()
-        true_idx = fit.result[0].model.parameters['index'].value
+        true_idx = fit.result[0].model.parameters['powerlaw.index'].value
         scan_idx = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)
-        profile = fit.likelihood_1d(model=fit.result[0].model, parname='index',
+        profile = fit.likelihood_1d(model=fit.result[0].model,
+                                    parname='powerlaw.index',
                                     parvals=scan_idx)
         argmin = np.argmin(profile)
         actual = scan_idx[argmin]
@@ -153,7 +154,7 @@ class TestFit:
                           forward_folded=False)
 
         scan_idx = np.linspace(1, 3, 20)
-        fit.plot_likelihood_1d(model=self.source_model, parname='index',
+        fit.plot_likelihood_1d(model=self.source_model, parname='powerlaw.index',
                                parvals=scan_idx)
         # TODO: add assert, see issue 294
 
@@ -188,9 +189,9 @@ class TestSpectralFit:
         result = self.fit.result[0]
         assert_allclose(result.statval, 32.8387, rtol=1e-4)
         pars = result.model.parameters
-        assert_allclose(pars['index'].value, 2.25423, rtol=1e-2)
-        assert pars['amplitude'].unit == u.Unit('cm-2 s-1 TeV-1')
-        assert_allclose(pars['amplitude'].value, 2.008654e-11, rtol=1e-2)
+        assert_allclose(pars['powerlaw.index'].value, 2.25423, rtol=1e-2)
+        assert pars['powerlaw.amplitude'].unit == u.Unit('cm-2 s-1 TeV-1')
+        assert_allclose(pars['powerlaw.amplitude'].value, 2.008654e-11, rtol=1e-2)
         assert_allclose(result.npred_src[60], 0.5638139, rtol=1e-3)
         self.fit.result[0].to_table()
 
@@ -198,8 +199,8 @@ class TestSpectralFit:
         self.fit.fit()
         self.fit.est_errors()
         result = self.fit.result[0]
-        assert_allclose(result.model.parameters.error('index'), 0.097866953, rtol=1e-3)
-        assert_allclose(result.model.parameters.error('amplitude'), 2.1994e-12, rtol=1e-3)
+        assert_allclose(result.model.parameters.error('powerlaw.index'), 0.097866953, rtol=1e-3)
+        assert_allclose(result.model.parameters.error('powerlaw.amplitude'), 2.1994e-12, rtol=1e-3)
         self.fit.result[0].to_table()
 
     def test_compound(self):
@@ -207,10 +208,10 @@ class TestSpectralFit:
         fit.fit()
         result = fit.result[0]
         pars = result.model.parameters
-        assert_allclose(pars['index'].value, 2.254163, rtol=1e-3)
+        assert_allclose(pars['powerlaw.index'].value, 2.254163, rtol=1e-3)
         # amplitude should come out roughly * 0.5
-        assert pars['amplitude'].unit == u.Unit('cm-2 s-1 TeV-1')
-        assert_allclose(pars['amplitude'].value, 1.030963e-11, rtol=1e-3)
+        assert pars['powerlaw.amplitude'].unit == u.Unit('cm-2 s-1 TeV-1')
+        assert_allclose(pars['powerlaw.amplitude'].value, 1.030963e-11, rtol=1e-3)
 
     def test_npred(self):
         self.fit.fit()
@@ -259,29 +260,29 @@ class TestSpectralFit:
         obs.edisp = None
         fit = SpectrumFit(obs_list=obs, model=self.pwl)
         fit.fit()
-        assert_allclose(fit.result[0].model.parameters['index'].value, 2.296, atol=0.02)
+        assert_allclose(fit.result[0].model.parameters['powerlaw.index'].value, 2.296, atol=0.02)
 
     def test_ecpl_fit(self):
         self.ecpl.parameters.set_parameter_errors(
-            {'amplitude': 1e-11 * u.Unit('cm-2 s-1 TeV-1'),
-             'lambda': 0.1 / u.TeV}
+            {'expcutoffpowerlaw.amplitude': 1e-11 * u.Unit('cm-2 s-1 TeV-1'),
+             'expcutoffpowerlaw.lambda_': 0.1 / u.TeV}
         )
         fit = SpectrumFit(self.obs_list[0], self.ecpl)
         fit.fit()
-        actual = fit.result[0].model.parameters['lambda_'].quantity
+        actual = fit.result[0].model.parameters['expcutoffpowerlaw.lambda_'].quantity
         assert actual.unit == 'TeV-1'
         assert_allclose(actual.value, 0.034241, rtol=1e-3)
 
     def test_joint_fit(self):
         self.pwl.parameters.set_parameter_errors(
-            {'amplitude': 1e-11 * u.Unit('cm-2 s-1 TeV-1')}
+            {'powerlaw.amplitude': 1e-11 * u.Unit('cm-2 s-1 TeV-1')}
         )
         fit = SpectrumFit(self.obs_list, self.pwl)
         fit.fit()
-        actual = fit.result[0].model.parameters['index'].value
+        actual = fit.result[0].model.parameters['powerlaw.index'].value
         assert_allclose(actual, 2.21225, rtol=1e-3)
 
-        actual = fit.result[0].model.parameters['amplitude'].quantity
+        actual = fit.result[0].model.parameters['powerlaw.amplitude'].quantity
         assert actual.unit == 'cm-2 s-1 TeV-1'
         assert_allclose(actual.value, 2.361871e-11, rtol=1e-3)
 
@@ -291,13 +292,13 @@ class TestSpectralFit:
         fit = SpectrumFit(obs_list, self.pwl)
         fit.fit()
         pars = fit.result[0].model.parameters
-        assert_allclose(pars['index'].value, 2.21338, rtol=1e-3)
-        assert u.Unit(pars['amplitude'].unit) == 'cm-2 s-1 TeV-1'
-        assert_allclose(pars['amplitude'].value, 2.361827e-11, rtol=1e-3)
+        assert_allclose(pars['powerlaw.index'].value, 2.21338, rtol=1e-3)
+        assert u.Unit(pars['powerlaw.amplitude'].unit) == 'cm-2 s-1 TeV-1'
+        assert_allclose(pars['powerlaw.amplitude'].value, 2.361827e-11, rtol=1e-3)
 
     def test_run(self, tmpdir):
         self.pwl.parameters.set_parameter_errors(
-            {'amplitude': 1e-11 * u.Unit('cm-2 s-1 TeV-1')}
+            {'powerlaw.amplitude': 1e-11 * u.Unit('cm-2 s-1 TeV-1')}
         )
         fit = SpectrumFit(self.obs_list, self.pwl)
         fit.run(outdir=tmpdir)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -403,9 +403,9 @@ class TestFluxPointFitter:
         model = PowerLaw(index=2.3, amplitude='1e-12 cm-2 s-1 TeV-1', reference='1 TeV')
         result = fitter.run(self.flux_points, model)
 
-        index = result['best-fit-model'].parameters['index']
+        index = result['best-fit-model'].parameters['powerlaw.index']
         assert_quantity_allclose(index.quantity, 2.216 * u.Unit(''), rtol=1e-3)
-        amplitude = result['best-fit-model'].parameters['amplitude']
+        amplitude = result['best-fit-model'].parameters['powerlaw.amplitude']
         assert_quantity_allclose(amplitude.quantity, 2.1616E-13 * u.Unit('cm-2 s-1 TeV-1'), rtol=1e-3)
         assert_allclose(result['statval'], 25.2059, rtol=1e-3)
         assert_allclose(result['dof'], 22)

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -259,7 +259,7 @@ def test_pwl_index_2_error():
     pars['amplitude'] = 1e-12 * u.Unit('TeV-1 cm-2 s-1')
     pars['reference'] = 1 * u.Unit('TeV')
     pars['index'] = 2 * u.Unit('')
-    errs['amplitude'] = 0.1e-12 * u.Unit('TeV-1 cm-2 s-1')
+    errs['powerlaw.amplitude'] = 0.1e-12 * u.Unit('TeV-1 cm-2 s-1')
 
     pwl = PowerLaw(**pars)
     pwl.parameters.set_parameter_errors(errs)

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -18,7 +18,7 @@ class TestSpectrumFitResult:
                                        amplitude=1e-11 * u.Unit('cm-2 s-1 TeV-1'),
                                        reference=1 * u.TeV)
         self.npred = self.obs.predicted_counts(self.best_fit_model).data.data.value
-        covar_axis = ['index', 'amplitude']
+        covar_axis = ['powerlaw.index', 'powerlaw.amplitude']
         covar = np.diag([0.1 ** 2, 1e-12 ** 2])
         self.best_fit_model.parameters.set_parameter_covariance(covar, covar_axis)
         self.fit_range = [0.1, 50] * u.TeV
@@ -35,7 +35,7 @@ class TestSpectrumFitResult:
     @requires_dependency('uncertainties')
     def test_basic(self):
         assert 'PowerLaw' in str(self.fit_result)
-        assert 'index' in self.fit_result.to_table().colnames
+        assert 'powerlaw.index' in self.fit_result.to_table().colnames
 
     @requires_dependency('yaml')
     def test_io(self, tmpdir):

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -75,8 +75,8 @@ class TestSpectrumSimulation:
     def test_without_aeff(self):
         e_true = EnergyBounds.equal_log_spacing(1, 10, 5, u.TeV)
         rate_model = self.source_model.copy()
-        rate_model.parameters['amplitude'].unit = u.Unit('TeV-1 s-1')
-        rate_model.parameters['amplitude'].value = 1
+        rate_model.parameters['powerlaw.amplitude'].unit = u.Unit('TeV-1 s-1')
+        rate_model.parameters['powerlaw.amplitude'].value = 1
         sim = SpectrumSimulation(source_model=rate_model,
                                  livetime=4*u.h,
                                  e_true=e_true 

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -64,14 +64,15 @@ class PhaseCurve(object):
     0.49059393580053845
     """
 
-    def __init__(self, table, time_0, phase_0, f0, f1, f2):
+    def __init__(self, table, time_0, phase_0, f0, f1, f2, name='phase_curve'):
+        self.name = name
         self.table = table
         self.parameters = ParameterList([
-            Parameter('time_0', time_0),
-            Parameter('phase_0', phase_0),
-            Parameter('f0', f0),
-            Parameter('f1', f1),
-            Parameter('f2', f2)]
+            Parameter(name, 'time_0', time_0),
+            Parameter(name, 'phase_0', phase_0),
+            Parameter(name, 'f0', f0),
+            Parameter(name, 'f1', f1),
+            Parameter(name, 'f2', f2)]
         )
 
     def phase(self, time):
@@ -86,11 +87,11 @@ class PhaseCurve(object):
         phase : array_like
         """
         pars = self.parameters
-        time_0 = pars['time_0'].value
-        phase_0 = pars['phase_0'].value
-        f0 = pars['f0'].value
-        f1 = pars['f1'].value
-        f2 = pars['f2'].value
+        time_0 = pars.parameters[0].value
+        phase_0 = pars.parameters[1].value
+        f0 = pars.parameters[2].value
+        f1 = pars.parameters[3].value
+        f2 = pars.parameters[4].value
 
         t = (time - time_0) * u.day.to(u.second)
         phase = self._evaluate_phase(t, phase_0, f0, f1, f2)

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -85,19 +85,19 @@ def make_minuit_par_kwargs(parameters):
     """
     kwargs = {}
     for par in parameters.parameters:
-        kwargs[par.name] = par.value
+        kwargs[par.fullname] = par.value
 
         min_ = None if np.isnan(par.min) else par.min
         max_ = None if np.isnan(par.max) else par.max
-        kwargs['limit_{}'.format(par.name)] = (min_, max_)
+        kwargs['limit_{}'.format(par.fullname)] = (min_, max_)
 
         if parameters.covariance is None:
-            kwargs['error_{}'.format(par.name)] = 1
+            kwargs['error_{}'.format(par.fullname)] = 1
         else:
-            kwargs['error_{}'.format(par.name)] = parameters.error(par.name)
+            kwargs['error_{}'.format(par.fullname)] = parameters.error(par.name)
 
         if par.frozen:
-            kwargs['fix_{}'.format(par.name)] = True
+            kwargs['fix_{}'.format(par.fullname)] = True
 
     return kwargs
 

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -94,7 +94,7 @@ def make_minuit_par_kwargs(parameters):
         if parameters.covariance is None:
             kwargs['error_{}'.format(par.fullname)] = 1
         else:
-            kwargs['error_{}'.format(par.fullname)] = parameters.error(par.name)
+            kwargs['error_{}'.format(par.fullname)] = parameters.error(par.fullname)
 
         if par.frozen:
             kwargs['fix_{}'.format(par.fullname)] = True

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -7,35 +7,37 @@ from .. import fit_iminuit
 
 
 def fcn(parameters):
-    x = parameters['x'].value
-    y = parameters['y'].value
-    z = parameters['z'].value
+    x = parameters['model.x'].value
+    y = parameters['model.y'].value
+    z = parameters['model.z'].value
     return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
 
 @requires_dependency('iminuit')
 def test_iminuit():
     pars = ParameterList(
-        [Parameter('x', 2.1), Parameter('y', 3.1), Parameter('z', 4.1)]
+        [Parameter('model', 'x', 2.1),
+         Parameter('model', 'y', 3.1),
+         Parameter('model', 'z', 4.1)]
     )
 
     minuit = fit_iminuit(function=fcn, parameters=pars)
 
-    assert_allclose(pars['x'].value, 2, rtol=1e-2)
-    assert_allclose(pars['y'].value, 3, rtol=1e-2)
-    assert_allclose(pars['z'].value, 4, rtol=1e-2)
+    assert_allclose(pars['model.x'].value, 2, rtol=1e-2)
+    assert_allclose(pars['model.y'].value, 3, rtol=1e-2)
+    assert_allclose(pars['model.z'].value, 4, rtol=1e-2)
 
-    assert_allclose(minuit.values['x'], 2, rtol=1e-2)
-    assert_allclose(minuit.values['y'], 3, rtol=1e-2)
-    assert_allclose(minuit.values['z'], 4, rtol=1e-2)
+    assert_allclose(minuit.values['model.x'], 2, rtol=1e-2)
+    assert_allclose(minuit.values['model.y'], 3, rtol=1e-2)
+    assert_allclose(minuit.values['model.z'], 4, rtol=1e-2)
 
     # Test freeze
-    pars['x'].frozen = True
+    pars['model.x'].frozen = True
     minuit = fit_iminuit(function=fcn, parameters=pars)
-    assert minuit.list_of_fixed_param() == ['x']
+    assert minuit.list_of_fixed_param() == ['model.x']
 
     # Test limits
-    pars['y'].min = 4
+    pars['model.y'].min = 4
     minuit = fit_iminuit(function=fcn, parameters=pars)
     states = minuit.get_param_states()
     assert not states[0]['has_limits']
@@ -46,7 +48,7 @@ def test_iminuit():
     assert states[1]['upper_limit'] == 0
 
     # Test stepsize via covariance matrix
-    pars.set_parameter_errors({'x': '0.2', 'y': '0.1'})
+    pars.set_parameter_errors({'model.x': '0.2', 'model.y': '0.1'})
     minuit = fit_iminuit(function=fcn, parameters=pars)
 
     assert minuit.migrad_ok()

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -8,9 +8,9 @@ from ..sherpa import fit_sherpa
 
 
 def fcn(parameters):
-    x = parameters['x'].value
-    y = parameters['y'].value
-    z = parameters['z'].value
+    x = parameters['model.x'].value
+    y = parameters['model.y'].value
+    z = parameters['model.z'].value
     return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2, 0
 
 
@@ -21,7 +21,8 @@ def fcn(parameters):
 @pytest.mark.parametrize('optimizer', ['moncar', 'simplex'])
 def test_sherpa(optimizer):
     pars = ParameterList(
-        [Parameter('x', 2.2), Parameter('y', 3.4), Parameter('z', 4.5)]
+        [Parameter('model', 'x', 2.2), Parameter('model', 'y', 3.4),
+         Parameter('model', 'z', 4.5)]
     )
 
     result = fit_sherpa(function=fcn, parameters=pars, optimizer=optimizer)
@@ -29,6 +30,6 @@ def test_sherpa(optimizer):
     assert result['success']
     assert result['nfev'] > 10
     assert_allclose(result['statval'], 0, atol=1e-2)
-    assert_allclose(pars['x'].value, 2, rtol=1e-2)
-    assert_allclose(pars['y'].value, 3, rtol=1e-2)
-    assert_allclose(pars['z'].value, 4, rtol=1e-2)
+    assert_allclose(pars['model.x'].value, 2, rtol=1e-2)
+    assert_allclose(pars['model.y'].value, 3, rtol=1e-2)
+    assert_allclose(pars['model.z'].value, 4, rtol=1e-2)

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -28,7 +28,7 @@ def test_from_xml():
         '''
     source_library = SourceLibrary.from_xml(xml)
     sky_model = source_library.skymodels[0]
-    assert_allclose(sky_model.parameters['lon_0'].value, 187.25)
+    assert_allclose(sky_model.parameters['xml_model.lon_0'].value, 187.25)
 
 
 def test_xml_errors():
@@ -64,49 +64,49 @@ def test_complex():
     assert isinstance(model1.spatial_model, spatial.SkyPointSource)
 
     pars1 = model1.parameters
-    assert pars1['index'].value == 2.1
-    assert pars1['index'].unit == ''
-    assert pars1['index'].max is np.nan
-    assert pars1['index'].min is np.nan
-    assert pars1['index'].frozen is False
+    assert pars1['xml_model.index'].value == 2.1
+    assert pars1['xml_model.index'].unit == ''
+    assert pars1['xml_model.index'].max is np.nan
+    assert pars1['xml_model.index'].min is np.nan
+    assert pars1['xml_model.index'].frozen is False
 
-    assert pars1['lon_0'].value == 0.5
-    assert pars1['lon_0'].unit == 'deg'
-    assert pars1['lon_0'].max == 360
-    assert pars1['lon_0'].min == -360
-    assert pars1['lon_0'].frozen is True
+    assert pars1['xml_model.lon_0'].value == 0.5
+    assert pars1['xml_model.lon_0'].unit == 'deg'
+    assert pars1['xml_model.lon_0'].max == 360
+    assert pars1['xml_model.lon_0'].min == -360
+    assert pars1['xml_model.lon_0'].frozen is True
 
-    assert pars1['lat_0'].value == 1.0
-    assert pars1['lat_0'].unit == 'deg'
-    assert pars1['lat_0'].max == 90
-    assert pars1['lat_0'].min == -90
-    assert pars1['lat_0'].frozen is True
+    assert pars1['xml_model.lat_0'].value == 1.0
+    assert pars1['xml_model.lat_0'].unit == 'deg'
+    assert pars1['xml_model.lat_0'].max == 90
+    assert pars1['xml_model.lat_0'].min == -90
+    assert pars1['xml_model.lat_0'].frozen is True
 
     model2 = sourcelib.skymodels[2]
     assert isinstance(model2.spectral_model, spectral.ExponentialCutoffPowerLaw)
     assert isinstance(model2.spatial_model, spatial.SkyGaussian)
 
     pars2 = model2.parameters
-    assert pars2['sigma'].unit == 'deg'
-    assert pars2['lambda_'].value == 0.01
-    assert pars2['lambda_'].unit == 'MeV-1'
-    assert pars2['lambda_'].min is np.nan
-    assert pars2['lambda_'].max is np.nan
-    assert pars2['index'].value == 2.2
-    assert pars2['index'].unit == ''
-    assert pars2['index'].max is np.nan
-    assert pars2['index'].min is np.nan
+    assert pars2['xml_model.sigma'].unit == 'deg'
+    assert pars2['xml_model.lambda_'].value == 0.01
+    assert pars2['xml_model.lambda_'].unit == 'MeV-1'
+    assert pars2['xml_model.lambda_'].min is np.nan
+    assert pars2['xml_model.lambda_'].max is np.nan
+    assert pars2['xml_model.index'].value == 2.2
+    assert pars2['xml_model.index'].unit == ''
+    assert pars2['xml_model.index'].max is np.nan
+    assert pars2['xml_model.index'].min is np.nan
 
     model3 = sourcelib.skymodels[3]
     assert isinstance(model3.spatial_model, spatial.SkyDisk)
     pars3 = model3.parameters
-    assert pars3['r_0'].unit == 'deg'
+    assert pars3['xml_model.r_0'].unit == 'deg'
 
     model4 = sourcelib.skymodels[4]
     assert isinstance(model4.spatial_model, spatial.SkyShell)
     pars4 = model4.parameters
-    assert pars4['radius'].unit == 'deg'
-    assert pars4['width'].unit == 'deg'
+    assert pars4['xml_model.radius'].unit == 'deg'
+    assert pars4['xml_model.width'].unit == 'deg'
 
     model5 = sourcelib.skymodels[5]
     assert isinstance(model5.spatial_model, spatial.SkyDiffuseMap)

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -213,17 +213,17 @@ def xml_to_model(xml, which):
         # Special case models for which the XML definition does not map one to
         # one to the gammapy model definition
         if type_ == 'PowerLaw':
-            model.parameters['index'].value *= -1
-            model.parameters['index'].min = np.nan
-            model.parameters['index'].max = np.nan
+            model.parameters['xml_model.index'].value *= -1
+            model.parameters['xml_model.index'].min = np.nan
+            model.parameters['xml_model.index'].max = np.nan
         if type_ == 'ExponentialCutoffPowerLaw':
-            model.parameters['lambda_'].value = 1 / model.parameters['lambda_'].value
-            model.parameters['lambda_'].unit = model.parameters['lambda_'].unit + '-1'
-            model.parameters['lambda_'].min = np.nan
-            model.parameters['lambda_'].max = np.nan
-            model.parameters['index'].value *= -1
-            model.parameters['index'].min = np.nan
-            model.parameters['index'].max = np.nan
+            model.parameters['xml_model.lambda_'].value = 1 / model.parameters['xml_model.lambda_'].value
+            model.parameters['xml_model.lambda_'].unit = model.parameters['xml_model.lambda_'].unit + '-1'
+            model.parameters['xml_model.lambda_'].min = np.nan
+            model.parameters['xml_model.lambda_'].max = np.nan
+            model.parameters['xml_model.index'].value *= -1
+            model.parameters['xml_model.index'].min = np.nan
+            model.parameters['xml_model.index'].max = np.nan
 
     return model
 
@@ -248,6 +248,7 @@ def xml_to_parameter_list(xml, which, type_):
         frozen = bool(1 - int(par['@free']))
 
         parameters.append(Parameter(
+            modelname='xml_model',
             name=name,
             value=value,
             unit=unit,

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -7,8 +7,10 @@ from ..modeling import Parameter, ParameterList
 
 
 def test_parameter_init():
-    par = Parameter('spam', 42, 'deg')
+    par = Parameter('model', 'spam', 42, 'deg')
     assert par.name == 'spam'
+    assert par.modelname == 'model'
+    assert par.fullname == 'model.spam'
     assert par.value == 42
     assert par.unit == 'deg'
     assert par.min is np.nan
@@ -17,19 +19,19 @@ def test_parameter_init():
 
 
 def test_parameter_repr():
-    par = Parameter('spam', 42, 'deg')
-    assert repr(par).startswith('Parameter(name=')
+    par = Parameter('model', 'spam', 42, 'deg')
+    assert repr(par).startswith('Parameter(modelname=')
 
 
 def test_parameter_list():
     pars = ParameterList([
-        Parameter('spam', 42, 'deg'),
-        Parameter('ham', 99, 'TeV'),
+        Parameter('model', 'spam', 42, 'deg'),
+        Parameter('model', 'ham', 99, 'TeV'),
     ])
     # This applies a unit transformation
     pars.set_parameter_errors({
-        'ham': '10000 GeV',
+        'model.ham': '10000 GeV',
     })
     assert_allclose(pars.covariance, [[0, 0], [0, 100]])
-    assert_allclose(pars.error('spam'), 0)
-    assert_allclose(pars.error('ham'), 10)
+    assert_allclose(pars.error('model.spam'), 0)
+    assert_allclose(pars.error('model.ham'), 10)


### PR DESCRIPTION
### Problem

This PR is motivated by the need to fit 2 source in the FoV in a 3D analysis. This was not possible so far because ``iminuit`` is not able to deal with different parameters having the same name. This situation naturally occurs when fitting e.g. two gaussians.

### Implementation in this PR

This PR add a ``modelname`` attribute to each ``Parameter``. This is analogous to Sherpa. Therefore the index parameter is now called ``PowerLaw.index`` by default, unless you give the PowerLaw model another name. This is bad in the sense that it requires a lot more typing when accessing Parameters for example to set the errors (see script in ``examples`` added in this PR for demonstration purposes). Also it is not yet clear when to use ``parname`` and when to use ``modelname.parname``. Note that this solution is just my first go at the 2 Gauss Problem. Comments welcome. Should we choose to stick with this solution, all callers of Parameter have to be updated (because they now expect a modelname, as a short term solution, we can find a default value)

### Alternatives

One could also have translated the parameters names to par1 .... parN in the minuit interface. This would have been less intrusive, but has the disadvantages that it will be much harder to use the Minuit object directly (which many people do at the moment) because all one sees would be par1 ... parN