### PR TITLE
Fix datasets access in tutorials and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima regions reproject pandoc ipython iminuit'
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython jupyter'
+        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib==2.2.3 pyyaml uncertainties pandas naima sherpa libgfortran iminuit runipy regions reproject pandoc ipython jupyter'
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ env:
 
         - FETCH_GAMMAPY_EXTRA=true
         - FETCH_GAMMA_CAT=true
+        - FETCH_GAMMAPY_FERMI_LAT_DATA=true
         - PACKAGING_TEST=false
         - TEST_FERMIPY=false
 
@@ -79,9 +80,9 @@ matrix:
                CONDA_DEPENDENCIES='Cython click regions pyyaml'
                PIP_DEPENDENCIES=''
 
-        # Run tests without GAMMAPY_EXTRA available
+        # Run tests without GAMMAPY_EXTRA/GAMMA_CAT/GAMMAPY_FERMI_LAT_DATA available
         - os: linux
-          env: FETCH_GAMMAPY_EXTRA=false PYTHON_VERSION=3.7 SETUP_CMD='test -V'
+          env: FETCH_GAMMAPY_EXTRA=false FETCH_GAMMA_CAT=false FETCH_GAMMAPY_FERMI_LAT_DATA=false PYTHON_VERSION=3.7 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
         # Build docs
@@ -169,6 +170,10 @@ install:
           export GAMMA_CAT=${HOME}/gamma-cat;
       fi
 
+    - if $FETCH_GAMMAPY_FERMI_LAT_DATA; then
+          git clone https://github.com/gammapy/gammapy-fermi-lat-data.git $HOME/gammapy-fermi-lat-data;
+          export GAMMAPY_FERMI_LAT_DATA=${HOME}/gammapy-fermi-lat-data;
+      fi
     # From https://conda.io/docs/bdist_conda.html
     # bdist_conda must be installed into a root conda environment,
     # as it imports conda and conda_build. It is included as part of the conda build package.

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -6,6 +6,7 @@ import click
 import logging
 import subprocess
 import time
+import sys
 
 log = logging.getLogger(__name__)
 
@@ -22,6 +23,10 @@ def cli_jupyter_run(ctx):
 def execute_notebook(path, loglevel=20):
     """Execute a Jupyter notebook."""
 
+    kernel_name = "python3"
+    if sys.version_info[0] < 3:
+        kernel_name = "python2"
+
     try:
         t = time.time()
         subprocess.call(
@@ -29,9 +34,10 @@ def execute_notebook(path, loglevel=20):
             "--allow-errors "
             "--log-level={} "
             "--ExecutePreprocessor.timeout=None "
+            "--ExecutePreprocessor.kernel_name={} "
             "--to notebook "
             "--inplace "
-            "--execute '{}'".format(loglevel, path),
+            "--execute '{}'".format(loglevel, kernel_name, path),
             shell=True,
         )
         t = (time.time() - t) / 60

--- a/process_tutorials.py
+++ b/process_tutorials.py
@@ -34,32 +34,25 @@ def ignoreall(d, files): return [
 def main():
 
     if len(sys.argv) != 2:
-        logging.info('Usage:')
-        logging.info('python process_tutorials.py tutorials')
-        logging.info('python process_tutorials.py tutorials/mynotebook.ipynb')
+        logging.info("Usage:")
+        logging.info("python process_tutorials.py tutorials")
+        logging.info("python process_tutorials.py tutorials/mynotebook.ipynb")
         sys.exit()
 
-    if 'GAMMAPY_EXTRA' not in os.environ:
-        logging.info('GAMMAPY_EXTRA environment variable not set.')
-        logging.info('Running notebook tests requires gammapy-extra.')
-        logging.info('Exiting now.')
-        sys.exit()
-
-    # make datasets symlink
-    try:
-        path_datasets = Path(os.environ['GAMMAPY_EXTRA']) / 'datasets'
-        os.symlink(str(path_datasets), 'datasets')
-    except Exception as ex:
-        logging.error('It was not possible to create a /datasets symlink')
-        logging.error(ex)
-        sys.exit()
+    env_vars = ["GAMMAPY_EXTRA", "GAMMA_CAT", "GAMMAPY_FERMI_LAT_DATA", "CTADATA"]
+    for var in env_vars:
+        if var not in os.environ:
+            logging.info(var + " environment variable not set.")
+            logging.info("Running notebook tests requires this environment variable.")
+            logging.info("Exiting now.")
+            sys.exit()
 
     # prepare folder structure
     pathsrc = Path(sys.argv[1])
-    path_temp = Path('temp')
-    path_empty_nbs = Path('tutorials')
-    path_filled_nbs = Path('docs') / 'notebooks'
-    path_static_nbs = Path('docs') / '_static' / 'notebooks'
+    path_temp = Path("temp")
+    path_empty_nbs = Path("tutorials")
+    path_filled_nbs = Path("docs") / "notebooks"
+    path_static_nbs = Path("docs") / "_static" / "notebooks"
 
     rmtree(str(path_temp), ignore_errors=True)
     path_temp.mkdir(parents=True, exist_ok=True)
@@ -76,12 +69,12 @@ def main():
         pathdest = path_temp / notebookname
         copyfile(str(pathsrc), str(pathdest))
     else:
-        logging.info('Notebook file does not exist.')
+        logging.info("Notebook file does not exist.")
         sys.exit()
 
     # strip and blackformat
-    subprocess.call('gammapy jupyter --src temp black', shell=True)
-    subprocess.call('gammapy jupyter --src temp strip', shell=True)
+    subprocess.call("gammapy jupyter --src temp black", shell=True)
+    subprocess.call("gammapy jupyter --src temp strip", shell=True)
 
     # test /run
     passed = True
@@ -98,27 +91,26 @@ def main():
             copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignoreall)
             for path in path_static_nbs.glob("*.ipynb"):
                 subprocess.call(
-                    "jupyter nbconvert --to script '{}'".format(str(path)),
-                    shell=True)
+                    "jupyter nbconvert --to script '{}'".format(str(path)), shell=True
+                )
             copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
         else:
             pathsrc = path_temp / notebookname
             pathdest = path_static_nbs / notebookname
             copyfile(str(pathsrc), str(pathdest))
             subprocess.call(
-                "jupyter nbconvert --to script '{}'".format(str(pathdest)),
-                shell=True)
+                "jupyter nbconvert --to script '{}'".format(str(pathdest)), shell=True
+            )
             pathdest = path_filled_nbs / notebookname
             copyfile(str(pathsrc), str(pathdest))
     else:
