### PR TITLE
Change SkyModel addition to return a SkyModels object

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -19,11 +19,11 @@ __all__ = [
 class SkyModelBase(Model):
     """Sky model base class"""
     def __add__(self, skymodel):
-        skymodels = []
-        if isinstance(self, SkyModels):
-            skymodels += self.skymodels
-        elif isinstance(self, SkyModel):
-            skymodels += [self, ]
+        skymodels = [self]
+        if isinstance(skymodel, SkyModels):
+            skymodels += skymodel.skymodels
+        elif isinstance(skymodel, (SkyModel, SkyDiffuseCube)):
+            skymodels += [skymodel]
         else:
             raise NotImplementedError
         return SkyModels(skymodels)
@@ -114,9 +114,7 @@ class SkyModels(SkyModelBase):
         str_ = self.__class__.__name__ + "\n\n"
 
         for idx, skymodel in enumerate(self.skymodels):
-            str_ += "Component: {idx}\n\n\t".format(idx=idx)
-            table = skymodel.parameters.to_table()
-            str_ += "\n\t".join(table.pformat())
+            str_ += "Component {idx}: {skymodel}\n\n\t".format(idx=idx, skymodel=skymodel)
             str_ += "\n\n"
 
         if self.parameters.covariance is not None:
@@ -124,6 +122,25 @@ class SkyModels(SkyModelBase):
             covariance = self.parameters.covariance_to_table()
             str_ += "\n\t".join(covariance.pformat())
         return str_
+
+    def __iadd__(self, skymodel):
+        if isinstance(skymodel, SkyModels):
+            self.skymodels += skymodel.skymodels
+        elif isinstance(skymodel, (SkyModel, SkyDiffuseCube)):
+            self.skymodels += [skymodel]
+        else:
+            raise NotImplementedError
+        return self
+
+    def __add__(self, skymodel):
+        skymodels = self.skymodels.copy()
+        if isinstance(skymodel, SkyModels):
+            skymodels += skymodel.skymodels
+        elif isinstance(skymodel, (SkyModel, SkyDiffuseCube)):
+            skymodels += [skymodel]
+        else:
+            raise NotImplementedError
+        return SkyModels(skymodels)
 
 
 class SkyModel(SkyModelBase):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -91,6 +91,29 @@ def compound_model(sky_model):
     return CompoundSkyModel(sky_model, sky_model, np.add)
 
 
+def test_skymodel_addition(sky_model, sky_models, diffuse_model):
+    result = sky_model + sky_model.copy()
+    assert isinstance(result, SkyModels)
+    assert len(result.skymodels) == 2
+
+    result = sky_model + sky_models
+    assert isinstance(result, SkyModels)
+    assert len(result.skymodels) == 3
+
+    result = sky_models + sky_model
+    assert isinstance(result, SkyModels)
+    assert len(result.skymodels) == 3
+
+    result = sky_models + diffuse_model
+    assert isinstance(result, SkyModels)
+    assert len(result.skymodels) == 3
+
+    result = sky_models + sky_models
+    assert isinstance(result, SkyModels)
+    assert len(result.skymodels) == 4
+
+
+
 def test_background_model(background):
     bkg1 = BackgroundModel(background, norm=2.0).evaluate()
     assert_allclose(bkg1.data[0][0][0], background.data[0][0][0] * 2.0, rtol=1e-3)

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -149,6 +149,11 @@ class TestSkyModels:
         assert q.shape == (5, 3, 4)
         assert_allclose(q.value, 3.536776513153229e-13)
 
+    @staticmethod
+    def test_str(sky_models):
+        assert "Component 0" in str(sky_models)
+        assert "Component 1" in str(sky_models)
+
 
 class TestSkyModel:
     @staticmethod

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -88,7 +88,7 @@ def sky_models(sky_model):
 
 @pytest.fixture(scope="session")
 def compound_model(sky_model):
-    return sky_model + sky_model
+    return CompoundSkyModel(sky_model, sky_model, np.add)
 
 
 def test_background_model(background):
@@ -104,15 +104,6 @@ def test_background_model(background):
 
 
 class TestSkyModels:
-    @staticmethod
-    def test_to_compound_model(sky_models):
-        model = sky_models.to_compound_model()
-        assert isinstance(model, CompoundSkyModel)
-        pars = model.parameters.parameters
-        assert len(pars) == 12
-        assert pars[0].name == "lon_0"
-        assert pars[-1].name == "reference"
-
     @staticmethod
     def test_parameters(sky_models):
         parnames = ["lon_0", "lat_0", "sigma", "index", "amplitude", "reference"] * 2

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -803,8 +803,7 @@
    "outputs": [],
    "source": [
     "# Checking normalization value (the closer to 1 the better)\n",
-    "print(\"Model 1: {}\\n\".format(model_combined.model1))\n",
-    "print(\"Model 2: {}\\n\".format(model_combined.model2))\n",
+    "print(model_combined)\n",
     "print(\"Background model: {}\\n\".format(background_model))"
    ]
   },
@@ -930,7 +929,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR includes the following changes:
* Change the `+` operator of two `SkyModel` objects to return a `SkyModels` objects instead of `CompoundSkyModel`
* Implement the `+` operator for `SkyModels`
* Remove `.parameters` setters on `SkyModel` and `SkyModels`, which are unused. In first place those were added to update parameters by the optimizer, which is now achieved by `Parameters.set_parameter_factors()`.
