### PR TITLE
Add sigma v estimator functionality for dark matter use case

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -141,9 +141,11 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Dark matter mass
     channel : str
         Annihilation channel for `~gammapy.astro.darkmatter.PrimaryFlux`
+    sv : float
+        Scale parameter for model fitting
     jfactor : `~astropy.units.Quantity`
         Integrated J-Factor
-        Needed when `~gammapy.image.models.SkyPointSource` spatial model is used.
+        Needed when `~gammapy.modeling.models.PointSpatialModel` spatial model is used.
         Default value 1.
     z: float
         Redshift value
@@ -170,19 +172,21 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
     """Thermally averaged annihilation cross-section"""
 
-    def __init__(self, mass, channel, jfactor=1, z=0, k=2):
+    def __init__(self, mass, channel, sv=1, jfactor=1, z=0, k=2):
+        self.sv = Parameter("sv", sv)
         self.k = k
         self.z = z
         self.mass = mass
         self.channel = channel
-        self.jfactor = Parameter("jfactor", jfactor.value, unit=jfactor.unit)
+        self.jfactor = jfactor
         self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
-        super().__init__([self.jfactor])
+        super().__init__([self.sv])
 
-    def evaluate(self, energy, jfactor):
+    def evaluate(self, energy, sv):
         """Evaluate dark matter annihilation model."""
         flux = (
-            jfactor
+            sv
+            * self.jfactor
             * self.THERMAL_RELIC_CROSS_SECTION
             * self.primary_flux(energy=energy * (1 + self.z))
             / self.k

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -141,8 +141,6 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Dark matter mass
     channel : str
         Annihilation channel for `~gammapy.astro.darkmatter.PrimaryFlux`
-    sv : float
-        Scale parameter for model fitting
     jfactor : `~astropy.units.Quantity`
         Integrated J-Factor
         Needed when `~gammapy.modeling.models.PointSpatialModel` spatial model is used.
@@ -151,6 +149,8 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Redshift value
     k: int
         Type of dark matter particle (k:2 Majorana, k:4 Dirac)
+    sv : `~gammapy.modeling.Parameter`
+        Scale free parameter for model fitting
 
     Examples
     --------
@@ -172,15 +172,17 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
     """Thermally averaged annihilation cross-section"""
 
-    def __init__(self, mass, channel, sv=1, jfactor=1, z=0, k=2):
-        self.sv = Parameter("sv", sv)
+    sv = Parameter("sv", 1)
+    """Scale free parameter for model fitting"""
+
+    def __init__(self, mass, channel, jfactor=1, z=0, k=2, sv=sv.value):
         self.k = k
         self.z = z
         self.mass = mass
         self.channel = channel
         self.jfactor = jfactor
         self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
-        super().__init__([self.sv])
+        super().__init__(sv=sv)
 
     def evaluate(self, energy, sv):
         """Evaluate dark matter annihilation model."""

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -141,10 +141,10 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Dark matter mass
     channel : str
         Annihilation channel for `~gammapy.astro.darkmatter.PrimaryFlux`
-    scale : float
-        Scale parameter for model fitting
     jfactor : `~astropy.units.Quantity`
-        Integrated J-Factor needed when `~gammapy.modeling.models.PointSpatialModel` spatial model is used
+        Integrated J-Factor
+        Needed when `~gammapy.image.models.SkyPointSource` spatial model is used.
+        Default value 1.
     z: float
         Redshift value
     k: int
@@ -170,22 +170,19 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     THERMAL_RELIC_CROSS_SECTION = 3e-26 * u.Unit("cm3 s-1")
     """Thermally averaged annihilation cross-section"""
 
-    scale = Parameter("scale", 1)
-
-    def __init__(self, mass, channel, scale=scale.quantity, jfactor=1, z=0, k=2):
+    def __init__(self, mass, channel, jfactor=1, z=0, k=2):
         self.k = k
         self.z = z
         self.mass = mass
         self.channel = channel
-        self.jfactor = jfactor
+        self.jfactor = Parameter("jfactor", jfactor.value, unit=jfactor.unit)
         self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
-        super().__init__(scale=scale)
+        super().__init__([self.jfactor])
 
-    def evaluate(self, energy, scale):
+    def evaluate(self, energy, jfactor):
         """Evaluate dark matter annihilation model."""
         flux = (
-            scale
-            * self.jfactor
+            jfactor
             * self.THERMAL_RELIC_CROSS_SECTION
             * self.primary_flux(energy=energy * (1 + self.z))
             / self.k

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -142,7 +142,7 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     channel : str
         Annihilation channel for `~gammapy.astro.darkmatter.PrimaryFlux`
     jfactor : `~astropy.units.Quantity`
-        Integrated J-Factor
+        Integrated J-Factor free parameter for model fitting.
         Needed when `~gammapy.modeling.models.PointSpatialModel` spatial model is used.
         Default value 1.
     z: float
@@ -175,20 +175,22 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
     sv = Parameter("sv", 1)
     """Scale free parameter for model fitting"""
 
-    def __init__(self, mass, channel, jfactor=1, z=0, k=2, sv=sv.value):
+    jfactor = Parameter("jfactor", 1 * u.Unit("GeV2 cm-5"))
+    """JFactor free parameter for model fitting"""
+
+    def __init__(self, mass, channel, z=0, k=2, jfactor=jfactor.value, sv=sv.value):
         self.k = k
         self.z = z
         self.mass = mass
         self.channel = channel
-        self.jfactor = jfactor
         self.primary_flux = PrimaryFlux(mass, channel=self.channel).table_model
-        super().__init__(sv=sv)
+        super().__init__(sv=sv, jfactor=jfactor)
 
-    def evaluate(self, energy, sv):
+    def evaluate(self, energy, sv, jfactor):
         """Evaluate dark matter annihilation model."""
         flux = (
             sv
-            * self.jfactor
+            * jfactor
             * self.THERMAL_RELIC_CROSS_SECTION
             * self.primary_flux(energy=energy * (1 + self.z))
             / self.k

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -143,14 +143,13 @@ class DarkMatterAnnihilationSpectralModel(SpectralModel):
         Annihilation channel for `~gammapy.astro.darkmatter.PrimaryFlux`
     jfactor : `~astropy.units.Quantity`
         Integrated J-Factor free parameter for model fitting.
-        Needed when `~gammapy.modeling.models.PointSpatialModel` spatial model is used.
-        Default value 1.
+        Default value 1 * u.Unit("GeV2 cm-5").
     z: float
         Redshift value
     k: int
         Type of dark matter particle (k:2 Majorana, k:4 Dirac)
     sv : `~gammapy.modeling.Parameter`
-        Scale free parameter for model fitting
+        Scale free parameter for model fitting.
 
     Examples
     --------

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -28,7 +28,7 @@ def test_DMAnnihilation():
         mass=massDM, channel=channel, jfactor=jfactor
     )
     integral_flux = model.integral(emin=emin, emax=emax).to("cm-2 s-1")
-    differential_flux = model.evaluate(energy=1 * u.TeV, scale=1).to("cm-2 s-1 TeV-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, sv=1).to("cm-2 s-1 TeV-1")
 
     assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-5)
     assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-5)

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -28,7 +28,7 @@ def test_DMAnnihilation():
         mass=massDM, channel=channel, jfactor=jfactor
     )
     integral_flux = model.integral(emin=emin, emax=emax).to("cm-2 s-1")