-        logging.info('Tests have not passed.')
-        logging.info('Tutorials not ready for documentation building process.')
+        logging.info("Tests have not passed.")
+        logging.info("Tutorials not ready for documentation building process.")
         rmtree(str(path_static_nbs), ignore_errors=True)
 
     # tear down
     rmtree(str(path_temp), ignore_errors=True)
-    os.unlink('datasets')
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -15,7 +15,7 @@ logging.basicConfig(level=logging.INFO)
 
 def get_notebooks():
     """Read `notebooks.yaml` info."""
-    filename = str(Path('tutorials') / 'notebooks.yaml')
+    filename = str(Path("tutorials") / "notebooks.yaml")
     with open(filename) as fh:
         notebooks = yaml.safe_load(fh)
     return notebooks
@@ -23,10 +23,10 @@ def get_notebooks():
 
 def requirement_missing(notebook):
     """Check if one of the requirements is missing."""
-    if notebook['requires'] is None:
+    if notebook["requires"] is None:
         return False
 
-    for package in notebook['requires'].split():
+    for package in notebook["requires"].split():
         try:
             working_set.require(package)
         except Exception as ex:
@@ -35,39 +35,36 @@ def requirement_missing(notebook):
 
 
 def main():
-    if 'GAMMAPY_EXTRA' not in os.environ:
-        logging.info('GAMMAPY_EXTRA environment variable not set.')
-        logging.info('Running notebook tests requires gammapy-extra.')
-        logging.info('Exiting now.')
-        sys.exit()
 
-    try:
-        path_datasets = Path(os.environ['GAMMAPY_EXTRA']) / 'datasets'
-        os.symlink(str(path_datasets), 'datasets')
-    except Exception as ex:
-        logging.error('It was not possible to create a /datasets symlink')
-        logging.error(ex)
-        sys.exit()
+    env_vars = ["GAMMAPY_EXTRA", "GAMMA_CAT", "GAMMAPY_FERMI_LAT_DATA"]
+    for var in env_vars:
+        if var not in os.environ:
+            logging.info(var + " environment variable not set.")
+            logging.info("Running notebook tests requires this environment variable.")
+            logging.info("Exiting now.")
+            sys.exit()
 
     passed = True
     yamlfile = get_notebooks()
-    dirnbs = Path('tutorials')
+    dirnbs = Path("tutorials")
 
     for notebook in yamlfile:
         if requirement_missing(notebook):
-            logging.info('Skipping notebook {} because requirement is missing.'.format(
-                notebook['name']))
+            logging.info(
+                "Skipping notebook {} because requirement is missing.".format(
+                    notebook["name"]
+                )
+            )
             continue
 
-        filename = notebook['name'] + '.ipynb'
+        filename = notebook["name"] + ".ipynb"
         path = dirnbs / filename
 
         if not test_notebook(path):
             passed = False
 
-    os.unlink('datasets')
     assert passed
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "# Define which data to use\n",
-    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/\")\n",
+    "data_store = DataStore.from_dir(\"$CTADATA/index/gps/\")\n",
     "obs_ids = [110380, 111140, 111159]\n",
     "obs_list = data_store.obs_list(obs_ids)"
    ]

--- a/tutorials/astropy_introduction.ipynb
+++ b/tutorials/astropy_introduction.ipynb
@@ -50,6 +50,7 @@
     "# most even with Astropy 1.0\n",
     "import numpy as np\n",
     "import astropy\n",
+    "import os\n",
     "\n",
     "print(\"numpy:\", np.__version__)\n",
     "print(\"astropy:\", astropy.__version__)"
