### PR TITLE
 gammapy jupyter CLI to perform global actions on notebooks 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima regions reproject pandoc ipython iminuit'
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython nbstripout'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
         - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme properties black'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme properties black'
+        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme black'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ env:
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima regions reproject pandoc ipython iminuit'
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython nbstripout'
 
-        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme testipynb'
+        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme properties black'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='nbsphinx==0.2.17 sphinx-click sphinx_rtd_theme black'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme testipynb'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/black_notebooks.py
+++ b/black_notebooks.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 def comment_magics(input):
-    """Coment magic commands."""
+    """Comment magic commands."""
     lines = input.splitlines(True)
     output = ""
     for line in lines:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -37,10 +37,10 @@ dependencies:
   - pandoc==2.1.3
   - pylint
   - flake8
+  - nbstripout
   - pip:
     - sphinx-rtd-theme==0.3
     - nbsphinx==0.2.17
     - sphinx-click
     - pydocstyle
     - black
-    - testipynb

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,7 +39,8 @@ dependencies:
   - flake8
   - pip:
     - sphinx-rtd-theme==0.3
-    - nbsphinx==0.2.17
+    - nbsphinx
     - sphinx-click
     - pydocstyle
     - black
+    - testipynb

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -37,7 +37,6 @@ dependencies:
   - pandoc==2.1.3
   - pylint
   - flake8
-  - nbstripout
   - pip:
     - sphinx-rtd-theme==0.3
     - nbsphinx==0.2.17

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -68,7 +68,7 @@ def cli_jupyter_stripout(ctx):
     for notebook in nblist:
 
         try:
-            subprocess.call(f'nbstripout {notebook}', shell=True)
+            subprocess.call("nbstripout '{}'".format(notebook), shell=True)
             print('Jupyter notebook {} stripped out.'.format(str(notebook)))
         except Exception as ex:
             log.error('Error stripping file {}'.format(str(notebook)))
@@ -87,10 +87,10 @@ def cli_jupyter_execute(ctx):
         try:
             t = time.time()
             subprocess.call(
-                f"jupyter nbconvert --allow-errors --ExecutePreprocessor.timeout=None --ExecutePreprocessor.kernel_name=python3 --to notebook --execute '{notebook}' --inplace",
+                "jupyter nbconvert --allow-errors --ExecutePreprocessor.timeout=None --ExecutePreprocessor.kernel_name=python3 --to notebook --execute '{}'.format(notebook) --inplace",
                 shell=True)
             t = (time.time() - t) / 60
-            print(f'Executing duration: {t:.2f} mn')
+            print('Executing duration: {:.2f} mn'.format(t))
         except Exception as ex:
             log.error('Error executing file {}'.format(str(notebook)))
             log.error(ex)

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -65,8 +65,28 @@ def cli_jupyter_stripout(ctx):
     print('Jupyter notebook {} stripped out.'.format(str(jupyterfile)))
 
 
+@click.command(name='execute')
+@click.pass_context
+def cli_jupyter_execute(ctx):
+    """Execute jupyter notebook."""
+
+    jupyterfile = Path(ctx.obj['file'])
+
+    try:
+        subprocess.call(
+            f'jupyter nbconvert --ExecutePreprocessor.timeout=None --to notebook --execute {jupyterfile} --output {jupyterfile}',
+            shell=True)
+    except Exception as ex:
+        log.error('Error executing file {}'.format(str(jupyterfile)))
+        log.error(ex)
+        sys.exit()
+
+    # inform
+    print('Jupyter notebook {} executed.'.format(str(jupyterfile)))
+
+
 def comment_magics(input):
-    """Coment magic commands when formatting cells."""
+    """Comment magic commands when formatting cells."""
 
     lines = input.splitlines(True)
     output = ""

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -6,6 +6,7 @@ from black import format_str
 import click
 import logging
 import nbformat
+import subprocess
 import sys
 from ..extern.pathlib import Path
 
@@ -15,7 +16,7 @@ log = logging.getLogger(__name__)
 @click.command(name='black')
 @click.pass_context
 def cli_jupyter_black(ctx):
-    """Format notebook cells with black."""
+    """Format cells with black."""
 
     jupyterfile = Path(ctx.obj['file'])
 
@@ -44,6 +45,24 @@ def cli_jupyter_black(ctx):
 
     # inform
     print('Jupyter notebook {} painted in black.'.format(str(jupyterfile)))
