### PR TITLE
Use GAMMAPY_DATA in Gammapy codebase

### DIFF
--- a/docs/catalog/gammacat.rst
+++ b/docs/catalog/gammacat.rst
@@ -19,8 +19,8 @@ Catalog
 
 The gamma-cat catalog is available here:
 
-* ``$GAMMA_CAT/docs/data/gammacat.fits.gz``: latest version
-* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz``:
+* ``$GAMMA_CAT/output/gammacat.fits.gz``: latest version
+* ``$GAMMAPY_DATA/catalogs/gammacat/gammacat.fits.gz``:
   a stable version copied to the ``gammapy-extra`` repo, used for the
   ``gammapy.catalog.gammacat`` tests.
 
@@ -28,8 +28,8 @@ To work with the gamma-cat catalog from Gammapy, pick a version and create a
 `~gammapy.catalog.SourceCatalogGammaCat`::
 
     from gammapy.catalog import SourceCatalogGammaCat
-    filename = '$GAMMA_CAT/docs/data/gammacat.fits.gz'
-    filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat.fits.gz'
+    filename = '$GAMMA_CAT/output/gammacat.fits.gz'
+    filename = '$GAMMAPY_DATA/catalogs/gammacat/gammacat.fits.gz'
     cat = SourceCatalogGammaCat(filename)
 
 TODO: add examples how to use it and links to notebooks.
@@ -43,8 +43,8 @@ JSON index file summarising all available data and containing pointers to the ot
 
 It is available here:
 
-* ``$GAMMA_CAT/docs/data/gammacat-datasets.json``: latest version
-* ``$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat-datasets.json``:
+* ``$GAMMA_CAT/output/gammacat-datasets.json``: latest version
+* ``$GAMMAPY_DATA/catalogs/gammacat/gammacat-datasets.json``:
   a stable version copied to the ``gammapy-extra`` repo, used for the
   ``gammapy.catalog.gammacat`` tests.
 
@@ -52,8 +52,8 @@ To work with the gamma-cat data collection from Gammapy, pick a version and
 create a `~gammapy.catalog.GammaCatDataCollection` class::
 
     from gammapy.catalog import GammaCatDataCollection
-    filename = '$GAMMA_CAT/docs/data/gammacat-datasets.json'
-    filename = '$GAMMAPY_EXTRA/datasets/catalogs/gammacat/gammacat-datasets.json'
+    filename = '$GAMMA_CAT/output/gammacat-datasets.json'
+    filename = '$GAMMAPY_DATA/catalogs/gammacat/gammacat-datasets.json'
     gammacat = GammaCatDataCollection.from_index(filename)
 
 TODO: add examples how to use it and links to notebooks.

--- a/docs/data/index.rst
+++ b/docs/data/index.rst
@@ -22,7 +22,7 @@ You can use the `~gammapy.data.EventList` class to load IACT gamma-ray event lis
 .. code-block:: python
 
     >>> from gammapy.data import EventList
-    >>> filename = '$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    >>> filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
     >>> events = EventList.read(filename)
 
 To load Fermi-LAT event lists, use the `~gammapy.data.EventListLAT` class:
@@ -30,7 +30,7 @@ To load Fermi-LAT event lists, use the `~gammapy.data.EventListLAT` class:
 .. code-block:: python
 
     >>> from gammapy.data import EventListLAT
-    >>> filename = '$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz'
+    >>> filename = '$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz'
     >>> events = EventListLAT.read(filename)
 
 The other main class in `gammapy.data` is the `~gammapy.data.DataStore`, which makes it easy
@@ -39,7 +39,7 @@ to load IACT data. E.g. an alternative way to load the events for observation ID
 .. code-block:: python
 
     >>> from gammapy.data import DataStore
-    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
+    >>> data_store = DataStore.from_dir('$GAMMAPY_DATA/hess-dl3-dr1')
     >>> events = data_store.obs(23523).events
 
 Using `gammapy.data`