@@ -334,7 +335,8 @@
    "outputs": [],
    "source": [
     "# Open Fermi 3FGL from the repo\n",
-    "table = Table.read(\"../datasets/catalogs/fermi/gll_psc_v16.fit.gz\", hdu=1)\n",
+    "filename = os.environ['GAMMAPY_EXTRA']+'/datasets/catalogs/fermi/gll_psc_v16.fit.gz'\n",
+    "table = Table.read(filename, hdu=1)\n",
     "# Alternatively, one can grab it from the server.\n",
     "# table = Table.read(\"http://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/gll_psc_v16.fit\")"
    ]
@@ -346,7 +348,7 @@
    "outputs": [],
    "source": [
     "# Note that a single FITS file might contain different tables in different HDUs\n",
-    "filename = \"../datasets/catalogs/fermi/gll_psc_v16.fit.gz\"\n",
+    "filename = os.environ['GAMMAPY_EXTRA']+'/datasets/catalogs/fermi/gll_psc_v16.fit.gz'\n",
     "# You can load a `fits.HDUList` and check the extension names\n",
     "print([_.name for _ in fits.open(filename)])\n",
     "# Then you can load by name or integer index via the `hdu` option\n",

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -104,8 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# data_store = DataStore.from_dir('$CTADATA/index/gps')\n",
-    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps/\")"
+    "data_store = DataStore.from_dir('$CTADATA/index/gps')"
    ]
   },
   {

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Computation of the CTA sensitivity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook explains how to derive the CTA sensitivity for a point-like IRF at a fixed zenith angle and fixed offset. The significativity is computed for the 1D analysis (On-OFF regions) and the LiMa formula.\n",
+    "\n",
+    "We will be using the following Gammapy classes:\n",
+    "\n",
+    "* [gammapy.irf.CTAIrf](http://docs.gammapy.org/dev/api/gammapy.irf.CTAIrf.html)\n",
+    "* [gammapy.spectrum.SensitivityEstimator](http://docs.gammapy.org/dev/api/gammapy.spectrum.SensitivityEstimator.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "As usual, we'll start with some setup ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.irf import CTAPerf\n",
+    "from gammapy.spectrum import SensitivityEstimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load IRFs\n",
+    "\n",
+    "First load the CTA IRFs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\n",
+    "irf = CTAPerf.read(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute sensitivity\n",
+    "\n",
+    "Choose a few parameters, then run the sentitivity computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sensitivity_estimator = SensitivityEstimator(irf=irf, livetime=\"5h\")\n",
+    "sensitivity_estimator.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "\n",
+    "The results are given as an Astropy table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the results table\n",
+    "sensitivity_estimator.results_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save it to file (could use e.g. format of CSV or ECSV or FITS)\n",
+    "# sensitivity_estimator.results_table.write('sensitivity.ecsv', format='ascii.ecsv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the sensitivity curve\n",
+    "t = sensitivity_estimator.results_table\n",
+    "\n",
+    "is_s = t[\"criterion\"] == \"significance\"\n",
+    "plt.plot(\n",
+    "    t[\"energy\"][is_s],\n",
+    "    t[\"e2dnde\"][is_s],\n",
+    "    \"s-\",\n",
+    "    color=\"red\",\n",
+    "    label=\"significance\",\n",
+    ")\n",
+    "\n",
+    "is_g = t[\"criterion\"] == \"gamma\"\n",
+    "plt.plot(\n",
+    "    t[\"energy\"][is_g], t[\"e2dnde\"][is_g], \"*-\", color=\"blue\", label=\"gamma\"\n",
+    ")\n",
+    "\n",
+    "plt.loglog()\n",
+    "plt.xlabel(\"Energy ({})\".format(t[\"energy\"].unit))\n",
+    "plt.ylabel(\"Sensitivity ({})\".format(t[\"e2dnde\"].unit))\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Also compute the sensitivity for a 20 hour observation\n",
+    "* Compare how the sensitivity differs between 5 and 20 hours by plotting the ratio as a function of energy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/detect_ts.ipynb
+++ b/tutorials/detect_ts.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "# Load data from files\n",
-    "filename = \"../datasets/fermi_survey/all.fits.gz\"\n",
+    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz\"\n",
     "opts = {\n",
     "    \"position\": SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"),\n",
     "    \"width\": (20, 8),\n",

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -55,6 +55,7 @@
     "from astropy.io import fits\n",
     "from astropy.wcs import WCS\n",
     "from gammapy.maps import Map, WcsNDMap, WcsGeom\n",
+    "import os\n",
     "\n",
     "# Warnings about XSPEC or DS9 can be ignored here\n",
     "import sherpa.astro.ui as sh"
