### PR TITLE
Hide progress bar in `gammapy download`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
     - if $FETCH_GAMMAPY_DATA; then
           export GAMMAPY_DATA=${HOME}/gammapy-data;
           pip install .;
-          gammapy download datasets --out=$GAMMAPY_DATA;
+          gammapy download datasets --out=$GAMMAPY_DATA --silent;
       fi
 
     - if [[ $SETUP_CMD == 'test-cov' ]]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Install Gammapy'
 
   - script: |
-      gammapy download datasets --out=$(GAMMAPY_DATA)
+      gammapy download datasets --out=$(GAMMAPY_DATA) --silent
     displayName: 'Get GAMMAPY_DATA'
 
   - script: |
@@ -115,7 +115,7 @@ jobs:
 
   - script: |
       source activate gammapy-dev
-      gammapy download datasets --out=$(GAMMAPY_DATA)
+      gammapy download datasets --out=$(GAMMAPY_DATA) --silent
     displayName: 'Get GAMMAPY_DATA'
 
   - script: |

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -17,13 +17,14 @@ log = logging.getLogger(__name__)
 )
 @click.option("--release", default="", help="Number of release - ex: 0.12)")
 @click.option("--modetutorials", default=False, hidden=True)
-def cli_download_notebooks(src, out, release, modetutorials):
+@click.option("--silent", default=True, is_flag=True, hidden=True)
+def cli_download_notebooks(src, out, release, modetutorials, silent):
     """Download notebooks"""
     plan = ComputePlan(src, out, release, "notebooks")
     if release:
         plan.getenvironment()
     down = ParallelDownload(
-        plan.getfilelist(), plan.getlocalfolder(), release, "notebooks", modetutorials
+        plan.getfilelist(), plan.getlocalfolder(), release, "notebooks", modetutorials, silent
     )
     down.run()
     print("")
@@ -39,13 +40,14 @@ def cli_download_notebooks(src, out, release, modetutorials):
 )
 @click.option("--release", default="", help="Number of release - ex: 0.12")
 @click.option("--modetutorials", default=False, hidden=True)
-def cli_download_scripts(src, out, release, modetutorials):
+@click.option("--silent", default=True, is_flag=True, hidden=False)
+def cli_download_scripts(src, out, release, modetutorials, silent):
     """Download scripts"""
     plan = ComputePlan(src, out, release, "scripts")
     if release:
         plan.getenvironment()
     down = ParallelDownload(
-        plan.getfilelist(), plan.getlocalfolder(), release, "scripts", modetutorials
+        plan.getfilelist(), plan.getlocalfolder(), release, "scripts", modetutorials, silent
     )
     down.run()
     print("")
@@ -61,11 +63,12 @@ def cli_download_scripts(src, out, release, modetutorials):
     show_default=True,
 )
 @click.option("--modetutorials", default=False, hidden=True)
-def cli_download_datasets(src, out, release, modetutorials):
+@click.option("--silent", default=True, is_flag=True, hidden=True)
+def cli_download_datasets(src, out, release, modetutorials, silent):
     """Download datasets"""
     plan = ComputePlan(src, out, release, "datasets", modetutorials=modetutorials)
     down = ParallelDownload(
-        plan.getfilelist(), plan.getlocalfolder(), release, "datasets", modetutorials
+        plan.getfilelist(), plan.getlocalfolder(), release, "datasets", modetutorials, silent
     )
     down.run()
     down.show_info_datasets()
@@ -82,7 +85,8 @@ def cli_download_datasets(src, out, release, modetutorials):
 )
 @click.option("--release", default="", help="Number of release - ex: 0.12")
 @click.option("--modetutorials", default=True, hidden=True)
-def cli_download_tutorials(ctx, src, out, release, modetutorials):
+@click.option("--silent", default=True, is_flag=True, hidden=True)
+def cli_download_tutorials(ctx, src, out, release, modetutorials, silent):
     """Download notebooks, scripts and datasets"""
     ctx.forward(cli_download_notebooks)
     ctx.forward(cli_download_scripts)

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -63,7 +63,7 @@ class ComputePlan:
         except ImportError:
             log.error("The parfive package needs to be installed to download files with gammapy download")
             return
-        dl = Downloader()
+        dl = Downloader(progress=False)
         filename_env = "gammapy-" + self.release + "-environment.yml"
         url_file_env = BASE_URL + "/install/" + filename_env
         filepath_env = str(self.outfolder / filename_env)
@@ -200,12 +200,13 @@ class ComputePlan:
 class ParallelDownload:
     """Manages the process of downloading files"""
 
-    def __init__(self, listfiles, outfolder, release, option, modetutorials):
+    def __init__(self, listfiles, outfolder, release, option, modetutorials, progress):
         self.listfiles = listfiles
         self.outfolder = outfolder
         self.release = release
         self.option = option
         self.modetutorials = modetutorials
+        self.progress = progress
         self.bar = 0
 
     def run(self):
@@ -218,7 +219,7 @@ class ParallelDownload:
         if self.listfiles:
             log.info("Content will be downloaded in {}".format(self.outfolder))
 
-        dl = Downloader()
+        dl = Downloader(progress=self.progress)
         for rec in self.listfiles:
             url = self.listfiles[rec]["url"]
             path = self.outfolder / self.listfiles[rec]["path"]


### PR DESCRIPTION
This PR adds option `--silent` in `gammapy download` to not show the progress bar.
It also adds this new option to `gammapy download` commands in CI config files for Travis and Azure.

```
$ gammapy download datasets --silent
INFO:gammapy.scripts.downloadclasses:Looking for datasets...
INFO:gammapy.scripts.downloadclasses:Reading https://raw.githubusercontent.com/gammapy/gammapy/master/dev/datasets/gammapy-data-index.json
INFO:gammapy.scripts.downloadclasses:Content will be downloaded in gammapy-datasets

*** You might want to declare GAMMAPY_DATA env variable
export GAMMAPY_DATA=/Users/jer/Desktop/gammapy-datasets
```