### PR TITLE
Fix map pixel solid angle computation

### DIFF
--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -107,13 +107,13 @@ def geom(map_type, ebounds, skydir):
             "map_type": "wcs",
             "ebounds": [0.1, 1, 10],
             "shape": (2, 3, 4),
-            "sum": 1061.348412,
+            "sum": 1050.930197,
         },
         {
             "map_type": "wcs",
             "ebounds": [0.1, 10],
             "shape": (1, 3, 4),
-            "sum": 1061.348412,
+            "sum": 1050.9301972,
         },
         # TODO: make this work for HPX
         # 'HpxGeom' object has no attribute 'separation'

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -42,7 +42,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 3.99815e11,
             "exposure_image": 7.921993e10,
-            "background": 27986.945,
+            "background": 27989.05,
         },
         {
             # Test single energy bin
@@ -51,7 +51,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 30422.17,
+            "background": 30424.451,
         },
         {
             # Test single energy bin with exclusion mask
@@ -61,7 +61,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 1.16866e11,
             "exposure_image": 1.16866e11,
-            "background": 30422.17,
+            "background": 30424.451,
         },
         {
             # Test for different e_true and e_reco bins
@@ -70,7 +70,7 @@ def geom(ebounds):
             "counts": 34366,
             "exposure": 5.971096e11,
             "exposure_image": 6.492968e10,
-            "background": 28758.129,
+            "background": 28760.283,
             "background_oversampling": 2,
         },
     ],

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -386,7 +386,7 @@ class TestSkyModelMapEvaluator:
     def test_compute_flux(evaluator):
         out = evaluator.compute_flux().to_value("cm-2 s-1")
         assert out.shape == (3, 4, 5)
-        assert_allclose(out.sum(), 1.291427605881036e-12, rtol=1e-5)
+        assert_allclose(out.sum(), 1.291414e-12, rtol=1e-5)
         assert_allclose(out[0, 0, 0], 4.630845e-14, rtol=1e-5)
 
     @staticmethod
@@ -404,7 +404,7 @@ class TestSkyModelMapEvaluator:
         npred = evaluator.apply_exposure(flux)
         out = evaluator.apply_edisp(npred)
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.sum(), 3.2758538225058153e-06, rtol=1e-5)
+        assert_allclose(out.data.sum(), 3.27582e-06, rtol=1e-5)
         assert_allclose(out.data[0, 0, 0], 4.630845e-08, rtol=1e-5)
 
     @staticmethod

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -186,9 +186,15 @@ def test_wcsgeom_solid_angle_ait():
     # Pixels that don't correspond to locations on ths sky
     # should have solid angles set to NaN
     ait_geom = WcsGeom.create(
-        skydir=(0, 0), npix=(10, 4), binsz=50, coordsys="GAL", proj="AIT"
+        skydir=(0, 0), width=(360, 180), binsz=20, coordsys="GAL", proj="AIT"
     )
-    solid_angle = ait_geom.solid_angle()
+    solid_angle = ait_geom.solid_angle().to_value("deg2")
+
+    assert_allclose(solid_angle[4, 1], 401.0819)
+    assert_allclose(solid_angle[4, 16], 401.0819)
+    assert_allclose(solid_angle[1, 8], 628.668307)
+    assert_allclose(solid_angle[7, 8], 287.576426)
+
     assert np.isnan(solid_angle[0, 0])
 
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -190,10 +190,10 @@ def test_wcsgeom_solid_angle_ait():
     )
     solid_angle = ait_geom.solid_angle().to_value("deg2")
 
-    assert_allclose(solid_angle[4, 1], 401.0819)
-    assert_allclose(solid_angle[4, 16], 401.0819)
-    assert_allclose(solid_angle[1, 8], 628.668307)
-    assert_allclose(solid_angle[7, 8], 287.576426)
+    assert_allclose(solid_angle[4, 1], 397.04838)
+    assert_allclose(solid_angle[4, 16], 397.751841)
+    assert_allclose(solid_angle[1, 8], 381.556269)
+    assert_allclose(solid_angle[7, 8], 398.34725)
 
     assert np.isnan(solid_angle[0, 0])
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -794,8 +794,8 @@ class WcsGeom(MapGeom):
         angle_up_left = up_left.position_angle(up_right) - low_left.position_angle(up_left)
 
         # compute area assuming a planar triangle
