### PR TITLE
Improved analysis_3d.ipynb

### DIFF
--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# 3D analysis\n",
     "\n",
-    "This tutorial shows how to run a 3D map-based analysis using three example observations of the Galactic center region with CTA."
+    "This tutorial shows how to run a 3D map-based analysis using some 1DC observations of the Galactic center region with CTA. For this tutorial the $CTADATA environment variable will be used (see https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki/Getting_data). More information about CTA DC1 can be found in https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki as well as in \"cta_1dc_introduction\" and \"cta_data_analysis\" tutorial notebooks.\n",
+    "\n",
+    "(note: part of this notebook can be run using $GAMMAPY_DATA variable instead of CTADATA, but not the galactic diffuse emission part yet)"
    ]
   },
   {
@@ -32,16 +34,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import numpy as np\n",
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.extern.pathlib import Path\n",
     "from gammapy.data import DataStore\n",
     "from gammapy.irf import EnergyDispersion\n",
-    "from gammapy.maps import WcsGeom, MapAxis, Map\n",
-    "from gammapy.cube import MapMaker, PSFKernel, MapFit\n",
-    "from gammapy.cube.models import SkyModel\n",
-    "from gammapy.spectrum.models import PowerLaw\n",
+    "from gammapy.maps import WcsGeom, MapAxis, Map, WcsNDMap\n",
+    "from gammapy.cube import MapMaker, MapEvaluator, PSFKernel, MapFit\n",
+    "from gammapy.cube.models import SkyModel,SkyDiffuseCube\n",
+    "from gammapy.spectrum.models import PowerLaw, ExponentialCutoffPowerLaw\n",
     "from gammapy.image.models import SkyGaussian, SkyPointSource\n",
     "from regions import CircleSkyRegion"
    ]
