### PR TITLE
Make apply_containment_fraction a stand-alone function

### DIFF
--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -164,22 +164,13 @@ def apply_containment_fraction(aeff, psf, radius):
         the output corrected 1D effective area
     """
     center_energies = aeff.energy.nodes
-    containment = []
-    for energy in center_energies:
-        try:
-            cont_ = psf.integral(energy, 0.0 * u.deg, radius)
-        except:
-            msg = "Containment correction failed for bin {}, energy {}."
-            log.warning(msg.format(index, energy))
-            cont_ = 1
 
-        containment.append(cont_)
+    containment = psf.containment(center_energies, radius)
 
-    containment = np.array(containment)
     corrected_aeff = EffectiveAreaTable(
         aeff.energy.lo,
         aeff.energy.hi,
-        data=aeff.data.data * containment,
+        data=aeff.data.data * np.squeeze(containment),
         meta=aeff.meta,
     )
     return corrected_aeff

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -9,6 +9,7 @@ __all__ = ["make_psf", "make_mean_psf", "make_mean_edisp", "apply_containment_fr
 
 log = logging.getLogger(__name__)
 
+
 def make_psf(observation, position, energy=None, rad=None):
     """Make energy-dependent PSF for a given source position.
 

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -5,7 +5,7 @@ import astropy.units as u
 from ..utils.energy import Energy
 from . import PSF3D, EnergyDependentTablePSF, IRFStacker, EffectiveAreaTable
 
-__all__ = ["make_psf", "make_mean_psf", "make_mean_edisp"]
+__all__ = ["make_psf", "make_mean_psf", "make_mean_edisp", "apply_containment_fraction"]
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -1,9 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import logging
+import numpy as np
+import astropy.units as u
 from ..utils.energy import Energy
-from . import EnergyDependentTablePSF, IRFStacker
+from . import PSF3D, EnergyDependentTablePSF, IRFStacker, EffectiveAreaTable
 
 __all__ = ["make_psf", "make_mean_psf", "make_mean_edisp"]
 
+log = logging.getLogger(__name__)
 
 def make_psf(observation, position, energy=None, rad=None):
     """Make energy-dependent PSF for a given source position.
@@ -142,6 +146,8 @@ def make_mean_edisp(
 def apply_containment_fraction(aeff, psf, radius):
     """ Estimate PSF containment inside a given radius and correct effective area for leaking flux.
 
+    The PSF and effective area must have the same binning in energy.
+
     Parameters
     ----------
     aeff : `~gammapy.irf.EffectiveAreaTable`
@@ -169,7 +175,6 @@ def apply_containment_fraction(aeff, psf, radius):
             containment.append(cont_)
 
     containment = np.array(containment)
