### PR TITLE
Add option for downloading the whole tutorials pack

### DIFF
--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -4,18 +4,12 @@ GitHub REST API is used to scan the tree-folder strucutre and get commmit hash.
 https://developer.github.com/v3/
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-import logging
 import click
-import sys
-import json
-# from .. import version
+import logging
 from ..extern.pathlib import Path
-from ..extern.six.moves.urllib.request import urlretrieve, urlopen
+from .downloadclass import DownloadProcess
 
 log = logging.getLogger(__name__)
-
-apigitUrl = 'https://api.github.com/repos/gammapy/'
-rawgitUrl = 'https://raw.githubusercontent.com/gammapy/'
 
 
 @click.command(name="notebooks")
@@ -24,39 +18,21 @@ def cli_download_notebooks(ctx):
     """Download notebooks"""
 
     downloadproc = DownloadProcess(
-        'gammapy-extra',
-        'notebooks',
-        ctx.obj['specfile'],
-        ctx.obj['specfold'],
-        ctx.obj['release'],
-        ['../environment.yml'],
-        Path(ctx.obj['localfold']) / 'notebooks',
-        ctx.obj['recursive']
+        "gammapy-extra",
+        "notebooks",
+        ctx.obj["specfile"],
+        ctx.obj["specfold"],
+        ctx.obj["release"],
+        ["../environment.yml"],
+        Path(ctx.obj["localfold"]),
+        ctx.obj["recursive"],
     )
 
-    # valid hash
     downloadproc.check_hash()
-
-    # get version label
-    version = ctx.obj['release']
-    if ctx.obj['release'] == '':
-        # uncomment when notebooks moved to gammapy repo
-        # version = version.version
-        version = 'master'
-
-    # rename notebooks folder with version label
-    verfolder = str(
-        Path(ctx.obj['localfold']) / 'notebooks-') + version
-    downloadproc.localfold = Path(verfolder)
-
-    # download
+    downloadproc.label_version()
+    downloadproc.build_folders()
+    downloadproc.build_files()
     downloadproc.run()
-
-    # rename environment.yml with version label
-    envfile = Path(ctx.obj['localfold']) / 'environment.yml'
-    verfile = str(
-        Path(ctx.obj['localfold']) / 'environment-') + version + '.yml'
-    envfile.rename(verfile)
 
 
 @click.command(name="datasets")
@@ -65,140 +41,61 @@ def cli_download_datasets(ctx):
     """Download datasets"""
 
     downloadproc = DownloadProcess(
-        'gammapy-extra',
-        'datasets',
-        ctx.obj['specfile'],
-        ctx.obj['specfold'],
-        ctx.obj['release'],
+        "gammapy-extra",
+        "datasets",
+        ctx.obj["specfile"],
+        ctx.obj["specfold"],
+        ctx.obj["release"],
         [],
-        Path(ctx.obj['localfold']) / 'datasets',
-        ctx.obj['recursive']
+        Path(ctx.obj["localfold"]) / "datasets",
+        ctx.obj["recursive"],
     )
 
-    # valid hash
     downloadproc.check_hash()
-
-    # download
+    downloadproc.build_folders()
+    downloadproc.build_files()
     downloadproc.run()
 
 
-class DownloadProcess:
-    """Manages the process of downloading content from the Github repository"""
+@click.command(name="tutorials")
+@click.pass_context
+def cli_download_tutorials(ctx):
+    """Download tutorial notebooks and datasets"""
 
-    def __init__(self, repo, repofold, specfile, specfold,
-                 release, listfiles, localfold, recursive):
+    if ctx.obj["specfile"] or ctx.obj["specfile"]:
+        log.info("--file and --foder are not allowed options for tutorials.")
+    if not ctx.obj["recursive"]:
+        log.info("--recursive is True for tutorials.")
 
