### PR TITLE
Change data access from all notebooks to GAMMAPY_DATA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,9 @@ RUN adduser --disabled-password \
 
 # download tutorials and datasets
 RUN gammapy download notebooks --out=${HOME}/gammapy-tutorials --release=0.9
-RUN git clone https://github.com/gammapy/gammapy-extra.git ${HOME}/gammapy-extra
+RUN gammapy download datasets --out=${HOME}/gammapy-datasets
 
+# RUN git clone https://github.com/gammapy/gammapy-extra.git ${HOME}/gammapy-extra
 # RUN git clone https://github.com/gammapy/gammapy-cat.git ${HOME}/gammapy-cat
 # RUN git clone https://github.com/gammapy/gammapy-fermi-lat-data.git ${HOME}/gammapy-fermi-lat-data
 
@@ -43,7 +44,7 @@ USER ${NB_USER}
 WORKDIR ${HOME}/gammapy-tutorials/notebooks-0.9
 
 # env vars used in tutorials
-ENV GAMMAPY_DATA ${HOME}/gammapy-extra/datasets
+ENV GAMMAPY_DATA ${HOME}/${HOME}/gammapy-datasets
 
 # ENV GAMMAPY_CAT ${HOME}/gammapy-cat
 # ENV GAMMAPY_FERMI_LAT_DATA ${HOME}/gammapy-fermi-lat-data

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -33,15 +33,6 @@
    "outputs": [],
    "source": [
     "# Check that you have the prepared Fermi-LAT dataset\n",
-    "!ls -1 $GAMMAPY_DATA/fermi_3fhl"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# We will use diffuse models from here\n",
     "!ls -1 $GAMMAPY_DATA/fermi_3fhl"
    ]
@@ -92,7 +83,7 @@
    "outputs": [],
    "source": [
     "events = EventList.read(\n",
-    "    \"$GAMMAPY_FERMI_LAT_DATA/3fhl/allsky/fermi_3fhl_events_selected.fits.gz\"\n",
+    "    \"$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_events_selected.fits.gz\"\n",
     ")\n",
     "print(events)"
    ]
@@ -239,7 +230,7 @@
    "outputs": [],
    "source": [
     "exposure_hpx = Map.read(\n",
-    "    \"$GAMMAPY_FERMI_LAT_DATA/3fhl/allsky/fermi_3fhl_exposure_cube_hpx.fits.gz\"\n",
+    "    \"$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_exposure_cube_hpx.fits.gz\"\n",
     ")\n",
     "# Unit is not stored in the file, set it manually\n",
     "exposure_hpx.unit = \"cm2 s\"\n",
@@ -321,7 +312,7 @@
    "outputs": [],
    "source": [
     "diffuse_galactic_fermi = Map.read(\n",
-    "    \"$GAMMAPY_EXTRA/datasets/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
+    "    \"$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
     ")\n",
     "# Unit is not stored in the file, set it manually\n",
     "diffuse_galactic_fermi.unit = \"cm-2 s-1 MeV-1 sr-1\"\n",
@@ -408,7 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_FERMI_LAT_DATA/isodiff/iso_P8R2_SOURCE_V6_v06.txt\"\n",
+    "filename = \"$GAMMAPY_DATA/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt\"\n",
     "interp_kwargs = {\"fill_value\": None}\n",
     "diffuse_iso = TableModel.read_fermi_isotropic_model(\n",
     "    filename=filename, interp_kwargs=interp_kwargs\n",
@@ -448,7 +439,7 @@
    "outputs": [],
    "source": [
     "psf = EnergyDependentTablePSF.read(\n",
-    "    \"$GAMMAPY_FERMI_LAT_DATA/3fhl/allsky/fermi_3fhl_psf_gc.fits.gz\"\n",
+    "    \"$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz\"\n",
     ")\n",
     "print(psf)"
    ]

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -41,8 +41,9 @@
   datasets:
     - fermi_survey
     - catalogs
-- name: fermi_lat GAMMAPY_FERMI_LAT_DATA
+- name: fermi_lat
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/fermi_lat.ipynb
+  requires: GAMMAPY_FERMI_LAT_DATA
   datasets:
     - fermi_3fhl
 - name: first_steps
@@ -98,9 +99,9 @@
     - joint-crab
 - name: spectrum_models
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_models.ipynb
-- name: spectrum_pipe GAMMA_CAT
+- name: spectrum_pipe
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_pipe.ipynb
-  requires: iminuit
+  requires: iminuit GAMMA_CAT
   datasets:
     - hess-dl3-dr1
     - gamma-cat

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -41,9 +41,8 @@
   datasets:
     - fermi_survey
     - catalogs
-- name: fermi_lat
+- name: fermi_lat GAMMAPY_FERMI_LAT_DATA
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/fermi_lat.ipynb
-  requires: GAMMAPY_FERMI_LAT_DATA
   datasets:
     - fermi_3fhl
 - name: first_steps
@@ -79,6 +78,7 @@
   requires: iminuit GAMMA_CAT
   datasets:
     - catalogs
+    - gamma-cat
 - name: simulate_3d
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/simulate_3d.ipynb
   requires: iminuit
@@ -98,11 +98,12 @@
     - joint-crab
 - name: spectrum_models
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_models.ipynb
-- name: spectrum_pipe
+- name: spectrum_pipe GAMMA_CAT
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_pipe.ipynb
-  requires: iminuit GAMMA_CAT
+  requires: iminuit
   datasets:
     - hess-dl3-dr1
+    - gamma-cat
 - name: spectrum_simulation
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_simulation.ipynb
   datasets:

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "fermi_3fgl = SourceCatalog3FGL()\n",
     "fermi_3fhl = SourceCatalog3FHL()\n",
-    "gammacat = SourceCatalogGammaCat()"
+    "gammacat = SourceCatalogGammaCat(\"$GAMMAPY_DATA/gamma-cat/gammacat.fits.gz\")"
    ]
   },
   {

--- a/tutorials/spectrum_pipe.ipynb
+++ b/tutorials/spectrum_pipe.ipynb
@@ -108,7 +108,7 @@
    "source": [
     "exclusion_mask = Map.create(skydir=crab_pos, width=(10, 10), binsz=0.02)\n",
     "\n",
-    "gammacat = SourceCatalogGammaCat()\n",
+    "gammacat = SourceCatalogGammaCat(\"$GAMMAPY_DATA/gamma-cat/gammacat.fits.gz\")\n",
     "\n",
     "regions = []\n",
     "for source in gammacat:\n",


### PR DESCRIPTION
This PR follows the suggestion in comment https://github.com/gammapy/gammapy/issues/1958#issuecomment-442874517 to use `$GAMMAPY_DATA` instead of `$GAMMAPY_FERMI_LAT_DATA` in one of the tutorials. The other two cannot be modified easily since they use `SourceCatalogGammaCat`, so access to the datasets is hardcoded in this class.
