### PR TITLE
Exclude dev code from coverage measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ __pycache__
 */version.py
 */cython_version.py
 htmlcov
-.coverage
+.coverage*
 .coverage.subprocess
 
 # Sphinx

--- a/gammapy/tests/coveragerc
+++ b/gammapy/tests/coveragerc
@@ -9,6 +9,14 @@ omit =
    gammapy/_astropy_init.py
    gammapy/cython_version.py
 
+   # Exclude some code that's only executed by the
+   # notebook tests or docs build (not users)
+   # from the coverage measurement
+   gammapy/utils/tutorials_test.py
+   gammapy/utils/tutorials_process.py
+   gammapy/utils/docs.py
+   gammapy/scripts/jupyter.py
+
 [report]
 exclude_lines =
    # Have to re-enable the standard pragma


### PR DESCRIPTION
I suggest we exclude the following files from the Gammapy code coverage measurement:

- [gammapy/utils/tutorials_test.py](https://github.com/gammapy/gammapy/blob/master/gammapy/utils/tutorials_test.py)
- [gammapy/utils/tutorials_process.py](https://github.com/gammapy/gammapy/blob/master/gammapy/utils/tutorials_process.py)
- [gammapy/utils/docs.py](https://github.com/gammapy/gammapy/blob/master/gammapy/utils/docs.py)
- [gammapy/scripts/jupyter.py](https://github.com/gammapy/gammapy/blob/master/gammapy/scripts/jupyter.py)

Those are not executed by users, and they are executed by devs and CI when running the notebook tests and docs build.

Adding pytest tests for `tutorials_test.py`, `tutorials_process.py` and `jupyter.py` wouldn't be hard, but that would basically be repeating what we already execute in subprocesses launched by pytests, so overall I'm not sure it's useful.

`gammapy/utils/docs.py` is extending Sphinx and is hard to write automated tests for, although of course if we feel it's useful we can do it.

Once these files are excluded (or we have decisions) the coverage report becomes really useful - showing many important lines of code that aren't tested and we can delete those or add tests if they should be used.

@adonath @registerrier @Bultako - Thoughts?