-        self.repo = repo
-        self.repofold = repofold
-        self.specfile = specfile
-        self.specfold = specfold
-        self.release = release
-        self.listfiles = listfiles
-        self.localfold = localfold
-        self.recursive = recursive
+    downnotebooks = DownloadProcess(
+        "gammapy-extra",
+        "notebooks",
+        "",
+        "",
+        ctx.obj["release"],
+        ["../environment.yml"],
+        Path(ctx.obj["localfold"]),
+        True,
+    )
 
-        if specfile and specfold:
-            log.error(
-                '--file and --foder are mutually exclusive options, only one is allowed.')
-            sys.exit()
+    downnotebooks.check_hash()
+    downnotebooks.label_version()
+    downnotebooks.build_folders()
+    downnotebooks.build_files(tutorials=True)
+    downnotebooks.run()
 
-    def run(self):
+    downdatasets = DownloadProcess(
+        "gammapy-extra",
+        "datasets",
+        "",
+        "",
+        ctx.obj["release"],
+        [],
+        Path(ctx.obj["localfold"]) / "datasets",
+        True,
+    )
 
-        # fill list of files
-        self.build_files()
-        print('Content will be downloaded in {}'.format(self.localfold))
-
-        # download files
-        if self.listfiles:
-            with click.progressbar(self.listfiles, label='Downloading files') as bar:
-                for f in bar:
-                    self.get_file(f)
-        else:
-            sys.exit()
-
-    def check_hash(self):
-
-        # installed local gammapy hash
-        if self.release == '' or self.release == 'master':
-            # uncomment when notebooks moved to gammapy repo
-            # self.release = version.githash
-            # refhash = 'refs/commits/' + self.release
-            self.release = 'master'
-            refhash = 'refs/heads/' + self.release
-        # release
-        elif self.release.startswith('v') and len(self.release) == 4:
-            refhash = 'refs/tags/' + self.release
-        # commit hash
-        elif len(self.release) == 40:
-            refhash = 'commits/' + self.release
-        # not allowed
-        else:
-            refhash = 'refs/tags/notallowed'
-
-        # check hash
-        url = apigitUrl + self.repo + '/git/' + refhash
-
-        try:
-            urlopen(url)
-        except Exception as ex:
-            log.error('Bad response from GitHub API.')
-            log.error(
-                'Bad value for release or commit hash: ' + self.release)
-            sys.exit()
-
-    def build_files(self):
-
-        if self.specfile:
-            ifolder = self.localfold / Path(self.specfile).parent
-            ifolder.mkdir(parents=True, exist_ok=True)
-            self.listfiles.append(self.specfile)
-        else:
-            json_files = self.get_json_tree()
-            self.parse_json_tree(json_files)
-
-    def get_json_tree(self):
-
-        url = apigitUrl + self.repo + '/git/trees/' + self.release + ':' + self.repofold
-        if self.specfold:
-            url = url + '/' + self.specfold
-        if self.recursive:
-            url = url + '?recursive=1'
-
-        try:
-            r = urlopen(url)
-            json_items = json.loads(r.read())
-            return json_items
-        except Exception as ex:
-            log.error('Bad response from GitHub API.')
-            log.error(ex)
-            sys.exit()
-
-    def parse_json_tree(self, json_files):
-
-        if self.specfold:
-            ifolder = self.localfold / Path(self.specfold)
-        else:
-            ifolder = self.localfold
-        ifolder.mkdir(parents=True, exist_ok=True)
-
-        for item in json_files['tree']:
-            if self.specfold:
-                item['path'] = self.specfold + '/' + item['path']
-            ifolder = self.localfold / Path(item['path'])
-            if item['type'] == 'tree':
-                if self.recursive:
-                    ifolder.mkdir(parents=True, exist_ok=True)
-            else:
-                self.listfiles.append(item['path'])
-
-    def get_file(self, filename):
-
-        url = rawgitUrl + self.repo + \
-            '/' + self.release + '/' + self.repofold + '/' + filename
-        filepath = self.localfold / filename
-
-        try:
-            urlretrieve(url, str(filepath))
-        except Exception as ex:
-            log.error(str(filepath) + ' could not be copied.')
-            log.error(ex)
+    downdatasets.check_hash()
+    downdatasets.build_folders()
+    downdatasets.build_files(tutorials=True, datasets=True)
+    downdatasets.run()

