### PR TITLE
Remove Github API in gammapy download CLI

### DIFF
--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -18,20 +18,11 @@ def cli_download_notebooks(ctx):
     """Download notebooks"""
 
     downloadproc = DownloadProcess(
-        "gammapy",
-        "tutorials",
-        ctx.obj["specfile"],
-        ctx.obj["specfold"],
-        ctx.obj["release"],
-        ["../environment.yml"],
-        Path(ctx.obj["localfold"]),
-        ctx.obj["recursive"],
+        ctx.obj["src"], ctx.obj["out"], ctx.obj["release"], "notebooks"
     )
 
-    downloadproc.check_hash()
-    downloadproc.label_version()
-    downloadproc.build_folders()
-    downloadproc.build_files()
+    downloadproc.setup()
+    downloadproc.files()
     downloadproc.run()
 
 
@@ -41,19 +32,11 @@ def cli_download_datasets(ctx):
     """Download datasets"""
 
     downloadproc = DownloadProcess(
-        "gammapy-extra",
-        "datasets",
-        ctx.obj["specfile"],
-        ctx.obj["specfold"],
-        ctx.obj["release"],
-        [],
-        Path(ctx.obj["localfold"]) / "datasets",
-        ctx.obj["recursive"],
+        ctx.obj["src"], ctx.obj["out"], ctx.obj["release"], "datasets"
     )
 
-    downloadproc.check_hash()
-    downloadproc.build_folders()
-    downloadproc.build_files()
+    downloadproc.setup()
+    downloadproc.files()
     downloadproc.run()
 
 
@@ -62,40 +45,18 @@ def cli_download_datasets(ctx):
 def cli_download_tutorials(ctx):
     """Download tutorial notebooks and datasets"""
 
-    if ctx.obj["specfile"] or ctx.obj["specfile"]:
-        log.info("--file and --foder are not allowed options for tutorials.")
-    if not ctx.obj["recursive"]:
-        log.info("--recursive is True for tutorials.")
-
     downnotebooks = DownloadProcess(
-        "gammapy",
-        "tutorials",
-        "",
-        "",
-        ctx.obj["release"],
-        ["../environment.yml"],
-        Path(ctx.obj["localfold"]),
-        True,
+        ctx.obj["src"], ctx.obj["out"], ctx.obj["release"], "notebooks"
     )
-
-    downnotebooks.check_hash()
-    downnotebooks.label_version()
-    downnotebooks.build_folders()
-    downnotebooks.build_files(tutorials=True)
+    downnotebooks.setup()
+    downnotebooks.files()
     downnotebooks.run()
 
     downdatasets = DownloadProcess(
-        "gammapy-extra",
-        "datasets",
-        "",
-        "",
-        ctx.obj["release"],
-        [],
-        Path(ctx.obj["localfold"]) / "datasets",
-        True,
+        ctx.obj["src"], ctx.obj["out"], ctx.obj["release"], "tutorials"
     )
-
-    downdatasets.check_hash()
-    downdatasets.build_folders()
-    downdatasets.build_files(tutorials=True, datasets=True)
+    downdatasets.setup()
+    downdatasets.files()
     downdatasets.run()
+
+    downnotebooks.show_info()

--- a/gammapy/scripts/downloadclass.py
+++ b/gammapy/scripts/downloadclass.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 RELEASES = ["0.8"]
 BASE_URL = "http://gammapy.org/download"
+YAML_URL = "https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/notebooks.yaml"
 
 
 class DownloadProcess(object):
@@ -119,8 +120,12 @@ class DownloadProcess(object):
     def parse_yaml(self):
         import yaml
 
-        filename_nbs = "gammapy-" + self.release + "-tutorials.yml"
-        url_nbs = BASE_URL + "/tutorials/" + filename_nbs
+        if version.release:
+            filename_nbs = "gammapy-" + self.release + "-tutorials.yml"
+            url_nbs = BASE_URL + "/tutorials/" + filename_nbs
+        else:
+            url_nbs = YAML_URL
+
         r = urlopen(url_nbs)
 
         for nb in yaml.safe_load(r.read()):

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -70,26 +70,21 @@ def cli_image():
 
 @cli.group("download", short_help="Download datasets and notebooks")
 @click.option(
-    "--dest",
+    "--out",
     prompt="destination folder",
     default="gammapy-tutorials",
     help="Folder where the files will be copied.",
 )
