### PR TITLE
Add default for @requires_data()

### DIFF
--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -5,7 +5,7 @@ from ....utils.testing import assert_quantity_allclose, requires_data
 from .. import PrimaryFlux, DMAnnihilation
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_primary_flux():
     with pytest.raises(ValueError):
         PrimaryFlux(channel="Spam", mDM=1 * u.TeV)
@@ -16,7 +16,7 @@ def test_primary_flux():
     assert_quantity_allclose(actual, desired)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_DMAnnihilation():
 
     channel = "b"

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -17,7 +17,7 @@ def jfact(geom):
     return jfactory.compute_jfactor()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_dmfluxmap(jfact):
 
     emin = 0.1 * u.TeV

--- a/gammapy/background/tests/test_phase.py
+++ b/gammapy/background/tests/test_phase.py
@@ -33,18 +33,18 @@ def phase_bkg_estimator(on_region, observations):
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_basic(phase_bkg_estimator):
     assert "PhaseBackgroundEstimator" in str(phase_bkg_estimator)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_run(phase_bkg_estimator):
     phase_bkg_estimator.run()
     assert len(phase_bkg_estimator.result) == 1
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_filter_events(observations, on_region):
     all_events = observations[0].events.select_circular_region(on_region)
     ev1 = PhaseBackgroundEstimator.filter_events(all_events, (0, 0.3))
