### PR TITLE
Raise error when creating Map with binsize=0

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -484,6 +484,8 @@ class MapAxis:
         nodes = np.array(nodes, ndmin=1)
         if len(nodes) < 1:
             raise ValueError("Nodes array must have at least one element.")
+        if len(nodes) != len(np.unique(nodes)):
+            raise ValueError("Remove duplicate elements from nodes")
 
         return cls(nodes, node_type="center", **kwargs)
 
@@ -505,6 +507,10 @@ class MapAxis:
         """
         if len(edges) < 2:
             raise ValueError("Edges array must have at least two elements.")
+        if len(nodes) != len(np.unique(nodes)):
+            raise ValueError(
+                "Remove duplicate elements! \n Cannot create axis with width=0"
+            )
 
         return cls(edges, node_type="edges", **kwargs)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -485,7 +485,7 @@ class MapAxis:
         if len(nodes) < 1:
             raise ValueError("Nodes array must have at least one element.")
         if len(nodes) != len(np.unique(nodes)):
-            raise ValueError("Node values must be unique")
+            raise ValueError("MapAxis: node values must be unique")
 
         return cls(nodes, node_type="center", **kwargs)
 
@@ -507,8 +507,8 @@ class MapAxis:
         """
         if len(edges) < 2:
             raise ValueError("Edges array must have at least two elements.")
-        if len(nodes) != len(np.unique(nodes)):
-            raise ValueError("Edge values must be unique")
+        if len(edges) != len(np.unique(edges)):
+            raise ValueError("MapAxis: edge values must be unique")
 
         return cls(edges, node_type="edges", **kwargs)
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -485,7 +485,7 @@ class MapAxis:
         if len(nodes) < 1:
             raise ValueError("Nodes array must have at least one element.")
         if len(nodes) != len(np.unique(nodes)):
-            raise ValueError("Remove duplicate elements from nodes")
+            raise ValueError("Node values must be unique")
 
         return cls(nodes, node_type="center", **kwargs)
 
@@ -508,9 +508,7 @@ class MapAxis:
         if len(edges) < 2:
             raise ValueError("Edges array must have at least two elements.")
         if len(nodes) != len(np.unique(nodes)):
-            raise ValueError(
-                "Remove duplicate elements! \n Cannot create axis with width=0"
-            )
+            raise ValueError("Edge values must be unique")
 
         return cls(edges, node_type="edges", **kwargs)
 

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -28,6 +28,9 @@ def test_mapaxis_init_from_edges(edges, interp):
     axis = MapAxis(edges, interp=interp)
     assert_allclose(axis.edges, edges)
     assert_allclose(axis.nbin, len(edges) - 1)
+    with pytest.raises(ValueError):
+        MapAxis.from_edges([1])
+        MapAxis.from_edges([0, 1, 1, 2])
 
 
 @pytest.mark.parametrize(("nodes", "interp"), mapaxis_geoms)
@@ -35,6 +38,9 @@ def test_mapaxis_from_nodes(nodes, interp):
     axis = MapAxis.from_nodes(nodes, interp=interp)
     assert_allclose(axis.center, nodes)
     assert_allclose(axis.nbin, len(nodes))
+    with pytest.raises(ValueError):
+        MapAxis.from_nodes([])
+        MapAxis.from_nodes([0, 1, 1, 2])
 
 
 @pytest.mark.parametrize(("nodes", "interp"), mapaxis_geoms)


### PR DESCRIPTION
As @mseglar found yesterday, reading a `MapAxis` with `bin_width=0` fails. However, no error is raised during Map creation or analysis, which is extremely confusing. This is because the `find_and_read_bands()` does not load duplicated elements.

https://github.com/gammapy/gammapy/blob/cc255addc8d671cc68325f0f143d47565a414437/gammapy/maps/geom.py#L141

I think it conceptually makes total sense to avoid bins with width 0. This PR raises an error during axis creation. 