### PR TITLE
Add a specialized  `EnergyAxis` 

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -9,3 +9,5 @@ from .edisp_map import *
 from .make import *
 from .fit import *
 from .simulate import *
+from .energy_axis import *
+

--- a/gammapy/cube/energy_axis.py
+++ b/gammapy/cube/energy_axis.py
@@ -50,20 +50,9 @@ class EnergyAxis(MapAxis):
         return self.edges[1:]
 
     @property
-    def energy(self):
-        return self.edges
-
-    @property
     def boundaries(self):
         """Energy range."""
         return u.Quantity([self.edges[0].value, self.edges[-1].value], self.unit)
-
-    @property
-    def bands(self):
-        """Width of the energy bins."""
-        upper = self.energy_hi
-        lower = self.energy_lo
-        return upper - lower
 
     @classmethod
     def from_lower_and_upper_bounds(cls, lower, upper, unit=None, interp='log', is_e_true=False):
@@ -87,6 +76,7 @@ class EnergyAxis(MapAxis):
 
         if unit is None:
             unit = upper.unit
+
         lower = u.Quantity(lower, unit)
         upper = u.Quantity(upper, unit)
         energy = u.Quantity(np.append(lower.value, upper.value[-1]), unit)

--- a/gammapy/cube/energy_axis.py
+++ b/gammapy/cube/energy_axis.py
@@ -1,0 +1,162 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+import astropy.units as u
+from astropy.io import fits
+from ..maps import MapAxis
+
+__all__ = ["EnergyAxis"]
+
+class EnergyAxis(MapAxis):
+    """A specialized MapAxis for energy
+
+    This can be used both for true or reco energy.
+
+    Parameters
+    ----------
+    nodes : `~astropy.units.Quantity`
+        a vector of energies
+    interp : str, `lin`or `log`
+        the interpolation mode, default 'log'
+    node_edges : str
+        type of axis: 'edges' or 'center'
+    is_e_true : bool
+        true energy axis if True, reco energy otherwise , Default False
+    """
+
+    def __init__(self, nodes, interp="log", node_type="edges", is_e_true=False):
+        unit = nodes.unit
+        nodes = nodes.value
+
+        super().__init__(nodes=nodes, interp=interp, name="energy",
+                         node_type=node_type, unit=unit)
+
+        if not self.unit.is_equivalent("eV"):
+            raise ValueError(
+                "Given unit {} is not an" " energy".format(self.unit.to_string())
+            )
+
+        if is_e_true == True:
+            self.e_true = True
+        else:
+            self.e_true = False
+
+    @property
+    def energy_lo(self):
+        return self.edges[:-1]
+
+    @property
+    def energy_hi(self):
+        return self.edges[1:]
+
+    @property
+    def energy(self):
+        return self.edges
+
+    @property
+    def boundaries(self):
+        """Energy range."""
+        return u.Quantity([self.edges[0].value, self.edges[-1].value], self.unit)
+
+    @property
+    def bands(self):
+        """Width of the energy bins."""
+        upper = self.energy_hi
+        lower = self.energy_lo
+        return upper - lower
+
+    @classmethod
+    def from_lower_and_upper_bounds(cls, lower, upper, unit=None, interp='log', is_e_true=False):
+        """EnergyAxis from lower and upper bounds.
+
+        If no unit is given, it will be taken from upper.
+
+        Parameters
+        ----------
+        lower,upper : `~astropy.units.Quantity`, float
+            Lowest and highest energy bin
+        unit : `~astropy.units.UnitBase`, str, None
+            Energy units
+        interp : str, `lin`or `log`
+            the interpolation mode, default 'log'
+        is_e_true : bool
+            true energy axis if True, reco energy otherwise , Default False
+        """
+        # np.append renders Quantities dimensionless
+        # http://docs.astropy.org/en/latest/known_issues.html#quantity-issues
+
+        if unit is None:
+            unit = upper.unit
+        lower = u.Quantity(lower, unit)
+        upper = u.Quantity(upper, unit)
+        energy = u.Quantity(np.append(lower.value, upper.value[-1]), unit)
+        return cls(energy, interp=interp, node_type='edges', is_e_true=is_e_true)
+
+    @classmethod
+    def equal_log_spacing(cls, emin, emax, nbins, unit=None, node_type='edges', is_e_true=False):
+        """EnergyAxis with equal log-spacing (`~gammapy.utils.energy.EnergyBounds`).
+
+        If no unit is given, it will be taken from emax.
+
+        Parameters
+        ----------
+        emin : `~astropy.units.Quantity`, float
+            Lowest energy bin
+        emax : `~astropy.units.Quantity`, float
+            Highest energy bin
+        nbins : int
+            Number of bins
+        unit : `~astropy.units.UnitBase`, str, None
+            Energy unit
+        node_edges : str
+            type of axis: 'edges' or 'center'
+        is_e_true : bool
+            true energy axis if True, reco energy otherwise , Default False
+        """
+        if unit is not None:
+            emin = u.Quantity(emin, unit)
+            emax = u.Quantity(emax, unit)
+        else:
+            emin = u.Quantity(emin)
+            emax = u.Quantity(emax)
+            unit = emax.unit
+            emin = emin.to(unit)
+
+        x_min, x_max = np.log10([emin.value, emax.value])
+        energy = u.Quantity(np.logspace(x_min, x_max, nbins + 1), unit)
+
+        return cls(nodes=energy, interp='log')
+
+    def find_energy_bin(self, energy):
+        """Find the bins that contain the specified energy values.
+
+        Parameters
+        ----------
+        energy : `~astropy.units.Quantity`
+            Array of energies to search for.
+
+        Returns
+        -------
+        bin_index : `~numpy.ndarray`
+            Indices of the energy bins containing the specified energies.
+        """
+        # check that the specified energy is within the boundaries
+        if not self.contains(energy).all():
+            ss_error = "Specified energy {}".format(energy)
+            ss_error += " is outside the boundaries {}".format(self.boundaries)
+            raise ValueError(ss_error)
+
+        bin_index = np.searchsorted(self.energy_hi, energy)
+
+        return bin_index
+
+    def contains(self, energy):
+        """Check of energy is contained in boundaries.
+
+        Parameters
+        ----------
+        energy : `~gammapy.utils.energy.Energy`
+            Array of energies to test
+        """
+        # TODO: Check if center_nodes should be working this way.
+        return (energy > self.edges[0]) & (energy < self.edges[-1])
+

