### PR TITLE
Update HESS data files used in tests and examples

### DIFF
--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -32,7 +32,7 @@ def on_region():
 @pytest.fixture
 def obs_list():
     """Example observation list for testing."""
-    datastore = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
+    datastore = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
     obs_ids = [23523, 23526]
     return datastore.obs_list(obs_ids)
 

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -37,6 +37,16 @@ def obs_list():
     return datastore.obs_list(obs_ids)
 
 
+@pytest.fixture
+def bkg_estimator():
+    """Example background estimator for testing."""
+    return ReflectedRegionsBackgroundEstimator(
+        obs_list=obs_list(),
+        on_region=on_region(),
+        exclusion_mask=mask(),
+    )
+
+
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_find_reflected_regions(mask, on_region):
@@ -69,15 +79,6 @@ def test_find_reflected_regions(mask, on_region):
     fregions.run()
     regions = fregions.reflected_regions
     assert len(regions) == 5
-
-
-@pytest.fixture
-def bkg_estimator():
-    """Example background estimator for testing."""
-    estimator = ReflectedRegionsBackgroundEstimator(obs_list=obs_list(),
-                                                    on_region=on_region(),
-                                                    exclusion_mask=mask())
-    return estimator
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -40,8 +40,7 @@ class DataStore(object):
     Here's an example how to create a `DataStore` to access H.E.S.S. data:
 
     >>> from gammapy.data import DataStore
-    >>> dir = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
-    >>> data_store = DataStore.from_dir(dir)
+    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
     >>> data_store.info()
     """
     DEFAULT_HDU_TABLE = 'hdu-index.fits.gz'

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -231,44 +231,6 @@ class DataStore(object):
         subhdutable.write(str(outdir / self.DEFAULT_HDU_TABLE), format='fits', overwrite=overwrite)
         subobstable.write(str(outdir / self.DEFAULT_OBS_TABLE), format='fits', overwrite=overwrite)
 
-    def data_summary(self, obs_id=None, summed=False):
-        """Create a summary `~astropy.table.Table` with HDU size information.
-
-        Parameters
-        ----------
-        obs_id : array-like
-            Observation IDs to include in the summary
-        summed : bool
-            Sum up file size?
-        """
-        if obs_id is None:
-            obs_id = self.obs_table['OBS_ID'].data
-
-        hdut = self.hdu_table
-        hdut.add_index('OBS_ID')
-        subhdut = hdut.loc[obs_id]
-
-        subhdut_grpd = subhdut.group_by('OBS_ID')
-        colnames = subhdut_grpd.groups[0]['HDU_CLASS']
-        temp = np.zeros(len(colnames), dtype=int)
-
-        rows = []
-        for key, group in zip(subhdut_grpd.groups.keys, subhdut_grpd.groups):
-            # This is needed to get the column order right
-            group.add_index('HDU_CLASS')
-            vals = group.loc[colnames]['SIZE']
-            if summed:
-                temp = temp + vals
-            else:
-                rows.append(np.append(key['OBS_ID'], vals))
-
-        if summed:
-            rows.append(temp)
-        else:
-            colnames = np.append(['OBS_ID'], colnames)
-
-        return Table(rows=rows, names=colnames)
-
     def check(self, checks='all'):
         """Check index tables and data files.
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -32,8 +32,6 @@ class DataStore(object):
         HDU index table
     obs_table : `~gammapy.data.ObservationTable`
         Observation index table
-    name : str
-        Data store name
 
     Examples
     --------
@@ -49,20 +47,12 @@ class DataStore(object):
     DEFAULT_OBS_TABLE = 'obs-index.fits.gz'
     """Default observation table filename."""
 
-    DEFAULT_NAME = 'noname'
-    """Default data store name."""
-
-    def __init__(self, hdu_table=None, obs_table=None, name=None):
+    def __init__(self, hdu_table=None, obs_table=None):
         self.hdu_table = hdu_table
         self.obs_table = obs_table
 
-        if name:
-            self.name = name
-        else:
-            self.name = self.DEFAULT_NAME
-
     @classmethod
-    def from_files(cls, base_dir, hdu_table_filename=None, obs_table_filename=None, name=None):
+    def from_files(cls, base_dir, hdu_table_filename=None, obs_table_filename=None):
         """Construct from HDU and observation index table files."""
         if hdu_table_filename:
             log.debug('Reading {}'.format(hdu_table_filename))
@@ -81,11 +71,10 @@ class DataStore(object):
         return cls(
             hdu_table=hdu_table,
             obs_table=obs_table,
-            name=name,
         )
 
     @classmethod
