### PR TITLE
Simplify datasets likelihood mask handling

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -165,17 +165,10 @@ class MapDataset(Dataset):
         """
         counts, npred = self._counts_data, self.npred().data
 
-        # TODO: add mask handling to _stat_sum, so that the temp copy
-        # created by the fancy indexing is avoided
-        if self.mask_fit is None and self.mask_safe is None:
-            stat = self._stat_sum(counts.ravel(), npred.ravel())
-        elif self.mask_fit is None:
-            stat = self._stat_sum(counts[self.mask_safe], npred[self.mask_safe])
-        elif self.mask_safe is None:
-            stat = self._stat_sum(counts[self.mask_fit], npred[self.mask_fit])
+        if self.mask is  not None:
+            stat = self._stat_sum(counts[self.mask], npred[self.mask])
         else:
-            mask_joined = self.mask_safe & self.mask_fit
-            stat = self._stat_sum(counts[mask_joined], npred[mask_joined])
+            stat = self._stat_sum(counts.ravel(), npred.ravel())
 
         return stat
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -111,20 +111,6 @@ class SpectrumDataset(Dataset):
         """Likelihood per bin given the current model parameters"""
         return cash(n_on=self.counts.data.data, mu_on=self.npred().data.data)
 
-    def likelihood(self):
-        """Total likelihood given the current model parameters.
-        """
-        if self.mask_fit is None and self.mask_safe is None:
-            stat = self.likelihood_per_bin()
-        elif self.mask_fit is None:
-            stat = self.likelihood_per_bin()[self.mask_safe]
-        elif self.mask_safe is None:
-            stat = self.likelihood_per_bin()[self.mask_fit]
-        else:
-            stat = self.likelihood_per_bin()[self.mask_safe & self.mask_fit]
-
-        return np.sum(stat, dtype=np.float64)
-
     def fake(self, random_state="random-seed"):
         """Simulate a fake `~gammapy.spectrum.CountsSpectrum`.
 
@@ -344,19 +330,6 @@ class SpectrumDatasetOnOff(Dataset):
         )
         return np.nan_to_num(on_stat_)
 
-    def likelihood(self):
-        """Total likelihood given the current model parameters.
-        """
-        if self.mask_fit is None and self.mask_safe is None:
-            stat = self.likelihood_per_bin()
-        elif self.mask_fit is None:
-            stat = self.likelihood_per_bin()[self.mask_safe]
-        elif self.mask_safe is None:
-            stat = self.likelihood_per_bin()[self.mask_fit]
-        else:
-            stat = self.likelihood_per_bin()[self.mask_safe & self.mask_fit]
-
-        return np.sum(stat, dtype=np.float64)
 
     @classmethod
     def read(cls, filename):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1219,20 +1219,6 @@ class FluxPointsDataset(Dataset):
             # TODO: add likelihood profiles
             pass
 
-    def likelihood(self):
-        """Total likelihood given the current model parameters.
-        """
-        if self.mask_fit is None and self.mask_safe is None:
-            stat = self.likelihood_per_bin()
-        elif self.mask_fit is None:
-            stat = self.likelihood_per_bin()[self.mask_safe]
-        elif self.mask_safe is None:
-            stat = self.likelihood_per_bin()[self.mask_fit]
-        else:
-            stat = self.likelihood_per_bin()[self.mask_safe & self.mask_fit]
-
-        return np.nansum(stat, dtype=np.float64)
-
     def residuals(self):
         """Compute flux point residuals
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1151,7 +1151,7 @@ class FluxPointsDataset(Dataset):
 
         from astropy import units as u
         from gammapy.spectrum import FluxPoints, FluxPointsDataset
-        form gammapy.utils.fitting import Fit
+        from gammapy.utils.fitting import Fit
         from gammapy.spectrum.models import PowerLaw
 
         filename = '$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits'
@@ -1163,7 +1163,7 @@ class FluxPointsDataset(Dataset):
         fit = Fit(dataset)
         result = fit.run()
         print(result)
-        print(result.model)
+        print(result.parameters.to_table())
     """
 
     def __init__(self, model, data, mask_fit=None, likelihood="chi2", mask_safe=None):
@@ -1171,6 +1171,13 @@ class FluxPointsDataset(Dataset):
         self.data = data
         self.mask_fit = mask_fit
         self.parameters = model.parameters
+
+        if data.sed_type != "dnde":
+            raise ValueError("Currently only flux points of type 'dnde' are supported.")
+
+        if mask_safe is None:
+            mask_safe = np.isfinite(data.table["dnde"])
+
         self.mask_safe = mask_safe
 
         if likelihood in ["chi2", "chi2assym"]:

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -42,7 +42,7 @@ class Dataset(abc.ABC):
         if self.mask is not None:
             stat = stat[self.mask]
 
-        return np.nansum(stat, dtype=np.float64)
+        return np.sum(stat, dtype=np.float64)
 
     @abc.abstractmethod
     def likelihood_per_bin(self):

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -21,14 +21,28 @@ class Dataset(abc.ABC):
     - `gammapy.spectrum.FluxPointsDataset`
     """
 
-    @abc.abstractmethod
-    def likelihood(self):
-        """Total likelihood (float, sum over bins).
+    @property
+    def mask(self):
+        """Combined fit and safe mask"""
+        if self.mask_safe is not None and self.mask_fit is not None:
+            mask = self.mask_safe & self.mask_fit
+        elif self.mask_fit is not None:
+            mask = self.mask_fit
+        elif self.mask_safe is not None:
+            mask = self.mask_safe
+        else:
+            mask = None
+        return mask
 
-        TODO: fix interface.
-        Remove ``parameters`` and ``mask``, add update method?
+    def likelihood(self):
+        """Total likelihood given the current model parameters.
         """
-        pass
+        stat = self.likelihood_per_bin()
+
+        if self.mask is not None:
+            stat = stat[self.mask]
+
+        return np.nansum(stat, dtype=np.float64)
 
     @abc.abstractmethod
     def likelihood_per_bin(self):


### PR DESCRIPTION
This PR implements the following changes:

- Add `Dataset.mask` attribute which combines the `mask_safe` and `mask_fit` for likelihood evaluation
- Implement `Dataset.likelihood()` on the base class
- Remove the `.likelihood()` methods on the sub-classes
- Add a default `mask_safe` to the `FluxPointsDataset` to avoid `NaN` values in the likelihood evaluation 