--- a/gammapy/cube/energy_axis.py
+++ b/gammapy/cube/energy_axis.py
@@ -23,9 +23,10 @@ class EnergyAxis(MapAxis):
         true energy axis if True, reco energy otherwise , Default False
     """
 
-    def __init__(self, nodes, interp="log", node_type="edges", is_e_true=False):
-        unit = nodes.unit
-        nodes = nodes.value
+    def __init__(self, nodes, unit=None, interp="log", node_type="edges", is_e_true=False):
+        if unit is None:
+            unit = nodes.unit
+            nodes = nodes.value
 
         super().__init__(nodes=nodes, interp=interp, name="energy",
                          node_type=node_type, unit=unit)
@@ -107,7 +108,7 @@ class EnergyAxis(MapAxis):
             Number of bins
         unit : `~astropy.units.UnitBase`, str, None
             Energy unit
-        node_edges : str
+        node_type : str
             type of axis: 'edges' or 'center'
         is_e_true : bool
             true energy axis if True, reco energy otherwise , Default False
@@ -122,9 +123,12 @@ class EnergyAxis(MapAxis):
             emin = emin.to(unit)
 
         x_min, x_max = np.log10([emin.value, emax.value])
-        energy = u.Quantity(np.logspace(x_min, x_max, nbins + 1), unit)
+        if node_type == 'edges':
+            energy = u.Quantity(np.logspace(x_min, x_max, nbins + 1), unit)
+        else:
+            energy = u.Quantity(np.logspace(x_min, x_max, nbins ), unit)
 
-        return cls(nodes=energy, interp='log')
+        return cls(nodes=energy, interp='log', node_type=node_type)
 
     def find_energy_bin(self, energy):
         """Find the bins that contain the specified energy values.
@@ -150,7 +154,7 @@ class EnergyAxis(MapAxis):
         return bin_index
 
     def contains(self, energy):
-        """Check of energy is contained in boundaries.
+        """Check if energy is contained in boundaries.
 
         Parameters
         ----------
