### PR TITLE
Remove unused map iter_by_pix and iter_by_coord methods

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -405,28 +405,8 @@ of the original map will be copied over to the projected map.
 
 .. _mapiter:
 
-Iterating on a Map
+Iterating by image
 ------------------
-
-Iterating over a map can be performed with the `~Map.iter_by_coord` and
-`~Map.iter_by_pix` methods.  These return an iterator that traverses the map
-returning (value, coordinate) pairs with map and pixel coordinates,
-respectively.  The optional ``buffersize`` argument can be used to split the
-iteration into chunks of a given size.  The following example illustrates how
-one can use this method to fill a map with a 2D Gaussian:
-
-.. code:: python
-
-    import numpy as np
-    from astropy.coordinates import SkyCoord
-    from gammapy.maps import Map
-
-    m = Map.create(binsz=0.05, map_type='wcs', width=10.0)
-    for val, coord in m.iter_by_coord(buffersize=10000):
-        skydir = SkyCoord(coord[0],coord[1], unit='deg')
-        sep = skydir.separation(m.geom.center_skydir).deg
-        new_val = np.exp(-sep**2/2.0)
-        m.set_by_coord(coord, new_val)
 
 For maps with non-spatial dimensions the `~Map.iter_by_image` method can be used
 to loop over image slices. The image plane index `idx` is returned in data order,

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from .geom import pix_tuple_to_idx, MapCoord
-from .utils import unpack_seq, INVALID_VALUE
+from .utils import INVALID_VALUE
 from ..utils.scripts import make_path
 
 __all__ = ["Map"]
@@ -339,56 +339,6 @@ class Map(metaclass=MapMeta):
         """
         for idx in np.ndindex(self.geom.shape_axes):
             yield self.data[idx[::-1]], idx[::-1]
-
-    def iter_by_pix(self, buffersize=1):
-        """Iterate over elements of the map.
-
-        Generator yielding tuples with values and pixel coordinates.
-
-        Parameters
-        ----------
-        buffersize : int
-            Set the size of the buffer.  The map will be returned in
-            chunks of the given size.
-
-        Returns
-        -------
-        val : `~numpy.ndarray`
-            Map values.
-        pix : tuple
-            Tuple of pixel coordinates.
-        """
-        pix = list(self.geom.get_idx(flat=True))
-        vals = self.data[np.isfinite(self.data)]
-        x = [vals] + pix
-        return unpack_seq(
-            np.nditer(x, flags=["external_loop", "buffered"], buffersize=buffersize)
-        )
-
-    def iter_by_coord(self, buffersize=1):
-        """Iterate over elements of the map.
-
-        Generator yielding tuples with values and map coordinates.
-
-        Parameters
-        ----------
-        buffersize : int
-            Set the size of the buffer.  The map will be returned in
-            chunks of the given size.
-
-        Returns
-        -------
-        val : `~numpy.ndarray`
-            Map values.
-        coords : tuple
-            Tuple of map coordinates.
-        """
-        coords = list(self.geom.get_coord(flat=True))
-        vals = self.data[np.isfinite(self.data)]
-        x = [vals] + coords
-        return unpack_seq(
-            np.nditer(x, flags=["external_loop", "buffered"], buffersize=buffersize)
-        )
 
     @abc.abstractmethod
     def sum_over_axes(self, keepdims=False):

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -149,12 +149,6 @@ class HpxSparseMap(HpxMap):
     def iter_by_image(self):
         raise NotImplementedError
 
-    def iter_by_pix(self):
-        raise NotImplementedError
-
-    def iter_by_coord(self):
-        raise NotImplementedError
-
     def sum_over_axes(self):
         raise NotImplementedError
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -231,21 +231,6 @@ def test_hpxmap_fill_by_coord(nside, nested, coordsys, region, axes, sparse):
 @pytest.mark.parametrize(
     ("nside", "nested", "coordsys", "region", "axes"), hpx_test_geoms
 )
-def test_hpxmap_iter(nside, nested, coordsys, region, axes):
-    m = HpxNDMap(
-        HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes)
-    )
-    coords = m.geom.get_coord(flat=True)
-    m.fill_by_coord(coords, coords[0])
-    for vals, pix in m.iter_by_pix(buffersize=100):
-        assert_allclose(vals, m.get_by_pix(pix))
-    for vals, coords in m.iter_by_coord(buffersize=100):
-        assert_allclose(vals, m.get_by_coord(coords))
-
-
-@pytest.mark.parametrize(
-    ("nside", "nested", "coordsys", "region", "axes"), hpx_test_geoms
-)
 def test_hpxmap_to_wcs(nside, nested, coordsys, region, axes):
     m = HpxNDMap(
         HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes)

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -321,22 +321,6 @@ def test_wcsndmap_interp_by_coord_fill_value():
 @pytest.mark.parametrize(
     ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
 )
-def test_wcsndmap_iter(npix, binsz, coordsys, proj, skydir, axes):
-    geom = WcsGeom.create(
-        npix=npix, binsz=binsz, proj=proj, coordsys=coordsys, axes=axes
-    )
-    m = WcsNDMap(geom)
-    coords = m.geom.get_coord()
-    m.fill_by_coord(coords, coords[0])
-    for vals, pix in m.iter_by_pix(buffersize=100):
-        assert_allclose(vals, m.get_by_pix(pix))
-    for vals, coords in m.iter_by_coord(buffersize=100):
-        assert_allclose(vals, m.get_by_coord(coords))
-
-
-@pytest.mark.parametrize(
-    ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
-)
 @pytest.mark.parametrize("keepdims", [True, False])
 def test_wcsndmap_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes, keepdims):
     geom = WcsGeom.create(

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -87,25 +87,6 @@ def interp_to_order(interp):
     return order_map.get(interp, None)
 
 
-def unpack_seq(seq, n=1):
-    """Utility to unpack the first N values of a tuple or list.
-
-    Remaining values are put into a single list which is the last element of the
-    return value. This partially simulates the extended unpacking
-    functionality available in Python 3.
-
-    Parameters
-    ----------
-    seq : list or tuple
-        Input sequence to be unpacked.
-    n : int
-        Number of elements of ``seq`` to unpack.  Remaining elements
-        are put into a single tuple.
-    """
-    for row in seq:
-        yield [e for e in row[:n]] + [row[n:]]
-
-
 def find_bands_hdu(hdu_list, hdu):
     """Discover the extension name of the BANDS HDU.
 


### PR DESCRIPTION
This PR removes the map iter_by_pix and iter_by_coord methods.

They are unused in Gammapy, no use case has come up for this so far. The use case given in the docs could just as well and much more efficiently be written by using the whole map directly, or by using `iter_by_image`.

Iterating over pixels in Python will never be efficient, should always be avoided. Almost all computations can be expressed using Numpy, and should that not be possible, one could use Numba or Cython, or if really needed, do this Python pixel loop where it's needed.

IMO we shouldn't leave such code in Gammapy, but start to either remove or improve quality as we work towards Gammapy v1.0. Note that this code is non-trivial and likely not very well written. E.g. the docstring of `unpack_seq` says that it is probably not needed in Python 3. Also the implementation of the pixel loop contains `list(self.geom.get_coord(flat=True))`, i.e. a Python list of all pixel coords is made, which takes a lot of memory. If a generator pixel iter were kept, it should not contain such a list inside. So the question is really: OK to remove? Or spend effort to improve before v1.0?

@registerrier @adonath - Thoughts?

