### PR TITLE
Introduce DataStoreChecker and ObservationChecker

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -418,3 +418,92 @@ class DataStore(object):
             colnames = np.append(['OBS_ID'], colnames)
 
         return Table(rows=rows, names=colnames)
+
+    def check(self, checks='all'):
+        checker = DataStoreChecker(self)
+        return checker.run(checks=checks)
+
+
+class DataStoreChecker(object):
+    CHECKS = OrderedDict(
+        obs_table='check_obs_table',
+        hdu_table='check_hdu_table',
+        # observations='check_observations',
+        # consistency='check_consistency',
+    )
+
+    def __init__(self, data_store):
+        self.data_store = data_store
+
+    def run(self, checks='all'):
+        if checks == 'all':
+            checks = self.CHECKS.keys()
+
+        unknown_checks = set(checks).difference(self.CHECKS.keys())
+        if unknown_checks:
+            raise ValueError('Unknown checks: {}'.format(unknown_checks))
+
+        for check in checks:
+            for record in getattr(self, self.CHECKS[check])():
+                yield record
+
+    def check_obs_table(self):
+        t = self.data_store.obs_table
+        m = t.meta
+        if m.get('HDUCLAS1', '') != 'INDEX':
+            yield {'type': 'error', 'hdu': 'obs-index', 'msg': 'Invalid header key. Must have HDUCLAS1=INDEX'}
+        if m.get('HDUCLAS2', '') != 'OBS':
+            yield {'type': 'error', 'hdu': 'obs-index', 'msg': 'Invalid header key. Must have HDUCLAS2=OBS'}
+
+    def check_hdu_table(self):
+        t = self.data_store.obs_table
+        m = t.meta
+        if m.get('HDUCLAS1', '') != 'INDEX':
+            yield {'type': 'error', 'hdu': 'hdu-index', 'msg': 'Invalid header key. Must have HDUCLAS1=INDEX'}
+        if m.get('HDUCLAS2', '') != 'HDU':
+            yield {'type': 'error', 'hdu': 'hdu-index', 'msg': 'Invalid header key. Must have HDUCLAS2=HDU'}
+
+    def check_observations(self):
+        """Perform some sanity checks for all observations.
+
+        Returns
+        -------
+        results : OrderedDict
+            dictionary containing failure messages for all runs that fail a check.
+        """
+        results = OrderedDict()
+
+        # Loop over all obs_ids in obs_table
+        for obs_id in self.obs_table['OBS_ID']:
+            messages = self.obs(obs_id).check_observation()
+            if len(messages) > 0:
+                results[obs_id] = messages
+
+        return results
+
+    def check_observation(self):
+        """Perform some basic sanity checks on this observation.
+
+        Returns
+        -------
+        results : list
+            List with failure messages for the checks that failed
+        """
+        messages = []
+        # Check that events table is not empty
+        if len(self.events.table) == 0:
+            messages.append('events table empty')
+        # Check that thresholds are meaningful for aeff
+        if self.aeff.meta['LO_THRES'] >= self.aeff.meta['HI_THRES']:
+            messages.append('LO_THRES >= HI_THRES in effective area meta data')
+        # Check that maximum value of aeff is greater than zero
+        if np.max(self.aeff.data.data) <= 0:
+            messages.append('maximum entry of effective area table <= 0')
+        # Check that maximum value of edisp matrix is greater than zero
+        if np.max(self.edisp.data.data) <= 0:
+            messages.append('maximum entry of energy dispersion table <= 0')
+        # Check that thresholds are meaningful for psf
+        if self.psf.energy_thresh_lo >= self.psf.energy_thresh_hi:
+            messages.append('LO_THRES >= HI_THRES in psf meta data')
+
+        return messages

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import sys
 import logging
 import numpy as np
 from collections import OrderedDict
@@ -429,12 +428,17 @@ class DataStore(object):
 
 
 class DataStoreChecker(object):
-    CHECKS = OrderedDict(
-        obs_table='check_obs_table',
-        hdu_table='check_hdu_table',
-        observations='check_observations',
-        consistency='check_consistency',
-    )
+    """Check data store.
+
+    Checks data format and a bit about the content.
+    """
+
+    CHECKS = OrderedDict([
+        ('obs_table', 'check_obs_table'),
+        ('hdu_table', 'check_hdu_table'),
+        ('observations', 'check_observations'),
+        ('consistency', 'check_consistency'),
+    ])
 
     def __init__(self, data_store):
         self.data_store = data_store
