### PR TITLE
Fix `frame` attribute of SkyDiffuseCube and SkyDiffuseMap

### DIFF
--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -309,7 +309,7 @@ class SkyDiffuseCube(SkyModelBase):
 
     @property
     def frame(self):
-        return self.position.frame
+        return self.position.frame.name
 
 
 class BackgroundModel(Model):

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -26,7 +26,7 @@ def sky_model():
 @pytest.fixture(scope="session")
 def diffuse_model():
     axis = MapAxis.from_nodes([0.1, 100], name="energy", unit="TeV", interp="log")
-    m = Map.create(npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1")
+    m = Map.create(npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1", coordsys="GAL")
     m.data += 42
     return SkyDiffuseCube(m)
 
@@ -248,6 +248,10 @@ class TestSkyDiffuseCube:
         radius = diffuse_model.evaluation_radius
         assert radius.unit == "deg"
         assert_allclose(radius.value, 4)
+
+    @staticmethod
+    def test_frame(diffuse_model):
+        assert diffuse_model.frame == "galactic"
 
 
 class TestSkyDiffuseCubeMapEvaluator:

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -577,4 +577,4 @@ class SkyDiffuseMap(SkySpatialModel):
 
     @property
     def frame(self):
-        return self.position.frame
+        return self.position.frame.name

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -147,7 +147,7 @@ def test_sky_diffuse_map():
     radius = model.evaluation_radius
     assert radius.unit == "deg"
     assert_allclose(radius.value, 0.64, rtol=1.0e-2)
-    assert model.frame.name == "fk5"
+    assert model.frame == "fk5"
 
 
 @requires_data("gammapy-data")


### PR DESCRIPTION
After having added the `frame` attribute to `SkyDiffuseMap` in #2106, I noticed that currently this attribute returns an `astropy` frame object, whereas all other models just give the name of the frame (e.g. `icrs`). Indeed, a string is expected e.g. [here](https://github.com/gammapy/gammapy/blob/c3c86e430932ed00fe1e2e63f958d1379209ac06/gammapy/cube/fit.py#L268).

This PR changes the `frame` attribute of `SkyDiffuseMap` and `SkyDiffuseCube` such that the name of the frame is returned.

I wanted to modify the test for the `SkyDiffuseCube` as well, but could not run the test since `$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits` could not be found (and is not retrieved by `gammapy download tutorials --release 0.11`). Help is appreciated here.