### PR TITLE
Fix TestReflectedRegionBackgroundEstimator.test_run

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -33,6 +33,7 @@ dependencies:
   - iminuit
   - pytest
   - pytest-cov
+  - pytest-xdist
   - sphinx
   - pandoc
   - pylint

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -43,12 +43,14 @@ def observations():
 @pytest.fixture(scope="session")
 def bkg_estimator(observations, exclusion_mask, on_region):
     """Example background estimator for testing."""
-    return ReflectedRegionsBackgroundEstimator(
+    maker = ReflectedRegionsBackgroundEstimator(
         observations=observations,
         on_region=on_region,
         exclusion_mask=exclusion_mask,
         min_distance_input="0.2 deg",
     )
+    maker.run()
+    return maker
 
 
 @requires_data()
@@ -88,11 +90,11 @@ def test_find_reflected_regions(exclusion_mask, on_region):
 
 @requires_data()
 class TestReflectedRegionBackgroundEstimator:
+
     def test_basic(self, bkg_estimator):
         assert "ReflectedRegionsBackgroundEstimator" in str(bkg_estimator)
 
     def test_run(self, bkg_estimator):
-        bkg_estimator.run()
         assert len(bkg_estimator.result[1].off_region) == 11
         assert "Reflected" in str(bkg_estimator.result[1])
 


### PR DESCRIPTION
@adonath @registerrier - I started using `pytest -n auto` to locally run tests in parallel using https://pypi.org/project/pytest-xdist/

For me, currently this reduces the time to execute all tests from 123 sec to 56 sec, which is nice.

It does mean test execution is non-deterministic though. Generally tests should be independent anyways, pytest doesn't guarantee any order. There was one fail where we depended on test order execution (`TestReflectedRegionBackgroundEstimator.test_run`), fixed here.

I also added `pytest-xdist` to the `environment.yml`, so that devs can use `pytest -n auto` if they want locally (the default remains non-parallel execution after installing the plugin).

Early in the project we used `pytest-xdist` in CI and this was causing issues - some fails started to come and go indeterministically, and test logs weren't linear and harder to read. So I'm not proposing we use that in CI for now, but I think having the dev env and being able to use it locally is nice.