### PR TITLE
Fix SourceCatalogHGPS.large_scale_component

### DIFF
--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -671,10 +671,8 @@ class SourceCatalogHGPS(SourceCatalog):
 
     @property
     def large_scale_component(self):
-        """Large scale component model (`~gammapy.catalog.SourceCatalogLargeScaleHGPS`).
-        """
-        table = self.table_large_scale_component
-        return SourceCatalogLargeScaleHGPS(table, spline_kwargs=dict(k=3, s=0, ext=0))
+        """Large scale component model (`~gammapy.catalog.SourceCatalogLargeScaleHGPS`)."""
+        return SourceCatalogLargeScaleHGPS(self.table_large_scale_component)
 
     def _make_source_object(self, index):
         """Make `SourceCatalogObject` for given row index"""

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -44,6 +44,10 @@ class TestSourceCatalogHGPS:
         c = cat.gaussian_component(83)
         assert c.name == "HGPSC 084"
 
+    @staticmethod
+    def test_large_scale_component(cat):
+        assert isinstance(cat.large_scale_component, SourceCatalogLargeScaleHGPS)
+
 
 @requires_data("gammapy-extra")
 class TestSourceCatalogObjectHGPS:


### PR DESCRIPTION
This PR is a fix for the issue mentioned at https://lgtm.com/projects/g/gammapy/gammapy/alerts/?mode=list
```
Keyword argument 'spline_kwargs' is not a supported parameter name of SourceCatalogLargeScaleHGPS.__init__. This alert was introduced in484fc362 months ago
```
(I don't see a way to create a permalink to LGTM)

Using the default interp should be fine. Alternatively we could also remove the possibility to customise interp there, i.e. remove the argument from `SourceCatalogLargeScaleHGPS.__init__` because it's not needed?