### PR TITLE
Remove SpectrumFit _est_errors_iminuit ?

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -43,26 +43,20 @@ class SpectrumFit(object):
         observation, use :func:`~gammapy.spectrum.PHACountsSpectrum.quality`
     method : {'iminuit'}
         Optimization backend for the fit
-    error_method : {'covar', 'conf', 'HESSE', 'MINOS'}
-        Method of the error estimation depending on the backend.
-        TODO: Not implemented yet. For now 'covar'/'HESSE' are used by default.
     """
 
     def __init__(self, obs_list, model, stat='wstat', forward_folded=True,
-                 fit_range=None, method='iminuit', error_method=None):
+                 fit_range=None, method='iminuit'):
         self.obs_list = obs_list
         self._model = model
         self.stat = stat
         self.forward_folded = forward_folded
         self.fit_range = fit_range
         self.method = method
-        self.error_method = error_method
 
         self._predicted_counts = None
         self._statval = None
 
-        self.covar_axis = None
-        self.covariance = None
         self._result = None
 
         self._check_valid_fit()
@@ -75,8 +69,6 @@ class SpectrumFit(object):
         ss += '\nForward Folded {}'.format(self.forward_folded)
         ss += '\nFit range {}'.format(self.fit_range)
         ss += '\nBackend {}'.format(self.method)
-        ss += '\nError Method {}'.format(self.error_method)
-
         return ss
 
     @property
@@ -414,40 +406,8 @@ class SpectrumFit(object):
 
     def est_errors(self):
         """Estimate parameter errors."""
-        if self.method == 'iminuit':
-            self._est_errors_iminuit()
-        else:
-            raise NotImplementedError('{}'.format(self.method))
-
-        for res in self.result:
-            res.covar_axis = self.covar_axis
-            res.covariance = self.covariance
-            res.model.parameters.set_parameter_covariance(self.covariance, self.covar_axis)
-
-    def _est_errors_iminuit(self):
-        # The iminuit covariance is a dict indexed by tuples containing combinations of
-        # parameter names
-
-        # create tuples of combinations
-        parameter_names = list()
-        parameter_names_minuit = self._iminuit_fit.parameters
-        for par, parname in zip(self._model.parameters.parameters,
-                                parameter_names_minuit):
-            if not par.frozen:
-                parameter_names.append(parname)
-
-        self.covar_axis = self._model.parameters.free
-        parameter_combinations = list(product(parameter_names, repeat=2))
-
-        if self._iminuit_fit.covariance:
-            iminuit_covariance = self._iminuit_fit.covariance
-            cov = np.array([iminuit_covariance[c] for c in parameter_combinations])
-        else:
-            # fit did not converge
-            cov = np.repeat(np.nan, len(parameter_combinations))
-
-        cov = cov.reshape(len(parameter_names), -1)
-        self.covariance = cov
+        # TODO: add this back once fitting backends support optimisation
+        # and error estimation as separate steps
 
     def run(self, outdir=None):
         """Run all steps and write result to disk.

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -18,9 +18,8 @@ class TestSpectrumFitResult:
                                        amplitude=1e-11 * u.Unit('cm-2 s-1 TeV-1'),
                                        reference=1 * u.TeV)
         self.npred = self.obs.predicted_counts(self.best_fit_model).data.data.value
-        covar_axis = ['index', 'amplitude']
-        covar = np.diag([0.1 ** 2, 1e-12 ** 2])
-        self.best_fit_model.parameters.set_parameter_covariance(covar, covar_axis)
+        covar = np.diag([0.1 ** 2, 1e-12 ** 2, 0])
+        self.best_fit_model.parameters.covariance = covar
         self.fit_range = [0.1, 50] * u.TeV
         self.fit_result = SpectrumFitResult(
             model=self.best_fit_model,

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -290,32 +290,6 @@ class ParameterList(object):
 
     # TODO: this is a temporary solution until we have a better way
     # to handle covariance matrices via a class
-    def set_parameter_covariance(self, covariance, covar_axis):
-        """
-        Set full correlated parameters errors.
-
-        Parameters
-        ----------
-        covariance : array-like
-            Covariance matrix
-        covar_axis : list
-            List of strings defining the parameter order in covariance
-        """
-        shape = (len(self.parameters), len(self.parameters))
-        covariance_new = np.zeros(shape)
-        idx_lookup = dict([(par.name, idx) for idx, par in enumerate(self.parameters)])
-
-        # TODO: make use of covariance matrix symmetry
-        for i, par in enumerate(covar_axis):
-            i_new = idx_lookup[par]
-            for j, par_other in enumerate(covar_axis):
-                j_new = idx_lookup[par_other]
-                covariance_new[i_new, j_new] = covariance[i, j]
-
-        self.covariance = covariance_new
-
-    # TODO: this is a temporary solution until we have a better way
-    # to handle covariance matrices via a class
     def error(self, parname):
         """Get parameter error.
 


### PR DESCRIPTION
@joleroi - I think today we said that [SpectrumFit._est_errors_iminuit](https://github.com/gammapy/gammapy/blob/57363f840a11826f1e26187055d3bc360d3e93b5/gammapy/spectrum/fit.py#L427) can be removed, now that we have [this](https://github.com/gammapy/gammapy/blob/57363f840a11826f1e26187055d3bc360d3e93b5/gammapy/utils/fitting/iminuit.py#L54)?

Can the whole `covar_axis` and `covariance` attribute be removed, now that it's on `ParameterList`?

Can you please make sure there's a test covering this, and then do this cleanup?