### PR TITLE
Adapt tests for Astropy master fails

### DIFF
--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -4,7 +4,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
-from ...utils.testing import assert_quantity_allclose
+from astropy.time import Time
+from ...utils.testing import assert_quantity_allclose, assert_time_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ...spectrum.models import (
     PowerLaw,
@@ -154,8 +155,11 @@ class TestFermi3FGLObject:
             "flux_errn",
         ]
 
-        assert lc.time_min[0].fits == "2008-08-02T00:33:19.000(UTC)"
-        assert lc.time_max[0].fits == "2008-09-01T10:31:04.625(UTC)"
+        expected = Time(54680.02313657408, format='mjd', scale='utc')
+        assert_time_allclose(lc.time_min[0], expected)
+
+        expected = Time(54710.43824797454, format='mjd', scale='utc')
+        assert_time_allclose(lc.time_max[0], expected)
 
         assert table["flux"].unit == "cm-2 s-1"
         assert_allclose(table["flux"][0], 2.384e-06, rtol=1e-3)

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+from astropy.version import version as astropy_version
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
 from astropy.table import Table
@@ -139,6 +140,12 @@ class PointingInfo(object):
         z_new = interp1d(t, xyz.z)(t_new)
         xyz_new = CartesianRepresentation(x_new, y_new, z_new)
         altaz_frame = AltAz(obstime=time, location=self.location)
-        return SkyCoord(
-            xyz_new, frame=altaz_frame, representation="unitspherical", unit="deg"
-        )
+
+        # FIXME: an API change in Astropy in 3.1 broke this
+        # See https://github.com/gammapy/gammapy/pull/1906
+        if astropy_version >= "3.1":
+            kwargs = {"representation_type": "unitspherical"}
+        else:
+            kwargs = {"representation": "unitspherical"}
+
+        return SkyCoord(xyz_new, frame=altaz_frame, unit="deg", **kwargs)

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-from ...utils.testing import requires_data
+from numpy.testing import assert_allclose
+from astropy.time import Time
+from ...utils.testing import requires_data, assert_time_allclose
 from ...data import GTI
 
 
@@ -11,12 +13,17 @@ def test_gti_hess():
     )
     gti = GTI.read(filename)
     assert "GTI" in str(gti)
-
     assert len(gti.table) == 1
-    assert "{:1.5f}".format(gti.time_delta[0]) == "1568.00000 s"
-    assert "{:1.5f}".format(gti.time_sum) == "1568.00000 s"
-    assert gti.time_start[0].iso == "2004-10-14 00:08:32.000"
-    assert gti.time_stop[-1].iso == "2004-10-14 00:34:40.000"
+
+    assert gti.time_delta[0].unit == 's'
+    assert_allclose(gti.time_delta[0].value,  1568.00000)
+    assert_allclose(gti.time_sum.value, 1568.00000)
+
+    expected = Time(53292.00592592593, format="mjd", scale="tt")
+    assert_time_allclose(gti.time_start[0], expected)
+
+    expected = Time(53292.02407407408, format="mjd", scale="tt")
+    assert_time_allclose(gti.time_stop[0], expected)
 
 
 @requires_data("gammapy-extra")
@@ -24,9 +31,14 @@ def test_gti_fermi():
     filename = "$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz"
     gti = GTI.read(filename)
     assert "GTI" in str(gti)
-
     assert len(gti.table) == 36589
-    assert "{:1.5f}".format(gti.time_delta[0]) == "352.49307 s"
-    assert "{:1.5f}".format(gti.time_sum) == "171273490.97510 s"
-    assert gti.time_start[0].fits == "2008-08-04T15:49:40.784(TT)"
-    assert gti.time_stop[-1].fits == "2015-01-31T23:50:42.784(TT)"
+
+    assert gti.time_delta[0].unit == 's'
+    assert_allclose(gti.time_delta[0].value,  352.49307)
+    assert_allclose(gti.time_sum.value, 171273490.97510)
+
+    expected = Time(54682.659499814814, format="mjd", scale="tt")
+    assert_time_allclose(gti.time_start[0], expected)
+
+    expected = Time(54682.66357959571, format="mjd", scale="tt")
+    assert_time_allclose(gti.time_stop[0], expected)

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -28,8 +28,8 @@ def test_data_store_observation(data_store):
     """Test DataStoreObservation class"""
     obs = data_store.obs(23523)
 
-    assert_time_allclose(obs.tstart, Time(53343.92234, scale="tt", format="mjd"))
-    assert_time_allclose(obs.tstop, Time(53343.941866, scale="tt", format="mjd"))
+    assert_time_allclose(obs.tstart, Time(53343.92234009259, scale="tt", format="mjd"))
+    assert_time_allclose(obs.tstop, Time(53343.94186555556, scale="tt", format="mjd"))
 
     c = SkyCoord(83.63333129882812, 21.51444435119629, unit="deg")
     assert_skycoord_allclose(obs.pointing_radec, c)

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_data, requires_dependency
+from astropy.time import Time
+from ...utils.testing import requires_data, requires_dependency, assert_time_allclose
 from ..pointing import PointingInfo
 
 
@@ -23,7 +24,8 @@ class TestPointingInfo:
         assert_allclose(height.value, 1834.999999999783)
 
     def test_time_ref(self):
-        assert self.pointing_info.time_ref.fits == "2001-01-01T00:01:04.184(TT)"
+        expected = Time(51910.00074287037, format="mjd", scale="tt")
+        assert_time_allclose(self.pointing_info.time_ref, expected)
 
     def test_table(self):
         assert len(self.pointing_info.table) == 100
@@ -31,7 +33,8 @@ class TestPointingInfo:
     def test_time(self):
         time = self.pointing_info.time
         assert len(time) == 100
-        assert time.fits[0] == "2004-01-21T19:50:02.184(TT)"
+        expected = Time(53025.826414166666, format="mjd", scale="tt")
+        assert_time_allclose(time[0], expected)
 
     def test_duration(self):
         duration = self.pointing_info.duration

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -144,13 +144,17 @@ def assert_skycoord_allclose(actual, desired):
     assert_allclose(actual.data.lat.value, desired.data.lat.value)
 
 
-def assert_time_allclose(actual, desired):
-    """Assert that two `astropy.time.Time` objects are almost the same."""
+def assert_time_allclose(actual, desired, atol=1e-3):
+    """Assert that two `astropy.time.Time` objects are almost the same.
+
+    atol is absolute tolerance in seconds.
+    """
     assert isinstance(actual, Time)
     assert isinstance(desired, Time)
-    assert_allclose(actual.value, desired.value)
     assert actual.scale == desired.scale
     assert actual.format == desired.format
+    dt = actual - desired
+    assert_allclose(dt.sec, 0, rtol=0, atol=atol)
 
 
 def assert_quantity_allclose(actual, desired, rtol=1.0e-7, atol=None, **kwargs):


### PR DESCRIPTION
There's a few new fails with Astropy master here:
https://travis-ci.org/gammapy/gammapy/jobs/451777968#L2744

It's minor changes, e.g. to the `Time` repr, and one small change in coordinates in the pointing class that we're not using yet.

I can fix those to work with old and new Astropy today or tomorrow.