### PR TITLE
Showing two decimals in energy

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -961,18 +961,18 @@ class Map(object):
         for axis in self.geom.axes:
             if axis.node_type == "edges":
                 options = [
-                    "{:.0f} - {:.0f} {}".format(val_min, val_max, axis.unit)
+                    "{:.2f} - {:.2f} {}".format(val_min, val_max, axis.unit)
                     for val_min, val_max in zip(axis.edges[:-1], axis.edges[1:])
                 ]
             else:
-                options = ["{:.0f} {}".format(val, axis.unit) for val in axis.center]
+                options = ["{:.2f} {}".format(val, axis.unit) for val in axis.center]
 
             interact_kwargs[axis.name] = SelectionSlider(
                 options=options,
                 description="Select {}:".format(axis.name),
                 continuous_update=False,
                 style={"description_width": "initial"},
-                layout={"width": "36%"},
+                layout={"width": "50%"},
             )
             interact_kwargs[axis.name + "_options"] = fixed(options)
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -961,11 +961,11 @@ class Map(object):
         for axis in self.geom.axes:
             if axis.node_type == "edges":
                 options = [
-                    "{:.2f} - {:.2f} {}".format(val_min, val_max, axis.unit)
+                    "{:.2e} - {:.2e} {}".format(val_min, val_max, axis.unit)
                     for val_min, val_max in zip(axis.edges[:-1], axis.edges[1:])
                 ]
             else:
-                options = ["{:.2f} {}".format(val, axis.unit) for val in axis.center]
+                options = ["{:.2e} {}".format(val, axis.unit) for val in axis.center]
 
             interact_kwargs[axis.name] = SelectionSlider(
                 options=options,


### PR DESCRIPTION
Very simple PR before the release.
With previous version, the energy were shown as 0-0 TeV if less than 1.
Before 
<img width="426" alt="capture d ecran 2018-09-07 a 11 45 42" src="https://user-images.githubusercontent.com/8652898/45211927-dba8a780-b293-11e8-8cf2-f4f5e48004ba.png">
After
<img width="422" alt="capture d ecran 2018-09-07 a 11 45 12" src="https://user-images.githubusercontent.com/8652898/45211928-dba8a780-b293-11e8-8752-85974e4df989.png">

@adonath can you have a quick look at it ? Were there any reason to have no decimals ?