-    def from_dir(cls, base_dir, name=None):
+    def from_dir(cls, base_dir):
         """Create from a directory.
 
         This assumes that the HDU and observations index tables
@@ -96,14 +85,12 @@ class DataStore(object):
             base_dir=base_dir,
             hdu_table_filename=base_dir / cls.DEFAULT_HDU_TABLE,
             obs_table_filename=base_dir / cls.DEFAULT_OBS_TABLE,
-            name=name,
         )
 
     @classmethod
     def from_config(cls, config):
         """Create from a config dict."""
         base_dir = config['base_dir']
-        name = config.get('name', cls.DEFAULT_NAME)
         hdu_table_filename = config.get('hduindx', cls.DEFAULT_HDU_TABLE)
         obs_table_filename = config.get('obsindx', cls.DEFAULT_OBS_TABLE)
 
@@ -114,7 +101,6 @@ class DataStore(object):
             base_dir=base_dir,
             hdu_table_filename=hdu_table_filename,
             obs_table_filename=obs_table_filename,
-            name=name,
         )
 
     @staticmethod
@@ -139,8 +125,7 @@ class DataStore(object):
 
     def info(self, show=True):
         """Print some info."""
-        s = 'Data store summary info:\n'
-        s += 'name: {!r}\n\n'.format(self.name)
+        s = 'Data store:\n'
         s += self.hdu_table.summary()
         s += '\n\n'
         s += self.obs_table.summary()

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -51,6 +51,9 @@ class DataStore(object):
         self.hdu_table = hdu_table
         self.obs_table = obs_table
 
+    def __str__(self):
+        return self.info(show=False)
+
     @classmethod
     def from_files(cls, base_dir, hdu_table_filename=None, obs_table_filename=None):
         """Construct from HDU and observation index table files."""
@@ -174,7 +177,7 @@ class DataStore(object):
                 obs = self.obs(_)
             except ValueError as err:
                 if skip_missing:
-                    log.warn('Obs {} not in store, skip.'.format(_))
+                    log.warning('Skipping observation that is not available: {}'.format(_))
                     continue
                 else:
                     raise err

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -185,49 +185,6 @@ class DataStore(object):
                 obslist.append(obs)
         return obslist
 
-    def load_all(self, hdu_type=None, hdu_class=None):
-        """Load a given file type for all observations.
-
-        Parameters
-        ----------
-        hdu_type : str
-            HDU type (see `~gammapy.data.HDUIndexTable.VALID_HDU_TYPE`)
-        hdu_class : str
-            HDU class (see `~gammapy.data.HDUIndexTable.VALID_HDU_CLASS`)
-
-        Returns
-        -------
-        list : python list of object
-            Object depends on type, e.g. for 'events' it is a list of `~gammapy.data.EventList`.
-        """
-        obs_ids = self.obs_table['OBS_ID']
-        return self.load_many(obs_ids=obs_ids, hdu_type=hdu_type, hdu_class=hdu_class)
-
-    def load_many(self, obs_ids, hdu_type=None, hdu_class=None):
-        """Load a given file type for certain observations in an observation table.
-
-        Parameters
-        ----------
-        obs_ids : list
-            List of observation IDs
-        hdu_type : str
-            HDU type (see `~gammapy.data.HDUIndexTable.VALID_HDU_TYPE`)
-        hdu_class : str
-            HDU class (see `~gammapy.data.HDUIndexTable.VALID_HDU_CLASS`)
-
-        Returns
-        -------
-        list : list of object
-            Object depends on type, e.g. for 'events' it is a list of `~gammapy.data.EventList`.
-        """
-        things = []
-        for obs_id in obs_ids:
-            obs = self.obs(obs_id=obs_id)
-            thing = obs.load(hdu_type=hdu_type, hdu_class=hdu_class)
-            things.append(thing)
-
-        return things
-
     def copy_obs(self, obs_id, outdir, hdu_class=None, verbose=False, overwrite=False):
         """Create a new `~gammapy.data.DataStore` containing a subset of observations.
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -404,7 +404,7 @@ class EventListBase(object):
             import matplotlib.pyplot as plt
             from gammapy.data import DataStore
 
-            ds = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
+            ds = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
             events = ds.obs(obs_id=23523).events
             events.plot_time()
             plt.show()

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -191,23 +191,6 @@ class EventListBase(object):
         return 1 - self.table.meta['DEADC']
 
     @property
-    def altaz_frame(self):
-        """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
-        return AltAz(obstime=self.time, location=self.location)
-
-    @property
-    def altaz(self):
-        """ALT / AZ position computed from RA / DEC (`~astropy.coordinates.SkyCoord`)"""
-        return self.radec.transform_to(self.altaz_frame)
-
-    @property
-    def altaz_from_table(self):
-        """ALT / AZ position from table (`~astropy.coordinates.SkyCoord`)"""
-        lon = self.table['AZ_PNT']
-        lat = self.table['ALT_PNT']
-        return SkyCoord(lon, lat, unit='deg', frame=self.altaz_frame)
-
-    @property
     def pointing_radec(self):
         """Pointing RA / DEC sky coordinates (`~astropy.coordinates.SkyCoord`)."""
         info = self.table.meta
@@ -578,14 +561,21 @@ class EventList(EventListBase):
         return 1 - self.table.meta['DEADC']
 
     @property
-    def altaz(self):
-        """Event horizontal sky coordinates (`~astropy.coordinates.SkyCoord`)."""
-        time = self.time
-        location = self.observatory_earth_location
-        altaz_frame = AltAz(obstime=time, location=location)
+    def altaz_frame(self):
+        """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
+        return AltAz(obstime=self.time, location=self.observatory_earth_location)
 
-        lon, lat = self.table['AZ'], self.table['ALT']
-        return SkyCoord(lon, lat, unit='deg', frame=altaz_frame)
+    @property
+    def altaz(self):
+        """ALT / AZ position computed from RA / DEC (`~astropy.coordinates.SkyCoord`)"""
+        return self.radec.transform_to(self.altaz_frame)
+
+    @property
+    def altaz_from_table(self):
+        """ALT / AZ position from table (`~astropy.coordinates.SkyCoord`)"""
+        lon = self.table['AZ']
+        lat = self.table['ALT']
+        return SkyCoord(lon, lat, unit='deg', frame=self.altaz_frame)
 
     @property
     def pointing_radec(self):

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -169,10 +169,12 @@ class HDUIndexTable(Table):
                              ''.format(obs_id, hdu_type, hdu_class))
         else:
             idx = idx[0]
