### PR TITLE
Remove SpectrumStats class

### DIFF
--- a/gammapy/data/obs_stats.py
+++ b/gammapy/data/obs_stats.py
@@ -2,7 +2,7 @@
 import astropy.units as u
 from ..stats import Stats, significance_on_off
 
-__all__ = ["ObservationStats", "SpectrumStats"]
+__all__ = ["ObservationStats"]
 
 
 class ObservationStats(Stats):
@@ -176,61 +176,3 @@ class ObservationStats(Stats):
         ss += "Sigma: {:.2f}\n".format(self.sigma)
 
         return ss
-
-
-class SpectrumStats(ObservationStats):
-    """Spectrum stats.
-
-    Extends `~gammapy.data.ObservationStats` with spectrum
-    specific information (energy bin info at the moment).
-    """
-
-    def __init__(self, **kwargs):
-        self.energy_min = kwargs.pop("energy_min", u.Quantity(0, "TeV"))
-        self.energy_max = kwargs.pop("energy_max", u.Quantity(0, "TeV"))
-        super().__init__(**kwargs)
-
-    def __str__(self):
-        ss = super().__str__()
-        ss += "energy range: {:.2f} - {:.2f}".format(self.energy_min, self.energy_max)
-        return ss
-
-    def to_dict(self):
-        """Convert to dict."""
-        data = super().to_dict()
-        data["energy_min"] = self.energy_min
-        data["energy_max"] = self.energy_max
-        return data
-
-    @classmethod
-    def from_observation_in_range(cls, observation, bg_estimate, energy_range):
-        """Create from `~gammapy.data.DataStoreObservation`.
-
-        Parameters
-        ----------
-        observation : `~gammapy.data.DataStoreObservation`
-            IACT data store observation
-        bg_estimate : `~gammapy.background.BackgroundEstimate`
-            Background estimate
-        energy_range : tuple of `~astropy.units.Quantity`
-            minimum and maximum energy
-        """
-        n_on = len(bg_estimate.off_events.select_energy(energy_range).table)
-        n_off = len(bg_estimate.off_events.select_energy(energy_range).table)
-        a_on = bg_estimate.a_on
-        a_off = bg_estimate.a_off
-
-        obs_id = observation.obs_id
-        livetime = observation.observation_live_time_duration
-
-        stats = cls(
-            n_on=n_on,
-            n_off=n_off,
-            a_on=a_on,
-            a_off=a_off,
-            obs_id=obs_id,
-            livetime=livetime,
-            energy_min=energy_range[0],
-            energy_max=energy_range[1],
-        )
-        return stats

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -114,27 +114,3 @@ class TestObservationStats:
         assert data["n_off"] == 1114
         assert_allclose(data["alpha"], 0.1111, rtol=1e-3)
         assert_allclose(data["livetime"].value, 26.211, rtol=1e-3)
-
-
-@pytest.fixture(scope="session")
-def spectrum_stats(on_region, observations):
-    obs = observations[0]
-    bge = ReflectedRegionsBackgroundEstimator(on_region=on_region, observations=obs)
-    bg = bge.process(obs)
-    e_range = [1 * u.TeV, 10 * u.TeV]
-    return SpectrumStats.from_observation_in_range(obs, bg, e_range)
-
-
-@requires_data("gammapy-data")
-class TestSpectrumStats:
-    @staticmethod
-    def test_str(spectrum_stats):
-        text = str(spectrum_stats)
-        assert "Observation summary report" in text
-        assert "energy range" in text
-
-    @staticmethod
-    def test_to_dict(spectrum_stats):
-        data = spectrum_stats.to_dict()
-        assert data["energy_min"] == 1 * u.TeV
-        assert data["energy_max"] == 10 * u.TeV

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -4,7 +4,7 @@ import pytest
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from regions import CircleSkyRegion
-from ...data import DataStore, Observations, ObservationStats, SpectrumStats
+from ...data import DataStore, Observations, ObservationStats
 from ...utils.testing import requires_data
 from ...background import ReflectedRegionsBackgroundEstimator
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -568,6 +568,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         )
 
 
+
 def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS"):
     """Create from `~astropy.io.fits.HDUList`."""
     counts_table = Table.read(hdulist[hdu1])

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -123,14 +123,15 @@ class SpectrumDataset(Dataset):
         energy = self.counts.energy.edges
         return CountsSpectrum(data=data, energy_lo=energy[:-1], energy_hi=energy[1:])
 
+    @property
     def excess(self):
         """Excess (counts - alpha * counts_off)"""
         excess = self.counts.data - self.background.data
         return self._as_counts_spectrum(excess)
 
     def residuals(self):
-        """Residuals (npred - excess)."""
-        residuals = self.npred().data - self.excess().data
+        """Residuals (npred_sig - excess)."""
+        residuals = self.npred().data - self.excess.data
         return self._as_counts_spectrum(residuals)
 
     def fake(self, random_state="random-seed"):
