### PR TITLE
Corrected cta_simulation notebook working with prod 3 IRFs

### DIFF
--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "offset = Angle(\"0.5 deg\")\n",
     "\n",
-    "energy_reco = np.logspace(-1.8, 1.5, 30) * u.TeV\n",
+    "energy_reco = np.logspace(-1.8, 1.5, 20) * u.TeV\n",
     "energy_true = np.logspace(-2, 2, 100) * u.TeV"
    ]
   },
@@ -161,7 +161,8 @@
    "source": [
     "## Compute sensitivity\n",
     "\n",
-    "Choose a few parameters, then run the sentitivity computation."
+    "We impose a minimal number of expected signal counts of 5 per bin and a minimal significance of 3 per bin. We assume an alpha of 0.2 (ratio between ON and OFF area).\n",
+    "We then run the sensitivity estimator."
    ]
   },
   {
@@ -171,7 +172,7 @@
    "outputs": [],
    "source": [
     "sensitivity_estimator = SensitivityEstimator(\n",
-    "    arf=arf, rmf=rmf, bkg=bkg, livetime=\"5h\"\n",
+    "    arf=arf, rmf=rmf, bkg=bkg, livetime=\"5h\", gamma_min=5, sigma=3, alpha=0.2\n",
     ")\n",
     "sensitivity_table = sensitivity_estimator.run()"
    ]
@@ -182,7 +183,8 @@
    "source": [
     "## Results\n",
     "\n",
-    "The results are given as an Astropy table."
+    "The results are given as an Astropy table. A column criterion allows to distinguish bins where the significance is limited by the signal statistical significance from bins where the sensitivity is limited by the number of signal counts.\n",
+    "This is visible in the plot below."
    ]
   },
   {
@@ -232,6 +234,37 @@
     "plt.xlabel(\"Energy ({})\".format(t[\"energy\"].unit))\n",
     "plt.ylabel(\"Sensitivity ({})\".format(t[\"e2dnde\"].unit))\n",
     "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We add some control plots showing the expected number of background counts per bin and the ON region size cut (here the 68% containment radius of the PSF)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot expected number of counts for signal and background\n",
+    "fig, ax1 = plt.subplots()\n",
+    "# ax1.plot( t[\"energy\"], t[\"excess\"],\"o-\", color=\"red\", label=\"signal\")\n",
+    "ax1.plot(\n",
+    "    t[\"energy\"], t[\"background\"], \"o-\", color=\"black\", label=\"blackground\"\n",
+    ")\n",
+    "\n",
+    "ax1.loglog()\n",
+    "ax1.set_xlabel(\"Energy ({})\".format(t[\"energy\"].unit))\n",
+    "ax1.set_ylabel(\"Expected number of bkg counts\")\n",
+    "\n",
+    "ax2 = ax1.twinx()\n",
+    "ax2.set_ylabel(\"ON region radius ({})\".format(on_radii.unit), color=\"red\")\n",
+    "ax2.semilogy(t[\"energy\"], on_radii, color=\"red\", label=\"PSF68\")\n",
+    "ax2.tick_params(axis=\"y\", labelcolor=\"red\")\n",
+    "ax2.set_ylim(0.01, 0.5)"
    ]
   },
   {

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Computation of the CTA sensitivity"
+    "# Estimation of the CTA point source sensitivity"
    ]
   },
   {
@@ -13,11 +13,12 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "This notebook explains how to derive the CTA sensitivity for a point-like IRF at a fixed zenith angle and fixed offset. The significativity is computed for the 1D analysis (On-OFF regions) and the LiMa formula.\n",
+    "This notebook explains how to estimate the CTA sensitivity for a point-like IRF at a fixed zenith angle and fixed offset using the full containement IRFs distributed for the CTA 1DC. The significativity is computed for a 1D analysis (On-OFF regions) and the LiMa formula. \n",
     "\n",
-    "We will be using the following Gammapy classes:\n",
+    "We use here an approximate approach with an energy dependent integration radius to take into account the variation of the PSF. We will first determine the 1D IRFs including a containment correction. \n",
     "\n",
-    "* gammapy.irf.CTAIrf\n",
+    "We will be using the following Gammapy class:\n",
+    "\n",
     "* [gammapy.spectrum.SensitivityEstimator](https://docs.gammapy.org/dev/api/gammapy.spectrum.SensitivityEstimator.html)"
    ]
   },
