### PR TITLE
Consistent argument name model in MapEvaluator and MapFit

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -45,7 +45,7 @@ class MapFit(object):
         self._minuit = None
 
         self.evaluator = MapEvaluator(
-            sky_model=self.model,
+            model=self.model,
             exposure=self.exposure,
             background=self.background,
             psf=self.psf,

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -370,7 +370,7 @@ class MapEvaluator(object):
 
     Parameters
     ----------
-    sky_model : `~gammapy.cube.models.SkyModel`
+    model : `~gammapy.cube.models.SkyModel`
         Sky model
     exposure : `~gammapy.maps.Map`
         Exposure map
@@ -382,8 +382,8 @@ class MapEvaluator(object):
         Energy dispersion
     """
 
-    def __init__(self, sky_model=None, exposure=None, background=None, psf=None, edisp=None):
-        self.sky_model = sky_model
+    def __init__(self, model=None, exposure=None, background=None, psf=None, edisp=None):
+        self.model = model
         self.exposure = exposure
         self.background = background
         self.psf = psf
@@ -456,7 +456,7 @@ class MapEvaluator(object):
             Units: ``cm-2 s-1 TeV-1 deg-2``
         """
         coord = (self.lon, self.lat, self.energy_center)
-        dnde = self.sky_model.evaluate(*coord)
+        dnde = self.model.evaluate(*coord)
         return dnde
 
     def compute_flux(self):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -87,7 +87,7 @@ def sky_model():
 @pytest.fixture
 def counts(sky_model, exposure, background, psf, edisp):
     evaluator = MapEvaluator(
-        sky_model=sky_model,
+        model=sky_model,
         exposure=exposure,
         background=background,
         psf=psf,


### PR DESCRIPTION
I realised that `MapFit` uses `model` as argument name and `MapEvaluator` uses `sky_model`. They are the same, so should be named consistently. This PR changes `MapEvaluator` argument to name `model`.