### PR TITLE
Remove parameters option of .likelihood() functions

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -159,7 +159,7 @@ class MapDataset(Dataset):
     def _counts_data(self):
         return self.counts.data.astype(float)
 
-    def likelihood(self, parameters):
+    def likelihood(self):
         """Total likelihood given the current model parameters.
 
         """

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -111,7 +111,7 @@ class SpectrumDataset(Dataset):
         """Likelihood per bin given the current model parameters"""
         return cash(n_on=self.counts.data.data, mu_on=self.npred().data.data)
 
-    def likelihood(self, parameters=None):
+    def likelihood(self):
         """Total likelihood given the current model parameters.
         """
         if self.mask_fit is None and self.mask_safe is None:
@@ -344,7 +344,7 @@ class SpectrumDatasetOnOff(Dataset):
         )
         return np.nan_to_num(on_stat_)
 
-    def likelihood(self, parameters):
+    def likelihood(self):
         """Total likelihood given the current model parameters.
         """
         if self.mask_fit is None and self.mask_safe is None:

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1232,7 +1232,7 @@ class FluxPointsDataset(Dataset):
             # TODO: add likelihood profiles
             pass
 
-    def likelihood(self, parameters):
+    def likelihood(self):
         """Total likelihood given the current model parameters.
         """
         if self.mask_fit is None and self.mask_safe is None:

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -22,7 +22,7 @@ class Dataset(abc.ABC):
     """
 
     @abc.abstractmethod
-    def likelihood(self, parameters):
+    def likelihood(self):
         """Total likelihood (float, sum over bins).
 
         TODO: fix interface.
@@ -83,12 +83,12 @@ class Datasets:
         is_ref_shape = [dataset.data_shape == ref_shape for dataset in self.datasets]
         return np.all(is_ref_shape)
 
-    def likelihood(self, parameters=None):
+    def likelihood(self):
         """Compute joint likelihood"""
         total_likelihood = 0
         # TODO: add parallel evaluation of likelihoods
         for dataset in self.datasets:
-            total_likelihood += dataset.likelihood(parameters=parameters)
+            total_likelihood += dataset.likelihood()
         return total_likelihood
 
     def __str__(self):

--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -14,7 +14,7 @@ class MinuitLikelihood(Likelihood):
 
     def fcn(self, *factors):
         self.parameters.set_parameter_factors(factors)
-        return self.function(self.parameters)
+        return self.function()
 
 
 def optimize_iminuit(parameters, function, **kwargs):

--- a/gammapy/utils/fitting/likelihood.py
+++ b/gammapy/utils/fitting/likelihood.py
@@ -29,4 +29,4 @@ class Likelihood:
 
     def fcn(self, factors):
         self.parameters.set_parameter_factors(factors)
-        return self.function(self.parameters)
+        return self.function()

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -32,7 +32,7 @@ class TSDifference:
     """Likelihood wrapper to compute TS differences"""
 
     def __init__(self, function, parameters, parameter, reoptimize, ts_diff):
-        self.loglike_ref = function(parameters)
+        self.loglike_ref = function()
         self.parameters = parameters
         self.function = function
         self.parameter = parameter
@@ -44,7 +44,7 @@ class TSDifference:
         self.parameter.factor = factor
         if self.reoptimize:
             optimize_scipy(self.parameters, self.function, method="L-BFGS-B")
-        value = self.function(self.parameters) - self.loglike_ref - self.ts_diff
+        value = self.function() - self.loglike_ref - self.ts_diff
         return value
 
 

--- a/gammapy/utils/fitting/sherpa.py
+++ b/gammapy/utils/fitting/sherpa.py
@@ -21,7 +21,7 @@ class SherpaLikelihood(Likelihood):
 
     def fcn(self, factors):
         self.parameters.set_parameter_factors(factors)
-        return self.function(self.parameters), 0
+        return self.function(), 0
 
 
 def optimize_sherpa(parameters, function, **kwargs):

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -10,26 +10,28 @@ from ...testing import requires_dependency
 pytest.importorskip("iminuit")
 
 
-class MyModel(Model):
-    """Dummy model class."""
-
+class MyDataset:
     def __init__(self):
         self.parameters = Parameters(
             [Parameter("x", 2), Parameter("y", 3e2), Parameter("z", 4e-2)]
         )
