### PR TITLE
changed optional arguments to TableModel

### DIFF
--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -689,7 +689,7 @@
    "version": "3.6.0"
   },
   "toc": {
-   "base_numbering": 1,
+   "base_numbering": 1.0,
    "nav_menu": {
     "height": "237px",
     "width": "253px"
@@ -706,9 +706,9 @@
   },
   "varInspector": {
    "cols": {
-    "lenName": 16,
-    "lenType": 16,
-    "lenVar": 40
+    "lenName": 16.0,
+    "lenType": 16.0,
+    "lenVar": 40.0
    },
    "kernels_config": {
     "python": {

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -409,7 +409,7 @@
    "outputs": [],
    "source": [
     "filename = \"$GAMMAPY_FERMI_LAT_DATA/isodiff/iso_P8R2_SOURCE_V6_v06.txt\"\n",
-    "interp_kwargs = {\"fill_value\": \"extrapolate\", \"kind\": \"cubic\"}\n",
+    "interp_kwargs = {\"fill_value\": None}\n",
     "diffuse_iso = TableModel.read_fermi_isotropic_model(\n",
     "    filename=filename, interp_kwargs=interp_kwargs\n",
     ")"


### PR DESCRIPTION
After PR #1855, `TableModel` is no longer based on spline interpolation, but on the `ScaledGridInterpolator` the options are therefore different (e.g. no cubic interpolation).

This PR updates arguments  in fermi_lat.ipynb 