### PR TITLE
Add select_region method for event lists

### DIFF
--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -12,6 +12,7 @@ from ..utils.fits import earth_location_from_dict
 from ..utils.scripts import make_path
 from ..utils.time import time_ref_from_dict
 from ..utils.testing import Checker
+from ..utils.regions import make_region
 
 __all__ = ["EventListBase", "EventList", "EventListLAT"]
 
@@ -384,16 +385,16 @@ class EventListBase:
 
         Parameters
         ----------
-        region : `~regions.SkyRegion` or list of `~regions.SkyRegion`
-            (List of) sky region(s)
+        region : `~regions.SkyRegion` or str
+            Sky region or string defining a sky region
+        wcs : `~astropy.wcs.WCS`
+            the world coordinate system transformation to assume
 
         Returns
         -------
         event_list : `EventList`
             Copy of event list with selection applied.
         """
-        if not isinstance(region, list):
-            region = list([region])
         mask = self.filter_region(region, wcs)
         return self.select_row_subset(mask)
 
@@ -402,19 +403,19 @@ class EventListBase:
 
         Parameters
         ----------
-        region : list of `~regions.SkyRegion`
-            List of sky regions
+        region : `~regions.SkyRegion` or str
+            Sky region or string defining a sky region
+        wcs : `~astropy.wcs.WCS`
+            the world coordinate system transformation to assume
 
         Returns
         -------
         index_array : `numpy.ndarray`
             Index array of selected events
         """
+        region = make_region(region)
         position = self.radec
-        mask = np.array([], dtype=int)
-        for reg in region:
-            temp = np.where(reg.contains(position, wcs))[0]
-            mask = np.union1d(mask, temp)
+        mask = np.where(region.contains(position, wcs))[0]
 
         return mask
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -379,6 +379,45 @@ class EventListBase:
 
         return mask
 
