### PR TITLE
Take observation time from GTI table

### DIFF
--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -367,7 +367,7 @@ class ObservationTable(Table):
         gti : `~gammapy.data.GTI`
             GTI table containing one row (TSTART and TSTOP of the observation with `obs_id`)
         """
-        header = OrderedDict(
+        meta = OrderedDict(
             EXTNAME="GTI",
             HDUCLASS="GADF",
             HDUDOC="https://github.com/open-gamma-ray-astro/gamma-astro-data-formats",
@@ -380,12 +380,13 @@ class ObservationTable(Table):
             TIMEREF=self.meta.get("TIMEREF", "LOCAL"),
         )
 
-        idx = self.get_obs_idx(obs_id)[0]
-        start = self["TSTART"][idx].astype("float64")
-        stop = self["TSTOP"][idx].astype("float64")
-        gti_table = Table([[start], [stop]], names=("START", "STOP"), meta=header)
+        obs = self.select_obs_id(obs_id)
 
-        return GTI(gti_table)
+        gti = Table(meta=meta)
+        gti['START'] = obs["TSTART"].quantity.to('s')
+        gti['STOP'] = obs["TSTOP"].quantity.to('s')
+
+        return GTI(gti)
 
 
 class ObservationTableChecker(Checker):

--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 import numpy as np
 from astropy.table import Table
 from astropy.units import Unit, Quantity
@@ -10,6 +10,7 @@ from astropy.utils import lazyproperty
 from ..utils.scripts import make_path
 from ..utils.time import time_relative_to_ref
 from ..utils.testing import Checker
+from .gti import GTI
 
 __all__ = ["ObservationTable"]
 
@@ -350,6 +351,41 @@ class ObservationTable(Table):
 
         else:
             raise ValueError("Invalid selection type: {}".format(selection["type"]))
+
+    def create_gti(self, obs_id):
+        """Returns a GTI table containing TSTART and TSTOP from the table.
+
+        TODO: This method can be removed once GTI tables are explicitly required in Gammapy.
+
+        Parameters
+        ----------
+        obs_id : int
+            ID of the observation for which the GTI table will be created
+
+        Returns
+        -------
+        gti : `~gammapy.data.GTI`
+            GTI table containing one row (TSTART and TSTOP of the observation with `obs_id`)
+        """
+        header = OrderedDict(
+            EXTNAME="GTI",
+            HDUCLASS="GADF",
+            HDUDOC="https://github.com/open-gamma-ray-astro/gamma-astro-data-formats",
+            HDUVERS="0.2",
+            HDUCLAS1="GTI",
+            MJDREFI=self.meta["MJDREFI"],
+            MJDREFF=self.meta["MJDREFF"],
+            TIMEUNIT=self.meta.get("TIMEUNIT", "s"),
+            TIMESYS=self.meta["TIMESYS"],
+            TIMEREF=self.meta.get("TIMEREF", "LOCAL"),
+        )
+
+        idx = self.get_obs_idx(obs_id)[0]
+        start = self["TSTART"][idx].astype("float64")
+        stop = self["TSTOP"][idx].astype("float64")
+        gti_table = Table([[start], [stop]], names=("START", "STOP"), meta=header)
+
+        return GTI(gti_table)
 
 
 class ObservationTableChecker(Checker):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -200,7 +200,11 @@ class DataStoreObservation(object):
         """Load `gammapy.data.GTI` object."""
         try:
             return self.load(hdu_type="gti")
-        except IndexError:  # HDU index file does not contain the GTI table. We catch this for backward compatibility.
+        except IndexError:
+            # For now we support data without GTI HDUs
+            # TODO: if GTI becomes required, we should drop this case
+            # CTA discussion in https://github.com/open-gamma-ray-astro/gamma-astro-data-formats/issues/20
+            # Added in Gammapy in https://github.com/gammapy/gammapy/pull/1908
             return self.data_store.obs_table.create_gti(obs_id=self.obs_id)
 
     @property

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -248,7 +248,10 @@ class DataStoreObservation(object):
 
         The wall time, including dead-time.
         """
-        return Quantity(self.obs_info["ONTIME"], "second")
+        try:
+            return self.gti.time_sum
+        except IndexError:  # HDU index file does not contain the GTI table
+            return Quantity(self.obs_info["ONTIME"], "second")
 
     @lazyproperty
     def observation_live_time_duration(self):
@@ -259,7 +262,10 @@ class DataStoreObservation(object):
         Computed as ``t_live = t_observation * (1 - f_dead)``
         where ``f_dead`` is the dead-time fraction.
         """
-        return Quantity(self.obs_info["LIVETIME"], "second")
+        try:
+            return self.gti.time_sum * (1 - self.observation_dead_time_fraction)
+        except IndexError:  # HDU index file does not contain the GTI table
+            return Quantity(self.obs_info["LIVETIME"], "second")
 
     @lazyproperty
     def observation_dead_time_fraction(self):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -223,13 +223,13 @@ class DataStoreObservation(object):
         """Load background object."""
         return self.load(hdu_type="bkg")
 
-    @lazyproperty
+    @property
     def obs_info(self):
         """Observation information (`~collections.OrderedDict`)."""
         row = self.data_store.obs_table.select_obs_id(obs_id=self.obs_id)[0]
         return table_row_to_dict(row)
 
-    @lazyproperty
+    @property
     def tstart(self):
         """Observation start time (`~astropy.time.Time`)."""
         met_ref = time_ref_from_dict(self.data_store.obs_table.meta)
@@ -237,7 +237,7 @@ class DataStoreObservation(object):
         time = met_ref + met
         return time
 
-    @lazyproperty
+    @property
     def tstop(self):
         """Observation stop time (`~astropy.time.Time`)."""
         met_ref = time_ref_from_dict(self.data_store.obs_table.meta)
@@ -264,7 +264,7 @@ class DataStoreObservation(object):
         """
         return self.gti.time_sum * (1 - self.observation_dead_time_fraction)
 
