### PR TITLE
Add stacking method for PSFMap

### DIFF
--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -52,6 +52,7 @@ def make_psf_map(psf, pointing, geom, max_offset, exposure_map = None):
     # Re-order axes to be consistent with expected geometry
     psf_values = np.transpose(psf_values, axes=(2, 0, 1))
 
+    # TODO: this probably does not ensure that probability is properly normalized in the PSFMap
     # Create Map and fill relevant entries
     psfmap = Map.from_geom(geom, unit="sr-1")
     psfmap.data[:, :, valid[0], valid[1]] += psf_values.to_value(psfmap.unit)

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -57,11 +57,6 @@ def make_psf_map(psf, pointing, geom, max_offset, exposure_map=None):
     psfmap = Map.from_geom(geom, unit="sr-1")
     psfmap.data[:, :, valid[0], valid[1]] += psf_values.to_value(psfmap.unit)
 
-    if exposure_map is not None:
-        # First adapt geometry, keep only energy axis
-        if exposure_map.geom != geom.to_image().to_cube([energy_axis]):
-            raise ValueError("PSFMap and exposure_map have inconsistent geometries")
-
     return PSFMap(psfmap, exposure_map)
 
 
@@ -123,6 +118,12 @@ class PSFMap:
             raise ValueError("Incorrect theta axis position in input Map")
 
         self._psf_map = psf_map
+
+        if exposure_map is not None:
+            # First adapt geometry, keep only energy axis
+            expected_geom = psf_map.geom.to_image().to_cube([psf_map.geom.axes[1]])
+            if exposure_map.geom != expected_geom:
+                raise ValueError("PSFMap and exposure_map have inconsistent geometries")
 
         self._exposure_map = exposure_map
 
@@ -317,7 +318,8 @@ class PSFMap:
     def stack(self, other):
         """Stack PSFMap with another one.
 
-        This works only if the PSFMap to be stacked contain compatible exposure maps.
+        The current PSFMap is unchanged and a new one is created and returned.
+        For the moment, this works only if the PSFMap to be stacked contain compatible exposure maps.
 
         Parameters
         ----------

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -10,7 +10,7 @@ from ..cube import PSFKernel
 __all__ = ["make_psf_map", "PSFMap"]
 
 
-def make_psf_map(psf, pointing, geom, max_offset, exposure_map = None):
+def make_psf_map(psf, pointing, geom, max_offset, exposure_map=None):
     """Make a psf map for a single observation
 
     Expected axes : rad and true energy in this specific order
@@ -60,7 +60,10 @@ def make_psf_map(psf, pointing, geom, max_offset, exposure_map = None):
     if exposure_map is not None:
         # First adapt geometry, keep only energy axis
         if exposure_map.geom != geom.to_image().to_cube([energy_axis]):
-            raise(ValueError,"Inconsistent geometries between PSFMap and its associated exposure")
+            raise (
+                ValueError,
+                "Inconsistent geometries between PSFMap and its associated exposure",
+            )
 
     return PSFMap(psfmap, exposure_map)
 
@@ -166,7 +169,9 @@ class PSFMap:
         """Write the Map object containing the PSF Library map."""
         hdulist = self._psf_map.to_hdulist(hdu="PSFMAP", hdu_bands="BANDSPSF")
         if self._exposure_map is not None:
-            new_hdulist = self._exposure_map.to_hdulist(hdu="EXPMAP", hdu_bands="BANDSEXP")
+            new_hdulist = self._exposure_map.to_hdulist(
+                hdu="EXPMAP", hdu_bands="BANDSEXP"
+            )
             hdulist.append(new_hdulist["EXPMAP"])
             hdulist.append(new_hdulist["BANDSEXP"])
 
