### PR TITLE
Simplify `PHACountsSpectrum`

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -325,30 +325,6 @@ class PHACountsSpectrum(CountsSpectrum):
         self.meta = meta or OrderedDict()
 
     @property
-    def phafile(self):
-        """PHA file associated with the observation."""
-        if isinstance(self.obs_id, list):
-            filename = "pha_stacked.fits"
-        else:
-            filename = "pha_obs{}.fits".format(self.obs_id)
-        return filename
-
-    @property
-    def arffile(self):
-        """ARF associated with the observation."""
-        return self.phafile.replace("pha", "arf")
-
-    @property
-    def rmffile(self):
-        """RMF associated with the observation."""
-        return self.phafile.replace("pha", "rmf")
-
-    @property
-    def bkgfile(self):
-        """Background PHA files associated with the observation."""
-        return self.phafile.replace("pha", "bkg")
-
-    @property
     def bins_in_safe_range(self):
         """Indices of bins within the energy thresholds"""
         idx = np.where(np.array(self.quality) == 0)[0]
@@ -453,12 +429,20 @@ class PHACountsSpectrum(CountsSpectrum):
         meta["exposure"] = self.livetime.to_value("s")
         meta["obs_id"] = self.obs_id
 
-        if not self.is_bkg:
-            if self.rmffile is not None:
-                meta["respfile"] = self.rmffile
 
-            meta["backfile"] = self.bkgfile
-            meta["ancrfile"] = self.arffile
+        if isinstance(self.obs_id, list):
+            phafile = "pha_stacked.fits"
+        else:
+            phafile = "pha_obs{}.fits".format(self.obs_id)
+
+        bkgfile = phafile.replace("pha", "bkg")
+        arffile = phafile.replace("pha", "arf")
+        rmffile = phafile.replace("pha", "rmf")
+
+        if not self.is_bkg:
+            meta["respfile"] = rmffile
+            meta["backfile"] = bkgfile
+            meta["ancrfile"] = arffile
             meta["hduclas2"] = "TOTAL"
         else:
             meta["hduclas2"] = "BKG"

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -463,6 +463,7 @@ class PHACountsSpectrum(CountsSpectrum):
         quality = None
         areascal = None
         backscal = None
+
         if "QUALITY" in counts_table.colnames:
             quality = counts_table["QUALITY"].data
         if "AREASCAL" in counts_table.colnames:

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -361,10 +361,6 @@ class PHACountsSpectrum(CountsSpectrum):
             idx = np.insert(idx, 0, idx[0] - 1)
         self.quality[idx] = 1
 
-    def reset_thresholds(self):
-        """Reset energy thresholds (declare all energy bins valid)."""
-        self.quality = np.zeros_like(self.quality)
-
     def rebin(self, parameter):
         """Rebin.
 

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -292,8 +292,6 @@ class PHACountsSpectrum(CountsSpectrum):
         Observation identifier, optional
     livetime : `~astropy.units.Quantity`, optional
         Observation livetime
-    offset : `~astropy.units.Quantity`, optional
-        Field of view offset
     meta : dict, optional
         Meta information
     """
@@ -309,7 +307,6 @@ class PHACountsSpectrum(CountsSpectrum):
         is_bkg=False,
         obs_id=None,
         livetime=None,
-        offset=None,
         meta=None,
     ):
         super().__init__(energy_lo, energy_hi, data)
@@ -325,7 +322,6 @@ class PHACountsSpectrum(CountsSpectrum):
         self.is_bkg = is_bkg
         self.obs_id = obs_id
         self.livetime = livetime
-        self.offset = offset
         self.meta = meta or OrderedDict()
 
     @property

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -429,7 +429,6 @@ class PHACountsSpectrum(CountsSpectrum):
         meta["exposure"] = self.livetime.to_value("s")
         meta["obs_id"] = self.obs_id
 
-
         if isinstance(self.obs_id, list):
             phafile = "pha_stacked.fits"
         else:
