### PR TITLE
Add default of "all" for DataStore.get_observations

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -236,13 +236,13 @@ class DataStore:
         """
         return DataStoreObservation(obs_id=int(obs_id), data_store=self)
 
-    def get_observations(self, obs_id, skip_missing=False):
+    def get_observations(self, obs_id=None, skip_missing=False):
         """Generate a `~gammapy.data.Observations`.
 
         Parameters
         ----------
         obs_id : list
-            Observation IDs.
+            Observation IDs (default of ``None`` means "all")
         skip_missing : bool, optional
             Skip missing observations, default: False
 
@@ -251,6 +251,9 @@ class DataStore:
         observations : `~gammapy.data.Observations`
             Container holding a list of `~gammapy.data.DataStoreObservation`
         """
+        if obs_id is None:
+            obs_id = self.obs_table["OBS_ID"].data
+
         obs_list = []
         for _ in obs_id:
             try:

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -66,6 +66,10 @@ def test_datastore_get_observations(data_store):
     observations = data_store.get_observations([23523, 23592])
     assert observations[0].obs_id == 23523
 
+    # Test that default is all observations
+    observations = data_store.get_observations()
+    assert len(observations) == 105
+
     with pytest.raises(ValueError):
         data_store.get_observations([11111, 23592])
 


### PR DESCRIPTION
This PR  adds a default of "all" to `DataStore.get_observations`.

It resolves #1255 .

I've changed my mind on this, especially now that we've added `from_events_files` I feel that always having to put `obs_id = data_store.obs_table["OBS_ID"].data` in each analysis script is annoying.

https://github.com/gammapy/gammapy/blob/12ab685eee6a4a80227fb7cee56ebf9d827c69a0/gammapy/data/data_store.py#L160-L179