### PR TITLE
Fix invalid value handling for maps with bool and int data

### DIFF
--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -82,7 +82,7 @@ def test_find_reflected_regions(exclusion_mask, on_region):
     fregions.exclusion_mask = small_mask
     fregions.run()
     regions = fregions.reflected_regions
-    assert len(regions) == 0
+    assert len(regions) == 5
 
 
 

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -71,15 +71,15 @@ def test_find_reflected_regions(exclusion_mask, on_region):
     regions = fregions.reflected_regions
     assert len(regions) == 16
 
-    # Test with maximum number of regions
-    fregions.max_region_number = 5
-    fregions.run()
-    regions = fregions.reflected_regions
-    assert len(regions) == 5
-
     # Test with too small exclusion
     small_mask = exclusion_mask.cutout(pointing, Angle("0.2 deg"))
     fregions.exclusion_mask = small_mask
+    fregions.run()
+    regions = fregions.reflected_regions
+    assert len(regions) == 16
+
+    # Test with maximum number of regions
+    fregions.max_region_number = 5
     fregions.run()
     regions = fregions.reflected_regions
     assert len(regions) == 5

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -77,6 +77,7 @@ def test_find_reflected_regions(exclusion_mask, on_region):
     fregions.run()
     regions = fregions.reflected_regions
     assert len(regions) == 16
+    assert_quantity_allclose(regions[3].center.icrs.ra, Angle("83.674 deg"), rtol=1e-2)
 
     # Test with maximum number of regions
     fregions.max_region_number = 5

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -71,19 +71,19 @@ def test_find_reflected_regions(exclusion_mask, on_region):
     regions = fregions.reflected_regions
     assert len(regions) == 16
 
-    # Test with too small exclusion
-    small_mask = exclusion_mask.cutout(pointing, Angle("0.2 deg"))
-    fregions.exclusion_mask = small_mask
-    fregions.run()
-    regions = fregions.reflected_regions
-    assert len(regions) == 16
-    assert_quantity_allclose(regions[3].center.icrs.ra, Angle("83.674 deg"), rtol=1e-2)
-
     # Test with maximum number of regions
     fregions.max_region_number = 5
     fregions.run()
     regions = fregions.reflected_regions
     assert len(regions) == 5
+
+    # Test with too small exclusion
+    small_mask = exclusion_mask.cutout(pointing, Angle("0.2 deg"))
+    fregions.exclusion_mask = small_mask
+    fregions.run()
+    regions = fregions.reflected_regions
+    assert len(regions) == 0
+
 
 
 @requires_data("gammapy-data")

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -728,14 +728,16 @@ class Map(metaclass=MapMeta):
         """
         # FIXME: Support local indexing here?
         # FIXME: Support slicing?
-        pix = [np.array(p, copy=False, ndmin=1) for p in pix]
         pix = np.broadcast_arrays(*pix)
-        msk = self.geom.contains_pix(pix)
-        vals = np.empty(pix[0].shape, dtype=self.data.dtype)
-        pix = tuple([p[msk] for p in pix])
         idx = self.geom.pix_to_idx(pix)
-        vals[msk] = self.get_by_idx(idx)
-        vals[~msk] = INVALID_VALUE[self.data.dtype]
+        vals = self.get_by_idx(idx)
+        mask = self.geom.contains_pix(pix)
+
+        if not mask.all():
+            invalid = INVALID_VALUE[self.data.dtype]
+            vals = vals.astype(type(invalid))
+            vals[~mask] = invalid
+
         return vals
 
     @abc.abstractmethod

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from .geom import pix_tuple_to_idx, MapCoord
-from .utils import unpack_seq
+from .utils import unpack_seq, INVALID_VALUE
 from ..utils.scripts import make_path
 
 __all__ = ["Map"]
@@ -705,12 +705,8 @@ class Map(metaclass=MapMeta):
            outside of map.
         """
         coords = MapCoord.create(coords, coordsys=self.geom.coordsys)