@@ -45,17 +46,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from gammapy.irf import CTAPerf\n",
-    "from gammapy.spectrum import SensitivityEstimator"
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import Angle\n",
+    "from gammapy.irf import load_cta_irfs\n",
+    "from gammapy.spectrum import SensitivityEstimator, CountsSpectrum"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load IRFs\n",
+    "## Define analysis region and energy binning\n",
     "\n",
-    "First load the CTA IRFs."
+    "Here we assume a source at 0.7 degree from pointing position. We perform a simple energy independent extraction for now with a radius of 0.1 degree."
    ]
   },
   {
@@ -64,8 +68,91 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_EXTRA/datasets/cta/perf_prod2/point_like_non_smoothed/South_5h.fits.gz\"\n",
-    "irf = CTAPerf.read(filename)"
+    "offset = Angle(\"0.5 deg\")\n",
+    "\n",
+    "energy_reco = np.logspace(-1.8, 1.5, 30) * u.TeV\n",
+    "energy_true = np.logspace(-2, 2, 100) * u.TeV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load IRFs\n",
+    "\n",
+    "We extract the 1D IRFs from the full 3D IRFs provided by CTA. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = (\n",
+    "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    ")\n",
+    "irfs = load_cta_irfs(filename)\n",
+    "arf = irfs[\"aeff\"].to_effective_area_table(offset, energy=energy_true)\n",
+    "rmf = irfs[\"edisp\"].to_energy_dispersion(\n",
+    "    offset, e_true=energy_true, e_reco=energy_reco\n",
+    ")\n",
+    "psf = irfs[\"psf\"].to_energy_dependent_table_psf(theta=offset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Determine energy dependent integration radius\n",
+    "\n",
+    "Here we will determine an integration radius that varies with the energy to ensure a constant fraction of flux enclosure (e.g. 68%). We then apply the fraction to the effective area table.\n",
+    "\n",
+    "By doing so we implicitly assume that energy dispersion has a neglible effect. This should be valid for large enough energy reco bins as long as the bias in the energy estimation is close to zero."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "containment = 0.68\n",
+    "energies = np.sqrt(energy_reco[1:] * energy_reco[:-1])\n",
+    "on_radii = psf.containment_radius(energies=energies, fraction=containment)\n",
+    "solid_angles = 2 * np.pi * (1 - np.cos(on_radii)) * u.sr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "arf.data.data *= containment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimate background \n",
+    "\n",
+    "We now provide a workaround to estimate the background from the tabulated IRF in the energy bins we consider.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bkg_data = irfs[\"bkg\"].evaluate_integrate(\n",
+    "    fov_lon=0 * u.deg, fov_lat=offset, energy_reco=energy_reco\n",
+    ")\n",
+    "bkg = CountsSpectrum(\n",
+    "    energy_reco[:-1], energy_reco[1:], data=(bkg_data * solid_angles)\n",
+    ")"
    ]
   },
   {
@@ -83,8 +170,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sensitivity_estimator = SensitivityEstimator(irf=irf, livetime=\"5h\")\n",
-    "sensitivity_estimator.run()"
+    "sensitivity_estimator = SensitivityEstimator(\n",
+    "    arf=arf, rmf=rmf, bkg=bkg, livetime=\"5h\"\n",
+    ")\n",
+    "sensitivity_table = sensitivity_estimator.run()"
    ]
   },
   {
@@ -103,7 +192,7 @@
    "outputs": [],
    "source": [
     "# Show the results table\n",
-    "sensitivity_estimator.results_table"
+    "sensitivity_table"
    ]
   },
   {
@@ -113,7 +202,7 @@
    "outputs": [],
    "source": [
     "# Save it to file (could use e.g. format of CSV or ECSV or FITS)\n",
-    "# sensitivity_estimator.results_table.write('sensitivity.ecsv', format='ascii.ecsv')"
+    "# sensitivity_table.write('sensitivity.ecsv', format='ascii.ecsv')"
    ]
   },
   {


### PR DESCRIPTION
This PR adapt to the new `SensitivityEstimator` API introduced in #1998 . It provides an approach to estimate the sensitivity with the full enclosure IRFs distributed with the CTA 1DC and shipped in gammapy datasets. This solves issues #1824 and #1943 .
