### PR TITLE
Cutout on WCS

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -84,22 +84,17 @@ class MapMaker:
 
     def _process_obs(self, obs, selection):
         # Compute cutout geometry and slices to stack results back later
-        cutout_map = Map.from_geom(self.geom).cutout(
-            position=obs.pointing_radec, width=2 * self.offset_max, mode="trim"
-        )
-        cutout_map_etrue = Map.from_geom(self.geom_true).cutout(
-            position=obs.pointing_radec, width=2 * self.offset_max, mode="trim"
-        )
-
+        cutout_geom = self.geom.cutout(position=obs.pointing_radec, width=2 * self.offset_max, mode="trim")
+        cutout_geom_etrue = self.geom_true.cutout(position=obs.pointing_radec, width=2 * self.offset_max, mode="trim")
         log.info("Processing observation: OBS_ID = {}".format(obs.obs_id))
 
         # Compute field of view mask on the cutout
-        coords = cutout_map.geom.get_coord()
+        coords = cutout_geom.get_coord()
         offset = coords.skycoord.separation(obs.pointing_radec)
         fov_mask = offset >= self.offset_max
 
         # Compute field of view mask on the cutout in true energy
-        coords_etrue = cutout_map_etrue.geom.get_coord()
+        coords_etrue = cutout_geom_etrue.get_coord()
         offset_etrue = coords_etrue.skycoord.separation(obs.pointing_radec)
         fov_mask_etrue = offset_etrue >= self.offset_max
 
@@ -114,8 +109,8 @@ class MapMaker:
         # Make maps for this observation
         maps_obs = MapMakerObs(
             observation=obs,
-            geom=cutout_map.geom,
-            geom_true=cutout_map_etrue.geom,
+            geom=cutout_geom,
+            geom_true=cutout_geom_etrue,
             fov_mask=fov_mask,
             fov_mask_etrue=fov_mask_etrue,
             exclusion_mask=exclusion_mask,
@@ -178,13 +173,13 @@ class MapMakerObs:
     """
 
     def __init__(
-        self,
-        observation,
-        geom,
-        geom_true=None,
-        fov_mask=None,
-        fov_mask_etrue=None,
-        exclusion_mask=None,
+            self,
+            observation,
+            geom,
+            geom_true=None,
+            fov_mask=None,
+            fov_mask_etrue=None,
+            exclusion_mask=None,
     ):
         self.observation = observation
         self.geom = geom

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -217,6 +217,21 @@ def test_wcsgeom_separation():
     assert_allclose(separation.value[0, 0], 0.7106291438079875)
 
 
+def test_cutout():
+    geom = WcsGeom.create(
+        skydir=(0, 0),
+        npix=10,
+        binsz=0.1,
+        coordsys="GAL",
+        proj="CAR",
+        axes=[MapAxis.from_edges([0, 2, 3])],
+    )
+    position = SkyCoord(0.1, 0.2, unit="deg", frame="galactic")
+    cutout_geom = geom.cutout(position=position, width=2 * 0.3 * u.deg, mode="trim")
+    assert_allclose(cutout_geom.center_coord, (0.1, 0.2, 2.))
+    assert cutout_geom.data_shape == (2, 6, 6)
+
+
 def test_wcsgeom_get_coord():
     geom = WcsGeom.create(
         skydir=(0, 0), npix=(4, 3), binsz=1, coordsys="GAL", proj="CAR"


### PR DESCRIPTION
This PR implemnt the cutout on the WCS class.
Allow to optimize a bit the MapMaker class to avoid to perform the cutout on the map directly to get the associated coord but directly on the wcs.