### PR TITLE
Fix EnergyDispersion write and to_sherpa

### DIFF
--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -484,7 +484,7 @@ class EnergyDispersion(object):
         return var / norm
 
     def to_sherpa(self, name):
-        """Convert to `sherpa.astro.data.DataARF`.
+        """Convert to `sherpa.astro.data.DataRMF`.
 
         Parameters
         ----------
@@ -500,9 +500,7 @@ class EnergyDispersion(object):
         table = self.to_table()
         n_grp = table["N_GRP"].data.astype(SherpaUInt)
         f_chan = table["F_CHAN"].data
-        f_chan = np.concatenate([row for row in f_chan]).astype(SherpaUInt)
         n_chan = table["N_CHAN"].data
-        n_chan = np.concatenate([row for row in n_chan]).astype(SherpaUInt)
         matrix = table["MATRIX"].data
 
         good = n_grp > 0
@@ -512,7 +510,9 @@ class EnergyDispersion(object):
 
         good = n_grp > 0
         f_chan = f_chan[good]
+        f_chan = np.concatenate([row for row in f_chan]).astype(SherpaUInt)
         n_chan = n_chan[good]
+        n_chan = np.concatenate([row for row in n_chan]).astype(SherpaUInt)
 
         return DataRMF(
             name=name,

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -139,7 +139,7 @@ class SpectrumObservationTester:
         # TODO: fix the to_sherpa
         # It broke with the update to the hess-dl3-dr1 dataset.
         # Error: https://gist.github.com/cdeil/0cf3456e0dd4204cdabc71eaa2cbb70f
-        # self.test_to_sherpa()
+        self.test_to_sherpa()
         self.test_peek()
         self.test_npred()
 

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -136,9 +136,6 @@ class SpectrumObservationTester:
         self.test_stats_table()
         self.test_total_stats()
         self.test_stats_in_safe_range()
-        # TODO: fix the to_sherpa
-        # It broke with the update to the hess-dl3-dr1 dataset.
-        # Error: https://gist.github.com/cdeil/0cf3456e0dd4204cdabc71eaa2cbb70f
         self.test_to_sherpa()
         self.test_peek()
         self.test_npred()


### PR DESCRIPTION
…grp>1

This should provide a correction to cases where the RMF is stored with some true energies have `n_grp`>1. 
