### PR TITLE
Rewrite getting started, improve tutorials and install pages

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -5,88 +5,178 @@
 Getting Started
 ===============
 
-If you'd like to get started using Gammapy, you've come to the right place!
+The best way to learn about Gammapy is to read and play with the examples in the
+Gammapy :ref:`tutorials`.
 
-Reading through this page will just take you a few minutes.
+This section explains the steps to get set up for the Gammapy tutorials on your
+machine:
 
-But we hope that you'll get curious and start executing the examples yourself,
-using Gammapy to analyse (simulated) H.E.S.S. and real Fermi-LAT data.
+1. Install Anaconda and the Gammapy environment
+2. Download tutorial notebooks and example datasets
+3. Check your setup
+4. Use Gammapy with Python, IPython or Jupyter
 
-If you're new to Python for gamma-ray astronomy and would like to learn the
-basics, we recommend you go to the `Scipy Lecture Notes`_ or the `Practical
-Python for Astronomers Tutorial`_.
+If you have used conda, Python, IPython and Jupyter before, you can just skim
+this page, and quickly copy & paste the commands to get set up.
 
-Gammapy as a Python package and set of science tools
-----------------------------------------------------
+Help!?
+------
 
-Gammapy is a Python package, consisting of functions and classes, that you can
-use as a flexible and extensible toolbox to implement and execute exactly the
-analysis you want.
+If you have any questions or issues, please ask for help on the Gammapy Slack,
+mailing list or on Github (whatever is easiest for you). (see `Gammapy contact`_)
 
-On top of that, Gammapy provides some command line tools (sometimes driven by a
-config file), and in the future we plan on adding web apps with a graphical user
-interface. To use those no Python programming skills are required, you'll just
-have to specify which data to analyse, with which method and parameters.
+Install
+-------
 
-Getting set up
---------------
+To install Gammapy, we recommend that you install the Anaconda distribution from
+https://www.anaconda.com/download/.
 
-First, make sure you have Gammapy installed (see :ref:`install`).
+It's free, works on Linux, MacOS and Windows. It installs in your home
+directory, no system privileges needed, and you can just delete it without
+problems if you don't need or want it any more.
 
-You can use this command to make sure the Python package is available::
+Besides the software included in the Anaconda distribution, it gives you the
+`conda`_ tool, which is a package and environment manager. We will use it to
+create a dedicated environment for the latest stable Gammapy version and a known
+good set of Gammapy dependencies (e.g. Python, Numpy and Astropy).
 
-    $ python -c 'import gammapy'
+Use the following commands to install and activate the ``gammapy-0.8`` conda
+environment:
 
-To check if the Gammapy command line tool has been installed and are available
-on your PATH, use this command::
+.. code-block:: bash
 
-    $ gammapy --version
+    # install anaconda
+    curl -O http://gammapy.org/install/gammapy-0.8-environment.yml
+    conda env create -f gammapy-0.8-environment.yml
+    conda activate gammapy-0.8
 
-The Gammapy tutorials use some example datasets that are stored in the
-``gammapy-extra`` repository on Github. So please go follow the instructions at
-:ref:`gammapyextra` to fetch those, then come back here.
+You should now be able to execute the following command, and it should print
+detailed information about your installation to the terminal:
 
-To check if ``gammapy-extra`` is available and the ``GAMMAPY_EXTRA`` shell
-environment variable set, use this command::
+.. code-block:: bash
 
-    $ echo $GAMMAPY_EXTRA
-    $ ls $GAMMAPY_EXTRA/logo/gammapy_banner.png
+    gammapy info
 
-Need help?
-----------
+If there is some issue, the following commands could help you to figure out
+your setup:
 
-If you have any questions or issues with installation, setup or Gammapy usage,
-lease use the `Gammapy mailing list`_!
+.. code-block:: bash
 
-Gammapy is a very young project, we know there are many missing features and
-issues. Please have some patience, and let us know what you want to do, so that
-we can set priorities.
+    conda info
+    which python
+    which ipython
+    which jupyter
+    which gammapy
+    env | grep PATH
+    python -c 'import gammapy; print(gammapy); print(gammapy.__version__)'
 
-Using Gammapy as a Python package
----------------------------------
+Note that every time you open a new terminal window, you will have to activate
+the Gammapy conda environment again before you can use it via:
 
-Here's a few very simple examples how to use Gammapy as a Python package.
+.. code-block:: bash
 
-What's the statistical significance when 10 events have been observed with a
-known background level of 4.2 according to [LiMa1983]_?
+    conda activate gammapy-0.8
 
