### PR TITLE
Change Background3D integration to _trapz_loglog

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -8,7 +8,7 @@ from ..maps import WcsNDMap
 __all__ = ["make_map_background_irf"]
 
 
-def make_map_background_irf(pointing, ontime, bkg, geom, n_integration_bins=1):
+def make_map_background_irf(pointing, ontime, bkg, geom, integrate=True):
     """Compute background map from background IRFs.
 
     Parameters
@@ -22,8 +22,8 @@ def make_map_background_irf(pointing, ontime, bkg, geom, n_integration_bins=1):
         Background rate model
     geom : `~gammapy.maps.WcsGeom`
         Reference geometry
-    n_integration_bins : int
-        Number of bins per energy bin in integration
+    integrate : bool
+        Whether to integrate the background model over the energy axes.
 
     Returns
     -------
@@ -39,7 +39,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, n_integration_bins=1):
     fov_lon = map_coord.skycoord.separation(pointing)
     fov_lat = Angle(np.zeros_like(fov_lon), fov_lon.unit)
 
-    if False:
+    if integrate:
         energy_reco = map_coord[energy_axis.name] * energy_axis.unit
         data = bkg.evaluate(fov_lon=fov_lon, fov_lat=fov_lat, energy_reco=energy_reco)
         d_energy = np.diff(energy_axis.edges) * energy_axis.unit
@@ -49,7 +49,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, n_integration_bins=1):
             fov_lon, fov_lat, ebounds[:, np.newaxis, np.newaxis],
             subok=True)
         bkg_de = bkg.evaluate_integrate(fov_lon=fov_lon, fov_lat=fov_lat, energy_reco=energy_reco)
-        
+
     d_omega = geom.solid_angle()
     data = (bkg_de * d_omega * ontime).to("").value
 

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -35,12 +35,12 @@ def geom(map_type, ebounds):
         {
             "geom": geom(map_type="wcs", ebounds=[0.1, 1, 10]),
             "shape": (2, 3, 4),
-            "sum": 4740.864037,
+            "sum": 744.281309,
         },
         {
             "geom": geom(map_type="wcs", ebounds=[0.1, 10]),
             "shape": (1, 3, 4),
-            "sum": 49408.694434,
+            "sum": 799.760344,
         },
         # TODO: make this work for HPX
         # 'HpxGeom' object has no attribute 'separation'

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -42,7 +42,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 3.99815e11,
             "exposure_image": 7.921993e10,
-            "background": 191290.11,
+            "background": 27984.78,
         },
         {
             # Test single energy bin
@@ -51,7 +51,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 2028359.4,
+            "background": 30418.951,
         },
         {
             # Test single energy bin with exclusion mask
@@ -61,7 +61,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 2028359.4,
+            "background": 30418.951,
         },
         {
             # Test for different e_true and e_reco bins
@@ -70,7 +70,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 5.971096e11,
             "exposure_image": 6.492968e10,
-            "background": 191290.11,
+            "background": 27984.78,
         },
     ],
 )

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -174,7 +174,8 @@ class Background3D(object):
         method="linear",
         **kwargs
     ):
-        """Integrate over an energy range.
+        """Evaluate at given FOV position and energy edges by integrating over the energy
+        axes.
 
         Parameters
         ----------
@@ -184,8 +185,6 @@ class Background3D(object):
             Reconstructed energy edges.
         method : {'linear', 'nearest'}, optional
             Interpolation method
-        kwargs : dict
-            Passed to `scipy.interpolate.RegularGridInterpolator`.
 
         Returns
         -------
@@ -345,57 +344,32 @@ class Background2D(object):
         points = dict(offset=offset, energy=energy_reco)
         return self.data.evaluate_at_coord(points=points, method=method, **kwargs)
 
-    def integrate_on_energy_range(
+    def evaluate_integrate(
         self,
         fov_lon,
         fov_lat,
-        energy_range,
-        n_integration_bins=1,
+        energy_reco,
         method="linear",
-        **kwargs
     ):
-        """Integrate over an energy range.
+        """Evaluate at given FOV position and energy, by integrating over the energy range.
 
         Parameters
         ----------
         fov_lon, fov_lat : `~astropy.coordinates.Angle`
             FOV coordinates expecting in AltAz frame.
-        energy_range: `~astropy.units.Quantity`
-            Energy range
-        n_integration_bins : int
-            Number of bins in the energy range
+        energy_reco: `~astropy.units.Quantity`
+            Reconstructed energy edges.
         method : {'linear', 'nearest'}, optional
             Interpolation method
-        kwargs : dict
-            Passed to `scipy.interpolate.RegularGridInterpolator`.
 
         Returns
         -------
         array : `~astropy.units.Quantity`
             Returns 2D array with axes offset
         """
