### PR TITLE
Expose model parameters as attributes

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -64,18 +64,21 @@ class PrimaryFlux:
 
         self.table_path = make_path(self.table_filename)
         if not self.table_path.exists():
-            message = "\n\nFile {} not found.\n" \
-                      "You may download the dataset needed with the following command:\n" \
-                      "gammapy download datasets --src dark_matter_spectra" \
-                      "".format(self.table_filename)
+            message = (
+                "\n\nFile {} not found.\n"
+                "You may download the dataset needed with the following command:\n"
+                "gammapy download datasets --src dark_matter_spectra"
+                "".format(self.table_filename)
+            )
 
             raise FileNotFoundError(message)
         else:
-            self.table = Table.read(str(self.table_path),
-                    format="ascii.fast_basic",
-                    guess=False,
-                    delimiter=" ",
-                )
+            self.table = Table.read(
+                str(self.table_path),
+                format="ascii.fast_basic",
+                guess=False,
+                delimiter=" ",
+            )
 
         self.mDM = mDM
         self.channel = channel
@@ -166,11 +169,22 @@ class DMAnnihilation(SpectralModel):
     * `2011JCAP...03..051 <http://adsabs.harvard.edu/abs/2011JCAP...03..051>`_
     """
 
+    __slots__ = [
+        "_parameters",
+        "mass",
+        "channel",
+        "scale",
+        "jfactor",
+        "z",
+        "k",
+        "primary_flux",
+    ]
+
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
     """Thermally averaged annihilation cross-section"""
 
     def __init__(self, mass, channel, scale=1, jfactor=1, z=0, k=2):
-        self.parameters = Parameters([Parameter("scale", scale)])
+        self._parameters = Parameters([Parameter("scale", scale)])
         self.k = k
         self.z = z
         self.mass = mass

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -170,7 +170,6 @@ class DMAnnihilation(SpectralModel):
     """
 
     __slots__ = [
-        "_parameters",
         "mass",
         "channel",
         "scale",

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -183,13 +183,14 @@ class DMAnnihilation(SpectralModel):
     """Thermally averaged annihilation cross-section"""
 
     def __init__(self, mass, channel, scale=1, jfactor=1, z=0, k=2):
-        self._parameters = Parameters([Parameter("scale", scale)])
+        self.scale = Parameter("scale", scale)
         self.k = k
         self.z = z
         self.mass = mass
         self.channel = channel
         self.jfactor = jfactor
         self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
+        super().__init__([self.scale])
 
     def evaluate(self, energy, scale):
         """Evaluate dark matter annihilation model."""

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -74,7 +74,7 @@ class SkyModels(SkyModelBase):
         for skymodel in skymodels:
             for p in skymodel.parameters:
                 params.append(p)
-        super().__init__(params)
+        self._parameters = Parameters(params)
 
     @property
     def parameters(self):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -486,7 +486,7 @@ class BackgroundModels:
         List of background models.
     """
 
-    __slots__ = ["models"]
+    __slots__ = ["models", "_parameters"]
 
     def __init__(self, models):
         self.models = models

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -13,12 +13,14 @@ __all__ = [
     "SkyModel",
     "SkyDiffuseCube",
     "BackgroundModel",
-    "BackgroundModels"
+    "BackgroundModels",
 ]
 
 
 class SkyModelBase(Model):
     """Sky model base class"""
+
+    __slots__ = []
 
     def __init__(self, params):
         super().__init__(params)
@@ -63,14 +65,21 @@ class SkyModels(SkyModelBase):
         sourcelib = SkyModels.read(filename)
     """
     frame = None
+
+    __slots__ = ["skymodels", "_parameters"]
+
     def __init__(self, skymodels):
         self.skymodels = skymodels
-
         params = []
         for skymodel in skymodels:
             for p in skymodel.parameters:
                 params.append(p)
         super().__init__(params)
+
+    @property
+    def parameters(self):
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
+        return self._parameters
 
     @classmethod
     def from_xml(cls, xml):
@@ -116,7 +125,9 @@ class SkyModels(SkyModelBase):
         str_ = self.__class__.__name__ + "\n\n"
 
         for idx, skymodel in enumerate(self.skymodels):
-            str_ += "Component {idx}: {skymodel}\n\n\t".format(idx=idx, skymodel=skymodel)
+            str_ += "Component {idx}: {skymodel}\n\n\t".format(
+                idx=idx, skymodel=skymodel
+            )
             str_ += "\n\n"
 
         if self.parameters.covariance is not None:
@@ -163,6 +174,9 @@ class SkyModel(SkyModelBase):
     name : str
         Model identifier
     """
+
+    __slots__ = ["name", "_spatial_model", "_spectral_model", "_parameters"]
+
     def __init__(self, spatial_model, spectral_model, name="SkyModel"):
         self.name = name
         self._spatial_model = spatial_model
@@ -170,7 +184,6 @@ class SkyModel(SkyModelBase):
         self._parameters = Parameters(
             spatial_model.parameters.parameters + spectral_model.parameters.parameters
         )
-        super().__init__(self._parameters.parameters)
 
     @property
     def spatial_model(self):
@@ -238,6 +251,9 @@ class CompoundSkyModel(SkyModelBase):
     operator : callable
         Binary operator to combine the models
     """
+
+    __slots__ = ["model1", "model2", "operator", "_parameters"]
+
     def __init__(self, model1, model2, operator):
         self.model1 = model1
         self.model2 = model2
@@ -245,7 +261,18 @@ class CompoundSkyModel(SkyModelBase):
         self._parameters = Parameters(
             self.model1.parameters.parameters + self.model2.parameters.parameters
         )
-        super().__init__(self._parameters.parameters)
+
+    @property
+    def parameters(self):
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        self._parameters = parameters
+        idx = len(self.model1.parameters.parameters)
+        self.model1.parameters.parameters = parameters.parameters[:idx]
+        self.model2.parameters.parameters = parameters.parameters[idx:]
 
     def __str__(self):
         ss = self.__class__.__name__
@@ -296,6 +323,8 @@ class SkyDiffuseCube(SkyModelBase):
         Default arguments are {'interp': 'linear', 'fill_value': 0}.
 
     """
+
+    __slots__ = ["_parameters", "map", "norm", "meta", "_interp_kwargs"]
 
     def __init__(self, map, norm=1, meta=None, interp_kwargs=None):
         axis = map.geom.get_axis_by_name("energy")
@@ -352,13 +381,12 @@ class SkyDiffuseCube(SkyModelBase):
     @property
     def evaluation_radius(self):
         """`~astropy.coordinates.Angle`"""
-        radius = np.max(self.map.geom.width) / 2.
+        radius = np.max(self.map.geom.width) / 2.0
         return radius
 
     @property
     def frame(self):
         return self.position.frame
-
 
 
 class BackgroundModel(Model):
@@ -383,6 +411,8 @@ class BackgroundModel(Model):
         Background evaluated on the Map
     """
 
+    __slots__ = ["_parameters", "map", "norm", "tilt", "reference"]
+
     def __init__(self, background, norm=1, tilt=0, reference="1 TeV"):
 
         axis = background.geom.get_axis_by_name("energy")
@@ -399,7 +429,12 @@ class BackgroundModel(Model):
         )
         super().__init__(self._parameters.parameters)
 
