### PR TITLE
Improve gammapy.astro code and tests

### DIFF
--- a/docs/astro/source/plot_pulsar_spindown.py
+++ b/docs/astro/source/plot_pulsar_spindown.py
@@ -6,7 +6,7 @@ from gammapy.astro.source import Pulsar
 
 t = Quantity(np.logspace(0, 6, 100), "yr")
 
-pulsar = Pulsar(P_0=Quantity(0.01, "s"), logB=12)
+pulsar = Pulsar(P_0=Quantity(0.01, "s"), B="1e12 G")
 
 plt.plot(t.value, 1 / pulsar.period(t).cgs.value)
 plt.xlabel("time [years]")

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -430,10 +430,9 @@ def add_observed_source_parameters(table):
     theta = np.pi / 2 * np.ones(len(table))  # Position angle?
     epsilon = np.zeros(len(table))  # Ellipticity?
 
-    S_SNR = astrometry.luminosity_to_flux(L_SNR, distance)
-    # Ld2_PSR = astrometry.luminosity_to_flux(L_PSR, distance)
+    S_SNR = L_SNR / (4 * np.pi * distance ** 2)
     Ld2_PSR = L_PSR / distance ** 2
-    S_PWN = astrometry.luminosity_to_flux(L_PWN, distance)
+    S_PWN = L_PWN / (4 * np.pi * distance ** 2)
 
     # Add columns
     table["ext_in_SNR"] = Column(ext_in_SNR, unit="deg")
@@ -504,7 +503,7 @@ def add_observed_parameters(table, obs_pos=None):
 
     try:
         luminosity = table["luminosity"]
