### PR TITLE
No copy of input and result model in fit

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -41,8 +41,7 @@ class MapFit(Fit):
         if mask is not None and mask.data.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
 
-        # Create a copy of the input model that is owned and modified by MapFit
-        self._model = model.copy()
+        self._model = model
         self.counts = counts
         self.exposure = exposure
         self.background = background

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -117,9 +117,9 @@ def test_map_fit(sky_model):
     )
     result = fit.run()
 
-    assert sky_model is not fit._model
-    assert fit._model is not result.model
-    assert sky_model is not result.model
+    assert sky_model is fit._model
+    assert fit._model is result.model
+    assert sky_model is result.model
 
     assert result.success
     assert "minuit" in repr(result)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -118,7 +118,9 @@ def test_map_fit(sky_model):
     result = fit.run()
 
     assert sky_model is not fit._model
+    assert fit._model is not result.model
     assert sky_model is not result.model
+
     assert result.success
     assert "minuit" in repr(result)
 

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -4,7 +4,6 @@ import logging
 import copy
 import numpy as np
 import astropy.units as u
-from ..utils.scripts import make_path
 from ..utils.fitting import Fit
 from .. import stats
 from .utils import CountsPredictor
@@ -43,7 +42,7 @@ class SpectrumFit(Fit):
         self, obs_list, model, stat="wstat", forward_folded=True, fit_range=None
     ):
         self.obs_list = obs_list
-        self._model = model.copy()
+        self._model = model
         self.stat = stat
         self.forward_folded = forward_folded
         self.fit_range = fit_range
@@ -301,7 +300,6 @@ class SpectrumFit(Fit):
         from . import SpectrumFitResult
 
         # run again with best fit parameters
-        model = self._model.copy()
 
         statname = self.stat
 
@@ -314,7 +312,7 @@ class SpectrumFit(Fit):
 
             results.append(
                 SpectrumFitResult(
-                    model=model,
+                    model=self._model,
                     fit_range=fit_range,
                     statname=statname,
                     statval=statval,

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1045,7 +1045,7 @@ class FluxPointFit(Fit):
     Parameters
     ----------
     model : `~gammapy.spectrum.models.SpectralModel`
-        Spectral model (with fit start parameters)
+        Spectral model
     data : `~gammapy.spectrum.FluxPoints`
         Flux points.
 
@@ -1070,7 +1070,7 @@ class FluxPointFit(Fit):
     """
 
     def __init__(self, model, data, stat="chi2"):
-        self._model = model.copy()
+        self._model = model
         self.data = data
 
         if stat in ["chi2", "chi2assym"]:

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -192,8 +192,13 @@ class TestSpectralFit:
     def test_basic_results(self):
         self.fit.run()
         result = self.fit.result[0]
-        assert_allclose(result.statval, 41.755949, rtol=1e-4)
         pars = result.model.parameters
+
+        assert self.pwl is not self.fit._model
+        assert self.fit._model is not result.model
+        assert self.pwl is not result.model
+
+        assert_allclose(result.statval, 41.755949, rtol=1e-4)
         assert_allclose(pars["index"].value, 2.7912, rtol=1e-3)
         assert pars["amplitude"].unit == "cm-2 s-1 TeV-1"
         assert_allclose(pars["amplitude"].value, 5.029e-11, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -194,9 +194,9 @@ class TestSpectralFit:
         result = self.fit.result[0]
         pars = result.model.parameters
 
-        assert self.pwl is not self.fit._model
-        assert self.fit._model is not result.model
-        assert self.pwl is not result.model
+        assert self.pwl is self.fit._model
+        assert self.fit._model is result.model
+        assert self.pwl is result.model
 
         assert_allclose(result.statval, 41.755949, rtol=1e-4)
         assert_allclose(pars["index"].value, 2.7912, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -261,10 +261,14 @@ class TestFluxPointFit:
         result = fitter.run(optimize_opts=optimize_opts)
         self.assert_result(result)
 
+        assert sed_model is not fitter._model
+        assert fitter._model is not result.model
+        assert sed_model is not result.model
+
     @requires_dependency("sherpa")
     @pytest.mark.skip(reason="Sherpa backend does not support fixing parameters yet.")
     def test_fit_pwl_sherpa(self, sed_model, sed_flux_points):
-        # TODO: add test for covariance or error estimation here?
+        # TODO: add test for covariance or error estimation here
         fit = FluxPointFit(sed_model, sed_flux_points)
         result = fit.optimize(backend="sherpa", method="simplex")
         self.assert_result(result)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -261,9 +261,9 @@ class TestFluxPointFit:
         result = fitter.run(optimize_opts=optimize_opts)
         self.assert_result(result)
 
-        assert sed_model is not fitter._model
-        assert fitter._model is not result.model
-        assert sed_model is not result.model
+        assert sed_model is fitter._model
+        assert fitter._model is result.model
+        assert sed_model is result.model
 
     @requires_dependency("sherpa")
     @pytest.mark.skip(reason="Sherpa backend does not support fixing parameters yet.")

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -85,6 +85,7 @@ def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
     except RuntimeError as error:
         message, success = str(error), False
         info = {"is_valid": False, "lower": np.nan, "upper": np.nan, "nfcn": 0}
+
     return {
         "success": success,
         "message": message,

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -472,3 +472,35 @@ class Parameters(object):
         """
         for par in self.parameters:
             par.autoscale(method)
+
+    @property
+    def restore_values(self):
+        """Context manager to modify the values of a `Parameters` objects
+        and restore its initial values afterwards.
+
+        Examples
+        --------
+        .. code:: python
+
+            from gammapy.spectrum import PowerLaw
+
+            pwl = PowerLaw(index=2)
+            with pwl.parameters.restore_values:
+                pwl.parameters["index"].value = 3
+
+            print(pwl.parameters["index"].value)
+        """
+        return restore_parameters_values(self)
+
+
+class restore_parameters_values:
+    def __init__(self, parameters):
+        self.parameters = parameters
+        self.values = [_.value for _ in parameters]
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, type, value, traceback):
+        for value, par in zip(self.values, self.parameters):
+            par.value = value

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -39,6 +39,8 @@ def test_run(backend):
     )
     pars = result.model.parameters
 