--- a/gammapy/scripts/downloadclass.py
+++ b/gammapy/scripts/downloadclass.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import sys
-import yaml
 from ..extern.six.moves.urllib.request import urlretrieve, urlopen
 from ..extern.pathlib import Path
 
@@ -159,6 +158,7 @@ class DownloadProcess(object):
                     self.listfiles.append(item["path"])
 
     def parse_yaml(self, datasets=False):
+        import yaml
 
         if datasets:
             notebooksfolder = "notebooks-" + self.release

--- a/gammapy/scripts/downloadclass.py
+++ b/gammapy/scripts/downloadclass.py
@@ -1,0 +1,218 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Download class for gammapy download CLI."""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import click
+import json
+import logging
+import os
+import sys
+import yaml
+from ..extern.six.moves.urllib.request import urlretrieve, urlopen
+from ..extern.pathlib import Path
+
+# from .. import version
+
+log = logging.getLogger(__name__)
+
+APIGIT_URL = "https://api.github.com/repos/gammapy/"
+RAWGIT_URL = "https://raw.githubusercontent.com/gammapy/"
+YAMLFLNAME = "notebooks.yaml"
+
+
+class DownloadProcess(object):
+    """Manages the process of downloading content from the Github repository"""
+
+    def __init__(
+        self,
+        repo,
+        repofold,
+        specfile,
+        specfold,
+        release,
+        listfiles,
+        localfold,
+        recursive,
+    ):
+
+        self.repo = repo
+        self.repofold = repofold
+        self.specfile = specfile
+        self.specfold = specfold
+        self.release = release
+        self.listfiles = listfiles
+        self.localfold = localfold
+        self.recursive = recursive
+
+        if specfile and specfold:
+            log.error(
+                "--file and --foder are mutually exclusive options, only one is allowed."
+            )
+            sys.exit()
+
+    def run(self):
+
+        log.info("Content will be downloaded in {}".format(self.localfold))
+
+        # download files
+        if self.listfiles:
+            with click.progressbar(self.listfiles, label="Downloading files") as bar:
+                for f in bar:
+                    self.get_file(f)
+        else:
+            sys.exit()
+
+    def check_hash(self):
+
+        # installed local gammapy hash
+        if self.release == "" or self.release == "master":
+            # uncomment when notebooks moved to gammapy repo
+            # self.release = version.githash
+            # refhash = 'refs/commits/' + self.release
+            self.release = "master"
+            refhash = "refs/heads/" + self.release
+        # release
+        elif self.release.startswith("v") and len(self.release) == 4:
+            refhash = "refs/tags/" + self.release
+        # commit hash
+        elif len(self.release) == 40:
+            refhash = "commits/" + self.release
+        # not allowed
+        else:
+            refhash = "refs/tags/notallowed"
+
+        # check hash
+        url = APIGIT_URL + self.repo + "/git/" + refhash
+        try:
+            urlopen(url)
+        except Exception as ex:
+            log.error("Bad response from GitHub API.")
+            log.error("Bad value for release or commit hash: " + self.release)
+            log.error(url)
+            sys.exit()
+
+    def label_version(self):
+
+        # rename notebooks folder with version label
+        verfolder = str(Path(self.localfold) / "notebooks-") + self.release
+        self.localfold = Path(verfolder)
+
+    def build_folders(self):
+
+        # make base folders
+        if self.specfile:
+            ifolder = self.localfold / Path(self.specfile).parent
+            ifolder.mkdir(parents=True, exist_ok=True)
+            self.listfiles.append(self.specfile)
+        elif self.specfold:
+            ifolder = self.localfold / Path(self.specfold)
+            ifolder.mkdir(parents=True, exist_ok=True)
+        else:
+            ifolder = self.localfold
+            ifolder.mkdir(parents=True, exist_ok=True)
+
+    def build_files(self, tutorials=False, datasets=False):
+
+        # fill files list
+        if not self.specfile:
+            if tutorials:
+                for folder in self.parse_yaml(datasets):
+                    self.specfold = folder
+                    ifolder = self.localfold / Path(self.specfold)
+                    ifolder.mkdir(parents=True, exist_ok=True)
+                    json_files = self.get_json_tree()
+                    self.parse_json_tree(json_files)
+            else:
+                json_files = self.get_json_tree()
+                self.parse_json_tree(json_files)
+
+    def get_json_tree(self):
+
+        url = (
+            APIGIT_URL + self.repo + "/git/trees/" + self.release + ":" + self.repofold
+        )
+        if self.specfold:
+            url = url + "/" + self.specfold
+        if self.recursive:
+            url = url + "?recursive=1"
+
+        try:
+            r = urlopen(url)
+            json_items = json.loads(r.read())
+            return json_items
+        except Exception as ex:
+            log.error("Bad response from GitHub API.")
+            log.error(url)
+            log.error(ex)
+            sys.exit()
+
+    def parse_json_tree(self, json_files):
+
+        if json_files:
+            for item in json_files["tree"]:
+                if self.specfold:
+                    item["path"] = self.specfold + "/" + item["path"]
+                ifolder = self.localfold / Path(item["path"])
+                if item["type"] == "tree":
+                    if self.recursive:
+                        ifolder.mkdir(parents=True, exist_ok=True)
+                else:
+                    self.listfiles.append(item["path"])
+
+    def parse_yaml(self, datasets=False):
+
+        if datasets:
+            notebooksfolder = "notebooks-" + self.release
+            yamlpath = self.localfold.parent / notebooksfolder / YAMLFLNAME
+        else:
+            self.localfold.mkdir(parents=True, exist_ok=True)
+            self.get_file("notebooks.yaml")
+            yamlpath = self.localfold / YAMLFLNAME
+
+        try:
+            with open(str(yamlpath)) as fh:
+                confignbs = yaml.safe_load(fh)
+        except IOError as ex:
+            log.error("{} could not be read.".format(str(yamlpath)))
+            sys.exit()
+
+        set_folders = set()
+        for nb in confignbs:
+            if nb["published"]:
+                if not datasets:
+                    self.listfiles.append(nb["name"] + ".ipynb")
+                else:
+                    if nb["datasets"]:
+                        for ds in nb["datasets"]:
+                            name, ext = os.path.splitext(ds)
+                            if not ext:
+                                set_folders.add(ds)
+                            else:
+                                if "/" in ds:
+                                    ifolder = self.localfold / Path(ds).parent
+                                    ifolder.mkdir(parents=True, exist_ok=True)
+                                self.listfiles.append(ds)
+        return set_folders
+
+    def get_file(self, filename):
+
+        url = (
+            RAWGIT_URL
+            + self.repo
+            + "/"
+            + self.release
+            + "/"
+            + self.repofold
+            + "/"
+            + filename
+        )
+        filepath = str(self.localfold / filename)
+
+        if filepath.endswith("../environment.yml"):
+            verfilename = "environment-" + self.release + ".yml"
+            filepath = filepath.replace("environment.yml", verfilename)
+
+        try:
+            urlretrieve(url, filepath)
+        except Exception as ex:
+            log.error(filepath + " could not be copied.")
+            log.error(ex)

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -152,9 +152,9 @@ def test_notebook(path):
             break
 
     if passed:
-        log.info("   ... PASSED {}".format(str(path)))
+        log.info("   ... PASSED")
         return True
     else:
-        log.info("   ... FAILED {}".format(str(path)))
+        log.info("   ... FAILED")
         log.info(report)
         return False

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -18,15 +18,25 @@ def print_version(ctx, param, value):
 
 
 # http://click.pocoo.org/5/documentation/#help-parameter-customization
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
-@click.group('gammapy', context_settings=CONTEXT_SETTINGS)
-@click.option('--log-level', default='info', help='Logging verbosity level.',
-              type=click.Choice(['debug', 'info', 'warning', 'error']))
-@click.option('--ignore-warnings', is_flag=True, help='Ignore warnings?')
-@click.option('--version', is_flag=True, callback=print_version,
-              expose_value=False, is_eager=True, help='Print version and exit.')
+@click.group("gammapy", context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--log-level",
+    default="info",
+    help="Logging verbosity level.",
+    type=click.Choice(["debug", "info", "warning", "error"]),
+)
+@click.option("--ignore-warnings", is_flag=True, help="Ignore warnings?")
+@click.option(
+    "--version",
+    is_flag=True,
+    callback=print_version,
+    expose_value=False,
+    is_eager=True,
+    help="Print version and exit.",
+)
 def cli(log_level, ignore_warnings):
     """Gammapy command line interface (CLI).
 
