### PR TITLE
Change Parameter unit to Unit object

### DIFF
--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -92,7 +92,7 @@ class SpectrumFitResult(object):
             val["fit_range"] = dict(
                 min=self.fit_range[0].value,
                 max=self.fit_range[1].value,
-                unit=str(self.fit_range.unit),
+                unit=self.fit_range.unit.to_string('fits'),
             )
         if self.statval is not None:
             val["statval"] = float(self.statval)

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -28,7 +28,7 @@ class Parameter(object):
         Factor
     scale : float, optional
         Scale (sometimes used in fitting)
-    unit : str, optional
+    unit : `~astropy.units.Unit` or str, optional
         Unit
     min : float, optional
         Minimum (sometimes used in fitting)
@@ -83,12 +83,12 @@ class Parameter(object):
 
     @property
     def unit(self):
-        """Unit (str)."""
+        """Unit (`~astropy.units.Unit`)."""
         return self._unit
 
     @unit.setter
     def unit(self, val):
-        self._unit = check_type(val, 'str')
+        self._unit = u.Unit(val)
 
     @property
     def min(self):
@@ -146,7 +146,7 @@ class Parameter(object):
         return dict(
             name=self.name,
             value=self.value,
-            unit=self.unit,
+            unit=self.unit.to_string('fits'),
             min=self.min,
             max=self.max,
             frozen=self.frozen,

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -218,7 +218,7 @@ def xml_to_model(xml, which):
             model.parameters['index'].max = np.nan
         if type_ == 'ExponentialCutoffPowerLaw':
             model.parameters['lambda_'].value = 1 / model.parameters['lambda_'].value
-            model.parameters['lambda_'].unit = model.parameters['lambda_'].unit + '-1'
+            model.parameters['lambda_'].unit = model.parameters['lambda_'].unit.to_string('fits') + '-1'
             model.parameters['lambda_'].min = np.nan
             model.parameters['lambda_'].max = np.nan
             model.parameters['index'].value *= -1

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
+from ...extern import six
 from ..modeling import Parameter, ParameterList
 
 
@@ -64,7 +65,7 @@ def test_parameter_repr():
 def test_parameter_to_dict():
     par = Parameter('spam', 42, 'deg')
     d = par.to_dict()
-    assert isinstance(d['unit'], str)
+    assert isinstance(d['unit'], six.string_types)
 
 
 def test_parameter_list():
@@ -80,12 +81,6 @@ def test_parameter_list():
     assert_allclose(pars.covariance, [[1e-2, 0], [0, 100]])
     assert_allclose(pars.error('spam'), 0.1)
     assert_allclose(pars.error(1), 10)
-
-    # pars.scale_parameter('ham', 10)
-    # assert_allclose(pars['ham'].value, 99)
-    # assert_allclose(pars['ham'].scale, 10)
-    # assert_allclose(pars['ham'].factor, 9.9)
-    # assert_allclose(pars.covariance, [[1e-2, 0], [0, 1]])
 
     pars.optimiser_rescale_parameters()
     assert_allclose(pars['spam'].factor, 1)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -61,6 +61,12 @@ def test_parameter_repr():
     assert repr(par).startswith('Parameter(name=')
 
 
+def test_parameter_to_dict():
+    par = Parameter('spam', 42, 'deg')
+    d = par.to_dict()
+    assert isinstance(d['unit'], str)
+
+
 def test_parameter_list():
     pars = ParameterList([
         Parameter('spam', 42, 'deg'),


### PR DESCRIPTION
This PR changes the Parameter unit attribute to be a Unit object.
@adonath - Please review.

Tests pass locally, you can just merge if the diff looks OK to you.

I'm using `par.unit.to_string('fits')` instead of `str(par.unit)` where I need to go to string. I did this in other places as well, specifically for the map unit attribute. I think it's a bit more maintainable that way, because this will make it possible to find all those places with text search if we need to review them or change something in the future, wheres `str` is almost impossible to find.