### PR TITLE
Rename ParameterList to Parameters

### DIFF
--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -53,7 +53,7 @@ It will print the following output to the console:
     Fit result info
     ---------------
     Model: PowerLaw
-    ParameterList
+    Parameters
     Parameter(name='index', value=2.1473880540790522, unit=Unit(dimensionless), min=0, max=None, frozen=False)
     Parameter(name='amplitude', value=2.7914083679020973e-11, unit=Unit("1 / (cm2 s TeV)"), min=0, max=None, frozen=False)
     Parameter(name='reference', value=1.0, unit=Unit("TeV"), min=None, max=None, frozen=True)

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -5,7 +5,7 @@ import abc
 import numpy as np
 import astropy.units as u
 from ...extern import six
-from ...utils.modeling import Parameter, ParameterList
+from ...utils.modeling import Parameter, Parameters
 from ...spectrum.utils import integrate_spectrum
 
 __all__ = [
@@ -88,7 +88,7 @@ class NFWProfile(DMProfile):
 
     def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('r_s', u.Quantity(r_s)),
             Parameter('rho_s', u.Quantity(rho_s))
         ])
@@ -132,7 +132,7 @@ class EinastoProfile(DMProfile):
         alpha = self.DEFAULT_ALPHA if alpha is None else alpha
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('r_s', u.Quantity(r_s)),
             Parameter('alpha', u.Quantity(alpha)),
             Parameter('rho_s', u.Quantity(rho_s))
@@ -169,7 +169,7 @@ class IsothermalProfile(DMProfile):
     def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('r_s', u.Quantity(r_s)),
             Parameter('rho_s', u.Quantity(rho_s))
         ])
@@ -204,7 +204,7 @@ class BurkertProfile(DMProfile):
     def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('r_s', u.Quantity(r_s)),
             Parameter('rho_s', u.Quantity(rho_s))
         ])
@@ -240,7 +240,7 @@ class MooreProfile(DMProfile):
     def __init__(self, r_s=None, rho_s=1 * u.Unit('GeV / cm3')):
         r_s = self.DEFAULT_SCALE_RADIUS if r_s is None else r_s
 
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('r_s', u.Quantity(r_s)),
             Parameter('rho_s', u.Quantity(rho_s))
         ])

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -4,7 +4,7 @@ import numpy as np
 import copy
 import astropy.units as u
 import operator
-from ..utils.modeling import ParameterList, Parameter
+from ..utils.modeling import Parameters, Parameter
 from ..utils.scripts import make_path
 from ..maps import Map
 
@@ -83,7 +83,7 @@ class SkyModel(object):
     """Sky model component.
 
     This model represents a factorised sky model.
-    It has a `~gammapy.utils.modeling.ParameterList`
+    It has a `~gammapy.utils.modeling.Parameters`
     combining the spatial and spectral parameters.
 
     TODO: add possibility to have a temporal model component also.
@@ -102,7 +102,7 @@ class SkyModel(object):
         self.name = name
         self._spatial_model = spatial_model
         self._spectral_model = spectral_model
-        self._parameters = ParameterList(
+        self._parameters = Parameters(
             spatial_model.parameters.parameters +
             spectral_model.parameters.parameters
         )
@@ -119,7 +119,7 @@ class SkyModel(object):
 
     @property
     def parameters(self):
-        """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
         return self._parameters
 
     @parameters.setter
@@ -193,14 +193,14 @@ class CompoundSkyModel(object):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
-        self._parameters = ParameterList(
+        self._parameters = Parameters(
             self.model1.parameters.parameters +
             self.model2.parameters.parameters
         )
 
     @property
     def parameters(self):
-        """Parameters (`~gammapy.utils.modeling.ParameterList`)"""
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
         return self._parameters
 
     @parameters.setter
@@ -260,7 +260,7 @@ class SumSkyModel(object):
         for model in self.components:
             for p in model.parameters.parameters:
                 pars.append(p)
-        self._parameters = ParameterList(pars)
+        self._parameters = Parameters(pars)
 
     @property
     def parameters(self):
@@ -315,7 +315,7 @@ class SkyDiffuseCube(object):
 
         self.map = map
         self._interp_opts = {'fill_value': 0, 'interp': 'linear'}
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('norm', norm),
         ])
         self.meta = {} if meta is None else meta

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from astropy.coordinates.angle_utilities import angular_separation
 from astropy.coordinates import Angle, Longitude, Latitude
 from ...extern import six