@@ -201,7 +202,7 @@ class SpectrumDataset(Dataset):
         ax = plt.gca() if ax is None else ax
 
         self.npred().plot(ax=ax, label="mu_src", energy_unit=self._e_unit)
-        self.excess().plot(ax=ax, label="Excess", fmt=".", energy_unit=self._e_unit)
+        self.excess.plot(ax=ax, label="Excess", fmt=".", energy_unit=self._e_unit)
 
         e_min, e_max = self.energy_range
         kwargs = {"color": "black", "linestyle": "dashed"}

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -242,21 +242,6 @@ class TestSpectrumDatasetOnOff:
         assert newdataset.counts_off is None
         assert newdataset.edisp is None
 
-    def test_total_stats(self):
-        dataset = SpectrumDatasetOnOff(
-            counts=self.on_counts,
-            counts_off=self.off_counts,
-            aeff=self.aeff,
-            edisp=self.edisp,
-            livetime=self.livetime,
-            backscale=1,
-            backscale_off=10,
-        )
-
-        assert dataset.counts.data.sum() == 3
-        assert dataset.counts_off.data == 40
-        assert dataset.excess().data.sum() == -1
-
     def test_energy_mask(self):
         mask = self.dataset.counts.energy_mask(emin=0.3 * u.TeV, emax=6 * u.TeV)
         desired = [False, True, True, False]

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -253,9 +253,9 @@ class TestSpectrumDatasetOnOff:
             backscale_off=10,
         )
 
-        assert dataset.total_stats.n_on == 3
-        assert dataset.total_stats.n_off == 40
-        assert dataset.total_stats.excess == -1
+        assert dataset.counts.data.sum() == 3
+        assert dataset.counts_off.data == 40
+        assert dataset.excess().data.sum() == -1
 
     def test_energy_mask(self):
         mask = self.dataset.counts.energy_mask(emin=0.3 * u.TeV, emax=6 * u.TeV)
@@ -493,10 +493,15 @@ class TestSpectrumDatasetOnOffStacker:
 
     def test_basic(self):
         assert "Stacker" in str(self.obs_stacker)
-        counts1 = self.obs_list[0].total_stats_safe_range.n_on
-        counts2 = self.obs_list[1].total_stats_safe_range.n_on
+        obs_1, obs_2 = self.obs_list
+
+        counts1 = obs_1.counts.data[obs_1.mask_safe].sum()
+        counts2 = obs_2.counts.data[obs_2.mask_safe].sum()
         summed_counts = counts1 + counts2
-        stacked_counts = self.obs_stacker.stacked_obs.total_stats.n_on
+
+        obs_stacked = self.obs_stacker.stacked_obs
+        stacked_counts = obs_stacked.counts.data.sum()
+
         assert summed_counts == stacked_counts
 
     def test_thresholds(self):

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -10,7 +10,7 @@ from ...utils.testing import requires_dependency, requires_data
 from ...spectrum import SpectrumExtraction, SpectrumDatasetOnOff
 from ...background import ReflectedRegionsBackgroundEstimator
 from ...maps import WcsGeom, WcsNDMap
-from ...data import DataStore
+from ...data import DataStore, ObservationStats
 
 
 @pytest.fixture(scope="session")
@@ -109,8 +109,9 @@ class TestSpectrumExtraction:
         containment_actual = extraction.containment[60]
 
         # TODO: Introduce assert_stats_allclose
-        n_on_actual = obs.total_stats.n_on
-        sigma_actual = obs.total_stats.sigma
+        stats = ObservationStats(**obs._info_dict())
+        n_on_actual = stats.n_on
+        sigma_actual = stats.sigma
 
         assert n_on_actual == results["n_on"]
         assert_allclose(sigma_actual, results["sigma"], atol=1e-2)

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -234,9 +234,7 @@
     "    alpha=0.2,\n",
     ")\n",
     "\n",
-    "sim.run(seeds)\n",
-    "print(sim.result)\n",
-    "print(sim.result[0])"
+    "sim.run(seeds)"
    ]
   },
   {
@@ -252,9 +250,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "n_on = [obs.total_stats.n_on for obs in sim.result]\n",
-    "n_off = [obs.total_stats.n_off for obs in sim.result]\n",
-    "excess = [obs.total_stats.excess for obs in sim.result]\n",
+    "n_on = [obs.counts.data.sum() for obs in sim.result]\n",
+    "n_off = [obs.counts_off.data.sum() for obs in sim.result]\n",
+    "excess = [obs.excess.data.sum() for obs in sim.result]\n",
     "\n",
     "fix, axes = plt.subplots(1, 3, figsize=(12, 4))\n",
     "axes[0].hist(n_on)\n",
@@ -436,7 +434,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR removes the `SpectrumStats` object with the goal to unify the API of the dataset classes and reduce the code complexity. I kept the functionality by introducing a minimal `._info_dict()` method, which is currently only used in one place in `.peek()`.