--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -57,7 +57,7 @@ The following example shows how to compute a TS image for Fermi-LAT survey data:
     from gammapy.detect import TSMapEstimator
     from gammapy.maps import Map
 
-    filename = '$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz'
+    filename = '$GAMMAPY_DATA/fermi_survey/all.fits.gz'
     maps = {}
     maps['counts'] = Map.read(filename, hdu='counts')
     maps['exposure'] = Map.read(filename, hdu='exposure')
@@ -88,7 +88,7 @@ dataset as above, the corresponding images can be computed using the
     from astropy.convolution import Tophat2DKernel
     from gammapy.maps import Map
     from gammapy.detect import compute_lima_image
-    filename = '$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz'
+    filename = '$GAMMAPY_DATA/fermi_survey/all.fits.gz'
     counts = Map.read(filename, hdu='COUNTS')
     background = Map.read(filename, hdu='BACKGROUND')
     kernel = Tophat2DKernel(5)

--- a/docs/image/index.rst
+++ b/docs/image/index.rst
@@ -26,7 +26,7 @@ such as e.g. an energy axis.
     :include-source:
 
     from gammapy.maps import Map
-    filename = '$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_vela.fits.gz'
+    filename = '$GAMMAPY_DATA/fermi_2fhl/fermi_2fhl_vela.fits.gz'
     image = Map.read(filename, hdu=2)
     image.plot()
 

--- a/docs/image/survey_example.py
+++ b/docs/image/survey_example.py
@@ -4,7 +4,7 @@ from astropy.coordinates import Angle
 from gammapy.maps import Map
 from gammapy.image import MapPanelPlotter
 
-filename = "$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz"
+filename = "$GAMMAPY_DATA/fermi_survey/all.fits.gz"
 survey_map = Map.read(filename, hdu="counts")
 survey_map.data = survey_map.data.astype("float")
 smoothed_map = survey_map.smooth(width=Angle(0.1, unit="deg"))

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -397,7 +397,7 @@ of the original map will be copied over to the projected map.
 
     from gammapy.maps import WcsNDMap, HpxGeom
 
-    m = WcsNDMap.read('$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits')
+    m = WcsNDMap.read('$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits')
     geom = HpxGeom.create(nside=8, coordsys='GAL')
     # Convert LAT standard IEM to HPX (nside=8)
     m_proj = m.reproject(geom)
@@ -546,7 +546,7 @@ This example shows how to fill a counts cube from an FT1 file:
     m = WcsNDMap.create(binsz=0.1, width=10.0, skydir=(45.0,30.0),
                         coordsys='CEL', axes=[energy_axis])
 
-    events = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
+    events = EventList.read('$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz')
 
     m.fill_by_coord({'skycoord': events.radec, 'energy': events.energy})
     m.write('ccube.fits', conv='fgst-ccube')
@@ -564,7 +564,7 @@ using the `~Map.cutout` method:
     from astropy import units as u
     from astropy.coordinates import SkyCoord
 
-    m = WcsNDMap.read('$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits')
+    m = WcsNDMap.read('$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits')
     position = SkyCoord(0, 0, frame="galactic", unit="deg")
     m_cutout = m.cutout(position=position, width=(5 * u.deg, 2 * u.deg))
     m_cutout.write('cutout.fits', conv='fgst-template')

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -194,8 +194,8 @@ the counts image we're creating.
       -h, --help   Show this message and exit.
 
     $ gammapy image bin \
-        $GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz \
-        $GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz \
+        $GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz \
+        $GAMMAPY_DATA/fermi_survey/all.fits.gz \
         out.fits
     INFO:gammapy.scripts.image_bin:Executing cli_image_bin
     INFO:gammapy.scripts.image_bin:Reading /Users/deil/code/gammapy-extra/datasets/fermi_2fhl/2fhl_events.fits.gz