-Getting the answer from Gammapy is easy. You import and call the
-`gammapy.stats.significance` function:
+Use the following commands to check which conda environment is active and which
+ones you have set up:
 
-.. code-block:: python
+.. code-block:: bash
 
+    conda info
+    conda env list
+
+If you're new to conda, you could also print out the `conda cheat sheet`_, which
+lists the common commands to install packages and work with environments.
+
+Download tutorials
+------------------
+
+The next step is to download the Gammapy tutorial notebooks and the example
+datasets used there (at the moment from CTA, H.E.S.S. and Fermi-LAT).
+
+.. code-block:: bash
+
+    gammapy download tutorials
+    cd gammapy-tutorials
+    export GAMMAPY_DATA=$PWD/datasets
+
+You might want to put the definition of the ``$GAMMAPY_DATA`` environment
+variable in your shell profile setup file that is executed when you open a new
+terminal (for example ``$HOME/.bash_profile``).
+
+The data files this will download, and also the files generated by the tutorial
+notebooks are small, in total less than 100 MB.
+
+The datasets are curated and stable, the notebooks are still under development
+just like Gammapy itself, and thus stored in a sub-folder that contains the
+Gammapy version number.
+
+The ``gammapy download`` command and versioning of the notebooks is new. If
+there are issues, note that you can just delete the folder any time using ``rm
+-r gammapy-tutorials`` and start over.
+
+Also note that it's of course possible to download just the notebooks or just
+the data files. See the help:
+
+.. code-block:: bash
+
+    gammapy download --help
+
+Use Gammapy
+-----------
+
+Congratulations: you are all set to start using Gammapy!
+
+Python
+++++++
+
+Gammapy is a Python package, so you can of course import and use it from Python:
+
+.. code-block:: bash
+
+    $ python
+    Python 3.6.0 | packaged by conda-forge | (default, Feb 10 2017, 07:08:35) 
+    [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)] on darwin
+    Type "help", "copyright", "credits" or "license" for more information.
     >>> from gammapy.stats import significance
     >>> significance(n_on=10, mu_bkg=4.2, method='lima')
     array([2.39791813])
 
+IPython
++++++++
+
+IPython is nicer to use for interactive analysis:
+
+.. code-block:: bash
+
+    $ ipython
+    Python 3.6.0 | packaged by conda-forge | (default, Feb 10 2017, 07:08:35) 
+    Type 'copyright', 'credits' or 'license' for more information
+    IPython 6.5.0 -- An enhanced Interactive Python. Type '?' for help.
+
+    In [1]: from gammapy.stats import significance
+
+    In [2]: significance(n_on=10, mu_bkg=4.2, method='lima')
+    Out[2]: array([2.39791813])
+
+For example you can use ``?`` to look up help for any Gammapy function, class or
+method from IPython:
+
+.. code-block:: bash
+
+    In [3]: significance?
+
+Of course, you can also use the Gammapy online docs if you prefer. For example
+see `gammapy.stats.significance`. The "search docs" field in the upper left is
+your friend.
+
 As another example, here's how you can create `gammapy.data.DataStore` and
-`gammapy.data.EventList` objects and start exploring some properties of the
-(simulated) H.E.S.S. event data:
+`gammapy.data.EventList` objects and start exploring H.E.S.S. data:
 
 .. code-block:: python
 
     >>> from gammapy.data import DataStore
-    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/')
+    >>> data_store = DataStore.from_dir('$GAMMAPY_DATA/hess-dl3-dr1/')
     >>> events = data_store.obs(obs_id=23523).events
     >>> print(events)
     EventList info:
@@ -95,58 +185,90 @@ As another example, here's how you can create `gammapy.data.DataStore` and
     - OBS_ID = 23523
     >>> events.energy.mean()
     <Quantity 4.418008 TeV>
+
+Try to make your first plot using a helper method in Gammapy that uses
+matplotlib:
+
+.. code-block:: python
+
     >>> events.peek()
+    >>> plt.savefig("events.png")
 
-How do you find something in Gammapy?
+Python script
++++++++++++++
 
-Often using the full-text search field is the quickest and simplest way. As you
-get to know the package, you'll learn the names of the different sub-packages
-that are available, like `gammapy.stats` or `gammapy.data`, and what
-functionality they contain.
+Another common way to use Gammapy is to write a Python script.
+Try it and put the following code into a file called ``example.py``:
 
-Another good way is tutorials, IPython and Jupyter notebooks ...
+.. code-block:: python
 
