### PR TITLE
Change many OrderedDict to dict

### DIFF
--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Galactic radial source distribution probability density functions."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 import numpy as np
 from numpy import exp, pi, log, abs, cos, sin
 from astropy.units import Quantity
@@ -510,11 +509,12 @@ class ValleeSpiral(LogSpiral):
         self.bar = dict(x=Quantity([x_0, x_1]), y=Quantity([y_0, y_1]))
 
 
-radial_distributions = OrderedDict()
-radial_distributions.__doc__ = """Radial distribution (dict mapping names to classes)."""
-radial_distributions['CB98'] = CaseBattacharya1998
-radial_distributions['F06'] = FaucherKaspi2006
-radial_distributions['L06'] = Lorimer2006
-radial_distributions['P90'] = Paczynski1990
-radial_distributions['YK04'] = YusifovKucuk2004
-radial_distributions['YK04B'] = YusifovKucuk2004B
+"""Radial distribution (dict mapping names to classes)."""
+radial_distributions = {
+    'CB98': CaseBattacharya1998,
+    'F06': FaucherKaspi2006,
+    'L06': Lorimer2006,
+    'P90': Paczynski1990,
+    'YK04': YusifovKucuk2004,
+    'YK04B': YusifovKucuk2004B,
+}

--- a/gammapy/astro/population/velocity.py
+++ b/gammapy/astro/population/velocity.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Pulsar velocity distribution models."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 import numpy as np
 from astropy.modeling import Fittable1DModel, Parameter
 from astropy.units import Quantity
@@ -120,8 +119,9 @@ class Paczynski1990Velocity(Fittable1DModel):
         return amplitude * 4. / (np.pi * v_0 * (1 + (v / v_0) ** 2) ** 2)
 
 
-velocity_distributions = OrderedDict()
-velocity_distributions.__doc__ = """Velocity distributions (dict mapping names to classes)."""
-velocity_distributions['H05'] = FaucherKaspi2006VelocityMaxwellian
-velocity_distributions['F06B'] = FaucherKaspi2006VelocityBimodal
-velocity_distributions['F06P'] = Paczynski1990Velocity
+"""Velocity distributions (dict mapping names to classes)."""
+velocity_distributions = {
+    'H05': FaucherKaspi2006VelocityMaxwellian,
+    'F06B': FaucherKaspi2006VelocityBimodal,
+    'F06P': Paczynski1990Velocity,
+}

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Ring background estimation."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 from itertools import product
 import numpy as np
 from astropy.convolution import Ring2DKernel, Tophat2DKernel
@@ -74,19 +73,19 @@ class AdaptiveRingBackgroundEstimator(object):
         if method not in ['fixed_width', 'fixed_r_in']:
             raise ValueError("Not a valid adaptive ring method.")
 
-        self._parameters = OrderedDict(
-            r_in=Angle(r_in),
-            r_out_max=Angle(r_out_max),
-            width=Angle(width),
-            stepsize=Angle(stepsize),
-            threshold_alpha=threshold_alpha,
-            theta=Angle(theta),
-            method=method,
-        )
+        self._parameters = {
+            'r_in': Angle(r_in),
+            'r_out_max': Angle(r_out_max),
+            'width': Angle(width),
+            'stepsize': Angle(stepsize),
+            'threshold_alpha': threshold_alpha,
+            'theta': Angle(theta),
+            'method': method,
+        }
 
     @property
     def parameters(self):
-        """OrderedDict of parameters"""
+        """Parameter dict."""
         return self._parameters
 
     def kernels(self, image):
@@ -213,7 +212,7 @@ class AdaptiveRingBackgroundEstimator(object):
         required = ['counts', 'exposure_on', 'exclusion']
         counts_map, exposure_on_map, exclusion_map = [images[_] for _ in required]
 
-        result = dict()
+        result = {}
         result['exposure_off'] = exposure_on_map.copy(unit='')
         result['off'] = exposure_on_map.copy(unit='')
         result['alpha'] = exposure_on_map.copy(unit='')
