### PR TITLE
Remove use of NDDataArray from  CountsSpectrum

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -228,33 +228,25 @@ class CountsSpectrum:
         """A deep copy of self."""
         return copy.deepcopy(self)
 
-    def rebin(self, parameter):
-        """Rebin.
+    def downsample(self, factor):
+        """Downsample spectrum.
 
         Parameters
         ----------
-        parameter : int
-            Number of bins to merge
+        factor : int
+            Downsampling factor.
 
         Returns
         -------
-        rebinned_spectrum : `~gammapy.spectrum.CountsSpectrum`
-            Rebinned spectrum
+        spectrum : `~gammapy.spectrum.CountsSpectrum`
+            Downsampled spectrum.
         """
         from ..extern.skimage import block_reduce
-
-        if len(self.data) % parameter != 0:
-            raise ValueError(
-                "Invalid rebin parameter: {}, nbins: {}".format(
-                    parameter, len(self.data)
-                )
-            )
-
-        data = block_reduce(self.data, block_size=(parameter,))
-        energy = self.energy.edges
+        data = block_reduce(self.data, block_size=(factor,))
+        energy = self.energy.downsample(factor).edges
         return self.__class__(
-            energy_lo=energy[:-1][0::parameter],
-            energy_hi=energy[1:][parameter - 1 :: parameter],
+            energy_lo=energy[:-1],
+            energy_hi=energy[1:],
             data=data,
         )
 
@@ -411,7 +403,7 @@ class PHACountsSpectrum(CountsSpectrum):
         """
         from ..extern.skimage import block_reduce
 
-        retval = super().rebin(parameter)
+        retval = super().downsample(parameter)
 
         quality_summed = block_reduce(np.array(self.quality), block_size=(parameter,))
 

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -26,8 +26,10 @@ class CountsSpectrum:
         Lower bin edges of energy axis
     energy_hi : `~astropy.units.Quantity`
         Upper bin edges of energy axis
-    data : `~astropy.units.Quantity`, array-like
-        Counts
+    data : `~numpy.ndarray`
+        Spectrum data.
+    unit : str or `~astropy.units.Unit`
+        Data unit
 
     Examples
     --------

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -51,6 +51,9 @@ class CountsSpectrum:
         e_edges = edges_from_lo_hi(energy_lo, energy_hi)
         self.energy = MapAxis.from_edges(e_edges, interp="log", name="energy")
 
+        if data is None:
+            data = np.zeros(self.energy.nbin)
+
         self.data = np.array(data)
         if not self.energy.nbin == self.data.size:
             raise ValueError("Incompatible data and energy axis size.")

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -410,7 +410,7 @@ class PHACountsSpectrum(CountsSpectrum):
         # Exclude groups where not all bins are within the safe threshold
         condition = quality_summed == parameter
         quality_rebinned = np.where(
-            condition, np.ones(len(retval.data.data)), np.zeros(len(retval.data.data))
+            condition, np.ones(len(retval.data)), np.zeros(len(retval.data))
         )
         retval.quality = np.array(quality_rebinned, dtype=int)
 

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -119,8 +119,6 @@ class CountsSpectrum:
     def fill(self, events):
         """Fill with list of events.
 
-        TODO: Move to `~gammapy.utils.nddata.NDDataArray`
-
         Parameters
         ----------
         events : `~astropy.units.Quantity`, `gammapy.data.EventList`,

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -260,7 +260,7 @@ class SpectrumDatasetOnOff(Dataset):
     @property
     def data_shape(self):
         """Shape of the counts data"""
-        return self.counts.data.data.shape
+        return self.counts.data.shape
 
     def npred(self):
         """Predicted counts vector."""

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -98,18 +98,18 @@ class SpectrumDataset(Dataset):
     @property
     def data_shape(self):
         """Shape of the counts data"""
-        return self.counts.data.data.shape
+        return self.counts.data.shape
 
     def npred(self):
         """Returns npred map (model + background)"""
         npred = self._predictor.compute_npred()
         if self.background:
-            npred.data.data += self.background.data.data
+            npred.data += self.background.data
         return npred
 
     def likelihood_per_bin(self):
         """Likelihood per bin given the current model parameters"""
-        return cash(n_on=self.counts.data.data, mu_on=self.npred().data.data)
+        return cash(n_on=self.counts.data, mu_on=self.npred().data)
 
     def fake(self, random_state="random-seed"):
         """Simulate a fake `~gammapy.spectrum.CountsSpectrum`.