-
     corrected_aeff = EffectiveAreaTable(
         aeff.energy.lo,
         aeff.energy.hi,

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -153,7 +153,7 @@ def apply_containment_fraction(aeff, psf, radius):
     ----------
     aeff : `~gammapy.irf.EffectiveAreaTable`
         the input 1D effective area
-    psf : `~gammapy.irf.EnergyDependentPSFTable`
+    psf : `~gammapy.irf.EnergyDependentTablePSF`
         the input 1D PSF
     radius : `~astropy.coordinates.Angle`
         the maximum angle
@@ -165,15 +165,15 @@ def apply_containment_fraction(aeff, psf, radius):
     """
     center_energies = aeff.energy.nodes
     containment = []
-    for index, energy in enumerate(center_energies):
+    for energy in center_energies:
         try:
             cont_ = psf.integral(energy, 0.0 * u.deg, radius)
         except:
             msg = "Containment correction failed for bin {}, energy {}."
             log.warning(msg.format(index, energy))
             cont_ = 1
-        finally:
-            containment.append(cont_)
+
+        containment.append(cont_)
 
     containment = np.array(containment)
     corrected_aeff = EffectiveAreaTable(

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -163,6 +163,6 @@ def test_apply_containment_fraction():
     )
 
     new_aeff = apply_containment_fraction(aeff, edep_psf_table, Angle("0.1 deg"))
-    print(new_aeff)
+
     assert_allclose(new_aeff.data.data.value, 1.0)
     assert new_aeff.data.data.unit == "m2"

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -155,8 +155,8 @@ def test_apply_containment_fraction():
     rad = Angle(np.linspace(0, 0.5, nrad), "deg")
     psf_table = TablePSF.from_shape(shape="disk", width="0.2 deg", rad=rad)
     psf_values = (
-        np.resize(psf_table._dp_domega.value, (n_edges_energy, nrad))
-        * psf_table._dp_domega.unit
+        np.resize(psf_table.psf_value.value, (n_edges_energy, nrad))
+        * psf_table.psf_value.unit
     )
     edep_psf_table = EnergyDependentTablePSF(
         aeff.energy.nodes, rad, psf_value=psf_values
@@ -164,5 +164,5 @@ def test_apply_containment_fraction():
 
     new_aeff = apply_containment_fraction(aeff, edep_psf_table, Angle("0.1 deg"))
 
-    assert_allclose(new_aeff.data.data.value, 1.0)
+    assert_allclose(new_aeff.data.data.value, 1.0, rtol=5e-4)
     assert new_aeff.data.data.unit == "m2"

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -4,7 +4,12 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import Angle, SkyCoord
 import astropy.units as u
-from ..irf_reduce import make_psf, make_mean_psf, make_mean_edisp, apply_containment_fraction
+from ..irf_reduce import (
+    make_psf,
+    make_mean_psf,
+    make_mean_edisp,
+    apply_containment_fraction,
+)
 from ..effective_area import EffectiveAreaTable
 from ..psf_table import EnergyDependentTablePSF, TablePSF
 from ...data import DataStore, Observations
@@ -139,19 +144,25 @@ def test_make_mean_edisp(data_store):
     i2 = np.where(rmf2.data.evaluate(e_reco=Energy(40, "TeV")) != 0)[0]
     assert_equal(i, i2)
 
+
 def test_apply_containment_fraction():
     n_edges_energy = 5
-    energy = EnergyBounds.equal_log_spacing(0.1, 10.,nbins=n_edges_energy, unit="TeV")
-    area = np.ones(n_edges_energy)*4*u.m**2
+    energy = EnergyBounds.equal_log_spacing(0.1, 10.0, nbins=n_edges_energy, unit="TeV")
+    area = np.ones(n_edges_energy) * 4 * u.m ** 2
     aeff = EffectiveAreaTable(energy.lower_bounds, energy.upper_bounds, data=area)
 
     nrad = 100
-    rad = Angle(np.linspace(0, 0.5, nrad), 'deg')
-    psf_table = TablePSF.from_shape(shape='disk', width='0.2 deg',rad=rad)
-    psf_values = np.resize(psf_table._dp_domega.value,(n_edges_energy,nrad))*psf_table._dp_domega.unit
-    edep_psf_table = EnergyDependentTablePSF(aeff.energy.nodes,rad,psf_value=psf_values)
+    rad = Angle(np.linspace(0, 0.5, nrad), "deg")
+    psf_table = TablePSF.from_shape(shape="disk", width="0.2 deg", rad=rad)
+    psf_values = (
+        np.resize(psf_table._dp_domega.value, (n_edges_energy, nrad))
+        * psf_table._dp_domega.unit
+    )
+    edep_psf_table = EnergyDependentTablePSF(
+        aeff.energy.nodes, rad, psf_value=psf_values
+    )
 
-    new_aeff = apply_containment_fraction(aeff, edep_psf_table, Angle('0.1 deg'))
+    new_aeff = apply_containment_fraction(aeff, edep_psf_table, Angle("0.1 deg"))
     print(new_aeff)
     assert_allclose(new_aeff.data.data.value, 1.0)
-    assert new_aeff.data.data.unit == 'm2'
+    assert new_aeff.data.data.unit == "m2"

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -3,7 +3,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy.coordinates import Angle, SkyCoord
-from ..irf_reduce import make_psf, make_mean_psf, make_mean_edisp
+import astropy.units as u
+from ..irf_reduce import make_psf, make_mean_psf, make_mean_edisp, apply_containment_fraction
+from ..effective_area import EffectiveAreaTable
+from ..psf_table import EnergyDependentTablePSF, TablePSF
 from ...data import DataStore, Observations
 from ...utils.testing import requires_data, assert_quantity_allclose
 from ...utils.energy import Energy, EnergyBounds
@@ -135,3 +138,20 @@ def test_make_mean_edisp(data_store):
     i = np.where(rmf.data.evaluate(e_reco=Energy(40, "TeV")) != 0)[0]
     i2 = np.where(rmf2.data.evaluate(e_reco=Energy(40, "TeV")) != 0)[0]
     assert_equal(i, i2)
+
+def test_apply_containment_fraction():
+    n_edges_energy = 5
+    energy = EnergyBounds.equal_log_spacing(0.1, 10.,nbins=n_edges_energy, unit="TeV")
+    area = np.ones(n_edges_energy)*4*u.m**2
+    aeff = EffectiveAreaTable(energy.lower_bounds, energy.upper_bounds, data=area)
+
+    nrad = 100
+    rad = Angle(np.linspace(0, 0.5, nrad), 'deg')
+    psf_table = TablePSF.from_shape(shape='disk', width='0.2 deg',rad=rad)
+    psf_values = np.resize(psf_table._dp_domega.value,(n_edges_energy,nrad))*psf_table._dp_domega.unit
+    edep_psf_table = EnergyDependentTablePSF(aeff.energy.nodes,rad,psf_value=psf_values)
+
+    new_aeff = apply_containment_fraction(aeff, edep_psf_table, Angle('0.1 deg'))
+    print(new_aeff)
+    assert_allclose(new_aeff.data.data.value, 1.0)
+    assert new_aeff.data.data.unit == 'm2'


### PR DESCRIPTION
Currently the only place where one can correct an `EffectiveAreaTable` for the fraction leaking outside an `EnergyDependentTablePSF` is in `SpectrumExtraction`. This functionality is nevertheless useful for other uses cases. For instance to compute a sensitivity from the full containment IRFs.
This PR introduces a new function in `irf.irf_reduce` that does this. It is now called in `SpectrumExtraction`.

