### PR TITLE
Implement SkyDisk and SkyEllipse edge parameter

### DIFF
--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -58,6 +58,13 @@ def test_sky_disk():
     assert radius.unit == "deg"
     assert_allclose(radius.value, r_0.value)
 
+def test_sky_disk_edge():
+    r_0 = 2 * u.deg
+    model = SkyDisk(lon_0="0 deg", lat_0="0 deg", r_0=r_0)
+    value_center = model(0 * u.deg, 0 * u.deg)
+    value_edge = model(r_0, 0 * u.deg)
+    assert_allclose((value_edge / value_center).to_value(""), 0.5)
+
 
 def test_sky_ellipse():
     pytest.importorskip("astropy", minversion="3.1.1")
@@ -106,6 +113,14 @@ def test_sky_ellipse():
         np.sum(mymap_2.quantity * u.sr ** -1 * m_geom_2.solid_angle()),
         np.sum(mymap_disk.quantity * u.sr ** -1 * m_geom_2.solid_angle()),
     )
+
+
+def test_sky_ellipse_edge():
+    r_0 = 2 * u.deg
+    model = SkyEllipse(lon_0="0 deg", lat_0="0 deg", semi_major=r_0, e=0.5, theta="0 deg")
+    value_center = model(0 * u.deg, 0 * u.deg)
+    value_edge = model(r_0, 0 * u.deg)
+    assert_allclose((value_edge / value_center).to_value(""), 0.5)
 
 
 def test_sky_shell():

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -116,6 +116,7 @@ def test_sky_ellipse():
 
 
 def test_sky_ellipse_edge():
+    pytest.importorskip("astropy", minversion="3.1.1")
     r_0 = 2 * u.deg
     model = SkyEllipse(lon_0="0 deg", lat_0="0 deg", semi_major=r_0, e=0.5, theta="0 deg")
     value_center = model(0 * u.deg, 0 * u.deg)


### PR DESCRIPTION
This PR implements an `edge` parameter for the `SkyDisk` and `SkyEllipse` model. This additional parameter is introduced to resolve #2109.