-        flux = astrometry.luminosity_to_flux(luminosity, distance)
+        flux = luminosity / (4 * np.pi * distance ** 2)
         table["flux"] = Column(flux.value, unit=flux.unit, description="Source flux")
     except KeyError:
         pass

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -36,14 +36,16 @@ def make_catalog_random_positions_cube(
 ):
     """Make a catalog of sources randomly distributed on a line, square or cube.
 
-    TODO: is this useful enough for general use or should we hide it as an
-      internal method to generate test datasets?
+    This can be used to study basic source population distribution effects,
+    e.g. what the distance distribution looks like, or for a given luminosity
+    function what the resulting flux distributions are for different spatial
+    configurations.
 
     Parameters
     ----------
     size : int, optional
         Number of sources
-    dimension : int, optional
+    dimension : {1, 2, 3}
         Number of dimensions
     dmax : int, optional
         Maximum distance in pc.
@@ -59,18 +61,19 @@ def make_catalog_random_positions_cube(
     random_state = get_random_state(random_state)
 
     # Generate positions 1D, 2D, or 3D
-    if dimension == 3:
+    if dimension == 1:
         x = random_state.uniform(-dmax, dmax, size)
-        y = random_state.uniform(-dmax, dmax, size)
-        z = random_state.uniform(-dmax, dmax, size)
+        y, z = 0, 0
     elif dimension == 2:
         x = random_state.uniform(-dmax, dmax, size)
         y = random_state.uniform(-dmax, dmax, size)
-        z = np.zeros_like(x)
-    else:
+        z = 0
+    elif dimension == 3:
         x = random_state.uniform(-dmax, dmax, size)
-        y = np.zeros_like(x)
-        z = np.zeros_like(x)
+        y = random_state.uniform(-dmax, dmax, size)
+        z = random_state.uniform(-dmax, dmax, size)
+    else:
+        raise ValueError("Invalid dimension: {}. Allowed: {{1, 2, 3}}".format(dimension))
 
     table = Table()
     table["x"] = Column(x, unit="pc", description="Galactic cartesian coordinate")

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -306,10 +306,11 @@ def add_pulsar_parameters(
     p0_birth = draw(0, 2, len(table), p_dist, random_state=random_state)
     p0_birth = Quantity(p0_birth, "s")
 
-    logB = random_state.normal(B_mean, B_stdv, len(table))
+    log10_b_psr = random_state.normal(B_mean, B_stdv, len(table))
+    b_psr = Quantity(10 ** log10_b_psr, "G")
 
     # Compute pulsar parameters
-    psr = Pulsar(p0_birth, logB)
+    psr = Pulsar(p0_birth, b_psr)
     p0 = psr.period(age)
     p1 = psr.period_dot(age)
     p1_birth = psr.P_dot_0
@@ -329,7 +330,7 @@ def add_pulsar_parameters(
     table["Tau0"] = Column(tau_0, unit="yr")
     table["L_PSR"] = Column(l_psr, unit="erg s-1")
     table["L0_PSR"] = Column(l0_psr, unit="erg s-1")
-    table["logB"] = Column(logB, unit="Gauss")
+    table["B_PSR"] = Column(b_psr, unit="Gauss", description="Pulsar magnetic field at the poles")
     return table
 
 
@@ -348,10 +349,10 @@ def add_pwn_parameters(table):
         E_SN = table["E_SN"].quantity[idx]
         n_ISM = table["n_ISM"].quantity[idx]
         P0_birth = table["P0_birth"].quantity[idx]
-        logB = table["logB"][idx]
+        b_psr = table["B_PSR"].quantity[idx]
 
         # Compute properties
-        pulsar = Pulsar(P0_birth, logB)
+        pulsar = Pulsar(P0_birth, b_psr)
         snr = SNRTrueloveMcKee(e_sn=E_SN, n_ISM=n_ISM)
         pwn = PWN(pulsar, snr)
         r_out_pwn = pwn.radius(age).to_value("pc")

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -27,7 +27,6 @@ __all__ = [
     "add_snr_parameters",
     "add_pulsar_parameters",
     "add_pwn_parameters",
-    "add_observed_source_parameters",
     "add_observed_parameters",
 ]
 
@@ -407,42 +406,6 @@ def add_pwn_parameters(table):
         unit="erg",
         description="PWN luminosity above 1 TeV",
     )
-    return table
-
-
-def add_observed_source_parameters(table):
-    """Add observed source parameters to the table."""
-    # Read relevant columns
-    distance = table["distance"]
-    r_in = table["r_in"]
-    r_out = table["r_out"]
-    r_out_PWN = table["r_out_PWN"]
-    L_SNR = table["L_SNR"]
-    L_PSR = table["L_PSR"]
-    L_PWN = table["L_PWN"]
-
-    # Compute properties
-    ext_in_SNR = astrometry.radius_to_angle(r_in, distance)
-    ext_out_SNR = astrometry.radius_to_angle(r_out, distance)
-    ext_out_PWN = astrometry.radius_to_angle(r_out_PWN, distance)
-
-    # Ellipse parameters not used for now
-    theta = np.pi / 2 * np.ones(len(table))  # Position angle?
-    epsilon = np.zeros(len(table))  # Ellipticity?
-
-    S_SNR = L_SNR / (4 * np.pi * distance ** 2)
-    Ld2_PSR = L_PSR / distance ** 2
-    S_PWN = L_PWN / (4 * np.pi * distance ** 2)
-
-    # Add columns
-    table["ext_in_SNR"] = Column(ext_in_SNR, unit="deg")
-    table["ext_out_SNR"] = Column(ext_out_SNR, unit="deg")
-    table["ext_out_PWN"] = Column(ext_out_PWN, unit="deg")
-    table["theta"] = Column(theta, unit="rad")
-    table["epsilon"] = Column(epsilon, unit="")
-    table["S_SNR"] = Column(S_SNR, unit="cm-2 s-1")
-    table["Ld2_PSR"] = Column(Ld2_PSR, unit="erg s-1 kpc-2")
-    table["S_PWN"] = Column(S_PWN, unit="cm-2 s-1")
     return table
 
 

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -355,17 +355,11 @@ def add_pwn_parameters(table):
         snr = SNRTrueloveMcKee(e_sn=E_SN, n_ISM=n_ISM)
         pwn = PWN(pulsar, snr)
         r_out_pwn = pwn.radius(age).to_value("pc")
-        L_PWN = pwn.luminosity_tev(age).to_value("erg")
-        results.append(dict(r_out_pwn=r_out_pwn, L_PWN=L_PWN))
+        results.append(dict(r_out_pwn=r_out_pwn))
 
     # Add columns to table
     table["r_out_PWN"] = Column(
         [_["r_out_pwn"] for _ in results], unit="pc", description="PWN outer radius"
-    )
-    table["L_PWN"] = Column(
-        [_["L_PWN"] for _ in results],
-        unit="erg",
-        description="PWN luminosity above 1 TeV",
     )
     return table
 

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -147,14 +147,10 @@ def test_add_pwn_parameters():
     d = table[0]
 
     assert len(table) == 10
-    assert len(table.colnames) == 28
+    assert len(table.colnames) == 27
 
     assert table["r_out_PWN"].unit == "pc"
     assert_allclose(d["r_out_PWN"], 0.5892196771927385, atol=1e-3)
-    assert (
-        table["L_PWN"].unit == "erg"
-    )  # TODO: erg is not a luminosity unit. Incorrect?
-    assert_allclose(d["L_PWN"], 7.057857699785925e45)
 
 
 def test_add_observed_parameters():
@@ -194,7 +190,7 @@ def test_chain_all():
     # Here we just run them in a chain and do very basic asserts
     # on the output so that we make sure we notice changes.
     assert len(table) == 10
-    assert len(table.colnames) == 35
+    assert len(table.colnames) == 34
 
     assert table["r_out_PWN"].unit == "pc"
     assert_allclose(d["r_out_PWN"], 0.5891300402092443)

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -15,16 +15,16 @@ from ...population import (
 
 def test_make_catalog_random_positions_cube():
     table = make_catalog_random_positions_cube(random_state=0)
+    d = table[0]
 
     assert len(table) == 100
     assert len(table.colnames) == 3
-    assert table["x"].unit == "pc"
-    assert table["y"].unit == "pc"
-    assert table["z"].unit == "pc"
 
-    d = table[0]
+    assert table["x"].unit == "pc"
     assert_allclose(d["x"], 0.0976270078546495)
+    assert table["y"].unit == "pc"
     assert_allclose(d["y"], 0.3556330735924602)
+    assert table["z"].unit == "pc"
     assert_allclose(d["z"], -0.37640823601179485)
 
     table = make_catalog_random_positions_cube(dimension=2, random_state=0)
@@ -37,43 +37,51 @@ def test_make_catalog_random_positions_cube():
 
 def test_make_catalog_random_positions_sphere():
     table = make_catalog_random_positions_sphere(random_state=0)
+    d = table[0]
 
     assert len(table) == 100
     assert len(table.colnames) == 3
-    assert table["lon"].unit == "rad"
-    assert table["lat"].unit == "rad"
-    assert table["distance"].unit == "pc"
 
-    d = table[0]
+    assert table["lon"].unit == "rad"
     assert_allclose(d["lon"], 3.4482969442579128)
+    assert table["lat"].unit == "rad"
     assert_allclose(d["lat"], 0.36359133530192267)
+    assert table["distance"].unit == "pc"
     assert_allclose(d["distance"], 0.6780943487897606)
 
 
 def test_make_base_catalog_galactic():
-    """Test that make_base_catalog_galactic uses random_state correctly.
-
-    Calling with a given seed should always give the same output.
-
-    Regression test for https://github.com/gammapy/gammapy/issues/959
-    """
     table = make_base_catalog_galactic(n_sources=10, random_state=0)
+    d = table[0]
+
     assert len(table) == 10
     assert len(table.colnames) == 13
 
-    d = table[0]
+    assert table["age"].unit == "yr"
     assert_allclose(d["age"], 548813.50392732478)
+    assert table["n_ISM"].unit == "cm-3"
     assert_allclose(d["n_ISM"], 1.0)
-    assert d["spiralarm"] == "Crux Scutum"
-    assert_allclose(d["x_birth"], 0.58513884292018437)
-    assert_allclose(d["y_birth"], -11.682838052120154)
-    assert_allclose(d["z_birth"], 0.15710279448905115)
-    assert_allclose(d["x"], 0.5828226720259867)
-    assert_allclose(d["y"], -11.658959390801584)
-    assert_allclose(d["z"], 0.35098629652725671)
+    assert table["spiralarm"].unit is None
+    assert d["spiralarm"] == "Perseus"
+    assert table["x_birth"].unit == "kpc"
+    assert_allclose(d["x_birth"], -2.57846191600981)
+    assert table["y_birth"].unit == "kpc"
+    assert_allclose(d["y_birth"], 10.010139593948578)
+    assert table["z_birth"].unit == "kpc"
+    assert_allclose(d["z_birth"], -0.056572220998886355)
+    assert table["x"].unit == "kpc"
+    assert_allclose(d["x"], -2.580778086904008)
+    assert table["y"].unit == "kpc"
+    assert_allclose(d["y"], 10.034018255267148)
+    assert table["z"].unit == "kpc"
+    assert_allclose(d["z"], 0.13731128103931922)
+    assert table["vx"].unit == "km/s"
     assert_allclose(d["vx"], -4.1266001441394655)
+    assert table["vy"].unit == "km/s"
     assert_allclose(d["vy"], 42.543357869627776)
-    assert_allclose(d["vz"], 345.43206179709432)
+    assert table["vz"].unit == "km/s"
+    assert_allclose(d["vz"], 345.4320617970943)
+    assert table["v_abs"].unit == "km/s"
     assert_allclose(d["v_abs"], 348.06648135803658)
 
 
@@ -87,9 +95,13 @@ def test_add_snr_parameters():
     assert len(table) == 2
     assert table.colnames == ["age", "n_ISM", "E_SN", "r_out", "r_in", "L_SNR"]
 
+    assert table["E_SN"].unit == "erg"
     assert_allclose(table["E_SN"], 1e51)
+    assert table["r_out"].unit == "pc"
     assert_allclose(table["r_out"], [1, 3.80730787743])
+    assert table["r_in"].unit == "pc"
     assert_allclose(table["r_in"], [0.9086, 3.45931993743])
+    assert table["L_SNR"].unit == "1 / s"
     assert_allclose(table["L_SNR"], [0, 1.0768e33])
 
 
@@ -102,15 +114,27 @@ def test_add_pulsar_parameters():
     assert len(table) == 2
     assert len(table.colnames) == 10
 
+    assert table["age"].unit == "yr"
     assert_allclose(table["age"], [100, 1000])
+    assert table["P0"].unit == "s"
     assert_allclose(table["P0"], [0.322829453422, 0.51352778881])
+    assert table["P1"].unit == ""
     assert_allclose(table["P1"], [4.54295751161e-14, 6.98423128444e-13])
+    assert table["P0_birth"].unit == "s"
     assert_allclose(table["P0_birth"], [0.322254715288, 0.388110930459])
+    assert table["P1_birth"].unit == ""
     assert_allclose(table["P1_birth"], [4.55105983192e-14, 9.24116423053e-13])
+    assert table["CharAge"].unit == "yr"
     assert_allclose(table["CharAge"], [2.32368825638e-22, 5.6826197937e-21])
+    assert table["Tau0"].unit == "yr"
     assert_allclose(table["Tau0"], [112189.64476, 6654.19039158])
+    assert table["L_PSR"].unit == "erg / s"
     assert_allclose(table["L_PSR"], [5.37834069771e34, 8.25708734631e35])
+    assert table["L0_PSR"].unit == "erg / s"
     assert_allclose(table["L0_PSR"], [5.36876555682e34, 6.24049160082e35])
+    assert (
+        table["logB"].unit == "G"
+    )  # TODO: logB should be dimensionless. Fix? Change to "B"?
     assert_allclose(table["logB"], [12.5883058913, 13.2824912596])
 
 
@@ -120,28 +144,41 @@ def test_add_pwn_parameters():
     table = add_snr_parameters(table)
     table = add_pulsar_parameters(table, random_state=0)
     table = add_pwn_parameters(table)
-    assert len(table) == 10
-
     d = table[0]
+
+    assert len(table) == 10
+    assert len(table.colnames) == 28
+
+    assert table["r_out_PWN"].unit == "pc"
     assert_allclose(d["r_out_PWN"], 0.5892196771927385, atol=1e-3)
+    assert (
+        table["L_PWN"].unit == "erg"
+    )  # TODO: erg is not a luminosity unit. Incorrect?
     assert_allclose(d["L_PWN"], 7.057857699785925e45)
 
 
 def test_add_observed_parameters():
     table = make_base_catalog_galactic(n_sources=10, random_state=0)
     table = add_observed_parameters(table)
+    d = table[0]
 
     assert len(table) == 10
     assert len(table.colnames) == 20
 
-    d = table[0]
-    assert_allclose(d["distance"], 3231.392591455106)
-    assert_allclose(d["GLON"], 169.54657778189639)
-    assert_allclose(d["GLAT"], 6.2356357665816162)
-    assert_allclose(d["VGLON"], 0.066778795313076678)
-    assert_allclose(d["VGLAT"], 5.6115948931932174)
-    assert_allclose(d["RA"], 86.308826288823127)
-    assert_allclose(d["DEC"], 41.090120056648828)
+    assert table["distance"].unit == "pc"
+    assert_allclose(d["distance"], 18713.340231191236)
+    assert table["GLON"].unit == "deg"
+    assert_allclose(d["GLON"], -7.9272056829002615)
+    assert table["GLAT"].unit == "deg"
+    assert_allclose(d["GLAT"], 0.42041812871409573)
+    assert table["VGLON"].unit == "deg / Myr"
+    assert_allclose(d["VGLON"], -0.005574473038475241)
+    assert table["VGLAT"].unit == "deg / Myr"
+    assert_allclose(d["VGLAT"], 1.0736832036530914)
+    assert table["RA"].unit == "deg"
+    assert_allclose(d["RA"], 260.9075160323843)
+    assert table["DEC"].unit == "deg"
+    assert_allclose(d["DEC"], -35.371104990114816)
 
 
 def test_chain_all():
@@ -151,6 +188,7 @@ def test_chain_all():
     table = add_pulsar_parameters(table, random_state=0)
     table = add_pwn_parameters(table)
     table = add_observed_parameters(table)
+    d = table[0]
 
     # Note: the individual functions are tested above.
     # Here we just run them in a chain and do very basic asserts
@@ -158,6 +196,7 @@ def test_chain_all():
     assert len(table) == 10
     assert len(table.colnames) == 35
 
-    d = table[0]
-    assert_allclose(d["r_out_PWN"], 0.589219, atol=1e-3)
-    assert_allclose(d["RA"], 86.308826288823127)
+    assert table["r_out_PWN"].unit == "pc"
+    assert_allclose(d["r_out_PWN"], 0.5891300402092443)
+    assert table["RA"].unit == "deg"
+    assert_allclose(d["RA"], 260.9075160323843)

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -23,9 +23,9 @@ def test_make_catalog_random_positions_cube():
     assert table["z"].unit == "pc"
 
     d = table[0]
-    assert_allclose(d["x"], 0.9762700785464951)
-    assert_allclose(d["y"], 3.556330735924602)
-    assert_allclose(d["z"], -3.764082360117948)
+    assert_allclose(d["x"], 0.0976270078546495)
+    assert_allclose(d["y"], 0.3556330735924602)
+    assert_allclose(d["z"], -0.37640823601179485)
 
     table = make_catalog_random_positions_cube(dimension=2, random_state=0)
     assert_equal(table["z"], 0)
@@ -36,15 +36,18 @@ def test_make_catalog_random_positions_cube():
 
 
 def test_make_catalog_random_positions_sphere():
-    size = 100
-    table = make_catalog_random_positions_sphere(
-        size=size, center="Milky Way", random_state=27
-    )
-    assert len(table) == size
+    table = make_catalog_random_positions_sphere(random_state=0)
+
+    assert len(table) == 100
+    assert len(table.colnames) == 3
+    assert table["lon"].unit == "rad"
+    assert table["lat"].unit == "rad"
+    assert table["distance"].unit == "pc"
 
     d = table[0]
-    assert_allclose(d["GLON"], 153.259708)
-    assert_allclose(d["GLAT"], 62.312573)
+    assert_allclose(d["lon"], 3.4482969442579128)
+    assert_allclose(d["lat"], 0.36359133530192267)
+    assert_allclose(d["distance"], 0.6780943487897606)
 
 
 def test_make_base_catalog_galactic():

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 from astropy.table import Table
 import astropy.units as u
 from ...population import (
@@ -14,9 +14,25 @@ from ...population import (
 
 
 def test_make_catalog_random_positions_cube():
-    size = 100
-    table = make_catalog_random_positions_cube(size=size)
-    assert len(table) == size
+    table = make_catalog_random_positions_cube(random_state=0)
+
+    assert len(table) == 100
+    assert len(table.colnames) == 3
+    assert table["x"].unit == "pc"
+    assert table["y"].unit == "pc"
+    assert table["z"].unit == "pc"
+
+    d = table[0]
+    assert_allclose(d["x"], 0.9762700785464951)
+    assert_allclose(d["y"], 3.556330735924602)
+    assert_allclose(d["z"], -3.764082360117948)
+
+    table = make_catalog_random_positions_cube(dimension=2, random_state=0)
+    assert_equal(table["z"], 0)
+
+    table = make_catalog_random_positions_cube(dimension=1, random_state=0)
+    assert_equal(table["y"], 0)
+    assert_equal(table["z"], 0)
 
 
 def test_make_catalog_random_positions_sphere():

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -132,10 +132,8 @@ def test_add_pulsar_parameters():
     assert_allclose(table["L_PSR"], [5.37834069771e34, 8.25708734631e35])
     assert table["L0_PSR"].unit == "erg / s"
     assert_allclose(table["L0_PSR"], [5.36876555682e34, 6.24049160082e35])
-    assert (
-        table["logB"].unit == "G"
-    )  # TODO: logB should be dimensionless. Fix? Change to "B"?
-    assert_allclose(table["logB"], [12.5883058913, 13.2824912596])
+    assert table["B_PSR"].unit == "G"
+    assert_allclose(table["B_PSR"], [3.875305e+12, 1.916422e+13], rtol=1e-5)
 
 
 def test_add_pwn_parameters():

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -10,7 +10,6 @@ from ...population import (
     add_pulsar_parameters,
     add_pwn_parameters,
     add_observed_parameters,
-    add_observed_source_parameters,
 )
 
 
@@ -27,8 +26,9 @@ def test_make_catalog_random_positions_sphere():
     )
     assert len(table) == size
 
-    assert_allclose(table["GLON"][0], 153.259708)
-    assert_allclose(table["GLAT"][0], 62.312573)
+    d = table[0]
+    assert_allclose(d["GLON"], 153.259708)
+    assert_allclose(d["GLAT"], 62.312573)
 
 
 def test_make_base_catalog_galactic():
@@ -40,28 +40,12 @@ def test_make_base_catalog_galactic():
     """
     table = make_base_catalog_galactic(n_sources=10, random_state=0)
     assert len(table) == 10
