### PR TITLE
Add make black command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,13 @@ flake8:
     --exclude=gammapy/extern,gammapy/conftest.py,gammapy/_astropy_init.py,__init__.py \
     --ignore=E501
 
+black:
+	# TODO: clean up one sub-package at a time and remove from the exclude
+	black $(PROJECT)/ \
+	--exclude="_astropy_init.py|extern/|astro/|background/|catalog/|cube/|data/|detect/|image/|irf/|maps/|scripts/|spectrum/|stats/|time/|/utils" \
+	--line-length 88 \
+	--skip-string-normalization
+
 # TODO: once the errors are fixed, remove the -E option and tackle the warnings
 # Note: pylint is very thorough, but slow, and has false positives or nitpicky stuff
 pylint:

--- a/gammapy/__init__.py
+++ b/gammapy/__init__.py
@@ -39,6 +39,7 @@ the following sub-packages (e.g. `gammapy.spectrum`):
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *
+
 # ----------------------------------------------------------------------------
 
 # For egg_info test builds to pass, put package imports here.
@@ -64,17 +65,18 @@ def song(karaoke=False):
     webbrowser.open('http://gammapy.org/gammapy_song.mp3')
 
     if karaoke:
-        lyrics = ("\nGammapy Song Lyrics\n"
-                  "-------------------\n\n"
-                  "Gammapy, gamma-ray data analysis package\n"
-                  "Gammapy, prototype software CTA science tools\n\n"
-                  "Supernova remnants, pulsar winds, AGN, Gamma, Gamma, Gammapy\n"
-                  "Galactic plane survey, pevatrons, Gammapy, Gamma, Gammapy\n"
-                  "Gammapy, github, continuous integration, readthedocs, travis, "
-                  "open source project\n\n"
-                  "Gammapy, Gammapy\n\n"
-                  "Supernova remnants, pulsar winds, AGN, Gamma, Gamma, Gammapy\n"
-                  )
+        lyrics = (
+            "\nGammapy Song Lyrics\n"
+            "-------------------\n\n"
+            "Gammapy, gamma-ray data analysis package\n"
+            "Gammapy, prototype software CTA science tools\n\n"
+            "Supernova remnants, pulsar winds, AGN, Gamma, Gamma, Gammapy\n"
+            "Galactic plane survey, pevatrons, Gammapy, Gamma, Gammapy\n"
+            "Gammapy, github, continuous integration, readthedocs, travis, "
+            "open source project\n\n"
+            "Gammapy, Gammapy\n\n"
+            "Supernova remnants, pulsar winds, AGN, Gamma, Gamma, Gammapy\n"
+        )
 
         centered = '\n'.join('{:^80}'.format(s) for s in lyrics.split('\n'))
         sys.stdout.write(centered)

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -32,6 +32,7 @@ PYTEST_HEADER_MODULES['photutils'] = 'photutils'
 def pytest_configure(config):
     """Print some info ..."""
     from .utils.testing import has_data
+
     print('')
     print('Gammapy test data availability:')
 
@@ -47,6 +48,7 @@ def pytest_configure(config):
         # Switch to non-interactive plotting backend to avoid GUI windows
         # popping up while running the tests.
         import matplotlib
+
         matplotlib.use('agg')
         print('Setting matplotlib backend to "agg" for the tests.')
     except ImportError:

--- a/gammapy/datasets/__init__.py
+++ b/gammapy/datasets/__init__.py
@@ -3,5 +3,3 @@
 """
 from .core import *
 from .load import *
-
-

--- a/gammapy/datasets/core.py
+++ b/gammapy/datasets/core.py
@@ -9,10 +9,7 @@ from astropy.table import Table
 import astropy.utils.data
 from ..extern.pathlib import Path
 
-__all__ = [
-    'Datasets',
-    'gammapy_extra',
-]
+__all__ = ['Datasets', 'gammapy_extra']
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +19,9 @@ log = logging.getLogger(__name__)
 DATASET_DIR = Path.home() / '.gammapy/datasets'
 
 
-def download_file(url, filename, overwrite=False, mkdir=True, show_progress=True, timeout=None):
+def download_file(
+    url, filename, overwrite=False, mkdir=True, show_progress=True, timeout=None
+):
     """Download a URL to a given filename.
 
     This is a wrapper for the `astropy.utils.data.download_file` function,
@@ -44,7 +43,8 @@ def download_file(url, filename, overwrite=False, mkdir=True, show_progress=True
 
     # This saves the file to a temp folder, with `cache=False` the Astropy cache isn't touched!
     temp_filename = astropy.utils.data.download_file(
-        remote_url=url, cache=False, show_progress=show_progress, timeout=timeout)
+        remote_url=url, cache=False, show_progress=show_progress, timeout=timeout
+    )
 
     shutil.move(temp_filename, str(filename))
 
@@ -61,11 +61,7 @@ def make_dataset(config):
     description = config.get('description')
     tags = config.get('tags')
     ds = OneFileDataset(
-        name=name,
-        filename=filename,
-        url=url,
-        description=description,
-        tags=tags
+        name=name, filename=filename, url=url, description=description, tags=tags
     )
     return ds
 
