### PR TITLE
Add SkyDiffuseMap normalization option

### DIFF
--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import abc
+import logging
 import numpy as np
 import astropy.units as u
 from astropy.coordinates.angle_utilities import angular_separation
@@ -20,6 +21,8 @@ __all__ = [
     'SkyDiffuseMap',
 ]
 
+
+log = logging.getLogger(__name__)
 
 @six.add_metaclass(abc.ABCMeta)
 class SkySpatialModel(object):

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -298,7 +298,7 @@ class SkyDiffuseMap(SkySpatialModel):
         self._interp_kwargs = interp_kwargs
 
     def normalize(self):
-        """Normalize the diffuse map model, so that in integrates to unity."""
+        """Normalize the diffuse map model so that it integrates to unity."""
         data = self.map.data / self.map.data.sum()
         data /= self.map.geom.solid_angle().to('sr').value
         self.map = self.map.copy(data=data, unit='sr-1')

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -96,13 +96,17 @@ def test_sky_diffuse_map():
 @requires_dependency('scipy')
 @requires_data('gammapy-extra')
 def test_sky_diffuse_map_normalize():
+    # define model map with a constant value of 1
     model_map = Map.create(map_type='wcs', width=(10, 5), binsz=0.5)
     model_map.data += 1.
-    data_map = Map.create(map_type='wcs', width=(10, 5), binsz=1)
     model = SkyDiffuseMap(model_map)
 
+    # define data map with a different spatial binning
+    data_map = Map.create(map_type='wcs', width=(10, 5), binsz=1)
     coords = data_map.geom.get_coord()
     solid_angle = data_map.geom.solid_angle()
-    flux = model(coords.lon * u.deg, coords.lat * u.deg) * solid_angle
+    vals = model(coords.lon * u.deg, coords.lat * u.deg) * solid_angle
 
-    assert_allclose(flux.sum().to('').value, 1, rtol=1e-4)
+    assert vals.unit == ''
+    integral = vals.sum()
+    assert_allclose(integral.value, 1, rtol=1e-4)


### PR DESCRIPTION
This PR implements a `SkyDiffuseMap.normalize()` method and `normalize` option in `__init__`, to normalize arbitrary templates, so that they integrate to unity. The default is `normalize=True`, but this also means, that we have to re-expose the normalize argument in `.read()` as the normalization can't be undone.