@@ -158,5 +162,5 @@ class EnergyAxis(MapAxis):
             Array of energies to test
         """
         # TODO: Check if center_nodes should be working this way.
-        return (energy > self.edges[0]) & (energy < self.edges[-1])
+        return (energy >= self.edges[0]) & (energy <= self.edges[-1])
 

--- a/gammapy/cube/tests/test_energy_axis.py
+++ b/gammapy/cube/tests/test_energy_axis.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+from numpy.testing import assert_equal
+import astropy.units as u
+from ...cube import EnergyAxis
+
+def test_EnergyAxis():
+    val = u.Quantity([1, 2, 3, 4, 5], "TeV")
+    actual = EnergyAxis(val, "GeV")
+    desired = EnergyAxis((1, 2, 3, 4, 5), "TeV")
+    assert_equal(actual, desired)
+
+    # New from template
+    energy = EnergyAxis([0, 1, 2, 3, 4, 5], "keV")
+    actual = energy.nbin
+    desired = 5
+    assert_equal(actual, desired)
+
+    actual = energy.unit
+    desired = u.keV
+    assert_equal(actual, desired)
+
+    energy = EnergyAxis([0, 1, 2, 3, 4, 5], "keV", node_type='center')
+    actual = energy.nbin
+    desired = 6
+    assert_equal(actual, desired)
+
+   # Equal log spacing
+    energy = EnergyAxis.equal_log_spacing(1 * u.TeV, 10 * u.TeV, 10)
+    actual = energy.nbin
+    desired = 10
+    assert_equal(actual, desired)
+
+ 

--- a/gammapy/cube/tests/test_energy_axis.py
+++ b/gammapy/cube/tests/test_energy_axis.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import astropy.units as u
@@ -22,6 +23,22 @@ def test_EnergyAxis():
     energy = EnergyAxis([0, 1, 2, 3, 4, 5], "keV", node_type='center')
     assert_equal(energy.nbin, 6)
 
+    # Test unit
+    with pytest.raises(ValueError):
+        EnergyAxis([0, 1, 2, 3, 4, 5], "m", node_type='center')
+
+
+def test_from_lower_and_upper_bounds():
+    lower_bounds = [1, 2, 3, 4]
+    upper_bounds = [2, 3, 4, 5]
+    actual = EnergyAxis.from_lower_and_upper_bounds(lower_bounds, upper_bounds, unit='TeV')
+    desired = EnergyAxis([1, 2, 3, 4, 5], "TeV")
+    assert_equal(actual, desired)
+
+    actual = EnergyAxis.from_lower_and_upper_bounds(lower_bounds, upper_bounds*u.GeV)
+    desired = EnergyAxis([1, 2, 3, 4, 5], "GeV")
+    assert_equal(actual, desired)
+
 
 def test_equal_log_spacing():
     energy = EnergyAxis.equal_log_spacing(1 * u.TeV, 10 * u.TeV, 10)
@@ -40,3 +57,14 @@ def test_contains():
     # Now for a center based axis with linear interpolation
     energy = EnergyAxis([1, 2, 3, 4, 5], "TeV", node_type='center', interp='lin')
     assert_equal(energy.contains(test_energies), [True, True, False])
+
+def test_find_energy_bin():
+    # First for an edge based axis
+    energy = EnergyAxis([1, 2, 3, 4, 5], "TeV")
+    test_energies = u.Quantity([1.5, 3.5], "TeV")
+    bins = energy.find_energy_bin(test_energies)
+    assert_allclose(bins, [0, 2])
+
+    test_energies = u.Quantity([0.5, 3.5, 5.6], "TeV")
+    with pytest.raises(ValueError):
+        bins = energy.find_energy_bin(test_energies)

--- a/gammapy/cube/tests/test_energy_axis.py
+++ b/gammapy/cube/tests/test_energy_axis.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_allclose
 import astropy.units as u
 from ...cube import EnergyAxis
 
@@ -10,25 +10,33 @@ def test_EnergyAxis():
     desired = EnergyAxis((1, 2, 3, 4, 5), "TeV")
     assert_equal(actual, desired)
 
-    # New from template
+    # Test log spaced
     energy = EnergyAxis([0, 1, 2, 3, 4, 5], "keV")
-    actual = energy.nbin
-    desired = 5
-    assert_equal(actual, desired)
+    assert_equal(energy.nbin, 5)
+    assert_equal(energy.unit, u.keV)
 
-    actual = energy.unit
-    desired = u.keV
-    assert_equal(actual, desired)
+    # Test lin spaced
+    energy = EnergyAxis([0, 1, 2, 3, 4, 5], "keV", interp='lin')
+    assert_equal(energy.center.to_value("keV"),[0.5, 1.5, 2.5, 3.5, 4.5])
 
     energy = EnergyAxis([0, 1, 2, 3, 4, 5], "keV", node_type='center')
-    actual = energy.nbin
-    desired = 6
-    assert_equal(actual, desired)
+    assert_equal(energy.nbin, 6)
 
-   # Equal log spacing
+
+def test_equal_log_spacing():
     energy = EnergyAxis.equal_log_spacing(1 * u.TeV, 10 * u.TeV, 10)
-    actual = energy.nbin
-    desired = 10
-    assert_equal(actual, desired)
+    assert_equal(energy.nbin, 10)
 
- 
+    energy = EnergyAxis.equal_log_spacing(1 * u.TeV, 10 * u.TeV, 10, node_type='center')
+    assert_equal(energy.nbin, 10)
+    assert_allclose(energy.center.to_value('TeV'), np.logspace(0.,1.,10))
+
+def test_contains():
+    # First for an edge based axis
+    energy = EnergyAxis([1, 2, 3, 4, 5], "TeV")
+    test_energies = u.Quantity([0.5, 3.5, 5.6], "TeV")
+    assert_equal(energy.contains(test_energies), [False, True, False])
+
+    # Now for a center based axis with linear interpolation
+    energy = EnergyAxis([1, 2, 3, 4, 5], "TeV", node_type='center', interp='lin')
+    assert_equal(energy.contains(test_energies), [True, True, False])


### PR DESCRIPTION
This PR proposes to introduce an `EnergyAxis` inherited from `MapAxis` to represent energies in `Map`. It could replace the current `EnergyBounds` while providing a standardized way to create `MapAxis` containing energies.
It can contain a specific member to define the nature (reco or true) of the energy axis. I don't how useful this is though.
Opinions @cdeil, @adonath, @AtreyeeS ?  