### PR TITLE
Change missing links in notebooks

### DIFF
--- a/tutorials/hgps.ipynb
+++ b/tutorials/hgps.ipynb
@@ -1142,7 +1142,7 @@
     "\n",
     "* Re-run this notebook, but change the HGPS source that was used for examples. If you have any questions about the data, try to access and print or plot it. Just to give a few ideas: How many identified pulsar wind nebulae are in HGPS? Which are the 5 brightest HGPS sources in the 1-10 TeV energy band? Which is the second-highest significance source in the HPGS image after the Galactic center?\n",
     "* Try to reproduce some of the figures in the HGPS paper. Don't try to reproduce them exactly, but just try to write ~ 10 lines of code to access the relevant HGPS data and make a quick plot that shows the same or similar information.\n",
-    "* Fit a spectral model to the spectral points of Vela X and compare with the HGPS model fit. (they should be similar, but not identical, in HGPS a likelihood fit to counts data was done). For this task, the [spectrum_models](https://docs.gammapy.org/dev/notebooks/spectrum_models.html) and [sed_fitting_gammacat_fermi](https://docs.gammapy.org/dev/notebooks/sed_fitting_gammacat_fermi.html) tutorials will be useful.\n"
+    "* Fit a spectral model to the spectral points of Vela X and compare with the HGPS model fit. (they should be similar, but not identical, in HGPS a likelihood fit to counts data was done). For this task, the [sed_fitting_gammacat_fermi](https://docs.gammapy.org/dev/notebooks/sed_fitting_gammacat_fermi.html) tutorials will be useful.\n"
    ]
   },
   {

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -380,12 +380,18 @@
     "\n",
     "This was an introduction to SED fitting in Gammapy.\n",
     "\n",
-    "* If you would like to learn how to perform a full Poisson maximum likelihood spectral fit, please check out the [spectrum pipe](spectrum_pipe.ipynb) tutorial.\n",
-    "* If you are interested in simulation of spectral data in the context of CTA, please check out the [spectrum simulation cta](spectrum_simulation_cta.ipynb) notebook.\n",
+    "* If you would like to learn how to perform a full Poisson maximum likelihood spectral fit, please check out the [spectrum analysis](spectrum_analysis.ipynb) tutorial.\n",
     "* To learn more about other parts of Gammapy (e.g. Fermi-LAT and TeV data analysis), check out the other tutorial notebooks.\n",
     "* To see what's available in Gammapy, browse the [Gammapy docs](https://docs.gammapy.org/) or use the full-text search.\n",
     "* If you have any questions, ask on the mailing list ."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -335,7 +335,7 @@
    "source": [
     "## Look at observations\n",
     "\n",
-    "Now we will look at the files we just created. We will use the [SpectrumObservation](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumObservation.html) object that are still in memory from the extraction step. Note, however, that you could also read them from disk if you have written them in the step above. The ``ANALYSIS_DIR`` folder contains 4 ``FITS`` files for each observation. These files are described in detail [here](https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/ogip/index.html). In short, they correspond to the on vector, the off vector, the effectie area, and the energy dispersion."
+    "Now we will look at the files we just created. We will use the [SpectrumDatasetOnOff](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumDatasetOnOff.html) object that are still in memory from the extraction step. Note, however, that you could also read them from disk if you have written them in the step above. The ``ANALYSIS_DIR`` folder contains 4 ``FITS`` files for each observation. These files are described in detail [here](https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/ogip/index.html). In short, they correspond to the on vector, the off vector, the effectie area, and the energy dispersion."
    ]
   },
   {

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "We will use the following classes:\n",
     "\n",
-    "* [gammapy.spectrum.SpectrumObservation](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumObservation.html)\n",
+    "* [gammapy.spectrum.SpectrumDatasetOnOff](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumDatasetOnOff.html)\n",
     "* [gammapy.spectrum.SpectrumSimulation](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumSimulation.html)\n",
     "* [gammapy.irf.load_cta_irfs](https://docs.gammapy.org/dev/api/gammapy.irf.load_cta_irfs.html)\n",
     "* [gammapy.spectrum.models.PowerLaw](https://docs.gammapy.org/dev/api/gammapy.spectrum.models.PowerLaw.html)"


### PR DESCRIPTION
This small PR corrects 4 notebooks which have incorrect links to other notebooks or documentation. This mostly comes from modifications introduced by PR #2139 and PR #2137 .