### PR TITLE
Move tutorials notebooks from Gammapy-extra repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ htmlcov
 MANIFEST
 
 # notebooks
-*.ipynb
 *.ipynb_checkpoints
 docs/_static/notebooks
 docs/notebooks

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -152,9 +152,9 @@ def test_notebook(path):
             break
 
     if passed:
-        log.info("   ... PASSED {}".format(str(path)))
+        log.info("   ... PASSED")
         return True
     else:
-        log.info("   ... FAILED {}".format(str(path)))
+        log.info("   ... FAILED")
         log.info(report)
         return False

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -12,17 +12,10 @@ import yaml
 
 logging.basicConfig(level=logging.INFO)
 
-if 'GAMMAPY_EXTRA' not in os.environ:
-    logging.info('GAMMAPY_EXTRA environment variable not set.')
-    logging.info('Running notebook tests requires gammapy-extra.')
-    logging.info('Exiting now.')
-    sys.exit()
-
 
 def get_notebooks():
     """Read `notebooks.yaml` info."""
-    filename = str(
-        Path(os.environ['GAMMAPY_EXTRA']) / 'notebooks' / 'notebooks.yaml')
+    filename = str(Path('tutorials') / 'notebooks.yaml')
     with open(filename) as fh:
         notebooks = yaml.safe_load(fh)
     return notebooks
@@ -41,15 +34,26 @@ def requirement_missing(notebook):
     return False
 
 
+if 'GAMMAPY_EXTRA' not in os.environ:
+    logging.info('GAMMAPY_EXTRA environment variable not set.')
+    logging.info('Running notebook tests requires gammapy-extra.')
+    logging.info('Exiting now.')
+    sys.exit()
+
+try:
+    path_datasets = Path(os.environ['GAMMAPY_EXTRA']) / 'datasets'
+    os.symlink(str(path_datasets), 'datasets')
+except Exception as ex:
+    logging.error('It was not possible to create a /datasets symlink')
+    logging.error(ex)
+    sys.exit()
+
+
 passed = True
 yamlfile = get_notebooks()
-dirnbs = Path(os.environ['GAMMAPY_EXTRA']) / 'notebooks'
+dirnbs = Path('tutorials')
 
 for notebook in yamlfile:
-    if not notebook['test']:
-        logging.info(
-            'Skipping notebook {} because test=false.'.format(notebook['name']))
-        continue
     if requirement_missing(notebook):
         logging.info('Skipping notebook {} because requirement is missing.'.format(
             notebook['name']))
@@ -60,4 +64,6 @@ for notebook in yamlfile:
 
     if not test_notebook(path):
         passed = False
