### PR TITLE
Unify interpolation and add broadcasting to ScaledRegularGridInterpolator 

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -37,12 +37,8 @@ def make_map_background_irf(pointing, ontime, bkg, geom):
     energy_axis = geom.get_axis_by_name("energy")
     energies = energy_axis.edges * energy_axis.unit
 
-    fov_lon, fov_lat, energy_reco = np.broadcast_arrays(
-        fov_lon, fov_lat, energies[:, np.newaxis, np.newaxis], subok=True
-    )
-
     bkg_de = bkg.evaluate_integrate(
-        fov_lon=fov_lon, fov_lat=fov_lat, energy_reco=energy_reco
+        fov_lon=fov_lon, fov_lat=fov_lat, energy_reco=energies[:, np.newaxis, np.newaxis]
     )
 
     d_omega = geom.solid_angle()

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -32,7 +32,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
     offset = geom.separation(pointing)
     energy = geom.axes[0].center * geom.axes[0].unit
 
-    exposure = aeff.data.evaluate(offset=offset, energy=energy)
+    exposure = aeff.data.evaluate(offset=offset, energy=energy[:, np.newaxis, np.newaxis])
     # TODO: Improve IRF evaluate to preserve energy axis if length 1
     # For now, we handle that case via this hack:
     if len(exposure.shape) < 3:

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -162,9 +162,9 @@ class Background3D(object):
         array : `~astropy.units.Quantity`
             Interpolated values, axis order is the same as for the NDData array
         """
-        points = dict(fov_lon=fov_lon, fov_lat=fov_lat, energy=energy_reco)
-        array = self.data.evaluate_at_coord(points=points, method=method, **kwargs)
-        return array
+        values = self.data.evaluate(fov_lon=fov_lon, fov_lat=fov_lat,
+                                    energy=energy_reco, method=method, **kwargs)
+        return values
 
     def evaluate_integrate(
         self, fov_lon, fov_lat, energy_reco, method="linear", **kwargs
@@ -336,8 +336,7 @@ class Background2D(object):
             Interpolated values, axis order is the same as for the NDData array
         """
         offset = np.sqrt(fov_lon ** 2 + fov_lat ** 2)