@@ -224,7 +223,7 @@ class AdaptiveRingBackgroundEstimator(object):
             exposure_on = exposure_on_map.get_image_by_idx(idx)
             exclusion = exclusion_map.get_image_by_idx(idx)
 
-            cubes = OrderedDict()
+            cubes = {}
 
             kernels = self.kernels(counts)
 
@@ -295,11 +294,11 @@ class RingBackgroundEstimator(object):
     """
 
     def __init__(self, r_in, width, use_fft_convolution=False):
-        self._parameters = dict(
-            r_in=Angle(r_in),
-            width=Angle(width),
-            use_fft_convolution=use_fft_convolution,
-        )
+        self._parameters = {
+            'r_in': Angle(r_in),
+            'width': Angle(width),
+            'use_fft_convolution': use_fft_convolution,
+        }
 
     @property
     def parameters(self):
@@ -349,7 +348,7 @@ class RingBackgroundEstimator(object):
 
         counts, exposure_on, exclusion = [images[_] for _ in required]
 
-        result = dict()
+        result = {}
         ring = self.kernel(counts)
 
         counts_excluded = counts.copy(data=counts.data * exclusion.data.astype('float'))

--- a/gammapy/catalog/registry.py
+++ b/gammapy/catalog/registry.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 from astropy.table import Table
 
 __all__ = [
@@ -21,8 +20,8 @@ class SourceCatalogRegistry(object):
     """
 
     def __init__(self):
-        self._available_catalogs = OrderedDict()
-        self._loaded_catalogs = OrderedDict()
+        self._available_catalogs = {}
+        self._loaded_catalogs = {}
 
     @classmethod
     def builtins(cls):
@@ -67,7 +66,7 @@ class SourceCatalogRegistry(object):
 
         It must be possible to load it via ``cls(*args)``.
         """
-        self._available_catalogs[name] = dict(cls=cls, args=args)
+        self._available_catalogs[name] = {'cls': cls, 'args': args}
 
     def __getitem__(self, name):
         if name not in self._available_catalogs:
@@ -95,11 +94,11 @@ class SourceCatalogRegistry(object):
         rows = []
         for name in self._available_catalogs.keys():
             cat = self[name]
-            rows.append(dict(
-                name=name,
-                description=cat.description,
-                sources=len(cat.table),
-            ))
+            rows.append({
+                'name': name,
+                'description': cat.description,
+                'sources': len(cat.table),
+            })
 
         return Table(rows=rows, names=['name', 'description', 'sources'])
 

--- a/gammapy/data/obs_stats.py
+++ b/gammapy/data/obs_stats.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 import numpy as np
 import astropy.units as u
 from ..stats import Stats, significance_on_off
@@ -65,7 +64,7 @@ class ObservationStats(Stats):
         self.gamma_rate = gamma_rate
 
         if bg_rate is None:
-            bg_rate =  self.alpha_obs * n_off / livetime
+            bg_rate = self.alpha_obs * n_off / livetime
         self.bg_rate = bg_rate
 
     @classmethod
@@ -185,24 +184,24 @@ class ObservationStats(Stats):
         )
 
     def to_dict(self):
-        """Data as an `~collections.OrderedDict`.
+        """Data as a dict.
 
         This is useful for serialisation or putting the info in a table.
         """
-        data = OrderedDict()
-        data['obs_id'] = self.obs_id
-        data['livetime'] = self.livetime
-        data['n_on'] = self.n_on
-        data['n_off'] = self.n_off
-        data['a_on'] = self.a_on
-        data['a_off'] = self.a_off
-        data['alpha'] = self.alpha
-        data['background'] = self.background
-        data['excess'] = self.excess
-        data['sigma'] = self.sigma
-        data['gamma_rate'] = self.gamma_rate
-        data['bg_rate'] = self.bg_rate
-        return data
+        return {
+            'obs_id': self.obs_id,
+            'livetime': self.livetime,
+            'n_on': self.n_on,
+            'n_off': self.n_off,
+            'a_on': self.a_on,
+            'a_off': self.a_off,
+            'alpha': self.alpha,
+            'background': self.background,
+            'excess': self.excess,
+            'sigma': self.sigma,
+            'gamma_rate': self.gamma_rate,
+            'bg_rate': self.bg_rate,
+        }
 
     def __str__(self):
         ss = '*** Observation summary report ***\n'

