### PR TITLE
Changed min value for increment angle

### DIFF
--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -123,7 +123,7 @@ class ReflectedRegionsFinder(object):
         self.center = center
 
         self.angle_increment = Angle(angle_increment)
-        if self.angle_increment < Angle(1, "deg"):
+        if self.angle_increment <= Angle(0, "deg"):
             raise ValueError("angle_increment is too small")
 
         self.min_distance = Angle(min_distance)


### PR DESCRIPTION
This change comes from issue #1798.
 The constraint on the increment angle for reflected regions determination is changed from >=1 deg to >0 deg. This increment is the rotation angle used to find the next reflected region. Very small values will yield long computation times for no good reasons and 0 would induce an infinite loop. 