### PR TITLE
Improvement of gammapy download

### DIFF
--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -9,13 +9,14 @@ import click
 
 import sys
 import json
+# from gammapy import version
 from ..extern.pathlib import Path
 from ..extern.six.moves.urllib.request import urlretrieve, urlopen
 
 log = logging.getLogger(__name__)
 
-apigitUrl = "https://api.github.com/repos/gammapy/gammapy-extra/git/trees/master:"
-rawgitUrl = "https://raw.githubusercontent.com/gammapy/gammapy-extra/master/"
+apigitUrl = 'https://api.github.com/repos/gammapy/'
+rawgitUrl = 'https://raw.githubusercontent.com/gammapy/'
 
 
 @click.command(name="notebooks")
@@ -23,9 +24,17 @@ rawgitUrl = "https://raw.githubusercontent.com/gammapy/gammapy-extra/master/"
 def cli_download_notebooks(ctx):
     """Download notebooks"""
 
-    localfolder = Path(ctx.obj["localfolder"])
-    downloadproc = DownloadProcess("notebooks", ["environment.yml"], localfolder)
+    downloadproc = DownloadProcess(
+        'gammapy-extra',
+        'notebooks',
+        ctx.obj['hash'],
+        ['../environment.yml'],
+        ctx.obj['localfolder']
+    )
     downloadproc.go()
+
+    # TODO
+    # rename environment.yml with downloadproc.hash
 
 
 @click.command(name="datasets")
@@ -33,22 +42,31 @@ def cli_download_notebooks(ctx):
 def cli_download_datasets(ctx):
     """Download datasets"""
 
-    localfolder = Path(ctx.obj["localfolder"])
-    downloadproc = DownloadProcess("datasets", [], localfolder)
+    downloadproc = DownloadProcess(
+        'gammapy-extra',
+        'datasets',
+        ctx.obj['hash'],
+        [],
+        ctx.obj['localfolder']
+    )
     downloadproc.go()
 
 
 class DownloadProcess:
     """Manages the process of downloading the folder of the Github repository"""
 
-    def __init__(self, repofold, listfiles, localfolder):
+    def __init__(self, repo, repofold, hash, listfiles, localfolder):
 
+        self.repo = repo
         self.repofold = repofold
+        self.hash = hash
         self.listfiles = listfiles
-        self.localfolder = localfolder
+        self.localfolder = Path(localfolder) / repofold
 
     def go(self):
 
+        # scan Github repo
+        self.check_hash()
         json_files = self.get_json_tree()
         self.parse_json_tree(json_files)
 
@@ -60,41 +78,79 @@ class DownloadProcess:
         # process finished
         self.show_info()
 
+    def check_hash(self):
+
+        # master
+        # notebooks still in gammapy-extra repo
+        if self.hash == '':
+            # installed gammapy version
+            # uncomment when notebooks moved to gammapy repo
+            # self.hash = version.githash
+            self.hash = 'master'
+            refhash = 'refs/heads/' + self.hash
+        # version
+        elif self.hash.startswith('v.'):
+            refhash = 'refs/tags/' + self.hash
+        # commit hash
+        elif len(self.hash) == 40:
+            refhash = 'commits/' + self.hash
+        # branch
+        else:
+            refhash = 'refs/heads/' + self.hash
+
+        # check hash
+        url = apigitUrl + self.repo + '/git/' + refhash
+        try:
+            urlopen(url)
+        except Exception as ex:
+            log.error('Failed: bad response from GitHub API')
+            log.error(
+                'Bad value for release, branch or hash: ' + self.hash)
+            log.error(ex)
+            sys.exit()
+
+        # name versioned notebooks folder
+        if self.repofold == 'notebooks':
+            v_nbfolder = str(self.localfolder) + '-' + self.hash
+            self.localfolder = Path(v_nbfolder)
+
     def get_json_tree(self):
 
-        url = apigitUrl + self.repofold + "?recursive=1"
+        url = apigitUrl + self.repo + '/git/trees/' + self.hash + ':' + \
+            self.repofold + '?recursive=1'
 
         try:
             r = urlopen(url)
             json_items = json.loads(r.read())
             return json_items
         except Exception as ex:
