### PR TITLE
test_notebooks.py uses gammapy.scripts.jupyter.test_notebook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython'
 
-        - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme testipynb'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -43,4 +43,3 @@ dependencies:
     - sphinx-click
     - pydocstyle
     - black
-    - testipynb


### PR DESCRIPTION
This PR removes `testipynb` dependency in `test_notebooks.py` and uses our own function to test notebooks - recently implemented in `gammapy jupyter` CLI in https://github.com/gammapy/gammapy/pull/1766