### PR TITLE
Minor clean up cube models

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -164,19 +164,19 @@ class MapEvaluator(object):
         """Energy axis bin centers (`~astropy.units.Quantity`)"""
         energy_axis = self.geom.axes[0]
         energy = energy_axis.center * energy_axis.unit
-        return energy
+        return energy[:, np.newaxis, np.newaxis]
 
     @lazyproperty
     def energy_edges(self):
         """Energy axis bin edges (`~astropy.units.Quantity`)"""
         energy_axis = self.geom.axes[0]
         energy = energy_axis.edges * energy_axis.unit
-        return energy
+        return energy[:, np.newaxis, np.newaxis]
 
     @lazyproperty
     def energy_bin_width(self):
         """Energy axis bin widths (`astropy.units.Quantity`)"""
-        return np.diff(self.energy_edges)
+        return np.diff(self.energy_edges, axis=0)
 
     @lazyproperty
     def lon_lat(self):
@@ -205,7 +205,6 @@ class MapEvaluator(object):
         """Map pixel bin volume (solid angle times energy bin width)."""
         omega = self.solid_angle
         de = self.energy_bin_width
-        de = de[:, np.newaxis, np.newaxis]
         return omega * de
 
     def compute_dnde(self):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -16,6 +16,23 @@ __all__ = [
 ]
 
 
+class SkyModelBase(object):
+    """Sky model base class"""
+
+    def copy(self):
+        """A deep copy"""
+        return copy.deepcopy(self)
+
+    def __add__(self, skymodel):
+        return CompoundSkyModel(self, skymodel, operator.add)
+
+    def __radd__(self, model):
+        return self.__add__(model)
+
+    def __call__(self, *args, **kwargs):
+        return self.evaluate(*args, **kwargs)
+
+
 class SkyModels(object):
     """Collection of `~gammapy.cube.models.SkyModel`
 
@@ -102,7 +119,7 @@ class SkyModels(object):
         return out
 
 
-class SkyModel(object):
+class SkyModel(SkyModelBase):
     """Sky model component.
 
     This model represents a factorised sky model.
@@ -188,18 +205,8 @@ class SkyModel(object):
         val = val_spatial * val_spectral
         return val.to('cm-2 s-1 TeV-1 deg-2')
 
-    def copy(self):
-        """A deep copy"""
-        return copy.deepcopy(self)
 
-    def __add__(self, skymodel):
-        return CompoundSkyModel(self, skymodel, operator.add)
-
-    def __radd__(self, model):
-        return self.__add__(model)
-
-
-class CompoundSkyModel(object):
+class CompoundSkyModel(SkyModelBase):
     """Represents the algebraic combination of two
     `~gammapy.cube.models.SkyModel`
 
@@ -259,11 +266,10 @@ class CompoundSkyModel(object):
         """
         val1 = self.model1.evaluate(lon, lat, energy)
         val2 = self.model2.evaluate(lon, lat, energy)
-
         return self.operator(val1, val2)
 
 
-class SkyDiffuseCube(object):
+class SkyDiffuseCube(SkyModelBase):
     """Cube sky map template model (3D).
 
     This is for a 3D map with an energy axis.

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -9,6 +9,7 @@ from ..utils.scripts import make_path
 from ..maps import Map
 
 __all__ = [
+    'SkyModelBase',
     'SkyModels',
     'SkyModel',
     'CompoundSkyModel',
@@ -274,9 +275,8 @@ class CompoundSkyModel(SkyModelBase):
 class SkyDiffuseCube(SkyModelBase):
     """Cube sky map template model (3D).
 
-    This is for a 3D map with an energy axis.
-    The map unit is assumed to be ``cm-2 s-1 MeV-1 sr-1``.
-    Use `~gammapy.image.models.SkyDiffuseMap` for 2D maps.
+    This is for a 3D map with an energy axis. Use `~gammapy.image.models.SkyDiffuseMap`
+    for 2D maps.
 
     Parameters
     ----------
