### PR TITLE
Fix minuit frozen pars handling in Fit.confidence()

### DIFF
--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -77,8 +77,9 @@ def covariance_iminuit(minuit):
 def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
     # TODO: this is ugly - design something better for translating to MINUIT parameter names.
     # Maybe a wrapper class MinuitParameters?
-    idx = parameters._get_idx(parameter)
-    var = _make_parname(idx, parameters[idx])
+    parameter = parameters[parameter]
+    idx = parameters.free_parameters.index(parameter)
+    var = _make_parname(idx, parameter)
 
     message, success = "Minos terminated successfully.", True
     try:

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -304,10 +304,7 @@ class Parameters:
         if isinstance(val, int):
             return val
         elif isinstance(val, Parameter):
-            for idx, par in enumerate(self.parameters):
-                if val is par:
-                    return idx
-            raise IndexError("No parameter: {!r}".format(val))
+            return self.parameters.index(val)
         elif isinstance(val, str):
             for idx, par in enumerate(self.parameters):
                 if val == par.name:

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -92,6 +92,19 @@ def test_confidence(backend):
     assert_allclose(dataset.parameters["x"].value, 2)
 
 
+@pytest.mark.parametrize("backend", ["minuit"])
+def test_confidence(backend):
+    dataset = MyDataset()
+    dataset.parameters["x"].frozen = True
+    fit = Fit(dataset)
+    fit.optimize(backend=backend)
+    result = fit.confidence("y")
+
+    assert result["success"] is True
+    assert_allclose(result["errp"], 1)
+    assert_allclose(result["errn"], 1)
+
+
 def test_likelihood_profile():
     dataset = MyDataset()
     fit = Fit(dataset)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -93,7 +93,7 @@ def test_confidence(backend):
 
 
 @pytest.mark.parametrize("backend", ["minuit"])
-def test_confidence(backend):
+def test_confidence_frozen(backend):
     dataset = MyDataset()
     dataset.parameters["x"].frozen = True
     fit = Fit(dataset)

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -120,7 +120,7 @@ def test_parameters_getitem(pars):
     with pytest.raises(IndexError):
         pars["lamb"]
 
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         pars[Parameter("bam!", 99)]
 
 


### PR DESCRIPTION
This PR fixes an issue reported by @lmohrmann. The bug was introduced in #2069, when the parameter freezing was moved from the Minuit backend to the Gammapy side. Only passing the free parameters to `Minuit`, broke the parameter naming in the `confidence_minuit` method, which was still based on the full parameter list.