### PR TITLE
Unify and fix testing of .plot() methods

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -1009,3 +1009,25 @@ Notes:
 * Finally, we realise that eventually probably CTA will define this, and Gammapy
   is only a prototype. So if CTA chooses something else, probably we will follow
   suite and do one more backward-incompatible change at some point to align with CTA.
+
+
+Testing of plotting functions
+-----------------------------
+
+Many of the data classes in Gammapy implement `.plot()` or `.peek()` methods to
+allow users a quick look in the data. Those methods should be tested using the
+`mpl_check_plot()` context manager. The context manager will take care of creating
+a new figure to plot on and writing the plot to a byte-stream to trigger the
+rendering of the plot, which can rasie errore as well. Here is a short example:
+
+.. code-block:: python
+
+    from gammapy.utils.testing import mpl_plot_check
+
+    with mpl_plot_check():
+        events.plot_histogram()
+
+With this approach we make sure that the plotting code is at least executed once
+and runs completely (up to saving the plot to file) without errors. In future we
+will maybe change to something like https://github.com/matplotlib/pytest-mpl
+to ensure that correct plots are produced.

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -1024,8 +1024,11 @@ rendering of the plot, which can rasie errore as well. Here is a short example:
 
     from gammapy.utils.testing import mpl_plot_check
 
-    with mpl_plot_check():
-        events.plot_histogram()
+    def test_plot():
+        import matplotlib.pyplot as plt
+        with mpl_plot_check():
+            plt.plot([1., 2., 3., 4., 5.])
+
 
 With this approach we make sure that the plotting code is at least executed once
 and runs completely (up to saving the plot to file) without errors. In future we

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -1014,7 +1014,7 @@ Notes:
 Testing of plotting functions
 -----------------------------
 
-Many of the data classes in Gammapy implement `.plot()` or `.peek()` methods to
+Many of the data classes in Gammapy implement ``.plot()`` or ``.peek()`` methods to
 allow users a quick look in the data. Those methods should be tested using the
 `mpl_check_plot()` context manager. The context manager will take care of creating
 a new figure to plot on and writing the plot to a byte-stream to trigger the

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from astropy.coordinates import SkyCoord, Angle
 from regions import CircleSkyRegion
-from ...utils.testing import requires_data, requires_dependency, assert_quantity_allclose
+from ...utils.testing import (requires_data, requires_dependency,
+                              assert_quantity_allclose, mpl_plot_check)
 from ...maps import WcsNDMap, WcsGeom
 from ...data import DataStore
 from ..reflected import ReflectedRegionsFinder, ReflectedRegionsBackgroundEstimator
@@ -98,6 +99,7 @@ class TestReflectedRegionBackgroundEstimator:
     @requires_dependency('matplotlib')
     def test_plot(self):
         self.bg_maker.run()
-        self.bg_maker.plot()
-        self.bg_maker.plot(idx=1)
-        self.bg_maker.plot(idx=[0, 1])
+        with mpl_plot_check():
+            self.bg_maker.plot()
+            self.bg_maker.plot(idx=1)
+            self.bg_maker.plot(idx=[0, 1])

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...data import EventList, EventListLAT, EventListDataset, EventListDatasetChecker
 
 
@@ -35,11 +35,13 @@ class TestEventListHESS:
 
     @requires_dependency('matplotlib')
     def test_peek(self):
-        self.events.peek()
+        with mpl_plot_check():
+            self.events.peek()
 
     @requires_dependency('matplotlib')
     def test_plot_offset2_distribution(self):
-        self.events.plot_offset2_distribution()
+        with mpl_plot_check():
+            self.events.plot_offset2_distribution()
 
 
 @requires_data('gammapy-extra')
@@ -53,7 +55,8 @@ class TestEventListFermi:
 
     @requires_dependency('matplotlib')
     def test_plot_image(self):
-        self.events.plot_image()
+        with mpl_plot_check():
+            self.events.plot_image()
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from regions import CircleSkyRegion
 from ...data import DataStore, ObservationTableSummary, ObservationSummary
 from ...data import ObservationStats
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data, requires_dependency, mpl_plot_check
 from ...background import ReflectedRegionsBackgroundEstimator
 
 
