### PR TITLE
Add `frame` attribute for SkyDiffuseMap

### DIFF
--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -507,8 +507,6 @@ class SkyDiffuseMap(SkySpatialModel):
 
     __slots__ = ["map", "norm", "meta", "_interp_kwargs"]
 
-    frame = None
-
     def __init__(self, map, norm=1, meta=None, normalize=True, interp_kwargs=None):
         if (map.data < 0).any():
             log.warning("Diffuse map has negative values. Check and fix this!")
@@ -576,3 +574,7 @@ class SkyDiffuseMap(SkySpatialModel):
     def position(self):
         """`~astropy.coordinates.SkyCoord`"""
         return self.map.geom.center_skydir
+
+    @property
+    def frame(self):
+        return self.position.frame

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -507,6 +507,8 @@ class SkyDiffuseMap(SkySpatialModel):
 
     __slots__ = ["map", "norm", "meta", "_interp_kwargs"]
 
+    frame = None
+
     def __init__(self, map, norm=1, meta=None, normalize=True, interp_kwargs=None):
         if (map.data < 0).any():
             log.warning("Diffuse map has negative values. Check and fix this!")

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -147,6 +147,7 @@ def test_sky_diffuse_map():
     radius = model.evaluation_radius
     assert radius.unit == "deg"
     assert_allclose(radius.value, 0.64, rtol=1.0e-2)
+    assert model.frame.name == "fk5"
 
 
 @requires_data("gammapy-data")


### PR DESCRIPTION
It seems the `frame` attribute is missing for `SkyDiffuseMap`, which leads to a crash when `MapDataset` tries to access it. This PR adds the `frame` attribute and sets it to `None`, as for the `SkyDiffuseConstant` model.