-            log.error("Failed: bad response from GitHub API")
+            log.error('Failed: bad response from GitHub API')
+            log.error(ex)
             sys.exit()
 
     def parse_json_tree(self, json_files):
 
-        for item in json_files["tree"]:
-
-            ipath = self.repofold + "/" + item["path"]
-            ifolder = self.localfolder / self.repofold / item["path"]
-
-            if item["type"] == "tree":
+        for item in json_files['tree']:
+            ifolder = self.localfolder / item['path']
+            if item['type'] == 'tree':
                 ifolder.mkdir(parents=True, exist_ok=True)
             else:
-                self.listfiles.append(ipath)
+                self.listfiles.append(item['path'])
 
     def get_file(self, filename):
 
-        url = rawgitUrl + filename
+        url = rawgitUrl + self.repo + \
+            '/' + self.hash + '/' + self.repofold + '/' + filename
         filepath = self.localfolder / filename
 
         try:
             urlretrieve(url, str(filepath))
         except Exception as ex:
-            log.error(str(filepath) + " could not be copied")
+            log.error(str(filepath) + ' could not be copied')
+            log.error(ex)
 
-    def show_info(self,):
+    def show_info(self):
 
-        print("The files have been downloaded in folder {}.".format(self.localfolder))
-        print("Process finished.")
+        print('The files have been downloaded in folder {}.'.format(
+            self.localfolder))
+        print('Process finished.')

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Command line tool to download datasets and notebooks from gammapy-extra GitHub repo.
-GitHub REST API is used to access tree-folder and file lists for a specific commit/tag.
+GitHub REST API is used to scan the tree-folder strucutre and get commmit hash.
 https://developer.github.com/v3/
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -9,7 +9,7 @@ import click
 
 import sys
 import json
-# from gammapy import version
+# from .. import version
 from ..extern.pathlib import Path
 from ..extern.six.moves.urllib.request import urlretrieve, urlopen
 
@@ -27,14 +27,36 @@ def cli_download_notebooks(ctx):
     downloadproc = DownloadProcess(
         'gammapy-extra',
         'notebooks',
+        ctx.obj['specfile'],
+        ctx.obj['specfold'],
         ctx.obj['hash'],
         ['../environment.yml'],
-        ctx.obj['localfolder']
+        Path(ctx.obj['localfold']) / 'notebooks'
     )
+
+    # valid hash
+    downloadproc.check_hash()
+
+    # get version label
+    version = ctx.obj['hash']
+    if ctx.obj['hash'] == '':
+        # uncomment when notebooks moved to gammapy repo
+        # version = version.version
+        version = 'master'
+
+    # rename notebooks folder with version label
+    verfolder = str(
+        Path(ctx.obj['localfold']) / 'notebooks-') + version
+    downloadproc.localfold = Path(verfolder)
+
+    # download
     downloadproc.go()
 
-    # TODO
-    # rename environment.yml with downloadproc.hash
+    # rename environment.yml with version label
+    envfile = Path(ctx.obj['localfold']) / 'environment.yml'
+    verfile = str(
+        Path(ctx.obj['localfold']) / 'environment-') + version + '.yml'
+    envfile.rename(verfile)
 
 
 @click.command(name="datasets")
@@ -45,51 +67,64 @@ def cli_download_datasets(ctx):
     downloadproc = DownloadProcess(
         'gammapy-extra',
         'datasets',
+        ctx.obj['specfile'],
+        ctx.obj['specfold'],
         ctx.obj['hash'],
         [],
-        ctx.obj['localfolder']
+        Path(ctx.obj['localfold']) / 'datasets'
     )
+
+    # valid hash
+    downloadproc.check_hash()
+
+    # download
     downloadproc.go()
 
 
 class DownloadProcess:
-    """Manages the process of downloading the folder of the Github repository"""
+    """Manages the process of downloading content from the Github repository"""
 
-    def __init__(self, repo, repofold, hash, listfiles, localfolder):
+    def __init__(self, repo, repofold, specfile, specfold,
+                 hash, listfiles, localfold):
 
         self.repo = repo
         self.repofold = repofold
+        self.specfile = specfile
+        self.specfold = specfold
         self.hash = hash
         self.listfiles = listfiles
