### PR TITLE
Introduce EDispMap class 

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -5,5 +5,6 @@ from .exposure import *
 from .background import *
 from .psf_kernel import *
 from .psf_map import *
+from .edisp_map import *
 from .make import *
 from .fit import *

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -44,7 +44,7 @@ def make_edisp_map(edisp, pointing, geom, max_offset, exposure_map=None):
     separations = pointing.separation(geom.to_image().get_coord().skycoord)
     valid = np.where(separations < max_offset)
 
-    # Compute PSF values
+    # Compute EDisp values
     edisp_values = edisp.data.evaluate(
         offset=separations[valid],
         e_true=energy[:, np.newaxis],
@@ -97,11 +97,11 @@ class EDispMap(object):
         # Create WcsGeom
         geom = WcsGeom.create(binsz=0.25*u.deg, width=10*u.deg, skydir=pointing, axes=[migra_axis, energy_axis])
 
-        # Extract EnergyDependentTablePSF from CTA 1DC IRF
+        # Extract EnergyDispersion2D from CTA 1DC IRF
         filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
         edisp2D = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
 
-        # create the PSFMap for the specified pointing
+        # create the EDispMap for the specified pointing
         edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset)
 
         # Get an Energy Dispersion (1D) at any position in the image
@@ -147,7 +147,7 @@ class EDispMap(object):
 
     @property
     def exposure_map(self):
-        """the exposure map associated to the PSFMap."""
+        """the exposure map associated to the EDispMap."""
         return self._exposure_map
 
     @property
@@ -267,7 +267,7 @@ class EDispMap(object):
 
         # Build the pixels tuple
         pix = np.meshgrid(pix_lon, pix_lat, pix_migra, pix_ener)
