### PR TITLE
Refactor FluxPointEstimator to use Datasets

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -100,7 +100,7 @@ class MapDataset(Dataset):
 
         self._evaluators = evaluators
 
-    @lazyproperty
+    @property
     def parameters(self):
         """List of parameters (`~gammapy.utils.fitting.Parameters`)"""
         if self.background_model:

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -88,13 +88,14 @@ class SpectrumAnalysisIACT:
 
         # TODO: Don't stack again if SpectrumFit has already done the stacking
         stacked_obs = self.extraction.spectrum_observations.stack()
-        self.egm = SpectrumEnergyGroupMaker(stacked_obs)
+        self.egm = SpectrumEnergyGroupMaker(stacked_obs.e_reco)
         self.egm.compute_groups_fixed(self.config["fp_binning"])
 
+        datasets = [obs.to_spectrum_dataset() for obs in self.extraction.spectrum_observations]
         self.flux_point_estimator = FluxPointEstimator(
             groups=self.egm.groups,
             model=self.fit.result[0].model,
-            obs=self.extraction.spectrum_observations,
+            datasets=datasets,
         )
         self.flux_points = self.flux_point_estimator.run()
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -265,22 +265,4 @@ class SpectrumDatasetOnOff(Dataset):
             OGIP PHA file to read
         """
         observation = SpectrumObservation.read(filename)
-        return SpectrumDatasetOnOff._from_spectrum_observation(observation)
-
-    # TODO: check if SpectrumObservation is needed in the long run
-    @classmethod
-    def _from_spectrum_observation(cls, observation):
-        """Creates a SpectrumDatasetOnOff from a SpectrumObservation object"""
-
-        # Build mask from quality vector
-        quality = observation.on_vector.quality
-        mask = quality == 0
-
-        return cls(
-            counts_on=observation.on_vector,
-            aeff=observation.aeff,
-            counts_off=observation.off_vector,
-            edisp=observation.edisp,
-            livetime=observation.livetime,
-            mask=mask,
-        )
+        return observation.to_spectrum_dataset()

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -21,6 +21,7 @@ from astropy.units import Quantity
 from astropy.table import Table
 from astropy.table import vstack as table_vstack
 from ..utils.table import table_from_row_data, table_row_to_dict
+from ..utils.energy import EnergyBounds
 
 __all__ = ["SpectrumEnergyGroup", "SpectrumEnergyGroups", "SpectrumEnergyGroupMaker"]
 
@@ -219,8 +220,8 @@ class SpectrumEnergyGroupMaker:
 
     Attributes
     ----------
-    obs : `~gammapy.spectrum.SpectrumObservation`
-        Spectrum observation data
+    e_reco : `~astropy.units.Quantity`
+        Array of reconstructed energies.
     groups : `~gammapy.spectrum.SpectrumEnergyGroups`
         List of energy groups
 
@@ -229,13 +230,13 @@ class SpectrumEnergyGroupMaker:
     SpectrumEnergyGroups, SpectrumEnergyGroup, FluxPointEstimator
     """
 
-    def __init__(self, obs):
-        self.obs = obs
+    def __init__(self, e_reco):
+        self.e_reco = EnergyBounds(e_reco)
         self.groups = None
 
     def groups_from_obs(self):
         """Compute energy groups with one group per energy bin."""
-        ebounds_obs = self.obs.e_reco
+        ebounds_obs = self.e_reco
         size = ebounds_obs.nbins
         table = Table()
         table["bin_idx"] = np.arange(size)
@@ -256,7 +257,7 @@ class SpectrumEnergyGroupMaker:
         ebounds : `~astropy.units.Quantity`
             Energy bounds array
         """
-        ebounds_src = self.obs.e_reco.to(ebounds.unit)
+        ebounds_src = self.e_reco.to(ebounds.unit)
         bin_edges_src = np.arange(len(ebounds_src))
 
         temp = np.interp(ebounds, ebounds_src, bin_edges_src)

--- a/gammapy/spectrum/energy_group.py
+++ b/gammapy/spectrum/energy_group.py
@@ -234,7 +234,7 @@ class SpectrumEnergyGroupMaker:
         self.e_reco = EnergyBounds(e_reco)
         self.groups = None
 
-    def groups_from_obs(self):
+    def compute_groups_from_obs(self):
         """Compute energy groups with one group per energy bin."""
         ebounds_obs = self.e_reco
         size = ebounds_obs.nbins

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -968,19 +968,15 @@ class FluxPointEstimator:
         result : dict
             Dict with ts and sqrt(ts) for the flux point.
         """
-        parameters = self.model.parameters
-
         loglike = self.datasets.likelihood()
-        norm_best_fit = parameters["norm"].value
 
         # store best fit amplitude, set amplitude of fit model to zero
-        parameters["norm"].value = 0
-        loglike_null = self.fit.total_stat(parameters)
-        parameters["norm"].value = 1.0
+        self.model.norm.value = 0
+        loglike_null = self.datasets.likelihood()
 
         # compute sqrt TS
         ts = np.abs(loglike_null - loglike)
