### PR TITLE
Add MapAxis.upsample() and MapAxis.downsample() methods

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -505,7 +505,7 @@ class Map(metaclass=MapMeta):
         pass
 
     @abc.abstractmethod
-    def downsample(self, factor, preserve_counts=True):
+    def downsample(self, factor, preserve_counts=True, axis=None):
         """Downsample the spatial dimension by a given factor.
 
         Parameters
@@ -516,6 +516,8 @@ class Map(metaclass=MapMeta):
             Preserve the integral over each bin.  This should be true
             if the map is an integral quantity (e.g. counts) and false if
             the map is a differential quantity (e.g. intensity).
+        axis : str
+            Which axis to downsample. By default spatial axes are downsampled.
 
         Returns
         -------
@@ -525,7 +527,7 @@ class Map(metaclass=MapMeta):
         pass
 
     @abc.abstractmethod
-    def upsample(self, factor, order=0, preserve_counts=True):
+    def upsample(self, factor, order=0, preserve_counts=True, axis=None):
         """Upsample the spatial dimension by a given factor.
 
         Parameters
@@ -538,6 +540,9 @@ class Map(metaclass=MapMeta):
             Preserve the integral over each bin.  This should be true
             if the map is an integral quantity (e.g. counts) and false if
             the map is a differential quantity (e.g. intensity).
+        axis : str
+            Which axis to upsample. By default spatial axes are upsampled.
+
 
         Returns
         -------

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1460,13 +1460,15 @@ class MapGeom(metaclass=MapGeomMeta):
         pass
 
     @abc.abstractmethod
-    def downsample(self, factor):
+    def downsample(self, factor, axis):
         """Downsample the spatial dimension of the geometry by a given factor.
 
         Parameters
         ----------
         factor : int
             Downsampling factor.
+        axis : str
+            Axis to downsample.
 
         Returns
         -------
@@ -1477,13 +1479,15 @@ class MapGeom(metaclass=MapGeomMeta):
         pass
 
     @abc.abstractmethod
-    def upsample(self, factor):
+    def upsample(self, factor, axis):
         """Upsample the spatial dimension of the geometry by a given factor.
 
         Parameters
         ----------
         factor : int
             Upsampling factor.
+        axis : str
+            Axis to upsample.
 
         Returns
         -------

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -729,7 +729,8 @@ class MapAxis:
             nbin=nbin,
             interp=self.interp,
             node_type=self.node_type,
-            unit=self.unit
+            unit=self.unit,
+            name=self.name
         )
 
     def upsample(self, factor):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -420,6 +420,11 @@ class MapAxis:
         return self.pix_to_coord(pix)
 
     @property
+    def interp(self):
+        """Map axis interpolation mode"""
+        return self._interp
+
+    @property
     def nbin(self):
         """Return number of bins."""
         return self._nbin

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -710,6 +710,59 @@ class MapAxis:
         groups.add_column(group_idx, name="group_idx", index=0)
         return groups
 