-        self.localfolder = Path(localfolder) / repofold
+        self.localfold = localfold
+
+        if specfile and specfold:
+            log.error(
+                '--file and --foder are exclusive options, only one is allowed.')
+            sys.exit()
 
     def go(self):
 
-        # scan Github repo
-        self.check_hash()
-        json_files = self.get_json_tree()
-        self.parse_json_tree(json_files)
+        # fill list of files
+        self.fill_listfiles()
+        print('Content will be downloaded in {}'.format(self.localfold))
 
-        # download files with progressbar
-        with click.progressbar(self.listfiles, label="Downloading files") as bar:
-            for f in bar:
-                self.get_file(f)
-
-        # process finished
-        self.show_info()
+        # download files
+        if self.listfiles:
+            with click.progressbar(self.listfiles, label='Downloading files') as bar:
+                for f in bar:
+                    self.get_file(f)
+        else:
+            sys.exit()
 
     def check_hash(self):
 
-        # master
-        # notebooks still in gammapy-extra repo
+        # installed local gammapy hash
         if self.hash == '':
-            # installed gammapy version
             # uncomment when notebooks moved to gammapy repo
             # self.hash = version.githash
+            # refhash = 'refs/commits/' + self.hash
             self.hash = 'master'
             refhash = 'refs/heads/' + self.hash
-        # version
-        elif self.hash.startswith('v.'):
+        # release
+        elif self.hash.startswith('v') and len(self.hash) == 4:
             refhash = 'refs/tags/' + self.hash
         # commit hash
         elif len(self.hash) == 40:
@@ -103,35 +138,47 @@ class DownloadProcess:
         try:
             urlopen(url)
         except Exception as ex:
-            log.error('Failed: bad response from GitHub API')
+            log.error('Bad response from GitHub API.')
             log.error(
                 'Bad value for release, branch or hash: ' + self.hash)
-            log.error(ex)
             sys.exit()
 
-        # name versioned notebooks folder
-        if self.repofold == 'notebooks':
-            v_nbfolder = str(self.localfolder) + '-' + self.hash
-            self.localfolder = Path(v_nbfolder)
+    def fill_listfiles(self):
+
+        if self.specfile:
+            ifolder = self.localfold / Path(self.specfile).parent
+            ifolder.mkdir(parents=True, exist_ok=True)
+            self.listfiles.append(self.specfile)
+        else:
+            json_files = self.get_json_tree()
+            self.parse_json_tree(json_files)
 
     def get_json_tree(self):
 
-        url = apigitUrl + self.repo + '/git/trees/' + self.hash + ':' + \
-            self.repofold + '?recursive=1'
+        url = apigitUrl + self.repo + '/git/trees/' + self.hash + ':' + self.repofold
+        if self.specfold:
+            url = url + '/' + self.specfold
+        url = url + '?recursive=1'
 
         try:
             r = urlopen(url)
             json_items = json.loads(r.read())
             return json_items
         except Exception as ex:
-            log.error('Failed: bad response from GitHub API')
+            log.error('Bad response from GitHub API.')
             log.error(ex)
             sys.exit()
 
     def parse_json_tree(self, json_files):
 
+        if self.specfold:
+            ifolder = self.localfold / Path(self.specfold)
+            ifolder.mkdir(parents=True, exist_ok=True)
+
         for item in json_files['tree']:
-            ifolder = self.localfolder / item['path']
+            if self.specfold:
+                item['path'] = self.specfold + '/' + item['path']
+            ifolder = self.localfold / Path(item['path'])
             if item['type'] == 'tree':
                 ifolder.mkdir(parents=True, exist_ok=True)
             else:
@@ -141,16 +188,10 @@ class DownloadProcess:
 
         url = rawgitUrl + self.repo + \
             '/' + self.hash + '/' + self.repofold + '/' + filename
-        filepath = self.localfolder / filename
+        filepath = self.localfold / filename
 
         try:
             urlretrieve(url, str(filepath))
         except Exception as ex:
-            log.error(str(filepath) + ' could not be copied')
+            log.error(str(filepath) + ' could not be copied.')
             log.error(ex)
