### PR TITLE
Improve output units of spectral models

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -42,7 +42,10 @@ class SpectralModel(Model):
         """Call evaluate method of derived classes"""
         kwargs = dict()
         for par in self.parameters.parameters:
-            kwargs[par.name] = par.quantity
+            quantity = par.quantity
+            if par.name in ["reference", "emin", "emax", "ecut"]:
+                quantity = quantity.to(energy.unit)
+            kwargs[par.name] = quantity
 
         return self.evaluate(energy, **kwargs)
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -43,7 +43,7 @@ class SpectralModel(Model):
         kwargs = dict()
         for par in self.parameters.parameters:
             quantity = par.quantity
-            if par.name in ["reference", "emin", "emax", "ecut"]:
+            if quantity.unit.physical_type == "energy":
                 quantity = quantity.to(energy.unit)
             kwargs[par.name] = quantity
 

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -229,6 +229,12 @@ def test_models(spectrum):
     assert_quantity_allclose(val[0], spectrum["val_at_2TeV"])
 
 
+def test_model_unit():
+    pwl = PowerLaw()
+    value = pwl(500 * u.MeV)
+    assert value.unit == "cm-2 s-1 TeV-1"
+
+
 @requires_dependency("matplotlib")
 @requires_data("gammapy-extra")
 def test_table_model_from_file():


### PR DESCRIPTION
This PR fixes #869 by converting the reference energies to the energy unit given by the user before evaluation.  