### PR TITLE
Add parameter auto scale

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -106,14 +106,6 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, edisp):
     sky_model.parameters['index'].value = 2
     sky_model.parameters['sigma'].frozen = True
 
-    sky_model.parameters.set_parameter_errors({
-        'lon_0': '0.01 deg',
-        'lat_0': '0.01 deg',
-        'sigma': '0.02 deg',
-        'index': 0.1,
-        'amplitude': '1e-13 cm-2 s-1 TeV-1',
-    })
-
     fit = MapFit(
         model=sky_model,
         counts=counts,

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -16,9 +16,6 @@ def get_config():
         amplitude=1e-11 * u.Unit('cm-2 s-1 TeV-1'),
         reference=1 * u.TeV,
     )
-    model.parameters.set_parameter_errors({
-        'amplitude': 1e-12 * u.Unit('cm-2 s-1 TeV-1')
-    })
     fp_binning = EnergyBounds.equal_log_spacing(1, 50, 4, 'TeV')
     return dict(
         outdir=None,

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -967,22 +967,8 @@ class FluxPointFitter(object):
             raise ValueError('Only the minuit fitting backend is supported.')
         return model
 
-    def dof(self, data, model):
-        """
-        Degrees of freedom.
-
-        Parameters
-        ----------
-        model : `~gammapy.spectrum.models.SpectralModel`
-            Spectral model
-        """
-        m = len(model.parameters.free)
-        n = len(data.table)
-        return n - m
-
     def run(self, data, model):
-        """
-        Run all fitting adn extra information steps.
+        """Run all fitting and extra information steps.
 
         Parameters
         ----------
@@ -997,8 +983,12 @@ class FluxPointFitter(object):
             Dictionary with fit results and debug output.
         """
         best_fit_model = self.fit(data, model)
-        dof = self.dof(data, best_fit_model)
         statval = self.stat(data, best_fit_model)[0]
+
+        # Compute degrees of freedom
+        n = len(data.table)
+        m = sum(1 for par in best_fit_model.parameters if not par.frozen)
+        dof = n - m
 
         return OrderedDict([
             ('best-fit-model', best_fit_model),

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -8,6 +8,7 @@ from astropy import units as u
 from astropy.io.registry import IORegistryError
 from ..utils.scripts import make_path
 from ..utils.table import table_standardise_units_copy, table_from_row_data
+from ..utils.fitting import fit_iminuit
 from .models import PowerLaw
 from .powerlaw import power_law_integral_flux
 from . import SpectrumObservationList, SpectrumObservation
@@ -946,8 +947,6 @@ class FluxPointFitter(object):
         best_fit_model : `~gammapy.spectrum.models.SpectralModel`
             Best fit model
         """
-        from ..utils.fitting import fit_iminuit
-
         p = self.parameters
         model = model.copy()
 

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -33,9 +33,8 @@ def fit_iminuit(parameters, function, opts_minuit=None):
     """
     from iminuit import Minuit
 
-    # TODO activate!
-    # if parameters.covariance is None:
-    #     parameters.scale()
+    if parameters.covariance is None:
+        parameters.scale()
 
     minuit_func = MinuitFunction(function, parameters)
 

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -33,7 +33,9 @@ def fit_iminuit(parameters, function, opts_minuit=None):
     """
     from iminuit import Minuit
 
-    # parameters.optimiser_rescale_parameters()
+    # TODO activate!
+    # if parameters.covariance is None:
+    #     parameters.scale()
 
     minuit_func = MinuitFunction(function, parameters)
 
@@ -51,9 +53,9 @@ def fit_iminuit(parameters, function, opts_minuit=None):
                     **opts_minuit)
     minuit.migrad()
 
-    parameters.optimiser_set_factors(minuit.args)
+    parameters.set_parameter_factors(minuit.args)
     if minuit.covariance is not None:
-        parameters.optimiser_set_covariance(_get_covar(minuit))
+        parameters.set_covariance_factors(_get_covar(minuit))
     else:
         log.warning("No covariance matrix found")
         parameters.covariance = None
@@ -85,7 +87,7 @@ class MinuitFunction(object):
         self.parameters = parameters
 
     def fcn(self, *factors):
-        self.parameters.optimiser_set_factors(factors)
+        self.parameters.set_parameter_factors(factors)
         return self.function(self.parameters)
 
 

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -31,7 +31,7 @@ class SherpaFunction(object):
         self.parameters = parameters
 
     def fcn(self, factors):
