### PR TITLE
Add conda env file for release v0.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,34 @@
+# Conda environment for Gammapy stable versions
+# Install:    conda env create -f environment.yml
+# Activate:   source activate gammapy_v08
+# Deactivate: source deactivate
+
+name: gammapy_v08
+
+channels:
+  - conda-forge
+  - sherpa
+
+dependencies:
+  - python==3.6
+  - ipython==6.5.0
+  - jupyter==1.0.0
+  - jupyterlab==0.33.8
+  - jupyterlab_launcher==0.11.2
+  - cython==0.28.5
+  - numpy==1.13
+  - astropy==3.0.4
+  - regions==0.2
+  - click==6.7
+  - pyyaml==3.12
+  - scipy==0.19.1
+  - photutils==0.4
+  - reproject==0.4
+  - uncertainties==3.0.2
+  - naima==0.8.1
+  - iminuit==1.2
+  - sherpa==4.10
+  - healpy==1.11.0
+  - matplotlib==2.2.2
+  - pandas==0.23.4
+  - gammapy==0.8

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 # Conda environment for Gammapy stable versions
 # Install:    conda env create -f environment.yml
-# Activate:   source activate gammapy_v08
+# Activate:   source activate gammapy-0.8
 # Deactivate: source deactivate
 
-name: gammapy_v08
+name: gammapy-0.8
 
 channels:
   - conda-forge


### PR DESCRIPTION
This PR adds a conda env file for release v0.8, as discussed in https://github.com/gammapy/gammapy/issues/1725

Another conda env file has been added to gammapy-webpage repo in https://github.com/gammapy/gammapy-webpage/pull/17

In the near future, this conda env file will be also used to create virtual environments for stable versioned releases in Binder, if tutorials are moved to this gammapy repo as proposed in PIG 4 https://github.com/gammapy/gammapy/blob/8ea7f92e758eca32386d468fcdfef479ee567703/docs/development/pigs/pig-004.rst

I would suggest, as a next step, to move environment-dev.yml file to `dev` folder, and modify documentation accordingly.
