### PR TITLE
Implementing `select_parameter` and `select_time` used by the ObservationFilter

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -379,15 +379,16 @@ class EventListBase(object):
             mask = np.union1d(mask, temp)
         return mask
 
-    def select_parameter(self, parameter, limits):
+    def select_parameter(self, parameter, band):
         """Select events with respect to a specified parameter
 
         Parameters
         ----------
         parameter : str
             Parameter used for the selection. Must be present in `self.table`.
-        limits : tuple
+        band : tuple or `astropy.units.Quantity`
             Min and max value for the parameter to be selected (min <= parameter < max).
+            If parameter is not dimensionless you have to provide a Quantity.
 
         Returns
         -------
@@ -399,10 +400,10 @@ class EventListBase(object):
         >>> from gammapy.data import EventList
         >>> event_list = EventList.read('events.fits')
         >>> phase_region = (0.3, 0.5)
-        >>> event_list = event_list.select_parameter(parameter='PHASE', limits=phase_region)
+        >>> event_list = event_list.select_parameter(parameter='PHASE', band=phase_region)
         """
-        mask = limits[0] <= self.table[parameter]
-        mask &= self.table[parameter] < limits[1]
+        mask = band[0] <= self.table[parameter].quantity
+        mask &= self.table[parameter].quantity < band[1]
         return self.select_row_subset(mask)
 
     def _default_plot_ebounds(self):

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -379,22 +379,31 @@ class EventListBase(object):
             mask = np.union1d(mask, temp)
         return mask
 
-    def select_custom(self, parameter, limits):
-        """Select events with respect to a custom parameter
+    def select_parameter(self, parameter, limits):
+        """Select events with respect to a specified parameter
 
         Parameters
         ----------
         parameter : str
             Parameter used for the selection. Must be present in `self.table`.
         limits : tuple
-            Min (inclusive) and max (exclusive) value for the parameter to be selected.
+            Min and max value for the parameter to be selected (min <= parameter < max).
 
         Returns
         -------
         event_list : `EventList`
             Copy of event list with selection applied.
+
+        Examples
+        --------
+        >>> from gammapy.data import EventList
+        >>> event_list = EventList.read('events.fits')
+        >>> phase_region = (0.3, 0.5)
+        >>> event_list = event_list.select_parameter(parameter='PHASE', limits=phase_region)
         """
-        raise NotImplementedError
+        mask = limits[0] <= self.table[parameter]
+        mask &= self.table[parameter] < limits[1]
+        return self.select_row_subset(mask)
 
     def _default_plot_ebounds(self):
         energy = self.energy

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -41,7 +41,7 @@ class ObservationFilter(object):
     EVENT_FILTER_TYPES = dict(
         box_region="select_sky_box",
         circular_region="select_circular_region",
-        custom="select_custom",
+        custom="select_parameter",
     )
 
     def __init__(self, time_filter=None, event_filters=None):

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -39,7 +39,6 @@ class ObservationFilter(object):
     """
 
     EVENT_FILTER_TYPES = dict(
-        box_region="select_sky_box",
         circular_region="select_circular_region",
         custom="select_parameter",
     )

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -30,7 +30,7 @@ class ObservationFilter(object):
     >>> from astropy.coordinates import Angle
     >>>
     >>> time_filter = Time(['2021-03-27T20:10:00', '2021-03-27T20:20:00'])