@@ -456,18 +460,18 @@ class DataStoreChecker(object):
         t = self.data_store.obs_table
         m = t.meta
         if m.get('HDUCLAS1', '') != 'INDEX':
-            yield {'type': 'error', 'hdu': 'obs-index', 'msg': 'Invalid header key. Must have HDUCLAS1=INDEX'}
+            yield {'level': 'error', 'hdu': 'obs-index', 'msg': 'Invalid header key. Must have HDUCLAS1=INDEX'}
         if m.get('HDUCLAS2', '') != 'OBS':
-            yield {'type': 'error', 'hdu': 'obs-index', 'msg': 'Invalid header key. Must have HDUCLAS2=OBS'}
+            yield {'level': 'error', 'hdu': 'obs-index', 'msg': 'Invalid header key. Must have HDUCLAS2=OBS'}
 
     def check_hdu_table(self):
         """Checks for the HDU index table."""
         t = self.data_store.hdu_table
         m = t.meta
         if m.get('HDUCLAS1', '') != 'INDEX':
-            yield {'type': 'error', 'hdu': 'hdu-index', 'msg': 'Invalid header key. Must have HDUCLAS1=INDEX'}
+            yield {'level': 'error', 'hdu': 'hdu-index', 'msg': 'Invalid header key. Must have HDUCLAS1=INDEX'}
         if m.get('HDUCLAS2', '') != 'HDU':
-            yield {'type': 'error', 'hdu': 'hdu-index', 'msg': 'Invalid header key. Must have HDUCLAS2=HDU'}
+            yield {'level': 'error', 'hdu': 'hdu-index', 'msg': 'Invalid header key. Must have HDUCLAS2=HDU'}
 
         # Check that all HDU in the data files exist
         for idx in range(len(t)):
@@ -475,7 +479,7 @@ class DataStoreChecker(object):
             try:
                 location_info.get_hdu()
             except KeyError:
-                yield {'type': 'error', 'msg': 'HDU not found: {!r}'.format(location_info.__dict__)}
+                yield {'level': 'error', 'msg': 'HDU not found: {!r}'.format(location_info.__dict__)}
 
         # TODO: all HDU in the index table should be present
 
@@ -485,7 +489,7 @@ class DataStoreChecker(object):
         obs_table_obs_id = set(self.data_store.obs_table['OBS_ID'])
         hdu_table_obs_id = set(self.data_store.hdu_table['OBS_ID'])
         if not obs_table_obs_id == hdu_table_obs_id:
-            yield {'type': 'error', 'msg': 'Inconsistent OBS_ID in obs and HDU index tables'}
+            yield {'level': 'error', 'msg': 'Inconsistent OBS_ID in obs and HDU index tables'}
 
         # TODO: obs table and events header should have the same times
 
@@ -493,28 +497,95 @@ class DataStoreChecker(object):
         """Perform some sanity checks for all observations."""
         for obs_id in self.data_store.obs_table['OBS_ID']:
             obs = self.data_store.obs(obs_id)
-
-            for records in self.check_observation(obs):
+            for records in ObservationChecker(obs).run():
                 yield records
 
-    @staticmethod
-    def check_observation(obs):
-        """Perform some basic sanity checks on this observation."""
 
-        # Check that events table is not empty
-        events = obs.events
+class ObservationChecker:
+    """Check an observation.
+
+    Checks data format and a bit about the content.
+    """
+
+    CHECKS = OrderedDict([
+        ('events', 'check_events'),
+        ('aeff', 'check_aeff'),
+        ('edisp', 'check_edisp'),
+        ('psf', 'check_psf'),
+    ])
+
+    def __init__(self, obs):
+        self.obs = obs
+
+    def _record(self, level='info', msg=None):
+        return {
+            'level': level,
+            'obs_id': self.obs.obs_id,
+            'msg': msg,
+        }
+
+    def run(self):
+        yield self._record(level='debug', msg='Starting observation check')
+
+        for record in self.check_events():
+            yield record
+
+        for record in self.check_aeff():
+            yield record
+
+        for record in self.check_edisp():
+            yield record
+
+        for record in self.check_psf():
+            yield record
+
+    def check_events(self):
+        yield self._record(level='debug', msg='Starting events check')
+
+        try:
+            events = self.obs.load('events')
+        except:
+            yield self._record(level='warning', msg='Loading events failed')
+            return
+
         if len(events.table) == 0:
-            yield {'type': 'error', 'obs_id': obs.obs_id, 'msg': 'Events table has zero rows'}
+            yield self._record(level='error', msg='Events table has zero rows')
 
