### PR TITLE
Map arithmetics

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1072,3 +1072,17 @@ class Map(object):
             out.data *= Quantity(other).value
             out.unit = out.unit * Quantity(other).unit
         return out
+
+    def __truediv__(self, other):
+        """ Divide two maps with compatible geometries together. Adapt unit accordingly.
+        """
+        out = self.copy()
+        if isinstance(other, Map):
+            # check consistency
+            # self.geom._check_compatibility(other.geom)
+            out.data /= other.data
+            out.unit = out.unit/other.unit
+        else:
+            out.data /= Quantity(other).value
+            out.unit = out.unit / Quantity(other).unit
+        return out

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1040,7 +1040,7 @@ class Map(object):
         out = self.copy()
         if isinstance(other, Map):
             # check consistency
-            #self.geom._check_compatibility(other.geom)
+            self.geom._check_compatibility(other.geom)
             out.data += other.quantity.to(self.unit).value
         else:
             out.data += Quantity(other).to(self.unit).value
@@ -1052,7 +1052,7 @@ class Map(object):
         out = self.copy()
         if isinstance(other, Map):
             # check consistency
-            # self.geom._check_compatibility(other.geom)
+            self.geom._check_compatibility(other.geom)
             out.data -= other.quantity.to(self.unit).value
         else:
             out.data -= Quantity(other).to(self.unit).value
@@ -1065,7 +1065,7 @@ class Map(object):
         out = self.copy()
         if isinstance(other, Map):
             # check consistency
-            # self.geom._check_compatibility(other.geom)
+            self.geom._check_compatibility(other.geom)
             out.data *= other.data
             out.unit = out.unit*other.unit
         else:
@@ -1079,7 +1079,7 @@ class Map(object):
         out = self.copy()
         if isinstance(other, Map):
             # check consistency
-            # self.geom._check_compatibility(other.geom)
+            self.geom._check_compatibility(other.geom)
             out.data /= other.data
             out.unit = out.unit/other.unit
         else:

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -7,6 +7,7 @@ import json
 import numpy as np
 from collections import OrderedDict
 from astropy import units as u
+from astropy.units import Quantity
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from .geom import pix_tuple_to_idx, MapCoord
@@ -1032,3 +1033,42 @@ class Map(object):
         str_ += "\tunit  : {!r} \n".format(str(self.unit))
         str_ += "\tdtype : {} \n".format(self.data.dtype)
         return str_
+
+    def __add__(self, other):
+        """ Add two maps with compatible geometries and units together
+        """
+        out = self.copy()
+        if isinstance(other, Map):
+            # check consistency
+            #self.geom._check_compatibility(other.geom)
+            out.data += other.quantity.to(self.unit).value
+        else:
+            out.data += Quantity(other).to(self.unit).value
+        return out
+
+    def __sub__(self, other):
+        """ Subtract two maps with compatible geometries and units together
+        """
+        out = self.copy()
+        if isinstance(other, Map):
+            # check consistency
+            # self.geom._check_compatibility(other.geom)
+            out.data -= other.quantity.to(self.unit).value
+        else:
+            out.data -= Quantity(other).to(self.unit).value
+
+        return out
+
+    def __mul__(self, other):
+        """ Multiply two maps with compatible geometries together. Adapt unit accordingly.
+        """
+        out = self.copy()
+        if isinstance(other, Map):
+            # check consistency
+            # self.geom._check_compatibility(other.geom)
+            out.data *= other.data
+            out.unit = out.unit*other.unit
+        else:
+            out.data *= Quantity(other).value
+            out.unit = out.unit * Quantity(other).unit
+        return out

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -600,6 +600,14 @@ class MapAxis(object):
         """Copy `MapAxis` object"""
         return copy.deepcopy(self)
 