@@ -126,7 +126,7 @@ class SpectrumDataset(Dataset):
             the fake count spectrum
         """
         random_state = get_random_state(random_state)
-        data = random_state.poisson(self.npred().data.data)
+        data = random_state.poisson(self.npred().data)
         energy = self.counts.energy.edges
         return CountsSpectrum(energy[:-1], energy[1:], data)
 
@@ -273,10 +273,10 @@ class SpectrumDatasetOnOff(Dataset):
         """Likelihood per bin given the current model parameters"""
         npred = self.npred()
         on_stat_ = wstat(
-            n_on=self.counts.data.data,
-            n_off=self.counts_off.data.data,
+            n_on=self.counts.data,
+            n_off=self.counts_off.data,
             alpha=self.alpha,
-            mu_sig=npred.data.data,
+            mu_sig=npred.data,
         )
         return np.nan_to_num(on_stat_)
 
@@ -310,12 +310,12 @@ class SpectrumDatasetOnOff(Dataset):
 
     def excess(self):
         """Excess (counts - alpha * counts_off)"""
-        excess = self.counts.data.data - self.alpha * self.counts_off.data.data
+        excess = self.counts.data - self.alpha * self.counts_off.data
         return self._as_counts_spectrum(excess)
 
     def residuals(self):
         """Residuals (npred - excess)."""
-        residuals = self.npred().data.data - self.excess().data.data
+        residuals = self.npred().data - self.excess().data
         return self._as_counts_spectrum(residuals)
 
     def peek(self, figsize=(10, 10)):
@@ -329,7 +329,7 @@ class SpectrumDatasetOnOff(Dataset):
         energy_unit = "TeV"
         if self.counts_off is not None:
             energy = self.counts_off.energy.edges
-            data = self.counts_off.data.data * self.alpha
+            data = self.counts_off.data * self.alpha
             background_vector = CountsSpectrum(
                 data=data, energy_lo=energy[:-1], energy_hi=energy[1:]
             )
@@ -442,7 +442,7 @@ class SpectrumDatasetOnOff(Dataset):
         residuals.plot(ax=ax, ecolor="black", fmt="none", energy_unit=self._e_unit)
         ax.axhline(0, color="black", lw=0.5)
 
-        ymax = 1.2 * max(residuals.data.data.value)
+        ymax = 1.2 * max(residuals.data)
         ax.set_ylim(-ymax, ymax)
 
         ax.set_xlabel("Energy [{}]".format(self._e_unit))
@@ -565,7 +565,7 @@ class SpectrumDatasetOnOff(Dataset):
 
         for ii in idx:
             if self.counts_off is not None:
-                n_off = int(self.counts_off.data.data.value[ii])
+                n_off = int(self.counts_off.data[ii])
                 a_off = self.counts_off._backscal_array[ii]
             else:
                 n_off = 0
@@ -574,7 +574,7 @@ class SpectrumDatasetOnOff(Dataset):
             stat = SpectrumStats(
                 energy_min=self.counts.energy.edges[ii],
                 energy_max=self.counts.energy.edges[ii + 1],
-                n_on=int(self.counts.data.data.value[ii]),
+                n_on=int(self.counts.data[ii]),
                 n_off=n_off,
                 a_on=self.counts._backscal_array[ii],
                 a_off=a_off,
@@ -695,7 +695,7 @@ class SpectrumDatasetOnOffStacker:
         stacked_data = np.zeros(energy.nbin)
         stacked_quality = np.ones(energy.nbin)
         for spec in counts_spectrum_list:
-            stacked_data += spec.counts_in_safe_range.value
+            stacked_data += spec.counts_in_safe_range.data
             temp = np.logical_and(stacked_quality, spec.quality)
             stacked_quality = np.array(temp, dtype=int)
 
@@ -719,11 +719,11 @@ class SpectrumDatasetOnOffStacker:
             bkscal_off_data = obs.counts_off._backscal_array.copy()
             bkscal_off += (
                 bkscal_on_data / bkscal_off_data
-            ) * obs.counts_off.counts_in_safe_range.value
+            ) * obs.counts_off.counts_in_safe_range
             alpha_sum += (obs.alpha * obs.counts_off.counts_in_safe_range).sum()
 
         with np.errstate(divide="ignore", invalid="ignore"):
-            stacked_bkscal_off = self.stacked_off_vector.data.data.value / bkscal_off
+            stacked_bkscal_off = self.stacked_off_vector.data / bkscal_off
             alpha_average = (
                 alpha_sum / self.stacked_off_vector.counts_in_safe_range.sum()
             )
@@ -732,7 +732,7 @@ class SpectrumDatasetOnOffStacker:
         # this leads to problems when fitting the data
         # use 1 for backscale of on_vector and 1 / alpha_average for backscale of off_vector
         alpha_correction = 1
-        idx = np.where(self.stacked_off_vector.data.data == 0)[0]
+        idx = np.where(self.stacked_off_vector.data == 0)[0]
         bkscal_on[idx] = alpha_correction
         # For the bins where the stacked OFF counts equal 0, the alpha value is performed by weighting on the total
         # OFF counts of each run

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1033,10 +1033,7 @@ class FluxPointsEstimator:
             if dataset.mask_safe is not None:
                 mask &= dataset.mask_safe
 
-            if isinstance(dataset, SpectrumDatasetOnOff):
-                counts.append(dataset.counts.data.data[mask].sum())
-            else:
-                counts.append(dataset.counts.data[mask].sum())
+            counts.append(dataset.counts.data[mask].sum())
 
         return {"counts": np.array(counts, dtype=int)}
 

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -78,7 +78,7 @@ class SensitivityEstimator:
         # then integrate bkg model and gamma over those energy bins.
         energy = self.rmf.e_reco.center
 
-        bkg_counts = (self.bkg.data.data.to("1/s") * self.livetime).value
+        bkg_counts = (self.bkg.quantity.to("1/s") * self.livetime).value
 
         excess_counts = excess_matching_significance_on_off(
             n_off=bkg_counts / self.alpha, alpha=self.alpha, significance=self.sigma
@@ -94,7 +94,7 @@ class SensitivityEstimator:
         predictor = SpectrumEvaluator(
             model, aeff=self.arf, edisp=self.rmf, livetime=self.livetime
         )
-        counts = predictor.compute_npred().data.data.value
+        counts = predictor.compute_npred().data
         phi_0 = excess_counts / counts
 
         dnde_model = model(energy=energy)

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -193,7 +193,7 @@ class SpectrumSimulation:
         off_counts = rand.poisson(self.npred_background.data / self.alpha)
 
         # Add background to on_vector
-        self.on_vector.data.data += bkg_counts
+        self.on_vector.data += bkg_counts
 
         # Create off vector
         off_vector = PHACountsSpectrum(

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -163,7 +163,7 @@ class SpectrumSimulation:
         rand : `~numpy.random.RandomState`
             random state
         """
