### PR TITLE
Small edit: Check fits column name in case insensitive way

### DIFF
--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -88,11 +88,11 @@ class Background3D(object):
         """Read from `~astropy.table.Table`."""
         # Spec says key should be "BKG", but there are files around
         # (e.g. CTA 1DC) that use "BGD". For now we support both
-        if "BKG" in table.colnames:
-            bkg_name = "BKG"
-        elif "BGD" in table.colnames:
-            bkg_name = "BGD"
-        else:
+        bkg_name = None
+        for aname in table.colnames:
+            if aname.upper() == "BKG" or aname.upper() == "BGD":
+                bkg_name = aname
+        if bkg_name is None:
             raise ValueError('Invalid column names. Need "BKG" or "BGD".')
 
         # Currently some files (e.g. CTA 1DC) contain unit in the FITS file

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -266,11 +266,11 @@ class Background2D(object):
         """Read from `~astropy.table.Table`."""
         # Spec says key should be "BKG", but there are files around
         # (e.g. CTA 1DC) that use "BGD". For now we support both
-        if "BKG" in table.colnames:
-            bkg_name = "BKG"
-        elif "BGD" in table.colnames:
-            bkg_name = "BGD"
-        else:
+        bkg_name = None
+        for aname in table.colnames:
+            if aname.upper() == "BKG" or aname.upper() == "BGD":
+                bkg_name = aname
+        if bkg_name is None:
             raise ValueError('Invalid column names. Need "BKG" or "BGD".')
 
         # Currently some files (e.g. CTA 1DC) contain unit in the FITS file


### PR DESCRIPTION
This is a very small (but necessary1) edit in `Background3D` and `Background2D`.
The HESS fits background rmfs have  column names in lower case, whereas the DC1 and the HESS fits release have in upper case.
I think it is better to deal with all fits serialisations in a case insensitive  manner.

