### PR TITLE
Fix parameter limit handling in fitting

### DIFF
--- a/gammapy/stats/poisson.py
+++ b/gammapy/stats/poisson.py
@@ -611,7 +611,7 @@ def _excess_matching_significance_lima(mu_bkg, significance):
         if n_on >= 0:
             return _significance_lima(n_on, mu_bkg) - significance
         else:
-            # This high value is to tell the optimiser to stay n_on >= 0
+            # This high value is to tell the optimizer to stay n_on >= 0
             return 1e10
 
     excess_guess = _excess_matching_significance_simple(mu_bkg, significance)
@@ -636,7 +636,7 @@ def _excess_matching_significance_on_off_lima(n_off, alpha, significance):
         if n_on >= 0:
             return _significance_lima_on_off(n_on, n_off, alpha) - significance
         else:
-            # This high value is to tell the optimiser to stay n_on >= 0
+            # This high value is to tell the optimizer to stay n_on >= 0
             return 1e10
 
     excess_guess = _excess_matching_significance_on_off_simple(

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -102,8 +102,8 @@ def make_minuit_par_kwargs(parameters):
         par = parameters[idx]
         kwargs[parname_] = par.factor
 
-        min_ = None if np.isnan(par.min) else par.min
-        max_ = None if np.isnan(par.max) else par.max
+        min_ = None if np.isnan(par.factor_min) else par.factor_min
+        max_ = None if np.isnan(par.factor_max) else par.factor_max
         kwargs["limit_{}".format(parname_)] = (min_, max_)
 
         kwargs["error_{}".format(parname_)] = 1

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -348,7 +348,7 @@ class Parameters(object):
             error = errors.get(par.name, 0)
             error = u.Quantity(error, par.unit).value
             diag.append(error)
-        self.covariance = np.diag(diag) ** 2
+        self.covariance = np.diag(np.power(diag, 2))
 
     # TODO: this is a temporary solution until we have a better way
     # to handle covariance matrices via a class
@@ -387,7 +387,7 @@ class Parameters(object):
     def set_parameter_factors(self, factors):
         """Set factor of all parameters.
 
-        Used in the optimiser interface.
+        Used in the optimizer interface.
         """
         for factor, parameter in zip(factors, self.parameters):
             parameter.factor = factor
@@ -400,7 +400,7 @@ class Parameters(object):
     def set_covariance_factors(self, matrix):
         """Set covariance from factor covariance matrix.
 
-        Used in the optimiser interface.
+        Used in the optimizer interface.
         """
         self.covariance = self._scale_matrix * matrix
 

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -191,8 +191,11 @@ class Parameter(object):
         Available methods:
 
         * ``scale10`` sets ``scale`` to power of 10,
-          so that factor is in the range 1 to 10
+          so that abs(factor) is in the range 1 to 10
         * ``factor1`` sets ``factor, scale = 1, value``
+
+        In both cases the sign of value is stored in ``factor``,
+        i.e. the ``scale`` is always positive.
 
         Parameters
         ----------
@@ -202,8 +205,8 @@ class Parameter(object):
         if method == "scale10":
             value = self.value
             if value != 0:
-                power = int(np.log10(np.absolute(value)))
-                scale = 10.0 ** power
+                exponent = np.floor(np.log10(np.abs(value)))
+                scale = np.power(10.0, exponent)
                 self.factor = value / scale
                 self.scale = scale
         elif method == "factor1":

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -15,6 +15,20 @@ class Parameter(object):
     """
     Class representing model parameters.
 
+    Note that the parameter value has been split into
+    a factor and scale like this::
+
+        value = factor x scale
+
+    Users should interact with the ``value``, ``quantity``
+    or ``min`` and ``max`` properties and consider the fact
+    that there is a ``factor``` and ``scale`` an implementation detail.
+
+    That was introduced for numerical stability in parameter and error
+    estimation methods, only in the Gammapy optimiser interface do we
+    interact with the ``factor``, ``factor_min`` and ``factor_max`` properties,
+    i.e. the optimiser "sees" the well-scaled problem.
+
     Parameters
     ----------
     name : str
@@ -97,6 +111,14 @@ class Parameter(object):
         self._min = float(val)
 
     @property
+    def factor_min(self):
+        """Factor min (float).
+
+        This ``factor_min = min / scale`` is for the optimizer interface.
+        """
+        return self.min / self.scale
+
+    @property
     def max(self):
         """Maximum (float)."""
         return self._max
@@ -104,6 +126,14 @@ class Parameter(object):
     @max.setter
     def max(self, val):
         self._max = float(val)
+
+    @property
+    def factor_max(self):
+        """Factor max (float).
+
+        This ``factor_max = max / scale`` is for the optimizer interface.
+        """
+        return self.max / self.scale
 
     @property
     def frozen(self):

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -56,9 +56,9 @@ def optimize_sherpa(parameters, function, **kwargs):
     optimizer = get_sherpa_optimizer(method)
     optimizer.config.update(kwargs)
 
-    pars = [par.value for par in parameters.parameters]
-    parmins = [par.min for par in parameters.parameters]
-    parmaxes = [par.max for par in parameters.parameters]
+    pars = [par.factor for par in parameters.parameters]
+    parmins = [par.factor_min for par in parameters.parameters]
+    parmaxes = [par.factor_max for par in parameters.parameters]
 
     statfunc = SherpaFunction(function, parameters)
 

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -4,7 +4,7 @@ import numpy as np
 __all__ = ["optimize_sherpa"]
 
 
-def get_sherpa_optimiser(name):
+def get_sherpa_optimizer(name):
     from sherpa.optmethods import LevMar, NelderMead, MonCar, GridSearch
 
     return {
@@ -53,7 +53,7 @@ def optimize_sherpa(parameters, function, **kwargs):
         Tuple containing the best fit factors, some info and the optimizer instance.
     """
     method = kwargs.pop("method", "simplex")
-    optimizer = get_sherpa_optimiser(method)
+    optimizer = get_sherpa_optimizer(method)
     optimizer.config.update(kwargs)
 
     pars = [par.value for par in parameters.parameters]

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -1,46 +1,76 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 from numpy.testing import assert_allclose
-from ...testing import requires_dependency
 from .. import Parameter, Parameters, optimize_iminuit
+
+pytest.importorskip("iminuit")
 
 
 def fcn(parameters):
     x = parameters["x"].value
     y = parameters["y"].value
     z = parameters["z"].value
-    return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
+    x_opt, y_opt, z_opt = 2, 3e2, 4e-2
+    return (x - x_opt) ** 2 + (y - y_opt) ** 2 + (z - z_opt) ** 2
 
 
-@requires_dependency("iminuit")
-def test_iminuit():
-    pars = Parameters([Parameter("x", 2.1), Parameter("y", 3.1), Parameter("z", 4.1)])
+@pytest.fixture()
+def pars():
+    x = Parameter("x", 2.1)
+    y = Parameter("y", 3.1, scale=1e2)
+    z = Parameter("z", 4.1, scale=1e-2)
+    return Parameters([x, y, z])
 
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
-    assert info["success"]
 
-    assert_allclose(factors, [2, 3, 4], rtol=1e-2)
-    assert_allclose(minuit.values["par_000_x"], 2, rtol=1e-2)
-    assert_allclose(minuit.values["par_001_y"], 3, rtol=1e-2)
-    assert_allclose(minuit.values["par_002_z"], 4, rtol=1e-2)
-
-    # Test freeze
-    pars["x"].frozen = True
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
-    assert info["success"]
-    assert minuit.list_of_fixed_param() == ["par_000_x"]
-
-    # Test limits
-    pars["y"].min = 4
+def test_iminuit_basic(pars):
     factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
 
     assert info["success"]
+
+    # Check the result in parameters is OK
+    assert_allclose(pars["x"].value, 2, rtol=1e-3)
+    assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
+    # Precision of estimate on "z" is very poor (0.040488). Why is it so bad?
+    assert_allclose(pars["z"].value, 4e-2, rtol=2e-2)
+
+    # Check that minuit sees the parameter factors correctly
+    assert_allclose(factors, [2, 3, 4], rtol=1e-3)
+    assert_allclose(minuit.values["par_000_x"], 2, rtol=1e-3)
+    assert_allclose(minuit.values["par_001_y"], 3, rtol=1e-3)
+    assert_allclose(minuit.values["par_002_z"], 4, rtol=1e-3)
+
+
+def test_iminuit_frozen(pars):
+    pars["y"].frozen = True
+
+    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+
+    assert info["success"]
+
+    assert_allclose(pars["y"].value, 3.1e2)
+    assert minuit.list_of_fixed_param() == ["par_001_y"]
+
+
+def test_iminuit_limits(pars):
+    pars["y"].min = 301
+
+    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+
+    assert info["success"]
+
+    # Check the result in parameters is OK
+    assert_allclose(pars["x"].value, 2, rtol=1e-2)
+    assert_allclose(pars["y"].value, 301, rtol=1e-3)
+
+    # Check that minuit sees the limit factors correctly
     states = minuit.get_param_states()
     assert not states[0]["has_limits"]
-    assert not states[2]["has_limits"]
 
-    assert states[1]["has_limits"]
-    assert states[1]["lower_limit"] == 4
+    y = states[1]
+    assert y["has_limits"]
+    assert_allclose(y["lower_limit"], 3.01)
+
     # The next assert can be added when we no longer test on iminuit 1.2
     # See https://github.com/gammapy/gammapy/pull/1771
     # assert states[1]["upper_limit"] is None

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -30,11 +30,15 @@ def test_parameter_init():
         Parameter(1, 2)
 
 
-def test_parameter_value():
-    par = Parameter("spam", 42, "deg", 10)
+def test_parameter_scale():
+    # Basic check how scale is used for value, min, max
+    par = Parameter("spam", 42, "deg", 10, 400, 500)
 
-    value = par.value
-    assert value == 420
+    assert par.value == 420
+    assert par.min == 400
+    assert_allclose(par.factor_min, 40)
+    assert par.max == 500
+    assert_allclose(par.factor_max, 50)
 
     par.value = 70
     assert par.scale == 10

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -69,12 +69,27 @@ def test_parameter_to_dict():
     assert isinstance(d["unit"], six.string_types)
 
 
-def test_parameter_large():
-    # Test case for Parameter with very large value
-    # Regression test for https://github.com/gammapy/gammapy/issues/1883
-    par = Parameter("a", 9e35)
+@pytest.mark.parametrize(
+    "method,value,factor,scale",
+    [
+        # Check method="scale10" in detail
+        ("scale10", 2e-10, 2, 1e-10),
+        ("scale10", 2e10, 2, 1e10),
+        ("scale10", -2e-10, -2, 1e-10),
+        ("scale10", -2e10, -2, 1e10),
+        # Check that results are OK for very large numbers
+        # Regression test for https://github.com/gammapy/gammapy/issues/1883
+        ("scale10", 9e35, 9, 1e35),
+        # Checks for the simpler method="factor1"
+        ("factor1", 2e10, 2, 1e10),
+        ("factor1", -2e10, -2, 1e10),
+    ],
+)
+def test_parameter_autoscale(method, value, factor, scale):
+    par = Parameter("", value)
     par.autoscale()
-    assert_allclose(par.scale, 1e35)
+    assert_allclose(par.factor, factor)
+    assert_allclose(par.scale, scale)
     assert isinstance(par.scale, float)
 
 
@@ -122,39 +137,8 @@ def test_parameters_set_covariance_factors(pars):
     assert_allclose(pars.covariance, cov_factor)
 
 
-def test_parameters_scale():
-    pars = Parameters(
-        [
-            Parameter("", factor=10, scale=5),
-            Parameter("", factor=10, scale=50),
-            Parameter("", factor=100, scale=5),
-            Parameter("", factor=-10, scale=1),
-            Parameter("", factor=0, scale=1),
-        ]
-    )
-
-    pars.autoscale()  # default: 'scale10'
-
-    assert_allclose(pars[0].factor, 5)
+def test_parameters_autoscale():
+    pars = Parameters([Parameter("", 20)])
+    pars.autoscale()
+    assert_allclose(pars[0].factor, 2)
     assert_allclose(pars[0].scale, 10)
-    assert_allclose(pars[1].factor, 5)
-    assert_allclose(pars[1].scale, 100)
-    assert_allclose(pars[2].factor, 5)
-    assert_allclose(pars[2].scale, 100)
-    assert_allclose(pars[3].factor, -1)
-    assert_allclose(pars[3].scale, 10)
-    assert_allclose(pars[4].factor, 0)
-    assert_allclose(pars[4].scale, 1)
-
-    pars.autoscale("factor1")
-
-    assert_allclose(pars[0].factor, 1)
-    assert_allclose(pars[0].scale, 50)
-    assert_allclose(pars[1].factor, 1)
-    assert_allclose(pars[1].scale, 500)
-    assert_allclose(pars[2].factor, 1)
-    assert_allclose(pars[2].scale, 500)
-    assert_allclose(pars[3].factor, 1)
-    assert_allclose(pars[3].scale, -10)
-    assert_allclose(pars[4].factor, 1)
-    assert_allclose(pars[4].scale, 0)

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -11,7 +11,16 @@ def fcn(parameters):
     x = parameters["x"].value
     y = parameters["y"].value
     z = parameters["z"].value
-    return (x - 2) ** 2 + (y - 3) ** 2 + (z - 4) ** 2
+    x_opt, y_opt, z_opt = 2, 3e5, 4e-5
+    return (x - x_opt) ** 2 + (y - y_opt) ** 2 + (z - z_opt) ** 2
+
+
+@pytest.fixture()
+def pars():
+    x = Parameter("x", 2.1)
+    y = Parameter("y", 3.1, scale=1e5)
+    z = Parameter("z", 4.1, scale=1e-5)
+    return Parameters([x, y, z])
 
 
 # TODO: levmar doesn't work yet; needs array of statval as return in likelihood
@@ -19,16 +28,17 @@ def fcn(parameters):
 
 
 @pytest.mark.parametrize("method", ["moncar", "simplex"])
-def test_sherpa(method):
-    pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])
-
+def test_sherpa(method, pars):
     factors, info, optimizer = optimize_sherpa(
         function=fcn, parameters=pars, method=method
     )
 
     assert info["success"]
