### PR TITLE
Further improve Fit class

### DIFF
--- a/docs/spectrum/fitting.rst
+++ b/docs/spectrum/fitting.rst
@@ -38,7 +38,7 @@ simulated crab runs using the `~gammapy.spectrum.SpectrumFit` class.
 
     fit = SpectrumFit(obs_list=obs_list, model=model)
     fit.statistic = 'WStat'
-    fit.fit()
+    fit.run()
 
 You can check the fit results by looking at
 `~gammapy.spectrum.SpectrumFitResult` that is attached to the

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -42,7 +42,7 @@ OGIP format and fit a spectral model.
         reference=1*u.TeV,
     )
     fit = SpectrumFit(obs_list=obs, model=model)
-    fit.fit()
+    fit.run()
     print(fit.result[0])
 
 It will print the following output to the console:

--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -87,4 +87,4 @@ compound_model.parameters.set_error(8, 0.1 * u.deg)
 compound_model.parameters.set_error(10, 1e-12 * u.Unit("cm-2 s-1 TeV-1"))
 
 fit = MapFit(model=compound_model, counts=counts_map, exposure=exposure_map)
-fit.fit()
+fit.run()

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -106,7 +106,7 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):
         psf=psf,
         edisp=edisp,
     )
-    result = fit.run(optimizer='minuit')
+    result = fit.run(backend='minuit')
 
     assert sky_model is not fit._model
     assert sky_model is not result.model

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -106,12 +106,17 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):
         psf=psf,
         edisp=edisp,
     )
-    result = fit.run()
-    pars = result.model.parameters
+    result = fit.run(optimizer='minuit')
 
     assert sky_model is not fit._model
     assert sky_model is not result.model
+    assert result.success
+    assert 'minuit' in repr(result)
 
+    stat_expected = 3840.0605649268496
+    assert_allclose(result.total_stat, stat_expected, rtol=1e-2)
+
+    pars = result.model.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
     assert_allclose(pars.error("lon_0"), 0.005895, rtol=1e-2)
 
@@ -120,7 +125,3 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):
 
     assert_allclose(pars["amplitude"].value, 1e-11, rtol=1e-2)
     assert_allclose(pars.error("amplitude"), 3.936e-13, rtol=1e-2)
-
-    stat = np.sum(fit.stat, dtype="float64")
-    stat_expected = 3840.0605649268496
-    assert_allclose(stat, stat_expected, rtol=1e-2)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -106,11 +106,11 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):
         psf=psf,
         edisp=edisp,
     )
-    result = fit.fit()
-    pars = result['best-fit-model'].parameters
+    result = fit.run()
+    pars = result.model.parameters
 
     assert sky_model is not fit._model
-    assert sky_model is not result['best-fit-model']
+    assert sky_model is not result.model
 
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
     assert_allclose(pars.error("lon_0"), 0.005895, rtol=1e-2)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -106,7 +106,7 @@ def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):
         psf=psf,
         edisp=edisp,
     )
-    result = fit.run(backend='minuit')
+    result = fit.run()
 
     assert sky_model is not fit._model
     assert sky_model is not result.model

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -9,6 +9,7 @@ from ..spectrum import (
     SpectrumResult,
 )
 from ..background import ReflectedRegionsBackgroundEstimator
+from ..utils.scripts import make_path
 
 __all__ = ["SpectrumAnalysisIACT"]
 
@@ -81,7 +82,7 @@ class SpectrumAnalysisIACT(object):
         )
         self.fit.run(optimize_opts=optimize_opts)
         modelname = self.fit.result[0].model.__class__.__name__
-        filename = self.config["outdir"] / "fit_result_{}.yaml".format(modelname)
+        filename = make_path(self.config["outdir"]) / "fit_result_{}.yaml".format(modelname)
         self.fit.result[0].to_yaml(filename=filename)
 
         # TODO: Don't stack again if SpectrumFit has already done the stacking

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -53,11 +53,11 @@ class SpectrumAnalysisIACT(object):
         ss += "\n{}".format(self.config)
         return ss
 
-    def run(self, opts_minuit=None):
+    def run(self, optimize_opts=None):
         """Run all steps."""
         log.info("Running {}".format(self.__class__.__name__))
         self.run_extraction()
-        self.run_fit(opts_minuit)
+        self.run_fit(optimize_opts)
 
     def run_extraction(self):
         """Run all steps for the spectrum extraction."""
@@ -74,12 +74,12 @@ class SpectrumAnalysisIACT(object):
 
         self.extraction.run()
 
-    def run_fit(self, opts_minuit=None):
+    def run_fit(self, optimize_opts=None):
         """Run all step for the spectrum fit."""
         self.fit = SpectrumFit(
             obs_list=self.extraction.observations, **self.config["fit"]
         )
