### PR TITLE
Implement MapDataset npred evaluation using cutouts

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -38,7 +38,7 @@ class MapDataset:
     likelihood : {"cash", "cstat"}
 	    Likelihood function to use for the fit.
 	evaluation_mode : {"local", "global"}
-        Model evaluation mode. The "cutout" mode evaluates the model components on smaller grids
+        Model evaluation mode. The "local" mode evaluates the model components on smaller grids
         and assigns spatially dependent IRFs (if provided) to the model component. This mode is
         recommended for local optimization algorithms. The "global" evaluation mode assumes a global PSF
         and energy dispersion and evaluates the model components on the full map. This mode is recommended
@@ -92,7 +92,7 @@ class MapDataset:
             evaluator = MapEvaluator(self.model, self.exposure, self.psf, self.edisp)
             self._evaluators = [evaluator]
         else:
-            raise ValueError("Not a valid model evaluation mode. Choose between 'cutout' and 'global'")
+            raise ValueError("Not a valid model evaluation mode. Choose between 'local' and 'global'")
 
     @lazyproperty
     def parameters(self):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -53,7 +53,7 @@ class SkyModels(SkyModelBase):
         filename = '$GAMMAPY_DATA/tests/models/fermi_model.xml'
         sourcelib = SkyModels.read(filename)
     """
-
+    frame = None
     def __init__(self, skymodels):
         self.skymodels = skymodels
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -52,8 +52,10 @@ def background(geom):
 
 
 def edisp(geom, geom_etrue):
-    e_true = geom_etrue.get_axis_by_name("energy").edges
-    e_reco = geom.get_axis_by_name("energy").edges
+    e_true_axis = geom_etrue.get_axis_by_name("energy")
+    e_reco_axis = geom.get_axis_by_name("energy")
+    e_true = e_true_axis.edges * e_true_axis.unit
+    e_reco = e_reco_axis.edges * e_reco_axis.unit
     return EnergyDispersion.from_diagonal_response(e_true=e_true, e_reco=e_reco)
 
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -128,6 +128,7 @@ def test_map_fit(sky_model):
         psf=psf_map,
         edisp=edisp_map,
         background_model=background_model_1,
+        evaluation_mode="local",
     )
 
     dataset_2 = MapDataset(
@@ -138,6 +139,7 @@ def test_map_fit(sky_model):
         psf=psf_map,
         edisp=edisp_map,
         background_model=background_model_2,
+        evaluation_mode="global"
     )
 
     background_model_1.parameters["norm"].value = 0.4

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -461,45 +461,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's cut out only part of the maps, so that we the fitting step does not take so long (we go from left to right one):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cmaps = {\n",
-    "    name: m.cutout(SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"), 2 * u.deg)\n",
-    "    for name, m in maps.items()\n",
-    "}\n",
-    "cmaps[\"counts\"].sum_over_axes().plot(stretch=\"sqrt\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Insted of the complete one, which was:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "counts.plot(stretch=\"sqrt\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Fit mask\n",
     "\n",
-    "To select a certain spatial region and/or energy range for the fit we can create a fit mask:"
+    "To select a certain energy range for the fit we can create a fit mask:"
    ]
   },
   {
@@ -508,29 +472,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = Map.from_geom(cmaps[\"counts\"].geom)\n",
+    "mask = Map.from_geom(maps[\"counts\"].geom)\n",
     "\n",
-    "region = CircleSkyRegion(center=src_pos, radius=0.6 * u.deg)\n",
-    "mask.data = mask.geom.region_mask([region])\n",
-    "\n",
-    "mask.get_image_by_idx((0,)).plot();"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In addition we also exclude the range below 0.3 TeV for the fit:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "coords = mask.geom.get_coord()\n",
-    "mask.data &= coords[\"energy\"] > 0.3"
+    "mask.data = coords[\"energy\"] > 0.3"
    ]
   },
   {
@@ -559,8 +504,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Defining a background model\n",
-    "\n",
     "Often, it is useful to fit the normalisation (and also the tilt) of the background. To do so, we have to define the background as a model. In this example, we will keep the tilt fixed and the norm free."
    ]
   },
@@ -570,7 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "background_model = BackgroundModel(cmaps[\"background\"], norm=1.1, tilt=0.0)\n",
+    "background_model = BackgroundModel(maps[\"background\"], norm=1.1, tilt=0.0)\n",
     "background_model.parameters[\"norm\"].frozen = False\n",
     "background_model.parameters[\"tilt\"].frozen = True"
    ]
@@ -590,8 +533,8 @@
    "source": [
     "dataset = MapDataset(\n",
     "    model=model,\n",
-    "    counts=cmaps[\"counts\"],\n",
-    "    exposure=cmaps[\"exposure\"],\n",
+    "    counts=maps[\"counts\"],\n",
+    "    exposure=maps[\"exposure\"],\n",
     "    background_model=background_model,\n",
     "    mask=mask,\n",
     "    psf=psf_kernel,\n",
@@ -630,13 +573,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that the background normalisation is very large (2.15). This is because of the large number of sources, and the presence of diffuse emission in the galactic center."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Check model fit\n",
     "\n",
     "We check the model fit by computing a residual image. For this we first get the number of predicted counts:"
@@ -664,7 +600,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "residual = cmaps[\"counts\"] - npred"
+    "residual = maps[\"counts\"] - npred"
    ]
   },
   {
@@ -674,7 +610,7 @@
    "outputs": [],
    "source": [
     "residual.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap=\"coolwarm\", vmin=-3, vmax=3, add_cbar=True\n",
+    "    cmap=\"coolwarm\", vmin=-1, vmax=1, add_cbar=True\n",
     ");"
    ]
   },
@@ -706,8 +642,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Apparently our model should be improved by adding a component for diffuse Galactic emission and at least one second point\n",
-    "source. But before we do that in the next section, we will fit the background as a model."
+    "Apparently our model should be improved by adding a component for diffuse Galactic emission and at least one second point source."
    ]
   },
   {
@@ -721,7 +656,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use both models at the same time, our diffuse model (the same from the Fermi file used before) and our model for the central source. This time, in order to make it more realistic, we will consider an exponential cut off power law spectral model for the source  (note that we are not constraining the fit with any mask this time). We will again fot the normalisation of the background."
+    "We use both models at the same time, our diffuse model (the same from the Fermi file used before) and our model for the central source. This time, in order to make it more realistic, we will consider an exponential cut off power law spectral model for the source. We will fit again the normalisation and tilt of the background."
    ]
   },
   {
@@ -735,7 +670,7 @@
     ")\n",
     "\n",
     "background_diffuse = BackgroundModel.from_skymodel(\n",
-    "    diffuse_model, exposure=cmaps[\"exposure\"], psf=psf_kernel\n",
+    "    diffuse_model, exposure=maps[\"exposure\"], psf=psf_kernel\n",
     ")"
    ]
   },
@@ -745,8 +680,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "background_irf = BackgroundModel(cmaps[\"background\"], norm=1.0, tilt=0.0)\n",
-    "\n",
+    "background_irf = BackgroundModel(maps[\"background\"], norm=1.0, tilt=0.0)\n",
     "background_total = background_irf + background_diffuse"
    ]
   },
@@ -756,12 +690,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spatial_model = SkyPointSource(lon_0=\"0.01 deg\", lat_0=\"0.01 deg\")\n",
+    "spatial_model = SkyPointSource(lon_0=\"-0.05 deg\", lat_0=\"-0.05 deg\")\n",
     "spectral_model = ExponentialCutoffPowerLaw(\n",
     "    index=2 * u.Unit(\"\"),\n",
-    "    amplitude=1e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
+    "    amplitude=3e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
     "    reference=1.0 * u.TeV,\n",
-    "    lambda_=1 / u.TeV,\n",
+    "    lambda_=0.1 / u.TeV,\n",
     ")\n",
     "\n",
     "model_ecpl = SkyModel(\n",
@@ -777,8 +711,8 @@
    "source": [
     "dataset_combined = MapDataset(\n",
     "    model=model_ecpl,\n",
-    "    counts=cmaps[\"counts\"],\n",
-    "    exposure=cmaps[\"exposure\"],\n",
+    "    counts=maps[\"counts\"],\n",
+    "    exposure=maps[\"exposure\"],\n",
     "    background_model=background_total,\n",
     "    psf=psf_kernel,\n",
     "    edisp=edisp,\n",
@@ -835,7 +769,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "residual2 = cmaps[\"counts\"] - dataset_combined.npred()"
+    "residual2 = maps[\"counts\"] - dataset_combined.npred()"
    ]
   },
   {
@@ -859,10 +793,10 @@
     "ax_2.set_title(\"With diffuse emission subtraction\")\n",
     "\n",
     "residual.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap=\"coolwarm\", vmin=-2, vmax=2, add_cbar=True, ax=ax_1\n",
+    "    cmap=\"coolwarm\", vmin=-1, vmax=1, add_cbar=True, ax=ax_1\n",
     ")\n",
     "residual2.sum_over_axes().smooth(width=0.05 * u.deg).plot(\n",
-    "    cmap=\"coolwarm\", vmin=-2, vmax=2, add_cbar=True, ax=ax_2\n",
+    "    cmap=\"coolwarm\", vmin=-1, vmax=1, add_cbar=True, ax=ax_2\n",
     ");"
    ]
   },
@@ -937,7 +871,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -602,7 +602,7 @@
    "source": [
     "excess = counts.copy()\n",
     "excess.data -= background_total.evaluate().data\n",
-    "excess.sum_over_axes().smooth(2).plot(\n",
+    "excess.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
     "    cmap=\"coolwarm\", vmin=-5, vmax=5, add_cbar=True\n",
     ")\n",
     "print(\"Excess counts: \", excess.data.sum())"
@@ -617,7 +617,7 @@
     "flux = excess.copy()\n",
     "flux.data /= exposure.data\n",
     "flux.unit = excess.unit / exposure.unit\n",
-    "flux.sum_over_axes().smooth(2).plot(stretch=\"sqrt\", add_cbar=True);"
+    "flux.sum_over_axes().smooth(\"0.1 deg\").plot(stretch=\"sqrt\", add_cbar=True);"
    ]
   },
   {

--- a/tutorials/hess.ipynb
+++ b/tutorials/hess.ipynb
@@ -272,8 +272,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "residual.sum_over_axes().smooth(3).plot(\n",
-    "    cmap=\"coolwarm\", vmin=-0.5, vmax=0.5, add_cbar=True\n",
+    "residual.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
+    "    cmap=\"coolwarm\", vmin=-0.2, vmax=0.2, add_cbar=True\n",
     ");"
    ]
   },

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -44,7 +44,7 @@
     "from gammapy.spectrum.models import PowerLaw\n",
     "from gammapy.image.models import SkyGaussian\n",
     "from gammapy.cube.models import SkyModel, SkyModels, BackgroundModel\n",
-    "from gammapy.cube import MapDataset, MapEvaluator, PSFKernel\n",
+    "from gammapy.cube import MapDataset, PSFKernel\n",
     "from gammapy.cube import make_map_exposure_true_energy, make_map_background_irf\n",
     "from gammapy.utils.fitting import Fit\n",
     "from gammapy.data import FixedPointingInfo"
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we have to compute `npred`  maps, i.e. \"predicted counts per pixel\" given the model and the observation infos: exposure, background, PSF and EDISP. The class `MapEvaluator` will compute the predicted counts from the `sky_model` and convolve it with the IRFs. Background counts have to be computed separately using the class `BackgroundModel`"
+    "Now we have to compute `npred`  maps, i.e. \"predicted counts per pixel\" given the model and the observation infos: exposure, background, PSF and EDISP. For this we use the `MapDataset` object:"
    ]
   },
   {
@@ -186,15 +186,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluator_src = MapEvaluator(   \n",
+    "background_model = BackgroundModel(background)\n",
+    "dataset = MapDataset(\n",
     "    model=sky_model,\n",
     "    exposure=exposure,\n",
+    "    background_model=background_model,\n",
     "    psf=psf_kernel,\n",
-    "    edisp=edisp,\n",
-    ")\n",
-    "npred_src = evaluator_src.compute_npred()\n",
-    "background_model = BackgroundModel(background)\n",
-    "npred_bkg = background_model.evaluate()\n"
+    "    edisp=edisp\n",
+    ")"
    ]
   },
   {
@@ -203,8 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "npred_data = npred_src.data + npred_bkg.data\n",
-    "npred_map = WcsNDMap(geom, npred_data)"
+    "npred = dataset.npred()"
    ]
   },
   {
@@ -213,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "npred_map.sum_over_axes().plot(add_cbar=True);"
+    "npred.sum_over_axes().plot(add_cbar=True);"
    ]
   },
   {
@@ -227,7 +225,7 @@
     "# npred to obtain simulated observed counts.\n",
     "# Compute counts as a Poisson fluctuation\n",
     "rng = np.random.RandomState(seed=42)\n",
-    "counts = rng.poisson(npred_data)\n",
+    "counts = rng.poisson(npred.data)\n",
     "counts_map = WcsNDMap(geom, counts)"
    ]
   },
@@ -257,19 +255,21 @@
    "outputs": [],
    "source": [
     "# Define sky model to fit the data\n",
-    "spatial_model = SkyGaussian(lon_0=\"0 deg\", lat_0=\"0 deg\", sigma=\"1 deg\")\n",
+    "spatial_model = SkyGaussian(lon_0=\"0.1 deg\", lat_0=\"0.1 deg\", sigma=\"0.5 deg\")\n",
     "spectral_model = PowerLaw(\n",
     "    index=2, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
     "model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)\n",
-    "\n",
-    "# Impose that specrtal index remains within limits\n",
-    "spectral_model.parameters[\"index\"].min = 0.0\n",
-    "spectral_model.parameters[\"index\"].max = 10.0\n",
-    "\n",
-    "print(model)\n",
-    "\n",
-    "#We do not want to fit the background in this case, so we will freeze the parameters\n",
+    "print(model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We do not want to fit the background in this case, so we will freeze the parameters\n",
     "background_model.parameters[\"norm\"].value = 1.0\n",
     "background_model.parameters[\"norm\"].frozen = True\n",
     "background_model.parameters[\"tilt\"].frozen = True\n",
@@ -283,14 +283,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
     "dataset = MapDataset(\n",
     "    model=model,\n",
-    "    counts=counts_map,\n",
     "    exposure=exposure,\n",
+    "    counts=counts_map,\n",
     "    background_model=background_model,\n",
     "    psf=psf_kernel,\n",
-    ")\n",
+    "    edisp=edisp\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
     "fit = Fit(dataset)\n",
     "result = fit.run(optimize_opts={\"print_level\": 1})"
    ]
@@ -379,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR includes the following changes:
- Create individual `MapEvaluator` objects for each model component
- Implement `MapEvaluator.update()` method to update the model evaluator by cutting out the corresponding part of the global exposure map and setting `edisp` as well as `psf`.
- Implement `MapEvaluator.needs_update` attribute, which checks, whether the model component drifted out from its cutout region. Currently the evaluator is updated, when the model component drifted more than `0.25 deg` from the cutout center, which approximately half a PSF kernel size. While this seems to work, it can be surely improved, e.g. by choosing a smaller update threshold for point sources, where the PSF is much more important. For extended source one could probably choose a larger one.
- Update the `analysis_3d.ipynb` notebook to run the fit on the whole image instead of a small cutout. This is now possible, because the performance of the fit improved a lot. I also removed the region mask, so that the background norm is better constrained.
- Implement the `likelihood` option for `MapDataset` which was documented, but not implemented.
- Minor changes to the `hess.ipynb`, `fermi_lat.ipynb` and `analysis_3d_joint,ipynb` notebooks.