### PR TITLE
Add edisp in MapEvaluator for simulate_3d notebook

### DIFF
--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -164,7 +164,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "edisp = irfs[\"edisp\"].to_energy_dispersion(offset=offset)\n",
+    "energy = axis.edges * axis.unit\n",
+    "edisp = irfs[\"edisp\"].to_energy_dispersion(offset, e_reco=energy, e_true=energy)\n",
     "edisp.plot_matrix();"
    ]
   },
@@ -179,7 +180,7 @@
     "# maps, i.e. \"predicted counts per pixel\" given the model and\n",
     "# the observation infos: exposure, background, PSF and EDISP\n",
     "evaluator = MapEvaluator(\n",
-    "    model=sky_model, exposure=exposure, background=background, psf=psf_kernel\n",
+    "    model=sky_model, exposure=exposure, background=background, psf=psf_kernel, edisp=edisp\n",
     ")"
    ]
   },
@@ -318,53 +319,6 @@
    "source": [
     "# TODO: show e.g. how to make a residual image"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## iminuit\n",
-    "\n",
-    "What we have done for now is to write a very thin wrapper for http://iminuit.readthedocs.io/\n",
-    "as a fitting backend. This is just a prototype, we will improve this interface and\n",
-    "add other fitting backends (e.g. Sherpa or scipy.optimize or emcee or ...)\n",
-    "\n",
-    "As a power-user, you can access ``fit._iminuit`` and get the full power of what is developed there already.\n",
-    "E.g. the ``fit.fit()`` call ran ``Minuit.migrad()`` and ``Minuit.hesse()`` in the background, and you have\n",
-    "access to e.g. the covariance matrix, or can check a likelihood profile, or can run ``Minuit.minos()``\n",
-    "to compute asymmetric errors or ..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Check correlation between model parameters\n",
-    "# As expected in this simple case,\n",
-    "# spatial parameters are uncorrelated,\n",
-    "# but the spectral model amplitude and index are correlated as always\n",
-    "fit.minuit.print_matrix()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# You can use likelihood profiles to check if your model is\n",
-    "# well constrained or not, and if the fit really converged\n",
-    "fit.minuit.draw_profile(\"par_002_sigma\");"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR addresses (not a real) issue https://github.com/gammapy/gammapy/issues/1956 using `edisp` param with energy axis for the instantiation of `MapEvaluator` class in `simulate_3d.ipynb` notebook.