### PR TITLE
Simplify and move energy threshold computation

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -247,7 +247,11 @@ class EffectiveAreaTable:
         return cleaned_data.max()
 
     def find_energy(self, aeff, emin=None, emax=None):
-        """Find energy for given effective area.
+        """Find energy for a given effective area.
+
+        In case the solution is not unique, provide the `emin` or `emax` arguments
+        to limit the solution to the given range. By default the peak energy of the
+        effective area is chosen as `emax`.
 
         Parameters
         ----------
@@ -261,14 +265,16 @@ class EffectiveAreaTable:
         Returns
         -------
         energy : `~astropy.units.Quantity`
-            Energy corresponding to aeff
+            Energy corresponding to the given aeff.
         """
         from ..spectrum.models import TableModel
+        energy = self.energy.nodes
 
         if emin is None:
-            emin = self.energy.nodes[0]
+            emin = energy[0]
         if emax is None:
-            emax = self.energy.nodes[-1]
+            # use the peak effective area as a default for the energy maximum
+            emax = energy[np.argmax(self.data.data)]
 
         aeff_spectrum = TableModel(self.energy.nodes, self.data.data, values_scale="lin")
         return aeff_spectrum.inverse(aeff, emin=emin, emax=emax)

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -270,7 +270,7 @@ class EffectiveAreaTable:
         if emax is None:
             emax = self.energy.nodes[-1]
 
-        aeff_spectrum = TableModel(self.energy.nodes, self.data.data)
+        aeff_spectrum = TableModel(self.energy.nodes, self.data.data, values_scale="lin")
         return aeff_spectrum.inverse(aeff, emin=emin, emax=emax)
 
     def to_sherpa(self, name):

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -276,8 +276,9 @@ class EffectiveAreaTable:
             # use the peak effective area as a default for the energy maximum
             emax = energy[np.argmax(self.data.data)]
 
-        aeff_spectrum = TableModel(self.energy.nodes, self.data.data, values_scale="lin")
+        aeff_spectrum = TableModel(energy, self.data.data, values_scale="lin")
         return aeff_spectrum.inverse(aeff, emin=emin, emax=emax)
+
 
     def to_sherpa(self, name):
         """Convert to `~sherpa.astro.data.DataARF`

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -441,6 +441,34 @@ class EnergyDispersion:
         bias = (e_reco - e_true_real) / e_true_real
         return bias
 
+    def get_bias_energy(self, bias, emin=None, emax=None):
+        """Find energy correspoding to a given bias
+
+        Parameters
+        ----------
+        bias : float
+            Bias value.
+        emin : `~astropy.units.Quantity`
+            Lower bracket value in case solution is not unique.
+        emax : `~astropy.units.Quantity`
+            Upper bracket value in case solution is not unique.
+
+        Returns
+        -------
+        bias_energy : `~astropy.unit.Quantity`
+            Bias energy
+        """
+        from ..spectrum.models import TableModel
+
+        if emin is None:
+            emin = self.energy.nodes[0]
+        if emax is None:
+            emax = self.energy.nodes[-1]
+
+        values = self.get_bias(self.e_true.nodes)
+        bias_spectrum = TableModel(self.e_true.nodes, values)
+        return bias_spectrum.inverse(bias, emin=emin, emax=emax)
+
     def get_mean(self, e_true):
         """Get mean reconstructed energy for a given true energy."""
         # find pdf for true energies

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -442,7 +442,11 @@ class EnergyDispersion:
         return bias
 
     def get_bias_energy(self, bias, emin=None, emax=None):
-        """Find energy correspoding to a given bias
+        """Find energy corresponding to a given bias.
+
+        In case the solution is not unique, provide the `emin` or `emax` arguments
+        to limit the solution to the given range.  By default the peak energy of the
+        bias is chosen as `emin`.
 
         Parameters
         ----------
@@ -456,19 +460,23 @@ class EnergyDispersion:
         Returns
         -------
         bias_energy : `~astropy.unit.Quantity`