-        msk = self.geom.contains(coords)
-        vals = np.empty(coords.shape, dtype=self.data.dtype)
-        coords = coords.apply_mask(msk)
-        idx = self.geom.coord_to_idx(coords)
-        vals[msk] = self.get_by_idx(idx)
-        vals[~msk] = np.nan
+        pix = self.geom.coord_to_pix(coords)
+        vals = self.get_by_pix(pix)
         return vals
 
     def get_by_pix(self, pix):
@@ -739,7 +735,7 @@ class Map(metaclass=MapMeta):
         pix = tuple([p[msk] for p in pix])
         idx = self.geom.pix_to_idx(pix)
         vals[msk] = self.get_by_idx(idx)
-        vals[~msk] = np.nan
+        vals[~msk] = INVALID_VALUE[self.data.dtype]
         return vals
 
     @abc.abstractmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from ..utils.interpolation import interpolation_scale
-from .utils import find_hdu, find_bands_hdu
+from .utils import find_hdu, find_bands_hdu, INVALID_INDEX
 
 __all__ = ["MapCoord", "MapGeom", "MapAxis"]
 
@@ -221,7 +221,7 @@ def pix_tuple_to_idx(pix):
             idx += [p]
         else:
             p_idx = np.rint(p).astype(int)
-            p_idx[~np.isfinite(p)] = -1
+            p_idx[~np.isfinite(p)] = INVALID_INDEX.int_value
             idx += [p_idx]
 
     return tuple(idx)
@@ -259,9 +259,9 @@ def coord_to_idx(edges, x, clip=False):
         ibin[x > edges[-1]] = len(edges) - 1
     else:
         with np.errstate(invalid="ignore"):
-            ibin[x > edges[-1]] = -1
+            ibin[x > edges[-1]] = INVALID_INDEX.int_value
 
-    ibin[~np.isfinite(x)] = -1
+    ibin[~np.isfinite(x)] = INVALID_INDEX.int_value
     return ibin
 
 
@@ -1212,7 +1212,7 @@ class MapGeom(metaclass=MapGeomMeta):
             Bool array.
         """
         idx = self.pix_to_idx(pix)
-        return np.all(np.stack([t != -1 for t in idx]), axis=0)
+        return np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
 
     def slice_by_idx(self, slices):
         """Create a new geometry by cutting in the non-spatial dimensions of

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -221,7 +221,7 @@ def pix_tuple_to_idx(pix):
             idx += [p]
         else:
             p_idx = np.rint(p).astype(int)
-            p_idx[~np.isfinite(p)] = INVALID_INDEX.int_value
+            p_idx[~np.isfinite(p)] = INVALID_INDEX.int
             idx += [p_idx]
 
     return tuple(idx)
@@ -259,9 +259,9 @@ def coord_to_idx(edges, x, clip=False):
         ibin[x > edges[-1]] = len(edges) - 1
     else:
         with np.errstate(invalid="ignore"):
-            ibin[x > edges[-1]] = INVALID_INDEX.int_value
+            ibin[x > edges[-1]] = INVALID_INDEX.int
 
-    ibin[~np.isfinite(x)] = INVALID_INDEX.int_value
+    ibin[~np.isfinite(x)] = INVALID_INDEX.int
     return ibin
 
 
@@ -1212,7 +1212,7 @@ class MapGeom(metaclass=MapGeomMeta):
             Bool array.
         """
         idx = self.pix_to_idx(pix)
-        return np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
+        return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
 
     def slice_by_idx(self, slices):
         """Create a new geometry by cutting in the non-spatial dimensions of

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -450,10 +450,10 @@ def get_superpixels(idx, nside_subpix, nside_superpix, nest=True):
     idx //= ratio
 
     if not nest:
-        m = idx == INVALID_INDEX.int_value
+        m = idx == INVALID_INDEX.int
         idx[m] = 0
         idx = hp.nest2ring(nside_superpix, idx)
-        idx[m] = INVALID_INDEX.int_value
+        idx[m] = INVALID_INDEX.int
 
     return idx
 