@@ -313,6 +313,8 @@ class SkyDiffuseCube(SkyModelBase):
     def read(cls, filename, **kwargs):
         """Read map from FITS file.
 
+        The default unit used if none is found in the file is ``cm-2 s-1 MeV-1 sr-1``.
+
         Parameters
         ----------
         filename : str
@@ -332,4 +334,4 @@ class SkyDiffuseCube(SkyModelBase):
         }
         val = self.map.interp_by_coord(coord, **self._interp_kwargs)
         norm = self.parameters['norm'].value
-        return norm * val * self.map.unit
+        return u.Quantity(norm * val, self.map.unit, copy=False)

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -166,6 +166,8 @@ class SkyModel(object):
     def evaluate(self, lon, lat, energy):
         """Evaluate the model at given points.
 
+        The model evaluation follows numpy broadcasting rules.
+
         Return differential surface brightness cube.
         At the moment in units: ``cm-2 s-1 TeV-1 deg-2``
 
@@ -183,10 +185,7 @@ class SkyModel(object):
         """
         val_spatial = self.spatial_model(lon, lat)  # pylint:disable=not-callable
         val_spectral = self.spectral_model(energy)  # pylint:disable=not-callable
-        val_spectral = np.atleast_1d(val_spectral)[:, np.newaxis, np.newaxis]
-
         val = val_spatial * val_spectral
-
         return val.to('cm-2 s-1 TeV-1 deg-2')
 
     def copy(self):
@@ -315,9 +314,6 @@ class SkyDiffuseCube(object):
 
     def evaluate(self, lon, lat, energy):
         """Evaluate model."""
-        energy = np.atleast_1d(energy)[:, np.newaxis, np.newaxis]
-        energy = energy.to(self.map.geom.axes[0].unit).value
-
         coord = {
             'lon': lon.to('deg').value,
             'lat': lat.to('deg').value,

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -29,8 +29,8 @@ class SkyModelBase(object):
     def __radd__(self, model):
         return self.__add__(model)
 
-    def __call__(self, *args, **kwargs):
-        return self.evaluate(*args, **kwargs)
+    def __call__(self, lon, lat, energy):
+        return self.evaluate(lon, lat, energy)
 
 
 class SkyModels(object):
@@ -203,6 +203,8 @@ class SkyModel(SkyModelBase):
         val_spatial = self.spatial_model(lon, lat)  # pylint:disable=not-callable
         val_spectral = self.spectral_model(energy)  # pylint:disable=not-callable
         val = val_spatial * val_spectral
+        # TODO: shall remove hard coded return units? If really needed users can
+        # always do this themselves. For fitting this also adds a performance penalty...
         return val.to('cm-2 s-1 TeV-1 deg-2')
 
 
@@ -289,7 +291,6 @@ class SkyDiffuseCube(SkyModelBase):
         Default arguments are {'interp': 'linear', 'fill_value': 0}.
 
     """
-
     def __init__(self, map, norm=1, meta=None, interp_kwargs=None):
         axis = map.geom.get_axis_by_name('energy')
 
@@ -302,7 +303,7 @@ class SkyDiffuseCube(SkyModelBase):
         ])
         self.meta = {} if meta is None else meta
 
-        interp_kwargs = interp_kwargs or {}
+        interp_kwargs = {} if interp_kwargs is None else interp_kwargs
         interp_kwargs.setdefault('interp', 'linear')
         interp_kwargs.setdefault('fill_value', 0)
         self._interp_kwargs = interp_kwargs

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -186,7 +186,7 @@ class TestSkyDiffuseCube:
     @pytest.fixture()
     def model():
         axis = MapAxis.from_nodes([0.1, 100], name='energy', unit='TeV', interp='log')
-        m = Map.create(npix=(4, 3), binsz=2, axes=[axis])
+        m = Map.create(npix=(4, 3), binsz=2, axes=[axis], unit='cm-2 s-1 MeV-1 sr-1')
         m.data += 42
         return SkyDiffuseCube(m)
 

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -100,7 +100,7 @@ class TestSkyModels:
         lat = 4 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
 
-        q = sky_models.evaluate(lon, lat, energy)
+        q = sky_models.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
 
         assert q.unit == 'cm-2 s-1 TeV-1 deg-2'
         assert q.shape == (5, 3, 4)
@@ -131,7 +131,7 @@ class TestSkyModel:
         q = sky_model.evaluate(lon, lat, energy)
 
         assert q.unit == 'cm-2 s-1 TeV-1 deg-2'