-        on_counts = rand.poisson(self.npred_source.data.data.value)
+        on_counts = rand.poisson(self.npred_source.data)
 
         on_vector = PHACountsSpectrum(
             energy_lo=self.e_reco[:-1],
@@ -189,8 +189,8 @@ class SpectrumSimulation:
         rand : `~numpy.random.RandomState`
             random state
         """
-        bkg_counts = rand.poisson(self.npred_background.data.data.value)
-        off_counts = rand.poisson(self.npred_background.data.data.value / self.alpha)
+        bkg_counts = rand.poisson(self.npred_background.data)
+        off_counts = rand.poisson(self.npred_background.data / self.alpha)
 
         # Add background to on_vector
         self.on_vector.data.data += bkg_counts

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -49,7 +49,7 @@ class TestCountsSpectrum:
     def test_downsample(self):
         rebinned_spec = self.spec.downsample(2)
         assert rebinned_spec.energy.nbin == self.spec.energy.nbin / 2
-        assert rebinned_spec.data.data.shape[0] == self.spec.data.data.shape[0] / 2
+        assert rebinned_spec.data.shape[0] == self.spec.data.shape[0] / 2
         assert rebinned_spec.total_counts == self.spec.total_counts
 
         idx = rebinned_spec.energy.coord_to_idx([2, 3, 5] * u.TeV)
@@ -110,7 +110,7 @@ class TestPHACountsSpectrum:
     @requires_dependency("sherpa")
     def test_to_sherpa(self):
         sherpa_dataset = self.spec.to_sherpa("test")
-        assert_allclose(sherpa_dataset.counts, self.spec.data.data)
+        assert_allclose(sherpa_dataset.counts, self.spec.data)
 
     def test_reset_thresholds(self):
         self.spec.reset_thresholds()

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -20,17 +20,6 @@ class TestCountsSpectrum:
             data=self.counts, energy_lo=self.bins[:-1], energy_hi=self.bins[1:]
         )
 
-    def test_init_wo_unit(self):
-        counts = [2, 5]
-        energy = [1, 2, 3] * u.TeV
-        spec = CountsSpectrum(data=counts, energy_lo=energy[:-1], energy_hi=energy[1:])
-        assert spec.data.data.unit.is_equivalent("")
-
-        counts = u.Quantity([2, 5])
-        spec = CountsSpectrum(data=counts, energy_lo=energy[:-1], energy_hi=energy[1:])
-
-        assert spec.data.data.unit.is_equivalent("")
-
     def test_wrong_init(self):
         bins = energy_logspace(1, 10, 8, "TeV")
         with pytest.raises(ValueError):
@@ -39,11 +28,6 @@ class TestCountsSpectrum:
                 energy_lo=bins[:-1],
                 energy_hi=bins[1:],
             )
-
-    def test_evaluate(self):
-        test_e = self.bins[2] + 0.1 * u.TeV
-        test_eval = self.spec.data.evaluate(energy=test_e)
-        assert_allclose(test_eval, self.counts[2])
 
     @requires_dependency("matplotlib")
     def test_plot(self):
@@ -71,7 +55,8 @@ class TestCountsSpectrum:
         with pytest.raises(ValueError):
             rebinned_spec = self.spec.rebin(4)
 
-        actual = rebinned_spec.data.evaluate(energy=[2, 3, 5] * u.TeV)
+        idx = rebinned_spec.energy.coord_to_idx([2, 3, 5] * u.TeV)
+        actual = rebinned_spec.data[idx]
         desired = [0, 7, 20]
         assert (actual == desired).all()
 
@@ -91,19 +76,6 @@ class TestPHACountsSpectrum:
         self.spec.obs_id = 42
         self.spec.livetime = 3 * u.h
 
-    def test_init_wo_unit(self):
-        counts = [2, 5]
-        energy = [1, 2, 3] * u.TeV
-        spec = PHACountsSpectrum(
-            data=counts, energy_lo=energy[:-1], energy_hi=energy[1:]
-        )
-        assert spec.data.data.unit.is_equivalent("")
-
-        counts = u.Quantity([2, 5])
-        spec = PHACountsSpectrum(
-            data=counts, energy_lo=energy[:-1], energy_hi=energy[1:]
-        )
-        assert spec.data.data.unit.is_equivalent("")
 
     def test_basic(self):
         assert "PHACountsSpectrum" in str(self.spec)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -46,14 +46,11 @@ class TestCountsSpectrum:
         spec2 = CountsSpectrum.read(filename)
         assert_quantity_allclose(spec2.energy.edges, self.bins)
 
-    def test_rebin(self):
-        rebinned_spec = self.spec.rebin(2)
+    def test_downsample(self):
+        rebinned_spec = self.spec.downsample(2)
         assert rebinned_spec.energy.nbin == self.spec.energy.nbin / 2
         assert rebinned_spec.data.data.shape[0] == self.spec.data.data.shape[0] / 2
         assert rebinned_spec.total_counts == self.spec.total_counts
-
-        with pytest.raises(ValueError):
-            rebinned_spec = self.spec.rebin(4)
 
         idx = rebinned_spec.energy.coord_to_idx([2, 3, 5] * u.TeV)
         actual = rebinned_spec.data[idx]

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -69,7 +69,7 @@ class TestSpectrumDataset:
         assert result.success
         assert "minuit" in repr(result)
 
-        npred = self.dataset.npred().data.data.sum()
+        npred = self.dataset.npred().data.sum()
         assert_allclose(npred, self.npred.sum(), rtol=1e-3)
         assert_allclose(result.total_stat, -18087404.624, rtol=1e-3)
 
@@ -86,7 +86,7 @@ class TestSpectrumDataset:
 
         assert isinstance(fake_spectrum, CountsSpectrum)
         assert_allclose(fake_spectrum.energy.edges, self.dataset.counts.energy.edges)
-        assert fake_spectrum.data.data.sum() == 907331
+        assert fake_spectrum.data.sum() == 907331
 
     def test_incorrect_mask(self):
         mask_fit = np.ones(self.nbins, dtype=np.dtype('float'))
@@ -175,7 +175,7 @@ class TestSpectrumDatasetOnOff:
         energy = self.aeff.energy.edges * self.aeff.energy.unit
         expected = self.aeff.data.data[0] * (energy[-1] - energy[0]) * const * livetime
 
-        assert_allclose(dataset.npred().data.data.sum(), expected.value)
+        assert_allclose(dataset.npred().data.sum(), expected.value)
 
     @requires_dependency("matplotlib")
     def test_peek(self):
@@ -303,7 +303,7 @@ class TestSimpleFit:
     def test_wstat(self):
         """WStat with on source and background spectrum"""
         on_vector = self.src.copy()
-        on_vector.data.data += self.bkg.data.data
+        on_vector.data += self.bkg.data
         obs = SpectrumDatasetOnOff(counts=on_vector, counts_off=self.off)
         obs.model = self.source_model
 
@@ -320,13 +320,13 @@ class TestSimpleFit:
     def test_joint(self):
         """Test joint fit for obs with different energy binning"""
         on_vector = self.src.copy()
-        on_vector.data.data += self.bkg.data.data
+        on_vector.data.data += self.bkg.data
         obs1 = SpectrumDatasetOnOff(counts=on_vector, counts_off=self.off)
         obs1.model = self.source_model
 
         src_rebinned = self.src.rebin(2)
         bkg_rebinned = self.off.rebin(2)
-        src_rebinned.data.data += self.bkg.rebin(2).data.data
+        src_rebinned.data.data += self.bkg.rebin(2).data
 
         obs2 = SpectrumDatasetOnOff(counts=src_rebinned, counts_off=bkg_rebinned)
         obs2.model = self.source_model
@@ -515,12 +515,12 @@ class TestSpectrumDatasetOnOffStacker:
             index=2, amplitude=2e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
         )
         self.obs_stacker.stacked_obs.model = pwl
-        npred_stacked = self.obs_stacker.stacked_obs.npred().data.data
+        npred_stacked = self.obs_stacker.stacked_obs.npred().data
         npred_summed = np.zeros_like(npred_stacked)
 
         for obs in self.obs_list:
             obs.model = pwl
-            npred_summed[obs.mask_safe] += obs.npred().data.data[obs.mask_safe]
+            npred_summed[obs.mask_safe] += obs.npred().data[obs.mask_safe]
 
         assert_allclose(npred_stacked, npred_summed)
 

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -154,7 +154,7 @@ class TestSpectrumDatasetOnOff:
         assert_allclose(self.dataset.alpha, 0.1)
 
     def test_data_shape(self):
-        assert self.dataset.data_shape == self.on_counts.data.data.shape
+        assert self.dataset.data_shape == self.on_counts.data.shape
 
     def test_mask_safe_setter(self):
         with pytest.raises(ValueError):
@@ -215,8 +215,8 @@ class TestSpectrumDatasetOnOff:
         filename = tmpdir / self.on_counts.phafile
         newdataset = SpectrumDatasetOnOff.from_ogip_files(filename)
 
-        assert_allclose(self.on_counts.data.data, newdataset.counts.data.data)
-        assert_allclose(self.off_counts.data.data, newdataset.counts_off.data.data)
+        assert_allclose(self.on_counts.data, newdataset.counts.data)
+        assert_allclose(self.off_counts.data, newdataset.counts_off.data)
         assert_allclose(self.edisp.pdf_matrix, newdataset.edisp.pdf_matrix)
 
     def test_to_from_ogip_files_no_edisp(self, tmpdir):
@@ -229,7 +229,7 @@ class TestSpectrumDatasetOnOff:
         filename = tmpdir / self.on_counts.phafile
         newdataset = SpectrumDatasetOnOff.from_ogip_files(filename)
 
-        assert_allclose(self.on_counts.data.data, newdataset.counts.data.data)
+        assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert newdataset.counts_off is None
         assert newdataset.edisp is None
 
@@ -320,13 +320,13 @@ class TestSimpleFit:
     def test_joint(self):
         """Test joint fit for obs with different energy binning"""
         on_vector = self.src.copy()
-        on_vector.data.data += self.bkg.data
+        on_vector.data += self.bkg.data
         obs1 = SpectrumDatasetOnOff(counts=on_vector, counts_off=self.off)
         obs1.model = self.source_model
 
         src_rebinned = self.src.rebin(2)
         bkg_rebinned = self.off.rebin(2)
-        src_rebinned.data.data += self.bkg.rebin(2).data
+        src_rebinned.data += self.bkg.rebin(2).data
 
         obs2 = SpectrumDatasetOnOff(counts=src_rebinned, counts_off=bkg_rebinned)
         obs2.model = self.source_model
@@ -379,7 +379,7 @@ class TestSpectralFit:
         assert_allclose(pars["index"].value, 2.817, rtol=1e-3)
         assert pars["amplitude"].unit == "cm-2 s-1 TeV-1"
         assert_allclose(pars["amplitude"].value, 5.142e-11, rtol=1e-3)
-        assert_allclose(self.obs_list[0].npred().data.data[60], 0.6102, rtol=1e-3)
+        assert_allclose(self.obs_list[0].npred().data[60], 0.6102, rtol=1e-3)
         pars.to_table()
 
     def test_basic_errors(self):

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -137,8 +137,8 @@ class TestSpectrumExtraction:
             testobs.aeff.data.data, extraction.spectrum_observations[0].aeff.data.data
         )
         assert_quantity_allclose(
-            testobs.counts.data.data,
-            extraction.spectrum_observations[0].counts.data.data,
+            testobs.counts.data,
+            extraction.spectrum_observations[0].counts.data,
         )
         assert_allclose(
             testobs.counts.energy.center,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -60,7 +60,7 @@ class TestFit:
         """Simple CASH fit to the on vector"""
         dataset = SpectrumDataset(model=self.source_model, counts=self.src)
 
-        npred = dataset.npred().data.data
+        npred = dataset.npred().data
         assert_allclose(npred[5], 660.5171, rtol=1e-5)
 
         stat_val = dataset.likelihood()

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -21,9 +21,9 @@ def sens():
     ereco = np.logspace(0, 1, 5) * u.TeV
     rmf = EnergyDispersion.from_diagonal_response(etrue, ereco)
 
-    bkg_array = np.ones(4) / u.s
-    bkg_array[-1] = 1e-3 / u.s
-    bkg = CountsSpectrum(energy_lo=ereco[:-1], energy_hi=ereco[1:], data=bkg_array)
+    bkg_array = np.ones(4)
+    bkg_array[-1] = 1e-3
+    bkg = CountsSpectrum(energy_lo=ereco[:-1], energy_hi=ereco[1:], data=bkg_array, unit="s-1")
 
     sens = SensitivityEstimator(
         arf=arf, rmf=rmf, bkg=bkg, livetime=1 * u.h, index=2, gamma_min=20, alpha=0.2

--- a/gammapy/spectrum/tests/test_simulation.py
+++ b/gammapy/spectrum/tests/test_simulation.py
@@ -61,7 +61,7 @@ class TestSpectrumSimulation:
         assert sim.obs.counts.total_counts == 161
         # The test value is taken from the test with edisp
         assert_allclose(
-            np.sum(sim.npred_source.data.data.value), 167.467572145, rtol=0.01
+            np.sum(sim.npred_source.data), 167.467572145, rtol=0.01
         )
 
     def test_without_aeff(self):

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -122,5 +122,5 @@ def test_counts_predictor(case):
     opts = case.copy()
     del opts["npred"]
     predictor = SpectrumEvaluator(**opts)
-    actual = predictor.compute_npred().total_counts.value
+    actual = predictor.compute_npred().total_counts
     assert_allclose(actual, case["npred"])

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -822,7 +822,7 @@ class LightCurveEstimator:
                 edisp=spec.edisp,
                 model=spectral_model,
             )
-            counts_predicted_excess = counts_predictor.compute_npred().data.data[
+            counts_predicted_excess = counts_predictor.compute_npred().data[
                 e_idx[:-1]
             ]
 
@@ -848,11 +848,11 @@ class LightCurveEstimator:
             if alpha_mean == 0.0:  # use backup if necessary
                 alpha_mean = alpha_mean_backup
 
-            flux = measured_excess / predicted_excess.value
+            flux = measured_excess / predicted_excess
             flux *= int_flux
 
             # Gaussian errors, TODO: should be improved
-            flux_err = int_flux / predicted_excess.value
+            flux_err = int_flux / predicted_excess
             delta_excess = excess_error(n_on=n_on, n_off=n_off, alpha=alpha_mean)
             flux_err *= delta_excess
 
@@ -863,7 +863,7 @@ class LightCurveEstimator:
             flux_ul = excess_ul_helene(
                 n_on - alpha_mean * n_off, delta_excess, ul_significance
             )
-            flux_ul *= int_flux / predicted_excess.value
+            flux_ul *= int_flux / predicted_excess
         else:
             flux = u.Quantity(0, "cm-2 s-1")
             flux_err = u.Quantity(0, "cm-2 s-1")

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -101,20 +101,6 @@ class NDDataArray:
         """Dimension (number of axes)"""
         return len(self.axes)
 
-    def find_node(self, **kwargs):
-        """Find next node
-
-        Parameters
-        ----------
-        kwargs : dict
-            Keys are the axis names, Values the evaluation points
-        """
-        node = []
-        for axis in self.axes:
-            lookup_val = Quantity(kwargs.pop(axis.name))
-            temp = axis.coord_to_idx(lookup_val)
-            node.append(temp)
-        return node
 
     def evaluate(self, method=None, **kwargs):
         """Evaluate NDData Array

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -53,15 +53,6 @@ class TestNDDataArray:
     def test_str(self, nddata_1d):
         assert "x" in str(nddata_1d)
 
-    def test_find_node_1d(self, nddata_1d):
-        node = nddata_1d.find_node(x=4)
-        assert_equal(node, [1])
-
-    def test_find_node_2d(self, nddata_2d):
-        node = nddata_2d.find_node(energy=100 * u.TeV, offset=0.4 * u.deg)
-        assert_equal(node[0], [1])
-        assert_equal(node[1], [2])
-
     def test_evaluate_shape_1d(self, nddata_1d):
         # Scalar input
         out = nddata_1d.evaluate(x=1.5)

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -151,7 +151,7 @@
     "    fov_lon=0 * u.deg, fov_lat=offset, energy_reco=energy_reco\n",
     ")\n",
     "bkg = CountsSpectrum(\n",
-    "    energy_reco[:-1], energy_reco[1:], data=(bkg_data * solid_angles)\n",
+    "    energy_reco[:-1], energy_reco[1:], data=(bkg_data * solid_angles).to_value(\"s-1\"), unit=\"s-1\"\n",
     ")"
    ]
   },
@@ -301,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR removes the use of `NDDataArray` from the `CountsSpectrum` class and makes `CountsSpectrum.data` a plain `np.ndarray`. This simplifies the data access, without loosing any functionality and makes the API more uniform with the `Map` object. 