### PR TITLE
Add quantity support to MapCoord and MapCoord based methods

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -621,7 +621,6 @@ class Map(object):
 
         idx = []
         for axis, value in zip(self.geom.axes, coords.values()):
-            value = u.Quantity(value).to(axis.unit).value
             idx.append(axis.coord_to_idx(value))
 
         return self.get_image_by_idx(idx, copy=copy)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -281,7 +281,7 @@ def coord_to_pix(edges, coord, interp='lin'):
 
     interp_fn = interp1d(
         fn(edges),
-        np.arange(len(edges)).astype(float),
+        np.arange(len(edges), dtype=float),
         fill_value='extrapolate',
     )
 
@@ -311,7 +311,7 @@ def pix_to_coord(edges, pix, interp='lin'):
         raise ValueError('Invalid interp: {}'.format(interp))
 
     interp_fn = interp1d(
-        np.arange(len(edges)).astype(float),
+        np.arange(len(edges), dtype=float),
         fn0(edges),
         fill_value='extrapolate',
     )

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -641,7 +641,7 @@ class MapCoord(object):
             (k, np.atleast_1d(np.asanyarray(v)))
             for k, v in data.items()
         ])
-        vals = np.broadcast_arrays(*data.values())
+        vals = np.broadcast_arrays(*data.values(), subok=True)
         self._data = OrderedDict(zip(data.keys(), vals))
         self._coordsys = coordsys
         self._match_by_name = match_by_name

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -373,10 +373,7 @@ class MapAxis(object):
         else:
             raise ValueError('Invalid node type: {}'.format(node_type))
 
-        pix = np.arange(nbin, dtype=float)
-        self._center = self.pix_to_coord(pix)
-        pix = np.arange(nbin + 1, dtype=float) - 0.5
-        self._bin_edges = self.pix_to_coord(pix)
+        self._nbin = nbin
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -403,17 +400,19 @@ class MapAxis(object):
     @property
     def edges(self):
         """Return array of bin edges."""
-        return self._bin_edges
+        pix = np.arange(self.nbin + 1, dtype=float) - 0.5
+        return self.pix_to_coord(pix)
 
     @property
     def center(self):
         """Return array of bin centers."""
-        return self._center
+        pix = np.arange(self.nbin, dtype=float)
+        return self.pix_to_coord(pix)
 
     @property
     def nbin(self):
         """Return number of bins."""
-        return len(self._bin_edges) - 1
+        return self._nbin
 
     @property
     def node_type(self):
@@ -527,7 +526,7 @@ class MapAxis(object):
             Array of axis coordinate values.
         """
         pix = pix - self._pix_offset
-        return pix_to_coord(self._nodes, pix, interp=self._interp)
+        return  pix_to_coord(self._nodes, pix, interp=self._interp)
 
     def coord_to_pix(self, coord):
         """Transform from axis to pixel coordinates.
@@ -542,6 +541,7 @@ class MapAxis(object):
         pix : `~numpy.ndarray`
             Array of pixel coordinate values.
         """
+        coord = u.Quantity(coord, self.unit).value
         pix = coord_to_pix(self._nodes, coord, interp=self._interp)
         return np.array(pix + self._pix_offset, ndmin=1)
 
@@ -562,6 +562,7 @@ class MapAxis(object):
         idx : `~numpy.ndarray`
             Array of bin indices.
         """
+        coord = u.Quantity(coord, self.unit).value
         return coord_to_idx(self.edges, coord, clip)
 
     def coord_to_idx_interp(self, coord):
@@ -572,6 +573,7 @@ class MapAxis(object):
         coord : `~numpy.ndarray`
             Array of axis coordinate values.
         """
+        coord = u.Quantity(coord, self.unit).value
         return (coord_to_idx(self.center[:-1], coord, clip=True),
                 coord_to_idx(self.center[:-1], coord, clip=True) + 1,)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -637,6 +637,9 @@ class MapCoord(object):
         if 'lon' not in data or 'lat' not in data:
             raise ValueError("data dictionary must contain axes named 'lon' and 'lat'.")
 
+        if issubclass(data['lon'].__class__, u.Quantity) or issubclass(data['lat'].__class__, u.Quantity):
+            raise ValueError('No quantities supported.')
+
         data = OrderedDict([
             (k, np.atleast_1d(np.asanyarray(v)))
             for k, v in data.items()
@@ -764,7 +767,7 @@ class MapCoord(object):
             raise TypeError('Type not supported: {}'.format(type(coords)))
 
     @classmethod
-    def _from_dict(cls, coords, coordsys=None, copy=False):
+    def _from_dict(cls, coords, coordsys=None):
         """Create from a dictionary of coordinate vectors."""
         if 'lon' in coords and 'lat' in coords:
             return cls(coords, coordsys=coordsys)
@@ -784,7 +787,7 @@ class MapCoord(object):
                              "or 'skycoord'.")
 
     @classmethod
-    def create(cls, data, coordsys=None, copy=False):
+    def create(cls, data, coordsys=None):
         """Create a new `~MapCoord` object.
 
         This method can be used to create either unnamed (with tuple input)
@@ -795,12 +798,9 @@ class MapCoord(object):
         data : `tuple`, `dict`, `~MapCoord` or `~astropy.coordinates.SkyCoord`
             Object containing coordinate arrays.
         coordsys : {'CEL', 'GAL', None}, optional