+    def _check_compatibility(self, other):
+        """Check if two axes objects are compatible with each other"""
+        from ..utils.testing import assert_quantity_allclose
+        try:
+            assert_quantity_allclose(self.edges*self.unit, other.edges*other.unit)
+        except:
+            raise ValueError("Inconsistent MapAxis")
+
 
 class MapCoord(object):
     """Represents a sequence of n-dimensional map coordinates.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1330,6 +1330,11 @@ class MapGeom(object):
         """Solid angle (`~astropy.units.Quantity` in ``sr``)."""
         pass
 
+    @abc.abstractmethod
+    def _check_compatibility(self, other):
+        """Check compatibility of two geoms"""
+        pass
+
     def _fill_header_from_axes(self, header):
         for idx, ax in enumerate(self.axes, start=1):
             key = "AXCOLS%i" % idx

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1732,6 +1732,28 @@ class HpxGeom(MapGeom):
         str_ += "\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
         return str_
 
+    def _check_compatibility(self, other):
+        # check overall shape and axes compatibility
+        if self.data_shape != other.data_shape:
+            raise ValueError("MapGeom data shapes differ")
+        for axis, otheraxis in zip(self.axes, other.axes):
+            axis._check_compatibility(otheraxis)
+
+        # check healpix geometry consistency
+        if self.nside != other.nside:
+            raise ValueError("HpxGeom differ")
+        if self.coordsys != other.coordsys:
+            raise ValueError("HpxGeom differ")
+        if self.order != other.order:
+            raise ValueError("HpxGeom differ")
+        if self.center_pix != other.center_pix:
+            raise ValueError("HpxGeom differ")
+        if self.center_coord != other.center_coord:
+            raise ValueError("HpxGeom differ")
+        if self.sparse or other.sparse:
+            raise ValueError("sparse geometries not supported")
+        if self.is_allsky and other.is_allsky is False:
+            raise ValueError("Non allsky HpxGeom not supported")
 
 class HpxToWcsMapping(object):
     """Stores the indices need to convert from HEALPIX to WCS.

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1750,7 +1750,7 @@ class HpxGeom(MapGeom):
             raise ValueError("HpxGeom differ")
         if self.center_coord != other.center_coord:
             raise ValueError("HpxGeom differ")
-        if self.sparse or other.sparse:
+        if self._sparse or other._sparse:
             raise ValueError("sparse geometries not supported")
         if self.is_allsky and other.is_allsky is False:
             raise ValueError("Non allsky HpxGeom not supported")

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -316,3 +316,21 @@ def test_map_reproject_hpx_to_wcs():
     m_r = m.reproject(geom_wcs)
     actual = m_r.get_by_coord({"lon": 0, "lat": 0, "energy": [1.0, 3.16227766, 10.0]})
     assert_allclose(actual, [287.5, 1055.5, 1823.5], rtol=1e-3)
+
+def test_mapaxis_compatibility():
+    axis1 = MapAxis(nodes=(1, 2, 3, 4), unit='TeV', node_type='center')
+    axis2 = MapAxis(nodes=(1, 2, 3, 4), unit='TeV', node_type='edges')
+    axis3 = MapAxis(nodes=(1, 2, 3, 4), unit='GeV', node_type='center')
+    axis4 = MapAxis(nodes=(1, 2, 3, 4), unit='cm', node_type='center')
+    axis5 = MapAxis(nodes=(1, 2, 3, 4), unit='TeV', node_type='center', interp='log')
+    axis6 = MapAxis(nodes=(0.5, 1.5, 2.5, 3.5, 4.5), unit='TeV', node_type='edges')
+
+    with pytest.raises(ValueError):
+        axis1._check_compatibility(axis2)
+    with pytest.raises(ValueError):
+        axis1._check_compatibility(axis3)
+    with pytest.raises(ValueError):
+        axis1._check_compatibility(axis4)
+    with pytest.raises(ValueError):
+        axis1._check_compatibility(axis5)
+    axis1._check_compatibility(axis6)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -733,3 +733,26 @@ def test_geom_repr():
     geom = HpxGeom(nside=8)
     assert geom.__class__.__name__ in repr(geom)
     assert "nside" in repr(geom)
+
+hpx_compatibility_test_geoms = [
+    (16, False, "GAL", None, True),
+    (16, True, "GAL", None, False),
+    (8, False, "GAL", None, False),
+    (16, False, "CEL", None, False),
+    (16, False, "GAL", "DISK(110.,75.,10.)", False)
+]
+
+@pytest.mark.parametrize(
+    ("nside", "nested", "coordsys", "region", "result"), hpx_compatibility_test_geoms
+)
+
+def test_geom_compatibility(nside, nested, coordsys, region, result):
+    geom0 = HpxGeom(16, False, "GAL", region=None)
+    geom1 = HpxGeom(nside, nested, coordsys, region=region)
+
+    if result is False:
+        with pytest.raises(ValueError):
+            geom0._check_compatibility(geom1)
+    else:
+        geom0._check_compatibility(geom1)
+

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -13,7 +13,7 @@ from ..hpx import HpxGeom
 from ..hpxmap import HpxMap
 from ..hpxnd import HpxNDMap
 from ..hpxsparse import HpxSparseMap