-    differential_flux = model.evaluate(energy=1 * u.TeV, sv=1).to("cm-2 s-1 TeV-1")
+    differential_flux = model.evaluate(energy=1 * u.TeV, sv=1, jfactor=jfactor).to("cm-2 s-1 TeV-1")
 
     assert_quantity_allclose(integral_flux.value, 6.19575457e-14, rtol=1e-5)
     assert_quantity_allclose(differential_flux.value, 2.97506768e-16, rtol=1e-5)

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -20,16 +20,3 @@ def jfact(geom):
     jfactory = JFactory(geom=geom, profile=profiles.NFWProfile(), distance=8 * u.kpc)
     return jfactory.compute_jfactor()
 
-
-@requires_data()
-def test_dmfluxmap(jfact):
-    emin = 0.1 * u.TeV
-    emax = 10 * u.TeV
-    massDM = 1 * u.TeV
-    channel = "W"
-
-    diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
-    int_flux = (jfact * diff_flux.integral(emin=emin, emax=emax)).to("cm-2 s-1")
-    actual = int_flux[5, 5]
-    desired = 1.94834138e-12 / u.cm ** 2 / u.s
-    assert_quantity_allclose(actual, desired, rtol=1e-5)

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -90,9 +90,6 @@ class SigmaVEstimator:
         Integrated J-Factor
         Needed when `~gammapy.image.models.SkyPointSource` spatial model is used.
         Default value 1.
