### PR TITLE
Correct asymmetric background map generation

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -26,6 +26,15 @@ def make_map_background_irf(pointing, ontime, bkg, geom):
     background : `~gammapy.maps.WcsNDMap`
         Background predicted counts sky cube in reco energy
     """
+    # TODO:
+    #  This implementation can be improved in two ways:
+    #  1. Create equal time intervals between TSTART and TSTOP and sum up the
+    #  background IRF for each interval. This is instead of multiplying by
+    #  the total ontime. This then handles the rotation of the FoV.
+    #  2. Use the pointing table (does not currently exist in CTA files) to
+    #  obtain the RA DEC and time for each interval. This then considers that
+    #  the pointing might change slightly over the observation duration
+
     # Get altaz coords for map
     map_coord = geom.to_image().get_coord()
     sky_coord = map_coord.skycoord

--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from astropy.coordinates import Angle
 from ..maps import WcsNDMap
+from ..utils.coordinates import sky_to_fov
 
 __all__ = ["make_map_background_irf"]
 
@@ -11,8 +11,8 @@ def make_map_background_irf(pointing, ontime, bkg, geom):
 
     Parameters
     ----------
-    pointing : `~astropy.coordinates.SkyCoord`
-        Pointing direction
+    pointing : `~gammapy.data.pointing.FixedPointingInfo`
+        Fixed Pointing info
     ontime : `~astropy.units.Quantity`
         Observation ontime. i.e. not corrected for deadtime
         see https://gamma-astro-data-formats.readthedocs.io/en/stable/irfs/full_enclosure/bkg/index.html#notes)
@@ -26,11 +26,18 @@ def make_map_background_irf(pointing, ontime, bkg, geom):
     background : `~gammapy.maps.WcsNDMap`
         Background predicted counts sky cube in reco energy
     """
-    # Compute FOV coordinates; at the moment assume symmetric background model
-    # TODO: implement FOV coordinates properly
+    # Get altaz coords for map
     map_coord = geom.to_image().get_coord()
