### PR TITLE
Adapt tutorials to the new Map.smooth() signature

### DIFF
--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "images[\"counts\"].smooth(radius=0.2 * u.deg).plot(stretch=\"sqrt\");"
+    "images[\"counts\"].smooth(width=0.1 * u.deg).plot(stretch=\"sqrt\");"
    ]
   },
   {

--- a/tutorials/astropy_introduction.ipynb
+++ b/tutorials/astropy_introduction.ipynb
@@ -335,7 +335,9 @@
    "outputs": [],
    "source": [
     "# Open Fermi 3FGL from the repo\n",
-    "filename = os.environ['GAMMAPY_EXTRA']+'/datasets/catalogs/fermi/gll_psc_v16.fit.gz'\n",
+    "filename = (\n",
+    "    os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/catalogs/fermi/gll_psc_v16.fit.gz\"\n",
+    ")\n",
     "table = Table.read(filename, hdu=1)\n",
     "# Alternatively, one can grab it from the server.\n",
     "# table = Table.read(\"http://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/gll_psc_v16.fit\")"
@@ -348,7 +350,9 @@
    "outputs": [],
    "source": [
     "# Note that a single FITS file might contain different tables in different HDUs\n",
-    "filename = os.environ['GAMMAPY_EXTRA']+'/datasets/catalogs/fermi/gll_psc_v16.fit.gz'\n",
+    "filename = (\n",
+    "    os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/catalogs/fermi/gll_psc_v16.fit.gz\"\n",
+    ")\n",
     "# You can load a `fits.HDUList` and check the extension names\n",
     "print([_.name for _ in fits.open(filename)])\n",
     "# Then you can load by name or integer index via the `hdu` option\n",

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir('$CTADATA/index/gps')"
+    "data_store = DataStore.from_dir(\"$CTADATA/index/gps\")"
    ]
   },
   {

--- a/tutorials/first_steps.ipynb
+++ b/tutorials/first_steps.ipynb
@@ -239,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vela_2fhl_smoothed = vela_2fhl.smooth(kernel=\"gauss\", radius=0.5 * u.deg)"
+    "vela_2fhl_smoothed = vela_2fhl.smooth(kernel=\"gauss\", width=0.2 * u.deg)"
    ]
   },
   {

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "# Read the fits file to load them in a sherpa model\n",
-    "filecounts = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_counts.fits'\n",
+    "filecounts = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_counts.fits\"\n",
     "hdr = fits.getheader(filecounts)\n",
     "wcs = WCS(hdr)\n",
     "\n",
@@ -77,9 +77,9 @@
     "sh.load_image(filecounts)\n",
     "sh.set_coord(\"logical\")\n",
     "\n",
-    "fileexp = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_exposure.fits'\n",
-    "filebkg = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_background.fits'\n",
-    "filepsf = os.environ['GAMMAPY_EXTRA'] + '/datasets/G300-0_test_psf.fits'\n",
+    "fileexp = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_exposure.fits\"\n",
+    "filebkg = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_background.fits\"\n",
+    "filepsf = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_psf.fits\"\n",
     "sh.load_table_model(\"expo\", fileexp)\n",
     "sh.load_table_model(\"bkg\", filebkg)\n",
     "sh.load_psf(\"psf\", filepsf)"
@@ -104,7 +104,7 @@
     "\n",
     "resid = Map.read(filecounts)\n",
     "resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
-    "resid_smooth = resid.smooth(radius=6)\n",
+    "resid_smooth = resid.smooth(width=6)\n",
     "resid_smooth.plot();"
    ]
   },
@@ -171,7 +171,7 @@
     "sh.freeze(g0)\n",
     "\n",
     "resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
-    "resid_smooth = resid.smooth(radius=6)\n",
+    "resid_smooth = resid.smooth(width=6)\n",
     "resid_smooth.plot(vmin=-0.5, vmax=1);"
    ]
   },
@@ -225,7 +225,7 @@
     "    sh.freeze(gs[i])\n",
     "\n",
     "    resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
-    "    resid_smooth = resid.smooth(radius=6)\n",
+    "    resid_smooth = resid.smooth(width=6)\n",
     "    resid_smooth.plot(vmin=-0.5, vmax=1)"
    ]
   },

--- a/tutorials/intro_maps.ipynb
+++ b/tutorials/intro_maps.ipynb
@@ -658,7 +658,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = os.environ['GAMMAPY_EXTRA']+\"/datasets/fermi_survey/all.fits.gz\"\n",
+    "filename = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/fermi_survey/all.fits.gz\"\n",
     "hdulist = fits.open(filename)\n",
     "hdulist.info()"
    ]
@@ -830,7 +830,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "smoothed = m_2fhl_gc.smooth(radius=0.2 * u.deg, kernel=\"gauss\")\n",
+    "smoothed = m_2fhl_gc.smooth(width=0.2 * u.deg, kernel=\"gauss\")\n",
     "smoothed.plot(stretch=\"sqrt\", add_cbar=True, vmax=4, cmap=\"inferno\");"
    ]
   },
@@ -849,7 +849,7 @@
    "source": [
     "rc_params = {\"figure.figsize\": (12, 5.4), \"font.size\": 12}\n",
     "with plt.rc_context(rc=rc_params):\n",
-    "    smoothed = m_2fhl_gc.smooth(radius=0.2 * u.deg, kernel=\"gauss\")\n",
+    "    smoothed = m_2fhl_gc.smooth(width=0.2 * u.deg, kernel=\"gauss\")\n",
     "    smoothed.plot(stretch=\"sqrt\", add_cbar=True, vmax=4);"
    ]
   },


### PR DESCRIPTION
This PR adapts the tutorial notebooks to the new signature of `WcsNDMap.smooth()`.

@Bultako @cdeil Just enjoy the clean diff, no need to review :-)