### PR TITLE
Add source catalog object position tests

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -250,12 +250,14 @@ def _skycoord_from_table(table):
     try:
         keys = table.colnames
     except AttributeError:
-        keys = table.keys()
+        keys = list(table.keys())
 
     if {"RAJ2000", "DEJ2000"}.issubset(keys):
         lon, lat, frame = "RAJ2000", "DEJ2000", "icrs"
     elif {"RA", "DEC"}.issubset(keys):
         lon, lat, frame = "RA", "DEC", "icrs"
+    elif {"ra", "dec"}.issubset(keys):
+        lon, lat, frame = "ra", "dec", "icrs"
     elif {"GLON", "GLAT"}.issubset(keys):
         lon, lat, frame = "GLON", "GLAT", "galactic"
     elif {"glon", "glat"}.issubset(keys):

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -66,7 +66,6 @@ class TestSourceCatalog:
         with pytest.raises(ValueError):
             self.cat[int]
 
-    # TODO: add test for this for each catalog
     def test_positions(self):
         positions = self.cat.positions
         assert len(positions) == 3
@@ -93,7 +92,6 @@ class TestSourceCatalogObject:
         assert isinstance(d["DEC"], Quantity)
         assert_quantity_allclose(d["DEC"], Quantity(2, "deg"))
 
-    # TODO: add test for this for each catalog
     def test_position(self):
         position = self.source.position
         assert_allclose(position.ra.deg, 43.3)

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -86,6 +86,11 @@ class TestFermi3FGLObject:
     def test_data(self):
         assert_allclose(self.source.data["Signif_Avg"], 30.669872283935547)
 
+    def test_position(self):
+        position = self.source.position
+        assert_allclose(position.ra.deg, 83.637199, atol=1e-3)
+        assert_allclose(position.dec.deg, 22.024099, atol=1e-3)
+
     def test_str(self):
         ss = str(self.source)
         assert "Source name          : 3FGL J0534.5+2201" in ss
@@ -201,6 +206,11 @@ class TestFermi1FHLObject:
     def test_name(self):
         assert self.source.name == self.source_name
 
+    def test_position(self):
+        position = self.source.position
+        assert_allclose(position.ra.deg, 83.628098, atol=1e-3)
+        assert_allclose(position.dec.deg, 22.0191, atol=1e-3)
+
     def test_spectral_model(self):
         model = self.source.spectral_model
         energy = u.Quantity(100, "GeV")
@@ -231,6 +241,11 @@ class TestFermi2FHLObject:
 
     def test_name(self):
         assert self.source.name == self.source_name
+
+    def test_position(self):
+        position = self.source.position
+        assert_allclose(position.ra.deg, 83.634102, atol=1e-3)
+        assert_allclose(position.dec.deg, 22.0215, atol=1e-3)
 
     def test_spectral_model(self):
         model = self.source.spectral_model
@@ -285,6 +300,11 @@ class TestFermi3FHLObject:
         assert isinstance(data["Flux_Band"], list)
         assert isinstance(data["Flux_Band"][0], float)
         assert_allclose(data["Flux_Band"][0], 5.1698894054652555e-09)
