### PR TITLE
Simplify flux point estimator implementation

### DIFF
--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -97,11 +97,11 @@ class SpectrumAnalysisIACT(object):
             model=self.fit.result[0].model,
             obs=self.extraction.observations,
         )
-        self.flux_point_estimator.compute_points()
+        self.flux_points = self.flux_point_estimator.run()
 
     @property
     def spectrum_result(self):
         """`~gammapy.spectrum.SpectrumResult`"""
         return SpectrumResult(
-            points=self.flux_point_estimator.flux_points, model=self.fit.result[0].model
+            points=self.flux_points, model=self.fit.result[0].model
         )

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -33,7 +33,7 @@ def test_spectrum_analysis_iact(tmpdir):
 
     analysis = SpectrumAnalysisIACT(observations=obs_list(), config=config)
     analysis.run()
-    flux_points = analysis.flux_point_estimator.flux_points
+    flux_points = analysis.flux_points
 
     assert len(flux_points.table) == 4
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -655,7 +655,14 @@ class FluxPointEstimator(object):
 
         self._obs = SpectrumObservationList(obs)
 
-    def compute_points(self):
+    def run(self):
+        """Run the flux point estimator
+        
+        Returns
+        -------
+        flux_points : `FluxPoints`
+            Estmated flux points.
+        """
         rows = []
         for group in self.groups:
             if group.bin_type != "normal":
@@ -667,7 +674,7 @@ class FluxPointEstimator(object):
 
         meta = OrderedDict([("method", "TODO"), ("SED_TYPE", "dnde")])
         table = table_from_row_data(rows=rows, meta=meta)
-        self.flux_points = FluxPoints(table)
+        return FluxPoints(table)
 
     def compute_flux_point(self, energy_group):
         log.debug("Computing flux point for energy group:\n{}".format(energy_group))

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -679,9 +679,10 @@ class FluxPointEstimator(object):
         # Put at log center of the bin
         energy_ref = np.sqrt(energy_group.energy_min * energy_group.energy_max)
 
-        return self.fit_point(
-            model=model, energy_group=energy_group, energy_ref=energy_ref
-        )
+        result = self.compute_dnde(model=model, energy_group=energy_group, energy_ref=energy_ref)
+        result.update(self.compute_dnde_err())
+        result.update(self.compute_dnde_ul())
+        return result
 
     @staticmethod
     def _get_spectral_model(global_model):
@@ -691,71 +692,43 @@ class FluxPointEstimator(object):
                 par.frozen = True
         return model
 
-    def compute_flux_point_ul(self, fit, stat_best_fit, delta_ts=4, negative=False):
+    def compute_dnde_err(self, sigma=1.):
         """
-        Compute upper limits for flux point values.
-
-
-        Parameters
-        ----------
-        fit : `SpectrumFit`
-            Instance of spectrum fit.
-        stat_best_fit : float
-            TS value for best fit result.
-        delta_ts : float (4)
-            Difference in log-likelihood for given confidence interval.
-            See Example below.
-        negative : bool
-            Compute limit in negative direction.
-
-
-        Examples
-        --------
-        To compute ~95% confidence upper limits (or 2 sigma) you can use::
-
-            from scipy.stats import chi2, norm
-
-            sigma = 2
-            cl = 1 - 2 * norm.sf(sigma) # using two sided p-value
-            delta_ts = chi2.isf(1 - cl, df=1)
+        Compute assymetric errors for a flux point.
 
         Returns
         -------
         dnde_ul : `~astropy.units.Quantity`
             Flux point upper limit.
         """
-        from scipy.optimize import brentq
-
-        model = fit.result[0].model.copy()
-        # this is a prototype for fast flux point upper limit
-        # calculation using brentq
-        amplitude = model.parameters["amplitude"].value / 1E-12
-        amplitude_err = model.parameters.error("amplitude") / 1E-12
-
-        if negative:
-            amplitude_max = amplitude
-            amplitude_min = amplitude_max - 1E3 * amplitude_err
-        else:
-            amplitude_max = amplitude + 1E3 * amplitude_err
-            amplitude_min = amplitude
-
-        def ts_diff(x):
-            model.parameters["amplitude"].value = x * 1E-12
-            stat = fit.total_stat(model.parameters)
-            return (stat_best_fit + delta_ts) - stat
-
+        amplitude = self._best_fit_model.parameters['amplitude']
         try:
-            result = brentq(
-                ts_diff, amplitude_min, amplitude_max, maxiter=100, rtol=1e-2
-            )
-            model.parameters["amplitude"].value = result * 1E-12
-            return model(model.parameters["reference"].quantity)
-        except (RuntimeError, ValueError):
-            # Where the root finding fails NaN is set as amplitude
-            log.debug("Flux point upper limit computation failed.")
-            return np.nan * u.Unit(model.parameters["amplitude"].unit)
+            result = self.fit.minuit.minos(var="par_001_amplitude", sigma=sigma)
+            errp = result["par_001_amplitude"].upper * amplitude.scale
+            errn = - result["par_001_amplitude"].lower * amplitude.scale
+        except RuntimeError:
+            errp, errn = np.nan, np.nan
+        return {"dnde_errp": u.Quantity(errp, amplitude.unit),
+                "dnde_errn": u.Quantity(errn, amplitude.unit)}
+    
+    def compute_dnde_ul(self, sigma=2):
+        """
+        Compute upper limit for a flux point.
 
-    def fit_point(self, model, energy_group, energy_ref, sqrt_ts_threshold=1):
+        Returns
+        -------
+        dnde_ul : `~astropy.units.Quantity`
+            Flux point upper limit.
+        """
+        amplitude = self._best_fit_model.parameters['amplitude']
+        try:
+            result = self.fit.minuit.minos(var="par_001_amplitude", sigma=sigma)
+            ul = result["par_001_amplitude"].upper * amplitude.scale + amplitude.value
+        except RuntimeError:
+            ul = np.nan        
+        return {'dnde_ul': u.Quantity(ul, amplitude.unit)}
+
+    def compute_dnde(self, model, energy_group, energy_ref, sqrt_ts_threshold=2):
         from .fit import SpectrumFit
 
         energy_min = energy_group.energy_min
@@ -782,29 +755,14 @@ class FluxPointEstimator(object):
         model.parameters["reference"].value = energy_ref.to("TeV").value
 
         self._fit = SpectrumFit(self.obs, model)
-
+        result = self.fit.run()
+  
         for index in range(len(quality_orig)):
             self.obs[index].on_vector.quality = quality_orig[index]
 
-        result = self.fit.run()
-
-        # compute TS value for all observations
-        stat_best_fit = result.total_stat
-
+        self._best_fit_model = result.model
         dnde, dnde_err = result.model.evaluate_error(energy_ref)
         sqrt_ts = self.fit.sqrt_ts(result.model.parameters)
-
-        dnde_ul = self.compute_flux_point_ul(self.fit, stat_best_fit=stat_best_fit)
-        dnde_errp = (
-            self.compute_flux_point_ul(
-                self.fit, stat_best_fit=stat_best_fit, delta_ts=1.
-            )
-            - dnde
-        )
-        dnde_errn = dnde - self.compute_flux_point_ul(
-            self.fit, stat_best_fit=stat_best_fit, delta_ts=1., negative=True
-        )
-
         return OrderedDict(
             [
                 ("e_ref", energy_ref),
@@ -812,11 +770,8 @@ class FluxPointEstimator(object):
                 ("e_max", energy_max),
                 ("dnde", dnde.to(DEFAULT_UNIT["dnde"])),
                 ("dnde_err", dnde_err.to(DEFAULT_UNIT["dnde"])),
-                ("dnde_ul", dnde_ul.to(DEFAULT_UNIT["dnde"])),
                 ("is_ul", sqrt_ts < sqrt_ts_threshold),
                 ("sqrt_ts", sqrt_ts),
-                ("dnde_errp", dnde_errp),
-                ("dnde_errn", dnde_errn),
             ]
         )
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -818,17 +818,12 @@ class FluxPointEstimator(object):
         for index in range(len(quality_orig)):
             self.obs[index].on_vector.quality = quality_orig[index]
 
-        log.debug(
-            "Calling Sherpa fit for flux point "
-            " in energy range:\n{}".format(self.fit)
-        )
-
         result = self.fit.run()
 
         # compute TS value for all observations
         stat_best_fit = result.total_stat
 
-        dnde, dnde_err = self.fit.result[0].model.evaluate_error(energy_ref)
+        dnde, dnde_err = result.model.evaluate_error(energy_ref)
         sqrt_ts = self.compute_flux_point_sqrt_ts(self.fit, stat_best_fit=stat_best_fit)
 
         dnde_ul = self.compute_flux_point_ul(self.fit, stat_best_fit=stat_best_fit)

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -625,10 +625,12 @@ class FluxPointEstimator(object):
     """
 
     def __init__(self, obs, groups, model):
-        self.obs = obs
+        if isinstance(obs, SpectrumObservation):
+            obs = SpectrumObservationList([obs])
+        self._obs = SpectrumObservationList(obs)
+        
         self.groups = groups
         self.model = model
-        self.flux_points = None
         self._fit = None
 
     def __str__(self):
@@ -647,13 +649,6 @@ class FluxPointEstimator(object):
     def obs(self):
         """Observations participating in the fit"""
         return self._obs
-
-    @obs.setter
-    def obs(self, obs):
-        if isinstance(obs, SpectrumObservation):
-            obs = SpectrumObservationList([obs])
-
-        self._obs = SpectrumObservationList(obs)
 
     def run(self):
         """Run the flux point estimator

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -755,40 +755,6 @@ class FluxPointEstimator(object):
             log.debug("Flux point upper limit computation failed.")
             return np.nan * u.Unit(model.parameters["amplitude"].unit)
 
