### PR TITLE
Improve Fit.likelihood_profile

### DIFF
--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -34,8 +34,8 @@ class SkySpatialModel(Model):
 
         if self.parameters.covariance is not None:
             ss += "\n\nCovariance: \n\n\t"
-            covar = self.parameters.covariance_to_table()
-            ss += "\n\t".join(covar.pformat())
+            covariance = self.parameters.covariance_to_table()
+            ss += "\n\t".join(covariance.pformat())
         return ss
 
     def __call__(self, lon, lat):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -49,8 +49,8 @@ class SpectralModel(Model):
 
         if self.parameters.covariance is not None:
             ss += "\n\nCovariance: \n\n\t"
-            covar = self.parameters.covariance_to_table()
-            ss += "\n\t".join(covar.pformat())
+            covariance = self.parameters.covariance_to_table()
+            ss += "\n\t".join(covariance.pformat())
         return ss
 
     def __call__(self, energy):

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -158,9 +158,7 @@ class TestFit:
         result = fit.run()
         true_idx = result.model.parameters["index"].value
         values = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)
-        profile = fit.likelihood_profile(
-            model=result.model, parameter="index", values=values
-        )
+        profile = fit.likelihood_profile("index", values=values)
         actual = values[np.argmin(profile["likelihood"])]
         assert_allclose(actual, true_idx, rtol=0.01)
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -349,12 +349,10 @@ class TestFluxPointFit:
     @requires_dependency("iminuit")
     def test_likelihood_profile(self, sed_model, sed_flux_points):
         optimize_opts = {"backend": "minuit"}
-        fitter = FluxPointFit(sed_model, sed_flux_points)
-        result = fitter.run(optimize_opts=optimize_opts)
+        fit = FluxPointFit(sed_model, sed_flux_points)
+        result = fit.run(optimize_opts=optimize_opts)
 
