### PR TITLE
Remove CompoundSkyModel

### DIFF
--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -38,7 +38,7 @@ sky_model_1 = SkyModel(spatial_model=spatial_model_1, spectral_model=spectral_mo
 
 sky_model_2 = SkyModel(spatial_model=spatial_model_2, spectral_model=spectral_model_2)
 
-compound_model = sky_model_1 + sky_model_2
+models = sky_model_1 + sky_model_2
 
 # Define map geometry
 axis = MapAxis.from_edges(np.logspace(-1.0, 1.0, 10), unit="TeV")
@@ -56,7 +56,7 @@ exposure_map = make_map_exposure_true_energy(
     pointing=pointing, livetime=livetime, aeff=aeff, geom=geom
 )
 
-evaluator = MapEvaluator(model=compound_model, exposure=exposure_map)
+evaluator = MapEvaluator(model=models, exposure=exposure_map)
 
 
 npred = evaluator.compute_npred()
@@ -81,10 +81,10 @@ counts_map.sum_over_axes().plot()
 # plt.show()
 plt.clf()
 
-compound_model.parameters.set_error(2, 0.1 * u.deg)
-compound_model.parameters.set_error(4, 1e-12 * u.Unit("cm-2 s-1 TeV-1"))
-compound_model.parameters.set_error(8, 0.1 * u.deg)
-compound_model.parameters.set_error(10, 1e-12 * u.Unit("cm-2 s-1 TeV-1"))
+models.parameters.set_error(2, 0.1 * u.deg)
+models.parameters.set_error(4, 1e-12 * u.Unit("cm-2 s-1 TeV-1"))
+models.parameters.set_error(8, 0.1 * u.deg)
+models.parameters.set_error(10, 1e-12 * u.Unit("cm-2 s-1 TeV-1"))
 
-fit = MapFit(model=compound_model, counts=counts_map, exposure=exposure_map)
+fit = MapFit(model=models, counts=counts_map, exposure=exposure_map)
 fit.run()

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -226,69 +226,6 @@ class SkyModel(SkyModelBase):
         return val_spatial * val_spectral
 
 
-class CompoundSkyModel(SkyModelBase):
-    """Represents the algebraic combination of two
-    `~gammapy.cube.models.SkyModel`
-
-    Parameters
-    ----------
-    model1, model2 : `SkyModel`
-        Two sky models
-    operator : callable
-        Binary operator to combine the models
-    """
-
-    __slots__ = ["model1", "model2", "operator"]
-
-    def __init__(self, model1, model2, operator):
-        self.model1 = model1
-        self.model2 = model2
-        self.operator = operator
-        parameters = self.model1.parameters.parameters + self.model2.parameters.parameters
-        super().__init__(parameters)
-
-    @property
-    def parameters(self):
-        """Parameters (`~gammapy.utils.modeling.Parameters`)"""
-        return self._parameters
-
-    @parameters.setter
-    def parameters(self, parameters):
-        self._parameters = parameters
-        idx = len(self.model1.parameters.parameters)
-        self.model1.parameters.parameters = parameters.parameters[:idx]
-        self.model2.parameters.parameters = parameters.parameters[idx:]
-
-    def __str__(self):
-        ss = self.__class__.__name__
-        ss += "\n    Component 1 : {}".format(self.model1)
-        ss += "\n    Component 2 : {}".format(self.model2)
-        ss += "\n    Operator : {}".format(self.operator)
-        return ss
-
-    def evaluate(self, lon, lat, energy):
-        """Evaluate the compound model at given points.
-
-        Return differential surface brightness cube.
-        At the moment in units: ``cm-2 s-1 TeV-1 deg-2``
-
-        Parameters
-        ----------
-        lon, lat : `~astropy.units.Quantity`
-            Spatial coordinates
-        energy : `~astropy.units.Quantity`
-            Energy coordinate
-
-        Returns
-        -------
-        value : `~astropy.units.Quantity`
-            Model value at the given point.
-        """
-        val1 = self.model1.evaluate(lon, lat, energy)
-        val2 = self.model2.evaluate(lon, lat, energy)
-        return self.operator(val1, val2)
-
-
 class SkyDiffuseCube(SkyModelBase):
     """Cube sky map template model (3D).
 


### PR DESCRIPTION
This PR removes the `CompoundSkyModel` class, because we don't have a solution for serialisation of this hierarchical models and no good API solution for accessing the model parameters either. A general modelling language for Gammapy is definitely an option for Gammapy 2.0, but before we implement this we should re-evaluate the use of `astropy.modeling.models` again, which already has support for this.  This PR also addresses #2090. 