@@ -34,11 +34,13 @@ class TestObservationSummaryTable:
 
     @requires_dependency('matplotlib')
     def test_plot_zenith(self):
-        self.table_summary.plot_zenith_distribution()
+        with mpl_plot_check():
+            self.table_summary.plot_zenith_distribution()
 
     @requires_dependency('matplotlib')
     def test_plot_offset(self):
-        self.table_summary.plot_offset_distribution()
+        with mpl_plot_check():
+            self.table_summary.plot_offset_distribution()
 
 
 @requires_data('gammapy-extra')
@@ -89,20 +91,25 @@ class TestObservationSummary:
 
     @requires_dependency('matplotlib')
     def test_plot_significance(self):
-        self.obs_summary.plot_significance_vs_livetime()
+        with mpl_plot_check():
+            self.obs_summary.plot_significance_vs_livetime()
 
     @requires_dependency('matplotlib')
     def test_plot_excess(self):
-        self.obs_summary.plot_excess_vs_livetime()
+        with mpl_plot_check():
+            self.obs_summary.plot_excess_vs_livetime()
 
     @requires_dependency('matplotlib')
     def test_plot_background(self):
-        self.obs_summary.plot_background_vs_livetime()
+        with mpl_plot_check():
+            self.obs_summary.plot_background_vs_livetime()
 
     @requires_dependency('matplotlib')
     def test_plot_gamma_rate(self):
-        self.obs_summary.plot_gamma_rate()
+        with mpl_plot_check():
+            self.obs_summary.plot_gamma_rate()
 
     @requires_dependency('matplotlib')
     def test_plot_background_rate(self):
-        self.obs_summary.plot_background_rate()
+        with mpl_plot_check():
+            self.obs_summary.plot_background_rate()

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -7,7 +7,7 @@ from astropy.table import Table
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency, mpl_savefig_check
+from ...utils.testing import requires_dependency, mpl_plot_check
 from ...maps import WcsNDMap, WcsGeom
 from ..profile import compute_binning, ImageProfile, ImageProfileEstimator
 
@@ -130,5 +130,5 @@ class TestImageProfile(object):
 
     @requires_dependency('matplotlib')
     def test_peek(self, cosine_profile):
-        cosine_profile.peek()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            cosine_profile.peek()

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -59,6 +59,7 @@ class TestEffectiveAreaTable2D:
         desired = aeff.data.evaluate(offset=offset)
         assert_equal(actual.value, desired.value)
 
+    @staticmethod
     def test_plot(aeff):
         with mpl_plot_check():
             aeff.plot()

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -5,7 +5,7 @@ import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose, assert_equal
 from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
 
 
@@ -38,10 +38,6 @@ class TestEffectiveAreaTable2D:
         test_val = aeff.data.evaluate(energy='14 TeV', offset='0.2 deg')
         assert_allclose(test_val.value, 740929.645, atol=1e-2)
 
-        aeff.plot()
-        aeff.plot_energy_dependence()
-        aeff.plot_offset_dependence()
-
         # Test ARF export
         offset = 0.236 * u.deg
         e_axis = np.logspace(0, 1, 20) * u.TeV
@@ -63,6 +59,16 @@ class TestEffectiveAreaTable2D:
         desired = aeff.data.evaluate(offset=offset)
         assert_equal(actual.value, desired.value)
 
+    def test_plot(aeff):
+        with mpl_plot_check():
+            aeff.plot()
+        
+        with mpl_plot_check():
+            aeff.plot_energy_dependence()
+        
+        with mpl_plot_check():
+            aeff.plot_offset_dependence()
+
 
 class TestEffectiveAreaTable:
 
@@ -75,7 +81,8 @@ class TestEffectiveAreaTable:
 
         assert_quantity_allclose(arf.data.evaluate(), arf.data.data)
 