@@ -64,6 +64,6 @@ def test_check_phase_intervals(pars):
     assert PhaseBackgroundEstimator._check_intervals(pars["p_in"]) == pars["p_out"]
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_process(phase_bkg_estimator, observations):
     assert isinstance(phase_bkg_estimator.process(observations[0]), BackgroundEstimate)

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -51,7 +51,7 @@ def bkg_estimator(observations, exclusion_mask, on_region):
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_find_reflected_regions(exclusion_mask, on_region):
     pointing = SkyCoord(83.2, 22.5, unit="deg")
     fregions = ReflectedRegionsFinder(
@@ -86,7 +86,7 @@ def test_find_reflected_regions(exclusion_mask, on_region):
     assert len(regions) == 5
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestReflectedRegionBackgroundEstimator:
     def test_basic(self, bkg_estimator):
         assert "ReflectedRegionsBackgroundEstimator" in str(bkg_estimator)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -68,7 +68,7 @@ SOURCES_3FHL = [
 ]
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFermi3FGLObject:
     @classmethod
     def setup_class(cls):
@@ -189,7 +189,7 @@ class TestFermi3FGLObject:
         assert str(self.cat["Crab"]) == str(self.cat[name])
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFermi1FHLObject:
     @classmethod
     def setup_class(cls):
@@ -220,7 +220,7 @@ class TestFermi1FHLObject:
         assert_quantity_allclose(actual, desired, rtol=1e-5)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFermi2FHLObject:
     @classmethod
     def setup_class(cls):
@@ -251,7 +251,7 @@ class TestFermi2FHLObject:
         assert_quantity_allclose(actual, desired, rtol=1e-3)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFermi3FHLObject:
     @classmethod
     def setup_class(cls):
@@ -321,7 +321,7 @@ class TestFermi3FHLObject:
         assert str(self.cat["Crab Nebula"]) == str(self.cat[name])
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalog3FGL:
     @classmethod
     def setup_class(cls):
@@ -351,7 +351,7 @@ class TestSourceCatalog3FGL:
         assert len(selection.table) == 143
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalog1FHL:
     @classmethod
     def setup_class(cls):
@@ -371,7 +371,7 @@ class TestSourceCatalog1FHL:
         assert str(self.cat["Crab"]) == str(self.cat[name])
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalog2FHL:
     @classmethod
     def setup_class(cls):
@@ -391,7 +391,7 @@ class TestSourceCatalog2FHL:
         assert str(self.cat["Crab"]) == str(self.cat[name])
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalog3FHL:
     @classmethod
     def setup_class(cls):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -59,7 +59,7 @@ def gammacat():
     return SourceCatalogGammaCat(filename=filename)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalogGammaCat:
     def test_source_table(self, gammacat):
         assert gammacat.name == "gamma-cat"
@@ -95,7 +95,7 @@ class TestSourceCatalogGammaCat:
         assert_allclose(source.spectral_model.parameters["index"].value, 2.2)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalogObjectGammaCat:
     def test_data(self, gammacat):
         source = gammacat[0]

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -11,14 +11,14 @@ def hawc_2hwc():
     return SourceCatalog2HWC()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalog2HWC:
     def test_source_table(self, hawc_2hwc):
         assert hawc_2hwc.name == "2hwc"
         assert len(hawc_2hwc.table) == 40
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalogObject2HWC:
     def test_data(self, hawc_2hwc):
         source = hawc_2hwc[0]

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -17,7 +17,7 @@ def cat():
     return SourceCatalogHGPS("$GAMMAPY_DATA/catalogs/hgps_catalog_v1.fits.gz")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalogHGPS:
     @staticmethod
     def test_source_table(cat):
@@ -48,7 +48,7 @@ class TestSourceCatalogHGPS:
         assert isinstance(cat.large_scale_component, SourceCatalogLargeScaleHGPS)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalogObjectHGPS:
     @pytest.fixture(scope="class")
     def source(self, cat):
@@ -247,7 +247,7 @@ class TestSourceCatalogObjectHGPS:
         assert_allclose(p["width"].value, 0.05)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSourceCatalogObjectHGPSComponent:
     @pytest.fixture(scope="class")
     def component(self, cat):

--- a/gammapy/catalog/tests/test_registry.py
+++ b/gammapy/catalog/tests/test_registry.py
@@ -14,13 +14,13 @@ def source_catalogs():
     return cats
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_info_table(source_catalogs):
     table = source_catalogs.info_table
     assert table.colnames == ["name", "description", "sources"]
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_getitem(source_catalogs):
     cat = source_catalogs["2fhl"]
     assert cat.name == "2fhl"

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -99,7 +99,7 @@ def geom(map_type, ebounds, skydir):
         raise ValueError()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "pars",
     [
@@ -142,7 +142,7 @@ def test_make_map_background_irf(bkg_3d, pars, fixed_pointing_info):
     assert_allclose(m.data.sum(), pars["sum"], rtol=1e-5)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_make_map_background_irf_constant(fixed_pointing_info_aligned):
     m = make_map_background_irf_with_symmetry(
         fpi=fixed_pointing_info_aligned, symmetry="constant"
@@ -156,7 +156,7 @@ def test_make_map_background_irf_constant(fixed_pointing_info_aligned):
             assert_allclose(d[:, 1], d[0, 1])
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_make_map_background_irf_sym(fixed_pointing_info_aligned):
     m = make_map_background_irf_with_symmetry(
         fpi=fixed_pointing_info_aligned, symmetry="symmetric"
@@ -166,7 +166,7 @@ def test_make_map_background_irf_sym(fixed_pointing_info_aligned):
         assert_allclose(d[0, 1], d[2, 1], rtol=1e-4)  # Symmetric along lat
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_make_map_background_irf_asym(fixed_pointing_info_aligned):
     m = make_map_background_irf_with_symmetry(
         fpi=fixed_pointing_info_aligned, symmetry="asymmetric"

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -29,7 +29,7 @@ def geom(map_type, ebounds):
         raise ValueError()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "pars",
     [

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -98,7 +98,7 @@ def counts(sky_model, exposure, background, psf, edisp):
 
 
 @requires_dependency("iminuit")
-@requires_data("gammapy-data")
+@requires_data()
 def test_map_fit(sky_model):
     ebounds = np.logspace(-1.0, 1.0, 3)
     ebounds_true = np.logspace(-1.0, 1.0, 4)
@@ -189,7 +189,7 @@ def test_map_fit(sky_model):
 
 
 @requires_dependency("iminuit")
-@requires_data("gammapy-data")
+@requires_data()
 def test_map_fit_one_energy_bin(sky_model):
     ebounds = np.logspace(-1.0, 1.0, 2)
     geom_r = geom(ebounds)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -31,7 +31,7 @@ def geom(ebounds):
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "pars",
     [
@@ -110,7 +110,7 @@ def test_map_maker(pars, observations, keepdims):
     assert_allclose(background.data.sum(), pars["background"], rtol=1e-5)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_map_maker_ring(observations):
     ring_bkg = RingBackgroundEstimator(r_in="0.5 deg", width="0.4 deg")
     geomd = geom(ebounds=[0.1, 1, 10])

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -256,7 +256,7 @@ class TestSkyDiffuseCube:
         assert_allclose(q.value.mean(), 42)
 
     @staticmethod
-    @requires_data("gammapy-data")
+    @requires_data()
     def test_read():
         model = SkyDiffuseCube.read(
             "$GAMMAPY_DATA/tests/unbundled/fermi/gll_iem_v02_cutout.fits"

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -13,7 +13,7 @@ from ...cube import MapDataset
 from ..simulate import simulate_dataset
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_simulate():
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -9,7 +9,7 @@ def data_store():
     return DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_datastore_hd_hap(data_store):
     """Test HESS HAP-HD data access."""
     obs = data_store.obs(obs_id=23523)
@@ -27,7 +27,7 @@ def test_datastore_hd_hap(data_store):
     assert str(type(obs.psf)) == "<class 'gammapy.irf.psf_3d.PSF3D'>"
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_datastore_from_dir():
     """Test the `from_dir` method."""
     data_store_rel_path = DataStore.from_dir(
@@ -44,7 +44,7 @@ def test_datastore_from_dir():
     assert "Data store" in data_store_abs_path.info(show=False)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_datastore_from_file():
     filename = "$GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz"
     data_store = DataStore.from_file(filename)
@@ -54,7 +54,7 @@ def test_datastore_from_file():
     obs.bkg
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_datastore_get_observations(data_store):
     """Test loading data and IRF files via the DataStore"""
     observations = data_store.get_observations([23523, 23592])
@@ -67,7 +67,7 @@ def test_datastore_get_observations(data_store):
     assert observations[0].obs_id == 23523
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_datastore_subset(tmpdir, data_store):
     """Test creating a datastore as subset of another datastore"""
     selected_obs = data_store.obs_table.select_obs_id([23523, 23592])
@@ -94,7 +94,7 @@ def test_datastore_subset(tmpdir, data_store):
     assert len(substore.hdu_table) == 2
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestDataStoreChecker:
     def setup(self):
         self.data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -11,7 +11,7 @@ from ...data.event_list import EventListBase, EventList, EventListLAT
 from ...maps import WcsGeom, Map, MapAxis
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEventListBase:
     def setup(self):
         filename = "$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_020136.fits.gz"
@@ -28,7 +28,7 @@ class TestEventListBase:
         )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEventListHESS:
     def setup(self):
         filename = (
@@ -98,7 +98,7 @@ class TestEventListHESS:
             self.events.peek()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEventListFermi:
     def setup(self):
         filename = "$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-events.fits.gz"
@@ -114,7 +114,7 @@ class TestEventListFermi:
             self.events.plot_image()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEventListChecker:
     def setup(self):
         self.event_list = EventList.read(

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -21,7 +21,7 @@ def observation():
     return ds.obs(20136)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_empty_observation_filter(observation):
     empty_obs_filter = ObservationFilter()
 
@@ -34,7 +34,7 @@ def test_empty_observation_filter(observation):
     assert filtered_gti == gti
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_filter_events(observation):
     custom_filter = {
         "type": "custom",
@@ -66,7 +66,7 @@ def test_filter_events(observation):
     assert np.all(region.center.separation(filtered_events.radec) < region_radius)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_filter_gti(observation):
     time_filter = Time([53090.125, 53090.130], format="mjd", scale="tt")
 

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -6,7 +6,7 @@ from ...utils.testing import requires_data, assert_time_allclose
 from ...data import GTI
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_gti_hess():
     filename = "$GAMMAPY_DATA/tests/unbundled/hess/run_0023037_hard_eventlist.fits.gz"
     gti = GTI.read(filename)
@@ -24,7 +24,7 @@ def test_gti_hess():
     assert_time_allclose(gti.time_stop[0], expected)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_gti_fermi():
     filename = "$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-events.fits.gz"
     gti = GTI.read(filename)
@@ -42,7 +42,7 @@ def test_gti_fermi():
     assert_time_allclose(gti.time_stop[0], expected)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "time_interval, expected_length, expected_times",
     [

--- a/gammapy/data/tests/test_hdu_index_table.py
+++ b/gammapy/data/tests/test_hdu_index_table.py
@@ -45,7 +45,7 @@ def test_hdu_index_table(hdu_index_table):
     assert hdu_index_table.summary().startswith("HDU index table")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_hdu_index_table_hd_hap():
     """Test HESS HAP-HD data access."""
     hdu_index = HDUIndexTable.read("$GAMMAPY_DATA/hess-dl3-dr1/hdu-index.fits.gz")

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -76,7 +76,7 @@ def stats_stacked_bad_on_region(bad_on_region, observations):
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestObservationStats:
     @staticmethod
     def test_str(stats):

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -10,7 +10,7 @@ from ...utils.testing import requires_data, requires_dependency, mpl_plot_check
 from ...background import ReflectedRegionsBackgroundEstimator
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestObservationSummaryTable:
     @classmethod
     def setup_class(cls):
@@ -41,7 +41,7 @@ class TestObservationSummaryTable:
             self.table_summary.plot_offset_distribution()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestObservationSummary:
     """
     Test observation summary.

--- a/gammapy/data/tests/test_obs_table.py
+++ b/gammapy/data/tests/test_obs_table.py
@@ -427,7 +427,7 @@ def test_create_gti():
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_observation_table_checker():
     path = "$GAMMAPY_DATA/cta-1dc/index/gps/obs-index.fits.gz"
     obs_table = ObservationTable.read(path)

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -13,7 +13,7 @@ def data_store():
     return DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_data_store_observation(data_store):
     """Test DataStoreObservation class"""
     obs = data_store.obs(23523)
@@ -31,7 +31,7 @@ def test_data_store_observation(data_store):
     assert_skycoord_allclose(obs.target_radec, c)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "time_interval, expected_times",
     [
@@ -78,7 +78,7 @@ def test_observation_select_time(data_store, time_interval, expected_times):
         assert len(new_obs.gti.table) == 0
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "time_interval, expected_times, expected_nr_of_obs",
     [
@@ -121,7 +121,7 @@ def test_observations_select_time(
         )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestObservationChecker:
     def setup(self):
         data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -5,7 +5,7 @@ from ...utils.testing import requires_data, assert_time_allclose
 from ..pointing import FixedPointingInfo, PointingInfo
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFixedPointingInfo:
     @classmethod
     def setup_class(cls):
@@ -49,7 +49,7 @@ class TestFixedPointingInfo:
         assert pos.name == "altaz"
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestPointingInfo:
     @classmethod
     def setup_class(cls):

--- a/gammapy/detect/tests/test_cwt.py
+++ b/gammapy/detect/tests/test_cwt.py
@@ -6,7 +6,7 @@ from ...detect import CWT, CWTKernels, CWTData
 from ...maps import Map
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestCWT:
     """Test CWT algorithm."""
 
@@ -125,7 +125,7 @@ class TestCWT:
         assert_allclose(transform_2d.sum(), 9.91731463861)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestCWTKernels:
     """Test CWTKernels"""
 
@@ -167,7 +167,7 @@ class TestCWTKernels:
         assert_equal(len(t), 13)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestCWTData:
     """
     Test CWTData class.

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -36,7 +36,7 @@ def kbe():
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_run_iteration(kbe, images):
     result = kbe.run_iteration(images)
     mask, background = result["exclusion"].data, result["background"].data
@@ -51,7 +51,7 @@ def test_run_iteration(kbe, images):
     assert_allclose(background, 42 * np.ones((10, 10)))
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_run(kbe, images):
     result = kbe.run(images)
     mask, background = result["exclusion"].data, result["background"].data
@@ -61,7 +61,7 @@ def test_run(kbe, images):
     assert len(kbe.images_stack) == 4
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_run_without_defaults(kbe, images):
     result = kbe.run({"counts": images["counts"]})
     mask, background = result["exclusion"].data, result["background"].data

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -6,7 +6,7 @@ from ...detect import compute_lima_image, compute_lima_on_off_image
 from ...maps import Map
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_compute_lima_image():
     """
     Test Li & Ma image against TS image for Tophat kernel
@@ -22,7 +22,7 @@ def test_compute_lima_image():
     assert_allclose(result_lima["significance"].data[1, 1], 0.164, atol=1e-3)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_compute_lima_on_off_image():
     """
     Test Li & Ma image with snippet from the H.E.S.S. survey data.

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -17,7 +17,7 @@ def input_maps():
     }
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_compute_ts_map(input_maps):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(5)
@@ -33,7 +33,7 @@ def test_compute_ts_map(input_maps):
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_compute_ts_map_downsampled(input_maps):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(2.5)
@@ -50,7 +50,7 @@ def test_compute_ts_map_downsampled(input_maps):
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_large_kernel(input_maps):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(100)

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -164,7 +164,7 @@ def test_sky_diffuse_constant():
     assert radius is None
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_sky_diffuse_map():
     filename = "$GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits"
     model = SkyDiffuseMap.read(filename, normalize=False)
@@ -180,7 +180,7 @@ def test_sky_diffuse_map():
     assert model.frame == "fk5"
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_sky_diffuse_map_normalize():
     # define model map with a constant value of 1
     model_map = Map.create(map_type="wcs", width=(10, 5), binsz=0.5)

--- a/gammapy/image/tests/test_asmooth.py
+++ b/gammapy/image/tests/test_asmooth.py
@@ -17,7 +17,7 @@ def input_maps():
     }
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_asmooth(input_maps):
     kernel = Tophat2DKernel
     scales = ASmooth.make_scales(3, factor=2, kernel=kernel) * 0.1 * u.deg

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -29,7 +29,7 @@ def bkg_3d():
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_background_3d_basics(bkg_3d):
     assert "NDDataArray summary info" in str(bkg_3d.data)
 

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -19,7 +19,7 @@ class TestEffectiveAreaTable2D:
     # TODO: split this out into separate tests, especially the plotting
     # Add I/O test
     @staticmethod
-    @requires_data("gammapy-data")
+    @requires_data()
     def test(aeff):
         assert aeff.data.axis("energy").nbin == 96
         assert aeff.data.axis("offset").nbin == 6
@@ -58,7 +58,7 @@ class TestEffectiveAreaTable2D:
 
     @staticmethod
     @requires_dependency("matplotlib")
-    @requires_data("gammapy-data")
+    @requires_data()
     def test_plot(aeff):
         with mpl_plot_check():
             aeff.plot()
@@ -73,7 +73,7 @@ class TestEffectiveAreaTable2D:
 class TestEffectiveAreaTable:
     @staticmethod
     @requires_dependency("matplotlib")
-    @requires_data("gammapy-data")
+    @requires_data()
     def test_EffectiveAreaTable(tmpdir, aeff):
         arf = aeff.to_effective_area_table(offset=0.3 * u.deg)
 

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -94,7 +94,7 @@ class TestEnergyDispersion:
             self.edisp.peek()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEnergyDispersion2D:
     def setup(self):
         # TODO: use from_gauss method to create know edisp (see below)

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -76,7 +76,7 @@ class FitsProductionTester:
 
 
 @pytest.mark.parametrize("prod", productions)
-@requires_data("gammapy-data")
+@requires_data()
 def test_fits_prods(prod):
     tester = FitsProductionTester(prod)
     tester.test_all()

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -5,7 +5,7 @@ from ...utils.testing import requires_data
 from ..io import load_cta_irfs
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_cta_irf():
     """Test that CTA IRFs can be loaded and evaluated."""
     irf = load_cta_irfs(

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -24,7 +24,7 @@ def data_store():
     return DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "pars",
     [
@@ -99,7 +99,7 @@ def test_make_psf(pars, data_store):
     assert_allclose(psf.psf_value.value[15, 50], pars["psf_value"], rtol=1e-3)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_make_mean_psf(data_store):
     position = SkyCoord(83.63, 22.01, unit="deg")
 
@@ -110,7 +110,7 @@ def test_make_mean_psf(data_store):
     assert_allclose(psf.psf_value.value[22, 22], 12206.1665)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_make_mean_edisp(data_store):
     position = SkyCoord(83.63, 22.01, unit="deg")
 

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -12,7 +12,7 @@ def psf_3d():
     return PSF3D.read(filename)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_3d_basics(psf_3d):
     assert_allclose(psf_3d.rad_lo[-1].value, 0.6704476475715637)
     assert psf_3d.rad_lo.shape == (900,)
@@ -31,7 +31,7 @@ def test_psf_3d_basics(psf_3d):
     assert "PSF3D" in psf_3d.info()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_3d_evaluate(psf_3d):
     q = psf_3d.evaluate(energy="1 TeV", offset="0.3 deg", rad="0.1 deg")
     assert_allclose(q.value, 21417.213824)
@@ -40,7 +40,7 @@ def test_psf_3d_evaluate(psf_3d):
     assert q.unit == "sr-1"
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_to_energy_dependent_table_psf(psf_3d):
     psf = psf_3d.to_energy_dependent_table_psf()
     assert psf.psf_value.shape == (18, 900)
@@ -48,7 +48,7 @@ def test_to_energy_dependent_table_psf(psf_3d):
     assert_allclose(radius, 0.172435, atol=1e-4)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_3d_containment_radius(psf_3d):
     q = psf_3d.containment_radius(energy="1 TeV")
     assert_allclose(q.value, 0.171025, rtol=1e-2)
@@ -60,7 +60,7 @@ def test_psf_3d_containment_radius(psf_3d):
     assert q.shape == (2,)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_3d_write(psf_3d, tmpdir):
     filename = str(tmpdir / "temp.fits")
     psf_3d.write(filename)
@@ -69,21 +69,21 @@ def test_psf_3d_write(psf_3d, tmpdir):
     assert_allclose(psf_3d.energy_lo[0].value, 0.02)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @requires_dependency("matplotlib")
 def test_psf_3d_plot_vs_rad(psf_3d):
     with mpl_plot_check():
         psf_3d.plot_psf_vs_rad()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @requires_dependency("matplotlib")
 def test_psf_3d_plot_containment(psf_3d):
     with mpl_plot_check():
         psf_3d.plot_containment(show_safe_energy=True)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @requires_dependency("matplotlib")
 def test_psf_3d_peek(psf_3d):
     with mpl_plot_check():

--- a/gammapy/irf/tests/test_psf_check.py
+++ b/gammapy/irf/tests/test_psf_check.py
@@ -5,7 +5,7 @@ from ..psf_3d import PSF3D
 from ..psf_check import PSF3DChecker
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestPSF3DChecker:
     def setup(self):
         filename = "$GAMMAPY_DATA/tests/hess-hap-hd-prod3/psf_table.fits.gz"

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -64,7 +64,7 @@ def make_test_psf(energy_bins=15, theta_bins=12):
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEnergyDependentMultiGaussPSF:
     @pytest.fixture(scope="session")
     def psf(self):
@@ -126,7 +126,7 @@ class TestEnergyDependentMultiGaussPSF:
         assert_allclose(np.squeeze(desired), actual, atol=0.005)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_cta_1dc():
     filename = (
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -13,7 +13,7 @@ def psf_king():
     return PSFKing.read(filename)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_king_evaluate(psf_king):
     param_off1 = psf_king.evaluate(energy="1 TeV", offset="0 deg")
     param_off2 = psf_king.evaluate("1 TeV", "1 deg")
@@ -24,7 +24,7 @@ def test_psf_king_evaluate(psf_king):
     assert_quantity_allclose(param_off2["sigma"], psf_king.sigma[2, 8])
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_king_to_table(psf_king):
     theta1 = Angle(0, "deg")
     theta2 = Angle(1, "deg")
@@ -52,7 +52,7 @@ def test_psf_king_to_table(psf_king):
     assert_quantity_allclose(integral, 1, atol=0.03)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_psf_king_write(psf_king, tmpdir):
     filename = str(tmpdir / "king.fits")
     psf_king.write(filename)

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -42,7 +42,7 @@ class TestTablePSF:
         assert_allclose(actual, radius.deg, rtol=1e-4)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestEnergyDependentTablePSF:
     def setup(self):
         filename = "$GAMMAPY_DATA/tests/unbundled/fermi/psf.fits"

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -536,7 +536,7 @@ def test_convolve_vs_smooth():
     assert_allclose(actual.data, desired.data, rtol=1e-3)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_convolve_nd():
     energy_axis = MapAxis.from_edges(
         np.logspace(-1.0, 1.0, 4), unit="TeV", name="energy"

--- a/gammapy/scripts/tests/test_image_bin.py
+++ b/gammapy/scripts/tests/test_image_bin.py
@@ -5,7 +5,7 @@ from ...maps import Map
 from ..main import cli
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_bin_image_main(tmpdir):
     """Run ``gammapy-bin-image`` and compare result to ``ctskymap``.
     """

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -39,7 +39,7 @@ def config():
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @requires_dependency("sherpa")
 def test_spectrum_analysis_iact(tmpdir, config, observations):
     config["outdir"] = tmpdir

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -311,7 +311,7 @@ class TestSimpleFit:
         assert_allclose(pars["index"].value, 1.920686, rtol=1e-3)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 @requires_dependency("iminuit")
 class TestSpectralFit:
     """Test fit in astrophysical scenario"""

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -64,7 +64,7 @@ def extraction(bkg_estimate, observations):
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestSpectrumExtraction:
     @staticmethod
     @pytest.mark.parametrize(

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -100,7 +100,7 @@ class TestFit:
 
 
 @requires_dependency("iminuit")
-@requires_data("gammapy-data")
+@requires_data()
 class TestSpectralFit:
     """Test fit in astrophysical scenario"""
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -152,7 +152,7 @@ def flux_points_likelihood():
     return FluxPoints.read(path).to_sed_type("dnde")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFluxPoints:
     def test_info(self, flux_points):
         info = str(flux_points)
@@ -214,7 +214,7 @@ class TestFluxPoints:
             flux_points_likelihood.plot_likelihood()
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_compute_flux_points_dnde_fermi():
     """
     Test compute_flux_points_dnde on fermi source.
@@ -241,7 +241,7 @@ def fit():
     return Fit(dataset)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 class TestFluxPointFit:
     @requires_dependency("iminuit")
     def test_fit_pwl_minuit(self, fit):

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -143,7 +143,7 @@ class TestFluxPointsEstimator:
 
     @staticmethod
     @requires_dependency("iminuit")
-    @requires_data("gammapy-data")
+    @requires_data()
     def test_run_map_pwl(fpe_map_pwl):
         fp = fpe_map_pwl.run()
 
@@ -170,7 +170,7 @@ class TestFluxPointsEstimator:
 
     @staticmethod
     @requires_dependency("iminuit")
-    @requires_data("gammapy-data")
+    @requires_data()
     def test_run_map_pwl_reoptimize(fpe_map_pwl_reoptimize):
         fp = fpe_map_pwl_reoptimize.run(steps=["err", "norm-scan", "ts"])
 

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -236,7 +236,7 @@ def test_model_unit():
 
 
 @requires_dependency("matplotlib")
-@requires_data("gammapy-data")
+@requires_data()
 def test_table_model_from_file():
     filename = "$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz"
     absorption_z03 = TableModel.read_xspec_model(filename=filename, param=0.3)
@@ -244,7 +244,7 @@ def test_table_model_from_file():
         absorption_z03.plot(energy_range=(0.03, 10), energy_unit=u.TeV, flux_unit="")
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_absorption():
     # absorption values for given redshift
     redshift = 0.117
@@ -301,7 +301,7 @@ def test_pwl_index_2_error():
     assert_quantity_allclose(eflux_err, 0.2302585e-12 * u.Unit("TeV cm-2 s-1"))
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_fermi_isotropic():
     filename = "$GAMMAPY_DATA/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt"
     model = TableModel.read_fermi_isotropic_model(filename)

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -32,7 +32,7 @@ def sens():
     return sens
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_cta_sensitivity_estimator(sens):
     table = sens.results_table
 

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -194,7 +194,7 @@ def spec_extraction():
     return extraction
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_lightcurve_estimator(spec_extraction):
     lc_estimator = LightCurveEstimator(spec_extraction)
 
@@ -241,7 +241,7 @@ def test_lightcurve_estimator(spec_extraction):
     # TODO: add asserts on all measured quantities
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_lightcurve_interval_maker(spec_extraction):
     table = LightCurveEstimator.make_time_intervals_fixes(500, spec_extraction)
     intervals = list(zip(table["t_start"], table["t_stop"]))
@@ -251,7 +251,7 @@ def test_lightcurve_interval_maker(spec_extraction):
     assert_allclose(t[1].value - t[0].value, 500 / (24 * 3600), rtol=1e-5)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_lightcurve_adaptative_interval_maker(spec_extraction):
     lc_estimator = LightCurveEstimator(spec_extraction)
     separator = [

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -16,14 +16,14 @@ def phase_curve():
     )
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_phasecurve_phase(phase_curve):
     time = 46300.0
     phase = phase_curve.phase(time)
     assert_allclose(phase, 0.7066006737999402)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_phasecurve_evaluate(phase_curve):
     time = 46300.0
     value = phase_curve.evaluate_norm_at_time(time)
@@ -42,19 +42,19 @@ def light_curve():
     return LightCurveTableModel.read(path)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_light_curve_str(light_curve):
     ss = str(light_curve)
     assert "LightCurveTableModel" in ss
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_light_curve_evaluate_norm_at_time(light_curve):
     val = light_curve.evaluate_norm_at_time(46300)
     assert_allclose(val, 0.021192223042749835)
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_light_curve_mean_norm_in_time_interval(light_curve):
     val = light_curve.mean_norm_in_time_interval(46300, 46301)
     assert_allclose(val, 0.021192284384617066)

--- a/gammapy/utils/serialization/tests/test_xml.py
+++ b/gammapy/utils/serialization/tests/test_xml.py
@@ -46,7 +46,7 @@ def test_xml_errors():
     # TODO: Think about a more elaborate XML validation scheme
 
 
-@requires_data("gammapy-data")
+@requires_data()
 def test_complex():
     filename = "$GAMMAPY_DATA/tests/models/examples.xml"
     sourcelib = SkyModels.read(filename)
@@ -114,7 +114,7 @@ def test_complex():
 
 
 @pytest.mark.xfail(reason="Need to improve XML read")
-@requires_data("gammapy-data")
+@requires_data()
 @pytest.mark.parametrize(
     "filename",
     [
@@ -136,7 +136,7 @@ def test_models(filename, tmpdir):
 
 
 @pytest.mark.xfail(reason="Need to improve XML read")
-@requires_data("gammapy-data")
+@requires_data()
 def test_sky_models_old_xml_file():
     filename = "$GAMMAPY_DATA/tests/models/shell.xml"
     sources = SkyModels.read(filename)
@@ -152,7 +152,7 @@ def test_sky_models_old_xml_file():
 
 
 @pytest.mark.xfail(reason="Need to improve XML read")
-@requires_data("gammapy-data")
+@requires_data()
 def test_sky_models_new_xml_file():
     filename = "$GAMMAPY_DATA/tests/models/ctadc_skymodel_gps_sources_bright.xml"
     sources = SkyModels.read(filename)

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -75,12 +75,18 @@ def requires_data(name):
 
         from gammapy.utils.testing import requires_data
 
-        @requires_data('gammapy-data')
+        @requires_data("gammapy-data")
         def test_using_data_files():
             filename = "$GAMMAPY_DATA/..."
             ...
     """
     import pytest
+
+    if not isinstance(name, str):
+        raise TypeError(
+            "You must call @requires_data with a name (str). "
+            'Usually this:  @requires_data("gammapy-data")'
+        )
 
     skip_it = not has_data(name)
 

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -66,7 +66,7 @@ def has_data(name):
         raise ValueError("Invalid name: {}".format(name))
 
 
-def requires_data(name):
+def requires_data(name="gammapy-data"):
     """Decorator to declare required data for tests.
 
     Examples
@@ -75,7 +75,7 @@ def requires_data(name):
 
         from gammapy.utils.testing import requires_data
 
-        @requires_data("gammapy-data")
+        @requires_data()
         def test_using_data_files():
             filename = "$GAMMAPY_DATA/..."
             ...
@@ -85,7 +85,7 @@ def requires_data(name):
     if not isinstance(name, str):
         raise TypeError(
             "You must call @requires_data with a name (str). "
-            'Usually this:  @requires_data("gammapy-data")'
+            'Usually this:  @requires_data()'
         )
 
     skip_it = not has_data(name)


### PR DESCRIPTION
This PR adds a default for `@requires_data()`, so that one doesn't have to type `@requires_data("gammapy-data")` each time.

It also improves the error message if someone puts `@requires_data` (was very cryptic before) without `@requires_data()`.

I don't want to change to `@requires_data` and make this a decorator for now, because I don't know how this interacts with the pytest decorator machinery.