@@ -52,7 +55,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gammapy info --no-envvar --no-dependencies --no-system"
+    "path = os.path.expandvars(\"$CTADATA\") \n",
+    "\n",
+    "if not os.path.exists(path):\n",
+    "    raise Exception(\"$CTADATA repository not found!\")\n",
+    "else:\n",
+    "    print(\"Great! your setup is correct.\")\n",
+    "    !gammapy info --no-envvar --no-system"
    ]
   },
   {
@@ -63,7 +72,7 @@
     "\n",
     "### Prepare input maps\n",
     "\n",
-    "We first use the `DataStore` object to access the CTA observations and retrieve a list of observations by passing the observations IDs to the `.obs_list()` method:"
+    "We first use the `DataStore` object to access the CTA observations and, after applying some selection cuts, we pass the selected observations ID's to the `.obs_list()` method:"
    ]
   },
   {
@@ -72,10 +81,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define which data to use\n",
-    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/cta-1dc/index/gps/\")\n",
-    "obs_ids = [110380, 111140, 111159]\n",
-    "obs_list = data_store.obs_list(obs_ids)"
+    "# Define which data to use and print some information\n",
+    "data_store = DataStore.from_dir('$CTADATA/index/gps')\n",
+    "data_store.info()\n",
+    "print('Total observation time (hours): ', data_store.obs_table['ONTIME'].sum() / 3600)\n",
+    "print('Observation table: ', data_store.obs_table.colnames)\n",
+    "print('HDU table: ', data_store.hdu_table.colnames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select some observations from these dataset\n",
+    "table = data_store.obs_table\n",
+    "pos_obs = SkyCoord(table['GLON_PNT'], table['GLAT_PNT'], frame='galactic', unit='deg')\n",
+    "pos_target = SkyCoord(0, 0, frame='galactic', unit='deg')\n",
+    "offset = pos_target.separation(pos_obs).deg\n",
+    "mask = (0 < offset) & (offset < 3)\n",
+    "table = table[mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print total number and ID's of observation list\n",
+    "print(\"{} observations selected:\".format(len(table)))\n",
+    "table[\"OBS_ID\"]\n",
+    "obs_id = table[\"OBS_ID\"].tolist()\n",
+    "obs_list = data_store.obs_list(obs_id)\n",
+    "print(obs_id)"
    ]
   },
   {
@@ -126,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The maps are prepare by calling the `.run()` method and passing the observation list `obs_list`. The `.run()` method returns a Python `dict` containing a `counts`, `background` and `exposure` map:"
+    "The maps are prepared by calling the `.run()` method and passing the observation list `obs_list`. The `.run()` method returns a Python `dict` containing a `counts`, `background` and `exposure` map:"
    ]
   },
   {
@@ -152,7 +192,7 @@
    "outputs": [],
    "source": [
     "counts = maps[\"counts\"].sum_over_axes()\n",
-    "counts.smooth(width=0.1 * u.deg).plot(stretch=\"sqrt\", add_cbar=True, vmax=6);"
+    "counts.smooth(width=0.1 * u.deg).plot(stretch=\"sqrt\", add_cbar=True, vmax = 90);"
    ]
   },
   {
@@ -169,9 +209,24 @@
    "outputs": [],
    "source": [
     "background = maps[\"background\"].sum_over_axes()\n",
-    "background.smooth(width=0.1 * u.deg).plot(\n",
-    "    stretch=\"sqrt\", add_cbar=True, vmax=6\n",
-    ");"
+    "background.smooth(width=0.1 * u.deg).plot(stretch=\"sqrt\", add_cbar=True, vmax=90);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And also the exposure image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exposure = maps[\"exposure\"].sum_over_axes()\n",
+    "exposure.smooth(width=0.1 * u.deg).plot(stretch=\"sqrt\", add_cbar=True);"
    ]
   },
   {
@@ -189,7 +244,120 @@
    "source": [
     "excess = Map.from_geom(geom.to_image())\n",
     "excess.data = counts.data - background.data\n",
-    "excess.smooth(5).plot(stretch=\"sqrt\");"
+    "excess.smooth(5).plot(stretch=\"sqrt\", add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a more realistic excess plot we can also take into account the diffuse galactic emission:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#A cutoff can speed things up here!\n",
+    "diffuse_gal = Map.read(\n",
+    "    \"$CTADATA/models/cube_iem.fits.gz\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Diffuse image: \",diffuse_gal.geom)\n",
+    "print(\"counts: \",maps[\"counts\"].geom)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the geometry of the images is completely different, so we need to apply our geometric configuration to the diffuse emission file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coord = maps[\"counts\"].geom.get_coord()\n",
+    "\n",
+    "data = diffuse_gal.interp_by_coord(\n",
+    "    {\n",
+    "        \"skycoord\": coord.skycoord,\n",
+    "        \"energy\": coord[\"energy\"]\n",
+    "        * maps[\"counts\"].geom.get_axis_by_name(\"energy\").unit,\n",
+    "    },\n",
+    "    interp=3,\n",
+    ")\n",
+    "diffuse_galactic = WcsNDMap(\n",
+    "    maps['counts'].geom, data\n",
+    ")\n",
+    "print(\"Before: \",diffuse_gal.geom)\n",
+    "print(\"Now (same as maps): \", diffuse_galactic.geom)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#diffuse_galactic.slice_by_idx({\"energy\": 0}).plot(add_cbar=True);\n",
+    "diffuse = diffuse_galactic.sum_over_axes()\n",
+    "diffuse.smooth(5).plot(stretch=\"sqrt\", add_cbar=True);\n",
+    "print(diffuse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now multiply the exposure for this diffuse emission to substract it from the counts along with the background."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combination = Map.from_geom(geom.to_image())\n",
+    "combination.data = diffuse.data*exposure.data\n",
+    "combination.smooth(5).plot(stretch=\"sqrt\", add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot then the excess image substracting now the effect of the diffuse galactic emission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "excess2 = Map.from_geom(geom.to_image())\n",
+    "excess2.data = counts.data - background.data - combination.data\n",
+    "\n",
+    "fig, axs = plt.subplots(1,2, figsize=(15, 5))\n",
+    "\n",
+    "axs[0].set_title(\"With diffuse emission substraction\")\n",
+    "axs[1].set_title(\"Without diffuse emission substraction\")\n",
+    "excess2.smooth(5).plot(cmap=\"coolwarm\", vmin = -10, vmax = 10, add_cbar=True, ax=axs[0]);\n",
+    "excess.smooth(5).plot(cmap=\"coolwarm\", vmin = -10, vmax = 10, add_cbar=True, ax=axs[1]);"
    ]
   },
   {
@@ -252,7 +420,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path = Path(\"analysis_3d\")\n",
+    "path = Path(\"TEST_analysis_3d\")\n",
     "path.mkdir(exist_ok=True)"
    ]
   },