-        sqrt_ts = np.sign(norm_best_fit) * np.sqrt(ts)
+        sqrt_ts = np.sqrt(ts)
         return {"sqrt_ts": sqrt_ts, "ts": ts}
 
     def estimate_norm_scan(self):
@@ -1003,6 +999,9 @@ class FluxPointEstimator:
         result : dict
             Dict with "norm" and "loglike" for the flux point.
         """
+        # start optimization with norm=1
+        self.model.norm.value = 1.0
+
         self.fit = Fit(self.datasets)
         result = self.fit.optimize()
 

--- a/gammapy/spectrum/observation.py
+++ b/gammapy/spectrum/observation.py
@@ -518,6 +518,24 @@ class SpectrumObservation:
         """A deep copy."""
         return copy.deepcopy(self)
 
+    def to_spectrum_dataset(self):
+        """Creates a SpectrumDatasetOnOff from a SpectrumObservation object"""
+        from .dataset import SpectrumDatasetOnOff
+
+        # Build mask from quality vector
+        quality = self.on_vector.quality
+        mask = quality == 0
+
+        return SpectrumDatasetOnOff(
+            counts_on=self.on_vector,
+            aeff=self.aeff,
+            counts_off=self.off_vector,
+            edisp=self.edisp,
+            livetime=self.livetime,
+            mask=mask,
+        )
+
+
 
 class SpectrumObservationList(UserList):
     """List of `~gammapy.spectrum.SpectrumObservation` objects."""

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -118,7 +118,7 @@ class TestSpectrumEnergyGroupMaker:
     @staticmethod
     def test_groups_from_obs(obs):
         seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
-        seg.groups_from_obs()
+        seg.compute_groups_from_obs()
         groups = seg.groups
 
         assert len(groups) == obs.e_reco.nbins

--- a/gammapy/spectrum/tests/test_energy_group.py
+++ b/gammapy/spectrum/tests/test_energy_group.py
@@ -117,7 +117,7 @@ class TestSpectrumEnergyGroupMaker:
 
     @staticmethod
     def test_groups_from_obs(obs):
-        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
         seg.groups_from_obs()
         groups = seg.groups
 
@@ -126,7 +126,7 @@ class TestSpectrumEnergyGroupMaker:
     @staticmethod
     def test_compute_groups_fixed_basic(obs):
         ebounds = [1, 2, 10] * u.TeV
-        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
@@ -145,7 +145,7 @@ class TestSpectrumEnergyGroupMaker:
         [[1.8, 4.8, 7.2] * u.TeV, [2, 5, 7] * u.TeV, [2000, 5000, 7000] * u.GeV],
     )
     def test_compute_groups_fixed_edges(obs, ebounds):
-        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
@@ -163,7 +163,7 @@ class TestSpectrumEnergyGroupMaker:
     @staticmethod
     def test_compute_groups_fixed_below_range(obs):
         ebounds = [0.7, 0.8, 1, 4] * u.TeV
-        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
@@ -179,7 +179,7 @@ class TestSpectrumEnergyGroupMaker:
     @staticmethod
     def test_compute_groups_fixed_above_range(obs):
         ebounds = [5, 7, 11, 13] * u.TeV
-        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
         seg.compute_groups_fixed(ebounds=ebounds)
         groups = seg.groups
 
@@ -196,6 +196,6 @@ class TestSpectrumEnergyGroupMaker:
     @staticmethod
     def test_compute_groups_fixed_outside_range(obs):
         ebounds = [20, 30, 40] * u.TeV
-        seg = SpectrumEnergyGroupMaker(obs=obs)
+        seg = SpectrumEnergyGroupMaker(e_reco=obs.e_reco)
         with pytest.raises(ValueError):
             seg.compute_groups_fixed(ebounds=ebounds)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -26,7 +26,7 @@ def simulate_dataset(model):
     )
     sim.run(seed=[0])
     obs = sim.result[0]
-    return SpectrumDatasetOnOff._from_spectrum_observation(obs)
+    return obs.to_spectrum_dataset()
 
 
 def define_energy_groups(dataset):

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -9,7 +9,6 @@ from ..energy_group import SpectrumEnergyGroupMaker
 from ..models import PowerLaw, ExponentialCutoffPowerLaw
 from ..simulation import SpectrumSimulation
 from ..flux_point import FluxPointEstimator
-from ..dataset import SpectrumDatasetOnOff
 
 
 # TODO: use pregenerate data instead

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
+import copy
 from collections import Counter
 import numpy as np
 from astropy.utils import lazyproperty
@@ -105,3 +106,7 @@ class Datasets:
             str_ += "\t{key}: {value} \n".format(key=key, value=value)
 
         return str_
+
+    def copy(self):
+        """A deep copy."""
+        return copy.deepcopy(self)

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -34,6 +34,10 @@ class Dataset(abc.ABC):
     def likelihood_per_bin(self):
         """Likelihood per bin given the current model parameters"""
 
+    def copy(self):
+        """A deep copy."""
+        return copy.deepcopy(self)
+
 
 class Datasets:
     """Join multiple datasets.
