### PR TITLE
Update HESS 4 Crab example dataset

### DIFF
--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -17,23 +17,30 @@ as well as classes for IACT data and observation handling.
 Getting Started
 ===============
 
-You can use the `~gammapy.data.EventList` class to load gamma-ray event lists:
+You can use the `~gammapy.data.EventList` class to load IACT gamma-ray event lists:
 
 .. code-block:: python
 
-    >>> from gammapy.data import EventListDataset
-    >>> filename = '$GAMMAPY_EXTRA/datasets/vela_region/events_vela.fits'
-    >>> events = EventListDataset.read(filename)
+    >>> from gammapy.data import EventList
+    >>> filename = '$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    >>> events = EventList.read(filename)
 
-TODO: ``events.info()`` gives s ``KeyError: 'ONTIME'``.
-Should we introduce a sub-class ``EventListIACT``?
+To load Fermi-LAT event lists, use the `~gammapy.data.EventListLAT` class:
 
 .. code-block:: python
 
-    >>> from gammapy.data import EventListDataset
-    >>> filename = '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/run023400-023599/run023523/hess_events_023523.fits.gz'
-    >>> events = EventListDataset.read(filename)
-    >>> events.info()
+    >>> from gammapy.data import EventListLAT
+    >>> filename = '$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz'
+    >>> events = EventListLAT.read(filename)
+
+The other main class in `gammapy.data` is the `~gammapy.data.DataStore`, which makes it easy
+to load IACT data. E.g. an alternative way to load the events for observation ID 23523 is this:
+
+.. code-block:: python
+
+    >>> from gammapy.data import DataStore
+    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
+    >>> events = data_store.obs(23523).events
 
 Using `gammapy.data`
 ====================

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -76,8 +76,8 @@ Getting the answer from Gammapy is easy. You import and call the
 .. code-block:: python
 
     >>> from gammapy.stats import significance
-    >>> significance(n_observed=10, mu_background=4.2, method='lima')
-    2.3979181291475453
+    >>> significance(n_on=10, mu_bkg=4.2, method='lima')
+    array([2.39791813])
 
 As another example, here's how you can create `gammapy.data.DataStore` and
 `gammapy.data.EventList` objects and start exploring some properties of the
@@ -86,12 +86,16 @@ As another example, here's how you can create `gammapy.data.DataStore` and
 .. code-block:: python
 
     >>> from gammapy.data import DataStore
-    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2/')
+    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/')
     >>> events = data_store.obs(obs_id=23523).events
-    >>> len(events)
-    1527
+    >>> print(events)
+    EventList info:
+    - Number of events: 7613
+    - Median energy: 0.953 TeV
+    - OBS_ID = 23523
     >>> events.energy.mean()
-    <Quantity 3.585395097732544 TeV>
+    <Quantity 4.418008 TeV>
+    >>> events.peek()
 
 How do you find something in Gammapy?
 

--- a/docs/spectrum/fitting.rst
+++ b/docs/spectrum/fitting.rst
@@ -21,24 +21,23 @@ simulated crab runs using the `~gammapy.spectrum.SpectrumFit` class.
 
 .. code-block:: python
 
-    import astropy.units as u
     from gammapy.spectrum import SpectrumObservation, SpectrumObservationList, SpectrumFit
     from gammapy.spectrum.models import PowerLaw
     import matplotlib.pyplot as plt
 
-    pha1 = "$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23592.fits"
-    pha2 = "$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23523.fits"
-    obs1 = SpectrumObservation.read(pha1)
-    obs2 = SpectrumObservation.read(pha2)
+    path = "$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/"
+    obs1 = SpectrumObservation.read(path + "pha_obs23523.fits")
+    obs2 = SpectrumObservation.read(path + "pha_obs23592.fits")
     obs_list = SpectrumObservationList([obs1, obs2])
 
-    model = PowerLaw(index = 2 * u.Unit(''),
-                     amplitude = 10 ** -12 * u.Unit('cm-2 s-1 TeV-1'),
-                     reference = 1 * u.TeV)
+    model = PowerLaw(
+        index=2,
+        amplitude='1e-12  cm-2 s-1 TeV-1',
+        reference='1 TeV',
+    )
 
