### PR TITLE
Introduce gammapy.utils.fitting.Model base class

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -4,7 +4,7 @@ import numpy as np
 import copy
 import astropy.units as u
 import operator
-from ..utils.fitting import Parameters, Parameter
+from ..utils.fitting import Parameters, Parameter, Model
 from ..utils.scripts import make_path
 from ..maps import Map
 
@@ -17,12 +17,8 @@ __all__ = [
 ]
 
 
-class SkyModelBase(object):
+class SkyModelBase(Model):
     """Sky model base class"""
-
-    def copy(self):
-        """A deep copy"""
-        return copy.deepcopy(self)
 
     def __add__(self, skymodel):
         return CompoundSkyModel(self, skymodel, operator.add)

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -1,14 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import copy
-import abc
 import logging
 import numpy as np
 import astropy.units as u
 from astropy.coordinates.angle_utilities import angular_separation
 from astropy.coordinates import Angle, Longitude, Latitude
-from ...extern import six
-from ...utils.fitting import Parameter, Parameters
+from ...utils.fitting import Parameter, Parameters, Model
 from ...maps import Map
 
 __all__ = [
@@ -25,10 +22,8 @@ __all__ = [
 log = logging.getLogger(__name__)
 
 
-@six.add_metaclass(abc.ABCMeta)
-class SkySpatialModel(object):
-    """SkySpatial model base class.
-    """
+class SkySpatialModel(Model):
+    """Sky spatial model base class."""
 
     def __str__(self):
         ss = self.__class__.__name__
@@ -50,10 +45,6 @@ class SkySpatialModel(object):
             kwargs[par.name] = par.quantity
 
         return self.evaluate(lon, lat, **kwargs)
-
-    def copy(self):
-        """A deep copy."""
-        return copy.deepcopy(self)
 
 
 class SkyPointSource(SkySpatialModel):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -2,7 +2,6 @@
 """Spectral models for Gammapy."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-import copy
 import operator
 import astropy.units as u
 from astropy.table import Table
@@ -10,7 +9,7 @@ from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from .utils import integrate_spectrum
 from ..utils.scripts import make_path
-from ..utils.fitting import Parameter, Parameters
+from ..utils.fitting import Parameter, Parameters, Model
 from ..utils.interpolation import ScaledRegularGridInterpolator
 
 __all__ = [
@@ -29,7 +28,7 @@ __all__ = [
 ]
 
 
-class SpectralModel(object):
+class SpectralModel(Model):
     """Spectral model base class.
 
     Derived classes should store their parameters as
@@ -37,10 +36,6 @@ class SpectralModel(object):
     See for example return pardict of
     `~gammapy.spectrum.models.PowerLaw`.
     """
-
-    def __repr__(self):
-        fmt = "{}()"
-        return fmt.format(self.__class__.__name__)
 
     def __str__(self):
         ss = self.__class__.__name__
@@ -451,10 +446,6 @@ class SpectralModel(object):
             energies.append(energy)
 
         return u.Quantity(energies, eunit, copy=False)
-
-    def copy(self):
-        """A deep copy."""
-        return copy.deepcopy(self)
 
 
 class ConstantModel(SpectralModel):

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -6,12 +6,12 @@ from astropy import units as u
 from astropy.table import Table
 from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
-from ..utils.fitting import Parameter, Parameters
+from ..utils.fitting import Parameter, Parameters, Model
 
 __all__ = ["PhaseCurveTableModel", "LightCurveTableModel"]
 
 
-class PhaseCurveTableModel(object):
+class PhaseCurveTableModel(Model):
     """Temporal phase curve model.
 
     Phase for a given time is computed as
@@ -120,7 +120,7 @@ class PhaseCurveTableModel(object):
         return np.interp(x=phase, xp=xp, fp=fp, period=1)
 
 
-class LightCurveTableModel(object):
+class LightCurveTableModel(Model):
     """Temporal light curve model.
 
     The lightcurve is given as a table with columns ``time`` and ``norm``.

--- a/gammapy/utils/fitting/__init__.py
+++ b/gammapy/utils/fitting/__init__.py
@@ -1,5 +1,6 @@
 """Fitting framework and backends."""
 from .parameter import *
+from .model import *
 from .fit import *
 from .iminuit import *
 from .sherpa import *

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -1,0 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import copy
+
+__all__ = ["Model"]
+
+
+class Model(object):
+    """Model base class."""
+
+    # TODO: expose model parameters as attributes
+
+    def copy(self):
+        """A deep copy."""
+        return copy.deepcopy(self)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -2,9 +2,9 @@
 """Unit tests for the Fit class"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-import copy
 from numpy.testing import assert_allclose
 from ..parameter import Parameter, Parameters
+from ..model import Model
 from ..fit import Fit
 
 pytest.importorskip("iminuit")
@@ -14,16 +14,13 @@ class MyData(object):
     """Dummy data class."""
 
 
-class MyModel(object):
+class MyModel(Model):
     """Dummy model class."""
 
     def __init__(self):
         self.parameters = Parameters(
             [Parameter("x", 2), Parameter("y", 3e2), Parameter("z", 4e-2)]
         )
-
-    def copy(self):
-        return copy.deepcopy(self)
 
 
 class MyFit(Fit):

--- a/gammapy/utils/fitting/tests/test_model.py
+++ b/gammapy/utils/fitting/tests/test_model.py
@@ -1,0 +1,21 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from ..parameter import Parameter, Parameters
+from ..model import Model
+
+
+class MyModel(Model):
+
+    def __init__(self):
+        self.parameters = Parameters(
+            [Parameter("x", 2), Parameter("y", 3e2), Parameter("z", 4e-2)]
+        )
+
+
+def test_model():
+    m = MyModel()
+
+    m2 = m.copy()
+
+    # Models should be independent
+    assert m.parameters is not m2.parameters
+    assert m.parameters[0] is not m2.parameters[0]


### PR DESCRIPTION
This PR introduces a `Model` base class. For now all it contains is `copy`, and it's not abstract because we don't have an abstract interface yet for all models that I could add.

@adonath - If you have any thoughts on something that should and can be added now already, let me know. Otherwise I think it's OK to introduce the base class now, and add to it piece by piece later.

Things that could go here are arithmetic operators, some helper methods to work with the parameters, expose the parameters as attributes, a registry that allows listing all model subclasses, ... In Astropy, they even managed to put `__call__` and `__init__` in the base class, and have a declarative scheme at the class-level for the parameters. Even that is possible if we change to a more uniform calling interface. All of those things would need to be prototyped before making a decision, and having the base class in place makes that easier (keep all existing tests working always).

@adonath - Please review.