@@ -205,7 +205,7 @@ the counts image we're creating.
 If you have the FTOOLS_ installed or other tools that can work with the files
 that Gammapy supports, you can of course use them together::
 
-    $ ftlist $GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz H
+    $ ftlist $GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz H
 
             Name               Type       Dimensions
             ----               ----       ----------

--- a/docs/spectrum/fitting.rst
+++ b/docs/spectrum/fitting.rst
@@ -25,7 +25,7 @@ simulated crab runs using the `~gammapy.spectrum.SpectrumFit` class.
     from gammapy.spectrum.models import PowerLaw
     import matplotlib.pyplot as plt
 
-    path = "$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/"
+    path = "$GAMMAPY_DATA/joint-crab/spectra/hess/"
     obs1 = SpectrumObservation.read(path + "pha_obs23523.fits")
     obs2 = SpectrumObservation.read(path + "pha_obs23592.fits")
     obs_list = SpectrumObservationList([obs1, obs2])

--- a/docs/spectrum/index.rst
+++ b/docs/spectrum/index.rst
@@ -32,7 +32,7 @@ OGIP format and fit a spectral model.
     from gammapy.spectrum import SpectrumObservation, SpectrumFit
     from gammapy.spectrum.models import PowerLaw
 
-    filename = '$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23523.fits'
+    filename = '$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits'
     obs = SpectrumObservation.read(filename)
 
     model = PowerLaw(

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -73,7 +73,7 @@ TODO: apply this to the 2FHL events and check which sources are variable as a ni
 
     from gammapy.data import EventList
     from gammapy.time import exptest
-    events = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz ', hdu='EVENTS')
+    events = EventList.read('$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz ', hdu='EVENTS')
     # TODO: cone select events for 2FHL catalog sources, compute mr for each and print 10 most variable sources
 
 Other codes

--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -10,7 +10,7 @@ from gammapy.utils.random import get_random_state
 from gammapy.cube import make_map_exposure_true_energy, MapFit, MapEvaluator
 from gammapy.cube.models import SkyModel
 
-filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+filename = "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 aeff = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
 
 # Define sky model to simulate the data

--- a/examples/example_observation_cta.py
+++ b/examples/example_observation_cta.py
@@ -7,12 +7,12 @@ from gammapy.irf import (
     Background3D,
 )
 
-filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
+filename = "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
 event_list = EventList.read(filename)
 gti = GTI.read(filename)
 
 filename = (
-    "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
 )
 aeff = EffectiveAreaTable2D.read(filename)
 bkg = Background3D.read(filename)

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -64,7 +64,7 @@ class PrimaryFlux(object):
     @lazyproperty
     def table(self):
         """Lookup table (`~astropy.table.Table`)."""
-        filename = "$GAMMAPY_EXTRA/datasets/dark_matter_spectra/AtProduction_gammas.dat"
+        filename = "$GAMMAPY_DATA/dark_matter_spectra/AtProduction_gammas.dat"
         return Table.read(
             str(make_path(filename)),
             format="ascii.fast_basic",

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -351,7 +351,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
             elif morph_type in ["Map", "Ring", "2D Gaussian x2"]:
                 filename = de["Spatial_Filename"].strip()
                 path = make_path(
-                    "$GAMMAPY_EXTRA/datasets/catalogs/fermi/Extended_archive_v15/Templates/"
+                    "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v15/Templates/"
                 )
                 return SkyDiffuseMap.read(path / filename)
             elif morph_type == "2D Gaussian":
@@ -953,7 +953,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
             elif morph_type in ["SpatialMap"]:
                 filename = de["Spatial_Filename"].strip()
                 path = make_path(
-                    "$GAMMAPY_EXTRA/datasets/catalogs/fermi/Extended_archive_v18/Templates/"
+                    "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/"
                 )
                 return SkyDiffuseMap.read(path / filename)
             elif morph_type == "RadialGauss":
@@ -1019,7 +1019,7 @@ class SourceCatalog3FGL(SourceCatalog):
     }
 
     def __init__(
-        self, filename="$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psc_v16.fit.gz"
+        self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v16.fit.gz"
     ):
         filename = str(make_path(filename))
 
@@ -1126,7 +1126,7 @@ class SourceCatalog1FHL(SourceCatalog):
     source_object_class = SourceCatalogObject1FHL
 
     def __init__(
-        self, filename="$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v07.fit.gz"
+        self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v07.fit.gz"
     ):
         filename = str(make_path(filename))
 
@@ -1160,7 +1160,7 @@ class SourceCatalog2FHL(SourceCatalog):
     source_object_class = SourceCatalogObject2FHL
 
     def __init__(
-        self, filename="$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v08.fit.gz"
+        self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v08.fit.gz"
     ):
         filename = str(make_path(filename))
 
@@ -1203,7 +1203,7 @@ class SourceCatalog3FHL(SourceCatalog):
     }
 
     def __init__(
-        self, filename="$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v13.fit.gz"
+        self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v13.fit.gz"
     ):
         filename = str(make_path(filename))
 

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -517,7 +517,7 @@ class GammaCatDataCollection(object):
         self.data_index = data_index
 
     @classmethod
