### PR TITLE
Remove copy option in gammapy.maps get_image, slice and cutout methods

### DIFF
--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -219,10 +219,10 @@ class AdaptiveRingBackgroundEstimator(object):
         result['alpha'] = exposure_on_map.copy(unit='')
         result['background'] = exposure_on_map.copy(unit='')
 
-        for img, idx in counts_map.iter_by_image():
-            counts = counts_map.get_image_by_idx(idx, copy=False)
-            exposure_on = exposure_on_map.get_image_by_idx(idx, copy=False)
-            exclusion = exclusion_map.get_image_by_idx(idx, copy=False)
+        for idx in np.ndindex(counts_map.geom.shape):
+            counts = counts_map.get_image_by_idx(idx)
+            exposure_on = exposure_on_map.get_image_by_idx(idx)
+            exclusion = exclusion_map.get_image_by_idx(idx)
 
             cubes = OrderedDict()
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -556,7 +556,7 @@ class Map(object):
         data = self.data[slices[::-1]]
         return self.__class__(geom=geom, data=data, unit=self.unit, meta=self.meta)
 
-    def get_image_by_coord(self, coords, copy=True):
+    def get_image_by_coord(self, coords):
         """Return spatial map at the given axis coordinates.
 
         Parameters
@@ -565,8 +565,6 @@ class Map(object):
             Tuple should be ordered as (x_0, ..., x_n) where x_i are coordinates
             for non-spatial dimensions of the map. Dict should specify the axis
             names of the non-spatial axes such as {'axes0': x_0, ..., 'axesn': x_n}.
-        copy : bool
-            Whether to make a copy of the data.
 
         Examples
         --------
@@ -625,9 +623,9 @@ class Map(object):
         for axis, value in zip(self.geom.axes, coords.values()):
             idx.append(axis.coord_to_idx(value))
 
-        return self.get_image_by_idx(idx, copy=copy)
+        return self.get_image_by_idx(idx)
 
-    def get_image_by_pix(self, pix, copy=True):
+    def get_image_by_pix(self, pix):
         """Return spatial map at the given axis pixel coordinates
 
         Parameters
@@ -636,8 +634,6 @@ class Map(object):
             Tuple of scalar pixel coordinates for each non-spatial dimension of
             the map. Tuple should be ordered as (I_0, ..., I_n). Pixel coordinates
             can be either float or integer type.
-        copy : bool
-            Whether to make a copy of the data.
 
         See Also
         --------
@@ -649,9 +645,9 @@ class Map(object):
             Map with spatial dimensions only.
         """
         idx = self.geom.pix_to_idx(pix)
-        return self.get_image_by_idx(idx, copy=copy)
+        return self.get_image_by_idx(idx)
 
-    def get_image_by_idx(self, idx, copy=True):
+    def get_image_by_idx(self, idx):
         """Return spatial map at the given axis pixel indices.
 
         Parameters
@@ -659,8 +655,6 @@ class Map(object):
         idx : tuple
             Tuple of scalar indices for each non spatial dimension of the map.
             Tuple should be ordered as (I_0, ..., I_n).
-        copy : bool
-            Whether to make a copy of the data.
 
         See Also
         --------
@@ -680,8 +674,6 @@ class Map(object):
 
         geom = self.geom.to_image()
         data = self.data[idx[::-1]]
-        if copy:
-            data = data.copy()
         return self.__class__(geom=geom, data=data, unit=self.unit, meta=self.meta)
 
     def get_by_coord(self, coords):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -533,7 +533,7 @@ class Map(object):
         """
         pass
 
-    def slice_by_idx(self, slices, copy=False):
+    def slice_by_idx(self, slices):
         """Slice sub map from map object.
 
         For usage examples, see :ref:`mapslicing`.
@@ -545,8 +545,6 @@ class Map(object):
             element for each non-spatial dimension. For integer indexing the
             correspoding axes is dropped from the map. Axes not specified in the
             dict are kept unchanged.
-        copy : bool
-            Whether to make a copy of the data.
 
         Returns
         -------
@@ -556,9 +554,6 @@ class Map(object):
         geom = self.geom.slice_by_idx(slices)
         slices = tuple([slices.get(ax.name, slice(None)) for ax in self.geom.axes])
         data = self.data[slices[::-1]]
-
-        if copy:
-            data = data.copy()
         return self.__class__(geom=geom, data=data, unit=self.unit, meta=self.meta)
 
     def get_image_by_coord(self, coords, copy=True):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -191,7 +191,7 @@ def lonlat_to_skycoord(lon, lat, coordsys):
     return SkyCoord(lon, lat, frame=coordsys_to_frame(coordsys), unit='deg')
 
 
-def pix_tuple_to_idx(pix, copy=False):
+def pix_tuple_to_idx(pix):
     """Convert a tuple of pixel coordinate arrays to a tuple of pixel
     indices.
 
@@ -201,9 +201,6 @@ def pix_tuple_to_idx(pix, copy=False):
     ----------
     pix : tuple
         Tuple of pixel coordinates with one element for each dimension.
-
-    copy : bool
-        Flag to set whether a copy or view is returned.
 
     Returns
     -------

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -831,7 +831,9 @@ class HpxGeom(MapGeom):
 
     def pix_to_idx(self, pix, clip=False):
         # FIXME: Look for better method to clip HPX indices
-        idx = list(pix_tuple_to_idx(pix, copy=True))
+        # TODO: copy idx to avoid modifying input pix?
+        # pix_tuple_to_idx seems to always make a copy!?
+        idx = pix_tuple_to_idx(pix)
         idx_local = self.global_to_local(idx)
         for i, _ in enumerate(idx):
 
@@ -1564,7 +1566,6 @@ class HpxGeom(MapGeom):
         wcs : `~gammapy.maps.WcsGeom`
             WCS geometry
         """
