### PR TITLE
Fix and unify `Map.iter_by_image()` behaviour

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -403,6 +403,8 @@ of the original map will be copied over to the projected map.
     m_proj = m.project(geom)
     m_proj.write('gll_iem_v06_hpx_nside8.fits')
 
+.. _mapiter:
+
 Iterating on a Map
 ------------------
 
@@ -429,7 +431,7 @@ one can use this method to fill a map with a 2D Gaussian:
 For maps with non-spatial dimensions the `~Map.iter_by_image` method can be used
 to loop over image slices. The image plane index `idx` is returned in data order,
 so that the data array can be indexed directly. Here is an example for an in-place
-convolution of an image using `astropy.convolution.convolve()` to interpolate NaN
+convolution of an image using `astropy.convolution.convolve` to interpolate NaN
 values:
 
 .. code:: python
@@ -437,8 +439,8 @@ values:
     import numpy as np
     from astropy.convolution import convolve
 
-    axis = MapAxis([1, 10, 100], interp='log', name='energy')
-    axis = MapAxis([1, 2, 3], interp='lin', name='time')
+    axis1 = MapAxis([1, 10, 100], interp='log', name='energy')
+    axis2 = MapAxis([1, 2, 3], interp='lin', name='time')
     m = Map.create(width=(5, 3), axes=[axis1, axis2], binsz=0.1)
     m.data[:, :, 15:18, 20:25] = np.nan
 

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -427,17 +427,26 @@ one can use this method to fill a map with a 2D Gaussian:
         m.set_by_coord(coord, new_val)
 
 For maps with non-spatial dimensions the `~Map.iter_by_image` method can be used
-to loop over image slices:
+to loop over image slices. The image plane index `idx` is returned in data order,
+so that the data array can be indexed directly. Here is an example for an in-place
+convolution of an image using `astropy.convolution.convolve()` to interpolate NaN
+values:
 
 .. code:: python
 
-    from astropy.coordinates import SkyCoord
-    from astropy.convolution import Gaussian2DKernel, convolve
-    from gammapy.maps import Map
+    import numpy as np
+    from astropy.convolution import convolve
 
-    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
+    axis = MapAxis([1, 10, 100], interp='log', name='energy')
+    axis = MapAxis([1, 2, 3], interp='lin', name='time')
+    m = Map.create(width=(5, 3), axes=[axis1, axis2], binsz=0.1)
+    m.data[:, :, 15:18, 20:25] = np.nan
+
     for img, idx in m.iter_by_image():
-        img = convolve(img, Gaussian2DKernel(x_stddev=2.0) )
+        kernel = np.ones((5, 5))
+        m.data[idx] = convolve(img, kernel)
+
+    assert not np.isnan(m.data).any()
 
 FITS I/O
 --------

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -213,8 +213,8 @@ class AdaptiveRingBackgroundEstimator(object):
         counts, exposure_on, exclusion = [images[_] for _ in required]
 
         if not counts.geom.is_image:
-            raise NotImplementedError('Adaptive ring background estimation only'
-                                      ' supported for 2D images.')
+            raise ValueError('Adaptive ring background estimation only supported'
+                             ' for 2D images.')
 
         kernels = self.kernels(counts)
         cubes = {}

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -210,48 +210,35 @@ class AdaptiveRingBackgroundEstimator(object):
             Result sky maps.
         """
         required = ['counts', 'exposure_on', 'exclusion']
-        counts_map, exposure_on_map, exclusion_map = [images[_] for _ in required]
+        counts, exposure_on, exclusion = [images[_] for _ in required]
 
-        if counts_map.geom.is_image():
+        if not counts.geom.is_image:
             raise NotImplementedError('Adaptive ring background estimation only'
                                       ' supported for 2D images.')
 
-        result = {}
-        result['exposure_off'] = exposure_on_map.copy(unit='')
-        result['off'] = exposure_on_map.copy(unit='')
-        result['alpha'] = exposure_on_map.copy(unit='')
-        result['background'] = exposure_on_map.copy(unit='')
-
-        counts = counts_map.get_image_by_idx(idx)
-        exposure_on = exposure_on_map.get_image_by_idx(idx)
-        exclusion = exclusion_map.get_image_by_idx(idx)
-
-        cubes = {}
-
         kernels = self.kernels(counts)
-
+        cubes = {}
         cubes['exposure_on'] = self._exposure_on_cube(exposure_on, kernels)
         cubes['exposure_off'] = self._exposure_off_cube(exposure_on, exclusion, kernels)
-
         cubes['off'] = self._off_cube(counts, exclusion, kernels)
         cubes['alpha_approx'] = self._alpha_approx_cube(cubes)
 
         exposure_off, off = self._reduce_cubes(cubes)
         alpha = exposure_on.data / exposure_off
-        not_has_exposure = ~(exposure_on.data > 0)
 
         # set data outside fov to zero
+        not_has_exposure = ~(exposure_on.data > 0)
         for data in [alpha, off, exposure_off]:
             data[not_has_exposure] = 0
 
         background = alpha * off
 
-        result['exposure_off'].data[idx] = exposure_off
-        result['off'].data[idx] = off
-        result['alpha'].data[idx] = alpha
-        result['background'].data[idx] = background
-
-        return result
+        return {
+            'exposure_off': counts.copy(data=exposure_off),
+            'off': counts.copy(data=off),
+            'alpha': counts.copy(data=alpha),
+            'background': counts.copy(data=background),
+        }
 
 
 class RingBackgroundEstimator(object):

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -5,17 +5,15 @@ from numpy.testing import assert_allclose
 import numpy as np
 from astropy import units as u
 from ...utils.testing import requires_dependency
-from ...maps import WcsNDMap, MapAxis
+from ...maps import WcsNDMap
 from ...background import RingBackgroundEstimator, AdaptiveRingBackgroundEstimator
 
 
 @pytest.fixture
 def images():
     fov = 2.5 * u.deg
-    axes = [MapAxis(np.logspace(0., 3., 3), interp='log'),
-            MapAxis(np.logspace(1., 3., 4), interp='lin')]
 
-    reference_image = WcsNDMap.create(binsz=0.05, npix=201, dtype=float, axes=axes)
+    reference_image = WcsNDMap.create(binsz=0.05, npix=201, dtype=float)
     reference_image.data += 1.
     coords = reference_image.geom.get_coord().skycoord
     center = reference_image.geom.center_skydir
@@ -43,9 +41,9 @@ def test_ring_background_estimator(images):
     in_fov = images['exposure_on'].data > 0
 
     assert_allclose(result['background'].data[in_fov], 2.)
-    assert_allclose(result['alpha'].data[in_fov].mean(), 0.00327, rtol=1e-3)
-    assert_allclose(result['exposure_off'].data[in_fov].mean(), 324.104, rtol=1e-3)
-    assert_allclose(result['off'].data[in_fov].mean(), 648.208, rtol=1e-3)
+    assert_allclose(result['alpha'].data[in_fov].mean(), 0.003488538457592745)
+    assert_allclose(result['exposure_off'].data[in_fov].mean(), 305.1268970794541)
+    assert_allclose(result['off'].data[in_fov].mean(), 610.2537941589082)
 
     assert_allclose(result['off'].data[~in_fov], 0.)
     assert_allclose(result['exposure_off'].data[~in_fov], 0.)

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -5,15 +5,17 @@ from numpy.testing import assert_allclose
 import numpy as np
 from astropy import units as u
 from ...utils.testing import requires_dependency
-from ...maps import WcsNDMap
+from ...maps import WcsNDMap, MapAxis
 from ...background import RingBackgroundEstimator, AdaptiveRingBackgroundEstimator
 
 
 @pytest.fixture
 def images():
     fov = 2.5 * u.deg
+    axes = [MapAxis(np.logspace(0., 3., 3), interp='log'),
+            MapAxis(np.logspace(1., 3., 4), interp='lin')]
 
-    reference_image = WcsNDMap.create(binsz=0.05, npix=201, dtype=float)
+    reference_image = WcsNDMap.create(binsz=0.05, npix=201, dtype=float, axes=axes)
     reference_image.data += 1.
     coords = reference_image.geom.get_coord().skycoord
     center = reference_image.geom.center_skydir
@@ -41,9 +43,9 @@ def test_ring_background_estimator(images):
     in_fov = images['exposure_on'].data > 0
 
     assert_allclose(result['background'].data[in_fov], 2.)
-    assert_allclose(result['alpha'].data[in_fov].mean(), 0.003488538457592745)
-    assert_allclose(result['exposure_off'].data[in_fov].mean(), 305.1268970794541)
-    assert_allclose(result['off'].data[in_fov].mean(), 610.2537941589082)
+    assert_allclose(result['alpha'].data[in_fov].mean(), 0.00327, rtol=1e-3)
+    assert_allclose(result['exposure_off'].data[in_fov].mean(), 324.104, rtol=1e-3)
+    assert_allclose(result['off'].data[in_fov].mean(), 648.208, rtol=1e-3)
 
     assert_allclose(result['off'].data[~in_fov], 0.)
     assert_allclose(result['exposure_off'].data[~in_fov], 0.)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -331,23 +331,7 @@ class Map(object):
         array and image plane index.
 
         The image plane index is in data order, so that the data array can be
-        indexed directly. Here is an example for an inplace convolution of an
-        image using `astropy.convolution.convolve()` to interpolate NaN values:
-
-
-        .. code::
-
-            import numpy as np
-            from astropy.convolution import convolve
-
-            axis = MapAxis([1, 10, 100], interp='log', name='energy')
-            axis = MapAxis([1, 2, 3], interp='lin', name='time')
-            m = Map.create(width=(5, 3), axes=[axis1, axis2], binsz=0.1)
-            m.data[:, :, 15:18, 20:25] = np.nan
-
-            for img, idx in m.iter_by_image():
-                kernel = np.ones((5, 5))
-                m.data[idx] = convolve(img, kernel)
+        indexed directly. See :ref:`mapiter` for further information.
 
         Returns
         -------

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -10,6 +10,7 @@ from astropy import units as u
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from .geom import pix_tuple_to_idx, MapCoord
+from .utils import unpack_seq
 from ..extern import six
 from ..utils.scripts import make_path
 
@@ -327,7 +328,7 @@ class Map(object):
 
     def iter_by_image(self):
         """Iterate over image planes of the map returning a tuple with the image
