### PR TITLE
Move gammapy.script.cta_irf to gammapy.irf.io

### DIFF
--- a/gammapy/irf/__init__.py
+++ b/gammapy/irf/__init__.py
@@ -12,4 +12,5 @@ from .psf_analytical import *
 from .psf_king import *
 from .energy_dispersion import *
 from .irf_stack import *
+from .io import *
 

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -5,8 +5,10 @@ from astropy.table import Table
 from ..utils.scripts import make_path
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.energy import EnergyBounds
-from ..irf import EffectiveAreaTable2D, EffectiveAreaTable, Background3D
-from ..irf import EnergyDispersion2D, EnergyDependentMultiGaussPSF
+from .effective_area import EffectiveAreaTable2D, EffectiveAreaTable
+from .background import Background3D
+from .energy_dispersion import EnergyDispersion2D
+from .psf_analytical import EnergyDependentMultiGaussPSF
 
 __all__ = [
     'CTAIrf',

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from astropy.units import Quantity
 from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check
 from ...utils.testing import assert_quantity_allclose
-from ..cta_irf import CTAIrf, CTAPerf
+from ..io import CTAIrf, CTAPerf
 
 
 @requires_dependency('scipy')

--- a/gammapy/scripts/__init__.py
+++ b/gammapy/scripts/__init__.py
@@ -3,5 +3,4 @@
 Gammapy command line interface (scripts).
 """
 from .spectrum_pipe import *
-from .cta_irf import *
 from .cta_sensitivity import *

--- a/gammapy/scripts/tests/test_cta_sensitivity.py
+++ b/gammapy/scripts/tests/test_cta_sensitivity.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose, assert_almost_equal
 import astropy.units as u
 from gammapy.utils.testing import requires_data, requires_dependency
 from gammapy.stats import significance_on_off
-from ..cta_irf import CTAPerf
+from ...irf.io import CTAPerf
 from ..cta_sensitivity import SensitivityEstimator
 
 


### PR DESCRIPTION
This PR is one step for the task described in #1551 . I move `gammapy/scripts/cta_irf.py` to `gammapy/irf/io.py` and adapt the one import where this is used. Zero changes to the classes or removals. I will send follow-up PRs shortly with further cleanup and improvements, but I want to go in small steps so that the PR diffs are easy to review.

Tests pass locally. Merging this now.

cc @registerrier @jjlk 