### PR TITLE
Enforce sorting of  MapAxis 

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -462,6 +462,8 @@ class MapAxis:
             nnode = nbin
         else:
             raise ValueError("Invalid node type: {!r}".format(node_type))
+        if lo_bnd == hi_bnd:
+            raise ValueError("MapAxis: Bound values must be unique")
 
         if interp == "lin":
             nodes = np.linspace(lo_bnd, hi_bnd, nnode)
@@ -495,6 +497,8 @@ class MapAxis:
             raise ValueError("Nodes array must have at least one element.")
         if len(nodes) != len(np.unique(nodes)):
             raise ValueError("MapAxis: node values must be unique")
+        if ~(np.all(nodes == np.sort(nodes)) or np.all(nodes[::-1] == np.sort(nodes))):
+            raise ValueError("MapAxis: node values must be sorted")
 
         return cls(nodes, node_type="center", **kwargs)
 
@@ -518,6 +522,8 @@ class MapAxis:
             raise ValueError("Edges array must have at least two elements.")
         if len(edges) != len(np.unique(edges)):
             raise ValueError("MapAxis: edge values must be unique")
+        if ~(np.all(edges == np.sort(edges)) or np.all(edges[::-1] == np.sort(edges))):
+            raise ValueError("MapAxis: edge values must be sorted")
 
         return cls(edges, node_type="edges", **kwargs)
 
@@ -645,7 +651,6 @@ class MapAxis:
         """Copy `MapAxis` object"""
         return copy.deepcopy(self)
 
-
     def group_table(self, edges):
         """Compute bin groups table for the map axis, given coarser bin edges.
 
@@ -700,8 +705,9 @@ class MapAxis:
                 "idx_min": edge_idx_end + 1,
                 "idx_max": self.nbin - 1,
                 "{}_min".format(self.name): edge_ref_end,
-                "{}_max".format(self.name): self.pix_to_coord(self.nbin - 0.5) * self.unit,
-                }
+                "{}_max".format(self.name): self.pix_to_coord(self.nbin - 0.5)
+                * self.unit,
+            }
             groups.add_row(vals=overflow)
 
         group_idx = Column(np.arange(len(groups)))

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -340,7 +340,13 @@ class MapAxis:
     # TODO: Cache an interpolation object?
 
     def __init__(self, nodes, interp="lin", name="", node_type="edges", unit=""):
+
         self.name = name
+
+        if len(nodes) != len(np.unique(nodes)):
+            raise ValueError("MapAxis: node values must be unique")
+        if ~(np.all(nodes == np.sort(nodes)) or np.all(nodes[::-1] == np.sort(nodes))):
+            raise ValueError("MapAxis: node values must be sorted")
 
         if isinstance(nodes, u.Quantity):
             unit = nodes.unit
@@ -462,8 +468,6 @@ class MapAxis:
             nnode = nbin
         else:
             raise ValueError("Invalid node type: {!r}".format(node_type))
-        if lo_bnd == hi_bnd:
-            raise ValueError("MapAxis: Bound values must be unique")
 
         if interp == "lin":
             nodes = np.linspace(lo_bnd, hi_bnd, nnode)
@@ -495,10 +499,6 @@ class MapAxis:
         """
         if len(nodes) < 1:
             raise ValueError("Nodes array must have at least one element.")
-        if len(nodes) != len(np.unique(nodes)):
-            raise ValueError("MapAxis: node values must be unique")
-        if ~(np.all(nodes == np.sort(nodes)) or np.all(nodes[::-1] == np.sort(nodes))):
-            raise ValueError("MapAxis: node values must be sorted")
 
         return cls(nodes, node_type="center", **kwargs)
 
@@ -520,10 +520,6 @@ class MapAxis:
         """
         if len(edges) < 2:
             raise ValueError("Edges array must have at least two elements.")
-        if len(edges) != len(np.unique(edges)):
-            raise ValueError("MapAxis: edge values must be unique")
-        if ~(np.all(edges == np.sort(edges)) or np.all(edges[::-1] == np.sort(edges))):
-            raise ValueError("MapAxis: edge values must be sorted")
 
         return cls(edges, node_type="edges", **kwargs)
 

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -31,6 +31,7 @@ def test_mapaxis_init_from_edges(edges, interp):
     with pytest.raises(ValueError):
         MapAxis.from_edges([1])
         MapAxis.from_edges([0, 1, 1, 2])
+        MapAxis.from_edges([0, 1, 3, 2])
 
 
 @pytest.mark.parametrize(("nodes", "interp"), mapaxis_geoms)
@@ -41,6 +42,7 @@ def test_mapaxis_from_nodes(nodes, interp):
     with pytest.raises(ValueError):
         MapAxis.from_nodes([])
         MapAxis.from_nodes([0, 1, 1, 2])
+        MapAxis.from_nodes([0, 1, 3, 2])
 
 
 @pytest.mark.parametrize(("nodes", "interp"), mapaxis_geoms)
@@ -49,6 +51,8 @@ def test_mapaxis_from_bounds(nodes, interp):
     assert_allclose(axis.edges[0], nodes[0])
     assert_allclose(axis.edges[-1], nodes[-1])
     assert_allclose(axis.nbin, 3)
+    with pytest.raises(ValueError):
+        MapAxis.from_bounds(1, 1, 1)
 
 
 @pytest.mark.parametrize(("nodes", "interp", "node_type"), mapaxis_geoms_node_type)
@@ -288,9 +292,9 @@ def test_group_table_basic(energy_axis_ref):
     bin_type = [_.strip() for _ in groups["bin_type"]]
     assert_equal(bin_type, ["normal", "normal"])
 
+
 @pytest.mark.parametrize(
-    "e_edges",
-    [[1.8, 4.8, 7.2] * u.TeV, [2, 5, 7] * u.TeV, [2000, 5000, 7000] * u.GeV],
+    "e_edges", [[1.8, 4.8, 7.2] * u.TeV, [2, 5, 7] * u.TeV, [2000, 5000, 7000] * u.GeV]
 )
 def test_group_table_edges(energy_axis_ref, e_edges):
     groups = energy_axis_ref.group_table(e_edges)


### PR DESCRIPTION
This PR addresses #2061 . The MapAxis are now enforced to be sorted during input.
The question of how to deal with `labelled axis` such as IRF classes or MC ids is left open for the time being.