### PR TITLE
Implement flux point estimation for `MapDataset`

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -363,7 +363,7 @@ class SourceCatalogObject3FGL(SourceCatalogObject):
         """Source sky model (`~gammapy.cube.models.SkyModel`)."""
         spatial_model = self.spatial_model
         spectral_model = self.spectral_model
-        return SkyModel(spatial_model, spectral_model)
+        return SkyModel(spatial_model, spectral_model, name=self.name)
 
     @property
     def is_pointlike(self):
@@ -903,7 +903,7 @@ class SourceCatalogObject3FHL(SourceCatalogObject):
         """Source sky model (`~gammapy.cube.models.SkyModel`)."""
         spatial_model = self.spatial_model
         spectral_model = self.spectral_model
-        return SkyModel(spatial_model, spectral_model)
+        return SkyModel(spatial_model, spectral_model, name=self.name)
 
     @property
     def is_pointlike(self):

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -547,13 +547,13 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
                 spectral_model_comp = spectral_model.copy()
                 # weight amplitude of the component
                 spectral_model_comp.parameters["amplitude"].value *= weight
-                models.append(SkyModel(component.spatial_model, spectral_model_comp))
+                models.append(SkyModel(component.spatial_model, spectral_model_comp, name=component.name))
 
             return SkyModels(models)
         else:
             spatial_model = self.spatial_model
             spectral_model = self.spectral_model(which=which)
-            return SkyModel(spatial_model, spectral_model)
+            return SkyModel(spatial_model, spectral_model, name=self.name)
 
     @property
     def flux_points(self):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -147,7 +147,7 @@ class SkyModels:
             if model.name == item:
                 return model
 
-        raise KeyError("Model '{}' not in model list.")
+        raise KeyError("Model '{}' not in model list.".format(item))
 
 
 class SkyModel(SkyModelBase):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -2,7 +2,7 @@
 import copy
 import numpy as np
 import astropy.units as u
-from ..utils.fitting import Parameter, Model
+from ..utils.fitting import Parameter, Model, Parameters
 from ..utils.scripts import make_path
 from ..maps import Map
 
@@ -36,7 +36,7 @@ class SkyModelBase(Model):
         return self.evaluate(lon, lat, energy)
 
 
-class SkyModels(SkyModelBase):
+class SkyModels:
     """Collection of `~gammapy.cube.models.SkyModel`
 
     Parameters
@@ -59,12 +59,14 @@ class SkyModels(SkyModelBase):
 
     def __init__(self, skymodels):
         self.skymodels = skymodels
-        parameters = []
 
-        for skymodel in skymodels:
+    @property
+    def parameters(self):
+        parameters = []
+        for skymodel in self.skymodels:
             for p in skymodel.parameters:
                 parameters.append(p)
-        super().__init__(parameters)
+        return Parameters(parameters)
 
     @classmethod
     def from_xml(cls, xml):
@@ -140,6 +142,13 @@ class SkyModels(SkyModelBase):
             raise NotImplementedError
         return SkyModels(skymodels)
 
+    def __getitem__(self, item):
+        for model in self.skymodels:
+            if model.name == item:
+                return model
+
+        raise KeyError("Model '{}' not in model list.")
+
 
 class SkyModel(SkyModelBase):
     """Sky model component.
@@ -162,7 +171,7 @@ class SkyModel(SkyModelBase):
 
     __slots__ = ["name", "_spatial_model", "_spectral_model"]
 
-    def __init__(self, spatial_model, spectral_model, name="SkyModel"):
+    def __init__(self, spatial_model, spectral_model, name="source"):
         self.name = name
         self._spatial_model = spatial_model
         self._spectral_model = spectral_model
@@ -180,6 +189,15 @@ class SkyModel(SkyModelBase):
     def spectral_model(self):
         """`~gammapy.spectrum.models.SpectralModel`"""
         return self._spectral_model
+
+    @spectral_model.setter
+    def spectral_model(self, model):
+        """`~gammapy.spectrum.models.SpectralModel`"""
+        self._spectral_model = model
+        self._parameters = Parameters(
+            self.spatial_model.parameters.parameters
+            + self.spectral_model.parameters.parameters
+        )
 
     @property
     def position(self):
