### PR TITLE
Fix multiprocess download in 2.7 / unicode warnings

### DIFF
--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Command line tool to download datasets and notebooks from gammapy-extra GitHub repo.
-GitHub REST API is used to scan the tree-folder strucutre and get commmit hash.
-https://developer.github.com/v3/
-"""
+"""Command line tool to download datasets and notebooks"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import click
 import logging

--- a/gammapy/scripts/downloadclass.py
+++ b/gammapy/scripts/downloadclass.py
@@ -17,6 +17,18 @@ YAML_URL = (
 )
 
 
+def get_file(ftuple):
+    url, filepath = ftuple
+    ifolder = Path(filepath).parent
+    ifolder.mkdir(parents=True, exist_ok=True)
+
+    try:
+        urlretrieve(url, filepath)
+    except Exception as ex:
+        log.error(filepath + " could not be copied.")
+        log.error(ex)
+
+
 class DownloadProcess(object):
     """Manage the process of downloading content"""
 
@@ -48,7 +60,7 @@ class DownloadProcess(object):
             if self.getenvfile:
                 try:
                     urlopen(url_env)
-                    self.get_file((url_env, filepath_env))
+                    get_file((url_env, filepath_env))
                 except Exception as ex:
                     log.error(ex)
                     exit()
@@ -100,14 +112,12 @@ class DownloadProcess(object):
     def run(self):
         log.info("Content will be downloaded in {}".format(self.localfold))
 
-        ftuplelist = []
         pool = mp.Pool(5)
         for rec in self.listfiles:
             url = self.listfiles[rec]["url"]
             path = self.localfold / self.listfiles[rec]["path"]
             ftuple = (url, str(path))
-            ftuplelist.append(ftuple)
-            pool.apply_async(self.get_file, args=(ftuple,), callback=self.progressbar)
+            pool.apply_async(get_file, args=(ftuple,), callback=self.progressbar)
         pool.close()
         pool.join()
         pool.close()
@@ -205,14 +215,3 @@ class DownloadProcess(object):
         sys.stdout.write(text)
         sys.stdout.flush()
 
-    @staticmethod
-    def get_file(ftuple):
-        url, filepath = ftuple
-        ifolder = Path(filepath).parent
-        ifolder.mkdir(parents=True, exist_ok=True)
-
-        try:
-            urlretrieve(url, filepath)
-        except Exception as ex:
-            log.error(filepath + " could not be copied.")
-            log.error(ex)

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -20,6 +20,8 @@ def print_version(ctx, param, value):
 # http://click.pocoo.org/5/documentation/#help-parameter-customization
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
+# https://click.palletsprojects.com/en/5.x/python3/#unicode-literals
+click.disable_unicode_literals_warning = True
 
 @click.group("gammapy", context_settings=CONTEXT_SETTINGS)
 @click.option(


### PR DESCRIPTION
This PR fixes multiprocess download in Python 2.7
https://travis-ci.org/gammapy/gammapy/jobs/433184895#L1956

It also disables unicode-literals warnings in CLI apps
http://click.pocoo.org/5/python3/#unicode-literals