### PR TITLE
Add GTI union

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -169,6 +169,9 @@ class GTI:
         """Union of overlapping time intervals.
 
         Returns a new `~gammapy.data.GTI` object.
+
+        Intervals that touch will be merged, e.g.
+        ``(1, 2)`` and ``(2, 3)`` will result in ``(1, 3)``.
         """
         # Algorithm to merge overlapping intervals is well-known,
         # see e.g. https://stackoverflow.com/a/43600953/498873

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -88,6 +88,11 @@ class GTI:
         return Quantity(stop - start, "second")
 
     @property
+    def time_ref(self):
+        """Time reference (`~astropy.time.Time`)."""
+        return time_ref_from_dict(self.table.meta)
+
+    @property
     def time_sum(self):
         """Sum of GTIs in seconds (`~astropy.units.Quantity`)."""
         return self.time_delta.sum()
@@ -95,16 +100,14 @@ class GTI:
     @property
     def time_start(self):
         """GTI start times (`~astropy.time.Time`)."""
-        met_ref = time_ref_from_dict(self.table.meta)
         met = Quantity(self.table["START"].astype("float64"), "second")
-        return met_ref + met
+        return self.time_ref + met
 
     @property
     def time_stop(self):
         """GTI end times (`~astropy.time.Time`)."""
-        met_ref = time_ref_from_dict(self.table.meta)
         met = Quantity(self.table["STOP"].astype("float64"), "second")
-        return met_ref + met
+        return self.time_ref + met
 
     def select_time(self, time_interval):
         """Select and crop GTIs in time interval.

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -53,6 +53,9 @@ class GTI:
     def __init__(self, table):
         self.table = table
 
+    def copy(self):
+        return self.__class__(self.table)
+
     @classmethod
     def read(cls, filename, **kwargs):
         """Read from FITS file.
@@ -136,6 +139,28 @@ class GTI:
 
         return self.__class__(gti_within)
 
+    def stack(self, other):
+        """Stack with another GTI.
+
+        This simply changes the time reference of the second GTI table
+        and stack the two tables. No logic is applied to the intervals.
+
+        Parameters
+        ----------
+        other : `~gammapy.data.GTI`
+            the GTI to stack to self
+
+        Returns
+        -------
+        new_gti : `~gammapy.data.GTI`
+            the new GTI
+        """
+        start = (other.time_start - self.time_ref).sec
+        end = (other.time_stop - self.time_ref).sec
+        table = Table(rows={"START": start, "END": end})
+
+        return astropy.table.vstack([self.table, table])
+
     def _interval_union(self, time_interval):
         """Performs union of interval with GTI
 
@@ -187,7 +212,7 @@ class GTI:
         union : `~gammapy.data.GTI`
             The merged GTI table
         """
-        new_gti = self.__class__(self.table)
+        new_gti = self.copy()
         for time_interval in zip(gti.time_start, gti.time_stop):
             new_gti = new_gti._interval_union(time_interval)
         return new_gti

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -95,10 +95,12 @@ def ref_dict():
     time_ref = Time("2018-10-29 20:00:00.000")
     return time_ref_to_dict(time_ref)
 
+
 @pytest.fixture(scope="session")
 def ref_dict2():
-    time_ref = Time("2018-10-29 21:00:00.000")
+    time_ref = Time("2018-10-30 20:00:00.000")
     return time_ref_to_dict(time_ref)
+
 
 @pytest.fixture(scope="session")
 def gti_list(ref_dict):
@@ -134,9 +136,15 @@ def overlapping_gti(ref_dict):
     )
     return GTI(gti_table)
 
+
 def test_gti_stack(gti_list, outside_gti):
     stacked_gti = gti_list.stack(outside_gti)
-    assert len(union.table) == 4
+    assert len(stacked_gti.table) == 4
+    assert stacked_gti.time_ref == gti_list.time_ref
+
+    inverse_stacked_gti = outside_gti.stack(gti_list)
+    assert inverse_stacked_gti.time_ref == outside_gti.time_ref
+    assert len(inverse_stacked_gti.table) == 4
 
 
 def test_gti_union(gti_list, outside_gti, overlapping_gti):