-    fit = SpectrumFit(obs_list=obs_list, model=model)
-    fit.statistic = 'WStat'
-    fit.run()
+    fit = SpectrumFit(obs_list=obs_list, model=model, stat='wstat')
+    result = fit.run()
 
 You can check the fit results by looking at
 `~gammapy.spectrum.SpectrumFitResult` that is attached to the
@@ -46,22 +45,40 @@ You can check the fit results by looking at
 
 .. code-block:: python
 
-    >>> print(fit.global_result)
+    >>> print(result)
+    FitResult
+
+        backend    : minuit
+        method     : minuit
+        success    : True
+        nfev       : 99
+        total stat : 63.00
+        message    : Optimization terminated successfully.
+
+    >>> print(fit.result[0])
 
     Fit result info
     ---------------
-    Best Fit Model: PowerLaw
-    index : 2.12+/-0.05
-    reference : 1e+09
-    amplitude : (2.08+/-0.00)e-20
-    --> Units: keV, cm, s
+    Model: PowerLaw
 
-    Statistic: 103.596 (wstat)
+    Parameters:
+
+           name     value     error         unit         min    max
+        --------- --------- --------- --------------- --------- ---
+            index 2.761e+00 1.094e-01                       nan nan
+        amplitude 5.118e-11 4.849e-12 1 / (cm2 s TeV)       nan nan
+        reference 1.000e+00 0.000e+00             TeV 0.000e+00 nan
+
     Covariance:
-    [u'index', u'amplitude']
-    [[  2.95033865e-03   3.08066478e-43]
-     [  3.08066478e-43   1.70801015e-82]]
-    Fit Range: [  0.49582929  82.70931131] TeV
+
+           name           index                amplitude        reference
+        --------- ---------------------- ---------------------- ---------
+            index   0.011973084948262436 3.3890114528842897e-13       0.0
+        amplitude 3.3890114528842897e-13 2.3510477262284227e-23       0.0
+        reference                    0.0                    0.0       0.0
+
+    Statistic: 21.076 (wstat)
+    Fit Range: [8.79922544e+08 1.00000000e+11] keV
 
 
 Interactive Sherpa Fit