@@ -67,17 +68,21 @@
    "outputs": [],
    "source": [
     "# Read the fits file to load them in a sherpa model\n",
-    "hdr = fits.getheader(\"../datasets/G300-0_test_counts.fits\")\n",
+    "filecounts = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_counts.fits'\n",
+    "hdr = fits.getheader(filecounts)\n",
     "wcs = WCS(hdr)\n",
     "\n",
     "sh.set_stat(\"cash\")\n",
     "sh.set_method(\"simplex\")\n",
-    "sh.load_image(\"../datasets/G300-0_test_counts.fits\")\n",
+    "sh.load_image(filecounts)\n",
     "sh.set_coord(\"logical\")\n",
     "\n",
-    "sh.load_table_model(\"expo\", \"../datasets/G300-0_test_exposure.fits\")\n",
-    "sh.load_table_model(\"bkg\", \"../datasets/G300-0_test_background.fits\")\n",
-    "sh.load_psf(\"psf\", \"../datasets/G300-0_test_psf.fits\")"
+    "fileexp = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_exposure.fits'\n",
+    "filebkg = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_background.fits'\n",
+    "filepsf = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_psf.fits'\n",
+    "sh.load_table_model(\"expo\", fileexp)\n",
+    "sh.load_table_model(\"bkg\", filebkg)\n",
+    "sh.load_psf(\"psf\", filepsf)"
    ]
   },
   {
@@ -97,7 +102,7 @@
     "bkg.ampl = 1\n",
     "sh.freeze(bkg)\n",
     "\n",
-    "resid = Map.read(\"../datasets/G300-0_test_counts.fits\")\n",
+    "resid = Map.read(filecounts)\n",
     "resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
     "resid_smooth = resid.smooth(radius=6)\n",
     "resid_smooth.plot();"

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -303,7 +303,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -317,7 +317,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/tutorials/intro_maps.ipynb
+++ b/tutorials/intro_maps.ipynb
@@ -41,7 +41,8 @@
    "source": [
     "%matplotlib inline\n",
     "import numpy as np\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import os"
    ]
   },
   {
@@ -657,7 +658,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hdulist = fits.open(\"../datasets/fermi_survey/all.fits.gz\")\n",
+    "filename = os.environ['GAMMAPY_EXTRA']+\"/datasets/fermi_survey/all.fits.gz\"\n",
+    "hdulist = fits.open(filename)\n",
     "hdulist.info()"
    ]
   },

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -1,0 +1,288 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Light curves\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "This tutorial explain how to compute a light curve with Gammapy.\n",
+    "\n",
+    "We will use the four Crab nebula observations from the [H.E.S.S. first public test data release](https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/) and compute per-observation fluxes. The Crab nebula is not known to be variable at TeV energies, so we expect constant brightness within statistical and systematic errors.\n",
+    "\n",
+    "The main classes we will use are:\n",
+    "\n",
+    "* [gammapy.time.LightCurve](http://docs.gammapy.org/dev/api/gammapy.time.LightCurve.html)\n",
+    "* [gammapy.time.LightCurveEstimator](http://docs.gammapy.org/dev/api/gammapy.time.LightCurveEstimator.html)\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "As usual, we'll start with some setup..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "from regions import CircleSkyRegion\n",
+    "from gammapy.utils.energy import EnergyBounds\n",
+    "from gammapy.data import DataStore\n",
+    "from gammapy.spectrum import SpectrumExtraction\n",
+    "from gammapy.spectrum.models import PowerLaw\n",
+    "from gammapy.background import ReflectedRegionsBackgroundEstimator\n",
+    "from gammapy.time import LightCurve, LightCurveEstimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spectrum\n",
+    "\n",
+    "The `LightCurveEstimator` is based on a 1d spectral analysis within each time bin.\n",
+    "So before we can make the light curve, we have to extract 1d spectra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_store = DataStore.from_dir(\"../datasets/hess-dl3-dr1/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = data_store.obs_table[\"OBS_SUBSET_TAG\"] == \"crab\"\n",
+    "obs_ids = data_store.obs_table[\"OBS_ID\"][mask].data\n",
+    "observations = data_store.obs_list(obs_ids)\n",
+    "print(observations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Target definition\n",
+    "target_position = SkyCoord(ra=83.63308, dec=22.01450, unit=\"deg\")\n",
+    "on_region_radius = Angle(\"0.2 deg\")\n",
+    "on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "bkg_estimator = ReflectedRegionsBackgroundEstimator(\n",
+    "    on_region=on_region, obs_list=observations\n",
+    ")\n",
+    "bkg_estimator.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ebounds = EnergyBounds.equal_log_spacing(0.7, 100, 50, unit=\"TeV\")\n",
+    "extraction = SpectrumExtraction(\n",
+    "    obs_list=observations,\n",
+    "    bkg_estimate=bkg_estimator.result,\n",
+    "    containment_correction=False,\n",
+    "    e_reco=ebounds,\n",
+    "    e_true=ebounds,\n",
+    ")\n",
+    "extraction.run()\n",
+    "spectrum_observations = extraction.observations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Light curve estimation\n",
+    "\n",
+    "OK, so now that we have prepared 1D spectra (not spectral models, just the 1D counts and exposure and 2D energy dispersion matrix), we can compute a lightcurve.\n",
+    "\n",
+    "To compute the light curve, a spectral model shape has to be assumed, and an energy band chosen.\n",
+    "The method is then to adjust the amplitude parameter of the spectral model in each time bin to the data, resulting in a flux measurement in each time bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Creat list of time bin intervals\n",
+    "# Here we do one time bin per observation\n",
+    "def time_intervals_per_obs(observations):\n",
+    "    for obs in observations:\n",
+    "        yield obs.tstart, obs.tstop\n",
+    "\n",
+    "\n",
+    "time_intervals = list(time_intervals_per_obs(observations))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Assumed spectral model\n",
+    "spectral_model = PowerLaw(\n",
+    "    index=2, amplitude=2.e-11 * u.Unit(\"1 / (cm2 s TeV)\"), reference=1 * u.TeV\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_range = [1, 100] * u.TeV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "lc_estimator = LightCurveEstimator(extraction)\n",
+    "lc = lc_estimator.light_curve(\n",
+    "    time_intervals=time_intervals,\n",
+    "    spectral_model=spectral_model,\n",
+    "    energy_range=energy_range,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "\n",
+    "The light curve measurement result is stored in a table. Let's have a look at the results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(lc.table.colnames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc.table[\"time_min\", \"time_max\", \"flux\", \"flux_err\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's compare to the expected flux of this source\n",
+    "from gammapy.spectrum import CrabSpectrum\n",
+    "\n",
+    "crab_spec = CrabSpectrum().model\n",
+    "crab_flux = crab_spec.integral(*energy_range).to(\"cm-2 s-1\")\n",
+    "crab_flux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = lc.plot(marker=\"o\", lw=2)\n",
+    "ax.hlines(\n",
+    "    crab_flux.value,\n",
+    "    xmin=lc.table[\"time_min\"].min(),\n",
+    "    xmax=lc.table[\"time_max\"].max(),\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Change the assumed spectral model shape (e.g. to a steeper power-law), and see how the integral flux estimate for the lightcurve changes.\n",
+    "* Try a time binning where you split the observation time for every run into two time bins.\n",
+    "* Try to analyse the PKS 2155 flare data from the H.E.S.S. first public test data release.\n",
+    "  Start with per-observation fluxes, and then try fluxes within 5 minute time bins for one or two of the observations where the source was very bright."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir(\"../datasets/hess-dl3-dr1/\")"
+    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/\")"
    ]
   },
   {

--- a/tutorials/nddata_demo.ipynb
+++ b/tutorials/nddata_demo.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to use the NDDataArray class"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook explains how to use the class [gammapy.utils.nddata.NDDataArray](http://docs.gammapy.org/dev/api/gammapy.utils.nddata.NDDataArray.html)\n",
+    "\n",
+    "The NDDataArray is basically an numpy array with associated axes and convenience methods for interpolation. For now \n",
+    "only the scipy [RegularGridInterpolator](https://docs.scipy.org/doc/scipy-0.14.0/reference/generated/scipy.interpolate.RegularGridInterpolator.html)\n",
+    "can be used, i.e. available interpolation methods are \"nearest neighbour\" and \"linear\". A spline interpolator\n",
+    "will be added in the future. The interpolation behaviour (\"log\", \"linear\") can be set for each axis individually.\n",
+    "\n",
+    "The NDDataArray is currently used in the following classes\n",
+    "\n",
+    "* [gammapy.irf.EffectiveAreaTable](http://docs.gammapy.org/dev/api/gammapy.irf.EffectiveAreaTable.html)\n",
+    "* [gammapy.irf.EffectiveAreaTable2D](http://docs.gammapy.org/dev/api/gammapy.irf.EffectiveAreaTable2D.html)\n",
+    "* [gammapy.irf.EnergyDispersion](http://docs.gammapy.org/dev/api/gammapy.irf.EnergyDispersion.html)\n",
+    "* [gammapy.spectrum.CountsSpectrum](http://docs.gammapy.org/dev/api/gammapy.spectrum.CountsSpectrum.html)\n",
+    "* Probably some more by now ...\n",
+    "\n",
+    "Feedback welcome!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "As usual, we'll start with some setup ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gammapy.utils.nddata import NDDataArray, DataAxis, BinnedDataAxis\n",
+    "from gammapy.utils.energy import Energy, EnergyBounds\n",
+    "import numpy as np\n",
+    "import astropy.units as u"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1D example\n",
+    "\n",
+    "Let's start with a simple example. A one dimensional array storing an exposure in ``cm-2 s-1`` as a function of energy. The energy axis is log spaced and thus also the interpolation shall take place in log."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energies = Energy.equal_log_spacing(10, 100, 10, unit=u.TeV)\n",
+    "x_axis = DataAxis(energies, name=\"energy\", interpolation_mode=\"log\")\n",
+    "data = np.arange(20, 0, -2) / u.cm ** 2 / u.s\n",
+    "nddata = NDDataArray(axes=[x_axis], data=data)\n",
+    "print(nddata)\n",
+    "print(nddata.axis(\"energy\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_energies = np.linspace(2, 6, 20) * 1e4 * u.GeV\n",
+    "eval_exposure = nddata.evaluate(energy=eval_energies, method=\"linear\")\n",
+    "\n",
+    "plt.plot(\n",
+    "    nddata.axis(\"energy\").nodes.value,\n",
+    "    nddata.data.value,\n",
+    "    \".\",\n",
+    "    label=\"Interpolation nodes\",\n",
+    ")\n",
+    "print(nddata.axis(\"energy\").nodes)\n",
+    "plt.plot(\n",
+    "    eval_energies.to(\"TeV\").value,\n",
+    "    eval_exposure,\n",
+    "    \"--\",\n",
+    "    label=\"Interpolated values\",\n",
+    ")\n",
+    "plt.xlabel(\"{} [{}]\".format(nddata.axes[0].name, nddata.axes[0].unit))\n",
+    "plt.ylabel(\"{} [{}]\".format(\"Exposure\", nddata.data.unit))\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2D example\n",
+    "\n",
+    "Another common use case is to store a Quantity as a function of field of view offset and energy. The following shows how to use the NDDataArray to slice the data array at any values of offset and energy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_data = EnergyBounds.equal_log_spacing(1, 10, 50, unit=u.TeV)\n",
+    "energy_axis = BinnedDataAxis(\n",
+    "    lo=energy_data.lower_bounds,\n",
+    "    hi=energy_data.upper_bounds,\n",
+    "    name=\"energy\",\n",
+    "    interpolation_mode=\"log\",\n",
+    ")\n",
+    "offset_data = np.linspace(0, 2, 4) * u.deg\n",
+    "offset_axis = DataAxis(offset_data, name=\"offset\")\n",
+    "\n",
+    "data_temp = 10 * np.exp(-energy_data.log_centers.value / 10)\n",
+    "data = np.outer(data_temp, (offset_data.value + 1))\n",
+    "\n",
+    "nddata2d = NDDataArray(\n",
+    "    axes=[energy_axis, offset_axis], data=data * u.Unit(\"cm-2 s-1 TeV-1\")\n",
+    ")\n",
+    "\n",
+    "print(nddata2d)\n",
+    "extent_x = nddata2d.axis(\"energy\").bins[[0, -1]].value\n",
+    "extent_y = nddata2d.axis(\"offset\").nodes[[0, -1]].value\n",
+    "extent = extent_x[0], extent_x[1], extent_y[0], extent_y[1]\n",
+    "plt.imshow(nddata2d.data.value, extent=extent, aspect=\"auto\")\n",
+    "plt.xlabel(\"Energy\")\n",
+    "plt.ylabel(\"Offset\")\n",
+    "plt.colorbar();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "offsets = [0.23, 1.23, 2] * u.deg\n",
+    "eval_energies = Energy.equal_log_spacing(3, 8, 20, u.TeV)\n",
+    "\n",
+    "for offset in offsets:\n",
+    "    slice_ = nddata2d.evaluate(offset=offset, energy=eval_energies)\n",
+    "    plt.plot(eval_energies.value, slice_, label=\"Offset: {}\".format(offset))\n",
+    "plt.xlabel(\"Energy [TeV]\")\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "navigate_num": "#000000",
+    "navigate_text": "#333333",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700",
+    "sidebar_border": "#EEEEEE",
+    "wrapper_background": "#FFFFFF"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "101px",
+    "width": "253px"
+   },
+   "navigate_menu": true,
+   "number_sections": false,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false,
+   "widenNotebook": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -2,9 +2,8 @@
 # It's used for automatic testing and downloading of datesets tutorials.
 # Let's keep it alphabetical.
 - name: analysis_3d