-    assert info["nfev"] > 10
-    assert_allclose(factors, [2, 3, 4], rtol=1e-2)
-    assert_allclose(pars["x"].value, 2, rtol=1e-2)
-    assert_allclose(pars["y"].value, 3, rtol=1e-2)
-    assert_allclose(pars["z"].value, 4, rtol=1e-2)
+
+    # Check the result in parameters is OK
+    assert_allclose(pars["x"].value, 2, rtol=1e-5)
+    assert_allclose(pars["y"].value, 3e5, rtol=1e-5)
+    assert_allclose(pars["z"].value, 4e-5, rtol=1e-5)
+
+    # Check that minuit sees the parameter factors correctly
+    assert_allclose(factors, [2, 3, 4], rtol=1e-3)

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -22,7 +22,9 @@ def fcn(parameters):
 def test_sherpa(method):
     pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])
 
-    factors, info, optimizer = optimize_sherpa(function=fcn, parameters=pars, method=method)
+    factors, info, optimizer = optimize_sherpa(
+        function=fcn, parameters=pars, method=method
+    )
 
     assert info["success"]
     assert info["nfev"] > 10

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -14,7 +14,7 @@ def fcn(parameters):
 
 
 # TODO: levmar doesn't work yet; needs array of statval as return in likelihood
