### PR TITLE
Partly refactor gammapy/spectrum/tests/test_fit.py to use SpectrumDataset

### DIFF
--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -77,16 +77,17 @@ class SpectrumDataset(Dataset):
 
     def npred(self):
         """Returns npred map (model + background)"""
-        model_npred = self.predictor.compute_npred().data.data
-        back_npred = self.background.data.data
-        total_npred = model_npred + back_npred
-        return total_npred
+        npred = self.predictor.compute_npred().data.data
+        if self.background:
+            npred += self.background.data.data
+        return npred
 
     def likelihood_per_bin(self):
         """Likelihood per bin given the current model parameters"""
         return cash(n_on=self.counts.data.data, mu_on=self.npred())
 
-    def likelihood(self, parameters, mask=None):
+    def likelihood(self, parameters=None
+                   , mask=None):
         """Total likelihood given the current model parameters.
 
         Parameters

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+from astropy import units as u
 from .observation import SpectrumObservation
 from .utils import SpectrumEvaluator
 from ..utils.fitting import Dataset, Parameters
@@ -126,6 +127,13 @@ class SpectrumDataset(Dataset):
         ebounds = self.counts.energy.bins
 
         return CountsSpectrum(ebounds[:-1], ebounds[1:], data)
+
+    @property
+    def energy_range(self):
+        """Energy range defined by the mask"""
+        e_lo = self.counts.energy.lo[self.mask]
+        e_hi = self.counts.energy.hi[self.mask]
+        return u.Quantity([e_lo.min(), e_hi.max()])
 
 
 class SpectrumDatasetOnOff(Dataset):
@@ -267,3 +275,10 @@ class SpectrumDatasetOnOff(Dataset):
         """
         observation = SpectrumObservation.read(filename)
         return observation.to_spectrum_dataset()
+
+    @property
+    def energy_range(self):
+        """Energy range defined by the mask"""
+        e_lo = self.counts_on.energy.lo[self.mask]
+        e_hi = self.counts_on.energy.hi[self.mask]
+        return u.Quantity([e_lo.min(), e_hi.max()])

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -300,10 +300,14 @@ class TestSpectralFit:
 
     def test_stacked_fit(self):
         stacked_obs = self.obs_list.stack()
-        obs_list = SpectrumObservationList([stacked_obs])
-        fit = SpectrumFit(obs_list, self.pwl)
-        fit.run()
-        pars = fit.result[0].model.parameters
+
+        dataset = stacked_obs.to_spectrum_dataset()
+        dataset.model = self.pwl
+
+        fit = Fit([dataset])
+        result = fit.run()
+        pars = result.parameters
+
         assert_allclose(pars["index"].value, 2.7767, rtol=1e-3)
         assert u.Unit(pars["amplitude"].unit) == "cm-2 s-1 TeV-1"
         assert_allclose(pars["amplitude"].value, 5.191e-11, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_results.py
+++ b/gammapy/spectrum/tests/test_results.py
@@ -51,7 +51,6 @@ class TestSpectrumFitResult:
     @requires_dependency("uncertainties")
     def test_basic(self, fit_result):
         assert "PowerLaw" in str(fit_result)
-        assert "index" in fit_result.to_table().colnames
 
     def test_io(self, tmpdir, fit_result):
         filename = tmpdir / "test.yaml"

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -486,7 +486,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(8, 6))\n",
-    "flux_points_dataset.peek()"
+    "flux_points_dataset.peek();"
    ]
   },
   {
@@ -518,22 +518,6 @@
    "source": [
     "stacked_result = stacked_fit.result\n",
     "print(stacked_result[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stacked_table = stacked_result[0].to_table(format=\".3g\")\n",
-    "stacked_table[\"method\"] = \"stacked\"\n",
-    "joint_table = joint_result[0].to_table(format=\".3g\")\n",
-    "joint_table[\"method\"] = \"joint\"\n",
-    "total_table = vstack_table([stacked_table, joint_table])\n",
-    "print(\n",
-    "    total_table[\"method\", \"index\", \"index_err\", \"amplitude\", \"amplitude_err\"]\n",
-    ")"
    ]
   },
   {


### PR DESCRIPTION
This PR partly refactors `gammapy/spectrum/tests/test_fit.py` to use `SpectrumDataset`, `SpectrumDatasetOnOff` and `Fit`. This is meant to be a first step towards refactoring the spectral analysis to use the `SpectrumDataset`, `SpectrumDatasetOnOff` and `Fit` classes. While implementing this, no numbers in the tests changed.