-        assert q.shape == (1, 1, 1)
+        assert np.isscalar(q.value)
         assert_allclose(q.value, 1.76838826e-13)
 
     @staticmethod
@@ -140,7 +140,7 @@ class TestSkyModel:
         lat = 4 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
 
-        q = sky_model.evaluate(lon, lat, energy)
+        q = sky_model.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
 
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value, 1.76838826e-13)
@@ -172,7 +172,7 @@ class TestCompoundSkyModel:
         lat = 4 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
 
-        q = compound_model.evaluate(lon, lat, energy)
+        q = compound_model.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
 
         assert q.unit == 'cm-2 s-1 TeV-1 deg-2'
         assert q.shape == (5, 3, 4)
@@ -195,7 +195,7 @@ class TestSkyDiffuseCube:
         # Check pixel inside map
         val = model.evaluate(0 * u.deg, 0 * u.deg, 10 * u.TeV)
         assert val.unit == 'cm-2 s-1 MeV-1 sr-1'
-        assert val.shape == (1, 1, 1)
+        assert val.shape == (1,)
         assert_allclose(val.value, 42)
 
         # Check pixel outside map (spatially)
@@ -212,7 +212,7 @@ class TestSkyDiffuseCube:
         lat = 2 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
 
-        q = model.evaluate(lon, lat, energy)
+        q = model.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
 
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value.mean(), 42)
@@ -226,7 +226,7 @@ class TestSkyDiffuseCube:
         # Check pixel inside map
         val = model.evaluate(0 * u.deg, 0 * u.deg, 100 * u.GeV)
         assert val.unit == 'cm-2 s-1 MeV-1 sr-1'
-        assert val.shape == (1, 1, 1)
+        assert val.shape == (1,)
         assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
 
 
@@ -236,19 +236,19 @@ class TestSkyModelMapEvaluator:
     @staticmethod
     def test_energy_center(evaluator):
         val = evaluator.energy_center
-        assert val.shape == (2,)
+        assert val.shape == (2, 1, 1)
         assert val.unit == 'TeV'
 
     @staticmethod
     def test_energy_edges(evaluator):
         val = evaluator.energy_edges
-        assert val.shape == (3,)
+        assert val.shape == (3, 1, 1)
         assert val.unit == 'TeV'
 
     @staticmethod
     def test_energy_bin_width(evaluator):
         val = evaluator.energy_bin_width
-        assert val.shape == (2,)
+        assert val.shape == (2, 1, 1)
         assert val.unit == 'TeV'
 
     @staticmethod

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -31,6 +31,14 @@ def sky_model():
 
 
 @pytest.fixture(scope='session')
+def diffuse_model():
+    axis = MapAxis.from_nodes([0.1, 100], name='energy', unit='TeV', interp='log')
+    m = Map.create(npix=(4, 3), binsz=2, axes=[axis], unit='cm-2 s-1 MeV-1 sr-1')
+    m.data += 42
+    return SkyDiffuseCube(m)
+
+
+@pytest.fixture(scope='session')
 def geom():
     axis = MapAxis.from_edges(np.logspace(-1, 1, 3), unit=u.TeV, name="energy")
     return WcsGeom.create(skydir=(0, 0), npix=(5, 4), coordsys='GAL', axes=[axis])
@@ -66,6 +74,11 @@ def psf(geom):
 @pytest.fixture(scope='session')
 def evaluator(sky_model, exposure, background, psf, edisp):
     return MapEvaluator(sky_model, exposure, background, psf=psf, edisp=edisp)
+
+
+@pytest.fixture(scope='session')
+def diffuse_evaluator(diffuse_model, exposure, background, psf, edisp):
+    return MapEvaluator(diffuse_model, exposure, background, psf=psf, edisp=edisp)
 
 
 class TestSkyModels:
@@ -181,38 +194,29 @@ class TestCompoundSkyModel:
 
 @requires_dependency('scipy')
 class TestSkyDiffuseCube:
-
     @staticmethod
-    @pytest.fixture()
-    def model():
-        axis = MapAxis.from_nodes([0.1, 100], name='energy', unit='TeV', interp='log')
-        m = Map.create(npix=(4, 3), binsz=2, axes=[axis], unit='cm-2 s-1 MeV-1 sr-1')
-        m.data += 42
-        return SkyDiffuseCube(m)
-
-    @staticmethod
-    def test_evaluate_scalar(model):
+    def test_evaluate_scalar(diffuse_model):
         # Check pixel inside map