+
+os.unlink('datasets')
 assert passed

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3D analysis\n",
+    "\n",
+    "This tutorial shows how to run a 3D map-based analysis (two spatial and one energy axis).\n",
+    "\n",
+    "The example data is three observations of the Galactic center region with CTA."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports and versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from gammapy.extern.pathlib import Path\n",
+    "from gammapy.data import DataStore\n",
+    "from gammapy.irf import EnergyDispersion\n",
+    "from gammapy.maps import WcsGeom, MapAxis, Map\n",
+    "from gammapy.cube import MapMaker, PSFKernel, MapFit\n",
+    "from gammapy.cube.models import SkyModel\n",
+    "from gammapy.spectrum.models import PowerLaw\n",
+    "from gammapy.image.models import SkyGaussian, SkyPointSource\n",
+    "from regions import CircleSkyRegion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gammapy info --no-envvar --no-dependencies --no-system"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make maps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define which data to use\n",
+    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/\")\n",
+    "obs_ids = [110380, 111140, 111159]\n",
+    "obs_list = data_store.obs_list(obs_ids)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define map geometry (spatial and energy binning)\n",
+    "axis = MapAxis.from_edges(\n",
+    "    np.logspace(-1., 1., 10), unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
+    ")\n",
+    "geom = WcsGeom.create(\n",
+    "    skydir=(0, 0),\n",
+    "    binsz=0.02,\n",
+    "    width=(10, 8),\n",
+    "    coordsys=\"GAL\",\n",
+    "    proj=\"CAR\",\n",
+    "    axes=[axis],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "maker = MapMaker(geom, 4. * u.deg)\n",
+    "maps = maker.run(obs_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# Make 2D images (for plotting, analysis will be 3D)\n",
+    "images = maker.make_images()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images[\"counts\"].smooth(radius=0.2 * u.deg).plot(stretch=\"sqrt\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images[\"background\"].plot(stretch=\"sqrt\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "residual = images[\"counts\"].copy()\n",
+    "residual.data -= images[\"background\"].data\n",
+    "residual.smooth(5).plot(stretch=\"sqrt\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute PSF kernel\n",
+    "\n",
+    "For the moment we rely on the ObservationList.make_mean_psf() method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "obs_list = data_store.obs_list(obs_ids)\n",
+    "src_pos = SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\")\n",
+    "\n",
+    "table_psf = obs_list.make_mean_psf(src_pos)\n",
+    "psf_kernel = PSFKernel.from_table_psf(\n",
+    "    table_psf, maps[\"exposure\"].geom, max_radius=\"0.3 deg\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute energy dispersion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "energy_axis = geom.get_axis_by_name(\"energy\")\n",
+    "energy = energy_axis.edges * energy_axis.unit\n",
+    "edisp = obs_list.make_mean_edisp(\n",
+    "    position=src_pos, e_true=energy, e_reco=energy\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save maps\n",
+    "\n",
+    "It's common to run the \"precompute\" step and the \"likelihood fit\" step separately,\n",
+    "because often the \"precompute\" of maps, PSF and EDISP is slow if you have a lot of data.\n",
+    "\n",
+    "Here it woudn't really be necessary, because the precompute step (everything above this cell)\n",
+    "takes less than a minute.\n",
+    "\n",
+    "But usually you would do it like this: write precomputed things to FITS files,\n",
+    "and then read them from your script that does the likelihood fitting without\n",
+    "having to run the precomputations again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write\n",
+    "path = Path(\"analysis_3d\")\n",
+    "path.mkdir(exist_ok=True)\n",
+    "maps[\"counts\"].write(str(path / \"counts.fits\"), overwrite=True)\n",
+    "maps[\"background\"].write(str(path / \"background.fits\"), overwrite=True)\n",
+    "maps[\"exposure\"].write(str(path / \"exposure.fits\"), overwrite=True)\n",
+    "psf_kernel.write(str(path / \"psf.fits\"), overwrite=True)\n",
+    "edisp.write(str(path / \"edisp.fits\"), overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read\n",
+    "maps = {\n",
+    "    \"counts\": Map.read(str(path / \"counts.fits\")),\n",
+    "    \"background\": Map.read(str(path / \"background.fits\")),\n",
+    "    \"exposure\": Map.read(str(path / \"exposure.fits\")),\n",
+    "}\n",
+    "psf_kernel = PSFKernel.read(str(path / \"psf.fits\"))\n",
+    "edisp = EnergyDispersion.read(str(path / \"edisp.fits\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cutout\n",
+    "\n",
+    "Let's cut out only part of the map, so that we can have a faster fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmaps = {\n",
+    "    name: m.cutout(SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"), 1.5 * u.deg)\n",
+    "    for name, m in maps.items()\n",
+    "}\n",
+    "cmaps[\"counts\"].sum_over_axes().plot(stretch=\"sqrt\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit mask\n",
+    "\n",
+    "To select a certain region and/or energy range for the fit we can create a fit mask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = Map.from_geom(cmaps[\"counts\"].geom)\n",
+    "\n",
+    "region = CircleSkyRegion(center=src_pos, radius=0.6 * u.deg)\n",
+    "mask.data = mask.geom.region_mask([region])\n",
+    "\n",
+    "mask.get_image_by_idx((0,)).plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition we also exclude the range below 0.3 TeV for the fit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coords = mask.geom.get_coord()\n",
+    "mask.data &= coords[\"energy\"] > 0.3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model fit\n",
+    "\n",
+    "- TODO: Add diffuse emission model? (it's 800 MB, maybe prepare a cutout)\n",
+    "- TODO: compare against true model known for DC1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spatial_model = SkyPointSource(lon_0=\"0.01 deg\", lat_0=\"0.01 deg\")\n",
+    "spectral_model = PowerLaw(\n",
+    "    index=2.2, amplitude=\"3e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
+    ")\n",
+    "model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fit = MapFit(\n",
+    "    model=model,\n",
+    "    counts=cmaps[\"counts\"],\n",
+    "    exposure=cmaps[\"exposure\"],\n",
+    "    background=cmaps[\"background\"],\n",
+    "    mask=mask,\n",
+    "    psf=psf_kernel,\n",
+    "    edisp=edisp,\n",
+    ")\n",
+    "\n",
+    "fit.fit(opts_minuit={\"print_level\": 1})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check model fit\n",
+    "\n",
+    "- plot counts spectrum for some on region (e.g. the one used in 1D spec analysis, 0.2 deg)\n",
+    "- plot residual image for some energy band (e.g. the total one used here)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameter error are not synched back to\n",
+    "# sub model components automatically yet\n",
+    "spec = model.spectral_model.copy()\n",
+    "print(spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For now, we can copy the parameter error manually\n",
+    "spec.parameters.set_parameter_errors(\n",
+    "    {\n",
+    "        \"index\": model.parameters.error(\"index\"),\n",
+    "        \"amplitude\": model.parameters.error(\"amplitude\"),\n",
+    "    }\n",
+    ")\n",
+    "print(spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_range = [0.1, 10] * u.TeV\n",
+    "spec.plot(energy_range, energy_power=2)\n",
+    "spec.plot_error(energy_range, energy_power=2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Analyse the second source in the field of view: G0.9+0.1\n",
+    "* Run the model fit with energy dispersion (pass edisp to MapFit)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/astro_dark_matter.ipynb
+++ b/tutorials/astro_dark_matter.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dark matter utilities\n",
+    "\n",
+    "## Introduction \n",
+    "\n",
+    "Gammapy has some convenience methods for dark matter analyses in [gammapy.astro.darkmatter](http://docs.gammapy.org/dev/astro/darkmatter/index.html). These include J-Factor computation and calculation the expected gamma flux for a number of annihilation channels. They are presented in this notebook. \n",
+    "\n",
+    "The basic concepts of indirect dark matter searches, however, are not explained. So this is aimed at people who already know what the want to do. A good introduction to indirect dark matter searches is given for example in https://arxiv.org/pdf/1012.4515.pdf (Chapter 1 and 5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "As always, we start with some setup for the notebook, and with imports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.astro.darkmatter import (\n",
+    "    profiles,\n",
+    "    JFactory,\n",
+    "    PrimaryFlux,\n",
+    "    compute_dm_flux,\n",
+    ")\n",
+    "\n",
+    "from gammapy.maps import WcsGeom, WcsNDMap\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from matplotlib.colors import LogNorm\n",
+    "from regions import CircleSkyRegion\n",
+    "import astropy.units as u\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Profiles\n",
+    "\n",
+    "The following dark matter profiles are currently implemented. Each model can be scaled to a given density at a certain distance. These parameters are controlled by ``profiles.DMProfile.LOCAL_DENSITY`` and ``profiles.DMProfile.DISTANCE_GC``"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profiles.DMProfile.__subclasses__()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for profile in profiles.DMProfile.__subclasses__():\n",
+    "    p = profile()\n",
+    "    p.scale_to_local_density()\n",
+    "    radii = np.logspace(-3, 2, 100) * u.kpc\n",
+    "    plt.plot(radii, p(radii), label=p.__class__.__name__)\n",
+    "\n",
+    "plt.loglog()\n",
+    "plt.axvline(8.5, linestyle=\"dashed\", color=\"black\", label=\"local density\")\n",
+    "plt.legend()\n",
+    "\n",
+    "print(\n",
+    "    \"The assumed local density is {} at a distance to the GC of {}\".format(\n",
+    "        profiles.DMProfile.LOCAL_DENSITY, profiles.DMProfile.DISTANCE_GC\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## J Factors\n",
+    "\n",
+    "There are utilies to compute J-Factor maps can can serve as a basis to compute J-Factors for certain regions. In the following we compute a J-Factor map for the Galactic Centre region"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile = profiles.NFWProfile()\n",
+    "\n",
+    "# Adopt standard values used in HESS\n",
+    "profiles.DMProfile.DISTANCE_GC = 8.5 * u.kpc\n",
+    "profiles.DMProfile.LOCAL_DENSITY = 0.39 * u.Unit(\"GeV / cm3\")\n",
+    "\n",
+    "profile.scale_to_local_density()\n",
+    "\n",
+    "position = SkyCoord(0.0, 0.0, frame=\"galactic\", unit=\"deg\")\n",
+    "geom = WcsGeom.create(binsz=0.05, skydir=position, width=3.0, coordsys=\"GAL\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jfactory = JFactory(\n",
+    "    geom=geom, profile=profile, distance=profiles.DMProfile.DISTANCE_GC\n",
+    ")\n",
+    "jfact = jfactory.compute_jfactor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jfact_map = WcsNDMap(geom=geom, data=jfact.value, unit=jfact.unit)\n",
+    "fig, ax, im = jfact_map.plot(cmap=\"viridis\", norm=LogNorm(), add_cbar=True)\n",
+    "plt.title(\"J-Factor [{}]\".format(jfact_map.unit))\n",
+    "\n",
+    "# 1 deg circle usually used in H.E.S.S. analyses\n",
+    "sky_reg = CircleSkyRegion(center=position, radius=1 * u.deg)\n",
+    "pix_reg = sky_reg.to_pixel(wcs=geom.wcs)\n",
+    "pix_reg.plot(ax=ax, facecolor=\"none\", edgecolor=\"red\", label=\"1 deg circle\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: https://arxiv.org/abs/1607.08142 cite 2.67e21 without the the +/- 0.3 deg band around the plane\n",
+    "mask = pix_reg.to_mask()\n",
+    "data = mask.multiply(jfact.data)\n",
+    "total_jfact = np.sum(data)\n",
+    "print(\n",
+    "    \"J-factor in 1 deg circle around GC assuming a \"\n",
+    "    \"{} is {:.3g}\".format(profile.__class__.__name__, total_jfact)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gamma-ray spectra at production\n",
+    "\n",
+    "The gamma-ray spectrum per annihilation is a further ingredient for a dark matter analysis. The following annihilation channels are supported. For more info see https://arxiv.org/pdf/1012.4515.pdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluxes = PrimaryFlux(mDM=\"1 TeV\", channel=\"eL\")\n",
+    "print(fluxes.allowed_channels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(4, 1, figsize=(6, 16))\n",
+    "mDMs = [0.01, 0.1, 1, 10] * u.TeV\n",
+    "\n",
+    "for mDM, ax in zip(mDMs, axes):\n",
+    "    fluxes.mDM = mDM\n",
+    "    ax.set_title(r\"m$_{{\\mathrm{{DM}}}}$ = {}\".format(mDM))\n",
+    "    ax.set_yscale(\"log\")\n",
+    "    ax.set_ylabel(\"dN/dE\")\n",
+    "\n",
+    "    for channel in [\"tau\", \"mu\", \"b\", \"Z\"]:\n",
+    "        fluxes.channel = channel\n",
+    "        fluxes.table_model.plot(\n",
+    "            energy_range=[mDM / 100, mDM],\n",
+    "            ax=ax,\n",
+    "            label=channel,\n",
+    "            flux_unit=\"1/GeV\",\n",
+    "        )\n",
+    "\n",
+    "axes[0].legend()\n",
+    "plt.subplots_adjust(hspace=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Flux maps\n",
+    "\n",
+    "Finally flux maps can be produced like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux = compute_dm_flux(\n",
+    "    jfact=jfact,\n",
+    "    prim_flux=fluxes,\n",
+    "    x_section=\"1e-26 cm3s-1\",\n",
+    "    energy_range=[0.1, 10] * u.TeV,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_map = WcsNDMap(geom=geom, data=flux.value, unit=flux.unit)\n",
+    "\n",
+    "fig, ax, im = flux_map.plot(cmap=\"viridis\", norm=LogNorm(), add_cbar=True)\n",
+    "plt.title(\n",
+    "    \"Flux [{}]\\n m$_{{DM}}$={}, channel={}\".format(\n",
+    "        flux_map.unit, fluxes.mDM.to(\"TeV\"), fluxes.channel\n",
+    "    )\n",
+    ");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/astropy_introduction.ipynb
+++ b/tutorials/astropy_introduction.ipynb
@@ -1,0 +1,739 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Astropy introduction for Gammapy users\n",
+    "\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "To become efficient at using Gammapy, you have to learn to use some parts of Astropy, especially FITS I/O and how to work with Table, Quantity, SkyCoord, Angle and Time objects.\n",
+    "\n",
+    "Gammapy is built on Astropy, meaning that data in Gammapy is often stored in Astropy objects, and the methods on those objects are part of the public Gammapy API.\n",
+    "\n",
+    "This tutorial is a quick introduction to the parts of Astropy you should know become familiar with to use Gammapy (or also when not using Gammapy, just doing astronomy from Python scripts). The largest part is devoted to tables, which are a the most important building block for Gammapy (event lists, flux points, light curves, ... many other thing are store in Table objects).\n",
+    "\n",
+    "We will:\n",
+    "\n",
+    "- open and write fits files with [io.fits](http://docs.astropy.org/en/stable/io/fits/index.html)\n",
+    "- manipulate [coordinates](http://docs.astropy.org/en/stable/coordinates/): [SkyCoord](http://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html)  and [Angle](http://docs.astropy.org/en/stable/coordinates/angles.html) classes\n",
+    "- use [units](http://docs.astropy.org/en/stable/units/index.html) and [Quantities](http://docs.astropy.org/en/stable/api/astropy.units.Quantity.html). See also this [tutorial](http://www.astropy.org/astropy-tutorials/Quantities.html)\n",
+    "- manipulate [Times and Dates](http://docs.astropy.org/en/stable/time/index.html)\n",
+    "- use [tables](http://docs.astropy.org/en/stable/table/index.html) with the [Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html) class with the Fermi catalog\n",
+    "- define regions in the sky with the [region](http://astropy-regions.readthedocs.io/en/latest/getting_started.html) package\n",
+    "\n",
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# to make plots appear in the notebook\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If something below doesn't work, here's how you\n",
+    "# can check what version of Numpy and Astropy you have\n",
+    "# All examples should work with Astropy 1.3,\n",
+    "# most even with Astropy 1.0\n",
+    "import numpy as np\n",
+    "import astropy\n",
+    "\n",
+    "print(\"numpy:\", np.__version__)\n",
+    "print(\"astropy:\", astropy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Units, Quantities and constants\n",
+    "import astropy.units as u\n",
+    "from astropy.units import Quantity\n",
+    "import astropy.constants as cst\n",
+    "\n",
+    "from astropy.io import fits\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from astropy.time import Time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Units and constants\n",
+    "\n",
+    "### Basic usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# One can create a Quantity like this\n",
+    "L = Quantity(1e35, unit=\"erg/s\")\n",
+    "# or like this\n",
+    "d = 8 * u.kpc\n",
+    "\n",
+    "# then one can produce new Quantities\n",
+    "flux = L / (4 * np.pi * d ** 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# And convert its value to an equivalent unit\n",
+    "flux.to(\"erg cm-2 s-1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux.to(\"W/m2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More generally a Quantity is a numpy array with a unit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "E = np.logspace(1, 4, 10) * u.GeV\n",
+    "E.to(\"TeV\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we compute the interaction time of protons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_eff = 30 * u.mbarn\n",
+    "density = 1 * u.cm ** -3\n",
+    "\n",
+    "interaction_time = (density * x_eff * cst.c) ** -1\n",
+    "\n",
+    "interaction_time.to(\"Myr\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Use Quantities in functions\n",
+    "\n",
+    "We compute here the energy loss rate of an electron of kinetic energy E in magnetic field B. See formula (5B10) in this [lecture](http://www.cv.nrao.edu/course/astr534/SynchrotronPower.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def electron_energy_loss_rate(B, E):\n",
+    "    \"\"\" energy loss rate of an electron of kinetic energy E in magnetic field B\n",
+    "    \"\"\"\n",
+    "    U_B = B ** 2 / (2 * cst.mu0)\n",
+    "    gamma = (\n",
+    "        E / (cst.m_e * cst.c ** 2) + 1\n",
+    "    )  # note that this works only because E/(cst.m_e*cst.c**2) is dimensionless\n",
+    "    beta = np.sqrt(1 - 1 / gamma ** 2)\n",
+    "    return 4. / 3. * cst.sigma_T * cst.c * gamma ** 2 * beta ** 2 * U_B\n",
+    "\n",
+    "\n",
+    "print(electron_energy_loss_rate(1e-5 * u.G, 1 * u.TeV).to(\"erg/s\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now plot it\n",
+    "E_elec = np.logspace(-1., 6, 100) * u.MeV\n",
+    "B = 1 * u.G\n",
+    "y = (E_elec / electron_energy_loss_rate(B, E_elec)).to(\"yr\")\n",
+    "plt.loglog(E_elec, y);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A frequent issue is homogeneity. One can use decorators to ensure it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This ensures that B and E are homogeneous to magnetic field strength and energy\n",
+    "# If not will raise a UnitError exception\n",
+    "@u.quantity_input(B=u.T, E=u.J)\n",
+    "def electron_energy_loss_rate(B, E):\n",
+    "    \"\"\" energy loss rate of an electron of kinetic energy E in magnetic field B\n",
+    "    \"\"\"\n",
+    "    U_B = B ** 2 / (2 * cst.mu0)\n",
+    "    gamma = (\n",
+    "        E / (cst.m_e * cst.c ** 2) + 1\n",
+    "    )  # note that this works only because E/(cst.m_e*cst.c**2) is dimensionless\n",
+    "    beta = np.sqrt(1 - 1 / gamma ** 2)\n",
+    "    return 4. / 3. * cst.sigma_T * cst.c * gamma ** 2 * beta ** 2 * U_B\n",
+    "\n",
+    "\n",
+    "# Now try it\n",
+    "try:\n",
+    "    print(electron_energy_loss_rate(1e-5 * u.G, 1 * u.Hz).to(\"erg/s\"))\n",
+    "except u.UnitsError as message:\n",
+    "    print(\"Incorrect unit: \" + str(message))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Coordinates\n",
+    "\n",
+    "Note that SkyCoord are arrays of coordinates. We will see that in more detail in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Different ways to create a SkyCoord\n",
+    "c1 = SkyCoord(10.625, 41.2, frame=\"icrs\", unit=\"deg\")\n",
+    "c1 = SkyCoord(\"00h42m30s\", \"+41d12m00s\", frame=\"icrs\")\n",
+    "\n",
+    "c2 = SkyCoord(83.633083, 22.0145, unit=\"deg\")\n",
+    "# If you have internet access, you could also use this to define the `source_pos`:\n",
+    "# c2 = SkyCoord.from_name(\"Crab\")     # Get the name from CDS\n",
+    "\n",
+    "print(c1.ra, c2.dec)\n",
+    "# separation returns an Angle object\n",
+    "print(\"Distance to Crab: \", c1.separation(c2))\n",
+    "print(\"Distance to Crab: \", c1.separation(c2).degree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Coordinate transformations\n",
+    "\n",
+    "How to change between coordinate frames. The Crab in Galactic coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c2b = c2.galactic\n",
+    "print(c2b)\n",
+    "print(c2b.l, c2b.b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time \n",
+    "\n",
+    "Is the Crab visible now?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "now = Time.now()\n",
+    "print(now)\n",
+    "print(now.mjd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the location for the AltAz system\n",
+    "from astropy.coordinates import EarthLocation, AltAz\n",
+    "\n",
+    "paris = EarthLocation(lat=48.8567 * u.deg, lon=2.3508 * u.deg)\n",
+    "\n",
+    "# calculate the horizontal coordinates\n",
+    "crab_altaz = c2.transform_to(AltAz(obstime=now, location=paris))\n",
+    "\n",
+    "print(crab_altaz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Table: Manipulating the 3FGL catalog\n",
+    "\n",
+    "Here we are going to do some selections with the 3FGL catalog. To do so we use the Table class from astropy.\n",
+    "\n",
+    "### Accessing the table\n",
+    "First, we need to open the catalog in a Table. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open Fermi 3FGL from the repo\n",
+    "table = Table.read(\"../datasets/catalogs/fermi/gll_psc_v16.fit.gz\", hdu=1)\n",
+    "# Alternatively, one can grab it from the server.\n",
+    "# table = Table.read(\"http://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/gll_psc_v16.fit\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that a single FITS file might contain different tables in different HDUs\n",
+    "filename = \"../datasets/catalogs/fermi/gll_psc_v16.fit.gz\"\n",
+    "# You can load a `fits.HDUList` and check the extension names\n",
+    "print([_.name for _ in fits.open(filename)])\n",
+    "# Then you can load by name or integer index via the `hdu` option\n",
+    "extended_source_table = Table.read(filename, hdu=\"ExtendedSources\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### General informations on the Table\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Statistics on each column\n",
+    "table.info(\"stats\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### list of column names\n",
+    "table.colnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HTML display\n",
+    "# table.show_in_browser(jsviewer=True)\n",
+    "# table.show_in_notebook(jsviewer=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing the table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The header keywords are stored as a dict\n",
+    "# table.meta\n",
+    "table.meta[\"TSMIN\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First row\n",
+    "table[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Spectral index of the 5 first entries\n",
+    "table[:5][\"Spectral_Index\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Which source has the lowest spectral index?\n",
+    "row = table[np.argmin(table[\"Spectral_Index\"])]\n",
+    "print(\n",
+    "    \"Hardest source: \",\n",
+    "    row[\"Source_Name\"],\n",
+    "    row[\"CLASS1\"],\n",
+    "    row[\"Spectral_Index\"],\n",
+    ")\n",
+    "\n",
+    "# Which source has the largest spectral index?\n",
+    "row = table[np.argmax(table[\"Spectral_Index\"])]\n",
+    "print(\n",
+    "    \"Softest source: \",\n",
+    "    row[\"Source_Name\"],\n",
+    "    row[\"CLASS1\"],\n",
+    "    row[\"Spectral_Index\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quantities and SkyCoords from a Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fluxes = table[\"nuFnu1000_3000\"].quantity\n",
+    "fluxes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coord = SkyCoord(table[\"GLON\"], table[\"GLAT\"], frame=\"galactic\")\n",
+    "coord.fk5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Selections in a Table\n",
+    "\n",
+    "Here we select Sources according to their class and do some whole sky chart"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get coordinates of FSRQs\n",
+    "fsrq = np.where(\n",
+    "    np.logical_or(table[\"CLASS1\"] == \"fsrq \", table[\"CLASS1\"] == \"FSQR \")\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is here for plotting purpose...\n",
+    "# glon = glon.wrap_at(180*u.degree)\n",
+    "\n",
+    "# Open figure\n",
+    "fig = plt.figure(figsize=(14, 8))\n",
+    "ax = fig.add_subplot(111, projection=\"aitoff\")\n",
+    "ax.scatter(\n",
+    "    coord[fsrq].l.wrap_at(180 * u.degree).radian,\n",
+    "    coord[fsrq].b.radian,\n",
+    "    color=\"k\",\n",
+    "    label=\"FSRQ\",\n",
+    ")\n",
+    "ax.grid(True)\n",
+    "ax.legend()\n",
+    "# ax.invert_xaxis()  -> This does not work for projections..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now do it for a series of classes\n",
+    "fig = plt.figure(figsize=(14, 10))\n",
+    "ax = fig.add_subplot(111, projection=\"aitoff\")\n",
+    "\n",
+    "source_classes = [\"\", \"psr\", \"spp\", \"fsrq\", \"bll\", \"bin\"]\n",
+    "\n",
+    "for source_class in source_classes:\n",
+    "    # We select elements with correct class in upper or lower characters\n",
+    "    index = np.array(\n",
+    "        [_.strip().lower() == source_class for _ in table[\"CLASS1\"]]\n",
+    "    )\n",
+    "\n",
+    "    label = source_class if source_class else \"unid\"\n",
+    "\n",
+    "    ax.scatter(\n",
+    "        coord[index].l.wrap_at(180 * u.degree).radian,\n",
+    "        coord[index].b.radian,\n",
+    "        label=label,\n",
+    "    )\n",
+    "\n",
+    "ax.grid(True)\n",
+    "ax.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating tables\n",
+    "\n",
+    "A `Table` is basically a dict mapping column names to column values, where a column value is a Numpy array (or Quantity object, which is a Numpy array sub-class). This implies that adding columns to a table after creation is nice and easy, but adding a row is hard and slow, basically all data has to be copied and all objects that make up a Table have to be re-created.\n",
+    "\n",
+    "Here's one way to create a `Table` from scratch: put the data into a list of dicts, and then call the `Table` constructor with the `rows` option."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = [dict(a=42, b=\"spam\"), dict(a=43, b=\"ham\")]\n",
+    "my_table = Table(rows=rows)\n",
+    "my_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Writing tables\n",
+    "\n",
+    "Writing tables to files is easy, you can just give the filename and format you want.\n",
+    "If you run a script repeatedly you might want to add `overwrite=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Examples how to write a table in different formats\n",
+    "# Uncomment if you really want to do it\n",
+    "\n",
+    "# my_table.write('/tmp/table.fits', format='fits')\n",
+    "# my_table.write('/tmp/table.fits.gz', format='fits')\n",
+    "# my_table.write('/tmp/table.ecsv', format='ascii.ecsv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "FITS (and some other formats, e.g. HDF5) support writing multiple tables to a single file.\n",
+    "The `table.write` API doesn't support that directly yet.\n",
+    "Here's how you can currently write multiple tables to a FITS file: you have to convert the `astropy.table.Table` objects to `astropy.io.fits.BinTable` objects, and then store them in a `astropy.io.fits.HDUList` objects and call `HDUList.writeto`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_table2 = Table(data=dict(a=[1, 2, 3]))\n",
+    "hdu_list = fits.HDUList(\n",
+    "    [\n",
+    "        fits.PrimaryHDU(),  # need an empty primary HDU\n",
+    "        fits.table_to_hdu(my_table),\n",
+    "        fits.table_to_hdu(my_table2),\n",
+    "    ]\n",
+    ")\n",
+    "# hdu_list.writeto('tables.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tables and pandas\n",
+    "\n",
+    "[pandas](http://pandas.pydata.org/) is one of the most-used packages in the scientific Python stack. Numpy provides the `ndarray` object and functions that operate on `ndarray` objects. Pandas provides the `Dataframe` and `Series` objects, which roughly correspond to the Astropy `Table` and `Column` objects. While both `pandas.Dataframe` and `astropy.table.Table` can often be used to work with tabular data, each has features that the other doesn't. When Astropy was started, it was decided to not base it on `pandas.Dataframe`, but to introduce `Table`, mainly because `pandas.Dataframe` doesn't support multi-dimensional columns, but FITS does and astronomers use sometimes.\n",
+    "\n",
+    "But `pandas.Dataframe` has a ton of features that `Table` doesn't, and is highly optimised, so if you find something to be hard with `Table`, you can convert it to a `Dataframe` and do your work there. As explained in the [interfacing with the pandas package](http://docs.astropy.org/en/stable/table/pandas.html) page in the Astropy docs, it is easy to go back and forth between Table and Dataframe:\n",
+    "\n",
+    "    table = Table.from_pandas(dataframe)\n",
+    "    dataframe = table.to_pandas()\n",
+    "\n",
+    "Let's try it out with the Fermi-LAT catalog.\n",
+    "\n",
+    "One little trick is needed when converting to a dataframe: we need to drop the multi-dimensional columns that the 3FGL catalog uses for a few columns (flux up/down errors, and lightcurves):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scalar_colnames = tuple(\n",
+    "    name for name in table.colnames if len(table[name].shape) <= 1\n",
+    ")\n",
+    "data_frame = table[scalar_colnames].to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you want to have a quick-look at the dataframe:\n",
+    "# data_frame\n",
+    "# data_frame.info()\n",
+    "# data_frame.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Just do demonstrate one of the useful DataFrame methods,\n",
+    "# this is how you can count the number of sources in each class:\n",
+    "data_frame[\"CLASS1\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you'd like to learn more about pandas, have a look [here](http://pandas.pydata.org/pandas-docs/stable/10min.html) or [here](http://nbviewer.jupyter.org/github/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/03.00-Introduction-to-Pandas.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "- When searched for the hardest and softest sources in 3FGL we did not look at the type of spectrum (PL, ECPL etc), find the hardest and softest PL sources instead. \n",
+    "- Replot the full sky chart of sources in ra-dec instead of galactic coordinates\n",
+    "- Find the 3FGL sources visible from Paris now"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/cta_1dc_introduction.ipynb
+++ b/tutorials/cta_1dc_introduction.ipynb
@@ -1,0 +1,1190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![CTA first data challenge logo](images/cta-1dc.png)\n",
+    "\n",
+    "# CTA first data challenge (1DC) with Gammapy\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "The [CTA observatory](https://www.cta-observatory.org/) has started a first data challenge (\"CTA 1DC\"), focusing on high-level data analysis. Gammapy is a prototype for the CTA science tools (see [Gammapy proceeding from ICRC 2017](https://github.com/gammapy/icrc2017-gammapy-poster/blob/master/proceeding/gammapy-icrc2017.pdf)), and while many things are work in progress (most importantly: source and background modeling and cube analysis), you can use it already to analyse the simulated CTA data.\n",
+    "\n",
+    "The main page for CTA 1DC is here:\n",
+    "https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki (CTA internal)\n",
+    "\n",
+    "There you will find information on 1DC sky models, data access, data organisation, simulation and analysis tools, simulated observations, as well as contact information if you have any questions or comments.\n",
+    "\n",
+    "### This tutorial notebook\n",
+    "\n",
+    "This notebook shows you how to get started with CTA 1DC data and what it contains.\n",
+    "\n",
+    "You will learn how to use Astropy and Gammapy to:\n",
+    "\n",
+    "* access event data\n",
+    "* access instrument response functions (IRFs)\n",
+    "* use index files and the ``gammapy.data.DataStore`` to access all data\n",
+    "* use the observation index file to select the observations you're interested in\n",
+    "* read model XML files from Python (not integrated in Gammapy yet)\n",
+    "\n",
+    "This is to familiarise ourselves with the data files and to get an overview.\n",
+    "\n",
+    "### Further information\n",
+    "\n",
+    "How to analyse the CTA 1DC data with Gammapy (make an image and spectrum) is shown in a second notebook [cta_data_analysis.ipynb](cta_data_analysis.ipynb). If you prefer, you can of course just skim or skip this notebook and go straight to second one.\n",
+    "\n",
+    "More tutorial notebooks for Gammapy are [here](../index.ipynb),\n",
+    "the Gammapy Sphinx docs are at at http://docs.gammapy.org\n",
+    "If you have a Gammapy-related question, please send an email to to Gammapy mailing list at http://groups.google.com/group/gammapy (registration required) or if you have an issue or feature request, file an issue here: https://github.com/gammapy/gammapy/issues/new (free Github account required, takes 1 min to set up).\n",
+    "\n",
+    "Please note that the 1DC data isn't public and results should be shared on CTA Redmine, as described here: https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki#Sharing-of-analysis-results. Unfortunately there's no good way yet to share Jupyter notebooks in CTA, as there is e.g. on Github and nbviewer which can show any public noteook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook and Gammapy Setup\n",
+    "\n",
+    "Before we get started, please execcute the following code cells.\n",
+    "\n",
+    "The first one configures the notebooks so that plots are shown inline (if you don't do this, separate windows will pop up). The second cell imports and checks the version of the packages we will use below. If you're missing some packages, install them and then select \"Kernel -> Restart\" above to restart this notebook.\n",
+    "\n",
+    "In case you're new to Jupyter notebooks: to execute a cell, select it, then type \"SHIFT\" + \"ENTER\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy\n",
+    "import gammapy\n",
+    "\n",
+    "print(\"numpy:\", np.__version__)\n",
+    "print(\"astropy:\", astropy.__version__)\n",
+    "print(\"gammapy:\", gammapy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting the 1DC data\n",
+    "\n",
+    "You can find infos how to download the 1DC data here: \n",
+    "https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki#Data-access\n",
+    "\n",
+    "Overall it's quite large (20 GB) and will take a while to download. You can just download a subset of the \"gps\", \"gc\", \"egal\" or \"agn\" datasets, the ones you're interested in.\n",
+    "\n",
+    "**In this tutorial, we will only use the \"gps\" (Galactic center survey) dataset, so maybe you could start by downloading that first.**\n",
+    "\n",
+    "While you wait, we strongly recommend you go over some [CTA basics](https://www.youtube.com/playlist?list=PLq3ItKoU0hy7ED6m1eve6WIFs7ibcv3YR) as well as some [Python basics](https://www.youtube.com/playlist?list=PL-Qryc-SVnnu0tPV623TFnrAEQLykkZF5) to prepare yourself for this tutorial.\n",
+    "\n",
+    "Got the data?\n",
+    "\n",
+    "Assuming you've followed the instructions, you should have the ``CTADATA`` environment variable pointing to the folder where all data is located. (Gammapy doesn't need or use the ``CALDB`` environment variable.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!echo $CTADATA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls $CTADATA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can find a description of the directories and files here:\n",
+    "https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki/Data_organisation\n",
+    "\n",
+    "A very detailed specification of the data formats is here:\n",
+    "http://gamma-astro-data-formats.readthedocs.io/\n",
+    "\n",
+    "But actually, instead of reading those pages, let's just explore the data and see how to load it with Gammapy ...\n",
+    "\n",
+    "Before we start, just in case the commands above show that you don't have `CTADATA` set:\n",
+    "\n",
+    "* you either have to exit the \"jupyter notebook\" command on your terminal, set the environment variable (I'm using bash and added the command `export CTADATA=/Users/deil/work/cta-dc/data/1dc/1dc` to my `~/.profile` file and then did `source ~/.profile`), then re-start Jupyter and this notebook.\n",
+    "* or you can set the environment variable by uncommentting the code in the following cell, setting the correct path, then executing it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import os\n",
+    "# os.environ['CTADATA'] = '/Users/deil/work/cta-dc/data/1dc/1dc'\n",
+    "# !echo $CTADATA\n",
+    "# !ls $CTADATA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Let's have a look around at the directories and files in `$CTADATA`.\n",
+    "\n",
+    "We will look at the `data` folder with events, the `caldb` folder with the IRFs and the `index` folder with the index files. At the end, we will also mention what the `model` and `obs` folder contains, but they aren't used with Gammapy, at least not at the moment.\n",
+    "\n",
+    "## EVENT data\n",
+    "\n",
+    "First, the EVENT data (RA, DEC, ENERGY, TIME of each photon or hadronic background event) is in the `data/baseline` folder, with one observation per file. The \"baseline\" refers to the assumed CTA array that was used to simulate the observations. The number in the filename is the observation identifier `OBS_ID` of the observation. Observations are ~ 30 minutes, pointing at a fixed location on the sky."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls $CTADATA"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls $CTADATA/data/baseline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls $CTADATA/data/baseline/gps | head -n3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# There's 3270 observations and 11 GB of event data for the gps dataset\n",
+    "!ls $CTADATA/data/baseline/gps | wc -l\n",
+    "!du -hs $CTADATA/data/baseline/gps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's open up the first event list using the Gammapy `EventList` class, which contains the ``EVENTS`` table data via the ``table`` attribute as an Astropy `Table` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.data import EventList\n",
+    "\n",
+    "events = EventList.read(\"$CTADATA/data/baseline/gps/gps_baseline_110000.fits\")\n",
+    "print(type(events))\n",
+    "print(type(events.table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First event (using [] for \"indexing\")\n",
+    "events.table[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First few events (using [] for \"slicing\")\n",
+    "events.table[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Event times can be accessed as Astropy Time objects\n",
+    "print(type(events.time))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events.time[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert event time to more human-readable format\n",
+    "print(events.time[:2].fits)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Event positions can be accessed as Astropy SkyCoord objects\n",
+    "print(type(events.radec))\n",
+    "events.radec[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events.galactic[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The event header information is stored\n",
+    "# in the `events.table.meta` dictionary\n",
+    "print(type(events.table.meta))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# E.g. to get the observation pointing position in degrees:\n",
+    "events.table.meta[\"RA_PNT\"], events.table.meta[\"DEC_PNT\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## EVENT analysis example\n",
+    "\n",
+    "As an example how to work with EVENT data, let's look at the spatial and energy distribution of the events for a single run.\n",
+    "\n",
+    "Note that EVENT data in Gammapy is just stored in an Astropy Table, which is basically a dictionary mapping column names to column data, where the column data is a Numpy array. This means you can efficienly process it from Python using any of the scientific Python tools you like (e.g. Numpy, Scipy, scikit-image, scikit-learn, ...)\n",
+    "\n",
+    "### EVENT spatial distribution\n",
+    "\n",
+    "To illustrate a bit how to work with EVENT table an header data,\n",
+    "let's plot the event positions as well as the pointing position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Event positions\n",
+    "pos = events.galactic[::300]  # sub-sample every 100th event\n",
+    "plt.scatter(pos.l.wrap_at(\"180 deg\").deg, pos.b.deg, s=10)\n",
+    "# Pointing position\n",
+    "pos_pnt = events.pointing_radec.galactic\n",
+    "plt.scatter(\n",
+    "    pos_pnt.l.wrap_at(\"180 deg\").deg, pos_pnt.b.deg, marker=\"*\", s=400, c=\"red\"\n",
+    ")\n",
+    "plt.xlabel(\"Galactic longitude (deg)\")\n",
+    "plt.ylabel(\"Galactic latitude (deg)\")\n",
+    "pos_pnt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### EVENT energy distribution\n",
+    "\n",
+    "Let's have a look at the event energy distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy = events.table[\"ENERGY\"].data\n",
+    "energy_bins = np.logspace(-2, 2, num=100)\n",
+    "plt.hist(energy, bins=energy_bins)\n",
+    "plt.semilogx()\n",
+    "plt.xlabel(\"Event energy (TeV)\")\n",
+    "plt.ylabel(\"Number of events\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A double-peak, at ~ 30 GeV and ~ 100 GeV? .... let's try to find out what's going on ...\n",
+    "\n",
+    "### EVENT MC_ID\n",
+    "\n",
+    "One idea could be to split the data into gamma-ray and hadronic background events.\n",
+    "Now from looking at the FITS header, one can see that ``MC_ID == 1`` is the hadronic background, and the other values are for different gamma-ray emission components."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_gamma = events.table[\"MC_ID\"] != 1\n",
+    "print(\"Number of events: \", len(events.table))\n",
+    "print(\"Number of gammas: \", is_gamma.sum())\n",
+    "print(\"Number of hadrons: \", len(events.table) - is_gamma.sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy = events.table[\"ENERGY\"].data\n",
+    "energy_bins = np.logspace(-2, 2, num=100)\n",
+    "opts = dict(bins=energy_bins, normed=True, histtype=\"step\")\n",
+    "plt.hist(energy[~is_gamma], label=\"hadron\", **opts)\n",
+    "plt.hist(energy[is_gamma], label=\"gamma\", **opts)\n",
+    "plt.loglog()\n",
+    "plt.xlabel(\"Event energy (TeV)\")\n",
+    "plt.ylabel(\"Number of events\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected, the energy spectra are roughly power-laws. \n",
+    "When plotting in log-log, one can see that the spectra are roughly power-laws (as expected), and the \"double peak\" we saw before looks more like a \"double energy threshold\" pattern.\n",
+    "It's there for gammas and background, and below 100 GeV the signal to background ratio is lower.\n",
+    "\n",
+    "What we're seeing here is the result of a mixed-array in CTA with LSTs, MSTs and SSTs, which  have different energy thresholds:\n",
+    "\n",
+    "* ~ 30 GeV is the energy threshold of the LSTs\n",
+    "* ~ 100 GeV is the energy threshold of the MSTs\n",
+    "* the energy threshold of the SSTs is at a few TeV and doesn't show up as a clear feature in the gamma and background energy distribution (probably the rise in slope in gamma in the 1-10 TeV range is due to the SSTs).\n",
+    "\n",
+    "Let's look a little deeper and also check the event offset distribution in the field of view ...\n",
+    "\n",
+    "### EVENT FOV offset\n",
+    "\n",
+    "The event position and offset in the field of view (FOV) can be computed from the event RA, DEC position and the observation pointing RA, DEC position.\n",
+    "\n",
+    "But actually, the field of view position is stored as extra columns in the EVENT list: ``DETX`` and ``DETY`` (angles in degree, I think RA / DEC aligned field of view system).\n",
+    "\n",
+    "I presume (hope) this unnecessary information will be dropped from the CTA event lists in the future to save some space (make the CTA DL3 data ~25% smaller), but for now, let's use those columns to compute the field of view offset and look at the offset-energy distribution of the events."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_bins = 10 ** np.linspace(-2, 2, 100)\n",
+    "offset_bins = np.arange(0, 5, 0.1)\n",
+    "\n",
+    "t = events.table\n",
+    "offset = np.sqrt(t[\"DETX\"] ** 2 + t[\"DETY\"] ** 2)\n",
+    "hist = np.histogram2d(\n",
+    "    x=t[\"ENERGY\"], y=offset, bins=(energy_bins, offset_bins)\n",
+    ")[0].T\n",
+    "\n",
+    "from matplotlib.colors import LogNorm\n",
+    "\n",
+    "plt.pcolormesh(energy_bins, offset_bins, hist, norm=LogNorm())\n",
+    "plt.semilogx()\n",
+    "plt.colorbar()\n",
+    "plt.xlabel(\"Energy (TeV)\")\n",
+    "plt.ylabel(\"Offset (deg)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So the CTA field of view increases with energy in steps. The energy distribution we saw before was the combination of the energy distribution at all offsets. Even at a single offset, the double energy-threshold at ~ 30 GeV and ~ 100 GeV is present.\n",
+    "\n",
+    "### Stacking EVENTS tables\n",
+    "\n",
+    "As a final example of how to work with event lists, here's now to apply arbitrary event selections and how to stack events tables from several observations into a single event list. \n",
+    "\n",
+    "We will just use `astropy.table.Table` directly, not go via the `gammapy.data.EventList` class. Note that you can always make an `EventList` object from a `Table` object via `event_list = EventList(table)`. One point to keep in mind is that `Table.read` doesn't resolve environment variables in filenames, so we'll use the Python standard library `os` package to construct the filenames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.table import Table\n",
+    "from astropy.table import vstack as table_vstack\n",
+    "\n",
+    "filename = os.path.join(\n",
+    "    os.environ[\"CTADATA\"], \"data/baseline/gps/gps_baseline_110000.fits\"\n",
+    ")\n",
+    "t1 = Table.read(filename, hdu=\"EVENTS\")\n",
+    "\n",
+    "filename = os.path.join(\n",
+    "    os.environ[\"CTADATA\"], \"data/baseline/gps/gps_baseline_110001.fits\"\n",
+    ")\n",
+    "t2 = Table.read(filename, hdu=\"EVENTS\")\n",
+    "tables = [t1, t2]\n",
+    "table = table_vstack(tables, metadata_conflicts=\"silent\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Number of events: \", len(table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's select gamma rays with energy above 10 TeV\n",
+    "mask_mc_id = table[\"MC_ID\"] != 1\n",
+    "mask_energy = table[\"ENERGY\"] > 10\n",
+    "mask = mask_mc_id & mask_energy\n",
+    "table2 = table[mask]\n",
+    "print(\"Number of events after selection:\", len(table2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When processing a lot or all of the 1DC events, you would write a for loop, and apply the event selection before putting the table in the list of tables, or you might run out of memory. An example is [here](https://github.com/gammasky/cta-dc/blob/master/data/cta_1dc_make_allsky_images.py).\n",
+    "\n",
+    "That's all for ``EVENTS``. You now know what every column in the event table contains, and how to work with event list tables using ``gammapy.data.EventList`` and ``astropy.table.Table``. \n",
+    "\n",
+    "Just in case that there is some observation parameter in the FITS EVENTS header that you're interested in, you can find the full description of the keys you can access via the ``events.table.meta`` dictionary [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/events/events.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## IRFs\n",
+    "\n",
+    "The CTA instrument reponse functions (IRFs) are given as FITS files in the `caldb` folder.\n",
+    "\n",
+    "Note that this is not realistic. Real CTA data at the DL3 level (what we have here, what users get) will mostly likely have per-observation or per-time interval IRFs, and the IRFs will not be stored in a separate CALDB folder, but distributed with the EVENTS (probably in the same file, or at least in the same folder, so that it's together).\n",
+    "\n",
+    "For now, the EVENT to IRF association (i.e. which IRF is the right one for given EVENTS) is done by index files. We will discuss those in the next section, but before we do, let's look at the CTA IRFs for one given configuration: `South_z20_50h`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!(cd $CTADATA && tree caldb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's look at the content of one of the IRF FITS files.\n",
+    "# IRFs are stored in `BinTable` HDUs in a weird format\n",
+    "# that you don't need to care about because it's implemented in Gammapy\n",
+    "irf_filename = os.path.join(\n",
+    "    os.environ[\"CTADATA\"], \"caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    ")\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "hdu_list = fits.open(irf_filename)\n",
+    "hdu_list.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Effective area\n",
+    "\n",
+    "The effective area is given as a 2-dim array with energy and field of view offset axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.irf import EffectiveAreaTable2D\n",
+    "\n",
+    "aeff = EffectiveAreaTable2D.read(irf_filename, hdu=\"EFFECTIVE AREA\")\n",
+    "print(type(aeff))\n",
+    "print(type(aeff.data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(aeff.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aeff.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the on-axis effective area at 10 TeV?\n",
+    "aeff.data.evaluate(energy=\"10 TeV\", offset=\"0 deg\").to(\"km2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is how you slice out an `EffectiveAreaTable` object\n",
+    "# at a given field of view offset for analysis\n",
+    "aeff.to_effective_area_table(offset=\"1 deg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Energy dispersion\n",
+    "\n",
+    "Let's have a look at the CTA energy dispersion with three axes: true energy, fov offset and migra = e_reco / e_true and has dP / dmigra as value.\n",
+    "\n",
+    "Similar to the event energy distribution above, we can see the mixed-telescope array reflected in the EDISP.\n",
+    "At low energies the events are only detected and reconstructed by the LSTs.\n",
+    "At ~100 GeV, the MSTs take over and EDISP is chaotic in the ~ 50 GeV to 100 GeV energy range.\n",
+    "So it can be useful to have quick access to IRFs like with Gammapy (e.g. for spectral line searches in this case), even if for 95% of science analyses users later won't have to look at the IRFs and just trust that everything is working."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.irf import EnergyDispersion2D\n",
+    "\n",
+    "edisp = EnergyDispersion2D.read(irf_filename, hdu=\"ENERGY DISPERSION\")\n",
+    "print(type(edisp))\n",
+    "print(type(edisp.data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(edisp.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edisp.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is how for analysis you could slice out an `EnergyDispersion`\n",
+    "# object at a given offset:\n",
+    "edisp.to_energy_dispersion(offset=\"0 deg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Point spread function\n",
+    "\n",
+    "The point spread function (PSF) in this case is given as an analytical Gaussian model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.irf import EnergyDependentMultiGaussPSF\n",
+    "\n",
+    "psf = EnergyDependentMultiGaussPSF.read(\n",
+    "    irf_filename, hdu=\"POINT SPREAD FUNCTION\"\n",
+    ")\n",
+    "print(psf.info())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is how for analysis you could slice out the PSF\n",
+    "# at a given field of view offset\n",
+    "psf.to_energy_dependent_table_psf(\"1 deg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Background\n",
+    "\n",
+    "The hadronic background for CTA DC-1 is given as a template model with an absolute rate that depends on `energy`, `detx` and `dety`. The coordinates `detx` and `dety` are angles in the \"field of view\" coordinate frame.\n",
+    "\n",
+    "Note that really the background model for DC-1 and most CTA IRFs produced so far are radially symmetric, i.e. only depend on the FOV offset. The background model here was rotated to fill the FOV in a rotationally symmetric way, for no good reason."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.irf import Background3D\n",
+    "\n",
+    "bkg = Background3D.read(irf_filename, hdu=\"BACKGROUND\")\n",
+    "print(bkg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: implement a peek method for Background3D\n",
+    "# bkg.peek()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkg.data.evaluate(energy=\"3 TeV\", fov_lon=\"1 deg\", fov_lat=\"0 deg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Index files and DataStore\n",
+    "\n",
+    "As we saw, you can access all of the CTA data using Astropy and Gammapy.\n",
+    "\n",
+    "But wouldn't it be nice if there were a better, simpler way?\n",
+    "\n",
+    "Imagine what life could be like if you had a butler that knows where all the files and HDUs are, and hands you the 1DC data on a silver platter, you just have to ask for it.\n",
+    "\n",
+    "![gammapy.data.DataStore - your butler for CTA data](images/gammapy_datastore_butler.png)\n",
+    "\n",
+    "Well, the butler exists. He's called `gammapy.data.DataStore` and he keeps track of the data using index files.\n",
+    "\n",
+    "### Index files\n",
+    "\n",
+    "The files with in the `index` folder with names `obs-index.fits.gz` and `hdu-index.fits.gz` are so called \"observation index files\" and \"HDU index files\".\n",
+    "\n",
+    "* The purpose of observation index files is to get a table of available observations, with the most relevant parameters commonly used for observation selection (e.g. pointing position or observation time). Their format is described in detail [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/obs_index/index.html).\n",
+    "* The purpose of HDU index files is to locate all FITS header data units (HDUs) for a given observation. At the moment, for each observation, there are six relevant HDUs: EVENTS, GTI, AEFF, EDISP, PSF and BKG. The format is described in detail [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/hdu_index/index.html).\n",
+    "\n",
+    "For 1DC there is one set of index files per simulated dataset, as well as a set of index files listing all available data in the all directory.\n",
+    "\n",
+    "Side comment: if you have data, but no index files, you should write a Python script to make the index files. As an example, the one I used to make the index files for 1DC is [here](https://github.com/gammasky/cta-dc/blob/master/data/cta_1dc_make_data_index_files.py)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!(cd $CTADATA && tree index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Gammapy DataStore\n",
+    "\n",
+    "If you want to access data and IRFs from the CTA 1DC GPS dataset, just create a `DataStore` by pointing at a folder where the index files are located."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.data import DataStore\n",
+    "\n",
+    "data_store = DataStore.from_dir(\"$CTADATA/index/gps\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out some basic information about the available data:\n",
+    "data_store.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The observation index is loaded as a table\n",
+    "print(\"Number of observations: \", len(data_store.obs_table))\n",
+    "print(data_store.obs_table.colnames)\n",
+    "print(\n",
+    "    \"Total observation time (hours): \",\n",
+    "    data_store.obs_table[\"ONTIME\"].sum() / 3600,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The HDU index is loaded as a table\n",
+    "print(len(data_store.hdu_table))\n",
+    "print(data_store.hdu_table.colnames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Of course, you can look at the tables if you like\n",
+    "# data_store.obs_table[:10].show_in_browser(jsviewer=True)\n",
+    "# data_store.hdu_table[:10].show_in_browser(jsviewer=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select observations\n",
+    "\n",
+    "With ``data_store.obs_table`` you have a table with the most common per-observation parameters that are used for observation selection. Using Python / Table methods it's easy to apply any selection you like, always with the goal of making a list or array of `OBS_ID`, which is then the input to analysis.\n",
+    "\n",
+    "For the current 1DC dataset it's pretty simple, because the only quantities useful for selection are:\n",
+    "* pointing position\n",
+    "* which irf (i.e. array  / zenith angle)\n",
+    "\n",
+    "With real data, there will be more parameters of interest, such as data quality, observation duration, zenith angle, time of observation, ...\n",
+    "\n",
+    "Let's look at one example: select observations that are at offset 1 to 2 deg from the Galactic center."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.coordinates import SkyCoord\n",
+    "\n",
+    "table = data_store.obs_table\n",
+    "pos_obs = SkyCoord(\n",
+    "    table[\"GLON_PNT\"], table[\"GLAT_PNT\"], frame=\"galactic\", unit=\"deg\"\n",
+    ")\n",
+    "pos_target = SkyCoord(0, 0, frame=\"galactic\", unit=\"deg\")\n",
+    "offset = pos_target.separation(pos_obs).deg\n",
+    "mask = (1 < offset) & (offset < 2)\n",
+    "table = table[mask]\n",
+    "print(\"Number of selected observations: \", len(table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the first few\n",
+    "table[[\"OBS_ID\", \"GLON_PNT\", \"GLAT_PNT\", \"IRF\"]][:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check which IRFs were used ... it's all south and 20 deg zenith angle\n",
+    "set(table[\"IRF\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the pointing positions\n",
+    "# The grid pointing positions at GLAT = +- 1.2 deg are visible\n",
+    "from astropy.coordinates import Angle\n",
+    "\n",
+    "plt.scatter(\n",
+    "    Angle(table[\"GLON_PNT\"], unit=\"deg\").wrap_at(\"180 deg\"), table[\"GLAT_PNT\"]\n",
+    ")\n",
+    "plt.xlabel(\"Galactic longitude (deg)\")\n",
+    "plt.ylabel(\"Galactic latitude (deg)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data\n",
+    "\n",
+    "Once you have selected the observations of interest, use the `DataStore` to load the data and IRF for those observations. Let's say we're interested in `OBS_ID=110000`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs = data_store.obs(obs_id=110000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(obs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.events.table[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.aeff"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.edisp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.psf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's an example how to loop over many observations and analyse them: [cta_1dc_make_allsky_images.py](https://github.com/gammasky/cta-dc/blob/master/data/cta_1dc_make_allsky_images.py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model XML files\n",
+    "\n",
+    "The 1DC sky model is distributed as a set of XML files, which in turn link to a ton of other FITS and text files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls $CTADATA/models/*.xml | xargs -n 1 basename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is what the XML file looks like\n",
+    "!tail -n 20 $CTADATA/models/models_gps.xml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At the moment, you cannot read and write these sky model XML files with Gammapy.\n",
+    "\n",
+    "There are multiple reasons why this XML serialisation format isn't implemented in Gammapy yet (all variants of \"it sucks\"):\n",
+    "\n",
+    "* XML is tedious to read and write for humans.\n",
+    "* The format is too strict in places: there are many use cases where \"min\", \"max\", \"free\" and \"error\" aren't needed, so it should be possible to omit them (see e.g. dummy values above)\n",
+    "* The parameter \"scale\" is an implementation detail that very few optimisers need. There's no reason to bother all gamma-ray astronomers with separating value and scale in model input and result files.\n",
+    "* The \"unit\" is missing. Pretty important piece of information, no?\n",
+    "  All people working on IACTs use \"TeV\", why should CTA be forced to use \"MeV\"?\n",
+    "* Ad-hoc extensions that keep being added and many models can't be put in one file (see extra ASCII and FITS files with tables or other info, e.g. pulsar models added for CTA 1DC). Admittedly complex model serialisation is an intrinsically hard problem, there is not simple and flexible solution.\n",
+    "\n",
+    "Also, to be honest, I also want to say / admit:\n",
+    "\n",
+    "* A model serialisation format is useful, even if it will never cover all use cases (e.g. energy-dependent morphology or an AGN with a variable spectrum, or complex FOV background models).\n",
+    "* The Gammapy model package isn't well-implemented or well-developed yet.\n",
+    "* So far users were happy to write a few lines of Python to define a model instead of XML.\n",
+    "* Clearly with CTA 1DC now using the XML format there's an important reason to support it, there is the legacy of Fermi-LAT using it and ctools using / extending it for CTA.\n",
+    "\n",
+    "So what now?\n",
+    "\n",
+    "* In Gammapy, we have started to implement a modeling package in `gammapy.utils.modeling`, with the goal of supporting this XML format as one of the serialisation formats. It's not very far along, will be a main focus for us, help is welcome.\n",
+    "* In addition we would like to support a second more human-friendly model format that looks something like [this](https://github.com/gammapy/gamma-cat/blob/b651de8d1d793e924764ffb13c8ec189bce9ea7d/input/data/2006/2006A%2526A...457..899A/tev-000025.yaml#L11)\n",
+    "* For now, you could use Gammalib to read the XML files, or you could read them directly with Python. The Python standard library contains [ElementTree](https://docs.python.org/3/library/xml.etree.elementtree.html) and there's [xmltodict](https://github.com/martinblech/xmltodict) which simply hands you back the XML file contents as a Python dictionary (containing a very nested hierarchical structure of Python dict and list objects and strings and numbers.\n",
+    "\n",
+    "As an example, here's how you can read an XML sky model and access the spectral parameters of one source (the last, \"Arp200\" visible above in the XML printout) and create a [gammapy.spectrum.models.PowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html) object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read XML file and access spectrum parameters\n",
+    "from gammapy.extern import xmltodict\n",
+    "\n",
+    "filename = os.path.join(os.environ[\"CTADATA\"], \"models/models_gps.xml\")\n",
+    "data = xmltodict.parse(open(filename).read())\n",
+    "data = data[\"source_library\"][\"source\"][-1]\n",
+    "data = data[\"spectrum\"][\"parameter\"]\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a spectral model the the right units\n",
+    "from astropy import units as u\n",
+    "from gammapy.spectrum.models import PowerLaw\n",
+    "\n",
+    "par_to_val = lambda par: float(par[\"@value\"]) * float(par[\"@scale\"])\n",
+    "spec = PowerLaw(\n",
+    "    amplitude=par_to_val(data[0]) * u.Unit(\"cm-2 s-1 MeV-1\"),\n",
+    "    index=par_to_val(data[1]),\n",
+    "    reference=par_to_val(data[2]) * u.Unit(\"MeV\"),\n",
+    ")\n",
+    "print(spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Easy: Go over this notebook again, and change the data / code a little bit:\n",
+    "    * Pick another run (any run you like)\n",
+    "    * Plot the energy-offset histogram of the events separately for gammas and background\n",
+    "\n",
+    "* Medium difficulty: Find all runs within 1 deg of the Crab nebula.\n",
+    "    * Load the \"all\" index file via the `DataStore`, then access the ``.obs_table``, then get an array-valued ``SkyCoord`` with all the observation pointing positions.\n",
+    "    * You can get the Crab nebula position with `astropy.coordinates.SkyCoord` via ``SkyCoord.from_name('crab')`` \n",
+    "    * Note that to compute the angular separation between two ``SkyCoord`` objects can be computed via ``separation = coord1.separation(coord2)``.\n",
+    "\n",
+    "* Hard: Find the PeVatrons in the 1DC data, i.e. the ~ 10 sources that are brightest at high energies (e.g. above 10 TeV).\n",
+    "    * This is difficult, because it's note clear how to best do this, and also because it's time-consuming to crunch through all relevant data for any given method.\n",
+    "    * One idea could be to go brute-force through **all** events, select the ones above 10 TeV and stack them all into one table. Then make an all-sky image and run a peak finder, or use an event cluster-finding method e.g. from scikit-learn.\n",
+    "    * Another idea could be to first make a list of targets of interest, either from the CTA 1DC sky model or from gamma-cat, compute the model integral flux above 10 TeV and pick candidates that way, then run analyses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# start typing here ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "* This notebook gave you an overview of the 1DC files and showed you have to access and work with them using Gammapy.\n",
+    "* To see how to do analysis, i.e. make a sky image and spectrum, see [cta_data_analysis.ipynb](cta_data_analysis.ipynb) next."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -1,0 +1,539 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![CTA first data challenge logo](images/cta-1dc.png)\n",
+    "\n",
+    "# CTA data analysis with Gammapy\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "**This notebook shows an example how to make a sky image and spectrum for simulated CTA data with Gammapy.**\n",
+    "\n",
+    "The dataset we will use is three observation runs on the Galactic center. This is a tiny (and thus quick to process and play with and learn) subset of the simulated CTA dataset that was produced for the first data challenge in August 2017.\n",
+    "\n",
+    "**This notebook can be considered part 2 of the introduction to CTA 1DC analysis. Part one is here: [cta_1dc_introduction.ipynb](cta_1dc_introduction.ipynb)**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "As usual, we'll start with some setup ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gammapy info --no-envvar --no-system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from astropy.convolution import Gaussian2DKernel\n",
+    "from regions import CircleSkyRegion\n",
+    "from gammapy.utils.energy import EnergyBounds\n",
+    "from gammapy.data import DataStore\n",
+    "from gammapy.spectrum import (\n",
+    "    SpectrumExtraction,\n",
+    "    SpectrumFit,\n",
+    "    SpectrumResult,\n",
+    "    models,\n",
+    "    SpectrumEnergyGroupMaker,\n",
+    "    FluxPointEstimator,\n",
+    ")\n",
+    "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
+    "from gammapy.cube import MapMaker\n",
+    "from gammapy.background import ReflectedRegionsBackgroundEstimator\n",
+    "from gammapy.detect import TSMapEstimator, find_peaks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configure the logger, so that the spectral analysis\n",
+    "# isn't so chatty about what it's doing.\n",
+    "import logging\n",
+    "\n",
+    "logging.basicConfig()\n",
+    "log = logging.getLogger(\"gammapy.spectrum\")\n",
+    "log.setLevel(logging.ERROR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select observations\n",
+    "\n",
+    "Like explained in [cta_1dc_introduction.ipynb](cta_1dc_introduction.ipynb), a Gammapy analysis usually starts by creating a `DataStore` and selecting observations.\n",
+    "\n",
+    "This is shown in detail in the other notebook, here we just pick three observations near the galactic center."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# data_store = DataStore.from_dir('$CTADATA/index/gps')\n",
+    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Just as a reminder: this is how to select observations\n",
+    "# from astropy.coordinates import SkyCoord\n",
+    "# table = data_store.obs_table\n",
+    "# pos_obs = SkyCoord(table['GLON_PNT'], table['GLAT_PNT'], frame='galactic', unit='deg')\n",
+    "# pos_target = SkyCoord(0, 0, frame='galactic', unit='deg')\n",
+    "# offset = pos_target.separation(pos_obs).deg\n",
+    "# mask = (1 < offset) & (offset < 2)\n",
+    "# table = table[mask]\n",
+    "# table.show_in_browser(jsviewer=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_id = [110380, 111140, 111159]\n",
+    "obs_list = data_store.obs_list(obs_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs_cols = [\"OBS_ID\", \"GLON_PNT\", \"GLAT_PNT\", \"LIVETIME\"]\n",
+    "data_store.obs_table.select_obs_id(obs_id)[obs_cols]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make sky images\n",
+    "\n",
+    "### Define map geometry\n",
+    "\n",
+    "Select the target position and define an ON region for the spectral analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "axis = MapAxis.from_edges(\n",
+    "    np.logspace(-1., 1., 10), unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
+    ")\n",
+    "geom = WcsGeom.create(\n",
+    "    skydir=(0, 0), npix=(500, 400), binsz=0.02, coordsys=\"GAL\", axes=[axis]\n",
+    ")\n",
+    "geom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute images\n",
+    "\n",
+    "Exclusion mask currently unused. Remove here or move to later in the tutorial?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_position = SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\")\n",
+    "on_radius = 0.2 * u.deg\n",
+    "on_region = CircleSkyRegion(center=target_position, radius=on_radius)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exclusion_mask = geom.to_image().region_mask([on_region], inside=False)\n",
+    "exclusion_mask = WcsNDMap(geom.to_image(), exclusion_mask)\n",
+    "exclusion_mask.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "maker = MapMaker(geom, offset_max=\"2 deg\")\n",
+    "maps = maker.run(obs_list)\n",
+    "print(maps.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The maps are cubes, with an energy axis.\n",
+    "# Let's also make some images:\n",
+    "images = maker.make_images()\n",
+    "\n",
+    "excess = images[\"counts\"].copy()\n",
+    "excess.data -= images[\"background\"].data\n",
+    "images[\"excess\"] = excess"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Show images\n",
+    "\n",
+    "Let's have a quick look at the images we computed ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images[\"counts\"].smooth(2).plot(vmax=5);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images[\"background\"].plot(vmax=5);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "images[\"excess\"].smooth(3).plot(vmax=2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source Detection\n",
+    "\n",
+    "Use the class [gammapy.detect.TSMapEstimator](http://docs.gammapy.org/dev/api/gammapy.detect.TSMapEstimator.html) and [gammapy.detect.find_peaks](http://docs.gammapy.org/dev/api/gammapy.detect.find_peaks.html) to detect sources on the images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kernel = Gaussian2DKernel(1, mode=\"oversample\").array\n",
+    "plt.imshow(kernel);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ts_image_estimator = TSMapEstimator()\n",
+    "images_ts = ts_image_estimator.run(images, kernel)\n",
+    "print(images_ts.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources = find_peaks(images_ts[\"sqrt_ts\"], threshold=8)\n",
+    "sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_pos = SkyCoord(sources[\"ra\"], sources[\"dec\"])\n",
+    "source_pos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot sources on top of significance sky image\n",
+    "images_ts[\"sqrt_ts\"].plot(add_cbar=True)\n",
+    "\n",
+    "plt.gca().scatter(\n",
+    "    source_pos.ra.deg,\n",
+    "    source_pos.dec.deg,\n",
+    "    transform=plt.gca().get_transform(\"icrs\"),\n",
+    "    color=\"none\",\n",
+    "    edgecolor=\"white\",\n",
+    "    marker=\"o\",\n",
+    "    s=200,\n",
+    "    lw=1.5,\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spatial analysis\n",
+    "\n",
+    "See other notebooks for how to run a 3D cube or 2D image based analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spectrum\n",
+    "\n",
+    "We'll run a spectral analysis using the classical reflected regions background estimation method,\n",
+    "and using the on-off (often called WSTAT) likelihood function.\n",
+    "\n",
+    "### Extraction\n",
+    "\n",
+    "The first step is to \"extract\" the spectrum, i.e. 1-dimensional counts and exposure and background vectors, as well as an energy dispersion matrix from the data and IRFs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "bkg_estimator = ReflectedRegionsBackgroundEstimator(\n",
+    "    obs_list=obs_list, on_region=on_region, exclusion_mask=exclusion_mask\n",
+    ")\n",
+    "bkg_estimator.run()\n",
+    "bkg_estimate = bkg_estimator.result\n",
+    "bkg_estimator.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "extract = SpectrumExtraction(obs_list=obs_list, bkg_estimate=bkg_estimate)\n",
+    "extract.run()\n",
+    "observations = extract.observations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Model fit\n",
+    "\n",
+    "The next step is to fit a spectral model, using all data (i.e. a \"global\" fit, using all energies)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "model = models.PowerLaw(\n",
+    "    index=2, amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    ")\n",
+    "fit = SpectrumFit(observations, model)\n",
+    "fit.fit()\n",
+    "fit.est_errors()\n",
+    "print(fit.result[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Spectral points\n",
+    "\n",
+    "Finally, let's compute spectral points. The method used is to first choose an energy binning, and then to do a 1-dim likelihood fit / profile to compute the flux and flux error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Flux points are computed on stacked observation\n",
+    "stacked_obs = extract.observations.stack()\n",
+    "print(stacked_obs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ebounds = EnergyBounds.equal_log_spacing(1, 40, 4, unit=u.TeV)\n",
+    "\n",
+    "seg = SpectrumEnergyGroupMaker(obs=stacked_obs)\n",
+    "seg.compute_groups_fixed(ebounds=ebounds)\n",
+    "\n",
+    "fpe = FluxPointEstimator(\n",
+    "    obs=stacked_obs, groups=seg.groups, model=fit.result[0].model\n",
+    ")\n",
+    "fpe.compute_points()\n",
+    "fpe.flux_points.table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot\n",
+    "\n",
+    "Let's plot the spectral model and points. You could do it directly, but there is a helper class.\n",
+    "Note that a spectral uncertainty band, a \"butterfly\" is drawn, but it is very thin, i.e. barely visible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total_result = SpectrumResult(\n",
+    "    model=fit.result[0].model, points=fpe.flux_points\n",
+    ")\n",
+    "\n",
+    "total_result.plot(\n",
+    "    energy_range=[1, 40] * u.TeV,\n",
+    "    fig_kwargs=dict(figsize=(8, 8)),\n",
+    "    point_kwargs=dict(color=\"green\"),\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Re-run the analysis above, varying some analysis parameters, e.g.\n",
+    "    * Select a few other observations\n",
+    "    * Change the energy band for the map\n",
+    "    * Change the spectral model for the fit\n",
+    "    * Change the energy binning for the spectral points\n",
+    "* Change the target. Make a sky image and spectrum for your favourite source.\n",
+    "    * If you don't know any, the Crab nebula is the \"hello world!\" analysis of gamma-ray astronomy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print('hello world')\n",
+    "# SkyCoord.from_name('crab')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "* This notebook showed an example of a first CTA analysis with Gammapy, using simulated 1DC data.\n",
+    "* This was part 2 for CTA 1DC turorial, the first part was here: [cta_1dc_introduction.ipynb](cta_1dc_introduction.ipynb)\n",
+    "* More tutorials (not 1DC or CTA specific) with Gammapy are [here](../index.ipynb)\n",
+    "* Let us know if you have any question or issues!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/cwt.ipynb
+++ b/tutorials/cwt.ipynb
@@ -1,0 +1,428 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CWT Algorithm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tutorial shows how to work with `CWT` algorithm for detecting gamma-ray sources.\n",
+    "\n",
+    "You can find the [docs here](http://docs.gammapy.org/dev/api/gammapy.detect.CWT.html#gammapy.detect.CWT)\n",
+    "and [source code on GitHub here](https://github.com/gammapy/gammapy/blob/master/gammapy/detect/cwt.py) for better understanding how the algorithm is constructed. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "On this section we just import some packages that can be used (or maybe not) in this tutorial. You can also see the versions of the packages in the outputs below and notice that this notebook was written on Python 2.7. Don't worry about that because the code is also Python 3 compatible. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Render our plots inline\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.rcParams[\"figure.figsize\"] = (15, 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import numpy as np\n",
+    "import scipy as sp\n",
+    "\n",
+    "print(\"Python version: \" + sys.version)\n",
+    "print(\"Numpy version: \" + np.__version__)\n",
+    "print(\"Scipy version: \" + sp.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CWT Algorithm. PlayGround"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First of all we import the data which should be analysied."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.io import fits\n",
+    "from astropy.coordinates import Angle, SkyCoord\n",
+    "from gammapy.maps import Map\n",
+    "\n",
+    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz\"\n",
+    "\n",
+    "counts = Map.read(filename=filename, hdu=\"COUNTS\")\n",
+    "background = Map.read(filename=filename, hdu=\"BACKGROUND\")\n",
+    "\n",
+    "width = Angle([20, 10], \"deg\")\n",
+    "position = counts.geom.center_skydir\n",
+    "counts = counts.cutout(position=position, width=width)\n",
+    "background = background.cutout(position=position, width=width)\n",
+    "\n",
+    "data = dict(counts=counts, background=background)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(15, 3))\n",
+    "\n",
+    "ax = fig.add_subplot(121, projection=data[\"counts\"].geom.wcs)\n",
+    "data[\"counts\"].plot(vmax=10, ax=ax, fig=fig)\n",
+    "\n",
+    "ax = fig.add_subplot(122, projection=data[\"background\"].geom.wcs)\n",
+    "data[\"background\"].plot(vmax=10, ax=ax, fig=fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's explore how CWT works. At first define parameters of the algorithm.  An imperative parameter is kernels (`detect.CWTKernels` object). So we should create it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Input parameters for CWTKernels\n",
+    "N_SCALE = 2  # Number of scales considered.\n",
+    "MIN_SCALE = 6.  # First scale used.\n",
+    "STEP_SCALE = 1.3  # Base scaling factor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.detect import CWTKernels\n",
+    "\n",
+    "cwt_kernels = CWTKernels(\n",
+    "    n_scale=N_SCALE, min_scale=MIN_SCALE, step_scale=STEP_SCALE\n",
+    ")\n",
+    "print(cwt_kernels.info_table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Other parameters are optional, in this demonstration define them all."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAX_ITER = 10  # The maximum number of iterations of the CWT algorithm.\n",
+    "TOL = 1e-5  # Tolerance for stopping criterion.\n",
+    "SIGNIFICANCE_THRESHOLD = 2.  # Measure of statistical significance.\n",
+    "SIGNIFICANCE_ISLAND_THRESHOLD = (\n",
+    "    None\n",
+    ")  # Measure is used for cleaning of isolated pixel islands.\n",
+    "REMOVE_ISOLATED = True  # If True, isolated pixels will be removed.\n",
+    "KEEP_HISTORY = True  # If you want to save images of all the iterations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's start to analyse input data. Import Logging module to see how the algorithm works during data analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.detect import CWT\n",
+    "import logging\n",
+    "\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)\n",
+    "cwt = CWT(\n",
+    "    kernels=cwt_kernels,\n",
+    "    tol=TOL,\n",
+    "    significance_threshold=SIGNIFICANCE_THRESHOLD,\n",
+    "    significance_island_threshold=SIGNIFICANCE_ISLAND_THRESHOLD,\n",
+    "    remove_isolated=REMOVE_ISOLATED,\n",
+    "    keep_history=KEEP_HISTORY,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to the algorithm was able to analyze source images, you need to convert them to a special format, i.e. create an CWTData object. Do this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.detect import CWTKernels, CWTData\n",
+    "\n",
+    "cwt_data = CWTData(\n",
+    "    counts=data[\"counts\"], background=data[\"background\"], n_scale=N_SCALE\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start the algorithm\n",
+    "cwt.analyze(cwt_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results of analysis\n",
+    "\n",
+    "Look at the results of CWT algorithm. Print all the images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PLOT_VALUE_MAX = 5\n",
+    "FIG_SIZE = (15, 35)\n",
+    "\n",
+    "fig = plt.figure(figsize=FIG_SIZE)\n",
+    "images = cwt_data.images()\n",
+    "for index, (name, image) in enumerate(images.items()):\n",
+    "    ax = fig.add_subplot(len(images), 2, index + 1, projection=image.geom.wcs)\n",
+    "    image.plot(vmax=PLOT_VALUE_MAX, fig=fig, ax=ax)\n",
+    "    plt.title(name)  # Maybe add a Name in SkyImage.plots?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see in the implementation of CWT above, it has the parameter `keep_history`. If you set to it `True`-value, it means that CWT would save all the images from iterations. Algorithm keeps images of only last CWT start.  Let's do this in the demonstration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = cwt.history\n",
+    "print(\n",
+    "    \"Number of iterations: {0}\".format(len(history) - 1)\n",
+    ")  # -1 because CWT save start images too"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's have a look, what's happening with images after the first iteration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_ITER = 1\n",
+    "assert 0 < N_ITER < len(history)\n",
+    "data_iter = history[N_ITER]\n",
+    "\n",
+    "fig = plt.figure(figsize=FIG_SIZE)\n",
+    "images_iter = data_iter.images()\n",
+    "for index, (name, image) in enumerate(images_iter.items()):\n",
+    "    ax = fig.add_subplot(\n",
+    "        len(images_iter), 2, index + 1, projection=image.geom.wcs\n",
+    "    )\n",
+    "    image.plot(vmax=PLOT_VALUE_MAX, fig=fig, ax=ax)\n",
+    "    plt.title(name)  # Maybe add a Name in SkyImage.plots?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can get the information about the one particular image in that way: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(data_iter.image_info(name=\"approx_bkg\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also get the information about cubes. Or information about all the data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(data_iter.cube_info(name=\"support\", per_scale=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(data_iter.cube_info(name=\"support\", per_scale=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also you can see the difference betwen the iterations in that way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = cwt.history  # get list of 'CWTData' objects\n",
+    "difference = (\n",
+    "    history[1] - history[0]\n",
+    ")  # get new `CWTData` obj, let's work with them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(difference.cube_info(\"support\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "difference.info_table.show_in_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=FIG_SIZE)\n",
+    "images_diff = difference.images()\n",
+    "for index, (name, image) in enumerate(images_diff.items()):\n",
+    "    ax = fig.add_subplot(\n",
+    "        len(images_diff), 2, index + 1, projection=image.geom.wcs\n",
+    "    )\n",
+    "    image.plot(vmax=PLOT_VALUE_MAX, fig=fig, ax=ax)\n",
+    "    plt.title(name)  # Maybe add a Name in SkyImage.plots?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can save the results if you want"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# cwt_data.write('test-cwt.fits', True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/tutorials/detect_ts.ipynb
+++ b/tutorials/detect_ts.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Source detection with Gammapy\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook show how to do source detection with Gammapy using one of the methods available in [gammapy.detect](http://docs.gammapy.org/dev/detect/index.html).\n",
+    "\n",
+    "We will do this:\n",
+    "\n",
+    "* produce 2-dimensional test-statistics (TS) images using Fermi-LAT 2FHL high-energy Galactic plane survey dataset\n",
+    "* run a peak finder to make a source catalog\n",
+    "* do some simple measurements on each source\n",
+    "* compare to the 2FHL catalog\n",
+    "\n",
+    "Note that what we do here is a quick-look analysis, the production of real source catalogs use more elaborate procedures.\n",
+    "\n",
+    "We will work with the following functions and classes:\n",
+    "\n",
+    "* [gammapy.maps.WcsNDMap](http://docs.gammapy.org/dev/api/gammapy.maps.WcsNDMap.html)\n",
+    "* [gammapy.detect.TSMapEstimator](http://docs.gammapy.org/dev/api/gammapy.detect.TSMapEstimator.html)\n",
+    "* [gammapy.detect.find_peaks](http://docs.gammapy.org/dev/api/gammapy.detect.find_peaks.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "As always, let's get started with some setup ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from astropy import units as u\n",
+    "from astropy.convolution import Gaussian2DKernel\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from gammapy.maps import Map\n",
+    "from gammapy.detect import TSMapEstimator, find_peaks\n",
+    "from gammapy.catalog import source_catalogs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute TS image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load data from files\n",
+    "filename = \"../datasets/fermi_survey/all.fits.gz\"\n",
+    "opts = {\n",
+    "    \"position\": SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"),\n",
+    "    \"width\": (20, 8),\n",
+    "}\n",
+    "maps = {\n",
+    "    \"counts\": Map.read(filename, hdu=\"COUNTS\").cutout(**opts),\n",
+    "    \"background\": Map.read(filename, hdu=\"BACKGROUND\").cutout(**opts),\n",
+    "    \"exposure\": Map.read(filename, hdu=\"EXPOSURE\").cutout(**opts),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# Compute a source kernel (source template) in oversample mode,\n",
+    "# PSF is not taken into account\n",
+    "kernel = Gaussian2DKernel(2.5, mode=\"oversample\")\n",
+    "estimator = TSMapEstimator()\n",
+    "images = estimator.run(maps, kernel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot images"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "images[\"sqrt_ts\"].plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "images[\"flux\"].plot(add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 5))\n",
+    "images[\"niter\"].plot(add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source catalog\n",
+    "\n",
+    "Let's run a peak finder on the `sqrt_ts` image to get a list of sources (positions and peak `sqrt_ts` values)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources = find_peaks(images[\"sqrt_ts\"], threshold=8)\n",
+    "sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot sources on top of significance sky image\n",
+    "plt.figure(figsize=(15, 5))\n",
+    "\n",
+    "images[\"sqrt_ts\"].plot()\n",
+    "\n",
+    "plt.gca().scatter(\n",
+    "    sources[\"ra\"],\n",
+    "    sources[\"dec\"],\n",
+    "    transform=plt.gca().get_transform(\"icrs\"),\n",
+    "    color=\"none\",\n",
+    "    edgecolor=\"black\",\n",
+    "    marker=\"o\",\n",
+    "    s=600,\n",
+    "    lw=1.5,\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Measurements\n",
+    "\n",
+    "* TODO: show cutout for a few sources and some aperture photometry measurements (e.g. energy distribution, significance, flux)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare to 2FHL\n",
+    "\n",
+    "TODO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fermi_2fhl = source_catalogs[\"2fhl\"]\n",
+    "fermi_2fhl.table[:5][[\"Source_Name\", \"GLON\", \"GLAT\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "TODO: put one or more exercises"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start exercises here!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "In this notebook, we have seen how to work with images and compute TS images from counts data, if a background estimate is already available.\n",
+    "\n",
+    "Here's some suggestions what to do next:\n",
+    "\n",
+    "- TODO: point to background estimation examples\n",
+    "- TODO: point to other docs ..."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -1,0 +1,730 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fermi-LAT data with Gammapy\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "This tutorial will show you how to work with Fermi-LAT data with Gammapy. As an example, we will look at the Galactic center region using the high-energy dataset that was used for the 3FHL catalog, in the energy range 10 GeV to 2 TeV.\n",
+    "\n",
+    "We note that support for Fermi-LAT data analysis in Gammapy is very limited. For most tasks, we recommend you use \n",
+    "[Fermipy](http://fermipy.readthedocs.io/), which is based on the [Fermi Science Tools](https://fermi.gsfc.nasa.gov/ssc/data/analysis/software/) (Fermi ST).\n",
+    "\n",
+    "Using Gammapy with Fermi-LAT data could be an option for you if you want to do an analysis that is not easily possible with Fermipy and the Fermi Science Tools. For example a joint likelihood fit of Fermi-LAT data with data e.g. from H.E.S.S., MAGIC, VERITAS or some other instrument, or analysis of Fermi-LAT data with a complex spatial or spectral model that is not available in Fermipy or the Fermi ST.\n",
+    "\n",
+    "Besides Gammapy, you might want to look at are [Sherpa](http://cxc.harvard.edu/sherpa/) or [3ML](https://threeml.readthedocs.io/). Or just using Python to roll your own analyis using several existing analysis packages. E.g. it it possible to use Fermipy and the Fermi ST to evaluate the likelihood on Fermi-LAT data, and Gammapy to evaluate it e.g. for IACT data, and to do a joint likelihood fit using e.g. [iminuit](http://iminuit.readthedocs.io/) or [emcee](http://dfm.io/emcee).\n",
+    "\n",
+    "To use Fermi-LAT data with Gammapy, you first have to use the Fermi ST to prepare an event list (using ``gtselect`` and ``gtmktime``, exposure cube (using ``gtexpcube2`` and PSF (using ``gtpsf``). You can then use [gammapy.data.EventList](http://docs.gammapy.org/dev/api/gammapy.data.EventList.html), [gammapy.maps](http://docs.gammapy.org/dev/maps/index.html) and the [gammapy.irf.EnergyDependentTablePSF](http://docs.gammapy.org/dev/api/gammapy.irf.EnergyDependentTablePSF.html) to read the Fermi-LAT maps and PSF, i.e. support for these high-level analysis products from the Fermi ST is built in. To do a 3D map analyis, you can use [MapFit](http://docs.gammapy.org/dev/api/gammapy.cube.MapFit.html) for Fermi-LAT data in the same way that it's use for IACT data. This is illustrated in this notebook. A 1D region-based spectral analysis is also possible, this will be illustrated in a future tutorial. There you have to extract 1D counts, exposure and background vectors and then pass them to [SpectrumFit](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumFit.html).\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "**IMPORTANT**: For this notebook you have to get the prepared ``3fhl`` dataset provided in the [gammapy-fermi-lat-data](https://github.com/gammapy/gammapy-fermi-lat-data) repository. Please follow the instructions [here](https://github.com/gammapy/gammapy-fermi-lat-data#get-the-data) to download the data and setup your environment.\n",
+    "\n",
+    "Note that the ``3fhl`` dataset is high-energy only, ranging from 10 GeV to 2 TeV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check that you have the prepared Fermi-LAT dataset\n",
+    "!ls -1 $GAMMAPY_FERMI_LAT_DATA/3fhl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We will use diffuse models from here\n",
+    "!ls -1 $GAMMAPY_EXTRA/datasets/fermi_3fhl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from astropy import units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.table import Table\n",
+    "from astropy.visualization import simple_norm\n",
+    "from gammapy.data import EventList\n",
+    "from gammapy.irf import EnergyDependentTablePSF\n",
+    "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
+    "from gammapy.spectrum.models import TableModel, PowerLaw, ConstantModel\n",
+    "from gammapy.image.models import SkyPointSource, SkyDiffuseConstant\n",
+    "from gammapy.cube.models import SkyModel, SkyDiffuseCube\n",
+    "from gammapy.cube import MapEvaluator, MapFit, PSFKernel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Events\n",
+    "\n",
+    "To load up the Fermi-LAT event list, use the [gammapy.data.EventList](http://docs.gammapy.org/dev/api/gammapy.data.EventList.html) class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events = EventList.read(\n",
+    "    \"$GAMMAPY_FERMI_LAT_DATA/3fhl/allsky/fermi_3fhl_events_selected.fits.gz\"\n",
+    ")\n",
+    "print(events)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The event data is stored in a [astropy.table.Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html) object. In case of the Fermi-LAT event list this contains all the additional information on positon, zenith angle, earth azimuth angle, event class, event type etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events.table.colnames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events.table[:5][[\"ENERGY\", \"RA\", \"DEC\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(events.time[0].iso)\n",
+    "print(events.time[-1].iso)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy = events.energy\n",
+    "energy.info(\"stats\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a short analysis example we will count the number of events above a certain minimum energy: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for e_min in [10, 100, 1000] * u.GeV:\n",
+    "    n = (events.energy > e_min).sum()\n",
+    "    print(\"Events above {0:4.0f}: {1:5.0f}\".format(e_min, n))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Counts\n",
+    "\n",
+    "Let us start to prepare things for an 3D map analysis of the Galactic center region with Gammapy. The first thing we do is to define the map geometry. We chose a TAN projection centered on position ``(glon, glat) = (0, 0)`` with pixel size 0.1 deg, and four energy bins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gc_pos = SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\")\n",
+    "energy_axis = MapAxis.from_edges(\n",
+    "    [10, 30, 100, 300, 2000], name=\"energy\", unit=\"GeV\", interp=\"log\"\n",
+    ")\n",
+    "counts = Map.create(\n",
+    "    skydir=gc_pos,\n",
+    "    npix=(100, 80),\n",
+    "    proj=\"TAN\",\n",
+    "    coordsys=\"GAL\",\n",
+    "    binsz=0.1,\n",
+    "    axes=[energy_axis],\n",
+    ")\n",
+    "# We put this call into the same Jupyter cell as the Map.create\n",
+    "# because otherwise we could accidentally fill the counts\n",
+    "# multiple times when executing the ``fill_by_coord`` multiple times.\n",
+    "counts.fill_by_coord(\n",
+    "    {\n",
+    "        \"skycoord\": events.radec,\n",
+    "        # The coord-based interface doesn't use Quantity,\n",
+    "        # so we need to pass energy in the same unit as\n",
+    "        # used for the map axis\n",
+    "        \"energy\": events.energy,\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts.geom.axes[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts.sum_over_axes().smooth(2).plot(stretch=\"sqrt\", vmax=30);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exposure\n",
+    "\n",
+    "The Fermi-LAT datatset contains the energy-dependent exposure for the whole sky as a HEALPix map computed with ``gtexpcube2``. This format is supported by ``gammapy.maps`` directly.\n",
+    "\n",
+    "Interpolating the exposure cube from the Fermi ST to get an exposure cube matching the spatial geometry and energy axis defined above with Gammapy is easy. The only point to watch out for is how exactly you want the energy axis and binning handled.\n",
+    "\n",
+    "Below we just use the default behaviour, which is linear interpolation in energy on the original exposure cube. Probably log interpolation would be better, but it doesn't matter much here, because the energy binning is fine. Finally, we just copy the counts map geometry, which contains an energy axis with `node_type=\"edges\"`. This is non-ideal for exposure cubes, but again, acceptable because exposure doesn't vary much from bin to bin, so the exact way interpolation occurs in later use of that exposure cube doesn't matter a lot. Of course you could define any energy axis for your exposure cube that you like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exposure_hpx = Map.read(\n",
+    "    \"$GAMMAPY_FERMI_LAT_DATA/3fhl/allsky/fermi_3fhl_exposure_cube_hpx.fits.gz\"\n",
+    ")\n",
+    "# Unit is not stored in the file, set it manually\n",
+    "exposure_hpx.unit = \"cm2 s\"\n",
+    "print(exposure_hpx.geom)\n",
+    "print(exposure_hpx.geom.axes[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exposure_hpx.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For exposure, we choose a geometry with node_type='center',\n",
+    "# whereas for counts it was node_type='edge'\n",
+    "axis = MapAxis.from_nodes(\n",
+    "    counts.geom.axes[0].center, name=\"energy\", unit=\"GeV\", interp=\"log\"\n",
+    ")\n",
+    "geom = WcsGeom(wcs=counts.geom.wcs, npix=counts.geom.npix, axes=[axis])\n",
+    "\n",
+    "coord = counts.geom.get_coord()\n",
+    "data = exposure_hpx.interp_by_coord(coord)\n",
+    "exposure = WcsNDMap(geom, data, unit=exposure_hpx.unit)\n",
+    "print(exposure.geom)\n",
+    "print(exposure.geom.axes[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exposure is almost constant accross the field of view\n",
+    "exposure.slice_by_idx({\"energy\": 0}).plot(add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exposure varies very little with energy at these high energies\n",
+    "energy = [10, 100, 1000] * u.GeV\n",
+    "exposure.get_by_coord({\"skycoord\": gc_pos, \"energy\": energy})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Galactic diffuse background"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Fermi-LAT collaboration provides a galactic diffuse emission model, that can be used as a background model for\n",
+    "Fermi-LAT source analysis.\n",
+    "\n",
+    "Diffuse model maps are very large (100s of MB), so as an example here, we just load one that represents a small cutout for the Galactic center region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diffuse_galactic_fermi = Map.read(\n",
+    "    \"$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
+    ")\n",
+    "# Unit is not stored in the file, set it manually\n",
+    "diffuse_galactic_fermi.unit = \"cm-2 s-1 MeV-1 sr-1\"\n",
+    "print(diffuse_galactic_fermi.geom)\n",
+    "print(diffuse_galactic_fermi.geom.axes[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Interpolate the diffuse emission model onto the counts geometry\n",
+    "# The resolution of `diffuse_galactic_fermi` is low: bin size = 0.5 deg\n",
+    "# We use ``interp=3`` which means cubic spline interpolation\n",
+    "coord = counts.geom.get_coord()\n",
+    "\n",
+    "data = diffuse_galactic_fermi.interp_by_coord(\n",
+    "    {\n",
+    "        \"skycoord\": coord.skycoord,\n",
+    "        \"energy\": coord[\"energy\"]\n",
+    "        * counts.geom.get_axis_by_name(\"energy\").unit,\n",
+    "    },\n",
+    "    interp=3,\n",
+    ")\n",
+    "diffuse_galactic = WcsNDMap(\n",
+    "    exposure.geom, data, unit=diffuse_galactic_fermi.unit\n",
+    ")\n",
+    "\n",
+    "print(diffuse_galactic.geom)\n",
+    "print(diffuse_galactic.geom.axes[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diffuse_galactic.slice_by_idx({\"energy\": 0}).plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Exposure varies very little with energy at these high energies\n",
+    "energy = np.logspace(1, 3, 10) * u.GeV\n",
+    "dnde = diffuse_galactic.interp_by_coord(\n",
+    "    {\"skycoord\": gc_pos, \"energy\": energy}, interp=\"linear\", fill_value=None\n",
+    ")\n",
+    "plt.plot(energy.value, dnde, \"*\")\n",
+    "plt.loglog()\n",
+    "plt.xlabel(\"Energy (GeV)\")\n",
+    "plt.ylabel(\"Flux (cm-2 s-1 MeV-1 sr-1)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: show how one can fix the extrapolate to high energy\n",
+    "# by computing and padding an extra plane e.g. at 1e3 TeV\n",
+    "# that corresponds to a linear extrapolation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Isotropic diffuse background\n",
+    "\n",
+    "To load the isotropic diffuse model with Gammapy, use the [gammapy.spectrum.models.TableModel](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.TableModel.html). We are using `'fill_value': 'extrapolate'` to extrapolate the model above 500 GeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"$GAMMAPY_FERMI_LAT_DATA/isodiff/iso_P8R2_SOURCE_V6_v06.txt\"\n",
+    "interp_kwargs = {\"fill_value\": \"extrapolate\", \"kind\": \"cubic\"}\n",
+    "diffuse_iso = TableModel.read_fermi_isotropic_model(\n",
+    "    filename=filename, interp_kwargs=interp_kwargs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot the model in the energy range between 50 GeV and 2000 GeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "erange = [50, 2000] * u.GeV\n",
+    "diffuse_iso.plot(erange, flux_unit=\"1 / (cm2 MeV s sr)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PSF\n",
+    "\n",
+    "Next we will tke a look at the PSF. It was computed using ``gtpsf``, in this case for the Galactic center position. Note that generally for Fermi-LAT, the PSF only varies little within a given regions of the sky, especially at high energies like what we have here. We use the [gammapy.irf.EnergyDependentTablePSF](http://docs.gammapy.org/dev/api/gammapy.irf.EnergyDependentTablePSF.html) class to load the PSF and use some of it's methods to get some information about it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf = EnergyDependentTablePSF.read(\n",
+    "    \"$GAMMAPY_FERMI_LAT_DATA/3fhl/allsky/fermi_3fhl_psf_gc.fits.gz\"\n",
+    ")\n",
+    "print(psf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get an idea of the size of the PSF we check how the containment radii of the Fermi-LAT PSF vari with energy and different containment fractions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8, 5))\n",
+    "psf.plot_containment_vs_energy(linewidth=2, fractions=[0.68, 0.95])\n",
+    "plt.xlim(50, 2000)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition we can check how the actual shape of the PSF varies with energy and compare it against the mean PSF between 50 GeV and 2000 GeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8, 5))\n",
+    "\n",
+    "for energy in [100, 300, 1000] * u.GeV:\n",
+    "    psf_at_energy = psf.table_psf_at_energy(energy)\n",
+    "    psf_at_energy.plot_psf_vs_rad(label=\"PSF @ {:.0f}\".format(energy), lw=2)\n",
+    "\n",
+    "erange = [50, 2000] * u.GeV\n",
+    "psf_mean = psf.table_psf_in_energy_band(energy_band=erange, spectral_index=2.3)\n",
+    "psf_mean.plot_psf_vs_rad(label=\"PSF Mean\", lw=4, c=\"k\", ls=\"--\")\n",
+    "\n",
+    "plt.xlim(1e-3, 0.3)\n",
+    "plt.ylim(1e3, 1e6)\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's compute a PSF kernel matching the pixel size of our map\n",
+    "psf_kernel = PSFKernel.from_table_psf(psf, counts.geom, max_radius=\"0.5 deg\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf_kernel.psf_kernel_map.sum_over_axes().plot(stretch=\"log\", add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Background\n",
+    "\n",
+    "Let's compute a background cube, with predicted number of background events per pixel from the diffuse Galactic and isotropic model components. For this, we use the use the [gammapy.cube.MapEvaluator](http://docs.gammapy.org/dev/api/gammapy.cube.MapEvaluator.html) to multiply with the exposure and apply the PSF. The Fermi-LAT energy dispersion at high energies is small, we neglect it here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = SkyDiffuseCube(diffuse_galactic)\n",
+    "\n",
+    "evaluator = MapEvaluator(model=model, exposure=exposure, psf=psf_kernel)\n",
+    "\n",
+    "background_gal = counts.copy(data=evaluator.compute_npred())\n",
+    "background_gal.sum_over_axes().plot()\n",
+    "print(\"Background counts from Galactic diffuse: \", background_gal.data.sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = SkyModel(SkyDiffuseConstant(), diffuse_iso)\n",
+    "\n",
+    "evaluator = MapEvaluator(model=model, exposure=exposure, psf=psf_kernel)\n",
+    "\n",
+    "background_iso = counts.copy(data=evaluator.compute_npred())\n",
+    "background_iso.sum_over_axes().plot()\n",
+    "print(\"Background counts from isotropic diffuse: \", background_iso.data.sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "background = background_gal.copy()\n",
+    "background.data += background_iso.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Excess and flux\n",
+    "\n",
+    "Let's compute an excess and flux image, by subtracting the background, and summing over the energy axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "excess = counts.copy()\n",
+    "excess.data -= background.data\n",
+    "excess.sum_over_axes().smooth(2).plot(\n",
+    "    cmap=\"coolwarm\", vmin=-5, vmax=5, add_cbar=True\n",
+    ")\n",
+    "print(\"Excess counts: \", excess.data.sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux = excess.copy()\n",
+    "flux.data /= exposure.data\n",
+    "flux.unit = excess.unit / exposure.unit\n",
+    "flux.sum_over_axes().smooth(2).plot(stretch=\"sqrt\", add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit\n",
+    "\n",
+    "Finally, the big finale: let's do a 3D map fit for the source at the Galactic center, to measure it's position and spectrum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = SkyModel(\n",
+    "    SkyPointSource(\"0 deg\", \"0 deg\"),\n",
+    "    PowerLaw(index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"),\n",
+    ")\n",
+    "fit = MapFit(\n",
+    "    model=model,\n",
+    "    counts=counts,\n",
+    "    exposure=exposure,\n",
+    "    background=background,\n",
+    "    psf=psf_kernel,\n",
+    ")\n",
+    "result = fit.fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "- Fit the position and spectrum of the source [SNR G0.9+0.1](http://gamma-sky.net/#/cat/tev/110).\n",
+    "- Make maps and fit the position and spectrum of the [Crab nebula](http://gamma-sky.net/#/cat/tev/25)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this tutorial you have seen how to work with Fermi-LAT data with Gammapy. You have to use the Fermi ST to prepare the exposure cube and PSF, and then you can use Gammapy for any event or map analysis using the same methods that are used to analyse IACT data.\n",
+    "\n",
+    "This works very well at high energies (here above 10 GeV), where the exposure and PSF is almost constant spatially and only varies a little with energy. It is not expected to give good results for low-energy data, where the Fermi-LAT PSF is very large. If you are interested to help us validate down to what energy Fermi-LAT analysis with Gammapy works well (e.g. by re-computing results from 3FHL or other published analysis results), or to extend the Gammapy capabilities (e.g. to work with energy-dependent multi-resolution maps and PSF), that would be very welcome!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {
+    "height": "237px",
+    "width": "253px"
+   },
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": "block",
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/first_steps.ipynb
+++ b/tutorials/first_steps.ipynb
@@ -1,0 +1,877 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Getting started with Gammapy\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "This is a getting started tutorial for [Gammapy](http://docs.gammapy.org/).\n",
+    "\n",
+    "In this tutorial we will use the [Second Fermi-LAT Catalog of High-Energy Sources (2FHL) catalog](http://fermi.gsfc.nasa.gov/ssc/data/access/lat/2FHL/), corresponding event list and images to learn how to work with some of the central Gammapy data structures.\n",
+    "\n",
+    "We will cover the following topics:\n",
+    "\n",
+    "* **Sky maps**\n",
+    "  * We will learn how to handle image based data with gammapy using a Fermi-LAT 2FHL example image. We will work with the following classes:\n",
+    "    - [gammapy.maps.WcsNDMap](http://docs.gammapy.org/dev/api/gammapy.maps.WcsNDMap.html)\n",
+    "    - [astropy.coordinates.SkyCoord](http://astropy.readthedocs.io/en/latest/coordinates/index.html)\n",
+    "    - [numpy.ndarray](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html)\n",
+    "\n",
+    "* **Event lists**\n",
+    "  * We will learn how to handle event lists with Gammapy. Important for this are the following classes: \n",
+    "    - [gammapy.data.EventList](http://docs.gammapy.org/dev/api/gammapy.data.EventList.html)\n",
+    "    - [astropy.table.Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table)\n",
+    "\n",
+    "* **Source catalogs**\n",
+    "  * We will show how to load source catalogs with Gammapy and explore the data using the following classes:\n",
+    "    - [gammapy.catalog.SourceCatalog](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalog.html), specifically [gammapy.catalog.SourceCatalog2FHL](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalog2FHL.html)\n",
+    "    - [astropy.table.Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table)\n",
+    "\n",
+    "* **Spectral models and flux points**\n",
+    "  * We will pick an example source and show how to plot its spectral model and flux points. For this we will use the following classes:\n",
+    "    - [gammapy.spectrum.SpectralModel](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.SpectralModel.html), specifically the [PowerLaw2](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw2.html) model.\n",
+    "    - [gammapy.spectrum.FluxPoints](http://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPoints.html#gammapy.spectrum.FluxPoints)\n",
+    "    - [astropy.table.Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table)\n",
+    "\n",
+    "If you're not yet familiar with the listed Astropy classes, maybe check out the [Astropy introduction for Gammapy users](astropy_introduction.ipynb) first."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "**Important**: to run this tutorial the environment variable `GAMMAPY_EXTRA` must be defined and point to the directory, where the gammapy-extra is respository located on your machine. To check whether your setup is correct you can execute the following cell:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "path = os.path.expandvars(\"$GAMMAPY_EXTRA/datasets\")\n",
+    "\n",
+    "if not os.path.exists(path):\n",
+    "    raise Exception(\"gammapy-extra repository not found!\")\n",
+    "else:\n",
+    "    print(\"Great your setup is correct!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case you encounter an error, you can un-comment and execute the following cell to continue. But we recommend to set up your enviroment correctly as decribed [here](http://docs.gammapy.org/dev/datasets/index.html#gammapy-extra) after you are done with this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# os.environ['GAMMAPY_EXTRA'] = os.path.join(os.getcwd(), '..')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can continue with the usual IPython notebooks and Python imports:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.visualization import simple_norm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Maps\n",
+    "\n",
+    "The [gammapy.maps](http://docs.gammapy.org/dev/maps) package contains classes to work with sky images and cubes.\n",
+    "\n",
+    "In this section, we will use a simple 2D sky image and will learn how to:\n",
+    "\n",
+    "* Read sky images from FITS files\n",
+    "* Smooth images\n",
+    "* Plot images\n",
+    "* Cutout parts from images\n",
+    "* Reproject images to different WCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.maps import Map\n",
+    "\n",
+    "vela_2fhl = Map.read(\n",
+    "    \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_vela.fits.gz\", hdu=\"COUNTS\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As the FITS file `fermi_2fhl_vela.fits.gz` contains mutiple image extensions and a map can only represent a single image, we explicitely specify to read the extension called 'COUNTS'.\n",
+    "\n",
+    "The image is a ``WCSNDMap`` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_2fhl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The shape of the image is 320x180 pixel and it is defined using a cartesian projection in galactic coordinates.\n",
+    "\n",
+    "The ``geom`` attribute is a ``WcsGeom`` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_2fhl.geom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a closer look a the `.data` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_2fhl.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That looks familiar! It just an *ordinary* 2 dimensional numpy array,  which means you can apply any known numpy method to it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\n",
+    "    \"Total number of counts in the image: {:.0f}\".format(vela_2fhl.data.sum())\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To show the image on the screen we can use the ``plot`` method. It basically calls [plt.imshow](http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.imshow), passing the `vela_2fhl.data` attribute but in addition handles axis with world coordinates using [wcsaxes](https://wcsaxes.readthedocs.io/en/latest/) and defines some defaults for nicer plots (e.g. the colormap 'afmhot'):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_2fhl.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make the structures in the image more visible we will smooth the data using a Gausian kernel with a radius of 0.5 deg. Again `smooth()` is a wrapper around existing functionality from the scientific Python libraries. In this case it is Scipy's [gaussian_filter](https://docs.scipy.org/doc/scipy-0.16.1/reference/generated/scipy.ndimage.filters.gaussian_filter.html) method. For convenience the kernel shape can be specified with as string and the smoothing radius with a quantity. It returns again a map object, that we can plot directly the same way we did above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_2fhl_smoothed = vela_2fhl.smooth(kernel=\"gauss\", radius=0.5 * u.deg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_2fhl_smoothed.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The smoothed plot already looks much nicer, but still the image is rather large. As we are mostly interested in the inner part of the image, we will cut out a quadratic region of the size 9 deg x 9 deg around Vela. Therefore we use ``Map.cutout`` to make a cutout map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define center and size of the cutout region\n",
+    "center = SkyCoord(265.0, -2.0, unit=\"deg\", frame=\"galactic\")\n",
+    "vela_2fhl_cutout = vela_2fhl_smoothed.cutout(center, 9 * u.deg)\n",
+    "vela_2fhl_cutout.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make this exercise a bit more scientifically useful, we will load a second image containing WMAP data from the same region:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_wmap = Map.read(\"$GAMMAPY_EXTRA/datasets/images/Vela_region_WMAP_K.fits\")\n",
+    "\n",
+    "# define a norm to stretch the data, so it is better visible\n",
+    "norm = simple_norm(vela_wmap.data, stretch=\"sqrt\", max_percent=99.9)\n",
+    "vela_wmap.plot(cmap=\"viridis\", norm=norm);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to make the structures in the data better visible we used the [simple_norm()](http://docs.astropy.org/en/stable/api/astropy.visualization.mpl_normalize.simple_norm.html#astropy.visualization.mpl_normalize.simple_norm) method, which allows to stretch the data for plotting. This is very similar to the methods that e.g. `ds9` provides. In addition we used a different colormap called 'viridis'. An overview of different colomaps can be found [here](http://matplotlib.org/examples/color/colormaps_reference.html). \n",
+    "\n",
+    "Now let's check the details of the WMAP image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vela_wmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see it is defined using a tangential projection and ICRS coordinates, which is different from the projection used for the `vela_2fhl` image. To compare both images we have to reproject one image to the WCS of the other. This can be achieved with the ``reproject`` method: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reproject and cut out the part we're interested in:\n",
+    "vela_wmap_reprojected = vela_wmap.reproject(vela_2fhl.geom)\n",
+    "vela_wmap_reprojected_cutout = vela_wmap_reprojected.cutout(center, 9 * u.deg)\n",
+    "vela_wmap_reprojected_cutout.plot(cmap=\"viridis\", norm=norm);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we will combine both images in single plot, by plotting WMAP contours on top of the smoothed Fermi-LAT 2FHL image:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax, _ = vela_2fhl_cutout.plot()\n",
+    "ax.contour(vela_wmap_reprojected_cutout.data, cmap=\"Blues\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercises\n",
+    "\n",
+    "* Add a marker and circle at the Vela pulsar position (you can find examples in the WCSAxes [documentation](https://wcsaxes.readthedocs.io/en/latest/overlays.html))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Event lists\n",
+    "\n",
+    "Almost any high-level gamma-ray data analysis starts with the raw measured counts data, which is stored in event lists. In Gammapy event lists are represented by the [gammapy.data.EventList](http://docs.gammapy.org/dev/api/gammapy.data.EventList.html) class. \n",
+    "\n",
+    "In this section we will learn how to:\n",
+    "\n",
+    "* Read event lists from FITS files\n",
+    "* Access and work with the `EventList` attributes such as `.table` and `.energy` \n",
+    "* Filter events lists using convenience methods\n",
+    "\n",
+    "Let's start with the import from the [gammapy.data](http://docs.gammapy.org/dev/data/index.html) submodule:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.data import EventList"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Very similar to the sky map class an event list can be created, by passing a filename to the `.read()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_2fhl = EventList.read(\n",
+    "    \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This time the actual data is stored as an [astropy.table.Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table) object. It can be accessed with `.table` attribute: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_2fhl.table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's try to find the total number of events contained int the list. This doesn't work:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Total number of events: {}\".format(len(events_2fhl.table)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because Gammapy objects don't redefine properties, that are accessible from the underlying Astropy of Numpy data object.\n",
+    "\n",
+    "So in this case of course we can directly use the `.table` attribute to find the total number of events:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Total number of events: {}\".format(len(events_2fhl.table)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can access any other attribute of the `Table` object as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_2fhl.table.colnames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For convenience we can access the most important event parameters as properties on the `EventList` objects. The attributes will return corresponding Astropy objects to represent the data, such as [astropy.units.Quantity](http://docs.astropy.org/en/stable/api/astropy.units.Quantity.html#astropy.units.Quantity), [astropy.coordinates.SkyCoord](http://docs.astropy.org/en/stable/api/astropy.coordinates.SkyCoord.html) or [astropy.time.Time](http://docs.astropy.org/en/stable/api/astropy.time.Time.html#astropy.time.Time) objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_2fhl.energy.to(\"GeV\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_2fhl.galactic\n",
+    "# events_2fhl.radec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events_2fhl.time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition `EventList` provides convenience methods to filter the event lists. One possible use case is to find the highest energy event within a radius of 0.5 deg around the vela position:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# select all events within a radius of 0.5 deg around center\n",
+    "events_vela_2fhl = events_2fhl.select_sky_cone(\n",
+    "    center=center, radius=0.5 * u.deg\n",
+    ")\n",
+    "\n",
+    "# sort events by energy\n",
+    "events_vela_2fhl.table.sort(\"ENERGY\")\n",
+    "\n",
+    "# and show highest energy photon\n",
+    "events_vela_2fhl.energy[-1].to(\"GeV\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercises\n",
+    "\n",
+    "* Make a counts energy spectrum for the galactic center region, within a radius of 10 deg."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source catalogs\n",
+    "\n",
+    "Gammapy provides a convenient interface to access and work with catalog based data. \n",
+    "\n",
+    "In this section we will learn how to:\n",
+    "\n",
+    "* Load builtins catalogs from [gammapy.catalog](http://docs.gammapy.org/dev/catalog/index.html)\n",
+    "* Sort and index the underlying Astropy tables\n",
+    "* Access data from individual sources\n",
+    "\n",
+    "Let's start with importing the 2FHL catalog object from the [gammapy.catalog](http://docs.gammapy.org/dev/catalog/index.html) submodule:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.catalog import SourceCatalog2FHL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we initialize the Fermi-LAT 2FHL catalog and directly take a look at the `.table` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fermi_2fhl = SourceCatalog2FHL(\n",
+    "    \"$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v08.fit.gz\"\n",
+    ")\n",
+    "fermi_2fhl.table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This looks very familiar again. The data is just stored as an [astropy.table.Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table) object. We have all the methods and attributes of the `Table` object available. E.g. we can sort the underlying table by `TS` to find the top 5 most significant sources:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sort table by TS\n",
+    "fermi_2fhl.table.sort(\"TS\")\n",
+    "\n",
+    "# invert the order to find the highest values and take the top 5\n",
+    "top_five_TS_2fhl = fermi_2fhl.table[::-1][:5]\n",
+    "\n",
+    "# print the top five significant sources with association and source class\n",
+    "top_five_TS_2fhl[[\"Source_Name\", \"ASSOC\", \"CLASS\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are interested in the data of an individual source you can access the information from catalog using the name of the source or any alias source name that is defined in the catalog:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mkn_421_2fhl = fermi_2fhl[\"2FHL J1104.4+3812\"]\n",
+    "\n",
+    "# or use any alias source name that is defined in the catalog\n",
+    "mkn_421_2fhl = fermi_2fhl[\"Mkn 421\"]\n",
+    "print(mkn_421_2fhl.data[\"TS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercises\n",
+    "\n",
+    "* Try to load the Fermi-LAT 3FHL catalog and check the total number of sources it contains.\n",
+    "* Select all the sources from the 2FHL catalog which are contained in the Vela region. Add markers for all these sources and try to add labels with the source names. The function [ax.text()](http://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.text.html#matplotlib.axes.Axes.text) might be helpful.\n",
+    "* Try to find the source class of the object at position ra=68.6803, dec=9.3331\n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spectral models and flux points\n",
+    "\n",
+    "In the previous section we learned how access basic data from individual sources in the catalog. Now we will go one step further and explore the full spectral information of sources. We will learn how to:\n",
+    "\n",
+    "* Plot spectral models\n",
+    "* Compute integral and energy fluxes\n",
+    "* Read and plot flux points\n",
+    "\n",
+    "As a first example we will start with the Crab Nebula:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_2fhl = fermi_2fhl[\"Crab\"]\n",
+    "print(crab_2fhl.spectral_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `crab_2fhl.spectral_model` is an instance of the [gammapy.spectrum.models.PowerLaw2](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw2.html#gammapy.spectrum.models.PowerLaw2) model, with the parameter values and errors taken from the 2FHL catalog. \n",
+    "\n",
+    "Let's plot the spectral model in the energy range between 50 GeV and 2000 GeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax_crab_2fhl = crab_2fhl.spectral_model.plot(\n",
+    "    energy_range=[50, 2000] * u.GeV, energy_power=0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We assign the return axes object to variable called `ax_crab_2fhl`, because we will re-use it later to plot the flux points on top.\n",
+    "\n",
+    "To compute the differential flux at 100 GeV we can simply call the model like normal Python function and convert to the desired units:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_2fhl.spectral_model(100 * u.GeV).to(\"cm-2 s-1 GeV-1\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we can compute the integral flux of the Crab between 50 GeV and 2000 GeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_2fhl.spectral_model.integral(emin=50 * u.GeV, emax=2000 * u.GeV).to(\n",
+    "    \"cm-2 s-1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can easily convince ourself, that it corresponds to the value given in the Fermi-LAT 2FHL catalog:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_2fhl.data[\"Flux50\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition we can compute the energy flux between 50 GeV and 2000 GeV:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_2fhl.spectral_model.energy_flux(emin=50 * u.GeV, emax=2000 * u.GeV).to(\n",
+    "    \"erg cm-2 s-1\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we will access the flux points data of the Crab:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(crab_2fhl.flux_points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to learn more about the different flux point formats you can read the specification [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/results/flux_points/index.html#flux-points).\n",
+    "\n",
+    "No we can check again the underlying astropy data structure by accessing the `.table` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_2fhl.flux_points.table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally let's combine spectral model and flux points in a single plot and scale with `energy_power=2` to obtain the spectral energy distribution:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = crab_2fhl.spectral_model.plot(\n",
+    "    energy_range=[50, 2000] * u.GeV, energy_power=2\n",
+    ")\n",
+    "crab_2fhl.flux_points.plot(ax=ax, energy_power=2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercises\n",
+    "\n",
+    "* Plot the spectral model and flux points for PKS 2155-304 for the 3FGL and 2FHL catalogs. Try to plot the error of the model (aka \"Butterfly\") as well. Note this requires the [uncertainties package](https://pythonhosted.org/uncertainties/) to be installed on your machine.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "This was a quick introduction to some of the high-level classes in Astropy and Gammapy.\n",
+    "\n",
+    "* To learn more about those classes, go to the API docs (links are in the introduction at the top).\n",
+    "* To learn more about other parts of Gammapy (e.g. Fermi-LAT and TeV data analysis), check out the other tutorial notebooks.\n",
+    "* To see what's available in Gammapy, browse the [Gammapy docs](http://docs.gammapy.org/) or use the full-text search.\n",
+    "* If you have any questions, ask on the mailing list."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/hgps.ipynb
+++ b/tutorials/hgps.ipynb
@@ -1,0 +1,1155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HGPS\n",
+    "\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "The **H.E.S.S. Galactic Plane Survey (HGPS)** is the first deep and wide survey of the Milky Way in TeV gamma-rays.\n",
+    "\n",
+    "In April 2018, a paper on the HGPS was published, and survey maps and a source catalog on the HGPS in FITS format released.\n",
+    "\n",
+    "More information, and the HGPS data for download in FITS format is available here:\n",
+    "https://www.mpi-hd.mpg.de/hfm/HESS/hgps\n",
+    "\n",
+    "**Please read the Appendix A of the paper to learn about the caveats to using the HGPS data. Especially note that the HGPS survey maps are correlated and thus no detailed source morphology analysis is possible, and also note the caveats concerning spectral models and spectral flux points.**\n",
+    "\n",
+    "## Notebook Overview\n",
+    "\n",
+    "This is a Jupyter notebook that illustrates how to work with the HGPS data from Python.\n",
+    "\n",
+    "You will learn how to access the HGPS images as well as the HGPS catalog and other tabular data using Astropy and Gammapy.\n",
+    "\n",
+    "* In the first part we will only use Astropy to do some basic things.\n",
+    "* Then in the second part we'll use Gammapy to do some things that are a little more advanced.\n",
+    "\n",
+    "The notebook is pretty long: feel free to skip ahead to a section of your choice after executing the cells in the \"Setup\" and \"Download data\" sections below.\n",
+    "\n",
+    "Note that there are other tools to work with FITS data that we don't explain here. Specifically [DS9](http://ds9.si.edu/) and [Aladin](http://aladin.u-strasbg.fr/) are good FITS image viewers, and [TOPCAT](http://www.star.bris.ac.uk/~mbt/topcat/) is great for FITS tables. Astropy and Gammapy are just one way to work with the HGPS data; any tool that can access FITS data can be used.\n",
+    "\n",
+    "## Packages\n",
+    "\n",
+    "We will be using the following Python packages\n",
+    "\n",
+    "* [astropy](http://docs.astropy.org/)\n",
+    "* [gammapy](http://docs.gammapy.org/)\n",
+    "* [matplotlib](https://matplotlib.org/) for plotting\n",
+    "\n",
+    "Under the hood all of those packages use Numpy arrays to store and work with data.\n",
+    "\n",
+    "More specifically, we will use the following functions and classes:\n",
+    "\n",
+    "* From [astropy](http://docs.astropy.org/), we will use [astropy.io.fits](http://docs.astropy.org/en/stable/io/fits/index.html) to read the FITS data, [astropy.table.Table](http://docs.astropy.org/en/stable/table/index.html) to work with the tables, but also [astropy.coordinates.SkyCoord](http://docs.astropy.org/en/stable/coordinates/index.html) and [astropy.wcs.WCS](http://docs.astropy.org/en/stable/wcs/index.html) to work with sky and pixel coordinates and [astropy.units.Quantity](http://docs.astropy.org/en/stable/units/index.html) to work with quantities.\n",
+    "\n",
+    "* From [gammapy](http://docs.gammapy.org/), we will use [gammapy.maps.WcsNDMap](http://docs.gammapy.org/dev/api/gammapy.maps.WcsNDMap.html) to work with the HGPS sky maps, and [gammapy.catalog.SourceCatalogHGPS](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalogHGPS.html) and [gammapy.catalog.SourceCatalogObjectHGPS](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalogObjectHGPS.html) to work with the HGPS catalog data, especially the HGPS spectral data using [gammapy.spectrum.models.SpectralModel](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.SpectralModel.html) and [gammapy.spectrum.FluxPoints](http://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPoints.html) objects.\n",
+    "\n",
+    "* [matplotlib](https://matplotlib.org/) for all plotting. For sky image plotting, we will use matplotlib via [astropy.visualization](http://docs.astropy.org/en/stable/visualization/index.html) and [gammapy.maps.WcsNDMap.plot](http://docs.gammapy.org/dev/api/gammapy.maps.WcsNDMap.html#gammapy.maps.WcsNDMap.plot).\n",
+    "\n",
+    "If you're not familiar with Python, Numpy, Astropy, Gammapy or matplotlib yet, use the tutorial introductions as explained [here](http://docs.gammapy.org/dev/tutorials.html), as well as the links to the documentation that we just mentioned."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We start by importing everything we will use in this notebook, and configuring the notebook to show plots inline.\n",
+    "\n",
+    "If you get an error here, you probably have to install the missing package and re-start the notebook.\n",
+    "\n",
+    "If you don't get an error, just go ahead, no nead to read the import code and text in this section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.io import fits\n",
+    "from astropy.table import Table\n",
+    "from astropy.wcs import WCS\n",
+    "\n",
+    "import astropy\n",
+    "\n",
+    "print(astropy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.maps import Map\n",
+    "from gammapy.catalog import SourceCatalogHGPS\n",
+    "\n",
+    "import gammapy\n",
+    "\n",
+    "print(gammapy.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import matplotlib\n",
+    "\n",
+    "print(matplotlib.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This will work on Python 3, but fail on Python 2\n",
+    "from pathlib import Path\n",
+    "from urllib.request import urlretrieve"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you're still using Python 2, please update to Python 3!\n",
+    "\n",
+    "Also, it's time to start using [JupyterLab](http://jupyterlab.readthedocs.io/)\n",
+    "(which is Python 3 only, Jupyter dropped Python 2 support in 2017).\n",
+    "\n",
+    "But OK, to be honest, actually everything here will work on Python 2,\n",
+    "we avoided the use of Python 3 only features for now.\n",
+    "You just have to import `Path` and `urlretrieve` from here instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This will work on Python 2 as well as Python 3\n",
+    "# from gammapy.extern.six.moves.urllib.request import urlretrieve\n",
+    "# from gammapy.extern.pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download Data\n",
+    "\n",
+    "First, you need to download the HGPS FITS data from https://www.mpi-hd.mpg.de/hfm/HESS/hgps .\n",
+    "\n",
+    "If you haven't already, you can use the following commands to download the files to your local working directory.\n",
+    "\n",
+    "You don't have to read the code in the next cell; that's just how to downlaod files from Python.\n",
+    "You could also download the files with your web browser, or from the command line e.g. with curl:\n",
+    "\n",
+    "    mkdir hgps_data\n",
+    "    cd hgps_data\n",
+    "    curl -O https://www.mpi-hd.mpg.de/hfm/HESS/hgps/data/hgps_catalog_v1.fits.gz\n",
+    "    curl -O https://www.mpi-hd.mpg.de/hfm/HESS/hgps/data/hgps_map_significance_0.1deg_v1.fits.gz\n",
+    "\n",
+    "**The rest of this notebook assumes that you have the data files at ``hgps_data_path``.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download HGPS data used in this tutorial to a folder of your choice\n",
+    "# The default `hgps_data` used here is a sub-folder in your current\n",
+    "# working directory (where you started the notebook)\n",
+    "hgps_data_path = Path(\"hgps_data\")\n",
+    "\n",
+    "# In this notebook we will only be working with the following files\n",
+    "# so we only download what is needed.\n",
+    "hgps_filenames = [\n",
+    "    \"hgps_catalog_v1.fits.gz\",\n",
+    "    \"hgps_map_significance_0.1deg_v1.fits.gz\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def hgps_data_download():\n",
+    "    base_url = \"https://www.mpi-hd.mpg.de/hfm/HESS/hgps/data/\"\n",
+    "    for filename in hgps_filenames:\n",
+    "        url = base_url + filename\n",
+    "        path = hgps_data_path / filename\n",
+    "        if path.exists():\n",
+    "            print(\"Already downloaded: {}\".format(path))\n",
+    "        else:\n",
+    "            print(\"Downloading {} to {}\".format(url, path))\n",
+    "            urlretrieve(url, str(path))\n",
+    "\n",
+    "\n",
+    "hgps_data_path.mkdir(parents=True, exist_ok=True)\n",
+    "hgps_data_download()\n",
+    "\n",
+    "print(\"\\n\\nFiles at {} :\\n\".format(hgps_data_path.absolute()))\n",
+    "for path in hgps_data_path.iterdir():\n",
+    "    print(path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Catalog with Astropy\n",
+    "\n",
+    "### FITS file content\n",
+    "\n",
+    "Let's start by just opening up `hgps_catalog_v1.fits.gz` and looking at the content.\n",
+    "\n",
+    "Note that ``astropy.io.fits.open`` doesn't work with `Path` objects yet,\n",
+    "so you have to call `str(path)` and pass a string."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = hgps_data_path / \"hgps_catalog_v1.fits.gz\"\n",
+    "hdu_list = fits.open(str(path))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdu_list.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are six tables. Each table and column is described in detail in the HGPS paper.\n",
+    "\n",
+    "### Access table data\n",
+    "\n",
+    "We could work with the `astropy.io.fits.HDUList` and `astropy.io.fits.BinTable` objects.\n",
+    "However, in Astropy a nicer class to work with tables has been developed: `astropy.table.Table`.\n",
+    "\n",
+    "We will only be using `Table`, so let's convert the FITS tabular data into a `Table` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = Table.read(hdu_list[\"HGPS_SOURCES\"])\n",
+    "\n",
+    "# Alternatively, reading from file directly would work like this:\n",
+    "# table = Table.read(str(path), hdu='HGPS_SOURCES')\n",
+    "# Usually you have to look first what HDUs are in a FITS file\n",
+    "# like we did above; `Table` is just for one table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List available columns\n",
+    "table.info()\n",
+    "# To get shorter output here, we just list a few\n",
+    "# table.info(out=None)['name', 'dtype', 'shape', 'unit'][:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rows are accessed by indexing into the table\n",
+    "# with an integer index (Python starts at index 0)\n",
+    "# table[0]\n",
+    "# To get shorter output here, we just list a few\n",
+    "table[0][table.colnames[:5]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Columns are accessed by indexing into the table\n",
+    "# with a column name string\n",
+    "# Then you can slice the column to get the rows you want\n",
+    "table[\"Source_Name\"][:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Accessing a given element of the table like this\n",
+    "table[\"Source_Name\"][5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you know some Python and Numpy, you can now start\n",
+    "# to ask questions about the HGPS data.\n",
+    "# Just to give one example: \"What spatial models are used?\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set(table[\"Spatial_Model\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert formats\n",
+    "\n",
+    "The HGPS catalog is only released in FITS format.\n",
+    "\n",
+    "We didn't provide multiple formats (DS9, CSV, XML, VOTABLE, ...) because everyone needs something a little different (in terms of format or content). Instead, here we show how you can convert to any format / content you like wiht a few lines of Python.\n",
+    "\n",
+    "#### DS9 region format\n",
+    "\n",
+    "At [Fermi-LAT 3FGL webpage](https://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/),\n",
+    "we see that they also provide [DS9 region files](http://ds9.si.edu/doc/ref/region.html) that look like this:\n",
+    "\n",
+    "    global color=red\n",
+    "    fk5;point(   0.0377, 65.7517)# point=cross text={3FGL J0000.1+6545}\n",
+    "    fk5;point(   0.0612,-37.6484)# point=cross text={3FGL J0000.2-3738}\n",
+    "    fk5;point(   0.2535, 63.2440)# point=cross text={3FGL J0001.0+6314}\n",
+    "    ... more lines, one for each source ...\n",
+    "\n",
+    "because many people use [DS9](http://ds9.si.edu/) to view astronomical images, and to overplot catalog data.\n",
+    "\n",
+    "Let's convert the HGPS catalog into this format.\n",
+    "(to avoid very long text output, we use `table[:3]` to just use the first three rows)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines = [\"global color=red\"]\n",
+    "for row in table[:3]:\n",
+    "    fmt = \"fk5;point({:.5f},{:.5f})# point=cross text={{{}}}\"\n",
+    "    vals = row[\"RAJ2000\"], row[\"DEJ2000\"], row[\"Source_Name\"]\n",
+    "    lines.append(fmt.format(*vals))\n",
+    "txt = \"\\n\".join(lines)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To save it to a DS9 region text file\n",
+    "path = hgps_data_path / \"hgps_my_format.reg\"\n",
+    "path.write_text(txt)\n",
+    "\n",
+    "# Print content of the file to check\n",
+    "print(path.read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that there is an extra package [astropy-regions](https://astropy-regions.readthedocs.io/) that has classes to represent region objects and supports the DS9 format. We could have used that to generate the DS9 region strings, or we could use it to read the DS9 region file via:\n",
+    "\n",
+    "    import regions\n",
+    "    region_list = regions.ds9.read_ds9(str(path))\n",
+    "\n",
+    "We will not show examples how to work with regions or how to do region-based analyses here, but if you want to do something like e.g. measure the total flux in a given region in the HGPS maps, the region package would be useful."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### CSV format\n",
+    "\n",
+    "Let's do one more example, converting part of the HGPS catalog table information to CSV, i.e. comma-separated format.\n",
+    "This is a format that can be read by any tool for tabular data, e.g. if you are using Excel or ROOT for your gamma-ray data analysis, this section is for you!\n",
+    "\n",
+    "Usually you can just use the CSV writer in Astropy like this:\n",
+    "\n",
+    "    path = hgps_data_path / 'hgps_my_format.csv'\n",
+    "    table.write(str(path), format='ascii.csv')\n",
+    "    \n",
+    "However, this doesn't work here for two reasons:\n",
+    "\n",
+    "1. this table contains metadata that trips up the Astropy CSV writer (I filed an [issue](https://github.com/astropy/astropy/issues/7357) with Astropy)\n",
+    "1. this table contains array-valued columns for the spectral points and CSV can only have scalar values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is the problematic header key\n",
+    "table.meta[\"comments\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These are the array-valued columns\n",
+    "array_colnames = tuple(\n",
+    "    name for name in table.colnames if len(table[name].shape) > 1\n",
+    ")\n",
+    "for name in array_colnames:\n",
+    "    print(name, table[name].shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# So each source has an array of spectral flux points,\n",
+    "# and FITS allows storing such arrays in table cells\n",
+    "# Knowing this, you could work with the spectral points directly.\n",
+    "# We won't give an example here; but instead show how to work\n",
+    "# with HGPS spectra in the Gammapy section below, because it's easier.\n",
+    "print(table[\"Flux_Points_Energy\"][0])\n",
+    "print(table[\"Flux_Points_Flux\"][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's get back to our actual goal of converting part of the HGPS catalog table data to CSV format.\n",
+    "The following code makes a copy of the table that contains just the scalar columns, then removes the `meta` information (most CSV variants / readers don't support metadata anyways) and writes a CSV file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scalar_colnames = tuple(\n",
+    "    name for name in table.colnames if len(table[name].shape) <= 1\n",
+    ")\n",
+    "table2 = table[scalar_colnames]\n",
+    "table2.meta = {}\n",
+    "path = hgps_data_path / \"hgps_my_format.csv\"\n",
+    "table2.write(str(path), format=\"ascii.csv\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Astropy ASCII writer and reader supports many variants.\n",
+    "Let's do one more example, using the ``ascii.fixed_width`` format which is a bit easier to read for humans.\n",
+    "We will just select a few columns and rows to print here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table2 = table[\"Source_Name\", \"GLON\", \"GLAT\"][:3]\n",
+    "table2.meta = {}\n",
+    "table2[\"Source_Name\"].format = \"<20s\"\n",
+    "table2[\"GLON\"].format = \">8.3f\"\n",
+    "table2[\"GLAT\"].format = \">8.3f\"\n",
+    "path = hgps_data_path / \"hgps_my_format.csv\"\n",
+    "table2.write(str(path), format=\"ascii.fixed_width\", overwrite=True)\n",
+    "\n",
+    "# Print the CSV file contents to check what we have\n",
+    "print(path.read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you know how to work with the HGPS catalog with Python and Astropy. For the other tables (e.g. `HGPS_GAUSS_COMPONENTS`) it's the same: you should read the description in the HGPS paper, then access the information you need or convert it to the format you want as shows for `HGPS_SOURCES` here). Let's move on and have a look at the HGPS maps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Maps with Astropy\n",
+    "\n",
+    "This section shows how to load an HGPS survey map with Astropy, and give examples how to work with sky and pixel coordinates to read off map values at given positions.\n",
+    "\n",
+    "We will keep it short, for further examples see the \"Maps with Gammapy\" section below.\n",
+    "\n",
+    "### Read\n",
+    "\n",
+    "To read the map, use `fits.open` to get an `HDUList` object, then access `[0]` to get the first and only image HDU in the FITS file, and finally use the `hdu.data` Numpy array, `hdu.header` header object or `wcs = WCS(hdu.header)` WCS object to work with the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = hgps_data_path / \"hgps_map_significance_0.1deg_v1.fits.gz\"\n",
+    "hdu_list = fits.open(str(path))\n",
+    "hdu_list.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdu = hdu_list[0]\n",
+    "type(hdu)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(hdu.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdu.data.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The FITS header contains the information about the\n",
+    "# WCS projection, i.e. the pixel to sky coordinate transform\n",
+    "hdu.header"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### WCS and coordinates\n",
+    "\n",
+    "To actually do pixel to sky coordinate transformations,\n",
+    "you have to create a \"Word coordinate system transform (WCS)\"\n",
+    "object from the FITS header."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs = WCS(hdu.header)\n",
+    "wcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's find the (arguably) most interesting pixel in the HGPS map and look up it's value in the significance image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pos = SkyCoord.from_name('Sgr A*')\n",
+    "pos = SkyCoord(266.416826, -29.007797, unit=\"deg\")\n",
+    "pos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xp, yp = pos.to_pixel(wcs)\n",
+    "xp, yp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that SkyCoord makes it easy to transform\n",
+    "# to other frames, and it knows about the frame\n",
+    "# of the WCS object, so for HGPS we have `frame=\"galactic\"`\n",
+    "# and in the call above the transformation from ICRS\n",
+    "# to Galactic and then to pixel all happened in the\n",
+    "# `pos.to_pixel` call. This gives the same pixel postion:\n",
+    "print(pos.galactic)\n",
+    "print(pos.galactic.to_pixel(wcs))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FITS WCS and Numpy have opposite array axis order\n",
+    "# So to look up a pixel in the `hdu.data` Numpy array,\n",
+    "# we need to switch to (y, x), and we also need to\n",
+    "# round correctly to the nearest int, thus the `+ 0.5`\n",
+    "idx = int(yp + 0.5), int(xp + 0.5)\n",
+    "idx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now, finally the value of this pixel\n",
+    "hdu.data[idx]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this is a significance map with correlation radius 0.1 deg.\n",
+    "That means that within a circle of radius 0.1 deg around the pixel center,\n",
+    "the signal has a significance of 74.2 sigma.\n",
+    "\n",
+    "This does not directly correspond to the significance of a gamma-ray source,\n",
+    "because this circle contains emission from multiple sources and underlying diffuse emission,\n",
+    "and for the sources in this circle their emission isn't fully contained because of the size of the HESS PSF.\n",
+    "\n",
+    "We remind you of the caveat the HGPS paper (see Appendix A) that it is not possible to do a detailed quantitative measurement on the released HGPS maps; the measurements in the HGPS paper were done using likelihood fits on uncorrelated counts images taking the PSF shape into account."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's do one more exercise: find the sky position for the pixel with the highest significance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The pixel with the maximum significance\n",
+    "hdu.data.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# So it is the pixel in the HGPS map that contains Sgr A*\n",
+    "# and we already roughly know it's position\n",
+    "# Still, let's find the exact pixel center sky position\n",
+    "\n",
+    "# We use `np.nanargmax` to find the index, but it's an index\n",
+    "# into the flattened array, so we have to \"unravel\" it to get a 2D index\n",
+    "yp, xp = np.unravel_index(np.nanargmax(hdu.data), hdu.data.shape)\n",
+    "yp, xp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pos = SkyCoord.from_pixel(xp, yp, wcs)\n",
+    "pos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, working with FITS images and sky / pixel coordinates directly requires that you learn how to use the WCS object and Numpy arrays and to know that the axis order is `(x, y)` in FITS and WCS, but `(row, column)`, i.e. `(y, x)` in Numpy. It seems quite complex at first, but most astronomers get used to it and manage after a while. `gammapy.maps.WcsNDMap` is a wrapper class that is a bit simpler to use (see below), but under the hood it just calls these Numpy and Astropy methods for you, so it's good to know what is going on in any case."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Catalog with Gammapy\n",
+    "\n",
+    "As you have seen above, working with the HGPS FITS catalog data using Astropy is pretty nice.\n",
+    "But still, there are some common tasks that aren't trivial to do and require reading the\n",
+    "FITS table description in detail and writing quite a bit of Python code.\n",
+    "\n",
+    "So that you don't have to, we have done this for HGPS in [gammapy.catalog.SourceCatalogHGPS](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalogHGPS.html) and also for a few other catalogs that are commonly used in gamma-ray astronomy in [gammapy.catalog](http://docs.gammapy.org/dev/catalog/index.html).\n",
+    "\n",
+    "### Read\n",
+    "\n",
+    "Let's start by reading the HGPS catalog via the `SourceCatalogHGPS` class (which is just a wrapper class for `astropy.table.Table`) and access some information about a given source. Feel free to choose any source you like here: we have chosen simply the first one on the table: the pulsar-wind nebula Vela X, a large and bright TeV source around the [Vela pulsar](https://en.wikipedia.org/wiki/Vela_Pulsar)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = hgps_data_path / \"hgps_catalog_v1.fits.gz\"\n",
+    "cat = SourceCatalogHGPS(path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tables\n",
+    "\n",
+    "Now all tables from the FITS file were loaded\n",
+    "and stored on the ``cat`` object. See the [SourceCatalogHGPS](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalogHGPS.html) docs, or just try accessing one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat.table.meta[\"EXTNAME\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat.table_components.meta[\"EXTNAME\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Source\n",
+    "\n",
+    "You can access a given source by row index (starting at zero) or by source name.\n",
+    "This creates [SourceCatalogObjectHGPS](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalogObjectHGPS.html) objects that have a copy of all the data for a given source. See the class docs for a full overview."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These all give the same source object\n",
+    "source = cat[0]\n",
+    "# When accessing by name, the value has to match exactly\n",
+    "# the content from one of these columns:\n",
+    "# `Source_Name` or `Identified_Object`\n",
+    "# which in this case are \"HESS J0835-455\" and \"Vela X\"\n",
+    "source = cat[\"HESS J0835-455\"]\n",
+    "source = cat[\"Vela X\"]\n",
+    "source"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To see a pretty-printed text version of all\n",
+    "# HGPS data on a given source:\n",
+    "print(source)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can also more selectively print subsets of info:\n",
+    "print(source.info(\"map\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All of the data for this source is available\n",
+    "# via the `source.data` dictionary if you want\n",
+    "# to do some computations\n",
+    "source.data[\"Flux_Spec_Int_1TeV\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The flux points are available as a Table\n",
+    "source.flux_points.table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The spectral model is available as a\n",
+    "# Gammapy spectral model object:\n",
+    "spectral_model = source.spectral_model()\n",
+    "print(spectral_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# One common task is to compute integral fluxes\n",
+    "# The error is computed using the covariance matrix\n",
+    "# (off-diagonal info not given in HGPS, i.e. this is an approximation)\n",
+    "spectral_model.integral_error(emin=1 * u.TeV, emax=10 * u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's plot the spectrum\n",
+    "source.spectral_model().plot(source.energy_range)\n",
+    "source.spectral_model().plot_error(source.energy_range)\n",
+    "source.flux_points.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or let's make the same plot in the common\n",
+    "# format with y = E^2 * dnde\n",
+    "opts = dict(energy_power=2, flux_unit=\"erg-1 cm-2 s-1\")\n",
+    "source.spectral_model().plot(source.energy_range, **opts)\n",
+    "source.spectral_model().plot_error(source.energy_range, **opts)\n",
+    "source.flux_points.plot(**opts)\n",
+    "plt.ylabel(\"E^2 dN/dE (erg cm-2 s-1)\")\n",
+    "plt.title(\"Vela X HGPS spectrum\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the next section we will see how to work with the HGPS survey maps from Gammapy, as well as work with other data from the catalog (position and morphology information)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Maps with Gammapy\n",
+    "\n",
+    "Let's use the [gammapy.maps.Map.read](http://docs.gammapy.org/dev/api/gammapy.maps.Map.html#gammapy.maps.Map.read) method to load up the HGPS significance survey map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = hgps_data_path / \"hgps_map_significance_0.1deg_v1.fits.gz\"\n",
+    "survey_map = Map.read(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Map has a quick-look plot method, but it's not\n",
+    "# very useful for a survey map that wide with default settings\n",
+    "survey_map.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is a little better\n",
+    "fig = plt.figure(figsize=(15, 3))\n",
+    "_ = survey_map.plot(stretch=\"sqrt\")\n",
+    "# Note that we also assign the return value (a tuple)\n",
+    "# from the plot method call to a variable called `_`\n",
+    "# This is to avoid Jupyter printing it like in the last cell,\n",
+    "# and generally `_` is a variable name used in Python\n",
+    "# for things you don't want to name or care about at all"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at a cutout of the Galactic center:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = survey_map.cutout(pos, width=(3.8, 2.5) * u.deg)\n",
+    "fig, ax, _ = image.plot(stretch=\"sqrt\", cmap=\"inferno\")\n",
+    "ax.coords[0].set_major_formatter(\"dd\")\n",
+    "ax.coords[1].set_major_formatter(\"dd\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Side comment: If you like, you can format stuff to make it a bit more pretty. With a few lines you can get nice plots, with a few dozen publication-quality images. This is using [matplotlib](https://matplotlib.org/) and [astropy.visualization](http://docs.astropy.org/en/stable/visualization/index.html). Both are pretty complex, but there's many examples available and there's not really another good alternative anyways for astronomical sky images at the moment, so you should just go ahead and learn those.\n",
+    "\n",
+    "There's also a convenience method to look up the map value at a given sky position.\n",
+    "Let's repeat this for the same position we did above with Numpy and Astropy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pos = SkyCoord(266.416826, -29.007797, unit=\"deg\")\n",
+    "survey_map.get_by_coord(pos)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Vela X\n",
+    "\n",
+    "To finish up this tutorial, let's do something a bit more advanced, than involves the survey map, the HGPS source catalog, the multi-Gauss morphology component model. Let's show the Vela X pulsar wind nebula and the Vela Junior supernova remnant, and overplot some HGPS catalog data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The spatial model for Vela X in HGPS was three Gaussians\n",
+    "print(source.name)\n",
+    "for component in source.components:\n",
+    "    print(component)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.visualization import simple_norm\n",
+    "from matplotlib.patches import Circle\n",
+    "\n",
+    "# Cutout and plot a nice image\n",
+    "pos = SkyCoord(264.5, -2.5, unit=\"deg\", frame=\"galactic\")\n",
+    "image = survey_map.cutout(pos, width=(\"6 deg\", \"4 deg\"))\n",
+    "norm = simple_norm(image.data, stretch=\"sqrt\", min_cut=0, max_cut=20)\n",
+    "fig = plt.figure(figsize=(12, 8))\n",
+    "fig, ax, _ = image.plot(fig=fig, norm=norm, cmap=\"inferno\")\n",
+    "transform = ax.get_transform(\"galactic\")\n",
+    "\n",
+    "# Overplot the pulsar\n",
+    "# print(SkyCoord.from_name('Vela pulsar').galactic)\n",
+    "ax.scatter(263.551, -2.787, transform=transform, s=500, color=\"cyan\")\n",
+    "\n",
+    "# Overplot the circle that was used for the HGPS spectral measurement of Vela X\n",
+    "# It is centered on the centroid of the emission and has a radius of 0.5 deg\n",
+    "x = source.data[\"GLON\"].value\n",
+    "y = source.data[\"GLAT\"].value\n",
+    "r = source.data[\"RSpec\"].value\n",
+    "c = Circle(\n",
+    "    (x, y), r, transform=transform, edgecolor=\"white\", facecolor=\"none\", lw=4\n",
+    ")\n",
+    "ax.add_patch(c)\n",
+    "\n",
+    "# Overplot circles that represent the components\n",
+    "for c in source.components:\n",
+    "    x = c.data[\"GLON\"].value\n",
+    "    y = c.data[\"GLAT\"].value\n",
+    "    r = c.data[\"Size\"].value\n",
+    "    c = Circle(\n",
+    "        (x, y), r, transform=transform, edgecolor=\"0.7\", facecolor=\"none\", lw=3\n",
+    "    )\n",
+    "    ax.add_patch(c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We note that for HGPS there are already spatial models available:\n",
+    "\n",
+    "    print(source.spatial_model())\n",
+    "    source.components[0].spatial_model\n",
+    "\n",
+    "With some effort, you can use those to make HGPS model flux images.\n",
+    "\n",
+    "There are two reasons we're not showing this here: First, the spatial model code in Gammapy is work in progress, it will change soon. Secondly, doing morphology measurements on the public HGPS maps is discouraged; we note again that the maps are correlated and no detailed PSF information is published. So please be careful / conservative when extracting quantitative mesurements from the HGPS maps e.g. for a source of interest for you."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusions\n",
+    "\n",
+    "This concludes this tutorial how to access and work with the HGPS data from Python, using Astropy and Gammapy.\n",
+    "\n",
+    "\n",
+    "* If you have any questions about the HGPS data, please use the contact given at https://www.mpi-hd.mpg.de/hfm/HESS/hgps/ .\n",
+    "* If you have any questions or issues about Astropy or Gammapy, please use the Gammapy mailing list (see http://gammapy.org/contact.html).\n",
+    "\n",
+    "**Please read the Appendix A of the paper to learn about the caveats to using the HGPS data. Especially note that the HGPS survey maps are correlated and thus no detailed source morphology analysis is possible, and also note the caveats concerning spectral models and spectral flux points.**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Re-run this notebook, but change the HGPS source that was used for examples. If you have any questions about the data, try to access and print or plot it. Just to give a few ideas: How many identified pulsar wind nebulae are in HGPS? Which are the 5 brightest HGPS sources in the 1-10 TeV energy band? Which is the second-highest significance source in the HPGS image after the Galactic center?\n",
+    "* Try to reproduce some of the figures in the HGPS paper. Don't try to reproduce them exactly, but just try to write ~ 10 lines of code to access the relevant HGPS data and make a quick plot that shows the same or similar information.\n",
+    "* Fit a spectral model to the spectral points of Vela X and compare with the HGPS model fit. (they should be similar, but not identical, in HGPS a likelihood fit to counts data was done). For this task, the [spectrum_models](http://docs.gammapy.org/dev/notebooks/spectrum_models.html) and [sed_fitting_gammacat_fermi](http://docs.gammapy.org/dev/notebooks/sed_fitting_gammacat_fermi.html) tutorials will be useful.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fitting 2D images with Sherpa\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "Sherpa is the X-ray satellite Chandra modeling and fitting application. It enables the user to construct complex models from simple definitions and fit those models to data, using a variety of statistics and optimization methods. \n",
+    "The issues of constraining the source position and morphology are common in X- and Gamma-ray astronomy. \n",
+    "This notebook will show you how to apply Sherpa to CTA data.\n",
+    "\n",
+    "Here we will set up Sherpa to fit the counts map and loading the ancillary images for subsequent use. A relevant test statistic for data with Poisson fluctuations is the one proposed by Cash (1979). The simplex (or Nelder-Mead) fitting algorithm is a good compromise between efficiency and robustness. The source fit is best performed in pixel coordinates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read sky images\n",
+    "The sky image that are loaded here have been prepared in a separated notebook. Here we start from those fits file and focus on the source fitting aspect.\n",
+    "\n",
+    "The info needed for sherpa are:\n",
+    "- Count map\n",
+    "- Background map\n",
+    "- Exposure map\n",
+    "- PSF map\n",
+    "\n",
+    "For info, the fits file are written in the following way in the Sky map generation notebook:\n",
+    "\n",
+    "```\n",
+    "images['counts']    .write(\"G300-0_test_counts.fits\", clobber=True)\n",
+    "images['exposure']  .write(\"G300-0_test_exposure.fits\", clobber=True)\n",
+    "images['background'].write(\"G300-0_test_background.fits\", clobber=True)\n",
+    "\n",
+    "##As psf is an array of quantities we cannot use the images['psf'].write() function\n",
+    "##all the other arrays do not have quantities. \n",
+    "fits.writeto(\"G300-0_test_psf.fits\",images['psf'].data.value,overwrite=True)\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import astropy.units as u\n",
+    "from astropy.io import fits\n",
+    "from astropy.wcs import WCS\n",
+    "from gammapy.maps import Map, WcsNDMap, WcsGeom\n",
+    "\n",
+    "# Warnings about XSPEC or DS9 can be ignored here\n",
+    "import sherpa.astro.ui as sh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read the fits file to load them in a sherpa model\n",
+    "hdr = fits.getheader(\"G300-0_test_counts.fits\")\n",
+    "wcs = WCS(hdr)\n",
+    "\n",
+    "sh.set_stat(\"cash\")\n",
+    "sh.set_method(\"simplex\")\n",
+    "sh.load_image(\"G300-0_test_counts.fits\")\n",
+    "sh.set_coord(\"logical\")\n",
+    "\n",
+    "sh.load_table_model(\"expo\", \"G300-0_test_exposure.fits\")\n",
+    "sh.load_table_model(\"bkg\", \"G300-0_test_background.fits\")\n",
+    "sh.load_psf(\"psf\", \"G300-0_test_psf.fits\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In principle one might first want to fit the background amplitude. However the background estimation method already yields the correct normalization, so we freeze the background amplitude to unity instead of adjusting it. The (smoothed) residuals from this background model are then computed and shown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sh.set_full_model(bkg)\n",
+    "bkg.ampl = 1\n",
+    "sh.freeze(bkg)\n",
+    "\n",
+    "resid = Map.read(\"G300-0_test_counts.fits\")\n",
+    "resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
+    "resid_smooth = resid.smooth(radius=6)\n",
+    "resid_smooth.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Find and fit the brightest source\n",
+    "We then find the position of the maximum in the (smoothed) residuals map, and fit a (symmetrical) Gaussian source with that initial position:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "yp, xp = np.unravel_index(\n",
+    "    np.nanargmax(resid_smooth.data), resid_smooth.data.shape\n",
+    ")\n",
+    "ampl = resid_smooth.get_by_pix((xp, yp))[0]\n",
+    "\n",
+    "sh.set_full_model(\n",
+    "    bkg + psf(sh.gauss2d.g0) * expo\n",
+    ")  # creates g0 as a gauss2d instance\n",
+    "g0.xpos, g0.ypos = xp, yp\n",
+    "sh.freeze(g0.xpos, g0.ypos)  # fix the position in the initial fitting step\n",
+    "\n",
+    "expo.ampl = (\n",
+    "    1e-9\n",
+    ")  # fix exposure amplitude so that typical exposure is of order unity\n",
+    "sh.freeze(expo)\n",
+    "sh.thaw(g0.fwhm, g0.ampl)  # in case frozen in a previous iteration\n",
+    "\n",
+    "g0.fwhm = 10  # give some reasonable initial values\n",
+    "g0.ampl = ampl"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "sh.fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fit all parameters of this Gaussian component, fix them and re-compute the residuals map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sh.thaw(g0.xpos, g0.ypos)\n",
+    "sh.fit()\n",
+    "sh.freeze(g0)\n",
+    "\n",
+    "resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
+    "resid_smooth = resid.smooth(radius=6)\n",
+    "resid_smooth.plot(vmin=-0.5, vmax=1);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Iteratively find and fit additional sources\n",
+    "Instantiate additional Gaussian components, and use them to iteratively fit sources, repeating the steps performed above for component g0. (The residuals map is shown after each additional source included in the model.) This takes some time..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# initialize components with fixed, zero amplitude\n",
+    "for i in range(1, 6):\n",
+    "    model = sh.create_model_component(\"gauss2d\", \"g\" + str(i))\n",
+    "    model.ampl = 0\n",
+    "    sh.freeze(model)\n",
+    "\n",
+    "gs = [g0, g1, g2, g3, g4, g5]\n",
+    "sh.set_full_model(bkg + psf(g0 + g1 + g2 + g3 + g4 + g5) * expo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "for i in range(1, len(gs)):\n",
+    "    yp, xp = np.unravel_index(\n",
+    "        np.nanargmax(resid_smooth.data), resid_smooth.data.shape\n",
+    "    )\n",
+    "    ampl = resid_smooth.get_by_pix((xp, yp))[0]\n",
+    "    gs[i].xpos, gs[i].ypos = xp, yp\n",
+    "    gs[i].fwhm = 10\n",
+    "    gs[i].ampl = ampl\n",
+    "\n",
+    "    sh.thaw(gs[i].fwhm)\n",
+    "    sh.thaw(gs[i].ampl)\n",
+    "    sh.fit()\n",
+    "\n",
+    "    sh.thaw(gs[i].xpos)\n",
+    "    sh.thaw(gs[i].ypos)\n",
+    "    sh.fit()\n",
+    "    sh.freeze(gs[i])\n",
+    "\n",
+    "    resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
+    "    resid_smooth = resid.smooth(radius=6)\n",
+    "    resid_smooth.plot(vmin=-0.5, vmax=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generating output table and Test Statistics estimation\n",
+    "When adding a new source, one need to check the significance of this new source. A frequently used method is the Test Statistics (TS). This is done by comparing the change of statistics when the source is included compared to the null hypothesis (no source ; in practice here we fix the amplitude to zero).\n",
+    "\n",
+    "$TS = Cstat(source) - Cstat(no source)$\n",
+    "\n",
+    "The criterion for a significant source detection is typically that it should improve the test statistic by at least 25 or 30. The last excess fitted (g5) thus not a significant source:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.stats import gaussian_fwhm_to_sigma\n",
+    "from astropy.table import Table\n",
+    "\n",
+    "rows = []\n",
+    "for g in gs:\n",
+    "    ampl = g.ampl.val\n",
+    "    g.ampl = 0\n",
+    "    stati = sh.get_stat_info()[0].statval\n",
+    "    g.ampl = ampl\n",
+    "    statf = sh.get_stat_info()[0].statval\n",
+    "    delstat = stati - statf\n",
+    "\n",
+    "    geom = resid.geom\n",
+    "    coord = geom.pix_to_coord((g.xpos.val, g.ypos.val))\n",
+    "    pix_scale = geom.pixel_scales.mean().deg\n",
+    "    sigma = g.fwhm.val * pix_scale * gaussian_fwhm_to_sigma\n",
+    "    rows.append(\n",
+    "        dict(delstat=delstat, glon=coord[0], glat=coord[1], sigma=sigma)\n",
+    "    )\n",
+    "\n",
+    "table = Table(rows=rows, names=rows[0])\n",
+    "for name in table.colnames:\n",
+    "    table[name].format = \".5g\"\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* If you look back to the original image: there's one source that looks like a shell-type supernova remnant.\n",
+    "    * Try to fit is with a shell morphology model (use ``sh.shell2d('shell')`` to create such a model).\n",
+    "    * Try to evaluate the ``TS`` and probability of the shell model compared to a Gaussian model hypothesis\n",
+    "    * You could also try a disk model (use ``sh.disk2d('disk')`` to create one)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "These are good resources to learn more about Sherpa:\n",
+    "\n",
+    "* https://python4astronomers.github.io/fitting/fitting.html\n",
+    "* https://github.com/DougBurke/sherpa-standalone-notebooks\n",
+    "\n",
+    "You could read over the examples there, and try to apply a similar analysis to this dataset here to practice.\n",
+    "\n",
+    "If you want a deeper understanding of how Sherpa works, then these proceedings are good introductions:\n",
+    "\n",
+    "* http://conference.scipy.org/proceedings/scipy2009/paper_8/full_text.pdf\n",
+    "* http://conference.scipy.org/proceedings/scipy2011/pdfs/brefsdal.pdf"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/intro_maps.ipynb
+++ b/tutorials/intro_maps.ipynb
@@ -1,0 +1,1034 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Gammapy Maps\n",
+    "\n",
+    "![Gammapy Maps Illustration](images/gammapy_maps.png)\n",
+    "\n",
+    "## Introduction\n",
+    "The [gammapy.maps](http://docs.gammapy.org/dev/maps/index.html) submodule contains classes for representing **sky images** with an **arbitrary number of non-spatial dimensions** such as energy, time, event class or any possible user-defined dimension (illustrated in the image above). The main `Map` data structure features a **uniform API** for [WCS](https://fits.gsfc.nasa.gov/fits_wcs.html) as well as [HEALPix](https://en.wikipedia.org/wiki/HEALPix) based images. The API also generalizes simple image based operations such as smoothing, interpolation and reprojection to the arbitrary extra dimensions and makes working with (2 + N)-dimensional hypercubes **as easy as working with a simple 2D image**. Further information is also provided on the [gammpy.maps](http://docs.gammapy.org/dev/maps/index.html) docs page.\n",
+    "\n",
+    "\n",
+    "In the following introduction we will **learn all the basics** of working with WCS based maps. HEALPix based maps will be covered in a future tutorial. We will cover the following topics in order:\n",
+    "\n",
+    "1. [Creating WCS Maps](#1.-Creating-WCS-Maps)\n",
+    "1. [Accessing and Modifying Data](#2.-Accessing-and-Modifying-Data)\n",
+    "1. [Reading and Writing](#3.-Reading-and-Writing)\n",
+    "1. [Visualizing and Plotting](#4.-Visualizing-and-Plotting)\n",
+    "1. [Reprojecting, Interpolating and Miscellaneous](#5.-Reprojecting,-Interpolating-and-Miscellaneous)\n",
+    "\n",
+    "\n",
+    "Make sure you have worked through he [First Steps with Gammapy](first_steps.ipynb) and [Astropy Introduction](astropy_introduction.ipynb) notebooks, because a solid knowledge about working with `SkyCoords` and `Quantity` objects as well as [Numpy](http://www.numpy.org/) is required for this tutorial.\n",
+    "\n",
+    "**Note:** This notebook is rather lengthy, but getting to know the `Map` data structure in detail is **essential for working with Gammapy** and will allow you to fulfill **complex analysis tasks with very few and simple code** in future!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  0. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u\n",
+    "from astropy.io import fits\n",
+    "from astropy.table import Table\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from gammapy.maps import Map, MapAxis, WcsGeom"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Creating WCS Maps\n",
+    "\n",
+    "### 1.1 Using Factory Methods\n",
+    "\n",
+    "Maps are most easily created using the `Map.create()` factory method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_allsky = Map.create()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling `Map.create()` without any further arguments creates by default an allsky WCS map using a CAR projection, ICRS coordinates and a pixel size of 1 deg. This can be easily checked by printing the `.geom` attribute of the map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(m_allsky.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `.geom` attribute is a `MapGeom` object, that defines the basic geometry of the map, such as size of the pixels, width and height of the image, coordinate system etc., but we will learn more about this object later.\n",
+    "\n",
+    "Besides the `.geom` attribute the map has also a `.data` attribute, which is just a plain `numpy.ndarray` and stores the data associated with this map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_allsky.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default maps are filled with zeros.\n",
+    "\n",
+    "Here is a second example that creates a WCS map centered on the Galactic center and now uses Galactic coordinates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skydir = SkyCoord(0, 0, frame=\"galactic\", unit=\"deg\")\n",
+    "m_gc = Map.create(\n",
+    "    binsz=0.02, width=(10, 5), skydir=skydir, coordsys=\"GAL\", proj=\"TAN\"\n",
+    ")\n",
+    "print(m_gc.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition we have defined a TAN projection, a pixel size of `0.02` deg and a width of the map of `10 deg x 5 deg`. The `width` argument also takes scalar value instead of a tuple, which is interpreted as both the width and height of the map, so that a quadratic map is created."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Creating from a Map Geometry\n",
+    "\n",
+    "As we have seen in the first examples, the `Map` object couples the data (stored as a `numpy.ndarray`) with a `MapGeom` object. The `MapGeom` object can be seen as a generalization of an `astropy.wcs.WCS` object, providing the information on how the data maps to physical coordinate systems. In some cases e.g. when creating many maps with the same WCS geometry it can be advantegeous to first create the map geometry independent of the map object itsself: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs_geom = WcsGeom.create(\n",
+    "    binsz=0.02, width=(10, 5), skydir=(0, 0), coordsys=\"GAL\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then create the map objects from the `wcs_geom` geometry specification:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maps = {}\n",
+    "\n",
+    "for name in [\"counts\", \"background\"]:\n",
+    "    maps[name] = Map.from_geom(wcs_geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `MapGeom` object also has a few helpful methods. E.g. we can check whether a given position on the sky is contained in the map geometry:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the position of the Galactic center and anti-center\n",
+    "positions = SkyCoord([0, 180], [0, 0], frame=\"galactic\", unit=\"deg\")\n",
+    "wcs_geom.contains(positions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or get the image center of the map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs_geom.center_skydir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can also retrieve the solid angle per pixel of the map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs_geom.solid_angle()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.3 Adding Non-Spatial Axes\n",
+    "\n",
+    "In many analysis scenarios we would like to add extra dimension to the maps to study e.g. energy or time dependency of the data. Those non-spatial dimensions are handled with the `MapAxis` object. Let us first define an energy axis, with 4 bins:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_axis = MapAxis.from_bounds(\n",
+    "    1, 100, nbin=4, unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
+    ")\n",
+    "print(energy_axis)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where `interp='log'` specifies that a logarithmic spacing is used between the bins, equivalent to `np.logspace(0, 2, 4)`. This `MapAxis` object we can now pass to `Map.create()` using the `axes=` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube = Map.create(\n",
+    "    binsz=0.02, width=(10, 5), coordsys=\"GAL\", axes=[energy_axis]\n",
+    ")\n",
+    "print(m_cube.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we see that besides `lon` and `lat` the map has an additional axes named `energy` with 4 bins. The total dimension of the map is now `ndim=3`.\n",
+    "\n",
+    "We can also add further axes by passing a list of `MapAxis` objects. To demonstrate this we create a time axis with\n",
+    "linearly spaced bins and pass both axes to `Map.create()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_axis = MapAxis.from_bounds(\n",
+    "    0, 24, nbin=24, unit=\"hour\", name=\"time\", interp=\"lin\"\n",
+    ")\n",
+    "\n",
+    "m_4d = Map.create(\n",
+    "    binsz=0.02, width=(10, 5), coordsys=\"GAL\", axes=[energy_axis, time_axis]\n",
+    ")\n",
+    "print(m_4d.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `MapAxis` object internally stores the coordinates or \"position values\" associated with every map axis bin or \"node\". We distinguish between two node types: `edges` and `center`. The node type `edges`(which is also the default) specifies that the data associated with this axis is integrated between the edges of the bin (e.g. counts data). The node type `center` specifies that the data is given at the center of the bin (e.g. exposure or differential fluxes).\n",
+    "\n",
+    "The edges of the bins can be checked with `.edges` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_axis.edges"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The numbers are given in the units we specified above, which can be checked again with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_axis.unit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The centers of the axis bins can be checked with the `.center` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_axis.center"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  2. Accessing and Modifying Data\n",
+    "\n",
+    "### 2.1 Accessing Map Data Values\n",
+    "\n",
+    "All map objects have a set of accessor methods, which can be used to access or update the contents of the map irrespective of its underlying representation. Those accessor methods accept as their first argument a coordinate `tuple` containing scalars, `list`, or `numpy.ndarray` with one tuple element for each dimension. Some methods additionally accept a `dict` or `MapCoord` argument, of which both allow to assign coordinates by axis name.\n",
+    "\n",
+    "Let us first begin with the `.get_by_idx()` method, that accepts a tuple of indices. The order of the indices corresponds to the axis order of the map: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_gc.get_by_idx((50, 30))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Important:** Gammapy uses a reversed index order in the map API with the longitude axes first. To achieve the same by directly indexing into the numpy array we have to call:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_gc.data[([30], [50])]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To check the order of the axes you can always print the `.geom` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(m_gc.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access values directly by sky coordinates we can use the `.get_by_coord()` method. This time we pass in a `dict`, specifying the axes names corresponding to the given coordinates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_gc.get_by_coord({\"lon\": [0, 180], \"lat\": [0, 0]})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The units of the coordinates are assumed to be in degrees in the coordinate system used by the map. If the coordinates do not correspond to the exact pixel center, the value of the nearest pixel center will be returned. For positions outside the map geometry `np.nan` is returned.\n",
+    "\n",
+    "The coordinate or idx arrays follow normal [Numpy broadcasting rules](https://jakevdp.github.io/PythonDataScienceHandbook/02.05-computation-on-arrays-broadcasting.html). So the following works as expected:\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lons = np.linspace(-4, 4, 10)\n",
+    "m_gc.get_by_coord({\"lon\": lons, \"lat\": 0})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or as an even more advanced example, we can provide `lats` as column vector and broadcasting to a 2D result array will be applied:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lons = np.linspace(-4, 4, 8)\n",
+    "lats = np.linspace(-4, 4, 8).reshape(-1, 1)\n",
+    "m_gc.get_by_coord({\"lon\": lons, \"lat\": lats})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 Modifying Map Data Values\n",
+    "\n",
+    "To modify and set map data values the `Map` object features as well a `.set_by_idx()` method: \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube.set_by_idx(idx=(10, 20, 3), vals=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube.get_by_idx((10, 20, 3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course there is also a `.set_by_coord()` method, which allows to set map data values in physical coordinates. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube.set_by_coord({\"lon\": 0, \"lat\": 0, \"energy\": 2 * u.TeV}, vals=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again the `lon` and `lat` values are assumed to be given in degrees in the coordinate system used by the map. For the energy axis, the unit is the one specified on the axis (use `m_cube.geom.axes[0].unit` to check if needed...)\n",
+    "\n",
+    "All `.xxx_by_coord()` methods accept `SkyCoord` objects as well. In this case we have to use the `skycoord` keyword instead of `lon` and `lat`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skycoords = SkyCoord([1.2, 3.4], [-0.5, 1.1], frame=\"galactic\", unit=\"deg\")\n",
+    "m_cube.set_by_coord({\"skycoord\": skycoords, \"energy\": 2 * u.TeV}, vals=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Indexing and Slicing Sub-Maps\n",
+    "\n",
+    "When you have worked with Numpy arrays in the past you are probably familiar with the concept of indexing and slicing\n",
+    "into data arrays. To support slicing of non-spatial axes of `Map` objects, the `Map` object has a `.slice_by_idx()` method, which allows to extract sub-maps from a larger map.\n",
+    "\n",
+    "The following example demonstrates how to get the map at the energy bin number 3:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_sub = m_cube.slice_by_idx({\"energy\": 3})\n",
+    "print(m_sub)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the returned object is again a `Map` with updated axes information. In this case, because we extracted only a single image, the energy axes is dropped from the map.\n",
+    "\n",
+    "To extract a sub-cube with a sliced energy axes we can use a normal `slice()` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_sub = m_cube.slice_by_idx({\"energy\": slice(1, 3)})\n",
+    "print(m_sub)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the returned object is also a `Map` object, but this time with updated energy axis specification.\n",
+    "\n",
+    "Slicing of multiple dimensions is supported by adding further entries to the dict passed to `.slice_by_idx()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_sub = m_4d.slice_by_idx({\"energy\": slice(1, 3), \"time\": slice(4, 10)})\n",
+    "print(m_sub)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For convenience there is also a `.get_image_by_coord()` method which allows to access image planes at given non-spatial physical coordinates. This method also supports `Quantity` objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = m_4d.get_image_by_coord({\"energy\": 4 * u.TeV, \"time\": 5 * u.h})\n",
+    "print(image.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  3. Reading and Writing\n",
+    "\n",
+    "Gammapy `Map` objects are serialized using the Flexible Image Transport Format (FITS). Depending on the pixelisation scheme (HEALPix or WCS) and presence of non-spatial dimensions the actual convention to write the FITS file is different.\n",
+    "By default Gammpy uses a generic convention named `gadf`, which will support WCS and HEALPix formats as well as an arbitrary number of non-spatial axes. The convention is documented in detail on the [Gamma Astro Data Formats](https://gamma-astro-data-formats.readthedocs.io/en/latest/skymaps/index.html) page.\n",
+    "\n",
+    "Other conventions required by specific software (e.g. the Fermi Science Tools) are supported as well. At the moment those are the following\n",
+    "\n",
+    "* `fgst-ccube`: Fermi counts cube format.\n",
+    "* `fgst-ltcube`: Fermi livetime cube format.\n",
+    "* `fgst-bexpcube`: Fermi exposure cube format\n",
+    "* `fgst-template`: Fermi Galactic diffuse and source template format. \n",
+    "* `fgst-srcmap` and `fgst-srcmap-sparse`: Fermi source map and sparse source map format.\n",
+    "\n",
+    "The conventions listed above only support an additional energy axis. \n",
+    "\n",
+    "### 3.1 Reading Maps\n",
+    "\n",
+    "Reading FITS files is mainly exposed via the `Map.read()` method.Let us take a look at a first example: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_gc.fits.gz\"\n",
+    "m_2fhl_gc = Map.read(filename)\n",
+    "print(m_2fhl_gc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default `Map.read()` will try to find the first valid data hdu in the filename and read the data from there. If mutliple HDUs are present in the FITS file, the desired one can be chosen with the additional `hdu=` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_2fhl_gc = Map.read(filename, hdu=\"background\")\n",
+    "print(m_2fhl_gc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In rare cases e.g. when the FITS file is not valid or meta data is missing from the header it can be necessary to modify the header of a certain HDU before creating the `Map` object. In this case we can use `astropy.io.fits` directly to read the FITS file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist = fits.open(\"../datasets/fermi_survey/all.fits.gz\")\n",
+    "hdulist.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And then modify the header keyword and use `Map.from_hdulist()` to create the `Map` object after:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist[\"exposure\"].header[\"BUNIT\"] = \"cm2 s\"\n",
+    "Map.from_hdulist(hdulist=hdulist, hdu=\"exposure\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 Writing Maps\n",
+    "\n",
+    "Writing FITS files is mainoy exposure via the `Map.write()` method. Here is a first example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube.write(\"example_cube.fits\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default Gammapy does not overwrite files. In this example we set `overwrite=True` in case the cell gets executed multiple times. Now we can read back the cube from disk using `Map.read()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube = Map.read(\"example_cube.fits\")\n",
+    "print(m_cube)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also choose a different FITS convention to write the example cube in a format compatible to the Fermi Galactic diffuse background model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_cube.write(\"example_cube_fgst.fits\", conv=\"fgst-template\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To understand a little bit better the generic `gadf` convention we use `Map.to_hdulist()` to generate a list of FITS HDUs first:   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist = m_4d.to_hdulist(conv=\"gadf\")\n",
+    "hdulist.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see the `HDUList` object contains to HDUs. The first one named `PRIMARY` contains the data array with shape corresponding to our data and the WCS information stored in the header:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist[\"PRIMARY\"].header"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The second HDU is a `BinTableHDU` named `PRIMARY_BANDS` contains the information on the non-spatial axes such as name, order, unit, min, max and center values of the axis bins. We use an `astropy.table.Table` to show the information:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Table.read(hdulist[\"PRIMARY_BANDS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  4. Visualizing and Plotting\n",
+    "\n",
+    "### 4.1 Plotting \n",
+    "\n",
+    "For debugging and inspecting the map data it is useful to plot ot visualize the images planes contained in the map. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_gc.fits.gz\"\n",
+    "m_2fhl_gc = Map.read(filename, hdu=\"counts\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After reading the map we can now plot it on the screen by calling the `.plot()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_2fhl_gc.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can easily improve the plot by calling `Map.smooth()` first and providing additional arguments to `.plot()`. Most of them are passed further to [plt.imshow()](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.imshow.html):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smoothed = m_2fhl_gc.smooth(radius=0.2 * u.deg, kernel=\"gauss\")\n",
+    "smoothed.plot(stretch=\"sqrt\", add_cbar=True, vmax=4, cmap=\"inferno\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the [plt.rc_context()](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.rc_context.html) context manager to further tweak the plot by adapting the figure and font size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rc_params = {\"figure.figsize\": (12, 5.4), \"font.size\": 12}\n",
+    "with plt.rc_context(rc=rc_params):\n",
+    "    smoothed = m_2fhl_gc.smooth(radius=0.2 * u.deg, kernel=\"gauss\")\n",
+    "    smoothed.plot(stretch=\"sqrt\", add_cbar=True, vmax=4);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 Interactive Plotting \n",
+    "\n",
+    "For maps with non-spatial dimensions the `Map` object features an interactive plotting method, that works in jupyter notebooks only (**Note:** it requires the package `ipywidgets` to be installed). We first read a small example cutout from the Fermi Galactic diffuse model and display the data cube by calling `.plot_interactive()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
+    "m_iem_gc = Map.read(filename)\n",
+    "\n",
+    "rc_params = {\n",
+    "    \"figure.figsize\": (12, 5.4),\n",
+    "    \"font.size\": 12,\n",
+    "    \"axes.formatter.limits\": (2, -2),\n",
+    "}\n",
+    "m_iem_gc.plot_interactive(add_cbar=True, stretch=\"sqrt\", rc_params=rc_params)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you can use the interactive slider to select an energy range and the corresponding image is diplayed on the screen. You can also use the radio buttons to select your preferred image stretching. We have passed additional keywords using the `rc_params` argument to improve the figure and font size. Those keywords are directly passed to the [plt.rc_context()](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.rc_context.html) context manager."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##  5. Reprojecting, Interpolating and Miscellaneous\n",
+    "\n",
+    "### 5.1 Reprojecting to Different Map Geometries\n",
+    "\n",
+    "The example map `m_iem_gc` is given in Galactic coordinates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(m_iem_gc.geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As an example we will now extract the image at `~10 GeV` and reproject it to ICRS coordinates. For this we first define the target map WCS geometry. As `.reproject()` only applies to the spatial axes, we do not have to specify any additional non-spatial axes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "skydir = SkyCoord(266.4, -28.9, frame=\"icrs\", unit=\"deg\")\n",
+    "wcs_geom_cel = WcsGeom.create(\n",
+    "    skydir=skydir, binsz=0.1, coordsys=\"CEL\", width=(8, 4)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we extract the image at `~10 GeV`, reproject to the target geometry and plot the result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_iem = m_iem_gc.get_image_by_coord({\"energy\": 10 * u.GeV})\n",
+    "m_iem_cel = m_iem.reproject(wcs_geom_cel)\n",
+    "m_iem_cel.plot(add_cbar=True, vmin=0, vmax=2.5e-9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Interpolating Map Values\n",
+    "\n",
+    "While for the reprojection example above we used `.get_image_by_coord()` to extract the closest image to `~10 GeV`, we can use the more general method `.interp_by_coord()` to interpolate in the energy axis as well. For this we first define again the target map geometry:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m_iem_10GeV = Map.from_geom(wcs_geom_cel)\n",
+    "coords = m_iem_10GeV.geom.get_coord()\n",
+    "\n",
+    "m_iem_10GeV.data = m_iem_gc.interp_by_coord(\n",
+    "    {\"skycoord\": coords.skycoord, \"energy\": 10 * u.GeV},\n",
+    "    interp=\"linear\",\n",
+    "    fill_value=np.nan,\n",
+    ")\n",
+    "m_iem_10GeV.plot(add_cbar=True, vmin=0, vmax=2.5e-9);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.3 Making Cutouts\n",
+    "\n",
+    "The `WCSNDMap` objects features a `.cutout()` method, which allows you to cut out a smaller part of a larger map. This can be useful, e.g. when working with allsky diffuse maps. Here is an example: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "position = SkyCoord(0, 0, frame=\"galactic\", unit=\"deg\")\n",
+    "m_iem_cutout = m_iem_gc.cutout(position=position, width=(4 * u.deg, 2 * u.deg))\n",
+    "\n",
+    "rc_params = {\n",
+    "    \"figure.figsize\": (12, 5.4),\n",
+    "    \"font.size\": 12,\n",
+    "    \"axes.formatter.limits\": (2, -2),\n",
+    "}\n",
+    "m_iem_cutout.plot_interactive(\n",
+    "    add_cbar=True, rc_params=rc_params, stretch=\"linear\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The returned object is again a `Map` object with udpated WCS information and data size. As one can see the cutout is automatically applied to all the non-spatial axes as well. The cutout width is given in the order of `(lon, lat)` and can be specified with units that will be handled correctly. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -1,0 +1,154 @@
+# This is a list of available notebooks.
+# It's used for automatic testing and downloading of datesets tutorials.
+# Let's keep it alphabetical.
+- name: analysis_3d
+  test: true
+  requires: iminuit
+  published: true
+  datasets:
+    - cta-1dc
+- name: astro_dark_matter
+  test: true
+  requires:
+  published: true
+  datasets:
+    - dark_matter_spectra
+- name: astropy_introduction
+  test: true
+  requires:
+  published: true
+  datasets:
+    - catalogs/fermi/gll_psc_v16.fit.gz
+- name: background_model
+  test: false
+  requires:
+  published: false
+  datasets:
+    - hess-dl3-dr1
+    - hess-crab4-hd-hap-prod2
+- name: cta_1dc_introduction
+  test: true
+  requires:
+  published: true
+  datasets:
+- name: cta_data_analysis
+  test: true
+  requires: sherpa
+  published: true
+  datasets:
+    - cta-1dc
+- name: cta_sensitivity
+  test: false
+  requires:
+  published: false
+  datasets:
+      - cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz
+- name: cwt
+  test: true
+  requires:
+  published: true
+  datasets:
+    - fermi_survey/all.fits.gz
+- name: detect_ts
+  test: true
+  requires:
+  published: true
+  datasets:
+    - fermi_survey/all.fits.gz
+    - catalogs/fermi/gll_psch_v08.fit.gz
+- name: fermi_lat
+  test: true
+  requires:
+  published: true
+  datasets:
+    - fermi_3fhl
+- name: first_steps
+  test: true
+  requires:
+  published: true
+  datasets:
+    - fermi_2fhl/fermi_2fhl_vela.fits.gz
+    - fermi_2fhl/2fhl_events.fits.gz
+    - images/Vela_region_WMAP_K.fits
+    - catalogs/fermi/gll_psch_v08.fit.gz
+- name: hgps
+  test: true
+  requires:
+  published: true
+  datasets:
+- name: image_fitting_with_sherpa
+  test: true
+  requires: sherpa
+  published: true
+  datasets:
+- name: intro_maps
+  test: true
+  requires:
+  published: true
+  datasets:
+    - fermi_2fhl/fermi_2fhl_gc.fits.gz
+    - fermi_3fhl/gll_iem_v06_cutout.fits
+    - fermi_survey/all.fits.gz
+- name: light_curve
+  test: true
+  requires: iminuit
+  published: false
+  datasets:
+    - hess-dl3-dr1
+- name: nddata_demo
+  test: false
+  requires:
+  published: false
+  datasets:
+- name: sed_fitting_gammacat_fermi
+  test: true
+  requires: iminuit
+  published: true
+  datasets:
+    - catalogs/fermi/gll_psc_v16.fit.gz
+    - catalogs/fermi/gll_psch_v13.fit.gz
+- name: simulate_3d
+  test: true
+  requires: iminuit
+  published: true
+  datasets:
+    - cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits
+- name: source_population_model
+  test: true
+  requires:
+  published: true
+  datasets:
+- name: spectrum_analysis
+  test: true
+  requires: iminuit
+  published: true
+  datasets:
+      - hess-dl3-dr1
+- name: spectrum_fitting_with_sherpa
+  test: true
+  requires: sherpa
+  published: true
+  datasets:
+    - hess-crab4_pha
+- name: spectrum_models
+  test: true
+  requires:
+  published: true
+  datasets:
+- name: spectrum_pipe
+  test: true
+  requires: iminuit
+  published: true
+  datasets:
+    - hess-dl3-dr1
+- name: spectrum_simulation_cta
+  test: false
+  requires: iminuit
+  published: true
+  datasets:
+    - cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits
+- name: spectrum_simulation
+  test: false
+  requires: iminuit
+  published: false
+  datasets:

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -2,153 +2,80 @@
 # It's used for automatic testing and downloading of datesets tutorials.
 # Let's keep it alphabetical.
 - name: analysis_3d
-  test: true
   requires: iminuit
-  published: true
   datasets:
     - cta-1dc
 - name: astro_dark_matter
-  test: true
   requires:
-  published: true
   datasets:
     - dark_matter_spectra
 - name: astropy_introduction
-  test: true
   requires:
-  published: true
   datasets:
     - catalogs/fermi/gll_psc_v16.fit.gz
-- name: background_model
-  test: false
-  requires:
-  published: false
-  datasets:
-    - hess-dl3-dr1
-    - hess-crab4-hd-hap-prod2
 - name: cta_1dc_introduction
-  test: true
   requires:
-  published: true
   datasets:
 - name: cta_data_analysis
-  test: true
   requires: sherpa
-  published: true
   datasets:
     - cta-1dc
-- name: cta_sensitivity
-  test: false
-  requires:
-  published: false
-  datasets:
-      - cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz
 - name: cwt
-  test: true
   requires:
-  published: true
   datasets:
     - fermi_survey/all.fits.gz
 - name: detect_ts
-  test: true
   requires:
-  published: true
   datasets:
     - fermi_survey/all.fits.gz
     - catalogs/fermi/gll_psch_v08.fit.gz
 - name: fermi_lat
-  test: true
   requires:
-  published: true
   datasets:
     - fermi_3fhl
 - name: first_steps
-  test: true
   requires:
-  published: true
   datasets:
     - fermi_2fhl/fermi_2fhl_vela.fits.gz
     - fermi_2fhl/2fhl_events.fits.gz
     - images/Vela_region_WMAP_K.fits
     - catalogs/fermi/gll_psch_v08.fit.gz
 - name: hgps
-  test: true
   requires:
-  published: true
   datasets:
 - name: image_fitting_with_sherpa
-  test: true
   requires: sherpa
-  published: true
   datasets:
 - name: intro_maps
-  test: true
   requires:
-  published: true
   datasets:
     - fermi_2fhl/fermi_2fhl_gc.fits.gz
     - fermi_3fhl/gll_iem_v06_cutout.fits
     - fermi_survey/all.fits.gz
-- name: light_curve
-  test: true
-  requires: iminuit
-  published: false
-  datasets:
-    - hess-dl3-dr1
-- name: nddata_demo
-  test: false
-  requires:
-  published: false
-  datasets:
 - name: sed_fitting_gammacat_fermi
-  test: true
   requires: iminuit
-  published: true
   datasets:
     - catalogs/fermi/gll_psc_v16.fit.gz
     - catalogs/fermi/gll_psch_v13.fit.gz
 - name: simulate_3d
-  test: true
   requires: iminuit
-  published: true
   datasets:
     - cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits
 - name: source_population_model
-  test: true
   requires:
-  published: true
   datasets:
 - name: spectrum_analysis
-  test: true
   requires: iminuit
-  published: true
   datasets:
       - hess-dl3-dr1
 - name: spectrum_fitting_with_sherpa
-  test: true
   requires: sherpa
-  published: true
   datasets:
     - hess-crab4_pha
 - name: spectrum_models
-  test: true
   requires:
-  published: true
   datasets:
 - name: spectrum_pipe
-  test: true
   requires: iminuit
-  published: true
   datasets:
     - hess-dl3-dr1
-- name: spectrum_simulation_cta
-  test: false
-  requires: iminuit
-  published: true
-  datasets:
-    - cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits
-- name: spectrum_simulation
-  test: false
-  requires: iminuit
-  published: false
-  datasets:

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -1,0 +1,456 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Flux point fitting in Gammapy\n",
+    "\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "In this tutorial we're going to learn how to fit spectral models to combined Fermi-LAT and IACT flux points.\n",
+    "\n",
+    "The central class we're going to use for this example analysis is:  \n",
+    "\n",
+    "- [gammapy.spectrum.FluxPointFitter](http://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPointFitter.html)\n",
+    "\n",
+    "In addition we will work with the following data classes:\n",
+    "\n",
+    "- [gammapy.spectrum.FluxPoints](http://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPoints.html)\n",
+    "- [gammapy.catalog.SourceCatalogGammaCat](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalogGammaCat.html)\n",
+    "- [gammapy.catalog.SourceCatalog3FHL](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalog3FHL.html)\n",
+    "- [gammapy.catalog.SourceCatalog3FGL](http://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalog3FGL.html)\n",
+    "\n",
+    "And the following spectral model classes:\n",
+    "\n",
+    "- [PowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html)\n",
+    "- [ExponentialCutoffPowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.ExponentialCutoffPowerLaw.html)\n",
+    "- [LogParabola](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.LogParabola.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Let us start with the usual IPython notebook and Python imports:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u\n",
+    "from gammapy.spectrum.models import (\n",
+    "    PowerLaw,\n",
+    "    ExponentialCutoffPowerLaw,\n",
+    "    LogParabola,\n",
+    ")\n",
+    "from gammapy.spectrum import FluxPointFitter, FluxPoints\n",
+    "from gammapy.catalog import (\n",
+    "    SourceCatalog3FGL,\n",
+    "    SourceCatalogGammaCat,\n",
+    "    SourceCatalog3FHL,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load spectral points\n",
+    "\n",
+    "For this analysis we choose to work with the source 'HESS J1507-622' and the associated Fermi-LAT sources '3FGL J1506.6-6219' and '3FHL J1507.9-6228e'. We load the source catalogs, and then access source of interest by name:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fermi_3fgl = SourceCatalog3FGL()\n",
+    "fermi_3fhl = SourceCatalog3FHL()\n",
+    "gammacat = SourceCatalogGammaCat()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_gammacat = gammacat[\"HESS J1507-622\"]\n",
+    "source_fermi_3fgl = fermi_3fgl[\"3FGL J1506.6-6219\"]\n",
+    "source_fermi_3fhl = fermi_3fhl[\"3FHL J1507.9-6228e\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The corresponding flux points data can be accessed with `.flux_points` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_points_gammacat = source_gammacat.flux_points\n",
+    "flux_points_gammacat.table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the Fermi-LAT catalogs, integral flux points are given. Currently the flux point fitter only works with differential flux points, so we apply the conversion here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_points_3fgl = source_fermi_3fgl.flux_points.to_sed_type(\n",
+    "    sed_type=\"dnde\", model=source_fermi_3fgl.spectral_model\n",
+    ")\n",
+    "flux_points_3fhl = source_fermi_3fhl.flux_points.to_sed_type(\n",
+    "    sed_type=\"dnde\", model=source_fermi_3fhl.spectral_model\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we stack the flux points into a single `FluxPoints` object and drop the upper limit values, because currently we can't handle them in the fit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# stack flux point tables\n",
+    "flux_points = FluxPoints.stack(\n",
+    "    [flux_points_gammacat, flux_points_3fhl, flux_points_3fgl]\n",
+    ")\n",
+    "\n",
+    "# drop the flux upper limit values\n",
+    "flux_points = flux_points.drop_ul()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fitter Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We initialze the fitter object with the `'chi2assym'` statistic, because we have assymmetric errors on the flux points. As optimizer we choose the `'simplex'` algorithm and to estimate the errors we use `'covar'` method: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fitter = FluxPointFitter(\n",
+    "    stat=\"chi2assym\", optimizer=\"minuit\", opts_minuit={\"print_level\": 1}\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power Law Fit\n",
+    "\n",
+    "First we start with fitting a simple [power law](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html#gammapy.spectrum.models.PowerLaw)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl = PowerLaw(\n",
+    "    index=2, amplitude=1e-12 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1. * u.TeV\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After creating the model we run the fit by passing the `'flux_points'` and `'pwl'` objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_pwl = fitter.run(flux_points, pwl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And print the result:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result_pwl[\"best-fit-model\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a quick check we print the value of the fit statistics per degrees of freedom as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result_pwl[\"statval/dof\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we plot the data points and the best fit model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = flux_points.plot(energy_power=2)\n",
+    "result_pwl[\"best-fit-model\"].plot(\n",
+    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    ")\n",
+    "result_pwl[\"best-fit-model\"].plot_error(\n",
+    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    ")\n",
+    "ax.set_ylim(1e-13, 1e-11);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exponential Cut-Off Powerlaw Fit\n",
+    "\n",
+    "Next we fit an [exponential cut-off power](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.ExponentialCutoffPowerLaw.html#gammapy.spectrum.models.ExponentialCutoffPowerLaw) law to the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ecpl = ExponentialCutoffPowerLaw(\n",
+    "    index=2,\n",
+    "    amplitude=1e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
+    "    reference=1. * u.TeV,\n",
+    "    lambda_=0.1 / u.TeV,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We run the fitter again by passing the flux points and the `ecpl` model instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_ecpl = fitter.run(flux_points, ecpl)\n",
+    "print(result_ecpl[\"best-fit-model\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result_ecpl[\"statval/dof\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We plot the data and best fit model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = flux_points.plot(energy_power=2)\n",
+    "result_ecpl[\"best-fit-model\"].plot(\n",
+    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    ")\n",
+    "result_ecpl[\"best-fit-model\"].plot_error(\n",
+    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    ")\n",
+    "ax.set_ylim(1e-13, 1e-11)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Log-Parabola Fit\n",
+    "\n",
+    "Finally we try to fit a [log-parabola](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.LogParabola.html#gammapy.spectrum.models.LogParabola) model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "log_parabola = LogParabola(\n",
+    "    alpha=2,\n",
+    "    amplitude=1e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
+    "    reference=1. * u.TeV,\n",
+    "    beta=0.1 * u.Unit(\"\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_log_parabola = fitter.run(flux_points, log_parabola)\n",
+    "print(result_log_parabola[\"best-fit-model\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result_log_parabola[\"statval/dof\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = flux_points.plot(energy_power=2)\n",
+    "result_log_parabola[\"best-fit-model\"].plot(\n",
+    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    ")\n",
+    "result_log_parabola[\"best-fit-model\"].plot_error(\n",
+    "    energy_range=[1e-4, 1e2] * u.TeV, ax=ax, energy_power=2\n",
+    ")\n",
+    "ax.set_ylim(1e-13, 1e-11);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "- Fit a `PowerLaw2` and `ExponentialCutoffPowerLaw3FGL` to the same data.\n",
+    "- Fit a `ExponentialCutoffPowerLaw` model to Vela X ('HESS J0835-455') only and check if the best fit values correspond to the values given in the Gammacat catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "This was an introduction to SED fitting in Gammapy.\n",
+    "\n",
+    "* If you would like to learn how to perform a full Poisson maximum likelihood spectral fit, please check out the [spectrum pipe](spectrum_pipe.ipynb) tutorial.\n",
+    "* If you are interested in simulation of spectral data in the context of CTA, please check out the [spectrum simulation cta](spectrum_simulation_cta.ipynb) notebook.\n",
+    "* To learn more about other parts of Gammapy (e.g. Fermi-LAT and TeV data analysis), check out the other tutorial notebooks.\n",
+    "* To see what's available in Gammapy, browse the [Gammapy docs](http://docs.gammapy.org/) or use the full-text search.\n",
+    "* If you have any questions, ask on the mailing list ."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3D simulation and fitting\n",
+    "\n",
+    "This tutorial shows how to do a 3D map-based simulation and fit.\n",
+    "\n",
+    "For a tutorial on how to do a 3D map analyse of existing data, see the `analysis_3d` tutorial.\n",
+    "\n",
+    "This can be useful to do a performance / sensitivity study, or to evaluate the capabilities of Gammapy or a given analysis method. Note that is is a binned simulation as is e.g. done also in Sherpa for Chandra, not an event sampling and anbinned analysis as is done e.g. in the Fermi ST or ctools."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports and versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from gammapy.irf import (\n",
+    "    EffectiveAreaTable2D,\n",
+    "    EnergyDispersion2D,\n",
+    "    EnergyDependentMultiGaussPSF,\n",
+    "    Background3D,\n",
+    ")\n",
+    "from gammapy.maps import WcsGeom, MapAxis, WcsNDMap, Map\n",
+    "from gammapy.spectrum.models import PowerLaw\n",
+    "from gammapy.image.models import SkyGaussian\n",
+    "from gammapy.cube.models import SkyModel, SkyModels\n",
+    "from gammapy.cube import MapFit, MapEvaluator, PSFKernel\n",
+    "from gammapy.cube import make_map_exposure_true_energy, make_map_background_irf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gammapy info --no-envvar --no-dependencies --no-system"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_irfs():\n",
+    "    \"\"\"Load CTA IRFs\"\"\"\n",
+    "    filename = \"$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "    psf = EnergyDependentMultiGaussPSF.read(\n",
+    "        filename, hdu=\"POINT SPREAD FUNCTION\"\n",
+    "    )\n",
+    "    aeff = EffectiveAreaTable2D.read(filename, hdu=\"EFFECTIVE AREA\")\n",
+    "    edisp = EnergyDispersion2D.read(filename, hdu=\"ENERGY DISPERSION\")\n",
+    "    bkg = Background3D.read(filename, hdu=\"BACKGROUND\")\n",
+    "    return dict(psf=psf, aeff=aeff, edisp=edisp, bkg=bkg)\n",
+    "\n",
+    "\n",
+    "irfs = get_irfs()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define sky model to simulate the data\n",
+    "spatial_model = SkyGaussian(lon_0=\"0.2 deg\", lat_0=\"0.1 deg\", sigma=\"0.3 deg\")\n",
+    "spectral_model = PowerLaw(\n",
+    "    index=3, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
+    ")\n",
+    "sky_model = SkyModel(\n",
+    "    spatial_model=spatial_model, spectral_model=spectral_model\n",
+    ")\n",
+    "print(sky_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define map geometry\n",
+    "axis = MapAxis.from_edges(\n",
+    "    np.logspace(-1., 1., 10), unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
+    ")\n",
+    "geom = WcsGeom.create(\n",
+    "    skydir=(0, 0), binsz=0.02, width=(5, 4), coordsys=\"GAL\", axes=[axis]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define some observation parameters\n",
+    "# Here we just have a single observation,\n",
+    "# we are not simulating many pointings / observations\n",
+    "pointing = SkyCoord(1, 0.5, unit=\"deg\", frame=\"galactic\")\n",
+    "livetime = 1 * u.hour\n",
+    "offset_max = 2 * u.deg\n",
+    "offset = Angle(\"2 deg\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exposure = make_map_exposure_true_energy(\n",
+    "    pointing=pointing, livetime=livetime, aeff=irfs[\"aeff\"], geom=geom\n",
+    ")\n",
+    "exposure.slice_by_idx({\"energy\": 3}).plot(add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "background = make_map_background_irf(\n",
+    "    pointing=pointing, livetime=livetime, bkg=irfs[\"bkg\"], geom=geom\n",
+    ")\n",
+    "background.slice_by_idx({\"energy\": 3}).plot(add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "psf = irfs[\"psf\"].to_energy_dependent_table_psf(theta=offset)\n",
+    "psf_kernel = PSFKernel.from_table_psf(psf, geom, max_radius=0.3 * u.deg)\n",
+    "psf_kernel.psf_kernel_map.sum_over_axes().plot(stretch=\"log\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edisp = irfs[\"edisp\"].to_energy_dispersion(offset=offset)\n",
+    "edisp.plot_matrix();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# The idea is that we have this class that can compute `npred`\n",
+    "# maps, i.e. \"predicted counts per pixel\" given the model and\n",
+    "# the observation infos: exposure, background, PSF and EDISP\n",
+    "evaluator = MapEvaluator(\n",
+    "    model=sky_model, exposure=exposure, background=background, psf=psf_kernel\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Accessing and saving a lot of the following maps is for debugging.\n",
+    "# Just for a simulation one doesn't need to store all these things.\n",
+    "# dnde = evaluator.compute_dnde()\n",
+    "# flux = evaluator.compute_flux()\n",
+    "npred = evaluator.compute_npred()\n",
+    "npred_map = WcsNDMap(geom, npred)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "npred_map.sum_over_axes().plot(add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This one line is the core of how to simulate data when\n",
+    "# using binned simulation / analysis: you Poisson fluctuate\n",
+    "# npred to obtain simulated observed counts.\n",
+    "# Compute counts as a Poisson fluctuation\n",
+    "rng = np.random.RandomState(seed=42)\n",
+    "counts = rng.poisson(npred)\n",
+    "counts_map = WcsNDMap(geom, counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts_map.sum_over_axes().plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit\n",
+    "\n",
+    "Now let's analyse the simulated data.\n",
+    "Here we just fit it again with the same model we had before, but you could do any analysis you like here, e.g. fit a different model, or do a region-based analysis, ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define sky model to fit the data\n",
+    "spatial_model = SkyGaussian(lon_0=\"0 deg\", lat_0=\"0 deg\", sigma=\"1 deg\")\n",
+    "spectral_model = PowerLaw(\n",
+    "    index=2, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
+    ")\n",
+    "model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)\n",
+    "print(model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fit = MapFit(\n",
+    "    model=model,\n",
+    "    counts=counts_map,\n",
+    "    exposure=exposure,\n",
+    "    background=background,\n",
+    "    psf=psf_kernel,\n",
+    ")\n",
+    "\n",
+    "fit.fit(opts_minuit={\"print_level\": 1})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"True values:\\n\\n{}\\n\\n\".format(sky_model.parameters))\n",
+    "print(\"Fit result:\\n\\n{}\\n\\n\".format(model.parameters))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: show e.g. how to make a residual image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## iminuit\n",
+    "\n",
+    "What we have done for now is to write a very thin wrapper for http://iminuit.readthedocs.io/\n",
+    "as a fitting backend. This is just a prototype, we will improve this interface and\n",
+    "add other fitting backends (e.g. Sherpa or scipy.optimize or emcee or ...)\n",
+    "\n",
+    "As a power-user, you can access ``fit.iminuit`` and get the full power of what is developed there already.\n",
+    "E.g. the ``fit.fit()`` call ran ``Minuit.migrad()`` and ``Minuit.hesse()`` in the background, and you have\n",
+    "access to e.g. the covariance matrix, or can check a likelihood profile, or can run ``Minuit.minos()``\n",
+    "to compute asymmetric errors or ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check correlation between model parameters\n",
+    "# As expected in this simple case,\n",
+    "# spatial parameters are uncorrelated,\n",
+    "# but the spectral model amplitude and index are correlated as always\n",
+    "fit.minuit.print_matrix()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can use likelihood profiles to check if your model is\n",
+    "# well constrained or not, and if the fit really converged\n",
+    "fit.minuit.draw_profile(\"par_002_sigma\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/source_population_model.ipynb
+++ b/tutorials/source_population_model.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Astrophysical source population modeling with Gammapy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "The [gammapy.astro.population](http://docs.gammapy.org/dev/astro/population/index.html) package contains some simple Galactic source population models.\n",
+    "\n",
+    "Here we provide some Python code to compute observable parameter distributions for Galactic gamma-ray source populations.\n",
+    "\n",
+    "* Observables: Flux, GLON, GLAT\n",
+    "* Source classes: Pulsar (PSR), Supernova remnant (SNR), pulsar wind nebula (PWN)\n",
+    "\n",
+    "References:\n",
+    "\n",
+    "* Section 6.2 in the Fermi-LAT collaboration paper [\"The First Fermi-LAT Catalog of Sources Above 10 GeV\"](http://adsabs.harvard.edu/abs/2013arXiv1306.6772T)\n",
+    "* Axel Donath's bachelor thesis [\"Modelling Galactic gamma-ray source populations\"](http://pubman.mpdl.mpg.de/pubman/item/escidoc:912132:1/component/escidoc:912131/BScThesis_ddonath.pdf), specifically Chapter 4.\n",
+    "* Casanova & Dingus (2008), [\"Constraints on the TeV source population and its contribution to the galactic diffuse TeV emission\"](http://adsabs.harvard.edu/abs/2008APh....29...63C)\n",
+    "* Strong (2007), [\"Source population synthesis and the Galactic diffuse gamma-ray emission\"](http://adsabs.harvard.edu/abs/2007Ap%26SS.309...35S)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from gammapy.utils.random import sample_powerlaw\n",
+    "from gammapy.astro import population"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulate positions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Spatial distribution using Lorimer (2006) model\n",
+    "n_sources = int(1e5)\n",
+    "\n",
+    "table = population.make_base_catalog_galactic(\n",
+    "    n_sources=n_sources,\n",
+    "    rad_dis=\"L06\",\n",
+    "    vel_dis=\"F06B\",\n",
+    "    max_age=1e6 * u.yr,\n",
+    "    spiralarms=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulate luminosities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Several source population models, e.g. the 1FHL paper or Strong (2007), use power-law luminosity functions.\n",
+    "\n",
+    "Here we implement the \"reference model\" from the 1FHL catalog paper section 6.2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Source luminosity (ph s^-1)\n",
+    "\n",
+    "luminosity = sample_powerlaw(x_min=1e34, x_max=1e37, gamma=1.5, size=n_sources)\n",
+    "table[\"luminosity\"] = luminosity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute observable parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = population.add_observed_parameters(table)\n",
+    "table.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The simulation is done, you could save the simulated catalog to a file.\n",
+    "\n",
+    "Here we just plot a few distributions to check if the results look OK."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(table[\"x\"][:1000], table[\"y\"][:1000]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(table[\"GLON\"], bins=100);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(table[\"GLAT\"], bins=100, log=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(table[\"GLON\"][:1000], table[\"GLAT\"][:1000]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(table[\"distance\"], bins=100, log=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(np.log10(table[\"luminosity\"]), bins=100, log=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(np.log10(table[\"flux\"]), bins=100, log=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: plot GLON, GLAT, FLUX distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "TODO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start exercises here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "TODO: summarise what was done here briefly.\n",
+    "\n",
+    "TODO: add some pointers to other documentation."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -1,0 +1,587 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spectral analysis with Gammapy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook explains in detail how to use the classes in [gammapy.spectrum](http://docs.gammapy.org/dev/spectrum/index.html) and related ones. Note, that there is also [spectrum_pipe.ipynb](spectrum_pipe.ipynb) which explains how to do the analysis using a high-level interface. This notebook is aimed at advanced users who want to script taylor-made analysis pipelines and implement new methods.\n",
+    "\n",
+    "Based on a datasets of 4 Crab observations with H.E.S.S. (simulated events for now) we will perform a full region based spectral analysis, i.e. extracting source and background counts from certain \n",
+    "regions, and fitting them using the forward-folding approach. We will use the following classes\n",
+    "\n",
+    "Data handling:\n",
+    "\n",
+    "* [gammapy.data.DataStore](http://docs.gammapy.org/dev/api/gammapy.data.DataStore.html)\n",
+    "* [gammapy.data.DataStoreObservation](http://docs.gammapy.org/dev/api/gammapy.data.DataStoreObservation.html)\n",
+    "* [gammapy.data.ObservationStats](http://docs.gammapy.org/dev/api/gammapy.data.ObservationStats.html)\n",
+    "* [gammapy.data.ObservationSummary](http://docs.gammapy.org/dev/api/gammapy.data.ObservationSummary.html)\n",
+    "\n",
+    "To extract the 1-dim spectral information:\n",
+    "\n",
+    "* [gammapy.spectrum.SpectrumObservation](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumObservation.html)\n",
+    "* [gammapy.spectrum.SpectrumExtraction](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumExtraction.html)\n",
+    "* [gammapy.background.ReflectedRegionsBackgroundEstimator](http://docs.gammapy.org/dev/api/gammapy.background.ReflectedRegionsBackgroundEstimator.html)\n",
+    "\n",
+    "\n",
+    "For the global fit (using Sherpa and WSTAT in the background):\n",
+    "\n",
+    "* [gammapy.spectrum.SpectrumFit](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumFit.html)\n",
+    "* [gammapy.spectrum.models.PowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html)\n",
+    "* [gammapy.spectrum.models.ExponentialCutoffPowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.ExponentialCutoffPowerLaw.html)\n",
+    "* [gammapy.spectrum.models.LogParabola](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.LogParabola.html)\n",
+    "\n",
+    "To compute flux points (a.k.a. \"SED\" = \"spectral energy distribution\")\n",
+    "\n",
+    "* [gammapy.spectrum.SpectrumResult](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumResult.html)\n",
+    "* [gammapy.spectrum.FluxPoints](http://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPoints.html)\n",
+    "* [gammapy.spectrum.SpectrumEnergyGroupMaker](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumEnergyGroupMaker.html)\n",
+    "* [gammapy.spectrum.FluxPointEstimator](http://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPointEstimator.html)\n",
+    "\n",
+    "Feedback welcome!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "As usual, we'll start with some setup ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check package versions\n",
+    "import gammapy\n",
+    "import numpy as np\n",
+    "import astropy\n",
+    "import regions\n",
+    "import sherpa\n",
+    "\n",
+    "print(\"gammapy:\", gammapy.__version__)\n",
+    "print(\"numpy:\", np.__version__)\n",
+    "print(\"astropy\", astropy.__version__)\n",
+    "print(\"regions\", regions.__version__)\n",
+    "print(\"sherpa\", sherpa.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from astropy.table import vstack as vstack_table\n",
+    "from regions import CircleSkyRegion\n",
+    "from gammapy.data import DataStore, ObservationList\n",
+    "from gammapy.data import ObservationStats, ObservationSummary\n",
+    "from gammapy.background.reflected import ReflectedRegionsBackgroundEstimator\n",
+    "from gammapy.utils.energy import EnergyBounds\n",
+    "from gammapy.spectrum import (\n",
+    "    SpectrumExtraction,\n",
+    "    SpectrumObservation,\n",
+    "    SpectrumFit,\n",
+    "    SpectrumResult,\n",
+    ")\n",
+    "from gammapy.spectrum.models import (\n",
+    "    PowerLaw,\n",
+    "    ExponentialCutoffPowerLaw,\n",
+    "    LogParabola,\n",
+    ")\n",
+    "from gammapy.spectrum import (\n",
+    "    FluxPoints,\n",
+    "    SpectrumEnergyGroupMaker,\n",
+    "    FluxPointEstimator,\n",
+    ")\n",
+    "from gammapy.maps import Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure logger\n",
+    "\n",
+    "Most high level classes in gammapy have the possibility to turn on logging or debug output. We well configure the logger in the following. For more info see https://docs.python.org/2/howto/logging.html#logging-basic-tutorial"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup the logger\n",
+    "import logging\n",
+    "\n",
+    "logging.basicConfig()\n",
+    "logging.getLogger(\"gammapy.spectrum\").setLevel(\"WARNING\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Data\n",
+    "\n",
+    "First, we select and load some H.E.S.S. observations of the Crab nebula (simulated events for now).\n",
+    "\n",
+    "We will access the events, effective area, energy dispersion, livetime and PSF for containement correction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datastore = DataStore.from_dir(\"../datasets/hess-dl3-dr1/\")\n",
+    "obs_ids = [23523, 23526, 23559, 23592]\n",
+    "obs_list = datastore.obs_list(obs_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Target Region\n",
+    "\n",
+    "The next step is to define a signal extraction region, also known as on region. In the simplest case this is just a [CircleSkyRegion](http://astropy-regions.readthedocs.io/en/latest/api/regions.CircleSkyRegion.html#regions.CircleSkyRegion), but here we will use the ``Target`` class in gammapy that is useful for book-keeping if you run several analysis in a script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_position = SkyCoord(ra=83.63, dec=22.01, unit=\"deg\", frame=\"icrs\")\n",
+    "on_region_radius = Angle(\"0.11 deg\")\n",
+    "on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create exclusion mask\n",
+    "\n",
+    "We will use the reflected regions method to place off regions to estimate the background level in the on region.\n",
+    "To make sure the off regions don't contain gamma-ray emission, we create an exclusion mask.\n",
+    "\n",
+    "Using http://gamma-sky.net/ we find that there's only one known gamma-ray source near the Crab nebula: the AGN called [RGB J0521+212](http://gamma-sky.net/#/cat/tev/23) at GLON = 183.604 deg and GLAT = -8.708 deg."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exclusion_region = CircleSkyRegion(\n",
+    "    center=SkyCoord(183.604, -8.708, unit=\"deg\", frame=\"galactic\"),\n",
+    "    radius=0.5 * u.deg,\n",
+    ")\n",
+    "\n",
+    "skydir = target_position.galactic\n",
+    "exclusion_mask = Map.create(\n",
+    "    npix=(150, 150), binsz=0.05, skydir=skydir, proj=\"TAN\", coordsys=\"GAL\"\n",
+    ")\n",
+    "\n",
+    "mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)\n",
+    "exclusion_mask.data = mask\n",
+    "exclusion_mask.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimate background\n",
+    "\n",
+    "Next we will manually perform a background estimate by placing [reflected regions](http://docs.gammapy.org/dev/background/reflected.html) around the pointing position and looking at the source statistics. This will result in a  [gammapy.background.BackgroundEstimate](http://docs.gammapy.org/dev/api/gammapy.background.BackgroundEstimate.html) that serves as input for other classes in gammapy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "background_estimator = ReflectedRegionsBackgroundEstimator(\n",
+    "    obs_list=obs_list, on_region=on_region, exclusion_mask=exclusion_mask\n",
+    ")\n",
+    "\n",
+    "background_estimator.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print(background_estimator.result[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8, 8))\n",
+    "background_estimator.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Source statistic\n",
+    "\n",
+    "Next we're going to look at the overall source statistics in our signal region. For more info about what debug plots you can create check out the [ObservationSummary](http://docs.gammapy.org/dev/api/gammapy.data.ObservationSummary.html#gammapy.data.ObservationSummary) class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stats = []\n",
+    "for obs, bkg in zip(obs_list, background_estimator.result):\n",
+    "    stats.append(ObservationStats.from_obs(obs, bkg))\n",
+    "\n",
+    "print(stats[1])\n",
+    "\n",
+    "obs_summary = ObservationSummary(stats)\n",
+    "fig = plt.figure(figsize=(10, 6))\n",
+    "ax1 = fig.add_subplot(121)\n",
+    "\n",
+    "obs_summary.plot_excess_vs_livetime(ax=ax1)\n",
+    "ax2 = fig.add_subplot(122)\n",
+    "obs_summary.plot_significance_vs_livetime(ax=ax2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extract spectrum\n",
+    "\n",
+    "Now, we're going to extract a spectrum using the [SpectrumExtraction](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumExtraction.html) class. We provide the reconstructed energy binning we want to use. It is expected to be a Quantity with unit energy, i.e. an array with an energy unit. We use a utility function to create it. We also provide the true energy binning to use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e_reco = EnergyBounds.equal_log_spacing(0.1, 40, 40, unit=\"TeV\")\n",
+    "e_true = EnergyBounds.equal_log_spacing(0.05, 100., 200, unit=\"TeV\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instantiate a [SpectrumExtraction](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumExtraction.html) object that will do the extraction. The containment_correction parameter is there to allow for PSF leakage correction if one is working with full enclosure IRFs. We also compute a threshold energy and store the result in OGIP compliant files (pha, rmf, arf). This last step might be omitted though."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ANALYSIS_DIR = \"crab_analysis\"\n",
+    "\n",
+    "extraction = SpectrumExtraction(\n",
+    "    obs_list=obs_list,\n",
+    "    bkg_estimate=background_estimator.result,\n",
+    "    containment_correction=False,\n",
+    ")\n",
+    "extraction.run()\n",
+    "\n",
+    "# Add a condition on correct energy range in case it is not set by default\n",
+    "extraction.compute_energy_threshold(method_lo=\"area_max\", area_percent_lo=10.0)\n",
+    "\n",
+    "print(extraction.observations[0])\n",
+    "# Write output in the form of OGIP files: PHA, ARF, RMF, BKG\n",
+    "# extraction.run(obs_list=obs_list, bkg_estimate=background_estimator.result, outdir=ANALYSIS_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look at observations\n",
+    "\n",
+    "Now we will look at the files we just created. We will use the [SpectrumObservation](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumObservation.html) object that are still in memory from the extraction step. Note, however, that you could also read them from disk if you have written them in the step above. The ``ANALYSIS_DIR`` folder contains 4 ``FITS`` files for each observation. These files are described in detail [here](https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/ogip/index.html). In short, they correspond to the on vector, the off vector, the effectie area, and the energy dispersion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# filename = ANALYSIS_DIR + '/ogip_data/pha_obs23523.fits'\n",
+    "# obs = SpectrumObservation.read(filename)\n",
+    "\n",
+    "# Requires IPython widgets\n",
+    "# _ = extraction.observations.peek()\n",
+    "\n",
+    "extraction.observations[0].peek()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit spectrum\n",
+    "\n",
+    "Now we'll fit a global model to the spectrum. First we do a joint likelihood fit to all observations. If you want to stack the observations see below. We will also produce a debug plot in order to show how the global fit matches one of the individual observations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = PowerLaw(\n",
+    "    index=2, amplitude=2e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    ")\n",
+    "\n",
+    "joint_fit = SpectrumFit(obs_list=extraction.observations, model=model)\n",
+    "\n",
+    "joint_fit.fit()\n",
+    "joint_fit.est_errors()\n",
+    "# fit.run(outdir = ANALYSIS_DIR)\n",
+    "\n",
+    "joint_result = joint_fit.result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax0, ax1 = joint_result[0].plot(figsize=(8, 8))\n",
+    "ax0.set_ylim(0, 20)\n",
+    "print(joint_result[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute Flux Points\n",
+    "\n",
+    "To round up out analysis we can compute flux points by fitting the norm of the global model in energy bands. We'll use a fixed energy binning for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define energy binning\n",
+    "ebounds = [0.3, 1.1, 3, 10.1, 30] * u.TeV\n",
+    "\n",
+    "stacked_obs = extraction.observations.stack()\n",
+    "\n",
+    "seg = SpectrumEnergyGroupMaker(obs=stacked_obs)\n",
+    "seg.compute_groups_fixed(ebounds=ebounds)\n",
+    "\n",
+    "print(seg.groups)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpe = FluxPointEstimator(\n",
+    "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model\n",
+    ")\n",
+    "fpe.compute_points()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpe.flux_points.plot()\n",
+    "fpe.flux_points.table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final plot with the best fit model and the flux points can be quickly made like this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectrum_result = SpectrumResult(\n",
+    "    points=fpe.flux_points, model=joint_result[0].model\n",
+    ")\n",
+    "ax0, ax1 = spectrum_result.plot(\n",
+    "    energy_range=joint_fit.result[0].fit_range,\n",
+    "    energy_power=2,\n",
+    "    flux_unit=\"erg-1 cm-2 s-1\",\n",
+    "    fig_kwargs=dict(figsize=(8, 8)),\n",
+    "    point_kwargs=dict(color=\"red\"),\n",
+    ")\n",
+    "\n",
+    "ax0.set_xlim(0.4, 50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stack observations\n",
+    "\n",
+    "And alternative approach to fitting the spectrum is stacking all observations first and the fitting a model to the stacked observation. This works as follows. A comparison to the joint likelihood fit is also printed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stacked_obs = extraction.observations.stack()\n",
+    "\n",
+    "stacked_fit = SpectrumFit(obs_list=stacked_obs, model=model)\n",
+    "stacked_fit.fit()\n",
+    "stacked_fit.est_errors()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stacked_result = stacked_fit.result\n",
+    "print(stacked_result[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stacked_table = stacked_result[0].to_table(format=\".3g\")\n",
+    "stacked_table[\"method\"] = \"stacked\"\n",
+    "joint_table = joint_result[0].to_table(format=\".3g\")\n",
+    "joint_table[\"method\"] = \"joint\"\n",
+    "total_table = vstack_table([stacked_table, joint_table])\n",
+    "print(\n",
+    "    total_table[\"method\", \"index\", \"index_err\", \"amplitude\", \"amplitude_err\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "Some things we might do:\n",
+    "\n",
+    "- Fit a different spectral model (ECPL or CPL or ...)\n",
+    "- Use different method or parameters to compute the flux points\n",
+    "- Do a chi^2 fit to the flux points and compare\n",
+    "\n",
+    "TODO: give pointers how to do this (and maybe write a notebook with solutions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start exercises here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "In this tutorial we learned how to extract counts spectra from an event list and generate the corresponding IRFs. Then we fitted a model to the observations and also computed flux points.\n",
+    "\n",
+    "Here's some suggestions where to go next:\n",
+    "\n",
+    "* if you want think this is way too complicated and just want to run a quick analysis check out [this notebook](spectrum_pipe.ipynb)\n",
+    "* if you interested in available fit statistics checkout [gammapy.stats](http://docs.gammapy.org/dev/stats/index.html)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/spectrum_fitting_with_sherpa.ipynb
+++ b/tutorials/spectrum_fitting_with_sherpa.ipynb
@@ -1,0 +1,210 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fitting gammapy spectra with sherpa\n",
+    "\n",
+    "Once we have exported the spectral files (PHA, ARF, RMF and BKG) in the OGIP format, it becomes possible to fit them later with gammapy or with any existing OGIP compliant tool such as XSpec or sherpa.\n",
+    "\n",
+    "We show here how to do so with sherpa using the high-level user interface. For a general view on how to use stand-alone sherpa, see this [tutorial](http://nbviewer.jupyter.org/github/sherpa/sherpa/blob/master/docs/SherpaQuickStart.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load data stack\n",
+    "\n",
+    "We first need to import the user interface and load the data with [load_data](http://cxc.harvard.edu/sherpa/ahelp/load_data.html). One can load files one by one, or more simply load them all at once through a [DataStack](http://cxc.harvard.edu/sherpa/ahelp/datastack.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.style.use(\"ggplot\")\n",
+    "\n",
+    "import glob  # to list files\n",
+    "from os.path import expandvars\n",
+    "from sherpa.astro.datastack import DataStack\n",
+    "import sherpa.astro.datastack as sh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sherpa\n",
+    "\n",
+    "print(\"sherpa:\", sherpa.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = DataStack()\n",
+    "ANALYSIS_DIR = expandvars(\"$GAMMAPY_EXTRA/datasets/hess-crab4_pha/\")\n",
+    "filenames = glob.glob(ANALYSIS_DIR + \"pha_obs*.fits\")\n",
+    "for filename in filenames:\n",
+    "    sh.load_data(ds, filename)\n",
+    "\n",
+    "# see what is stored\n",
+    "ds.show_stack()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define source model\n",
+    "\n",
+    "We can now use sherpa models. We need to remember that they were designed for X-ray astronomy and energy is written in keV. \n",
+    "\n",
+    "Here we start with a simple PL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the source model\n",
+    "ds.set_source(\"powlaw1d.p1\")\n",
+    "\n",
+    "# Change reference energy of the model\n",
+    "p1.ref = 1e9  # 1 TeV = 1e9 keV\n",
+    "p1.gamma = 2.0\n",
+    "p1.ampl = 1e-20  # in cm**-2 s**-1 keV**-1\n",
+    "\n",
+    "# View parameters\n",
+    "print(p1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit and error estimation\n",
+    "\n",
+    "We need to set the correct statistic: [WSTAT](http://cxc.harvard.edu/sherpa/ahelp/wstat.html). We use functions [set_stat](http://cxc.harvard.edu/sherpa/ahelp/set_stat.html) to define the fit statistic, [notice](http://cxc.harvard.edu/sherpa/ahelp/notice.html) to set the energy range, and [fit](http://cxc.harvard.edu/sherpa/ahelp/fit.html)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Define the statistic\n",
+    "sh.set_stat(\"wstat\")\n",
+    "\n",
+    "### Define the fit range\n",
+    "ds.notice(0.6e9, 20e9)\n",
+    "\n",
+    "### Do the fit\n",
+    "ds.fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results plot\n",
+    "\n",
+    "Note that sherpa does not provide flux points. It also only provides plot for each individual spectrum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sh.get_data_plot_prefs()[\"xlog\"] = True\n",
+    "sh.get_data_plot_prefs()[\"ylog\"] = True\n",
+    "ds.plot_fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Errors and confidence contours\n",
+    "\n",
+    "We use [conf](http://cxc.harvard.edu/sherpa/ahelp/conf.html) and [reg_proj](http://cxc.harvard.edu/sherpa/ahelp/reg_proj.html) functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute confidence intervals\n",
+    "ds.conf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute confidence contours for amplitude and index\n",
+    "sh.reg_unc(p1.gamma, p1.ampl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "- Change the energy range of the fit to be only 2 to 10 TeV\n",
+    "- Fit the built-in Sherpa exponential cutoff powerlaw model\n",
+    "- Define your own spectral model class (e.g. powerlaw again to practice) and fit it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/spectrum_models.ipynb
+++ b/tutorials/spectrum_models.ipynb
@@ -1,0 +1,363 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spectral models in Gammapy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook explains how to use the functions and classes in [gammapy.spectrum.models](http://docs.gammapy.org/dev/spectrum/#module-gammapy.spectrum.models) in order to work with spectral models.\n",
+    "\n",
+    "The following clases will be used:\n",
+    "\n",
+    "* [gammapy.spectrum.models.PowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html)\n",
+    "* [gammapy.utils.modelling.Parameter](http://docs.gammapy.org/dev/api/gammapy.utils.modeling.Parameter.html)\n",
+    "* [gammapy.utils.modelling.Parameters](http://docs.gammapy.org/dev/api/gammapy.utils.modeling.Parameters.html)\n",
+    "* [gammapy.spectrum.models.SpectralModel](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.SpectralModel.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Same procedure as in every script ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from gammapy.spectrum import models\n",
+    "from gammapy.utils.modeling import Parameter, Parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a model\n",
+    "\n",
+    "To create a spectral model, instantiate an object of the spectral model class you're interested in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl = models.PowerLaw()\n",
+    "print(pwl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will use default values for the model parameters, which is rarely what you want.\n",
+    "\n",
+    "Usually you will want to specify the parameters on object creation.\n",
+    "One way to do this is to pass `astropy.utils.Quantity` objects like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl = models.PowerLaw(\n",
+    "    index=2.3, amplitude=1e-12 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    ")\n",
+    "print(pwl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you see, some of the parameters have default ``min`` and ``values`` as well as a ``frozen`` flag. This is only relevant in the context of spectral fitting and thus covered in [spectrum_analysis.ipynb](https://github.com/gammapy/gammapy-extra/blob/master/notebooks/spectrum_analysis.ipynb). Also, the parameter errors are not set. This will be covered later in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get and set model parameters\n",
+    "\n",
+    "The model parameters are stored in the ``Parameters`` object on the spectal model. Each model parameter is a ``Parameter`` instance. It has a ``value`` and a ``unit`` attribute, as well as a ``quantity`` property for convenience."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pwl.parameters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pwl.parameters[\"index\"])\n",
+    "pwl.parameters[\"index\"].value = 2.6\n",
+    "print(pwl.parameters[\"index\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pwl.parameters[\"amplitude\"])\n",
+    "pwl.parameters[\"amplitude\"].quantity = 2e-12 * u.Unit(\"m-2 TeV-1 s-1\")\n",
+    "print(pwl.parameters[\"amplitude\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## List available models\n",
+    "\n",
+    "All spectral models in gammapy are subclasses of ``SpectralModel``. The list of available models is shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models.SpectralModel.__subclasses__()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting\n",
+    "\n",
+    "In order to plot a model you can use the ``plot`` function. It expects an energy range as argument. You can also chose flux and energy units as well as an energy power for the plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_range = [0.1, 10] * u.TeV\n",
+    "pwl.plot(energy_range, energy_power=2, energy_unit=\"GeV\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameter errors\n",
+    "\n",
+    "Parameters are stored internally as covariance matrix. There are, however, convenience methods to set individual parameter errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl.parameters.set_parameter_errors(\n",
+    "    {\"index\": 0.2, \"amplitude\": 0.1 * pwl.parameters[\"amplitude\"].quantity}\n",
+    ")\n",
+    "print(pwl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can access the parameter errors like this"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl.parameters.covariance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl.parameters.error(\"index\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can plot the butterfly using the ``plot_error`` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = pwl.plot_error(energy_range, color=\"blue\", alpha=0.2)\n",
+    "pwl.plot(energy_range, ax=ax, color=\"blue\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Integral fluxes\n",
+    "\n",
+    "You've probably asked yourself already, if it's possible to integrated models. Yes, it is. Where analytical solutions are available, these are used by default. Otherwise, a numerical integration is performed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl.integral(emin=1 * u.TeV, emax=10 * u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User-defined model\n",
+    "\n",
+    "Now we'll see how you can define a custom model. To do that you need to subclass ``SpectralModel``. All ``SpectralModel`` subclasses need to have an ``__init__`` function, which sets up the ``Parameters`` of the model and a ``static`` function called ``evaluate`` where the mathematical expression for the model is defined.\n",
+    "\n",
+    "As an example we will use a PowerLaw plus a Gaussian (with fixed width)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class UserModel(models.SpectralModel):\n",
+    "    def __init__(self, index, amplitude, reference, mean, width):\n",
+    "        self.parameters = Parameters(\n",
+    "            [\n",
+    "                Parameter(\"index\", index, min=0),\n",
+    "                Parameter(\"amplitude\", amplitude, min=0),\n",
+    "                Parameter(\"reference\", reference, frozen=True),\n",
+    "                Parameter(\"mean\", mean, min=0),\n",
+    "                Parameter(\"width\", width, min=0, frozen=True),\n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def evaluate(energy, index, amplitude, reference, mean, width):\n",
+    "        pwl = models.PowerLaw.evaluate(\n",
+    "            energy=energy,\n",
+    "            index=index,\n",
+    "            amplitude=amplitude,\n",
+    "            reference=reference,\n",
+    "        )\n",
+    "        gauss = amplitude * np.exp(-(energy - mean) ** 2 / (2 * width ** 2))\n",
+    "        return pwl + gauss"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = UserModel(\n",
+    "    index=2,\n",
+    "    amplitude=1e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
+    "    reference=1 * u.TeV,\n",
+    "    mean=5 * u.TeV,\n",
+    "    width=0.2 * u.TeV,\n",
+    ")\n",
+    "print(model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_range = [1, 10] * u.TeV\n",
+    "model.plot(energy_range=energy_range);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's next?\n",
+    "\n",
+    "In this tutorial we learnd how to work with spectral models.\n",
+    "\n",
+    "Go to [gammapy.spectrum](http://docs.gammapy.org/dev/spectrum/index.html) to learn more."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/spectrum_pipe.ipynb
+++ b/tutorials/spectrum_pipe.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spectrum analysis with Gammapy (run pipeline)\n",
+    "\n",
+    "In this tutorial we will learn how to perform a 1d spectral analysis.\n",
+    "\n",
+    "We will use a \"pipeline\" or \"workflow\" class to run a standard analysis. If you're interested in implementation detail of the analysis in order to create a custom analysis class, you should read ([spectrum_analysis.ipynb](spectrum_analysis.ipynb)) that executes the analysis using lower-level classes and methods in Gammapy. \n",
+    "\n",
+    "In this tutorial we will use the folling Gammapy classes:\n",
+    "\n",
+    "- [gammapy.data.DataStore](http://docs.gammapy.org/dev/api/gammapy.data.DataStore.html) to load the data to \n",
+    "- [gammapy.scripts.SpectrumAnalysisIACT](http://docs.gammapy.org/dev/api/gammapy.scripts.SpectrumAnalysisIACT.html) to run the analysis\n",
+    "\n",
+    "We use 4 Crab observations from H.E.S.S. for testing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "As usual, we'll start with some setup for the notebook, and import the functionality we need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from regions import CircleSkyRegion\n",
+    "\n",
+    "from gammapy.utils.energy import EnergyBounds\n",
+    "from gammapy.data import DataStore\n",
+    "from gammapy.scripts import SpectrumAnalysisIACT\n",
+    "from gammapy.catalog import SourceCatalogGammaCat\n",
+    "from gammapy.maps import Map\n",
+    "from gammapy.spectrum.models import LogParabola\n",
+    "from gammapy.spectrum import CrabSpectrum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select data\n",
+    "\n",
+    "First, we select and load some H.E.S.S. data (simulated events for now). In real life you would do something fancy here, or just use the list of observations someone send you (and hope they have done something fancy before). We'll just use the standard gammapy 4 crab runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_store = DataStore.from_dir(\"../datasets/hess-dl3-dr1/\")\n",
+    "mask = data_store.obs_table[\"OBS_SUBSET_TAG\"] == \"crab\"\n",
+    "obs_ids = data_store.obs_table[\"OBS_ID\"][mask].data\n",
+    "observations = data_store.obs_list(obs_ids)\n",
+    "print(obs_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the analysis\n",
+    "\n",
+    "Now we'll define the input for the spectrum analysis. It will be done the python way, i.e. by creating a config dict containing python objects. We plan to add also the convenience to configure the analysis using a plain text config file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crab_pos = SkyCoord.from_name(\"crab\")\n",
+    "on_region = CircleSkyRegion(crab_pos, 0.15 * u.deg)\n",
+    "\n",
+    "model = LogParabola(\n",
+    "    alpha=2.3,\n",
+    "    beta=0.01,\n",
+    "    amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
+    "    reference=1 * u.TeV,\n",
+    ")\n",
+    "\n",
+    "flux_point_binning = EnergyBounds.equal_log_spacing(0.7, 30, 5, u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exclusion_mask = Map.create(skydir=crab_pos, width=(10, 10), binsz=0.02)\n",
+    "\n",
+    "gammacat = SourceCatalogGammaCat()\n",
+    "\n",
+    "regions = []\n",
+    "for source in gammacat:\n",
+    "    if not exclusion_mask.geom.contains(source.position):\n",
+    "        continue\n",
+    "    region = CircleSkyRegion(source.position, 0.15 * u.deg)\n",
+    "    regions.append(region)\n",
+    "\n",
+    "exclusion_mask.data = exclusion_mask.geom.region_mask(regions, inside=False)\n",
+    "exclusion_mask.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = dict(\n",
+    "    outdir=None,\n",
+    "    background=dict(\n",
+    "        on_region=on_region,\n",
+    "        exclusion_mask=exclusion_mask,\n",
+    "        min_distance=0.1 * u.rad,\n",
+    "    ),\n",
+    "    extraction=dict(containment_correction=False),\n",
+    "    fit=dict(\n",
+    "        model=model,\n",
+    "        stat=\"wstat\",\n",
+    "        forward_folded=True,\n",
+    "        fit_range=flux_point_binning[[0, -1]],\n",
+    "    ),\n",
+    "    fp_binning=flux_point_binning,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the analysis\n",
+    "\n",
+    "TODO: Clean up the log (partly done, get rid of remaining useless warnings)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis = SpectrumAnalysisIACT(observations=observations, config=config)\n",
+    "analysis.run(opts_minuit={\"print_level\": 1})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "\n",
+    "Let's look at the results, and also compare with a previously published Crab nebula spectrum for reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(analysis.fit.result[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opts = {\n",
+    "    \"energy_range\": analysis.fit.fit_range,\n",
+    "    \"energy_power\": 2,\n",
+    "    \"flux_unit\": \"erg-1 cm-2 s-1\",\n",
+    "}\n",
+    "axes = analysis.spectrum_result.plot(**opts)\n",
+    "CrabSpectrum().model.plot(ax=axes[0], **opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "Rerun the analysis, changing some aspects of the analysis as you like:\n",
+    "\n",
+    "* only use one or two observations\n",
+    "* a different spectral model\n",
+    "* different config options for the spectral analysis\n",
+    "* different energy binning for the spectral point computation\n",
+    "\n",
+    "Observe how the measured spectrum changes."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR continues with the process of syncing Gammapy codebase and documentation tutorials, as it is discussed in [PIG 4 - Setup for tutorial notebooks and data](https://github.com/gammapy/gammapy/blob/8ea7f92e758eca32386d468fcdfef479ee567703/docs/development/pigs/pig-004.rst) - https://github.com/gammapy/gammapy/pull/1419

The `tutorials` folder in Gammapy repo will be the place where notebooks published in the documentation will be stored, stripped of output cells. It will also be used to download the tutorials pack with `gammapy download tutorials` CLI. The `notebooks` folder in Gammapy-extra repo will still be there, and may be used by developers for any other purposes.

- Flags `test` and `published` have been removed from the config file `tutorials/notebook.yaml`
- All notebooks published in the documentation must be in the `tutorials` folder.
- All notebooks in the `tutorials` folder must pass regression tests with `test_notebooks.py`.

A subsequent PR will follow to modify the documentation process accordingly, as well as for downloading tutorials from the Gammapy repo with `gammapy download tutorials` (added in https://github.com/gammapy/gammapy/pull/1786)