### PR TITLE
Correct TableModel and ConstantModel output dimension

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -552,7 +552,7 @@ class PowerLaw(SpectralModel):
     """
 
     def __init__(
-        self, index=2., amplitude=1E-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
+        self, index=2.0, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
     ):
         self.parameters = Parameters(
             [
@@ -708,7 +708,7 @@ class PowerLaw(SpectralModel):
         """
         p = self.parameters
         base = value / p["amplitude"].quantity
-        return p["reference"].quantity * np.power(base, -1. / p["index"].value)
+        return p["reference"].quantity * np.power(base, -1.0 / p["index"].value)
 
 
 class PowerLaw2(SpectralModel):
@@ -748,7 +748,7 @@ class PowerLaw2(SpectralModel):
 
     def __init__(
         self,
-        amplitude=1E-12 * u.Unit("cm-2 s-1"),
+        amplitude=1e-12 * u.Unit("cm-2 s-1"),
         index=2,
         emin=0.1 * u.TeV,
         emax=100 * u.TeV,
@@ -842,7 +842,7 @@ class PowerLaw2(SpectralModel):
             "emin"
         ].quantity.to("TeV").value ** (-index + 1)
         term = (bottom / top) * (value / p["amplitude"].quantity).to("1 / TeV")
-        return np.power(term.value, -1. / index) * u.TeV
+        return np.power(term.value, -1.0 / index) * u.TeV
 
 
 class ExponentialCutoffPowerLaw(SpectralModel):
@@ -880,7 +880,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
     def __init__(
         self,
         index=1.5,
-        amplitude=1E-12 * u.Unit("cm-2 s-1 TeV-1"),
+        amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
         reference=1 * u.TeV,
         lambda_=0.1 / u.TeV,
     ):
@@ -964,7 +964,7 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
     def __init__(
         self,
         index=1.5,
-        amplitude=1E-12 * u.Unit("cm-2 s-1 TeV-1"),
+        amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
         reference=1 * u.TeV,
         ecut=10 * u.TeV,
     ):
@@ -1031,7 +1031,7 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         self,
         index_1=1.5,
         index_2=2,
-        amplitude=1E-12 * u.Unit("cm-2 s-1 TeV-1"),
+        amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
         reference=1 * u.TeV,
         ecut=10 * u.TeV,
     ):
