### PR TITLE
Remove copy option in PSFMap and EDispMap stack

### DIFF
--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -61,7 +61,7 @@ def make_edisp_map(edisp, pointing, geom, max_offset, exposure_map=None):
     return EDispMap(edispmap, exposure_map)
 
 
-class EDispMap(object):
+class EDispMap:
     """Class containing the Map of Energy Dispersions and allowing to interact with it.
 
     Parameters
@@ -294,7 +294,7 @@ class EDispMap(object):
             data=data,
         )
 
-    def stack(self, other, copy=True):
+    def stack(self, other):
         """Stack EdispMap with another one.
 
         The current EdispMap is unchanged and a new one is created and returned.
@@ -303,8 +303,6 @@ class EDispMap(object):
         ----------
         other : `~gammapy.cube.EDispMap`
             the edispmap to be stacked with this one.
-        copy : bool
-            if set to True returns a new EdispMap
 
         Returns
         -------
@@ -343,9 +341,4 @@ class EDispMap(object):
         # We need to remove the extra axis in the total exposure
         reproj_exposure.quantity = total_exposure[:, 0, :, :]
 
-        if copy:
-            return EDispMap(reproj_edispmap, reproj_exposure)
-        else:
-            self.edisp_map = reproj_edispmap
-            self.exposure_map = reproj_exposure
-            return self
+        return EDispMap(reproj_edispmap, reproj_exposure)

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -62,7 +62,7 @@ def make_edisp_map(edisp, pointing, geom, max_offset, exposure_map=None):
 
 
 class EDispMap:
-    """Class containing the Map of Energy Dispersions and allowing to interact with it.
+    """Energy dispersion map.
 
     Parameters
     ----------
@@ -80,27 +80,26 @@ class EDispMap:
         import numpy as np
         from astropy import units as u
         from astropy.coordinates import SkyCoord
-        from gammapy.maps import Map, WcsGeom, MapAxis
+        from gammapy.maps import WcsGeom, MapAxis
         from gammapy.irf import EnergyDispersion2D, EffectiveAreaTable2D
-        from gammapy.cube import make_edisp_map, EDispMap, make_map_exposure_true_energy
+        from gammapy.cube import make_edisp_map, make_map_exposure_true_energy
 
-        # Define energy axis. Note that the name is fixed.
-        energy_axis = MapAxis.from_edges(np.logspace(-1., 1., 4), unit='TeV', name='energy')
-        # Define migra axis. Again note the axis name
-        migras = np.linspace(0., 3.0, 100)
-        migra_axis = MapAxis.from_edges(migras, unit='', name='migra')
-
-        # Define parameters
-        pointing = SkyCoord(0., 0., unit='deg')
+        # Define energy dispersion map geometry
+        energy_axis = MapAxis.from_edges(np.logspace(-1, 1, 4), unit="TeV", name="energy")
+        migra_axis = MapAxis.from_edges(np.linspace(0, 3, 100), name="migra")
+        pointing = SkyCoord(0, 0, unit="deg")
         max_offset = 4 * u.deg
-
-        # Create WcsGeom
-        geom = WcsGeom.create(binsz=0.25*u.deg, width=10*u.deg, skydir=pointing, axes=[migra_axis, energy_axis])
+        geom = WcsGeom.create(
+            binsz=0.25 * u.deg,
+            width=10 * u.deg,
+            skydir=pointing,
+            axes=[migra_axis, energy_axis],
+        )
 
         # Extract EnergyDispersion2D from CTA 1DC IRF
-        filename = '$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits'
-        edisp2D = EnergyDispersion2D.read(filename, hdu='ENERGY DISPERSION')
-        aeff2d = EffectiveAreaTable2D.read(filename, hdu='EFFECTIVE AREA')
+        filename = "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+        edisp2D = EnergyDispersion2D.read(filename, hdu="ENERGY DISPERSION")
+        aeff2d = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
 
         # Create the exposure map
         exposure_geom = geom.to_image().to_cube([energy_axis])
@@ -110,10 +109,12 @@ class EDispMap:
         edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset, exposure_map)
 
         # Get an Energy Dispersion (1D) at any position in the image
-        edisp = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'), e_reco=np.logspace(-1.,1.,10)*u.TeV)
+        pos = SkyCoord(2.0, 2.5, unit="deg")
+        e_reco = np.logspace(-1.0, 1.0, 10) * u.TeV
+        edisp = edisp_map.get_energy_dispersion(pos=pos, e_reco=e_reco)
 
         # Write map to disk
