### PR TITLE
Add dev docs build on Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 
 variables:
   GAMMAPY_EXTRA: $(Agent.HomeDirectory)/gammapy-extra
-  GAMMAPY_DATA: $(Agent.HomeDirectory)/gammapy-extra/datasets
+  GAMMAPY_DATA: $(Agent.HomeDirectory)/gammapy-data
 
 jobs:
 
@@ -39,14 +39,22 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
+      pip install -e .
+      python -m gammapy info
+    displayName: 'Install Gammapy'
+
+  - script: |
+      gammapy download datasets --out=$(GAMMAPY_DATA)
+    displayName: 'Get GAMMAPY_DATA'
+
+  - script: |
+      # TODO: Is gammapy-extra even needed for docs build?
       # TODO: find a way to have smaller test data download to get faster CI builds
       # This currently downloads 294 MB, and the `datasets` folder in master has 133 MB
       git clone --depth 1 -b master https://github.com/gammapy/gammapy-extra.git $(GAMMAPY_EXTRA)
-    displayName: 'Get test data'
+    displayName: 'Get GAMMAPY_EXTRA'
 
   - script: |
-      pip install -e .
-      python -m gammapy info
       pytest gammapy --junitxml=junit/test-results.xml
     displayName: 'Run pytest'
 
@@ -56,8 +64,8 @@ jobs:
       testRunTitle: 'Python $(python.version)'
     condition: succeededOrFailed()
 
-# TODO: set this up using conda and our environment.yml
-- job: 'Dev Docs'
+
+- job: 'DevDocs'
   pool:
     vmImage: 'Ubuntu 16.04'
 
@@ -66,3 +74,39 @@ jobs:
     inputs:
       versionSpec: '3.x'
       architecture: 'x64'
+
+  - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
+    displayName: Add conda to PATH
+
+  - script: |
+      conda env create --file environment-dev.yml
+      source activate gammapy-dev
+      pip install -e .
+      gammapy info
+    displayName: 'Create gammapy-dev conda environment'
+
+  - script: |
+      source activate gammapy-dev
+      gammapy download datasets --out=$(GAMMAPY_DATA)
+    displayName: 'Get GAMMAPY_DATA'
+
+  - script: |
+      # TODO: Is gammapy-extra even needed for docs build?
+      # TODO: find a way to have smaller test data download to get faster CI builds
+      # This currently downloads 294 MB, and the `datasets` folder in master has 133 MB
+      git clone --depth 1 -b master https://github.com/gammapy/gammapy-extra.git $(GAMMAPY_EXTRA)
+    displayName: 'Get GAMMAPY_EXTRA'
+
+  - script: |
+      source activate gammapy-dev
+      python -m gammapy.utils.tutorials_process
+    displayName: 'Run tutorial Jupyter notebooks'
+
+  - script: |
+      source activate gammapy-dev
+      python setup.py build_docs
+    displayName: 'Run Sphinx documentation build'
+
+  - script: |
+      echo TODO
+    displayName: 'Push HTML to Github pages'


### PR DESCRIPTION
This PR adds a dev docs build on Azure pipelines, using a separate job and the a gammapy-dev conda env installation using conda.

This fixes the Azure pipelines build fails we currently have in Gammapy master, so I'm merging this.
I will implement that step to deploy the dev docs to Github pages shortly in a follow-up commit in master.

Related: #1241, #1876, #1886