### PR TITLE
Add naima spectral models

### DIFF
--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1550,6 +1550,7 @@ class NaimaModel(SpectralModel):
         plt.legend(loc='best')
         plt.show()
     """
+    import naima.models as naima_models
     import naima.radiative as naima_radiative
 
     #TODO: prevent users from setting new attributes after init
@@ -1560,13 +1561,13 @@ class NaimaModel(SpectralModel):
         self.distance = Parameter("distance", distance, frozen=True)
         self.seed = seed
 
-        parameters = []
-        try:
-            param_names = self._particle_distribution.param_names
-        except:
-            # This ensures the support of naima.models.TableModel
+        # This ensures the support of naima.models.TableModel
+        if isinstance(self._particle_distribution, naima_models.TableModel):
             param_names = ["amplitude"]
+        else:
+            param_names = self._particle_distribution.param_names
 
+        parameters = []
         for name in param_names:
             value = getattr(self._particle_distribution, name)
             setattr(self, name, Parameter(name, value))
@@ -1595,7 +1596,7 @@ class NaimaModel(SpectralModel):
 
         if isinstance(rm, naima_radiative.BaseElectron):
             w = rm.compute_We(Eemin=Emin, Eemax=Emax)
-        elif isinstance(rm, naima_radiative.BaseProton):
+        else:
             w = rm.compute_Wp(Epmin=Emin, Epmax=Emax)
 
         return w

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1476,8 +1476,8 @@ class NaimaModel(SpectralModel):
         self.distance = Parameter("distance", distance)
 
         parameters = []
-        model_parameters = self.radiative_model.particle_distribution.__dict__
-        for (name, quantity) in model_parameters.items():
+        parameters_dict = self.radiative_model.particle_distribution.__dict__
+        for (name, quantity) in parameters_dict.items():
             if name[0] == "_" or name == "unit":
                 continue
             parameters.append(Parameter(name, quantity))
@@ -1503,13 +1503,12 @@ class NaimaModel(SpectralModel):
 
     def freeze(self, name, freeze=True):
         """"""
-        parameters = self.parameters.parameters
-        for parameter in parameters:
-            if parameter.name == name:
-                parameter.frozen = freeze
-                return
+        try:
+            par_idx = self.parameters._get_idx(name)
+        except:
+            raise AttributeError("Parameter {} not found".format(name))
 
-        raise AttributeError("Parameter {} not found".format(name))
+        self.parameters.parameters[par_idx].frozen = freeze
 
     @staticmethod
     def evaluate(energy, radiative_model, seed, distance, kwargs):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1550,6 +1550,7 @@ class NaimaModel(SpectralModel):
         plt.legend(loc='best')
         plt.show()
     """
+    import naima.radiative as naima_radiative
 
     #TODO: prevent users from setting new attributes after init
 
@@ -1572,12 +1573,10 @@ class NaimaModel(SpectralModel):
             parameters.append(getattr(self, name))
 
         # In case of a synchrotron radiative model, append B to the fittable parameters
-        try:
+        if 'B' in self.radiative_model.param_names:
             B = getattr(self.radiative_model, "B")
             setattr(self, "B", Parameter("B", B))
             parameters.append(getattr(self, "B"))
-        except:
-            pass
 
         super().__init__(parameters)
 
@@ -1592,10 +1591,12 @@ class NaimaModel(SpectralModel):
         Emax : :class:`~astropy.units.Quantity`, float optional
             Maximum particle energy for energy content calculation.
         """
-        try:
-            w = self.radiative_model.compute_We(Eemin=Emin, Eemax=Emax)
-        except:
-            w = self.radiative_model.compute_Wp(Epmin=Emin, Epmax=Emax)
+        self.radiative_model = rm
+
+        if isinstance(rm, naima_radiative.BaseElectron):
+            w = rm.compute_We(Eemin=Emin, Eemax=Emax)
+        elif isinstance(rm, naima_radiative.BaseProton):
+            w = rm.compute_Wp(Epmin=Emin, Epmax=Emax)
 
         return w
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -5,7 +5,6 @@ import numpy as np
 from scipy.optimize import brentq
 import astropy.units as u
 from astropy.table import Table
-import naima
 from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.scripts import make_path
@@ -1550,6 +1549,8 @@ class NaimaModel(SpectralModel):
         plt.legend(loc='best')
         plt.show()
     """
