### PR TITLE
Dataset access in notebooks with $GAMMAPY_DATA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,7 @@ env:
 
         - CONDA_CHANNELS='conda-forge sherpa'
 
-        - FETCH_GAMMAPY_EXTRA=true
-        - FETCH_GAMMA_CAT=true
-        - FETCH_GAMMAPY_FERMI_LAT_DATA=true
+        - FETCH_GAMMAPY_DATA=true
         - PACKAGING_TEST=false
         - TEST_FERMIPY=false
 
@@ -80,9 +78,9 @@ matrix:
                CONDA_DEPENDENCIES='Cython click regions pyyaml'
                PIP_DEPENDENCIES=''
 
-        # Run tests without GAMMAPY_EXTRA/GAMMA_CAT/GAMMAPY_FERMI_LAT_DATA available
+        # Run tests without GAMMAPY_DATA available
         - os: linux
-          env: FETCH_GAMMAPY_EXTRA=false FETCH_GAMMA_CAT=false FETCH_GAMMAPY_FERMI_LAT_DATA=false PYTHON_VERSION=3.7 SETUP_CMD='test -V'
+          env: FETCH_GAMMAPY_DATA=false PYTHON_VERSION=3.7 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
         # Build docs
@@ -160,20 +158,11 @@ install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 
-    - if $FETCH_GAMMAPY_EXTRA; then
+    - if $FETCH_GAMMAPY_DATA; then
           git clone https://github.com/gammapy/gammapy-extra.git $HOME/gammapy-extra;
-          export GAMMAPY_EXTRA=${HOME}/gammapy-extra;
+          export GAMMAPY_DATA=${HOME}/gammapy-extra/datasets;
       fi
 
-    - if $FETCH_GAMMA_CAT; then
-          git clone https://github.com/gammapy/gamma-cat.git $HOME/gamma-cat;
-          export GAMMA_CAT=${HOME}/gamma-cat;
-      fi
-
-    - if $FETCH_GAMMAPY_FERMI_LAT_DATA; then
-          git clone https://github.com/gammapy/gammapy-fermi-lat-data.git $HOME/gammapy-fermi-lat-data;
-          export GAMMAPY_FERMI_LAT_DATA=${HOME}/gammapy-fermi-lat-data;
-      fi
     # From https://conda.io/docs/bdist_conda.html
     # bdist_conda must be installed into a root conda environment,
     # as it imports conda and conda_build. It is included as part of the conda build package.

--- a/process_tutorials.py
+++ b/process_tutorials.py
@@ -39,13 +39,11 @@ def main():
         logging.info("python process_tutorials.py tutorials/mynotebook.ipynb")
         sys.exit()
 
-    env_vars = ["GAMMAPY_EXTRA", "GAMMA_CAT", "GAMMAPY_FERMI_LAT_DATA"]
-    for var in env_vars:
-        if var not in os.environ:
-            logging.info(var + " environment variable not set.")
-            logging.info("Running notebook tests requires this environment variable.")
-            logging.info("Exiting now.")
-            sys.exit()
+    if "GAMMAPY_DATA" not in os.environ:
+        logging.info("GAMMAPY_DATA environment variable not set.")
+        logging.info("Running notebook tests requires this environment variable.")
+        logging.info("Exiting now.")
+        sys.exit()
 
     # prepare folder structure
     pathsrc = Path(sys.argv[1])

--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -36,13 +36,11 @@ def requirement_missing(notebook):
 
 def main():
 
-    env_vars = ["GAMMAPY_EXTRA", "GAMMA_CAT", "GAMMAPY_FERMI_LAT_DATA"]
-    for var in env_vars:
-        if var not in os.environ:
-            logging.info(var + " environment variable not set.")
-            logging.info("Running notebook tests requires this environment variable.")
-            logging.info("Exiting now.")
-            sys.exit()
+    if "GAMMAPY_DATA" not in os.environ:
+        logging.info("GAMMAPY_DATA environment variable not set.")
+        logging.info("Running notebook tests requires this environment variable.")
+        logging.info("Exiting now.")
+        sys.exit()
 
     passed = True
     yamlfile = get_notebooks()

