### PR TITLE
Modify irfmap stacking

### DIFF
--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -334,13 +334,19 @@ class EDispMap(object):
 
         # Reproject other exposure
         exposure_coord = self.exposure_map.geom.get_coord()
-        reproj_exposure = Map.from_geom(self.exposure_map.geom, unit=self.exposure_map.unit)
-        reproj_exposure.fill_by_coord(exposure_coord, other.exposure_map.get_by_coord(exposure_coord))
+        reproj_exposure = Map.from_geom(
+            self.exposure_map.geom, unit=self.exposure_map.unit
+        )
+        reproj_exposure.fill_by_coord(
+            exposure_coord, other.exposure_map.get_by_coord(exposure_coord)
+        )
 
         # Reproject other psfmap using same geom
         edispmap_coord = self.edisp_map.geom.get_coord()
-        reproj_edispmap = Map.from_geom(self.edisp_map.geom, unit = self.edisp_map.unit)
-        reproj_edispmap.fill_by_coord(edispmap_coord, other.edisp_map.get_by_coord(edispmap_coord))
+        reproj_edispmap = Map.from_geom(self.edisp_map.geom, unit=self.edisp_map.unit)
+        reproj_edispmap.fill_by_coord(
+            edispmap_coord, other.edisp_map.get_by_coord(edispmap_coord)
+        )
 
         exposure = self.exposure_map.quantity[:, np.newaxis, :, :]
         stacked_edisp_quantity = self.quantity * exposure
@@ -353,6 +359,6 @@ class EDispMap(object):
 
         reproj_edispmap.quantity = stacked_edisp_quantity
         # We need to remove the extra axis in the total exposure
-        reproj_exposure.quantity = total_exposure[:,0,:,:]
+        reproj_exposure.quantity = total_exposure[:, 0, :, :]
 
         return EDispMap(reproj_edispmap, reproj_exposure)

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -118,7 +118,7 @@ class EDispMap(object):
         if edisp_map.geom.axes[0].name.upper() != "MIGRA":
             raise ValueError("Incorrect migra axis position in input Map")
 
-        self._edisp_map = edisp_map
+        self.edisp_map = edisp_map
 
         if exposure_map is not None:
             # First adapt geometry, keep only energy axis
@@ -128,32 +128,7 @@ class EDispMap(object):
                     "EDispMap and exposure_map have inconsistent geometries"
                 )
 
-        self._exposure_map = exposure_map
-
-    @property
-    def edisp_map(self):
-        """the EDispMap itself (`~gammapy.maps.Map`)"""
-        return self._edisp_map
-
-    @property
-    def data(self):
-        """the EDispMap data"""
-        return self._edisp_map.data
-
-    @property
-    def quantity(self):
-        """the EDispMap data as a quantity"""
-        return self._edisp_map.quantity
-
-    @property
-    def exposure_map(self):
-        """the exposure map associated to the EDispMap."""
-        return self._exposure_map
-
-    @property
-    def geom(self):
-        """The EDispMap MapGeom object"""
-        return self._edisp_map.geom
+        self.exposure_map = exposure_map
 
     @classmethod
     def from_hdulist(
@@ -254,13 +229,13 @@ class EDispMap(object):
             )
 
         # axes ordering fixed. Could be changed.
-        pix_ener = np.arange(self.geom.axes[1].nbin)
+        pix_ener = np.arange(self.edisp_map.geom.axes[1].nbin)
 
         # Define a vector of migration with mig_step step
-        mrec_min = self.geom.axes[0].edges[0]
-        mrec_max = self.geom.axes[0].edges[-1]
+        mrec_min = self.edisp_map.geom.axes[0].edges[0]
+        mrec_max = self.edisp_map.geom.axes[0].edges[-1]
         mig_array = np.arange(mrec_min, mrec_max, migra_step)
-        pix_migra = (mig_array - mrec_min) / mrec_max * self.geom.axes[0].nbin
+        pix_migra = (mig_array - mrec_min) / mrec_max * self.edisp_map.geom.axes[0].nbin
 
         # Convert position to pixels
         pix_lon, pix_lat = self.edisp_map.geom.to_image().coord_to_pix(position)
@@ -351,7 +326,7 @@ class EDispMap(object):
         )
 
         exposure = self.exposure_map.quantity[:, np.newaxis, :, :]
-        stacked_edisp_quantity = self.quantity * exposure
+        stacked_edisp_quantity = self.edisp_map.quantity * exposure
 
         other_exposure = reproj_exposure.quantity[:, np.newaxis, :, :]
         stacked_edisp_quantity += reproj_edispmap.quantity * other_exposure

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -314,7 +314,7 @@ class EDispMap(object):
             data=data,
         )
 