@@ -260,7 +428,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the write the maps and IRFs to disk by calling the dedicated `.write()` methods:"
+    "And then write the maps and IRFs to disk by calling the dedicated `.write()` methods:"
    ]
   },
   {
@@ -311,7 +479,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's cut out only part of the maps, so that we the fitting step does not take so long:"
+    "Let's cut out only part of the maps, so that we the fitting step does not take so long (we go from left to right one):"
    ]
   },
   {
@@ -325,6 +493,22 @@
     "    for name, m in maps.items()\n",
     "}\n",
     "cmaps[\"counts\"].sum_over_axes().plot(stretch=\"sqrt\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Insted of the complete one, which was:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "counts.plot(stretch=\"sqrt\");"
    ]
   },
   {
@@ -373,7 +557,7 @@
    "source": [
     "### Model fit\n",
     "\n",
-    "No we are ready for the actual likelihood fit. We first define the model as a combination of a point source with a powerlaw:"
+    "No we are ready for the actual likelihood fit. We first define the model as a combination of a point source with an exponential cutt off power law:"
    ]
   },
   {
@@ -383,8 +567,11 @@
    "outputs": [],
    "source": [
     "spatial_model = SkyPointSource(lon_0=\"0.01 deg\", lat_0=\"0.01 deg\")\n",
-    "spectral_model = PowerLaw(\n",
-    "    index=2.2, amplitude=\"3e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
+    "spectral_model = ExponentialCutoffPowerLaw(\n",
+    "    index=2 * u.Unit(''),\n",
+    "    amplitude=1e-12 * u.Unit('cm-2 s-1 TeV-1'),\n",
+    "    reference=1. * u.TeV,\n",
+    "    lambda_=1 / u.TeV\n",
     ")\n",
     "model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)"
    ]
@@ -431,12 +618,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result.model)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Check model fit\n",
     "\n",
-    "Finally we check the model fit by cmputing a residual image. For this we first get the number of predicted counts from the fit evaluator:"
+    "We check the model fit by computing a residual image. For this we first get the number of predicted counts from the fit evaluator:"
    ]
   },
   {
@@ -472,7 +668,7 @@
    "outputs": [],
    "source": [
     "residual.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap=\"coolwarm\", vmin=-3, vmax=3, add_cbar=True\n",
+    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True\n",
     ");"
    ]
   },
