### PR TITLE
Re-factor TablePSF class

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -129,7 +129,7 @@ def test_map_fit(sky_model):
 
     npred = fit.evaluator.compute_npred().sum()
     assert_allclose(npred, 2455.230889, rtol=1e-3)
-    assert_allclose(result.total_stat, 5417.350078, rtol=1e-3)
+    assert_allclose(result.total_stat, 5424.791272, rtol=1e-3)
 
     pars = fit.evaluator.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
@@ -220,4 +220,4 @@ def test_map_fit_bkg(sky_model):
     )
     result = fit.run()
     assert_allclose(background_model.parameters["norm"].value, 0.98307, rtol=1e-3)
-    assert_allclose(result.total_stat, 5417.350, atol=0.01)
+    assert_allclose(result.total_stat, 5424.79128, atol=0.01)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -160,7 +160,7 @@ def test_containment_radius_map(tmpdir):
     m = psfmap.containment_radius_map(1 * u.TeV)
     coord = SkyCoord(0.3, 0, unit="deg")
     val = m.interp_by_coord(coord)
-    assert_allclose(val, 0.216275, rtol=1e-3)
+    assert_allclose(val, 0.226477, rtol=1e-3)
 
 
 def test_psfmap_stacking():

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -7,17 +7,20 @@ from astropy.units import Quantity, Unit
 from astropy.coordinates import Angle
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
+from scipy.interpolate import interp2d
 from ..extern.validator import validate_physical_type
 from ..utils.array import array_stats_str
 from ..utils.energy import Energy, EnergyBounds
 from ..utils.scripts import make_path
 from ..utils.gauss import MultiGauss2D
+from ..utils.interpolation import ScaledRegularGridInterpolator
 from .psf_3d import PSF3D
 from . import EnergyDependentTablePSF
 
 __all__ = ["EnergyDependentMultiGaussPSF"]
 
 log = logging.getLogger(__name__)
+
 
 
 class EnergyDependentMultiGaussPSF:
@@ -97,6 +100,19 @@ class EnergyDependentMultiGaussPSF:
         self.norms = norms
         self.energy_thresh_lo = energy_thresh_lo.to("TeV")
         self.energy_thresh_hi = energy_thresh_hi.to("TeV")
+
+        self._interp_norms = self._setup_interpolators(self.norms)
+        self._interp_sigmas = self._setup_interpolators(self.sigmas)
+
+    def _setup_interpolators(self, values_list):
+        interps = []
+        for values in values_list:
+            interp = ScaledRegularGridInterpolator(
+                points=(self.theta.value, self.energy.value),
+                values=values
+                )
+            interps.append(interp)
+        return interps
 
     @classmethod
     def read(cls, filename, hdu="PSF_2D_GAUSS"):
