### PR TITLE
Fix map docs examples

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -538,17 +538,19 @@ This example shows how to fill a counts cube from an FT1 file:
 
 .. code:: python
 
-    from astropy.io import fits
+    from gammapy.data import EventList
     from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
 
-    h = fits.open('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
-    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+
+    energy_axis = MapAxis.from_bounds(10., 2E3, 12, interp='log', name='energy', unit='GeV')
     m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
                         coordsys='CEL', axes=[energy_axis])
-    m.fill_by_coord((h['EVENTS'].data.field('RA'),
-                    h['EVENTS'].data.field('DEC'),
-                    h['EVENTS'].data.field('ENERGY')))
+
+    events = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
+
+    m.fill_by_coord({'skycoord': events.radec, 'energy': events.energy})
     m.write('ccube.fits', conv='fgst-ccube')
+
 
 Generating a Cutout of a Model Cube
 -----------------------------------
@@ -561,10 +563,10 @@ using the `~Map.reproject` method:
     from gammapy.maps import WcsGeom, WcsNDMap
 
     m = WcsNDMap.read('$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits')
-    geom = WcsGeom(binsz=0.125, skydir=(0, 0), coordsys='GAL', proj='AIT')
+
+    geom = WcsGeom.create(binsz=0.1, skydir=(0, 0), coordsys='GAL', proj='AIT', width=(3, 3))
     m_proj = m.reproject(geom)
     m_proj.write('cutout.fits', conv='fgst-template')
-
 
 Using `gammapy.maps`
 ====================

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -77,7 +77,7 @@ passing a list of `~MapAxis` objects for non-spatial dimensions with the
     from astropy.coordinates import SkyCoord
 
     position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
