### PR TITLE
Rename backscale attribute to acceptance

### DIFF
--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -131,8 +131,8 @@ class SpectrumExtraction:
             counts_off=self._off_vector,
             edisp=self._edisp,
             livetime=observation.observation_live_time_duration,
-            backscale=1,
-            backscale_off=bkg.a_off,
+            acceptance=1,
+            acceptance_off=bkg.a_off,
             obs_id=observation.obs_id,
         )
 

--- a/gammapy/spectrum/simulation.py
+++ b/gammapy/spectrum/simulation.py
@@ -142,9 +142,9 @@ class SpectrumSimulation:
         self.simulate_source_counts(random_state)
         if self.background_model is not None:
             self.simulate_background_counts(random_state)
-            backscale_off = 1 / self.alpha
+            acceptance_off = 1 / self.alpha
         else:
-            backscale_off = None
+            acceptance_off = None
 
         obs = SpectrumDatasetOnOff(
             counts=self.on_vector,
@@ -152,8 +152,8 @@ class SpectrumSimulation:
             aeff=self.aeff,
             edisp=self.edisp,
             livetime=self.livetime,
-            backscale=1,
-            backscale_off=backscale_off,
+            acceptance=1,
+            acceptance_off=acceptance_off,
             obs_id=obs_id,
         )
         self.obs = obs

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -140,8 +140,8 @@ class TestSpectrumDatasetOnOff:
             aeff=self.aeff,
             edisp=self.edisp,
             livetime=self.livetime,
-            backscale=np.ones(elo.shape),
-            backscale_off=np.ones(elo.shape) * 10,
+            acceptance=np.ones(elo.shape),
+            acceptance_off=np.ones(elo.shape) * 10,
             obs_id="test",
         )
 
@@ -183,8 +183,8 @@ class TestSpectrumDatasetOnOff:
             aeff=self.aeff,
             livetime=self.livetime,
             edisp=self.edisp,
-            backscale=1,
-            backscale_off=10,
+            acceptance=1,
+            acceptance_off=10,
         )
         with mpl_plot_check():
             dataset.peek()
@@ -199,8 +199,8 @@ class TestSpectrumDatasetOnOff:
             aeff=self.aeff,
             livetime=self.livetime,
             edisp=self.edisp,
-            backscale=1,
-            backscale_off=10,
+            acceptance=1,
+            acceptance_off=10,
         )
         with mpl_plot_check():
             dataset.plot_fit()
@@ -213,8 +213,8 @@ class TestSpectrumDatasetOnOff:
             edisp=self.edisp,
             livetime=self.livetime,
             mask_safe=np.ones(self.on_counts.energy.nbin, dtype=bool),
-            backscale=1,
-            backscale_off=10,
+            acceptance=1,
+            acceptance_off=10,
             obs_id="test",
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
@@ -231,7 +231,7 @@ class TestSpectrumDatasetOnOff:
             aeff=self.aeff,
             livetime=self.livetime,
             mask_safe=np.ones(self.on_counts.energy.nbin, dtype=bool),
-            backscale=1,
+            acceptance=1,
             obs_id="test",
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
@@ -296,8 +296,8 @@ class TestSimpleFit:
         obs = SpectrumDatasetOnOff(
             counts=on_vector,
             counts_off=self.off,
-            backscale=1,
-            backscale_off=1 / self.alpha,
+            acceptance=1,
+            acceptance_off=1 / self.alpha,
         )
         obs.model = self.source_model
 
@@ -439,8 +439,8 @@ def make_observation_list():
         edisp=edisp,
         livetime=livetime,
         mask_safe=np.ones(on_vector.energy.nbin, dtype=bool),
-        backscale=1,
-        backscale_off=2,
+        acceptance=1,
+        acceptance_off=2,
         obs_id=2,
     )
     obs2 = SpectrumDatasetOnOff(
@@ -450,8 +450,8 @@ def make_observation_list():
         edisp=edisp,
         livetime=livetime,
         mask_safe=np.ones(on_vector.energy.nbin, dtype=bool),
-        backscale=1,
-        backscale_off=4,
+        acceptance=1,
+        acceptance_off=4,
         obs_id=2,
     )
 


### PR DESCRIPTION
This PR includes the following changes:

- Rename `SpectrumDatasetOnOff.backscale` to `SpectrumDatasetOnOff.acceptance`
- Rename `SpectrumDatasetOnOff.backscale_off` to `SpectrumDatasetOnOff.acceptance_off`

I also adapted the corresponding tests.