### PR TITLE
Replace \textnormal with \text in docstrings

### DIFF
--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -45,9 +45,7 @@ class DMProfile(abc.ABC):
         r"""Integrate squared dark matter profile numerically.
 
         .. math::
-
             F(r_{min}, r_{max}) = \int_{r_{min}}^{r_{max}}\rho(r)^2 dr
-
 
         Parameters
         ----------
@@ -64,7 +62,6 @@ class NFWProfile(DMProfile):
     r"""NFW Profile.
 
     .. math::
-
         \rho(r) = \rho_s \frac{r_s}{r}\left(1 + \frac{r}{r_s}\right)^{-2}
 
     Parameters
@@ -99,7 +96,6 @@ class EinastoProfile(DMProfile):
     r"""Einasto Profile.
 
     .. math::
-
         \rho(r) = \rho_s \exp{
             \left(-\frac{2}{\alpha}\left[
             \left(\frac{r}{r_s}\right)^{\alpha} - 1\right] \right)}
@@ -146,9 +142,7 @@ class EinastoProfile(DMProfile):
 class IsothermalProfile(DMProfile):
     r"""Isothermal Profile.
 
-    .. math::
-
-        \rho(r) = \frac{\rho_s}{1 + (r/r_s)^2}
+    .. math:: \rho(r) = \frac{\rho_s}{1 + (r/r_s)^2}
 
     Parameters
     ----------
@@ -180,9 +174,7 @@ class IsothermalProfile(DMProfile):
 class BurkertProfile(DMProfile):
     r"""Burkert Profile.
 
-    .. math::
-
-        \rho(r) = \frac{\rho_s}{(1 + r/r_s)(1 + (r/r_s)^2)}
+    .. math:: \rho(r) = \frac{\rho_s}{(1 + r/r_s)(1 + (r/r_s)^2)}
 
     Parameters
     ----------
@@ -215,7 +207,6 @@ class MooreProfile(DMProfile):
     r"""Moore Profile.
 
     .. math::
-
         \rho(r) = \rho_s \left(\frac{r_s}{r}\right)^{1.16}
         \left(1 + \frac{r}{r_s} \right)^{-1.84}
 

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -131,7 +131,6 @@ class DMAnnihilation(SpectralModel):
     The gamma-ray flux is computed as follows:
 
     .. math::
-
         \frac{\mathrm d \phi}{\mathrm d E} =
         \frac{\langle \sigma\nu \rangle}{4\pi k m^2_{\mathrm{DM}}}
         \frac{\mathrm d N}{\mathrm dE} \times J(\Delta\Omega)

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -61,7 +61,7 @@ class SimplePulsar:
         """Magnetic field strength at the polar cap (`~astropy.units.Quantity`).
 
         .. math::
-            B = 3.2\\cdot 10^{19} (P\\dot{P})^{1/2} [\\textnormal(Gauss)]
+            B = 3.2\\cdot 10^{19} (P\\dot{P})^{1/2} [\\text(Gauss)]
         """
         return B_CONST * np.sqrt(self.P * self.P_dot)
 
@@ -192,7 +192,7 @@ class Pulsar(SimplePulsar):
         """Magnetic field at polar cap (assumed constant).
 
         .. math::
-            B = 3.2\\cdot 10^{19} (P\\dot{P})^{1/2} [\\textnormal(Gauss)]
+            B = 3.2\\cdot 10^{19} (P\\dot{P})^{1/2} [\\text(Gauss)]
 
         Parameters
         ----------

--- a/gammapy/astro/source/pulsar.py
+++ b/gammapy/astro/source/pulsar.py
@@ -42,8 +42,7 @@ class SimplePulsar:
     def luminosity_spindown(self):
         """Spin-down luminosity (`~astropy.units.Quantity`).
 
-        .. math::
-            \\dot{L} = 4\\pi^2 I \\frac{\\dot{P}}{P^{3}}
+        .. math:: \\dot{L} = 4\\pi^2 I \\frac{\\dot{P}}{P^{3}}
         """
         return 4 * np.pi ** 2 * self.I * self.P_dot / self.P ** 3
 
@@ -51,8 +50,7 @@ class SimplePulsar:
     def tau(self):
         """Characteristic age (`~astropy.units.Quantity`).
 
