### PR TITLE
Adapt tests to latest pytest versions

### DIFF
--- a/gammapy/background/tests/test_phase.py
+++ b/gammapy/background/tests/test_phase.py
@@ -8,7 +8,7 @@ from ...data import DataStore, EventList
 from .. import BackgroundEstimate, PhaseBackgroundEstimator
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def on_region():
     """Example on_region for testing."""
     pos = SkyCoord("08h35m20.65525s", "-45d10m35.1545s", frame="icrs")
@@ -16,7 +16,7 @@ def on_region():
     return CircleSkyRegion(pos, radius)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def observations():
     """Example observation list for testing."""
     datastore = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/cta-1dc/index/gps")
@@ -24,11 +24,11 @@ def observations():
 
 
 @pytest.fixture(scope="session")
-def phase_bkg_estimator():
+def phase_bkg_estimator(on_region, observations):
     """Example background estimator for testing."""
     return PhaseBackgroundEstimator(
-        observations=observations(),
-        on_region=on_region(),
+        observations=observations,
+        on_region=on_region,
         on_phase=(0.5, 0.6),
         off_phase=(0.7, 1),
     )

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -632,10 +632,7 @@ class SourceCatalogHGPS(SourceCatalog):
 
     def __init__(self, filename=None, hdu="HGPS_SOURCES"):
         if not filename:
