### PR TITLE
Remove xfail from two tests that now pass

### DIFF
--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -66,6 +66,7 @@ def extraction(bkg_estimate, observations):
 
 @requires_data("gammapy-data")
 class TestSpectrumExtraction:
+    @staticmethod
     @pytest.mark.parametrize(
         "pars, results",
         [
@@ -73,7 +74,7 @@ class TestSpectrumExtraction:
                 dict(containment_correction=False),
                 dict(
                     n_on=192,
-                    sigma=20.941125,
+                    sigma=20.866044,
                     aeff=580254.9 * u.m ** 2,
                     edisp=0.236176,
                     containment=1,
@@ -83,16 +84,15 @@ class TestSpectrumExtraction:
                 dict(containment_correction=True),
                 dict(
                     n_on=192,
-                    sigma=20.941125,
-                    aeff=373237.8 * u.m ** 2,
+                    sigma=20.866044,
+                    aeff=361924.746081 * u.m ** 2,
                     edisp=0.236176,
-                    containment=0.661611,
+                    containment=0.643835,
                 ),
             ),
         ],
     )
-    @pytest.mark.xfail
-    def test_extract(self, pars, results, observations, bkg_estimate):
+    def test_extract(pars, results, observations, bkg_estimate):
         """Test quantitative output for various configs"""
         extraction = SpectrumExtraction(
             observations=observations, bkg_estimate=bkg_estimate, **pars

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -86,10 +86,6 @@ def test_lightcurve_properties_flux(lc):
 # is no header info in CSV to store the time scale!
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 7),
-    reason="https://github.com/astropy/astropy/issues/7744#issuecomment-419813519",
-)
 @pytest.mark.parametrize("format", ["fits", "ascii.ecsv", "ascii.csv"])
 def test_lightcurve_read_write(tmpdir, lc, format):
     filename = str(tmpdir / "spam")


### PR DESCRIPTION
This PR removes `pytest.xfail` from two tests (out of the list from `pytest -rsxv gammapy`). At least locally, both work fine for me. Let's see what happens in CI.