+    def _up_down_sample(self, nbin):
+        if self.node_type == "edges":
+            nodes = self.edges
+        else:
+            nodes = self.center
+
+        lo_bnd, hi_bnd = nodes.min(), nodes.max()
+
+        return self.from_bounds(
+            lo_bnd=lo_bnd,
+            hi_bnd=hi_bnd,
+            nbin=nbin,
+            interp=self.interp,
+            node_type=self.node_type,
+            unit=self.unit
+        )
+
+    def upsample(self, factor):
+        """Upsample map axis by a given factor.
+
+        Parameters
+        ----------
+        factor : int
+            Upsampling factor.
+
+
+        Returns
+        -------
+        axis : `MapAxis`
+            Usampled map axis.
+
+        """
+        nbin = self.nbin * factor
+        return self._up_down_sample(nbin)
+
+    def downsample(self, factor):
+        """Downsample map axis by a given factor.
+
+        Parameters
+        ----------
+        factor : int
+            Downsampling factor.
+
+
+        Returns
+        -------
+        axis : `MapAxis`
+            Downsampled map axis.
+
+        """
+        nbin = int(self.nbin / factor)
+        return self._up_down_sample(nbin)
+
 
 class MapCoord:
     """Represents a sequence of n-dimensional map coordinates.

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -272,6 +272,30 @@ def test_squash():
     assert_allclose(ax_sq.center, 1.5)
 
 
+def test_upsample():
+    axis = MapAxis(
+        nodes=[0, 1, 2, 3], unit="TeV", name="energy", node_type="edges", interp="lin"
+    )
+    axis_up =  axis.upsample(10)
+
+    assert_allclose(axis_up.nbin, 10 * axis.nbin)
+    assert_allclose(axis_up.edges[0], axis.edges[0])
+    assert_allclose(axis_up.edges[-1], axis.edges[-1])
+    assert axis_up.node_type == axis.node_type
+
+
+def test_downsample():
+    axis = MapAxis(
+        nodes=[0, 1, 2, 3, 4, 5, 6, 7, 8], unit="TeV", name="energy", node_type="edges", interp="lin"
+    )
+    axis_down =  axis.downsample(2)
+
+    assert_allclose(axis_down.nbin, 0.5 * axis.nbin)
+    assert_allclose(axis_down.edges[0], axis.edges[0])
+    assert_allclose(axis_down.edges[-1], axis.edges[-1])
+    assert axis_down.node_type == axis.node_type
+
+
 @pytest.fixture(scope="session")
 def energy_axis_ref():
     edges = np.arange(1, 11) * u.TeV

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -451,9 +451,30 @@ def test_wcsndmap_upsample(npix, binsz, coordsys, proj, skydir, axes):
         npix=npix, binsz=binsz, proj=proj, coordsys=coordsys, axes=axes
     )
     m = WcsNDMap(geom, unit="m2")
-    m2 = m.upsample(2, order=0, preserve_counts=True)
+    m2 = m.upsample(2, preserve_counts=True)
     assert_allclose(np.nansum(m.data), np.nansum(m2.data))
     assert m.unit == m2.unit
+
+
+def test_wcsndmap_upsample_axis():
+    axis = MapAxis.from_nodes([1, 2, 3, 4], name="test")
+    geom = WcsGeom.create(npix=(4, 4), axes=[axis])
+    m = WcsNDMap(geom, unit="m2")
+    m.data += 1
+
+    m2 = m.upsample(2, preserve_counts=True, axis="test")
+    assert m2.data.shape == (8, 4, 4)
+    assert_allclose(m.data.sum(), m2.data.sum())
+
+
+def test_wcsndmap_downsample_axis():
+    axis = MapAxis.from_nodes([1, 2, 3, 4], name="test")
+    geom = WcsGeom.create(npix=(4, 4), axes=[axis])
+    m = WcsNDMap(geom, unit="m2")
+    m.data += 1
+
+    m2 = m.downsample(2, preserve_counts=True, axis="test")
+    assert m2.data.shape == (2, 4, 4)
 
 
 def test_coadd_unit():

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -738,6 +738,10 @@ class WcsGeom(MapGeom):
             wcs = get_resampled_wcs(self.wcs, factor, True)
             return self._init_copy(wcs=wcs, npix=npix, cdelt=cdelt)
         else:
+            if not self.is_regular:
+                raise NotImplementedError("Upsamling in non-spatial axes not"
+                                          " support for irregular geometries")
+
             axes = copy.deepcopy(self.axes)
             idx = self.get_axis_index_by_name(axis)
             axes[idx] = axes[idx].downsample(factor)
@@ -751,6 +755,9 @@ class WcsGeom(MapGeom):
             wcs = get_resampled_wcs(self.wcs, factor, False)
             return self._init_copy(wcs=wcs, npix=npix, cdelt=cdelt)
         else:
+            if not self.is_regular:
+                raise NotImplementedError("Upsamling in non-spatial axes not"
+                                          " support for irregular geometries")
             axes = copy.deepcopy(self.axes)
             idx = self.get_axis_index_by_name(axis)
             axes[idx] = axes[idx].upsample(factor)

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -380,10 +380,14 @@ class WcsNDMap(WcsMap):
 
         return map_out
 
-    def upsample(self, factor, preserve_counts=True, axis=None):
+    def upsample(self, factor, order=0, preserve_counts=True, axis=None):
         geom = self.geom.upsample(factor, axis=axis)
-        coords = geom.get_coord()
-        data = self.get_by_coord(coords=coords)
+        idx = geom.get_idx()
+        pix = (
+                  (idx[0] - 0.5 * (factor - 1)) / factor,
+                  (idx[1] - 0.5 * (factor - 1)) / factor,
+              ) + idx[2:]
+        data = map_coordinates(self.data.T, pix, order=order, mode="nearest")
 
         if preserve_counts:
             if axis is None:


### PR DESCRIPTION
This PR includes the following changes:
- Add `MapAxis.upsample()` and `MapAxis.downsample()` methods
- Add `axis` argument to `WcsGeom.upsample()` and `WcsGeom.downsample()`
- Add `axis` argument to `WcsNDMap.upsample()` and `WcsNDMap.downsample()`
- Add tests...

The use case is for example the evaluation of background models or diffuse model using oversampling in the energy axis, instead of integration. The `geom` is oversampled in the given axis, before the evaluation, then the data is put into a new map and the new map is downsampled again.