-            Bias energy
+            Reconstructed energy corresponding to the given bias.
         """
         from ..spectrum.models import TableModel
-        energy = self.e_true.nodes
-        values = self.get_bias(energy)
+        e_true = self.e_true.nodes
+        values = self.get_bias(e_true)
 
         if emin is None:
-            emin = energy[np.nanargmax(values)]
+            # use the peak bias energy as default minimum
+            emin = e_true[np.nanargmax(values)]
         if emax is None:
-            emax = energy[-1]
+            emax = e_true[-1]
 
-        bias_spectrum = TableModel(energy, values)
-        return bias_spectrum.inverse(Quantity(bias), emin=emin, emax=emax)
+        bias_spectrum = TableModel(e_true, values)
+        e_true = bias_spectrum.inverse(Quantity(bias), emin=emin, emax=emax)
+
+        # return reconstructed energy
+        return e_true * (1 + bias)
 
     def get_mean(self, e_true):
         """Get mean reconstructed energy for a given true energy."""

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -461,13 +461,13 @@ class EnergyDispersion:
         from ..spectrum.models import TableModel
 
         if emin is None:
-            emin = self.energy.nodes[0]
+            emin = self.e_true.nodes[0]
         if emax is None:
-            emax = self.energy.nodes[-1]
+            emax = self.e_true.nodes[-1]
 
         values = self.get_bias(self.e_true.nodes)
-        bias_spectrum = TableModel(self.e_true.nodes, values)
-        return bias_spectrum.inverse(bias, emin=emin, emax=emax)
+        bias_spectrum = TableModel(self.e_true.nodes, values, values_scale="lin")
+        return bias_spectrum.inverse(Quantity(bias), emin=emin, emax=emax)
 
     def get_mean(self, e_true):
         """Get mean reconstructed energy for a given true energy."""

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -459,14 +459,15 @@ class EnergyDispersion:
             Bias energy
         """
         from ..spectrum.models import TableModel
+        energy = self.e_true.nodes
+        values = self.get_bias(energy)
 
         if emin is None:
-            emin = self.e_true.nodes[0]
+            emin = energy[np.nanargmax(values)]
         if emax is None:
-            emax = self.e_true.nodes[-1]
+            emax = energy[-1]
 
-        values = self.get_bias(self.e_true.nodes)
-        bias_spectrum = TableModel(self.e_true.nodes, values, values_scale="lin")
+        bias_spectrum = TableModel(energy, values)
         return bias_spectrum.inverse(Quantity(bias), emin=emin, emax=emax)
 
     def get_mean(self, e_true):

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -473,10 +473,10 @@ class EnergyDispersion:
             emax = e_true[-1]
 
         bias_spectrum = TableModel(e_true, values)
-        e_true = bias_spectrum.inverse(Quantity(bias), emin=emin, emax=emax)
+        e_true_bias = bias_spectrum.inverse(Quantity(bias), emin=emin, emax=emax)
 
         # return reconstructed energy
-        return e_true * (1 + bias)
+        return e_true_bias * (1 + bias)
 
     def get_mean(self, e_true):
         """Get mean reconstructed energy for a given true energy."""

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -101,6 +101,10 @@ class TestEffectiveAreaTable:
         assert elo_threshold.unit == "TeV"
         assert_allclose(elo_threshold.value, 0.552741, rtol=1e-3)
 
+        ehi_threshold = arf.find_energy(0.9 * arf.max_area, reverse=True)
+        assert ehi_threshold.unit == "TeV"
+        assert_allclose(ehi_threshold.value, 53.600246, rtol=1e-3)
+
         # Test evaluation outside safe range
         data = [np.nan, np.nan, 0, 0, 1, 2, 3, np.nan, np.nan]
         energy = np.logspace(0, 10, 10) * u.TeV

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -101,7 +101,7 @@ class TestEffectiveAreaTable:
         assert elo_threshold.unit == "TeV"
         assert_allclose(elo_threshold.value, 0.554086, rtol=1e-3)
 
