### PR TITLE
Simplify map axis handling

### DIFF
--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -55,7 +55,7 @@ def fill_map_counts(counts_map, events):
     cols = {k.upper(): v for k, v in events.table.columns.items()}
 
     for axis in counts_map.geom.axes:
-        if axis.name.lower() in ['energy', 'energy_reco']:
+        if axis.name.upper() in ['ENERGY', 'ENERGY_RECO']:
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict[axis.name] = events.energy.to(axis.unit)
         # TODO: add proper extraction for time

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -55,7 +55,7 @@ def fill_map_counts(counts_map, events):
     cols = {k.upper(): v for k, v in events.table.columns.items()}
 
     for axis in counts_map.geom.axes:
-        if axis.type == 'energy':
+        if axis.name.lower() in ['energy', 'energy_reco']:
             # This axis is the energy. We treat it differently because axis.name could be e.g. 'energy_reco'
             coord_dict[axis.name] = events.energy.to(axis.unit)
         # TODO: add proper extraction for time

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -85,13 +85,20 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
         the input table PSF
     geom : `~gammapy.maps.MapGeom`
         the target geometry. The PSF kernel will be centered on the spatial centre.
-        the geometry axes should contain an energy MapAxis. The kernel will be
-        duplicated along other axes.
+        the geometry axes should contain an energy MapAxis, named 'energy_true' or 'energy'.
+        The kernel will be duplicated along other axes.
     factor : int
         the oversample factor to compute the PSF
     """
     # Find energy axis in geom
-    energy_axis = geom.get_axis_by_type('energy')
+    try:
+        energy_axis = geom.get_axis_by_name('energy_true')
+    except ValueError:
+        try:
+            energy_axis = geom.get_axis_by_name('energy')
+        except:
+            raise ValueError("Cannot find energy axis name.")
+
     energy_idx = geom.axes.index(energy_axis)
     energy_unit = u.Unit(energy_axis.unit)
 
@@ -185,7 +192,7 @@ class PSFKernel(object):
             the input table PSF
         geom : `~gammapy.maps.WcsGeom`
             the target geometry. The PSF kernel will be centered on the central pixel.
-            the geometry axes should contain an energy MapAxis.
+            the geometry axes should contain an energy MapAxis named 'energy' or 'energy_true'.
         max_radius : `~astropy.coordinates.Angle`
             the maximum radius of the PSF kernel.
         factor : int

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -36,7 +36,7 @@ def make_psf_map(psf, pointing, geom, max_offset):
     psfmap : `~gammapy.cube.PSFMap`
         the resulting PSF map
     """
-    energy_axis = geom.get_axis_by_name('energy_true')
+    energy_axis = geom.get_axis_by_name('energy')
     energy = energy_axis.center * energy_axis.unit
 
     rad_axis = geom.get_axis_by_name('theta')
@@ -81,7 +81,7 @@ class PSFMap(object):
         from astropy.coordinates import SkyCoord
 
         # Define energy axis. Note that the name is fixed.
-        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy_true')
+        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy')
         # Define rad axis. Again note the axis name
         rads = np.linspace(0., 0.5, 100) * u.deg
         rad_axis = MapAxis.from_edges(rads, unit='deg', name='theta')
