### PR TITLE
Modifs in the Sphinx documentation building process

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ extensions.extend(
         "sphinx.ext.mathjax",
     ]
 )
-nbsphinx_execute = setup_cfg["execute_notebooks"]
+nbsphinx_execute = 'never'
 
 # --
 

--- a/process_tutorials.py
+++ b/process_tutorials.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""
+Process tutorials notebooks for publication in documentation.
+"""
+import logging
+import os
+import subprocess
+import sys
+from shutil import copytree, rmtree
+from gammapy.extern.pathlib import Path
+from gammapy.scripts.jupyter import test_notebook
+
+logging.basicConfig(level=logging.INFO)
+
+if 'GAMMAPY_EXTRA' not in os.environ:
+    logging.info('GAMMAPY_EXTRA environment variable not set.')
+    logging.info('Running notebook tests requires gammapy-extra.')
+    logging.info('Exiting now.')
+    sys.exit()
+
+# make datasets symlink
+try:
+    path_datasets = Path(os.environ['GAMMAPY_EXTRA']) / 'datasets'
+    os.symlink(str(path_datasets), 'datasets')
+except Exception as ex:
+    logging.error('It was not possible to create a /datasets symlink')
+    logging.error(ex)
+    sys.exit()
+
+# prepare folder structure
+path_temp = Path('temp')
+path_empty_nbs = Path('tutorials')
+path_filled_nbs = Path('docs') / 'notebooks'
+path_static_nbs = Path('docs') / '_static' / 'notebooks'
+
+rmtree(str(path_temp), ignore_errors=True)
+rmtree(str(path_filled_nbs), ignore_errors=True)
+rmtree(str(path_static_nbs), ignore_errors=True)
+
+# work in temporal folder
+
+
+def ignorefiles(d, files): return [
+    f
+    for f in files
+    if os.path.isfile(os.path.join(d, f))
+    and f[-6:] != '.ipynb'
+    and f[-4:] != '.png'
+]
+
+
+copytree(str(path_empty_nbs), str(path_temp), ignore=ignorefiles)
+
+# test /run
+passed = True
+for path in path_temp.glob("*.ipynb"):
+    if not test_notebook(path):
+        passed = False
+
+if passed:
+    # convert into scripts
+    def ignoreall(d, files): return [
+        f
+        for f in files
+        if os.path.isfile(os.path.join(d, f))
+        and f[-6:] != '.ipynb'
+    ]
+    copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignoreall)
+    for path in path_static_nbs.glob("*.ipynb"):
+        subprocess.call(
+            "jupyter nbconvert --to script '{}'".format(str(path)),
+            shell=True)
+
+    # copy filled notebooks
+    copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
+
+else:
+    logging.info('Tests have not passed.')
+    logging.info('Tutorials not ready for documentation building process.')
+    rmtree(str(path_static_nbs), ignore_errors=True)
+
+# tear down
+rmtree(str(path_temp), ignore_errors=True)
+os.unlink('datasets')

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,12 +27,17 @@ edit_on_github = False
 github_project = gammapy/gammapy
 url_docs = http://docs.gammapy.org/dev/
 
-# configure whether to run nbsphinx; see http://nbsphinx.readthedocs.io/en/stable/never-execute.html
-execute_notebooks = never
-# configure version of notebooks in Binder
+# notebooks processing in documentation building
+# if building docs for a stable release
+# build_notebooks = True
+# git_commit = version number i.e. v0.8
+
+# skip notebooks in documentation building
+# optimizes build documentation when modifying only RST files
+build_notebooks = False
+
+# version of notebooks in Binder
 git_commit = master
-# build fixed-notebooks; set to False optimizes build documentation when modifying docs
-build_notebooks = True
 
 [entry_points]
 gammapy = gammapy.scripts.main:cli

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ url_docs = http://docs.gammapy.org/dev/
 
 # skip notebooks in documentation building
 # optimizes build documentation when modifying only RST files
-build_notebooks = False
+build_notebooks = True
 
 # version of notebooks in Binder
 git_commit = master

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -67,17 +67,17 @@
    "outputs": [],
    "source": [
     "# Read the fits file to load them in a sherpa model\n",
-    "hdr = fits.getheader(\"G300-0_test_counts.fits\")\n",
+    "hdr = fits.getheader(\"../datasets/G300-0_test_counts.fits\")\n",
     "wcs = WCS(hdr)\n",
     "\n",
     "sh.set_stat(\"cash\")\n",
     "sh.set_method(\"simplex\")\n",
-    "sh.load_image(\"G300-0_test_counts.fits\")\n",
+    "sh.load_image(\"../datasets/G300-0_test_counts.fits\")\n",
     "sh.set_coord(\"logical\")\n",
     "\n",
-    "sh.load_table_model(\"expo\", \"G300-0_test_exposure.fits\")\n",
-    "sh.load_table_model(\"bkg\", \"G300-0_test_background.fits\")\n",
-    "sh.load_psf(\"psf\", \"G300-0_test_psf.fits\")"
+    "sh.load_table_model(\"expo\", \"../datasets/G300-0_test_exposure.fits\")\n",
+    "sh.load_table_model(\"bkg\", \"../datasets/G300-0_test_background.fits\")\n",
+    "sh.load_psf(\"psf\", \"../datasets/G300-0_test_psf.fits\")"
    ]
   },
   {
@@ -97,7 +97,7 @@
     "bkg.ampl = 1\n",
     "sh.freeze(bkg)\n",
     "\n",
-    "resid = Map.read(\"G300-0_test_counts.fits\")\n",
+    "resid = Map.read(\"../datasets/G300-0_test_counts.fits\")\n",
     "resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
     "resid_smooth = resid.smooth(radius=6)\n",
     "resid_smooth.plot();"
@@ -303,7 +303,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -317,7 +317,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.1"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   },
   "varInspector": {
    "cols": {


### PR DESCRIPTION
This PR modifies the Sphinx documentation building process relative to the build of HTML-fixed formatted notebooks present as tutorials.

It also modifies the manual process to follow to incorporate tutorials to the documentation, which is the following:

- Preprocess tutorials present in the recently added `tutorials` folder in Gammapy repo.
<pre>
~/git/gammapy$ python process_tutorials.py 
INFO:gammapy.scripts.jupyter:   ... TESTING temp/detect_ts.ipynb
INFO:gammapy.scripts.jupyter:   ... Executing duration: 0.23 mn
INFO:gammapy.scripts.jupyter:   ... PASSED
INFO:gammapy.scripts.jupyter:   ... TESTING temp/fermi_lat.ipynb
....
....
</pre>

- If regression tests for all notebooks in the `tutorials` folder pass:
<pre>
~/git/gammapy$ python setup.py build_docs
</pre>

In the case you would need to modify an existing notebooks of the tutorials, you would need:
* to create a symlink `datasets` at the root of the local git Gammapy repo pointing to `$GAMMAPY_EXTRA/datasets `. 
* `gammapy jupyter --src=modified_notebook.ipynb execute`
* `cp modified_notebook.ipynb docs/notebooks`
* `gammapy jupyter --src=modified_notebook.ipynb stripout`

In a following PR the ` process_tutorials.py` script will be updated to accept one notebook as param and merge the last three steps into a single pre-process one.