--- a/tutorials/astropy_introduction.ipynb
+++ b/tutorials/astropy_introduction.ipynb
@@ -335,9 +335,7 @@
    "outputs": [],
    "source": [
     "# Open Fermi 3FGL from the repo\n",
-    "filename = (\n",
-    "    os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/catalogs/fermi/gll_psc_v16.fit.gz\"\n",
-    ")\n",
+    "filename = os.environ[\"GAMMAPY_DATA\"] + \"catalogs/fermi/gll_psc_v16.fit.gz\"\n",
     "table = Table.read(filename, hdu=1)\n",
     "# Alternatively, one can grab it from the server.\n",
     "# table = Table.read(\"http://fermi.gsfc.nasa.gov/ssc/data/access/lat/4yr_catalog/gll_psc_v16.fit\")"
@@ -350,9 +348,7 @@
    "outputs": [],
    "source": [
     "# Note that a single FITS file might contain different tables in different HDUs\n",
-    "filename = (\n",
-    "    os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/catalogs/fermi/gll_psc_v16.fit.gz\"\n",
-    ")\n",
+    "filename = os.environ[\"GAMMAPY_DATA\"] + \"catalogs/fermi/gll_psc_v16.fit.gz\"\n",
     "# You can load a `fits.HDUList` and check the extension names\n",
     "print([_.name for _ in fits.open(filename)])\n",
     "# Then you can load by name or integer index via the `hdu` option\n",

--- a/tutorials/cwt.ipynb
+++ b/tutorials/cwt.ipynb
@@ -79,7 +79,7 @@
     "from astropy.coordinates import Angle, SkyCoord\n",
     "from gammapy.maps import Map\n",
     "\n",
-    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz\"\n",
+    "filename = \"$GAMMAPY_DATA/fermi_survey/all.fits.gz\"\n",
     "\n",
     "counts = Map.read(filename=filename, hdu=\"COUNTS\")\n",
     "background = Map.read(filename=filename, hdu=\"BACKGROUND\")\n",

--- a/tutorials/detect_ts.ipynb
+++ b/tutorials/detect_ts.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "# Load data from files\n",
-    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz\"\n",
+    "filename = \"$GAMMAPY_DATA/fermi_survey/all.fits.gz\"\n",
     "opts = {\n",
     "    \"position\": SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"),\n",
     "    \"width\": (20, 8),\n",

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "# Check that you have the prepared Fermi-LAT dataset\n",
-    "!ls -1 $GAMMAPY_FERMI_LAT_DATA/3fhl"
+    "!ls -1 $GAMMAPY_DATA/fermi_3fhl"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "# We will use diffuse models from here\n",
-    "!ls -1 $GAMMAPY_EXTRA/datasets/fermi_3fhl"
+    "!ls -1 $GAMMAPY_DATA/fermi_3fhl"
    ]
   },
   {

--- a/tutorials/first_steps.ipynb
+++ b/tutorials/first_steps.ipynb
@@ -57,10 +57,10 @@
    "source": [
     "import os\n",
     "\n",
-    "path = os.path.expandvars(\"$GAMMAPY_EXTRA/datasets\")\n",
+    "path = os.path.expandvars(\"$GAMMAPY_DATA\")\n",
     "\n",
     "if not os.path.exists(path):\n",
-    "    raise Exception(\"gammapy-extra repository not found!\")\n",
+    "    raise Exception(\"gammapy-data repository not found!\")\n",
     "else:\n",
     "    print(\"Great your setup is correct!\")"
    ]
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# os.environ['GAMMAPY_EXTRA'] = os.path.join(os.getcwd(), '..')"
+    "# os.environ['GAMMAPY_DATA'] = os.path.join(os.getcwd(), '..')"
    ]
   },
   {
@@ -136,7 +136,7 @@
     "from gammapy.maps import Map\n",
     "\n",
     "vela_2fhl = Map.read(\n",
-    "    \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_vela.fits.gz\", hdu=\"COUNTS\"\n",
+    "    \"$GAMMAPY_DATA/fermi_2fhl/fermi_2fhl_vela.fits.gz\", hdu=\"COUNTS\"\n",
     ")"
    ]
   },
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vela_wmap = Map.read(\"$GAMMAPY_EXTRA/datasets/images/Vela_region_WMAP_K.fits\")\n",
+    "vela_wmap = Map.read(\"$GAMMAPY_DATA/images/Vela_region_WMAP_K.fits\")\n",
     "\n",
     "# define a norm to stretch the data, so it is better visible\n",
     "norm = simple_norm(vela_wmap.data, stretch=\"sqrt\", max_percent=99.9)\n",
@@ -399,9 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events_2fhl = EventList.read(\n",
-    "    \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz\"\n",
-    ")"
+    "events_2fhl = EventList.read(\"$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz\")"
    ]
   },
   {
@@ -586,7 +584,7 @@
    "outputs": [],
    "source": [
     "fermi_2fhl = SourceCatalog2FHL(\n",
-    "    \"$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v08.fit.gz\"\n",
+    "    \"$GAMMAPY_DATA/catalogs/fermi/gll_psch_v08.fit.gz\"\n",
     ")\n",
     "fermi_2fhl.table"
    ]

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "# Read the fits file to load them in a sherpa model\n",
-    "filecounts = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_counts.fits\"\n",
+    "filecounts = os.environ[\"GAMMAPY_DATA\"] + \"/sherpaCTA/G300-0_test_counts.fits\"\n",
     "hdr = fits.getheader(filecounts)\n",
     "wcs = WCS(hdr)\n",
     "\n",
@@ -77,9 +77,9 @@
     "sh.load_image(filecounts)\n",
     "sh.set_coord(\"logical\")\n",
     "\n",
-    "fileexp = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_exposure.fits\"\n",
-    "filebkg = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_background.fits\"\n",
-    "filepsf = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/G300-0_test_psf.fits\"\n",
+    "fileexp = os.environ[\"GAMMAPY_DATA\"] + \"/sherpaCTA/G300-0_test_exposure.fits\"\n",
+    "filebkg = os.environ[\"GAMMAPY_DATA\"] + \"/sherpaCTA/G300-0_test_background.fits\"\n",
+    "filepsf = os.environ[\"GAMMAPY_DATA\"] + \"/sherpaCTA/G300-0_test_psf.fits\"\n",
     "sh.load_table_model(\"expo\", fileexp)\n",
     "sh.load_table_model(\"bkg\", filebkg)\n",
     "sh.load_psf(\"psf\", filepsf)"

--- a/tutorials/intro_maps.ipynb
+++ b/tutorials/intro_maps.ipynb
@@ -623,7 +623,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_gc.fits.gz\"\n",
+    "filename = \"$GAMMAPY_DATA/fermi_2fhl/fermi_2fhl_gc.fits.gz\"\n",
     "m_2fhl_gc = Map.read(filename)\n",
     "print(m_2fhl_gc)"
    ]
