### PR TITLE
Require iminuit 1.3.2

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -30,7 +30,7 @@ dependencies:
   - healpy
   - reproject
   - sherpa
-  - iminuit
+  - iminuit>=1.3.2
   - pytest
   - pytest-cov
   - sphinx

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - reproject==0.4
   - uncertainties==3.0.2
   - naima==0.8.1
-  - iminuit==1.2
+  - iminuit==1.3.2
   - sherpa==4.10
   - healpy==1.11.0
   - matplotlib==2.2.2

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -43,4 +43,6 @@ def test_iminuit():
 
     assert states[1]["has_limits"]
     assert states[1]["lower_limit"] == 4
-    assert states[1]["upper_limit"] is None
+    # The next assert can be added when we no longer test on iminuit 1.2
+    # See https://github.com/gammapy/gammapy/pull/1771
+    # assert states[1]["upper_limit"] is None

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -43,4 +43,4 @@ def test_iminuit():
 
     assert states[1]["has_limits"]
     assert states[1]["lower_limit"] == 4
-    assert states[1]["upper_limit"] == 0
+    assert states[1]["upper_limit"] is None

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
           'reproject',
           'uncertainties>=2.4',
           'naima',
-          'iminuit',
+          'iminuit>=1.3.2',
           'sherpa',
       ],
       plotting=[


### PR DESCRIPTION
This PR fixes the broken iminuit test (#1768) and I'll also update setup.py and the conda env files to list iminuit >= 1.3.2 (#1718) .