### PR TITLE
Introduce gammapy.cube.models?

### DIFF
--- a/docs/cube/index.rst
+++ b/docs/cube/index.rst
@@ -38,3 +38,7 @@ Reference/API
 .. automodapi:: gammapy.cube
     :no-inheritance-diagram:
     :include-all-objects:
+
+.. automodapi:: gammapy.cube.models
+    :no-inheritance-diagram:
+    :include-all-objects:

--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -2,7 +2,6 @@
 """
 Sky cubes (3-dimensional: energy, lon, lat).
 """
-from .models import *
 from .counts import *
 from .exposure import *
 from .background import *

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1,12 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from .models import MapEvaluator
-from ..stats import cash
+from astropy.utils import lazyproperty
+import astropy.units as u
 from ..utils.fitting import fit_iminuit
+from ..stats import cash
+from ..maps import Map
 
 __all__ = [
     'MapFit',
+    'MapEvaluator',
 ]
 
 
@@ -97,3 +100,157 @@ class MapFit(object):
                              function=self.total_stat,
                              opts_minuit=opts_minuit)
         self._minuit = minuit
+
+class MapEvaluator(object):
+    """Sky model evaluation on maps.
+
+    This is a first attempt to compute flux as well as predicted counts maps.
+
+    The basic idea is that this evaluator is created once at the start
+    of the analysis, and pre-computes some things.
+    It it then evaluated many times during likelihood fit when model parameters
+    change, re-using pre-computed quantities each time.
+    At the moment it does some things, e.g. cache and re-use energy and coordinate grids,
+    but overall it is not an efficient implementation yet.
+
+    For now, we only make it work for 3D WCS maps with an energy axis.
+    No HPX, no other axes, those can be added later here or via new
+    separate model evaluator classes.
+
+    We should discuss how to organise the model and IRF evaluation code,
+    and things like integrations and convolutions in a good way.
+
+    Parameters
+    ----------
+    model : `~gammapy.cube.models.SkyModel`
+        Sky model
+    exposure : `~gammapy.maps.Map`
+        Exposure map
+    background : `~gammapy.maps.Map`
+        background map
+    psf : `~gammapy.cube.PSFKernel`
+        PSF kernel
+    edisp : `~gammapy.irf.EnergyDispersion`
+        Energy dispersion
+    """
+
+    def __init__(self, model=None, exposure=None, background=None, psf=None, edisp=None):
+        self.model = model
+        self.exposure = exposure
+        self.background = background
+        self.psf = psf
+        self.edisp = edisp
+
+    @lazyproperty
+    def geom(self):
+        return self.exposure.geom
+
+    @lazyproperty
+    def geom_image(self):
+        return self.geom.to_image()
+
+    @lazyproperty
+    def energy_center(self):
+        """Energy axis bin centers (`~astropy.units.Quantity`)"""
+        energy_axis = self.geom.axes[0]
+        energy = energy_axis.center * energy_axis.unit
+        return energy
+
+    @lazyproperty
+    def energy_edges(self):
+        """Energy axis bin edges (`~astropy.units.Quantity`)"""
+        energy_axis = self.geom.axes[0]
+        energy = energy_axis.edges * energy_axis.unit
+        return energy
+
+    @lazyproperty
+    def energy_bin_width(self):
+        """Energy axis bin widths (`astropy.units.Quantity`)"""
+        return np.diff(self.energy_edges)
+
+    @lazyproperty
+    def lon_lat(self):
+        """Spatial coordinate pixel centers.
+
+        Returns ``lon, lat`` tuple of `~astropy.units.Quantity`.
+        """
+        lon, lat = self.geom_image.get_coord()
+        return lon * u.deg, lat * u.deg
+
+    @lazyproperty
+    def lon(self):
+        return self.lon_lat[0]
+
+    @lazyproperty
+    def lat(self):
+        return self.lon_lat[1]
+
+    @lazyproperty
+    def solid_angle(self):
+        """Solid angle per pixel"""
+        return self.geom.solid_angle()
+
+    @lazyproperty
+    def bin_volume(self):
+        """Map pixel bin volume (solid angle times energy bin width)."""
+        omega = self.solid_angle
+        de = self.energy_bin_width
+        de = de[:, np.newaxis, np.newaxis]
+        return omega * de
+
+    def compute_dnde(self):
+        """Compute model differential flux at map pixel centers.
+
+        Returns
+        -------
+        model_map : `~gammapy.map.Map`
+            Sky cube with data filled with evaluated model values.
+            Units: ``cm-2 s-1 TeV-1 deg-2``
+        """
+        coord = (self.lon, self.lat, self.energy_center)
+        dnde = self.model.evaluate(*coord)
+        return dnde
+
+    def compute_flux(self):
+        """Compute model integral flux over map pixel volumes.
+
+        For now, we simply multiply dnde with bin volume.
+        """
+        dnde = self.compute_dnde()
+        volume = self.bin_volume
+        flux = dnde * volume
+        return flux.to('cm-2 s-1')
+
+    def apply_exposure(self, flux):
+        """Compute npred cube
+
+        For now just divide flux cube by exposure
+        """
+        npred_ = (flux * self.exposure.quantity).to('')
+        npred = Map.from_geom(self.geom, unit='')
+        npred.data = npred_.value
+        return npred
+
+    def apply_psf(self, npred):
+        """Convolve npred cube with PSF"""
+        return self.psf.apply(npred)
+
+    def apply_edisp(self, npred):
+        """Convolve npred cube with edisp"""
+        a = np.rollaxis(npred, 0, 3)
+        npred1 = np.dot(a, self.edisp.pdf_matrix)
+        return np.rollaxis(npred1, 2, 0)
+
+    def compute_npred(self):
+        """Evaluate model predicted counts.
+        """
+        flux = self.compute_flux()
+        npred = self.apply_exposure(flux)
+        if self.psf is not None:
+            npred = self.apply_psf(npred)
+        # TODO: discuss and decide whether we need to make map objects in `apply_aeff` and `apply_psf`.
+        if self.edisp is not None:
+            npred.data = self.apply_edisp(npred.data)
+        if self.background:
+            npred.data += self.background.data
+        return npred.data

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -4,7 +4,6 @@ import numpy as np
 import copy
 import astropy.units as u
 import operator
