### PR TITLE
Improve spectrum/models.py coverage

### DIFF
--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -126,6 +126,31 @@ TEST_MODELS = [
         integral_1_10TeV=u.Quantity(35.9999999999999, "cm-2 s-1"),
         eflux_1_10TeV=u.Quantity(198.00000000000006, "TeV cm-2 s-1"),
     ),
+    dict(
+        name="powerlaw_index1",
+        model=PowerLaw(
+            index=1 * u.Unit(""),
+            amplitude=2 / u.cm ** 2 / u.s / u.TeV,
+            reference=1 * u.TeV,
+        ),
+        val_at_2TeV=u.Quantity(1.0, "cm-2 s-1 TeV-1"),
+        integral_1_10TeV=u.Quantity(4.605170185, "cm-2 s-1"),
+        eflux_1_10TeV=u.Quantity(18., "TeV cm-2 s-1"),
+    ),
+    dict(
+        name="ecpl_2",
+        model=ExponentialCutoffPowerLaw(
+            index=2. * u.Unit(""),
+            amplitude=4 / u.cm ** 2 / u.s / u.TeV,
+            reference=1 * u.TeV,
+            lambda_=0.1 / u.TeV,
+        ),
+        val_at_2TeV=u.Quantity(0.81873075, "cm-2 s-1 TeV-1"),
+        integral_1_10TeV=u.Quantity(2.83075297, "cm-2 s-1"),
+        eflux_1_10TeV=u.Quantity(6.41406327, "TeV cm-2 s-1"),
+        e_peak=np.nan*u.TeV,
+    ),
+
 ]
 
 # Add compound models
@@ -352,11 +377,12 @@ def test_fermi_isotropic():
     )
 
 
-def test_ecpl_intergrate():
-    # regresseion test to check the numerical integration for small energy bins
+def test_ecpl_integrate():
+    # regression test to check the numerical integration for small energy bins
     ecpl = ExponentialCutoffPowerLaw()
     value = ecpl.integral(1 * u.TeV, 1.1 * u.TeV)
     assert_quantity_allclose(value, 8.380714e-14 * u.Unit("s-1 cm-2"))
+
 
 
 @requires_dependency("naima")

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -6,6 +6,7 @@ from ...utils.energy import EnergyBounds
 from ...utils.testing import assert_quantity_allclose
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ..models import (
+    SpectralModel,
     PowerLaw,
     PowerLaw2,
     ExponentialCutoffPowerLaw,
@@ -263,6 +264,18 @@ def test_model_plot():
     with mpl_plot_check():
         pwl.plot_error((1*u.TeV, 10*u.TeV))
 
+def test_to_from_dict():
+    spectrum = TEST_MODELS[0]
+    model = spectrum["model"]
+
+    model_dict = model.to_dict()
+    new_model = SpectralModel.from_dict(model_dict)
+
+    assert isinstance(new_model, PowerLaw)
+
+    actual = [par.value for par in new_model.parameters]
+    desired = [par.value for par in model.parameters]
+    assert_quantity_allclose(actual, desired)
 
 @requires_dependency("matplotlib")
 @requires_data()

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -251,9 +251,9 @@ def test_models(spectrum):
     if "e_peak" in spectrum:
         assert_quantity_allclose(model.e_peak, spectrum["e_peak"], rtol=1e-2)
 
-    # inverse for TableModel is not implemented
-    if not (isinstance(model, TableModel) or isinstance(model, ConstantModel) or spectrum["name"] == 'compound6'):
-        assert_quantity_allclose(model.inverse(value), 2 * u.TeV, rtol=0.05)
+    # inverse for ConstantModel is irrelevant
+    if not (isinstance(model, ConstantModel) or spectrum["name"] == 'compound6'):
+        assert_quantity_allclose(model.inverse(value), 2 * u.TeV, rtol=0.01)
 
     model.to_dict()
 

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -177,6 +177,18 @@ TEST_MODELS.append(
         eflux_1_10TeV=TEST_MODELS[0]["eflux_1_10TeV"] * 0.5,
     )
 )
+
+TEST_MODELS.append(
+    dict(
+        name="compound6",
+        model=TEST_MODELS[7]["model"] + u.Quantity(4,'cm-2 s-1 TeV-1'),
+        val_at_2TeV=TEST_MODELS[7]["val_at_2TeV"]*2 ,
+        integral_1_10TeV=TEST_MODELS[7]["integral_1_10TeV"]*2,
+        eflux_1_10TeV=TEST_MODELS[7]["eflux_1_10TeV"]*2 ,
+    )
+)
+
+
 # The table model imports scipy.interpolate in `__init__`,
 # so we skip it if scipy is not available
 try:
@@ -214,7 +226,7 @@ def test_models(spectrum):
         assert_quantity_allclose(model.e_peak, spectrum["e_peak"], rtol=1e-2)
 
     # inverse for TableModel is not implemented
-    if not (isinstance(model, TableModel) or isinstance(model, ConstantModel)):
+    if not (isinstance(model, TableModel) or isinstance(model, ConstantModel) or spectrum["name"] == 'compound6'):
         assert_quantity_allclose(model.inverse(value), 2 * u.TeV, rtol=0.05)
 
     model.to_dict()

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -246,6 +246,23 @@ def test_model_unit():
     value = pwl(500 * u.MeV)
     assert value.unit == "cm-2 s-1 TeV-1"
 
+@requires_dependency("matplotlib")
+@requires_dependency("uncertainties")
+def test_model_plot():
+    pars, errs = {}, {}
+    pars["amplitude"] = 1e-12 * u.Unit("TeV-1 cm-2 s-1")
+    pars["reference"] = 1 * u.Unit("TeV")
+    pars["index"] = 2 * u.Unit("")
+    errs["amplitude"] = 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")
+
+    pwl = PowerLaw(**pars)
+    pwl.parameters.set_parameter_errors(errs)
+    with mpl_plot_check():
+        pwl.plot((1*u.TeV, 10*u.TeV))
+
+    with mpl_plot_check():
+        pwl.plot_error((1*u.TeV, 10*u.TeV))
+
 
 @requires_dependency("matplotlib")
 @requires_data()


### PR DESCRIPTION
This PR adds a few tests to improve the coverage of `spectrum/models.py`.

