### PR TITLE
corrected simulate_3d.ipynb

### DIFF
--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -156,7 +156,7 @@
    "outputs": [],
    "source": [
     "background = make_map_background_irf(\n",
-    "    pointing=pointing, livetime=livetime, bkg=irfs[\"bkg\"], geom=geom\n",
+    "    pointing=pointing, ontime=livetime, bkg=irfs[\"bkg\"], geom=geom\n",
     ")\n",
     "background.slice_by_idx({\"energy\": 3}).plot(add_cbar=True);"
    ]

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -266,6 +266,11 @@
     "    index=2, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
     "model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)\n",
+    "\n",
+    "# Impose that specrtal index remains within limits\n",
+    "spectral_model.parameters['index'].min = 0.\n",
+    "spectral_model.parameters['index'].max = 10.\n",
+    "\n",
     "print(model)"
    ]
   },


### PR DESCRIPTION
The PR introduces some correction to the simulation and fitting notebook simulate_3d.ipynb by adding min and max value to the spectral index. This helps the fit to converge.
Also the argument `livetime` is changed to `ontime` in the call to `make_background_irf`.