-        arf.plot()
+        with mpl_plot_check():
+            arf.plot()
 
         filename = str(tmpdir / 'effarea_test.fits')
         arf.write(filename)

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -21,7 +21,6 @@ class TestEffectiveAreaTable2D:
     # Add I/O test
     @staticmethod
     @requires_dependency('scipy')
-    @requires_dependency('matplotlib')
     @requires_data('gammapy-extra')
     def test(aeff):
         assert aeff.data.axis('energy').nbins == 73
@@ -60,6 +59,8 @@ class TestEffectiveAreaTable2D:
         assert_equal(actual.value, desired.value)
 
     @staticmethod
+    @requires_dependency('matplotlib')
+    @requires_data('gammapy-extra')
     def test_plot(aeff):
         with mpl_plot_check():
             aeff.plot()

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EnergyDispersion2D
-f
+
 
 @requires_dependency('scipy')
 class TestEnergyDispersion:

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -5,11 +5,10 @@ import pytest
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import Angle
 import astropy.units as u
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EnergyDispersion2D
-from ...utils.testing import mpl_savefig_check
-
+f
 
 @requires_dependency('scipy')
 class TestEnergyDispersion:
@@ -86,18 +85,18 @@ class TestEnergyDispersion:
 
     @requires_dependency('matplotlib')
     def test_plot_matrix(self):
-        self.edisp.plot_matrix()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.edisp.plot_matrix()
 
     @requires_dependency('matplotlib')
     def test_plot_bias(self):
-        self.edisp.plot_bias()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.edisp.plot_bias()
 
     @requires_dependency('matplotlib')
     def test_peek(self):
-        self.edisp.peek()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.edisp.peek()
 
 
 @requires_dependency('scipy')
@@ -186,15 +185,15 @@ class TestEnergyDispersion2D:
 
     @requires_dependency('matplotlib')
     def test_plot_migration(self):
-        self.edisp.plot_migration()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.edisp.plot_migration()
 
     @requires_dependency('matplotlib')
     def test_plot_bias(self):
-        self.edisp.plot_bias()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.edisp.plot_bias()
 
     @requires_dependency('matplotlib')
     def test_peek(self):
-        self.edisp.peek()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.edisp.peek()

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
-from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check
+from ...utils.testing import requires_data, requires_dependency, mpl_plot_check
 from ...utils.testing import assert_quantity_allclose
 from ..io import CTAIrf, CTAPerf
 
@@ -42,5 +42,5 @@ def test_cta_irf():
 def test_point_like_perf():
     filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
     cta_perf = CTAPerf.read(filename)
-    cta_perf.peek()
-    mpl_savefig_check()
+    with mpl_plot_check():
+        cta_perf.peek()

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
-from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...irf import PSF3D
 
 pytest.importorskip('scipy')
@@ -75,19 +75,19 @@ def test_psf_3d_write(psf_3d, tmpdir):
 @requires_data('gammapy-extra')
 @requires_dependency('matplotlib')
 def test_psf_3d_plot_vs_rad(psf_3d):
-    psf_3d.plot_psf_vs_rad()
-    mpl_savefig_check()
+    with mpl_plot_check():
+        psf_3d.plot_psf_vs_rad()
 
 
 @requires_data('gammapy-extra')
 @requires_dependency('matplotlib')
 def test_psf_3d_plot_containment(psf_3d):
-    psf_3d.plot_containment(show_safe_energy=True)
-    mpl_savefig_check()
+    with mpl_plot_check():     
+        psf_3d.plot_containment(show_safe_energy=True)
 
 
 @requires_data('gammapy-extra')
 @requires_dependency('matplotlib')
 def test_psf_3d_peek(psf_3d):
-    psf_3d.peek()
-    mpl_savefig_check()
+    with mpl_plot_check():    
+        psf_3d.peek()

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import pytest
 from astropy.units import Quantity
 from astropy.coordinates import Angle
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.testing import assert_quantity_allclose
 from ...irf import TablePSF, EnergyDependentTablePSF
 
@@ -116,11 +116,13 @@ class TestEnergyDependentTablePSF:
 
     @requires_dependency('matplotlib')
     def test_plot(self):
