### PR TITLE
Introducing the Observations class

### DIFF
--- a/gammapy/background/phase.py
+++ b/gammapy/background/phase.py
@@ -24,7 +24,7 @@ class PhaseBackgroundEstimator(object):
     ----------
     on_region : `~regions.CircleSkyRegion`
         Target region in the sky
-    obs_list : `~gammapy.data.ObservationList`
+    obs_list : `~gammapy.data.Observations`
         Observations to process
     on_phase : `tuple` or list of tuples
         on-phase defined by the two edges of each interval (edges are excluded)

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -280,7 +280,7 @@ class ReflectedRegionsBackgroundEstimator(object):
     ----------
     on_region : `~regions.CircleSkyRegion`
         Target region
-    obs_list : `~gammapy.data.ObservationList`
+    obs_list : `~gammapy.data.Observations`
         Observations to process
     kwargs : dict
         Forwarded to `gammapy.background.ReflectedRegionsFinder`

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -53,8 +53,8 @@ class MapMaker(object):
 
         Parameters
         --------------
-        obs_list : `~gammapy.data.ObservationList`
-            List of observations
+        obs_list : `~gammapy.data.Observations`
+            Observations to process
         selection : list
             List of str, selecting which maps to make.
             Available: 'counts', 'exposure', 'background'

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -7,7 +7,7 @@ from ..utils.testing import Checker
 from .obs_table import ObservationTable
 from .hdu_index_table import HDUIndexTable
 from .obs_table import ObservationTableChecker
-from .observations import DataStoreObservation, ObservationList, ObservationChecker
+from .observations import DataStoreObservation, Observations, ObservationChecker
 
 __all__ = ["DataStore"]
 
@@ -184,7 +184,7 @@ class DataStore(object):
         return DataStoreObservation(obs_id=int(obs_id), data_store=self)
 
     def obs_list(self, obs_id, skip_missing=False):
-        """Generate a `~gammapy.data.ObservationList`.
+        """Generate a `~gammapy.data.Observations`.
 
         Parameters
         ----------
@@ -195,10 +195,10 @@ class DataStore(object):
 
         Returns
         -------
-        obs : `~gammapy.data.ObservationList`
-            List of `~gammapy.data.DataStoreObservation`
+        obs_list : `~gammapy.data.Observations`
+            Container holding a list of `~gammapy.data.DataStoreObservation`
         """
-        obslist = ObservationList()
+        obs_list = []
         for _ in obs_id:
             try:
                 obs = self.obs(_)
@@ -209,8 +209,8 @@ class DataStore(object):
                 else:
                     raise err
             else:
-                obslist.append(obs)
-        return obslist
+                obs_list.append(obs)
+        return Observations(obs_list)
 
     def copy_obs(self, obs_id, outdir, hdu_class=None, verbose=False, overwrite=False):
         """Create a new `~gammapy.data.DataStore` containing a subset of observations.

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -15,7 +15,7 @@ from ..utils.fits import earth_location_from_dict
 from ..utils.table import table_row_to_dict
 from ..utils.time import time_ref_from_dict
 
-__all__ = ["ObservationCTA", "DataStoreObservation", "ObservationList"]
+__all__ = ["ObservationCTA", "DataStoreObservation", "Observations"]
 
 log = logging.getLogger(__name__)
 
@@ -359,11 +359,22 @@ class DataStoreObservation(object):
         return checker.run(checks=checks)
 
 
-class ObservationList(UserList):
-    """List of `~gammapy.data.DataStoreObservation`.
+class Observations(object):
+    """Container class that holds a list of observations.
 
