### PR TITLE
Add Fit.covar method

### DIFF
--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -329,9 +329,9 @@ class TestFluxPointFit:
 
     @requires_dependency("sherpa")
     def test_fit_pwl_sherpa(self, sed_model, sed_flux_points):
-        optimize_opts = {"backend": "sherpa", "method": "simplex"}
-        fitter = FluxPointFit(sed_model, sed_flux_points)
-        result = fitter.run(optimize_opts=optimize_opts, steps=["optimize"])
+        # TODO: add covar or error estimation here?
+        fit = FluxPointFit(sed_model, sed_flux_points)
+        result = fit.optimize(backend='sherpa', method='simplex')
         self.assert_result(result)
 
     @staticmethod

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 from .likelihood import Likelihood
 
-__all__ = ["optimize_iminuit"]
+__all__ = ["optimize_iminuit", "covar_iminuit"]
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +58,10 @@ def optimize_iminuit(parameters, function, **kwargs):
     }
     optimizer = minuit
     return factors, info, optimizer
+
+
+def covar_iminuit(minuit):
+    return _get_covar(minuit)
 
 
 # this code is copied from https://github.com/iminuit/iminuit/blob/master/iminuit/_minimize.py#L95

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from .likelihood import Likelihood
 
-__all__ = ["optimize_scipy"]
+__all__ = ["optimize_scipy", "covar_scipy"]
 
 
 def optimize_scipy(parameters, function, **kwargs):
@@ -20,3 +21,8 @@ def optimize_scipy(parameters, function, **kwargs):
     optimizer = None
 
     return factors, info, optimizer
+
+
+# TODO: implement, e.g. with numdifftools.Hessian
+def covar_scipy(parameters, function):
+    raise NotImplementedError

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -33,7 +33,7 @@ class MyFit(Fit):
 @pytest.mark.parametrize("backend", ["minuit", "sherpa", "scipy"])
 def test_optimize(backend):
     fit = MyFit()
-    result = fit.run(optimize_opts={"backend": backend})
+    result = fit.optimize(backend=backend)
     pars = result.model.parameters
 
     assert result.success is True
@@ -47,7 +47,9 @@ def test_optimize(backend):
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_covar(backend):
     fit = MyFit()
-    result = fit.run(optimize_opts={"backend": backend})
+    result = fit.run(
+        optimize_opts={"backend": backend}, covar_opts={"backend": backend}
+    )
     pars = result.model.parameters
 
     assert_allclose(pars.error("x"), 1, rtol=1e-7)


### PR DESCRIPTION
This PR adds a `Fit.covar` method. It doesn't implement this yet for scipy or sherpa, it just prepares the Fit interface.

The idea is to develop the fitting framework to have stateless backends, and for `Fit` to have separate compute tasks for `optimize`, `covar`, `conf`, `profile` and `contour`.

For now `minuit` is a stateful backend, so we hold on to the `minuit` instance in the `fit` class and pass it back in on each call (covar in this case).

I also made a small change to the `optimise` method to return a `FitResult`. And I made a small change to the `run` method to be opinionated as clearly a combined `optimize` and `covar` and nothing else. I think we could consider removing it completely or keep as-is, I'm -1 to extend it with other tasks like `conf`, `profile` and `contour`.

Just now I saw that I forgot to call `hesse` in the `iminuit_covar`. This could be because MINUIT often automatically calls `hesse` from `migrad`, or it could be because we don't have a good test case yet.
I'll improve the tests and look at that tomorrow.