### PR TITLE
Allow different energy binning for true and reconstructed energy in Maps

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -214,24 +214,25 @@ class MapEvaluator(object):
 
         Parameters
         ----------
-        npred: `~gammapy.maps.Map`
-                predicted counts in true energy bins
+        npred : `~gammapy.maps.Map`
+            Predicted counts in true energy bins
 
         Returns
         ---------
-        npred_reco: `~gammapy.maps.Map`
-                    predicted counts in reco energy bins
+        npred_reco : `~gammapy.maps.Map`
+            Predicted counts in reco energy bins
         """
-
         loc = npred.geom.get_axis_index_by_name("energy")
         data = np.rollaxis(npred.data, loc, len(npred.data))
         data = np.dot(data, self.edisp.pdf_matrix)
-        data = np.rollaxis(data, -1, loc) #now dim is in ereco
-        e_reco_axis = MapAxis.from_edges(self.edisp.e_reco.bins, unit=self.edisp.e_reco.unit)
+        data = np.rollaxis(data, -1, loc)
+        e_reco_axis = MapAxis.from_edges(
+            self.edisp.e_reco.bins, unit=self.edisp.e_reco.unit
+        )
         geom_ereco = self.exposure.geom.to_image().to_cube(axes=[e_reco_axis])
-        npred1 = Map.from_geom(geom_ereco, unit="")
-        npred1.data = data
-        return npred1
+        npred = Map.from_geom(geom_ereco, unit="")
+        npred.data = data
+        return npred
 
     def compute_npred(self):
         """

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -214,19 +214,22 @@ class MapEvaluator(object):
 
         Parameters
         ----------
-        npred: npred map in e_true
+        npred: `~gammapy.maps.Map`
+                predicted counts in true energy bins
 
         Returns
         ---------
-        npred_reco: npred map in e_reco
+        npred_reco: `~gammapy.maps.Map`
+                    predicted counts in reco energy bins
         """
 
         loc = npred.geom.get_axis_index_by_name("energy")
         data = np.rollaxis(npred.data, loc, len(npred.data))
         data = np.dot(data, self.edisp.pdf_matrix)
         data = np.rollaxis(data, -1, loc) #now dim is in ereco
-        #TODO: get the geometry from the exposure map and edisp
-        npred1 = Map.from_geom(self.background.geom, unit="")
+        e_reco_axis = MapAxis.from_edges(self.edisp.e_reco.bins, unit=self.edisp.e_reco.unit)
+        geom_ereco = self.exposure.geom.to_image().to_cube(axes=[e_reco_axis])
+        npred1 = Map.from_geom(geom_ereco, unit="")
         npred1.data = data
         return npred1
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -210,12 +210,21 @@ class MapEvaluator(object):
         return npred.convolve(self.psf)
 
     def apply_edisp(self, npred):
-        """Convolve map data with energy dispersion."""
+        """Convolve map data with energy dispersion.
+
+        npred: npred map in e_true
+        Returns
+        -------
+        npred_reco: npred map in e_reco
+        """
+
         loc = npred.geom.get_axes_dimension_by_name("energy")
         data = np.moveaxis(npred.data, loc, -1)
         data = np.dot(data, self.edisp.pdf_matrix)
-        npred.data = np.moveaxis(data, -1, loc)
-        return npred
+        data1 = np.moveaxis(data, -1, loc) #now dim is in ereco
+        npred1 = Map.from_geom(self.background.geom, unit="")
+        npred1.data = data1
+        return npred1
 
     def compute_npred(self):
         """

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -126,7 +126,7 @@ class MapMaker(object):
         # Stack observation maps to total
         for name in selection:
             data = maps_obs[name].quantity.to(self.maps[name].unit).value
-            self.maps[name].fill_by_coord(coords, data)
+            self.maps[name].fill_by_coord(coords_etrue, data) if name == "exposure" else self.maps[name].fill_by_coord(coords, data)
 
     def make_images(self, spectrum=None):
         """Create 2D images by summing over the energy axis.

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
+import numpy as np
 from astropy.nddata.utils import NoOverlapError
 from astropy.coordinates import Angle
 from ..maps import Map, WcsGeom
@@ -68,7 +69,7 @@ class MapMaker(object):
         # Initialise zero-filled maps
         for name in selection:
             if name == "exposure":
-                self.maps[name] = Map.from_geom(self.geom_true, unit="m2")
+                self.maps[name] = Map.from_geom(self.geom_true, unit="m2 s")
             else:
                 self.maps[name] = Map.from_geom(self.geom, unit="")
 
@@ -116,7 +117,7 @@ class MapMaker(object):
         maps_obs = MapMakerObs(
             obs=obs,
             geom=cutout_map.geom,
-            geom_true=self.geom_true,
+            geom_true=cutout_map_etrue.geom,
             fov_mask=fov_mask,
             fov_mask_etrue=fov_mask_etrue,
             exclusion_mask=exclusion_mask,
@@ -214,8 +215,8 @@ class MapMakerObs(object):
             aeff=self.obs.aeff,
             geom=self.geom_true,
         )
-        if self.fov_mask is not None:
-            exposure.data[..., self.fov_mask] = 0
+        if self.fov_mask_etrue is not None:
+            exposure.data[..., self.fov_mask_etrue] = 0
         self.maps["exposure"] = exposure
 
     def _make_background(self):

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -176,7 +176,15 @@ class MapMakerObs(object):
         Exclusion mask (used by some background estimators)
     """
 
