### PR TITLE
Fix spectrum energy grouping, use nearest neighbor method

### DIFF
--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import OrderedDict
 from copy import deepcopy
 import numpy as np
+import logging
 from ..extern.six.moves import UserList
 import astropy.units as u
 from astropy.units import Quantity
@@ -30,6 +31,7 @@ __all__ = [
     'SpectrumEnergyGroupMaker',
 ]
 
+log = logging.getLogger(__name__) 
 
 class SpectrumEnergyGroup(object):
     """Spectrum energy group.
@@ -204,7 +206,12 @@ class SpectrumEnergyGroups(UserList):
             if group.contains_energy(energy):
                 return idx
 
-        raise IndexError('No group found with energy: {}'.format(energy))
+        # energy is below groups 
+        if energy < self[0].energy_min: 
+            return -1
+        # energy is above
+        if energy >= self[-1].energy_max: 
+            return -2
 
 
 class SpectrumEnergyGroupMaker(object):
@@ -269,56 +276,64 @@ class SpectrumEnergyGroupMaker(object):
         ebounds : `~astropy.units.Quantity`
             Energy bounds array
         """
-        ebounds_obs = self.obs.e_reco
-        groups = []
+        ebounds_src = self.obs.e_reco
+        bin_edges_src = np.arange(len(ebounds_src))
+        
+        temp = np.interp(ebounds, ebounds_src, bin_edges_src)
+        bin_edges = np.round(temp, decimals=0).astype(np.int)
 
-        # Calculate all differences between `ebounds` and `ebounds_obs`
-        # Find the indices where the sign changes
-        energy_binning_offset = ebounds - 1 * u.MeV
-        diff = energy_binning_offset[:, np.newaxis] - ebounds_obs.lower_bounds
-        lower_indices = np.argmin(np.sign(diff), axis=1)
-        # Make sure the last bin is not the first bin.
-        if lower_indices[-1] == 0:
-            lower_indices[-1] = ebounds_obs.nbins
+        # Check for duplicates
+        duplicates_removed = list()
+        for _ in bin_edges:
+            if _ not in duplicates_removed:
+                duplicates_removed.append(_)
 
-        energy_group_idx = 0
+        if len(duplicates_removed) != len(bin_edges):
+            warn_str = "Input binning\n{}\n contains bins that are finer than the"
+            warn_str += " target binning\n{}\nor outside the valid range"
+            log.warn(warn_str.format(ebounds, ebounds_src)) 
+        bin_edges = duplicates_removed
 
-        if lower_indices[0] > 0:
-            # Create underflow group
+        # Create normal bins
+        groups = list()
+        for idx in np.arange(len(bin_edges) - 1):
             group = SpectrumEnergyGroup(
-                energy_group_idx=energy_group_idx,
-                bin_idx_min=0,
-                bin_idx_max=lower_indices[0] - 1,
-                bin_type='underflow',
-                energy_min=ebounds_obs.lower_bounds[0],
-                energy_max=ebounds_obs.upper_bounds[lower_indices[0] - 1],
-            )
-            groups.append(group)
-            energy_group_idx += 1
-
-        # Create normal groups (could be none)
-        for index in range(len(ebounds) - 1):
-            group = SpectrumEnergyGroup(
-                energy_group_idx=energy_group_idx,
-                bin_idx_min=lower_indices[index],
-                bin_idx_max=lower_indices[index + 1] - 1,
+                energy_group_idx=-1,
+                bin_idx_min=bin_edges[idx],
+                bin_idx_max=bin_edges[idx+1] - 1,
                 bin_type='normal',
-                energy_min=ebounds_obs.lower_bounds[lower_indices[index]],
-                energy_max=ebounds_obs.upper_bounds[lower_indices[index + 1] - 1],
+                energy_min=ebounds_src[bin_edges[idx]],
+                energy_max=ebounds_src[bin_edges[idx+1]],
             )
             groups.append(group)
-            energy_group_idx += 1
 