-
-
-class MyDataset:
-    def __init__(self):
-        self.model = MyModel()
-        self.parameters = self.model.parameters
         self.data_shape = (1,)
 
-    def likelihood(self, parameters, mask=None):
+    def likelihood(self):
         # self._model.parameters = parameters
-        x, y, z = [p.value for p in self.model.parameters]
+        x, y, z = [p.value for p in self.parameters]
         x_opt, y_opt, z_opt = 2, 3e2, 4e-2
         return (x - x_opt) ** 2 + (y - y_opt) ** 2 + (z - z_opt) ** 2
+
+    def fcn(self):
+        x, y, z = [p.value for p in self.parameters]
+        x_opt, y_opt, z_opt = 2, 3e5, 4e-5
+        x_err, y_err, z_err = 0.2, 3e4, 4e-6
+        return (
+            ((x - x_opt) / x_err) ** 2
+            + ((y - y_opt) / y_err) ** 2
+            + ((z - z_opt) / z_err) ** 2
+    )
 
 
 @pytest.mark.parametrize("backend", ["minuit"])

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -7,17 +7,19 @@ from .. import Parameter, Parameters, optimize_iminuit, confidence_iminuit
 pytest.importorskip("iminuit")
 
 
-def fcn(parameters):
-    x = parameters["x"].value
-    y = parameters["y"].value
-    z = parameters["z"].value
-    x_opt, y_opt, z_opt = 2, 3e5, 4e-5
-    x_err, y_err, z_err = 0.2, 3e4, 4e-6
-    return (
-        ((x - x_opt) / x_err) ** 2
-        + ((y - y_opt) / y_err) ** 2
-        + ((z - z_opt) / z_err) ** 2
-    )
+class MyDataset:
+    def __init__(self, parameters):
+        self.parameters = parameters
+
+    def fcn(self):
+        x, y, z = [p.value for p in self.parameters]
+        x_opt, y_opt, z_opt = 2, 3e5, 4e-5
+        x_err, y_err, z_err = 0.2, 3e4, 4e-6
+        return (
+            ((x - x_opt) / x_err) ** 2
+            + ((y - y_opt) / y_err) ** 2
+            + ((z - z_opt) / z_err) ** 2
+        )
 
 
 @pytest.fixture()
@@ -29,10 +31,11 @@ def pars():
 
 
 def test_iminuit_basic(pars):
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    ds = MyDataset(pars)
+    factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars)
 
     assert info["success"]
-    assert_allclose(fcn(pars), 0, atol=1e-5)
+    assert_allclose(ds.fcn(), 0, atol=1e-5)
 
     # Check the result in parameters is OK
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
@@ -48,35 +51,39 @@ def test_iminuit_basic(pars):
 
 
 def test_iminuit_stepsize(pars):
+    ds = MyDataset(pars)
+
     pars.apply_autoscale = False
     pars.covariance = np.diag([0.2, 3e4, 4e-6]) ** 2
 
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars)
 
     assert info["success"]
-    assert_allclose(fcn(pars), 0, atol=1e-5)
+    assert_allclose(ds.fcn(), 0, atol=1e-5)
     assert_allclose(pars["x"].value, 2, rtol=1e-3)
     assert_allclose(pars["y"].value, 3e5, rtol=1e-3)
     assert_allclose(pars["z"].value, 4e-5, rtol=2e-2)
 
 
 def test_iminuit_frozen(pars):
+    ds = MyDataset(pars)
     pars["y"].frozen = True
 
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars)
 
     assert info["success"]
 
     assert_allclose(pars["x"].value, 2, rtol=1e-4)
     assert_allclose(pars["y"].value, 3.1e5)
     assert_allclose(pars["z"].value, 4.0e-5, rtol=1e-4)
-    assert_allclose(fcn(pars), 0.111112, rtol=1e-5)
+    assert_allclose(ds.fcn(), 0.111112, rtol=1e-5)
 
 
 def test_iminuit_limits(pars):
+    ds = MyDataset(pars)
     pars["y"].min = 301000
 
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars)
 
     assert info["success"]
 
@@ -98,16 +105,18 @@ def test_iminuit_limits(pars):
 
 
 def test_migrad_opts(pars):
