### PR TITLE
Support BUNIT FITS header key?

### DIFF
--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -179,7 +179,7 @@ class HpxMap(Map):
 
         hdu_out = self.make_hdu(hdu=hdu, hdu_bands=hdu_bands, sparse=sparse, conv=conv)
         hdu_out.header["META"] = json.dumps(self.meta)
-        hdu_out.header["UNIT"] = self.unit.to_string("fits")
+        hdu_out.header["BUNIT"] = self.unit.to_string("fits")
 
         hdu_list = fits.HDUList([fits.PrimaryHDU(), hdu_out])
 

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -73,7 +73,7 @@ class HpxNDMap(HpxMap):
 
         meta = cls._get_meta_from_header(hdu.header)
 
-        unit = hdu.header.get("UNIT", "")
+        unit = hdu.header.get("BUNIT", "")
         map_out = cls(hpx, None, meta=meta, unit=unit)
 
         colnames = hdu.columns.names

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -184,7 +184,7 @@ def test_map_unit_read_write(map_type, unit):
     hdu_list = m.to_hdulist(hdu='COUNTS')
     header = hdu_list['COUNTS'].header
 
-    assert Unit(header['UNIT']) == Unit(unit)
+    assert Unit(header['BUNIT']) == Unit(unit)
 
     m2 = Map.from_hdulist(hdu_list)
     assert m2.unit == unit

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -183,7 +183,7 @@ class WcsMap(Map):
 
         hdu_out.header["META"] = json.dumps(self.meta)
 
-        hdu_out.header["UNIT"] = self.unit.to_string("fits")
+        hdu_out.header["BUNIT"] = self.unit.to_string("fits")
 
         if hdu == "PRIMARY":
             hdulist = [hdu_out]

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -103,7 +103,7 @@ class WcsNDMap(WcsMap):
         shape_wcs = tuple([np.max(geom.npix[0]), np.max(geom.npix[1])])
         meta = cls._get_meta_from_header(hdu.header)
 
-        unit = hdu.header.get("UNIT", "")
+        unit = hdu.header.get("BUNIT", "")
 
         map_out = cls(geom, meta=meta, unit=unit)
 


### PR DESCRIPTION
This is a reminder issue for me to look check if we should support `BUNIT` on `Map.read`.

the CTA 1DC diffuse model was given like this:
```
$ ftlist $CTADATA/models/cube_iem.fits.gz K | grep UNIT
CUNIT1  = 'deg'                / Units of coordinate increment and value
CUNIT2  = 'deg'                / Units of coordinate increment and value
BUNIT   = 'photon/cm2/s/MeV/sr' / Photon flux
TUNIT1  = 'MeV     '
```

and currently `Map.read` doesn't read `BUNIT`:
```
>>> from gammapy.maps import Map
>>> m = Map.read('$CTADATA/models/cube_iem.fits.gz')
>>> m.unit
Unit(dimensionless)
```

@robertazanin @facero @registerrier  - For now, when using the diffuse model, please always load it via `SkyDiffuseCube.read` - there we set the default unit and the model should come out OK to use with MapEvaluator and MapFit.

https://github.com/gammapy/gammapy/blob/327e4d3ba253c139478fd5c8d8e8adf6fbc9df0b/gammapy/cube/models.py#L325