-    @lazyproperty
+    @property
+    def parameters(self):
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
+        return self._parameters
+
+    @property
     def energy_center(self):
         """True energy axis bin centers (`~astropy.units.Quantity`)"""
         energy_axis = self.map.geom.get_axis_by_name("energy")
@@ -434,7 +469,10 @@ class BackgroundModel(Model):
             PSF to apply.
         """
         from .fit import MapEvaluator
-        evaluator = MapEvaluator(model=skymodel, exposure=exposure, edisp=edisp, psf=psf)
+
+        evaluator = MapEvaluator(
+            model=skymodel, exposure=exposure, edisp=edisp, psf=psf
+        )
         background = evaluator.compute_npred()
         return cls(background=background, **kwargs)
 
@@ -449,15 +487,16 @@ class BackgroundModel(Model):
         return BackgroundModels(models)
 
 
-
 class BackgroundModels:
     """Background models.
-
     Parameters
     ----------
     models : list of `BackgroundModel`
         List of background models.
     """
+
+    __slots__ = ["models", "_parameters"]
+
     def __init__(self, models):
         self.models = models
         pars = []
@@ -465,7 +504,11 @@ class BackgroundModels:
             for p in model.parameters:
                 pars.append(p)
         self._parameters = Parameters(pars)
-        super().__init__(self._parameters.parameters)
+
+    @property
+    def parameters(self):
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
+        return self._parameters
 
     def evaluate(self):
         """Evaluate background models."""

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -7,7 +7,7 @@ from ...irf import load_cta_irfs
 from ...maps import WcsGeom, MapAxis
 from ...spectrum.models import PowerLaw
 from ...image.models import SkyGaussian
-from ...cube.models import SkyModel
+from ...cube.models import SkyModel, SkyModels
 from ...cube import MapDataset
 from ..simulate import simulate_dataset
 
@@ -43,7 +43,7 @@ def test_simulate():
     )
 
     assert isinstance(dataset, MapDataset)
-    assert isinstance(dataset.model, SkyModel)
+    assert isinstance(dataset.model, SkyModels)
 
     assert dataset.counts.data.dtype is np.dtype("int")
     assert_allclose(dataset.counts.data[5, 20, 20],5)

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -31,14 +31,9 @@ class SkySpatialModel(Model):
     def __init__(self, params):
         super().__init__(params)
 
-    @property
-    def parameters(self):
-        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
-        return self._parameters
-
-    @parameters.setter
-    def parameters(self, parameters):
-        self._parameters = parameters
+    #    @parameters.setter
+    #    def parameters(self, parameters):
+    #        self._parameters = parameters
 
     def __call__(self, lon, lat):
         """Call evaluate method"""
@@ -77,17 +72,21 @@ class SkyPointSource(SkySpatialModel):
         Coordinate frame of `lon_0` and `lat_0`.
     """
 
-    __slots__ = ["frame", "_parameters", "lon_0", "lat_0"]
+    __slots__ = ["frame", "lon_0", "lat_0"]
 
     def __init__(self, lon_0, lat_0, frame="galactic"):
         self.frame = frame
-        self._parameters = Parameters(
-            [
-                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
-                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
-            ]
+        self.lon_0 = Parameter(
+            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
         )
-        super().__init__(self._parameters.parameters)
+        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):
@@ -158,18 +157,22 @@ class SkyGaussian(SkySpatialModel):
         Coordinate frame of `lon_0` and `lat_0`.
     """
 
-    __slots__ = ["frame", "_parameters", "lon_0", "lat_0", "sigma"]
+    __slots__ = ["frame", "lon_0", "lat_0", "sigma"]
 
     def __init__(self, lon_0, lat_0, sigma, frame="galactic"):
         self.frame = frame
-        self._parameters = Parameters(
-            [
-                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
-                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
-                Parameter("sigma", Angle(sigma), min=0),
-            ]
+        self.lon_0 = Parameter(
+            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
         )
-        super().__init__(self._parameters.parameters)
+        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.sigma = Parameter("sigma", Angle(sigma), min=0)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):
@@ -220,18 +223,22 @@ class SkyDisk(SkySpatialModel):
         Coordinate frame of `lon_0` and `lat_0`.
     """
 
