### PR TITLE
Unify Dataset mask handling

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -28,7 +28,7 @@ class MapDataset(Dataset):
         Counts cube
     exposure : `~gammapy.maps.WcsNDMap`
         Exposure cube
-    mask_fit : `~gammapy.maps.WcsNDMap`
+    mask_fit : `~numpy.ndarray`
         Mask to apply to the likelihood for fitting.
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel
@@ -62,7 +62,7 @@ class MapDataset(Dataset):
         evaluation_mode="local",
         mask_safe=None,
     ):
-        if mask_fit is not None and mask_fit.data.dtype != np.dtype("bool"):
+        if mask_fit is not None and mask_fit.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
 
         self.evaluation_mode = evaluation_mode
@@ -172,9 +172,9 @@ class MapDataset(Dataset):
         elif self.mask_fit is None:
             stat = self._stat_sum(counts[self.mask_safe], npred[self.mask_safe])
         elif self.mask_safe is None:
-            stat = self._stat_sum(counts[self.mask_fit.data], npred[self.mask_fit.data])
+            stat = self._stat_sum(counts[self.mask_fit], npred[self.mask_fit])
         else:
-            mask_joined = self.mask_safe & self.mask_fit.data
+            mask_joined = self.mask_safe & self.mask_fit
             stat = self._stat_sum(counts[mask_joined], npred[mask_joined])
 
         return stat

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -45,6 +45,8 @@ class MapDataset(Dataset):
         This mode is recommended for local optimization algorithms.
         The "global" evaluation mode evaluates the model components on the full map.
         This mode is recommended for global optimization algorithms.
+    mask_safe : `~numpy.ndarray`
+        Mask defining the safe data range.
     """
 
     def __init__(
@@ -58,6 +60,7 @@ class MapDataset(Dataset):
         background_model=None,
         likelihood="cash",
         evaluation_mode="local",
+        mask_safe=None,
     ):
         if mask_fit is not None and mask_fit.data.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
@@ -70,6 +73,7 @@ class MapDataset(Dataset):
         self.psf = psf
         self.edisp = edisp
         self.background_model = background_model
+        self.mask_safe = mask_safe
 
         if likelihood == "cash":
             self._stat = cash
@@ -155,26 +159,22 @@ class MapDataset(Dataset):
     def _counts_data(self):
         return self.counts.data.astype(float)
 
-    def likelihood(self, parameters, mask=None):
+    def likelihood(self, parameters):
         """Total likelihood given the current model parameters.
 