-from astropy.utils import lazyproperty
 from ..utils.modeling import ParameterList, Parameter
 from ..utils.scripts import make_path
 from ..maps import Map
@@ -15,7 +14,6 @@ __all__ = [
     'CompoundSkyModel',
     'SumSkyModel',
     'SkyDiffuseCube',
-    'MapEvaluator',
 ]
 
 
@@ -347,158 +345,3 @@ class SkyDiffuseCube(object):
         val = self.map.interp_by_coord(coord, **self._interp_opts)
         norm = self.parameters['norm'].value
         return norm * val * u.Unit('cm-2 s-1 MeV-1 sr-1')
-
-
-class MapEvaluator(object):
-    """Sky model evaluation on maps.
-
-    This is a first attempt to compute flux as well as predicted counts maps.
-
-    The basic idea is that this evaluator is created once at the start
-    of the analysis, and pre-computes some things.
-    It it then evaluated many times during likelihood fit when model parameters
-    change, re-using pre-computed quantities each time.
-    At the moment it does some things, e.g. cache and re-use energy and coordinate grids,
-    but overall it is not an efficient implementation yet.
-
-    For now, we only make it work for 3D WCS maps with an energy axis.
-    No HPX, no other axes, those can be added later here or via new
-    separate model evaluator classes.
-
-    We should discuss how to organise the model and IRF evaluation code,
-    and things like integrations and convolutions in a good way.
-
-    Parameters
-    ----------
-    model : `~gammapy.cube.models.SkyModel`
-        Sky model
-    exposure : `~gammapy.maps.Map`
-        Exposure map
-    background : `~gammapy.maps.Map`
-        background map
-    psf : `~gammapy.cube.PSFKernel`
-        PSF kernel
-    edisp : `~gammapy.irf.EnergyDispersion`
-        Energy dispersion
-    """
-
-    def __init__(self, model=None, exposure=None, background=None, psf=None, edisp=None):
-        self.model = model
-        self.exposure = exposure
-        self.background = background
-        self.psf = psf
-        self.edisp = edisp
-
-    @lazyproperty
-    def geom(self):
-        return self.exposure.geom
-
-    @lazyproperty
-    def geom_image(self):
-        return self.geom.to_image()
-
-    @lazyproperty
-    def energy_center(self):
-        """Energy axis bin centers (`~astropy.units.Quantity`)"""
-        energy_axis = self.geom.axes[0]
-        energy = energy_axis.center * energy_axis.unit
-        return energy
-
-    @lazyproperty
-    def energy_edges(self):
-        """Energy axis bin edges (`~astropy.units.Quantity`)"""
-        energy_axis = self.geom.axes[0]
-        energy = energy_axis.edges * energy_axis.unit
-        return energy
-
-    @lazyproperty
-    def energy_bin_width(self):
-        """Energy axis bin widths (`astropy.units.Quantity`)"""
-        return np.diff(self.energy_edges)
-
-    @lazyproperty
-    def lon_lat(self):
-        """Spatial coordinate pixel centers.
-
-        Returns ``lon, lat`` tuple of `~astropy.units.Quantity`.
-        """
-        lon, lat = self.geom_image.get_coord()
-        return lon * u.deg, lat * u.deg
-
-    @lazyproperty
-    def lon(self):
-        return self.lon_lat[0]
-
-    @lazyproperty
-    def lat(self):
-        return self.lon_lat[1]
-
-    @lazyproperty
-    def solid_angle(self):
-        """Solid angle per pixel"""
-        return self.geom.solid_angle()
-
-    @lazyproperty
-    def bin_volume(self):
-        """Map pixel bin volume (solid angle times energy bin width)."""
-        omega = self.solid_angle
-        de = self.energy_bin_width
-        de = de[:, np.newaxis, np.newaxis]
-        return omega * de
-
-    def compute_dnde(self):
-        """Compute model differential flux at map pixel centers.
-
-        Returns
-        -------
-        model_map : `~gammapy.map.Map`
-            Sky cube with data filled with evaluated model values.
-            Units: ``cm-2 s-1 TeV-1 deg-2``
-        """
-        coord = (self.lon, self.lat, self.energy_center)
-        dnde = self.model.evaluate(*coord)
-        return dnde
-
-    def compute_flux(self):
-        """Compute model integral flux over map pixel volumes.
-
-        For now, we simply multiply dnde with bin volume.
-        """
-        dnde = self.compute_dnde()
-        volume = self.bin_volume
-        flux = dnde * volume
-        return flux.to('cm-2 s-1')
-
-    def apply_exposure(self, flux):
-        """Compute npred cube
-
-        For now just divide flux cube by exposure
-        """
-        npred_ = (flux * self.exposure.quantity).to('')
-        npred = Map.from_geom(self.geom, unit='')
-        npred.data = npred_.value
-        return npred
-
-    def apply_psf(self, npred):
-        """Convolve npred cube with PSF"""
-        return self.psf.apply(npred)
-
-    def apply_edisp(self, npred):
-        """Convolve npred cube with edisp"""
-        a = np.rollaxis(npred, 0, 3)
-        npred1 = np.dot(a, self.edisp.pdf_matrix)
-        return np.rollaxis(npred1, 2, 0)
-
-    def compute_npred(self):
-        """Evaluate model predicted counts.
-        """
-        flux = self.compute_flux()
-        npred = self.apply_exposure(flux)
-        if self.psf is not None:
-            npred = self.apply_psf(npred)
-        # TODO: discuss and decide whether we need to make map objects in `apply_aeff` and `apply_psf`.
-        if self.edisp is not None:
-            npred.data = self.apply_edisp(npred.data)
-        if self.background:
-            npred.data += self.background.data
-        return npred.data

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -11,8 +11,8 @@ from ...irf.energy_dispersion import EnergyDispersion
 from ...maps import MapAxis, WcsGeom, WcsNDMap, Map
 from ...image.models import SkyGaussian
 from ...spectrum.models import PowerLaw