@@ -222,23 +238,16 @@ class EnergyDependentMultiGaussPSF:
         psf : `~gammapy.morphology.MultiGauss2D`
             Multigauss PSF object.
         """
-        energy = Energy(energy)
-        theta = Angle(theta)
-
-        # Find nearest energy value
-        i = np.argmin(np.abs(self.energy - energy))
-        j = np.argmin(np.abs(self.theta - theta))
-
-        # TODO: Use some kind of interpolation to get PSF
-        # parameters for every energy and theta
-
-        # Select correct gauss parameters for given energy and theta
-        sigmas = [_[j][i] for _ in self.sigmas]
-        norms = [_[j][i] for _ in self.norms]
+        energy = Energy(energy).to_value(self.energy.unit)
+        theta = Quantity(theta).to_value(self.theta.unit)
 
         pars = {}
-        pars["scale"], pars["A_2"], pars["A_3"] = norms
-        pars["sigma_1"], pars["sigma_2"], pars["sigma_3"] = sigmas
+        for name, interp_norm in zip(["scale", "A_2", "A_3"], self._interp_norms):
+            pars[name] = interp_norm((theta, energy))
+
+        for idx, interp_sigma in enumerate(self._interp_sigmas):
+            pars["sigma_{}".format(idx + 1)] = interp_sigma((theta, energy))
+
         psf = HESSMultiGaussPSF(pars)
         return psf.to_MultiGauss2D(normalize=True)
 

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -7,7 +7,6 @@ from astropy.units import Quantity, Unit
 from astropy.coordinates import Angle
 from astropy.convolution import Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
-from scipy.interpolate import interp2d
 from ..extern.validator import validate_physical_type
 from ..utils.array import array_stats_str
 from ..utils.energy import Energy, EnergyBounds

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -2,10 +2,6 @@
 import logging
 import numpy as np
 from astropy.io import fits
-<<<<<<< HEAD
-=======
-from astropy.units import Quantity
->>>>>>> Clean up TablePSF
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from ..utils.interpolation import ScaledRegularGridInterpolator
@@ -26,15 +22,15 @@ class TablePSF:
     ----------
     rad : `~astropy.units.Quantity` with angle units
         Offset wrt source position
-    dp_domega : `~astropy.units.Quantity` with sr^-1 units
+    psf_value : `~astropy.units.Quantity` with sr^-1 units
         PSF value array
     interp_kwargs : dict
         Keyword arguments passed to `ScaledRegularGridInterpolator`
     """
 
-    def __init__(self, rad, dp_domega, interp_kwargs=None):
+    def __init__(self, rad, psf_value, interp_kwargs=None):
         self.rad = Angle(rad).to("rad")
-        self.psf_value = u.Quantity(dp_domega).to("sr^-1")
+        self.psf_value = u.Quantity(psf_value).to("sr^-1")
 
         self._interp_kwargs = interp_kwargs or {}
         self._setup_interpolators()
@@ -168,7 +164,7 @@ class TablePSF:
         rad : `~astropy.coordinates.Angle`
             Containment radius angle
         """
-        rad_max = np.linspace(0, self.rad[-1].to_value("deg"), 10 * len(self.rad)) * u.deg
+        rad_max = Angle(np.linspace(0, self.rad[-1].to_value("deg"), 10 * len(self.rad)), "deg")
         containment = self.containment(rad_max=rad_max)
 
         fraction = np.atleast_1d(fraction)

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 from astropy.io import fits
 from astropy import units as u
-from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates import Angle
 from astropy.utils import lazyproperty
 from scipy.integrate import cumtrapz
 from ..utils.interpolation import ScaledRegularGridInterpolator
@@ -274,9 +274,6 @@ class EnergyDependentTablePSF:
         values = cumtrapz(
             rad_drad.to_value("rad-1"), rad.to_value("rad"), initial=0, axis=1
         )
-
-        with np.errstate(divide="ignore", invalid="ignore"):
-            values /= values[:, [-1]]
 
         points = (self.energy.value, rad)
         return ScaledRegularGridInterpolator(points=points, values=values, fill_value=1)

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -1,8 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-from scipy.interpolate import UnivariateSpline
 from astropy.io import fits
+<<<<<<< HEAD
+=======
+from astropy.units import Quantity
+>>>>>>> Clean up TablePSF
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from ..utils.interpolation import ScaledRegularGridInterpolator
@@ -15,19 +18,9 @@ __all__ = ["TablePSF", "EnergyDependentTablePSF"]
 
 log = logging.getLogger(__name__)
 
-# Default PSF spline keyword arguments
-# TODO: test and document
-DEFAULT_PSF_SPLINE_KWARGS = dict(k=1, s=0)
-
 
 class TablePSF:
     r"""Radially-symmetric table PSF.
-
-    This PSF represents a :math:`PSF(r)=dP / d\Omega(r)`
-    spline interpolation curve for a given set of offset :math:`r`
-    and :math:`PSF` points.
-
-    Uses `scipy.interpolate.UnivariateSpline`.
 
     Parameters
     ----------
@@ -35,40 +28,34 @@ class TablePSF:
         Offset wrt source position
     dp_domega : `~astropy.units.Quantity` with sr^-1 units
         PSF value array
