### PR TITLE
FluxPointEstimator test and docs improvements

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -185,12 +185,6 @@ class SkyModel(SkyModelBase):
             self.__class__.__name__, self.spatial_model, self.spectral_model
         )
 
-    def __str__(self):
-        ss = "{}\n\n".format(self.__class__.__name__)
-        ss += "spatial_model = {}\n\n".format(self.spatial_model)
-        ss += "spectral_model = {}\n".format(self.spectral_model)
-        return ss
-
     def evaluate(self, lon, lat, energy):
         """Evaluate the model at given points.
 

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -25,19 +25,6 @@ log = logging.getLogger(__name__)
 class SkySpatialModel(Model):
     """Sky spatial model base class."""
 
-    def __str__(self):
-        ss = self.__class__.__name__
-        ss += "\n\nParameters: \n\n\t"
-
-        table = self.parameters.to_table()
-        ss += "\n\t".join(table.pformat())
-
-        if self.parameters.covariance is not None:
-            ss += "\n\nCovariance: \n\n\t"
-            covariance = self.parameters.covariance_to_table()
-            ss += "\n\t".join(covariance.pformat())
-        return ss
-
     def __call__(self, lon, lat):
         """Call evaluate method"""
         kwargs = dict()

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -637,7 +637,7 @@ class FluxPoints(object):
 
             y_err = (0.5 * y_ul[is_ul].value, np.zeros_like(y_ul[is_ul].value))
 
-            kwargs.setdefault("c", ebar[0].get_color())
+            kwargs.setdefault("color", ebar[0].get_color())
 
             # pop label keyword to avoid that it appears twice in the legend
             kwargs.pop("label", None)

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -25,7 +25,18 @@ REQUIRED_COLUMNS = OrderedDict(
         ("flux", ["e_min", "e_max", "flux"]),
         ("eflux", ["e_min", "e_max", "eflux"]),
         # TODO: extend required columns
-        ("likelihood", ["e_min", "e_max", "e_ref", "ref_dnde", "norm", "norm_scan", "dloglike_scan"]),
+        (
+            "likelihood",
+            [
+                "e_min",
+                "e_max",
+                "e_ref",
+                "ref_dnde",
+                "norm",
+                "norm_scan",
+                "dloglike_scan",
+            ],
+        ),
     ]
 )
 
@@ -656,7 +667,13 @@ class FluxPoints(object):
         return ax
 
     def plot_likelihood(
-        self, ax=None, energy_unit="TeV", add_cbar=True, y_values=None, y_unit=None, **kwargs
+        self,
+        ax=None,
+        energy_unit="TeV",
+        add_cbar=True,
+        y_values=None,
+        y_unit=None,
+        **kwargs
     ):
         """Plot likelihood SED profiles as a density plot..
 
@@ -691,7 +708,9 @@ class FluxPoints(object):
         if y_values is None:
             ref_values = self.table["ref_" + self.sed_type].quantity
             y_values = np.logspace(
-                np.log10(ref_values.value.min()) - 1, np.log10(ref_values.value.max()) + 1, 500
+                np.log10(ref_values.value.min()) - 1,
+                np.log10(ref_values.value.max()) + 1,
+                500,
             )
             y_values = u.Quantity(y_values, y_unit, copy=False)
 
@@ -704,7 +723,9 @@ class FluxPoints(object):
             y_ref = self.table["ref_" + self.sed_type].quantity[idx]
             norm = (y_values / y_ref).to_value("")
             norm_scan = self.table[idx]["norm_scan"]
-            dloglike_scan = self.table[idx]["dloglike_scan"] - self.table[idx]["loglike"]
+            dloglike_scan = (
+                self.table[idx]["dloglike_scan"] - self.table[idx]["loglike"]
+            )
             z[idx] = _interp_likelihood_profile(norm_scan, dloglike_scan, norm)
 
         kwargs.setdefault("vmax", 0)
@@ -788,7 +809,9 @@ class FluxPointEstimator(object):
         self.model = ScaleModel(model)
         self.model.parameters["norm"].min = 0
         if norm_values is None:
-            norm_values = np.logspace(np.log10(norm_min), np.log10(norm_max), norm_n_values)
+            norm_values = np.logspace(
+                np.log10(norm_min), np.log10(norm_max), norm_n_values
+            )
         self.norm_values = norm_values
         self.sigma = sigma
         self.sigma_ul = sigma_ul

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -25,7 +25,7 @@ REQUIRED_COLUMNS = OrderedDict(
         ("flux", ["e_min", "e_max", "flux"]),
         ("eflux", ["e_min", "e_max", "eflux"]),
         # TODO: extend required columns
-        ("likelihood", ["e_min", "e_max", "e_ref", "ref_dnde", "norm"]),
+        ("likelihood", ["e_min", "e_max", "e_ref", "ref_dnde", "norm", "norm_scan", "dloglike_scan"]),
     ]
 )
 
@@ -149,7 +149,7 @@ class FluxPoints(object):
         self.table = table_standardise_units_copy(table)
         # validate that the table is a valid representation
         # of the given flux point sed type
-        self._validate_table(self.table)
+        self._validate_table(self.table, table.meta["SED_TYPE"])
 
     def __repr__(self):
         fmt = '{}(sed_type="{}", n_points={})'
@@ -449,9 +449,8 @@ class FluxPoints(object):
                 return sed_type
 
     @staticmethod
-    def _validate_table(table):
+    def _validate_table(table, sed_type):
         """Validate input table."""
-        sed_type = table.meta["SED_TYPE"]
         required = set(REQUIRED_COLUMNS[sed_type])
 
         if not required.issubset(table.colnames):
@@ -686,6 +685,7 @@ class FluxPoints(object):
         if ax is None:
             ax = plt.gca()
 
+        self._validate_table(self.table, "likelihood")
         y_unit = u.Unit(y_unit or DEFAULT_UNIT[self.sed_type])
 
         if y_values is None:

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -538,7 +538,7 @@ class PowerLaw(SpectralModel):
             [
                 Parameter("index", index),
                 Parameter("amplitude", amplitude),
-                Parameter("reference", reference, min=0, frozen=True),
+                Parameter("reference", reference, frozen=True),
             ]
         )
 
@@ -1166,7 +1166,7 @@ class TableModel(SpectralModel):
     def __init__(
         self, energy, values, norm=1, values_scale="log", interp_kwargs=None, meta=None
     ):
