### PR TITLE
Add gammapy.utils.regions helpers

### DIFF
--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -137,6 +137,10 @@ Reference/API
     :no-inheritance-diagram:
     :include-all-objects:
 
+.. automodapi:: gammapy.utils.regions
+    :no-inheritance-diagram:
+    :include-all-objects:
+
 .. automodapi:: gammapy.utils.scripts
     :no-inheritance-diagram:
     :include-all-objects:

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -1,0 +1,99 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Regions helper functions.
+
+Throughout Gammapy, we use `regions` to represent and work with regions.
+
+https://astropy-regions.readthedocs.io
+
+The functions ``make_region`` and ``make_pixel_region`` should be used
+throughout Gammapy in all functions that take ``region`` objects as input.
+They do conversion to a standard form, and some validation.
+
+We might add in other conveniences and features here, e.g. sky coord contains
+without a WCS (see "sky and pixel regions" in PIG 10), or some HEALPix integration.
+
+TODO: before Gammapy v1.0, discuss what to do about ``gammapy.utils.regions``.
+Options: keep as-is, hide from the docs, or to remove it completely
+(if the functionality is available in ``astropy-regions`` directly.
+"""
+from regions import DS9Parser, SkyRegion, PixelRegion
+
+__all__ = ["make_region", "make_pixel_region"]
+
+
+def make_region(region):
+    """Make region object (`regions.Region`).
+
+    See also:
+
+    * `gammapy.utils.regions.make_pixel_region`
+    * https://astropy-regions.readthedocs.io/en/latest/ds9.html
+    * http://ds9.si.edu/doc/ref/region.html
+
+    Parameters
+    ----------
+    region : `regions.Region` or str
+        Region object or DS9 string representation
+
+    Examples
+    --------
+    If a region object in DS9 string format is given, the corresponding
+    region object is created. Note that in the DS9 format "image"
+    or "physical" coordinates start at 1, whereas `regions.PixCoord`
+    starts at 0 (as does Python, Numpy, Astropy, Gammapy, ...).
+
+    >>> from gammapy.utils.regions import make_region
+    >>> make_region("image;circle(10,20,3)")
+    <CirclePixelRegion(PixCoord(x=9.0, y=19.0), radius=3.0)>
+    >>> make_region("galactic;circle(10,20,3)")
+    <CircleSkyRegion(<SkyCoord (Galactic): (l, b) in deg
+        (10., 20.)>, radius=3.0 deg)>
+
+    If a region object is passed in, it is returned unchanged:
+
+    >>> region = make_region("image;circle(10,20,3)")
+    >>> region2 = make_region(region)
+    >>> region is region2
+    True
+    """
+    if isinstance(region, str):
+        # This is basic and works for simple regions
+        # It could be extended to cover more things,
+        # like e.g. compound regions, exclusion regions, ....
+        return DS9Parser(region).shapes[0].to_region()
+    else:
+        return region
+
+
+def make_pixel_region(region, wcs=None):
+    """Make pixel region object (`regions.PixelRegion`).
+
+    See also: `gammapy.utils.regions.make_region`
+
+    Parameters
+    ----------
+    region : `regions.Region` or str
+        Region object or DS9 string representation
+    wcs : `astropy.wcs.WCS`
+        WCS
+
+    Examples
+    --------
+    >>> from gammapy.maps import WcsGeom
+    >>> from gammapy.utils.regions import make_pixel_region
+    >>> wcs = WcsGeom.create().wcs
+    >>> region = make_pixel_region("galactic;circle(10,20,3)", wcs)
+    >>> region
+    <CirclePixelRegion(PixCoord(x=570.9301128316974, y=159.935542455567), radius=6.061376992149382)>
+    """
+    if isinstance(region, str):
+        region = make_region(region)
+
+    if isinstance(region, SkyRegion):
+        if wcs is None:
+            raise ValueError("Need wcs to convert to pixel region")
+        return region.to_pixel(wcs)
+    elif isinstance(region, PixelRegion):
+        return region
+    else:
+        raise TypeError("Invalid type: {!r}".format(region))

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -1,0 +1,53 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Here we test the functions in `gammapy.utils.regions`.
+
+We can also add tests for specific functionality and behaviour
+in https://astropy-regions.readthedocs.io that we rely on in Gammapy.
+That package is still work in progress and not fully developed and
+stable, so need to establish a bit what works and what doesn't.
+"""
+import pytest
+from numpy.testing import assert_allclose
+import regions
+from ...maps import WcsGeom
+from ..regions import make_region, make_pixel_region
+
+
+def test_make_region():
+    reg = make_region("image;circle(10,20,3)")
+    assert isinstance(reg, regions.CirclePixelRegion)
+    assert reg.center.x == 9
+    assert reg.center.y == 19
+    assert reg.radius == 3
+
+    reg = make_region("galactic;circle(10,20,3)")
+    assert reg.center.l.deg == 10
+    assert reg.center.b.deg == 20
+    assert reg.radius.to_value("deg") == 3
+
+    # Existing regions should pass through
+    reg2 = make_region(reg)
+    assert reg is reg2
+
+
+def test_make_pixel_region():
+    wcs = WcsGeom.create().wcs
+
+    reg = make_pixel_region("image;circle(10,20,3)")
+    assert isinstance(reg, regions.CirclePixelRegion)
+    assert reg.center.x == 9
+    assert reg.center.y == 19
+    assert reg.radius == 3
+
+    reg = make_pixel_region("galactic;circle(10,20,3)", wcs)
+    assert isinstance(reg, regions.CirclePixelRegion)
+    assert_allclose(reg.center.x, 570.9301128316974)
+    assert_allclose(reg.center.y, 159.935542455567)
+    assert_allclose(reg.radius, 6.061376992149382)
+
+    with pytest.raises(ValueError):
+        make_pixel_region("galactic;circle(10,20,3)")
+
+    with pytest.raises(TypeError):
+        make_pixel_region(99)


### PR DESCRIPTION
This PR adds the region helper functions described in PIG 10 "regions" in https://github.com/gammapy/gammapy/blob/09a7312eb87780afebdef77761def171ad3ce44d/docs/development/pigs/pig-010.rst#region-arguments in  #2129 .

I could shorten the PIG a bit before merging (deadline for comments is today), and instead reference this PR.

The next steps here are to change [region_mask](https://docs.gammapy.org/0.11/api/gammapy.maps.WcsGeom.html#gammapy.maps.WcsGeom.region_mask) to use this helper function, I'd prefer to dot that in a follow-up PR.

And then to refactor and clean up https://docs.gammapy.org/0.11/api/gammapy.data.ObservationTable.html#gammapy.data.ObservationTable.select_observations I think probably we want to add a convenience to make sky regions like circle work without a WCS, or at least give users a helper function to make a dummy WCS because it's non-trivial and needs a docstring and tests.

So if we add something like this, we could then either remove the `None` default for `wcs` from these functions, or we could keep it, but make the default WCS if the caller didn't pass one:
```python
def make_default_wcs(sky_region):
    """TODO: document"""
    # TODO: is this the best way to make a default WCS?
    from astropy.wcs.utils import celestial_frame_to_wcs

    center = sky_region.center  # TODO: could compute center for polygon here for now
    wcs = celestial_frame_to_wcs(center.frame)
    wcs.wcs.crval = center.data.lon.deg, center.data.lat.deg

    return wcs


def sky_region_contains(sky_region, sky_coord, wcs=None):
    if wcs is None:
        wcs = make_default_wcs(sky_region)

    pix_coord = PixCoord.from_sky(sky_coord, wcs)
    pix_region = sky_region.to_pixel(wcs)
    return pix_region.contains(pix_coord)
```

Most analyses will start with a cone selection on a run list (or a bow for the Galactic plane), and asking the user to make a WCS at that point in the notebook seems a bit weird to me. But we could go that way, and add convenience methods on `WcsGeom` to do something like this:
```
geom = WcsGeom.create(...)
mask = geom.contains(obs_table.sky_coord, border="3 deg")
obs_table = obs_table[mask]
```

I know I'm mixing a few questions here, but I'd like to continue with this in the next 2 days and get as far as I can - so @adonath @registerrier please comment.