### PR TITLE
Add tests for gammapy.utils.modeling.Fit

### DIFF
--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -162,7 +162,7 @@ class Parameter(object):
     def quantity(self, val):
         val = u.Quantity(val)
         self.value = val.value
-        self.unit = str(val.unit)
+        self.unit = val.unit
 
     def __repr__(self):
         return (
@@ -302,7 +302,7 @@ class Parameters(object):
         else:
             t["error"] = [self.error(idx) for idx in range(len(self.parameters))]
 
-        t["unit"] = [p.unit for p in self.parameters]
+        t["unit"] = [p.unit.to_string('fits') for p in self.parameters]
         t["min"] = [p.min for p in self.parameters]
         t["max"] = [p.max for p in self.parameters]
 

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -302,7 +302,7 @@ class Parameters(object):
         else:
             t["error"] = [self.error(idx) for idx in range(len(self.parameters))]
 
-        t["unit"] = [p.unit.to_string('fits') for p in self.parameters]
+        t["unit"] = [p.unit.to_string("fits") for p in self.parameters]
         t["min"] = [p.min for p in self.parameters]
         t["max"] = [p.max for p in self.parameters]
 

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -1,0 +1,64 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Unit tests for the Fit class"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import copy
+from numpy.testing import assert_allclose
+from ..parameter import Parameter, Parameters
+from ..fit import Fit
+
+pytest.importorskip("iminuit")
+
+
+class MyData(object):
+    """Dummy data class."""
+
+
+class MyModel(object):
+    """Dummy model class."""
+
+    def __init__(self):
+        self.parameters = Parameters(
+            [Parameter("x", 2), Parameter("y", 3e2), Parameter("z", 4e-2)]
+        )
+
+    def copy(self):
+        return copy.deepcopy(self)
+
+
+class MyFit(Fit):
+    def __init__(self, model, data):
+        self._model = model
+        self.data = data
+
+    def total_stat(self, parameters):
+        # self._model.parameters = parameters
+        x, y, z = [p.value for p in parameters]
+        x_opt, y_opt, z_opt = 2, 3e2, 4e-2
+        return (x - x_opt) ** 2 + (y - y_opt) ** 2 + (z - z_opt) ** 2
+
+
+# TODO: parametrize the test, re-use it for the range of backends
+# and optimiser / error estimator configurations we want to support
+def test():
+    data = MyData()
+    model = MyModel()
+    fit = MyFit(model, data)
+    result = fit.run(optimize_opts={"backend": "minuit"})
+    pars = result.model.parameters
+
+    assert result.success is True
+    assert_allclose(result.total_stat, 0)
+
+    assert_allclose(pars["x"].value, 2, rtol=1e-3)
+    assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
+    assert_allclose(pars["z"].value, 4e-2, rtol=1e-3)
+
+    assert_allclose(pars.error("x"), 1, rtol=1e-7)
+    assert_allclose(pars.error("y"), 1, rtol=1e-7)
+    assert_allclose(pars.error("z"), 1, rtol=1e-7)
+
+    # TODO: Add asserts once correlation method is added in the Parameters class.
+    # assert_allclose(pars.correlation("b1", "b2"), -0.455547, rtol=1e-7)
+    # assert_allclose(pars.correlation("b1", "b3"), -0.838906, rtol=1e-7)
+    # assert_allclose(pars.correlation("b2", "b3"), 0.821333, rtol=1e-7)

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -27,6 +27,7 @@ def test_iminuit_basic(pars):
     factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
 
     assert info["success"]
+    assert_allclose(fcn(pars), 0, atol=1e-5)
 
     # Check the result in parameters is OK
     assert_allclose(pars["x"].value, 2, rtol=1e-3)

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -34,6 +34,7 @@ def test_sherpa(method, pars):
     )
 
     assert info["success"]
+    assert_allclose(fcn(pars), 0, atol=1e-5)
 
     # Check the result in parameters is OK
     assert_allclose(pars["x"].value, 2, rtol=1e-5)


### PR DESCRIPTION
This PR adds `gammapy/utils/fitting/tests/test_fit.py` with a test that represents a unit test for our `Fit` class, or alternatively could be considered a high-level test for our iminuit back-end.

Before I thought that we have a bug in how we apply the parameter `scale` values (we have `value = factor x scale`) to the covariance matrix in the iminuit backend. But now I think that we are just not getting accurate covariance matrices from Minuit even for such simple cases.

There is still the caveat that I don't really understand if the likelihood here is correct or not, i.e. corresponds to what NIST / scipy.optimise.curve_fit / statsmodels use. Maybe the bug is there and iminuit does give good results?

I'd prefer to merge this in soon, then add scipy to have a second opinion on the covariance estimate (see #1907), and then continue with these tests.

@hdembinski - Is there a way to ask `iminuit` to compute higher-precision parameter values and errors, especially to give a better estimate of the covariance matrix?

@adonath - Would it be OK if I introduce a `Model` base class. Start super small, just with the `copy` and default `__call__` given here. Then it can grow over time as we develop our package. Do you think it's a good move? 

The other thing I'm not a fan of is that one has to write a `Fit` class, with the private `_model` everywhere, to use Gammapy. Not sure what to do here, i.e. if we should split that out into a `Stat` base class or something else.