### PR TITLE
Implement likelihood_profile_ul_scipy

### DIFF
--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -2,13 +2,12 @@
 import logging
 from collections import OrderedDict
 import numpy as np
-from scipy.optimize import brentq
 from astropy.table import Table, vstack
 from astropy import units as u
 from astropy.io.registry import IORegistryError
 from ..utils.scripts import make_path
 from ..utils.table import table_standardise_units_copy, table_from_row_data
-from ..utils.interpolation import ScaledRegularGridInterpolator
+from ..utils.interpolation import interpolate_likelihood_profile
 from ..utils.fitting import Dataset, Datasets, Fit
 from .models import PowerLaw, ScaleModel
 from .powerlaw import power_law_integral_flux
@@ -707,7 +706,7 @@ class FluxPoints:
             norm = (y_values / y_ref).to_value("")
             norm_scan = row["norm_scan"]
             dloglike_scan = row["dloglike_scan"] - row["loglike"]
-            interp = _interp_likelihood_profile(norm_scan, dloglike_scan)
+            interp = interpolate_likelihood_profile(norm_scan, dloglike_scan)
             z[idx] = interp((norm,))
 
         kwargs.setdefault("vmax", 0)

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -59,18 +59,6 @@ DEFAULT_UNIT = OrderedDict(
 )
 
 
-def _interp_likelihood_profile(norm_scan, dloglike_scan):
-    """Helper function to interpolate likelihood profiles"""
-    # likelihood profiles are typically of parabolic shape, so we use a
-    # sqrt scaling of the values and perform linear interpolation on the scaled
-    # values
-    sign = np.sign(np.gradient(dloglike_scan))
-    interp = ScaledRegularGridInterpolator(
-        points=(norm_scan,), values=sign * dloglike_scan, values_scale="sqrt"
-    )
-    return interp
-
-
 class FluxPoints:
     """Flux points container.
 

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -5,7 +5,12 @@ from scipy.optimize.zeros import RootResults
 from .likelihood import Likelihood
 from ..interpolation import interpolate_likelihood_profile
 
-__all__ = ["optimize_scipy", "covariance_scipy", "confidence_scipy", "likelihood_profile_ul_scipy"]
+__all__ = [
+    "optimize_scipy",
+    "covariance_scipy",
+    "confidence_scipy",
+    "likelihood_profile_ul_scipy",
+]
 
 
 def optimize_scipy(parameters, function, **kwargs):
@@ -130,8 +135,9 @@ def covariance_scipy(parameters, function):
     raise NotImplementedError
 
 
-
-def likelihood_profile_ul_scipy(value_scan, dloglike_scan, delta_ts=4, interp_scale="sqrt", **kwargs):
+def likelihood_profile_ul_scipy(
+    value_scan, dloglike_scan, delta_ts=4, interp_scale="sqrt", **kwargs
+):
     """Compute upper limit of a parameter from a likelihood profile.
 
     Parameters
