### PR TITLE
Fix `integrate_spectrum` for small integration ranges 

### DIFF
--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -314,7 +314,7 @@ def test_ecpl_intergrate():
     # regresseion test to check the numerical integration for small energy bins
     ecpl = ExponentialCutoffPowerLaw()
     value = ecpl.integral(1 * u.TeV, 1.1 * u.TeV)
-    assert_quantity_allclose(value, 0 * u.Unit("s-1 cm-2"))
+    assert_quantity_allclose(value, 8.380714e-14 * u.Unit("s-1 cm-2"))
 
 
 @requires_dependency("naima")

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -310,6 +310,13 @@ def test_fermi_isotropic():
     )
 
 
+def test_ecpl_intergrate():
+    # regresseion test to check the numerical integration for small energy bins
+    ecpl = ExponentialCutoffPowerLaw()
+    value = ecpl.integral(1 * u.TeV, 1.1 * u.TeV)
+    assert_quantity_allclose(value, 0 * u.Unit("s-1 cm-2"))
+
+
 @requires_dependency("naima")
 class TestNaimaModel:
     # Used to test model value at 2 TeV

--- a/gammapy/spectrum/utils.py
+++ b/gammapy/spectrum/utils.py
@@ -150,7 +150,7 @@ def integrate_spectrum(func, xmin, xmax, ndecade=100, intervals=False):
     if np.isscalar(xmin):
         logmin = np.log10(xmin)
         logmax = np.log10(xmax)
-        n = int((logmax - logmin)) * ndecade
+        n = int((logmax - logmin) * ndecade)
         x = np.logspace(logmin, logmax, n)
     else:
         x = np.append(xmin, xmax[-1])


### PR DESCRIPTION
This PR fixes a bug in the `integrate_spectrum` method reported by @luca-giunti. If `emin` and `emax` was within the same decade, the integration method would return `0`, as the total number of sub-bins for the integration would be rounded to `0`. A regression test is added as well.