### PR TITLE
Change counts_on to counts attribute in SpectrumDatasetOnOff

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -126,7 +126,7 @@ class SpectrumExtraction:
             self.containment = np.ones(self._aeff.energy.nbin)
 
         spectrum_observation = SpectrumDatasetOnOff(
-            counts_on=self._on_vector,
+            counts=self._on_vector,
             aeff=self._aeff,
             counts_off=self._off_vector,
             edisp=self._edisp,

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -867,7 +867,7 @@ class FluxPointsEstimator:
         """Energy grouping table `~astropy.table.Table`"""
         dataset = self.datasets.datasets[0]
         try:
-            energy_axis = dataset.counts_on.energy
+            energy_axis = dataset.counts.energy
         except AttributeError:
             energy_axis = dataset.counts.geom.get_axis_by_name("energy")
         return energy_axis.group_table(self.e_edges)

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -145,13 +145,13 @@ class SpectrumSimulation:
         if self.background_model is not None:
             self.simulate_background_counts(random_state)
         obs = SpectrumDatasetOnOff(
-            counts_on=self.on_vector,
+            counts=self.on_vector,
             counts_off=self.off_vector,
             aeff=self.aeff,
             edisp=self.edisp,
             livetime=self.livetime
         )
-        obs.counts_on.obs_id = obs_id
+        obs.counts.obs_id = obs_id
         self.obs = obs
 
     def simulate_source_counts(self, rand):

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -108,7 +108,7 @@ class TestSpectrumDatasetOnOff:
 
     def test_init_no_model(self):
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             edisp=self.edisp,
@@ -123,7 +123,7 @@ class TestSpectrumDatasetOnOff:
 
     def test_alpha(self):
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             edisp=self.edisp,
@@ -135,7 +135,7 @@ class TestSpectrumDatasetOnOff:
 
     def test_data_shape(self):
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             edisp=self.edisp,
@@ -149,7 +149,7 @@ class TestSpectrumDatasetOnOff:
         model = ConstantModel(const)
         livetime = 1 * u.s
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             model=model,
@@ -171,7 +171,7 @@ class TestSpectrumDatasetOnOff:
 
         with pytest.raises(ValueError):
             SpectrumDatasetOnOff(
-                counts_on=self.on_counts,
+                counts=self.on_counts,
                 counts_off=self.off_counts,
                 aeff=self.aeff,
                 edisp=self.edisp,
@@ -182,7 +182,7 @@ class TestSpectrumDatasetOnOff:
     @requires_dependency("matplotlib")
     def test_peek(self):
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             livetime=self.livetime,
@@ -195,7 +195,7 @@ class TestSpectrumDatasetOnOff:
     def test_plot_fit(self):
         model = PowerLaw()
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             model=model,
             aeff=self.aeff,
@@ -208,7 +208,7 @@ class TestSpectrumDatasetOnOff:
 
     def test_to_from_ogip_files(self, tmpdir):
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             edisp=self.edisp,
@@ -218,13 +218,13 @@ class TestSpectrumDatasetOnOff:
         filename = tmpdir / self.on_counts.phafile
         newdataset = SpectrumDatasetOnOff.from_ogip_files( str(filename) )
 
-        assert_allclose(self.on_counts.data.data, newdataset.counts_on.data.data)
+        assert_allclose(self.on_counts.data.data, newdataset.counts.data.data)
         assert_allclose(self.off_counts.data.data, newdataset.counts_off.data.data)
         assert_allclose(self.edisp.pdf_matrix, newdataset.edisp.pdf_matrix)
 
     def test_total_stats(self):
         dataset = SpectrumDatasetOnOff(
-            counts_on=self.on_counts,
+            counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=self.aeff,
             edisp=self.edisp,
@@ -278,7 +278,7 @@ class TestSimpleFit:
         """WStat with on source and background spectrum"""
         on_vector = self.src.copy()
         on_vector.data.data += self.bkg.data.data
-        obs = SpectrumDatasetOnOff(counts_on=on_vector, counts_off=self.off)
+        obs = SpectrumDatasetOnOff(counts=on_vector, counts_off=self.off)
         obs.model = self.source_model
 
         self.source_model.parameters.index = 1.12
@@ -295,14 +295,14 @@ class TestSimpleFit:
         """Test joint fit for obs with different energy binning"""
         on_vector = self.src.copy()
         on_vector.data.data += self.bkg.data.data
-        obs1 = SpectrumDatasetOnOff(counts_on=on_vector, counts_off=self.off)
+        obs1 = SpectrumDatasetOnOff(counts=on_vector, counts_off=self.off)
         obs1.model = self.source_model
 
         src_rebinned = self.src.rebin(2)
         bkg_rebinned = self.off.rebin(2)
         src_rebinned.data.data += self.bkg.rebin(2).data.data
 
-        obs2 = SpectrumDatasetOnOff(counts_on=src_rebinned, counts_off=bkg_rebinned)
+        obs2 = SpectrumDatasetOnOff(counts=src_rebinned, counts_off=bkg_rebinned)
         obs2.model = self.source_model
 
         fit = Fit([obs1, obs2])
@@ -431,10 +431,10 @@ def make_observation_list():
     on_vector.livetime = livetime
     on_vector.obs_id = 2
     obs1 = SpectrumDatasetOnOff(
-        counts_on=on_vector, counts_off=off_vector1, aeff=aeff, edisp=edisp, livetime=livetime
+        counts=on_vector, counts_off=off_vector1, aeff=aeff, edisp=edisp, livetime=livetime
     )
     obs2 = SpectrumDatasetOnOff(
-        counts_on=on_vector, counts_off=off_vector2, aeff=aeff, edisp=edisp, livetime=livetime
+        counts=on_vector, counts_off=off_vector2, aeff=aeff, edisp=edisp, livetime=livetime
     )
 
     obs_list = [obs1, obs2]
@@ -455,7 +455,7 @@ class TestSpectrumDatasetOnOffStacker:
 
     def test_basic(self):
         assert "Stacker" in str(self.obs_stacker)
-        assert "stacked" in str(self.obs_stacker.stacked_obs.counts_on.phafile)
+        assert "stacked" in str(self.obs_stacker.stacked_obs.counts.phafile)
         counts1 = self.obs_list[0].total_stats_safe_range.n_on
         counts2 = self.obs_list[1].total_stats_safe_range.n_on
         summed_counts = counts1 + counts2

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -136,12 +136,12 @@ class TestSpectrumExtraction:
             testobs.aeff.data.data, extraction.spectrum_observations[0].aeff.data.data
         )
         assert_quantity_allclose(
-            testobs.counts_on.data.data,
-            extraction.spectrum_observations[0].counts_on.data.data,
+            testobs.counts.data.data,
+            extraction.spectrum_observations[0].counts.data.data,
         )
         assert_allclose(
-            testobs.counts_on.energy.center,
-            extraction.spectrum_observations[0].counts_on.energy.center,
+            testobs.counts.energy.center,
+            extraction.spectrum_observations[0].counts.energy.center,
         )
 
     @requires_dependency("sherpa")

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -78,7 +78,7 @@ class TestFit:
 
     def test_fit_range(self):
         """Test fit range without complication of thresholds"""
-        dataset = SpectrumDatasetOnOff(counts_on=self.src)
+        dataset = SpectrumDatasetOnOff(counts=self.src)
         dataset.model = self.source_model
 
         assert np.sum(dataset.mask) == self.nbins
@@ -138,7 +138,7 @@ class TestSpectralFit:
     def test_fit_range(self):
         # Fit range not restriced fit range should be the thresholds
         obs = self.obs_list[0]
-        desired = obs.counts_on.lo_threshold
+        desired = obs.counts.lo_threshold
 
         actual = obs.energy_range[0]
 
@@ -149,9 +149,9 @@ class TestSpectralFit:
         dataset = self.obs_list[0]
 
         # Bring aeff in RECO space
-        energy = dataset.counts_on.energy.center
+        energy = dataset.counts.energy.center
         data = dataset.aeff.data.evaluate(energy=energy)
-        e_edges = dataset.counts_on.energy.edges
+        e_edges = dataset.counts.energy.edges
 
         dataset.aeff = EffectiveAreaTable(
             data=data,

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -34,31 +34,31 @@ class TestSpectrumSimulation:
 
     def test_without_background(self):
         self.sim.simulate_obs(seed=23, obs_id=23)
-        assert self.sim.obs.counts_on.total_counts == 160
+        assert self.sim.obs.counts.total_counts == 160
 
     def test_with_background(self):
         self.sim.background_model = self.background_model
         self.sim.alpha = self.alpha
         self.sim.simulate_obs(seed=23, obs_id=23)
-        assert self.sim.obs.counts_on.total_counts == 530
+        assert self.sim.obs.counts.total_counts == 530
         assert self.sim.obs.counts_off.total_counts == 1112
 
     def test_observations_list(self):
         seeds = np.arange(5)
         self.sim.run(seed=seeds)
         assert (np.array([_.obs_id for _ in self.sim.result]) == seeds).all()
-        assert self.sim.result[0].counts_on.total_counts == 158
-        assert self.sim.result[1].counts_on.total_counts == 158
-        assert self.sim.result[2].counts_on.total_counts == 161
-        assert self.sim.result[3].counts_on.total_counts == 168
-        assert self.sim.result[4].counts_on.total_counts == 186
+        assert self.sim.result[0].counts.total_counts == 158
+        assert self.sim.result[1].counts.total_counts == 158
+        assert self.sim.result[2].counts.total_counts == 161
+        assert self.sim.result[3].counts.total_counts == 168
+        assert self.sim.result[4].counts.total_counts == 186
 
     def test_without_edisp(self):
         sim = SpectrumSimulation(
             aeff=self.sim.aeff, source_model=self.sim.source_model, livetime=4 * u.h
         )
         sim.simulate_obs(seed=23, obs_id=23)
-        assert sim.obs.counts_on.total_counts == 161
+        assert sim.obs.counts.total_counts == 161
         # The test value is taken from the test with edisp
         assert_allclose(
             np.sum(sim.npred_source.data.data.value), 167.467572145, rtol=0.01
@@ -72,4 +72,4 @@ class TestSpectrumSimulation:
             source_model=self.source_model, livetime=4 * u.h, e_true=e_true
         )
         sim.simulate_obs(seed=23, obs_id=23)
-        assert sim.obs.counts_on.total_counts == 10509
+        assert sim.obs.counts.total_counts == 10509

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -460,11 +460,11 @@ class LightCurveEstimator:
         off = self.off_evt_list[t_index]
         on = self.on_evt_list[t_index]
         # introduce the e_reco binning here
-        e_reco = spec.counts_on.energy.edges
+        e_reco = spec.counts.energy.edges
         if energy_range is not None:
-            emin = e_reco[e_reco.searchsorted(max(spec.counts_on.lo_threshold, energy_range[0]))]
+            emin = e_reco[e_reco.searchsorted(max(spec.lo_threshold, energy_range[0]))]
             emax = e_reco[
-                e_reco.searchsorted(min(spec.counts_on.hi_threshold, energy_range[1])) - 1
+                e_reco.searchsorted(min(spec.hi_threshold, energy_range[1])) - 1
             ]
             # filter the event list with energy
             on = on.select_energy([emin, emax])
@@ -808,8 +808,8 @@ class LightCurveEstimator:
             e_idx = np.where(
                 np.logical_and.reduce(
                     (
-                        e_reco >= spec.counts_on.lo_threshold,  # threshold
-                        e_reco <= spec.counts_on.hi_threshold,  # threshold
+                        e_reco >= spec.lo_threshold,  # threshold
+                        e_reco <= spec.hi_threshold,  # threshold
                         e_reco >= energy_range[0],  # user
                         e_reco <= energy_range[-1],
                     )  # user

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -425,7 +425,7 @@
     "stacker = SpectrumDatasetOnOffStacker(extraction.spectrum_observations)\n",
     "dataset_stacked = stacker.run()\n",
     "\n",
-    "e_min, e_max = dataset_stacked.counts_on.lo_threshold.to_value(\"TeV\"), 30\n",
+    "e_min, e_max = dataset_stacked.counts.lo_threshold.to_value(\"TeV\"), 30\n",
     "e_edges = np.logspace(np.log10(e_min), np.log10(e_max), 15) * u.TeV"
    ]
   },


### PR DESCRIPTION
This PR modifies the name of the `counts_on` attribute to `counts`.
This ensures naming consistency with other datasets, e.g. `MapDataset` and should allow a more uniform treatment in other parts of the code (e.g. in utils/fitting).