### PR TITLE
Adding a background model PR1

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -385,6 +385,5 @@ class BackgroundModel(Model):
         tilt = self.parameters["tilt"].value
         reference = self.parameters["reference"].quantity
         tilt_factor = np.power((self.energy_center/reference).to(""), -tilt)
-        print(tilt_factor)
         return u.Quantity(norm * self.map.data * tilt_factor, self.map.unit, copy=False)
 

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -93,9 +93,11 @@ def test_BackgroundModel(background):
 
 
 class TestSkyModels:
+    def setup(self):
+        self.sky_models = SkyModels([sky_model(), sky_model()])
 
-    def test_to_compound_model(self, sky_model):
-        sky_models = SkyModels([sky_model, sky_model])
+    def test_to_compound_model(self):
+        sky_models = self.sky_models
         model = sky_models.to_compound_model()
         assert isinstance(model, CompoundSkyModel)
         pars = model.parameters.parameters
@@ -103,8 +105,8 @@ class TestSkyModels:
         assert pars[0].name == "lon_0"
         assert pars[-1].name == "reference"
 
-    def test_parameters(self, sky_model):
-        sky_models = SkyModels([sky_model, sky_model])
+    def test_parameters(self):
+        sky_models = self.sky_models
         parnames = ["lon_0", "lat_0", "sigma", "index", "amplitude", "reference"] * 2
         assert sky_models.parameters.names == parnames
 
@@ -118,8 +120,8 @@ class TestSkyModels:
         sky_models.parameters = sky_models.parameters.copy()
         assert sky_models.parameters.parameters[-1].value == 1
 
-    def test_evaluate(self, sky_model):
-        sky_models = SkyModels([sky_model, sky_model])
+    def test_evaluate(self):
+        sky_models = self.sky_models
         lon = 3 * u.deg * np.ones(shape=(3, 4))
         lat = 4 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
@@ -145,11 +147,11 @@ class TestSkyModel:
         # Check that model parameters are references to the spatial and spectral parts
         p1 = sky_model.parameters["lon_0"]
         p2 = sky_model.spatial_model.parameters["lon_0"]
-        #assert p1 is p2
+        assert p1 is p2
 
         p1 = sky_model.parameters["amplitude"]
         p2 = sky_model.spectral_model.parameters["amplitude"]
-        #assert p1 is p2
+        assert p1 is p2
 
     @staticmethod
     def test_evaluate_scalar(sky_model):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -9,7 +9,7 @@ from ...maps import MapAxis, WcsGeom, Map
 from ...irf.energy_dispersion import EnergyDispersion
 from ...cube.psf_kernel import PSFKernel
 from ...cube.models import SkyDiffuseCube, BackgroundModel
-from ...image.models import SkyGaussian,
+from ...image.models import SkyGaussian
 from ...spectrum.models import PowerLaw
 from ..fit import MapEvaluator
 from ..models import SkyModel, SkyModels, CompoundSkyModel
@@ -81,14 +81,16 @@ def evaluator(sky_model, exposure, background, psf, edisp):
 def diffuse_evaluator(diffuse_model, exposure, background, psf, edisp):
     return MapEvaluator(diffuse_model, exposure, background, psf=psf, edisp=edisp)
 
+
 def test_BackgroundModel(background):
-    bkg1 = BackgroundModel(background, norm=2.0)
+    bkg1 = BackgroundModel(background, norm=2.0).evaluate()
     assert_allclose(bkg1[0][0][0], background.data[0][0][0] * 2.0, rtol=1e-3)
     assert_allclose(bkg1.sum(), background.data.sum()*2.0, rtol=1e-3)
 
-    bkg2 = BackgroundModel(background, norm=2.0, tilt=0.2)
-    assert_allclose(bkg2[0][0][0], 1e-7, rtol=1e-3)
-    assert_allclose(bkg2.sum(), 3e-7, rtol=1e-3)
+    bkg2 = BackgroundModel(background, norm=2.0, tilt=0.2).evaluate()
+    assert_allclose(bkg2[0][0][0], 2.254e-07, rtol=1e-3)
+    assert_allclose(bkg2.sum(), 7.352e-06, rtol=1e-3)
+
 
 class TestSkyModels:
     def setup(self):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -82,12 +82,12 @@ def diffuse_evaluator(diffuse_model, exposure, background, psf, edisp):
     return MapEvaluator(diffuse_model, exposure, background, psf=psf, edisp=edisp)
 
 
