### PR TITLE
Clean up TableModel implementation

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -117,5 +117,5 @@ class PrimaryFlux(object):
         return TableModel(
             energy=energies,
             values=dN_dE,
-            scale_logy=False
+            interp='lin'
         )

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -215,7 +215,7 @@ def test_table_model_from_file():
     filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
     absorption_z03 = TableModel.read_xspec_model(filename=filename, param=0.3)
     absorption_z03.plot(energy_range=(0.03, 10),
-                        energy_unit=u.TeV)
+                        energy_unit=u.TeV, flux_unit='')
 
 
 @requires_data('gammapy-extra')


### PR DESCRIPTION
This PR cleans up the implementation of the `TableModel` class in `gammapy.spectrum`. It removes the `.plot()` method, because it is already in the base class. The case of linear y axis scaling was replaced by a docs example how to modify the y scale. Note that the test reference values remain unchanged.