-        # Interpolate in the PSF map. Squeeze to remove dimensions of length 1
+        # Interpolate in the EDisp map. Squeeze to remove dimensions of length 1
         edisp_values = np.squeeze(
             self.edisp_map.interp_by_pix(pix)
             * u.Unit(self.edisp_map.unit)  # * migra_step

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -1,0 +1,134 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import Angle
+from ..irf import EnergyDispersion
+from ..maps import Map
+
+__all__ = ["make_edisp_map", "EDispMap"]
+
+class EDispMap(object):
+    """Class containing the Map of Energy Dispersions and allowing to interact with it.
+
+    Parameters
+    ----------
+    edisp_map : `~gammapy.maps.Map`
+        the input Energy Dispersion Map. Should be a Map with 2 non spatial axes.
+        migra and true energy axes should be given in this specific order.
+
+    Examples
+    --------
+    ::
+
+        import numpy as np
+        from astropy import units as u
+        from astropy.coordinates import SkyCoord
+        from gammapy.maps import Map, WcsGeom, MapAxis
+        from gammapy.irf import EnergyDispersion2D
+        from gammapy.cube import make_edisp_map, EDispMap
+
+        # Define energy axis. Note that the name is fixed.
+        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy')
+        # Define migra axis. Again note the axis name
+        migras = np.linspace(0., 3.0, 100)
+        migra_axis = MapAxis.from_edges(migras, unit='', name='migra')
+
+        # Define parameters
+        pointing = SkyCoord(0., 0., unit='deg')
+        max_offset = 4 * u.deg
+
+        # Create WcsGeom
+        geom = WcsGeom.create(binsz=0.25*u.deg, width=10*u.deg, skydir=pointing, axes=[migra_axis, energy_axis])
+
+        # Extract EnergyDependentTablePSF from CTA 1DC IRF
+        filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
+        edisp2D = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
+
+        # create the PSFMap for the specified pointing
+        edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset)
+
+        # Get an Energy Dispersion (1D) at any position in the image
+        psf_table = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'))
+
+        # Write map to disk
+        edisp_map.write('edisp_map.fits')
+    """
+
+    def __init__(self, edisp_map):
+        if edisp_map.geom.axes[1].name.upper() != "ENERGY":
+            raise ValueError("Incorrect energy axis position in input Map")
+
+        if edisp_map.geom.axes[0].name.upper() != "MIGRA":
+            raise ValueError("Incorrect migra axis position in input Map")
+
+        self._edisp_map = edisp_map
+
+    @property
+    def edisp_map(self):
+        """the EDispMap itself (`~gammapy.maps.Map`)"""
+        return self._edisp_map
+
+    @property
+    def data(self):
+        """the EDispMap data"""
+        return self._edisp_map.data
+
+    @property
+    def quantity(self):
+        """the EDispMap data as a quantity"""
+        return self._edisp_map.quantity
+
+    @property
+    def geom(self):
+        """The EDispMap MapGeom object"""
+        return self._edisp_map.geom
+
+    @classmethod
+    def read(cls, filename, **kwargs):
+        """Read a edisp_map from file and create a EDispMap object"""
+        edmap = Map.read(filename, **kwargs)
+        return cls(edmap)
+
+    def write(self, *args, **kwargs):
+        """Write the Map object containing the EDisp Library map."""
+        self._edisp_map.write(*args, **kwargs)
+
+    def get_energy_dispersion(self, position):
+        """ Returns EnergyDispersion at a given position
+
+        Parameters
+        ----------
+        position : `~astropy.coordinates.SkyCoord`
+            the target position. Should be a single coordinates
+
+        Returns
+        -------
+        psf_table : `~gammapy.irf.EnergyDependentTablePSF`
+            the table PSF
+        """
+        if position.size != 1:
+            raise ValueError(
+                "EnergyDependentTablePSF can be extracted at one single position only."
+            )
+
+        # axes ordering fixed. Could be changed.
+        pix_ener = np.arange(self.geom.axes[1].nbin)
+        pix_rad = np.arange(self.geom.axes[0].nbin)
+
+        # Convert position to pixels
+        pix_lon, pix_lat = self.edisp_map.geom.to_image().coord_to_pix(position)
+
+        # Build the pixels tuple
+        pix = np.meshgrid(pix_lon, pix_lat, pix_rad, pix_ener)
+
+        # Interpolate in the PSF map. Squeeze to remove dimensions of length 1
+        psf_values = np.squeeze(
+            self.edisp_map.interp_by_pix(pix) * u.Unit(self.edisp_map.unit)
+        )
+
+        energies = self.edisp_map.geom.axes[1].center * self.edisp_map.geom.axes[1].unit
+        rad = self.edisp_map.geom.axes[0].center * self.edisp_map.geom.axes[0].unit
+
+        # Beware. Need to revert rad and energies to follow the TablePSF scheme.
+        return EnergyDependentTablePSF(energy=energies, rad=rad, psf_value=psf_values.T)

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -16,7 +16,7 @@ def make_edisp_map(edisp, pointing, geom, max_offset, exposure_map=None):
 
     Parameters
     ----------
-    psf : `~gammapy.irf.EnergyDispersion2D`
+    edisp : `~gammapy.irf.EnergyDispersion2D`
         the 2D Energy Dispersion IRF
     pointing : `~astropy.coordinates.SkyCoord`
         the pointing direction
@@ -69,6 +69,9 @@ class EDispMap(object):
     edisp_map : `~gammapy.maps.Map`
         the input Energy Dispersion Map. Should be a Map with 2 non spatial axes.
         migra and true energy axes should be given in this specific order.
+    exposure_map : `~gammapy.maps.Map`, optional
+        the associated exposure map.
+        default is None
 
     Examples
     --------
@@ -102,7 +105,7 @@ class EDispMap(object):
         edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset)
 
         # Get an Energy Dispersion (1D) at any position in the image
-        psf_table = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'))
+        edisp = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'))
 
         # Write map to disk
         edisp_map.write('edisp_map.fits')
@@ -234,15 +237,15 @@ class EDispMap(object):
         ----------
         position : `~astropy.coordinates.SkyCoord`
             the target position. Should be a single coordinates
-
-        Returns
-        -------
-        psf_table : `~gammapy.irf.EnergyDependentTablePSF`
-            the table PSF
         e_reco : `~astropy.units.Quantity`
             Reconstruced energy axis binning
         migra_step : float
             Integration step in migration
