### PR TITLE
Add gammapy.utils.fitting.scipy

### DIFF
--- a/gammapy/utils/fitting/__init__.py
+++ b/gammapy/utils/fitting/__init__.py
@@ -6,5 +6,6 @@ from .likelihood import *
 from .fit import *
 
 # Backends
+from .scipy import *
 from .iminuit import *
 from .sherpa import *

--- a/gammapy/utils/fitting/__init__.py
+++ b/gammapy/utils/fitting/__init__.py
@@ -1,6 +1,10 @@
 """Fitting framework and backends."""
+# Core
 from .parameter import *
 from .model import *
+from .likelihood import *
 from .fit import *
+
+# Backends
 from .iminuit import *
 from .sherpa import *

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -8,6 +8,7 @@ from astropy.utils.misc import InheritDocstrings
 from ...extern import six
 from .iminuit import optimize_iminuit, _get_covar
 from .sherpa import optimize_sherpa
+from .scipy import optimize_scipy
 
 
 __all__ = ["Fit"]
@@ -24,7 +25,7 @@ class Fit(object):
     """Abstract Fit base class.
     """
 
-    _optimize_funcs = {"minuit": optimize_iminuit, "sherpa": optimize_sherpa}
+    _optimize_funcs = {"minuit": optimize_iminuit, "sherpa": optimize_sherpa, "scipy": optimize_scipy}
 
     @abc.abstractmethod
     def total_stat(self, parameters):
@@ -148,6 +149,9 @@ class Fit(object):
             parameters.autoscale()
 
         optimize = self._optimize_funcs[backend]
+        # TODO: change this calling interface!
+        # probably should pass a likelihood, which has a model, which has parameters
+        # and return something simpler, not a tuple of three things
         factors, info, optimizer = optimize(
             parameters=parameters, function=self.total_stat, **kwargs
         )

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import logging
 import numpy as np
+from .likelihood import Likelihood
 
 __all__ = ["optimize_iminuit"]
 
@@ -24,7 +25,7 @@ def optimize_iminuit(parameters, function, **kwargs):
 
     Returns
     -------