-        ehi_threshold = arf.find_energy(0.9 * arf.max_area, emin=30 * u.TeV)
+        ehi_threshold = arf.find_energy(0.9 * arf.max_area, emin=30 * u.TeV, emax=100 * u.TeV)
         assert ehi_threshold.unit == "TeV"
         assert_allclose(ehi_threshold.value, 53.347217, rtol=1e-3)
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -99,7 +99,7 @@ class TestEffectiveAreaTable:
 
         elo_threshold = arf.find_energy(0.1 * arf.max_area)
         assert elo_threshold.unit == "TeV"
-        assert_allclose(elo_threshold.value, 0.552741, rtol=1e-3)
+        assert_allclose(elo_threshold.value, 0.554086, rtol=1e-3)
 
         ehi_threshold = arf.find_energy(0.9 * arf.max_area, reverse=True)
         assert ehi_threshold.unit == "TeV"

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -101,9 +101,9 @@ class TestEffectiveAreaTable:
         assert elo_threshold.unit == "TeV"
         assert_allclose(elo_threshold.value, 0.554086, rtol=1e-3)
 
-        ehi_threshold = arf.find_energy(0.9 * arf.max_area, reverse=True)
+        ehi_threshold = arf.find_energy(0.9 * arf.max_area, emin=30 * u.TeV)
         assert ehi_threshold.unit == "TeV"
-        assert_allclose(ehi_threshold.value, 53.600246, rtol=1e-3)
+        assert_allclose(ehi_threshold.value, 53.347217, rtol=1e-3)
 
         # Test evaluation outside safe range
         data = [np.nan, np.nan, 0, 0, 1, 2, 3, np.nan, np.nan]

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -201,11 +201,12 @@ class SpectrumObservation:
         # vector, otherwise Sherpa will not understand the files
 
         # Low threshold
+        e_center = np.sqrt(self.e_true[0] * self.e_true[-1])
         if method_lo == "area_max":
             aeff_thres = kwargs["area_percent_lo"] / 100 * self.aeff.max_area
-            thres_lo = self.aeff.find_energy(aeff_thres)
+            thres_lo = self.aeff.find_energy(aeff_thres, emax=e_center)
         elif method_lo == "energy_bias":
-            thres_lo = self.edisp.get_bias_energy(kwargs["bias_percent_lo"] / 100)
+            thres_lo = self.edisp.get_bias_energy(kwargs["bias_percent_lo"] / 100, emax=e_center)
         elif method_lo == "none":
             thres_lo = self.e_true[0]
         else:
@@ -218,10 +219,11 @@ class SpectrumObservation:
         # High threshold
         if method_hi == "area_max":
             aeff_thres = kwargs["area_percent_hi"] / 100 * self.aeff.max_area
-            thres_hi = self.aeff.find_energy(aeff_thres)
+            thres_hi = self.aeff.find_energy(aeff_thres, emin=e_center, emax=self.e_true[-1])
         elif method_hi == "energy_bias":
             thres_hi = self.edisp.get_bias_energy(
-                kwargs["bias_percent_hi"] / 100
+                kwargs["bias_percent_hi"] / 100,
+                emin=e_center,
             )
         elif method_hi == "none":
             thres_hi = self.e_true[-1]

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -201,12 +201,11 @@ class SpectrumObservation:
         # vector, otherwise Sherpa will not understand the files
 
         # Low threshold
-        e_center = np.sqrt(self.e_true[0] * self.e_true[-1])
         if method_lo == "area_max":
             aeff_thres = kwargs["area_percent_lo"] / 100 * self.aeff.max_area
-            thres_lo = self.aeff.find_energy(aeff_thres, emax=e_center)
+            thres_lo = self.aeff.find_energy(aeff_thres)
         elif method_lo == "energy_bias":