@@ -110,7 +110,7 @@ class PSFMap(object):
     """
 
     def __init__(self, psf_map):
-        if psf_map.geom.axes[1].name.upper() != 'ENERGY_TRUE':
+        if psf_map.geom.axes[1].name.upper() != 'ENERGY':
             raise ValueError("Incorrect energy axis position in input Map")
 
         if psf_map.geom.axes[0].name.upper() != 'THETA':

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -2,8 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose
-from astropy.table import Column
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data
@@ -16,7 +14,7 @@ pytest.importorskip('scipy')
 # TODO: move these two cases to different test functions?
 # Would allow to change the asserts in `test_fill_map_counts` to something much more specific / useful, no?
 axis_energy_reco = MapAxis(np.logspace(-1., 1.5, 10), interp='log', node_type='edge',
-                           name='energy_reco', unit='TeV')
+                           name='energy', unit='TeV')
 
 # initial time of run 110380 from cta 1DC
 times = np.linspace(664504199, 664504199 + 1900., 10)
@@ -84,20 +82,3 @@ def test_fill_map_counts_keyerror(events):
     cntmap = WcsNDMap.create(binsz=0.1, npix=10, axes=[axis])
     with pytest.raises(KeyError):
         fill_map_counts(cntmap, events)
-
-@requires_data('gammapy-extra')
-def test_fill_map_counts_multiple_energy_axes(events):
-    axis_mc = MapAxis([0, 2, 4], name='energy_mc', unit='TeV')
-    axis_reco = MapAxis([0.001, 1000.], name='energy_reco', unit='TeV')
-    axis = MapAxis([0.001, 1000.], name='energy', unit='TeV')
-
-    cntmap1 = WcsNDMap.create(binsz=1, npix=10, coordsys='GAL', axes=[axis, axis_mc])
-    cntmap2 = WcsNDMap.create(binsz=1, npix=10, coordsys='GAL', axes=[axis_mc, axis_reco])
-
-    events.table['ENERGY_MC'] = 1*u.TeV
-
-    # Check that energy_mc entries are placed in the right axis
-    fill_map_counts(cntmap1, events)
-    assert_allclose(cntmap1.data.sum(axis=(1, 2, 3)), [105592, 0])
-    fill_map_counts(cntmap2, events)
-    assert_allclose(cntmap2.data.sum(axis=(0, 2, 3)), [105592, 0])

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -66,11 +66,7 @@ def test_fill_map_counts_hpx(events):
 
     axis_det = MapAxis([-2, 1, 5], node_type='edge', name='detx', unit='deg')
     # This test to check entries without units in eventlist table do not fail
-<<<<<<< HEAD
     axis_evt = MapAxis((0, 100000, 150000), node_type='edge', name='event_id')
-=======
-    axis_evt = MapAxis((0, 100000, 150000), node_type='edge', name='event_id', unit='')
->>>>>>> Added check on energy axis name following predefined conventions and added test with multiple energy axis names
 
     geom = HpxGeom(256, coordsys='GAL', axes=[axis_evt, axis_det])
 

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -94,8 +94,7 @@ def test_fill_map_counts_multiple_energy_axes(events):
     cntmap1 = WcsNDMap.create(binsz=1, npix=10, coordsys='GAL', axes=[axis, axis_mc])
     cntmap2 = WcsNDMap.create(binsz=1, npix=10, coordsys='GAL', axes=[axis_mc, axis_reco])
 
-    col_mc = Column(np.ones(len(events.table)) * u.TeV, name='ENERGY_MC')
-    events.table.add_column(col_mc)
+    events.table['ENERGY_MC'] = 1*u.TeV
 
     # Check that energy_mc entries are placed in the right axis
     fill_map_counts(cntmap1, events)

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -100,12 +100,3 @@ def test_energy_dependent_psf_kernel():
     some_map_convolved = psf_kernel.apply(some_map)
 
     assert_allclose(some_map_convolved.data.sum(axis=(1, 2)), np.array((0, 1, 1)))
-
-    # Now test behaviour if energy axis is not energy or energy_true
-    energy_reco_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy_reco')
-
-    # Create WcsGeom and map
-    geom = WcsGeom.create(binsz=0.02 * u.deg, width=4.0 * u.deg, axes=[energy_reco_axis])
-    some_map = Map.from_geom(geom)
-    with pytest.raises(ValueError):
-        psf_kernel = PSFKernel.from_table_psf(table_psf, geom, max_radius=1 * u.deg)

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -99,3 +100,12 @@ def test_energy_dependent_psf_kernel():
     some_map_convolved = psf_kernel.apply(some_map)
 
     assert_allclose(some_map_convolved.data.sum(axis=(1, 2)), np.array((0, 1, 1)))
+
+    # Now test behaviour if energy axis is not energy or energy_true
+    energy_reco_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy_reco')
+
+    # Create WcsGeom and map
+    geom = WcsGeom.create(binsz=0.02 * u.deg, width=4.0 * u.deg, axes=[energy_reco_axis])
+    some_map = Map.from_geom(geom)
+    with pytest.raises(ValueError):
+        psf_kernel = PSFKernel.from_table_psf(table_psf, geom, max_radius=1 * u.deg)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -36,7 +36,7 @@ def test_make_psf_map():
     psf = fake_psf3d(0.3 * u.deg)
 
     pointing = SkyCoord(0, 0, unit='deg')
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV', name='energy_true')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV', name='energy')
     rad_axis = MapAxis(nodes=np.linspace(0., 1., 51), unit='deg', name='theta')
 
     geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis])
@@ -54,7 +54,7 @@ def test_psfmap(tmpdir):
     psf = fake_psf3d(0.15 * u.deg)
 
     pointing = SkyCoord(0, 0, unit='deg')
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV', name='energy_true')
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2., 10.], unit='TeV', name='energy')
     rad_axis = MapAxis(nodes=np.linspace(0., 0.6, 50), unit='deg', name='theta')
 
     geom = WcsGeom.create(skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis])
@@ -82,11 +82,12 @@ def test_psfmap(tmpdir):
 
     assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)
 
+
 @requires_dependency('scipy')
 def test_containment_radius_map(tmpdir):
     psf = fake_psf3d(0.15 * u.deg)
     pointing = SkyCoord(0, 0, unit='deg')
-    energy_axis = MapAxis(nodes=[0.2, 1, 2], unit='TeV', name='energy_true')
+    energy_axis = MapAxis(nodes=[0.2, 1, 2], unit='TeV', name='energy')
     psf_theta_axis = MapAxis(nodes=np.linspace(0., 0.6, 30), unit='deg', name='theta')
     geom = WcsGeom.create(skydir=pointing, binsz=0.5, width=(4, 3), axes=[psf_theta_axis, energy_axis])
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -363,14 +363,6 @@ class MapAxis(object):
         self._node_type = node_type
         self._unit = u.Unit('' if unit is None else unit)
 
-        # Set axis type from its unit
-        if self._unit.is_equivalent("eV"):
-            self._type = 'energy'
-        elif self._unit.is_equivalent("s"):
-            self._type = 'time'
-        else:
-            self._type = 'any'
-
         # Set pixel coordinate of first node
         if node_type == 'edge':
             self._pix_offset = -0.5
@@ -432,11 +424,6 @@ class MapAxis(object):
     def unit(self):
         """Return coordinate axis unit."""
         return self._unit
-
-    @property
-    def type(self):
-        """Return coordinate axis type."""
-        return self._type
 
     @classmethod
     def from_bounds(cls, lo_bnd, hi_bnd, nbin, **kwargs):
@@ -614,7 +601,6 @@ class MapAxis(object):
         str_ = self.__class__.__name__
         str_ += "\n\n"
         str_ += "\tname     : {}\n".format(self.name)
-        str_ += "\ttype     : {}\n".format(self.type)
         str_ += "\tunit     : {}\n".format(self.unit)
         str_ += "\tnbins    : {}\n".format(self.nbin)
         str_ += "\tnode type: {}\n".format(self.node_type)
@@ -1395,28 +1381,6 @@ class MapGeom(object):
             if axis.name.upper() == name.upper():
                 return axis
         raise ValueError("Cannot find axis named {}".format(name))
-
-    def get_axis_by_type(self, type):
-        """Returns axis of given type.
-
-        Parameters
-        ----------
-        type : str in {'energy', 'time', 'any'}
-           the name of the requested type of axis
-
-        Returns
-        -------
-        axes : `~gammapy.maps.MapAxis`
-            the corresponding  axis
-        """
-        valid_types = ('energy', 'time', 'any')
-        if type not in valid_types:
-            raise ValueError("Invalid axis type {}. Should be {}.".format(type, valid_types))
-
-        for i, axis in enumerate(self.axes):
-            if axis.type == type:
-                return axis
-        raise ValueError("Cannot find type {}".format(type))
 
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1353,34 +1353,23 @@ class MapGeom(object):
         """Whether the geom is equivalent to an image without extra dimensions."""
         if self.axes is None:
             return True
-        is_image = len(self.axes) == 0
-        return is_image
-
-    @property
-    def axes_names(self):
-        """Returns list of axes names"""
-        return [_.name for _ in self.axes]
+        return len(self.axes) == 0
 
     def get_axis_by_name(self, name):
-        """Return axis with corresponding name
+        """Get an axis by name (case in-sensitive).
 
         Parameters
         ----------
         name : str
-           the name of the requested axis
+           Name of the requested axis
 
         Returns
         -------
         axis : `~gammapy.maps.MapAxis`
-            the corresponding axis
-
+            Axis
         """
