### PR TITLE
Introduce `WcsNDMap.convolve()` method

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -234,7 +234,7 @@ class MapEvaluator(object):
 
     def apply_psf(self, npred):
         """Convolve npred cube with PSF"""
-        return self.psf.apply(npred)
+        return npred.convolve(self.psf)
 
     def apply_edisp(self, npred):
         """Convolve npred cube with edisp"""

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -5,7 +5,6 @@ import warnings
 from astropy.coordinates import Angle
 from astropy.coordinates.angle_utilities import angular_separation
 import astropy.units as u
-from astropy.convolution import convolve_fft
 from ..utils.gauss import Gauss2DPDF
 from ..maps import Map, WcsGeom
 from ..irf import TablePSF

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -66,7 +66,7 @@ def test_psf_kernel_convolve():
     # is kernel maximum at the center?
     assert kernel.psf_kernel_map.data[30, 30] == np.max(kernel.psf_kernel_map.data)
 
-    conv_map = kernel.apply(testmap)
+    conv_map = testmap.convolve(kernel)
 
     # Is convolved map normalization OK
     assert_allclose(conv_map.data.sum(), 2.0, atol=1e-3)
@@ -95,6 +95,6 @@ def test_energy_dependent_psf_kernel():
 
     assert psf_kernel.psf_kernel_map.data.shape == (3, 101, 101)
 
-    some_map_convolved = psf_kernel.apply(some_map)
+    some_map_convolved = some_map.convolve(psf_kernel)
 
     assert_allclose(some_map_convolved.data.sum(axis=(1, 2)), np.array((0, 1, 1)))

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -159,12 +159,10 @@ class KernelBackgroundEstimator(object):
         Estimate background by convolving the excluded counts image with
         the background kernel and renormalizing the image.
         """
-        from scipy.ndimage import convolve
-        vals = convolve(counts.data * exclusion.data, self.kernel_bkg, mode='constant')
-        norm = convolve(exclusion.data, self.kernel_bkg, mode='constant')
-        bkg = Map.from_geom(counts.geom)
-        bkg.data = vals / norm
-        return bkg
+        counts_excluded = counts.copy(data=counts.data * exclusion.data)
+        vals = counts_excluded.convolve(self.kernel_bkg)
+        norm = exclusion.convolve(self.kernel_bkg)
+        return counts.copy(data=vals.data / norm.data)
 
     @staticmethod
     def _is_converged(result, result_previous):

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -39,20 +39,18 @@ def compute_lima_image(counts, background, kernel, exposure=None):
     --------
     gammapy.stats.significance
     """
-    from scipy.ndimage import convolve
-
     # Kernel is modified later make a copy here
     kernel = deepcopy(kernel)
 
     kernel.normalize('peak')
     conv_opt = dict(mode='constant', cval=np.nan)
 
-    counts_conv = convolve(counts.data, kernel.array, **conv_opt)
-    background_conv = convolve(background.data, kernel.array, **conv_opt)
+    counts_conv = counts.convolve(kernel.array, use_fft=False, **conv_opt).data
+    background_conv = background.convolve(kernel.array, use_fft=False, **conv_opt).data
     excess_conv = counts_conv - background_conv
     significance_conv = significance(counts_conv, background_conv, method='lima')
 