-        maxbin = lower_indices[-1]
-        if maxbin < ebounds_obs.nbins:
-            # Create overflow group
-            group = SpectrumEnergyGroup(
-                energy_group_idx=energy_group_idx,
-                bin_idx_min=maxbin,
-                bin_idx_max=ebounds_obs.nbins - 1,
+        # Add underflow bin
+        start_edge = groups[0].bin_idx_min
+        if  start_edge != 0:
+            underflow = SpectrumEnergyGroup(
+                energy_group_idx=-1,
+                bin_idx_min=0,
+                bin_idx_max=start_edge - 1,
+                bin_type='underflow',
+                energy_min=ebounds_src[0],
+                energy_max=ebounds_src[start_edge],
+            )
+            groups.insert(0, underflow)
+
+        # Add overflow bin
+        end_edge = groups[-1].bin_idx_max
+        if  end_edge != ebounds_src.nbins - 1:
+            overflow = SpectrumEnergyGroup(
+                energy_group_idx=-1,
+                bin_idx_min=end_edge + 1,
+                bin_idx_max=ebounds_src.nbins - 1,
                 bin_type='overflow',
-                energy_min=ebounds_obs.lower_bounds[maxbin],
-                energy_max=ebounds_obs.upper_bounds[-1])
-            groups.append(group)
+                energy_min=ebounds_src[end_edge + 1],
+                energy_max=ebounds_src[-1],
+            )
+            groups.append(overflow)
 
-        self.groups = SpectrumEnergyGroups(groups)
+        # Set energy_group_idx
+        for group_idx, group in enumerate(groups):
+            group.energy_group_idx = group_idx
+        self.groups = SpectrumEnergyGroups(groups) 

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -96,10 +96,6 @@ class SpectrumEnergyGroup(object):
         table['energy_max'] = self.energy_max
         return table
 
-    def contains_energy(self, energy):
-        """Does this group contain a given energy?"""
-        return (self.energy_min <= energy) & (energy < self.energy_max)
-
 
 class SpectrumEnergyGroups(UserList):
     """List of `~gammapy.spectrum.SpectrumEnergyGroup` objects.
@@ -200,19 +196,6 @@ class SpectrumEnergyGroups(UserList):
         energy.append(self[-1].energy_max)
         return Quantity(energy)
 
-    def find_list_idx(self, energy):
-        """Find the list index corresponding to a given energy."""
-        for idx, group in enumerate(self):
-            if group.contains_energy(energy):
-                return idx
-
-        # energy is below groups 
-        if energy < self[0].energy_min: 
-            return -1
-        # energy is above
-        if energy >= self[-1].energy_max: 
-            return -2
-
 
 class SpectrumEnergyGroupMaker(object):
     """Energy bin groups for spectral analysis.
@@ -283,16 +266,13 @@ class SpectrumEnergyGroupMaker(object):
         bin_edges = np.round(temp, decimals=0).astype(np.int)
 
         # Check for duplicates
-        duplicates_removed = list()
-        for _ in bin_edges:
-            if _ not in duplicates_removed:
-                duplicates_removed.append(_)
-
+        duplicates_removed = set(bin_edges)
         if len(duplicates_removed) != len(bin_edges):
             warn_str = "Input binning\n{}\n contains bins that are finer than the"
-            warn_str += " target binning\n{}\nor outside the valid range"
+            warn_str += " target binning\n{}\n or outside the valid range"
             log.warn(warn_str.format(ebounds, ebounds_src)) 
-        bin_edges = duplicates_removed
+        bin_edges = list(duplicates_removed)
+        bin_edges.sort()
 
         # Create normal bins
         groups = list()

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -44,12 +44,6 @@ class TestSpectrumEnergyGroup:
         assert_equal(table["energy_group_idx"], 3)
         assert_equal(table["bin_type"], "normal")
 
-    def test_contains_energy(self, group):
-        energy = [99, 100, 199, 200] * u.TeV
-        actual = group.contains_energy(energy)
-        expected = [False, True, True, False]
-        assert_equal(actual, expected)
-
 
 class TestSpectrumEnergyGroups:
     @pytest.fixture()
@@ -100,14 +94,6 @@ class TestSpectrumEnergyGroups:
         expected = [100, 210, 260, 270, 300] * u.TeV
         assert_allclose(actual, expected)
         assert actual.unit == "TeV"