-from ...utils.testing import mpl_plot_check, requires_dependency
+from ...utils.testing import mpl_plot_check, requires_dependency, assert_quantity_allclose
 
 pytest.importorskip("scipy")
 pytest.importorskip("healpy")
@@ -382,3 +382,26 @@ def test_plot_poly():
     m = HpxNDMap.create(binsz=10)
     with mpl_plot_check():
         m.plot(method="poly")
+
+def test_hpxmap_addition_subtraction():
+    map1 = HpxMap.create(nside=8, unit='cm2')
+    map2 = HpxMap.create(nside=8, unit='m2')
+
+    map1 += 1*u.cm**2
+    map2 += 1*u.cm**2
+    assert_allclose(map2.data, 1e-4)
+    map3 = map1 - map2
+    assert_quantity_allclose(map3.quantity, 0*u.cm**2)
+
+def test_hpxmap_multiplication_division():
+    map1 = HpxMap.create(nside=8, unit='cm2')
+    map2 = HpxMap.create(nside=8, unit='s')
+    map3 = HpxMap.create(nside=8, unit='')
+
+    map1 += 1*u.m**2
+    map2 += 1000 * u.s
+    expo = map1 * map2
+    assert_quantity_allclose(expo.quantity, 1e7*u.cm**2*u.s)
+    map3.data += 1.0
+    flux = map3 / expo
+    assert_quantity_allclose(flux.quantity, 1e-7*u.cm**-2*u.s**-1)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -316,7 +316,7 @@ compatibility_test_geoms = [
 )
 def test_geom_compatibility(npix, binsz, coordsys, proj, skypos, axes, result):
     geom0 = WcsGeom.create(
-        skydir=skydir, npix=10, binsz=0.1, proj="CAR", coordsys="GAL", axes=axes
+        skydir=skydir, npix=10, binsz=0.1, proj="CAR", coordsys="GAL", axes=test_axis1
     )
     geom1 = WcsGeom.create(
         skydir=skypos, npix=npix, binsz=binsz, proj=proj, coordsys=coordsys, axes=axes
@@ -324,6 +324,6 @@ def test_geom_compatibility(npix, binsz, coordsys, proj, skypos, axes, result):
 
     if result is False:
         with pytest.raises(ValueError):
-            geom._check_compatibility(geom1)
+            geom0._check_compatibility(geom1)
     else:
-        geom._check_compatibility(geom1)
+        geom0._check_compatibility(geom1)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -296,3 +296,21 @@ def test_get_axis_index_by_name():
     assert geom.get_axis_index_by_name("Energy") == 0
     with pytest.raises(ValueError):
         geom.get_axis_index_by_name("time")
+
+
+test_axis1 = [MapAxis(nodes=(1,2,3,4), unit='TeV', node_type='center')]
+test_axis2 = [MapAxis(nodes=(1,2,3,4), unit='TeV', node_type='center'),
+              MapAxis(nodes=(1,2,3), unit='TeV', node_type='center')]
+
+
+compatibility_test_geoms = [
+    (10, 0.1, "GAL", "CAR", skydir, test_axis1),
+    (10, 0.1, "GAL", "CAR", skydir, test_axis2),
+    (10, 0.1, "GAL", "CAR", skydir.galactic, test_axis1),
+]
+
+@pytest.mark.parametrize(
+    ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
+)
+def test_geom_compatibility(npix, binsz, coordsys, proj, skydir, axes):
+    

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -304,13 +304,26 @@ test_axis2 = [MapAxis(nodes=(1,2,3,4), unit='TeV', node_type='center'),
 
 
 compatibility_test_geoms = [
-    (10, 0.1, "GAL", "CAR", skydir, test_axis1),
-    (10, 0.1, "GAL", "CAR", skydir, test_axis2),
-    (10, 0.1, "GAL", "CAR", skydir.galactic, test_axis1),
+    (10, 0.1, "GAL", "CAR", skydir, test_axis1, True),
+    (10, 0.1, "GAL", "TAN", skydir, test_axis1, False),
+    (8, 0.1, "GAL", "CAR", skydir, test_axis1, False),
+    (10, 0.1, "GAL", "CAR", skydir, test_axis2, False),
+    (10, 0.1, "GAL", "CAR", skydir.galactic, test_axis1, True)
 ]
 
 @pytest.mark.parametrize(
-    ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
+    ("npix", "binsz", "coordsys", "proj", "skypos", "axes", "result"), compatibility_test_geoms
 )
-def test_geom_compatibility(npix, binsz, coordsys, proj, skydir, axes):
-    
+def test_geom_compatibility(npix, binsz, coordsys, proj, skypos, axes, result):
+    geom0 = WcsGeom.create(
+        skydir=skydir, npix=10, binsz=0.1, proj="CAR", coordsys="GAL", axes=axes
+    )
+    geom1 = WcsGeom.create(
+        skydir=skypos, npix=npix, binsz=binsz, proj=proj, coordsys=coordsys, axes=axes
+    )
+
+    if result is False:
+        with pytest.raises(ValueError):
+            geom._check_compatibility(geom1)
+    else:
+        geom._check_compatibility(geom1)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -566,4 +566,3 @@ def test_wcsmap_multiplication_division():
     map3.data += 1.0
     flux = map3 / expo
     assert_quantity_allclose(flux.quantity, 1e-7*u.cm**-2*u.s**-1)
-    

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -544,7 +544,7 @@ def test_plot_allsky():
     with mpl_plot_check():
         m.plot()
 
-def map_addition_subtraction():
+def test_wcsmap_addition_subtraction():
     map1 = WcsNDMap.create(skydir=(0, 0), unit='cm2', binsz=0.1, npix=(10, 10))
     map2 = WcsNDMap.create(skydir=(0, 0), unit='m2', binsz=0.1, npix=(10, 10))
 
@@ -554,7 +554,7 @@ def map_addition_subtraction():
     map3 = map1 - map2
     assert_quantity_allclose(map3.quantity, 0*u.cm**2)
 
-def map_multiplication_division():
+def test_wcsmap_multiplication_division():
     map1 = WcsNDMap.create(skydir=(0, 0), unit='cm2', binsz=0.1, npix=(10, 10))
     map2 = WcsNDMap.create(skydir=(0, 0), unit='s', binsz=0.1, npix=(10, 10))
     map3 = WcsNDMap.create(skydir=(0, 0), unit='', binsz=0.1, npix=(10, 10))
@@ -563,7 +563,7 @@ def map_multiplication_division():
     map2 += 1000 * u.s
     expo = map1 * map2
     assert_quantity_allclose(expo.quantity, 1e7*u.cm**2*u.s)
-    flux.data += 1.0
+    map3.data += 1.0
     flux = map3 / expo
-    assert_allclose(flux.data, 1e-7)
-    assert flux.unit == Unit('cm-2 s-1')
+    assert_quantity_allclose(flux.quantity, 1e-7*u.cm**-2*u.s**-1)
+    

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -882,6 +882,16 @@ class WcsGeom(MapGeom):
         )
         return str_
 
+    def _check_compatibility(self, other):
+        # check overall shape and axes compatibility
+        if self.data_shape != other.data_shape:
+            raise ValueError("MapGeom data shapes differ")
+#        for axis, otheraxis in zip(self.axes, other.axes):
+#            axis._check_compatibility(otheraxis)
+
+        # check WCS consistency
+        if self.wcs.wcs.compare(other.wcs.wcs):
+            raise ValueError("MapGeom WCS differ")
 
 def create_wcs(
     skydir, coordsys="CEL", projection="AIT", cdelt=1.0, crpix=1.0, axes=None

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -890,7 +890,7 @@ class WcsGeom(MapGeom):
 #            axis._check_compatibility(otheraxis)
 
         # check WCS consistency
-        if self.wcs.wcs.compare(other.wcs.wcs):
+        if self.wcs.wcs.compare(other.wcs.wcs) is False:
             raise ValueError("MapGeom WCS differ")
 
 def create_wcs(

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -886,8 +886,8 @@ class WcsGeom(MapGeom):
         # check overall shape and axes compatibility
         if self.data_shape != other.data_shape:
             raise ValueError("MapGeom data shapes differ")
-#        for axis, otheraxis in zip(self.axes, other.axes):
-#            axis._check_compatibility(otheraxis)
+        for axis, otheraxis in zip(self.axes, other.axes):
+            axis._check_compatibility(otheraxis)
 
         # check WCS consistency
         if self.wcs.wcs.compare(other.wcs.wcs) is False:


### PR DESCRIPTION
This PR solves issue #1873 introducing addition, subtraction, multiplication and division for `gammapy.maps`.
A `_check_consistency` method is added on `MapAxis`, `WcsGeom` and `HpxGeom` to check that maps have identical geometries. 
Operation with simple quantities are also supported e.g. map += 1e7*u.s*u.m**2

Quantities are converted for addition and subtraction raising an error if units are incompatible and for multiplication and division the units are respectively multiplied and divided.