-        self.parameters = Parameters([Parameter("norm", norm, min=0, unit="")])
+        self.parameters = Parameters([Parameter("norm", norm, unit="")])
         self.energy = energy
         self.values = values
         self.meta = dict() if meta is None else meta

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -40,19 +40,6 @@ class SpectralModel(Model):
     `~gammapy.spectrum.models.PowerLaw`.
     """
 
-    def __str__(self):
-        ss = self.__class__.__name__
-        ss += "\n\nParameters: \n\n\t"
-
-        table = self.parameters.to_table()
-        ss += "\n\t".join(table.pformat())
-
-        if self.parameters.covariance is not None:
-            ss += "\n\nCovariance: \n\n\t"
-            covariance = self.parameters.covariance_to_table()
-            ss += "\n\t".join(covariance.pformat())
-        return ss
-
     def __call__(self, energy):
         """Call evaluate method of derived classes"""
         kwargs = dict()

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -13,12 +13,9 @@ from ...utils.testing import (
     mpl_plot_check,
 )
 from ...utils.fitting import Parameters
-from ..results import SpectrumResult
-from ..fit import SpectrumFit
-from ..observation import SpectrumObservation
-from ..energy_group import SpectrumEnergyGroupMaker
 from ..models import PowerLaw, SpectralModel
-from ..flux_point import FluxPoints, FluxPointFit, FluxPointEstimator
+from ..flux_point import FluxPoints, FluxPointFit
+
 
 FLUX_POINTS_FILES = [
     "diff_flux_points.ecsv",
@@ -151,99 +148,16 @@ def test_compute_flux_points_dnde_exp(method):
     assert_quantity_allclose(actual, desired, rtol=1e-8)
 
 
-@pytest.fixture(scope="session")
-def obs():
-    filename = "$GAMMAPY_EXTRA/datasets/joint-crab/spectra/hess/pha_obs23523.fits"
-    obs = SpectrumObservation.read(filename)
-    return obs
-
-
-@pytest.fixture(scope="session")
-def model():
-    model = PowerLaw()
-    fit = SpectrumFit(obs(), model)
-    result = fit.run()
-    return result.model
-
-
-@pytest.fixture(scope="session")
-def seg():
-    ebounds = [0.3, 1, 30] * u.TeV
-    segm = SpectrumEnergyGroupMaker(obs=obs())
-    segm.compute_groups_fixed(ebounds=ebounds)
-    return segm.groups
-
-
-@requires_data("gammapy-extra")
-@requires_dependency("matplotlib")
-class TestFluxPointEstimator:
-    def setup(self):
-        self.fpe = FluxPointEstimator(obs=obs(), model=model(), groups=seg(), norm_n_values=3)
-        self.flux_points = self.fpe.run()
-
-    def test_str(self):
-        assert "FluxPointEstimator" in str(self.fpe)
-
-    def test_energy_range(self):
-        group = self.fpe.groups[1]
-        point = self.fpe.estimate_flux_point(group)
-        fit_range = self.fpe.fit.true_fit_range[0]
-        assert_quantity_allclose(fit_range[0], group.energy_min)
-        assert_quantity_allclose(fit_range[1], group.energy_max)
-
-    def test_values(self):
-        flux_points = self.flux_points
-
-        actual = flux_points.table["dnde"][0]
-        assert_allclose(actual, 2.361e-10, rtol=1e-2)
-
-        actual = flux_points.table["dnde_err"][0]
-        assert_allclose(actual, 2.9128e-11, rtol=1e-2)
-
-        actual = flux_points.table["dnde_errn"][0]
-        assert_allclose(actual, 2.804949e-11, rtol=1e-2)
-
-        actual = flux_points.table["dnde_errp"][0]
-        assert_allclose(actual, 3.023831e-11, rtol=1e-2)
-
-        actual = flux_points.table["dnde_ul"][0]
-        assert_allclose(actual, 2.98694e-10, rtol=1e-2)
-
-        actual = flux_points.table["sqrt_ts"][0]
-        assert_allclose(actual, 13.66, rtol=1e-2)
-
-        actual = flux_points.table["norm"][0]
-        assert_allclose(actual, 0.941443, rtol=1e-5)
-
-        actual = flux_points.table["norm_scan"][0]
-        assert_allclose(actual, [0.2, 1, 5], rtol=1e-5)
-
-        actual = flux_points.table["dloglike_scan"][0]
-        assert_allclose(actual, [90.650449, 9.826327, 392.489161], rtol=1e-5)
-
-
-    def test_spectrum_result(self):
-        flux_points = self.flux_points
-        result = SpectrumResult(model=self.fpe.model.model, points=flux_points)
-
-        actual = result.flux_point_residuals[0][0]
-        assert_allclose(actual, -0.058407, rtol=1e-2)
-
-        actual = result.flux_point_residuals[1][0]
-        assert_allclose(actual, 0.116119, rtol=1e-2)
-
-        with mpl_plot_check():
-            result.plot(energy_range=[1, 10] * u.TeV)
-
-    def test_plot_likelihood(self):
-        with mpl_plot_check():
-            self.flux_points.plot_likelihood()
-
-
 @pytest.fixture(params=FLUX_POINTS_FILES, scope="session")
 def flux_points(request):
     path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/" + request.param
     return FluxPoints.read(path)
+
+
+@pytest.fixture(scope="session")
+def flux_points_likelihood():
+    path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/binlike.fits"
+    return FluxPoints.read(path).to_sed_type("dnde")
 
 
 @requires_dependency("yaml")
@@ -302,6 +216,11 @@ class TestFluxPoints:
     def test_plot(self, flux_points):
         with mpl_plot_check():
             flux_points.plot()
+
+    @requires_dependency("matplotlib")
+    def test_plot_likelihood(self, flux_points_likelihood):
+        with mpl_plot_check():
+            flux_points_likelihood.plot_likelihood()
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -323,7 +323,9 @@ def test_compute_flux_points_dnde_fermi():
 @pytest.fixture(scope="session")
 def sed_flux_points():
     path = "$GAMMAPY_EXTRA/test_datasets/spectrum/flux_points/diff_flux_points.fits"
-    return FluxPoints.read(path)
+    fp = FluxPoints.read(path)
+    fp.table["e_ref"] = fp.e_ref.to("TeV")
+    return fp
 
 
 @pytest.fixture(scope="session")
@@ -341,6 +343,7 @@ class TestFluxPointFit:
         self.assert_result(result)
 
     @requires_dependency("sherpa")
+    @pytest.mark.skip(reason="Sherpa backend does not support fixing parameters yet.")
     def test_fit_pwl_sherpa(self, sed_model, sed_flux_points):
         # TODO: add test for covariance or error estimation here?
         fit = FluxPointFit(sed_model, sed_flux_points)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -9,9 +9,7 @@ from ..models import PowerLaw, ExponentialCutoffPowerLaw
 from ..simulation import SpectrumSimulation
 from ..flux_point import FluxPointEstimator
 from ...irf import EffectiveAreaTable
-from ...utils.testing import (
-    assert_quantity_allclose,
-)
+from ...utils.testing import assert_quantity_allclose
 
 
 # TODO: use pregenerate data instead

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -1,0 +1,96 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from astropy import units as u
+from ..energy_group import SpectrumEnergyGroupMaker
+from ..models import PowerLaw, ExponentialCutoffPowerLaw
+from ..simulation import SpectrumSimulation
+from ..flux_point import FluxPointEstimator
+from ...irf import EffectiveAreaTable
+from ...utils.testing import (
+    assert_quantity_allclose,
+)
+
+
+# TODO: use pregenerate data instead
+def simulate_obs(model):
+    energy = np.logspace(-0.5, 1.5, 21) * u.TeV
+    aeff = EffectiveAreaTable.from_parametrization(energy=energy)
+    bkg_model = PowerLaw(index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1")
+    sim = SpectrumSimulation(
+        aeff=aeff,
+        source_model=model,
+        livetime=100 * u.h,
+        background_model=bkg_model,
+        alpha=0.2,
+    )
+    sim.run(seed=[0])
+    return sim.result[0]
+
+
+def define_energy_groups(obs):
+    # the energy bounds ar choosen such, that one flux point is
+    ebounds = [0.1, 1, 10, 100] * u.TeV
+    segm = SpectrumEnergyGroupMaker(obs=obs)
+    segm.compute_groups_fixed(ebounds=ebounds)
+    return segm.groups
+
+
+def create_fpe(model):
+    obs = simulate_obs(model)
+    groups = define_energy_groups(obs)
+    return FluxPointEstimator(obs=obs, model=model, groups=groups, norm_n_values=3)
+
+
+@pytest.fixture(scope="session")
+def fpe_pwl():
+    return create_fpe(PowerLaw())
+
+
+@pytest.fixture(scope="session")
+def fpe_ecpl():
+    return create_fpe(ExponentialCutoffPowerLaw(lambda_="1 TeV-1"))
+
+
+class TestFluxPointEstimator:
+    def test_str(self, fpe_pwl):
+        assert "FluxPointEstimator" in str(fpe_pwl)
+
+    def test_energy_range(self, fpe_pwl):
+        group = fpe_pwl.groups[1]
+        fpe_pwl.estimate_flux_point(group)
+        fit_range = fpe_pwl.fit.true_fit_range[0]
+        assert_quantity_allclose(fit_range[0], group.energy_min)
+        assert_quantity_allclose(fit_range[1], group.energy_max)
+
+    def test_run_pwl(self, fpe_pwl):
+        fp = fpe_pwl.run()
+        actual = fp.table["norm"].data
+        assert_allclose(actual, [1.080933, 0.910776, 0.922278], rtol=1e-5)
+
+        actual = fp.table["norm_err"].data
+        assert_allclose(actual, [0.066364, 0.061025, 0.179742], rtol=1e-5)
+
+        actual = fp.table["norm_errn"].data
+        assert_allclose(actual, [0.065305, 0.060409, 0.17148], rtol=1e-5)
+
+        actual = fp.table["norm_errp"].data
+        assert_allclose(actual, [0.067454, 0.061646, 0.188288], rtol=1e-5)
+
+        actual = fp.table["norm_ul"].data
+        assert_allclose(actual, [1.216227, 1.035472, 1.316878], rtol=1e-5)
+
+        actual = fp.table["sqrt_ts"].data
+        assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-5)
+
+        actual = fp.table["norm_scan"][0]
+        assert_allclose(actual, [0.2, 1, 5], rtol=1e-5)
+
+        actual = fp.table["dloglike_scan"][0]
+        assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-5)
+
+    def test_run_ecpl(self, fpe_ecpl):
+        fp = fpe_ecpl.estimate_flux_point(fpe_ecpl.groups[1])
+        assert_allclose(fp["norm"], 1, rtol=1e-1)

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -194,17 +194,17 @@ class Fit(object):
         # TODO: wrap MINUIT in a stateless backend
         if backend == "minuit":
             if hasattr(self, "minuit"):
-                covariance_factors = compute(self.minuit)
+                covariance_factors, info = compute(self.minuit)
             else:
                 raise RuntimeError("To use minuit, you must first optimize.")
         else:
             function = self.total_stat
-            covariance_factors = compute(parameters, function)
+            covariance_factors, info = compute(parameters, function)
 
         parameters.set_covariance_factors(covariance_factors)
 
         # TODO: decide what to return, and fill the info correctly!
-        return CovarianceResult(model=self._model.copy(), success=True, nfev=0)
+        return CovarianceResult(model=self._model.copy(), success=info["success"], nfev=0)
 
     def confidence(self, parameter, backend="minuit", sigma=1, **kwargs):
         """Estimate confidence interval.

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -204,7 +204,9 @@ class Fit(object):
         parameters.set_covariance_factors(covariance_factors)
 
         # TODO: decide what to return, and fill the info correctly!
