### PR TITLE
Testipynb bundled in extern folder as a single script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme'
+        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme properties'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme testipynb'
+        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -43,4 +43,3 @@ dependencies:
     - sphinx-click
     - pydocstyle
     - black
-    - testipynb

--- a/gammapy/extern/__init__.py
+++ b/gammapy/extern/__init__.py
@@ -18,8 +18,10 @@ Alphabetical order:
   Origin: https://github.com/astrofrog/sedfitter/blob/master/sedfitter/utils/validator.py
 * ``xmltodict.py`` for easily converting XML from / to Python dicts
   Origin: https://github.com/martinblech/xmltodict/blob/master/xmltodict.py
-* ``zeros.py`` - Modified copy of the file from ``scipy.optimize``,
-  used by the TS map computation code.
 * ``skimage.py`` - utility functions copied from scikit-image
   They have the same BSD license as we do.
+* ``testipynb.py`` is a modification of copy from Github on 2018-09-06
+  Origin: https://github.com/opengeophysics/testipynb/blob/master/testipynb/testipynb.py
+  See also: https://github.com/opengeophysics/testipynb
+  MIT license.
 """

--- a/gammapy/extern/testipynb.py
+++ b/gammapy/extern/testipynb.py
@@ -1,0 +1,222 @@
+import unittest
+import sys
+import os
+import pprint
+import nbformat
+from nbconvert.preprocessors import (
+    ClearOutputPreprocessor, ExecutePreprocessor
+)
+from nbconvert.preprocessors.execute import CellExecutionError
+import properties
+
+
+__all__ = ['TestNotebooks']
+
+
+def get_test(nbname, nbpath, timeout=600):
+    """
+    construct a test method based on on the notebook name, path, and
+    nbconvert Preprocessor options
+
+    ** Required Inputs **
+    :param str nbname: name of the notebook (without the file extension)
+    :param str nbpath: full filepath to the notebook including the '.ipynb'
+                       file extension
+
+    ** Optional Inputs **
+    :param int timeout: preprocessor timeout
+
+    ** Returns **
+    :returns: test_func a function for testing the notebook using nbconvert
+    """
+
+    # use nbconvert to execute the notebook
+    def test_func(self):
+        cwd = os.getcwd()
+        passing = True
+        print(
+            "\n---------------------"
+            " Testing {0}.ipynb "
+            "---------------------".format(nbname)
+        )
+
+        if (
+            (nbname in self.ignore) or
+            (nbname in self.py2_ignore and sys.version_info[0] == 2)
+        ):
+            print(" Skipping {}".format(nbname))
+            return
+
+        run_path = os.path.sep.join(nbpath.split(os.path.sep)[:-1])
+        os.chdir(run_path)
+        ep = ClearOutputPreprocessor(
+            resources={'metadata': {'path': run_path}}
+        )
+
+        with open(nbpath) as f:
+            nb = nbformat.read(f, as_version=4)
+
+            ep.preprocess(nb, {})
+
+            ex = ExecutePreprocessor(
+                timeout=timeout,
+                kernel_name='python{}'.format(sys.version_info[0]),
+                allow_errors=True,
+                resources={'metadata': {'path': run_path}}
+            )
+
+            out = ex.preprocess(nb, {})
+            os.chdir(cwd)
+
+            for cell in out[0]['cells']:
+                if 'outputs' in cell.keys():
+                    for output in cell['outputs']:
+                        if output['output_type'] == 'error':
+                            passing = False
+
+                            err_msg = []
+                            for o in output['traceback']:
+                                err_msg += ["{}".format(o)]
+                            err_msg = "\n".join(err_msg)
+
+                            msg = """
+\n ... {} FAILED \n
+{} in cell [{}] \n-----------\n{}\n-----------\n
+                            """.format(
+                                nbname, output['ename'],
+                                cell['execution_count'], cell['source'],
+                            )
+
+                            traceback = """
+----------------- >> begin Traceback << ----------------- \n
+{}\n
+\n----------------- >> end Traceback << -----------------\n
+                            """.format(err_msg)
+
+                            print(u"{}".format(msg + traceback))
+
+                            assert passing, msg
+
+            print("   ... {0} Passed \n".format(nbname))
+
+    return test_func
+
+
+class TestNotebooks(properties.HasProperties, unittest.TestCase):
+
+    _name = properties.String(
+        "test name",
+        default = "NbTestCase"
+    )
+
+    directory = properties.String(
+        "directory where the notebooks are stored",
+        required=True,
+        default='.'
+    )
+
+    ignore = properties.List(
+        "list of notebooks to ignore when testing",
+        properties.String("file to ignore when testing"),
+        default=[]
+    )
+
+    py2_ignore = properties.List(
+        "list of notebook names to ignore if testing on python 2",
+        properties.String("file to ignore in python 2"),
+        default=[]
+    )
+
+    timeout = properties.Integer(
+        "timeout length for the execution of the notebook",
+        default=600,
+        min=0
+    )
+
+    _nbpaths = properties.List(
+        "paths to all of the notebooks",
+        properties.String("path to notebook")
+    )
+
+    _nbnames = properties.List(
+        "names of all of the notebooks without the '.ipynb' file extension",
+        properties.String("name of notebook")
+    )
+
+    @properties.validator('directory')
+    def _use_abspath(self, change):
+        change['value'] = os.path.abspath(change['value'])
+
+    def __init__(self, **kwargs):
+        super(TestNotebooks, self).__init__(**kwargs)
+        nbpaths = []  # list of notebooks, with file paths
+        nbnames = []  # list of notebook names (for making the tests)
+
+        # walk the test directory and find all notebooks
+        for dirname, dirnames, filenames in os.walk(self.directory):
+            for filename in filenames:
+                if (
+                    filename.endswith(".ipynb") and not
+                    filename.endswith("-checkpoint.ipynb")
+                ):
+                    # get abspath of notebook
+                    nbpaths.append(
+                        dirname + os.path.sep + filename
+                    )
+                    # strip off the file extension
+                    nbnames.append("".join(filename[:-6]))
+        self._nbpaths = nbpaths
+        self._nbnames = nbnames
+
+    @property
+    def test_dict(self):
+        """
+        dictionary of the name of the test (keys) and test functions (values)
+        built based upon the directory provided
+        """
+        if getattr(self, '_test_dict', None) is None:
+            tests = dict()
+
+            # build test for each notebook
+            for nb, nbpath in zip(self._nbnames, self._nbpaths):
+                tests["test_"+nb] = get_test(nb, nbpath, timeout=self.timeout)
+            self._test_dict = tests
+        return self._test_dict
+
+    def get_tests(self, obj=None):
+        """
+        Create a unittest.TestCase object to attach the unit tests to.
+        """
+        # create class to unit test notebooks
+        if obj is None:
+            obj = "{}".format(self._name)
+            obj = type(obj, (unittest.TestCase,), self.test_dict)
+        else:
+            for key, val in self.test_dict:
+                setattr(obj, key, val)
+        obj.ignore = self.ignore
+        obj.py2_ignore = self.py2_ignore
+        return obj
+
+
+    def run_tests(self):
+        """
+        Run the unit-tests. Returns :code:`True` if all tests were successful
+        and code`False` if there was a failure.
+
+        .. code:: python
+
+            import nbtest
+            test = nbtest.TestNotebooks(directory='./notebooks')
+            passed = test.run_tests()
+            assert(passed)
+
+        """
+        NbTestCase = self.get_tests()
+        tests = unittest.TestSuite(map(NbTestCase, self.test_dict.keys()))
+        result = unittest.TestResult()
+        testRunner = unittest.TextTestRunner()
+        result = testRunner.run(tests)
+        return result.wasSuccessful()
+
+

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -4,12 +4,12 @@ Test if IPython notebooks work.
 """
 import os
 import sys
-import testipynb
 import unittest
 import logging
 from pkg_resources import working_set
 from pprint import pprint
 from gammapy.extern.pathlib import Path
+from gammapy.extern import testipynb
 import yaml
 
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This PR bundles `testipynb` - used in notebooks tests https://github.com/gammapy/gammapy/pull/1365 - as a single script in `gammapy/extern` folder, as it is the case for other code used in the `gammapy` project. It avoids to have `testipynb` as a dependency requirement and provides us with the flexibility to modify the code to our specific needs.

This PR also provides a slightly modified version of `testipynb`:
- the code has been refactored and cleaned
- the conversion of notebooks is done via `subprocess` call
- the scan of the folder provided for test is done in a non-recursive manner
 