-    Could be extended to hold a more generic class of observations.
+    Parameters:
+    ----------
+    obs_list : list
+        A list of `~gammapy.data.DataStoreObservation`
     """
+    def __init__(self, obs_list=None):
+        self.obs_list = obs_list or []
+
+    def __getitem__(self, key):
+        return self.obs_list[key]
+
+    def __len__(self):
+        return len(self.obs_list)
 
     def __str__(self):
         s = self.__class__.__name__ + "\n"

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -5,7 +5,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from regions import CircleSkyRegion
-from ...data import DataStore, ObservationList, ObservationStats
+from ...data import DataStore, Observations, ObservationStats
 from ...utils.testing import requires_data, requires_dependency
 from ...background import ReflectedRegionsBackgroundEstimator
 
@@ -14,7 +14,7 @@ from ...background import ReflectedRegionsBackgroundEstimator
 def obs_list():
     data_store = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/")
     run_list = [23523, 23526]
-    return ObservationList([data_store.obs(_) for _ in run_list])
+    return Observations([data_store.obs(_) for _ in run_list])
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -6,7 +6,7 @@ import pytest
 from astropy.coordinates import Angle, SkyCoord
 from astropy.units import Quantity
 from astropy.time import Time
-from ...data import DataStore, ObservationList, EventList, GTI, ObservationCTA
+from ...data import DataStore, Observations, EventList, GTI, ObservationCTA
 from ...irf import EffectiveAreaTable2D, EnergyDispersion2D, PSF3D
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.testing import (

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -58,8 +58,8 @@ def make_mean_psf(obs_list, position, energy=None, rad=None):
 
     Parameters
     ----------
-    obs_list : `~gammapy.data.ObservationList`
-        List of observations for which to compute the PSF
+    obs_list : `~gammapy.data.Observations`
+        Observations for which to compute the PSF
     position : `~astropy.coordinates.SkyCoord`
         Position at which to compute the PSF
     energy : `~astropy.units.Quantity`
@@ -114,8 +114,8 @@ def make_mean_edisp(
 
     Parameters
     ----------
-    obs_list : `~gammapy.data.ObservationList`
-        List of observations for which to compute the EDISP
+    obs_list : `~gammapy.data.Observations`
+        Observations for which to compute the EDISP
     position : `~astropy.coordinates.SkyCoord`
         Position at which to compute the EDISP
     e_true : `~gammapy.utils.energy.EnergyBounds`

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose, assert_equal
 import pytest
 from astropy.coordinates import Angle, SkyCoord
 from ..irf_reduce import make_psf, make_mean_psf, make_mean_edisp
-from ...data import DataStore, ObservationList
+from ...data import DataStore, Observations
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.testing import assert_quantity_allclose
 from ...utils.energy import Energy
@@ -107,7 +107,7 @@ def test_make_mean_psf(data_store):
     psf2 = make_psf(obs2, position=position, energy=energy, rad=None)
     psf1_int = psf1.table_psf_in_energy_band(energy_band, spectral_index=2.3)
     psf2_int = psf2.table_psf_in_energy_band(energy_band, spectral_index=2.3)
-    obs_list = ObservationList([obs1, obs2])
+    obs_list = Observations([obs1, obs2])
     psf_tot = make_mean_psf(obs_list, position=position, energy=energy)
     psf_tot_int = psf_tot.table_psf_in_energy_band(energy_band, spectral_index=2.3)
 
@@ -125,7 +125,7 @@ def test_make_mean_edisp(data_store):
 
     obs1 = data_store.obs(23523)
     obs2 = data_store.obs(23592)
-    obs_list = ObservationList([obs1, obs2])
+    obs_list = Observations([obs1, obs2])
 
     e_true = EnergyBounds.equal_log_spacing(0.01, 150, 80, "TeV")
     e_reco = EnergyBounds.equal_log_spacing(0.5, 100, 15, "TeV")

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -38,7 +38,7 @@ class SpectrumAnalysisIACT(object):
 
     Parameters
     ----------
-    observations : `~gammapy.data.ObservationList`
+    observations : `~gammapy.data.Observations`
         Observations to analyse
     config : dict
         Config dict

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -31,7 +31,7 @@ class SpectrumExtraction(object):
 
     Parameters
     ----------
-    obs_list : `~gammapy.data.ObservationList`
+    obs_list : `~gammapy.data.Observations`
         Observations to process
     bkg_estimate : `~gammapy.background.BackgroundEstimate`
         Background estimate, e.g. of

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -98,7 +98,7 @@
     "from astropy.coordinates import SkyCoord, Angle\n",
     "from astropy.table import vstack as vstack_table\n",
     "from regions import CircleSkyRegion\n",
-    "from gammapy.data import DataStore, ObservationList\n",
+    "from gammapy.data import DataStore, Observations\n",
     "from gammapy.data import ObservationStats, ObservationSummary\n",
     "from gammapy.background.reflected import ReflectedRegionsBackgroundEstimator\n",
     "from gammapy.utils.energy import EnergyBounds\n",


### PR DESCRIPTION
This PR is the first step to implement PIG #1877
It starts to evolve the `ObservationList` class into the new `Observations` class.
This PR takes care of the renaming, and introduces a basic version of the `Observations`class that works with the current analysis classes. All tests pass locally (only unrelated fails).

A followup PR would be to introduce a convenience class method `.from_index(dir, obs_ids)` and to adopt the notebooks accordingly.

There are two more things i wanted further feedback on (@cdeil @registerrier @adonath):
- we are using `obs_list` for attributes that hold/return a, now, `Observations` object. Should we change this name to something like `obss` or stick to `obs_list`
- i saw that there is an [`SpectrumObservationList` class](https://docs.gammapy.org/0.8/api/gammapy.spectrum.SpectrumObservationList.html?highlight=spectrumobservationlist). Should i change this as well to keep Gammapy more consistent overall? 