### PR TITLE
Add unit, meta and geom property setter in Map base class

### DIFF
--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -39,7 +39,6 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
     if len(exposure.shape) < 3:
         exposure = np.expand_dims(exposure.value, 0) * exposure.unit
 
-    exposure *= livetime
-    data = exposure.to('m2 s')
+    exposure = (exposure * livetime).to('m2 s')
 
-    return WcsNDMap(geom, data)
+    return WcsNDMap(geom, exposure.value, unit=exposure.unit)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -43,13 +43,9 @@ class Map(object):
     """
 
     def __init__(self, geom, data, meta=None, unit=''):
-        self._geom = geom
-        if isinstance(data, Quantity):
-            self._data = data.value
-            self.unit = data.unit
-        else:
-            self._data = data
-            self.unit = unit
+        self.geom = geom
+        self.data = data
+        self.unit = unit
 
         if meta is None:
             self.meta = {}
@@ -76,7 +72,6 @@ class Map(object):
 
     @geom.setter
     def geom(self, val):
-        # TODO: add checks? E.g. shape like below?
         self._geom = val
 
     @property
@@ -86,8 +81,13 @@ class Map(object):
 
     @data.setter
     def data(self, val):
-        if val.shape != self._data.shape:
-            raise ValueError('Wrong shape.')
+        if val.shape != self.geom.data_shape:
+            raise ValueError('Shape {!r} does not match map data shape {!r}'
+                             ''.format(val.shape, self.geom.data_shape))
+
+        if isinstance(val, u.Quantity):
+            raise TypeError('No Quantity allowed in map data. Set data and unit separately.')
+
         self._data = val
 
     @property
@@ -116,9 +116,6 @@ class Map(object):
     @quantity.setter
     def quantity(self, val):
         val = Quantity(val)
-        if val.shape != self.data.shape:
-            raise ValueError('Wrong shape.')
-
         self.data = val.value
         self.unit = val.unit
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -951,7 +951,7 @@ class Map(object):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        geom = self.geom.__class__.__name__[:3]
+        geom = self.geom.__class__.__name__
         str_ += "\tgeom      : {} \n ".format(geom)
         str_ += "\tunit      : {} \n".format(self.unit)
         str_ += "\tdata shape: {}\n".format(self.data.shape)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -93,11 +93,11 @@ class Map(object):
     @property
     def unit(self):
         """Map unit (`~astropy.units.Unit`)"""
-        return Unit(self._unit)
+        return self._unit
 
     @unit.setter
     def unit(self, val):
-        self._unit = Unit(val).to_string()
+        self._unit = Unit(val)
 
     @property
     def meta(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -78,7 +78,7 @@ def make_axes_cols(axes, axis_names=None):
 
         for colname, v in zip(colnames, [axes_ctr, axes_min, axes_max]):
             array = np.ravel(v[i])
-            unit = ax.unit.to_string()
+            unit = ax.unit.to_string('fits')
             cols.append(fits.Column(colname, 'E', array=array, unit=unit))
 
     return cols

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -911,6 +911,12 @@ class MapGeom(object):
 
     @property
     @abc.abstractmethod
+    def data_shape(self):
+        """Shape of the Numpy data array matching this geometry."""
+        pass
+
+    @property
+    @abc.abstractmethod
     def is_allsky(self):
         pass
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -606,6 +606,13 @@ class HpxGeom(MapGeom):
                                    [ax.pix_to_coord((float(ax.nbin) - 1.0) / 2.) for ax in self.axes])
         self._center_pix = self.coord_to_pix(self._center_coord)
 
+    @property
+    def data_shape(self):
+        """Shape of the Numpy data array matching this geometry."""
+        npix_shape = [np.max(self.npix)]
+        ax_shape = [ax.nbin for ax in self.axes]
+        return tuple(npix_shape + ax_shape)[::-1]
+
     def _create_lookup(self, region):
         """Create local-to-global pixel lookup table."""
 
@@ -1747,7 +1754,6 @@ class HpxGeom(MapGeom):
         axes = [_.name for _ in self.axes]
         str_ += "\taxes      : {}\n".format(", ".join(axes))
         return str_
-
 
 
 class HpxToWcsMapping(object):

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -159,7 +159,7 @@ class HpxMap(Map):
         hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse,
                                 conv=conv)
         hdu_out.header['META'] = json.dumps(self.meta)
-        hdu_out.header['UNIT'] = self._unit
+        hdu_out.header['UNIT'] = self.unit.to_string('fits')
 
         hdu_list = fits.HDUList([fits.PrimaryHDU(), hdu_out])
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -38,14 +38,10 @@ class HpxNDMap(HpxMap):
 
     def __init__(self, geom, data=None, dtype='float32', meta=None, unit=''):
 
-        shape = tuple([np.max(geom.npix)] + [ax.nbin for ax in geom.axes])
-        shape_np = shape[::-1]
+        data_shape = geom.data_shape
 
         if data is None:
-            data = self._make_default_data(geom, shape_np, dtype)
-        elif data.shape != shape_np:
-            raise ValueError('Wrong shape for input data array. Expected {} '
-                             'but got {}'.format(shape_np, data.shape))
+            data = self._make_default_data(geom, data_shape, dtype)
 
         super(HpxNDMap, self).__init__(geom, data, meta, unit)
         self._wcs2d = None

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import numpy as np
 from numpy.testing import assert_equal
 from astropy.coordinates import SkyCoord
+import astropy.units as u
 from astropy.units import Unit, Quantity
 from ..base import Map
 from ..geom import MapAxis
@@ -192,3 +193,28 @@ def test_map_unit_read_write(map_type, unit):
 def test_map_repr(map_type, unit):
     m = Map.create(binsz=0.1, width=10.0, map_type=map_type, unit=unit)
     assert m.__class__.__name__ in repr(m)
+
+
+def test_map_properties():
+    # Test default values and types of all map properties,
+    # as well as the behaviour for the property get and set.
+
+    m = Map.create(npix=(3, 2))
+
+    assert isinstance(m.geom, WcsGeom)
+    m.geom = m.geom
+    assert isinstance(m.geom, WcsGeom)
+
+    assert isinstance(m.unit, u.CompositeUnit)
+    assert m.unit == ''
+    m.unit = 'cm-2 s-1'
+    assert m.unit.to_string() == '1 / (cm2 s)'
+
+    assert isinstance(m.data, np.ndarray)
+    assert m.data.dtype == np.float32
+    assert m.data.shape == (2, 3)
+    assert_equal(m.data, 0)
+
+    assert isinstance(m.meta, OrderedDict)
+    m.meta = {'spam': 42}
+    assert isinstance(m.meta, OrderedDict)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -173,6 +173,13 @@ class WcsGeom(MapGeom):
                                                   self.wcs)
 
     @property
+    def data_shape(self):
+        """Shape of the Numpy data array matching this geometry."""
+        npix_shape = [np.max(self.npix[0]), np.max(self.npix[1])]
+        ax_shape = [ax.nbin for ax in self.axes]
+        return tuple(npix_shape + ax_shape)[::-1]
+
+    @property
     def wcs(self):
         """WCS projection object."""
         return self._wcs

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -166,7 +166,7 @@ class WcsMap(Map):
 
         hdu_out.header['META'] = json.dumps(self.meta)
 
-        hdu_out.header['UNIT'] = self._unit
+        hdu_out.header['UNIT'] = self.unit.to_string('fits')
 
         if hdu == 'PRIMARY':
             hdulist = [hdu_out]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -45,16 +45,10 @@ class WcsNDMap(WcsMap):
     def __init__(self, geom, data=None, dtype='float32', meta=None, unit=''):
         # TODO: Figure out how to mask pixels for integer data types
 
-        # Shape in WCS or FITS order is `shape`, in Numpy axis order is `shape_np`
-        shape = tuple([np.max(geom.npix[0]), np.max(geom.npix[1])] +
-                      [ax.nbin for ax in geom.axes])
-        shape_np = shape[::-1]
+        data_shape = geom.data_shape
 
         if data is None:
-            data = self._make_default_data(geom, shape_np, dtype)
-        elif data.shape != shape_np:
-            raise ValueError('Wrong shape for input data array. Expected {} '
-                             'but got {}'.format(shape_np, data.shape))
+            data = self._make_default_data(geom, data_shape, dtype)
 
         super(WcsNDMap, self).__init__(geom, data, meta, unit)
 


### PR DESCRIPTION
This PR adds property setters for unit, meta and geom in the Map base class.

While working on #1545 I noticed that it's currently not possible to set the unit on a map. This was necessary here, because I'm reading a FITS map that doesn't have the unit set:
```
m = Map.read('$GAMMAPY_EXTRA/test_datasets/unbundled/fermi/gll_iem_v02_cutout.fits', )
# Unit is not set at all in that file, so we have to do it manually here:
m.unit = 'cm-2 s-1 MeV-1 sr-1'
```

Locally all tests pass for me, so I think I'll just merge this in shortly. If there's any issues or something can be done in a better way, please shout and I'll adjust / fit in the next days.

cc @woodmd @adonath @registerrier 