### PR TITLE
Rename SourceLibrary to SkyModels

### DIFF
--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -1,25 +1,14 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import astropy.units as u
-from astropy.coordinates import SkyCoord, Angle
-from gammapy.irf import (
-    EffectiveAreaTable2D,
-    EnergyDispersion2D,
-    EnergyDependentMultiGaussPSF,
-    Background3D,
-)
-from gammapy.maps import WcsGeom, MapAxis, WcsNDMap, Map
+from astropy.coordinates import SkyCoord
+from gammapy.irf import EffectiveAreaTable2D
+from gammapy.maps import WcsGeom, MapAxis, WcsNDMap
 from gammapy.spectrum.models import PowerLaw
 from gammapy.image.models import SkyGaussian
 from gammapy.utils.random import get_random_state
-from gammapy.cube import (
-    make_map_exposure_true_energy,
-    SkyModel,
-    MapFit,
-    MapEvaluator,
-    SourceLibrary,
-    PSFKernel,
-)
+from gammapy.cube import make_map_exposure_true_energy, MapFit, MapEvaluator
+from gammapy.cube.models import SkyModel
 
 filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
 aeff = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
@@ -64,7 +53,7 @@ pointing = SkyCoord(0.2, 0.5, unit="deg", frame="galactic")
 livetime = 20 * u.hour
 
 exposure_map = make_map_exposure_true_energy(
-    pointing=pointing, livetime=livetime, aeff=aeff, geom=geom
+    pointing=pointing, livetime=livetime, aeff=aeff, geom=geom,
 )
 
 evaluator = MapEvaluator(model=compound_model, exposure=exposure_map)

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -17,7 +17,7 @@ from ..utils.scripts import make_path
 from ..spectrum import FluxPoints
 from ..spectrum.models import PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw
 from ..image.models import SkyPointSource, SkyGaussian, SkyShell
-from ..cube.models import SkyModel, SourceLibrary
+from ..cube.models import SkyModel, SkyModels
 from .core import SourceCatalog, SourceCatalogObject
 
 __all__ = [
@@ -445,8 +445,8 @@ class SourceCatalogGammaCat(SourceCatalog):
             source_name_alias=source_name_alias,
         )
 
-    def to_source_library(self):
-        """Convert to a `~gammapy.utils.modeling.SourceLibrary`.
+    def to_sky_models(self):
+        """Convert to a `~gammapy.utils.modeling.SkyModels`.
 
         TODO: add an option whether to skip or raise on missing models or data.
         """
@@ -460,7 +460,7 @@ class SourceCatalogGammaCat(SourceCatalog):
                 log.warning('Skipping source {} (missing data in gamma-cat)'.format(source.name))
                 continue
 
-        return SourceLibrary(source_list)
+        return SkyModels(source_list)
 
 
 class GammaCatDataCollection(object):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -80,8 +80,8 @@ class TestSourceCatalogGammaCat:
             cat.table.sort(sort_key)
             assert cat[name].name == name
 
-    def test_to_source_library(self, gammacat):
-        sources = gammacat.to_source_library()
+    def test_to_sky_models(self, gammacat):
+        sources = gammacat.to_sky_models()
         source = sources.skymodels[0]
 
         assert len(sources.skymodels) == 74

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -9,7 +9,7 @@ from ..utils.scripts import make_path
 from ..maps import Map
 
 __all__ = [
-    'SourceLibrary',
+    'SkyModels',
     'SkyModel',
     'CompoundSkyModel',
     'SumSkyModel',
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-class SourceLibrary(object):
+class SkyModels(object):
     """Collection of `~gammapy.cube.models.SkyModel`
 
     Parameters
@@ -28,11 +28,11 @@ class SourceLibrary(object):
     Examples
     --------
 
-    Read a SourceLibrary from an XML file::
+    Read from an XML file::
 
-        from gammapy.cube import SourceLibrary
+        from gammapy.cube import SkyModels
         filename = '$GAMMAPY_EXTRA/test_datasets/models/fermi_model.xml'