-        array and image plane index.
+        array and image plane index in the data array.
 
         Returns
         -------
@@ -337,7 +338,7 @@ class Map(object):
             Index of image plane.
         """
         for idx in np.ndindex(self.geom.shape):
-            yield self.data[idx[::-1]], idx
+            yield self.data[idx[::-1]], idx[::-1]
 
     def iter_by_pix(self, buffersize=1):
         """Iterate over elements of the map returning a tuple with values and

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -328,7 +328,26 @@ class Map(object):
 
     def iter_by_image(self):
         """Iterate over image planes of the map returning a tuple with the image
-        array and image plane index in the data array.
+        array and image plane index.
+
+        The image plane index is in data order, so that the data array can be
+        indexed directly. Here is an example for an inplace convolution of an
+        image using `astropy.convolution.convolve()` to interpolate NaN values:
+
+
+        .. code::
+
+            import numpy as np
+            from astropy.convolution import convolve
+
+            axis = MapAxis([1, 10, 100], interp='log', name='energy')
+            axis = MapAxis([1, 2, 3], interp='lin', name='time')
+            m = Map.create(width=(5, 3), axes=[axis1, axis2], binsz=0.1)
+            m.data[:, :, 15:18, 20:25] = np.nan
+
+            for img, idx in m.iter_by_image():
+                kernel = np.ones((5, 5))
+                m.data[idx] = convolve(img, kernel)
 
         Returns
         -------

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.io import fits
 from astropy.units import Quantity
-from .utils import unpack_seq
 from .geom import MapCoord, pix_tuple_to_idx, coord_to_idx
 from .utils import interp_to_order
 from .hpxmap import HpxMap

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -171,24 +171,6 @@ class HpxNDMap(HpxMap):
         hpx2wcs.fill_wcs_map_from_hpx_data(hpx_data, wcs_data, normalize)
         return WcsNDMap(wcs, wcs_data, unit=self.unit)
 
-    def iter_by_image(self):
-        for idx in np.ndindex(self.geom.shape):
-            yield self.data[idx[::-1]], idx
-
-    def iter_by_pix(self, buffersize=1):
-        idx = list(self.geom.get_idx(flat=True))
-        vals = self.data[np.isfinite(self.data)]
-        return unpack_seq(np.nditer([vals] + idx,
-                                    flags=['external_loop', 'buffered'],
-                                    buffersize=buffersize))
-
-    def iter_by_coord(self, buffersize=1):
-        coords = list(self.geom.get_coord(flat=True))
-        vals = self.data[np.isfinite(self.data)]
-        return unpack_seq(np.nditer([vals] + coords,
-                                    flags=['external_loop', 'buffered'],
-                                    buffersize=buffersize))
-
     def sum_over_axes(self):
         """Sum over all non-spatial dimensions.
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -247,13 +247,14 @@ def test_map_properties():
 
 @requires_dependency('reproject')
 def test_map_reproject_wcs_to_wcs():
