### PR TITLE
Make parnames unambigious in minuit interface

### DIFF
--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -1,0 +1,104 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord, Angle
+from gammapy.irf import (
+    EffectiveAreaTable2D,
+    EnergyDispersion2D,
+    EnergyDependentMultiGaussPSF,
+    Background3D,
+)
+from gammapy.maps import WcsGeom, MapAxis, WcsNDMap, Map
+from gammapy.spectrum.models import PowerLaw
+from gammapy.image.models import SkyGaussian
+from gammapy.utils.random import get_random_state
+from gammapy.cube import (
+    make_map_exposure_true_energy,
+    SkyModel,
+    MapFit,
+    MapEvaluator,
+    SourceLibrary,
+    PSFKernel,
+)
+
+filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+aeff = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
+
+# Define sky model to simulate the data
+lon_0_1 = 0.2
+lon_0_2 = 0.4
+lat_0_1 = 0.1
+lat_0_2 = 0.6
+
+spatial_model_1 = SkyGaussian(
+    lon_0=lon_0_1 * u.deg, lat_0=lat_0_1 * u.deg, sigma="0.3 deg"
+)
+spatial_model_2 = SkyGaussian(
+    lon_0=lon_0_2 * u.deg, lat_0=lat_0_2 * u.deg, sigma="0.2 deg",
+)
+
+spectral_model_1 = PowerLaw(
+    index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV",
+)
+
+spectral_model_2 = PowerLaw(
+    index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV", 
+)
+
+sky_model_1 = SkyModel(spatial_model=spatial_model_1, spectral_model=spectral_model_1)
+
+sky_model_2 = SkyModel(spatial_model=spatial_model_2, spectral_model=spectral_model_2)
+
+compound_model = sky_model_1 + sky_model_2
+
+# Define map geometry
+axis = MapAxis.from_edges(np.logspace(-1., 1., 10), unit="TeV")
+geom = WcsGeom.create(
+    skydir=(0, 0), binsz=0.02, width=(2, 2), coordsys="GAL", axes=[axis]
+)
+
+
+# Define some observation parameters
+# we are not simulating many pointings / observations
+pointing = SkyCoord(0.2, 0.5, unit="deg", frame="galactic")
+livetime = 20 * u.hour
+
+exposure_map = make_map_exposure_true_energy(
+    pointing=pointing, livetime=livetime, aeff=aeff, geom=geom
+)
+
+evaluator = MapEvaluator(model=compound_model, exposure=exposure_map)
+
+
+npred = evaluator.compute_npred()
+npred_map = WcsNDMap(geom, npred)
+
+fig, ax, cbar = npred_map.sum_over_axes().plot(add_cbar=True)
+ax.scatter(
+    [lon_0_1, lon_0_2, pointing.galactic.l.degree],
+    [lat_0_1, lat_0_2, pointing.galactic.b.degree],
+    transform=ax.get_transform("galactic"),
+    marker="+",
+    color="cyan",
+)
+# plt.show()
+plt.clf()
+
+rng = get_random_state(42)
+counts = rng.poisson(npred)
+counts_map = WcsNDMap(geom, counts)
+
+counts_map.sum_over_axes().plot()
+# plt.show()
+plt.clf()
+
+compound_model.parameters.set_parameter_errors({
+    'gaussian.sigma'  : 0.1 * u.deg,
+    'pl1.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
+    'roberta.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
+})
+
+fit = MapFit(model=compound_model, counts=counts_map, exposure=exposure_map)
+print(compound_model.parameters)
+
+fit.fit()

--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -92,13 +92,10 @@ counts_map.sum_over_axes().plot()
 # plt.show()
 plt.clf()
 
-compound_model.parameters.set_parameter_errors({
-    'gaussian.sigma'  : 0.1 * u.deg,
-    'pl1.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
-    'roberta.amplitude' : 1e-12 * u.Unit('cm-2 s-1 TeV-1'),
-})
+compound_model.parameters.set_error(2, 0.1 * u.deg)
+compound_model.parameters.set_error(4, 1e-12 * u.Unit('cm-2 s-1 TeV-1'))
+compound_model.parameters.set_error(8, 0.1 * u.deg)
+compound_model.parameters.set_error(10, 1e-12 * u.Unit('cm-2 s-1 TeV-1'))
 
 fit = MapFit(model=compound_model, counts=counts_map, exposure=exposure_map)