-        sourcelib = SourceLibrary.from_xml(filename)
+        sourcelib = SkyModels.from_xml(filename)
     """
 
     def __init__(self, skymodels):
@@ -40,13 +40,13 @@ class SourceLibrary(object):
 
     @classmethod
     def from_xml(cls, xml):
-        """Read SourceLibrary from XML string"""
-        from ..utils.serialization import xml_to_source_library
-        return xml_to_source_library(xml)
+        """Read from XML string."""
+        from ..utils.serialization import xml_to_sky_models
+        return xml_to_sky_models(xml)
 
     @classmethod
     def read(cls, filename):
-        """Read SourceLibrary from XML file
+        """Read from XML file.
 
         The XML definition of some models is uncompatible with the models
         currently implemented in gammapy. Therefore the following modifications
@@ -63,9 +63,9 @@ class SourceLibrary(object):
         return cls.from_xml(xml)
 
     def to_xml(self, filename):
-        """Write SourceLibrary to XML file"""
-        from ..utils.serialization import source_library_to_xml
-        xml = source_library_to_xml(self)
+        """Write to XML file."""
+        from ..utils.serialization import sky_models_to_xml
+        xml = sky_models_to_xml(self)
         filename = make_path(filename)
         with filename.open('w') as output:
             output.write(xml)

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -14,7 +14,7 @@ from ...spectrum.models import PowerLaw
 from ..fit import MapEvaluator
 from ..models import (
     SkyModel,
-    SourceLibrary,
+    SkyModels,
     CompoundSkyModel,
     SumSkyModel,
 )
@@ -68,12 +68,12 @@ def evaluator(sky_model, exposure, background, psf, edisp):
     return MapEvaluator(sky_model, exposure, background, psf=psf, edisp=edisp)
 
 
-class TestSourceLibrary:
+class TestSkyModels:
     def setup(self):
-        self.source_library = SourceLibrary([sky_model(), sky_model()])
+        self.sky_models = SkyModels([sky_model(), sky_model()])
 
     def test_to_compound_model(self):
-        model = self.source_library.to_compound_model()
+        model = self.sky_models.to_compound_model()
         assert isinstance(model, CompoundSkyModel)
         pars = model.parameters.parameters
         assert len(pars) == 12
@@ -81,7 +81,7 @@ class TestSourceLibrary:
         assert pars[-1].name == 'reference'
 
     def test_to_sum_model(self):
-        model = self.source_library.to_sum_model()
+        model = self.sky_models.to_sum_model()
         assert isinstance(model, SumSkyModel)
         pars = model.parameters.parameters
         assert len(pars) == 12

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -6,8 +6,8 @@ from numpy.testing import assert_allclose
 from ...testing import requires_data, requires_dependency
 from ....spectrum import models as spectral
 from ....image import models as spatial
-from ....cube.models import SourceLibrary
-from ...serialization import xml_to_source_library, UnknownModelError
+from ....cube.models import SkyModels
+from ...serialization import xml_to_sky_models, UnknownModelError
 
 
 def test_from_xml():
@@ -26,8 +26,8 @@ def test_from_xml():
             </source>
         </source_library>
         '''
-    source_library = SourceLibrary.from_xml(xml)
-    sky_model = source_library.skymodels[0]
+    sky_models = SkyModels.from_xml(xml)
+    sky_model = sky_models.skymodels[0]
     assert_allclose(sky_model.parameters['lon_0'].value, 187.25)
 
 
@@ -42,7 +42,7 @@ def test_xml_errors():
     xml += '</source_library>'
 
     with pytest.raises(UnknownModelError):
-        xml_to_source_library(xml)
+        xml_to_sky_models(xml)
 
     # TODO: Think about a more elaborate XML validation scheme
 
@@ -51,7 +51,7 @@ def test_xml_errors():
 @requires_dependency('scipy')
 def test_complex():
     filename = '$GAMMAPY_EXTRA/test_datasets/models/examples.xml'
-    sourcelib = SourceLibrary.read(filename)
+    sourcelib = SkyModels.read(filename)
 
     assert len(sourcelib.skymodels) == 7
 
@@ -124,10 +124,10 @@ def test_complex():
 ])
 def test_models(filename, tmpdir):
     outfile = tmpdir / 'models_out.xml'
-    sourcelib = SourceLibrary.read(filename)
+    sourcelib = SkyModels.read(filename)
     sourcelib.to_xml(outfile)
 
-    sourcelib_roundtrip = SourceLibrary.from_xml(outfile)
+    sourcelib_roundtrip = SkyModels.from_xml(outfile)
 
     for model, model_roundtrip in zip(sourcelib.skymodels,
                                       sourcelib_roundtrip.skymodels):
@@ -136,9 +136,9 @@ def test_models(filename, tmpdir):
 
 @pytest.mark.xfail(reason='Need to improve XML read')
 @requires_data('gammapy-extra')
-def test_source_library_old_xml_file():
+def test_sky_models_old_xml_file():
     filename = '$GAMMAPY_EXTRA/test_datasets/models/shell.xml'
-    sources = SourceLibrary.read(filename)
+    sources = SkyModels.read(filename)
 
     assert len(sources.source_list) == 2
 
@@ -152,9 +152,9 @@ def test_source_library_old_xml_file():
 
 @pytest.mark.xfail(reason='Need to improve XML read')
 @requires_data('gammapy-extra')
-def test_source_library_new_xml_file():
+def test_sky_models_new_xml_file():
     filename = '$GAMMAPY_EXTRA/test_datasets/models/ctadc_skymodel_gps_sources_bright.xml'
-    sources = SourceLibrary.read(filename)
+    sources = SkyModels.read(filename)
 
     assert len(sources.source_list) == 47
 

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -16,18 +16,18 @@ from ..modeling import Parameter, ParameterList
 from ...maps import Map
 from ...image import models as spatial
 from ...spectrum import models as spectral
-from ...cube.models import SourceLibrary, SkyModel
+from ...cube.models import SkyModels, SkyModel
 
 log = logging.getLogger(__name__)
 
 __all__ = [
     'UnknownModelError',
     'UnknownParameterError',
-    'xml_to_source_library',
+    'xml_to_sky_models',
     'xml_to_skymodel',
     'xml_to_model',
     'xml_to_parameter_list',
-    'source_library_to_xml',
+    'sky_models_to_xml',
 ]
 
 # TODO: Move to a separate file ?
@@ -146,7 +146,7 @@ class UnknownParameterError(ValueError):
     """Error when encountering unknown parameters."""
 
 
-def xml_to_source_library(xml):
+def xml_to_sky_models(xml):
     """
     Convert XML to `~gammapy.cube.models.SkyModelList`
     """
@@ -157,7 +157,7 @@ def xml_to_source_library(xml):
         skymodel = xml_to_skymodel(xml_skymodel)
         if skymodel is not None:
             skymodels.append(skymodel)
-    return SourceLibrary(skymodels)
+    return SkyModels(skymodels)
 
 
 def xml_to_skymodel(xml):
@@ -259,9 +259,9 @@ def xml_to_parameter_list(xml, which, type_):
     return ParameterList(parameters)
 
 
-def source_library_to_xml(sourcelib):
+def sky_models_to_xml(sourcelib):
     """
-    Convert `~gammapy.cube.models.SourceLibrary` to XML
+    Convert `~gammapy.cube.models.SkyModels` to XML
     """
     xml = '<?xml version="1.0" encoding="utf-8"?>\n'
     xml += '<source_library title="source library">\n'


### PR DESCRIPTION
This PR renames `SourceLibrary` to `SkyModel`. It's  a first step for #1652 .
I'll merge this now, and do the merge with `SkySumModel` in a follow-up PR.