### PR TITLE
Add Scipy as core dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. _gammapy_0p8_release:
 
+0.9 (2018-11-19)
+----------------
+
+- Add Scipy as core dependency
+- Require Astropy > 2.0
+
+
 0.8 (2018-09-23)
 ----------------
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -10,7 +10,6 @@ from ....utils.testing import (
 from .. import PrimaryFlux
 
 
-
 @requires_data("gammapy-extra")
 def test_primary_flux():
     with pytest.raises(ValueError):

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -10,7 +10,7 @@ from ....utils.testing import (
 from .. import PrimaryFlux
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_primary_flux():
     with pytest.raises(ValueError):

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -27,7 +27,7 @@ def prim_flux():
     return PrimaryFlux(mDM=1 * u.TeV, channel="W")
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_dmfluxmapmaker(jfact, prim_flux):
     x_section = 1e-26 * u.Unit("cm3 s-1")

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -27,7 +27,6 @@ def prim_flux():
     return PrimaryFlux(mDM=1 * u.TeV, channel="W")
 
 
-
 @requires_data("gammapy-extra")
 def test_dmfluxmapmaker(jfact, prim_flux):
     x_section = 1e-26 * u.Unit("cm3 s-1")

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -138,7 +138,7 @@ def test_add_pulsar_parameters():
     assert_allclose(table["logB"], [12.5883058913, 13.2824912596])
 
 
-@requires_dependency("scipy")
+
 def test_add_pwn_parameters():
     table = make_base_catalog_galactic(n_sources=10, random_state=0)
     # To compute PWN parameters we need PSR and SNR parameters first
@@ -152,7 +152,7 @@ def test_add_pwn_parameters():
     assert_allclose(d["L_PWN"], 7.057857699785925e45)
 
 
-@requires_dependency("scipy")
+
 def test_chain_all():
     """
     Test that running the simulation functions in chain works

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -138,7 +138,6 @@ def test_add_pulsar_parameters():
     assert_allclose(table["logB"], [12.5883058913, 13.2824912596])
 
 
-
 def test_add_pwn_parameters():
     table = make_base_catalog_galactic(n_sources=10, random_state=0)
     # To compute PWN parameters we need PSR and SNR parameters first
@@ -150,7 +149,6 @@ def test_add_pwn_parameters():
     d = table[0]
     assert_allclose(d["r_out_PWN"], 0.5892196771927385, atol=1e-3)
     assert_allclose(d["L_PWN"], 7.057857699785925e45)
-
 
 
 def test_chain_all():

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Pulsar wind nebula (PWN) source models."""
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
 import astropy.constants as const
+from scipy.optimize import fsolve
+
 from ...extern.validator import validate_physical_type
 from ..source import Pulsar, SNRTrueloveMcKee
 
@@ -67,8 +70,6 @@ class PWN(object):
         t_coll : `~astropy.units.Quantity`
             Time of collision.
         """
-        from scipy.optimize import fsolve
-
         def time_coll(t):
             t = Quantity(t, "yr")
             r_pwn = self._radius_free_expansion(t).to_value("cm")

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -70,6 +70,7 @@ class PWN(object):
         t_coll : `~astropy.units.Quantity`
             Time of collision.
         """
+
         def time_coll(t):
             t = Quantity(t, "yr")
             r_pwn = self._radius_free_expansion(t).to_value("cm")

--- a/gammapy/astro/source/tests/test_pulsar.py
+++ b/gammapy/astro/source/tests/test_pulsar.py
@@ -62,7 +62,7 @@ def test_Pulsar_luminosity_spindown():
     assert_allclose(pulsar.luminosity_spindown(time).value, reference)
 
 
-@requires_dependency("scipy")
+
 def test_Pulsar_energy_integrated():
     """Test against numerical integration"""
     energies = []

--- a/gammapy/astro/source/tests/test_pulsar.py
+++ b/gammapy/astro/source/tests/test_pulsar.py
@@ -62,7 +62,6 @@ def test_Pulsar_luminosity_spindown():
     assert_allclose(pulsar.luminosity_spindown(time).value, reference)
 
 
-
 def test_Pulsar_energy_integrated():
     """Test against numerical integration"""
     energies = []

--- a/gammapy/astro/source/tests/test_pwn.py
+++ b/gammapy/astro/source/tests/test_pwn.py
@@ -10,12 +10,10 @@ t = Quantity([0, 1, 10, 100, 1000, 10000, 100000], "yr")
 pwn = PWN()
 
 
-
 def test_PWN_radius():
     """Test SNR luminosity"""
     r = [0, 1.334e14, 2.114e15, 3.350e16, 5.310e17, 6.927e17, 6.927e17]
     assert_allclose(pwn.radius(t).value, r, rtol=1e-3)
-
 
 
 def test_magnetic_field():

--- a/gammapy/astro/source/tests/test_pwn.py
+++ b/gammapy/astro/source/tests/test_pwn.py
@@ -10,14 +10,14 @@ t = Quantity([0, 1, 10, 100, 1000, 10000, 100000], "yr")
 pwn = PWN()
 
 
-@requires_dependency("scipy")
+
 def test_PWN_radius():
     """Test SNR luminosity"""
     r = [0, 1.334e14, 2.114e15, 3.350e16, 5.310e17, 6.927e17, 6.927e17]
     assert_allclose(pwn.radius(t).value, r, rtol=1e-3)
 
 
-@requires_dependency("scipy")
+
 def test_magnetic_field():
     """Test SNR luminosity"""
     b = [np.nan, 1.753e-03, 8.788e-05, 4.404e-06, 2.207e-07, 4.685e-07, 1.481e-06]

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
+
 import numpy as np
 from astropy.coordinates import Angle
+from scipy.ndimage import distance_transform_edt
 from regions import PixCoord, CirclePixelRegion
+
 from ..maps import WcsNDMap
 from .background_estimate import BackgroundEstimate
 
@@ -39,8 +42,6 @@ def _compute_distance_image(mask_map):
     distance : `~gammapy.maps.WcsNDMap`
         Map of distance to nearest exclusion region.
     """
-    from scipy.ndimage import distance_transform_edt
-
     max_value = 1e10
 
     if np.all(mask_map.data == 1):

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -49,7 +49,7 @@ def bkg_estimator():
     )
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_find_reflected_regions(mask, on_region):
     pointing = SkyCoord(83.2, 22.5, unit="deg")
@@ -86,7 +86,7 @@ def test_find_reflected_regions(mask, on_region):
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 class TestReflectedRegionBackgroundEstimator:
     def setup(self):
         self.bg_maker = bkg_estimator()

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -49,7 +49,6 @@ def bkg_estimator():
     )
 
 
-
 @requires_data("gammapy-extra")
 def test_find_reflected_regions(mask, on_region):
     pointing = SkyCoord(83.2, 22.5, unit="deg")
@@ -86,7 +85,6 @@ def test_find_reflected_regions(mask, on_region):
 
 
 @requires_data("gammapy-extra")
-
 class TestReflectedRegionBackgroundEstimator:
     def setup(self):
         self.bg_maker = bkg_estimator()

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -32,7 +32,7 @@ def images():
     return images
 
 
-@requires_dependency("scipy")
+
 def test_ring_background_estimator(images):
     ring = RingBackgroundEstimator(0.35 * u.deg, 0.3 * u.deg)
 
@@ -50,7 +50,7 @@ def test_ring_background_estimator(images):
     assert_allclose(result["alpha"].data[~in_fov], 0.0)
 
 
-@requires_dependency("scipy")
+
 class TestAdaptiveRingBackgroundEstimator:
     def setup(self):
         self.images = {}

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -4,7 +4,6 @@ import pytest
 from numpy.testing import assert_allclose
 import numpy as np
 from astropy import units as u
-from ...utils.testing import requires_dependency
 from ...maps import WcsNDMap
 from ...background import RingBackgroundEstimator, AdaptiveRingBackgroundEstimator
 

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -31,7 +31,6 @@ def images():
     return images
 
 
-
 def test_ring_background_estimator(images):
     ring = RingBackgroundEstimator(0.35 * u.deg, 0.3 * u.deg)
 
@@ -47,7 +46,6 @@ def test_ring_background_estimator(images):
     assert_allclose(result["off"].data[~in_fov], 0.0)
     assert_allclose(result["exposure_off"].data[~in_fov], 0.0)
     assert_allclose(result["alpha"].data[~in_fov], 0.0)
-
 
 
 class TestAdaptiveRingBackgroundEstimator:

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -272,9 +272,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += "{:<25s} : {}\n\n".format("Number of upper limits", d["sed_n_ul"])
 
         try:
-            lines = self.flux_points.table_formatted.pformat(
-                max_width=-1, max_lines=-1
-            )
+            lines = self.flux_points.table_formatted.pformat(max_width=-1, max_lines=-1)
             ss += "\n".join(lines)
         except NoDataAvailableError:
             ss += "\nNo spectral points available for this source."

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -4,11 +4,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import os
 from collections import OrderedDict
+
 import numpy as np
 import astropy.units as u
 from astropy.table import Table
 from astropy.coordinates import Angle
 from astropy.modeling.models import Gaussian1D
+from scipy.interpolate import UnivariateSpline
+
 from ..extern.pathlib import Path
 from ..utils.scripts import make_path
 from ..utils.table import table_row_to_dict
@@ -736,8 +739,6 @@ class SourceCatalogLargeScaleHGPS(object):
     """
 
     def __init__(self, table, spline_kwargs=None):
-        from scipy.interpolate import UnivariateSpline
-
         if spline_kwargs is None:
             spline_kwargs = dict(k=1, s=0)
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -131,8 +131,7 @@ class TestFermi3FGLObject:
         assert "flux_ul" in flux_points.table.colnames
         assert flux_points.sed_type == "flux"
 
-        desired = [1.645888e-06, 5.445407e-07, 1.255338e-07, 2.545524e-08,
-                   2.263189e-09]
+        desired = [1.645888e-06, 5.445407e-07, 1.255338e-07, 2.545524e-08, 2.263189e-09]
         assert_allclose(flux_points.table["flux"].data, desired, rtol=1e-5)
 
     def test_flux_points_ul(self):
@@ -155,10 +154,10 @@ class TestFermi3FGLObject:
             "flux_errn",
         ]
 
-        expected = Time(54680.02313657408, format='mjd', scale='utc')
+        expected = Time(54680.02313657408, format="mjd", scale="utc")
         assert_time_allclose(lc.time_min[0], expected)
 
-        expected = Time(54710.43824797454, format='mjd', scale='utc')
+        expected = Time(54710.43824797454, format="mjd", scale="utc")
         assert_time_allclose(lc.time_max[0], expected)
 
         assert table["flux"].unit == "cm-2 s-1"
@@ -307,8 +306,7 @@ class TestFermi3FHLObject:
         assert len(flux_points.table) == 5
         assert "flux_ul" in flux_points.table.colnames
 
-        desired = [5.169889e-09, 2.245024e-09, 9.243175e-10, 2.758956e-10,
-                   6.684021e-11]
+        desired = [5.169889e-09, 2.245024e-09, 9.243175e-10, 2.758956e-10, 6.684021e-11]
         assert_allclose(flux_points.table["flux"].data, desired, rtol=1e-3)
 
     @pytest.mark.parametrize(

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -289,7 +289,7 @@ class TestSourceCatalogObjectHGPSComponent:
         assert "SkyModel" in str(model)
 
 
-@requires_dependency("scipy")
+
 class TestSourceCatalogLargeScaleHGPS:
     def setup(self):
         table = Table()

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -289,7 +289,6 @@ class TestSourceCatalogObjectHGPSComponent:
         assert "SkyModel" in str(model)
 
 
-
 class TestSourceCatalogLargeScaleHGPS:
     def setup(self):
         table = Table()

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -97,7 +97,6 @@ def counts(sky_model, exposure, background, psf, edisp):
     return WcsNDMap(background.geom, npred)
 
 
-
 @requires_dependency("iminuit")
 @requires_data("gammapy-extra")
 def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -97,7 +97,7 @@ def counts(sky_model, exposure, background, psf, edisp):
     return WcsNDMap(background.geom, npred)
 
 
-@requires_dependency("scipy")
+
 @requires_dependency("iminuit")
 @requires_data("gammapy-extra")
 def test_cube_fit(sky_model, counts, exposure, psf, background, mask, edisp):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -202,7 +202,6 @@ class TestCompoundSkyModel:
         assert_allclose(q.value, 3.536776513153229e-13)
 
 
-
 class TestSkyDiffuseCube:
     @staticmethod
     def test_evaluate_scalar(diffuse_model):
@@ -246,7 +245,6 @@ class TestSkyDiffuseCube:
         assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
 
 
-
 class TestSkyDiffuseCubeMapEvaluator:
     @staticmethod
     def test_compute_dnde(diffuse_evaluator):
@@ -288,7 +286,6 @@ class TestSkyDiffuseCubeMapEvaluator:
         assert out.shape == (2, 4, 5)
         assert_allclose(out.sum(), 1.106403e12, rtol=1e-5)
         assert_allclose(out[0, 0, 0], 5.586252e08, rtol=1e-5)
-
 
 
 class TestSkyModelMapEvaluator:

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -202,7 +202,7 @@ class TestCompoundSkyModel:
         assert_allclose(q.value, 3.536776513153229e-13)
 
 
-@requires_dependency("scipy")
+
 class TestSkyDiffuseCube:
     @staticmethod
     def test_evaluate_scalar(diffuse_model):
@@ -246,7 +246,7 @@ class TestSkyDiffuseCube:
         assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
 
 
-@requires_dependency("scipy")
+
 class TestSkyDiffuseCubeMapEvaluator:
     @staticmethod
     def test_compute_dnde(diffuse_evaluator):
@@ -290,7 +290,7 @@ class TestSkyDiffuseCubeMapEvaluator:
         assert_allclose(out[0, 0, 0], 5.586252e08, rtol=1e-5)
 
 
-@requires_dependency("scipy")
+
 class TestSkyModelMapEvaluator:
     @staticmethod
     def test_energy_center(evaluator):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ...maps import MapAxis, WcsGeom, Map
 from ...irf.energy_dispersion import EnergyDispersion
 from ...cube.psf_kernel import PSFKernel

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -31,7 +31,7 @@ def fake_psf3d(sigma=0.15 * u.deg):
     return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values)
 
 
-@requires_dependency("scipy")
+
 def test_make_psf_map():
     psf = fake_psf3d(0.3 * u.deg)
 
@@ -51,7 +51,7 @@ def test_make_psf_map():
     assert psfmap.data.shape == (4, 50, 25, 25)
 
 
-@requires_dependency("scipy")
+
 def test_psfmap(tmpdir):
     psf = fake_psf3d(0.15 * u.deg)
 
@@ -95,7 +95,7 @@ def test_psfmap(tmpdir):
     assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)
 
 