-        area_low_right = 0.5 * low.rad * right.rad * np.sin(angle_low_right.rad)
-        area_up_left = 0.5 * up.rad * left.rad * np.sin(angle_up_left.rad)
+        area_low_right = 0.5 * low * right * np.sin(angle_low_right)
+        area_up_left = 0.5 * up * left * np.sin(angle_up_left)
 
         return u.Quantity(area_low_right + area_up_left, "sr", copy=False)
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -152,32 +152,6 @@ def _make_image_header(
     return header
 
 
-def area_spherical_triangle_angle(a, b, C):
-    """Compute the area of a spherical triangle.
-
-    The formula is based on the spherical excess theorem, see
-    https://en.wikipedia.org/wiki/Spherical_trigonometry#Area_and_spherical_excess
-
-
-    Parameters
-    ----------
-    a : `~numpy.ndarray`
-        One side of the triangle.
-    b : `~numpy.ndarray`
-        Second side of the triangle.
-    C : `~numpy.ndarray`
-        Angle enclosed by a and b
-
-    Returns
-    -------
-    area : `~numpy.ndarray`
-        Area of the spherical triangle.
-    """
-    top = np.tan(0.5 * a) * np.tan(0.5 * b) * np.sin(C)
-    bottom = 1 + np.tan(0.5 * a) * np.tan(0.5 * b) * np.cos(C)
-    return 2 * np.arctan2(top, bottom)
-
-
 class WcsGeom(MapGeom):
     """Geometry class for WCS maps.
 
@@ -819,11 +793,11 @@ class WcsGeom(MapGeom):
         angle_low_right = low_right.position_angle(up_right) - low_right.position_angle(low_left)
         angle_up_left = up_left.position_angle(up_right) - low_left.position_angle(up_left)
 
-        area_low_right = area_spherical_triangle_angle(low.rad, right.rad, angle_low_right.rad)
-        area_up_left = area_spherical_triangle_angle(up.rad, left.rad, angle_up_left.rad)
+        # compute area assuming a planar triangle
+        area_low_right = 0.5 * low.rad * right.rad * np.sin(angle_low_right.rad)
+        area_up_left = 0.5 * up.rad * left.rad * np.sin(angle_up_left.rad)
 
         return u.Quantity(area_low_right + area_up_left, "sr", copy=False)
-
 
     def separation(self, center):
         """Compute sky separation wrt a given center.

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -128,8 +128,8 @@ def test_map_sampling():
 
     assert len(events) == 2
     assert_allclose(events["TIME"].data, [175.035023, 4217.336952], rtol=1e-5)
-    assert_allclose(events["RA_TRUE"].data, [266.307081, 266.442255], rtol=1e-5)
-    assert_allclose(events["DEC_TRUE"].data, [-28.753408, -28.742696], rtol=1e-5)
+    assert_allclose(events["RA_TRUE"].data, [266.638497, 266.578664], rtol=1e-5)
+    assert_allclose(events["DEC_TRUE"].data, [-28.930393, -28.815534], rtol=1e-5)
     assert_allclose(events["ENERGY_TRUE"].data, [2.755397, 1.72316], rtol=1e-5)
 
     assert_allclose(events.meta["ONTIME"], 8 * 3600)


### PR DESCRIPTION
The computation of the solid angle in `WCSGeom.solid_angle()` was based on the approximation of rectangular pixels. This lead to problems for WCS projections, where strong distortions of the pixels occurs, such as an all sky AIT projection or local projections at high latitudes (see https://github.com/gammapy/gammapy/issues/2150#issuecomment-494745461,  [TODO comment in the code](https://github.com/gammapy/gammapy/blob/master/gammapy/maps/wcs.py#L782), and privately reported by @lmohrmann).

This PR changes the current implementation to a method that splits the pixel into two spherical triangles and uses the [spherical excess theorem](https://en.wikipedia.org/wiki/Spherical_trigonometry#Area_and_spherical_excess) to compute the area of the triangles. A short comparison between the old and new method is presented in https://github.com/adonath/notebooks-public/blob/master/solid_angle.ipynb. 

From a quick test it seems the new method is ~4 times slower. For now I would propose to change to the new slower, but more correct method and later think about optimisations, or alternative faster methods.