-  requires: iminuit
+  requires: iminuit cta_data
   datasets:
-    - cta-1dc
 - name: astro_dark_matter
   requires:
   datasets:
@@ -14,12 +13,11 @@
   datasets:
     - catalogs/fermi/gll_psc_v16.fit.gz
 - name: cta_1dc_introduction
-  requires:
+  requires: cta_data
   datasets:
 - name: cta_data_analysis
-  requires: sherpa
+  requires: sherpa cta_data
   datasets:
-    - cta-1dc
 - name: cwt
   requires:
   datasets:
@@ -58,9 +56,8 @@
     - catalogs/fermi/gll_psc_v16.fit.gz
     - catalogs/fermi/gll_psch_v13.fit.gz
 - name: simulate_3d
-  requires: iminuit
+  requires: iminuit cta_data
   datasets:
-    - cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits
 - name: source_population_model
   requires:
   datasets:

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -44,6 +44,10 @@
 - name: image_fitting_with_sherpa
   requires: sherpa
   datasets:
+      - G300-0_test_background.fits
+      - G300-0_test_counts.fits
+      - G300-0_test_exposure.fits
+      - G300-0_test_psf.fits
 - name: intro_maps
   requires:
   datasets:

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "def get_irfs():\n",
     "    \"\"\"Load CTA IRFs\"\"\"\n",