@@ -505,15 +505,15 @@ def get_subpixels(idx, nside_superpix, nside_subpix, nest=True):
     if not np.all(npix[0] == npix):
         x = np.broadcast_to(x, idx.shape + x.shape)
         idx = idx[..., None] + x
-        idx[x >= np.broadcast_to(npix[..., None], x.shape)] = INVALID_INDEX.int_value
+        idx[x >= np.broadcast_to(npix[..., None], x.shape)] = INVALID_INDEX.int
     else:
         idx = idx[..., None] + x
 
     if not nest:
-        m = idx == INVALID_INDEX.int_value
+        m = idx == INVALID_INDEX.int
         idx[m] = 0
         idx = hp.nest2ring(nside_subpix[..., None], idx)
-        idx[m] = INVALID_INDEX.int_value
+        idx[m] = INVALID_INDEX.int
 
     return idx
 
@@ -724,9 +724,9 @@ class HpxGeom(MapGeom):
         else:
             idx_local = unravel_hpx_index(retval, self._npix)
 
-        m = np.any(np.stack([t == INVALID_INDEX.int_value for t in idx_local]), axis=0)
+        m = np.any(np.stack([t == INVALID_INDEX.int for t in idx_local]), axis=0)
         for i, t in enumerate(idx_local):
-            idx_local[i][m] = INVALID_INDEX.int_value
+            idx_local[i][m] = INVALID_INDEX.int
 
         if not ravel:
             return idx_local
@@ -796,7 +796,7 @@ class HpxGeom(MapGeom):
             pix = tuple([pix] + bins)
             if np.any(m):
                 for p in pix:
-                    p[m] = INVALID_INDEX.int_value
+                    p[m] = INVALID_INDEX.int
         else:
             pix = (hp.ang2pix(self.nside, theta, phi, nest=self.nest),)
 
@@ -820,14 +820,14 @@ class HpxGeom(MapGeom):
                 nside = self.nside
 
             ipix = np.round(pix[0]).astype(int)
-            m = ipix == INVALID_INDEX.int_value
+            m = ipix == INVALID_INDEX.int
             ipix[m] = 0
             theta, phi = hp.pix2ang(nside, ipix, nest=self.nest)
             coords = [np.degrees(phi), np.degrees(np.pi / 2.0 - theta)]
             coords = tuple(coords + vals)
             if np.any(m):
                 for c in coords:
-                    c[m] = INVALID_INDEX.float_value
+                    c[m] = INVALID_INDEX.float
         else:
             ipix = np.round(pix[0]).astype(int)
             theta, phi = hp.pix2ang(self.nside, ipix, nest=self.nest)
@@ -879,7 +879,7 @@ class HpxGeom(MapGeom):
             idx = self.get_idx()
             slices = (slice(None),) + slices
             idx = [p[slices[::-1]] for p in idx]
-            idx = [p[p != INVALID_INDEX.int_value] for p in idx]
+            idx = [p[p != INVALID_INDEX.int] for p in idx]
             if drop_axes:
                 idx = [idx[i] for i in range(len(idx)) if i in slice_dims]
             region = tuple(idx)
@@ -1679,7 +1679,7 @@ class HpxGeom(MapGeom):
             pix = self.global_to_local(pix)
 
         if flat:
-            pix = tuple([p[p != INVALID_INDEX.int_value] for p in pix])
+            pix = tuple([p[p != INVALID_INDEX.int] for p in pix])
 
         return pix
 
@@ -1695,7 +1695,7 @@ class HpxGeom(MapGeom):
 
     def contains(self, coords):
         idx = self.coord_to_idx(coords)
-        return np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
+        return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
 
     def get_skydirs(self):
         """Get the sky coordinates of all the pixels in this geometry."""

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -7,6 +7,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity
+from .utils import INVALID_INDEX
 from .wcs import WcsGeom
 from .geom import MapGeom, MapCoord, pix_tuple_to_idx
 from .geom import coordsys_to_frame, skycoord_to_lonlat