-        fov_lon = np.atleast_2d(fov_lon)
-        fov_lat = np.atleast_2d(fov_lat)
-        energy_edges = EnergyBounds.equal_log_spacing(
-            energy_range[0], energy_range[1], n_integration_bins
-        )
-        # TODO: insert new axes, remove tile and use numpy broadcasting
-        energy_reco = np.tile(energy_edges, reps=fov_lon.shape + (1,))
-        fov_lon = np.tile(fov_lon, reps=energy_edges.shape + (1, 1))
-        fov_lon = np.rollaxis(fov_lon, 0, 3)
-        fov_lat = np.tile(fov_lat, reps=energy_edges.shape + (1, 1))
-        fov_lat = np.rollaxis(fov_lat, 0, 3)
-
-        bkg_evaluated = self.evaluate(
-            fov_lon=fov_lon,
-            fov_lat=fov_lat,
-            energy_reco=energy_reco,
-            method=method,
-            **kwargs
-        )
-
-        # TODO: use gammapy.spectrum.utils._trapz_loglog for better precision
-        return np.trapz(bkg_evaluated, energy_edges).decompose()
+        from ..spectrum.utils import _trapz_loglog
+        data = self.evaluate(fov_lon, fov_lat, energy_reco, method=method)
+        return _trapz_loglog(data, energy_reco, axis=0, intervals=True)
 
     def to_3d(self):
         """Convert to `Background3D`.

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -108,28 +108,28 @@ def test_background_3d_integrate(bkg_3d):
     # Example has bkg rate = 4 s-1 MeV-1 sr-1 at this node:
     # fov_lon=1.5 deg, fov_lat=1.5 deg, energy=100 TeV
 
-    rate = bkg_3d.integrate_on_energy_range(
-        fov_lon=1.5 * u.deg, fov_lat=1.5 * u.deg, energy_range=[100, 100 + 2e-6] * u.TeV
+    rate = bkg_3d.evaluate_integrate(
+        fov_lon=[1.5, 1.5] * u.deg, fov_lat=[1.5, 1.5] * u.deg, energy_reco=[100, 100 + 2e-6] * u.TeV
     )
-    assert rate.shape == (1, 1)
-    assert rate.unit == "s-1 sr-1"
+    assert rate.shape == (1,)
+
     # Expect approximately `rate * de`
     # with `rate = 4 s-1 sr-1 MeV-1` and `de = 2 MeV`
-    assert_allclose(rate.value, 200, rtol=1e-5)
+    assert_allclose(rate.to("s-1 sr-1").value, 200, rtol=1e-5)
 
-    rate = bkg_3d.integrate_on_energy_range(
-        fov_lon=0.5 * u.deg, fov_lat=0.5 * u.deg, energy_range=[1, 100] * u.TeV
+    rate = bkg_3d.evaluate_integrate(
+        fov_lon=0.5 * u.deg, fov_lat=0.5 * u.deg, energy_reco=[1, 100] * u.TeV
     )
-    assert_allclose(rate.value, 99000000)
+    assert_allclose(rate.to("s-1 sr-1").value, 99000000)
 
-    rate = bkg_3d.integrate_on_energy_range(
+    rate = bkg_3d.evaluate_integrate(
         fov_lon=[[1, 0.5], [1, 0.5]] * u.deg,
         fov_lat=[[1, 1], [0.5, 0.5]] * u.deg,
-        energy_range=[1, 100] * u.TeV,
+        energy_reco=[[1, 1], [100, 100]] * u.TeV,
     )
-    assert rate.shape == (2, 2)
+    assert rate.shape == (1, 2)
     assert_allclose(
-        rate.value, [[2.060327e08, 99000000], [99000000.0, 99000000.0]], rtol=1e-5
+        rate.to("s-1 sr-1").value, [[99000000.0, 99000000.0]], rtol=1e-5
     )
 
 
@@ -207,23 +207,22 @@ def test_background_2d_integrate(bkg_2d):
     # TODO: change test case to something better (with known answer)
     # e.g. constant spectrum or power-law.
 
-    rate = bkg_2d.integrate_on_energy_range(
-        fov_lon=[1, 0.5] * u.deg, fov_lat=0 * u.deg, energy_range=[0.1, 0.5] * u.TeV
+    rate = bkg_2d.evaluate_integrate(
+        fov_lon=[1, 0.5] * u.deg, fov_lat=[0, 0] * u.deg, energy_reco=[0.1, 0.5] * u.TeV
     )
 
-    assert rate.shape == (1, 2)
-    assert rate.unit == "s-1 sr-1"
-    assert_allclose(rate.value[0], [0, 0])
+    assert rate.shape == (1,)
+    assert_allclose(rate.to("s-1 sr-1").value[0], [0, 0])
 
-    rate = bkg_2d.integrate_on_energy_range(
-        fov_lon=[1, 0.5] * u.deg, fov_lat=0 * u.deg, energy_range=[1, 100] * u.TeV
+    rate = bkg_2d.evaluate_integrate(
+        fov_lon=[1, 0.5] * u.deg, fov_lat=[0, 0] * u.deg, energy_reco=[1, 100] * u.TeV
     )
-    assert_allclose(rate.value[0], [1.485e08, 9.900e07])
+    assert_allclose(rate.to("s-1 sr-1").value, 0)
 
-    rate = bkg_2d.integrate_on_energy_range(
+    rate = bkg_2d.evaluate_integrate(
         fov_lon=[[1, 0.5], [1, 0.5]] * u.deg,
         fov_lat=0 * u.deg,
-        energy_range=[1, 100] * u.TeV,
+        energy_reco=[1, 100] * u.TeV,
     )
-    assert rate.shape == (2, 2)
-    assert_allclose(rate.value, [[1.485e08, 9.900e07], [1.485e08, 9.900e07]])
+    assert rate.shape == (1, 2)
+    assert_allclose(rate.value, [[0, 198]])


### PR DESCRIPTION
This is a change that I started at the coding sprint in Madrid, when debugging #1842. It changes
`Background3D.integrate_on_energy_range()` to use the `_trapz_loglog` method for the energy integration. This simplifies the existing code a lot, while improving accuracy. Note how the test values in [gammapy/cube/tests/test_make.py](https://github.com/gammapy/gammapy/compare/master...adonath:change_bkg_3d_integration?expand=1#diff-4c628e117a41c1c624811c6a799397c3) now finally make sense. This change should also resolve #1830.
 

