### PR TITLE
Remove infinite values from models

### DIFF
--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -49,7 +49,7 @@ class SkySpatialModel(object):
         for par in self.parameters.parameters:
             kwargs[par.name] = par.quantity
 
-        return self.evaluate(lon, lat, **kwargs)
+        return np.nan_to_num(self.evaluate(lon, lat, **kwargs),copy=False)
 
     def copy(self):
         """A deep copy."""

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -5,6 +5,7 @@ import numpy as np
 import copy
 import operator
 import astropy.units as u
+from astropy.units import Quantity
 from astropy.table import Table
 from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
@@ -565,7 +566,7 @@ class PowerLaw(SpectralModel):
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
         """Evaluate the model (static function)."""
-        return amplitude * np.power((energy / reference), -index)
+        return amplitude*np.power(energy / reference, -index)
 
     def integral(self, emin, emax, **kwargs):
         r"""Integrate power law analytically.

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -566,7 +566,7 @@ class PowerLaw(SpectralModel):
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
         """Evaluate the model (static function)."""
-        return amplitude*np.power(energy / reference, -index)
+        return amplitude * np.power(energy / reference, -index)
 
     def integral(self, emin, emax, **kwargs):
         r"""Integrate power law analytically.

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -61,7 +61,7 @@ class SpectralModel(object):
         for par in self.parameters.parameters:
             kwargs[par.name] = par.quantity
 
-        return self.evaluate(energy, **kwargs)
+        return np.nan_to_num(self.evaluate(energy, **kwargs), copy=False)
 
     def __mul__(self, model):
         if not isinstance(model, SpectralModel):

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
+from numpy.testing import assert_allclose
 import astropy.units as u
 from ...utils.energy import EnergyBounds
 from ...utils.testing import assert_quantity_allclose
@@ -304,3 +305,13 @@ def test_fermi_isotropic():
     assert_quantity_allclose(
         model(50 * u.GeV), 1.463 * u.Unit("1e-13 MeV-1 cm-2 s-1 sr-1"), rtol=1e-3
     )
+
+def test_finite_values():
+    pars=dict()
+    pars["amplitude"] = 1e-12 * u.Unit("TeV-1 cm-2 s-1")
+    pars["reference"] = 1 * u.Unit("TeV")
+    pars["index"] = 200 * u.Unit("")
+    pwl = PowerLaw(**pars)
+
+    res = pwl(0.001*u.TeV)
+    assert_allclose(np.isinf(res), False)


### PR DESCRIPTION
At the moment, models can return infinite values for some weird choice of parameters. This likely contributes to issue #1868 . In this case the minimizer tests spectral indices as large as 100 and `PowerLaw.__calc__` can return `np.inf` which breaks the statistics evaluation.

This PR adds `numpy.nan_to_num` in `Model.__calc__` methods to prevent such situations to happen. A test is added too.