### PR TITLE
Arithmetics of maps

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1036,13 +1036,14 @@ class Map(object):
     def _arithmetics(self, operator, other, copy):
         """ Perform arithmetics on maps after checking geometry consistency"""
         if isinstance(other, Map):
-            # TODO: check consitency
+            # TODO: check consistency
             q = other.quantity
         else:
-            q = Quantity(other, copy=False)
+            q = u.Quantity(other, copy=False)
 
         out = self.copy() if copy else self
         out.quantity = operator(out.quantity, q)
+        return out
 
     def __add__(self, other):
         return self._arithmetics(np.add, other, copy=True)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1032,3 +1032,38 @@ class Map(object):
         str_ += "\tunit  : {!r} \n".format(str(self.unit))
         str_ += "\tdtype : {} \n".format(self.data.dtype)
         return str_
+
+    def _arithmetics(self, operator, other, copy):
+        """ Perform arithmetics on maps after checking geometry consistency"""
+        if isinstance(other, Map):
+            # TODO: check consitency
+            q = other.quantity
+        else:
+            q = Quantity(other, copy=False)
+
+        out = self.copy() if copy else self
+        out.quantity = operator(out.quantity, q)
+
+    def __add__(self, other):
+        return self._arithmetics(np.add, other, copy=True)
+
+    def __iadd__(self, other):
+        return self._arithmetics(np.add, other, copy=False)
+
+    def __sub__(self, other):
+        return self._arithmetics(np.subtract, other, copy=True)
+
+    def __isub__(self, other):
+        return self._arithmetics(np.subtract, other, copy=False)
+
+    def __mul__(self, other):
+        return self._arithmetics(np.multiply, other, copy=True)
+
+    def __imul__(self, other):
+        return self._arithmetics(np.multiply, other, copy=False)
+
+    def __truediv__(self, other):
+        return self._arithmetics(np.true_divide, other, copy=True)
+
+    def __itruediv__(self, other):
+        return self._arithmetics(np.true_divide, other, copy=False)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -349,3 +349,16 @@ def test_map_arithmetics(binsz, width, map_type, skydir, axes):
     assert_quantity_allclose(m3.quantity, 1 * u.m**2)
 
     # multiplication
+    m4 = Map.create(
+        binsz=binsz, width=width, map_type=map_type, skydir=skydir, axes=axes, unit="hour")
+    m4.data += 1.0
+    m5 = m3 * m4
+    assert_quantity_allclose(m5.quantity, 3600 * u.m**2 * u.s)
+
+    # division
+    m5 /= 3.6 * u.s
+    assert_quantity_allclose(m5.quantity, 1e3 * u.m**2)
+
+    # check unit consistency
+    with pytest.raises(u.UnitConversionError):
+        m5 += 1*u.W

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_equal, assert_allclose
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.units import Unit, Quantity
-from ...utils.testing import requires_dependency, assert_quantity_allclose
+from ...utils.testing import requires_dependency
 from ..base import Map
 from ..geom import MapAxis
 from ..wcs import WcsGeom

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -318,64 +318,58 @@ def test_map_reproject_hpx_to_wcs():
     assert_allclose(actual, [287.5, 1055.5, 1823.5], rtol=1e-3)
 
 
-map_arithmetics_args = [("wcs"),
-                        ("hpx"),
-]
+map_arithmetics_args = [("wcs"), ("hpx")]
 
-@pytest.mark.parametrize(
-    ("map_type"), map_arithmetics_args
-)
+
+@pytest.mark.parametrize(("map_type"), map_arithmetics_args)
 def test_map_arithmetics(map_type):
 
-    m1 = Map.create(
-        binsz=0.1, width=1.0, map_type=map_type, skydir=(0,0), unit="m2")
+    m1 = Map.create(binsz=0.1, width=1.0, map_type=map_type, skydir=(0, 0), unit="m2")
 
-    m2 = Map.create(
-        binsz=0.1, width=1.0, map_type=map_type, skydir=(0,0), unit="m2")
+    m2 = Map.create(binsz=0.1, width=1.0, map_type=map_type, skydir=(0, 0), unit="m2")
     m2.data += 1.0
 
     # addition
-    m1 += 1 * u.cm**2
-    assert m1.unit == u.Unit('m2')
+    m1 += 1 * u.cm ** 2
+    assert m1.unit == u.Unit("m2")
     assert_allclose(m1.data, 1e-4)
 
     m3 = m1 + m2
-    assert m3.unit == u.Unit('m2')
+    assert m3.unit == u.Unit("m2")
     assert_allclose(m3.data, 1.0001)
 
     # substraction
-    m3 -=  1 * u.cm**2
-    assert m3.unit == u.Unit('m2')
+    m3 -= 1 * u.cm ** 2
+    assert m3.unit == u.Unit("m2")
     assert_allclose(m3.data, 1.0)
 
     m3 = m2 - m1
-    assert m3.unit == u.Unit('m2')
+    assert m3.unit == u.Unit("m2")
     assert_allclose(m3.data, 0.9999)
 
-    m4 = Map.create(
-        binsz=0.1, width=1.0, map_type=map_type, skydir=(0,0), unit="s")
+    m4 = Map.create(binsz=0.1, width=1.0, map_type=map_type, skydir=(0, 0), unit="s")
     m4.data += 1.0
 
     # multiplication
     m1 *= 1e4
-    assert m1.unit == u.Unit('m2')
+    assert m1.unit == u.Unit("m2")
     assert_allclose(m1.data, 1)
 
     m5 = m2 * m4
-    assert m5.unit == u.Unit('m2s')
+    assert m5.unit == u.Unit("m2s")
     assert_allclose(m5.data, 1)
 
     # division
     m5 /= 10 * u.s
-    assert m5.unit == u.Unit('m2')
+    assert m5.unit == u.Unit("m2")
     assert_allclose(m5.data, 0.1)
 
     # check unit consistency
     with pytest.raises(u.UnitConversionError):
-        m5 += 1*u.W
+        m5 += 1 * u.W
 
-    m1.data *= 0.
-    m1.unit = ''
+    m1.data *= 0.0
+    m1.unit = ""
     m1 += 4
-    assert m1.unit == u.Unit('')
+    assert m1.unit == u.Unit("")
     assert_allclose(m1.data, 4)


### PR DESCRIPTION
This is a first commit for arithmetics of maps. As suggested by @cdeil we use a general `Map._arithmetics` function to limit code duplication in the various operators.

Tests check that quantities are correctly handled for various geometries and check that a `UnitConversionError` is raised if an incorrect operation is attempted.

A proper compatibility check or map geometries will be added later in a subsequent PR.