-            filename = (
-                Path(os.environ["HGPS_ANALYSIS"])
-                / "data/catalogs/HGPS3/release/HGPS_v0.4.fits"
-            )
+            filename = "$GAMMAPY_EXTRA/datasets/catalogs/hgps_catalog_v1.fits.gz"
 
         filename = str(make_path(filename))
         table = Table.read(filename, hdu=hdu)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -23,24 +23,28 @@ from .. import (
 SOURCES_3FGL = [
     dict(
         idx=0,
+        name="3FGL J0000.1+6545",
         spec_type=PowerLaw,
         dnde=u.Quantity(1.4351261e-9, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.1356270e-10, "cm-2 s-1 GeV-1"),
     ),
     dict(
         idx=4,
+        name="3FGL J0001.4+2120",
         spec_type=LogParabola,
         dnde=u.Quantity(8.3828599e-10, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.6713238e-10, "cm-2 s-1 GeV-1"),
     ),
     dict(
         idx=55,
+        name="3FGL J0023.4+0923",
         spec_type=ExponentialCutoffPowerLaw3FGL,
         dnde=u.Quantity(1.8666925e-09, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.2068837e-10, "cm-2 s-1 GeV-1"),
     ),
     dict(
         idx=960,
+        name="3FGL J0835.3-4510",
         spec_type=PLSuperExpCutoff3FGL,
         dnde=u.Quantity(1.6547128794756733e-06, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(1.6621504e-11, "cm-2 s-1 MeV-1"),
@@ -50,12 +54,14 @@ SOURCES_3FGL = [
 SOURCES_3FHL = [
     dict(
         idx=352,
+        name="3FHL J0534.5+2201",
         spec_type=PowerLaw,
         dnde=u.Quantity(6.3848912826152664e-12, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.679593524691324e-13, "cm-2 s-1 GeV-1"),
     ),
     dict(
         idx=1442,
+        name="3FHL J2158.8-3013",
         spec_type=LogParabola,
         dnde=u.Quantity(2.056998292908196e-12, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(4.219030630302381e-13, "cm-2 s-1 GeV-1"),

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -79,12 +79,12 @@ class TestSourceCatalogGammaCat:
         for name in names:
             assert str(gammacat[name]) == str(gammacat["W28"])
 
-    def test_sort_table(self):
+    def test_sort_table(self, gammacat):
         name = "HESS J1848-018"
         sort_keys = ["ra", "dec", "reference_id"]
         for sort_key in sort_keys:
             # this test modifies the catalog, so we make a copy
-            cat = gammacat()
+            cat = gammacat.copy()
             cat.table.sort(sort_key)
             assert cat[name].name == name
 

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -1,23 +1,39 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
+from astropy.coordinates import SkyCoord, Angle
+from regions import CircleSkyRegion
 from ...utils.energy import EnergyBounds
 from ...utils.testing import requires_dependency, requires_data
-from ...background.tests.test_reflected import observations, on_region
 from ...spectrum.models import PowerLaw
 from ..spectrum_pipe import SpectrumAnalysisIACT
+from ...data import DataStore
 
 
-def get_config():
+@pytest.fixture(scope="session")
+def observations():
+    """Example observation list for testing."""
+    datastore = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1")
+    obs_ids = [23523, 23526]
+    return datastore.get_observations(obs_ids)
+
+
+@pytest.fixture(scope="session")
+def config():
     """Get test config, extend to several scenarios"""
     model = PowerLaw(
         index=2, amplitude=1e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
     )
+
+    pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
+    radius = Angle(0.11, "deg")
+    on_region = CircleSkyRegion(pos, radius)
     fp_binning = EnergyBounds.equal_log_spacing(1, 50, 4, "TeV")
     return dict(
         outdir=None,
-        background=dict(on_region=on_region()),
+        background=dict(on_region=on_region),
         extraction=dict(),
         fit=dict(model=model),
         fp_binning=fp_binning,
@@ -26,11 +42,10 @@ def get_config():
 
 @requires_data("gammapy-extra")
 @requires_dependency("sherpa")
-def test_spectrum_analysis_iact(tmpdir):
-    config = get_config()
+def test_spectrum_analysis_iact(tmpdir, config, observations):
     config["outdir"] = tmpdir
 
-    analysis = SpectrumAnalysisIACT(observations=observations(), config=config)
+    analysis = SpectrumAnalysisIACT(observations=observations, config=config)
     analysis.run()
     flux_points = analysis.flux_points
 

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 import numpy as np
-import copy
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord, Angle
@@ -34,7 +33,7 @@ def on_region():
     return region
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def observations():
     """Example observation list for testing."""
     datastore = DataStore.from_dir("$GAMMAPY_EXTRA/datasets/hess-dl3-dr1")
@@ -42,7 +41,7 @@ def observations():
     return datastore.get_observations(obs_ids)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def bkg_estimate(observations, on_region, exclusion_mask):
     """An example background estimate"""
     est = ReflectedRegionsBackgroundEstimator(
@@ -53,7 +52,7 @@ def bkg_estimate(observations, on_region, exclusion_mask):
     return est.result
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def extraction(bkg_estimate, observations):
     """An example SpectrumExtraction for tests."""
     # Restrict true energy range covered by HAP exporter
@@ -117,9 +116,6 @@ class TestSpectrumExtraction:
 
     @staticmethod
     def test_alpha(observations, bkg_estimate):
-        bkg_estimate = copy.deepcopy(bkg_estimate)
-
-        # TODO: don't modify fixtures in tests!
         bkg_estimate[0].a_off = 0
         bkg_estimate[1].a_off = 2
         extraction = SpectrumExtraction(

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -201,13 +201,12 @@ def spec_extraction():
 
 
 @requires_data("gammapy-extra")
-def test_lightcurve_estimator():
-    spec_extract = spec_extraction()
-    lc_estimator = LightCurveEstimator(spec_extract)
+def test_lightcurve_estimator(spec_extraction):
+    lc_estimator = LightCurveEstimator(spec_extraction)
 
     # param
     intervals = []
-    for obs in spec_extract.observations:
+    for obs in spec_extraction.observations:
         intervals.append([obs.events.time[0], obs.events.time[-1]])
 
     model = PowerLaw(
@@ -249,10 +248,8 @@ def test_lightcurve_estimator():
 
 
 @requires_data("gammapy-extra")
-def test_lightcurve_interval_maker():
-    spec_extract = spec_extraction()
-
-    table = LightCurveEstimator.make_time_intervals_fixes(500, spec_extract)
+def test_lightcurve_interval_maker(spec_extraction):
+    table = LightCurveEstimator.make_time_intervals_fixes(500, spec_extraction)
     intervals = list(zip(table["t_start"], table["t_stop"]))
 
     assert len(intervals) == 9
@@ -261,9 +258,8 @@ def test_lightcurve_interval_maker():
 
 
 @requires_data("gammapy-extra")
-def test_lightcurve_adaptative_interval_maker():
-    spec_extract = spec_extraction()
-    lc_estimator = LightCurveEstimator(spec_extract)
+def test_lightcurve_adaptative_interval_maker(spec_extraction):
+    lc_estimator = LightCurveEstimator(spec_extraction)
     separator = [
         Time((53343.94050200008 + 53343.952979345195) / 2, scale="tt", format="mjd")
     ]
@@ -271,7 +267,7 @@ def test_lightcurve_adaptative_interval_maker():
         significance=3,
         significance_method="lima",
         energy_range=[0.2, 100] * u.TeV,
-        spectrum_extraction=spec_extract,
+        spectrum_extraction=spec_extraction,
         separators=separator,
     )
     assert_allclose(table["significance"] >= 3, True)


### PR DESCRIPTION
This PR adapts all tests in Gammapy to work with the latest pytest version (>4.0), specifically it removes
all explicit calls of pytest fixtures. This resolves #1618. 