--- a/gammapy/data/observers.py
+++ b/gammapy/data/observers.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Location of gamma-ray observatories."""
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 from astropy.coordinates import EarthLocation
 
 __all__ = [
@@ -9,11 +8,11 @@ __all__ = [
 ]
 
 
-observatory_locations = OrderedDict()
-observatory_locations.__doc__ = """Gamma-ray observatory locations (`~collections.OrderedDict`).
+observatory_locations = {}
+"""Gamma-ray observatory locations (dict).
 
-This is an `~collections.OrderedDict` with string keys
-nd values of type `~astropy.coordinates.EarthLocation`.
+This is a dict with observatory names as keys
+and values of type `~astropy.coordinates.EarthLocation`.
 
 Not that with ``EarthLocation`` the orientation of angles is as follows:
 

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import logging
 import numpy as np
-from collections import OrderedDict
 from astropy.io import fits
 from astropy.table import Table
 from astropy.convolution import Gaussian2DKernel, MexicanHat2DKernel
@@ -345,7 +344,7 @@ class CWTKernels(object):
         self.scales = np.array([min_scale * step_scale ** _ for _ in range(n_scale)],
                                dtype=float)
 
-        self.kern_base = dict()
+        self.kern_base = {}
         for idx_scale, scale in enumerate(self.scales):
             if old:
                 self.kern_base[idx_scale] = difference_of_gauss_kernel(scale, step_scale)
@@ -364,7 +363,7 @@ class CWTKernels(object):
             Information about object with str characteristic as keys and
             characteristic results as values.
         """
-        info_dict = OrderedDict()
+        info_dict = {}
         info_dict['Number of scales'] = self.n_scale
         info_dict['Minimal scale'] = self.min_scale
         info_dict['Step scale'] = self.step_scale
@@ -386,19 +385,19 @@ class CWTKernels(object):
 
         Returns
         -------
-        table : `~astropy.Table`
+        table : `~astropy.table.Table`
             Information about the object.
         """
         info_dict = self._info()
 
-        table = []
+        rows = []
         for name in info_dict:
-            table_line = dict()
-            table_line['Name'] = name
-            table_line['Source'] = info_dict[name]
-            table.append(table_line)
+            rows.append({
+                'Name': name,
+                'Source': info_dict[name],
+            })
 
-        return Table(rows=table, names=['Name', 'Source'])
+        return Table(rows=rows, names=['Name', 'Source'])
 
 
 class CWTData(object):
@@ -570,12 +569,12 @@ class CWTData(object):
 
         Returns
         -------
-        images : `~collections.OrderedDict`
+        images : dict
             Dictionary with keys {'counts', 'background', 'model', 'approx',
             'approx_bkg', 'transform_2d', 'maximal', 'support_2d'}
             and 2D `~numpy.ndarray` images as values.
         """
