### PR TITLE
Change HDUIndexTable.get_hdu to leave FITS file open

### DIFF
--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -61,8 +61,10 @@ class HDULocation(object):
     def get_hdu(self):
         """Get HDU."""
         filename = str(self.path(abs_path=True))
-        with fits.open(filename, memmap=False) as hdu_list:
-            return hdu_list[self.hdu_name]
+        # Here we're intentionally not calling `with fits.open`
+        # because we don't want the file to remain open.
+        hdu_list = fits.open(filename, memmap=False)
+        return hdu_list[self.hdu_name]
 
     def load(self):
         """Load HDU as appropriate class.

--- a/gammapy/data/tests/test_hdu_index_table.py
+++ b/gammapy/data/tests/test_hdu_index_table.py
@@ -61,6 +61,10 @@ def test_hdu_index_table_hd_hap():
     hdu = location.get_hdu()
     assert hdu.name == "EVENTS"
 
+    # The next line is to check if the HDU is still accessible
+    # See https://github.com/gammapy/gammapy/issues/1775
+    assert hdu.filebytes() == 285120
+
     assert (
         str(location.path(abs_path=False)) == "data/hess_dl3_dr1_obs_id_023523.fits.gz"
     )


### PR DESCRIPTION
I think this change was a mistake, I'll revert it now.

https://github.com/gammapy/gammapy/commit/e1a8c458ce49d85d2712c3bb581a95e5128cb5e4#diff-184c9997306579e0442e4589dcb10a94R62

The main use case for `get_hdu` is to be able to access the HDU after the call, and currently this is not the case:

```
$ ./make.py release-store
INFO:__main__:CLI: release-store
INFO:hess_dl3_dr1.data_release:Executing `release-store`
INFO:hess_dl3_dr1.utils:Using HESS_DL3_DR1_HESS_DATA_DIR /Users/deil/todo_sort/work/_Data/hess/fits/hap-hd/fits_prod_dr1_v0.6_update2
INFO:hess_dl3_dr1.data_release:indir: /Users/deil/todo_sort/work/_Data/hess/fits/hap-hd/fits_prod_dr1_v0.6_update2
INFO:hess_dl3_dr1.data_release:outdir release_store
INFO:hess_dl3_dr1.data_release:Reformat and write new obs index file
INFO:hess_dl3_dr1.data_release:Writing release_store/obs-index.fits.gz
INFO:hess_dl3_dr1.data_release:Reformat and write new hdu index file
Traceback (most recent call last):
  File "./make.py", line 261, in <module>
    cli()
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "./make.py", line 68, in cli_release_store
    make_release_store()
  File "/Users/deil/work/code/HESS-DL3-DR1/hess_dl3_dr1/data_release.py", line 39, in make_release_store
    hdu = make_hdu_table(ds, obs_ids)
  File "/Users/deil/work/code/HESS-DL3-DR1/hess_dl3_dr1/data_release.py", line 185, in make_hdu_table
    ('SIZE', hdu.filebytes())
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/astropy/io/fits/hdu/base.py", line 922, in filebytes
    return self._writeheader(f)[1] + self._writedata(f)[1]
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/astropy/io/fits/hdu/base.py", line 592, in _writedata
    size += self._writedata_direct_copy(fileobj)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/astropy/io/fits/hdu/base.py", line 624, in _writedata_direct_copy
    raw = self._get_raw_data(self._data_size, 'ubyte', self._data_offset)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/astropy/io/fits/hdu/base.py", line 475, in _get_raw_data
    return self._file.readarray(offset=offset, dtype=code, shape=shape)
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/site-packages/astropy/io/fits/file.py", line 286, in readarray
    filepos = self._file.tell()
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/gzip.py", line 367, in seek
    self._check_not_closed()
  File "/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.6/_compression.py", line 14, in _check_not_closed
    raise ValueError("I/O operation on closed file")
ValueError: I/O operation on closed file
```