+    import naima
+
     #TODO: prevent users from setting new attributes after init
 
     def __init__(self, radiative_model, distance=1.0 * u.kpc, seed=None):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1470,7 +1470,7 @@ class AbsorbedSpectralModel(SpectralModel):
 class NaimaModel(SpectralModel):
     r"""A wrapper for `Naima <https://naima.readthedocs.io/en/latest/>`_ models
 
-    This class provides an interface with the models defined in the `naima.models` module.
+    This class provides an interface with the models defined in the `~naima.models` module.
     The model accepts as a positional argument a Naima
     `radiative model <https://naima.readthedocs.io/en/latest/radiative.html>`_ instance, used
     to compute the non-thermal emission from populations of relativistic electrons or protons
@@ -1481,21 +1481,21 @@ class NaimaModel(SpectralModel):
     `fit to flux points <https://naima.readthedocs.io/en/latest/mcmc.html>`_ featured in
     Naima. All the parameters defining the parent population of charged particles are stored as
     `~gammapy.utils.modeling.Parameter` and left free by default.
-    In case that the radiative model is `naima.radiative.Synchrotron`,
+    In case that the radiative model is `~naima.radiative.Synchrotron`,
     the magnetic field strength may also be fitted. Parameters can be freezed/unfreezed before the fit, and
     maximum/minimum values can be set to limit the parameters space to the physically interesting region
     (see the example below).
 
     Parameters
     ----------
-    radiative_model :
+    radiative_model : `~naima.models.BaseRadiative`
         An instance of a radiative model defined in `~naima.models`
     distance : `~astropy.units.Quantity`, optional
         Distance to the source. If set to 0, the intrinsic differential
         luminosity will be returned. Default is 1 kpc
     seed : str or list of str, optional
         Seed photon field(s) to be considered for the `radiative_model` flux computation,
-        in case of a `naima.models.InverseCompton` model. It can be a subset of the
+        in case of a `~naima.models.InverseCompton` model. It can be a subset of the
         `seed_photon_fields` list defining the `radiative_model`. Default is the whole list
         of photon fields
 
@@ -1515,7 +1515,7 @@ class NaimaModel(SpectralModel):
 
         particle_distribution = naima.models.ExponentialCutoffPowerLaw(1e30 / u.eV, 10 * u.TeV, 3.0, 30 * u.TeV)
         radiative_model = naima.radiative.InverseCompton(
-            ECPL,
+            particle_distribution,
             seed_photon_fields=[
                 "CMB",
                 ["FIR", 26.5 * u.K, 0.415 * u.eV / u.cm ** 3],
@@ -1524,13 +1524,6 @@ class NaimaModel(SpectralModel):
         )
 
         model = NaimaModel(radiative_model, distance=1.5 * u.kpc)
-
-        # Parameters are all left free by default. They can be freezed like this:
-        IC.e_0.frozen=True
-        IC.beta.frozen=True
-
-        # Plot the model
-        fig, ax = plt.subplots(figsize=(8, 6))
 
         opts = {
             "energy_range" : [10 * u.GeV, 80 * u.TeV],
@@ -1544,7 +1537,7 @@ class NaimaModel(SpectralModel):
         # Plot the separate contributions from each seed photon field
         for seed, ls in zip(['CMB','FIR'], ['-','--']):
             model = NaimaModel(radiative_model, seed=seed, distance=1.5 * u.kpc)
-                model.plot(label="IC ({})".format(seed), ls=ls, color="gray", **opts)
+            model.plot(label="IC ({})".format(seed), ls=ls, color="gray", **opts)
 
         plt.legend(loc='best')
         plt.show()
@@ -1579,25 +1572,6 @@ class NaimaModel(SpectralModel):
 
         super().__init__(parameters)
 
-    def compute_W(self, Emin=None, Emax=None):
-        """Energy in elecrons or protons (depending on the model), between Emin and Emax.
-        If Emin and Emax are not passed, the total enery in elecrons/protons is returned.
-
-        Parameters
-        ----------
-        Emin : :class:`~astropy.units.Quantity`, float optional
-            Minimum particle energy for energy content calculation.
-        Emax : :class:`~astropy.units.Quantity`, float optional
-            Maximum particle energy for energy content calculation.
-        """
-        self.radiative_model = rm
-
-        if isinstance(rm, naima.radiative.BaseElectron):
-            w = rm.compute_We(Eemin=Emin, Eemax=Emax)
-        else:
-            w = rm.compute_Wp(Epmin=Emin, Epmax=Emax)
-
-        return w
 
     def evaluate(self, energy, **kwargs):
         """Evaluate the model"""

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -4,7 +4,6 @@ import operator
 import numpy as np
 from scipy.optimize import brentq
 import astropy.units as u
-from astropy.constants import c
 from astropy.table import Table
 from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
@@ -1470,30 +1469,20 @@ class AbsorbedSpectralModel(SpectralModel):
 
 class NaimaModel(SpectralModel):
     r""""""
-    from naima import models
-
     __slots__ = ["radiative_model", "distance"]
 
     def __init__(self, radiative_model, distance=1.0 * u.kpc):
         self.radiative_model = radiative_model
-        self.distance = Parameter("distance", distance, frozen=True)
-        parameters = []
+        self.distance = Parameter("distance", distance)
 
+        parameters = []
         model_parameters = self.radiative_model.particle_distribution.__dict__
         for (name, quantity) in model_parameters.items():
             if name[0] == "_" or name == "unit":
                 continue
             parameters.append(Parameter(name, quantity))
 
-        try:
-            B = self.radiative_model.B
-            parameters.append(Parameter("B", B))
-        except:
-            pass
-
         super().__init__(parameters)
-        #     add the possibility to normalize using the (observed) gamma-ray energy flux
-        #     change the test and the doc
 
     def __call__(self, energy, seed=None, distance=None):
         """Call evaluate method"""
@@ -1525,11 +1514,6 @@ class NaimaModel(SpectralModel):
     @staticmethod
     def evaluate(energy, radiative_model, seed, distance, kwargs):
         """Evaluate the model (static function)."""
-        try:
-            radiative_model.B = kwargs.pop("B").quantity
-        except:
-            pass
-
         parameters_dict = radiative_model.particle_distribution.__dict__
         for key, value in kwargs.items():
             parameters_dict[key] = kwargs.get(key, value)

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.optimize import brentq
 import astropy.units as u
 from astropy.table import Table
+import naima
 from ..utils.energy import EnergyBounds
 from ..utils.nddata import NDDataArray, BinnedDataAxis
 from ..utils.scripts import make_path
@@ -1477,8 +1478,7 @@ class NaimaModel(SpectralModel):
     due to interactions with the ISM or with radiation and magnetic fields.
 
     One of the advantages provided by this class consists in the possibility of performing a maximum
-    likelihood spectral fit of the model's parameters
-    directly on observations (using the `gammapy.spectrum.SpectrumFit` class), as opposed to the MCMC
+    likelihood spectral fit of the model's parameters directly on observations, as opposed to the MCMC
     `fit to flux points <https://naima.readthedocs.io/en/latest/mcmc.html>`_ featured in
     Naima. All the parameters defining the parent population of charged particles are stored as
     `~gammapy.utils.modeling.Parameter` and left free by default.
@@ -1550,9 +1550,6 @@ class NaimaModel(SpectralModel):
         plt.legend(loc='best')
         plt.show()
     """