-        self.parameters.optimiser_set_factors(factors)
+        self.parameters.set_parameter_factors(factors)
         return self.function(self.parameters)
 
 
@@ -55,7 +55,10 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
         Parameter list with best-fit values
     """
     optimizer = get_sherpa_optimiser(optimizer)
-    # parameters.optimiser_rescale_parameters()
+
+    # TODO activate!
+    # if parameters.covariance is None:
+    #     parameters.scale()
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]
@@ -81,6 +84,6 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
     result['nfev'] = result['info']['nfev']
 
     # Copy final results into the parameters object
-    parameters.optimiser_set_factors(result['factors'])
+    parameters.set_parameter_factors(result['factors'])
 
     return result

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -56,9 +56,8 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
     """
     optimizer = get_sherpa_optimiser(optimizer)
 
-    # TODO activate!
-    # if parameters.covariance is None:
-    #     parameters.scale()
+    if parameters.covariance is None:
+        parameters.scale()
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -32,11 +32,13 @@ def test_iminuit():
     # Test freeze
     pars['x'].frozen = True
     minuit = fit_iminuit(function=fcn, parameters=pars)
+    assert minuit.migrad_ok()
     assert minuit.list_of_fixed_param() == ['par_000_x']
 
     # Test limits
     pars['y'].min = 4
     minuit = fit_iminuit(function=fcn, parameters=pars)
+    assert minuit.migrad_ok()
     states = minuit.get_param_states()
     assert not states[0]['has_limits']
     assert not states[2]['has_limits']
@@ -45,8 +47,3 @@ def test_iminuit():
     assert states[1]['lower_limit'] == 4
     assert states[1]['upper_limit'] == 0
 
-    # Test stepsize via covariance matrix
-    pars.set_parameter_errors({'x': '0.2', 'y': '0.1'})
-    minuit = fit_iminuit(function=fcn, parameters=pars)
-
-    assert minuit.migrad_ok()

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -377,7 +377,7 @@ class Parameters(object):
         Available methods:
 
         * ``scale10`` sets ``scale`` to power of 10,
-          so that factor is in the range 0.1 to 1
+          so that factor is in the range 1 to 10
         * ``factor1`` sets ``factor, scale = 1, value``
 
         Parameters
@@ -388,7 +388,7 @@ class Parameters(object):
         for par in self.parameters:
             if method == 'scale10':
                 value = par.value
-                scale = np.power(10, int(np.log10(value)))
+                scale = 10 ** int(np.log10(value))
                 par.factor = value / scale
                 par.scale = scale
             elif method == 'factor1':

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-Model parameter handling
-"""
+"""Model parameter classes."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import copy
 from ..extern import six
 from astropy import units as u