-            Set the coordinate system for longitude and latitude.  If
+            Set the coordinate system for longitude and latitude. If
             None longitude and latitude will be assumed to be in
             the coordinate system native to a given map geometry.
-        copy : bool
-            Make copies of the input coordinate arrays.  If False this
-            object will store views.
 
         Examples
         --------

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -176,8 +176,7 @@ def test_mapcoords_create():
     assert coords.ndim == 3
 
     # 3D OrderedDict w/ vectors
-    coords = MapCoord.create(OrderedDict([('energy', energy),
-                                          ('lat', lat), ('lon', lon)]))
+    coords = MapCoord.create(dict(energy=energy, lat=lat, lon=lon))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords['energy'], energy)
@@ -187,12 +186,8 @@ def test_mapcoords_create():
     assert coords.ndim == 3
 
     # Quantities
-    coords = MapCoord.create(OrderedDict([('energy', energy * u.TeV),
-                                          ('lat', lat * u.deg), ('lon', lon * u.deg)]))
-
+    coords = MapCoord.create(dict(energy=energy * u.TeV, lat=lat, lon=lon))
     assert coords['energy'].unit == 'TeV'
-    assert coords['lon'].unit == 'deg'
-    assert coords['lat'].unit == 'deg'
 
 
 def test_mapcoords_to_coordsys():

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -4,6 +4,7 @@ import pytest
 from collections import OrderedDict
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy import units as u
 from astropy.coordinates import SkyCoord
 from ..geom import MapAxis, MapCoord
 
@@ -184,6 +185,14 @@ def test_mapcoords_create():
     assert_allclose(coords[1], lat)
     assert_allclose(coords[2], lon)
     assert coords.ndim == 3
+
+    # Quantities
+    coords = MapCoord.create(OrderedDict([('energy', energy * u.TeV),
+                                          ('lat', lat * u.deg), ('lon', lon * u.deg)]))
+
+    assert coords['energy'].unit == 'TeV'
+    assert coords['lon'].unit == 'deg'
+    assert coords['lat'].unit == 'deg'
 
 
 def test_mapcoords_to_coordsys():

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -197,8 +197,8 @@ def test_set_get_by_coord_quantities():
     geom = WcsGeom.create(binsz=0.1, npix=(3, 4), axes=[ax])
     m = WcsNDMap(geom)
     coords_dict = {
-        'lon': 0 * u.deg,
-        'lat': 0 * u.deg,
+        'lon': 0,
+        'lat': 0,
         'energy': 1000 * u.GeV
     }
 
@@ -261,6 +261,22 @@ def test_wcsndmap_interp_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(coords[1], m.interp_by_coord(coords, interp=1))
     if geom.is_regular and not geom.is_allsky:
         assert_allclose(coords[1], m.interp_by_coord(coords, interp='cubic'))
+
+
+def test_interp_by_coord_quantities():
+    ax = MapAxis(np.logspace(0., 3., 3), interp='log', name='energy', unit='TeV')
+    geom = WcsGeom.create(binsz=0.1, npix=(3, 3), axes=[ax])
+    m = WcsNDMap(geom)
+    coords_dict = {
+        'lon': 0,
+        'lat': 0,
+        'energy': 1000 * u.GeV
+    }
+
+    m.set_by_coord(coords_dict, 42)
+
+    coords_dict['energy'] = 1 * u.TeV
+    assert_allclose(42, m.interp_by_coord(coords_dict, interp='nearest'))
 
 
 def test_wcsndmap_interp_by_coord_fill_value():

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -192,6 +192,22 @@ def test_wcsndmap_set_get_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(coords[0], m.get_by_coord(map_coords))
 
 
+def test_set_get_by_coord_quantities():
+    ax = MapAxis(np.logspace(0., 3., 3), interp='log', name='energy', unit='TeV')
+    geom = WcsGeom.create(binsz=0.1, npix=(3, 4), axes=[ax])
+    m = WcsNDMap(geom)
+    coords_dict = {
+        'lon': 0 * u.deg,
+        'lat': 0 * u.deg,
+        'energy': 1000 * u.GeV
+    }
+
+    m.set_by_coord(coords_dict, 42)
+
+    coords_dict['energy'] = 1 * u.TeV
+    assert_allclose(42, m.get_by_coord(coords_dict))
+
+
 @pytest.mark.parametrize(('npix', 'binsz', 'coordsys', 'proj', 'skydir', 'axes'),
                          wcs_test_geoms)
 def test_wcsndmap_fill_by_coord(npix, binsz, coordsys, proj, skydir, axes):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -433,7 +433,7 @@ class WcsNDMap(WcsMap):
 
     def downsample(self, factor, preserve_counts=True):
         geom = self.geom.downsample(factor)
-        block_size = tuple([factor, factor] + [1] * (self.geom.ndim - 2))
+        block_size = (factor, factor) + (1,) * len(self.geom.axes)
         data = block_reduce(self.data, block_size[::-1], np.nansum)
         if not preserve_counts:
             data /= factor ** 2


### PR DESCRIPTION
This PR adds quantity support to the `MapAxis.coord_to_idx()`, `MapAxis.idx_to_coord()` as well as the `MapCoord` object. This will fix issue #1646 in a general way. This PR also contains a few unrelated changes, as I cleaned up and simplified some code "on the fly". I decided to remove the copy option of `MapCoord`, as we do not have this in any other class init and the `MapCoord` object as a `.copy()` anyway.