-from ...utils.modeling import Parameter, ParameterList
+from ...utils.modeling import Parameter, Parameters
 from ...maps import Map
 
 __all__ = [
@@ -70,7 +70,7 @@ class SkyPointSource(SkySpatialModel):
     """
 
     def __init__(self, lon_0, lat_0):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('lon_0', Longitude(lon_0)),
             Parameter('lat_0', Latitude(lat_0))
         ])
@@ -114,7 +114,7 @@ class SkyGaussian(SkySpatialModel):
     """
 
     def __init__(self, lon_0, lat_0, sigma):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('lon_0', Longitude(lon_0)),
             Parameter('lat_0', Latitude(lat_0)),
             Parameter('sigma', Angle(sigma))
@@ -158,7 +158,7 @@ class SkyDisk(SkySpatialModel):
     """
 
     def __init__(self, lon_0, lat_0, r_0):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('lon_0', Longitude(lon_0)),
             Parameter('lat_0', Latitude(lat_0)),
             Parameter('r_0', Angle(r_0))
@@ -209,7 +209,7 @@ class SkyShell(SkySpatialModel):
     """
 
     def __init__(self, lon_0, lat_0, radius, width):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('lon_0', Longitude(lon_0)),
             Parameter('lat_0', Latitude(lat_0)),
             Parameter('radius', Angle(radius)),
@@ -244,7 +244,7 @@ class SkyDiffuseConstant(SkySpatialModel):
     """
 
     def __init__(self, value=1):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('value', value),
         ])
 
@@ -273,7 +273,7 @@ class SkyDiffuseMap(SkySpatialModel):
     def __init__(self, map, norm=1, meta=None):
         self.map = map
         self._interp_opts = {'fill_value': 0, 'interp': 'linear'}
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('norm', norm),
         ])
         self.meta = dict() if meta is None else meta

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy import units as u
 from .models import PowerLaw, LogParabola, ExponentialCutoffPowerLaw, SpectralModel
-from ..utils.modeling import ParameterList
+from ..utils.modeling import Parameters
 
 __all__ = [
     'CrabSpectrum',
@@ -58,7 +58,7 @@ class MeyerCrabModel(SpectralModel):
     coefficients = np.array([-0.00449161, 0, 0.0473174, -0.179475, -0.53616, -10.2708])
 
     def __init__(self):
-        self.parameters = ParameterList([])
+        self.parameters = Parameters([])
 
     @staticmethod
     def evaluate(energy):

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -282,7 +282,7 @@ class SpectrumFit(object):
 
         Parameters
         ----------
-        parameters : `~gammapy.utils.fitting.ParameterList`
+        parameters : `~gammapy.utils.fitting.Parameters`
             Model parameters
         """
         self._model.parameters = parameters
@@ -374,7 +374,7 @@ class SpectrumFit(object):
 
         Parameters
         ----------
-        parameters : `~gammapy.utils.modeling.ParameterList`
+        parameters : `~gammapy.utils.modeling.Parameters`
             Best fit parameters
         """
         from . import SpectrumFitResult

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -11,7 +11,7 @@ from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from .utils import integrate_spectrum
 from ..utils.scripts import make_path
-from ..utils.modeling import Parameter, ParameterList
+from ..utils.modeling import Parameter, Parameters
 
 __all__ = [
     'SpectralModel',
@@ -33,7 +33,7 @@ class SpectralModel(object):
     """Spectral model base class.
 
     Derived classes should store their parameters as
-    `~gammapy.utils.modeling.ParameterList`
+    `~gammapy.utils.modeling.Parameters`
     See for example return pardict of
     `~gammapy.spectrum.models.PowerLaw`.
     """
@@ -236,7 +236,7 @@ class SpectralModel(object):
     def from_dict(cls, val):
         """Create from dict."""
         classname = val.pop('name')
-        parameters = ParameterList.from_dict(val)
+        parameters = Parameters.from_dict(val)
         model = globals()[classname]()
         model.parameters = parameters
         model.parameters.covariance = parameters.covariance
@@ -436,7 +436,7 @@ class ConstantModel(SpectralModel):
     """
 
     def __init__(self, const):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('const', const)
         ])
 
@@ -461,7 +461,7 @@ class CompoundSpectralModel(SpectralModel):
     @property
     def parameters(self):
         val = self.model1.parameters.parameters + self.model2.parameters.parameters
-        return ParameterList(val)
+        return Parameters(val)
 
     @parameters.setter
     def parameters(self, parameters):
@@ -523,7 +523,7 @@ class PowerLaw(SpectralModel):
 
     def __init__(self, index=2., amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
                  reference=1 * u.TeV):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('index', index),
             Parameter('amplitude', amplitude),
             Parameter('reference', reference, min=0, frozen=True)