@@ -71,17 +75,17 @@ class Datasets:
         """List of datasets"""
         return self._datasets
 
-    @lazyproperty
+    @property
     def types(self):
         """Types of the contained datasets"""
         return [type(dataset).__name__ for dataset in self.datasets]
 
-    @lazyproperty
+    @property
     def is_all_same_type(self):
         """Whether all contained datasets are of the same type"""
         return np.all(np.array(self.types) == self.types[0])
 
-    @lazyproperty
+    @property
     def is_all_same_shape(self):
         """Whether all contained datasets have the same data shape"""
         ref_shape = self.datasets[0].data_shape

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -58,11 +58,13 @@ class Datasets:
 
         self.mask = mask
 
+    @lazyproperty
+    def parameters(self):
         # join parameter lists
         parameters = []
         for dataset in self.datasets:
             parameters += dataset.parameters.parameters
-        self.parameters = Parameters(parameters)
+        return Parameters(parameters)
 
     @property
     def datasets(self):

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -442,11 +442,13 @@
    "source": [
     "ebounds = EnergyBounds.equal_log_spacing(1, 40, 4, unit=u.TeV)\n",
     "\n",
-    "seg = SpectrumEnergyGroupMaker(obs=stacked_obs)\n",
+    "seg = SpectrumEnergyGroupMaker(e_reco=stacked_obs.e_reco)\n",
     "seg.compute_groups_fixed(ebounds=ebounds)\n",
     "\n",
+    "dataset = stacked_obs.to_spectrum_dataset()\n",
+    "\n",
     "fpe = FluxPointEstimator(\n",
-    "    obs=stacked_obs, groups=seg.groups, model=fit.result[0].model\n",
+    "    datasets=[dataset], groups=seg.groups, model=fit.result[0].model\n",
     ")\n",
     "flux_points = fpe.run()\n",
     "flux_points.table_formatted"

--- a/tutorials/pulsar_analysis.ipynb
+++ b/tutorials/pulsar_analysis.ipynb
@@ -488,11 +488,12 @@
    "outputs": [],
    "source": [
     "stacked_obs = extraction.spectrum_observations.stack()\n",
-    "seg = SpectrumEnergyGroupMaker(obs=stacked_obs)\n",
+    "seg = SpectrumEnergyGroupMaker(e_reco=stacked_obs.e_reco)\n",
     "\n",
     "seg.compute_groups_fixed(ebounds=ebounds)\n",
+    "dataset = stacked_obs.to_spectrum_dataset()\n",
     "fpe = FluxPointEstimator(\n",
-    "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model\n",
+    "    datasets=[dataset], groups=seg.groups, model=joint_result[0].model\n",
     ")\n",
     "flux_points = fpe.run()\n",
     "\n",
@@ -587,6 +588,13 @@
    "source": [
     "This tutorial suffers a bit from the lack of statistics: there were 9 Vela observations in the CTA DC1 while there is only one here. When done on the 9 observations, the spectral analysis is much better agreement between the input model and the gammapy fit."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -421,7 +421,7 @@
     "ebounds = np.logspace(np.log10(e_min), np.log10(e_max), 15) * u.TeV\n",
     "\n",
     "\n",
-    "seg = SpectrumEnergyGroupMaker(obs=stacked_obs)\n",
+    "seg = SpectrumEnergyGroupMaker(e_reco=stacked_obs.e_reco)\n",
     "seg.compute_groups_fixed(ebounds=ebounds)\n",
     "\n",
     "print(seg.groups)"
@@ -433,8 +433,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "dataset = stacked_obs.to_spectrum_dataset()\n",
+    "\n",
     "fpe = FluxPointEstimator(\n",
-    "    obs=stacked_obs, groups=seg.groups, model=joint_result[0].model\n",
+    "    datasets=[dataset], groups=seg.groups, model=joint_result[0].model\n",
     ")\n",
     "flux_points = fpe.run()"
    ]
@@ -564,6 +566,13 @@
    "source": [
     "# Start exercises here"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -582,7 +591,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR refactors the `FluxPointEstimator` to use `Datasets` instead of a `SpectrumObservationList`. It includes the following changes:

- Refactor `FluxPointEstimator` to take a list of `SpectrumDatasetOnOff` on input.
- Change the `SpectrumEnergyGroupMaker` to just take `e_reco` instead of a `SpectrumObservation` object (the only info used for now was `obs.e_reco`)
- Move `SpectrumDatasets._from_spectrum_observation()` to `SpectrumObservation.to_spectrum_dataset()` as a compatibility helper method for the transition phase to `SpectrumDataset` and `SpectrumDatasetOnOff`.

TODO:
- [x] Adapt tutorials to the changes