### PR TITLE
Add residuals method for map dataset

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -236,7 +236,9 @@ class MapDataset(Dataset):
         axes = []
 
         # residuals cube
-        residuals = self.residuals(norm=norm) * self.mask
+        residuals = self.residuals(norm=norm)
+        if self.mask:
+            residuals *= self.mask
 
         geom = residuals.geom
         edges = geom.axes[0].edges

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -180,7 +180,7 @@ class MapDataset(Dataset):
         """
         residuals = self.counts - self.npred()
 
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid="ignore"):
             if norm == "model":
                 residuals /= self.npred()
             elif norm == "sqrt_model":
@@ -236,9 +236,7 @@ class MapDataset(Dataset):
         axes = []
 
         # residuals cube
-        residuals = self.residuals(norm=norm)
-        if self.mask:
-            residuals *= self.mask
+        residuals = self.residuals(norm=norm) * self.mask
 
         geom = residuals.geom
         edges = geom.axes[0].edges
@@ -248,27 +246,22 @@ class MapDataset(Dataset):
             width=smooth_radius, kernel=kernel
         )
 
-        position = on_region.center if on_region else geom.center_skydir
-        if not width:
-            width = tuple(geom.width)
-        spatial_residuals = spatial_residuals.cutout(position=position, width=width)
+        if width:
+            position = on_region.center if on_region else geom.center_skydir
+            spatial_residuals = spatial_residuals.cutout(position=position, width=width)
 
         # If no region is provided, skip spectral residuals
         if on_region:
             ncols = 2
         else:
-            ncols=1
+            ncols = 1
         axes.append(fig.add_subplot(1, ncols, 1, projection=spatial_residuals.geom.wcs))
 
-        kwargs.setdefault('cmap', 'coolwarm')
-        kwargs.setdefault('stretch', 'linear')
-        kwargs.setdefault('vmin', -5)
-        kwargs.setdefault('vmax', 5)
-        spatial_residuals.plot(
-            ax=axes[0],
-            add_cbar=True,
-            **kwargs
-        )
+        kwargs.setdefault("cmap", "coolwarm")
+        kwargs.setdefault("stretch", "linear")
+        kwargs.setdefault("vmin", -5)
+        kwargs.setdefault("vmax", 5)
+        spatial_residuals.plot(ax=axes[0], add_cbar=True, **kwargs)
 
         # Spectral residuals
         if on_region:

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -12,7 +12,6 @@ from ..maps import Map
 from ..irf import EnergyDispersion
 from .models import SkyModel, SkyModels, BackgroundModel
 from .psf_kernel import PSFKernel
-from astropy.coordinates import Angle
 from gammapy.spectrum.core import CountsSpectrum
 
 __all__ = ["MapEvaluator", "MapDataset"]

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -202,7 +202,7 @@ class MapDataset(Dataset):
         on_region=None,
         width=None,
         figsize=(15, 4),
-        **kwargs,
+        **kwargs
     ):
         """
         Plot spatial and spectral residuals. The spectral residuals are extracted from the provided `on_region`,

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from ...utils.testing import requires_data, requires_dependency
+from ...utils.testing import requires_data, requires_dependency, mpl_plot_check
 from ...utils.fitting import Fit
 from ...irf import EffectiveAreaTable2D, EnergyDependentMultiGaussPSF
 from ...irf.energy_dispersion import EnergyDispersion
@@ -170,6 +170,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
     assert dataset.edisp.e_true.unit == dataset_new.edisp.e_true.unit
 
 
+
 @requires_dependency("iminuit")
 @requires_data()
 def test_map_fit(sky_model, geom, geom_etrue):
@@ -228,6 +229,9 @@ def test_map_fit(sky_model, geom, geom_etrue):
     with pytest.raises(ValueError):
         dataset_1.model.skymodels[0].spatial_model.lon_0.value = 150
         dataset_1.npred()
+
+    with mpl_plot_check():
+        dataset_1.plot_residuals()
 
 
 @requires_dependency("iminuit")

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -1010,3 +1010,6 @@ class Map(abc.ABC):
 
     def __itruediv__(self, other):
         return self._arithmetics(np.true_divide, other, copy=False)