-
-    def test_find_list_idx(self, groups):
-        assert groups.find_list_idx(energy=100 * u.TeV) == 0  # On the edge
-        assert groups.find_list_idx(energy=270 * u.TeV) == 3  # On the edge
-        assert groups.find_list_idx(energy=271 * u.TeV) == 3  # inside a bin
-
-        assert groups.find_list_idx(energy=99 * u.TeV) == -1  # too low
-        assert groups.find_list_idx(energy=300 * u.TeV) == -2  # too high
 
 
 class TestSpectrumEnergyGroupMaker:

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -48,15 +48,13 @@ class TestSpectrumEnergyGroup:
 class TestSpectrumEnergyGroups:
     @pytest.fixture()
     def groups(self):
-        return SpectrumEnergyGroups(
-            [
-                # energy_group_idx, bin_idx_min, bin_idx_max, bin_type, energy_min, energy_max
-                SpectrumEnergyGroup(0, 10, 20, "normal", 100 * u.TeV, 210 * u.TeV),
-                SpectrumEnergyGroup(1, 21, 25, "normal", 210 * u.TeV, 260 * u.TeV),
-                SpectrumEnergyGroup(5, 26, 26, "normal", 260 * u.TeV, 270 * u.TeV),
-                SpectrumEnergyGroup(6, 27, 30, "normal", 270 * u.TeV, 300 * u.TeV),
-            ]
-        )
+        return SpectrumEnergyGroups([
+            # energy_group_idx, bin_idx_min, bin_idx_max, bin_type, energy_min, energy_max
+            SpectrumEnergyGroup(0, 10, 20, "normal", 100 * u.TeV, 210 * u.TeV),
+            SpectrumEnergyGroup(1, 21, 25, "normal", 210 * u.TeV, 260 * u.TeV),
+            SpectrumEnergyGroup(5, 26, 26, "normal", 260 * u.TeV, 270 * u.TeV),
+            SpectrumEnergyGroup(6, 27, 30, "normal", 270 * u.TeV, 300 * u.TeV),
+        ])
 
     def test_repr(self, groups):
         assert repr(groups) == "SpectrumEnergyGroups(len=4)"
@@ -69,7 +67,7 @@ class TestSpectrumEnergyGroups:
     def test_copy(self, groups):
         """Make sure groups.copy() is a deep copy"""
         groups2 = groups.copy()
-        groups2[0].bin_type == "spam"
+        groups2[0].bin_type = "spam"
         assert groups[0].bin_type == "normal"
 
     def test_group_table(self, groups):
@@ -122,12 +120,10 @@ class TestSpectrumEnergyGroupMaker:
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
-        expected = SpectrumEnergyGroups(
-            [
-                SpectrumEnergyGroup(0, 0, 0, "normal", 1 * u.TeV, 2 * u.TeV),
-                SpectrumEnergyGroup(1, 1, 8, "normal", 2 * u.TeV, 10 * u.TeV),
-            ]
-        )
+        expected = SpectrumEnergyGroups([
+            SpectrumEnergyGroup(0, 0, 0, "normal", 1 * u.TeV, 2 * u.TeV),
+            SpectrumEnergyGroup(1, 1, 8, "normal", 2 * u.TeV, 10 * u.TeV),
+        ])
 
         assert groups == expected
 
@@ -137,14 +133,12 @@ class TestSpectrumEnergyGroupMaker:
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
-        expected = SpectrumEnergyGroups(
-            [
-                SpectrumEnergyGroup(0, 0, 0, "underflow", 1 * u.TeV, 2 * u.TeV),
-                SpectrumEnergyGroup(1, 1, 3, "normal", 2 * u.TeV, 5 * u.TeV),
-                SpectrumEnergyGroup(2, 4, 5, "normal", 5 * u.TeV, 7 * u.TeV),
-                SpectrumEnergyGroup(3, 6, 8, "overflow", 7 * u.TeV, 10 * u.TeV),
-            ]
-        )
+        expected = SpectrumEnergyGroups([
+            SpectrumEnergyGroup(0, 0, 0, "underflow", 1 * u.TeV, 2 * u.TeV),
+            SpectrumEnergyGroup(1, 1, 3, "normal", 2 * u.TeV, 5 * u.TeV),
+            SpectrumEnergyGroup(2, 4, 5, "normal", 5 * u.TeV, 7 * u.TeV),
+            SpectrumEnergyGroup(3, 6, 8, "overflow", 7 * u.TeV, 10 * u.TeV),
+        ])
 
         assert groups == expected
 
