### PR TITLE
Clean up test stdout output

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import OrderedDict
 import sys
 from copy import deepcopy
-from pprint import pprint
 import numpy as np
 from ..extern import six
 from astropy.utils import lazyproperty

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -52,13 +52,6 @@ class SourceCatalogObject(object):
         """Row index of source in catalog (int)"""
         return self.data[self._source_index_key]
 
-    def pprint(self, file=None):
-        """Pretty-print source data"""
-        if not file:
-            file = sys.stdout
-
-        pprint(self.data, stream=file)
-
     @property
     def _data_python_dict(self):
         """Convert ``data`` into a Python dict that only contains

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -92,7 +92,3 @@ class TestSourceCatalogObject:
 
         assert isinstance(d['DEC'], Quantity)
         assert_quantity_allclose(d['DEC'], Quantity(2, 'deg'))
-
-    def test_pprint(self):
-        # TODO: capture output and assert that it contains some substring
-        self.source.pprint()

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -85,7 +85,6 @@ class TestSourceCatalogObject:
 
     def test_data(self):
         d = self.source.data
-        print(d)
         assert isinstance(d, OrderedDict)
         assert isinstance(d['RA'], float)
         assert_allclose(d['RA'], 43.3)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -75,10 +75,6 @@ class TestFermi3FGLObject:
     def test_data(self):
         assert_allclose(self.source.data['Signif_Avg'], 30.669872283935547)
 
-    def test_pprint(self):
-        # TODO: add assert on output
-        self.source.pprint()
-
     def test_str(self):
         ss = str(self.source)
         assert 'Source name          : 3FGL J0534.5+2201' in ss
@@ -234,9 +230,6 @@ class TestFermi3FHLObject:
 
     def test_data(self):
         assert_allclose(self.source.data['Signif_Avg'], 168.64082)
-
-    def test_pprint(self):
-        self.source.pprint()
 
     def test_str(self):
         source = self.cat['3FHL J2301.9+5855e']  # Picking an extended source

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -102,7 +102,6 @@ class TestSourceCatalogObjectGammaCat:
     @pytest.mark.parametrize('ref', SOURCES, ids=lambda _: _['name'])
     def test_str(self, gammacat, ref):
         ss = str(gammacat[ref['name']])
-        print(ss)
         assert ss == SOURCES_STR[ref['name']]
 
     def test_data_python_dict(self, gammacat):
@@ -165,7 +164,6 @@ class TestSourceCatalogObjectGammaCat:
 
         spatial_model = source.spatial_model
 
-        # print(spatial_model); 1 /0
         # TODO: put better asserts on model properties
         # TODO: add a point and shell source -> separate list of sources for morphology test parametrization?
         assert spatial_model.__class__.__name__ == ref['spatial_model']

--- a/gammapy/catalog/tests/test_registry.py
+++ b/gammapy/catalog/tests/test_registry.py
@@ -23,14 +23,6 @@ def test_info_table(source_catalogs):
     assert table.colnames == ['name', 'description', 'sources']
 
 
-# 2HWC catalog is in ECSV format, which requires yaml to read the header
-@requires_dependency('yaml')
-@requires_data('gammapy-extra')
-def test_info(source_catalogs):
-    # TODO: assert output somehow
-    source_catalogs.info()
-
-
 @requires_data('gammapy-extra')
 def test_getitem(source_catalogs):
     cat = source_catalogs['2fhl']

--- a/gammapy/data/tests/test_observers.py
+++ b/gammapy/data/tests/test_observers.py
@@ -8,7 +8,7 @@ from ...data import observatory_locations
 def test_observatory_locations():
     # Check one example
     location = observatory_locations['hess']
-    assert_allclose(location.longitude.deg, Angle('16d30m00.8s').deg)
-    assert_allclose(location.latitude.deg, Angle('-23d16m18.4s').deg)
+    assert_allclose(location.lone.deg, Angle('16d30m00.8s').deg)
+    assert_allclose(location.lat.deg, Angle('-23d16m18.4s').deg)
     assert_allclose(location.height.value, 1835)
     assert str(location.height.unit) == 'm'

--- a/gammapy/data/tests/test_observers.py
+++ b/gammapy/data/tests/test_observers.py
@@ -8,7 +8,7 @@ from ...data import observatory_locations
 def test_observatory_locations():
     # Check one example
     location = observatory_locations['hess']
-    assert_allclose(location.lone.deg, Angle('16d30m00.8s').deg)
+    assert_allclose(location.lon.deg, Angle('16d30m00.8s').deg)
     assert_allclose(location.lat.deg, Angle('-23d16m18.4s').deg)
     assert_allclose(location.height.value, 1835)
     assert str(location.height.unit) == 'm'

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from copy import deepcopy
 import logging
+import numpy as np
 from ..stats import significance, significance_on_off
 
 __all__ = [
@@ -87,7 +88,8 @@ def compute_lima_on_off_image(n_on, n_off, a_on, a_off, kernel):
 
     significance_conv = significance_on_off(n_on_conv, n_off.data, alpha_conv, method='lima')
 
-    background_conv = alpha_conv * n_off.data
+    with np.errstate(invalid='ignore'):
+        background_conv = alpha_conv * n_off.data
     excess_conv = n_on_conv - background_conv
 
     return {

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -148,7 +148,7 @@ def measure_curve_of_growth(image, position, radius_max=None, radius_n=10):
     containment : `~astropy.units.Quantity`
         Corresponding contained flux.
     """
