### PR TITLE
Add SpectrumDataset class

### DIFF
--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -13,7 +13,7 @@ __all__ = ["SpectrumFit", "SpectrumDataset"]
 log = logging.getLogger(__name__)
 
 class SpectrumDataset:
-    """Perform spectral model likelihood fit on a CountsSpectrum.
+    """Compute spectral model fit statistic on a CountsSpectrum.
 
     Parameters
     ----------

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -3,7 +3,7 @@ import logging
 import copy
 import numpy as np
 import astropy.units as u
-from ..utils.fitting import Fit
+from ..utils.fitting import Fit, Parameters
 from .. import stats
 from .utils import CountsPredictor
 from .observation import SpectrumObservationList, SpectrumObservation
@@ -70,7 +70,7 @@ class SpectrumDataset:
     @property
     def data_shape(self):
         """Shape of the counts data"""
-        return self.counts.data.data.shape
+        return self.counts.data.shape
 
     def npred(self):
         """Returns npred map (model + background)"""
@@ -82,7 +82,7 @@ class SpectrumDataset:
 
     def likelihood_per_bin(self):
         """Likelihood per bin given the current model parameters"""
-        return cash(n_on=self.counts.data.data, mu_on=self.npred())
+        return stats.cash(n_on=self.counts.data.data, mu_on=self.npred())
 
     def likelihood(self, parameters, mask=None):
         """Total likelihood given the current model parameters.

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -8,9 +8,99 @@ from .. import stats
 from .utils import CountsPredictor
 from .observation import SpectrumObservationList, SpectrumObservation
 
-__all__ = ["SpectrumFit"]
+__all__ = ["SpectrumFit", "SpectrumDataset"]
 
 log = logging.getLogger(__name__)
+
+class SpectrumDataset:
+    """Perform spectral model likelihood fit on a CountsSpectrum.
+
+    Parameters
+    ----------
+    model : `~gammapy.spectrum.models.SpectralModel`
+        Fit model
+    counts : `~gammapy.spectrum.CountsSpectrum`
+        Counts spectrum
+    livetime : float
+        Livetime
+    mask : numpy.array
+        Mask to apply to the likelihood.
+    aeff : `~gammapy.irf.EffectiveAreaTable`
+        Effective area
+    edisp : `~gammapy.irf.EnergyDispersion`
+        Energy dispersion
+    background: `~gammapy.spectrum.CountsSpectrum`
+        Background to use for the fit.
+    """
+
+    def __init__(
+        self,
+        model,
+        counts=None,
+        livetime=None,
+        mask=None,
+        aeff=None,
+        edisp=None,
+        background=None,
+    ):
+        if mask is not None and mask.dtype != np.dtype("bool"):
+            raise ValueError("mask data must have dtype bool")
+
+        self.model = model
+        self.counts = counts
+        self.livetime = livetime
+        self.mask = mask
+        self.aeff = aeff
+        self.edisp = edisp
+        self.background = background
+
+        self.parameters = Parameters(self.model.parameters.parameters)
+
+        if edisp is None:
+            self.predictor = CountsPredictor(model=self.model,
+                                              livetime=self.livetime,
+                                              aeff=self.aeff,
+                                              e_true=self.counts.energy.bins)
+        else:
+            self.predictor = CountsPredictor(model=self.model,
+                                        aeff=self.aeff,
+                                        edisp=self.edisp,
+                                        livetime=self.livetime)
+
+    @property
+    def data_shape(self):
+        """Shape of the counts data"""
+        return self.counts.data.data.shape
+
+    def npred(self):
+        """Returns npred map (model + background)"""
+        self.predictor.run()
+        model_npred = self.predictor.npred.data.data
+        back_npred = self.background.data.data
+        total_npred = model_npred + back_npred
+        return total_npred
+
+    def likelihood_per_bin(self):
+        """Likelihood per bin given the current model parameters"""
+        return cash(n_on=self.counts.data.data, mu_on=self.npred())
+
+    def likelihood(self, parameters, mask=None):
+        """Total likelihood given the current model parameters.
+
+        Parameters
+        ----------
+        mask : `~numpy.ndarray`
+            Mask to be combined with the dataset mask.
+        """
+        if self.mask is None and mask is None:
+            stat = self.likelihood_per_bin()
+        elif self.mask is None:
+            stat = self.likelihood_per_bin()[mask]
+        elif mask is None:
+            stat = self.likelihood_per_bin()[self.mask]
+        else:
+            stat = self.likelihood_per_bin()[mask & self.mask]
+        return np.sum(stat, dtype=np.float64)
 
 
 class SpectrumFit(Fit):

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.random import get_random_state
 from ...irf import EffectiveAreaTable
-from ...utils.fitting import Fit, Parameters
+from ...utils.fitting import Fit
 from ...spectrum import (
     CountsSpectrum,
     PHACountsSpectrum,
@@ -17,7 +17,7 @@ from ...spectrum import (
     SpectrumDataset,
 )
 
-
+@requires_dependency("iminuit")
 class TestSpectrumDataset:
     """Test fit on counts spectra without any IRFs"""
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -5,7 +5,9 @@ from numpy.testing import assert_allclose
 from ...utils.testing import requires_data, requires_dependency
 from ...utils.random import get_random_state
 from ...irf import EffectiveAreaTable
+from ...utils.fitting import Fit, Parameters
 from ...spectrum import (
+    CountsSpectrum,
     PHACountsSpectrum,
     SpectrumObservationList,
     SpectrumObservation,
@@ -23,7 +25,7 @@ class TestSpectrumDataset:
         self.nbins = 30
         binning = np.logspace(-1, 1, self.nbins + 1) * u.TeV
 
-        self.source_model = PowerLaw(
+        self.source_model = models.PowerLaw(
             index=2.1, amplitude=1e5 / u.TeV / u.s, reference=0.1 * u.TeV
         )
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -77,6 +77,13 @@ class TestSpectrumDataset:
         assert_allclose(pars["amplitude"].value, 1e5, rtol=1e-3)
         assert_allclose(pars.error("amplitude"), 153.450, rtol=1e-2)
 
+    def test_fake(self):
+        """Test the fake dataset"""
+        fake_spectrum = self.dataset.fake(314)
+
+        assert isinstance(fake_spectrum, CountsSpectrum)
+        assert_allclose(fake_spectrum.energy.bins, self.dataset.counts.energy.bins)
+        assert fake_spectrum.data.data.sum() == 907331
 
 @requires_dependency("sherpa")
 class TestFit:


### PR DESCRIPTION
This PR introduces a first implementation of `SpectrumDataset`. It relies only on `cash` statistics and uses `CountsSpectrum` as inputs for data and bkg.