+
+    def __array__(self):
+        return self.data

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -6,6 +6,7 @@ from astropy.io import fits
 from astropy.coordinates import SkyCoord
 from astropy.convolution import Gaussian2DKernel
 import astropy.units as u
+from regions import CircleSkyRegion
 from ...utils.testing import requires_dependency, requires_data, mpl_plot_check
 from ...cube import PSFKernel
 from ...irf import EnergyDependentMultiGaussPSF
@@ -568,3 +569,19 @@ def test_plot_allsky():
     m = WcsNDMap.create(binsz=10 * u.deg)
     with mpl_plot_check():
         m.plot()
+
+
+def test_get_spectrum():
+    axis = MapAxis.from_bounds(1, 10, nbin=3, unit="TeV", name="energy")
+
+    geom = WcsGeom.create(skydir=(0, 0), width=(2.5, 2.5), binsz=0.5, axes=[axis], coordsys="GAL")
+
+    m = Map.from_geom(geom)
+    m.data += 1
+
+    center = SkyCoord(0, 0, frame="galactic", unit="deg")
+    region = CircleSkyRegion(center=center, radius=1 * u.deg)
+
+    spec = m.get_spectrum(region=region)
+
+    assert_allclose(spec.data, [13., 13., 13.])

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -599,7 +599,6 @@ class WcsNDMap(WcsMap):
 
         return on_counts
 
-
     def convolve(self, kernel, use_fft=True, **kwargs):
         """
         Convolve map with a kernel.

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -468,6 +468,7 @@ class WcsNDMap(WcsMap):
         kwargs.setdefault("interpolation", "nearest")
         kwargs.setdefault("origin", "lower")
         kwargs.setdefault("cmap", "afmhot")
+
         norm = simple_norm(data[np.isfinite(data)], stretch)
         kwargs.setdefault("norm", norm)
 
@@ -590,7 +591,7 @@ class WcsNDMap(WcsMap):
         from ..spectrum import CountsSpectrum
 
         if region:
-            mask = self.geom.region_mask([region], inside=True)
+            mask = self.geom.region_mask([region])
         else:
             mask = 1
 
@@ -598,7 +599,7 @@ class WcsNDMap(WcsMap):
 
         energy_axis = self.geom.get_axis_by_name("energy")
         edges = energy_axis.edges
-        return CountsSpectrum(data=data, energy_lo=edges[:1], energy_hi=edges[1:])
+        return CountsSpectrum(data=data, energy_lo=edges[:-1], energy_hi=edges[1:])
 
     def convolve(self, kernel, use_fft=True, **kwargs):
         """

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -573,7 +573,7 @@ class WcsNDMap(WcsMap):
         """Extract spectrum in a given region.
 
         The spectrum can be computed by summing (or, more generally, applying `func`)
-        along the spatial axies in each energy bin. This occurs only inside the `region`,
+        along the spatial axes in each energy bin. This occurs only inside the `region`,
         which by default is assumed to be the whole spatial extension of the map.
 
         Parameters

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -172,7 +172,8 @@ class CountsSpectrum:
         bounds = self.energy.edges.to_value(energy_unit)
         xerr = [x - bounds[:-1], bounds[1:] - x]
         yerr = np.sqrt(counts) if show_poisson_errors else 0
-        kwargs.setdefault("fmt", "")
+        kwargs.setdefault("fmt", ".")
+        kwargs.setdefault("color", "black")
         ax.errorbar(x, counts, xerr=xerr, yerr=yerr, **kwargs)
         if show_energy is not None:
             ener_val = u.Quantity(show_energy).to_value(energy_unit)

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -209,19 +209,33 @@ class SpectrumDataset(Dataset):
         return ax
 
     def residuals(self, norm=None):
+        """Compute the spectral residuals (`~~gammapy.spectrum.core.CountsSpectrum`).
+
+        Available options are:
+        - `norm=None` (default) for: data - model
+        - `norm='model'` for: (data - model)/model
+        - `norm='sqrt_model'` for: (data - model)/sqrt(model)
+
+        Parameters
+        ----------
+        norm: `str`, optional
+            normalization used to compute the residuals. Choose between `None`, `model` and `sqrt_model`.
+
+        """
 
         residuals = self.counts.data - self.npred().data
 
-        if norm == "model":
-            residuals /= self.npred().data
-        elif norm == "sqrt_model":
-            residuals /= np.sqrt(self.npred().data)
-        elif norm != None:
-            raise AttributeError(
-                "Invalid normalization: {}. Choose between 'model' and 'sqrt_model'".format(
-                    self.norm
+        with np.errstate(invalid='ignore'):
+            if norm == "model":
+                residuals /= self.npred().data
+            elif norm == "sqrt_model":
+                residuals /= np.sqrt(self.npred().data)
+            elif norm != None:
+                raise AttributeError(
+                    "Invalid normalization: {}. Choose between 'model' and 'sqrt_model'".format(
+                        self.norm
+                    )
                 )
-            )
 
         residuals = np.nan_to_num(residuals)
 
@@ -230,10 +244,13 @@ class SpectrumDataset(Dataset):
     def plot_residuals(self, norm=None, ax=None):
         """Plot residuals.
 
