### PR TITLE
Add test for KernelBackgroundEstimator without defaults

### DIFF
--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -87,7 +87,7 @@ class KernelBackgroundEstimator(object):
         # initial mask, if not present
         if 'exclusion' not in images:
             exclusion = Map.from_geom(images['counts'].geom)
-            exclusion += 1
+            exclusion.data += 1
             images['exclusion'] = exclusion
 
         # initial background estimate, if not present

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -70,9 +70,7 @@ def test_run(kbe, images):
 
 @requires_data('gammapy-extra')
 def test_run_without_defaults(kbe, images):
-    images.pop('exclusion')
-    images.pop('background')
-    result = kbe.run(images)
+    result = kbe.run({'counts': images['counts']})
     mask, background = result['exclusion'].data, result['background'].data
 
     assert_allclose(mask.sum(), 89)

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -66,3 +66,15 @@ def test_run(kbe, images):
     assert_allclose(mask.sum(), 89)
     assert_allclose(background, 42 * np.ones((10, 10)))
     assert len(kbe.images_stack) == 4
+
+
+@requires_data('gammapy-extra')
+def test_run_without_defaults(kbe, images):
+    images.pop('exclusion')
+    images.pop('background')
+    result = kbe.run(images)
+    mask, background = result['exclusion'].data, result['background'].data
+
+    assert_allclose(mask.sum(), 89)
+    assert_allclose(background, 42 * np.ones((10, 10)))
+    assert len(kbe.images_stack) == 4


### PR DESCRIPTION
I think there was a :bug: in the ``KernelBackgroundEstimator``. @adonath - can you check?