-        self.psf.plot_containment_vs_energy()
+        with mpl_plot_check():
+            self.psf.plot_containment_vs_energy()
 
         energy = Quantity(1, 'GeV')
         psf_1GeV = self.psf.table_psf_at_energy(energy)
-        psf_1GeV.plot_psf_vs_rad()
+        with mpl_plot_check():
+            psf_1GeV.plot_psf_vs_rad()
 
     # TODO: fix this test (move the code from examples/plot_irfs.py here)
     @pytest.mark.xfail
@@ -128,4 +130,5 @@ class TestEnergyDependentTablePSF:
     def test_plot2(self):
         # psf.plot_containment('fermi_psf_containment.pdf')
         # psf.plot_exposure('fermi_psf_exposure.pdf')
-        self.psf.plot_psf_vs_rad()
+        with mpl_plot_check():
+            self.psf.plot_psf_vs_rad()

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -13,6 +13,7 @@ from ..hpx import HpxGeom
 from ..hpxmap import HpxMap
 from ..hpxnd import HpxNDMap
 from ..hpxsparse import HpxSparseMap
+from ...utils.testing import mpl_plot_check, requires_dependency
 
 pytest.importorskip('scipy')
 pytest.importorskip('healpy')
@@ -320,3 +321,17 @@ def test_coadd_unit():
     m1.coadd(m2)
 
     assert_allclose(m1.data, 1.0001)
+
+
+@requires_dependency('matplotlib')
+def test_plot():
+    m = HpxNDMap.create(binsz=10)
+    with mpl_plot_check():
+        m.plot()
+
+
+@requires_dependency('matplotlib')
+def test_plot_poly():
+    m = HpxNDMap.create(binsz=10)
+    with mpl_plot_check():
+        m.plot(method='poly')

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -7,7 +7,7 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy.convolution import Gaussian2DKernel
 import astropy.units as u
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...cube import PSFKernel
 from ...irf import EnergyDependentMultiGaussPSF
 from ..utils import fill_poisson
@@ -500,3 +500,16 @@ def test_convolve_pixel_scale_error():
     with pytest.raises(ValueError) as err:
         m.convolve(kernel)
         assert 'Kernel shape larger' in str(err.value)
+
+
+@requires_dependency('matplotlib')
+def test_plot():
+    m = WcsNDMap.create(binsz=0.1 * u.deg, width=1 * u.deg)
+    with mpl_plot_check():
+        m.plot(add_cbar=True)
+
+@requires_dependency('matplotlib')
+def test_plot_allsky():
+    m = WcsNDMap.create(binsz=10 * u.deg)
+    with mpl_plot_check():
+        m.plot()

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -447,10 +447,6 @@ class WcsNDMap(WcsMap):
         caxes = ax.imshow(data, **kwargs)
         cbar = fig.colorbar(caxes, ax=ax, label=str(self.unit)) if add_cbar else None
 
-        if cbar:
-            cbar.formatter.set_powerlimits((0, 0))
-            cbar.update_ticks()
-
         if self.geom.is_allsky:
             ax = self._plot_format_allsky(ax)
         else:

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import numpy as np
 import astropy.units as u
 from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency
+from ...utils.testing import requires_dependency, mpl_plot_check
 from ...utils.energy import EnergyBounds
 from .. import CountsSpectrum, PHACountsSpectrum
 
@@ -44,8 +44,11 @@ class TestCountsSpectrum:
 
     @requires_dependency('matplotlib')
     def test_plot(self):
-        self.spec.plot()
-        self.spec.plot_hist()
+        with mpl_plot_check():
+            self.spec.plot()
+        
+        with mpl_plot_check():
+            self.spec.plot_hist()
 
     def test_io(self, tmpdir):
         filename = tmpdir / 'test.fits'

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.random import get_random_state
 from ...irf import EffectiveAreaTable
 from ...spectrum import (
@@ -152,8 +152,9 @@ class TestFit:
                           forward_folded=False)
 
         scan_idx = np.linspace(1, 3, 20)