-    assert table.colnames == [
-        "age",
-        "n_ISM",
-        "spiralarm",
-        "x_birth",
-        "y_birth",
-        "z_birth",
-        "x",
-        "y",
-        "z",
-        "vx",
-        "vy",
-        "vz",
-        "v_abs",
-    ]
+    assert len(table.colnames) == 13
 
     d = table[0]
-
     assert_allclose(d["age"], 548813.50392732478)
     assert_allclose(d["n_ISM"], 1.0)
     assert d["spiralarm"] == "Crux Scutum"
-
     assert_allclose(d["x_birth"], 0.58513884292018437)
     assert_allclose(d["y_birth"], -11.682838052120154)
     assert_allclose(d["z_birth"], 0.15710279448905115)
@@ -72,26 +56,6 @@ def test_make_base_catalog_galactic():
     assert_allclose(d["vy"], 42.543357869627776)
     assert_allclose(d["vz"], 345.43206179709432)
     assert_allclose(d["v_abs"], 348.06648135803658)
-
-
-def test_add_observed_parameters():
-    table = make_base_catalog_galactic(n_sources=10, random_state=0)
-    table = add_observed_parameters(table)
-
-    assert len(table) == 10
-    assert set(table.colnames).issuperset(
-        ["distance", "GLON", "GLAT", "VGLON", "VGLAT", "RA", "DEC"]
-    )
-
-    d = table[0]
-
-    assert_allclose(d["distance"], 3231.392591455106)
-    assert_allclose(d["GLON"], 169.54657778189639)
-    assert_allclose(d["GLAT"], 6.2356357665816162)
-    assert_allclose(d["VGLON"], 0.066778795313076678)
-    assert_allclose(d["VGLAT"], 5.6115948931932174)
-    assert_allclose(d["RA"], 86.308826288823127)
-    assert_allclose(d["DEC"], 41.090120056648828)
 
 
 def test_add_snr_parameters():
