### PR TITLE
Add joint likelihood fit test for `MapDataset`

### DIFF
--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -83,12 +83,12 @@ def diffuse_evaluator(diffuse_model, exposure, psf, edisp):
 
 @pytest.fixture(scope="session")
 def sky_models(sky_model):
-    return SkyModels([sky_model, sky_model])
+    return SkyModels([sky_model, sky_model.copy()])
 
 
 @pytest.fixture(scope="session")
 def compound_model(sky_model):
-    return CompoundSkyModel(sky_model, sky_model, np.add)
+    return CompoundSkyModel(sky_model, sky_model.copy(), np.add)
 
 
 def test_skymodel_addition(sky_model, sky_models, diffuse_model):

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -231,9 +231,19 @@ class Parameters:
     """
 
     def __init__(self, parameters, covariance=None, apply_autoscale=True):
-        self._parameters = parameters
+        self._parameters = self._filter_unique_parameters(parameters)
         self.covariance = covariance
         self.apply_autoscale = apply_autoscale
+
+    def _filter_unique_parameters(self, parameters):
+        """Filter unique parameters from a list of parameters"""
+        unique_parameters = []
+
+        for par in parameters:
+            if par not in unique_parameters:
+                unique_parameters.append(par)
+
+        return unique_parameters
 
     def _init_covariance(self):
         if self.covariance is None:

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -235,7 +235,8 @@ class Parameters:
         self.covariance = covariance
         self.apply_autoscale = apply_autoscale
 
-    def _filter_unique_parameters(self, parameters):
+    @staticmethod
+    def _filter_unique_parameters(parameters):
         """Filter unique parameters from a list of parameters"""
         unique_parameters = []
 


### PR DESCRIPTION
This PR modifies the existing `cube/test_fit.py` to do a joint-likelihood fit of two `MapDataset` object. During the test I noticed the background level for the test was much too low, to be meaningfully constrained, that's why I increased it.