-
-    def show_info(self):
-
-        print('The files have been downloaded in folder {}.'.format(
-            self.localfolder))
-        print('Process finished.')

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -68,21 +68,33 @@ def cli_image():
     """Analysis - 2D images"""
 
 
-@cli.group("download", short_help="Download datasets and notebooks")
-@click.option(
-    "--folder",
-    prompt="target folder",
-    default="gammapy-tutorials",
-    help="Folder where the files will be copied.",
-)
+@cli.group('download', short_help='Download datasets and notebooks')
+@click.option('--folder', prompt='target folder', default='gammapy-tutorials',
+              help='Folder where the files will be copied.')
+@click.option('--hash', default='',
+              help='Version release, branch or commit hash in Github repo.')
 @click.pass_context
-def cli_download(ctx, folder):
-    """
+def cli_download(ctx, folder, hash):
+    """Download datasets and notebooks.
+
     Download from the 'gammapy-extra' Github repository the content of
     'datasets' or 'notebooks' folders. The files are copied into a folder
     created at the current working directory.
+
+    \b
+    Examples
+    --------
+
+    \b
+    $ gammapy download notebooks
+    $ gammapy download datasets
+    $ gammapy download --folder=myfolder datasets
+    $ gammapy download --hash=master notebooks
     """
-    ctx.obj = {"localfolder": folder}
+    ctx.obj = {
+        'localfolder': folder,
+        'hash': hash,
+    }
 
 
 @cli.group('jupyter', short_help='Perform actions on notebooks')

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -63,12 +63,13 @@ def cli_image():
               help='Folder where the files will be copied.')
 @click.option('--file', default='',
               help='Specific file to download.')
-@click.option('--folder', default='',
+@click.option('--fold', default='',
               help='Specific folder to download.')
 @click.option('--hash', default='',
-              help='Version release, branch or commit hash in Github repo.')
+              help='Release, branch or commit hash in Github repo.')
+@click.option('--recursive/--no-recursive', default=True, help='Deactivate recursive scan of a folder.')
 @click.pass_context
-def cli_download(ctx, dest, file, folder, hash):
+def cli_download(ctx, dest, file, fold, hash, recursive):
     """Download datasets and notebooks.
 
     Download from the 'gammapy-extra' Github repository the content of
@@ -83,14 +84,15 @@ def cli_download(ctx, dest, file, folder, hash):
     $ gammapy download notebooks
     $ gammapy download datasets
     $ gammapy download --file=first_steps.ipynb notebooks
-    $ gammapy download --dest=localfolder --folder=catalogs/fermi datasets
+    $ gammapy download --dest=localfolder --fold=catalogs/fermi --no-recursive datasets
     $ gammapy download --hash=master notebooks
     """
     ctx.obj = {
         'localfold': dest,
         'specfile': file,
-        'specfold': folder,
+        'specfold': fold,
         'hash': hash,
+        'recursive': recursive
     }
 
 

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -65,11 +65,11 @@ def cli_image():
               help='Specific file to download.')
 @click.option('--fold', default='',
               help='Specific folder to download.')
-@click.option('--hash', default='',
-              help='Release, branch or commit hash in Github repo.')
+@click.option('--release', default='',
+              help='Release or commit hash in Github repo.')
 @click.option('--recursive/--no-recursive', default=True, help='Deactivate recursive scan of a folder.')
 @click.pass_context
-def cli_download(ctx, dest, file, fold, hash, recursive):
+def cli_download(ctx, dest, file, fold, release, recursive):
     """Download datasets and notebooks.
 
     Download from the 'gammapy-extra' Github repository the content of
@@ -85,13 +85,13 @@ def cli_download(ctx, dest, file, fold, hash, recursive):
     $ gammapy download datasets
     $ gammapy download --file=first_steps.ipynb notebooks
     $ gammapy download --dest=localfolder --fold=catalogs/fermi --no-recursive datasets