-    "    filename = \"$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "    filename = \"$CTADATA/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     "    psf = EnergyDependentMultiGaussPSF.read(\n",
     "        filename, hdu=\"POINT SPREAD FUNCTION\"\n",
     "    )\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datastore = DataStore.from_dir(\"../datasets/hess-dl3-dr1/\")\n",
+    "datastore = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/\")\n",
     "obs_ids = [23523, 23526, 23559, 23592]\n",
     "obs_list = datastore.obs_list(obs_ids)"
    ]

--- a/tutorials/spectrum_pipe.ipynb
+++ b/tutorials/spectrum_pipe.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir(\"../datasets/hess-dl3-dr1/\")\n",
+    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/\")\n",
     "mask = data_store.obs_table[\"OBS_SUBSET_TAG\"] == \"crab\"\n",
     "obs_ids = data_store.obs_table[\"OBS_ID\"][mask].data\n",
     "observations = data_store.obs_list(obs_ids)\n",

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -1,0 +1,278 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spectrum simulation with Gammapy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "This notebook explains how to use the functions and classes in [gammapy.spectrum](http://docs.gammapy.org/dev/spectrum/index.html) in order to simulate and fit spectra.\n",
+    "\n",
+    "First, we will simulate and fit a pure power law without any background. Than we will add a power law shaped background component. Finally, we will see how to simulate and fit a user defined model. For all scenarios a toy detector will be simulated. For an example using real CTA IRFs, checkout [this notebook](https://github.com/gammapy/gammapy-extra/blob/master/notebooks/spectrum_simulation_cta.ipynb).\n",
+    "\n",
+    "The following clases will be used:\n",
+    "\n",
+    "* [gammapy.irf.EffectiveAreaTable](http://docs.gammapy.org/dev/api/gammapy.irf.EffectiveAreaTable.html)\n",
+    "* [gammapy.irf.EnergyDispersion](http://docs.gammapy.org/dev/api/gammapy.irf.EnergyDispersion)\n",
+    "* [gammapy.spectrum.SpectrumObservation](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumObservation.html)\n",
+    "* [gammapy.spectrum.SpectrumSimulation](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumSimulation.html)\n",
+    "* [gammapy.spectrum.SpectrumFit](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumFit.html)\n",
+    "* [gammapy.spectrum.models.PowerLaw](http://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Same procedure as in every script ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from gammapy.irf import EnergyDispersion, EffectiveAreaTable\n",
+    "from gammapy.spectrum import SpectrumSimulation, SpectrumFit\n",
+    "from gammapy.spectrum.models import PowerLaw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create detector\n",
+    "\n",
+    "For the sake of self consistency of this tutorial, we will simulate a simple detector. For a real application you would want to replace this part of the code with loading the IRFs or your detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e_true = np.logspace(-2, 2.5, 109) * u.TeV\n",
+    "e_reco = np.logspace(-2, 2, 79) * u.TeV\n",
+    "\n",
+    "edisp = EnergyDispersion.from_gauss(\n",
+    "    e_true=e_true, e_reco=e_reco, sigma=0.2, bias=0\n",
+    ")\n",
+    "aeff = EffectiveAreaTable.from_parametrization(energy=e_true)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 6))\n",
+    "edisp.plot_matrix(ax=axes[0])\n",
+    "aeff.plot(ax=axes[1]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Power law\n",
+    "\n",
+    "In this section we will simulate one observation using a power law model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwl = PowerLaw(\n",
+    "    index=2.3, amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    ")\n",
+    "print(pwl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "livetime = 2 * u.h\n",
+    "sim = SpectrumSimulation(\n",
+    "    aeff=aeff, edisp=edisp, source_model=pwl, livetime=livetime\n",
+    ")\n",
+    "sim.simulate_obs(seed=2309, obs_id=1)\n",
+    "print(sim.obs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit = SpectrumFit(obs_list=sim.obs, model=pwl.copy(), stat=\"cash\")\n",
+    "fit.fit_range = [1, 10] * u.TeV\n",
+    "fit.run()\n",
+    "print(fit.result[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Include background\n",
+    "\n",
+    "In this section we will include a background component. Furthermore, we will also simulate more than one observation and fit each one individuallt in order to get average fit results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkg_model = PowerLaw(\n",
+    "    index=2.5, amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "n_obs = 30\n",
+    "seeds = np.arange(n_obs)\n",
+    "\n",
+    "sim = SpectrumSimulation(\n",
+    "    aeff=aeff,\n",
+    "    edisp=edisp,\n",
+    "    source_model=pwl,\n",
+    "    livetime=livetime,\n",
+    "    background_model=bkg_model,\n",
+    "    alpha=0.2,\n",
+    ")\n",
+    "\n",
+    "sim.run(seeds)\n",
+    "print(sim.result)\n",
+    "print(sim.result[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before moving on to the fit let's have a look at the simulated observations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_on = [obs.total_stats.n_on for obs in sim.result]\n",
+    "n_off = [obs.total_stats.n_off for obs in sim.result]\n",
+    "excess = [obs.total_stats.excess for obs in sim.result]\n",
+    "\n",
+    "fix, axes = plt.subplots(1, 3, figsize=(12, 4))\n",
+    "axes[0].hist(n_on)\n",
+    "axes[0].set_xlabel(\"n_on\")\n",
+    "axes[1].hist(n_off)\n",
+    "axes[1].set_xlabel(\"n_off\")\n",
+    "axes[2].hist(excess)\n",
+    "axes[2].set_xlabel(\"excess\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "results = []\n",
+    "for obs in sim.result:\n",
+    "    fit = SpectrumFit(obs, pwl.copy(), stat=\"wstat\")\n",
+    "    fit.optimize()\n",
+    "    results.append(\n",
+    "        {\n",
+    "            \"index\": fit.result[0].model.parameters[\"index\"].value,\n",
+    "            \"amplitude\": fit.result[0].model.parameters[\"amplitude\"].value,\n",
+    "        }\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = np.array([_[\"index\"] for _ in results])\n",
+    "plt.hist(index, bins=10)\n",
+    "print(\"spectral index: {:.2f} +/- {:.2f}\".format(index.mean(), index.std()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Fit a pure power law and the user define model to the observation you just simulated. You can start with the user defined model described in the [spectrum_models.ipynb](https://github.com/gammapy/gammapy-extra/blob/master/notebooks/spectrum_models.ipynb) notebook.\n",
+    "* Vary the observation lifetime and see when you can distinguish the two models (Hint: You get the final likelihood of a fit from `fit.result[0].statval`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's next\n",
+    "\n",
+    "In this tutorial we learnd how to simulate and fit data using a toy detector. Go to [gammapy.spectrum](http://docs.gammapy.org/dev/spectrum/index.html) to see what else you can do with gammapy."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/spectrum_simulation_cta.ipynb
+++ b/tutorials/spectrum_simulation_cta.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spectrum simulation for CTA\n",
+    "\n",
+    "A quick example how to simulate and fit a spectrum for the [Cherenkov Telescope Array (CTA)](https://www.cta-observatory.org).\n",
+    "\n",
+    "We will use the following classes:\n",
+    "\n",
+    "* [gammapy.spectrum.SpectrumObservation](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumObservation.html)\n",
+    "* [gammapy.spectrum.SpectrumSimulation](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumSimulation.html)\n",
+    "* [gammapy.spectrum.SpectrumFit](http://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumFit.html)\n",
+    "* [gammapy.irf.CTAIrf](http://docs.gammapy.org/dev/api/gammapy.irf.CTAIrf.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from gammapy.irf import EnergyDispersion, EffectiveAreaTable\n",
+    "from gammapy.spectrum import SpectrumSimulation, SpectrumFit\n",
+    "from gammapy.spectrum.models import PowerLaw\n",
+    "from gammapy.irf import CTAIrf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define simulation parameters parameters\n",
+    "livetime = 1 * u.h\n",
+    "offset = 0.5 * u.deg\n",
+    "# Energy from 0.1 to 100 TeV with 10 bins/decade\n",
+    "energy = np.logspace(-1, 2, 31) * u.TeV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define spectral model\n",
+    "model = PowerLaw(\n",
+    "    index=2.1,\n",
+    "    amplitude=2.5e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
+    "    reference=1 * u.TeV,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load IRFs\n",
+    "filename = \"$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "cta_irf = CTAIrf.read(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aeff = cta_irf.aeff.to_effective_area_table(offset=offset, energy=energy)\n",
+    "aeff.plot()\n",
+    "plt.loglog()\n",
+    "print(cta_irf.aeff.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edisp = cta_irf.edisp.to_energy_dispersion(\n",
+    "    offset=offset, e_true=energy, e_reco=energy\n",
+    ")\n",
+    "edisp.plot_matrix()\n",
+    "print(edisp.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate data\n",
+    "sim = SpectrumSimulation(\n",
+    "    aeff=aeff, edisp=edisp, source_model=model, livetime=livetime\n",
+    ")\n",
+    "sim.simulate_obs(seed=42, obs_id=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim.obs.peek()\n",
+    "print(sim.obs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Spectral analysis\n",
+    "\n",
+    "Now that we have some simulated CTA counts spectrum, let's analyse it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fit data\n",
+    "fit = SpectrumFit(obs_list=sim.obs, model=model, stat=\"cash\")\n",
+    "fit.run()\n",
+    "result = fit.result[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energy_range = [0.1, 100] * u.TeV\n",
+    "model.plot(energy_range=energy_range, energy_power=2)\n",
+    "result.model.plot(energy_range=energy_range, energy_power=2)\n",
+    "result.model.plot_error(energy_range=energy_range, energy_power=2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Change the observation time to something longer or shorter. Does the observation and spectrum results change as you expected?\n",
+    "* Change the spectral model, e.g. add a cutoff at 5 TeV, or put a steep-spectrum source with spectral index of 4.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Start the exercises here!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What next?\n",
+    "\n",
+    "In this tutorial we simulated and analysed the spectrum of source using CTA prod 2 IRFs.\n",
+    "\n",
+    "If you'd like to go further, please see the other tutorial notebooks."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/spectrum_simulation_cta.ipynb
+++ b/tutorials/spectrum_simulation_cta.ipynb
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "# Load IRFs\n",
-    "filename = \"$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "filename = \"$CTADATA/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     "cta_irf = CTAIrf.read(filename)"
    ]
   },


### PR DESCRIPTION
This PR fixes datasets access in code cells of tutorials notebooks as proposed in https://github.com/gammapy/gammapy/pull/1791#issuecomment-422436116 

The env vars used are `$GAMMAPY_EXTRA`, `$GAMMA_CAT`, `$GAMMAPY_FERMI_LAT_DATA` and `$CTADATA`. It also avoids regression tests in Travis CI for notebooks using `$CTADATA` - CTA 1DC datasets - , since these are not public and are not easily fetched as the others. `$GAMMAPY_EXTRA`, `$GAMMA_CAT`, `$GAMMAPY_FERMI_LAT_DATA` are fetched in Travis CI integration environment.

The scripts `process_tutorials.py` used locally to build the documentation and `test_notebooks.py` used in Travis CI check the availability of these env vars.


