### PR TITLE
Remove likelihood profiles from FitResult

### DIFF
--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -164,21 +164,6 @@ class TestFit:
         actual = values[np.argmin(profile["likelihood"])]
         assert_allclose(actual, true_idx, rtol=0.01)
 
-    @requires_dependency("matplotlib")
-    def test_plot(self):
-        obs = SpectrumObservation(on_vector=self.src)
-        fit = SpectrumFit(
-            obs_list=obs, stat="cash", model=self.source_model, forward_folded=False
-        )
-
-        profile_opts = {"parameters": ["index"]}
-        result = fit.run(
-            steps=["optimize", "errors", "profiles"], profile_opts=profile_opts
-        )
-
-        with mpl_plot_check():
-            result.plot_likelihood_profile("index")
-
 
 @requires_dependency("sherpa")
 @requires_dependency("scipy")

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -186,7 +186,7 @@ class Fit(object):
             parameters.covariance = None
         return model
 
-    def run(self, steps="all", optimize_opts=None, profile_opts=None):
+    def run(self, steps="all", optimize_opts=None):
         """
         Run all fitting steps.
 
@@ -196,8 +196,6 @@ class Fit(object):
             Which fitting steps to run.
         optimize_opts : dict
             Options passed to `Fit.optimize`.
-        profile_opts : dict
-            Options passed to `Fit.likelihood_profiles`.
 
         Returns
         -------
@@ -215,13 +213,6 @@ class Fit(object):
         if "errors" in steps:
             result["model"] = self._estimate_errors(result["model"])
 
-        if "profiles" in steps:
-            if profile_opts == None:
-                profile_opts = {}
-            result["likelihood_profiles"] = self.likelihood_profiles(
-                result["model"], **profile_opts
-            )
-
         return FitResult(**result)
 
 
@@ -237,7 +228,6 @@ class FitResult(object):
         message,
         backend,
         method,
-        likelihood_profiles=None,
     ):
         self._model = model
         self._success = success
@@ -246,7 +236,6 @@ class FitResult(object):
         self._message = message
         self._backend = backend
         self._method = method
-        self._likelihood_profiles = likelihood_profiles
 
     @property
     def model(self):
@@ -293,35 +282,3 @@ class FitResult(object):
         str_ += "\ttotal stat : {:.2f}\n".format(self.total_stat)
         str_ += "\tmessage    : {}\n".format(self.message)
         return str_
-
-    @property
-    def likelihood_profiles(self):
-        """Likelihood profiles for paramaters."""
-        return self._likelihood_profiles
-
-    def plot_likelihood_profile(self, parameter, ax=None, **kwargs):
-        """Plot likelihood profile for a given parameter.
-
-        Parameters
-        ----------
-        parameter : str
-            Parameter to plot profile for.
-
-        Returns
-        -------
-        ax : `matplotlib.pyplot.Axes`
-            Axes object.
-        """
-        import matplotlib.pyplot as plt
-
-        if ax is None:
-            ax = plt.gca()
-
-        ts_diff = self.likelihood_profiles[parameter]["likelihood"] - self.total_stat
-        values = self.likelihood_profiles[parameter]["values"]
-
-        ax.plot(values, ts_diff, **kwargs)
-        unit = self.model.parameters[parameter].unit
-        ax.set_xlabel(parameter + "[unit]".format(unit=unit))
-        ax.set_ylabel("TS difference")
-        return ax


### PR DESCRIPTION
This PR removes the likelihood profile from the FitResult, and the automatic computation of the likelihood profile from the `Fit.run` method.

@adonath - As discussed last Friday, I feel that a do-all "run" is not a good idea. Neither Sherpa, nor iminuit or as far as I know any modeling / fitting has it in the API. The problem is that every user wants something different, so we'd have to compute everything, e.g. also likelihood contours, and asymmetric errors, and often those are super-slow. We'd also have to expose all or many of the options to configure the algorithms (e.g. step sizes, ranges of the profiles) on the `Fit.run`.

The current design of having a `FitResult` that's de-coupled from `Fit` can only store things that are computed in `run`, so it follows that the likelihood profile is removed from `FitResult`. That's in line again with Sherpa or iminuit who don't offer likelihood profiles on the FitResult class. Generally I think we should keep the FitResult class very simple (a glorified dict to have a docstring and some checking where it's filled), otherwise it becomes confusing what belongs on the `Fit` class and what on the `FitResult`.

Finally, the `plot_likelihood_profile` method is removed completely. @adonath and I think that it's better to first build out the fitting classes and methods, and only once `gammapy.utils.fitting` is more advanced, discuss whether to add plotting code again. Good plotting code is a can of worms and would slow us down. Most Gammapy users know how to call `plt.plot(values, likelihood)` to plot a likelihood profile and we'll give docs examples.