+    def select_region(self, region, wcs):
+        """Select events in circular regions.
+
+        Parameters
+        ----------
+        region : `~regions.SkyRegion` or list of `~regions.SkyRegion`
+            (List of) sky region(s)
+
+        Returns
+        -------
+        event_list : `EventList`
+            Copy of event list with selection applied.
+        """
+        if not isinstance(region, list):
+            region = list([region])
+        mask = self.filter_region(region, wcs)
+        return self.select_row_subset(mask)
+
+    def filter_region(self, region, wcs):
+        """Create selection mask for event in given circular regions.
+
+        Parameters
+        ----------
+        region : list of `~regions.SkyRegion`
+            List of sky regions
+
+        Returns
+        -------
+        index_array : `numpy.ndarray`
+            Index array of selected events
+        """
+        position = self.radec
+        mask = np.array([], dtype=int)
+        for reg in region:
+            temp = np.where(reg.contains(position, wcs))[0]
+            mask = np.union1d(mask, temp)
+
+        return mask
+
     def select_parameter(self, parameter, band):
         """Select events with respect to a specified parameter.
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -381,14 +381,14 @@ class EventListBase:
         return mask
 
     def select_region(self, region, wcs):
-        """Select events in circular regions.
+        """Select events in given region.
 
         Parameters
         ----------
         region : `~regions.SkyRegion` or str
             Sky region or string defining a sky region
         wcs : `~astropy.wcs.WCS`
-            the world coordinate system transformation to assume
+            The world coordinate system transformation to assume
 
         Returns
         -------
@@ -399,14 +399,14 @@ class EventListBase:
         return self.select_row_subset(mask)
 
     def filter_region(self, region, wcs):
-        """Create selection mask for event in given circular regions.
+        """Create selection mask for event in given region.
 
         Parameters
         ----------
         region : `~regions.SkyRegion` or str
             Sky region or string defining a sky region
         wcs : `~astropy.wcs.WCS`
-            the world coordinate system transformation to assume
+            The world coordinate system transformation to assume
 
         Returns
         -------

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -146,8 +146,14 @@ class TestEventSelection:
         new_list = self.evt_list.select_region(self.on_regions[0], geom.wcs)
         assert len(new_list.table) == 2
 
-        new_list = self.evt_list.select_region(self.on_regions, geom.wcs)
+        union_region = self.on_regions[0].union(self.on_regions[1])
+        new_list = self.evt_list.select_region(union_region, geom.wcs)
         assert len(new_list.table) == 3
+
+        region_string = 'fk5;box(0,10, 0.25, 0.15)'
+        new_list = self.evt_list.select_region(region_string, geom.wcs)
+        assert len(new_list.table) == 1
+
 
     def test_map_select(self):
         axis = MapAxis.from_edges((0.5, 2.0), unit="TeV", name="ENERGY")

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -135,8 +135,19 @@ class TestEventSelection:
         evt_table = Table([ra, dec, energy], names=["RA", "DEC", "ENERGY"])
         self.evt_list = EventListBase(evt_table)
 
-        center = SkyCoord(0.0, 0.0, frame="icrs", unit="deg")
-        self.on_region = CircleSkyRegion(center, radius=1.0 * u.deg)
+        center1 = SkyCoord(0.0, 0.0, frame="icrs", unit="deg")
+        on_region1 = CircleSkyRegion(center1, radius=1.0 * u.deg)
+        center2 = SkyCoord(0.0, 10.0, frame="icrs", unit="deg")
+        on_region2 = CircleSkyRegion(center2, radius=0.5 * u.deg)
+        self.on_regions = [on_region1, on_region2]
+
+    def test_region_select(self):
+        geom = WcsGeom.create(skydir=(0, 0), binsz=0.2, width=4.0 * u.deg, proj="TAN")
+        new_list = self.evt_list.select_region(self.on_regions[0], geom.wcs)
+        assert len(new_list.table) == 2
+
+        new_list = self.evt_list.select_region(self.on_regions, geom.wcs)
+        assert len(new_list.table) == 3
 
     def test_map_select(self):
         axis = MapAxis.from_edges((0.5, 2.0), unit="TeV", name="ENERGY")
@@ -144,9 +155,7 @@ class TestEventSelection:
             skydir=(0, 0), binsz=0.2, width=4.0 * u.deg, proj="TAN", axes=[axis]
         )
 
-        mask_data = geom.region_mask(regions=[self.on_region], inside=True).astype(
-            float
-        )
+        mask_data = geom.region_mask(regions=[self.on_regions[0]], inside=True)
         mask = Map.from_geom(geom, data=mask_data)
         new_list = self.evt_list.select_map_mask(mask)
         assert len(new_list.table) == 2

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from regions import CircleSkyRegion
+from regions import CircleSkyRegion, RectangleSkyRegion
 from numpy.testing import assert_allclose
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...data.event_list import EventListBase, EventList, EventListLAT
@@ -138,7 +138,7 @@ class TestEventSelection:
         center1 = SkyCoord(0.0, 0.0, frame="icrs", unit="deg")
         on_region1 = CircleSkyRegion(center1, radius=1.0 * u.deg)
         center2 = SkyCoord(0.0, 10.0, frame="icrs", unit="deg")
-        on_region2 = CircleSkyRegion(center2, radius=0.5 * u.deg)
+        on_region2 = RectangleSkyRegion(center2, width=0.5 * u.deg, height=0.3*u.deg)
         self.on_regions = [on_region1, on_region2]
 
     def test_region_select(self):

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -16,7 +16,7 @@ TODO: before Gammapy v1.0, discuss what to do about ``gammapy.utils.regions``.
 Options: keep as-is, hide from the docs, or to remove it completely
 (if the functionality is available in ``astropy-regions`` directly.
 """
-from regions import DS9Parser, SkyRegion, PixelRegion
+from regions import DS9Parser, SkyRegion, PixelRegion, Region
 
 __all__ = ["make_region", "make_pixel_region"]
 
@@ -61,8 +61,10 @@ def make_region(region):
         # It could be extended to cover more things,
         # like e.g. compound regions, exclusion regions, ....
         return DS9Parser(region).shapes[0].to_region()
-    else:
+    elif isinstance(region, Region):
         return region
+    else:
+        raise TypeError("Invalid type: {!r}".format(region))
 
 
 def make_pixel_region(region, wcs=None):

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -30,6 +30,8 @@ def test_make_region():
     reg2 = make_region(reg)
     assert reg is reg2
 
+    with pytest.raises(TypeError):
+        make_pixel_region([reg])
 
 def test_make_pixel_region():
     wcs = WcsGeom.create().wcs


### PR DESCRIPTION
Following PIG 10, see #2129 this PR introduces an `EventListBase.select_region(region, wcs)` as well as some tests.

This will be used for PR #2089 to properly select events.