-# optimiser='gridsearch' would require very low tolerance asserts, not added for now
+# method='gridsearch' would require very low tolerance asserts, not added for now
 
 
 @requires_dependency("sherpa")
@@ -22,7 +22,7 @@ def fcn(parameters):
 def test_sherpa(method):
     pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])
 
-    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars, method=method)
+    factors, info, optimizer = optimize_sherpa(function=fcn, parameters=pars, method=method)
 
     assert info["success"]
     assert info["nfev"] > 10

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -2,8 +2,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from numpy.testing import assert_allclose
-from ...testing import requires_dependency
 from .. import Parameter, Parameters, optimize_sherpa
+
+pytest.importorskip("sherpa")
 
 
 def fcn(parameters):
@@ -17,7 +18,6 @@ def fcn(parameters):
 # method='gridsearch' would require very low tolerance asserts, not added for now
 
 
-@requires_dependency("sherpa")
 @pytest.mark.parametrize("method", ["moncar", "simplex"])
 def test_sherpa(method):
     pars = Parameters([Parameter("x", 2.2), Parameter("y", 3.4), Parameter("z", 4.5)])


### PR DESCRIPTION
This PR fixes the parameter limit handling for iminuit and sherpa in gammapy.utils.fitting.

This was reported in #1878 and the changes here are what we discussed last wee (see https://github.com/gammapy/gammapy/issues/1878#issuecomment-434637040).

While working on this I noticed two other small and related issues, fixed in 
1b25f8e (make the factor 10 autoscale behave as intended for scales smaller than 1) and in 
b0a6505 I changed `get_sherpa_optimizer` to be spelled with "z" instead of "s", giving us now consistency with spelling of "optimize" in Gammapy.

@adonath @registerrier - Please review.

For the min / max scale I wasn't sure what to put as data member and what as derived property.
For now, I left `min` and `max` as data member, and added `factor_min = min / scale` and `factor_max = max / scale` as derived properties. I.e. it's opposite from `value = factor * scale` where `factor` is the data member.

I looked at http://cta.irap.omp.eu/gammalib-devel/doxygen/classGOptimizerPar.html#details and see that they have always the `factor` as data member, and then `value`, `min` and `max` all defined as factor times scale properties:
```
value    = m_factor_value    * m_scale
error    = m_factor_error    * m_scale
gradient = m_factor_gradient * m_scale
min      = m_factor_min      * m_scale
max      = m_factor_max      * m_scale
```
I think I like that a little bit better, because it's a bit more uniform.

@adonath @registerrier - Any thoughts / preference on this point?