-        self.fit.run(opts_minuit=opts_minuit)
+        self.fit.run(optimize_opts=optimize_opts)
         modelname = self.fit.result[0].model.__class__.__name__
         filename = self.config["outdir"] / "fit_result_{}.yaml".format(modelname)
         self.fit.result[0].to_yaml(filename=filename)

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class SpectrumFit(Fit):
     """Orchestrate a 1D counts spectrum fit.
 
-    After running the :func:`~gammapy.spectrum.SpectrumFit.fit` method, the fit
+    After running the :func:`~gammapy.spectrum.SpectrumFit.run` method, the fit
     results are available in :func:`~gammapy.spectrum.SpectrumFit.result`. For usage
     examples see :ref:`spectral_fitting`
 
@@ -37,8 +37,6 @@ class SpectrumFit(Fit):
         The intersection between the fit range and the observation thresholds will be used.
         If you want to control which bins are taken into account in the fit for each
         observation, use :func:`~gammapy.spectrum.PHACountsSpectrum.quality`
-    method : {'iminuit'}
-        Optimization backend for the fit
     """
 
     def __init__(
@@ -48,14 +46,12 @@ class SpectrumFit(Fit):
         stat="wstat",
         forward_folded=True,
         fit_range=None,
-        method="iminuit",
     ):
         self.obs_list = obs_list
         self._model = model.copy()
         self.stat = stat
         self.forward_folded = forward_folded
         self.fit_range = fit_range
-        self.method = method
 
         self._predicted_counts = None
         self._statval = None
@@ -71,7 +67,6 @@ class SpectrumFit(Fit):
         ss += "\nStat {}".format(self.stat)
         ss += "\nForward Folded {}".format(self.forward_folded)
         ss += "\nFit range {}".format(self.fit_range)
-        ss += "\nBackend {}".format(self.method)
         return ss
 
     @property

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -948,8 +948,10 @@ class FluxPointFit(Fit):
         data = self.data.table["dnde"].quantity.to(model.unit)
         data_errp = self.data.table["dnde_errp"].quantity
         data_errn = self.data.table["dnde_errn"].quantity