+
+
+@click.command(name='stripout')
+@click.pass_context
+def cli_jupyter_stripout(ctx):
+    """Strip output cells."""
+
+    jupyterfile = Path(ctx.obj['file'])
+
+    try:
+        subprocess.call(f'nbstripout {jupyterfile}', shell=True)
+    except Exception as ex:
+        log.error('Error stripping file {}'.format(str(jupyterfile)))
+        log.error(ex)
+        sys.exit()
+
+    # inform
+    print('Jupyter notebook {} stripped out.'.format(str(jupyterfile)))
 
 
 def comment_magics(input):

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -35,9 +35,14 @@ def cli_jupyter_black(ctx):
         fmt = nb.cells[cellnumber]['source']
         if nb.cells[cellnumber]['cell_type'] == 'code':
             try:
+                semicolon = 0
                 fmt = comment_magics(fmt)
+                if fmt.endswith(';'):
+                    semicolon = 1
                 fmt = format_str(src_contents=fmt,
                                  line_length=79).rstrip()
+                if semicolon:
+                    fmt += ';'
             except Exception as ex:
                 logging.info(ex)
             fmt = fmt.replace("###-MAGIC COMMAND-", "")

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -1,0 +1,62 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Command line tool to perform devel management actions on jupyter notebooks."""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+from black import format_str
+import click
+import logging
+import nbformat
+import sys
+from ..extern.pathlib import Path
+
+log = logging.getLogger(__name__)
+
+
+@click.command(name='black')
+@click.pass_context
+def cli_jupyter_black(ctx):
+    """Format notebook cells with black."""
+
+    jupyterfile = Path(ctx.obj['file'])
+
+    try:
+        nb = nbformat.read(str(jupyterfile), as_version=nbformat.NO_CONVERT)
+    except Exception as ex:
+        log.error('Error parsing file {}'.format(str(jupyterfile)))
+        log.error(ex)
+        sys.exit()
+
+    # paint cells in black
+    for cellnumber, cell in enumerate(nb.cells):
+        fmt = nb.cells[cellnumber]['source']
+        if nb.cells[cellnumber]['cell_type'] == 'code':
+            try:
+                fmt = comment_magics(fmt)
+                fmt = format_str(src_contents=fmt,
+                                 line_length=79).rstrip()
+            except Exception as ex:
+                logging.info(ex)
+            fmt = fmt.replace("###-MAGIC COMMAND-", "")
+        nb.cells[cellnumber]['source'] = fmt
+
+    # write formatted notebook
+    nbformat.write(nb, str(jupyterfile))
+
+    # inform
+    print('Jupyter notebook {} painted in black.'.format(str(jupyterfile)))
+
+
+def comment_magics(input):
+    """Coment magic commands when formatting cells."""
+
+    lines = input.splitlines(True)
+    output = ""
+    for line in lines:
+        new_line = ""
+        if line.startswith("%") or line.startswith("!"):
+            new_line = new_line + "###-MAGIC COMMAND-" + line
+        if new_line:
+            output = output + new_line
+        else:
+            output = output + line
+    return output

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -1,132 +1,25 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Command line tool to perform devel management actions on jupyter notebooks."""
+"""Command line tool to perform actions on jupyter notebooks."""
 
 from __future__ import absolute_import, division, print_function, unicode_literals
-from black import format_str
 import click
 import logging
-import nbformat
 import subprocess
 import time
-from ..extern.pathlib import Path
 
 log = logging.getLogger(__name__)
-
-
-@click.command(name='black')
-@click.pass_context
-def cli_jupyter_black(ctx):
-    """Format code cells with black."""
-
-    for path in build_nblist(ctx):
-        rawnb = read_notebook(path)
-
-        for cell in rawnb.cells:
-            fmt = cell['source']
-            if cell['cell_type'] == 'code':
-                try:
-                    fmt = '\n'.join(tag_magics(fmt))
-                    has_semicolon = fmt.endswith(';')
-                    fmt = format_str(src_contents=fmt,
-                                     line_length=79).rstrip()
-                    if has_semicolon:
-                        fmt += ';'
-                except Exception as ex:
-                    logging.info(ex)
-                fmt = fmt.replace("###-MAGIC COMMAND-", "")
-            cell['source'] = fmt
-
-        if rawnb:
-            nbformat.write(rawnb, str(path))
-            log.info('Jupyter notebook {} painted in black.'.format(str(path)))
-
-
-@click.command(name='stripout')
-@click.pass_context
-def cli_jupyter_stripout(ctx):
-    """Strip output cells."""
-
-    for path in build_nblist(ctx):
-        rawnb = read_notebook(path)
-
-        for cell in rawnb.cells:
-            if cell['cell_type'] == 'code':
-                cell['outputs'] = []
-
-        if rawnb:
-            nbformat.write(rawnb, str(path))
-            log.info('Jupyter notebook {} output stripped.'.format(str(path)))
 
 
 @click.command(name='execute')
 @click.pass_context
 def cli_jupyter_execute(ctx):