@@ -119,6 +115,7 @@ class Datasets(object):
     datasets : list of `Dataset` objects
         List of datasets
     """
+
     # DEFAULT_CONFIG_FILE = Path.home() / '.gammapy/data-register.yaml'
     DEFAULT_CONFIG_FILE = astropy.utils.data.get_pkg_data_filename('datasets.yaml')
 
@@ -149,6 +146,7 @@ class Datasets(object):
     @staticmethod
     def _load_config(filename):
         import yaml
+
         with Path(filename).open() as fh:
             config = yaml.safe_load(fh)
         return config
@@ -203,6 +201,7 @@ class GammapyExtraNotFoundError(OSError):
 
     You have to set the GAMMAPY_EXTRA environment variable so that it's found.
     """
+
     pass
 
 

--- a/gammapy/datasets/load.py
+++ b/gammapy/datasets/load.py
@@ -78,12 +78,14 @@ def load_tev_spectrum(source_name):
         Energy spectrum as a table (one flux point per row).
     """
     if source_name == 'crab':
-        filename = gammapy_extra.filename('test_datasets/unbundled/tev_spectra/crab_hess_spec.txt')
+        filename = gammapy_extra.filename(
+            'test_datasets/unbundled/tev_spectra/crab_hess_spec.txt'
+        )
     else:
-        raise ValueError('Data not available for source: {}'.format(source_name))
+        raise ValueError('Data not available for source: {!r}'.format(source_name))
 
-    table = Table.read(filename, format='ascii',
-                       names=['energy', 'flux', 'flux_lo', 'flux_hi'])
+    names = ['energy', 'flux', 'flux_lo', 'flux_hi']
+    table = Table.read(filename, format='ascii', names=names)
     table['flux_err'] = 0.5 * (table['flux_lo'] + table['flux_hi'])
     return table
 
@@ -128,7 +130,9 @@ def load_crab_flux_points(component='both'):
     Aleksic et al. Astron. Astrophys. 540 2012
     and Abdo et al. Astrophys. J. Suppl. Ser. 208 2013.
     """
-    filename = gammapy_extra.filename('test_datasets/unbundled/tev_spectra/crab_mwl.fits.gz')
+    filename = gammapy_extra.filename(
+        'test_datasets/unbundled/tev_spectra/crab_mwl.fits.gz'
+    )
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UnitsWarning)
@@ -176,8 +180,9 @@ def load_diffuse_gamma_spectrum(reference):
 
 
 def _read_diffuse_gamma_spectrum_fermi(filename):
-    table = Table.read(filename, format='ascii',
-                       names=['energy', 'flux', 'flux_hi', 'flux_lo'])
+    table = Table.read(
+        filename, format='ascii', names=['energy', 'flux', 'flux_hi', 'flux_lo']
+    )
     table['flux_err'] = 0.5 * (table['flux_lo'] + table['flux_hi'])
 
     table['energy'] = Quantity(table['energy'], 'MeV').to('TeV')
@@ -222,8 +227,9 @@ def load_electron_spectrum(reference):
 
 
 def _read_electron_spectrum_hess(filename):
-    table = Table.read(filename, format='ascii',
-                       names=['energy', 'flux', 'flux_lo', 'flux_hi'])
+    table = Table.read(
+        filename, format='ascii', names=['energy', 'flux', 'flux_lo', 'flux_hi']
+    )
     table['flux_err'] = 0.5 * (table['flux_lo'] + table['flux_hi'])
 
     table['energy'] = Quantity(table['energy'], 'GeV').to('TeV')
@@ -244,8 +250,8 @@ def _read_electron_spectrum_fermi(filename):
 
     table = Table()
     table['energy'] = Quantity(t['E'], 'GeV').to('TeV')
-    table['flux'] = Quantity(t['y'], 'm^-2 s^-1 GeV^-1 sr^-1').to('m^-2 s^-1 TeV^-1 sr^-1')
-    flux_err = 0.5 * (t['yerrtot_lo'] + t['yerrtot_up'])
-    table['flux_err'] = Quantity(flux_err, 'm^-2 s^-1 GeV^-1 sr^-1').to('m^-2 s^-1 TeV^-1 sr^-1')
+    table['flux'] = Quantity(t['y'], 'm-2 s-1 GeV-1 sr-1').to('m-2 s-1 TeV-1 sr-1')
+    val = 0.5 * (t['yerrtot_lo'] + t['yerrtot_up'])
+    table['flux_err'] = Quantity(val, 'm-2 s-1 GeV-1 sr-1').to('m-2 s-1 TeV-1 sr-1')
 
     return table

--- a/gammapy/datasets/setup_package.py
+++ b/gammapy/datasets/setup_package.py
@@ -2,7 +2,5 @@
 
 
 def get_package_data():
-    files = [
-        'datasets.yaml',
-    ]
+    files = ['datasets.yaml']
     return {'gammapy.datasets': files}

--- a/gammapy/datasets/tests/test_load.py
+++ b/gammapy/datasets/tests/test_load.py
@@ -3,9 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_data
 from ..core import gammapy_extra
-from ...datasets import (
-    load_poisson_stats_image,
-)
+from ...datasets import load_poisson_stats_image
 
 
 @requires_data('gammapy-extra')


### PR DESCRIPTION
This PR adds a `make black` command that runs black on our code.

For now, I have added all the Gammapy sub-packages to the exclude pattern.

This allows us to do one at a time, at any time we like.

Let's fix some issues with maps and modeling and come back to this cleanup later.

#1423 is still open.