-        sigma = np.where(model > data, data_errp, data_errn)
-        return ((data - model) / sigma).to("").value ** 2
+
+        val_n = ((data - model) / data_errn).to("").value ** 2
+        val_p = ((data - model) / data_errp).to("").value ** 2
+        return np.where(model > data, val_p, val_n)
 
     @property
     def stat(self):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -945,7 +945,7 @@ class FluxPointFit(Fit):
         Assymetric chi2 statistics for a list of flux points and model.
         """
         model = self._model(self.data.e_ref)
-        data = self.data.table["dnde"].quantity
+        data = self.data.table["dnde"].quantity.to(model.unit)
         data_errp = self.data.table["dnde_errp"].quantity
         data_errn = self.data.table["dnde_errn"].quantity
         sigma = np.where(model > data, data_errp, data_errn)

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -824,10 +824,10 @@ class FluxPointEstimator(object):
             " in energy range:\n{}".format(self.fit)
         )
 
-        result = self.fit.fit()
+        result = self.fit.run()
 
         # compute TS value for all observations
-        stat_best_fit = result["statval"]
+        stat_best_fit = result.total_stat
 
         dnde, dnde_err = self.fit.result[0].model.evaluate_error(energy_ref)
         sqrt_ts = self.compute_flux_point_sqrt_ts(self.fit, stat_best_fit=stat_best_fit)

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -77,7 +77,7 @@ class TestFit:
         assert_allclose(np.sum(fit.statval[0]), -107346.5291, rtol=1e-5)
 
         self.source_model.parameters["index"].value = 1.12
-        fit.fit()
+        fit.run()
         # These values are check with sherpa fits, do not change
         pars = fit.result[0].model.parameters
         assert_allclose(pars["index"].value, 1.995525, rtol=1e-3)
@@ -97,7 +97,7 @@ class TestFit:
             stat="wstat",
             forward_folded=False,
         )
-        fit.fit()
+        fit.run()
         pars = fit.result[0].model.parameters
         assert_allclose(pars["index"].value, 1.997342, rtol=1e-3)
         assert_allclose(pars["amplitude"].value, 100245.187067, rtol=1e-3)
@@ -114,7 +114,7 @@ class TestFit:
             model=self.source_model,
             forward_folded=False,
         )
-        fit.fit()
+        fit.run()
         pars = fit.result[0].model.parameters
         assert_allclose(pars["index"].value, 1.996456, rtol=1e-3)
 
@@ -155,7 +155,7 @@ class TestFit:
         fit = SpectrumFit(
             obs_list=obs, stat="cash", model=self.source_model, forward_folded=False
         )
-        fit.fit()
+        fit.run()
         true_idx = fit.result[0].model.parameters["index"].value
         scan_idx = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)
         profile = fit.likelihood_1d(
@@ -208,7 +208,7 @@ class TestSpectralFit:
     @requires_dependency("iminuit")
     def test_basic_results(self):
         self.fit.method = "iminuit"
-        self.fit.fit()
+        self.fit.run()
         result = self.fit.result[0]
         assert_allclose(result.statval, 32.8387, rtol=1e-4)
         pars = result.model.parameters
@@ -219,7 +219,7 @@ class TestSpectralFit:
         self.fit.result[0].to_table()
 
     def test_basic_errors(self):
-        self.fit.fit()
+        self.fit.run()
         result = self.fit.result[0]
         assert_allclose(result.model.parameters.error("index"), 0.097866953, rtol=1e-3)
         assert_allclose(
@@ -230,7 +230,7 @@ class TestSpectralFit:
     def test_compound(self):
         model = self.pwl * 2
         fit = SpectrumFit(self.obs_list[0], model)
-        fit.fit()
+        fit.run()
         result = fit.result[0]
         pars = result.model.parameters
         assert_allclose(pars["index"].value, 2.254578, rtol=1e-3)
@@ -239,7 +239,7 @@ class TestSpectralFit:
         assert_allclose(p.value, 3.169233e-12, rtol=1e-3)
 
     def test_npred(self):
-        self.fit.fit()
+        self.fit.run()
         actual = (
             self.fit.obs_list[0]
             .predicted_counts(self.fit.result[0].model)
@@ -249,7 +249,7 @@ class TestSpectralFit:
         assert_allclose(actual, desired)
 
     def test_stats(self):
-        self.fit.fit()
+        self.fit.run()
         stats = self.fit.result[0].stat_per_bin
         actual = np.sum(stats)
         desired = self.fit.result[0].statval
@@ -290,19 +290,19 @@ class TestSpectralFit:
         )
         obs.edisp = None
         fit = SpectrumFit(obs_list=obs, model=self.pwl)
-        fit.fit()
+        fit.run()
         assert_allclose(fit.result[0].model.parameters["index"].value, 2.296, atol=0.02)
 
     def test_ecpl_fit(self):
         fit = SpectrumFit(self.obs_list[0], self.ecpl)
-        fit.fit()
+        fit.run()
         actual = fit.result[0].model.parameters["lambda_"].quantity
         assert actual.unit == "TeV-1"
         assert_allclose(actual.value, 0.034231, rtol=1e-2)
 
     def test_joint_fit(self):
         fit = SpectrumFit(self.obs_list, self.pwl)
-        fit.fit()
+        fit.run()
         actual = fit.result[0].model.parameters["index"].value
         assert_allclose(actual, 2.21225, rtol=1e-3)
 
@@ -314,7 +314,7 @@ class TestSpectralFit:
         stacked_obs = self.obs_list.stack()
         obs_list = SpectrumObservationList([stacked_obs])
         fit = SpectrumFit(obs_list, self.pwl)
-        fit.fit()
+        fit.run()
         pars = fit.result[0].model.parameters
         assert_allclose(pars["index"].value, 2.21338, rtol=1e-3)
         assert u.Unit(pars["amplitude"].unit) == "cm-2 s-1 TeV-1"

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -207,7 +207,6 @@ class TestSpectralFit:
 
     @requires_dependency("iminuit")
     def test_basic_results(self):
-        self.fit.method = "iminuit"
         self.fit.run()
         result = self.fit.result[0]
         assert_allclose(result.statval, 32.8387, rtol=1e-4)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -169,8 +169,8 @@ def obs():
 def model():
     model = PowerLaw()
     fit = SpectrumFit(obs(), model)
-    result = fit.fit()
-    return result['best-fit-model']
+    result = fit.run()
+    return result.model
 
 
 @pytest.fixture(scope="session")
@@ -353,12 +353,12 @@ class TestFluxPointFit:
         model = PowerLaw(index=2.3, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV")
 
         fitter = FluxPointFit(model, data)
-        result = fitter.fit()
+        result = fitter.run()
 
-        index = result["best-fit-model"].parameters["index"]
+        index = result.model.parameters["index"]
         assert_quantity_allclose(index.quantity, 2.216 * u.Unit(""), rtol=1e-3)
-        amplitude = result["best-fit-model"].parameters["amplitude"]
+        amplitude = result.model.parameters["amplitude"]
         assert_quantity_allclose(
             amplitude.quantity, 2.1616E-13 * u.Unit("cm-2 s-1 TeV-1"), rtol=1e-3
         )
-        assert_allclose(result["statval"], 25.2059, rtol=1e-3)
+        assert_allclose(result.total_stat, 25.2059, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -344,21 +344,41 @@ def test_compute_flux_points_dnde_fermi():
         assert_quantity_allclose(actual[:-1], desired[:-1], rtol=1e-1)
 
 
-@requires_data("gammapy-extra")
-@requires_dependency("iminuit")
-class TestFluxPointFit:
-    def test_fit_pwl(self):
-        path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/diff_flux_points.fits"
-        data = FluxPoints.read(path)
-        model = PowerLaw(index=2.3, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV")
+@pytest.fixture(scope='session')
+def sed_flux_points():
+    path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/diff_flux_points.fits"
+    return FluxPoints.read(path)
 
-        fitter = FluxPointFit(model, data)
-        result = fitter.run()
+@pytest.fixture(scope='session')
+def sed_model():
+    return PowerLaw(index=2.3, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV")
+
+
+@requires_data("gammapy-extra")
+class TestFluxPointFit:
+    @requires_dependency("iminuit")
+    def test_fit_pwl_minuit(self, sed_model, sed_flux_points):
+        optimize_opts = {"backend": "minuit"}
+        fitter = FluxPointFit(sed_model, sed_flux_points)
+        result = fitter.run(optimize_opts=optimize_opts)
+        self.assert_result(result)
+
+    @requires_dependency("sherpa")
+    def test_fit_pwl_sherpa(self, sed_model, sed_flux_points):
+        optimize_opts = {"backend": "sherpa", "method": "simplex"}
+        fitter = FluxPointFit(sed_model, sed_flux_points)
+        result = fitter.run(optimize_opts=optimize_opts, steps=["optimize"])
+        self.assert_result(result)
+
+    @staticmethod
+    def assert_result(result):
+        assert result.success
+        assert_allclose(result.total_stat, 25.2059, rtol=1e-3)
 
         index = result.model.parameters["index"]
-        assert_quantity_allclose(index.quantity, 2.216 * u.Unit(""), rtol=1e-3)
-        amplitude = result.model.parameters["amplitude"]
-        assert_quantity_allclose(
-            amplitude.quantity, 2.1616E-13 * u.Unit("cm-2 s-1 TeV-1"), rtol=1e-3
-        )
-        assert_allclose(result.total_stat, 25.2059, rtol=1e-3)
+        assert_allclose(index.value, 2.216, rtol=1e-3)
+
+        # Right now sherpa also fits the reference energy
+        amplitude = result.model(1 * u.TeV).to('cm-2 s-1 TeV-1')
+        assert_allclose(amplitude.value, 2.1616E-13, rtol=1e-3)
+

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -112,8 +112,6 @@ class Fit(object):
         ----------
         steps : {"all", "optimize", "errors"}
             Which fitting steps to run.
-        backend : {"minuit", "sherpa"}
-            Which fitting backend to use. See `optimize` for details.
         optimize_opts : dict
             Options passed to `Fit.optimize`.
 
@@ -128,7 +126,7 @@ class Fit(object):
         if "optimize" in steps:
             if optimize_opts == None:
                 optimize_opts = {}
-            result = self.optimize(backend=backend, **optimize_opts)
+            result = self.optimize(**optimize_opts)
 
         if "errors" in steps:
             result = self._estimate_errors(result)

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -39,12 +39,13 @@ class Fit(object):
         Parameters
         ----------
         backend : {"minuit", "sherpa"}
-            Which optimizer to use. See https://iminuit.readthedocs.io for details
-            on the the option `"minuit"`.
-            See http://cxc.cfa.harvard.edu/sherpa/methods/index.html for details
-            on the other methods.
+            Which fitting backend to use.
         opts : dict (optional)
-            Options passed to `iminuit.Minuit` constructor
+            Options passed to the optmizer. See https://iminuit.readthedocs.io
+            for details on the `"minuit"` backend.
+            See http://cxc.cfa.harvard.edu/sherpa/methods/index.html for details
+            on the on the `"sherpa"` backend. To choose sherpa optimization method
+            use e.g. `opts = {"method": "simplex"}`.
 
         Returns
         -------
@@ -93,7 +94,7 @@ class Fit(object):
             parameters.covariance = None
         return fit_result
 
-    def run(self, steps="all", optimizer='minuit', opts_minuit=None):
+    def run(self, steps="all", backend='minuit', opts=None):
         """
         Run all fitting steps.
 
