### PR TITLE
Fix Sphinx nitpicky warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,7 +301,7 @@ See the complete `Gammapy 0.7 merged pull requests list on Github <https://githu
 - [#1246] Improve map read method (Matthew Wood)
 - [#1240] Finish change to Click in gammapy.scripts (Christoph Deil)
 - [#1238] Clean up catalog image code (Axel Donath)
-- [#1235] Introduce main `gammapy` command line tool (Axel Donath and Christoph Deil)
+- [#1235] Introduce main ``gammapy`` command line tool (Axel Donath and Christoph Deil)
 - [#1227] Remove gammapy-data-show and gammapy-cube-bin (Christoph Deil)
 - [#1226] Make DataStoreObservation properties less lazy (Christoph Deil)
 - [#1220] Fix flux point computation for non-power-law models (Axel Donath)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,7 +89,7 @@ This list is incomplete. Small improvements and bug fixes are not listed here.
 See the complete `Gammapy 0.8 merged pull requests list on Github <https://github.com/gammapy/gammapy/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A0.8+is%3Amerged+>`__.
 
 - [#1696] Add paramter auto scale (Johannes Kind and Christoph Deil)
-- [#1695] Add WCSNDMap convolve method (Axel Donath)
+- [#1695] Add WcsNDMap convolve method (Axel Donath)
 - [#1685] Add quantity support to map coordinates (Axel Donath)
 - [#1681] Add make_images method in MapMaker (Axel Donath)
 - [#1675] Add gammapy.stats.excess_matching_significance (Christoph Deil)

--- a/docs/astro/darkmatter/index.rst
+++ b/docs/astro/darkmatter/index.rst
@@ -24,7 +24,6 @@ The spectral models in `gammapy.astro.darkmatter.PrimaryFlux` are based on
 annihilation channels). These models are most commonly used in VHE dark matter
 analyses.
 
-
 Other packages
 ==============
 
@@ -74,7 +73,7 @@ profiles.
 The DMFitFunction is also implemented in `fermipy.spectrum.DMFitFunction`_.
 It is a spectral model based on `Jeltema & Profuma 2008`_. From a quick look I
 didn't see where they get the spectral template from (obviously not `Cirelli et
-al. 2011`_) but `DarkSUSY_` is mentioned in the paper.
+al. 2011`_) but `DarkSUSY`_ is mentioned in the paper.
 
 DMFitFunction is also implemented in `astromodels`_.
 
@@ -97,12 +96,11 @@ gamLike
 `GamLike`_ contains likelihood functions for most leading gamma-ray indirect
 searches for dark matter, including Fermi-LAT observations of dwarfs and the
 Galactic Centre (GC), HESS observations of the GC, and projected sensitivites
-for CTA observations of the GC. It is released in tandem with the `GAMBIT_`
+for CTA observations of the GC. It is released in tandem with the `GAMBIT`_
 module `DarkBit`_.  DarkBit can be used for directly computing observables and
 likelihoods, for any combination of parameter values in some underlying
 particle model. GamLike can somehow be use to reproduce HESS results (Section
 6.2.2. of the DarkBit paper). But I don't fully understand how.
-
 
 Using `gammapy.spectrum`
 ========================
@@ -122,34 +120,18 @@ Reference/API
     :no-inheritance-diagram:
     :include-all-objects:
 
-
 .. _GammaLib 1.3 release: http://cta.irap.omp.eu/gammalib-devel/admin/release_history/1.3.html
 .. _Feature request #1520:  https://cta-redmine.irap.omp.eu/issues/1520
 .. _Cirelli et al. 2011: http://iopscience.iop.org/article/10.1088/1475-7516/2011/03/051/pdf
 .. _Cirelli 2014: http://www.marcocirelli.net/otherworks/HDR.pdf
-
 .. _DMFitFunction: https://fermi.gsfc.nasa.gov/ssc/data/analysis/scitools/source_models.html#DMFitFunction
-
 .. _fermipy/dmsky: https://github.com/fermiPy/dmsky
-
 .. _fermipy/dmpipe: https://github.com/fermiPy/dmpipe
-
 .. _fermipy.spectrum.DMFitFunction: https://github.com/fermiPy/fermipy/blob/1c2291a4cbdf30f3940a472bcce2a45984c339a6/fermipy/spectrum.py#L504
-
 .. _Jeltema & Profuma 2008: http://iopscience.iop.org/article/10.1088/1475-7516/2008/11/003/meta
-
 .. _astromodels: https://github.com/giacomov/astromodels/blob/master/astromodels/functions/dark_matter/dm_models.py
-
 .. _CLUMPY: http://lpsc.in2p3.fr/clumpy/
-
 .. _DarkSUSY: http://www.darksusy.org/
-
 .. _GamLike: https://bitbucket.org/weniger/gamlike
-
 .. _GAMBIT: https://gambit.hepforge.org/
-
 .. _DarkBit: https://link.springer.com/article/10.1140%2Fepjc%2Fs10052-017-5155-4
-
-
-
-

--- a/docs/astro/index.rst
+++ b/docs/astro/index.rst
@@ -15,8 +15,8 @@ This module contains utility functions for some astrophysical scenarios:
 * `gammapy.astro.population` for astrophysical population models
 * `gammapy.astro.darkmatter` for dark matter spatial and spectral models
 
-The `gammapy.astro` module is in a prototyping phase and its scope and future
-are currently beeing discussed. It is likely that some of the functionality will
+The ``gammapy.astro`` sub-package is in a prototyping phase and its scope and future
+are currently being discussed. It is likely that some of the functionality will
 be removed or split out into a separate package at some point.
 
 Getting Started

--- a/docs/catalog/index.rst
+++ b/docs/catalog/index.rst
@@ -62,7 +62,7 @@ access by integer row index or source name. The ``SourceCatalogObject`` class
 implements in ``__str__`` a pretty-printed version of ``source.data``, so that
 you can ``print(source)``, as well as factory methods to create Gammapy objects
 such as `gammapy.spectrum.models.SpectralModel` or
-``gammapy.image.models.SpatialModel`` or `gammapy.spectrum.FluxPoints`
+``gammapy.image.models.SkySpatialModel`` or `gammapy.spectrum.FluxPoints`
 representing spatial and spectral models, or spectral points, which you can then
 print or plot or use for simulation and analysis.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,4 +248,4 @@ suppress_warnings = [
     'ref.citation'
 ]
 
-# nitpicky = True
+nitpicky = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,4 +248,4 @@ suppress_warnings = [
     'ref.citation'
 ]
 
-nitpicky = True
+# nitpicky = True

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -566,7 +566,7 @@ Methods that use interpolation should provide an option to the caller to pass in
 ``RegularGridInterpolator`` in case the default behaviour doesn't suit the application.
 
 TODO: we have some classes (aeff2d and edisp2d) that pre-compute an interpolator, currently in the constructor.
-In those cases the ``interp_kwargs`` would have to be exposed e.g. also on the `read` and other constructors.
+In those cases the ``interp_kwargs`` would have to be exposed e.g. also on the ``read`` and other constructors.
 Do we want / need that?
 
 
@@ -652,7 +652,7 @@ Here's an example how to write ``__repr__``::
             self.__class__.__name__, self.name, self.age
         )
 
-Note how we use `{!r}` in the format string to fill in the ``repr`` of the
+Note how we use ``{!r}`` in the format string to fill in the ``repr`` of the
 object being formatted, and how we used ``self.__class__.__name__`` to avoid
 duplicating the class name (easier to refactor code, and shows sub-class name if
 repr is inherited).
@@ -865,11 +865,6 @@ In these cases, the following shorter format omitting the *Returns* section is r
 Usually the parameter description doesn't fit on the one line, so it's
 recommended to always keep this in the *Parameters* section.
 
-This is just a recommendation, e.g. for `gammapy.cube.SkyCube.spectral_index`
-we decided to use this shorter format, but for `gammapy.cube.SkyCube.flux` we
-decided to stick with the more verbose format, because the return type and units
-didn't fit on the first line.
-
 A common case where the short format is appropriate are class properties,
 because they always return a single object.
 As an example see `gammapy.data.EventList.radec`, which is reproduced here:
@@ -887,8 +882,7 @@ As an example see `gammapy.data.EventList.radec`, which is reproduced here:
 Class attributes
 ++++++++++++++++
 
-Class attributes (data members) and properties are currently a bit of a mess,
-see `~gammapy.cube.SkyCube` as an example.
+Class attributes (data members) and properties are currently a bit of a mess.
 Attributes are listed in an *Attributes* section because I've listed them in a class-level
 docstring attributes section as recommended `here`__.
 Properties are listed in separate *Attributes summary* and *Attributes Documentation*
@@ -897,10 +891,7 @@ sections, which is confusing to users ("what's the difference between attributes
 .. __: https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt#class-docstring
 
 One solution is to always use properties, but that can get very verbose if we have to write
-so many getters and setters. I don't have a solution for this yet ... for now I'll go read
-`this`__ and meditate.
-
-.. __: https://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descriptor_writeup.ipynb
+so many getters and setters. We could start using descriptors.
 
 TODO: make a decision on this and describe the issue / solution here.
 

--- a/docs/development/intro.rst
+++ b/docs/development/intro.rst
@@ -189,8 +189,8 @@ Make a working example
 * Explain "documentation driven development" and "test driven development"
 
 * make a branch
-* test in `examples`
-* `import IPython; IPython.embed` trick
+* test in ``examples``
+* ``import IPython; IPython.embed`` trick
 
 
 Integrate the code in Gammapy

--- a/docs/install/dependencies.rst
+++ b/docs/install/dependencies.rst
@@ -23,7 +23,7 @@ The required core dependencies of Gammapy are:
 
 * `Numpy`_ - the fundamental package for scientific computing with Python
 * `Astropy`_ - the core package for Astronomy in Python
-* `regions`_ - Astropy regions package. Planned for inclusion in Astropy core as `astropy.regions`.
+* `regions`_ - Astropy regions package. Planned for inclusion in Astropy core as ``astropy.regions``.
 * `click`_ for making command line tools
 
 Optional dependencies of Gammapy:

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -501,7 +501,7 @@ using a format other than the GADF format:
 Visualization
 -------------
 
-All map objects provide a `~Map.plot` method for generating a visualization of a
+All map objects provide a ``plot`` method for generating a visualization of a
 map.  This method returns figure, axes, and image objects that can be used to
 further tweak/customize the image.
 

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -301,7 +301,7 @@ example::
 
 If you're new to Python command line tools or Click, probably setuptools entry
 points and click groups seem very complex. And they are, compared to the rest of
-Gammapy which is just `def` and `class` statements to make functions and
+Gammapy which is just ``def`` and ``class`` statements to make functions and
 classes, i.e. "normal" Python code. Just know that to use and even work on the
 Gammapy CLI you don't have to understand how it works under the hood, but if you
 want to, it's actually not that complex.
@@ -318,7 +318,7 @@ Note how sub-commands are ``click.Command`` objects::
     click.core.Command
 
 that are independent and how the main ``cli`` is created via ``cli.add_command``
-calls in `gammapy/scripts/main.py`.
+calls in `gammapy/scripts/main.py`_.
 
 Now you have a basic understanding how things work and should be able to work on
 Gammapy CLI (e.g. add more functionality to the CLI interface). If you're

--- a/docs/time/period.rst
+++ b/docs/time/period.rst
@@ -37,7 +37,7 @@ chance if the underlying light curve would consist of Gaussian white-noise only.
 Both, periodogram and light curve can be plotted with
 `~gammapy.time.plot_periodogram`.
 
-See the `astropy`-docs for more details about the Lomb-Scargle periodogram and
+See the Astropy docs for more details about the Lomb-Scargle periodogram and
 its false alarm probability [1]_. The loss functions for the robust periodogram
 are provided by `scipy.optimize.least_squares` [2]_.
 
@@ -186,11 +186,11 @@ return following FAP:
 ===========   ===================
 method        FAP
 ===========   ===================
-`single`      :math:`1.04e^{-21}`
-`naive`       :math:`5.40e^{-16}`
-`davies`      :math:`4.05e^{-15}`
-`baluev`      :math:`4.05e^{-15}`
-`bootstrap`   :math:`0.0`
+'single'      :math:`1.04e^{-21}`
+'naive'       :math:`5.40e^{-16}`
+'davies'      :math:`4.05e^{-15}`
+'baluev'      :math:`4.05e^{-15}`
+'bootstrap'   :math:`0.0`
 ===========   ===================
 
 The plot of the light curve shows no evidence for outliers. Thus,

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -97,8 +97,8 @@ time systems in a nutshell`_.
 It's not clear yet how to best implement METs in Gammapy, it's one of the tasks
 here: https://github.com/gammapy/gammapy/issues/284
 
-For now, we use the `gammapy.time.time_ref_from_dict`,
-`gammapy.time.time_relative_to_ref` and `gammapy.time.absolute_time` functions
+For now, we use the `gammapy.utils.time.time_ref_from_dict`,
+`gammapy.utils.time.time_relative_to_ref` and `gammapy.utils.time.absolute_time` functions
 to convert MET floats to `~astropy.time.Time` objects via the reference times
 stored in FITS headers.
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -866,8 +866,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
     @property
     def spatial_model(self):
-        """Source spatial model (`~gammapy.image.models.SpatialModel`).
-        """
+        """Source spatial model (`~gammapy.image.models.SkySpatialModel`)."""
         d = self.data
 
         pars = {}

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -920,6 +920,8 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 class SourceCatalog3FGL(SourceCatalog):
     """Fermi-LAT 3FGL source catalog.
 
+    Reference: https://ui.adsabs.harvard.edu/#abs/2015ApJS..218...23A
+
     One source is represented by `~gammapy.catalog.SourceCatalogObject3FGL`.
     """
     name = '3fgl'
@@ -985,21 +987,19 @@ class SourceCatalog3FGL(SourceCatalog):
         """
         source_class_info = np.array([_.strip() for _ in self.table['CLASS1']])
 
-        if source_class in self.source_categories:
-            category = set(self.source_categories[source_class])
+        cats = self.source_categories
+        if source_class in cats:
+            category = set(cats[source_class])
         elif source_class == 'ALL':
-            category = set(self.source_categories['EXTRA-GALACTIC']
-                           + self.source_categories['GALACTIC'])
+            category = set(cats['EXTRA-GALACTIC'] + cats['GALACTIC'])
         elif source_class == 'all':
-            category = set(self.source_categories['extra-galactic']
-                           + self.source_categories['galactic'])
+            category = set(cats['extra-galactic'] + cats['galactic'])
         elif source_class in np.unique(source_class_info):
             category = set([source_class])
         else:
-            raise ValueError("'{}' ist not a valid source class.".format(source_class))
+            raise ValueError("Invalid source_class: {!r}".format(source_class))
 
-        selection = np.array([_ in category for _ in source_class_info])
-        return selection
+        return np.array([_ in category for _ in source_class_info])
 
     def select_source_class(self, source_class):
         """
@@ -1025,6 +1025,8 @@ class SourceCatalog3FGL(SourceCatalog):
 
 class SourceCatalog1FHL(SourceCatalog):
     """Fermi-LAT 1FHL source catalog.
+
+    Reference: http://adsabs.harvard.edu/abs/2013ApJS..209...34A
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject1FHL`.
     """
@@ -1054,6 +1056,8 @@ class SourceCatalog1FHL(SourceCatalog):
 
 class SourceCatalog2FHL(SourceCatalog):
     """Fermi-LAT 2FHL source catalog.
+
+    Reference: http://adsabs.harvard.edu/abs/2016ApJS..222....5A
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject2FHL`.
     """
@@ -1085,6 +1089,8 @@ class SourceCatalog2FHL(SourceCatalog):
 
 class SourceCatalog3FHL(SourceCatalog):
     """Fermi-LAT 3FHL source catalog.
+
+    Reference: http://adsabs.harvard.edu/abs/2017ApJS..232...18A
 
     One source is represented by `~gammapy.catalog.SourceCatalogObject3FHL`.
     """

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -253,7 +253,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
     @property
     def spectral_model(self):
-        """Best fit spectral model (`~gammapy.spectrum.SpectralModel`)."""
+        """Best fit spectral model (`~gammapy.spectrum.models.SpectralModel`)."""
         spec_type = self.data['SpectrumType'].strip()
 
         pars, errs = {}, {}
@@ -296,7 +296,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     @property
     def spatial_model(self):
         """
-        Source spatial model (`~gammapy.image.models.SpatialModel`).
+        Source spatial model (`~gammapy.image.models.SkySpatialModel`).
         """
         d = self.data
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -972,13 +972,13 @@ class SourceCatalog3FGL(SourceCatalog):
             Source class designator as defined in Table 3. There are a few extra
             selections available:
 
-            - `'ALL'`: all identified objects
-            - `'all'`: all objects with associations
-            - `'galactic'`: all sources with an associated galactic object
-            - `'GALACTIC'`: all identified galactic sources
-            - `'extra-galactic'`: all sources with an associated extra-galactic object
-            - `'EXTRA-GALACTIC'`: all identified extra-galactic sources
-            - `'unassociated'`: all unassociated objects
+            - 'ALL': all identified objects
+            - 'all': all objects with associations
+            - 'galactic': all sources with an associated galactic object
+            - 'GALACTIC': all identified galactic sources
+            - 'extra-galactic': all sources with an associated extra-galactic object
+            - 'EXTRA-GALACTIC': all identified extra-galactic sources
+            - 'unassociated': all unassociated objects
 
         Returns
         -------
@@ -1140,13 +1140,13 @@ class SourceCatalog3FHL(SourceCatalog):
             Source class designator as defined in Table 3. There are a few extra
             selections available:
 
-            - `'ALL'`: all identified objects
-            - `'all'`: all objects with associations
-            - `'galactic'`: all sources with an associated galactic object
-            - `'GALACTIC'`: all identified galactic sources
-            - `'extra-galactic'`: all sources with an associated extra-galactic object
-            - `'EXTRA-GALACTIC'`: all identified extra-galactic sources
-            - `'unassociated'`: all unassociated objects
+            - 'ALL': all identified objects
+            - 'all': all objects with associations
+            - 'galactic': all sources with an associated galactic object
+            - 'GALACTIC': all identified galactic sources
+            - 'extra-galactic': all sources with an associated extra-galactic object
+            - 'EXTRA-GALACTIC': all identified extra-galactic sources
+            - 'unassociated': all unassociated objects
 
         Returns
         -------

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -446,7 +446,7 @@ class SourceCatalogGammaCat(SourceCatalog):
         )
 
     def to_sky_models(self):
-        """Convert to a `~gammapy.utils.modeling.SkyModels`.
+        """Convert to a `~gammapy.cube.models.SkyModels`.
 
         TODO: add an option whether to skip or raise on missing models or data.
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -286,7 +286,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
     @property
     def spatial_model(self):
-        """Source spatial model (`~gammapy.image.models.SpatialModel`).
+        """Source spatial model (`~gammapy.image.models.SkySpatialModel`).
 
         TODO: add parameter errors!
         """

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -597,17 +597,17 @@ class GammaCatResourceIndex(object):
 
     @property
     def unique_source_ids(self):
-        """Sorted list of unique source IDs (`list(int)`)."""
+        """Sorted list of unique source IDs (list of int)."""
         return sorted(set([resource.source_id for resource in self.resources]))
 
     @property
     def unique_reference_ids(self):
-        """Sorted list of unique source IDs (`list(str)`)."""
+        """Sorted list of unique source IDs (list of str)."""
         return sorted(set([resource.reference_id for resource in self.resources]))
 
     @property
     def global_ids(self):
-        """List of global resource IDs (`list(str)`).
+        """List of global resource IDs (list of str).
 
         In original order, not sorted.
         """

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -476,7 +476,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
     @property
     def spatial_model(self):
-        """Spatial model (`~gammapy.image.models.SpatialModel`).
+        """Spatial model (`~gammapy.image.models.SkySpatialModel`).
 
         One of the following models (given by ``Spatial_Model`` in the catalog):
 

--- a/gammapy/catalog/registry.py
+++ b/gammapy/catalog/registry.py
@@ -59,7 +59,7 @@ class SourceCatalogRegistry(object):
 
     @property
     def catalog_names(self):
-        """Catalog names (`list`)."""
+        """Catalog names (list of str)."""
         return list(self._available_catalogs.keys())
 
     def register(self, name, cls, args=()):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -21,7 +21,7 @@ class MapFit(object):
 
     Parameters
     ----------
-    model : `~gammapy.cube.SkyModel`
+    model : `~gammapy.cube.models.SkyModel`
         Fit model
     counts : `~gammapy.maps.WcsNDMap`
         Counts cube
@@ -213,7 +213,7 @@ class MapEvaluator(object):
 
         Returns
         -------
-        model_map : `~gammapy.map.Map`
+        model_map : `~gammapy.maps.Map`
             Sky cube with data filled with evaluated model values.
             Units: ``cm-2 s-1 TeV-1 deg-2``
         """

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -273,7 +273,7 @@ class SkyDiffuseCube(object):
 
     Parameters
     ----------
-    map : `~gammapy.map.Map`
+    map : `~gammapy.maps.Map`
         Map template
     norm : float
         Norm parameter (multiplied with map values)

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -113,7 +113,7 @@ class SkyModel(object):
 
     Parameters
     ----------
-    spatial_model : `~gammapy.image.models.SpatialModel`
+    spatial_model : `~gammapy.image.models.SkySpatialModel`
         Spatial model (must be normalised to integrate to 1)
     spectral_model : `~gammapy.spectrum.models.SpectralModel`
         Spectral model

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-import warnings
 from astropy.coordinates import Angle
 from astropy.coordinates.angle_utilities import angular_separation
 import astropy.units as u
@@ -210,21 +209,21 @@ class PSFKernel(object):
         """Create Gaussian PSF.
 
         This is used for testing and examples.
-        The map geometry parameters (pixel size, energy bins) are taken from `geom`.
+        The map geometry parameters (pixel size, energy bins) are taken from ``geom``.
         The Gaussian width ``sigma`` is a scalar,
 
         TODO : support array input if it should vary along the energy axis.
 
         Parameters
         ----------
-        geom : `~gammapy.map.WcsGeom`
+        geom : `~gammapy.maps.WcsGeom`
             Map geometry
         sigma : `~astropy.coordinates.Angle`
             Gaussian width.
         max_radius : `~astropy.coordinates.Angle`
             Desired kernel map size.
         factor : int
-            the oversample factor to compute the PSF
+            Oversample factor to compute the PSF
 
         Returns
         -------

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -211,7 +211,7 @@ class DataStore(object):
         Returns
         -------
         list : python list of object
-            Object depends on type, e.g. for `events` it is a list of `~gammapy.data.EventList`.
+            Object depends on type, e.g. for 'events' it is a list of `~gammapy.data.EventList`.
         """
         obs_ids = self.obs_table['OBS_ID']
         return self.load_many(obs_ids=obs_ids, hdu_type=hdu_type, hdu_class=hdu_class)
@@ -231,7 +231,7 @@ class DataStore(object):
         Returns
         -------
         list : list of object
-            Object depends on type, e.g. for `events` it is a list of `~gammapy.data.EventList`.
+            Object depends on type, e.g. for 'events' it is a list of `~gammapy.data.EventList`.
         """
         things = []
         for obs_id in obs_ids:

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -391,12 +391,12 @@ class EventListBase(object):
 
         Parameters
         ----------
-        region : list of `~region.SkyRegion`
+        region : list of `~regions.SkyRegion`
             List of sky regions
 
         Returns
         -------
-        index_array : `np.array`
+        index_array : `numpy.ndarray`
             Index array of selected events
         """
         position = self.radec

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -13,7 +13,7 @@ __all__ = [
 class GTI(object):
     """Good time intervals (GTI) `~astropy.table.Table`.
 
-    Data format specification: ref:`gadf:iact-gti`
+    Data format specification: :ref:`gadf:iact-gti`
 
     Note: at the moment dead-time and live-time is in the
     EVENTS header ... the GTI header just deals with

--- a/gammapy/data/obs_stats.py
+++ b/gammapy/data/obs_stats.py
@@ -114,11 +114,8 @@ class ObservationStats(Stats):
 
     @property
     def sigma(self):
-        """Li-Ma significance for observation statistics (`float`).
-        """
-        sigma = significance_on_off(
-            self.n_on, self.n_off, self.alpha, method='lima')
-        return sigma
+        """Li-Ma significance for observation statistics (float)."""
+        return significance_on_off(self.n_on, self.n_off, self.alpha, method='lima')
 
     @classmethod
     def stack(cls, stats_list):

--- a/gammapy/data/obs_summary.py
+++ b/gammapy/data/obs_summary.py
@@ -177,7 +177,7 @@ class ObservationSummary(object):
             self.sigma[index] = stack.sigma
 
     def obs_wise_summary(self):
-        """Observation wise summary report (`str`)."""
+        """Observation wise summary report (str)."""
         ss = '*** Observation Wise summary ***\n'
         for obs in self.obs_stats:
             ss += '{}\n'.format(obs)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -53,7 +53,7 @@ class ObservationCTA(object):
 
         Computed as ``t_live = t_observation * (1 - f_dead)``
         where ``f_dead`` is the dead-time fraction.
-    observation_dead_time_fraction : `float`
+    observation_dead_time_fraction : float
         Dead-time fraction
 
         Defined as dead-time over observation time.

--- a/gammapy/image/asmooth.py
+++ b/gammapy/image/asmooth.py
@@ -91,16 +91,16 @@ class ASmooth(object):
 
         Parameters
         ----------
-        counts : `~gammapy.maps.WCSNDMap`
+        counts : `~gammapy.maps.WcsNDMap`
             Counts map
-        background : `~gammapy.maps.WCSNDMap`
+        background : `~gammapy.maps.WcsNDMap`
             Background map
-        exposure : `~gammapy.maps.WCSNDMap`
+        exposure : `~gammapy.maps.WcsNDMap`
             Exposure map
 
         Returns
         -------
-        images : dict of `~gammapy.maps.WCSNDMap`
+        images : dict of `~gammapy.maps.WcsNDMap`
             Smoothed images; keys are:
                 * 'counts'
                 * 'background'

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -262,7 +262,7 @@ class SkyDiffuseMap(SkySpatialModel):
 
     Parameters
     ----------
-    map : `~gammapy.map.Map`
+    map : `~gammapy.maps.Map`
         Map template
     norm : float
         Norm parameter (multiplied with map values)

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -47,7 +47,7 @@ class Background3D(object):
     Data           : size = 27216, min =  0.000 1 / (MeV s sr), max =  0.421 1 / (MeV s sr)
     """
     default_interp_kwargs = dict(bounds_error=False, fill_value=None)
-    """Default Interpolation kwargs for `~NDDataArray`. Extrapolate."""
+    """Default Interpolation kwargs for `~gammapy.utils.nddata.NDDataArray`. Extrapolate."""
 
     def __init__(self, energy_lo, energy_hi,
                  fov_lon_lo, fov_lon_hi, fov_lat_lo, fov_lat_hi,
@@ -132,7 +132,7 @@ class Background3D(object):
         return table
 
     def to_fits(self, name='BACKGROUND'):
-        """Convert to `~astropy.io.fits.BinTable`."""
+        """Convert to `~astropy.io.fits.BinTableHDU`."""
         return fits.BinTableHDU(self.to_table(), name=name)
 
     def evaluate(self, fov_lon, fov_lat, energy_reco, method="linear", **kwargs):
@@ -219,7 +219,7 @@ class Background2D(object):
         Background rate (usually: ``s^-1 MeV^-1 sr^-1``)
     """
     default_interp_kwargs = dict(bounds_error=False, fill_value=None)
-    """Default Interpolation kwargs for `~NDDataArray`. Extrapolate."""
+    """Default Interpolation kwargs for `~gammapy.utils.nddata.NDDataArray`. Extrapolate."""
 
     def __init__(self, energy_lo, energy_hi,
                  offset_lo, offset_hi,
@@ -297,7 +297,7 @@ class Background2D(object):
         return table
 
     def to_fits(self, name='BACKGROUND'):
-        """Convert to `~astropy.io.fits.BinTable`."""
+        """Convert to `~astropy.io.fits.BinTableHDU`."""
         return fits.BinTableHDU(self.to_table(), name=name)
 
     def evaluate(self, fov_lon, fov_lat, energy_reco, method="linear", **kwargs):

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -65,7 +65,7 @@ class CTAIrf(object):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             File containing the IRFs
         """
         filename = str(make_path(filename))
@@ -372,7 +372,7 @@ class CTAPerf(object):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             File containing the IRFs
         """
         filename = str(make_path(filename))
@@ -441,9 +441,9 @@ class CTAPerf(object):
 
         Parameters
         ----------
-        cta_perf : `list` of `~gammapy.scripts.CTAPerf`
+        cta_perf : list of `~gammapy.scripts.CTAPerf`
            List of performance
-        labels : `list` of `str`
+        labels : list of str
            List of labels
         """
         import matplotlib.pyplot as plt

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -143,7 +143,7 @@ class Map(object):
             List of `~MapAxis` objects for each non-spatial dimension.
             If None then the map will be a 2D image.
         dtype : str
-            Data type, default is ``float32``
+            Data type, default is 'float32'
         unit : str or `~astropy.units.Unit`
             Data unit.
         meta : `~collections.OrderedDict`

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -101,7 +101,7 @@ class Map(object):
 
     @property
     def meta(self):
-        """Map meta (`~OrderedDict`)"""
+        """Map meta (`~collections.OrderedDict`)"""
         return self._meta
 
     @meta.setter
@@ -207,7 +207,6 @@ class Map(object):
             data array
         meta : `~collections.OrderedDict`
             Dictionary to store meta data.
-
         map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
             Map type.  Selects the class that will be used to
             instantiate the map.  The map type should be consistent
@@ -813,8 +812,7 @@ class Map(object):
         pass
 
     def fill_by_coord(self, coords, weights=None):
-        """Fill pixels at the given map coordinates with values in `weights`
-        vector.
+        """Fill pixels at ``coords`` with given ``weights``.
 
         Parameters
         ----------
@@ -822,7 +820,6 @@ class Map(object):
             Coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
-
         weights : `~numpy.ndarray`
             Weights vector. If None then a unit weight will be assumed
             for each element in `coords`.
@@ -831,8 +828,7 @@ class Map(object):
         self.fill_by_idx(idx, weights)
 
     def fill_by_pix(self, pix, weights=None):
-        """Fill pixels at the given pixel coordinates with values in `weights`
-        vector.
+        """Fill pixels at ``pix`` with given ``weights``.
 
         Parameters
         ----------
@@ -842,7 +838,6 @@ class Map(object):
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
             Pixel indices can be either float or integer type.  Float
             indices will be rounded to the nearest integer.
-
         weights : `~numpy.ndarray`
             Weights vector. If None then a unit weight will be assumed
             for each element in `pix`.
@@ -852,8 +847,7 @@ class Map(object):
 
     @abc.abstractmethod
     def fill_by_idx(self, idx, weights=None):
-        """Fill pixels at the given pixel indices with values in `weights`
-        vector.
+        """Fill pixels at ``idx`` with given ``weights``.
 
         Parameters
         ----------
@@ -861,7 +855,6 @@ class Map(object):
             Tuple of pixel index arrays for each dimension of the map.
             Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
-
         weights : `~numpy.ndarray`
             Weights vector. If None then a unit weight will be assumed
             for each element in `idx`.
@@ -897,7 +890,6 @@ class Map(object):
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
             Pixel indices can be either float or integer type.  Float
             indices will be rounded to the nearest integer.
-
         vals : `~numpy.ndarray`
             Values vector. Pixels at `pix` will be set to these values.
         """
@@ -915,7 +907,6 @@ class Map(object):
             Tuple of pixel index arrays for each dimension of the map.
             Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
-
         vals : `~numpy.ndarray`
             Values vector. Pixels at `idx` will be set to these values.
         """

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -13,7 +13,6 @@ from .geom import pix_tuple_to_idx, MapCoord
 from ..extern import six
 from ..utils.scripts import make_path
 
-
 __all__ = [
     'Map',
 ]
@@ -197,7 +196,7 @@ class Map(object):
 
     @staticmethod
     def from_geom(geom, meta=None, data=None, map_type='auto', unit=''):
-        """Generate an empty map from a `Geom` instance.
+        """Generate an empty map from a `MapGeom` instance.
 
         Parameters
         ----------
@@ -209,10 +208,9 @@ class Map(object):
             Dictionary to store meta data.
         map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
             Map type.  Selects the class that will be used to
-            instantiate the map.  The map type should be consistent
-            with the geometry.  If map_type is 'auto' then an
-            appropriate map type will be inferred from type of
-            ``geom``.
+            instantiate the map. The map type should be consistent
+            with the geometry. If map_type is 'auto' then an
+            appropriate map type will be inferred from type of ``geom``.
         unit : str or `~astropy.units.Unit`
             Data unit.
 
@@ -238,8 +236,7 @@ class Map(object):
 
     @staticmethod
     def from_hdulist(hdulist, hdu=None, hdu_bands=None, map_type='auto'):
-        """Create from `astropy.io.fits.HDUList`.
-        """
+        """Create from `astropy.io.fits.HDUList`."""
         if map_type == 'auto':
             map_type = Map._get_map_type(hdulist, hdu)
         cls_out = Map._get_map_cls(map_type)
@@ -479,13 +476,12 @@ class Map(object):
         ----------
         crop_width : {sequence, array_like, int}
             Number of pixels cropped from the edges of each axis.
-            Defined analogously to `pad_with` from `~numpy.pad`.
+            Defined analogously to ``pad_with`` from `numpy.pad`.
 
         Returns
         -------
         map : `Map`
             Cropped map.
-
         """
         pass
 
@@ -821,8 +817,7 @@ class Map(object):
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
         weights : `~numpy.ndarray`
-            Weights vector. If None then a unit weight will be assumed
-            for each element in `coords`.
+            Weights vector. Default is weight of one.
         """
         idx = self.geom.coord_to_idx(coords)
         self.fill_by_idx(idx, weights)
@@ -839,8 +834,7 @@ class Map(object):
             Pixel indices can be either float or integer type.  Float
             indices will be rounded to the nearest integer.
         weights : `~numpy.ndarray`
-            Weights vector. If None then a unit weight will be assumed
-            for each element in `pix`.
+            Weights vector. Default is weight of one.
         """
         idx = pix_tuple_to_idx(pix)
         return self.fill_by_idx(idx, weights=weights)
@@ -856,14 +850,12 @@ class Map(object):
             Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
         weights : `~numpy.ndarray`
-            Weights vector. If None then a unit weight will be assumed
-            for each element in `idx`.
+            Weights vector. Default is weight of one.
         """
         pass
 
     def set_by_coord(self, coords, vals):
-        """Set pixels at the given map coordinates to the values in `vals`
-        vector.
+        """Set pixels at ``coords`` with given ``vals``.
 
         Parameters
         ----------
@@ -871,16 +863,14 @@ class Map(object):
             Coordinate arrays for each dimension of the map.  Tuple
             should be ordered as (lon, lat, x_0, ..., x_n) where x_i
             are coordinates for non-spatial dimensions of the map.
-
         vals : `~numpy.ndarray`
-            Values vector.  Pixels at `coords` will be set to these values.
+            Values vector.
         """
         idx = self.geom.coord_to_pix(coords)
         self.set_by_pix(idx, vals)
 
     def set_by_pix(self, pix, vals):
-        """Set pixels at the given pixel coordinates to the values in `vals`
-        vector.
+        """Set pixels at ``pix`` with given ``vals``.
 
         Parameters
         ----------
@@ -891,15 +881,14 @@ class Map(object):
             Pixel indices can be either float or integer type.  Float
             indices will be rounded to the nearest integer.
         vals : `~numpy.ndarray`
-            Values vector. Pixels at `pix` will be set to these values.
+            Values vector.
         """
         idx = pix_tuple_to_idx(pix)
         return self.set_by_idx(idx, vals)
 
     @abc.abstractmethod
     def set_by_idx(self, idx, vals):
-        """Set pixels at the given pixel indices to the values in `vals`
-        vector.
+        """Set pixels at ``idx`` with given ``vals``.
 
         Parameters
         ----------
@@ -908,7 +897,7 @@ class Map(object):
             Tuple should be ordered as (I_lon, I_lat, I_0, ..., I_n)
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
         vals : `~numpy.ndarray`
-            Values vector. Pixels at `idx` will be set to these values.
+            Values vector.
         """
         pass
 
@@ -922,14 +911,12 @@ class Map(object):
             Axis name to slide through, with the interactive slider. By default
             the first non-spatial axis is used.
         rc_params : dict
-            Matplotlib rc parameters passed to `matplotlib.rc_context(rc=rc_params)`,
-            to style the plot.
+            Passed to ``matplotlib.rc_context(rc=rc_params)`` to style the plot.
         **kwargs : dict
-            Keyword arguments passed to `WcsND.plot()`.
+            Keyword arguments passed to `WcsNDMap.plot`.
 
         Examples
         --------
-
         You can try this out e.g. using a Fermi-LAT diffuse model cube with an energy axis::
 
             from gammapy.maps import Map
@@ -937,12 +924,10 @@ class Map(object):
             m = Map.read("$GAMMAPY_EXTRA/datasets/vela_region/gll_iem_v05_rev1_cutout.fits")
             m.plot_interactive(cmap='gnuplot2')
 
-        If you would like to adjust the figure size you can use the `rc_params`
-        argument.
+        If you would like to adjust the figure size you can use the ``rc_params`` argument::
 
             rc_params = {'figure.figsize': (12, 6), 'font.size': 12}
             m.plot_interactive(rc_params=rc_params)
-
         """
         import matplotlib as mpl
         import matplotlib.pyplot as plt
@@ -965,18 +950,17 @@ class Map(object):
         if map_axis.node_type == 'edge':
             edges = map_axis.edges
             options = ['{:.0f} - {:.0f} {}'.format(val_min, val_max, map_axis.unit) for
-                         val_min, val_max in zip(edges[:-1], edges[1:])]
+                       val_min, val_max in zip(edges[:-1], edges[1:])]
         else:
             center = map_axis.center
             options = ['{:.0f} {}'.format(val, map_axis.unit) for val in center]
-
 
         @interact(
             val=SelectionSlider(options=options, description='Select {}:'.format(axis),
                                 continuous_update=False, style={'description_width': 'initial'},
                                 layout={'width': '36%'}),
             stretch=RadioButtons(options=['linear', 'sqrt', 'log'], value=stretch,
-                                 description='Select stretch:', style={'description_width': 'initial'} ),
+                                 description='Select stretch:', style={'description_width': 'initial'}),
         )
         def _plot_interactive(val, stretch):
             idx = options.index(val)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -806,7 +806,7 @@ class MapCoord(object):
 
         Parameters
         ----------
-        data : `tuple`, `dict`, `~MapCoord` or `~astropy.coordinates.SkyCoord`
+        data : tuple, dict, `MapCoord` or `~astropy.coordinates.SkyCoord`
             Object containing coordinate arrays.
         coordsys : {'CEL', 'GAL', None}, optional
             Set the coordinate system for longitude and latitude. If

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -180,8 +180,8 @@ class HpxMap(Map):
             then the WCS map will have the same dimensionality as the
             HEALPix one.
         normalize : bool
-            True -> preserve integral by splitting HEALPIX values between bins
-        proj  : str
+            Preserve integral by splitting HEALPIX values between bins?
+        proj : str
             WCS-projection
         oversample : float
             Oversampling factor for WCS map. This will be the
@@ -249,7 +249,7 @@ class HpxMap(Map):
         sparse : bool
             Set INDXSCHM to SPARSE and sparsify the map by only
             writing pixels with non-zero amplitude.
-        conv : {'fgst-ccube','fgst-template','gadf',None}, optional
+        conv : {'fgst-ccube', 'fgst-template', 'gadf', None}, optional
             FITS format convention.  If None this will be set to the
             default convention of the map.
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -8,9 +8,8 @@ import astropy.units as u
 from astropy.nddata import Cutout2D
 from astropy.convolution import Tophat2DKernel
 from ..extern.skimage import block_reduce
-from .base import Map
 from .utils import unpack_seq
-from .geom import pix_tuple_to_idx, axes_pix_to_coord
+from .geom import pix_tuple_to_idx
 from .wcs import _check_width
 from .utils import interp_to_order
 from .wcsmap import WcsGeom, WcsMap
@@ -504,7 +503,7 @@ class WcsNDMap(WcsMap):
         radius : `~astropy.units.Quantity` or float
             Smoothing width given as quantity or float. If a float is given it
             interpreted as smoothing width in pixels. If an (angular) quantity
-            is given it converted to pixels using `geom.wcs.wcs.cdelt`.
+            is given it converted to pixels using ``geom.wcs.wcs.cdelt``.
         kernel : {'gauss', 'disk', 'box'}
             Kernel shape
         kwargs : dict
@@ -552,7 +551,7 @@ class WcsNDMap(WcsMap):
 
         Parameters
         ----------
-        kernel : `PSFKernel` or `numpy.ndarray`
+        kernel : `~gammapy.cube.PSFKernel` or `numpy.ndarray`
             Convolution kernel.
         use_fft : bool
             Use `scipy.signal.fftconvolve` or `scipy.ndimage.convolve`.

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -196,7 +196,7 @@ class SpectrumFit(object):
         ----------
         obs : `~gammapy.spectrum.SpectrumObservation`
             Response functions
-        model : `~gammapy.spectrum.SpectralModel`
+        model : `~gammapy.spectrum.models.SpectralModel`
             Source or background model
         forward_folded : bool, default: True
             Fold model with IRFs

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -203,7 +203,7 @@ class SpectrumFit(object):
 
         Returns
         ------
-        predicted_counts: `np.array`
+        predicted_counts : `numpy.ndarray`
             Predicted counts for one observation
         """
         predictor = CountsPredictor(model=model)

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -244,7 +244,7 @@ class FluxPoints(object):
         ----------
         sed_type : {'dnde'}
              SED type to convert to.
-        model : `~gammapy.spectrum.SpectralModel`
+        model : `~gammapy.spectrum.models.SpectralModel`
             Spectral model assumption.  Note that the value of the amplitude parameter
             does not matter. Still it is recommended to use something with the right
             scale and units. E.g. `amplitude = 1e-12 * u.Unit('cm-2 s-1 TeV-1')`

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1175,7 +1175,7 @@ class TableModel(SpectralModel):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             File containing the XSPEC model
         param : float
             Model parameter value
@@ -1226,7 +1226,7 @@ class TableModel(SpectralModel):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             filename
         """
         filename = str(make_path(filename))
@@ -1310,7 +1310,7 @@ class Absorption(object):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             File containing the model.
         """
 
@@ -1380,9 +1380,9 @@ class Absorption(object):
 
         Parameters
         ----------
-        parameter : `float`
+        parameter : float
             Parameter value.
-        unit : `str`, (optional)
+        unit : str, (optional)
             desired value for energy axis
         """
         energy_axis = self.data.axes[1]
@@ -1406,9 +1406,9 @@ class AbsorbedSpectralModel(SpectralModel):
         Spectral model.
     absorption : `~gammapy.spectrum.models.Absorption`
         Absorption model.
-    parameter : `float`
+    parameter : float
         parameter value for absorption model
-    parameter_name : `str`, optional
+    parameter_name : str, optional
         parameter name
     """
 

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -334,7 +334,7 @@ class SpectrumResult(object):
         fit_kwargs : dict, optional
             forwarded to :func:`gammapy.spectrum.models.SpectralModel.plot`
         butterfly_kwargs : dict, optional
-            forwarded to :func:`gammapy.spectrum.SpectralModel.plot_error`
+            forwarded to :func:`gammapy.spectrum.models.SpectralModel.plot_error`
         point_kwargs : dict, optional
             forwarded to :func:`gammapy.spectrum.FluxPoints.plot`
         fig_kwargs : dict, optional

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -22,17 +22,17 @@ class SensitivityEstimator(object):
         IRF object
     livetime : `~astropy.units.Quantity`
         Livetime (object with the units of time), e.g. 5*u.h
-    slope : `float`, optional
+    slope : float, optional
         Index of the spectral shape (Power-law), should be positive (>0)
-    alpha : `float`, optional
+    alpha : float, optional
         On/OFF normalisation
-    sigma : `float`, optional
+    sigma : float, optional
         Minimum significance
-    gamma_min : `float`, optional
+    gamma_min : float, optional
         Minimum number of gamma-rays
-    bkg_sys : `float`, optional
+    bkg_sys : float, optional
         Fraction of Background systematics relative to the number of ON counts
-    random: : `int`, optional
+    random: : int, optional
         Number of random trial to derive the number of gamma-rays
 
     Examples
@@ -54,7 +54,7 @@ class SensitivityEstimator(object):
     -----
     For the moment, only the differential point-like sensitivity is computed at a fixed offset.
     This class allows to determine for each reconstructed energy bin the flux associated to the number of gamma-ray
-    events for which the significance is 'sigma', and being larger than 'gamma_min' and 'bkg_sys'% larger than the
+    events for which the significance is ``sigma``, and being larger than ``gamma_min`` and ``bkg_sys``% larger than the
     number of background events in the ON region
 
     TODO:
@@ -109,7 +109,7 @@ class SensitivityEstimator(object):
         Notes
         -----
         Find the number of needed gamma excess events using newtons method.
-        Defines a function `significance_on_off(x, off, alpha) - self.sigma`
+        Defines a function ``significance_on_off(x, off, alpha) - self.sigma``
         and uses scipy.optimize.newton to find the `x` for which this function
         is zero.
         """
@@ -165,8 +165,7 @@ class SensitivityEstimator(object):
         return flux
 
     def run(self):
-        """Run the algorithm to compute the differential sensitivity as explained in the document of the class.
-        """
+        """Run the computation."""
         # Creation of the spectral shape
         norm = 1 * u.Unit('cm-2 s-1 TeV-1')
         index = self.slope

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -54,7 +54,7 @@ class SensitivityEstimator(object):
     -----
     For the moment, only the differential point-like sensitivity is computed at a fixed offset.
     This class allows to determine for each reconstructed energy bin the flux associated to the number of gamma-ray
-    events for which the significance is ``sigma``, and being larger than ``gamma_min`` and ``bkg_sys``% larger than the
+    events for which the significance is ``sigma``, and being larger than ``gamma_min`` and ``bkg_sys`` percent larger than the
     number of background events in the ON region
 
     TODO:

--- a/gammapy/stats/poisson.py
+++ b/gammapy/stats/poisson.py
@@ -40,7 +40,7 @@ def background(n_off, alpha):
 
     Returns
     -------
-    background : ndarray
+    background : `numpy.ndarray`
         Background estimate for the on region
 
     Examples
@@ -73,7 +73,7 @@ def background_error(n_off, alpha):
 
     Returns
     -------
-    background : ndarray
+    background : `numpy.ndarray`
         Background estimate for the on region
 
     Examples
@@ -107,7 +107,7 @@ def excess(n_on, n_off, alpha):
 
     Returns
     -------
-    excess : ndarray
+    excess : `numpy.ndarray`
         Excess estimate for the on region
 
     Examples
@@ -144,7 +144,7 @@ def excess_error(n_on, n_off, alpha):
 
     Returns
     -------
-    excess_error : ndarray
+    excess_error : `numpy.ndarray`
         Excess error estimate
 
     Examples
@@ -198,7 +198,7 @@ def significance(n_on, mu_bkg, method='lima', n_on_min=1):
 
     Returns
     -------
-    significance : ndarray
+    significance : `numpy.ndarray`
         Significance according to the method chosen.
 
     References
@@ -502,7 +502,7 @@ def excess_matching_significance(mu_bkg, significance, method='lima'):
 
     Returns
     -------
-    excess : ndarray
+    excess : `numpy.ndarray`
         Excess
 
     See Also

--- a/gammapy/stats/significance.py
+++ b/gammapy/stats/significance.py
@@ -22,7 +22,7 @@ def significance_to_probability_normal(significance):
 
     Returns
     -------
-    probability : ndarray
+    probability : `numpy.ndarray`
         One-sided tail probability
 
     See Also

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -245,10 +245,10 @@ class LightCurve(object):
 
         Returns
         -------
-        y : `~numpy.ndarray` of `float`
+        y : `numpy.ndarray`
             Flux values
-        (yn, yp) : (`~numpy.ndarray` of `float`, `~numpy.ndarray` of `float`)
-            Tuple of flux error values
+        (yn, yp) : tuple of `numpy.ndarray`
+            Flux error values
         """
         y = self.table['flux'].quantity.to(unit)
 
@@ -275,9 +275,9 @@ class LightCurve(object):
 
         Returns
         -------
-        is_ul : `~numpy.ndarray` of `bool`
-            True if the corresponding flux point is an upper limit
-        yul : `~numpy.ndarray` of `float`
+        is_ul : `numpy.ndarray`
+            Is flux point is an upper limit? (boolean array)
+        yul : `numpy.ndarray`
             Flux upper limit values
         """
         try:
@@ -306,11 +306,10 @@ class LightCurve(object):
 
         Returns
         -------
-        x : `~numpy.ndarray` of `float` or of `~datetime.datetime`
+        x : `~numpy.ndarray` or of `~datetime.datetime`
             Time values or `~datetime.datetime` instances if 'iso' is chosen
             as time format
-        (xn, xp) : (`~numpy.ndarray` of `float` or of `~datetime.timedelta`,
-                    `~numpy.ndarray` of `float` or of `~datetime.timedelta`)
+        (xn, xp) : tuple of `numpy.ndarray` of `~datetime.timedelta`
             Tuple of time error values or `~datetime.timedelta` instances if
             'iso' is chosen as time format
         """
@@ -476,7 +475,7 @@ class LightCurveEstimator(object):
 
         Parameters
         ----------
-        time_holder : `list` of float and flag
+        time_holder : list of float and flag
             Contains a list of a time and a flag in 2-element arrays
         obs_properties : `~astropy.table.Table`
             Contains the dead time fraction and ratio of the on/off region
@@ -526,7 +525,6 @@ class LightCurveEstimator(object):
     def make_time_intervals_min_significance(self, significance, significance_method, energy_range,
                                              spectrum_extraction, separators=None):
         """
-
         Create time intervals such that each bin of a light curve reach a given significance
 
         The function work event by event to create an interval containing enough statistic and then starting a new one
@@ -541,7 +539,7 @@ class LightCurveEstimator(object):
             True energy range to evaluate integrated flux (true energy)
         spectrum_extraction : `~gammapy.spectrum.SpectrumExtraction`
             Contains statistics, IRF and event lists
-        separators : `list` of `~astropy.time.Time`
+        separators : list of `~astropy.time.Time`
             Contains a list of time to stop the current point creation (not saved) and start a new one
             Mostly useful between observations separated by a large time gap
 
@@ -554,9 +552,7 @@ class LightCurveEstimator(object):
         --------
         extract intervals for light curve :
             intervals = list(zip(table['t_start'], table['t_stop']))
-
         """
-
         # The function create a list of time associated with identifiers called time_holder.
         # The identifiers can be 'on' for the on events, 'off' for the off events, 'start' for the start of an
         # observation, 'end for the end of an observation and 'break' for a separator.
@@ -644,7 +640,7 @@ class LightCurveEstimator(object):
 
         Parameters
         ----------
-        time_intervals : `list` of `~astropy.time.Time`
+        time_intervals : list of `~astropy.time.Time`
             List of time intervals
         spectral_model : `~gammapy.spectrum.models.SpectralModel`
             Spectral model

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -136,13 +136,6 @@ class LightCurveTableModel(object):
     This class also contains an ``integral`` method, making the computation of
     mean fluxes for a given time interval a one-liner.
 
-    TODO: Improve this class!
-    This class is very preliminary / work in progress.
-    An obvious issue is that `gammapy.time.LightCurve` has the same name,
-    which has a good potential to confuse users.
-    Another poitn is the API for time, i.e. when to take floats or time objects.
-    We plan to discuss this `LightCurve` and the `PhaseCurveTableModel` model classes soon.
-
     Parameters
     ----------
     table : `~astropy.table.Table`

--- a/gammapy/time/period.py
+++ b/gammapy/time/period.py
@@ -29,27 +29,27 @@ def robust_periodogram(time, flux, flux_err=None, periods=None, loss='linear', s
 
     The function returns a dictionary with the following content:
 
-    - ``periods`` (`~numpy.ndarray`) -- Period grid in units of ``t``
-    - ``power`` (`~numpy.ndarray`) -- Periodogram peaks at periods of ``pgrid``
-    - ``best_period`` (`float`) -- Period of the highest periodogram peak
+    - ``periods`` (`numpy.ndarray`) -- Period grid in units of ``t``
+    - ``power`` (`numpy.ndarray`) -- Periodogram peaks at periods of ``pgrid``
+    - ``best_period`` (float) -- Period of the highest periodogram peak
 
     Parameters
     ----------
-    time : `~numpy.ndarray`
+    time : `numpy.ndarray`
         Time array of the light curve
-    flux : `~numpy.ndarray`
+    flux : `numpy.ndarray`
         Flux array of the light curve
-    flux_err : `~numpy.ndarray`
+    flux_err : `numpy.ndarray`
         Flux error array of the light curve.
         Is set to 1 if not given.
-    periods : `~numpy.ndarray`
+    periods : `numpy.ndarray`
         Period grid on which the periodogram is performed.
         If not given, a linear grid will be computed limited by the length of the light curve and the Nyquist frequency.
-    loss : `str` (optional, default='linear')
+    loss : str (optional, default='linear')
         Loss function for the robust regression.
         Available: `{'linear', 'soft_l1', 'huber', 'cauchy', 'arctan'}`.
         If not given, `'linear'` will be used, resulting in the Lomb-Scargle periodogram.
-    scale : `float` (optional, default=1)
+    scale : float (optional, default=1)
         Loss scale parameter to define margin between inlier and outlier residuals.
         If not given, will be set to 1.
 

--- a/gammapy/time/period.py
+++ b/gammapy/time/period.py
@@ -40,15 +40,13 @@ def robust_periodogram(time, flux, flux_err=None, periods=None, loss='linear', s
     flux : `numpy.ndarray`
         Flux array of the light curve
     flux_err : `numpy.ndarray`
-        Flux error array of the light curve.
-        Is set to 1 if not given.
+        Flux error array of the light curve. Default is 1.
     periods : `numpy.ndarray`
         Period grid on which the periodogram is performed.
         If not given, a linear grid will be computed limited by the length of the light curve and the Nyquist frequency.
-    loss : str (optional, default='linear')
+    loss : {'linear', 'soft_l1', 'huber', 'cauchy', 'arctan'}
         Loss function for the robust regression.
-        Available: `{'linear', 'soft_l1', 'huber', 'cauchy', 'arctan'}`.
-        If not given, `'linear'` will be used, resulting in the Lomb-Scargle periodogram.
+        Default is 'linear', resulting in the Lomb-Scargle periodogram.
     scale : float (optional, default=1)
         Loss scale parameter to define margin between inlier and outlier residuals.
         If not given, will be set to 1.

--- a/gammapy/time/plot_periodogram.py
+++ b/gammapy/time/plot_periodogram.py
@@ -15,20 +15,20 @@ def plot_periodogram(time, flux, periods, power, flux_err=None, best_period=None
 
     Parameters
     ----------
-    time : `~numpy.ndarray`
+    time : `numpy.ndarray`
         Time array of the light curve
-    flux : `~numpy.ndarray`
+    flux : `numpy.ndarray`
         Flux array of the light curve
-    periods : `~numpy.ndarray`
+    periods : `numpy.ndarray`
         Periods for the periodogram
-    power : `~numpy.ndarray`
+    power : `numpy.ndarray`
         Periodogram peaks of the data
-    flux_err : `~numpy.ndarray` (optional, default=None)
+    flux_err : `numpy.ndarray` (optional, default=None)
         Flux error array of the light curve.
         Is set to 0 if not given.
-    best_period : `float` (optional, default=None)
+    best_period : float (optional, default=None)
         Period of the highest periodogram peak
-    fap : `float` (optional, default=None)
+    fap : float (optional, default=None)
         False alarm probability of ``best_period`` under a certain significance criterion.
 
     Returns

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -25,28 +25,28 @@ def simulate_test_data(period, amplitude, t_length, n_data, n_obs, n_outliers):
 
     Parameters
     ----------
-    period : `float`
+    period : float
         period of model
-    amplitude : `float`
+    amplitude : float
         amplitude of model
-    t_length : `float`
+    t_length : float
         length of data set in units of time
-    n_data : `int`
+    n_data : int
         number of points for the test data
-    n_obs : `int`
+    n_obs : int
         number of unevenly data points for the observation data
-    n_outliers : `int`
+    n_outliers : int
         number of outliers in the test data
 
     Returns
     ----------
-    t : `~numpy.ndarray`
+    t : `numpy.ndarray`
         time for observation
-    dt : `float`
+    dt : float
         time resolution of test data
-    y : `~numpy.ndarray`
+    y : `numpy.ndarray`
         flux of observation
-    dy : `~numpy.ndarray`
+    dy : `numpy.ndarray`
         flux error of observation
     """
     rand = np.random.RandomState(42)
@@ -77,18 +77,18 @@ def fap_astropy(power, freq, t, y, dy, method=dict(baluev=0)):
 
     Parameters
     ----------
-    power : `~numpy.ndarray`
+    power : `numpy.ndarray`
         power of periodogram
-    freq : `~numpy.ndarray`
+    freq : `numpy.ndarray`
         frequencies at withc the periodogram is computed
-    t, y, dy : `~numpy.ndarray`
+    t, y, dy : `numpy.ndarray`
         time, flux and flux error or light curve
-    method : `dict`
+    method : dict
         dictionary of methods with their respective false alarm probability
 
     Returns
     -------
-    fap : `dict`
+    fap : dict
         false alarm probability dictionary (see description above).
     """
     ls = LombScargle(t, y, dy, normalization='standard')

--- a/gammapy/utils/coordinates/other.py
+++ b/gammapy/utils/coordinates/other.py
@@ -12,6 +12,7 @@ __all__ = [
 
 # TODO: replace this with the default from the Galactocentric frame in astropy.coordinates
 D_SUN_TO_GALACTIC_CENTER = Quantity(8.5, 'kpc')
+"""Default assumed distance from the Sun to the Galactic center (`~astropy.units.Quantity`)"""
 
 
 def cartesian(r, theta):

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -261,7 +261,7 @@ class SmartHDUList(object):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             Filename
         """
         filename = str(make_path(filename))
@@ -279,7 +279,7 @@ class SmartHDUList(object):
 
         Parameters
         ----------
-        filename : `str`
+        filename : str
             Filename
         """
         filename = str(make_path(filename))

--- a/gammapy/utils/modeling.py
+++ b/gammapy/utils/modeling.py
@@ -184,7 +184,7 @@ class Parameter(object):
 
 
 class Parameters(object):
-    """List of `~gammapy.spectrum.models.Parameter`
+    """List of `Parameter`.
 
     Holds covariance matrix
 

--- a/gammapy/utils/time.py
+++ b/gammapy/utils/time.py
@@ -29,7 +29,7 @@ def time_ref_from_dict(meta, format='mjd', scale='tt'):
     time : `~astropy.time.Time`
         Time object with ``format='MJD'``
     """
-    # Note: the `float` call here is to make sure we use 64-bit
+    # Note: the float call here is to make sure we use 64-bit
     mjd = float(meta['MJDREFI']) + float(meta['MJDREFF'])
     scale = meta.get('TIMESYS', scale).lower()
     return Time(mjd, format=format, scale=scale)


### PR DESCRIPTION
This PR fixes a bunch of small Sphinx docs issues pointed out by setting `nitpicky=True` and running `python setup.py build_docs`, mostly broken links to the API docs.