### PR TITLE
Move find_peaks to gammapy.detect

### DIFF
--- a/gammapy/detect/__init__.py
+++ b/gammapy/detect/__init__.py
@@ -6,3 +6,4 @@ from .kernel import *
 from .cwt import *
 from .test_statistics import *
 from .lima import *
+from .find import *

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -1,0 +1,96 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+from ..maps import WcsNDMap
+
+__all__ = [
+    'find_peaks',
+]
+
+
+def find_peaks(image, threshold, min_distance=1):
+    """Find local peaks in an image.
+
+    This is a very simple peak finder, that finds local peaks
+    (i.e. maxima) in images above a given ``threshold`` within
+    a given ``min_distance`` around each given pixel.
+
+    If you get multiple spurious detections near a peak, usually
+    it's best to smooth the image a bit, or to compute it using
+    a different method in the first place to result in a smooth image.
+    You can also increase the ``min_distance`` parameter.
+
+    The output table contains one row per peak and the following columns:
+
+    - ``x`` and ``y`` are the pixel coordinates (first pixel at zero)
+    - ``ra`` and ``dec`` are the RA / DEC sky coordinates (ICRS frame)
+    - ``value`` is the pixel value
+
+    It is sorted by peak value, starting with the highest value.
+
+    If there are no pixel values above the threshold, an empty table is returned.
+
+    There are more featureful peak finding and source detection methods
+    e.g. in the ``photutils`` or ``scikit-image`` Python packages.
+
+    Parameters
+    ----------
+    image : `~gammapy.maps.WcsNDMap`
+        2D map
+    threshold : float or array-like
+        The data value or pixel-wise data values to be used for the
+        detection threshold.  A 2D ``threshold`` must have the same
+        shape as tha map ``data``.
+    min_distance : int
+        Minimum pixel distance between peaks.
+        Smallest possible value and default is 1 pixel.
+
+    Returns
+    -------
+    output : `~astropy.table.Table`
+        Table with parameters of detected peaks
+    """
+    from scipy.ndimage import maximum_filter
+
+    # Input validation
+
+    if not isinstance(image, WcsNDMap):
+        raise TypeError('find_peaks only supports WcsNDMap')
+
+    if not image.geom.is_image:
+        raise ValueError('find_peaks only supports 2D images')
+
+    size = 2 * min_distance + 1
+
+    data = image.data
+
+    # Handle edge case of constant data; treat as no peak
+    if np.all(data == data.flat[0]):
+        return Table()
+
+    # Run peak finder
+    data_max = maximum_filter(data, size=size, mode='constant')
+    mask = (data == data_max) & (data > threshold)
+    y, x = mask.nonzero()
+    value = data[y, x]
+
+    # Make and return results table
+
+    if len(value) == 0:
+        return Table()
+
+    coord = SkyCoord.from_pixel(x, y, wcs=image.geom.wcs).icrs
+
+    table = Table()
+    table['value'] = value * image.unit
+    table['x'] = x
+    table['y'] = y
+    table['ra'] = coord.ra
+    table['dec'] = coord.dec
+
+    table.sort('value')
+    table.reverse()
+
+    return table

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -92,6 +92,10 @@ def find_peaks(image, threshold, min_distance=1):
     table['ra'] = coord.ra
     table['dec'] = coord.dec
 
+    table['ra'].format = '.5f'
+    table['dec'].format = '.5f'
+    table['value'].format = '.5g'
+
     table.sort('value')
     table.reverse()
 

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -64,15 +64,13 @@ def find_peaks(image, threshold, min_distance=1):
 
     size = 2 * min_distance + 1
 
-    data = image.data
+    # Remove non-finite values to avoid warnings or spurious detection
+    data = image.data.copy()
+    data[~np.isfinite(data)] = np.nanmin(data)
 
     # Handle edge case of constant data; treat as no peak
     if np.all(data == data.flat[0]):
         return Table()
-
-    # Remove non-finite values to avoid warnings or spurious detection
-    data = data.copy()
-    data[~np.isfinite(data)] = threshold - 1
 
     # Run peak finder
     data_max = maximum_filter(data, size=size, mode='constant')

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -70,6 +70,10 @@ def find_peaks(image, threshold, min_distance=1):
     if np.all(data == data.flat[0]):
         return Table()
 