@@ -101,10 +102,10 @@ class Fit(object):
         ----------
         steps : {"all", "optimize", "errors"}
             Which fitting steps to run.
-        optimizer : {"minuit", "levmar", "simplex", "moncar", "gridsearch"}
-            Which optimizer to use. See `.optimize()` for details.
-        opts_minuit : dict (optional)
-            Options passed to `iminuit.Minuit` constructor
+        backend : {"minuit", "sherpa"}
+            Which fitting backend to use. See `optimize` for details.
+        opts : dict (optional)
+            Options passed to the optimizer. See `optimize` for details.
 
         Returns
         -------
@@ -115,7 +116,7 @@ class Fit(object):
             steps = ["optimize", "errors"]
 
         if "optimize" in steps:
-            result = self.optimize(optimizer=optimizer, opts_minuit=opts_minuit)
+            result = self.optimize(backend=backend, opts=opts)
 
         if "errors" in steps:
             result = self._estimate_errors(result)

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -70,7 +70,7 @@ class Fit(object):
         factors, info, optimizer = optimize(
             parameters=parameters,
             function=self.total_stat,
-            **kwargs,
+            **kwargs
         )
 
         # As preliminary solution would like to provide a possibility that the user

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -139,12 +139,12 @@ class FitResult(object):
 
     @property
     def success(self):
-        """Best fit model."""
+        """Fit success status flag."""
         return self._success
 
     @property
     def nfev(self):
-        """Number of function evaluations."""
+        """Number of function evaluations until convergence or stop."""
         return self._nfev
 
     @property
@@ -154,7 +154,7 @@ class FitResult(object):
 
     @property
     def message(self):
-        """Optimizer message."""
+        """Optimizer status message."""
         return self._message
 
     @property

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -75,7 +75,7 @@ class Fit(object):
         result["model"] = self._model.copy()
         result["total_stat"] = self.total_stat(self._model.parameters)
         result["optimizer"] = optimizer
