### PR TITLE
Fix unit conversion in SpectrumEnergyGroupMaker

### DIFF
--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -251,7 +251,7 @@ class SpectrumEnergyGroupMaker(object):
         ebounds : `~astropy.units.Quantity`
             Energy bounds array
         """
-        ebounds_src = self.obs.e_reco
+        ebounds_src = self.obs.e_reco.to(ebounds.unit)
         bin_edges_src = np.arange(len(ebounds_src))
 
         temp = np.interp(ebounds, ebounds_src, bin_edges_src)
@@ -277,6 +277,11 @@ class SpectrumEnergyGroupMaker(object):
                 energy_max=ebounds_src[bin_edges[idx + 1]],
             )
             groups.append(group)
+
+        if groups == []:
+            err_str = "Input binning\n{}\n has no overlap with"
+            err_str += " target binning\n{}"
+            raise ValueError(err_str.format(ebounds, ebounds_src))
 
         # Add underflow bin
         start_edge = groups[0].bin_idx_min

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -127,7 +127,10 @@ class TestSpectrumEnergyGroupMaker:
 
         assert groups == expected
 
-    @pytest.mark.parametrize("ebounds", [[1.8, 4.8, 7.2] * u.TeV, [2, 5, 7] * u.TeV])
+    @pytest.mark.parametrize("ebounds", [
+        [1.8, 4.8, 7.2] * u.TeV,
+        [2, 5, 7] * u.TeV,
+        [2000, 5000, 7000] * u.GeV])
     def test_compute_groups_fixed_edges(self, obs, ebounds):
         seg = SpectrumEnergyGroupMaker(obs=obs)
         seg.compute_groups_fixed(ebounds=ebounds)
@@ -168,3 +171,9 @@ class TestSpectrumEnergyGroupMaker:
         ])
 
         assert groups == expected
+
+    def test_compute_groups_fixed_outside_range(self, obs):
+        ebounds = [20, 30, 40] * u.TeV
+        seg = SpectrumEnergyGroupMaker(obs=obs)
+        with pytest.raises(ValueError):
+            seg.compute_groups_fixed(ebounds=ebounds)


### PR DESCRIPTION
This fixes #1368 

It also add a useful error message in case the desired flux point binning does not overlap at all with the binning of the ``SpectrumObservation``