### PR TITLE
Exchange value by factor and scale in Parameter

### DIFF
--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -78,8 +78,9 @@ class TestSpectrumSimulation:
     def test_without_aeff(self):
         e_true = EnergyBounds.equal_log_spacing(1, 10, 5, u.TeV)
         rate_model = self.source_model.copy()
-        rate_model.parameters['amplitude'].unit = u.Unit('TeV-1 s-1')
-        rate_model.parameters['amplitude'].value = 1
+        par = rate_model.parameters['amplitude']
+        par.unit = 'TeV-1 s-1'
+        par.value = 1
         sim = SpectrumSimulation(
             source_model=rate_model,
             livetime=4 * u.h,

--- a/gammapy/utils/array.py
+++ b/gammapy/utils/array.py
@@ -9,8 +9,6 @@ __all__ = ['array_stats_str',
            'shape_divisible_by',
            'symmetric_crop_pad_width']
 
-all_integer_types = six.integer_types + (np.integer,)
-
 
 def array_stats_str(x, label=''):
     """Make a string summarising some stats for an array.
@@ -109,5 +107,42 @@ def symmetric_crop_pad_width(shape, new_shape):
     return ywidth, xwidth
 
 
+def check_type(val, category):
+    if category == 'str':
+        return _check_str(val)
+    elif category == 'number':
+        return _check_number(val)
+    elif category == 'bool':
+        return _check_bool(val)
+    else:
+        raise ValueError('Invalid category: {}'.format(category))
+
+
+def _check_str(val):
+    if isinstance(val, six.string_types):
+        return val
+    else:
+        raise TypeError('Expected a string. Got: {!r}'.format(val))
+
+
+def _check_number(val):
+    if _is_float(val) or _is_int(val):
+        return val
+    raise TypeError('Expected a number. Got: {!r}'.format(val))
+
+
 def _is_int(val):
-    return isinstance(val, all_integer_types)
+    int_types = six.integer_types + (np.integer,)
+    return isinstance(val, int_types)
+
+
+def _is_float(val):
+    float_types = (float, np.floating)
+    return isinstance(val, float_types)
+
+
+def _check_bool(val):
+    if isinstance(val, bool):
+        return val
+    else:
+        raise TypeError('Expected a bool. Got: {!r}'.format(val))

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -30,8 +30,8 @@ class SherpaFunction(object):
         self.function = function
         self.parameters = parameters
 
-    def fcn(self, values):
-        self.parameters.update_values_from_tuple(values)
+    def fcn(self, factors):
+        self.parameters.optimiser_set_factors(factors)
         return self.function(self.parameters)
 
 
@@ -55,6 +55,7 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
         Parameter list with best-fit values
     """
     optimizer = get_sherpa_optimiser(optimizer)
+    # parameters.optimiser_rescale_parameters()
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]
@@ -71,7 +72,7 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
 
     result = {
         'success': result[0],
-        'values': result[1],
+        'factors': result[1],
         'statval': result[2],
         'message': result[3],
         'info': result[4],  # that's a dict, content varies based on optimiser
@@ -80,6 +81,6 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
     result['nfev'] = result['info']['nfev']
 
     # Copy final results into the parameters object
-    parameters.update_values_from_tuple(result['values'])
+    parameters.optimiser_set_factors(result['factors'])
 
     return result

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -29,6 +29,7 @@ def test_sherpa(optimizer):
     assert result['success']
     assert result['nfev'] > 10
     assert_allclose(result['statval'], 0, atol=1e-2)
+    assert_allclose(result['factors'], [2, 3, 4], rtol=1e-2)
     assert_allclose(pars['x'].value, 2, rtol=1e-2)
     assert_allclose(pars['y'].value, 3, rtol=1e-2)
     assert_allclose(pars['z'].value, 4, rtol=1e-2)

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -23,10 +23,12 @@ class Parameter(object):
     ----------
     name : str
         Name
-    value : float or `~astropy.units.Quantity`
-        Value
+    factor : float or `~astropy.units.Quantity`
+        Factor
     unit : str, optional
         Unit
+    scale : float, optional
+        Scale
     min : float, optional
         Minimum (sometimes used in fitting)
     max : float, optional
@@ -34,16 +36,18 @@ class Parameter(object):
     frozen : bool, optional
         Frozen? (used in fitting)
     """
-    __slots__ = ['_name', '_value', '_unit', '_min', '_max', '_frozen']
+    __slots__ = ['_name', '_factor', '_unit', '_scale', '_min', '_max', '_frozen']
 
-    def __init__(self, name, value, unit='', min=np.nan, max=np.nan, frozen=False):
+    def __init__(self, name, factor, unit='', scale=1, min=np.nan, max=np.nan,
+                 frozen=False):
         self.name = name
 
-        if isinstance(value, u.Quantity) or isinstance(value, six.string_types):
-            self.quantity = value
+        if isinstance(factor, u.Quantity) or isinstance(factor, six.string_types):
+                self.quantity = value
         else:
-            self.value = value
+            self.factor = factor
             self.unit = unit
+            self.scale = scale
 
         self.min = min
         self.max = max
@@ -58,12 +62,12 @@ class Parameter(object):
         self._name = str(val)
 
     @property
-    def value(self):
-        return self._value
+    def factor(self):
+        return self._factor
 
-    @value.setter
-    def value(self, val):
-        self._value = float(val)
+    @factor.setter
+    def factor(self, val):
+        self._factor = float(val)
 
     @property
     def unit(self):
@@ -72,6 +76,14 @@ class Parameter(object):
     @unit.setter
     def unit(self, val):
         self._unit = str(val)
+
+    @property
+    def scale(self):
+        return self._scale
+
+    @scale.setter
+    def scale(self, val):
+        self._scale = float(val)
 
     @property
     def min(self):
@@ -98,13 +110,23 @@ class Parameter(object):
         self._frozen = bool(val)
 
     @property
+    def value(self):
+        return self._factor * self._scale
+
+    @value.setter
+    def value(self, val):
+        self._factor = float(val)
+        self._scale = 1
+
+    @property
     def quantity(self):
         return self.value * u.Unit(self.unit)
 
     @quantity.setter
     def quantity(self, par):
         par = u.Quantity(par)
-        self.value = par.value
+        self.factor = par.value
+        self.scale = 1
         self.unit = str(par.unit)
 
     def __repr__(self):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -8,6 +8,7 @@ import copy
 from ..extern import six
 from astropy import units as u
 from astropy.table import Table, Column, vstack
+from .array import check_type
 
 __all__ = [
     'Parameter',
@@ -60,7 +61,7 @@ class Parameter(object):
 
     @name.setter
     def name(self, val):
-        self._name = str(val)
+        self._name = check_type(val, 'str')
 
     @property
     def factor(self):
@@ -69,7 +70,7 @@ class Parameter(object):
 
     @factor.setter
     def factor(self, val):
-        self._factor = float(val)
+        self._factor = check_type(val, 'number')
 
     @property
     def scale(self):
@@ -78,7 +79,7 @@ class Parameter(object):
 
     @scale.setter
     def scale(self, val):
-        self._scale = float(val)
+        self._scale = check_type(val, 'number')
 
     @property
     def unit(self):
@@ -87,7 +88,7 @@ class Parameter(object):
 
     @unit.setter
     def unit(self, val):
-        self._unit = str(val)
+        self._unit = check_type(val, 'str')
 
     @property
     def min(self):
@@ -114,7 +115,7 @@ class Parameter(object):
 
     @frozen.setter
     def frozen(self, val):
-        self._frozen = bool(val)
+        self._frozen = check_type(val, 'bool')
 
     @property
     def value(self):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -25,10 +25,10 @@ class Parameter(object):
         Name
     factor : float or `~astropy.units.Quantity`
         Factor
-    unit : str, optional
-        Unit
     scale : float, optional
         Scale
+    unit : str, optional
+        Unit
     min : float, optional
         Minimum (sometimes used in fitting)
     max : float, optional
@@ -36,14 +36,14 @@ class Parameter(object):
     frozen : bool, optional
         Frozen? (used in fitting)
     """
-    __slots__ = ['_name', '_factor', '_unit', '_scale', '_min', '_max', '_frozen']
+    __slots__ = ['_name', '_factor', '_scale', '_unit', '_min', '_max', '_frozen']
 
     def __init__(self, name, factor, unit='', scale=1, min=np.nan, max=np.nan,
                  frozen=False):
         self.name = name
 
         if isinstance(factor, u.Quantity) or isinstance(factor, six.string_types):
-                self.quantity = value
+            self.quantity = value
         else:
             self.factor = factor
             self.unit = unit
@@ -70,20 +70,20 @@ class Parameter(object):
         self._factor = float(val)
 
     @property
-    def unit(self):
-        return self._unit
-
-    @unit.setter
-    def unit(self, val):
-        self._unit = str(val)
-
-    @property
     def scale(self):
         return self._scale
 
     @scale.setter
     def scale(self, val):
         self._scale = float(val)
+
+    @property
+    def unit(self):
+        return self._unit
+
+    @unit.setter
+    def unit(self, val):
+        self._unit = str(val)
 
     @property
     def min(self):
@@ -115,8 +115,7 @@ class Parameter(object):
 
     @value.setter
     def value(self, val):
-        self._factor = float(val)
-        self._scale = 1
+        self._factor = float(val) / self._scale
 
     @property
     def quantity(self):
@@ -125,8 +124,7 @@ class Parameter(object):
     @quantity.setter
     def quantity(self, par):
         par = u.Quantity(par)
-        self.factor = par.value
-        self.scale = 1
+        self.value = par.value
         self.unit = str(par.unit)
 
     def __repr__(self):

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -355,3 +355,25 @@ class ParameterList(object):
         """Update parameter values from a tuple of values."""
         for value, parameter in zip(values, self.parameters):
             parameter.value = value
+
+    def scale_parameter(self, parname, scale):
+        """Scale parameter
+
+        This method updates the ``scale`` of a given parameter and makes sure
+        that the covariance matrix (if set) is scaled accordingly
+
+        Parameters
+        ----------
+        parname : str, int
+            Parameter name or index
+        scale : float 
+            Parameter scale
+        """
+        idx = self._get_idx(parname)
+        par = self[idx]
+        par.scale = scale
+        par.factor /= scale
+
+        if self.covariance is not None:
+            self.covariance[idx,] /= scale
+            self.covariance[:,idx] /= scale

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -371,9 +371,22 @@ class ParameterList(object):
         """
         idx = self._get_idx(parname)
         par = self[idx]
+        ratio = scale / par.scale
         par.scale = scale
-        par.factor /= scale
+        par.factor = par.factor / ratio
 
         if self.covariance is not None:
             self.covariance[idx,] /= scale
             self.covariance[:,idx] /= scale
+
+    def scale_parameters_to_unity(self):
+        """Scale all parameters
+
+        This methods scales all parameters such that the factor is of order
+        unity
+        """
+        for par in self.parameters:
+            temp = int(np.log10(par.value))
+            scale = 10 ** temp
+            print(par.name, scale)
+            self.scale_parameter(par.name, scale)

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -223,7 +223,7 @@ class ParameterList(object):
         pars = list()
         for par in val['parameters']:
             pars.append(Parameter(name=par['name'],
-                                  value=float(par['value']),
+                                  factor=float(par['value']),
                                   unit=par['unit'],
                                   min=float(par['min']),
                                   max=float(par['max']),

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -41,13 +41,13 @@ class Parameter(object):
     def __init__(self, name, factor, unit='', scale=1, min=np.nan, max=np.nan,
                  frozen=False):
         self.name = name
+        self.scale = scale
 
         if isinstance(factor, u.Quantity) or isinstance(factor, six.string_types):
-            self.quantity = value
+            self.quantity = factor
         else:
             self.factor = factor
             self.unit = unit
-            self.scale = scale
 
         self.min = min
         self.max = max
@@ -376,8 +376,8 @@ class ParameterList(object):
         par.factor = par.factor / ratio
 
         if self.covariance is not None:
-            self.covariance[idx,] /= scale
-            self.covariance[:,idx] /= scale
+            self.covariance[idx,] /= ratio
+            self.covariance[:,idx] /= ratio
 
     def scale_parameters_to_unity(self):
         """Scale all parameters
@@ -390,3 +390,11 @@ class ParameterList(object):
             scale = 10 ** temp
             print(par.name, scale)
             self.scale_parameter(par.name, scale)
+
+    def scale_parameters_to_1(self):
+        """Scale all parameters
+
+        This methods scales all parameters such that ``scale=1``
+        """
+        for par in self.parameters:
+            self.scale_parameter(par.name, 1)

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -242,14 +242,16 @@ def xml_to_parameter_list(xml, which, type_):
             msg = "Parameter '{}' not registered for {} model {}"
             raise UnknownParameterError(msg.format(par['@name'], which, type_))
 
-        value = float(par['@value']) * float(par['@scale'])
+        factor = float(par['@value'])
+        scale = float(par['@scale'])
         min_ = float(par.get('@min', 'nan'))
         max_ = float(par.get('@max', 'nan'))
         frozen = bool(1 - int(par['@free']))
 
         parameters.append(Parameter(
             name=name,
-            value=value,
+            factor=factor,
+            scale=scale,
             unit=unit,
             min=min_,
             max=max_,

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from ..modeling import Parameter, ParameterList
@@ -15,6 +16,35 @@ def test_parameter_init():
     assert par.min is np.nan
     assert par.max is np.nan
     assert par.frozen is False
+
+    par = Parameter('spam', '42 deg')
+    assert par.factor == 42
+    assert par.scale == 1
+    assert par.unit == 'deg'
+
+def test_parameter_value():
+    par = Parameter('spam', 42, 'deg', 10)
+
+    value = par.value
+    assert isinstance(value, float)
+    assert value == 420
+
+    par.value = 70
+    assert par.scale == 10
+    assert_allclose(par.factor, 7)
+
+
+def test_parameter_quantity():
+    par = Parameter('spam', 42, 'deg', 10)
+
+    quantity = par.quantity
+    assert quantity.unit == 'deg'
+    assert quantity.value == 420
+
+    par.quantity = '70 deg'
+    assert_allclose(par.factor, 7)
+    assert par.scale == 10
+    assert par.unit == 'deg'
 
 
 def test_parameter_repr():

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -33,3 +33,9 @@ def test_parameter_list():
     assert_allclose(pars.covariance, [[1e-2, 0], [0, 100]])
     assert_allclose(pars.error('spam'), 0.1)
     assert_allclose(pars.error(1), 10)
+
+    pars.scale_parameter('ham', 10)
+    assert_allclose(pars['ham'].value, 99)
+    assert_allclose(pars['ham'].scale, 10)
+    assert_allclose(pars['ham'].factor, 9.9)
+    assert_allclose(pars.covariance, [[1e-2, 0], [0, 1]])

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -8,6 +8,8 @@ from ..modeling import Parameter, ParameterList
 def test_parameter_init():
     par = Parameter('spam', 42, 'deg')
     assert par.name == 'spam'
+    assert par.factor == 42
+    assert par.scale == 1
     assert par.value == 42
     assert par.unit == 'deg'
     assert par.min is np.nan
@@ -34,21 +36,15 @@ def test_parameter_list():
     assert_allclose(pars.error('spam'), 0.1)
     assert_allclose(pars.error(1), 10)
 
-    pars.scale_parameter('ham', 10)
-    assert_allclose(pars['ham'].value, 99)
-    assert_allclose(pars['ham'].scale, 10)
-    assert_allclose(pars['ham'].factor, 9.9)
-    assert_allclose(pars.covariance, [[1e-2, 0], [0, 1]])
+    # pars.scale_parameter('ham', 10)
+    # assert_allclose(pars['ham'].value, 99)
+    # assert_allclose(pars['ham'].scale, 10)
+    # assert_allclose(pars['ham'].factor, 9.9)
+    # assert_allclose(pars.covariance, [[1e-2, 0], [0, 1]])
 
-    pars.scale_parameters_to_unity()
-    assert_allclose(pars['spam'].scale, 10)
-    assert_allclose(pars['spam'].factor, 4.2)
-    assert_allclose(pars['ham'].scale, 10)
-    assert_allclose(pars['ham'].factor, 9.9)
-
-    pars.scale_parameters_to_1()
+    pars.optimiser_rescale_parameters()
+    assert_allclose(pars['spam'].factor, 1)
+    assert_allclose(pars['spam'].scale, 42)
+    assert_allclose(pars['ham'].factor, 1)
+    assert_allclose(pars['ham'].scale, 99)
     assert_allclose(pars.covariance, [[1e-2, 0], [0, 100]])
-    assert_allclose(pars['spam'].scale, 1)
-    assert_allclose(pars['spam'].factor, 42)
-    assert_allclose(pars['ham'].scale, 1)
-    assert_allclose(pars['ham'].factor, 99)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -39,3 +39,9 @@ def test_parameter_list():
     assert_allclose(pars['ham'].scale, 10)
     assert_allclose(pars['ham'].factor, 9.9)
     assert_allclose(pars.covariance, [[1e-2, 0], [0, 1]])
+
+    pars.scale_parameters_to_unity()
+    assert_allclose(pars['spam'].factor, 4.2)
+    assert_allclose(pars['spam'].scale, 10)
+    assert_allclose(pars['ham'].scale, 10)
+    assert_allclose(pars['ham'].factor, 9.9)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -41,7 +41,14 @@ def test_parameter_list():
     assert_allclose(pars.covariance, [[1e-2, 0], [0, 1]])
 
     pars.scale_parameters_to_unity()
-    assert_allclose(pars['spam'].factor, 4.2)
     assert_allclose(pars['spam'].scale, 10)
+    assert_allclose(pars['spam'].factor, 4.2)
     assert_allclose(pars['ham'].scale, 10)
     assert_allclose(pars['ham'].factor, 9.9)
+
+    pars.scale_parameters_to_1()
+    assert_allclose(pars.covariance, [[1e-2, 0], [0, 100]])
+    assert_allclose(pars['spam'].scale, 1)
+    assert_allclose(pars['spam'].factor, 42)
+    assert_allclose(pars['ham'].scale, 1)
+    assert_allclose(pars['ham'].factor, 99)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -22,11 +22,20 @@ def test_parameter_init():
     assert par.scale == 1
     assert par.unit == 'deg'
 
+    with pytest.raises(TypeError):
+        Parameter(1, 2)
+
+    p = Parameter('spam', 42)
+    with pytest.raises(TypeError):
+        p.factor = '99'
+    with pytest.raises(TypeError):
+        p.scale = '99'
+
+
 def test_parameter_value():
     par = Parameter('spam', 42, 'deg', 10)
 
     value = par.value
-    assert isinstance(value, float)
     assert value == 420
 
     par.value = 70


### PR DESCRIPTION
Triggered by #1531 

With the current changes, the behaviour of ``Parameter`` to the outside does not change at all. Only the way the Parameter value is stored internally changes, namely by storing the parameter value as ``factor`` and ``scale``

In addition I added two methods to ``ParameterList`` (I'm not happy with the names, please make suggestions). One to scale all parameters such that ``factor`` is or order 1 (``scale_parameters_to_unity``) and one that reverts this such that ``scale=1`` (``scale_parameters_to_1``). The idea is that the first of these methods be called before the fit, to have useful values for the optimizer (need to be changed to work on ``factor`` rather than ``value``) and the second one be called after the fit, so the user basically doesn't notice that something happend in between.