-        profile = fitter.likelihood_profile(
-            model=result.model, parameter="amplitude", nvalues=3, bounds=1
-        )
+        profile = fit.likelihood_profile("amplitude", nvalues=3, bounds=1)
 
         ts_diff = profile["likelihood"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
@@ -363,9 +361,7 @@ class TestFluxPointFit:
         err = result.model.parameters.error("amplitude")
         values = np.array([value - err, value, value + err])
 
-        profile = fitter.likelihood_profile(
-            model=result.model, parameter="amplitude", values=values
-        )
+        profile = fit.likelihood_profile("amplitude", values=values)
 
         ts_diff = profile["likelihood"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -329,7 +329,7 @@ class TestFluxPointFit:
 
     @requires_dependency("sherpa")
     def test_fit_pwl_sherpa(self, sed_model, sed_flux_points):
-        # TODO: add covar or error estimation here?
+        # TODO: add test for covariance or error estimation here?
         fit = FluxPointFit(sed_model, sed_flux_points)
         result = fit.optimize(backend="sherpa", method="simplex")
         self.assert_result(result)

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -19,8 +19,8 @@ def fit_result():
         index=2.1, amplitude=1e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
     )
     npred = obs.predicted_counts(best_fit_model).data.data.value
-    covar = np.diag([0.1 ** 2, 1e-12 ** 2, 0])
-    best_fit_model.parameters.covariance = covar
+    covariance = np.diag([0.1 ** 2, 1e-12 ** 2, 0])
+    best_fit_model.parameters.covariance = covariance
     fit_range = [0.1, 50] * u.TeV
     return SpectrumFitResult(
         model=best_fit_model,

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -4,9 +4,9 @@ import abc
 import numpy as np
 from astropy.utils.misc import InheritDocstrings
 from ...extern import six
-from .iminuit import optimize_iminuit, covar_iminuit, confidence_iminuit
+from .iminuit import optimize_iminuit, covariance_iminuit, confidence_iminuit
 from .sherpa import optimize_sherpa
-from .scipy import optimize_scipy, covar_scipy
+from .scipy import optimize_scipy, covariance_scipy
 
 __all__ = ["Fit"]
 
@@ -34,9 +34,9 @@ class Registry(object):
             "sherpa": optimize_sherpa,
             "scipy": optimize_scipy,
         },
-        "covar": {
-            "minuit": covar_iminuit,
-            # "scipy": covar_scipy,
+        "covariance": {
+            "minuit": covariance_iminuit,
+            "scipy": covariance_scipy,
         },
         "confidence": {"minuit": confidence_iminuit},
     }
@@ -76,7 +76,7 @@ class Fit(object):
     def _parameters(self):
         return self._model.parameters
 
-    def run(self, optimize_opts=None, covar_opts=None):
+    def run(self, optimize_opts=None, covariance_opts=None):
         """
         Run all fitting steps.
 
@@ -84,8 +84,8 @@ class Fit(object):
         ----------
         optimize_opts : dict
             Options passed to `Fit.optimize`.
-        covar_opts : dict
-            Options passed to `Fit.covar`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -96,21 +96,21 @@ class Fit(object):
             optimize_opts = {}
         optimize_result = self.optimize(**optimize_opts)
 
-        if covar_opts is None:
-            covar_opts = {}
+        if covariance_opts is None:
+            covariance_opts = {}
 
-        covar_opts.setdefault("backend", "minuit")
+        covariance_opts.setdefault("backend", "minuit")
 
-        if covar_opts["backend"] not in registry.register["covar"]:
-            log.warning("No covar estimate - not supported by this backend.")
+        if covariance_opts["backend"] not in registry.register["covariance"]:
+            log.warning("No covariance estimate - not supported by this backend.")
             return optimize_result
 
-        covar_result = self.covariance(**covar_opts)
+        covariance_result = self.covariance(**covariance_opts)
         # TODO: not sure how best to report the results
         # back or how to form the FitResult object.
-        optimize_result._model = covar_result.model
-        optimize_result._success = optimize_result.success and covar_result.success
-        optimize_result._nfev += covar_result.nfev
+        optimize_result._model = covariance_result.model
+        optimize_result._success = optimize_result.success and covariance_result.success
+        optimize_result._nfev += covariance_result.nfev
 
         return optimize_result
 
@@ -135,7 +135,6 @@ class Fit(object):
                 * http://cxc.cfa.harvard.edu/sherpa/ahelp/montecarlo.html
                 * http://cxc.cfa.harvard.edu/sherpa/ahelp/gridsearch.html
                 * http://cxc.cfa.harvard.edu/sherpa/ahelp/levmar.html
-
 
         Returns
         -------
@@ -185,10 +184,10 @@ class Fit(object):
 
         Returns
         -------
-        result : `CovarResult`
+        result : `CovarianceResult`
             Results
         """
-        compute = registry.get("covar", backend)
+        compute = registry.get("covariance", backend)
         parameters = self._parameters
 
         # TODO: wrap MINUIT in a stateless backend
@@ -204,7 +203,7 @@ class Fit(object):
         parameters.set_covariance_factors(covariance_factors)
 
         # TODO: decide what to return, and fill the info correctly!
-        return CovarResult(model=self._model.copy(), success=True, nfev=0)
+        return CovarianceResult(model=self._model.copy(), success=True, nfev=0)
 
     def confidence(self, parameter, backend="minuit", sigma=1, **kwargs):
         """Estimate confidence interval.
@@ -241,7 +240,9 @@ class Fit(object):
             raise NotImplementedError()
 
     def likelihood_profile(self, model, parameter, values=None, bounds=2, nvalues=11):
-        """Compute likelihood profile for a single parameter of the model.
+        """Compute likelihood profile.
+
+        The method used is to vary one parameter, keeping all others fixed.
 
         Parameters
         ----------
@@ -288,9 +289,21 @@ class Fit(object):
 
         return {"values": values, "likelihood": np.array(likelihood)}
 
+    def minos_profile(self):
+        """Compute MINOS profile.
 
-class CovarResult(object):
-    """Covar result object."""
+        The method used is to vary one parameter, then re-optimise all other free parameters.
+
+        Calls ``iminuit.Minuit.mnprofile``
+
+        TODO: available in Sherpa as well?
+        TODO: find a better name.
+        """
+        raise NotImplementedError
+
+
+class CovarianceResult(object):
+    """Covariance result object."""
 
     def __init__(self, model, success, nfev):
         self._model = model

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -240,7 +240,7 @@ class Fit(object):
         else:
             raise NotImplementedError()
 
-    def likelihood_profile(self, model, parameter, values=None, bounds=2, nvalues=11):
+    def likelihood_profile(self, parameter, values=None, bounds=2, nvalues=11):
         """Compute likelihood profile.
 
         The method used is to vary one parameter, keeping all others fixed.
@@ -250,8 +250,6 @@ class Fit(object):
 
         Parameters
         ----------
-        model : `~gammapy.spectrum.models.SpectralModel`
-            Model to compute the likelihood profile for.
         parameter : `~gammapy.utils.fitting.Parameter`
             Parameter of interest
         values : `~astropy.units.Quantity` (optional)
@@ -270,25 +268,23 @@ class Fit(object):
         results : dict
             Dictionary with keys "values" and "likelihood".
         """
-        # TODO: change the API to be consistent with the other methods.
-        # Don't pass in a model. Instead make a `parameters` copy on enter here.
-        self._model = model.copy()
-
-        likelihood = []
+        idx = self._parameters._get_idx(parameter)
+        parameters = self._parameters.copy()
 
         if values is None:
             if isinstance(bounds, tuple):
                 parmin, parmax = bounds
             else:
-                parerr = model.parameters.error(parameter)
-                parval = model.parameters[parameter].value
+                parerr = parameters.error(idx)
+                parval = parameters[idx].value
                 parmin, parmax = parval - bounds * parerr, parval + bounds * parerr
 
             values = np.linspace(parmin, parmax, nvalues)
 
+        likelihood = []
         for value in values:
-            self._parameters[parameter].value = value
-            stat = self.total_stat(self._parameters)
+            parameters[idx].value = value
+            stat = self.total_stat(parameters)
             likelihood.append(stat)
 
         return {"values": values, "likelihood": np.array(likelihood)}

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy.utils.misc import InheritDocstrings
 from ...extern import six
 from .iminuit import optimize_iminuit, covariance_iminuit, confidence_iminuit
-from .sherpa import optimize_sherpa
+from .sherpa import optimize_sherpa, covariance_sherpa
 from .scipy import optimize_scipy, covariance_scipy
 
 __all__ = ["Fit"]
@@ -36,6 +36,7 @@ class Registry(object):
         },
         "covariance": {
             "minuit": covariance_iminuit,
+            "sherpa": covariance_sherpa,
             "scipy": covariance_scipy,
         },
         "confidence": {"minuit": confidence_iminuit},
@@ -243,6 +244,9 @@ class Fit(object):
         """Compute likelihood profile.
 
         The method used is to vary one parameter, keeping all others fixed.
+        So this is taking a "slice" or "scan" of the likelihood.
+
+        See also: `Fit.minos_profile`.
 
         Parameters
         ----------
@@ -292,11 +296,49 @@ class Fit(object):
     def minos_profile(self):
         """Compute MINOS profile.
 
-        The method used is to vary one parameter, then re-optimise all other free parameters.
+        The method used is to vary one parameter,
+        then re-optimise all other free parameters
+        and to take the likelihood at that point.
+
+        See also: `Fit.likelihood_profile`
 
         Calls ``iminuit.Minuit.mnprofile``
+        TODO: what does Sherpa do?
+        TODO: find a better name.
+        """
+        raise NotImplementedError
 
-        TODO: available in Sherpa as well?
+    def likelihood_contour(self):
+        """Compute likelihood contour.
+
+        The method used is to vary two parameters, keeping all others fixed.
+        So this is taking a "slice" or "scan" of the likelihood.
+
+        See also: `Fit.minos_contour`
+
+        Parameters
+        ----------
+        TODO
+
+        Returns
+        -------
+        TODO
+        """
+        raise NotImplementedError
+
+    def minos_contour(self):
+        """Compute MINOS contour.
+
+        This is a contouring algorithm for a 2D function
+        which is not simply the likelihood function.
+        That 2D function is given at each point (par_1, par_2)
+        by re-optimising all other free parameters,
+        and taking the likelihood at that point.
+
+        Very compute-intensive and slow.
+
+        Calls ``iminuit.Minuit.mncontour``
+        TODO: what does Sherpa do?
         TODO: find a better name.
         """
         raise NotImplementedError

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -6,7 +6,7 @@ import logging
 import numpy as np
 from .likelihood import Likelihood
 
-__all__ = ["optimize_iminuit", "covar_iminuit", "confidence_iminuit"]
+__all__ = ["optimize_iminuit", "covariance_iminuit", "confidence_iminuit"]
 
 log = logging.getLogger(__name__)
 
@@ -59,9 +59,9 @@ def optimize_iminuit(parameters, function, **kwargs):
     return factors, info, optimizer
 
 
-def covar_iminuit(minuit):
+def covariance_iminuit(minuit):
     # TODO: add minuit.hesse() call once we have better tests
-    return _get_covar(minuit)
+    return _get_covariance(minuit)
 
 
 def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
@@ -122,8 +122,8 @@ def make_minuit_par_kwargs(parameters):
     return kwargs
 
 
-def _get_covar(minuit):
-    """Get full covar matrix as Numpy array.
+def _get_covariance(minuit):
+    """Get full covariance matrix as Numpy array.
 
     This was added as `minuit.np_covariance` in `iminuit` in v1.3,
     but we still want to support v1.2

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -237,7 +237,7 @@ class Parameters(object):
         self.covariance = covariance
         self.apply_autoscale = apply_autoscale
 
-    def _init_covar(self):
+    def _init_covariance(self):
         if self.covariance is None:
             shape = (len(self.parameters), len(self.parameters))
             self.covariance = np.zeros(shape)
@@ -265,7 +265,7 @@ class Parameters(object):
         ss = self.__class__.__name__
         for par in self.parameters:
             ss += "\n{}".format(par)
-        ss += "\n\nCovariance: \n{}".format(self.covariance)
+        ss += "\n\ncovariance: \n{}".format(self.covariance)
         return ss
 
     def _get_idx(self, val):
@@ -418,7 +418,7 @@ class Parameters(object):
         err : float or Quantity
             Parameter error
         """
-        self._init_covar()
+        self._init_covariance()
 
         idx = self._get_idx(parname)
         err = u.Quantity(err, self[idx].unit).value

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -274,17 +274,20 @@ class Parameters(object):
         The input can be a parameter object, parameter name (str)
         or if a parameter index (int) is passed in, it is simply returned.
         """
-        if isinstance(val, Parameter):
+        if isinstance(val, six.integer_types):
+            return val
+        elif isinstance(val, Parameter):
             for idx, par in enumerate(self.parameters):
                 if val is par:
                     return idx
-        if isinstance(val, six.string_types):
+            raise IndexError("No parameter: {!r}".format(val))
+        elif isinstance(val, six.string_types):
             for idx, par in enumerate(self.parameters):
                 if val == par.name:
                     return idx
-            raise IndexError("Parameter {!r} not found.".format(val, self))
+            raise IndexError("No parameter: {!r}".format(val))
         else:
-            return val
+            raise TypeError("Invalid type: {!r}".format(type(val)))
 
     def __getitem__(self, name):
         """Access parameter by name or index"""

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
-import numpy as np
 from .likelihood import Likelihood
 
-__all__ = ["optimize_scipy", "covar_scipy"]
+__all__ = ["optimize_scipy", "covariance_scipy"]
 
 
 def optimize_scipy(parameters, function, **kwargs):
@@ -24,5 +23,5 @@ def optimize_scipy(parameters, function, **kwargs):
 
 
 # TODO: implement, e.g. with numdifftools.Hessian
-def covar_scipy(parameters, function):
+def covariance_scipy(parameters, function):
     raise NotImplementedError

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from .likelihood import Likelihood
 
-__all__ = ["optimize_sherpa"]
+__all__ = ["optimize_sherpa", "covariance_sherpa"]
 
 
 def get_sherpa_optimizer(name):
@@ -61,3 +61,7 @@ def optimize_sherpa(parameters, function, **kwargs):
     optimizer = optimizer
 
     return factors, info, optimizer
+
+
+def covariance_sherpa():
+    raise NotImplementedError

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -79,6 +79,6 @@ def test_confidence(backend):
 def test_likelihood_profile():
     fit = MyFit()
     fit.run()
-    result = fit.likelihood_profile(fit._model, "x", nvalues=3)
+    result = fit.likelihood_profile("x", nvalues=3)
     assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
     assert_allclose(result["likelihood"], [4, 0, 4], atol=1e-7)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -30,6 +30,23 @@ class MyFit(Fit):
         return (x - x_opt) ** 2 + (y - y_opt) ** 2 + (z - z_opt) ** 2
 
 
+@pytest.mark.parametrize("backend", ["minuit"])
+def test_run(backend):
+    fit = MyFit()
+    result = fit.run(
+        optimize_opts={"backend": backend}, covariance_opts={"backend": backend}
+    )
+    pars = result.model.parameters
+
+    assert_allclose(pars.error("x"), 1, rtol=1e-7)
+    assert_allclose(pars.error("y"), 1, rtol=1e-7)
+    assert_allclose(pars.error("z"), 1, rtol=1e-7)
+
+    assert_allclose(pars.correlation[0, 1], 0, atol=1e-7)
+    assert_allclose(pars.correlation[0, 2], 0, atol=1e-7)
+    assert_allclose(pars.correlation[1, 2], 0, atol=1e-7)
+
+
 @pytest.mark.parametrize("backend", ["minuit", "sherpa", "scipy"])
 def test_optimize(backend):
     fit = MyFit()
@@ -43,22 +60,9 @@ def test_optimize(backend):
     assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
     assert_allclose(pars["z"].value, 4e-2, rtol=1e-3)
 
-
-@pytest.mark.parametrize("backend", ["minuit"])
-def test_covar(backend):
-    fit = MyFit()
-    result = fit.run(
-        optimize_opts={"backend": backend}, covar_opts={"backend": backend}
-    )
-    pars = result.model.parameters
-
-    assert_allclose(pars.error("x"), 1, rtol=1e-7)
-    assert_allclose(pars.error("y"), 1, rtol=1e-7)
-    assert_allclose(pars.error("z"), 1, rtol=1e-7)
-
-    assert_allclose(pars.correlation[0, 1], 0, atol=1e-7)
-    assert_allclose(pars.correlation[0, 2], 0, atol=1e-7)
-    assert_allclose(pars.correlation[1, 2], 0, atol=1e-7)
+# TODO: add some extra covariance tests, in addition to run
+# Probably mainly if error message is OK if optimize didn't run first.
+# def test_covariance():
 
 
 @pytest.mark.parametrize("backend", ["minuit"])

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -60,6 +60,7 @@ def test_optimize(backend):
     assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
     assert_allclose(pars["z"].value, 4e-2, rtol=1e-3)
 
+
 # TODO: add some extra covariance tests, in addition to run
 # Probably mainly if error message is OK if optimize didn't run first.
 # def test_covariance():
@@ -73,3 +74,11 @@ def test_confidence(backend):
     assert result["is_valid"] is True
     assert_allclose(result["lower"], -1)
     assert_allclose(result["upper"], +1)
+
+
+def test_likelihood_profile():
+    fit = MyFit()
+    fit.run()
+    result = fit.likelihood_profile(fit._model, "x", nvalues=3)
+    assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
+    assert_allclose(result["likelihood"], [4, 0, 4], atol=1e-7)

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -108,6 +108,24 @@ def test_parameters_basics(pars):
     assert_allclose(pars.error(1), 10)
 
 
+def test_parameters_getitem(pars):
+    assert pars[1].name == "ham"
+    assert pars["ham"].name == "ham"
+    assert pars[pars[1]].name == "ham"
+
+    with pytest.raises(TypeError):
+        pars[42.3]
+
+    with pytest.raises(IndexError):
+        pars[3]
+
+    with pytest.raises(IndexError):
+        pars["lamb"]
+
+    with pytest.raises(IndexError):
+        pars[Parameter("bam!", 99)]
+
+
 def test_parameters_to_table(pars):
     pars.set_error("ham", 1e-10 / 3)
     table = pars.to_table()


### PR DESCRIPTION
@adonath - This PR improves the `Fit.likelihood_profile` API as we discussed today. I removed the `model` argument, and adapted the one caller in the `FluxPointEstimator`.

I also did a bit of cleanup and prepared other things here: improve `Parameters.__getitem__` and add unit tests. Add unit test for `Fit.profile`. Go for consistent "covariance" instead of mix of "covar" and "covariance", Add placeholder methods for the profile and contour methods that we want. I can add those tomorrow, we should try to find a good name for the "minos_profile". I didn't dare put "profile_likelihood_profile". :-)

I'm not changing the logic or where copies happen yet as discussed today, that's for tomorrow.