-    def __init__(self, obs, geom, geom_true=None, fov_mask=None, fov_mask_etrue=None, exclusion_mask=None):
+    def __init__(
+        self,
+        obs,
+        geom,
+        geom_true=None,
+        fov_mask=None,
+        fov_mask_etrue=None,
+        exclusion_mask=None,
+    ):
         self.obs = obs
         self.geom = geom
         self.geom_true = geom_true if geom_true else geom

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -126,7 +126,10 @@ class MapMaker(object):
         # Stack observation maps to total
         for name in selection:
             data = maps_obs[name].quantity.to(self.maps[name].unit).value
-            self.maps[name].fill_by_coord(coords_etrue, data) if name == "exposure" else self.maps[name].fill_by_coord(coords, data)
+            if name == "exposure":
+                self.maps[name].fill_by_coord(coords_etrue, data)
+            else:
+                self.maps[name].fill_by_coord(coords, data)
 
     def make_images(self, spectrum=None):
         """Create 2D images by summing over the energy axis.

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -99,11 +99,13 @@ class MapMaker(object):
         offset = coords.skycoord.separation(obs.pointing_radec)
         fov_mask = offset >= self.offset_max
 
+        # Compute field of view mask on the cutout in true energy
         coords_etrue = cutout_map_etrue.geom.get_coord()
         offset_etrue = coords_etrue.skycoord.separation(obs.pointing_radec)
         fov_mask_etrue = offset_etrue >= self.offset_max
 
         # Only if there is an exclusion mask, make a cutout
+        # Exclusion mask only on the background, so only in reco-energy
         exclusion_mask = self.maps.get("exclusion", None)
         if exclusion_mask is not None:
             exclusion_mask = exclusion_mask.cutout(
@@ -116,7 +118,7 @@ class MapMaker(object):
             geom=cutout_map.geom,
             geom_true=self.geom_true,
             fov_mask=fov_mask,
-            fov_mask_etrue = fov_mask_etrue,
+            fov_mask_etrue=fov_mask_etrue,
             exclusion_mask=exclusion_mask,
         ).run(selection)
 
@@ -212,8 +214,8 @@ class MapMakerObs(object):
             aeff=self.obs.aeff,
             geom=self.geom_true,
         )
-        if self.fov_mask_etrue is not None:
-            exposure.data[..., self.fov_mask_etrue] = 0
+        if self.fov_mask is not None:
+            exposure.data[..., self.fov_mask] = 0
         self.maps["exposure"] = exposure
 
     def _make_background(self):

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -38,6 +38,7 @@ def geom(ebounds):
         {
             # Default, normal test case
             "geom": geom(ebounds=[0.1, 1, 10]),
+            "geom_true": None,
             "counts": 34366,
             "exposure": 3.99815e+11,
             "exposure_image": 7.921993e+10,
@@ -46,24 +47,35 @@ def geom(ebounds):
         {
             # Test single energy bin
             "geom": geom(ebounds=[0.1, 10]),
+            "geom_true": None,
             "counts": 34366,
             "exposure": 1.16866e+11,
             "exposure_image": 1.16866e+11,
             "background": 1988492.8,
         },
         {
-            # Test single energy bin
+            # Test single energy bin with exclusion mask
             "geom": geom(ebounds=[0.1, 10]),
+            "geom_true": None,
             "exclusion_mask": Map.from_geom(geom(ebounds=[0.1, 10])),
             "counts": 34366,
             "exposure": 1.16866e+11,
             "exposure_image": 1.16866e+11,
             "background": 1988492.8,
         },
+        {
+            # Test for different e_true and e_reco bins
+            "geom": geom(ebounds=[0.1, 1, 10]),
+            "geom_true": geom(ebounds=[0.1, 0.5, 2.5, 10.0]),
+            "counts": 34366,
+            "exposure": 5.971096e+11,
+            "exposure_image": 6.492968e+10,
+            "background": 187528.89,
+        },
     ],
 )
 def test_map_maker(pars, obs_list):
-    maker = MapMaker(geom=pars["geom"], offset_max="2 deg")
+    maker = MapMaker(geom=pars["geom"], geom_true=pars["geom_true"], offset_max="2 deg")
 
     maps = maker.run(obs_list)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1405,12 +1405,12 @@ class MapGeom(object):
 
         Returns
         -------
-        i : integer
+        index : int
             The number of the dimension of the specified axis in the map geom
 
         """
