### PR TITLE
Fix MapAxis interpolation FITS serialisation

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -69,8 +69,6 @@ def make_axes_cols(axes, axis_names=None):
 
         if name == "ENERGY":
             colnames = ["ENERGY", "E_MIN", "E_MAX"]
-        elif name == "TIME":
-            colnames = ["TIME", "T_MIN", "T_MAX"]
         else:
             s = "AXIS%i" % i if name == "" else name
             colnames = [s, s + "_MIN", s + "_MAX"]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -6,6 +6,7 @@ import inspect
 import re
 from collections import OrderedDict
 import logging
+
 log = logging.getLogger(__name__)
 
 import numpy as np
@@ -122,12 +123,19 @@ def find_and_read_bands(hdu, header=None):
             name = re.search("(.+)_MIN", cols[0]).group(1)
         else:
             name = cols[0]
-        interp_key = "INTERP%i" % (i+1)
-        if header is not None and interp_key in header:
-            if header[interp_key] in ["sqrt", "log", "lin"]:
-                interp = header[interp_key]
+
+        interp_header_key = "INTERP%i" % (i + 1)
+        if header is not None and interp_header_key in header:
+            interp_header_val = header[interp_header_key]
+            if interp_header_val in ["sqrt", "log", "lin"]:
+                interp = interp_header_val
             else:
-                log.warning("UNKNOWN INTERP KEYWORD IN HEADER. USING DEFAULT!")
+                log.warning(
+                    "Invalid map axis interp: {!r}. Using default: {!r}".format(
+                        interp_header_val, interp
+                    )
+                )
+
         unit = hdu.data.columns[cols[0]].unit
         if unit is None and header is not None:
             unit = header.get("CUNIT%i" % (3 + i), "")
@@ -1355,8 +1363,7 @@ class MapGeom(object):
                 raise ValueError("Invalid node type {!r}".format(ax.node_type))
 
             key_interp = "INTERP%i" % idx
-            header[key_interp]=ax._interp
-
+            header[key_interp] = ax._interp
 
     @property
     def is_image(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -5,6 +5,8 @@ import copy
 import inspect
 import re
 from collections import OrderedDict
+import logging
+log = logging.getLogger(__name__)
 
 import numpy as np
 from astropy.utils.misc import InheritDocstrings
@@ -120,10 +122,12 @@ def find_and_read_bands(hdu, header=None):
             name = re.search("(.+)_MIN", cols[0]).group(1)
         else:
             name = cols[0]
-        intp = "INTERP%i" % (i+1)
-        if header is not None:
-            if intp in header:
-                interp = header[intp]
+        interp_key = "INTERP%i" % (i+1)
+        if header is not None and interp_key in header:
+            if header[interp_key] in ["sqrt", "log", "lin"]:
+                interp = header[interp_key]
+            else:
+                log.warning("UNKNOWN INTERP KEYWORD IN HEADER. USING DEFAULT!")
         unit = hdu.data.columns[cols[0]].unit
         if unit is None and header is not None:
             unit = header.get("CUNIT%i" % (3 + i), "")

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -121,8 +121,9 @@ def find_and_read_bands(hdu, header=None):
         else:
             name = cols[0]
         intp = "INTERP%i" % (i+1)
-        if intp in header:
-            interp = header[intp]
+        if header is not None:
+            if intp in header:
+                interp = header[intp]
         unit = hdu.data.columns[cols[0]].unit
         if unit is None and header is not None:
             unit = header.get("CUNIT%i" % (3 + i), "")

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -120,7 +120,9 @@ def find_and_read_bands(hdu, header=None):
             name = re.search("(.+)_MIN", cols[0]).group(1)
         else:
             name = cols[0]
-
+        intp = "INTERP%i" % (i+1)
+        if intp in header:
+            interp = header[intp]
         unit = hdu.data.columns[cols[0]].unit
         if unit is None and header is not None:
             unit = header.get("CUNIT%i" % (3 + i), "")
@@ -1346,6 +1348,10 @@ class MapGeom(object):
                 header[key] = name
             else:
                 raise ValueError("Invalid node type {!r}".format(ax.node_type))
+
+            key_interp = "INTERP%i" % idx
+            header[key_interp]=ax._interp
+
 
     @property
     def is_image(self):

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -332,3 +332,13 @@ def test_wcs_geom_equal(npix, binsz, coordsys, proj, skypos, axes, result):
 
     assert (geom0 == geom1) is result
     assert (geom0 != geom1) is not result
+
+@pytest.mark.parametrize("node_type", ["edges", "center"])
+@pytest.mark.parametrize("interp", ["log", "linear", "sqrt"])
+def test_read_write():
+    energy_axis = MapAxis(nodes=np.logspace(-2., 2, 5), unit='TeV', name='energy', node_type='edges', interp='log')
+    time_axis = MapAxis(nodes=np.linspace(0.0, 1000.0, 4), unit='s', name='time', node_type='edges', interp='lin')
+    random_axis = MapAxis(nodes=np.linspace(0.1, 100.0, 3), unit='', name='something', node_type='center', interp='lin')
+    geom = WcsGeom.create(skydir=(0, 0), binsz=1, npix=10, axes=[energy_axis, time_axis, random_axis])
+    m = Map.from_geom(geom, unit='m2')
+    m.write('test.fits', overwrite=True)


### PR DESCRIPTION
This PR addresses #1887
 
1. Removed the special column names for the time.
2. Added an INTERP%i (where i is the axis number) keyword to the header. If this exists, it is read appropriately. Otherwise, it defaults to `log` for `energy` and `lin` for other axes.