-    """Execute jupyter notebook."""
+    """Execute Jupyter notebooks."""
 
-    for path in build_nblist(ctx):
+    for path in ctx.obj['paths']:
         run_notebook(path)
 
 
-@click.command(name='test')
-@click.pass_context
-def cli_jupyter_test(ctx):
-    """Check if Jupyter notebook is broken."""
-
-    for path in build_nblist(ctx):
-        run_notebook(path)
-        rawnb = read_notebook(path)
-
-        if rawnb:
-            report = ""
-            passed = True
-            log.info("   ... Testing {}".format(str(path)))
-            for cell in rawnb.cells:
-                if 'outputs' in cell.keys():
-                    for output in cell['outputs']:
-                        if output['output_type'] == 'error':
-                            passed = False
-                            traceitems = ["--TRACEBACK: "]
-                            for o in output['traceback']:
-                                traceitems.append("{}".format(o))
-                            traceback = "\n".join(traceitems)
-                            infos = "\n\n{} in cell [{}]\n\n" \
-                                    "--SOURCE CODE: \n{}\n\n".format(
-                                        output['ename'],
-                                        cell['execution_count'],
-                                        cell['source']
-                                    )
-                            report = report + infos + traceback
-            if passed:
-                log.info("   ... {} Passed".format(str(path)))
-            else:
-                log.info("   ... {} Failed".format(str(path)))
-                log.info(report)
-
-
-def tag_magics(cellcode):
-    """Comment magic commands when formatting cells."""
-
-    lines = cellcode.splitlines(False)
-    for line in lines:
-        if line.startswith("%") or line.startswith("!"):
-            magic_line = "###-MAGIC COMMAND-" + line
-            yield magic_line
-        else:
-            yield line
-
-
-def build_nblist(ctx):
-    """Fill list of notebooks in a the given folder."""
-
-    if ctx.obj['file']:
-        yield Path(ctx.obj['file'])
-    else:
-        for f in Path(ctx.obj['fold']).iterdir():
-            if f.name.endswith('.ipynb'):
-                yield f
-
-
-def run_notebook(path):
+def run_notebook(path, loglevel=20):
     """Execute a Jupyter notebook."""
 
     try:
@@ -134,24 +27,134 @@ def run_notebook(path):
         subprocess.call(
             "jupyter nbconvert "
             "--allow-errors "
+            "--log-level={} "
             "--ExecutePreprocessor.timeout=None "
             "--ExecutePreprocessor.kernel_name=python3 "
             "--to notebook "
             "--inplace "
-            "--execute '{}'".format(path),
+            "--execute '{}'".format(loglevel, path),
             shell=True)
         t = (time.time() - t) / 60
-        log.info('Executing duration: {:.2f} mn'.format(t))
+        log.info('   ... Executing duration: {:.2f} mn'.format(t))
     except Exception as ex:
         log.error('Error executing file {}'.format(str(path)))
         log.error(ex)
 
 
