### PR TITLE
Dark matter annihilation flux / spectral model

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -172,6 +172,7 @@ class DMAnnihilation(SpectralModel):
         self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
 
     def evaluate(self, energy, scale):
+        """Evaluate dark matter annihilation model."""
         flux = (
             scale
             * self.jfactor

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -169,14 +169,14 @@ class DMAnnihilation(SpectralModel):
         self.mass = mass
         self.channel = channel
         self.jfactor = jfactor
-        self.table_model = PrimaryFlux(mass, channel=self.channel).table_model
+        self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
 
     def evaluate(self, energy, scale):
         flux = (
             scale
             * self.jfactor
             * self.THERMAL_RELIC_CROSS_SECTION
-            * self.table_model.evaluate(energy=energy * (1 + self.z), norm=1)
+            * self.primary_flux.evaluate(energy=energy * (1 + self.z), norm=1)
             / self.k
             / self.mass
             / self.mass

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -117,16 +117,53 @@ class PrimaryFlux:
 
 
 class DMAnnihilModel(SpectralModel):
+    r"""Spectral model for dark matter annihilation.
+
+    The gamma-ray flux is computed as follows:
+
+    .. math::
+
+        \frac{\mathrm d \phi}{\mathrm d E \mathrm d\Omega} =
+        \frac{\langle \sigma\nu \rangle}{4\pi k m^2_{\mathrm{DM}}}
+        \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
+
+    Parameters
+    ----------
+    mass : `~astropy.units.Quantity`
+        Dark matter mass
+    channel : str
+        Annihilation channel for `~gammapy.astro.darkmatter.PrimaryFlux`
+    scale : float
+        Scale parameter for model fitting
+    jfact : `~astropy.units.Quantity`
+        Integrated J-Factor needed when `~gammapy.image.models.SkyPointSource` spatial model is used
+    z: float
+        Redshift value
+    k: int
+        Type of dark matter particle (k:2 Majorana, k:4 Dirac)
+
+    Examples
+    --------
+    This is how to instantiate a `DMAnnihilModel` model::
+
+        from astropy import units as u
+        from gammapy.astro.darkmatter import DMAnnihilModel
+
+        channel = "b"
+        massDM = 5000*u.Unit("GeV")
+        jfactor = 3.41e19 * u.Unit("GeV2 cm-5")
+        modelDM = DMAnnihilModel(mass=massDM, channel=channel, jfactor=jfactor)
+
+    References
+    ----------
+    * `2011JCAP...03..051 <http://adsabs.harvard.edu/abs/2011JCAP...03..051>`_
+    """
 
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
-    """Thermal relic cross section"""
+    """Thermally averaged annihilation cross-section"""
 
     def __init__(self, mass, channel, scale=1, jfactor=1, z=0, k=2):
-        self.parameters = Parameters(
-            [
-                Parameter("scale", scale),
-            ]
-        )
+        self.parameters = Parameters([Parameter("scale", scale)])
         self.k = k
         self.z = z
         self.mass = mass
@@ -136,13 +173,13 @@ class DMAnnihilModel(SpectralModel):
 
     def evaluate(self, energy, scale):
         flux = (
-                scale
-                * self.jfactor
-                * self.THERMAL_RELIC_CROSS_SECTION
-                * self.table_model.evaluate(energy=energy * (1 + self.z), norm=1)
-                / self.k
-                / self.mass
-                / self.mass
-                / (4 * np.pi)
+            scale
+            * self.jfactor
+            * self.THERMAL_RELIC_CROSS_SECTION
+            * self.table_model.evaluate(energy=energy * (1 + self.z), norm=1)
+            / self.k
+            / self.mass
+            / self.mass
+            / (4 * np.pi)
         )
         return flux

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -9,7 +9,7 @@ from ...utils.scripts import make_path
 from ...utils.fitting import Parameter, Parameters
 from ...spectrum.models import SpectralModel, TableModel
 
-__all__ = ["PrimaryFlux", "DMAnnihilModel"]
+__all__ = ["PrimaryFlux", "DMAnnihilation"]
 
 
 class PrimaryFlux:
@@ -116,7 +116,7 @@ class PrimaryFlux:
         return TableModel(energy=energies, values=dN_dE, values_scale="lin")
 
 
-class DMAnnihilModel(SpectralModel):
+class DMAnnihilation(SpectralModel):
     r"""Spectral model for dark matter annihilation.
 
     The gamma-ray flux is computed as follows:
@@ -144,15 +144,15 @@ class DMAnnihilModel(SpectralModel):
 
     Examples
     --------
-    This is how to instantiate a `DMAnnihilModel` model::
+    This is how to instantiate a `DMAnnihilation` model::
 
         from astropy import units as u
-        from gammapy.astro.darkmatter import DMAnnihilModel
+        from gammapy.astro.darkmatter import DMAnnihilation
 
         channel = "b"
         massDM = 5000*u.Unit("GeV")
         jfactor = 3.41e19 * u.Unit("GeV2 cm-5")
-        modelDM = DMAnnihilModel(mass=massDM, channel=channel, jfactor=jfactor)
+        modelDM = DMAnnihilation(mass=massDM, channel=channel, jfactor=jfactor)
 
     References
     ----------

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -123,7 +123,7 @@ class DMAnnihilModel(SpectralModel):
 
     .. math::
 
-        \frac{\mathrm d \phi}{\mathrm d E \mathrm d\Omega} =
+        \frac{\mathrm d \phi}{\mathrm d E} =
         \frac{\langle \sigma\nu \rangle}{4\pi k m^2_{\mathrm{DM}}}
         \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
 

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -2,7 +2,7 @@
 import pytest
 import astropy.units as u
 from ....utils.testing import assert_quantity_allclose, requires_data
-from .. import PrimaryFlux
+from .. import PrimaryFlux, DMAnnihilation
 
 
 @requires_data("gammapy-data")
@@ -14,3 +14,19 @@ def test_primary_flux():
     actual = primflux.table_model(500 * u.GeV)
     desired = 9.328234e-05 / u.GeV
     assert_quantity_allclose(actual, desired)
+
+
+def test_DMAnnihilation():
+
+    channel = "b"
+    massDM = 5 * u.TeV
+    jfactor = 3.41e19 * u.Unit("GeV2 cm-5")
+    emin = 0.01 * u.TeV
+    emax = 10 * u.TeV
+
+    model = DMAnnihilation(mass=massDM, channel=channel, jfactor=jfactor)
+    integral_flux = model.integral(emin=emin, emax=emax).to("cm-2 s-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
+
+    assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-5)
+    assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-5)

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 import astropy.units as u
 
-__all__ = ["JFactory", "compute_dm_flux"]
+__all__ = ["JFactory"]
 
 
 class JFactory:
@@ -52,41 +52,3 @@ class JFactory:
         """
         diff_jfact = self.compute_differential_jfactor()
         return diff_jfact * self.geom.to_image().solid_angle()
-
-
-def compute_dm_flux(jfact, prim_flux, x_section, energy_range):
-    r"""Create dark matter flux maps.
-
-    The gamma-ray flux is computed as follows:
-
-    .. math::
-
-        \frac{\mathrm d \phi}{\mathrm d E \mathrm d\Omega} =
-        \frac{\langle \sigma\nu \rangle}{8\pi m^2_{\mathrm{DM}}}
-        \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)
-
-    Parameters
-    ----------
-    jfact : `~astropy.units.Quantity`
-        J-Factor as computed by `~gammapy.astro.darkmatter.JFactory`
-    prim_flux : `~gammapy.astro.darkmatter.PrimaryFlux`
-        Primary gamma-ray flux
-    x_section : `~astropy.units.Quantity`
-        Velocity averaged annihilation cross section, :math:`\langle \sigma\nu\rangle`
-    energy_range : tuple of `~astropy.units.Quantity`
-        Energy range for the map
-
-    Returns
-    -------
-    flux : `~astropy.units.Quantity`
-        DM Flux
-
-    References
-    ----------
-    * `2011JCAP...03..051 <http://adsabs.harvard.edu/abs/2011JCAP...03..051>`_
-    """
-    prefactor = x_section / (8 * np.pi * prim_flux.mDM ** 2)
-    int_flux = prim_flux.table_model.integral(
-        emin=energy_range[0], emax=energy_range[1]
-    )
-    return (jfact * prefactor * int_flux).to("cm-2 s-1")

--- a/tutorials/astro_dark_matter.ipynb
+++ b/tutorials/astro_dark_matter.ipynb
@@ -32,7 +32,7 @@
     "    profiles,\n",
     "    JFactory,\n",
     "    PrimaryFlux,\n",
-    "    compute_dm_flux,\n",
+    "    DMAnnihilModel,\n",
     ")\n",
     "\n",
     "from gammapy.maps import WcsGeom, WcsNDMap\n",
@@ -226,11 +226,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flux = compute_dm_flux(\n",
-    "    jfact=jfact,\n",
-    "    prim_flux=fluxes,\n",
-    "    x_section=\"1e-26 cm3s-1\",\n",
-    "    energy_range=[0.1, 10] * u.TeV,\n",
+    "channel = \"Z\"\n",
+    "massDM = 10 * u.TeV\n",
+    "diff_flux = DMAnnihilModel(mass=massDM, channel=channel)\n",
+    "int_flux = (jfact * diff_flux.integral(emin=0.1 * u.TeV, emax=10 * u.TeV)).to(\n",
+    "    \"cm-2 s-1\"\n",
     ")"
    ]
   },
@@ -240,22 +240,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flux_map = WcsNDMap(geom=geom, data=flux.value, unit=flux.unit)\n",
+    "flux_map = WcsNDMap(geom=geom, data=int_flux.value, unit=\"cm-2 s-1\")\n",
     "\n",
     "fig, ax, im = flux_map.plot(cmap=\"viridis\", norm=LogNorm(), add_cbar=True)\n",
     "plt.title(\n",
     "    \"Flux [{}]\\n m$_{{DM}}$={}, channel={}\".format(\n",
-    "        flux_map.unit, fluxes.mDM.to(\"TeV\"), fluxes.channel\n",
+    "        int_flux.unit, fluxes.mDM.to(\"TeV\"), fluxes.channel\n",
     "    )\n",
     ");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "gammapy-dev",
    "language": "python",
-   "name": "python3"
+   "name": "gammapy-dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -268,6 +275,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.0"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,

--- a/tutorials/astro_dark_matter.ipynb
+++ b/tutorials/astro_dark_matter.ipynb
@@ -32,7 +32,7 @@
     "    profiles,\n",
     "    JFactory,\n",
     "    PrimaryFlux,\n",
-    "    DMAnnihilModel,\n",
+    "    DMAnnihilation,\n",
     ")\n",
     "\n",
     "from gammapy.maps import WcsGeom, WcsNDMap\n",
@@ -228,7 +228,7 @@
    "source": [
     "channel = \"Z\"\n",
     "massDM = 10 * u.TeV\n",
-    "diff_flux = DMAnnihilModel(mass=massDM, channel=channel)\n",
+    "diff_flux = DMAnnihilation(mass=massDM, channel=channel)\n",
     "int_flux = (jfact * diff_flux.integral(emin=0.1 * u.TeV, emax=10 * u.TeV)).to(\n",
     "    \"cm-2 s-1\"\n",
     ")"
@@ -260,9 +260,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gammapy-dev",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "gammapy-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR adds a new spectral model class `DMAnnihilModel` accounting for the flux issued from the annihilation of dark matter particles. This class is needed to simulate counts datasets and fit them to models for different annihilation channels and dark matter masses.

The `compute_dm_flux` utility function has been removed, since it is no longer needed, and the existing dark matter notebook fixed accordingly.