-    result : (factors, info, optmizer)
+    result : (factors, info, optimizer)
         Tuple containing the best fit factors, some info and the optimizer instance.
     """
     from iminuit import Minuit
@@ -36,7 +37,7 @@ def optimize_iminuit(parameters, function, **kwargs):
     kwargs.update(make_minuit_par_kwargs(parameters))
 
     parnames = _make_parnames(parameters)
-    minuit_func = MinuitFunction(function, parameters)
+    minuit_func = Likelihood(function, parameters)
 
     minuit = Minuit(minuit_func.fcn, forced_parameters=parnames, **kwargs)
     minuit.migrad()
@@ -69,26 +70,6 @@ def _make_parnames(parameters):
         "par_{:03d}_{}".format(idx, par.name)
         for idx, par in enumerate(parameters.parameters)
     ]
-
-
-class MinuitFunction(object):
-    """Wrapper for iminuit
-
-    Parameters
-    ----------
-    parameters : `~gammapy.utils.modeling.Parameters`
-        Parameters with starting values
-    function : callable
-        Likelihood function
-    """
-
-    def __init__(self, function, parameters):
-        self.function = function
-        self.parameters = parameters
-
-    def fcn(self, *factors):
-        self.parameters.set_parameter_factors(factors)
-        return self.function(self.parameters)
 
 
 def make_minuit_par_kwargs(parameters):

--- a/gammapy/utils/fitting/likelihood.py
+++ b/gammapy/utils/fitting/likelihood.py
@@ -28,6 +28,6 @@ class Likelihood(object):
         self.function = function
         self.parameters = parameters
 
-    def fcn(self, *factors):
+    def fcn(self, factors):
         self.parameters.set_parameter_factors(factors)
         return self.function(self.parameters)

--- a/gammapy/utils/fitting/likelihood.py
+++ b/gammapy/utils/fitting/likelihood.py
@@ -1,0 +1,33 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+__all__ = ["Likelihood"]
+
+
+# TODO: get rid of this wrapper class? Or use it in a better way?
+class Likelihood(object):
+    """Wrapper of the likelihood function used by the optimiser.
+
+    This might become superfluous if we introduce a
+    generic ``Likelihood`` interface and use that directly,
+    or change the ``Fit`` class to work with ``Model``
+    and ``Likelihood`` objects.
+
+    For now, this class does the translation of parameter
+    values and the parameter factors the optimiser sees.
+
+    Parameters
+    ----------
+    parameters : `~gammapy.utils.modeling.Parameters`
+        Parameters with starting values
+    function : callable
+        Likelihood function
+    """
+
+    def __init__(self, function, parameters):
+        self.function = function
+        self.parameters = parameters
+
+    def fcn(self, *factors):
+        self.parameters.set_parameter_factors(factors)
+        return self.function(self.parameters)

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,9 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numpy as np
+from .likelihood import Likelihood
 
 __all__ = ["optimize_scipy"]
 
 
-def optimize_scipy():
-    pass
+def optimize_scipy(parameters, function, **kwargs):
+    from scipy.optimize import minimize
+
+    pars = [par.factor for par in parameters.parameters]
+    likelihood = Likelihood(function, parameters)
+
+    # TODO: understand options for this optimiser
+    tol = kwargs.pop('tol', 1e-2)
+    result = minimize(likelihood.fcn, pars, tol=tol, **kwargs)
+
+    factors = result.x
+    info = {"success": result.success, "message": result.message, "nfev": result.nfev}
+    optimizer = None
+
+    return factors, info, optimizer

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,0 +1,9 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+
+__all__ = ["optimize_scipy"]
+
+
+def optimize_scipy():
+    pass

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -17,7 +17,7 @@ def get_sherpa_optimizer(name):
 
 
 class SherpaLikelihood(Likelihood):
-    """Likelihood function interface the way Sherpa likes it."""
+    """Likelihood function interface for Sherpa."""
     def fcn(self, factors):
         self.parameters.set_parameter_factors(factors)
         return self.function(self.parameters), 0
@@ -55,6 +55,8 @@ def optimize_sherpa(parameters, function, **kwargs):
             statfunc=statfunc.fcn, pars=pars, parmins=parmins, parmaxes=parmaxes
         )
 
+    factors = result[1]
     info = {"success": result[0], "message": result[3], "nfev": result[4]["nfev"]}
+    optimizer = optimizer
 
-    return result[1], info, optimizer
+    return factors, info, optimizer

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from .likelihood import Likelihood
 
 __all__ = ["optimize_sherpa"]
 
@@ -15,21 +16,8 @@ def get_sherpa_optimizer(name):
     }[name]()
 
 
-class SherpaFunction(object):
-    """Wrapper for Sherpa
-
-    Parameters
-    ----------
-    parameters : `~gammapy.utils.modeling.Parameters`
-        Parameters with starting values
-    function : callable
-        Likelihood function
-    """
-
-    def __init__(self, function, parameters):
-        self.function = function
-        self.parameters = parameters
-
+class SherpaLikelihood(Likelihood):
+    """Likelihood function interface the way Sherpa likes it."""
     def fcn(self, factors):
         self.parameters.set_parameter_factors(factors)
         return self.function(self.parameters), 0
@@ -60,7 +48,7 @@ def optimize_sherpa(parameters, function, **kwargs):
     parmins = [par.factor_min for par in parameters.parameters]
     parmaxes = [par.factor_max for par in parameters.parameters]
 
-    statfunc = SherpaFunction(function, parameters)
+    statfunc = SherpaLikelihood(function, parameters)
 
     with np.errstate(invalid="ignore"):
         result = optimizer.fit(

--- a/gammapy/utils/fitting/tests/test_scipy.py
+++ b/gammapy/utils/fitting/tests/test_scipy.py
@@ -1,0 +1,2 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals


### PR DESCRIPTION
This PR adds a first version of the interface to scipy.optimize.minimize and is a first step for #1907.

I also introduce a `Likelihood` class that groups the `function` and `parameters`, with the idea that this likelihood object would be what's passed to the backend methods, and they would either use it directly if the support a simple API (like `scipy.optimize.minimize`) or write an adapter.

On the user side, the responsibility of the `Fit` class could be to be the manager and uniform API where the user passes a `Likelihood` in and then can analyse it, i.e. optimise, covar, conf, profile, contour. A key property would be that it's backend-agnostic, the current hard-coded MINUIT stuff in the Fit class should be removed and replaced with a generic interface (probably a combination of an API on Parameters, Likelihood and Fit).

I'll merge this now if tests pass, and continue in follow-up small PRs instead of accumulating one huge PR throughout this week. But comments and suggestions are highly welcome any time, I'm happy to change the implementation or API and iterate towards something good, as long as the existing functionality keeps working.

@adonath @registerrier - Thoughts?