### PR TITLE
SensitivityEstimator correction to limit bin size effects

### DIFF
--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -100,8 +100,8 @@ class SensitivityEstimator(object):
         counts = predictor.npred.data.data.value
         phi_0 = excess_counts / counts
 
-        dnde_model = model(energy=energy)
-        diff_flux = (phi_0 * dnde_model * energy ** 2).to("erg / (cm2 s)")
+        flux_model = model.integral(emin=self.rmf.e_reco.lo, emax=self.rmf.e_reco.hi)
+        diff_flux = (phi_0 * flux_model*energy).to("erg / (cm2 s)")
 
         # TODO: take self.bkg_sys into account
         # and add a criterion 'bkg sys'

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -42,14 +42,14 @@ def test_cta_sensitivity_estimator(sens):
 
     row = table[0]
     assert_allclose(row["energy"], 1.33352, rtol=1e-3)
-    assert_allclose(row["e2dnde"], 3.40101e-11, rtol=1e-3)
+    assert_allclose(row["e2dnde"], 1.985e-11, rtol=1e-3)
     assert_allclose(row["excess"], 334.454, rtol=1e-3)
     assert_allclose(row["background"], 3600, rtol=1e-3)
     assert row["criterion"] == "significance"
 
     row = table[3]
     assert_allclose(row["energy"], 7.49894, rtol=1e-3)
-    assert_allclose(row["e2dnde"], 1.14367e-11, rtol=1e-3)
+    assert_allclose(row["e2dnde"], 6.6748e-12, rtol=1e-3)
     assert_allclose(row["excess"], 20, rtol=1e-3)
     assert_allclose(row["background"], 3.6, rtol=1e-3)
     assert row["criterion"] == "gamma"


### PR DESCRIPTION
This small PR is a fix to the issue of bin size when estimating sensitivity with the `SensitivityEstimator`.  It replaces the E**2 dN/dE with energy times integral flux over bin.  
This should be better @jjlk no?