@@ -154,12 +148,10 @@ class TestSpectrumEnergyGroupMaker:
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
-        expected = SpectrumEnergyGroups(
-            [
-                SpectrumEnergyGroup(0, 0, 2, "normal", 1 * u.TeV, 4 * u.TeV),
-                SpectrumEnergyGroup(1, 3, 8, "overflow", 4 * u.TeV, 10 * u.TeV),
-            ]
-        )
+        expected = SpectrumEnergyGroups([
+            SpectrumEnergyGroup(0, 0, 2, "normal", 1 * u.TeV, 4 * u.TeV),
+            SpectrumEnergyGroup(1, 3, 8, "overflow", 4 * u.TeV, 10 * u.TeV),
+        ])
 
         assert groups == expected
 
@@ -169,14 +161,10 @@ class TestSpectrumEnergyGroupMaker:
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
-        expected = SpectrumEnergyGroups(
-            [
-                SpectrumEnergyGroup(0, 0, 3, "underflow", 1 * u.TeV, 5 * u.TeV),
-                SpectrumEnergyGroup(1, 4, 5, "normal", 5 * u.TeV, 7 * u.TeV),
-                SpectrumEnergyGroup(2, 6, 8, "normal", 7 * u.TeV, 10 * u.TeV),
-            ]
-        )
+        expected = SpectrumEnergyGroups([
+            SpectrumEnergyGroup(0, 0, 3, "underflow", 1 * u.TeV, 5 * u.TeV),
+            SpectrumEnergyGroup(1, 4, 5, "normal", 5 * u.TeV, 7 * u.TeV),
+            SpectrumEnergyGroup(2, 6, 8, "normal", 7 * u.TeV, 10 * u.TeV),
+        ])
 
-        print(groups)
-        print(expected)
         assert groups == expected

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -6,26 +6,29 @@ from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from ..core import PHACountsSpectrum
 from ..observation import SpectrumObservation
-from ..energy_group import SpectrumEnergyGroups, SpectrumEnergyGroupMaker, SpectrumEnergyGroup
+from ..energy_group import (
+    SpectrumEnergyGroups,
+    SpectrumEnergyGroupMaker,
+    SpectrumEnergyGroup,
+)
 
 
 class TestSpectrumEnergyGroup:
-
     @pytest.fixture()
     def group(self):
-        return SpectrumEnergyGroup(3, 10, 20, 'normal', 100 * u.TeV, 200 * u.TeV)
+        return SpectrumEnergyGroup(3, 10, 20, "normal", 100 * u.TeV, 200 * u.TeV)
 
     def test_init(self, group):
         """Establish argument order in `__init__` and attributes."""
         assert group.energy_group_idx == 3
         assert group.bin_idx_min == 10
         assert group.bin_idx_max == 20
-        assert group.bin_type == 'normal'
+        assert group.bin_type == "normal"
         assert group.energy_min == 100 * u.TeV
         assert group.energy_max == 200 * u.TeV
 
     def test_repr(self, group):
-        assert 'SpectrumEnergyGroup' in repr(group)
+        assert "SpectrumEnergyGroup" in repr(group)
 
     def test_to_dict(self, group):
         # Check that it round-trips
@@ -37,9 +40,9 @@ class TestSpectrumEnergyGroup:
 
     def test_bin_table(self, group):
         table = group.bin_table
-        assert_equal(table['bin_idx'], np.arange(10, 21))
-        assert_equal(table['energy_group_idx'], 3)
-        assert_equal(table['bin_type'], 'normal')
+        assert_equal(table["bin_idx"], np.arange(10, 21))
+        assert_equal(table["energy_group_idx"], 3)
+        assert_equal(table["bin_type"], "normal")
 
     def test_contains_energy(self, group):
         energy = [99, 100, 199, 200] * u.TeV
@@ -49,30 +52,31 @@ class TestSpectrumEnergyGroup:
 
 
 class TestSpectrumEnergyGroups:
-
     @pytest.fixture()
     def groups(self):
