### PR TITLE
Make image mapmaker

### DIFF
--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -46,7 +46,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
 
     return WcsNDMap(geom, exposure.value, unit=exposure.unit)
 
-def make_map_exposure_reco_energy(exposure_map, spectrum, edisp=None):
+def make_map_exposure_reco_energy(exposure_map, spectrum=None, edisp=None):
     """Create an exposure map in reco energy from an exposure map in true energy.
 
     Exposure in true energy is weighted with an input spectrum and redistributed in

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -7,7 +7,7 @@ from ..maps import WcsNDMap, MapAxis, Map
 
 __all__ = [
     'make_map_exposure_true_energy',
-    'weighted_exposure',
+    'weighted_exposure_image',
 ]
 
 
@@ -46,7 +46,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
 
     return WcsNDMap(geom, exposure.value, unit=exposure.unit)
 
-def weighted_exposure(exposure_map, spectrum=None):
+def weighted_exposure_image(exposure_map, spectrum=None):
     """Create an exposure map in reco energy from an exposure map in true energy.
 
     Exposure in true energy is weighted with an input spectrum and redistributed in
@@ -66,17 +66,17 @@ def weighted_exposure(exposure_map, spectrum=None):
         Resulting weighted image. The unit is the same as the input map.
     """
     expo_map = exposure_map.copy()
-    etrue_axis = expo_map.geom.get_axis_by_name("energy")
-    etrue_center = etrue_axis.center * etrue_axis.unit
-    etrue_edges = etrue_axis.edges * etrue_axis.unit
-    binsize = np.diff(etrue_edges)
+    energy_axis = expo_map.geom.get_axis_by_name("energy")
+    energy_center = energy_axis.center * energy_axis.unit
+    energy_edges = energy_axis.edges * energy_axis.unit
+    binsize = np.diff(energy_edges)
 
     if spectrum is None:
         spectrum = PowerLaw(index=2.0)
-    weights = spectrum(etrue_center)*binsize
+    weights = spectrum(energy_center)*binsize
     weights /= weights.sum()
 
     for img, idx in expo_map.iter_by_image():
         img *= weights[idx].value
 
-    return expo_map
+    return expo_map.sum_over_axes()

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -6,7 +6,7 @@ from astropy.nddata.utils import NoOverlapError
 from astropy.coordinates import Angle
 from ..maps import Map, WcsGeom
 from .counts import fill_map_counts
-from .exposure import make_map_exposure_true_energy, weighted_exposure
+from .exposure import make_map_exposure_true_energy, weighted_exposure_image
 from .background import make_map_background_irf, _fov_background_norm
 
 __all__ = [
@@ -135,8 +135,7 @@ class MapMaker(object):
         images = dict()
         for name, map in self.maps.items():
             if name == 'exposure':
-                expo = weighted_exposure(map, spectrum)
-                images[name] = expo.sum_over_axes()
+                images[name] = weighted_exposure_image(map, spectrum)
             else:
                 images[name] = map.sum_over_axes()
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -139,7 +139,8 @@ class MapMaker(object):
             if name == 'exposure':
                 expo_reco = make_map_exposure_reco_energy(map, spectrum, edisp)
                 images[name] = expo_reco.sum_over_axes()
-            images[name] = map.sum_over_axes()
+            else:
+                images[name] = map.sum_over_axes()
 
         return images
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -6,7 +6,7 @@ from astropy.nddata.utils import NoOverlapError
 from astropy.coordinates import Angle
 from ..maps import Map, WcsGeom
 from .counts import fill_map_counts
-from .exposure import make_map_exposure_true_energy, make_map_exposure_reco_energy
+from .exposure import make_map_exposure_true_energy, weighted_exposure
 from .background import make_map_background_irf, _fov_background_norm
 
 __all__ = [
@@ -116,18 +116,16 @@ class MapMaker(object):
             data = maps_obs[name].quantity.to(self.maps[name].unit).value
             self.maps[name].fill_by_coord(coords, data)
 
-    def make_images(self, spectrum=None, edisp=None):
+    def make_images(self, spectrum=None):
         """Create 2D maps by summing over energy axis.
