### PR TITLE
Use absolute imports (except same-module)

### DIFF
--- a/gammapy/__init__.py
+++ b/gammapy/__init__.py
@@ -35,11 +35,11 @@ the following sub-packages (e.g. `gammapy.spectrum`):
 
 __all__ = ["__version__", "test", "song"]
 
-from pkg_resources import DistributionNotFound, get_distribution
+import pkg_resources
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
     # package is not installed
     pass
 

--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -3,8 +3,8 @@
 import abc
 import numpy as np
 import astropy.units as u
-from ...spectrum.utils import integrate_spectrum
-from ...utils.fitting import Parameter, Parameters
+from gammapy.spectrum import integrate_spectrum
+from gammapy.utils.fitting import Parameter, Parameters
 
 __all__ = [
     "DMProfile",

--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -3,9 +3,9 @@
 import numpy as np
 import astropy.units as u
 from astropy.table import Table
-from ...spectrum.models import SpectralModel, TableModel
-from ...utils.fitting import Parameter
-from ...utils.scripts import make_path
+from gammapy.spectrum.models import SpectralModel, TableModel
+from gammapy.utils.fitting import Parameter
+from gammapy.utils.scripts import make_path
 
 __all__ = ["PrimaryFlux", "DMAnnihilation"]
 

--- a/gammapy/astro/darkmatter/tests/test_profiles.py
+++ b/gammapy/astro/darkmatter/tests/test_profiles.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
-from ....utils.testing import assert_quantity_allclose
-from .. import profiles
+from gammapy.astro.darkmatter import profiles
+from gammapy.utils.testing import assert_quantity_allclose
 
 dm_profiles = [
     profiles.NFWProfile,

--- a/gammapy/astro/darkmatter/tests/test_spectra.py
+++ b/gammapy/astro/darkmatter/tests/test_spectra.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import astropy.units as u
-from ....utils.testing import assert_quantity_allclose, requires_data
-from .. import DMAnnihilation, PrimaryFlux
+from gammapy.astro.darkmatter import DMAnnihilation, PrimaryFlux
+from gammapy.utils.testing import assert_quantity_allclose, requires_data
 
 
 @requires_data()
@@ -18,7 +18,6 @@ def test_primary_flux():
 
 @requires_data()
 def test_DMAnnihilation():
-
     channel = "b"
     massDM = 5 * u.TeV
     jfactor = 3.41e19 * u.Unit("GeV2 cm-5")

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import astropy.units as u
-from ....maps import WcsGeom
-from ....utils.testing import assert_quantity_allclose, requires_data
-from .. import DMAnnihilation, JFactory, profiles
+from gammapy.astro.darkmatter import DMAnnihilation, JFactory, profiles
+from gammapy.maps import WcsGeom
+from gammapy.utils.testing import assert_quantity_allclose, requires_data
 
 
 @pytest.fixture(scope="session")
@@ -19,7 +19,6 @@ def jfact(geom):
 
 @requires_data()
 def test_dmfluxmap(jfact):
-
     emin = 0.1 * u.TeV
     emax = 10 * u.TeV
     massDM = 1 * u.TeV

--- a/gammapy/astro/population/simulate.py
+++ b/gammapy/astro/population/simulate.py
@@ -4,16 +4,16 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Column, Table
 from astropy.units import Quantity
-from ...utils import coordinates as astrometry
-from ...utils.coordinates import D_SUN_TO_GALACTIC_CENTER
-from ...utils.random import (
+from gammapy.astro.source import PWN, SNR, Pulsar, SNRTrueloveMcKee
+from gammapy.utils import coordinates as astrometry
+from gammapy.utils.random import (
     draw,
     get_random_state,
     pdf,
     sample_sphere,
     sample_sphere_distance,
 )
-from ..population.spatial import (
+from .spatial import (
     RMAX,
     RMIN,
     ZMAX,
@@ -22,8 +22,7 @@ from ..population.spatial import (
     FaucherSpiral,
     radial_distributions,
 )
-from ..population.velocity import VMAX, VMIN, velocity_distributions
-from ..source import PWN, SNR, Pulsar, SNRTrueloveMcKee
+from .velocity import VMAX, VMIN, velocity_distributions
 
 __all__ = [
     "make_catalog_random_positions_cube",
@@ -394,7 +393,7 @@ def add_observed_parameters(table, obs_pos=None):
     table : `~astropy.table.Table`
         Modified input table with columns added
     """
-    obs_pos = obs_pos or [D_SUN_TO_GALACTIC_CENTER, 0, 0]
+    obs_pos = obs_pos or [astrometry.D_SUN_TO_GALACTIC_CENTER, 0, 0]
 
     # Get data
     x, y, z = table["x"].quantity, table["y"].quantity, table["z"].quantity

--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -3,8 +3,8 @@
 import numpy as np
 from astropy.modeling import Fittable1DModel, Parameter
 from astropy.units import Quantity
-from ...utils.coordinates import D_SUN_TO_GALACTIC_CENTER, cartesian, polar
-from ...utils.random import get_random_state
+from gammapy.utils.coordinates import D_SUN_TO_GALACTIC_CENTER, cartesian, polar
+from gammapy.utils.random import get_random_state
 
 __all__ = [
     "CaseBattacharya1998",

--- a/gammapy/astro/population/tests/test_simulate.py
+++ b/gammapy/astro/population/tests/test_simulate.py
@@ -2,7 +2,7 @@
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.table import Table
-from ...population import (
+from gammapy.astro.population import (
     add_observed_parameters,
     add_pulsar_parameters,
     add_pwn_parameters,

--- a/gammapy/astro/population/tests/test_spatial.py
+++ b/gammapy/astro/population/tests/test_spatial.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
-from ..spatial import (
+from gammapy.astro.population.spatial import (
     CaseBattacharya1998,
     Exponential,
     FaucherKaspi2006,

--- a/gammapy/astro/population/tests/test_velocity.py
+++ b/gammapy/astro/population/tests/test_velocity.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
-from ..velocity import (
+from gammapy.astro.population.velocity import (
     FaucherKaspi2006VelocityBimodal,
     FaucherKaspi2006VelocityMaxwellian,
     Paczynski1990Velocity,

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -5,8 +5,8 @@ from scipy.optimize import fsolve
 import astropy.constants as const
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
-from ..source.pulsar import Pulsar
-from ..source.snr import SNRTrueloveMcKee
+from .pulsar import Pulsar
+from .snr import SNRTrueloveMcKee
 
 __all__ = ["PWN"]
 

--- a/gammapy/astro/source/pwn.py
+++ b/gammapy/astro/source/pwn.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Pulsar wind nebula (PWN) source models."""
 import numpy as np
-from scipy.optimize import fsolve
-import astropy.constants as const
+import scipy.optimize
+import astropy.constants
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
 from .pulsar import Pulsar
@@ -74,7 +74,7 @@ class PWN:
             return r_pwn - r_shock
 
         # 4e3 years is a typical value that works for fsolve
-        return Quantity(fsolve(time_coll, 4e3), "yr")
+        return Quantity(scipy.optimize.fsolve(time_coll, 4e3), "yr")
 
     def radius(self, t):
         r"""Radius of the PWN at age t.
@@ -120,4 +120,4 @@ class PWN:
         t = Quantity(t, "yr")
         energy = self.pulsar.energy_integrated(t)
         volume = 4.0 / 3 * np.pi * self.radius(t) ** 3
-        return np.sqrt(2 * const.mu0 * self.eta_B * energy / volume)
+        return np.sqrt(2 * astropy.constants.mu0 * self.eta_B * energy / volume)

--- a/gammapy/astro/source/snr.py
+++ b/gammapy/astro/source/snr.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Supernova remnant (SNR) source models."""
 import numpy as np
-import astropy.constants as const
+import astropy.constants
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
 
@@ -34,7 +34,7 @@ class SNR:
         e_sn="1e51 erg",
         theta=Quantity(0.1),
         n_ISM=Quantity(1, "cm-3"),
-        m_ejecta=const.M_sun,
+        m_ejecta=astropy.constants.M_sun,
         t_stop=Quantity(1e6, "K"),
         age=None,
         morphology="Shell2D",
@@ -42,7 +42,7 @@ class SNR:
     ):
         self.e_sn = Quantity(e_sn, "erg")
         self.theta = theta
-        self.rho_ISM = n_ISM * const.m_p
+        self.rho_ISM = n_ISM * astropy.constants.m_p
         self.n_ISM = n_ISM
         self.m_ejecta = m_ejecta
         self.t_stop = t_stop
@@ -90,7 +90,7 @@ class SNR:
         """
         # proportional constant for the free expansion phase
         term_1 = (self.e_sn / Quantity(1e51, "erg")) ** (1.0 / 2)
-        term_2 = (self.m_ejecta / const.M_sun) ** (-1.0 / 2)
+        term_2 = (self.m_ejecta / astropy.constants.M_sun) ** (-1.0 / 2)
         return Quantity(0.01, "pc/yr") * term_1 * term_2 * t
 
     def _radius_sedov_taylor(self, t):
@@ -143,7 +143,7 @@ class SNR:
         # Flux in 1 k distance according to Drury formula 9
         term_0 = energy_min / Quantity(1, "TeV")
         term_1 = self.e_sn / Quantity(1e51, "erg")
-        term_2 = self.rho_ISM / (Quantity(1, "cm-3") * const.m_p)
+        term_2 = self.rho_ISM / (Quantity(1, "cm-3") * astropy.constants.m_p)
         L = self.theta * term_0 ** (1 - self.spectral_index) * term_1 * term_2
 
         # Corresponding luminosity
@@ -170,8 +170,10 @@ class SNR:
             \text{yr}
         """
         term1 = (self.e_sn / Quantity(1e51, "erg")) ** (-1.0 / 2)
-        term2 = (self.m_ejecta / const.M_sun) ** (5.0 / 6)
-        term3 = (self.rho_ISM / (Quantity(1, "cm-3") * const.m_p)) ** (-1.0 / 3)
+        term2 = (self.m_ejecta / astropy.constants.M_sun) ** (5.0 / 6)
+        term3 = (self.rho_ISM / (Quantity(1, "cm-3") * astropy.constants.m_p)) ** (
+            -1.0 / 3
+        )
         return Quantity(200, "yr") * term1 * term2 * term3
 
     @lazyproperty
@@ -190,7 +192,11 @@ class SNR:
             \left(\frac{\rho_{ISM}}{1.66\cdot 10^{-24}g/cm^3}\right)^{-1/3}
             \text{yr}
         """
-        term1 = 3 * const.m_p.cgs / (100 * const.k_B.cgs * self.t_stop)
+        term1 = (
+            3
+            * astropy.constants.m_p.cgs
+            / (100 * astropy.constants.k_B.cgs * self.t_stop)
+        )
         term2 = (self.e_sn / self.rho_ISM) ** (2.0 / 5)
         return ((term1 * term2) ** (5.0 / 6)).to("yr")
 

--- a/gammapy/astro/source/tests/test_pulsar.py
+++ b/gammapy/astro/source/tests/test_pulsar.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import scipy.integrate
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from astropy.units import Quantity
@@ -63,14 +64,13 @@ def test_Pulsar_luminosity_spindown():
 def test_Pulsar_energy_integrated():
     """Test against numerical integration"""
     energies = []
-    from scipy.integrate import quad
 
     def lumi(t):
         t = Quantity(t, "s")
         return pulsar.luminosity_spindown(t).value
 
     for t_ in time:
-        energy = quad(lumi, 0, t_.cgs.value, epsrel=0.01)[0]
+        energy = scipy.integrate.quad(lumi, 0, t_.cgs.value, epsrel=0.01)[0]
         energies.append(energy)
     # The last value is quite inaccurate, because integration is over several decades
     assert_allclose(energies, pulsar.energy_integrated(time).value, rtol=0.2)

--- a/gammapy/astro/source/tests/test_pulsar.py
+++ b/gammapy/astro/source/tests/test_pulsar.py
@@ -2,8 +2,8 @@
 from numpy.testing import assert_allclose
 from astropy.table import Table
 from astropy.units import Quantity
-from ....utils.testing import assert_quantity_allclose
-from ...source import Pulsar, SimplePulsar
+from gammapy.astro.source import Pulsar, SimplePulsar
+from gammapy.utils.testing import assert_quantity_allclose
 
 pulsar = Pulsar()
 time = Quantity([1e2, 1e4, 1e6, 1e8], "yr")

--- a/gammapy/astro/source/tests/test_pwn.py
+++ b/gammapy/astro/source/tests/test_pwn.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
-from ...source import PWN
+from gammapy.astro.source import PWN
 
 t = Quantity([0, 1, 10, 100, 1000, 10000, 100000], "yr")
 pwn = PWN()

--- a/gammapy/astro/source/tests/test_snr.py
+++ b/gammapy/astro/source/tests/test_snr.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
-from ...source import SNR, SNRTrueloveMcKee
+from gammapy.astro.source import SNR, SNRTrueloveMcKee
 
 t = Quantity([0, 1, 10, 100, 1000, 10000], "yr")
 snr = SNR()

--- a/gammapy/background/phase.py
+++ b/gammapy/background/phase.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from ..data import EventList
+from gammapy.data import EventList
 from .background_estimate import BackgroundEstimate
 
 __all__ = ["PhaseBackgroundEstimator"]

--- a/gammapy/background/reflected.py
+++ b/gammapy/background/reflected.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from regions import PixCoord
-from ..maps import Map, WcsGeom, WcsNDMap
+from gammapy.maps import Map, WcsGeom, WcsNDMap
 from .background_estimate import BackgroundEstimate
 
 __all__ = ["ReflectedRegionsFinder", "ReflectedRegionsBackgroundEstimator"]

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -4,7 +4,7 @@ from itertools import product
 import numpy as np
 from astropy.convolution import Ring2DKernel, Tophat2DKernel
 from astropy.coordinates import Angle
-from ..image.utils import scale_cube
+from gammapy.image.utils import scale_cube
 
 __all__ = ["AdaptiveRingBackgroundEstimator", "RingBackgroundEstimator"]
 

--- a/gammapy/background/ring.py
+++ b/gammapy/background/ring.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Ring background estimation."""
-from itertools import product
+import itertools
 import numpy as np
 from astropy.convolution import Ring2DKernel, Tophat2DKernel
 from astropy.coordinates import Angle
@@ -122,7 +122,7 @@ class AdaptiveRingBackgroundEstimator:
             raise ValueError("Invalid method: {}".format(p["method"]))
 
         kernels = []
-        for r_in, width in product(r_ins, widths):
+        for r_in, width in itertools.product(r_ins, widths):
             kernel = Ring2DKernel(r_in, width)
             kernel.normalize("peak")
             kernels.append(kernel)

--- a/gammapy/background/tests/test_phase.py
+++ b/gammapy/background/tests/test_phase.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from astropy.coordinates import Angle, SkyCoord
-from ...data import DataStore, EventList
-from ...utils.regions import SphericalCircleSkyRegion
-from ...utils.testing import requires_data
-from .. import BackgroundEstimate, PhaseBackgroundEstimator
+from gammapy.background import BackgroundEstimate, PhaseBackgroundEstimator
+from gammapy.data import DataStore, EventList
+from gammapy.utils.regions import SphericalCircleSkyRegion
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/background/tests/test_reflected.py
+++ b/gammapy/background/tests/test_reflected.py
@@ -8,15 +8,18 @@ from regions import (
     EllipseSkyRegion,
     RectangleSkyRegion,
 )
-from ...data import DataStore
-from ...maps import WcsGeom, WcsNDMap
-from ...utils.testing import (
+from gammapy.background import (
+    ReflectedRegionsBackgroundEstimator,
+    ReflectedRegionsFinder,
+)
+from gammapy.data import DataStore
+from gammapy.maps import WcsGeom, WcsNDMap
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
     requires_data,
     requires_dependency,
 )
-from ..reflected import ReflectedRegionsBackgroundEstimator, ReflectedRegionsFinder
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/background/tests/test_ring.py
+++ b/gammapy/background/tests/test_ring.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
-from ...background import AdaptiveRingBackgroundEstimator, RingBackgroundEstimator
-from ...maps import WcsNDMap
+from gammapy.background import AdaptiveRingBackgroundEstimator, RingBackgroundEstimator
+from gammapy.maps import WcsNDMap
 
 
 @pytest.fixture

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -5,8 +5,8 @@ from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
-from ..utils.array import _is_int
-from ..utils.table import table_from_row_data, table_row_to_dict
+from gammapy.utils.array import _is_int
+from gammapy.utils.table import table_from_row_data, table_row_to_dict
 
 __all__ = ["SourceCatalog", "SourceCatalogObject"]
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -5,11 +5,11 @@ import numpy as np
 import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
-from ..cube.models import SkyModel
-from ..image.models import SkyDiffuseMap, SkyDisk, SkyGaussian, SkyPointSource
-from ..maps import Map
-from ..spectrum import FluxPoints
-from ..spectrum.models import (
+from gammapy.cube.models import SkyModel
+from gammapy.image.models import SkyDiffuseMap, SkyDisk, SkyGaussian, SkyPointSource
+from gammapy.maps import Map
+from gammapy.spectrum import FluxPoints
+from gammapy.spectrum.models import (
     ExponentialCutoffPowerLaw3FGL,
     LogParabola,
     PLSuperExpCutoff3FGL,
@@ -17,9 +17,9 @@ from ..spectrum.models import (
     PowerLaw,
     PowerLaw2,
 )
-from ..time import LightCurve
-from ..utils.scripts import make_path
-from ..utils.table import table_standardise_units_inplace
+from gammapy.time import LightCurve
+from gammapy.utils.scripts import make_path
+from gammapy.utils.table import table_standardise_units_inplace
 from .core import SourceCatalog, SourceCatalogObject
 
 __all__ = [

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -3,10 +3,11 @@
 
 https://github.com/gammapy/gamma-cat
 """
+import collections
 import functools
 import json
 import logging
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
@@ -580,7 +581,7 @@ class GammaCatResource:
     def to_namedtuple(self):
         """Convert to `collections.namedtuple`."""
         d = self.to_dict()
-        return namedtuple("GammaCatResourceNamedTuple", d.keys())(**d)
+        return collections.namedtuple("GammaCatResourceNamedTuple", d.keys())(**d)
 
     def to_dict(self):
         """Convert to `collections.OrderedDict`."""

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -10,11 +10,11 @@ from collections import OrderedDict, namedtuple
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
-from ..cube.models import SkyModel, SkyModels
-from ..image.models import SkyGaussian, SkyPointSource, SkyShell
-from ..spectrum import FluxPoints
-from ..spectrum.models import ExponentialCutoffPowerLaw, PowerLaw, PowerLaw2
-from ..utils.scripts import make_path
+from gammapy.cube.models import SkyModel, SkyModels
+from gammapy.image.models import SkyGaussian, SkyPointSource, SkyShell
+from gammapy.spectrum import FluxPoints
+from gammapy.spectrum.models import ExponentialCutoffPowerLaw, PowerLaw, PowerLaw2
+from gammapy.utils.scripts import make_path
 from .core import SourceCatalog, SourceCatalogObject
 
 __all__ = [

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -2,8 +2,8 @@
 """HAWC catalogs (https://www.hawc-observatory.org)."""
 import numpy as np
 from astropy.table import Table
-from ..spectrum.models import PowerLaw
-from ..utils.scripts import make_path
+from gammapy.spectrum.models import PowerLaw
+from gammapy.utils.scripts import make_path
 from .core import SourceCatalog, SourceCatalogObject
 
 __all__ = ["SourceCatalog2HWC", "SourceCatalogObject2HWC"]

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -6,13 +6,13 @@ import astropy.units as u
 from astropy.coordinates import Angle
 from astropy.modeling.models import Gaussian1D
 from astropy.table import Table
-from ..cube.models import SkyModel, SkyModels
-from ..image.models import SkyGaussian, SkyPointSource, SkyShell
-from ..spectrum import FluxPoints
-from ..spectrum.models import ExponentialCutoffPowerLaw, PowerLaw
-from ..utils.interpolation import ScaledRegularGridInterpolator
-from ..utils.scripts import make_path
-from ..utils.table import table_row_to_dict
+from gammapy.cube.models import SkyModel, SkyModels
+from gammapy.image.models import SkyGaussian, SkyPointSource, SkyShell
+from gammapy.spectrum import FluxPoints
+from gammapy.spectrum.models import ExponentialCutoffPowerLaw, PowerLaw
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+from gammapy.utils.scripts import make_path
+from gammapy.utils.table import table_row_to_dict
 from .core import SourceCatalog, SourceCatalogObject
 
 __all__ = [

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -5,8 +5,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Column, Table
 from astropy.units import Quantity
-from ...utils.testing import assert_quantity_allclose
-from ..core import SourceCatalog
+from gammapy.catalog import SourceCatalog
+from gammapy.utils.testing import assert_quantity_allclose
 
 
 def make_test_catalog():

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -4,25 +4,25 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.time import Time
-from ...spectrum.models import (
+from gammapy.catalog import (
+    SourceCatalog1FHL,
+    SourceCatalog2FHL,
+    SourceCatalog3FGL,
+    SourceCatalog3FHL,
+    SourceCatalog4FGL,
+)
+from gammapy.spectrum.models import (
     ExponentialCutoffPowerLaw3FGL,
     LogParabola,
     PLSuperExpCutoff3FGL,
     PLSuperExpCutoff4FGL,
     PowerLaw,
 )
-from ...utils.testing import (
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     assert_time_allclose,
     requires_data,
     requires_dependency,
-)
-from .. import (
-    SourceCatalog1FHL,
-    SourceCatalog2FHL,
-    SourceCatalog3FGL,
-    SourceCatalog3FHL,
-    SourceCatalog4FGL,
 )
 
 SOURCES_4FGL = [

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -3,12 +3,16 @@ from collections import OrderedDict
 import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
-from ...utils.testing import (
+from gammapy.catalog import (
+    GammaCatResource,
+    GammaCatResourceIndex,
+    SourceCatalogGammaCat,
+)
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     requires_data,
     requires_dependency,
 )
-from ..gammacat import GammaCatResource, GammaCatResourceIndex, SourceCatalogGammaCat
 
 SOURCES = [
     {

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -2,8 +2,8 @@
 import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...utils.testing import requires_data, requires_dependency
-from ..hawc import SourceCatalog2HWC
+from gammapy.catalog import SourceCatalog2HWC
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -6,13 +6,13 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.table import Table
-from ...spectrum.models import ExponentialCutoffPowerLaw, PowerLaw
-from ...utils.testing import (
+from gammapy.catalog import SourceCatalogHGPS, SourceCatalogLargeScaleHGPS
+from gammapy.spectrum.models import ExponentialCutoffPowerLaw, PowerLaw
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     requires_data,
     requires_dependency,
 )
-from ..hess import SourceCatalogHGPS, SourceCatalogLargeScaleHGPS
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import Counter
+import collections
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -123,7 +123,7 @@ class TestSourceCatalogObjectHGPS:
 
     @staticmethod
     def test_spectral_model_type(cat):
-        spec_types = Counter([_.spectral_model_type for _ in cat])
+        spec_types = collections.Counter([_.spectral_model_type for _ in cat])
         assert spec_types == {"pl": 66, "ecpl": 12}
 
     @staticmethod
@@ -175,7 +175,7 @@ class TestSourceCatalogObjectHGPS:
 
     @staticmethod
     def test_spatial_model_type(cat):
-        morph_types = Counter([_.spatial_model_type for _ in cat])
+        morph_types = collections.Counter([_.spatial_model_type for _ in cat])
         assert morph_types == {
             "gaussian": 52,
             "2-gaussian": 8,

--- a/gammapy/catalog/tests/test_registry.py
+++ b/gammapy/catalog/tests/test_registry.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
-from ...utils.testing import requires_data
-from ..gammacat import SourceCatalogGammaCat
-from ..registry import SourceCatalogRegistry
+from gammapy.catalog import SourceCatalogGammaCat, SourceCatalogRegistry
+from gammapy.utils.testing import requires_data
 from .test_core import make_test_catalog
 
 

--- a/gammapy/catalog/tests/test_snrcat.py
+++ b/gammapy/catalog/tests/test_snrcat.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
-from ..snrcat import SourceCatalogSNRcat
+from gammapy.catalog import SourceCatalogSNRcat
 
 
 @pytest.mark.skip(reason="see https://github.com/gammapy/gammapy/issues/2162")

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -3,10 +3,10 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 import os
+import astropy.version
 from astropy.tests.helper import enable_deprecations_as_exceptions
-from astropy.version import version as astropy_version
 
-if astropy_version < "3.0":
+if astropy.version.version < "3.0":
     # With older versions of Astropy, we actually need to import the pytest
     # plugins themselves in order to make them discoverable by pytest.
     from astropy.tests.pytest_plugins import *

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -37,7 +37,7 @@ PYTEST_HEADER_MODULES["reproject"] = "reproject"
 
 def pytest_configure(config):
     """Print some info ..."""
-    from .utils.testing import has_data
+    from gammapy.utils.testing import has_data
 
     print("")
     print("Gammapy test data availability:")

--- a/gammapy/cube/background.py
+++ b/gammapy/cube/background.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from astropy.coordinates import SkyOffsetFrame
-from ..data import FixedPointingInfo
-from ..maps import WcsNDMap
-from ..utils.coordinates import sky_to_fov
+from gammapy.data import FixedPointingInfo
+from gammapy.maps import WcsNDMap
+from gammapy.utils.coordinates import sky_to_fov
 
 __all__ = ["make_map_background_irf"]
 

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -2,8 +2,8 @@
 import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
-from ..irf import EnergyDispersion
-from ..maps import Map
+from gammapy.irf import EnergyDispersion
+from gammapy.maps import Map
 
 __all__ = ["make_edisp_map", "EDispMap"]
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from ..maps import WcsNDMap
-from ..spectrum.models import PowerLaw
+from gammapy.maps import WcsNDMap
+from gammapy.spectrum.models import PowerLaw
 
 __all__ = ["make_map_exposure_true_energy"]
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -5,14 +5,14 @@ import astropy.units as u
 from astropy.io import fits
 from astropy.nddata.utils import NoOverlapError
 from astropy.utils import lazyproperty
-from ..irf import EnergyDispersion
-from ..maps import Map
-from ..stats import cash, cash_sum_cython, cstat, cstat_sum_cython
-from ..utils.fitting import Dataset, Parameters
-from ..utils.random import get_random_state
-from ..utils.scripts import make_path
-from .models import BackgroundModel, SkyModel, SkyModels
-from .psf_kernel import PSFKernel
+from gammapy.cube.models import BackgroundModel, SkyModel, SkyModels
+from gammapy.cube.psf_kernel import PSFKernel
+from gammapy.irf import EnergyDispersion
+from gammapy.maps import Map
+from gammapy.stats import cash, cash_sum_cython, cstat, cstat_sum_cython
+from gammapy.utils.fitting import Dataset, Parameters
+from gammapy.utils.random import get_random_state
+from gammapy.utils.scripts import make_path
 
 __all__ = ["MapEvaluator", "MapDataset"]
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -3,7 +3,7 @@ import logging
 from astropy.coordinates import Angle
 from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.utils import lazyproperty
-from ..maps import Map, WcsGeom
+from gammapy.maps import Map, WcsGeom
 from .background import make_map_background_irf
 from .counts import fill_map_counts
 from .exposure import _map_spectrum_weight, make_map_exposure_true_energy

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -3,11 +3,11 @@ import copy
 from pathlib import Path
 import numpy as np
 import astropy.units as u
-from ..image.models import SkySpatialModel
-from ..maps import Map
-from ..spectrum.models import SpectralModel
-from ..utils.fitting import Model, Parameter, Parameters
-from ..utils.scripts import make_path, write_yaml
+from gammapy.image.models import SkySpatialModel
+from gammapy.maps import Map
+from gammapy.spectrum.models import SpectralModel
+from gammapy.utils.fitting import Model, Parameter, Parameters
+from gammapy.utils.scripts import make_path, write_yaml
 
 __all__ = [
     "SkyModelBase",

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -3,10 +3,10 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import Angle
 from astropy.coordinates.angle_utilities import angular_separation
-from ..irf import TablePSF
-from ..maps import Map, WcsGeom
-from ..spectrum.models import PowerLaw
-from ..utils.gauss import Gauss2DPDF
+from gammapy.irf import TablePSF
+from gammapy.maps import Map, WcsGeom
+from gammapy.spectrum.models import PowerLaw
+from gammapy.utils.gauss import Gauss2DPDF
 
 __all__ = ["PSFKernel"]
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -3,9 +3,9 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from astropy.coordinates import Angle
-from ..cube import PSFKernel
-from ..irf import EnergyDependentTablePSF
-from ..maps import Map
+from gammapy.cube import PSFKernel
+from gammapy.irf import EnergyDependentTablePSF
+from gammapy.maps import Map
 
 __all__ = ["make_psf_map", "PSFMap"]
 

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -1,15 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Simulate observations"""
 import astropy.units as u
-from ..cube import (
+from gammapy.cube import (
     MapDataset,
     PSFKernel,
     make_map_background_irf,
     make_map_exposure_true_energy,
 )
-from ..cube.models import BackgroundModel
-from ..maps import WcsNDMap
-from ..utils.random import get_random_state
+from gammapy.cube.models import BackgroundModel
+from gammapy.maps import WcsNDMap
+from gammapy.utils.random import get_random_state
 
 __all__ = ["simulate_dataset"]
 

--- a/gammapy/cube/tests/test_background.py
+++ b/gammapy/cube/tests/test_background.py
@@ -5,11 +5,11 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.time import Time
-from ...data.pointing import FixedPointingInfo
-from ...irf import Background3D
-from ...maps import HpxGeom, MapAxis, WcsGeom
-from ...utils.testing import requires_data
-from ..background import make_map_background_irf
+from gammapy.cube import make_map_background_irf
+from gammapy.data import FixedPointingInfo
+from gammapy.irf import Background3D
+from gammapy.maps import HpxGeom, MapAxis, WcsGeom
+from gammapy.utils.testing import requires_data
 
 pytest.importorskip("healpy")
 

--- a/gammapy/cube/tests/test_counts.py
+++ b/gammapy/cube/tests/test_counts.py
@@ -4,10 +4,10 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table
-from ...data import EventList
-from ...maps import HpxGeom, Map, MapAxis, WcsNDMap
-from ...utils.testing import requires_dependency
-from ..counts import fill_map_counts
+from gammapy.cube import fill_map_counts
+from gammapy.data import EventList
+from gammapy.maps import HpxGeom, Map, MapAxis, WcsNDMap
+from gammapy.utils.testing import requires_dependency
 
 
 @pytest.fixture()

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -4,9 +4,9 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
-from ...cube import EDispMap, make_edisp_map, make_map_exposure_true_energy
-from ...irf import EffectiveAreaTable2D, EnergyDispersion2D
-from ...maps import MapAxis, WcsGeom
+from gammapy.cube import EDispMap, make_edisp_map, make_map_exposure_true_energy
+from gammapy.irf import EffectiveAreaTable2D, EnergyDispersion2D
+from gammapy.maps import MapAxis, WcsGeom
 
 
 def fake_aeff2d(area=1e6 * u.m ** 2):

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -2,11 +2,11 @@
 import pytest
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
-from ...irf import EffectiveAreaTable2D
-from ...maps import HpxGeom, MapAxis, WcsGeom, WcsNDMap
-from ...spectrum.models import ConstantModel
-from ...utils.testing import requires_data
-from ..exposure import _map_spectrum_weight, make_map_exposure_true_energy
+from gammapy.cube.exposure import _map_spectrum_weight, make_map_exposure_true_energy
+from gammapy.irf import EffectiveAreaTable2D
+from gammapy.maps import HpxGeom, MapAxis, WcsGeom, WcsNDMap
+from gammapy.spectrum.models import ConstantModel
+from gammapy.utils.testing import requires_data
 
 pytest.importorskip("healpy")
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -5,15 +5,18 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from ...image.models import SkyGaussian
-from ...irf import EffectiveAreaTable2D, EnergyDependentMultiGaussPSF
-from ...irf.energy_dispersion import EnergyDispersion
-from ...maps import Map, MapAxis, WcsGeom
-from ...spectrum.models import PowerLaw
-from ...utils.fitting import Fit
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
-from .. import MapDataset, PSFKernel, make_map_exposure_true_energy
-from ..models import BackgroundModel, SkyModel
+from gammapy.cube import MapDataset, PSFKernel, make_map_exposure_true_energy
+from gammapy.cube.models import BackgroundModel, SkyModel
+from gammapy.image.models import SkyGaussian
+from gammapy.irf import (
+    EffectiveAreaTable2D,
+    EnergyDependentMultiGaussPSF,
+    EnergyDispersion,
+)
+from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.spectrum.models import PowerLaw
+from gammapy.utils.fitting import Fit
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 @pytest.fixture

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -5,11 +5,11 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from ...background import RingBackgroundEstimator
-from ...data import DataStore
-from ...maps import Map, MapAxis, WcsGeom
-from ...utils.testing import requires_data
-from ..make import MapMaker, MapMakerRing
+from gammapy.background import RingBackgroundEstimator
+from gammapy.cube import MapMaker, MapMakerRing
+from gammapy.data import DataStore
+from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/cube/tests/test_models.py
+++ b/gammapy/cube/tests/test_models.py
@@ -3,15 +3,19 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...cube.models import BackgroundModel, BackgroundModels, SkyDiffuseCube
-from ...cube.psf_kernel import PSFKernel
-from ...image.models import SkyGaussian
-from ...irf.energy_dispersion import EnergyDispersion
-from ...maps import Map, MapAxis, WcsGeom
-from ...spectrum.models import PowerLaw
-from ...utils.testing import requires_data
-from ..fit import MapEvaluator
-from ..models import SkyModel, SkyModels
+from gammapy.cube import MapEvaluator, PSFKernel
+from gammapy.cube.models import (
+    BackgroundModel,
+    BackgroundModels,
+    SkyDiffuseCube,
+    SkyModel,
+    SkyModels,
+)
+from gammapy.image.models import SkyGaussian
+from gammapy.irf import EnergyDispersion
+from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.spectrum.models import PowerLaw
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -3,9 +3,9 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle
-from ...irf import TablePSF
-from ...maps import MapAxis, WcsGeom
-from .. import PSFKernel
+from gammapy.cube import PSFKernel
+from gammapy.irf import TablePSF
+from gammapy.maps import MapAxis, WcsGeom
 
 
 def test_table_psf_to_kernel_map():

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -4,9 +4,9 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
-from ...cube import PSFMap, make_map_exposure_true_energy, make_psf_map
-from ...irf import PSF3D, EffectiveAreaTable2D
-from ...maps import MapAxis, WcsGeom
+from gammapy.cube import PSFMap, make_map_exposure_true_energy, make_psf_map
+from gammapy.irf import PSF3D, EffectiveAreaTable2D
+from gammapy.maps import MapAxis, WcsGeom
 
 
 def fake_psf3d(sigma=0.15 * u.deg, shape="gauss"):

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -3,14 +3,13 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from ...cube import MapDataset
-from ...cube.models import SkyModel, SkyModels
-from ...image.models import SkyGaussian
-from ...irf import load_cta_irfs
-from ...maps import MapAxis, WcsGeom
-from ...spectrum.models import PowerLaw
-from ...utils.testing import requires_data
-from ..simulate import simulate_dataset
+from gammapy.cube import MapDataset, simulate_dataset
+from gammapy.cube.models import SkyModel, SkyModels
+from gammapy.image.models import SkyGaussian
+from gammapy.irf import load_cta_irfs
+from gammapy.maps import MapAxis, WcsGeom
+from gammapy.spectrum.models import PowerLaw
+from gammapy.utils.testing import requires_data
 
 
 @requires_data()

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -4,8 +4,8 @@ import subprocess
 from pathlib import Path
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from ..utils.scripts import make_path
-from ..utils.testing import Checker
+from gammapy.utils.scripts import make_path
+from gammapy.utils.testing import Checker
 from .hdu_index_table import HDUIndexTable
 from .obs_table import ObservationTable, ObservationTableChecker
 from .observations import DataStoreObservation, ObservationChecker, Observations

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -7,12 +7,12 @@ from astropy.coordinates.angle_utilities import angular_separation
 from astropy.table import Table
 from astropy.table import vstack as vstack_tables
 from astropy.units import Quantity, Unit
-from ..utils.energy import energy_logspace
-from ..utils.fits import earth_location_from_dict
-from ..utils.regions import make_region
-from ..utils.scripts import make_path
-from ..utils.testing import Checker
-from ..utils.time import time_ref_from_dict
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.fits import earth_location_from_dict
+from gammapy.utils.regions import make_region
+from gammapy.utils.scripts import make_path
+from gammapy.utils.testing import Checker
+from gammapy.utils.time import time_ref_from_dict
 
 __all__ = ["EventListBase", "EventList", "EventListLAT"]
 

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import collections
 import logging
-from collections import namedtuple
 import numpy as np
 from astropy.coordinates import AltAz, Angle, SkyCoord
 from astropy.coordinates.angle_utilities import angular_separation
@@ -763,7 +763,7 @@ class EventListChecker(Checker):
         "ALTITUDE",
     ]
 
-    _col = namedtuple("col", ["name", "unit"])
+    _col = collections.namedtuple("col", ["name", "unit"])
     columns_required = [
         _col(name="EVENT_ID", unit=""),
         _col(name="TIME", unit="s"),

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -2,8 +2,8 @@
 import numpy as np
 from astropy.table import Table, vstack
 from astropy.units import Quantity
-from ..utils.scripts import make_path
-from ..utils.time import time_ref_from_dict, time_relative_to_ref
+from gammapy.utils.scripts import make_path
+from gammapy.utils.time import time_ref_from_dict, time_relative_to_ref
 
 __all__ = ["GTI"]
 

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils import lazyproperty
-from ..utils.scripts import make_path
+from gammapy.utils.scripts import make_path
 
 __all__ = ["HDULocation", "HDUIndexTable"]
 

--- a/gammapy/data/obs_stats.py
+++ b/gammapy/data/obs_stats.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import astropy.units as u
-from ..stats import Stats, significance_on_off
+from gammapy.stats import Stats, significance_on_off
 
 __all__ = ["ObservationStats"]
 

--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -6,10 +6,10 @@ from astropy.table import Table
 from astropy.time import Time
 from astropy.units import Quantity, Unit
 from astropy.utils import lazyproperty
-from ..utils.regions import SphericalCircleSkyRegion
-from ..utils.scripts import make_path
-from ..utils.testing import Checker
-from ..utils.time import time_relative_to_ref
+from gammapy.utils.regions import SphericalCircleSkyRegion
+from gammapy.utils.scripts import make_path
+from gammapy.utils.testing import Checker
+from gammapy.utils.time import time_relative_to_ref
 from .gti import GTI
 
 __all__ = ["ObservationTable"]

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -5,10 +5,10 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
-from ..utils.fits import earth_location_from_dict
-from ..utils.table import table_row_to_dict
-from ..utils.testing import Checker
-from ..utils.time import time_ref_from_dict
+from gammapy.utils.fits import earth_location_from_dict
+from gammapy.utils.table import table_row_to_dict
+from gammapy.utils.testing import Checker
+from gammapy.utils.time import time_ref_from_dict
 from .event_list import EventListChecker
 from .filters import ObservationFilter
 from .pointing import FixedPointingInfo

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from scipy.interpolate import interp1d
+import scipy.interpolate
 from astropy.coordinates import AltAz, CartesianRepresentation, SkyCoord
 from astropy.table import Table
 from astropy.units import Quantity
@@ -227,9 +227,9 @@ class PointingInfo:
         t_new = time.mjd
         t = self.time.mjd
         xyz = self.altaz.cartesian
-        x_new = interp1d(t, xyz.x)(t_new)
-        y_new = interp1d(t, xyz.y)(t_new)
-        z_new = interp1d(t, xyz.z)(t_new)
+        x_new = scipy.interpolate.interp1d(t, xyz.x)(t_new)
+        y_new = scipy.interpolate.interp1d(t, xyz.y)(t_new)
+        z_new = scipy.interpolate.interp1d(t, xyz.z)(t_new)
         xyz_new = CartesianRepresentation(x_new, y_new, z_new)
         altaz_frame = AltAz(obstime=time, location=self.location)
 

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -5,9 +5,9 @@ from astropy.table import Table
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
 from astropy.version import version as astropy_version
-from ..utils.fits import earth_location_from_dict
-from ..utils.scripts import make_path
-from ..utils.time import time_ref_from_dict
+from gammapy.utils.fits import earth_location_from_dict
+from gammapy.utils.scripts import make_path
+from gammapy.utils.time import time_ref_from_dict
 
 __all__ = ["FixedPointingInfo", "PointingInfo"]
 

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -2,8 +2,8 @@
 import os
 from pathlib import Path
 import pytest
-from ...data import DataStore
-from ...utils.testing import requires_data
+from gammapy.data import DataStore
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/data/tests/test_event_list.py
+++ b/gammapy/data/tests/test_event_list.py
@@ -6,9 +6,9 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from regions import CircleSkyRegion, RectangleSkyRegion
-from ...data.event_list import EventList, EventListBase, EventListLAT
-from ...maps import Map, MapAxis, WcsGeom
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.data import EventList, EventListBase, EventListLAT
+from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 @requires_data()

--- a/gammapy/data/tests/test_filters.py
+++ b/gammapy/data/tests/test_filters.py
@@ -5,9 +5,9 @@ from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
-from ...data import GTI, DataStore, EventListBase, ObservationFilter
-from ...utils.regions import SphericalCircleSkyRegion
-from ...utils.testing import assert_time_allclose, requires_data
+from gammapy.data import GTI, DataStore, EventListBase, ObservationFilter
+from gammapy.utils.regions import SphericalCircleSkyRegion
+from gammapy.utils.testing import assert_time_allclose, requires_data
 
 
 def test_event_filter_types():

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -4,9 +4,9 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
-from ...data import GTI
-from ...utils.testing import assert_time_allclose, requires_data
-from ...utils.time import time_ref_to_dict
+from gammapy.data import GTI
+from gammapy.utils.testing import assert_time_allclose, requires_data
+from gammapy.utils.time import time_ref_to_dict
 
 
 @requires_data()

--- a/gammapy/data/tests/test_hdu_index_table.py
+++ b/gammapy/data/tests/test_hdu_index_table.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
 import pytest
-from ...utils.scripts import make_path
-from ...utils.testing import requires_data
-from ..hdu_index_table import HDUIndexTable
+from gammapy.data import HDUIndexTable
+from gammapy.utils.scripts import make_path
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/data/tests/test_obs_stats.py
+++ b/gammapy/data/tests/test_obs_stats.py
@@ -4,9 +4,9 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from ...background import ReflectedRegionsBackgroundEstimator
-from ...data import DataStore, Observations, ObservationStats
-from ...utils.testing import requires_data
+from gammapy.background import ReflectedRegionsBackgroundEstimator
+from gammapy.data import DataStore, Observations, ObservationStats
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/data/tests/test_obs_summary.py
+++ b/gammapy/data/tests/test_obs_summary.py
@@ -4,14 +4,14 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from ...background import ReflectedRegionsBackgroundEstimator
-from ...data import (
+from gammapy.background import ReflectedRegionsBackgroundEstimator
+from gammapy.data import (
     DataStore,
     ObservationStats,
     ObservationSummary,
     ObservationTableSummary,
 )
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 @requires_data()

--- a/gammapy/data/tests/test_obs_table.py
+++ b/gammapy/data/tests/test_obs_table.py
@@ -3,16 +3,15 @@ import numpy as np
 from astropy.coordinates import AltAz, Angle, SkyCoord
 from astropy.time import Time, TimeDelta
 from astropy.units import Quantity
-from ...data import GTI
-from ...utils.random import get_random_state, sample_sphere
-from ...utils.testing import (
+from gammapy.data import GTI, observatory_locations
+from gammapy.data.obs_table import ObservationTable, ObservationTableChecker
+from gammapy.utils.random import get_random_state, sample_sphere
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     assert_time_allclose,
     requires_data,
 )
-from ...utils.time import time_ref_from_dict, time_relative_to_ref
-from ..obs_table import ObservationTable, ObservationTableChecker
-from ..observers import observatory_locations
+from gammapy.utils.time import time_ref_from_dict, time_relative_to_ref
 
 
 def make_test_observation_table(

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from ...data import DataStore
-from ...utils.testing import (
+from gammapy.data import DataStore
+from gammapy.utils.testing import (
     assert_skycoord_allclose,
     assert_time_allclose,
     requires_data,

--- a/gammapy/data/tests/test_observers.py
+++ b/gammapy/data/tests/test_observers.py
@@ -1,11 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
-from ...data import observatory_locations
+from gammapy.data import observatory_locations
 
 
 def test_observatory_locations():
-    # Check one example
     location = observatory_locations["hess"]
     assert_allclose(location.lon.deg, Angle("16d30m00.8s").deg)
     assert_allclose(location.lat.deg, Angle("-23d16m18.4s").deg)

--- a/gammapy/data/tests/test_pointing.py
+++ b/gammapy/data/tests/test_pointing.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.time import Time
-from ...utils.testing import assert_time_allclose, requires_data
-from ..pointing import FixedPointingInfo, PointingInfo
+from gammapy.data import FixedPointingInfo, PointingInfo
+from gammapy.utils.testing import assert_time_allclose, requires_data
 
 
 @requires_data()

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -7,7 +7,7 @@ from scipy.signal import fftconvolve
 from astropy.convolution import Gaussian2DKernel, MexicanHat2DKernel
 from astropy.io import fits
 from astropy.table import Table
-from ..maps import MapAxis, WcsGeom, WcsNDMap
+from gammapy.maps import MapAxis, WcsGeom, WcsNDMap
 
 __all__ = ["CWT", "CWTData", "CWTKernels"]
 

--- a/gammapy/detect/cwt.py
+++ b/gammapy/detect/cwt.py
@@ -2,8 +2,8 @@
 import copy
 import logging
 import numpy as np
-from scipy.ndimage import label
-from scipy.signal import fftconvolve
+import scipy.ndimage
+import scipy.signal
 from astropy.convolution import Gaussian2DKernel, MexicanHat2DKernel
 from astropy.io import fits
 from astropy.table import Table
@@ -130,20 +130,22 @@ class CWT:
 
         log.debug("Computing transform and error")
         for idx_scale, kern in self.kernels.kern_base.items():
-            data._transform_3d[idx_scale] = fftconvolve(excess, kern, mode="same")
+            data._transform_3d[idx_scale] = scipy.signal.fftconvolve(
+                excess, kern, mode="same"
+            )
             data._error[idx_scale] = np.sqrt(
-                fftconvolve(total_background, kern ** 2, mode="same")
+                scipy.signal.fftconvolve(total_background, kern ** 2, mode="same")
             )
         log.debug("Error sum: {:.4f}".format(data._error.sum()))
         log.debug("Error max: {:.4f}".format(data._error.max()))
 
         log.debug("Computing approx and approx_bkg")
-        data._approx = fftconvolve(
+        data._approx = scipy.signal.fftconvolve(
             data._counts - data._model - data._background,
             self.kernels.kern_approx,
             mode="same",
         )
-        data._approx_bkg = fftconvolve(
+        data._approx_bkg = scipy.signal.fftconvolve(
             data._background, self.kernels.kern_approx, mode="same"
         )
         log.debug("Approximate sum: {:.4f}".format(data._approx.sum()))
@@ -191,7 +193,7 @@ class CWT:
             mask = significance[idx_scale] > self.significance_threshold
 
             # Produce a list of connex structures in the support
-            labeled_mask, n_structures = label(mask)
+            labeled_mask, n_structures = scipy.ndimage.label(mask)
             for struct_label in range(n_structures):
                 coords = np.where(labeled_mask == struct_label + 1)
 

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.ndimage import maximum_filter
+import scipy.ndimage
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from gammapy.maps import WcsNDMap
@@ -69,7 +69,7 @@ def find_peaks(image, threshold, min_distance=1):
         return Table()
 
     # Run peak finder
-    data_max = maximum_filter(data, size=size, mode="constant")
+    data_max = scipy.ndimage.maximum_filter(data, size=size, mode="constant")
     mask = (data == data_max) & (data > threshold)
     y, x = mask.nonzero()
     value = data[y, x]

--- a/gammapy/detect/find.py
+++ b/gammapy/detect/find.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy.ndimage import maximum_filter
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from ..maps import WcsNDMap
+from gammapy.maps import WcsNDMap
 
 __all__ = ["find_peaks"]
 

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -5,7 +5,7 @@ from scipy.ndimage import binary_erosion
 from scipy.ndimage.morphology import binary_fill_holes
 from astropy.convolution import CustomKernel, Tophat2DKernel
 from astropy.coordinates import Angle
-from ..maps import Map
+from gammapy.maps import Map
 from .lima import compute_lima_image
 
 log = logging.getLogger(__name__)

--- a/gammapy/detect/kernel.py
+++ b/gammapy/detect/kernel.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-from scipy.ndimage import binary_erosion
-from scipy.ndimage.morphology import binary_fill_holes
+import scipy.ndimage
 from astropy.convolution import CustomKernel, Tophat2DKernel
 from astropy.coordinates import Angle
 from gammapy.maps import Map
@@ -176,7 +175,7 @@ class KernelBackgroundEstimator:
         mask = (
             significance.data < self.parameters["significance_threshold"]
         ) | np.isnan(significance.data)
-        mask = binary_erosion(mask, structure, border_value=1)
+        mask = scipy.ndimage.binary_erosion(mask, structure, border_value=1)
 
         return counts.copy(data=mask.astype("float"))
 
@@ -201,5 +200,5 @@ class KernelBackgroundEstimator:
 
         # Because of pixel to pixel noise, the masks can still differ.
         # This is handled by removing structures of the scale of one pixel
-        mask = binary_fill_holes(mask)
+        mask = scipy.ndimage.binary_fill_holes(mask)
         return np.all(mask)

--- a/gammapy/detect/lima.py
+++ b/gammapy/detect/lima.py
@@ -2,7 +2,7 @@
 import copy
 import logging
 import numpy as np
-from ..stats import significance, significance_on_off
+from gammapy.stats import significance, significance_on_off
 
 __all__ = ["compute_lima_image", "compute_lima_on_off_image"]
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -8,8 +8,8 @@ from multiprocessing import Pool
 import numpy as np
 from scipy.optimize import brentq, newton
 from astropy.convolution import CustomKernel, Kernel2D
-from ..stats import cash, cash_sum_cython
-from ..utils.array import shape_2N, symmetric_crop_pad_width
+from gammapy.stats import cash, cash_sum_cython
+from gammapy.utils.array import shape_2N, symmetric_crop_pad_width
 from ._test_statistics_cython import (
     _amplitude_bounds_cython,
     _f_cash_root_cython,

--- a/gammapy/detect/tests/test_cwt.py
+++ b/gammapy/detect/tests/test_cwt.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
-from ...detect import CWT, CWTData, CWTKernels
-from ...maps import Map
-from ...utils.testing import requires_data
+from gammapy.detect import CWT, CWTData, CWTKernels
+from gammapy.maps import Map
+from gammapy.utils.testing import requires_data
 
 
 @requires_data()

--- a/gammapy/detect/tests/test_find.py
+++ b/gammapy/detect/tests/test_find.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from numpy.testing import assert_allclose
-from ...maps import Map
-from ..find import find_peaks
+from gammapy.detect import find_peaks
+from gammapy.maps import Map
 
 
 class TestFindPeaks:

--- a/gammapy/detect/tests/test_kernel.py
+++ b/gammapy/detect/tests/test_kernel.py
@@ -2,9 +2,9 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from ...maps import Map
-from ...utils.testing import requires_data
-from ..kernel import KernelBackgroundEstimator
+from gammapy.detect import KernelBackgroundEstimator
+from gammapy.maps import Map
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/detect/tests/test_lima.py
+++ b/gammapy/detect/tests/test_lima.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.convolution import Tophat2DKernel
-from ...detect import compute_lima_image, compute_lima_on_off_image
-from ...maps import Map
-from ...utils.testing import requires_data
+from gammapy.detect import compute_lima_image, compute_lima_on_off_image
+from gammapy.maps import Map
+from gammapy.utils.testing import requires_data
 
 
 @requires_data()

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -2,9 +2,9 @@
 import pytest
 from numpy.testing import assert_allclose
 from astropy.convolution import Gaussian2DKernel
-from ...detect import TSMapEstimator
-from ...maps import Map
-from ...utils.testing import requires_data
+from gammapy.detect import TSMapEstimator
+from gammapy.maps import Map
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/image/asmooth.py
+++ b/gammapy/image/asmooth.py
@@ -3,7 +3,7 @@
 import numpy as np
 from astropy.convolution import Gaussian2DKernel, Tophat2DKernel
 from astropy.coordinates import Angle
-from ..stats import significance
+from gammapy.stats import significance
 from .utils import scale_cube
 
 __all__ = ["ASmooth"]

--- a/gammapy/image/measure.py
+++ b/gammapy/image/measure.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.optimize import brentq
+import scipy.optimize
 from astropy.units import Quantity
 
 __all__ = [
@@ -100,7 +100,7 @@ def measure_containment_radius(image, position, containment_fraction=0.8):
             - containment_fraction
         )
 
-    containment_radius = brentq(func, a=0, b=separation.max().value)
+    containment_radius = scipy.optimize.brentq(func, a=0, b=separation.max().value)
     return Quantity(containment_radius, separation.unit)
 
 

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-from scipy.integrate import quad
-from scipy.special import erf
+import scipy.integrate
+import scipy.special
 import astropy.units as u
 from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord
 from astropy.coordinates.angle_utilities import angular_separation, position_angle
@@ -29,7 +29,7 @@ EDGE_WIDTH_95 = 2.326174307353347
 
 def smooth_edge(x, width):
     value = (x / width).to_value("")
-    return 0.5 * (1 - erf(value * EDGE_WIDTH_95))
+    return 0.5 * (1 - scipy.special.erf(value * EDGE_WIDTH_95))
 
 
 class SkySpatialModel(Model):
@@ -513,7 +513,10 @@ class SkyEllipse(SkySpatialModel):
             return 1 - np.sqrt(1 - 1 / (B + C * cs2))
 
         return (
-            2 * quad(lambda x: integral_fcn(x, semi_major, semi_minor), 0, np.pi)[0]
+            2
+            * scipy.integrate.quad(
+                lambda x: integral_fcn(x, semi_major, semi_minor), 0, np.pi
+            )[0]
         ) ** -1
 
     def evaluate(self, lon, lat, lon_0, lat_0, semi_major, e, phi, edge):

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -6,8 +6,8 @@ from scipy.special import erf
 import astropy.units as u
 from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord
 from astropy.coordinates.angle_utilities import angular_separation, position_angle
-from ...maps import Map
-from ...utils.fitting import Model, Parameter
+from gammapy.maps import Map
+from gammapy.utils.fitting import Model, Parameter
 
 __all__ = [
     "SkySpatialModel",

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -3,9 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ....maps import Map, WcsGeom
-from ....utils.testing import requires_data
-from ..core import (
+from gammapy.image.models import (
     SkyDiffuseConstant,
     SkyDiffuseMap,
     SkyDisk,
@@ -15,6 +13,8 @@ from ..core import (
     SkyPointSource,
     SkyShell,
 )
+from gammapy.maps import Map, WcsGeom
+from gammapy.utils.testing import requires_data
 
 
 def test_sky_point_source():

--- a/gammapy/image/tests/test_asmooth.py
+++ b/gammapy/image/tests/test_asmooth.py
@@ -3,9 +3,9 @@ import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.convolution import Tophat2DKernel
-from ...maps import Map
-from ...utils.testing import requires_data
-from ..asmooth import ASmooth
+from gammapy.image import ASmooth
+from gammapy.maps import Map
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/image/tests/test_measure.py
+++ b/gammapy/image/tests/test_measure.py
@@ -4,14 +4,14 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.modeling.models import Gaussian2D
-from ...image import (
+from gammapy.image import (
     measure_containment,
     measure_containment_radius,
     measure_curve_of_growth,
     measure_image_moments,
 )
-from ...maps import WcsGeom, WcsNDMap
-from ...utils.testing import assert_quantity_allclose
+from gammapy.maps import WcsGeom, WcsNDMap
+from gammapy.utils.testing import assert_quantity_allclose
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/image/tests/test_plotting.py
+++ b/gammapy/image/tests/test_plotting.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
-from ...image import (
+from gammapy.image import (
     MapPanelPlotter,
     colormap_hess,
     colormap_milagro,
     illustrate_colormap,
 )
-from ...maps import Map
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.maps import Map
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 def _check_cmap_rgb_vals(vals, cmap, vmin=0, vmax=1):

--- a/gammapy/image/tests/test_profile.py
+++ b/gammapy/image/tests/test_profile.py
@@ -5,13 +5,13 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.table import Table
-from ...maps import WcsGeom, WcsNDMap
-from ...utils.testing import (
+from gammapy.image.profile import ImageProfile, ImageProfileEstimator, compute_binning
+from gammapy.maps import WcsGeom, WcsNDMap
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
     requires_dependency,
 )
-from ..profile import ImageProfile, ImageProfileEstimator, compute_binning
 
 
 @requires_dependency("pandas")

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -4,10 +4,10 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
-from ..maps import MapAxis
-from ..maps.utils import edges_from_lo_hi
-from ..utils.nddata import NDDataArray
-from ..utils.scripts import make_path
+from gammapy.maps import MapAxis
+from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.utils.nddata import NDDataArray
+from gammapy.utils.scripts import make_path
 
 __all__ = ["Background3D", "Background2D"]
 

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -4,11 +4,11 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
-from ..maps import MapAxis
-from ..maps.utils import edges_from_lo_hi
-from ..utils.energy import energy_logcenter
-from ..utils.nddata import NDDataArray
-from ..utils.scripts import make_path
+from gammapy.maps import MapAxis
+from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.utils.energy import energy_logcenter
+from gammapy.utils.nddata import NDDataArray
+from gammapy.utils.scripts import make_path
 
 __all__ = ["EffectiveAreaTable", "EffectiveAreaTable2D"]
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -6,12 +6,12 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
-from ..maps import MapAxis
-from ..maps.utils import edges_from_lo_hi
-from ..utils.energy import energy_logcenter
-from ..utils.fits import energy_axis_to_ebounds
-from ..utils.nddata import NDDataArray
-from ..utils.scripts import make_path
+from gammapy.maps import MapAxis
+from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.utils.energy import energy_logcenter
+from gammapy.utils.fits import energy_axis_to_ebounds
+from gammapy.utils.nddata import NDDataArray
+from gammapy.utils.scripts import make_path
 
 __all__ = ["EnergyDispersion", "EnergyDispersion2D"]
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from collections import OrderedDict
 import numpy as np
-from scipy.special import erf
+import scipy.special
 from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
@@ -800,7 +800,7 @@ class EnergyDispersion2D:
         s = np.sqrt(2) * sigma
         t1 = (migra2d_hi - 1 - bias) / s
         t2 = (migra2d_lo - 1 - bias) / s
-        pdf = (erf(t1) - erf(t2)) / 2
+        pdf = (scipy.special.erf(t1) - scipy.special.erf(t2)) / 2
 
         pdf_array = pdf.T[:, :, np.newaxis] * np.ones(len(offset) - 1)
 

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ..utils.scripts import make_path
+from gammapy.utils.scripts import make_path
 from .background import Background3D
 from .effective_area import EffectiveAreaTable2D
 from .energy_dispersion import EnergyDispersion2D

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -2,7 +2,8 @@
 import logging
 import numpy as np
 from astropy.units import Quantity
-from ..irf import EffectiveAreaTable, EnergyDispersion
+from .effective_area import EffectiveAreaTable
+from .energy_dispersion import EnergyDispersion
 
 __all__ = ["IRFStacker"]
 

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -5,10 +5,10 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.utils import lazyproperty
-from ..utils.array import array_stats_str
-from ..utils.energy import energy_logspace
-from ..utils.interpolation import ScaledRegularGridInterpolator
-from ..utils.scripts import make_path
+from gammapy.utils.array import array_stats_str
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+from gammapy.utils.scripts import make_path
 from .psf_table import EnergyDependentTablePSF, TablePSF
 
 __all__ = ["PSF3D"]

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -7,11 +7,11 @@ from astropy.io import fits
 from astropy.stats import gaussian_fwhm_to_sigma
 from astropy.table import Table
 from astropy.units import Quantity, Unit
-from ..utils.array import array_stats_str
-from ..utils.energy import energy_logspace
-from ..utils.gauss import MultiGauss2D
-from ..utils.interpolation import ScaledRegularGridInterpolator
-from ..utils.scripts import make_path
+from gammapy.utils.array import array_stats_str
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.gauss import MultiGauss2D
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+from gammapy.utils.scripts import make_path
 from .psf_3d import PSF3D
 from .psf_table import EnergyDependentTablePSF
 

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -5,8 +5,8 @@ from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
-from ..utils.array import array_stats_str
-from ..utils.scripts import make_path
+from gammapy.utils.array import array_stats_str
+from gammapy.utils.scripts import make_path
 from .psf_table import EnergyDependentTablePSF
 
 __all__ = ["PSFKing"]

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -6,11 +6,11 @@ from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.utils import lazyproperty
-from ..utils.array import array_stats_str
-from ..utils.energy import energy_logspace
-from ..utils.gauss import Gauss2DPDF
-from ..utils.interpolation import ScaledRegularGridInterpolator
-from ..utils.scripts import make_path
+from gammapy.utils.array import array_stats_str
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.gauss import Gauss2DPDF
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+from gammapy.utils.scripts import make_path
 
 __all__ = ["TablePSF", "EnergyDependentTablePSF"]
 

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-from scipy.integrate import cumtrapz
+import scipy.integrate
 from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.io import fits
@@ -51,7 +51,9 @@ class TablePSF:
             rad = self.rad
 
         rad_drad = 2 * np.pi * rad * self.evaluate(rad)
-        values = cumtrapz(rad_drad.to_value("rad-1"), rad.to_value("rad"), initial=0)
+        values = scipy.integrate.cumtrapz(
+            rad_drad.to_value("rad-1"), rad.to_value("rad"), initial=0
+        )
 
         return ScaledRegularGridInterpolator(points=(rad,), values=values, fill_value=1)
 
@@ -277,7 +279,7 @@ class EnergyDependentTablePSF:
             rad = self.rad
 
         rad_drad = 2 * np.pi * rad * self.evaluate(energy=self.energy, rad=rad)
-        values = cumtrapz(
+        values = scipy.integrate.cumtrapz(
             rad_drad.to_value("rad-1"), rad.to_value("rad"), initial=0, axis=1
         )
 

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...utils.testing import requires_data
-from ..background import Background2D, Background3D
+from gammapy.irf import Background2D, Background3D
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
-from ...irf.effective_area import EffectiveAreaTable, EffectiveAreaTable2D
-from ...utils.testing import (
+from gammapy.irf import EffectiveAreaTable, EffectiveAreaTable2D
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
     requires_data,

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -4,9 +4,9 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.coordinates import Angle
-from ...irf import EnergyDispersion, EnergyDispersion2D
-from ...utils.energy import energy_logspace
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.irf import EnergyDispersion, EnergyDispersion2D
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 class TestEnergyDispersion:

--- a/gammapy/irf/tests/test_fits_prod.py
+++ b/gammapy/irf/tests/test_fits_prod.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...data import DataStore
-from ...utils.testing import requires_data
+from gammapy.data import DataStore
+from gammapy.utils.testing import requires_data
 
 # TODO: clean up these FITS production tests
 # There is some duplication with `gammapy/data/tests/test_data_store.py`

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
-from ...utils.testing import requires_data
-from ..io import load_cta_irfs
+from gammapy.irf import load_cta_irfs
+from gammapy.utils.testing import requires_data
 
 
 @requires_data()

--- a/gammapy/irf/tests/test_irf_reduce.py
+++ b/gammapy/irf/tests/test_irf_reduce.py
@@ -4,19 +4,20 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
-from ...data import DataStore, Observations
-from ...utils.energy import energy_logspace
-from ...utils.testing import assert_quantity_allclose, requires_data
-from ..effective_area import EffectiveAreaTable
-from ..energy_dispersion import EnergyDispersion
-from ..irf_reduce import (
+from gammapy.data import DataStore, Observations
+from gammapy.irf import (
+    EffectiveAreaTable,
+    EnergyDependentTablePSF,
+    EnergyDispersion,
+    TablePSF,
     apply_containment_fraction,
     compute_energy_thresholds,
     make_mean_edisp,
     make_mean_psf,
     make_psf,
 )
-from ..psf_table import EnergyDependentTablePSF, TablePSF
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.testing import assert_quantity_allclose, requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/irf/tests/test_irf_write.py
+++ b/gammapy/irf/tests/test_irf_write.py
@@ -3,9 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.io import fits
-from ..background import Background3D
-from ..effective_area import EffectiveAreaTable2D
-from ..energy_dispersion import EnergyDispersion2D
+from gammapy.irf import Background3D, EffectiveAreaTable2D, EnergyDispersion2D
 
 
 class TestIRFWrite:

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -2,8 +2,8 @@
 import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
-from ...irf import PSF3D
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.irf import PSF3D
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/irf/tests/test_psf_check.py
+++ b/gammapy/irf/tests/test_psf_check.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
-from ...utils.testing import requires_data
-from ..psf_3d import PSF3D
-from ..psf_check import PSF3DChecker
+from gammapy.irf import PSF3D
+from gammapy.irf.psf_check import PSF3DChecker
+from gammapy.utils.testing import requires_data
 
 
 @requires_data()

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -5,12 +5,12 @@ from numpy.testing import assert_allclose, assert_almost_equal
 from astropy import units as u
 from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename
-from ...utils.testing import requires_data
-from ..psf_gauss import (
+from gammapy.irf.psf_gauss import (
     EnergyDependentMultiGaussPSF,
     HESSMultiGaussPSF,
     multi_gauss_psf_kernel,
 )
+from gammapy.utils.testing import requires_data
 
 
 def make_test_psf(energy_bins=15, theta_bins=12):

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -2,8 +2,8 @@
 import pytest
 import numpy as np
 from astropy.coordinates import Angle
-from ...irf import PSFKing
-from ...utils.testing import assert_quantity_allclose, requires_data
+from gammapy.irf import PSFKing
+from gammapy.utils.testing import assert_quantity_allclose, requires_data
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/irf/tests/test_psf_table.py
+++ b/gammapy/irf/tests/test_psf_table.py
@@ -3,8 +3,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import Angle
-from ...irf import EnergyDependentTablePSF, TablePSF
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.irf import EnergyDependentTablePSF, TablePSF
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 class TestTablePSF:

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
-from ..utils.scripts import make_path
+from gammapy.utils.scripts import make_path
 from .geom import MapCoord, pix_tuple_to_idx
 from .utils import INVALID_VALUE
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -6,7 +6,7 @@ import logging
 import re
 from collections import OrderedDict
 import numpy as np
-from scipy.interpolate import interp1d
+import scipy.interpolate
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -272,7 +272,7 @@ def coord_to_pix(edges, coord, interp="lin"):
     """Convert axis to pixel coordinates for given interpolation scheme."""
     scale = interpolation_scale(interp)
 
-    interp_fn = interp1d(
+    interp_fn = scipy.interpolate.interp1d(
         scale(edges), np.arange(len(edges), dtype=float), fill_value="extrapolate"
     )
 
@@ -283,7 +283,7 @@ def pix_to_coord(edges, pix, interp="lin"):
     """Convert pixel to grid coordinates for given interpolation scheme."""
     scale = interpolation_scale(interp)
 
-    interp_fn = interp1d(
+    interp_fn = scipy.interpolate.interp1d(
         np.arange(len(edges), dtype=float), scale(edges), fill_value="extrapolate"
     )
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Column, QTable
-from ..utils.interpolation import interpolation_scale
+from gammapy.utils.interpolation import interpolation_scale
 from .utils import INVALID_INDEX, find_bands_hdu, find_hdu
 
 __all__ = ["MapCoord", "MapGeom", "MapAxis"]

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -2,7 +2,7 @@
 import numpy as np
 from astropy.io import fits
 from astropy.units import Quantity
-from ..utils.units import unit_from_fits_image_hdu
+from gammapy.utils.units import unit_from_fits_image_hdu
 from .geom import MapCoord, pix_tuple_to_idx
 from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order
 from .hpxmap import HpxMap

--- a/gammapy/maps/reproject.py
+++ b/gammapy/maps/reproject.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.ndimage import map_coordinates
+import scipy.ndimage
 import astropy.units as u
 
 __all__ = ["reproject_car_to_hpx", "reproject_car_to_wcs"]
@@ -54,7 +54,7 @@ def reproject_car_to_hpx(input_data, coord_system_out, nside, order=1, nested=Fa
     # Interpolate
     data = np.pad(data, 3, mode="wrap")
 
-    healpix_data = map_coordinates(
+    healpix_data = scipy.ndimage.map_coordinates(
         data, [xinds + 3, yinds + 3], order=order, mode="wrap", cval=np.nan
     )
 
@@ -92,7 +92,7 @@ def reproject_car_to_wcs(input_data, wcs_out, shape_out, order=1):
     # Make sure image is floating point. We do this only now because
     # we want to avoid converting the whole input array if possible
     slice_in = np.asarray(slice_in, dtype=float)
-    slice_out[:, :] = map_coordinates(
+    slice_out[:, :] = scipy.ndimage.map_coordinates(
         slice_in, coordinates + 3, order=order, cval=np.nan, mode="constant"
     ).reshape(slice_out.shape)
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -6,13 +6,8 @@ from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Quantity, Unit
-from ...utils.testing import requires_dependency
-from ..base import Map
-from ..geom import MapAxis
-from ..hpx import HpxGeom
-from ..hpxnd import HpxNDMap
-from ..wcs import WcsGeom
-from ..wcsnd import WcsNDMap
+from gammapy.maps import HpxGeom, HpxNDMap, Map, MapAxis, WcsGeom, WcsNDMap
+from gammapy.utils.testing import requires_dependency
 
 pytest.importorskip("numpy", "1.12.0")
 pytest.importorskip("healpy")

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from ..geom import MapAxis, MapCoord
+from gammapy.maps import MapAxis, MapCoord
 
 mapaxis_geoms = [
     (np.array([0.25, 0.75, 1.0, 2.0]), "lin"),

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.io import fits
-from ..geom import MapAxis, MapCoord
-from ..hpx import (
+from gammapy.maps import MapAxis, MapCoord
+from gammapy.maps.hpx import (
     HpxGeom,
     get_hpxregion_dir,
     get_hpxregion_size,

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -5,14 +5,10 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from ...utils.testing import mpl_plot_check, requires_dependency
-from ..base import Map
-from ..geom import MapAxis, coordsys_to_frame
-from ..hpx import HpxGeom
-from ..hpxmap import HpxMap
-from ..hpxnd import HpxNDMap
-from ..hpxsparse import HpxSparseMap
-from ..utils import fill_poisson
+from gammapy.maps import HpxGeom, HpxMap, HpxNDMap, HpxSparseMap, Map, MapAxis
+from gammapy.maps.geom import coordsys_to_frame
+from gammapy.maps.utils import fill_poisson
+from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
 pytest.importorskip("numpy", "1.12.0")
 pytest.importorskip("healpy")

--- a/gammapy/maps/tests/test_hpxsparse.py
+++ b/gammapy/maps/tests/test_hpxsparse.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-from ..geom import MapAxis
-from ..hpx import HpxGeom
-from ..hpxsparse import HpxSparseMap
+from gammapy.maps import HpxGeom, HpxSparseMap, MapAxis
 
 pytest.importorskip("healpy")
 

--- a/gammapy/maps/tests/test_sparse.py
+++ b/gammapy/maps/tests/test_sparse.py
@@ -2,8 +2,8 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from .._sparse import merge_sparse_arrays
-from ..sparse import SparseArray
+from gammapy.maps import SparseArray
+from gammapy.maps._sparse import merge_sparse_arrays
 
 test_params = [(8,), (8, 16), (8, 16, 32)]
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -5,9 +5,8 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import fits
-from ..base import Map
-from ..geom import MapAxis
-from ..wcs import WcsGeom, _check_width
+from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.maps.wcs import _check_width
 
 axes1 = [MapAxis(np.logspace(0.0, 3.0, 3), interp="log", name="energy")]
 axes2 = [

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -7,15 +7,12 @@ from astropy.convolution import Gaussian2DKernel
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from regions import CircleSkyRegion
-from ...cube import PSFKernel
-from ...irf import EnergyDependentMultiGaussPSF
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
-from ..base import Map
-from ..geom import MapAxis, MapCoord, coordsys_to_frame
-from ..hpx import HpxGeom
-from ..utils import fill_poisson
-from ..wcs import WcsGeom
-from ..wcsnd import WcsNDMap
+from gammapy.cube import PSFKernel
+from gammapy.irf import EnergyDependentMultiGaussPSF
+from gammapy.maps import HpxGeom, Map, MapAxis, MapCoord, WcsGeom, WcsNDMap
+from gammapy.maps.geom import coordsys_to_frame
+from gammapy.maps.utils import fill_poisson
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 pytest.importorskip("reproject")
 

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from astropy.io import fits
-from ..utils.random import get_random_state
+from gammapy.utils.random import get_random_state
 
 
 class InvalidValue:

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -8,9 +8,9 @@ import astropy.units as u
 from astropy.convolution import Tophat2DKernel
 from astropy.io import fits
 from astropy.nddata import Cutout2D
-from ..extern.skimage import block_reduce
-from ..utils.interpolation import ScaledRegularGridInterpolator
-from ..utils.units import unit_from_fits_image_hdu
+from gammapy.extern.skimage import block_reduce
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+from gammapy.utils.units import unit_from_fits_image_hdu
 from .geom import pix_tuple_to_idx
 from .reproject import reproject_car_to_hpx, reproject_car_to_wcs
 from .utils import INVALID_INDEX, interp_to_order

--- a/gammapy/scripts/check.py
+++ b/gammapy/scripts/check.py
@@ -7,7 +7,7 @@ for developers and the test runner from including it in test collection.
 import logging
 import warnings
 import click
-from .. import test
+from gammapy import test
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from urllib.request import urlopen
 import yaml
-from .. import __version__
+from gammapy import __version__
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/scripts/image_bin.py
+++ b/gammapy/scripts/image_bin.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import click
-from ..cube import fill_map_counts
-from ..data import EventList
-from ..maps import Map
+from gammapy.cube import fill_map_counts
+from gammapy.data import EventList
+from gammapy.maps import Map
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from collections import OrderedDict
 import click
-from .. import __version__
+from gammapy import __version__
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/scripts/main.py
+++ b/gammapy/scripts/main.py
@@ -4,7 +4,7 @@ import sys
 import warnings
 from pathlib import Path
 import click
-from .. import __version__
+from gammapy import __version__
 
 
 # We implement the --version following the example from here:

--- a/gammapy/scripts/spectrum_pipe.py
+++ b/gammapy/scripts/spectrum_pipe.py
@@ -1,15 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import yaml
-from ..background import ReflectedRegionsBackgroundEstimator
-from ..spectrum import (
+from gammapy.background import ReflectedRegionsBackgroundEstimator
+from gammapy.spectrum import (
     FluxPointsDataset,
     FluxPointsEstimator,
     SpectrumDatasetOnOffStacker,
     SpectrumExtraction,
 )
-from ..utils.fitting import Fit
-from ..utils.scripts import make_path
+from gammapy.utils.fitting import Fit
+from gammapy.utils.scripts import make_path
 
 __all__ = ["SpectrumAnalysisIACT"]
 

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
 import pytest
-from ...utils.testing import requires_dependency, run_cli
-from ..main import cli
+from gammapy.scripts.main import cli
+from gammapy.utils.testing import requires_dependency, run_cli
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/scripts/tests/test_image_bin.py
+++ b/gammapy/scripts/tests/test_image_bin.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
-from ...maps import Map
-from ...utils.testing import assert_wcs_allclose, requires_data, run_cli
-from ..main import cli
+from gammapy.maps import Map
+from gammapy.scripts.main import cli
+from gammapy.utils.testing import assert_wcs_allclose, requires_data, run_cli
 
 
 @requires_data()

--- a/gammapy/scripts/tests/test_info.py
+++ b/gammapy/scripts/tests/test_info.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ...utils.testing import run_cli
-from ..main import cli
+from gammapy.scripts.main import cli
+from gammapy.utils.testing import run_cli
 
 
 def test_cli_info_help():

--- a/gammapy/scripts/tests/test_main.py
+++ b/gammapy/scripts/tests/test_main.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ... import __version__
-from ...utils.testing import run_cli
-from ..main import cli
+from gammapy import __version__
+from gammapy.scripts.main import cli
+from gammapy.utils.testing import run_cli
 
 
 def test_cli_no_args():

--- a/gammapy/scripts/tests/test_spectrum_pipe.py
+++ b/gammapy/scripts/tests/test_spectrum_pipe.py
@@ -4,11 +4,11 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
-from ...data import DataStore
-from ...spectrum.models import PowerLaw
-from ...utils.energy import energy_logspace
-from ...utils.testing import requires_data, requires_dependency
-from ..spectrum_pipe import SpectrumAnalysisIACT
+from gammapy.data import DataStore
+from gammapy.scripts import SpectrumAnalysisIACT
+from gammapy.spectrum.models import PowerLaw
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -5,11 +5,11 @@ import numpy as np
 import astropy.units as u
 from astropy.io import fits
 from astropy.table import Table
-from ..data import EventList
-from ..maps import MapAxis
-from ..maps.utils import edges_from_lo_hi
-from ..utils.fits import ebounds_to_energy_axis, energy_axis_to_ebounds
-from ..utils.scripts import make_path
+from gammapy.data import EventList
+from gammapy.maps import MapAxis
+from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.utils.fits import ebounds_to_energy_axis, energy_axis_to_ebounds
+from gammapy.utils.scripts import make_path
 
 __all__ = ["CountsSpectrum"]
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -5,13 +5,13 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
-from ..data import ObservationStats
-from ..irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
-from ..stats import cash, wstat
-from ..utils.fits import energy_axis_to_ebounds
-from ..utils.fitting import Dataset, Parameters
-from ..utils.random import get_random_state
-from ..utils.scripts import make_path
+from gammapy.data import ObservationStats
+from gammapy.irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
+from gammapy.stats import cash, wstat
+from gammapy.utils.fits import energy_axis_to_ebounds
+from gammapy.utils.fitting import Dataset, Parameters
+from gammapy.utils.random import get_random_state
+from gammapy.utils.scripts import make_path
 from .core import CountsSpectrum
 from .utils import SpectrumEvaluator
 

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import numpy as np
 import astropy.units as u
 from regions import CircleSkyRegion
-from ..irf import PSF3D, apply_containment_fraction, compute_energy_thresholds
-from ..utils.scripts import make_path
+from gammapy.irf import PSF3D, apply_containment_fraction, compute_energy_thresholds
+from gammapy.utils.scripts import make_path
 from .core import CountsSpectrum
 from .dataset import SpectrumDatasetOnOff
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -5,10 +5,10 @@ import numpy as np
 from astropy import units as u
 from astropy.io.registry import IORegistryError
 from astropy.table import Table, vstack
-from ..utils.fitting import Dataset, Datasets, Fit
-from ..utils.interpolation import interpolate_likelihood_profile
-from ..utils.scripts import make_path
-from ..utils.table import table_from_row_data, table_standardise_units_copy
+from gammapy.utils.fitting import Dataset, Datasets, Fit
+from gammapy.utils.interpolation import interpolate_likelihood_profile
+from gammapy.utils.scripts import make_path
+from gammapy.utils.table import table_from_row_data, table_standardise_units_copy
 from .dataset import SpectrumDatasetOnOff
 from .models import PowerLaw, ScaleModel
 

--- a/gammapy/spectrum/models.py
+++ b/gammapy/spectrum/models.py
@@ -5,10 +5,10 @@ import numpy as np
 from scipy.optimize import brentq
 import astropy.units as u
 from astropy.table import Table
-from ..utils.energy import energy_logspace
-from ..utils.fitting import Model, Parameter, Parameters
-from ..utils.interpolation import ScaledRegularGridInterpolator
-from ..utils.scripts import make_path
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.fitting import Model, Parameter, Parameters
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+from gammapy.utils.scripts import make_path
 from .utils import integrate_spectrum
 
 __all__ = [

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import astropy.units as u
 from astropy.table import Column, Table
-from ..stats import excess_matching_significance_on_off
+from gammapy.stats import excess_matching_significance_on_off
 from .models import PowerLaw
 from .utils import SpectrumEvaluator
 

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import astropy.units as u
-from ...utils.energy import energy_logspace
-from ...utils.testing import (
+from gammapy.spectrum import CountsSpectrum
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
     requires_dependency,
 )
-from .. import CountsSpectrum
 
 
 class TestCountsSpectrum:

--- a/gammapy/spectrum/tests/test_cosmic_ray.py
+++ b/gammapy/spectrum/tests/test_cosmic_ray.py
@@ -1,7 +1,7 @@
 import pytest
 import astropy.units as u
-from ...spectrum import create_cosmic_ray_spectral_model
-from ...utils.testing import assert_quantity_allclose
+from gammapy.spectrum import create_cosmic_ray_spectral_model
+from gammapy.utils.testing import assert_quantity_allclose
 
 Cosmic_rays_SPECTRA = [
     dict(

--- a/gammapy/spectrum/tests/test_crab.py
+++ b/gammapy/spectrum/tests/test_crab.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import astropy.units as u
-from ...spectrum import create_crab_spectral_model
-from ...utils.testing import assert_quantity_allclose
+from gammapy.spectrum import create_crab_spectral_model
+from gammapy.utils.testing import assert_quantity_allclose
 
 CRAB_SPECTRA = [
     dict(

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -5,19 +5,19 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
-from ...data import GTI
-from ...irf import EffectiveAreaTable, EnergyDispersion
-from ...spectrum import (
+from gammapy.data import GTI
+from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.spectrum import (
     CountsSpectrum,
     SpectrumDataset,
     SpectrumDatasetOnOff,
     SpectrumDatasetOnOffStacker,
 )
-from ...utils.fitting import Fit
-from ...utils.random import get_random_state
-from ...utils.testing import mpl_plot_check, requires_data, requires_dependency
-from ...utils.time import time_ref_to_dict
-from ..models import ConstantModel, ExponentialCutoffPowerLaw, PowerLaw
+from gammapy.spectrum.models import ConstantModel, ExponentialCutoffPowerLaw, PowerLaw
+from gammapy.utils.fitting import Fit
+from gammapy.utils.random import get_random_state
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
+from gammapy.utils.time import time_ref_to_dict
 
 
 @requires_dependency("iminuit")

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -5,11 +5,11 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
-from ...background import ReflectedRegionsBackgroundEstimator
-from ...data import DataStore, ObservationStats
-from ...maps import WcsGeom, WcsNDMap
-from ...spectrum import SpectrumDatasetOnOff, SpectrumExtraction
-from ...utils.testing import (
+from gammapy.background import ReflectedRegionsBackgroundEstimator
+from gammapy.data import DataStore, ObservationStats
+from gammapy.maps import WcsGeom, WcsNDMap
+from gammapy.spectrum import SpectrumDatasetOnOff, SpectrumExtraction
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     requires_data,
     requires_dependency,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -8,11 +8,11 @@ from gammapy.spectrum import (
     SpectrumDataset,
     SpectrumDatasetOnOff,
     SpectrumDatasetOnOffStacker,
-    models,
 )
-from ...utils.fitting import Fit
-from ...utils.random import get_random_state
-from ...utils.testing import requires_data, requires_dependency
+from gammapy.spectrum.models import PowerLaw, ExponentialCutoffPowerLaw
+from gammapy.utils.fitting import Fit
+from gammapy.utils.random import get_random_state
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 @requires_dependency("sherpa")
@@ -22,10 +22,10 @@ class TestFit:
     def setup(self):
         self.nbins = 30
         binning = np.logspace(-1, 1, self.nbins + 1) * u.TeV
-        self.source_model = models.PowerLaw(
+        self.source_model = PowerLaw(
             index=2, amplitude=1e5 / u.TeV, reference=0.1 * u.TeV
         )
-        self.bkg_model = models.PowerLaw(
+        self.bkg_model = PowerLaw(
             index=3, amplitude=1e4 / u.TeV, reference=0.1 * u.TeV
         )
 
@@ -109,11 +109,11 @@ class TestSpectralFit:
         obs2 = SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23592.fits")
         self.obs_list = [obs1, obs2]
 
-        self.pwl = models.PowerLaw(
+        self.pwl = PowerLaw(
             index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
         )
 
-        self.ecpl = models.ExponentialCutoffPowerLaw(
+        self.ecpl = ExponentialCutoffPowerLaw(
             index=2,
             amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
             reference=1 * u.TeV,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -2,8 +2,8 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...irf import EffectiveAreaTable
-from ...spectrum import (
+from gammapy.irf import EffectiveAreaTable
+from gammapy.spectrum import (
     CountsSpectrum,
     SpectrumDataset,
     SpectrumDatasetOnOff,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -9,7 +9,7 @@ from gammapy.spectrum import (
     SpectrumDatasetOnOff,
     SpectrumDatasetOnOffStacker,
 )
-from gammapy.spectrum.models import PowerLaw, ExponentialCutoffPowerLaw
+from gammapy.spectrum.models import ExponentialCutoffPowerLaw, PowerLaw
 from gammapy.utils.fitting import Fit
 from gammapy.utils.random import get_random_state
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -25,9 +25,7 @@ class TestFit:
         self.source_model = PowerLaw(
             index=2, amplitude=1e5 / u.TeV, reference=0.1 * u.TeV
         )
-        self.bkg_model = PowerLaw(
-            index=3, amplitude=1e4 / u.TeV, reference=0.1 * u.TeV
-        )
+        self.bkg_model = PowerLaw(index=3, amplitude=1e4 / u.TeV, reference=0.1 * u.TeV)
 
         self.alpha = 0.1
         random_state = get_random_state(23)

--- a/gammapy/spectrum/tests/test_flux_point_core.py
+++ b/gammapy/spectrum/tests/test_flux_point_core.py
@@ -4,8 +4,8 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table
-from ..flux_point import FluxPoints
-from ..models import PowerLaw
+from gammapy.spectrum import FluxPoints
+from gammapy.spectrum.models import PowerLaw
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -4,16 +4,18 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from ...cube import simulate_dataset
-from ...cube.models import SkyModel
-from ...image.models import SkyGaussian
-from ...irf import EffectiveAreaTable, load_cta_irfs
-from ...maps import MapAxis, WcsGeom
-from ...utils.testing import requires_data, requires_dependency
-from ..dataset import SpectrumDatasetOnOff
-from ..flux_point import FluxPointsEstimator
-from ..models import ExponentialCutoffPowerLaw, PowerLaw
-from ..utils import SpectrumEvaluator
+from gammapy.cube import simulate_dataset
+from gammapy.cube.models import SkyModel
+from gammapy.image.models import SkyGaussian
+from gammapy.irf import EffectiveAreaTable, load_cta_irfs
+from gammapy.maps import MapAxis, WcsGeom
+from gammapy.spectrum import (
+    FluxPointsEstimator,
+    SpectrumDatasetOnOff,
+    SpectrumEvaluator,
+)
+from gammapy.spectrum.models import ExponentialCutoffPowerLaw, PowerLaw
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 # TODO: use pregenerate data instead

--- a/gammapy/spectrum/tests/test_models.py
+++ b/gammapy/spectrum/tests/test_models.py
@@ -2,14 +2,7 @@
 import pytest
 import numpy as np
 import astropy.units as u
-from ...utils.energy import energy_logspace
-from ...utils.testing import (
-    assert_quantity_allclose,
-    mpl_plot_check,
-    requires_data,
-    requires_dependency,
-)
-from ..models import (
+from gammapy.spectrum.models import (
     AbsorbedSpectralModel,
     Absorption,
     ConstantModel,
@@ -24,6 +17,13 @@ from ..models import (
     SpectralLogGaussian,
     SpectralModel,
     TableModel,
+)
+from gammapy.utils.energy import energy_logspace
+from gammapy.utils.testing import (
+    assert_quantity_allclose,
+    mpl_plot_check,
+    requires_data,
+    requires_dependency,
 )
 
 

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -3,10 +3,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...irf import EffectiveAreaTable, EnergyDispersion
-from ...utils.testing import requires_data
-from ..core import CountsSpectrum
-from ..sensitivity import SensitivityEstimator
+from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.spectrum import CountsSpectrum, SensitivityEstimator
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture()

--- a/gammapy/spectrum/tests/test_utils.py
+++ b/gammapy/spectrum/tests/test_utils.py
@@ -4,10 +4,15 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.units import Quantity
-from ...irf import EffectiveAreaTable, EnergyDispersion
-from ...spectrum import SpectrumEvaluator, integrate_spectrum
-from ...utils.testing import assert_quantity_allclose, requires_dependency
-from ..models import ExponentialCutoffPowerLaw, PowerLaw, PowerLaw2, TableModel
+from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.spectrum import SpectrumEvaluator, integrate_spectrum
+from gammapy.spectrum.models import (
+    ExponentialCutoffPowerLaw,
+    PowerLaw,
+    PowerLaw2,
+    TableModel,
+)
+from gammapy.utils.testing import assert_quantity_allclose, requires_dependency
 
 
 def test_integrate_spectrum():

--- a/gammapy/stats/feldman_cousins.py
+++ b/gammapy/stats/feldman_cousins.py
@@ -2,7 +2,7 @@
 """Feldman Cousins algorithm to compute parameter confidence limits."""
 import logging
 import numpy as np
-from scipy.stats import norm, poisson, rankdata
+import scipy.stats
 
 __all__ = [
     "fc_find_acceptance_interval_gauss",
@@ -43,7 +43,7 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
         Acceptance interval
     """
 
-    dist = norm(loc=mu, scale=sigma)
+    dist = scipy.stats.norm(loc=mu, scale=sigma)
 
     x_bin_width = x_bins[1] - x_bins[0]
 
@@ -62,7 +62,7 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
         else:
             # Implementing the boundary condition at zero
             mu_best = max(0, x)
-            prob_mu_best = norm.pdf(x, loc=mu_best, scale=sigma)
+            prob_mu_best = scipy.stats.norm.pdf(x, loc=mu_best, scale=sigma)
             # probMuBest should never be zero. Check it just in case.
             if prob_mu_best == 0.0:
                 r.append(0.0)
@@ -78,7 +78,7 @@ def fc_find_acceptance_interval_gauss(mu, sigma, x_bins, alpha):
             "desired confidence level for this mu!"
         )
 
-    rank = rankdata(-r, method="dense")
+    rank = scipy.stats.rankdata(-r, method="dense")
 
     index_array = np.arange(x_bins.size)
 
@@ -124,7 +124,7 @@ def fc_find_acceptance_interval_poisson(mu, background, x_bins, alpha):
     (x_min, x_max) : tuple of floats
         Acceptance interval
     """
-    dist = poisson(mu=mu + background)
+    dist = scipy.stats.poisson(mu=mu + background)
 
     x_bin_width = x_bins[1] - x_bins[0]
 
@@ -135,7 +135,7 @@ def fc_find_acceptance_interval_poisson(mu, background, x_bins, alpha):
         p.append(dist.pmf(x))
         # Implementing the boundary condition at zero
         muBest = max(0, x - background)
-        probMuBest = poisson.pmf(x, mu=muBest + background)
+        probMuBest = scipy.stats.poisson.pmf(x, mu=muBest + background)
         # probMuBest should never be zero. Check it just in case.
         if probMuBest == 0.0:
             r.append(0.0)
@@ -151,7 +151,7 @@ def fc_find_acceptance_interval_poisson(mu, background, x_bins, alpha):
             "desired confidence level for this mu!"
         )
 
-    rank = rankdata(-r, method="dense")
+    rank = scipy.stats.rankdata(-r, method="dense")
 
     index_array = np.arange(x_bins.size)
 

--- a/gammapy/stats/normal.py
+++ b/gammapy/stats/normal.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Conversion functions for test statistic <-> significance <-> probability."""
 import numpy as np
-from scipy.optimize import fsolve
-from scipy.special import erf, erfinv
-from scipy.stats import norm
+import scipy.optimize
+import scipy.special
+import scipy.stats
 
 __all__ = [
     "significance_to_probability_normal",
@@ -44,7 +44,7 @@ def significance_to_probability_normal(significance):
     >>> significance_to_probability_normal(10)
     7.6198530241604696e-24
     """
-    return norm.sf(significance)
+    return scipy.stats.norm.sf(significance)
 
 
 def probability_to_significance_normal(probability):
@@ -70,7 +70,7 @@ def probability_to_significance_normal(probability):
     >>> probability_to_significance_normal(1e-10)
     6.3613409024040557
     """
-    return norm.isf(probability)
+    return scipy.stats.norm.isf(probability)
 
 
 def _p_to_s_direct(probability, one_sided=True):
@@ -80,7 +80,7 @@ def _p_to_s_direct(probability, one_sided=True):
     """
     probability = 1 - probability  # We want p to be the tail probability
     temp = np.where(one_sided, 2 * probability - 1, probability)
-    return np.sqrt(2) * erfinv(temp)
+    return np.sqrt(2) * scipy.special.erfinv(temp)
 
 
 def _s_to_p_direct(significance, one_sided=True):
@@ -88,7 +88,7 @@ def _s_to_p_direct(significance, one_sided=True):
 
     Note: _p_to_s_direct was solved for p.
     """
-    temp = erf(significance / np.sqrt(2))
+    temp = scipy.special.erf(significance / np.sqrt(2))
     probability = np.where(one_sided, (temp + 1) / 2.0, temp)
     return 1 - probability  # We want p to be the tail probability
 
@@ -120,4 +120,4 @@ def significance_to_probability_normal_limit(significance, guess=1e-100):
         else:
             return 1e100
 
-    return fsolve(f, guess)
+    return scipy.optimize.fsolve(f, guess)

--- a/gammapy/stats/poisson.py
+++ b/gammapy/stats/poisson.py
@@ -5,9 +5,9 @@
 * background estimated from ``n_off`
 """
 import numpy as np
-from scipy.optimize import fsolve
-from scipy.special import erf
-from scipy.stats import norm, poisson
+import scipy.optimize
+import scipy.special
+import scipy.stats
 from .normal import significance_to_probability_normal
 
 __all__ = [
@@ -340,10 +340,10 @@ def _significance_direct(n_on, mu_bkg):
     # for n_on included or more, because `poisson.sf(k)` returns the
     # probability for more than k, with k excluded
     # For `n_on = 0` this returns `
-    probability = poisson.sf(n_on - 1, mu_bkg)
+    probability = scipy.stats.poisson.sf(n_on - 1, mu_bkg)
 
     # Convert probability to a significance
-    return norm.isf(probability)
+    return scipy.stats.norm.isf(probability)
 
 
 def _significance_direct_on_off(n_on, n_off, alpha):
@@ -368,7 +368,7 @@ def _significance_direct_on_off(n_on, n_off, alpha):
         probability -= term_1 * term_2
 
     # Convert probability to a significance
-    return norm.isf(probability)
+    return scipy.stats.norm.isf(probability)
 
 
 def excess_ul_helene(excess, excess_error, significance):
@@ -400,33 +400,33 @@ def excess_ul_helene(excess, excess_error, significance):
     if excess >= 0.0:
         zeta = excess / excess_error
         value = zeta / np.sqrt(2.0)
-        integral = (1.0 + erf(value)) / 2.0
+        integral = (1.0 + scipy.special.erf(value)) / 2.0
         integral2 = 1.0 - conf_level1 * integral
         value_old = value
         value_new = value_old + 0.01
         if integral > integral2:
             value_new = 0.0
-        integral = (1.0 + erf(value_new)) / 2.0
+        integral = (1.0 + scipy.special.erf(value_new)) / 2.0
     else:
         zeta = -excess / excess_error
         value = zeta / np.sqrt(2.0)
-        integral = 1 - (1.0 + erf(value)) / 2.0
+        integral = 1 - (1.0 + scipy.special.erf(value)) / 2.0
         integral2 = 1.0 - conf_level1 * integral
         value_old = value
         value_new = value_old + 0.01
-        integral = (1.0 + erf(value_new)) / 2.0
+        integral = (1.0 + scipy.special.erf(value_new)) / 2.0
 
     # The 1st Loop is for Speed & 2nd For Precision
     while integral < integral2:
         value_old = value_new
         value_new = value_new + 0.01
-        integral = (1.0 + erf(value_new)) / 2.0
+        integral = (1.0 + scipy.special.erf(value_new)) / 2.0
     value_new = value_old + 0.0000001
-    integral = (1.0 + erf(value_new)) / 2.0
+    integral = (1.0 + scipy.special.erf(value_new)) / 2.0
 
     while integral < integral2:
         value_new = value_new + 0.0000001
-        integral = (1.0 + erf(value_new)) / 2.0
+        integral = (1.0 + scipy.special.erf(value_new)) / 2.0
     value_new = value_new * np.sqrt(2.0)
 
     if excess >= 0.0:
@@ -567,7 +567,7 @@ def _excess_matching_significance_lima(mu_bkg, significance):
 
     # solver options to control robustness / accuracy / speed
     opts = dict(factor=0.1)
-    n_on = fsolve(target_significance, n_on_guess, **opts)
+    n_on = scipy.optimize.fsolve(target_significance, n_on_guess, **opts)
     return n_on - mu_bkg
 
 
@@ -592,7 +592,7 @@ def _excess_matching_significance_on_off_lima(n_off, alpha, significance):
 
     # solver options to control robustness / accuracy / speed
     opts = dict(factor=0.1)
-    n_on = fsolve(target_significance, n_on_guess, **opts)
+    n_on = scipy.optimize.fsolve(target_significance, n_on_guess, **opts)
     return n_on - background(n_off, alpha)
 
 

--- a/gammapy/stats/tests/test_data.py
+++ b/gammapy/stats/tests/test_data.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
-from ...stats import Stats
+from gammapy.stats import Stats
 
 
 @pytest.fixture

--- a/gammapy/stats/tests/test_feldman_cousins.py
+++ b/gammapy/stats/tests/test_feldman_cousins.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 import scipy.stats
 from numpy.testing import assert_allclose
-from ...stats import (
+from gammapy.stats import (
     fc_construct_acceptance_intervals,
     fc_construct_acceptance_intervals_pdfs,
     fc_find_acceptance_interval_gauss,

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from ... import stats
+from gammapy import stats
 
 
 @pytest.fixture

--- a/gammapy/stats/tests/test_normal.py
+++ b/gammapy/stats/tests/test_normal.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
-from ...stats import (
+from gammapy.stats import (
     probability_to_significance_normal,
     probability_to_significance_normal_limit,
     significance_to_probability_normal,

--- a/gammapy/stats/tests/test_poisson.py
+++ b/gammapy/stats/tests/test_poisson.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from ..poisson import (
+from gammapy.stats import (
     background,
     background_error,
     excess,

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
-from ..utils.scripts import make_path
+from gammapy.utils.scripts import make_path
 
 __all__ = ["LightCurve"]
 

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -2,11 +2,11 @@
 import logging
 from collections import OrderedDict
 import numpy as np
-from ..spectrum import FluxPoints, SpectrumDatasetOnOff
-from ..spectrum.models import ScaleModel
-from ..time import LightCurve
-from ..utils.fitting import Datasets, Fit
-from ..utils.table import table_from_row_data
+from gammapy.spectrum import FluxPoints, SpectrumDatasetOnOff
+from gammapy.spectrum.models import ScaleModel
+from gammapy.time import LightCurve
+from gammapy.utils.fitting import Datasets, Fit
+from gammapy.utils.table import table_from_row_data
 
 __all__ = ["LightCurveEstimator"]
 

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.interpolate import InterpolatedUnivariateSpline
+import scipy.interpolate
 from astropy import units as u
 from astropy.table import Table
 from astropy.utils import lazyproperty
@@ -196,7 +196,7 @@ class LightCurveTableModel(Model):
     def _interpolator(self):
         x = self.table["TIME"].data
         y = self.table["NORM"].data
-        return InterpolatedUnivariateSpline(x, y, k=1)
+        return scipy.interpolate.InterpolatedUnivariateSpline(x, y, k=1)
 
     @lazyproperty
     def _time_ref(self):

--- a/gammapy/time/models.py
+++ b/gammapy/time/models.py
@@ -4,9 +4,9 @@ import scipy.interpolate
 from astropy import units as u
 from astropy.table import Table
 from astropy.utils import lazyproperty
-from ..utils.fitting import Model, Parameter
-from ..utils.scripts import make_path
-from ..utils.time import time_ref_from_dict
+from gammapy.utils.fitting import Model, Parameter
+from gammapy.utils.scripts import make_path
+from gammapy.utils.time import time_ref_from_dict
 
 __all__ = ["PhaseCurveTableModel", "LightCurveTableModel"]
 

--- a/gammapy/time/period.py
+++ b/gammapy/time/period.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from collections import OrderedDict
 import numpy as np
-from scipy.optimize import least_squares
+import scipy.optimize
 
 __all__ = ["robust_periodogram", "plot_periodogram"]
 
@@ -123,14 +123,14 @@ def _robust_regression(time, flux, flux_err, periods, loss, scale):
     chi_noise = np.empty([len(periods)])
 
     for i in range(len(periods)):
-        chi_model[i] = least_squares(
+        chi_model[i] = scipy.optimize.least_squares(
             _model,
             beta0,
             loss=loss,
             f_scale=scale,
             args=(x, periods[i], time, flux, flux_err),
         ).cost
-        chi_noise[i] = least_squares(
+        chi_noise[i] = scipy.optimize.least_squares(
             _noise, mu, loss=loss, f_scale=scale, args=(time, flux, flux_err)
         ).cost
     power = 1 - chi_model / chi_noise

--- a/gammapy/time/simulate.py
+++ b/gammapy/time/simulate.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.time import TimeDelta
-from ..utils.random import get_random_state
+from gammapy.utils.random import get_random_state
 
 __all__ = ["random_times"]
 

--- a/gammapy/time/tests/test_events.py
+++ b/gammapy/time/tests/test_events.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.units import Quantity
-from ..events import exptest
-from ..simulate import random_times
+from gammapy.time import exptest, random_times
 
 
 def test_exptest():

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from datetime import datetime, timedelta
+import datetime
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -142,8 +142,11 @@ def test_lightcurve_plot_flux_ul(lc, flux_unit):
         (
             "iso",
             (
-                [datetime(2010, 1, 2), datetime(2010, 1, 6, 12)],
-                ([timedelta(1), timedelta(3.5)], [timedelta(1), timedelta(3.5)]),
+                [datetime.datetime(2010, 1, 2), datetime.datetime(2010, 1, 6, 12)],
+                (
+                    [datetime.timedelta(1), datetime.timedelta(3.5)],
+                    [datetime.timedelta(1), datetime.timedelta(3.5)],
+                ),
             ),
         ),
     ],

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -6,19 +6,18 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
-from ...spectrum.models import PowerLaw
-from ...spectrum.tests.test_flux_point_estimator import (
+from gammapy.spectrum.models import PowerLaw
+from gammapy.spectrum.tests.test_flux_point_estimator import (
     simulate_map_dataset,
     simulate_spectrum_dataset,
 )
-from ...utils.testing import (
+from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
     requires_data,
     requires_dependency,
 )
-from ..lightcurve import LightCurve
-from ..lightcurve_estimator import LightCurveEstimator
+from gammapy.time import LightCurve, LightCurveEstimator
 
 # time time_min time_max flux flux_err flux_ul
 # 48705.1757 48705.134 48705.2174 0.57 0.29 nan

--- a/gammapy/time/tests/test_models.py
+++ b/gammapy/time/tests/test_models.py
@@ -2,9 +2,9 @@
 import pytest
 from numpy.testing import assert_allclose
 from astropy.table import Table
-from ...utils.scripts import make_path
-from ...utils.testing import requires_data
-from ..models import LightCurveTableModel, PhaseCurveTableModel
+from gammapy.utils.scripts import make_path
+from gammapy.utils.testing import requires_data
+from gammapy.time.models import LightCurveTableModel, PhaseCurveTableModel
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.stats import LombScargle
-from ...utils.testing import requires_dependency
-from ..period import plot_periodogram, robust_periodogram
+from gammapy.utils.testing import requires_dependency
+from gammapy.time import plot_periodogram, robust_periodogram
 
 pytest.importorskip("astropy", "3.0")
 

--- a/gammapy/time/tests/test_simulate.py
+++ b/gammapy/time/tests/test_simulate.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_almost_equal
 from astropy.units import Quantity
-from ..simulate import random_times
+from gammapy.time import random_times
 
 
 def test_random_times():

--- a/gammapy/utils/coordinates/tests/test_fov.py
+++ b/gammapy/utils/coordinates/tests/test_fov.py
@@ -1,20 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
-from astropy.units import deg
-from ..fov import fov_to_sky, sky_to_fov
+import astropy.units as u
+from gammapy.utils.coordinates import fov_to_sky, sky_to_fov
 
 
 def test_fov_to_sky():
     # test some simple cases
-    az, alt = fov_to_sky(1 * deg, 1 * deg, 0 * deg, 0 * deg)
+    az, alt = fov_to_sky(1 * u.deg, 1 * u.deg, 0 * u.deg, 0 * u.deg)
     assert_allclose(az.value, 359)
     assert_allclose(alt.value, 1)
 
-    az, alt = fov_to_sky(-1 * deg, 1 * deg, 180 * deg, 0 * deg)
+    az, alt = fov_to_sky(-1 * u.deg, 1 * u.deg, 180 * u.deg, 0 * u.deg)
     assert_allclose(az.value, 181)
     assert_allclose(alt.value, 1)
 
-    az, alt = fov_to_sky(1 * deg, 0 * deg, 0 * deg, 60 * deg)
+    az, alt = fov_to_sky(1 * u.deg, 0 * u.deg, 0 * u.deg, 60 * u.deg)
     assert_allclose(az.value, 358, rtol=1e-3)
     assert_allclose(alt.value, 59.985, rtol=1e-3)
 
@@ -25,7 +25,7 @@ def test_fov_to_sky():
     az_pointing = [52.42056255, 52.24706061, 52.06655505, 51.86795724]
     alt_pointing = [51.11908203, 51.23454751, 51.35376141, 51.48385814]
     az, alt = fov_to_sky(
-        fov_altaz_lon * deg, fov_altaz_lat * deg, az_pointing * deg, alt_pointing * deg
+        fov_altaz_lon * u.deg, fov_altaz_lat * u.deg, az_pointing * u.deg, alt_pointing * u.deg
     )
     assert_allclose(az.value, [51.320575, 50.899125, 52.154053, 48.233023])
     assert_allclose(alt.value, [49.505451, 50.030165, 51.811739, 54.700102])
@@ -33,15 +33,15 @@ def test_fov_to_sky():
 
 def test_sky_to_fov():
     # test some simple cases
-    lon, lat = sky_to_fov(1 * deg, 1 * deg, 0 * deg, 0 * deg)
+    lon, lat = sky_to_fov(1 * u.deg, 1 * u.deg, 0 * u.deg, 0 * u.deg)
     assert_allclose(lon.value, -1)
     assert_allclose(lat.value, 1)
 
-    lon, lat = sky_to_fov(269 * deg, 0 * deg, 270 * deg, 0 * deg)
+    lon, lat = sky_to_fov(269 * u.deg, 0 * u.deg, 270 * u.deg, 0 * u.deg)
     assert_allclose(lon.value, 1)
     assert_allclose(lat.value, 0, atol=1e-7)
 
-    lon, lat = sky_to_fov(1 * deg, 60 * deg, 0 * deg, 60 * deg)
+    lon, lat = sky_to_fov(1 * u.deg, 60 * u.deg, 0 * u.deg, 60 * u.deg)
     assert_allclose(lon.value, -0.5, rtol=1e-3)
     assert_allclose(lat.value, 0.003779, rtol=1e-3)
 
@@ -51,7 +51,7 @@ def test_sky_to_fov():
     alt = [49.505451, 50.030165, 51.811739, 54.700102]
     az_pointing = [52.42056255, 52.24706061, 52.06655505, 51.86795724]
     alt_pointing = [51.11908203, 51.23454751, 51.35376141, 51.48385814]
-    lon, lat = sky_to_fov(az * deg, alt * deg, az_pointing * deg, alt_pointing * deg)
+    lon, lat = sky_to_fov(az * u.deg, alt * u.deg, az_pointing * u.deg, alt_pointing * u.deg)
     assert_allclose(
         lon.value, [0.7145614, 0.86603433, -0.05409698, 2.10295248], rtol=1e-5
     )

--- a/gammapy/utils/coordinates/tests/test_other.py
+++ b/gammapy/utils/coordinates/tests/test_other.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.units import Quantity
-from ...coordinates import galactic
+from gammapy.utils.coordinates import galactic
 
 
 def test_galactic():

--- a/gammapy/utils/fitting/parameter.py
+++ b/gammapy/utils/fitting/parameter.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy import units as u
 from astropy.table import Table
 from astropy.units.core import UnitConversionError
-from ..array import check_type
+from gammapy.utils.array import check_type
 
 __all__ = ["Parameter", "Parameters"]
 

--- a/gammapy/utils/fitting/sampling.py
+++ b/gammapy/utils/fitting/sampling.py
@@ -2,8 +2,6 @@
 """MCMC sampling helper functions using ``emcee``."""
 import logging
 import numpy as np
-import corner
-import emcee
 
 __all__ = ["uniform_prior", "run_mcmc", "plot_trace", "plot_corner"]
 
@@ -81,6 +79,8 @@ def run_mcmc(dataset, nwalkers=8, nrun=1000, threads=1):
     sampler : `emcee.EnsembleSampler`
         sampler object containing the trace of all walkers.
     """
+    import emcee
+
     dataset.parameters.autoscale()  # Autoscale parameters
     pars = [par.factor for par in dataset.parameters.free_parameters]
     ndim = len(pars)
@@ -154,8 +154,10 @@ def plot_corner(sampler, dataset, nburn=0):
     nburn : int
         Number of runs to discard, because considered part of the burn-in phase
     """
+    from corner import corner
+
     labels = [par.name for par in dataset.parameters.free_parameters]
 
     samples = sampler.chain[:, nburn:, :].reshape((-1, len(labels)))
 
-    corner.corner(samples, labels=labels, quantiles=[0.16, 0.5, 0.84], show_titles=True)
+    corner(samples, labels=labels, quantiles=[0.16, 0.5, 0.84], show_titles=True)

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import scipy.optimize
-from ..interpolation import interpolate_likelihood_profile
+from gammapy.utils.interpolation import interpolate_likelihood_profile
 from .likelihood import Likelihood
 
 __all__ = [

--- a/gammapy/utils/fitting/scipy.py
+++ b/gammapy/utils/fitting/scipy.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from scipy.optimize import brentq, minimize
-from scipy.optimize.zeros import RootResults
+import scipy.optimize
 from ..interpolation import interpolate_likelihood_profile
 from .likelihood import Likelihood
 
@@ -24,7 +23,9 @@ def optimize_scipy(parameters, function, **kwargs):
         bounds.append((parmin, parmax))
 
     likelihood = Likelihood(function, parameters)
-    result = minimize(likelihood.fcn, pars, bounds=bounds, method=method, **kwargs)
+    result = scipy.optimize.minimize(
+        likelihood.fcn, pars, bounds=bounds, method=method, **kwargs
+    )
 
     factors = result.x
     info = {"success": result.success, "message": result.message, "nfev": result.nfev}
@@ -76,7 +77,7 @@ def _confidence_scipy_brentq(
     message, success = "Confidence terminated successfully.", True
 
     try:
-        result = brentq(ts_diff.fcn, full_output=True, **kwargs)
+        result = scipy.optimize.brentq(ts_diff.fcn, full_output=True, **kwargs)
     except ValueError:
         message = (
             "Confidence estimation failed, because bracketing interval"
@@ -85,7 +86,9 @@ def _confidence_scipy_brentq(
         success = False
         result = (
             np.nan,
-            RootResults(root=np.nan, iterations=0, function_calls=0, flag=0),
+            scipy.optimize.RootResults(
+                root=np.nan, iterations=0, function_calls=0, flag=0
+            ),
         )
 
     suffix = "errp" if upper else "errn"
@@ -169,6 +172,6 @@ def likelihood_profile_ul_scipy(
 
     idx = np.argmin(dloglike_scan)
     norm_best_fit = value_scan[idx]
-    ul = brentq(f, a=norm_best_fit, b=value_scan[-1], **kwargs)
+    ul = scipy.optimize.brentq(f, a=norm_best_fit, b=value_scan[-1], **kwargs)
 
     return ul

--- a/gammapy/utils/fitting/tests/test_datasets.py
+++ b/gammapy/utils/fitting/tests/test_datasets.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
-from ..datasets import Datasets
+from gammapy.utils.fitting import Datasets
 from .test_fit import MyDataset
 
 

--- a/gammapy/utils/fitting/tests/test_fit.py
+++ b/gammapy/utils/fitting/tests/test_fit.py
@@ -2,9 +2,8 @@
 """Unit tests for the Fit class"""
 import pytest
 from numpy.testing import assert_allclose
-from ...testing import requires_dependency
-from ..fit import Fit
-from ..parameter import Parameter, Parameters
+from gammapy.utils.testing import requires_dependency
+from gammapy.utils.fitting import Fit, Parameter, Parameters
 
 pytest.importorskip("iminuit")
 

--- a/gammapy/utils/fitting/tests/test_iminuit.py
+++ b/gammapy/utils/fitting/tests/test_iminuit.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from .. import Parameter, Parameters, confidence_iminuit, optimize_iminuit
+from gammapy.utils.fitting import Parameter, Parameters, confidence_iminuit, optimize_iminuit
 
 pytest.importorskip("iminuit")
 

--- a/gammapy/utils/fitting/tests/test_model.py
+++ b/gammapy/utils/fitting/tests/test_model.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ..model import Model
-from ..parameter import Parameter, Parameters
+from gammapy.utils.fitting import Model, Parameter, Parameters
 
 
 class MyModel(Model):

--- a/gammapy/utils/fitting/tests/test_parameter.py
+++ b/gammapy/utils/fitting/tests/test_parameter.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from .. import Parameter, Parameters
+from gammapy.utils.fitting import Parameter, Parameters
 
 
 def test_parameter_init():

--- a/gammapy/utils/fitting/tests/test_scipy.py
+++ b/gammapy/utils/fitting/tests/test_scipy.py
@@ -2,7 +2,7 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from .. import (
+from gammapy.utils.fitting import (
     Parameter,
     Parameters,
     confidence_scipy,

--- a/gammapy/utils/fitting/tests/test_sherpa.py
+++ b/gammapy/utils/fitting/tests/test_sherpa.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
-from .. import Parameter, Parameters, optimize_sherpa
+from gammapy.utils.fitting import Parameter, Parameters, optimize_sherpa
 
 pytest.importorskip("sherpa")
 

--- a/gammapy/utils/gauss.py
+++ b/gammapy/utils/gauss.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Multi-Gaussian distribution utilities (Gammapy internal)."""
 import numpy as np
-from scipy.optimize import brentq
+import scipy.optimize
 
 
 class Gauss2DPDF:
@@ -302,7 +302,7 @@ class MultiGauss2D:
         # Expand until we really find a theta_max
         while f(theta_max) < 0:
             theta_max *= 2
-        return brentq(f, a=0, b=theta_max)
+        return scipy.optimize.brentq(f, a=0, b=theta_max)
 
     def match_sigma(self, containment_fraction):
         """Compute equivalent Gauss width.

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Interpolation utilities"""
 import numpy as np
-from scipy.interpolate import RegularGridInterpolator, interp1d
+import scipy.interpolate
 from astropy import units as u
 
 __all__ = [
@@ -60,11 +60,13 @@ class ScaledRegularGridInterpolator:
             kwargs.setdefault("fill_value", None)
 
         if axis is None:
-            self._interpolate = RegularGridInterpolator(
+            self._interpolate = scipy.interpolate.RegularGridInterpolator(
                 points=points_scaled, values=values_scaled, **kwargs
             )
         else:
-            self._interpolate = interp1d(points_scaled[0], values_scaled, axis=axis)
+            self._interpolate = scipy.interpolate.interp1d(
+                points_scaled[0], values_scaled, axis=axis
+            )
 
     def __call__(self, points, method="linear", clip=True, **kwargs):
         """Interpolate data points.

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -193,13 +193,11 @@ def interpolate_likelihood_profile(value_scan, dloglike_scan, interp_scale="sqrt
     -------
     interp : `ScaledRegularGridInterpolator`
         Interpolator instance.
-
     """
     # likelihood profiles are typically of parabolic shape, so we use a
     # sqrt scaling of the values and perform linear interpolation on the scaled
     # values
     sign = np.sign(np.gradient(dloglike_scan))
-    interp = ScaledRegularGridInterpolator(
+    return ScaledRegularGridInterpolator(
         points=(value_scan,), values=sign * dloglike_scan, values_scale=interp_scale
     )
-    return interp

--- a/gammapy/utils/random/tests/test_inverse_cdf.py
+++ b/gammapy/utils/random/tests/test_inverse_cdf.py
@@ -6,13 +6,13 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
-from ....cube import MapEvaluator
-from ....cube.models import SkyModel
-from ....image.models import SkyGaussian
-from ....maps import Map, MapAxis
-from ....spectrum.models import PowerLaw
-from ....time.models import LightCurveTableModel
-from ..inverse_cdf import InverseCDFSampler, MapEventSampler
+from gammapy.cube import MapEvaluator
+from gammapy.cube.models import SkyModel
+from gammapy.image.models import SkyGaussian
+from gammapy.maps import Map, MapAxis
+from gammapy.spectrum.models import PowerLaw
+from gammapy.time.models import LightCurveTableModel
+from gammapy.utils.random import InverseCDFSampler, MapEventSampler
 
 
 def uniform_dist(x, a, b):

--- a/gammapy/utils/random/tests/test_random.py
+++ b/gammapy/utils/random/tests/test_random.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import Angle
-from ....utils.testing import assert_quantity_allclose
+from gammapy.utils.testing import assert_quantity_allclose
 from ..utils import sample_powerlaw, sample_sphere, sample_sphere_distance
 
 

--- a/gammapy/utils/random/utils.py
+++ b/gammapy/utils/random/utils.py
@@ -2,7 +2,7 @@
 """Helper functions to work with distributions."""
 import numbers
 import numpy as np
-from scipy.integrate import quad
+import scipy.integrate
 from astropy.coordinates import Angle
 
 __all__ = [
@@ -21,7 +21,7 @@ def normalize(func, x_min, x_max):
     """Normalize a 1D function over a given range."""
 
     def f(x):
-        return func(x) / quad(func, x_min, x_max)[0]
+        return func(x) / scipy.integrate.quad(func, x_min, x_max)[0]
 
     return f
 

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -2,7 +2,7 @@
 """Utils to create scripts and command-line tools"""
 import logging
 import sys
-from os.path import expandvars
+import os.path
 from pathlib import Path
 import yaml
 
@@ -97,7 +97,7 @@ def make_path(path):
     # TODO: raise error or warning if environment variables that don't resolve are used
     # e.g. "spam/$DAMN/ham" where `$DAMN` is not defined
     # Otherwise this can result in cryptic errors later on
-    return Path(expandvars(str(path)))
+    return Path(os.path.expandvars(str(path)))
 
 
 def recursive_merge_dicts(a, b):

--- a/gammapy/utils/scripts_test.py
+++ b/gammapy/utils/scripts_test.py
@@ -5,8 +5,8 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+import pkg_resources
 import yaml
-from pkg_resources import working_set
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def requirement_missing(script):
             return False
         for package in script["requires"].split():
             try:
-                working_set.require(package)
+                pkg_resources.working_set.require(package)
             except Exception:
                 return True
     return False

--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -10,6 +10,7 @@ from astropy.time import Time
 __all__ = [
     "requires_dependency",
     "requires_data",
+    "mpl_plot_check",
     "assert_quantity_allclose",
     "assert_wcs_allclose",
     "assert_skycoord_allclose",

--- a/gammapy/utils/tests/test_array.py
+++ b/gammapy/utils/tests/test_array.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from ..array import array_stats_str, shape_2N
+from gammapy.utils.array import array_stats_str, shape_2N
 
 
 def test_array_stats_str():

--- a/gammapy/utils/tests/test_energy.py
+++ b/gammapy/utils/tests/test_energy.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy import units as u
-from ..energy import energy_logcenter, energy_logspace
+from gammapy.utils.energy import energy_logcenter, energy_logspace
 
 
 def test_energy_logspace():

--- a/gammapy/utils/tests/test_fits.py
+++ b/gammapy/utils/tests/test_fits.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from astropy.io import fits
 from astropy.table import Column, Table
-from ..fits import SmartHDUList
+from gammapy.utils.fits import SmartHDUList
 
 
 def make_test_hdu_list():

--- a/gammapy/utils/tests/test_gauss.py
+++ b/gammapy/utils/tests/test_gauss.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
+import scipy.integrate
 from numpy.testing import assert_almost_equal, assert_equal
-from scipy.integrate import dblquad, quad
 from ..gauss import Gauss2DPDF, MultiGauss2D
 
 
@@ -21,15 +21,15 @@ class TestGauss2DPDF:
             assert_almost_equal(actual, desired)
             # Check that distribution integrates to 1
             xy_max = 5 * g.sigma  # integration range
-            integral = dblquad(g, -xy_max, xy_max, lambda _: -xy_max, lambda _: xy_max)[
-                0
-            ]
+            integral = scipy.integrate.dblquad(
+                g, -xy_max, xy_max, lambda _: -xy_max, lambda _: xy_max
+            )[0]
             assert_almost_equal(integral, 1, decimal=5)
 
     def test_dpdtheta2(self):
         for g in self.gs:
             theta2_max = (7 * g.sigma) ** 2
-            integral = quad(g.dpdtheta2, 0, theta2_max)[0]
+            integral = scipy.integrate.quad(g.dpdtheta2, 0, theta2_max)[0]
             assert_almost_equal(integral, 1, decimal=5)
 
     def test_containment(self):
@@ -59,14 +59,16 @@ class TestMultiGauss2D:
     def test_call():
         m = MultiGauss2D(sigmas=[1, 2], norms=[3, 4])
         xy_max = 5 * m.max_sigma  # integration range
-        integral = dblquad(m, -xy_max, xy_max, lambda _: -xy_max, lambda _: xy_max)[0]
+        integral = scipy.integrate.dblquad(
+            m, -xy_max, xy_max, lambda _: -xy_max, lambda _: xy_max
+        )[0]
         assert_almost_equal(integral, 7, decimal=5)
 
     @staticmethod
     def test_dpdtheta2():
         m = MultiGauss2D(sigmas=[1, 2], norms=[3, 4])
         theta2_max = (7 * m.max_sigma) ** 2
-        integral = quad(m.dpdtheta2, 0, theta2_max)[0]
+        integral = scipy.integrate.quad(m.dpdtheta2, 0, theta2_max)[0]
         assert_almost_equal(integral, 7, decimal=5)
 
     @staticmethod

--- a/gammapy/utils/tests/test_gauss.py
+++ b/gammapy/utils/tests/test_gauss.py
@@ -2,7 +2,7 @@
 import numpy as np
 import scipy.integrate
 from numpy.testing import assert_almost_equal, assert_equal
-from ..gauss import Gauss2DPDF, MultiGauss2D
+from gammapy.utils.gauss import Gauss2DPDF, MultiGauss2D
 
 
 class TestGauss2DPDF:

--- a/gammapy/utils/tests/test_nddata.py
+++ b/gammapy/utils/tests/test_nddata.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from ...maps import MapAxis
-from ..nddata import NDDataArray
+from gammapy.maps import MapAxis
+from gammapy.utils.nddata import NDDataArray
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/utils/tests/test_regions.py
+++ b/gammapy/utils/tests/test_regions.py
@@ -12,8 +12,8 @@ from numpy.testing import assert_allclose, assert_equal
 import astropy.units as u
 import regions
 from astropy.coordinates import SkyCoord
-from ...maps import WcsGeom
-from ..regions import SphericalCircleSkyRegion, make_pixel_region, make_region
+from gammapy.maps import WcsGeom
+from gammapy.utils.regions import SphericalCircleSkyRegion, make_pixel_region, make_region
 
 
 def test_make_region():

--- a/gammapy/utils/tests/test_scripts.py
+++ b/gammapy/utils/tests/test_scripts.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ...utils.scripts import recursive_merge_dicts
+from gammapy.utils.scripts import recursive_merge_dicts
 
 
 def test_recursive_merge_dicts():

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -4,7 +4,7 @@ import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Column, Table
-from ..table import table_from_row_data, table_row_to_dict, table_standardise_units_copy
+from gammapy.utils.table import table_from_row_data, table_row_to_dict, table_standardise_units_copy
 
 
 def test_table_standardise_units():

--- a/gammapy/utils/tests/test_time.py
+++ b/gammapy/utils/tests/test_time.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
 from astropy.time import Time, TimeDelta
-from ..time import (
+from gammapy.utils.time import (
     absolute_time,
     time_ref_from_dict,
     time_ref_to_dict,

--- a/gammapy/utils/tests/test_units.py
+++ b/gammapy/utils/tests/test_units.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ..units import standardise_unit
+from gammapy.utils.units import standardise_unit
 
 
 def test_standardise_unit():

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from distutils.util import strtobool
 from pathlib import Path
-from ..scripts.jupyter import notebook_test
+from gammapy.scripts.jupyter import notebook_test
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -3,11 +3,11 @@
 import argparse
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from distutils.util import strtobool
 from pathlib import Path
-from shutil import copyfile, copytree, rmtree
 from ..scripts.jupyter import notebook_test
 
 log = logging.getLogger(__name__)
@@ -55,20 +55,20 @@ def build_notebooks(args):
     path_filled_nbs = Path("docs") / "notebooks"
     path_static_nbs = Path("docs") / "_static" / "notebooks"
 
-    rmtree(str(path_temp), ignore_errors=True)
+    shutil.rmtree(str(path_temp), ignore_errors=True)
     path_temp.mkdir(parents=True, exist_ok=True)
     path_filled_nbs.mkdir(parents=True, exist_ok=True)
     path_static_nbs.mkdir(parents=True, exist_ok=True)
 
     if pathsrc == path_empty_nbs:
-        rmtree(str(path_temp), ignore_errors=True)
-        rmtree(str(path_static_nbs), ignore_errors=True)
-        rmtree(str(path_filled_nbs), ignore_errors=True)
-        copytree(str(path_empty_nbs), str(path_temp), ignore=ignorefiles)
+        shutil.rmtree(str(path_temp), ignore_errors=True)
+        shutil.rmtree(str(path_static_nbs), ignore_errors=True)
+        shutil.rmtree(str(path_filled_nbs), ignore_errors=True)
+        shutil.copytree(str(path_empty_nbs), str(path_temp), ignore=ignorefiles)
     elif pathsrc.exists():
         notebookname = pathsrc.name
         pathdest = path_temp / notebookname
-        copyfile(str(pathsrc), str(pathdest))
+        shutil.copyfile(str(pathsrc), str(pathdest))
     else:
         log.info("Notebook file does not exist.")
         sys.exit()
@@ -88,7 +88,7 @@ def build_notebooks(args):
     # copy generated filled notebooks to doc
     if pathsrc == path_empty_nbs:
         # copytree is needed to copy subfolder images
-        copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignorefiles)
+        shutil.copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignorefiles)
         for path in path_static_nbs.glob("*.ipynb"):
             subprocess.run(
                 [
@@ -101,11 +101,11 @@ def build_notebooks(args):
                     str(path),
                 ]
             )
-        copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
+        shutil.copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
     else:
         pathsrc = path_temp / notebookname
         pathdest = path_static_nbs / notebookname
-        copyfile(str(pathsrc), str(pathdest))
+        shutil.copyfile(str(pathsrc), str(pathdest))
         subprocess.run(
             [
                 sys.executable,
@@ -118,10 +118,10 @@ def build_notebooks(args):
             ]
         )
         pathdest = path_filled_nbs / notebookname
-        copyfile(str(pathsrc), str(pathdest))
+        shutil.copyfile(str(pathsrc), str(pathdest))
 
     # tear down
-    rmtree(str(path_temp), ignore_errors=True)
+    shutil.rmtree(str(path_temp), ignore_errors=True)
 
 
 def main():

--- a/gammapy/utils/tutorials_test.py
+++ b/gammapy/utils/tutorials_test.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 import pkg_resources
 import yaml
-from ..scripts.jupyter import notebook_test
+from gammapy.scripts.jupyter import notebook_test
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/utils/tutorials_test.py
+++ b/gammapy/utils/tutorials_test.py
@@ -2,11 +2,11 @@
 """Test if Jupyter notebooks work."""
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
-from shutil import copytree, rmtree
+import pkg_resources
 import yaml
-from pkg_resources import working_set
 from ..scripts.jupyter import notebook_test
 
 log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def requirement_missing(notebook):
             return False
         for package in notebook["requires"].split():
             try:
-                working_set.require(package)
+                pkg_resources.working_set.require(package)
             except Exception:
                 return True
     return False
@@ -46,8 +46,8 @@ def main():
     # setup
     path_temp = Path("temp")
     path_empty_nbs = Path("tutorials")
-    rmtree(str(path_temp), ignore_errors=True)
-    copytree(str(path_empty_nbs), str(path_temp))
+    shutil.rmtree(str(path_temp), ignore_errors=True)
+    shutil.copytree(str(path_empty_nbs), str(path_temp))
 
     for notebook in get_notebooks():
         if requirement_missing(notebook):
@@ -65,7 +65,7 @@ def main():
             passed = False
 
     # tear down
-    rmtree(str(path_temp), ignore_errors=True)
+    shutil.rmtree(str(path_temp), ignore_errors=True)
 
     if not passed:
         sys.exit("Some tests failed. Existing now.")


### PR DESCRIPTION
This PR changes from relative to absolute imports throughout Gammapy. Except local same-module imports.

Before:
```
from ...table import table_row_to_dict
from .core import SourceCatalog, SourceCatalogObject
```

After:
```
from gammapy.utils.table import table_row_to_dict
from .core import SourceCatalog, SourceCatalogObject
```

This is following the lead of Astropy: https://github.com/astropy/astropy/pull/8200

IMO the absolute imports do have some real advantages:
- Imports within Gammapy (especially tests) are mostly the same as outside (examples, notebooks), making it easier to read and recognise and copy & paste
- For me basically it's a guessing game whether I should type `..` or `...` or `....` and I find it weird that it's different depending where I'm currently writing code, especially in tests

I didn't find a tool for this, so I'm going through all files top to bottom, it's work in progress.

@adonath - OK?