+        The normalization used for the residuals computation can be controlled using the `norm` parameter.
         Parameters
         ----------
         ax : `~matplotlib.pyplot.Axes`
             Axes object.
+        norm: `str`
+            normalization used to compute the residuals. Choose between `None`, `model` and `sqrt_model`.
 
         Returns
         -------

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -229,7 +229,7 @@ class SpectrumDataset(Dataset):
                 residuals /= self.npred().data
             elif norm == "sqrt_model":
                 residuals /= np.sqrt(self.npred().data)
-            elif norm != None:
+            elif norm is not None:
                 raise AttributeError(
                     "Invalid normalization: {}. Choose between 'model' and 'sqrt_model'".format(
                         self.norm

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -225,7 +225,7 @@ class SpectrumDataset(Dataset):
 
         residuals = self.counts.data - self.npred().data
 
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid="ignore"):
             if norm == "model":
                 residuals /= self.npred().data
             elif norm == "sqrt_model":

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -211,15 +211,14 @@ class SpectrumDataset(Dataset):
     def residuals(self, norm=None):
         """Compute the spectral residuals (`~~gammapy.spectrum.core.CountsSpectrum`).
 
-        Available options are:
-        - `norm=None` (default) for: data - model
-        - `norm='model'` for: (data - model)/model
-        - `norm='sqrt_model'` for: (data - model)/sqrt(model)
-
         Parameters
         ----------
         norm: `str`, optional
-            normalization used to compute the residuals. Choose between `None`, `model` and `sqrt_model`.
+            Normalization used to compute the residuals. Available options are:
+                - `norm=None` (default) for: data - model
+                - `norm='model'` for: (data - model)/model
+                - `norm='sqrt_model'` for: (data - model)/sqrt(model)
+
 
         """
 
@@ -241,16 +240,17 @@ class SpectrumDataset(Dataset):
 
         return self._as_counts_spectrum(residuals)
 
-    def plot_residuals(self, norm=None, ax=None):
+    def plot_residuals(self, norm=None, ax=None, **kwargs):
         """Plot residuals.
 
-        The normalization used for the residuals computation can be controlled using the `norm` parameter.
         Parameters
         ----------
         ax : `~matplotlib.pyplot.Axes`
             Axes object.
         norm: `str`
             normalization used to compute the residuals. Choose between `None`, `model` and `sqrt_model`.
+        **kwargs : dict
+            Keywords passed to `CountsSpectrum.plot()`
 
         Returns
         -------
@@ -266,12 +266,13 @@ class SpectrumDataset(Dataset):
         if not norm:
             label = "(counts - model)"
         elif norm == "model":
-            label = "(counts - model)/model"
+            label = "(counts - model) / model"
         elif norm == "sqrt_model":
-            label = "(counts - model)/sqrt(model)"
+            label = "(counts - model) / sqrt(model)"
 
         residuals.plot(
-            ax=ax, ecolor="black", fmt="none", energy_unit=self._e_unit, label=label
+            ax=ax, ecolor="black", fmt="none", energy_unit=self._e_unit, label=label,
+            **kwargs
         )
         ax.axhline(0, color="black", lw=0.5)
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1252,7 +1252,7 @@ class FluxPointsDataset(Dataset):
                 residuals /= model
             elif norm == "sqrt_model":
                 residuals /= np.sqrt(model)
-            elif norm != None:
+            elif norm is not None:
                 raise AttributeError(
                     "Invalid normalization: {}. Choose between 'model' and 'sqrt_model'".format(
                         norm

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1224,7 +1224,18 @@ class FluxPointsDataset(Dataset):
             pass
 
     def residuals(self, norm=None):
-        """Compute flux point residuals (`~numpy.ndarray`).
+        """Compute the flux point residuals (`~numpy.ndarray`).
+
+        Available options are:
+        - `norm=None` (default) for: flux points - model
+        - `norm='model'` for: (flux points - model)/model
+        - `norm='sqrt_model'` for: (flux points - model)/sqrt(model)
+
+        Parameters
+        ----------
+        norm: `str`, optional
+            normalization used to compute the residuals. Choose between `None`, `model` and `sqrt_model`.
+
         """
         fp = self.data
         data = fp.table[fp.sed_type].quantity
@@ -1232,23 +1243,30 @@ class FluxPointsDataset(Dataset):
         model = self.model(fp.e_ref)
         residuals = data - model
 
-        if norm == "model":
-            residuals /= model
-        elif norm == "sqrt_model":
-            residuals /= np.sqrt(model)
-        elif norm != None:
-            raise AttributeError(
-                "Invalid normalization: {}. Choose between 'model' and 'sqrt_model'".format(
-                    norm
+        with np.errstate(invalid='ignore'):
+            if norm == "model":
+                residuals /= model
+            elif norm == "sqrt_model":
+                residuals /= np.sqrt(model)
+            elif norm != None:
+                raise AttributeError(
+                    "Invalid normalization: {}. Choose between 'model' and 'sqrt_model'".format(
+                        norm
+                    )
                 )
-            )
 
         # Remove residuals for upper_limits
         residuals[fp.is_ul] = np.nan
         return residuals
 
     def peek(self, norm=None, **kwargs):
-        """Plot flux points, best fit model and residuals."""
+        """Plot flux points, best fit model and residuals.
+
+        Parameters
+        ----------
+        norm: `str`
+            normalization used to compute the spectral residuals. Choose between `None`, `model` and `sqrt_model`.
+        """
         from matplotlib.gridspec import GridSpec
         import matplotlib.pyplot as plt
 
@@ -1277,10 +1295,13 @@ class FluxPointsDataset(Dataset):
     def plot_residuals(self, norm=None, ax=None, **kwargs):
         """Plot flux point residuals.
 
+        The normalization used for the residuals computation can be controlled using the `norm` parameter.
         Parameters
         ----------
         ax : `~matplotlib.pyplot.Axes`
             Axes object.
+        norm: `str`
+            normalization used to compute the spectral residuals. Choose between `None`, `model` and `sqrt_model`.
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.errorbar`.
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1224,18 +1224,22 @@ class FluxPointsDataset(Dataset):
             pass
 
     def residuals(self, norm=None):
-        """Compute the flux point residuals (`~numpy.ndarray`).
-
-        Available options are:
-        - `norm=None` (default) for: flux points - model
-        - `norm='model'` for: (flux points - model)/model
-        - `norm='sqrt_model'` for: (flux points - model)/sqrt(model)
+        """Compute the flux point residuals ().
 
         Parameters
         ----------
         norm: `str`, optional
-            normalization used to compute the residuals. Choose between `None`, `model` and `sqrt_model`.
+            Normalization used to compute the residuals. Choose between `None`,
+            `model` and `sqrt_model`. Available options are:
+                - `norm=None` (default) for: flux points - model
+                - `norm='model'` for: (flux points - model)/model
+                - `norm='sqrt_model'` for: (flux points - model)/sqrt(model)
 
+
+        Returns
+        -------
+        residuals : `~numpy.ndarray`
+            Residuals array.
         """
         fp = self.data
         data = fp.table[fp.sed_type].quantity
@@ -1292,16 +1296,15 @@ class FluxPointsDataset(Dataset):
     def _e_unit(self):
         return self.data.e_ref.unit
 
-    def plot_residuals(self, norm=None, ax=None, **kwargs):
+    def plot_residuals(self, ax=None, norm=None,  **kwargs):
         """Plot flux point residuals.
 
-        The normalization used for the residuals computation can be controlled using the `norm` parameter.
         Parameters
         ----------
         ax : `~matplotlib.pyplot.Axes`
             Axes object.
         norm: `str`
-            normalization used to compute the spectral residuals. Choose between `None`, `model` and `sqrt_model`.
+            Normalization used to compute the spectral residuals. See `FLuxPointsDataset.residuals`
         **kwargs : dict
             Keyword arguments passed to `~matplotlib.pyplot.errorbar`.
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1243,7 +1243,7 @@ class FluxPointsDataset(Dataset):
         model = self.model(fp.e_ref)
         residuals = data - model
 
-        with np.errstate(invalid='ignore'):
+        with np.errstate(invalid="ignore"):
             if norm == "model":
                 residuals /= model
             elif norm == "sqrt_model":

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -20,6 +20,11 @@ class Dataset(abc.ABC):
     - `gammapy.spectrum.SpectrumDataset`
     - `gammapy.spectrum.FluxPointsDataset`
     """
+    _residuals_labels = {
+            "diff": "data - model",
+            "diff/model": "(data - model) / model",
+            "diff/sqrt(model)": "(data - model) / sqrt(model)",
+        }
 
     @property
     def mask(self):
@@ -51,6 +56,22 @@ class Dataset(abc.ABC):
     def copy(self):
         """A deep copy."""
         return copy.deepcopy(self)
+
+    @staticmethod
+    def _compute_residuals(data, model, method="diff"):
+        with np.errstate(invalid="ignore"):
+            if method == "diff":
+                residuals = data - model
+            elif method == "diff/model":
+                residuals = (data - model) / model
+            elif method == "diff/sqrt(model)":
+                residuals = (data - model) / np.sqrt(model)
+            else:
+                raise AttributeError(
+                    "Invalid method: {}. Choose between 'diff',"
+                    " 'diff/model' and 'diff/sqrt(model)'".format(method)
+                )
+        return residuals
 
 
 class Datasets:

--- a/tutorials/analysis_3d_joint.ipynb
+++ b/tutorials/analysis_3d_joint.ipynb
@@ -28,7 +28,7 @@
     "from pathlib import Path\n",
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
-    "from regions import RectangleSkyRegion"
+    "from regions import CircleSkyRegion"
    ]
   },
   {
@@ -365,9 +365,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rectangle = RectangleSkyRegion(\n",
-    "    geom.center_skydir, width=3 * u.deg, height=0.8 * u.deg\n",
-    ")"
+    "region = CircleSkyRegion(spatial_model.position, radius=0.15 * u.deg)"
    ]
   },
   {
@@ -383,9 +381,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasets[0].plot_residuals(\n",
-    "    on_region=rectangle, vmin=-1, vmax=1, width=(4 * u.deg, 3 * u.deg)\n",
-    ")"
+    "ax_image, ax_spec = datasets[0].plot_residuals(region=region, vmin=-0.5, vmax=0.5, method=\"diff\")"
    ]
   },
   {
@@ -394,9 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasets[1].plot_residuals(\n",
-    "    on_region=rectangle, vmin=-1, vmax=1, width=(4 * u.deg, 3 * u.deg)\n",
-    ")"
+    "datasets[1].plot_residuals(region=region, vmin=-0.5, vmax=0.5);"
    ]
   },
   {
@@ -405,9 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasets[2].plot_residuals(\n",
-    "    on_region=rectangle, vmin=-1, vmax=1, width=(4 * u.deg, 3 * u.deg)\n",
-    ")"
+    "datasets[2].plot_residuals(region=region, vmin=-0.5, vmax=0.5);"
    ]
   },
   {
@@ -442,13 +434,6 @@
     "    vmin=-1, vmax=1, cmap=\"coolwarm\", add_cbar=True, stretch=\"linear\"\n",
     ");"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/analysis_3d_joint.ipynb
+++ b/tutorials/analysis_3d_joint.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,9 +133,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10.9 s, sys: 768 ms, total: 11.7 s\n",
+      "Wall time: 11.7 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "observations_data = {}\n",
@@ -161,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,9 +180,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'observations_data' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-11-0e208a18a93b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0mtable_psf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmake_psf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msrc_pos\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mpsf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mPSFKernel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_table_psf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtable_psf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgeom\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmax_radius\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"0.5 deg\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0mobservations_data\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mobs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobs_id\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"psf\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpsf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0;31m# create Edisp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'observations_data' is not defined"
+     ]
+    }
+   ],
    "source": [
     "for obs in observations:\n",
     "    table_psf = make_psf(obs, src_pos)\n",

--- a/tutorials/analysis_3d_joint.ipynb
+++ b/tutorials/analysis_3d_joint.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,18 +21,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "from astropy import units as u\n",
-    "from astropy.coordinates import SkyCoord"
+    "from astropy.coordinates import SkyCoord\n",
+    "from regions import RectangleSkyRegion"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,18 +134,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 10.9 s, sys: 768 ms, total: 11.7 s\n",
-      "Wall time: 11.7 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%time\n",
     "observations_data = {}\n",
@@ -170,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,21 +172,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'observations_data' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-11-0e208a18a93b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m     \u001b[0mtable_psf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmake_psf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msrc_pos\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m     \u001b[0mpsf\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mPSFKernel\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_table_psf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtable_psf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgeom\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmax_radius\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"0.5 deg\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0mobservations_data\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mobs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mobs_id\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"psf\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpsf\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0;31m# create Edisp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'observations_data' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for obs in observations:\n",
     "    table_psf = make_psf(obs, src_pos)\n",
@@ -371,29 +351,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each `MapDataset` object is equipped with a method called `plot.residuals()`, which displays the spatial and spectral residuals (computed as *counts-model*) for the dataset. Optionally, these can be normalized as *(counts-model)/model* or *(counts-model)/sqrt(model)*, by passing the parameter `norm='model` or `norm=sqrt_model`.\n",
+    "\n",
+    "First of all, let's define a region for the spectral extraction:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_residuals(dataset):\n",
-    "    npred = dataset.npred()\n",
-    "    residual = (dataset.counts - npred).sum_over_axes().smooth(\"0.08 deg\")\n",
-    "    _, ax, _ = residual.plot(\n",
-    "        vmin=-0.5, vmax=0.5, cmap=\"coolwarm\", add_cbar=True, stretch=\"linear\"\n",
-    "    )\n",
-    "    x_center, y_center, _ = dataset.counts.geom.center_coord\n",
-    "    fov = Circle(\n",
-    "        (x_center, y_center), radius=4, transform=ax.get_transform(\"galactic\")\n",
-    "    )\n",
-    "    ax.images[0].set_clip_path(fov)"
+    "rectangle = RectangleSkyRegion(\n",
+    "    geom.center_skydir, width=3 * u.deg, height=0.8 * u.deg\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each observation has different energy threshold. Keep in mind that the residuals are not meaningful below the energy threshold."
+    "We can now inspect the residuals for each dataset, separately:"
    ]
   },
   {
@@ -402,59 +383,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_residuals(datasets[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_residuals(datasets[1])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_residuals(datasets[2])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally we compute as stacked residual map (this requires to run the `analysis_3d` tutorial first):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "npred_stacked = Map.from_geom(geom)\n",
-    "counts_stacked = Map.from_geom(geom)\n",
-    "\n",
-    "for dataset in datasets:\n",
-    "    npred = dataset.npred()\n",
-    "    coords = npred.geom.get_coord()\n",
-    "\n",
-    "    npred_stacked.fill_by_coord(coords, npred.data)\n",
-    "    counts_stacked.fill_by_coord(coords, dataset.counts.data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "residual_stacked = (\n",
-    "    (counts_stacked - npred_stacked).sum_over_axes().smooth(\"0.1 deg\")\n",
+    "datasets[0].plot_residuals(\n",
+    "    on_region=rectangle, vmin=-1, vmax=1, width=(4 * u.deg, 3 * u.deg)\n",
     ")"
    ]
   },
@@ -464,7 +394,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "residual_stacked.plot(\n",
+    "datasets[1].plot_residuals(\n",
+    "    on_region=rectangle, vmin=-1, vmax=1, width=(4 * u.deg, 3 * u.deg)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datasets[2].plot_residuals(\n",
+    "    on_region=rectangle, vmin=-1, vmax=1, width=(4 * u.deg, 3 * u.deg)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can compute a stacked residual map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "residuals_stacked = Map.from_geom(geom)\n",
+    "\n",
+    "for dataset in datasets:\n",
+    "    residuals = dataset.residuals()\n",
+    "    coords = residuals.geom.get_coord()\n",
+    "\n",
+    "    residuals_stacked.fill_by_coord(coords, residuals.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "residuals_stacked.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
     "    vmin=-1, vmax=1, cmap=\"coolwarm\", add_cbar=True, stretch=\"linear\"\n",
     ");"
    ]

--- a/tutorials/cta_sensitivity.ipynb
+++ b/tutorials/cta_sensitivity.ipynb
@@ -151,7 +151,10 @@
     "    fov_lon=0 * u.deg, fov_lat=offset, energy_reco=energy_reco\n",
     ")\n",
     "bkg = CountsSpectrum(\n",
-    "    energy_reco[:-1], energy_reco[1:], data=(bkg_data * solid_angles).to_value(\"s-1\"), unit=\"s-1\"\n",
+    "    energy_reco[:-1],\n",
+    "    energy_reco[1:],\n",
+    "    data=(bkg_data * solid_angles).to_value(\"s-1\"),\n",
+    "    unit=\"s-1\",\n",
     ")"
    ]
   },

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -213,10 +213,10 @@
    "outputs": [],
    "source": [
     "sh.set_method(\"levmar\")\n",
-    "sh.set_method_opt('xtol', 1e-5)\n",
-    "sh.set_method_opt('ftol', 1e-5)\n",
-    "sh.set_method_opt('gtol', 1e-5)\n",
-    "sh.set_method_opt('epsfcn', 1e-5)"
+    "sh.set_method_opt(\"xtol\", 1e-5)\n",
+    "sh.set_method_opt(\"ftol\", 1e-5)\n",
+    "sh.set_method_opt(\"gtol\", 1e-5)\n",
+    "sh.set_method_opt(\"epsfcn\", 1e-5)"
    ]
   },
   {

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -322,7 +322,6 @@
    },
    "outputs": [],
    "source": [
-    "\n",
     "# Now let's define a function to init parameters and run the MCMC with emcee\n",
     "# Depending on your number of walkers, Nrun and dimensionality, this can take a while (> minutes)\n",
     "\n",


### PR DESCRIPTION
This PR addresses  [#2236](https://github.com/gammapy/gammapy/issues/2236). It may not be very refined yet (e.g. no docstrings for the new nmethods), but I would like to receive some feedback on it.

Basically, two things are achieved here:
- a `.residuals()` and `.plot_residuals()` method are implemented for the MapDataset class. The .plot_residuals() method plots: the spectral residuals, extracted from a `region` passed by the user, and the spatial residuals (with the same region overlayed). 
- the residuals computation is unified between the MapDataset, FluxPointsDataset and SpectrumDataset. Namely, in each case the user can choose between three options via a keyword argument  called `norm`: default is `norm=None`, corresponding to `counts-model`, while the other available options are `norm='model'` for `(counts-model)/model` and `norm='sqrt_model'` for `(counts-model)/sqrt(model)`. These options are similar to [what ctools have](http://cta.irap.omp.eu/ctools/users/reference_manual/csresmap.html#csresmap) (in subsequent PRs we could also consider something like the `SIGNIFICANCE` algorithm they implement, or some kind of Li&Ma computation).

I have tested the new methods in a [notebook](https://github.com/luca-giunti/share/blob/master/Residuals_testing.ipynb). There, I create a MapDataset, FluxPointsDataset and SpectrumDataset and plot the residuals.