-    __slots__ = ["frame", "_parameters", "lon_0", "lat_0", "r_0"]
+    __slots__ = ["frame", "lon_0", "lat_0", "r_0"]
 
     def __init__(self, lon_0, lat_0, r_0, frame="galactic"):
         self.frame = frame
-        self._parameters = Parameters(
-            [
-                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
-                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
-                Parameter("r_0", Angle(r_0)),
-            ]
+        self.lon_0 = Parameter(
+            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
         )
-        super().__init__(self._parameters.parameters)
+        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.r_0 = Parameter("r_0", Angle(r_0))
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):
@@ -330,16 +337,7 @@ class SkyEllipse(SkySpatialModel):
         plt.show()
     """
 
-    __slots__ = [
-        "frame",
-        "_parameters",
-        "lon_0",
-        "lat_0",
-        "semi_major",
-        "e",
-        "theta",
-        "_offset_by",
-    ]
+    __slots__ = ["frame", "lon_0", "lat_0", "semi_major", "e", "theta", "_offset_by"]
 
     def __init__(self, lon_0, lat_0, semi_major, e, theta, frame="galactic"):
         try:
@@ -350,16 +348,20 @@ class SkyEllipse(SkySpatialModel):
             raise ImportError("The SkyEllipse model requires astropy>=3.1")
 
         self.frame = frame
-        self._parameters = Parameters(
-            [
-                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
-                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
-                Parameter("semi_major", Angle(semi_major)),
-                Parameter("e", e, min=0, max=1),
-                Parameter("theta", Angle(theta)),
-            ]
+        self.lon_0 = Parameter(
+            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
         )
-        super().__init__(self._parameters.parameters)
+        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.semi_major = Parameter("semi_major", Angle(semi_major))
+        self.e = Parameter("e", e, min=0, max=1)
+        self.theta = Parameter("theta", Angle(theta))
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):
@@ -440,19 +442,23 @@ class SkyShell(SkySpatialModel):
         Coordinate frame of `lon_0` and `lat_0`.
     """
 
-    __slots__ = ["frame", "_parameters", "lon_0", "lat_0", "radius", "width"]
+    __slots__ = ["frame", "lon_0", "lat_0", "radius", "width"]
 
     def __init__(self, lon_0, lat_0, radius, width, frame="galactic"):
         self.frame = frame
-        self._parameters = Parameters(
-            [
-                Parameter("lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180),
-                Parameter("lat_0", Latitude(lat_0), min=-90, max=90),
-                Parameter("radius", Angle(radius)),
-                Parameter("width", Angle(width)),
-            ]
+        self.lon_0 = Parameter(
+            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
         )
-        super().__init__(self._parameters.parameters)
+        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.radius = Parameter("radius", Angle(radius))
+        self.width = Parameter("width", Angle(width))
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):
@@ -496,13 +502,16 @@ class SkyDiffuseConstant(SkySpatialModel):
         Value
     """
 
-    __slots__ = ["_parameters", "value"]
+    __slots__ = ["value"]
 
     frame = None
 
     def __init__(self, value=1):
-        self._parameters = Parameters([Parameter("value", value)])
-        super().__init__(self._parameters.parameters)
+        self.value = Parameter("value", value)
+
+        params = []
+        params.append(getattr(self, "value"))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):
@@ -543,7 +552,7 @@ class SkyDiffuseMap(SkySpatialModel):
         Default arguments are {'interp': 'linear', 'fill_value': 0}.
     """
 
-    __slots__ = ["map", "_parameters", "norm", "meta", "_interp_kwargs"]
+    __slots__ = ["map", "norm", "meta", "_interp_kwargs"]
 
     def __init__(self, map, norm=1, meta=None, normalize=True, interp_kwargs=None):
         if (map.data < 0).any():
@@ -557,14 +566,17 @@ class SkyDiffuseMap(SkySpatialModel):
         if normalize:
             self.normalize()
 
-        self._parameters = Parameters([Parameter("norm", norm)])
+        self.norm = Parameter("norm", norm)
         self.meta = dict() if meta is None else meta
 
         interp_kwargs = {} if interp_kwargs is None else interp_kwargs
         interp_kwargs.setdefault("interp", "linear")
         interp_kwargs.setdefault("fill_value", 0)
         self._interp_kwargs = interp_kwargs
-        super().__init__(self._parameters.parameters)
+
+        params = []
+        params.append(getattr(self, "norm"))
+        super().__init__(params)
 
     @property
     def evaluation_radius(self):

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -26,15 +26,6 @@ log = logging.getLogger(__name__)
 class SkySpatialModel(Model):
     """Sky spatial model base class."""
 
-    __slots__ = []
-
-    def __init__(self, params):
-        super().__init__(params)
-
-    #    @parameters.setter
-    #    def parameters(self, parameters):
-    #        self._parameters = parameters
-
     def __call__(self, lon, lat):
         """Call evaluate method"""
         kwargs = dict()
@@ -81,12 +72,7 @@ class SkyPointSource(SkySpatialModel):
         )
         self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.lon_0, self.lat_0])
 
     @property
     def evaluation_radius(self):
@@ -167,12 +153,7 @@ class SkyGaussian(SkySpatialModel):
         self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
         self.sigma = Parameter("sigma", Angle(sigma), min=0)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.lon_0, self.lat_0, self.sigma])
 
     @property
     def evaluation_radius(self):
@@ -233,12 +214,7 @@ class SkyDisk(SkySpatialModel):
         self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
         self.r_0 = Parameter("r_0", Angle(r_0))
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.lon_0, self.lat_0, self.r_0])
 
     @property
     def evaluation_radius(self):