-    xsection: `~astropy.units.Quantity` (optional)
-        Thermally averaged annihilation cross-section.
-        Default value declared in `~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel`.
 
     Examples
     --------
@@ -126,6 +123,9 @@ class SigmaVEstimator:
     RATIO = 2.71
     """Value for the likelihood ratio criteria - set to 2.71 by default."""
 
+    XSECTION = DarkMatterAnnihilationSpectralModel.THERMAL_RELIC_CROSS_SECTION
+    """Value for the thermal relic cross section."""
+
     def __init__(
         self,
         dataset,
@@ -133,8 +133,8 @@ class SigmaVEstimator:
         channels,
         background_model,
         jfactor=1,
-        xsection=None,
     ):
+
 
         self.dataset = dataset
         self.masses = masses
@@ -148,9 +148,6 @@ class SigmaVEstimator:
         self.z = dm_params_container.z
         self.k = dm_params_container.k
 
-        if not xsection:
-            xsection = DarkMatterAnnihilationSpectralModel.THERMAL_RELIC_CROSS_SECTION
-        self.xsection = xsection
 
     def run(
         self,
@@ -304,7 +301,7 @@ class SigmaVEstimator:
                 maxiter=100,
                 rtol=1e-5,
             )
-            sigma_v = sv_ul * self.xsection
+            sigma_v = sv_ul * self.XSECTION
         except Exception as ex:
             sigma_v = None
             sv_best = None

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -220,7 +220,6 @@ class SigmaVEstimator:
                 )
                 try:
                     fit = Fit(dataset_loop)