-        Parameters
-        ----------
-        mask : `~numpy.ndarray`
-            Mask to be combined with the dataset mask.
         """
         counts, npred = self._counts_data, self.npred().data
 
         # TODO: add mask handling to _stat_sum, so that the temp copy
         # created by the fancy indexing is avoided
-        if self.mask_fit is None and mask is None:
+        if self.mask_fit is None and self.mask_safe is None:
             stat = self._stat_sum(counts.ravel(), npred.ravel())
         elif self.mask_fit is None:
-            stat = self._stat_sum(counts[mask], npred[mask])
-        elif mask is None:
+            stat = self._stat_sum(counts[self.mask_safe], npred[self.mask_safe])
+        elif self.mask_safe is None:
             stat = self._stat_sum(counts[self.mask_fit.data], npred[self.mask_fit.data])
         else:
-            mask_joined = mask & self.mask_fit.data
+            mask_joined = self.mask_safe & self.mask_fit.data
             stat = self._stat_sum(counts[mask_joined], npred[mask_joined])
 
         return stat

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -28,8 +28,8 @@ class MapDataset(Dataset):
         Counts cube
     exposure : `~gammapy.maps.WcsNDMap`
         Exposure cube
-    mask : `~gammapy.maps.WcsNDMap`
-        Mask to apply to the likelihood.
+    mask_fit : `~gammapy.maps.WcsNDMap`
+        Mask to apply to the likelihood for fitting.
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel
     edisp : `~gammapy.irf.EnergyDispersion`
@@ -52,21 +52,21 @@ class MapDataset(Dataset):
         model,
         counts=None,
         exposure=None,
-        mask=None,
+        mask_fit=None,
         psf=None,
         edisp=None,
         background_model=None,
         likelihood="cash",
         evaluation_mode="local",
     ):
-        if mask is not None and mask.data.dtype != np.dtype("bool"):
+        if mask_fit is not None and mask_fit.data.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
 
         self.evaluation_mode = evaluation_mode
         self.model = model
         self.counts = counts
         self.exposure = exposure
-        self.mask = mask
+        self.mask_fit = mask_fit
         self.psf = psf
         self.edisp = edisp
         self.background_model = background_model
@@ -167,14 +167,14 @@ class MapDataset(Dataset):
 
         # TODO: add mask handling to _stat_sum, so that the temp copy
         # created by the fancy indexing is avoided
-        if self.mask is None and mask is None:
+        if self.mask_fit is None and mask is None:
             stat = self._stat_sum(counts.ravel(), npred.ravel())
-        elif self.mask is None:
+        elif self.mask_fit is None:
             stat = self._stat_sum(counts[mask], npred[mask])
         elif mask is None:
-            stat = self._stat_sum(counts[self.mask.data], npred[self.mask.data])
+            stat = self._stat_sum(counts[self.mask_fit.data], npred[self.mask_fit.data])
         else:
-            mask_joined = mask & self.mask.data
+            mask_joined = mask & self.mask_fit.data
             stat = self._stat_sum(counts[mask_joined], npred[mask_joined])
 
         return stat

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -77,7 +77,7 @@ def sky_model():
     return SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
 
-def mask(geom, sky_model):
+def mask_fit(geom, sky_model):
     p = sky_model.spatial_model.parameters
     center = SkyCoord(p["lon_0"].value, p["lat_0"].value, frame="galactic", unit="deg")
     circle = CircleSkyRegion(center=center, radius=1 * u.deg)
@@ -119,14 +119,14 @@ def test_map_fit(sky_model):
         sky_model, exposure_map, background_model_2, psf_map, edisp_map
     )
 
-    mask_map = mask(geom_r, sky_model)
+    mask_map = mask_fit(geom_r, sky_model)
     sky_model.parameters["sigma"].frozen = True
 
     dataset_1 = MapDataset(
         model=sky_model,
         counts=counts_map_1,
         exposure=exposure_map,
-        mask=mask_map,
+        mask_fit=mask_map,
         psf=psf_map,
         edisp=edisp_map,
         background_model=background_model_1,
@@ -137,7 +137,7 @@ def test_map_fit(sky_model):
         model=sky_model,
         counts=counts_map_2,
         exposure=exposure_map,
-        mask=mask_map,
+        mask_fit=mask_map,
         psf=psf_map,
         edisp=edisp_map,
         background_model=background_model_2,
@@ -200,7 +200,7 @@ def test_map_fit_one_energy_bin(sky_model):
     edisp_map = edisp(geom_r, geom_r)
     exposure_map = exposure(geom_r)
     counts_map = counts(sky_model, exposure_map, background_model, psf_map, edisp_map)
-    mask_map = mask(geom_r, sky_model)
+    mask_map = mask_fit(geom_r, sky_model)
 
     sky_model.parameters["index"].value = 3.0
     sky_model.parameters["index"].frozen = True
@@ -212,7 +212,7 @@ def test_map_fit_one_energy_bin(sky_model):
         model=sky_model,
         counts=counts_map,
         exposure=exposure_map,
-        mask=mask_map,
+        mask_fit=mask_map,
         psf=psf_map,
         edisp=edisp_map,
         background_model=background_model,

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -176,8 +176,11 @@ def test_map_fit(sky_model):
     assert_allclose(pars[9].value, 1, rtol=1e-2)
     assert_allclose(pars.error(pars[9]), 0.02104, rtol=1e-2)
 
-    # test global mask evaluation
-    fit.datasets.mask = geom_r.energy_mask(emin=1 * u.TeV)
+    # test mask_safe evaluation
+    mask_safe = geom_r.energy_mask(emin=1 * u.TeV)
+    dataset_1.mask_safe = mask_safe
+    dataset_2.mask_safe = mask_safe
+
     stat = fit.datasets.likelihood()
     assert_allclose(stat, 5895.205587)
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -81,9 +81,7 @@ def mask_fit(geom, sky_model):
     p = sky_model.spatial_model.parameters
     center = SkyCoord(p["lon_0"].value, p["lat_0"].value, frame="galactic", unit="deg")
     circle = CircleSkyRegion(center=center, radius=1 * u.deg)
-    data = geom.region_mask([circle])
-    return WcsNDMap(geom=geom, data=data)
-
+    return geom.region_mask([circle])
 
 def counts(sky_model, exposure, background, psf, edisp):
     """This computes the total npred"""

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -261,6 +261,23 @@ class CountsSpectrum:
         )
 
 
+    def energy_mask(self, emin=None, emax=None):
+        """Create a mask for a given energy range.
+
+        Parameters
+        ----------
+        emin, emax : `~astropy.units.Quantity`
+            Energy range
+        """
+        edges = self.energy.edges
+
+        # set default values
+        emin = emin if emin is not None else edges[0]
+        emax = emax if emax is not None else edges[-1]
+
+        return (edges[:-1] > emin) & (edges[1:] < emax)
+
+
 class PHACountsSpectrum(CountsSpectrum):
     """Counts spectrum corresponding to OGIP PHA format.
 

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -240,7 +240,12 @@ class SpectrumExtraction:
         """
         for obs in self.spectrum_observations:
             emin, emax = compute_energy_thresholds(obs.aeff, obs.edisp, **kwargs)
-            obs.mask_safe = obs.counts.energy_mask(emin=emin, emax=emax)
+            mask_safe = obs.counts.energy_mask(emin=emin, emax=emax)
+
+            if obs.mask_safe is not None:
+                obs.mask_safe &= mask_safe
+            else:
+                obs.mask_safe = mask_safe
 
 
     def write(self, outdir, ogipdir="ogip_data", use_sherpa=False, overwrite=False):

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -240,13 +240,8 @@ class SpectrumExtraction:
         """
         for obs in self.spectrum_observations:
             emin, emax = compute_energy_thresholds(obs.aeff, obs.edisp, **kwargs)