-        .. math::
-            \\tau = \\frac{P}{2\\dot{P}}
+        .. math:: \\tau = \\frac{P}{2\\dot{P}}
         """
         return (self.P / (2 * self.P_dot)).to("yr")
 
@@ -60,8 +58,7 @@ class SimplePulsar:
     def magnetic_field(self):
         """Magnetic field strength at the polar cap (`~astropy.units.Quantity`).
 
-        .. math::
-            B = 3.2\\cdot 10^{19} (P\\dot{P})^{1/2} [\\text(Gauss)]
+        .. math:: B = 3.2 \\cdot 10^{19} (P\\dot{P})^{1/2} \\text{ Gauss}
         """
         return B_CONST * np.sqrt(self.P * self.P_dot)
 
@@ -132,8 +129,7 @@ class Pulsar(SimplePulsar):
 
         Time-integrated spin-down luminosity since birth.
 
-        .. math::
-            E(t) = \\dot{L}_0 \\tau_0 \\frac{t}{t + \\tau_0}
+        .. math:: E(t) = \\dot{L}_0 \\tau_0 \\frac{t}{t + \\tau_0}
 
         Parameters
         ----------
@@ -163,8 +159,7 @@ class Pulsar(SimplePulsar):
         P_dot for a given period and magnetic field B, assuming a dipole
         spin-down.
 
-        .. math::
-            \\dot{P}(t) = \\frac{B^2}{3.2 \\cdot 10^{19} P(t)}
+        .. math:: \\dot{P}(t) = \\frac{B^2}{3.2 \\cdot 10^{19} P(t)}
 
         Parameters
         ----------
@@ -177,8 +172,7 @@ class Pulsar(SimplePulsar):
     def tau(self, t):
         """Characteristic age at real age t.
 
-        .. math::
-            \\tau = \\frac{P}{2\\dot{P}}
+        .. math:: \\tau = \\frac{P}{2\\dot{P}}
 
         Parameters
         ----------
@@ -192,7 +186,7 @@ class Pulsar(SimplePulsar):
         """Magnetic field at polar cap (assumed constant).
 
         .. math::
-            B = 3.2\\cdot 10^{19} (P\\dot{P})^{1/2} [\\text(Gauss)]
+            B = 3.2 \\cdot 10^{19} (P\\dot{P})^{1/2} \\text{ Gauss}
 
         Parameters
         ----------

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -81,8 +81,9 @@ class PWN:
         During the free expansion phase the radius of the PWN evolves like:
 
         .. math::
-            R_{PWN}(t) = 1.44\\text{pc}\\left(\\frac{E_{SN}^3\\dot{E}_0^2}
+            R_{PWN}(t) = 1.44 \\left(\\frac{E_{SN}^3\\dot{E}_0^2}
             {M_{ej}^5}\\right)^{1/10}t^{6/5}
+            \\text{pc}
 
         After the collision with the reverse shock of the SNR, the radius is
         assumed to be constant (See `~gammapy.astro.source.SNRTrueloveMcKee.radius_reverse_shock`).

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -57,7 +57,7 @@ class SNR:
         The radius during the free expansion phase is given by:
 
         .. math::
-            r_{SNR}(t) \\approx 0.01 \\textnormal{}
+            r_{SNR}(t) \\approx 0.01 \\text{}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{-1/2} t
 
@@ -125,7 +125,7 @@ class SNR:
             L_{\\gamma}(\\geq 1TeV) \\approx 10^{34} \\theta
             \\left(\\frac{E_{SN}}{10^{51} erg}\\right)
             \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24} g/cm^{3}} \\right)
-            \\textnormal{ph} s^{-1}
+            \\text{ph} s^{-1}
 
         Reference: http://adsabs.harvard.edu/abs/1994A%26A...287..959D (Formula (7)).
 
@@ -162,7 +162,7 @@ class SNR:
         The time scale is given by:
 
         .. math::
-            t_{begin} \\approx 200 \\ \\textnormal{}
+            t_{begin} \\approx 200 \\ \\text{}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{-1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{5/6}
             \\left(\\frac{\\rho_{ISM}}{10^{-24}g/cm^3}\\right)^{-1/3}
@@ -182,7 +182,7 @@ class SNR:
         The time scale is given by:
 
         .. math::
-            t_{end} \\approx 43000 \\textnormal{ }
+            t_{end} \\approx 43000 \\text{ }
             \\left(\\frac{m}{1.66\\cdot 10^{-24}g}\\right)^{5/6}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/3}
             \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24}g/cm^3}\\right)^{-1/3}
@@ -227,7 +227,7 @@ class SNRTrueloveMcKee(SNR):
 
         .. math::
             R_{ch} = M_{ej}^{1/3}\\rho_{ISM}^{-1/3} \\ \\
-            \\textnormal{and} \\ \\ t_{ch} = E_{SN}^{-1/2}M_{ej}^{5/6}\\rho_{ISM}^{-1/3}
+            \\text{and} \\ \\ t_{ch} = E_{SN}^{-1/2}M_{ej}^{5/6}\\rho_{ISM}^{-1/3}
 
         Parameters
         ----------

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -57,9 +57,10 @@ class SNR:
         The radius during the free expansion phase is given by:
 
         .. math::
-            r_{SNR}(t) \\approx 0.01 \\text{}
+            r_{SNR}(t) \\approx 0.01
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{-1/2} t
+            \\text{ pc}
 
         The radius during the Sedov-Taylor phase evolves like:
 
@@ -125,7 +126,7 @@ class SNR:
             L_{\\gamma}(\\geq 1TeV) \\approx 10^{34} \\theta
             \\left(\\frac{E_{SN}}{10^{51} erg}\\right)
             \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24} g/cm^{3}} \\right)
-            \\text{ph} s^{-1}
+            \\text{ s}^{-1}
 
         Reference: http://adsabs.harvard.edu/abs/1994A%26A...287..959D (Formula (7)).
 
@@ -162,10 +163,11 @@ class SNR:
         The time scale is given by:
 
         .. math::
-            t_{begin} \\approx 200 \\ \\text{}
+            t_{begin} \\approx 200
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{-1/2}
             \\left(\\frac{M_{ej}}{M_{\\odot}}\\right)^{5/6}
             \\left(\\frac{\\rho_{ISM}}{10^{-24}g/cm^3}\\right)^{-1/3}
+            \\text{yr}
         """
         term1 = (self.e_sn / Quantity(1e51, "erg")) ** (-1.0 / 2)
         term2 = (self.m_ejecta / const.M_sun) ** (5.0 / 6)
