### PR TITLE
Drop Python 3.5 CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+               PYTEST_VERSION<3.7
 
         - os: linux
           env: PYTHON_VERSION=3.6 ASTROPY_VERSION=dev SETUP_CMD='test -V'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - CONDA_DOCS_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml uncertainties=3.0 pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml uncertainties=3.0 pandas naima sherpa libgfortran iminuit regions reproject pandoc ipython jupyter'
 
-        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy pytest-cov'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 
@@ -90,7 +90,6 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-               PYTEST_VERSION<3.7
 
         - os: linux
           env: PYTHON_VERSION=3.6 ASTROPY_VERSION=dev SETUP_CMD='test -V'

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
 
         # MacOS X tests
         - os: osx
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OSX
 
         # The main build that's used for coverage measurement
@@ -65,7 +65,7 @@ matrix:
 
         # Run tests without optional dependencies
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test -V'
                CONDA_DEPENDENCIES='Cython click regions'
                PIP_DEPENDENCIES='pytest-astropy'
 
@@ -86,13 +86,9 @@ matrix:
           env: PYTHON_VERSION=3.7 SETUP_CMD='bdist_conda'
                PACKAGING_TEST=true
 
-        # Older Python versions
-        - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test -V'
-
         # Test with Astropy dev and LTS versions
         - os: linux
-          env: PYTHON_VERSION=3.5 ASTROPY_VERSION=lts SETUP_CMD='test -V'
+          env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts SETUP_CMD='test -V'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
         - os: linux
@@ -119,12 +115,12 @@ matrix:
 
         # Test Jupyter notebooks
         - os: linux
-          env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-nb'
+          env: PYTHON_VERSION=3.6 MAIN_CMD='make' SETUP_CMD='test-nb'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
 
         # Test example scripts
         - os: linux
-          env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-scripts'
+          env: PYTHON_VERSION=3.6 MAIN_CMD='make' SETUP_CMD='test-scripts'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
     # You can move builds that temporarily fail because of some non-Gammapy here.
@@ -132,7 +128,7 @@ matrix:
     # copy the part from the `include` section above here.
 #    allow_failures:
 #        - os: linux
-#          env: PYTHON_VERSION=3.5 MAIN_CMD='make' SETUP_CMD='test-nb'
+#          env: PYTHON_VERSION=3.6 MAIN_CMD='make' SETUP_CMD='test-nb'
 #               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ jobs:
 
   strategy:
     matrix:
-      Python35:
+      Python36:
         imageName: 'ubuntu-16.04'
-        python.version: '3.5'
-      Windows35:
+        python.version: '3.6'
+      Windows36:
         imageName: 'vs2017-win2016'
-        python.version: '3.5'
+        python.version: '3.6'
       Windows37:
         imageName: 'vs2017-win2016'
         python.version: '3.7'
@@ -31,7 +31,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip setuptools
       pip install pytest pytest-cov cython numpy astropy regions pyyaml click pytest-astropy
-      pip install matplotlib reproject iminuit uncertainties==3.0.*
+      pip install matplotlib reproject iminuit uncertainties
     displayName: 'Install dependencies'
 
   - script: |

--- a/gammapy/astro/population/tests/test_spatial.py
+++ b/gammapy/astro/population/tests/test_spatial.py
@@ -50,8 +50,8 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("case", test_cases, ids=lambda _: _["class"])
-def test_velocity_model(case):
+@pytest.mark.parametrize("case", test_cases, ids=lambda _: _["class"].__name__)
+def test_spatial_model(case):
     model = case["class"]()
     y = model(case["x"])
     assert_allclose(y, case["y"], rtol=1e-5)

--- a/gammapy/astro/population/tests/test_spatial.py
+++ b/gammapy/astro/population/tests/test_spatial.py
@@ -15,7 +15,6 @@ from ..spatial import (
     ZMAX,
     Exponential,
 )
