### PR TITLE
Fix pytest test collection in test_profile.py

### DIFF
--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -123,8 +123,8 @@ class TestImageProfile:
     def test_profile_x_edges(cosine_profile):
         assert_quantity_allclose(cosine_profile.x_ref.sum(), 0 * u.deg)
 
-    @pytest.mark.parametrize("kernel", ["gauss", "box"])
     @staticmethod
+    @pytest.mark.parametrize("kernel", ["gauss", "box"])
     def test_smooth(cosine_profile, kernel):
         # smoothing should preserve the mean
         desired_mean = cosine_profile.profile.mean()
@@ -135,8 +135,8 @@ class TestImageProfile:
         # smoothing should decrease errors
         assert smoothed.profile_err.mean() < cosine_profile.profile_err.mean()
 
-    @requires_dependency("matplotlib")
     @staticmethod
+    @requires_dependency("matplotlib")
     def test_peek(cosine_profile):
         with mpl_plot_check():
             cosine_profile.peek()


### PR DESCRIPTION
Locally I saw this pytest warning that two tests aren't collected:
```
$ pytest -v gammapy

Gammapy test data availability:
gammapy-data ... yes
Gammapy environment variables:
GAMMAPY_DATA = /Users/deil/work/gammapy-tutorials/datasets
Setting matplotlib backend to "agg" for the tests.
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.7.0, pytest-4.0.0, py-1.7.0, pluggy-0.8.0 -- /Users/deil/software/anaconda3/envs/gammapy-dev/bin/python
cachedir: .pytest_cache
rootdir: /Users/deil/work/code/gammapy, inifile: setup.cfg
plugins: remotedata-0.3.1, openfiles-0.3.0, mock-1.10.0, doctestplus-0.1.3, cov-2.6.0, arraydiff-0.2, hypothesis-3.68.0
collecting 463 items                                                                                                                                               /Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.7/site-packages/_pytest/mark/structures.py:236: PytestWarning: cannot collect 'test_smooth' because it is not a function.
  def __call__(self, *args, **kwargs):
/Users/deil/software/anaconda3/envs/gammapy-dev/lib/python3.7/site-packages/_pytest/mark/structures.py:236: PytestWarning: cannot collect 'test_peek' because it is not a function.
  def __call__(self, *args, **kwargs):
collected 1463 items                                                                                                                         
```

The warning doesn't seem to appear in CI (probably pytest version dependent), but one can see that these two tests aren't collected in CI here:
https://travis-ci.org/gammapy/gammapy/jobs/521154511#L2009-L2018

Simply exchanging the order of the decorators and putting `@staticmethod` first seems to resolve the issue - locally tests are collected and run for me.

Let's see what happens in the various CI builds ...