### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,11 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
+        # TODO: update the next build from Python 3.6 to 3.7
+        # when this CI-helpers issue is resolved:
+        # https://github.com/astropy/ci-helpers/issues/301#issuecomment-419813895
         - os: linux
-          env: PYTHON_VERSION=3.7 SETUP_CMD='build_docs -w'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
 
         # Test conda build (which runs a bunch of useful tests after building the package)

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ env:
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
     matrix:
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
 
@@ -69,7 +68,7 @@ matrix:
 
         # The main build that's used for coverage measurement
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='test -V --coverage'
+          env: PYTHON_VERSION=3.7 SETUP_CMD='test -V --coverage'
 
         # Run tests without optional dependencies
         # TODO: remove pyyaml here again as soon as this is resolved
@@ -82,7 +81,7 @@ matrix:
 
         # Run tests without GAMMAPY_EXTRA available
         - os: linux
-          env: FETCH_GAMMAPY_EXTRA=false PYTHON_VERSION=3.6 SETUP_CMD='test -V'
+          env: FETCH_GAMMAPY_EXTRA=false PYTHON_VERSION=3.7 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
         # Build docs
@@ -90,13 +89,13 @@ matrix:
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='build_docs -w'
+          env: PYTHON_VERSION=3.7 SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
 
         # Test conda build (which runs a bunch of useful tests after building the package)
         # See https://conda.io/docs/bdist_conda.html
         - os: linux
-          env: PYTHON_VERSION=3.6 MAIN_CMD='make' SETUP_CMD='conda'
+          env: PYTHON_VERSION=3.7 MAIN_CMD='make' SETUP_CMD='conda'
                PACKAGING_TEST=true
 
         # Older Python versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,10 @@ environment:
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 
+      - PYTHON_VERSION: "3.7"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
+
 
 platform:
     -x64

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import sys
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -84,6 +85,12 @@ def test_lightcurve_properties_flux(lc):
 # TODO: extend these tests to cover other time scales.
 # In those cases, CSV should not round-trip because there
 # is no header info in CSV to store the time scale!
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 7),
+    reason="https://github.com/astropy/astropy/issues/7744#issuecomment-419813519",
+)
 @requires_dependency("yaml")
 @pytest.mark.parametrize("format", ["fits", "ascii.ecsv", "ascii.csv"])
 def test_lightcurve_read_write(tmpdir, lc, format):


### PR DESCRIPTION
Python 3.7 was released 2018-06-28 and now people will start to use it (e.g. I got it today by default when making a conda env).

I'll try to add a CI build for Python 3.7, to see if we can support it for v0.8 already.

Probably in Gammapy there's zero or very few changes needed, because Python 3.7 should be compatible with previous Python 3 releases, this is mostly a CI config / setup task.

Numpy and Astropy still support it in the latest stable releases, for regions it's being added at the moment (see https://github.com/astropy/regions/pull/208), for iminuit see https://github.com/iminuit/iminuit/issues/270 .