-                    fit.datasets.parameters.apply_autoscale = False
                     fit_result = fit.run(optimize_opts, covariance_opts)
                     likemin = fit_result.total_stat
                     profile = fit.likelihood_profile(

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -65,22 +65,23 @@ class JFactory:
 
 
 class SigmaVEstimator:
-    r"""Estimates :math:`\langle \sigma\nu\rangle` for a list of annihilation channels and particle masses.
+    r"""Estimates :math:`\sigma\nu` for a list of annihilation channels and particle masses.
 
-    To estimate the different values of :math:`\langle \sigma\nu\rangle` a random poisson realization for a given
-    dark matter annihilation simulated 3D dataset is fitted to a list of `~gammapy.astro.darkmatter.DMAnnihilation`
-    models, that are created within the range of the given lists of annihilation channels and particle masses. For
-    each model fitted in flux, the value of the scale parameter that makes :math:`\delta TS > 2.71` is multiplied by
-    the thermal relic cross section and take it as the estimated value for that :math:`\langle \sigma\nu\rangle`.
+    To estimate the different values of :math:`\sigma\nu`, a random poisson realization for a given
+    annihilation simulated dataset is fitted to a list of `~gammapy.astro.darkmatter.DMAnnihilation`
+    models. These are created within the range of the given lists of annihilation channels and particle
+    masses. For each fit, the value of the scale parameter that makes :math:`\Delta TS > 2.71` is
+    multiplied by the thermal relic cross section, and subsequently taken as the estimated value of
+    :math:`\sigma\nu`.
 
     Parameters
     ----------
     dataset : `~gammapy.cube.fit.MapDataset`
-        Specific random realization of simulated dark matter annihilation dataset
+        Simulated dark matter annihilation dataset
     masses : list of `~astropy.units.Quantity`
-        List of mDM where the values of :math:`\langle \sigma\nu\rangle` will be calculated
+        List of particle masses where the values of :math:`\sigma\nu` will be calculated
     channels : list of strings allowed in `~gammapy.astro.darkmatter.PrimaryFlux`
-        List of channels where the values of :math:`\langle \sigma\nu\rangle` will be calculated
+        List of channels where the values of :math:`\sigma\nu` will be calculated
     jfact : `~astropy.units.Quantity` (optional)
         Integrated J-Factor needed when `~gammapy.image.models.SkyPointSource` spatial model is used, default value 1
     absorption_model : `~gammapy.spectrum.models.Absorption` (optional)
@@ -91,6 +92,20 @@ class SigmaVEstimator:
         Type of dark matter particle (k:2 Majorana, k:4 Dirac), default value 2
     xsection: `~astropy.units.Quantity` (optional)
         Thermally averaged annihilation cross-section, default value declared in `~gammapy.astro.darkmatter.DMAnnihilation`
+
+    Examples
+    --------
+    This is how you may run the `SigmaVEstimator`::
+
+        import logging
+        logging.basicConfig()
+        logging.getLogger("gammapy.astro.darkmatter.utils").setLevel("INFO")
+
+        jfact = 3.41e19 * u.Unit("GeV2 cm-5")
+        channels = ["b", "t", "Z"]
+        masses = [70, 200, 500, 5000, 10000, 50000, 100000]*u.GeV
+        estimator = SigmaVEstimator(simulated_dataset, masses, channels, jfact=JFAC)
+        result = estimator.run()
     """
 
     def __init__(self, dataset, masses, channels, jfact=1, absorption_model=None, z=0, k=2, xsection=None):

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -3,7 +3,7 @@
 import astropy.units as u
 from gammapy.modeling.models import AbsorbedSpectralModel
 from gammapy.modeling import Fit
-from gammapy.spectrum import SpectrumDatasetOnOff
+from gammapy.datasets import SpectrumDatasetOnOff
 from gammapy.utils.table import table_from_row_data
 from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel
 from scipy.optimize import brentq
@@ -190,7 +190,7 @@ class SigmaVEstimator:
 
         # default options in sv curve
         if stat_profile_opts is None:
-            stat_profile_opts = dict(bounds=5, nvalues=50)
+            stat_profile_opts = dict(bounds=(-25, 150), nvalues=50)
 
         # initialize data containers
         for ch in self.channels:
@@ -345,7 +345,6 @@ class SigmaVEstimator:
         j_best = None
         stat_profile_opts["parameter"] = "sv"
         dataset_loop.models.parameters["sv"].frozen = False
-
         if nuisance and dataset_loop.nuisance:
             prior = dataset_loop.nuisance["j"].value
             halfrange = dataset_loop.nuisance["width"] * dataset_loop.nuisance["sigmaj"].value
@@ -353,7 +352,7 @@ class SigmaVEstimator:
             dataset_loop.models.parameters["jfactor"].min = prior - halfrange
             dataset_loop.models.parameters["jfactor"].max = prior + halfrange
             fit = Fit([dataset_loop])
-            fit_result = fit.run(optimize_opts, covariance_opts)
+            fit_result = fit.run("minuit", optimize_opts, covariance_opts)
             sv_best = fit_result.parameters["sv"].value
             j_best = fit_result.parameters["jfactor"].value
             likemin = dataset_loop.stat_sum()
@@ -361,7 +360,7 @@ class SigmaVEstimator:
         else:
             dataset_loop.models.parameters["jfactor"].frozen = True
             fit = Fit([dataset_loop])
-            fit_result = fit.run(optimize_opts, covariance_opts)
+            fit_result = fit.run("minuit", optimize_opts, covariance_opts)
             sv_best = fit_result.parameters["sv"].value
             likemin = dataset_loop.stat_sum()
             statprofile = fit.stat_profile(**stat_profile_opts)

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -186,7 +186,7 @@ class SigmaVEstimator:
             Dict with results as `~astropy.table.Table` objects for each channel.
         """
 
-        spatial_model = self.dataset.model.spatial_model
+        spatial_model = self.dataset.model.skymodels[0].spatial_model
         counts_map = WcsNDMap(
             self.dataset.counts.geom, np.random.poisson(self.dataset.npred().data)
         )

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -117,8 +117,15 @@ class SigmaVEstimator:
         self._counts_map = WcsNDMap(self._geom, np.random.poisson(dataset.npred().data))
 
 
-    def run(self):
+    def run(self, optimize_opts=None, covariance_opts=None):
         """Run the SigmaVEstimator for all channels and masses.
+
+        Parameters
+        ----------
+        optimize_opts : dict
+            Options passed to `Fit.optimize`.
+        covariance_opts : dict
+            Options passed to `Fit.covariance`.
 
         Returns
         -------
@@ -163,7 +170,7 @@ class SigmaVEstimator:
                 try:
                     fit = Fit(dataset_loop)
                     fit.datasets.parameters.apply_autoscale = False
-                    fit_result = fit.run()
+                    fit_result = fit.run(optimize_opts, covariance_opts)
 
                     profile = fit.likelihood_profile(parameter="scale", bounds=5, nvalues=50)
                     xvals = profile["values"]

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -166,6 +166,7 @@ class SigmaVEstimator:
     def run(
         self,
         runs,
+        nuissance=None,
         likelihood_profile_opts=dict(bounds=100, nvalues=50),
         optimize_opts=None,
         covariance_opts=None,
@@ -176,6 +177,8 @@ class SigmaVEstimator:
         ----------
         runs: int
             Number of runs where to perform the fitting
+        nuissance: dict
+            Dictionary with nuissance parameters
         likelihood_profile_opts : dict
             Options passed to `~gammapy.utils.fitting.Fit.likelihood_profile`.
         optimize_opts : dict
@@ -274,6 +277,7 @@ class SigmaVEstimator:
         ch,
         run,
         mass,
+        nuissance=None,
         likelihood_profile_opts=None,
         optimize_opts=None,
         covariance_opts=None,

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -5,7 +5,7 @@ from astropy.units import Quantity
 from gammapy.modeling.models import AbsorbedSpectralModel
 from gammapy.modeling import Fit
 from gammapy.utils.table import table_from_row_data
-from gammapy.astro.darkmatter import DMAnnihilation
+from gammapy.astro.darkmatter import DarkMatterAnnihilationSpectralModel
 from scipy.optimize import brentq
 from scipy.interpolate import interp1d
 import numpy as np
@@ -68,7 +68,7 @@ class SigmaVEstimator:
     r"""Estimates :math:`\sigma\nu` for a list of annihilation channels and particle masses.
 
     To estimate the different values of :math:`\sigma\nu`, a random poisson realization for a given
-    annihilation simulated dataset is fitted to a list of `~gammapy.astro.darkmatter.DMAnnihilation`
+    annihilation simulated dataset is fitted to a list of `~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel`
     models. These are created within the range of the given lists of annihilation channels and particle
     masses. For each fit, the value of the scale parameter (in the range of the physical region >=0)
     that makes the likelihood ratio :math:`-2\lambda_P = RATIO` is multiplied by the thermal relic cross
@@ -88,7 +88,7 @@ class SigmaVEstimator:
         For the moment, a CountSpectrum.
     xsection: `~astropy.units.Quantity` (optional)
         Thermally averaged annihilation cross-section.
-        Default value declared in `~gammapy.astro.darkmatter.DMAnnihilation`.
+        Default value declared in `~gammapy.astro.darkmatter.DarkMatterAnnihilationSpectralModel`.
 
     Examples
     --------
@@ -100,7 +100,7 @@ class SigmaVEstimator:
 
         # Create annihilation model
         JFAC = 3.41e19 * u.Unit("GeV2 cm-5")
-        flux_model = DMAnnihilation(mass=5000*u.GeV, channel="b", jfactor=JFAC)
+        flux_model = DarkMatterAnnihilationSpectralModel(mass=5000*u.GeV, channel="b", jfactor=JFAC)
 
         # Create an empty SpectrumDataSetOnOff dataset
         dataset = SpectrumDatasetOnOff(
@@ -144,7 +144,7 @@ class SigmaVEstimator:
         self.k = dm_params_container.k
 
         if not xsection:
-            xsection = DMAnnihilation.THERMAL_RELIC_CROSS_SECTION
+            xsection = DarkMatterAnnihilationSpectralModel.THERMAL_RELIC_CROSS_SECTION
         self.xsection = xsection
 
     def run(
@@ -196,7 +196,7 @@ class SigmaVEstimator:
                 for mass in self.masses:
                     log.info(f"Mass: {mass}")
                     row = {}
-                    DMAnnihilation.THERMAL_RELIC_CROSS_SECTION = self.xsection
+                    DarkMatterAnnihilationSpectralModel.THERMAL_RELIC_CROSS_SECTION = self.xsection
                     dataset_loop = self._set_model_dataset(ch, mass)
                     fit_result = self._fit_dataset(
                         dataset_loop,
@@ -241,7 +241,7 @@ class SigmaVEstimator:
 
     def _set_model_dataset(self, ch, mass):
         """Set model to fit in dataset."""
-        flux_model = DMAnnihilation(
+        flux_model = DarkMatterAnnihilationSpectralModel(
             mass=mass, channel=ch, jfactor=self.jfactor, z=self.z, k=self.k
         )
         if isinstance(self.dataset.model, AbsorbedSpectralModel):

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -241,7 +241,7 @@ class SigmaVEstimator:
                     scale_max = max(xvals)
 
                     scale_found = brentq(
-                        interp1d(xvals, yvals, kind="cubic"),
+                        interp1d(xvals, yvals, kind="quadratic"),
                         scale_min,
                         scale_max,
                         maxiter=100,

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -78,7 +78,7 @@ class SigmaVEstimator:
     Parameters
     ----------
     dataset : `~gammapy.spectrum.dataset.SpectrumDatasetOnOff`
-        Simulated dark matter annihilation spectrum dataset.
+        Simulated dark matter annihilation spectrum OnOff dataset.
     masses : list of `~astropy.units.Quantity`
         List of particle masses where the values of :math:`\sigma\nu` will be calculated.
     channels : list of strings allowed in `~gammapy.astro.darkmatter.PrimaryFlux`
@@ -99,11 +99,14 @@ class SigmaVEstimator:
         logging.basicConfig()
         logging.getLogger("gammapy.astro.darkmatter.utils").setLevel("INFO")
 
-        # Create annihilation model
+        # Define annihilation model
         JFAC = 3.41e19 * u.Unit("GeV2 cm-5")
         flux_model = DarkMatterAnnihilationSpectralModel(mass=5000*u.GeV, channel="b", jfactor=JFAC)
 
-        # Create an empty SpectrumDataSetOnOff dataset
+        # Define a background model for the off counts as a CountsSpectrum
+        bkg = CountsSpectrum(energy_min, energy_max, data=offcounts)
+
+        # Define an empty SpectrumDataSetOnOff dataset
         dataset = SpectrumDatasetOnOff(
             aeff=aeff,
             edisp=edisp,
@@ -116,8 +119,19 @@ class SigmaVEstimator:
         # Define channels and masses to run estimator
         channels = ["b", "t", "Z"]
         masses = [70, 200, 500, 5000, 10000, 50000, 100000]*u.GeV
+
+        # Define nuissance parameters
+        nuissance = dict(
+            j=JFAC,
+            jobs=JFAC,
+            sigmaj=0.1*JFAC
+        )
+
+        # Instantiate the estimator
         estimator = SigmaVEstimator(dataset, masses, channels, background_model=bkg, jfactor=JFAC)
-        result = estimator.run(likelihood_profile_opts=dict(bounds=(0, 500), nvalues=100))
+
+        # Run the estimator
+        result = estimator.run(10, nuissance=nuissance, likelihood_profile_opts=dict(bounds=(0, 500), nvalues=100))
     """
 
     RATIO = 2.71

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -12,6 +12,7 @@ from ...utils.table import table_from_row_data
 from .spectra import DMAnnihilation
 from scipy.optimize import brentq
 from scipy.interpolate import interp1d
+import numpy as np
 import logging
 
 __all__ = ["JFactory", "SigmaVEstimator"]

--- a/gammapy/astro/darkmatter/utils.py
+++ b/gammapy/astro/darkmatter/utils.py
@@ -341,6 +341,7 @@ class SigmaVEstimator:
             fit_result = resfits[idx]
             log.debug(f"J best: {js[idx]}")
         else:
+            dataset_loop.models[0].spectral_model.parameters["jfactor"].frozen = True
             fit = Fit([dataset_loop])
             fit_result = fit.run(optimize_opts, covariance_opts)
             statprofile = fit.stat_profile(**stat_profile_opts)

--- a/tutorials/astro_dark_matter.ipynb
+++ b/tutorials/astro_dark_matter.ipynb
@@ -209,43 +209,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Flux maps\n",
-    "\n",
-    "Finally flux maps can be produced like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "channel = \"Z\"\n",
-    "massDM = 10 * u.TeV\n",
-    "diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)\n",
-    "int_flux = (jfact * diff_flux.integral(emin=0.1 * u.TeV, emax=10 * u.TeV)).to(\n",
-    "    \"cm-2 s-1\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "flux_map = WcsNDMap(geom=geom, data=int_flux.value, unit=\"cm-2 s-1\")\n",
-    "\n",
-    "fig, ax, im = flux_map.plot(cmap=\"viridis\", norm=LogNorm(), add_cbar=True)\n",
-    "plt.title(\n",
-    "    f\"Flux [{int_flux.unit}]\\n m$_{{DM}}$={fluxes.mDM.to('TeV')}, channel={fluxes.channel}\"\n",
-    ");"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
This PR adds a new class `SigmaVEstimator` in `astro.darkmatter.utils` as a first attempt to address a general use case in the dark matter community. See a preliminary notebook using  `SigmaVEstimator` [here](https://github.com/peroju/dm-gammapy/blob/master/notebooks/DarkMatterUseCaseUpgraded.ipynb).

It still needs to be improved, mainly with a clear method on how to estimate upper limits when fitting extremely low signals compared to the background model. Once this point will be solved, tests could be added accordingly.

For the moment I leave it as an open/work in progress PR, in case it needs discussion at this stage.