+    assert fit._model is not result.model
+
     assert_allclose(pars.error("x"), 1, rtol=1e-7)
     assert_allclose(pars.error("y"), 1, rtol=1e-7)
     assert_allclose(pars.error("z"), 1, rtol=1e-7)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -39,7 +39,11 @@ def test_run(backend):
     )
     pars = result.model.parameters
 
-    assert fit._model is not result.model
+    assert fit._model is result.model
+
+    assert_allclose(pars["x"].value, 2, rtol=1e-3)
+    assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
+    assert_allclose(pars["z"].value, 4e-2, rtol=1e-3)
 
     assert_allclose(pars.error("x"), 1, rtol=1e-7)
     assert_allclose(pars.error("y"), 1, rtol=1e-7)
@@ -57,6 +61,7 @@ def test_optimize(backend):
     result = fit.optimize(backend=backend)
     pars = result.model.parameters
 
+    assert fit._model is result.model
     assert result.success is True
     assert_allclose(result.total_stat, 0)
 
@@ -74,10 +79,15 @@ def test_optimize(backend):
 def test_confidence(backend):
     fit = MyFit()
     fit.optimize(backend=backend)
+    print(fit._parameters)
     result = fit.confidence("x")
+    print(fit._parameters)
     assert result["is_valid"] is True
     assert_allclose(result["lower"], -1)
     assert_allclose(result["upper"], +1)
+
+    # Check that original value state wasn't changed
+    assert_allclose(fit._model.parameters["x"].value, 2)
 
 
 def test_likelihood_profile():
@@ -86,3 +96,6 @@ def test_likelihood_profile():
     result = fit.likelihood_profile("x", nvalues=3)
     assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
     assert_allclose(result["likelihood"], [4, 0, 4], atol=1e-7)
+
+    # Check that original value state wasn't changed
+    assert_allclose(fit._model.parameters["x"].value, 2)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -79,9 +79,7 @@ def test_optimize(backend):
 def test_confidence(backend):
     fit = MyFit()
     fit.optimize(backend=backend)
-    print(fit._parameters)
     result = fit.confidence("x")
-    print(fit._parameters)
     assert result["is_valid"] is True
     assert_allclose(result["lower"], -1)
     assert_allclose(result["upper"], +1)


### PR DESCRIPTION
As discussed previously (see https://github.com/gammapy/gammapy/issues/1783#issuecomment-439392127 and Gammapy call last week), @adonath and I propose to avoid making model copies.

At the moment there are three separate copies:
- User defined input model
- `fit._model`
- `fit.result.model`

Clearly this has great potential to confuse users, the more model copies the more complex.

The reason the model copies were introduced was because `fit.profile` or manually modifying state on `fit.minuit` resulted in changes to the input and results model previously. `fit.profile` has already been changed to make a copy of the parameters object on enter, it no longer has this issue. Other methods like contour or confidence interval computation should work the same. Soon there will be no more need to access `fit.minuit` directly, and if someone does she's an expert and can call `mymodel.copy()` herself.

So this PR removes all the copying.

Given that parameter values and covar are currrently stored in `model.parameters`, the model owns that state, and the fit methods modify it in place. Whether we still want to return `result.model` at all can be discussed later. For now I keep it for backward compatibiltiy.  It's just another reference to the one model that was passed in, users can access results from either the input model or `results.model`. The `fit._model` will probably be replaced with something else, @adonath will make a proposal or PIG concerning a better design of the `fit` class.

For now, I have added asserts to the tests for fit classes we have (`Fit`, `MapFit`, `SpectrumFit` and `FluxPointFit`) that establish the copy behaviour, as expected copies are currently made. I'll add one more commit here to actually change the behaviour, and adapt tests and docs tomorrow.

cc @registerrier @adonath @AtreyeeS