### PR TITLE
Change map quantity to view instead of copy

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -111,11 +111,11 @@ class Map(object):
     @property
     def quantity(self):
         """Map data times unit (`~astropy.units.Quantity`)"""
-        return self.data * self.unit
+        return u.Quantity(self.data, self.unit, copy=False)
 
     @quantity.setter
     def quantity(self, val):
-        val = u.Quantity(val)
+        val = u.Quantity(val, copy=False)
         self.data = val.value
         self.unit = val.unit
 


### PR DESCRIPTION
This PR is a small modification on `Map.quantity` to return a view on the `Quantity` object instead of creating it with a copy of `Map.data`.
The change is made on the property and on the setter.