@@ -154,7 +160,9 @@ def likelihood_profile_ul_scipy(value_scan, dloglike_scan, delta_ts=4, interp_sc
     ul : float
         Upper limit value.
     """
-    interp = interpolate_likelihood_profile(value_scan, dloglike_scan, interp_scale=interp_scale)
+    interp = interpolate_likelihood_profile(
+        value_scan, dloglike_scan, interp_scale=interp_scale
+    )
 
     def f(x):
         return interp((x,)) - delta_ts

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -3,8 +3,7 @@ import numpy as np
 from scipy.optimize import minimize, brentq
 from scipy.optimize.zeros import RootResults
 from .likelihood import Likelihood
-from ..interpolation import ScaledRegularGridInterpolator
-
+from ..interpolation import interpolate_likelihood_profile
 
 __all__ = ["optimize_scipy", "covariance_scipy", "confidence_scipy", "likelihood_profile_ul_scipy"]
 
@@ -131,17 +130,6 @@ def covariance_scipy(parameters, function):
     raise NotImplementedError
 
 
-def _interp_likelihood_profile(value_scan, dloglike_scan, interp_scale="sqrt"):
-    """Helper function to interpolate likelihood profiles"""
-    # likelihood profiles are typically of parabolic shape, so we use a
-    # sqrt scaling of the values and perform linear interpolation on the scaled
-    # values
-    sign = np.sign(np.gradient(dloglike_scan))
-    interp = ScaledRegularGridInterpolator(
-        points=(value_scan,), values=sign * dloglike_scan, values_scale=interp_scale
-    )
-    return interp
-
 
 def likelihood_profile_ul_scipy(value_scan, dloglike_scan, delta_ts=4, interp_scale="sqrt", **kwargs):
     """Compute upper limit of a parameter from a likelihood profile.
@@ -166,7 +154,7 @@ def likelihood_profile_ul_scipy(value_scan, dloglike_scan, delta_ts=4, interp_sc
     ul : float
         Upper limit value.
     """
-    interp = _interp_likelihood_profile(value_scan, dloglike_scan, interp_scale=interp_scale)
+    interp = interpolate_likelihood_profile(value_scan, dloglike_scan, interp_scale=interp_scale)
 
     def f(x):
         return interp((x,)) - delta_ts

--- a/gammapy/utils/fitting/tests/test_scipy.py
+++ b/gammapy/utils/fitting/tests/test_scipy.py
@@ -2,7 +2,13 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from .. import Parameter, Parameters, optimize_scipy, confidence_scipy, likelihood_profile_ul_scipy
+from .. import (
+    Parameter,
+    Parameters,
+    optimize_scipy,
+    confidence_scipy,
+    likelihood_profile_ul_scipy,
+)
 
 
 def fcn(parameters):
@@ -95,9 +101,3 @@ def test_likelihood_profile_ul_scipy():
 
     ul = likelihood_profile_ul_scipy(x, x, interp_scale="lin")
     assert_allclose(ul, 4)
-
-
-
-
-
-

--- a/gammapy/utils/fitting/tests/test_scipy.py
+++ b/gammapy/utils/fitting/tests/test_scipy.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
-from .. import Parameter, Parameters, optimize_scipy, confidence_scipy
+from .. import Parameter, Parameters, optimize_scipy, confidence_scipy, likelihood_profile_ul_scipy
 
 
 def fcn(parameters):
@@ -84,3 +85,19 @@ def test_scipy_confidence(pars):
 
     assert_allclose(result["errp"], 0.2, rtol=1e-3)
     assert_allclose(result["errn"], 0.2, rtol=1e-3)
+
+
+def test_likelihood_profile_ul_scipy():
+    x = np.linspace(-5, 5, 7)
+    y = x ** 2
+    ul = likelihood_profile_ul_scipy(x, y)
+    assert_allclose(ul, 2)
+
+    ul = likelihood_profile_ul_scipy(x, x, interp_scale="lin")
+    assert_allclose(ul, 4)
+
+
+
+
+
+

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -168,3 +168,33 @@ class LinearScale(InterpolationScale):
     @staticmethod
     def _inverse(values):
         return values
+
+
+def interpolate_likelihood_profile(value_scan, dloglike_scan, interp_scale="sqrt"):
+    """Helper function to interpolate likelihood profiles.
+
+    Parameters
+    ----------
+    value_scan : `~numpy.ndarray`
+        Array of parameter values.
+    dloglike_scan : `~numpy.ndarray`
+        Array of delta log-likelihood values, with respect to the minimum.
+    interp_scale : {"sqrt", "lin"}
+        Interpolation scale applied to the likelihood profile. If the profile is
+        of parabolic shape, a "sqrt" scaling is recommended. In other cases or
+        for fine sampled profiles a "lin" can also be used.
+
+    Returns
+    -------
+    interp : `ScaledRegularGridInterpolator`
+        Interpolator instance.
+
+    """
+    # likelihood profiles are typically of parabolic shape, so we use a
+    # sqrt scaling of the values and perform linear interpolation on the scaled
+    # values
+    sign = np.sign(np.gradient(dloglike_scan))
+    interp = ScaledRegularGridInterpolator(
+        points=(value_scan,), values=sign * dloglike_scan, values_scale=interp_scale
+    )
+    return interp

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -5,7 +5,11 @@ from scipy.interpolate import RegularGridInterpolator, interp1d
 from astropy import units as u
 
 
-__all__ = ["ScaledRegularGridInterpolator", "interpolation_scale"]
+__all__ = [
+    "ScaledRegularGridInterpolator",
+    "interpolation_scale",
+    "interpolate_likelihood_profile",
+]
 
 
 class ScaledRegularGridInterpolator:


### PR DESCRIPTION
This PR brings back the helper method ` likelihood_profile_ul_scipy` to compute UL from likelihood profiles removed in https://github.com/gammapy/gammapy/commit/4f5f762d1425b724ae9482219b08cf4019e70e81 and also implements corresponding tests.