-    @lazyproperty
+    @property
     def observation_dead_time_fraction(self):
         """Dead-time fraction (float).
 
@@ -280,35 +280,35 @@ class DataStoreObservation(object):
         """
         return 1 - self.obs_info["DEADC"]
 
-    @lazyproperty
+    @property
     def pointing_radec(self):
         """Pointing RA / DEC sky coordinates (`~astropy.coordinates.SkyCoord`)."""
         lon, lat = self.obs_info["RA_PNT"], self.obs_info["DEC_PNT"]
         return SkyCoord(lon, lat, unit="deg", frame="icrs")
 
-    @lazyproperty
+    @property
     def pointing_altaz(self):
         """Pointing ALT / AZ sky coordinates (`~astropy.coordinates.SkyCoord`)."""
         alt, az = self.obs_info["ALT_PNT"], self.obs_info["AZ_PNT"]
         return SkyCoord(az, alt, unit="deg", frame="altaz")
 
-    @lazyproperty
+    @property
     def pointing_zen(self):
         """Pointing zenith angle sky (`~astropy.units.Quantity`)."""
         return Quantity(self.obs_info["ZEN_PNT"], unit="deg")
 
-    @lazyproperty
+    @property
     def target_radec(self):
         """Target RA / DEC sky coordinates (`~astropy.coordinates.SkyCoord`)."""
         lon, lat = self.obs_info["RA_OBJ"], self.obs_info["DEC_OBJ"]
         return SkyCoord(lon, lat, unit="deg", frame="icrs")
 
-    @lazyproperty
+    @property
     def observatory_earth_location(self):
         """Observatory location (`~astropy.coordinates.EarthLocation`)."""
         return earth_location_from_dict(self.obs_info)
 
-    @lazyproperty
+    @property
     def muoneff(self):
         """Observation muon efficiency."""
         return self.obs_info["MUONEFF"]

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -39,6 +39,24 @@ def test_data_store_observation(data_store):
 
 
 @requires_data("gammapy-extra")
+def test_create_missing_gti():
+    """Test the DataStoreObservation._create_missing_gti() method.
+
+    For the 'hess-dl3-dr1' data set, the GTI tables contain only the 'TSTART' and 'TSTOP' from the 'event list' and
+    'obs index' header. The `DataStoreObservation._create_missing_gti()` method creates a GTI table on-the-fly using
+    exactly those values.
+    """
+    ds = data_store()
+    obs_time_1 = ds.obs(20136).observation_time_duration
+
+    ds = data_store()  # DataStore saves some lazyproperties when accessing a hdu location -> we create a new one
+    ds.hdu_table.remove_row(1)  # Remove reference to GTI table -> GTI table will be created on-the-fly
+    obs_time_2 = ds.obs(20136).observation_time_duration
+
+    assert obs_time_1 == obs_time_2
+
+
+@requires_data("gammapy-extra")
 def test_data_store_observation_to_observation_cta(data_store):
     """Test the DataStoreObservation.to_observation_cta conversion method"""
     obs = data_store.obs(23523).to_observation_cta()

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -35,26 +35,6 @@ def test_data_store_observation(data_store):
 
 
 @requires_data("gammapy-extra")
-def test_missing_gti(data_store):
-    """This tests the case when a GTI table is missing in the HDU index file.
-
-    For backward compatibility we create a GTI table on-the-fly by means of the Obs Index file
-    TODO: This method can be removed once GTI tables are explicitly required in Gammapy.
-    """
-    obs = data_store.obs(20136)
-    hdu_bkp = data_store.hdu_table.copy()
-    # remove the row with the GTI file location for obs_id 20136
-    data_store.hdu_table.remove_row(1)
-
-    try:
-        gti = obs.gti
-    finally:
-        data_store.hdu_table = hdu_bkp
-
-    assert type(gti) == GTI
-
-
-@requires_data("gammapy-extra")
 def test_data_store_observation_to_observation_cta(data_store):
     """Test the DataStoreObservation.to_observation_cta conversion method"""
     obs = data_store.obs(23523).to_observation_cta()


### PR DESCRIPTION
This PR addresses issues #1866 and #1504.

The observation time will now be calculated using the GTI table pointed to in the HDU index file.
For backward compatibility, it will take the observation time from the Obs index file if there is no GTI table available.

Maybe we could add a warning that taking the obs time from the Obs index file is deprecated and will raise an error in the future?

I checked the data sets we have in gammapy-extra for differences between the live-times (computed from the GTI table and taken from the obs index file). Only the data sets
* `datasets/hess-crab4-hd-hap-prod2` and
* `test_datasets/cube/data`

show a deviation of about 0.1-0.5%. For the rest of the data sets there is basically no difference.
For `datasets/hess-crab4-pa` there is no GTI table available.