-            # TODO: add proper energy range setter to SpectrumDatasetOnOff
-            # Is a reset required or not?
-            if reset:
-                obs.reset_thresholds()
+            obs.mask_safe = obs.counts.energy_mask(emin=emin, emax=emax)
 
-            obs.lo_threshold = emin
-            obs.hi_threshold = emax
 
     def write(self, outdir, ogipdir="ogip_data", use_sherpa=False, overwrite=False):
         """Write results to disk as OGIP format.

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1140,8 +1140,8 @@ class FluxPointsDataset(Dataset):
         Spectral model
     data : `~gammapy.spectrum.FluxPoints`
         Flux points.
-    mask : `numpy.ndarray`
-        Mask to apply to the likelihood.
+    mask_fit : `numpy.ndarray`
+        Mask to apply to the likelihood for fitting.
     likelihood : {"chi2", "chi2assym"}
         Likelihood function to use for the fit.
 
@@ -1166,10 +1166,10 @@ class FluxPointsDataset(Dataset):
         print(result.model)
     """
 
-    def __init__(self, model, data, mask=None, likelihood="chi2"):
+    def __init__(self, model, data, mask_fit=None, likelihood="chi2"):
         self.model = model
         self.data = data
-        self.mask = mask
+        self.mask_fit = mask_fit
         self.parameters = model.parameters
 
         if likelihood in ["chi2", "chi2assym"]:
@@ -1226,14 +1226,14 @@ class FluxPointsDataset(Dataset):
         mask : `~numpy.ndarray`
             Mask to be combined with the dataset mask.
         """
-        if self.mask is None and mask is None:
+        if self.mask_fit is None and mask is None:
             stat = self.likelihood_per_bin()
-        elif self.mask is None:
+        elif self.mask_fit is None:
             stat = self.likelihood_per_bin()[mask]
         elif mask is None:
-            stat = self.likelihood_per_bin()[self.mask]
+            stat = self.likelihood_per_bin()[self.mask_fit]
         else:
-            stat = self.likelihood_per_bin()[mask & self.mask]
+            stat = self.likelihood_per_bin()[mask & self.mask_fit]
 
         return np.nansum(stat, dtype=np.float64)
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1039,8 +1039,8 @@ class FluxPointsEstimator:
 
         for dataset in self.datasets.datasets:
             mask = self.datasets.mask.copy()
-            if dataset.mask is not None:
-                mask &= dataset.mask
+            if dataset.mask_fit is not None:
+                mask &= dataset.mask_fit
 
             if isinstance(dataset, SpectrumDatasetOnOff):
                 counts.append(dataset.counts.data.data[mask].sum())

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -961,7 +961,8 @@ class FluxPointsEstimator:
             ]
         )
 
-        self.datasets.mask = self._energy_mask(e_group)
+        for dataset in self.datasets.datasets:
+            dataset.mask_fit = self._energy_mask(e_group)
 
         self._set_scale_model()
 
@@ -1038,9 +1039,9 @@ class FluxPointsEstimator:
         counts = []
 
         for dataset in self.datasets.datasets:
-            mask = self.datasets.mask.copy()
-            if dataset.mask_fit is not None:
-                mask &= dataset.mask_fit
+            mask = dataset.mask_fit
+            if dataset.mask_safe is not None:
+                mask &= dataset.mask_safe
 
             if isinstance(dataset, SpectrumDatasetOnOff):
                 counts.append(dataset.counts.data.data[mask].sum())

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -166,19 +166,6 @@ class TestSpectrumDatasetOnOff:
 
         assert_allclose(dataset.npred().data.data.sum(), expected.value)
 
-    def test_incorrect_mask(self):
-        mask_fit = np.ones(self.on_counts.data.data.shape, dtype="int")
-
-        with pytest.raises(ValueError):
-            SpectrumDatasetOnOff(
-                counts=self.on_counts,
-                counts_off=self.off_counts,
-                aeff=self.aeff,
-                edisp=self.edisp,
-                livetime=self.livetime,
-                mask_fit=mask_fit,
-            )
-
     @requires_dependency("matplotlib")
     def test_peek(self):
         dataset = SpectrumDatasetOnOff(
@@ -482,7 +469,7 @@ class TestSpectrumDatasetOnOffStacker:
 
         for obs in self.obs_list:
             obs.model = pwl
-            npred_summed[obs.mask_fit] += obs.npred().data.data[obs.mask_fit]
+            npred_summed[obs.mask_safe] += obs.npred().data.data[obs.mask_safe]
 
         assert_allclose(npred_stacked, npred_summed)
 

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -167,7 +167,7 @@ class TestSpectrumDatasetOnOff:
         assert_allclose(dataset.npred().data.data.sum(), expected.value)
 
     def test_incorrect_mask(self):
-        mask = np.ones(self.on_counts.data.data.shape, dtype="int")
+        mask_fit = np.ones(self.on_counts.data.data.shape, dtype="int")
 
         with pytest.raises(ValueError):
             SpectrumDatasetOnOff(
@@ -176,7 +176,7 @@ class TestSpectrumDatasetOnOff:
                 aeff=self.aeff,
                 edisp=self.edisp,
                 livetime=self.livetime,
-                mask=mask,
+                mask_fit=mask_fit,
             )
 
     @requires_dependency("matplotlib")
@@ -482,7 +482,7 @@ class TestSpectrumDatasetOnOffStacker:
 
         for obs in self.obs_list:
             obs.model = pwl
-            npred_summed[obs.mask] += obs.npred().data.data[obs.mask]
+            npred_summed[obs.mask_fit] += obs.npred().data.data[obs.mask_fit]
 
         assert_allclose(npred_stacked, npred_summed)
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -81,7 +81,7 @@ class TestFit:
         dataset = SpectrumDatasetOnOff(counts=self.src)
         dataset.model = self.source_model
 
-        assert np.sum(dataset.mask) == self.nbins
+        assert np.sum(dataset.mask_fit) == self.nbins
         e_min, e_max = dataset.energy_range
 
         assert_allclose(e_max.value, 10)
@@ -130,7 +130,7 @@ class TestSpectralFit:
         result = fit.run()
 
         stats = dataset.likelihood_per_bin()
-        actual = np.sum(stats[dataset.mask])
+        actual = np.sum(stats[dataset.mask_fit])
 
         desired = result.total_stat
         assert_allclose(actual, desired)

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -81,7 +81,7 @@ class TestFit:
         dataset = SpectrumDatasetOnOff(counts=self.src)
         dataset.model = self.source_model
 
-        assert np.sum(dataset.mask_fit) == self.nbins
+        assert np.sum(dataset.mask_safe) == self.nbins
         e_min, e_max = dataset.energy_range
 
         assert_allclose(e_max.value, 10)
@@ -130,7 +130,7 @@ class TestSpectralFit:
         result = fit.run()
 
         stats = dataset.likelihood_per_bin()
-        actual = np.sum(stats[dataset.mask_fit])
+        actual = np.sum(stats[dataset.mask_safe])
 
         desired = result.total_stat
         assert_allclose(actual, desired)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -188,3 +188,18 @@ class TestFluxPointsEstimator:
 
         actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
         assert_allclose(actual, 3.698882, rtol=1e-2)
+
+
+def test_no_likelihood_contribution():
+    dataset = simulate_spectrum_dataset(PowerLaw())
+    dataset.model = PowerLaw()
+    dataset.mask_safe = np.zeros(dataset.data_shape, dtype=bool)
+
+    fpe = FluxPointsEstimator([dataset], e_edges=[1, 10] * u.TeV)
+
+    with pytest.raises(ValueError) as e:
+        fpe.run()
+        assert "No dataset contributes" in e.args[0]
+
+
+

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -65,7 +65,7 @@ def simulate_map_dataset():
 def fpe_map_pwl():
     dataset_1 = simulate_map_dataset()
     dataset_2 = dataset_1.copy()
-    dataset_2.mask_fit = np.zeros(dataset_2.data_shape).astype(bool)
+    dataset_2.mask_safe = np.zeros(dataset_2.data_shape).astype(bool)
 
     e_edges = [0.1, 1, 10, 100] * u.TeV
     return FluxPointsEstimator(

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -65,7 +65,7 @@ def simulate_map_dataset():
 def fpe_map_pwl():
     dataset_1 = simulate_map_dataset()
     dataset_2 = dataset_1.copy()
-    dataset_2.mask = np.zeros(dataset_2.data_shape).astype(bool)
+    dataset_2.mask_fit = np.zeros(dataset_2.data_shape).astype(bool)
 
     e_edges = [0.1, 1, 10, 100] * u.TeV
     return FluxPointsEstimator(

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -22,7 +22,7 @@ class Dataset(abc.ABC):
     """
 
     @abc.abstractmethod