-    fov_lon = map_coord.skycoord.separation(pointing)
-    fov_lat = Angle(np.zeros_like(fov_lon), fov_lon.unit)
+    sky_coord = map_coord.skycoord
+    altaz_coord = sky_coord.transform_to(pointing.altaz_frame)
+
+    # Compute FOV coordinates of map relative to pointing
+    fov_lon, fov_lat = sky_to_fov(
+        altaz_coord.az,
+        altaz_coord.alt,
+        pointing.altaz.az,
+        pointing.altaz.alt
+    )
 
     energy_axis = geom.get_axis_by_name("energy")
     energies = energy_axis.edges * energy_axis.unit

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -233,7 +233,7 @@ class MapMakerObs:
 
     def _make_background(self):
         background = make_map_background_irf(
-            pointing=self.observation.pointing_radec,
+            pointing=self.observation.fixed_pointing_info,
             ontime=self.observation.observation_time_duration,
             bkg=self.observation.bkg,
             geom=self.geom,

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -150,7 +150,7 @@ def test_make_map_background_irf_constant(bkg_3d_constant, fixed_pointing_info):
         bkg=bkg_3d_constant,
         geom=WcsGeom.create(
             npix=(3, 3),
-            binsz=2,
+            binsz=4,
             axes=[axis],
             skydir=fixed_pointing_info.radec
         ),
@@ -170,10 +170,10 @@ def test_make_map_background_irf_sym(bkg_3d_symmetric, fixed_pointing_info):
     m = make_map_background_irf(
         pointing=fixed_pointing_info,
         ontime="42 s",
-        bkg=bkg_3d_constant,
+        bkg=bkg_3d_symmetric,
         geom=WcsGeom.create(
             npix=(3, 3),
-            binsz=2,
+            binsz=4,
             axes=[axis],
             skydir=fixed_pointing_info.radec
         ),
@@ -193,7 +193,7 @@ def test_make_map_background_irf_asym(bkg_3d_asymmetric, fixed_pointing_info):
         bkg=bkg_3d_asymmetric,
         geom=WcsGeom.create(
             npix=(3, 3),
-            binsz=2,
+            binsz=4,
             axes=[axis],
             skydir=fixed_pointing_info.radec
         ),

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -1,13 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
-from astropy.coordinates import SkyCoord
+from astropy import units as u
 from ...utils.testing import requires_data
 from ...maps import WcsGeom, HpxGeom, MapAxis
 from ...irf import Background3D
 from ..background import make_map_background_irf
+from ...data.pointing import FixedPointingInfo
 
 pytest.importorskip("healpy")
+
+@pytest.fixture(scope="session")
+def fixed_pointing_info():
+    filename = (
+        "$GAMMAPY_DATA/cta-1dc/data/baseline/gps/gps_baseline_110380.fits"
+    )
+    return FixedPointingInfo.read(filename)
 
 
 @pytest.fixture(scope="session")
@@ -18,10 +27,30 @@ def bkg_3d():
     return Background3D.read(filename, hdu="BACKGROUND")
 
 
-def geom(map_type, ebounds):
+@pytest.fixture(scope="session")
+def bkg_3d_asymmetric():
+    """Example with simple values to test evaluate"""
+    energy = [0.1, 10, 1000] * u.TeV
+    fov_lon = [0, 1, 2, 3] * u.deg
+    fov_lat = [0, 1, 2, 3] * u.deg
+
+    data = np.ones((2, 3, 3)) * u.Unit("s-1 MeV-1 sr-1")
+    data *= np.arange(1, 4).reshape(1, 3, 1)
+    return Background3D(
+        energy_lo=energy[:-1],
+        energy_hi=energy[1:],
+        fov_lon_lo=fov_lon[:-1],
+        fov_lon_hi=fov_lon[1:],
+        fov_lat_lo=fov_lat[:-1],
+        fov_lat_hi=fov_lat[1:],
+        data=data,
+    )
+
+
+def geom(map_type, ebounds, skydir):
     axis = MapAxis.from_edges(ebounds, name="energy", unit="TeV", interp="log")
     if map_type == "wcs":
-        return WcsGeom.create(npix=(4, 3), binsz=2, axes=[axis])
+        return WcsGeom.create(npix=(4, 3), binsz=2, axes=[axis], skydir=skydir)
     elif map_type == "hpx":
         return HpxGeom(256, axes=[axis])
     else:
@@ -33,14 +62,16 @@ def geom(map_type, ebounds):
     "pars",
     [
         {
-            "geom": geom(map_type="wcs", ebounds=[0.1, 1, 10]),
+            "map_type": "wcs",
+            "ebounds": [0.1, 1, 10],
             "shape": (2, 3, 4),
-            "sum": 744.268356,
+            "sum": 928.955085,
         },
         {
-            "geom": geom(map_type="wcs", ebounds=[0.1, 10]),
+            "map_type": "wcs",
+            "ebounds": [0.1, 10],
             "shape": (1, 3, 4),
-            "sum": 799.743734,
+            "sum": 1006.720592,
         },
         # TODO: make this work for HPX
         # 'HpxGeom' object has no attribute 'separation'
@@ -51,14 +82,33 @@ def geom(map_type, ebounds):
         # },
     ],
 )
-def test_make_map_background_irf(bkg_3d, pars):
+
+def test_make_map_background_irf(bkg_3d, pars, fixed_pointing_info):
     m = make_map_background_irf(
-        pointing=SkyCoord(2, 1, unit="deg"),
+        pointing=fixed_pointing_info,
         ontime="42 s",
         bkg=bkg_3d,
-        geom=pars["geom"],
+        geom=geom(
+            map_type=pars['map_type'],
+            ebounds=pars['ebounds'],
+            skydir=fixed_pointing_info.radec
+        ),
     )
 
     assert m.data.shape == pars["shape"]
     assert m.unit == ""
     assert_allclose(m.data.sum(), pars["sum"], rtol=1e-5)
+
+def test_make_map_background_irf_asym(bkg_3d_asymmetric, fixed_pointing_info):
+    m = make_map_background_irf(
+        pointing=fixed_pointing_info,
+        ontime="42 s",
+        bkg=bkg_3d_asymmetric,
+        geom=geom(
+            map_type="wcs",
+            ebounds=[0.1, 1, 10],
+            skydir=fixed_pointing_info.radec
+        ),
+    )
+    assert_allclose(m.data[0, 0, 0], 34420.569872, rtol=1e-5)
+    assert_allclose(m.data[0, 1, 2], 47216.385951, rtol=1e-5)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -39,7 +39,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 3.99815e11,
             "exposure_image": 7.921993e10,
-            "background": 27981.977,
+            "background": 27988.54,
         },
         {
             # Test single energy bin
@@ -48,7 +48,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 30415.916,
+            "background": 30424.088,
         },
         {
             # Test single energy bin with exclusion mask
@@ -58,7 +58,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 30415.916,
+            "background": 30424.088,
         },
         {
             # Test for different e_true and e_reco bins
@@ -67,7 +67,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 5.971096e11,
             "exposure_image": 6.492968e10,
-            "background": 27981.977,
+            "background": 27988.54,
         },
     ],
 )

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -39,7 +39,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 3.99815e11,
             "exposure_image": 7.921993e10,