-        # # Check that thresholds are meaningful for aeff
-        # if self.aeff.meta['LO_THRES'] >= self.aeff.meta['HI_THRES']:
-        #     messages.append('LO_THRES >= HI_THRES in effective area meta data')
-        # # Check that maximum value of aeff is greater than zero
-        # if np.max(self.aeff.data.data) <= 0:
-        #     messages.append('maximum entry of effective area table <= 0')
-        # # Check that maximum value of edisp matrix is greater than zero
-        # if np.max(self.edisp.data.data) <= 0:
-        #     messages.append('maximum entry of energy dispersion table <= 0')
-        # # Check that thresholds are meaningful for psf
-        # if self.psf.energy_thresh_lo >= self.psf.energy_thresh_hi:
-        #     messages.append('LO_THRES >= HI_THRES in psf meta data')
+    def check_aeff(self):
+        yield self._record(level='debug', msg='Starting aeff check')
+
+        try:
+            aeff = self.obs.load('aeff')
+        except:
+            yield self._record(level='warning', msg='Loading aeff failed')
+            return
+
+        # Check that thresholds are meaningful for aeff
+        if 'LO_THRES' in aeff.meta and 'HI_THRES' in aeff.meta and aeff.meta['LO_THRES'] >= aeff.meta['HI_THRES']:
+            yield self._record(level='error', msg='LO_THRES >= HI_THRES in effective area meta data')
+
+        # Check that maximum value of aeff is greater than zero
+        if np.max(aeff.data.data) <= 0:
+            yield self._record(level='error', msg='maximum entry of effective area table <= 0')
+
+    def check_edisp(self):
+        yield self._record(level='debug', msg='Starting edisp check')
+
+        try:
+            edisp = self.obs.load('edisp')
+        except:
+            yield self._record(level='warning', msg='Loading edisp failed')
+            return
+
+        # Check that maximum value of edisp matrix is greater than zero
+        if np.max(edisp.data.data) <= 0:
+            yield self._record(level='error', msg='maximum entry of edisp is <= 0')
+
+    def check_psf(self):
+        yield self._record(level='debug', msg='Starting psf check')
+
+        try:
+            psf = self.obs.load('psf')
+        except:
+            yield self._record(level='warning', msg='Loading psf failed')
+            return

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -936,17 +936,16 @@ class EventListDatasetChecker(object):
     logger : `logging.Logger` or None
         Logger to use (use module-level Gammapy logger by default)
     """
-    CHECKS = OrderedDict(
-        misc='check_misc',
-        times='check_times',
-        coordinates='check_coordinates',
-    )
+    CHECKS = OrderedDict([
+        ('misc', 'check_misc'),
+        ('times', 'check_times'),
+        ('coordinates', 'check_coordinates'),
+    ])
 
-    accuracy = OrderedDict(
-        angle=Angle('1 arcsec'),
-        time=Quantity(1, 'microsecond'),
-
-    )
+    accuracy = {
+        'angle': Angle('1 arcsec'),
+        'time': Quantity(1, 'microsecond'),
+    }
 
     def __init__(self, event_list_dataset, logger=None):
         self.dset = event_list_dataset

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -936,7 +936,7 @@ class EventListDatasetChecker(object):
     logger : `logging.Logger` or None
         Logger to use (use module-level Gammapy logger by default)
     """
