### PR TITLE
Rewrite FluxpointEstimator

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1271,6 +1271,28 @@ class TableModel(SpectralModel):
         return norm * values
 
 
+class ScaleModel(SpectralModel):
+    """
+    Wrapper model to scale another spectral model at a given reference energy.
+
+    Parameters
+    ----------
+    model : `SpectralModel`
+        Spectral model to wrap.
+    norm : float
+        Scale to apply at the reference energy.
+
+    """
+    def __init__(self, model, norm=1):
+        self.parameters = Parameters([
+            Parameter("norm", norm, unit=""),
+            ])
+        self.model = model
+
+    def evaluate(self, energy, norm):
+        return norm * self.model(energy)
+
+
 class Absorption(object):
     """Gamma-ray absorption models.
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -215,7 +215,7 @@ class TestFluxPointEstimator:
     def test_spectrum_result(self):
         # TODO: Don't run this again
         flux_points = self.fpe.run()
-        result = SpectrumResult(model=self.fpe.model, points=flux_points)
+        result = SpectrumResult(model=self.fpe.model.model, points=flux_points)
 
         actual = result.flux_point_residuals[0][0]
         assert_allclose(actual, -0.058407, rtol=1e-2)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -200,14 +200,14 @@ class TestFluxPointEstimator:
         actual = flux_points.table["dnde_err"][0]
         assert_allclose(actual, 2.9128e-11, rtol=1e-2)
 
-        actual = flux_points.table["dnde_ul"][0]
-        assert_allclose(actual, 2.994e-10, rtol=1e-2)
-
         actual = flux_points.table["dnde_errn"][0]
         assert_allclose(actual, 2.804949e-11, rtol=1e-2)
 
         actual = flux_points.table["dnde_errp"][0]
         assert_allclose(actual, 3.023831e-11, rtol=1e-2)
+
+        actual = flux_points.table["dnde_ul"][0]
+        assert_allclose(actual, 3.132841e-10, rtol=1e-2)
 
         actual = flux_points.table["sqrt_ts"][0]
         assert_allclose(actual, 13.66, rtol=1e-2)

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -105,7 +105,7 @@ class Fit(object):
             log.warning("No covar estimate - not supported by this backend.")
             return optimize_result
 
-        covar_result = self.covar(**covar_opts)
+        covar_result = self.covariance(**covar_opts)
         # TODO: not sure how best to report the results
         # back or how to form the FitResult object.
         optimize_result._model = covar_result.model
@@ -173,7 +173,7 @@ class Fit(object):
             **info
         )
 
-    def covar(self, backend="minuit"):
+    def covariance(self, backend="minuit"):
         """Estimate the covariance matrix.
 
         Assumes that the model parameters are already optimised.


### PR DESCRIPTION
This PR includes the following changes:
* Introduce a spectral model `ScaleModel`, that allows to scale arbitrary other spectral models with a `norm` parameter
* Rewrite the `FluxPointEstimator` to use this new `ScaleModel`
* Adapt the  `FluxPointEstimator` to recent changes in the `Fit` class API 

In a follow up PR I will implement the computation of likelihood profiles for flux points.