-Using Gammapy from the Jupyter notebooks
-----------------------------------------
+    """Example Python script using Gammapy"""
+    from gammapy.data import DataStore
+    data_store = DataStore.from_dir('$GAMMAPY_DATA/hess-dl3-dr1/')
+    events = data_store.obs(obs_id=23523).events
+    print(events.energy.mean())
 
-In the last section you've seen how to use Gammapy as a Python package. To
-become good at using it, you have to learn the Gammapy API (application
-programming interface). One way to do this is to read documentation. A more
-interactive (and arguably more fun) way is to play with Gammapy code and
-gamma-ray data in Jupyter notebooks.
+You can run it with Python:
 
-Jupyter notebooks are documents that combine code input and text and graphical
-output, and are wonderful tools to learn and explore (both programming and the
-data), and finally to share results with your colleagues.
+.. code-block:: bash
 
-So now is a good time to have a look here: :ref:`tutorials`. Try executing the
-cells locally on your machine as you read through the text and code.
+    $ python example.py
+    4.418007850646973 TeV
 
-Using Gammapy via command line tools
-------------------------------------
+If you want to continue with interactive data or results analysis after
+running some Python code, use IPython like this:
 
-The ``gammapy`` command line tool lets you execute some very common analysis
-tasks directly from the command line. Try this::
+.. code-block:: bash
 
-    $ gammapy --help
-    $ gammapy --version
+    $ ipython -i example.py
 
-Further information about the ``gammapy`` command line interface is here:
-:ref:`scripts`
+Command line
+++++++++++++
 
-That page also includes information how the ``gammapy`` command line tool works
-and what to do if it doesn't work (likely you have to add the ``bin`` directory
-where Gammapy is installed to your ``PATH`` shell environment variable). It even
-has a section with a tutorial how to write your own command line tools if this
-is something you want.
+As you have already seen, installing Gammapy gives you a ``gammapy`` command line
+tool with subcommands such as ``gammapy info`` or ``gammapy download``.
 
-What next?
-----------
+We plan to add a high-level interface to Gammapy soon that will let you run
+Gammapy analyses via the command line interface, probably driven by a config
+file. This is not available yet, for now you have to use Gammapy as a Python
+package.
 
-If you'd like to continue with tutorials to learn Gammapy, go here:
+Jupyter notebooks
++++++++++++++++++
+
+To learn more about Gammapy, and also for interactive data analysis in general,
+we recommend you use Jupyter notebooks. Assuming you have Gammapy installed and
+the Gammapy conda environment activated, and your terminal current working
+directory is the ``gammapy-tutorials`` folder as explained above, start
+`JupyterLab`_ like this:
+
+.. code-block:: bash
+
+    $ jupyter lab
+
+This should open up your the JupyterLab app in your web browser, where you can
+create new Jupyter notebooks or open up existing ones.
+
+If you haven't used Jupyter before, try typing ``print("Hello Jupyter")`` in the
+first input cell, and use the keyboard shortcut ``SHIFT + ENTER`` to execute it.
+
+If you have problems and think you might not be using the right Python or
+importing Gammapy isn't working or giving you the right version, checking your
+Python executable and import path might help you find the issue:
+
+.. code-block:: python
+
+    import sys
+    print(sys.executable)
+    print(sys.path)
+
+To check which Gammapy you are using you can use this:
+
+.. code-block:: python
+
+    import gammapy
+    print(gammapy)
+    print(gammapy.__version__)
+
+Now you should be all set and to use Gammapy. Let's move on to the
 :ref:`tutorials`.
-
-To learn about some specific functionality that could be useful for your work,
-start browsing the "Getting Started" section of Gammapy sub-package that might
-be of interest to you (e.g. `gammapy.data`, `gammapy.catalog`,
-`gammapy.spectrum`, ...).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,8 +7,8 @@
 
 
 Gammapy is a community-developed, open-source Python package for gamma-ray
