### PR TITLE
Fix test_counts_predictor

### DIFF
--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -84,44 +84,26 @@ def get_test_cases():
     e_true = Quantity(np.logspace(-1, 2, 120), "TeV")
     e_reco = Quantity(np.logspace(-1, 2, 100), "TeV")
     return [
+        dict(model=PowerLaw(amplitude="1e2 TeV-1"), e_true=e_true, npred=999),
         dict(
-            model=PowerLaw(
-                index=2, reference=Quantity(1, "TeV"), amplitude=Quantity(1e2, "TeV-1")
-            ),
-            e_true=e_true,
-            npred=999,
-        ),
-        dict(
-            model=PowerLaw(
-                index=2,
-                reference=Quantity(1, "TeV"),
-                amplitude=Quantity(1e-11, "TeV-1 cm-2 s-1"),
-            ),
+            model=PowerLaw(amplitude="1e-11 TeV-1 cm-2 s-1"),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
-            livetime=Quantity(10, "h"),
-            npred=1448.059605038253,
+            livetime="10 h",
+            npred=1448.05960,
         ),
         dict(
-            model=PowerLaw(
-                index=2,
-                reference=Quantity(1, "GeV"),
-                amplitude=Quantity(1e-11, "GeV-1 cm-2 s-1"),
-            ),
+            model=PowerLaw(reference="1 GeV", amplitude="1e-11 GeV-1 cm-2 s-1"),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
-            livetime=Quantity(30, "h"),
-            npred=4.344178815114759,
+            livetime="30 h",
+            npred=4.34417881,
         ),
         dict(
-            model=PowerLaw(
-                index=2,
-                reference=Quantity(1, "TeV"),
-                amplitude=Quantity(1e-11, "TeV-1 cm-2 s-1"),
-            ),
+            model=PowerLaw(amplitude="1e-11 TeV-1 cm-2 s-1"),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             edisp=EnergyDispersion.from_gauss(
                 e_reco=e_reco, e_true=e_true, bias=0, sigma=0.2
             ),
-            livetime=Quantity(10, "h"),
+            livetime="10 h",
             npred=1437.450076,
         ),
         dict(
@@ -129,15 +111,16 @@ def get_test_cases():
                 energy=[0.1, 0.2, 0.3, 0.4] * u.TeV,
                 values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
             ),
-            npred=0.5545130625383198,
             e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
+            npred=0.554513062,
         ),
     ]
 
 
 @pytest.mark.parametrize("case", get_test_cases())
 def test_counts_predictor(case):
-    desired = case.pop("npred")
-    predictor = SpectrumEvaluator(**case)
+    opts = case.copy()
+    del opts["npred"]
+    predictor = SpectrumEvaluator(**opts)
     actual = predictor.compute_npred().total_counts.value
-    assert_allclose(actual, desired)
+    assert_allclose(actual, case["npred"])


### PR DESCRIPTION
This PR fixes `test_counts_predictor` for the case where the test is run more than once, e.g. via:
```
pytest gammapy/spectrum/tests/test_utils.py --count 2
```

Instead of mutating the input case dict, I now make a copy first and leave the dict which represents global state in the test session alone.

This test was also the cause of a lot of confusion (mostly on my side) last year when I filed https://github.com/pytest-dev/pytest/issues/4390 and the recommendation there by the pytest people was to avoid mutating the test cases data structure from the test.

The rest of the diff is all the same, just removed some boilerplate to write it in a shorter way.

This issue and #2176 and #2177 are the only fails I found when running Gammapy tests multiple times or in parallel - so overall with small effort we can get to a very good reliability state for our testing. (And we should avoid the HTTP request in the one remaining test, see #2162).