-        points = dict(offset=offset, energy=energy_reco)
-        return self.data.evaluate_at_coord(points=points, method=method, **kwargs)
+        return self.data.evaluate(offset=offset, energy=energy_reco, method=method, **kwargs)
 
     def evaluate_integrate(self, fov_lon, fov_lat, energy_reco, method="linear"):
         """Evaluate at given FOV position and energy, by integrating over the energy range.

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -544,7 +544,7 @@ class EffectiveAreaTable2D(object):
 
         offset = self.data.axis("offset").bins
         energy = self.data.axis("energy").bins
-        aeff = self.data.evaluate(offset=offset, energy=energy)
+        aeff = self.data.evaluate(offset=offset, energy=energy[:, np.newaxis])
 
         vmin, vmax = np.nanmin(aeff.value), np.nanmax(aeff.value)
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -983,14 +983,16 @@ class EnergyDispersion2D(object):
         ax = plt.gca() if ax is None else ax
 
         if offset is None:
-            offset = Angle([1], "deg")
+            offset = Angle(1, "deg")
 
         e_true = self.data.axis("e_true").bins
         migra = self.data.axis("migra").bins
 
         x = e_true.value
         y = migra.value
-        z = self.data.evaluate(offset=offset, e_true=e_true, migra=migra).value
+        z = self.data.evaluate(offset=offset,
+                               e_true=e_true.reshape(1, -1, 1),
+                               migra=migra.reshape(1, 1, -1)).value[0]
 
         caxes = ax.pcolormesh(x, y, z.T, **kwargs)
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -57,7 +57,7 @@ class TestEffectiveAreaTable2D:
         offset = 1.2 * u.deg
         actual = aeff.to_effective_area_table(offset=offset).data.data
         desired = aeff.data.evaluate(offset=offset)
-        assert_equal(actual.value, desired.value)
+        assert_equal(actual.value, desired.value.squeeze())
 
     @staticmethod
     @requires_dependency("matplotlib")

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -132,10 +132,12 @@ class TestEnergyDispersion2D:
 
         # Check output shape
         energy = [1, 2] * u.TeV
-        migra = [0.98, 0.97, 0.7]
-        offset = [0.1, 0.2] * u.deg
-        actual = self.edisp.data.evaluate(e_true=energy, migra=migra, offset=offset)
-        assert_allclose(actual.shape, (2, 3, 2))
+        migra = np.array([0.98, 0.97, 0.7])
+        offset = [0.1, 0.2, 0.3, 0.4] * u.deg
+        actual = self.edisp.data.evaluate(e_true=energy.reshape(-1, 1, 1),
+                                          migra=migra.reshape(1, -1, 1),
+                                          offset=offset.reshape(1, 1, -1))
+        assert_allclose(actual.shape, (2, 3, 4))
 
         # Check evaluation at all nodes
         actual = self.edisp.data.evaluate().shape

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -281,7 +281,7 @@ def test_wcsndmap_interp_by_coord(npix, binsz, coordsys, proj, skydir, axes):
 
 
 def test_interp_by_coord_quantities():
-    ax = MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy", unit="TeV")
+    ax = MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy", unit="TeV", node_type="center")
     geom = WcsGeom.create(binsz=0.1, npix=(3, 3), axes=[ax])
     m = WcsNDMap(geom)
     coords_dict = {"lon": 0, "lat": 0, "energy": 1000 * u.GeV}
@@ -289,7 +289,7 @@ def test_interp_by_coord_quantities():
     m.set_by_coord(coords_dict, 42)
 
     coords_dict["energy"] = 1 * u.TeV
-    assert_allclose(42, m.interp_by_coord(coords_dict, interp="nearest"))
+    assert_allclose(42., m.interp_by_coord(coords_dict, interp="nearest"))
 
 
 def test_wcsndmap_interp_by_coord_fill_value():

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -9,11 +9,12 @@ from astropy.nddata import Cutout2D
 from astropy.convolution import Tophat2DKernel
 from scipy.ndimage import gaussian_filter, uniform_filter, convolve
 from scipy.signal import fftconvolve
-from scipy.interpolate import RegularGridInterpolator, griddata
+from scipy.interpolate import griddata
 from scipy.ndimage import map_coordinates
 
 from ..extern.skimage import block_reduce
 from ..utils.units import unit_from_fits_image_hdu
+from ..utils.interpolation import ScaledRegularGridInterpolator
 from .geom import pix_tuple_to_idx
 from .wcs import _check_width
 from .utils import interp_to_order
@@ -175,10 +176,10 @@ class WcsNDMap(WcsMap):
         else:
             data = self.data.T
 
-        fn = RegularGridInterpolator(
+        fn = ScaledRegularGridInterpolator(
             grid_pix, data, fill_value=fill_value, bounds_error=False, method=method
         )
-        return fn(tuple(pix))
+        return fn(tuple(pix), clip=False)
 
     def _interp_by_pix_map_coordinates(self, pix, order=1):
         pix = tuple(

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1188,7 +1188,7 @@ class TableModel(SpectralModel):
         interp_kwargs.setdefault("values_scale", "log")
 
         self._evaluate = ScaledRegularGridInterpolator(
-            points=(np.log(energy.value),), values=values.value, **interp_kwargs
+            points=(np.log(energy.value),), values=values, **interp_kwargs
         )
 
     @classmethod
@@ -1268,7 +1268,7 @@ class TableModel(SpectralModel):
         """Evaluate the model (static function)."""
         x = np.log(energy.to_value(self.energy.unit))
         values = self._evaluate((x,), clip=True)
-        return u.Quantity(norm.value * values, self.values.unit, copy=False)
+        return norm * values
 
 
 class Absorption(object):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1267,9 +1267,8 @@ class TableModel(SpectralModel):
     def evaluate(self, energy, norm):
         """Evaluate the model (static function)."""
         x = np.log(energy.to_value(self.energy.unit))
-        vals = self._evaluate(x, clip=True)
-        vals = np.reshape(vals, x.shape)
-        return u.Quantity(norm.value * vals, self.values.unit, copy=False)
+        values = self._evaluate((x,), clip=True)
+        return u.Quantity(norm.value * values, self.values.unit, copy=False)
 
 
 class Absorption(object):

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -68,12 +68,13 @@ class ScaledRegularGridInterpolator(object):
         values = self.scale.inverse(values.reshape(points[0].shape))
 
         if clip:
-            np.clip(values, 0, np.inf, out=values)
+            values = np.clip(values, 0, np.inf)
 
         if self._values_unit:
             return u.Quantity(values, self._values_unit, copy=False)
         else:
             return values
+
 
 
 def interpolation_scale(scale="lin"):

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -162,17 +162,17 @@ class NDDataArray(object):
             shapes = values[0].shape
 
         # Flatten in order to support 2D array input
-        values = [_.flatten() for _ in values]
+        values = [_.flat for _ in values]
         points = list(itertools.product(*values))
 
         if self._regular_grid_interp is None:
             self._add_regular_grid_interp()
 
-        res = self._regular_grid_interp(points, method=method, **kwargs)
-
+        res = self._regular_grid_interp._interpolate(points, method=method, **kwargs)
+        res = np.clip(res, 0, np.inf)
         out = np.reshape(res, shapes).squeeze()
+        return Quantity(out, self.data.unit, copy=False)
 
-        return out * self.data.unit
 
     def evaluate_at_coord(self, points, method="linear", **kwargs):
         """Evaluate NDData Array on set of points.