@@ -182,10 +184,11 @@ class SNR:
         The time scale is given by:
 
         .. math::
-            t_{end} \\approx 43000 \\text{ }
+            t_{end} \\approx 43000
             \\left(\\frac{m}{1.66\\cdot 10^{-24}g}\\right)^{5/6}
             \\left(\\frac{E_{SN}}{10^{51}erg}\\right)^{1/3}
             \\left(\\frac{\\rho_{ISM}}{1.66\\cdot 10^{-24}g/cm^3}\\right)^{-1/3}
+            \\text{yr}
         """
         term1 = 3 * const.m_p.cgs / (100 * const.k_B.cgs * self.t_stop)
         term2 = (self.e_sn / self.rho_ISM) ** (2.0 / 5)

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -118,8 +118,8 @@ class TSMapEstimator:
 
         TS = \\left \\{
                  \\begin{array}{ll}
-                   -TS & : \\textnormal{if} \\ F < 0 \\\\
-                   \\ \\ TS & : \\textnormal{else}
+                   -TS & : \\text{if} \\ F < 0 \\\\
+                   \\ \\ TS & : \\text{else}
                  \\end{array}
                \\right.
 
@@ -221,8 +221,8 @@ class TSMapEstimator:
         .. math::
             \sqrt{TS} = \left \{
             \begin{array}{ll}
-              -\sqrt{-TS} & : \textnormal{if} \ TS < 0 \\
-              \sqrt{TS} & : \textnormal{else}
+              -\sqrt{-TS} & : \text{if} \ TS < 0 \\
+              \sqrt{TS} & : \text{else}
             \end{array}
             \right.
 

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -57,10 +57,7 @@ class SkySpatialModel(Model):
 class SkyPointSource(SkySpatialModel):
     r"""Point Source.
 
-    .. math::
-
-        \phi(lon, lat) = \delta{(lon - lon_0, lat - lat_0)}
-
+    .. math:: \phi(lon, lat) = \delta{(lon - lon_0, lat - lat_0)}
 
     Parameters
     ----------
