### PR TITLE
Add likelihood profile methods to `Fit`

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -289,40 +289,6 @@ class SpectrumFit(Fit):
         except KeyError:
             raise ValueError("No observation livetime given")
 
-    def likelihood_1d(self, model, parname, parvals):
-        """Compute likelihood profile.
-
-        Parameters
-        ----------
-        model : `~gammapy.spectrum.models.SpectralModel`
-            Model to draw likelihood profile for
-        parname : str
-            Parameter to calculate profile for
-        parvals : `~astropy.units.Quantity`
-            Parameter values
-        """
-        likelihood = []
-        self._model = model
-        for val in parvals:
-            self._model.parameters[parname].value = val
-            stat = self.total_stat(self._model.parameters)
-            likelihood.append(stat)
-        return np.array(likelihood)
-
-    def plot_likelihood_1d(self, ax=None, **kwargs):
-        """Plot 1-dim likelihood profile.
-
-        See :func:`~gammapy.spectrum.SpectrumFit.likelihood_1d`
-        """
-        import matplotlib.pyplot as plt
-
-        ax = plt.gca() if ax is None else ax
-
-        yy = self.likelihood_1d(**kwargs)
-        ax.plot(kwargs["parvals"], yy)
-        ax.set_xlabel(kwargs["parname"])
-        return ax
-
     @property
     def result(self):
         """Bundle fit results into `~gammapy.spectrum.SpectrumFitResult`.

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -386,7 +386,7 @@ class TestFluxPointFit:
 
         profile = fitter.likelihood_profile(
             model=result.model,
-            parname="amplitude",
+            parameter="amplitude",
             nvalues=3,
             bounds=1
             )
@@ -401,7 +401,7 @@ class TestFluxPointFit:
 
         profile = fitter.likelihood_profile(
                 model=result.model,
-                parname="amplitude",
+                parameter="amplitude",
                 values=values,
                 )
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -387,8 +387,24 @@ class TestFluxPointFit:
         profile = fitter.likelihood_profile(
             model=result.model,
             parname="amplitude",
-            nvalues=3
+            nvalues=3,
+            bounds=1
             )
 
         ts_diff = profile['likelihood'] - result.total_stat
-        assert_allclose(ts_diff, [440.4, 0, 440.4], rtol=1e-2)
+        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2)
+
+
+        value = result.model.parameters["amplitude"].value
+        err = result.model.parameters.error("amplitude")
+        values = np.array([value - err, value, value + err])
+
+        profile = fitter.likelihood_profile(
+                model=result.model,
+                parname="amplitude",
+                values=values,
+                )
+
+        ts_diff = profile['likelihood'] - result.total_stat
+        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2)
+

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -392,7 +392,7 @@ class TestFluxPointFit:
             )
 
         ts_diff = profile['likelihood'] - result.total_stat
-        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2)
+        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=5e-2)
 
 
         value = result.model.parameters["amplitude"].value
@@ -406,5 +406,5 @@ class TestFluxPointFit:
                 )
 
         ts_diff = profile['likelihood'] - result.total_stat
-        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2)
+        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=5e-2)
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -392,7 +392,7 @@ class TestFluxPointFit:
             )
 
         ts_diff = profile['likelihood'] - result.total_stat
-        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=5e-2)
+        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
 
 
         value = result.model.parameters["amplitude"].value
@@ -406,5 +406,5 @@ class TestFluxPointFit:
                 )
 
         ts_diff = profile['likelihood'] - result.total_stat
-        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=5e-2)
+        assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -377,3 +377,18 @@ class TestFluxPointFit:
         # Right now sherpa also fits the reference energy
         amplitude = result.model(1 * u.TeV).to("cm-2 s-1 TeV-1")
         assert_allclose(amplitude.value, 2.1616E-13, rtol=1e-3)
+
+    @requires_dependency("iminuit")
+    def test_likelihood_profile(self, sed_model, sed_flux_points):
+        optimize_opts = {"backend": "minuit"}
+        fitter = FluxPointFit(sed_model, sed_flux_points)
+        result = fitter.run(optimize_opts=optimize_opts)
+
+        profile = fitter.likelihood_profile(
+            model=result.model,
+            parname="amplitude",
+            nvalues=3
+            )
+
+        ts_diff = profile['likelihood'] - result.total_stat
+        assert_allclose(ts_diff, [440.4, 0, 440.4], rtol=1e-2)

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -31,22 +31,22 @@ class Fit(object):
         """Total likelihood given the current model parameters"""
         pass
 
-    def likelihood_profiles(self, model, parnames="all"):
+    def likelihood_profiles(self, model, parameters="all"):
         """Compute likelihood profiles for multiple parameters.
 
         Parameters
         ----------
         model : `~gammapy.spectrum.models.SpectralModel` or `~gammapy.cube.models.SkyModel`
             Model to compute the likelihood profile for.
-        parnames : list of str or "all"
+        parameters : list of str or "all"
             For which parameters to compute likelihood profiles.
         """
         profiles = {}
 
-        if parnames == "all":
-            parnames = [par.name for par in model.paramaters]
+        if parameters == "all":
+            parameters = [par.name for par in model.paramaters]
 
-        for parname in parnames:
+        for parname in parameters:
             profiles[parname] = self.likelihood_profile(model, parname)
         return profiles
 
@@ -253,13 +253,6 @@ class FitResult(object):
     def method(self):
         """Optimizer method used for the fit."""
         return self._method
-
-    def to_dict(self):
-        """Convert to `dict` object"""
-        data = {}
-        for name in []:
-            data[name] = getattr(self, name)
-        return data
 
     def __repr__(self):
         str_ = self.__class__.__name__

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -50,7 +50,7 @@ class Fit(object):
             profiles[parname] = self.likelihood_profile(model, parname)
         return profiles
 
-    def likelihood_profile(self, model, parname, parvalues=None, nvalues=11, bounds=2):
+    def likelihood_profile(self, model, parname, values=None, bounds=2, nvalues=11):
         """Compute likelihood profile for a single parameter of the model.
 
         Parameters
@@ -60,11 +60,15 @@ class Fit(object):
         parname : str
             Parameter to calculate profile for
         values : `~astropy.units.Quantity` (optional)
-            Parameter values
+            Parameter values to evaluate the likelihood for.
+        bounds : int or tuple of float
+            When an `int` is passed the bounds are computed from `bounds * sigma`
+            from the best fit value of the parameter, where `sigma` corresponds to
+            the one sigma error on the parameter. If a tuple of floats is given
+            those are taken as the min and max values and `nvalues` are linearly
+            spaced between those.
         nvalues : int
             Number of parameter grid points to use.
-        sigma : int
-            Pass
 
         Returns
         -------
@@ -75,7 +79,7 @@ class Fit(object):
 
         likelihood = []
 
-        if parvalues is None:
+        if values is None:
             if isinstance(bounds, tuple):
                 parmin, parmax = bounds
             else:


### PR DESCRIPTION
This PR adds  a `.likelihood_profile()` method to the `Fit` object, which can be used to compute likelihood profiles for given parameters. The computed likelihood profiles are also added to the `FitResult` object, which features a convenience method to plot those. The old `SpectrumFit` likelihood profile methods are deleted.