-            thres_lo = self.edisp.get_bias_energy(kwargs["bias_percent_lo"] / 100, emax=e_center)
+            thres_lo = self.edisp.get_bias_energy(kwargs["bias_percent_lo"] / 100)
         elif method_lo == "none":
             thres_lo = self.e_true[0]
         else:

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -209,7 +209,7 @@ class SpectrumObservation:
         elif method_lo == "none":
             thres_lo = self.e_true[0]
         else:
-            raise ValueError("Undefine method for low threshold: {}".format(method_lo))
+            raise ValueError("Undefined method for low threshold: {}".format(method_lo))
 
         self.on_vector.lo_threshold = thres_lo
         if self.off_vector is not None:
@@ -218,11 +218,13 @@ class SpectrumObservation:
         # High threshold
         if method_hi == "area_max":
             aeff_thres = kwargs["area_percent_hi"] / 100 * self.aeff.max_area
-            thres_hi = self.aeff.find_energy(aeff_thres, emin=e_center, emax=self.e_true[-1])
+            e_min = self.e_true[-1]
+            thres_hi = self.aeff.find_energy(aeff_thres, emin=e_min)
         elif method_hi == "energy_bias":
+            e_min = self.e_true[-1]
             thres_hi = self.edisp.get_bias_energy(
                 kwargs["bias_percent_hi"] / 100,
-                emin=e_center,
+                emin=e_min,
             )
         elif method_hi == "none":
             thres_hi = self.e_true[-1]

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -205,7 +205,7 @@ class SpectrumObservation:
             aeff_thres = kwargs["area_percent_lo"] / 100 * self.aeff.max_area
             thres_lo = self.aeff.find_energy(aeff_thres)
         elif method_lo == "energy_bias":
-            thres_lo = self._find_bias_energy(kwargs["bias_percent_lo"] / 100)
+            thres_lo = self.edisp.get_bias_energy(kwargs["bias_percent_lo"] / 100)
         elif method_lo == "none":
             thres_lo = self.e_true[0]
         else:
@@ -218,10 +218,10 @@ class SpectrumObservation:
         # High threshold
         if method_hi == "area_max":
             aeff_thres = kwargs["area_percent_hi"] / 100 * self.aeff.max_area
-            thres_hi = self.aeff.find_energy(aeff_thres, reverse=True)
+            thres_hi = self.aeff.find_energy(aeff_thres)
         elif method_hi == "energy_bias":
-            thres_hi = self._find_bias_energy(
-                kwargs["bias_percent_hi"] / 100, reverse=True
+            thres_hi = self.edisp.get_bias_energy(
+                kwargs["bias_percent_hi"] / 100
             )
         elif method_hi == "none":
             thres_hi = self.e_true[-1]
@@ -233,31 +233,6 @@ class SpectrumObservation:
         self.on_vector.hi_threshold = thres_hi
         if self.off_vector is not None:
             self.off_vector.hi_threshold = thres_hi
-
-    def _find_bias_energy(self, bias_value, reverse=False):
-        """Helper function to interpolate between bias values to retrieve an energy"""
-        e = self.e_true.log_centers
-        bias = np.abs(self.edisp.get_bias(e))
-        with np.errstate(invalid="ignore"):
-            valid = np.where(bias <= bias_value)[0]
-        idx = valid[0]
-        if reverse:
-            idx = valid[-1]
-        if not reverse:
-            if idx == 0:
-                energy = self.e_true[idx].value
-            else:
-                energy = np.interp(
-                    bias_value, (bias[[idx - 1, idx]].value), (e[[idx - 1, idx]].value)
-                )
-        else:
-            if idx == e.size - 1:
-                energy = self.e_true[idx + 1].value
-            else:
-                energy = np.interp(
-                    bias_value, (bias[[idx, idx + 1]].value), (e[[idx, idx + 1]].value)
-                )
-        return energy * self.e_true.unit
 
     @property
     def background_vector(self):

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -28,7 +28,7 @@ def test_spectrum_observation_1():
         npred=109.014552,
         excess=169.916667,
         excess_safe_range=116.33,
-        lo_threshold=8.912509e+08,
+        lo_threshold=1.e+09,
         hi_threshold=1e11,
     )
     tester = SpectrumObservationTester(obs, pars)
