### PR TITLE
Modify spectum.sensitivity to use a CountsSpectrum as input background model

### DIFF
--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -20,7 +20,7 @@ class SensitivityEstimator(object):
         1D effective area
     rmf : `~gammapy.irf.EnergyDispersion`
         energy dispersion table
-    bkg : `~gammapy.utils.NDDataArray`
+    bkg : `~gammapy.spectrum.CountsSpectrum`
         the background array
     livetime : `~astropy.units.Quantity`
         Livetime (object with the units of time), e.g. 5*u.h
@@ -93,7 +93,7 @@ class SensitivityEstimator(object):
         # then integrate bkg model and gamma over those energy bins.
         energy = self.rmf.e_reco.log_center()
 
-        bkg_counts = (self.bkg.data * self.livetime).value
+        bkg_counts = (self.bkg.data.data * self.livetime).value
 
         excess_counts = excess_matching_significance_on_off(
             n_off=bkg_counts / self.alpha, alpha=self.alpha, significance=self.sigma

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -5,6 +5,9 @@ from numpy.testing import assert_allclose
 import numpy as np
 import astropy.units as u
 from ...utils.testing import requires_data
+from gammapy.utils.testing import requires_data
+from gammapy.utils.nddata import NDDataArray
+from gammapy.irf import EffectiveAreaTable, EnergyDispersion
 from ..sensitivity import SensitivityEstimator
 
 

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -5,9 +5,8 @@ from numpy.testing import assert_allclose
 import numpy as np
 import astropy.units as u
 from ...utils.testing import requires_data
-from gammapy.utils.testing import requires_data
-from gammapy.utils.nddata import NDDataArray
-from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from ...irf import EffectiveAreaTable, EnergyDispersion
+from ..core import CountsSpectrum
 from ..sensitivity import SensitivityEstimator
 
 
@@ -25,7 +24,7 @@ def sens():
 
     bkg_array = np.ones(4)/u.s
     bkg_array[-1] = 1e-3/u.s
-    bkg = NDDataArray([rmf.data.axis("e_reco")], data=bkg_array)
+    bkg = CountsSpectrum(energy_lo=ereco[:-1], energy_hi=ereco[1:], data=bkg_array)
 
     sens = SensitivityEstimator(arf=arf, rmf=rmf, bkg=bkg, livetime=1 * u.h, slope=2, gamma_min=20, alpha=0.2)
     sens.run()

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -41,25 +41,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'CTAPerf'",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-b9f53885d5c3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mgammapy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mirf\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mCTAPerf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mgammapy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspectrum\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mSensitivityEstimator\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mImportError\u001b[0m: cannot import name 'CTAPerf'"
-     ],
-     "output_type": "error"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from astropy.coordinates import Angle\n",
-    "from gammapy.spectrum import SensitivityEstimator\n",
-    "from gammapy.irf import load_cta_irfs"
+    "from gammapy.irf import CTAPerf\n",
+    "from gammapy.spectrum import SensitivityEstimator"
    ]
   },
   {
@@ -73,50 +60,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'CTAPerf' is not defined",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-3-b41a41c65272>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mfilename\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mirf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mCTAPerf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'CTAPerf' is not defined"
-     ],
-     "output_type": "error"
-    }
-   ],
-   "source": [
-    "filename = \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
-    "irfs = load_cta_irfs(filename)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Extract reduced IRFs\n",
-    "\n",
-    "We extract from the full 3D IRFs the relevant effective area and energy dispersion at the specific offset we are interested in."
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "offset = Angle(\"0.7 deg\")\n",
-    "arf = irfs['aeff'].to_effective_area_table(offset)\n",
-    "rmf = irfs['edisp'].to_energy_dispersion(offset)"
+    "filename = \"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\n",
+    "irf = CTAPerf.read(filename)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -129,21 +79,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'SensitivityEstimator' is not defined",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-6e82811d30c1>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msensitivity_estimator\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSensitivityEstimator\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mirf\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mirf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlivetime\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"5h\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0msensitivity_estimator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'SensitivityEstimator' is not defined"
-     ],
-     "output_type": "error"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sensitivity_estimator = SensitivityEstimator(irf=irf, livetime=\"5h\")\n",
     "sensitivity_estimator.run()"
@@ -160,21 +98,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'sensitivity_estimator' is not defined",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-5-4efcdd92d4bb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Show the results table\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0msensitivity_estimator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresults_table\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m: name 'sensitivity_estimator' is not defined"
-     ],
-     "output_type": "error"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Show the results table\n",
     "sensitivity_estimator.results_table"