-    axis = MapAxis.from_bounds(1.0, 10.0, 3, interp='log', name='energy', node_type='center')
+    axis1 = MapAxis.from_bounds(1.0, 10.0, 3, interp='log', name='energy', node_type='center')
+    axis2 = MapAxis.from_bounds(1.0, 10.0, 4, interp='lin', name='time', node_type='center')
     geom_wcs_1 = WcsGeom.create(skydir=(266.405, -28.936), npix=(11, 11),
-                                binsz=0.1, axes=[axis], coordsys='CEL')
+                                binsz=0.1, axes=[axis1, axis2], coordsys='CEL')
     geom_wcs_2 = WcsGeom.create(skydir=(0, 0), npix=(11, 11), binsz=0.1,
-                                axes=[axis], coordsys='GAL')
+                                axes=[axis1, axis2], coordsys='GAL')
 
-    data = np.arange(11 * 11 * 3).reshape(geom_wcs_1.data_shape)
+    data = np.arange(11 * 11 * 3 * 4).reshape(geom_wcs_1.data_shape)
     m = WcsNDMap(geom_wcs_1, data=data)
     m_r = m.reproject(geom_wcs_2)
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -462,10 +462,10 @@ def test_convolve_vs_smooth():
     m = WcsNDMap.create(binsz=binsz, width=1.05 * u.deg, axes=axes)
     m.data[:, :, 10, 10] = 1.
 
-    desired = m.smooth(kernel='gauss', radius=0.25 * u.deg)
-    gauss = Gaussian2DKernel(5)
+    desired = m.smooth(kernel='gauss', radius=0.5 * u.deg, mode='constant')
+    gauss = Gaussian2DKernel(5).array
     actual = m.convolve(kernel=gauss)
-    assert_allclose(actual, desired)
+    assert_allclose(actual.data, desired.data, rtol=1e-3)
 
 
 @requires_dependency('scipy')

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -8,7 +8,6 @@ import astropy.units as u
 from astropy.nddata import Cutout2D
 from astropy.convolution import Tophat2DKernel
 from ..extern.skimage import block_reduce
-from .utils import unpack_seq
 from .geom import pix_tuple_to_idx
 from .wcs import _check_width
 from .utils import interp_to_order

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -220,24 +220,6 @@ class WcsNDMap(WcsMap):
         idx = pix_tuple_to_idx(idx)
         self.data.T[idx] = vals
 
-    def iter_by_image(self):
-        for idx in np.ndindex(self.geom.shape):
-            yield self.data[idx[::-1]], idx
-
-    def iter_by_pix(self, buffersize=1):
-        pix = list(self.geom.get_idx(flat=True))
-        vals = self.data[np.isfinite(self.data)]
-        return unpack_seq(np.nditer([vals] + pix,
-                                    flags=['external_loop', 'buffered'],
-                                    buffersize=buffersize))
-
-    def iter_by_coord(self, buffersize=1):
-        coords = list(self.geom.get_coord(flat=True))
-        vals = self.data[np.isfinite(self.data)]
-        return unpack_seq(np.nditer([vals] + coords,
-                                    flags=['external_loop', 'buffered'],
-                                    buffersize=buffersize))
-
     def sum_over_axes(self):
         axis = tuple(range(self.data.ndim - 2))
         data = np.nansum(self.data, axis=axis)


### PR DESCRIPTION
This PR fixes and unifies the `Map.iter_by_image()` behaviour by returning a reversed `idx`. The  behaviour is now documented and used uniformly in `.convolve()`, `.smooth()` and `.reproject()`.
This PR also fixes #1728.