### PR TITLE
Use map axis names well, remove axis type

### DIFF
--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -55,7 +55,7 @@ def fill_map_counts(counts_map, events):
     cols = {k.upper(): v for k, v in events.table.columns.items()}
 
     for axis in counts_map.geom.axes:
-        if axis.name.lower() in ['energy', 'energy_reco']:
+        if axis.name.upper() in ['ENERGY', 'ENERGY_RECO']:
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict[axis.name] = events.energy.to(axis.unit)
         # TODO: add proper extraction for time

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -55,7 +55,7 @@ def fill_map_counts(counts_map, events):
     cols = {k.upper(): v for k, v in events.table.columns.items()}
 
     for axis in counts_map.geom.axes:
-        if axis.type == 'energy':
+        if axis.name.lower() in ['energy', 'energy_reco']:
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict[axis.name] = events.energy.to(axis.unit)
         # TODO: add proper extraction for time

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -85,13 +85,20 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
         the input table PSF
     geom : `~gammapy.maps.MapGeom`
         the target geometry. The PSF kernel will be centered on the spatial centre.
-        the geometry axes should contain an energy MapAxis. The kernel will be
-        duplicated along other axes.
+        the geometry axes should contain an energy MapAxis, named 'energy_true' or 'energy'.
+        The kernel will be duplicated along other axes.
     factor : int
         the oversample factor to compute the PSF
     """
     # Find energy axis in geom
-    energy_axis = geom.get_axis_by_type('energy')
+    try:
+        energy_axis = geom.get_axis_by_name('energy_true')
+    except ValueError:
+        try:
+            energy_axis = geom.get_axis_by_name('energy')
+        except:
+            raise ValueError("Cannot find energy axis name.")
+
     energy_idx = geom.axes.index(energy_axis)
     energy_unit = u.Unit(energy_axis.unit)
 
@@ -185,7 +192,7 @@ class PSFKernel(object):
             the input table PSF
         geom : `~gammapy.maps.WcsGeom`
             the target geometry. The PSF kernel will be centered on the central pixel.
-            the geometry axes should contain an energy MapAxis.
+            the geometry axes should contain an energy MapAxis named 'energy' or 'energy_true'.
         max_radius : `~astropy.coordinates.Angle`
             the maximum radius of the PSF kernel.
         factor : int

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -66,11 +66,7 @@ def test_fill_map_counts_hpx(events):
 
     axis_det = MapAxis([-2, 1, 5], node_type='edge', name='detx', unit='deg')
     # This test to check entries without units in eventlist table do not fail
-<<<<<<< HEAD
     axis_evt = MapAxis((0, 100000, 150000), node_type='edge', name='event_id')
-=======
-    axis_evt = MapAxis((0, 100000, 150000), node_type='edge', name='event_id', unit='')
->>>>>>> Added check on energy axis name following predefined conventions and added test with multiple energy axis names
 
     geom = HpxGeom(256, coordsys='GAL', axes=[axis_evt, axis_det])
 

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -94,8 +94,7 @@ def test_fill_map_counts_multiple_energy_axes(events):
     cntmap1 = WcsNDMap.create(binsz=1, npix=10, coordsys='GAL', axes=[axis, axis_mc])
     cntmap2 = WcsNDMap.create(binsz=1, npix=10, coordsys='GAL', axes=[axis_mc, axis_reco])
 
-    col_mc = Column(np.ones(len(events.table)) * u.TeV, name='ENERGY_MC')
-    events.table.add_column(col_mc)
+    events.table['ENERGY_MC'] = 1*u.TeV
 
     # Check that energy_mc entries are placed in the right axis
     fill_map_counts(cntmap1, events)

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -99,3 +100,12 @@ def test_energy_dependent_psf_kernel():
     some_map_convolved = psf_kernel.apply(some_map)
 
     assert_allclose(some_map_convolved.data.sum(axis=(1, 2)), np.array((0, 1, 1)))
+
+    # Now test behaviour if energy axis is not energy or energy_true
+    energy_reco_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy_reco')
+
+    # Create WcsGeom and map
+    geom = WcsGeom.create(binsz=0.02 * u.deg, width=4.0 * u.deg, axes=[energy_reco_axis])
+    some_map = Map.from_geom(geom)
+    with pytest.raises(ValueError):
+        psf_kernel = PSFKernel.from_table_psf(table_psf, geom, max_radius=1 * u.deg)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -363,14 +363,6 @@ class MapAxis(object):
         self._node_type = node_type
         self._unit = u.Unit('' if unit is None else unit)
 
-        # Set axis type from its unit
-        if self._unit.is_equivalent("eV"):
-            self._type = 'energy'
-        elif self._unit.is_equivalent("s"):
-            self._type = 'time'
-        else:
-            self._type = 'any'
-
         # Set pixel coordinate of first node
         if node_type == 'edge':
             self._pix_offset = -0.5
@@ -432,11 +424,6 @@ class MapAxis(object):
     def unit(self):
         """Return coordinate axis unit."""
         return self._unit
-
-    @property
-    def type(self):
-        """Return coordinate axis type."""
-        return self._type
 
     @classmethod
     def from_bounds(cls, lo_bnd, hi_bnd, nbin, **kwargs):
@@ -614,7 +601,6 @@ class MapAxis(object):
         str_ = self.__class__.__name__
         str_ += "\n\n"
         str_ += "\tname     : {}\n".format(self.name)
-        str_ += "\ttype     : {}\n".format(self.type)
         str_ += "\tunit     : {}\n".format(self.unit)
         str_ += "\tnbins    : {}\n".format(self.nbin)
         str_ += "\tnode type: {}\n".format(self.node_type)
@@ -1395,28 +1381,6 @@ class MapGeom(object):
             if axis.name.upper() == name.upper():
                 return axis
         raise ValueError("Cannot find axis named {}".format(name))
-
-    def get_axis_by_type(self, type):
-        """Returns axis of given type.
-
-        Parameters
-        ----------
-        type : str in {'energy', 'time', 'any'}
-           the name of the requested type of axis
-
-        Returns
-        -------
-        axes : `~gammapy.maps.MapAxis`
-            the corresponding  axis
-        """
-        valid_types = ('energy', 'time', 'any')
-        if type not in valid_types:
-            raise ValueError("Invalid axis type {}. Should be {}.".format(type, valid_types))
-
-        for i, axis in enumerate(self.axes):
-            if axis.type == type:
-                return axis
-        raise ValueError("Cannot find type {}".format(type))
 
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.


### PR DESCRIPTION
This removes the call to `axis.type` and `fill_map_counts` now relies on the naming scheme `energy` or `energy_reco` for the `EventList.energy` property.
A test is added to ensure that another axis having an `energy_mc` name produces expected results.