### PR TITLE
Turn enable_deprecations_as_exceptions on in conftest.py

### DIFF
--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -117,9 +117,7 @@ def make_catalog_random_positions_sphere(
         distance[0], distance[1], size, random_state=random_state
     )
 
-    # TODO: it shouldn't be necessary here to convert to cartesian ourselves ...
-    x, y, z = spherical_to_cartesian(radius, lat, lon)
-    pos = SkyCoord(x, y, z, frame="galactocentric", representation_type="cartesian")
+    pos = SkyCoord(lon, lat, distance=radius, frame="galactic")
 
     if center == "Milky Way":
         pass

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -119,7 +119,7 @@ def make_catalog_random_positions_sphere(
 
     # TODO: it shouldn't be necessary here to convert to cartesian ourselves ...
     x, y, z = spherical_to_cartesian(radius, lat, lon)
-    pos = SkyCoord(x, y, z, frame="galactocentric", representation="cartesian")
+    pos = SkyCoord(x, y, z, frame="galactocentric", representation_type="cartesian")
 
     if center == "Milky Way":
         pass

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -22,8 +22,11 @@ def test_make_catalog_random_positions_cube():
 
 def test_make_catalog_random_positions_sphere():
     size = 100
-    table = make_catalog_random_positions_sphere(size=size, center="Milky Way")
+    table = make_catalog_random_positions_sphere(size=size, center="Milky Way", random_state=27)
     assert len(table) == size
+
+    assert_allclose(table["GLON"][0], 153.259708)
+    assert_allclose(table["GLAT"][0], 62.312573)
 
 
 def test_make_base_catalog_galactic():

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -22,7 +22,8 @@ packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version.version
 
 # Treat all DeprecationWarnings as exceptions
-# enable_deprecations_as_exceptions()
+from astropy.tests.helper import enable_deprecations_as_exceptions
+enable_deprecations_as_exceptions()
 
 # Declare for which packages version numbers should be displayed
 # when running the tests

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -23,7 +23,8 @@ TESTED_VERSIONS[packagename] = version.version
 
 # Treat all DeprecationWarnings as exceptions
 from astropy.tests.helper import enable_deprecations_as_exceptions
-enable_deprecations_as_exceptions()
+#TODO: add numpy again once https://github.com/astropy/regions/pull/252 is addressed
+enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=["numpy"])
 
 # Declare for which packages version numbers should be displayed
 # when running the tests

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -461,8 +461,8 @@ class EnergyDependentTablePSF:
         containment = self.containment(energy=energy, rad_max=rad_max)
 
         if not np.allclose(containment.max(axis=1), 1, atol=0.01):
-            log.warn("PSF does not integrate to unity within a precision of 1% in each energy bin."
-                     " Containment radius computation might give biased results.")
+            log.warning("PSF does not integrate to unity within a precision of 1% in each energy bin."
+                        " Containment radius computation might give biased results.")
 
         # find nearest containment value
         fraction_idx = np.argmin(np.abs(containment - fraction), axis=1)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -50,7 +50,7 @@ class Map(metaclass=MapMeta):
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.
         """
-        argnames = inspect.getargspec(self.__init__).args
+        argnames = inspect.getfullargspec(self.__init__).args
         argnames.remove("self")
         argnames.remove("dtype")
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1429,7 +1429,7 @@ class MapGeom(metaclass=MapGeomMeta):
     def _init_copy(self, **kwargs):
         """Init map instance by copying missing init arguments from self.
         """
-        argnames = inspect.getargspec(self.__init__).args
+        argnames = inspect.getfullargspec(self.__init__).args
         argnames.remove("self")
 
         for arg in argnames:

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -155,7 +155,7 @@ def integrate_spectrum(func, xmin, xmax, ndecade=100, intervals=False):
     if np.isscalar(xmin):
         logmin = np.log10(xmin)
         logmax = np.log10(xmax)
-        n = (logmax - logmin) * ndecade
+        n = int((logmax - logmin)) * ndecade
         x = np.logspace(logmin, logmax, n)
     else:
         x = np.append(xmin, xmax[-1])

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -74,7 +74,7 @@ def test_numerical_confidence_interval_pdfs():
     cl = 0.90
 
     x_bins = np.arange(0, n_bins_x)
-    mu_bins = np.linspace(mu_min, mu_max, mu_max / step_width_mu + 1, endpoint=True)
+    mu_bins = np.linspace(mu_min, mu_max, int(mu_max / step_width_mu) + 1, endpoint=True)
 
     matrix = [scipy.stats.poisson(mu + background).pmf(x_bins) for mu in mu_bins]
 
@@ -121,7 +121,7 @@ def test_numerical_confidence_interval_values():
     cl = 0.90
 
     x_bins = np.linspace(-n_sigma * sigma, n_sigma * sigma, n_bins_x, endpoint=True)
-    mu_bins = np.linspace(mu_min, mu_max, mu_max / step_width_mu + 1, endpoint=True)
+    mu_bins = np.linspace(mu_min, mu_max, int(mu_max / step_width_mu) + 1, endpoint=True)
 
     distribution_dict = {
         mu: [scipy.stats.norm.rvs(loc=mu, scale=sigma, size=5000)] for mu in mu_bins

--- a/gammapy/utils/distributions/general_random.py
+++ b/gammapy/utils/distributions/general_random.py
@@ -22,7 +22,7 @@ class GeneralRandom:
     after computing to inversecdf to free memory since it is
     not required for random number generation."""
 
-    def __init__(self, pdf, min_range, max_range, ninversecdf=None, ran_res=1e3):
+    def __init__(self, pdf, min_range, max_range, ninversecdf=None, ran_res=1000):
         """Initialize the lookup table
 
         Inputs:


### PR DESCRIPTION
Re-submit of #780 following the advice of @bsipocz to turn it on: https://github.com/gammapy/gammapy/pull/780#issuecomment-476901145

I ran it locally and nothing came up. If it is possible to have this on in CI and only fail sometimes, not every week or two, then maybe it is better to have this on in CI.

@adonath - your call.