-        return result
+        return FitResult(**result)
 
     # TODO: this is a preliminary solution to restore the old behaviour
     def _estimate_errors(self, fit_result):
@@ -108,3 +108,54 @@ class Fit(object):
             result = self._estimate_errors(result)
 
         return result
+
+
+class FitResult(object):
+    """Fit result object."""
+    def __init__(self, model, success, nfev, total_stat, message, optimizer):
+        self._model = model
+        self._success = success
+        self._nfev = nfev
+        self._total_stat = total_stat
+        self._message = message
+        self._optimizer = optimizer
+
+    @property
+    def model(self):
+        """Best fit model."""
+        return self._model
+
+    @property
+    def success(self):
+        """Best fit model."""
+        return self._success
+
+    @property
+    def nfev(self):
+        """Number of function evaluations."""
+        return self._nfev
+
+    @property
+    def total_stat(self):
+        """Value of the fit statistic at minimum."""
+        return self._total_stat
+
+    @property
+    def message(self):
+        """Optimizer message."""
+        return self._message
+
+    @property
+    def optimizer(self):
+        """Optimizer used for the fit."""
+        return self._optimizer
+
+    def __repr__(self):
+        str_ = self.__class__.__name__
+        str_ += "\n\n"
+        str_ += "\toptimizer : {}".format(self.optimizer)
+        str_ += "\tsuccess   : {}".format(self.success)
+        str_ += "\tnfev      : {}".format(self.nfev)
+        str_ += "\ttotal stat: {}".format(self.total_stat)
+        str_ += "\tmessage   : {}".format(self.message)
+        return str_

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -160,9 +160,9 @@ class FitResult(object):
     def __repr__(self):
         str_ = self.__class__.__name__
         str_ += "\n\n"
-        str_ += "\toptimizer : {}".format(self.optimizer)
-        str_ += "\tsuccess   : {}".format(self.success)
-        str_ += "\tnfev      : {}".format(self.nfev)
-        str_ += "\ttotal stat: {}".format(self.total_stat)
-        str_ += "\tmessage   : {}".format(self.message)
+        str_ += "\toptimizer  : {}\n".format(self.optimizer)
+        str_ += "\tsuccess    : {}\n".format(self.success)
+        str_ += "\tnfev       : {}\n".format(self.nfev)
+        str_ += "\ttotal stat : {:.2f}\n".format(self.total_stat)
+        str_ += "\tmessage    : {}\n".format(self.message)
         return str_

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -5,7 +5,9 @@ import abc
 from astropy.utils.misc import InheritDocstrings
 
 from ...extern import six
-from .iminuit import fit_iminuit
+from .iminuit import fit_iminuit, _get_covar
+from .sherpa import fit_sherpa
+
 
 __all__ = ["Fit"]
 
@@ -20,38 +22,71 @@ class FitMeta(InheritDocstrings, abc.ABCMeta):
 class Fit(object):
     """Abstract Fit base class.
     """
-
     @abc.abstractmethod
     def total_stat(self, parameters):
         """Total likelihood given the current model parameters"""
         pass
 
-    def fit(self, opts_minuit=None):
+    def fit(self, optimizer="minuit", opts_minuit=None):
         """Run the fit
 
         Parameters
         ----------
+        optimizer : {"minuit", "levmar", "simplex", "moncar", "gridsearch"}
+            Which optimizer to use. See https://iminuit.readthedocs.io for details
+            on the the option `"minuit"`.
+            See http://cxc.cfa.harvard.edu/sherpa/methods/index.html for details
+            on the other methods.
         opts_minuit : dict (optional)
             Options passed to `iminuit.Minuit` constructor
 
         Returns
         -------
-        fit_result : dict
-            Dictionary with the fit result.
+        fit_result : `FitResult`
+            Fit result object with the fit results.
         """
-        result = fit_iminuit(
-            parameters=self._model.parameters,
-            function=self.total_stat,
-            opts_minuit=opts_minuit,
-        )
-        self._minuit = result.pop("minuit")
+        parameters = self._model.parameters
 
-        if not result["success"]:
-            log.info("Fit failed with message {}".format(result["message"]))
+        if parameters.apply_autoscale:
+            parameters.autoscale()
 
-        result["best-fit-model"] = self._model.copy()
-        result["statval"] = self.total_stat(self._model.parameters)
+        if optimizer == 'minuit':
+            result = fit_iminuit(
+                parameters=parameters,
+                function=self.total_stat,
+                opts_minuit=opts_minuit,
+            )
+            # As a preliminary solution we attach the Minuit object to the Fit
+            # class as a hidden attribute, so that it becomes available to the
+            # user
+            self._minuit = result.pop("minuit")
+        elif optimizer in ["levmar", "simplex", "moncar", "gridsearch"]:
+            result = fit_sherpa(
+                parameters=parameters,
+                function=self.total_stat,
+                optimizer=optimizer,
+            )
+        else:
+            raise ValueError("{} is not a valid optimizer.",format(optimizer))
+
+        # Copy final results into the parameters object
+        parameters.set_parameter_factors(result.pop("factors"))
+
+        result["model"] = self._model.copy()
+        result["total_stat"] = self.total_stat(self._model.parameters)
+        result["optimizer"] = optimizer
         return result
