### PR TITLE
Speed up sherpa fitting tutorial

### DIFF
--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -51,7 +51,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Generate the required Maps\n",
+    "## 1. Generating the required Maps\n",
     "\n",
     "We first generate the required maps using 3 simulated runs on the Galactic center, exactly as in the [analysis_3d](analysis_3d.ipynb) tutorial.\n",
     "\n",
@@ -172,6 +172,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 2. Analysis using sherpha\n",
+    "\n",
     "### Read the maps and store them in a sherpa model\n",
     "\n",
     "We now have the prepared files which sherpa can read. \n",
@@ -195,6 +197,35 @@
     "sh.load_table_model(\"expo\", \"analysis_3d/exposure_2D.fits\")\n",
     "sh.load_table_model(\"bkg\", \"analysis_3d/background_2D.fits\")\n",
     "sh.load_psf(\"psf\", \"analysis_3d/psf_2D.fits\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To speed up this tutorial, we change the fit optimazation method to Levenberg-Marquardt and fix a required tolerance. This can make the fitting less robust, and in practise, you can skip this step unless you understand what is going on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sh.set_method(\"levmar\")\n",
+    "sh.set_method_opt('xtol', 1e-5)\n",
+    "sh.set_method_opt('ftol', 1e-5)\n",
+    "sh.set_method_opt('gtol', 1e-5)\n",
+    "sh.set_method_opt('epsfcn', 1e-5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sh.get_method())"
    ]
   },
   {
@@ -283,6 +314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "sh.thaw(g0.xpos, g0.ypos)\n",
     "sh.fit()\n",
     "sh.freeze(g0)"
@@ -304,7 +336,8 @@
    "metadata": {},
    "source": [
     "### Iteratively find and fit additional sources\n",
-    "Instantiate additional Gaussian components, and use them to iteratively fit sources, repeating the steps performed above for component g0. (The residuals map is shown after each additional source included in the model.) This takes some time..."
+    "\n",
+    "The residual map still shows the presence of additional components. Instantiate additional Gaussian components, and use them to iteratively fit sources, repeating the steps performed above for component g0. (The residuals map is shown after each additional source included in the model.) This would typically be done for many sources, but since this takes quite a bit of time, we demonstrate it for 3 iterations only here...."
    ]
   },
   {
@@ -314,12 +347,12 @@
    "outputs": [],
    "source": [
     "# initialize components with fixed, zero amplitude\n",
-    "for i in range(1, 10):\n",
+    "for i in range(1, 3):\n",
     "    model = sh.create_model_component(\"gauss2d\", \"g\" + str(i))\n",
     "    model.ampl = 0\n",
     "    sh.freeze(model)\n",
     "\n",
-    "gs = [g0, g1, g2]\n",
+    "sources = [g0, g1, g2]\n",
     "sh.set_full_model(bkg + psf(g0 + g1 + g2) * expo)"
    ]
   },
@@ -330,23 +363,23 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "for i in range(1, len(gs)):\n",
+    "for gs in sources:\n",
     "    yp, xp = np.unravel_index(\n",
     "        np.nanargmax(resid_smooth.data), resid_smooth.data.shape\n",
     "    )\n",
     "    ampl = resid_smooth.get_by_pix((xp, yp))[0]\n",
-    "    gs[i].xpos, gs[i].ypos = xp, yp\n",
-    "    gs[i].fwhm = 10\n",
-    "    gs[i].ampl = ampl\n",
+    "    gs.xpos, gs.ypos = xp, yp\n",
+    "    gs.fwhm = 10\n",
+    "    gs.ampl = ampl\n",
     "\n",
-    "    sh.thaw(gs[i].fwhm)\n",
-    "    sh.thaw(gs[i].ampl)\n",
+    "    sh.thaw(gs.fwhm)\n",
+    "    sh.thaw(gs.ampl)\n",
     "    sh.fit()\n",
     "\n",
-    "    sh.thaw(gs[i].xpos)\n",
-    "    sh.thaw(gs[i].ypos)\n",
+    "    sh.thaw(gs.xpos)\n",
+    "    sh.thaw(gs.ypos)\n",
     "    sh.fit()\n",
-    "    sh.freeze(gs[i])\n",
+    "    sh.freeze(gs)\n",
     "\n",
     "    resid.data = sh.get_data_image().y - sh.get_model_image().y\n",
     "    resid_smooth = resid.smooth(width=6)"
@@ -383,7 +416,7 @@
     "from astropy.table import Table\n",
     "\n",
     "rows = []\n",
-    "for g in gs:\n",
+    "for g in sources:\n",
     "    ampl = g.ampl.val\n",
     "    g.ampl = 0\n",
     "    stati = sh.get_stat_info()[0].statval\n",
@@ -403,7 +436,7 @@
     "table = Table(rows=rows, names=rows[0])\n",
     "for name in table.colnames:\n",
     "    table[name].format = \".5g\"\n",
-    "table"
+    "print(table)"
    ]
   },
   {
@@ -435,13 +468,6 @@
     "* http://conference.scipy.org/proceedings/scipy2009/paper_8/full_text.pdf\n",
     "* http://conference.scipy.org/proceedings/scipy2011/pdfs/brefsdal.pdf"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -460,7 +486,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This addresses #2186.
Changing the optimiser and the tolerances make the tutorial run in 32.7 sec on my machine as opposed to 116.8 sec earlier, without visibly changing the fit parameters. This runtime is comparable to the analysis_3d runtime.