### PR TITLE
Improve __repr__ methods in Gammapy

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -948,10 +948,12 @@ class Map(object):
         str_ = self.__class__.__name__
         str_ += "\n\n"
         geom = self.geom.__class__.__name__
-        str_ += "\tgeom      : {} \n ".format(geom)
-        str_ += "\tunit      : {} \n".format(self.unit)
-        str_ += "\tdata shape: {}\n".format(self.data.shape)
-        str_ += "\tdata mean : {:.1e} {}\n".format(np.nanmean(self.data), self.unit)
-        str_ += "\tdata min  : {:.1e} {}\n".format(np.nanmin(self.data), self.unit)
-        str_ += "\tdata max  : {:.1e} {}\n".format(np.nanmax(self.data), self.unit)
+        str_ += "\tgeom  : {} \n ".format(geom)
+        axes = ['skycoord'] if self.geom.is_hpx else ['lon', 'lat']
+        axes = axes + [_.name for _ in self.geom.axes]
+        str_ += "\taxes  : {}\n".format(", ".join(axes))
+        str_ += "\tshape : {}\n".format(self.geom.data_shape[::-1])
+        str_ += "\tndim  : {}\n".format(self.geom.ndim)
+        str_ += "\tunit  : {!r} \n".format(str(self.unit))
+        str_ += "\tdtype : {} \n".format(self.data.dtype)
         return str_

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -607,13 +607,22 @@ class MapAxis(object):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        str_ += "\tname     : {}\n".format(self.name)
-        str_ += "\tunit     : {}\n".format(self.unit)
-        str_ += "\tnbins    : {}\n".format(self.nbin)
-        str_ += "\tnode type: {}\n".format(self.node_type)
-        str_ += "\tedge min : {:.1e} {}\n".format(self.edges.min(), self.unit)
-        str_ += "\tedge max : {:.1e} {}\n".format(self.edges.max(), self.unit)
-        str_ += "\tinterp   : {}\n".format(self._interp)
+        line_format = '\t{key:<10s} : {value:<10s}\n'
+
+        repr_dict = OrderedDict()
+        repr_dict['name'] = self.name
+        repr_dict['unit'] = '{!r}'.format(str(self.unit))
+        repr_dict['nbins'] = str(self.nbin)
+        repr_dict['node type'] = self.node_type
+
+        vals = self.edges if self.node_type == 'edge' else self.center
+        repr_dict['{} min'.format(self.node_type)] = '{:.1e} {}'.format(vals.min(), str(self.unit))
+        repr_dict['{} max'.format(self.node_type)] = '{:.1e} {}'.format(vals.max(), str(self.unit))
+
+        repr_dict['interp'] = self._interp
+
+        for key, value in repr_dict.items():
+            str_ += line_format.format(key=key, value=value)
         return str_
 
 
@@ -884,10 +893,10 @@ class MapCoord(object):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        str_ += "\taxes    : {}\n".format(list(self._data.keys()))
-        str_ += "\tshape   : {}\n".format(self.shape)
-        str_ += "\tndim    : {}\n".format(self.ndim)
-        str_ += "\tcoordsys: {}\n".format(self.coordsys)
+        str_ += "\taxes     : {}\n".format(', '.join(self._data.keys()))
+        str_ += "\tshape    : {}\n".format(self.shape[::-1])
+        str_ += "\tndim     : {}\n".format(self.ndim)
+        str_ += "\tcoordsys : {}\n".format(self.coordsys)
         return str_
 
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -566,7 +566,7 @@ class HpxGeom(MapGeom):
         arrays.  This option is only compatible with partial-sky maps
         with an analytic geometry (e.g. DISK).
     """
-
+    is_hpx = True
     def __init__(self, nside, nest=True, coordsys='CEL', region=None,
                  axes=None, conv='gadf', sparse=False):
 
@@ -1727,16 +1727,16 @@ class HpxGeom(MapGeom):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        str_ += "\tnpix      : {npix[0]} pix\n".format(npix=self.npix)
-        str_ += "\tnside     : {nside[0]}\n".format(nside=self.nside)
-        str_ += "\tnested    : {}\n".format(self.nest)
-        str_ += "\tcoordsys  : {}\n".format(self.coordsys)
-        str_ += "\tprojection: {}\n".format(self.projection)
+        axes = ['skycoord'] + [_.name for _ in self.axes]
+        str_ += "\taxes       : {}\n".format(", ".join(axes))
+        str_ += "\tshape      : {}\n".format(self.data_shape[::-1])
+        str_ += "\tndim       : {}\n".format(self.ndim)
+        str_ += "\tnside      : {nside[0]}\n".format(nside=self.nside)
+        str_ += "\tnested     : {}\n".format(self.nest)
+        str_ += "\tcoordsys   : {}\n".format(self.coordsys)
+        str_ += "\tprojection : {}\n".format(self.projection)
         lon, lat = self.center_skydir.data.lon.deg, self.center_skydir.data.lat.deg
-        str_ += "\tcenter    : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
-        str_ += "\tndim      : {}\n".format(self.ndim)
-        axes = [_.name for _ in self.axes]
-        str_ += "\taxes      : {}\n".format(", ".join(axes))
+        str_ += "\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
         return str_
 
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -154,7 +154,7 @@ class WcsGeom(MapGeom):
     """
     _slice_spatial_axes = slice(0, 2)
     _slice_non_spatial_axes = slice(2, -1)
