### PR TITLE
ReflectedRegionsBackgroundEstimator.plot legend in spectrum_analysis.ipynb

### DIFF
--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -256,7 +256,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(8, 8))\n",
-    "background_estimator.plot()"
+    "background_estimator.plot(add_legend=True)"
    ]
   },
   {


### PR DESCRIPTION
Just a really quick update on the notebook (as suggested yesterday by @registerrier in #1870) to reflect the change on the ReflectedRegionsBackgroundEstimator.plot() legend option.