### PR TITLE
Remove tests for old hess-crab4-pa

### DIFF
--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -58,27 +58,6 @@ def test_datastore_from_file():
 
 
 @requires_data("gammapy-extra")
-def test_datastore_pa():
-    """Test HESS ParisAnalysis data access."""
-    data_store = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-crab4-pa")
-
-    obs = data_store.obs(obs_id=23523)
-    filename = str(obs.location(hdu_type="bkg").path(abs_path=False))
-    assert filename == "background/bgmodel_alt7_az0.fits.gz"
-
-    assert (
-        str(type(obs.aeff))
-        == "<class 'gammapy.irf.effective_area.EffectiveAreaTable2D'>"
-    )
-    assert (
-        str(type(obs.edisp))
-        == "<class 'gammapy.irf.energy_dispersion.EnergyDispersion2D'>"
-    )
-    assert str(type(obs.psf)) == "<class 'gammapy.irf.psf_king.PSFKing'>"
-    assert str(type(obs.bkg)) == "<class 'gammapy.irf.background.Background3D'>"
-
-
-@requires_data("gammapy-extra")
 def test_datastore_get_observations(data_store):
     """Test loading data and IRF files via the DataStore"""
     observations = data_store.get_observations([23523, 23592])

--- a/gammapy/data/tests/test_hdu_index_table.py
+++ b/gammapy/data/tests/test_hdu_index_table.py
@@ -108,25 +108,3 @@ def test_hdu_index_table_hd_hap():
         hdu_index.hdu_location(obs_id=23523, hdu_class="invalid")
     msg = "Invalid hdu_class: invalid. Valid values are: ['events', 'gti', 'aeff_2d', 'edisp_2d', 'psf_table', 'psf_3gauss', 'psf_king', 'bkg_2d', 'bkg_3d']"
     assert exc.value.args[0] == msg
-
-
-@requires_data("gammapy-extra")
-def test_hdu_index_table_pa():
-    """Test HESS ParisAnalysis data access."""
-    hdu_index = HDUIndexTable.read(
-        "$GAMMAPY_EXTRA/datasets/hess-crab4-pa/hdu-index.fits.gz"
-    )
-
-    # A few valid queries
-
-    location = hdu_index.hdu_location(obs_id=23523, hdu_type="psf")
-    assert (
-        str(location.path(abs_path=False))
-        == "run23400-23599/run23523/psf_king_23523.fits.gz"
-    )
-
-    location = hdu_index.hdu_location(obs_id=23523, hdu_class="psf_king")
-    assert (
-        str(location.path(abs_path=False))
-        == "run23400-23599/run23523/psf_king_23523.fits.gz"
-    )

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -14,15 +14,6 @@ from ...utils.testing import requires_data
 # The goal would be to not accidentally break support for old files
 productions = [
     dict(
-        prod="pa-release1",
-        datastore="$GAMMAPY_EXTRA/datasets/hess-crab4-pa",
-        test_obs=23523,
-        aeff_ref=207835.9,
-        psf_type="psf_king",
-        psf_ref=51.004,
-        edisp_ref=2.783,
-    ),
-    dict(
         prod="hap-hd-prod2",
         datastore="$GAMMAPY_EXTRA/datasets/hess-crab4-hd-hap-prod2",
         test_obs=23523,


### PR DESCRIPTION
This PR removes the tests for the old `hess-crab4-pa` files. Discussion is in #1954.