### PR TITLE
Fix test_likelihood_profile in test_flux_point.py

### DIFF
--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -230,7 +230,7 @@ def test_compute_flux_points_dnde_fermi():
         assert_quantity_allclose(actual[:-1], desired[:-1], rtol=1e-1)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture()
 def fit():
     path = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
     data = FluxPoints.read(path)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -268,8 +268,8 @@ class TestFluxPointFit:
         reference = result.parameters["reference"]
         assert_allclose(reference.value, 1, rtol=1e-8)
 
-    @requires_dependency("iminuit")
     @staticmethod
+    @requires_dependency("iminuit")
     def test_likelihood_profile(fit):
         optimize_opts = {"backend": "minuit"}
 


### PR DESCRIPTION
l noticed that `gammapy/spectrum/tests/test_flux_point.py::TestFluxPointFit::test_likelihood_profile` isn't collected:
```
collecting ... /Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.7/site-packages/_pytest/mark/structures.py:236: PytestWarning: cannot collect 'test_likelihood_profile' because it is not a function.
  def __call__(self, *args, **kwargs):
```

Not sure yet what the right fix is.

If I change the order of the decorators (see attached commit), the test runs and fails like this:
```
$ pytest -v gammapy/spectrum/tests/test_flux_point.py

Gammapy test data availability:
gammapy-data ... yes
Gammapy environment variables:
GAMMAPY_DATA = /Users/deil/work/gammapy-tutorials/datasets
Setting matplotlib backend to "agg" for the tests.
=============================================================================== test session starts ===============================================================================
platform darwin -- Python 3.7.0, pytest-4.0.0, py-1.7.0, pluggy-0.8.0 -- /Users/deil/software/anaconda3/envs/gammapy-dev/bin/python
cachedir: .pytest_cache
rootdir: /Users/deil/work/code/gammapy, inifile: setup.cfg
plugins: remotedata-0.3.1, openfiles-0.3.0, mock-1.10.0, doctestplus-0.1.3, cov-2.6.0, arraydiff-0.2, hypothesis-3.68.0
collected 46 items                                                                                                                                                                

gammapy/spectrum/tests/test_flux_point.py::test_e_ref_lafferty PASSED                                                                                                       [  2%]
gammapy/spectrum/tests/test_flux_point.py::test_dnde_from_flux PASSED                                                                                                       [  4%]
gammapy/spectrum/tests/test_flux_point.py::test_compute_flux_points_dnde_exp[table] PASSED                                                                                  [  6%]
gammapy/spectrum/tests/test_flux_point.py::test_compute_flux_points_dnde_exp[lafferty] PASSED                                                                               [  8%]
gammapy/spectrum/tests/test_flux_point.py::test_compute_flux_points_dnde_exp[log_center] PASSED                                                                             [ 10%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_info[diff_flux_points.ecsv] PASSED                                                                          [ 13%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_ref[diff_flux_points.ecsv] PASSED                                                                         [ 15%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_min[diff_flux_points.ecsv] PASSED                                                                         [ 17%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_max[diff_flux_points.ecsv] PASSED                                                                         [ 19%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_fits[diff_flux_points.ecsv] PASSED                                                                    [ 21%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_ecsv[diff_flux_points.ecsv] PASSED                                                                    [ 23%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_drop_ul[diff_flux_points.ecsv] PASSED                                                                       [ 26%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_stack[diff_flux_points.ecsv] PASSED                                                                         [ 28%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_plot[diff_flux_points.ecsv] PASSED                                                                          [ 30%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_info[diff_flux_points.fits] PASSED                                                                          [ 32%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_ref[diff_flux_points.fits] PASSED                                                                         [ 34%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_min[diff_flux_points.fits] PASSED                                                                         [ 36%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_max[diff_flux_points.fits] PASSED                                                                         [ 39%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_fits[diff_flux_points.fits] PASSED                                                                    [ 41%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_ecsv[diff_flux_points.fits] PASSED                                                                    [ 43%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_drop_ul[diff_flux_points.fits] PASSED                                                                       [ 45%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_stack[diff_flux_points.fits] PASSED                                                                         [ 47%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_plot[diff_flux_points.fits] PASSED                                                                          [ 50%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_info[flux_points.ecsv] PASSED                                                                               [ 52%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_ref[flux_points.ecsv] PASSED                                                                              [ 54%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_min[flux_points.ecsv] PASSED                                                                              [ 56%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_max[flux_points.ecsv] PASSED                                                                              [ 58%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_fits[flux_points.ecsv] PASSED                                                                         [ 60%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_ecsv[flux_points.ecsv] PASSED                                                                         [ 63%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_drop_ul[flux_points.ecsv] PASSED                                                                            [ 65%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_stack[flux_points.ecsv] PASSED                                                                              [ 67%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_plot[flux_points.ecsv] PASSED                                                                               [ 69%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_info[flux_points.fits] PASSED                                                                               [ 71%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_ref[flux_points.fits] PASSED                                                                              [ 73%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_min[flux_points.fits] PASSED                                                                              [ 76%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_e_max[flux_points.fits] PASSED                                                                              [ 78%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_fits[flux_points.fits] PASSED                                                                         [ 80%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_write_ecsv[flux_points.fits] PASSED                                                                         [ 82%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_drop_ul[flux_points.fits] PASSED                                                                            [ 84%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_stack[flux_points.fits] PASSED                                                                              [ 86%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_plot[flux_points.fits] PASSED                                                                               [ 89%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPoints::test_plot_likelihood PASSED                                                                                      [ 91%]
gammapy/spectrum/tests/test_flux_point.py::test_compute_flux_points_dnde_fermi PASSED                                                                                       [ 93%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPointFit::test_fit_pwl_minuit PASSED                                                                                     [ 95%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPointFit::test_fit_pwl_sherpa PASSED                                                                                     [ 97%]
gammapy/spectrum/tests/test_flux_point.py::TestFluxPointFit::test_likelihood_profile FAILED                                                                                 [100%]

==================================================================================== FAILURES =====================================================================================
____________________________________________________________________ TestFluxPointFit.test_likelihood_profile _____________________________________________________________________

fit = <gammapy.utils.fitting.fit.Fit object at 0x1c2067c4e0>

    @staticmethod
    @requires_dependency("iminuit")
    def test_likelihood_profile(fit):
        optimize_opts = {"backend": "minuit"}
    
        result = fit.run(optimize_opts=optimize_opts)
    
        profile = fit.likelihood_profile("amplitude", nvalues=3, bounds=1)
    
        ts_diff = profile["likelihood"] - result.total_stat
>       assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
E       AssertionError: 
E       Not equal to tolerance rtol=0.01, atol=1e-07
E       
E       (mismatch 66.66666666666666%)
E        x: array([174.013323,   0.      , 174.013325])
E        y: array([110.1,   0. , 110.1])

gammapy/spectrum/tests/test_flux_point.py:281: AssertionError
======================================================================= 1 failed, 45 passed in 3.97 seconds =======================================================================
```

When run individually like this it seems to work:
```
pytest -v gammapy/spectrum/tests/test_flux_point.py::TestFluxPointFit::test_likelihood_profile
```

@adonath - can you have a look?

If it's not clear what's going on, let me know, and I'll try to figure it out tomorrow.