@@ -449,10 +450,10 @@ def get_superpixels(idx, nside_subpix, nside_superpix, nest=True):
     idx //= ratio
 
     if not nest:
-        m = idx == -1
+        m = idx == INVALID_INDEX.int_value
         idx[m] = 0
         idx = hp.nest2ring(nside_superpix, idx)
-        idx[m] = -1
+        idx[m] = INVALID_INDEX.int_value
 
     return idx
 
@@ -504,15 +505,15 @@ def get_subpixels(idx, nside_superpix, nside_subpix, nest=True):
     if not np.all(npix[0] == npix):
         x = np.broadcast_to(x, idx.shape + x.shape)
         idx = idx[..., None] + x
-        idx[x >= np.broadcast_to(npix[..., None], x.shape)] = -1
+        idx[x >= np.broadcast_to(npix[..., None], x.shape)] = INVALID_INDEX.int_value
     else:
         idx = idx[..., None] + x
 
     if not nest:
-        m = idx == -1
+        m = idx == INVALID_INDEX.int_value
         idx[m] = 0
         idx = hp.nest2ring(nside_subpix[..., None], idx)
-        idx[m] = -1
+        idx[m] = INVALID_INDEX.int_value
 
     return idx
 
@@ -723,9 +724,9 @@ class HpxGeom(MapGeom):
         else:
             idx_local = unravel_hpx_index(retval, self._npix)
 
-        m = np.any(np.stack([t == -1 for t in idx_local]), axis=0)
+        m = np.any(np.stack([t == INVALID_INDEX.int_value for t in idx_local]), axis=0)
         for i, t in enumerate(idx_local):
-            idx_local[i][m] = -1
+            idx_local[i][m] = INVALID_INDEX.int_value
 
         if not ravel:
             return idx_local
@@ -795,7 +796,7 @@ class HpxGeom(MapGeom):
             pix = tuple([pix] + bins)
             if np.any(m):
                 for p in pix:
-                    p[m] = -1
+                    p[m] = INVALID_INDEX.int_value
         else:
             pix = (hp.ang2pix(self.nside, theta, phi, nest=self.nest),)
 
@@ -819,14 +820,14 @@ class HpxGeom(MapGeom):
                 nside = self.nside
 
             ipix = np.round(pix[0]).astype(int)
-            m = ipix == -1
+            m = ipix == INVALID_INDEX.int_value
             ipix[m] = 0
             theta, phi = hp.pix2ang(nside, ipix, nest=self.nest)
             coords = [np.degrees(phi), np.degrees(np.pi / 2.0 - theta)]
             coords = tuple(coords + vals)
             if np.any(m):
                 for c in coords:
-                    c[m] = np.nan
+                    c[m] = INVALID_INDEX.float_value
         else:
             ipix = np.round(pix[0]).astype(int)
             theta, phi = hp.pix2ang(self.nside, ipix, nest=self.nest)
@@ -878,7 +879,7 @@ class HpxGeom(MapGeom):
             idx = self.get_idx()
             slices = (slice(None),) + slices
             idx = [p[slices[::-1]] for p in idx]
-            idx = [p[p != -1] for p in idx]
+            idx = [p[p != INVALID_INDEX.int_value] for p in idx]
             if drop_axes:
                 idx = [idx[i] for i in range(len(idx)) if i in slice_dims]
             region = tuple(idx)
@@ -1678,7 +1679,7 @@ class HpxGeom(MapGeom):
             pix = self.global_to_local(pix)
 
         if flat:
-            pix = tuple([p[p != -1] for p in pix])
+            pix = tuple([p[p != INVALID_INDEX.int_value] for p in pix])
 
         return pix
 
@@ -1694,7 +1695,7 @@ class HpxGeom(MapGeom):
 
     def contains(self, coords):
         idx = self.coord_to_idx(coords)
-        return np.all(np.stack([t != -1 for t in idx]), axis=0)
+        return np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
 
     def get_skydirs(self):
         """Get the sky coordinates of all the pixels in this geometry."""

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -308,7 +308,7 @@ class HpxNDMap(HpxMap):
 
         pix, wts = hp.get_interp_weights(nside, theta, phi, nest=self.geom.nest)
         wts[:, m] = 0
