### PR TITLE
correction to MapFit.apply_edisp

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -223,7 +223,7 @@ class MapEvaluator(object):
             Predicted counts in reco energy bins
         """
         loc = npred.geom.get_axis_index_by_name("energy")
-        data = np.rollaxis(npred.data, loc, len(npred.data))
+        data = np.rollaxis(npred.data, loc, len(npred.data.shape))
         data = np.dot(data, self.edisp.pdf_matrix)
         data = np.rollaxis(data, -1, loc)
         e_reco_axis = MapAxis.from_edges(


### PR DESCRIPTION
This provides a correction to a bug in `apply_edisp`. 
It passed the test because the energy axis length in 3 in the test.
 