-from .test_velocity import velocity_models_1D
 
 radial_models_1D = {
     FaucherKaspi2006: {
@@ -69,13 +68,11 @@ radial_models_1D = {
     },
 }
 
-radial_models_1D.update(velocity_models_1D)
-
 
 @pytest.mark.parametrize(
     ("model_class", "test_parameters"), list(radial_models_1D.items())
 )
-class TestMorphologyModels(Fittable1DModelTester):
+class TestRadialModels(Fittable1DModelTester):
     @classmethod
     def setup_class(cls):
         cls.N = 100

--- a/gammapy/astro/population/tests/test_spatial.py
+++ b/gammapy/astro/population/tests/test_spatial.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
 import pytest
-from astropy.modeling.tests.test_models import Fittable1DModelTester
+from numpy.testing import assert_allclose
 from ..spatial import (
     FaucherKaspi2006,
     Lorimer2006,
@@ -9,78 +8,50 @@ from ..spatial import (
     YusifovKucuk2004B,
     Paczynski1990,
     CaseBattacharya1998,
-    RMIN,
-    RMAX,
-    ZMIN,
-    ZMAX,
     Exponential,
 )
 
-radial_models_1D = {
-    FaucherKaspi2006: {
-        "parameters": [1, 7.04, 1.83],
-        "x_values": [0.1, 1, 10],
-        "y_values": [0.00022217, 0.00127107, 0.07972058],
-        "x_lim": [RMIN.value, RMAX.value],
-        "integral": 1,
+test_cases = [
+    {
+        "class": FaucherKaspi2006,
+        "x": [0.1, 1, 10],
+        "y": [0.0002221728797095, 0.00127106525755, 0.0797205770877],
     },
-    Lorimer2006: {
-        "parameters": [1, 1.9, 5],
-        "x_values": [0.1, 1, 10],
-        "y_values": [0.03020158, 1.41289246, 0.56351182],
-        "x_lim": [RMIN.value, RMAX.value],
-        "integral": 1,
+    {
+        "class": Lorimer2006,
+        "x": [0.1, 1, 10],
+        "y": [0.03020158, 1.41289246, 0.56351182],
     },
-    Paczynski1990: {
-        "parameters": [1, 4.5],
-        "x_values": [0.1, 1, 10],
-        "y_values": [0.04829743, 0.03954259, 0.00535151],
-        "x_lim": [RMIN.value, RMAX.value],
-        "integral": 1,
+    {
+        "class": Paczynski1990,
+        "x": [0.1, 1, 10],
+        "y": [0.04829743, 0.03954259, 0.00535151],
     },
-    YusifovKucuk2004: {
-        "parameters": [1, 1.64, 4.01, 0.55],
-        "x_values": [0.1, 1, 10],
-        "y_values": [0.55044445, 1.5363482, 0.66157715],
-        "x_lim": [RMIN.value, RMAX.value],
-        "integral": 1,
+    {
+        "class": YusifovKucuk2004,
+        "x": [0.1, 1, 10],
+        "y": [0.55044445, 1.5363482, 0.66157715],
     },
-    YusifovKucuk2004B: {
-        "parameters": [1, 4, 6.8],
-        "x_values": [0.1, 1, 10],
-        "y_values": [1.76840095e-08, 8.60773150e-05, 6.42641018e-04],
-        "x_lim": [RMIN.value, RMAX.value],
-        "integral": 1,
+    {
+        "class": YusifovKucuk2004B,
+        "x": [0.1, 1, 10],
+        "y": [1.76840095e-08, 8.60773150e-05, 6.42641018e-04],
     },
-    CaseBattacharya1998: {
-        "parameters": [1, 2, 3.53],
-        "x_values": [0.1, 1, 10],
-        "y_values": [0.00453091, 0.31178967, 0.74237311],
-        "x_lim": [RMIN.value, RMAX.value],
-        "integral": 1,
+    {
+        "class": CaseBattacharya1998,
+        "x": [0.1, 1, 10],
+        "y": [0.00453091, 0.31178967, 0.74237311],
     },
-    Exponential: {
-        "parameters": [1, 0.05],
-        "x_values": [0, 0.25, 0.5],
-        "y_values": [1.00000000e00, 6.73794700e-03, 4.53999298e-05],
-        "x_lim": [ZMIN.value, ZMAX.value],
-        "integral": 1,
+    {
+        "class": Exponential,
+        "x": [0, 0.25, 0.5],
+        "y": [1.00000000e00, 6.73794700e-03, 4.53999298e-05],
     },
-}
+]
 
 
-@pytest.mark.parametrize(
-    ("model_class", "test_parameters"), list(radial_models_1D.items())
-)
-class TestRadialModels(Fittable1DModelTester):
-    @classmethod
-    def setup_class(cls):
-        cls.N = 100
-        cls.M = 100
-        cls.eval_error = 0.0001
-        cls.fit_error = 10
-        cls.x = 5.3
-        cls.y = 6.7
-        cls.x1 = np.arange(1, 10, 0.1)
-        cls.y1 = np.arange(1, 10, 0.1)
-        cls.y2, cls.x2 = np.mgrid[:10, :8]
+@pytest.mark.parametrize("case", test_cases, ids=lambda _: _["class"])
+def test_velocity_model(case):
+    model = case["class"]()
+    y = model(case["x"])
+    assert_allclose(y, case["y"], rtol=1e-5)

--- a/gammapy/astro/population/tests/test_velocity.py
+++ b/gammapy/astro/population/tests/test_velocity.py
@@ -1,53 +1,29 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
 import pytest
-from astropy.modeling.tests.test_models import Fittable1DModelTester
+from numpy.testing import assert_allclose
 from ..velocity import (
     FaucherKaspi2006VelocityMaxwellian,
     Paczynski1990Velocity,
     FaucherKaspi2006VelocityBimodal,
-    VMAX,
-    VMIN,
 )
 
-velocity_models_1D = {
-    FaucherKaspi2006VelocityMaxwellian: {
-        "parameters": [1, 265],
-        "x_values": [1, 10, 100, 1000],
-        "y_values": [4.28745276e-08, 4.28443169e-06, 3.99282978e-04, 3.46767268e-05],
-        "x_lim": [VMIN.value, VMAX.value],
-        "integral": 1,
+test_cases = [
+    {
+        "class": FaucherKaspi2006VelocityMaxwellian,
+        "x": [1, 10],
+        "y": [4.28745276e-08, 4.28443169e-06],
     },
-    FaucherKaspi2006VelocityBimodal: {
-        "parameters": [1, 160, 780, 0.9],
-        "constraints": {"fixed": {"sigma_2": True, "w": True}},
-        "x_values": [1, 10, 100, 1000],
-        "y_values": [1.754811e-07, 1.751425e-05, 1.443781e-03, 7.391701e-05],
-        "x_lim": [VMIN.value, VMAX.value],
-        "integral": 1,
+    {
+        "class": FaucherKaspi2006VelocityBimodal,
+        "x": [1, 10],
+        "y": [1.754811e-07, 1.751425e-05],
     },
-    Paczynski1990Velocity: {
-        "parameters": [1, 560],
-        "x_values": [1, 10, 100, 1000],
-        "y_values": [0.00227363, 0.00227219, 0.00213529, 0.00012958],
-        "x_lim": [VMIN.value, VMAX.value],
-        "integral": 1,
-    },
-}
+    {"class": Paczynski1990Velocity, "x": [1, 10], "y": [0.00227363, 0.00227219]},
+]
 
 
-@pytest.mark.parametrize(
-    ("model_class", "test_parameters"), list(velocity_models_1D.items())
-)
-class TestVelocityModels(Fittable1DModelTester):
-    @classmethod
-    def setup_class(cls):
-        cls.N = 100
-        cls.M = 100
-        cls.eval_error = 0.0001
-        cls.fit_error = 10
-        cls.x = 5.3
-        cls.y = 6.7
-        cls.x1 = np.arange(1, 10, 0.1)
-        cls.y1 = np.arange(1, 10, 0.1)
-        cls.y2, cls.x2 = np.mgrid[:10, :8]
+@pytest.mark.parametrize("case", test_cases, ids=lambda _: _["class"])
+def test_velocity_model(case):
+    model = case["class"]()
+    y = model(case["x"])
+    assert_allclose(y, case["y"], rtol=1e-5)

--- a/gammapy/astro/population/tests/test_velocity.py
+++ b/gammapy/astro/population/tests/test_velocity.py
@@ -22,7 +22,7 @@ test_cases = [
 ]
 
 
-@pytest.mark.parametrize("case", test_cases, ids=lambda _: _["class"])
+@pytest.mark.parametrize("case", test_cases, ids=lambda _: _["class"].__name__)
 def test_velocity_model(case):
     model = case["class"]()
     y = model(case["x"])

--- a/gammapy/astro/population/tests/test_velocity.py
+++ b/gammapy/astro/population/tests/test_velocity.py
@@ -39,7 +39,7 @@ velocity_models_1D = {
 @pytest.mark.parametrize(
     ("model_class", "test_parameters"), list(velocity_models_1D.items())
 )
-class TestMorphologyModels(Fittable1DModelTester):
+class TestVelocityModels(Fittable1DModelTester):
     @classmethod
     def setup_class(cls):
         cls.N = 100

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -14,23 +14,19 @@ def test_cta_irf():
 
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
-    rad = Quantity(0.1, "deg")
-    migra = 1
 
     val = irf["aeff"].data.evaluate(energy=energy, offset=offset)
-    assert_allclose(val.value, 545269.4675532734)
+    assert_allclose(val.value, 545269.4675, rtol=1e-5)
     assert val.unit == "m2"
 
-    val = irf["edisp"].data.evaluate(offset=offset, e_true=energy, migra=migra)
-    assert_allclose(val.value, 3183.688224335546)
+    val = irf["edisp"].data.evaluate(offset=offset, e_true=energy, migra=1)
+    assert_allclose(val.value, 3183.6882, rtol=1e-5)
     assert val.unit == ""
 
     psf = irf["psf"].psf_at_energy_and_theta(energy=energy, theta=offset)
-    val = psf(rad)
-    assert_allclose(val, 4.868832183085153)
+    val = psf(Quantity(0.1, "deg"))
+    assert_allclose(val, 4.868832183, rtol=1e-5)
 
-    val = irf["bkg"].data.evaluate(
-        energy=energy, fov_lon=offset, fov_lat=Quantity(0, "deg")
-    )
-    assert_allclose(val.value, 9.400071082017065e-05)
+    val = irf["bkg"].data.evaluate(energy=energy, fov_lon=offset, fov_lat="0 deg")
+    assert_allclose(val.value, 9.400071e-05, rtol=1e-5)
     assert val.unit == "1 / (MeV s sr)"

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -883,7 +883,7 @@ class ExponentialCutoffPowerLaw(SpectralModel):
         pwl = amplitude * (energy / reference) ** (-index)
         try:
             cutoff = np.exp(-energy * lambda_)
-        except AttributeError:
+        except (AttributeError, TypeError):
             from uncertainties.unumpy import exp
 
             cutoff = exp(-energy * lambda_)
@@ -962,7 +962,7 @@ class ExponentialCutoffPowerLaw3FGL(SpectralModel):
         pwl = amplitude * (energy / reference) ** (-index)
         try:
             cutoff = np.exp((reference - energy) / ecut)
-        except AttributeError:
+        except (AttributeError, TypeError):
             from uncertainties.unumpy import exp
 
             cutoff = exp((reference - energy) / ecut)
@@ -1029,7 +1029,7 @@ class PLSuperExpCutoff3FGL(SpectralModel):
         pwl = amplitude * (energy / reference) ** (-index_1)
         try:
             cutoff = np.exp((reference / ecut) ** index_2 - (energy / ecut) ** index_2)
-        except AttributeError:
+        except (AttributeError, TypeError):
             from uncertainties.unumpy import exp
 
             cutoff = exp((reference / ecut) ** index_2 - (energy / ecut) ** index_2)
@@ -1101,7 +1101,7 @@ class PLSuperExpCutoff4FGL(SpectralModel):
         pwl = amplitude * (energy / reference) ** (-index_1)
         try:
             cutoff = np.exp(expfactor * (reference ** index_2 - energy ** index_2))
-        except AttributeError:
+        except (AttributeError, TypeError):
             from uncertainties.unumpy import exp
 
             cutoff = exp(expfactor * (reference ** index_2 - energy ** index_2))
@@ -1173,7 +1173,7 @@ class LogParabola(SpectralModel):
         try:
             xx = (energy / reference).to("")
             exponent = -alpha - beta * np.log(xx)
-        except AttributeError:
+        except (AttributeError, TypeError):
             from uncertainties.unumpy import log
 
             xx = energy / reference

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -265,7 +265,7 @@ except ImportError:
 
 @requires_dependency("uncertainties")
 @requires_dependency("scipy")
-@pytest.mark.parametrize("spectrum", TEST_MODELS, ids=[_["name"] for _ in TEST_MODELS])
+@pytest.mark.parametrize("spectrum", TEST_MODELS, ids=lambda _: _["name"])
 def test_models(spectrum):
     model = spectrum["model"]
     energy = 2 * u.TeV
@@ -455,7 +455,7 @@ class TestNaimaModel:
     e_array = [2, 10, 20] * u.TeV
     e_array = e_array[:, np.newaxis, np.newaxis]
 
-    def test_pion_decay_(self):
+    def test_pion_decay(self):
         import naima
 
         particle_distribution = naima.models.PowerLaw(


### PR DESCRIPTION
This PR drops Python 3.5 testing in continuous integration, changing the relevant builds to Python 3.6.

This should resolve this error which appeared with the recently released Numpy 1.17 in combination with old Astropy versions:
https://travis-ci.org/gammapy/gammapy/jobs/566755815#L2804

conda-forge stopped building on Python 3.5 a while ago, so the alternatives to this change would be to pin to older Numpy, or xfail this test for the relevant versions.

But since we plan to propose to drop Python 3.5 soon anyways (see #2218), this change is the simplest solution for now. I note that I'm not pre-deciding on that PIG, if it turns out that we do want to support Python 3.5 in the coming weeks, we can adjust our CI and do that before the v0.14 release. Code clean-up to use Python 3.6 features should not happen now, only once #2218 is decided.