-    import naima.models as naima_models
-    import naima.radiative as naima_radiative
-
     #TODO: prevent users from setting new attributes after init
 
     def __init__(self, radiative_model, distance=1.0 * u.kpc, seed=None):
@@ -1562,7 +1559,7 @@ class NaimaModel(SpectralModel):
         self.seed = seed
 
         # This ensures the support of naima.models.TableModel
-        if isinstance(self._particle_distribution, naima_models.TableModel):
+        if isinstance(self._particle_distribution, naima.models.TableModel):
             param_names = ["amplitude"]
         else:
             param_names = self._particle_distribution.param_names
@@ -1594,7 +1591,7 @@ class NaimaModel(SpectralModel):
         """
         self.radiative_model = rm
 
-        if isinstance(rm, naima_radiative.BaseElectron):
+        if isinstance(rm, naima.radiative.BaseElectron):
             w = rm.compute_We(Eemin=Emin, Eemax=Emax)
         else:
             w = rm.compute_Wp(Epmin=Emin, Epmax=Emax)

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1468,23 +1468,21 @@ class AbsorbedSpectralModel(SpectralModel):
 
 
 class NaimaModel(SpectralModel):
-    r"""A wrapper for `Naima <https://naima.readthedocs.io/en/latest/>`_ models
+    r"""A wrapper for Naima models
 
     This class provides an interface with the models defined in the `~naima.models` module.
-    The model accepts as a positional argument a Naima
-    `radiative model <https://naima.readthedocs.io/en/latest/radiative.html>`_ instance, used
-    to compute the non-thermal emission from populations of relativistic electrons or protons
-    due to interactions with the ISM or with radiation and magnetic fields.
+    The model accepts as a positional argument a `Naima <https://naima.readthedocs.io/en/latest/>`_
+    radiative model instance, used to compute the non-thermal emission from populations of
+    relativistic electrons or protons due to interactions with the ISM or with radiation and magnetic fields.
 
     One of the advantages provided by this class consists in the possibility of performing a maximum
     likelihood spectral fit of the model's parameters directly on observations, as opposed to the MCMC
     `fit to flux points <https://naima.readthedocs.io/en/latest/mcmc.html>`_ featured in
     Naima. All the parameters defining the parent population of charged particles are stored as
-    `~gammapy.utils.modeling.Parameter` and left free by default.
-    In case that the radiative model is `~naima.radiative.Synchrotron`,
-    the magnetic field strength may also be fitted. Parameters can be freezed/unfreezed before the fit, and
-    maximum/minimum values can be set to limit the parameters space to the physically interesting region
-    (see the example below).
+    `~gammapy.utils.modeling.Parameter` and left free by default. In case that the radiative model is `
+    ~naima.radiative.Synchrotron`, the magnetic field strength may also be fitted. Parameters can be
+    freezed/unfreezed before the fit, and maximum/minimum values can be set to limit the parameters space to
+    the physically interesting region.
 
     Parameters
     ----------
@@ -1542,8 +1540,6 @@ class NaimaModel(SpectralModel):
         plt.legend(loc='best')
         plt.show()
     """
