### PR TITLE
Adding the InverseCDFSampler 

### DIFF
--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -40,24 +40,24 @@ InverseCDFSampler
 The first building block of the event simulator is a class that samples from a given probability function (PSF). For this
 we use the inverse CDF sampling method (https://en.wikipedia.org/wiki/Inverse_transform_sampling). In more detail, it
 calculates the cumulative distribution function and, once a set of random numbers is determined, it samples a set of events.
-The proposed implementation follows closely what's proposed here https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584:
+The proposed implementation follows closely what is described here https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584:
 
 The basic design of the class is as following:
 
 .. code::
-	
-	from gammapy.utils.distributions import InverseCDFSampler
+
+    from gammapy.utils.distributions import InverseCDFSampler
 
     pdf = np.array()
-	cdf_sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
+    cdf_sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
 
 Where the `gammapy.utils.random.get_random_state` method is used. The class implements mainly the `.sample()` method
 to draw samples from the given pdf:
 
 .. code::
-	
-	cdf_sampler = InverseCDFSampler()
-	samples = cdf_sampler.sample(size=100)
+
+    cdf_sampler = InverseCDFSampler()
+    samples = cdf_sampler.sample(size=100)
 
 The returned object is a `np.ndarray` containing the sampled indices.
 
@@ -67,8 +67,8 @@ by specifying the `axis` argument:
 
 .. code::
 
-	cdf_sampler = InverseCDFSampler(pdf=pdfs, axis=0)
-	samples = cdf_sampler.sample(size=1)
+    cdf_sampler = InverseCDFSampler(pdf=pdfs, axis=0)
+    samples = cdf_sampler.sample(size=1)
 
 
 The `InverseCDFSampler` could possibly implement a few helper functions to plot the CDF or PDF. The `InverseCDFSampler`
@@ -87,78 +87,76 @@ time dependence of the model, output data structures and sampling of the total n
 Starting from a predicted number of counts map (e.g. computed by the `MapEvaluator`):
 
 .. code::
-	
-	src = SkyModel()
-	evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
-	npred_map = evaluator.compute_npred()
+
+    src = SkyModel()
+    evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
+    npred_map = evaluator.compute_npred()
 
 The `MapEventSampler` takes this map and a lightcurve model as an input and allows to sample from it with the `.sample()`
 method:
 
 .. code::
 
-	lightcurve = LightCurveTableModel() # or PhaseCurveTableModel()
-	src_sampler = MapEventSampler(npred_map, lightcurve, t_min=, t_max=)
+    lightcurve = LightCurveTableModel() # or PhaseCurveTableModel()
+    src_sampler = MapEventSampler(npred_map, lightcurve, t_min=, t_max=)
 
     # draw total number of events
     n_events = src_sampler.npred_total()
 
-	# draw events as an astropy table
-	events_src = map_sampler.sample()
+    # draw events as an astropy table
+    events_src = map_sampler.sample()
 
 If no lightcurve is provided a constant rate can be assumed e.g. for background models:
 
 .. code::
 
-	bkg_map = BackgroundModel().map
-	bkg_sampler = MapEventSampler(bkg_map, t_min=, t_max=) 
-	events_bkg = bkg_sample.sample()
+    bkg_map = BackgroundModel().map
+    bkg_sampler = MapEventSampler(bkg_map, t_min=, t_max=)
+    events_bkg = bkg_sample.sample()
+
 
 It remains to answer the question what to do when the source lightcurve is shorter than the total exposure time: do we
-repeat the temporal information or do we just consider the remaining time as a flat or  lightcurve?
+repeat the temporal information or do we just consider the remaining time as a flat lightcurve?
 
 
 IRFMapSampler
 =============
 
-We introduce a class that bundles the IRF psf and energy dispersion and applies them to the previously sampled event list. 
-In more detail, the class will take as input the `MapEventSampler.sample` source object and then it evaluates a map of 
-the psf and the energy dispersion calculated for each event true position and true energy. The reconstructed energies and 
-positions are then listed into an astropy table. We propose two different options to accomplish this task, which should work 
-as follows:
+The handle correctly the spatially varying IRFs, we propose to introduce an `IRFMapSampler` class. Based on the `PSFMap`
+and `EDispMap` as an input it interpolates the "correct" IRF at the position of a given event and applies it. In more detail
+the class will calculate the psf and the energy dispersion for each event true position and true energy. The reconstructed
+energies and positions are then appended to the event list. The IRFs are assumed to be constant and not time-dependent.
+The time dependency will be handled higher level, by a loop over good time-intervals. The class would be used as following:
 
 .. code::
 
-	events = vstack([events_src_1, events_src_2, ..., events_src_N])
-	irf_sampler = IRFMapSampler(events, psf_map, edisp_map)
-	events_obs = irf_sampler.sample()
+    events = vstack([events_src_1, events_src_2, ..., events_src_N])
+    irf_sampler = IRFMapSampler(psf_map, edisp_map)
 
-	# or
+    events = irf_sampler.sample_psf(events)
+    events = irf_sampler.sample_edisp(events)
 
-	irf_sampler = IRFMapSampler(psf_map, edisp_map)
-	events = irf_sampler.sample_psf(events)
-	events = irf_sampler.sample_edisp(events)
-
-In the first case, the IRF is applied to the stacking of all the simulated sources, with the `IRFSampler` class which
-contains only the `sample` method. In the second case, the `IRFSampler` reads the psf and energy maps only, and then 
-it contains two methods that apply separately the psf and edisp corrections to the events; for more than one simulated 
-source, a loop will be needed.
-
+Alternatively the IRFs could be applied per model component and be handled in the `MapEventSampler`. However in this case
+the IRFs would not be applied correctly for e.g. very extended sources, because the IRF changes over region of the source.
+If we find the approach with the `IRFMapSampler` to be not performant enough or problematic in memory use, it can be still
+used as a simple fallback solution.
 
 MapDatasetEventSampler?
 =======================
 
-Propose high level structure:
+To combine the `MapEventSampler` and `IRFMapSampler` objects we finally propose to introduce a `MapDatasetEventSampler`,
+which executes the sampling from all source components, applies the IRFs, samples from the background model and returns
+a stacked, combined event list.
+
+This is the proposed high level API:
 
 .. code::
     
     dataset_sampler = MapDatasetEventSampler(dataset)
     events = dataset_sampler.sample()
 
-    # or alternatively
-
-    events = dataset.sample_events()
-
+This requires to add `t_min` and `t_max` information to `MapDataset` or maybe a `MapDataset.gti` attribute, defining the
+GTI for the given dataset. In addition it also requires to add a lightcurve model to the `SkyModel`.
 
 More detailed:
 
@@ -191,19 +189,30 @@ More detailed:
     events_total = vstack([events_reco, event_bkg])
 
 
-
-Unresolved questions: 
-- the dataset class does not take into account the time variability...issue
-- a class, at top, that bundles multiple observations (pointings, IRF, GIT...)
+Simulating multiple observations
+================================
+The question of simulating mutiple observations from e.g. an `ObservationTable` or `GTI` object as it is needed for
+simulating data for the CTA data challenge is not addressed in this PIG.
 
 
 
 Alternatives
 ============
+Instead of introducing a parallel class structure of sampler objects once could introduce `.sample()` methods on the
+existing related classes in Gammapy:
 
-Use the ctools sampler for data challenge?
-Use the ASTRI sampler and write in a format compatible with Gammapy? 
-Always use binned simulation?
+- `events_src = MapEvaluator.sample()` to sample from a source model
+- `events = EdispMap.sample(events=)` to apply the energy dispersion
+- `events = PsfMap.sample(events=)` to appy the PSF
+- `events = MapDataset.sample()` to combine all together.
+
+This has the advantage of a smaller API, but is less flexible.
+
+
+Binned Simulation
+-----------------
+As an alternative approach one could also use binned simulations by fluctuating the number of counts in each bin of a
+given map or spectrum. This is not a real alternative, but could be offered in addition and used depending on the use case.
 
 
 List of proposed pull requests
@@ -211,14 +220,13 @@ List of proposed pull requests
 
 This is a proposal for a list of pull requests implementing the proposed changes, ordered by priority:
 
-1. Introduce the InverseCDFSampler.
-2. Dismiss the ``general_random`` class in gammapy.utils.distributions.
-3. Implement the InverseCDFSampler into gammapy.utils.distributions (Gammapy v.0.12).
-4. Introduce the MapEventSampler class.
-5. Implement MapEventSampler into gammapy. ... (v.0.12).?
-6. Introduce the IRFSampler class.
-7. Implement IRFSampler into gammapy. ... (v.0.12). ?
-
+1. Rename `gammapy.utils.distributions` to `gammapy.utils.random` and move the current `gammapy.utils.random` there (v0.12).
+2. Remove the currently unused `GeneralRandomArray` class (v0.12)
+3. Implement the InverseCDFSampler in `gammapy.utils.random` in `inverse_cdf.py` and add tests.
+4. Remove the current `GeneralRandom` class and adapt `gammapy.astro.population.simulate` accordingly.
+5. Implement `MapEventSampler` class ... (v0.13, v0.14)?
+6. Implement IRFSampler into gammapy. ... (v0.13, v0.14)?
+7. Implement IRFSampler into gammapy. ... (v0.13, v0.14)?
 
 Decision
 ========

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -13,13 +13,17 @@ PIG 9 - Event simulator
 * Discussion:  
 
 Introduction
-========
+============
 
-An event simulator of gamma events is of high importance in exploiting the potentiality of the future Cherenkov Telescope Array (CTA). It will allows us to simulate sources with different spectral and morphological properties, hence investigating the best configurations for each type of objects and the expected performances of CTA.
-We note that an event simulator is currently required by the CTA Science Tools. In addition, there will be the possibility to adopt it to simulate the next CTA Data Challenge (DC2).
-Therefore, we propose to create an event simulator which sample random events for given sources. It will need input maps where spatial morphology and spectral distributions are provided. Then the proposed simulator will be able to apply the PSF and energy dispersion, for each simulated observation, to correct position and energy of the sampled events. Source lightcurves will be also taken into account to simulate temporal variations.
-Furthermore, the sampler will possibly include the simulation of background events. 
-The output of the simulator is an astropy table. 
+An event simulator of gamma events is of high importance in exploiting the potentiality of the future Cherenkov Telescope
+Array (CTA). It will allows us to simulate sources with different spectral and morphological properties, hence investigating
+the best configurations for each type of objects and the expected performances of CTA. We note that an event simulator is
+currently required by the CTA Science Tools. In addition, there will be the possibility to adopt it to simulate the next
+CTA Data Challenge (DC2). Therefore, we propose to create an event simulator which sample random events for given sources.
+It will need input maps where spatial morphology and spectral distributions are provided. Then the proposed simulator will
+be able to apply the PSF and energy dispersion, for each simulated observation, to correct position and energy of the sampled
+events. Source lightcurves will be also taken into account to simulate temporal variations. Furthermore, the sampler will
+possibly include the simulation of background events. The output of the simulator is an astropy table.
 
 Proposal
 ========
@@ -27,9 +31,11 @@ Proposal
 We propose to introduce the following classes to implement the simulator in Gammapy:
 
 InverseCDFSampler
-========
+=================
 
-The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function for a given input probability distribution function. In more detail, it calculates the cumulative distribution function and, once a set of random numbers is determined, it samples a set of events.
+The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function for
+a given input probability distribution function. In more detail, it calculates the cumulative distribution function and,
+once a set of random numbers is determined, it samples a set of events.
 
 The basic design of the class works as following:
 
@@ -53,13 +59,86 @@ that will allow us to sample alternatively along all the axes or a given axis of
 
 
 MapEventSampler
-========
+===============
 
-- We should resolve the question on how does it relate with the Gammapy MapDataset class. 
+src = SkyModel()
+evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
+npred_map = evaluator.compute_npred()
+
+src_sampler = MapEventSampler(npred_map, psf_map, edisp_map)
+events_src = map_sampler.sample()
+# events_src is an astropy table
+
+bkg_map = Map()
+bkg_sampler = MapEventSampler(bkg_map, psf_map=None, edisp_map=None)
+events_bkg = bkg_sample.sample()
+
+
+IRFMapSampler
+=============
+
+events = vstack([events_src_1, events_src_2, ..., events_src_N])
+irf_sampler = IRFSampler(events, psf_map, edisp_map)
+events_obs = irf_sampler.sample()
+
+# or
+
+irf_sampler = IRFSampler(psf_map, edisp_map)
+events = irf_sampler.sample_psf(events)
+events = irf_sampler.sample_edisp(events)
+
+
+
+MapDatasetEventSampler?
+=======================
+
+Propose high level structure:
+
+    dataset_sampler = MapDatasetEventSampler(dataset)
+    events = dataset_sampler.sample()
+
+    # or alternatively
+
+    events = dataset.sample_events()
+
+
+More detailed:
+
+    events = []
+
+    # sample from source components
+    for evaluator in dataset._evaluators:
+        evaluator.psf = None?
+        evaluator.edisp = None?
+        npred = evaluator.compute_npred()
+
+        sampler = MapEventSampler(npred)
+
+        # set an ID for the source component?
+        
+        events.append(sampler.sample())
+
+    events_stacked = vstack(events)
+
+    # apply IRFs
+    irf_sampler = IRFSampler(events_stacked, dataset.psf_map, dataset.edisp_map)
+    events_reco = irf_sampler.sample()
+
+    # sample from background
+    bkg_sampler = MapEventSampler(dataset.background_model.map)
+    events_bkg = bkg_sampler.sample()
+
+    events_total = vstack([events_reco, event_bkg])
+
+
 
 
 Alternatives
 ============
+
+Use the ctools sampler for data challenge?
+Use the ASTRI sampler and write in a format compatible with Gammapy? 
+Always use binned simulation?
 
 
 List of proposed pull requests

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -28,6 +28,26 @@ We propose to introduce the following classes to implement the simulator in Gamm
 InverseCDFSampler
 ========
 
+The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function. The sampling can be performed on alternatively all the axes or a given axis.
+
+It should work as the following:
+
+from gammapy.utils.distributions import InverseCDFSampler
+
+cdf_sampler = InverseCDFSampler(pdf=npred_map.data, axis=None, random_state=random_state)
+
+where ``npred_map.data`` is an input map for the probability distribution function.
+
+
+The class implements the following methods:
+
+
+cdf_sampler = InverseCDFSampler()
+
+cdf_sampler.sample_axis()
+
+cdf_sampler.sample()
+
 
 
 class InverseCDFSampler:

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -3,7 +3,7 @@
 .. _pig-009:
 
 ***********************
-PIG 9 - Event simulator
+PIG 9 - Event Sampler
 ***********************
 
 * Author: Fabio Pintore, Andrea Giuliani, Axel Donath
@@ -12,35 +12,52 @@ PIG 9 - Event simulator
 * Status: 
 * Discussion:  
 
-Introduction
+Abstract
 ============
 
-An event simulator of gamma events is of high importance in exploiting the potentiality of the future Cherenkov Telescope
-Array (CTA). It will allows us to simulate sources with different spectral and morphological properties adn e.g. investigating
-the best configurations for each type of objects and the expected performance of CTA on this data. An event simulator is also listed
-as a requirement for the future CTA Science Tools. For this reason, we propose to implement a framework for event simulation
-in Gammapy. Based on finely binned input maps, containing the predicted number of counts for a given source with a defined
-morphological and spectral model, it samples events using the inverse cumulative distribution (Inverse CDF). In addition
-a light curve model can be taken into account. Then the proposed simulator will be able to apply the PSF and energy dispersion
-to each sampled event. Furthermore, the sampler will include the simulation of background events, again based on finely
-binned maps. The final output of the simulator is a stacked event list with source and background events for a given
-observation.
+An event sampler of gamma events is of high importance in exploiting the potentiality 
+of the future Cherenkov Telescope Array (CTA). It will allows us to simulate sources 
+with different spectral and morphological properties adn e.g. investigating the best 
+configurations for each type of objects and the expected performance of CTA on this 
+data. An event sampler is also listed as a requirement for the future CTA Science 
+Tools. For this reason, we propose to implement a framework for event simulation in 
+Gammapy. Based on finely binned input maps, containing the predicted number of counts
+for a given source with a defined morphological and spectral model, it samples events 
+using the inverse cumulative distribution (Inverse CDF). 
 
+This approach is different from the one adopted by the FERMI tools and the CTOOLS/Ctobssim, 
+as they make use of the rejection sampling method (see an example here _gammalib).
+Generally, when facing with discrete distribution, the Inverse CDF method is very efficient
+although there are cases where it may be less precise. Instead, the rejection sampling
+method can be highly precise but it is less efficient (for example should the distribution
+have narrow features). Implenting the latter in Gammapy would be problematic at this 
+moment, as in Python it would neeed for loops on each sampled model, implying a very 
+slow approach. However, we note also that the Inverse CDF method is the one used by 
+ASTRIsim, the simulator of the AGILE collaboration. 
+Furthermore, it is important to mention that Gammapy already implements a preliminary 
+binned simulation, for example for spectra or 3D-simulations (e.g. _spec and _three-D).
 
-A working prototype of the event sample can be found at this URL: https://github.com/fabiopintore/notebooks-public/blob/master/gammapy-event-sampling/prototype.ipynb
+The proposed simulator not only samples the spectral and morphology properties, but it 
+will also take into account the possibility to sample a light curve model. Then the proposed 
+event sampler will be able to apply the PSF and energy dispersion to each sampled event. 
+Furthermore, the sampler will include the simulation of background events, again based 
+on finely binned maps. The final output of the sampler is a stacked event list with 
+source and background events for a given observation.
+
+A working prototype of the event sample can be found in Prototype_ .
 
 Proposal
 ========
 
-We propose to introduce the following classes to implement the event simulation framework in Gammapy.
+We propose to introduce the following classes to implement the event sampler framework
+in Gammapy.
 
 InverseCDFSampler
 =================
 
-The first building block of the event simulator is a class that samples from a given probability function (PSF). For this
-we use the inverse CDF sampling method (https://en.wikipedia.org/wiki/Inverse_transform_sampling). In more detail, it
-calculates the cumulative distribution function and, once a set of random numbers is determined, it samples a set of events.
-The proposed implementation follows closely what is described here https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584:
+The first building block of the event sampler is a class that samples from a given 
+probability function (PSF). For this we use the inverse CDF sampling method (inverseCDF_). 
+The proposed implementation follows closely what is described here_:
 
 The basic design of the class is as following:
 
@@ -51,8 +68,8 @@ The basic design of the class is as following:
     pdf = np.array()
     cdf_sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
 
-Where the `gammapy.utils.random.get_random_state` method is used. The class implements mainly the `.sample()` method
-to draw samples from the given pdf:
+Where the `gammapy.utils.random.get_random_state` method is used. The class 
+implements mainly the `.sample()` method to draw samples from the given pdf:
 
 .. code::
 
@@ -61,9 +78,10 @@ to draw samples from the given pdf:
 
 The returned object is a `np.ndarray` containing the sampled indices.
 
-In addition the `InverseCDFSampler` should have the possibility to sample only along a given axis of the PDF. This features is
-required to handle sampling of multiple PDFs at the same time to avoid a Python loop over the PDFs. This will be supported
-by specifying the `axis` argument:
+In addition the `InverseCDFSampler` should have the possibility to sample only 
+along a given axis of the PDF. This features is required to handle sampling of 
+multiple PDFs at the same time to avoid a Python loop over the PDFs. This will 
+be supported by specifying the `axis` argument:
 
 .. code::
 
@@ -71,18 +89,24 @@ by specifying the `axis` argument:
     samples = cdf_sampler.sample(size=1)
 
 
-The `InverseCDFSampler` could possibly implement a few helper functions to plot the CDF or PDF. The `InverseCDFSampler`
-class will replace the current `GeneralRandom` and `GeneralRandomArray` classes in `gammapy.utils.distributions`.
-Possibly the `InverseCDFSampler` needs a to support transforming PDFs e.g. log transformations of power-laws to maintain
-accuracy. The need for this is unclear.
+The `InverseCDFSampler` could possibly implement a few helper functions to plot 
+the CDF or PDF. The `InverseCDFSampler` class will replace the current 
+`GeneralRandom` and `GeneralRandomArray` classes in `gammapy.utils.distributions`. 
+Possibly the `InverseCDFSampler` needs to support transforming PDFs e.g. log 
+transformations of power-laws to maintain accuracy. The need for this is unclear.
 
 
 MapEventSampler
 ===============
 
-To support sampling from the predicted number of counts maps for source as well as background maps, we propose to
-introduce a `MapEventSampler` class. The responsibility of this class is to handle the physical coordinate transformations,
-time dependence of the model, output data structures and sampling of the total number of observed events.
+To support sampling from the predicted number of counts maps for source as well 
+as background maps, we propose to introduce a `MapEventSampler` class. The 
+responsibility of this class is to handle the physical coordinate transformations, 
+time dependence of the model, output data structures and sampling of the total 
+number of observed events. We note that this class does not scatter the events
+within each bin but it places them at the bin center. This may results in artifacts
+in the analysis when adopting a different binning. However, once the PSF is applied, 
+this is no more an issue as the event positions will be randomly scattered.
 
 Starting from a predicted number of counts map (e.g. computed by the `MapEvaluator`):
 
@@ -92,8 +116,8 @@ Starting from a predicted number of counts map (e.g. computed by the `MapEvaluat
     evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
     npred_map = evaluator.compute_npred()
 
-The `MapEventSampler` takes this map and a lightcurve model as an input and allows to sample from it with the `.sample()`
-method:
+The `MapEventSampler` takes this map and a lightcurve model as an input and 
+allows to sample from it with the `.sample()` method:
 
 .. code::
 
@@ -106,7 +130,8 @@ method:
     # draw events as an astropy table
     events_src = map_sampler.sample()
 
-If no lightcurve is provided a constant rate can be assumed e.g. for background models:
+If no lightcurve is provided a constant rate can be assumed e.g. for 
+background models:
 
 .. code::
 
@@ -115,38 +140,42 @@ If no lightcurve is provided a constant rate can be assumed e.g. for background 
     events_bkg = bkg_sample.sample()
 
 
-It remains to answer the question what to do when the source lightcurve is shorter than the total exposure time: do we
-repeat the temporal information or do we just consider the remaining time as a flat lightcurve?
 
+IRFEventDistibutor
+=================
 
-IRFMapSampler
-=============
-
-To handle correctly the spatially varying IRFs, we propose to introduce an `IRFMapSampler` class. Based on the `PSFMap`
-and `EDispMap` as an input it interpolates the "correct" IRF at the position of a given event and applies it. In more detail
-the class will calculate the psf and the energy dispersion for each event true position and true energy. The reconstructed
-energies and positions are then appended to the event list. The IRFs are assumed to be constant and not time-dependent.
-The time dependency will be handled higher level, by a loop over good time-intervals. The class would be used as following:
+We also propose a class to handle correctly the spatially varying IRFs, we suggest
+to introduce an `IRFEventDistibutor` class. Based on the `PSFMap` and `EDispMap` 
+as an input it interpolates the "correct" IRF at the position of a given event and
+applies it. In more detail the class will calculate the psf and the energy dispersion 
+for each event true position and true energy. The reconstructed energies and 
+positions are then appended to the event list. The IRFs are assumed to be constant
+and not time-dependent. The time dependency will be handled higher level, by a loop
+over good time-intervals. The class would be used as following:
 
 .. code::
 
     events = vstack([events_src_1, events_src_2, ..., events_src_N])
-    irf_sampler = IRFMapSampler(psf_map, edisp_map)
+    event_distributor = IRFEventDistibutor(psf_map, edisp_map)
 
-    events = irf_sampler.sample_psf(events)
-    events = irf_sampler.sample_edisp(events)
+    events = irf_distributor.sample_psf(events)
+    events = irf_distributor.sample_edisp(events)
 
-Alternatively the IRFs could be applied per model component and be handled in the `MapEventSampler`. However in this case
-the IRFs would not be applied correctly for e.g. very extended sources, because the IRF changes over region of the source.
-If we find the approach with the `IRFMapSampler` to be not performant enough or problematic in memory use, it can be still
-used as a simple fallback solution.
+Alternatively the IRFs could be applied per model component and be handled in 
+the `MapEventSampler`. However in this case the IRFs would not be applied 
+correctly for e.g. very extended sources, because the IRF changes over region 
+of the source. If we find the approach with the `IRFEventDistibutor` to be not 
+performant enough or problematic in memory use, it can be still used as a 
+simple fallback solution.
 
-MapDatasetEventSampler?
+
+MapDatasetEventSampler
 =======================
 
-To combine the `MapEventSampler` and `IRFMapSampler` objects we finally propose to introduce a `MapDatasetEventSampler`,
-which executes the sampling from all source components, applies the IRFs, samples from the background model and returns
-a stacked, combined event list.
+To combine the `MapEventSampler` and `IRFMapSampler` objects we finally propose 
+to introduce a `MapDatasetEventSampler`, which executes the sampling from all 
+source components, applies the IRFs, samples from the background model and 
+returns a stacked, combined event list.
 
 This is the proposed high level API:
 
@@ -155,8 +184,9 @@ This is the proposed high level API:
     dataset_sampler = MapDatasetEventSampler(dataset)
     events = dataset_sampler.sample()
 
-This requires to add `t_min` and `t_max` information to `MapDataset` or maybe a `MapDataset.gti` attribute, defining the
-GTI for the given dataset. In addition it also requires to add a lightcurve model to the `SkyModel`.
+This requires to add `t_min` and `t_max` information to `MapDataset` or maybe a 
+`MapDataset.gti` attribute, defining the GTI for the given dataset. In addition 
+it also requires to add a lightcurve model to the `SkyModel`.
 
 More detailed:
 
@@ -189,50 +219,65 @@ More detailed:
     events_total = vstack([events_reco, event_bkg])
 
 
-Simulating multiple observations
-================================
-The question of simulating mutiple observations from e.g. an `ObservationTable` or `GTI` object as it is needed for
-simulating data for the CTA data challenge is not addressed in this PIG.
-
-
-
-Alternatives
-============
-Instead of introducing a parallel class structure of sampler objects once could introduce `.sample()` methods on the
-existing related classes in Gammapy:
+Convenience API
+===============
+---ADD a few more words about the possibility that the users do not to import a IRF
+class but they can directly use the `MapEventSampler'.---
+Additional methods to the `MapEventSampler' can be included to take into account
+the PSF and Edisp corrections. This may be done as follows:
 
 - `events_src = MapEvaluator.sample()` to sample from a source model
-- `events = EdispMap.sample(events=)` to apply the energy dispersion
-- `events = PsfMap.sample(events=)` to apply the PSF
+- `events = EdispMapDistributor.sample(events=)` to apply the energy dispersion
+- `events = PsfMapDistributor.sample(events=)` to apply the PSF
 - `events = MapDataset.sample()` to combine all together.
 
-This has the advantage of a smaller API, but is less flexible.
+This has the advantage of a smaller API but, for more than one simulated source,
+it needs the use a cycles.
+
+It remains to answer the question what to do when the source lightcurve is 
+shorter than the total exposure time: do we repeat the temporal information 
+or do we just consider the remaining time as a flat lightcurve?
 
 
-Binned Simulation
------------------
-As an alternative approach one could also use binned simulations by fluctuating the number of counts in each bin of a
-given map or spectrum. This is not a real alternative, but could be offered in addition and used depending on the use case.
+Simulating multiple observations
+================================
+The question of simulating mutiple observations from e.g. an `ObservationTable` 
+or `GTI` object as it is needed for simulating data for the CTA data challenge 
+is not addressed in this PIG.
 
 
 List of proposed pull requests
 ==============================
 
-This is a proposal for a list of pull requests implementing the proposed changes, ordered by priority:
+This is a proposal for a list of pull requests implementing the proposed changes, 
+ordered by priority:
 
-1. Rename `gammapy.utils.distributions` to `gammapy.utils.random` and move the current `gammapy.utils.random` there (v0.12).
+1. Rename `gammapy.utils.distributions' to `gammapy.utils.random' and move the 
+   current `gammapy.utils.random' there (v0.12).
 2. Remove the currently unused `GeneralRandomArray` class (v0.12)
-3. Implement the InverseCDFSampler in `gammapy.utils.random` in `inverse_cdf.py` and add tests.
-4. Remove the current `GeneralRandom` class and adapt `gammapy.astro.population.simulate` accordingly.
-5. Implement `MapEventSampler` class ... (v0.13, v0.14)?
-6. Implement IRFSampler into gammapy. ... (v0.13, v0.14)?
-7. Implement IRFSampler into gammapy. ... (v0.13, v0.14)?
+3. Implement the InverseCDFSampler in `gammapy.utils.random' in `inverse_cdf.py' 
+   and add tests.
+4. Remove the current `GeneralRandom` class and adapt `gammapy.astro.population.simulate' 
+   accordingly.
+5. Implement `MapEventSampler` class into `gammapy.utils.?' and named it 
+   `map_evesampler.py' and include some tests. (v0.13, v0.14)?
+6. Add tutorial on how to use the `MapEventSampler' applying it to both sources and background.
+7. Implement `IRFEventDistibutor' into `gammapy.cube' with the name `event_distributor.py'
+   and add some tests. (v0.13, v0.14)?
+8. Implement `MapDatasetEventSampler' into `gammapy.data'(?) and add some tests. (v0.13, v0.14)?
+9. Add tutorial for event simulations of different kinds of sources. (v0.13, v0.14)?
+
 
 Decision
 ========
 
 
 
-
+.. _Prototype: https://github.com/fabiopintore/notebooks-public/blob/master/gammapy-event-sampling/prototype.ipynb
+.. _inverseCDF: https://en.wikipedia.org/wiki/Inverse_transform_sampling
+.. _here: https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584
+.. _gammalib: http://cta.irap.omp.eu/gammalib/doxygen/GModelSpatialRadialGauss_8cpp_source.html#l00325
+.. _spec: https://docs.gammapy.org/0.11/api/gammapy.spectrum.SpectrumSimulation.html
+.. _three-D: https://docs.gammapy.org/0.11/notebooks/simulate_3d.html
 
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -28,92 +28,25 @@ We propose to introduce the following classes to implement the simulator in Gamm
 InverseCDFSampler
 ========
 
-The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function. The sampling can be performed on alternatively all the axes or a given axis.
+The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function for a given input probability distribution function. In particular, it determines a set of random numbers and calculate the cumulative distribution function.
 
 It should work as the following:
 
-from gammapy.utils.distributions import InverseCDFSampler
+	from gammapy.utils.distributions import InverseCDFSampler
 
-cdf_sampler = InverseCDFSampler(pdf=npred_map.data, axis=None, random_state=random_state)
-
-where ``npred_map.data`` is an input map for the probability distribution function.
+	cdf_sampler = InverseCDFSampler(pdf=npred_map.data, axis=None, random_state=random_state)
 
 
 The class implements the following methods:
 
+	cdf_sampler = InverseCDFSampler()
 
-cdf_sampler = InverseCDFSampler()
+	cdf_sampler.sample_axis()
 
-cdf_sampler.sample_axis()
-
-cdf_sampler.sample()
-
+	cdf_sampler.sample()
 
 
-
-class InverseCDFSampler:
-    """Inverse CDF sampler.
-    
-    Parameters
-    ----------
-    pdf : `~`gammapy.maps.Map`
-      predicted source counts  
-    
-    """
-    def __init__(self, pdf, axis=None, random_state=0):
-        """Determines a set of random numbers and calculate the cumulative distribution function"""
-        self.random_state = get_random_state(random_state) 
-        self.axis = axis       
-        
-        if axis is not None:
-            self.cdf = np.cumsum(pdf, axis=self.axis)
-            self.cdf /= self.cdf[:, [-1]]
-        else:
-            self.pdf_shape = pdf.shape  #gives the shape of the PDF array
-
-            pdf = pdf.ravel() / pdf.sum()  #flattens the array along one axis
-            self.sortindex = np.argsort(pdf, axis=None) #sorting of the elements and giving the indexes
-
-            self.pdf = pdf[self.sortindex]  #sort the pdf array
-            self.cdf = np.cumsum(self.pdf)  #evaluate the cumulative sum of the PDF array
-        
-    def sample_axis(self):
-        """Sample along a given axis.
-        """
-        choice = self.random_state.uniform(high=1, size=len(self.cdf))
-        
-        #find the indices corresponding to this point on the CDF
-        index = np.argmin(np.abs(choice.reshape(-1, 1) - self.cdf), axis=self.axis)
-        
-        return index + self.random_state.uniform(low=-0.5, high=0.5,
-                                                 size=len(self.cdf))
-    def sample(self, size):
-        """Draw sample from the given PDF.
-        
-        Parameters
-        ----------
-        size : int
-            Number of samples to draw.
-            
-        Returns
-        -------
-        index : tuple of `~numpy.ndarray`
-            Coordinates of the drawn sample      
-        """
-        #pick numbers which are uniformly random over the cumulative distribution function
-        choice = self.random_state.uniform(high=1, size=size)
-
-        #find the indices corresponding to this point on the CDF
-        index = np.searchsorted(self.cdf, choice)
-        index = self.sortindex[index]
-
-        # map back to multi-dimensional indexing
-        index = np.unravel_index(index, self.pdf_shape) 
-        index = np.vstack(index)
-
-        index = index + self.random_state.uniform(low=-0.5, high=0.5,
-                                      size=index.shape)
-        return index
+that will allow us to sample alternatively along all the axes or a given axis of the input map.
 
 
 - It remains the question on how does it relate with the Gammapy MapDataset class. 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -98,7 +98,7 @@ method:
 .. code::
 
 	lightcurve = LightCurveTableModel() # or PhaseCurveTableModel()
-	src_sampler = MapEventSampler(npred_map, lightcurve)
+	src_sampler = MapEventSampler(npred_map, lightcurve, t_min=, t_max=)
 
     # draw total number of events
     n_events = src_sampler.npred_total()
@@ -111,7 +111,7 @@ If no lightcurve is provided a constant rate can be assumed e.g. for background 
 .. code::
 
 	bkg_map = BackgroundModel().map
-	bkg_sampler = MapEventSampler(bkg_map, t_min=, t_max=)
+	bkg_sampler = MapEventSampler(bkg_map, t_min=, t_max=) 
 	events_bkg = bkg_sample.sample()
 
 It remains to answer the question what to do when the source lightcurve is shorter than the total exposure time: do we
@@ -190,6 +190,11 @@ More detailed:
 
     events_total = vstack([events_reco, event_bkg])
 
+
+
+Unresolved questions: 
+- the dataset class does not take into account the time variability...issue
+- a class, at top, that bundles multiple observations (pointings, IRF, GIT...)
 
 
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -17,8 +17,9 @@ Introduction
 
 An event simulator of gamma events is of high importance in exploiting the potentiality of the future Cherenkov Telescope Array (CTA). It will allows us to simulate sources with different spectral and morphological properties, hence investigating the best configurations for each type of objects and the expected performances of CTA.
 We note that an event simulator is currently required by the CTA Science Tools. In addition, there will be the possibility to adopt it to simulate the next CTA Data Challenge (DC2).
-Therefore, we propose to create an event simulator, which sample random events for given sources. It will need input maps with spatial morphology and spectral distributions. The proposed simulator will also be able to apply, from the IRF, the PSF and energy dispersion to correct position and energy of the sampled events. In addition, it will possibly include the simulation of background events. 
-The output of the simulator will be astropy table. 
+Therefore, we propose to create an event simulator which sample random events for given sources. It will need input maps where spatial morphology and spectral distributions are provided. Then the proposed simulator will be able to apply the PSF and energy dispersion, for each simulated observation, to correct position and energy of the sampled events. Source lightcurves will be also taken into account to simulate temporal variations.
+Furthermore, the sampler will possibly include the simulation of background events. 
+The output of the simulator is an astropy table. 
 
 Proposal
 ========
@@ -28,13 +29,15 @@ We propose to introduce the following classes to implement the simulator in Gamm
 InverseCDFSampler
 ========
 
-The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function for a given input probability distribution function. In particular, it determines a set of random numbers and calculate the cumulative distribution function.
+The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function for a given input probability distribution function. In more detail, it calculates the cumulative distribution function and, once a set of random numbers is determined, it samples a set of events.
 
-It should work as the following:
+The basic design of the class works as following:
 
 	from gammapy.utils.distributions import InverseCDFSampler
 
 	cdf_sampler = InverseCDFSampler(pdf=npred_map.data, axis=None, random_state=random_state)
+
+where the gammapy.utils.random.get_random_state method is used.
 
 
 The class implements the following methods:
@@ -49,6 +52,9 @@ The class implements the following methods:
 that will allow us to sample alternatively along all the axes or a given axis of the input map.
 
 
+MapEventSampler
+========
+
 - It remains the question on how does it relate with the Gammapy MapDataset class. 
 
 
@@ -61,9 +67,9 @@ List of proposed pull requests
 
 This is a proposal for a list of pull requests implementing the proposed changes, ordered by priority:
 
-1. Introduce the InverseCDFSampler .
+1. Introduce the InverseCDFSampler.
 2. Dismiss the ``general_random`` class in gammapy.utils.distributions.
-3. Implement the InverseCDFSampler into gammapy.utils.distributions (in Gammapy v.0.12).
+3. Implement the InverseCDFSampler into gammapy.utils.distributions (Gammapy v.0.12).
 
 
 Decision

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -12,16 +12,122 @@ PIG 9 - Event simulator
 * Status: 
 * Discussion:  
 
-Abstract
+Introduction
 ========
 
-We aim at creating an event simulator, which sample random events from an input map with spatial morphology and spectral distribution. The proposed simulator takes into account PSF and energy dispersion corrections, possibly includes the simulation of background events, and it gives an output astropy table. We developed our simulator on the basis of the "ASTRIsim" simulator, written in IDL.
-We note that it is important to build an event simulator because this is required by the CTA Science Tools. In addition, it will be used to simulate the next CTA Data Challenge (DC2).
-
+An event simulator of gamma events is of high importance in exploiting the potentiality of the future Cherenkov Telescope Array (CTA). It will allows us to simulate sources with different spectral and morphological properties, hence investigating the best configurations for each type of objects and the expected performances of CTA.
+We note that an event simulator is currently required by the CTA Science Tools. In addition, there will be the possibility to adopt it to simulate the next CTA Data Challenge (DC2).
+Therefore, we propose to create an event simulator, which sample random events for given sources. It will need input maps with spatial morphology and spectral distributions. The proposed simulator will also be able to apply, from the IRF, the PSF and energy dispersion to correct position and energy of the sampled events. In addition, it will possibly include the simulation of background events. 
+The output of the simulator will be astropy table. 
 
 Proposal
 ========
 
+We propose to introduce the following classes to implement the simulator in Gammapy:
+
+InverseCDFSampler
+========
+
+
+
+class InverseCDFSampler:
+    """Inverse CDF sampler.
+    
+    Parameters
+    ----------
+    pdf : `~`gammapy.maps.Map`
+      predicted source counts  
+    
+    """
+    def __init__(self, pdf, axis=None, random_state=0):
+        """Determines a set of random numbers and calculate the cumulative distribution function"""
+        self.random_state = get_random_state(random_state) 
+        self.axis = axis       
+        
+        if axis is not None:
+            self.cdf = np.cumsum(pdf, axis=self.axis)
+            self.cdf /= self.cdf[:, [-1]]
+        else:
+            self.pdf_shape = pdf.shape  #gives the shape of the PDF array
+
+            pdf = pdf.ravel() / pdf.sum()  #flattens the array along one axis
+            self.sortindex = np.argsort(pdf, axis=None) #sorting of the elements and giving the indexes
+
+            self.pdf = pdf[self.sortindex]  #sort the pdf array
+            self.cdf = np.cumsum(self.pdf)  #evaluate the cumulative sum of the PDF array
+        
+    def sample_axis(self):
+        """Sample along a given axis.
+        """
+        choice = self.random_state.uniform(high=1, size=len(self.cdf))
+        
+        #find the indices corresponding to this point on the CDF
+        index = np.argmin(np.abs(choice.reshape(-1, 1) - self.cdf), axis=self.axis)
+        
+        return index + self.random_state.uniform(low=-0.5, high=0.5,
+                                                 size=len(self.cdf))
+    def sample(self, size):
+        """Draw sample from the given PDF.
+        
+        Parameters
+        ----------
+        size : int
+            Number of samples to draw.
+            
+        Returns
+        -------
+        index : tuple of `~numpy.ndarray`
+            Coordinates of the drawn sample      
+        """
+        #pick numbers which are uniformly random over the cumulative distribution function
+        choice = self.random_state.uniform(high=1, size=size)
+
+        #find the indices corresponding to this point on the CDF
+        index = np.searchsorted(self.cdf, choice)
+        index = self.sortindex[index]
+
+        # map back to multi-dimensional indexing
+        index = np.unravel_index(index, self.pdf_shape) 
+        index = np.vstack(index)
+
+        index = index + self.random_state.uniform(low=-0.5, high=0.5,
+                                      size=index.shape)
+        return index
+
+
+- It remains the question on how does it relate with the Gammapy MapDataset class. 
+
+
+Alternatives
+============
+
+
+List of proposed pull requests
+==============================
+
+This is a proposal for a list of pull requests implementing the proposed changes, ordered by priority:
+
+1. Introduce the InverseCDFSampler .
+2. Dismiss the ``general_random`` class in gammapy.utils.distributions.
+3. Implement the InverseCDFSampler into gammapy.utils.distributions (in Gammapy v.0.12).
+
+
+Decision
+========
+
+
+
+
+
+
+
+
+
+
+
+
+
+#####################################
 - the design follows the ASTRIsim simulator
 - the latter requests the expected source flux cube for a given spectrum and morphology, prior the application of the IRF
 - (to the counts-cube can be associated a light-curve)
@@ -76,7 +182,8 @@ We propose a new class labelled as 'MapEventSampler', which takes in input the p
 We create a method called 'sample_events' that randomizes the map of predicted source counts to which are then applied the correct PSF and energy dispersion per event. The PSF and Energy dispersion corrections are not taken into account with a loop on the events.
 
 
-- How does it relate with the MapDataset?
+
+
 - to discuss: introduce the time of each event. In this moment, we just provide a counts-cube for all the components, but this does not allow us to associate the events to different light-curves. --> solution: create counts-cube for each component, apply the light-curve, and then stack all the components...
 
 The approach we propose works well only if the resolution in energy and spatial coordinates is very fine, in particular smaller than the IRF energy and PSF resolution. The choice of the map resolution is left to the user.
@@ -129,38 +236,9 @@ The approach we propose works well only if the resolution in energy and spatial 
              return EventList(table)
 
 
-The 'sample()' method returns an astropy table containing source+bkg events.
-
-.. code::
-
-    pdf = Map()
-
-    table = pdf.sample(n_samples, ramdoms_state=0)
-
-    sampler = MapEventSampler(pdf)
-
-    table = sample.sample(random_state=0)
- 
-
-
-
-Alternatives
-============
-
-
-List of proposed pull requests
-==============================
-
 - Copy of the stack-overflow code that implements the sampling of n-dimensional discrete probability distributions (details are given in https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584)
 - We would like to improve the GeneralRandomArray class (details are given in https://github.com/gammapy/gammapy/issues/74)
 
 
 - Events simulator and IRF corrections
-
-
-
-
-Decision
-========
-
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -1,0 +1,44 @@
+.. include:: ../../references.txt
+
+.. _pig-009:
+
+***********************
+PIG 9 - Event simulator
+***********************
+
+* Author: Fabio Pintore, Andrea Giuliani, Axel Donath
+* Created: Feb 04, 2019 
+* Accepted: 
+* Status: 
+* Discussion:  
+
+Abstract
+========
+
+- create event simulator 
+- required by the CTA Science Tools
+- needed to simulate the DC2
+
+
+Proposal
+========
+
+- the design follows the ASTRIsim
+- expected source counts cube for a given spectrum and morphology, prior the application of the IRF
+(- the counts-cube can be associated to a light-curve)
+- expected background counts cube evaluated from the IRF
+- the energy dispersion is applied to the source counts
+- the PSF is applied to the source counts
+- source and background events are stacked together 
+- write them all into an event list file (.fits)
+
+
+Alternatives
+============
+
+
+
+Decision
+========
+
+

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -15,9 +15,8 @@ PIG 9 - Event simulator
 Abstract
 ========
 
-- create an event simulator 
-- required by the CTA Science Tools
-- necessary to simulate the DC2
+We aim at creating an event simulator, which sample random events from an input map with spatial morphology and spectral distribution. The proposed simulator takes into account PSF and energy dispersion corrections, possibly includes the simulation of background events, and it gives an output astropy table. We developed our simulator on the basis of the "ASTRIsim" simulator, written in IDL.
+We note that it is important to build an event simulator because this is required by the CTA Science Tools. In addition, it will be used to simulate the next CTA Data Challenge (DC2).
 
 
 Proposal
@@ -31,6 +30,10 @@ Proposal
 - the PSF is applied to the source counts
 - source and background events are stacked together 
 - write them all into an event list file (.fits)
+
+We propose to create an event simulator based on Gammapy, which is needed for the Science Tools, and it would allow a valid alternative to ctobssim. 
+We designed our simulator exploiting the already available ASTRI simulator (ASTRIsim), written in IDL. ASTRIsim starts from an input source flux cube (possibly associated to a spatial map), gives a set of simulated events (with associated positions, energies and times). Furthermore, there is possibility to provide an input light-curve to take into account source time variability.
+
 
 We would like to improve the class presented in general_random_array.py issue. We propose to add the sorting of the cumulative distribution and then we also want to provide an interpolation along the bins. This class has to be extended sampling along a given axis and not along all the array. 
 
@@ -132,7 +135,7 @@ The 'sample()' method returns an astropy table containing source+bkg events.
 
     pdf = Map()
 
-    table = psf.sample(n_samples, ramdoms_state=0)
+    table = pdf.sample(n_samples, ramdoms_state=0)
 
     sampler = MapEventSampler(pdf)
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -50,6 +50,7 @@ cdf_sampler.sample()
 
 
 
+
 class InverseCDFSampler:
     """Inverse CDF sampler.
     

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -61,9 +61,10 @@ that will allow us to sample alternatively along all the axes or a given axis of
 MapEventSampler
 ===============
 
-To sample events, it is fundamental to create a map of the predicted events. This can be done with the MapDataset class 
-which takes as input a Skymodel(s) and a given exposure time. The predicted event map is then given to the new proposed 
-class MapEventSampler(). The source events will be simulated as following:
+The next fundamental step is the creation of a map of the predicted events. This can be performed, for a given exposure time,
+ with the MapDataset class which takes as input a Skymodel(s) object. The predicted event map is then the input of the new 
+proposed class MapEventSampler(). The same approach can be applied to the background events. The source events will be simulated 
+as following:
 
 src = SkyModel()
 evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
@@ -77,16 +78,17 @@ bkg_map = Map()
 bkg_sampler = MapEventSampler(bkg_map, psf_map=None, edisp_map=None)
 events_bkg = bkg_sample.sample()
 
-where the MapEventSampler() class can be used to generate both source and background events.
+where the MapEventSampler() class can be used to generate alternatively source or background events.
 
 
 IRFMapSampler
 =============
 
-We introduce a class that applies the IRF properties to the previously sampled event list. In more detail, the class 
-will take as input the MapEventSampler source object and then it evaluates a map of the psf and energy dispersion 
-calculated for each event true position and true energy. The reconstructed energy and positions are then listed into 
-an astropy table. We propose two different options to accomplish this task, which should work as follows:
+We introduce a class that bundles the IRF psf and energy dispersion and applies them to the previously sampled event list. 
+In more detail, the class will take as input the MapEventSampler.sample() source object and then it evaluates a map of 
+the psf and the energy dispersion calculated for each event true position and true energy. The reconstructed energies and 
+positions are then listed into an astropy table. We propose two different options to accomplish this task, which should work 
+as follows:
 
 events = vstack([events_src_1, events_src_2, ..., events_src_N])
 irf_sampler = IRFSampler(events, psf_map, edisp_map)
@@ -98,9 +100,10 @@ irf_sampler = IRFSampler(psf_map, edisp_map)
 events = irf_sampler.sample_psf(events)
 events = irf_sampler.sample_edisp(events)
 
-In the first case, the IRF is applied to the stacking of all the simulated sources, with the IRFSampler class which
+In the first case, the IRF is applied to the stacking of all the simulated sources, with the IRFSampler() class which
 contains only the sample() method. In the second case, the IRFSampler reads the psf and energy maps only, and then 
-it contains two methods that apply the psf and edisp corrections to the events; for more than one source, a loop is needed.
+it contains two methods that apply separately the psf and edisp corrections to the events; for more than one simulated 
+source, a loop will be needed.
 
 
 MapDatasetEventSampler?

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -55,7 +55,7 @@ that will allow us to sample alternatively along all the axes or a given axis of
 MapEventSampler
 ========
 
-- It remains the question on how does it relate with the Gammapy MapDataset class. 
+- We should resolve the question on how does it relate with the Gammapy MapDataset class. 
 
 
 Alternatives

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -61,6 +61,10 @@ that will allow us to sample alternatively along all the axes or a given axis of
 MapEventSampler
 ===============
 
+To sample events, it is fundamental to create a map of the predicted events. This can be done with the MapDataset class 
+which takes as input a Skymodel(s) and a given exposure time. The predicted event map is then given to the new proposed 
+class MapEventSampler(). The source events will be simulated as following:
+
 src = SkyModel()
 evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
 npred_map = evaluator.compute_npred()
@@ -73,9 +77,16 @@ bkg_map = Map()
 bkg_sampler = MapEventSampler(bkg_map, psf_map=None, edisp_map=None)
 events_bkg = bkg_sample.sample()
 
+where the MapEventSampler() class can be used to generate both source and background events.
+
 
 IRFMapSampler
 =============
+
+We introduce a class that applies the IRF properties to the previously sampled event list. In more detail, the class 
+will take as input the MapEventSampler source object and then it evaluates a map of the psf and energy dispersion 
+calculated for each event true position and true energy. The reconstructed energy and positions are then listed into 
+an astropy table. We propose two different options to accomplish this task, which should work as follows:
 
 events = vstack([events_src_1, events_src_2, ..., events_src_N])
 irf_sampler = IRFSampler(events, psf_map, edisp_map)
@@ -87,6 +98,9 @@ irf_sampler = IRFSampler(psf_map, edisp_map)
 events = irf_sampler.sample_psf(events)
 events = irf_sampler.sample_edisp(events)
 
+In the first case, the IRF is applied to the stacking of all the simulated sources, with the IRFSampler class which
+contains only the sample() method. In the second case, the IRFSampler reads the psf and energy maps only, and then 
+it contains two methods that apply the psf and edisp corrections to the events; for more than one source, a loop is needed.
 
 
 MapDatasetEventSampler?
@@ -149,6 +163,10 @@ This is a proposal for a list of pull requests implementing the proposed changes
 1. Introduce the InverseCDFSampler.
 2. Dismiss the ``general_random`` class in gammapy.utils.distributions.
 3. Implement the InverseCDFSampler into gammapy.utils.distributions (Gammapy v.0.12).
+4. Introduce the MapEventSampler class.
+5. Implement MapEventSampler into gammapy. ... (v.0.12).?
+6. Introduce the IRFSampler class.
+7. Implement IRFSampler into gammapy. ... (v.0.12). ?
 
 
 Decision
@@ -158,126 +176,4 @@ Decision
 
 
 
-
-
-
-
-
-
-
-
-#####################################
-- the design follows the ASTRIsim simulator
-- the latter requests the expected source flux cube for a given spectrum and morphology, prior the application of the IRF
-- (to the counts-cube can be associated a light-curve)
-- expected background counts cube evaluated from the IRF
-- the energy dispersion is applied to the source counts
-- the PSF is applied to the source counts
-- source and background events are stacked together 
-- write them all into an event list file (.fits)
-
-We propose to create an event simulator based on Gammapy, which is needed for the Science Tools, and it would allow a valid alternative to ctobssim. 
-We designed our simulator exploiting the already available ASTRI simulator (ASTRIsim), written in IDL. ASTRIsim starts from an input source flux cube (possibly associated to a spatial map), gives a set of simulated events (with associated positions, energies and times). Furthermore, there is possibility to provide an input light-curve to take into account source time variability.
-
-
-We would like to improve the class presented in general_random_array.py issue. We propose to add the sorting of the cumulative distribution and then we also want to provide an interpolation along the bins. This class has to be extended sampling along a given axis and not along all the array. 
-
-.. code::
-
-    class InverseCDFSampler:
-         """Inverse CDF folder"""
-         def __init__(self, pdf, random_state=0):
-             self.random_state = get_random_state(random_state)
-             self.pdf_shape = pdf.shape
-
-             pdf = pdf.ravel() / pdf.sum()
-             self.sortindex = np.argsort(pdf, axis=None)
-
-             self.pdf = pdf[self.sortindex]
-             self.cdf = np.cumsum(self.pdf)
-
-
-         def sample(self, size):
-             #pick numbers which are uniformly random over the cumulative 
-    distribution function
-             choice = self.random_state.uniform(high=1, size=size)
-
-             #find the indices corresponding to this point on the CDF
-             index = np.searchsorted(self.cdf, choice)
-             index = self.sortindex[index]
-
-             # map back to multi-dimensional indexing
-             index = np.unravel_index(index, self.pdf_shape)
-             index = np.vstack(index)
-
-             index = index + self.random_state.uniform(low=-0.5, high=0.5, 
-    size=index.shape)
-             return index
-
-
-We propose a new class labelled as 'MapEventSampler', which takes in input the predicted events, the PSF, energy dispersion and background maps. This includes the methods which implement energy dispersion (
-'apply_edisp') and PSF ('apply_psf') corrections, and calculate the background and source events. 
-
-We create a method called 'sample_events' that randomizes the map of predicted source counts to which are then applied the correct PSF and energy dispersion per event. The PSF and Energy dispersion corrections are not taken into account with a loop on the events.
-
-
-
-
-- to discuss: introduce the time of each event. In this moment, we just provide a counts-cube for all the components, but this does not allow us to associate the events to different light-curves. --> solution: create counts-cube for each component, apply the light-curve, and then stack all the components...
-
-The approach we propose works well only if the resolution in energy and spatial coordinates is very fine, in particular smaller than the IRF energy and PSF resolution. The choice of the map resolution is left to the user.
-
-.. code::
-
-    class MapEventSampler:
-         """Map event sampler"""
-         def __init__(self, npred_map, psf_map, edisp_map, background_map, 
-    random_state=0):
-             self.random_state = get_random_state(random_state)
-             self.npred = npred
-
-         def npred_total(self):
-             return self.random_state.poisson(self.npred.data.sum())
-
-         def apply_edisp(self, events):
-             # apply energy dispersion to list of events
-             pdf = self.edisp_map.interp_by_coord({"skycoord": events.radec, 
-    "energy": events.energy})
-
-             return events
-
-         def apply_psf(self, events):
-             # apply psf to list of events
-             rad = np.linspace(0, 1 * u.deg, 100)[np.newaxis;, :]
-             pdf = self.psf_map.interp_by_coord({"skycoord": events.radec, 
-    "energy": events.energy, "rad" rad})
-
-             # sample from pdf along rad axis
-             return events
-
-         def sample_background(self):
-             # sample from background model without applying IRFs
-             return events
-
-         def sample_npred(self):
-             n_events = self.npred_total()
-             pix_coords = self.cdf_sampler.sample(10 * n_events)
-             return self.npred.geom.pix_to_coord(pix_coords[::-1])
-
-         def sample_events(self):
-             events = self.sample_npred()
-             events = self.apply_psf(events)
-             events = self.apply_edisp(events)
-
-             bkg_events = self.sample_background()
-
-             table = vstack(events, bkg_events)
-             return EventList(table)
-
-
-- Copy of the stack-overflow code that implements the sampling of n-dimensional discrete probability distributions (details are given in https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584)
-- We would like to improve the GeneralRandomArray class (details are given in https://github.com/gammapy/gammapy/issues/74)
-
-
-- Events simulator and IRF corrections
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -74,7 +74,7 @@ We create a method called 'sample_events' that randomizes the map of predicted s
 
 
 - How does it relate with the MapDataset?
-
+- to discuss: introduce the time of each event. In this moment, we just provide a counts-cube for all the components, but this does not allow us to associate the events to different light-curves. --> solution: create counts-cube for each component, apply the light-curve, and then stack all the components...
 
 The approach we propose works well only if the resolution in energy and spatial coordinates is very fine, in particular smaller than the IRF energy and PSF resolution. The choice of the map resolution is left to the user.
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -20,7 +20,7 @@ Array (CTA). It will allows us to simulate sources with different spectral and m
 the best configurations for each type of objects and the expected performance of CTA on this data. An event simulator is also listed
 as a requirement for the future CTA Science Tools. For this reason, we propose to implement a framework for event simulation
 in Gammapy. Based on finely binned input maps, containing the predicted number of counts for a given source with a defined
-morphological and spectral model it samples events using the inverse cumulative distribution (Inverse CDF). In addition
+morphological and spectral model, it samples events using the inverse cumulative distribution (Inverse CDF). In addition
 a light curve model can be taken into account. Then the proposed simulator will be able to apply the PSF and energy dispersion
 to each sampled event. Furthermore, the sampler will include the simulation of background events, again based on finely
 binned maps. The final output of the simulator is a stacked event list with source and background events for a given
@@ -62,7 +62,7 @@ to draw samples from the given pdf:
 The returned object is a `np.ndarray` containing the sampled indices.
 
 In addition the `InverseCDFSampler` should have the possibility to sample only along a given axis of the PDF. This features is
-required to handle sampling of multiple PDFs a the same time to avoid a Python loop over the PDFs. This will be supported
+required to handle sampling of multiple PDFs at the same time to avoid a Python loop over the PDFs. This will be supported
 by specifying the `axis` argument:
 
 .. code::
@@ -122,7 +122,7 @@ repeat the temporal information or do we just consider the remaining time as a f
 IRFMapSampler
 =============
 
-The handle correctly the spatially varying IRFs, we propose to introduce an `IRFMapSampler` class. Based on the `PSFMap`
+To handle correctly the spatially varying IRFs, we propose to introduce an `IRFMapSampler` class. Based on the `PSFMap`
 and `EDispMap` as an input it interpolates the "correct" IRF at the position of a given event and applies it. In more detail
 the class will calculate the psf and the energy dispersion for each event true position and true energy. The reconstructed
 energies and positions are then appended to the event list. The IRFs are assumed to be constant and not time-dependent.
@@ -203,7 +203,7 @@ existing related classes in Gammapy:
 
 - `events_src = MapEvaluator.sample()` to sample from a source model
 - `events = EdispMap.sample(events=)` to apply the energy dispersion
-- `events = PsfMap.sample(events=)` to appy the PSF
+- `events = PsfMap.sample(events=)` to apply the PSF
 - `events = MapDataset.sample()` to combine all together.
 
 This has the advantage of a smaller API, but is less flexible.

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -39,46 +39,42 @@ once a set of random numbers is determined, it samples a set of events.
 
 The basic design of the class works as following:
 
+.. code::
+	
 	from gammapy.utils.distributions import InverseCDFSampler
-
 	cdf_sampler = InverseCDFSampler(pdf=npred_map.data, axis=None, random_state=random_state)
 
-where the gammapy.utils.random.get_random_state method is used.
+Where the `gammapy.utils.random.get_random_state` method is used. The class implements the following methods:
 
-
-The class implements the following methods:
-
+.. code::
+	
 	cdf_sampler = InverseCDFSampler()
-
 	cdf_sampler.sample_axis()
-
 	cdf_sampler.sample()
 
-
-that will allow us to sample alternatively along all the axes or a given axis of the input map.
+That will allow us to sample alternatively along all the axes or a given axis of the input map.
 
 
 MapEventSampler
 ===============
 
-The next fundamental step is the creation of a map of the predicted events. This can be performed, for a given exposure time,
- with the MapDataset class which takes as input a Skymodel(s) object. The predicted event map is then the input of the new 
-proposed class MapEventSampler(). The same approach can be applied to the background events. The source events will be simulated 
-as following:
+The next fundamental step is the creation of a map of the predicted events. This can be performed, for a given exposure time, with the `MapDataset` class which takes as input a Skymodel(s) object. The predicted event map is then the input of the new proposed class `MapEventSampler`. The same approach can be applied to the background events. The source events will be simulated as following:
 
-src = SkyModel()
-evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
-npred_map = evaluator.compute_npred()
+.. code::
+	
+	src = SkyModel()
+	evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
+	npred_map = evaluator.compute_npred()
 
-src_sampler = MapEventSampler(npred_map, psf_map, edisp_map)
-events_src = map_sampler.sample()
-# events_src is an astropy table
+	src_sampler = MapEventSampler(npred_map, psf_map, edisp_map)
+	events_src = map_sampler.sample()
+	# events_src is an astropy table
 
-bkg_map = Map()
-bkg_sampler = MapEventSampler(bkg_map, psf_map=None, edisp_map=None)
-events_bkg = bkg_sample.sample()
+	bkg_map = Map()
+	bkg_sampler = MapEventSampler(bkg_map, psf_map=None, edisp_map=None)
+	events_bkg = bkg_sample.sample()
 
-where the MapEventSampler() class can be used to generate alternatively source or background events.
+Where the `MapEventSampler` class can be used to generate alternatively source or background events.
 
 
 IRFMapSampler
@@ -90,15 +86,17 @@ the psf and the energy dispersion calculated for each event true position and tr
 positions are then listed into an astropy table. We propose two different options to accomplish this task, which should work 
 as follows:
 
-events = vstack([events_src_1, events_src_2, ..., events_src_N])
-irf_sampler = IRFSampler(events, psf_map, edisp_map)
-events_obs = irf_sampler.sample()
+.. code::
 
-# or
+	events = vstack([events_src_1, events_src_2, ..., events_src_N])
+	irf_sampler = IRFSampler(events, psf_map, edisp_map)
+	events_obs = irf_sampler.sample()
 
-irf_sampler = IRFSampler(psf_map, edisp_map)
-events = irf_sampler.sample_psf(events)
-events = irf_sampler.sample_edisp(events)
+	# or
+
+	irf_sampler = IRFSampler(psf_map, edisp_map)
+	events = irf_sampler.sample_psf(events)
+	events = irf_sampler.sample_edisp(events)
 
 In the first case, the IRF is applied to the stacking of all the simulated sources, with the IRFSampler() class which
 contains only the sample() method. In the second case, the IRFSampler reads the psf and energy maps only, and then 
@@ -111,6 +109,8 @@ MapDatasetEventSampler?
 
 Propose high level structure:
 
+.. code::
+    
     dataset_sampler = MapDatasetEventSampler(dataset)
     events = dataset_sampler.sample()
 
@@ -120,6 +120,8 @@ Propose high level structure:
 
 
 More detailed:
+
+.. code::
 
     events = []
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -20,15 +20,15 @@ Array (CTA). It will allows us to simulate sources with different spectral and m
 the best configurations for each type of objects and the expected performances of CTA. We note that an event simulator is
 currently required by the CTA Science Tools. In addition, there will be the possibility to adopt it to simulate the next
 CTA Data Challenge (DC2). Therefore, we propose to create an event simulator which sample random events for given sources.
-It will need input maps where spatial morphology and spectral distributions are provided. Then the proposed simulator will
-be able to apply the PSF and energy dispersion, for each simulated observation, to correct position and energy of the sampled
-events. Source lightcurves will be also taken into account to simulate temporal variations. Furthermore, the sampler will
-possibly include the simulation of background events. The output of the simulator is an astropy table.
+It will need input maps where spatial morphology and spectral distributions are provided, and optionally also the time 
+variability will be given. Then the proposed simulator will be able to apply the PSF and energy dispersion, for each simulated observation, to correct position and energy of the sampled events. Source lightcurves will be also taken into account to 
+simulate temporal variations. Furthermore, the sampler will possibly include the simulation of background events. The output
+of the simulator is an astropy table. A link to a Jupyter event sampler prototype can be found at this URL: https://github.com/fabiopintore/notebooks-public/blob/master/gammapy-event-sampling/prototype.ipynb
 
 Proposal
 ========
 
-We propose to introduce the following classes to implement the simulator in Gammapy:
+We propose to introduce the following classes to implement the simulator in Gammapy.
 
 InverseCDFSampler
 =================
@@ -58,7 +58,10 @@ That will allow us to sample alternatively along all the axes or a given axis of
 MapEventSampler
 ===============
 
-The next fundamental step is the creation of a map of the predicted events. This can be performed, for a given exposure time, with the `MapDataset` class which takes as input a Skymodel(s) object. The predicted event map is then the input of the new proposed class `MapEventSampler`. The same approach can be applied to the background events. The source events will be simulated as following:
+The next fundamental step is the creation of a map of the predicted events. This can be performed, for a given exposure time, 
+with the `MapDataset` class which takes as input a `Skymodel` object. The predicted event map is then the input of the new 
+proposed class `MapEventSampler`. The same approach can be applied to the background events. The source events will be simulated 
+as following:
 
 .. code::
 	
@@ -66,22 +69,25 @@ The next fundamental step is the creation of a map of the predicted events. This
 	evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
 	npred_map = evaluator.compute_npred()
 
-	src_sampler = MapEventSampler(npred_map, psf_map, edisp_map)
+	src_sampler = MapEventSampler(npred_map, lightcurve) 
 	events_src = map_sampler.sample()
 	# events_src is an astropy table
 
 	bkg_map = Map()
-	bkg_sampler = MapEventSampler(bkg_map, psf_map=None, edisp_map=None)
+	bkg_sampler = MapEventSampler(npred_map, bkg_map, exposure)
 	events_bkg = bkg_sample.sample()
 
-Where the `MapEventSampler` class can be used to generate alternatively source or background events.
+Where the `MapEventSampler` class can be used to generate alternatively source or background events. It is important to note 
+that the `MapEventSampler` takes into account the temporal information (lightcurve) for the source, while for the background 
+the time of events arrival are sampled evenly along the whole exposure time. It remains to answer the question what to do when 
+the source lightcurve is shorter than the total exposure time: do we repeat the temporal information or do we just consider the remaining time as a flat lightcurve?
 
 
 IRFMapSampler
 =============
 
 We introduce a class that bundles the IRF psf and energy dispersion and applies them to the previously sampled event list. 
-In more detail, the class will take as input the MapEventSampler.sample() source object and then it evaluates a map of 
+In more detail, the class will take as input the `MapEventSampler.sample` source object and then it evaluates a map of 
 the psf and the energy dispersion calculated for each event true position and true energy. The reconstructed energies and 
 positions are then listed into an astropy table. We propose two different options to accomplish this task, which should work 
 as follows:
@@ -89,17 +95,17 @@ as follows:
 .. code::
 
 	events = vstack([events_src_1, events_src_2, ..., events_src_N])
-	irf_sampler = IRFSampler(events, psf_map, edisp_map)
+	irf_sampler = IRFMapSampler(events, psf_map, edisp_map)
 	events_obs = irf_sampler.sample()
 
 	# or
 
-	irf_sampler = IRFSampler(psf_map, edisp_map)
+	irf_sampler = IRFMapSampler(psf_map, edisp_map)
 	events = irf_sampler.sample_psf(events)
 	events = irf_sampler.sample_edisp(events)
 
-In the first case, the IRF is applied to the stacking of all the simulated sources, with the IRFSampler() class which
-contains only the sample() method. In the second case, the IRFSampler reads the psf and energy maps only, and then 
+In the first case, the IRF is applied to the stacking of all the simulated sources, with the `IRFSampler` class which
+contains only the `sample` method. In the second case, the `IRFSampler` reads the psf and energy maps only, and then 
 it contains two methods that apply separately the psf and edisp corrections to the events; for more than one simulated 
 source, a loop will be needed.
 

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -7,7 +7,7 @@ PIG 9 - Event simulator
 ***********************
 
 * Author: Fabio Pintore, Andrea Giuliani, Axel Donath
-* Created: Feb 04, 2019 
+* Created: May 03, 2019
 * Accepted: 
 * Status: 
 * Discussion:  
@@ -16,52 +16,75 @@ Introduction
 ============
 
 An event simulator of gamma events is of high importance in exploiting the potentiality of the future Cherenkov Telescope
-Array (CTA). It will allows us to simulate sources with different spectral and morphological properties, hence investigating
-the best configurations for each type of objects and the expected performances of CTA. We note that an event simulator is
-currently required by the CTA Science Tools. In addition, there will be the possibility to adopt it to simulate the next
-CTA Data Challenge (DC2). Therefore, we propose to create an event simulator which sample random events for given sources.
-It will need input maps where spatial morphology and spectral distributions are provided, and optionally also the time 
-variability will be given. Then the proposed simulator will be able to apply the PSF and energy dispersion, for each simulated observation, to correct position and energy of the sampled events. Source lightcurves will be also taken into account to 
-simulate temporal variations. Furthermore, the sampler will possibly include the simulation of background events. The output
-of the simulator is an astropy table. A link to a Jupyter event sampler prototype can be found at this URL: https://github.com/fabiopintore/notebooks-public/blob/master/gammapy-event-sampling/prototype.ipynb
+Array (CTA). It will allows us to simulate sources with different spectral and morphological properties adn e.g. investigating
+the best configurations for each type of objects and the expected performance of CTA on this data. An event simulator is also listed
+as a requirement for the future CTA Science Tools. For this reason, we propose to implement a framework for event simulation
+in Gammapy. Based on finely binned input maps, containing the predicted number of counts for a given source with a defined
+morphological and spectral model it samples events using the inverse cumulative distribution (Inverse CDF). In addition
+a light curve model can be taken into account. Then the proposed simulator will be able to apply the PSF and energy dispersion
+to each sampled event. Furthermore, the sampler will include the simulation of background events, again based on finely
+binned maps. The final output of the simulator is a stacked event list with source and background events for a given
+observation.
+
+
+A working prototype of the event sample can be found at this URL: https://github.com/fabiopintore/notebooks-public/blob/master/gammapy-event-sampling/prototype.ipynb
 
 Proposal
 ========
 
-We propose to introduce the following classes to implement the simulator in Gammapy.
+We propose to introduce the following classes to implement the event simulation framework in Gammapy.
 
 InverseCDFSampler
 =================
 
-The first step of an event simulator can be obtained by developing a sampler of the cumulative distribution function for
-a given input probability distribution function. In more detail, it calculates the cumulative distribution function and,
-once a set of random numbers is determined, it samples a set of events.
+The first building block of the event simulator is a class that samples from a given probability function (PSF). For this
+we use the inverse CDF sampling method (https://en.wikipedia.org/wiki/Inverse_transform_sampling). In more detail, it
+calculates the cumulative distribution function and, once a set of random numbers is determined, it samples a set of events.
+The proposed implementation follows closely what's proposed here https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584:
 
-The basic design of the class works as following:
+The basic design of the class is as following:
 
 .. code::
 	
 	from gammapy.utils.distributions import InverseCDFSampler
-	cdf_sampler = InverseCDFSampler(pdf=npred_map.data, axis=None, random_state=random_state)
 
-Where the `gammapy.utils.random.get_random_state` method is used. The class implements the following methods:
+    pdf = np.array()
+	cdf_sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
+
+Where the `gammapy.utils.random.get_random_state` method is used. The class implements mainly the `.sample()` method
+to draw samples from the given pdf:
 
 .. code::
 	
 	cdf_sampler = InverseCDFSampler()
-	cdf_sampler.sample_axis()
-	cdf_sampler.sample()
+	samples = cdf_sampler.sample(size=100)
 
-That will allow us to sample alternatively along all the axes or a given axis of the input map.
+The returned object is a `np.ndarray` containing the sampled indices.
+
+In addition the `InverseCDFSampler` should have the possibility to sample only along a given axis of the PDF. This features is
+required to handle sampling of multiple PDFs a the same time to avoid a Python loop over the PDFs. This will be supported
+by specifying the `axis` argument:
+
+.. code::
+
+	cdf_sampler = InverseCDFSampler(pdf=pdfs, axis=0)
+	samples = cdf_sampler.sample(size=1)
+
+
+The `InverseCDFSampler` could possibly implement a few helper functions to plot the CDF or PDF. The `InverseCDFSampler`
+class will replace the current `GeneralRandom` and `GeneralRandomArray` classes in `gammapy.utils.distributions`.
+Possibly the `InverseCDFSampler` needs a to support transforming PDFs e.g. log transformations of power-laws to maintain
+accuracy. The need for this is unclear.
 
 
 MapEventSampler
 ===============
 
-The next fundamental step is the creation of a map of the predicted events. This can be performed, for a given exposure time, 
-with the `MapDataset` class which takes as input a `Skymodel` object. The predicted event map is then the input of the new 
-proposed class `MapEventSampler`. The same approach can be applied to the background events. The source events will be simulated 
-as following:
+To support sampling from the predicted number of counts maps for source as well as background maps, we propose to
+introduce a `MapEventSampler` class. The responsibility of this class is to handle the physical coordinate transformations,
+time dependence of the model, output data structures and sampling of the total number of observed events.
+
+Starting from a predicted number of counts map (e.g. computed by the `MapEvaluator`):
 
 .. code::
 	
@@ -69,18 +92,30 @@ as following:
 	evaluator = MapEvaluator(src, exposure, psf=None, edisp=None)
 	npred_map = evaluator.compute_npred()
 
-	src_sampler = MapEventSampler(npred_map, lightcurve) 
-	events_src = map_sampler.sample()
-	# events_src is an astropy table
+The `MapEventSampler` takes this map and a lightcurve model as an input and allows to sample from it with the `.sample()`
+method:
 
-	bkg_map = Map()
-	bkg_sampler = MapEventSampler(npred_map, bkg_map, exposure)
+.. code::
+
+	lightcurve = LightCurveTableModel() # or PhaseCurveTableModel()
+	src_sampler = MapEventSampler(npred_map, lightcurve)
+
+    # draw total number of events
+    n_events = src_sampler.npred_total()
+
+	# draw events as an astropy table
+	events_src = map_sampler.sample()
+
+If no lightcurve is provided a constant rate can be assumed e.g. for background models:
+
+.. code::
+
+	bkg_map = BackgroundModel().map
+	bkg_sampler = MapEventSampler(bkg_map, t_min=, t_max=)
 	events_bkg = bkg_sample.sample()
 
-Where the `MapEventSampler` class can be used to generate alternatively source or background events. It is important to note 
-that the `MapEventSampler` takes into account the temporal information (lightcurve) for the source, while for the background 
-the time of events arrival are sampled evenly along the whole exposure time. It remains to answer the question what to do when 
-the source lightcurve is shorter than the total exposure time: do we repeat the temporal information or do we just consider the remaining time as a flat lightcurve?
+It remains to answer the question what to do when the source lightcurve is shorter than the total exposure time: do we
+repeat the temporal information or do we just consider the remaining time as a flat or  lightcurve?
 
 
 IRFMapSampler

--- a/docs/development/pigs/pig-009.rst
+++ b/docs/development/pigs/pig-009.rst
@@ -15,26 +15,145 @@ PIG 9 - Event simulator
 Abstract
 ========
 
-- create event simulator 
+- create an event simulator 
 - required by the CTA Science Tools
-- needed to simulate the DC2
+- necessary to simulate the DC2
 
 
 Proposal
 ========
 
-- the design follows the ASTRIsim
-- expected source counts cube for a given spectrum and morphology, prior the application of the IRF
-(- the counts-cube can be associated to a light-curve)
+- the design follows the ASTRIsim simulator
+- the latter requests the expected source flux cube for a given spectrum and morphology, prior the application of the IRF
+- (to the counts-cube can be associated a light-curve)
 - expected background counts cube evaluated from the IRF
 - the energy dispersion is applied to the source counts
 - the PSF is applied to the source counts
 - source and background events are stacked together 
 - write them all into an event list file (.fits)
 
+We would like to improve the class presented in general_random_array.py issue. We propose to add the sorting of the cumulative distribution and then we also want to provide an interpolation along the bins. This class has to be extended sampling along a given axis and not along all the array. 
+
+.. code::
+
+    class InverseCDFSampler:
+         """Inverse CDF folder"""
+         def __init__(self, pdf, random_state=0):
+             self.random_state = get_random_state(random_state)
+             self.pdf_shape = pdf.shape
+
+             pdf = pdf.ravel() / pdf.sum()
+             self.sortindex = np.argsort(pdf, axis=None)
+
+             self.pdf = pdf[self.sortindex]
+             self.cdf = np.cumsum(self.pdf)
+
+
+         def sample(self, size):
+             #pick numbers which are uniformly random over the cumulative 
+    distribution function
+             choice = self.random_state.uniform(high=1, size=size)
+
+             #find the indices corresponding to this point on the CDF
+             index = np.searchsorted(self.cdf, choice)
+             index = self.sortindex[index]
+
+             # map back to multi-dimensional indexing
+             index = np.unravel_index(index, self.pdf_shape)
+             index = np.vstack(index)
+
+             index = index + self.random_state.uniform(low=-0.5, high=0.5, 
+    size=index.shape)
+             return index
+
+
+We propose a new class labelled as 'MapEventSampler', which takes in input the predicted events, the PSF, energy dispersion and background maps. This includes the methods which implement energy dispersion (
+'apply_edisp') and PSF ('apply_psf') corrections, and calculate the background and source events. 
+
+We create a method called 'sample_events' that randomizes the map of predicted source counts to which are then applied the correct PSF and energy dispersion per event. The PSF and Energy dispersion corrections are not taken into account with a loop on the events.
+
+
+- How does it relate with the MapDataset?
+
+
+The approach we propose works well only if the resolution in energy and spatial coordinates is very fine, in particular smaller than the IRF energy and PSF resolution. The choice of the map resolution is left to the user.
+
+.. code::
+
+    class MapEventSampler:
+         """Map event sampler"""
+         def __init__(self, npred_map, psf_map, edisp_map, background_map, 
+    random_state=0):
+             self.random_state = get_random_state(random_state)
+             self.npred = npred
+
+         def npred_total(self):
+             return self.random_state.poisson(self.npred.data.sum())
+
+         def apply_edisp(self, events):
+             # apply energy dispersion to list of events
+             pdf = self.edisp_map.interp_by_coord({"skycoord": events.radec, 
+    "energy": events.energy})
+
+             return events
+
+         def apply_psf(self, events):
+             # apply psf to list of events
+             rad = np.linspace(0, 1 * u.deg, 100)[np.newaxis;, :]
+             pdf = self.psf_map.interp_by_coord({"skycoord": events.radec, 
+    "energy": events.energy, "rad" rad})
+
+             # sample from pdf along rad axis
+             return events
+
+         def sample_background(self):
+             # sample from background model without applying IRFs
+             return events
+
+         def sample_npred(self):
+             n_events = self.npred_total()
+             pix_coords = self.cdf_sampler.sample(10 * n_events)
+             return self.npred.geom.pix_to_coord(pix_coords[::-1])
+
+         def sample_events(self):
+             events = self.sample_npred()
+             events = self.apply_psf(events)
+             events = self.apply_edisp(events)
+
+             bkg_events = self.sample_background()
+
+             table = vstack(events, bkg_events)
+             return EventList(table)
+
+
+The 'sample()' method returns an astropy table containing source+bkg events.
+
+.. code::
+
+    pdf = Map()
+
+    table = psf.sample(n_samples, ramdoms_state=0)
+
+    sampler = MapEventSampler(pdf)
+
+    table = sample.sample(random_state=0)
+ 
+
+
 
 Alternatives
 ============
+
+
+List of proposed pull requests
+==============================
+
+- Copy of the stack-overflow code that implements the sampling of n-dimensional discrete probability distributions (details are given in https://stackoverflow.com/questions/21100716/fast-arbitrary-distribution-random-sampling/21101584#21101584)
+- We would like to improve the GeneralRandomArray class (details are given in https://github.com/gammapy/gammapy/issues/74)
+
+
+- Events simulator and IRF corrections
+
 
 
 

--- a/gammapy/utils/random/__init__.py
+++ b/gammapy/utils/random/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions / classes for working with distributions
+(e.g. probability density functions)
+"""
+from .inverse_cdf import *
+from .utils import *

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -1,0 +1,81 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+from .utils import get_random_state
+
+
+#__all__ = [
+#    "normalize",
+#    "density",
+#    "draw",
+#    "pdf",
+#    "get_random_state",
+#    "sample_sphere",
+#    "sample_sphere_distance",
+#    "sample_powerlaw",
+#]
+
+
+class InverseCDFSampler:
+    """Inverse CDF sampler.
+       It determines a set of random numbers and calculate the cumulative distribution function.
+       
+        Parameters
+        ----------
+        pdf : `~`gammapy.maps.Map`
+        predicted source counts
+        
+        """
+    def __init__(self, pdf, axis=None, random_state=0):
+        self.random_state = get_random_state(random_state)
+        self.axis = axis
+        
+        if axis is not None:
+            self.cdf = np.cumsum(pdf, axis=self.axis)
+            self.cdf /= self.cdf[:, [-1]]
+        else:
+            self.pdf_shape = pdf.shape  #gives the shape of the PDF array
+            
+            pdf = pdf.ravel() / pdf.sum()  #flattens the array along one axis
+            self.sortindex = np.argsort(pdf, axis=None) #sorting of the elements and giving the indexes
+            
+            self.pdf = pdf[self.sortindex]  #sort the pdf array
+            self.cdf = np.cumsum(self.pdf)  #evaluate the cumulative sum of the PDF array
+
+    def sample_axis(self):
+        """Sample along a given axis.
+        """
+        choice = self.random_state.uniform(high=1, size=len(self.cdf))
+
+        #find the indices corresponding to this point on the CDF
+        index = np.argmin(np.abs(choice.reshape(-1, 1) - self.cdf), axis=self.axis)
+
+        return index + self.random_state.uniform(low=-0.5, high=0.5,
+                 size=len(self.cdf))
+
+    def sample(self, size):
+        """Draw sample from the given PDF.
+
+        Parameters
+        ----------
+        size : int
+        Number of samples to draw.
+
+        Returns
+        -------
+        index : tuple of `~numpy.ndarray`
+        Coordinates of the drawn sample
+        """
+        #pick numbers which are uniformly random over the cumulative distribution function
+        choice = self.random_state.uniform(high=1, size=size)
+
+        #find the indices corresponding to this point on the CDF
+        index = np.searchsorted(self.cdf, choice)
+        index = self.sortindex[index]
+
+        # map back to multi-dimensional indexing
+        index = np.unravel_index(index, self.pdf_shape) 
+        index = np.vstack(index)
+
+        index = index + self.random_state.uniform(low=-0.5, high=0.5,
+                                              size=index.shape)
+        return index

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -1,25 +1,37 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.table import Table
 from ..inverse_cdf import InverseCDFSampler
-from gammapy.time.models import LightCurveTableModel
 import numpy as np
+from numpy.testing import assert_allclose
+import scipy, scipy.optimize, scipy.ndimage
+import scipy.stats as stats
 
 
-def ct_rate(x):
-    return np.exp(-x/20)
+def uniform_dist(n_elem):
+    return np.ones(n_elem)
 
-def random_light_curve():
-    x = np.linspace(0,100,100)
-    table = Table()
-    table['time'] = x
-    table['rate'] = ct_rate(x)
-    lc = LightCurveTableModel(table)
+def gauss_dist(x, mu=0, sigma=0.1):
+    return stats.norm.pdf(x,mu,sigma)
 
-    t_data = lc.table['time'].data
-    count_rate = lc.table['rate'].data
-    lc = np.vstack([times,ctss])
+def gaus(x, k, sig, mu):
+    return k * np.exp((-(x-mu)**2)/(2*sig**2))   # 1 gauss
 
-    plt.plot(t_data,count_rate)
+def test_uniform_dist_sampling():
+    for i in np.arange(1,100):
+        idx = InverseCDFSampler(uniform_dist(n_elem=100000), random_state=0)
+        sampled_elem = idx.sample(1000)
+        hist = np.histogram(sampled_elem[0],bins=100)
+        assert_allclose((np.mean(hist[0]) * 100./1000.), 1.0, atol=1e-4)
 
-    sampled_times = InverseCDFSampler(pdf=count_rate,random_state=0)
-    times=sampled_times.sample(10000)
+def test_norm_dist_sampling():
+    for i in np.arange(1,100):
+        x = np.arange(-i,i,i/1000.)
+        sigma = i/100.
+        idx = InverseCDFSampler(gauss_dist(x=x, mu=0, sigma=sigma), random_state=0)
+        sampled_elem = idx.sample(1000)
+        a1, b1 = np.histogram((sampled_elem[0]),bins=100)
+        b2 = (b1 + np.roll(b1,1))/2.0
+        b2 = np.delete(b2, 0)
+        guess = np.array([50, 0.05, 1000])
+        fitParams, fitCovariances = scipy.optimize.curve_fit(gaus, b2, a1, guess, sigma=(np.zeros(len(b2))+0.01), maxfev=100000)
+        assert_allclose(fitParams[2], 1000., atol=0.15)

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -1,9 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.table import Table
 from ..inverse_cdf import InverseCDFSampler
 import numpy as np
 from numpy.testing import assert_allclose
-import scipy, scipy.optimize, scipy.ndimage
+import scipy.optimize
 import scipy.stats as stats
 
 

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -1,0 +1,25 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from astropy.table import Table
+from ..inverse_cdf import InverseCDFSampler
+from gammapy.time.models import LightCurveTableModel
+import numpy as np
+
+
+def ct_rate(x):
+    return np.exp(-x/20)
+
+def random_light_curve():
+    x = np.linspace(0,100,100)
+    table = Table()
+    table['time'] = x
+    table['rate'] = ct_rate(x)
+    lc = LightCurveTableModel(table)
+
+    t_data = lc.table['time'].data
+    count_rate = lc.table['rate'].data
+    lc = np.vstack([times,ctss])
+
+    plt.plot(t_data,count_rate)
+
+    sampled_times = InverseCDFSampler(pdf=count_rate,random_state=0)
+    times=sampled_times.sample(10000)

--- a/gammapy/utils/random/utils.py
+++ b/gammapy/utils/random/utils.py
@@ -1,0 +1,45 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Helper functions to work with distributions."""
+from scipy.integrate import quad
+from ...utils.random import get_random_state
+from ...utils.distributions import GeneralRandom
+
+__all__ = ["normalize", "density", "draw", "pdf"]
+
+
+def normalize(func, x_min, x_max):
+    """Normalize a 1D function over a given range."""
+
+    def f(x):
+        return func(x) / quad(func, x_min, x_max)[0]
+
+    return f
+
+
+def pdf(func):
+    """One-dimensional PDF of a given radial surface density."""
+
+    def f(x):
+        return x * func(x)
+
+    return f
+
+
+def density(func):
+    """Radial surface density of a given one dimensional PDF."""
+
+    def f(x):
+        return func(x) / x
+
+    return f
+
+
+def draw(low, high, size, dist, random_state="random-seed", *args, **kwargs):
+    """Allows drawing of random numbers from any distribution."""
+    random_state = get_random_state(random_state)
+
+    def f(x):
+        return dist(x, *args, **kwargs)
+
+    d = GeneralRandom(f, low, high)
+    return d.draw(size, random_state=random_state)

--- a/gammapy/utils/random/utils.py
+++ b/gammapy/utils/random/utils.py
@@ -1,45 +1,213 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Helper functions to work with distributions."""
+import numbers
+import numpy as np
+from astropy.coordinates import Angle
 from scipy.integrate import quad
-from ...utils.random import get_random_state
-from ...utils.distributions import GeneralRandom
 
-__all__ = ["normalize", "density", "draw", "pdf"]
+
+__all__ = [
+           "get_random_state",
+           "sample_sphere",
+           "sample_sphere_distance",
+           "sample_powerlaw",
+           "normalize",
+           "density",
+           "draw",
+           "pdf"
+           ]
+
 
 
 def normalize(func, x_min, x_max):
     """Normalize a 1D function over a given range."""
-
+    
     def f(x):
         return func(x) / quad(func, x_min, x_max)[0]
-
+    
     return f
 
 
 def pdf(func):
     """One-dimensional PDF of a given radial surface density."""
-
+    
     def f(x):
         return x * func(x)
-
+    
     return f
 
 
 def density(func):
     """Radial surface density of a given one dimensional PDF."""
-
+    
     def f(x):
         return func(x) / x
-
+    
     return f
 
 
 def draw(low, high, size, dist, random_state="random-seed", *args, **kwargs):
     """Allows drawing of random numbers from any distribution."""
+    from .general_random import GeneralRandom
+    
     random_state = get_random_state(random_state)
-
+    
     def f(x):
         return dist(x, *args, **kwargs)
-
+    
     d = GeneralRandom(f, low, high)
     return d.draw(size, random_state=random_state)
+
+
+def get_random_state(init):
+    """Get a `numpy.random.RandomState` instance.
+        The purpose of this utility function is to have a flexible way
+        to initialise a `~numpy.random.RandomState` instance,
+        a.k.a. a random number generator (``rng``).
+        See :ref:`dev_random` for usage examples and further information.
+        Parameters
+        ----------
+        init : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+        Available options to initialise the RandomState object:
+        * ``int`` -- new RandomState instance seeded with this integer
+        (calls `~numpy.random.RandomState` with ``seed=init``)
+        * ``'random-seed'`` -- new RandomState instance seeded in a random way
+        (calls `~numpy.random.RandomState` with ``seed=None``)
+        * ``'global-rng'``, return the RandomState singleton used by ``numpy.random``.
+        * `~numpy.random.RandomState` -- do nothing, return the input.
+        Returns
+        -------
+        random_state : `~numpy.random.RandomState`
+        RandomState instance.
+        """
+    if isinstance(init, (numbers.Integral, np.integer)):
+        return np.random.RandomState(init)
+    elif init == "random-seed":
+        return np.random.RandomState(None)
+    elif init == "global-rng":
+        return np.random.mtrand._rand
+    elif isinstance(init, np.random.RandomState):
+        return init
+    else:
+        raise ValueError(
+                         "{} cannot be used to seed a numpy.random.RandomState"
+                         " instance".format(init)
+                         )
+
+
+def sample_sphere(size, lon_range=None, lat_range=None, random_state="random-seed"):
+    """Sample random points on the sphere.
+        Reference: http://mathworld.wolfram.com/SpherePointPicking.html
+        Parameters
+        ----------
+        size : int
+        Number of samples to generate
+        lon_range : `~astropy.coordinates.Angle`, optional
+        Longitude range (min, max)
+        lat_range : `~astropy.coordinates.Angle`, optional
+        Latitude range (min, max)
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+        Defines random number generator initialisation.
+        Passed to `~gammapy.utils.random.get_random_state`.
+        Returns
+        -------
+        lon, lat: `~astropy.coordinates.Angle`
+        Longitude and latitude coordinate arrays
+        """
+    random_state = get_random_state(random_state)
+    
+    if lon_range is None:
+        lon_range = Angle([0.0, 360.0], "deg")
+    
+    if lat_range is None:
+        lat_range = Angle([-90.0, 90.0], "deg")
+    
+    # Sample random longitude
+    u = random_state.uniform(size=size)
+    lon = lon_range[0] + (lon_range[1] - lon_range[0]) * u
+
+    # Sample random latitude
+    v = random_state.uniform(size=size)
+    z_range = np.sin(lat_range)
+    z = z_range[0] + (z_range[1] - z_range[0]) * v
+    lat = np.arcsin(z)
+    
+    return lon, lat
+
+
+def sample_sphere_distance(
+                           distance_min=0, distance_max=1, size=None, random_state="random-seed"
+                           ):
+    """Sample random distances if the 3-dim space density is constant.
+        This function uses inverse transform sampling
+        (`Wikipedia <http://en.wikipedia.org/wiki/Inverse_transform_sampling>`__)
+        to generate random distances for an observer located in a 3-dim
+        space with constant source density in the range ``(distance_min, distance_max)``.
+        Parameters
+        ----------
+        distance_min, distance_max : float, optional
+        Distance range in which to sample
+        size : int or tuple of ints, optional
+        Output shape. Default: one sample. Passed to `numpy.random.uniform`.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+        Defines random number generator initialisation.
+        Passed to `~gammapy.utils.random.get_random_state`.
+        Returns
+        -------
+        distance : array
+        Array of samples
+        """
+    random_state = get_random_state(random_state)
+    
+    # Since the differential distribution is dP / dr ~ r ^ 2,
+    # we have a cumulative distribution
+    #     P(r) = a * r ^ 3 + b
+    # with P(r_min) = 0 and P(r_max) = 1 implying
+    #     a = 1 / (r_max ^ 3 - r_min ^ 3)
+    #     b = -a * r_min ** 3
+    
+    a = 1.0 / (distance_max ** 3 - distance_min ** 3)
+    b = -a * distance_min ** 3
+    
+    # Now for inverse transform sampling we need to use the inverse of
+    #     u = a * r ^ 3 + b
+    # which is
+    #     r = [(u - b)/ a] ^ (1 / 3)
+    u = random_state.uniform(size=size)
+    distance = ((u - b) / a) ** (1.0 / 3)
+    
+    return distance
+
+
+def sample_powerlaw(x_min, x_max, gamma, size=None, random_state="random-seed"):
+    """Sample random values from a power law distribution.
+        f(x) = x ** (-gamma) in the range x_min to x_max
+        It is assumed that *gamma* is the **differential** spectral index.
+        Reference: http://mathworld.wolfram.com/RandomNumber.html
+        Parameters
+        ----------
+        x_min : float
+        x range minimum
+        x_max : float
+        x range maximum
+        gamma : float
+        Power law index
+        size : int, optional
+        Number of samples to generate
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+        Defines random number generator initialisation.
+        Passed to `~gammapy.utils.random.get_random_state`.
+        Returns
+        -------
+        x : array
+        Array of samples from the distribution
+        """
+    random_state = get_random_state(random_state)
+    
+    size = int(size)
+    
+    exp = -gamma
+    base = random_state.uniform(x_min ** exp, x_max ** exp, size)
+    x = base ** (1 / exp)
+    
+    return x


### PR DESCRIPTION
This PR implement the new class InverseCDFSampler into `gammapy.utils.random'. This PR request is necessary to the Event-Sampler discussed in #2136 .

We added two tests that use the InverseCDFSampler class to sample from a uniform distribution or a gaussian distribution. The tests compare the sampled distributions with the expected ones.