### PR TITLE
Remove git_commit flag in the doc building process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ docs-sphinx:
 docs-all:
 	which python
 	pip install -e .
-	python -m gammapy.utils.tutorials_process --src="$(src)" --release="$(release)" --nbs="$(nbs)"
+	python -m gammapy.utils.tutorials_process --src="$(src)" --nbs="$(nbs)"
 	python setup.py build_docs
 
 docs-show:

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -785,13 +785,12 @@ execute the build doc process with the ``src`` parameter with value the name of 
 considered notebook. i.e. ``make docs-all src=tutorials/my-notebook.ipynb``
 
 Each *fixed-text* Sphinx formatted notebook present in the documentation has its
-own link pointing to its specific space in Gammapy Binder. Since notebooks are
-evolving with Gammapy functionalities and documentation, it is possible to link
-the different versions of the notebooks to the same versions built in Gammapy Binder.
-For stable releases, it is useful to use the ``release`` parameter with the value
-of the release label tag used in Github. This value will be used to build the links
-to Binder for that specific stable release for each of the tutorials published in
-the :ref:`tutorials` section. i.e. ``make docs-all release=v0.8``
+own link pointing to its specific Binder space in the `gammapy-webpage` repository.
+Since notebooks are evolving with Gammapy features and documentation, the different
+versions of the notebooks are linked to the versioned Binder environments. In this
+sense, it is important to publish as stable docs those built with stable release
+versions of Gammapy so the links to Binder in the tutorials point to stable tagged
+Binder environments in the `gammapy-webpage` repository.
 
 Documentation guidelines
 ------------------------

--- a/docs/development/release.rst
+++ b/docs/development/release.rst
@@ -71,9 +71,9 @@ Steps for the day of the release:
 #. Follow the instructions how to release an Astropy affiliated package
    `here <http://docs.astropy.org/en/latest/development/affiliated-packages.html#releasing-an-affiliated-package>`__.
 #. Check that the tarball and description (which is from ``LONG_DESCRIPTION.rst``) on PyPI is OK.
+#. Build the stable release documentation and publish it in `gammapy-docs` `Github repository <https://github.com/gammapy/gammapy-docs>`__
 #. Update the Gammapy stable branch to point to the new tag
    as described `here <http://docs.astropy.org/en/latest/development/releasing.html>`__.
-#. Add the new version of docs in `gammapy-docs` `Github repository <https://github.com/gammapy/gammapy-docs>`__
 #. Add the environment and tutorials YAML files, as well as the JSON datasets file in `gammapy-webpage` `Github repository <https://github.com/gammapy/gammapy-webpage>`__
 #. Update the Binder Dockerfile in the `gammapy-webpage` Github repository, changing the Gammapy release number in four different
    lines, and create the tag release accordingly in the `master` branch.

--- a/gammapy/utils/docs.py
+++ b/gammapy/utils/docs.py
@@ -27,6 +27,7 @@ from docutils import nodes
 from sphinx.util import logging
 from nbformat.v4 import new_markdown_cell
 import nbformat
+from .. import version
 
 try:
     gammapy_data_path = Path(os.environ["GAMMAPY_DATA"])
@@ -112,14 +113,14 @@ def gammapy_sphinx_ext_activate():
     roles.register_local_role("gp-notebook", LinkNotebook)
 
 
-def parse_notebooks(folder, url_docs, git_commit):
+def parse_notebooks(folder, url_docs):
     """
     Modifies raw and html-fixed notebooks so they will not have broken links
     to other files in the documentation. Adds a box to the sphinx formatted
     notebooks with info and links to the *.ipynb and *.py files.
     """
-    if git_commit.startswith("v"):
-        release_number_docs = release_number_binder = git_commit.replace("v", "")
+    if version.release:
+        release_number_docs = release_number_binder = version.version
     else:
         release_number_binder = "master"
         release_number_docs = "dev"
@@ -191,12 +192,11 @@ def gammapy_sphinx_notebooks(setup_cfg):
         return
 
     url_docs = setup_cfg["url_docs"]
-    git_commit = setup_cfg["git_commit"]
 
     # fix links
     filled_notebooks_folder = Path("notebooks")
     download_notebooks_folder = Path("_static") / "notebooks"
 
     if filled_notebooks_folder.is_dir():
-        parse_notebooks(filled_notebooks_folder, url_docs, git_commit)
-        parse_notebooks(download_notebooks_folder, url_docs, git_commit)
+        parse_notebooks(filled_notebooks_folder, url_docs)
+        parse_notebooks(download_notebooks_folder, url_docs)

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -29,15 +29,12 @@ def setup_sphinx_params(args):
     if not args.nbs:
         flagnotebooks = "False"
     build_notebooks_line = "build_notebooks = {}\n".format(flagnotebooks)
-    git_commit_line = "git_commit = {}\n".format(args.release)
 
     file_str = ""
     with open(setupfilename) as f:
         for line in f:
             if line.startswith("build_notebooks ="):
                 line = build_notebooks_line
-            if line.startswith("git_commit ="):
-                line = git_commit_line
             file_str += line
 
     with open(setupfilename, "w") as f:
@@ -133,14 +130,11 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--src", help="Tutorial notebook or folder to process")
-    parser.add_argument("--release", help="Release tag for Binder links")
     parser.add_argument("--nbs", help="Notebooks are considered in Sphinx")
     args = parser.parse_args()
 
     if not args.src:
         args.src = "tutorials"
-    if not args.release:
-        args.release = "master"
     if not args.nbs:
         args.nbs = "True"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,12 +35,6 @@ url_docs = https://docs.gammapy.org/dev/
 # To only builf RST files you can set `build_notebooks=False`
 # To speed up the documentation build
 build_notebooks = True
-#
-# Version of notebooks used in Binder
-# Must be a tag release in the gammapy-webpage Github repo
-git_commit = master
-#
-#
 
 [entry_points]
 gammapy = gammapy.scripts.main:cli


### PR DESCRIPTION
This PR addresses issue https://github.com/gammapy/gammapy/issues/1828 as suggested in https://github.com/gammapy/gammapy/pull/2200#issuecomment-498635209.

It removes the `git_commit` flag declared in `setup.cfg` file, that was used to make Binder links present in HTML tutorials, and links to https://docs.gammapy.org present in downloadable *.ipynb files. With this change, the command to build the documentation for releases does not need the `--release` flag anymore. Those links will point to stable tagged Binder envs and stable version of the docs, only if the documentation is built using a stable release of Gammapy. In the other cases, the links will point to the `dev` versions of Binder and docs respectively.

