### PR TITLE
Use parfive in gammapy download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties=3.0 pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties=3.0 pandas naima sherpa libgfortran iminuit regions reproject pandoc ipython jupyter'
 
-        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy parfive'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 
@@ -67,7 +67,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES='Cython click regions'
-               PIP_DEPENDENCIES='pytest-astropy'
+               PIP_DEPENDENCIES='pytest-astropy parfive'
 
         # Run tests without GAMMAPY_EXTRA available
         - os: linux
@@ -99,7 +99,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
-               PIP_DEPENDENCIES='uncertainties==3.0.* git+http://github.com/sherpa/sherpa.git#egg=sherpa pytest-astropy'
+               PIP_DEPENDENCIES='uncertainties==3.0.* git+http://github.com/sherpa/sherpa.git#egg=sherpa pytest-astropy parfive'
 
         # Test Fermipy master against gammapy master
         - os: linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip setuptools
-      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy
+      pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy parfive
       pip install matplotlib reproject iminuit uncertainties
     displayName: 'Install dependencies'
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -49,3 +49,4 @@ dependencies:
     - numdifftools
     - pytest-astropy
     - twine
+    - parfive

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -5,7 +5,7 @@ import json
 import logging
 import sys
 import yaml
-from urllib.request import urlretrieve, urlopen
+from urllib.request import urlopen
 from pathlib import Path
 from .. import version
 
@@ -58,13 +58,20 @@ class ComputePlan:
         log.info("Looking for {}...".format(self.option))
 
     def getenvironment(self):
+        try:
+            from parfive import Downloader
+        except ImportError:
+            log.error("The parfive package needs to be installed to download files with gammapy download")
+            return
+        dl = Downloader()
         filename_env = "gammapy-" + self.release + "-environment.yml"
         url_file_env = BASE_URL + "/install/" + filename_env
         filepath_env = str(self.outfolder / filename_env)
+        dl.enqueue_file(url_file_env, path=filepath_env)
         try:
             log.info("Downloading {}".format(url_file_env))
             Path(filepath_env).parent.mkdir(parents=True, exist_ok=True)
-            urlretrieve(url_file_env, filepath_env)
+            dl.download()
         except Exception as ex:
             log.error(ex)
             exit()

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -213,15 +213,13 @@ class ParallelDownload:
             md5 = ""
             if "hashmd5" in self.listfiles[rec]:
                 md5 = self.listfiles[rec]["hashmd5"]
-            ifolder = Path(path).parent
-            ifolder.mkdir(parents=True, exist_ok=True)
             retrieve = True
             if md5 and path.exists():
                 md5local = hashlib.md5(path.read_bytes()).hexdigest()
-                if md5local != md5:
+                if md5local == md5:
                     retrieve = False
             if retrieve:
-                dl.enqueue_file(url, path=str(path))
+                dl.enqueue_file(url, path=str(path.parent))
 
         try:
             dl.download()

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -7,7 +7,6 @@ import sys
 import yaml
 from urllib.request import urlretrieve, urlopen
 from pathlib import Path
-from parfive import Downloader
 from .. import version
 
 log = logging.getLogger(__name__)
@@ -203,6 +202,12 @@ class ParallelDownload:
         self.bar = 0
 
     def run(self):
+        try:
+            from parfive import Downloader
+        except ImportError:
+            log.error("The parfive package needs to be installed to download files with gammapy download")
+            return
+
         if self.listfiles:
             log.info("Content will be downloaded in {}".format(self.outfolder))
 

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
 import pytest
-from ...utils.testing import run_cli
+from ...utils.testing import run_cli, requires_dependency
 from ..main import cli
 
 
@@ -27,6 +27,7 @@ def test_cli_download_help():
     assert "Usage" in result.output
 
 
+@requires_dependency("parfive")
 @pytest.mark.remote_data
 def test_cli_download_datasets(files_dir, config):
     option_out = "--out={}".format(files_dir)
@@ -39,6 +40,7 @@ def test_cli_download_datasets(files_dir, config):
     assert "GAMMAPY_DATA" in result.output
 
 
+@requires_dependency("parfive")
 @pytest.mark.remote_data
 def test_cli_download_notebooks(files_dir, config):
     option_out = "--out={}".format(files_dir)
@@ -54,6 +56,7 @@ def test_cli_download_notebooks(files_dir, config):
     assert (Path(files_dir) / dirname / filename).exists()
 
 
+@requires_dependency("parfive")
 @pytest.mark.remote_data
 def test_cli_download_scripts(files_dir, config):
     option_out = "--out={}".format(files_dir)
@@ -68,6 +71,7 @@ def test_cli_download_scripts(files_dir, config):
     assert (Path(files_dir) / dirname / filename).exists()
 
 
+@requires_dependency("parfive")
 @pytest.mark.remote_data
 def test_cli_download_tutorials(files_dir, config):
     option_out = "--out={}".format(files_dir)

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
       'regions>=0.4',
       'pyyaml',
       'click',
+      'parfive',
     ],
     extras_require=dict(
       analysis=[

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ setup(
       'regions>=0.4',
       'pyyaml',
       'click',
-      'parfive',
     ],
     extras_require=dict(
       analysis=[
@@ -120,6 +119,7 @@ setup(
           'naima',
           'iminuit>=1.3.2',
           'sherpa',
+          'parfive',
       ],
       plotting=[
           'matplotlib>=2.1',


### PR DESCRIPTION
This PR addresses issue https://github.com/gammapy/gammapy/issues/2269.

It uses [parfive](https://github.com/Cadair/parfive) package for async files downloading, removing the need of `multiprocessing`, and using an external well-tested solution. 

The download times are highly reduced.

Without `parfive`.
```
time gammapy download datasets
INFO:gammapy.scripts.downloadclasses:Looking for datasets...
INFO:gammapy.scripts.downloadclasses:Reading https://raw.githubusercontent.com/gammapy/gammapy/master/dev/datasets/gammapy-data-index.json
INFO:gammapy.scripts.downloadclasses:Content will be downloaded in gammapy-datasets
Downloading files [==================================================] 100% 

*** You might want to declare GAMMAPY_DATA env variable
export GAMMAPY_DATA=/Users/jer/Desktop/gammapy-datasets


real	1m46.545s
user	0m15.772s
sys	0m2.390s
```

With `parfive`.

```
time gammapy download datasets
INFO:gammapy.scripts.downloadclasses:Looking for datasets...
INFO:gammapy.scripts.downloadclasses:Reading https://raw.githubusercontent.com/gammapy/gammapy/master/dev/datasets/gammapy-data-index.json
INFO:gammapy.scripts.downloadclasses:Content will be downloaded in gammapy-datasets
Files Downloaded: 100%|██████████████████████████████████████████████ 569/569 [00:36<00:00, 15.56file/s]
                                                                                                                                                                                                                                                                              
*** You might want to declare GAMMAPY_DATA env variable                                                                                                                                                                                                                       
export GAMMAPY_DATA=/Users/jer/Desktop/gammapy-datasets                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                              
real	0m39.452s
user	0m10.294s
sys	0m1.784s
```

```
du -hs gammapy-datasets/
162M	gammapy-datasets/
```

This PR adds `parfive` as a new external dependency, which in turn needs the following requirements:
- Python 3.5+
- aiohttp
- tqdm