@@ -117,7 +114,6 @@ class SkyGaussian(SkySpatialModel):
     r"""Two-dimensional symmetric Gaussian model
 
     .. math::
-
         \phi(\text{lon}, \text{lat}) = N \times \text{exp}\left\{-\frac{1}{2}
             \frac{1-\text{cos}\theta}{1-\text{cos}\sigma}\right\}\,,
 
@@ -127,7 +123,6 @@ class SkyGaussian(SkySpatialModel):
     the sphere:
 
     .. math::
-
         N = \frac{1}{4\pi a\left[1-\text{exp}(-1/a)\right]}\,,\,\,\,\,
         a = 1-\text{cos}\sigma\,.
 
@@ -135,7 +130,6 @@ class SkyGaussian(SkySpatialModel):
     In the limit of small :math:`\theta` and :math:`\sigma`, this definition reduces to the usual form:
 
     .. math::
-
         \phi(\text{lon}, \text{lat}) = \frac{1}{2\pi\sigma^2} \exp{\left(-\frac{1}{2}
             \frac{\theta^2}{\sigma^2}\right)}
 
@@ -189,7 +183,6 @@ class SkyDisk(SkySpatialModel):
     r"""Constant radial disk model.
 
     .. math::
-
         \phi(lon, lat) = \frac{1}{2 \pi (1 - \cos{r_0}) } \cdot
                 \begin{cases}
                     1 & \text{for } \theta \leq r_0 \\
@@ -438,7 +431,6 @@ class SkyShell(SkySpatialModel):
     r"""Shell model.
 
     .. math::
-
         \phi(lon, lat) = \frac{3}{2 \pi (r_{out}^3 - r_{in}^3)} \cdot
                 \begin{cases}
                     \sqrt{r_{out}^2 - \theta^2} - \sqrt{r_{in}^2 - \theta^2} &

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -438,9 +438,7 @@ class EnergyDispersion:
 
         Bias is defined as
 
-        .. math::
-
-            \frac{E_{reco}-E_{true}}{E_{true}}
+        .. math:: \frac{E_{reco}-E_{true}}{E_{true}}
 
         Parameters
         ----------

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -21,7 +21,6 @@ class IRFStacker:
     and :math:`l` denote a bin in reconstructed and true energy, respectively.
 
     .. math::
-
         \epsilon_{jk} =\left\{\begin{array}{cl} 1, & \mbox{if
             bin k is inside the energy thresholds}\\ 0, & \mbox{otherwise} \end{array}\right.
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -679,7 +679,6 @@ class SpectrumDatasetOnOffStacker:
     respectively.
 
     .. math::
-
         \epsilon_{jk} =\left\{\begin{array}{cl} 1, & \mbox{if
             bin k is inside the energy thresholds}\\ 0, & \mbox{otherwise} \end{array}\right.
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -436,9 +436,7 @@ class SpectralModel(Model):
 class ConstantModel(SpectralModel):
     r"""Constant model
 
-    .. math::
-
-        \phi(E) = k
+    .. math:: \phi(E) = k
 
     Parameters
     ----------

--- a/gammapy/spectrum/powerlaw.py
+++ b/gammapy/spectrum/powerlaw.py
@@ -122,7 +122,6 @@ def power_law_energy_flux(I, g=g_DEFAULT, e=1, e1=1, e2=10):
     The analytical solution for the powerlaw case is given by:
 
     .. math::
-
         G(E_1, E_2) = I(\epsilon, \infty) \, \frac{1-\Gamma}
         {2-\Gamma} \, \frac{E_1^{2-\Gamma} - E_2^{2-\Gamma}}{\epsilon^{1-\Gamma}}
 


### PR DESCRIPTION
This PR replaces all uses of `\textnormal` with `\text` in docstrings.

@Bultako - thanks for proposing this solution!

For reference: As one can see [here](https://docs.gammapy.org/0.11/api/gammapy.astro.source.SNR.html#gammapy.astro.source.SNR.sedov_taylor_begin) in the v0.11 docs and already [here](https://docs.gammapy.org/0.7/api/gammapy.astro.source.SNR.html#gammapy.astro.source.SNR.sedov_taylor_begin) in the v0.7 docs, `\textnormal` isn't rendered in HTML and just shown verbatim.
I don't know when this broke, and it's a bit annoying that there's no warning in the Sphinx log about math formatting issues (and not even in the browser dev tools from MathJax.js). But OK, we don't touch math often and we can check manually.