-            log.warn('Found multiple HDU matching: OBS_ID = {}, HDU_TYPE = {}, HDU_CLASS = {}.'
-                     ''.format(obs_id, hdu_type, hdu_class) +
-                     ' Returning the first entry, which has HDU_TYPE = {} and HDU_CLASS = {}'
-                     ''.format(self[idx]['HDU_TYPE'], self[idx]['HDU_CLASS']))
+            log.warning(
+                'Found multiple HDU matching: OBS_ID = {}, HDU_TYPE = {}, HDU_CLASS = {}.'
+                ''.format(obs_id, hdu_type, hdu_class) +
+                ' Returning the first entry, which has HDU_TYPE = {} and HDU_CLASS = {}'
+                ''.format(self[idx]['HDU_TYPE'], self[idx]['HDU_CLASS'])
+            )
 
         return self.location_info(idx)
 

--- a/gammapy/data/obs_summary.py
+++ b/gammapy/data/obs_summary.py
@@ -38,9 +38,7 @@ class ObservationTableSummary(object):
                            self.obs_table['DEC_PNT'],
                            unit='deg')
 
-        offset = pnt_pos.separation(self.target_pos)
-
-        return offset
+        return pnt_pos.separation(self.target_pos)
 
     def __str__(self):
         ss = '*** Observation summary ***\n'

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -41,14 +41,6 @@ def test_datastore_pa():
 
 
 @requires_data('gammapy-extra')
-def test_datastore_load_all(data_store):
-    """Test loading data and IRF files via the DataStore"""
-    event_lists = data_store.load_all(hdu_class='events')
-    assert_allclose(event_lists[0].table['ENERGY'][0], 1.1156039)
-    assert_allclose(event_lists[-1].table['ENERGY'][0], 1.0204216)
-
-
-@requires_data('gammapy-extra')
 def test_datastore_obslist(data_store):
     """Test loading data and IRF files via the DataStore"""
     obslist = data_store.obs_list([23523, 23592])

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing import assert_allclose
 import pytest
 from ...data import DataStore
 from ...utils.testing import requires_data
@@ -10,7 +9,7 @@ pytest.importorskip('scipy')
 
 @pytest.fixture(scope='session')
 def data_store():
-    return DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    return DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/')
 
 
 @requires_data('gammapy-extra')
@@ -22,7 +21,7 @@ def test_datastore_hd_hap(data_store):
     assert str(type(obs.gti)) == "<class 'gammapy.data.gti.GTI'>"
     assert str(type(obs.aeff)) == "<class 'gammapy.irf.effective_area.EffectiveAreaTable2D'>"
     assert str(type(obs.edisp)) == "<class 'gammapy.irf.energy_dispersion.EnergyDispersion2D'>"
-    assert str(type(obs.psf)) == "<class 'gammapy.irf.psf_gauss.EnergyDependentMultiGaussPSF'>"
+    assert str(type(obs.psf)) == "<class 'gammapy.irf.psf_3d.PSF3D'>"
 
 
 @requires_data('gammapy-extra')
@@ -78,17 +77,6 @@ def test_datastore_subset(tmpdir, data_store):
 
     substore = DataStore.from_dir(storedir)
     assert len(substore.hdu_table) == 2
-
-
-@requires_data('gammapy-extra')
-def test_data_summary(data_store):
-    """Test data summary function"""
-    t = data_store.data_summary([23523, 23592])
-    assert t[0]['events'] == 620975
-    assert t[1]['edisp_2d'] == 28931
-
-    t = data_store.data_summary([23523, 23592], summed=True)
-    assert t[0]['psf_3gauss'] == 6042
 
 
 @requires_data('gammapy-extra')

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -18,7 +18,7 @@ class TestEventListHESS:
         assert self.events.time[0].iso == '2004-10-14 00:08:39.214'
         assert self.events.radec[0].to_string() == '82.7068 19.8186'
         assert self.events.galactic[0].to_string(precision=2) == '185.96 -7.69'
-        assert self.events.altaz[0].to_string() == '46.2059 31.2001'
+        assert self.events.altaz[0].to_string() == '46.5793 30.8799'
         assert_allclose(self.events.offset[0].value, 1.904497742652893, rtol=1e-5)
         assert '{:1.5f}'.format(self.events.energy[0]) == '11.64355 TeV'
 
@@ -29,6 +29,10 @@ class TestEventListHESS:
 
     def test_altaz(self):
         altaz = self.events.altaz
+        assert_allclose(altaz[0].az.deg, 46.579258, atol=1e-3)
+        assert_allclose(altaz[0].alt.deg, 30.879939, atol=1e-3)
+
+        altaz = self.events.altaz_from_table
         assert_allclose(altaz[0].az.deg, 46.205875, atol=1e-3)
         assert_allclose(altaz[0].alt.deg, 31.200132, atol=1e-3)
         # TODO: add asserts for frame properties

--- a/gammapy/data/tests/test_hdu_index_table.py
+++ b/gammapy/data/tests/test_hdu_index_table.py
@@ -39,10 +39,10 @@ def test_hdu_index_table(hdu_index_table):
 @requires_data('gammapy-extra')
 def test_hdu_index_table_hd_hap():
     """Test HESS HAP-HD data access."""
-    hdu_index = HDUIndexTable.read('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/hdu-index.fits.gz')
+    hdu_index = HDUIndexTable.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/hdu-index.fits.gz')
 
     assert list(hdu_index.meta) == ['BASE_DIR']
