### PR TITLE
Add fit minos_contour method

### DIFF
--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -918,8 +918,7 @@ class FluxPointEstimator(object):
             Dict with asymmetric errors for the flux point norm.
         """
         result = self.fit.confidence(parameter="norm", sigma=self.sigma)
-        norm_errp, norm_errn = result["upper"], -result["lower"]
-        return {"norm_errp": norm_errp, "norm_errn": norm_errn}
+        return {"norm_errp": result["errp"], "norm_errn": result["errn"]}
 
     def estimate_norm_err(self):
         """Estimate covariance errors for a flux point.
@@ -943,7 +942,7 @@ class FluxPointEstimator(object):
         """
         norm = self.model.parameters["norm"].value
         result = self.fit.confidence(parameter="norm", sigma=self.sigma_ul)
-        return {"norm_ul": result["upper"] + norm}
+        return {"norm_ul": result["errp"] + norm}
 
     def estimate_norm_ts(self):
         """Estimate ts and sqrt(ts) for the flux point.

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -230,7 +230,7 @@ class Fit(object):
         Returns
         -------
         result : dict
-            Dictionary with keys "upper", 'lower", "success" and "nfev".
+            Dictionary with keys "errp", 'errn", "success" and "nfev".
         """
         compute = registry.get("confidence", backend)
         parameters = self._parameters
@@ -250,12 +250,12 @@ class Fit(object):
             else:
                 raise NotImplementedError()
 
-        lower = parameter.scale * result["lower"]
-        upper = parameter.scale * result["upper"]
+        errp = parameter.scale * result["errp"]
+        errn = parameter.scale * result["errn"]
 
         return {
-            "lower": lower,
-            "upper": upper,
+            "errp": errp,
+            "errn": errn,
             "success": result["success"],
             "nfev": result["nfev"],
         }

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -246,7 +246,9 @@ class Fit(object):
             else:
                 raise NotImplementedError()
 
-        # TODO: decide about result format
+        result["lower"] = parameter.scale * result["lower"]
+        result["upper"] = parameter.scale * result["upper"]
+
         return result
 
     def likelihood_profile(self, parameter, values=None, bounds=2, nvalues=11):

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -88,8 +88,8 @@ def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
     return {
         "success": success,
         "message": message,
-        "lower": info["lower"],
-        "upper": info["upper"],
+        "errp": info["upper"],
+        "errn": -info["lower"],
         "nfev": info["nfcn"],
     }
 

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -88,7 +88,6 @@ def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
     return {
         "success": success,
         "message": message,
-        "is_valid": info["is_valid"],
         "lower": info["lower"],
         "upper": info["upper"],
         "nfev": info["nfcn"],
@@ -105,7 +104,15 @@ def mncontour(minuit, parameters, x, y, numpoints, sigma):
     x_info, y_info, contour = minuit.mncontour(x, y, numpoints, sigma)
     contour = np.array(contour)
 
-    return {"x": contour[:, 0], "y": contour[:, 1], "x_info": x_info, "y_info": y_info}
+    success = x_info["is_valid"] and y_info["is_valid"]
+
+    return {
+        "success": success,
+        "x": contour[:, 0],
+        "y": contour[:, 1],
+        "x_info": x_info,
+        "y_info": y_info,
+    }
 
 
 # this code is copied from https://github.com/iminuit/iminuit/blob/master/iminuit/_minimize.py#L95

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -5,7 +5,7 @@ import logging
 import numpy as np
 from .likelihood import Likelihood
 
-__all__ = ["optimize_iminuit", "covariance_iminuit", "confidence_iminuit"]
+__all__ = ["optimize_iminuit", "covariance_iminuit", "confidence_iminuit", "mncontour"]
 
 log = logging.getLogger(__name__)
 
@@ -93,6 +93,19 @@ def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
         "upper": info["upper"],
         "nfev": info["nfcn"],
     }
+
+
+def mncontour(minuit, parameters, x, y, numpoints, sigma):
+    idx = parameters._get_idx(x)
+    x = _make_parname(idx, parameters[idx])
+
+    idx = parameters._get_idx(y)
+    y = _make_parname(idx, parameters[idx])
+
+    x_info, y_info, contour = minuit.mncontour(x, y, numpoints, sigma)
+    contour = np.array(contour)
+
+    return {"x": contour[:, 0], "y": contour[:, 1], "x_info": x_info, "y_info": y_info}
 
 
 # this code is copied from https://github.com/iminuit/iminuit/blob/master/iminuit/_minimize.py#L95

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -83,8 +83,8 @@ def test_confidence(backend):
     result = fit.confidence("x")
 
     assert result["success"] is True
-    assert_allclose(result["lower"], -1)
-    assert_allclose(result["upper"], +1)
+    assert_allclose(result["errp"], 1)
+    assert_allclose(result["errn"], 1)
 
     # Check that original value state wasn't changed
     assert_allclose(fit._model.parameters["x"].value, 2)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -97,3 +97,23 @@ def test_likelihood_profile():
 
     # Check that original value state wasn't changed
     assert_allclose(fit._model.parameters["x"].value, 2)
+
+
+def test_minos_contour():
+    fit = MyFit()
+    fit.optimize(backend="minuit")
+    result = fit.minos_contour("x", "y")
+
+    assert result["is_valid"] is True
+
+    x = result["x"]
+    assert_allclose(len(x), 10)
+    assert_allclose(x[0], 1, rtol=1e-5)
+    assert_allclose(x[-1], 1.499963, rtol=1e-5)
+    y = result["y"]
+    assert_allclose(len(y), 10)
+    assert_allclose(y[0], 300, rtol=1e-5)
+    assert_allclose(y[-1], 300.866004, rtol=1e-5)
+
+    # Check that original value state wasn't changed
+    assert_allclose(fit._model.parameters["x"].value, 2)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -39,6 +39,7 @@ def test_run(backend):
     )
     pars = result.model.parameters
 
+    assert result.success is True
     assert fit._model is result.model
 
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
@@ -80,7 +81,8 @@ def test_confidence(backend):
     fit = MyFit()
     fit.optimize(backend=backend)
     result = fit.confidence("x")
-    assert result["is_valid"] is True
+
+    assert result["success"] is True
     assert_allclose(result["lower"], -1)
     assert_allclose(result["upper"], +1)
 
@@ -92,6 +94,7 @@ def test_likelihood_profile():
     fit = MyFit()
     fit.run()
     result = fit.likelihood_profile("x", nvalues=3)
+
     assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
     assert_allclose(result["likelihood"], [4, 0, 4], atol=1e-7)
 
@@ -104,7 +107,7 @@ def test_minos_contour():
     fit.optimize(backend="minuit")
     result = fit.minos_contour("x", "y")
 
-    assert result["is_valid"] is True
+    assert result["success"] is True
 
     x = result["x"]
     assert_allclose(len(x), 10)


### PR DESCRIPTION
This PR adds `Fit.minos_contour` that wraps https://iminuit.readthedocs.io/en/latest/api.html#iminuit.Minuit.mncontour

It also contains a commit that fixes the return value of `Fit.confidence`, to multiply the parameter factor with the scale.

This wasn't noticed because the test case we have is bad. I can change the test case tonight, but would prefer to do it in a separate PR because it'll result in a large diff.