@@ -248,7 +266,8 @@ class SkyDiffuseCube(SkyModelBase):
 
     __slots__ = ["map", "norm", "meta", "_interp_kwargs"]
 
-    def __init__(self, map, norm=1, meta=None, interp_kwargs=None):
+    def __init__(self, map, norm=1, meta=None, interp_kwargs=None, name="diffuse"):
+        self.name = name
         axis = map.geom.get_axis_by_name("energy")
 
         if axis.node_type != "center":

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -157,22 +157,8 @@ class SkyModels:
         return SkyModels(skymodels)
 
     def __getitem__(self, item):
-        for model in self.skymodels:
-            if model.name == item:
-                return model
-
-        raise KeyError("Model '{}' not in model list.".format(item))
-
-    def __setitem__(self, name, model):
-        if not name == model.name:
-            raise ValueError("Model name must be '{}'".format(name))
-
-        if name not in self.names:
-            raise KeyError("Model '{}' not in model list.".format(name))
-
-        for idx, _ in enumerate(self.skymodels):
-            if _.name == name:
-                self.skymodels[idx] = model
+        idx = self.names.index(item)
+        return self.skymodels[idx]
 
 
 

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -20,7 +20,7 @@ def sky_model():
     spectral_model = PowerLaw(
         index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
     )
-    return SkyModel(spatial_model, spectral_model)
+    return SkyModel(spatial_model, spectral_model, name="source-1")
 
 
 @pytest.fixture(scope="session")
@@ -85,12 +85,18 @@ def diffuse_evaluator(diffuse_model, exposure, psf, edisp):
 
 @pytest.fixture(scope="session")
 def sky_models(sky_model):
-    sky_model_2 = sky_model.copy()
-    sky_model_2.name = "source-2"
-    return SkyModels([sky_model, sky_model_2])
+    sky_model_2 = sky_model.copy(name="source-2")
+    sky_model_3 = sky_model.copy(name="source-3")
+    return SkyModels([sky_model_2, sky_model_3])
+
+@pytest.fixture(scope="session")
+def sky_models_2(sky_model):
+    sky_model_4 = sky_model.copy(name="source-4")
+    sky_model_5 = sky_model.copy(name="source-5")
+    return SkyModels([sky_model_4, sky_model_5])
 
 
-def test_skymodel_addition(sky_model, sky_models, diffuse_model):
+def test_skymodel_addition(sky_model, sky_models, sky_models_2, diffuse_model):
     result = sky_model + sky_model.copy()
     assert isinstance(result, SkyModels)
     assert len(result.skymodels) == 2
@@ -107,7 +113,7 @@ def test_skymodel_addition(sky_model, sky_models, diffuse_model):
     assert isinstance(result, SkyModels)
     assert len(result.skymodels) == 3
 
-    result = sky_models + sky_models
+    result = sky_models + sky_models_2
     assert isinstance(result, SkyModels)
     assert len(result.skymodels) == 4
 
@@ -166,11 +172,11 @@ class TestSkyModels:
 
     @staticmethod
     def test_get_item(sky_models):
-        model = sky_models["source"]
-        assert model.name == "source"
-
         model = sky_models["source-2"]
         assert model.name == "source-2"
+
+        model = sky_models["source-3"]
+        assert model.name == "source-3"
 
         with pytest.raises(KeyError):
             sky_models["spam"]

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -85,7 +85,9 @@ def diffuse_evaluator(diffuse_model, exposure, psf, edisp):
 
 @pytest.fixture(scope="session")
 def sky_models(sky_model):
-    return SkyModels([sky_model, sky_model.copy()])
+    sky_model_2 = sky_model.copy()
+    sky_model_2.name = "source-2"
+    return SkyModels([sky_model, sky_model_2])
 
 
 def test_skymodel_addition(sky_model, sky_models, diffuse_model):