-@click.option("--file", default="", help="Specific file to download.")
-@click.option("--fold", default="", help="Specific folder to download.")
-@click.option("--release", default="", help="Release or commit hash in Github repo.")
-@click.option(
-    "--recursive/--no-recursive",
-    default=True,
-    help="Deactivate recursive scan of a folder.",
-)
+@click.option("--src", default="", help="Specific notebook or dataset to download.")
+@click.option("--release", default="", help="Gammapy release for notebboks.")
 @click.pass_context
-def cli_download(ctx, dest, file, fold, release, recursive):
+def cli_download(ctx, out, src, release):
     """Download datasets and notebooks.
 
-    Download from the 'gammapy-extra' Github repository the content of
-    'datasets' or 'notebooks' folders. The files are copied into a folder
-    created at the current working directory.
+    Download notebooks published as tutorials and the related datasets needed
+    to execute them. It is also possible to download individual notebooks
+    or datasets. The files are copied into a folder created at the current
+    working directory.
 
     \b
     Examples
@@ -98,17 +93,11 @@ def cli_download(ctx, dest, file, fold, release, recursive):
     \b
     $ gammapy download notebooks
     $ gammapy download datasets
-    $ gammapy download --release master tutorials
-    $ gammapy download --file first_steps.ipynb notebooks
-    $ gammapy download --dest localfolder --fold catalogs/fermi --no-recursive datasets
+    $ gammapy download --release 0.8 tutorials
+    $ gammapy download --src first_steps notebooks
+    $ gammapy download --src fermi_3fhl --out localfolder datasets
     """
-    ctx.obj = {
-        "localfold": dest,
-        "specfile": file,
-        "specfold": fold,
-        "release": release,
-        "recursive": recursive,
-    }
+    ctx.obj = {"out": out, "src": src, "release": release}
 
 
 @cli.group("jupyter", short_help="Perform actions on notebooks")

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -23,14 +23,14 @@ def get_notebooks():
 
 def requirement_missing(notebook):
     """Check if one of the requirements is missing."""
-    if notebook["requires"] is None:
-        return False
-
-    for package in notebook["requires"].split():
-        try:
-            working_set.require(package)
-        except Exception as ex:
-            return True
+    if 'requires' in notebook:
+        if notebook["requires"] is None:
+            return False
+        for package in notebook["requires"].split():
+            try:
+                working_set.require(package)
+            except Exception as ex:
+                return True
     return False
 
 

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -2,81 +2,105 @@
 # It's used for automatic testing and downloading of datesets tutorials.
 # Let's keep it alphabetical.
 - name: analysis_3d
-  requires: iminuit cta_data
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/analysis_3d.ipynb
+  requires: iminuit
   datasets:
+    - cta-1dc
 - name: astro_dark_matter
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/astro_dark_matter.ipynb
   datasets:
     - dark_matter_spectra
 - name: astropy_introduction
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/astropy_introduction.ipynb
   datasets:
-    - catalogs/fermi/gll_psc_v16.fit.gz
+    - catalogs/fermi
 - name: cta_1dc_introduction
-  requires: cta_data
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/cta_1dc_introduction.ipynb
   datasets:
+    - cta-1dc
+  images:
+    - cta-1dc
+    - gammapy_datastore_butler
 - name: cta_data_analysis
-  requires: sherpa cta_data
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/cta_data_analysis.ipynb
+  requires: sherpa
   datasets:
+    - cta-1dc
+  images:
+    - cta-1dc
 - name: cwt
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/cwt.ipynb
   datasets:
-    - fermi_survey/all.fits.gz
+    - fermi_survey
 - name: detect_ts
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/detect_ts.ipynb
   datasets:
-    - fermi_survey/all.fits.gz
-    - catalogs/fermi/gll_psch_v08.fit.gz
+    - fermi_survey
+    - catalogs/fermi
 - name: fermi_lat
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/fermi_lat.ipynb
   datasets:
     - fermi_3fhl
 - name: first_steps
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/first_steps.ipynb
   datasets:
