### PR TITLE
Unifiy handling of numpy warnings and fixing various DeprecationWarnings

### DIFF
--- a/gammapy/data/obs_stats.py
+++ b/gammapy/data/obs_stats.py
@@ -59,8 +59,14 @@ class ObservationStats(Stats):
             self.alpha_obs = a_on / a_off
         else:
             self.alpha_obs = 0
-        self.gamma_rate = gamma_rate or self.excess / livetime
-        self.bg_rate = bg_rate or self.alpha_obs * n_off / livetime
+
+        if gamma_rate is None:
+            gamma_rate = self.excess / livetime
+        self.gamma_rate = gamma_rate
+
+        if bg_rate is None:
+            bg_rate =  self.alpha_obs * n_off / livetime
+        self.bg_rate = bg_rate
 
     @classmethod
     def from_obs(cls, obs, bg_estimate):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -320,8 +320,12 @@ class DataStoreObservation(object):
             Energy dependent psf table
         """
         offset = position.separation(self.pointing_radec)
-        energy = energy or self.psf.to_energy_dependent_table_psf(theta=offset).energy
-        rad = rad or self.psf.to_energy_dependent_table_psf(theta=offset).rad
+
+        if energy is None:
+            energy = self.psf.to_energy_dependent_table_psf(theta=offset).energy
+
+        if rad is None:
+            rad = self.psf.to_energy_dependent_table_psf(theta=offset).rad
 
         if isinstance(self.psf, PSF3D):
             # PSF3D is a table PSF, so we use the native RAD binning by default
@@ -435,8 +439,11 @@ class ObservationList(UserList):
         """
         psf = self[0].make_psf(position, energy, rad)
 
-        rad = rad or psf.rad
-        energy = energy or psf.energy
+        if rad is None:
+            rad = psf.rad
+        if energy is None:
+            energy = psf.energy
+
         exposure = psf.exposure
         psf_value = psf.psf_value.T * psf.exposure
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -836,7 +836,8 @@ class EnergyDispersion2D(object):
         vals = self.data.evaluate(offset=offset, e_true=e_true, migra=mig_array)
 
         # Compute normalized cumulative sum to prepare integration
-        tmp = np.nan_to_num(np.cumsum(vals) / np.sum(vals))
+        with np.errstate(invalid='ignore'):
+            tmp = np.nan_to_num(np.cumsum(vals) / np.sum(vals))
 
         # Determine positions (bin indices) of e_reco bounds in migration array
         pos_mig = np.digitize(migra_e_reco, mig_array) - 1

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -101,7 +101,9 @@ class IRFStacker(object):
 
             aefftedisp += edisp_data.transpose() * aefft_current
 
