### PR TITLE
Change livetime for background

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -8,15 +8,16 @@ from ..maps import WcsNDMap
 __all__ = ["make_map_background_irf"]
 
 
-def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1):
+def make_map_background_irf(pointing, ontime, bkg, geom, n_integration_bins=1):
     """Compute background map from background IRFs.
 
     Parameters
     ----------
     pointing : `~astropy.coordinates.SkyCoord`
         Pointing direction
-    livetime : `~astropy.units.Quantity`
-        Observation livetime
+    ontime : `~astropy.units.Quantity`
+        Observation ontime. i.e. not corrected for deadtime
+        see https://gamma-astro-data-formats.readthedocs.io/en/stable/irfs/full_enclosure/bkg/index.html#notes)
     bkg : `~gammapy.irf.Background3D`
         Background rate model
     geom : `~gammapy.maps.WcsGeom`
@@ -55,7 +56,7 @@ def make_map_background_irf(pointing, livetime, bkg, geom, n_integration_bins=1)
             )
 
     d_omega = geom.solid_angle()
-    data = (bkg_de * d_omega * livetime).to("").value
+    data = (bkg_de * d_omega * ontime).to("").value
 
     return WcsNDMap(geom, data=data)
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -233,7 +233,7 @@ class MapMakerObs(object):
     def _make_background(self):
         background = make_map_background_irf(
             pointing=self.obs.pointing_radec,
-            livetime=self.obs.observation_live_time_duration,
+            ontime=self.obs.observation_time_duration,
             bkg=self.obs.bkg,
             geom=self.geom,
         )

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -54,7 +54,7 @@ def geom(map_type, ebounds):
 def test_make_map_background_irf(bkg_3d, pars):
     m = make_map_background_irf(
         pointing=SkyCoord(2, 1, unit="deg"),
-        livetime="42 s",
+        ontime="42 s",
         bkg=bkg_3d,
         geom=pars["geom"],
     )

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -42,7 +42,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 3.99815e+11,
             "exposure_image": 7.921993e+10,
-            "background": 187464.31,
+            "background": 191290.11,
         },
         {
             # Test single energy bin
@@ -51,7 +51,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e+11,
             "exposure_image": 1.16866e+11,
-            "background": 1987792.1,
+            "background": 2028359.4,
         },
         {
             # Test single energy bin with exclusion mask
@@ -61,7 +61,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e+11,
             "exposure_image": 1.16866e+11,
-            "background": 1987792.1,
+            "background": 2028359.4,
         },
         {
             # Test for different e_true and e_reco bins
@@ -70,7 +70,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 5.971096e+11,
             "exposure_image": 6.492968e+10,
-            "background": 187464.31,
+            "background": 191290.11,
         },
     ],
 )


### PR DESCRIPTION
This PR changes the calls to `make_map_background_irf`to take ontime i.e. (TSTOP-TSTART) rather than livetime (i.e. ontime corrected by dead time fraction) to follow the specifications presented in:
https://gamma-astro-data-formats.readthedocs.io/en/stable/irfs/full_enclosure/bkg/index.html#notes

docstring is changed as well as the call in `MapMakerObs`. Tests are updated accordingly.