### PR TITLE
Add hess notebook to gammapy download list

### DIFF
--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -57,6 +57,10 @@
     - images
     - catalogs
     - ebl
+- name: hess
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/hess.ipynb
+  datasets:
+    - hess-dl3-dr1
 - name: hgps
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/hgps.ipynb
 - name: image_analysis


### PR DESCRIPTION
This PR just adds the `hess.ipynb` notebook to the index file listing the tutorials to provide with `gammapy download`.