@@ -491,37 +490,3 @@ class PHACountsSpectrum(CountsSpectrum):
         filename = make_path(filename)
         with fits.open(str(filename), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
-
-    def to_sherpa(self, name):
-        """Convert to `sherpa.astro.data.DataPHA`.
-
-        Parameters
-        ----------
-        name : str
-            Instance name
-        """
-        from sherpa.utils import SherpaFloat
-        from sherpa.astro.data import DataPHA
-
-        table = self.to_table()
-
-        # Workaround to avoid https://github.com/sherpa/sherpa/issues/248
-        if np.isscalar(self.backscal):
-            backscal = self.backscal
-        else:
-            backscal = self.backscal.copy()
-            if np.allclose(backscal.mean(), backscal):
-                backscal = backscal[0]
-
-        return DataPHA(
-            name=name,
-            channel=(table["CHANNEL"].data + 1).astype(SherpaFloat),
-            counts=table["COUNTS"].data.astype(SherpaFloat),
-            quality=table["QUALITY"].data,
-            exposure=self.livetime.to_value("s"),
-            backscal=backscal,
-            areascal=self.areascal,
-            syserror=None,
-            staterror=None,
-            grouping=None,
-        )

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -188,19 +188,6 @@ class SpectrumDatasetOnOff(Dataset):
         self.mask_safe = mask_safe
 
     @property
-    def livetime(self):
-        return self._livetime
-
-    @livetime.setter
-    def livetime(self, livetime):
-        self._livetime = livetime
-        if self.counts is not None:
-            self.counts.livetime = livetime
-        # TODO : check if off might have different exposure
-        if self.counts_off is not None:
-            self.counts_off.livetime = livetime
-
-    @property
     def mask_safe(self):
         """Inverse of counts spectrum quality mask."""
         return np.logical_not(self.counts.quality)
@@ -473,10 +460,12 @@ class SpectrumDatasetOnOff(Dataset):
         arffile = phafile.replace("pha", "arf")
         rmffile = phafile.replace("pha", "rmf")
 
+        self.counts.livetime = self.livetime
         self.counts.write(outdir / phafile, overwrite=overwrite, use_sherpa=use_sherpa)
         self.aeff.write(outdir / arffile, overwrite=overwrite, use_sherpa=use_sherpa)
 
         if self.counts_off is not None:
+            self.counts_off.livetime = self.livetime
             self.counts_off.write(
                 outdir / bkgfile, overwrite=overwrite, use_sherpa=use_sherpa
             )
@@ -499,7 +488,9 @@ class SpectrumDatasetOnOff(Dataset):
         """
         filename = make_path(filename)
         dirname = filename.parent
+
         on_vector = PHACountsSpectrum.read(filename)
+
         phafile = filename.name
 
         try:

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -181,10 +181,6 @@ class SpectrumDatasetOnOff(Dataset):
         self.aeff = aeff
         self.edisp = edisp
         self.model = model
-
-        if mask_safe is None:
-            mask_safe = np.logical_not(counts.quality)
-
         self.mask_safe = mask_safe
 
     @property
@@ -499,7 +495,7 @@ class SpectrumDatasetOnOff(Dataset):
         arffile = phafile.replace("pha", "arf")
         effective_area = EffectiveAreaTable.read(str(dirname / arffile))
 
-        mask_safe = on_vector.quality == 0
+        mask_safe = np.logical_not(on_vector.quality)
 
         return cls(
             counts=on_vector,
@@ -770,4 +766,5 @@ class SpectrumDatasetOnOffStacker:
             aeff=self.stacked_aeff,
             edisp=self.stacked_edisp,
             livetime=self.total_livetime,
+            mask_safe=np.logical_not(self.stacked_on_vector.quality)
         )

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -102,7 +102,3 @@ class TestPHACountsSpectrum:
         assert (spec_rebinned.quality == [1, 0, 0, 1]).all()
         assert_quantity_allclose(spec_rebinned.hi_threshold, 5.623413251903491 * u.TeV)
         assert_quantity_allclose(spec_rebinned.lo_threshold, 1.778279410038922 * u.TeV)
-
-    def test_reset_thresholds(self):
-        self.spec.reset_thresholds()
-        assert_allclose(self.spec.quality, 0.0)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -103,11 +103,6 @@ class TestPHACountsSpectrum:
         assert_quantity_allclose(spec_rebinned.hi_threshold, 5.623413251903491 * u.TeV)
         assert_quantity_allclose(spec_rebinned.lo_threshold, 1.778279410038922 * u.TeV)
 
-    @requires_dependency("sherpa")
-    def test_to_sherpa(self):
-        sherpa_dataset = self.spec.to_sherpa("test")
-        assert_allclose(sherpa_dataset.counts, self.spec.data)
-
     def test_reset_thresholds(self):
         self.spec.reset_thresholds()
         assert_allclose(self.spec.quality, 0.0)

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -162,10 +162,6 @@ class TestSpectrumDatasetOnOff:
     def test_data_shape(self):
         assert self.dataset.data_shape == self.on_counts.data.shape
 
-    def test_mask_safe_setter(self):
-        with pytest.raises(ValueError):
-            self.dataset.mask_safe = np.ones(self.dataset.data_shape, dtype="float")
-
     def test_npred_no_edisp(self):
         const = 1 / u.TeV / u.cm ** 2 / u.s
         model = ConstantModel(const)

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -218,7 +218,7 @@ class TestSpectrumDatasetOnOff:
             livetime=self.livetime,
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
-        filename = tmpdir / self.on_counts.phafile
+        filename = tmpdir / "pha_obstest.fits"
         newdataset = SpectrumDatasetOnOff.from_ogip_files(filename)
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
@@ -230,7 +230,7 @@ class TestSpectrumDatasetOnOff:
             counts=self.on_counts, aeff=self.aeff, livetime=self.livetime
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
-        filename = tmpdir / self.on_counts.phafile
+        filename = tmpdir / "pha_obstest.fits"
         newdataset = SpectrumDatasetOnOff.from_ogip_files(filename)
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
@@ -499,7 +499,6 @@ class TestSpectrumDatasetOnOffStacker:
 
     def test_basic(self):
         assert "Stacker" in str(self.obs_stacker)
-        assert "stacked" in str(self.obs_stacker.stacked_obs.counts.phafile)
         counts1 = self.obs_list[0].total_stats_safe_range.n_on
         counts2 = self.obs_list[1].total_stats_safe_range.n_on
         summed_counts = counts1 + counts2

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -212,6 +212,7 @@ class TestSpectrumDatasetOnOff:
             aeff=self.aeff,
             edisp=self.edisp,
             livetime=self.livetime,
+            mask_safe=np.logical_not(self.on_counts.quality)
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
         filename = tmpdir / "pha_obstest.fits"
@@ -223,7 +224,8 @@ class TestSpectrumDatasetOnOff:
 
     def test_to_from_ogip_files_no_edisp(self, tmpdir):
         dataset = SpectrumDatasetOnOff(
-            counts=self.on_counts, aeff=self.aeff, livetime=self.livetime
+            counts=self.on_counts, aeff=self.aeff, livetime=self.livetime,
+            mask_safe=np.logical_not(self.on_counts.quality)
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
         filename = tmpdir / "pha_obstest.fits"
@@ -463,6 +465,7 @@ def make_observation_list():
         aeff=aeff,
         edisp=edisp,
         livetime=livetime,
+        mask_safe=np.logical_not(on_vector.quality)
     )
     obs2 = SpectrumDatasetOnOff(
         counts=on_vector,
@@ -470,6 +473,7 @@ def make_observation_list():
         aeff=aeff,
         edisp=edisp,
         livetime=livetime,
+        mask_safe=np.logical_not(on_vector.quality)
     )
 
     obs_list = [obs1, obs2]

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -78,7 +78,7 @@ class TestFit:
 
     def test_fit_range(self):
         """Test fit range without complication of thresholds"""
-        dataset = SpectrumDatasetOnOff(counts=self.src)
+        dataset = SpectrumDatasetOnOff(counts=self.src, mask_safe=np.logical_not(self.src.quality))
         dataset.model = self.source_model
 
         assert np.sum(dataset.mask_safe) == self.nbins
@@ -88,7 +88,7 @@ class TestFit:
         assert_allclose(e_min.value, 0.1)
 
     def test_likelihood_profile(self):
-        dataset = SpectrumDataset(model=self.source_model, counts=self.src)
+        dataset = SpectrumDataset(model=self.source_model, counts=self.src, mask_safe=np.logical_not(self.src.quality))
         fit = Fit([dataset])
         result = fit.run()
         true_idx = result.parameters["index"].value

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -384,7 +384,8 @@
     "extract = SpectrumExtraction(\n",
     "    observations=observations, bkg_estimate=bkg_estimate\n",
     ")\n",
-    "extract.run()"
+    "extract.run()\n",
+    "extract.compute_energy_threshold()"
    ]
   },
   {


### PR DESCRIPTION
This PR simplifies the `PHACountsSpectrum`, so that it becomes easier to refactor and finally remove in following PRs. It includes the following changes:

- Remove `.to_sherpa()`method. The data can be written to file (there is a `use_sherpa` option, which writes in a sherpa compatible format) and read with sherpa again. I think there is no strong motivation to directly convert to `DataPHA` object.
- Remove the `SpectrumDatasetOnOff.livetime` setter, so that the info is not duplicated on the `counts` and `counts_off` objects anymore.
- Remove the `SpectrumDatasetOnOff.mask_safe` setter, so that the array is not duplicated on the `counts` and `counts_off` objects anymore.
- Remove the `PHACountsSpectrum.offset` attribute, which only used internally in `SpectrumExtraction`, but never for likelihood evaluation or I/O.
- Remove attributes from `PHACountsSpectrum` defining the filenames for I/O. The creation of filenames was moved to the `.to_hdulist()` methods instead.
- Remove the unused `reset_thresholds()` method. 