### PR TITLE
Change CTADATA to GAMMAPY_DATA in notebooks

### DIFF
--- a/process_tutorials.py
+++ b/process_tutorials.py
@@ -39,7 +39,7 @@ def main():
         logging.info("python process_tutorials.py tutorials/mynotebook.ipynb")
         sys.exit()
 
-    env_vars = ["GAMMAPY_EXTRA", "GAMMA_CAT", "GAMMAPY_FERMI_LAT_DATA", "CTADATA"]
+    env_vars = ["GAMMAPY_EXTRA", "GAMMA_CAT", "GAMMAPY_FERMI_LAT_DATA"]
     for var in env_vars:
         if var not in os.environ:
             logging.info(var + " environment variable not set.")

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "# Define which data to use\n",
-    "data_store = DataStore.from_dir(\"$CTADATA/index/gps/\")\n",
+    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/cta-1dc/index/gps/\")\n",
     "obs_ids = [110380, 111140, 111159]\n",
     "obs_list = data_store.obs_list(obs_ids)"
    ]

--- a/tutorials/cta_1dc_introduction.ipynb
+++ b/tutorials/cta_1dc_introduction.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "![CTA first data challenge logo](images/cta-1dc.png)\n",
     "\n",
-    "# CTA first data challenge (1DC) with Gammapy\n"
+    "# CTA first data challenge (1DC) with Gammapy"
    ]
   },
   {
@@ -15,7 +15,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "The [CTA observatory](https://www.cta-observatory.org/) has started a first data challenge (\"CTA 1DC\"), focusing on high-level data analysis. Gammapy is a prototype for the CTA science tools (see [Gammapy proceeding from ICRC 2017](https://github.com/gammapy/icrc2017-gammapy-poster/blob/master/proceeding/gammapy-icrc2017.pdf)), and while many things are work in progress (most importantly: source and background modeling and cube analysis), you can use it already to analyse the simulated CTA data.\n",
+    "In 2017 and 2018, the [CTA observatory](https://www.cta-observatory.org/) did a first data challenge, called CTA DC-1, where CTA high-level data was simulated assuming a sky model and using CTA IRFs.\n",
     "\n",
     "The main page for CTA 1DC is here:\n",
     "https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki (CTA internal)\n",
@@ -38,13 +38,7 @@
     "\n",
     "### Further information\n",
     "\n",
-    "How to analyse the CTA 1DC data with Gammapy (make an image and spectrum) is shown in a second notebook [cta_data_analysis.ipynb](cta_data_analysis.ipynb). If you prefer, you can of course just skim or skip this notebook and go straight to second one.\n",
-    "\n",
-    "More tutorial notebooks for Gammapy are [here](../index.ipynb),\n",
-    "the Gammapy Sphinx docs are at at http://docs.gammapy.org\n",
-    "If you have a Gammapy-related question, please send an email to to Gammapy mailing list at http://groups.google.com/group/gammapy (registration required) or if you have an issue or feature request, file an issue here: https://github.com/gammapy/gammapy/issues/new (free Github account required, takes 1 min to set up).\n",
-    "\n",
-    "Please note that the 1DC data isn't public and results should be shared on CTA Redmine, as described here: https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki#Sharing-of-analysis-results. Unfortunately there's no good way yet to share Jupyter notebooks in CTA, as there is e.g. on Github and nbviewer which can show any public noteook."
+    "How to analyse the CTA 1DC data with Gammapy (make an image and spectrum) is shown in a second notebook [cta_data_analysis.ipynb](cta_data_analysis.ipynb). If you prefer, you can of course just skim or skip this notebook and go straight to second one."
    ]
   },
   {
@@ -89,20 +83,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getting the 1DC data\n",
+    "## DC-1 data\n",
     "\n",
-    "You can find infos how to download the 1DC data here: \n",
+    "In this and other Gammapy tutorials we will only access a few data files from CTA DC-1 from `$GAMMAPY_DATA/cta-1dc` that you will have if you followed the \"Getting started with Gammapy\" instructions and executed `gammapy download tutorials`.\n",
+    "\n",
+    "Information how to download more or all of the DC-1 data (in total 20 GB) is here:\n",
     "https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki#Data-access\n",
     "\n",
-    "Overall it's quite large (20 GB) and will take a while to download. You can just download a subset of the \"gps\", \"gc\", \"egal\" or \"agn\" datasets, the ones you're interested in.\n",
-    "\n",
-    "**In this tutorial, we will only use the \"gps\" (Galactic center survey) dataset, so maybe you could start by downloading that first.**\n",
-    "\n",
-    "While you wait, we strongly recommend you go over some [CTA basics](https://www.youtube.com/playlist?list=PLq3ItKoU0hy7ED6m1eve6WIFs7ibcv3YR) as well as some [Python basics](https://www.youtube.com/playlist?list=PL-Qryc-SVnnu0tPV623TFnrAEQLykkZF5) to prepare yourself for this tutorial.\n",
-    "\n",
-    "Got the data?\n",
-    "\n",
-    "Assuming you've followed the instructions, you should have the ``CTADATA`` environment variable pointing to the folder where all data is located. (Gammapy doesn't need or use the ``CALDB`` environment variable.)\n"
+    "Working with that data with Gammapy is identical to what we show here, except that the recommended way to do it is to point `DataStore.read` at `$CTADATA/index/gps` or whatever dataset or files you'd like to access there."
    ]
   },
   {
@@ -111,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!echo $CTADATA"
+    "!echo $GAMMAPY_DATA/cta-1dc"
    ]
   },
   {
@@ -120,37 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls $CTADATA"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can find a description of the directories and files here:\n",
-    "https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki/Data_organisation\n",
-    "\n",
-    "A very detailed specification of the data formats is here:\n",
-    "http://gamma-astro-data-formats.readthedocs.io/\n",
-    "\n",
-    "But actually, instead of reading those pages, let's just explore the data and see how to load it with Gammapy ...\n",
-    "\n",
-    "Before we start, just in case the commands above show that you don't have `CTADATA` set:\n",
-    "\n",
-    "* you either have to exit the \"jupyter notebook\" command on your terminal, set the environment variable (I'm using bash and added the command `export CTADATA=/Users/deil/work/cta-dc/data/1dc/1dc` to my `~/.profile` file and then did `source ~/.profile`), then re-start Jupyter and this notebook.\n",
-    "* or you can set the environment variable by uncommentting the code in the following cell, setting the correct path, then executing it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import os\n",
-    "# os.environ['CTADATA'] = '/Users/deil/work/cta-dc/data/1dc/1dc'\n",
-    "# !echo $CTADATA\n",
-    "# !ls $CTADATA"
+    "!ls $GAMMAPY_DATA/cta-1dc"
    ]
   },
   {
@@ -164,7 +122,7 @@
     "\n",
     "## EVENT data\n",
     "\n",
-    "First, the EVENT data (RA, DEC, ENERGY, TIME of each photon or hadronic background event) is in the `data/baseline` folder, with one observation per file. The \"baseline\" refers to the assumed CTA array that was used to simulate the observations. The number in the filename is the observation identifier `OBS_ID` of the observation. Observations are ~ 30 minutes, pointing at a fixed location on the sky."
+    "First, the EVENT data (RA, DEC, ENERGY, TIME of each photon or hadronic background event) is in the `data` folder, with one observation per file. The \"baseline\" refers to the assumed CTA array that was used to simulate the observations. The number in the filename is the observation identifier `OBS_ID` of the observation. Observations are ~ 30 minutes, pointing at a fixed location on the sky."
    ]
   },
   {
@@ -173,36 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls $CTADATA"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ls $CTADATA/data/baseline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ls $CTADATA/data/baseline/gps | head -n3"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# There's 3270 observations and 11 GB of event data for the gps dataset\n",
-    "!ls $CTADATA/data/baseline/gps | wc -l\n",
-    "!du -hs $CTADATA/data/baseline/gps"
+    "!ls -1 $GAMMAPY_DATA/cta-1dc/data/baseline/gps"
    ]
   },
   {
@@ -220,9 +149,26 @@
    "source": [
     "from gammapy.data import EventList\n",
     "\n",
-    "events = EventList.read(\"$CTADATA/data/baseline/gps/gps_baseline_110000.fits\")\n",
-    "print(type(events))\n",
-    "print(type(events.table))"
+    "path = \"$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits\"\n",
+    "events = EventList.read(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(events)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(events.table)"
    ]
   },
   {
@@ -252,7 +198,7 @@
    "outputs": [],
    "source": [
     "# Event times can be accessed as Astropy Time objects\n",
-    "print(type(events.time))"
+    "type(events.time)"
    ]
   },
   {
@@ -370,7 +316,7 @@
     "plt.hist(energy, bins=energy_bins)\n",
     "plt.semilogx()\n",
     "plt.xlabel(\"Event energy (TeV)\")\n",
-    "plt.ylabel(\"Number of events\")"
+    "plt.ylabel(\"Number of events\");"
    ]
   },
   {
@@ -405,13 +351,13 @@
    "source": [
     "energy = events.table[\"ENERGY\"].data\n",
     "energy_bins = np.logspace(-2, 2, num=100)\n",
-    "opts = dict(bins=energy_bins, normed=True, histtype=\"step\")\n",
+    "opts = dict(bins=energy_bins, density=True, histtype=\"step\")\n",
     "plt.hist(energy[~is_gamma], label=\"hadron\", **opts)\n",
     "plt.hist(energy[is_gamma], label=\"gamma\", **opts)\n",
     "plt.loglog()\n",
     "plt.xlabel(\"Event energy (TeV)\")\n",
     "plt.ylabel(\"Number of events\")\n",
-    "plt.legend()"
+    "plt.legend();"
    ]
   },
   {
@@ -446,7 +392,7 @@
    "outputs": [],
    "source": [
     "energy_bins = 10 ** np.linspace(-2, 2, 100)\n",
-    "offset_bins = np.arange(0, 5, 0.1)\n",
+    "offset_bins = np.arange(0, 5.5, 0.1)\n",
     "\n",
     "t = events.table\n",
     "offset = np.sqrt(t[\"DETX\"] ** 2 + t[\"DETY\"] ** 2)\n",
@@ -469,6 +415,22 @@
    "source": [
     "So the CTA field of view increases with energy in steps. The energy distribution we saw before was the combination of the energy distribution at all offsets. Even at a single offset, the double energy-threshold at ~ 30 GeV and ~ 100 GeV is present.\n",
     "\n",
+    "There is also a quick-look peek method you can use to get a peek at the contents of an event list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "events.peek()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Stacking EVENTS tables\n",
     "\n",
     "As a final example of how to work with event lists, here's now to apply arbitrary event selections and how to stack events tables from several observations into a single event list. \n",
@@ -487,12 +449,12 @@
     "from astropy.table import vstack as table_vstack\n",
     "\n",
     "filename = os.path.join(\n",
-    "    os.environ[\"CTADATA\"], \"data/baseline/gps/gps_baseline_110000.fits\"\n",
+    "    os.environ[\"GAMMAPY_DATA\"], \"cta-1dc/data/baseline/gps/gps_baseline_110380.fits\"\n",
     ")\n",
     "t1 = Table.read(filename, hdu=\"EVENTS\")\n",
     "\n",
     "filename = os.path.join(\n",
-    "    os.environ[\"CTADATA\"], \"data/baseline/gps/gps_baseline_110001.fits\"\n",
+    "    os.environ[\"GAMMAPY_DATA\"], \"cta-1dc/data/baseline/gps/gps_baseline_111140.fits\"\n",
     ")\n",
     "t2 = Table.read(filename, hdu=\"EVENTS\")\n",
     "tables = [t1, t2]\n",
@@ -552,7 +514,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!(cd $CTADATA && tree caldb)"
+    "!(cd $GAMMAPY_DATA/cta-1dc && tree caldb)"
    ]
   },
   {
@@ -565,7 +527,7 @@
     "# IRFs are stored in `BinTable` HDUs in a weird format\n",
     "# that you don't need to care about because it's implemented in Gammapy\n",
     "irf_filename = os.path.join(\n",
-    "    os.environ[\"CTADATA\"], \"caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "    os.environ[\"GAMMAPY_DATA\"], \"cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     ")\n",
     "from astropy.io import fits\n",
     "\n",
@@ -589,10 +551,25 @@
    "outputs": [],
    "source": [
     "from gammapy.irf import EffectiveAreaTable2D\n",
-    "\n",
-    "aeff = EffectiveAreaTable2D.read(irf_filename, hdu=\"EFFECTIVE AREA\")\n",
-    "print(type(aeff))\n",
-    "print(type(aeff.data))"
+    "aeff = EffectiveAreaTable2D.read(irf_filename, hdu=\"EFFECTIVE AREA\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(aeff)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(aeff.data)"
    ]
   },
   {
@@ -655,7 +632,6 @@
    "outputs": [],
    "source": [
     "from gammapy.irf import EnergyDispersion2D\n",
-    "\n",
     "edisp = EnergyDispersion2D.read(irf_filename, hdu=\"ENERGY DISPERSION\")\n",
     "print(type(edisp))\n",
     "print(type(edisp.data))"
@@ -798,9 +774,7 @@
     "* The purpose of observation index files is to get a table of available observations, with the most relevant parameters commonly used for observation selection (e.g. pointing position or observation time). Their format is described in detail [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/obs_index/index.html).\n",
     "* The purpose of HDU index files is to locate all FITS header data units (HDUs) for a given observation. At the moment, for each observation, there are six relevant HDUs: EVENTS, GTI, AEFF, EDISP, PSF and BKG. The format is described in detail [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/hdu_index/index.html).\n",
     "\n",
-    "For 1DC there is one set of index files per simulated dataset, as well as a set of index files listing all available data in the all directory.\n",
-    "\n",
-    "Side comment: if you have data, but no index files, you should write a Python script to make the index files. As an example, the one I used to make the index files for 1DC is [here](https://github.com/gammasky/cta-dc/blob/master/data/cta_1dc_make_data_index_files.py)."
+    "For 1DC there is one set of index files per simulated dataset, as well as a set of index files listing all available data in the all directory."
    ]
   },
   {
@@ -809,7 +783,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!(cd $CTADATA && tree index)"
+    "!(cd $GAMMAPY_DATA/cta-1dc && tree index)"
    ]
   },
   {
@@ -828,8 +802,12 @@
    "outputs": [],
    "source": [
     "from gammapy.data import DataStore\n",
+    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/cta-1dc/index/gps\")\n",
     "\n",
-    "data_store = DataStore.from_dir(\"$CTADATA/index/gps\")"
+    "# If you want to access all CTA DC-1 data,\n",
+    "# set the CTADATA env var and use this:\n",
+    "# data_store = DataStore.from_dir(\"$CTADATA/index/gps\")\n",
+    "# Or point at the directly with the index files directly"
    ]
   },
   {
@@ -851,10 +829,8 @@
     "# The observation index is loaded as a table\n",
     "print(\"Number of observations: \", len(data_store.obs_table))\n",
     "print(data_store.obs_table.colnames)\n",
-    "print(\n",
-    "    \"Total observation time (hours): \",\n",
-    "    data_store.obs_table[\"ONTIME\"].sum() / 3600,\n",
-    ")"
+    "# Compute and print total obs time in hours\n",
+    "print(data_store.obs_table[\"ONTIME\"].sum() / 3600)"
    ]
   },
   {
@@ -958,7 +934,7 @@
    "source": [
     "## Load data\n",
     "\n",
-    "Once you have selected the observations of interest, use the `DataStore` to load the data and IRF for those observations. Let's say we're interested in `OBS_ID=110000`."
+    "Once you have selected the observations of interest, use the `DataStore` to load the data and IRF for those observations. Let's say we're interested in `OBS_ID=110380`."
    ]
   },
   {
@@ -967,7 +943,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs = data_store.obs(obs_id=110000)"
+    "obs = data_store.obs(obs_id=110380)"
    ]
   },
   {
@@ -994,7 +970,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs.events.table[:5]"
+    "obs.events.table[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.gti"
    ]
   },
   {
@@ -1025,6 +1010,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs.bkg"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1046,7 +1040,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls $CTADATA/models/*.xml | xargs -n 1 basename"
+    "# TODO: copy an example XML file for tutorials\n",
+    "# This one is no good: $CTADATA/models/models_gps.xml\n",
+    "# Too large, private in CTA, loads large diffuse model\n",
+    "# We need to prepare something custom.\n",
+    "# !ls $CTADATA/models/*.xml | xargs -n 1 basename"
    ]
   },
   {
@@ -1056,7 +1054,7 @@
    "outputs": [],
    "source": [
     "# This is what the XML file looks like\n",
-    "!tail -n 20 $CTADATA/models/models_gps.xml"
+    "# !tail -n 20 $CTADATA/models/models_gps.xml"
    ]
   },
   {
@@ -1097,13 +1095,13 @@
    "outputs": [],
    "source": [
     "# Read XML file and access spectrum parameters\n",
-    "from gammapy.extern import xmltodict\n",
+    "# from gammapy.extern import xmltodict\n",
     "\n",
-    "filename = os.path.join(os.environ[\"CTADATA\"], \"models/models_gps.xml\")\n",
-    "data = xmltodict.parse(open(filename).read())\n",
-    "data = data[\"source_library\"][\"source\"][-1]\n",
-    "data = data[\"spectrum\"][\"parameter\"]\n",
-    "data"
+    "# filename = os.path.join(os.environ[\"CTADATA\"], \"models/models_gps.xml\")\n",
+    "# data = xmltodict.parse(open(filename).read())\n",
+    "# data = data[\"source_library\"][\"source\"][-1]\n",
+    "# data = data[\"spectrum\"][\"parameter\"]\n",
+    "# data"
    ]
   },
   {
@@ -1113,16 +1111,16 @@
    "outputs": [],
    "source": [
     "# Create a spectral model the the right units\n",
-    "from astropy import units as u\n",
-    "from gammapy.spectrum.models import PowerLaw\n",
+    "# from astropy import units as u\n",
+    "# from gammapy.spectrum.models import PowerLaw\n",
     "\n",
-    "par_to_val = lambda par: float(par[\"@value\"]) * float(par[\"@scale\"])\n",
-    "spec = PowerLaw(\n",
-    "    amplitude=par_to_val(data[0]) * u.Unit(\"cm-2 s-1 MeV-1\"),\n",
-    "    index=par_to_val(data[1]),\n",
-    "    reference=par_to_val(data[2]) * u.Unit(\"MeV\"),\n",
-    ")\n",
-    "print(spec)"
+    "# par_to_val = lambda par: float(par[\"@value\"]) * float(par[\"@scale\"])\n",
+    "# spec = PowerLaw(\n",
+    "#     amplitude=par_to_val(data[0]) * u.Unit(\"cm-2 s-1 MeV-1\"),\n",
+    "#     index=par_to_val(data[1]),\n",
+    "#     reference=par_to_val(data[2]) * u.Unit(\"MeV\"),\n",
+    "# )\n",
+    "# print(spec)"
    ]
   },
   {
@@ -1186,5 +1184,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir('$CTADATA/index/gps')"
+    "data_store = DataStore.from_dir('$GAMMAPY_DATA/cta-1dc/index/gps')"
    ]
   },
   {

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "def get_irfs():\n",
     "    \"\"\"Load CTA IRFs\"\"\"\n",
-    "    filename = \"$CTADATA/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "    filename = \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     "    psf = EnergyDependentMultiGaussPSF.read(\n",
     "        filename, hdu=\"POINT SPREAD FUNCTION\"\n",
     "    )\n",

--- a/tutorials/spectrum_simulation_cta.ipynb
+++ b/tutorials/spectrum_simulation_cta.ipynb
@@ -88,7 +88,7 @@
    "outputs": [],
    "source": [
     "# Load IRFs\n",
-    "filename = \"$CTADATA/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "filename = \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
     "cta_irf = CTAIrf.read(filename)"
    ]
   },


### PR DESCRIPTION
This PR changes the use of CTADATA to GAMMAPY_DATA/cta-1dc in tutorial notebooks.

It should allow all notebooks to be tested and executed in CI and by anyone, no more private data used.

cc @Bultako @adonath 