-from astropy.table import Table, Column
+from astropy.table import Table
 from .array import check_type
 
 __all__ = [
@@ -171,6 +169,15 @@ class Parameters(object):
         self._parameters = parameters
         self.covariance = covariance
 
+    def _init_covar(self):
+        if self.covariance is None:
+            shape = (len(self.parameters), len(self.parameters))
+            self.covariance = np.zeros(shape)
+
+    def copy(self):
+        """A deep copy"""
+        return copy.deepcopy(self)
+
     @property
     def parameters(self):
         """List of `Parameter`."""
@@ -180,6 +187,11 @@ class Parameters(object):
     @parameters.setter
     def parameters(self, vals):
         self._parameters = vals
+
+    @property
+    def names(self):
+        """List of parameter names"""
+        return [par.name for par in self.parameters]
 
     def __str__(self):
         ss = self.__class__.__name__
@@ -268,11 +280,6 @@ class Parameters(object):
         return table
 
     @property
-    def names(self):
-        """List of parameter names"""
-        return [par.name for par in self.parameters]
-
-    @property
     def _ufloats(self):
         """
         Return dict of ufloats with covariance
@@ -342,15 +349,6 @@ class Parameters(object):
         idx = self._get_idx(parname)
         err = u.Quantity(err, self[idx].unit).value
         self.covariance[idx, idx] = err ** 2
-
-    def _init_covar(self):
-        if self.covariance is None:
-            shape = (len(self.parameters), len(self.parameters))
-            self.covariance = np.zeros(shape)
-
-    def copy(self):
-        """A deep copy"""
-        return copy.deepcopy(self)
 
     def optimiser_set_factors(self, factors):
         """Set factor of all parameters.

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -87,14 +87,6 @@ def test_parameters_basics(pars):
     assert_allclose(pars.error(1), 10)
 
 
-def test_parametrs_rescale(pars):
-    pars.optimiser_rescale_parameters()
-    assert_allclose(pars['spam'].factor, 1)
-    assert_allclose(pars['spam'].scale, 42)
-    assert_allclose(pars['ham'].factor, 1)
-    assert_allclose(pars['ham'].scale, 99)
-
-
 def test_parameters_covariance_to_table(pars):
     with pytest.raises(ValueError):
         pars.covariance_to_table()
@@ -102,3 +94,46 @@ def test_parameters_covariance_to_table(pars):
     pars.set_error('ham', 10)
     table = pars.covariance_to_table()
     assert_allclose(table['ham'][1], 100)
+
+
+def test_parameters_set_parameter_factors(pars):
+    pars.set_parameter_factors([77, 78])
+    assert_allclose(pars['spam'].factor, 77)
+    assert_allclose(pars['spam'].scale, 1)
+    assert_allclose(pars['ham'].factor, 78)
+    assert_allclose(pars['ham'].scale, 1)
+
+
+def _test_parameters_set_covariance_factors(pars):
+    cov_factor = [[3, 4], [7, 8]]
+    pars.set_covariance_factors(cov_factor)
+
+    assert isinstance(pars.covariance, np.ndarray)
+    cov_value = [[0, 0], [0, 0]]
+    assert_allclose(pars.covariance, cov_value)
+
+
+def test_parameters_scale():
+    pars = Parameters([
+        Parameter('', factor=10, scale=5),
+        Parameter('', factor=10, scale=50),
+        Parameter('', factor=100, scale=5),
+    ])
+
+    pars.scale()  # default: 'scale10'
+
+    assert_allclose(pars[0].factor, 5)
+    assert_allclose(pars[0].scale, 10)
+    assert_allclose(pars[1].factor, 5)
+    assert_allclose(pars[1].scale, 100)
+    assert_allclose(pars[2].factor, 5)
+    assert_allclose(pars[2].scale, 100)
+
+    pars.scale('factor1')
+
+    assert_allclose(pars[0].factor, 1)
+    assert_allclose(pars[0].scale, 50)
+    assert_allclose(pars[1].factor, 1)
+    assert_allclose(pars[1].scale, 500)
+    assert_allclose(pars[2].factor, 1)
+    assert_allclose(pars[2].scale, 500)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -87,6 +87,13 @@ def test_parameters_basics(pars):
     assert_allclose(pars.error(1), 10)
 
 
+def test_parameters_to_table(pars):
+    pars.set_error('ham', 1e-10 / 3)
+    table = pars.to_table()
+    assert len(table) == 2
+    assert len(table.columns) == 6
+
+
 def test_parameters_covariance_to_table(pars):
     with pytest.raises(ValueError):
         pars.covariance_to_table()


### PR DESCRIPTION
This PR implements parameter auto-scaling before fitting to address the issue reported in #1531 and is one of the solutions discussed there.

@facero @robertazanin @bkhelifi @registerrier @cosimoNigro  or anyone that is running analyses with Gammapy at the moment:

It should no longer be necessary to call `model.parameters.set_parameter_errors`. Now you should only set reasonable start values before the fit (e.g. spectral index of 2 and a flux norm of 1e-11 or 1e-12), and then run it.

Also: Please update to iminuit 1.3.2 that @hdembinski released today: http://iminuit.readthedocs.io/en/latest/changelog.html#august-5-2018
That fixes a bug in the covariance matrix reported by iminuit that is present in iminui 1.3.0 and 1.3.1 (but should not be there in iminui 1.2 or 1.3.2 or any later version).

In the few fits that we run have automated in Gammapy: they now all work without `set_parameter_errors` and results come out the same. Except for `SpectrumFit.test_compound`, there the fitted flux amplitude has changed. I'm not sure why, maybe the fit wasn't converging before and we asserted on arbitrary values. We should always add an assert on fit status in tests. I'll let this one slide and merge this now, so that people can start testing this.

Please report any issues you find soon, the Gammapy v0.8 release is planned for Monday!
(e.g. incorrect results, errors, non-converging fits, ...)