@@ -356,12 +332,7 @@ class SkyEllipse(SkySpatialModel):
         self.e = Parameter("e", e, min=0, max=1)
         self.theta = Parameter("theta", Angle(theta))
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.lon_0, self.lat_0, self.semi_major, self.e, self.theta])
 
     @property
     def evaluation_radius(self):
@@ -453,12 +424,7 @@ class SkyShell(SkySpatialModel):
         self.radius = Parameter("radius", Angle(radius))
         self.width = Parameter("width", Angle(width))
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.lon_0, self.lat_0, self.radius, self.width])
 
     @property
     def evaluation_radius(self):
@@ -509,9 +475,7 @@ class SkyDiffuseConstant(SkySpatialModel):
     def __init__(self, value=1):
         self.value = Parameter("value", value)
 
-        params = []
-        params.append(getattr(self, "value"))
-        super().__init__(params)
+        super().__init__([self.value])
 
     @property
     def evaluation_radius(self):
@@ -574,9 +538,7 @@ class SkyDiffuseMap(SkySpatialModel):
         interp_kwargs.setdefault("fill_value", 0)
         self._interp_kwargs = interp_kwargs
 
-        params = []
-        params.append(getattr(self, "norm"))
-        super().__init__(params)
+        super().__init__([self.norm])
 
     @property
     def evaluation_radius(self):

--- a/gammapy/spectrum/crab.py
+++ b/gammapy/spectrum/crab.py
@@ -56,7 +56,7 @@ class MeyerCrabModel(SpectralModel):
     coefficients = np.array([-0.00449161, 0, 0.0473174, -0.179475, -0.53616, -10.2708])
 
     def __init__(self):
-        self.parameters = Parameters([])
+        self._parameters = Parameters([])
 
     @staticmethod
     def evaluate(energy):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -42,15 +42,6 @@ class SpectralModel(Model):
     def __init__(self, params):
         super().__init__(params)
 
-    @property
-    def parameters(self):
-        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
-        return self._parameters
-
-    @parameters.setter
-    def parameters(self, parameters):
-        self._parameters = parameters
-
     def __call__(self, energy):
         """Call evaluate method of derived classes"""
         kwargs = dict()
@@ -458,11 +449,14 @@ class ConstantModel(SpectralModel):
         :math:`k`
     """
 
-    __slots__ = ["_parameters", "const"]
+    __slots__ = ["const"]
 
     def __init__(self, const):
-        self._parameters = Parameters([Parameter("const", const)])
-        super().__init__(self._parameters.parameters)
+        self.const = Parameter("const", const)
+
+        params = []
+        params.append(getattr(self, "const"))
+        super().__init__(params)
 
     @staticmethod
     def evaluate(energy, const):
@@ -533,17 +527,19 @@ class PowerLaw(SpectralModel):
         plt.show()
     """
 
-    __slots__ = ["_parameters", "index", "amplitude", "reference"]
+    __slots__ = ["index", "amplitude", "reference"]
 
     def __init__(self, index=2.0, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV"):
-        self._parameters = Parameters(
-            [
-                Parameter("index", index),
-                Parameter("amplitude", amplitude),
-                Parameter("reference", reference, frozen=True),
-            ]
-        )
-        super().__init__(self._parameters.parameters)
+        self.index = Parameter("index", index)
+        self.amplitude = Parameter("amplitude", amplitude)
+        self.reference = Parameter("reference", reference, frozen=True)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
@@ -724,20 +720,22 @@ class PowerLaw2(SpectralModel):
         plt.show()
     """
 
-    __slots__ = ["_parameters", "index", "amplitude", "emin", "emax"]
+    __slots__ = ["index", "amplitude", "emin", "emax"]
 
     def __init__(
         self, amplitude="1e-12 cm-2 s-1", index=2, emin="0.1 TeV", emax="100 TeV"
     ):
-        self._parameters = Parameters(
-            [
-                Parameter("amplitude", amplitude),
-                Parameter("index", index),
-                Parameter("emin", emin, frozen=True),
-                Parameter("emax", emax, frozen=True),
-            ]
-        )
-        super().__init__(self._parameters.parameters)
+        self.amplitude = Parameter("amplitude", amplitude)
+        self.index = Parameter("index", index)
+        self.emin = Parameter("emin", emin, frozen=True)
+        self.emax = Parameter("emax", emax, frozen=True)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @staticmethod
     def evaluate(energy, amplitude, index, emin, emax):
@@ -855,7 +853,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         plt.show()
     """
 
-    __slots__ = ["_parameters", "index", "amplitude", "reference", "lambda_"]
+    __slots__ = ["index", "amplitude", "reference", "lambda_"]
 
     def __init__(
         self,
@@ -864,15 +862,17 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         reference="1 TeV",
         lambda_="0.1 TeV-1",
     ):
-        self._parameters = Parameters(
-            [
-                Parameter("index", index),
-                Parameter("amplitude", amplitude),
-                Parameter("reference", reference, frozen=True),
-                Parameter("lambda_", lambda_),
-            ]
-        )
-        super().__init__(self._parameters.parameters)
+        self.index = Parameter("index", index)
+        self.amplitude = Parameter("amplitude", amplitude)
+        self.reference = Parameter("reference", reference, frozen=True)
+        self.lambda_ = Parameter("lambda_", lambda_)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, lambda_):
@@ -937,7 +937,7 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         plt.show()
     """
 
-    __slots__ = ["_parameters", "index", "amplitude", "reference", "ecut"]
+    __slots__ = ["index", "amplitude", "reference", "ecut"]
 
     def __init__(
         self,
@@ -946,15 +946,17 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         reference="1 TeV",
         ecut="10 TeV",
     ):
-        self._parameters = Parameters(
-            [
-                Parameter("index", index),
-                Parameter("amplitude", amplitude),
-                Parameter("reference", reference, frozen=True),
-                Parameter("ecut", ecut),
-            ]
-        )
-        super().__init__(self._parameters.parameters)
+        self.index = Parameter("index", index)
+        self.amplitude = Parameter("amplitude", amplitude)
+        self.reference = Parameter("reference", reference, frozen=True)
+        self.ecut = Parameter("ecut", ecut)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, ecut):
@@ -1003,7 +1005,7 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         plt.show()
     """
 
