### PR TITLE
Unify unit handling in gammapy.maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -6,13 +6,13 @@ import inspect
 import json
 import numpy as np
 from collections import OrderedDict
-from ..extern import six
-from ..utils.scripts import make_path
 from astropy import units as u
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
-from astropy.units import Quantity, Unit
 from .geom import pix_tuple_to_idx, MapCoord
+from ..extern import six
+from ..utils.scripts import make_path
+
 
 __all__ = [
     'Map',
@@ -97,7 +97,7 @@ class Map(object):
 
     @unit.setter
     def unit(self, val):
-        self._unit = Unit(val)
+        self._unit = u.Unit(val)
 
     @property
     def meta(self):
@@ -115,7 +115,7 @@ class Map(object):
 
     @quantity.setter
     def quantity(self, val):
-        val = Quantity(val)
+        val = u.Quantity(val)
         self.data = val.value
         self.unit = val.unit
 
@@ -404,7 +404,7 @@ class Map(object):
         # data vectors directly
         idx = map_in.geom.get_idx()
         coords = map_in.geom.get_coord()
-        vals = Quantity(map_in.get_by_idx(idx), map_in.unit)
+        vals = u.Quantity(map_in.get_by_idx(idx), map_in.unit)
         self.fill_by_coord(coords, vals)
 
     def reproject(self, geom, order=1, mode='interp'):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -125,7 +125,8 @@ def find_and_read_bands(hdu, header=None):
         unit = hdu.data.columns[cols[0]].unit
         if unit is None and header is not None:
             unit = header.get('CUNIT%i' % (3 + i), '')
-
+        if unit is None:
+            unit = ''
         if len(cols) == 2:
             xmin = np.unique(hdu.data.field(cols[0]))
             xmax = np.unique(hdu.data.field(cols[1]))
@@ -351,17 +352,17 @@ class MapAxis(object):
     unit : str
         String specifying the data units.
     """
-
+    __slots__ = ['_name', '_nodes', '_node_type', '_interp', '_pix_offset', '_nbin', '_unit']
     # TODO: Add methods to faciliate FITS I/O.
     # TODO: Cache an interpolation object?
 
     def __init__(self, nodes, interp='lin', name='',
                  node_type='edge', unit=''):
-        self._name = name
-        self._interp = interp
+        self.name = name
+        self.unit = unit
         self._nodes = nodes
         self._node_type = node_type
-        self._unit = u.Unit('' if unit is None else unit)
+        self._interp = interp
 
         # Set pixel coordinate of first node
         if node_type == 'edge':
@@ -423,6 +424,10 @@ class MapAxis(object):
     def unit(self):
         """Return coordinate axis unit."""
         return self._unit
+
+    @unit.setter
+    def unit(self, val):
+        self._unit = u.Unit(val)
 
     @classmethod
     def from_bounds(cls, lo_bnd, hi_bnd, nbin, **kwargs):


### PR DESCRIPTION
This PR unifies the unit handling in `gammapy.maps`. Now `MapAxis.unit` is always an `astropy.units.Unit`.