### PR TITLE
Testing with a pytest version that is guaranteed to work with LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+               PYTEST_VERSION=3.6
 
         - os: linux
           env: PYTHON_VERSION=3.5 ASTROPY_VERSION=dev SETUP_CMD='test -V'


### PR DESCRIPTION
The newest pytest versions are not available for python 3.5 and there were some issues with a few minor versions of pytest recently, so to guarantee we don't run into irrelevant upstream issues that has been fixed, we should use a version that is guaranteed to work with the given LTS astropy version.