@@ -58,7 +58,7 @@ def test_spectrum_observation_2():
         npred=292.00223031875987,
         excess=824,
         excess_safe_range=824,
-        lo_threshold=0.012045,
+        lo_threshold=0.013219,
         hi_threshold=100,
     )
     tester = SpectrumObservationTester(obs, pars)
@@ -193,8 +193,8 @@ class SpectrumObservationTester:
                 bias_percent_hi=10
             )
 
-            assert_allclose(self.obs.lo_threshold.value, self.vals["lo_threshold"], rtol=1e-5)
-            assert_allclose(self.obs.hi_threshold.value, self.vals["hi_threshold"], rtol=1e-5)
+            assert_allclose(self.obs.lo_threshold.value, self.vals["lo_threshold"], rtol=1e-4)
+            assert_allclose(self.obs.hi_threshold.value, self.vals["hi_threshold"], rtol=1e-4)
             self.obs.reset_thresholds()
 
 

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -59,7 +59,7 @@ def test_spectrum_observation_2():
         excess=824,
         excess_safe_range=824,
         lo_threshold=0.012045,
-        hi_threshold=83.021757,
+        hi_threshold=100,
     )
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
@@ -188,7 +188,7 @@ class SpectrumObservationTester:
         if self.obs.edisp is not None:
             self.obs.compute_energy_threshold(
                 method_lo="energy_bias",
-                method_hi="energy_bias",
+                method_hi="none",
                 bias_percent_lo=10,
                 bias_percent_hi=10
             )

--- a/gammapy/spectrum/tests/test_observation.py
+++ b/gammapy/spectrum/tests/test_observation.py
@@ -28,6 +28,8 @@ def test_spectrum_observation_1():
         npred=109.014552,
         excess=169.916667,
         excess_safe_range=116.33,
+        lo_threshold=8.912509e+08,
+        hi_threshold=1e11,
     )
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
@@ -56,6 +58,8 @@ def test_spectrum_observation_2():
         npred=292.00223031875987,
         excess=824,
         excess_safe_range=824,
+        lo_threshold=0.012045,
+        hi_threshold=83.021757,
     )
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
@@ -77,7 +81,13 @@ def test_spectrum_observation_3():
     )
     obs = SpectrumObservation(on_vector=on_vector, aeff=aeff)
     pars = dict(
-        total_on=171, livetime=livetime, npred=1425.6, excess=171, excess_safe_range=171
+        total_on=171,
+        livetime=livetime,
+        npred=1425.6,
+        excess=171,
+        excess_safe_range=171,
+        lo_threshold=0.1,
+        hi_threshold=10
     )
     tester = SpectrumObservationTester(obs, pars)
     tester.test_all()
@@ -134,6 +144,7 @@ class SpectrumObservationTester:
         self.test_to_sherpa()
         self.test_peek()
         self.test_npred()
+        self.test_energy_thresholds()
 
     def test_basic(self):
         assert "Observation summary report" in str(self.obs)
@@ -172,6 +183,19 @@ class SpectrumObservationTester:
     def test_peek(self):
         with mpl_plot_check():
             self.obs.peek()
+
+    def test_energy_thresholds(self):
+        if self.obs.edisp is not None:
+            self.obs.compute_energy_threshold(
+                method_lo="energy_bias",
+                method_hi="energy_bias",
+                bias_percent_lo=10,
+                bias_percent_hi=10
+            )
+
+            assert_allclose(self.obs.lo_threshold.value, self.vals["lo_threshold"], rtol=1e-5)
+            assert_allclose(self.obs.hi_threshold.value, self.vals["hi_threshold"], rtol=1e-5)
+            self.obs.reset_thresholds()
 
 
 def _read_hess_obs():


### PR DESCRIPTION
This PR moves the energy threshold computation to the `EnergyDispersion` class, so that it can be re-used for 3D analysis. It also adds tests and simplifies the algorithm to find the bias energy . 