@@ -117,19 +81,9 @@ def test_add_pulsar_parameters():
     table = add_pulsar_parameters(table, random_state=0)
 
     assert len(table) == 2
-    assert table.colnames == [
-        "age",
-        "P0",
-        "P1",
-        "P0_birth",
-        "P1_birth",
-        "CharAge",
-        "Tau0",
-        "L_PSR",
-        "L0_PSR",
-        "logB",
-    ]
+    assert len(table.colnames) == 10
 
+    assert_allclose(table["age"], [100, 1000])
     assert_allclose(table["P0"], [0.322829453422, 0.51352778881])
     assert_allclose(table["P1"], [4.54295751161e-14, 6.98423128444e-13])
     assert_allclose(table["P0_birth"], [0.322254715288, 0.388110930459])
@@ -154,22 +108,37 @@ def test_add_pwn_parameters():
     assert_allclose(d["L_PWN"], 7.057857699785925e45)
 
 
+def test_add_observed_parameters():
+    table = make_base_catalog_galactic(n_sources=10, random_state=0)
+    table = add_observed_parameters(table)
+
+    assert len(table) == 10
+    assert len(table.colnames) == 20
+
+    d = table[0]
+    assert_allclose(d["distance"], 3231.392591455106)
+    assert_allclose(d["GLON"], 169.54657778189639)
+    assert_allclose(d["GLAT"], 6.2356357665816162)
+    assert_allclose(d["VGLON"], 0.066778795313076678)
+    assert_allclose(d["VGLAT"], 5.6115948931932174)
+    assert_allclose(d["RA"], 86.308826288823127)
+    assert_allclose(d["DEC"], 41.090120056648828)
+
+
 def test_chain_all():
-    """
-    Test that running the simulation functions in chain works
-    """
+    # Test that running the simulation functions in chain works
     table = make_base_catalog_galactic(n_sources=10, random_state=0)
     table = add_snr_parameters(table)
     table = add_pulsar_parameters(table, random_state=0)
     table = add_pwn_parameters(table)
     table = add_observed_parameters(table)
-    table = add_observed_source_parameters(table)
 
     # Note: the individual functions are tested above.
     # Here we just run them in a chain and do very basic asserts
     # on the output so that we make sure we notice changes.
     assert len(table) == 10
-    assert len(table.colnames) == 43
+    assert len(table.colnames) == 35
+
     d = table[0]
-    assert_allclose(d["r_out_PWN"], 0.5892196771927385, atol=1e-3)
+    assert_allclose(d["r_out_PWN"], 0.589219, atol=1e-3)
     assert_allclose(d["RA"], 86.308826288823127)

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -93,8 +93,8 @@ class Pulsar(SimplePulsar):
     ----------
     P_0 : float
         Period at birth
-    logB : float
-        Logarithm of the magnetic field, which is constant
+    B : `~astropy.units.Quantity`
+        Magnetic field strength at the poles (Gauss)
     n : float
         Spin-down braking index
     I : float