-def test_BackgroundModel(background):
+def test_background_model(background):
     bkg1 = BackgroundModel(background, norm=2.0).evaluate()
     assert_allclose(bkg1[0][0][0], background.data[0][0][0] * 2.0, rtol=1e-3)
     assert_allclose(bkg1.sum(), background.data.sum()*2.0, rtol=1e-3)
 
-    bkg2 = BackgroundModel(background, norm=2.0, tilt=0.2).evaluate()
+    bkg2 = BackgroundModel(background, norm=2.0, tilt=0.2, reference="1000 GeV").evaluate()
     assert_allclose(bkg2[0][0][0], 2.254e-07, rtol=1e-3)
     assert_allclose(bkg2.sum(), 7.352e-06, rtol=1e-3)
 

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -93,11 +93,9 @@ def test_BackgroundModel(background):
 
 
 class TestSkyModels:
-    def setup(self):
-        self.sky_models = SkyModels([sky_model(), sky_model()])
 
-    def test_to_compound_model(self):
-        sky_models = self.sky_models
+    def test_to_compound_model(self, sky_model):
+        sky_models = SkyModels([sky_model, sky_model])
         model = sky_models.to_compound_model()
         assert isinstance(model, CompoundSkyModel)
         pars = model.parameters.parameters
@@ -105,8 +103,8 @@ class TestSkyModels:
         assert pars[0].name == "lon_0"
         assert pars[-1].name == "reference"
 
-    def test_parameters(self):
-        sky_models = self.sky_models
+    def test_parameters(self, sky_model):
+        sky_models = SkyModels([sky_model, sky_model])
         parnames = ["lon_0", "lat_0", "sigma", "index", "amplitude", "reference"] * 2
         assert sky_models.parameters.names == parnames
 
@@ -120,8 +118,8 @@ class TestSkyModels:
         sky_models.parameters = sky_models.parameters.copy()
         assert sky_models.parameters.parameters[-1].value == 1
 
-    def test_evaluate(self):
-        sky_models = self.sky_models
+    def test_evaluate(self, sky_model):
+        sky_models = SkyModels([sky_model, sky_model])
         lon = 3 * u.deg * np.ones(shape=(3, 4))
         lat = 4 * u.deg * np.ones(shape=(3, 4))
         energy = [1, 1, 1, 1, 1] * u.TeV
@@ -147,11 +145,11 @@ class TestSkyModel:
         # Check that model parameters are references to the spatial and spectral parts
         p1 = sky_model.parameters["lon_0"]
         p2 = sky_model.spatial_model.parameters["lon_0"]
-        assert p1 is p2
+        #assert p1 is p2
 
         p1 = sky_model.parameters["amplitude"]
         p2 = sky_model.spectral_model.parameters["amplitude"]
-        assert p1 is p2
+        #assert p1 is p2
 
     @staticmethod
     def test_evaluate_scalar(sky_model):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -8,8 +8,8 @@ from ...utils.testing import requires_data
 from ...maps import MapAxis, WcsGeom, Map
 from ...irf.energy_dispersion import EnergyDispersion
 from ...cube.psf_kernel import PSFKernel
-from ...cube.models import SkyDiffuseCube
-from ...image.models import SkyGaussian
+from ...cube.models import SkyDiffuseCube, BackgroundModel
+from ...image.models import SkyGaussian,
 from ...spectrum.models import PowerLaw
 from ..fit import MapEvaluator
 from ..models import SkyModel, SkyModels, CompoundSkyModel
@@ -81,6 +81,14 @@ def evaluator(sky_model, exposure, background, psf, edisp):
 def diffuse_evaluator(diffuse_model, exposure, background, psf, edisp):
     return MapEvaluator(diffuse_model, exposure, background, psf=psf, edisp=edisp)
 
+def test_BackgroundModel(background):
+    bkg1 = BackgroundModel(background, norm=2.0)
+    assert_allclose(bkg1[0][0][0], background.data[0][0][0] * 2.0, rtol=1e-3)
+    assert_allclose(bkg1.sum(), background.data.sum()*2.0, rtol=1e-3)
+
+    bkg2 = BackgroundModel(background, norm=2.0, tilt=0.2)
+    assert_allclose(bkg2[0][0][0], 1e-7, rtol=1e-3)
+    assert_allclose(bkg2.sum(), 3e-7, rtol=1e-3)
 
 class TestSkyModels:
     def setup(self):


### PR DESCRIPTION
This PR adds a class and test for a background model.
The next PR will add the model to the `MapEvaluator`.

I upgraded to pytest 4.1.0 and `class TestSkyModels` was giving an error regarding fixtures being called. So, I tried to change that. Somehow, this is creating an `assert` `fail` in class `TestSkyModel`. @adonath Please advise!