@@ -276,11 +281,17 @@ class PSFMap:
             the stacked psfmap
         """
         if self.exposure_map is None or other.exposure_map is None:
-            raise(ValueError, "Missing exposure map for PSFMap.stack")
+            raise (ValueError, "Missing exposure map for PSFMap.stack")
 
-        total_exposure = self.exposure_map+other.exposure_map
-        stacked_psf_quantity = self.quantity * self.exposure_map.quantity[:,np.newaxis,:,:]
-        stacked_psf_quantity += other.quantity * other.exposure_map.quantity[:,np.newaxis,:,:]
-        stacked_psf_quantity /= total_exposure.quantity[:,np.newaxis,:,:]
-        stacked_psf = Map.from_geom(self.geom, data= stacked_psf_quantity.to('1/sr').value, unit='1/sr')
+        total_exposure = self.exposure_map + other.exposure_map
+        stacked_psf_quantity = (
+            self.quantity * self.exposure_map.quantity[:, np.newaxis, :, :]
+        )
+        stacked_psf_quantity += (
+            other.quantity * other.exposure_map.quantity[:, np.newaxis, :, :]
+        )
+        stacked_psf_quantity /= total_exposure.quantity[:, np.newaxis, :, :]
+        stacked_psf = Map.from_geom(
+            self.geom, data=stacked_psf_quantity.to("1/sr").value, unit="1/sr"
+        )
         return PSFMap(stacked_psf, total_exposure)

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -60,7 +60,9 @@ def make_psf_map(psf, pointing, geom, max_offset, exposure_map=None):
     if exposure_map is not None:
         # First adapt geometry, keep only energy axis
         if exposure_map.geom != geom.to_image().to_cube([energy_axis]):
-            raise ValueError("Inconsistent geometries between PSFMap and its associated exposure")
+            raise ValueError(
+                "Inconsistent geometries between PSFMap and its associated exposure"
+            )
 
     return PSFMap(psfmap, exposure_map)
 
@@ -278,7 +280,7 @@ class PSFMap:
             the stacked psfmap
         """
         if self.exposure_map is None or other.exposure_map is None:
-            raise (ValueError, "Missing exposure map for PSFMap.stack")
+            raise ValueError("Missing exposure map for PSFMap.stack")
 
         total_exposure = self.exposure_map + other.exposure_map
         exposure = self.exposure_map.quantity[:, np.newaxis, :, :]

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -125,3 +125,30 @@ def test_containment_radius_map(tmpdir):
     val = m.interp_by_coord(coord)
 
     assert_allclose(val, 0.227463, rtol=1e-3)
+
+
+def test_psfmap_stacking():
+    psf = fake_psf3d(0.15 * u.deg)
+    aeff2d = fake_aeff2d()
+
+    pointing = SkyCoord(0, 0, unit="deg")
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy")
+    rad_axis = MapAxis(nodes=np.linspace(0.0, 0.6, 50), unit="deg", name="theta")
+
+    geom = WcsGeom.create(
+       skydir=pointing, binsz=0.2, width=5, axes=[rad_axis, energy_axis]
+    )
+
+    exposure_geom = WcsGeom.create(
+        skydir=pointing, binsz=0.2, width=5, axes=[energy_axis]
+    )
+
+    exposure_map1 = make_map_exposure_true_energy(pointing, '1 h', aeff2d, exposure_geom)
+    exposure_map2 = make_map_exposure_true_energy(pointing, '2 h', aeff2d, exposure_geom)
+
+    psfmap1 = make_psf_map(psf, pointing, geom, 3 * u.deg, exposure_map1)
+    psfmap2 = make_psf_map(psf, pointing, geom, 3 * u.deg, exposure_map2)
+
+    psfmap = psfmap1.stack(psfmap2)
+
+

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -91,6 +91,7 @@ def build_test_psfmap(size, shape="gauss"):
 
 def test_psfmap_to_table_psf():
     psfmap = build_test_psfmap(0.15 * u.deg)
+    psf = fake_psf3d(0.15 * u.deg)
     # Extract EnergyDependentTablePSF
     table_psf = psfmap.get_energy_dependent_table_psf(SkyCoord(1, 1, unit="deg"))
 
@@ -107,7 +108,7 @@ def test_psfmap_to_table_psf():
     )
 
 