@@ -711,7 +711,7 @@ class PowerLaw2(SpectralModel):
 
     def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1'), index=2,
                  emin=0.1 * u.TeV, emax=100 * u.TeV):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('amplitude', amplitude),
             Parameter('index', index),
             Parameter('emin', emin, frozen=True),
@@ -834,7 +834,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
 
     def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
                  reference=1 * u.TeV, lambda_=0.1 / u.TeV):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('index', index),
             Parameter('amplitude', amplitude),
             Parameter('reference', reference, frozen=True),
@@ -910,7 +910,7 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
 
     def __init__(self, index=1.5, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
                  reference=1 * u.TeV, ecut=10 * u.TeV):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('index', index),
             Parameter('amplitude', amplitude),
             Parameter('reference', reference, frozen=True),
@@ -969,7 +969,7 @@ class PLSuperExpCutoff3FGL(SpectralModel):
     def __init__(self, index_1=1.5, index_2=2, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'),
                  reference=1 * u.TeV, ecut=10 * u.TeV):
         # TODO: order or parameters is different from argument list / docstring. Make uniform!
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('amplitude', amplitude),
             Parameter('reference', reference, frozen=True),
             Parameter('ecut', ecut),
@@ -1037,7 +1037,7 @@ class LogParabola(SpectralModel):
 
     def __init__(self, amplitude=1E-12 * u.Unit('cm-2 s-1 TeV-1'), reference=10 * u.TeV,
                  alpha=2, beta=1):
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('amplitude', amplitude),
             Parameter('reference', reference, frozen=True),
             Parameter('alpha', alpha),
@@ -1111,7 +1111,7 @@ class TableModel(SpectralModel):
 
     def __init__(self, energy, values, scale=1, scale_logy=True, meta=None):
         from scipy.interpolate import interp1d
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('scale', scale, min=0, unit='')
         ])
         self.energy = energy
@@ -1486,7 +1486,7 @@ class AbsorbedSpectralModel(SpectralModel):
                         frozen=True)
         param_list.append(par)
 
-        self.parameters = ParameterList(param_list)
+        self.parameters = Parameters(param_list)
 
     def evaluate(self, energy, **kwargs):
         """Evaluate the model at a given energy."""

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -114,7 +114,7 @@ class SpectrumFitResult(object):
 
         return cls(model=model, fit_range=energy_range)
 
-    # TODO: rather add this to ParameterList?
+    # TODO: rather add this to Parameters?
     def to_table(self, energy_unit="TeV", flux_unit="cm-2 s-1 TeV-1", **kwargs):
         """Convert to `~astropy.table.Table`.
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -8,7 +8,7 @@ from astropy.table import Table
 import astropy.units as u
 from ...catalog.fermi import SourceCatalog3FGL
 from ...utils.testing import requires_dependency, requires_data, assert_quantity_allclose
-from ...utils.modeling import ParameterList
+from ...utils.modeling import Parameters
 from ..results import SpectrumResult
 from ..fit import SpectrumFit
 from ..observation import SpectrumObservation
@@ -25,7 +25,7 @@ FLUX_POINTS_FILES = [
 
 
 class LWTestModel(SpectralModel):
-    parameters = ParameterList([])
+    parameters = Parameters([])
 
     @staticmethod
     def evaluate(x):
@@ -39,7 +39,7 @@ class LWTestModel(SpectralModel):
 
 
 class XSqrTestModel(SpectralModel):
-    parameters = ParameterList([])
+    parameters = Parameters([])
 
     @staticmethod
     def evaluate(x):
@@ -53,7 +53,7 @@ class XSqrTestModel(SpectralModel):
 
 
 class ExpTestModel(SpectralModel):
-    parameters = ParameterList([])
+    parameters = Parameters([])
 
     @staticmethod
     def evaluate(x):

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from astropy.table import Table
 from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
-from ..utils.modeling import Parameter, ParameterList
+from ..utils.modeling import Parameter, Parameters
 
 __all__ = [
     'PhaseCurveTableModel',
@@ -66,7 +66,7 @@ class PhaseCurveTableModel(object):
 
     def __init__(self, table, time_0, phase_0, f0, f1, f2):
         self.table = table
-        self.parameters = ParameterList([
+        self.parameters = Parameters([
             Parameter('time_0', time_0),
             Parameter('phase_0', phase_0),
             Parameter('f0', f0),

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -17,7 +17,7 @@ def fit_iminuit(parameters, function, opts_minuit=None):
 
     Parameters
     ----------
-    parameters : `~gammapy.utils.modeling.ParameterList`
+    parameters : `~gammapy.utils.modeling.Parameters`
         Parameters with starting values
     function : callable
         Likelihood function
@@ -26,7 +26,7 @@ def fit_iminuit(parameters, function, opts_minuit=None):
 
     Returns
     -------
-    parameters : `~gammapy.utils.modeling.ParameterList`
+    parameters : `~gammapy.utils.modeling.Parameters`
         Parameters with best-fit values
     minuit : `~iminuit.Minuit`
         Minuit object
@@ -74,7 +74,7 @@ class MinuitFunction(object):
 
     Parameters
     ----------
-    parameters : `~gammapy.utils.modeling.ParameterList`
+    parameters : `~gammapy.utils.modeling.Parameters`
         Parameters with starting values
     function : callable
         Likelihood function

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -20,7 +20,7 @@ class SherpaFunction(object):
 
     Parameters
     ----------
-    parameters : `~gammapy.utils.modeling.ParameterList`
+    parameters : `~gammapy.utils.modeling.Parameters`
         Parameters with starting values
     function : callable
         Likelihood function
@@ -40,7 +40,7 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
 
     Parameters
     ----------
-    parameters : `~gammapy.utils.modeling.ParameterList`
+    parameters : `~gammapy.utils.modeling.Parameters`
         Parameter list with starting values.
     function : callable
         Likelihood function
@@ -51,7 +51,7 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
 
     Returns
     -------
-    parameters : `~gammapy.utils.modeling.ParameterList`
+    parameters : `~gammapy.utils.modeling.Parameters`
         Parameter list with best-fit values
     """
     optimizer = get_sherpa_optimiser(optimizer)

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from ...modeling import ParameterList, Parameter
+from ...modeling import Parameters, Parameter
 from ...testing import requires_dependency
 from .. import fit_iminuit
 
