### PR TITLE
Improve test coverage in gammapy.spectrum and gammapy.image

### DIFF
--- a/gammapy/image/tests/test_plotting.py
+++ b/gammapy/image/tests/test_plotting.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from astropy.coordinates import Angle
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency
-from ...image import colormap_hess, colormap_milagro
+from ...utils.testing import requires_dependency, mpl_plot_check
+from ...image import colormap_hess, colormap_milagro, MapPanelPlotter
+from ...maps import Map
 
 
 def _check_cmap_rgb_vals(vals, cmap, vmin=0, vmax=1):
@@ -42,3 +44,14 @@ def test_colormap_milagro():
         (1.0, (1.0, 1.0, 1.0)),
     ]
     _check_cmap_rgb_vals(vals, cmap)
+
+
+def test_map_panel_plotter():
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+    plotter = MapPanelPlotter(figure=fig, xlim=Angle([-5, 5], "deg"), ylim=Angle([-2, 2], "deg"), npanels=2)
+    map_image = Map.read("$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-counts.fits.gz")
+
+    with mpl_plot_check():
+        plotter.plot(map_image)

--- a/gammapy/image/tests/test_plotting.py
+++ b/gammapy/image/tests/test_plotting.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.coordinates import Angle
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_dependency, mpl_plot_check
-from ...image import colormap_hess, colormap_milagro, MapPanelPlotter
+from ...utils.testing import requires_dependency, mpl_plot_check, requires_data
+from ...image import colormap_hess, colormap_milagro, MapPanelPlotter, illustrate_colormap
 from ...maps import Map
 
 
@@ -46,6 +46,8 @@ def test_colormap_milagro():
     _check_cmap_rgb_vals(vals, cmap)
 
 
+@requires_data()
+@requires_dependency("matplotlib")
 def test_map_panel_plotter():
     import matplotlib.pyplot as plt
 
@@ -55,3 +57,9 @@ def test_map_panel_plotter():
 
     with mpl_plot_check():
         plotter.plot(map_image)
+
+
+@requires_dependency("matplotlib")
+def test_illustrate_colormap():
+    with mpl_plot_check():
+        illustrate_colormap("afmhot")

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -291,6 +291,7 @@ class TestFluxPointFit:
 
 
     @staticmethod
+    @requires_dependency("matplotlib")
     def test_fp_dataset_peek(fit):
         fp_dataset = fit.datasets.datasets[0]
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -288,3 +288,12 @@ class TestFluxPointFit:
 
         ts_diff = profile["likelihood"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
+
+
+    @staticmethod
+    def test_fp_dataset_peek(fit):
+        fp_dataset = fit.datasets.datasets[0]
+
+        with mpl_plot_check():
+            fp_dataset.peek()
+


### PR DESCRIPTION
This PR improves the test coverage in `gammapy.spectrum` and `gammapy.image` by adding a few more tests.