### PR TITLE
Correct diagonal matrix creation in EnergyDispersion

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -227,20 +227,19 @@ class MapEvaluator(object):
 
         For now just divide flux cube by exposure
         """
-        npred_ = (flux * self.exposure.quantity).to('')
         npred = Map.from_geom(self.geom, unit='')
-        npred.data = npred_.value
+        npred.data = (flux * self.exposure.quantity).to('').value
         return npred
 
     def apply_psf(self, npred):
         """Convolve npred cube with PSF"""
         return self.psf.apply(npred)
 
-    def apply_edisp(self, npred):
-        """Convolve npred cube with edisp"""
-        a = np.rollaxis(npred, 0, 3)
-        npred1 = np.dot(a, self.edisp.pdf_matrix)
-        return np.rollaxis(npred1, 2, 0)
+    def apply_edisp(self, data):
+        """Convolve map data with energy dispersion."""
+        data = np.rollaxis(data, 0, 3)
+        data = np.dot(data, self.edisp.pdf_matrix)
+        return np.rollaxis(data, 2, 0)
 
     def compute_npred(self):
         """Evaluate model predicted counts.

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -51,7 +51,7 @@ def background(geom):
 @pytest.fixture(scope='session')
 def edisp(geom):
     e_true = geom.get_axis_by_name('energy').edges
-    return EnergyDispersion.from_diagonal_matrix(e_true=e_true)
+    return EnergyDispersion.from_diagonal_response(e_true=e_true)
 
 
 @pytest.fixture(scope='session')

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -41,6 +41,7 @@ def geom():
 def exposure(geom):
     m = Map.from_geom(geom)
     m.quantity = np.ones((2, 4, 5)) * u.Quantity('100 m2 s')
+    m.data[1] *= 10
     return m
 
 
@@ -293,14 +294,16 @@ class TestSkyModelMapEvaluator:
         out = evaluator.compute_dnde()
         assert out.shape == (2, 4, 5)
         assert out.unit == 'cm-2 s-1 TeV-1 deg-2'
-        assert_allclose(out.value.mean(), 7.460919e-14, rtol=1e-5)
+        assert_allclose(out.value.sum(), 2.984368e-12, rtol=1e-5)
+        assert_allclose(out.value[0, 0, 0], 1.336901e-13, rtol=1e-5)
 
     @staticmethod
     def test_compute_flux(evaluator):
         out = evaluator.compute_flux()
         assert out.shape == (2, 4, 5)
         assert out.unit == 'cm-2 s-1'
-        assert_allclose(out.value.mean(), 1.828206748668197e-14, rtol=1e-5)
+        assert_allclose(out.value.sum(), 7.312833e-13, rtol=1e-5)
+        assert_allclose(out.value[0, 0, 0], 3.007569e-14, rtol=1e-5)
 
     @staticmethod
     def test_apply_psf(evaluator):
@@ -308,17 +311,20 @@ class TestSkyModelMapEvaluator:
         npred = evaluator.apply_exposure(flux)
         out = evaluator.apply_psf(npred)
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.mean(), 1.2574065e-08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 9.144771e-07, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 1.563604e-08, rtol=1e-5)
 
     @staticmethod
     def test_apply_edisp(evaluator):
         flux = evaluator.compute_flux()
         out = evaluator.apply_edisp(flux.value)
         assert out.shape == (2, 4, 5)
-        assert_allclose(out.mean(), 1.828206748668197e-14, rtol=1e-5)
+        assert_allclose(out.sum(), 7.312833e-13, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 3.007569e-14, rtol=1e-5)
 
     @staticmethod
     def test_compute_npred(evaluator):
         out = evaluator.compute_npred()
         assert out.shape == (2, 4, 5)
-        assert_allclose(out.sum(), 45.02963e-07, rtol=1e-5)
+        assert_allclose(out.sum(), 4.914477e-06, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 1.15636e-07, rtol=1e-5)

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -54,7 +54,7 @@ def background(geom):
 @pytest.fixture(scope='session')
 def edisp(geom):
     e_true = geom.get_axis_by_name('energy').edges
-    return EnergyDispersion.from_diagonal_matrix(e_true=e_true)
+    return EnergyDispersion.from_diagonal_response(e_true=e_true)
 
 
 @pytest.fixture(scope='session')

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -182,7 +182,7 @@ class EnergyDispersion(object):
 
         Examples
         --------
-        
+
         >>> e_true = [0.5, 1, 2, 4, 6] * u.TeV
         >>> e_reco = [2, 4, 6] * u.TeV
         >>> edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -182,17 +182,18 @@ class EnergyDispersion(object):
 
         Examples
         --------
+        If ``e_true`` equals ``e_reco``, you get a diagonal matrix::
 
-        >>> e_true = [0.5, 1, 2, 4, 6] * u.TeV
-        >>> e_reco = [2, 4, 6] * u.TeV
-        >>> edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
-        >>> edisp.plot_matrix()
+            e_true = [0.5, 1, 2, 4, 6] * u.TeV
+            edisp = EnergyDispersion.from_diagonal_response(e_true)
+            edisp.plot_matrix()
 
-        For a square matrix where e_true = e_reco
-        >>> e_true = [0.5, 1, 2, 4, 6] * u.TeV
-        >>> edisp = EnergyDispersion.from_diagonal_response(e_true)
-        >>> edisp.plot_matrix()
+        Example with different energy binnings::
 