-    - fermi_2fhl/fermi_2fhl_vela.fits.gz
-    - fermi_2fhl/2fhl_events.fits.gz
-    - images/Vela_region_WMAP_K.fits
-    - catalogs/fermi/gll_psch_v08.fit.gz
+    - fermi_2fhl
+    - images
+    - catalogs/fermi
 - name: hgps
-  requires:
-  datasets:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/hgps.ipynb
 - name: image_fitting_with_sherpa
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/image_fitting_with_sherpa.ipynb
   requires: sherpa
   datasets:
-      - G300-0_test_background.fits
-      - G300-0_test_counts.fits
-      - G300-0_test_exposure.fits
-      - G300-0_test_psf.fits
+    - sherpaCTA
 - name: intro_maps
-  requires:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/intro_maps.ipynb
   datasets:
-    - fermi_2fhl/fermi_2fhl_gc.fits.gz
-    - fermi_3fhl/gll_iem_v06_cutout.fits
-    - fermi_survey/all.fits.gz
+    - fermi_2fhl
+    - fermi_3fhl
+    - fermi_survey
+  images:
+    - gammapy_maps
+- name: light_curve
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/light_curve.ipynb
+- name: nddata_demo
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/nddata_demo.ipynb
 - name: sed_fitting_gammacat_fermi
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/sed_fitting_gammacat_fermi.ipynb
   requires: iminuit
   datasets:
-    - catalogs/fermi/gll_psc_v16.fit.gz
-    - catalogs/fermi/gll_psch_v13.fit.gz
+    - catalogs/fermi
+    - catalogs/fermi
 - name: simulate_3d
-  requires: iminuit cta_data
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/simulate_3d.ipynb
+  requires: iminuit
   datasets:
+    - cta-1dc
 - name: source_population_model
-  requires:
-  datasets:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/source_population_model.ipynb
 - name: spectrum_analysis
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_analysis.ipynb
   requires: iminuit
   datasets:
     - hess-dl3-dr1
 - name: spectrum_fitting_with_sherpa
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_fitting_with_sherpa.ipynb
   requires: sherpa
   datasets:
     - joint-crab
 - name: spectrum_models
-  requires:
-  datasets:
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_models.ipynb
 - name: spectrum_pipe
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_pipe.ipynb
   requires: iminuit
   datasets:
     - hess-dl3-dr1
+- name: spectrum_simulation
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_simulation.ipynb
+  datasets:
+    - cta-1dc
+- name: spectrum_simulation_cta
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_simulation_cta.ipynb
+  datasets:
+    - cta-1dc


### PR DESCRIPTION
This PR removes dependency of the Github REST API to download notebooks anda datasets from tutorials. It uses lookup index files delivered by http://gammapy.org web page:

* http://gammapy.org/download/data/gammapy-data-index.json
* http://gammapy.org/download/tutorials/gammapy-0.8-tutorials.yml
* http://gammapy.org/download/install/gammapy-0.8-environment.yml

The `test_notebook.py` script makes use of the config tutorials yaml file served by http://gammapy.org, this local config file for notebooks has been removed. The environment yml file will be removed in a next PR grouping fixes for Binder related with this files structure. 

Most of the code of `gammapy download` CLI has been refactored, and the interface / options have been simplified.

<pre>
$ gammapy download
Usage: gammapy download [OPTIONS] COMMAND [ARGS]...

  Download datasets and notebooks.

  Download notebooks published as tutorials and the related datasets needed
  to execute them. It is also possible to download individual notebooks or
  datasets. The files are copied into a folder created at the current
  working directory.

  Examples
  --------

  $ gammapy download notebooks
  $ gammapy download datasets
  $ gammapy download --release 0.8 tutorials
  $ gammapy download --src first_steps notebooks
  $ gammapy download --src fermi_3fhl --out localfolder datasets

Options:
  --out TEXT      Folder where the files will be copied.
  --src TEXT      Specific notebook or dataset to download.
  --release TEXT  Gammapy release for notebboks.
  -h, --help      Show this message and exit.

Commands:
  datasets   Download datasets
  notebooks  Download notebooks
  tutorials  Download tutorial notebooks and datasets
</pre>