### PR TITLE
Introduce the MapEventSampler class 

### DIFF
--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -206,19 +206,26 @@ class LightCurveTableModel(Model):
     def _time(self):
         return self._time_ref + self.table["TIME"].data * u.s
 
-    def evaluate_norm_at_time(self, time):
+    def evaluate_norm_at_time(self, time, ext_mode=3):
         """Evaluate for a given time.
 
         Parameters
         ----------
         time : array_like
             Time since the ``reference`` time.
+        ext_mode : int or str, optional
+            Controls the extrapolation mode for elements not in the interval defined by the knot sequence.
+            if ext=0 or ‘extrapolate’, return the extrapolated value.
+            if ext=1 or ‘zeros’, return 0
+            if ext=2 or ‘raise’, raise a ValueError
+            if ext=3 of ‘const’, return the boundary value.
+            The default value is 0.
 
         Returns
         -------
         norm : array_like
         """
-        return self._interpolator(time)
+        return self._interpolator(time, ext=ext_mode)
 
     def mean_norm_in_time_interval(self, time_min, time_max):
         """Compute mean ``norm`` in a given time interval.

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+from astropy.table import Table
+from astropy import units as u
+
 from .utils import get_random_state
 
 
@@ -77,3 +80,118 @@ class InverseCDFSampler:
 
         index = index + self.random_state.uniform(low=-0.5, high=0.5, size=index.shape)
         return index
+
+
+
+class MapEventSampler:
+    """Map event sampler.
+
+    Parameters
+    ----------
+
+    npred_map : `~gammapy.maps.Map`
+            Predicted number of counts map.
+    random_state : integer
+            Take a `numpy.random.RandomState` instance.
+    lc : `~gammapy.time.models.LightCurveTableModel`
+            Input light-curve of the source, given with columns labelled
+            as "time" and "normalization" (arbitrary units): the bin time
+            HAS to be costant.
+    tmin : start time of the sampling, in seconds.
+    tmax : stop time of the sampling, in seconds.
+    """
+
+    def __init__(self, npred_map, random_state=0,
+                  lc = None, tmin=0, tmax=3600):
+        self.random_state = get_random_state(random_state)
+        self.npred_map = npred_map
+        self.lc = lc
+        self.tmin=tmin
+        self.tmax=tmax
+    
+    def npred_total(self):
+        """ Calculate the total number of the sampled predicted events.
+            
+        Returns
+        -------
+        random_state.poisson() : Number of predicted events.
+        """
+
+        return self.random_state.poisson(np.sum(self.npred_map.data))
+
+    def sample_npred(self):
+        """ Calculate energy and coordinates of the sampled source events.
+            
+        Returns
+        -------
+        coords : array with coordinates and energies of the sampled events.
+        """
+
+        self.n_events = self.npred_total()
+        
+        cdf_sampler = InverseCDFSampler(self.npred_map.data, random_state=self.random_state)
+        
+        pix_coords = cdf_sampler.sample(self.n_events)
+        self.coords = self.npred_map.geom.pix_to_coord(pix_coords[::-1])
+
+        return self.coords
+        
+    def sample_timepred(self):
+        """ Calculate the times of arrival of the sampled source events 
+
+        Returns
+        -------
+        ToA : array with times of the sampled events.
+        """
+ 
+        n_events = self.n_events
+        if self.lc is not None:
+            start_lc = self.lc.table['time'].data[0]
+            stop_lc = self.lc.table['time'].data[-1]
+            if (self.tmin >= start_lc) and (self.tmax <= stop_lc):
+                time_range = np.where((self.lc.table['time'].data >= self.tmin) & (self.lc.table['time'].data <= self.tmax))
+                normalization = self.lc.table['normalization'].data[time_range]
+                time_sampler = InverseCDFSampler(normalization,random_state=self.random_state)
+                self.ToA = time_sampler.sample(n_events)[0]
+            
+            elif ((self.tmin >= start_lc) and (self.tmax > stop_lc) and (self.tmin < stop_lc)):
+                time_range = np.where((self.lc.table['time'].data >= self.tmin))
+                # we assume a constant source, with a mean source normalization in the choosen interval, when tmax > stop_lc
+                dt = self.lc.table['time'].data[1] - self.lc.table['time'].data[0]
+                mean_norm = (1. /(stop_lc-self.tmin) *
+                np.sum(self.lc.table['normalization'].data[time_range] * np.full(len(time_range[0]),dt)) )
+                normalization = np.append(self.lc.table['normalization'].data[time_range], np.full(int(self.tmax - stop_lc), mean_norm) )
+                time_sampler = InverseCDFSampler(normalization,random_state=self.random_state)
+                self.ToA = time_sampler.sample(n_events)[0]
+    
+            else:
+                self.ToA = self.tmin + self.random_state.uniform(high=(self.tmax-self.tmin), size=n_events)
+
+        else:
+            self.ToA = self.tmin + self.random_state.uniform(high=(self.tmax-self.tmin), size=n_events)
+        
+        return self.ToA
+            
+    def sample_events(self):
+        """It converts the given sampled event list into an astropy table.
+            
+        Parameters
+        ----------
+        coords : output of sample_npred()
+        ToA : output of sample_timepred()
+
+        Returns
+        -------
+        events : event list in an astropy table format.
+        """
+
+        events = Table()
+        events['lon_true'] = self.coords[0] * u.deg
+        events['lat_true'] = self.coords[1] * u.deg
+        events['e_true'] = self.coords[2] * u.TeV
+        try:
+           events['time'] = self.ToA * u.s
+        except:
+            print("<<Warning: no event times have been sampled. \n>>")
+        return events
+

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from collections import OrderedDict
 import numpy as np
 from astropy.table import Table
 from astropy.time import Time
@@ -7,7 +8,7 @@ from astropy.utils import lazyproperty
 
 from .utils import get_random_state
 
-__all__ = ["InverseCDFSampler", "MapEventSampler", "IRFEventDistributor"]
+__all__ = ["InverseCDFSampler", "MapEventSampler"]
 
 
 class InverseCDFSampler:
@@ -94,109 +95,122 @@ class MapEventSampler:
     ----------
     npred_map : `~gammapy.maps.Map`
             Predicted number of counts map.
+    t_min : `astropy.time.Time` object.
+            Start time of the sampling.
+    t_max : `astropy.time.Time` object.
+            Stop time of the sampling.
+    t_delta : `~astropy.units.Quantity`
+            Time step used for sampling of the temporal model.
+    temporal_model : `~gammapy.time.models.LightCurveTableModel` or `~gammapy.time.models.PhaseCurveTableModel`
+            Input light (or phase)-curve model of the source, given with columns labelled
+            as "time" (or "phase)" and "normalization" (arbitrary units).
     random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`.
-    lc : `~gammapy.time.models.LightCurveTableModel` or `~gammapy.time.models.PhaseCurveTableModel`
-            Input light (or phase)-curve model of the source, given with columns labelled
-            as "time" (or "phase)" and "normalization" (arbitrary units): the bin step
-            HAS to be costant.
-    tmin : `astropy.units.Quantity` or `astropy.time.TIME` object.
-            Start time of the sampling.
-    tmax : `astropy.units.Quantity` or `astropy.time.TIME` object.
-            Stop time of the sampling.
     """
 