-print(compound_model.parameters)
-
 fit.fit()

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -126,6 +126,7 @@ class SkyModel(object):
 
     @parameters.setter
     def parameters(self, parameters):
+        self._parameters = parameters
         idx = len(self.spatial_model.parameters.parameters)
         self._spatial_model.parameters.parameters = parameters.parameters[:idx]
         self._spectral_model.parameters.parameters = parameters.parameters[idx:]
@@ -194,18 +195,19 @@ class CompoundSkyModel(object):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
-
-    # TODO: Think about how to deal with covariance matrix
-    @property
-    def parameters(self):
-        """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
-        return ParameterList(
-            self.model1.parameters.parameters +
+        self._parameters = ParameterList(
+            self.model1.parameters.parameters + 
             self.model2.parameters.parameters
         )
 
+    @property
+    def parameters(self):
+        """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
+        return self._parameters
+
     @parameters.setter
     def parameters(self, parameters):
+        self._parameters = parameters
         idx = len(self.model1.parameters.parameters)
         self.model1.parameters.parameters = parameters.parameters[:idx]
         self.model2.parameters.parameters = parameters.parameters[idx:]

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -429,9 +429,14 @@ class SpectrumFit(object):
         # parameter names
 
         # create tuples of combinations
-        d = self._model.parameters.to_dict()
-        parameter_names = [l['name'] for l in d['parameters'] if not l['frozen']]
-        self.covar_axis = parameter_names
+        parameter_names = list()
+        parameter_names_minuit = self._iminuit_fit.parameters
+        for par, parname in zip(self._model.parameters.parameters,
+                                parameter_names_minuit):
+            if not par.frozen:
+                parameter_names.append(parname)
+
+        self.covar_axis = self._model.parameters.free
         parameter_combinations = list(product(parameter_names, repeat=2))
 
         if self._iminuit_fit.covariance:

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -95,7 +95,8 @@ def make_minuit_par_kwargs(parameters):
     """
     kwargs = {}
     parnames = _make_parnames(parameters)
-    for parname_, par in zip(parnames, parameters.parameters):
+    for idx, parname_, in enumerate(parnames):
+        par = parameters[idx]
         kwargs[parname_] = par.value
 
         min_ = None if np.isnan(par.min) else par.min
@@ -105,7 +106,7 @@ def make_minuit_par_kwargs(parameters):
         if parameters.covariance is None:
             kwargs['error_{}'.format(parname_)] = 1
         else:
-            kwargs['error_{}'.format(parname_)] = np.sqrt(self.covariance[par_idx, par_idx])
+            kwargs['error_{}'.format(parname_)] = parameters.error(idx)
 
         if par.frozen:
             kwargs['fix_{}'.format(parname_)] = True

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -25,14 +25,14 @@ def test_iminuit():
     assert_allclose(pars['y'].value, 3, rtol=1e-2)
     assert_allclose(pars['z'].value, 4, rtol=1e-2)
 
-    assert_allclose(minuit.values['x'], 2, rtol=1e-2)
-    assert_allclose(minuit.values['y'], 3, rtol=1e-2)
-    assert_allclose(minuit.values['z'], 4, rtol=1e-2)
+    assert_allclose(minuit.values['par_000_x'], 2, rtol=1e-2)
+    assert_allclose(minuit.values['par_001_y'], 3, rtol=1e-2)
+    assert_allclose(minuit.values['par_002_z'], 4, rtol=1e-2)
 
     # Test freeze
     pars['x'].frozen = True
     minuit = fit_iminuit(function=fcn, parameters=pars)
-    assert minuit.list_of_fixed_param() == ['x']
+    assert minuit.list_of_fixed_param() == ['par_000_x']
 
     # Test limits
     pars['y'].min = 4

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -163,20 +163,20 @@ class ParameterList(object):
         ss += '\n\nCovariance: \n{}'.format(self.covariance)
         return ss
 
-    def _name_to_idx(self, name):
-        """Convert parameter name to index if str is given"""
-        if isinstance(name, six.string_types):
+    def _get_idx(self, val):
+        """Convert parameter name or index to index"""
+        if isinstance(val, six.string_types):
             for idx, par in enumerate(self.parameters):
-                if name == par.name:
+                if val == par.name:
                     return idx
-            raise IndexError('Parameter {} not found for : {}'.format(name, self))
+            raise IndexError('Parameter {} not found for : {}'.format(val, self))
 
         else:
-            return name
+            return val
 
     def __getitem__(self, name):
         """Access parameter by name or index"""
-        idx = self._name_to_idx(name)
+        idx = self._get_idx(name)
         return self.parameters[idx]
 
     def to_dict(self):
@@ -345,7 +345,7 @@ class ParameterList(object):
         if self.covariance is None:
             raise ValueError('Covariance matrix not set.')
 
-        idx = self._name_to_idx(parname)
+        idx = self._get_idx(parname)
         return np.sqrt(self.covariance[idx, idx])
 
     # TODO: this is a temporary solution until we have a better way
@@ -363,7 +363,7 @@ class ParameterList(object):
             shape = (len(self.parameters), len(self.parameters))
             self.covariance = np.zeros(shape) 
 
-        idx = self._name_to_idx(parname)
+        idx = self._get_idx(parname)
         err = u.Quantity(err, self[idx].unit).value
         self.covariance[idx, idx] = err ** 2
 

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -163,13 +163,21 @@ class ParameterList(object):
         ss += '\n\nCovariance: \n{}'.format(self.covariance)
         return ss
 
-    def __getitem__(self, name):
-        """Access parameter by name"""
-        for par in self.parameters:
-            if name == par.name:
-                return par
+    def _name_to_idx(self, name):
+        """Convert parameter name to index if str is given"""
+        if isinstance(name, six.string_types):
+            for idx, par in enumerate(self.parameters):
+                if name == par.name:
+                    return idx
+            raise IndexError('Parameter {} not found for : {}'.format(name, self))
 
-        raise IndexError('Parameter {} not found for : {}'.format(name, self))
+        else:
+            return name
+
+    def __getitem__(self, name):
+        """Access parameter by name or index"""
+        idx = self._name_to_idx(name)
+        return self.parameters[idx]
 
     def to_dict(self):
         retval = dict(parameters=list(), covariance=None)
@@ -289,6 +297,7 @@ class ParameterList(object):
         errors : dict of `~astropy.units.Quantity`
             Dict of parameter errors.
         """