-    radius_max = radius_max or Quantity(0.2, 'deg')
+    radius_max = radius_max if radius_max is not None else Quantity(0.2, 'deg')
     containment = []
     radii = Quantity(np.linspace(0, radius_max.value, radius_n), radius_max.unit)
     for radius in radii:

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -167,9 +167,10 @@ class PSFKing(object):
         r2 = r * r
         sigma2 = sigma * sigma
 
-        term1 = 1 / (2 * np.pi * sigma2)
-        term2 = 1 - 1 / gamma
-        term3 = (1 + r2 / (2 * gamma * sigma2)) ** (-gamma)
+        with np.errstate(divide='ignore'):
+            term1 = 1 / (2 * np.pi * sigma2)
+            term2 = 1 - 1 / gamma
+            term3 = (1 + r2 / (2 * gamma * sigma2)) ** (-gamma)
 
         return term1 * term2 * term3
 
@@ -232,8 +233,8 @@ class PSFKing(object):
         energies = self.energy
 
         # Defaults
-        theta = theta or Angle(0, 'deg')
-        rad = rad or Angle(np.arange(0, 1.5, 0.005), 'deg')
+        theta = theta if theta is not None else Angle(0, 'deg')
+        rad = rad if rad is not None else Angle(np.arange(0, 1.5, 0.005), 'deg')
         psf_value = Quantity(np.empty((len(energies), len(rad))), 'deg^-2')
 
         for i, energy in enumerate(energies):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -251,7 +251,8 @@ def coord_to_idx(edges, x, clip=False):
         ibin[x < edges[0]] = 0
         ibin[x > edges[-1]] = len(edges) - 1
     else:
-        ibin[x > edges[-1]] = -1
+        with np.errstate(invalid='ignore'):
+            ibin[x > edges[-1]] = -1
 
     ibin[~np.isfinite(x)] = -1
     return ibin

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -538,7 +538,6 @@ def test_hpxgeom_solid_angle():
                           axes=[MapAxis.from_edges([0, 2, 3])])
 
     solid_angle = geom.solid_angle()
-    print(float(solid_angle.value))
 
     assert solid_angle.shape == (1,)
     assert_allclose(solid_angle.value, 0.016362461737446838)

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -61,8 +61,8 @@ class SpectrumExtraction(object):
 
         self.obs_list = obs_list
         self.bkg_estimate = bkg_estimate
-        self.e_reco = e_reco or self.DEFAULT_RECO_ENERGY
-        self.e_true = e_true or self.DEFAULT_TRUE_ENERGY
+        self.e_reco = e_reco if e_reco is not None else self.DEFAULT_RECO_ENERGY
+        self.e_true = e_true if e_true is not None else self.DEFAULT_TRUE_ENERGY
         self.containment_correction = containment_correction
         self.max_alpha = max_alpha
         self.use_recommended_erange = use_recommended_erange

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -77,11 +77,11 @@ class TestNDDataArray:
 
     def test_evaluate_2d(self, nddata_2d):
         # Case 1: axis1 = scalar, axis2 = array
-        out = nddata_2d.evaluate(energy=0 * u.TeV, offset=[0, 0] * u.deg)
+        out = nddata_2d.evaluate(energy=1 * u.TeV, offset=[0, 0] * u.deg)
         assert out.shape == (2,)
 
         # Case 2: axis1 = array, axis2 = array
-        out = nddata_2d.evaluate(energy=[0, 0, 0] * u.TeV, offset=[0, 0] * u.deg)
+        out = nddata_2d.evaluate(energy=[1, 1, 1] * u.TeV, offset=[0, 0] * u.deg)
         assert out.shape == (3, 2)
 
         # Case 3: axis1 array, axis2 = 2Darray


### PR DESCRIPTION
This PR cleans up the test stdout output, by removing unnecessary print statements and numpy `RuntimeWarning`. It also removes the `SourceCatalogObject.pprint()` method as it is superseded by `__str__` and  `.info()` methods.