-            "background": 27988.54,
+            "background": 27986.945,
         },
         {
             # Test single energy bin
@@ -48,7 +48,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 30424.088,
+            "background": 30422.17,
         },
         {
             # Test single energy bin with exclusion mask
@@ -58,7 +58,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 30424.088,
+            "background": 30422.17,
         },
         {
             # Test for different e_true and e_reco bins
@@ -67,7 +67,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 5.971096e11,
             "exposure_image": 6.492968e10,
-            "background": 27988.54,
+            "background": 27986.945,
         },
     ],
 )

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -11,6 +11,7 @@ from ..utils.fits import earth_location_from_dict
 from ..utils.table import table_row_to_dict
 from ..utils.time import time_ref_from_dict
 from .filters import ObservationFilter
+from .pointing import FixedPointingInfo
 
 __all__ = ["DataStoreObservation", "Observations"]
 
@@ -206,6 +207,11 @@ class DataStoreObservation:
     def pointing_zen(self):
         """Pointing zenith angle sky (`~astropy.units.Quantity`)."""
         return Quantity(self.obs_info["ZEN_PNT"], unit="deg")
+
+    @property
+    def fixed_pointing_info(self):
+        """Fixed pointing info for this observation (`FixedPointingInfo`)."""
+        return FixedPointingInfo(self.events.table.meta)
 
     @property
     def target_radec(self):

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -95,7 +95,6 @@ class FixedPointingInfo:
     def radec(self):
         """RA / DEC pointing postion from table
         (`~astropy.coordinates.SkyCoord`)"""
-        print(self.meta.keys())
         ra = self.meta["RA_PNT"]
         dec = self.meta["DEC_PNT"]
         return SkyCoord(ra, dec, unit="deg", frame="icrs")

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -9,7 +9,102 @@ from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
 from ..utils.fits import earth_location_from_dict
 
-__all__ = ["PointingInfo"]
+__all__ = [
+    "FixedPointingInfo",
+    "PointingInfo",
+]
+
+
+class FixedPointingInfo:
+    """IACT array pointing info.
+
+    Data format specification: :ref:`gadf:iact-pnt`
+
+    Parameters
+    ----------
+    meta : `~astropy.table.Table.meta`
+        Meta header info from Table on pointing
+
+    Examples
+    --------
+    >>> from gammapy.data import PointingInfo
+    >>> path = '$GAMMAPY_DATA/tests/hess_event_list.fits'
+    >>> pointing_info = PointingInfo.read(path)
+    >>> print(pointing_info)
+    """
+
+    def __init__(self, meta):
+        self.meta = meta
+
+    @classmethod
+    def read(cls, filename, hdu="EVENTS"):
+        """Read pointing information table from file to obtain the metadata.
+
+        Parameters
+        ----------
+        filename : str
+            File name
+        hdu : int or str
+            HDU number or name
+
+        Returns
+        -------
+        pointing_info : `PointingInfo`
+            Pointing info object
+        """
+        filename = make_path(filename)
+        table = Table.read(str(filename), hdu=hdu)
+        return cls(meta=table.meta)
+
+    @lazyproperty
+    def location(self):
+        """Observatory location (`~astropy.coordinates.EarthLocation`)."""
+        return earth_location_from_dict(self.meta)
+
+    @lazyproperty
+    def time_ref(self):
+        """Time reference (`~astropy.time.Time`)"""
+        return time_ref_from_dict(self.meta)
+
+    @lazyproperty
+    def time_start(self):
+        """Start time (`~astropy.time.Time`)"""
+        t_start = Quantity(self.meta['TSTART'], "second")
+        return self.time_ref + t_start
+
+    @lazyproperty
+    def time_stop(self):
+        """Stop time (`~astropy.time.Time`)"""
+        t_stop = Quantity(self.meta['TSTOP'], "second")
+        return self.time_ref + t_stop
+
+    @lazyproperty
+    def duration(self):
+        """Pointing duration (`~astropy.time.TimeDelta`).
+
+        The time difference between the TSTART and TSTOP.
+        """
+        return self.time_stop - self.time_start
+
+    @lazyproperty
+    def radec(self):
+        """RA / DEC pointing postion from table
+        (`~astropy.coordinates.SkyCoord`)"""
+        print(self.meta.keys())
+        lon = self.meta["RA_PNT"]
+        lat = self.meta["DEC_PNT"]
+        return SkyCoord(lon, lat, unit="deg", frame="icrs")
+
+    @lazyproperty
+    def altaz_frame(self):
+        """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
+        return AltAz(obstime=self.time_start, location=self.location)
+
+    @lazyproperty
+    def altaz(self):
+        """ALT / AZ pointing position computed from RA / DEC
+        (`~astropy.coordinates.SkyCoord`)"""
+        return self.radec.transform_to(self.altaz_frame)
 
 
 class PointingInfo:

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -79,6 +79,11 @@ class FixedPointingInfo:
         return self.time_ref + t_stop
 
     @lazyproperty
+    def obstime(self):
+        """Average observation time for the observation (`~astropy.time.Time`)"""
+        return self.time_start + self.duration / 2
+
+    @lazyproperty
     def duration(self):
         """Pointing duration (`~astropy.time.TimeDelta`).
 