+        # TODO: Mark as deprecated
         diag = []
         for par in self.parameters:
             error = errors.get(par.name, 0)
@@ -330,16 +339,33 @@ class ParameterList(object):
 
         Parameters
         ----------
-        parname : str
-            Parameter
+        parname : str, int
+            Parameter name or index
         """
         if self.covariance is None:
             raise ValueError('Covariance matrix not set.')
 
-        for i, parameter in enumerate(self.parameters):
-            if parameter.name == parname:
-                return np.sqrt(self.covariance[i, i])
-        raise ValueError('Could not find parameter {}'.format(parname))
+        idx = self._name_to_idx(parname)
+        return np.sqrt(self.covariance[idx, idx])
+
+    # TODO: this is a temporary solution until we have a better way
+    # to handle covariance matrices via a class
+    def set_error(self, parname, err):
+        """
+        Return error on a given parameter
+
+        Parameters
+        ----------
+        parname : str, int
+            Parameter name or index
+        """
+        if self.covariance is None:
+            shape = (len(self.parameters), len(self.parameters))
+            self.covariance = np.zeros(shape) 
+
+        idx = self._name_to_idx(parname)
+        err = u.Quantity(err, self[idx].unit).value
+        self.covariance[idx, idx] = err ** 2
 
     def copy(self):
         """A deep copy"""

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -30,6 +30,7 @@ def test_parameter_list():
     pars.set_parameter_errors({
         'ham': '10000 GeV',
     })
-    assert_allclose(pars.covariance, [[0, 0], [0, 100]])
-    assert_allclose(pars.error('spam'), 0)
-    assert_allclose(pars.error('ham'), 10)
+    pars.set_error(0, 0.1)
+    assert_allclose(pars.covariance, [[1e-2, 0], [0, 100]])
+    assert_allclose(pars.error('spam'), 0.1)
+    assert_allclose(pars.error(1), 10)


### PR DESCRIPTION
This is a follow up to #1636 

The main issue that remains is the following. If one has a parameterlist with ambigious parameter names, e.g. ``gamma``, ``index``, ``amplitude``, ``gamma`` it is not possible to set or get the error of the second ``gamma`` parameter, because of the way we handle the covariance matrix at the moment. See [here](https://github.com/gammapy/gammapy/blob/master/gammapy/utils/modeling.py#L340) and [here](https://github.com/gammapy/gammapy/blob/master/gammapy/utils/modeling.py#L294).

So before this really works, we need to find a better way to handle the covariance matrix, cc @adonath 