-@requires_dependency("scipy")
+
 def test_containment_radius_map(tmpdir):
     psf = fake_psf3d(0.15 * u.deg)
     pointing = SkyCoord(0, 0, unit="deg")

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -8,7 +8,6 @@ from astropy.coordinates import SkyCoord
 from ...irf import PSF3D
 from ...maps import MapAxis, WcsGeom
 from ...cube import PSFMap, make_psf_map
-from ...utils.testing import requires_dependency
 
 
 def fake_psf3d(sigma=0.15 * u.deg):

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -30,7 +30,6 @@ def fake_psf3d(sigma=0.15 * u.deg):
     return PSF3D(energy_lo, energy_hi, offsets, rad_lo, rad_hi, psf_values)
 
 
-
 def test_make_psf_map():
     psf = fake_psf3d(0.3 * u.deg)
 
@@ -48,7 +47,6 @@ def test_make_psf_map():
     assert psfmap.psf_map.geom.axes[1] == energy_axis
     assert psfmap.psf_map.unit == Unit("sr-1")
     assert psfmap.data.shape == (4, 50, 25, 25)
-
 
 
 def test_psfmap(tmpdir):
@@ -92,7 +90,6 @@ def test_psfmap(tmpdir):
     new_psfmap = PSFMap.read(filename)
 
     assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)
-
 
 
 def test_containment_radius_map(tmpdir):

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,10 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+<<<<<<< HEAD
 from astropy.version import version as astropy_version
+=======
+
+>>>>>>> Remove delayed scipy imports
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
 from astropy.table import Table
 from astropy.coordinates import SkyCoord, AltAz, CartesianRepresentation
+from scipy.interpolate import interp1d
+
 from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
 from ..utils.fits import earth_location_from_dict
@@ -130,8 +136,6 @@ class PointingInfo(object):
 
     def altaz_interpolate(self, time):
         """Interpolate pointing for a given time."""
-        from scipy.interpolate import interp1d
-
         t_new = time.mjd
         t = self.time.mjd
         xyz = self.altaz.cartesian

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,10 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-<<<<<<< HEAD
 from astropy.version import version as astropy_version
-=======
-
->>>>>>> Remove delayed scipy imports
 from astropy.utils import lazyproperty
 from astropy.units import Quantity
 from astropy.table import Table

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -15,8 +15,8 @@ def test_gti_hess():
     assert "GTI" in str(gti)
     assert len(gti.table) == 1
 
-    assert gti.time_delta[0].unit == 's'
-    assert_allclose(gti.time_delta[0].value,  1568.00000)
+    assert gti.time_delta[0].unit == "s"
+    assert_allclose(gti.time_delta[0].value, 1568.00000)
     assert_allclose(gti.time_sum.value, 1568.00000)
 
     expected = Time(53292.00592592593, format="mjd", scale="tt")
@@ -33,8 +33,8 @@ def test_gti_fermi():
     assert "GTI" in str(gti)
     assert len(gti.table) == 36589
 
-    assert gti.time_delta[0].unit == 's'
-    assert_allclose(gti.time_delta[0].value,  352.49307)
+    assert gti.time_delta[0].unit == "s"
+    assert_allclose(gti.time_delta[0].value, 352.49307)
     assert_allclose(gti.time_sum.value, 171273490.97510)
 
     expected = Time(54682.659499814814, format="mjd", scale="tt")

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -48,7 +48,6 @@ def stats_stacked(on_region, observations):
 
 
 @requires_data("gammapy-extra")
-
 class TestObservationStats(object):
     def test_str(self, stats):
         text = str(stats)

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -48,7 +48,7 @@ def stats_stacked(on_region, observations):
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 class TestObservationStats(object):
     def test_str(self, stats):
         text = str(stats)

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -6,7 +6,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from regions import CircleSkyRegion
 from ...data import DataStore, Observations, ObservationStats
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
 from ...background import ReflectedRegionsBackgroundEstimator
 
 

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -43,7 +43,7 @@ class TestObservationSummaryTable:
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 class TestObservationSummary:
     """
     Test observation summary.

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -43,7 +43,6 @@ class TestObservationSummaryTable:
 
 
 @requires_data("gammapy-extra")
-
 class TestObservationSummary:
     """
     Test observation summary.

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -1,21 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
-from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
 from astropy.time import Time
-from ...data import DataStore, Observations, EventList, GTI, ObservationCTA
+from ...data import DataStore, EventList, GTI, ObservationCTA
 from ...irf import EffectiveAreaTable2D, EnergyDispersion2D, PSF3D
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
 from ...utils.testing import (
     assert_quantity_allclose,
     assert_time_allclose,
     assert_skycoord_allclose,
 )
-from ...utils.energy import Energy
-from ...utils.energy import EnergyBounds
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
 from astropy.time import Time
-from ...utils.testing import requires_data, requires_dependency, assert_time_allclose
+from ...utils.testing import requires_data, assert_time_allclose
 from ..pointing import PointingInfo
 
 

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -58,7 +58,6 @@ class TestPointingInfo:
         assert_allclose(pos.alt.deg, 41.37921408774436)
         assert pos.name == "altaz"
 
-
     def test_altaz_interpolate(self):
         time = self.pointing_info.time[0]
         pos = self.pointing_info.altaz_interpolate(time)

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -58,7 +58,7 @@ class TestPointingInfo:
         assert_allclose(pos.alt.deg, 41.37921408774436)
         assert pos.name == "altaz"
 
-    @requires_dependency("scipy")
+
     def test_altaz_interpolate(self):
         time = self.pointing_info.time[0]
         pos = self.pointing_info.altaz_interpolate(time)

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -2,10 +2,14 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import copy
 import logging
+
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 from astropy.convolution import Gaussian2DKernel, MexicanHat2DKernel
+from scipy.signal import fftconvolve
+from scipy.ndimage import label
+
 from ..maps import WcsNDMap, MapAxis, WcsGeom
 
 __all__ = ["CWT", "CWTData", "CWTKernels"]
@@ -122,8 +126,6 @@ class CWT(object):
         data : `~gammapy.detect.CWTData`
             Images for transform.
         """
-        from scipy.signal import fftconvolve
-
         total_background = data._model + data._background + data._approx
         excess = data._counts - total_background
         log.debug("Excess sum: {0:.4f}".format(excess.sum()))
@@ -175,8 +177,6 @@ class CWT(object):
         data : `~gammapy.detect.CWTData`
             Images after transform.
         """
-        from scipy.ndimage import label
-
         log.debug("Computing significance")
         significance = data._transform_3d / data._error
 

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -1,8 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from scipy.ndimage import maximum_filter
+
 from ..maps import WcsNDMap
 
 __all__ = ["find_peaks"]
@@ -50,8 +53,6 @@ def find_peaks(image, threshold, min_distance=1):
     output : `~astropy.table.Table`
         Table with parameters of detected peaks
     """
-    from scipy.ndimage import maximum_filter
-
     # Input validation
 
     if not isinstance(image, WcsNDMap):

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -1,9 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
+
 import numpy as np
 from astropy.coordinates import Angle
 from astropy.convolution import Tophat2DKernel, CustomKernel
+from scipy.ndimage import binary_erosion
+from scipy.ndimage.morphology import binary_fill_holes
+
 from ..maps import Map
 from .lima import compute_lima_image
 
@@ -166,8 +170,6 @@ class KernelBackgroundEstimator(object):
         return images["significance"]
 
     def _estimate_exclusion(self, counts, significance):
-        from scipy.ndimage import binary_erosion
-
         radius = self.parameters["mask_dilation_radius"].deg
         scale = counts.geom.pixel_scales.mean().deg
         mask_dilation_radius_pix = radius / scale
@@ -197,8 +199,6 @@ class KernelBackgroundEstimator(object):
 
         Criterion: exclusion masks unchanged in subsequent iterations.
         """