@@ -79,8 +96,8 @@ example dataset used above. It makes use of the Sherpa `datastack module
     from sherpa.astro import datastack
     from sherpa.models import PowLaw1D
 
-    pha1 = gammapy_extra.filename('datasets/hess-crab4_pha/pha_obs23592.fits')
-    pha2 = gammapy_extra.filename('datasets/hess-crab4_pha/pha_obs23523.fits')
+    pha1 = gammapy_extra.filename('datasets/joint-crab/spectra/hess//pha_obs23592.fits')
+    pha2 = gammapy_extra.filename('datasets/joint-crab/spectra/hess//pha_obs23523.fits')
     phalist = ','.join([pha1, pha2])
 
     ds = datastack.DataStack()

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -29,19 +29,18 @@ OGIP format and fit a spectral model.
 
 .. code-block:: python
 
-    import astropy.units as u
-    from gammapy.datasets import gammapy_extra
-    from gammapy.spectrum import SpectrumObservation, SpectrumFit, models
+    from gammapy.spectrum import SpectrumObservation, SpectrumFit
+    from gammapy.spectrum.models import PowerLaw
 
-    filename = '$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23592.fits'
+    filename = '$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23523.fits'
     obs = SpectrumObservation.read(filename)
 
-    model = models.PowerLaw(
-        index=2 * u.Unit(''),
-        amplitude=1e-12*u.Unit('cm-2 s-1 TeV-1'),
-        reference=1*u.TeV,
+    model = PowerLaw(
+        index=2,
+        amplitude='1e-12 cm-2 s-1 TeV-1',
+        reference='1 TeV',
     )
-    fit = SpectrumFit(obs_list=obs, model=model)
+    fit = SpectrumFit(obs_list=[obs], model=model)
     fit.run()
     print(fit.result[0])
 
@@ -52,17 +51,25 @@ It will print the following output to the console:
     Fit result info
     ---------------
     Model: PowerLaw
-    Parameters
-    Parameter(name='index', value=2.1473880540790522, unit=Unit(dimensionless), min=0, max=None, frozen=False)
-    Parameter(name='amplitude', value=2.7914083679020973e-11, unit=Unit("1 / (cm2 s TeV)"), min=0, max=None, frozen=False)
-    Parameter(name='reference', value=1.0, unit=Unit("TeV"), min=None, max=None, frozen=True)
 
-    Covariance: [[  6.89132245e-03   1.12566759e-13   0.00000000e+00]
-     [  1.12566759e-13   7.26865610e-24   0.00000000e+00]
-     [  0.00000000e+00   0.00000000e+00   0.00000000e+00]]
+    Parameters:
 
-    Statistic: 46.051 (wstat)
-    Fit Range: [  5.99484250e+08   1.00000000e+11] keV
+           name     value     error         unit         min    max
+        --------- --------- --------- --------------- --------- ---
+            index 2.791e+00 1.456e-01                       nan nan
+        amplitude 5.030e-11 6.251e-12 1 / (cm2 s TeV)       nan nan
+        reference 1.000e+00 0.000e+00             TeV 0.000e+00 nan
+
+    Covariance:
+
+           name           index               amplitude        reference
+        --------- --------------------- ---------------------- ---------
+            index  0.021213640646334082  5.788340722422449e-13       0.0
+        amplitude 5.788340722422449e-13 3.9079614123597625e-23       0.0
+        reference                   0.0                    0.0       0.0
+
+    Statistic: 41.756 (wstat)
+    Fit Range: [8.79922544e+08 1.00000000e+11] keV
 
 Using `gammapy.spectrum`
 ========================

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -57,10 +57,8 @@ class EventListBase(object):
 
     def __init__(self, table):
 
-        # TODO: remove this temp fix once we change to a new test dataset
-        # This is a temp fix because this test dataset is used for many Gammapy tests
-        # but it doesn't have the units set properly
-        # '$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2'
+        # TODO: remove this temp fix once we drop support for `hess-hd-hap-prod2`
+        # There the unit wasn't set correctly in the FITS table, so this hack is needed.
         if "ENERGY" in table.colnames:
             if not table["ENERGY"].unit:
                 table["ENERGY"].unit = "TeV"
@@ -402,20 +400,6 @@ class EventListBase(object):
         -------
         ax : `~matplotlib.axes.Axes`
             Axes
-
-        Examples
-        --------
-        Plot the rate of the events:
-
-        .. plot::
-            :include-source:
-
-            import matplotlib.pyplot as plt
-            from gammapy.data import EventList
-
-            events = EventList.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz')
-            events.plot_time()
-            plt.show()
         """
         import matplotlib.pyplot as plt
 
@@ -474,7 +458,7 @@ class EventListBase(object):
         Load an example event list:
 
         >>> from gammapy.data import EventList
-        >>> events = EventList.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz')
+        >>> events = EventList.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz')
 
         Plot the offset^2 distribution wrt. the observation pointing position
         (this is a commonly used plot to check the background spatial distribution):
@@ -553,7 +537,8 @@ class EventList(EventListBase):
     To load an example H.E.S.S. event list:
 
     >>> from gammapy.data import EventList
-    >>> events = EventList.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz')
+    >>> filename = '$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    >>> events = EventList.read(filename)
     """
 
     @property

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -71,7 +71,7 @@ class SpectrumObservation(object):
     ::
 
         from gammapy.spectrum import SpectrumObservation
-        filename = '$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23523.fits'
+        filename = '$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23523.fits'
         obs = SpectrumObservation.read(filename)
         print(obs)
     """
@@ -609,17 +609,16 @@ class SpectrumObservationList(UserList):
         method : str, {'inclusive', 'exclusive'}
             Maximum or minimum range
         """
-        lo_thres = Quantity([obs.lo_threshold for obs in self])
-        hi_thres = Quantity([obs.hi_threshold for obs in self])
+        unit = 'TeV'
+        lo = [obs.lo_threshold.to(unit).value for obs in self]
+        hi = [obs.hi_threshold.to(unit).value for obs in self]
 
         if method == "inclusive":
-            safe_range = [np.min(lo_thres), np.max(hi_thres)]
+            return Quantity([min(lo), max(hi)], unit)
         elif method == "exclusive":
-            safe_range = [np.max(lo_thres), np.min(hi_thres)]
+            return Quantity([max(lo), min(hi)], unit)
         else:
             raise ValueError("Invalid method: {}".format(method))
-
-        return safe_range
 
     def write(self, outdir=None, pha_typeII=False, **kwargs):
         """Create OGIP files
@@ -756,7 +755,7 @@ class SpectrumObservationStacker(object):
     Examples
     --------
     >>> from gammapy.spectrum import SpectrumObservationList, SpectrumObservationStacker
-    >>> obs_list = SpectrumObservationList.read('$GAMMAPY_EXTRA/datasets/hess-crab4_pha')
+    >>> obs_list = SpectrumObservationList.read('$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess')
     >>> obs_stacker = SpectrumObservationStacker(obs_list)
     >>> obs_stacker.run()
     >>> print(obs_stacker.stacked_obs)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -155,7 +155,7 @@ def test_compute_flux_points_dnde_exp(method):
 
 @pytest.fixture(scope="session")
 def obs():
-    filename = "$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23523.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23523.fits"
     obs = SpectrumObservation.read(filename)
     return obs
 
@@ -199,13 +199,13 @@ class TestFluxPointEstimator:
         flux_points = self.fpe.flux_points
 
         actual = flux_points.table["dnde"][0]
-        assert_allclose(actual, 4.988e-11, rtol=1e-2)
+        assert_allclose(actual, 2.361e-10, rtol=1e-2)
 
         actual = flux_points.table["dnde_err"][0]
-        assert_allclose(actual, 6.2382e-12, rtol=1e-2)
+        assert_allclose(actual, 2.9128e-11, rtol=1e-2)
 
         actual = flux_points.table["dnde_ul"][0]
-        assert_allclose(actual, 6.3298e-11, rtol=1e-2)
+        assert_allclose(actual, 2.994e-10, rtol=1e-2)
 
         actual = flux_points.table["dnde_errn"][0]
         assert_allclose(actual, np.nan, rtol=1e-2)
@@ -219,7 +219,7 @@ class TestFluxPointEstimator:
         result = SpectrumResult(model=self.fpe.model, points=self.fpe.flux_points)
 
         actual = result.flux_point_residuals[0][0]
-        assert_allclose(actual, -0.32176, rtol=1e-2)
+        assert_allclose(actual, -0.058407, rtol=1e-2)
 
         actual = result.flux_point_residuals[1][0]
         assert_allclose(actual, np.nan, rtol=1e-2)

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -13,10 +13,10 @@ from .. import SpectrumObservation, SpectrumFitResult, FluxPoints, SpectrumResul
 
 @pytest.fixture(scope="session")
 def fit_result():
-    filename = "$GAMMAPY_EXTRA/datasets/hess-crab4_pha/pha_obs23592.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23592.fits"
     obs = SpectrumObservation.read(filename)
     best_fit_model = PowerLaw(
-        index=2.1 * u.Unit(""),
+        index=2.1,
         amplitude=1e-11 * u.Unit("cm-2 s-1 TeV-1"),
         reference=1 * u.TeV,
     )

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -67,11 +67,11 @@
 - name: spectrum_analysis
   requires: iminuit
   datasets:
-      - hess-dl3-dr1
+    - hess-dl3-dr1
 - name: spectrum_fitting_with_sherpa
   requires: sherpa
   datasets:
-    - hess-crab4_pha
+    - joint-crab
 - name: spectrum_models
   requires:
   datasets:

--- a/tutorials/spectrum_models.ipynb
+++ b/tutorials/spectrum_models.ipynb
@@ -18,8 +18,8 @@
     "The following clases will be used:\n",
     "\n",
     "* [gammapy.spectrum.models.PowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html)\n",
-    "* [gammapy.utils.modelling.Parameter](http://docs.gammapy.org/dev/api/gammapy.utils.modeling.Parameter.html)\n",
-    "* [gammapy.utils.modelling.Parameters](http://docs.gammapy.org/dev/api/gammapy.utils.modeling.Parameters.html)\n",
+    "* [gammapy.utils.fitting.Parameter](http://docs.gammapy.org/dev/api/gammapy.utils.fitting.Parameter.html)\n",
+    "* [gammapy.utils.fitting.Parameters](http://docs.gammapy.org/dev/api/gammapy.utils.fitting.Parameters.html)\n",
     "* [gammapy.spectrum.models.SpectralModel](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.SpectralModel.html)"
    ]
   },


### PR DESCRIPTION
This PR updates many tests and examples that used a very old and bad version of 4 Crab runs from HESS (actually a simulated buggy dataset based on HESS IRFs) with the real deal, which is now available: https://github.com/gammapy/gammapy-extra/tree/master/datasets/joint-crab

I will finish this transition soon in a second PR.
