### PR TITLE
Add SkyModel.position and frame attribute

### DIFF
--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -184,7 +184,7 @@ class TestSourceCatalogObjectHGPS:
         model = cat["HESS J1119-614"].sky_model()
         p = model.parameters
         assert_allclose(p["amplitude"].value, 7.959899015960725e-13)
-        assert_allclose(p["lon_0"].value, 292.1280822753906)
+        assert_allclose(p["lon_0"].value, -67.871918)
         assert_allclose(p["lat_0"].value, -0.5332353711128235)
         assert_allclose(p["sigma"].value, 0.09785966575145721)
 
@@ -241,7 +241,7 @@ class TestSourceCatalogObjectHGPS:
         model = cat["Vela Junior"].sky_model()
         p = model.parameters
         assert_allclose(p["amplitude"].value, 3.2163001428830995e-11)
-        assert_allclose(p["lon_0"].value, 266.2873840332031)
+        assert_allclose(p["lon_0"].value, -93.712616)
         assert_allclose(p["lat_0"].value, -1.243260383605957)
         assert_allclose(p["radius"].value, 0.95)
         assert_allclose(p["width"].value, 0.05)

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -14,8 +14,8 @@ class MapDataset:
 
     Parameters
     ----------
-    model : `~gammapy.cube.models.SkyModel`
-        Fit model
+    model : `~gammapy.cube.models.SkyModel` or `~gammapy.cube.models.SkyModels`
+        Source sky models.
     counts : `~gammapy.maps.WcsNDMap`
         Counts cube
     exposure : `~gammapy.maps.WcsNDMap`
@@ -26,8 +26,8 @@ class MapDataset:
         PSF kernel
     edisp : `~gammapy.irf.EnergyDispersion`
         Energy dispersion
-    background_model: `~gammapy.cube.models.BackgroundModel`
-        Background model to use for the fit.
+    background_model: `~gammapy.cube.models.BackgroundModel` or `~gammapy.cube.models.BackgroundModel`
+        Background models to use for the fit.
     likelihood : {"cash"}
 	    Likelihood function to use for the fit.
     """
@@ -142,6 +142,15 @@ class MapEvaluator:
         return self.exposure.geom
 
     @lazyproperty
+    def geom_reco(self):
+        edges = self.edisp.e_reco.bins
+        e_reco_axis = MapAxis.from_edges(
+            edges=edges, name="energy",
+            unit=self.edisp.e_reco.unit,
+            interp=self.edisp.e_reco.interpolation_mode)
+        return self.geom_image.to_cube(axes=[e_reco_axis])
+
+    @lazyproperty
     def geom_image(self):
         return self.geom.to_image()
 
@@ -171,11 +180,13 @@ class MapEvaluator:
         Returns ``lon, lat`` tuple of `~astropy.units.Quantity`.
         """
         coord = self.geom_image.get_coord()
-        frame = self.model.position.frame
-        coordsys = "CEL" if frame == "icrs" else "GAL"
+        frame = self.model.frame
 
-        if not coord.coordsys == coordsys:
-            coord = coord.to_coordsys(coordsys)
+        if frame is not None:
+            coordsys = "CEL" if frame == "icrs" else "GAL"
+
+            if not coord.coordsys == coordsys:
+                coord = coord.to_coordsys(coordsys)
 
         return (u.Quantity(coord.lon, "deg", copy=False), u.Quantity(coord.lat, "deg", copy=False))
 
@@ -228,7 +239,7 @@ class MapEvaluator:
         For now just divide flux cube by exposure
         """
         npred = (flux * self.exposure.quantity).to_value("")
-        return self.exposure.copy(data=npred)
+        return Map.from_geom(self.geom, data=npred, unit="")
 
     def apply_psf(self, npred):
         """Convolve npred cube with PSF"""
@@ -251,13 +262,7 @@ class MapEvaluator:
         data = np.rollaxis(npred.data, loc, len(npred.data.shape))
         data = np.dot(data, self.edisp.pdf_matrix)
         data = np.rollaxis(data, -1, loc)
-        e_reco_axis = MapAxis.from_edges(
-            self.edisp.e_reco.bins, unit=self.edisp.e_reco.unit, name="energy"
-        )
-        geom_ereco = self.exposure.geom.to_image().to_cube(axes=[e_reco_axis])
-        npred = Map.from_geom(geom_ereco, unit="")
-        npred.data = data
-        return npred
+        return Map.from_geom(self.geom_reco, data=data, unit="")
 
     def compute_npred(self):
         """

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -134,15 +134,14 @@ class MapEvaluator:
         self.psf = psf
         self.edisp = edisp
 
