### PR TITLE
Legend option for ReflectedRegionsBackgroundEstimator.plot()

### DIFF
--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -340,7 +340,7 @@ class ReflectedRegionsBackgroundEstimator(object):
         idx : int, optional
             Observations to include in the plot, default: all
         add_legend : boolean, optional
-            Enable/disable legend in the plot, defaul: False
+            Enable/disable legend in the plot, default: False
         """
         import matplotlib.pyplot as plt
 

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -330,7 +330,7 @@ class ReflectedRegionsBackgroundEstimator(object):
             method="Reflected Regions",
         )
 
-    def plot(self, fig=None, ax=None, cmap=None, idx=None):
+    def plot(self, fig=None, ax=None, cmap=None, idx=None, leg=False):
         """Standard debug plot.
 
         Parameters
@@ -339,6 +339,8 @@ class ReflectedRegionsBackgroundEstimator(object):
             Color map to use
         idx : int, optional
             Observations to include in the plot, default: all
+        leg : boolean, optional
+            Enable/disable legend in the plot, defaul: False
         """
         import matplotlib.pyplot as plt
 
@@ -383,6 +385,7 @@ class ReflectedRegionsBackgroundEstimator(object):
                 linewidths=3,
             )
 
-        ax.legend(handles=handles)
+        if leg:
+            ax.legend(handles=handles)
 
         return fig, ax, cbar

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -330,7 +330,7 @@ class ReflectedRegionsBackgroundEstimator(object):
             method="Reflected Regions",
         )
 
-    def plot(self, fig=None, ax=None, cmap=None, idx=None, leg=False):
+    def plot(self, fig=None, ax=None, cmap=None, idx=None, add_legend=False):
         """Standard debug plot.
 
         Parameters
@@ -339,7 +339,7 @@ class ReflectedRegionsBackgroundEstimator(object):
             Color map to use
         idx : int, optional
             Observations to include in the plot, default: all
-        leg : boolean, optional
+        add_legend : boolean, optional
             Enable/disable legend in the plot, defaul: False
         """
         import matplotlib.pyplot as plt
@@ -385,7 +385,7 @@ class ReflectedRegionsBackgroundEstimator(object):
                 linewidths=3,
             )
 
-        if leg:
+        if add_legend:
             ax.legend(handles=handles)
 
         return fig, ax, cbar

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -110,3 +110,5 @@ class TestReflectedRegionBackgroundEstimator:
             self.bg_maker.plot()
             self.bg_maker.plot(idx=1)
             self.bg_maker.plot(idx=[0, 1])
+            self.bg_maker.plot(add_legend=True)
+


### PR DESCRIPTION
As discussed in issue [#1847](https://github.com/gammapy/gammapy/issues/1847), I have added the option for adding the legend into the plot (set as False by default).