### PR TITLE
Simplify Jupyter notebook execution

### DIFF
--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -31,20 +31,11 @@ def cli_jupyter_run(ctx, tutor, kernel):
 
 def execute_notebook(path, kernel="python3", loglevel=30):
     """Execute a Jupyter notebook."""
-    try:
-        import jupyter
-
-        jupyter_module = "jupyter"
-    except ImportError:
-        import jupyter_core
-
-        jupyter_module = "jupyter_core"
-
     t = time.time()
     cmd = [
         sys.executable,
         "-m",
-        jupyter_module,
+        "jupyter",
         "nbconvert",
         "--allow-errors",
         "--log-level={}".format(loglevel),

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -90,15 +90,6 @@ def build_notebooks(args):
 
     # convert into scripts
     # copy generated filled notebooks to doc
-    try:
-        import jupyter
-
-        jupyter_module = "jupyter"
-    except ImportError:
-        import jupyter_core
-
-        jupyter_module = "jupyter_core"
-
     if pathsrc == path_empty_nbs:
         # copytree is needed to copy subfolder images
         copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignorefiles)
@@ -107,7 +98,7 @@ def build_notebooks(args):
                 [
                     sys.executable,
                     "-m",
-                    jupyter_module,
+                    "jupyter",
                     "nbconvert",
                     "--to",
                     "script",
@@ -123,7 +114,7 @@ def build_notebooks(args):
             [
                 sys.executable,
                 "-m",
-                jupyter_module,
+                "jupyter",
                 "nbconvert",
                 "--to",
                 "script",


### PR DESCRIPTION
This PR is a small cleanup / simplification to our scripts to execute Jupyter notebooks.

It reverts the addition that was made in #2070 where this try-except was added to either use `jupyter_core` or `jupyter`.

For me currently, `python -m jupyter` works fine (and actually `python -m jupyter_core` does as well):
```
(gammapy-dev) hfm-1804a:gammapy deil$ python -m jupyter_core
usage: __main__.py [-h] [--version] [--config-dir] [--data-dir]
                   [--runtime-dir] [--paths] [--json]
                   [subcommand]
__main__.py: error: one of the arguments --version subcommand --config-dir --data-dir --runtime-dir --paths is required
(gammapy-dev) hfm-1804a:gammapy deil$ python -m jupyter
usage: jupyter.py [-h] [--version] [--config-dir] [--data-dir] [--runtime-dir]
                  [--paths] [--json]
                  [subcommand]
jupyter.py: error: one of the arguments --version subcommand --config-dir --data-dir --runtime-dir --paths is required
```
This removes a few lines that usually show up in static code analysis and code coverage, and maybe also improves speed a little bit by not importing Jupyter in the calling process, only in the subprocess.

I made a PR to see what happens in CI.

@Bultako - OK?

Or alternatively: can you give versions and mention when / why we would need to support two ways to do this with Jupyter?

Note that this is only dev tooling, users will not execute this, i.e. IMO we don't need to support old Jupyter versions here.