-        self.parameters = Parameters(self.model.parameters.parameters)
-
     @lazyproperty
     def geom(self):
-        """This will give the energy axes in e_true"""
+        """True energy map geometry (`~gammapy.maps.MapGeom`)"""
         return self.exposure.geom
 
     @lazyproperty
     def geom_reco(self):
+        """Reco energy map geometry (`~gammapy.maps.MapGeom`)"""
         edges = self.edisp.e_reco.bins
         e_reco_axis = MapAxis.from_edges(
             edges=edges, name="energy",
@@ -152,6 +151,7 @@ class MapEvaluator:
 
     @lazyproperty
     def geom_image(self):
+        """Image map geometry (`~gammapy.maps.MapGeom`)"""
         return self.geom.to_image()
 
     @lazyproperty
@@ -163,7 +163,7 @@ class MapEvaluator:
 
     @lazyproperty
     def energy_edges(self):
-        """Energy axis bin edges (`~astropy.units.Quantity`)"""
+        """True energy axis bin edges (`~astropy.units.Quantity`)"""
         energy_axis = self.geom.get_axis_by_name("energy")
         energy = energy_axis.edges * energy_axis.unit
         return energy[:, np.newaxis, np.newaxis]
@@ -175,9 +175,7 @@ class MapEvaluator:
 
     @lazyproperty
     def lon_lat(self):
-        """Spatial coordinate pixel centers.
-
-        Returns ``lon, lat`` tuple of `~astropy.units.Quantity`.
+        """Spatial coordinate pixel centers (``lon, lat`` tuple of `~astropy.units.Quantity`).
         """
         coord = self.geom_image.get_coord()
         frame = self.model.frame

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -170,8 +170,14 @@ class MapEvaluator:
 
         Returns ``lon, lat`` tuple of `~astropy.units.Quantity`.
         """
-        lon, lat = self.geom_image.get_coord()
-        return (u.Quantity(lon, "deg", copy=False), u.Quantity(lat, "deg", copy=False))
+        coord = self.geom_image.get_coord()
+        frame = self.model.position.frame
+        coordsys = "CEL" if frame == "icrs" else "GAL"
+
+        if not coord.coordsys == coordsys:
+            coord = coord.to_coordsys(coordsys)
+
+        return (u.Quantity(coord.lon, "deg", copy=False), u.Quantity(coord.lat, "deg", copy=False))
 
     @lazyproperty
     def lon(self):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -184,6 +184,16 @@ class SkyModel(SkyModelBase):
         """Parameters (`~gammapy.utils.modeling.Parameters`)"""
         return self._parameters
 
+    @property
+    def position(self):
+        """`~astropy.coordinates.SkyCoord`"""
+        return self.spatial_model.position
+
+    @property
+    def evaluation_radius(self):
+        """`~astropy.coordinates.Angle`"""
+        return self.spatial_model.evaluation_radius
+
     def __repr__(self):
         fmt = "{}(spatial_model={!r}, spectral_model={!r})"
         return fmt.format(
@@ -341,6 +351,18 @@ class SkyDiffuseCube(SkyModelBase):
     def copy(self):
         """A shallow copy"""
         return copy.copy(self)
+
+    @property
+    def position(self):
+        """`~astropy.coordinates.SkyCoord`"""
+        return self.map.geom.center_skydir
+
+    @property
+    def evaluation_radius(self):
+        """`~astropy.coordinates.Angle`"""
+        radius = np.max(self.map.geom.width) / 2.
+        return radius
+
 
 
 class BackgroundModel(Model):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -13,6 +13,7 @@ __all__ = [
     "SkyModel",
     "SkyDiffuseCube",
     "BackgroundModel",
+    "BackgroundModels"
 ]
 
 
@@ -194,6 +195,10 @@ class SkyModel(SkyModelBase):
         """`~astropy.coordinates.Angle`"""
         return self.spatial_model.evaluation_radius
 
+    @property
+    def frame(self):
+        return self.spatial_model.frame
+
     def __repr__(self):
         fmt = "{}(spatial_model={!r}, spectral_model={!r})"
         return fmt.format(
@@ -363,6 +368,10 @@ class SkyDiffuseCube(SkyModelBase):
         radius = np.max(self.map.geom.width) / 2.
         return radius
 
+    @property
+    def frame(self):
+        return self.position.frame
+
 
 
 class BackgroundModel(Model):
@@ -396,7 +405,7 @@ class BackgroundModel(Model):
         self.map = background
         self.parameters = Parameters(
             [
-                Parameter("norm", norm, unit=""),
+                Parameter("norm", norm, unit="", min=0),
                 Parameter("tilt", tilt, unit="", frozen=True),
                 Parameter("reference", reference, frozen=True),
             ]
@@ -417,3 +426,77 @@ class BackgroundModel(Model):
         tilt_factor = np.power((self.energy_center / reference).to(""), -tilt)
         back_values = norm * self.map.data * tilt_factor.value
         return self.map.copy(data=back_values)
+
+    @classmethod
+    def from_skymodel(cls, skymodel, exposure, edisp=None, psf=None, **kwargs):
+        """Create background model from sky model by applying IRFs.
+
+        Typically used for diffuse Galactic emission models or constant diffuse emission
+        models.
+
+        Parameters
+        ----------
+        skymodel : `SkyModel` or `SkyDiffuseCube`
+            Sky model.
+        exposure : `Map`
+            Exposure map.
+        edisp : `EnergyDispersion`
+            Energy dispersion.
+        psf : `PSFKernel`
+            PSF to apply.
+        """
+        from .fit import MapEvaluator
+        evaluator = MapEvaluator(model=skymodel, exposure=exposure, edisp=edisp, psf=psf)
+        background = evaluator.compute_npred()
+        return cls(background=background, **kwargs)
+
+    def __add__(self, model):
+        models = [self]
+        if isinstance(model, BackgroundModels):
+            models += model.models
+        elif isinstance(model, BackgroundModel):
+            models += [model]
+        else:
+            raise NotImplementedError
+        return BackgroundModels(models)
+
+
+
+class BackgroundModels:
+    """Background models.
+
+    Parameters
+    ----------
+    models : list of `BackgroundModel`
+        List of background models.
+    """
+    def __init__(self, models):
+        self.models = models
+        pars = []
+        for model in models:
+            for p in model.parameters:
+                pars.append(p)
+        self.parameters = Parameters(pars)
+
+    def evaluate(self):
+        """Evaluate background models."""
+        for idx, model in enumerate(self.models):
+            if idx == 0:
+                vals = model.evaluate()
+            else:
+                vals += model.evaluate()
+        return vals
+
+    def __iadd__(self, model):
+        if isinstance(model, BackgroundModels):
+            self.models += model.models
+        elif isinstance(model, BackgroundModel):
+            self.models += [model]
+        else:
+            raise NotImplementedError
+        return self
+
+    def __add__(self, model):
+        model_ = self.copy()
+        model_ += model
+        return model_

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -271,6 +271,12 @@ class TestSkyDiffuseCube:
         assert val.shape == (1,)
         assert_allclose(val.value, 1.396424e-12, rtol=1e-5)
 
+    @staticmethod
+    def test_evaluation_radius(diffuse_model):
+        radius = diffuse_model.evaluation_radius
+        assert radius.unit == "deg"
+        assert_allclose(radius.value, 4)
+
 
 class TestSkyDiffuseCubeMapEvaluator:
     @staticmethod

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -136,7 +136,7 @@ class SkyGaussian(SkySpatialModel):
     @property
     def evaluation_radius(self):
         r"""Returns the effective radius of the sky region where the model evaluates to non-zero.
-        For a Gaussian source, we fix it to :math:`7\sigma`.
+        For a Gaussian source, we fix it to :math:`5\sigma`.
 
         Returns
         -------
@@ -144,7 +144,7 @@ class SkyGaussian(SkySpatialModel):
            Radius in angular units
 
         """
-        radius = 7 * self.parameters["sigma"].quantity
+        radius = 5 * self.parameters["sigma"].quantity
         return radius
 
     @staticmethod

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -41,7 +41,7 @@ class SkySpatialModel(Model):
             lon = self.parameters["lon_0"].quantity
             lat = self.parameters["lat_0"].quantity
             return SkyCoord(lon, lat, frame=self.frame)
-        except KeyError:
+        except IndexError:
             raise ValueError("Model does not have a defined center position")
 
 
@@ -454,7 +454,7 @@ class SkyDiffuseConstant(SkySpatialModel):
     value : `~astropy.units.Quantity`
         Value
     """
-
+    frame = None
     def __init__(self, value=1):
         self.parameters = Parameters([Parameter("value", value)])
 

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -40,9 +40,10 @@ class SkySpatialModel(Model):
             # TODO: this relies on hard-coded parameter names, which is not the ideal solution
             lon = self.parameters["lon_0"].quantity
             lat = self.parameters["lat_0"].quantity
-            return SkyCoord(lon, lat, self.frame)
+            return SkyCoord(lon, lat, frame=self.frame)
         except KeyError:
             raise ValueError("Model does not have a defined center position")
+
 
 class SkyPointSource(SkySpatialModel):
     r"""Point Source.

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -562,3 +562,8 @@ class SkyDiffuseMap(SkySpatialModel):
         coord = {"lon": lon.to_value("deg"), "lat": lat.to_value("deg")}
         val = self.map.interp_by_coord(coord, **self._interp_kwargs)
         return u.Quantity(norm.value * val, self.map.unit, copy=False)
+
+    @property
+    def position(self):
+        """`~astropy.coordinates.SkyCoord`"""
+        return self.map.geom.center_skydir

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -66,7 +66,7 @@ class SkyPointSource(SkySpatialModel):
     def __init__(self, lon_0, lat_0, frame="galactic"):
         self.frame = frame
         self.parameters = Parameters(
-            [Parameter("lon_0", Longitude(lon_0)), Parameter("lat_0", Latitude(lat_0))]
+            [Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180), Parameter("lat_0", Latitude(lat_0), min=-90, max=90)]
         )
 
     @property
@@ -142,8 +142,8 @@ class SkyGaussian(SkySpatialModel):
         self.frame = frame
         self.parameters = Parameters(
             [
-                Parameter("lon_0", Longitude(lon_0)),
-                Parameter("lat_0", Latitude(lat_0)),
+                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
+                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
                 Parameter("sigma", Angle(sigma), min=0),
             ]
         )
@@ -201,8 +201,8 @@ class SkyDisk(SkySpatialModel):
         self.frame = frame
         self.parameters = Parameters(
             [
-                Parameter("lon_0", Longitude(lon_0)),
-                Parameter("lat_0", Latitude(lat_0)),
+                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
+                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
                 Parameter("r_0", Angle(r_0)),
             ]
         )
@@ -315,8 +315,8 @@ class SkyEllipse(SkySpatialModel):
         self.frame = frame
         self.parameters = Parameters(
             [
-                Parameter("lon_0", Longitude(lon_0)),
-                Parameter("lat_0", Latitude(lat_0)),
+                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
+                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
                 Parameter("semi_major", Angle(semi_major)),
                 Parameter("e", e, min=0, max=1),
                 Parameter("theta", Angle(theta)),
@@ -406,8 +406,8 @@ class SkyShell(SkySpatialModel):
         self.frame = frame
         self.parameters = Parameters(
             [
-                Parameter("lon_0", Longitude(lon_0)),
-                Parameter("lat_0", Latitude(lat_0)),
+                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
+                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
                 Parameter("radius", Angle(radius)),
                 Parameter("width", Angle(width)),
             ]

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -37,7 +37,7 @@ def test_sky_gaussian():
     assert_allclose(ratio, np.exp(0.5))
     radius = model.evaluation_radius
     assert radius.unit == "deg"
-    assert_allclose(radius.value, 7 * sigma.value)
+    assert_allclose(radius.value, 5 * sigma.value)
 
 
 def test_sky_disk():

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -23,7 +23,12 @@ def test_sky_point_source():
     assert val.unit == "deg-2"
     assert_allclose(val.sum().value, 1)
     radius = model.evaluation_radius
-    assert_allclose(radius, 4)
+    assert radius.unit == "deg"
+    assert_allclose(radius.value, 0)
+    assert model.frame == "galactic"
+
+    assert_allclose(model.position.l.deg, 2.5)
+    assert_allclose(model.position.b.deg, 2.5)
 
 
 def test_sky_gaussian():
@@ -141,7 +146,7 @@ def test_sky_diffuse_map():
     assert_allclose(val.value, desired)
     radius = model.evaluation_radius
     assert radius.unit == "deg"
-    assert_allclose(radius.value, 1.28, rtol=1.0e-2)
+    assert_allclose(radius.value, 0.64, rtol=1.0e-2)
 
 
 @requires_data("gammapy-data")

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -80,7 +80,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
 
     if not geom.is_allsky:
         coords = geom.center_coord[:2] + tuple([ax.center[0] for ax in geom.axes])
-        coords[0][...] += 2.0 * np.max(geom.width[0])
+        coords[0][...] += 2.0 * np.max(geom.width[0].to_value("deg"))
         idx = geom.coord_to_idx(coords)
         assert_allclose(np.full_like(coords[0], -1, dtype=int), idx[0])
         idx = geom.coord_to_idx(coords, clip=True)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -480,7 +480,7 @@ def test_make_cutout(mode):
     actual = cutout.data.sum()
     assert_allclose(actual, 36.0)
     assert_allclose(cutout.geom.shape, m.geom.shape)
-    assert_allclose(cutout.geom.width, [[2.0], [3.0]])
+    assert_allclose(cutout.geom.width.to_value("deg"), [[2.0], [3.0]])
 
 
 def test_convolve_vs_smooth():

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -237,7 +237,9 @@ class WcsGeom(MapGeom):
     @property
     def width(self):
         """Tuple with image dimension in deg in longitude and latitude."""
-        return (self._cdelt[0] * self._npix[0], self._cdelt[1] * self._npix[1])
+        dlon = self._cdelt[0] * self._npix[0]
+        dlat = self._cdelt[1] * self._npix[1]
+        return (dlon * u.deg, dlat * u.deg)
 
     @property
     def pixel_area(self):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -239,7 +239,7 @@ class WcsGeom(MapGeom):
         """Tuple with image dimension in deg in longitude and latitude."""
         dlon = self._cdelt[0] * self._npix[0]
         dlat = self._cdelt[1] * self._npix[1]
-        return (dlon * u.deg, dlat * u.deg)
+        return (dlon, dlat) * u.deg
 
     @property
     def pixel_area(self):

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -41,7 +41,12 @@
     "from gammapy.irf import EnergyDispersion, make_mean_psf, make_mean_edisp\n",
     "from gammapy.maps import WcsGeom, MapAxis, Map, WcsNDMap\n",
     "from gammapy.cube import MapMaker, MapEvaluator, PSFKernel, MapDataset\n",
-    "from gammapy.cube.models import SkyModel, SkyDiffuseCube, BackgroundModel\n",
+    "from gammapy.cube.models import (\n",
+    "    SkyModel,\n",
+    "    SkyDiffuseCube,\n",
+    "    BackgroundModel,\n",
+    "    BackgroundModels,\n",
+    ")\n",
     "from gammapy.spectrum.models import PowerLaw, ExponentialCutoffPowerLaw\n",
     "from gammapy.image.models import SkyGaussian, SkyPointSource\n",
     "from gammapy.utils.fitting import Fit\n",
@@ -566,8 +571,8 @@
    "outputs": [],
    "source": [
     "background_model = BackgroundModel(cmaps[\"background\"], norm=1.1, tilt=0.0)\n",
-    "background_model.parameters['norm'].frozen = False\n",
-    "background_model.parameters['tilt'].frozen = True"
+    "background_model.parameters[\"norm\"].frozen = False\n",
+    "background_model.parameters[\"tilt\"].frozen = True"
    ]
   },
   {
@@ -727,7 +732,22 @@
    "source": [
     "diffuse_model = SkyDiffuseCube.read(\n",
     "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\"\n",
+    ")\n",
+    "\n",
+    "background_diffuse = BackgroundModel.from_skymodel(\n",
+    "    diffuse_model, exposure=cmaps[\"exposure\"], psf=psf_kernel\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "background_irf = BackgroundModel(cmaps[\"background\"], norm=1.0, tilt=0.0)\n",
+    "\n",
+    "background_total = background_irf + background_diffuse"
    ]
   },
   {
@@ -743,15 +763,10 @@
     "    reference=1.0 * u.TeV,\n",
     "    lambda_=1 / u.TeV,\n",
     ")\n",
+    "\n",
     "model_ecpl = SkyModel(\n",
     "    spatial_model=spatial_model, spectral_model=spectral_model\n",
-    ")\n",
-    "\n",
-    "background_model = BackgroundModel(cmaps[\"background\"], norm=1.0, tilt=0.0)\n",
-    "background_model.parameters['norm'].frozen = False\n",
-    "background_model.parameters['tilt'].frozen = True\n",
-    "\n",
-    "model_combined = diffuse_model + model_ecpl"
+    ")"
    ]
   },
   {
@@ -761,11 +776,12 @@
    "outputs": [],
    "source": [
     "dataset_combined = MapDataset(\n",
-    "    model=model_combined,\n",
+    "    model=model_ecpl,\n",
     "    counts=cmaps[\"counts\"],\n",
     "    exposure=cmaps[\"exposure\"],\n",
-    "    background_model=background_model,\n",
+    "    background_model=background_total,\n",
     "    psf=psf_kernel,\n",
+    "    edisp=edisp,\n",
     ")"
    ]
   },
@@ -778,15 +794,6 @@
     "%%time\n",
     "fit_combined = Fit(dataset_combined)\n",
     "result_combined = fit_combined.run()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(model_ecpl)"
    ]
   },
   {
@@ -803,8 +810,9 @@
    "outputs": [],
    "source": [
     "# Checking normalization value (the closer to 1 the better)\n",
-    "print(model_combined)\n",
-    "print(\"Background model: {}\\n\".format(background_model))"
+    "print(model_ecpl, \"\\n\")\n",
+    "print(background_irf, \"\\n\")\n",
+    "print(background_diffuse, \"\\n\")"
    ]
   },
   {

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -59,7 +59,7 @@
     "from astropy.table import Table\n",
     "from astropy.visualization import simple_norm\n",
     "from gammapy.data import EventList\n",
-    "from gammapy.irf import EnergyDependentTablePSF\n",
+    "from gammapy.irf import EnergyDependentTablePSF, EnergyDispersion\n",
     "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
     "from gammapy.spectrum.models import TableModel, PowerLaw, ConstantModel\n",
     "from gammapy.image.models import SkyPointSource, SkyDiffuseConstant\n",
@@ -500,7 +500,7 @@
    "outputs": [],
    "source": [
     "# Let's compute a PSF kernel matching the pixel size of our map\n",
-    "psf_kernel = PSFKernel.from_table_psf(psf, counts.geom, max_radius=\"0.5 deg\")"
+    "psf_kernel = PSFKernel.from_table_psf(psf, counts.geom, max_radius=\"1 deg\")"
    ]
   },
   {
@@ -510,6 +510,25 @@
    "outputs": [],
    "source": [
     "psf_kernel.psf_kernel_map.sum_over_axes().plot(stretch=\"log\", add_cbar=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Energy Dispersion\n",
+    "For simplicity we assume a diagonal energy dispersion:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e_true = exposure.geom.axes[0].edges * exposure.geom.axes[0].unit\n",
+    "e_reco = counts.geom.axes[0].edges * counts.geom.axes[0].unit\n",
+    "edisp = EnergyDispersion.from_diagonal_response(e_true=e_true, e_reco=e_reco)"
    ]
   },
   {
@@ -529,11 +548,14 @@
    "source": [
     "model = SkyDiffuseCube(diffuse_galactic)\n",
     "\n",
-    "evaluator = MapEvaluator(model=model, exposure=exposure, psf=psf_kernel)\n",
+    "background_gal = BackgroundModel.from_skymodel(\n",
+    "    model, exposure=exposure, psf=psf_kernel, edisp=edisp\n",
+    ")\n",
     "\n",
-    "background_gal = evaluator.compute_npred()\n",
-    "background_gal.sum_over_axes().plot()\n",
-    "print(\"Background counts from Galactic diffuse: \", background_gal.data.sum())"
+    "background_gal.map.sum_over_axes().plot()\n",
+    "print(\n",
+    "    \"Background counts from Galactic diffuse: \", background_gal.map.data.sum()\n",
+    ")"
    ]
   },
   {
@@ -544,11 +566,14 @@
    "source": [
     "model = SkyModel(SkyDiffuseConstant(), diffuse_iso)\n",
     "\n",
-    "evaluator = MapEvaluator(model=model, exposure=exposure, psf=psf_kernel)\n",
+    "background_iso = BackgroundModel.from_skymodel(\n",
+    "    model, exposure=exposure, edisp=edisp\n",
+    ")\n",
     "\n",
-    "background_iso = evaluator.compute_npred()\n",
-    "background_iso.sum_over_axes().plot(add_cbar=True)\n",
-    "print(\"Background counts from isotropic diffuse: \", background_iso.data.sum())"
+    "background_iso.map.sum_over_axes().plot(add_cbar=True)\n",
+    "print(\n",
+    "    \"Background counts from isotropic diffuse: \", background_iso.map.data.sum()\n",
+    ")"
    ]
   },
   {
@@ -557,11 +582,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#This is a temporary fix to ensure energy axis node_type=\"edges\".\n",
-    "#To be removed once MapEvaluator correctly handles node_type\n",
-    "back_data = background_iso + background_gal\n",
-    "background = counts.copy(data=back_data.data)\n",
-    "background.sum_over_axes().plot(add_cbar=True)"
+    "background_total = background_iso + background_gal"
    ]
   },
   {
@@ -580,7 +601,7 @@
    "outputs": [],
    "source": [
     "excess = counts.copy()\n",
-    "excess.data -= background.data\n",
+    "excess.data -= background_total.evaluate().data\n",
     "excess.sum_over_axes().smooth(2).plot(\n",
     "    cmap=\"coolwarm\", vmin=-5, vmax=5, add_cbar=True\n",
     ")\n",
@@ -618,12 +639,12 @@
     "    SkyPointSource(\"0 deg\", \"0 deg\"),\n",
     "    PowerLaw(index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"),\n",
     ")\n",
-    "background_model = BackgroundModel(background)\n",
+    "\n",
     "dataset = MapDataset(\n",
     "    model=model,\n",
     "    counts=counts,\n",
     "    exposure=exposure,\n",
-    "    background_model=background_model,\n",
+    "    background_model=background_total,\n",
     "    psf=psf_kernel,\n",
     ")\n",
     "fit = Fit(dataset)\n",
@@ -645,7 +666,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(dataset.parameters.to_table())"
+    "dataset.parameters.to_table()"
    ]
   },
   {
@@ -654,7 +675,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(result.parameters.covariance_to_table())"
+    "residual = counts - dataset.npred()\n",
+    "residual.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
+    "    cmap=\"coolwarm\", vmin=-3, vmax=3, add_cbar=True\n",
+    ");"
    ]
   },
   {

--- a/tutorials/hess.ipynb
+++ b/tutorials/hess.ipynb
@@ -184,12 +184,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spatial_model = SkyPointSource(lon_0=\"83.6 deg\", lat_0=\"22.0 deg\")\n",
+    "spatial_model = SkyPointSource(\n",
+    "    lon_0=\"83.6 deg\", lat_0=\"22.0 deg\", frame=\"icrs\"\n",
+    ")\n",
     "spectral_model = PowerLaw(\n",
     "    index=2.6, amplitude=\"5e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
     "model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)\n",
-    "background_model = BackgroundModel(maps[\"background\"], norm=1.0)"
+    "background_model = BackgroundModel(maps[\"background\"], norm=1.0)\n",
+    "background_model.parameters[\"tilt\"].frozen = False"
    ]
   },
   {
@@ -352,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR contains the following changes:
- Add a `.frame` and `.position` attribute to `SkySpatialModel` and `SkyModel`
- Add frame handling to `MapEvaluator`, such that the spatial model is always evaluated with the right coordinate system defined by the model.
- Change the default wrapping angle of the `lon_0` parameter of spatial models to `180 deg`. I noticed that in the `analysis_3d.ipynb` notebook the fit did not converge, when the start value was set to to `lon_0 = -0.05`, because by default it was wrapped at `360 deg`. The optimiser cannot deal with this jump.
- Introduce default `min` and `max` values for `lon_0` and `lat_0` to constrain the models position to the sphere. With the failing fit I noticed that the optimiser tried values `lat_0 > 90` or `lat_0 < -90`. 
- Introduce a `BackgroundModel.from_skymodel()` method, which allows to create a background model from a `SkyDiffuseCube` or `SkyDiffuseConstant` model. The motivation is that this vastly improves the performance of the fit (~factor 20-30), because the model is not interpolated and convolved anymore in every fit iteration, but just scaled and tilted.
- Introduce a `BackgroundModels` class to handle the sum of multiple background models. The use case here was the `fermi_lat.ipynb` notebook, where two independent components for the `galactic` and `constant` diffuse model are used.
