### PR TITLE
Clean up `maps/wcs.py`

### DIFF
--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -52,7 +52,7 @@ def test_make_image():
         [100, 200, 1000], name="energy", unit="TeV", interp="log"
     )
     geom = WcsGeom.create(binsz=0.1, npix=20, axes=[energy_axis])
-    exposures = np.ones(geom.shape)
+    exposures = np.ones(geom.shape_axes)
     sigma = 0.5 * u.deg
     kernel = PSFKernel.from_gauss(geom, sigma)
     psf2D = kernel.make_image(exposures=exposures)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -7,7 +7,7 @@ from ...irf import load_cta_irfs
 from ...maps import WcsGeom, MapAxis
 from ...spectrum.models import PowerLaw
 from ...image.models import SkyGaussian
-from ...cube.models import SkyModel
+from ...cube.models import SkyModel, SkyModels
 from ...cube import MapDataset
 from ..simulate import simulate_dataset
 
@@ -43,7 +43,7 @@ def test_simulate():
     )
 
     assert isinstance(dataset, MapDataset)
-    assert isinstance(dataset.model, SkyModel)
+    assert isinstance(dataset.model, SkyModels)
 
     assert dataset.counts.data.dtype is np.dtype("int")
     assert_allclose(dataset.counts.data[5, 20, 20],5)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -341,7 +341,7 @@ class Map(metaclass=MapMeta):
         idx : tuple
             Index of image plane.
         """
-        for idx in np.ndindex(self.geom.shape):
+        for idx in np.ndindex(self.geom.shape_axes):
             yield self.data[idx[::-1]], idx[::-1]
 
     def iter_by_pix(self, buffersize=1):

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -173,7 +173,7 @@ class HpxNDMap(HpxMap):
             wcs = hpx2wcs.wcs.to_image()
         else:
             hpx_data = self.data
-            wcs_shape = tuple([t.flat[0] for t in hpx2wcs.npix]) + self.geom.shape
+            wcs_shape = tuple([t.flat[0] for t in hpx2wcs.npix]) + self.geom.shape_axes
             wcs_data = np.zeros(wcs_shape).T
             wcs = hpx2wcs.wcs.to_cube(self.geom.axes)
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -127,7 +127,7 @@ def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
 
     # Test none slicing
     sliced = m.slice_by_idx({})
-    assert_equal(m.geom.shape, sliced.geom.shape)
+    assert_equal(m.geom.shape_axes, sliced.geom.shape_axes)
 
     slices = {"energy": slice(0, 1), "time": slice(0, 2)}
     sliced = m.slice_by_idx(slices)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -129,7 +129,8 @@ def test_wcsgeom_contains(npix, binsz, coordsys, proj, skydir, axes):
         npix=npix, binsz=binsz, skydir=skydir, proj=proj, coordsys=coordsys, axes=axes
     )
     coords = geom.get_coord()
-    coords = [c[np.isfinite(c)] for c in coords]
+    m = np.isfinite(coords[0])
+    coords = [c[m] for c in coords]
     assert_allclose(geom.contains(coords), np.ones(coords[0].shape, dtype=bool))
 
     if axes is not None:

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -479,7 +479,7 @@ def test_make_cutout(mode):
     cutout = m.cutout(position=pos, width=(2.0, 3.0) * u.deg, mode=mode)
     actual = cutout.data.sum()
     assert_allclose(actual, 36.0)
-    assert_allclose(cutout.geom.shape, m.geom.shape)
+    assert_allclose(cutout.geom.shape_axes, m.geom.shape_axes)
     assert_allclose(cutout.geom.width.to_value("deg"), [[2.0], [3.0]])
 
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -164,7 +164,7 @@ class WcsGeom(MapGeom):
     """
 
     _slice_spatial_axes = slice(0, 2)
-    _slice_non_spatial_axes = slice(2, -1)
+    _slice_non_spatial_axes = slice(2, None)
     is_hpx = False
 
     def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, conv="gadf"):
@@ -179,9 +179,6 @@ class WcsGeom(MapGeom):
 
         # Shape to use for WCS transformations
         wcs_shape = max([get_shape(t) for t in [npix, cdelt]])
-        if np.sum(wcs_shape) > 1 and wcs_shape != self.shape_axes:
-            raise ValueError()
-
         self._npix = cast_to_shape(npix, wcs_shape, int)
         self._cdelt = cast_to_shape(cdelt, wcs_shape, float)
 