+
+    # TODO: this is a preliminary solution to restore the old behaviour
+    def _estimate_errors(self, fit_result):
+        parameters = fit_result.model.parameters
+
+        if self._minuit.covariance is not None:
+            parameters.set_covariance_factors(_get_covar(self._minuit))
+        else:
+            log.warning("No covariance matrix found")
+            parameters.covariance = None
+        return fit_result
 
     def run(self, steps="all", opts_minuit=None):
         """
@@ -64,9 +99,12 @@ class Fit(object):
 
         """
         if steps == "all":
-            steps = ["fit"]
+            steps = ["fit", "errors"]
 
-        result = {}
         if "fit" in steps:
-            result.update(self.fit(opts_minuit=opts_minuit))
+            result = self.fit(opts_minuit=opts_minuit)
+
+        if "errors" in steps:
+            result = self._estimate_errors(result)
+
         return result

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -85,7 +85,7 @@ class Fit(object):
             model=self._model.copy(),
             total_stat=self.total_stat(self._model.parameters),
             backend=backend,
-            method=kwargs.get("method"),
+            method=kwargs.get("method", backend),
             **info
             )
 
@@ -184,7 +184,7 @@ class FitResult(object):
         str_ = self.__class__.__name__
         str_ += "\n\n"
         str_ += "\tbackend    : {}\n".format(self.backend)
-        str_ += "\tmethod    : {}\n".format(self.method)
+        str_ += "\tmethod     : {}\n".format(self.method)
         str_ += "\tsuccess    : {}\n".format(self.success)
         str_ += "\tnfev       : {}\n".format(self.nfev)
         str_ += "\ttotal stat : {:.2f}\n".format(self.total_stat)

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -10,7 +10,7 @@ __all__ = ["optimize_iminuit"]
 log = logging.getLogger(__name__)
 
 
-def optimize_iminuit(parameters, function, opts=None):
+def optimize_iminuit(parameters, function, **kwargs):
     """iminuit optimization
 
     Parameters
@@ -19,7 +19,7 @@ def optimize_iminuit(parameters, function, opts=None):
         Parameters with starting values
     function : callable
         Likelihood function
-    opts : dict (optional)
+    **kwargs : dict
         Options passed to `iminuit.Minuit` constructor
 
     Returns
@@ -31,17 +31,14 @@ def optimize_iminuit(parameters, function, opts=None):
 
     # In Gammapy, we have the factor 2 in the likelihood function
     # This means `errordef=1` in the Minuit interface is correct
-    opts_minuit = {"errordef": 1, "print_level": 0}
-
-    if opts:
-        opts_minuit.update(opts)
-
-    opts_minuit.update(make_minuit_par_kwargs(parameters))
+    kwargs.setdefault("errordef", 1)
+    kwargs.setdefault("print_level", 0)
+    kwargs.update(make_minuit_par_kwargs(parameters))
 
     parnames = _make_parnames(parameters)
     minuit_func = MinuitFunction(function, parameters)
 
-    minuit = Minuit(minuit_func.fcn, forced_parameters=parnames, **opts_minuit)
+    minuit = Minuit(minuit_func.fcn, forced_parameters=parnames, **kwargs)
     minuit.migrad()
 
     info = {

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -5,12 +5,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import numpy as np
 
-__all__ = ["fit_iminuit"]
+__all__ = ["optimize_iminuit"]
 
 log = logging.getLogger(__name__)
 
 
-def fit_iminuit(parameters, function, opts_minuit=None):
+def optimize_iminuit(parameters, function, opts_minuit=None):
     """iminuit optimization
 
     Parameters

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -35,7 +35,7 @@ class SherpaFunction(object):
         return self.function(self.parameters), 0
 
 
-def optimize_sherpa(parameters, function, opts=None):
+def optimize_sherpa(parameters, function, **kwargs):
     """Sherpa optimization wrapper method.
 
     Parameters
@@ -44,21 +44,17 @@ def optimize_sherpa(parameters, function, opts=None):
         Parameter list with starting values.
     function : callable
         Likelihood function
-    opts : dict
-        Options dict passed to the optimizer. Can contain the "method"
-        keyword to choose from {'levmar', 'simplex', 'moncar', 'gridsearch'}.
-        See http://cxc.cfa.harvard.edu/sherpa/methods/index.html
-        for details on the different options available.
+    **kwargs : dict
+        Options passed to the optimizer instance.
 
     Returns
     -------
     result : (factors, info, optimizer)
         Tuple containing the best fit factors, some info and the optimizer instance.
     """
-    if opts is None:
-        opts = {"method": "simplex"}
-
-    optimizer = get_sherpa_optimiser(opts["method"])
+    method = kwargs.pop("method", "simplex")
+    optimizer = get_sherpa_optimiser(method)
+    optimizer.config.update(kwargs)
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -50,13 +50,10 @@ def fit_sherpa(parameters, function, optimizer="simplex"):
 
     Returns
     -------