-    __slots__ = ["_parameters", "index_1", "index_2", "amplitude", "reference", "ecut"]
+    __slots__ = ["index_1", "index_2", "amplitude", "reference", "ecut"]
 
     def __init__(
         self,
@@ -1013,16 +1015,18 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         reference="1 TeV",
         ecut="10 TeV",
     ):
-        self._parameters = Parameters(
-            [
-                Parameter("index_1", index_1),
-                Parameter("index_2", index_2),
-                Parameter("amplitude", amplitude),
-                Parameter("reference", reference, frozen=True),
-                Parameter("ecut", ecut),
-            ]
-        )
-        super().__init__(self._parameters.parameters)
+        self.index_1 = Parameter("index_1", index_1)
+        self.index_2 = Parameter("index_2", index_2)
+        self.amplitude = Parameter("amplitude", amplitude)
+        self.reference = Parameter("reference", reference, frozen=True)
+        self.ecut = Parameter("ecut", ecut)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @staticmethod
     def evaluate(energy, amplitude, reference, ecut, index_1, index_2):
@@ -1078,20 +1082,22 @@ class LogParabola(SpectralModel):
         plt.show()
     """
 
-    __slots__ = ["_parameters", "amplitude", "reference", "alpha", "beta"]
+    __slots__ = ["amplitude", "reference", "alpha", "beta"]
 
     def __init__(
         self, amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2, beta=1
     ):
-        self._parameters = Parameters(
-            [
-                Parameter("amplitude", amplitude),
-                Parameter("reference", reference, frozen=True),
-                Parameter("alpha", alpha),
-                Parameter("beta", beta),
-            ]
-        )
-        super().__init__(self._parameters.parameters)
+        self.amplitude = Parameter("amplitude", amplitude)
+        self.reference = Parameter("reference", reference, frozen=True)
+        self.alpha = Parameter("alpha", alpha)
+        self.beta = Parameter("beta", beta)
+
+        params = []
+        for slot in self.__slots__:
+            attr = getattr(self, slot)
+            if isinstance(attr, Parameter):
+                params.append(getattr(self, slot))
+        super().__init__(params)
 
     @classmethod
     def from_log10(cls, amplitude, reference, alpha, beta):
@@ -1159,12 +1165,12 @@ class TableModel(SpectralModel):
         Meta information, meta['filename'] will be used for serialization
     """
 
-    __slots__ = ["_parameters", "energy", "values", "norm", "meta", "_evaluate"]
+    __slots__ = ["energy", "values", "norm", "meta", "_evaluate"]
 
     def __init__(
         self, energy, values, norm=1, values_scale="log", interp_kwargs=None, meta=None
     ):
-        self._parameters = Parameters([Parameter("norm", norm, unit="")])
+        self.norm = Parameter("norm", norm, unit="")
         self.energy = energy
         self.values = values
         self.meta = dict() if meta is None else meta
@@ -1175,7 +1181,10 @@ class TableModel(SpectralModel):
         self._evaluate = ScaledRegularGridInterpolator(
             points=(np.log(energy.value),), values=values, **interp_kwargs
         )
-        super().__init__(self._parameters.parameters)
+
+        params = []
+        params.append(getattr(self, "norm"))
+        super().__init__(params)
 
     @classmethod
     def read_xspec_model(cls, filename, param, **kwargs):
@@ -1268,12 +1277,15 @@ class ScaleModel(SpectralModel):
         Multiplicative norm factor for the model value.
     """
 
-    __slots__ = ["_parameters", "norm", "model"]
+    __slots__ = ["norm", "model"]
 
     def __init__(self, model, norm=1):
-        self._parameters = Parameters([Parameter("norm", norm, unit="")])
+        self.norm = Parameter("norm", norm, unit="")
         self.model = model
-        super().__init__(self._parameters.parameters)
+
+        params = []
+        params.append(getattr(self, "norm"))
+        super().__init__(params)
 
     def evaluate(self, energy, norm):
         return norm * self.model(energy)
@@ -1454,13 +1466,7 @@ class AbsorbedSpectralModel(SpectralModel):
         parameter name
     """
 