@@ -108,6 +110,10 @@ def test_skymodel_addition(sky_model, sky_models, diffuse_model):
     result = sky_models + sky_models
     assert isinstance(result, SkyModels)
     assert len(result.skymodels) == 4
+
+    result = sky_model + sky_models
+    assert isinstance(result, SkyModels)
+    assert len(result.skymodels) == 3
 
 
 def test_background_model(background):
@@ -157,6 +163,17 @@ class TestSkyModels:
     def test_str(sky_models):
         assert "Component 0" in str(sky_models)
         assert "Component 1" in str(sky_models)
+
+    @staticmethod
+    def test_get_item(sky_models):
+        model = sky_models["source"]
+        assert model.name == "source"
+
+        model = sky_models["source-2"]
+        assert model.name == "source-2"
+
+        with pytest.raises(KeyError):
+            sky_models["spam"]
 
 
 class TestSkyModel:

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -178,8 +178,9 @@ class TestSkyModels:
         model = sky_models["source-3"]
         assert model.name == "source-3"
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError) as error:
             sky_models["spam"]
+            assert "spam" in error.message
 
 
 class TestSkyModel:

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -129,7 +129,7 @@ class SpectrumAnalysisIACT:
 
         datasets_fp = self.extraction.spectrum_observations.to_spectrum_datasets()
 