+    # Remove non-finite values to avoid warnings or spurious detection
+    data = data.copy()
+    data[~np.isfinite(data)] = threshold - 1
+
     # Run peak finder
     data_max = maximum_filter(data, size=size, mode='constant')
     mask = (data == data_max) & (data > threshold)

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -17,7 +17,7 @@ class TestFindPeaks:
         image.data[3, 4] = 10
         image.data[3, 5] = 12
         image.data[3, 6] = np.nan
-        image.data[0, 9] = 99
+        image.data[0, 9] = 1e20
 
         table = find_peaks(image, threshold=3)
 
@@ -28,7 +28,7 @@ class TestFindPeaks:
 
         row = table[0]
         assert tuple((row['x'], row['y'])) == (9, 0)
-        assert_allclose(row['value'], 99)
+        assert_allclose(row['value'], 1e20)
         assert_allclose(row['ra'], 359.55)
         assert_allclose(row['dec'], -0.2)
 

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from numpy.testing import assert_allclose
+from ...utils.testing import requires_dependency
+from ...maps import Map
+from ..find import find_peaks
+
+
+@requires_dependency('scipy')
+class TestFindPeaks:
+
+    def test_simple(self):
+        """Test a simple example"""
+        image = Map.create(npix=(10, 5), unit='s')
+        image.data[3, 3] = 11
+        image.data[3, 4] = 10
+        image.data[3, 5] = 12
+        image.data[0, 9] = 99
+
+        table = find_peaks(image, threshold=3)
+
+        assert len(table) == 3
+        assert table['value'].unit == 's'
+        assert table['ra'].unit == 'deg'
+        assert table['dec'].unit == 'deg'
+
+        row = table[0]
+        assert tuple((row['x'], row['y'])) == (9, 0)
+        assert_allclose(row['value'], 99)
+        assert_allclose(row['ra'], 359.55)
+        assert_allclose(row['dec'], -0.2)
+
+        row = table[1]
+        assert tuple((row['x'], row['y'])) == (5, 3)
+        assert_allclose(row['value'], 12)
+
+    def test_no_peak(self):
+        image = Map.create(npix=(10, 5))
+        image.data[3, 5] = 12
+
+        table = find_peaks(image, threshold=12.1)
+        assert len(table) == 0
+
+    def test_constant(self):
+        image = Map.create(npix=(10, 5))
+
+        table = find_peaks(image, threshold=3)
+        assert len(table) == 0

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency
 from ...maps import Map
@@ -15,6 +16,7 @@ class TestFindPeaks:
         image.data[3, 3] = 11
         image.data[3, 4] = 10
         image.data[3, 5] = 12