-    __slots__ = [
-        "_parameters",
-        "spectral_model",
-        "absorption",
-        "parameter",
-        "parameter_name",
-    ]
+    __slots__ = ["spectral_model", "absorption", "parameter", "parameter_name"]
 
     def __init__(
         self, spectral_model, absorption, parameter, parameter_name="redshift"

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -36,12 +36,6 @@ class SpectralModel(Model):
     See for example return pardict of
     `~gammapy.spectrum.models.PowerLaw`.
     """
-
-    __slots__ = []
-
-    def __init__(self, params):
-        super().__init__(params)
-
     def __call__(self, energy):
         """Call evaluate method of derived classes"""
         kwargs = dict()
@@ -454,9 +448,7 @@ class ConstantModel(SpectralModel):
     def __init__(self, const):
         self.const = Parameter("const", const)
 
-        params = []
-        params.append(getattr(self, "const"))
-        super().__init__(params)
+        super().__init__([self.const])
 
     @staticmethod
     def evaluate(energy, const):
@@ -474,9 +466,8 @@ class CompoundSpectralModel(SpectralModel):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
-        self._parameters = Parameters(
-            self.model1.parameters.parameters + self.model2.parameters.parameters
-        )
+        parameters = self.model1.parameters.parameters + self.model2.parameters.parameters
+        super().__init__(parameters)
 
     # TODO: Think about how to deal with covariance matrix
 
@@ -534,12 +525,7 @@ class PowerLaw(SpectralModel):
         self.amplitude = Parameter("amplitude", amplitude)
         self.reference = Parameter("reference", reference, frozen=True)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.index, self.amplitude, self.reference])
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference):
@@ -730,12 +716,7 @@ class PowerLaw2(SpectralModel):
         self.emin = Parameter("emin", emin, frozen=True)
         self.emax = Parameter("emax", emax, frozen=True)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.index, self.amplitude, self.emin, self.emax])
 
     @staticmethod
     def evaluate(energy, amplitude, index, emin, emax):
@@ -867,12 +848,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         self.reference = Parameter("reference", reference, frozen=True)
         self.lambda_ = Parameter("lambda_", lambda_)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.index, self.amplitude, self.reference, self.lambda_])
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, lambda_):
@@ -951,12 +927,7 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         self.reference = Parameter("reference", reference, frozen=True)
         self.ecut = Parameter("ecut", ecut)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.index, self.amplitude, self.reference, self.ecut])
 
     @staticmethod
     def evaluate(energy, index, amplitude, reference, ecut):
@@ -1021,12 +992,7 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         self.reference = Parameter("reference", reference, frozen=True)
         self.ecut = Parameter("ecut", ecut)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.index_1, self.index_2, self.amplitude, self.reference, self.ecut])
 
     @staticmethod
     def evaluate(energy, amplitude, reference, ecut, index_1, index_2):
@@ -1092,12 +1058,7 @@ class LogParabola(SpectralModel):
         self.alpha = Parameter("alpha", alpha)
         self.beta = Parameter("beta", beta)
 
-        params = []
-        for slot in self.__slots__:
-            attr = getattr(self, slot)
-            if isinstance(attr, Parameter):
-                params.append(getattr(self, slot))
-        super().__init__(params)
+        super().__init__([self.amplitude, self.reference, self.alpha, self.beta])
 
     @classmethod
     def from_log10(cls, amplitude, reference, alpha, beta):
@@ -1182,9 +1143,7 @@ class TableModel(SpectralModel):
             points=(np.log(energy.value),), values=values, **interp_kwargs
         )
 
-        params = []
-        params.append(getattr(self, "norm"))
-        super().__init__(params)
+        super().__init__([self.norm])
 
     @classmethod
     def read_xspec_model(cls, filename, param, **kwargs):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -37,6 +37,8 @@ class SpectralModel(Model):
     `~gammapy.spectrum.models.PowerLaw`.
     """
 
+    __slots__ = []
+
     def __init__(self, params):
         super().__init__(params)
 
@@ -44,6 +46,10 @@ class SpectralModel(Model):
     def parameters(self):
         """Parameters (`~gammapy.utils.modeling.Parameters`)"""
         return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        self._parameters = parameters
 
     def __call__(self, energy):
         """Call evaluate method of derived classes"""
@@ -452,6 +458,8 @@ class ConstantModel(SpectralModel):
         :math:`k`
     """
 
+    __slots__ = ["_parameters", "const"]
+
     def __init__(self, const):
         self._parameters = Parameters([Parameter("const", const)])
         super().__init__(self._parameters.parameters)
@@ -472,8 +480,10 @@ class CompoundSpectralModel(SpectralModel):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
-        self._parameters = self.model1.parameters.parameters + self.model2.parameters.parameters
-        super().__init__(self._parameters.parameters)
+        self._parameters = Parameters(
+            self.model1.parameters.parameters + self.model2.parameters.parameters
+        )
+
     # TODO: Think about how to deal with covariance matrix
 
     def __str__(self):
@@ -522,6 +532,8 @@ class PowerLaw(SpectralModel):
         pwl.plot(energy_range=[0.1, 100] * u.TeV)
         plt.show()
     """
+
+    __slots__ = ["_parameters", "index", "amplitude", "reference"]
 
     def __init__(self, index=2.0, amplitude="1e-12 cm-2 s-1 TeV-1", reference="1 TeV"):
         self._parameters = Parameters(
@@ -712,6 +724,8 @@ class PowerLaw2(SpectralModel):
         plt.show()
     """
 
+    __slots__ = ["_parameters", "index", "amplitude", "emin", "emax"]
+
     def __init__(
         self, amplitude="1e-12 cm-2 s-1", index=2, emin="0.1 TeV", emax="100 TeV"
     ):
@@ -841,6 +855,8 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         plt.show()
     """
 
+    __slots__ = ["_parameters", "index", "amplitude", "reference", "lambda_"]
+
     def __init__(
         self,
         index=1.5,
@@ -921,6 +937,8 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         plt.show()
     """
 
+    __slots__ = ["_parameters", "index", "amplitude", "reference", "ecut"]
+
     def __init__(
         self,
         index=1.5,
@@ -984,6 +1002,8 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         secpl_3fgl.plot(energy_range=[0.1, 100] * u.TeV)
         plt.show()
     """
+
+    __slots__ = ["_parameters", "index_1", "index_2", "amplitude", "reference", "ecut"]
 
     def __init__(
         self,
@@ -1057,6 +1077,8 @@ class LogParabola(SpectralModel):
         log_parabola.plot(energy_range=[0.1, 100] * u.TeV)
         plt.show()
     """
+
+    __slots__ = ["_parameters", "amplitude", "reference", "alpha", "beta"]
 
     def __init__(
         self, amplitude="1e-12 cm-2 s-1 TeV-1", reference="10 TeV", alpha=2, beta=1
@@ -1136,6 +1158,8 @@ class TableModel(SpectralModel):
     meta : dict, optional
         Meta information, meta['filename'] will be used for serialization
     """
+
+    __slots__ = ["_parameters", "energy", "values", "norm", "meta", "_evaluate"]
 
     def __init__(
         self, energy, values, norm=1, values_scale="log", interp_kwargs=None, meta=None
@@ -1244,6 +1268,8 @@ class ScaleModel(SpectralModel):
         Multiplicative norm factor for the model value.
     """
 
+    __slots__ = ["_parameters", "norm", "model"]
+
     def __init__(self, model, norm=1):
         self._parameters = Parameters([Parameter("norm", norm, unit="")])
         self.model = model
@@ -1302,6 +1328,8 @@ class Absorption:
         # show plot
         plt.show()
     """
+
+    __slots__ = ["energy_lo", "energy_hi", "param_lo", "param_hi", "data"]
 
     def __init__(self, energy_lo, energy_hi, param_lo, param_hi, data):
         axes = [
@@ -1426,6 +1454,14 @@ class AbsorbedSpectralModel(SpectralModel):
         parameter name
     """
 
+    __slots__ = [
+        "_parameters",
+        "spectral_model",
+        "absorption",
+        "parameter",
+        "parameter_name",
+    ]
+
     def __init__(
         self, spectral_model, absorption, parameter, parameter_name="redshift"
     ):
@@ -1444,11 +1480,9 @@ class AbsorbedSpectralModel(SpectralModel):
         max_ = self.absorption.data.axes[0].lo[-1]
         par = Parameter(parameter_name, parameter, min=min_, max=max_, frozen=True)
         param_list.append(par)
-
         self._parameters = Parameters(param_list)
-        super().__init__(self._parameters.parameters)
 
-def evaluate(self, energy, **kwargs):
+    def evaluate(self, energy, **kwargs):
         """Evaluate the model at a given energy."""
         # assign redshift value and remove it from dictionnary
         # since it does not belong to the spectral model

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -25,7 +25,9 @@ FLUX_POINTS_FILES = [
 
 
 class LWTestModel(SpectralModel):
-    parameters = Parameters([])
+    def __init__(self):
+        self._parameters = Parameters([])
+        super().__init__(self._parameters)
 
     @staticmethod
     def evaluate(x):
@@ -39,7 +41,9 @@ class LWTestModel(SpectralModel):
 
 
 class XSqrTestModel(SpectralModel):
-    parameters = Parameters([])
+    def __init__(self):
+        self._parameters = Parameters([])
+        super().__init__(self._parameters)
 
     @staticmethod
     def evaluate(x):
@@ -53,7 +57,9 @@ class XSqrTestModel(SpectralModel):
 
 
 class ExpTestModel(SpectralModel):
-    parameters = Parameters([])
+    def __init__(self):
+        self._parameters = Parameters([])
+        super().__init__(self._parameters)
 
     @staticmethod
     def evaluate(x):

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -66,7 +66,8 @@ class TestSpectrumSimulation:
 
     def test_without_aeff(self):
         e_true = EnergyBounds.equal_log_spacing(1, 10, 5, u.TeV)
-        self.source_model.parameters["amplitude"].quantity = "1 TeV-1 s-1"
+        self.source_model.amplitude.unit = "TeV-1 s-1"
+        self.source_model.amplitude.value = 1
         sim = SpectrumSimulation(
             source_model=self.source_model, livetime=4 * u.h, e_true=e_true
         )

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -59,17 +59,22 @@ class PhaseCurveTableModel(Model):
     0.49059393580053845
     """
 
+    __slots__ = ["table", "time_0", "phase_0", "f0", "f1", "f2"]
+
     def __init__(self, table, time_0, phase_0, f0, f1, f2):
         self.table = table
-        self.parameters = Parameters(
-            [
-                Parameter("time_0", time_0),
-                Parameter("phase_0", phase_0),
-                Parameter("f0", f0),
-                Parameter("f1", f1),
-                Parameter("f2", f2),
-            ]
-        )
+        self.time_0=Parameter("time_0", time_0)
+        self.phase_0 = Parameter("phase_0", phase_0)
+        self.f0 = Parameter("f0", f0)
+        self.f1 = Parameter("f1", f1)
+        self.f2 = Parameter("f2", f2)
+
+        params = []
+        for slot in self.__slots__:
+           attr = getattr(self, slot)
+           if isinstance(attr, Parameter):
+               params.append(getattr(self, slot))
+        super().__init__(params)
 
     def phase(self, time):
         """Evaluate phase for a given time.

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -7,7 +7,9 @@ __all__ = ["Model"]
 class Model:
     """Model base class."""
 
-    # TODO: expose model parameters as attributes
+    def __init__(self, params):
+        for par in params:
+            setattr(self, par.name, par)
 
     def copy(self):
         """A deep copy."""

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -12,8 +12,6 @@ class Model:
 
     def __init__(self, params):
         self._parameters = Parameters(params)
-        for par in params:
-            setattr(self, par.name, par)
 
     @property
     def parameters(self):

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -7,6 +7,8 @@ __all__ = ["Model"]
 class Model:
     """Model base class."""
 
+    __slots__ = []
+
     def __init__(self, params):
         for par in params:
             setattr(self, par.name, par)

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
+from .parameter import Parameters
 
 __all__ = ["Model"]
 
@@ -7,11 +8,21 @@ __all__ = ["Model"]
 class Model:
     """Model base class."""
 
-    __slots__ = []
+    __slots__ = ["_parameters"]
 
     def __init__(self, params):
+        self._parameters = Parameters(params)
         for par in params:
             setattr(self, par.name, par)
+
+    @property
+    def parameters(self):
+        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        self._parameters = parameters
 
     def copy(self):
         """A deep copy."""

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -3,6 +3,7 @@
 import copy
 import numpy as np
 from astropy import units as u
+from astropy.units.core import UnitConversionError
 from astropy.table import Table
 from ..array import check_type
 
@@ -12,21 +13,16 @@ __all__ = ["Parameter", "Parameters"]
 class Parameter:
     """
     Class representing model parameters.
-
     Note that the parameter value has been split into
     a factor and scale like this::
-
         value = factor x scale
-
     Users should interact with the ``value``, ``quantity``
     or ``min`` and ``max`` properties and consider the fact
     that there is a ``factor``` and ``scale`` an implementation detail.
-
     That was introduced for numerical stability in parameter and error
     estimation methods, only in the Gammapy optimiser interface do we
     interact with the ``factor``, ``factor_min`` and ``factor_max`` properties,
     i.e. the optimiser "sees" the well-scaled problem.
-
     Parameters
     ----------
     name : str
@@ -54,7 +50,9 @@ class Parameter:
         self.scale = scale
 
         if isinstance(factor, u.Quantity) or isinstance(factor, str):
-            self.quantity = factor
+            val = u.Quantity(factor)
+            self.value = val.value
+            self.unit = val.unit
         else:
             self.factor = factor
             self.unit = unit
@@ -111,7 +109,6 @@ class Parameter:
     @property
     def factor_min(self):
         """Factor min (float).
-
         This ``factor_min = min / scale`` is for the optimizer interface.
         """
         return self.min / self.scale
@@ -128,7 +125,6 @@ class Parameter:
     @property
     def factor_max(self):
         """Factor max (float).
-
         This ``factor_max = max / scale`` is for the optimizer interface.
         """
         return self.max / self.scale
@@ -159,8 +155,16 @@ class Parameter:
     @quantity.setter
     def quantity(self, val):
         val = u.Quantity(val)
-        self.value = val.value
-        self.unit = val.unit
+        try:
+            val.to(self.unit)
+            self.value = val.value
+            self.unit = val.unit
+        except UnitConversionError:
+            raise UnitConversionError(
+                "{0} parameter must have units homogeneous with {1}".format(
+                    self.name, self.unit
+                )
+            )
 
     def __repr__(self):
         return (
@@ -183,18 +187,13 @@ class Parameter:
 
     def autoscale(self, method="scale10"):
         """Autoscale the parameters.
-
         Set ``factor`` and ``scale`` according to ``method``
-
         Available methods:
-
         * ``scale10`` sets ``scale`` to power of 10,
           so that abs(factor) is in the range 1 to 10
         * ``factor1`` sets ``factor, scale = 1, value``
-
         In both cases the sign of value is stored in ``factor``,
         i.e. the ``scale`` is always positive.
-
         Parameters
         ----------
         method : {'factor1', 'scale10'}
@@ -215,9 +214,7 @@ class Parameter:
 
 class Parameters:
     """List of `Parameter`.
-
     Holds covariance matrix
-
     Parameters
     ----------
     parameters : list of `Parameter`
@@ -284,7 +281,6 @@ class Parameters:
 
     def _get_idx(self, val):
         """Get position index for a given parameter.
-
         The input can be a parameter object, parameter name (str)
         or if a parameter index (int) is passed in, it is simply returned.
         """
@@ -395,7 +391,6 @@ class Parameters:
     def set_parameter_errors(self, errors):
         """
         Set uncorrelated parameters errors.
-
         Parameters
         ----------
         errors : dict of `~astropy.units.Quantity`
@@ -412,7 +407,6 @@ class Parameters:
     # to handle covariance matrices via a class
     def error(self, parname):
         """Get parameter error.
-
         Parameters
         ----------
         parname : str, int
@@ -428,7 +422,6 @@ class Parameters:
     # to handle covariance matrices via a class
     def set_error(self, parname, err):
         """Set parameter error.
-
         Parameters
         ----------
         parname : str, int
@@ -445,9 +438,7 @@ class Parameters:
     @property
     def correlation(self):
         r"""Correlation matrix (`numpy.ndarray`).
-
         Correlation :math:`C` is related to covariance :math:`\Sigma` via:
-
         .. math::
             C_{ij} = \frac{ \Sigma_{ij} }{ \sqrt{\Sigma_{ii} \Sigma_{jj}} }
         """
@@ -456,7 +447,6 @@ class Parameters:
 
     def set_parameter_factors(self, factors):
         """Set factor of all parameters.
-
         Used in the optimizer interface.
         """
         idx = 0
@@ -481,7 +471,6 @@ class Parameters:
 
     def set_covariance_factors(self, matrix):
         """Set covariance from factor covariance matrix.
-
         Used in the optimizer interface.
         """
         if not np.sqrt(matrix.size) == len(self.parameters):
@@ -491,9 +480,7 @@ class Parameters:
 
     def autoscale(self, method="scale10"):
         """Autoscale all parameters.
-
         See :func:`~gammapy.utils.modelling.Parameter.autoscale`
-
         Parameters
         ----------
         method : {'factor1', 'scale10'}
@@ -505,20 +492,15 @@ class Parameters:
     @property
     def restore_values(self):
         """Context manager to restore values.
-
         A copy of the values is made on enter,
         and those values are restored on exit.
-
         Examples
         --------
         ::
-
             from gammapy.spectrum.models import PowerLaw
-
             pwl = PowerLaw(index=2)
             with pwl.parameters.restore_values:
                 pwl.parameters["index"].value = 3
-
             print(pwl.parameters["index"].value)
         """
         return restore_parameters_values(self)


### PR DESCRIPTION
Exposed the parameters of the spatial/spectral/sky models as attributes, by implementing  __setattr__ in the Model base class and taking care of parameters lock down 