@@ -502,10 +698,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exercises\n",
-    "\n",
-    "* Analyse the second source in the field of view: G0.9+0.1\n",
-    "* Run the model fit with energy dispersion (pass edisp to MapFit)"
+    "This result can be compared with the model used for the 1DC:"
    ]
   },
   {
@@ -513,7 +706,238 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "dc1_model = ExponentialCutoffPowerLaw(\n",
+    "    index = 2.14 * u.Unit(''),\n",
+    "    amplitude = 2.55e-12 * u.Unit('cm-2 s-1 TeV-1'),\n",
+    "    reference= 1. * u.TeV,\n",
+    "    lambda_= 0.0934 / u.TeV\n",
+    ")\n",
+    "dc1_model.parameters.to_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.model.parameters.to_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec = result.model.spectral_model\n",
+    "energy_range = [0.3, 10] * u.TeV\n",
+    "spec.plot(energy_range=energy_range, energy_power=2)\n",
+    "ax = spec.plot_error(energy_range=energy_range, energy_power=2)\n",
+    "ax = dc1_model.plot(energy_range, energy_power=2, color='red')\n",
+    "ax.legend(['Spectral Fit', 'DC1 model'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see this discrepancy between the fit and the DC1 model due to the diffuse emission... so let's improve this."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding galactic diffuse emission to model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use both models at the same time, our diffuse model (taken from 1DC idem file) and our previous model for the central source (note that we are not constraining the fit with any mask this time)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diffuse_model = SkyDiffuseCube.read(\"$CTADATA/models/cube_iem.fits.gz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "combined_fit = MapFit(\n",
+    "    model=diffuse_model+model,\n",
+    "    counts=cmaps[\"counts\"],\n",
+    "    exposure=cmaps[\"exposure\"],\n",
+    "    background=cmaps[\"background\"],\n",
+    "    psf=psf_kernel\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "result_combined=combined_fit.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(result_combined.model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see we have now two components in our model, and we can access them separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Checking normalization value (the closer to 1 the better)\n",
+    "print(\"FIRST MODEL (SkyDiffuseCube): \",result_combined.model.model1.parameters)\n",
+    "print(\"SECOND MODEL (SkyModel): \",result_combined.model.model2.parameters)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Obtaining a normalization parameter of 0.77, which is not bad... We can now plot the residual image considering this improved model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "npred_combined = combined_fit.evaluator.compute_npred()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.cm as cm\n",
+    "residual2 = Map.from_geom(cmaps[\"counts\"].geom)\n",
+    "residual2.data = cmaps[\"counts\"].data - npred_combined.data\n",
+    "residual2.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
+    "    cmap = cm.jet, vmin = -30, vmax=30, add_cbar=True\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just as a comparison, we can plot our previous residual map (left) and the new one (right) with the same scale:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1,2, figsize=(15, 5))\n",
+    "\n",
+    "axs[0].set_title(\"Without diffuse emission substraction\")\n",
+    "axs[1].set_title(\"With diffuse emission substraction\")\n",
+    "residual.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
+    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True, ax=axs[0]\n",
+    ");\n",
+    "residual2.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
+    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True, ax=axs[1]\n",
+    ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we can compare again our model (including now the diffuse emission) with the one used for the DC1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec2 = result_combined.model.model2.spectral_model\n",
+    "spec2.plot(energy_range=energy_range, energy_power=2)\n",
+    "ax = dc1_model.plot(energy_range, energy_power=2, color='red')\n",
+    "ax.legend(['Spectral Fit', 'DC1 model'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Results seems to be better (but not perfect yet). As an example, let's compare flux values at 1TeV for both models:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spec2.evaluate(energy=1*u.TeV, index = 2.079 * u.Unit(''), amplitude=2.662e-12 * u.Unit('cm-2 s-1 TeV-1'), \n",
+    "                   reference=1. * u.TeV, lambda_=1.149e-01 / u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dc1_model.evaluate(energy=1*u.TeV, index = 2.14 * u.Unit(''), amplitude=2.55e-12 * u.Unit('cm-2 s-1 TeV-1'), \n",
+    "                   reference=1. * u.TeV, lambda_=0.0934 / u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next step to improve our model even more would be getting rid of the other bright source (G0.9+0.1)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "* Analyse the second source in the field of view: G0.9+0.1 and add it to the combined model.\n",
+    "* Run the model fit with energy dispersion (pass edisp to MapFit with different true and reco energy bins)."
+   ]
   }
  ],
  "metadata": {

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -817,8 +817,8 @@
    "outputs": [],
    "source": [
     "#Checking normalization value (the closer to 1 the better)\n",
-    "print(\"FIRST MODEL (SkyDiffuseCube): \",result_combined.model.model1.parameters)\n",
-    "print(\"SECOND MODEL (SkyModel): \",result_combined.model.model2.parameters)"
+    "print(\"First model (SkyDiffuseCube): \",result_combined.model.model1.parameters)\n",
+    "print(\"Second model (SkyModel): \",result_combined.model.model2.parameters)"
    ]
   },
   {
@@ -834,21 +834,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "npred_combined = combined_fit.evaluator.compute_npred()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.cm as cm\n",
+    "npred_combined = combined_fit.evaluator.compute_npred()\n",
+    "\n",
     "residual2 = Map.from_geom(cmaps[\"counts\"].geom)\n",
-    "residual2.data = cmaps[\"counts\"].data - npred_combined.data\n",
-    "residual2.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap = cm.jet, vmin = -30, vmax=30, add_cbar=True\n",
-    ");"
+    "residual2.data = cmaps[\"counts\"].data - npred_combined.data"
    ]
   },
   {
@@ -864,15 +853,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axs = plt.subplots(1,2, figsize=(15, 5))\n",
+    "plt.figure(figsize=(15, 5))\n",
+    "ax_1 = plt.subplot(121, projection=residual.geom.wcs)\n",
+    "ax_2 = plt.subplot(122, projection=residual.geom.wcs)\n",
     "\n",
-    "axs[0].set_title(\"Without diffuse emission substraction\")\n",
-    "axs[1].set_title(\"With diffuse emission substraction\")\n",
+    "ax_1.set_title(\"Without diffuse emission subtraction\")\n",
+    "ax_2.set_title(\"With diffuse emission subtraction\")\n",
+    "\n",
     "residual.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True, ax=axs[0]\n",
+    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True, ax=ax_1\n",
     ");\n",
     "residual2.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True, ax=axs[1]\n",
+    "    cmap=\"coolwarm\", vmin = -40, vmax=40, add_cbar=True, ax=ax_2\n",
     ");"
    ]
   },