-    def from_index_file(cls, filename="$GAMMA_CAT/docs/data/gammacat-datasets.json"):
+    def from_index_file(cls, filename="$GAMMA_CAT/output/gammacat-datasets.json"):
         """Create from index file."""
         path = make_path(filename)
         # TODO: make a list of `GammaCatResource`, as well as a dict by ``resource_id`` for lookup!

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -166,7 +166,7 @@ class SourceCatalog2HWC(SourceCatalog):
 
     source_object_class = SourceCatalogObject2HWC
 
-    def __init__(self, filename="$GAMMAPY_EXTRA/datasets/catalogs/2HWC.ecsv"):
+    def __init__(self, filename="$GAMMAPY_DATA/catalogs/2HWC.ecsv"):
         filename = str(make_path(filename))
         table = Table.read(filename, format="ascii.ecsv")
 

--- a/gammapy/cube/counts.py
+++ b/gammapy/cube/counts.py
@@ -30,7 +30,7 @@ def fill_map_counts(counts_map, events):
         from gammapy.maps import Map
         from gammapy.data import EventList
         from gammapy.cube import fill_map_counts
-        events = EventList.read('$GAMMAPY_EXTRA/datasets/cta-1dc/data/baseline/gps/gps_baseline_110380.fits')
+        events = EventList.read('$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits')
         counts = Map.create(coordsys='GAL', skydir=(0, 0), binsz=0.1, npix=(120, 100))
         fill_map_counts(counts, events)
         counts.plot()
@@ -41,8 +41,8 @@ def fill_map_counts(counts_map, events):
         from gammapy.maps import Map
         from gammapy.data import EventList
         from gammapy.cube import fill_map_counts
-        events = EventList.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
-        reference_map = Map.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_gc.fits.gz')
+        events = EventList.read('$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz')
+        reference_map = Map.read('$GAMMAPY_DATA/fermi_2fhl/fermi_2fhl_gc.fits.gz')
         counts = Map.from_geom(reference_map.geom)
         fill_map_counts(counts, events)
         counts.smooth(3).plot()

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -145,7 +145,7 @@ class PSFKernel(object):
         some_map.fill_by_coord([[0.2,0.4],[-0.1,0.6],[0.5,3.6]])
 
         # Extract EnergyDependentTablePSF from CTA 1DC IRF
-        filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+        filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
         psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
         table_psf = psf.to_energy_dependent_table_psf(theta=0.5*u.deg)
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -91,7 +91,7 @@ class PSFMap(object):
         geom = WcsGeom.create(binsz=0.25*u.deg, width=10*u.deg, skydir=pointing, axes=[rad_axis, energy_axis])
 
         # Extract EnergyDependentTablePSF from CTA 1DC IRF
