### PR TITLE
Added `to_observation_cta` method to `DataStoreObservation`

### DIFF
--- a/examples/example_observation_cta.py
+++ b/examples/example_observation_cta.py
@@ -8,17 +8,15 @@ cal_file = make_path('$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/Sou
 
 event_list = EventList.read(data_file)
 
-kwargs = dict(obs_id=event_list.table.meta['OBS_ID'],
-              events=event_list,
-              gti=GTI.read(data_file),
-              psf=EnergyDependentMultiGaussPSF.read(cal_file, hdu='Point Spread Function'),
-              aeff=EffectiveAreaTable2D.read(cal_file),
-              edisp=EnergyDispersion2D.read(cal_file, hdu='Energy Dispersion'),
-              bkg=Background3D.read(cal_file),
-              pointing_radec=event_list.pointing_radec,
-              observation_live_time_duration=event_list.observation_live_time_duration,
-              observation_dead_time_fraction=event_list.observation_dead_time_fraction,
-              )
-
-obs = ObservationCTA(**kwargs)
+obs = ObservationCTA(obs_id=event_list.table.meta['OBS_ID'],
+                     events=event_list,
+                     gti=GTI.read(data_file),
+                     psf=EnergyDependentMultiGaussPSF.read(cal_file, hdu='Point Spread Function'),
+                     aeff=EffectiveAreaTable2D.read(cal_file),
+                     edisp=EnergyDispersion2D.read(cal_file, hdu='Energy Dispersion'),
+                     bkg=Background3D.read(cal_file),
+                     pointing_radec=event_list.pointing_radec,
+                     observation_live_time_duration=event_list.observation_live_time_duration,
+                     observation_dead_time_fraction=event_list.observation_dead_time_fraction
+                     )
 print(obs)

--- a/examples/example_observation_cta.py
+++ b/examples/example_observation_cta.py
@@ -1,0 +1,24 @@
+"""Example of how to create an ObservationCTA from CTA's 1DC"""
+from gammapy.utils.scripts import make_path
+from gammapy.data import ObservationCTA, EventList, GTI
+from gammapy.irf import EnergyDependentMultiGaussPSF, EffectiveAreaTable2D, EnergyDispersion2D, Background3D
+
+data_file = make_path('$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits')
+cal_file = make_path('$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits')
+
+event_list = EventList.read(data_file)
+
+kwargs = dict(obs_id=event_list.table.meta['OBS_ID'],
+              events=event_list,
+              gti=GTI.read(data_file),
+              psf=EnergyDependentMultiGaussPSF.read(cal_file, hdu='Point Spread Function'),
+              aeff=EffectiveAreaTable2D.read(cal_file),
+              edisp=EnergyDispersion2D.read(cal_file, hdu='Energy Dispersion'),
+              bkg=Background3D.read(cal_file),
+              pointing_radec=event_list.pointing_radec,
+              observation_live_time_duration=event_list.observation_live_time_duration,
+              observation_dead_time_fraction=event_list.observation_dead_time_fraction,
+              )
+
+obs = ObservationCTA(**kwargs)
+print(obs)

--- a/examples/example_observation_cta.py
+++ b/examples/example_observation_cta.py
@@ -1,22 +1,28 @@
 """Example of how to create an ObservationCTA from CTA's 1DC"""
-from gammapy.utils.scripts import make_path
 from gammapy.data import ObservationCTA, EventList, GTI
 from gammapy.irf import EnergyDependentMultiGaussPSF, EffectiveAreaTable2D, EnergyDispersion2D, Background3D
 
-data_file = make_path('$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits')
-cal_file = make_path('$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits')
+filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits'
+event_list = EventList.read(filename)
+gti = GTI.read(filename)
 
-event_list = EventList.read(data_file)
+filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
+aeff = EffectiveAreaTable2D.read(filename)
+bkg = Background3D.read(filename)
+edisp = EnergyDispersion2D.read(filename, hdu='Energy Dispersion')
+psf = EnergyDependentMultiGaussPSF.read(filename, hdu='Point Spread Function')
 
-obs = ObservationCTA(obs_id=event_list.table.meta['OBS_ID'],
-                     events=event_list,
-                     gti=GTI.read(data_file),
-                     psf=EnergyDependentMultiGaussPSF.read(cal_file, hdu='Point Spread Function'),
-                     aeff=EffectiveAreaTable2D.read(cal_file),
-                     edisp=EnergyDispersion2D.read(cal_file, hdu='Energy Dispersion'),
-                     bkg=Background3D.read(cal_file),
-                     pointing_radec=event_list.pointing_radec,
-                     observation_live_time_duration=event_list.observation_live_time_duration,
-                     observation_dead_time_fraction=event_list.observation_dead_time_fraction
-                     )
+obs = ObservationCTA(
+    obs_id=event_list.table.meta['OBS_ID'],
+    events=event_list,
+    gti=gti,
+    psf=psf,
+    aeff=aeff,
+    edisp=edisp,
+    bkg=bkg,
+    pointing_radec=event_list.pointing_radec,
+    observation_live_time_duration=event_list.observation_live_time_duration,
+    observation_dead_time_fraction=event_list.observation_dead_time_fraction,
+)
+
 print(obs)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -359,6 +359,31 @@ class DataStoreObservation(object):
 
         return messages
 
+    def to_observation_cta(self):
+        """
+        Convert a `~gammapy.data.DataStoreObservation` to an `~gammapy.data.ObservationCTA`
+
+        Returns
+        -------
+        obs : `~gammapy.data.ObservationCTA`
+            An observation container that stores all class attributes in memory
+
+        """
+        # maps the ObservationCTA class attributes to the DataStoreObservation properties
+        obs_cta_kwargs = {'obs_id': 'obs_id', 'gti': 'gti', 'events': 'events', 'aeff': 'aeff', 'edisp': 'edisp',
+                          'psf': 'psf', 'bkg': 'bkg', 'pointing_radec': 'pointing_radec',
+                          'observation_live_time_duration': 'observation_live_time_duration',
+                          'observation_dead_time_fraction': 'observation_dead_time_fraction'}
+
+        for obs_cta_kwarg, ds_obs_prop in obs_cta_kwargs.items():
+            try:
+                obs_cta_kwargs[obs_cta_kwarg] = getattr(self, ds_obs_prop)
+            except Exception as exception:
+                log.warning(exception)
+                obs_cta_kwargs[obs_cta_kwarg] = None
+
+        return ObservationCTA(**obs_cta_kwargs)
+
 
 class ObservationList(UserList):
     """List of `~gammapy.data.DataStoreObservation`.

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -366,7 +366,7 @@ class DataStoreObservation(object):
 
     def to_observation_cta(self):
         """
-        Convert a `~gammapy.data.DataStoreObservation` to an `~gammapy.data.ObservationCTA`
+        Convert to `~gammapy.data.ObservationCTA`
 
         Returns
         -------

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -74,6 +74,7 @@ class ObservationCTA(object):
     examples/example_observation_cta.py
 
     """
+
     def __init__(self, obs_id=None, gti=None, events=None, aeff=None, edisp=None, psf=None, bkg=None,
                  pointing_radec=None, observation_live_time_duration=None, observation_dead_time_fraction=None,
                  meta=None):
@@ -87,17 +88,18 @@ class ObservationCTA(object):
         self.pointing_radec = pointing_radec
         self.observation_live_time_duration = observation_live_time_duration
         self.observation_dead_time_fraction = observation_dead_time_fraction
-        if not meta:
-            meta = OrderedDict()
-        self.meta = meta
+        self.meta = meta or OrderedDict()
 
     def __str__(self):
         """Generate summary info string."""
         ss = 'Info for OBS_ID = {}\n'.format(self.obs_id)
-        ss += '- Start time: {}\n'.format(np.atleast_1d(self.gti.time_start.fits)[0] if self.gti else 'None')
+
         ss += '- Pointing pos: RA {:.2f} / Dec {:.2f}\n'.format(
             self.pointing_radec.ra if self.pointing_radec else 'None',
             self.pointing_radec.dec if self.pointing_radec else 'None')
+
+        tstart = np.atleast_1d(self.gti.time_start.fits)[0] if self.gti else 'None'
+        ss += '- Start time: {}\n'.format(tstart)
         ss += '- Observation duration: {}\n'.format(self.gti.time_sum if self.gti else 'None')
         ss += '- Dead-time fraction: {:5.3f} %\n'.format(100 * self.observation_dead_time_fraction)
 
@@ -365,29 +367,38 @@ class DataStoreObservation(object):
         return messages
 
     def to_observation_cta(self):
-        """
-        Convert to `~gammapy.data.ObservationCTA`
+        """Convert to `~gammapy.data.ObservationCTA`.
+
+        This loads all observation-related info from disk
+        and stores it in the in-memory ``ObservationCTA``.
 
         Returns
         -------
         obs : `~gammapy.data.ObservationCTA`
-            An observation container that stores all class attributes in memory
-
+            Observation
         """
         # maps the ObservationCTA class attributes to the DataStoreObservation properties
-        obs_cta_kwargs = {'obs_id': 'obs_id', 'gti': 'gti', 'events': 'events', 'aeff': 'aeff', 'edisp': 'edisp',
-                          'psf': 'psf', 'bkg': 'bkg', 'pointing_radec': 'pointing_radec',
-                          'observation_live_time_duration': 'observation_live_time_duration',
-                          'observation_dead_time_fraction': 'observation_dead_time_fraction'}
+        props = {
+            'obs_id': 'obs_id',
+            'gti': 'gti',
+            'events': 'events',
+            'aeff': 'aeff',
+            'edisp': 'edisp',
+            'psf': 'psf',
+            'bkg': 'bkg',
+            'pointing_radec': 'pointing_radec',
+            'observation_live_time_duration': 'observation_live_time_duration',
+            'observation_dead_time_fraction': 'observation_dead_time_fraction',
+        }
 
-        for obs_cta_kwarg, ds_obs_prop in obs_cta_kwargs.items():
+        for obs_cta_kwarg, ds_obs_prop in props.items():
             try:
-                obs_cta_kwargs[obs_cta_kwarg] = getattr(self, ds_obs_prop)
+                props[obs_cta_kwarg] = getattr(self, ds_obs_prop)
             except Exception as exception:
                 log.warning(exception)
-                obs_cta_kwargs[obs_cta_kwarg] = None
+                props[obs_cta_kwarg] = None
 
-        return ObservationCTA(**obs_cta_kwargs)
+        return ObservationCTA(**props)
 
 
 class ObservationList(UserList):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -70,26 +70,8 @@ class ObservationCTA(object):
 
     Examples
     --------
-    Create an observation from the CTA 1DC:
-
-    >>> from gammapy.data import ObservationCTA, EventList, GTI
-    >>> from gammapy.irf import EnergyDependentMultiGaussPSF, EffectiveAreaTable2D, EnergyDispersion2D, Background3D
-    >>>
-    >>> data_file = '$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits'
-    >>> cal_file = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
-    >>>
-    >>> kwargs = dict(events = EventList.read(data_file),
-    >>>               gti = GTI.read(data_file),
-    >>>               psf = EnergyDependentMultiGaussPSF.read(cal_file, hdu='Point Spread Function'),
-    >>>               aeff = EffectiveAreaTable2D.read(cal_file),
-    >>>               edisp = EnergyDispersion2D.read(cal_file, hdu='Energy Dispersion'),
-    >>>               bkg = Background3D.read(cal_file),
-    >>>               pointing_radec = EventList.read(data_file).pointing_radec,
-    >>>               observation_live_time_duration = EventList.read(data_file).observation_live_time_duration,
-    >>>               observation_dead_time_fraction = EventList.read(data_file).observation_dead_time_fraction,
-    >>>          )
-    >>>
-    >>> obs = ObservationCTA(obs_id=110380, **kwargs)
+    A minimal working example of how to create an observation from CTA's 1DC is given in
+    examples/example_observation_cta.py
 
     """
     def __init__(self, obs_id=None, gti=None, events=None, aeff=None, edisp=None, psf=None, bkg=None,

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -68,6 +68,29 @@ class ObservationCTA(object):
     meta : `~collections.OrderedDict`
         Dictionary to store metadata
 
+    Examples
+    --------
+    Create an observation from the CTA 1DC:
+
+    >>> from gammapy.data import ObservationCTA, EventList, GTI
+    >>> from gammapy.irf import EnergyDependentMultiGaussPSF, EffectiveAreaTable2D, EnergyDispersion2D, Background3D
+    >>>
+    >>> data_file = '$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits'
+    >>> cal_file = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
+    >>>
+    >>> kwargs = dict(events = EventList.read(data_file),
+    >>>               gti = GTI.read(data_file),
+    >>>               psf = EnergyDependentMultiGaussPSF.read(cal_file, hdu='Point Spread Function'),
+    >>>               aeff = EffectiveAreaTable2D.read(cal_file),
+    >>>               edisp = EnergyDispersion2D.read(cal_file, hdu='Energy Dispersion'),
+    >>>               bkg = Background3D.read(cal_file),
+    >>>               pointing_radec = EventList.read(data_file).pointing_radec,
+    >>>               observation_live_time_duration = EventList.read(data_file).observation_live_time_duration,
+    >>>               observation_dead_time_fraction = EventList.read(data_file).observation_dead_time_fraction,
+    >>>          )
+    >>>
+    >>> obs = ObservationCTA(obs_id=110380, **kwargs)
+
     """
     def __init__(self, obs_id=None, gti=None, events=None, aeff=None, edisp=None, psf=None, bkg=None,
                  pointing_radec=None, observation_live_time_duration=None, observation_dead_time_fraction=None,
@@ -89,7 +112,7 @@ class ObservationCTA(object):
     def __str__(self):
         """Generate summary info string."""
         ss = 'Info for OBS_ID = {}\n'.format(self.obs_id)
-        ss += '- Start time: {:.2f}\n'.format(np.atleast_1d(self.gti.time_start.fits)[0] if self.gti else 'None')
+        ss += '- Start time: {}\n'.format(np.atleast_1d(self.gti.time_start.fits)[0] if self.gti else 'None')
         ss += '- Pointing pos: RA {:.2f} / Dec {:.2f}\n'.format(
             self.pointing_radec.ra if self.pointing_radec else 'None',
             self.pointing_radec.dec if self.pointing_radec else 'None')

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -37,6 +37,25 @@ def test_data_store_observation(data_store):
     assert_skycoord_allclose(obs.target_radec, c)
 
 
+@requires_data('gammapy-extra')
+def test_data_store_observation_to_observation_cta(data_store):
+    from gammapy.data import EventList, GTI, ObservationCTA
+    from gammapy.irf import EffectiveAreaTable2D, EnergyDispersion2D, EnergyDependentMultiGaussPSF
+
+    obs = data_store.obs(23523).to_observation_cta()
+
+    assert type(obs) == ObservationCTA
+    assert type(obs.obs_id) == int
+    assert type(obs.gti) == GTI
+    assert type(obs.events) == EventList
+    assert type(obs.aeff) == EffectiveAreaTable2D
+    assert type(obs.edisp) == EnergyDispersion2D
+    assert type(obs.psf) == EnergyDependentMultiGaussPSF
+    assert type(obs.pointing_radec) == SkyCoord
+    assert type(obs.observation_live_time_duration) == Quantity
+    assert type(obs.observation_dead_time_fraction) == np.float64
+
+
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 @pytest.mark.parametrize("pars,result", [

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -7,7 +7,8 @@ from astropy.coordinates import Angle, SkyCoord
 from astropy.units import Quantity
 import astropy.units as u
 from astropy.time import Time
-from ...data import DataStore, ObservationList
+from ...data import DataStore, ObservationList, EventList, GTI, ObservationCTA
+from ...irf import EffectiveAreaTable2D, EnergyDispersion2D, EnergyDependentMultiGaussPSF
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.testing import assert_quantity_allclose, assert_time_allclose, assert_skycoord_allclose
 from ...utils.energy import Energy
@@ -39,9 +40,7 @@ def test_data_store_observation(data_store):
 
 @requires_data('gammapy-extra')
 def test_data_store_observation_to_observation_cta(data_store):
-    from gammapy.data import EventList, GTI, ObservationCTA
-    from gammapy.irf import EffectiveAreaTable2D, EnergyDispersion2D, EnergyDependentMultiGaussPSF
-
+    """Test the DataStoreObservation.to_observation_cta conversion method"""
     obs = data_store.obs(23523).to_observation_cta()
 
     assert type(obs) == ObservationCTA


### PR DESCRIPTION
This PR is a next step towards a working `ObservationCTA` class.

I added an example docstring of how to create an `ObservationCTA` from "scratch", that is without an `DataStore` object for CTA's 1DC data.
A new method in `DataStoreObservation` was added to return an equivalent observation as `ObservationCTA` object.

This is still not ready to merge, i'm still missing a test for the new method.
Hopefully i manage to provide a test before Saturday, otherwise i will do it when i'm back from holidays in two weeks.

A next PR would be to subclass `DataStoreObservation(ObservationCTA)` to avoid code duplication.
