### PR TITLE
Updating astropy_helpers to 2.0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,11 +88,9 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 MAIN_CMD='make' SETUP_CMD='docs-all'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
-        # TODO: update the next build from Python 3.6 to 3.7
-        # when this CI-helpers issue is resolved:
-        # https://github.com/astropy/ci-helpers/issues/301#issuecomment-419813895
+
         - os: linux
-          env: PYTHON_VERSION=3.6 MAIN_CMD='make' SETUP_CMD='docs-all'
+          env: PYTHON_VERSION=3.7 MAIN_CMD='make' SETUP_CMD='docs-all'
                CONDA_DEPENDENCIES=$CONDA_DOCS_DEPENDENCIES
 
         # Test conda build (which runs a bunch of useful tests after building the package)

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -38,13 +38,19 @@ latest version of this module.
 
 import contextlib
 import errno
-import imp
 import io
 import locale
 import os
 import re
 import subprocess as sp
 import sys
+
+__minimum_python_version__ = (2, 7)
+
+if sys.version_info < __minimum_python_version__:
+    print("ERROR: Python {} or later is required by astropy-helpers".format(
+        __minimum_python_version__))
+    sys.exit(1)
 
 try:
     from ConfigParser import ConfigParser, RawConfigParser
@@ -66,35 +72,15 @@ else:
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
+# Check that setuptools 1.0 or later is present
+from distutils.version import LooseVersion
 
-# Some pre-setuptools checks to ensure that either distribute or setuptools >=
-# 0.7 is used (over pre-distribute setuptools) if it is available on the path;
-# otherwise the latest setuptools will be downloaded and bootstrapped with
-# ``ez_setup.py``.  This used to be included in a separate file called
-# setuptools_bootstrap.py; but it was combined into ah_bootstrap.py
 try:
-    import pkg_resources
-    _setuptools_req = pkg_resources.Requirement.parse('setuptools>=0.7')
-    # This may raise a DistributionNotFound in which case no version of
-    # setuptools or distribute is properly installed
-    _setuptools = pkg_resources.get_distribution('setuptools')
-    if _setuptools not in _setuptools_req:
-        # Older version of setuptools; check if we have distribute; again if
-        # this results in DistributionNotFound we want to give up
-        _distribute = pkg_resources.get_distribution('distribute')
-        if _setuptools != _distribute:
-            # It's possible on some pathological systems to have an old version
-            # of setuptools and distribute on sys.path simultaneously; make
-            # sure distribute is the one that's used
-            sys.path.insert(1, _distribute.location)
-            _distribute.activate()
-            imp.reload(pkg_resources)
-except:
-    # There are several types of exceptions that can occur here; if all else
-    # fails bootstrap and use the bootstrapped version
-    from ez_setup import use_setuptools
-    use_setuptools()
-
+    import setuptools
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+except (ImportError, AssertionError):
+    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after
 # initializing submodule with ah_boostrap.py

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -33,7 +33,7 @@ dependencies:
   - iminuit>=1.3.2
   - pytest
   - pytest-cov
-  - sphinx==1.7.9
+  - sphinx
   - pandoc==2.1.3
   - pylint
   - flake8


### PR DESCRIPTION
~Do not merge yet, it's opened for testing and needs to be updated to point to the actual release when it's released.~

@cdeil  - Is there any workarounds that was added recently in order to ship 0.9 but I really need to remove here?