-    $ gammapy download --hash=master notebooks
+    $ gammapy download --release=master notebooks
     """
     ctx.obj = {
         'localfold': dest,
         'specfile': file,
         'specfold': fold,
-        'hash': hash,
+        'release': release,
         'recursive': recursive
     }
 

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -18,25 +18,15 @@ def print_version(ctx, param, value):
 
 
 # http://click.pocoo.org/5/documentation/#help-parameter-customization
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.group("gammapy", context_settings=CONTEXT_SETTINGS)
-@click.option(
-    "--log-level",
-    default="info",
-    help="Logging verbosity level",
-    type=click.Choice(["debug", "info", "warning", "error"]),
-)
-@click.option("--ignore-warnings", is_flag=True, help="Ignore warnings?")
-@click.option(
-    "--version",
-    is_flag=True,
-    callback=print_version,
-    expose_value=False,
-    is_eager=True,
-    help="Print version and exit",
-)
+@click.group('gammapy', context_settings=CONTEXT_SETTINGS)
+@click.option('--log-level', default='info', help='Logging verbosity level.',
+              type=click.Choice(['debug', 'info', 'warning', 'error']))
+@click.option('--ignore-warnings', is_flag=True, help='Ignore warnings?')
+@click.option('--version', is_flag=True, callback=print_version,
+              expose_value=False, is_eager=True, help='Print version and exit.')
 def cli(log_level, ignore_warnings):
     """Gammapy command line interface (CLI).
 
@@ -69,12 +59,16 @@ def cli_image():
 
 
 @cli.group('download', short_help='Download datasets and notebooks')
-@click.option('--folder', prompt='target folder', default='gammapy-tutorials',
+@click.option('--dest', prompt='destination folder', default='gammapy-tutorials',
               help='Folder where the files will be copied.')
+@click.option('--file', default='',
+              help='Specific file to download.')
+@click.option('--folder', default='',
+              help='Specific folder to download.')
 @click.option('--hash', default='',
               help='Version release, branch or commit hash in Github repo.')
 @click.pass_context
-def cli_download(ctx, folder, hash):
+def cli_download(ctx, dest, file, folder, hash):
     """Download datasets and notebooks.
 
     Download from the 'gammapy-extra' Github repository the content of
@@ -88,11 +82,14 @@ def cli_download(ctx, folder, hash):
     \b
     $ gammapy download notebooks
     $ gammapy download datasets
-    $ gammapy download --folder=myfolder datasets
+    $ gammapy download --file=first_steps.ipynb notebooks
+    $ gammapy download --dest=localfolder --folder=catalogs/fermi datasets
     $ gammapy download --hash=master notebooks
     """
     ctx.obj = {
-        'localfolder': folder,
+        'localfold': dest,
+        'specfile': file,
+        'specfold': folder,
         'hash': hash,
     }
 


### PR DESCRIPTION
This PR extends functionalities of `gammapy download` - initially added in https://github.com/gammapy/gammapy/pull/1369 as a CLI to address issues of [PIG 4 - Setup for tutorial notebooks and data](https://github.com/gammapy/gammapy/blob/8ea7f92e758eca32386d468fcdfef479ee567703/docs/development/pigs/pig-004.rst) in https://github.com/gammapy/gammapy/pull/1419.

This PR provides `gammapy download` with new options:
- specify gammapy version release or commit hash in Github repo
- downloading a specific file or all content from a specific folder
- recursive/no-recursive flag to avoid content download recursively

<pre>
$ gammapy download 
Usage: gammapy download [OPTIONS] COMMAND [ARGS]...

  Download datasets and notebooks.

  Download from the 'gammapy-extra' Github repository the content of
  'datasets' or 'notebooks' folders. The files are copied into a folder
  created at the current working directory.

  Examples
  --------

  $ gammapy download notebooks
  $ gammapy download datasets
  $ gammapy download --file=first_steps.ipynb notebooks
  $ gammapy download --dest=localfolder --fold=catalogs/fermi --no-recursive datasets
  $ gammapy download --hash=master notebooks

Options:
  --dest TEXT                   Folder where the files will be copied.
  --file TEXT                   Specific file to download.
  --fold TEXT                   Specific folder to download.
  --hash TEXT                   Release or commit hash in Github repo.
  --recursive / --no-recursive  Deactivate recursive scan of a folder.
  -h, --help                    Show this message and exit.

Commands:
  datasets   Download datasets
  notebooks  Download notebooks
</pre>