-        skydir = self.center_skydir.copy()
         binsz = np.min(get_pix_size_from_nside(self.nside)) / oversample
         width = (2.0 * self._get_region_size() +
                  np.max(get_pix_size_from_nside(self.nside)))
@@ -1580,10 +1581,8 @@ class HpxGeom(MapGeom):
         else:
             axes = copy.deepcopy(self.axes)
 
-        geom = WcsGeom.create(width=width, binsz=binsz, coordsys=self.coordsys,
-                              axes=axes, skydir=skydir, proj=proj)
-
-        return geom
+        return WcsGeom.create(width=width, binsz=binsz, coordsys=self.coordsys,
+                              axes=axes, skydir=self.center_skydir, proj=proj)
 
     def get_idx(self, idx=None, local=False, flat=False):
         if idx is not None and np.any(np.array(idx) >= np.array(self._shape)):

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -131,11 +131,11 @@ def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
 
     slices = {'energy': 0,
               'time': 1}
-    sliced = m.slice_by_idx(slices, copy=True)
+    sliced = m.slice_by_idx(slices)
     assert sliced.geom.is_image
     slices = tuple([slices[ax.name] for ax in m.geom.axes])
     assert_equal(m.data[slices[::-1]], sliced.data)
-    assert sliced.data.base is not data
+    assert sliced.data.base is data
 
 
 @pytest.mark.parametrize('map_type', ['wcs', 'hpx', 'hpx-sparse'])

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -482,11 +482,6 @@ class WcsGeom(MapGeom):
         header['WCSSHAPE'] = '({})'.format(shape)
         return header
 
-    def distance_to_edge(self, skydir):
-        """Angular distance from the given direction and
-        the edge of the projection."""
-        raise NotImplementedError
-
     def get_image_shape(self, idx):
         """Get the shape of the image plane at index ``idx``."""
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -490,9 +490,6 @@ class WcsGeom(MapGeom):
         else:
             return int(self.npix[0][idx]), int(self.npix[1][idx])
 
-    def get_image_wcs(self, idx):
-        raise NotImplementedError
-
     def get_idx(self, idx=None, flat=False):
         pix = self.get_pix(idx=idx, mode='center')
         if flat:

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -640,10 +640,12 @@ class WcsGeom(MapGeom):
         return tuple(coords)
 
     def pix_to_idx(self, pix, clip=False):
-        idxs = pix_tuple_to_idx(pix, copy=True)
+        # TODO: copy idx to avoid modifying input pix?
+        # pix_tuple_to_idx seems to always make a copy!?
+        idxs = pix_tuple_to_idx(pix)
         if not self.is_regular:
             ibin = [pix[2 + i] for i, ax in enumerate(self.axes)]
-            ibin = pix_tuple_to_idx(ibin, copy=True)
+            ibin = pix_tuple_to_idx(ibin)
             for i, ax in enumerate(self.axes):
                 np.clip(ibin[i], 0, ax.nbin - 1, out=ibin[i])
             npix = (self.npix[0][ibin], self.npix[1][ibin])

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -587,7 +587,7 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(data=convolved_data)
 
-    def cutout(self, position, width, mode='trim', copy=True):
+    def cutout(self, position, width, mode='trim'):
         """
         Create a cutout around a given position.
 
@@ -600,14 +600,11 @@ class WcsNDMap(WcsMap):
             If only one value is passed, a square region is extracted.
         mode : {'trim', 'partial', 'strict'}
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
-        copy : bool, optional
-               If False (default), then the cutout data will be a view into the original data  array.
-               If True, then the cutout data will hold a copy of the original data array.
 
         Returns
         -------
         cutout : `~gammapy.maps.WcsNDMap`
-            The cutout map itself
+            Cutout map
         """
         width = _check_width(width)
         idx = (0,) * len(self.geom.axes)
@@ -625,8 +622,5 @@ class WcsNDMap(WcsMap):
 
         geom = WcsGeom(c2d.wcs, c2d.shape[::-1], axes=self.geom.axes)
         data = self.data[cutout_slices]
-
-        if copy:
-            data = data.copy()
 
         return self._init_copy(geom=geom, data=data)


### PR DESCRIPTION
This PR removes the copy option in the gammapy.maps get_image and slice methods. @adonath and I discussed this offline, and find that it's simpler to not offer that option all over the place, but to return views of data numpy arrays always, and let the calling code call `.copy` on the return value if they really need to.

This way it's simple, and fast by default. The drawback here is that a few users will modify the return value and be surprised that the original changes. But that will also happen for them when using Python lists or Numpy arrays, so users just have to learn what a view of a Numpy array is. And it's actually rare in practice to modify `.data` manually and get bitten by this.

The code that loops over image planes in ring.py is probably buggy if there's 2 or more extra axes. @adonath will have a look and send a follow-up PR.

@adonath - Please have a look.