### PR TITLE
Remove shell out in subprocess calls

### DIFF
--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -45,17 +45,19 @@ def execute_notebook(path, kernel="python3", loglevel=20):
 
     try:
         t = time.time()
-        subprocess.call(
-            "jupyter nbconvert "
-            "--allow-errors "
-            "--log-level={} "
-            "--ExecutePreprocessor.timeout=None "
-            "--ExecutePreprocessor.kernel_name={} "
-            "--to notebook "
-            "--inplace "
-            "--execute '{}'".format(loglevel, kernel, path),
-            shell=True,
-        )
+        cmd = [
+            sys.executable, "-m", "jupyter", "nbconvert",
+            "--allow-errors",
+            "--log-level={}".format(loglevel),
+            "--ExecutePreprocessor.timeout=None",
+            "--ExecutePreprocessor.kernel_name={}".format(kernel),
+            "--to",
+            "notebook",
+            "--inplace",
+            "--execute",
+            "{}".format(path)
+        ]
+        subprocess.call(cmd)
         t = (time.time() - t) / 60
         log.info("   ... Executing duration: {:.2f} mn".format(t))
     except Exception as ex:

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -87,8 +87,12 @@ def build_notebooks(args):
         sys.exit()
 
     # strip and blackformat
-    subprocess.call("gammapy jupyter --src temp black", shell=True)
-    subprocess.call("gammapy jupyter --src temp strip", shell=True)
+    subprocess.call(
+        [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "black"]
+    )
+    subprocess.call(
+        [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "strip"]
+    )
 
     # test /run
     passed = True
@@ -105,7 +109,15 @@ def build_notebooks(args):
         copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignoreall)
         for path in path_static_nbs.glob("*.ipynb"):
             subprocess.call(
-                "jupyter nbconvert --to script '{}'".format(str(path)), shell=True
+                [
+                    sys.executable,
+                    "-m",
+                    "jupyter",
+                    "nbconvert",
+                    "--to",
+                    "script",
+                    "{}".format(str(path)),
+                ]
             )
         copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
     else:
@@ -113,7 +125,15 @@ def build_notebooks(args):
         pathdest = path_static_nbs / notebookname
         copyfile(str(pathsrc), str(pathdest))
         subprocess.call(
-            "jupyter nbconvert --to script '{}'".format(str(pathdest)), shell=True
+            [
+                sys.executable,
+                "-m",
+                "jupyter",
+                "nbconvert",
+                "--to",
+                "script",
+                "{}".format(str(pathdest)),
+            ]
         )
         pathdest = path_filled_nbs / notebookname
         copyfile(str(pathsrc), str(pathdest))


### PR DESCRIPTION
This PR modifies the way how subprocess calls to `gammapy jupyter` and `jupyter nbconvert` are done in scripts used to build the documentation and execute notebooks from the command line. This PR aims to solve issue https://github.com/gammapy/gammapy/issues/1876