### PR TITLE
Improve test_statistics test code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,9 @@ matrix:
 
         # The main build that's used for coverage measurement
         - os: linux
-          env: PYTHON_VERSION=3.7 SETUP_CMD='test -V --coverage'
+          # TODO: do we need html output? Or whould we set `--junitxml=somefile.xml`?
+          env: PYTHON_VERSION=3.7 COVERAGE_BUILD=true
+               MAIN_CMD='python -m pytest gammapy --cov=gammapy --cov-report=html'
 
         # Run tests without optional dependencies
         - os: linux
@@ -191,6 +193,6 @@ script:
       fi
 
 after_success:
-    - if [[ $SETUP_CMD == 'test -V --coverage' ]]; then
+    - if $COVERAGE_BUILD; then
           coveralls --rcfile='gammapy/tests/coveragerc';
       fi


### PR DESCRIPTION
@adonath - The test coverage for `gammapy/detect/test_statistics.py` is now only 49% :
https://coveralls.io/builds/18247864/source?filename=gammapy%2Fdetect%2Ftest_statistics.py

Can you please make this better?
(remove unused code, or add one test exercising most of the code if needed)