### PR TITLE
Add Dataset abstract base class

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 from astropy.utils import lazyproperty
 import astropy.units as u
-from ..utils.fitting import Parameters
+from ..utils.fitting import Parameters, Dataset
 from ..stats import cash, cstat
 from ..maps import Map, MapAxis
 from .models import SkyModel, SkyModels
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 CUTOUT_MARGIN = 0.1 * u.deg
 
 
-class MapDataset:
+class MapDataset(Dataset):
     """Perform sky model likelihood fit on maps.
 
     Parameters
@@ -33,7 +33,7 @@ class MapDataset:
         PSF kernel
     edisp : `~gammapy.irf.EnergyDispersion`
         Energy dispersion
-    background_model: `~gammapy.cube.models.BackgroundModel` or `~gammapy.cube.models.BackgroundModel`
+    background_model : `~gammapy.cube.models.BackgroundModel` or `~gammapy.cube.models.BackgroundModels`
         Background models to use for the fit.
     likelihood : {"cash", "cstat"}
         Likelihood function to use for the fit.
@@ -164,6 +164,7 @@ class MapDataset:
             stat = self.likelihood_per_bin()[self.mask.data]
         else:
             stat = self.likelihood_per_bin()[mask & self.mask.data]
+
         return np.sum(stat, dtype=np.float64)
 
 

--- a/gammapy/spectrum/fit.py
+++ b/gammapy/spectrum/fit.py
@@ -3,7 +3,7 @@ import logging
 import copy
 import numpy as np
 import astropy.units as u
-from ..utils.fitting import Fit, Parameters
+from ..utils.fitting import Fit, Parameters, Dataset
 from .. import stats
 from ..utils.random import get_random_state
 from .core import CountsSpectrum
@@ -15,7 +15,7 @@ __all__ = ["SpectrumFit", "SpectrumDataset"]
 log = logging.getLogger(__name__)
 
 
-class SpectrumDataset:
+class SpectrumDataset(Dataset):
     """Compute spectral model fit statistic on a CountsSpectrum.
 
     Parameters
@@ -26,13 +26,13 @@ class SpectrumDataset:
         Counts spectrum
     livetime : float
         Livetime
-    mask : numpy.array
+    mask : `~numpy.ndarray`
         Mask to apply to the likelihood.
     aeff : `~gammapy.irf.EffectiveAreaTable`
         Effective area
     edisp : `~gammapy.irf.EnergyDispersion`
         Energy dispersion
-    background: `~gammapy.spectrum.CountsSpectrum`
+    background : `~gammapy.spectrum.CountsSpectrum`
         Background to use for the fit.
     """
 
@@ -107,6 +107,7 @@ class SpectrumDataset:
             stat = self.likelihood_per_bin()[self.mask]
         else:
             stat = self.likelihood_per_bin()[mask & self.mask]
+
         return np.sum(stat, dtype=np.float64)
 
     def fake(self, random_state='random-seed'):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -8,6 +8,7 @@ from astropy.io.registry import IORegistryError
 from ..utils.scripts import make_path
 from ..utils.table import table_standardise_units_copy, table_from_row_data
 from ..utils.interpolation import ScaledRegularGridInterpolator
+from ..utils.fitting import Dataset
 from .models import PowerLaw, ScaleModel
 from .powerlaw import power_law_integral_flux
 from .observation import SpectrumObservationList, SpectrumObservation
@@ -1028,7 +1029,7 @@ class FluxPointEstimator:
             obs.on_vector.quality = quality
 
 
-class FluxPointsDataset:
+class FluxPointsDataset(Dataset):
     """
     Fit a set of flux points with a parametric model.
 
@@ -1097,8 +1098,7 @@ class FluxPointsDataset:
         return FluxPointsDataset._likelihood_chi2(data, model, sigma)
 
     def flux_pred(self):
-        """Compute predicted flux.
-        """
+        """Compute predicted flux."""
         return self.model(self.data.e_ref)
 
     def likelihood_per_bin(self):
@@ -1133,4 +1133,5 @@ class FluxPointsDataset:
             stat = self.likelihood_per_bin()[self.mask]
         else:
             stat = self.likelihood_per_bin()[mask & self.mask]
+
         return np.nansum(stat, dtype=np.float64)

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -1,10 +1,37 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import abc
 from collections import Counter
 import numpy as np
 from astropy.utils import lazyproperty
 from .parameter import Parameters
 
-__all__ = ["Datasets"]
+__all__ = ["Dataset", "Datasets"]
+
+
+class Dataset(abc.ABC):
+    """Dataset abstract base class.
+
+    TODO: add tutorial how to create your own dataset types.
+
+    For now, see existing examples in Gammapy how this works:
+
+    - `gammapy.cube.MapDataset`
+    - `gammapy.spectrum.SpectrumDataset`
+    - `gammapy.spectrum.FluxPointsDataset`
+    """
+
+    @abc.abstractmethod
+    def likelihood(self, parameters, mask=None):
+        """Total likelihood (float, sum over bins).
+
+        TODO: fix interface.
+        Remove ``parameters`` and ``mask``, add update method?
+        """
+        pass
+
+    @abc.abstractmethod
+    def likelihood_per_bin(self):
+        """Likelihood per bin given the current model parameters"""
 
 
 class Datasets:
@@ -43,7 +70,7 @@ class Datasets:
 
     @lazyproperty
     def types(self):
-        """Types of the contained dataets"""
+        """Types of the contained datasets"""
         return [type(dataset).__name__ for dataset in self.datasets]
 
     @lazyproperty


### PR DESCRIPTION
This PR introduces a `gammapy.utils.fitting.Dataset` abstract base class.

It serves to define the interface / document the API a Dataset needs to work with Datasets.
Also it means that in parameter sections of docstrings links to `Dataset` will resolve, whereas currently they give unresolved reference error when running the Sphinx build with `nitpicky=True`.
Also it makes it easy to find all Dataset classes in Gammapy, e.g. in PyCharm.

![Screenshot 2019-03-29 at 14 12 44](https://user-images.githubusercontent.com/852409/55235030-c2b21480-522c-11e9-8887-4cfb4b719b9f.png)

This will help a bit in the coming weeks to finalise / refactor this interface - currently parameters is passed to the `likelihood` method, but not used or mentioned in the docstring. And `mask` is passed, which I think is problematic, we'll have to re-discuss...