### PR TITLE
Remove added PyCharm metadata from cells in notebooks

### DIFF
--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -75,6 +75,7 @@ def cli_jupyter_strip(ctx):
         rawnb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
 
         for cell in rawnb.cells:
+            cell["metadata"].pop('pycharm', None)
             if cell["cell_type"] == "code":
                 cell["execution_count"] = None
                 cell["outputs"] = []


### PR DESCRIPTION
This small PR addresses issue https://github.com/gammapy/gammapy/issues/2096 removing the `pycharm` metadata added to all cells when editing notebooks with PyCharm IDE. This action of removing the `pycharm` metadata is undertaken when executing `gammapy jupyter strip` to remove the output cells as well as others undesired metadata.