### PR TITLE
Add `select_time` method to `Observations`

### DIFF
--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import copy
 import logging
 
 __all__ = ["ObservationFilter"]
@@ -94,3 +95,7 @@ class ObservationFilter(object):
             return data.select_time(self.time_filter)
         else:
             return data
+
+    def copy(self):
+        """Copy the `ObservationFilter` object."""
+        return copy.deepcopy(self)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -233,15 +233,14 @@ class DataStoreObservation(object):
         """Select a time interval of the observation.
 
         Parameter
-        =========
+        ---------
         time_interval : `astropy.time.Time`
             Start and stop time of the selected time interval. For now we only support a single time interval.
 
         Returns
-        =======
+        -------
         new_obs : `~gammapy.data.DataStoreObservation`
             A new observation instance of the specified time interval
-
         """
         new_obs_filter = self.obs_filter.copy()
         new_obs_filter.time_filter = time_interval
@@ -286,20 +285,19 @@ class Observations(object):
         """Select a time interval of the observations.
 
         Parameter
-        =========
+        ---------
         time_interval : `astropy.time.Time`
             Start and stop time of the selected time interval. For now we only support a single time interval.
 
         Returns
-        =======
+        -------
         new_observations : `~gammapy.data.Observations`
             A new observations instance of the specified time interval
-
         """
         new_obs_list = []
         for obs in self:
             new_obs = obs.select_time(time_interval)
-            if len(new_obs.events.table) > 0:
+            if len(new_obs.gti.table) > 0:
                 new_obs_list.append(new_obs)
 
         return self.__class__(new_obs_list)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -228,7 +228,6 @@ class DataStoreObservation(object):
         """Quick-look plots in a few panels."""
         raise NotImplementedError
 
-
     def select_time(self, time_interval):
         """Select a time interval of the observation.
 
@@ -245,7 +244,9 @@ class DataStoreObservation(object):
         new_obs_filter = self.obs_filter.copy()
         new_obs_filter.time_filter = time_interval
 
-        return self.__class__(obs_id=self.obs_id, data_store=self.data_store, obs_filter=new_obs_filter)
+        return self.__class__(
+            obs_id=self.obs_id, data_store=self.data_store, obs_filter=new_obs_filter
+        )
 
     def check(self, checks="all"):
         """Run checks.

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -229,6 +229,25 @@ class DataStoreObservation(object):
         raise NotImplementedError
 
 
+    def select_time(self, time_interval):
+        """Select a time interval of the observation.
+
+        Parameter
+        =========
+        time_interval : `astropy.time.Time`
+            Start and stop time of the selected time interval. For now we only support a single time interval.
+
+        Returns
+        =======
+        new_obs : `~gammapy.data.DataStoreObservation`
+            A new observation instance of the specified time interval
+
+        """
+        new_obs_filter = self.obs_filter.copy()
+        new_obs_filter.time_filter = time_interval
+
+        return self.__class__(obs_id=self.obs_id, data_store=self.data_store, obs_filter=new_obs_filter)
+
     def check(self, checks="all"):
         """Run checks.
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -282,6 +282,28 @@ class Observations(object):
             s += str(obs)
         return s
 
+    def select_time(self, time_interval):
+        """Select a time interval of the observations.
+
+        Parameter
+        =========
+        time_interval : `astropy.time.Time`
+            Start and stop time of the selected time interval. For now we only support a single time interval.
+
+        Returns
+        =======
+        new_observations : `~gammapy.data.Observations`
+            A new observations instance of the specified time interval
+
+        """
+        new_obs_list = []
+        for obs in self:
+            new_obs = obs.select_time(time_interval)
+            if len(new_obs.events.table) > 0:
+                new_obs_list.append(new_obs)
+
+        return self.__class__(new_obs_list)
+
 
 class ObservationChecker(Checker):
     """Check an observation.

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -15,8 +15,7 @@ class TestEventListBase:
         self.events = EventListBase.read(filename)
 
     @pytest.mark.parametrize(
-        "parameter, band",
-        [("ENERGY", (0.8*u.TeV, 5.0*u.TeV))],
+        "parameter, band", [("ENERGY", (0.8 * u.TeV, 5.0 * u.TeV))]
     )
     def test_select_parameter(self, parameter, band):
         selected_events = self.events.select_parameter(parameter, band)

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -61,7 +61,6 @@ def test_gti_fermi():
 def test_select_time(time_interval, expected_length, expected_times):
     filename = "$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-events.fits.gz"
     gti = GTI.read(filename)
-    print(gti.time_start[0], gti.time_stop[-1], len(gti.table))
 
     gti_selected = gti.select_time(time_interval)
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -35,13 +35,27 @@ def test_data_store_observation(data_store):
 @pytest.mark.parametrize(
     "time_interval, expected_times",
     [
-        (Time(["2004-12-04T22:10:00", "2004-12-04T22:30:00"], format="isot", scale="tt"),
-         Time(["2004-12-04T22:10:00", "2004-12-04T22:30:00"], format="isot", scale="tt")),
-        (Time([53343.930, 53343.940], format="mjd", scale="tt"),
-         Time([53343.930, 53343.940], format="mjd", scale="tt")),
-        (Time([10., 100000.], format='mjd', scale='tt'),
-         Time([53343.92234009, 53343.94186563], format='mjd', scale='tt')),
-        (Time([10., 20.], format='mjd', scale='tt'), None),
+        (
+            Time(
+                ["2004-12-04T22:10:00", "2004-12-04T22:30:00"],
+                format="isot",
+                scale="tt",
+            ),
+            Time(
+                ["2004-12-04T22:10:00", "2004-12-04T22:30:00"],
+                format="isot",
+                scale="tt",
+            ),
+        ),
+        (
+            Time([53343.930, 53343.940], format="mjd", scale="tt"),
+            Time([53343.930, 53343.940], format="mjd", scale="tt"),
+        ),
+        (
+            Time([10.0, 100000.0], format="mjd", scale="tt"),
+            Time([53343.92234009, 53343.94186563], format="mjd", scale="tt"),
+        ),
+        (Time([10.0, 20.0], format="mjd", scale="tt"), None),
     ],
 )
 def test_observation_select_time(data_store, time_interval, expected_times):
@@ -52,8 +66,11 @@ def test_observation_select_time(data_store, time_interval, expected_times):
     new_obs = obs.select_time(time_interval)
 
     if expected_times:
-        expected_times.format = 'mjd'
-        assert np.all((new_obs.events.time >= expected_times[0]) & (new_obs.events.time < expected_times[1]))
+        expected_times.format = "mjd"
+        assert np.all(
+            (new_obs.events.time >= expected_times[0])
+            & (new_obs.events.time < expected_times[1])
+        )
         assert_time_allclose(new_obs.gti.time_start[0], expected_times[0], atol=0.01)
         assert_time_allclose(new_obs.gti.time_stop[-1], expected_times[1], atol=0.01)
     else:


### PR DESCRIPTION
This PR belongs to scenario 5 of the PIG #1877 .

It introduces a `select_time` method on the `DataStoreObservation` and `Observations` class. This method can be used to select a certain time interval to perform an analysis on.