### PR TITLE
Make links in notebooks point to right docs version

### DIFF
--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -129,7 +129,7 @@ def parse_notebooks(folder, url_docs, git_commit):
 
 **This is a fixed-text formatted version of a Jupyter notebook**
 
-- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy-webpage/{git_commit}?urlpath=lab/tree/{nb_filename})
+- Try online [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/gammapy/gammapy-webpage/{release_number_binder}?urlpath=lab/tree/{nb_filename})
 - You can contribute with your own notebooks in this
 [GitHub repository](https://github.com/gammapy/gammapy/tree/master/tutorials).
 - **Source files:**

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -23,12 +23,6 @@ def ignorefiles(d, files):
     ]
 
 
-def ignoreall(d, files):
-    return [
-        f for f in files if os.path.isfile(os.path.join(d, f)) and f[-6:] != ".ipynb"
-    ]
-
-
 def setup_sphinx_params(args):
     flagnotebooks = "True"
     setupfilename = "setup.cfg"
@@ -91,14 +85,11 @@ def build_notebooks(args):
     )
 
     # test /run
-    passed = True
     for path in path_temp.glob("*.ipynb"):
-        if not notebook_test(path):
-            passed = False
+        notebook_test(path)
 
     # convert into scripts
     # copy generated filled notebooks to doc
-    # if passed:
     try:
         import jupyter
 
@@ -110,7 +101,7 @@ def build_notebooks(args):
 
     if pathsrc == path_empty_nbs:
         # copytree is needed to copy subfolder images
-        copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignoreall)
+        copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignorefiles)
         for path in path_static_nbs.glob("*.ipynb"):
             subprocess.call(
                 [
@@ -142,11 +133,6 @@ def build_notebooks(args):
         pathdest = path_filled_nbs / notebookname
         copyfile(str(pathsrc), str(pathdest))
 
-    # else:
-    #    log.info("Tests have not passed.")
-    #    log.info("Tutorials not ready for documentation building process.")
-    #    rmtree(str(path_static_nbs), ignore_errors=True)
-
     # tear down
     rmtree(str(path_temp), ignore_errors=True)
 
@@ -172,8 +158,6 @@ def main():
     except Exception as ex:
         log.error(ex)
         sys.exit()
-    # if not args.release.startswith("v") and args.release != "master":
-    #    args.release = "v" + args.release
 
     setup_sphinx_params(args)
 

--- a/tutorials/first_steps.ipynb
+++ b/tutorials/first_steps.ipynb
@@ -539,7 +539,7 @@
     "### Exercises\n",
     "\n",
     "* Try to load the Fermi-LAT 2FHL catalog and check the total number of sources it contains.\n",
-    "* Select all the sources from the 2FHL catalog which are contained in the Galactic Center region. The methods [`WcsGeom.contains()`](https://docs.gammapy.org/stable/api/gammapy.maps.WcsGeom.html#gammapy.maps.WcsGeom.contains) and [`SourceCatalog.positions`](https://docs.gammapy.org/stable/api/gammapy.catalog.SourceCatalog.html#gammapy.catalog.SourceCatalog.positions) might be helpful for this. Add markers for all these sources and try to add labels with the source names. The function [ax.text()](http://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.text.html#matplotlib.axes.Axes.text) might be also helpful.\n",
+    "* Select all the sources from the 2FHL catalog which are contained in the Galactic Center region. The methods [`WcsGeom.contains()`](https://docs.gammapy.org/dev/api/gammapy.maps.WcsGeom.html#gammapy.maps.WcsGeom.contains) and [`SourceCatalog.positions`](https://docs.gammapy.org/dev/api/gammapy.catalog.SourceCatalog.html#gammapy.catalog.SourceCatalog.positions) might be helpful for this. Add markers for all these sources and try to add labels with the source names. The function [ax.text()](http://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.text.html#matplotlib.axes.Axes.text) might be also helpful.\n",
     "* Try to find the source class of the object at position ra=68.6803, dec=9.3331\n",
     " "
    ]
@@ -686,7 +686,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you want to learn more about the different flux point formats you can read the specification [here](http://gamma-astro-data-formats.readthedocs.io/en/latest/results/flux_points/index.html#flux-points).\n",
+    "If you want to learn more about the different flux point formats you can read the specification [here](https://gamma-astro-data-formats.readthedocs.io/en/latest/spectra/flux_points/index.html).\n",
     "\n",
     "No we can check again the underlying astropy data structure by accessing the `.table` attribute:"
    ]

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "Just for fun: if each fit procedure takes 10s, we're talking about 5h of computing time to estimate the correlation plots. \n",
     "\n",
-    "There are many MCMC packages in the python ecosystem but here we will focus on [emcee](http://url), a lightweight Python package. A description is provided here : [Foreman-Mackey, Hogg, Lang & Goodman (2012)](https://arxiv.org/abs/1202.3665)."
+    "There are many MCMC packages in the python ecosystem but here we will focus on [emcee](https://emcee.readthedocs.io), a lightweight Python package. A description is provided here : [Foreman-Mackey, Hogg, Lang & Goodman (2012)](https://arxiv.org/abs/1202.3665)."
    ]
   },
   {

--- a/tutorials/spectrum_fitting_with_sherpa.ipynb
+++ b/tutorials/spectrum_fitting_with_sherpa.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Once we have exported the spectral files (PHA, ARF, RMF and BKG) in the OGIP format, it becomes possible to fit them later with gammapy or with any existing OGIP compliant tool such as XSpec or sherpa.\n",
     "\n",
-    "We show here how to do so with sherpa using the high-level user interface. For a general view on how to use stand-alone sherpa, see https://sherpa.readthedocs.io."
+    "We show here how to do so with sherpa using the high-level user interface. For a general view on how to use stand-alone sherpa, see https://sherpa.readthedocs.io"
    ]
   },
   {


### PR DESCRIPTION
This PR addresses issue https://github.com/gammapy/gammapy/issues/2175

It modifies how `_statics/notebooks/*.ipynb` are generated in the doc build process, making absolute links pointing to https://docs.gammapy.org/ to point to the release version declared in command `make docs-all release=vx.z`. 

Links in the `download/tutorials/gammapy-x.z-tutorials.yml` YAML files in `gammapy-webpage` repository have been already modified to point to their right version of https://docs.gammapy.org/vx.z/_statics/notebooks/*.ipynb as well as the links in the old tutorials docs pointing them to their right version (instead of dev). Note that for next releases the links in the tutorials YAML file in `gammapy-webpage` should be pointing to https://docs.gammapy.org/vx.z/_statics/notebooks/*.ipynb notebooks.

As suggested in https://github.com/gammapy/gammapy/issues/2175#issuecomment-497283199 finding broken links in notebooks can be easily done with other tools.