### PR TITLE
Fix Numpy dev build on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,6 @@ matrix:
         # Test with other numpy versions
         - os: linux
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
       - texlive-latex-extra
       - dvipng
       - gfortran
-      # gcc added to fix the Numpy dev build: https://github.com/gammapy/gammapy/pull/1997#issuecomment-456793025
-      - gcc
 
 env:
     global:
@@ -126,8 +124,6 @@ matrix:
                TEST_FERMIPY=true
 
         # Test with other numpy versions
-        - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ addons:
       - texlive-latex-extra
       - dvipng
       - gfortran
+      # gcc added to fix the Numpy dev build: https://github.com/gammapy/gammapy/pull/1997#issuecomment-456793025
+      - gcc
 
 env:
     global:
@@ -125,7 +127,7 @@ matrix:
 
         # Test with other numpy versions
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V' NPY_DISTUTILS_APPEND_FLAGS=1
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V'
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
         - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
 
         # Test with other numpy versions
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=dev SETUP_CMD='test -V' NPY_DISTUTILS_APPEND_FLAGS=1
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=prerelease SETUP_CMD='test -V'
         - os: linux


### PR DESCRIPTION
This is an attempt to fix the Numpy dev build on travis-ci.

I think the issue might be that `conda install libgfortran` is missing, so no Fortran and Numpy build gives Fortran-related linker errors: https://travis-ci.org/gammapy/gammapy/jobs/482838855#L1597
