### PR TITLE
Tutorial for lightcurve analysis

### DIFF
--- a/tutorials/temporal_analysis.ipynb
+++ b/tutorials/temporal_analysis.ipynb
@@ -1,0 +1,384 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " # Temporal analysis with gammapy\n",
+    " \n",
+    " - PKS 2155-304 flare runs from the HESS Public data release\n",
+    " - Assume template background already made using https://docs.gammapy.org/dev/notebooks/background_model.html\n",
+    " - Do a 3D map based analysis keeping only the amplitude free\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import astropy.units as u\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from astropy.coordinates import SkyCoord, Angle\n",
+    "\n",
+    "from gammapy.data import ObservationFilter, DataStore, DataStoreObservation\n",
+    "from gammapy.irf import EffectiveAreaTable2D, EnergyDispersion2D, EnergyDependentMultiGaussPSF, Background3D\n",
+    "from gammapy.spectrum.models import PowerLaw, PowerLaw2\n",
+    "from gammapy.image.models import SkyPointSource\n",
+    "from gammapy.cube import MapEvaluator, PSFKernel, MapMaker, MapMakerObs, MapDataset\n",
+    "from gammapy.utils.fitting import Fit\n",
+    "from gammapy.cube import make_map_exposure_true_energy, make_map_background_irf\n",
+    "from gammapy.maps import WcsGeom, MapAxis, WcsNDMap, Map\n",
+    "from gammapy.cube.models import SkyModel, SkyModels, BackgroundModel\n",
+    "from gammapy.cube.exposure import _map_spectrum_weight\n",
+    "from astropy.time import Time\n",
+    "from regions import CircleSkyRegion\n",
+    "from gammapy.irf import make_mean_psf\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load the data - standard process - use the hdu-index-table with the background files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Get DR1 data\n",
+    "\n",
+    "path = (\n",
+    "    Path(os.environ[\"GAMMAPY_DATA\"])\n",
+    "    / \"hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz\"\n",
+    ")\n",
+    "datastore = DataStore.from_file(path)\n",
+    "src=SkyCoord.from_name(\"PKS 2155-304\")\n",
+    "sep=SkyCoord.separation(src,datastore.obs_table.pointing_radec)\n",
+    "Radius=2.3\n",
+    "srcruns=(datastore.obs_table[sep<Radius*u.deg])\n",
+    "myid=srcruns['OBS_ID'].data\n",
+    "mylist=datastore.get_observations(myid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Steps for standard 3D analysis\n",
+    "\n",
+    "Standard 3D analysis as explained in analysis_3d will be performed for each time bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define geoms\n",
+    "emin, emax = [0.1, 10] * u.TeV\n",
+    "energy_axis = MapAxis.from_bounds(\n",
+    "    emin.value, emax.value, 10, unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
+    ")\n",
+    "geom = WcsGeom.create(\n",
+    "    skydir=src,\n",
+    "    binsz=0.02,\n",
+    "    width=(10, 8),\n",
+    "    coordsys=\"CEL\",\n",
+    "    proj=\"CAR\",\n",
+    "    axes=[energy_axis],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the source model - Use a pointsource + integrated power law model to directly get flux\n",
+    "\n",
+    "spatial_model = SkyPointSource(lon_0=src.ra, lat_0=src.dec, frame=\"icrs\")\n",
+    "spectral_model = PowerLaw2(\n",
+    "    emin=emin, emax=emax, index=2.0, amplitude=\"3e-10 cm-2 s-1\"\n",
+    ")\n",
+    "sky_model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)\n",
+    "sky_model.parameters[\"index\"].frozen = True\n",
+    "sky_model.parameters[\"lon_0\"].frozen = True\n",
+    "sky_model.parameters[\"lat_0\"].frozen = True\n",
+    "sky_model.parameters[\"amplitude\"].min = 0.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = CircleSkyRegion(center=src, radius=0.6 * u.deg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# psf_kernel and MapMaker for each segment\n",
+    "def make_maps(observations):\n",
+    "    maker = MapMaker(geom, offset_max=2.0 * u.deg)\n",
+    "    spectrum = PowerLaw2(index=2)\n",
+    "    maps2D = maker.run_images(observations, spectrum=spectrum, keepdims=True)\n",
+    "    geom2d = maps2D[\"exposure\"].geom\n",
+    "    \n",
+    "    table_psf = make_mean_psf(observations,src)\n",
+    "\n",
+    "    table_psf_2d = table_psf.table_psf_in_energy_band(\n",
+    "    (emin, emax), spectrum=spectrum)\n",
+    "\n",
+    "    # PSF kernel used for the model convolution\n",
+    "    psf_kernel = PSFKernel.from_table_psf(\n",
+    "        table_psf_2d, geom2d, max_radius=\"0.3 deg\"\n",
+    "        )\n",
+    "    \n",
+    "    return maps2D, psf_kernel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Choose the time binning - PKS flare example\n",
+    "\n",
+    "From the DR1 paper, we can see that the flare runs are taken on the night 2006-07-29 - 2006-07-30.\n",
+    "We make 5 min bins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_start = Time(\"2006-07-29 20:00:00.000\")\n",
+    "time_stop = Time(\"2006-07-30 06:00:00.00\")\n",
+    "time_step = 5.0 * u.min\n",
+    "time_0 = time_start"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10min 27s, sys: 32.1 s, total: 10min 59s\n",
+      "Wall time: 3min 57s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "\n",
+    "map_segments = []\n",
+    "psf_segments = []\n",
+    "\n",
+    "mjd = []\n",
+    "while time_start<time_stop:\n",
+    "    \n",
+    "    # get smaller observation lists\n",
+    "    t2 = time_start+time_step\n",
+    "    time_interval = Time([time_start.value, t2.value])\n",
+    "    obs = mylist.select_time(time_interval)\n",
+    "    \n",
+    "    \n",
+    "    #Proceed with further analysis only if there are observations in the selected time window\n",
+    "    if len(obs) > 0: \n",
+    "        \n",
+    "        maps, psf = make_maps(obs)\n",
+    "        map_segments.append(maps)\n",
+    "        psf_segments.append(psf)\n",
+    "        \n",
+    "        mjd.append((time_start+time_step/2.0).mjd)\n",
+    "    time_start = t2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Quick look excess\n",
+    "excess_counts = []\n",
+    "excess_err = []\n",
+    "for amap in map_segments:\n",
+    "    excess = amap['counts'] - amap['background']\n",
+    "    mask = amap['counts'].geom.region_mask([region])\n",
+    "    excess = excess * mask\n",
+    "    c_err = np.sqrt((amap['counts']*mask).data.sum())\n",
+    "    b_err = np.sqrt((amap['background']*mask).data.sum())\n",
+    "    excess_counts.append(excess.data.sum())\n",
+    "    excess_err.append(c_err+b_err)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0,0.5,'Excess counts')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZAAAAEKCAYAAAA8QgPpAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3X20XHV97/H395w8nRsiJ3AChZOkiTQXtT4kNCIp97oskQfRSkpBwNuClDZ0SVm2Khjqvct61+0FxRarbSlRbLHthVCKEAUFmoguKRCCCUFFmvAgeaCSSBIhHvJ0vvePvedkss/eM3se9uy9Zz6vtc7KzJ49M99zMjPf+f2+vwdzd0RERBrVl3cAIiJSTkogIiLSFCUQERFpihKIiIg0RQlERESaogQiIiJNUQIREZGmKIGIiEhTlEBERKQpE/IOIEtDQ0M+Z86cvMMQESmVxx9/fIe7z6h3XlcnkDlz5rB27dq8wxARKRUz+0ma89SFJSIiTVECERGRpuSaQMxs0MzuMLMfm9lTZrbIzI4yswfMbGP47/TwXDOzL5jZJjPbYGYn5Rm7iEivy7sF8lfAt9z9DcDbgKeAZcAqd58HrAqvA7wHmBf+LAVu7Hy4IiJSkVsCMbPXAe8EbgZw933uvgs4B7glPO0WYEl4+Rzgqx54BBg0s+M6HLaIiITybIG8HtgO/L2ZrTOzL5vZVOBYd38RIPz3mPD8YWBz1f23hMdERCQHeSaQCcBJwI3uvgDYw6HuqjgWc2zcdopmttTM1prZ2u3bt7cnUhERGSfPBLIF2OLuj4bX7yBIKD+tdE2F/75Udf6sqvvPBLZFH9Tdl7v7QndfOGNG3XkwIiLSpNwSiLv/J7DZzE4MDy0GfgSsBC4Jj10C3B1eXglcHI7GOgXYXenqkmxccNPDXHDTw3mHISIFlfdM9CuBfzazScCzwKUESe12M7sMeAE4Pzz3XuBsYBPwi/BcERHJSa4JxN3XAwtjblocc64DV2QelIiIpJL3PBARESkpJRAREWmKEoiIiDRFCURERJqiBCJdQUOORTpPCURERJqiBCKx7lq3lXUv7OLR517m1OtWc9e6rXmHJCIFowQi49y1bivX3Pkk+w6OArB11wjX3PmkkoiIHEYJRMa5/r6nGdl/8LBjI/sPcv19T+cUkYgUkRKIjLNt10hDx0WkNymB9KB6I5aOHxxo6LiI9CYlEBnnqjNPZGBi/2HHBib2c9WZJybcQ0R6Ud6r8UoBLVkQbPR49R0b2HdwlOHBAa4688Sx4yIioAQiCZYsGObWNS8AsOLyRTlHU1tlyPG+g6Ocet1qJTuRDlEXlpSahhyL5EctkB5RKZoXvTWRVuX32bJzJHHIsVohItlSC0RKTUOORfKjBCKlpiHHIvlRAukx3bbGlYYci+RHNZAuFq177Hhlb2zBGShtvUBDjkXyowTSQzbvHBlLHhW1Cs5lKbiXacixSDfJtQvLzJ43syfNbL2ZrQ2PHWVmD5jZxvDf6eFxM7MvmNkmM9tgZiflGXsZRZNHRTMFZ23gJCJFqIH8hrvPd/eF4fVlwCp3nwesCq8DvAeYF/4sBW7seKQlN6k//r9bBWcRaUYREkjUOcAt4eVbgCVVx7/qgUeAQTM7Lo8Ay6Z6prZFbitjwblsAwHUWpNulXcCceB+M3vczJaGx4519xcBwn+PCY8PA5ur7rslPCY1RAvnXnXb8OAA1577llIVnJNmnu94ZW/OkYn0nryL6Ke6+zYzOwZ4wMx+XOPc6JdnOPzzMDgpSERLAWbPnt2eKEssrnAOQXfWQ8tOyyGi1iRtdrV55whD0ybnFJVIb8q1BeLu28J/XwK+BpwM/LTSNRX++1J4+hZgVtXdZwLbYh5zubsvdPeFM2bMyDL8UkgqnCcdL7qkgn9Zfx+RMsstgZjZVDObVrkMnAH8AFgJXBKedglwd3h5JXBxOBrrFGB3patLxqvUCZIkFdTz0EiNIKngPzw4oCG8Ih2W56fIscD3zOwJYA1wj7t/C7gOON3MNgKnh9cB7gWeBTYBXwI+3PmQyyFaJ4jqM5g1vZwjrzTzXKQ4cquBuPuzwNtijv8MWBxz3IErOhBa6cXVCSqGBweYMqGvpXpBnvtvaOa5SHEUpx9D2qbWxMCHlp3WcvLIe/+NJQuGWTB7kHfMPYqHlp2m5CGSEyWQLpRUJ2hH3SNpFNT19z3d8mN3o7LNWRFphBJIF4qrE7Sr7lGG/TeKMnGvCK01kSzlPQ9EMhBXJ6iue7QyWun4wQG2xiQLLYcyXq3WmrrdpBuoBdKlonWCdk2y68QoqKK0IFpVhtaaSCuUQKQhSxYMc+25bxmrp7S6HEo31wi0W6J0OyUQaVi7RkF1+7pWmrMi3U41kB5RhFna0R0SW1nXqgi/Tz2asyLdTglEDhP9kM9SL6xrpd0SpZupC0tyk+V8FRHJnt6pkpukGkEr81W6uSgvUjTqwupi7ewyyaJrK6lGUOnyaVRSUb76uUSkfdQCkZa1Mm8jOqILaLoFoWVWRDpLLRBpShYF4VZbEJq4J9JZaoFIYbTagtDEPZHOUgKRMVkWoNM8dqstiKJO3Ftx+SIN4ZWupAQiQLYrx6Z97FZbEO1eZkVEalMCESDbAnTax25HC0KbTYl0joroAtTuPmp1C9t6XVPR7h0t/SFSDkogAiTv83HkwMSW51Y0soeIlv4QKQ91YQmQ3H1kRs3upzTF8aIWt/PQLXudiEABEoiZ9ZvZOjP7Rnh9rpk9amYbzWyFmU0Kj08Or28Kb5+TZ9zdJqkAvesX+2PPr3RtpSmOq7gt0p1yTyDAR4Cnqq5/BrjB3ecBO4HLwuOXATvd/VeAG8LzpEqr327jCtC1RkY1UniPPvata17QN3GRkss1gZjZTOC9wJfD6wacBtwRnnILsCS8fE54nfD2xeH5kqFa3U+a+d2b1A0nFXkX0T8PXA1MC68fDexy9wPh9S1ApZ9jGNgM4O4HzGx3eP6OzoXbe2ptinT9fU+nLo53korvIp2RWwvEzN4HvOTuj1cfjjnVU9xW/bhLzWytma3dvn17GyKVpLkVKo6L9LY8WyCnAu83s7OBKcDrCFokg2Y2IWyFzAS2hedvAWYBW8xsAnAk8HL0Qd19ObAcYOHCheMSjLRPVlu2qgUhUg65tUDc/Rp3n+nuc4ALgdXu/j+AbwPnhaddAtwdXl4ZXie8fbW7K0HkTDO/09NmV9Jt8q6BxPkEcJuZ/R9gHXBzePxm4B/NbBNBy+PCnOKTJvVyy6LRpeo7uTe9SLMKkUDc/UHgwfDys8DJMee8Bpzf0cBKpNXlRio68YHVrljLpNaQ527/3aV7FWEeiLSo1ZV0sxqWGfe4Wa762wnN/q26ZcizuuGkmhJIFyjTVq5lirWdOr3ZVRZfCsqe/KX9GkogZjbdzN6aVTDSnE58u23Xpkjd8k28Ud0w5LlXk78kq1sDMbMHgfeH564HtpvZd9z9oxnHJik1stptFhpJLHnHmpeshjx3Uq8mf0mWpgVypLv/HDgX+Ht3/zXg3dmGJY0o07fbMsXabvWGPOe9REi959ee8xKVJoFMMLPjgA8A38g4HmlCmVa7LVOseSliofqCmx5myoS+nk3+Ei/NMN5PA/cB33P3x8zs9cDGbMOSRjW7EVMeQ2obibUI8yE6GcOOV/a2vIFXVoamTebKxfNK3Q0n7ZWmBfKiu7/V3T8MY/M0/jLbsKQTshxVU8Rv0a3qxO+0eedIoQvVWnlAqqVJIF9MeUxKJqtRNVklpjxrBEktg3YnkcrjRzVSqO7G5C3FlNiFZWaLgF8HZphZ9Yir1wH98feSMslqVE03zrrevHNk3Id7Fr/TpP6+2CSStlDd6JIpIq2oVQOZBBwRnjOt6vjPObTYoZRYVkNqu3G4ZztaBlC/jjJr+gDbdr92WAJupFDdjclbiisxgbj7d4DvmNk/uPtPOhiTdMhVZ57INXc+2fSHVZJunOuR1DKY2N+exRyqBzMMDkxk/8FRDox6w4XqZpN3L65PJq1L8+qfbGbLzex+M1td+ck8MslcVkNqyzjXo159Zdb0gXG/U58Fx1sV7XbaNbKfUXdOGJracKE6KUlP7O8b+/2iv2u9mlW0prLjlb1N/Z7SfdIM4/0X4O8I9i0/WOdcyVEzw0ybHf5b7zGh9qzrNM8V/VY8ZUIfQ9MmNxRLM0Nwq+9Tq2XQTDxxz7MlZuTVqAd1l0YltSqPP3JK4n2Sur2uvmMDX1y1kW27XzssuQxM7OfKxfMajk26T5oWyAF3v9Hd17j745WfzCOTUqp8u211uGfct+Jnduzp6Miiei2DVpJHtaTupaS6Sy1JrcpasdZ6/qIPK5Z8pUkgXzezD5vZcWZ2VOUn88ikp8V9K67o1CqwcTE02zKoJanbaVKT9ZVGk3et52/X4AHpTmleoZcAVwH/Djwe/qzNMiiReh9QnfgW3M6WQS1xNaN21Veaff6Bif3Mmj6QmMTKPCBC2qduDcTd53YiEGlOEZb6yELSSK5qWX8LToqh2ZZBkriaUav1lVaf/6ozTxyrjbUyrFi6W5rl3C+OO+7uX21/OJKHIiafuGJwVNbfguNiqLQM2j3sNYvBDHGS4o57/lvXvKD1r6SmNKOw3l51eQqwGPg+oAQiNbXyQRj9VmyAV93ezm/BSaO9kloGQKlme1f/fmuee3ns75g27k4lNymfum1xd7+y6ucPgAUEs9RFDtPuNZiqi8E3XDC/4fkqaeKpN9oLOKwgverj7+K1A6Mtj0zq1HpV0d/PI7cnxa25H5JGmhZI1C+AlgeBm9kU4LvA5DCOO9z9U2Y2F7gNOIqgpfO77r7PzCYTtHp+DfgZcIG7P99qHNIeWa/B1Oi34LTxpBntdfyRUw6rR7S6VEtSbNHnaUXlb3TqdatrdgPC+Ljj4uuztoQlXaZuC8TMvm5mK8Ofe4Cngbvb8Nx7gdPc/W3AfOAsMzsF+Axwg7vPA3YCl4XnXwbsdPdfAW4Iz5OCKNp+2WnjSTPaKzpst9Wd+ZJia/fwYEiX1KLLsXRq+LKUX5rhJJ8D/iL8+b/AO919WatP7IFXw6sTwx8HTgPuCI/fAiwJL58TXie8fbGZ6XtRQRRtAcW08aT50I8O2211qZZ2Dg9udhvairjhwo3Gl/dWvJKfNDWQ7wA/JliRdzqwr11Pbmb9ZrYeeAl4AHgG2OXuB8JTtgCV/oZhYHMY0wFgN3B0u2IpoyLt+1C0/bLTxhOXDKKiw3ZbXUMsKbbhwYG2F6lr/X7DgwPMPXrqWLfZissXseLyRW2f2CjdK00X1geANcD5BPuiP2pmbVnO3d0Puvt8YCZwMvDGuNMqodS4rTrepWa21szWbt++vR1hFlKWuwk2I6sFFCsfalnFE00G0RdZZUJdVCtLtXRyscm4ZHfC0NSxuONqLknxffa8t7Y9Pim3NEX0TwJvd/eXAMxsBvBvHOpmapm77zKzB4FTgEEzmxC2MmYC28LTtgCzgC1mNgE4Eng55rGWA8sBFi5cOC7BdIui7fuQZgHFosZTXaC/6OTZmf8Orf6tkiaPJh2PDkCo193Urv/Lbp3kKoekSSB9leQR+hnpaic1hYlof5g8BoB3ExTGv02wYdVtBMuoVAr2K8PrD4e3r3b3rk0Q9RSt5gDZzxdo9DGbiadTcx6KPrei6PFJMaRJBN8ys/vM7ENm9iHgHuCbbXju44Bvm9kG4DHgAXf/BvAJ4KNmtomgxnFzeP7NwNHh8Y8CLRfyy6xoNQcpnyLV0KSc0qyFdZWZnQv8N4Iu4uXu/rVWn9jdNxBMSowef5agHhI9/hpBHUbIbjfBbqYulUN2vLK3LfN2tJNhb0uzFtZc4F53vzO8PmBmczSJL1v1PuyKVnOQzmtlw63NO0fGDctttIaW9eRRKb60OxL+etX1g+Gxt8efLlmISyjqp85Xnn/zuBZE2tniKy5fxNxl98Te1kgNrWgDOaTz0iSQCe4+NvcjXFZEa2FJrKIlsrTxFC3uJNWtjqhRh2d27IntSor+fklL1TdSQ2tkIIe6D7tTmgSy3cze7+4rAczsHGBHtmGJ5KdTH3KNPk+0yyhJmq6kNDW0evHVSkLt2M9eii/NKKw/BP7UzF4wsxcIRkktzTYsEYmqtfBjVL11yFqdTQ/JEw5/4w0zxnWvPfezPVrRtwulGYX1DHCKmR0BmLu/kn1YIu3VDaOFGp3jU+/8VmtoSQM5tBhj70i9nHvVwodSIOpTrq9bRgul2eY3en7W4pLQn6xYH3tuu/eSl/xpdbQC0gSv9iraUvPNiusy6jM45ohJHVtbKw0txtg79D9aMHHflq/6lyd4/Cc7lVCaVMRlX5oRV7eYe/RU5s44ouV6RjslrQBc6T7U67d7pFmN93wzmxZe/p9mdqeZnZR9aL0p7tvy/lHnwGiw7Ffeq+6WUTct+xJdBbgysqmV1YGziDFphWO9frtLmhbI/3L3V8zsvwFnEmzqdGO2YfWuNN+Ky9j9kqdOLp9eNs0ul19PJaFN6u9LvQ+7lE+aBFL5Ovxe4EZ3vxvQRMKMpP1WXLbulzy1Y8iqNCepcK7Xb3dIMwprq5ndRLjcuplNRrWTzMRN8IpTxu6XPGnZl+zU+ntO6u+LTSJ6/XaHNAnkA8BZwOfCvTuOA67KNqzeFR1bPzgwkT37DrD/4KGOAHW/SEXRk+Gs6QNs2/2aVo3uUmlaEscB97j7RjN7F8GS6msyjarHVRdE13/qDK4/723qfpExWdUtsjA0bbK6D7tYmhbIvwILzexXCDZ1Wgn8P+DsLAOTQ9T9ImkU9bWh12/3SpNARt39QLip1Ofd/Ytmti7rwESk3JQsul+aBLLfzC4CLgZ+Mzw2MbuQRLKhDzSR9kpTA7kUWAT8ubs/F+5Q+E/ZhiUiIkWXZjXeH5nZJ4DZ4fXngOuyDqzX6duyiBRdmj3RfxP4HMHkwblmNh/43+7+/qyDk0OUUESkaNJ0Yf0ZcDKwC8Dd1wNzW31iM5tlZt82s6fM7Idm9pHw+FFm9oCZbQz/nR4eNzP7gpltMrMNWo9LpDzaMfT4gpseHtsaV4ohTQI54O67I8eiy9s04wDwMXd/I3AKcIWZvQlYBqxy93nAqvA6wHuAeeHPUrQel0jXUZIolzQJ5Adm9kGg38zmmdkXgX9v9Ynd/UV3/354+RXgKWAYOIdgwUbCf5eEl88BvuqBR4DBcFa8iJSMEkV3SJNArgR+FdhLMIFwN/DH7QzCzOYAC4BHgWPd/UUIkgxwTHjaMLC56m5bwmMiIpKDNKOwfgF8Mvxpu3Cv9X8F/tjdf25miafGhRfzeEsJuriYPXt2u8IUEZGINBtKPWBmg1XXp5vZfe14cjObSJA8/tnd7wwP/7TSNRX++1J4fAswq+ruM4Ft0cd09+XuvtDdF86YMaMdYYpIhtSdVV5purCG3H1X5Yq77+RQt1LTLGhq3Aw85e5/WXXTSuCS8PIlwN1Vxy8OR2OdAuyudHWJdLMyfcBmFetd67ay7oVd2ta5YNIkkFEzG+sLMrNfpj2jsE4Ffhc4zczWhz9nE0xSPN3MNgKnc2jS4r3As8Am4EvAh9sQg4gURFKSuGvdVq6588mxfUW0LW5xpFkL65PA98zsO+H1dxLWGFrh7t8jvq4BsDjmfAeuaPV5RSoq35Q1SbOzKoli38FRTr1uNVMmBN9j45IEwPX3PT1ug7XKtrhaFj5faYro3won7Z1C8IH/J+6+I/PIepA+0KTbxbUm+gz6zDgwenjHRiVJJG1/q21x85emiH6Zu+9w92+4+9eBnWb2qQ7EJiJdJq41MeqMSx4V23aNJG5/q21x85emBrLYzO41s+PM7M3AI8C0jOMSEcpVPE4Ta6OthuMHB7jqzBMZmNh/2PG02+KWaQBCGaXpwvqgmV0APAn8ArjI3R/KPDKRHpdUPAYK1/efNtbjBwfYmjKJVJJE5f5X37GBfQdHGQ6TSuW4un7zk6YLax7wEYL5Gs8Dv2tm/yXjuEQyVYZv9rWKx0WTNta41kSc6N7pSxYMs2D2IO+YexQPLTuNW9e8oJZFAaQZhfV14Ap3XxXO3fgo8BjB8ibSJtGRKdXfsKL0jas1ZflmX6bicdpYo62JJA8tO619wUlm0tRATnb3VRAMpXX3v+DQAofSBhrn3lll+WZfpuJxI7FWWhOT+uM/fpKOS/Ek/k+Z2dUA4fpU50duvjTTqLpctLBXlg+0blGWb/atFI87rZlYZ00fGHefPguOSznUSvUXVl2+JnLbWRnE0pMuuOnhxKJi0T7QukVZvtkvWTDMtee+ZewbebQuUCTNxDo0bfK4+8w9eipD0ya3JaYy1LnKrlYNxBIux12XFkzq74vtD477QGukViLxrjrzRK6588nDWn1F/Wa/ZMEwt655ASh+zauZWKP3qVUYrzxm9Xtg/qfv59W9Bzgw6oe9H8pS5yq7WgnEEy7HXZcWzJo+wLbdr9X9QNOboj3qDQuV/NRLPNH3wK6R/WO3afmTzquVQN5mZj8naG0MhJcJr0/JPLIeMjRtMlcunlf3A01vivYp0zf7btTs3zzuPVBNy590VmICcff6g7WlbdJ8oOlNIb0uzWu9svxJXG2xaHWuskszD0TaqFb/7ZQJfTULiHpT9KYytZCaibWR+6SZyV5Z/qQsda4y04DrDorrv60sIrd11wjP/WwPO17Zm3j/Mg3rFMlCvZns1cuflGUEW5mpBdJB9fpvRx0270z+dqXib3uV6Zu9BKLvgcGBiWOt+Oj7QXWu7CmBdFCa/ttayzuA3hQiSUN/9X7oPHVhdVCaWsWw6hkiUhJKIB2Utv9WRKQM1IXVQY3039aiprpIsuouLb1XsqUE0mHqvxVpL7138pNrAjGzrwDvA15y9zeHx44CVgBzCDaw+oC77wz3Ivkr4GyCnRE/5O7fzyNuEcmXkkYx5F0D+QfGr+y7DFjl7vOAVeF1gPcA88KfpcCNHYpRRERi5JpA3P27wMuRw+cAt4SXb+HQ5lXnAF8NN7V6BBg0s+M6E6mIdFp03xwpniLWQI519xcB3P1FMzsmPD4MbK46b0t47MUOx9cyNb9FsqHtDjqriAkkSdweJOOWlTezpQRdXMyePTvrmFqmZCLSHtruoPPyroHE+Wmlayr896Xw+BZgVtV5M4Ft0Tu7+3J3X+juC2fMmJF5sCJSDNoauvOKmEBWApeEly8B7q46frEFTgF2V7q6RKS7NLMdrbY76LxcE4iZ3Qo8DJxoZlvM7DLgOuB0M9sInB5eB7gXeBbYBHwJ+HAOIYtIxpK6ouolkUb2uleBvj1yrYG4+0UJNy2OOdeBK7KNSETy1uzOm9oDpPPKVEQXkR7QbFeUtjvoPCUQESmUVnbe1HYHnVXEIrqI9LA8dt5UTaQ5aoFkRIskijQn666ouMmG1fTeTU8JREQKJ6uuqKQRXscfOYWhaZPb9jy9QglERLpKrYSTNMJr884RJZAmKIGISCG1uwvpgpseji3OA+w7ODo2aXHKhD4lk5SUQNpIfacixTapv2+s+yrO1l0j9FWtuqf3dG0ahZWBZpZhEJHszZo+MG6EV9SowzM79nDqdavZ8creDkVWTkogbbbjlb3jinQfvX09iz/3YL6BifSwype6Z3bsYfKEPib0xS3ufbitu0Z47md7lERqUAJps807R8YV6UY9OC4inRcdebVrZD+j7pwwNJXhOpMT9d6tTQmkQdUTjqovV48tj1Or31VEshM38qqSGOImLUbpvZtMCaQNot9wkqgeItJ5SWto7Ts4ypIFw1x77luY1F/7ozDuvZv0ZbKXKIG0Qdw3nDhpl6UWkfZJWkOrkjSWLBhmwexBThiamtga0Xs3nhJIGzSyYY12SBPprKS1tT573lsPOzY0bXLN1sjI/oNcfceGzOIsI80DaUB1nWP+p+/n1b0HODDq9Jtx0Mdtz55IO6SJdE4ja2tVllB59LmXYx+r0k0dXU+revJhL80dUQJJKW4kR0Vc8ugz6DPjwOj429IsSy0i7dPo2lpJEw4n9ffFrqcFh+aO9NJMdiWQlNLWOQCGBweYMiFoBm/b/Zp2SBMpuGhSmTV9YNx7t8+C47U+C6Iz2budaiAppe12esfco3ho2WkMTZs8rk91eHCAa899i3ZIE8nBissXpWp9rLh8Eas+/q5x7925R09laNrkup8FvTR3RC2QlJJ2SatWXXyrfqFqhzSR8qnu9rro5NlcfccGntmxJ1XNs3qvkW7+wqgWSAoX3PQwUyb01ZxwNDCxn1nTVdsQ6TbR5YnSDpipN/S3G+aOlC6BmNlZZva0mW0ys2Wdet5od9TgwMSx9XQqXVNJhbO0TWcRKZ645Ymq1Sp5VIb+lj1RJClVF5aZ9QN/A5wObAEeM7OV7v6jTjx/dCRHdLheNzdVRXpVrRUm3jH3qLHurVaWMSrr0N+ytUBOBja5+7Puvg+4DTin3U9y17qtnHrdauYuu0dLOov0sBWXL0pccDE6kz1pAmK9ZVLKrGy/2TCwuer6lvBY21TGeG/dNYIT9GM+s2PP2N4eSiYivaXWTPbqFkPcXiNJtdHqPYPmf/p+Hv/JzlLuH1SqLiziuxsPq2iZ2VJgKcDs2bMbfoJ6Y7wHJvZz5eJ5QPmamyLSuLQz2YemTebKxfMOO+833jCD2x/bMjbJsDIHLGlScqXw/sVVGxmaNrnwnzFlSyBbgFlV12cC26pPcPflwHKAhQsXpl9fJFRvjHdlLSvVO0R6R72Z7HHD9i86efa4GevX3PkkUyb21SzKj+w/yOadIy3NZu9UTaVsXViPAfPMbK6ZTQIuBFa28wnSLDOitaxEpJ643oyR/QfZ+Yv9Cfc4JKnwnmbobye31C5VAnH3A8AfAfcBTwG3u/sP2/kcaTaY0VpWIlJPq180m0kAcet0ZbkMfdm6sHD3e4F7s3r8StfU9fc9zdZdIxiHF1m0lpVIb0rbHVQ579TrVseuXtFvMGlCf0N7CEH9aQIX3PRw7K6oWXa7l6oF0ilLFgzz0LLTeP6693LDBfO1lpWINCypN+Ogw+QJfWMTkasnJffb+HFClQSQpmsqqesrq2730rVAOq2LUZduAAAKKklEQVTRZaBFRGD86K3q3oxdI/vpMzhhaCqrPv6usbrGmoR9SCotkWjXVPXzQPIy9Fl1u6sFIiKSkepJhtEhodWr9laWO6r1QR9XkI/ukJg0FyWrbnclEBGRjKVd5iSu26vW/iLRHRKf2bHnsO6xrLvd1YWVgrquRKQVSV1L0WVSot1egwMTeXXvAUYTVgCO2yFx18h+Bib287nzs6/XqgUiIpKhFZcv4rPnvTV111Kl2+uEoansPTAauy12xb6Do3zs9idiu7euv+/p9vwCNagFIiKSsbTLoVTbvHMkseuruiCftD9JJyY8K4GIiHRAoyM6ay0Dn2aNpk5MeFYXlohIwdRaRj6NTk14VgIRESmgpBFZE2oNy6KzE57VhSUi0iGNjOhMqptAsBx8deF8YGI/xx85peNLwCuBiIgUVK26STSxVM7rJCUQEZGSiUsseazRpxqIiIg0RS0QEZECK/JKGEogIiIlVITEoi4sERFpihKIiIg0RQlERESaogQiIiJNUQIREZGm5JJAzOx8M/uhmY2a2cLIbdeY2SYze9rMzqw6flZ4bJOZLet81CIiUi2vFsgPgHOB71YfNLM3ARcCvwqcBfytmfWbWT/wN8B7gDcBF4XniohITnKZB+LuTwGYjVtV8hzgNnffCzxnZpuAk8PbNrn7s+H9bgvP/VFnIhYRkaii1UCGgc1V17eEx5KOi4hITjJrgZjZvwG/FHPTJ9397qS7xRxz4hNd7KZcZrYUWBpefdXMWt0YeAjY0eJj5EWx50Ox50Oxt88vpzkpswTi7u9u4m5bgFlV12cC28LLScejz7scWN7Ec8cys7XuvrD+mcWj2POh2POh2DuvaF1YK4ELzWyymc0F5gFrgMeAeWY218wmERTaV+YYp4hIz8uliG5mvwV8EZgB3GNm6939THf/oZndTlAcPwBc4e4Hw/v8EXAf0A98xd1/mEfsIiISyGsU1teAryXc9ufAn8ccvxe4N+PQ4rStOywHij0fij0fir3DzD22Fi0iIlJT0WogIiJSEj2bQMzseTN70szWm9namNuPNLOvm9kT4bIrl1bddjC833oz63gxP0Xs083sa2a2wczWmNmbq27LfUmYFuOved+smdmgmd1hZj82s6fMbFHkdjOzL4R/3w1mdlLVbZeY2cbw55KSxZ73a75e7G8ws4fNbK+ZfTxyW66v+RZjz/X1Xpe79+QP8DwwVOP2PwU+E16eAbwMTAqvv1rw2K8HPhVefgOwKrzcDzwDvB6YBDwBvKks8ae5bwdivwX4/fDyJGAwcvvZwDcJ5jSdAjwaHj8KeDb8d3p4eXoZYg9vy/s1Xy/2Y4C3E9RPP151PPfXfLOxh7fl+nqv99OzLZAUHJhmwXorRxAkkAP5hpTam4BVAO7+Y2COmR1LsCzMJnd/1t33AZUlYYomKf5cmdnrgHcCNwO4+z533xU57Rzgqx54BBg0s+OAM4EH3P1ld98JPECw3lsZYs9Vmtjd/SV3fwzYH7l7rq/5FmMvvF5OIA7cb2aPh7PXo/4aeCPBhMUngY+4+2h42xQzW2tmj5jZkg7FW61e7E8QLFaJmZ1MMKt0JsVZEqbZ+NPcN0uvB7YDf29m68zsy2Y2NXJOUZfjaSV2yPc1nyb2JGX4u9eS5+u9rl5OIKe6+0kEK/xeYWbvjNx+JrAeOB6YD/x1+G0CYLYHs0Y/CHzezE7oVNCherFfB0w3s/XAlcA6gtZT0lIxndZs/Gnum6UJwEnAje6+ANgDRPvUk/7Gef/tW4kd8n3Np4k9SRn+7rXk+Xqvq2cTiLtvC/99iWBOysmRUy4F7gyb85uA5wj646vv+yzwILCgQ2ETef7Y2N395+5+qbvPBy4mqOE8R+2lYjqmhfjT/L9laQuwxd0fDa/fQfDhED0n7m+c99++ldjzfs2nib3WfYv+d0+U8+u9rp5MIGY21cymVS4DZxDsUVLtBWBxeM6xwInAs+EIocnh8SHgVDq4rHya2MNRH5PCq78PfNfdf04BloRpJf6U/2+Zcff/BDab2YnhocWM/79fCVwcjmg6Bdjt7i8SrKJwRvj6mR7Gfl8ZYs/7NZ8y9iS5vuZbiT3v13sqeVfx8/gh6Jd8Ivz5IcEKwQB/CPxhePl44H6C+scPgN8Jj/96eOyJ8N/LChj7ImAj8GPgTqpG+xCMtPkPgpEpnyzo3z42/qT7djj++cBaYANwF8GIqurYjWDzs2fC18fCqvv+HrAp/Lm0LLHn/ZpPGfsvEXzb/zmwK7z8uoK85puKvQiv93o/mokuIiJN6ckuLBERaZ0SiIiINEUJREREmqIEIiIiTVECERHpIDP7MzPbaocWpzw75pwpFiwkWlnM9dNVt51mZt83sx+Y2S1mNiFy37dbsPjleSnj6Q9nyX+j0d9FCUQkA2bmZvaPVdcnmNn2ypvUzD5kZn8dXq7+QNloZnea2Zvyil3ax8zeZWb/EHPTDe4+P/yJ2yhvL3Cau7+NYBjwWWZ2ipn1ESzOeKG7vxn4CTC2srOZ9QOfobE5Rh8Bnmrg/DFKICLZ2AO82cwGwuunA1trnF/5QJkHrABWm9mMrIOUYvLAq+HVieGPA0cDe939P8LbHgB+u+quVwL/CrxU/XhmdpWZPWbBMv3VrZmZwHuBLzcTpxKISHa+SfDmBLgIuDXNndx9BcEk1g9mFJfk74/CD/OvhCsTjBN2La0nSAYPeLAcyg5gopktDE87j3CpFjMbBn4L+LvI45wBzCNYBmU+8GtVa2p9HrgaGKUJSiAi2bkNuNDMpgBvBR6tc3617xOuvSblY2aPhh/+XwbeX1XvOBO4ETiB4MP8ReAv4h7D3Q96sB7cTOBkM3uzBzO/LwRuMLM1wCscWmj088An3P1g5KHOCH/Wceh1Nc/M3ge85O6PN/t7Tqh/iog0w903mNkcgtZHXD93LXGryEpJuPs7IKiBAB9y9w/FnWdmXwJqFq/dfZeZPUiwf8wP3P1h4L+H9z8D+K/hqQuB28wMYAg428wqq3Bf6+43RZ77WoLkdjYwBXidmf2Tu/9O2t9TLRCRbK0EPkfK7qsqC2iysCnFZodv0vVbxCyQaGYzzGwwvDwAvJtgbTjM7Jjw38nAJwi7rNx9rrvPcfc5BKv+ftjd7yIoqP+emR0R3m/YzI5x92vcfWZ4/oXA6kaSB6gFIpK1rxCsavtk+G20LjP7bYIuh49lGZjk5rNmNp+gKP48cDmAmR0PfNndzwaOA24JR1X1Abe7e6WlclXY/dRHsM/I6lpP5u73m9kbgYfD1smrwO8QKbQ3Q4spimTAzF519yMix95FsOf1+8zs94E3uvvHzOzPgD8g2LluKsE30k+6e8eWTBdphhKISA7M7AZgo7v/bd6xiDRLCUSkw8zsm8Ak4Fx33513PCLNUgIREZGmaBSWiIg0RQlERESaogQiIiJNUQIREZGmKIGIiEhTlEBERKQp/x9de2FyMjMD5AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.errorbar(mjd,excess_counts,yerr=excess_err,fmt=\"o\")    \n",
+    "plt.xlabel(\"MJD\")\n",
+    "plt.ylabel(\"Excess counts\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The binning seems reasonable. Now, do a 3D fitting to get proper flux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1min 16s, sys: 2.22 s, total: 1min 18s\n",
+      "Wall time: 19.8 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "flux = []\n",
+    "flux_err = []\n",
+    "for amap,psf in zip(map_segments,psf_segments):\n",
+    "    \n",
+    "    #Copy the source model\n",
+    "    model = sky_model.copy()\n",
+    "    \n",
+    "    # Make the background model\n",
+    "    background_model = BackgroundModel(amap[\"background\"])\n",
+    "    background_model.parameters[\"norm\"].frozen = True\n",
+    "    background_model.parameters[\"tilt\"].frozen = True\n",
+    "          \n",
+    "    #Now fit\n",
+    "    dataset = MapDataset(\n",
+    "        model=model,\n",
+    "        counts=amap[\"counts\"],\n",
+    "        exposure=amap[\"exposure\"],\n",
+    "        background_model=background_model,\n",
+    "        mask_fit=mask,\n",
+    "        psf=psf,\n",
+    "    )\n",
+    "        \n",
+    "    fit = Fit(dataset)\n",
+    "    result = fit.run()\n",
+    "    flux.append(model.parameters['amplitude'].value)\n",
+    "    flux_err.append(result.parameters.error('amplitude'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0,0.5,'flux')"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAERCAYAAAB4jRxOAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJzt3X+UHWWd5/H3tztN0mKwgx2P0iYmsAoqYqI9YMyuA9GZIKwakd2oZ1zH0SX+mJ3REdhw3F1H53jMiKPjzDhjWEV0x8UosDkcBgTWiM6wEUxIICAC8kOg40gCCb9sQtL93T+qblN9U1W37o+6t+rW53VOn9yfVc+9nf7e536f7/M85u6IiEj/G+h1A0REpDsU8EVEKkIBX0SkIhTwRUQqQgFfRKQiFPBFRCqicAHfzC42s0fM7PYOHe8vzez28GdtJ44pIlJGhQv4wCXA6Z04kJmdCbwOWAacApxnZkd14tgiImVTuIDv7j8BHoveZmbHmdkPzGy7mf2zmZ2Q8XCvAn7s7ofc/WngVjr0YSIiUjaFC/gJLgL+i7u/HjgX+PuMz7sVeKuZPc/MRoHTgEU5tVFEpNDm9LoBjZjZ84E3At83s9rNc8P7zgI+G/O0CXdf7e7XmdnvAP8P2ANsBQ7l32oRkeKxIq6lY2ZLgKvc/cQw536Xu7+kA8f938A/uvvV7R5LRKRsCp/ScfcngPvN7D8AWOC1WZ5rZoNm9sLw8knAScB1uTVWRKTACtfDN7NLgVOBUeA3wKeBLcA/AC8BhoDvuntcKqf+WPOAW8KrTwAfdvedOTRbRKTwChfwRUQkH4VP6YiISGcUqkpndHTUlyxZ0utmiIiUxvbt2/e6+8Isjy1UwF+yZAnbtm3rdTNERErDzH6V9bFK6YiIVIQCvohIRSjgi4hUhAK+iEhFKOCLiFSEAr6ISEUo4IuIVIQCvohIRSjgl8zajVtZu3Frr5shIiWkgC8iUhEK+CIiFaGALyJSEQr4fUK5fRFpRAFfRKQiFPBFRCpCAb9ENu+YYMeD+7np/sdYuWELm3dM9LpJIlIiCvglsXnHBBdcsYtnp6YBmNg/yQVX7FLQF5HMCrXjlSS78Nq7mDw4Neu2yYNTXHjtXQDseHA/z05Ns3LDFs5bfTxrlo/1opkiUmDq4ZfE7v2TsbfXevrq+YtII+rhF1yt1PKYkWEmYoL+oFliz1+9fBGJUg+/JM5bfTzDQ4OzbhseGmTKPfbxSd8IRKS6cg/4ZjZoZjvM7Kq8z9XP1iwf4/NnvYYjBoNf2djIMJ8/6zWMjQzHPv6YhNtFpLq6kdL5U+BO4KgunKuvrVk+xqU3PwjApnUrZm6/4Ipds9I6w0ODnLf6+K63T0SKLdcevpm9FDgT+Hqe56mypJ6/8vciUi/vHv5fA+cD85MeYGbnAOcALF68OOfmlEttolW03DJOUs9fRCQqtx6+mf174BF33572OHe/yN3H3X184cKFeTWndJImWu198kCPWyYiZZVnD38l8HYzOwOYBxxlZv/o7n+Q4zn7wtqNW2d69lGTB6d4aN8ko/Pn9qhlIlJmufXw3f0Cd3+puy8B3g1sUbDPrj7YN7pdRKQRTbwqqCMGB2KDe21wtp5y9yLSSFcCvrvfANzQjXOVVW1GbS1wL1owzO7Hnzms3FIVOCLSKs20LajR+XNVbikiHaWUTsFESzEf3jfJogXDjM6fq5SNiLRNAb9A9j554LBSzAHrcaNEpG8o4BfIQ/smDxuonfbgdhGRdimHXwDRNE4clWKKSCco4PdY/YzaOEkrYoqINEMBv8fiti6MSlv5cu3GrTPlnCIijSiH32NpG5WMjQxrf1oR6RgF/B5L2rrwiMEBbly/qgctEpF+pZROj8VtXThgwUzbfqVUlEhvqIffY7V0zfmX3cazU9OMjQwzb86AVsQUkY5TD78A1iwfY/niEU5ZejQ3rl+VKdjXSjlvuv8xVm7YwuYdE11oqYiUmXr4BdRoGYWkzVEADfCKSCL18EsorpRz8uAUF157V49alJ2+mYj0jgJ+CSWVcqaVeBZB0jcTBX2R7lBKpyCaWQ0zqZTzmILPyE37ZqJUlEj+1MMvobhSzrQZuUVR1m8mIv1CAb+E1iwfa2pzlKLUvSd9Ayn6NxORfqGAX1L1pZxlSImU9ZuJSL9QDl+6Jm6SmdYKEukeBXzpqjXLx7j05geB5gaqRaR9Sun0OdW9i0iNevglphm5ItIMBfw+1qjuvVa50+3UilI5Ir2hlE4fU927iEQp4PexItW9F2UugEiVKeD3MdW9i0iUcvh9LI+6917l/UWkfQr4fa4Ide+10tBnp6ZZuWGLJluJ9IhSOhXVrfp8LYksUhwK+BXUzSBc5s1aRPqNUjoVEE3lrN24dSa9EjV5cIrzL7uNS29+MDH100pqRqWhIsWhHn4F1Qf7RrdD698KilQaKlJ1CvgVVFtHP+vt0HpqRqWhIsWhgF9BixYMxwbhRQuSe91JKZiJ/ZOpE6qa3axFRPKjHH6FRHPwI8NDHJya5tC0MzYyzGknLOR7P3uYe/c+zcoNW5g3Z4DR+XNn8vlJ++imfSuoKUJpqIjk2MM3s3lmdrOZ3Wpmd5jZZ/I6V1nludxA/bHrc/D7Jw8y7c5xo0dy3urjuXz7xKz8/P2PPs3eJw/MPD8pNZP2raCMtASE9LM8UzoHgFXu/lpgGXC6mb0hx/NJirgc/LTDQ/smU++rSUrNjM6fG3s+BU6R4skt4HvgqfDqUPjjeZ1P0iXl4J+dmk69L6p+H10g8+StTetWxKZz9MEg0j25Dtqa2aCZ7QQeAa5395tiHnOOmW0zs2179uzJszmVETeLNqkM8ojBgdQSyaRArhm0IuWTa8B39yl3Xwa8FDjZzE6MecxF7j7u7uMLFy7MszmFktfSBkmB+LQTFsbm4L9w9kmx+fmapEDejzNotR2k9LuulGW6+37gBuD0bpyv6PLsHScF4h/9Yk9ieWR9fr5eNJDXUjNpZZpZFSnA6huLVEGeVToLzWwkvDwMvAX4RV7nK5M8e8dpSxnU5+CjtfC1+7IeNy1FlCWQFy3A9uM3FpF6efbwXwL8yMxuA35GkMO/KsfzlUae68u0u5RBUi+//vlxaaABg5HhOZkCedECrNb8kSrIs0rnNndf7u4nufuJ7v7ZvM5VNnmuL9PuUgZJs3Drnx9Xprn0hUeyf/JQpkBetACrNX+kCrS0Qg/kub5Mo6UMksoja0bnz828FEJ9imh0/tzEBdiypoR6FWC15o9UgZZW6IE8th6sP34rSxlEHxt9/tqNW1OXTYbnBmCTxKWELrhi16xvA70MsHn/TkSKQAG/R/plfZlN61YcNgBbLyklBMUKsP3yOxFJooAvbYsbgK1JC+QKsCLdpYDfp9oNoM08P22gtbYEg4j0ngJ+D5WhV5tlW8N2lk4umjL8TkRaVb6/SOmarJOjkmrysyyd3KhqSEQ6RwFfEmWdHJVUk5+0dLKI9IZSOpKomclRGoAVKT718CVR0SZHiUh7FPAlkWafivQXpXQkUbOTo5TKESk2BXxJpdx8b9W2f6wtcVG7LNIKpXRERCpCPXxpSD3K8tK3AolSD18kwdqNW2cCpkg/UA9fpKCiy1os+8x1PHXgEIemPXGJC5FG1MPvIvUYJav6ZS32Tx7k0LQD2ff/LdIm8VIMCvgiMXodLNOWnIbG+/8WbZN4KQYFfJE6RQiWWfb2TXtM0TaJl2JQwO8QpWv6RxGCZZblK9IeU7RN4qUYFPC7pNcpAsmuCMEyblmLqEZLXGgdJImjgJ+D+t5+EVIEkl0RgmX9ktMjw0PMGTAgWH7682e9JrVKR+sgSRwF/A6o773vffLArPuLkCKQ7IoSLNcsH2P54hFOWXo0Oz/9+7z+ZQs4ZenR3Lh+VcOSzLg9Chp9SEj/Ux1+m+J672FHDAh6+3Hb/4HyqfWKMiu02UXjikrrIEm9hgHfzF7k7o/U3Xa8u6t7SnzvfdrhoX3PBfMjBgdmPhCilE8trm4Hy05+2BXlg1OKJ0sP/5/N7L+7+/cAzOyTwAeBV+XaspJI6qXXNv2eN2eARQuG2f34M7M+GJRPlSyiQbuVAK6gL1FZcvinAu8zs++b2U+AVwAn59qqEknrpU/sn+T+R58GUD61gTyqmNotlc26wXq752n1tasUWJrVMOC7+6+BHwArgCXAt939qZzbVRqNyudq6Z3oAFyWQbcq6WQVU9mCYKcruFT+K2kaBnwzux44BTgROAP4spl9Me+GlUV9NUScWnqnvnpHAmWuYmo3wHbytav8VxrJktL5qrv/J3ff7+63A28EHs+5XaVS672nBf2J/ZPsfvwZ3nPy4i62rBw6NdEpGnyXfeY6tv9qX6493U4E2FZfe9wHTZYPj7J9A5LOypLS2Vx3/ZC7/0V+TSqvRQuGU9M7Zem1dlsnJjp1YnXJZnWid570GodSOg9JHzQq/5VGsqR0njSzJ8KfZ8xsyszUw48xOn9uw/SO/vgO14mJTu2uLtmsTs2viHvtAxZ0HpIkfdAMmsU+XuW/UtOwLNPd50evm9kaVKVzmGg1x6U3PzizcUU9/fEdrhMTnbIE2aQA3apOzK+Ie+3z5gwwOn9u4nOSXuuUO8NDg4nlv9ENVbSJSjU1vbRCmOJZlUNb+kpceke198narWLKEmTTvnk1Ixo46/vUrfyOo6/9vNXH89C+ydSxh6TXesTgQGL5rwZ0BbKldM6K/JxtZhsA70LbSmvTuhX88NxTVXvfRY3KYxulSbKqD5zRP4R2f8d7nzyQKSinpYGSPjjLXAklnZNlpu3bIpcPAQ8A78ilNX1Ga5k0p/49amaJgPrUyMjw0MwesLXL9+59uu1URtJYwRGDA9y4/vAvvllfw6Z1K1i5YUtiUI62t5NpII0pVUuWHP4HWjmwmS0Cvg28GJgGLnL3r7RyLJEs6j9g127cyt4nD7D78WcOq9ipPb5ZaUtptKuZoBx9re85eTHnX3Zb6gfaMSPDsWMYGlOqlsSAb2Z/k/ZEd/+TBsc+BHzS3W8xs/nAdjO73t1/3kI7RWI16kE/tG/ysGAc12vOeq6hhIHasQ4EzmaD8qZ1KxJz8zD7A+281cdzwRW7tJ5TxaXl8M8CtgP3hf/W/6Ry91+7+y3h5SeBOwElsCWTVmewRte/2bRuBQcTet6tpjKaGYxv9jW0Up6aNTev9fEF0lM6TwA3AFcCp7VzEjNbAiwHboq57xzgHIDFizULVZInFsHsXmuWMsNOpTKi5xoZHuLg1DSHpj2xhDTra4hqpTy11TSQxpSqKS3gf41g0bRjgW2R242gOOHYLCcws+cDlwMfd/cn6u9394uAiwDGx8f7rvpHf1jNS+u11oJfN1MZcbN4BwyOGz2SH557asuvIU6zQVm5eWlGYkrH3f/G3V8JXOzux0Z+lrp71mA/RBDsv+PuV3SozdLnsvRau5nKyLLJTSuvoROaTQNlXfJZ+lOWKp2PtHJgMzPgG8Cd7v6lVo4h1ZSl19rNVEbSuZLGB6C9nnczbeyX7RilO/LcxHwl8D5glZntDH/OyPF80ica9Vpr1TJx0ipaWu3ZtrK4Wzc3QtdeC5JVbpuYu/u/wGEzz0UaytJr7ea2ka2MA3S7593Kh5n2vq2e3AK+SDuS0jDNVst0qi3QfPAuU1WMgn81KOBLabRSLdMpWYO3AqcUmQK+FFZ90EyqlnnmUPvLGuQl+hqK+mGgZZOrQwFfSqPXC4AVLVC3Ixrkb77/sZlVP2vzGf72h/cwOn9uX71mybdKR6SjOrEVYp7SllJod7PzTrczaYlnCOYzpM0xkPJSwJfS6GapY7PSNhiJu+/PvreTN3/xhp60tdF2kBCs/lmEDyfpLKV0pDSKPMmo0czfZmfq5qmZFFi7y0lLsaiHL6VS1ElGaeMLaWvo96IH3WwKTDtj9Q8FfCmdIq4Hkza+kBZge7G3bKPtIONoZ6z+oIAv0gFp4wuNAmy3e9BxC8odN3okpyw9OnEjl6IMjEt7lMOXUihqDXtNlvGF2n1xut2DTpvJrJ2x+pcCvkiHpM3Grd1Xq32vV5QedJEHxqV9CvgiXRLdg7YIPeikb0tlWgNImqOA36Kipxj6ST9N/S9LD1r/r/uTAr4UWit7w/ZSlkCpHrT0iqp0WlCkafL9LutWhmVTxNJS6X8K+E1Km0IvndfrBdNE+okCfpP6tcdZVEVfMK3K1m7cOjOWFXddikcBvwlrN26N3Zga1OPMS5EXTKsypTXLSQG/SUc0uXm2tCduVujnz3pNIQdsqyIprbn3yQM9bpk0oiqdjKKlgcbsNcTV48yXqlqKJSmt+dC+SUbnz+1RqyQL9fAzSNswQj1OqZq01T+V4ik29fAzSNow4ojBAW5cv6oHLaoe9eyL45iR4cSxLCj+XIkqUw+/gbSB2oMJC2GJ9LMsyyurcq2YFPAz0ECtyHPqB9KTqHKteBTwU9QP1EZpoFaqLLrzWNIa+kMNPhCk+/QbSaCBWpFA0oSq2vIQSSmeXm3hKMk0aJtAA7Uih69UOm/OAKPz584aRK9fATRatqwB3GJRDz9BUv5RA7VSFXETrO7d+3Rs6WUtxXPE4MCsb8OgAdwiUQ+/Tu2ra1LpmQZqpSqSvuVCcs+9KFs4Sjz18BNoDRepukZBur7nvmndCg3gFpx+Cwm0hotUXZZvs/UfChrALTYF/BTR0rMb169SsJdKyTLBqv5Dob6jFC1n1t4RvaeAHxG35Kt2JpKqSgvekJzi1ABucSngh7STlcjh1iwf4+7PvZUHNpzJl9cuy5zi3LRuRWJFW9o6PJIvVemE0nayUipHJAj+zfwtpC2ytnLDFs5bfbz+trostx6+mV1sZo+Y2e15naOTtHeqSGeljQHoG3Rv5JnSuQQ4Pcfjd5T2ThXprEaLrCmf3325BXx3/wnwWF7H7zTV3Yt0Xm0AN4m+QXdXzwdtzewcM9tmZtv27NnTs3ao7l4kH2kTsqLfoJMWaZPO6XnAd/eL3H3c3ccXLlzY07ao7l4kH42+QceVREvnqUpHRHJXv6Lm2MjwTJVOUkl09HnSGQr4dTTJSiQfa5aPcenNDwKz/85UEt09uQV8M7sUOBUYNbOHgU+7+zfyOp+IFF99hyptz2gN6HZebgHf3d+T17FFpPxqefskKonuvJ4P2haBqgNEuqs+b19PJdH5qHzAV3WASPelba4yNjLMMS+YN5Pvl86pdMDXgmkivZGUnzfgxvWrGJ0/t7sNqohKB/y06gARyY+WMumNSgd8LZgm0htpE7GUZs1PpQO+ehkivZG0lAmgNGuOKjvxau3GrcybM8Dw0OCstI6qA0S6I259/ZUbtmgSVo4qGfBrXxmfnZpmZHiIg1PTHJr2WdO9RaT7lGbNV+UCfn1lzv7JgwwYHDd6JD8899TeNk6k4pJ2yXJgyfp/UqesTZXL4cdV5kw7PHMofgKIiHRP2i5ZoJx+uyoX8PWVUaS46gdzB80Oe4xKp1vX1wE/bskEVeaIFFt0X4pp99jHNNtB0/Ipgb4N+Em1vNrKUKT4Nq1bwaZ1KxI7Yg6q0W9BXwb8tCUTtJWhSHmk5fSz5vM1kes55glfmXphfHzct23b1tYx1m7cOlNyWW9sZJgb169q6/gi0l2bd0zM7JQVJ+3vutb5q59r00+dPDPb7u7jWR7bVz38aH19HA3MipTPmuVj3P25t3L48G1gYv9kYs9d62XN1jcBv9H62qCBWZEyS/v7TUrvqCpvtr4J+Gnra4MGZkXKrlGNfrTnvnnHBK/41DUkJayrOujbNzNt0z6xx0aGOe2EhZx/2W18fNNOzdYTKaHa3+uF196Vug9ulm/78Ny3guix+13f9PCTvu7Vgvvl2ye0Ap9Iya1ZPsaN61cxljKfptG3/aiq5fP7JuCn1ddr4Eakv6T9vTebn28ln1/WiVx9E/Br9fVjI8MYs+vrNXAj0l/S/t6Tvu3HLdMAzRdzlLmuv29y+BC/vjYkr8Cnqh2R8kr6ez9v9fGxtffvev0Yl2+faGv/i6RJnbX2FF1fBfwkSf8BVLUj0h+ik7PGRoZ51+vH+NEv9rB7/yTHRIo0xl92NBdeexe790/yguEhzOATm3Zy4bV3JRZyRI89aMZU3WTVMm3QUomAX/tFRP9DqEpHpD/E9bov3z4RO5u29q2gfgZuUk+9/tj1wb6mLOnhvltaQUSqZeWGLbEp27QlF5KeE31ureAj7XFZzpW3yi6tICLV00pRRqMe+cT+ST6xaWemYG+kL+9QJAr4IlJqrexxkaVgIy33Uav4scjjyjC/RwFfREqtlT0uGi3TkGZ4aJC/+o+vZWxk+LAPhaLP71HAF5FSS6vJz/qcpBr9emWf31OJKh0R6W9JNflZnxO3bn69+oHZTs3vqc3Y3bRuRVPPa4UCvohUXv3CbNHcPMSniOLm99QGcJd95jrMYP9vD3JMuHhj3LyA6B4eKzdsyb1cXGWZIiJ1Nu+YmJmgdUzKvJ3a4+I+JNKkzfxtdjeuZsoyFfBFRNrUqK4/TtysXWi+pl91+CIiXdTKQG0vZu0q4IuItKmTCzHmuaijAr6ISJvaqeuPyntRx1yrdMzsdOArwCDwdXff0OlzZB1cERHJS7TKJ7oSZ32VTpb1e0pZpWNmg8DdwO8BDwM/A97j7j9Pek6zg7ZxtbOtjHKLiHTD0vX/FFvJY8D9G85s6ZhFGbQ9Gfilu9/n7s8C3wXe0ckTaOtCESmTVtb96aQ8A/4Y8FDk+sPhbbOY2Tlmts3Mtu3Zs6epE5RxarOIVFcr6/50Up4BP25xisO+zbj7Re4+7u7jCxcubOoEvf60FBFpRivr/nRSnoO2DwOLItdfCuzu5Am0daGIlE0r6/50Sp4B/2fAy81sKTABvBt4bydPUD8yriodEZFkuQV8dz9kZn8MXEtQlnmxu9/R6fP08tNSRKRMcq3Dd/ergavzPIeIiGSjmbYiIhWhgC8iUhEK+CIiFaGALyJSEYXaAMXM9gC/avHpo8DeDjanm9T23lDbe6PMbYfitf9l7p5p1mqhAn47zGxb1gWEikZt7w21vTfK3HYod/uV0hERqQgFfBGRiuingH9RrxvQBrW9N9T23ihz26HE7e+bHL6IiKTrpx6+iIikUMAXEamIwgd8MzvdzO4ys1+a2fqY++ea2abw/pvMbEnkvgvC2+8ys9XdbHd4/pbabmZLzGzSzHaGP1/rdtvDdjRq/5vM7BYzO2RmZ9fd934zuyf8eX/3Wj1z/nbaPhV576/sXqtnzt+o7X9mZj83s9vM7Idm9rLIfUV/39PaXvT3/cNmtits37+Y2asi9/U01mTm7oX9IVhW+V7gWOAI4FbgVXWP+SjwtfDyu4FN4eVXhY+fCywNjzNYkrYvAW4vwXu/BDgJ+DZwduT2o4H7wn8XhJcXlKHt4X1PFfx9Pw14Xnj5I5H/N2V432PbXpL3/ajI5bcDPwgv9zTWNPNT9B5+lo3Q3wF8K7x8GfBmM7Pw9u+6+wF3vx/4ZXi8bmmn7UXQsP3u/oC73wZM1z13NXC9uz/m7vuA64HTu9HoUDtt77Usbf+Ru/82vPpTgt3koBzve1Lbey1L25+IXD2S57Zs7XWsyazoAT/LRugzj3H3Q8DjwAszPjdP7bQdYKmZ7TCzH5vZv8u7sTHaef/K8N6nmWdm28zsp2a2prNNa6jZtn8QuKbF53ZaO22HErzvZvYxM7sX+ALwJ808twhy3QClA7JshJ70mEybqOeonbb/Gljs7o+a2euBzWb26roeRt7aef/K8N6nWezuu83sWGCLme1y93s71LZGMrfdzP4AGAd+t9nn5qSdtkMJ3nd3/yrwVTN7L/DfgPdnfW4RFL2Hn2Uj9JnHmNkc4AXAYxmfm6eW2x5+NXwUwN23E+QEX5F7ixPaFmrm/SvDe5/I3XeH/94H3AAs72TjGsjUdjN7C/Ap4O3ufqCZ5+aonbaX4n2P+C5Q+xbS6/c9u14PIqT9EHwDuY9gIKQ2kPLqusd8jNkDn98LL7+a2QMp99HdQdt22r6w1laCQaQJ4OiivfeRx17C4YO29xMMHC4IL3et/W22fQEwN7w8CtxD3eBdr9tOEAjvBV5ed3vh3/eUtpfhfX955PLbgG3h5Z7GmqZeZ68bkOEXcQZwd/if5FPhbZ8l6B0AzAO+TzBQcjNwbOS5nwqfdxfw1rK0HXgXcEf4n+gW4G0Ffe9/h6B38zTwKHBH5Ll/FL6uXwIfKEvbgTcCu8L3fhfwwQK2/f8CvwF2hj9Xluh9j217Sd73r4R/lzuBHxH5QOh1rMn6o6UVREQqoug5fBER6RAFfBGRilDAFxGpCAV8EZGKUMAXEakIBXzBzNzM/lfk+hwz22NmV4XX/9DM/i68/OdmNhGuGHiPmV0RXTWw7rg3hKsHvj3muTvN7Izw9pMjt91qZu+MHONPzex2M7vDzD4ec45zw/aPhtdPNbPHI8f7Hwlte3O4WmZt5cN/U3f/2eFxx8PrQ2b2rXC1xDvN7IJGbUx5vbHHMrN5ZnZz+B7cYWafiRzrG+Htt5nZZWb2/PD22BUck97TBucwM/ucmd0dtqu2dEAqMxsOz/Ns7fcgBdXrulD99P4HeArYAQyH199KUGt8VXj9D4G/Cy//OXBu5LlrgX8FFsYc9wZgPHJ91nMjtz8PmBNefgnwCMFEmBOB22v3E9RwRye/LAKuBX4FjIa3nVprd4PXfDfwyvDyR4FLIvfNB35CsLjXeHjbewkWyKq19wGCFTcT25jyepOOZcDzw9uHgJuAN4TXoys1fglYH3N7dAXHpPc07RwfIFg9dCC8/qKYtl8CnJrwnj5Q+z3op5g/6uFLzTXAmeHl9wCXZnmSu28CriMIYi1x9996sHgcBJPRapNDXgn8NHL/j4F3Rp76ZeB8Wlu3xIGjwssvYPZU+L8gWBzrmbrHHxkugTEMPAs8kaGNSec+7FgeeCp8zFD44/DcSo1mZuFzZt0eOjJye+x7mnYOguWKP+vu0+FjH2nwOqRkFPCl5rvAu81sHsE68Tc18dxbgBMyPvaPw7TExWa2oHajmZ1iZncQzLL8cBisbgfeZGYPlWfMAAADtklEQVQvNLPnEcyErK099HZgwt1vjTnHijBlcY2ZvTqhHR8Crjazh4H3ARvC4y4HFrn7VXWPv4xgVu6vgQeBL7r7Y2ltTHm9ScfCzAbNbCdBj/x6d5/5PZjZNwm+TZ0A/G3k9rgVHJPe07RzHAestWDFymvM7OUJ752UlAK+AODB2vBLCHr3Vzf59Kxr+P8DQVBZRhDs/ipy/pvc/dUESx5cYGbz3P1O4C8J1nX/AcG0+0NhYP0UEJefvwV4mbu/liAobk5oyyeAM9z9pcA3gS+Z2QDBt4ZPxjz+ZGAKOIZgvZRPmtmxSW1s8HpjjxW+D1PuvoxgAa6TzezEyHv0gfA5dxKk0mq3f9XdjwP+K8EKjonvaYNzzAWecfdx4H8CFwOY2eraeABB2ujr4fVmOgVSAAr4EnUl8EUypnMilhMEoVTu/psw2EwTBJTDNokIA+jTBLlx3P0b7v46d38TwSqo9xAE0aXArWb2AEHgusXMXuzuT9RSFu5+NTBUP5BoZguB10Z6tpsI1nKZH573hvC4bwCuDAdu30uQHz8YpjpuJFjeN6mNaa838ViR92E/wRjI6XW3T4XtfVfMWxxdwTHxPU05x8PA5eHl/0PwTQ93v9bdl4UfElcCHwqvnxLTBikwBXyJupggh7sr6xPM7F3A75PhQ8LMXhK5+k6CdAhmtjTMZ2PBHqfHEwwAYmYvCv9dDJwFXOruu9z9Re6+xN2XEASq17n7v5rZi8M8N2Z2MsH/8UfrmrIPeIGZ1Zac/j3gTnd/3N1HI8f9KcHCWdsIUi+rwkqWIwk+DH6R1Ma015t0LDNbaGYj4XOHgbeEt5uFVUTha3tb5NzRtMuZhB82Se9p0jnC528GVoWXf5dgYFv6SNE3QJEucveHCVYErDcHOBC5/gkLNrA4kiCIrXL3PRlO8QUzW0YwSPgAsC68/d8C683sIMGWgx91973hfZeb2QuBg8DHPNi6L83ZwEfM7BAwCbzbPSghMbOrCXqnu83sP4fHnib4APijBsf9KkHq53aCFNY3wzRYWhuTXm/ssczsJOBbZjZI8EH1PXe/Kkw1fcvMjgoffyvBACsEYwRvCc+9j2BDjsT3NOkc4XM2AN8xs08QVG59qMF7IiWj1TKlITP7MnCPu/99k8+7gaAscVsuDZNCCdNg45EPaykYpXQklZldQ5DL/U4LT38MuCSsqJE+ZeHEK4ISz6JtCi8R6uGLiFSEevgiIhWhgC8iUhEK+CIiFaGALyJSEQr4IiIV8f8BUiUO3CvZ7AUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.errorbar(np.subtract(mjd,mjd[0]),flux,yerr=flux_err,fmt=\"o\")    \n",
+    "plt.xlabel(\"MJD [\" + str(mjd[0]) + \"+]\")\n",
+    "plt.ylabel(\"flux\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
@registerrier @cdeil @adonath 
This PR adds a tutorial for lightcurve analysis using 3D analysis. The time filtering seems to work as expected.

The PR is not merge ready, and needs some cleanup. I have not striped out the output so that it is easier now to take a look. Should we just have a tutorial for lightcurves for now? Or do we need to have a separate high level class like `gammapy.time.LightCurveEstimator`?
I have no particular preference for either. The tutorial seems simple enough for users to be able to replicate.
Or, a `LightCurve` class can also be implemented with `Lightcurve.quick_look()` and `Lightcuve.run()` to get the plots.