-    import naima
-
     #TODO: prevent users from setting new attributes after init
 
     def __init__(self, radiative_model, distance=1.0 * u.kpc, seed=None):

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1547,6 +1547,7 @@ class NaimaModel(SpectralModel):
     #TODO: prevent users from setting new attributes after init
 
     def __init__(self, radiative_model, distance=1.0 * u.kpc, seed=None):
+        import naima
         self.radiative_model = radiative_model
         self._particle_distribution = self.radiative_model.particle_distribution
         self.distance = Parameter("distance", distance, frozen=True)

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -194,37 +194,6 @@ try:
 except ImportError:
     pass
 
-# Add compound models
-TEST_MODELS.append(
-    dict(
-        name="compound1",
-        model=TEST_MODELS[0]["model"] * 5,
-        val_at_2TeV=TEST_MODELS[0]["val_at_2TeV"] * 5,
-        integral_1_10TeV=TEST_MODELS[0]["integral_1_10TeV"] * 5,
-        eflux_1_10TeV=TEST_MODELS[0]["eflux_1_10TeV"] * 5,
-    )
-)
-
-TEST_MODELS.append(
-    dict(
-        name="compound2",
-        model=5 * TEST_MODELS[0]["model"],
-        val_at_2TeV=TEST_MODELS[0]["val_at_2TeV"] * 5,
-        integral_1_10TeV=TEST_MODELS[0]["integral_1_10TeV"] * 5,
-        eflux_1_10TeV=TEST_MODELS[0]["eflux_1_10TeV"] * 5,
-    )
-)
-
-TEST_MODELS.append(
-    dict(
-        name="compound3",
-        model=TEST_MODELS[0]["model"] + TEST_MODELS[0]["model"],
-        val_at_2TeV=TEST_MODELS[0]["val_at_2TeV"] * 2,
-        integral_1_10TeV=TEST_MODELS[0]["integral_1_10TeV"] * 2,
-        eflux_1_10TeV=TEST_MODELS[0]["eflux_1_10TeV"] * 2,
-    )
-)
-
 # Add Naima models
 particle_distributions = [
     models.PowerLaw(amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5),

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-from naima import models, radiative
+import naima
 import astropy.units as u
 from ...utils.energy import EnergyBounds
 from ...utils.testing import assert_quantity_allclose
@@ -196,8 +196,8 @@ except ImportError:
 
 # Add Naima models
 particle_distributions = [
-    models.PowerLaw(amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5),
-    models.ExponentialCutoffBrokenPowerLaw(
+    naima.models.PowerLaw(amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5),
+    naima.models.ExponentialCutoffBrokenPowerLaw(
         amplitude=2e33 / u.eV,
         e_0=10 * u.TeV,
         alpha_1=2.5,
@@ -205,12 +205,12 @@ particle_distributions = [
         e_break=900 * u.GeV,
         e_cutoff=10 * u.TeV,
     ),
-    models.LogParabola(amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=1.3, beta=0.5),
+    naima.models.LogParabola(amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=1.3, beta=0.5),
 ]
 radiative_models = [
-    radiative.PionDecay(particle_distributions[0], nh=1 * u.cm ** -3),
-    radiative.InverseCompton(particle_distributions[1], seed_photon_fields=["CMB"]),
-    radiative.Synchrotron(particle_distributions[2], B=2 * u.G),
+    naima.radiative.PionDecay(particle_distributions[0], nh=1 * u.cm ** -3),
+    naima.radiative.InverseCompton(particle_distributions[1], seed_photon_fields=["CMB"]),
+    naima.radiative.Synchrotron(particle_distributions[2], B=2 * u.G),
 ]
 
 TEST_MODELS.append(
@@ -245,6 +245,7 @@ TEST_MODELS.append(
 
 
 @requires_dependency("uncertainties")
+@requires_dependency("naima")
 @pytest.mark.parametrize("spectrum", TEST_MODELS, ids=[_["name"] for _ in TEST_MODELS])
 def test_models(spectrum):
     model = spectrum["model"]


### PR DESCRIPTION
This PR introduces a preliminary implementation for a interface with Naima models. 

A few things are still not in place (see the TODO list), but I would like to receive some feedback before carrying on!

I have added a new `SpectralModel`, called `NaimaModel`. The purpose of this class is wrapping the models defined in `naima.models/naima.radiative`, i.e. translating the parameters in a format that allows to perform a spectral fit directly within gammapy.

In this implementation, the user is supposed to have his own Naima installation. He needs to define a particle distribution and a radiative model, and pass the latter as an argument to a new NaimaModel instance:
```
 >>> particle_distribution = Naima.models.ExponentialCutoffPowerLaw(
 ...       amplitude =1e34 / u.eV,
 ...           e_0 =3 * u.TeV,
 ...           alpha = 2.7,
 ...           e_cutoff =10 * u.TeV,
... )
>>> radiative_model = Naima.radiative.InverseCompton(
...            particle_distribution,
...            seed_photon_fields=["CMB"],
...            Eemin=100 * u.GeV,
... )
>>> model = NaimaModel(radiative_model)
```

The model parameters and are left free by default. They can be freezed/unfreezed through the `.freeze()`method:
```
>>> model.parameters.parameters
[Parameter(name='amplitude', value=1e+34, factor=1e+34, scale=1.0, unit='eV-1', min=nan, max=nan, frozen=False),
 Parameter(name='e_0', value=3.0, factor=3.0, scale=1.0, unit='TeV', min=nan, max=nan, frozen=False),
 Parameter(name='alpha', value=2.7, factor=2.7, scale=1.0, unit='', min=nan, max=nan, frozen=False),
 Parameter(name='e_cutoff', value=10.0, factor=10.0, scale=1.0, unit='TeV', min=nan, max=nan, frozen=False),
 Parameter(name='beta', value=1.0, factor=1.0, scale=1.0, unit='', min=nan, max=nan, frozen=False)]
>>> model.freeze('e_0')
>>> model.freeze('beta')
```
The distance to the source is 1 kpc by default, but can be changed. In the case of an inverse Compton radiative model, instantiated with  a list of `seed_photon_fields`, the model can still be evaluated using only a subset of that list. This might be useful, for example, for plotting purpose: indeed, one may want to see a different curve for each separate photon field.

As a test, I have reproduced the joint-crab paper fit (see the [notebook)](https://github.com/open-gamma-ray-astro/joint-crab/blob/master/4_naima.ipynb).

TODO:

- Implement a way to set min/max values for the parameters;
- add the possibility to fit the magnetic field strenght;
- add a way to access the total energy in electrons/protons (useful to check if the fit result is realistic)
- give the possibility to normalize the model using the (observed) gamma-ray flux, instead of the `amplitude` of the particle distribution. (Not easy probably) 
- add documentation (possibly including an example)

Any idea or comment is welcome! Cheers