-        edisp_map.write('edisp_map.fits')
+        edisp_map.write("edisp_map.fits")
     """
 
     def __init__(self, edisp_map, exposure_map):

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -110,7 +110,7 @@ class EDispMap(object):
         edisp_map = make_edisp_map(edisp2D, pointing, geom, max_offset, exposure_map)
 
         # Get an Energy Dispersion (1D) at any position in the image
-        edisp = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'))
+        edisp = edisp_map.get_energy_dispersion(SkyCoord(2., 2.5, unit='deg'), e_reco=np.logspace(-1.,1.,10)*u.TeV)
 
         # Write map to disk
         edisp_map.write('edisp_map.fits')

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -295,7 +295,7 @@ class PSFMap:
 
         return m
 
-    def stack(self, other, copy=True):
+    def stack(self, other):
         """Stack PSFMap with another one.
 
         The other PSFMap is projected on the current PSFMap geometry.
@@ -304,8 +304,6 @@ class PSFMap:
         ----------
         other : `~gammapy.cube.PSFMap`
             the psfmap to be stacked with this one.
-        copy : bool
-            if set to True returns a new PSFMap
 
         Returns
         -------
@@ -344,9 +342,4 @@ class PSFMap:
         # We need to remove the extra axis in the total exposure
         reproj_exposure.quantity = total_exposure[:, 0, :, :]
 
-        if copy:
-            return PSFMap(reproj_psfmap, reproj_exposure)
-        else:
-            self.psf_map = reproj_psfmap
-            self.exposure_map = reproj_exposure
-            return self
+        return PSFMap(reproj_psfmap, reproj_exposure)

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -124,6 +124,3 @@ def test_edisp_map_stacking():
     edmap_stack = edmap1.stack(edmap2, True)
     assert_allclose(edmap_stack.edisp_map.data, edmap1.edisp_map.data)
     assert_allclose(edmap_stack.exposure_map.data, edmap1.exposure_map.data * 3)
-
-    edmap1.stack(edmap2, False)
-    assert_allclose(edmap1.edisp_map.data, edmap_stack.edisp_map.data)

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -27,7 +27,6 @@ def fake_aeff2d(area=1e6 * u.m ** 2):
 
 
 def make_edisp_map_test():
-
     etrue = [0.2, 0.7, 1.5, 2.0, 10.0] * u.TeV
     migra = np.linspace(0.0, 3.0, 51)
     offsets = np.array((0.0, 1.0, 2.0, 3.0)) * u.deg
@@ -59,7 +58,6 @@ def make_edisp_map_test():
 
 
 def test_make_edisp_map():
-
     energy_axis = MapAxis(
         nodes=[0.2, 0.7, 1.5, 2.0, 10.0],
         unit="TeV",
@@ -96,7 +94,6 @@ def test_edisp_map_to_from_hdulist():
 def test_edisp_map_read_write(tmpdir):
     edmap = make_edisp_map_test()
 
-    # test read/write
     filename = str(tmpdir / "edispmap.fits")
     edmap.write(filename, overwrite=True)
     new_edmap = EDispMap.read(filename)

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -121,6 +121,6 @@ def test_edisp_map_stacking():
     edmap2 = make_edisp_map_test()
     edmap2.exposure_map.quantity *= 2
 
-    edmap_stack = edmap1.stack(edmap2, True)
+    edmap_stack = edmap1.stack(edmap2)
     assert_allclose(edmap_stack.edisp_map.data, edmap1.edisp_map.data)
     assert_allclose(edmap_stack.exposure_map.data, edmap1.exposure_map.data * 3)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -168,12 +168,12 @@ def test_psfmap_stacking():
     psfmap2 = make_test_psfmap(0.1 * u.deg, shape="flat")
     psfmap2.exposure_map.quantity *= 2
 
-    psfmap_stack = psfmap1.stack(psfmap2, True)
+    psfmap_stack = psfmap1.stack(psfmap2)
     assert_allclose(psfmap_stack.psf_map.data, psfmap1.psf_map.data)
     assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
 
     psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
-    psfmap_stack = psfmap1.stack(psfmap3, True)
+    psfmap_stack = psfmap1.stack(psfmap3)
 
     assert_allclose(psfmap_stack.psf_map.data[0, 40, 20, 20], 0.0)
     assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -179,8 +179,5 @@ def test_psfmap_stacking():
     assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)
     assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 58052.78955078125)
 
-    psfmap1.stack(psfmap3, False)
-    assert_allclose(psfmap1.psf_map.data, psfmap_stack.psf_map.data)
-
 
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations


### PR DESCRIPTION
This is a quick PR to remove the `copy` option in `EDispMap.stack()` and `PSFMap.stack()`. 
The option does not bring anything that cannot be done with: `edisp=edisp.stack(other)` (there is no in-place stacking).

The example code of `EdispMap` is corrected and now runs, the `(Object)` inheritance is removed too.
