### PR TITLE
Add pydocstyle docstring checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ pylint:
 # D202: No blank lines allowed after function docstring (found 1)
 # D204: 1 blank line required after class docstring (found 0)
 # D205: 1 blank line required between summary line and description (found 0)
-# D209: Multi-line docstring closing quotes should be on a separate line
 # D210: No whitespaces allowed surrounding docstring text
 # D301: Use r""" if any backslashes in a docstring
 # D400: First line should end with a period (not ')')
@@ -104,7 +103,7 @@ pydocstyle:
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
 	--match='(?!test_).*\.py' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D301,D400,D401,D403,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D210,D301,D400,D401,D403,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ pylint:
 # D205: 1 blank line required between summary line and description (found 0)
 # D209: Multi-line docstring closing quotes should be on a separate line
 # D210: No whitespaces allowed surrounding docstring text
-# D300: Use """triple double quotes""" (found """"-quotes)
 # D301: Use r""" if any backslashes in a docstring
 # D400: First line should end with a period (not ')')
 # D401: First line should be in imperative mood; try rephrasing (found 'Function')
@@ -105,7 +104,7 @@ pydocstyle:
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
 	--match='(?!test_).*\.py' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D301,D400,D401,D403,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -102,12 +102,11 @@ pylint:
 # D401: First line should be in imperative mood; try rephrasing (found 'Function')
 # D403: First word of the first line should be properly capitalized ('Add', not 'add')
 # D404: First word of the docstring should not be `This`
-# D405: Section name should be properly capitalized ('See Also', not 'See also')
 pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ pylint:
 
 # TODO: fix and re-activate check for the following:
 # D103: Missing docstring in public function
-# D201: No blank lines allowed before function docstring (found 1)
 # D202: No blank lines allowed after function docstring (found 1)
 # D204: 1 blank line required after class docstring (found 0)
 # D205: 1 blank line required between summary line and description (found 0)
@@ -105,6 +104,7 @@ pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
+	--match='(?!test_).*\.py' \
 	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D410
 
 # TODO: add test and code quality checks for `examples`

--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,11 @@ pylint:
 # D404: First word of the docstring should not be `This`
 # D405: Section name should be properly capitalized ('See Also', not 'See also')
 # D409: Section underline should match the length of its name (Expected 7 dashes in section 'Returns', got 8)
-# D412: No blank lines allowed between a section header and its content ('Examples')
 pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410,D412
+	--add-ignore=D100,D102,D103,D104,D105,D200,D201,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ pylint:
 # D202: No blank lines allowed after function docstring (found 1)
 # D204: 1 blank line required after class docstring (found 0)
 # D205: 1 blank line required between summary line and description (found 0)
-# D210: No whitespaces allowed surrounding docstring text
 # D301: Use r""" if any backslashes in a docstring
 # D400: First line should end with a period (not ')')
 # D401: First line should be in imperative mood; try rephrasing (found 'Function')
@@ -103,7 +102,7 @@ pydocstyle:
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
 	--match='(?!test_).*\.py' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D210,D301,D400,D401,D403,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D301,D400,D401,D403,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -103,12 +103,11 @@ pylint:
 # D403: First word of the first line should be properly capitalized ('Add', not 'add')
 # D404: First word of the docstring should not be `This`
 # D405: Section name should be properly capitalized ('See Also', not 'See also')
-# D409: Section underline should match the length of its name (Expected 7 dashes in section 'Returns', got 8)
 pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D409,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D405,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/Makefile
+++ b/Makefile
@@ -101,12 +101,11 @@ pylint:
 # D400: First line should end with a period (not ')')
 # D401: First line should be in imperative mood; try rephrasing (found 'Function')
 # D403: First word of the first line should be properly capitalized ('Add', not 'add')
-# D404: First word of the docstring should not be `This`
 pydocstyle:
 	pydocstyle $(PROJECT) \
 	--convention=numpy \
 	--match-dir='^(?!extern).*' \
-	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D404,D410
+	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D204,D205,D209,D210,D300,D301,D400,D401,D403,D410
 
 # TODO: add test and code quality checks for `examples`
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -417,7 +417,6 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
 
         Examples
         --------
-
         >>> from gammapy.catalog import source_catalogs
         >>> source = source_catalogs['3fgl']['3FGL J0349.9-2102']
         >>> lc = source.lightcurve

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -29,17 +29,11 @@ log = logging.getLogger(__name__)
 
 
 class NoDataAvailableError(LookupError):
