### PR TITLE
Force parameter numbers to float

### DIFF
--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -67,7 +67,7 @@ class Parameter(object):
 
     @factor.setter
     def factor(self, val):
-        self._factor = check_type(val, "number")
+        self._factor = float(val)
 
     @property
     def scale(self):
@@ -76,7 +76,7 @@ class Parameter(object):
 
     @scale.setter
     def scale(self, val):
-        self._scale = check_type(val, "number")
+        self._scale = float(val)
 
     @property
     def unit(self):
@@ -173,7 +173,7 @@ class Parameter(object):
             value = self.value
             if value != 0:
                 power = int(np.log10(np.absolute(value)))
-                scale = 10 ** power
+                scale = float(10 ** power)
                 self.factor = value / scale
                 self.scale = scale
         elif method == "factor1":

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -392,14 +392,17 @@ class Parameters(object):
         for factor, parameter in zip(factors, self.parameters):
             parameter.factor = factor
 
+    @property
+    def _scale_matrix(self):
+        scales = [par.scale for par in self.parameters]
+        return np.outer(scales, scales)
+
     def set_covariance_factors(self, matrix):
         """Set covariance from factor covariance matrix.
 
         Used in the optimiser interface.
         """
-        scales = np.array([par.scale for par in self.parameters])
-        scale_matrix = scales[:, np.newaxis] * scales
-        self.covariance = scale_matrix * matrix
+        self.covariance = self._scale_matrix * matrix
 
     def autoscale(self, method="scale10"):
         """Autoscale all parameters.

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -112,13 +112,10 @@ def test_parameters_set_parameter_factors(pars):
     assert_allclose(pars["ham"].scale, 1)
 
 
-def _test_parameters_set_covariance_factors(pars):
+def test_parameters_set_covariance_factors(pars):
     cov_factor = [[3, 4], [7, 8]]
     pars.set_covariance_factors(cov_factor)
-
-    assert isinstance(pars.covariance, np.ndarray)
-    cov_value = [[0, 0], [0, 0]]
-    assert_allclose(pars.covariance, cov_value)
+    assert_allclose(pars.covariance, cov_factor)
 
 
 def test_parameters_scale():

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -11,8 +11,11 @@ def test_parameter_init():
     par = Parameter("spam", 42, "deg")
     assert par.name == "spam"
     assert par.factor == 42
+    assert isinstance(par.factor, float)
     assert par.scale == 1
+    assert isinstance(par.scale, float)
     assert par.value == 42
+    assert isinstance(par.value, float)
     assert par.unit == "deg"
     assert par.min is np.nan
     assert par.max is np.nan
@@ -25,12 +28,6 @@ def test_parameter_init():
 
     with pytest.raises(TypeError):
         Parameter(1, 2)
-
-    p = Parameter("spam", 42)
-    with pytest.raises(TypeError):
-        p.factor = "99"
-    with pytest.raises(TypeError):
-        p.scale = "99"
 
 
 def test_parameter_value():
@@ -66,6 +63,15 @@ def test_parameter_to_dict():
     par = Parameter("spam", 42, "deg")
     d = par.to_dict()
     assert isinstance(d["unit"], six.string_types)
+
+
+def test_parameter_large():
+    # Test case for Parameter with very large value
+    # Regression test for https://github.com/gammapy/gammapy/issues/1883
+    par = Parameter("a", 9e35)
+    par.autoscale()
+    assert_allclose(par.scale, 1e35)
+    assert isinstance(par.scale, float)
 
 
 @pytest.fixture()


### PR DESCRIPTION
I noticed that fitting very large parameters, like 1e35, fails in a weird way:
https://github.com/gammasky/joint-crab/pull/155

The problem comes because `int ** int` in Python creates bit int numbers, and when passed to Numpy, those are stored as Python int objects in an array of dtype object:
```
>>> import numpy as np
>>> (10 ** 35).bit_length()
117
>>> np.array(10 ** 35)
array(100000000000000000000000000000000000, dtype=object)
>>> np.array(1e35)
array(1.e+35)
```

In Gammapy these types are created here:

https://github.com/gammapy/gammapy/blob/045980e8ad1d5ab64cefab52469865d47c072759/gammapy/utils/fitting/parameter.py#L175-L178

And then a covariance matrix of dtype object is created here:

https://github.com/gammapy/gammapy/blob/045980e8ad1d5ab64cefab52469865d47c072759/gammapy/utils/fitting/parameter.py#L395-L402

And then operations that assume float numbers fail.

One simple solution is to always convert `par.factor` and `par.scale` to `float`, which is the Python 64-bit float type. This would be mu suggestion. Currently there is a property setter, which also lets through other number types.