-    def compute_flux_point_sqrt_ts(self, fit, stat_best_fit):
-        """
-        Compute sqrt(TS) for flux point.
-
-
-        Parameters
-        ----------
-        fit : `SpectrumFit`
-            Instance of spectrum fit.
-        stat_best_fit : float
-            TS value for best fit result.
-
-
-        Returns
-        -------
-        sqrt_ts : float
-            Sqrt(TS) for flux point.
-
-        """
-        model = fit.result[0].model.copy()
-        # store best fit amplitude, set amplitude of fit model to zero
-        amplitude = model.parameters["amplitude"].value
-
-        # determine TS value for amplitude zero
-        model.parameters["amplitude"].value = 0
-        stat_null = fit.total_stat(model.parameters)
-
-        # set amplitude of fit model to best fit amplitude
-        model.parameters["amplitude"].value = amplitude
-
-        # compute sqrt TS
-        ts = np.abs(stat_null - stat_best_fit)
-        return np.sign(amplitude) * np.sqrt(ts)
-
     def fit_point(self, model, energy_group, energy_ref, sqrt_ts_threshold=1):
         from .fit import SpectrumFit
 
@@ -826,7 +792,7 @@ class FluxPointEstimator(object):
         stat_best_fit = result.total_stat
 
         dnde, dnde_err = result.model.evaluate_error(energy_ref)
-        sqrt_ts = self.compute_flux_point_sqrt_ts(self.fit, stat_best_fit=stat_best_fit)
+        sqrt_ts = self.fit.sqrt_ts(result.model.parameters)
 
         dnde_ul = self.compute_flux_point_ul(self.fit, stat_best_fit=stat_best_fit)
         dnde_errp = (

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -16,7 +16,6 @@ from . import SpectrumObservationList, SpectrumObservation
 
 __all__ = [
     "FluxPoints",
-    # 'FluxPointProfiles',
     "FluxPointEstimator",
     "FluxPointFit",
 ]
@@ -857,32 +856,6 @@ class FluxPointEstimator(object):
                 ("dnde_errn", dnde_errn),
             ]
         )
-
-
-class FluxPointProfiles(object):
-    """Flux point likelihood profiles.
-
-    See :ref:`gadf:likelihood_sed`.
-
-    TODO: merge this class with the classes in ``fermipy/castro.py``,
-    which are much more advanced / feature complete.
-    This is just a temp solution because we don't have time for that.
-
-    Parameters
-    ----------
-    table : `~astropy.table.Table`
-        Table holding the data
-    """
-
-    def __init__(self, table):
-        self.table = table
-
-    @classmethod
-    def read(cls, filename, **kwargs):
-        """Read from file."""
-        filename = make_path(filename)
-        table = Table.read(str(filename), **kwargs)
-        return cls(table=table)
 
 
 class FluxPointFit(Fit):

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -207,10 +207,10 @@ class TestFluxPointEstimator:
         assert_allclose(actual, 2.994e-10, rtol=1e-2)
 
         actual = flux_points.table["dnde_errn"][0]
-        assert_allclose(actual, np.nan, rtol=1e-2)
+        assert_allclose(actual, 2.804949e-11, rtol=1e-2)
 
         actual = flux_points.table["dnde_errp"][0]
-        assert_allclose(actual, np.nan, rtol=1e-2)
+        assert_allclose(actual, 3.023831e-11, rtol=1e-2)
 
         actual = flux_points.table["sqrt_ts"][0]
         assert_allclose(actual, 13.66, rtol=1e-2)
@@ -225,7 +225,7 @@ class TestFluxPointEstimator:
         assert_allclose(actual, -0.058407, rtol=1e-2)
 
         actual = result.flux_point_residuals[1][0]
-        assert_allclose(actual, np.nan, rtol=1e-2)
+        assert_allclose(actual, 0.116119, rtol=1e-2)
 
         with mpl_plot_check():
             result.plot(energy_range=[1, 10] * u.TeV)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -18,7 +18,7 @@ from ..fit import SpectrumFit
 from ..observation import SpectrumObservation
 from ..energy_group import SpectrumEnergyGroupMaker
 from ..models import PowerLaw, SpectralModel
