### PR TITLE
Update parameter scaling mechanism

### DIFF
--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -33,9 +33,6 @@ def fit_iminuit(parameters, function, opts_minuit=None):
     """
     from iminuit import Minuit
 
-    if parameters.covariance is None:
-        parameters.scale()
-
     minuit_func = MinuitFunction(function, parameters)
 
     if opts_minuit is None:
@@ -105,10 +102,7 @@ def make_minuit_par_kwargs(parameters):
         max_ = None if np.isnan(par.max) else par.max
         kwargs['limit_{}'.format(parname_)] = (min_, max_)
 
-        if parameters.covariance is None:
-            kwargs['error_{}'.format(parname_)] = 1
-        else:
-            kwargs['error_{}'.format(parname_)] = parameters.error(idx)
+        kwargs['error_{}'.format(parname_)] = 1
 
         if par.frozen:
             kwargs['fix_{}'.format(parname_)] = True

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -33,6 +33,9 @@ def fit_iminuit(parameters, function, opts_minuit=None):
     """
     from iminuit import Minuit
 
+    if parameters.apply_autoscale:
+        parameters.autoscale()
+
     minuit_func = MinuitFunction(function, parameters)
 
     if opts_minuit is None:

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -57,7 +57,7 @@ def fit_sherpa(parameters, function, optimizer='simplex'):
     optimizer = get_sherpa_optimiser(optimizer)
 
     if parameters.covariance is None:
-        parameters.scale()
+        parameters.autoscale()
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -172,9 +172,11 @@ class Parameter(object):
         """
         if method == 'scale10':
             value = self.value
-            scale = 10 ** int(np.log10(value))
-            self.factor = value / scale
-            self.scale = scale
+            if value != 0:
+                power = int(np.log10(np.absolute(value)))
+                scale = 10 ** power
+                self.factor = value / scale
+                self.scale = scale
         elif method == 'factor1':
             self.factor, self.scale = 1, self.value
         else:

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -192,14 +192,18 @@ class Parameters(object):
     ----------
     parameters : list of `Parameter`
         List of parameters
-    covariance : `~numpy.ndarray`
+    covariance : `~numpy.ndarray`, optional
         Parameters covariance matrix.
         Order of values as specified by `parameters`.
+    apply_autoscale : bool, optional
+        Flag for optimizers, if True parameters are autoscaled before the fit,
+        see `~gammapy.utils.modeling.Parameter.autoscale`
     """
 
-    def __init__(self, parameters, covariance=None):
+    def __init__(self, parameters, covariance=None, apply_autoscale=True):
         self._parameters = parameters
         self.covariance = covariance
+        self.apply_autoscale = apply_autoscale
 
     def _init_covar(self):
         if self.covariance is None:

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -154,6 +154,32 @@ class Parameter(object):
             frozen=self.frozen,
         )
 
+    def autoscale(self, method='scale10'):
+        """Autoscale the parameters.
+
+        Set ``factor`` and ``scale`` according to ``method``
+
+        Available methods:
+
+        * ``scale10`` sets ``scale`` to power of 10,
+          so that factor is in the range 1 to 10
+        * ``factor1`` sets ``factor, scale = 1, value``
+
+        Parameters
+        ----------
+        method : {'factor1', 'scale10'}
+            Method to apply
+        """
+        if method == 'scale10':
+            value = self.value
+            scale = 10 ** int(np.log10(value))
+            self.factor = value / scale
+            self.scale = scale
+        elif method == 'factor1':
+            self.factor, self.scale = 1, self.value
+        else:
+            raise ValueError('Invalid method: {}'.format(method))
+
 
 class Parameters(object):
     """List of `~gammapy.spectrum.models.Parameter`
@@ -366,19 +392,11 @@ class Parameters(object):
         scale_matrix = scales[:, np.newaxis] * scales
         self.covariance = scale_matrix * matrix
 
-    def scale(self, method='scale10'):
-        """Re-scale the parameters.
+    def autoscale(self, method='scale10'):
+        """Autoscale all parameters.
 
-        By re-scale, we mean to change ``factor`` and ``scale``,
-        keeping the ``value = factor x scale`` the same.
-
-        You can call this method before fitting.
-
-        Available methods:
-
-        * ``scale10`` sets ``scale`` to power of 10,
-          so that factor is in the range 1 to 10
-        * ``factor1`` sets ``factor, scale = 1, value``
+        see :func:`~gammapy.utils.modelling.Parameter.autoscale`
+        
 
         Parameters
         ----------
@@ -386,12 +404,4 @@ class Parameters(object):
             Method to apply
         """
         for par in self.parameters:
-            if method == 'scale10':
-                value = par.value
-                scale = 10 ** int(np.log10(value))
-                par.factor = value / scale
-                par.scale = scale
-            elif method == 'factor1':
-                par.factor, par.scale = 1, par.value
-            else:
-                raise ValueError('Invalid method: {}'.format(method))
+            par.autoscale(method)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -125,6 +125,8 @@ def test_parameters_scale():
         Parameter('', factor=10, scale=5),
         Parameter('', factor=10, scale=50),
         Parameter('', factor=100, scale=5),
+        Parameter('', factor=-10, scale=1),
+        Parameter('', factor=0, scale=1),
     ])
 
     pars.autoscale()  # default: 'scale10'
@@ -135,6 +137,10 @@ def test_parameters_scale():
     assert_allclose(pars[1].scale, 100)
     assert_allclose(pars[2].factor, 5)
     assert_allclose(pars[2].scale, 100)
+    assert_allclose(pars[3].factor, -1)
+    assert_allclose(pars[3].scale, 10)
+    assert_allclose(pars[4].factor, 0)
+    assert_allclose(pars[4].scale, 1)
 
     pars.autoscale('factor1')
 
@@ -144,3 +150,7 @@ def test_parameters_scale():
     assert_allclose(pars[1].scale, 500)
     assert_allclose(pars[2].factor, 1)
     assert_allclose(pars[2].scale, 500)
+    assert_allclose(pars[3].factor, 1)
+    assert_allclose(pars[3].scale, -10)
+    assert_allclose(pars[4].factor, 1)
+    assert_allclose(pars[4].scale, 0)

--- a/gammapy/utils/tests/test_modeling.py
+++ b/gammapy/utils/tests/test_modeling.py
@@ -127,7 +127,7 @@ def test_parameters_scale():
         Parameter('', factor=100, scale=5),
     ])
 
-    pars.scale()  # default: 'scale10'
+    pars.autoscale()  # default: 'scale10'
 
     assert_allclose(pars[0].factor, 5)
     assert_allclose(pars[0].scale, 10)
@@ -136,7 +136,7 @@ def test_parameters_scale():
     assert_allclose(pars[2].factor, 5)
     assert_allclose(pars[2].scale, 100)
 
-    pars.scale('factor1')
+    pars.autoscale('factor1')
 
     assert_allclose(pars[0].factor, 1)
     assert_allclose(pars[0].scale, 50)


### PR DESCRIPTION
This PR
* Add support for parameters with negative and zero values (thereby fixing #1698)
* Removes the possibility to set the minuit stepsize via the covariance matrix
* Introduces an ``apply_autoscale`` flag to ``ParameterList`` in order to turn off the parameter autoscaling in the fit