-    def stack(self, other):
+    def stack(self, other, copy=True):
         """Stack EdispMap with another one.
 
         The current EdispMap is unchanged and a new one is created and returned.
@@ -323,6 +323,8 @@ class EDispMap(object):
         ----------
         other : `~gammapy.cube.EDispMap`
             the edispmap to be stacked with this one.
+        copy : bool
+            if set to True returns a new EdispMap
 
         Returns
         -------
@@ -361,4 +363,9 @@ class EDispMap(object):
         # We need to remove the extra axis in the total exposure
         reproj_exposure.quantity = total_exposure[:, 0, :, :]
 
-        return EDispMap(reproj_edispmap, reproj_exposure)
+        if copy:
+            return EDispMap(reproj_edispmap, reproj_exposure)
+        else:
+            self._edisp_map = reproj_edispmap
+            self._exposure_map = reproj_exposure
+            return self

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -81,8 +81,8 @@ class EDispMap(object):
         from astropy import units as u
         from astropy.coordinates import SkyCoord
         from gammapy.maps import Map, WcsGeom, MapAxis
-        from gammapy.irf import EnergyDispersion2D
-        from gammapy.cube import make_edisp_map, EDispMap
+        from gammapy.irf import EnergyDispersion2D, EffectiveAreaTable2D
+        from gammapy.cube import make_edisp_map, EDispMap, make_map_exposure_true_energy
 
         # Define energy axis. Note that the name is fixed.
         energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy')
@@ -100,9 +100,14 @@ class EDispMap(object):
         # Extract EnergyDispersion2D from CTA 1DC IRF
         filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
         edisp2D = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
+        aeff2d = EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
+
+        # Create the exposure map
+        exposure_geom = geom.to_image().to_cube([energy_axis])
+        exposure_map = make_map_exposure_true_energy(pointing, "1 h", aeff2d, exposure_geom)
 
         # create the EDispMap for the specified pointing
-        edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset)
+        edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset, exposure_map)
 
         # Get an Energy Dispersion (1D) at any position in the image
         edisp = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'))

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -341,6 +341,6 @@ class EDispMap(object):
         if copy:
             return EDispMap(reproj_edispmap, reproj_exposure)
         else:
-            self._edisp_map = reproj_edispmap
-            self._exposure_map = reproj_exposure
+            self.edisp_map = reproj_edispmap
+            self.exposure_map = reproj_exposure
             return self

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -318,14 +318,15 @@ class PSFMap:
     def stack(self, other, copy=True):
         """Stack PSFMap with another one.
 
-        The current PSFMap is unchanged and a new one is created and returned.
+        The other PSFMap is projected on the current PSFMap geometry.
 
         Parameters
         ----------
         other : `~gammapy.cube.PSFMap`
             the psfmap to be stacked with this one.
         copy : bool
-            if set to False returns a new PSFMap
+            if set to True returns a new PSFMap
+
         Returns
         -------
         new : `~gammapy.cube.PSFMap`

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -319,7 +319,6 @@ class PSFMap:
         """Stack PSFMap with another one.
 
         The current PSFMap is unchanged and a new one is created and returned.
-        For the moment, this works only if the PSFMap to be stacked contain compatible exposure maps.
 
         Parameters
         ----------

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -117,7 +117,7 @@ class PSFMap:
         if psf_map.geom.axes[0].name.upper() != "THETA":
             raise ValueError("Incorrect theta axis position in input Map")
 
-        self._psf_map = psf_map
+        self.psf_map = psf_map
 
         if exposure_map is not None:
             # First adapt geometry, keep only energy axis
@@ -125,32 +125,8 @@ class PSFMap:
             if exposure_map.geom != expected_geom:
                 raise ValueError("PSFMap and exposure_map have inconsistent geometries")
 
-        self._exposure_map = exposure_map
+        self.exposure_map = exposure_map
 
-    @property
-    def psf_map(self):
-        """the PSFMap itself (`~gammapy.maps.Map`)"""
-        return self._psf_map
-
-    @property
-    def data(self):
-        """the PSFMap data"""
-        return self._psf_map.data
-
-    @property
-    def quantity(self):
-        """the PSFMap data as a quantity"""
-        return self._psf_map.quantity
-
-    @property
-    def exposure_map(self):
-        """the exposure map associated to the PSFMap."""
-        return self._exposure_map
-
-    @property
-    def geom(self):
-        """The PSFMap MapGeom object"""
-        return self._psf_map.geom
 
     @classmethod
     def from_hdulist(
@@ -246,8 +222,8 @@ class PSFMap:
             )
 
         # axes ordering fixed. Could be changed.
-        pix_ener = np.arange(self.geom.axes[1].nbin)
-        pix_rad = np.arange(self.geom.axes[0].nbin)
+        pix_ener = np.arange(self.psf_map.geom.axes[1].nbin)
+        pix_rad = np.arange(self.psf_map.geom.axes[0].nbin)
 
         # Convert position to pixels
         pix_lon, pix_lat = self.psf_map.geom.to_image().coord_to_pix(position)
@@ -305,8 +281,8 @@ class PSFMap:
         containment_radius_map : `~gammapy.maps.Map`
             Containment radius map
         """