@@ -106,7 +106,7 @@ class Pulsar(SimplePulsar):
     def __init__(
         self,
         P_0=Quantity(0.1, "s"),
-        logB=10,
+        B="1e10 G",
         n=3,
         I=DEFAULT_I,
         R=DEFAULT_R,
@@ -114,11 +114,12 @@ class Pulsar(SimplePulsar):
         L_0=None,
         morphology="Delta2D",
     ):
+        B = Quantity(B).to("G")
         self.I = I
         self.R = R
         self.P_0 = P_0
-        self.logB = logB
-        self.P_dot_0 = (Quantity(10 ** logB, "gauss") / B_CONST) ** 2 / P_0
+        self.B = B
+        self.P_dot_0 = (B / B_CONST) ** 2 / P_0
         self.tau_0 = P_0 / (2 * self.P_dot_0)
         self.n = float(n)
         self.beta = (n + 1.0) / (n - 1.0)
@@ -245,7 +246,8 @@ class Pulsar(SimplePulsar):
             t = self.age
         else:
             raise ValueError("Need time variable or age attribute.")
-        return Quantity(10 ** self.logB, "gauss") ** 2 / (self.period(t) * B_CONST ** 2)
+
+        return self.B ** 2 / (self.period(t) * B_CONST ** 2)
 
     def tau(self, t=None):
         """Characteristic age at real age t.

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -130,22 +130,6 @@ class Pulsar(SimplePulsar):
         if L_0 is None:
             self.L_0 = 4 * np.pi ** 2 * self.I * self.P_dot_0 / self.P_0 ** 3
 
-    def luminosity_tev(self, t=None, fraction=0.1):
-        """Gamma-ray luminosity assumed to be a certain fraction of the spin-down luminosity.
-
-        Parameters
-        ----------
-        t : `~astropy.units.Quantity`
-            Time after birth of the pulsar.
-        """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
-        return self.luminosity_spindown(t) * fraction
-
     def luminosity_spindown(self, t=None):
         """Spin down luminosity  at age t.
 

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -135,16 +135,3 @@ class PWN:
         energy = self.pulsar.energy_integrated(t)
         volume = 4.0 / 3 * np.pi * self.radius(t) ** 3
         return np.sqrt(2 * const.mu0 * self.eta_B * energy / volume)
-
-    def luminosity_tev(self, t=None, fraction=0.1):
-        """TeV luminosity from a simple evolution model.
-
-        Assumes that the luminosity is just a fraction of the total energy content
-        of the pulsar. No cooling is considered and therefore the estimate is very bad.
-
-        Parameters
-        ----------
-        t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
-        """
-        return fraction * self.pulsar.energy_integrated(t)

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -5,7 +5,6 @@ from astropy.units import Quantity
 from astropy.utils import lazyproperty
 import astropy.constants as const
 from scipy.optimize import fsolve
-from ...extern.validator import validate_physical_type
 from ..source import Pulsar, SNRTrueloveMcKee
 
 __all__ = ["PWN"]
@@ -47,8 +46,7 @@ class PWN:
         self.eta_B = eta_B
         self.morphology = morphology
         if age is not None:
-            validate_physical_type("age", age, "time")
-            self.age = age
+            self.age = Quantity(age, "yr")
 
     def _radius_free_expansion(self, t):
         """Radius at age t during free expansion phase.
@@ -77,43 +75,33 @@ class PWN:
         # 4e3 years is a typical value that works for fsolve
         return Quantity(fsolve(time_coll, 4e3), "yr")
 
-    def radius(self, t=None):
+    def radius(self, t):
         """Radius of the PWN at age t.
+
+        During the free expansion phase the radius of the PWN evolves like:
+
+        .. math::
+            R_{PWN}(t) = 1.44\\text{pc}\\left(\\frac{E_{SN}^3\\dot{E}_0^2}
+            {M_{ej}^5}\\right)^{1/10}t^{6/5}
+
+        After the collision with the reverse shock of the SNR, the radius is
+        assumed to be constant (See `~gammapy.astro.source.SNRTrueloveMcKee.radius_reverse_shock`).
 
         Reference: http://adsabs.harvard.edu/abs/2006ARA%26A..44...17G (Formula 8).
 
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
-
-        Notes
-        -----
-        During the free expansion phase the radius of the PWN evolves like:
-
-        .. math::
-
-            R_{PWN}(t) = 1.44\\text{pc}\\left(\\frac{E_{SN}^3\\dot{E}_0^2}
-            {M_{ej}^5}\\right)^{1/10}t^{6/5}
-
-        After the collision with the reverse shock of the SNR, the radius is
-        assumed to be constant (See `~gammapy.astro.source.SNRTrueloveMcKee.radius_reverse_shock`)
-
+            Time after birth of the SNR
         """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
-        # Radius at time of collision
-        r_coll = self._radius_free_expansion(self._collision_time)
+        t = Quantity(t, "yr")
+        r_collision = self._radius_free_expansion(self._collision_time)
         r = np.where(
-            t < self._collision_time, self._radius_free_expansion(t).value, r_coll.value
+            t < self._collision_time, self._radius_free_expansion(t).value, r_collision.value
         )
         return Quantity(r, "cm")
 
-    def magnetic_field(self, t=None):
+    def magnetic_field(self, t):
         """Estimate of the magnetic field inside the PWN.
 
         By assuming that a certain fraction of the spin down energy is
@@ -123,15 +111,9 @@ class PWN:
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
+            Time after birth of the SNR
         """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
-
+        t = Quantity(t, "yr")
         energy = self.pulsar.energy_integrated(t)
         volume = 4.0 / 3 * np.pi * self.radius(t) ** 3
         return np.sqrt(2 * const.mu0 * self.eta_B * energy / volume)

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -27,7 +27,7 @@ class SNR:
     m_ejecta : `~astropy.units.Quantity`
         Ejecta mass (g)
     t_stop : `~astropy.units.Quantity`
-        Post-shock temperature where gamma-ray emission stops.
+        Post-shock temperature where gamma-ray emission stops
     """
 
     def __init__(
@@ -59,7 +59,7 @@ class SNR:
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
+            Time after birth of the SNR
 
         Notes
         -----
@@ -76,7 +76,6 @@ class SNR:
         .. math::
 
             r_{SNR}(t) \\approx \\left(\\frac{E_{SN}}{\\rho_{ISM}}\\right)^{1/5}t^{2/5}
-
         """
         if t is not None:
             validate_physical_type("t", t, "time")
@@ -97,8 +96,7 @@ class SNR:
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
-
+            Time after birth of the SNR
         """
         # proportional constant for the free expansion phase
         term_1 = (self.e_sn / Quantity(1e51, "erg")) ** (1.0 / 2)
@@ -111,8 +109,7 @@ class SNR:
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
-
+            Time after birth of the SNR
         """
         R_FE = self._radius_free_expansion(self.sedov_taylor_begin)
         return R_FE * (t / self.sedov_taylor_begin) ** (2.0 / 5)
@@ -123,8 +120,7 @@ class SNR:
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
-
+            Time after birth of the SNR
         """
         return self.radius(t) * (1 - fraction)
 
@@ -139,9 +135,9 @@ class SNR:
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
+            Time after birth of the SNR
         energy_min : `~astropy.units.Quantity`
-            Lower energy limit for the luminosity.
+            Lower energy limit for the luminosity
 
         Notes
         -----
@@ -153,7 +149,6 @@ class SNR:
             \\left(\\frac{E_{SN}}{10^{51} erg}\\right)
             \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24} g/cm^{3}} \\right)
             \\textnormal{ph} s^{-1}
