### PR TITLE
Add DataStoreMaker for IACT DL3 indexing

### DIFF
--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+from pathlib import Path
 import pytest
 from ...utils.testing import requires_data
 from ...data import DataStore
@@ -140,7 +142,7 @@ class TestDataStoreMaker:
         hdu_class = ["events", "gti", "aeff_2d", "edisp_2d", "psf_3gauss", "bkg_3d"]
         assert list(self.data_store.hdu_table["HDU_CLASS"]) == 4 * hdu_class
 
-    def test_observation(self):
+    def test_observation(self, monkeypatch):
         """Check that one observation can be accessed OK"""
         obs = self.data_store.obs(110380)
         assert obs.obs_id == 110380
@@ -148,7 +150,10 @@ class TestDataStoreMaker:
         assert obs.events.time[0].iso == "2021-01-21 12:00:03.045"
         assert obs.gti.time_start[0].iso == "2021-01-21 12:00:00.000"
 
-        # TODO: set env CALDB = "$GAMMAPY_DATA/cta-1dc/caldb"
+        # Note: IRF access requires the CALDB env var
+        caldb_path = Path(os.environ["GAMMAPY_DATA"]) / Path("cta-1dc/caldb")
+        monkeypatch.setenv("CALDB", str(caldb_path))
+
         assert obs.aeff.__class__.__name__ == "EffectiveAreaTable2D"
         assert obs.bkg.__class__.__name__ == "Background3D"
         assert obs.edisp.__class__.__name__ == "EnergyDispersion2D"


### PR DESCRIPTION
This PR adds a `DataStoreMaker` and a `DataStore.from_events_files` method.

The use case (see docstring and test) is to make it possible to analyse IACT DL3 data if you don't have HDU&OBS index files, or to create HDU&OBS index files with Gammapy.

There are different formats in use how EVENTS and IRFs are linked, we probably want to support a few. 

This initial version is supposed to work for data from CTA 1DC or from ctobssim, for the cases where CALDB is used to link to the IRFs. This was a feature request by @debaice , and pair-coded, to be able to analyse ctobssim output with Gammapy.

This PR is a step to address #1597 and #1303 .

I also would like to address #1255 here to allow `datastore.get_observations()` and to by default use all observations, by adding this:
```
if obs_id is None:
    obs_id = self.obs_table['OBS_ID'].data
```
For this case now where one makes a `DataStore` on the fly already for the data one wants, this is very  common and convenient.

@adonath @lmohrmann @debaice or anyone interested in IACT data access / indexing - Thoughts?