### PR TITLE
Subclass SpectrumDatasetOnOff

### DIFF
--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -175,7 +175,7 @@ class TestSpectrumDatasetOnOff:
         energy = self.aeff.energy.edges * self.aeff.energy.unit
         expected = self.aeff.data.data[0] * (energy[-1] - energy[0]) * const * livetime
 
-        assert_allclose(dataset.npred().data.sum(), expected.value)
+        assert_allclose(dataset.npred_sig().data.sum(), expected.value)
 
     @requires_dependency("matplotlib")
     def test_peek(self):

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -48,7 +48,7 @@ class TestSpectrumDataset:
             energy_lo=binning[:-1], energy_hi=binning[1:], data=source_counts
         )
         self.dataset = SpectrumDataset(
-            self.source_model, self.src, self.livetime, None, None, None, self.bkg
+            model=self.source_model, counts=self.src, livetime=self.livetime, background=self.bkg
         )
 
     def test_data_shape(self):
@@ -91,13 +91,11 @@ class TestSpectrumDataset:
         mask_fit = np.ones(self.nbins, dtype=np.dtype("float"))
         with pytest.raises(ValueError):
             SpectrumDataset(
-                self.source_model,
-                self.src,
-                self.livetime,
-                mask_fit,
-                None,
-                None,
-                self.bkg,
+                model=self.source_model,
+                counts=self.src,
+                livetime=self.livetime,
+                mask_fit=mask_fit,
+                background=self.bkg,
             )
 
     def test_set_model(self):


### PR DESCRIPTION
This PR introduce the inheritance of `SpectrumDatasetOnOff` from `SpectrumDataset` to avoid code duplication. It includes the following changes:

- Make `SpectrumDatasetOnOff` a sub-class of `SpectrumDataset`
- Move `.residuals()`, `.plot_` and `.excess()` methods to `SpectrumDataset`
- Rename `SpectrumDatasetOnOff.npred()` to `.npred_sig()`, because it only computes the expected counts from the source model, not including the background. 

In total I think this is a good change. It avoids code duplication, without introducing much complexity.