-    spline_kwargs : dict
-        Keyword arguments passed to `~scipy.interpolate.UnivariateSpline`
-
-    Notes
-    -----
-    * This PSF class works well for model PSFs of arbitrary shape (represented by a table),
-      but might give unstable results if the PSF has noise.
-      E.g. if ``dp_domega`` was estimated from histograms of real or simulated event data
-      with finite statistics, it will have noise and it is your responsibility
-      to check that the interpolating spline is reasonable.
-    * To customize the spline, pass keyword arguments to `~scipy.interpolate.UnivariateSpline`
-      in ``spline_kwargs``. E.g. passing ``dict(k=1)`` changes from the default cubic to
-      linear interpolation.
-    * TODO: evaluate spline for ``(log(rad), log(PSF))`` for numerical stability?
-    * TODO: merge morphology.theta class functionality with this class.
-    * TODO: add FITS I/O methods
-    * TODO: add ``normalize`` argument to ``__init__`` with default ``True``?
-    * TODO: ``__call__`` doesn't show up in the html API docs, but it should:
-      https://github.com/astropy/astropy/pull/2135
+    interp_kwargs : dict
+        Keyword arguments passed to `ScaledRegularGridInterpolator`
     """
 
-    def __init__(self, rad, dp_domega, spline_kwargs=DEFAULT_PSF_SPLINE_KWARGS):
+    def __init__(self, rad, dp_domega, interp_kwargs=None):
+        self.rad = Angle(rad).to("rad")
+        self.psf_value = u.Quantity(dp_domega).to("sr^-1")
 
-        self._rad = Angle(rad).to("radian")
-        self._dp_domega = u.Quantity(dp_domega).to("sr^-1")
+        self._interp_kwargs = interp_kwargs or {}
+        self._setup_interpolators()
 
-        assert self._rad.ndim == self._dp_domega.ndim == 1
-        assert self._rad.shape == self._dp_domega.shape
+    @property
+    def _rad_axis(self):
+        from ..maps import MapAxis
+        return MapAxis.from_nodes(self.rad.to_value("deg"), unit="deg")
+ 
+    def _setup_interpolators(self):
+        self._interpolate = ScaledRegularGridInterpolator(
+            points=(self.rad.to_value("rad"),), values=self.psf_value, 
+            **self._interp_kwargs)
 
-        # Store input arrays as quantities in default internal units
-        self._dp_dr = (2 * np.pi * self._rad * self._dp_domega).to("radian^-1")
-        self._spline_kwargs = spline_kwargs
+        drad = np.diff(self._rad_axis.edges) * u.deg
+        integral = (2 * np.pi * self.rad * self.psf_value * drad).cumsum()
 
-        self._compute_splines(spline_kwargs)
+        self._interpolate_integral = ScaledRegularGridInterpolator(
+            points=(self.rad.to_value("rad"),), values=integral.to_value(""), fill_value=1,
+            )
+
 
     @classmethod
     def from_shape(cls, shape, width, rad):
@@ -116,39 +103,19 @@ class TablePSF:
 
     def info(self):
         """Print basic info."""
-        ss = array_stats_str(self._rad.degree, "offset")
+        ss = array_stats_str(self.rad.deg, "offset")
         ss += "integral = {}\n".format(self.integral())
 
-        for containment in [50, 68, 80, 95]:
+        for containment in [68, 80, 95]:
             radius = self.containment_radius(0.01 * containment)
             ss += "containment radius {} deg for {}%\n".format(
-                radius.degree, containment
+                radius.deg, containment
             )
 
         return ss
 
-    # TODO: remove because it's not flexible enough?
-    def __call__(self, lon, lat):
-        """Evaluate PSF at a 2D position.
 