-        filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
+        filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
         psf = EnergyDependentMultiGaussPSF.read(filename, hdu='POINT SPREAD FUNCTION')
         psf3d = psf.to_psf3d(rads)
 

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -14,7 +14,7 @@ pytest.importorskip("healpy")
 
 @pytest.fixture(scope="session")
 def bkg_3d():
-    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     return Background3D.read(filename, hdu="BACKGROUND")
 
 

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -15,7 +15,7 @@ pytest.importorskip("healpy")
 
 @pytest.fixture(scope="session")
 def aeff():
-    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc//caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     return EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
 
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -26,7 +26,7 @@ def geom():
 
 @pytest.fixture(scope="session")
 def exposure(geom):
-    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     aeff = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
 
     exposure_map = make_map_exposure_true_energy(
@@ -53,7 +53,7 @@ def edisp(geom):
 
 @pytest.fixture(scope="session")
 def psf(geom):
-    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     psf = EnergyDependentMultiGaussPSF.read(filename, hdu="POINT SPREAD FUNCTION")
 
     table_psf = psf.to_energy_dependent_table_psf(theta=0.5 * u.deg)

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -34,7 +34,7 @@ class DataStore(object):
     Here's an example how to create a `DataStore` to access H.E.S.S. data:
 
     >>> from gammapy.data import DataStore
-    >>> data_store = DataStore.from_dir('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1')
+    >>> data_store = DataStore.from_dir('$GAMMAPY_DATA/hess-dl3-dr1')
     >>> data_store.info()
     """
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -458,7 +458,7 @@ class EventListBase(object):
         Load an example event list:
 
         >>> from gammapy.data import EventList
-        >>> events = EventList.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz')
+        >>> events = EventList.read('$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz')
 
         Plot the offset^2 distribution wrt. the observation pointing position
         (this is a commonly used plot to check the background spatial distribution):
@@ -537,7 +537,7 @@ class EventList(EventListBase):
     To load an example H.E.S.S. event list:
 
     >>> from gammapy.data import EventList
-    >>> filename = '$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    >>> filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
     >>> events = EventList.read(filename)
     """
 
@@ -688,7 +688,7 @@ class EventListLAT(EventListBase):
     To load an example Fermi-LAT event list (the one corresponding to the 2FHL catalog dataset):
 
     >>> from gammapy.data import EventListLAT
-    >>> filename = '$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz'
+    >>> filename = '$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz'
     >>> events = EventListLAT.read(filename)
     """
 

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -27,7 +27,7 @@ class GTI(object):
     Load GTIs for a H.E.S.S. event list:
 
     >>> from gammapy.data import GTI
-    >>> gti = GTI.read('$GAMMAPY_EXTRA/datasets/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz')
+    >>> gti = GTI.read('$GAMMAPY_DATA/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz')
     >>> print(gti)
     GTI info:
     - Number of GTIs: 1
@@ -39,7 +39,7 @@ class GTI(object):
 
     Load GTIs for a Fermi-LAT event list:
 
-    >>> gti = GTI.read('$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz')
+    >>> gti = GTI.read('$GAMMAPY_DATA/fermi_2fhl/2fhl_events.fits.gz')
     >>> print(gti)
     GTI info:
     - Number of GTIs: 36589

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -445,7 +445,7 @@ class CWTData(object):
     --------
     >>> from gammapy.maps import Map
     >>> from gammapy.detect import CWTData
-    >>> filename = '$GAMMAPY_EXTRA/datasets/fermi_survey/all.fits.gz'
+    >>> filename = '$GAMMAPY_DATA/fermi_survey/all.fits.gz'
     >>> image = Map.read(filename, hdu='COUNTS')
     >>> background = Map.read(filename, hdu='BACKGROUND')
     >>> data = CWTData(counts=image, background=background, n_scale=2)

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -33,7 +33,7 @@ class Background3D(object):
     Here's an example you can use to learn about this class:
 
     >>> from gammapy.irf import Background3D
-    >>> filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+    >>> filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
     >>> bkg_3d = Background3D.read(filename, hdu='BACKGROUND')
     >>> print(bkg_3d)
     Background3D

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -335,7 +335,7 @@ class EffectiveAreaTable2D(object):
     Here's an example you can use to learn about this class:
 
     >>> from gammapy.irf import EffectiveAreaTable2D
-    >>> filename = '$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits'
+    >>> filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
     >>> aeff = EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
     >>> print(aeff)
     EffectiveAreaTable2D

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -12,7 +12,7 @@ from ...irf.effective_area import EffectiveAreaTable2D, EffectiveAreaTable
 @pytest.fixture(scope="session")
 def aeff():
     filename = (
-        "$GAMMAPY_EXTRA/datasets/hess-dl3-dr1//data/hess_dl3_dr1_obs_id_023523.fits.gz"
+        "$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz"
     )
     return EffectiveAreaTable2D.read(filename, hdu="AEFF")
 

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -130,7 +130,7 @@ class TestEnergyDependentMultiGaussPSF:
 @requires_dependency("scipy")
 @requires_data("gammapy-extra")
 def test_psf_cta_1dc():
-    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta//1dc/bcf/South_z20_50h/irf_file.fits"
+    filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     psf_irf = EnergyDependentMultiGaussPSF.read(filename, hdu="POINT SPREAD FUNCTION")
 
     # Check that PSF is filled with 0 for energy / offset where no PSF info is given.

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1244,7 +1244,7 @@ class TableModel(SpectralModel):
         Fill table from an EBL model (Franceschini, 2008)
 
         >>> from gammapy.spectrum.models import TableModel
-        >>> filename = '$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz'
+        >>> filename = '$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz'
         >>> table_model = TableModel.read_xspec_model(filename=filename, param=0.3)
         """
         filename = str(make_path(filename))
@@ -1434,9 +1434,9 @@ class Absorption(object):
             `Link <http://adsabs.harvard.edu/abs/2010ApJ...712..238F>`__
         """
         models = dict()
-        models["franceschini"] = "$GAMMAPY_EXTRA/datasets/ebl/ebl_franceschini.fits.gz"
-        models["dominguez"] = "$GAMMAPY_EXTRA/datasets/ebl/ebl_dominguez11.fits.gz"
-        models["finke"] = "$GAMMAPY_EXTRA/datasets/ebl/frd_abs.fits.gz"
+        models["franceschini"] = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
+        models["dominguez"] = "$GAMMAPY_DATA/ebl/ebl_dominguez11.fits.gz"
+        models["finke"] = "$GAMMAPY_DATA/ebl/frd_abs.fits.gz"
 
         return cls.read(models[name])
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -71,7 +71,7 @@ class SpectrumObservation(object):
     ::
 
         from gammapy.spectrum import SpectrumObservation
-        filename = '$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23523.fits'
+        filename = '$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs23523.fits'
         obs = SpectrumObservation.read(filename)
         print(obs)
     """
@@ -755,7 +755,7 @@ class SpectrumObservationStacker(object):
     Examples
     --------
     >>> from gammapy.spectrum import SpectrumObservationList, SpectrumObservationStacker
-    >>> obs_list = SpectrumObservationList.read('$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess')
+    >>> obs_list = SpectrumObservationList.read('$GAMMAPY_DATA/joint-crab/spectra/hess')
     >>> obs_stacker = SpectrumObservationStacker(obs_list)
     >>> obs_stacker.run()
     >>> print(obs_stacker.stacked_obs)

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -39,7 +39,7 @@ class SensitivityEstimator(object):
         from gammapy.irf import CTAPerf
         from gammapy.spectrum import SensitivityEstimator
 
-        filename = '$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
+        filename = '$GAMMAPY_DATA/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz'
         irf = CTAPerf.read(filename)
         sensitivity_estimator = SensitivityEstimator(irf=irf, livetime='5h')
         sensitivity_estimator.run()

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -224,7 +224,7 @@ class SmartHDUList(object):
     object, and then stores it away in the ``hdu_list`` attribute:
 
     >>> from gammapy.utils.fits import SmartHDUList
-    >>> hdus = SmartHDUList.open('$GAMMAPY_EXTRA/datasets/catalogs/fermi/gll_psch_v08.fit.gz')
+    >>> hdus = SmartHDUList.open('$GAMMAPY_DATA/catalogs/fermi/gll_psch_v08.fit.gz')
     >>> type(hdus.hdu_list)
     astropy.io.fits.hdu.hdulist.HDUList
 

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\n",
+    "filename = \"$GAMMAPY_DATA/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\n",
     "irf = CTAPerf.read(filename)"
    ]
   },

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -13,7 +13,7 @@
 - name: astropy_introduction
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/astropy_introduction.ipynb
   datasets:
-    - catalogs/fermi
+    - catalogs
 - name: cta_1dc_introduction
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/cta_1dc_introduction.ipynb
   datasets:
@@ -36,7 +36,7 @@
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/detect_ts.ipynb
   datasets:
     - fermi_survey
-    - catalogs/fermi
+    - catalogs
 - name: fermi_lat
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/fermi_lat.ipynb
   datasets:
@@ -46,12 +46,7 @@
   datasets:
     - fermi_2fhl
     - images
-    - catalogs/fermi
-- name: hess
-  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/hess.ipynb
-  requires: iminuit
-  datasets:
-    - hess-dl3-dr1
+    - catalogs
 - name: hgps
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/hgps.ipynb
 - name: image_fitting_with_sherpa
@@ -75,8 +70,7 @@
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/sed_fitting_gammacat_fermi.ipynb
   requires: iminuit
   datasets:
-    - catalogs/fermi
-    - catalogs/fermi
+    - catalogs
 - name: simulate_3d
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/simulate_3d.ipynb
   requires: iminuit


### PR DESCRIPTION
This PR replaces `$GAMMAPY_EXTRA` by `$GAMMAPY_DATA` hardcoded in the codebase of Gammapy, which prevents reproducibility of tutorials and catalog access for users not having env vars like `$GAMMAPY_EXTRA` or  `$GAMMA_CAT`.