-
         """
         if t is not None:
             validate_physical_type("t", t, "time")
@@ -190,7 +185,6 @@ class SNR:
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{-1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{5/6}
             \\left(\\frac{\\rho_{ISM}}{10^{-24}g/cm^3}\\right)^{-1/3}
-
         """
         term1 = (self.e_sn / Quantity(1e51, "erg")) ** (-1.0 / 2)
         term2 = (self.m_ejecta / const.M_sun) ** (5.0 / 6)
@@ -212,7 +206,6 @@ class SNR:
             \\left(\\frac{m}{1.66\\cdot 10^{-24}g}\\right)^{5/6}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/3}
             \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24}g/cm^3}\\right)^{-1/3}
-
         """
         term1 = 3 * const.m_p.cgs / (100 * const.k_B.cgs * self.t_stop)
         term2 = (self.e_sn / self.rho_ISM) ** (2.0 / 5)
@@ -242,7 +235,7 @@ class SNRTrueloveMcKee(SNR):
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
+            Time after birth of the SNR
 
         Notes
         -----
@@ -265,7 +258,6 @@ class SNRTrueloveMcKee(SNR):
 
             R_{ch} = M_{ej}^{1/3}\\rho_{ISM}^{-1/3} \\ \\
             \\textnormal{and} \\ \\ t_{ch} = E_{SN}^{-1/2}M_{ej}^{5/6}\\rho_{ISM}^{-1/3}
-
         """
         if t is not None:
             validate_physical_type("t", t, "time")
@@ -288,8 +280,7 @@ class SNRTrueloveMcKee(SNR):
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
-
+            Time after birth of the SNR
         """
         return 1.12 * self.r_c * (t / self.t_c) ** (2.0 / 3)
 
@@ -299,7 +290,7 @@ class SNRTrueloveMcKee(SNR):
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
+            Time after birth of the SNR
         """
         term1 = self._radius_free_expansion(self.sedov_taylor_begin) ** (5.0 / 2)
         term2 = (2.026 * (self.e_sn / self.rho_ISM)) ** (1.0 / 2)
@@ -319,7 +310,7 @@ class SNRTrueloveMcKee(SNR):
         Parameters
         ----------
         t : `~astropy.units.Quantity`
-            Time after birth of the SNR.
+            Time after birth of the SNR
 
         Notes
         -----

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -4,7 +4,6 @@ import numpy as np
 from astropy.units import Quantity
 import astropy.constants as const
 from astropy.utils import lazyproperty
-from ...extern.validator import validate_physical_type
 
 __all__ = ["SNR", "SNRTrueloveMcKee"]
 
@@ -32,7 +31,7 @@ class SNR:
 
     def __init__(
         self,
-        e_sn=Quantity(1e51, "erg"),
+        e_sn="1e51 erg",
         theta=Quantity(0.1),
         n_ISM=Quantity(1, "cm-3"),
         m_ejecta=const.M_sun,
@@ -41,7 +40,7 @@ class SNR:
         morphology="Shell2D",
         spectral_index=2.1,
     ):
-        self.e_sn = e_sn
+        self.e_sn = Quantity(e_sn, "erg")
         self.theta = theta
         self.rho_ISM = n_ISM * const.m_p
         self.n_ISM = n_ISM
@@ -50,23 +49,14 @@ class SNR:
         self.morphology = morphology
         self.spectral_index = spectral_index
         if age is not None:
-            validate_physical_type("age", age, "time")
-            self.age = age
+            self.age = Quantity(age, "yr")
 
-    def radius(self, t=None):
+    def radius(self, t):
         """Outer shell radius at age t.
 
-        Parameters
-        ----------
-        t : `~astropy.units.Quantity`
-            Time after birth of the SNR
-
-        Notes
-        -----
         The radius during the free expansion phase is given by:
 
         .. math::
-
             r_{SNR}(t) \\approx 0.01 \\textnormal{}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{-1/2} t
@@ -74,15 +64,14 @@ class SNR:
         The radius during the Sedov-Taylor phase evolves like:
 
         .. math::
-
             r_{SNR}(t) \\approx \\left(\\frac{E_{SN}}{\\rho_{ISM}}\\right)^{1/5}t^{2/5}
+
+        Parameters
+        ----------
+        t : `~astropy.units.Quantity`
+            Time after birth of the SNR
         """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
+        t = Quantity(t, "yr")
         r = np.where(
             t > self.sedov_taylor_begin,
             self._radius_sedov_taylor(t).to_value("cm"),
@@ -124,11 +113,19 @@ class SNR:
         """
         return self.radius(t) * (1 - fraction)
 
-    def luminosity_tev(self, t=None, energy_min=Quantity(1, "TeV")):
+    def luminosity_tev(self, t, energy_min="1 TeV"):
         """Gamma-ray luminosity above ``energy_min`` at age ``t``.
 
         The luminosity is assumed constant in a given age interval and zero
         before and after. The assumed spectral index is 2.1.
+
+        The gamma-ray luminosity above 1 TeV is given by:
+
+        .. math::
+            L_{\\gamma}(\\geq 1TeV) \\approx 10^{34} \\theta
+            \\left(\\frac{E_{SN}}{10^{51} erg}\\right)
+            \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24} g/cm^{3}} \\right)
+            \\textnormal{ph} s^{-1}
 
         Reference: http://adsabs.harvard.edu/abs/1994A%26A...287..959D (Formula (7)).
 
@@ -138,24 +135,9 @@ class SNR:
             Time after birth of the SNR
         energy_min : `~astropy.units.Quantity`
             Lower energy limit for the luminosity
-
-        Notes
-        -----
-        The gamma-ray luminosity above 1 TeV is given by:
-
-        .. math::
-
-            L_{\\gamma}(\\geq 1TeV) \\approx 10^{34} \\theta
-            \\left(\\frac{E_{SN}}{10^{51} erg}\\right)
-            \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24} g/cm^{3}} \\right)
-            \\textnormal{ph} s^{-1}
         """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
+        t = Quantity(t, "yr")
+        energy_min = Quantity(energy_min, "TeV")
 
         # Flux in 1 k distance according to Drury formula 9
         term_0 = energy_min / Quantity(1, "TeV")
@@ -173,14 +155,13 @@ class SNR:
     def sedov_taylor_begin(self):
         """Characteristic time scale when the Sedov-Taylor phase of the SNR's evolution begins.
 
-        Notes
-        -----
         The beginning of the Sedov-Taylor phase of the SNR is defined by the condition,
         that the swept up mass of the surrounding medium equals the mass of the
-        ejected mass. The time scale is given by:
+        ejected mass.
+
+        The time scale is given by:
 
         .. math::