-    def likelihood(self, parameters, mask=None):
+    def likelihood(self, parameters):
         """Total likelihood (float, sum over bins).
 
         TODO: fix interface.
@@ -46,21 +46,12 @@ class Datasets:
     ----------
     datasets : `Dataset` or list of `Dataset`
         List of `Dataset` objects ot be joined.
-    mask : `~numpy.ndarray`
-        Global fitting mask used for all datasets.
     """
 
-    def __init__(self, datasets, mask=None):
+    def __init__(self, datasets):
         if not isinstance(datasets, list):
             datasets = [datasets]
         self._datasets = datasets
-
-        if mask is not None and not self.is_all_same_shape:
-            raise ValueError(
-                "Cannot apply mask if datasets are not of the same type and shape."
-            )
-
-        self.mask = mask
 
     @lazyproperty
     def parameters(self):
@@ -98,7 +89,7 @@ class Datasets:
         # TODO: add parallel evaluation of likelihoods
         for dataset in self.datasets:
             total_likelihood += dataset.likelihood(
-                parameters=parameters, mask=self.mask
+                parameters=parameters
             )
         return total_likelihood
 

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -85,6 +85,10 @@ def _confidence_scipy_brentq(parameters, parameter, function, sigma, reoptimize,
 
 
 def confidence_scipy(parameters, parameter, function, sigma, reoptimize=True, **kwargs):
+
+    if len(parameters.free_parameters) <= 1:
+        reoptimize = False
+
     with parameters.restore_values:
         result = _confidence_scipy_brentq(
             parameters=parameters,

--- a/gammapy/utils/fitting/tests/test_datasets.py
+++ b/gammapy/utils/fitting/tests/test_datasets.py
@@ -8,7 +8,7 @@ from ..datasets import Datasets
 
 @pytest.fixture(scope="session")
 def datasets():
-    return Datasets([MyDataset(), MyDataset()], mask=np.array([True]))
+    return Datasets([MyDataset(), MyDataset()])
 
 
 class TestDatasets:

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -457,10 +457,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = Map.from_geom(maps[\"counts\"].geom)\n",
-    "\n",
-    "coords = mask.geom.get_coord()\n",
-    "mask.data = coords[\"energy\"] > 0.3"
+    "coords = maps[\"counts\"].geom.get_coord()\n",
+    "mask = coords[\"energy\"] > 0.3"
    ]
   },
   {
@@ -521,7 +519,7 @@
     "    counts=maps[\"counts\"],\n",
     "    exposure=maps[\"exposure\"],\n",
     "    background_model=background_model,\n",
-    "    mask=mask,\n",
+    "    mask_fit=mask,\n",
     "    psf=psf_kernel,\n",
     "    edisp=edisp,\n",
     ")"

--- a/tutorials/analysis_3d_joint.ipynb
+++ b/tutorials/analysis_3d_joint.ipynb
@@ -266,9 +266,8 @@
     "\n",
     "    # optionally define a safe energy threshold\n",
     "    emin = None\n",
-    "    mask_data = counts.geom.energy_mask(emin=emin)\n",
-    "    mask = Map.from_geom(geom=counts.geom, data=mask_data)\n",
-    "\n",
+    "    mask = counts.geom.energy_mask(emin=emin)\n",
+    "    \n",
     "    dataset = MapDataset(\n",
     "        model=model,\n",
     "        counts=counts,\n",
@@ -276,7 +275,7 @@
     "        psf=psf,\n",
     "        edisp=edisp,\n",
     "        background_model=background_model,\n",
-    "        mask=mask,\n",
+    "        mask_fit=mask,\n",
     "    )\n",
     "\n",
     "    datasets.append(dataset)"
@@ -473,7 +472,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/image_analysis.ipynb
+++ b/tutorials/image_analysis.ipynb
@@ -184,10 +184,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = Map.from_geom(geom2d)\n",
-    "\n",
     "region = CircleSkyRegion(center=src_pos, radius=0.6 * u.deg)\n",
-    "mask.data = mask.geom.region_mask([region])"
+    "mask = geom2d.region_mask([region])"
    ]
   },
   {
@@ -245,7 +243,7 @@
     "    counts=maps2D[\"counts\"],\n",
     "    exposure=maps2D[\"exposure\"],\n",
     "    background_model=background_model,\n",
-    "    mask=mask,\n",
+    "    mask_fit=mask,\n",
     "    psf=psf_kernel,\n",
     ")"
    ]
@@ -327,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR implements a uniform mask handling for all dataset classes we have:
- Rename the  current `mask` attributes to `mask_fit`
- Introduce a second mask `mask_safe` which define the safe data range for each dataset
- Remove the global mask on `Datasets`
- Make the `MapDataset.mask_fit` a numpy array for consistency. 