### PR TITLE
WIP: Enable DocSearch for gammapy documentation

### DIFF
--- a/docs/_static/gammapy.css
+++ b/docs/_static/gammapy.css
@@ -46,3 +46,39 @@ table.docutils {
 .wy-table-odd td {
      background-color: #fff;
 }
+
+
+/* DocSearch customization
+
+/* Main dropdown wrapper */
+.algolia-autocomplete .ds-dropdown-menu {
+  width: 500px;
+}
+
+/* Main category (eg. Getting Started) */
+.algolia-autocomplete .algolia-docsearch-suggestion--category-header {
+  color: darkgray;
+  border: 1px solid gray;
+}
+
+/* Category (eg. Downloads) */
+.algolia-autocomplete .algolia-docsearch-suggestion--subcategory-column {
+  color: var(--gammapy-lightgray);
+}
+
+/* Title (eg. Bootstrap CDN) */
+.algolia-autocomplete .algolia-docsearch-suggestion--title {
+  font-weight: bold;
+  color: black;
+}
+
+/* Description description (eg. Bootstrap currently works...) */
+.algolia-autocomplete .algolia-docsearch-suggestion--text {
+  font-size: 0.8rem;
+  color: var(--gammapy-lightgray);
+}
+
+/* Highlighted text */
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: var(--gammapy-primary);
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,14 @@
+{% extends "!layout.html" %}
+
+
+{% block footer %}
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript"> docsearch({
+apiKey: 'f25822251ba19a1d2877c212ed9dbf8f',
+indexName: 'gammapy',
+inputSelector: 'rtd-search-form'
+debug: false // Set debug to true if you want to inspect the dropdown
+});
+</script>
+{{ super() }}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,6 +154,7 @@ def setup(app):
     app.add_stylesheet("gammapy.css")
     app.add_javascript("copybutton.js")
     app.add_javascript("gammapy.js")
+    app.add_stylesheet("https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css")
 
 
 # copybutton.js provides hide/show button for python prompts >>>


### PR DESCRIPTION
This PR implements #2283 (sorry it took so long)

The configuration file that was used to create the search index lives [here](https://github.com/algolia/docsearch-configs/blob/master/configs/gammapy.json). We can make PRs to this page in order to update the config (which I will soon do in order to add a proper version handling)

You can access to the full Algolia analytics for this index on TODO (I'm working on it)

It hard to test this PR before merging it into master, because the index only works for URLs pointing to `docs.gammapy.org`. One way to test the index is installing the [docsearch scraper](https://community.algolia.com/docsearch/run-your-own.html) manually and the launch the docsearch playground.