### PR TITLE
Use subprocess.run consistently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ matrix:
 
         # Test example scripts
         - os: linux
-          env: PYTHON_VERSION=3.7 MAIN_CMD='make' SETUP_CMD='test-scripts'
+          env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-scripts'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
     # You can move builds that temporarily fail because of some non-Gammapy here.

--- a/gammapy/utils/scripts_test.py
+++ b/gammapy/utils/scripts_test.py
@@ -60,11 +60,7 @@ def main():
 
     for script in get_scripts():
         if requirement_missing(script):
-            log.info(
-                "Skipping script {} because requirement is missing.".format(
-                    script["name"]
-                )
-            )
+            log.info("Skipping script (missing requirement): {}".format(script["name"]))
             continue
 
         filename = script["name"] + ".py"

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -73,7 +73,6 @@ def build_notebooks(args):
         log.info("Notebook file does not exist.")
         sys.exit()
 
-    # strip and blackformat
     subprocess.run(
         [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "black"]
     )
@@ -99,7 +98,7 @@ def build_notebooks(args):
                     "nbconvert",
                     "--to",
                     "script",
-                    "{}".format(str(path)),
+                    str(path),
                 ]
             )
         copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
@@ -115,7 +114,7 @@ def build_notebooks(args):
                 "nbconvert",
                 "--to",
                 "script",
-                "{}".format(str(pathdest)),
+                str(pathdest),
             ]
         )
         pathdest = path_filled_nbs / notebookname


### PR DESCRIPTION
@Bultako - Could you please update these subprocess calls to use `subprocess.run`?
```
$ ack subprocess.call gammapy
gammapy/utils/tutorials_process.py
77:    subprocess.call(
80:    subprocess.call(
94:            subprocess.call(
110:        subprocess.call(

gammapy/scripts/jupyter.py
51:    if subprocess.call(cmd):

gammapy/data/data_store.py
311:            subprocess.call(cmd)
```

We recently introduced `subprocess.run` in Gammapy here:
https://github.com/gammapy/gammapy/blob/92fa85c7cbe26c89d9eb6403e3c5341256b5c860/gammapy/utils/scripts_test.py#L39

And to get it to work I had to change to Python 3.7 because the `capture_output` option was only added in Python 3.7:
https://github.com/gammapy/gammapy/commit/63b5ed9bd64e00e928bfb778ccd572412984585b#diff-354f30a63fb0907d4ad57269548329e3

Now I read https://docs.python.org/3/library/subprocess.html and found out that `subprocess.run` is the new and recommended high-level API, we should use it consistently.

Looking at https://github.com/python/cpython/blob/28be388e69c6e88d5c04abcc714db5ec526e4f5e/Lib/subprocess.py#L465-L470 I see that `capture_output=True` is really exactly the same as `stdout=subprocess.PIPE, stderr=subprocess.PIPE`, and we could just use those options and change the CI test back to Python 3.5 to make sure it works on all Python versions we support.

One thing that's not clear to me is if we really want to separate, or if we want to join the stdout and stderr for these subprocess calls?
Probably we want to use `stdout=subprocess.PIPE, stderr=subprocess. STDOUT` as shown [here](https://pymotw.com/3/subprocess/#combining-regular-and-error-output) to combine the two in all calls, because a combined single output is much more readable than to split the two streams (what one would see on the console if no subprocess was called)?

@Bultako - if you'd prefer me to make a PR for this, please assign to me and leave a comment concerning the stdout/stderr question.