-
-        # TODO : we implictly assume all axes have different names. This should be enforced at MapGeom creation.
-        for i, axis in enumerate(self.axes):
-            if axis.name.upper() == name.upper():
-                return axis
-        raise ValueError("Cannot find axis named {}".format(name))
+        axes = {axis.name.upper(): axis for axis in self.axes}
+        return axes[name.upper()]
 
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -555,7 +555,7 @@ class WcsNDMap(WcsMap):
 
         @interact(
             index=widgets.IntSlider(min=0, max=self.data.shape[0] - 1, step=1, value=1,
-                                    description=self.geom.axes_names[0] + ' slice'),
+                                    description=self.geom.axes[0].name + ' slice'),
             stretch=widgets.RadioButtons(options=['linear', 'sqrt', 'log'], value='sqrt',
                                          description='Plot stretch'),
             ax=fixed(ax),
@@ -571,7 +571,7 @@ class WcsNDMap(WcsMap):
             if ax is None:
                 ax = fig.add_subplot(1, 1, 1, projection=self.geom.wcs)
 
-            axes = self.geom.get_axis_by_name(self.geom.axes_names[0])
+            axes = self.geom.axes[0]
 
             data = self.get_image_by_idx([index]).data
             norm = simple_norm(data[np.isfinite(data)], stretch)


### PR DESCRIPTION
This PR is a continuation of #1637 that @registerrier started.

I'm splitting this out because it's controversial what to do, so I'll remove my commit there and put this PR as an alternative proposal.

I feel that we should go all-in on http://docs.gammapy.org/dev/development/howto.html#coordinate-and-axis-names and make choices on axis names.

Specifically I feel that we should make a choice for axis name "energy" in counts cubes, and thus in the fill helper function. I realise that this is a compromise, as a few people might fill counts cubes with MC events with true energy. But IMO the cost of supporting different axes names throughout Gammapy is too high.

For the PSF kernel, I have a preference for also axis name "energy", and that's what I put here. But choosing "energy_true" there would also be OK for me.

What I don't want is to start to support multiple names, subsets of  `{'energy', 'energy_reco', 'energy_true'}` in multiple places **for the same thing and axis**.

I think this will lead to hard to write, read and maintain code in many places of Gammapy.
https://github.com/gammapy/gammapy/pull/1637/commits/d796e4bce5ccc9af3217f3f38e016122c580470e#diff-621b8929adf5a7424f964d94de0a3e48L94