@@ -204,8 +204,7 @@ class NDDataArray(object):
                 for axis in self.axes
             ]
         )
-        res = self._regular_grid_interp(points, method=method, **kwargs)
-        return res * self.data.unit
+        return self._regular_grid_interp(points, method=method, **kwargs)
 
     def _add_regular_grid_interp(self, interp_kwargs=None):
         """Add `~scipy.interpolate.RegularGridInterpolator`

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -143,9 +143,12 @@ class NDDataArray(object):
             Interpolated values, axis order is the same as for the NDData array
         """
         values = []
-        for axis in self.axes:
+        for idx, axis in enumerate(self.axes):
             # Extract values for each axis, default: nodes
-            temp = Quantity(kwargs.pop(axis.name, axis.nodes))
+            shape = np.ones(len(self.axes), dtype=int)
+            shape[idx] = -1
+            default =  axis.nodes.reshape(shape)
+            temp = Quantity(kwargs.pop(axis.name, default))
             # Transform to correct unit
             temp = temp.to_value(axis.unit)
             # Transform to match interpolation behaviour of axis
@@ -155,56 +158,10 @@ class NDDataArray(object):
         if kwargs != {}:
             raise ValueError("Input given for unknown axis: {}".format(kwargs))
 
-        # This is necessary since np.append does not support the 1D case
-        if self.dim > 1:
-            shapes = np.concatenate([np.shape(_) for _ in values])
-        else:
-            shapes = values[0].shape
-
-        # Flatten in order to support 2D array input
-        values = [_.flat for _ in values]
-        points = list(itertools.product(*values))
-
         if self._regular_grid_interp is None:
             self._add_regular_grid_interp()
 