-        pix[:, m] = INVALID_INDEX.int_value
+        pix[:, m] = INVALID_INDEX.int
 
         if not self.geom.is_regular:
             pix_local = [self.geom.global_to_local([pix] + list(idxs))[0]]
@@ -316,7 +316,7 @@ class HpxNDMap(HpxMap):
             pix_local = [self.geom[pix]]
 
         # If a pixel lies outside of the geometry set its index to the center pixel
-        m = pix_local[0] == INVALID_INDEX.int_value
+        m = pix_local[0] == INVALID_INDEX.int
         if m.any():
             coords_ctr = [coords.lon, coords.lat]
             coords_ctr += [ax.pix_to_coord(t) for ax, t in zip(self.geom.axes, idxs)]
@@ -355,7 +355,7 @@ class HpxNDMap(HpxMap):
             if not self.geom.is_regular:
                 pix, wts = self._get_interp_weights(coords, pix_i)
 
-            wts[pix[0] == INVALID_INDEX.int_value] = 0
+            wts[pix[0] == INVALID_INDEX.int] = 0
             wt[~np.isfinite(wt)] = 0
             val += np.nansum(wts * wt * self.data.T[tuple(pix[:1] + pix_i)], axis=0)
 
@@ -363,7 +363,7 @@ class HpxNDMap(HpxMap):
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
-        msk = np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
+        msk = np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
         if weights is not None:
             weights = weights[msk]
         idx = [t[msk] for t in idx]

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 from astropy.units import Quantity
 from ..utils.units import unit_from_fits_image_hdu
 from .geom import MapCoord, pix_tuple_to_idx
-from .utils import interp_to_order
+from .utils import interp_to_order, INVALID_INDEX
 from .hpxmap import HpxMap
 from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order
 
@@ -308,7 +308,7 @@ class HpxNDMap(HpxMap):
 
         pix, wts = hp.get_interp_weights(nside, theta, phi, nest=self.geom.nest)
         wts[:, m] = 0
-        pix[:, m] = -1
+        pix[:, m] = INVALID_INDEX.int_value
 
         if not self.geom.is_regular:
             pix_local = [self.geom.global_to_local([pix] + list(idxs))[0]]
@@ -316,7 +316,7 @@ class HpxNDMap(HpxMap):
             pix_local = [self.geom[pix]]
 
         # If a pixel lies outside of the geometry set its index to the center pixel
-        m = pix_local[0] == -1
+        m = pix_local[0] == INVALID_INDEX.int_value
         if m.any():
             coords_ctr = [coords.lon, coords.lat]
             coords_ctr += [ax.pix_to_coord(t) for ax, t in zip(self.geom.axes, idxs)]
@@ -355,7 +355,7 @@ class HpxNDMap(HpxMap):
             if not self.geom.is_regular:
                 pix, wts = self._get_interp_weights(coords, pix_i)
 
-            wts[pix[0] == -1] = 0
+            wts[pix[0] == INVALID_INDEX.int_value] = 0
             wt[~np.isfinite(wt)] = 0
             val += np.nansum(wts * wt * self.data.T[tuple(pix[:1] + pix_i)], axis=0)
 
@@ -363,7 +363,7 @@ class HpxNDMap(HpxMap):
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
-        msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
+        msk = np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
         if weights is not None:
             weights = weights[msk]
         idx = [t[msk] for t in idx]

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -157,6 +157,17 @@ def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
     m.set_by_pix(pix, coords[0])
     assert_allclose(coords[0], m.get_by_pix(pix))
 