+            e_true = [0.5, 1, 2, 4, 6] * u.TeV
+            e_reco = [2, 4, 6] * u.TeV
+            edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
+            edisp.plot_matrix()
         """
         if e_reco is None:
             e_reco = e_true

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -180,15 +180,20 @@ class EnergyDispersion(object):
         if e_reco is None:
             e_reco = e_true
 
-        data = np.flipud(np.eye(len(e_reco) - 1))
+        e_true_center = 0.5 * (e_true[1:] + e_true[:-1])
+        Etrue, Ereco_lo = np.meshgrid(e_true_center, e_reco[:-1])
+        Etrue, Ereco_hi = np.meshgrid(e_true_center, e_reco[1:])
+
+        data = np.logical_and(Etrue >= Ereco_lo, Etrue < Ereco_hi)
+        data = np.transpose(data).astype('float')
 
         return cls(
-            e_true_lo=e_true[:-1],
-            e_true_hi=e_true[1:],
-            e_reco_lo=e_reco[:-1],
-            e_reco_hi=e_reco[1:],
-            data=data,
-        )
+                e_true_lo=e_true[:-1],
+                e_true_hi=e_true[1:],
+                e_reco_lo=e_reco[:-1],
+                e_reco_hi=e_reco[1:],
+                data=data,
+            )
 
     @classmethod
     def from_hdulist(cls, hdulist, hdu1='MATRIX', hdu2='EBOUNDS'):

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -31,8 +31,8 @@ class TestEnergyDispersion:
         edisp = EnergyDispersion.from_diagonal_matrix(e_true)
 
         assert edisp.pdf_matrix.shape == (3, 3)
-        assert_equal(edisp.pdf_matrix[0][0], 0)
-        assert_equal(edisp.pdf_matrix[2][0], 1)
+        assert_equal(edisp.pdf_matrix[0][0], 1)
+        assert_equal(edisp.pdf_matrix[2][0], 0)
 
         assert edisp.e_reco.bins.unit == 'TeV'
         assert_allclose(edisp.e_reco.bins.value, e_true.value)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -26,26 +26,27 @@ class TestEnergyDispersion:
             bias=self.bias,
         )
 
-    def test_from_diagonal_matrix(self):
+    def test_from_diagonal_response(self):
         e_true = [0.5, 1, 2, 4, 6] * u.TeV
         e_reco = [2, 4, 6] * u.TeV
 
-        edisp = EnergyDispersion.from_diagonal_matrix(e_true, e_reco)
+        edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
 
         assert edisp.pdf_matrix.shape == (4, 2)
-        expected = np.array(   [[0, 0],
-                                [0, 0],
-                                [1, 0],
-                                [0, 1]]
-                             )
+        expected = [[0, 0],
+                    [0, 0],
+                    [1, 0],
+                    [0, 1]]
+
         assert_equal(edisp.pdf_matrix, expected)
 
         # Test square matrix
-        edisp = EnergyDispersion.from_diagonal_matrix(e_true)
+        edisp = EnergyDispersion.from_diagonal_response(e_true)
         assert_allclose(edisp.e_reco.bins.value, e_true.value)
         assert edisp.e_reco.bins.unit == 'TeV'
         assert_equal(edisp.pdf_matrix[0][0], 1)
         assert_equal(edisp.pdf_matrix[2][0], 0)
+        assert edisp.pdf_matrix.sum() == 4
 
     def test_str(self):
         assert 'EnergyDispersion' in str(self.edisp)

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -27,15 +27,25 @@ class TestEnergyDispersion:
         )
 
     def test_from_diagonal_matrix(self):
-        e_true = [1, 3, 7, 10] * u.TeV
-        edisp = EnergyDispersion.from_diagonal_matrix(e_true)
+        e_true = [0.5, 1, 2, 4, 6] * u.TeV
+        e_reco = [2, 4, 6] * u.TeV
 
-        assert edisp.pdf_matrix.shape == (3, 3)
+        edisp = EnergyDispersion.from_diagonal_matrix(e_true, e_reco)
+
+        assert edisp.pdf_matrix.shape == (4, 2)
+        expected = np.array(   [[0, 0],
+                                [0, 0],
+                                [1, 0],
+                                [0, 1]]
+                             )
+        assert_equal(edisp.pdf_matrix, expected)
+
+        # Test square matrix
+        edisp = EnergyDispersion.from_diagonal_matrix(e_true)
+        assert_allclose(edisp.e_reco.bins.value, e_true.value)
+        assert edisp.e_reco.bins.unit == 'TeV'
         assert_equal(edisp.pdf_matrix[0][0], 1)
         assert_equal(edisp.pdf_matrix[2][0], 0)
-
-        assert edisp.e_reco.bins.unit == 'TeV'
-        assert_allclose(edisp.e_reco.bins.value, e_true.value)
 
     def test_str(self):
         assert 'EnergyDispersion' in str(self.edisp)


### PR DESCRIPTION
The current version of diagonal matrix is incorrect. It uses `np.eye` which produces in case of non-square matrix:
`plt.imshow(np.eye(20,10))`

![figure_2](https://user-images.githubusercontent.com/5047091/43950636-242192a6-9c91-11e8-87a0-5217dc0f0d5f.png)

whereas you should get:
```
val=EnergyDispersion.from_diagonal_matrix(np.logspace(-1,1,20)*u.TeV, (np.logspace(-1,1,10)*u.TeV))
```
![figure_1](https://user-images.githubusercontent.com/5047091/43951015-40be66c2-9c92-11e8-903e-9bc9fedd5034.png)