+
+        Exposure is weighted with assumed spectrum
 
         Parameters
         ----------
         spectrum : `~gammapy.spectrum.models.SpectralModel`, default is None
             Spectral model to use to weight exposure in true energy
             If None is passed, a power law of photon index -2 is assumed.
-        edisp : `~gammapy.irf.EnergyDispersion`, default is None.
-            Energy Dispersion response to redistribute true energies to reco energies
-            If no energy dispersion is passed, a diagonal one is assumed with identical true and reco
-            energy bins. This is the default behaviour.
 
         Returns
         -------
@@ -137,8 +135,8 @@ class MapMaker(object):
         images = dict()
         for name, map in self.maps.items():
             if name == 'exposure':
-                expo_reco = make_map_exposure_reco_energy(map, spectrum, edisp)
-                images[name] = expo_reco.sum_over_axes()
+                expo = weighted_exposure(map, spectrum)
+                images[name] = expo.sum_over_axes()
             else:
                 images[name] = map.sum_over_axes()
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -116,6 +116,24 @@ class MapMaker(object):
             data = maps_obs[name].quantity.to(self.maps[name].unit).value
             self.maps[name].fill_by_coord(coords, data)
 
+    def make_images(self, spectrum):
+        """Create 2D maps by summing over energy axis.
+
+        Returns
+        -------
+        images : dict of `~gammapy.maps.Map`
+            the dictionary of images
+        """
+        images = dict()
+        for name, map in self.maps.items():
+            if name == 'exposure':
+                weights =
+                res = Map.from_geom(map.geom.to_image())
+                for img, idx in map.iter_by_image():
+                    res.data += img*
+            images[name] = map.sum_over_axes()
+
+        return images
 
 class MapMakerObs(object):
     """Make maps for a single IACT observation.

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -33,6 +33,7 @@ def geom(ebounds):
         'geom': geom(ebounds=[0.1, 1, 10]),
         'counts': 34366,
         'exposure': 3.99815e+11,
+        'exposure_image': 7.921993e+10,
         'background': 187528.89,
     },
     {
@@ -40,6 +41,7 @@ def geom(ebounds):
         'geom': geom(ebounds=[0.1, 10]),
         'counts': 34366,
         'exposure': 1.16866e+11,
+        'exposure_image': 1.16866e+11,
         'background': 1988492.8,
     },
     {
@@ -48,6 +50,7 @@ def geom(ebounds):
         'exclusion_mask': Map.from_geom(geom(ebounds=[0.1, 10])),
         'counts': 34366,
         'exposure': 1.16866e+11,
+        'exposure_image': 1.16866e+11,
         'background': 1988492.8,
     },
 
@@ -57,6 +60,7 @@ def test_map_maker(pars, obs_list):
         geom=pars['geom'],
         offset_max='2 deg',
     )
+
     maps = maker.run(obs_list)
 
     counts = maps['counts']
@@ -68,5 +72,19 @@ def test_map_maker(pars, obs_list):
     assert_allclose(exposure.data.sum(), pars['exposure'], rtol=1e-5)
 
     background = maps['background']
+    assert background.unit == ""
+    assert_allclose(background.data.sum(), pars['background'], rtol=1e-5)
+
+    images = maker.make_images()
+
+    counts = images['counts']
+    assert counts.unit == ""
+    assert_allclose(counts.data.sum(), pars['counts'], rtol=1e-5)
+
+    exposure = images['exposure']
+    assert exposure.unit == "m2 s"
+    assert_allclose(exposure.data.sum(), pars['exposure_image'], rtol=1e-5)
+
+    background = images['background']
     assert background.unit == ""
     assert_allclose(background.data.sum(), pars['background'], rtol=1e-5)


### PR DESCRIPTION
This is a first commit for the code to produce 2D images in `MapMaker`. It relies on a new function in cube/exposure.py that compute a weighted exposure cube in reco energy, using an input energy dispersion in the form of `EnergyDispersion`.
This should provide an exposure in `m2 s` so that dividing excesses by this map should yield integral fluxes in the considered energy bins.

Test are missing. Will add them soon.

Opinions @cdeil, @adonath, @leajouvin ?