+def test_get_by_coord_bool_int():
+    mask = WcsNDMap.create(width=2,dtype='bool')
+    coords={'lon': [1, 3], 'lat':[1., 0.]}
+    vals = mask.get_by_coord(coords)
+    assert not vals.any()
+
+    mask = WcsNDMap.create(width=2, dtype='int')
+    coords = {'lon': [1, 3], 'lat': [1., 0.]}
+    vals = mask.get_by_coord(coords)
+    assert_allclose(vals, np.iinfo(np.int32).min)
+
 
 @pytest.mark.parametrize(
     ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -158,15 +158,15 @@ def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
     assert_allclose(coords[0], m.get_by_pix(pix))
 
 def test_get_by_coord_bool_int():
-    mask = WcsNDMap.create(width=2,dtype='bool')
-    coords={'lon': [1, 3], 'lat':[1., 0.]}
+    mask = WcsNDMap.create(width=2, dtype='bool')
+    coords={'lon': [0, 3], 'lat':[0, 3]}
     vals = mask.get_by_coord(coords)
-    assert not vals.any()
+    assert_allclose(vals, [0, np.nan])
 
     mask = WcsNDMap.create(width=2, dtype='int')
-    coords = {'lon': [1, 3], 'lat': [1., 0.]}
+    coords = {'lon': [0, 3], 'lat': [0, 3]}
     vals = mask.get_by_coord(coords)
-    assert_allclose(vals, np.iinfo(np.int32).min)
+    assert_allclose(vals, [0, np.nan])
 
 
 @pytest.mark.parametrize(

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -6,26 +6,26 @@ from ..utils.random import get_random_state
 
 class InvalidValue:
     """Class to define placeholder for invalid array values."""
-    float_value = np.nan
-    int_value = np.iinfo(np.int32).min
-    bool_value = False
+    float = np.nan
+    int = np.nan
+    bool = np.nan
 
     def __getitem__(self, dtype):
         if np.issubdtype(dtype, np.integer):
-            return self.int_value
+            return self.int
         elif np.issubdtype(dtype, np.floating):
-            return self.float_value
+            return self.float
         elif np.issubdtype(dtype, np.dtype(bool).type):
-            return self.bool_value
+            return self.bool
         else:
             raise ValueError("No invalid value placeholder defined for {}".format(dtype))
 
 
 class InvalidIndex:
     """Class to define placeholder for invalid array indices."""
-    float_value = np.nan
-    int_value = -1
-    bool_value = False
+    float = np.nan
+    int = -1
+    bool = False
 
 
 INVALID_VALUE = InvalidValue()

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -5,7 +5,7 @@ from ..utils.random import get_random_state
 
 
 class InvalidValue:
-    """Class to define placeholder for invalid values."""
+    """Class to define placeholder for invalid array values."""
     float_value = np.nan
     int_value = np.iinfo(np.int32).min
     bool_value = False
@@ -21,7 +21,15 @@ class InvalidValue:
             raise ValueError("No invalid value placeholder defined for {}".format(dtype))
 
 
+class InvalidIndex:
+    """Class to define placeholder for invalid array indices."""
+    float_value = np.nan
+    int_value = -1
+    bool_value = False
+
+
 INVALID_VALUE = InvalidValue()
+INVALID_INDEX = InvalidIndex()
 
 
 def fill_poisson(map_in, mu, random_state="random-seed"):

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,6 +1,27 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
 from astropy.io import fits
 from ..utils.random import get_random_state
+
+
+class InvalidValue:
+    """Class to define placeholder for invalid values."""
+    float_value = np.nan
+    int_value = np.iinfo(np.int32).min
+    bool_value = False
+
+    def __getitem__(self, dtype):
+        if np.issubdtype(dtype, np.integer):
+            return self.int_value
+        elif np.issubdtype(dtype, np.floating):
+            return self.float_value
+        elif np.issubdtype(dtype, np.dtype(bool).type):
+            return self.bool_value
+        else:
+            raise ValueError("No invalid value placeholder defined for {}".format(dtype))
+
+
+INVALID_VALUE = InvalidValue()
 
 
 def fill_poisson(map_in, mu, random_state="random-seed"):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -581,8 +581,13 @@ class WcsGeom(MapGeom):
         pix = self._get_pix_all(idx=idx, mode=mode)
         coords = self.pix_to_coord(pix)
         m = np.isfinite(coords[0])
+<<<<<<< HEAD
         for _ in pix:
             _[~m] = INVALID_INDEX.float
+=======
+        for i in range(len(pix)):
+            pix[i][~m] = INVALID_INDEX.float
+>>>>>>> Use np.nan as placeholder consistently
         return pix
 
     def get_coord(self, idx=None, flat=False, mode="center"):
@@ -679,7 +684,7 @@ class WcsGeom(MapGeom):
 
     def contains(self, coords):
         idx = self.coord_to_idx(coords)
-        return np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
+        return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
 
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -581,13 +581,8 @@ class WcsGeom(MapGeom):
         pix = self._get_pix_all(idx=idx, mode=mode)
         coords = self.pix_to_coord(pix)
         m = np.isfinite(coords[0])
-<<<<<<< HEAD
         for _ in pix:
             _[~m] = INVALID_INDEX.float
-=======
-        for i in range(len(pix)):
-            pix[i][~m] = INVALID_INDEX.float
->>>>>>> Use np.nan as placeholder consistently
         return pix
 
     def get_coord(self, idx=None, flat=False, mode="center"):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -13,6 +13,7 @@ from regions import SkyRegion
 from ..utils.wcs import get_resampled_wcs
 from .geom import MapGeom, MapCoord, pix_tuple_to_idx, skycoord_to_lonlat
 from .geom import get_shape, make_axes, find_and_read_bands, axes_pix_to_coord
+from .utils import INVALID_INDEX
 
 __all__ = ["WcsGeom"]
 
@@ -581,7 +582,7 @@ class WcsGeom(MapGeom):
         coords = self.pix_to_coord(pix)
         m = np.isfinite(coords[0])
         for _ in pix:
-            _[~m] = np.nan
+            _[~m] = INVALID_INDEX.float
         return pix
 
     def get_coord(self, idx=None, flat=False, mode="center"):
@@ -678,7 +679,7 @@ class WcsGeom(MapGeom):
 
     def contains(self, coords):
         idx = self.coord_to_idx(coords)
-        return np.all(np.stack([t != -1 for t in idx]), axis=0)
+        return np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
 
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -87,7 +87,7 @@ class WcsNDMap(WcsMap):
         else:
             data = np.full(shape_np, np.nan, dtype=dtype)
             idx = geom.get_idx()
-            m = np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
+            m = np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
             data[m] = 0.0
 
         return data
@@ -211,7 +211,7 @@ class WcsNDMap(WcsMap):
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
-        msk = np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
+        msk = np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
         idx = [t[msk] for t in idx]
 
         if weights is not None:

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -14,7 +14,7 @@ from ..utils.units import unit_from_fits_image_hdu
 from ..utils.interpolation import ScaledRegularGridInterpolator
 from .geom import pix_tuple_to_idx
 from .wcs import _check_width
-from .utils import interp_to_order
+from .utils import interp_to_order, INVALID_INDEX
 from .wcsmap import WcsGeom, WcsMap
 from .reproject import reproject_car_to_hpx, reproject_car_to_wcs
 
@@ -87,7 +87,7 @@ class WcsNDMap(WcsMap):
         else:
             data = np.full(shape_np, np.nan, dtype=dtype)
             idx = geom.get_idx()
-            m = np.all(np.stack([t != -1 for t in idx]), axis=0)
+            m = np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
             data[m] = 0.0
 
         return data
@@ -211,7 +211,7 @@ class WcsNDMap(WcsMap):
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
-        msk = np.all(np.stack([t != -1 for t in idx]), axis=0)
+        msk = np.all(np.stack([t != INVALID_INDEX.int_value for t in idx]), axis=0)
         idx = [t[msk] for t in idx]
 
         if weights is not None:


### PR DESCRIPTION
This PR contains the following changes:
- Introduce and use `InvalidValue` helper class to work with invalid values in `gammapy/maps`
- Introduce and use `InvalidIndex` helper class to work with invalid indices in `gammapy/maps` 
- Fix issue #2074 
- Fix `ReflectedRegionFinder` test
