### PR TITLE
Improve flux points class

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -44,21 +44,6 @@ def compute_flux_points_ul(quantity, quantity_errp):
     return 2 * quantity_errp + quantity
 
 
-def format_flux_points_table(table):
-    """Returns formatted version of a flux points table"""
-    table = table.copy()
-
-    for column in table.colnames:
-        if column in ["sqrt_TS", "e_ref", "e_min", "e_max"]:
-            table[column].format = ".1f"
-        elif column == "is_ul":
-            continue
-        else:
-            table[column].format = ".3"
-
-    return table
-
-
 class SourceCatalogObject3FGL(SourceCatalogObject):
     """One source from the Fermi-LAT 3FGL catalog.
 
@@ -261,9 +246,8 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     def _info_spectral_points(self):
         """Print spectral points."""
         ss = "\n*** Spectral points ***\n\n"
-        lines = format_flux_points_table(self.flux_points.table).pformat(max_width=-1, max_lines=-1)
+        lines = self.flux_points.table_formatted.pformat(max_width=-1, max_lines=-1)
         ss += "\n".join(lines)
-
         return ss + "\n"
 
     def _info_lightcurve(self):
@@ -790,7 +774,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _info_spectral_points(self):
         """Print spectral points."""
         ss = "\n*** Spectral points ***\n\n"
-        lines = format_flux_points_table(self.flux_points.table).pformat(max_width=-1, max_lines=-1)
+        lines = self.flux_points.table_formatted.pformat(max_width=-1, max_lines=-1)
         ss += "\n".join(lines)
         return ss + "\n"
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -44,6 +44,21 @@ def compute_flux_points_ul(quantity, quantity_errp):
     return 2 * quantity_errp + quantity
 
 
+def format_flux_points_table(table):
+    """Returns formatted version of a flux points table"""
+    table = table.copy()
+
+    for column in table.colnames:
+        if column in ["sqrt_TS", "e_ref", "e_min", "e_max"]:
+            table[column].format = ".1f"
+        elif column == "is_ul":
+            continue
+        else:
+            table[column].format = ".3"
+
+    return table
+
+
 class SourceCatalogObject3FGL(SourceCatalogObject):
     """One source from the Fermi-LAT 3FGL catalog.
 
@@ -246,7 +261,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
     def _info_spectral_points(self):
         """Print spectral points."""
         ss = "\n*** Spectral points ***\n\n"
-        lines = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
+        lines = format_flux_points_table(self.flux_points.table).pformat(max_width=-1, max_lines=-1)
         ss += "\n".join(lines)
 
         return ss + "\n"
@@ -373,28 +388,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         return self.data["Extended_Source_Name"].strip() == ""
 
     @property
-    def _flux_points_table_formatted(self):
-        """Returns formatted version of self.flux_points.table"""
-        table = self.flux_points.table.copy()
-        flux_cols = [
-            "flux",
-            "flux_errn",
-            "flux_errp",
-            "e2dnde",
-            "e2dnde_errn",
-            "e2dnde_errp",
-            "flux_ul",
-            "e2dnde_ul",
-            "dnde",
-        ]
-        table["sqrt_TS"].format = ".1f"
-        table["e_ref"].format = ".1f"
-        for _ in flux_cols:
-            table[_].format = ".3"
-
-        return table
-
-    @property
     def flux_points(self):
         """Flux points (`~gammapy.spectrum.FluxPoints`)."""
         table = Table()
@@ -430,8 +423,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
         # Square root of test statistic
         table["sqrt_TS"] = [self.data["Sqrt_TS" + _] for _ in self._ebounds_suffix]
-
-        table["dnde"] = (nuFnu * e_ref ** -2).to("TeV-1 cm-2 s-1")
         return FluxPoints(table)
 
     def _get_flux_values(self, prefix, unit="cm-2 s-1"):
@@ -540,12 +531,7 @@ class SourceCatalogObject1FHL(SourceCatalogObject):
         table["flux_ul"] = np.nan * flux_err.unit
         flux_ul = compute_flux_points_ul(table["flux"], table["flux_errp"])
         table["flux_ul"][is_ul] = flux_ul[is_ul]
-
-        flux_points = FluxPoints(table)
-
-        # TODO: change this and leave it up to the caller to convert to dnde
-        # See https://github.com/gammapy/gammapy/issues/1034
-        return flux_points.to_sed_type("dnde", model=self.spectral_model)
+        return FluxPoints(table)
 
     @property
     def spectral_model(self):
