### PR TITLE
Using explicit imports to fix pytest 3.7+ issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties pandas naima sherpa libgfortran iminuit regions reproject pandoc ipython jupyter'
 
-        - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme pytest-astropy'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 
@@ -77,7 +77,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES='Cython click regions pyyaml'
-               PIP_DEPENDENCIES=''
+               PIP_DEPENDENCIES='pytest-astropy'
 
         # Run tests without GAMMAPY_EXTRA available
         - os: linux
@@ -121,7 +121,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
-               PIP_DEPENDENCIES='uncertainties git+http://github.com/sherpa/sherpa.git#egg=sherpa'
+               PIP_DEPENDENCIES='uncertainties git+http://github.com/sherpa/sherpa.git#egg=sherpa pytest-astropy'
 
         # Test Fermipy master against gammapy master
         - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
       CONDA_DEPENDENCIES: "Cython click pyyaml scipy jinja2 click matplotlib"
-      PIP_DEPENDENCIES: "regions"
+      PIP_DEPENDENCIES: "regions pytest-astropy"
       FETCH_GAMMAPY_EXTRA: true
       ASTROPY_USE_SYSTEM_PYTEST: 1
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install pytest pytest-cov cython numpy astropy regions pyyaml click
+      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy
     displayName: 'Install dependencies'
 
   - script: |

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -45,3 +45,4 @@ dependencies:
     - black
     - naima
     - numdifftools
+    - pytest-astropy

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -2,7 +2,7 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 import os
-from astropy.tests.pytest_plugins import *
+from astropy.tests.pytest_plugins import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 from . import version
 
 packagename = os.path.basename(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,8 @@ setup(
       plotting=[
           'matplotlib>=2.1',
       ],
+      test=['pytest-astropy',
+      ],
     ),
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
Long story short (details in https://github.com/astropy/astropy/issues/8177 and xrefs therein), this should with pytest 3.7+ issues where tests are not picked up only doctests from narrative documentation. I'm adding a fix into astropy and we'll definitely open updates to users of the package template but the ETA for that is definitely longer than your plans for gammapy v0.9.