### PR TITLE
Improve plot_interactive() method

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -967,16 +967,16 @@ class Map(object):
 
         """
         import matplotlib as mpl
-        from ipywidgets.widgets.interaction import interact, fixed
-        from ipywidgets import SelectionSlider, RadioButtons
         import matplotlib.pyplot as plt
+        from ipywidgets.widgets.interaction import interact
+        from ipywidgets import SelectionSlider, RadioButtons
 
         kwargs.setdefault('interpolation', 'nearest')
         kwargs.setdefault('origin', 'lower')
         kwargs.setdefault('cmap', 'afmhot')
 
         rc_params = rc_params or {}
-        stretch = kwargs.pop('stretch', None) or 'sqrt'
+        stretch = kwargs.pop('stretch', 'sqrt')
 
         if self.geom.is_image:
             raise TypeError('Use .plot() for 2D Maps')

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -976,6 +976,7 @@ class Map(object):
         kwargs.setdefault('cmap', 'afmhot')
 
         rc_params = rc_params or {}
+        stretch = kwargs.pop('stretch', None) or 'sqrt'
 
         if self.geom.is_image:
             raise TypeError('Use .plot() for 2D Maps')
@@ -986,7 +987,7 @@ class Map(object):
         @interact(
             idx=IntSlider(min=0, max=map_axis.nbin - 1, step=1, value=0,
                                     description=axis + ' idx'),
-            stretch=RadioButtons(options=['linear', 'sqrt', 'log'], value='sqrt',
+            stretch=RadioButtons(options=['linear', 'sqrt', 'log'], value=stretch,
                                          description='Plot stretch'),
         )
         def _plot_interactive(idx, stretch):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -934,6 +934,71 @@ class Map(object):
         """
         pass
 
+    def plot_interactive(self, axis=None, **kwargs):
+        """
+        Plot map with interactive widgets to explore the non spatial axes.
+
+        Parameters
+        ----------
+        axis : str
+            Axis name to slide through, with the interactive slider. By default
+            the first non-spatial axis is used.
+        **kwargs : dict
+            Keyword arguments passed to `WcsND.plot()`.
+
+        Examples
+        --------
+
+        You can try this out e.g. using a Fermi-LAT diffuse model cube with an energy axis::
+
+            %matplotlib inline
+            from gammapy.maps import Map
+
+            m = Map.read("$GAMMAPY_EXTRA/datasets/vela_region/gll_iem_v05_rev1_cutout.fits")
+            m.plot_interactive(cmap='gnuplot2')
+
+        If you would like to adjust the figure size you can use the `matplotlib.rc_context()`
+        context manager.
+
+            import matplotlib as mpl
+            with mpl.rc_context(rc={'figure.figsize': (12, 6)}):
+                m.plot_interactive()
+
+        """
+        from ipywidgets.widgets.interaction import interact, fixed
+        from ipywidgets import IntSlider, RadioButtons
+        import matplotlib.pyplot as plt
+
+        kwargs.setdefault('interpolation', 'nearest')
+        kwargs.setdefault('origin', 'lower')
+        kwargs.setdefault('cmap', 'afmhot')
+
+        if self.geom.is_image:
+            raise TypeError('Use .plot() for 2D Maps')
+
+        axis = axis or self.geom.axes[0].name
+        map_axis = self.geom.get_axis_by_name(axis)
+
+        @interact(
+            idx=IntSlider(min=0, max=map_axis.nbin - 1, step=1, value=0,
+                                    description=axis + ' idx'),
+            stretch=RadioButtons(options=['linear', 'sqrt', 'log'], value='sqrt',
+                                         description='Plot stretch'),
+        )
+        def _plot_interactive(idx, stretch):
+            img = self.get_image_by_idx([idx])
+            fig, ax, cbar = img.plot(stretch=stretch, **kwargs)
+
+            if map_axis.node_type == 'edge':
+                edges = map_axis.edges
+                title = '{:.0f} - {:.0f} '.format(edges[idx], edges[idx + 1])
+            else:
+                center = map_axis.center
+                title = '{:.0f} '.format(center[idx])
+            title += str(map_axis.unit)
+            ax.set_title(title)
+            plt.show()
+
     def copy(self, **kwargs):
         """Copy map instance and overwrite given attributes, except for geometry.
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -170,7 +170,7 @@ class HpxNDMap(HpxMap):
 
         # FIXME: Should reimplement instantiating map first and fill data array
         hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize)
-        return WcsNDMap(wcs, wcs_data)
+        return WcsNDMap(wcs, wcs_data, unit=self.unit)
 
     def iter_by_image(self):
         for idx in np.ndindex(self.geom.shape):
@@ -470,7 +470,7 @@ class HpxNDMap(HpxMap):
 
         return map_out
 
-    def plot(self, method='raster', ax=None, idx=None, normalize=False, proj='AIT', oversample=4,
+    def plot(self, method='raster', ax=None, normalize=False, proj='AIT', oversample=2,
              width_pix=1000, **kwargs):
         """Quickplot method.
 
@@ -498,9 +498,6 @@ class HpxNDMap(HpxMap):
             be set to the number of pixels satisfying ``oversample``
             or ``width_pix`` whichever is smaller.  If this parameter
             is None then the width will be set from ``oversample``.
-        idx : tuple
-            Set the image slice to plot if this map has non-spatial
-            dimensions.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.imshow`.
         Returns

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -482,10 +482,7 @@ class WcsNDMap(WcsMap):
 
         # Grid and ticks
         glon_spacing, glat_spacing = 45, 15
-        try:
-            lon, lat = ax.coords['glon'], ax.coords['glat']
-        except KeyError:
-            lon, lat = ax.coords['ra'], ax.coords['dec']
+        lon, lat = ax.coords
         lon.set_ticks(spacing=glon_spacing * u.deg, color='w', alpha=0.8)
         lat.set_ticks(spacing=glat_spacing * u.deg)
         lon.set_ticks_visible(False)


### PR DESCRIPTION
This PR improves the `.plot_interactive()` method in the following ways:

* Reuse `.plot()` for the plotting of images
* Move `.plot_interactive()` to the `Map` base class, so that it works for hpx maps as well
* Add an `axis` argument to `.plot_interactive()` to choose the axis for which to have the slider
* Add a `rc_params` argument to `.plot_interactive()` to allow users to easily style the plot. Typically
this is done outside the plotting function with `with mpl.rc_context():`, but for some reason this does not work with interactive plotting so I decided to pass the options.
* If the users passes `.plot_interactive(stretch='something')` this is now used as the default.
* The axis title is now set depending on the node type of the axis. For `edges` an interval is given, while for `center` the center value is shown per bin.
* Replace `IntSlider` with a `SelectionSlider` so that e.g. energy ranges can be chosen directly, without having to wait for the plotting. I also changed to `continuous_update=False`, to avoid dragging of the plot, when sliding through the whole range of values. 
* Add an option for nicer all-sky plots to `.plot()`

This is what the all-sky plot and selection slider looks like now:
![plot_interactive_allsky](https://user-images.githubusercontent.com/3715928/44266500-0cfcfd00-a22b-11e8-9f5c-9a5d8cc436a0.png)
