### PR TITLE
Introducing the ObservationFilter class

### DIFF
--- a/gammapy/data/__init__.py
+++ b/gammapy/data/__init__.py
@@ -18,3 +18,4 @@ from .obs_table import *
 from .obs_summary import *
 from .obs_stats import *
 from .observations import *
+from .filters import *

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -268,6 +268,16 @@ class EventListBase(object):
 
     def select_time(self, time_interval):
         """Select events in time interval.
+
+        Parameters
+        ----------
+        time_interval : `astropy.time.Time`
+            Start time (inclusive) and stop time (exclusive) for the selection.
+
+        Returns
+        -------
+        events : `EventList`
+            Copy of event list with selection applied.
         """
         time = self.time
         mask = time_interval[0] <= time
@@ -368,6 +378,23 @@ class EventListBase(object):
             temp = np.where(separation < reg.radius)[0]
             mask = np.union1d(mask, temp)
         return mask
+
+    def select_custom(self, parameter, limits):
+        """Select events with respect to a custom parameter
+
+        Parameters
+        ----------
+        parameter : str
+            Parameter used for the selection. Must be present in `self.table`.
+        limits : tuple
+            Min (inclusive) and max (exclusive) value for the parameter to be selected.
+
+        Returns
+        -------
+        event_list : `EventList`
+            Copy of event list with selection applied.
+        """
+        raise NotImplementedError
 
     def _default_plot_ebounds(self):
         energy = self.energy

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -1,0 +1,94 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import logging
+
+__all__ = ["ObservationFilter"]
+
+log = logging.getLogger(__name__)
+
+
+class ObservationFilter(object):
+    """Holds and applies filters to observation data
+
+    Parameters
+    ----------
+    time_filter : `astropy.time.Time`
+        Start and stop time of the selected time interval. For now we only support a single time interval.
+    event_filters : list of dict
+        An event filter dictionary needs two keys:
+        'type' : str, one of the event filter types specified in `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`
+        'opts' : dict, it is passed on to the method of the `~gammapy.data.EventListBase` class
+                 that corresponds to the filter type (see `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`)
+        The filtered event list will be an intersection of all filters. A union of filters is not supported yet.
+
+    Examples
+    --------
+    >>> from gammapy.data import ObservationFilter
+    >>> from astropy.time import Time
+    >>> from astropy.coordinates import Angle
+    >>>
+    >>> time_span = Time(['2021-01-01T00:00:00', '2021-01-01T00:20:00'])
+    >>> region_filter = {'type': 'box_region', 'opts': dict(lon_lim=Angle([150, 300], 'deg'),
+    >>>                                                     lat_lim=Angle([-50, 0], 'deg'))}
+    >>> phase_filter = {'type': 'custom', 'opts': dict(parameter='PHASE', limits=(0.2, 0.8))}
+    >>>
+    >>> my_obs_filter = ObservationFilter(time_filter=time_span, event_filters=[region_filter, phase_filter])
+    """
+
+    EVENT_FILTER_TYPES = {
+        'box_region': 'select_sky_box',
+        'circular region': 'select_circular_region',
+        'custom': 'select_custom',
+    }
+
+    def __init__(self, time_filter=None, event_filters=None):
+        self.time_filter = time_filter
+        self.event_filters = event_filters or []
+
+    def filter_events(self, events):
+        """Applies the filters to an event list
+
+        Parameters
+        ----------
+        events : `~gammapy.data.EventListBase`
+            Event list to which the filters will be applied
+
+        Returns
+        -------
+        filtered_events : `~gammapy.data.EventListBase`
+            The filtered event list
+        """
+        filtered_events = self._filter_by_time(events)
+
+        for f in self.event_filters:
+            method_str = self.EVENT_FILTER_TYPES[f['type']]
+            filtered_events = getattr(filtered_events, method_str)(**f['opts'])
+
+        return filtered_events
+
+    def filter_gti(self, gti):
+        """Applies the filters to a GTI table
+
+        Parameters
+        ----------
+        gti : `~gammapy.data.GTI`
+            GTI table to which the filters will be applied
+
+        Returns
+        -------
+        filtered_gti : `~gammapy.data.GTI`
+            The filtered GTI table
+        """
+        filtered_gti = self._filter_by_time(gti)
+
+        return filtered_gti
+
+    def _filter_by_time(self, data):
+        """Returns a new time filtered data object.
+
+        Calls the `select_time` method of the data object.
+        """
+        if self.time_filter:
+            return data.select_time(self.time_filter)
+        else:
+            return data

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -25,7 +25,7 @@ class ObservationFilter(object):
 
     Examples
     --------
-    >>> from gammapy.data import ObservationFilter, DataStore
+    >>> from gammapy.data import ObservationFilter, DataStore, DataStoreObservation
     >>> from astropy.time import Time
     >>> from astropy.coordinates import Angle
     >>>
@@ -34,14 +34,14 @@ class ObservationFilter(object):
     >>>
     >>> my_obs_filter = ObservationFilter(time_filter=time_filter, event_filters=[phase_filter])
     >>>
