### PR TITLE
Make map interp_image a private method

### DIFF
--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -128,8 +128,6 @@ def test_wcs_nd_map_data_transpose_issue(tmpdir):
     # and then filled via an in-place Numpy array operation
     m.data += data
     assert_equal(m.data, data)
-    # This is done e.g. in `m.interp_image` or probably also other operations,
-    # sometimes they operate on `m.data` in-place.
 
     # Data should be unmodified after write / read to normal image format
     filename = str(tmpdir / 'normal.fits.gz')


### PR DESCRIPTION
This PR makes the map interp_image method private. It's a small cleanup PR in preparation of v0.8.

In #1644 I proposed to remove it, but actually it's used currently in the reproject methods.

I've left a TODO comment that we should look into replacing it to avoid duplication of interpolation functionality.

My suggestion would be to merge this now, and then to defer #1644 to v0.9. 

@adonath - Please review.