### PR TITLE
MapFit fails with integer mask

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -38,6 +38,9 @@ class MapFit(object):
     def __init__(
         self, model, counts, exposure, background=None, mask=None, psf=None, edisp=None
     ):
+        if mask is not None and mask.data.dtype != np.dtype('bool'):
+            raise ValueError('mask data must have dtype bool')
+
         self.model = model
         self.counts = counts
         self.exposure = exposure


### PR DESCRIPTION
@facero reported that `MapFit` "hangs" in his example. Turns out the cause was that he was passing an integer dtype array as mask, and then this fancy indexing to apply the mask doesn't do at all what we want (basically it was running on no pixels, so the fit was hanging at 100% CPU):

https://github.com/gammapy/gammapy/blob/f6fe37db6aab7969e10c029b29da158bb97b077f/gammapy/cube/fit.py#L91

```
In [17]: np.arange(5)[np.ones(5)]
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-17-f6da791f2d42> in <module>()
----> 1 np.arange(5)[np.ones(5)]

IndexError: arrays used as indices must be of integer (or boolean) type

In [18]: np.arange(5)[np.ones(5, dtype=bool)]
Out[18]: array([0, 1, 2, 3, 4])

In [19]: np.arange(5)[np.ones(5, dtype=int)]
Out[19]: array([1, 1, 1, 1, 1])
```

I briefly discussed offline with @adonath and we think raising a `TypeError` on `MapFit.__init__` if the mask dtype isn't bool would be OK. I plan to put that check in later today.

Of course there's other possible solutions, e.g. to make a mask dtype cast and Map object copy on init, or maybe to rewrite the `self.stat[self.mask.data] ` expression somehow.