-    >>> my_obs = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps").obs(111630)
-    >>> my_obs.obs_filter = my_obs_filter
+    >>> ds = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")
+    >>> my_obs = DataStoreObservation(obs_id=111630, data_store=ds, obs_filter=my_obs_filter)
     """
 
     EVENT_FILTER_TYPES = dict(
-        box_region='select_sky_box',
-        circular_region='select_circular_region',
-        custom='select_custom',
+        box_region="select_sky_box",
+        circular_region="select_circular_region",
+        custom="select_custom",
     )
 
     def __init__(self, time_filter=None, event_filters=None):
@@ -64,8 +64,8 @@ class ObservationFilter(object):
         filtered_events = self._filter_by_time(events)
 
         for f in self.event_filters:
-            method_str = self.EVENT_FILTER_TYPES[f['type']]
-            filtered_events = getattr(filtered_events, method_str)(**f['opts'])
+            method_str = self.EVENT_FILTER_TYPES[f["type"]]
+            filtered_events = getattr(filtered_events, method_str)(**f["opts"])
 
         return filtered_events
 

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -16,30 +16,33 @@ class ObservationFilter(object):
         Start and stop time of the selected time interval. For now we only support a single time interval.
     event_filters : list of dict
         An event filter dictionary needs two keys:
-        'type' : str, one of the event filter types specified in `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`
-        'opts' : dict, it is passed on to the method of the `~gammapy.data.EventListBase` class
-                 that corresponds to the filter type (see `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`)
+
+        - **type** : str, one of the keys in `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`
+        - **opts** : dict, it is passed on to the method of the `~gammapy.data.EventListBase` class that corresponds to
+          the filter type (see `~gammapy.data.ObservationFilter.EVENT_FILTER_TYPES`)
+
         The filtered event list will be an intersection of all filters. A union of filters is not supported yet.
 
     Examples
     --------
-    >>> from gammapy.data import ObservationFilter
+    >>> from gammapy.data import ObservationFilter, DataStore
     >>> from astropy.time import Time
     >>> from astropy.coordinates import Angle
     >>>
-    >>> time_span = Time(['2021-01-01T00:00:00', '2021-01-01T00:20:00'])
-    >>> region_filter = {'type': 'box_region', 'opts': dict(lon_lim=Angle([150, 300], 'deg'),
-    >>>                                                     lat_lim=Angle([-50, 0], 'deg'))}
+    >>> time_filter = Time(['2021-03-27T20:10:00', '2021-03-27T20:20:00'])
     >>> phase_filter = {'type': 'custom', 'opts': dict(parameter='PHASE', limits=(0.2, 0.8))}
     >>>
-    >>> my_obs_filter = ObservationFilter(time_filter=time_span, event_filters=[region_filter, phase_filter])
+    >>> my_obs_filter = ObservationFilter(time_filter=time_filter, event_filters=[phase_filter])
+    >>>
+    >>> my_obs = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps").obs(111630)
+    >>> my_obs.obs_filter = my_obs_filter
     """
 
-    EVENT_FILTER_TYPES = {
-        'box_region': 'select_sky_box',
-        'circular region': 'select_circular_region',
-        'custom': 'select_custom',
-    }
+    EVENT_FILTER_TYPES = dict(
+        box_region='select_sky_box',
+        circular_region='select_circular_region',
+        custom='select_custom',
+    )
 
     def __init__(self, time_filter=None, event_filters=None):
         self.time_filter = time_filter

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
 from astropy.table import Table
-from ..utils.time import time_ref_from_dict
+from ..utils.time import time_ref_from_dict, time_relative_to_ref
 from ..utils.scripts import make_path
 
 __all__ = ["GTI"]
@@ -102,3 +102,18 @@ class GTI(object):
         met_ref = time_ref_from_dict(self.table.meta)
         met = Quantity(self.table["STOP"].astype("float64"), "second")
         return met_ref + met
+
+    def select_time(self, time_interval):
+        """Select and crop GTIs in time interval.
+
+        Parameters
+        ----------
+        time_interval : `astropy.time.Time`
+            Start and stop time for the selection.
+
+        Returns
+        -------
+        gti : `GTI`
+            Copy of the GTI table with selection applied.
+        """
+        raise NotImplementedError

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from astropy.units import Quantity
 from astropy.table import Table
-from ..utils.time import time_ref_from_dict, time_relative_to_ref
+from ..utils.time import time_ref_from_dict
 from ..utils.scripts import make_path
 
 __all__ = ["GTI"]

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -201,7 +201,7 @@ class DataStoreObservation(object):
 
     @property
     def gti(self):
-        """Load `gammapy.data.GTI` object."""
+        """Load `gammapy.data.GTI` object and apply the filter."""
         try:
             gti = self.load(hdu_type="gti")
         except IndexError:

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -1,7 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from gammapy.data import DataStore, ObservationFilter
+from gammapy.data import DataStore, ObservationFilter, EventListBase
 from ...utils.testing import requires_data
+
+
+def test_event_filter_types():
+    for method_str in ObservationFilter.EVENT_FILTER_TYPES.values():
+        assert hasattr(EventListBase, method_str)
+
 
 @requires_data("gammapy-extra")
 def test_empty_ObservationFilter():
@@ -17,6 +23,3 @@ def test_empty_ObservationFilter():
     gti = obs.gti
     filtered_gti = empty_obs_filter.filter_gti(gti)
     assert filtered_gti == gti
-
-
-

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+from gammapy.data import DataStore, ObservationFilter
+from ...utils.testing import requires_data
+
+@requires_data("gammapy-extra")
+def test_empty_ObservationFilter():
+    ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1")
+    obs = ds.obs(20136)
+
+    empty_obs_filter = ObservationFilter()
+
+    events = obs.events
+    filtered_events = empty_obs_filter.filter_events(events)
+    assert filtered_events == events
+
+    gti = obs.gti
+    filtered_gti = empty_obs_filter.filter_gti(gti)
+    assert filtered_gti == gti
+
+
+


### PR DESCRIPTION
This PR is part of the PIG #1877 (roughly the 2 scenario of the implementation road map).

I send the PR now to maybe discuss it tomorrow in the call, but i am still missing tests, so not ready to merge yet!

In principle this PR already enables us to add a time filter and some event filters to an observation, which will be applied on the fly when accessing the `events` and `gti` properties of the `DataStoreObservation`.
