### PR TITLE
Propagate opts_minuit in fitting functions

### DIFF
--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -53,11 +53,11 @@ class SpectrumAnalysisIACT(object):
         ss += "\n{}".format(self.config)
         return ss
 
-    def run(self):
+    def run(self, opts_minuit=None):
         """Run all steps."""
         log.info("Running {}".format(self.__class__.__name__))
         self.run_extraction()
-        self.run_fit()
+        self.run_fit(opts_minuit)
 
     def run_extraction(self):
         """Run all steps for the spectrum extraction."""
@@ -74,12 +74,12 @@ class SpectrumAnalysisIACT(object):
 
         self.extraction.run()
 
-    def run_fit(self):
+    def run_fit(self, opts_minuit=None):
         """Run all step for the spectrum fit."""
         self.fit = SpectrumFit(
             obs_list=self.extraction.observations, **self.config["fit"]
         )
-        self.fit.run(outdir=self.config["outdir"])
+        self.fit.run(outdir=self.config["outdir"], opts_minuit=opts_minuit)
 
         # TODO: Don't stack again if SpectrumFit has already done the stacking
         stacked_obs = self.extraction.observations.stack()

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -413,7 +413,7 @@ class SpectrumFit(object):
         # TODO: add this back once fitting backends support optimisation
         # and error estimation as separate steps
 
-    def run(self, outdir=None):
+    def run(self, outdir=None, opts_minuit=None):
         """Run all steps and write result to disk.
 
         Parameters
@@ -423,7 +423,7 @@ class SpectrumFit(object):
         """
         log.info("Running {}".format(self))
 
-        self.fit()
+        self.fit(opts_minuit)
         self.est_errors()
 
         if outdir is not None:


### PR DESCRIPTION
This PR enables passing options `opts_minuit` for fitting functions where this feature is missing. The main purpose is to provide the user with the possibility to display the fitting results table (see http://docs.gammapy.org/dev/notebooks/spectrum_pipe.html), keeping this display hidden by default.

Following step will be to slightly modify the notebooks using this feature in `gammapy-extra`