-        from scipy.ndimage.morphology import binary_fill_holes
-
         mask = result["exclusion"].data == result_previous["exclusion"].data
 
         # Because of pixel to pixel noise, the masks can still differ.

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -623,6 +623,7 @@ def _compute_flux_err_conf(amplitude, counts, background, model, c_1, error_sigm
     """
     Compute amplitude errors using likelihood profile method.
     """
+
     def ts_diff(x, counts, background, model):
         return (c_1 + error_sigma ** 2) - f_cash(x, counts, background, model)
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -6,8 +6,11 @@ import contextlib
 import warnings
 from functools import partial
 from multiprocessing import Pool
+
 import numpy as np
 from astropy.convolution import CustomKernel, Kernel2D
+from scipy.optimize import newton, brentq
+
 from ..utils.array import shape_2N, symmetric_crop_pad_width
 from ._test_statistics_cython import (
     _cash_cython,
@@ -545,8 +548,6 @@ def _root_amplitude(counts, background, model, flux, rtol=RTOL):
     niter : int
         Number of function evaluations needed for the fit.
     """
-    from scipy.optimize import newton
-
     args = (counts, background, model)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -583,8 +584,6 @@ def _root_amplitude_brentq(counts, background, model, rtol=RTOL):
     niter : int
         Number of function evaluations needed for the fit.
     """
-    from scipy.optimize import brentq
-
     # Compute amplitude bounds and assert counts > 0
     bounds = _amplitude_bounds_cython(counts, background, model)
     amplitude_min, amplitude_max, amplitude_min_total = bounds
@@ -624,8 +623,6 @@ def _compute_flux_err_conf(amplitude, counts, background, model, c_1, error_sigm
     """
     Compute amplitude errors using likelihood profile method.
     """
-    from scipy.optimize import brentq
-
     def ts_diff(x, counts, background, model):
         return (c_1 + error_sigma ** 2) - f_cash(x, counts, background, model)
 

--- a/gammapy/detect/tests/test_cwt.py
+++ b/gammapy/detect/tests/test_cwt.py
@@ -7,7 +7,7 @@ from ...detect import CWT, CWTKernels, CWTData
 from ...maps import Map
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestCWT:
     """Test CWT algorithm."""
@@ -129,7 +129,7 @@ class TestCWT:
         assert_allclose(transform_2d.sum(), 9.91731463861)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestCWTKernels:
     """Test CWTKernels"""
@@ -172,7 +172,7 @@ class TestCWTKernels:
         assert_equal(len(t), 13)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestCWTData:
     """

--- a/gammapy/detect/tests/test_cwt.py
+++ b/gammapy/detect/tests/test_cwt.py
@@ -7,7 +7,6 @@ from ...detect import CWT, CWTKernels, CWTData
 from ...maps import Map
 
 
-
 @requires_data("gammapy-extra")
 class TestCWT:
     """Test CWT algorithm."""
@@ -129,7 +128,6 @@ class TestCWT:
         assert_allclose(transform_2d.sum(), 9.91731463861)
 
 
-
 @requires_data("gammapy-extra")
 class TestCWTKernels:
     """Test CWTKernels"""
@@ -170,7 +168,6 @@ class TestCWTKernels:
         t = self.kernels_new.info_table
         assert_equal(t.colnames, ["Name", "Source"])
         assert_equal(len(t), 13)
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/detect/tests/test_cwt.py
+++ b/gammapy/detect/tests/test_cwt.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ...detect import CWT, CWTKernels, CWTData
 from ...maps import Map
 

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency
 from ...maps import Map
 from ..find import find_peaks
 

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -7,7 +7,7 @@ from ...maps import Map
 from ..find import find_peaks
 
 
-@requires_dependency("scipy")
+
 class TestFindPeaks:
     def test_simple(self):
         """Test a simple example"""

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -6,7 +6,6 @@ from ...maps import Map
 from ..find import find_peaks
 
 
-
 class TestFindPeaks:
     def test_simple(self):
         """Test a simple example"""

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -7,7 +7,6 @@ from ...detect import compute_lima_image, compute_lima_on_off_image
 from ...maps import Map
 
 
-
 @requires_data("gammapy-extra")
 def test_compute_lima_image():
     """
@@ -24,7 +23,6 @@ def test_compute_lima_image():
 
     assert_allclose(result_lima["significance"].data[100, 100], 30.814916, atol=1e-3)
     assert_allclose(result_lima["significance"].data[1, 1], 0.164, atol=1e-3)
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
 from astropy.convolution import Tophat2DKernel
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ...detect import compute_lima_image, compute_lima_on_off_image
 from ...maps import Map
 

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -7,7 +7,7 @@ from ...detect import compute_lima_image, compute_lima_on_off_image
 from ...maps import Map
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_compute_lima_image():
     """
@@ -26,7 +26,7 @@ def test_compute_lima_image():
     assert_allclose(result_lima["significance"].data[1, 1], 0.164, atol=1e-3)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_compute_lima_on_off_image():
     """

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -1,7 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.units import Quantity
+from scipy.optimize import brentq
+
 
 __all__ = [
     "measure_containment_fraction",
@@ -87,8 +90,6 @@ def measure_containment_radius(image, position, containment_fraction=0.8):
     containment_radius :
         Containment radius (pix)
     """
-    from scipy.optimize import brentq
-
     data = image.quantity
     coords = image.geom.get_coord()
     separation = coords.skycoord.separation(position)

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -62,7 +62,6 @@ def test_sky_diffuse_constant():
     assert_allclose(val.value, 42)
 
 
-
 @requires_data("gammapy-extra")
 def test_sky_diffuse_map():
     filename = "$GAMMAPY_EXTRA/datasets/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
@@ -73,7 +72,6 @@ def test_sky_diffuse_map():
     assert val.unit == "sr-1"
     desired = [3269.178107, 0]
     assert_allclose(val.value, desired)
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -62,7 +62,7 @@ def test_sky_diffuse_constant():
     assert_allclose(val.value, 42)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_sky_diffuse_map():
     filename = "$GAMMAPY_EXTRA/datasets/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
@@ -75,7 +75,7 @@ def test_sky_diffuse_map():
     assert_allclose(val.value, desired)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_sky_diffuse_map_normalize():
     # define model map with a constant value of 1

--- a/gammapy/image/profile.py
+++ b/gammapy/image/profile.py
@@ -2,10 +2,15 @@
 """Tools to create profiles (i.e. 1D "slices" from 2D images)"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
+
 import numpy as np
 from astropy.table import Table
 from astropy import units as u
 from astropy.coordinates import Angle
+from astropy.convolution import Gaussian1DKernel, Box1DKernel
+from scipy.ndimage import gaussian_filter, uniform_filter, convolve
+from scipy import ndimage
+
 
 __all__ = ["ImageProfile", "ImageProfileEstimator"]
 
@@ -136,8 +141,6 @@ class ImageProfileEstimator(object):
         """
         Estimate image profile.
         """
-        from scipy import ndimage
-
         p = self.parameters
         labels = self._label_image(image, mask)
 
@@ -292,10 +295,6 @@ class ImageProfile(object):
         profile : `ImageProfile`
             Smoothed image profile.
         """
-        from scipy.ndimage.filters import uniform_filter, gaussian_filter
-        from scipy.ndimage import convolve
-        from astropy.convolution import Gaussian1DKernel, Box1DKernel
-
         table = self.table.copy()
         profile = table["profile"]
 

--- a/gammapy/image/tests/test_asmooth.py
+++ b/gammapy/image/tests/test_asmooth.py
@@ -10,7 +10,6 @@ from ...maps import Map
 from ..asmooth import ASmooth
 
 
-
 @requires_data("gammapy-extra")
 def test_asmooth():
     filename = make_path("$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_vela.fits.gz")

--- a/gammapy/image/tests/test_asmooth.py
+++ b/gammapy/image/tests/test_asmooth.py
@@ -10,7 +10,7 @@ from ...maps import Map
 from ..asmooth import ASmooth
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_asmooth():
     filename = make_path("$GAMMAPY_EXTRA/datasets/fermi_2fhl/fermi_2fhl_vela.fits.gz")

--- a/gammapy/image/tests/test_asmooth.py
+++ b/gammapy/image/tests/test_asmooth.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.convolution import Gaussian2DKernel
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
 from ...utils.scripts import make_path
 from ...maps import Map
 from ..asmooth import ASmooth

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -5,7 +5,7 @@ import pytest
 from astropy import units as u
 from astropy.modeling.models import Gaussian2D
 from astropy.coordinates import SkyCoord
-from ...utils.testing import assert_quantity_allclose, requires_dependency
+from ...utils.testing import assert_quantity_allclose
 from ...maps import WcsGeom, WcsNDMap
 from ...image import (
     measure_containment_radius,

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -56,7 +56,7 @@ def test_measure_containment(gaussian_image):
     assert_quantity_allclose(frac, ref, rtol=0.01)
 
 
-@requires_dependency("scipy")
+
 def test_measure_containment_radius(gaussian_image):
     """Test measure_containment_radius function"""
     position = SkyCoord(0, 0, frame="galactic", unit="deg")

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -56,7 +56,6 @@ def test_measure_containment(gaussian_image):
     assert_quantity_allclose(frac, ref, rtol=0.01)
 
 
-
 def test_measure_containment_radius(gaussian_image):
     """Test measure_containment_radius function"""
     position = SkyCoord(0, 0, frame="galactic", unit="deg")

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -46,7 +46,7 @@ def cosine_profile():
     return ImageProfile(table)
 
 
-@requires_dependency("scipy")
+
 class TestImageProfileEstimator(object):
     def test_lat_profile_sum(self, checkerboard_image):
         p = ImageProfileEstimator(axis="lat", method="sum")
@@ -116,7 +116,7 @@ class TestImageProfile(object):
     def test_profile_x_edges(self, cosine_profile):
         assert_quantity_allclose(cosine_profile.x_ref.sum(), 0 * u.deg)
 
-    @requires_dependency("scipy")
+
     @pytest.mark.parametrize("kernel", ["gauss", "box"])
     def test_smooth(self, cosine_profile, kernel):
         # smoothing should preserve the mean

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -46,7 +46,6 @@ def cosine_profile():
     return ImageProfile(table)
 
 
-
 class TestImageProfileEstimator(object):
     def test_lat_profile_sum(self, checkerboard_image):
         p = ImageProfileEstimator(axis="lat", method="sum")
@@ -115,7 +114,6 @@ class TestImageProfile(object):
 
     def test_profile_x_edges(self, cosine_profile):
         assert_quantity_allclose(cosine_profile.x_ref.sum(), 0 * u.deg)
-
 
     @pytest.mark.parametrize("kernel", ["gauss", "box"])
     def test_smooth(self, cosine_profile, kernel):

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -4,8 +4,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 from multiprocessing import Pool
 from functools import partial
+
 import numpy as np
 from astropy.convolution import Gaussian2DKernel
+from scipy.signal import fftconvolve
+from scipy.ndimage.filters import gaussian_filter
+
 
 __all__ = ["scale_cube"]
 
@@ -13,9 +17,6 @@ log = logging.getLogger(__name__)
 
 
 def _fftconvolve_wrap(kernel, data):
-    from scipy.signal import fftconvolve
-    from scipy.ndimage.filters import gaussian_filter
-
     # wrap gaussian filter as a special case, because the gain in
     # performance is factor ~100
     if isinstance(kernel, Gaussian2DKernel):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -1,11 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from collections import OrderedDict
+
 import numpy as np
 from astropy.io import fits
 from astropy.coordinates import Angle
 from astropy.units import Quantity
 from astropy.table import Table
+from scipy.special import erf
+
 from ..utils.energy import EnergyBounds, Energy
 from ..utils.scripts import make_path
 from ..utils.nddata import NDDataArray, BinnedDataAxis
@@ -723,8 +726,6 @@ class EnergyDispersion2D(object):
         pdf_threshold : float, optional
             Zero suppression threshold
         """
-        from scipy.special import erf
-
         e_true = EnergyBounds(e_true)
         # erf does not work with Quantities
         true = e_true.log_centers.to_value("TeV")

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.table import Table
 from astropy.io import fits
 from astropy.units import Quantity
 from astropy.coordinates import Angle
+from scipy.interpolate import RegularGridInterpolator
+
 from ..utils.array import array_stats_str
 from ..utils.energy import Energy
 from ..utils.scripts import make_path
@@ -202,8 +205,6 @@ class PSF3D(object):
         values : `~astropy.units.Quantity`
             Interpolated value
         """
-        from scipy.interpolate import RegularGridInterpolator
-
         if not interp_kwargs:
             interp_kwargs = dict(bounds_error=False, fill_value=None)
 

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
+
 import numpy as np
 from astropy.io import fits
 from astropy.units import Quantity
 from astropy.coordinates import Angle, SkyCoord
+from scipy.interpolate import UnivariateSpline, RegularGridInterpolator
+
 from ..utils.gauss import Gauss2DPDF
 from ..utils.scripts import make_path
 from ..utils.array import array_stats_str
@@ -308,8 +311,6 @@ class TablePSF(object):
         * `_cdf_spline` is used to compute integral and for normalisation.
         * `_ppf_spline` is used to compute containment radii.
         """
-        from scipy.interpolate import UnivariateSpline
-
         # Compute spline and normalize.
         x, y = self._rad.value, self._dp_domega.value
         self._dp_domega_spline = UnivariateSpline(x, y, **spline_kwargs)
@@ -480,8 +481,6 @@ class EnergyDependentTablePSF(object):
         """
         if interp_kwargs is None:
             interp_kwargs = dict(bounds_error=False, fill_value=None)
-
-        from scipy.interpolate import RegularGridInterpolator
 
         if energy is None:
             energy = self.energy

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -30,7 +30,6 @@ def bkg_3d():
     )
 
 
-
 @requires_data("gammapy-extra")
 def test_background_3d_basics(bkg_3d):
     assert "NDDataArray summary info" in str(bkg_3d.data)
@@ -75,7 +74,6 @@ def test_background_3d_read_write(tmpdir, bkg_3d):
     assert data.unit == "s-1 MeV-1 sr-1"
 
 
-
 def test_background_3d_evaluate(bkg_3d):
     # Evaluate at nodes where we put a non-zero value
     res = bkg_3d.evaluate(
@@ -101,7 +99,6 @@ def test_background_3d_evaluate(bkg_3d):
     )
     assert_allclose(res.value, [[1, 1], [3.162278, 1]], rtol=1e-5)
     assert res.shape == (2, 2)
-
 
 
 def test_background_3d_integrate(bkg_3d):
@@ -148,7 +145,6 @@ def bkg_2d():
         offset_hi=offset[1:],
         data=data,
     )
-
 
 
 def test_background_2d_evaluate(bkg_2d):
@@ -200,7 +196,6 @@ def test_background_2d_read_write(tmpdir, bkg_2d):
     data = bkg_2d_2.data.data
     assert data.shape == (2, 3)
     assert data.unit == "s-1 MeV-1 sr-1"
-
 
 
 def test_background_2d_integrate(bkg_2d):

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -30,7 +30,7 @@ def bkg_3d():
     )
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_background_3d_basics(bkg_3d):
     assert "NDDataArray summary info" in str(bkg_3d.data)
@@ -75,7 +75,7 @@ def test_background_3d_read_write(tmpdir, bkg_3d):
     assert data.unit == "s-1 MeV-1 sr-1"
 
 
-@requires_dependency("scipy")
+
 def test_background_3d_evaluate(bkg_3d):
     # Evaluate at nodes where we put a non-zero value
     res = bkg_3d.evaluate(
@@ -103,7 +103,7 @@ def test_background_3d_evaluate(bkg_3d):
     assert res.shape == (2, 2)
 
 
-@requires_dependency("scipy")
+
 def test_background_3d_integrate(bkg_3d):
     # Example has bkg rate = 4 s-1 MeV-1 sr-1 at this node:
     # fov_lon=1.5 deg, fov_lat=1.5 deg, energy=100 TeV
@@ -150,7 +150,7 @@ def bkg_2d():
     )
 
 
-@requires_dependency("scipy")
+
 def test_background_2d_evaluate(bkg_2d):
     # TODO: the test cases here can probably be improved a bit
     # There's some redundancy, and no case exactly at a node in energy
@@ -202,7 +202,7 @@ def test_background_2d_read_write(tmpdir, bkg_2d):
     assert data.unit == "s-1 MeV-1 sr-1"
 
 
-@requires_dependency("scipy")
+
 def test_background_2d_integrate(bkg_2d):
     # TODO: change test case to something better (with known answer)
     # e.g. constant spectrum or power-law.

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ..background import Background3D, Background2D
 
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -22,7 +22,7 @@ class TestEffectiveAreaTable2D:
     # TODO: split this out into separate tests, especially the plotting
     # Add I/O test
     @staticmethod
-    @requires_dependency("scipy")
+
     @requires_data("gammapy-extra")
     def test(aeff):
         assert aeff.data.axis("energy").nbins == 96
@@ -76,7 +76,7 @@ class TestEffectiveAreaTable2D:
 
 class TestEffectiveAreaTable:
     @staticmethod
-    @requires_dependency("scipy")
+
     @requires_dependency("matplotlib")
     @requires_data("gammapy-extra")
     def test_EffectiveAreaTable(tmpdir, aeff):

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -22,7 +22,6 @@ class TestEffectiveAreaTable2D:
     # TODO: split this out into separate tests, especially the plotting
     # Add I/O test
     @staticmethod
-
     @requires_data("gammapy-extra")
     def test(aeff):
         assert aeff.data.axis("energy").nbins == 96
@@ -76,7 +75,6 @@ class TestEffectiveAreaTable2D:
 
 class TestEffectiveAreaTable:
     @staticmethod
-
     @requires_dependency("matplotlib")
     @requires_data("gammapy-extra")
     def test_EffectiveAreaTable(tmpdir, aeff):

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -10,7 +10,7 @@ from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EnergyDispersion2D
 
 
-@requires_dependency("scipy")
+
 class TestEnergyDispersion:
     def setup(self):
         self.e_true = np.logspace(0, 1, 101) * u.TeV
@@ -96,7 +96,7 @@ class TestEnergyDispersion:
             self.edisp.peek()
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestEnergyDispersion2D:
     def setup(self):

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -10,7 +10,6 @@ from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EnergyDispersion2D
 
 
-
 class TestEnergyDispersion:
     def setup(self):
         self.e_true = np.logspace(0, 1, 101) * u.TeV
@@ -94,7 +93,6 @@ class TestEnergyDispersion:
     def test_peek(self):
         with mpl_plot_check():
             self.edisp.peek()
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from ...data import DataStore
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 
 # TODO: clean up these FITS production tests
 # There is some duplication with `gammapy/data/tests/test_data_store.py`

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -87,7 +87,6 @@ class FitsProductionTester:
 
 @pytest.mark.parametrize("prod", productions)
 @requires_data("gammapy-extra")
-
 def test_fits_prods(prod):
     tester = FitsProductionTester(prod)
     tester.test_all()

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -87,7 +87,7 @@ class FitsProductionTester:
 
 @pytest.mark.parametrize("prod", productions)
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_fits_prods(prod):
     tester = FitsProductionTester(prod)
     tester.test_all()

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -6,7 +6,7 @@ from ...utils.testing import assert_quantity_allclose
 from ..io import CTAIrf, CTAPerf
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_cta_irf():
     """Test that CTA IRFs can be loaded and evaluated."""

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -6,7 +6,6 @@ from ...utils.testing import assert_quantity_allclose
 from ..io import CTAIrf, CTAPerf
 
 
-
 @requires_data("gammapy-extra")
 def test_cta_irf():
     """Test that CTA IRFs can be loaded and evaluated."""

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -17,7 +17,7 @@ def data_store():
     return DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/")
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 @pytest.mark.parametrize(
     "pars",
@@ -94,7 +94,7 @@ def test_make_psf(pars, data_store):
     assert_allclose(psf.psf_value.value[15, 50], pars["psf_value"], rtol=1e-3)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_make_mean_psf(data_store):
     position = SkyCoord(83.63, 22.01, unit="deg")
@@ -118,7 +118,7 @@ def test_make_mean_psf(data_store):
     assert_allclose(psf_tot_int.containment_radius(0.68).deg, 0.117803, rtol=1e-3)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_make_mean_edisp(data_store):
     position = SkyCoord(83.63, 22.01, unit="deg")

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -6,7 +6,7 @@ import pytest
 from astropy.coordinates import Angle, SkyCoord
 from ..irf_reduce import make_psf, make_mean_psf, make_mean_edisp
 from ...data import DataStore, Observations
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
 from ...utils.testing import assert_quantity_allclose
 from ...utils.energy import Energy
 from ...utils.energy import EnergyBounds

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -17,7 +17,6 @@ def data_store():
     return DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/")
 
 
-
 @requires_data("gammapy-extra")
 @pytest.mark.parametrize(
     "pars",
@@ -94,7 +93,6 @@ def test_make_psf(pars, data_store):
     assert_allclose(psf.psf_value.value[15, 50], pars["psf_value"], rtol=1e-3)
 
 
-
 @requires_data("gammapy-extra")
 def test_make_mean_psf(data_store):
     position = SkyCoord(83.63, 22.01, unit="deg")
@@ -116,7 +114,6 @@ def test_make_mean_psf(data_store):
     assert_allclose(psf1_int.containment_radius(0.68).deg, 0.12307, rtol=1e-3)
     assert_allclose(psf2_int.containment_radius(0.68).deg, 0.11231, rtol=1e-3)
     assert_allclose(psf_tot_int.containment_radius(0.68).deg, 0.117803, rtol=1e-3)
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/irf/tests/test_psf_check.py
+++ b/gammapy/irf/tests/test_psf_check.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ..psf_3d import PSF3D
 from ..psf_check import PSF3DChecker
 

--- a/gammapy/irf/tests/test_psf_check.py
+++ b/gammapy/irf/tests/test_psf_check.py
@@ -6,7 +6,6 @@ from ..psf_3d import PSF3D
 from ..psf_check import PSF3DChecker
 
 
-
 @requires_data("gammapy-extra")
 class TestPSF3DChecker:
     def setup(self):

--- a/gammapy/irf/tests/test_psf_check.py
+++ b/gammapy/irf/tests/test_psf_check.py
@@ -6,7 +6,7 @@ from ..psf_3d import PSF3D
 from ..psf_check import PSF3DChecker
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestPSF3DChecker:
     def setup(self):

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -65,7 +65,7 @@ def make_test_psf(energy_bins=15, theta_bins=12):
     )
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestEnergyDependentMultiGaussPSF:
     @pytest.fixture(scope="session")
@@ -127,7 +127,7 @@ class TestEnergyDependentMultiGaussPSF:
         assert_allclose(np.squeeze(desired), actual, rtol=0.01)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_psf_cta_1dc():
     filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
@@ -146,7 +146,7 @@ def test_psf_cta_1dc():
     assert_allclose(psf.containment_radius(0.68).deg, 0.053728, atol=1e-4)
 
 
-@requires_dependency("scipy")
+
 class TestHESS:
     @staticmethod
     def test_dpdtheta2():

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -65,7 +65,6 @@ def make_test_psf(energy_bins=15, theta_bins=12):
     )
 
 
-
 @requires_data("gammapy-extra")
 class TestEnergyDependentMultiGaussPSF:
     @pytest.fixture(scope="session")
@@ -127,7 +126,6 @@ class TestEnergyDependentMultiGaussPSF:
         assert_allclose(np.squeeze(desired), actual, rtol=0.01)
 
 
-
 @requires_data("gammapy-extra")
 def test_psf_cta_1dc():
     filename = "$GAMMAPY_EXTRA/datasets/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
@@ -144,7 +142,6 @@ def test_psf_cta_1dc():
     psf = psf_irf.to_energy_dependent_table_psf("2 deg")
     psf = psf.table_psf_at_energy("1 TeV")
     assert_allclose(psf.containment_radius(0.68).deg, 0.053728, atol=1e-4)
-
 
 
 class TestHESS:

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_almost_equal
 from astropy.utils.data import get_pkg_data_filename
 from astropy.io import fits
 from astropy import units as u
-from ...utils.testing import requires_dependency, requires_data
+from ...utils.testing import requires_data
 from ..psf_gauss import EnergyDependentMultiGaussPSF
 from ..psf_gauss import multi_gauss_psf_kernel, HESSMultiGaussPSF
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -5,14 +5,17 @@ import copy
 import inspect
 import re
 from collections import OrderedDict
+
 import numpy as np
-from ..extern import six
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from scipy.interpolate import interp1d
+
 from .utils import find_hdu, find_bands_hdu
 from ..utils.interpolation import interpolation_scale
+from ..extern import six
 
 __all__ = ["MapCoord", "MapGeom", "MapAxis"]
 
@@ -264,8 +267,6 @@ def bin_to_val(edges, bins):
 def coord_to_pix(edges, coord, interp="lin"):
     """Convert axis coordinates to pixel coordinates using the chosen
     interpolation scheme."""
-    from scipy.interpolate import interp1d
-
     scale = interpolation_scale(interp)
 
     interp_fn = interp1d(
@@ -278,8 +279,6 @@ def coord_to_pix(edges, coord, interp="lin"):
 def pix_to_coord(edges, pix, interp="lin"):
     """Convert pixel coordinates to grid coordinates using the chosen
     interpolation scheme."""
-    from scipy.interpolate import interp1d
-
     scale = interpolation_scale(interp)
 
     interp_fn = interp1d(

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import astropy.units as u
+from scipy.ndimage import map_coordinates
+
 
 __all__ = ["reproject_car_to_hpx", "reproject_car_to_wcs"]
 
@@ -33,7 +35,6 @@ def _get_input_pix_celestial(wcs_in, wcs_out, shape_out):
 
 def reproject_car_to_hpx(input_data, coord_system_out, nside, order=1, nested=False):
     import healpy as hp
-    from scipy.ndimage import map_coordinates
     from reproject.wcs_utils import convert_world_coordinates
     from reproject.healpix.utils import parse_coord_system
 
@@ -72,8 +73,6 @@ def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
     ensure that the interpolation of the CAR projection is correctly
     wrapped in longitude.
     """
-    from scipy.ndimage import map_coordinates
-
     slice_in, wcs_in = input_data
 
     array_new = np.zeros(shape_out)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -448,7 +448,6 @@ def test_coadd_unit():
     assert_allclose(m1.data, 1.0001)
 
 
-
 @pytest.mark.parametrize("kernel", ["gauss", "box", "disk"])
 def test_smooth(kernel):
     axes = [
@@ -478,7 +477,6 @@ def test_make_cutout(mode):
     assert_allclose(cutout.geom.width, [[2.0], [3.0]])
 
 
-
 def test_convolve_vs_smooth():
     axes = [
         MapAxis(np.logspace(0.0, 3.0, 3), interp="log"),
@@ -493,7 +491,6 @@ def test_convolve_vs_smooth():
     gauss = Gaussian2DKernel(10).array
     actual = m.convolve(kernel=gauss)
     assert_allclose(actual.data, desired.data, rtol=1e-3)
-
 
 
 @requires_data("gammapy-extra")
@@ -517,7 +514,6 @@ def test_convolve_nd():
     mc = m.convolve(psf_kernel)
 
     assert_allclose(mc.data.sum(axis=(1, 2)), [0, 1, 1], atol=1e-5)
-
 
 
 def test_convolve_pixel_scale_error():

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -448,7 +448,7 @@ def test_coadd_unit():
     assert_allclose(m1.data, 1.0001)
 
 
-@requires_dependency("scipy")
+
 @pytest.mark.parametrize("kernel", ["gauss", "box", "disk"])
 def test_smooth(kernel):
     axes = [
@@ -478,7 +478,7 @@ def test_make_cutout(mode):
     assert_allclose(cutout.geom.width, [[2.0], [3.0]])
 
 
-@requires_dependency("scipy")
+
 def test_convolve_vs_smooth():
     axes = [
         MapAxis(np.logspace(0.0, 3.0, 3), interp="log"),
@@ -495,7 +495,7 @@ def test_convolve_vs_smooth():
     assert_allclose(actual.data, desired.data, rtol=1e-3)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_convolve_nd():
     energy_axis = MapAxis.from_edges(
@@ -519,7 +519,7 @@ def test_convolve_nd():
     assert_allclose(mc.data.sum(axis=(1, 2)), [0, 1, 1], atol=1e-5)
 
 
-@requires_dependency("scipy")
+
 def test_convolve_pixel_scale_error():
     m = WcsNDMap.create(binsz=0.05 * u.deg, width=5 * u.deg)
     kgeom = WcsGeom.create(binsz=0.04 * u.deg, width=0.5 * u.deg)

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -25,7 +25,7 @@ def get_config():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 @requires_dependency("sherpa")
 def test_spectrum_analysis_iact(tmpdir):
     config = get_config()

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -25,7 +25,6 @@ def get_config():
 
 
 @requires_data("gammapy-extra")
-
 @requires_dependency("sherpa")
 def test_spectrum_analysis_iact(tmpdir):
     config = get_config()

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -284,7 +284,9 @@ class FluxPoints(object):
         for suffix in ["", "_ul", "_err", "_errp", "_errn"]:
             try:
                 data = table["dnde" + suffix].quantity
-                table["e2dnde" + suffix] =  (e_ref ** 2 * data).to(DEFAULT_UNIT["e2dnde"])
+                table["e2dnde" + suffix] = (e_ref ** 2 * data).to(
+                    DEFAULT_UNIT["e2dnde"]
+                )
             except KeyError:
                 continue
 
@@ -295,7 +297,7 @@ class FluxPoints(object):
         for suffix in ["", "_ul", "_err", "_errp", "_errn"]:
             try:
                 data = table["e2dnde" + suffix].quantity
-                table["dnde" + suffix] =  (data / e_ref ** 2).to(DEFAULT_UNIT["dnde"])
+                table["dnde" + suffix] = (data / e_ref ** 2).to(DEFAULT_UNIT["dnde"])
             except KeyError:
                 continue
 
@@ -520,12 +522,7 @@ class FluxPoints(object):
         return self.table["e_max"].quantity
 
     def plot(
-        self,
-        ax=None,
-        energy_unit="TeV",
-        flux_unit=None,
-        energy_power=0,
-        **kwargs
+        self, ax=None, energy_unit="TeV", flux_unit=None, energy_power=0, **kwargs
     ):
         """Plot flux points.
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1,10 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Spectral models for Gammapy."""
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import operator
 import astropy.units as u
 from astropy.table import Table
+from scipy.optimize import brentq
+
 from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from .utils import integrate_spectrum
@@ -429,8 +432,6 @@ class SpectralModel(Model):
         energy : `~astropy.units.Quantity`
             Energies at which the model has the given ``value``.
         """
-        from scipy.optimize import brentq
-
         eunit = "TeV"
 
         energies = []

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -10,7 +10,7 @@ from ...utils.energy import EnergyBounds
 from .. import CountsSpectrum, PHACountsSpectrum
 
 
-@requires_dependency("scipy")
+
 class TestCountsSpectrum:
     def setup(self):
         self.counts = [0, 0, 2, 5, 17, 3]
@@ -72,7 +72,7 @@ class TestCountsSpectrum:
         assert (actual == desired).all()
 
 
-@requires_dependency("scipy")
+
 class TestPHACountsSpectrum:
     def setup(self):
         counts = [1, 2, 5, 6, 1, 7, 23, 2]

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -10,7 +10,6 @@ from ...utils.energy import EnergyBounds
 from .. import CountsSpectrum, PHACountsSpectrum
 
 
-
 class TestCountsSpectrum:
     def setup(self):
         self.counts = [0, 0, 2, 5, 17, 3]
@@ -70,7 +69,6 @@ class TestCountsSpectrum:
         actual = rebinned_spec.data.evaluate(energy=[2, 3, 5] * u.TeV)
         desired = [0, 7, 20]
         assert (actual == desired).all()
-
 
 
 class TestPHACountsSpectrum:

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -29,7 +29,6 @@ def extraction():
     )
 
 
-
 @requires_data("gammapy-extra")
 class TestSpectrumExtraction:
     @pytest.mark.parametrize(

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -29,7 +29,7 @@ def extraction():
     )
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestSpectrumExtraction:
     @pytest.mark.parametrize(

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
+from ...utils.testing import requires_data, requires_dependency
 from ...utils.random import get_random_state
 from ...irf import EffectiveAreaTable
 from ...spectrum import (

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -166,7 +166,6 @@ class TestFit:
 
 
 @requires_dependency("sherpa")
-
 @requires_data("gammapy-extra")
 class TestSpectralFit:
     """Test fitter in astrophysical scenario"""

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -166,7 +166,7 @@ class TestFit:
 
 
 @requires_dependency("sherpa")
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestSpectralFit:
     """Test fitter in astrophysical scenario"""

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -88,7 +88,6 @@ def test_e_ref_lafferty():
     assert_allclose(actual, desired, atol=1e-3)
 
 
-
 def test_dnde_from_flux():
     """Tests y-value normalization adjustment method.
     """
@@ -112,7 +111,6 @@ def test_dnde_from_flux():
     actual = flux * (dnde_model / dnde)
     # Compare
     assert_allclose(actual, desired, rtol=1e-6)
-
 
 
 @pytest.mark.parametrize("method", ["table", "lafferty", "log_center"])
@@ -179,7 +177,6 @@ def seg():
 @requires_data("gammapy-extra")
 @requires_dependency("sherpa")
 @requires_dependency("matplotlib")
-
 class TestFluxPointEstimator:
     def setup(self):
         self.fpe = FluxPointEstimator(obs=obs(), model=model(), groups=seg())

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -88,7 +88,7 @@ def test_e_ref_lafferty():
     assert_allclose(actual, desired, atol=1e-3)
 
 
-@requires_dependency("scipy")
+
 def test_dnde_from_flux():
     """Tests y-value normalization adjustment method.
     """
@@ -114,7 +114,7 @@ def test_dnde_from_flux():
     assert_allclose(actual, desired, rtol=1e-6)
 
 
-@requires_dependency("scipy")
+
 @pytest.mark.parametrize("method", ["table", "lafferty", "log_center"])
 def test_compute_flux_points_dnde_exp(method):
     """
@@ -179,7 +179,7 @@ def seg():
 @requires_data("gammapy-extra")
 @requires_dependency("sherpa")
 @requires_dependency("matplotlib")
-@requires_dependency("scipy")
+
 class TestFluxPointEstimator:
     def setup(self):
         self.fpe = FluxPointEstimator(obs=obs(), model=model(), groups=seg())

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -239,7 +239,6 @@ def test_table_model_from_file():
 
 
 @requires_data("gammapy-extra")
-
 def test_absorption():
     # absorption values for given redshift
     redshift = 0.117
@@ -297,7 +296,6 @@ def test_pwl_index_2_error():
 
 
 @requires_data("gammapy-extra")
-
 def test_fermi_isotropic():
     filename = "$GAMMAPY_EXTRA/datasets/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt"
     model = TableModel.read_fermi_isotropic_model(filename)

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -239,7 +239,7 @@ def test_table_model_from_file():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_absorption():
     # absorption values for given redshift
     redshift = 0.117
@@ -297,7 +297,7 @@ def test_pwl_index_2_error():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_fermi_isotropic():
     filename = "$GAMMAPY_EXTRA/datasets/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt"
     model = TableModel.read_fermi_isotropic_model(filename)

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -17,7 +17,7 @@ from .. import (
 )
 
 
-@requires_dependency("scipy")
+
 @requires_dependency("sherpa")
 @requires_data("gammapy-extra")
 def test_spectrum_observation_1():
@@ -35,7 +35,7 @@ def test_spectrum_observation_1():
     tester.test_all()
 
 
-@requires_dependency("scipy")
+
 @requires_dependency("sherpa")
 @requires_data("gammapy-extra")
 def test_spectrum_observation_2():
@@ -64,7 +64,7 @@ def test_spectrum_observation_2():
     tester.test_all()
 
 
-@requires_dependency("scipy")
+
 @requires_dependency("sherpa")
 @requires_data("gammapy-extra")
 def test_spectrum_observation_3():
@@ -87,7 +87,7 @@ def test_spectrum_observation_3():
     tester.test_all()
 
 
-@requires_dependency("scipy")
+
 @requires_dependency("sherpa")
 @requires_data("gammapy-extra")
 def make_observation_list():
@@ -186,7 +186,7 @@ def _read_hess_obs():
     return SpectrumObservationList([obs1, obs2])
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestSpectrumObservationStacker:
     def setup(self):
@@ -245,7 +245,7 @@ class TestSpectrumObservationStacker:
         assert_allclose(obs_stacker.stacked_obs.alpha[1], 2.5 / 8.0)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestSpectrumObservationList:
     def setup(self):

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -17,7 +17,6 @@ from .. import (
 )
 
 
-
 @requires_dependency("sherpa")
 @requires_data("gammapy-extra")
 def test_spectrum_observation_1():
@@ -33,7 +32,6 @@ def test_spectrum_observation_1():
     )
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
-
 
 
 @requires_dependency("sherpa")
@@ -64,7 +62,6 @@ def test_spectrum_observation_2():
     tester.test_all()
 
 
-
 @requires_dependency("sherpa")
 @requires_data("gammapy-extra")
 def test_spectrum_observation_3():
@@ -85,7 +82,6 @@ def test_spectrum_observation_3():
     )
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
-
 
 
 @requires_dependency("sherpa")
@@ -186,7 +182,6 @@ def _read_hess_obs():
     return SpectrumObservationList([obs1, obs2])
 
 
-
 @requires_data("gammapy-extra")
 class TestSpectrumObservationStacker:
     def setup(self):
@@ -243,7 +238,6 @@ class TestSpectrumObservationStacker:
         assert_allclose(obs_stacker.stacked_obs.alpha[0], 1.25 / 4.0)
         # When the OFF stack observation counts=0, the alpha is averaged on the total OFF counts for each run.
         assert_allclose(obs_stacker.stacked_obs.alpha[1], 2.5 / 8.0)
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/spectrum/tests/test_profile.py
+++ b/gammapy/spectrum/tests/test_profile.py
@@ -29,7 +29,6 @@ class TestFluxPointProfiles:
         assert t.colnames == ["norm", "dloglike"]
         assert_allclose(t["dloglike"], [2124.5451, 2128.8706, 2124.5451], rtol=1e-3)
 
-
     def test_get_reference_spectrum(self):
         s = self.profiles.get_reference_spectrum()
         assert len(s.energy) == 24

--- a/gammapy/spectrum/tests/test_profile.py
+++ b/gammapy/spectrum/tests/test_profile.py
@@ -29,7 +29,7 @@ class TestFluxPointProfiles:
         assert t.colnames == ["norm", "dloglike"]
         assert_allclose(t["dloglike"], [2124.5451, 2128.8706, 2124.5451], rtol=1e-3)
 
-    @requires_dependency("scipy")
+
     def test_get_reference_spectrum(self):
         s = self.profiles.get_reference_spectrum()
         assert len(s.energy) == 24

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -54,7 +54,6 @@ def spectrum_result(flux_points):
     return SpectrumResult(model=model, points=flux_points)
 
 
-
 @requires_data("gammapy-extra")
 class TestSpectrumFitResult:
     @requires_dependency("uncertainties")
@@ -74,7 +73,6 @@ class TestSpectrumFitResult:
     def test_plot(self, fit_result):
         with mpl_plot_check():
             fit_result.plot()
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -54,7 +54,7 @@ def spectrum_result(flux_points):
     return SpectrumResult(model=model, points=flux_points)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestSpectrumFitResult:
     @requires_dependency("uncertainties")
@@ -76,7 +76,7 @@ class TestSpectrumFitResult:
             fit_result.plot()
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 class TestSpectrumResult:
     def test_basic(self, spectrum_result):

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -17,7 +17,7 @@ def sens():
     return sens
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_cta_sensitivity_estimator(sens):
     table = sens.results_table

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.utils.testing import requires_data, requires_dependency
+from gammapy.utils.testing import requires_data
 from ...irf.io import CTAPerf
 from ..sensitivity import SensitivityEstimator
 

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -17,7 +17,6 @@ def sens():
     return sens
 
 
-
 @requires_data("gammapy-extra")
 def test_cta_sensitivity_estimator(sens):
     table = sens.results_table

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -8,7 +8,6 @@ from .. import SpectrumExtraction, SpectrumSimulation
 from ..models import PowerLaw
 
 
-
 class TestSpectrumSimulation:
     def setup(self):
         e_true = SpectrumExtraction.DEFAULT_TRUE_ENERGY

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import astropy.units as u
 import numpy as np
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency
 from ...utils.energy import EnergyBounds
 from ...irf import EnergyDispersion, EffectiveAreaTable
 from .. import SpectrumExtraction, SpectrumSimulation

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -9,7 +9,7 @@ from .. import SpectrumExtraction, SpectrumSimulation
 from ..models import PowerLaw
 
 
-@requires_dependency("scipy")
+
 class TestSpectrumSimulation:
     def setup(self):
         e_true = SpectrumExtraction.DEFAULT_TRUE_ENERGY

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -87,9 +87,7 @@ def get_test_cases():
     return [
         dict(
             model=PowerLaw(
-                index=2,
-                reference=Quantity(1, "TeV"),
-                amplitude=Quantity(1e2, "TeV-1"),
+                index=2, reference=Quantity(1, "TeV"), amplitude=Quantity(1e2, "TeV-1")
             ),
             e_true=e_true,
             npred=999,
@@ -136,7 +134,6 @@ def get_test_cases():
             e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
         ),
     ]
-
 
 
 @pytest.mark.parametrize("case", get_test_cases())

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -84,64 +84,58 @@ def test_integrate_spectrum_ecpl():
 def get_test_cases():
     e_true = Quantity(np.logspace(-1, 2, 120), "TeV")
     e_reco = Quantity(np.logspace(-1, 2, 100), "TeV")
-
-    try:
-        pass
-    except ImportError:
-        return []
-    else:
-        return [
-            dict(
-                model=PowerLaw(
-                    index=2,
-                    reference=Quantity(1, "TeV"),
-                    amplitude=Quantity(1e2, "TeV-1"),
-                ),
-                e_true=e_true,
-                npred=999,
+    return [
+        dict(
+            model=PowerLaw(
+                index=2,
+                reference=Quantity(1, "TeV"),
+                amplitude=Quantity(1e2, "TeV-1"),
             ),
-            dict(
-                model=PowerLaw(
-                    index=2,
-                    reference=Quantity(1, "TeV"),
-                    amplitude=Quantity(1e-11, "TeV-1 cm-2 s-1"),
-                ),
-                aeff=EffectiveAreaTable.from_parametrization(e_true),
-                livetime=Quantity(10, "h"),
-                npred=1448.059605038253,
+            e_true=e_true,
+            npred=999,
+        ),
+        dict(
+            model=PowerLaw(
+                index=2,
+                reference=Quantity(1, "TeV"),
+                amplitude=Quantity(1e-11, "TeV-1 cm-2 s-1"),
             ),
-            dict(
-                model=PowerLaw(
-                    index=2,
-                    reference=Quantity(1, "GeV"),
-                    amplitude=Quantity(1e-11, "GeV-1 cm-2 s-1"),
-                ),
-                aeff=EffectiveAreaTable.from_parametrization(e_true),
-                livetime=Quantity(30, "h"),
-                npred=4.344178815114759,
+            aeff=EffectiveAreaTable.from_parametrization(e_true),
+            livetime=Quantity(10, "h"),
+            npred=1448.059605038253,
+        ),
+        dict(
+            model=PowerLaw(
+                index=2,
+                reference=Quantity(1, "GeV"),
+                amplitude=Quantity(1e-11, "GeV-1 cm-2 s-1"),
             ),
-            dict(
-                model=PowerLaw(
-                    index=2,
-                    reference=Quantity(1, "TeV"),
-                    amplitude=Quantity(1e-11, "TeV-1 cm-2 s-1"),
-                ),
-                aeff=EffectiveAreaTable.from_parametrization(e_true),
-                edisp=EnergyDispersion.from_gauss(
-                    e_reco=e_reco, e_true=e_true, bias=0, sigma=0.2
-                ),
-                livetime=Quantity(10, "h"),
-                npred=1437.4542016322125,
+            aeff=EffectiveAreaTable.from_parametrization(e_true),
+            livetime=Quantity(30, "h"),
+            npred=4.344178815114759,
+        ),
+        dict(
+            model=PowerLaw(
+                index=2,
+                reference=Quantity(1, "TeV"),
+                amplitude=Quantity(1e-11, "TeV-1 cm-2 s-1"),
             ),
-            dict(
-                model=TableModel(
-                    energy=[0.1, 0.2, 0.3, 0.4] * u.TeV,
-                    values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
-                ),
-                npred=0.5545130625383198,
-                e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
+            aeff=EffectiveAreaTable.from_parametrization(e_true),
+            edisp=EnergyDispersion.from_gauss(
+                e_reco=e_reco, e_true=e_true, bias=0, sigma=0.2
             ),
-        ]
+            livetime=Quantity(10, "h"),
+            npred=1437.4542016322125,
+        ),
+        dict(
+            model=TableModel(
+                energy=[0.1, 0.2, 0.3, 0.4] * u.TeV,
+                values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
+            ),
+            npred=0.5545130625383198,
+            e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
+        ),
+    ]
 
 
 

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -144,7 +144,7 @@ def get_test_cases():
         ]
 
 
-@requires_dependency("scipy")
+
 @pytest.mark.parametrize("case", get_test_cases())
 def test_counts_predictor(case):
     desired = case.pop("npred")

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -86,7 +86,7 @@ def get_test_cases():
     e_reco = Quantity(np.logspace(-1, 2, 100), "TeV")
 
     try:
-        import scipy
+        pass
     except ImportError:
         return []
     else:

--- a/gammapy/stats/feldman_cousins.py
+++ b/gammapy/stats/feldman_cousins.py
@@ -3,6 +3,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import numpy as np
+from scipy.stats import norm, poisson, rankdata
+
 
 __all__ = [
     "fc_find_acceptance_interval_gauss",
@@ -42,9 +44,8 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
     (x_min, x_max) : tuple of floats
         Acceptance interval
     """
-    from scipy import stats
 
-    dist = stats.norm(loc=mu, scale=sigma)
+    dist = norm(loc=mu, scale=sigma)
 
     x_bin_width = x_bins[1] - x_bins[0]
 
@@ -63,7 +64,7 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
         else:
             # Implementing the boundary condition at zero
             mu_best = max(0, x)
-            prob_mu_best = stats.norm.pdf(x, loc=mu_best, scale=sigma)
+            prob_mu_best = norm.pdf(x, loc=mu_best, scale=sigma)
             # probMuBest should never be zero. Check it just in case.
             if prob_mu_best == 0.0:
                 r.append(0.0)
@@ -79,7 +80,7 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
             "desired confidence level for this mu!"
         )
 
-    rank = stats.rankdata(-r, method="dense")
+    rank = rankdata(-r, method="dense")
 
     index_array = np.arange(x_bins.size)
 
@@ -125,9 +126,7 @@ def fc_find_acceptance_interval_poisson(mu, background, x_bins, alpha):
     (x_min, x_max) : tuple of floats
         Acceptance interval
     """
-    from scipy import stats
-
-    dist = stats.poisson(mu=mu + background)
+    dist = poisson(mu=mu + background)
 
     x_bin_width = x_bins[1] - x_bins[0]
 
@@ -138,7 +137,7 @@ def fc_find_acceptance_interval_poisson(mu, background, x_bins, alpha):
         p.append(dist.pmf(x))
         # Implementing the boundary condition at zero
         muBest = max(0, x - background)
-        probMuBest = stats.poisson.pmf(x, mu=muBest + background)
+        probMuBest = poisson.pmf(x, mu=muBest + background)
         # probMuBest should never be zero. Check it just in case.
         if probMuBest == 0.0:
             r.append(0.0)
@@ -154,7 +153,7 @@ def fc_find_acceptance_interval_poisson(mu, background, x_bins, alpha):
             "desired confidence level for this mu!"
         )
 
-    rank = stats.rankdata(-r, method="dense")
+    rank = rankdata(-r, method="dense")
 
     index_array = np.arange(x_bins.size)
 

--- a/gammapy/stats/poisson.py
+++ b/gammapy/stats/poisson.py
@@ -6,8 +6,14 @@ Poisson significance computations for these two cases.
 * background estimated from ``n_off`
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from .significance import significance_to_probability_normal
+
 import numpy as np
+from scipy.stats import norm, poisson
+from scipy.special import erf
+from scipy.optimize import fsolve
+
+from .significance import significance_to_probability_normal
+
 
 __all__ = [
     "background",
@@ -273,8 +279,6 @@ def _significance_direct(n_on, mu_bkg):
     >>> stats.poisson._significance_direct(0, 0.1)
     1.309617799458493
     """
-    from scipy.stats import norm, poisson
-
     # Compute tail probability to see n_on or more counts
     probability = poisson.sf(n_on, mu_bkg)
 
@@ -402,14 +406,11 @@ def _significance_direct_on_off(n_on, n_off, alpha):
     * TODO: check coverage with MC simulation
     * TODO: implement in Cython and vectorize n_on (accept numpy  array n_on as input)
     """
-    from math import factorial as fac
-    from scipy.stats import norm
-
     # Compute tail probability to see n_on or more counts
     probability = 1
     for n in range(0, n_on):
         term_1 = alpha ** n / (1 + alpha) ** (n_off + n + 1)
-        term_2 = fac(n_off + n) / (fac(n) * fac(n_off))
+        term_2 = np.math.factorial(n_off + n) / (fac(n) * fac(n_off))
         probability -= term_1 * term_2
 
     # Convert probability to a significance
@@ -444,12 +445,9 @@ def excess_ul_helene(excess, excess_error, significance):
     if excess_error <= 0:
         raise ValueError("Non-positive excess_error: {}".format(excess_error))
 
-    from math import sqrt
-    from scipy.special import erf
-
     if excess >= 0.0:
         zeta = excess / excess_error
-        value = zeta / sqrt(2.0)
+        value = zeta / np.sqrt(2.0)
         integral = (1.0 + erf(value)) / 2.0
         integral2 = 1.0 - conf_level1 * integral
         value_old = value
@@ -459,7 +457,7 @@ def excess_ul_helene(excess, excess_error, significance):
         integral = (1.0 + erf(value_new)) / 2.0
     else:
         zeta = -excess / excess_error
-        value = zeta / sqrt(2.0)
+        value = zeta / np.sqrt(2.0)
         integral = 1 - (1.0 + erf(value)) / 2.0
         integral2 = 1.0 - conf_level1 * integral
         value_old = value
@@ -477,7 +475,7 @@ def excess_ul_helene(excess, excess_error, significance):
     while integral < integral2:
         value_new = value_new + 0.0000001
         integral = (1.0 + erf(value_new)) / 2.0
-    value_new = value_new * sqrt(2.0)
+    value_new = value_new * np.sqrt(2.0)
 
     if excess >= 0.0:
         conf_limit = (value_new + zeta) * excess_error
@@ -599,8 +597,6 @@ def _excess_matching_significance_on_off_simple(n_off, alpha, significance):
 # it can be analytically inverted because the n_on appears inside and outside the log
 # So probably root finding is still needed here.
 def _excess_matching_significance_lima(mu_bkg, significance):
-    from scipy.optimize import fsolve
-
     # Significance not well-defined for n_on < 0
     # Return Nan if given significance can't be reached
     s0 = _significance_lima(n_on=1e-5, mu_bkg=mu_bkg)
@@ -624,8 +620,6 @@ def _excess_matching_significance_lima(mu_bkg, significance):
 
 
 def _excess_matching_significance_on_off_lima(n_off, alpha, significance):
-    from scipy.optimize import fsolve
-
     # Significance not well-defined for n_on < 0
     # Return Nan if given significance can't be reached
     s0 = _significance_lima_on_off(n_on=1e-5, n_off=n_off, alpha=alpha)

--- a/gammapy/stats/significance.py
+++ b/gammapy/stats/significance.py
@@ -2,7 +2,12 @@
 """Conversion functions for test statistic <-> significance <-> probability.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
+from scipy.stats import norm
+from scipy.special import erfinv, erf
+from scipy.optimize import fsolve
+
 
 __all__ = [
     "significance_to_probability_normal",
@@ -43,8 +48,6 @@ def significance_to_probability_normal(significance):
     >>> significance_to_probability_normal(10)
     7.6198530241604696e-24
     """
-    from scipy.stats import norm
-
     return norm.sf(significance)
 
 
@@ -71,8 +74,6 @@ def probability_to_significance_normal(probability):
     >>> probability_to_significance_normal(1e-10)
     6.3613409024040557
     """
-    from scipy.stats import norm
-
     return norm.isf(probability)
 
 
@@ -81,8 +82,6 @@ def _p_to_s_direct(probability, one_sided=True):
 
     Reference: RooStats User Guide Equations (6,7).
     """
-    from scipy.special import erfinv
-
     probability = 1 - probability  # We want p to be the tail probability
     temp = np.where(one_sided, 2 * probability - 1, probability)
     return np.sqrt(2) * erfinv(temp)
@@ -93,8 +92,6 @@ def _s_to_p_direct(significance, one_sided=True):
 
     Note: _p_to_s_direct was solved for p.
     """
-    from scipy.special import erf
-
     temp = erf(significance / np.sqrt(2))
     probability = np.where(one_sided, (temp + 1) / 2.0, temp)
     return 1 - probability  # We want p to be the tail probability
@@ -121,8 +118,6 @@ def significance_to_probability_normal_limit(significance, guess=1e-100):
     See p_to_s_limit docstring
     Note: s^2 = u - log(u) can't be solved analytically.
     """
-    from scipy.optimize import fsolve
-
     def f(probability):
         if probability > 0:
             return probability_to_significance_normal_limit(probability) - significance

--- a/gammapy/stats/significance.py
+++ b/gammapy/stats/significance.py
@@ -118,6 +118,7 @@ def significance_to_probability_normal_limit(significance, guess=1e-100):
     See p_to_s_limit docstring
     Note: s^2 = u - log(u) can't be solved analytically.
     """
+
     def f(probability):
         if probability > 0:
             return probability_to_significance_normal_limit(probability) - significance

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -18,7 +18,6 @@ from ...stats import (
 )
 
 
-
 def test_acceptance_interval_gauss():
     sigma = 1
     n_sigma = 10
@@ -47,7 +46,6 @@ def test_acceptance_interval_gauss():
         fc_find_acceptance_interval_gauss(0, 1, x_bins, cl)
 
 
-
 def test_acceptance_interval_poisson():
     background = 0.5
     n_bins_x = 100
@@ -68,7 +66,6 @@ def test_acceptance_interval_poisson():
     # Pass too few x_bins to reach confidence level.
     with pytest.raises(ValueError):
         fc_find_acceptance_interval_poisson(0, 7, x_bins[0:10], cl)
-
 
 
 def test_numerical_confidence_interval_pdfs():
@@ -115,7 +112,6 @@ def test_numerical_confidence_interval_pdfs():
     # A higher accuracy would require a higher mu_max, which would increase
     # the computation time.
     assert_allclose(average_upper_limit, 4.42, atol=0.1)
-
 
 
 def test_numerical_confidence_interval_values():

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 from scipy import stats
 
-from ...utils.testing import requires_dependency
 from ...stats import (
     fc_find_acceptance_interval_gauss,
     fc_find_acceptance_interval_poisson,

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -1,8 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
+from scipy import stats
+
 from ...utils.testing import requires_dependency
 from ...stats import (
     fc_find_acceptance_interval_gauss,
@@ -70,8 +73,6 @@ def test_acceptance_interval_poisson():
 
 
 def test_numerical_confidence_interval_pdfs():
-    from scipy import stats
-
     background = 3.0
     step_width_mu = 0.005
     mu_min = 0
@@ -119,8 +120,6 @@ def test_numerical_confidence_interval_pdfs():
 
 
 def test_numerical_confidence_interval_values():
-    from scipy import stats
-
     sigma = 1
     n_sigma = 10
     n_bins_x = 100

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -16,7 +16,7 @@ from ...stats import (
 )
 
 
-@requires_dependency("scipy")
+
 def test_acceptance_interval_gauss():
     sigma = 1
     n_sigma = 10
@@ -45,7 +45,7 @@ def test_acceptance_interval_gauss():
         fc_find_acceptance_interval_gauss(0, 1, x_bins, cl)
 
 
-@requires_dependency("scipy")
+
 def test_acceptance_interval_poisson():
     background = 0.5
     n_bins_x = 100
@@ -68,7 +68,7 @@ def test_acceptance_interval_poisson():
         fc_find_acceptance_interval_poisson(0, 7, x_bins[0:10], cl)
 
 
-@requires_dependency("scipy")
+
 def test_numerical_confidence_interval_pdfs():
     from scipy import stats
 
@@ -117,7 +117,7 @@ def test_numerical_confidence_interval_pdfs():
     assert_allclose(average_upper_limit, 4.42, atol=0.1)
 
 
-@requires_dependency("scipy")
+
 def test_numerical_confidence_interval_values():
     from scipy import stats
 

--- a/gammapy/stats/tests/test_significance.py
+++ b/gammapy/stats/tests/test_significance.py
@@ -9,7 +9,6 @@ from ...stats import (
 )
 
 
-
 def test_significance_to_probability_normal():
     significance = 5
     p = significance_to_probability_normal(significance)
@@ -17,7 +16,6 @@ def test_significance_to_probability_normal():
 
     s = probability_to_significance_normal(p)
     assert_allclose(s, significance)
-
 
 
 def test_significance_to_probability_normal_limit():

--- a/gammapy/stats/tests/test_significance.py
+++ b/gammapy/stats/tests/test_significance.py
@@ -10,7 +10,7 @@ from ...stats import (
 )
 
 
-@requires_dependency("scipy")
+
 def test_significance_to_probability_normal():
     significance = 5
     p = significance_to_probability_normal(significance)
@@ -20,7 +20,7 @@ def test_significance_to_probability_normal():
     assert_allclose(s, significance)
 
 
-@requires_dependency("scipy")
+
 def test_significance_to_probability_normal_limit():
     significance = 5
     p = significance_to_probability_normal_limit(significance)

--- a/gammapy/stats/tests/test_significance.py
+++ b/gammapy/stats/tests/test_significance.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency
 from ...stats import (
     significance_to_probability_normal,
     probability_to_significance_normal,

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.utils import lazyproperty
 from astropy import units as u
 from astropy.table import Table
+from scipy.interpolate import InterpolatedUnivariateSpline
+
 from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
 from ..utils.fitting import Parameter, Parameters, Model
@@ -190,11 +193,8 @@ class LightCurveTableModel(Model):
 
     @lazyproperty
     def _interpolator(self):
-        from scipy.interpolate import InterpolatedUnivariateSpline
-
         x = self.table["TIME"].data
         y = self.table["NORM"].data
-
         return InterpolatedUnivariateSpline(x, y, k=1)
 
     @lazyproperty

--- a/gammapy/time/period.py
+++ b/gammapy/time/period.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from collections import OrderedDict
 import numpy as np
 
+from scipy.optimize import least_squares
+
 __all__ = ["robust_periodogram"]
 
 
@@ -116,8 +118,6 @@ def _robust_regression(time, flux, flux_err, periods, loss, scale):
     """
     Periodogram peaks for a given loss function and scale.
     """
-    from scipy.optimize import least_squares
-
     beta0 = np.array([0, 1, 0])
     mu = np.median(flux)
     x = np.ones([len(time), len(beta0)])

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -114,7 +114,6 @@ def test_lightcurve_fvar(lc):
     assert_allclose(fvar_err, 0.07905694150420949, rtol=1e-2)
 
 
-
 def test_lightcurve_chisq(lc):
     chi2, pval = lc.compute_chisq()
     assert_quantity_allclose(chi2, 1.0000000000000001e-11)
@@ -202,7 +201,6 @@ def spec_extraction():
 
 
 @requires_data("gammapy-extra")
-
 def test_lightcurve_estimator():
     spec_extract = spec_extraction()
     lc_estimator = LightCurveEstimator(spec_extract)
@@ -251,7 +249,6 @@ def test_lightcurve_estimator():
 
 
 @requires_data("gammapy-extra")
-
 def test_lightcurve_interval_maker():
     spec_extract = spec_extraction()
 
@@ -264,7 +261,6 @@ def test_lightcurve_interval_maker():
 
 
 @requires_data("gammapy-extra")
-
 def test_lightcurve_adaptative_interval_maker():
     spec_extract = spec_extraction()
     lc_estimator = LightCurveEstimator(spec_extract)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -114,7 +114,7 @@ def test_lightcurve_fvar(lc):
     assert_allclose(fvar_err, 0.07905694150420949, rtol=1e-2)
 
 
-@requires_dependency("scipy")
+
 def test_lightcurve_chisq(lc):
     chi2, pval = lc.compute_chisq()
     assert_quantity_allclose(chi2, 1.0000000000000001e-11)
@@ -202,7 +202,7 @@ def spec_extraction():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_lightcurve_estimator():
     spec_extract = spec_extraction()
     lc_estimator = LightCurveEstimator(spec_extract)
@@ -251,7 +251,7 @@ def test_lightcurve_estimator():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_lightcurve_interval_maker():
     spec_extract = spec_extraction()
 
@@ -264,7 +264,7 @@ def test_lightcurve_interval_maker():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_lightcurve_adaptative_interval_maker():
     spec_extract = spec_extraction()
     lc_estimator = LightCurveEstimator(spec_extract)

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from ...utils.scripts import make_path
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
 from ..models import PhaseCurveTableModel, LightCurveTableModel
 
 

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -49,12 +49,10 @@ def test_light_curve_str(light_curve):
     assert "LightCurveTableModel" in ss
 
 
-
 @requires_data("gammapy-extra")
 def test_light_curve_evaluate_norm_at_time(light_curve):
     val = light_curve.evaluate_norm_at_time(46300)
     assert_allclose(val, 0.021192223042749835)
-
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -49,14 +49,14 @@ def test_light_curve_str(light_curve):
     assert "LightCurveTableModel" in ss
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_light_curve_evaluate_norm_at_time(light_curve):
     val = light_curve.evaluate_norm_at_time(46300)
     assert_allclose(val, 0.021192223042749835)
 
 
-@requires_dependency("scipy")
+
 @requires_data("gammapy-extra")
 def test_light_curve_mean_norm_in_time_interval(light_curve):
     val = light_curve.mean_norm_in_time_interval(46300, 46301)

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.stats import LombScargle
 from ..period import robust_periodogram
-from ...utils.testing import requires_dependency
 
 pytest.importorskip("astropy", "3.0")
 

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -116,7 +116,6 @@ def fap_astropy(power, freq, t, y, dy, method=dict(baluev=0)):
     return fap
 
 
-
 @pytest.mark.parametrize(
     "pars",
     [

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -117,7 +117,7 @@ def fap_astropy(power, freq, t, y, dy, method=dict(baluev=0)):
     return fap
 
 
-@requires_dependency("scipy")
+
 @pytest.mark.parametrize(
     "pars",
     [

--- a/gammapy/time/tests/test_plot_periodogram.py
+++ b/gammapy/time/tests/test_plot_periodogram.py
@@ -8,7 +8,6 @@ from .test_period import simulate_test_data, fap_astropy
 pytest.importorskip("astropy", "3.0")
 
 
-
 def test_plot_periodogram():
     pars = dict(
         period=7,

--- a/gammapy/time/tests/test_plot_periodogram.py
+++ b/gammapy/time/tests/test_plot_periodogram.py
@@ -1,13 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
+from ...utils.testing import requires_dependency
 from ..period import robust_periodogram
 from ..plot_periodogram import plot_periodogram
 from .test_period import simulate_test_data, fap_astropy
 
 pytest.importorskip("astropy", "3.0")
 
-
+@requires_dependency("matplotlib")
 def test_plot_periodogram():
     pars = dict(
         period=7,

--- a/gammapy/time/tests/test_plot_periodogram.py
+++ b/gammapy/time/tests/test_plot_periodogram.py
@@ -9,7 +9,7 @@ from .test_period import simulate_test_data, fap_astropy
 pytest.importorskip("astropy", "3.0")
 
 
-@requires_dependency("scipy")
+
 def test_plot_periodogram():
     pars = dict(
         period=7,

--- a/gammapy/time/tests/test_plot_periodogram.py
+++ b/gammapy/time/tests/test_plot_periodogram.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-from ...utils.testing import requires_dependency
 from ..period import robust_periodogram
 from ..plot_periodogram import plot_periodogram
 from .test_period import simulate_test_data, fap_astropy

--- a/gammapy/utils/distributions/utils.py
+++ b/gammapy/utils/distributions/utils.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Helper functions to work with distributions."""
 from __future__ import absolute_import, division, print_function, unicode_literals
+from scipy.integrate import quad
 
 from ...utils.random import get_random_state
 from ...utils.distributions import GeneralRandom
@@ -11,8 +12,6 @@ __all__ = ["normalize", "density", "draw", "pdf"]
 def normalize(func, x_min, x_max):
     """Normalize a 1D function over a given range.
     """
-    from scipy.integrate import quad
-
     def f(x):
         return func(x) / quad(func, x_min, x_max)[0]
 

--- a/gammapy/utils/distributions/utils.py
+++ b/gammapy/utils/distributions/utils.py
@@ -12,6 +12,7 @@ __all__ = ["normalize", "density", "draw", "pdf"]
 def normalize(func, x_min, x_max):
     """Normalize a 1D function over a given range.
     """
+
     def f(x):
         return func(x) / quad(func, x_min, x_max)[0]
 

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -219,16 +219,7 @@ class Fit(object):
 class FitResult(object):
     """Fit result object."""
 
-    def __init__(
-        self,
-        model,
-        success,
-        nfev,
-        total_stat,
-        message,
-        backend,
-        method,
-    ):
+    def __init__(self, model, success, nfev, total_stat, message, backend, method):
         self._model = model
         self._success = success
         self._nfev = nfev

--- a/gammapy/utils/fitting/tests/test_model.py
+++ b/gammapy/utils/fitting/tests/test_model.py
@@ -4,7 +4,6 @@ from ..model import Model
 
 
 class MyModel(Model):
-
     def __init__(self):
         self.parameters = Parameters(
             [Parameter("x", 2), Parameter("y", 3e2), Parameter("z", 4e-2)]

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -2,6 +2,8 @@
 """Multi-Gaussian distribution utitities (Gammapy internal)."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from scipy.optimize import brentq
+
 
 __doctest_requires__ = {("gaussian_sum_moments"): ["uncertainties"]}
 
@@ -292,7 +294,6 @@ class MultiGauss2D(object):
                 "containment_fraction = {} not possible for integral = {}"
                 "".format(containment_fraction, self.integral)
             )
-        from scipy.optimize import brentq
 
         def f(theta):
             # positive if theta too large

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -2,6 +2,7 @@
 """Interpolation utilities"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from scipy.interpolate import RegularGridInterpolator
 
 
 __all__ = ["ScaledRegularGridInterpolator", "interpolation_scale"]
@@ -28,8 +29,6 @@ class ScaledRegularGridInterpolator(object):
 
     # TODO: add points scaling or axis scaling argument
     def __init__(self, points, values, values_scale="lin", extrapolate=True, **kwargs):
-        from scipy.interpolate import RegularGridInterpolator
-
         self.scale = interpolation_scale(values_scale)
         values_scaled = self.scale(values)
 
@@ -58,7 +57,7 @@ class ScaledRegularGridInterpolator(object):
 
 def interpolation_scale(scale="lin"):
     """Interpolation scaling.
-    
+
     Parameters
     ----------
     scale : {"lin", "log", "sqrt"}

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -48,7 +48,7 @@ def test_xml_errors():
 
 
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 def test_complex():
     filename = "$GAMMAPY_EXTRA/test_datasets/models/examples.xml"
     sourcelib = SkyModels.read(filename)
@@ -117,7 +117,7 @@ def test_complex():
 
 @pytest.mark.xfail(reason="Need to improve XML read")
 @requires_data("gammapy-extra")
-@requires_dependency("scipy")
+
 @pytest.mark.parametrize(
     "filename",
     [

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -48,7 +48,6 @@ def test_xml_errors():
 
 
 @requires_data("gammapy-extra")
-
 def test_complex():
     filename = "$GAMMAPY_EXTRA/test_datasets/models/examples.xml"
     sourcelib = SkyModels.read(filename)
@@ -117,7 +116,6 @@ def test_complex():
 
 @pytest.mark.xfail(reason="Need to improve XML read")
 @requires_data("gammapy-extra")
-
 @pytest.mark.parametrize(
     "filename",
     [

--- a/gammapy/utils/tests/test_gauss.py
+++ b/gammapy/utils/tests/test_gauss.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
 from astropy.modeling.models import Gaussian2D
 from astropy.convolution import discretize_model
+from scipy.integrate import quad, dblquad
 from ..testing import requires_dependency
 from ...maps import WcsNDMap
 from ...image import measure_image_moments
@@ -21,8 +22,6 @@ class TestGauss2DPDF:
         self.gs = [Gauss2DPDF(0.1), Gauss2DPDF(1), Gauss2DPDF(1)]
 
     def test_call(self):
-        from scipy.integrate import dblquad
-
         # Check that value at origin matches the one given here:
         # http://en.wikipedia.org/wiki/Multivariate_normal_distribution#Bivariate_case
         for g in self.gs:
@@ -37,8 +36,6 @@ class TestGauss2DPDF:
             assert_almost_equal(integral, 1, decimal=5)
 
     def test_dpdtheta2(self):
-        from scipy.integrate import quad
-
         for g in self.gs:
             theta2_max = (7 * g.sigma) ** 2
             integral = quad(g.dpdtheta2, 0, theta2_max)[0]
@@ -69,16 +66,12 @@ class TestMultiGauss2D:
     checking that their integrals."""
 
     def test_call(self):
-        from scipy.integrate import dblquad
-
         m = MultiGauss2D(sigmas=[1, 2], norms=[3, 4])
         xy_max = 5 * m.max_sigma  # integration range
         integral = dblquad(m, -xy_max, xy_max, lambda _: -xy_max, lambda _: xy_max)[0]
         assert_almost_equal(integral, 7, decimal=5)
 
     def test_dpdtheta2(self):
-        from scipy.integrate import quad
-
         m = MultiGauss2D(sigmas=[1, 2], norms=[3, 4])
         theta2_max = (7 * m.max_sigma) ** 2
         integral = quad(m.dpdtheta2, 0, theta2_max)[0]

--- a/gammapy/utils/tests/test_gauss.py
+++ b/gammapy/utils/tests/test_gauss.py
@@ -12,7 +12,7 @@ from ..gauss import Gauss2DPDF, MultiGauss2D, gaussian_sum_moments
 BINSZ = 0.02
 
 
-@requires_dependency("scipy")
+
 class TestGauss2DPDF:
     """Note that we test __call__ and dpdtheta2 by
     checking that their integrals as advertised are 1."""
@@ -63,7 +63,7 @@ class TestGauss2DPDF:
         assert_equal(g.sigma, 5)
 
 
-@requires_dependency("scipy")
+
 class TestMultiGauss2D:
     """Note that we test __call__ and dpdtheta2 by
     checking that their integrals."""

--- a/gammapy/utils/tests/test_gauss.py
+++ b/gammapy/utils/tests/test_gauss.py
@@ -13,7 +13,6 @@ from ..gauss import Gauss2DPDF, MultiGauss2D, gaussian_sum_moments
 BINSZ = 0.02
 
 
-
 class TestGauss2DPDF:
     """Note that we test __call__ and dpdtheta2 by
     checking that their integrals as advertised are 1."""
@@ -58,7 +57,6 @@ class TestGauss2DPDF:
     def test_gauss_convolve(self):
         g = Gauss2DPDF(sigma=3).gauss_convolve(sigma=4)
         assert_equal(g.sigma, 5)
-
 
 
 class TestMultiGauss2D:

--- a/gammapy/utils/tests/test_units.py
+++ b/gammapy/utils/tests/test_units.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import astropy.units as u
 from ..units import standardise_unit
 
 

--- a/setup.py
+++ b/setup.py
@@ -106,13 +106,13 @@ setup(
     install_requires=[
       'numpy>=1.10',
       'astropy>=2.0',
+      'scipy>=0.15',
       'regions>=0.3',
       'click',
     ],
     extras_require=dict(
       analysis=[
           'pyyaml',
-          'scipy>=0.15',
           'reproject',
           'uncertainties>=2.4',
           'naima',


### PR DESCRIPTION
As discussed in #1863, this PR adds Scipy as a core dependency for Gammapy:

* Add Scipy as a core dependency in `setup.py`
* Remove the calls to `requires_dependency("scipy")`
* Move delayed imports to the top
   