### PR TITLE
Improvements to FluxPointEstimator

### DIFF
--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -861,7 +861,7 @@ class FluxPointsEstimator:
         for counts, dataset in zip(counts_all, self.datasets.datasets):
             if isinstance(dataset, MapDataset) and counts == 0:
                 if dataset.background_model is not None:
-                    dataset.background_model.parameters.frozen = True
+                    dataset.background_model.parameters.freeze_all()
 
     def _set_scale_model(self):
         # set the model on all datasets
@@ -1043,7 +1043,7 @@ class FluxPointsEstimator:
                 mask &= dataset.mask
 
             if isinstance(dataset, SpectrumDatasetOnOff):
-                counts.append(dataset.counts_on.data.data[mask].sum())
+                counts.append(dataset.counts.data.data[mask].sum())
             else:
                 counts.append(dataset.counts.data[mask].sum())
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -860,7 +860,8 @@ class FluxPointsEstimator:
 
         for counts, dataset in zip(counts_all, self.datasets.datasets):
             if isinstance(dataset, MapDataset) and counts == 0:
-                dataset.background_model.parameters.frozen = True
+                if dataset.background_model is not None:
+                    dataset.background_model.parameters.frozen = True
 
     def _set_scale_model(self):
         # set the model on all datasets
@@ -980,7 +981,7 @@ class FluxPointsEstimator:
                 )
 
             if steps == "all":
-                steps = ["err", "errp-errn", "ul", "ts", "norm-scan", "counts"]
+                steps = ["err", "counts", "errp-errn", "ul", "ts", "norm-scan"]
 
             if "err" in steps:
                 result.update(self.estimate_norm_err())
