### PR TITLE
Rename regions as_patch to as_artist

### DIFF
--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -219,12 +219,12 @@ class ReflectedRegionsFinder(object):
         """
         fig, ax, cbar = self.exclusion_mask.plot(fig=fig, ax=ax, cmap="gray")
         wcs = self.exclusion_mask.geom.wcs
-        on_patch = self.region.to_pixel(wcs=wcs).as_patch(color="red", alpha=0.6)
+        on_patch = self.region.to_pixel(wcs=wcs).as_artist(color="red", alpha=0.6)
         ax.add_patch(on_patch)
 
         for off in self.reflected_regions:
             tmp = off.to_pixel(wcs=wcs)
-            off_patch = tmp.as_patch(color="blue", alpha=0.6)
+            off_patch = tmp.as_artist(color="blue", alpha=0.6)
             ax.add_patch(off_patch)
 
             test_pointing = self.center
@@ -345,7 +345,7 @@ class ReflectedRegionsBackgroundEstimator(object):
         fig, ax, cbar = self.finder.exclusion_mask.plot(fig=fig, ax=ax)
 
         wcs = self.finder.exclusion_mask.geom.wcs
-        on_patch = self.on_region.to_pixel(wcs=wcs).as_patch(color="red")
+        on_patch = self.on_region.to_pixel(wcs=wcs).as_artist(color="red")
         ax.add_patch(on_patch)
 
         result = self.result
@@ -365,7 +365,7 @@ class ReflectedRegionsBackgroundEstimator(object):
 
             off_regions = result[idx_].off_region
             for off in off_regions:
-                off_patch = off.to_pixel(wcs=wcs).as_patch(
+                off_patch = off.to_pixel(wcs=wcs).as_artist(
                     alpha=0.8, color=colors[idx_], label="Obs {}".format(obs.obs_id)
                 )
                 handle = ax.add_patch(off_patch)

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -102,6 +102,9 @@ class TestReflectedRegionBackgroundEstimator:
 
     @requires_dependency("matplotlib")
     def test_plot(self):
+        # The following line can be removed once we drop support for regions 0.2
+        # See https://github.com/gammapy/gammapy/issues/1758
+        pytest.importorskip("regions", minversion="0.3")
         self.bg_maker.run()
         with mpl_plot_check():
             self.bg_maker.plot()


### PR DESCRIPTION
There will be a change in the upcoming regions 0.3 release, renaming `as_patch` to `as_artist`:
https://github.com/astropy/regions/pull/218

We're calling this once in Gammapy here:
https://github.com/gammapy/gammapy/search?q=as_patch&unscoped_q=as_patch

This is a reminder issue for me to put something in Gammapy that works with the old and new version of regions.