-    assert hdu_index.base_dir == make_path('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2')
+    assert hdu_index.base_dir == make_path('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
 
     # A few valid queries
 
@@ -50,16 +50,16 @@ def test_hdu_index_table_hd_hap():
     hdu = location.get_hdu()
     assert hdu.name == 'EVENTS'
 
-    assert str(location.path(abs_path=False)) == 'run023400-023599/run023523/hess_events_023523.fits.gz'
+    assert str(location.path(abs_path=False)) == 'data/hess_dl3_dr1_obs_id_023523.fits.gz'
     path1 = str(location.path(abs_path=True))
     path2 = str(location.path(abs_path=False))
     assert path1.endswith(path2)
 
-    location = hdu_index.hdu_location(obs_id=23523, hdu_class='psf_3gauss')
-    assert str(location.path(abs_path=False)) == 'run023400-023599/run023523/hess_psf_3gauss_023523.fits.gz'
+    location = hdu_index.hdu_location(obs_id=23523, hdu_class='psf_table')
+    assert str(location.path(abs_path=False)) == 'data/hess_dl3_dr1_obs_id_023523.fits.gz'
 
     location = hdu_index.hdu_location(obs_id=23523, hdu_type='psf')
-    assert str(location.path(abs_path=False)) == 'run023400-023599/run023523/hess_psf_3gauss_023523.fits.gz'
+    assert str(location.path(abs_path=False)) == 'data/hess_dl3_dr1_obs_id_023523.fits.gz'
 
     # A few invalid queries
 

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -12,7 +12,7 @@ from ...background import ReflectedRegionsBackgroundEstimator
 
 @pytest.fixture(scope='session')
 def obs_list():
-    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/')
     run_list = [23523, 23526]
     return ObservationList([data_store.obs(_) for _ in run_list])
 
@@ -53,14 +53,14 @@ class TestObservationStats(object):
 
     def test_to_dict(self, stats):
         data = stats.to_dict()
-        assert data['n_on'] == 235
-        assert data['n_off'] == 107
+        assert data['n_on'] == 425
+        assert data['n_off'] == 395
         assert_allclose(data['alpha'], 0.333, rtol=1e-2)
-        assert_allclose(data['sigma'], 16.973577445630323, rtol=1e-3)
+        assert_allclose(data['sigma'], 16.430, rtol=1e-3)
 
     def test_stack(self, stats_stacked):
         data = stats_stacked.to_dict()
-        assert data['n_on'] == 454
-        assert data['n_off'] == 226
+        assert data['n_on'] == 900
+        assert data['n_off'] == 766
         assert_allclose(data['alpha'], 0.333, rtol=1e-2)
-        assert_allclose(data['sigma'], 22.89225735104067, rtol=1e-3)
+        assert_allclose(data['sigma'], 25.244, rtol=1e-3)

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose, assert_equal
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.units import Quantity
-import astropy.units as u
 from astropy.time import Time
 from ...data import DataStore, ObservationList, EventList, GTI, ObservationCTA
 from ...irf import EffectiveAreaTable2D, EnergyDispersion2D, PSF3D

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -8,7 +8,7 @@ from astropy.units import Quantity
 import astropy.units as u
 from astropy.time import Time
 from ...data import DataStore, ObservationList, EventList, GTI, ObservationCTA
-from ...irf import EffectiveAreaTable2D, EnergyDispersion2D, EnergyDependentMultiGaussPSF
+from ...irf import EffectiveAreaTable2D, EnergyDispersion2D, PSF3D
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.testing import assert_quantity_allclose, assert_time_allclose, assert_skycoord_allclose
 from ...utils.energy import Energy
@@ -17,7 +17,7 @@ from ...utils.energy import EnergyBounds
 
 @pytest.fixture(scope='session')
 def data_store():
-    return DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    return DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/')
 
 
 @requires_data('gammapy-extra')
@@ -25,13 +25,13 @@ def test_data_store_observation(data_store):
     """Test DataStoreObservation class"""
     obs = data_store.obs(23523)
 
-    assert_time_allclose(obs.tstart, Time(51545.11740650318, scale='tt', format='mjd'))
-    assert_time_allclose(obs.tstop, Time(51545.11740672924, scale='tt', format='mjd'))
+    assert_time_allclose(obs.tstart, Time(53343.92234, scale='tt', format='mjd'))
+    assert_time_allclose(obs.tstop, Time(53343.941866, scale='tt', format='mjd'))
 
     c = SkyCoord(83.63333129882812, 21.51444435119629, unit='deg')
     assert_skycoord_allclose(obs.pointing_radec, c)
 
-    c = SkyCoord(26.533863067626953, 40.60616683959961, unit='deg')
+    c = SkyCoord(22.481705, 41.38979, unit='deg')
     assert_skycoord_allclose(obs.pointing_altaz, c)
 
     c = SkyCoord(83.63333129882812, 22.01444435119629, unit='deg')
@@ -49,7 +49,7 @@ def test_data_store_observation_to_observation_cta(data_store):
     assert type(obs.events) == EventList
     assert type(obs.aeff) == EffectiveAreaTable2D
     assert type(obs.edisp) == EnergyDispersion2D
-    assert type(obs.psf) == EnergyDependentMultiGaussPSF
+    assert type(obs.psf) == PSF3D
     assert type(obs.pointing_radec) == SkyCoord
     assert type(obs.observation_live_time_duration) == Quantity
     assert type(obs.observation_dead_time_fraction) == np.float64
@@ -57,45 +57,75 @@ def test_data_store_observation_to_observation_cta(data_store):
 
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
-@pytest.mark.parametrize("pars,result", [
-    (dict(energy=None, rad=None),
-     dict(energy_shape=18, rad_shape=300, psf_energy=2.5178505859375 * u.TeV,
-          psf_rad=0.05 * u.deg,
-          psf_exposure=Quantity(6878545291473.34, "cm2 s"),
-          psf_value=Quantity(1837.4367332530592, "1/sr"))),
-    (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"), rad=None),
-     dict(energy_shape=101, rad_shape=300,
-          psf_energy=1.2589254117941673 * u.TeV, psf_rad=0.05 * u.deg,
-          psf_exposure=Quantity(4622187644084.735, "cm2 s"),
-          psf_value=Quantity(1682.8135627097995, "1/sr"))),
-    (dict(energy=None, rad=Angle(np.arange(0, 2, 0.002), 'deg')),
-     dict(energy_shape=18, rad_shape=1000,
-          psf_energy=2.5178505859375 * u.TeV, psf_rad=0.02 * u.deg,
-          psf_exposure=Quantity(6878545291473.34, "cm2 s"),
-          psf_value=Quantity(20455.914082287516, "1/sr"))),
-    (dict(energy=EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"),
-          rad=Angle(np.arange(0, 2, 0.002), 'deg')),
-     dict(energy_shape=101, rad_shape=1000,
-          psf_energy=1.2589254117941673 * u.TeV, psf_rad=0.02 * u.deg,
-          psf_exposure=Quantity(4622187644084.735, "cm2 s"),
-          psf_value=Quantity(25016.103907407552, "1/sr"))),
+@pytest.mark.parametrize("pars", [
+    {
+        'energy': None,
+        'rad': None,
+        'energy_shape': (32,),
+        'psf_energy': 865.9643,
+        'rad_shape': (144,),
+        'psf_rad': 0.0015362848,
+        'psf_exposure': 3.14711e12,
+        'psf_value_shape': (32, 144),
+        'psf_value': 4369.96391,
+    },
+    {
+        'energy': EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"),
+        'rad': None,
+        'energy_shape': (101,),
+        'psf_energy': 1412.537545,
+        'rad_shape': (144,),
+        'psf_rad': 0.0015362848,
+        'psf_exposure': 4.688142e+12,
+        'psf_value_shape': (101, 144),
+        'psf_value': 3726.58798,
+    },
+    {
+        'energy': None,
+        'rad': Angle(np.arange(0, 2, 0.002), 'deg'),
+        'energy_shape': (32,),
+        'psf_energy': 865.9643,
+        'rad_shape': (1000,),
+        'psf_rad': 0.000524,
+        'psf_exposure': 3.14711e+12,
+        # TODO: should this be psf_value_shape == (32, 1000) ?
+        'psf_value_shape': (32, 144),
+        'psf_value': 4369.96391,
+    },
+    {
+        'energy': EnergyBounds.equal_log_spacing(1, 10, 100, "TeV"),
+        'rad': Angle(np.arange(0, 2, 0.002), 'deg'),
+        'energy_shape': (101,),
+        'psf_energy': 1412.537545,
+        'rad_shape': (1000,),
+        'psf_rad': 0.000524,
+        'psf_exposure': 4.688142e+12,
+        'psf_value_shape': (101, 144),
+        'psf_value': 3726.58798,
+    },
 ])
-def test_make_psf(pars, result, data_store):
-    position = SkyCoord(83.63, 22.01, unit='deg')
+def test_make_psf(pars, data_store):
+    psf = data_store.obs(23523).make_psf(
+        position=SkyCoord(83.63, 22.01, unit='deg'),
+        energy=pars["energy"],
+        rad=pars["rad"],
+    )
 
-    obs1 = data_store.obs(23523)
-    psf = obs1.make_psf(position=position, energy=pars["energy"], rad=pars["rad"])
+    assert psf.energy.unit == "GeV"
+    assert psf.energy.shape == pars["energy_shape"]
+    assert_allclose(psf.energy.value[15], pars["psf_energy"], rtol=1e-3)
 
-    assert_allclose(psf.rad.shape, result["rad_shape"])
-    assert_allclose(psf.energy.shape, result["energy_shape"])
-    assert_allclose(psf.exposure.shape, result["energy_shape"])
-    assert_allclose(psf.psf_value.shape, (result["energy_shape"],
-                                          result["rad_shape"]))
+    assert psf.rad.unit == "rad"
+    assert psf.rad.shape == pars["rad_shape"]
+    assert_allclose(psf.rad.value[15], pars["psf_rad"], rtol=1e-3)
 
-    assert_quantity_allclose(psf.rad[10], result["psf_rad"])
-    assert_quantity_allclose(psf.energy[10], result["psf_energy"])
-    assert_quantity_allclose(psf.exposure[10], result["psf_exposure"])
-    assert_quantity_allclose(psf.psf_value[10, 50], result["psf_value"])
+    assert psf.exposure.unit == "cm2 s"
+    assert psf.exposure.shape == pars["energy_shape"]
+    assert_allclose(psf.exposure.value[15], pars["psf_exposure"], rtol=1e-3)
+
+    assert psf.psf_value.unit == "sr-1"
+    assert psf.psf_value.shape == pars["psf_value_shape"]
+    assert_allclose(psf.psf_value.value[15, 50], pars["psf_value"], rtol=1e-3)
 
 
 @requires_dependency('scipy')

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -211,7 +211,7 @@ class PSF3D(object):
         data_interp = interpolator(pix_coords)
         return Quantity(data_interp.reshape(shape), self.psf_value.unit)
 
-    def to_energy_dependent_table_psf(self, theta='0 deg', exposure=None):
+    def to_energy_dependent_table_psf(self, theta='0 deg', rad=None, exposure=None):
         """
         Convert PSF3D in EnergyDependentTablePSF.
 
@@ -219,6 +219,9 @@ class PSF3D(object):
         ----------
         theta : `~astropy.coordinates.Angle`
             Offset in the field of view
+        rad : `~astropy.coordinates.Angle`
+            Offset from PSF center used for evaluating the PSF on a grid.
+            Default is the ``rad`` from this PSF.
         exposure : `~astropy.units.Quantity`
             Energy dependent exposure. Should be in units equivalent to 'cm^2 s'.
             Default exposure = 1.
@@ -230,8 +233,13 @@ class PSF3D(object):
         """
         theta = Angle(theta)
         energies = self._energy_logcenter()
-        rad = self._rad_center()
-        psf_value = self.evaluate(offset=theta)
+
+        if rad is None:
+            rad = self._rad_center()
+        else:
+            rad = Angle(rad)
+
+        psf_value = self.evaluate(offset=theta, rad=rad)
         psf_value = psf_value[:, 0, :].transpose()
 
         return EnergyDependentTablePSF(

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -11,8 +11,8 @@ from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
 
 @pytest.fixture(scope='session')
 def aeff():
-    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_aeff_2d_023523.fits.gz'
-    return EffectiveAreaTable2D.read(filename, hdu='AEFF_2D')
+    filename = '$GAMMAPY_EXTRA/datasets/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    return EffectiveAreaTable2D.read(filename, hdu='AEFF')
 
 
 class TestEffectiveAreaTable2D:
@@ -23,19 +23,19 @@ class TestEffectiveAreaTable2D:
     @requires_dependency('scipy')
     @requires_data('gammapy-extra')
     def test(aeff):
-        assert aeff.data.axis('energy').nbins == 73
+        assert aeff.data.axis('energy').nbins == 96
         assert aeff.data.axis('offset').nbins == 6
-        assert aeff.data.data.shape == (73, 6)
+        assert aeff.data.data.shape == (96, 6)
 
         assert aeff.data.axis('energy').unit == 'TeV'
         assert aeff.data.axis('offset').unit == 'deg'
         assert aeff.data.data.unit == 'm2'
 
-        assert_quantity_allclose(aeff.high_threshold, 99.083 * u.TeV, rtol=1e-3)
-        assert_quantity_allclose(aeff.low_threshold, 0.603 * u.TeV, rtol=1e-3)
+        assert_quantity_allclose(aeff.high_threshold, 100 * u.TeV, rtol=1e-3)
+        assert_quantity_allclose(aeff.low_threshold, 0.870964 * u.TeV, rtol=1e-3)
 
         test_val = aeff.data.evaluate(energy='14 TeV', offset='0.2 deg')
-        assert_allclose(test_val.value, 740929.645, atol=1e-2)
+        assert_allclose(test_val.value, 683177.5, rtol=1e-3)
 
         # Test ARF export
         offset = 0.236 * u.deg
@@ -102,7 +102,8 @@ class TestEffectiveAreaTable:
         assert ener_below < test_ener and test_ener < ener_above
 
         elo_threshold = arf.find_energy(0.1 * arf.max_area)
-        assert_quantity_allclose(elo_threshold, 0.43669092057562997 * u.TeV)
+        assert elo_threshold.unit == 'TeV'
+        assert_allclose(elo_threshold.value, 0.552741, rtol=1e-3)
 
         # Test evaluation outside safe range
         data = [np.nan, np.nan, 0, 0, 1, 2, 3, np.nan, np.nan]

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -9,6 +9,15 @@ from ...utils.testing import requires_dependency, requires_data
 
 productions = [
     dict(
+        prod='hess-dl3-dr1',
+        datastore='$GAMMAPY_EXTRA/datasets/hess-dl3-dr1',
+        test_obs=23523,
+        aeff_ref=229490.739393 * u.m ** 2,
+        psf_type='psf_table',
+        psf_ref=237.759291 / u.sr,
+        edisp_ref=2.247649,
+    ),
+    dict(
         prod='hap-hd-prod2',
         datastore='$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2',
         test_obs=23523,
@@ -48,20 +57,20 @@ class FitsProductionTester:
         aeff = self.obs.load(hdu_type='aeff', hdu_class='aeff_2d')
         actual = aeff.data.evaluate(energy=self.ref_energy, offset=self.ref_offset)
         desired = self.ref_dict['aeff_ref']
-        assert_quantity_allclose(actual, desired)
+        assert_quantity_allclose(actual, desired, rtol=1e-3)
 
     def test_edisp(self):
         edisp = self.obs.load(hdu_type='edisp', hdu_class='edisp_2d')
         actual = edisp.data.evaluate(e_true=self.ref_energy, offset=self.ref_offset, migra=self.ref_migra)
         desired = self.ref_dict['edisp_ref']
-        assert_quantity_allclose(actual, desired)
+        assert_quantity_allclose(actual, desired, rtol=1e-3)
 
     def test_psf(self):
         psf = self.obs.load(hdu_type='psf', hdu_class=self.ref_dict['psf_type'])
         table_psf = psf.to_energy_dependent_table_psf(rad=self.ref_rad, theta=self.ref_offset)
         actual = table_psf.evaluate(energy=self.ref_energy)
         desired = self.ref_dict['psf_ref']
-        assert_quantity_allclose(actual[0][4], desired)
+        assert_quantity_allclose(actual[0][4], desired, rtol=1e-3)
 
 
 @pytest.mark.parametrize('prod', productions)

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -2,38 +2,43 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
+from numpy.testing import assert_allclose
 import astropy.units as u
 from ...data import DataStore
-from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data
 
+# TODO: clean up these FITS production tests
+# There is some duplication with `gammapy/data/tests/test_data_store.py`
+# This should either be moved there, or to a separate test file
+# called "test legacy" or "test high level" or something like that
+# The goal would be to not accidentally break support for old files
 productions = [
     dict(
-        prod='hess-dl3-dr1',
-        datastore='$GAMMAPY_EXTRA/datasets/hess-dl3-dr1',
+        prod='pa-release1',
+        datastore='$GAMMAPY_EXTRA/datasets/hess-crab4-pa',
         test_obs=23523,
-        aeff_ref=229490.739393 * u.m ** 2,
-        psf_type='psf_table',
-        psf_ref=237.759291 / u.sr,
-        edisp_ref=2.247649,
+        aeff_ref=207835.9,
+        psf_type='psf_king',
+        psf_ref=51.004,
+        edisp_ref=2.783,
     ),
     dict(
         prod='hap-hd-prod2',
         datastore='$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2',
         test_obs=23523,
-        aeff_ref=267252.7018649852 * u.m ** 2,
+        aeff_ref=267252.7,
         psf_type='psf_3gauss',
-        psf_ref=106.31031643387723 / u.sr,
-        edisp_ref=2.059754779846907,
+        psf_ref=106.310,
+        edisp_ref=2.059,
     ),
     dict(
-        prod='pa-release1',
-        datastore='$GAMMAPY_EXTRA/datasets/hess-crab4-pa',
+        prod='hess-dl3-dr1',
+        datastore='$GAMMAPY_EXTRA/datasets/hess-dl3-dr1',
         test_obs=23523,
-        aeff_ref=207835.97395833334 * u.m ** 2,
-        psf_type='psf_king',
-        psf_ref=51.0044923171571 / u.sr,
-        edisp_ref=2.783763964427291,
+        aeff_ref=229490.7,
+        psf_type='psf_table',
+        psf_ref=237.759,
+        edisp_ref=2.247,
     ),
 ]
 
@@ -57,20 +62,23 @@ class FitsProductionTester:
         aeff = self.obs.load(hdu_type='aeff', hdu_class='aeff_2d')
         actual = aeff.data.evaluate(energy=self.ref_energy, offset=self.ref_offset)
         desired = self.ref_dict['aeff_ref']
-        assert_quantity_allclose(actual, desired, rtol=1e-3)
+        assert actual.unit == 'm2'
+        assert_allclose(actual.value, desired, rtol=1e-3)
 
     def test_edisp(self):
         edisp = self.obs.load(hdu_type='edisp', hdu_class='edisp_2d')
         actual = edisp.data.evaluate(e_true=self.ref_energy, offset=self.ref_offset, migra=self.ref_migra)
         desired = self.ref_dict['edisp_ref']
-        assert_quantity_allclose(actual, desired, rtol=1e-3)
+        assert actual.unit == ''
+        assert_allclose(actual.value, desired, rtol=1e-3)
 
     def test_psf(self):
         psf = self.obs.load(hdu_type='psf', hdu_class=self.ref_dict['psf_type'])
         table_psf = psf.to_energy_dependent_table_psf(rad=self.ref_rad, theta=self.ref_offset)
         actual = table_psf.evaluate(energy=self.ref_energy)
         desired = self.ref_dict['psf_ref']
-        assert_quantity_allclose(actual[0][4], desired, rtol=1e-3)
+        assert actual.unit == 'sr-1'
+        assert_allclose(actual.value[0][4], desired, rtol=1e-3)
 
 
 @pytest.mark.parametrize('prod', productions)

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -41,5 +41,5 @@ def test_spectrum_analysis_iact(tmpdir):
 
     dnde = flux_points.table['dnde'].quantity
     dnde.unit == 'cm-2 s-1 TeV-1'
-    assert_allclose(dnde[0].value, 7.168938e-12, rtol=1e-2)
-    assert_allclose(dnde[-1].value, 6.093336e-15, rtol=1e-2)
+    assert_allclose(dnde[0].value, 6.601518e-12, rtol=1e-2)
+    assert_allclose(dnde[-1].value, 1.295918e-15, rtol=1e-2)

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -35,17 +35,17 @@ def extraction():
 @requires_data('gammapy-extra')
 class TestSpectrumExtraction:
     @pytest.mark.parametrize("pars, results", [
-        (dict(containment_correction=False), dict(n_on=172,
-                                                  sigma=24.56,
-                                                  aeff=549861.8 * u.m ** 2,
-                                                  edisp=0.2595896944765074,
+        (dict(containment_correction=False), dict(n_on=192,
+                                                  sigma=20.971149,
+                                                  aeff=580254.9 * u.m ** 2,
+                                                  edisp=0.236176,
                                                   containment=1,
                                                   )),
-        (dict(containment_correction=True), dict(n_on=172,
-                                                 sigma=24.56,
-                                                 aeff=412731.8 * u.m ** 2,
-                                                 edisp=0.2595896944765074,
-                                                 containment=0.7645777148101338,
+        (dict(containment_correction=True), dict(n_on=192,
+                                                 sigma=20.971149,
+                                                 aeff=373237.8 * u.m ** 2,
+                                                 edisp=0.236176,
+                                                 containment=0.661611,
                                                  ))
     ])
     def test_extract(self, pars, results, obs_list, bkg_estimate):
@@ -109,6 +109,7 @@ class TestSpectrumExtraction:
         assert_allclose(actual, desired)
 
     def test_compute_energy_threshold(self, extraction):
+        extraction.run()
         extraction.compute_energy_threshold(method_lo="area_max", area_percent_lo=10)
         actual = extraction.observations[0].lo_threshold
-        assert_quantity_allclose(actual, 0.6812920690579611 * u.TeV, rtol=1e-3)
+        assert_quantity_allclose(actual, 0.879923 * u.TeV, rtol=1e-3)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -150,7 +150,7 @@ def test_lightcurve_plot_time(lc, time_format, output):
 # TODO: Reuse fixtures from spectrum tests
 @pytest.fixture(scope='session')
 def spec_extraction():
-    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/')
     obs_ids = [23523, 23526]
     obs_list = data_store.obs_list(obs_ids)
 
@@ -202,15 +202,15 @@ def test_lightcurve_estimator():
 
     assert_quantity_allclose(len(table), 2)
 
-    assert_allclose(table['flux'][0], 3.759367126537715e-11, rtol=1e-2)
-    assert_allclose(table['flux'][-1], 3.8700838947652217e-11, rtol=1e-2)
+    assert_allclose(table['flux'][0], 4.309371e-11, rtol=1e-3)
+    assert_allclose(table['flux'][-1], 3.543012e-11, rtol=1e-3)
 
-    assert_allclose(table['flux_err'][0], 3.175731544692804e-12, rtol=1e-2)
-    assert_allclose(table['flux_err'][-1], 3.181191593075743e-12, rtol=1e-2)
+    assert_allclose(table['flux_err'][0], 4.135581e-12, rtol=1e-3)
+    assert_allclose(table['flux_err'][-1], 3.654781e-12, rtol=1e-3)
 
     # TODO: change dataset and also add LC point with weak signal
     # or even negative excess that is an UL
-    assert_allclose(table['flux_ul'][0], 4.712087e-11, rtol=1e-2)
+    assert_allclose(table['flux_ul'][0], 5.550045e-11, rtol=1e-3)
     assert not table['is_ul'][0]
 
     # same but with threshold equal to 2 TeV
@@ -221,8 +221,7 @@ def test_lightcurve_estimator():
     )
     table = lc.table
 
-    # assert_allclose(table['flux'][0], 1.02122885108e-11, rtol=1e-2)
-    assert_allclose(table['flux'][0], 7.52856493381838e-12, rtol=1e-2)
+    assert_allclose(table['flux'][0], 5.051995e-12, rtol=1e-3)
 
     # TODO: add test exercising e_reco selection
     # TODO: add asserts on all measured quantities
@@ -254,10 +253,10 @@ def test_lightcurve_adaptative_interval_maker():
         spectrum_extraction=spec_extract,
         separators=separator)
     assert_allclose(table['significance'] >= 3, True)
-    assert_allclose(table['t_start'][5].value, 53343.92371392407, rtol=1e-10)
+    assert_allclose(table['t_start'][5].value, 53343.927374, rtol=1e-10)
     assert_allclose(table['alpha'][5], 0.0833333, rtol=1e-5)
-    assert_allclose(len(table), 71)
-    assert_allclose(table['t_start'][0].value, 53343.92096938292, rtol=1e-10)
-    assert_allclose(table['t_stop'][70].value, 53343.97229090575, rtol=1e-10)
-    assert_allclose(np.logical_and(table['t_start'] < separator[0],
-                                   table['t_stop'] > separator[0]), False)
+    assert len(table) == 57
+    assert_allclose(table['t_start'][0].value, 53343.922392, rtol=1e-10)
+    assert_allclose(table['t_stop'][-1].value, 53343.973528, rtol=1e-10)
+    val = (table['t_start'] < separator[0]) & (table['t_stop'] > separator[0])
+    assert_allclose(val, False)

--- a/gammapy/utils/serialization/xml.py
+++ b/gammapy/utils/serialization/xml.py
@@ -167,7 +167,7 @@ def xml_to_skymodel(xml):
     type_ = xml['@type']
     # TODO: Support ctools radial acceptance
     if type_ == 'RadialAcceptance':
-        log.warn("Radial acceptance models are not supported")
+        log.warning("Radial acceptance models are not supported")
         return None
 
     name = xml['@name']


### PR DESCRIPTION
This PR updates Gammapy tests and docs examples to use the new and good files from https://github.com/gammapy/gammapy-extra/tree/master/datasets/hess-dl3-dr1

Fixes #1744 .

This is work in progress, I'm just opening it now because as I go through I also do some some code polishing and fixes, mostly in gammapy.data, and wanted to leave some notes here . E.g. in 
2054ba0 I removed the unused and unnecessary "name" attribute of `DataStore`, in 
6b020c6 I fixed the EventList altaz property

Next I will remove the `load_all` and `load_many` methods on the DataStore. They are unused, called only from one test which would now be very slow if 100 event lists are loaded. It looks like adding them was my suggestion in 2016 (https://github.com/gammapy/gammapy/pull/383#issuecomment-173571298) and by now I don't think these two-line helper methods are useful (as can be seen by the fact that we don't have a single caller for this any more in Gammapy).

Work in progress ... I'll merge later today.