@@ -1058,7 +1059,7 @@ class FluxPointsEstimator:
         """
         norm = self.model.parameters["norm"]
 
-        # TODO: the minuit backend as convergence problems when the likelihood is not
+        # TODO: the minuit backend has convergence problems when the likelihood is not
         #  of parabolic shape, which is the case, when there are zero counts in the
         #  energy bin. For this case we change to the scipy backend.
         counts = self.estimate_counts()["counts"]

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -109,31 +109,31 @@ class TestFluxPointsEstimator:
     def test_run_pwl(fpe_pwl):
         fp = fpe_pwl.run()
         actual = fp.table["norm"].data
-        assert_allclose(actual, [1.081434, 0.91077 , 0.922176], rtol=1e-5)
+        assert_allclose(actual, [1.081434, 0.91077 , 0.922176], rtol=1e-3)
 
         actual = fp.table["norm_err"].data
-        assert_allclose(actual, [0.066374, 0.061025, 0.179729], rtol=1e-5)
+        assert_allclose(actual, [0.066374, 0.061025, 0.179729], rtol=1e-2)
 
         actual = fp.table["norm_errn"].data
-        assert_allclose(actual, [0.065803, 0.060403, 0.171376], rtol=1e-5)
+        assert_allclose(actual, [0.065803, 0.060403, 0.171376], rtol=1e-2)
 
         actual = fp.table["norm_errp"].data
-        assert_allclose(actual, [0.06695 , 0.061652, 0.18839], rtol=1e-5)
+        assert_allclose(actual, [0.06695 , 0.061652, 0.18839], rtol=1e-2)
 
         actual = fp.table["counts"].data.squeeze()
-        assert_allclose(actual, [1490, 748, 43], rtol=1e-5)
+        assert_allclose(actual, [1490, 748, 43])
 
         actual = fp.table["norm_ul"].data
-        assert_allclose(actual, [1.216227, 1.035472, 1.316878], rtol=1e-5)
+        assert_allclose(actual, [1.216227, 1.035472, 1.316878], rtol=1e-2)
 
         actual = fp.table["sqrt_ts"].data
-        assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-5)
+        assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-2)
 
         actual = fp.table["norm_scan"][0][[0, 5, -1]]
-        assert_allclose(actual, [0.2, 1, 5], rtol=1e-5)
+        assert_allclose(actual, [0.2, 1, 5])
 
         actual = fp.table["dloglike_scan"][0][[0, 5, -1]]
-        assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-5)
+        assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-2)
 
     @staticmethod
     @requires_dependency("iminuit")
@@ -154,7 +154,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [0.069966, 0.052617, 0.092854], rtol=1e-2)
 
         actual = fp.table["counts"].data
-        assert_allclose(actual, [[44445, 0], [1911, 0], [292, 0]], rtol=1e-2)
+        assert_allclose(actual, [[44445, 0], [1911, 0], [292, 0]])
 
         actual = fp.table["norm_ul"].data
         assert_allclose(actual, [1.121379, 1.048815, 1.270037], rtol=1e-2)
@@ -163,7 +163,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [16.165806, 27.121415, 22.04104], rtol=1e-2)
 
         actual = fp.table["norm_scan"][0]
-        assert_allclose(actual, [0.2, 1, 5], rtol=1e-3)
+        assert_allclose(actual, [0.2, 1, 5])
 
         actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
         assert_allclose(actual, [1.536452e02, 8.762343e-02, 1.883447e03], rtol=1e-2)
@@ -184,7 +184,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, 23.971251, rtol=1e-2)
 
         actual = fp.table["norm_scan"][0]
-        assert_allclose(actual, 1, rtol=1e-3)
+        assert_allclose(actual, 1)
 
         actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
         assert_allclose(actual, 3.698882, rtol=1e-2)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -178,13 +178,13 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, 0.884621, rtol=1e-3)
 
         actual = fp.table["norm_err"].data
-        assert_allclose(actual, 0.058005, rtol=1e-3)
+        assert_allclose(actual, 0.058005, rtol=1e-2)
 
         actual = fp.table["sqrt_ts"].data
-        assert_allclose(actual, 23.971251, rtol=1e-3)
+        assert_allclose(actual, 23.971251, rtol=1e-2)
 
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, 1, rtol=1e-3)
 
         actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
-        assert_allclose(actual, 3.698882, rtol=1e-3)
+        assert_allclose(actual, 3.698882, rtol=1e-2)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -106,19 +106,22 @@ class TestFluxPointsEstimator:
     def test_run_pwl(fpe_pwl):
         fp = fpe_pwl.run()
         actual = fp.table["norm"].data
-        assert_allclose(actual, [1.080933, 0.910776, 0.922278], rtol=1e-5)
+        assert_allclose(actual, [1.081434, 0.91077 , 0.922176], rtol=1e-5)
 
         actual = fp.table["norm_err"].data
-        assert_allclose(actual, [0.066364, 0.061025, 0.179742], rtol=1e-5)
+        assert_allclose(actual, [0.066374, 0.061025, 0.179729], rtol=1e-5)
 
         actual = fp.table["norm_errn"].data
-        assert_allclose(actual, [0.065305, 0.060409, 0.17148], rtol=1e-5)
+        assert_allclose(actual, [0.065803, 0.060403, 0.171376], rtol=1e-5)
 
         actual = fp.table["norm_errp"].data
-        assert_allclose(actual, [0.067454, 0.061646, 0.188288], rtol=1e-5)
+        assert_allclose(actual, [0.06695 , 0.061652, 0.18839], rtol=1e-5)
+
+        actual = fp.table["counts"].data.squeeze()
+        assert_allclose(actual, [1490, 748, 43], rtol=1e-5)
 
         actual = fp.table["norm_ul"].data
-        assert_allclose(actual, [1.219995, 1.037478, 1.321045], rtol=1e-5)
+        assert_allclose(actual, [1.216227, 1.035472, 1.316878], rtol=1e-5)
 
         actual = fp.table["sqrt_ts"].data
         assert_allclose(actual, [18.568429, 18.054651, 7.057121], rtol=1e-5)
@@ -166,7 +169,7 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, 0.884621, rtol=1e-3)
 
         actual = fp.table["norm_err"].data
-        assert_allclose(actual, 0.058067, rtol=1e-3)
+        assert_allclose(actual, 0.058005, rtol=1e-3)
 
         actual = fp.table["sqrt_ts"].data
         assert_allclose(actual, 23.971251, rtol=1e-3)

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -218,7 +218,7 @@ class Fit:
         # TODO: decide what to return, and fill the info correctly!
         return CovarianceResult(backend=backend, method=method, parameters=parameters, success=info["success"], message=info["message"])
 
-    def confidence(self, parameter, backend="minuit", sigma=1, **kwargs):
+    def confidence(self, parameter, backend="minuit", sigma=1, reoptimize=True, **kwargs):
         """Estimate confidence interval.
 
         Extra ``kwargs`` are passed to the backend.