-    def __init__(self, npred_map, tmin, tmax, random_state=0, lc=None, dt_bin=None):
-
-        self.random_state = get_random_state(random_state)
+    def __init__(self, npred_map, t_min, t_max, t_delta="1 s", temporal_model=None, random_state=0):
         self.npred_map = npred_map
-        self.lc = lc
-
-        if isinstance(tmin, Time) and isinstance(tmax, Time):
-            t_ref = Time(
-                "2019-01-01 00:00:00", scale="utc"
-            )  # hardcoded reference epoch
-            self.tmin = ((tmin.decimalyear - t_ref.decimalyear) * u.year).to(u.s)
-            self.tmax = ((tmax.decimalyear - t_ref.decimalyear) * u.year).to(u.s)
-
-        else:
-            self.tmin = tmin.to(u.s)
-            self.tmax = tmax.to(u.s)
-
-        if dt_bin == None:
-            self.dt_bin = self.tmax.value - self.tmin.value
+        self.temporal_model = temporal_model
+        self.t_min = Time(t_min)
+        self.t_max = Time(t_max)
+        self.t_delta = u.Quantity(t_delta)
+        self.random_state = get_random_state(random_state)
 
     @lazyproperty
     def npred_total(self):
-        """ Calculate the total number of the sampled predicted events.
-            
+        """Sample the total number of predicted events.
+
         Returns
         -------