-from ..flux_point import FluxPoints, FluxPointProfiles, FluxPointFit, FluxPointEstimator
+from ..flux_point import FluxPoints, FluxPointFit, FluxPointEstimator
 
 FLUX_POINTS_FILES = [
     "diff_flux_points.ecsv",
@@ -226,16 +226,6 @@ class TestFluxPointEstimator:
 
         with mpl_plot_check():
             result.plot(energy_range=[1, 10] * u.TeV)
-
-
-@requires_data("gammapy-extra")
-class TestFluxPointProfiles:
-    def setup(self):
-        filename = "$GAMMAPY_EXTRA/datasets/spectrum/llsed_hights.fits"
-        self.sed = FluxPointProfiles.read(filename)
-
-    def test_basics(self):
-        assert isinstance(self.sed.table, Table)
 
 
 @pytest.fixture(params=FLUX_POINTS_FILES, scope="session")

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -195,8 +195,7 @@ class TestFluxPointEstimator:
         assert_quantity_allclose(fit_range[1], group.energy_max)
 
     def test_values(self):
-        self.fpe.compute_points()
-        flux_points = self.fpe.flux_points
+        flux_points = self.fpe.run()
 
         actual = flux_points.table["dnde"][0]
         assert_allclose(actual, 2.361e-10, rtol=1e-2)
@@ -215,8 +214,8 @@ class TestFluxPointEstimator:
 
     def test_spectrum_result(self):
         # TODO: Don't run this again
-        self.fpe.compute_points()
-        result = SpectrumResult(model=self.fpe.model, points=self.fpe.flux_points)
+        flux_points = self.fpe.run()
+        result = SpectrumResult(model=self.fpe.model, points=flux_points)
 
         actual = result.flux_point_residuals[0][0]
         assert_allclose(actual, -0.058407, rtol=1e-2)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -212,6 +212,10 @@ class TestFluxPointEstimator:
         actual = flux_points.table["dnde_errp"][0]
         assert_allclose(actual, np.nan, rtol=1e-2)
 
+        actual = flux_points.table["sqrt_ts"][0]
+        assert_allclose(actual, 13.66, rtol=1e-2)
+
+
     def test_spectrum_result(self):
         # TODO: Don't run this again
         flux_points = self.fpe.run()

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -96,6 +96,25 @@ class Fit(object):
 
         return {"values": values, "likelihood": np.array(likelihood)}
 
+    def sqrt_ts(self, parameters):
+        """Compute the sqrt(TS) of a model against the null hypthesis, that
+        the amplitude of the model is zero.
+        """
+        stat_best_fit = self.total_stat(parameters)
+
+        # store best fit amplitude, set amplitude of fit model to zero
+        amplitude = parameters["amplitude"].value
+        parameters["amplitude"].value = 0
+        stat_null = self.total_stat(parameters)
+
+        # set amplitude of fit model to best fit amplitude
+        parameters["amplitude"].value = amplitude
+
+        # compute sqrt TS
+        ts = np.abs(stat_null - stat_best_fit)
+        return np.sign(amplitude) * np.sqrt(ts)
+
+
     def optimize(self, backend="minuit", **kwargs):
         """Run the optimization
 

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -444,8 +444,8 @@
     "fpe = FluxPointEstimator(\n",
     "    obs=stacked_obs, groups=seg.groups, model=fit.result[0].model\n",
     ")\n",
-    "fpe.compute_points()\n",
-    "fpe.flux_points.table"
+    "flux_points = fpe.run()\n",
+    "flux_points.table"
    ]
   },
   {
@@ -465,7 +465,7 @@
    "outputs": [],
    "source": [
     "total_result = SpectrumResult(\n",
-    "    model=fit.result[0].model, points=fpe.flux_points\n",
+    "    model=fit.result[0].model, points=flux_points\n",
     ")\n",
     "\n",
     "total_result.plot(\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -432,7 +432,7 @@
     "fpe = FluxPointEstimator(\n",
     "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model\n",
     ")\n",
-    "fpe.compute_points()"
+    "flux_points = fpe.run()"
    ]
   },
   {
@@ -441,8 +441,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpe.flux_points.plot()\n",
-    "fpe.flux_points.table"
+    "flux_points.plot()\n",
+    "flux_points.table"
    ]
   },
   {
@@ -459,7 +459,7 @@
    "outputs": [],
    "source": [
     "spectrum_result = SpectrumResult(\n",
-    "    points=fpe.flux_points, model=joint_result[0].model\n",
+    "    points=flux_points, model=joint_result[0].model\n",
     ")\n",
     "ax0, ax1 = spectrum_result.plot(\n",
     "    energy_range=joint_fit.result[0].fit_range,\n",


### PR DESCRIPTION
This PR simplifies the `FluxPointEstimator`  implementation to get rid of the custom `brentq` UL and asymmetric error estimation. 