### PR TITLE
Remove unused map utility functions

### DIFF
--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1715,20 +1715,6 @@ class HpxGeom(MapGeom):
         frame = "galactic" if self.coordsys == "GAL" else "icrs"
         return SkyCoord(coords[0], coords[1], unit="deg", frame=frame)
 
-    def skydir_to_pix(self, skydir):
-        """Return the pixel index of a SkyCoord object."""
-        # FIXME: What should this method do for maps with non-spatial dimensions?
-        if self.coordsys in ["CEL", "EQU"]:
-            skydir = skydir.transform_to("icrs")
-            lon = skydir.ra.deg
-            lat = skydir.dec.deg
-        else:
-            skydir = skydir.transform_to("galactic")
-            lon = skydir.l.deg
-            lat = skydir.b.deg
-
-        return self.pix_to_coord((lat, lon))
-
     def solid_angle(self):
         """Solid angle array (`~astropy.units.Quantity` in ``sr``).
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1053,51 +1053,6 @@ def world2pix(wcs, cdelt, crpix, coord):
     )
 
 
-def skydir_to_pix(skydir, wcs):
-    """Convert skydir object to pixel coordinates.
-
-    Gracefully handles 0-d coordinate arrays.
-
-    Parameters
-    ----------
-    skydir : `~astropy.coordinates.SkyCoord`
-        TODO
-    wcs : `~astropy.wcs.WCS`
-        TODO
-
-    Returns
-    -------
-    xp, yp : `numpy.ndarray`
-       The pixel coordinates
-    """
-    if len(skydir.shape) > 0 and len(skydir) == 0:
-        return [np.empty(0), np.empty(0)]
-
-    return skydir.to_pixel(wcs, origin=0)
-
-
-def pix_to_skydir(xpix, ypix, wcs):
-    """Convert pixel coordinates to a skydir object.
-
-    Gracefully handles 0-d coordinate arrays.
-    Always returns a celestial coordinate.
-
-    Parameters
-    ----------
-    xpix, ypix : `numpy.ndarray`
-        TODO
-    wcs : `~astropy.wcs.WCS`
-        TODO
-    """
-    xpix = np.array(xpix)
-    ypix = np.array(ypix)
-
-    if xpix.ndim > 0 and len(xpix) == 0:
-        return SkyCoord(np.empty(0), np.empty(0), unit="deg", frame="icrs")
-
-    return SkyCoord.from_pixel(xpix, ypix, wcs, origin=0).transform_to("icrs")
-
-
 def get_projection(wcs):
     return wcs.wcs.ctype[0][5:]
 
@@ -1127,30 +1082,3 @@ def wcs_to_axes(w, npix):
     z += np.log10(w.wcs.crval[2])
 
     return x, y, z
-
-
-def get_map_skydir(filename, maphdu=0):
-    filename = str(make_path(filename))
-    with fits.open(filename, memmap=False) as hdu_list:
-        wcs = WCS(hdu_list[maphdu].header)
-    return wcs_to_skydir(wcs)
-
-
-def wcs_to_skydir(wcs):
-    lon = wcs.wcs.crval[0]
-    lat = wcs.wcs.crval[1]
-    coordsys = get_coordys(wcs)
-    if coordsys == "GAL":
-        return SkyCoord(lon, lat, unit="deg", frame="galactic").transform_to("icrs")
-    else:
-        return SkyCoord(lon, lat, unit="deg", frame="icrs")
-
-
-def is_galactic(wcs):
-    coordsys = get_coordys(wcs)
-    if coordsys == "GAL":
-        return True
-    elif coordsys == "CEL":
-        return False
-    else:
-        raise ValueError("Unsupported coordinate system: {}".format(coordsys))


### PR DESCRIPTION
This PR fixes #1735 .

It removes `HpxGeom.skydir_to_pix` as well as the functions `skydir_to_pix`, `pix_to_skydir`, `get_map_skydir`, `wcs_to_skydir` and `is_galactic` in `gammapy/maps/wcs.py`.

All of those were never called, i.e. completely unused and untested.

@adonath @woodmd  - Do you think we should keep those, or OK to remove for now?