### PR TITLE
Add exclusion mask handling to MapFit 

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -29,7 +29,7 @@ class MapFit(object):
         Exposure cube
     background : `~gammapy.maps.WcsNDMap`
         Background Cube
-    background : `~gammapy.maps.WcsNDMap`
+    exclusion_mask : `~gammapy.maps.WcsNDMap`
         Exclusion mask.
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -85,11 +85,11 @@ def sky_model():
 
 
 @pytest.fixture
-def exclusion_mask(geom, sky_model):
+def mask(geom, sky_model):
     p = sky_model.spatial_model.parameters
     center = SkyCoord(p['lon_0'].value, p['lat_0'].value, frame='galactic', unit='deg')
     circle = CircleSkyRegion(center=center, radius=1 * u.deg)
-    data = geom.region_mask([circle], inside=False)
+    data = geom.region_mask([circle])
     return WcsNDMap(geom=geom, data=data)
 
 
@@ -109,7 +109,7 @@ def counts(sky_model, exposure, background, psf, edisp):
 @requires_dependency('scipy')
 @requires_dependency('iminuit')
 @requires_data('gammapy-extra')
-def test_cube_fit(sky_model, counts, exposure, psf, background, exclusion_mask, edisp):
+def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):
     sky_model.parameters['lon_0'].value = 0.5
     sky_model.parameters['lat_0'].value = 0.5
     sky_model.parameters['index'].value = 2
@@ -120,7 +120,7 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, exclusion_mask, 
         counts=counts,
         exposure=exposure,
         background=background,
-        exclusion_mask=exclusion_mask,
+        mask=mask,
         psf=psf,
         edisp=edisp,
     )


### PR DESCRIPTION
This PR implements the handling of an exclusion mask in the `MapFit` object. I tried a few possible implementations, such as applying the exclusion mask to the `stat` array and in the `total_stat()` method.
In the end the most efficient solution was to apply the mask directly to the exposure map and setting the exposure of the corresponding pixels to zero. The downside is, that the exposure map is now different for `MapFit` and `MapEvaluater`. There the question whether `MapEvaluater` should take an exclasion mask as well. I was sure whether this makes sense, but maybe it does?