### PR TITLE
Add parameter freezing for sherpa backend

### DIFF
--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -243,7 +243,7 @@ def fit():
     data = FluxPoints.read(path)
     data.table["e_ref"] = data.e_ref.to("TeV")
 
-    model = PowerLaw(index=2.3, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV")
+    model = PowerLaw(index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV")
     dataset = FluxPointsDataset(model, data)
     return Fit(dataset)
 
@@ -257,7 +257,6 @@ class TestFluxPointFit:
         self.assert_result(result)
 
     @requires_dependency("sherpa")
-    @pytest.mark.skip(reason="Sherpa backend does not support fixing parameters yet.")
     def test_fit_pwl_sherpa(self, fit):
         result = fit.optimize(backend="sherpa", method="simplex")
         self.assert_result(result)
@@ -270,9 +269,11 @@ class TestFluxPointFit:
         index = result.parameters["index"]
         assert_allclose(index.value, 2.216, rtol=1e-3)
 
-        # Right now sherpa also fits the reference energy
         amplitude = result.parameters["amplitude"]
         assert_allclose(amplitude.value, 2.1616e-13, rtol=1e-3)
+
+        reference = result.parameters["reference"]
+        assert_allclose(reference.value, 1, rtol=1e-8)
 
     @requires_dependency("iminuit")
     @staticmethod

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -63,7 +63,7 @@ def covariance_iminuit(minuit):
 
     message, success = "Hesse terminated successfully.", True
     try:
-        covariance_factors = minuit.np_covariance
+        covariance_factors = minuit.np_covariance()
     except TypeError:
         N = len(minuit.args)
         covariance_factors = np.nan * np.ones((N, N))
@@ -146,15 +146,14 @@ def make_minuit_par_kwargs(parameters):
     kwargs = {"forced_parameters": names}
 
     for name, par in zip(names, parameters):
-        if not par.frozen:
-            kwargs[name] = par.factor
+        kwargs[name] = par.factor
 
-            min_ = None if np.isnan(par.factor_min) else par.factor_min
-            max_ = None if np.isnan(par.factor_max) else par.factor_max
-            kwargs["limit_{}".format(name)] = (min_, max_)
+        min_ = None if np.isnan(par.factor_min) else par.factor_min
+        max_ = None if np.isnan(par.factor_max) else par.factor_max
+        kwargs["limit_{}".format(name)] = (min_, max_)
 
-            kwargs["error_{}".format(name)] = 1
-            kwargs["fix_{}".format(name)] = par.frozen
+        kwargs["error_{}".format(name)] = 1
+        kwargs["fix_{}".format(name)] = par.frozen
 
     return kwargs
 

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -249,6 +249,11 @@ class Parameters:
         """List of `Parameter`."""
         return self._parameters
 
+    @property
+    def free_parameters(self):
+        """List of free parameters"""
+        return [par for par in self.parameters if not par.frozen]
+
     # TODO: replace this with a better API to update parameters
     @parameters.setter
     def parameters(self, vals):
@@ -464,7 +469,10 @@ class Parameters:
 
         Used in the optimizer interface.
         """
-        self.covariance = self._scale_matrix * self._expand_factor_matrix(matrix)
+        if not np.sqrt(matrix.size) == len(self.parameters):
+            matrix = self._expand_factor_matrix(matrix)
+
+        self.covariance = self._scale_matrix * matrix
 
     def autoscale(self, method="scale10"):
         """Autoscale all parameters.

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -45,9 +45,9 @@ def optimize_sherpa(parameters, function, **kwargs):
     optimizer = get_sherpa_optimizer(method)
     optimizer.config.update(kwargs)
 
-    pars = [par.factor for par in parameters.parameters if not par.frozen]
-    parmins = [par.factor_min for par in parameters.parameters if not par.frozen]
-    parmaxes = [par.factor_max for par in parameters.parameters if not par.frozen]
+    pars = [par.factor for par in parameters.free_parameters]
+    parmins = [par.factor_min for par in parameters.free_parameters]
+    parmaxes = [par.factor_max for par in parameters.free_parameters]
 
     statfunc = SherpaLikelihood(function, parameters)
 

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -45,9 +45,9 @@ def optimize_sherpa(parameters, function, **kwargs):
     optimizer = get_sherpa_optimizer(method)
     optimizer.config.update(kwargs)
 
-    pars = [par.factor for par in parameters.parameters]
-    parmins = [par.factor_min for par in parameters.parameters]
-    parmaxes = [par.factor_max for par in parameters.parameters]
+    pars = [par.factor for par in parameters.parameters if not par.frozen]
+    parmins = [par.factor_min for par in parameters.parameters if not par.frozen]
+    parmaxes = [par.factor_max for par in parameters.parameters if not par.frozen]
 
     statfunc = SherpaLikelihood(function, parameters)
 

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -10,15 +10,16 @@ def fcn(parameters):
     x = parameters["x"].value
     y = parameters["y"].value
     z = parameters["z"].value
-    x_opt, y_opt, z_opt = 2, 3e2, 4e-2
-    return (x - x_opt) ** 2 + (y - y_opt) ** 2 + (z - z_opt) ** 2
+    x_opt, y_opt, z_opt = 2, 3e5, 4e-5
+    x_err, y_err, z_err = 0.2, 3e4, 4e-6
+    return ((x - x_opt) / x_err) ** 2 + ((y - y_opt) / y_err) ** 2 + ((z - z_opt) / z_err) ** 2
 
 
 @pytest.fixture()
 def pars():
     x = Parameter("x", 2.1)
-    y = Parameter("y", 3.1, scale=1e2)
-    z = Parameter("z", 4.1, scale=1e-2)
+    y = Parameter("y", 3.1, scale=1e5)
+    z = Parameter("z", 4.1, scale=1e-5)
     return Parameters([x, y, z])
 
 
@@ -30,9 +31,9 @@ def test_iminuit_basic(pars):
 
     # Check the result in parameters is OK
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
-    assert_allclose(pars["y"].value, 3e2, rtol=1e-3)
+    assert_allclose(pars["y"].value, 3e5, rtol=1e-3)
     # Precision of estimate on "z" is very poor (0.040488). Why is it so bad?
-    assert_allclose(pars["z"].value, 4e-2, rtol=2e-2)
+    assert_allclose(pars["z"].value, 4e-5, rtol=2e-2)
 
     # Check that minuit sees the parameter factors correctly
     assert_allclose(factors, [2, 3, 4], rtol=1e-3)
@@ -48,15 +49,16 @@ def test_iminuit_frozen(pars):
 
     assert info["success"]
 
-    assert_allclose(pars["x"].value, 2.004907, rtol=1e-5)
-    assert_allclose(pars["y"].value, 3.1e2)
-    assert_allclose(pars["z"].value, 0.044906, rtol=1e-5)
-    assert_allclose(fcn(pars), 100, rtol=1e-5)
+    assert_allclose(pars["x"].value, 2, rtol=1e-4)
+    assert_allclose(pars["y"].value, 3.1e5)
+    assert_allclose(pars["z"].value, 4.e-5, rtol=1e-4)
+    assert_allclose(fcn(pars), 0.111112, rtol=1e-5)
+
     assert minuit.list_of_fixed_param() == ["par_001_y"]
 
 
 def test_iminuit_limits(pars):
-    pars["y"].min = 301
+    pars["y"].min = 301000
 
     factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
 
@@ -64,7 +66,7 @@ def test_iminuit_limits(pars):
 
     # Check the result in parameters is OK
     assert_allclose(pars["x"].value, 2, rtol=1e-2)
-    assert_allclose(pars["y"].value, 301, rtol=1e-3)
+    assert_allclose(pars["y"].value, 301000, rtol=1e-3)
 
     # Check that minuit sees the limit factors correctly
     states = minuit.get_param_states()

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -48,7 +48,10 @@ def test_iminuit_frozen(pars):
 
     assert info["success"]
 
+    assert_allclose(pars["x"].value, 2.004907, rtol=1e-5)
     assert_allclose(pars["y"].value, 3.1e2)
+    assert_allclose(pars["z"].value, 0.044906, rtol=1e-5)
+    assert_allclose(fcn(pars), 100, rtol=1e-5)
     assert minuit.list_of_fixed_param() == ["par_001_y"]
 
 

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -149,7 +149,7 @@ def test_parameters_set_parameter_factors(pars):
 
 
 def test_parameters_set_covariance_factors(pars):
-    cov_factor = [[3, 4], [7, 8]]
+    cov_factor = np.array([[3, 4], [7, 8]])
     pars.set_covariance_factors(cov_factor)
     assert_allclose(pars.covariance, cov_factor)
 

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -29,7 +29,7 @@ def pars():
 
 @pytest.mark.parametrize("method", ["moncar", "simplex"])
 def test_sherpa(method, pars):
-    factors, info, optimizer = optimize_sherpa(
+    factors, info, _ = optimize_sherpa(
         function=fcn, parameters=pars, method=method
     )
 
@@ -45,11 +45,10 @@ def test_sherpa(method, pars):
     assert_allclose(factors, [2, 3, 4])
 
 
-
 def test_sherpa_frozen(pars):
     pars["y"].frozen = True
 
-    factors, info, minuit = optimize_sherpa(function=fcn, parameters=pars)
+    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars)
 
     assert info["success"]
     assert_allclose(pars["x"].value, 2)
@@ -61,7 +60,7 @@ def test_sherpa_frozen(pars):
 def test_sherpa_limits(pars):
     pars["y"].min = 301000
 
-    factors, info, minuit = optimize_sherpa(function=fcn, parameters=pars)
+    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars)
 
     assert info["success"]
 

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -12,7 +12,7 @@ def fcn(parameters):
     z = parameters["z"].value
     x_opt, y_opt, z_opt = 2, 3e5, 4e-5
     x_err, y_err, z_err = 0.2, 3e4, 4e-6
-    return ((x - x_opt) / x_err) ** 2 + ((y - y_opt) / y_err) ** 2 +((z - z_opt) / z_err) ** 2
+    return ((x - x_opt) / x_err) ** 2 + ((y - y_opt) / y_err) ** 2 + ((z - z_opt) / z_err) ** 2
 
 
 @pytest.fixture()
@@ -56,3 +56,15 @@ def test_sherpa_frozen(pars):
     assert_allclose(pars["y"].value, 3.1e5)
     assert_allclose(pars["z"].value, 4.1e-5)
     assert_allclose(fcn(pars), 0.173611, rtol=1e-6)
+
+
+def test_sherpa_limits(pars):
+    pars["y"].min = 301000
+
+    factors, info, minuit = optimize_sherpa(function=fcn, parameters=pars)
+
+    assert info["success"]
+
+    # Check the result in parameters is OK
+    assert_allclose(pars["x"].value, 2, rtol=1e-2)
+    assert_allclose(pars["y"].value, 301000, rtol=1e-3)


### PR DESCRIPTION
This PR adds parameter freezing for the sherpa backend. It also improves the `optimise_sherpa` and `optimise_minuit` tests.