@@ -182,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,21 +118,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'sensitivity_estimator' is not defined",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-1c25fd00268d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Plot the sensitivity curve\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mt\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msensitivity_estimator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresults_table\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mis_s\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mt\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"criterion\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"significance\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m plt.plot(\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'sensitivity_estimator' is not defined"
-     ],
-     "output_type": "error"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Plot the sensitivity curve\n",
     "t = sensitivity_estimator.results_table\n",
@@ -243,7 +157,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": []

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -41,12 +41,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'CTAPerf'",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-b9f53885d5c3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mgammapy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mirf\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mCTAPerf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mgammapy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mspectrum\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mSensitivityEstimator\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'CTAPerf'"
+     ],
+     "output_type": "error"
+    }
+   ],
    "source": [
-    "from gammapy.irf import CTAPerf\n",
-    "from gammapy.spectrum import SensitivityEstimator"
+    "from astropy.coordinates import Angle\n",
+    "from gammapy.spectrum import SensitivityEstimator\n",
+    "from gammapy.irf import load_cta_irfs"
    ]
   },
   {
@@ -60,13 +73,50 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'CTAPerf' is not defined",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-3-b41a41c65272>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mfilename\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mirf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mCTAPerf\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'CTAPerf' is not defined"
+     ],
+     "output_type": "error"
+    }
+   ],
+   "source": [
+    "filename = \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    "irfs = load_cta_irfs(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extract reduced IRFs\n",
+    "\n",
+    "We extract from the full 3D IRFs the relevant effective area and energy dispersion at the specific offset we are interested in."
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\n",
-    "irf = CTAPerf.read(filename)"
+    "offset = Angle(\"0.7 deg\")\n",
+    "arf = irfs['aeff'].to_effective_area_table(offset)\n",
+    "rmf = irfs['edisp'].to_energy_dispersion(offset)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -79,9 +129,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'SensitivityEstimator' is not defined",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-6e82811d30c1>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msensitivity_estimator\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSensitivityEstimator\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mirf\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mirf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlivetime\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"5h\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0msensitivity_estimator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'SensitivityEstimator' is not defined"
+     ],
+     "output_type": "error"
+    }
+   ],
    "source": [
     "sensitivity_estimator = SensitivityEstimator(irf=irf, livetime=\"5h\")\n",
     "sensitivity_estimator.run()"
@@ -98,9 +160,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'sensitivity_estimator' is not defined",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-4efcdd92d4bb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Show the results table\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0msensitivity_estimator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresults_table\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'sensitivity_estimator' is not defined"
+     ],
+     "output_type": "error"
+    }
+   ],
    "source": [
     "# Show the results table\n",
     "sensitivity_estimator.results_table"
@@ -108,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,9 +192,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'sensitivity_estimator' is not defined",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-1c25fd00268d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Plot the sensitivity curve\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mt\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msensitivity_estimator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresults_table\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mis_s\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mt\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"criterion\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"significance\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m plt.plot(\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'sensitivity_estimator' is not defined"
+     ],
+     "output_type": "error"
+    }
+   ],
    "source": [
     "# Plot the sensitivity curve\n",
     "t = sensitivity_estimator.results_table\n",
@@ -157,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
This PR is replacing the dependency of `SensitivityEstimator` on the old `CTAPerf` object. The `EffectiveAreaTable` (e.g. `arf`), the `EnergyDispersion` (e.g. `rmf`) are explicitly passed. The background model is passed as a `CountsSpectrum` for now. In the future, a `SpectralBackgroundModel` should be used instead once it is correctly implemented in the `Datasets` framework.
This should solve #1517 .

The modified cta_sensitivity notebook will come in another PR (to solve issue #1943 and #1824  ).