### PR TITLE
Changed from CountsPredictor to SpectrumEvaluator

### DIFF
--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -10,7 +10,7 @@ from ..utils.table import table_from_row_data
 from ..data import ObservationStats
 from ..irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
 from .core import CountsSpectrum, PHACountsSpectrum, PHACountsSpectrumList
-from .utils import CountsPredictor
+from .utils import SpectrumEvaluator
 
 __all__ = [
     "SpectrumStats",
@@ -346,11 +346,10 @@ class SpectrumObservation:
         npred : `~gammapy.spectrum.CountsSpectrum`
             Predicted counts
         """
-        predictor = CountsPredictor(
+        predictor = SpectrumEvaluator(
             model=model, edisp=self.edisp, aeff=self.aeff, livetime=self.livetime
         )
-        predictor.run()
-        return predictor.npred
+        return predictor.compute_npred()
 
     @classmethod
     def read(cls, filename):

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -3,7 +3,7 @@ from astropy.table import Table, Column
 import astropy.units as u
 from ..stats import excess_matching_significance_on_off
 from .models import PowerLaw
-from .utils import CountsPredictor
+from .utils import SpectrumEvaluator
 
 __all__ = ["SensitivityEstimator"]
 
@@ -91,11 +91,10 @@ class SensitivityEstimator:
         )
 
         # TODO: simplify the following computation
-        predictor = CountsPredictor(
+        predictor = SpectrumEvaluator(
             model, aeff=self.arf, edisp=self.rmf, livetime=self.livetime
         )
-        predictor.run()
-        counts = predictor.npred.data.data.value
+        counts = predictor.compute_npred().data.data.value
         phi_0 = excess_counts / counts
 
         dnde_model = model(energy=energy)

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import logging
 from ..utils.random import get_random_state
 from ..utils.energy import EnergyBounds
-from .utils import CountsPredictor
+from .utils import SpectrumEvaluator
 from .core import PHACountsSpectrum
 from .observation import SpectrumObservation, SpectrumObservationList
 
@@ -62,33 +62,31 @@ class SpectrumSimulation:
     def npred_source(self):
         """Predicted source `~gammapy.spectrum.CountsSpectrum`.
 
-        Calls :func:`gammapy.spectrum.utils.CountsPredictor`.
+        Calls :func:`gammapy.spectrum.utils.SpectrumEvaluator`.
         """
-        predictor = CountsPredictor(
+        predictor = SpectrumEvaluator(
             livetime=self.livetime,
             aeff=self.aeff,
             edisp=self.edisp,
             e_true=self.e_true,
             model=self.source_model,
         )
-        predictor.run()
-        return predictor.npred
+        return predictor.compute_npred()
 
     @property
     def npred_background(self):
         """Predicted background (`~gammapy.spectrum.CountsSpectrum`).
 
-        Calls :func:`gammapy.spectrum.utils.CountsPredictor`.
+        Calls :func:`gammapy.spectrum.utils.SpectrumEvaluator`.
         """
-        predictor = CountsPredictor(
+        predictor = SpectrumEvaluator(
             livetime=self.livetime,
             aeff=self.aeff,
             edisp=self.edisp,
             e_true=self.e_true,
             model=self.background_model,
         )
-        predictor.run()
-        return predictor.npred
+        return predictor.compute_npred()
 
     @property
     def e_reco(self):

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency
 from ...irf import EffectiveAreaTable, EnergyDispersion
-from ...spectrum import integrate_spectrum, CountsPredictor
+from ...spectrum import integrate_spectrum, SpectrumEvaluator
 from ..powerlaw import power_law_energy_flux, power_law_evaluate, power_law_flux
 from ..models import ExponentialCutoffPowerLaw, PowerLaw, TableModel
 
@@ -138,7 +138,6 @@ def get_test_cases():
 @pytest.mark.parametrize("case", get_test_cases())
 def test_counts_predictor(case):
     desired = case.pop("npred")
-    predictor = CountsPredictor(**case)
-    predictor.run()
-    actual = predictor.npred.total_counts.value
+    predictor = SpectrumEvaluator(**case)
+    actual = predictor.compute_npred().total_counts.value
     assert_allclose(actual, desired)

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
-from ..spectrum.utils import CountsPredictor
+from ..spectrum.utils import SpectrumEvaluator
 from ..stats.poisson import excess_error, excess_ul_helene
 from ..utils.scripts import make_path
 from ..utils.table import table_from_row_data
@@ -815,14 +815,13 @@ class LightCurveEstimator:
                     )  # user
                 )
             )[0]
-            counts_predictor = CountsPredictor(
+            counts_predictor = SpectrumEvaluator(
                 livetime=livetime_to_add,
                 aeff=spec.aeff,
                 edisp=spec.edisp,
                 model=spectral_model,
             )
-            counts_predictor.run()
-            counts_predicted_excess = counts_predictor.npred.data.data[e_idx[:-1]]
+            counts_predicted_excess = counts_predictor.compute_npred().data.data[e_idx[:-1]]
 
             obs_predicted_excess = np.sum(counts_predicted_excess)
 


### PR DESCRIPTION
This PR implements proposed PR 12 from PIG 7.

It basically changes the name of `CountsPredictor` to `SpectrumEvaluator` to follow the `MapEvaluator` and modifies its API to use `SpectrumEvaluator.compute_npred()`
instead of 
```
predictor.run()
predictor.npred
``` 