-        return SpectrumEnergyGroups([
-            # energy_group_idx, bin_idx_min, bin_idx_max, bin_type, energy_min, energy_max
-            SpectrumEnergyGroup(0, 10, 20, 'normal', 100 * u.TeV, 210 * u.TeV),
-            SpectrumEnergyGroup(1, 21, 25, 'normal', 210 * u.TeV, 260 * u.TeV),
-            SpectrumEnergyGroup(5, 26, 26, 'normal', 260 * u.TeV, 270 * u.TeV),
-            SpectrumEnergyGroup(6, 27, 30, 'normal', 270 * u.TeV, 300 * u.TeV),
-        ])
+        return SpectrumEnergyGroups(
+            [
+                # energy_group_idx, bin_idx_min, bin_idx_max, bin_type, energy_min, energy_max
+                SpectrumEnergyGroup(0, 10, 20, "normal", 100 * u.TeV, 210 * u.TeV),
+                SpectrumEnergyGroup(1, 21, 25, "normal", 210 * u.TeV, 260 * u.TeV),
+                SpectrumEnergyGroup(5, 26, 26, "normal", 260 * u.TeV, 270 * u.TeV),
+                SpectrumEnergyGroup(6, 27, 30, "normal", 270 * u.TeV, 300 * u.TeV),
+            ]
+        )
 
     def test_repr(self, groups):
-        assert repr(groups) == 'SpectrumEnergyGroups(len=4)'
+        assert repr(groups) == "SpectrumEnergyGroups(len=4)"
 
     def test_str(self, groups):
         txt = str(groups)
-        assert 'SpectrumEnergyGroups' in txt
-        assert 'energy_group_idx' in txt
+        assert "SpectrumEnergyGroups" in txt
+        assert "energy_group_idx" in txt
 
     def test_copy(self, groups):
         """Make sure groups.copy() is a deep copy"""
         groups2 = groups.copy()
-        groups2[0].bin_type == 'spam'
-        assert groups[0].bin_type == 'normal'
+        groups2[0].bin_type == "spam"
+        assert groups[0].bin_type == "normal"
 
     def test_group_table(self, groups):
         """Check that info to and from group table round-trips"""
@@ -89,28 +93,25 @@ class TestSpectrumEnergyGroups:
         actual = groups.energy_range
         expected = [100, 300] * u.TeV
         assert_allclose(actual, expected)
-        assert actual.unit == 'TeV'
+        assert actual.unit == "TeV"
 
     def test_energy_bounds(self, groups):
         actual = groups.energy_bounds
         expected = [100, 210, 260, 270, 300] * u.TeV
         assert_allclose(actual, expected)
-        assert actual.unit == 'TeV'
+        assert actual.unit == "TeV"
 
     def test_find_list_idx(self, groups):
+        assert groups.find_list_idx(energy=100 * u.TeV) == 0  # On the edge
         assert groups.find_list_idx(energy=270 * u.TeV) == 3  # On the edge
         assert groups.find_list_idx(energy=271 * u.TeV) == 3  # inside a bin
 
-        with pytest.raises(IndexError):
-            groups.find_list_idx(energy=99 * u.TeV)  # too low
-
-        with pytest.raises(IndexError):
-            groups.find_list_idx(energy=300 * u.TeV)  # too high, left edge is not inclusive
+        assert groups.find_list_idx(energy=99 * u.TeV) == -1  # too low
+        assert groups.find_list_idx(energy=300 * u.TeV) == -2  # too high
 
 
 class TestSpectrumEnergyGroupMaker:
-
-    @pytest.fixture(scope='session')
+    @pytest.fixture(scope="session")
     def obs(self):
         """An example SpectrumObservation object for tests."""
         pha_ebounds = np.arange(1, 11) * u.TeV
@@ -118,7 +119,7 @@ class TestSpectrumEnergyGroupMaker:
             energy_lo=pha_ebounds[:-1],
             energy_hi=pha_ebounds[1:],
             data=np.zeros(len(pha_ebounds) - 1),
-            livetime=99 * u.s
+            livetime=99 * u.s,
         )
         return SpectrumObservation(on_vector=on_vector)
 
@@ -129,35 +130,67 @@ class TestSpectrumEnergyGroupMaker:
 
         assert len(groups) == obs.e_reco.nbins
 
