### PR TITLE
Modify map cutout method

### DIFF
--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -56,7 +56,7 @@ def test_find_reflected_regions(mask, on_region):
     assert len(regions) == 16
 
     # Test with too small exclusion
-    small_mask = mask.make_cutout(pointing, Angle('0.2 deg'))[0]
+    small_mask = mask.cutout(pointing, Angle('0.2 deg'))
     fregions.exclusion_mask = small_mask
     fregions.run()
     regions = fregions.reflected_regions

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -93,7 +93,7 @@ class MapMaker(object):
         # Only if there is an exclusion mask, make a cutout
         exclusion_mask = self.maps.get('exclusion', None)
         if exclusion_mask is not None:
-            exclusion_mask, _ = exclusion_mask.cutout(
+            exclusion_mask = exclusion_mask.cutout(
                 position=obs.pointing_radec,
                 width=2 * self.offset_max,
                 mode='trim',

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_data
 from ...data import DataStore
-from ...maps import WcsGeom, MapAxis
+from ...maps import WcsGeom, MapAxis, Map
 from ..make import MapMaker
 
 pytest.importorskip('scipy')
@@ -42,6 +42,15 @@ def geom(ebounds):
         'exposure': 1.16866e+11,
         'background': 1988492.8,
     },
+    {
+        # Test single energy bin
+        'geom': geom(ebounds=[0.1, 10]),
+        'exclusion_mask': Map.from_geom(geom(ebounds=[0.1, 10])),
+        'counts': 34366,
+        'exposure': 1.16866e+11,
+        'background': 1988492.8,
+    },
+
 ])
 def test_map_maker(pars, obs_list):
     maker = MapMaker(

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -31,7 +31,6 @@ def geom(ebounds):
     {
         # Default, normal test case
         'geom': geom(ebounds=[0.1, 1, 10]),
-        'mode': 'trim',
         'counts': 34366,
         'exposure': 3.99815e+11,
         'background': 187528.89,
@@ -39,25 +38,15 @@ def geom(ebounds):
     {
         # Test single energy bin
         'geom': geom(ebounds=[0.1, 10]),
-        'mode': 'trim',
         'counts': 34366,
         'exposure': 1.16866e+11,
         'background': 1988492.8,
-    },
-    {
-        # Test strict mode
-        'geom': geom(ebounds=[0.1, 1, 10]),
-        'mode': 'strict',
-        'counts': 21981,
-        'exposure': 2.592941e+11,
-        'background': 121457.695,
     },
 ])
 def test_map_maker(pars, obs_list):
     maker = MapMaker(
         geom=pars['geom'],
         offset_max='2 deg',
-        cutout_mode=pars['mode'],
     )
     maps = maker.run(obs_list)
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -403,7 +403,7 @@ def test_smooth(kernel):
     actual = smoothed.data.sum()
     assert_allclose(actual, desired)
 
-
+@pytest.mark.parametrize('mode', ['partial', 'strict', 'trim'])
 def test_make_cutout():
     pos = SkyCoord(0, 0, unit='deg', frame='galactic')
     geom = WcsGeom.create(npix=(10, 10), binsz=1, skydir=pos,

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -404,12 +404,12 @@ def test_smooth(kernel):
     assert_allclose(actual, desired)
 
 @pytest.mark.parametrize('mode', ['partial', 'strict', 'trim'])
-def test_make_cutout():
+def test_make_cutout(mode):
     pos = SkyCoord(0, 0, unit='deg', frame='galactic')
     geom = WcsGeom.create(npix=(10, 10), binsz=1, skydir=pos,
                           proj='CAR', coordsys='GAL', axes=axes2)
     m = WcsNDMap(geom, data=np.ones((3, 2, 10, 10)), unit='m2')
-    cutout, _ = m.make_cutout(position=pos, width=(2.0, 3.0) * u.deg)
+    cutout = m.cutout(position=pos, width=(2.0, 3.0) * u.deg, mode=mode)
     actual = cutout.data.sum()
     assert_allclose(actual, 36.0)
     assert_allclose(cutout.geom.shape, m.geom.shape)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -628,7 +628,7 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(data=data)
 
-    def cutout(self, position, width, mode='partial', copy=True):
+    def cutout(self, position, width, mode='trim', copy=True):
         """
         Create a cutout of a WcsNDMap around a given position.
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -628,7 +628,7 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(data=data)
 
-    def make_cutout(self, position, width, mode="strict", copy=True):
+    def cutout(self, position, width, mode='partial', copy=True):
         """
         Create a cutout of a WcsNDMap around a given position.
 
@@ -665,4 +665,4 @@ class WcsNDMap(WcsMap):
         if copy:
             data = data.copy()
 
-        return self._init_copy(geom=geom, data=data), cutout_slices
+        return self._init_copy(geom=geom, data=data)


### PR DESCRIPTION
This PR modifies the `WcsNDMap.make_cutout()` method as following:

* Rename to `WcsNDMap.cutout()`, as we never use the `make_` prefix for any of the `Map` methods.
* Remove returning the slices, because this confused many users.

I was thinking about reintroducing a `WcsGeom.cutout_slices()` method, but I decided against for various reasons. The main use case is to make a cutout from a larger map, compute something on the cutout and paste the result again in the larger map. Once we decide to do this via slicing (which is without doubt the most efficient approach for wcs maps), we loose the functionality for `HpxMaps` and we have to recode the same algorithms, which is bad. Instead I decided to use `Map.fill_by_coord()` to paste the data from the cutout back into the larger map. I already modified the `MapMaker` to work like this and it gives exactly the same results. I also removed the mode handling from `MapMaker`, because I don't see any use case, where users would reject observations, that are not fully contained. If they want to do so, they can still filter the observation list beforehand. 
