### PR TITLE
Fix Fit.minos contour method for frozen parameters.

### DIFF
--- a/gammapy/utils/fitting/iminuit.py
+++ b/gammapy/utils/fitting/iminuit.py
@@ -99,11 +99,13 @@ def confidence_iminuit(minuit, parameters, parameter, sigma, maxcall=0):
 
 
 def mncontour(minuit, parameters, x, y, numpoints, sigma):
-    idx = parameters._get_idx(x)
-    x = _make_parname(idx, parameters[idx])
+    par_x = parameters[x]
+    idx_x = parameters.free_parameters.index(par_x)
+    x = _make_parname(idx_x, par_x)
 
-    idx = parameters._get_idx(y)
-    y = _make_parname(idx, parameters[idx])
+    par_y = parameters[y]
+    idx_y = parameters.free_parameters.index(par_y)
+    y = _make_parname(idx_y, par_y)
 
     x_info, y_info, contour = minuit.mncontour(x, y, numpoints, sigma)
     contour = np.array(contour)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -135,18 +135,18 @@ def test_minos_contour():
     dataset = MyDataset()
     fit = Fit(dataset)
     fit.optimize(backend="minuit")
-    result = fit.minos_contour("x", "y")
+    result = fit.minos_contour("y", "z")
 
     assert result["success"] is True
 
     x = result["x"]
     assert_allclose(len(x), 10)
-    assert_allclose(x[0], 1, rtol=1e-5)
-    assert_allclose(x[-1], 1.499963, rtol=1e-5)
+    assert_allclose(x[0], 299, rtol=1e-5)
+    assert_allclose(x[-1], 299.133975, rtol=1e-5)
     y = result["y"]
     assert_allclose(len(y), 10)
-    assert_allclose(y[0], 300, rtol=1e-5)
-    assert_allclose(y[-1], 300.866004, rtol=1e-5)
+    assert_allclose(y[0], 0.04, rtol=1e-5)
+    assert_allclose(y[-1], 0.54, rtol=1e-5)
 
     # Check that original value state wasn't changed
-    assert_allclose(dataset.parameters["x"].value, 2)
+    assert_allclose(dataset.parameters["y"].value, 300)

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -133,6 +133,7 @@ def test_likelihood_profile_reoptimize():
 
 def test_minos_contour():
     dataset = MyDataset()
+    dataset.parameters["x"].frozen = True
     fit = Fit(dataset)
     fit.optimize(backend="minuit")
     result = fit.minos_contour("y", "z")


### PR DESCRIPTION
This PR fixes #2258 and modifies the test to cover the bug. A more detailed description of the problem is given in https://github.com/gammapy/gammapy/issues/2258#issuecomment-505472953. 