+
+        Returns
+        -------
+        edisp : `~gammapy.irf.EnergyDispersion`
+            the energy dispersion (i.e. rmf object)
         """
         # TODO: reduce code duplication with EnergyDispersion2D.get_response
         if position.size != 1:

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -45,12 +45,12 @@ def make_edisp_map_test():
     edisp2d = EnergyDispersion2D.from_gauss(etrue, migra, 0.0, 0.2, offsets)
 
     geom = WcsGeom.create(
-        skydir=pointing, binsz=0.2, width=5, axes=[migra_axis, energy_axis]
+        skydir=pointing, binsz=1., width=5., axes=[migra_axis, energy_axis]
     )
 
     aeff2d = fake_aeff2d()
     exposure_geom = WcsGeom.create(
-        skydir=pointing, binsz=0.2, width=5, axes=[energy_axis]
+        skydir=pointing, binsz=1., width=5., axes=[energy_axis]
     )
 
     exposure_map = make_map_exposure_true_energy(pointing, "1 h", aeff2d, exposure_geom)
@@ -74,7 +74,7 @@ def test_make_edisp_map():
     assert edmap.edisp_map.geom.axes[0] == migra_axis
     assert edmap.edisp_map.geom.axes[1] == energy_axis
     assert edmap.edisp_map.unit == Unit("")
-    assert edmap.data.shape == (4, 50, 25, 25)
+    assert edmap.data.shape == (4, 50, 5, 5)
 
 
 def test_edisp_map_to_from_hdulist():

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -7,9 +7,27 @@ from astropy.units import Unit
 from astropy.coordinates import SkyCoord
 from ...irf import EnergyDispersion2D
 from ...maps import MapAxis, WcsGeom
-from ...cube import EDispMap
+from ...cube import EDispMap, make_edisp_map
 
 
+def test_make_edisp_map():
+
+    edisp2d = EnergyDispersion2D.from_gauss(e_true, migra, 0.0, 0.1, offset)
+
+    pointing = SkyCoord(0, 0, unit="deg")
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy")
+    migra_axis = MapAxis(nodes=np.linspace(0.0, 3.0, 51), unit="", name="migra")
+
+    geom = WcsGeom.create(
+        skydir=pointing, binsz=0.2, width=5, axes=[migra_axis, energy_axis]
+    )
+
+    edmap = make_edisp_map(edisp2d, pointing, geom, 3 * u.deg)
+
+    assert edmap.psf_map.geom.axes[0] == migra_axis
+    assert edmap.psf_map.geom.axes[1] == energy_axis
+    assert edmap.psf_map.unit == Unit("sr-1")
+    assert edmap.data.shape == (4, 50, 25, 25)
 
 
 

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -12,6 +12,9 @@ from ...cube import EDispMap, make_edisp_map
 
 def test_make_edisp_map():
 
+    etrue = [0.2, 0.7, 1.5, 2.0, 10.0]*u.TeV
+    migra = np.linspace(0.0, 3.0, 51)
+
     edisp2d = EnergyDispersion2D.from_gauss(e_true, migra, 0.0, 0.1, offset)
 
     pointing = SkyCoord(0, 0, unit="deg")
@@ -31,7 +34,7 @@ def test_make_edisp_map():
 
 
 
-def test_edisp_map(tmpdir):
-    migra = np.linspace(0.,3.0,100.)
-    edisp2d = EnergyDispersion2D.from_gauss(e_true, migra, 0.0, 0.1, offset)
+#def test_edisp_map(tmpdir):
+#    migra = np.linspace(0.,3.0,100.)
+#    edisp2d = EnergyDispersion2D.from_gauss(e_true, migra, 0.0, 0.1, offset)
 

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -1,0 +1,19 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import, division, print_function, unicode_literals
+import numpy as np
+from numpy.testing import assert_allclose
+import astropy.units as u
+from astropy.units import Unit
+from astropy.coordinates import SkyCoord
+from ...irf import EnergyDispersion2D
+from ...maps import MapAxis, WcsGeom
+from ...cube import EDispMap
+
+
+
+
+
+def test_edisp_map(tmpdir):
+    migra = np.linspace(0.,3.0,100.)
+    edisp2d = EnergyDispersion2D.from_gauss(e_true, migra, 0.0, 0.1, offset)
+


### PR DESCRIPTION
This PR introduces the `EDispMap`class to be used to contain the energy dispersion at each position in a `Map`. The 1D `EnergyDispersion` used to convert from the `e_true` space to `e_reco` space is obtained with the `EDispMap.get_energy_dispersion(position, e_reco)` method.
At the moment, the `stacking` method works only for maps with identical `MapGeom`.

There is significant code duplication with `PSFMap`. This might be partly solved by using inheritance from e.g. a more general `IRFMap`