-def read_notebook(path):
-    """Read a Jupyter notebook raw structure."""
-    try:
-        return nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
-    except Exception as ex:
-        log.error('Error parsing file {}'.format(str(path)))
-        log.error(ex)
-        return
+@click.command(name='stripout')
+@click.pass_context
+def cli_jupyter_stripout(ctx):
+    """Strip output cells."""
+    import nbformat
+
+    for path in ctx.obj['paths']:
+        rawnb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
+
+        for cell in rawnb.cells:
+            if cell['cell_type'] == 'code':
+                cell['outputs'] = []
+
+        nbformat.write(rawnb, str(path))
+        log.info('Jupyter notebook {} stripped out.'.format(str(path)))
+
+
+@click.command(name='black')
+@click.pass_context
+def cli_jupyter_black(ctx):
+    """Format code cells with black."""
+    import nbformat
+
+    for path in ctx.obj['paths']:
+        rawnb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
+        blacknb = BlackNotebook(rawnb)
+        blacknb.blackformat()
+        rawnb = blacknb.rawnb
+        nbformat.write(rawnb, str(path))
+        log.info('Jupyter notebook {} blacked.'.format(str(path)))
+
+
+class BlackNotebook:
+    """Manage the process of black formatting."""
+
+    MAGIC_TAG = "###-MAGIC TAG-"
+
+    def __init__(self, rawnb):
+
+        self.rawnb = rawnb
+
+    def blackformat(self):
+        """Format code cells."""
+        from black import format_str
+
+        for cell in self.rawnb.cells:
+            fmt = cell['source']
+            if cell['cell_type'] == 'code':
+                try:
+                    fmt = '\n'.join(self.tag_magics(fmt))
+                    has_semicolon = fmt.endswith(';')
+                    fmt = format_str(src_contents=fmt,
+                                     line_length=79).rstrip()
+                    if has_semicolon:
+                        fmt += ';'
+                except Exception as ex:
+                    logging.info(ex)
+                fmt = fmt.replace(self.MAGIC_TAG, "")
+            cell['source'] = fmt
+
+    def tag_magics(self, cellcode):
+        """Comment magic commands."""
+
+        lines = cellcode.splitlines(False)
+        for line in lines:
+            if line.startswith("%") or line.startswith("!"):
+                magic_line = self.MAGIC_TAG + line
+                yield magic_line
+            else:
+                yield line
+
+
+@click.command(name='test')
+@click.pass_context
+def cli_jupyter_test(ctx):
+    """Check if Jupyter notebooks are broken."""
+
+    for path in ctx.obj['paths']:
+        test_notebook(path)
+
+
+def test_notebook(path):
+    """Execute and parse a Jupyter notebook exposing broken cells."""
+    import nbformat
+
+    passed = True
+    log.info("   ... TESTING {}".format(str(path)))
+    run_notebook(path, 30)
+    rawnb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
+
+    for cell in rawnb.cells:
+        if 'outputs' in cell.keys():
+            for output in cell['outputs']:
+                if output['output_type'] == 'error':
+                    passed = False
+                    traceitems = ["--TRACEBACK: "]
+                    for o in output['traceback']:
+                        traceitems.append("{}".format(o))
+                    traceback = "\n".join(traceitems)
+                    infos = "\n\n{} in cell [{}]\n\n" \
+                            "--SOURCE CODE: \n{}\n\n".format(
+                                output['ename'],
+                                cell['execution_count'],
+                                cell['source']
+                            )
+                    report = infos + traceback
+                    break
+        if not passed:
+            break
+
+    if passed:
+        log.info("   ... PASSED {}".format(str(path)))
+        return True
+    else:
+        log.info("   ... FAILED {}".format(str(path)))
+        log.info(report)
+        return False

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -22,40 +22,31 @@ log = logging.getLogger(__name__)
 def cli_jupyter_black(ctx):
     """Format code cells with black."""
 
-    nblist = build_nblist(ctx)
-
-    for notebook in nblist:
-
+    for path in build_nblist(ctx):
         try:
-            nb = nbformat.read(str(notebook), as_version=nbformat.NO_CONVERT)
+            nb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
         except Exception as ex:
-            log.error('Error parsing file {}'.format(str(notebook)))
+            log.error('Error parsing file {}'.format(str(path)))
             log.error(ex)
             sys.exit()
 
-        # paint cells in black
-        for cellnumber, cell in enumerate(nb.cells):
-            fmt = nb.cells[cellnumber]['source']
-            if nb.cells[cellnumber]['cell_type'] == 'code':
+        for cell in nb.cells:
+            fmt = cell['source']
+            if cell['cell_type'] == 'code':
                 try:
-                    semicolon = 0
-                    fmt = comment_magics(fmt)
-                    if fmt.endswith(';'):
-                        semicolon = 1
+                    fmt = '\n'.join(tag_magics(fmt))
+                    has_semicolon = fmt.endswith(';')
                     fmt = format_str(src_contents=fmt,
                                      line_length=79).rstrip()
-                    if semicolon:
+                    if has_semicolon:
                         fmt += ';'
                 except Exception as ex:
                     logging.info(ex)
                 fmt = fmt.replace("###-MAGIC COMMAND-", "")
-            nb.cells[cellnumber]['source'] = fmt
+            cell['source'] = fmt
 
-        # write formatted notebook
-        nbformat.write(nb, str(notebook))
-
-        # inform
-        print('Jupyter notebook {} painted in black.'.format(str(notebook)))
+        nbformat.write(nb, str(path))
+        log.info('Jupyter notebook {} painted in black.'.format(str(path)))
 
 
 @click.command(name='stripout')