@@ -91,14 +96,14 @@ class FixedPointingInfo:
         """RA / DEC pointing postion from table
         (`~astropy.coordinates.SkyCoord`)"""
         print(self.meta.keys())
-        lon = self.meta["RA_PNT"]
-        lat = self.meta["DEC_PNT"]
-        return SkyCoord(lon, lat, unit="deg", frame="icrs")
+        ra = self.meta["RA_PNT"]
+        dec = self.meta["DEC_PNT"]
+        return SkyCoord(ra, dec, unit="deg", frame="icrs")
 
     @lazyproperty
     def altaz_frame(self):
         """ALT / AZ frame (`~astropy.coordinates.AltAz`)."""
-        return AltAz(obstime=self.time_start, location=self.location)
+        return AltAz(obstime=self.obstime, location=self.location)
 
     @lazyproperty
     def altaz(self):

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -44,8 +44,8 @@ class TestFixedPointingInfo:
 
     def test_altaz(self):
         pos = self.fpi.altaz
-        assert_allclose(pos.az.deg, 11.45751357)
-        assert_allclose(pos.alt.deg, 41.34088901)
+        assert_allclose(pos.az.deg, 7.48272)
+        assert_allclose(pos.alt.deg, 41.84191)
         assert pos.name == "altaz"
 
 

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -2,7 +2,52 @@
 from numpy.testing import assert_allclose
 from astropy.time import Time
 from ...utils.testing import requires_data, assert_time_allclose
-from ..pointing import PointingInfo
+from ..pointing import FixedPointingInfo, PointingInfo
+
+
+@requires_data("gammapy-data")
+class TestFixedPointingInfo:
+    @classmethod
+    def setup_class(cls):
+        filename = "$GAMMAPY_DATA/tests/hess_event_list.fits"
+        cls.fpi = FixedPointingInfo.read(filename)
+
+    def test_location(self):
+        lon, lat, height = self.fpi.location.geodetic
+        assert_allclose(lon.deg, 16.5002222222222)
+        assert_allclose(lat.deg, -23.2717777777778)
+        assert_allclose(height.value, 1834.999999999783)
+
+    def test_time_ref(self):
+        expected = Time(51910.00074287037, format="mjd", scale="tt")
+        assert_time_allclose(self.fpi.time_ref, expected)
+
+    def test_time_start(self):
+        time = self.fpi.time_start
+        expected = Time(53025.826414166666, format="mjd", scale="tt")
+        assert_time_allclose(time, expected)
+
+    def test_time_stop(self):
+        time = self.fpi.time_stop
+        expected = Time(53025.844770648146, format="mjd", scale="tt")
+        assert_time_allclose(time, expected)
+
+    def test_duration(self):
+        duration = self.fpi.duration
+        assert_allclose(duration.sec, 1586.0000000044238)
+
+    def test_radec(self):
+        pos = self.fpi.radec
+        assert_allclose(pos.ra.deg, 83.633333333333)
+        assert_allclose(pos.dec.deg, 24.51444444)
+        assert pos.name == "icrs"
+
+    def test_altaz(self):
+        pos = self.fpi.altaz
+        assert_allclose(pos.az.deg, 11.45751357)
+        assert_allclose(pos.alt.deg, 41.34088901)
+        assert pos.name == "altaz"
+
 
 
 @requires_data("gammapy-data")


### PR DESCRIPTION
Previously, the background map returned from `make_map_background_irf` assumed a symmetric background IRF in the FoV. This PR correctly calculates the FoV coordinates to evaluate the background at. This is achieved with the `FixedPointingInfo` class, which eases the conversion from sky coordinates to FoV coordinates.

The `FixedPointingInfo` is generated from the pointing metadata contained in the `EVENTS` hdu. 

Adresses #1987