-        fit.plot_likelihood_1d(model=self.source_model, parname='index',
-                               parvals=scan_idx)
+        with mpl_plot_check():
+            fit.plot_likelihood_1d(model=self.source_model, parname='index',
+                                   parvals=scan_idx)
         # TODO: add assert, see issue 294
 
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -6,7 +6,8 @@ from numpy.testing import assert_allclose
 from astropy.table import Table
 import astropy.units as u
 from ...catalog.fermi import SourceCatalog3FGL
-from ...utils.testing import requires_dependency, requires_data, assert_quantity_allclose
+from ...utils.testing import (requires_dependency, requires_data,
+                              assert_quantity_allclose, mpl_plot_check)
 from ...utils.modeling import Parameters
 from ..results import SpectrumResult
 from ..fit import SpectrumFit
@@ -225,7 +226,8 @@ class TestFluxPointEstimator:
         actual = result.flux_point_residuals[1][0]
         assert_allclose(actual, 0.08519, rtol=1e-2)
 
-        result.plot(energy_range=[1, 10] * u.TeV)
+        with mpl_plot_check():
+            result.plot(energy_range=[1, 10] * u.TeV)
 
 
 @requires_data('gammapy-extra')
@@ -298,7 +300,8 @@ class TestFluxPoints:
 
     @requires_dependency('matplotlib')
     def test_plot(self, flux_points):