-    """Generic error used in Gammapy, when some data isn't available.
-    """
-
-    pass
+    """Generic error used in Gammapy, when some data isn't available."""
 
 
 class GammaCatNotFoundError(OSError):
-    """The gamma-cat repo is not available.
-    """
-
-    pass
+    """The gamma-cat repo is not available."""
 
 
 class SourceCatalogObjectGammaCat(SourceCatalogObject):
@@ -62,7 +56,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         info : {'all', 'basic', 'position, 'model'}
             Comma separated list of options
         """
-
         if info == "all":
             info = "basic,position,model"
 

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -151,7 +151,7 @@ class SourceCatalog2HWC(SourceCatalog):
     used to make the catalog, but then in the discussion considered as one source.
 
     References
-    -----------
+    ----------
     .. [1] Abeysekara et al, "The 2HWC HAWC Observatory Gamma Ray Catalog",
        On ADS: `2017ApJ...843...40A <http://adsabs.harvard.edu/abs/2017ApJ...843...40A>`__
     """

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -29,7 +29,6 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
         info : {'all', 'basic', 'position', 'spectrum'}
             Comma separated list of options
         """
-
         if info == "all":
             info = "basic,position,spectrum"
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -35,7 +35,7 @@ FLUX_TO_CRAB_DIFF = 100 / 3.5060459323111307e-11
 class SourceCatalogObjectHGPSComponent:
     """One Gaussian component from the HGPS catalog.
 
-    See also
+    See Also
     --------
     SourceCatalogHGPS, SourceCatalogObjectHGPS
     """

--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -8,3 +8,4 @@ from .psf_map import *
 from .edisp_map import *
 from .make import *
 from .fit import *
+from .simulate import *

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -231,14 +231,14 @@ class EDispMap(object):
         hdulist.writeto(filename, overwrite=overwrite)
 
     def get_energy_dispersion(self, position, e_reco, migra_step=5e-3):
-        """ Returns EnergyDispersion at a given position
+        """Get energy dispersion at a given position.
 
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`
             the target position. Should be a single coordinates
         e_reco : `~astropy.units.Quantity`
-            Reconstruced energy axis binning
+            Reconstructed energy axis binning
         migra_step : float
             Integration step in migration
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -404,7 +404,7 @@ class MapEvaluator:
             Predicted counts in true energy bins
 
         Returns
-        ---------
+        -------
         npred_reco : `~gammapy.maps.Map`
             Predicted counts in reco energy bins
         """

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -45,12 +45,10 @@ class MapMaker:
             self.maps["exclusion"] = exclusion_mask
 
     def run(self, observations, selection=None):
-        """
-        Run MapMaker for a list of observations to create
-        stacked counts, exposure and background maps
+        """Make maps for a list of observations.
 
         Parameters
-        --------------
+        ----------
         observations : `~gammapy.data.Observations`
             Observations to process
         selection : list
@@ -59,7 +57,7 @@ class MapMaker:
             By default, all maps are made.
 
         Returns
-        -----------
+        -------
         maps: dict of stacked counts, background and exposure maps.
         """
         selection = _check_selection(selection)

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -389,11 +389,6 @@ class BackgroundModel(Model):
         Additional tilt in the spectrum
     reference : `~astropy.units.Quantity`
         Reference energy of the tilt.
-
-    Returns
-    ---------
-    background_map : `~gammapy.maps.Map`
-        Background evaluated on the Map
     """
 
     __slots__ = ["map", "norm", "tilt", "reference"]
@@ -419,7 +414,13 @@ class BackgroundModel(Model):
         return energy[:, np.newaxis, np.newaxis]
 
     def evaluate(self):
-        """Evaluate background model"""
+        """Evaluate background model.
+
+        Returns
+        -------
+        background_map : `~gammapy.maps.Map`
+            Background evaluated on the Map
+        """
         norm = self.parameters["norm"].value
         tilt = self.parameters["tilt"].value
         reference = self.parameters["reference"].quantity

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -46,7 +46,6 @@ class SkyModels(SkyModelBase):
 
     Examples
     --------
-
     Read from an XML file::
 
         from gammapy.cube import SkyModels

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -265,7 +265,7 @@ class PSFKernel:
         self.psf_kernel_map.write(*args, **kwargs)
 
     def make_image(self, exposures, spectrum=None):
-        """ Make a 2D PSF from a PSF kernel
+        """Make a 2D PSF from a PSF kernel.
 
         The PSF Kernel is first weighed with a spectrum and an array of exposures.
         The PSF is also normalised after summation.

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -228,7 +228,7 @@ class PSFMap:
         hdulist.writeto(filename, overwrite=overwrite)
 
     def get_energy_dependent_table_psf(self, position):
-        """ Returns EnergyDependentTable PSF at a given position
+        """Get energy-dependent PSF at a given position.
 
         Parameters
         ----------

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -20,8 +20,7 @@ def simulate_dataset(
     max_radius=0.8 * u.deg,
     random_state="random-seed",
 ):
-
-    """Simulate a 3D dataset
+    """Simulate a 3D dataset.
     
     Simulate a source defined with a sky model for a given pointing,
     geometry and irfs for a given exposure time.
@@ -53,7 +52,6 @@ def simulate_dataset(
     dataset : `~gammapy.cube.fit.MapDataset`
         A dataset of the simulated observation.
     """
-
     background = make_map_background_irf(
         pointing=pointing, ontime=livetime, bkg=irfs["bkg"], geom=geom
     )

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -48,7 +48,7 @@ def simulate_dataset(
         Defines random number generator initialisation.
 
     Returns
-    ---------
+    -------
     dataset : `~gammapy.cube.fit.MapDataset`
         A dataset of the simulated observation.
     """

--- a/gammapy/data/obs_summary.py
+++ b/gammapy/data/obs_summary.py
@@ -64,7 +64,7 @@ class ObservationTableSummary:
             By default, 30 bins from 0 deg to max zenith + 5 deg is used.
 
         Returns
-        --------
+        -------
         ax : `~matplotlib.axes.Axes`
             Axis
         """

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -93,8 +93,7 @@ class FixedPointingInfo:
 
     @lazyproperty
     def radec(self):
-        """RA / DEC pointing postion from table
-        (`~astropy.coordinates.SkyCoord`)"""
+        """RA/DEC pointing position from table (`~astropy.coordinates.SkyCoord`)."""
         ra = self.meta["RA_PNT"]
         dec = self.meta["DEC_PNT"]
         return SkyCoord(ra, dec, unit="deg", frame="icrs")
@@ -106,8 +105,7 @@ class FixedPointingInfo:
 
     @lazyproperty
     def altaz(self):
-        """ALT / AZ pointing position computed from RA / DEC
-        (`~astropy.coordinates.SkyCoord`)"""
+        """ALT/AZ pointing position computed from RA/DEC (`~astropy.coordinates.SkyCoord`)."""
         return self.radec.transform_to(self.altaz_frame)
 
 

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -72,7 +72,7 @@ def compute_lima_on_off_image(n_on, n_off, a_on, a_off, kernel):
         Dictionary containing result maps
         Keys are: significance, n_on, background, excess, alpha
 
-    See also
+    See Also
     --------
     gammapy.stats.significance_on_off
     """

--- a/gammapy/image/plotting.py
+++ b/gammapy/image/plotting.py
@@ -291,7 +291,6 @@ def grayify_colormap(cmap, mode="hsp"):
 
     References
     ----------
-
     .. [1] Darel Rex Finley, "HSP Color Model - Alternative to HSV (HSB) and HSL"
        http://alienryderflex.com/hsp.html
 

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -16,7 +16,7 @@ class Background3D:
     Data format specification: :ref:`gadf:bkg_3d`
 
     Parameters
-    -----------
+    ----------
     energy_lo, energy_hi : `~astropy.units.Quantity`
         Energy binning
     fov_lon_lo, fov_lon_hi : `~astropy.units.Quantity`
@@ -218,7 +218,7 @@ class Background2D:
     Data format specification: :ref:`gadf:bkg_2d`
 
     Parameters
-    -----------
+    ----------
     energy_lo, energy_hi : `~astropy.units.Quantity`
         Energy binning
     offset_lo, offset_hi : `~astropy.units.Quantity`

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -17,11 +17,9 @@ class EffectiveAreaTable:
     TODO: Document
 
     Parameters
-    -----------
-    energy_lo : `~astropy.units.Quantity`
-        Lower bin edges of energy axis
-    energy_hi : `~astropy.units.Quantity`
-        Upper bin edges of energy axis
+    ----------
+    energy_lo, energy_hi : `~astropy.units.Quantity`
+        Energy axis bin edges
     data : `~astropy.units.Quantity`
         Effective area
 
@@ -305,7 +303,7 @@ class EffectiveAreaTable2D:
     Data format specification: :ref:`gadf:aeff_2d`
 
     Parameters
-    -----------
+    ----------
     energy_lo, energy_hi : `~astropy.units.Quantity`
         Energy binning
     offset_lo, offset_hi : `~astropy.units.Quantity`

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -144,7 +144,7 @@ def make_mean_edisp(
 
 
 def apply_containment_fraction(aeff, psf, radius):
-    """ Estimate PSF containment inside a given radius and correct effective area for leaking flux.
+    """Estimate PSF containment inside a given radius and correct effective area for leaking flux.
 
     The PSF and effective area must have the same binning in energy.
 

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -464,7 +464,7 @@ class EnergyDependentMultiGaussPSF:
         )
 
     def to_psf3d(self, rad):
-        """ Creates a PSF3D from an analytical PSF.
+        """Create a PSF3D from an analytical PSF.
 
         Parameters
         ----------

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -567,7 +567,8 @@ class HESSMultiGaussPSF:
 
         Note: We have to set norm = 2 * A * sigma ^ 2, because in
         MultiGauss2D norm represents the integral, and in HESS A
-        represents the amplitude at 0."""
+        represents the amplitude at 0.
+        """
         sigmas, norms = [], []
         for ii in range(1, self.n_gauss() + 1):
             A = self.pars["A_{}".format(ii)]

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -725,7 +725,7 @@ class Map(metaclass=MapMeta):
             Pixel indices can be either float or integer type.
 
         Returns
-        ----------
+        -------
         vals : `~numpy.ndarray`
            Array of pixel values.  np.nan used to flag coordinates
            outside of map
@@ -754,7 +754,7 @@ class Map(metaclass=MapMeta):
             for WCS maps and (I_hpx, I_0, ..., I_n) for HEALPix maps.
 
         Returns
-        ----------
+        -------
         vals : `~numpy.ndarray`
            Array of pixel values.
            np.nan used to flag coordinate outside of map
@@ -1006,7 +1006,7 @@ class Map(metaclass=MapMeta):
             Keyword arguments to overwrite in the map constructor.
 
         Returns
-        --------
+        -------
         copy : `Map`
             Copied Map.
         """

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1029,7 +1029,7 @@ class Map(metaclass=MapMeta):
         return str_
 
     def _arithmetics(self, operator, other, copy):
-        """ Perform arithmetics on maps after checking geometry consistency"""
+        """Perform arithmetics on maps after checking geometry consistency."""
         if isinstance(other, Map):
             if self.geom == other.geom:
                 q = other.quantity

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -543,7 +543,6 @@ class Map(metaclass=MapMeta):
         -------
         map : `Map`
             Upsampled map.
-
         """
         pass
 
@@ -580,9 +579,17 @@ class Map(metaclass=MapMeta):
             for non-spatial dimensions of the map. Dict should specify the axis
             names of the non-spatial axes such as {'axes0': x_0, ..., 'axesn': x_n}.
 
+        Returns
+        -------
+        map_out : `Map`
+            Map with spatial dimensions only.
+
+        See Also
+        --------
+        get_image_by_idx, get_image_by_pix
+
         Examples
         --------
-
         ::
 
             import numpy as np
@@ -619,15 +626,6 @@ class Map(metaclass=MapMeta):
 
             # Get image by coord dict with quantities
             image = m_wcs.get_image_by_coord({'energy': 0.5 * u.TeV, 'time': 1 * u.h})
-
-        See Also
-        --------
-        get_image_by_idx, get_image_by_pix
-
-        Returns
-        -------
-        map_out : `Map`
-            Map with spatial dimensions only.
         """
         if isinstance(coords, tuple):
             axes_names = [_.name for _ in self.geom.axes]

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1447,7 +1447,7 @@ class MapGeom(metaclass=MapGeomMeta):
             Keyword arguments to overwrite in the map geometry constructor.
 
         Returns
-        --------
+        -------
         copy : `MapGeom`
             Copied map geometry.
         """

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -175,14 +175,11 @@ def skycoord_to_lonlat(skycoord, coordsys=None):
     -------
     lon : `~numpy.ndarray`
         Longitude in degrees.
-
     lat : `~numpy.ndarray`
         Latitude in degrees.
-
     frame : str
         Name of coordinate frame.
     """
-
     if coordsys in ["CEL", "C"]:
         skycoord = skycoord.transform_to("icrs")
     elif coordsys in ["GAL", "G"]:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -271,8 +271,7 @@ def bin_to_val(edges, bins):
 
 
 def coord_to_pix(edges, coord, interp="lin"):
-    """Convert axis coordinates to pixel coordinates using the chosen
-    interpolation scheme."""
+    """Convert axis to pixel coordinates for given interpolation scheme."""
     scale = interpolation_scale(interp)
 
     interp_fn = interp1d(
@@ -283,8 +282,7 @@ def coord_to_pix(edges, coord, interp="lin"):
 
 
 def pix_to_coord(edges, pix, interp="lin"):
-    """Convert pixel coordinates to grid coordinates using the chosen
-    interpolation scheme."""
+    """Convert pixel to grid coordinates for given interpolation scheme."""
     scale = interpolation_scale(interp)
 
     interp_fn = interp1d(

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1407,7 +1407,7 @@ class HpxGeom(MapGeom):
         return cls.from_header(hdu.header, hdu_bands=hdu_bands, pix=pix)
 
     def make_header(self, **kwargs):
-        """"Build and return FITS header for this HEALPIX map."""
+        """Build and return FITS header for this HEALPIX map."""
         header = fits.Header()
         conv = kwargs.get("conv", HPX_FITS_CONVENTIONS[self.conv])
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -735,7 +735,7 @@ class HpxGeom(MapGeom):
             return ravel_hpx_index(idx_local, self.npix)
 
     def __getitem__(self, idx_global):
-        """This implements the global-to-local index lookup.
+        """Implement global-to-local index lookup.
 
         For all-sky maps it just returns the input array.  For
         partial-sky maps it returns the local indices corresponding to

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1697,7 +1697,7 @@ class HpxGeom(MapGeom):
         return np.all(np.stack([t != -1 for t in idx]), axis=0)
 
     def get_skydirs(self):
-        """Get the sky coordinates of all the pixels in this geometry. """
+        """Get the sky coordinates of all the pixels in this geometry."""
         coords = self.get_coord()
         frame = "galactic" if self.coordsys == "GAL" else "icrs"
         return SkyCoord(coords[0], coords[1], unit="deg", frame=frame)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -433,7 +433,6 @@ def get_superpixels(idx, nside_subpix, nside_superpix, nest=True):
         Indices of HEALpix pixels of nside ``nside_superpix`` that
         contain pixel indices ``idx`` of nside ``nside_subpix``.
     """
-
     import healpy as hp
 
     idx = np.array(idx)
@@ -621,7 +620,6 @@ class HpxGeom(MapGeom):
 
     def _create_lookup(self, region):
         """Create local-to-global pixel lookup table."""
-
         if isinstance(region, str):
             ipix = [
                 self.get_index_list(nside, self._nest, region)

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -1804,13 +1804,15 @@ class HpxToWcsMapping:
     @property
     def lmap(self):
         """An array(nx,ny) giving the mapping of the local HEALPIX pixel
-        indices for each WCS pixel"""
+        indices for each WCS pixel.
+        """
         return self._lmap
 
     @property
     def valid(self):
-        """An array(nx,ny) of bools giving if each WCS pixel in inside the
-        HEALPIX region"""
+        """Array(nx,ny) of bools giving if each WCS pixel in inside the
+        HEALPIX region.
+        """
         return self._valid
 
     @classmethod

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -217,8 +217,10 @@ class WcsGeom(MapGeom):
 
     @property
     def coordsys(self):
-        """Coordinate system of the projection, either Galactic ('GAL') or
-        Equatorial ('CEL')."""
+        """Coordinate system of the projection.
+
+        Galactic ('GAL') or Equatorial ('CEL').
+        """
         return self._coordsys
 
     @property
@@ -236,10 +238,10 @@ class WcsGeom(MapGeom):
 
     @property
     def is_regular(self):
-        """Flag identifying whether this geometry is regular in non-spatial
-        dimensions.  False for multi-resolution or irregular
-        geometries.  If true all image planes have the same pixel
-        geometry.
+        """Is this geometry is regular in non-spatial dimensions (bool)?
+
+        - False for multi-resolution or irregular geometries.
+        - True if all image planes have the same pixel geometry.
         """
         if self.npix[0].size > 1:
             return False

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -531,7 +531,6 @@ class WcsGeom(MapGeom):
 
     def get_image_shape(self, idx):
         """Get the shape of the image plane at index ``idx``."""
-
         if self.is_regular:
             return int(self.npix[0]), int(self.npix[1])
         else:

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -336,8 +336,7 @@ class WcsNDMap(WcsMap):
         return self._init_copy(geom=geom, data=data)
 
     def _pad_coadd(self, geom, pad_width, mode, cval, order):
-        """Pad a map manually by coadding the original map with the new
-        map."""
+        """Pad a map manually by coadding the original map with the new map."""
         idx_in = self.geom.get_idx(flat=True)
         idx_in = tuple([t + w for t, w in zip(idx_in, pad_width)])[::-1]
         idx_out = geom.get_idx(flat=True)[::-1]

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -224,7 +224,7 @@ class SpectrumEnergyGroupMaker:
     groups : `~gammapy.spectrum.SpectrumEnergyGroups`
         List of energy groups
 
-    See also
+    See Also
     --------
     SpectrumEnergyGroups, SpectrumEnergyGroup, FluxPointEstimator
     """

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -236,7 +236,6 @@ class SpectrumExtraction:
         See `SpectrumObservation.compute_energy_threshold` for full
         documentation about the options.
         """
-
         for obs in self.spectrum_observations:
             obs.compute_energy_threshold(**kwargs)
 

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -179,7 +179,7 @@ class SpectrumFit(Fit):
             Fold model with IRFs
 
         Returns
-        ------
+        -------
         predicted_counts : `numpy.ndarray`
             Predicted counts for one observation
         """
@@ -230,7 +230,7 @@ class SpectrumFit(Fit):
             Predicted counts
 
         Returns
-        ------
+        -------
         statsval : tuple of `~numpy.ndarray`
             Statval
         """

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -258,7 +258,6 @@ class FluxPoints:
 
         Examples
         --------
-
         >>> from gammapy.spectrum import FluxPoints
         >>> filename = '$GAMMAPY_DATA/tests/spectrum/flux_points/flux_points.fits'
         >>> flux_points = FluxPoints.read(filename)
@@ -1047,7 +1046,6 @@ class FluxPointsDataset:
 
     Examples
     --------
-
     Load flux points from file and fit with a power-law model::
 
         from astropy import units as u

--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -199,8 +199,7 @@ def power_law_f_from_points(e1, e2, f1, f2, e):
 def power_law_f_with_err(
     I_val=1, I_err=0, g_val=g_DEFAULT, g_err=0, e=1, e1=1, e2=E_INF
 ):
-    """Wrapper for f so the user doesn't have to know about
-    the uncertainties module"""
+    """Evaluate power-law ``dnde`` and propagate errors."""
     from uncertainties import unumpy
 
     I = unumpy.uarray(I_val, I_err)
@@ -214,8 +213,7 @@ def power_law_f_with_err(
 def power_law_I_with_err(
     f_val=1, f_err=0, g_val=g_DEFAULT, g_err=0, e=1, e1=1, e2=E_INF
 ):
-    """Wrapper for f so the user doesn't have to know about
-    the uncertainties module"""
+    """Evaluate power-law flux and propagate errors."""
     from uncertainties import unumpy
 
     f = unumpy.uarray(f_val, f_err)

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -74,7 +74,6 @@ class SensitivityEstimator:
 
     def run(self):
         """Run the computation."""
-
         # TODO: let the user decide on energy binning
         # then integrate bkg model and gamma over those energy bins.
         energy = self.rmf.e_reco.log_center()

--- a/gammapy/tests/__init__.py
+++ b/gammapy/tests/__init__.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This packages contains affiliated package tests.
+Global tests for Gammapy (involving several sub-packages)
+could go in this folder.
 """

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -483,7 +483,7 @@ class LightCurveEstimator:
 
     @staticmethod
     def _alpha(time_holder, obs_properties, n, istart, i):
-        """ Helper function for make_time_intervals_min_significance
+        """Helper function for make_time_intervals_min_significance.
 
         Parameters
         ----------

--- a/gammapy/utils/coordinates/other.py
+++ b/gammapy/utils/coordinates/other.py
@@ -39,7 +39,8 @@ def polar(x, y):
 
 def galactic(x, y, z, obs_pos=None):
     """Compute galactic coordinates lon, lat (deg) and distance (kpc)
-    for given position in cartesian coordinates (kpc)"""
+    for given position in cartesian coordinates (kpc).
+    """
     obs_pos = obs_pos or [D_SUN_TO_GALACTIC_CENTER, 0, 0]
     y_prime = y + D_SUN_TO_GALACTIC_CENTER
     d = np.sqrt(x ** 2 + y_prime ** 2 + z ** 2)

--- a/gammapy/utils/distributions/general_random.py
+++ b/gammapy/utils/distributions/general_random.py
@@ -20,7 +20,8 @@ class GeneralRandom:
 
     Note: Should it be required the cdf could be deleted
     after computing to inversecdf to free memory since it is
-    not required for random number generation."""
+    not required for random number generation.
+    """
 
     def __init__(self, pdf, min_range, max_range, ninversecdf=None, ran_res=1e3):
         """Initialize the lookup table
@@ -108,7 +109,8 @@ class GeneralRandom:
         """Plot the pdf, cdf and inversecdf
         and a random distribution of sample size N.
 
-        Useful for illustrating the interpolation and debugging."""
+        Useful for illustrating the interpolation and debugging.
+        """
         import matplotlib.pyplot as plt
 
         # Plot the cdf

--- a/gammapy/utils/distributions/utils.py
+++ b/gammapy/utils/distributions/utils.py
@@ -8,8 +8,7 @@ __all__ = ["normalize", "density", "draw", "pdf"]
 
 
 def normalize(func, x_min, x_max):
-    """Normalize a 1D function over a given range.
-    """
+    """Normalize a 1D function over a given range."""
 
     def f(x):
         return func(x) / quad(func, x_min, x_max)[0]
@@ -18,8 +17,7 @@ def normalize(func, x_min, x_max):
 
 
 def pdf(func):
-    """Returns the one dimensional PDF of a given radial surface density.
-    """
+    """One-dimensional PDF of a given radial surface density."""
 
     def f(x):
         return x * func(x)
@@ -28,8 +26,7 @@ def pdf(func):
 
 
 def density(func):
-    """Returns the radial surface density of a given one dimensional PDF.
-    """
+    """Radial surface density of a given one dimensional PDF."""
 
     def f(x):
         return func(x) / x

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -65,7 +65,6 @@ class DocsImage(Image):
 
 def LinkNotebook(name, rawtext, notebook, lineno, inliner, options={}, content=[]):
     """Link to a notebook"""
-
     # check if file exists in local notebooks folder
     nbfolder = Path("notebooks")
     nbfilename = notebook + ".ipynb"
@@ -118,7 +117,6 @@ def parse_notebooks(folder, url_docs, git_commit):
     to other files in the documentation. Adds a box to the sphinx formatted
     notebooks with info and links to the *.ipynb and *.py files.
     """
-
     DOWNLOAD_CELL = """
 <div class="alert alert-info">
 
@@ -176,10 +174,7 @@ def parse_notebooks(folder, url_docs, git_commit):
 
 
 def gammapy_sphinx_notebooks(setup_cfg):
-    """
-    Manages the processes for the building of sphinx formatted notebooks
-    """
-
+    """Manage creation of Sphinx-formatted notebooks."""
     if not strtobool(setup_cfg["build_notebooks"]):
         log.info("Config build_notebooks is False; skipping notebook processing")
         return

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -218,7 +218,6 @@ class SmartHDUList:
 
     Examples
     --------
-
     Opening a SmartHDUList calls `astropy.io.fits.open` to get a `~astropy.io.fits.HDUList`
     object, and then stores it away in the ``hdu_list`` attribute:
 

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -413,7 +413,6 @@ def gaussian_sum_moments(F, sigma, x, y, cov_matrix, shift=0.5):
 
     Notes
     -----
-
     The 0th moment (total flux) is given by:
 
     .. math::


### PR DESCRIPTION
There's http://www.pydocstyle.org/ , a tool that automatically checks docstrings.

Recently the `--convention=numpy` option was implemented and seems to work OK:
https://github.com/astropy/astropy/issues/5504#issuecomment-274365728

Here's what it currently says for Gammapy:
https://gist.github.com/cdeil/3f4dab6afd37d90eb4d5e4a5d66159a3

We should add it to Gammapy, which really means:
- [ ] Develop a set of options for `pydocstyle` (ignored files and errors) that passes.
- [ ] Fix all docstring issues it reports, one file or class of error at a time.
- [ ] Add this to the Makefile and run the checks on travis-ci, to make sure we stay clean for the future.