-        The PSF is centered on ``(0, 0)``.
-
-        Parameters
-        ----------
-        lon, lat : `~astropy.coordinates.Angle`
-            Longitude / latitude position
-
-        Returns
-        -------
-        psf_value : `~astropy.units.Quantity`
-            PSF value
-        """
-        center = SkyCoord(0, 0, unit="radian")
-        point = SkyCoord(lon, lat)
-        rad = center.separation(point)
-        return self.evaluate(rad)
-
-    def evaluate(self, rad, quantity="dp_domega"):
+    def evaluate(self, rad):
         r"""Evaluate PSF.
 
         The following PSF quantities are available:
@@ -157,47 +124,27 @@ class TablePSF:
 
             .. math:: \frac{dP}{d\Omega}
 
-        * 'dp_dr': PDF per 1-dim offset :math:`r` in radian^-1
-
-            .. math:: \frac{dP}{dr} = 2 \pi r \frac{dP}{d\Omega}
 
         Parameters
         ----------
         rad : `~astropy.coordinates.Angle`
             Offset wrt source position
-        quantity : {'dp_domega', 'dp_dr'}
-            Which PSF quantity?
 
         Returns
         -------
         psf_value : `~astropy.units.Quantity`
             PSF value
         """
-        rad = Angle(rad)
+        rad = np.atleast_1d(u.Quantity(rad, "rad").value)
+        return self._interpolate((rad,))
+        
 
-        shape = rad.shape
-        x = np.array(rad.radian).flat
-
-        if quantity == "dp_domega":
-            y = self._dp_domega_spline(x)
-            unit = "sr^-1"
-        elif quantity == "dp_dr":
-            y = self._dp_dr_spline(x)
-            unit = "radian^-1"
-        else:
-            ss = "Invalid quantity: {}\n".format(quantity)
-            ss += "Choose one of: 'dp_domega', 'dp_dr'"
-            raise ValueError(ss)
-
-        y = np.clip(a=y, a_min=0, a_max=None)
-        return u.Quantity(y, unit).reshape(shape)
-
-    def integral(self, rad_min=None, rad_max=None):
-        """Compute PSF integral, aka containment fraction.
+    def containment(self, rad_max):
+        """Compute PSF containment fraction.
 
         Parameters
         ----------
-        rad_min, rad_max : `~astropy.units.Quantity` with angle units
+        rad_max : `~astropy.units.Quantity`
             Offset angle range
 
         Returns
@@ -205,23 +152,8 @@ class TablePSF:
         integral : float
             PSF integral
         """
-        if rad_min is None:
-            rad_min = self._rad[0]
-        else:
-            rad_min = Angle(rad_min)
-
-        if rad_max is None:
-            rad_max = self._rad[-1]
-        else:
-            rad_max = Angle(rad_max)
-
-        rad_min = self._rad_clip(rad_min)
-        rad_max = self._rad_clip(rad_max)
-
-        cdf_min = self._cdf_spline(rad_min)
-        cdf_max = self._cdf_spline(rad_max)
-
-        return cdf_max - cdf_min
+        rad = np.atleast_1d(u.Quantity(rad_max, "rad").value)
+        return self._interpolate_integral((rad,))
 
     def containment_radius(self, fraction):
         """Containment radius.
@@ -236,8 +168,13 @@ class TablePSF:
         rad : `~astropy.coordinates.Angle`
             Containment radius angle
         """
-        rad = self._ppf_spline(fraction)
-        return Angle(rad, "radian").to("deg")
+        rad_max = np.linspace(0, self.rad[-1].to_value("deg"), 10 * len(self.rad)) * u.deg
+        containment = self.containment(rad_max=rad_max)
+
+        fraction = np.atleast_1d(fraction)
+
+        fraction_idx = np.argmin(np.abs(containment - fraction[:, np.newaxis]), axis=1)
+        return rad_max[fraction_idx].to("deg")
 
     def normalize(self):
         """Normalize PSF to unit integral.
@@ -245,16 +182,8 @@ class TablePSF:
         Computes the total PSF integral via the :math:`dP / dr` spline
         and then divides the :math:`dP / dr` array.
         """