+        image.data[3, 6] = np.nan
         image.data[0, 9] = 99
 
         table = find_peaks(image, threshold=3)

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -2,9 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from astropy.units import Quantity
-from astropy.coordinates import SkyCoord
-from astropy.table import Table, Column
-from ..maps import WcsNDMap
 
 __all__ = [
     'measure_containment_fraction',
@@ -12,7 +9,6 @@ __all__ = [
     'measure_image_moments',
     'measure_containment',
     'measure_curve_of_growth',
-    'find_peaks',
 ]
 
 
@@ -163,87 +159,3 @@ def measure_curve_of_growth(image, position, radius_max=None, radius_n=10):
     return radii, Quantity(containment)
 
 
-def find_peaks(image, threshold, min_distance=1):
-    """Find local peaks in an image.
-
-    This is a very simple peak finder, that finds local peaks
-    (i.e. maxima) in images above a given ``threshold`` within
-    a given ``min_distance`` around each given pixel.
-
-    If you get multiple spurious detections near a peak, usually
-    it's best to smooth the image a bit, or to compute it using
-    a different method in the first place to result in a smooth image.
-    You can also increase the ``min_distance`` parameter.
-
-    The output table contains one row per peak and the following columns:
-
-    - ``x`` and ``y`` are the pixel coordinates (first pixel at zero)
-    - ``ra`` and ``dec`` are the RA / DEC sky coordinates (ICRS frame)
-    - ``value`` is the pixel value
-
-    It is sorted by peak value, starting with the highest value.
-
-    If there are no pixel values above the threshold, an empty table is returned.
-
-    There are more featureful peak finding and source detection methods
-    e.g. in the ``photutils`` or ``scikit-image`` Python packages.
-
-    Parameters
-    ----------
-    image : `~gammapy.maps.WcsNDMap`
-        2D map
-    threshold : float or array-like
-        The data value or pixel-wise data values to be used for the
-        detection threshold.  A 2D ``threshold`` must have the same
-        shape as tha map ``data``.
-    min_distance : int
-        Minimum pixel distance between peaks.
-        Smallest possible value and default is 1 pixel.
-
-    Returns
-    -------
-    output : `~astropy.table.Table`
-        Table with parameters of detected peaks
-    """
-    from scipy.ndimage import maximum_filter
-
-    # Input validation
-
-    if not isinstance(image, WcsNDMap):
-        raise TypeError('find_peaks only supports WcsNDMap')
-
-    if not image.geom.is_image:
-        raise ValueError('find_peaks only supports 2D images')
-
-    size = 2 * min_distance + 1
-
-    data = image.data
-
-    # Handle edge case of constant data; treat as no peak
-    if np.all(data == data.flat[0]):
-        return Table()
-
-    # Run peak finder
-    data_max = maximum_filter(data, size=size, mode='constant')
-    mask = (data == data_max) & (data > threshold)
-    y, x = mask.nonzero()
-    value = data[y, x]
-
-    # Make and return results table
-
-    if len(value) == 0:
-        return Table()
-
-    coord = SkyCoord.from_pixel(x, y, wcs=image.geom.wcs).icrs
-
-    table = Table()
-    table['value'] = value * image.unit
-    table['x'] = x
-    table['y'] = y
-    table['ra'] = coord.ra
-    table['dec'] = coord.dec
-
-    table.sort('value')
-    table.reverse()
-
-    return table

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -1,19 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
 from astropy import units as u
 from astropy.modeling.models import Gaussian2D
 from astropy.coordinates import SkyCoord
 from ...utils.testing import assert_quantity_allclose, requires_dependency
-from ...maps import WcsGeom, WcsNDMap, Map
+from ...maps import WcsGeom, WcsNDMap
 from ...image import (
     measure_containment_radius,
     measure_image_moments,
     measure_containment,
     measure_curve_of_growth,
-    find_peaks,
 )
 
 
@@ -75,45 +73,3 @@ def test_measure_curve_of_growth(gaussian_image):
     sigma = 0.2 * u.deg
     containment_ana = u.Quantity(1 - np.exp(-0.5 * (radius / sigma) ** 2).value, 'cm-2 s-1')
     assert_quantity_allclose(containment, containment_ana, rtol=0.1)
-
-
-@requires_dependency('scipy')
-class TestFindPeaks:
-
-    def test_simple(self):
-        """Test a simple example"""
-        image = Map.create(npix=(10, 5), unit='s')
-        image.data[3, 3] = 11
-        image.data[3, 4] = 10
-        image.data[3, 5] = 12
-        image.data[0, 9] = 99
-
-        table = find_peaks(image, threshold=3)
-
-        assert len(table) == 3
-        assert table['value'].unit == 's'
-        assert table['ra'].unit == 'deg'
-        assert table['dec'].unit == 'deg'
-
-        row = table[0]
-        assert tuple((row['x'], row['y'])) == (9, 0)
-        assert_allclose(row['value'], 99)
-        assert_allclose(row['ra'], 359.55)
-        assert_allclose(row['dec'], -0.2)
-
-        row = table[1]
-        assert tuple((row['x'], row['y'])) == (5, 3)
-        assert_allclose(row['value'], 12)
-
-    def test_no_peak(self):
-        image = Map.create(npix=(10, 5))
-        image.data[3, 5] = 12
-
-        table = find_peaks(image, threshold=12.1)
-        assert len(table) == 0
-
-    def test_constant(self):
-        image = Map.create(npix=(10, 5))
-
-        table = find_peaks(image, threshold=3)
-        assert len(table) == 0


### PR DESCRIPTION
This PR is a follow-up to #1759 - it moves `find_peaks` to `gammapy.detect`.

I also added a second commit to handle non-finite data values, to never be a peak or cause warnings.
For those code lines, I'm not sure if this is the best way to write it. It should work for almost all cases, even int data, except extreme cases where data values at the minimum representable int value occur, or where such big float numbers occur that `threshold == threshold - 1`. @adonath - If you know of a better / safer way to write this that always works, please put it.

Before I was getting this from the tutorial notebook, where find_peaks is run on TS images that frequently have NaN at the edges:
```
/Users/deil/work/code/gammapy/gammapy/image/measure.py:228: RuntimeWarning: invalid value encountered in greater
  mask = (data == data_max) & (data > threshold)
```

I'll add a commit to set nice default column format precision and merge.