@@ -237,6 +237,8 @@ class Fit:
             Parameter of interest
         sigma : float
             Number of standard deviations for the confidence level
+        reoptimize : bool
+            Re-optimize other parameters, when computing the confidence region.
         **kwargs : dict
             Keyword argument passed ot the confidence estimation method.
 
@@ -261,17 +263,11 @@ class Fit:
                 else:
                     raise RuntimeError("To use minuit, you must first optimize.")
             else:
-                result = compute(parameters, parameter, self.datasets.likelihood, sigma, **kwargs)
+                result = compute(parameters, parameter, self.datasets.likelihood, sigma, reoptimize, **kwargs)
 
-        errp = parameter.scale * result["errp"]
-        errn = parameter.scale * result["errn"]
-
-        return {
-            "errp": errp,
-            "errn": errn,
-            "success": result["success"],
-            "nfev": result["nfev"],
-        }
+        result["errp"] *= parameter.scale
+        result["errn"] *= parameter.scale
+        return result
 
     def likelihood_profile(
         self,

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -155,11 +155,16 @@ def make_minuit_par_kwargs(parameters):
         min_ = None if np.isnan(par.factor_min) else par.factor_min
         max_ = None if np.isnan(par.factor_max) else par.factor_max
         kwargs["limit_{}".format(name)] = (min_, max_)
-        try:
+
+        if parameters.covariance is not None:
             error = parameters.error(par) / par.scale
-        except ValueError:
-            # default to 1 if covariance is not set
+        elif parameters.apply_autoscale:
             error = 1
+        else:
+            error = 1
+            log.warning("Neither covariance matrix set nor auto-scaling of parameters activated."
+                        "Assuming stepsize of 1, which could lead to convergence problems of the "
+                        "Minuit optimizer.")
 
         kwargs["error_{}".format(name)] = error
 

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -528,15 +528,10 @@ class Parameters:
         """
         return restore_parameters_values(self)
 
-    @property
-    def frozen(self):
-        """Frozen parameters"""
-        return [par.frozen for par in self.parameters]
-
-    @frozen.setter
-    def frozen(self, value):
+    def freeze_all(self):
+        """Freeze all parameters"""
         for par in self.parameters:
-            par.frozen = value
+            par.frozen = True
 
 
 class restore_parameters_values:

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -528,6 +528,16 @@ class Parameters:
         """
         return restore_parameters_values(self)
 
+    @property
+    def frozen(self):
+        """Frozen parameters"""
+        return [par.frozen for par in self.parameters]
+
+    @frozen.setter
+    def frozen(self, value):
+        for par in self.parameters:
+            par.frozen = value
+
 
 class restore_parameters_values:
     def __init__(self, parameters):

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.optimize import minimize, brentq
+from scipy.optimize import minimize, brentq, RootResults
 from .likelihood import Likelihood
 
 
@@ -29,23 +29,25 @@ def optimize_scipy(parameters, function, **kwargs):
 
 class TSDifference:
     """Likelihood wrapper to compute TS differences"""
-    def __init__(self, function, parameters, parameter, ts_diff):
+    def __init__(self, function, parameters, parameter, reoptimize, ts_diff):
         self.loglike_ref = function(parameters)
         self.parameters = parameters
         self.function = function
         self.parameter = parameter
         self.parameter.frozen = True
         self.ts_diff = ts_diff
+        self.reoptimize = reoptimize
 
     def fcn(self, factor):
         self.parameter.factor = factor
-        optimize_scipy(self.parameters, self.function)
+        if self.reoptimize:
+            optimize_scipy(self.parameters, self.function, method="L-BFGS-B")
         value = self.function(self.parameters) - self.loglike_ref - self.ts_diff
         return value
 
 
-def _confidence_scipy_brentq(parameters, parameter, function, sigma, upper=True, **kwargs):
-    ts_diff = TSDifference(function, parameters, parameter, ts_diff=sigma ** 2)
+def _confidence_scipy_brentq(parameters, parameter, function, sigma, reoptimize, upper=True, **kwargs):
+    ts_diff = TSDifference(function, parameters, parameter, reoptimize, ts_diff=sigma ** 2)
 
     kwargs.setdefault("a", parameter.factor)
 
@@ -68,6 +70,7 @@ def _confidence_scipy_brentq(parameters, parameter, function, sigma, upper=True,
         message = ("Confidence estimation failed, because bracketing interval"
                    " does not contain a unique solution. Try setting the interval by hand.")
         success = False
+        result = np.nan, RootResults(root=np.nan, iterations=0, function_calls=0, flag=0)
 
     suffix = "errp" if upper else "errn"
 
@@ -80,7 +83,7 @@ def _confidence_scipy_brentq(parameters, parameter, function, sigma, upper=True,
     }
 
 
-def confidence_scipy(parameters, parameter, function, sigma, **kwargs):
+def confidence_scipy(parameters, parameter, function, sigma, reoptimize=True, **kwargs):
     with parameters.restore_values:
         result = _confidence_scipy_brentq(
             parameters=parameters,
@@ -88,6 +91,7 @@ def confidence_scipy(parameters, parameter, function, sigma, **kwargs):
             function=function,
             sigma=sigma,
             upper=False,
+            reoptimize=reoptimize,
             **kwargs)
 
     with parameters.restore_values:
@@ -97,6 +101,7 @@ def confidence_scipy(parameters, parameter, function, sigma, **kwargs):
             function=function,
             sigma=sigma,
             upper=True,
+            reoptimize=reoptimize,
             **kwargs)
 
     result.update(result_errp)

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.optimize import minimize, brentq, RootResults
+from scipy.optimize import minimize, brentq
+from scipy.optimize.zeros import RootResults
 from .likelihood import Likelihood
 
 

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 from .. import Parameter, Parameters, optimize_iminuit, confidence_iminuit
 
@@ -44,6 +45,19 @@ def test_iminuit_basic(pars):
     assert_allclose(minuit.values["par_000_x"], 2, rtol=1e-3)
     assert_allclose(minuit.values["par_001_y"], 3, rtol=1e-3)
     assert_allclose(minuit.values["par_002_z"], 4, rtol=1e-3)
+
+
+def test_iminuit_stepsize(pars):
+    pars.apply_autoscale = False
+    pars.covariance = np.diag([0.2, 3e4, 4e-6]) ** 2
+
+    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+
+    assert info["success"]
+    assert_allclose(fcn(pars), 0, atol=1e-5)
+    assert_allclose(pars["x"].value, 2, rtol=1e-3)
+    assert_allclose(pars["y"].value, 3e5, rtol=1e-3)
+    assert_allclose(pars["z"].value, 4e-5, rtol=2e-2)
 
 
 def test_iminuit_frozen(pars):


### PR DESCRIPTION
This PR includes the following changes:

- Add `FluxPointsEstimator.estimate_counts()` method, that computes how many counts (per observation) actually contribute to the measurement. The info is also stored in the output table.
- Change back to the upper limit computation with iminuit, but use the ccipy backend when there are zero counts in the energy bin.
- Freeze the parameters of the background model if an observation has zero counts, that contribute to the measurement