@@ -58,16 +68,21 @@ def cli_image():
     """Analysis - 2D images"""
 
 
-@cli.group('download', short_help='Download datasets and notebooks')
-@click.option('--dest', prompt='destination folder', default='gammapy-tutorials',
-              help='Folder where the files will be copied.')
-@click.option('--file', default='',
-              help='Specific file to download.')
-@click.option('--fold', default='',
-              help='Specific folder to download.')
-@click.option('--release', default='',
-              help='Release or commit hash in Github repo.')
-@click.option('--recursive/--no-recursive', default=True, help='Deactivate recursive scan of a folder.')
+@cli.group("download", short_help="Download datasets and notebooks")
+@click.option(
+    "--dest",
+    prompt="destination folder",
+    default="gammapy-tutorials",
+    help="Folder where the files will be copied.",
+)
+@click.option("--file", default="", help="Specific file to download.")
+@click.option("--fold", default="", help="Specific folder to download.")
+@click.option("--release", default="", help="Release or commit hash in Github repo.")
+@click.option(
+    "--recursive/--no-recursive",
+    default=True,
+    help="Deactivate recursive scan of a folder.",
+)
 @click.pass_context
 def cli_download(ctx, dest, file, fold, release, recursive):
     """Download datasets and notebooks.
@@ -83,22 +98,21 @@ def cli_download(ctx, dest, file, fold, release, recursive):
     \b
     $ gammapy download notebooks
     $ gammapy download datasets
+    $ gammapy download --release=master tutorials
     $ gammapy download --file=first_steps.ipynb notebooks
     $ gammapy download --dest=localfolder --fold=catalogs/fermi --no-recursive datasets
-    $ gammapy download --release=master notebooks
     """
     ctx.obj = {
-        'localfold': dest,
-        'specfile': file,
-        'specfold': fold,
-        'release': release,
-        'recursive': recursive
+        "localfold": dest,
+        "specfile": file,
+        "specfold": fold,
+        "release": release,
+        "recursive": recursive,
     }
 
 
