### PR TITLE
Introduce IrfMapMaker

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -562,19 +562,18 @@ class IrfMapMaker:
 
     def _process_obs(self, obs):
         # Compute cutout geometry and slices to stack results back later
-        cutout_geom = self.geom.cutout(position=obs.pointing_radec, width=2 * self.offset_max, mode="trim")
         log.info("Processing observation: OBS_ID = {}".format(obs.obs_id))
 
         # Compute field of view mask on the cutout
-        coords = cutout_geom.get_coord()
+        coords = self.geom.get_coord()
         offset = coords.skycoord.separation(obs.pointing_radec)
         fov_mask = offset >= self.offset_max
 
         exposure = make_map_exposure_true_energy(
-            pointing=obs.pointing_radec,
-            livetime=obs.observation_live_time_duration,
-            aeff=obs.aeff,
-            geom=self.geom_true,
+            pointing=self.obs.pointing_radec,
+            livetime=self.obs.observation_live_time_duration,
+            aeff=self.obs.aeff,
+            geom=self.geom,
         )
         exposure.data[..., fov_mask] = 0
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -580,15 +580,10 @@ class IrfMapMaker:
         exposure.data[..., fov_mask] = 0
 
         if self.rad_axis is not None:
-            cutout_psf_geom = self.psf_geom.cutout(
-                position=obs.pointing_radec,
-                width=2 * self.offset_max,
-                mode="trim"
-            )
             obs_psf_map = make_psf_map(
                 psf=obs.psf,
                 pointing=obs.pointing_radec,
-                geom=cutout_psf_geom,
+                geom=self.psf_geom,
                 max_offset=self.offset_max,
                 exposure_map=exposure
             )
@@ -596,11 +591,10 @@ class IrfMapMaker:
             self.psf_map = self.psf_map.stack(obs_psf_map)
 
         if self.migra_axis is not None:
-            cutout_edisp_geom = self.edisp_geom.cutout(position=obs.pointing_radec, width=2 * self.offset_max, mode="trim")
             obs_edisp_map = make_edisp_map(
                 edisp=obs.edisp,
                 pointing=obs.pointing_radec,
-                geom=cutout_edisp_geom,
+                geom=self.edisp_geom,
                 max_offset=self.offset_max,
                 exposure_map=exposure
             )

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -835,8 +835,8 @@ class WcsGeom(MapGeom):
 
         Returns
         -------
-        cutout : `~gammapy.maps.WcsNDMap`
-            Cutout map
+        cutout : `~gammapy.maps.WcsGeom`
+            Cutout WcsGeom
         """
         width = _check_width(width)
         dummy_data = np.empty(self.to_image().data_shape)


### PR DESCRIPTION
This PR introduces an `IrfMapMaker` that produces stacked `PsfMap` and `EDispMap`  for a collection of `Observations`. 
The logic of the `MapMaker` and the `MapMakerObs` is not kept here. Main differences are:
- no cutout is computed for each observation. All IrfMaps are computed on the full grid but only at positions inside `offset_max` as implemented in `make_psf_map` and `make_edisp_map`. This is required because the `.stack()` methods uses `Map` arithmetics which require compatible geometries.
- there is no `MapMakerObs`  for single observations since it is barely needed anymore. For joint fits, we might return the result in the `.process_obs()` method.

The PR is still incomplete and is here for comments/discussion.