### PR TITLE
Debug why pytest hangs or fails in some CI builds

### DIFF
--- a/gammapy/_astropy_init.py
+++ b/gammapy/_astropy_init.py
@@ -34,6 +34,7 @@ if not _ASTROPY_SETUP_:  # noqa
     # Create the test function for self test
     from astropy.tests.runner import TestRunner
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+    test.__test__ = False
     __all__ += ['test']
 
     # add these here so we only need to cleanup the namespace at the end


### PR DESCRIPTION
Currently in some of our CI builds pytest fails for unknown reasons.

One issue is the KeyError described in https://github.com/pytest-dev/pytest/issues/4390 it's probably a combination of changes or bugs in pytest, and what astropy-helpers does.

In some other builds, pytest either hangs without output for 10 min and is cancelled, or finds zero tests in test collection. This is described and links to build logs here: https://github.com/pytest-dev/pytest/issues/4390#issuecomment-440760706

In #1939 I updated `gammapy/_astropy_init.py` from the package-template, because that contained fixes in the past months concerning how pytest is run, but that didn't resolve the issue, I didn't notice any change, the CI builds still fail the same way.

In this PR I set `PYTEST_DEBUG=1` in CI, in the hope that this will reveal what the issue is. I note that in https://github.com/pytest-dev/pytest/issues/4434 someone reports an issue in pytest where it hangs when calling `pytest.main`, for as of now unknown reasons. Also in https://github.com/pytest-dev/pytest/issues/4390#issuecomment-440739213 ff a pytest dev commented that the issues originate because we are running pytest from pytest. I don't know if that is still the case in the latest version of `_astropy_init.py`?

@bsipocz or @astrofrog - If you could have a look at this issue, it would be super helpful!