-        res = self._regular_grid_interp._interpolate(points, method=method, **kwargs)
-        res = np.clip(res, 0, np.inf)
-        out = np.reshape(res, shapes).squeeze()
-        return Quantity(out, self.data.unit, copy=False)
-
-
-    def evaluate_at_coord(self, points, method="linear", **kwargs):
-        """Evaluate NDData Array on set of points.
-
-        TODO: merge with `evaluate`?
-        This method was added to support evaluating on arbitrary arrays
-        of coordinates, not just on the outer product like `evaluate`.
-
-        Parameters
-        ----------
-        points: dict
-            contains the coordinates on which you want to interpolate (axis_name: value)
-        method : str {'linear', 'nearest'}, optional
-            Interpolation method
-        kwargs : dict
-            Keys are the axis names, Values the evaluation points
-
-        Returns
-        -------
-        array : `~astropy.units.Quantity`
-            Interpolated values, axis order is the same as for the NDData array
-        """
-        if self._regular_grid_interp is None:
-            self._add_regular_grid_interp()
-
-        points = tuple(
-            [
-                axis._interp_values(points[axis.name].to_value(axis.unit))
-                for axis in self.axes
-            ]
-        )
-        return self._regular_grid_interp(points, method=method, **kwargs)
+        return self._regular_grid_interp(values, method=method, **kwargs)
 
     def _add_regular_grid_interp(self, interp_kwargs=None):
         """Add `~scipy.interpolate.RegularGridInterpolator`
@@ -220,7 +177,7 @@ class NDDataArray(object):
             interp_kwargs = self.interp_kwargs
         points = [a._interp_nodes() for a in self.axes]
 
-        values = self.data.value
+        values = self.data
 
         # If values contains nan, only setup interpolator in valid range
         if np.isnan(values).any():

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -66,7 +66,7 @@ class TestNDDataArray:
     def test_evaluate_shape_1d(self, nddata_1d):
         # Scalar input
         out = nddata_1d.evaluate(x=1.5)
-        assert out.shape == ()
+        assert out.shape == (1,)
 
         # Array input
         out = nddata_1d.evaluate(x=[0, 1.5])
@@ -82,28 +82,30 @@ class TestNDDataArray:
         assert out.shape == (2,)
 
         # Case 2: axis1 = array, axis2 = array
-        out = nddata_2d.evaluate(energy=[1, 1, 1] * u.TeV, offset=[0, 0] * u.deg)
+        offset, energy = [0, 0] * u.deg, [1, 1, 1] * u.TeV
+        out = nddata_2d.evaluate(energy=energy[:, np.newaxis], offset=offset)
         assert out.shape == (3, 2)
 
         # Case 3: axis1 array, axis2 = 2Darray
+        offset, energy = [0, 0] * u.deg, np.zeros((12, 3)) * u.TeV
         out = nddata_2d.evaluate(
-            energy=np.zeros((12, 3)) * u.TeV, offset=[0, 0] * u.deg
+            energy=energy[:, :, np.newaxis], offset=offset
         )
         assert out.shape == (12, 3, 2)
 
     @pytest.mark.parametrize("shape", [(2,), (3, 2), (4, 2, 3)])
-    def test_evaluate_at_coord_2d(self, nddata_2d, shape):
+    def test_evaluate_2d_shape(self, nddata_2d, shape):
         points = dict(
             energy=np.ones(shape) * 1 * u.TeV, offset=np.ones(shape) * 0.3 * u.deg
         )
-        out = nddata_2d.evaluate_at_coord(points=points)
+        out = nddata_2d.evaluate(**points)
         assert out.shape == shape
         assert_allclose(out.value, 1)
 
         points = dict(
             energy=np.ones(shape) * 100 * u.TeV, offset=np.ones(shape) * 0.3 * u.deg
         )
-        out = nddata_2d.evaluate_at_coord(points=points)
+        out = nddata_2d.evaluate(**points)
         assert_allclose(out.value, 5)
 
     def test_evaluate_1d_linear(self, nddata_1d):


### PR DESCRIPTION
This PR implements the following changes:

* Add Quantity handling and broadcasting to `ScaledRegularGridInterpolator`
* Use the `ScaledRegularGridInterpolator` in `hess.py`
* Adapt the `TableModel` to the changes
* Adapt `NDData.evaluate` to the changes, especially change it to follow Numpy broadcasting rules.
* Remove  `NDData.evaluate_at_coord()`, because it is not needed anymore.