-    # TODO: we should make coopies of the geom to make them independent objects
+    # TODO: we should make copies of the geom to make them independent objects
     images = {
         'significance': counts.copy(data=significance_conv),
         'counts': counts.copy(data=counts_conv),
@@ -104,8 +102,8 @@ def compute_lima_on_off_image(n_on, n_off, a_on, a_off, kernel, exposure=None):
     kernel.normalize('peak')
     conv_opt = dict(mode='constant', cval=np.nan)
 
-    n_on_conv = convolve(n_on.data, kernel.array, **conv_opt)
-    a_on_conv = convolve(a_on.data, kernel.array, **conv_opt)
+    n_on_conv = n_on.convolve(kernel.array, use_fft=False, **conv_opt).data
+    a_on_conv = a_on.convolve(kernel.array, use_fft=False, **conv_opt).data
     alpha_conv = a_on_conv / a_off.data
     background_conv = alpha_conv * n_off.data
     excess_conv = n_on_conv - background_conv

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -164,11 +164,9 @@ class TSMapEstimator(object):
         flux_approx : `WcsNDMap`
             Approximate flux map.
         """
-        from scipy.signal import fftconvolve
         flux = (maps['counts'].data - maps['background'].data) / maps['exposure'].data
-        flux = fftconvolve(flux, kernel.array, mode='same')
-        flux /= np.sum(kernel.array ** 2)
-        return maps['counts'].copy(data=flux)
+        flux = maps['counts'].copy(data=flux / np.sum(kernel.array ** 2))
+        return flux.convolve(kernel.array)
 
     @staticmethod
     def mask_default(maps, kernel):

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -26,6 +26,9 @@ def test_compute_lima_image():
 
     assert_allclose(result_lima['significance'].data[100, 100], 30.814916, atol=1e-3)
     assert_allclose(result_lima['flux'].data[100, 100], 4.10000e-10, atol=3e-12)
+    assert_allclose(result_lima['significance'].data[1, 1], np.nan, atol=1e-3)
+    assert_allclose(result_lima['flux'].data[1, 1], np.nan, atol=3e-12)
+
 
 
 @requires_dependency('scipy')

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -629,17 +629,21 @@ class WcsNDMap(WcsMap):
 
     def convolve(self, kernel, use_fft=True, **kwargs):
         """
-        Convolve map with given kernel.
+        Convolve map with a kernel.
+
+        If the kernel is two dimensional, it is applied to all image planes likewise.
+        If the kernel is higher dimensional it must match the map in the number of
+        dimensions and the correspoding kernel is selected for every image plane.
 
         Parameters
         ----------
-        kernel : `PSFKernel` or `np.ndarray`
+        kernel : `PSFKernel` or `numpy.ndarray`
             Convolution kernel.
         use_fft : bool
-            Use `~scipy.signal.fftconvolve` or `~scipy.ndimage.convolve`.
+            Use `scipy.signal.fftconvolve` or `scipy.ndimage.convolve`.
         kwargs : dict
-            Keyword arguments passed to `~scipy.signal.fftconvolve` or
-            `~scipy.ndimage.convolve`.
+            Keyword arguments passed to `scipy.signal.fftconvolve` or
+            `scipy.ndimage.convolve`.
 
         Returns
         -------

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -652,12 +652,14 @@ class WcsNDMap(WcsMap):
 
         conv_function = fftconvolve if use_fft else convolve
         convolved_data = np.empty_like(self.data)
+        if use_fft:
+            kwargs.setdefault('mode', 'same')
 
         if isinstance(kernel, PSFKernel):
              kernel = kernel._psf_kernel_map.data
 
         for img, idx in self.iter_by_image():
-            idx = None if kernel.ndim == 2 else idx
+            idx = Ellipsis if kernel.ndim == 2 else idx
             convolved_data[idx] = conv_function(img, kernel[idx], **kwargs)
 
         return self._init_copy(data=convolved_data)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -651,7 +651,7 @@ class WcsNDMap(WcsMap):
         from ..cube.psf_kernel import PSFKernel
 
         conv_function = fftconvolve if use_fft else convolve
-        convolved_data = np.empty_like(self.data)
+        convolved_data = np.empty(self.data.shape, dtype=np.float32)
         if use_fft:
             kwargs.setdefault('mode', 'same')
 


### PR DESCRIPTION
Image convolution is used in many places in Gammapy (`gammapy.cube`, `gammapy.detect`, `gammapy.image`). This PR introduces a `WcsNDMap.convolve()` method to unify the usage of image convolutions in Gammapy. So far different functions from astropy as well as scipy have beem used.  To make a choice, which functions to use for  `WcsNDMap.convolve()` I wrote a [notebook comparing the performance](https://github.com/adonath/notebooks-public/blob/master/convolution_functions_comparison.ipynb) of the different convolutions functions in astropy and scipy. The clear winners are `scipy.signal.fftconvolve` and `scipy.ndimage.convolve`. The notebook also shows, that for `scipy.signal.fftconvolve` the runtime only weakly depends on the kernel size. Choosing the fft convolution we might avoid the need for energy dependent kernel sizes.