-        coords = self.geom.to_image().get_coord().skycoord.flatten()
-        m = Map.from_geom(self.geom.to_image(), unit="deg")
+        coords = self.psf_map.geom.to_image().get_coord().skycoord.flatten()
+        m = Map.from_geom(self.psf_map.geom.to_image(), unit="deg")
 
         for coord in coords:
             psf_table = self.get_energy_dependent_table_psf(coord)
@@ -352,7 +328,7 @@ class PSFMap:
         )
 
         exposure = self.exposure_map.quantity[:, np.newaxis, :, :]
-        stacked_psf_quantity = self.quantity * exposure
+        stacked_psf_quantity = self.psf_map.quantity * exposure
 
         other_exposure = reproj_exposure.quantity[:, np.newaxis, :, :]
         stacked_psf_quantity += reproj_psfmap.quantity * other_exposure
@@ -367,6 +343,6 @@ class PSFMap:
         if copy:
             return PSFMap(reproj_psfmap, reproj_exposure)
         else:
-            self._psf_map = reproj_psfmap
-            self._exposure_map = reproj_exposure
+            self.psf_map = reproj_psfmap
+            self.exposure_map = reproj_exposure
             return self

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -315,7 +315,7 @@ class PSFMap:
 
         return m
 
-    def stack(self, other, in_place=True):
+    def stack(self, other, copy=True):
         """Stack PSFMap with another one.
 
         The current PSFMap is unchanged and a new one is created and returned.
@@ -324,7 +324,7 @@ class PSFMap:
         ----------
         other : `~gammapy.cube.PSFMap`
             the psfmap to be stacked with this one.
-        in_place : bool
+        copy : bool
             if set to False returns a new PSFMap
         Returns
         -------
@@ -363,4 +363,9 @@ class PSFMap:
         # We need to remove the extra axis in the total exposure
         reproj_exposure.quantity = total_exposure[:, 0, :, :]
 
-        return PSFMap(reproj_psfmap, reproj_exposure)
+        if copy:
+            return PSFMap(reproj_psfmap, reproj_exposure)
+        else:
+            self._psf_map = reproj_psfmap
+            self._exposure_map = reproj_exposure
+            return self

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -315,7 +315,7 @@ class PSFMap:
 
         return m
 
-    def stack(self, other):
+    def stack(self, other, in_place=True):
         """Stack PSFMap with another one.
 
         The current PSFMap is unchanged and a new one is created and returned.
@@ -324,7 +324,8 @@ class PSFMap:
         ----------
         other : `~gammapy.cube.PSFMap`
             the psfmap to be stacked with this one.
-
+        in_place : bool
+            if set to False returns a new PSFMap
         Returns
         -------
         new : `~gammapy.cube.PSFMap`

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -335,13 +335,19 @@ class PSFMap:
 
         # Reproject other exposure
         exposure_coord = self.exposure_map.geom.get_coord()
-        reproj_exposure = Map.from_geom(self.exposure_map.geom, unit=self.exposure_map.unit)
-        reproj_exposure.fill_by_coord(exposure_coord, other.exposure_map.get_by_coord(exposure_coord))
+        reproj_exposure = Map.from_geom(
+            self.exposure_map.geom, unit=self.exposure_map.unit
+        )
+        reproj_exposure.fill_by_coord(
+            exposure_coord, other.exposure_map.get_by_coord(exposure_coord)
+        )
 
         # Reproject other psfmap using same geom
         psfmap_coord = self.psf_map.geom.get_coord()
-        reproj_psfmap = Map.from_geom(self.psf_map.geom, unit = self.psf_map.unit)
-        reproj_psfmap.fill_by_coord(psfmap_coord, other.psf_map.get_by_coord(psfmap_coord))
+        reproj_psfmap = Map.from_geom(self.psf_map.geom, unit=self.psf_map.unit)
+        reproj_psfmap.fill_by_coord(
+            psfmap_coord, other.psf_map.get_by_coord(psfmap_coord)
+        )
 
         exposure = self.exposure_map.quantity[:, np.newaxis, :, :]
         stacked_psf_quantity = self.quantity * exposure