-        flux_points.plot()
+        with mpl_plot_check():
+            flux_points.plot()
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -4,7 +4,7 @@ import pytest
 import astropy.units as u
 from ...utils.energy import EnergyBounds
 from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ..models import (PowerLaw, PowerLaw2, ExponentialCutoffPowerLaw,
                       ExponentialCutoffPowerLaw3FGL, LogParabola,
                       TableModel, AbsorbedSpectralModel, Absorption,
@@ -214,8 +214,9 @@ def test_models(spectrum):
 def test_table_model_from_file():
     filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
     absorption_z03 = TableModel.read_xspec_model(filename=filename, param=0.3)
-    absorption_z03.plot(energy_range=(0.03, 10),
-                        energy_unit=u.TeV, flux_unit='')
+    with mpl_plot_check():
+        absorption_z03.plot(energy_range=(0.03, 10),
+                            energy_unit=u.TeV, flux_unit='')
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 from numpy.testing import assert_allclose
 from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data, mpl_savefig_check
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.scripts import make_path
 from ...irf import EffectiveAreaTable, EnergyDispersion
 from .. import (
@@ -177,8 +177,8 @@ class SpectrumObservationTester:
 
     @requires_dependency('matplotlib')
     def test_peek(self):
-        self.obs.peek()
-        mpl_savefig_check()
+        with mpl_plot_check():
+            self.obs.peek()
 
 
 @requires_dependency('scipy')

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -5,7 +5,7 @@ import astropy.units as u
 import pytest
 from astropy.table import Table
 from ...utils.testing import assert_quantity_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.energy import EnergyBounds
 from ..models import PowerLaw, ConstantModel
 from .. import SpectrumObservation, SpectrumFitResult, FluxPoints, SpectrumResult
@@ -74,7 +74,8 @@ class TestSpectrumFitResult:
 
     @requires_dependency("matplotlib")
     def test_plot(self, fit_result):
-        fit_result.plot()
+        with mpl_plot_check():
+            fit_result.plot()
 
 
 @requires_dependency("scipy")
@@ -91,4 +92,5 @@ class TestSpectrumResult:
     @requires_dependency("matplotlib")
     @requires_dependency("uncertainties")
     def test_plot(self, spectrum_result):
-        spectrum_result.plot(energy_range=[1, 10] * u.TeV, energy_power=2)
+        with mpl_plot_check():
+            spectrum_result.plot(energy_range=[1, 10] * u.TeV, energy_power=2)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -9,7 +9,7 @@ from astropy.time import Time
 import astropy.units as u
 from astropy.table import Table, Column
 from regions import CircleSkyRegion
-from ...utils.testing import requires_data, requires_dependency, mpl_savefig_check
+from ...utils.testing import requires_data, requires_dependency, mpl_plot_check
 from ...utils.testing import assert_quantity_allclose
 from ...utils.energy import EnergyBounds
 from ...data import DataStore
@@ -113,8 +113,8 @@ def test_lightcurve_chisq(lc):
 
 @requires_dependency('matplotlib')
 def test_lightcurve_plot(lc):
-    lc.plot()
-    mpl_savefig_check()
+    with mpl_plot_check():
+        lc.plot()
 
 
 @pytest.mark.parametrize('flux_unit', ['cm-2 s-1'])

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -148,21 +148,6 @@ def assert_time_allclose(actual, desired):
     assert actual.format == desired.format
 
 
-def mpl_savefig_check():
-    """Call matplotlib savefig for the current figure.
-
-    This will trigger a render of the Figure, which can sometimes
-    raise errors if there is a problem; i.e. we call this at the
-    end of every plotting test for now.
-
-    This is writing to an in-memory byte buffer, i.e. is faster
-    than writing to disk.
-    """
-    import matplotlib.pyplot as plt
-    from io import BytesIO
-    plt.savefig(BytesIO(), format='png')
-
-
 def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None, **kwargs):
     # TODO: change this later to explicitly check units are the same!
     # assert actual.unit == desired.unit
@@ -200,3 +185,24 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         raise u.UnitsError("`rtol` should be dimensionless")
 
     return actual.value, desired.value, rtol.value, atol.value
+
+
+class MPLPlotCheck(object):
+    """Matplotlib plotting test context manager.
+
+    It create a new figure on __enter__ and calls savefig for the
+    current figure in __exit__. This will trigger a render of the
+    Figure, which can sometimes raise errors if there is a problem.
+
+    This is writing to an in-memory byte buffer, i.e. is faster
+    than writing to disk.
+    """
+    def __enter__(self):
+        import matplotlib.pyplot as plt
+        plt.figure()
+
+    def __exit__(self):
+        from io import BytesIO
+        plt.savefig(BytesIO(), format='png')
+
+mpl_plot_check = MPLPlotCheck

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -187,7 +187,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
     return actual.value, desired.value, rtol.value, atol.value
 
 
-class MPLPlotCheck(object):
+class _MPLPlotCheck(object):
     """Matplotlib plotting test context manager.
 
     It create a new figure on __enter__ and calls savefig for the
@@ -201,8 +201,9 @@ class MPLPlotCheck(object):
         import matplotlib.pyplot as plt
         plt.figure()
 
-    def __exit__(self):
+    def __exit__(self, type, value, traceback):
+        import matplotlib.pyplot as plt
         from io import BytesIO
         plt.savefig(BytesIO(), format='png')
 
-mpl_plot_check = MPLPlotCheck
+mpl_plot_check = _MPLPlotCheck

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -187,7 +187,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
     return actual.value, desired.value, rtol.value, atol.value
 
 
-class _MPLPlotCheck(object):
+def mpl_plot_check():
     """Matplotlib plotting test context manager.
 
     It create a new figure on __enter__ and calls savefig for the
@@ -197,13 +197,16 @@ class _MPLPlotCheck(object):
     This is writing to an in-memory byte buffer, i.e. is faster
     than writing to disk.
     """
-    def __enter__(self):
-        import matplotlib.pyplot as plt
-        plt.figure()
+    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt
+    from io import BytesIO
 
-    def __exit__(self, type, value, traceback):
-        import matplotlib.pyplot as plt
-        from io import BytesIO
-        plt.savefig(BytesIO(), format='png')
+    class MPLPlotCheck(object):
+        def __enter__(self):
+            plt.figure()
 
-mpl_plot_check = _MPLPlotCheck
+        def __exit__(self, type, value, traceback):
+            plt.savefig(BytesIO(), format='png')
+            plt.close()
+
+    return MPLPlotCheck()


### PR DESCRIPTION
This PR fixes the issue described in #1745, by introducing the `mpl_plot_check()` context manager and changes all the exiting plot test to use it.