### PR TITLE
Add ImageMaker with ring background estimation

### DIFF
--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -7,7 +7,7 @@ from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_data
 from ...data import DataStore
 from ...maps import WcsGeom, MapAxis, Map
-from ..make import MapMaker
+from ..make import MapMaker, ImageMaker
 
 pytest.importorskip("scipy")
 
@@ -92,3 +92,9 @@ def test_map_maker(pars, obs_list):
     background = images["background"]
     assert background.unit == ""
     assert_allclose(background.data.sum(), pars["background"], rtol=1e-5)
+
+
+def _test_image_maker(geom, obs_list):
+    maker = ImageMaker(geom, offset_max='2 deg')
+    images = maker.run(obs_list)
+    print(images)


### PR DESCRIPTION
@registerrier and I started to prototype an ImageMaker that supports ring background estimation.

The idea was to do it in a separate class for now, and then many to merge the functionality in with the MapMaker, or maybe to keep it separate.

We kind of got stuck, because we wanted to re-use code from MapMaker via subclassing, but then it got complex because the `geom.get_coord` call was in a non-optimal place due to efficiency reasons. It might be possible to resolve this (see #1848) or to cache the coord grid somewhere (e.g. on geom), tbd.

@registerrier - I don't plan to work on this further, can you please continue this later, or just close and re-start MapMaker improvements from master.