### PR TITLE
Remove astropy InheritDocstrings

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -14,11 +14,7 @@ from ..utils.scripts import make_path
 __all__ = ["Map"]
 
 
-class MapMeta(abc.ABCMeta):
-    pass
-
-
-class Map(metaclass=MapMeta):
+class Map(abc.ABC):
     """Abstract map class.
 
     This can represent WCS- or HEALPIX-based maps

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -6,7 +6,6 @@ import json
 from collections import OrderedDict
 import numpy as np
 from astropy import units as u
-from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from .geom import pix_tuple_to_idx, MapCoord
 from .utils import INVALID_VALUE
@@ -15,7 +14,7 @@ from ..utils.scripts import make_path
 __all__ = ["Map"]
 
 
-class MapMeta(InheritDocstrings, abc.ABCMeta):
+class MapMeta(abc.ABCMeta):
     pass
 
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1090,11 +1090,7 @@ class MapCoord:
         return self.__class__(coords, coordsys=self.coordsys)
 
 
-class MapGeomMeta(abc.ABCMeta):
-    pass
-
-
-class MapGeom(metaclass=MapGeomMeta):
+class MapGeom(abc.ABC):
     """Base class for WCS and HEALPix geometries."""
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 import logging
 import numpy as np
 from scipy.interpolate import interp1d
-from astropy.utils.misc import InheritDocstrings
 from astropy.io import fits
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -1091,7 +1090,7 @@ class MapCoord:
         return self.__class__(coords, coordsys=self.coordsys)
 
 
-class MapGeomMeta(InheritDocstrings, abc.ABCMeta):
+class MapGeomMeta(abc.ABCMeta):
     pass
 
 

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-import abc
 import numpy as np
 from .iminuit import optimize_iminuit, covariance_iminuit, confidence_iminuit, mncontour
 from .sherpa import optimize_sherpa, covariance_sherpa
@@ -10,10 +9,6 @@ from .datasets import Datasets
 __all__ = ["Fit"]
 
 log = logging.getLogger(__name__)
-
-
-class FitMeta(abc.ABCMeta):
-    pass
 
 
 class Registry:

--- a/gammapy/utils/fitting/fit.py
+++ b/gammapy/utils/fitting/fit.py
@@ -2,7 +2,6 @@
 import logging
 import abc
 import numpy as np
-from astropy.utils.misc import InheritDocstrings
 from .iminuit import optimize_iminuit, covariance_iminuit, confidence_iminuit, mncontour
 from .sherpa import optimize_sherpa, covariance_sherpa
 from .scipy import optimize_scipy, covariance_scipy, confidence_scipy
@@ -13,7 +12,7 @@ __all__ = ["Fit"]
 log = logging.getLogger(__name__)
 
 
-class FitMeta(InheritDocstrings, abc.ABCMeta):
+class FitMeta(abc.ABCMeta):
     pass
 
 


### PR DESCRIPTION
This PR addresses some of the concerns of issue https://github.com/gammapy/gammapy/issues/2221 removing [astropy.utils.misc.InheritDocstrings](http://docs.astropy.org/en/stable/api/astropy.utils.misc.InheritDocstrings.html) in the Gammapy code-base. I've checked this modif does not imply any change in the related documentation generated.