@@ -63,16 +54,20 @@ def cli_jupyter_black(ctx):
 def cli_jupyter_stripout(ctx):
     """Strip output cells."""
 
-    nblist = build_nblist(ctx)
-
-    for notebook in nblist:
-
+    for path in build_nblist(ctx):
         try:
-            subprocess.call("nbstripout '{}'".format(notebook), shell=True)
-            print('Jupyter notebook {} stripped out.'.format(str(notebook)))
+            nb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
         except Exception as ex:
-            log.error('Error stripping file {}'.format(str(notebook)))
+            log.error('Error parsing file {}'.format(str(path)))
             log.error(ex)
+            sys.exit()
+
+        for cell in nb.cells:
+            if cell['cell_type'] == 'code':
+                cell['outputs'] = []
+
+        nbformat.write(nb, str(path))
+        log.info('Jupyter notebook {} output stripped.'.format(str(path)))
 
 
 @click.command(name='execute')
@@ -80,19 +75,22 @@ def cli_jupyter_stripout(ctx):
 def cli_jupyter_execute(ctx):
     """Execute jupyter notebook."""
 
-    nblist = build_nblist(ctx)
-
-    for notebook in nblist:
-
+    for path in build_nblist(ctx):
         try:
             t = time.time()
             subprocess.call(
-                "jupyter nbconvert --allow-errors --ExecutePreprocessor.timeout=None --ExecutePreprocessor.kernel_name=python3 --to notebook --execute '{}'.format(notebook) --inplace",
+                "jupyter nbconvert "
+                "--allow-errors "
+                "--ExecutePreprocessor.timeout=None "
+                "--ExecutePreprocessor.kernel_name=python3 "
+                "--to notebook "
+                "--inplace "
+                "--execute '{}'".format(path),
                 shell=True)
             t = (time.time() - t) / 60
-            print('Executing duration: {:.2f} mn'.format(t))
+            log.info('Executing duration: {:.2f} mn'.format(t))
         except Exception as ex:
-            log.error('Error executing file {}'.format(str(notebook)))
+            log.error('Error executing file {}'.format(str(path)))
             log.error(ex)
 
 
@@ -101,49 +99,41 @@ def cli_jupyter_execute(ctx):
 def cli_jupyter_test(ctx):
     """Check if jupyter notebook is broken."""
 
-    notebook = Path(ctx.obj['file'])
+    path = Path(ctx.obj['file'])
     folder = Path(ctx.obj['fold'])
     ignorelist = []
 
     if ctx.obj['file']:
-        # ignore all files except jupyterfile
-        for f in notebook.parent.iterdir():
-            if notebook.name != f.name and f.name.endswith('.ipynb'):
+        # ignore all files except --file
+        for f in path.parent.iterdir():
+            if path.name != f.name and f.name.endswith('.ipynb'):
                 nbname = f.name.replace('.ipynb', '')
                 ignorelist.append(nbname)
-        folder = notebook.parent
-
-        print('oups')
+        folder = path.parent
 
     testnb = testipynb.TestNotebooks(
         directory=str(folder), ignore=ignorelist)
     TestCase.assertTrue(testnb, testnb.run_tests())
 
 
-def comment_magics(input):
+def tag_magics(input):
     """Comment magic commands when formatting cells."""
 
-    lines = input.splitlines(True)
-    output = ""
+    lines = input.splitlines(False)
     for line in lines:
-        new_line = ""
         if line.startswith("%") or line.startswith("!"):
-            new_line = new_line + "###-MAGIC COMMAND-" + line
-        if new_line:
-            output = output + new_line
+            magic_line = "###-MAGIC COMMAND-" + line
+            yield magic_line
         else:
-            output = output + line
-    return output
+            yield line
 
 
 def build_nblist(ctx):
     """Fill list of notebooks in a the given folder."""
 
-    nblist = []
     if ctx.obj['file']:
-        nblist.append(Path(ctx.obj['file']))
+        yield Path(ctx.obj['file'])
     else:
         for f in Path(ctx.obj['fold']).iterdir():
             if f.name.endswith('.ipynb'):
-                nblist.append(f)
-    return nblist
+                yield f

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -126,5 +126,8 @@ def add_subcommands():
     from .jupyter import cli_jupyter_execute
     cli_jupyter.add_command(cli_jupyter_execute)
 