-    parameters : `~gammapy.utils.modeling.Parameters`
-        Parameter list with best-fit values
+    result : dict
+        Result dict with the best fit parameters and optimizer info.
     """
     optimizer = get_sherpa_optimiser(optimizer)
-
-    if parameters.covariance is None:
-        parameters.autoscale()
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]
@@ -68,17 +65,9 @@ def fit_sherpa(parameters, function, optimizer="simplex"):
         statfunc=statfunc.fcn, pars=pars, parmins=parmins, parmaxes=parmaxes
     )
 
-    result = {
+    return {
         "success": result[0],
         "factors": result[1],
-        "statval": result[2],
         "message": result[3],
-        "info": result[4],  # that's a dict, content varies based on optimiser
+        "nfev": result[4]["nfev"],
     }
-
-    result["nfev"] = result["info"]["nfev"]
-
-    # Copy final results into the parameters object
-    parameters.set_parameter_factors(result["factors"])
-
-    return result

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 
 __all__ = ["optimize_sherpa"]
 
@@ -31,7 +32,7 @@ class SherpaFunction(object):
 
     def fcn(self, factors):
         self.parameters.set_parameter_factors(factors)
-        return self.function(self.parameters)
+        return self.function(self.parameters), 0
 
 
 def optimize_sherpa(parameters, function, optimizer="simplex"):
@@ -61,9 +62,10 @@ def optimize_sherpa(parameters, function, optimizer="simplex"):
 
     statfunc = SherpaFunction(function, parameters)
 
-    result = optimizer.fit(
-        statfunc=statfunc.fcn, pars=pars, parmins=parmins, parmaxes=parmaxes
-    )
+    with np.errstate(invalid='ignore'):
+        result = optimizer.fit(
+            statfunc=statfunc.fcn, pars=pars, parmins=parmins, parmaxes=parmaxes
+        )
 
     return {
         "success": result[0],

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -35,7 +35,7 @@ class SherpaFunction(object):
         return self.function(self.parameters), 0
 
 
-def optimize_sherpa(parameters, function, optimizer="simplex"):
+def optimize_sherpa(parameters, function, opts=None):
     """Sherpa optimization wrapper method.
 
     Parameters
@@ -44,17 +44,21 @@ def optimize_sherpa(parameters, function, optimizer="simplex"):
         Parameter list with starting values.
     function : callable
         Likelihood function
-    optimizer : {'levmar', 'simplex', 'moncar', 'gridsearch'}
-        Which optimizer to use for the fit. See
-        http://cxc.cfa.harvard.edu/sherpa/methods/index.html
+    opts : dict
+        Options dict passed to the optimizer. Can contain the "method"
+        keyword to choose from {'levmar', 'simplex', 'moncar', 'gridsearch'}.
+        See http://cxc.cfa.harvard.edu/sherpa/methods/index.html
         for details on the different options available.
 
     Returns
     -------
-    result : dict
-        Result dict with the best fit parameters and optimizer info.
+    result : (factors, info, optimizer)
+        Tuple containing the best fit factors, some info and the optimizer instance.
     """
-    optimizer = get_sherpa_optimiser(optimizer)
+    if opts is None:
+        opts = {"method": "simplex"}
+
+    optimizer = get_sherpa_optimiser(opts["method"])
 
     pars = [par.value for par in parameters.parameters]
     parmins = [par.min for par in parameters.parameters]
@@ -67,9 +71,10 @@ def optimize_sherpa(parameters, function, optimizer="simplex"):
             statfunc=statfunc.fcn, pars=pars, parmins=parmins, parmaxes=parmaxes
         )
 
-    return {
+    info = {
         "success": result[0],
-        "factors": result[1],
         "message": result[3],
         "nfev": result[4]["nfev"],
     }
+
+    return result[1], info, optimizer

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__all__ = ["fit_sherpa"]
+__all__ = ["optimize_sherpa"]
 
 
 def get_sherpa_optimiser(name):
@@ -34,7 +34,7 @@ class SherpaFunction(object):
         return self.function(self.parameters)
 
 
-def fit_sherpa(parameters, function, optimizer="simplex"):
+def optimize_sherpa(parameters, function, optimizer="simplex"):
     """Sherpa optimization wrapper method.
 
     Parameters

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -16,26 +16,25 @@ def fcn(parameters):
 def test_iminuit():
     pars = Parameters([Parameter("x", 2.1), Parameter("y", 3.1), Parameter("z", 4.1)])
 
-    minuit = optimize_iminuit(function=fcn, parameters=pars)["minuit"]
+    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    assert info['success']
 
-    assert_allclose(pars["x"].value, 2, rtol=1e-2)
-    assert_allclose(pars["y"].value, 3, rtol=1e-2)
-    assert_allclose(pars["z"].value, 4, rtol=1e-2)
-
+    assert_allclose(factors, [2, 3, 4], rtol=1e-2)
     assert_allclose(minuit.values["par_000_x"], 2, rtol=1e-2)
     assert_allclose(minuit.values["par_001_y"], 3, rtol=1e-2)
     assert_allclose(minuit.values["par_002_z"], 4, rtol=1e-2)
 
     # Test freeze
     pars["x"].frozen = True
