### PR TITLE
Read field-of-view coordinate system definition from BKG FITS header

### DIFF
--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -36,7 +36,6 @@ def geom(ebounds):
             # Default, normal test case
             "geom": geom(ebounds=[0.1, 1, 10]),
             "geom_true": None,
-            "bkg_coordsys":"fov_altaz",
             "counts": 34366,
             "exposure": 3.99815e11,
             "exposure_image": 7.921993e10,
@@ -46,7 +45,6 @@ def geom(ebounds):
             # Test single energy bin
             "geom": geom(ebounds=[0.1, 10]),
             "geom_true": None,
-            "bkg_coordsys":"fov_altaz",
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
@@ -56,7 +54,6 @@ def geom(ebounds):
             # Test single energy bin with exclusion mask
             "geom": geom(ebounds=[0.1, 10]),
             "geom_true": None,
-            "bkg_coordsys":"fov_altaz",
             "exclusion_mask": Map.from_geom(geom(ebounds=[0.1, 10])),
             "counts": 34366,
             "exposure": 1.16866e11,
@@ -67,27 +64,16 @@ def geom(ebounds):
             # Test for different e_true and e_reco bins
             "geom": geom(ebounds=[0.1, 1, 10]),
             "geom_true": geom(ebounds=[0.1, 0.5, 2.5, 10.0]),
-            "bkg_coordsys":"fov_altaz",
             "counts": 34366,
             "exposure": 5.971096e11,
             "exposure_image": 6.492968e10,
-            "background": 27986.945,
-        },
-        {
-            # Test with a different bkg_coordsys
-            "geom": geom(ebounds=[0.1, 1, 10]),
-            "geom_true": None,
-            "bkg_coordsys":"fov_radec",
-            "counts": 34366,
-            "exposure": 3.99815e11,
-            "exposure_image": 7.921993e10,
             "background": 27986.945,
         },
     ],
 )
 @pytest.mark.parametrize("keepdims", [True, False])
 def test_map_maker(pars, observations, keepdims):
-    maker = MapMaker(geom=pars["geom"], geom_true=pars["geom_true"], offset_max="2 deg", bkg_coordsys=pars["bkg_coordsys"])
+    maker = MapMaker(geom=pars["geom"], geom_true=pars["geom_true"], offset_max="2 deg")
 
     maps = maker.run(observations)
 

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -36,6 +36,7 @@ def geom(ebounds):
             # Default, normal test case
             "geom": geom(ebounds=[0.1, 1, 10]),
             "geom_true": None,
+            "bkg_coordsys":"fov_altaz",
             "counts": 34366,
             "exposure": 3.99815e11,
             "exposure_image": 7.921993e10,
@@ -45,6 +46,7 @@ def geom(ebounds):
             # Test single energy bin
             "geom": geom(ebounds=[0.1, 10]),
             "geom_true": None,
+            "bkg_coordsys":"fov_altaz",
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
@@ -54,6 +56,7 @@ def geom(ebounds):
             # Test single energy bin with exclusion mask
             "geom": geom(ebounds=[0.1, 10]),
             "geom_true": None,
+            "bkg_coordsys":"fov_altaz",
             "exclusion_mask": Map.from_geom(geom(ebounds=[0.1, 10])),
             "counts": 34366,
             "exposure": 1.16866e11,
@@ -64,16 +67,27 @@ def geom(ebounds):
             # Test for different e_true and e_reco bins
             "geom": geom(ebounds=[0.1, 1, 10]),
             "geom_true": geom(ebounds=[0.1, 0.5, 2.5, 10.0]),
+            "bkg_coordsys":"fov_altaz",
             "counts": 34366,
             "exposure": 5.971096e11,
             "exposure_image": 6.492968e10,
+            "background": 27986.945,
+        },
+        {
+            # Test with a different bkg_coordsys
+            "geom": geom(ebounds=[0.1, 1, 10]),
+            "geom_true": None,
+            "bkg_coordsys":"fov_radec",
+            "counts": 34366,
+            "exposure": 3.99815e11,
+            "exposure_image": 7.921993e10,
             "background": 27986.945,
         },
     ],
 )
 @pytest.mark.parametrize("keepdims", [True, False])
 def test_map_maker(pars, observations, keepdims):
-    maker = MapMaker(geom=pars["geom"], geom_true=pars["geom_true"], offset_max="2 deg")
+    maker = MapMaker(geom=pars["geom"], geom_true=pars["geom_true"], offset_max="2 deg", bkg_coordsys=pars["bkg_coordsys"])
 
     maps = maker.run(observations)
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -20,9 +20,9 @@ class Background3D:
     energy_lo, energy_hi : `~astropy.units.Quantity`
         Energy binning
     fov_lon_lo, fov_lon_hi : `~astropy.units.Quantity`
-        FOV coordinate X-axis binning, in AltAz frame.
+        FOV coordinate X-axis binning.
     fov_lat_lo, fov_lat_hi : `~astropy.units.Quantity`
-        FOV coordinate Y-axis binning, in AltAz frame.
+        FOV coordinate Y-axis binning.
     data : `~astropy.units.Quantity`
         Background rate (usually: ``s^-1 MeV^-1 sr^-1``)
 


### PR DESCRIPTION
This PR adds a parameter to `MapMaker` and `MapMakerObs` that lets the user define the coordinate system in which the background model is provided. In particular, this adds the possibility to provide the model in a RA/Dec-aligned coordinate system.