-    >>> phase_filter = {'type': 'custom', 'opts': dict(parameter='PHASE', limits=(0.2, 0.8))}
+    >>> phase_filter = {'type': 'custom', 'opts': dict(parameter='PHASE', band=(0.2, 0.8))}
     >>>
     >>> my_obs_filter = ObservationFilter(time_filter=time_filter, event_filters=[phase_filter])
     >>>

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -118,17 +118,17 @@ class GTI(object):
         """
         # get GTIs that fall within the time_interval
         mask = self.time_start >= time_interval[1]
-        mask &= self.time_stop <= time_interval[0]
+        mask |= self.time_stop <= time_interval[0]
         gti_within = self.table[~mask]
 
         # crop the GTIs
         start_met = time_relative_to_ref(time_interval[0], self.table.meta)
         idx = gti_within['START'] < start_met
-        gti_within['START'][idx] = start_met
+        gti_within['START'][idx] = start_met.value
 
         stop_met = time_relative_to_ref(time_interval[1], self.table.meta)
         idx = gti_within['STOP'] > stop_met
-        gti_within['STOP'][idx] = stop_met
+        gti_within['STOP'][idx] = stop_met.value
 
         return self.__class__(gti_within)
 

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 from astropy.units import Quantity
 from astropy.table import Table
 from ..utils.time import time_ref_from_dict, time_relative_to_ref
@@ -117,18 +118,15 @@ class GTI(object):
             Copy of the GTI table with selection applied.
         """
         # get GTIs that fall within the time_interval
-        mask = self.time_start >= time_interval[1]
-        mask |= self.time_stop <= time_interval[0]
-        gti_within = self.table[~mask]
+        mask = self.time_start < time_interval[1]
+        mask &= self.time_stop > time_interval[0]
+        gti_within = self.table[mask]
 
         # crop the GTIs
         start_met = time_relative_to_ref(time_interval[0], self.table.meta)
-        idx = gti_within['START'] < start_met
-        gti_within['START'][idx] = start_met.value
-
         stop_met = time_relative_to_ref(time_interval[1], self.table.meta)
-        idx = gti_within['STOP'] > stop_met
-        gti_within['STOP'][idx] = stop_met.value
+        np.clip(gti_within['START'], start_met.value, stop_met.value, out=gti_within['START'])
+        np.clip(gti_within['STOP'], start_met.value, stop_met.value, out=gti_within['STOP'])
 
         return self.__class__(gti_within)
 

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
+import numpy as np
+from astropy import units as u
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...data.event_list import EventListBase, EventList, EventListLAT
@@ -13,14 +15,14 @@ class TestEventListBase:
         self.events = EventListBase.read(filename)
 
     @pytest.mark.parametrize(
-        "parameter, limits",
-        [("TIME", (101962604.0, 101964280.0)), ("ENERGY", (0.8, 5.0))],
+        "parameter, band",
+        [("ENERGY", (0.8*u.TeV, 5.0*u.TeV))],
     )
