### PR TITLE
Add tests for LightCurveEstimator3D

### DIFF
--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -73,7 +73,11 @@ class SpectrumDataset(Dataset):
             raise ValueError("mask data must have dtype bool")
 
         self.counts = counts
-        self.livetime = u.Quantity(livetime)
+
+        if livetime is not None:
+            livetime = u.Quantity(livetime)
+
+        self.livetime = livetime
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp
@@ -417,7 +421,11 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         self.counts = counts
         self.counts_off = counts_off
-        self.livetime = u.Quantity(livetime)
+
+        if livetime is not None:
+            livetime = u.Quantity(livetime)
+
+        self.livetime = livetime
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -73,7 +73,7 @@ class SpectrumDataset(Dataset):
             raise ValueError("mask data must have dtype bool")
 
         self.counts = counts
-        self.livetime = livetime
+        self.livetime = u.Quantity(livetime)
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp
@@ -417,7 +417,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         self.counts = counts
         self.counts_off = counts_off
-        self.livetime = livetime
+        self.livetime = u.Quantity(livetime)
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -17,7 +17,7 @@ from ...maps import MapAxis, WcsGeom
 
 
 # TODO: use pregenerate data instead
-def simulate_spectrum_dataset(model):
+def simulate_spectrum_dataset(model, random_state=0):
     energy = np.logspace(-0.5, 1.5, 21) * u.TeV
     aeff = EffectiveAreaTable.from_parametrization(energy=energy)
     bkg_model = PowerLaw(index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1")
@@ -37,7 +37,7 @@ def simulate_spectrum_dataset(model):
     )
 
     bkg_model = eval.compute_npred()
-    dataset.fake(random_state=0, background_model=bkg_model)
+    dataset.fake(random_state=random_state, background_model=bkg_model)
     return dataset
 
 
@@ -48,7 +48,7 @@ def create_fpe(model):
     return FluxPointsEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=11)
 
 
-def simulate_map_dataset():
+def simulate_map_dataset(random_state=0):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
@@ -65,7 +65,7 @@ def simulate_map_dataset():
     pwl = PowerLaw(amplitude="1e-11 cm-2 s-1 TeV-1")
     skymodel = SkyModel(spatial_model=gauss, spectral_model=pwl, name="source")
     dataset = simulate_dataset(
-        skymodel=skymodel, geom=geom, pointing=skydir, irfs=irfs, random_state=0
+        skymodel=skymodel, geom=geom, pointing=skydir, irfs=irfs, random_state=random_state
     )
     return dataset
 

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -16,8 +16,7 @@ log = logging.getLogger(__name__)
 class LightCurveEstimator3D:
     """Flux Points estimated for each time bin.
 
-    Estimates flux points for a given list of datasets.
-    This new class will replace the current LightCurveEstimator
+    Estimates flux points for a given list of datasets, each per time bin.
 
     Parameters
     ----------
@@ -101,18 +100,18 @@ class LightCurveEstimator3D:
     def ref_model(self):
         return self.model.model
 
-    def run(self, eref, emin, emax, steps="all"):
+    def run(self, e_ref, e_min, e_max, steps="all"):
         """Run light curve extraction.
 
         Normalize integral and energy flux between emin and emax.
 
         Parameters
         ----------
-        eref : `~astropy.unit.Quantity`
+        e_ref : `~astropy.unit.Quantity`
             reference energy of dnde flux normalization
-        emin : `~astropy.unit.Quantity`
+        e_min : `~astropy.unit.Quantity`
             minimum energy of integral and energy flux normalization interval
-        emax : `~astropy.unit.Quantity`
+        e_max : `~astropy.unit.Quantity`
             minimum energy of integral and energy flux normalization interval
         steps : list of str
             Which steps to execute. Available options are:
@@ -130,9 +129,9 @@ class LightCurveEstimator3D:
         lightcurve : `~gammapy.time.LightCurve`
             the Light Curve object
         """
-        self.e_ref = eref
-        self.e_min = emin
-        self.e_max = emax
+        self.e_ref = e_ref
+        self.e_min = e_min
+        self.e_max = e_max
 
         rows = []
 
@@ -252,8 +251,6 @@ class LightCurveEstimator3D:
         result : dict
             Dict with an array with one entry per dataset with counts for the flux point.
         """
-        counts = []
-
         # TODO : use e_min and e_max interval for counts calculation
         # TODO : add off counts and excess? for DatasetOnOff
         # TODO : this may require a loop once we support Datasets per time bin
@@ -261,9 +258,9 @@ class LightCurveEstimator3D:
         if dataset.mask_safe is not None:
             mask &= dataset.mask_safe
 
-        counts.append(dataset.counts.data[mask].sum())
+        counts = dataset.counts.data[mask].sum()
 
-        return {"counts": np.array(counts, dtype=int)}
+        return {"counts": counts}
 
     def estimate_norm_ul(self, dataset):
         """Estimate upper limit for a flux point.

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -12,15 +12,12 @@ from ...utils.testing import requires_data, requires_dependency, mpl_plot_check
 from ...utils.testing import assert_quantity_allclose
 from ...utils.energy import energy_logspace
 from ...data import DataStore
-from ...spectrum import SpectrumExtraction, SpectrumDatasetOnOff, CountsSpectrum
+from ...spectrum import SpectrumExtraction
 from ...spectrum.tests.test_flux_point_estimator import simulate_spectrum_dataset, simulate_map_dataset
-from ...irf import EnergyDispersion, EffectiveAreaTable
-from ...spectrum.models import PowerLaw, PowerLaw2
+from ...spectrum.models import PowerLaw
 from ...background import ReflectedRegionsBackgroundEstimator
 from ..lightcurve import LightCurve, LightCurveEstimator
 from ..lightcurve_estimator import LightCurveEstimator3D
-from ...cube import MapDataset
-from ...cube.models import SkyModel
 
 
 

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -281,6 +281,8 @@ def get_spectrum_datasets():
     return [dataset_1, dataset_2]
 
 
+@requires_data()
+@requires_dependency("iminuit")
 def test_lightcurve_estimator_spectrum_datasets():
     datasets = get_spectrum_datasets()
 
@@ -325,6 +327,8 @@ def get_map_datasets():
     return [dataset_1, dataset_2]
 
 
+@requires_data()
+@requires_dependency("iminuit")
 def test_lightcurve_estimator_map_datasets():
     datasets = get_map_datasets()
 


### PR DESCRIPTION
This PR adds minimal tests for the `LightCurveEstimator3D` for `SpectrumDatasetOnOff` as well as `MapDataset`.