### PR TITLE
Replace subprocess.call with subprocess.run

### DIFF
--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -308,7 +308,7 @@ class DataStore:
             if not overwrite:
                 cmd += ["-n"]
             cmd += [str(loc.path()), str(targetdir)]
-            subprocess.call(cmd)
+            subprocess.run(cmd)
 
         filename = str(outdir / self.DEFAULT_HDU_TABLE)
         subhdutable.write(filename, format="fits", overwrite=overwrite)

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -31,7 +31,6 @@ def cli_jupyter_run(ctx, tutor, kernel):
 
 def execute_notebook(path, kernel="python3", loglevel=30):
     """Execute a Jupyter notebook."""
-    t = time.time()
     cmd = [
         sys.executable,
         "-m",
@@ -47,16 +46,15 @@ def execute_notebook(path, kernel="python3", loglevel=30):
         "--execute",
         "{}".format(path),
     ]
-
-    try:
-        cp = subprocess.run(cmd)
-        cp.check_returncode()
-        t = time.time() - t
-        log.info("   ... Executing duration: {:.1f} seconds".format(t))
-        return True
-    except subprocess.CalledProcessError:
+    t = time.time()
+    completed_process = subprocess.run(cmd)
+    t = time.time() - t
+    if completed_process.returncode:
         log.error("Error executing file {}".format(str(path)))
         return False
+    else:
+        log.info("   ... Executing duration: {:.1f} seconds".format(t))
+        return True
 
 
 @click.command(name="strip")

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -48,13 +48,15 @@ def execute_notebook(path, kernel="python3", loglevel=30):
         "{}".format(path),
     ]
 
-    if subprocess.call(cmd):
-        log.error("Error executing file {}".format(str(path)))
-        return False
-    else:
+    try:
+        cp = subprocess.run(cmd)
+        cp.check_returncode()
         t = time.time() - t
         log.info("   ... Executing duration: {:.1f} seconds".format(t))
         return True
+    except subprocess.CalledProcessError:
+        log.error("Error executing file {}".format(str(path)))
+        return False
 
 
 @click.command(name="strip")

--- a/gammapy/utils/scripts_test.py
+++ b/gammapy/utils/scripts_test.py
@@ -73,7 +73,8 @@ def main():
         if not script_test(path):
             passed = False
 
-    assert passed
+    if not passed:
+        sys.exit("Some tests failed. Existing now.")
 
 
 if __name__ == "__main__":

--- a/gammapy/utils/scripts_test.py
+++ b/gammapy/utils/scripts_test.py
@@ -36,7 +36,7 @@ def script_test(path):
     log.info("   ... EXECUTING {}".format(str(path)))
 
     cmd = [sys.executable, str(path)]
-    cp = subprocess.run(cmd, capture_output=True)
+    cp = subprocess.run(cmd, stderr=subprocess.PIPE)
     if cp.returncode:
         log.info("   ... FAILED")
         log.info("   ___ TRACEBACK")

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -74,10 +74,10 @@ def build_notebooks(args):
         sys.exit()
 
     # strip and blackformat
-    subprocess.call(
+    subprocess.run(
         [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "black"]
     )
-    subprocess.call(
+    subprocess.run(
         [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "strip"]
     )
 
@@ -91,7 +91,7 @@ def build_notebooks(args):
         # copytree is needed to copy subfolder images
         copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignorefiles)
         for path in path_static_nbs.glob("*.ipynb"):
-            subprocess.call(
+            subprocess.run(
                 [
                     sys.executable,
                     "-m",
@@ -107,7 +107,7 @@ def build_notebooks(args):
         pathsrc = path_temp / notebookname
         pathdest = path_static_nbs / notebookname
         copyfile(str(pathsrc), str(pathdest))
-        subprocess.call(
+        subprocess.run(
             [
                 sys.executable,
                 "-m",

--- a/gammapy/utils/tutorials_test.py
+++ b/gammapy/utils/tutorials_test.py
@@ -67,7 +67,8 @@ def main():
     # tear down
     rmtree(str(path_temp), ignore_errors=True)
 
-    assert passed
+    if not passed:
+        sys.exit("Some tests failed. Existing now.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses https://github.com/gammapy/gammapy/issues/2220

We only need to capture traceback errors in `scripts_test.py`, no need to capture output anywhere with `subprocess.run` since we already have our solution to capture tracebacks from the execution of notebooks.

I have decided to use the `stderr=subprocess.PIPE` flag so we can display a cleaner traceback via logging, and prevent the display of potential outputs issued from the execution of scripts.