### PR TITLE
Add sections in documentation navigation bar

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ started, we recommend you follow the installation and setup instructions in
 :ref:`getting-started` and then learn Gammapy via the Jupyter :ref:`tutorials`.
 
 .. toctree::
+    :caption: Getting Started
     :maxdepth: 1
 
     getting-started
@@ -41,6 +42,7 @@ about each sub-package. Those pages also contain very detailed reference
 documentation for every function and class in Gammapy.
 
 .. toctree::
+    :caption: User Guide
     :maxdepth: 1
 
     data/index
@@ -71,6 +73,7 @@ as well as information about `Gammapy contact and communication channels`_. Most
 development takes place on the `Gammapy GitHub page`_.
 
 .. toctree::
+    :caption: Developer Documentation
     :maxdepth: 1
 
     development/index
@@ -81,6 +84,7 @@ development takes place on the `Gammapy GitHub page`_.
 References and Changelog
 ------------------------
 .. toctree::
+    :caption: References and Changelog
     :maxdepth: 1
 
     references

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,9 @@ webpage ( https://gammapy.org ) contains information about Gammapy, including
 news and contact information if you have any questions, want to report and issue
 or request a feature, or need help with anything Gammapy-related.
 
+To get started with Gammapy, follow the installation and setup instructions in
+:ref:`getting-started` and then learn Gammapy via the Jupyter :ref:`tutorials`.
+
 .. _gammapy_intro:
 .. toctree::
     :caption: Getting Started
@@ -25,10 +28,6 @@ or request a feature, or need help with anything Gammapy-related.
     install/index
     references
     changelog
-
-Gammapy works with Python 2 and 3, on Linux, Mac OS X and Windows. To get
-started, we recommend you follow the installation and setup instructions in
-:ref:`getting-started` and then learn Gammapy via the Jupyter :ref:`tutorials`.
 
 .. _gammapy_package:
 .. toctree::
@@ -53,12 +52,6 @@ started, we recommend you follow the installation and setup instructions in
     catalog/index
     astro/index
 
-As mentioned in the :ref:`getting-started`, the Gammapy package is structured as
-a series of sub-packages. We recommend that you start to learn Gammapy via the
-:ref:`tutorials`, and then consult the following pages for further information
-about each sub-package. Those pages also contain very detailed reference
-documentation for every function and class in Gammapy.
-
 .. _gammapy_dev:
 .. toctree::
     :caption: Developer Documentation
@@ -66,10 +59,3 @@ documentation for every function and class in Gammapy.
     :maxdepth: 1
 
     development/index
-
-The Gammapy webpage contains information about the `Gammapy project and team`_
-as well as information about `Gammapy contact and communication channels`_. Most
-development takes place on the `Gammapy GitHub page`_.
-
-.. _Gammapy project and team: https://gammapy.org/team.html
-.. _Gammapy contact and communication channels: https://gammapy.org/contact.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,8 @@
 
 |
 
+Gammapy
+-------
 
 Gammapy is a community-developed, open-source Python package for gamma-ray
 astronomy. It is a prototype for the `CTA`_ science tools. This page
@@ -14,14 +16,6 @@ news and contact information if you have any questions, want to report and issue
 or request a feature, or need help with anything Gammapy-related.
 
 .. _gammapy_intro:
-
-Getting started
----------------
-
-Gammapy works with Python 2 and 3, on Linux, Mac OS X and Windows. To get
-started, we recommend you follow the installation and setup instructions in
-:ref:`getting-started` and then learn Gammapy via the Jupyter :ref:`tutorials`.
-
 .. toctree::
     :caption: Getting Started
     :maxdepth: 1
@@ -29,20 +23,16 @@ started, we recommend you follow the installation and setup instructions in
     getting-started
     tutorials
     install/index
+    references
+    changelog
+
+Gammapy works with Python 2 and 3, on Linux, Mac OS X and Windows. To get
+started, we recommend you follow the installation and setup instructions in
+:ref:`getting-started` and then learn Gammapy via the Jupyter :ref:`tutorials`.
 
 .. _gammapy_package:
-
-Gammapy package
----------------
-
-As mentioned in the :ref:`getting-started`, the Gammapy package is structured as
-a series of sub-packages. We recommend that you start to learn Gammapy via the
-:ref:`tutorials`, and then consult the following pages for further information
-about each sub-package. Those pages also contain very detailed reference
-documentation for every function and class in Gammapy.
-
 .. toctree::
-    :caption: User Guide
+    :caption: Gammapy Package
     :maxdepth: 1
 
     data/index
@@ -63,29 +53,23 @@ documentation for every function and class in Gammapy.
     catalog/index
     astro/index
 
-.. _gammapy_dev:
+As mentioned in the :ref:`getting-started`, the Gammapy package is structured as
+a series of sub-packages. We recommend that you start to learn Gammapy via the
+:ref:`tutorials`, and then consult the following pages for further information
+about each sub-package. Those pages also contain very detailed reference
+documentation for every function and class in Gammapy.
 
-Developer documentation
------------------------
+.. _gammapy_dev:
+.. toctree::
+    :caption: Developer Documentation
+    :titlesonly:
+    :maxdepth: 1
+
+    development/index
 
 The Gammapy webpage contains information about the `Gammapy project and team`_
 as well as information about `Gammapy contact and communication channels`_. Most
 development takes place on the `Gammapy GitHub page`_.
 
-.. toctree::
-    :caption: Developer Documentation
-    :maxdepth: 1
-
-    development/index
-
 .. _Gammapy project and team: https://gammapy.org/team.html
 .. _Gammapy contact and communication channels: https://gammapy.org/contact.html
-
-References and Changelog
-------------------------
-.. toctree::
-    :caption: References and Changelog
-    :maxdepth: 1
-
-    references
-    changelog

--- a/docs/install/check.rst
+++ b/docs/install/check.rst
@@ -21,7 +21,7 @@ Common issues
 -------------
 
 If you have an issue with Gammapy installation or usage, please check this list.
-If your issue is not adressed, please send an email to the mailing list.
+If your issue is not addressed, please send an email to the mailing list.
 
 - Q: I get an error mentioning something (e.g. Astropy) isn't available,
   but I did install it.
@@ -39,8 +39,8 @@ If your issue is not adressed, please send an email to the mailing list.
 Known issues
 ------------
 
-- **Astropy <3.0.5 and Matplotlib 3.0**: There is an incompatibility between
-WCSAxes and Matplotlib 3.0, which causes the inline plotting in notebooks to
-fail. The issue as well as a temporary workaround is decribed
-`here https://github.com/gammapy/gammapy/issues/1843#issuecomment-435909533`_.
-The issue has been fixed since Astropy 3.0.5.
+- **Astropy =<3.1 and Matplotlib 3.0**
+
+There is an incompatibility between WCSAxes and Matplotlib 3.0, which causes
+the inline plotting in notebooks to fail. The issue as well as a temporary workaround is
+described `here <https://github.com/gammapy/gammapy/issues/1843#issuecomment-435909533>`__.

--- a/docs/install/check.rst
+++ b/docs/install/check.rst
@@ -39,7 +39,7 @@ If your issue is not addressed, please send an email to the mailing list.
 Known issues
 ------------
 
-- **Astropy =<3.1 and Matplotlib 3.0**
+- **Astropy <3.0.5 and Matplotlib 3.0**
 
 There is an incompatibility between WCSAxes and Matplotlib 3.0, which causes
 the inline plotting in notebooks to fail. The issue as well as a temporary workaround is


### PR DESCRIPTION
This PR addresses issue https://github.com/gammapy/gammapy/issues/1917
It groups links in the menu in three main sections:
- Getting Started
- Gammapy Package
- Developer Documentation

<img width="220" alt="menu" src="https://user-images.githubusercontent.com/328261/48570050-a196fa00-e903-11e8-8f4e-789211be4645.png">