@@ -15,7 +15,7 @@ def fcn(parameters):
 
 @requires_dependency('iminuit')
 def test_iminuit():
-    pars = ParameterList(
+    pars = Parameters(
         [Parameter('x', 2.1), Parameter('y', 3.1), Parameter('z', 4.1)]
     )
 

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from numpy.testing import assert_allclose
 from ...testing import requires_dependency
-from ...modeling import Parameter, ParameterList
+from ...modeling import Parameter, Parameters
 from ..sherpa import fit_sherpa
 
 
@@ -20,7 +20,7 @@ def fcn(parameters):
 @requires_dependency('sherpa')
 @pytest.mark.parametrize('optimizer', ['moncar', 'simplex'])
 def test_sherpa(optimizer):
-    pars = ParameterList(
+    pars = Parameters(
         [Parameter('x', 2.2), Parameter('y', 3.4), Parameter('z', 4.5)]
     )
 

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -450,10 +450,10 @@ def gaussian_sum_moments(F, sigma, x, y, cov_matrix, shift=0.5):
         values += [sigma[i], x[i], y[i], F[i]]
 
     # Set up parameters with uncertainties
-    parameter_list = uncertainties.correlated_values(values, cov_matrix)
+    parameters = uncertainties.correlated_values(values, cov_matrix)
 
     # Reorder parameters by splitting into 4-tuples
-    parameters = list(zip(*[iter(parameter_list)] * 4))
+    parameters = list(zip(*[iter(parameters)] * 4))
 
     def zero_moment(parameters):
         """0th moment of the sum of Gaussian components."""

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -12,7 +12,7 @@ from .array import check_type
 
 __all__ = [
     'Parameter',
-    'ParameterList',
+    'Parameters',
 ]
 
 
@@ -153,7 +153,7 @@ class Parameter(object):
         )
 
 
-class ParameterList(object):
+class Parameters(object):
     """List of `~gammapy.spectrum.models.Parameter`
 
     Holds covariance matrix

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from ...extern import six
-from ..modeling import Parameter, ParameterList
+from ..modeling import Parameter, Parameters
 
 
 def test_parameter_init():
@@ -68,8 +68,8 @@ def test_parameter_to_dict():
     assert isinstance(d['unit'], six.string_types)
 
 
-def test_parameter_list():
-    pars = ParameterList([
+def test_parameters():
+    pars = Parameters([
         Parameter('spam', 42, 'deg'),
         Parameter('ham', 99, 'TeV'),
     ])


### PR DESCRIPTION
This PR renames `ParameterList` to `Parameters`.

The problem with `ParameterList` is that it suggests that this is a list. But it's not a list, you can't e.g. slice into it and it doesn't have other list methods like append, index, insert, reverse, sort.

I considered sub-classing list here, and also sub-classing `OrderedDict`, but decided to pursue this existing direction of having a wrapper class with a small API.

I'll send a follow-up PR shortly that makes the `parameters` attribute private, improving the public API to work with `Parameters`.