-        random_state.poisson() : int
-                        Number of predicted events.
+        npred_total : int
+            Number of predicted events.
         """
 
         return self.random_state.poisson(np.sum(self.npred_map.data))
 
-    def sample_npred(self):
-        """ Calculate energy and Galactic coordinates of the sampled source events.
+    def sample_position_energy(self, n_events=None):
+        """Sample position and energy of events.
+
+        Parameters
+        ----------
+        n_events : int
+            Number of events to sample.
             
         Returns
         -------
         coords : `~gammapy.maps.MapCoord` object.
-                Sequence of coordinates and energies of the sampled events.
+            Sequence of coordinates and energies of the sampled events.
         """
+        from ...maps import MapCoord
+        n_events = self.npred_total if n_events is None else n_events
 
-        cdf_sampler = InverseCDFSampler(
+        sampler = InverseCDFSampler(
             self.npred_map.data, random_state=self.random_state
         )
 
-        pix_coords = cdf_sampler.sample(self.npred_total)
-        coords = self.npred_map.geom.pix_to_coord(pix_coords[::-1])
+        coords_pix = sampler.sample(n_events)
+        coords = self.npred_map.geom.pix_to_coord(coords_pix[::-1])
 
-        return coords
+        # TODO: pix_to_coord should return a MapCoord object
+        geom = self.npred_map.geom
+        axes_names = ["lon", "lat"] + [ax.name for ax in geom.axes]
+        cdict = OrderedDict(zip(axes_names, coords))
+        cdict["energy"] *= geom.get_axis_by_name("energy").unit
+        return MapCoord.create(cdict, coordsys=geom.coordsys)
 
-    @lazyproperty
-    def sample_timepred(self):
-        """ Calculate the times of arrival of the sampled source events.
+    def sample_time(self, n_events=None):
+        """Sample arrival times of events.
+
+        Parameters
+        ----------
+        n_events : int
+            Number of events to sample.
 
         Returns
         -------
-        ToA : `~numpy.array`
-            array with times of the sampled events.
+        time : `~astropy.units.Quantity`
+            Array with times of the sampled events.
         """
+        n_events = self.npred_total if n_events is None else n_events
 
-        if self.lc is not None:
-            t = np.linspace(self.tmin.value, self.tmax.value, self.dt_bin)
-            normalization = self.lc.evaluate_norm_at_time(t)
-            time_sampler = InverseCDFSampler(
-                normalization, random_state=self.random_state
+        ontime = self.t_max - self.t_min
+
+        if self.temporal_model is not None:
+            t = np.arange(0, ontime.sec, self.t_delta.to_value("s")) * u.second
+            pdf = self.temporal_model.evaluate_norm_at_time(t)
+
+            sampler = InverseCDFSampler(
+                pdf=pdf, random_state=self.random_state
             )
-            ToA = time_sampler.sample(self.npred_total)[0]
-
+            time_pix = sampler.sample(n_events)[0]
+            time = np.interp(time_pix, np.arange(len(t)), t.to_value("s")) * u.second
         else:
-            ToA = self.tmin.value + self.random_state.uniform(
-                high=(self.tmax.value - self.tmin.value), size=self.npred_total
-            )
+            time = self.random_state.uniform(high=ontime.sec, size=n_events) * u.second
 
-        return ToA
+        return time
 
-    def sample_events(self):
+    def sample_events(self, n_events=None):
         """It converts the given sampled event list into an astropy table.
-            
+
+        Parameters
+        ----------
+        n_events : int
+            Number of events to sample.
+
+
         Returns
         -------
         events : `~astropy.table`
             Sampled event list in an astropy table format.
         """
 
-        coords = self.sample_npred()
+        coords = self.sample_position_energy(n_events)
+        skycoord = coords.skycoord
 
         events = Table()
-        events["RA_TRUE"] = coords[0] * u.deg
-        events["DEC_TRUE"] = coords[1] * u.deg
-        events["ENERGY_TRUE"] = coords[2] * u.TeV
-        events["TIME"] = self.sample_timepred * u.s
-
+        events["RA_TRUE"] = skycoord.icrs.ra
+        events["DEC_TRUE"] = skycoord.icrs.dec
+        events["ENERGY_TRUE"] = coords["energy"]
+        events["TIME"] = self.sample_time(n_events)
         return events

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -137,7 +137,7 @@ class MapEventSampler:
         return self.coords
         
     def sample_timepred(self):
-        """ Calculate the times of arrival of the sampled source events 
+        """ Calculate the times of arrival of the sampled source events.
 
         Returns
         -------
@@ -162,8 +162,8 @@ class MapEventSampler:
                 common_idx = np.where((times>=start_lc) & (times<=stop_lc))
                 uncommon_idx = np.where((times<start_lc) | (times>stop_lc))
                 common_time = times[common_idx]
-                uncommon_time = times[uncommon_idx]
-                
+#                uncommon_time = times[uncommon_idx]
+
                 #calculate the normalization in the common times and
                 #the mean lc normalization in the rest
                 norm = self.lc.evaluate_norm_at_time(common_time)
@@ -198,7 +198,7 @@ class MapEventSampler:
         events['e_true'] = self.coords[2] * u.TeV
         try:
            events['time'] = self.ToA * u.s
-        except:
+        except Exception:
             print("<<Warning: no event times have been sampled. \n>>")
         return events
 

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -5,6 +5,11 @@ from astropy import units as u
 
 from .utils import get_random_state
 
+__all__ = [
+           "InverseCDFSampler",
+           "MapEventSampler",
+]
+
 
 class InverseCDFSampler:
     """Inverse CDF sampler.

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -160,8 +160,8 @@ class MapEventSampler:
 
                 #select the lc times in the time range [t_min,t_max]
                 common_idx = np.where((times>=start_lc) & (times<=stop_lc))
-                uncommon_idx = np.where((times<start_lc) | (times>stop_lc))
                 common_time = times[common_idx]
+#                uncommon_idx = np.where((times<start_lc) | (times>stop_lc))
 #                uncommon_time = times[uncommon_idx]
 
                 #calculate the normalization in the common times and

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -7,7 +7,7 @@ from astropy.utils import lazyproperty
 
 from .utils import get_random_state
 
-__all__ = ["InverseCDFSampler", "MapEventSampler"]
+__all__ = ["InverseCDFSampler", "MapEventSampler", "IRFEventDistributor"]
 
 
 class InverseCDFSampler:
@@ -148,8 +148,6 @@ class MapEventSampler:
                 Sequence of coordinates and energies of the sampled events.
         """
 
-        #        self.n_events = self.npred_total()
-
         cdf_sampler = InverseCDFSampler(
             self.npred_map.data, random_state=self.random_state
         )
@@ -169,7 +167,6 @@ class MapEventSampler:
             array with times of the sampled events.
         """
 
-        #        n_events = self.n_events
         if self.lc is not None:
             t = np.linspace(self.tmin.value, self.tmax.value, self.dt_bin)
             normalization = self.lc.evaluate_norm_at_time(t)

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -101,24 +101,28 @@ class MapEventSampler:
             Input light (or phase)-curve model of the source, given with columns labelled
             as "time" (or "phase)" and "normalization" (arbitrary units): the bin step
             HAS to be costant.
-    tmin : `astropy.units.Quantity` object.
+    tmin : `astropy.units.Quantity` or `astropy.time.TIME` object.
             Start time of the sampling.
-    tmax : `astropy.units.Quantity` object.
+    tmax : `astropy.units.Quantity` or `astropy.time.TIME` object.
             Stop time of the sampling.
     """
 
-    def __init__(
-        self, npred_map, tmin, tmax, random_state=0, lc=None, phase_lc=None, dt_bin=None
-    ):
-
-        #        t_ref = Time('2019-01-01 00:00:00', scale='utc') #hardcoded reference epoch
+    def __init__(self, npred_map, tmin, tmax, random_state=0, lc=None, dt_bin=None):
 
         self.random_state = get_random_state(random_state)
         self.npred_map = npred_map
         self.lc = lc
-        self.phase_lc = phase_lc
-        self.tmin = tmin.to(u.s)
-        self.tmax = tmax.to(u.s)
+
+        if isinstance(tmin, Time) and isinstance(tmax, Time):
+            t_ref = Time(
+                "2019-01-01 00:00:00", scale="utc"
+            )  # hardcoded reference epoch
+            self.tmin = ((tmin.decimalyear - t_ref.decimalyear) * u.year).to(u.s)
+            self.tmax = ((tmax.decimalyear - t_ref.decimalyear) * u.year).to(u.s)
+
+        else:
+            self.tmin = tmin.to(u.s)
+            self.tmax = tmax.to(u.s)
 
         if dt_bin == None:
             self.dt_bin = self.tmax.value - self.tmin.value

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -97,12 +97,12 @@ class MapEventSampler:
             Passed to `~gammapy.utils.random.get_random_state`.
     lc : `~gammapy.time.models.LightCurveTableModel`
             Input light-curve of the source, given with columns labelled
-            as "time" and "normalization" (arbitrary units): the bin time
+            as "time" (in seconds) and "normalization" (arbitrary units): the bin time
             HAS to be costant.
     tmin : float
-            Start time of the sampling, in seconds.
+            Start time of the sampling, defined in seconds.
     tmax : float
-            Stop time of the sampling, in seconds.
+            Stop time of the sampling, defined in seconds.
     """
 
     def __init__(self, npred_map, random_state=0,
@@ -122,10 +122,10 @@ class MapEventSampler:
                         Number of predicted events.
         """
 
-        return random_state.poisson(np.sum(self.npred_map.data))
+        return self.random_state.poisson(np.sum(self.npred_map.data))
 
     def sample_npred(self):
-        """ Calculate energy and coordinates of the sampled source events.
+        """ Calculate energy and Galactic coordinates of the sampled source events.
             
         Returns
         -------
@@ -183,4 +183,3 @@ class MapEventSampler:
             events['TIME'] = self.sample_timepred() * u.s
         
         return events
-

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -96,20 +96,25 @@ class MapEventSampler:
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`.
     lc : `~gammapy.time.models.LightCurveTableModel`
-            Input light-curve of the source, given with columns labelled
+            Input light-curve model of the source, given with columns labelled
             as "time" (in seconds) and "normalization" (arbitrary units): the bin time
             HAS to be costant.
+    phase_lc : `~gammapy.time.models.PhaseCurveTableModel`
+            Input phase-curve model of the source, given with columns labelled
+            as "Phase" and "normalization" (arbitrary units): the bin time
+            HAS to be costant.
     tmin : float
-            Start time of the sampling, defined in seconds.
+            Start time of the sampling, given in seconds.
     tmax : float
-            Stop time of the sampling, defined in seconds.
+            Stop time of the sampling, given in seconds.
     """
 
     def __init__(self, npred_map, random_state=0,
-                  lc = None, tmin=0, tmax=3600):
+                  lc = None, phase_lc=None, tmin=0, tmax=3600):
         self.random_state = get_random_state(random_state)
         self.npred_map = npred_map
         self.lc = lc
+        self.phase_lc = phase_lc
         self.tmin=tmin
         self.tmax=tmax
     
@@ -156,6 +161,13 @@ class MapEventSampler:
             n_tbin = self.tmax - self.tmin
             t = np.linspace(self.tmin,self.tmax,n_tbin)
             normalization = self.lc._interpolator(t,ext=3)
+            time_sampler = InverseCDFSampler(normalization, random_state=self.random_state)
+            ToA = time_sampler.sample(n_events)[0]
+
+        if (self.phase_lc is not None) and (self.tmax>0):
+            n_tbin = self.tmax - self.tmin
+            t = np.linspace(self.tmin,self.tmax,n_tbin)
+            normalization = self.phase_lc.evaluate_norm_at_time(t)
             time_sampler = InverseCDFSampler(normalization, random_state=self.random_state)
             ToA = time_sampler.sample(n_events)[0]
 

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -5,10 +5,7 @@ from astropy import units as u
 
 from .utils import get_random_state
 
-__all__ = [
-           "InverseCDFSampler",
-           "MapEventSampler",
-]
+__all__ = ["InverseCDFSampler", "MapEventSampler"]
 
 
 class InverseCDFSampler:
@@ -88,7 +85,6 @@ class InverseCDFSampler:
         return index
 
 
-
 class MapEventSampler:
     """Map event sampler.
 
@@ -114,15 +110,16 @@ class MapEventSampler:
             Stop time of the sampling, given in seconds.
     """
 
-    def __init__(self, npred_map, random_state=0,
-                  lc = None, phase_lc=None, tmin=0, tmax=3600):
+    def __init__(
+        self, npred_map, random_state=0, lc=None, phase_lc=None, tmin=0, tmax=3600
+    ):
         self.random_state = get_random_state(random_state)
         self.npred_map = npred_map
         self.lc = lc
         self.phase_lc = phase_lc
-        self.tmin=tmin
-        self.tmax=tmax
-    
+        self.tmin = tmin
+        self.tmax = tmax
+
     def npred_total(self):
         """ Calculate the total number of the sampled predicted events.
             
@@ -144,14 +141,16 @@ class MapEventSampler:
         """
 
         self.n_events = self.npred_total()
-        
-        cdf_sampler = InverseCDFSampler(self.npred_map.data, random_state=self.random_state)
-        
+
+        cdf_sampler = InverseCDFSampler(
+            self.npred_map.data, random_state=self.random_state
+        )
+
         pix_coords = cdf_sampler.sample(self.n_events)
         coords = self.npred_map.geom.pix_to_coord(pix_coords[::-1])
 
         return coords
-        
+
     def sample_timepred(self):
         """ Calculate the times of arrival of the sampled source events.
 
@@ -160,24 +159,30 @@ class MapEventSampler:
         ToA : `~numpy.array`
             array with times of the sampled events.
         """
-        
+
         n_events = self.n_events
-        if (self.lc is not None) and (self.tmax>0):
+        if (self.lc is not None) and (self.tmax > 0):
             n_tbin = self.tmax - self.tmin
-            t = np.linspace(self.tmin,self.tmax,n_tbin)
-            normalization = self.lc._interpolator(t,ext=3)
-            time_sampler = InverseCDFSampler(normalization, random_state=self.random_state)
+            t = np.linspace(self.tmin, self.tmax, n_tbin)
+            normalization = self.lc._interpolator(t, ext=3)
+            time_sampler = InverseCDFSampler(
+                normalization, random_state=self.random_state
+            )
             ToA = time_sampler.sample(n_events)[0]
 
-        if (self.phase_lc is not None) and (self.tmax>0):
+        if (self.phase_lc is not None) and (self.tmax > 0):
             n_tbin = self.tmax - self.tmin
-            t = np.linspace(self.tmin,self.tmax,n_tbin)
+            t = np.linspace(self.tmin, self.tmax, n_tbin)
             normalization = self.phase_lc.evaluate_norm_at_time(t)
-            time_sampler = InverseCDFSampler(normalization, random_state=self.random_state)
+            time_sampler = InverseCDFSampler(
+                normalization, random_state=self.random_state
+            )
             ToA = time_sampler.sample(n_events)[0]
 
         else:
-            ToA = self.tmin + self.random_state.uniform(high=(self.tmax-self.tmin), size=n_events)
+            ToA = self.tmin + self.random_state.uniform(
+                high=(self.tmax - self.tmin), size=n_events
+            )
 
         return ToA
 
@@ -193,10 +198,10 @@ class MapEventSampler:
         coords = self.sample_npred()
 
         events = Table()
-        events['lon_true'] = coords[0] * u.deg
-        events['lat_true'] = coords[1] * u.deg
-        events['e_true'] = coords[2] * u.TeV
-        if ((self.lc is not None) and (self.tmax>0)) or (self.tmax>0):
-            events['TIME'] = self.sample_timepred() * u.s
-        
+        events["lon_true"] = coords[0] * u.deg
+        events["lat_true"] = coords[1] * u.deg
+        events["e_true"] = coords[2] * u.TeV
+        if ((self.lc is not None) and (self.tmax > 0)) or (self.tmax > 0):
+            events["TIME"] = self.sample_timepred() * u.s
+
         return events

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -121,17 +121,17 @@ def test_map_sampling():
     table["NORM"] = rate(time)
     lc = LC(table)
 
-    tmin = 9
-    tmax = 30000
+    tmin = 9 * u.s
+    tmax = 30000 * u.s
     sampler = MapEventSampler(npred, random_state=0, lc=lc, tmin=tmin, tmax=tmax)
-    ntot = sampler.npred_total()
+    ntot = sampler.npred_total
     sampler = MapEventSampler(npred, random_state=0, lc=lc, tmin=tmin, tmax=tmax)
     events = sampler.sample_events()
 
     position = SkyCoord(
-        events["lon_true"], events["lat_true"], frame="galactic", unit="deg"
+        events["RA_TRUE"], events["DEC_TRUE"], frame="galactic", unit="deg"
     )
 
     assert_allclose(ntot, len(events), 0.001)
-    assert max(events["TIME"]) < tmax
+    assert max(events["TIME"]) < tmax.value
     assert max(npred.geom.center_skydir.separation(position)) < npred.geom.width[0]

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -5,7 +5,6 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
-import matplotlib.pyplot as plt
 
 from ..inverse_cdf import InverseCDFSampler, MapEventSampler
 from  ....cube import MapEvaluator

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -122,7 +122,6 @@ def test_map_sampling():
     events=sampler.sample_events()
 
     position = SkyCoord(events['lon_true'], events['lat_true'], frame='galactic', unit='deg')
-    npred.geom.center_skydir.separation(c)
 
     assert_allclose(ntot, len(events), 0.001)
     assert max(events['TIME'])<tmax

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -128,7 +128,7 @@ def test_time_sampling():
     lc = LC(table)
 
     npred = source_model()
-    
+
     sampler = MapEventSampler(npred, random_state=0, lc=lc, tmin=0, tmax=80000)
     events_src=sampler.sample_npred()
     time_events = sampler.sample_timepred()

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -121,9 +121,9 @@ def test_map_sampling():
     sampler = MapEventSampler(npred, random_state=0, lc=lc, tmin=tmin, tmax=tmax)
     events=sampler.sample_events()
 
-    c = position = SkyCoord(events['lon_true'], events['lat_true'], frame='galactic', unit='deg')
+    position = SkyCoord(events['lon_true'], events['lat_true'], frame='galactic', unit='deg')
     npred.geom.center_skydir.separation(c)
 
     assert_allclose(ntot, len(events), 0.001)
     assert max(events['TIME'])<tmax
-    assert max(npred.geom.center_skydir.separation(c)) < npred.geom.width[0]
+    assert max(npred.geom.center_skydir.separation(position)) < npred.geom.width[0]

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord,Angle
+import matplotlib.pyplot as plt
 
 from ..inverse_cdf import InverseCDFSampler, MapEventSampler
 from  ....cube import MapEvaluator
@@ -20,6 +21,9 @@ def uniform_dist(x, a, b):
 
 def gauss_dist(x, mu, sigma):
     return stats.norm.pdf(x, mu, sigma)
+
+def po(x):
+    return x**(-1.*2)
 
 def source_model():
     position = SkyCoord(0.0, 0.0, frame='galactic', unit='deg')
@@ -107,13 +111,24 @@ def test_map_sampling():
     time_events = sampler.sample_timepred()
     evt = sampler.sample_events()
 
+    plt.hist(evt['e_true'], bins=np.logspace(0, 2, 10), density=True)
+    plt.plot(np.arange(1,100), po(np.arange(1,100)))
+    plt.loglog()
+    plt.show()
+
 
 def test_npred_total():
+    n_test = 1000
+    npred_tot = np.zeros(n_test,int)
     npred = source_model()
-
+    tot = np.sum(npred.data)
+    
     sampler = MapEventSampler(npred, random_state=0, tmin=0, tmax=30000)
-    npred_tot = sampler.npred_total()
 
+    for i in np.arange(0,n_test):
+        npred_tot[i] = sampler.npred_total()
+
+    assert_allclose(np.mean(npred_tot), tot, rtol=0.1)
 
 
 

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -133,6 +133,7 @@ def test_time_sampling():
     events_src=sampler.sample_npred()
     time_events = sampler.sample_timepred()
     evt = sampler.sample_events()
+    print(events_src, time_events)
     
     plt.hist(evt['time'], bins=100)
     plt.show()
@@ -143,7 +144,7 @@ def test_npred_total():
     npred_tot = np.zeros(n_test,int)
     npred = source_model()
     tot = np.sum(npred.data)
-    
+
     sampler = MapEventSampler(npred, random_state=0, tmin=0, tmax=30000)
 
     for i in np.arange(0,n_test):

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -48,9 +48,9 @@ def source_model():
     exposure.data = 1e10 * 10000 * np.ones(exposure.data.shape)
 
     evaluator = MapEvaluator(model=skymodel, exposure=exposure)
-    
+
     npred = evaluator.compute_npred()
-    
+
     return npred
 
 

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -134,7 +134,7 @@ def test_time_sampling():
     time_events = sampler.sample_timepred()
     evt = sampler.sample_events()
     print(events_src, time_events)
-    
+
     plt.hist(evt['time'], bins=100)
     plt.show()
 

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -4,14 +4,14 @@ import scipy.stats as stats
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.table import Table
-from astropy.coordinates import SkyCoord,Angle
+from astropy.coordinates import SkyCoord
 import matplotlib.pyplot as plt
 
 from ..inverse_cdf import InverseCDFSampler, MapEventSampler
 from  ....cube import MapEvaluator
 from ....cube.models import SkyModel
 from ....image.models import SkyGaussian
-from ....maps import Map, MapAxis, WcsGeom
+from ....maps import Map, MapAxis
 from ....spectrum.models import PowerLaw
 from ....time.models import LightCurveTableModel as LC
 
@@ -107,10 +107,10 @@ def test_norm_dist_sampling():
 
 def test_map_sampling():
     npred = source_model()
-
     sampler = MapEventSampler(npred, random_state=0, tmin=0, tmax=30000)
     events_src=sampler.sample_npred()
     time_events = sampler.sample_timepred()
+    print(events_src, time_events)
     evt = sampler.sample_events()
 
     plt.hist(evt['e_true'], bins=np.logspace(0, 2, 10), density=True)


### PR DESCRIPTION
This PR introduces the `MapEventSampler` class which samples a set of events from a given probability distribution function. The class is fundamental in the development of a Gammapy simulator, as described in the pig-009 (docs/development/pigs/pig-009.rst).

The `MapEventSampler` requires an `MapEvaluator` object, a start and stop time, and also a light-curves to take into account temporal variability. 
The main methods are: a calculator of the predicted counts from the given input map (`MapEvaluator.npred_total()`), an event sampler that provides the coordinates and energies (`MapEvaluator.sample_npred`), and the times of arrival (`MapEvaluator.sample_timepred`) of the events. These are then stored into an `astropy` Table object (`MapEvaluator.sample_events`).

The `MapEventSampler` class is included in `inverse_cdf.py` in `gammapy.utils.random`. Some tests have also been added.

I highlight that some more work is necessary to improve the sampling of the temporal variability.