### PR TITLE
Adding Binder space for Gammapy repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# This is the Dockerfile to run Gammapy on Binder
+#
+
+FROM continuumio/miniconda3
+MAINTAINER Gammapy developers <gammapy@googlegroups.com>
+
+# compilers
+RUN apt-get update && apt-get install -y build-essential
+RUN pip install --upgrade pip 
+
+# install good version of notebook for Binder
+# RUN pip install --no-cache-dir notebook==5.*
+
+# install dependencies - including the dev version of Gammapy
+COPY environment.yml binder.py tmp/
+WORKDIR tmp/
+RUN conda update conda
+RUN conda install -q -y pyyaml
+RUN python binder.py
+
+# add gammapy user running the jupyter notebook process
+ENV NB_USER gammapy
+ENV NB_UID 1000
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+
+# copy repo in /home/gammapy
+# COPY . ${HOME}
+
+RUN gammapy download --release=master --dest=${HOME}/gammapy-tutorials tutorials
+
+# setting ownerships
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+
+# start JupyterLab server in tutorials dir
+USER ${NB_USER}
+WORKDIR ${HOME}/gammapy-tutorials/notebooks-master
+
+# env vars used in tutorials
+ENV GAMMAPY_EXTRA /home/${NB_USER}/gammapy-tutorials
+ENV CTADATA /home/${NB_USER}/gammapy-tutorials/datasets/cta-1dc

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN adduser --disabled-password \
 # copy repo in /home/gammapy
 # COPY . ${HOME}
 
-RUN gammapy download --release=master --dest=${HOME}/gammapy-tutorials tutorials
+RUN gammapy download --release=master --dest=${HOME}/gammapy-tutorials notebooks
 
 # setting ownerships
 USER root
@@ -42,5 +42,11 @@ USER ${NB_USER}
 WORKDIR ${HOME}/gammapy-tutorials/notebooks-master
 
 # env vars used in tutorials
-ENV GAMMAPY_EXTRA /home/${NB_USER}/gammapy-tutorials
-ENV CTADATA /home/${NB_USER}/gammapy-tutorials/datasets/cta-1dc
+RUN git clone https://github.com/gammapy/gammapy-extra.git ${HOME}/gammapy-tutorials/gammapy-extra
+ENV GAMMAPY_EXTRA ${HOME}/gammapy-tutorials/gammapy-extra
+
+RUN git clone https://github.com/gammapy/gamma-cat.git  ${HOME}/gammapy-tutorials/gammapy-cat
+ENV GAMMAPY_CAT ${HOME}/gammapy-tutorials/gammapy-cat
+
+RUN git clone https://github.com/gammapy/gammapy-fermi-lat-data.git ${HOME}/gammapy-tutorials/gammapy-fermi-lat-data
+ENV GAMMAPY_FERMI_LAT_DATA ${HOME}/gammapy-tutorials/gammapy-fermi-lat-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,13 @@ RUN adduser --disabled-password \
 
 RUN gammapy download --release=master --dest=${HOME}/gammapy-tutorials notebooks
 
+# remove tutorials using CTA 1DC
+RUN rm ${HOME}/gammapy-tutorials/notebooks-master/analysis_3d.ipynb
+RUN rm ${HOME}/gammapy-tutorials/notebooks-master/cta_1dc_introduction.ipynb
+RUN rm ${HOME}/gammapy-tutorials/notebooks-master/cta_data_analysis.ipynb
+RUN rm ${HOME}/gammapy-tutorials/notebooks-master/simulate_3d.ipynb
+RUN rm ${HOME}/gammapy-tutorials/notebooks-master/spectrum_simulation_cta.ipynb
+
 # setting ownerships
 USER root
 RUN chown -R ${NB_UID} ${HOME}

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ A Python Package for Gamma-ray Astronomy.
 .. image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
     :target: http://www.astropy.org/
 
+.. image:: http://mybinder.org/badge.svg
+    :target: https://mybinder.org/v2/gh/gammapy/gammapy/master?urlpath=lab/tree/first_steps.ipynb
 
 Status shields
 ++++++++++++++

--- a/binder.py
+++ b/binder.py
@@ -1,0 +1,24 @@
+"""This script is executed from Dockerfile configuration file
+It installs software dependencies declared in environment.yml
+in the docker container built for the Binder service.
+"""
+
+import yaml
+import sys
+import conda.cli
+from pip._internal import main as pip_main
+
+with open("environment.yml") as stream:
+    content = yaml.load(stream)
+
+for chan in content['channels']:
+    print("RUN conda config --add channels {}".format(chan))
+    conda.cli.main('conda', 'config',  '--add', 'channels', chan)
+
+for pack in content['dependencies']:
+    if isinstance(pack, str):
+        print("RUN conda install -q -y {}".format(pack))
+        conda.cli.main('conda', 'install',  '-y', '-q', pack)
+    else:
+        print("RUN pip install {}".format(pack['pip'][0]))
+        pip_main(["install", pack['pip'][0]])

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -125,9 +125,9 @@ def modif_nb_links(folder, url_docs, git_commit):
 <div class='alert alert-info'>
 **This is a fixed-text formatted version of a Jupyter notebook.**
 
-- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy-extra/{git_commit}?urlpath=lab/tree/{nb_filename})
+- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy/{git_commit}?urlpath=lab/tree/{nb_filename})
 - You can contribute with your own notebooks in this
-[GitHub repository](https://github.com/gammapy/gammapy-extra/tree/master/notebooks).
+[GitHub repository](https://github.com/gammapy/gammapy/tree/master/tutorials).
 - **Source files:**
 [{nb_filename}](../_static/notebooks/{nb_filename}) |
 [{py_filename}](../_static/notebooks/{py_filename})


### PR DESCRIPTION
This PR adds Binder space functionality for Gammapy repo.

Content in documentation webpage http://docs.gammapy.org will need to be updated with content generated with this version of `utils/docs.py` to replace links to Gammapy-extra repo Binder space with the new ones pointing to this Gammapy repo Binder space. Once the content in docs webpage is updated, we could procede to remove duplicated tutorials in Gammapy-extra repo.

When proceeding to make a release the files `environment.yml`, `Dockerfile` and `README.rst` must be updated to use the right Gammapy version number in the release-tagged Binder space and link it.