-    def test_select_parameter(self, parameter, limits):
-        selected_events = self.events.select_parameter(parameter, limits)
-        assert all(
-            (selected_events.table[parameter] >= limits[0])
-            & (selected_events.table[parameter] < limits[1])
+    def test_select_parameter(self, parameter, band):
+        selected_events = self.events.select_parameter(parameter, band)
+        assert np.all(
+            (selected_events.table[parameter].quantity >= band[0])
+            & (selected_events.table[parameter].quantity < band[1])
         )
 
 

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -1,8 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
-from ...data.event_list import EventList, EventListLAT
+from ...data.event_list import EventListBase, EventList, EventListLAT
+
+
+@requires_data("gammapy-extra")
+class TestEventListBase:
+    def setup(self):
+        filename = "$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
+        self.events = EventListBase.read(filename)
+
+    @pytest.mark.parametrize(
+        "parameter, limits",
+        [("TIME", (101962604.0, 101964280.0)), ("ENERGY", (0.8, 5.0))],
+    )
+    def test_select_parameter(self, parameter, limits):
+        selected_events = self.events.select_parameter(parameter, limits)
+        assert all(
+            (selected_events.table[parameter] >= limits[0])
+            & (selected_events.table[parameter] < limits[1])
+        )
 
 
 @requires_data("gammapy-extra")

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -1,5 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
+from astropy.coordinates import SkyCoord, Angle
+from astropy.time import Time
+from astropy import units as u
+from regions import CircleSkyRegion
 from ...data import DataStore, ObservationFilter, EventListBase
 from ...utils.testing import requires_data
 
@@ -9,17 +14,67 @@ def test_event_filter_types():
         assert hasattr(EventListBase, method_str)
 
 
-@requires_data("gammapy-extra")
-def test_empty_ObservationFilter():
-    ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1")
-    obs = ds.obs(20136)
+@pytest.fixture(scope="session")
+def observation():
+    ds = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1/")
+    return ds.obs(20136)
 
+
+@requires_data("gammapy-extra")
+def test_empty_observation_filter(observation):
     empty_obs_filter = ObservationFilter()
 
-    events = obs.events
+    events = observation.events
     filtered_events = empty_obs_filter.filter_events(events)
     assert filtered_events == events
 
-    gti = obs.gti
+    gti = observation.gti
     filtered_gti = empty_obs_filter.filter_gti(gti)
     assert filtered_gti == gti
+
+
+@requires_data("gammapy-extra")
+def test_filter_events(observation):
+    custom_filter = {
+        "type": "custom",
+        "opts": {"parameter": "ENERGY", "limits": (0.8, 10.0)},
+    }
+
+    target_position = SkyCoord(ra=229.2, dec=-58.3, unit="deg", frame="icrs")
+    region_radius = Angle("0.2 deg")
+    region = CircleSkyRegion(center=target_position, radius=region_radius)
+    circular_region_filter = {"type": "circular_region", "opts": {"region": region}}
+
+    time_filter = Time([53090.12, 53090.13], format="mjd", scale="tt")
+
+    obs_filter = ObservationFilter(
+        event_filters=[custom_filter, circular_region_filter], time_filter=time_filter
+    )
+
+    events = observation.events
+    filtered_events = obs_filter.filter_events(events)
+
+    assert all(
+        (filtered_events.energy >= 0.8 * u.TeV)
+        & (filtered_events.energy < 10.0 * u.TeV)
+    )
+    assert all(
+        (filtered_events.time >= time_filter[0])
+        & (filtered_events.time < time_filter[1])
+    )
+    assert all(region.center.separation(filtered_events.radec) < region_radius)
+
+
+@requires_data("gammapy-extra")
+def test_filter_gti(observation):
+    time_filter = Time([53090.12, 53090.13], format="mjd", scale="tt")
+
+    obs_filter = ObservationFilter(time_filter=time_filter)
+
+    gti = observation.gti
+    filtered_gti = obs_filter.filter_gti(gti)
+
+    assert all(
+        (filtered_gti.time_start >= time_filter[0])
+        & (filtered_gti.time_stop <= time_filter[1])
+    )

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -74,7 +74,5 @@ def test_filter_gti(observation):
     gti = observation.gti
     filtered_gti = obs_filter.filter_gti(gti)
 
-    assert all(
-        (filtered_gti.time_start >= time_filter[0])
-        & (filtered_gti.time_stop <= time_filter[1])
-    )
+    assert all(filtered_gti.time_start >= time_filter[0])
+    assert all(filtered_gti.time_stop <= time_filter[1])

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord, Angle
 from astropy.time import Time
@@ -74,5 +75,9 @@ def test_filter_gti(observation):
     gti = observation.gti
     filtered_gti = obs_filter.filter_gti(gti)
 
-    assert all(filtered_gti.time_start >= time_filter[0])
-    assert all(filtered_gti.time_stop <= time_filter[1])
+    # small workaround to test for greater/less than or equal to
+    abs_diff = np.abs((filtered_gti.time_start - time_filter[0]).sec)  # absolute differences in seconds
+    assert all((filtered_gti.time_start > time_filter[0]) | (abs_diff < 0.001))
+
+    abs_diff = np.abs((filtered_gti.time_stop - time_filter[1]).sec)  # absolute differences in seconds
+    assert all((filtered_gti.time_stop < time_filter[1]) | (abs_diff < 0.001))

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -76,7 +76,7 @@ def test_filter_gti(observation):
     gti = observation.gti
     filtered_gti = obs_filter.filter_gti(gti)
 
-    assert type(filtered_gti) == GTI
+    assert isinstance(filtered_gti, GTI)
     assert_time_allclose(filtered_gti.time_start, time_filter[0])
     assert_time_allclose(filtered_gti.time_stop, time_filter[1])
 

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -47,20 +47,27 @@ def test_gti_fermi():
 
 @requires_data("gammapy-extra")
 @pytest.mark.parametrize(
-    "time_interval",
+    "time_interval, expected_length, expected_times",
     [
-        Time(["2008-08-04T16:21:00", "2008-08-04T19:10:00"], format="isot", scale="tt"),
-        Time([54682.68125, 54682.79861111], format="mjd", scale="tt"),
+        (Time(["2008-08-04T16:21:00", "2008-08-04T19:10:00"], format="isot", scale="tt"), 2,
+         Time(["2008-08-04T16:21:00", "2008-08-04T19:10:00"], format="isot", scale="tt")),
+        (Time([54682.68125, 54682.79861111], format="mjd", scale="tt"), 2,
+         Time([54682.68125, 54682.79861111], format="mjd", scale="tt")),
+        (Time([10., 100000.], format='mjd', scale='tt'), 36589,
+         Time([54682.659499814814, 57053.993550740735], format='mjd', scale='tt')),
+        (Time([10., 20.], format='mjd', scale='tt'), 0, None),
     ],
 )
-def test_select_time(time_interval):
+def test_select_time(time_interval, expected_length, expected_times):
     filename = "$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz"
     gti = GTI.read(filename)
+    print(gti.time_start[0], gti.time_stop[-1], len(gti.table))
 
     gti_selected = gti.select_time(time_interval)
 
-    assert len(gti_selected.table) == 2
+    assert len(gti_selected.table) == expected_length
 
-    time_interval.format = "mjd"
-    assert_time_allclose(gti_selected.time_start[0], time_interval[0])
-    assert_time_allclose(gti_selected.time_stop[-1], time_interval[1])
+    if expected_length != 0:
+        expected_times.format = "mjd"
+        assert_time_allclose(gti_selected.time_start[0], expected_times[0])
+        assert_time_allclose(gti_selected.time_stop[-1], expected_times[1])

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 from numpy.testing import assert_allclose
 from astropy.time import Time
 from ...utils.testing import requires_data, assert_time_allclose
@@ -42,3 +43,24 @@ def test_gti_fermi():
 
     expected = Time(54682.66357959571, format="mjd", scale="tt")
     assert_time_allclose(gti.time_stop[0], expected)
+
+
+@requires_data("gammapy-extra")
+@pytest.mark.parametrize(
+    "time_interval",
+    [
+        Time(["2008-08-04T16:21:00", "2008-08-04T19:10:00"], format="isot", scale="tt"),
+        Time([54682.68125, 54682.79861111], format="mjd", scale="tt"),
+    ],
+)
+def test_select_time(time_interval):
+    filename = "$GAMMAPY_EXTRA/datasets/fermi_2fhl/2fhl_events.fits.gz"
+    gti = GTI.read(filename)
+
+    gti_selected = gti.select_time(time_interval)
+
+    assert len(gti_selected.table) == 2
+
+    time_interval.format = "mjd"
+    assert_time_allclose(gti_selected.time_start[0], time_interval[0])
+    assert_time_allclose(gti_selected.time_stop[-1], time_interval[1])


### PR DESCRIPTION
This is the first PR of the third scenario of #1877 .
It implements two "select" methods (`EventListBase.select_parameter` and `GTI.select_time`) that will be used in the `ObservationFilter`.

Actually i renamed the `EventListBase.select_custom` method to `EventListBase.select_parameter`, because it sounds more intuitive to me.

Apart from the tests to the "select" methods, i also expanded the tests for the `ObservationFilter`. All tests pass locally.

A follow-up PR would be to introduce a "select_time" method on the `DataStoreObservation` that automatically adds the necessary filter to the observation. I will also try to update a bit PIG #1877 to further outline the implementation road map.