-def test_psfmap_to_table_psf():
+def test_psfmap_to_psf_kernel():
     psfmap = build_test_psfmap(0.15 * u.deg)
 
     energy_axis = psfmap.geom.axes[1]

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -68,7 +68,7 @@ def test_make_psf_map():
     assert psfmap.data.shape == (4, 50, 25, 25)
 
 
-def build_test_psfmap(size, shape="gauss"):
+def make_test_psfmap(size, shape="gauss"):
     psf = fake_psf3d(size, shape)
     aeff2d = fake_aeff2d()
 
@@ -90,7 +90,7 @@ def build_test_psfmap(size, shape="gauss"):
 
 
 def test_psfmap_to_table_psf():
-    psfmap = build_test_psfmap(0.15 * u.deg)
+    psfmap = make_test_psfmap(0.15 * u.deg)
     psf = fake_psf3d(0.15 * u.deg)
     # Extract EnergyDependentTablePSF
     table_psf = psfmap.get_energy_dependent_table_psf(SkyCoord(1, 1, unit="deg"))
@@ -109,7 +109,7 @@ def test_psfmap_to_table_psf():
 
 
 def test_psfmap_to_psf_kernel():
-    psfmap = build_test_psfmap(0.15 * u.deg)
+    psfmap = make_test_psfmap(0.15 * u.deg)
 
     energy_axis = psfmap.geom.axes[1]
     # create PSFKernel
@@ -121,7 +121,7 @@ def test_psfmap_to_psf_kernel():
 
 
 def test_psfmap_to_from_hdulist():
-    psfmap = build_test_psfmap(0.15 * u.deg)
+    psfmap = make_test_psfmap(0.15 * u.deg)
     hdulist = psfmap.to_hdulist(psf_hdu="PSF", psf_hdubands="BANDS")
     assert "PSF" in hdulist
     assert "BANDS" in hdulist
@@ -135,7 +135,7 @@ def test_psfmap_to_from_hdulist():
 
 
 def test_psfmap_read_write(tmpdir):
-    psfmap = build_test_psfmap(0.15 * u.deg)
+    psfmap = make_test_psfmap(0.15 * u.deg)
 
     # test read/write
     filename = str(tmpdir / "psfmap.fits")
@@ -163,24 +163,20 @@ def test_containment_radius_map(tmpdir):
 
 
 def test_psfmap_stacking():
-    psfmap1 = build_test_psfmap(0.1 * u.deg, shape="flat")
-    psfmap2 = build_test_psfmap(0.1 * u.deg, shape="flat")
+    psfmap1 = make_test_psfmap(0.1 * u.deg, shape="flat")
+    psfmap2 = make_test_psfmap(0.1 * u.deg, shape="flat")
     psfmap2.exposure_map.quantity *= 2
 
     psfmap_stack = psfmap1.stack(psfmap2)
     assert_allclose(psfmap_stack.data, psfmap1.data)
     assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
 
-    psfmap3 = build_test_psfmap(0.3 * u.deg, shape="flat")
+    psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
     psfmap_stack = psfmap1.stack(psfmap3)
 
-    assert_allclose(psfmap_stack.data[:, 40, :, :], 0.0)
-    assert_allclose(
-        psfmap_stack.data[:, 20, :, :], psfmap3.data[:, 20, :, :] * 0.5, rtol=1e-4
-    )
-    assert_allclose(
-        psfmap_stack.data[:, 0, :, :], psfmap3.data[:, 0, :, :] * 5.0, rtol=1e-4
-    )
+    assert_allclose(psfmap_stack.data[0, 40, 20, 20], 0.0)
+    assert_allclose(psfmap_stack.data[0, 20, 20, 20], 5805.28955078125)
+    assert_allclose(psfmap_stack.data[0, 0, 20, 20], 58052.78955078125)
 
 
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations


### PR DESCRIPTION
This PR introduces the possibility to stack two `PSFMap`. To do so, it adds:
- an `exposure_map` member of `PSFMap`. Implictly it should have the same `geom` as the `PSFMap` after removing the `rad`axis.
- the stacking method itself.
- some test

An improved version of the test should compare `make_mean_psf` and `PSFMap.stack`.