@@ -617,12 +603,7 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         table["flux_ul"] = np.nan * flux_err.unit
         flux_ul = compute_flux_points_ul(table["flux"], table["flux_errp"])
         table["flux_ul"][is_ul] = flux_ul[is_ul]
-
-        flux_points = FluxPoints(table)
-
-        # TODO: change this and leave it up to the caller to convert to dnde
-        # See https://github.com/gammapy/gammapy/issues/1034
-        return flux_points.to_sed_type("dnde", model=self.spectral_model)
+        return FluxPoints(table)
 
     @property
     def spectral_model(self):
@@ -809,7 +790,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
     def _info_spectral_points(self):
         """Print spectral points."""
         ss = "\n*** Spectral points ***\n\n"
-        lines = self._flux_points_table_formatted.pformat(max_width=-1, max_lines=-1)
+        lines = format_flux_points_table(self.flux_points.table).pformat(max_width=-1, max_lines=-1)
         ss += "\n".join(lines)
         return ss + "\n"
 
@@ -866,28 +847,6 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         return model
 
     @property
-    def _flux_points_table_formatted(self):
-        """Returns formatted version of self.flux_points.table"""
-        table = self.flux_points.table.copy()
-        flux_cols = [
-            "flux",
-            "flux_errn",
-            "flux_errp",
-            "e2dnde",
-            "e2dnde_errn",
-            "e2dnde_errp",
-            "flux_ul",
-            "e2dnde_ul",
-            "dnde",
-        ]
-        table["sqrt_ts"].format = ".1f"
-        table["e_ref"].format = ".1f"
-        for _ in flux_cols:
-            table[_].format = ".3"
-
-        return table
-
-    @property
     def flux_points(self):
         """Flux points (`~gammapy.spectrum.FluxPoints`)."""
         table = Table()
@@ -923,11 +882,6 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
 
         # Square root of test statistic
         table["sqrt_ts"] = self.data["Sqrt_TS_Band"]
-
-        # TODO: remove this computation here.
-        # # Instead provide a method on the FluxPoints class like `to_dnde()` or something.
-        table["dnde"] = (e2dnde * e_ref ** -2).to("cm-2 s-1 TeV-1")
-
         return FluxPoints(table)
 
     @property

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -272,7 +272,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += "{:<25s} : {}\n\n".format("Number of upper limits", d["sed_n_ul"])
 
         try:
-            lines = self._flux_points_table_formatted.pformat(
+            lines = self.flux_points.table_formatted.pformat(
                 max_width=-1, max_lines=-1
             )
             ss += "\n".join(lines)
@@ -381,16 +381,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         m["source_id"] = d["source_id"]
         m["common_name"] = d["common_name"]
         m["reference_id"] = d["reference_id"]
-
-    @property
-    def _flux_points_table_formatted(self):
-        """Returns formatted version of self.flux_points.table"""
-        table = self.flux_points.table.copy()
-        table["e_ref"].format = ".3f"
-        flux_cols = ["dnde", "dnde_errn", "dnde_errp", "dnde_err"]
-        for _ in set(table.colnames) & set(flux_cols):
-            table[_].format = ".3e"
-        return table
 
     @property
     def flux_points(self):

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -406,21 +406,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         ss = "\n*** Flux points info ***\n\n"
         ss += "Number of flux points: {}\n".format(d["N_Flux_Points"])
         ss += "Flux points table: \n\n"
-
-        flux_points = self.flux_points.table.copy()
-
-        energy_cols = ["e_ref", "e_min", "e_max"]
-        flux_cols = ["dnde", "dnde_errn", "dnde_errp", "dnde_ul"]
-        cols = energy_cols + flux_cols + ["is_ul"]
-        flux_points = flux_points[cols]
-
-        for _ in energy_cols:
-            flux_points[_].format = ".3f"
-
-        for _ in flux_cols:
-            flux_points[_].format = ".3e"
-
-        lines = flux_points.pformat(max_width=-1, max_lines=-1)
+        lines = self.flux_points.table_formatted.pformat(max_width=-1, max_lines=-1)
         ss += "\n".join(lines)
         return ss + "\n"
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -128,9 +128,11 @@ class TestFermi3FGLObject:
 
         assert len(flux_points.table) == 5
         assert "flux_ul" in flux_points.table.colnames
+        assert flux_points.sed_type == "flux"
 
-        desired = [8.174943e-03, 7.676263e-04, 6.119782e-05, 3.350906e-06, 1.308784e-08]
-        assert_allclose(flux_points.table["dnde"].data, desired, rtol=1e-5)
+        desired = [1.645888e-06, 5.445407e-07, 1.255338e-07, 2.545524e-08,
+                   2.263189e-09]
+        assert_allclose(flux_points.table["flux"].data, desired, rtol=1e-5)
 
     def test_flux_points_ul(self):
         source = self.cat["3FGL J0000.2-3738"]
@@ -301,8 +303,9 @@ class TestFermi3FHLObject:
         assert len(flux_points.table) == 5
         assert "flux_ul" in flux_points.table.colnames
 
-        desired = [5.124e-07, 7.370e-08, 9.044e-09, 7.681e-10, 4.307e-11]
-        assert_allclose(flux_points.table["dnde"].data, desired, rtol=1e-3)
+        desired = [5.169889e-09, 2.245024e-09, 9.243175e-10, 2.758956e-10,
+                   6.684021e-11]
+        assert_allclose(flux_points.table["flux"].data, desired, rtol=1e-3)
 
     @pytest.mark.parametrize(
         "name", ["Crab Nebula", "3FHL J0534.5+2201", "3FGL J0534.5+2201i"]

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -360,7 +360,7 @@ class DataStoreObservation(object):
 class Observations(object):
     """Container class that holds a list of observations.
 
-    Parameters:
+    Parameters
     ----------
     obs_list : list
         A list of `~gammapy.data.DataStoreObservation`

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -141,6 +141,19 @@ class FluxPoints(object):
         fmt = '{}(sed_type="{}", n_points={})'
         return fmt.format(self.__class__.__name__, self.sed_type, len(self.table))
 
+    @property
+    def table_formatted(self):
+        """Return formatted version of the flux points table. Used for pretty printing"""
+        table = self.table.copy()
+
+        for column in table.colnames:
+            if column.startswith(("dnde", "eflux", "flux", "e2dnde")):
+                table[column].format = ".3e"
+            elif column in ("e_min", "e_max", "e_ref", "sqrt_TS"):
+                table[column].format = ".3f"
+
+        return table
+
     @classmethod
     def read(cls, filename, **kwargs):
         """Read flux points.
@@ -251,7 +264,6 @@ class FluxPoints(object):
         table["dnde"] = dnde
 
         if "flux_err" in table.colnames:
-            # TODO: implement better error handling, e.g. MC based method
             table["dnde_err"] = dnde * table["flux_err"].quantity / flux
 
         if "flux_errn" in table.colnames:

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -236,6 +236,58 @@ class FluxPoints(object):
         table_drop_ul = self.table[~self.is_ul]
         return self.__class__(table_drop_ul)
 
+    def _flux_to_dnde(self, e_ref, table, model, pwl_approx):
+        if model is None:
+            model = PowerLaw()
+
+        e_min, e_max = self.e_min, self.e_max
+
+        flux = table["flux"].quantity
+        dnde = self._dnde_from_flux(flux, model, e_ref, e_min, e_max, pwl_approx)
+
+        # Add to result table
+        table["e_ref"] = e_ref
+        table["dnde"] = dnde
+
+        if "flux_err" in table.colnames:
+            # TODO: implement better error handling, e.g. MC based method
+            table["dnde_err"] = dnde * table["flux_err"].quantity / flux
+
+        if "flux_errn" in table.colnames:
+            table["dnde_errn"] = dnde * table["flux_errn"].quantity / flux
+            table["dnde_errp"] = dnde * table["flux_errp"].quantity / flux
+
+        if "flux_ul" in table.colnames:
+            flux_ul = table["flux_ul"].quantity
+            dnde_ul = self._dnde_from_flux(
+                flux_ul, model, e_ref, e_min, e_max, pwl_approx
+            )
+            table["dnde_ul"] = dnde_ul
+
+        return table
+
+    @staticmethod
+    def _dnde_to_e2dnde(e_ref, table):
+        for suffix in ["", "_ul", "_err", "_errp", "_errn"]:
+            try:
+                data = table["dnde" + suffix].quantity
+                table["e2dnde" + suffix] =  (e_ref ** 2 * data).to(DEFAULT_UNIT["e2dnde"])
+            except KeyError:
+                continue
+
+        return table
+
+    @staticmethod
+    def _e2dnde_to_dnde(e_ref, table):
+        for suffix in ["", "_ul", "_err", "_errp", "_errn"]:
+            try:
+                data = table["e2dnde" + suffix].quantity
+                table["dnde" + suffix] =  (e_ref ** -2 * data).to(DEFAULT_UNIT["dnde"])
+            except KeyError:
+                continue
+
+        return table
+
     def to_sed_type(self, sed_type, method="log_center", model=None, pwl_approx=False):
         """Convert to a different SED type (return new `FluxPoints`).
 
@@ -275,52 +327,30 @@ class FluxPoints(object):
         >>> model = PowerLaw(index=2.2)
         >>> flux_points_dnde = flux_points.to_sed_type('dnde', model=model)
         """
-        # TODO: implement other directions. Refactor!
-        if sed_type != "dnde":
+        # TODO: implement other directions.
+        table = self.table.copy()
+
+        if self.sed_type == "flux" and sed_type == "dnde":
+            # Compute e_ref
+            if method == "table":
+                e_ref = table["e_ref"].quantity
+            elif method == "log_center":
+                e_ref = np.sqrt(self.e_min * self.e_max)
+            elif method == "lafferty":
+                # set e_ref that it represents the mean dnde in the given energy bin
+                e_ref = self._e_ref_lafferty(model, self.e_min, self.e_max)
+            else:
+                raise ValueError("Invalid method: {}".format(method))
+            table = self._flux_to_dnde(e_ref, table, model, pwl_approx)
+
+        elif self.sed_type == "dnde" and sed_type == "e2dnde":
+            table = self._dnde_to_e2dnde(self.e_ref, table)
+        elif self.sed_type == "e2dnde" and sed_type == "dnde":
+            table = self._e2dnde_to_dnde(self.e_ref, table)
+        else:
             raise NotImplementedError
 
-        if model is None:
-            model = PowerLaw()
-
-        input_table = self.table.copy()
-
-        e_min, e_max = self.e_min, self.e_max
-
-        # Compute e_ref
-        if method == "table":
-            e_ref = input_table["e_ref"].quantity
-        elif method == "log_center":
-            e_ref = np.sqrt(e_min * e_max)
-        elif method == "lafferty":
-            # set e_ref that it represents the mean dnde in the given energy bin
-            e_ref = self._e_ref_lafferty(model, e_min, e_max)
-        else:
-            raise ValueError("Invalid method: {}".format(method))
-
-        flux = input_table["flux"].quantity
-        dnde = self._dnde_from_flux(flux, model, e_ref, e_min, e_max, pwl_approx)
-
-        # Add to result table
-        table = input_table.copy()
-        table["e_ref"] = e_ref
-        table["dnde"] = dnde
-
-        if "flux_err" in table.colnames:
-            # TODO: implement better error handling, e.g. MC based method
-            table["dnde_err"] = dnde * table["flux_err"].quantity / flux
-
-        if "flux_errn" in table.colnames:
-            table["dnde_errn"] = dnde * table["flux_errn"].quantity / flux
-            table["dnde_errp"] = dnde * table["flux_errp"].quantity / flux
-
-        if "flux_ul" in table.colnames:
-            flux_ul = table["flux_ul"].quantity
-            dnde_ul = self._dnde_from_flux(
-                flux_ul, model, e_ref, e_min, e_max, pwl_approx
-            )
-            table["dnde_ul"] = dnde_ul
-
-        table.meta["SED_TYPE"] = "dnde"
+        table.meta["SED_TYPE"] = sed_type
         return FluxPoints(table)
 
     @staticmethod

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -296,11 +296,12 @@ class SpectrumResult(object):
         """
         e_ref = self.points.table["e_ref"].quantity
         points = self.points.table["dnde"].quantity
-        points_err = self.points.get_flux_err()
-
-        # Deal with asymmetric errors
-        if isinstance(points_err, tuple):
-            points_err = np.sqrt(points_err[0] * points_err[1])
+        try:
+            points_err = self.points.table["dnde_err"].quantity
+        except KeyError:
+            points_errp = self.points.table["dnde_errp"].quantity
+            points_errn = self.points.table["dnde_errp"].quantity
+            points_err = np.sqrt(points_errp * points_errn)
 
         model_val = self.model(e_ref)
         residuals = ((points - model_val) / model_val).to_value("")

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -294,6 +294,22 @@ class TestFluxPoints:
             flux_points.plot()
 
 
+@requires_data("gammapy-extra")
+def test_compute_flux_points_dnde_fermi():
+    """
+    Test compute_flux_points_dnde on fermi source.
+    """
+    fermi_3fgl = SourceCatalog3FGL()
+    source = fermi_3fgl["3FGL J0835.3-4510"]
+    flux_points = source.flux_points.to_sed_type(
+        "dnde", model=source.spectral_model, method="log_center", pwl_approx=True
+    )
+    for column in ["dnde", "dnde_errn", "dnde_errp", "dnde_ul"]:
+        actual = flux_points.table["e2" + column].quantity
+        desired = flux_points.table[column].quantity * flux_points.e_ref ** 2
+        assert_quantity_allclose(actual[:-1], desired[:-1], rtol=1e-1)
+
+
 @pytest.fixture(scope="session")
 def sed_flux_points():
     path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/diff_flux_points.fits"

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -294,43 +294,6 @@ class TestFluxPoints:
             flux_points.plot()
 
 
-@requires_data("gammapy-extra")
-def test_compute_flux_points_dnde():
-    """
-    Test compute_flux_points_dnde on reference spectra.
-    """
-    path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/"
-    flux_points = FluxPoints.read(path + "flux_points.fits")
-    desired_fp = FluxPoints.read(path + "diff_flux_points.fits")
-
-    # TODO: verify index=2.2, but it seems to give reasonable values
-    model = PowerLaw(2.2 * u.Unit(""), 1e-12 * u.Unit("cm-2 s-1 TeV-1"), 1 * u.TeV)
-    actual_fp = flux_points.to_sed_type("dnde", model=model, method="log_center")
-
-    for column in ["dnde", "dnde_err", "dnde_ul"]:
-        actual = actual_fp.table[column].quantity
-        desired = desired_fp.table[column].quantity
-        assert_quantity_allclose(actual, desired, rtol=1e-12)
-
-
-@requires_data("gammapy-extra")
-def test_compute_flux_points_dnde_fermi():
-    """
-    Test compute_flux_points_dnde on fermi source.
-    """
-    fermi_3fgl = SourceCatalog3FGL()
-    source = fermi_3fgl["3FGL J0835.3-4510"]
-
-    flux_points = source.flux_points.to_sed_type(
-        "dnde", model=source.spectral_model, method="log_center", pwl_approx=True
-    )
-
-    for column in ["dnde", "dnde_errn", "dnde_errp", "dnde_ul"]:
-        actual = flux_points.table["e2" + column].quantity
-        desired = flux_points.table[column].quantity * flux_points.e_ref ** 2
-        assert_quantity_allclose(actual[:-1], desired[:-1], rtol=1e-1)
-
-
 @pytest.fixture(scope="session")
 def sed_flux_points():
     path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/diff_flux_points.fits"

--- a/gammapy/spectrum/tests/test_flux_point_core.py
+++ b/gammapy/spectrum/tests/test_flux_point_core.py
@@ -10,39 +10,40 @@ from ..flux_point import FluxPoints
 
 
 @pytest.fixture(scope="session")
-def flux_points_dnde():
-    e_ref = [np.sqrt(10), np.sqrt(10 * 100)] * u.TeV
-    pwl = PowerLaw()
+def model():
+    return PowerLaw()
 
+
+@pytest.fixture(scope="session")
+def flux_points_dnde(model):
+    e_ref = [np.sqrt(10), np.sqrt(10 * 100)] * u.TeV
     table = Table()
     table.meta["SED_TYPE"] = "dnde"
     table["e_ref"] = e_ref
-    table["dnde"] = pwl(e_ref)
+    table["dnde"] = model(e_ref)
     return FluxPoints(table)
 
 
 @pytest.fixture(scope="session")
-def flux_points_e2dnde():
+def flux_points_e2dnde(model):
     e_ref = [np.sqrt(10), np.sqrt(10 * 100)] * u.TeV
-    pwl = PowerLaw()
-
     table = Table()
     table.meta["SED_TYPE"] = "e2dnde"
     table["e_ref"] = e_ref
-    table["e2dnde"] = (pwl(e_ref) * e_ref ** 2).to("erg cm-2 s-1")
+    table["e2dnde"] = (model(e_ref) * e_ref ** 2).to("erg cm-2 s-1")
     return FluxPoints(table)
 
 
 @pytest.fixture(scope="session")
-def flux_points_flux():
+def flux_points_flux(model):
     e_min = [1, 10] * u.TeV
     e_max = [10, 100] * u.TeV
-    pwl = PowerLaw()
+
     table = Table()
     table.meta["SED_TYPE"] = "flux"
     table["e_min"] = e_min
     table["e_max"] = e_max
-    table["flux"] = pwl.integral(e_min, e_max)
+    table["flux"] = model.integral(e_min, e_max)
     return FluxPoints(table)
 
 

--- a/gammapy/spectrum/tests/test_flux_point_core.py
+++ b/gammapy/spectrum/tests/test_flux_point_core.py
@@ -5,12 +5,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Table
 import astropy.units as u
-from ...utils.testing import (
-    requires_dependency,
-    requires_data,
-    assert_quantity_allclose,
-    mpl_plot_check,
-)
 from ..models import PowerLaw
 from ..flux_point import FluxPoints
 

--- a/gammapy/spectrum/tests/test_flux_point_core.py
+++ b/gammapy/spectrum/tests/test_flux_point_core.py
@@ -1,0 +1,71 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy.table import Table
+import astropy.units as u
+from ...utils.testing import (
+    requires_dependency,
+    requires_data,
+    assert_quantity_allclose,
+    mpl_plot_check,
+)
+from ..models import PowerLaw
+from ..flux_point import FluxPoints
+
+
+@pytest.fixture(scope="session")
+def flux_points_dnde():
+    e_ref = [np.sqrt(10), np.sqrt(10 * 100)] * u.TeV
+    pwl = PowerLaw()
+
+    table = Table()
+    table.meta["SED_TYPE"] = "dnde"
+    table["e_ref"] = e_ref
+    table["dnde"] = pwl(e_ref)
+    return FluxPoints(table)
+
+
+@pytest.fixture(scope="session")
+def flux_points_e2dnde():
+    e_ref = [np.sqrt(10), np.sqrt(10 * 100)] * u.TeV
+    pwl = PowerLaw()
+
+    table = Table()
+    table.meta["SED_TYPE"] = "e2dnde"
+    table["e_ref"] = e_ref
+    table["e2dnde"] = (pwl(e_ref) * e_ref ** 2).to("erg cm-2 s-1")
+    return FluxPoints(table)
+
+
+@pytest.fixture(scope="session")
+def flux_points_flux():
+    e_min = [1, 10] * u.TeV
+    e_max = [10, 100] * u.TeV
+    pwl = PowerLaw()
+    table = Table()
+    table.meta["SED_TYPE"] = "flux"
+    table["e_min"] = e_min
+    table["e_max"] = e_max
+    table["flux"] = pwl.integral(e_min, e_max)
+    return FluxPoints(table)
+
+
+def test_dnde_to_e2dnde(flux_points_dnde, flux_points_e2dnde):
+    actual = flux_points_dnde.to_sed_type("e2dnde").table
+    desired = flux_points_e2dnde.table
+    assert_allclose(actual["e2dnde"], desired["e2dnde"])
+
+
+def test_e2dnde_to_dnde(flux_points_e2dnde, flux_points_dnde):
+    actual = flux_points_e2dnde.to_sed_type("dnde").table
+    desired = flux_points_dnde.table
+    assert_allclose(actual["dnde"], desired["dnde"])
+
+
+def test_flux_to_dnde(flux_points_flux, flux_points_dnde):
+    actual = flux_points_flux.to_sed_type("dnde", method="log_center").table
+    desired = flux_points_dnde.table
+    assert_allclose(actual["e_ref"], desired["e_ref"])
+    assert_allclose(actual["dnde"], desired["dnde"])

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -45,7 +45,7 @@ class CountsPredictor(object):
                                             sigma=0.3, bias=0)
 
         model = models.PowerLaw(index=2.3,
-                                amplitude="2.5e-12 cm-2 s-1 TeV-1"),
+                                amplitude="2.5e-12 cm-2 s-1 TeV-1",
                                 reference="1 TeV")
 
         livetime = 1 * u.h


### PR DESCRIPTION
This PR addresses the issues #1034 as well as #918. It implements the following changes:

* Remove the internal SED type conversion of flux points from the Fermi catalog objects.
* Implement the possibility to convert from `dnde` -> `e2dnde` and back. 
* Add unit tests for the sed type conversions.
* Remove the `sed_type` option from `FluxPoints.plot()`, to avoid confusion.


