### PR TITLE
Add sphinx-astropy for dev env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties=3.0 pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties=3.0 pandas naima sherpa libgfortran iminuit regions reproject pandoc ipython jupyter'
 
-        - PIP_DEPENDENCIES='nbsphinx sphinx-click sphinx_rtd_theme pytest-astropy'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -38,6 +38,7 @@ dependencies:
   - pylint
   - flake8
   - pip:
+    - sphinx-astropy
     - sphinx-rtd-theme
     - nbsphinx
     - sphinx-click


### PR DESCRIPTION
I noticed that `sphinx-astropy` was missing from the `gammapy-dev` env.

It's auto-fetched on `python setup.py build_docs` via some magic if missing:
https://gist.github.com/debaice/987f289706d1c51d01bade906b99536a#file-gistfile1-txt-L397-L399
But that's bad - some build environments (e.g. Debian) only allow internet access at some phases, not at any time. Or if a dev is without internet access. It's cleaner to have env install first, then docs build.