### PR TITLE
Improve ObservationStats

### DIFF
--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -25,9 +25,24 @@ def on_region():
 
 
 @pytest.fixture(scope="session")
+def bad_on_region():
+    pos = SkyCoord(83.6333 * u.deg, 21.5144 * u.deg)
+    on_size = 0.3 * u.deg
+    return CircleSkyRegion(pos, on_size)
+
+
+@pytest.fixture(scope="session")
 def stats(on_region, observations):
     obs = observations[0]
     bge = ReflectedRegionsBackgroundEstimator(on_region=on_region, observations=obs)
+    bg = bge.process(obs)
+    return ObservationStats.from_observation(obs, bg)
+
+
+@pytest.fixture(scope="session")
+def stats_bad_on_region(bad_on_region, observations):
+    obs = observations[0]
+    bge = ReflectedRegionsBackgroundEstimator(on_region=bad_on_region, observations=obs)
     bg = bge.process(obs)
     return ObservationStats.from_observation(obs, bg)
 
@@ -47,6 +62,22 @@ def stats_stacked(on_region, observations):
     )
 
 
+@pytest.fixture(scope="session")
+def stats_stacked_bad_on_region(bad_on_region, observations):
+    bge = ReflectedRegionsBackgroundEstimator(
+        on_region=bad_on_region, observations=observations
+    )
+    bge.run()
+
+    return ObservationStats.stack(
+        [
+            ObservationStats.from_observation(obs, bg)
+            for obs, bg in zip(observations, bge.result)
+        ]
+    )
+
+
+
 @requires_data("gammapy-extra")
 class TestObservationStats(object):
     def test_str(self, stats):
@@ -59,6 +90,13 @@ class TestObservationStats(object):
         assert data["n_off"] == 395
         assert_allclose(data["alpha"], 0.333, rtol=1e-2)
         assert_allclose(data["sigma"], 16.430, rtol=1e-3)
+        assert_allclose(data["gamma_rate"].value, 11.127, rtol=1e-3)
+        assert_allclose(data["bg_rate"].value, 4.995, rtol=1e-3)
+        assert_allclose(data["livetime"].value, 26.362, rtol=1e-3)
+
+    def test_bad_on(self, stats_bad_on_region):
+        data = stats_bad_on_region.to_dict()
+        assert data["alpha"] == 0
 
     def test_stack(self, stats_stacked):
         data = stats_stacked.to_dict()
@@ -66,3 +104,10 @@ class TestObservationStats(object):
         assert data["n_off"] == 766
         assert_allclose(data["alpha"], 0.333, rtol=1e-2)
         assert_allclose(data["sigma"], 25.244, rtol=1e-3)
+
+    def test_stack_bad_on(self, stats_stacked_bad_on_region):
+        data = stats_stacked_bad_on_region.to_dict()
+        assert data["n_on"] == 156
+        assert data["n_off"] == 1003
+        assert_allclose(data["alpha"], 0.125, rtol=1e-3)
+        assert_allclose(data["livetime"].value, 26.211, rtol=1e-3)


### PR DESCRIPTION
Following #1955, this PR improves the `ObservationStats` class and the associated tests. Note that several superfluous parameters to `__init__` have been removed. This should rarely lead to problems, since instances of this class are usually created by the `from_observation` factory function.