-@cli.group('jupyter', short_help='Perform actions on notebooks')
-@click.option('--src', default='.',
-              help='Local folder or Jupyter notebook filename.')
+@cli.group("jupyter", short_help="Perform actions on notebooks")
+@click.option("--src", default=".", help="Local folder or Jupyter notebook filename.")
 @click.pass_context
 def cli_jupyter(ctx, src):
     """
@@ -126,41 +140,52 @@ def cli_jupyter(ctx, src):
         sys.exit()
 
     if path.is_dir():
-        paths = list(path.glob('*.ipynb'))
+        paths = list(path.glob("*.ipynb"))
     else:
         paths = [path]
 
-    ctx.obj = {
-        'paths': paths,
-    }
+    ctx.obj = {"paths": paths}
 
 
 def add_subcommands():
     from .info import cli_info
+
     cli.add_command(cli_info)
 
     from .check import cli_check
+
     cli.add_command(cli_check)
 
     from .image_bin import cli_image_bin
+
     cli_image.add_command(cli_image_bin)
 
     from .download import cli_download_notebooks
+
     cli_download.add_command(cli_download_notebooks)
 
     from .download import cli_download_datasets
+
     cli_download.add_command(cli_download_datasets)
 
+    from .download import cli_download_tutorials
+
+    cli_download.add_command(cli_download_tutorials)
+
     from .jupyter import cli_jupyter_black
+
     cli_jupyter.add_command(cli_jupyter_black)
 
     from .jupyter import cli_jupyter_stripout
+
     cli_jupyter.add_command(cli_jupyter_stripout)
 
     from .jupyter import cli_jupyter_execute
+
     cli_jupyter.add_command(cli_jupyter_execute)
 
     from .jupyter import cli_jupyter_test
+
     cli_jupyter.add_command(cli_jupyter_test)
 
 

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from ...utils.testing import run_cli
 from ..main import cli
 from ...extern.pathlib import Path
+from ...utils.testing import requires_dependency
 import pytest
 
 
@@ -18,6 +19,7 @@ def test_cli_download_help():
 
 
 @pytest.mark.xfail
+@requires_dependency("yaml")
 def test_cli_download_datasets(files_dir):
     filename = "data-register.yaml"
     option_dest = "--dest=" + str(files_dir)
@@ -31,6 +33,7 @@ def test_cli_download_datasets(files_dir):
 
 
 @pytest.mark.xfail
+@requires_dependency("yaml")
 def test_cli_download_notebooks(files_dir):
     release = 'master'
     filename = "first_steps.ipynb"


### PR DESCRIPTION
This PR provides the option `tutorials` for the `gammapy download` CLI.
The `download.py` script has been refactored and most of the code added into a new `gammapyclass.py`script.

The notebooks downloaded are those declared as `published: true` in the `notebooks/notebooks.yaml` file in Gammapy-extra Github repo. For each one of these notebooks the datasets associated to them, as declared in `notebooks/notebooks.yaml` file are also downloaded. 

Notebooks and datasets are downloaded from the Gammapy-extra Github  repo, using the [Github Rest API](https://developer.github.com/v3/) to scan the folders and fetch the list of files inside them.

This PR is another step to achieve goals in [PIG 4 - Setup for tutorial notebooks and data](https://github.com/gammapy/gammapy/blob/8ea7f92e758eca32386d468fcdfef479ee567703/docs/development/pigs/pig-004.rst) - https://github.com/gammapy/gammapy/pull/1419
 
Next steps after code review and merging.
- [ ] Copy the notebooks to Gammapy repo from Gammapy-extra and download them from there.
- [ ] Use index lookup files to fetch the list of files in the folders, and get rid of Github Rest API.

Other actions.
- [ ] Fix access to datasets in notebooks as discussed in https://github.com/gammapy/gammapy/issues/1784
- [ ] Fix declaration of datasets in `notebooks/notebooks.yaml`
- [ ] Clean content and folder structure in Gammapy-extra `datasets` folder.

<pre>
$ gammapy download 
Usage: gammapy download [OPTIONS] COMMAND [ARGS]...

  Download datasets and notebooks.

  Download from the 'gammapy-extra' Github repository the content of
  'datasets' or 'notebooks' folders. The files are copied into a folder
  created at the current working directory.

  Examples
  --------

  $ gammapy download notebooks
  $ gammapy download datasets
  $ gammapy download --release=master tutorials
  $ gammapy download --file=first_steps.ipynb notebooks
  $ gammapy download --dest=localfolder --fold=catalogs/fermi --no-recursive datasets

Options:
  --dest TEXT                   Folder where the files will be copied.
  --file TEXT                   Specific file to download.
  --fold TEXT                   Specific folder to download.
  --release TEXT                Release or commit hash in Github repo.
  --recursive / --no-recursive  Deactivate recursive scan of a folder.
  -h, --help                    Show this message and exit.

Commands:
  datasets   Download datasets
  notebooks  Download notebooks
  tutorials  Download tutorial notebooks and datasets
</pre>