@@ -658,7 +658,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = os.environ[\"GAMMAPY_EXTRA\"] + \"/datasets/fermi_survey/all.fits.gz\"\n",
+    "filename = os.environ[\"GAMMAPY_DATA\"] + \"/fermi_survey/all.fits.gz\"\n",
     "hdulist = fits.open(filename)\n",
     "hdulist.info()"
    ]
@@ -797,7 +797,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_gc.fits.gz\"\n",
+    "filename = \"$GAMMAPY_DATA/fermi_2fhl/fermi_2fhl_gc.fits.gz\"\n",
     "m_2fhl_gc = Map.read(filename, hdu=\"counts\")"
    ]
   },
@@ -868,7 +868,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
+    "filename = \"$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
     "m_iem_gc = Map.read(filename)\n",
     "\n",
     "rc_params = {\n",

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/\")"
+    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")"
    ]
   },
   {

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datastore = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/\")\n",
+    "datastore = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")\n",
     "obs_ids = [23523, 23526, 23559, 23592]\n",
     "obs_list = datastore.obs_list(obs_ids)"
    ]

--- a/tutorials/spectrum_fitting_with_sherpa.ipynb
+++ b/tutorials/spectrum_fitting_with_sherpa.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "ds = DataStack()\n",
-    "ANALYSIS_DIR = expandvars(\"$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/\")\n",
+    "ANALYSIS_DIR = expandvars(\"$GAMMAPY_DATA/joint-crab/spectra/hess/\")\n",
     "filenames = glob.glob(ANALYSIS_DIR + \"pha_obs*.fits\")\n",
     "for filename in filenames:\n",
     "    sh.load_data(ds, filename)\n",

--- a/tutorials/spectrum_pipe.ipynb
+++ b/tutorials/spectrum_pipe.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir(\"$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/\")\n",
+    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")\n",
     "mask = data_store.obs_table[\"OBS_SUBSET_TAG\"] == \"crab\"\n",
     "obs_ids = data_store.obs_table[\"OBS_ID\"][mask].data\n",
     "observations = data_store.obs_list(obs_ids)\n",


### PR DESCRIPTION
This PR fixes data access in notebooks replacing $GAMMAPY_EXTRA, relative paths, and/or other env vars by $GAMMAPY_DATA env var. 

Regression tests on notebooks show that some of them are broken, due to env vars hard coded in the Gammapy code-base or datasets not properly defined in the [notebooks config file](http://gammapy.org/download/tutorials/gammapy-0.8-tutorials.yml).

Output of the tests [here](https://gist.github.com/Bultako/68257c5f86af7847fec0a74e393dc0f2).

Broken notebooks (5/23) are:
* astro_dark_matter.ipynb
* detect_ts.ipynb
* fermi_lat.ipynb
* spectrum_pipe.ipynb
* sed_fitting_gammacat_fermi.ipynb

It also modifs Travis CI config file and build docs script to use GAMMAPY_DATA env var.