@@ -1105,7 +1105,7 @@ class LogParabola(SpectralModel):
 
     def __init__(
         self,
-        amplitude=1E-12 * u.Unit("cm-2 s-1 TeV-1"),
+        amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
         reference=10 * u.TeV,
         alpha=2,
         beta=1,
@@ -1200,14 +1200,11 @@ class TableModel(SpectralModel):
 
         interp_kwargs = interp_kwargs or {}
         interp_kwargs.setdefault("values_scale", "log")
-        
+
         self._evaluate = ScaledRegularGridInterpolator(
-            points=(np.log(energy.value),),
-            values=values.value,
-            **interp_kwargs
+            points=(np.log(energy.value),), values=values.value, **interp_kwargs
         )
-        
-    
+
     @classmethod
     def read_xspec_model(cls, filename, param, **kwargs):
         """Read XSPEC table model

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1285,6 +1285,7 @@ class TableModel(SpectralModel):
         """Evaluate the model (static function)."""
         x = np.log(energy.to(self.energy.unit).value)
         vals = self._evaluate(x, clip=True)
+        vals = np.reshape(vals, x.shape)
         return u.Quantity(norm.value * vals, self.values.unit, copy=False)
 
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -473,7 +473,7 @@ class ConstantModel(SpectralModel):
     @staticmethod
     def evaluate(energy, const):
         """Evaluate the model (static function)."""
-        return np.ones(len(np.atleast_1d(energy))) * const
+        return np.ones(np.atleast_1d(energy).shape) * const
 
 
 class CompoundSpectralModel(SpectralModel):

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -40,7 +40,7 @@ TEST_MODELS = [
             amplitude=4 / u.cm ** 2 / u.s / u.TeV,
             reference=1 * u.TeV,
         ),
-        val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), "cm-2 s-1 TeV-1"),
+        val_at_2TeV=u.Quantity(4 * 2.0 ** (-2.3), "cm-2 s-1 TeV-1"),
         integral_1_10TeV=u.Quantity(2.9227116204223784, "cm-2 s-1"),
         eflux_1_10TeV=u.Quantity(6.650836884969039, "TeV cm-2 s-1"),
     ),
@@ -63,7 +63,7 @@ TEST_MODELS = [
             emin=1 * u.TeV,
             emax=10 * u.TeV,
         ),
-        val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), "cm-2 s-1 TeV-1"),
+        val_at_2TeV=u.Quantity(4 * 2.0 ** (-2.3), "cm-2 s-1 TeV-1"),
         integral_1_10TeV=u.Quantity(2.9227116204223784, "cm-2 s-1"),
         eflux_1_10TeV=u.Quantity(6.650836884969039, "TeV cm-2 s-1"),
     ),
@@ -171,7 +171,7 @@ TEST_MODELS.append(
 TEST_MODELS.append(
     dict(
         name="compound5",
-        model=TEST_MODELS[0]["model"] - TEST_MODELS[0]["model"] / 2.,
+        model=TEST_MODELS[0]["model"] - TEST_MODELS[0]["model"] / 2.0,
         val_at_2TeV=0.5 * TEST_MODELS[0]["val_at_2TeV"],
         integral_1_10TeV=TEST_MODELS[0]["integral_1_10TeV"] * 0.5,
         eflux_1_10TeV=TEST_MODELS[0]["eflux_1_10TeV"] * 0.5,
@@ -185,7 +185,7 @@ try:
             name="table_model",
             model=table_model(),
             # Values took from power law expectation
-            val_at_2TeV=u.Quantity(4 * 2. ** (-2.3), "cm-2 s-1 TeV-1"),
+            val_at_2TeV=u.Quantity(4 * 2.0 ** (-2.3), "cm-2 s-1 TeV-1"),
             integral_1_10TeV=u.Quantity(2.9227116204223784, "cm-2 s-1"),
             eflux_1_10TeV=u.Quantity(6.650836884969039, "TeV cm-2 s-1"),
         )
@@ -211,7 +211,7 @@ def test_models(spectrum):
     )
 
     if "e_peak" in spectrum:
-        assert_quantity_allclose(model.e_peak, spectrum["e_peak"], rtol=1E-2)
+        assert_quantity_allclose(model.e_peak, spectrum["e_peak"], rtol=1e-2)
 
     # inverse for TableModel is not implemented
     if not (isinstance(model, TableModel) or isinstance(model, ConstantModel)):
@@ -223,7 +223,7 @@ def test_models(spectrum):
 
     # check that an array evaluation works (otherwise e.g. plotting raises an error)
     e_array = [2, 10, 20] * u.TeV
-    e_array = e_array[:,np.newaxis,np.newaxis]
+    e_array = e_array[:, np.newaxis, np.newaxis]
     val = model(e_array)
     assert val.shape == e_array.shape
     assert_quantity_allclose(val[0], spectrum["val_at_2TeV"])
@@ -292,8 +292,8 @@ def test_pwl_index_2_error():
     assert_quantity_allclose(flux_err, 9e-14 * u.Unit("cm-2 s-1"))
 
     eflux, eflux_err = pwl.energy_flux_error(1 * u.TeV, 10 * u.TeV)
-    assert_quantity_allclose(eflux, 2.302585E-12 * u.Unit("TeV cm-2 s-1"))
-    assert_quantity_allclose(eflux_err, 0.2302585E-12 * u.Unit("TeV cm-2 s-1"))
+    assert_quantity_allclose(eflux, 2.302585e-12 * u.Unit("TeV cm-2 s-1"))
+    assert_quantity_allclose(eflux_err, 0.2302585e-12 * u.Unit("TeV cm-2 s-1"))
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
+import numpy as np
 import astropy.units as u
 from ...utils.energy import EnergyBounds
 from ...utils.testing import assert_quantity_allclose
@@ -222,7 +223,9 @@ def test_models(spectrum):
 
     # check that an array evaluation works (otherwise e.g. plotting raises an error)
     e_array = [2, 10, 20] * u.TeV
+    e_array = e_array[:,np.newaxis,np.newaxis]
     val = model(e_array)
+    assert val.shape == e_array.shape
     assert_quantity_allclose(val[0], spectrum["val_at_2TeV"])
 
 

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -48,11 +48,12 @@ class ScaledRegularGridInterpolator(object):
             values = self._interpolate([points], method, **kwargs)
         else:
             values = self._interpolate(points, method, **kwargs)
+            values = np.reshape(values,points.shape)
+
         values = self.scale.inverse(values)
 
         if clip:
             np.clip(values, 0, np.inf, out=values)
-
         return values
 
 

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -76,7 +76,9 @@ def interpolation_scale(scale="lin"):
 
 class LogScale(object):
     """Logarithmic scaling"""
+
     tiny = np.finfo(np.float32).tiny
+
     def __call__(self, values):
         values = np.clip(values, self.tiny, np.inf)
         return np.log(values)

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -48,7 +48,6 @@ class ScaledRegularGridInterpolator(object):
             values = self._interpolate([points], method, **kwargs)
         else:
             values = self._interpolate(points, method, **kwargs)
-            values = np.reshape(values,points.shape)
 
         values = self.scale.inverse(values)
 


### PR DESCRIPTION
This PR comes to correct #1869.
The problem arose because `SkyModel.evaluate` uses numpy broadcasting. The spectrum has to have a dimension `(n,1,1)` to be properly broadcast when multiplied with the spatial model.
This was not the case with the `TableModel`. 
A `numpy.reshape` is added in `TableModel.evaluate` to ensure dimension is conserved. 

A test is also added on spectral models to check that the dimensions of input and output quantities are equal. This required to modify `ConstantModel` which did not follow the rule.  
 