-        stacked_edisp = np.nan_to_num(aefftedisp / aefft)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            stacked_edisp = np.nan_to_num(aefftedisp / aefft)
+
         self.stacked_edisp = EnergyDispersion(
             e_true_lo=self.list_edisp[0].e_true.lo,
             e_true_hi=self.list_edisp[0].e_true.hi,

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -396,17 +396,16 @@ class EnergyDependentMultiGaussPSF(object):
         """
         # Convert energies to log center
         energies = self.energy
-
         # Defaults and input handling
-        if theta:
-            theta = Angle(theta)
-        else:
+        if theta is None:
             theta = Angle(0, 'deg')
-
-        if rad:
-            rad = Angle(rad).to('deg')
         else:
+            theta = Angle(theta)
+
+        if rad is None:
             rad = Angle(np.arange(0, 1.5, 0.005), 'deg')
+        else:
+            rad = Angle(rad).to('deg')
 
         psf_value = Quantity(np.zeros((energies.size, rad.size)), 'deg^-2')
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -380,7 +380,7 @@ class HpxNDMap(HpxMap):
 
             wts[pix[0] == -1] = 0.0
             wt[~np.isfinite(wt)] = 0.0
-            val += np.nansum(wts * wt * self.data.T[pix[:1] + pix_i], axis=0)
+            val += np.nansum(wts * wt * self.data.T[tuple(pix[:1] + pix_i)], axis=0)
 
         return val
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -846,8 +846,9 @@ class SpectrumObservationStacker(object):
             bkscal_off += (bkscal_on_data / bkscal_off_data) * obs.off_vector.counts_in_safe_range.value
             alpha_sum += (obs.alpha * obs.off_vector.counts_in_safe_range).sum()
 
-        stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
-        alpha_average = alpha_sum / self.stacked_off_vector.counts_in_safe_range.sum()
+        with np.errstate(divide='ignore', invalid='ignore'):
+            stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
+            alpha_average = alpha_sum / self.stacked_off_vector.counts_in_safe_range.sum()
 
         # there should be no nan values in backscal_on or backscal_off
         # this leads to problems when fitting the data

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -219,6 +219,7 @@ def _trapz_loglog(y, x, axis=-1, intervals=False):
     slice2 = [slice(None)] * y.ndim
     slice1[axis] = slice(None, -1)
     slice2[axis] = slice(1, None)
+    slice1, slice2 = tuple(slice1), tuple(slice2)
 
     # arrays with uncertainties contain objects
     if y.dtype == 'O':

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -49,9 +49,9 @@ def cash(n_on, mu_on):
       <http://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
     # suppress zero division warnings, they are corrected below
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         stat = 2 * (mu_on - n_on * np.log(mu_on))
-    stat[mu_on == 0] == 0
+        stat = np.where(mu_on > 0, stat, 0)
     return stat
 
 

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -22,7 +22,7 @@ def cash(n_on, mu_on):
     The Cash statistic is defined as:
 
     .. math::
-        C = 2 \left( n_{on} - n_{on} \log \mu_{on} \right)
+        C = 2 \left( \mu_{on} - n_{on} \log \mu_{on} \right)
 
     and :math:`C = 0` where :math:`\mu <= 0`.
     For more information see :ref:`fit-statistics`
@@ -48,14 +48,10 @@ def cash(n_on, mu_on):
     * `Cash 1979, ApJ 228, 939
       <http://adsabs.harvard.edu/abs/1979ApJ...228..939C>`_
     """
-    n_on = np.asanyarray(n_on, dtype=np.float64)
-    mu_on = np.asanyarray(mu_on, dtype=np.float64)
-
     # suppress zero division warnings, they are corrected below
-    with np.warnings.catch_warnings():
-        np.warnings.filterwarnings('ignore')
+    with np.errstate(divide='ignore'):
         stat = 2 * (mu_on - n_on * np.log(mu_on))
-    stat = np.where(mu_on > 0, stat, 0)
+    stat[~np.isfinite(stat)] == 0
     return stat
 
 
@@ -161,16 +157,14 @@ def wstat(n_on, n_off, alpha, mu_sig, mu_bkg=None, extra_terms=True):
     term1 = mu_sig + (1 + alpha) * mu_bkg
 
     # suppress zero division warnings, they are corrected below
-    with np.warnings.catch_warnings():
-        np.warnings.filterwarnings('ignore')
+    with np.errstate(divide='ignore'):
         term2_ = - n_on * np.log(mu_sig + alpha * mu_bkg)
     # Handle n_on == 0
     condition = (n_on == 0)
     term2 = np.where(condition, 0, term2_)
 
     # suppress zero division warnings, they are corrected below
-    with np.warnings.catch_warnings():
-        np.warnings.filterwarnings('ignore')
+    with np.errstate(divide='ignore'):
         term3_ = - n_off * np.log(mu_bkg)
     # Handle n_off == 0
     condition = (n_off == 0)
@@ -210,8 +204,7 @@ def get_wstat_gof_terms(n_on, n_off):
     term = np.zeros(len(n_on))
 
     # suppress zero division warnings, they are corrected below
-    with np.warnings.catch_warnings():
-        np.warnings.filterwarnings('ignore')
+    with np.errstate(divide='ignore'):
         term1 = - n_on * (1 - np.log(n_on))
         term2 = - n_off * (1 - np.log(n_off))
 

--- a/gammapy/stats/fit_statistics.py
+++ b/gammapy/stats/fit_statistics.py
@@ -51,7 +51,7 @@ def cash(n_on, mu_on):
     # suppress zero division warnings, they are corrected below
     with np.errstate(divide='ignore'):
         stat = 2 * (mu_on - n_on * np.log(mu_on))
-    stat[~np.isfinite(stat)] == 0
+    stat[mu_on == 0] == 0
     return stat
 
 
@@ -157,14 +157,14 @@ def wstat(n_on, n_off, alpha, mu_sig, mu_bkg=None, extra_terms=True):
     term1 = mu_sig + (1 + alpha) * mu_bkg
 
     # suppress zero division warnings, they are corrected below
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         term2_ = - n_on * np.log(mu_sig + alpha * mu_bkg)
     # Handle n_on == 0
     condition = (n_on == 0)
     term2 = np.where(condition, 0, term2_)
 
     # suppress zero division warnings, they are corrected below
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         term3_ = - n_off * np.log(mu_bkg)
     # Handle n_off == 0
     condition = (n_off == 0)
@@ -204,7 +204,7 @@ def get_wstat_gof_terms(n_on, n_off):
     term = np.zeros(len(n_on))
 
     # suppress zero division warnings, they are corrected below
-    with np.errstate(divide='ignore'):
+    with np.errstate(divide='ignore', invalid='ignore'):
         term1 = - n_on * (1 - np.log(n_on))
         term2 = - n_off * (1 - np.log(n_off))
 


### PR DESCRIPTION
This PR unifies the handling of numpy warnings by using the `np.errstate()` context manager. I did not review., whether it is justified to suppress the warnings. In addition a fixed two `DeprecationWarnings` related to quantities and using lists for indexing in numpy arrays.
.
  