### PR TITLE
Add pyyaml as core dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -181,7 +181,6 @@ script:
 
     - if $FETCH_GAMMAPY_DATA; then
           export GAMMAPY_DATA=${HOME}/gammapy-data;
-          pip install pyyaml;
           pip install .;
           gammapy download datasets --out=$GAMMAPY_DATA;
       fi

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -6,9 +6,6 @@ import astropy.units as u
 from ...utils.testing import requires_data, requires_dependency
 from ..hawc import SourceCatalog2HWC
 
-# 2HWC catalog is in ECSV format, which requires yaml to read the header
-pytest.importorskip("yaml")
-
 
 @pytest.fixture(scope="session")
 def hawc_2hwc():

--- a/gammapy/catalog/tests/test_registry.py
+++ b/gammapy/catalog/tests/test_registry.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data
 from ..registry import SourceCatalogRegistry
 from ..gammacat import SourceCatalogGammaCat
 from .test_core import make_test_catalog
@@ -15,8 +15,6 @@ def source_catalogs():
     return cats
 
 
-# 2HWC catalog is in ECSV format, which requires yaml to read the header
-@requires_dependency("yaml")
 @requires_data("gammapy-extra")
 def test_info_table(source_catalogs):
     table = source_catalogs.info_table

--- a/gammapy/scripts/setup_package.py
+++ b/gammapy/scripts/setup_package.py
@@ -1,6 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-
-def get_package_data():
-    files = ["data_browser/templates/*", "data_browser/static/*", "*.yaml"]
-    return {"gammapy.scripts": files}

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import pytest
 from ...extern.pathlib import Path
-from ...utils.testing import requires_dependency, run_cli
+from ...utils.testing import run_cli
 from ..main import cli
 
 
@@ -16,7 +16,6 @@ def test_cli_download_help():
     assert "Usage" in result.output
 
 
-@requires_dependency("yaml")
 @pytest.mark.remote_data
 def test_cli_download_datasets(files_dir):
     dataset = "ebl"
@@ -30,7 +29,6 @@ def test_cli_download_datasets(files_dir):
     assert path.exists()
 
 
-@requires_dependency("yaml")
 @pytest.mark.remote_data
 def test_cli_download_notebooks(files_dir):
     release = "0.8"

--- a/gammapy/spectrum/results.py
+++ b/gammapy/spectrum/results.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import absolute_import, division, print_function, unicode_literals
+import yaml
 import numpy as np
 from astropy.table import Table, Column
 import astropy.units as u
@@ -84,8 +85,6 @@ class SpectrumFitResult(object):
         mode : str
             Write mode
         """
-        import yaml
-
         d = self.to_dict()
         val = yaml.safe_dump(d, default_flow_style=False)
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -160,7 +160,6 @@ def flux_points_likelihood():
     return FluxPoints.read(path).to_sed_type("dnde")
 
 
-@requires_dependency("yaml")
 @requires_data("gammapy-extra")
 class TestFluxPoints:
     def test_info(self, flux_points):

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -61,7 +61,6 @@ class TestSpectrumFitResult:
         assert "PowerLaw" in str(fit_result)
         assert "index" in fit_result.to_table().colnames
 
-    @requires_dependency("yaml")
     def test_io(self, tmpdir, fit_result):
         filename = tmpdir / "test.yaml"
         fit_result.to_yaml(filename)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -91,7 +91,6 @@ def test_lightcurve_properties_flux(lc):
     sys.version_info >= (3, 7),
     reason="https://github.com/astropy/astropy/issues/7744#issuecomment-419813519",
 )
-@requires_dependency("yaml")
 @pytest.mark.parametrize("format", ["fits", "ascii.ecsv", "ascii.csv"])
 def test_lightcurve_read_write(tmpdir, lc, format):
     filename = str(tmpdir / "spam")

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import sys
 import logging
+import yaml
 from os.path import expandvars
 from ..extern.pathlib import Path
 
@@ -51,8 +52,6 @@ def read_yaml(filename, logger=None):
     filename : `~gammapy.extern.pathlib.Path`, str
         File to read
     """
-    import yaml
-
     filename = make_path(filename)
     if logger is not None:
         logger.info("Reading {}".format(filename))
@@ -72,8 +71,6 @@ def write_yaml(dictionary, filename, logger=None):
     filename : str, `~gammapy.exter.pathlib.Path`
         file to write
     """
-    import yaml
-
     filename = make_path(filename)
     filename.parent.mkdir(exist_ok=True)
     if logger is not None:

--- a/gammapy/utils/tutorials_test.py
+++ b/gammapy/utils/tutorials_test.py
@@ -3,6 +3,7 @@ import os
 import sys
 import logging
 from pkg_resources import working_set
+import yaml
 from ..extern.pathlib import Path
 from ..scripts.jupyter import notebook_test
 
@@ -11,7 +12,6 @@ log = logging.getLogger(__name__)
 
 def get_notebooks():
     """Read `notebooks.yaml` info."""
-    import yaml
     path = Path("tutorials") / "notebooks.yaml"
     with path.open() as fh:
         return yaml.safe_load(fh)

--- a/setup.py
+++ b/setup.py
@@ -108,11 +108,11 @@ setup(
       'astropy>=2.0',
       'scipy>=0.15',
       'regions>=0.3',
+      'pyyaml',
       'click',
     ],
     extras_require=dict(
       analysis=[
-          'pyyaml',
           'reproject',
           'uncertainties>=2.4',
           'naima',


### PR DESCRIPTION
This PR adds `pyyaml` as a core dependency of Gammapy.

In practice this means that we list `pyyaml` in `install_requires` in `setup.py`, and that `pip install gammapy` will always install `pyyaml` automatically as a dependency if it isn't already present.

We currently mostly use YAML to read ECSV files, as well as for the `gammapy download` functionality. We already use it for model serialisation a bit, and plan to use it more extensively in the future (xref #329). Very likely YAML will be used in the high-level Gammapy interface as config file format (and for model serialisation), so really the vast majority of users will need it. Fermipy does already use it, so this is not adding an extra dependency for them.

The changes here are similar to what @adonath did when we made Scipy a core dependency in #1919 - mostly moving imports to the top and removing a few `requires_dependency` decorators on tests. I plan to mention this clearly in the changelog, but in a follow-up PR.