+
+    def test_position(self):
+        position = self.source.position
+        assert_allclose(position.ra.deg, 83.634834, atol=1e-3)
+        assert_allclose(position.dec.deg, 22.019203, atol=1e-3)
 
     @requires_dependency("uncertainties")
     @pytest.mark.parametrize("ref", SOURCES_3FHL, ids=lambda _: _["name"])

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -23,6 +23,8 @@ SOURCES = [
         "n_flux_points": 24,
         "is_pointlike": False,
         "spatial_model": "SkyGaussian",
+        "ra": 128.287003,
+        "dec": -45.189999,
     },
     {
         "name": "HESS J1848-018",
@@ -36,6 +38,8 @@ SOURCES = [
         "n_flux_points": 11,
         "is_pointlike": False,
         "spatial_model": "SkyGaussian",
+        "ra": 282.119995,
+        "dec": -1.792,
     },
     {
         "name": "HESS J1813-178",
@@ -49,6 +53,8 @@ SOURCES = [
         "n_flux_points": 13,
         "is_pointlike": False,
         "spatial_model": "SkyGaussian",
+        "ra": 273.362915,
+        "dec": -17.84889,
     },
 ]
 
@@ -64,6 +70,9 @@ class TestSourceCatalogGammaCat:
     def test_source_table(self, gammacat):
         assert gammacat.name == "gamma-cat"
         assert len(gammacat.table) == 162
+
+    def test_positions(self, gammacat):
+        assert len(gammacat.positions) == 162
 
     def test_w28_alias_names(self, gammacat):
         names = [
@@ -164,6 +173,15 @@ class TestSourceCatalogObjectGammaCat:
         flux_points = source.flux_points
 
         assert len(flux_points.table) == ref["n_flux_points"]
+
+    @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
+    def test_position(self, gammacat, ref):
+        source = gammacat[ref["name"]]
+
+        position = source.position
+
+        assert_allclose(position.ra.deg, ref["ra"], atol=1e-3)
+        assert_allclose(position.dec.deg, ref["dec"], atol=1e-3)
 
     @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
     def test_spatial_model(self, gammacat, ref):

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -7,35 +7,49 @@ from ..hawc import SourceCatalog2HWC
 
 
 @pytest.fixture(scope="session")
-def hawc_2hwc():
+def cat():
     return SourceCatalog2HWC()
 
 
 @requires_data()
 class TestSourceCatalog2HWC:
-    def test_source_table(self, hawc_2hwc):
-        assert hawc_2hwc.name == "2hwc"
-        assert len(hawc_2hwc.table) == 40
+    @staticmethod
+    def test_source_table(cat):
+        assert cat.name == "2hwc"
+        assert len(cat.table) == 40
+
+    @staticmethod
+    def test_positions(cat):
+        assert len(cat.positions) == 40
 
 
 @requires_data()
 class TestSourceCatalogObject2HWC:
-    def test_data(self, hawc_2hwc):
-        source = hawc_2hwc[0]
+    @staticmethod
+    def test_data(cat):
+        source = cat[0]
         assert source.data["source_name"] == "2HWC J0534+220"
 
-    def test_str(self, hawc_2hwc):
-        source = hawc_2hwc[0]
+    @staticmethod
+    def test_position(cat):
+        position = cat[0].position
+        assert_allclose(position.ra.deg, 83.628, atol=1e-3)
+        assert_allclose(position.dec.deg, 22.024, atol=1e-3)
+
+    @staticmethod
+    def test_str(cat):
+        source = cat[0]
         assert "2HWC J0534+220" in str(source)
         assert "No second spectrum available for this source" in str(source)
 
-        source = hawc_2hwc[1]
+        source = cat[1]
         assert "2HWC J0631+169" in str(source)
         assert "Spectrum 1:" in str(source)
 
+    @staticmethod
     @requires_dependency("uncertainties")
-    def test_spectral_models_one(self, hawc_2hwc):
-        source = hawc_2hwc[0]
+    def test_spectral_models_one(cat):
+        source = cat[0]
         assert source.n_spectra == 1
 
         spectral_models = source.spectral_models
@@ -48,10 +62,11 @@ class TestSourceCatalogObject2HWC:
         assert flux_err.unit == "cm-2 s-1"
         assert_allclose(flux_err.value, 1.671177271712936e-14)
 
+    @staticmethod
     @requires_dependency("uncertainties")
-    def test_spectral_models_two(self, hawc_2hwc):
+    def test_spectral_models_two(cat):
         # This test is just to check that sources with 2 spectra also work OK.
-        source = hawc_2hwc[1]
+        source = cat[1]
         assert source.n_spectra == 2
 
         spectral_models = source.spectral_models

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -25,6 +25,10 @@ class TestSourceCatalogHGPS:
         assert len(cat.table) == 78
 
     @staticmethod
+    def test_positions(cat):
+        assert len(cat.positions) == 78
+
+    @staticmethod
     def test_table_components(cat):
         assert len(cat.table_components) == 98
 
@@ -94,6 +98,12 @@ class TestSourceCatalogObjectHGPS:
         source = cat["HESS J1713-397"]
         assert source.data["Spatial_Model"] == "Shell"
         assert "Source name          : HESS J1713-397" in str(source)
+
+    @staticmethod
+    def test_position(source):
+        position = source.position
+        assert_allclose(position.ra.deg, 280.95162964)
+        assert_allclose(position.dec.deg, -3.55410194)
 
     @staticmethod
     def test_components(source):


### PR DESCRIPTION
This PR is a follow-up to #2262 which adds source catalog object position tests for all our catalogs, resolving two TODO comments introduced there.