-    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', name='energy', unit='GeV')
 
     # Create a WCS Map
     m_wcs = Map.create(binsz=0.1, map_type='wcs', skydir=position, width=10.0,
@@ -100,7 +100,7 @@ cube with a pixel size proportional to the Fermi-LAT PSF:
     from astropy.coordinates import SkyCoord
 
     position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
-    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', name='energy', unit='GeV')
 
     binsz = np.sqrt((3.0*(energy_axis.center/100.)**-0.8)**2 + 0.1**2)
 
@@ -133,8 +133,8 @@ the use of `~Map.slice_by_idx()` on a map with a time and energy axes:
     from astropy.coordinates import SkyCoord
 
     position = SkyCoord(0.0, 5.0, frame='galactic', unit='deg')
-    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', unit='GeV')
-    time_axis = MapAxis.from_bounds(0., 12, 12, interp='lin', unit='h')
+    energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log', unit='GeV', name='energy')
+    time_axis = MapAxis.from_bounds(0., 12, 12, interp='lin', unit='h', name='time')
 
     # Create a WCS Map
     m_wcs = Map.create(binsz=0.02, map_type='wcs', skydir=position, width=10.0,
@@ -242,8 +242,8 @@ following demonstrates how one can set pixel values:
 
     m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-    m.set_by_coord( ([-0.05,-0.05],[0.05,0.05]), [0.5, 1.5] )
-    m.fill_by_coord( ([-0.05,-0.05],[0.05,0.05]), weights=[0.5, 1.5] )
+    m.set_by_coord(([-0.05, -0.05], [0.05, 0.05]), [0.5, 1.5])
+    m.fill_by_coord( ([-0.05, -0.05], [0.05, 0.05]), weights=[0.5, 1.5])
 
 Interface with `~MapCoord` and `~astropy.coordinates.SkyCoord`
 --------------------------------------------------------------
@@ -270,8 +270,8 @@ transformed to match the coordinate system of the map.
     m = Map.create(binsz=0.1, map_type='wcs', width=10.0,
                   coordsys='GAL', axes=[energy_axis])
 
-    m.set_by_coord( (skycoord, energy), [0.5, 1.5] )
-    m.get_by_coord( (skycoord, energy) )
+    m.set_by_coord((skycoord, energy), [0.5, 1.5])
+    m.get_by_coord((skycoord, energy))
 
 A `~MapCoord` or `dict` argument can be used to interact with a map object
 without reference to the axis ordering of the map geometry:
@@ -279,10 +279,10 @@ without reference to the axis ordering of the map geometry:
 .. code:: python
 
     coord = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
-    m.set_by_coord( coord, [0.5, 1.5] )
-    m.get_by_coord( coord, )
-    m.set_by_coord( dict(lon=lon, lat=lat, energy=energy), [0.5, 1.5] )
-    m.get_by_coord( dict(lon=lon, lat=lat, energy=energy) )
+    m.set_by_coord(coord, [0.5, 1.5])
+    m.get_by_coord(coord)
+    m.set_by_coord(dict(lon=lon, lat=lat, energy=energy), [0.5, 1.5])
+    m.get_by_coord(dict(lon=lon, lat=lat, energy=energy))
 
 However when using the named axis interface the axis name string (e.g. as given
 by `MapAxis.name`) must match the name given in the method argument.  The two
@@ -381,8 +381,8 @@ coordinates is only supported for WCS-based maps.
 
     m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
 
-    m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='linear' )
-    m.interp_by_coord( ([-0.05,-0.05],[0.05,0.05]), interp='cubic' )
+    m.interp_by_coord(([-0.05, -0.05], [0.05, 0.05]), interp='linear')
+    m.interp_by_coord(([-0.05, -0.05], [0.05, 0.05]), interp='cubic')
 
 Projection
 ----------
@@ -397,10 +397,10 @@ of the original map will be copied over to the projected map.
 
     from gammapy.maps import WcsNDMap, HpxGeom
 
-    m = WcsNDMap.read('gll_iem_v06.fits')
+    m = WcsNDMap.read('$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits')
     geom = HpxGeom.create(nside=8, coordsys='GAL')
     # Convert LAT standard IEM to HPX (nside=8)
-    m_proj = m.project(geom)
+    m_proj = m.reproject(geom)
     m_proj.write('gll_iem_v06_hpx_nside8.fits')
 
 .. _mapiter:
@@ -524,8 +524,8 @@ further tweak/customize the image.
 
     m = Map.create(binsz=0.1, map_type='wcs', width=10.0)
     fill_poisson(m, mu=1.0, random_state=0)
-    fig, ax, im = m.plot(cmap='magma')
-    plt.colorbar(im)
+    m.plot(cmap='magma')
+    plt.show()
 
 
 Examples
@@ -541,7 +541,7 @@ This example shows how to fill a counts cube from an FT1 file:
     from astropy.io import fits
     from gammapy.maps import WcsGeom, WcsNDMap, MapAxis
 
-    h = fits.open('ft1.fits')
+    h = fits.open('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
     energy_axis = MapAxis.from_bounds(100., 1E5, 12, interp='log')
     m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
                         coordsys='CEL', axes=[energy_axis])
@@ -560,8 +560,8 @@ using the `~Map.reproject` method:
 
     from gammapy.maps import WcsGeom, WcsNDMap
 
-    m = WcsNDMap.read('gll_iem_v06.fits')
-    geom = WcsGeom(binsz=0.125, skydir=(45.0,30.0), coordsys='GAL', proj='AIT')
+    m = WcsNDMap.read('$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits')
+    geom = WcsGeom(binsz=0.125, skydir=(0, 0), coordsys='GAL', proj='AIT')
     m_proj = m.reproject(geom)
     m_proj.write('cutout.fits', conv='fgst-template')
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -447,7 +447,9 @@ class Map(object):
             geom = geom.copy(axes=axes)
         else:
             axes_eq = geom.ndim == self.geom.ndim
-            axes_eq &= np.all([ax0 == ax1 for ax0, ax1 in zip(geom.axes, self.geom.axes)])
+            axes_eq &= np.all(
+                [ax0 == ax1 for ax0, ax1 in zip(geom.axes, self.geom.axes)]
+            )
 
             if not axes_eq:
                 raise ValueError(

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -442,16 +442,20 @@ class Map(object):
         map : `Map`
             Reprojected map.
         """
-        axes_eq = geom.ndim == self.geom.ndim
-        axes_eq &= np.all([ax0 == ax1 for ax0, ax1 in zip(geom.axes, self.geom.axes)])
+        if geom.is_image:
+            axes = [ax.copy() for ax in self.geom.axes]
+            geom = geom.copy(axes=axes)
+        else:
+            axes_eq = geom.ndim == self.geom.ndim
+            axes_eq &= np.all([ax0 == ax1 for ax0, ax1 in zip(geom.axes, self.geom.axes)])
 
-        if not axes_eq and not geom.is_image:
-            raise ValueError(
-                "Map and target geometry non-spatial axes must match."
-                "Use interp_by_coord to interpolate in non-spatial axes."
-            )
+            if not axes_eq:
+                raise ValueError(
+                    "Map and target geometry non-spatial axes must match."
+                    "Use interp_by_coord to interpolate in non-spatial axes."
+                )
 
-        if geom.projection == "HPX":
+        if geom.is_hpx:
             return self._reproject_to_hpx(geom, mode=mode, order=order)
         else:
             return self._reproject_to_wcs(geom, mode=mode, order=order)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -623,6 +623,9 @@ class MapAxis(object):
         str_ += fmt.format("interp", self._interp)
         return str_
 
+    def copy(self):
+        """Copy `MapAxis` object"""
+        return copy.deepcopy(self)
 
 class MapCoord(object):
     """Represents a sequence of n-dimensional map coordinates.
@@ -891,7 +894,7 @@ class MapCoord(object):
         return self.__class__(data, self.coordsys, self._match_by_name)
 
     def copy(self):
-        """Copy geom object."""
+        """Copy `MapCoord` object."""
         return copy.deepcopy(self)
 
     def __repr__(self):
@@ -1403,6 +1406,17 @@ class MapGeom(object):
 
         return self.__class__(**kwargs)
 
-    def copy(self):
-        """Deep copy."""
-        return copy.deepcopy(self)
+    def copy(self, **kwargs):
+        """Copy `MapGeom` instance and overwrite given attributes.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Keyword arguments to overwrite in the map geometry constructor.
+
+        Returns
+        --------
+        copy : `MapGeom`
+            Copied map geometry.
+        """
+        return self._init_copy(**kwargs)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -627,6 +627,7 @@ class MapAxis(object):
         """Copy `MapAxis` object"""
         return copy.deepcopy(self)
 
+
 class MapCoord(object):
     """Represents a sequence of n-dimensional map coordinates.
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -266,7 +266,7 @@ def test_map_reproject_wcs_to_wcs():
         coordsys="CEL",
     )
     geom_wcs_2 = WcsGeom.create(
-        skydir=(0, 0), npix=(11, 11), binsz=0.1, axes=[axis1, axis2], coordsys="GAL"
+        skydir=(0, 0), npix=(11, 11), binsz=0.1, coordsys="GAL"
     )
 
     spatial_data = np.zeros((11, 11))

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -265,9 +265,7 @@ def test_map_reproject_wcs_to_wcs():
         axes=[axis1, axis2],
         coordsys="CEL",
     )
-    geom_wcs_2 = WcsGeom.create(
-        skydir=(0, 0), npix=(11, 11), binsz=0.1, coordsys="GAL"
-    )
+    geom_wcs_2 = WcsGeom.create(skydir=(0, 0), npix=(11, 11), binsz=0.1, coordsys="GAL")
 
     spatial_data = np.zeros((11, 11))
     energy_data = energy_nodes.reshape(3, 1, 1)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -187,7 +187,9 @@ class WcsGeom(MapGeom):
 
         # By convention CRPIX is indexed from 1
         if crpix is None:
-            self._crpix = tuple(1.0 + (np.array(self._npix) - 1.0) / 2.)
+            crpix = tuple(1.0 + (np.array(self._npix) - 1.0) / 2.)
+
+        self._crpix = crpix
 
     @property
     def data_shape(self):


### PR DESCRIPTION
This PR fixes the examples in `docs/maps/index.rst` and fixes a bug in `Map.reproject()`, when reprojecting ND maps onto 2D image geometries, which was supposed to work, but didn't.