@@ -890,9 +882,9 @@
    "outputs": [],
    "source": [
     "spec2 = result_combined.model.model2.spectral_model\n",
-    "spec2.plot(energy_range=energy_range, energy_power=2)\n",
-    "ax = dc1_model.plot(energy_range, energy_power=2, color='red')\n",
-    "ax.legend(['Spectral Fit', 'DC1 model'])"
+    "ax = spec2.plot(energy_range=energy_range, energy_power=2, label='Spectral Fit')\n",
+    "dc1_model.plot(energy_range, energy_power=2, color='red', label='DC1 model', ax=ax)\n",
+    "plt.legend()"
    ]
   },
   {
@@ -908,8 +900,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spec2.evaluate(energy=1*u.TeV, index = 2.079 * u.Unit(''), amplitude=2.662e-12 * u.Unit('cm-2 s-1 TeV-1'), \n",
-    "                   reference=1. * u.TeV, lambda_=1.149e-01 / u.TeV)"
+    "spec2(energy=1*u.TeV)"
    ]
   },
   {
@@ -918,8 +909,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dc1_model.evaluate(energy=1*u.TeV, index = 2.14 * u.Unit(''), amplitude=2.55e-12 * u.Unit('cm-2 s-1 TeV-1'), \n",
-    "                   reference=1. * u.TeV, lambda_=0.0934 / u.TeV)"
+    "dc1_model(energy=1*u.TeV)"
    ]
   },
   {
@@ -935,9 +925,15 @@
    "source": [
     "## Exercises\n",
     "\n",
-    "* Analyse the second source in the field of view: G0.9+0.1 and add it to the combined model.\n",
-    "* Run the model fit with energy dispersion (pass edisp to MapFit with different true and reco energy bins)."
+    "* Analyse the second source in the field of view: G0.9+0.1 and add it to the combined model."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Hi!

In the Madrid Gammapy sprint code I modified the "analysis_3d.ipynb" tutorial notebook to add the galactic diffuse emission subtraction to our model in order to get a better agreement between 1DC input and model fit (with Axel's help). I have used some files from the DC1 (complete gps/index and cube_iem.fits) so the $CTADATA environment is needed (I have also added link to the DC1 website with information about how to download files and set environment variables).

I think this could be interesting to show how to treat different models at the same time and how to deal with diffuse emission as well, not only bright sources.

Thanks!

Ignacio Minaya