### PR TITLE
Improve EventList plots

### DIFF
--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -43,14 +43,34 @@ class TestEventListHESS:
         assert len(stacked_list.table) == 49 * 3
 
     @requires_dependency("matplotlib")
-    def test_peek(self):
+    def test_plot_time(self):
         with mpl_plot_check():
-            self.events.peek()
+            self.events.plot_time()
+
+    @requires_dependency("matplotlib")
+    def test_plot_energy(self):
+        with mpl_plot_check():
+            self.events.plot_energy()
 
     @requires_dependency("matplotlib")
     def test_plot_offset2_distribution(self):
         with mpl_plot_check():
             self.events.plot_offset2_distribution()
+
+    @requires_dependency("matplotlib")
+    def test_plot_energy_offset(self):
+        with mpl_plot_check():
+            self.events.plot_energy_offset()
+
+    @requires_dependency("matplotlib")
+    def test_plot_image(self):
+        with mpl_plot_check():
+            self.events.plot_image()
+
+    @requires_dependency("matplotlib")
+    def test_peek(self):
+        with mpl_plot_check():
+            self.events.peek()
 
 
 @requires_data("gammapy-extra")


### PR DESCRIPTION
The EventList plots, especially the image, currently doesn't come out nicely, because it's just a histogram of RA / DEC values, and the range is chosen to cover all events, and usually there's a few misreconstructed events from somewhere else in the sky (at least in HESS).

I plan to change this now to make a WCS counts map (local TAN projection centered on pointing position) and choose the FOV as a few deg by default (but offer an option to the user to adjust this).

For http://docs.gammapy.org/dev/_modules/gammapy/data/event_list.html#EventList.plot_image that plots the DETX / DETY, I'll just remove it for now, and then once we have FOV coordinates properly implemented in Gammapy with the events and IRFs, we can add debug plots back there as well. Since it's defined as spherical coordinates, probably also there it would be easiest to make a Map object with a TAN projection at the image center, but that can be discussed later once the code to work with FOV coordinates is in place and clearly defined.

cc @lmohrmann @facero 

https://gist.github.com/cdeil/188f00ab19bbb883971d7d0a3055cbf5

![image](https://user-images.githubusercontent.com/852409/45551484-678b7800-b82e-11e8-88eb-a475cb556578.png)
