### PR TITLE
Raise deprecations coming from numpy

### DIFF
--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -25,8 +25,7 @@ TESTED_VERSIONS[packagename] = version.version
 # Treat all DeprecationWarnings as exceptions
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
-# TODO: add numpy again once https://github.com/astropy/regions/pull/252 is addressed
-enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=["numpy", "astropy"])
+enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=["astropy"])
 
 # Declare for which packages version numbers should be displayed
 # when running the tests

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -25,7 +25,9 @@ TESTED_VERSIONS[packagename] = version.version
 # Treat all DeprecationWarnings as exceptions
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
-enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=["astropy"])
+# Remove naima ignore once https://github.com/zblz/naima/issues/185
+# is addressed and released
+enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=["naima", "astropy"])
 
 # Declare for which packages version numbers should be displayed
 # when running the tests

--- a/gammapy/utils/energy.py
+++ b/gammapy/utils/energy.py
@@ -31,7 +31,7 @@ def energy_logspace(emin, emax, nbins, unit=None, per_decade=False):
     x_min, x_max = np.log10([emin.value, emax.value])
 
     if per_decade:
-        nbins = (x_max - x_min) * nbins
+        nbins = int((x_max - x_min) * nbins)
 
     energy = np.logspace(x_min, x_max, nbins)
 


### PR DESCRIPTION
Better to catch and clean them early than when they turn to errors.