-
             t_{begin} \\approx 200 \\ \\textnormal{}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{-1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{5/6}
@@ -195,13 +176,12 @@ class SNR:
     def sedov_taylor_end(self):
         """Characteristic time scale when the Sedov-Taylor phase of the SNR's evolution ends.
 
-        Notes
-        -----
         The end of the Sedov-Taylor phase of the SNR is defined by the condition, that the
-        temperature at the shock drops below T = 10^6 K. The time scale is given by:
+        temperature at the shock drops below T = 10^6 K.
+
+        The time scale is given by:
 
         .. math::
-
             t_{end} \\approx 43000 \\textnormal{ }
             \\left(\\frac{m}{1.66\\cdot 10^{-24}g}\\right)^{5/6}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/3}
@@ -229,42 +209,32 @@ class SNRTrueloveMcKee(SNR):
             * self.rho_ISM ** (-1.0 / 3)
         )
 
-    def radius(self, t=None):
+    def radius(self, t):
         """Outer shell radius at age t.
 
-        Parameters
-        ----------
-        t : `~astropy.units.Quantity`
-            Time after birth of the SNR
-
-        Notes
-        -----
         The radius during the free expansion phase is given by:
 
         .. math::
-
             R_{SNR}(t) = 1.12R_{ch}\\left(\\frac{t}{t_{ch}}\\right)^{2/3}
 
         The radius during the Sedov-Taylor phase evolves like:
 
         .. math::
-
             R_{SNR}(t) = \\left[R_{SNR, ST}^{5/2} + \\left(2.026\\frac{E_{SN}}
             {\\rho_{ISM}}\\right)^{1/2}(t - t_{ST})\\right]^{2/5}
 
         Using the characteristic dimensions:
 
         .. math::
-
             R_{ch} = M_{ej}^{1/3}\\rho_{ISM}^{-1/3} \\ \\
             \\textnormal{and} \\ \\ t_{ch} = E_{SN}^{-1/2}M_{ej}^{5/6}\\rho_{ISM}^{-1/3}
+
+        Parameters
+        ----------
+        t : `~astropy.units.Quantity`
+            Time after birth of the SNR
         """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
+        t = Quantity(t, "yr")
 
         # Evaluate `_radius_sedov_taylor` on `t > self.sedov_taylor_begin`
         # only to avoid a warning
@@ -307,33 +277,24 @@ class SNRTrueloveMcKee(SNR):
     def radius_reverse_shock(self, t):
         """Reverse shock radius at age t.
 
-        Parameters
-        ----------
-        t : `~astropy.units.Quantity`
-            Time after birth of the SNR
-
-        Notes
-        -----
         Initially the reverse shock co-evolves with the radius of the SNR:
 
         .. math::
-
             R_{RS}(t) = \\frac{1}{1.19}r_{SNR}(t)
 
         After a time :math:`t_{core} \\simeq 0.25t_{ch}` the reverse shock reaches
         the core and then propagates as:
 
         .. math::
-
             R_{RS}(t) = \\left[1.49 - 0.16 \\frac{t - t_{core}}{t_{ch}} - 0.46
             \\ln \\left(\\frac{t}{t_{core}}\\right)\\right]\\frac{R_{ch}}{t_{ch}}t
+
+        Parameters
+        ----------
+        t : `~astropy.units.Quantity`
+            Time after birth of the SNR
         """
-        if t is not None:
-            validate_physical_type("t", t, "time")
-        elif hasattr(self, "age"):
-            t = self.age
-        else:
-            raise ValueError("Need time variable or age attribute.")
+        t = Quantity(t, "yr")
 
         # Time when reverse shock reaches the "core"
         t_core = 0.25 * self.t_c

--- a/gammapy/astro/source/tests/test_pulsar.py
+++ b/gammapy/astro/source/tests/test_pulsar.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
-import numpy as np
 from astropy.units import Quantity
 from astropy.table import Table
 from ....utils.testing import assert_quantity_allclose
@@ -78,6 +77,7 @@ def test_Pulsar_energy_integrated():
 
 
 def test_Pulsar_magnetic_field():
-    """Test against numerical integration"""
-    reference = np.ones_like(time.value) * (10 ** pulsar.logB)
-    assert_allclose(pulsar.magnetic_field(time).value, reference)
+    b = pulsar.magnetic_field(time)
+    assert b.unit == "G"
+    assert pulsar.B.unit == "G"
+    assert_allclose(b.value, pulsar.B.value)

--- a/gammapy/utils/coordinates/other.py
+++ b/gammapy/utils/coordinates/other.py
@@ -6,8 +6,6 @@ from astropy.units import Unit, Quantity
 __all__ = [
     "cartesian",
     "galactic",
-    "luminosity_to_flux",
-    "flux_to_luminosity",
     "radius_to_angle",
     "angle_to_radius",
     "velocity_glon_glat",
@@ -49,16 +47,6 @@ def galactic(x, y, z, obs_pos=None):
     return d, glon, glat
 
 
-def luminosity_to_flux(luminosity, distance):
-    """Distance is assumed to be in kpc"""
-    return luminosity / (4 * np.pi * distance ** 2)
-
-
-def flux_to_luminosity(flux, distance):
-    """Distance is assumed to be in kpc"""
-    return flux * 4 * np.pi * distance ** 2
-
-
 def radius_to_angle(radius, distance):
     """Radius (pc), distance(kpc), angle(deg)"""
     return np.arctan(radius / distance)
@@ -75,25 +63,15 @@ def velocity_glon_glat(x, y, z, vx, vy, vz):
 
     Parameters
     ----------
-    x : `~astropy.units.Quantity`
-        Position in x direction
-    y : `~astropy.units.Quantity`
-        Position in y direction
-    z : `~astropy.units.Quantity`
-        Position in z direction
-    vx : `~astropy.units.Quantity`
-        Velocity in x direction
-    vy : `~astropy.units.Quantity`
-        Velocity in y direction
-    vz : `~astropy.units.Quantity`
-        Velocity in z direction
+    x, y, z : `~astropy.units.Quantity`
+        Position in x, y, z direction
+    vx, vy, vz : `~astropy.units.Quantity`
+        Velocity in x, y, z direction
 
     Returns
     -------
-    v_glon : `~astropy.units.Quantity`
-        Projected velocity in Galactic longitude
-    v_glat : `~astropy.units.Quantity`
-        Projected velocity in Galactic latitude
+    v_glon, v_glat : `~astropy.units.Quantity`
+        Projected velocity in Galactic sky coordinates
     """
     y_prime = y + D_SUN_TO_GALACTIC_CENTER
     d = np.sqrt(x ** 2 + y_prime ** 2 + z ** 2)
@@ -116,25 +94,15 @@ def motion_since_birth(v, age, theta, phi):
         Absolute value of the velocity
     age : `~astropy.units.Quantity`
         Age of the source.
-    theta : `~astropy.units.Quantity`
-        Angular direction of the velocity.
-    phi : `~astropy.units.Quantity`
+    theta, phi : `~astropy.units.Quantity`
         Angular direction of the velocity.
 
     Returns
     -------
-    dx : `~astropy.units.Quantity`
-        Displacement in x direction
-    dy : `~astropy.units.Quantity`
-        Displacement in y direction
-    dz : `~astropy.units.Quantity`
-        Displacement in z direction
-    vx : `~astropy.units.Quantity`
-        Velocity in x direction
-    vy : `~astropy.units.Quantity`
-        Velocity in y direction
-    vz : `~astropy.units.Quantity`
-        Velocity in z direction
+    dx, dy, dz : `~astropy.units.Quantity`
+        Displacement in x, y, z direction
+    vx, vy, vz : `~astropy.units.Quantity`
+        Velocity in x, y, z direction
     """
     vx = v * np.cos(phi) * np.sin(theta)
     vy = v * np.sin(phi) * np.sin(theta)

--- a/gammapy/utils/coordinates/other.py
+++ b/gammapy/utils/coordinates/other.py
@@ -6,8 +6,6 @@ from astropy.units import Unit, Quantity
 __all__ = [
     "cartesian",
     "galactic",
-    "radius_to_angle",
-    "angle_to_radius",
     "velocity_glon_glat",
     "motion_since_birth",
     "polar",
@@ -45,16 +43,6 @@ def galactic(x, y, z, obs_pos=None):
     glon = np.arctan2(x, y_prime).to("deg")
     glat = np.arcsin(z / d).to("deg")
     return d, glon, glat
-
-
-def radius_to_angle(radius, distance):
-    """Radius (pc), distance(kpc), angle(deg)"""
-    return np.arctan(radius / distance)
-
-
-def angle_to_radius(angle, distance):
-    """Radius (pc), distance(kpc), angle(deg)"""
-    return np.tan(angle * distance)
 
 
 def velocity_glon_glat(x, y, z, vx, vy, vz):

--- a/gammapy/utils/random.py
+++ b/gammapy/utils/random.py
@@ -96,45 +96,6 @@ def sample_sphere(size, lon_range=None, lat_range=None, random_state="random-see
     return lon, lat
 
 
-def sample_powerlaw(x_min, x_max, gamma, size=None, random_state="random-seed"):
-    """Sample random values from a power law distribution.
-
-    f(x) = x ** (-gamma) in the range x_min to x_max
-
-    It is assumed that *gamma* is the **differential** spectral index.
-
-    Reference: http://mathworld.wolfram.com/RandomNumber.html
-
-    Parameters
-    ----------
-    x_min : float
-        x range minimum
-    x_max : float
-        x range maximum
-    gamma : float
-        Power law index
-    size : int, optional
-        Number of samples to generate
-    random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
-        Defines random number generator initialisation.
-        Passed to `~gammapy.utils.random.get_random_state`.
-
-    Returns
-    -------
-    x : array
-        Array of samples from the distribution
-    """
-    random_state = get_random_state(random_state)
-
-    size = int(size)
-
-    exp = -gamma
-    base = random_state.uniform(x_min ** exp, x_max ** exp, size)
-    x = base ** (1 / exp)
-
-    return x
-
-
 def sample_sphere_distance(
     distance_min=0, distance_max=1, size=None, random_state="random-seed"
 ):
@@ -180,3 +141,42 @@ def sample_sphere_distance(
     distance = ((u - b) / a) ** (1.0 / 3)
 
     return distance
+
+
+def sample_powerlaw(x_min, x_max, gamma, size=None, random_state="random-seed"):
+    """Sample random values from a power law distribution.
+
+    f(x) = x ** (-gamma) in the range x_min to x_max
+
+    It is assumed that *gamma* is the **differential** spectral index.
+
+    Reference: http://mathworld.wolfram.com/RandomNumber.html
+
+    Parameters
+    ----------
+    x_min : float
+        x range minimum
+    x_max : float
+        x range maximum
+    gamma : float
+        Power law index
+    size : int, optional
+        Number of samples to generate
+    random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+        Defines random number generator initialisation.
+        Passed to `~gammapy.utils.random.get_random_state`.
+
+    Returns
+    -------
+    x : array
+        Array of samples from the distribution
+    """
+    random_state = get_random_state(random_state)
+
+    size = int(size)
+
+    exp = -gamma
+    base = random_state.uniform(x_min ** exp, x_max ** exp, size)
+    x = base ** (1 / exp)
+
+    return x

--- a/gammapy/utils/tests/test_random.py
+++ b/gammapy/utils/tests/test_random.py
@@ -97,13 +97,6 @@ def test_sample_sphere():
         ).any()
 
 
-def test_sample_powerlaw():
-    random_state = np.random.RandomState(seed=0)
-
-    x = sample_powerlaw(x_min=0.1, x_max=10, gamma=2, size=2, random_state=random_state)
-    assert_allclose(x, [0.14886601, 0.1873559])
-
-
 def test_sample_sphere_distance():
     random_state = np.random.RandomState(seed=0)
 
@@ -117,3 +110,10 @@ def test_sample_sphere_distance():
     )
     assert x.min() >= 0.1
     assert x.max() <= 42
+
+
+def test_sample_powerlaw():
+    random_state = np.random.RandomState(seed=0)
+
+    x = sample_powerlaw(x_min=0.1, x_max=10, gamma=2, size=2, random_state=random_state)
+    assert_allclose(x, [0.14886601, 0.1873559])


### PR DESCRIPTION
This PR started with the goal to replace `gammapy/utils/coordinates/other.py` (that code is older than Astropy and somehow survived until now) with use of `astropy.coordinates`, continuing #2185 from yesterday.  This PR implements many things noted in #977, but I won't do all here (e.g. not write a high-level tutorial notebook).

The only caller of that code is `gammapy.astro.population`, in `spatial.py` and `simulate.py`.

I quickly started noticing bugs and issues there, so by now this PR is mostly a mixed bag of improvements in `gammapy.astro` code, docstrings and tests.

- [x] Remove `add_observed_source_parameters` - it was buggy, not tested, and not really useful
- [x] Improve `make_catalog_random_positions_cube` and  `make_catalog_random_positions_sphere`
- [x] Add tests with asserts on all columns and units from the functions in `simulate.py`
- [x] Remove `PWN.luminosity_tev` and `L_PWN` in `simulate.py`. It was the energy dumped by the pulsar in `erg`, but there was no radiation model or timescale and thus no luminosity to give.
- [x] Remove `Pulsar.luminosity_tev` (not useful, just callse `Pulsar.luminosity_spindown` and multiplies with a number the user passes in.
- [x] Change `Pulsar` attribute from `logB` to `B` to avoid ambiguity concerning `log_10` or `log_e`.
- [x] Change from `validate_physical_type` to pass through `Quantity`, like we do everywhere else in Gammapy
- [x] Put method description in the main part of the docstring, instead of always having it in a `Notes` section. That's IMO a bit shorter, easier to grok, and more consistent with the rest of Gammapy / Astropy.

The diff here is already ~ 500 lines, hard to review. I'm merging this now, and will send a follow-up PR to rewrite `gammapy/utils/coordinates/other.py` and the coords code in `gammapy.astro.population`.

