### PR TITLE
Add ObservationTableChecker and improve EVENTS checker

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -734,6 +734,8 @@ class EventListChecker(Checker):
         "ONTIME",
         "LIVETIME",
         "DEADC",
+        "RA_PNT",
+        "DEC_PNT",
         # TODO: what to do about these?
         # They are currently listed as required in the spec,
         # but I think we should just require ICRS and those

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -112,4 +112,4 @@ class TestDataStoreChecker:
 
     def test_check_all(self):
         records = list(self.data_store.check())
-        assert len(records) == 43
+        assert len(records) == 48

--- a/gammapy/data/tests/test_obs_table.py
+++ b/gammapy/data/tests/test_obs_table.py
@@ -4,10 +4,12 @@ import numpy as np
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord, AltAz
 from astropy.time import Time, TimeDelta
+from ...utils.testing import requires_data
 from ...utils.time import time_ref_from_dict, time_relative_to_ref
 from ...utils.random import sample_sphere, get_random_state
 from ...catalog import skycoord_from_table
-from .. import ObservationTable, observatory_locations
+from ..obs_table import ObservationTable, ObservationTableChecker
+from ..observers import observatory_locations
 
 
 def make_test_observation_table(
@@ -392,3 +394,13 @@ def test_select_sky_regions():
         border=border,
     )
     common_sky_region_select_test_routines(obs_table, selection)
+
+
+@requires_data("gammapy-extra")
+def test_observation_table_checker():
+    path = "$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/obs-index.fits.gz"
+    obs_table = ObservationTable.read(path)
+    checker = ObservationTableChecker(obs_table)
+
+    records = list(checker.run())
+    assert len(records) == 7


### PR DESCRIPTION
This PR adds a first version of an ObservationTableChecker, and also adds a check for the RA_PNT and DEC_PNT header keys of the EventListChecker. This was an important oversight in the spec (https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/pull/130) and in the checker.
