### PR TITLE
Delay pytest import in testing.py

### DIFF
--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import Counter
 import pytest
 import numpy as np
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord, Angle
 from astropy.table import Table

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 from astropy.convolution import Tophat2DKernel
 from ...utils.testing import requires_dependency, requires_data
 from ...detect import compute_lima_image, compute_lima_on_off_image

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-from numpy.testing.utils import assert_allclose
+from numpy.testing import assert_allclose
 from astropy.convolution import Gaussian2DKernel
 from ...utils.testing import requires_data
 from ...maps import Map

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
-from numpy.testing.utils import assert_allclose, assert_almost_equal
+from numpy.testing import assert_allclose, assert_almost_equal
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
 from astropy import units as u

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -3,12 +3,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import os
-import pytest
 import astropy.units as u
 from astropy.time import Time
 from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
-from ..datasets import gammapy_extra
 
 __all__ = [
     "requires_dependency",
@@ -39,6 +37,7 @@ def requires_dependency(name):
             import scipy
             ...
     """
+    import pytest
     if name in _requires_dependency_cache:
         skip_it = _requires_dependency_cache[name]
     else:
@@ -85,6 +84,7 @@ def requires_data(name):
             filename = gammapy_extra.filename('...')
             ...
     """
+    import pytest
     skip_it = not has_data(name)
 
     reason = "Missing data: {}".format(name)


### PR DESCRIPTION
This is needed to make 'gammapy info' work without pytest.