### PR TITLE
Skip tests of notebooks if version package does not match

### DIFF
--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -6,6 +6,7 @@ import os
 import sys
 import subprocess
 import logging
+from pkg_resources import working_set
 from pprint import pprint
 import yaml
 
@@ -42,10 +43,9 @@ def requirement_missing(notebook):
 
     for package in notebook['requires'].split():
         try:
-            __import__(package)
-        except ImportError:
-            logging.warning('Skipping notebook {} because dependency {} is missing.'
-                            ''.format(notebook['name'], package))
+            working_set.require(package)
+        except Exception as ex:
+            logging.warning('Skipping notebook {} because dependency {} is missing.'.format(notebook['name'], package))
             return True
 
     return False


### PR DESCRIPTION
This PR addresses issue https://github.com/gammapy/gammapy/issues/846
When the version of the dependency requirement is noted in the `notebooks.yaml` file, the test of a specific notebook is skipped if number of the installed package does not match with the requirement.

In the example below the test for the notebook `spectrum_analysis.ipynb` will be skipped if the exec environment does not provide a version 4.10.0 for the package sherpa.

<pre>
- name: spectrum_analysis
  test: true
  requires: sherpa==4.10.0
</pre>