We can see `$GAMMAPY_DATA` has a data-repo stuck to Gammapy that is defined in http://gammapy.org/download/data/gammapy-data-index.json The codebase of Gammapy needs `$GAMMAPY_DATA`, only a few exceptional cases (mostly related with gammacat) may still be fixed.

* `gammapy download datasets` downloads the whole `$GAMMAPY_DATA` repo.
* `gammapy download notebooks` downloads **does not**  download the repo.
* `gammapy download tutorials` downloads a big fraction of this repo, almost all the datasets of `$GAMMAPY_DATA` are used in the tutorials.

I have left `$GAMMAPY_EXTRA` in the `test_*.py` scripts, this env var is used by developers to access datasets that will not be provided to users.

I'm afraid developers should have `$GAMMAPY_EXTRA` and `$GAMMAPY_DATA` pointing to the same path ?  `export GAMMAPY_DATA=$GAMMAPY_EXTRA/datasets`

Local regression test pass, and three notebooks remain broken for those not having  `$GAMMAPY_FERMI_LAT_DATA` or  `$GAMMA_CAT`declared:
* fermilat needs `$GAMMAPY_FERMI_LAT_DATA`
* sed_fitting_gammacat_fermi needs `$GAMMA_CAT`
* spectrum_pipe needs `$GAMMA_CAT`




