### PR TITLE
Links specific notebooks in Binder

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -52,14 +52,7 @@ If you have any questions, ask for help. See http://gammapy.org/contact.html
 Execute tutorials online
 ------------------------
 
-If you want, you can execute latest version of the collection of notebooks
-on-line accessing the `Gammapy Binder
-<http://mybinder.org/repo/gammapy/gammapy-extra>`__ space.
-
-Click the "launch binder" link here, or at the top of each notebook below:
-
-.. image:: http://mybinder.org/badge.svg
-    :target: http://mybinder.org/repo/gammapy/gammapy-extra
+You can execute the notebooks on-line, click on the **Try online in Binder** link at the top of each of the notebooks below.
 
 Note that this is a free, temporary notebook server. You cannot upload your data
 or save your work there. For that, install Gammapy on your machine and work

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -52,11 +52,13 @@ If you have any questions, ask for help. See http://gammapy.org/contact.html
 Execute tutorials online
 ------------------------
 
-You can execute the notebooks on-line, click on the **Try online in Binder** link at the top of each of the notebooks below.
+.. image:: http://mybinder.org/badge.svg
 
-Note that this is a free, temporary notebook server. You cannot upload your data
-or save your work there. For that, install Gammapy on your machine and work
-there.
+You can execute the notebooks on-line.
+Just click on the *launch binder* badge placed at the top of each of the notebooks below.
+
+Note that this is a free, temporary notebook server. You cannot save your work there and retrieve it afterwards.
+For that, install Gammapy on your machine and work there.
 
 The basics
 ----------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -35,7 +35,7 @@ dependencies:
   - pytest
   - pytest-cov
   - sphinx
-  - pandoc
+  - pandoc==2.1.3
   - pylint
   - flake8
   - pip:

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -124,8 +124,8 @@ def modif_nb_links(folder, url_docs, git_commit):
 <div class='alert alert-info'>
 **This is a fixed-text formatted version of a Jupyter notebook.**
 
-- [Try online in Binder](https://mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?urlpath=lab/tree/{nb_filename}).
-- You can also contribute with your own notebooks in this
+- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?urlpath=lab/tree/{nb_filename})
+- You can contribute with your own notebooks in this
 [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 - **Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -89,7 +89,7 @@ def make_link_node(rawtext, app, refuri, notebook, options):
 
     relpath = refuri.split(str(Path('/gammapy/docs')))[1]
     foldersplit = relpath.split(os.sep)
-    base = '../' * (len(foldersplit) - 2) + 'notebooks' + os.sep
+    base = (('..' + os.sep) * (len(foldersplit) - 2)) + 'notebooks' + os.sep
     full_name = notebook + '.html'
     ref = base + full_name
     roles.set_classes(options)
@@ -124,8 +124,7 @@ def modif_nb_links(folder, url_docs, git_commit):
 <div class='alert alert-info'>
 **This is a fixed-text formatted version of a Jupyter notebook.**
 
-- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?urlpath=lab)
- and then double-click on **{nb_filename}** file.
+- [Try online in Binder](https://mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?urlpath=lab/tree/{nb_filename}).
 - You can also contribute with your own notebooks in this
 [GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
 - **Source files:**


### PR DESCRIPTION
This PR enables direct links to specific notebooks in Binder JupyterLab interface from the static tutorials, instead of a generic link landing in the notebooks directory. 

It also removes the link to Binder from the `tutorials.rst` file, so all links to Binder versions may be dynamically configured with `git_commit` param in the `setup.cfg`  configuration file. 