-    @pytest.mark.parametrize('ebounds', [
-        [1.25, 4.5, 6.5] * u.TeV,
-        [2, 5, 7] * u.TeV,
-    ])
-    def test_compute_groups_fixed(self, obs, ebounds):
+    def test_compute_groups_fixed_basic(self, obs):
+        ebounds = [1, 2, 10] * u.TeV
         seg = SpectrumEnergyGroupMaker(obs=obs)
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
-        expected = SpectrumEnergyGroups([
-            SpectrumEnergyGroup(0, 0, 0, 'underflow', 1 * u.TeV, 2 * u.TeV),
-            SpectrumEnergyGroup(1, 1, 3, 'normal', 2 * u.TeV, 5 * u.TeV),
-            SpectrumEnergyGroup(2, 4, 5, 'normal', 5 * u.TeV, 7 * u.TeV),
-            SpectrumEnergyGroup(3, 6, 8, 'overflow', 7 * u.TeV, 10 * u.TeV),
-        ])
+        expected = SpectrumEnergyGroups(
+            [
+                SpectrumEnergyGroup(0, 0, 0, "normal", 1 * u.TeV, 2 * u.TeV),
+                SpectrumEnergyGroup(1, 1, 8, "normal", 2 * u.TeV, 10 * u.TeV),
+            ]
+        )
 
         assert groups == expected
 
-    @pytest.mark.parametrize('ebounds', [
-        [-1, 6, 100] * u.TeV,
-    ])
-    def test_compute_groups_fixed_out_of_bounds(self, obs, ebounds):
+    @pytest.mark.parametrize("ebounds", [[1.8, 4.8, 7.2] * u.TeV, [2, 5, 7] * u.TeV])
+    def test_compute_groups_fixed_edges(self, obs, ebounds):
         seg = SpectrumEnergyGroupMaker(obs=obs)
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
-        expected = SpectrumEnergyGroups([
-            SpectrumEnergyGroup(0, 0, 4, 'normal', 1 * u.TeV, 6 * u.TeV),
-            SpectrumEnergyGroup(1, 5, 8, 'normal', 6 * u.TeV, 10 * u.TeV),
-        ])
+        expected = SpectrumEnergyGroups(
+            [
+                SpectrumEnergyGroup(0, 0, 0, "underflow", 1 * u.TeV, 2 * u.TeV),
+                SpectrumEnergyGroup(1, 1, 3, "normal", 2 * u.TeV, 5 * u.TeV),
+                SpectrumEnergyGroup(2, 4, 5, "normal", 5 * u.TeV, 7 * u.TeV),
+                SpectrumEnergyGroup(3, 6, 8, "overflow", 7 * u.TeV, 10 * u.TeV),
+            ]
+        )
 
+        assert groups == expected
+
+    def test_compute_groups_fixed_below_range(self, obs):
+        ebounds = [0.7, 0.8, 1, 4] * u.TeV
+        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg.compute_groups_fixed(ebounds=ebounds)
+        groups = seg.groups
+
+        expected = SpectrumEnergyGroups(
+            [
+                SpectrumEnergyGroup(0, 0, 2, "normal", 1 * u.TeV, 4 * u.TeV),
+                SpectrumEnergyGroup(1, 3, 8, "overflow", 4 * u.TeV, 10 * u.TeV),
+            ]
+        )
+
+        assert groups == expected
+
+    def test_compute_groups_fixed_above_range(self, obs):
+        ebounds = [5, 7, 11, 13] * u.TeV
+        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg.compute_groups_fixed(ebounds=ebounds)
+        groups = seg.groups
+
+        expected = SpectrumEnergyGroups(
+            [
+                SpectrumEnergyGroup(0, 0, 3, "underflow", 1 * u.TeV, 5 * u.TeV),
+                SpectrumEnergyGroup(1, 4, 5, "normal", 5 * u.TeV, 7 * u.TeV),
+                SpectrumEnergyGroup(2, 6, 8, "normal", 7 * u.TeV, 10 * u.TeV),
+            ]
+        )
+
+        print(groups)
+        print(expected)
         assert groups == expected


### PR DESCRIPTION
This PR addresses issues that have been raised after the coding sprint, e.g. #1638 .
It simplifies the algorithm matching the user binning to the fine binning of an observation. Now nearest neighbour interpolation is used. This has already been suggested at the coding spring by @adonath and @mackaiver