### PR TITLE
Use concurrent.futures.ProcessPoolExecutor?

### DIFF
--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions to compute TS images."""
 import logging
-import contextlib
 import warnings
 from functools import partial
-from multiprocessing import Pool
+from concurrent.futures import ProcessPoolExecutor
 import numpy as np
 from scipy.optimize import newton, brentq
 from astropy.convolution import CustomKernel, Kernel2D
@@ -334,11 +333,9 @@ class TSMapEstimator:
         x, y = np.where(mask.data)
         positions = list(zip(x, y))
 
-        with contextlib.closing(Pool(processes=p["n_jobs"])) as pool:
+        with ProcessPoolExecutor(max_workers=p["n_jobs"]) as executor:
             log.info("Using {} jobs to compute TS map.".format(p["n_jobs"]))
-            results = pool.map(wrap, positions)
-
-        pool.join()
+            results = list(executor.map(wrap, positions))
 
         # Set TS values at given positions
         j, i = zip(*positions)

--- a/gammapy/image/utils.py
+++ b/gammapy/image/utils.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Image utility functions"""
 import logging
-from multiprocessing import Pool
+from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 import numpy as np
 from scipy.signal import fftconvolve
@@ -49,10 +49,9 @@ def scale_cube(data, kernels, parallel=True):
     wrap = partial(_fftconvolve_wrap, data=data)
 
     if parallel:
-        pool = Pool()
-        result = pool.map(wrap, kernels)
-        pool.close()
-        pool.join()
+        with ProcessPoolExecutor() as executor:
+            result = executor.map(wrap, kernels)
     else:
         result = map(wrap, kernels)
+
     return np.dstack(result)


### PR DESCRIPTION
This PR changes the use of `multiprocessing.Pool.map` (which we use in 2 places) to  `concurrent.futures.ProcessPoolExecutor.map`.

I thought the two would be pretty much equivalent, only that `ProcessPoolExecutor` would do the `close` automatically at the end of the with block, and give cleaner shutdown in some cases where exceptions occur in child processes (from what I've read somewhere).

But actually it looks like they are not equivalent: `ProcessPoolExecutor` is much slower when I run this:
```
$ pytest -v gammapy/detect/tests/test_test_statistics.py --durations=0

66.93s call     gammapy/detect/tests/test_test_statistics.py::test_compute_ts_map
6.25s call     gammapy/detect/tests/test_test_statistics.py::test_compute_ts_map_downsampled
```
This is on my Macbook with 4 cores on Python 3.7 and I see 4 child process, each not running at 100%, but at only 20%.

So this shouldn't be merged. We need to understand the CPU & memory characteristics of the old and new solution first, or just keep the old one. I'm putting this to the side for now, but wanted to have this experiment committed and a reminder, because I wanted to look at and understand multiprocessing better anyways at some point. The task here is to measure CPU and memory usage for these two use cases, with the old and new implementation.