### PR TITLE
Implement oversampling option for background model evaluation.

### DIFF
--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -25,6 +25,8 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None):
         Background rate model
     geom : `~gammapy.maps.WcsGeom`
         Reference geometry
+    oversampling: int
+        Oversampling factor in energy, used for the background model evaluation.
 
     Returns
     -------
@@ -41,7 +43,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None):
     #  the pointing might change slightly over the observation duration
 
     # Get altaz coords for map
-    if oversampling:
+    if oversampling is not None:
         geom = geom.upsample(factor=oversampling, axis="energy")
 
     map_coord = geom.to_image().get_coord()
@@ -73,7 +75,7 @@ def make_map_background_irf(pointing, ontime, bkg, geom, oversampling=None):
     data = (bkg_de * d_omega * ontime).to_value("")
     bkg_map = WcsNDMap(geom, data=data)
 
-    if oversampling:
+    if oversampling is not None:
         bkg_map = bkg_map.downsample(factor=oversampling, axis="energy")
 
     return bkg_map

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -28,9 +28,11 @@ class MapMaker:
         If none, the same as geom is assumed
     exclusion_mask : `~gammapy.maps.Map`
         Exclusion mask
+    background_oversampling : int
+        Background oversampling factor in energy axis.
     """
 
-    def __init__(self, geom, offset_max, geom_true=None, exclusion_mask=None):
+    def __init__(self, geom, offset_max, geom_true=None, exclusion_mask=None, background_oversampling=None):
         if not isinstance(geom, WcsGeom):
             raise ValueError("MapMaker only works with WcsGeom")
 
@@ -41,6 +43,7 @@ class MapMaker:
         self.geom_true = geom_true if geom_true else geom
         self.offset_max = Angle(offset_max)
         self.exclusion_mask = exclusion_mask
+        self.background_oversampling = background_oversampling
 
     def _get_empty_maps(self, selection):
         # Initialise zero-filled maps
@@ -115,6 +118,7 @@ class MapMaker:
             geom_true=cutout_geom_etrue,
             offset_max=self.offset_max,
             exclusion_mask=cutout_exclusion,
+            background_oversampling=self.background_oversampling,
         )
 
     @staticmethod
@@ -192,13 +196,15 @@ class MapMakerObs:
     """
 
     def __init__(
-        self, observation, geom, offset_max, geom_true=None, exclusion_mask=None
+        self, observation, geom, offset_max, geom_true=None, exclusion_mask=None,
+            background_oversampling=None,
     ):
         self.observation = observation
         self.geom = geom
         self.geom_true = geom_true if geom_true else geom
         self.offset_max = offset_max
         self.exclusion_mask = exclusion_mask
+        self.background_oversampling = background_oversampling
         self.maps = {}
 
     def _fov_mask(self, coords):
@@ -276,6 +282,7 @@ class MapMakerObs:
             ontime=self.observation.observation_time_duration,
             bkg=self.observation.bkg,
             geom=self.geom,
+            background_oversampling=self.background_oversampling
         )
         if self.fov_mask is not None:
             background.data[..., self.fov_mask] = 0

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -107,13 +107,13 @@ def geom(map_type, ebounds, skydir):
             "map_type": "wcs",
             "ebounds": [0.1, 1, 10],
             "shape": (2, 3, 4),
-            "sum": 940.167672,
+            "sum": 1061.348412,
         },
         {
             "map_type": "wcs",
             "ebounds": [0.1, 10],
             "shape": (1, 3, 4),
-            "sum": 1019.495516,
+            "sum": 1061.348412,
         },
         # TODO: make this work for HPX
         # 'HpxGeom' object has no attribute 'separation'
@@ -134,6 +134,7 @@ def test_make_map_background_irf(bkg_3d, pars, fixed_pointing_info):
             ebounds=pars["ebounds"],
             skydir=fixed_pointing_info.radec,
         ),
+        oversampling=10,
     )
 
     assert m.data.shape == pars["shape"]


### PR DESCRIPTION
This PR implements an `oversampling` option for the background model evaluation in the `MapMaker` class. The default behaviour remains unchanged, but users have now the option to choose the oversampling factor for the energy integration of the background model, if they want to. 

This PR supersedes: #2083 by @lmohrmann.