+from ..models import SkyModel
 from .. import (
-    SkyModel,
     MapEvaluator,
     MapFit,
     make_map_exposure_true_energy,

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -11,12 +11,12 @@ from ...cube.psf_kernel import PSFKernel
 from ...cube.models import SkyDiffuseCube
 from ...image.models import SkyGaussian
 from ...spectrum.models import PowerLaw
+from ..fit import MapEvaluator
 from ..models import (
     SkyModel,
     SourceLibrary,
     CompoundSkyModel,
     SumSkyModel,
-    MapEvaluator,
 )
 
 

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -4,9 +4,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from ...testing import requires_data, requires_dependency
-from ....cube import SourceLibrary
 from ....spectrum import models as spectral
 from ....image import models as spatial
+from ....cube.models import SourceLibrary
 from ...serialization import xml_to_source_library, UnknownModelError
 
 


### PR DESCRIPTION
Currently gammapy.cube.models are exposed in gammapy.cube namespace:
http://docs.gammapy.org/dev/cube/index.html#reference-api

For [gammapy.image](http://docs.gammapy.org/dev/image/index.html#reference-api) and [gammapy.spectrum](http://docs.gammapy.org/dev/spectrum/index.html#reference-api) and [gammapy.time](http://docs.gammapy.org/dev/time/index.html#reference-api) there is a separate `models` sub-package, i.e. the models appear in their own list in the docs.

I realise the future of `gammapy.cube` and some other Gammapy sub-packages is uncertain, and we'll probably need a larger re-organisation for v0.9.

Still, I'd suggest to expose the cube models in `gammapy.cube.models` for now.

@registerrier @adonath - OK?