-    minuit = optimize_iminuit(function=fcn, parameters=pars)["minuit"]
-    assert minuit.migrad_ok()
+    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    assert info['success']
     assert minuit.list_of_fixed_param() == ["par_000_x"]
 
     # Test limits
     pars["y"].min = 4
-    minuit = optimize_iminuit(function=fcn, parameters=pars)["minuit"]
-    assert minuit.migrad_ok()
+    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+
+    assert info['success']
     states = minuit.get_param_states()
     assert not states[0]["has_limits"]
     assert not states[2]["has_limits"]

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
 from ...testing import requires_dependency
-from .. import Parameter, Parameters, fit_iminuit
+from .. import Parameter, Parameters, optimize_iminuit
 
 
 def fcn(parameters):
@@ -16,7 +16,7 @@ def fcn(parameters):
 def test_iminuit():
     pars = Parameters([Parameter("x", 2.1), Parameter("y", 3.1), Parameter("z", 4.1)])
 
-    minuit = fit_iminuit(function=fcn, parameters=pars)["minuit"]
+    minuit = optimize_iminuit(function=fcn, parameters=pars)["minuit"]
 
     assert_allclose(pars["x"].value, 2, rtol=1e-2)
     assert_allclose(pars["y"].value, 3, rtol=1e-2)
@@ -28,13 +28,13 @@ def test_iminuit():
 
     # Test freeze
     pars["x"].frozen = True
-    minuit = fit_iminuit(function=fcn, parameters=pars)["minuit"]
+    minuit = optimize_iminuit(function=fcn, parameters=pars)["minuit"]
     assert minuit.migrad_ok()
     assert minuit.list_of_fixed_param() == ["par_000_x"]
 
     # Test limits
     pars["y"].min = 4
-    minuit = fit_iminuit(function=fcn, parameters=pars)["minuit"]
+    minuit = optimize_iminuit(function=fcn, parameters=pars)["minuit"]
     assert minuit.migrad_ok()
     states = minuit.get_param_states()
     assert not states[0]["has_limits"]

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -18,15 +18,16 @@ def fcn(parameters):
 
 
 @requires_dependency("sherpa")
-@pytest.mark.parametrize("optimizer", ["moncar", "simplex"])
-def test_sherpa(optimizer):
+@pytest.mark.parametrize("method", ["moncar", "simplex"])
+def test_sherpa(method):
     pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])
 
-    result = optimize_sherpa(function=fcn, parameters=pars, optimizer=optimizer)
+    opts = {"method": method}
+    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars, opts=opts)
 
-    assert result["success"]
-    assert result["nfev"] > 10
-    assert_allclose(result["factors"], [2, 3, 4], rtol=1e-2)
+    assert info["success"]
+    assert info["nfev"] > 10
+    assert_allclose(factors, [2, 3, 4], rtol=1e-2)
     assert_allclose(pars["x"].value, 2, rtol=1e-2)
     assert_allclose(pars["y"].value, 3, rtol=1e-2)
     assert_allclose(pars["z"].value, 4, rtol=1e-2)

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -22,8 +22,7 @@ def fcn(parameters):
 def test_sherpa(method):
     pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])
 
-    opts = {"method": method}
-    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars, opts=opts)
+    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars, method=method)
 
     assert info["success"]
     assert info["nfev"] > 10

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from numpy.testing import assert_allclose
 from ...testing import requires_dependency
-from .. import Parameter, Parameters, fit_sherpa
+from .. import Parameter, Parameters, optimize_sherpa
 
 
 def fcn(parameters):
     x = parameters["x"].value
     y = parameters["y"].value
     z = parameters["z"].value
-    return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2, 0
+    return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
 
 
 # TODO: levmar doesn't work yet; needs array of statval as return in likelihood
@@ -22,11 +22,10 @@ def fcn(parameters):
 def test_sherpa(optimizer):
     pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])
 
-    result = fit_sherpa(function=fcn, parameters=pars, optimizer=optimizer)
+    result = optimize_sherpa(function=fcn, parameters=pars, optimizer=optimizer)
 
     assert result["success"]
     assert result["nfev"] > 10
-    assert_allclose(result["statval"], 0, atol=1e-2)
     assert_allclose(result["factors"], [2, 3, 4], rtol=1e-2)
     assert_allclose(pars["x"].value, 2, rtol=1e-2)
     assert_allclose(pars["y"].value, 3, rtol=1e-2)


### PR DESCRIPTION
This PR is a follow up to #1785. It implements the following changes:

* Add a minimal `FitResult` object
* Activate the sherpa fitting backend
* Rename `Fit.fit()` to `Fit.optimize()` and make `Fit.run()` the main function to be called by the user.
* Implement a preliminary hidden `_estimate_errors()` method, which is needed to recreate the old behavior to set the errors on the best fit model . The API of this is still very bad and I did not want to make it public. Hopefully we can replace it soon with a better implementation, offering the `minos` and `hesse` options of `Minuit` to the users.