### PR TITLE
Fix opts_minuit handling in fit_minuit()

### DIFF
--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -921,6 +921,8 @@ class FluxPointFitter(object):
         Select optimizer
     ul_handling : {'ignore'}
         How to handle flux point upper limits in the fit
+    opts_minuit : dict
+        Options passed to the `Minuit` fit object.
 
     Examples
     --------
@@ -976,6 +978,8 @@ class FluxPointFitter(object):
 
         Parameters
         ----------
+        data : list of `~gammapy.spectrum.FluxPoints`
+            Flux points.
         model : `~gammapy.spectrum.models.SpectralModel`
             Spectral model (with fit start parameters)
 


### PR DESCRIPTION
This PR fixes the handling of the `opts_minuit` argument in `fit_minuit()`, because in the initial implementation it was modified internally by `fit_minuit()`. 