### PR TITLE
Default print_level=0 for iminuit?

### DIFF
--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -46,10 +46,15 @@ def fit_iminuit(parameters, function, opts_minuit=None):
     # This means `errordef=1` in the Minuit interface is correct
     opts_minuit.setdefault('errordef', 1)
 
+    opts_minuit.setdefault('print_level', 0)
+
     parnames = _make_parnames(parameters)
-    minuit = Minuit(minuit_func.fcn,
-                    forced_parameters=parnames,
-                    **opts_minuit)
+    minuit = Minuit(
+        minuit_func.fcn,
+        forced_parameters=parnames,
+        **opts_minuit
+    )
+
     minuit.migrad()
 
     parameters.set_parameter_factors(minuit.args)
@@ -123,6 +128,6 @@ def _get_covar(minuit):
     m = np.zeros((n, n))
     for i1, k1 in enumerate(minuit.parameters):
         for i2, k2 in enumerate(minuit.parameters):
-            if set([k1, k2]).issubset(minuit.list_of_vary_param()):
+            if {k1, k2} <= set(minuit.list_of_vary_param()):
                 m[i1, i2] = minuit.covariance[(k1, k2)]
     return m


### PR DESCRIPTION
Currently when computing spectral points in Jupyter, one gets a lot of HTML output, one fit result table for every fit / spectral point.

See e.g. here: https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/notebooks/spectrum_analysis.ipynb#Compute-Flux-Points

We could expose `opts_iminuit` for spectral points also, and pass `print_level=0` there from scripts, or by default.

But I'm thinking probably we should make `print_level=0` the default, so that iminuit is silent by default and becomes more of a "backend", not the primary means everywhere to show fit results.

And then probably we should also expose the `opts_iminuit` for FluxPointEstimator, but doing this backend configuration well will probably take longer, e.g. there are different options experts might want to pass to Minuit init or migrad call or hesse call or ...

@adonath - Thoughts?