### PR TITLE
Improve .lo_threshold setter for `PHACountsSpectrum` and improve tests for spectrum.core.py 

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -328,7 +328,7 @@ class PHACountsSpectrum(CountsSpectrum):
         super().__init__(energy_lo, energy_hi, data)
         if quality is None:
             quality = np.zeros(self.energy.nbin, dtype="i2")
-        self._quality = quality
+        self.quality = quality
         if backscal is None:
             backscal = np.ones(self.energy.nbin)
         self.backscal = backscal
@@ -340,15 +340,6 @@ class PHACountsSpectrum(CountsSpectrum):
         self.livetime = livetime
         self.offset = offset
         self.meta = meta or OrderedDict()
-
-    @property
-    def quality(self):
-        """Bins in safe energy range (1 = bad, 0 = good)."""
-        return self._quality
-
-    @quality.setter
-    def quality(self, quality):
-        self._quality = quality
 
     @property
     def phafile(self):
@@ -396,7 +387,7 @@ class PHACountsSpectrum(CountsSpectrum):
     @lo_threshold.setter
     def lo_threshold(self, thres):
         idx = np.where((self.energy.edges[:-1]) < thres)[0]
-        self._quality[idx] = 1
+        self.quality[idx] = 1
 
     @property
     def hi_threshold(self):
@@ -409,7 +400,7 @@ class PHACountsSpectrum(CountsSpectrum):
         idx = np.where((self.energy.edges[:-1]) > thres)[0]
         if len(idx) != 0:
             idx = np.insert(idx, 0, idx[0] - 1)
-        self._quality[idx] = 1
+        self.quality[idx] = 1
 
     def reset_thresholds(self):
         """Reset energy thresholds (declare all energy bins valid)."""

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -396,7 +396,7 @@ class PHACountsSpectrum(CountsSpectrum):
     @lo_threshold.setter
     def lo_threshold(self, thres):
         idx = np.where((self.energy.edges[:-1]) < thres)[0]
-        self.quality[idx] = 1
+        self._quality[idx] = 1
 
     @property
     def hi_threshold(self):
@@ -409,7 +409,7 @@ class PHACountsSpectrum(CountsSpectrum):
         idx = np.where((self.energy.edges[:-1]) > thres)[0]
         if len(idx) != 0:
             idx = np.insert(idx, 0, idx[0] - 1)
-        self.quality[idx] = 1
+        self._quality[idx] = 1
 
     def reset_thresholds(self):
         """Reset energy thresholds (declare all energy bins valid)."""

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -124,7 +124,7 @@ class TestPHACountsSpectrum:
             self.spec.energy.edges * self.spec.energy.unit,
         )
 
-    def test_backscal_array(self, tmpdir):
+    def test_backscal_array(self):
         self.spec.backscal = np.arange(self.spec.energy.nbin)
         table = self.spec.to_table()
         assert table["BACKSCAL"][2] == 2
@@ -134,3 +134,7 @@ class TestPHACountsSpectrum:
         assert (spec_rebinned.quality == [1, 0, 0, 1]).all()
         assert_quantity_allclose(spec_rebinned.hi_threshold, 5.623413251903491 * u.TeV)
         assert_quantity_allclose(spec_rebinned.lo_threshold, 1.778279410038922 * u.TeV)
+
+    def test_reset_thresholds(self):
+        self.spec.reset_thresholds()
+        assert_allclose(self.spec.quality, np.zeros(8))

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -53,6 +53,9 @@ class TestCountsSpectrum:
         with mpl_plot_check():
             self.spec.plot_hist()
 
+        with mpl_plot_check():
+            self.spec.peek()
+
     def test_io(self, tmpdir):
         filename = tmpdir / "test.fits"
         self.spec.write(filename)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -135,6 +135,11 @@ class TestPHACountsSpectrum:
         assert_quantity_allclose(spec_rebinned.hi_threshold, 5.623413251903491 * u.TeV)
         assert_quantity_allclose(spec_rebinned.lo_threshold, 1.778279410038922 * u.TeV)
 
+    @requires_dependency("sherpa")
+    def test_to_sherpa(self):
+        sherpa_dataset = self.spec.to_sherpa("test")
+        assert_allclose(sherpa_dataset.counts, self.spec.data.data)
+
     def test_reset_thresholds(self):
         self.spec.reset_thresholds()
         assert_allclose(self.spec.quality, np.zeros(8))

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -145,4 +145,4 @@ class TestPHACountsSpectrum:
 
     def test_reset_thresholds(self):
         self.spec.reset_thresholds()
-        assert_allclose(self.spec.quality, np.zeros(8))
+        assert_allclose(self.spec.quality, 0.)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -48,7 +48,7 @@ class TestCountsSpectrum:
     @requires_dependency("matplotlib")
     def test_plot(self):
         with mpl_plot_check():
-            self.spec.plot()
+            self.spec.plot(show_energy=1*u.TeV)
 
         with mpl_plot_check():
             self.spec.plot_hist()


### PR DESCRIPTION
This PR resolves an issue coming from the pylint diagnostics:
```
E: gammapy/spectrum/core.py:399:8: 'self.quality' does not support item assignment (unsupported-assignment-operation)
E: gammapy/spectrum/core.py:412:8: 'self.quality' does not support item assignment (unsupported-assignment-operation)
```
It also improves testing, in particular by adding a test to the `PHACountsSpectrum.to_sherpa` which was completely missing.