@@ -354,6 +360,6 @@ class PSFMap:
 
         reproj_psfmap.quantity = stacked_psf_quantity
         # We need to remove the extra axis in the total exposure
-        reproj_exposure.quantity = total_exposure[:,0,:,:]
+        reproj_exposure.quantity = total_exposure[:, 0, :, :]
 
         return PSFMap(reproj_psfmap, reproj_exposure)

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -124,3 +124,6 @@ def test_edisp_map_stacking():
     edmap_stack = edmap1.stack(edmap2)
     assert_allclose(edmap_stack.data, edmap1.data)
     assert_allclose(edmap_stack.exposure_map.data, edmap1.exposure_map.data * 3)
+
+    edmap1.stack(edmap2, False)
+    assert_allclose(edmap1.edisp_map.data, edmap_stack.edisp_map.data)

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -121,7 +121,7 @@ def test_edisp_map_stacking():
     edmap2 = make_edisp_map_test()
     edmap2.exposure_map.quantity *= 2
 
-    edmap_stack = edmap1.stack(edmap2)
+    edmap_stack = edmap1.stack(edmap2, True)
     assert_allclose(edmap_stack.edisp_map.data, edmap1.edisp_map.data)
     assert_allclose(edmap_stack.exposure_map.data, edmap1.exposure_map.data * 3)
 

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -74,7 +74,7 @@ def test_make_edisp_map():
     assert edmap.edisp_map.geom.axes[0] == migra_axis
     assert edmap.edisp_map.geom.axes[1] == energy_axis
     assert edmap.edisp_map.unit == Unit("")
-    assert edmap.data.shape == (4, 50, 5, 5)
+    assert edmap.edisp_map.data.shape == (4, 50, 5, 5)
 
 
 def test_edisp_map_to_from_hdulist():
@@ -89,7 +89,7 @@ def test_edisp_map_to_from_hdulist():
         hdulist, edisp_hdu="EDISP", edisp_hdubands="BANDSEDISP"
     )
     assert_allclose(edmap.edisp_map.data, new_edmap.edisp_map.data)
-    assert new_edmap.geom == edmap.geom
+    assert new_edmap.edisp_map.geom == edmap.edisp_map.geom
     assert new_edmap.exposure_map.geom == edmap.exposure_map.geom
 
 
@@ -122,7 +122,7 @@ def test_edisp_map_stacking():
     edmap2.exposure_map.quantity *= 2
 
     edmap_stack = edmap1.stack(edmap2)
-    assert_allclose(edmap_stack.data, edmap1.data)
+    assert_allclose(edmap_stack.edisp_map.data, edmap1.edisp_map.data)
     assert_allclose(edmap_stack.exposure_map.data, edmap1.exposure_map.data * 3)
 
     edmap1.stack(edmap2, False)

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -45,12 +45,12 @@ def make_edisp_map_test():
     edisp2d = EnergyDispersion2D.from_gauss(etrue, migra, 0.0, 0.2, offsets)
 
     geom = WcsGeom.create(
-        skydir=pointing, binsz=1., width=5., axes=[migra_axis, energy_axis]
+        skydir=pointing, binsz=1.0, width=5.0, axes=[migra_axis, energy_axis]
     )
 
     aeff2d = fake_aeff2d()
     exposure_geom = WcsGeom.create(
-        skydir=pointing, binsz=1., width=5., axes=[energy_axis]
+        skydir=pointing, binsz=1.0, width=5.0, axes=[energy_axis]
     )
 
     exposure_map = make_map_exposure_true_energy(pointing, "1 h", aeff2d, exposure_geom)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -182,4 +182,5 @@ def test_psfmap_stacking():
     psfmap1.stack(psfmap3, False)
     assert_allclose(psfmap1.psf_map.data, psfmap_stack.psf_map.data)
 
+
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -147,7 +147,7 @@ def test_psfmap_read_write(tmpdir):
     assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)
 
 
-def test_containment_radius_map(tmpdir):
+def test_containment_radius_map():
     psf = fake_psf3d(0.15 * u.deg)
     pointing = SkyCoord(0, 0, unit="deg")
     energy_axis = MapAxis(nodes=[0.2, 1, 2], unit="TeV", name="energy")
@@ -168,12 +168,12 @@ def test_psfmap_stacking():
     psfmap2 = make_test_psfmap(0.1 * u.deg, shape="flat")
     psfmap2.exposure_map.quantity *= 2
 