-        for dataset in datasets_fp:
+        for dataset in datasets_fp.datasets:
             dataset.model = model
 
         self.flux_point_estimator = FluxPointsEstimator(

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -4,7 +4,7 @@ import yaml
 from ..utils.scripts import make_path
 from ..utils.fitting import Fit
 from ..spectrum import (
-    FluxPointEstimator,
+    FluxPointsEstimator,
     FluxPointsDataset,
     SpectrumExtraction,
 )
@@ -130,7 +130,7 @@ class SpectrumAnalysisIACT:
         stacked_obs = self.extraction.spectrum_observations.stack()
 
         datasets_fp = self.extraction.spectrum_observations.to_spectrum_datasets(model=model)
-        self.flux_point_estimator = FluxPointEstimator(
+        self.flux_point_estimator = FluxPointsEstimator(
             e_edges=self.config["fp_binning"],
             datasets=datasets_fp,
         )

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -127,9 +127,11 @@ class SpectrumAnalysisIACT:
 
         self.write(filename=filename)
 
-        stacked_obs = self.extraction.spectrum_observations.stack()
+        datasets_fp = self.extraction.spectrum_observations.to_spectrum_datasets()
 
-        datasets_fp = self.extraction.spectrum_observations.to_spectrum_datasets(model=model)
+        for dataset in datasets_fp:
+            dataset.model = model
+
         self.flux_point_estimator = FluxPointsEstimator(
             e_edges=self.config["fp_binning"],
             datasets=datasets_fp,

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -129,10 +129,9 @@ class SpectrumAnalysisIACT:
 
         stacked_obs = self.extraction.spectrum_observations.stack()
 
-        datasets_fp = self.extraction.spectrum_observations.to_spectrum_datasets()
+        datasets_fp = self.extraction.spectrum_observations.to_spectrum_datasets(model=model)
         self.flux_point_estimator = FluxPointEstimator(
             e_edges=self.config["fp_binning"],
-            model=model,
             datasets=datasets_fp,
         )
         fp = self.flux_point_estimator.run()

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -786,7 +786,7 @@ class FluxPointsEstimator:
         self,
         datasets,
         e_edges,
-        source=None,
+        source="",
         norm_min=0.2,
         norm_max=5,
         norm_n_values=11,
@@ -808,9 +808,9 @@ class FluxPointsEstimator:
 
         dataset = self.datasets.datasets[0]
 
-        if source is not None:
+        try:
             model = dataset.model[source].spectral_model
-        else:
+        except TypeError:
             model = dataset.model
 
         self.model = ScaleModel(model)
@@ -836,9 +836,9 @@ class FluxPointsEstimator:
     def _set_scale_model(self):
         # set the model on all datasets
         for dataset in self.datasets.datasets:
-            if self.source is not None:
+            try:
                 dataset.model[self.source].spectral_model = self.model
-            else:
+            except TypeError:
                 dataset.model = self.model
 
     @property
@@ -852,7 +852,7 @@ class FluxPointsEstimator:
         try:
             energy_axis = dataset.counts_on.energy
         except AttributeError:
-            energy_axis = datasets.counts.geom.get_axis_by_name("energy")
+            energy_axis = dataset.counts.geom.get_axis_by_name("energy")
         return energy_axis.group_table(self.e_edges)
 
     def __str__(self):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -12,7 +12,7 @@ from ..utils.fitting import Dataset, Datasets, Fit
 from .models import PowerLaw, ScaleModel
 from .powerlaw import power_law_integral_flux
 
-__all__ = ["FluxPoints", "FluxPointEstimator", "FluxPointsDataset"]
+__all__ = ["FluxPoints", "FluxPointsEstimator", "FluxPointsDataset"]
 
 log = logging.getLogger(__name__)
 
@@ -740,7 +740,7 @@ class FluxPoints:
         return ax
 
 
-class FluxPointEstimator:
+class FluxPointsEstimator:
     """Flux points estimator.
 
     Estimates flux points for a given list of spectral datasets, energies and

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -1248,10 +1248,7 @@ class ScaleModel(SpectralModel):
     def __init__(self, model, norm=1):
         self.norm = Parameter("norm", norm, unit="")
         self.model = model
-
-        params = []
-        params.append(getattr(self, "norm"))
-        super().__init__(params)
+        super().__init__([self.norm])
 
     def evaluate(self, energy, norm):
         return norm * self.model(energy)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -36,7 +36,7 @@ def create_fpe(model):
     dataset = simulate_spectrum_dataset(model)
     e_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.model = model
-    return FluxPointsEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3)
+    return FluxPointsEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=11)
 
 
 def simulate_map_dataset():
@@ -97,15 +97,15 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [0.067454, 0.061646, 0.188288], rtol=1e-5)
 
         actual = fp.table["norm_ul"].data
-        assert_allclose(actual, [1.216227, 1.035472, 1.316878], rtol=1e-5)
+        assert_allclose(actual, [1.219995, 1.037478, 1.321045], rtol=1e-5)
 
         actual = fp.table["sqrt_ts"].data
         assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-5)
 
-        actual = fp.table["norm_scan"][0]
+        actual = fp.table["norm_scan"][0][[0, 5, -1]]
         assert_allclose(actual, [0.2, 1, 5], rtol=1e-5)
 
-        actual = fp.table["dloglike_scan"][0]
+        actual = fp.table["dloglike_scan"][0][[0, 5, -1]]
         assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-5)
 
     @staticmethod

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -3,15 +3,20 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
+from astropy.coordinates import SkyCoord
 from ...utils.testing import requires_dependency
-from ...irf import EffectiveAreaTable
+from ...irf import EffectiveAreaTable, load_cta_irfs
 from ..models import PowerLaw, ExponentialCutoffPowerLaw
 from ..simulation import SpectrumSimulation
 from ..flux_point import FluxPointEstimator
+from ...cube import simulate_dataset
+from ...cube.models import SkyModel
+from ...image.models import SkyGaussian
+from ...maps import MapAxis, WcsGeom
 
 
 # TODO: use pregenerate data instead
-def simulate_dataset(model):
+def simulate_spectrum_dataset(model):
     energy = np.logspace(-0.5, 1.5, 21) * u.TeV
     aeff = EffectiveAreaTable.from_parametrization(energy=energy)
     bkg_model = PowerLaw(index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1")
@@ -28,10 +33,36 @@ def simulate_dataset(model):
 
 
 def create_fpe(model):
-    dataset = simulate_dataset(model)
+    dataset = simulate_spectrum_dataset(model)
     e_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.model = model
     return FluxPointEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3)
+
+
+def simulate_map_dataset():
+    filename = (
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    irfs = load_cta_irfs(filename)
+
+    skydir = SkyCoord("0 deg", "0 deg", frame="galactic")
+    edges = np.logspace(-1, 2, 15) * u.TeV
+    energy_axis = MapAxis.from_edges(edges=edges, name="energy")
+
+    geom = WcsGeom.create(skydir=skydir, width=(4, 4), binsz=0.1, axes=[energy_axis], coordsys="GAL")
+
+    gauss = SkyGaussian("0 deg", "0 deg", "0.4 deg", frame="galactic")
+    pwl = PowerLaw(amplitude="1e-11 cm-2 s-1 TeV-1")
+    skymodel = SkyModel(spatial_model=gauss, spectral_model=pwl, name="source")
+    dataset = simulate_dataset(skymodel=skymodel, geom=geom, pointing=skydir, irfs=irfs, random_state=0)
+    return dataset
+
+
+@pytest.fixture(scope="session")
+def fpe_map_pwl():
+    dataset = simulate_map_dataset()
+    e_edges = [0.1, 1, 10, 100] * u.TeV
+    return FluxPointEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3, source="source")
 
 
 @pytest.fixture(scope="session")
@@ -82,3 +113,24 @@ class TestFluxPointEstimator:
     def test_run_ecpl(fpe_ecpl):
         fp = fpe_ecpl.estimate_flux_point(fpe_ecpl.e_groups[1])
         assert_allclose(fp["norm"], 1, rtol=1e-1)
+
+
+    @staticmethod
+    @requires_dependency("iminuit")
+    def test_run_map_pwl(fpe_map_pwl):
+        fp = fpe_map_pwl.run(steps=["err", "norm-scan", "ts"])
+
+        actual = fp.table["norm"].data
+        assert_allclose(actual, [0.97922 , 0.94081 , 1.074426], rtol=1e-5)
+
+        actual = fp.table["norm_err"].data
+        assert_allclose(actual, [0.069967, 0.052631, 0.093025], rtol=1e-4)
+
+        actual = fp.table["sqrt_ts"].data
+        assert_allclose(actual, [16.165811, 27.121425, 22.040969], rtol=1e-5)
+
+        actual = fp.table["norm_scan"][0]
+        assert_allclose(actual, [0.2, 1, 5], rtol=1e-5)
+
+        actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
+        assert_allclose(actual, [1.536460e+02, 8.756689e-02, 1.883420e+03], rtol=1e-5)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -121,16 +121,16 @@ class TestFluxPointEstimator:
         fp = fpe_map_pwl.run(steps=["err", "norm-scan", "ts"])
 
         actual = fp.table["norm"].data
-        assert_allclose(actual, [0.97922 , 0.94081 , 1.074426], rtol=1e-5)
+        assert_allclose(actual, [0.97922 , 0.94081 , 1.074426], rtol=1e-3)
 
         actual = fp.table["norm_err"].data
-        assert_allclose(actual, [0.069967, 0.052631, 0.093025], rtol=1e-4)
+        assert_allclose(actual, [0.069967, 0.052631, 0.093025], rtol=1e-3)
 
         actual = fp.table["sqrt_ts"].data
-        assert_allclose(actual, [16.165811, 27.121425, 22.040969], rtol=1e-5)
+        assert_allclose(actual, [16.165811, 27.121425, 22.040969], rtol=1e-3)
 
         actual = fp.table["norm_scan"][0]
-        assert_allclose(actual, [0.2, 1, 5], rtol=1e-5)
+        assert_allclose(actual, [0.2, 1, 5], rtol=1e-3)
 
         actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
-        assert_allclose(actual, [1.536460e+02, 8.756689e-02, 1.883420e+03], rtol=1e-5)
+        assert_allclose(actual, [1.536460e+02, 8.756689e-02, 1.883420e+03], rtol=1e-3)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -30,7 +30,8 @@ def simulate_dataset(model):
 def create_fpe(model):
     dataset = simulate_dataset(model)
     e_edges = [0.1, 1, 10, 100] * u.TeV
-    return FluxPointEstimator(datasets=[dataset], model=model, e_edges=e_edges, norm_n_values=3)
+    dataset.model = model
+    return FluxPointEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3)
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -8,7 +8,7 @@ from ...utils.testing import requires_dependency
 from ...irf import EffectiveAreaTable, load_cta_irfs
 from ..models import PowerLaw, ExponentialCutoffPowerLaw
 from ..simulation import SpectrumSimulation
-from ..flux_point import FluxPointEstimator
+from ..flux_point import FluxPointsEstimator
 from ...cube import simulate_dataset
 from ...cube.models import SkyModel
 from ...image.models import SkyGaussian
@@ -36,7 +36,7 @@ def create_fpe(model):
     dataset = simulate_spectrum_dataset(model)
     e_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.model = model
-    return FluxPointEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3)
+    return FluxPointsEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3)
 
 
 def simulate_map_dataset():
@@ -62,7 +62,7 @@ def simulate_map_dataset():
 def fpe_map_pwl():
     dataset = simulate_map_dataset()
     e_edges = [0.1, 1, 10, 100] * u.TeV
-    return FluxPointEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3, source="source")
+    return FluxPointsEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=3, source="source")
 
 
 @pytest.fixture(scope="session")
@@ -75,10 +75,10 @@ def fpe_ecpl():
     return create_fpe(ExponentialCutoffPowerLaw(lambda_="1 TeV-1"))
 
 
-class TestFluxPointEstimator:
+class TestFluxPointsEstimator:
     @staticmethod
     def test_str(fpe_pwl):
-        assert "FluxPointEstimator" in str(fpe_pwl)
+        assert "FluxPointsEstimator" in str(fpe_pwl)
 
     @staticmethod
     @requires_dependency("iminuit")

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -42,6 +42,7 @@
     "from gammapy.cube import MapMaker, PSFKernel, MapDataset\n",
     "from gammapy.cube.models import SkyModel, SkyDiffuseCube, BackgroundModel\n",
     "from gammapy.spectrum.models import PowerLaw, ExponentialCutoffPowerLaw\n",
+    "from gammapy.spectrum import FluxPointsEstimator\n",
     "from gammapy.image.models import SkyPointSource\n",
     "from gammapy.utils.fitting import Fit"
    ]
@@ -683,7 +684,8 @@
     ")\n",
     "\n",
     "model_ecpl = SkyModel(\n",
-    "    spatial_model=spatial_model, spectral_model=spectral_model\n",
+    "    spatial_model=spatial_model, spectral_model=spectral_model,\n",
+    "    name=\"gc-source\"\n",
     ")"
    ]
   },
@@ -788,7 +790,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally we can check again our model (including now the diffuse emission):"
+    "Finally we compute flux points and check again our model (including now the diffuse emission):"
    ]
   },
   {
@@ -797,7 +799,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_ecpl.spectral_model.plot(energy_range=energy_range, energy_power=2)"
+    "e_edges = [0.3, 1, 3, 10] * u.TeV\n",
+    "fpe = FluxPointsEstimator(datasets=[dataset_combined], e_edges=e_edges, source=\"gc-source\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "flux_points = fpe.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = flux_points.plot(energy_power=2)\n",
+    "model_ecpl.spectral_model.plot(ax=ax, energy_range=energy_range, energy_power=2);"
    ]
   },
   {
@@ -854,7 +877,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -62,7 +62,7 @@
     "from gammapy.spectrum import (\n",
     "    SpectrumExtraction,\n",
     "    models,\n",
-    "    FluxPointEstimator,\n",
+    "    FluxPointsEstimator,\n",
     "    FluxPointsDataset,\n",
     ")\n",
     "from gammapy.maps import MapAxis, WcsNDMap, WcsGeom\n",
@@ -444,10 +444,9 @@
     "ebounds = EnergyBounds.equal_log_spacing(1, 40, 4, unit=u.TeV)\n",
     "\n",
     "dataset = stacked_obs.to_spectrum_dataset()\n",
+    "dataset.model = model\n",
     "\n",
-    "fpe = FluxPointEstimator(\n",
-    "    datasets=[dataset], e_edges=ebounds, model=model\n",
-    ")\n",
+    "fpe = FluxPointsEstimator(datasets=[dataset], e_edges=ebounds)\n",
     "flux_points = fpe.run()\n",
     "flux_points.table_formatted"
    ]

--- a/tutorials/pulsar_analysis.ipynb
+++ b/tutorials/pulsar_analysis.ipynb
@@ -67,7 +67,7 @@
     "from gammapy.utils.fitting import Fit\n",
     "from gammapy.spectrum import (\n",
     "    SpectrumExtraction,\n",
-    "    FluxPointEstimator,\n",
+    "    FluxPointsEstimator,\n",
     "    FluxPointsDataset,\n",
     ")"
    ]
@@ -484,14 +484,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ebounds = EnergyBounds.equal_log_spacing(0.04, 0.4, 7, u.TeV)\n",
+    "e_edges = EnergyBounds.equal_log_spacing(0.04, 0.4, 7, u.TeV)\n",
     "\n",
     "stacked_obs = extraction.spectrum_observations.stack()\n",
     "dataset = stacked_obs.to_spectrum_dataset()\n",
+    "dataset.model = model\n",
     "\n",
-    "fpe = FluxPointEstimator(\n",
-    "    datasets=[dataset], e_edges=ebounds, model=model\n",
-    ")\n",
+    "fpe = FluxPointsEstimator(datasets=[dataset], e_edges=e_edges)\n",
     "\n",
     "flux_points = fpe.run()\n",
     "flux_points.table[\"is_ul\"] = flux_points.table[\"ts\"] < 1\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -41,7 +41,7 @@
     "To compute flux points (a.k.a. \"SED\" = \"spectral energy distribution\")\n",
     "\n",
     "* [gammapy.spectrum.FluxPoints](https://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPoints.html)\n",
-    "* [gammapy.spectrum.FluxPointEstimator](https://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPointEstimator.html)\n",
+    "* [gammapy.spectrum.FluxPointsEstimator](https://docs.gammapy.org/dev/api/gammapy.spectrum.FluxPointsEstimator.html)\n",
     "\n",
     "Feedback welcome!"
    ]
@@ -101,7 +101,7 @@
     "from gammapy.utils.energy import EnergyBounds\n",
     "from gammapy.spectrum import SpectrumExtraction\n",
     "from gammapy.spectrum.models import PowerLaw\n",
-    "from gammapy.spectrum import FluxPointEstimator, FluxPointsDataset\n",
+    "from gammapy.spectrum import FluxPointsEstimator, FluxPointsDataset\n",
     "from gammapy.maps import Map\n",
     "from gammapy.utils.fitting import Fit"
    ]
@@ -431,10 +431,9 @@
    "outputs": [],
    "source": [
     "dataset_stacked = stacked_obs.to_spectrum_dataset()\n",
+    "dataset_stacked.model = model\n",
     "\n",
-    "fpe = FluxPointEstimator(\n",
-    "    datasets=[dataset_stacked], e_edges=e_edges, model=model\n",
-    ")\n",
+    "fpe = FluxPointsEstimator(datasets=[dataset_stacked], e_edges=e_edges)\n",
     "flux_points = fpe.run()"
    ]
   },


### PR DESCRIPTION
This PR addresses #2125. It includes the following changes:
- Add `SkyModels.__getitem__` operator which allows to access model components by name, this is required to specify for which component in the model, the flux points should be computed.
- Change the `FluxPointEstimator` to work with `MapDataset`.
- Remove the `model` argument of the `FluxPointEstimator`, because the model is defined on the dataset now.
- Rename `FluxPointEstimator` to `FluxPointsEstimator` for consistency
- Add a `reoptimize` option for computing flux points and re-optimizing other (free) model parameters, such as background norm etc. 


Remaining TODOs:
- [x] Rename `FluxPointEstimator` to `FluxPointsEstimator`
- [x] Add an example how to use the `FluxPointsEstimator` with a `MapDataset` to one of the tutorials
- [x] Add a check for unique names in the `SkyModels.__init__` method.