### PR TITLE
Add geometry check for map arithmetics

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1039,7 +1039,7 @@ class Map(object):
             if self.geom == other.geom:
                 q = other.quantity
             else:
-                raise ValueError("Map Arithemtics: Inconsistent geometries.")
+                raise ValueError("Map Arithmetics: Inconsistent geometries.")
         else:
             q = u.Quantity(other, copy=False)
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1036,8 +1036,10 @@ class Map(object):
     def _arithmetics(self, operator, other, copy):
         """ Perform arithmetics on maps after checking geometry consistency"""
         if isinstance(other, Map):
-            # TODO: check consistency
-            q = other.quantity
+            if self.geom == other.geom:
+                q = other.quantity
+            else:
+                raise ValueError("Map Arithemtics: Inconsistent geometries.")
         else:
             q = u.Quantity(other, copy=False)
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -376,15 +376,13 @@ def test_map_arithmetics(map_type):
 
 
 def test_arithmetics_inconsistent_geom():
-    m_wcs = Map.create(binsz=0.1, width=1.0, map_type="wcs", skydir=(0, 0), unit="m2")
-    m_wcs_incorrect = Map.create(
-        binsz=0.1, width=2.0, map_type="wcs", skydir=(0, 0), unit="m2"
-    )
+    m_wcs = Map.create(binsz=0.1, width=1.0)
+    m_wcs_incorrect = Map.create(binsz=0.1, width=2.0)
 
     with pytest.raises(ValueError):
         m_wcs += m_wcs_incorrect
 
-    m_hpx = Map.create(binsz=0.1, width=1.0, map_type="hpx", skydir=(0, 0), unit="m2")
+    m_hpx = Map.create(binsz=0.1, width=1.0, map_type="hpx")
     with pytest.raises(ValueError):
         m_wcs += m_hpx
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -374,29 +374,33 @@ def test_map_arithmetics(map_type):
     assert m1.unit == u.Unit("")
     assert_allclose(m1.data, 4)
 
+
 def test_arithmetics_inconsistent_geom():
-    m_wcs = Map.create(binsz=0.1, width=1.0, map_type='wcs', skydir=(0, 0), unit="m2")
-    m_wcs_incorrect = Map.create(binsz=0.1, width=2.0, map_type='wcs', skydir=(0, 0), unit="m2")
+    m_wcs = Map.create(binsz=0.1, width=1.0, map_type="wcs", skydir=(0, 0), unit="m2")
+    m_wcs_incorrect = Map.create(
+        binsz=0.1, width=2.0, map_type="wcs", skydir=(0, 0), unit="m2"
+    )
 
     with pytest.raises(ValueError):
         m_wcs += m_wcs_incorrect
 
-    m_hpx = Map.create(binsz=0.1, width=1.0, map_type='hpx', skydir=(0, 0), unit="m2")
+    m_hpx = Map.create(binsz=0.1, width=1.0, map_type="hpx", skydir=(0, 0), unit="m2")
     with pytest.raises(ValueError):
         m_wcs += m_hpx
 
+
 # TODO: correct serialization for lin axis for energy
-#map_serialization_args = [("log"), ("lin")]
+# map_serialization_args = [("log"), ("lin")]
 
 map_serialization_args = [("log")]
 
-@pytest.mark.parametrize(("interp"), map_serialization_args)
 
+@pytest.mark.parametrize(("interp"), map_serialization_args)
 def test_arithmetics_after_serialization(tmpdir, interp):
     axis = MapAxis.from_bounds(
         1.0, 10.0, 3, interp=interp, name="energy", node_type="center"
     )
-    m_wcs = Map.create(binsz=0.1, width=1.0, map_type='wcs', skydir=(0, 0), axes=[axis])
+    m_wcs = Map.create(binsz=0.1, width=1.0, map_type="wcs", skydir=(0, 0), axes=[axis])
     m_wcs += 1
 
     filename = str(tmpdir / "map.fits")
@@ -405,4 +409,4 @@ def test_arithmetics_after_serialization(tmpdir, interp):
 
     m_wcs += m_wcs_serialized
 
-    assert_allclose(m_wcs.data, 2.)
+    assert_allclose(m_wcs.data, 2.0)

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -373,3 +373,14 @@ def test_map_arithmetics(map_type):
     m1 += 4
     assert m1.unit == u.Unit("")
     assert_allclose(m1.data, 4)
+
+def test_arithmetics_inconsistent_geom():
+    m_wcs = Map.create(binsz=0.1, width=1.0, map_type='wcs', skydir=(0, 0), unit="m2")
+    m_wcs_incorrect = Map.create(binsz=0.1, width=2.0, map_type='wcs', skydir=(0, 0), unit="m2")
+
+    with pytest.raises(ValueError):
+        m_wcs += m_wcs_incorrect
+
+    m_hpx = Map.create(binsz=0.1, width=1.0, map_type='hpx', skydir=(0, 0), unit="m2")
+    with pytest.raises(ValueError):
+        m_wcs += m_hpx

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -384,3 +384,25 @@ def test_arithmetics_inconsistent_geom():
     m_hpx = Map.create(binsz=0.1, width=1.0, map_type='hpx', skydir=(0, 0), unit="m2")
     with pytest.raises(ValueError):
         m_wcs += m_hpx
+
+# TODO: correct serialization for lin axis for energy
+#map_serialization_args = [("log"), ("lin")]
+
+map_serialization_args = [("log")]
+
+@pytest.mark.parametrize(("interp"), map_serialization_args)
+
+def test_arithmetics_after_serialization(tmpdir, interp):
+    axis = MapAxis.from_bounds(
+        1.0, 10.0, 3, interp=interp, name="energy", node_type="center"
+    )
+    m_wcs = Map.create(binsz=0.1, width=1.0, map_type='wcs', skydir=(0, 0), axes=[axis])
+    m_wcs += 1
+
+    filename = str(tmpdir / "map.fits")
+    m_wcs.write(filename, overwrite=True)
+    m_wcs_serialized = Map.read(filename)
+
+    m_wcs += m_wcs_serialized
+
+    assert_allclose(m_wcs.data, 2.)


### PR DESCRIPTION
This PR adds a check on the `MapGeom` consistencies for each operation as well as the relevant tests.

A test for arithmetics after serialization is partly commented out as long as issue #1887 is still there. 