@@ -194,14 +191,18 @@ class WcsGeom(MapGeom):
     @property
     def data_shape(self):
         """Shape of the Numpy data array matching this geometry."""
+        return self._shape[::-1]
+
+    @property
+    def _shape(self):
         npix_shape = [np.max(self.npix[0]), np.max(self.npix[1])]
         ax_shape = [ax.nbin for ax in self.axes]
-        return tuple(npix_shape + ax_shape)[::-1]
+        return tuple(npix_shape + ax_shape)
 
     @property
     def shape_axes(self):
         """Shape of non-spatial axes."""
-        return tuple([ax.nbin for ax in self._axes])
+        return self._shape[self._slice_non_spatial_axes]
 
     @property
     def wcs(self):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -179,7 +179,7 @@ class WcsGeom(MapGeom):
 
         # Shape to use for WCS transformations
         wcs_shape = max([get_shape(t) for t in [npix, cdelt]])
-        if np.sum(wcs_shape) > 1 and wcs_shape != self.shape:
+        if np.sum(wcs_shape) > 1 and wcs_shape != self.shape_axes:
             raise ValueError()
 
         self._npix = cast_to_shape(npix, wcs_shape, int)
@@ -197,6 +197,11 @@ class WcsGeom(MapGeom):
         npix_shape = [np.max(self.npix[0]), np.max(self.npix[1])]
         ax_shape = [ax.nbin for ax in self.axes]
         return tuple(npix_shape + ax_shape)[::-1]
+
+    @property
+    def shape_axes(self):
+        """Shape of non-spatial axes."""
+        return tuple([ax.nbin for ax in self._axes])
 
     @property
     def wcs(self):
@@ -261,11 +266,6 @@ class WcsGeom(MapGeom):
     def axes(self):
         """List of non-spatial axes."""
         return self._axes
-
-    @property
-    def shape(self):
-        """Shape of non-spatial axes."""
-        return tuple([ax.nbin for ax in self._axes])
 
     @property
     def ndim(self):
@@ -567,14 +567,14 @@ class WcsGeom(MapGeom):
             shape = (np.max(self._npix[0]), np.max(self._npix[1]))
 
             if idx is None:
-                shape = shape + self.shape
+                shape = shape + self.shape_axes
             else:
                 shape = shape + (1,) * len(self.axes)
 
             pix2 = [
                 np.full(shape, np.nan, dtype=float) for i in range(2 + len(self.axes))
             ]
-            for idx_img in np.ndindex(self.shape):
+            for idx_img in np.ndindex(self.shape_axes):
 
                 if idx is not None and idx_img != idx:
                     continue

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -8,7 +8,6 @@ from astropy.nddata import Cutout2D
 from astropy.coordinates import SkyCoord, Angle
 from astropy.coordinates.angle_utilities import angular_separation
 from astropy.wcs.utils import proj_plane_pixel_scales
-from astropy.utils import lazyproperty
 import astropy.units as u
 from regions import SkyRegion
 from ..utils.wcs import get_resampled_wcs
@@ -611,6 +610,9 @@ class WcsGeom(MapGeom):
 
     def coord_to_pix(self, coords):
         coords = MapCoord.create(coords, coordsys=self.coordsys)
+
+        if coords.size == 0:
+            return tuple([np.array([]) for i in range(coords.ndim)])
 
         c = self.coord_to_tuple(coords)
         # Variable Bin Size

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -61,7 +61,7 @@ class WcsNDMap(WcsMap):
         # Check whether corners of each image plane are valid
         coords = []
         if not geom.is_regular:
-            for idx in np.ndindex(geom.shape):
+            for idx in np.ndindex(geom.shape_axes):
                 pix = (
                     np.array([0.0, float(geom.npix[0][idx] - 1)]),
                     np.array([0.0, float(geom.npix[1][idx] - 1)]),
@@ -82,7 +82,7 @@ class WcsNDMap(WcsMap):
                 data = np.zeros(shape_np, dtype=dtype)
             else:
                 data = np.full(shape_np, np.nan, dtype=dtype)
-                for idx in np.ndindex(geom.shape):
+                for idx in np.ndindex(geom.shape_axes):
                     data[idx, slice(geom.npix[0][idx]), slice(geom.npix[1][idx])] = 0.0
         else:
             data = np.full(shape_np, np.nan, dtype=dtype)


### PR DESCRIPTION
This PR contains the following changes:
- Rename `WcsGeom.shape` to `WcsGeom.shape_axes`, because the original name was misleading.
- Restructure and simply `WcsGeom.get_pix()`
- Remove untested and unused functions