-
+    is_hpx = False
     def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, conv='gadf'):
         self._wcs = wcs
         self._coordsys = get_coordys(wcs)
@@ -832,16 +832,16 @@ class WcsGeom(MapGeom):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        str_ += "\tnpix      : {npix[0][0]} x {npix[1][0]} pix\n".format(npix=self.npix)
-        str_ += "\tcoordsys  : {}\n".format(self.coordsys)
-        str_ += "\tprojection: {}\n".format(self.projection)
+        axes = ['lon', 'lat'] + [_.name for _ in self.axes]
+        str_ += "\taxes       : {}\n".format(", ".join(axes))
+        str_ += "\tshape      : {}\n".format(self.data_shape[::-1])
+        str_ += "\tndim       : {}\n".format(self.ndim)
+        str_ += "\tcoordsys   : {}\n".format(self.coordsys)
+        str_ += "\tprojection : {}\n".format(self.projection)
         lon, lat = float(self.center_skydir.data.lon.deg), float(self.center_skydir.data.lat.deg)
-        str_ += "\tcenter    : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
-        str_ += ("\twidth     : {width[0][0]:.1f} x {width[1][0]:.1f} "
+        str_ += "\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
+        str_ += ("\twidth      : {width[0][0]:.1f} x {width[1][0]:.1f} "
                  "deg\n".format(width=self.width))
-        str_ += "\tndim      : {}\n".format(self.ndim)
-        axes = [_.name for _ in self.axes]
-        str_ += "\taxes      : {}\n".format(", ".join(axes))
         return str_
 
 


### PR DESCRIPTION
This PR addresses #1699. It improves and further unifies the `__repr__` methods of `Map` and related objects. Here is what the current implementation looks like:

### WcsNDMap
```
WcsNDMap

	geom  : WcsGeom 
 	axes  : lon, lat, energy
	shape : (720, 360, 10)
	ndim  : 3
	unit  : '' 
	dtype : float32 
```

### HpxNDMap
```
HpxNDMap

	geom  : HpxGeom 
 	axes  : skycoord, energy
	shape : (196608, 10)
	ndim  : 3
	unit  : '' 
	dtype : float32 
```
Note that there is an inconsistency with `ndim` and the shape, but this is intrinsic. The question is whether you count the coordinate axes as one or two for the hpx maps.

### MapAxis
```
MapAxis

	name       : energy    
	unit       : ''        
	nbins      : 10        
	node type  : center    
	center min : 1.0e+00   
	center max : 1.0e+01   
	interp     : lin  
```
```
MapAxis

	name       : energy    
	unit       : ''        
	nbins      : 10        
	node type  : edge      
	edge min   : 1.0e+00   
	edge max   : 1.0e+01   
	interp     : lin    
```
### MapCoord
```
MapCoord

	axes     : lon, lat, energy
	shape    : (720, 360, 10)
	ndim     : 3
	coordsys : CEL
```