-        val = model.evaluate(0 * u.deg, 0 * u.deg, 10 * u.TeV)
+        val = diffuse_model.evaluate(0 * u.deg, 0 * u.deg, 10 * u.TeV)
         assert val.unit == 'cm-2 s-1 MeV-1 sr-1'
         assert val.shape == (1,)
         assert_allclose(val.value, 42)
 
         # Check pixel outside map (spatially)
-        val = model.evaluate(100 * u.deg, 0 * u.deg, 10 * u.TeV)
+        val = diffuse_model.evaluate(100 * u.deg, 0 * u.deg, 10 * u.TeV)
         assert_allclose(val.value, 0)
 
         # Check pixel outside energy range
-        val = model.evaluate(0 * u.deg, 0 * u.deg, 200 * u.TeV)
+        val = diffuse_model.evaluate(0 * u.deg, 0 * u.deg, 200 * u.TeV)
         assert_allclose(val.value, 0)
 
     @staticmethod
-    def test_evaluate_array(model):
+    def test_evaluate_array(diffuse_model):
         lon = 1 * u.deg * np.ones(shape=(3, 4))
         lat = 2 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
 
-        q = model.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
+        q = diffuse_model.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
 
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value.mean(), 42)
@@ -228,6 +232,50 @@ class TestSkyDiffuseCube:
         assert val.unit == 'cm-2 s-1 MeV-1 sr-1'
         assert val.shape == (1,)
         assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
+
+
+@requires_dependency('scipy')
+class TestSkyDiffuseCubeMapEvaluator:
+    @staticmethod
+    def test_compute_dnde(diffuse_evaluator):
+        out = diffuse_evaluator.compute_dnde()
+        assert out.shape == (2, 4, 5)
+        out = out.to('cm-2 s-1 MeV-1 sr-1')
+        assert_allclose(out.value.sum(), 1680, rtol=1e-5)
+        assert_allclose(out.value[0, 0, 0], 42, rtol=1e-5)
+
+    @staticmethod
+    def test_compute_flux(diffuse_evaluator):
+        out = diffuse_evaluator.compute_flux()
+        assert out.shape == (2, 4, 5)
+        out = out.to('cm-2 s-1')
+        assert_allclose(out.value.sum(), 633263.444803, rtol=1e-5)
+        assert_allclose(out.value[0, 0, 0], 2878.196184, rtol=1e-5)
+
+    @staticmethod
+    def test_apply_psf(diffuse_evaluator):
+        flux = diffuse_evaluator.compute_flux()
+        npred = diffuse_evaluator.apply_exposure(flux)
+        out = diffuse_evaluator.apply_psf(npred)
+        assert out.data.shape == (2, 4, 5)
+        assert_allclose(out.data.sum(), 4.004864e+12, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 1.380614e+09, rtol=1e-5)
+
+    @staticmethod
+    def test_apply_edisp(diffuse_evaluator):
+        flux = diffuse_evaluator.compute_flux()
+        out = diffuse_evaluator.apply_edisp(flux.value)
+        assert out.shape == (2, 4, 5)
+        assert_allclose(out.sum(), 633263.444803, rtol=1e-5)
+        assert_allclose(out[0, 0, 0], 2878.196184, rtol=1e-5)
+
+    @staticmethod
+    def test_compute_npred(diffuse_evaluator):
+        out = diffuse_evaluator.compute_npred()
+        assert out.shape == (2, 4, 5)
+        assert_allclose(out.sum(), 4.004864e+12, rtol=1e-5)
+        assert_allclose(out[0, 0, 0], 1.380614e+09, rtol=1e-5)
+
 
 
 @requires_dependency('scipy')


### PR DESCRIPTION
This PR does a minor clean up and improvements of  the cube models.

* Remove the hard coded reshaping of the energy arrays in `SkyModel.evaluate()` and `SkyDiffuseCube.evaluate()`, so we don't break the numpy broadcasting.
* Introduce a `SKyModelBase` class
* Add regression test for the evaluation of `SkyDiffuseCube` model using the `MapEvaluator`, this is useful to tackle #1689.