### PR TITLE
Implement excess_matching_significance and add test

### DIFF
--- a/gammapy/stats/tests/test_poisson.py
+++ b/gammapy/stats/tests/test_poisson.py
@@ -10,6 +10,7 @@ from ..poisson import (
     excess_error,
     significance,
     significance_on_off,
+    excess_matching_significance,
     excess_matching_significance_on_off,
     excess_ul_helene,
 )
@@ -75,9 +76,28 @@ def test_significance_on_off(p):
     assert_allclose(s, p['s'], atol=1e-5)
 
 
-@pytest.mark.xfail()
+# TODO: tests should be improved to also cover edge cases,
+# similarly to the tests we have for excess_matching_significance_on_off
 def test_excess_matching_significance():
-    raise NotImplementedError
+    actual = excess_matching_significance(mu_bkg=100, significance=5, method='simple')
+    assert_allclose(actual, 50)
+
+    actual = excess_matching_significance(mu_bkg=100, significance=5, method='lima')
+    assert_allclose(actual, 54.012755, atol=1e-3)
+
+    # Negative significance should work
+    excess = excess_matching_significance(mu_bkg=100, significance=-5, method='simple')
+    assert_allclose(excess, -50, atol=1e-3)
+    excess = excess_matching_significance(mu_bkg=100, significance=-5, method='lima')
+    assert_allclose(excess, -45.631273, atol=1e-3)
+
+    # Cases that can't be achieved with n_on >= 0 should return NaN
+    excess = excess_matching_significance(mu_bkg=1, significance=-2)
+    assert np.isnan(excess)
+
+    # Arrays should work
+    excess = excess_matching_significance(mu_bkg=[1, 2], significance=5)
+    assert_allclose(excess, [8.327276, 10.550546], atol=1e-3)
 
 
 def test_excess_matching_significance_on_off():


### PR DESCRIPTION
This PR implements `excess_matching_significance` and adds some tests, following the existing implementation and tests for `excess_matching_significance_on_off`.

I realise there's some code duplication and `_excess_matching_significance_lima` could maybe be simplified. I tried to make one root finding function and dispatch to it from both `_excess_matching_significance_lima` and `_excess_matching_significance_lima_on_off`. It worked, but I found it to be quite complex, so I preferred the ~ 10 line copy & paste & adapt over that complexity. Maybe there is a better way?

(the reason I did this was that it was one of the very few remaining cases of an xfailed test in Gammapy - we can get rid of all of them by tomorrow)

@bkhelifi @registerrier @adonath or anyone familiar with this - please review.