-astronomy. It is a prototype for the `CTA`_ science tools. This page (
-http://docs.gammapy.org ) contains the Gammapy documentation. The Gammapy
+astronomy. It is a prototype for the `CTA`_ science tools. This page
+(http://docs.gammapy.org ) contains the Gammapy documentation. The Gammapy
 webpage ( http://gammapy.org ) contains information about Gammapy, including
 news and contact information if you have any questions, want to report and issue
 or request a feature, or need help with anything Gammapy-related.
@@ -18,16 +18,16 @@ or request a feature, or need help with anything Gammapy-related.
 Getting started
 ---------------
 
-Gammapy works with Python 2 and 3, on Linux, Mac OS X and (partly) Windows. See
-:ref:`install` for information how to get started and the :ref:`tutorials` to
-start to learn how to use Gammapy.
+Gammapy works with Python 2 and 3, on Linux, Mac OS X and Windows. To get
+started, we recommend you follow the installation and setup instructions in
+:ref:`getting-started` and then learn Gammapy via the Jupyter :ref:`tutorials`.
 
 .. toctree::
     :maxdepth: 1
 
-    install/index
     getting-started
     tutorials
+    install/index
 
 .. _gammapy_package:
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -1,5 +1,15 @@
 .. include:: ../references.txt
 
+.. note::
+
+    The recommended way to install Gammapy is to use conda and to follow
+    the simple instructions in :ref:`getting-started`.
+
+    This section contains some additional information concerning the conda
+    installation as well as information on alternative ways to install Gammapy and
+    it's dependencies like Numpy and Astropy, e.g. using pip or Macports or your
+    Linux package manager.
+
 .. _install:
 
 ************

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -29,7 +29,8 @@
 .. _pandas: http://pandas.pydata.org
 .. _pip: https://pip.pypa.io/en/stable/
 .. _pip install instructions: https://pip.pypa.io/en/latest/installing.html#install-pip
-.. _conda: http://conda.pydata.org/
+.. _conda: https://conda.io/docs/
+.. _conda cheat sheet: https://conda.io/docs/_downloads/conda-cheatsheet.pdf
 .. _PyFACT: http://adsabs.harvard.edu/abs/2012AIPC.1505..789R
 .. _healpy: https://healpy.readthedocs.io/en/latest/
 .. _HEALPix: https://en.wikipedia.org/wiki/HEALPix
@@ -86,6 +87,7 @@
 .. _Gammapy mailing list: https://groups.google.com/forum/#!forum/gammapy
 .. _Gammapy Github page: https://github.com/gammapy/gammapy
 .. _Gammapy documentation: http://docs.gammapy.org/
+.. _Gammapy contact: http://gammapy.org/contact.html
 .. _Gammapy project summary on Open HUB: https://www.openhub.net/p/gammapy
 .. _Gammapy page on PyPI: https://pypi.org/project/gammapy
 .. _Gammapy contributors page on Github: https://github.com/gammapy/gammapy/graphs/contributors
@@ -106,7 +108,8 @@
 
 .. _Github clone URL help article: https://help.github.com/articles/which-remote-url-should-i-use/
 
-.. _Gammapy tutorial notebooks on nbviewer: https://nbviewer.jupyter.org/github/gammapy/gammapy-extra/blob/master/index.ipynb
+.. _Jupyter: http://jupyter.org
+.. _JupyterLab: https://jupyterlab.readthedocs.io/
 .. _nbsphinx: https://nbsphinx.readthedocs.io
 .. _Installing Python Packages from a Jupyter Notebook: http://jakevdp.github.io/blog/2017/12/05/installing-python-packages-from-jupyter/
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -5,94 +5,19 @@
 Tutorial notebooks
 ==================
 
-What is this?
--------------
+This page lists the Gammapy tutorials that are available as `Jupyter`_ notebooks.
 
--  This is an overview of tutorial `Jupyter <http://jupyter.org/>`__
-   notebooks for `Gammapy <http://gammapy.org>`__, a Python package for
-   gamma-ray astronomy.
--  The notebooks complement the Gammapy Sphinx-based documentation at
-   http://docs.gammapy.org
--  The notebooks and example datasets are available at
-   https://github.com/gammapy/gammapy-extra
+You can read them here, or execute them using a temporary cloud server in Binder.
 
-Set up
-------
+To execute them locally, you have to first install Gammapy locally and download
+the tutorial notebooks and example datasets. The setup steps are described here:
+:ref:`getting-started`. Remember that you can always use ``gammapy info`` to check your setup.
 
-The Gammapy installation instructions are here: :ref:`install`
-
-One quick way to get set up, that works the same on Linux, Mac and Windows is
-this:
-
-* Install Anaconda or Miniconda (see https://www.anaconda.com/download/ )
-* Get the following repository that contains the Gammapy tutorial notebooks::
-
-    git clone https://github.com/gammapy/gammapy-extra.git
-    export GAMMAPY_EXTRA=$PWD/gammapy-extra
-
-* Create a Python conda environment that contains all software used in the tutorials::
-
-    cd gammapy-extra
-    conda env create -f environment.yml
-
-* If you already have that environment, but want to update::
-
-    conda env update -f environment.yml
-
-* Activate the environment and start Jupyter::
-
-    source activate gammapy-tutorial
-    cd notebooks
-    jupyter notebook
-
-* Select and start the notebook you want in your webbrowser.
-
-If you have any questions, ask for help. See http://gammapy.org/contact.html
-
-Execute tutorials online
-------------------------
-
-.. image:: http://mybinder.org/badge.svg
-
-You can execute the notebooks on-line.
-Just click on the *launch binder* badge placed at the top of each of the notebooks below.
-
-Note that this is a free, temporary notebook server. You cannot save your work there and retrieve it afterwards.
-For that, install Gammapy on your machine and work there.
-
-The basics
-----------
-
-Gammapy is a Python package built on Numpy and Astropy, and the tutorials are
-Jupyter notebooks. If you're already familar with those, you can skip to the
-next section and start learning about Gammapy.
-
-To learn the basics, here are a few good resources.
-
-Python
-++++++
-
-- `A Whirlwind tour of Python <http://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/Index.ipynb>`__ (learn Python)
-
-Scientific Python
-+++++++++++++++++
-
-- `Python data science handbook <http://nbviewer.jupyter.org/github/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/Index.ipynb>`__ (learn IPython, Numpy, matplotlib)
-
-Astropy
-+++++++
-
-- `Astropy introduction for Gammapy users <notebooks/astropy_introduction.html>`__  | *astropy_introduction.ipynb*
-- `Astropy Hands On (1st ASTERICS-OBELICS International School) <https://github.com/Asterics2020-Obelics/School2017/blob/master/astropy/astropy_hands_on.ipynb>`__
-
-Other useful resources:
-
-- http://www.astropy.org/astropy-tutorials
-- http://astropy.readthedocs.io
-- https://python4astronomers.github.io/
+.. _tutorials_notebooks:
 
 Notebooks
 ---------
+
 .. toctree::
    :hidden:
 
@@ -141,6 +66,8 @@ Interested to do a first analysis of simulated CTA data?
 - `Fitting gammapy spectra with sherpa <notebooks/spectrum_fitting_with_sherpa.html>`__ | *spectrum_fitting_with_sherpa.ipynb*
 - `Flux point fitting with Gammapy <notebooks/sed_fitting_gammacat_fermi.html>`__ | *sed_fitting_gammacat_fermi.ipynb*
 
+.. _tutorials_extras:
+
 Extra topics
 ------------
 .. toctree::
@@ -157,3 +84,28 @@ These notebooks contain examples on some more specialised functionality in Gamma
 - `Astrophysical source population modeling with Gammapy <notebooks/source_population_model.html>`__ | *source_population_model.ipynb*
 - `Continuous wavelet transform on gamma-ray images <notebooks/cwt.html>`__ | *cwt.ipynb*
 - `Dark matter spatial and spectral models <notebooks/astro_dark_matter.html>`__ | *astro_dark_matter.ipynb*
+
+.. _tutorials_basics:
+
+Basics
+------
+
+Gammapy is a Python package built on Numpy and Astropy, so for now you have to learn
+a bit of Python, Numpy and Astropy to be able to use Gammapy.
+To make plots you have to learn a bit of matplotlib.
+
+We plan to add a very simple to use high-level interface to Gammapy where you just have to
+adjust a config file, but that isn't available yet.
+
+Here are some great resources:
+
+- Python: `A Whirlwind tour of Python <https://nbviewer.jupyter.org/github/jakevdp/WhirlwindTourOfPython/blob/master/Index.ipynb>`__
+- IPython, Jupyter, Numpy, matplotlib: `Python data science handbook <http://nbviewer.jupyter.org/github/jakevdp/PythonDataScienceHandbook/blob/master/notebooks/Index.ipynb>`__
+- `Astropy introduction for Gammapy users <notebooks/astropy_introduction.html>`__  | *astropy_introduction.ipynb*
+- `Astropy Hands On (1st ASTERICS-OBELICS International School) <https://github.com/Asterics2020-Obelics/School2017/blob/master/astropy/astropy_hands_on.ipynb>`__
+
+Other useful resources:
+
+- http://www.astropy.org/astropy-tutorials
+- http://astropy.readthedocs.io
+- https://python4astronomers.github.io


### PR DESCRIPTION
This PR contains a rewrite of the getting started page, and improves the tutorials and install docs pages. The index.rst landing page now very prominently points people to first getting started (which is a step by step how to get set up and use gammapy page) and then to the Jupyter tutorials, which is just a listinig of the tutorials we have.

This is already describing the solution that @Bultako has been working on and is finalising at the moment to have `gammapy download` for tutorial notebooks and example data.

@Bultako - I would prefer to merge this in and then adjust as needed tomorrow and already ask a few people to try this out tomorrow or Friday latest.

But up to you, if you want to review and leave comments here, I can continue to work on this later tonight or tomorrow morning.