### PR TITLE
Add symmetric gaussian model defined on the plane

### DIFF
--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -201,6 +201,8 @@ class SkyDisk(SkySpatialModel):
         """Evaluate the model (static function)."""
         sep = angular_separation(lon, lat, lon_0, lat_0)
 
+
+        # Surface area of a spherical cap, see https://en.wikipedia.org/wiki/Spherical_cap
         norm = 1.0 / (2 * np.pi * (1 - np.cos(r_0)))
         return u.Quantity(norm.value * (sep <= r_0), "sr-1", copy=False)
 

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -7,6 +7,7 @@ from ....utils.testing import requires_data
 from ..core import (
     SkyPointSource,
     SkyGaussian,
+    PlaneGaussian,
     SkyDisk,
     SkyShell,
     SkyDiffuseConstant,
@@ -30,6 +31,16 @@ def test_sky_gaussian():
     assert val.unit == "deg-2"
     assert model.parameters["sigma"].min == 0
     assert_allclose(val.to_value("sr-1"), [316.8970202, 118.6505303])
+
+
+def test_plane_gaussian():
+    model = PlaneGaussian(lon_0="1 deg", lat_0="45 deg", sigma="1 deg")
+    lon = [1, 359] * u.deg
+    lat = 46 * u.deg
+    val = model(lon, lat)
+    assert val.unit == "deg-2"
+    assert model.parameters["sigma"].min == 0
+    assert_allclose(val.to_value("sr-1"), [316.8970202, 42.88734798])
 
 
 def test_sky_disk():


### PR DESCRIPTION
I added a symmetric Gaussian spatial model defined and normalized on the plane, called `PlaneGaussian`. The distance on the sky is computed by a function called `planar_separation`, that uses the ordinary Pythagoras rule (taking care of the `Longitude` and `Latitude` wrapping). Other models defined on the plane may subsequently be added (e.g. elongated gaussian, disk, ellipse, ..), in a similar way.