-    psfmap_stack = psfmap1.stack(psfmap2)
+    psfmap_stack = psfmap1.stack(psfmap2, False)
     assert_allclose(psfmap_stack.data, psfmap1.data)
     assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
 
     psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
-    psfmap_stack = psfmap1.stack(psfmap3)
+    psfmap_stack = psfmap1.stack(psfmap3, False)
 
     assert_allclose(psfmap_stack.data[0, 40, 20, 20], 0.0)
     assert_allclose(psfmap_stack.data[0, 20, 20, 20], 5805.28955078125)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -65,7 +65,7 @@ def test_make_psf_map():
     assert psfmap.psf_map.geom.axes[0] == rad_axis
     assert psfmap.psf_map.geom.axes[1] == energy_axis
     assert psfmap.psf_map.unit == Unit("sr-1")
-    assert psfmap.data.shape == (4, 50, 25, 25)
+    assert psfmap.psf_map.data.shape == (4, 50, 25, 25)
 
 
 def make_test_psfmap(size, shape="gauss"):
@@ -113,7 +113,7 @@ def test_psfmap_to_table_psf():
 def test_psfmap_to_psf_kernel():
     psfmap = make_test_psfmap(0.15 * u.deg)
 
-    energy_axis = psfmap.geom.axes[1]
+    energy_axis = psfmap.psf_map.geom.axes[1]
     # create PSFKernel
     kern_geom = WcsGeom.create(binsz=0.02, width=5.0, axes=[energy_axis])
     psfkernel = psfmap.get_psf_kernel(
@@ -132,7 +132,7 @@ def test_psfmap_to_from_hdulist():
 
     new_psfmap = PSFMap.from_hdulist(hdulist, psf_hdu="PSF", psf_hdubands="BANDS")
     assert_allclose(psfmap.psf_map.data, new_psfmap.psf_map.data)
-    assert new_psfmap.geom == psfmap.geom
+    assert new_psfmap.psf_map.geom == psfmap.psf_map.geom
     assert new_psfmap.exposure_map.geom == psfmap.exposure_map.geom
 
 
@@ -169,15 +169,15 @@ def test_psfmap_stacking():
     psfmap2.exposure_map.quantity *= 2
 
     psfmap_stack = psfmap1.stack(psfmap2, True)
-    assert_allclose(psfmap_stack.data, psfmap1.data)
+    assert_allclose(psfmap_stack.psf_map.data, psfmap1.psf_map.data)
     assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
 
     psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
     psfmap_stack = psfmap1.stack(psfmap3, True)
 
-    assert_allclose(psfmap_stack.data[0, 40, 20, 20], 0.0)
-    assert_allclose(psfmap_stack.data[0, 20, 20, 20], 5805.28955078125)
-    assert_allclose(psfmap_stack.data[0, 0, 20, 20], 58052.78955078125)
+    assert_allclose(psfmap_stack.psf_map.data[0, 40, 20, 20], 0.0)
+    assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)
+    assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 58052.78955078125)
 
     psfmap1.stack(psfmap3, False)
     assert_allclose(psfmap1.psf_map.data, psfmap_stack.psf_map.data)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -168,16 +168,18 @@ def test_psfmap_stacking():
     psfmap2 = make_test_psfmap(0.1 * u.deg, shape="flat")
     psfmap2.exposure_map.quantity *= 2
 
-    psfmap_stack = psfmap1.stack(psfmap2, False)
+    psfmap_stack = psfmap1.stack(psfmap2, True)
     assert_allclose(psfmap_stack.data, psfmap1.data)
     assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
 
     psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
-    psfmap_stack = psfmap1.stack(psfmap3, False)
+    psfmap_stack = psfmap1.stack(psfmap3, True)
 
     assert_allclose(psfmap_stack.data[0, 40, 20, 20], 0.0)
     assert_allclose(psfmap_stack.data[0, 20, 20, 20], 5805.28955078125)
     assert_allclose(psfmap_stack.data[0, 0, 20, 20], 58052.78955078125)
 
+    psfmap1.stack(psfmap3, False)
+    assert_allclose(psfmap1.psf_map.data, psfmap_stack.psf_map.data)
 
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations


### PR DESCRIPTION
This PR changes the behavior of `PSFMap.stack(other)` and `EDispMap.stack(other)`. 

The two geometries have to be identical in the current version. With this change, the `other` IRF `Map` is reprojected on the target geometry. This is necessary to allow `IRFMapMaker` to use cutouts  in the similar manner as `MapMaker`. See discussion in PR #2056 .