-        return OrderedDict(
+        return dict(
             counts=self.counts,
             background=self.background,
             model=self.model,
@@ -593,11 +592,11 @@ class CWTData(object):
 
         Returns
         -------
-        cubes : `~collections.OrderedDict`
+        cubes : dict
             Dictionary with keys {'transform_3d', 'error', 'support_3d'} and 3D
             `~numpy.ndarray` cubes as values.
         """
-        return OrderedDict(
+        return dict(
             transform_3d=self.transform_3d,
             error=self.error,
             support=self.support_3d,
@@ -619,18 +618,15 @@ class CWTData(object):
         info : dict
             The information about the data.
         """
-        info = OrderedDict()
-        info['Name'] = name
-        if len(data.shape) == 2:
-            info['Shape'] = '2D image'
-        else:
-            info['Shape'] = '3D cube'
-        info['Variance'] = data.var()
-        info['Mean'] = data.mean()
-        info['Max value'] = data.max()
-        info['Min value'] = data.min()
-        info['Sum values'] = data.sum()
-        return info
+        return {
+            'Name': name,
+            'Shape': '2D image' if len(data.shape) == 2 else '3D cube',
+            'Variance': data.var(),
+            'Mean': data.mean(),
+            'Max value': data.max(),
+            'Min value': data.min(),
+            'Sum values': data.sum(),
+        }
 
     def image_info(self, name):
         """Compute image info.
@@ -661,10 +657,10 @@ class CWTData(object):
 
         rows = []
         for metric in info_dict:
-            table_line = dict()
-            table_line['Metrics'] = metric
-            table_line['Source'] = info_dict[metric]
-            rows.append(table_line)
+            rows.append({
+                'Metrics': metric,
+                'Source': info_dict[metric],
+            })
 
         return Table(rows=rows, names=['Metrics', 'Source'])
 
@@ -698,11 +694,11 @@ class CWTData(object):
                 info_dict = self._metrics_info(data=cube.data[index],
                                                name=name)
                 for metric in info_dict:
-                    table_line = dict()
-                    table_line['Scale power'] = index + 1
-                    table_line['Metrics'] = metric
-                    table_line['Source'] = info_dict[metric]
-                    rows.append(table_line)
+                    rows.append({
+                        'Scale power': index + 1,
+                        'Metrics': metric,
+                        'Source': info_dict[metric],
+                    })
 
                 # For missing values in `Power scale` column
                 scale_mask = np.ones(len(info_dict), dtype=bool)
@@ -715,10 +711,10 @@ class CWTData(object):
         elif per_scale is False:
             info_dict = self._metrics_info(data=cube.data, name=name)
             for metric in info_dict:
-                table_line = dict()
-                table_line['Metrics'] = metric
-                table_line['Source'] = info_dict[metric]
-                rows.append(table_line)
+                rows.append({
+                    'Metrics': metric,
+                    'Source': info_dict[metric],
+                })
             columns = ['Metrics', 'Source']
             table = Table(rows=rows, names=columns)
         else:

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import contextlib
 import warnings
-from collections import OrderedDict
 from functools import partial
 from multiprocessing import Pool
 import numpy as np
@@ -137,16 +136,16 @@ class TSMapEstimator(object):
         if error_method not in ['covar', 'conf']:
             raise ValueError("Not a valid error method '{}'".format(error_method))
 
-        p = OrderedDict()
-        p['method'] = method
-        p['error_method'] = error_method
-        p['error_sigma'] = error_sigma
-        p['ul_method'] = ul_method
-        p['ul_sigma'] = ul_sigma
-        p['n_jobs'] = n_jobs
-        p['threshold'] = threshold
-        p['rtol'] = rtol
-        self.parameters = p
+        self.parameters = {
+            'method': method,
+            'error_method': error_method,
+            'error_sigma': error_sigma,
+            'ul_method': ul_method,
+            'ul_sigma': ul_sigma,
+            'n_jobs': n_jobs,
+            'threshold': threshold,
+            'rtol': rtol,
+        }
 
     @staticmethod
     def flux_default(maps, kernel):
@@ -154,8 +153,8 @@ class TSMapEstimator(object):
 
         Parameters
         ----------
-        maps : `OrderedDict` or `Dict`
-            Dict of input sky maps. Requires `counts`, `background` and `exposure` maps.
+        maps : dict
+            Input sky maps. Requires `counts`, `background` and `exposure` maps.
         kernel : `astropy.convolution.Kernel2D`
             Source model kernel.
 
@@ -174,8 +173,8 @@ class TSMapEstimator(object):
 
         Parameters
         ----------
-        maps : `OrderedDict` or `Dict`
-            Dict of input sky maps. . Requires `background` and `exposure`.
+        maps : dict
+            Input sky maps. Requires `background` and `exposure`.
         kernel : `astropy.convolution.Kernel2D`
             Source model kernel.
 
@@ -240,8 +239,8 @@ class TSMapEstimator(object):
         ----------
         kernel : `astropy.convolution.Kernel2D` or 2D `~numpy.ndarray`
             Source model kernel.
-        maps : `OrderedDict`
-            List of input sky maps.
+        maps : dict
+            Input sky maps.
         which : list of str or 'all'
             Which maps to compute.
         downsampling_factor : int
@@ -251,7 +250,7 @@ class TSMapEstimator(object):
 
         Returns
         -------
-        maps : `OrderedDict`
+        maps : dict
             Result maps.
         """
         p = self.parameters
@@ -276,7 +275,7 @@ class TSMapEstimator(object):
         if which == 'all':
             which = ['ts', 'sqrt_ts', 'flux', 'flux_err', 'flux_ul', 'niter']
 
-        result = OrderedDict()
+        result = {}
         for name in which:
             data = np.nan * np.ones_like(maps['counts'].data)
             result[name] = maps['counts'].copy(data=data)

--- a/gammapy/image/asmooth.py
+++ b/gammapy/image/asmooth.py
@@ -3,7 +3,6 @@
 Implementation of adaptive smoothing algorithms.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import Angle
 from astropy.convolution import Gaussian2DKernel, Tophat2DKernel
@@ -42,8 +41,12 @@ class ASmooth(object):
 
     def __init__(self, kernel=Gaussian2DKernel, method='simple', threshold=5,
                  scales=None):
-        self.parameters = OrderedDict(kernel=kernel, method=method,
-                                      threshold=threshold, scales=scales)
+        self.parameters = {
+            'kernel': kernel,
+            'method': method,
+            'threshold': threshold,
+            'scales': scales,
+        }
 
     def kernels(self, pixel_scale):
         """

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -604,22 +604,15 @@ class MapAxis(object):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        line_format = '\t{key:<10s} : {value:<10s}\n'
-
-        repr_dict = OrderedDict()
-        repr_dict['name'] = self.name
-        repr_dict['unit'] = '{!r}'.format(str(self.unit))
-        repr_dict['nbins'] = str(self.nbin)
-        repr_dict['node type'] = self.node_type
-
+        fmt = '\t{:<10s} : {:<10s}\n'
+        str_ += fmt.format('name', self.name)
+        str_ += fmt.format('unit', '{!r}'.format(str(self.unit)))
+        str_ += fmt.format('nbins', str(self.nbin))
+        str_ += fmt.format('node type', self.node_type)
         vals = self.edges if self.node_type == 'edge' else self.center
-        repr_dict['{} min'.format(self.node_type)] = '{:.1e} {}'.format(vals.min(), str(self.unit))
-        repr_dict['{} max'.format(self.node_type)] = '{:.1e} {}'.format(vals.max(), str(self.unit))
-
-        repr_dict['interp'] = self._interp
-
-        for key, value in repr_dict.items():
-            str_ += line_format.format(key=key, value=value)
+        str_ += fmt.format('{} min'.format(self.node_type), '{:.1e} {}'.format(vals.min(), str(self.unit)))
+        str_ += fmt.format('{} max'.format(self.node_type), '{:.1e} {}'.format(vals.max(), str(self.unit)))
+        str_ += fmt.format('interp', self._interp)
         return str_
 
 
@@ -734,8 +727,7 @@ class MapCoord(object):
         else:
             raise ValueError('Unrecognized input type.')
 
-        return cls(coords_dict, coordsys=coordsys,
-                   match_by_name=False)
+        return cls(coords_dict, coordsys=coordsys, match_by_name=False)
 
     @classmethod
     def _from_skycoord(cls, coords, coordsys=None):
@@ -784,8 +776,7 @@ class MapCoord(object):
             return cls(coords, coordsys=coordsys)
         elif 'skycoord' in coords:
             coords_dict = OrderedDict()
-            lon, lat, frame = skycoord_to_lonlat(
-                coords['skycoord'], coordsys=coordsys)
+            lon, lat, frame = skycoord_to_lonlat(coords['skycoord'], coordsys=coordsys)
             coords_dict['lon'] = lon
             coords_dict['lat'] = lat
             for k, v in coords.items():

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -51,8 +51,8 @@ class HpxConv(object):
         return copy.deepcopy(HPX_FITS_CONVENTIONS[convname])
 
 
-# Various conventions for storing HEALPIX maps in FITS files
-HPX_FITS_CONVENTIONS = OrderedDict()
+HPX_FITS_CONVENTIONS = {}
+"""Various conventions for storing HEALPIX maps in FITS files"""
 HPX_FITS_CONVENTIONS[None] = HpxConv('gadf', bands_hdu='BANDS')
 HPX_FITS_CONVENTIONS['gadf'] = HpxConv('gadf', bands_hdu='BANDS')
 HPX_FITS_CONVENTIONS['fgst-ccube'] = HpxConv('fgst-ccube')

--- a/gammapy/spectrum/cosmic_ray.py
+++ b/gammapy/spectrum/cosmic_ray.py
@@ -5,7 +5,6 @@ For measurements, the "Database of Charged Cosmic Rays (CRDB)" is a great resour
 http://lpsc.in2p3.fr/cosmic-rays-db/
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 import numpy as np
 from astropy.units import Quantity
 
@@ -57,12 +56,13 @@ def cosmic_ray_flux(energy, particle='proton'):
     flux : `~astropy.units.Quantity`
         Cosmic ray flux in unit ``m^-2 s^-1 TeV^-1 sr^-1``
     """
-    pars = OrderedDict()
-    pars['electron'] = OrderedDict(N=6.85e-5, k=3.21, L=3.19e-3, E_p=0.107, w=0.776)
-    pars['proton'] = OrderedDict(N=0.096, k=2.70)
-    pars['N'] = OrderedDict(N=0.0719, k=2.64)
-    pars['Si'] = OrderedDict(N=0.0284, k=2.66)
-    pars['Fe'] = OrderedDict(N=0.0134, k=2.63)
+    pars = {
+        'electron': {'N': 6.85e-5, 'k': 3.21, 'L': 3.19e-3, 'E_p': 0.107, 'w': 0.776},
+        'proton': {'N': 0.096, 'k': 2.70},
+        'N': {'N': 0.0719, 'k': 2.64},
+        'Si': {'N': 0.0284, 'k': 2.66},
+        'Fe': {'N': 0.0134, 'k': 2.63},
+    }
 
     if particle == 'electron':
         return _electron_spectrum(energy, **pars['electron'])

--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -12,7 +12,6 @@
   directly on the spectral model classes some day.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import OrderedDict
 import numpy as np
 
 __all__ = [
@@ -256,9 +255,9 @@ def power_law_compatibility(par_low, par_high):
     sigma_high = (g_match - g_high) / g_err_high
     sigma_combined = np.sqrt(sigma_low ** 2 + sigma_high ** 2)
 
-    return OrderedDict([
-        ('g_match', g_match),
-        ('sigma_low', sigma_low),
-        ('sigma_high', sigma_high),
-        ('sigma_combined', sigma_combined),
-    ])
+    return {
+        'g_match': g_match,
+        'sigma_low': sigma_low,
+        'sigma_high': sigma_high,
+        'sigma_combined': sigma_combined,
+    }


### PR DESCRIPTION
This PR changes many collections.OrderedDict in Gammapy to dict.

Since Python 3.6, dict is ordered, so once we drop the older Python, we can remove all OrderedDict.

For now, I've kept OrderedDict in places where order might matter, i.e. meta and map coords.