### PR TITLE
Corrected ReflectedRegionFinder to recompute default mask for each observation

### DIFF
--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -191,7 +191,7 @@ class ReflectedRegionsFinder:
         )
 
         # Distance image
-        self._distance_image = _compute_distance_image(self.reference_map)#exclusion_mask)
+        self._distance_image = _compute_distance_image(self.reference_map)
 
     def find_regions(self):
         """Find reflected regions."""

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -62,7 +62,7 @@ def test_find_reflected_regions(exclusion_mask, on_region):
     )
     fregions.run()
     regions = fregions.reflected_regions
-    assert len(regions) == 15
+    assert len(regions) == 14
     assert_quantity_allclose(regions[3].center.icrs.ra, Angle("83.674 deg"), rtol=1e-2)
 
     # Test without exclusion

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -106,6 +106,6 @@ class TestObservationStats:
     def test_stack_bad_on(self, stats_stacked_bad_on_region):
         data = stats_stacked_bad_on_region.to_dict()
         assert data["n_on"] == 156
-        assert data["n_off"] == 1003
+        assert data["n_off"] == 1006
         assert_allclose(data["alpha"], 0.125, rtol=1e-3)
         assert_allclose(data["livetime"].value, 26.211, rtol=1e-3)


### PR DESCRIPTION
This PR solves issue #2043 by introducing a `reference_map` member in `ReflectedRegionFinder`.

In case an  `exclusion_mask` is provided, the `reference_map` is set to the `exclusion_mask`.

If no `exclusion_mask` is provided a default `reference_map` is computed each time `ReflectedRegionFinder.run()` is called. This ensures that the `WCS` of the map used to compute the reflected regions is consistent with the observation at hand.

Note that ideally we should always use this default reference map and retroject the `exclusion_maks` on it.  