### PR TITLE
Add MapGeom.__eq__ operator 

### DIFF
--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1732,6 +1732,31 @@ class HpxGeom(MapGeom):
         str_ += "\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n".format(lon=lon, lat=lat)
         return str_
 
+    def __eq__(self, other):
+        """Test equality between two `~gammapy.maps.HpxGeom`"""
+        if not isinstance(other, self.__class__):
+            raise TypeError('Cannot compare HpxGeom with {}'.format(other.__class__))
+
+        if self._sparse or other._sparse:
+            raise ValueError("sparse geometries not supported")
+        if self.is_allsky and other.is_allsky is False:
+            raise ValueError("Non allsky HpxGeom not supported")
+
+        # check overall shape and axes compatibility
+        if self.data_shape != other.data_shape:
+            return False
+
+        result = True
+        for axis, otheraxis in zip(self.axes, other.axes):
+            result &= axis == otheraxis
+
+        return (
+               result
+                and self.nside == other.nside
+                and self.coordsys == other.coordsys
+                and self.order == other.order
+                and self.nest == other.nest
+            )
 
 class HpxToWcsMapping(object):
     """Stores the indices need to convert from HEALPIX to WCS.

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -733,3 +733,27 @@ def test_geom_repr():
     geom = HpxGeom(nside=8)
     assert geom.__class__.__name__ in repr(geom)
     assert "nside" in repr(geom)
+
+hpx_equality_test_geoms = [
+    (16, False, "GAL", None, True),
+    (16, True, "GAL", None, False),
+    (8, False, "GAL", None, False),
+    (16, False, "CEL", None, False)
+]
+
+@pytest.mark.parametrize(
+    ("nside", "nested", "coordsys", "region", "result"), hpx_equality_test_geoms
+)
+
+def test_hpxgeom_equal(nside, nested, coordsys, region, result):
+    geom0 = HpxGeom(16, False, "GAL", region=None)
+    geom1 = HpxGeom(nside, nested, coordsys, region=region)
+
+    assert (geom0 == geom1) is result
+
+def test_hpxgeom_equal_raise_error():
+    geom0 = HpxGeom(16, False, "GAL", region=None)
+    geom1 = HpxGeom(16, False, "GAL", "DISK(110.,75.,10.)")
+    with pytest.raises(ValueError):
+        geom0 == geom1
+        

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -296,3 +296,35 @@ def test_get_axis_index_by_name():
     assert geom.get_axis_index_by_name("Energy") == 0
     with pytest.raises(ValueError):
         geom.get_axis_index_by_name("time")
+
+test_axis1 = [MapAxis(nodes=(1,2,3,4), unit='TeV', node_type='center')]
+test_axis2 = [MapAxis(nodes=(1,2,3,4), unit='TeV', node_type='center'),
+              MapAxis(nodes=(1,2,3), unit='TeV', node_type='center')]
+
+skydir2 = SkyCoord(110.0, 75.0+1e-8, unit="deg", frame="icrs")
+skydir3 = SkyCoord(110.0, 75.0+1e-3, unit="deg", frame="icrs")
+
+compatibility_test_geoms = [
+    (10, 0.1, "GAL", "CAR", skydir, test_axis1, True),
+    (10, 0.1, "GAL", "CAR", skydir2, test_axis1, True),
+    (10, 0.1, "GAL", "CAR", skydir3, test_axis1, False),
+    (10, 0.1, "GAL", "TAN", skydir, test_axis1, False),
+    (8, 0.1, "GAL", "CAR", skydir, test_axis1, False),
+    (10, 0.1, "GAL", "CAR", skydir, test_axis2, False),
+    (10, 0.1, "GAL", "CAR", skydir.galactic, test_axis1, True)
+]
+
+@pytest.mark.parametrize(
+    ("npix", "binsz", "coordsys", "proj", "skypos", "axes", "result"), compatibility_test_geoms
+)
+def test_wcs_geom_equal(npix, binsz, coordsys, proj, skypos, axes, result):
+    geom0 = WcsGeom.create(
+        skydir=skydir, npix=10, binsz=0.1, proj="CAR", coordsys="GAL", axes=test_axis1
+    )
+    geom1 = WcsGeom.create(
+        skydir=skypos, npix=npix, binsz=binsz, proj=proj, coordsys=coordsys, axes=axes
+    )
+
+    assert (geom0 == geom1) is result
+
+    

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -327,4 +327,5 @@ def test_wcs_geom_equal(npix, binsz, coordsys, proj, skypos, axes, result):
 
     assert (geom0 == geom1) is result
 
-    
+    with pytest.raises(TypeError):
+        geom0 == geom0.wcs.wcs

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -882,6 +882,20 @@ class WcsGeom(MapGeom):
         )
         return str_
 
+    def __eq__(self, other):
+        """Test equality between two `~gammapy.maps.WcsGeom`. Espect tolerance of 1e-6 for `~astropy.wcs.WCS` objects"""
+        if not isinstance(other, self.__class__):
+            raise TypeError('Cannot compare WcsGeom with {}'.format(other.__class__))
+
+        # check overall shape and axes compatibility
+        if self.data_shape != other.data_shape:
+            return False
+
+        result = True
+        for axis, otheraxis in zip(self.axes, other.axes):
+            result &= axis == otheraxis
+        # check WCS consistency
+        return result and self.wcs.wcs.compare(other.wcs.wcs, tolerance=1e-6)
 
 def create_wcs(
     skydir, coordsys="CEL", projection="AIT", cdelt=1.0, crpix=1.0, axes=None


### PR DESCRIPTION
This PR introduces the `__eq__` operator on both `WcsGeom` and `HpxGeom`. 

`MapAxis` equality is tested as well as geometry consistency. In the case of `WcsGeom` we use a a tolerance of 1e-6 for WCS comparison. The latter is obtained with `~astrop.wcs.WCS.compare`.

A later PR will add the equality check for map arithmetics.