-        axes = {axis.name.upper(): idx for idx, axis in enumerate(self.axes)}
-        return axes[name.upper()]
+        names = [axis.name.upper() for axis in self.axes]
+        return names.index(name.upper())
 
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1396,18 +1396,17 @@ class MapGeom(object):
         return axes[name.upper()]
 
     def get_axis_index_by_name(self, name):
-        """Get an axis location by name (case in-sensitive).
+        """Get an axis index by name (case in-sensitive).
 
         Parameters
         ----------
         name : str
-           Name of the requested axis
+           Axis name
 
         Returns
         -------
         index : int
-            The number of the dimension of the specified axis in the map geom
-
+            Axis index
         """
         names = [axis.name.upper() for axis in self.axes]
         return names.index(name.upper())
@@ -1438,9 +1437,3 @@ class MapGeom(object):
             Copied map geometry.
         """
         return self._init_copy(**kwargs)
-
-
-
-
-
-

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1421,3 +1421,26 @@ class MapGeom(object):
             Copied map geometry.
         """
         return self._init_copy(**kwargs)
+
+    def get_axes_dimension_by_name(self, name):
+        """
+        Get an axis location by name (case in-sensitive).
+
+        Parameters
+        ----------
+        name : str
+           Name of the requested axis
+
+        Returns
+        -------
+        i : integer
+            The number of the dimension of the specified axis in the map geom
+
+        """
+        for i in range(self.ndim - 2):
+            if (self.axes[i].name.lower() == name.lower()):
+                return i
+
+
+
+

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1395,6 +1395,23 @@ class MapGeom(object):
         axes = {axis.name.upper(): axis for axis in self.axes}
         return axes[name.upper()]
 
+    def get_axis_index_by_name(self, name):
+        """Get an axis location by name (case in-sensitive).
+
+        Parameters
+        ----------
+        name : str
+           Name of the requested axis
+
+        Returns
+        -------
+        i : integer
+            The number of the dimension of the specified axis in the map geom
+
+        """
+        axes = {axis.name.upper(): idx for idx, axis in enumerate(self.axes)}
+        return axes[name.upper()]
+
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.
         """
@@ -1422,24 +1439,7 @@ class MapGeom(object):
         """
         return self._init_copy(**kwargs)
 
-    def get_axes_dimension_by_name(self, name):
-        """
-        Get an axis location by name (case in-sensitive).
 
-        Parameters
-        ----------
-        name : str
-           Name of the requested axis
-
-        Returns
-        -------
-        i : integer
-            The number of the dimension of the specified axis in the map geom
-
-        """
-        for i in range(self.ndim - 2):
-            if (self.axes[i].name.lower() == name.lower()):
-                return i
 
 
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -289,10 +289,10 @@ def test_check_width_bad_input():
     with pytest.raises(IndexError):
         _check_width(width=(10,))
 
+
 def test_get_axis_index_by_name():
-    e_axis = MapAxis.from_edges([1,5], name="energy")
+    e_axis = MapAxis.from_edges([1, 5], name="energy")
     geom = WcsGeom.create(width=5, binsz=1., axes=[e_axis])
-    assert_allclose(geom.get_axis_index_by_name("Energy"), 0)
+    assert geom.get_axis_index_by_name("Energy") == 0
     with pytest.raises(ValueError):
         geom.get_axis_index_by_name("time")
-

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -288,3 +288,11 @@ def test_check_width(width, out):
 def test_check_width_bad_input():
     with pytest.raises(IndexError):
         _check_width(width=(10,))
+
+def test_get_axis_index_by_name():
+    e_axis = MapAxis.from_edges([1,5], name="energy")
+    geom = WcsGeom.create(width=5, binsz=1., axes=[e_axis])
+    assert_allclose(geom.get_axis_index_by_name("Energy"), 0)
+    with pytest.raises(ValueError):
+        geom.get_axis_index_by_name("time")
+


### PR DESCRIPTION
This PR lets maps have different geometries for the true and reco energy.
The exposure and PSF map is in true energies, the counts and background map in reco energies.
Changes are made in map creation (MapMaker) and model evaluation and fitting.