### PR TITLE
Fix HpxNDMap.interp_by_coord for coord dict

### DIFF
--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -320,15 +320,15 @@ class HpxNDMap(HpxMap):
 
         import healpy as hp
 
-        c = MapCoord.create(coords)
-        coords_ctr = list(coords[:2])
+        coords = MapCoord.create(coords)
+        coords_ctr = [coords.lon, coords.lat]
         coords_ctr += [ax.pix_to_coord(t)
                        for ax, t in zip(self.geom.axes, idxs)]
         idx_ctr = pix_tuple_to_idx(self.geom.coord_to_pix(coords_ctr))
         idx_ctr = self.geom.global_to_local(idx_ctr)
 
-        theta = np.array(np.pi / 2. - np.radians(c.lat), ndmin=1)
-        phi = np.array(np.radians(c.lon), ndmin=1)
+        theta = np.array(np.pi / 2. - np.radians(coords.lat), ndmin=1)
+        phi = np.array(np.radians(coords.lon), ndmin=1)
 
         m = ~np.isfinite(theta)
         theta[m] = 0.0

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -180,6 +180,16 @@ def test_hpxmap_interp_by_coord(nside, nested, coordsys, region, axes):
                     m.interp_by_coord(coords, interp='linear'))
 
 
+def test_hpxmap_interp_by_coord_dict():
+    # Regression test, call interp_by_coord_with a dict
+    m = HpxNDMap(HpxGeom(nside=1))
+    coords = m.geom.get_coord(flat=True)
+    m.set_by_coord(coords, coords[1])
+
+    val = m.interp_by_coord({'lon': 99, 'lat': 42})
+    assert_allclose(val, 42, atol=1)
+
+
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes', 'sparse'),
                          hpx_test_geoms_sparse)
 def test_hpxmap_fill_by_coord(nside, nested, coordsys, region, axes, sparse):
@@ -268,6 +278,7 @@ def test_hpxmap_upsample(nside, nested, coordsys, region, axes):
     m_up = m.upsample(2, preserve_counts=False)
     assert_allclose(4.0 * np.nansum(m.data), np.nansum(m_up.data))
     assert m.unit == m_up.unit
+
 
 @pytest.mark.parametrize(('nside', 'nested', 'coordsys', 'region', 'axes'),
                          hpx_test_geoms)


### PR DESCRIPTION
This PR fixes a bug in HpxNDMap.interp_by_coord where coord was given as a dict.

The implementation was changed to only use the MapCoord created at the top, without accessing the input coord in addition below.

A regression tests is added. It now passes, but without the change failed like this:

```
__________________________________________________________________ test_hpxmap_interp_by_coord_dict __________________________________________________________________

    def test_hpxmap_interp_by_coord_dict():
        # Regression test, call interp_by_coord_with a dict
        m = HpxNDMap(HpxGeom(nside=1))
>       val = m.interp_by_coord({'lon': 0, 'lat': 0})

gammapy/maps/tests/test_hpxmap.py:186: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
gammapy/maps/hpxnd.py:305: in interp_by_coord
    return self._interp_by_coord(coords, order)
gammapy/maps/hpxnd.py:365: in _interp_by_coord
    pix, wts = self._get_interp_weights(coords, idx_ax)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = HpxNDMap

	geom      : Hpx 
 	unit      :  
	data shape: (12,)
	data mean : 0.0e+00 
	data min  : 0.0e+00 
	data max  : 0.0e+00 

coords = {'lat': 0, 'lon': 0}, idxs = ()

    def _get_interp_weights(self, coords, idxs):
    
        import healpy as hp
    
        # c = MapCoord.create(coords)
        # del coords
>       coords_ctr = list(coords[:2])
E       TypeError: unhashable type: 'slice'

gammapy/maps/hpxnd.py:325: TypeError
```

Merging this now.