-        integral = self.integral()
-
-        self._dp_dr /= integral
-
-        # Clip to small positive number to avoid divide by 0
-        rad = np.clip(self._rad.radian, 1e-6, None)
-
-        rad = u.Quantity(rad, "radian")
-        self._dp_domega = self._dp_dr / (2 * np.pi * rad)
-        self._compute_splines(self._spline_kwargs)
+        integral = self.containment(self.rad[-1])
+        self.psf_value /= integral 
 
     def broaden(self, factor, normalize=True):
         r"""Broaden PSF by scaling the offset array.
@@ -274,77 +203,30 @@ class TablePSF:
         normalize : bool
             Normalize PSF after broadening
         """
-        self._rad *= factor
-        # We define broadening such that self._dp_domega remains the same
-        # so we only have to re-compute self._dp_dr and the slines here.
-        self._dp_dr = (2 * np.pi * self._rad * self._dp_domega).to("radian^-1")
-        self._compute_splines(self._spline_kwargs)
-
+        self.rad *= factor
+        self._setup_interpolators()
         if normalize:
             self.normalize()
 
-    def plot_psf_vs_rad(self, ax=None, quantity="dp_domega", **kwargs):
+    def plot_psf_vs_rad(self, ax=None,  **kwargs):
         """Plot PSF vs radius.
 
-        TODO: describe PSF ``quantity`` argument in a central place and link to it from here.
+        Parameters
+        ----------
+        ax : ``
+
+        kwargs : dict
+            Keyword arguments passed to `matplotlib.pyplot.plot`
         """
         import matplotlib.pyplot as plt
 
         ax = plt.gca() if ax is None else ax
 
-        x = self._rad.to("deg")
-        y = self.evaluate(self._rad, quantity)
+        ax.plot(self.rad.to_value("deg"), self.psf_value.to_value("sr-1"), **kwargs)
+        ax.set_yscale("log")
+        ax.set_xlabel("Radius (deg)")
+        ax.set_ylabel("PSF (sr-1)")
 
-        ax.plot(x.value, y.value, **kwargs)
-        ax.loglog()
-        ax.set_xlabel("Radius ({})".format(x.unit))
-        ax.set_ylabel("PSF ({})".format(y.unit))
-
-    def _compute_splines(self, spline_kwargs=DEFAULT_PSF_SPLINE_KWARGS):
-        """Compute two splines representing the PSF.
-
-        * `_dp_domega_spline` is used to evaluate the 2D PSF.
-        * `_dp_dr_spline` is not really needed for most applications,
-          but is available via `eval`.
-        * `_cdf_spline` is used to compute integral and for normalisation.
-        * `_ppf_spline` is used to compute containment radii.
-        """
-        # Compute spline and normalize.
-        x, y = self._rad.value, self._dp_domega.value
-        self._dp_domega_spline = UnivariateSpline(x, y, **spline_kwargs)
-
-        x, y = self._rad.value, self._dp_dr.value
-        self._dp_dr_spline = UnivariateSpline(x, y, **spline_kwargs)
-
-        # We use the terminology for scipy.stats distributions
-        # http://docs.scipy.org/doc/scipy/reference/tutorial/stats.html#common-methods
-
-        # cdf = "cumulative distribution function"
-        self._cdf_spline = self._dp_dr_spline.antiderivative()
-
-        # ppf = "percent point function" (inverse of cdf)
-        # Here's a discussion on methods to compute the ppf
-        # http://mail.scipy.org/pipermail/scipy-user/2010-May/025237.html
-        y = self._rad.value
-        x = self.integral(Angle(0, "rad"), self._rad)
-
-        # Since scipy 1.0 the UnivariateSpline requires that x is strictly increasing
-        # So only keep nodes where this is the case (and always keep the first one):
-        x, idx = np.unique(x, return_index=True)
-        y = y[idx]
-
-        # Dummy values, for cases where one really doesn't have a valid PSF.
-        if len(x) < 4:
-            x = [0, 1, 2, 3]
-            y = [0, 0, 0, 0]
-
-        self._ppf_spline = UnivariateSpline(x, y, **spline_kwargs)
-
-    def _rad_clip(self, rad):
-        """Clip to radius support range, because spline extrapolation is unstable."""
-        rad = Angle(rad, "radian").radian
-        rad = np.clip(rad, 0, self._rad[-1].radian)
-        return rad
 
 
 class EnergyDependentTablePSF:

--- a/gammapy/irf/tests/data/psf_info.txt
+++ b/gammapy/irf/tests/data/psf_info.txt
@@ -6,7 +6,7 @@ Energy hi      : size =    15, min =  0.158 TeV, max = 100.000 TeV
 Energy lo      : size =    15, min =  0.100 TeV, max = 63.096 TeV
 Safe energy threshold lo:  0.100 TeV
 Safe energy threshold hi: 100.000 TeV
-68% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.13575056 deg
-68% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.12244168 deg
-95% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.28951817 deg
-95% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.26113401 deg
+68% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.13457222 deg
+68% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.12126335 deg
+95% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.28700509 deg
+95% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.25862096 deg

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -18,7 +18,7 @@ productions = [
         test_obs=23523,
         aeff_ref=267252.7,
         psf_type="psf_3gauss",
-        psf_ref=106.310,
+        psf_ref=63.360562,
         edisp_ref=2.059,
     ),
     dict(

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -56,7 +56,7 @@ def test_psf_3d_containment_radius(psf_3d):
     assert q.unit == "deg"
 
     q = psf_3d.containment_radius(energy=[1, 3] * u.TeV)
-    assert_allclose(q.value, [0.171702, 0.157779], rtol=1e-2)
+    assert_allclose(q.value, [0.172447, 0.159405], rtol=1e-2)
     assert q.shape == (2,)
 
 

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -45,7 +45,7 @@ def test_to_energy_dependent_table_psf(psf_3d):
     psf = psf_3d.to_energy_dependent_table_psf()
     assert psf.psf_value.shape == (18, 900)
     radius = psf.table_psf_at_energy("1 TeV").containment_radius(0.68).deg
-    assert_allclose(radius, 0.170509, atol=1e-4)
+    assert_allclose(radius, 0.172435, atol=1e-4)
 
 
 @requires_data("gammapy-data")
@@ -56,7 +56,7 @@ def test_psf_3d_containment_radius(psf_3d):
     assert q.unit == "deg"
 
     q = psf_3d.containment_radius(energy=[1, 3] * u.TeV)
-    assert_allclose(q.value, [0.171025, 0.155722], rtol=1e-2)
+    assert_allclose(q.value, [0.171702, 0.157779], rtol=1e-2)
     assert q.shape == (2,)
 
 

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -45,7 +45,7 @@ def test_to_energy_dependent_table_psf(psf_3d):
     psf = psf_3d.to_energy_dependent_table_psf()
     assert psf.psf_value.shape == (18, 900)
     radius = psf.table_psf_at_energy("1 TeV").containment_radius(0.68).deg
-    assert_allclose(radius, 0.171445, atol=1e-4)
+    assert_allclose(radius, 0.170509, atol=1e-4)
 
 
 @requires_data("gammapy-data")

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -143,7 +143,7 @@ def test_psf_cta_1dc():
     # Check that evaluation works for an energy / offset where an energy is available
     psf = psf_irf.to_energy_dependent_table_psf("2 deg")
     psf = psf.table_psf_at_energy("1 TeV")
-    assert_allclose(psf.containment_radius(0.68).deg, 0.051345, atol=1e-4)
+    assert_allclose(psf.containment_radius(0.68).deg, 0.053838, atol=1e-4)
 
 
 class TestHESS:

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -94,7 +94,7 @@ class TestEnergyDependentMultiGaussPSF:
         energy = 1 * u.TeV
         theta = 0 * u.deg
 
-        rad = np.linspace(0, 1, 100) * u.deg
+        rad = np.linspace(0, 2, 300) * u.deg
         table_psf = psf.to_energy_dependent_table_psf(theta, rad=rad)
 
         psf_at_energy = psf.psf_at_energy_and_theta(energy, theta)
@@ -102,7 +102,7 @@ class TestEnergyDependentMultiGaussPSF:
         containment = [0.68, 0.8, 0.9]
         desired = [psf_at_energy.containment_radius(_) for _ in containment]
 
-        table_psf_at_energy = table_psf.table_psf_at_energy(energy, method="nearest")
+        table_psf_at_energy = table_psf.table_psf_at_energy(energy)
         actual = table_psf_at_energy.containment_radius(containment)
 
         assert_allclose(desired, actual.degree, rtol=1e-2)
@@ -143,7 +143,7 @@ def test_psf_cta_1dc():
     # Check that evaluation works for an energy / offset where an energy is available
     psf = psf_irf.to_energy_dependent_table_psf("2 deg")
     psf = psf.table_psf_at_energy("1 TeV")
-    assert_allclose(psf.containment_radius(0.68).deg, 0.053728, atol=1e-4)
+    assert_allclose(psf.containment_radius(0.68).deg, 0.051345, atol=1e-4)
 
 
 class TestHESS:

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.units import Quantity
+from astropy import units as u
 from astropy.coordinates import Angle
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...utils.testing import assert_quantity_allclose
@@ -14,9 +14,18 @@ class TestTablePSF:
     def test_gauss():
         # Make an example PSF for testing
         width = Angle(0.3, "deg")
+        
+        # containment radius for 80% containment
+        radius = width * np.sqrt(2 * np.log(5))
+        
         rad = Angle(np.linspace(0, 2.3, 1000), "deg")
         psf = TablePSF.from_shape(shape="gauss", width=width, rad=rad)
-        assert_allclose(psf.integral(), 1, rtol=1e-3)
+        
+        assert_allclose(psf.containment(radius), 0.8, rtol=1e-2)
+
+        desired = radius.to_value("deg")
+        actual = psf.containment_radius(0.8).to_value("deg")
+        assert_allclose(actual, desired, rtol=1e-2)
 
     @staticmethod
     def test_disk():
@@ -24,25 +33,13 @@ class TestTablePSF:
         rad = Angle(np.linspace(0, 2.3, 1000), "deg")
         psf = TablePSF.from_shape(shape="disk", width=width, rad=rad)
 
-        # Check psf.evaluate by checking if probabilities sum to 1
-        psf_value = psf.evaluate(rad, quantity="dp_dr")
-        integral = np.sum(np.diff(rad.radian) * psf_value[:-1])
-        assert_allclose(integral.value, 1, rtol=1e-3)
-
-        psf_value = psf.evaluate(rad, quantity="dp_domega")
+        psf_value = psf.evaluate(rad)
         psf_value = (2 * np.pi * rad * psf_value).to("radian^-1")
         integral = np.sum(np.diff(rad.radian) * psf_value[:-1])
+
         assert_allclose(integral.value, 1, rtol=1e-3)
+        assert_allclose(psf.containment(Angle(2, "deg")), 1, rtol=1e-3)
 
-        assert_allclose(psf.integral(), 1, rtol=1e-3)
-        assert_allclose(psf.integral(*Angle([0, 10], "deg")), 1, rtol=1e-3)
-        assert_allclose(psf.integral(*Angle([0, 1], "deg")), 0.25, rtol=1e-4)
-        assert_allclose(psf.integral(*Angle([1, 2], "deg")), 0.75, rtol=1e-2)
-
-        # TODO
-        # actual = psf.containment_radius([0.01, 0.25, 0.99])
-        # desired = Angle([0, 1, 2], 'deg')
-        # assert_quantity_allclose(actual, desired, rtol=1e-3)
 
     # TODO: is this useful in addition to the previous tests?
     @staticmethod
@@ -55,19 +52,15 @@ class TestTablePSF:
         # Test inputs
         rad = Angle([0.1, 0.3], "deg")
 
-        actual = psf.evaluate(rad=rad, quantity="dp_domega")
-        desired = Quantity([5491.52067694, 3521.07804604], "sr^-1")
+        actual = psf.evaluate(rad=rad)
+        desired = u.Quantity([5491.52067694, 3521.07804604], "sr^-1")
         assert_quantity_allclose(actual, desired)
-
-        actual = psf.evaluate(rad=rad, quantity="dp_dr")
-        desired = Quantity([60.22039017, 115.83738017], "rad^-1")
-        assert_quantity_allclose(actual, desired, rtol=1e-6)
 
         rad_min = Angle([0.0, 0.1, 0.3], "deg")
         rad_max = Angle([0.1, 0.3, 2.0], "deg")
-        actual = psf.integral(rad_min, rad_max)
-        desired = [0.05403975, 0.33942469, 0.60653066]
-        assert_allclose(actual, desired)
+        actual = psf.containment(rad_max) - psf.containment(rad_min)
+        desired = [0.055256, 0.340536, 0.604203]
+        assert_allclose(actual, desired, rtol=1e-5)
 
 
 @requires_data("gammapy-data")
@@ -80,23 +73,24 @@ class TestEnergyDependentTablePSF:
         # TODO: test __init__
 
         # Test cases
-        energy = Quantity(1, "GeV")
+        energy = u.Quantity(1, "GeV")
         rad = Angle(0.1, "deg")
-        energies = Quantity([1, 2], "GeV").to("TeV")
+        energies = u.Quantity([1, 2], "GeV").to("TeV")
         rads = Angle([0.1, 0.2], "deg")
 
         # actual = psf.evaluate(energy=energy, rad=rad)
-        # desired = Quantity(17760.814249206363, 'sr^-1')
+        # desired = u.Quantity(17760.814249206363, 'sr^-1')
         # assert_quantity_allclose(actual, desired)
 
         # actual = psf.evaluate(energy=energies, rad=rads)
-        # desired = Quantity([17760.81424921, 5134.17706619], 'sr^-1')
+        # desired = u.Quantity([17760.81424921, 5134.17706619], 'sr^-1')
         # assert_quantity_allclose(actual, desired)
 
         psf1 = self.psf.table_psf_at_energy(energy)
         containment = np.linspace(0, 0.95, 3)
-        containment_radius = psf1.containment_radius(containment)
-        assert_allclose(containment_radius, Angle([0, 0.19426847, 1.03806372], "deg"))
+        actual = psf1.containment_radius(containment).to_value("deg")
+        desired =  [0., 0.188798, 1.026798]
+        assert_allclose(actual, desired, rtol=1e-5)
         # TODO: test average_psf
         # psf2 = psf.psf_in_energy_band(energy_band, spectrum)
 
@@ -105,8 +99,7 @@ class TestEnergyDependentTablePSF:
         # TODO: test info
         # TODO: test plotting methods
 
-        desired = 1.0
-        energy_band = Quantity([10, 500], "GeV")
+        energy_band = u.Quantity([10, 500], "GeV")
         psf_band = self.psf.table_psf_in_energy_band(energy_band)
 
     @requires_dependency("matplotlib")
@@ -114,7 +107,7 @@ class TestEnergyDependentTablePSF:
         with mpl_plot_check():
             self.psf.plot_containment_vs_energy()
 
-        energy = Quantity(1, "GeV")
+        energy = u.Quantity(1, "GeV")
         psf_1GeV = self.psf.table_psf_at_energy(energy)
         with mpl_plot_check():
             psf_1GeV.plot_psf_vs_rad()


### PR DESCRIPTION
This is a follow-up PR to #2019 and introduces the following changes:

- Re-factor the `TablePSF`class and remove the `UnivariateSpline` interpolation by replacing it with the `ScaledRegularGridInterpolator` from `gammapy.utils`.
- Add bi-linear interpolation to `EnergyDepdendentMultiGaussPSF`
- Fix the containment computation in `TablePSF` and `EnergyDepdendentTablePSF`, which was introduced incorrectly in #2019.