### PR TITLE
Improve SensitivityEstimator

### DIFF
--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -34,8 +34,6 @@ class SensitivityEstimator(object):
         Minimum number of gamma-rays
     bkg_sys : float, optional
         Fraction of Background systematics relative to the number of ON counts
-    random: : int, optional
-        Number of random trial to derive the number of gamma-rays
 
     Examples
     --------
@@ -61,7 +59,7 @@ class SensitivityEstimator(object):
     number of background events in the ON region.
     """
 
-    def __init__(self, irf, livetime, slope=2., alpha=0.2, sigma=5., gamma_min=10., bkg_sys=0.05, random=0):
+    def __init__(self, irf, livetime, slope=2., alpha=0.2, sigma=5., gamma_min=10., bkg_sys=0.05):
         self.irf = irf
 
         self.livetime = u.Quantity(livetime).to('s')
@@ -70,7 +68,6 @@ class SensitivityEstimator(object):
         self.sigma = sigma
         self.gamma_min = gamma_min
         self.bkg_sys = bkg_sys
-        self.random = random
 
         self._results_table = None
 
@@ -91,13 +88,7 @@ class SensitivityEstimator(object):
 
         bkg_counts = (self.irf.bkg.data.data * self.livetime).value
 
-        if self.random < 1:
-            excess_counts = self.get_excess(bkg_counts)
-        else:
-            ex = self.get_excess(np.random.poisson(bkg_counts))
-            for ii in range(self.random - 1):
-                ex += self.get_excess(np.random.poisson(bkg_counts))
-            excess_counts = ex / float(self.random)
+        excess_counts = self.get_excess(bkg_counts)
 
         phi_0 = self.get_1TeV_differential_flux(excess_counts, model, self.irf.aeff, self.irf.rmf)
         energy = reco_energy.log_center()

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -23,7 +23,10 @@ def test_cta_sensitivity_table(sens):
     table = sens.results_table
 
     assert len(table) == 21
-    assert table.colnames == ['ENERGY', 'FLUX', 'excess', 'background']
+    assert table.colnames == [
+        'ENERGY', 'FLUX', 'excess',
+        'background', 'is_gamma_limited',
+    ]
     assert table['ENERGY'].unit == 'TeV'
     assert table['FLUX'].unit == 'erg / (cm2 s)'
 
@@ -32,18 +35,21 @@ def test_cta_sensitivity_table(sens):
     assert_allclose(row['FLUX'], 1.2656e-10, rtol=1e-3)
     assert_allclose(row['excess'], 339.143, rtol=1e-3)
     assert_allclose(row['background'], 3703.48, rtol=1e-3)
+    assert row['is_gamma_limited'] == False
 
     row = table[9]
     assert_allclose(row['ENERGY'], 1, rtol=1e-3)
     assert_allclose(row['FLUX'], 4.28759e-13, rtol=1e-3)
     assert_allclose(row['excess'], 18.1072, rtol=1e-3)
     assert_allclose(row['background'], 5.11857, rtol=1e-3)
+    assert row['is_gamma_limited'] == False
 
     row = table[20]
     assert_allclose(row['ENERGY'], 158.489, rtol=1e-3)
     assert_allclose(row['FLUX'], 9.0483e-12, rtol=1e-3)
     assert_allclose(row['excess'], 10, rtol=1e-3)
     assert_allclose(row['background'], 0.00566093, rtol=1e-3)
+    assert row['is_gamma_limited'] == True
 
 
 @requires_dependency('scipy')

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -24,32 +24,32 @@ def test_cta_sensitivity_table(sens):
 
     assert len(table) == 21
     assert table.colnames == [
-        'ENERGY', 'FLUX', 'excess',
-        'background', 'is_gamma_limited',
+        'energy', 'e2dnde', 'excess',
+        'background', 'criterion',
     ]
-    assert table['ENERGY'].unit == 'TeV'
-    assert table['FLUX'].unit == 'erg / (cm2 s)'
+    assert table['energy'].unit == 'TeV'
+    assert table['e2dnde'].unit == 'erg / (cm2 s)'
 
     row = table[0]
-    assert_allclose(row['ENERGY'], 0.015848, rtol=1e-3)
-    assert_allclose(row['FLUX'], 1.2656e-10, rtol=1e-3)
+    assert_allclose(row['energy'], 0.015848, rtol=1e-3)
+    assert_allclose(row['e2dnde'], 1.2656e-10, rtol=1e-3)
     assert_allclose(row['excess'], 339.143, rtol=1e-3)
     assert_allclose(row['background'], 3703.48, rtol=1e-3)
-    assert row['is_gamma_limited'] == False
+    assert row['criterion'] == 'significance'
 
     row = table[9]
-    assert_allclose(row['ENERGY'], 1, rtol=1e-3)
-    assert_allclose(row['FLUX'], 4.28759e-13, rtol=1e-3)
+    assert_allclose(row['energy'], 1, rtol=1e-3)
+    assert_allclose(row['e2dnde'], 4.28759e-13, rtol=1e-3)
     assert_allclose(row['excess'], 18.1072, rtol=1e-3)
     assert_allclose(row['background'], 5.11857, rtol=1e-3)
-    assert row['is_gamma_limited'] == False
+    assert row['criterion'] == 'significance'
 
     row = table[20]
-    assert_allclose(row['ENERGY'], 158.489, rtol=1e-3)
-    assert_allclose(row['FLUX'], 9.0483e-12, rtol=1e-3)
+    assert_allclose(row['energy'], 158.489, rtol=1e-3)
+    assert_allclose(row['e2dnde'], 9.0483e-12, rtol=1e-3)
     assert_allclose(row['excess'], 10, rtol=1e-3)
     assert_allclose(row['background'], 0.00566093, rtol=1e-3)
-    assert row['is_gamma_limited'] == True
+    assert row['criterion'] == 'gamma'
 
 
 @requires_dependency('scipy')

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -1,84 +1,53 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-from numpy.testing import assert_allclose, assert_almost_equal
+from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.utils.testing import requires_data, requires_dependency
-from gammapy.stats import significance_on_off
 from ...irf.io import CTAPerf
 from ..sensitivity import SensitivityEstimator
 
 
-@requires_dependency('scipy')
-@requires_data('gammapy-extra')
-def test_cta_sensitivity():
-    """Run sensitivity estimation for one CTA IRF example."""
-    # TODO: change the test case to something simple that's easy to understand?
-    # E.g. a step function in AEFF and a very small Gaussian EDISP?
+@pytest.fixture()
+def sens():
     filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
     irf = CTAPerf.read(filename)
-
     sens = SensitivityEstimator(irf=irf, livetime=5.0 * u.h)
     sens.run()
-    table = sens.diff_sensi_table
+    return sens
+
+
+@requires_dependency('scipy')
+@requires_data('gammapy-extra')
+def test_cta_sensitivity_table(sens):
+    table = sens.results_table
 
     assert len(table) == 21
+    assert table.colnames == ['ENERGY', 'FLUX', 'excess', 'background']
+    assert table['ENERGY'].unit == 'TeV'
+    assert table['FLUX'].unit == 'erg / (cm2 s)'
 
-    # Assert on relevant values in three energy bins
-    # TODO: add asserts on other quantities: excess, exposure
-    assert_allclose(table['ENERGY'][0], 0.015848932787775993)
-    assert_allclose(table['FLUX'][0], 1.265689381204479e-10)
+    row = table[0]
+    assert_allclose(row['ENERGY'], 0.015848, rtol=1e-3)
+    assert_allclose(row['FLUX'], 1.2656e-10, rtol=1e-3)
+    assert_allclose(row['excess'], 339.143, rtol=1e-3)
+    assert_allclose(row['background'], 3703.48, rtol=1e-3)
 
-    assert_allclose(table['ENERGY'][9], 1)
-    assert_allclose(table['FLUX'][9], 4.2875940141105596e-13)
+    row = table[9]
+    assert_allclose(row['ENERGY'], 1, rtol=1e-3)
+    assert_allclose(row['FLUX'], 4.28759e-13, rtol=1e-3)
+    assert_allclose(row['excess'], 18.1072, rtol=1e-3)
+    assert_allclose(row['background'], 5.11857, rtol=1e-3)
 
-    assert_allclose(table['ENERGY'][20], 158.4893035888672)
-    assert_allclose(table['FLUX'][20], 9.048305001092968e-12)
+    row = table[20]
+    assert_allclose(row['ENERGY'], 158.489, rtol=1e-3)
+    assert_allclose(row['FLUX'], 9.0483e-12, rtol=1e-3)
+    assert_allclose(row['excess'], 10, rtol=1e-3)
+    assert_allclose(row['background'], 0.00566093, rtol=1e-3)
 
 
-# TODO: fix this test
-@pytest.mark.xfail
 @requires_dependency('scipy')
-def test_cta_min_gamma():
-    """Run sensitivity estimation for one CTA IRF example."""
-
-    sens = SensitivityEstimator(
-        irf=None,
-        livetime=5.0 * u.h,
-        gamma_min=100
-    )
-    e = sens.get_excess([0, 0, 0, 0])
-    assert_allclose([100, 100, 100, 100], e)
-
-    # Assert on a few rows of the result table
-    assert len(table) == 21
-
-    assert_allclose(
-        table['ENERGY'][[0, 9, 20]],
-        [0.0158489, 1.0, 158.489],
-        rtol=0.01,
-    )
-    assert_allclose(
-        table['FLUX'][[0, 9, 20]],
-        [1.223534e-10, 4.272442e-13, 9.047706e-12],
-        rtol=0.01,
-    )
-
-
-# TODO: fix this test
-@pytest.mark.xfail
-@requires_dependency('scipy')
-def test_cta_correct_sigma():
-    """Run sensitivity estimation for one CTA IRF example."""
-
-    sens = SensitivityEstimator(
-        irf=None,
-        livetime=5.0 * u.h,
-        gamma_min=10,
-        sigma=10.0
-    )
-    excess = sens.get_excess([1200])
-    off = 1200 * 5
-    on = excess + 1200
-    sigma = significance_on_off(on, off, alpha=0.2)
-    assert_almost_equal(sigma, 10, decimal=1)
+@requires_dependency('matplotlib')
+@requires_data('gammapy-extra')
+def test_cta_sensitivity_plot(sens):
+    sens.plot()


### PR DESCRIPTION
The SensitivityEstimator code and tests should be improved.

Here's what we currently have:
- https://github.com/gammapy/gammapy/blob/master/gammapy/spectrum/sensitivity.py
- https://github.com/gammapy/gammapy/blob/master/gammapy/spectrum/tests/test_sensitivity.py

First the tests should be improved, i.e. the two TODOs there addressed in the one working test, and the two xfail tests removed or fixed.

Then once we have a few more good asserts in the tests, the implementation should be improved.

This method should be deleted:

https://github.com/gammapy/gammapy/blob/281af2077f6bb7a8af7137e92304a767faf57d8e/gammapy/spectrum/sensitivity.py#L96

and instead http://docs.gammapy.org/dev/api/gammapy.stats.excess_matching_significance_on_off.html should be called, which should give the same result.

One final question I have is whether this random number generation makes sense, or if we can get rid of this to get a deterministic and simpler sensitivity computation:

https://github.com/gammapy/gammapy/blob/281af2077f6bb7a8af7137e92304a767faf57d8e/gammapy/spectrum/sensitivity.py#L181-L187
