### PR TITLE
Modify and add test to MapAxis.__eq__

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -355,6 +355,7 @@ class MapAxis(object):
         self._nbin = nbin
 
     def __eq__(self, other):
+        """Test axis equality. Absolute and relative tolerances of 1e-6 are used"""
         if not isinstance(other, self.__class__):
             return NotImplemented
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -355,19 +355,17 @@ class MapAxis(object):
         self._nbin = nbin
 
     def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return (
-                np.allclose(self._nodes, other._nodes)
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        # TODO: implement an allclose method for MapAxis and call it here
+        other_quantity = other.edges * other.unit
+        other_values = other_quantity.to(self.unit).value
+        return (
+                np.allclose(self.edges, other_values, atol=1e-6, rtol=1e-6)
                 and self._node_type == other._node_type
                 and self._interp == other._interp
-                and self._unit == other._unit
-            )
-        return NotImplemented
-
-    def __ne__(self, other):
-        if isinstance(other, self.__class__):
-            return not self.__eq__(other)
-        return NotImplemented
+        )
 
     @property
     def name(self):

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -225,3 +225,23 @@ def test_mapaxis_repr():
 def test_mapcoord_repr():
     coord = MapCoord({"lon": 0, "lat": 0, "energy": 5})
     assert "MapCoord" in repr(coord)
+
+mapaxis_geoms_node_type_unit = [
+    (np.array([0.25, 0.75, 1.0, 2.0]), "lin", "edges", ""),
+    (np.array([0.25, 0.75, 1.0, 2.0]), "log", "edges", ""),
+    (np.array([0.25, 0.75, 1.0, 2.0]), "log", "edges", "TeV"),
+    (np.array([0.25, 0.75, 1.0, 2.0]), "sqrt", "edges", ""),
+    (np.array([0.25, 0.75, 1.0, 2.0]), "lin", "center", "s"),
+    (np.array([0.25, 0.75, 1.0, 2.0]), "log", "center", "s"),
+    (np.array([0.25, 0.75, 1.0, 2.0]), "sqrt", "center", "s"),
+]
+
+@pytest.mark.parametrize(("nodes", "interp", "node_type", "unit"), mapaxis_geoms_node_type_unit)
+def test_mapaxis_equal(nodes, interp, node_type, unit):
+    axis1 = MapAxis(nodes, name="test", unit=unit, interp=interp, node_type=node_type)
+
+    axis2 = MapAxis(nodes+1e-7, name="test", unit=unit, interp=interp, node_type=node_type)
+    assert axis1 == axis2
+
+    axis3 = MapAxis(nodes+1e-3, name="test", unit=unit, interp=interp, node_type=node_type)
+    assert axis1 != axis3


### PR DESCRIPTION
This PR changes the logic of `MapAxis.__eq__` to include tolerances and proper unit handling of axes nodes.

Tolerance is needed in particular in the case of serialized axes where rounding errors will change the expected value. Absolute and relative tolerances have been set at 1e-6. 

A future PR should implement an `allclose` method for `MapAxis`. 