@@ -163,8 +171,10 @@ def test_gti_union(gti_list, outside_gti, overlapping_gti):
     assert_time_allclose(union.time_start[0], overlapping_gti.time_start[0])
     assert_time_allclose(union.time_stop[0], gti_list.time_stop[1])
     assert_time_allclose(union.time_start[2], outside_gti.time_start[0])
+    assert_time_allclose(union.time_ref, gti_list.time_ref)
 
     # Reverse union order should give the same result
     union2 = new_gti.union(gti_list)
     assert_time_allclose(union.time_start, union2.time_start)
     assert_time_allclose(union.time_stop, union2.time_stop)
+    assert_time_allclose(union.time_ref, new_gti.time_ref)

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -95,6 +95,10 @@ def ref_dict():
     time_ref = Time("2018-10-29 20:00:00.000")
     return time_ref_to_dict(time_ref)
 
+@pytest.fixture(scope="session")
+def ref_dict2():
+    time_ref = Time("2018-10-29 21:00:00.000")
+    return time_ref_to_dict(time_ref)
 
 @pytest.fixture(scope="session")
 def gti_list(ref_dict):
@@ -112,11 +116,11 @@ def gti_list(ref_dict):
 
 
 @pytest.fixture(scope="session")
-def outside_gti(ref_dict):
+def outside_gti(ref_dict2):
     start = u.Quantity([1 * u.d])
     stop = start + 30 * u.min
     gti_table = Table(
-        [start.to("s"), stop.to("s")], names=("START", "STOP"), meta=ref_dict
+        [start.to("s"), stop.to("s")], names=("START", "STOP"), meta=ref_dict2
     )
     return GTI(gti_table)
 
@@ -129,6 +133,10 @@ def overlapping_gti(ref_dict):
         [start.to("s"), stop.to("s")], names=("START", "STOP"), meta=ref_dict
     )
     return GTI(gti_table)
+
+def test_gti_stack(gti_list, outside_gti):
+    stacked_gti = gti_list.stack(outside_gti)
+    assert len(union.table) == 4
 
 
 def test_gti_union(gti_list, outside_gti, overlapping_gti):

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -149,21 +149,21 @@ def test_gti_stack(gti_list, outside_gti):
 
 def test_gti_union(gti_list, outside_gti, overlapping_gti):
     # interval after all intervals in the list
-    union = gti_list.union(outside_gti)
+    union = gti_list.stack(outside_gti).union()
     assert len(union.table) == 4
     assert_allclose(union.time_sum.to_value("h"), 2)
     assert_time_allclose(union.time_start[3], outside_gti.time_start[0])
 
     # interval covering the first interval in the list and part of the second
-    union = gti_list.union(overlapping_gti)
+    union = gti_list.stack(overlapping_gti).union()
     assert len(union.table) == 2
     assert_allclose(union.time_sum.to_value("h"), 2.5)
     assert_time_allclose(union.time_start[0], overlapping_gti.time_start[0])
     assert_time_allclose(union.time_stop[0], gti_list.time_stop[1])
 
     # now take union of outside and overlap
-    new_gti = overlapping_gti.union(outside_gti)
-    union = gti_list.union(new_gti)
+    new_gti = overlapping_gti.stack(outside_gti).union()
+    union = gti_list.stack(new_gti).union()
 
     assert len(new_gti.table) == 2
     assert len(union.table) == 3
@@ -174,7 +174,7 @@ def test_gti_union(gti_list, outside_gti, overlapping_gti):
     assert_time_allclose(union.time_ref, gti_list.time_ref)
 
     # Reverse union order should give the same result
-    union2 = new_gti.union(gti_list)
+    union2 = new_gti.stack(gti_list).union()
     assert_time_allclose(union.time_start, union2.time_start)
     assert_time_allclose(union.time_stop, union2.time_stop)
     assert_time_allclose(union.time_ref, new_gti.time_ref)


### PR DESCRIPTION
In order to prepare for light curve analysis with datasets, see PIG 11 #1451 , we need to add timing information on `Dataset`. To be able to deal with stacking, `GTI` union is necessary. This PR provides a `GTI.union(gti)` method that performs union of the time intervals in the two `GTI`.