+    from .jupyter import cli_jupyter_test
+    cli_jupyter.add_command(cli_jupyter_test)
+
 
 add_subcommands()

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -84,16 +84,23 @@ def cli_download(ctx, folder):
 
 
 @cli.group('jupyter', short_help='Perform actions on notebooks')
-@click.option('--file', prompt='target file',
+@click.option('--file', default='',
               help='Jupyter notebook filename.')
+@click.option('--fold', default='.',
+              help='Local folder with Jupyter notebooks.')
 @click.pass_context
-def cli_jupyter(ctx, file):
+def cli_jupyter(ctx, file, fold):
     """
     Perform a series of actions on Jupyter notebooks.
     """
     ctx.obj = {
         'file': file,
+        'fold': fold,
     }
+
+    if file and fold != '.':
+        print('--file and --fold are exclusive options, only one is allowed.')
+        sys.exit()
 
 
 def add_subcommands():

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -83,6 +83,19 @@ def cli_download(ctx, folder):
     ctx.obj = {"localfolder": folder}
 
 
+@cli.group('jupyter', short_help='Perform actions on notebooks')
+@click.option('--file', prompt='target file',
+              help='Jupyter notebook filename.')
+@click.pass_context
+def cli_jupyter(ctx, file):
+    """
+    Perform a series of actions on Jupyter notebooks.
+    """
+    ctx.obj = {
+        'file': file,
+    }
+
+
 def add_subcommands():
     from .info import cli_info
 
@@ -103,6 +116,9 @@ def add_subcommands():
     from .download import cli_download_datasets
 
     cli_download.add_command(cli_download_datasets)
+
+    from .jupyter import cli_jupyter_black
+    cli_jupyter.add_command(cli_jupyter_black)
 
 
 add_subcommands()

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -120,5 +120,8 @@ def add_subcommands():
     from .jupyter import cli_jupyter_black
     cli_jupyter.add_command(cli_jupyter_black)
 
+    from .jupyter import cli_jupyter_stripout
+    cli_jupyter.add_command(cli_jupyter_stripout)
+
 
 add_subcommands()

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -92,6 +92,20 @@ def cli_download(ctx, folder):
 def cli_jupyter(ctx, file, fold):
     """
     Perform a series of actions on Jupyter notebooks.
+
+    The chosen action is applied for every Jupyter notebook present in the
+    current working directory. Option --file allows to chose a single file,
+    while option --fold allows to choose a different folder to scan. These
+    options are mutually exclusive, only one is allowed.
+
+    \b
+    Examples
+    --------
+    \b
+    $ gammapy jupyter black
+    $ gammapy jupyter --file=notebook.ipynb execute
+    $ gammapy jupyter --fold=myfolder/tutorials test
+    $ gammapy jupyter stripout
     """
     ctx.obj = {
         'file': file,
@@ -99,7 +113,7 @@ def cli_jupyter(ctx, file, fold):
     }
 
     if file and fold != '.':
-        print('--file and --fold are exclusive options, only one is allowed.')
+        print('--file and --fold are mutually exclusive options, only one is allowed.')
         sys.exit()
 
 

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -123,5 +123,8 @@ def add_subcommands():
     from .jupyter import cli_jupyter_stripout
     cli_jupyter.add_command(cli_jupyter_stripout)
 
+    from .jupyter import cli_jupyter_execute
+    cli_jupyter.add_command(cli_jupyter_execute)
+
 
 add_subcommands()


### PR DESCRIPTION
This PR provides a new CLI ` gammapy jupyter` to perform global actions on a list of notebooks present in the current working dir, in a specific folder or for a specific file. The list of actions that provides are: strip output cells, execute, unittest to find broken notebooks and black-format.

<pre>
$ gammapy jupyter 
Usage: gammapy jupyter [OPTIONS] COMMAND [ARGS]...

  Perform a series of actions on Jupyter notebooks.

  The chosen action is applied for every Jupyter notebook present in the
  current working directory. Option --file allows to chose a single file,
  while option --fold allows to choose a different folder to scan. These
  options are mutually exclusive, only one is allowed.

  Examples
  --------
  
  $ gammapy jupyter stripout
  $ gammapy jupyter --src=mynotebooks.ipynb execute
  $ gammapy jupyter --src=myfolder/tutorials test
  $ gammapy jupyter black

Options:
  --src TEXT  Local folder or Jupyter notebook filename.
  -h, --help  Show this message and exit.

Commands:
  black     Format code cells with black.
  execute   Execute Jupyter notebooks.
  stripout  Strip output cells.
  test      Check if Jupyter notebooks are broken.
</pre>



 