-    _AVAILABLE_CHECKS = OrderedDict(
+    CHECKS = OrderedDict(
         misc='check_misc',
         times='check_times',
         coordinates='check_coordinates',
@@ -971,15 +971,15 @@ class EventListDatasetChecker(object):
             Everything ok?
         """
         if checks == 'all':
-            checks = self._AVAILABLE_CHECKS.keys()
+            checks = self.CHECKS.keys()
 
-        unknown_checks = set(checks).difference(self._AVAILABLE_CHECKS.keys())
+        unknown_checks = set(checks).difference(self.CHECKS.keys())
         if unknown_checks:
             raise ValueError('Unknown checks: {}'.format(unknown_checks))
 
         ok = True
         for check in checks:
-            check_method = getattr(self, self._AVAILABLE_CHECKS[check])
+            check_method = getattr(self, self.CHECKS[check])
             ok &= check_method()
 
         return ok

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -22,7 +22,6 @@ __all__ = [
     'EventList',
     'EventListLAT',
     'EventListDataset',
-    'EventListDatasetChecker',
 ]
 
 log = logging.getLogger(__name__)
@@ -929,12 +928,6 @@ class EventListDatasetChecker(object):
     """Event list dataset checker.
 
     Data format specification: ref:`gadf:iact-events`
-
-    Having such a checker is useful at the moment because
-    the CTA data formats are quickly evolving and there's
-    various sources of event list data, e.g. exporters are
-    being written for the existing IACTs and simulators
-    are being written for CTA.
 
     Parameters
     ----------

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -62,8 +62,8 @@ class HDULocation(object):
     def get_hdu(self):
         """Get HDU."""
         filename = str(self.path(abs_path=True))
-        hdu_list = fits.open(filename, memmap=False)
-        return hdu_list[self.hdu_name]
+        with fits.open(filename, memmap=False) as hdu_list:
+            return hdu_list[self.hdu_name]
 
     def load(self):
         """Load HDU as appropriate class.
@@ -232,7 +232,7 @@ class HDUIndexTable(Table):
     def location_info(self, idx):
         """Create `HDULocation` for a given row index."""
         row = self[idx]
-        location = HDULocation(
+        return HDULocation(
             obs_id=row['OBS_ID'],
             hdu_type=row['HDU_TYPE'].strip(),
             hdu_class=row['HDU_CLASS'].strip(),
@@ -241,7 +241,6 @@ class HDUIndexTable(Table):
             file_name=row['FILE_NAME'].strip(),
             hdu_name=row['HDU_NAME'].strip(),
         )
-        return location
 
     @lazyproperty
     def _hdu_class_stripped(self):

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -106,5 +106,5 @@ class TestDataStoreChecker:
 
     def test_check_all(self):
         records = list(self.data_store.check())
-        print(records)
+        from pprint import pprint; pprint(records)
         assert len(records) == 4

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -107,4 +107,4 @@ class TestDataStoreChecker:
     def test_check_all(self):
         records = list(self.data_store.check())
         from pprint import pprint; pprint(records)
-        assert len(records) == 4
+        assert len(records) == 24

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from numpy.testing import assert_allclose
 import pytest
 from ...data import DataStore
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
+
+pytest.importorskip('scipy')
 
 
 @pytest.fixture(scope='session')
@@ -11,7 +13,6 @@ def data_store():
     return DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
 
 
-@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_datastore_hd_hap(data_store):
     """Test HESS HAP-HD data access."""
@@ -24,7 +25,6 @@ def test_datastore_hd_hap(data_store):
     assert str(type(obs.psf)) == "<class 'gammapy.irf.psf_gauss.EnergyDependentMultiGaussPSF'>"
 
 
-@requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_datastore_pa():
     """Test HESS ParisAnalysis data access."""
@@ -100,6 +100,11 @@ def test_data_summary(data_store):
 
 
 @requires_data('gammapy-extra')
-def test_check_observations(data_store):
-    result = data_store.check_observations()
-    assert len(result) == 0
+class TestDataStoreChecker:
+    def setup(self):
+        self.data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps')
+
+    def test_check_all(self):
+        records = list(self.data_store.check())
+        print(records)
+        assert len(records) == 4

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
-from ...data import EventList, EventListLAT, EventListDataset, EventListDatasetChecker
+from ...data.event_list import EventList, EventListLAT, EventListDataset, EventListDatasetChecker
 
 
 @requires_data('gammapy-extra')
@@ -73,7 +73,7 @@ class TestEventListDataset:
 
 @pytest.mark.xfail
 @requires_data('gammapy-extra')
-class TestEventListDatasetChecker():
+class TestEventListDatasetChecker:
     def test(self):
         filename = '$GAMMAPY_EXTRA/test_datasets/unbundled/hess/run_0023037_hard_eventlist.fits.gz'
         dset = EventListDataset.read(filename)

--- a/gammapy/irf/psf_check.py
+++ b/gammapy/irf/psf_check.py
@@ -4,9 +4,7 @@ from collections import OrderedDict
 import math
 import numpy as np
 
-__all__ = [
-    'PSF3DChecker',
-]
+__all__ = []
 
 
 class PSF3DChecker(object):


### PR DESCRIPTION
This PR introduces a DataStoreChecker and ObservationChecker.

The basic idea is to yield records, which are dicts, and to let callers filter or format those record.
This is simple and efficient in Python, this would even allow writing the stream of records without making a list, i.e. allows checking a lot of data without memory increasing if we used lists.

I will make another PR tonight removing the EventListDatasetChecker (which is mostly broken), and to add the useful checks from there (with tests) to the ObservationChecker.

cc @dcfidalgo @maxnoe