-        return CovarianceResult(model=self._model.copy(), success=info["success"], nfev=0)
+        return CovarianceResult(
+            model=self._model.copy(), success=info["success"], nfev=0
+        )
 
     def confidence(self, parameter, backend="minuit", sigma=1, **kwargs):
         """Estimate confidence interval.

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -61,7 +61,18 @@ def optimize_iminuit(parameters, function, **kwargs):
 
 def covariance_iminuit(minuit):
     # TODO: add minuit.hesse() call once we have better tests
-    return _get_covariance(minuit)
+
+    message, success = "Hesse terminated successfully.", True
+    try:
+        covariance_factors = _get_covariance(minuit)
+    except  :
+        N = len(minuit.args)
+        covariance_factors = np.nan * np.ones((N, N))
+        message, success = "Hesse failed", False
+    return covariance_factors, {
+        "success": success,
+        "message": message,
+    }
 
 
 def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -65,7 +65,7 @@ def covariance_iminuit(minuit):
     message, success = "Hesse terminated successfully.", True
     try:
         covariance_factors = _get_covariance(minuit)
-    except:
+    except TypeError:
         N = len(minuit.args)
         covariance_factors = np.nan * np.ones((N, N))
         message, success = "Hesse failed", False

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -65,14 +65,11 @@ def covariance_iminuit(minuit):
     message, success = "Hesse terminated successfully.", True
     try:
         covariance_factors = _get_covariance(minuit)
-    except  :
+    except:
         N = len(minuit.args)
         covariance_factors = np.nan * np.ones((N, N))
         message, success = "Hesse failed", False
-    return covariance_factors, {
-        "success": success,
-        "message": message,
-    }
+    return covariance_factors, {"success": success, "message": message}
 
 
 def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -26,4 +26,3 @@ class Model(object):
             covariance = self.parameters.covariance_to_table()
             ss += "\n\t".join(covariance.pformat())
         return ss
-

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -13,3 +13,17 @@ class Model(object):
     def copy(self):
         """A deep copy."""
         return copy.deepcopy(self)
+
+    def __str__(self):
+        ss = self.__class__.__name__
+        ss += "\n\nParameters: \n\n\t"
+
+        table = self.parameters.to_table()
+        ss += "\n\t".join(table.pformat())
+
+        if self.parameters.covariance is not None:
+            ss += "\n\nCovariance: \n\n\t"
+            covariance = self.parameters.covariance_to_table()
+            ss += "\n\t".join(covariance.pformat())
+        return ss
+

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -315,6 +315,7 @@ class Parameters(object):
         t["unit"] = [p.unit.to_string("fits") for p in self.parameters]
         t["min"] = [p.min for p in self.parameters]
         t["max"] = [p.max for p in self.parameters]
+        t["frozen"] = [p.frozen for p in self.parameters]
 
         for name in ["value", "error", "min", "max"]:
             t[name].format = ".3e"

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -130,7 +130,7 @@ def test_parameters_to_table(pars):
     pars.set_error("ham", 1e-10 / 3)
     table = pars.to_table()
     assert len(table) == 2
-    assert len(table.columns) == 6
+    assert len(table.columns) == 7
 
 
 def test_parameters_covariance_to_table(pars):

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -405,7 +405,7 @@
    "source": [
     "## Compute Flux Points\n",
     "\n",
-    "To round up out analysis we can compute flux points by fitting the norm of the global model in energy bands. We'll use a fixed energy binning for now."
+    "To round up our analysis we can compute flux points by fitting the norm of the global model in energy bands. We'll use a fixed energy binning for now."
    ]
   },
   {
@@ -415,7 +415,8 @@
    "outputs": [],
    "source": [
     "# Define energy binning\n",
-    "ebounds = [0.3, 1.1, 3, 10.1, 30] * u.TeV\n",
+    "e_min, e_max = stacked_obs.lo_threshold.to_value(\"TeV\"), 30\n",
+    "ebounds = np.logspace(np.log10(e_min), np.log10(e_max), 15) * u.TeV\n",
     "\n",
     "stacked_obs = extraction.spectrum_observations.stack()\n",
     "\n",
@@ -432,7 +433,7 @@
    "outputs": [],
    "source": [
     "fpe = FluxPointEstimator(\n",
-    "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model\n",
+    "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model, norm_min=0.2, norm_max=10\n",
     ")\n",
     "flux_points = fpe.run()"
    ]
@@ -443,7 +444,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flux_points.plot()\n",
     "flux_points.table_formatted"
    ]
   },
@@ -451,7 +451,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The final plot with the best fit model and the flux points can be quickly made like this"
+    "Now we plot the flux points and their likelihood profiles. For the plotting of upper limits we choose a threshold of TS < 4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_points.table[\"is_ul\"] = flux_points.table[\"ts\"] < 4\n",
+    "ax = flux_points.plot(energy_power=2, flux_unit=\"erg-1 cm-2 s-1\", c=\"darkorange\")\n",
+    "flux_points.to_sed_type(\"e2dnde\").plot_likelihood(ax=ax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final plot with the best fit model, flux points and residuals can be quickly made like this"
    ]
   },
   {
@@ -468,7 +486,6 @@
     "    energy_power=2,\n",
     "    flux_unit=\"erg-1 cm-2 s-1\",\n",
     "    fig_kwargs=dict(figsize=(8, 8)),\n",
-    "    point_kwargs=dict(color=\"red\"),\n",
     ")\n",
     "\n",
     "ax0.set_xlim(0.4, 50)"
@@ -543,20 +560,6 @@
    "outputs": [],
    "source": [
     "# Start exercises here"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## What next?\n",
-    "\n",
-    "In this tutorial we learned how to extract counts spectra from an event list and generate the corresponding IRFs. Then we fitted a model to the observations and also computed flux points.\n",
-    "\n",
-    "Here's some suggestions where to go next:\n",
-    "\n",
-    "* if you want think this is way too complicated and just want to run a quick analysis check out [this notebook](spectrum_pipe.ipynb)\n",
-    "* if you interested in available fit statistics checkout [gammapy.stats](https://docs.gammapy.org/dev/stats/index.html)"
    ]
   }
  ],

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -415,10 +415,11 @@
    "outputs": [],
    "source": [
     "# Define energy binning\n",
+    "stacked_obs = extraction.spectrum_observations.stack()\n",
+    "\n",
     "e_min, e_max = stacked_obs.lo_threshold.to_value(\"TeV\"), 30\n",
     "ebounds = np.logspace(np.log10(e_min), np.log10(e_max), 15) * u.TeV\n",
     "\n",
-    "stacked_obs = extraction.spectrum_observations.stack()\n",
     "\n",
     "seg = SpectrumEnergyGroupMaker(obs=stacked_obs)\n",
     "seg.compute_groups_fixed(ebounds=ebounds)\n",
@@ -432,9 +433,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpe = FluxPointEstimator(\n",
-    "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model, norm_min=0.2, norm_max=10\n",
-    ")\n",
+    "fpe = FluxPointEstimator(obs=stacked_obs, groups=seg.groups, model=joint_result[0].model )\n",
     "flux_points = fpe.run()"
    ]
   },
@@ -461,7 +460,7 @@
    "outputs": [],
    "source": [
     "flux_points.table[\"is_ul\"] = flux_points.table[\"ts\"] < 4\n",
-    "ax = flux_points.plot(energy_power=2, flux_unit=\"erg-1 cm-2 s-1\", c=\"darkorange\")\n",
+    "ax = flux_points.plot(energy_power=2, flux_unit=\"erg-1 cm-2 s-1\", color=\"darkorange\")\n",
     "flux_points.to_sed_type(\"e2dnde\").plot_likelihood(ax=ax)"
    ]
   },


### PR DESCRIPTION
This PR includes test and docs improvements for the `FluxPointEstimator`:

* Add a dedicated  `test_flux_point_esti,ator.py` file, where test are run on a simulated observation for pwl as well as ecpl models
* Add a nice likelihood profile plot to `spectrum_analysis.ipynb`

There a  few minor unrelated changes:
* Move the `__str__` of to the Model base class 
* Add the `frozen` parameter attribute to the `Parameters.to_table()` method