+    ds = MyDataset(pars)
     kwargs = {}
     kwargs["migrad_opts"] = {"ncall": 20}
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars, **kwargs)
+    factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars, **kwargs)
     assert info["nfev"] == 20
 
 
 def test_iminuit_confidence(pars):
-    factors, info, minuit = optimize_iminuit(function=fcn, parameters=pars)
+    ds = MyDataset(pars)
+    factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars)
 
-    assert_allclose(fcn(pars), 0, atol=1e-5)
+    assert_allclose(ds.fcn(), 0, atol=1e-5)
 
     par = pars["x"]
     par.min, par.max = 0, 10

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -6,17 +6,19 @@ from .. import Parameter, Parameters, optimize_sherpa
 pytest.importorskip("sherpa")
 
 
-def fcn(parameters):
-    x = parameters["x"].value
-    y = parameters["y"].value
-    z = parameters["z"].value
-    x_opt, y_opt, z_opt = 2, 3e5, 4e-5
-    x_err, y_err, z_err = 0.2, 3e4, 4e-6
-    return (
-        ((x - x_opt) / x_err) ** 2
-        + ((y - y_opt) / y_err) ** 2
-        + ((z - z_opt) / z_err) ** 2
-    )
+class MyDataset:
+    def __init__(self, parameters):
+        self.parameters = parameters
+
+    def fcn(self):
+        x, y, z = [p.value for p in self.parameters]
+        x_opt, y_opt, z_opt = 2, 3e5, 4e-5
+        x_err, y_err, z_err = 0.2, 3e4, 4e-6
+        return (
+            ((x - x_opt) / x_err) ** 2
+            + ((y - y_opt) / y_err) ** 2
+            + ((z - z_opt) / z_err) ** 2
+        )
 
 
 @pytest.fixture()
@@ -33,10 +35,11 @@ def pars():
 
 @pytest.mark.parametrize("method", ["moncar", "simplex"])
 def test_sherpa(method, pars):
-    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars, method=method)
+    ds = MyDataset(pars)
+    factors, info, _ = optimize_sherpa(function=ds.fcn, parameters=pars, method=method)
 
     assert info["success"]
-    assert_allclose(fcn(pars), 0, atol=1e-12)
+    assert_allclose(ds.fcn(), 0, atol=1e-12)
 
     # Check the result in parameters is OK
     assert_allclose(pars["x"].value, 2)
@@ -48,21 +51,23 @@ def test_sherpa(method, pars):
 
 
 def test_sherpa_frozen(pars):
+    ds = MyDataset(pars)
     pars["y"].frozen = True
 
-    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars)
+    factors, info, _ = optimize_sherpa(function=ds.fcn, parameters=pars)
 
     assert info["success"]
     assert_allclose(pars["x"].value, 2)
     assert_allclose(pars["y"].value, 3.1e5)
     assert_allclose(pars["z"].value, 4.0e-5)
-    assert_allclose(fcn(pars), 0.11111111, rtol=1e-6)
+    assert_allclose(ds.fcn(), 0.11111111, rtol=1e-6)
 
 
 def test_sherpa_limits(pars):
+    ds = MyDataset(pars)
     pars["y"].min = 301000
 
-    factors, info, _ = optimize_sherpa(function=fcn, parameters=pars)
+    factors, info, _ = optimize_sherpa(function=ds.fcn, parameters=pars)
 
     assert info["success"]
 

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -245,7 +245,7 @@
     "\n",
     "    # dataset.likelihood returns Cash statistics values\n",
     "    # emcee will maximisise the LogLikelihood so we need -dataset.likelihood\n",
-    "    total_lnprob = -dataset.likelihood(None) + lnprob_priors\n",
+    "    total_lnprob = -dataset.likelihood() + lnprob_priors\n",
     "\n",
     "    if verb:\n",
     "        print(\"Parameters are:\", pars)\n",
@@ -311,7 +311,7 @@
     "dataset.parameters[\"lambda_\"].value = 0.05\n",
     "\n",
     "print(dataset.model)\n",
-    "print(\"LL =\", dataset.likelihood(dataset.parameters))"
+    "print(\"log(L) =\", dataset.likelihood())"
    ]
   },
   {


### PR DESCRIPTION
This PR removes the unused `parameters` option of the `Dataset.likelihood()` methods we currently have.