### PR TITLE
Improve Fit class, add confidence method

### DIFF
--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -214,25 +214,6 @@ class Fit(object):
         else:
             raise NotImplementedError()
 
-    def likelihood_profiles(self, model, parameters="all"):
-        """Compute likelihood profiles for multiple parameters.
-
-        Parameters
-        ----------
-        model : `~gammapy.spectrum.models.SpectralModel` or `~gammapy.cube.models.SkyModel`
-            Model to compute the likelihood profile for.
-        parameters : list of str or "all"
-            For which parameters to compute likelihood profiles.
-        """
-        profiles = {}
-
-        if parameters == "all":
-            parameters = [par.name for par in model.paramaters]
-
-        for parname in parameters:
-            profiles[parname] = self.likelihood_profile(model, parname)
-        return profiles
-
     def likelihood_profile(self, model, parameter, values=None, bounds=2, nvalues=11):
         """Compute likelihood profile for a single parameter of the model.
 
@@ -279,6 +260,7 @@ class Fit(object):
 
         return {"values": values, "likelihood": np.array(likelihood)}
 
+    # TODO: delete once Axel removes the caller in FluxPointEstimator
     def sqrt_ts(self, parameters):
         """Compute the sqrt(TS) of a model against the null hypthesis, that
         the amplitude of the model is zero.

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -64,7 +64,7 @@ def covar_iminuit(minuit):
     return _get_covar(minuit)
 
 
-def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall):
+def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
     # TODO: this is ugly - design something better for translating to MINUIT parameter names.
     # Maybe a wrapper class MinuitParameters?
     idx = parameters._get_idx(parameter)

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -269,13 +269,20 @@ class Parameters(object):
         return ss
 
     def _get_idx(self, val):
-        """Convert parameter name or index to index"""
+        """Get position index for a given parameter.
+
+        The input can be a parameter object, parameter name (str)
+        or if a parameter index (int) is passed in, it is simply returned.
+        """
+        if isinstance(val, Parameter):
+            for idx, par in enumerate(self.parameters):
+                if val is par:
+                    return idx
         if isinstance(val, six.string_types):
             for idx, par in enumerate(self.parameters):
                 if val == par.name:
                     return idx
-            raise IndexError("Parameter {} not found for : {}".format(val, self))
-
+            raise IndexError("Parameter {!r} not found.".format(val, self))
         else:
             return val
 

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -66,7 +66,6 @@ def test_confidence(backend):
     fit = MyFit()
     fit.optimize(backend=backend)
     result = fit.confidence("x")
-    print(result)
     assert result["is_valid"] is True
     assert_allclose(result["lower"], -1)
     assert_allclose(result["upper"], +1)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -61,4 +61,12 @@ def test_covar(backend):
     assert_allclose(pars.correlation[1, 2], 0, atol=1e-7)
 
 
-# TODO: add confidence interval (conf in Sherpa, minos in MINUIT)
+@pytest.mark.parametrize("backend", ["minuit"])
+def test_confidence(backend):
+    fit = MyFit()
+    fit.optimize(backend=backend)
+    result = fit.confidence("x")
+    print(result)
+    assert result["is_valid"] is True
+    assert_allclose(result["lower"], -1)
+    assert_allclose(result["upper"], +1)


### PR DESCRIPTION
This PR improves the `Fit` class in `gammapy.utils.fitting` a bit, doing some polishing.
It also adds a new feature `Fit.covariance` as a new feature, wrapping `Minuit.minos`.
Seems to work OK for one simple example, see `test_confidence`

I also made a small change to the `Parameters` class, so that one can access parameters not just by name and number, but also to pass a Parameter object in.
This is what Sherpa does, users can pass in Parameter objects, not just names, see e.g. https://sherpa.readthedocs.io/en/latest/quick.html#a-single-parameter .
I'd like to evolve the Fit API more i this direction, because if you have a double-Gaussian, then you currently can't reach the second parameter by name. Maybe that globally unique name can be achieved, maybe not, but working with Parameter objects more in the API seems like a nice solution to me.

@adonath - Please review, especially if you're OK to have the `sigma` option in `confidence`, or if you want or need some other API, like being able to select a `TS` difference to reach instead. Did we make a decision there in the discussion on API to select confidence intervals?
Note that both MINUIT and Sherpa use an option "sigma" here:
https://sherpa.readthedocs.io/en/latest/fit/index.html#changing-the-error-bounds
So I think I'm +1 to also go that route, but I'm not sure. Especially the whole question of one vs two-sided is a bit more unintuitive with "sigma" ,no?