### PR TITLE
Move catalog test data to text files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,6 @@ test-nb:
 test-scripts:
 	python -m gammapy.utils.scripts_test
 
-data-update:
-	gammapy download datasets --out=$GAMMAPY_DATA
-
 clean-nb:
 	python -m gammapy jupyter --src=tutorials black
 	python -m gammapy jupyter --src=tutorials strip

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ test-nb:
 test-scripts:
 	python -m gammapy.utils.scripts_test
 
+data-update:
+	gammapy download datasets --out=$GAMMAPY_DATA
+
 clean-nb:
 	python -m gammapy jupyter --src=tutorials black
 	python -m gammapy jupyter --src=tutorials strip

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,6 @@ docs-all:
 docs-show:
 	open docs/_build/html/index.html
 
-# TODO: fix gammapy/catalog/tests/test_gammacat.py (move to ref txt file and exclude here?)
 trailing-spaces:
 	find $(PROJECT) examples docs -name "*.py" -exec perl -pi -e 's/[ \t]*$$//' {} \;
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -644,6 +644,7 @@ class SourceCatalogHGPS(SourceCatalog):
 
         self._table_components = Table.read(filename, hdu="HGPS_GAUSS_COMPONENTS")
         self._table_associations = Table.read(filename, hdu="HGPS_ASSOCIATIONS")
+        self._table_associations["Separation"].format = ".6f"
         self._table_identifications = Table.read(filename, hdu="HGPS_IDENTIFICATIONS")
         self._table_large_scale_component = Table.read(
             filename, hdu="HGPS_LARGE_SCALE_COMPONENT"

--- a/gammapy/catalog/registry.py
+++ b/gammapy/catalog/registry.py
@@ -68,8 +68,8 @@ class SourceCatalogRegistry:
 
     def __getitem__(self, name):
         if name not in self._available_catalogs:
-            msg = 'Unknown catalog: "{}". '.format(name)
-            msg += "Available catalogs: {}".format(self.catalog_names)
+            msg = 'Unknown catalog: {!r}. '.format(name)
+            msg += "Available catalogs: {!r}".format(self.catalog_names)
             raise KeyError(msg)
 
         if name not in self._loaded_catalogs:

--- a/gammapy/catalog/tests/data/2hwc_j0534+220.txt
+++ b/gammapy/catalog/tests/data/2hwc_j0534+220.txt
@@ -1,0 +1,22 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 0
+Source name:    : 2HWC J0534+220
+
+*** Position info ***
+
+RA                   : 83.628 deg
+DEC                  : 22.024 deg
+GLON                 : 184.547 deg
+GLAT                 : -5.783 deg
+Position error       : 0.057 deg
+
+*** Spectral info ***
+
+Spectrum 0:
+Flux at 7 TeV        : 1.85e-13 +- 2.38e-15 cm-2 s-1 TeV-1
+Spectral index       : -2.580 +- 0.010
+Test radius          : 0.0 deg
+
+No second spectrum available for this source

--- a/gammapy/catalog/tests/data/2hwc_j0631+169.txt
+++ b/gammapy/catalog/tests/data/2hwc_j0631+169.txt
@@ -1,0 +1,26 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 1
+Source name:    : 2HWC J0631+169
+
+*** Position info ***
+
+RA                   : 97.998 deg
+DEC                  : 16.997 deg
+GLON                 : 195.614 deg
+GLAT                 : 3.507 deg
+Position error       : 0.114 deg
+
+*** Spectral info ***
+
+Spectrum 0:
+Flux at 7 TeV        : 6.71e-15 +- 1.47e-15 cm-2 s-1 TeV-1
+Spectral index       : -2.570 +- 0.150
+Test radius          : 0.0 deg
+
+Spectrum 1:
+Flux at 7 TeV        : 4.87e-14 +- 6.85e-15 cm-2 s-1 TeV-1
+Spectral index       : -2.230 +- 0.080
+Test radius          : 2.0 deg
+

--- a/gammapy/catalog/tests/data/3fgl_J0000.1+6545.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0000.1+6545.txt
@@ -1,0 +1,57 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 0
+Source name          : 3FGL J0000.1+6545 
+Extended name        :                   
+Associations         : 
+Other names          : 2FGL J2359.6+6543c
+Class                :      
+TeVCat flag          : No TeV association
+Other flags          : Source-to-background ratio less than 10% in highest band in which TS > 25. Background is integrated over the 68%-confidence area (pi*r_682) or 1 square degree, whichever is smaller.
+
+*** Position info ***
+
+RA                   : 0.038 deg
+DEC                  : 65.752 deg
+GLON                 : 117.694 deg
+GLAT                 : 3.403 deg
+
+Semimajor (68%)      : 0.0628 deg
+Semiminor (68%)      : 0.0481 deg
+Position angle (68%) : 41.03 deg
+Semimajor (95%)      : 0.1019 deg
+Semiminor (95%)      : 0.0780 deg
+Position angle (95%) : 41.03 deg
+ROI number           : 185
+
+*** Spectral info ***
+
+Spectrum type                                 : PowerLaw        
+Detection significance (100 MeV - 300 GeV)    : 6.813
+Significance curvature                        : 3.4
+Pivot energy                                  : 1159 MeV
+Power law spectral index                      : 2.411
+Spectral index                                : 2.411 +- 0.082
+Flux Density at pivot energy                  : 1.01e-12 +- 1.49e-13 cm-2 MeV-1 s-1
+Integral flux (1 - 100 GeV)                   : 1.02e-09 +- 1.58e-10 cm-2 s-1
+Energy flux (100 MeV - 100 GeV)               : 1.36e-11 +- 2.07e-12 erg cm-2 s-1
+
+*** Spectral points ***
+
+  e_min     e_max        flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul    sqrt_TS 
+   MeV       MeV     1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s) erg / (cm2 s) erg / (cm2 s) erg / (cm2 s)       1 / (cm2 s) erg / (cm2 s)          
+--------- ---------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- ---------
+  100.000    300.000   1.808e-08   8.395e-09   8.236e-09     4.175e-12     1.938e-12     1.902e-12 False         nan           nan 2.1687548
+  300.000   1000.000   6.941e-09   1.353e-09   1.367e-09     4.544e-12     8.856e-13     8.948e-13 False         nan           nan  5.269711
+ 1000.000   3000.000   1.237e-09   2.251e-10   2.343e-10     2.855e-12     5.198e-13     5.411e-13 False         nan           nan   6.02224
+ 3000.000  10000.000   5.781e-11   4.045e-11   4.853e-11     3.784e-13     2.648e-13     3.177e-13 False         nan           nan 1.5091934
+10000.000 100000.000   2.840e-11   1.484e-11   1.915e-11     4.317e-13     2.257e-13     2.912e-13 False         nan           nan 2.4211686
+
+*** Lightcurve info ***
+
+Lightcurve measured in the energy band: 100 MeV - 100 GeV
+
+Variability index : 40.754
+
+No peak measured for this source.

--- a/gammapy/catalog/tests/data/3fgl_J0001.4+2120.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0001.4+2120.txt
@@ -1,0 +1,58 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 4
+Source name          : 3FGL J0001.4+2120 
+Extended name        :                   
+Associations         : TXS 2358+209, 3EG J2359+2041
+Other names          : 
+Class                : fsrq 
+TeVCat flag          : No TeV association
+Other flags          : None
+
+*** Position info ***
+
+RA                   : 0.361 deg
+DEC                  : 21.338 deg
+GLON                 : 107.665 deg
+GLAT                 : -40.047 deg
+
+Semimajor (68%)      : 0.1298 deg
+Semiminor (68%)      : 0.1162 deg
+Position angle (68%) : -32.55 deg
+Semimajor (95%)      : 0.2105 deg
+Semiminor (95%)      : 0.1884 deg
+Position angle (95%) : -32.55 deg
+ROI number           : 326
+
+*** Spectral info ***
+
+Spectrum type                                 : LogParabola     
+Detection significance (100 MeV - 300 GeV)    : 11.350
+Significance curvature                        : 4.4
+beta                                          : 0.5191451907157898 +- 0.15508420765399933
+Pivot energy                                  : 311 MeV
+Power law spectral index                      : 2.777
+Spectral index                                : 2.305 +- 0.180
+Flux Density at pivot energy                  : 2.52e-11 +- 2.8e-12 cm-2 MeV-1 s-1
+Integral flux (1 - 100 GeV)                   : 2.94e-10 +- 7.58e-11 cm-2 s-1
+Energy flux (100 MeV - 100 GeV)               : 8.07e-12 +- 8.38e-13 erg cm-2 s-1
+
+*** Spectral points ***
+
+  e_min     e_max        flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul    sqrt_TS 
+   MeV       MeV     1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s) erg / (cm2 s) erg / (cm2 s) erg / (cm2 s)       1 / (cm2 s) erg / (cm2 s)          
+--------- ---------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- ---------
+  100.000    300.000   1.524e-08   2.378e-09   2.390e-09     3.773e-12     5.888e-13     5.918e-13 False         nan           nan 6.7877107
+  300.000   1000.000   3.640e-09   5.311e-10   5.450e-10     2.260e-12     3.297e-13     3.384e-13 False         nan           nan 7.5911775
+ 1000.000   3000.000   3.565e-10   9.341e-11   1.018e-10     7.153e-13     1.874e-13     2.042e-13 False         nan           nan 4.5168524
+ 3000.000  10000.000   8.414e-15         nan   1.924e-11     4.392e-17           nan     1.004e-13  True   3.849e-11     2.009e-13       0.0
+10000.000 100000.000   1.036e-14         nan   1.126e-11     9.595e-17           nan     1.043e-13  True   2.252e-11     2.087e-13       0.0
+
+*** Lightcurve info ***
+
+Lightcurve measured in the energy band: 100 MeV - 100 GeV
+
+Variability index : 130.336
+
+No peak measured for this source.

--- a/gammapy/catalog/tests/data/3fgl_J0023.4+0923.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0023.4+0923.txt
@@ -1,0 +1,58 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 55
+Source name          : 3FGL J0023.4+0923 
+Extended name        :                   
+Associations         : PSR J0023+0923
+Other names          : 1FGL J0023.5+0930, 2FGL J0023.5+0924
+Class                : PSR  
+TeVCat flag          : No TeV association
+Other flags          : None
+
+*** Position info ***
+
+RA                   : 5.865 deg
+DEC                  : 9.389 deg
+GLON                 : 111.455 deg
+GLAT                 : -52.858 deg
+
+Semimajor (68%)      : 0.0525 deg
+Semiminor (68%)      : 0.0485 deg
+Position angle (68%) : -86.71 deg
+Semimajor (95%)      : 0.0852 deg
+Semiminor (95%)      : 0.0786 deg
+Position angle (95%) : -86.71 deg
+ROI number           : 576
+
+*** Spectral info ***
+
+Spectrum type                                 : PLExpCutoff     
+Detection significance (100 MeV - 300 GeV)    : 13.328
+Significance curvature                        : 5.7
+Cutoff energy                                 : 984 +- 239 MeV
+Pivot energy                                  : 905 MeV
+Power law spectral index                      : 2.283
+Spectral index                                : 0.971 +- 0.303
+Flux Density at pivot energy                  : 2.27e-12 +- 2.53e-13 cm-2 MeV-1 s-1
+Integral flux (1 - 100 GeV)                   : 1.12e-09 +- 1.25e-10 cm-2 s-1
+Energy flux (100 MeV - 100 GeV)               : 7.28e-12 +- 8.09e-13 erg cm-2 s-1
+
+*** Spectral points ***
+
+  e_min     e_max        flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul    sqrt_TS  
+   MeV       MeV     1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s) erg / (cm2 s) erg / (cm2 s) erg / (cm2 s)       1 / (cm2 s) erg / (cm2 s)           
+--------- ---------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- ----------
+  100.000    300.000   3.158e-09   2.421e-09   2.484e-09     8.263e-13     6.335e-13     6.500e-13 False         nan           nan  1.3162491
+  300.000   1000.000   3.743e-09   4.966e-10   5.139e-10     2.719e-12     3.607e-13     3.733e-13 False         nan           nan   8.734414
+ 1000.000   3000.000   9.629e-10   1.320e-10   1.395e-10     2.157e-12     2.958e-13     3.125e-13 False         nan           nan   9.994864
+ 3000.000  10000.000   5.029e-11   2.401e-11   3.044e-11     2.625e-13     1.253e-13     1.589e-13 False         nan           nan  2.7636795
+10000.000 100000.000   7.682e-12         nan   1.888e-11     7.117e-14           nan     1.749e-13  True   4.544e-11     4.210e-13 0.96025896
+
+*** Lightcurve info ***
+
+Lightcurve measured in the energy band: 100 MeV - 100 GeV
+
+Variability index : 51.375
+
+No peak measured for this source.

--- a/gammapy/catalog/tests/data/3fgl_J0835.3-4510.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0835.3-4510.txt
@@ -1,0 +1,58 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 960
+Source name          : 3FGL J0835.3-4510 
+Extended name        :                   
+Associations         : PSR J0835-4510, Vela, Vela Pulsar, 1AGL J0835-4509
+Other names          : 0FGL J0835.4-4510, 1FGL J0835.3-4510, 2FGL J0835.3-4510, 1FHL J0835.3-4510
+Class                : PSR  
+TeVCat flag          : Small TeV source
+Other flags          : None
+
+*** Position info ***
+
+RA                   : 128.838 deg
+DEC                  : -45.178 deg
+GLON                 : 263.555 deg
+GLAT                 : -2.787 deg
+
+Semimajor (68%)      : 0.0032 deg
+Semiminor (68%)      : 0.0032 deg
+Position angle (68%) : 20.08 deg
+Semimajor (95%)      : 0.0052 deg
+Semiminor (95%)      : 0.0052 deg
+Position angle (95%) : 20.08 deg
+ROI number           : 88
+
+*** Spectral info ***
+
+Spectrum type                                 : PLSuperExpCutoff
+Detection significance (100 MeV - 300 GeV)    : 1048.959
+Significance curvature                        : 54.0
+Super-exponential cutoff index                : 0.47586068511009216 +- 0.008638832718133926
+Pivot energy                                  : 833 MeV
+Power law spectral index                      : 1.952
+Spectral index                                : 1.003 +- 0.018
+Flux Density at pivot energy                  : 2.33e-09 +- 4.4e-12 cm-2 MeV-1 s-1
+Integral flux (1 - 100 GeV)                   : 1.3e-06 +- 2.89e-09 cm-2 s-1
+Energy flux (100 MeV - 100 GeV)               : 8.93e-09 +- 1.73e-11 erg cm-2 s-1
+
+*** Spectral points ***
+
+  e_min     e_max        flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul    sqrt_TS  
+   MeV       MeV     1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s) erg / (cm2 s) erg / (cm2 s) erg / (cm2 s)       1 / (cm2 s) erg / (cm2 s)           
+--------- ---------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- ----------
+  100.000    300.000   5.376e-06   2.615e-08   2.615e-08     1.372e-09     6.673e-12     6.673e-12 False         nan           nan  160.97115
+  300.000   1000.000   3.217e-06   7.406e-09   7.406e-09     2.292e-09     5.278e-12     5.278e-12 False         nan           nan  528.53766
+ 1000.000   3000.000   1.070e-06   3.075e-09   3.075e-09     2.525e-09     7.256e-12     7.256e-12 False         nan           nan   711.6319
+ 3000.000  10000.000   2.162e-07   1.255e-09   1.255e-09     1.321e-09     7.670e-12     7.670e-12 False         nan           nan  465.89935
+10000.000 100000.000   1.138e-08   2.888e-10   2.888e-10     1.055e-10     2.676e-12     2.676e-12 False         nan           nan 111.192406
+
+*** Lightcurve info ***
+
+Lightcurve measured in the energy band: 100 MeV - 100 GeV
+
+Variability index : 20.009
+
+No peak measured for this source.

--- a/gammapy/catalog/tests/data/3fhl_j2301.9+5855e.txt
+++ b/gammapy/catalog/tests/data/3fhl_j2301.9+5855e.txt
@@ -1,0 +1,63 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 1500
+Source name          : 3FHL J2301.9+5855e
+Extended name        : FGES J2301.9+5855 
+Associations     : CTB 109, 3FGL J2301.2+5853
+ASSOC_PROB_BAY   : nan
+ASSOC_PROB_LR    : nan
+Class            : SNR    
+TeVCat flag      : No TeV association
+
+Significance (10 GeV - 2 TeV)    : 7.974
+Npred                            : 53.1
+
+*** Position info ***
+
+RA                   : 345.494 deg
+DEC                  : 58.920 deg
+GLON                 : 109.203 deg
+GLAT                 : -1.003 deg
+
+Semimajor (95%)      : nan deg
+Semiminor (95%)      : nan deg
+Position angle (95%) : nan deg
+ROI number           : 479
+*** Extended source information ***
+Model form       : Disk       
+Model semimajor  : 0.2488 deg
+Model semiminor  : 0.2488 deg
+Position angle   : 0.0000 deg
+Spatial function : RadialDisk 
+Spatial filename :                         
+
+
+*** Spectral fit info ***
+
+Spectrum type                    : PowerLaw   
+Significance curvature           : 1.0
+Power-law spectral index         : 2.006 +- 0.174
+Pivot energy                     : 30.2 GeV
+Flux Density at pivot energy     : 1.61e-12 +- 2.81e-13 cm-2 GeV-1 s-1
+Integral flux (10 GeV - 1 TeV)   : 1.46e-10 +- 2.57e-11 cm-2 s-1
+Energy flux (10 GeV - TeV)       : 1.08e-11 +- 2.9e-12 erg cm-2 s-1
+
+*** Spectral points ***
+
+ e_min   e_max       flux     flux_errn   flux_errp      e2dnde     e2dnde_errn   e2dnde_errp  is_ul   flux_ul     e2dnde_ul   sqrt_ts
+  GeV     GeV    1 / (cm2 s) 1 / (cm2 s) 1 / (cm2 s) erg / (cm2 s) erg / (cm2 s) erg / (cm2 s)       1 / (cm2 s) erg / (cm2 s)        
+------- -------- ----------- ----------- ----------- ------------- ------------- ------------- ----- ----------- ------------- -------
+ 10.000   20.000   7.545e-11   1.849e-11   2.071e-11     2.417e-12     5.923e-13     6.632e-13 False         nan           nan   5.446
+ 20.000   50.000   4.747e-11   1.296e-11   1.507e-11     2.534e-12     6.916e-13     8.042e-13 False         nan           nan   5.218
+ 50.000  150.000   2.058e-11   7.593e-12   9.512e-12     2.471e-12     9.117e-13     1.142e-12 False         nan           nan   4.016
+150.000  500.000   4.437e-12   3.076e-12   4.877e-12     1.522e-12     1.055e-12     1.673e-12 False         nan           nan   1.791
+500.000 2000.000   6.598e-17         nan   4.626e-12     7.039e-17           nan     4.936e-12  True   9.252e-12     9.872e-12   0.000
+
+*** Other info ***
+
+HEP Energy       : 364.828 GeV
+HEP Probability  : 0.849
+Bayesian Blocks  : 1 (not variable)
+Redshift         : nan
+NuPeak_obs       : nan Hz

--- a/gammapy/catalog/tests/data/gammacat_hess_j1813-178.txt
+++ b/gammapy/catalog/tests/data/gammacat_hess_j1813-178.txt
@@ -1,0 +1,90 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 118
+Common name     : HESS J1813-178
+Other names     : HESS J1813-178,G12.82-0.02,PSR J1813-1749,CXOU J181335.1-174957,IGR J18135-1751,W33
+Location        : gal
+Class           : pwn
+
+TeVCat ID       : 114
+TeVCat 2 ID     : Unhlxa
+TeVCat name     : TeV J1813-178
+
+TGeVCat ID      : 116
+TGeVCat name    : TeV J1813-1750
+
+Discoverer      : hess
+Discovery date  : 2005-03
+Seen by         : hess,magic
+Reference       : 2006ApJ...636..777A
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 273.363 deg
+DEC                  : -17.849 deg
+GLON                 : 12.787 deg
+GLAT                 : 0.000 deg
+
+Measurement:
+RA                   : 273.408 deg
+DEC                  : -17.842 deg
+GLON                 : 12.813 deg
+GLAT                 : -0.034 deg
+Position error       : 0.005 deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.036 deg
+Sigma error               : 0.006 deg
+Sigma2                    : nan deg
+Sigma2 error              : nan deg
+Position angle            : nan deg
+Position angle error      : nan deg
+Position angle frame      : 
+
+*** Spectral info ***
+
+Significance    : 13.500
+Livetime        : 9.700 h
+
+Spectrum type   : pl2
+flux            : 1.42e-11 +- 1.1e-12 (stat) +- 3e-13 (sys) cm-2 s-1
+index           : 2.09 +- 0.08 (stat) +- 0.2 (sys)
+e_min           : 0.2 TeV
+e_max           : nan TeV
+
+Energy range         : (nan, nan) TeV
+theta                : 0.15 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 2.68e-12 +- 2.55e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.46e-12 +- 3.69e-13 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 11.844 +- 1.780 (% Crab)
+Integrated flux (1-10 TeV)     : 8.92e-12 +- 1.46e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2006ApJ...636..777A
+Number of spectral points : 13
+Number of upper limits    : 0
+
+e_ref        dnde         dnde_errn       dnde_errp   
+ TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+------ --------------- --------------- ---------------
+ 0.323       2.736e-11       5.690e-12       5.971e-12
+ 0.427       1.554e-11       3.356e-12       3.559e-12
+ 0.574       8.142e-12       1.603e-12       1.716e-12
+ 0.777       4.567e-12       9.319e-13       1.007e-12
+ 1.023       2.669e-12       5.586e-13       6.110e-13
+ 1.373       1.518e-12       3.378e-13       3.721e-13
+ 1.841       7.966e-13       2.166e-13       2.426e-13
+ 2.476       3.570e-13       1.135e-13       1.295e-13
+ 3.159       3.321e-13       8.757e-14       1.012e-13
+ 4.414       1.934e-13       5.764e-14       6.857e-14
+ 5.560       4.461e-14       2.130e-14       2.844e-14
+10.765       1.318e-14       6.056e-15       1.085e-14
+22.052       1.372e-14       6.128e-15       1.178e-14

--- a/gammapy/catalog/tests/data/gammacat_hess_j1848-018.txt
+++ b/gammapy/catalog/tests/data/gammacat_hess_j1848-018.txt
@@ -1,0 +1,87 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 134
+Common name     : HESS J1848-018
+Other names     : HESS J1848-018,1HWC J1849-017c,WR121a,W43
+Location        : gal
+Class           : unid
+
+TeVCat ID       : 187
+TeVCat 2 ID     : hcE3Ou
+TeVCat name     : TeV J1848-017
+
+TGeVCat ID      : 128
+TGeVCat name    : TeV J1848-0147
+
+Discoverer      : hess
+Discovery date  : 2008-07
+Seen by         : hess
+Reference       : 2008AIPC.1085..372C
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 282.120 deg
+DEC                  : -1.792 deg
+GLON                 : 31.000 deg
+GLAT                 : -0.159 deg
+
+Measurement:
+RA                   : 282.121 deg
+DEC                  : -1.792 deg
+GLON                 : 31.000 deg
+GLAT                 : -0.160 deg
+Position error       : nan deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.320 deg
+Sigma error               : 0.020 deg
+Sigma2                    : nan deg
+Sigma2 error              : nan deg
+Position angle            : nan deg
+Position angle error      : nan deg
+Position angle frame      : 
+
+*** Spectral info ***
+
+Significance    : 9.000
+Livetime        : 50.000 h
+
+Spectrum type   : pl
+norm            : 3.7e-12 +- 4e-13 (stat) +- 7e-13 (sys) cm-2 s-1 TeV-1
+index           : 2.8 +- 0.2 (stat) +- 0.2 (sys)
+reference       : 1.0 TeV
+
+Energy range         : (0.9, 12.0) TeV
+theta                : 0.2 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 3.7e-12 +- 4e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.06e-12 +- 3.19e-13 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 9.909 +- 1.536 (% Crab)
+Integrated flux (1-10 TeV)     : 6.24e-12 +- 1.22e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2008AIPC.1085..372C
+Number of spectral points : 11
+Number of upper limits    : 0
+
+e_ref        dnde         dnde_errn       dnde_errp   
+ TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+------ --------------- --------------- ---------------
+ 0.624       9.942e-12       3.301e-12       3.265e-12
+ 0.878       6.815e-12       1.042e-12       1.029e-12
+ 1.284       1.707e-12       3.889e-13       3.826e-13
+ 1.881       5.027e-13       1.566e-13       1.533e-13
+ 2.754       3.266e-13       7.526e-14       7.323e-14
+ 4.033       8.183e-14       3.609e-14       3.503e-14
+ 5.905       2.979e-14       1.981e-14       1.921e-14
+ 8.648       4.022e-15       9.068e-15       8.729e-15
+12.663      -6.647e-15       3.786e-15       3.675e-15
+18.542       3.735e-15       2.009e-15       1.786e-15
+27.173      -5.317e-16       9.236e-16       8.568e-16

--- a/gammapy/catalog/tests/data/gammacat_vela_x.txt
+++ b/gammapy/catalog/tests/data/gammacat_vela_x.txt
@@ -1,0 +1,101 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 36
+Common name     : Vela X
+Other names     : HESS J0835-455
+Location        : gal
+Class           : pwn
+
+TeVCat ID       : 86
+TeVCat 2 ID     : yVoFOS
+TeVCat name     : TeV J0835-456
+
+TGeVCat ID      : 37
+TGeVCat name    : TeV J0835-4536
+
+Discoverer      : hess
+Discovery date  : 2006-03
+Seen by         : hess
+Reference       : 2012A&A...548A..38A
+
+*** Position info ***
+
+SIMBAD:
+RA                   : 128.287 deg
+DEC                  : -45.190 deg
+GLON                 : 263.332 deg
+GLAT                 : -3.106 deg
+
+Measurement:
+RA                   : 128.750 deg
+DEC                  : -45.600 deg
+GLON                 : 263.856 deg
+GLAT                 : -3.089 deg
+Position error       : nan deg
+
+*** Morphology info ***
+
+Morphology model type     : gauss
+Sigma                     : 0.480 deg
+Sigma error               : 0.030 deg
+Sigma2                    : 0.360 deg
+Sigma2 error              : 0.030 deg
+Position angle            : 41.000 deg
+Position angle error      : 7.000 deg
+Position angle frame      : radec
+
+*** Spectral info ***
+
+Significance    : 27.900
+Livetime        : 53.100 h
+
+Spectrum type   : ecpl
+norm            : 1.46e-11 +- 8e-13 (stat) +- 3e-12 (sys) cm-2 s-1 TeV-1
+index           : 1.32 +- 0.06 (stat) +- 0.12 (sys)
+e_cut           : 14.0 +- 1.6 (stat) +- 2.6 (stat) TeV
+reference       : 1.0 TeV
+
+Energy range         : (0.75, nan) TeV
+theta                : 1.2 deg
+
+
+Derived fluxes:
+Spectral model norm (1 TeV)    : 1.36e-11 +- 7.53e-13 (stat) cm-2 s-1 TeV-1
+Integrated flux (>1 TeV)       : 2.1e-11 +- 1.97e-12 (stat) cm-2 s-1
+Integrated flux (>1 TeV)       : 101.425 +- 9.511 (% Crab)
+Integrated flux (1-10 TeV)     : 9.27e-11 +- 9.59e-12 (stat) erg cm-2 s-1
+
+*** Spectral points ***
+
+SED reference id          : 2012A&A...548A..38A
+Number of spectral points : 24
+Number of upper limits    : 0
+
+e_ref        dnde         dnde_errn       dnde_errp   
+ TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
+------ --------------- --------------- ---------------
+ 0.719       1.055e-11       3.284e-12       3.280e-12
+ 0.868       1.304e-11       2.130e-12       2.130e-12
+ 1.051       9.211e-12       1.401e-12       1.399e-12
+ 1.274       8.515e-12       9.580e-13       9.610e-13
+ 1.546       5.378e-12       7.070e-13       7.090e-13
+ 1.877       4.455e-12       5.050e-13       5.070e-13
+ 2.275       3.754e-12       3.300e-13       3.340e-13
+ 2.759       2.418e-12       2.680e-13       2.700e-13
+ 3.352       1.605e-12       1.800e-13       1.830e-13
+ 4.078       1.445e-12       1.260e-13       1.290e-13
+ 4.956       9.240e-13       9.490e-14       9.700e-14
+ 6.008       7.348e-13       6.470e-14       6.710e-14
+ 7.271       3.863e-13       4.540e-14       4.700e-14
+ 8.795       3.579e-13       3.570e-14       3.750e-14
+10.650       1.696e-13       2.490e-14       2.590e-14
+12.910       1.549e-13       2.060e-14       2.160e-14
+15.650       6.695e-14       1.134e-14       1.230e-14
+18.880       2.105e-14       1.390e-14       1.320e-14
+22.620       3.279e-14       6.830e-15       7.510e-15
+26.870       3.026e-14       5.910e-15       6.660e-15
+31.610       1.861e-14       4.380e-15       5.120e-15
+36.970       5.653e-15       2.169e-15       2.917e-15
+43.080       3.479e-15       1.641e-15       2.410e-15
+52.370       1.002e-15       8.327e-16       1.615e-15

--- a/gammapy/catalog/tests/data/hess_j1713-397.txt
+++ b/gammapy/catalog/tests/data/hess_j1713-397.txt
@@ -1,0 +1,127 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 33
+Source name          : HESS J1713-397
+Analysis reference   : EXTERN
+Source class         : SNR
+Identified object    : RX J1713.7-3946
+Gamma-Cat id         : 96
+
+
+*** Info from map analysis ***
+
+RA                   :  258.355 deg = 17h13m25s
+DEC                  :  -39.771 deg = -39d46m16s
+GLON                 :  347.311 +/- nan deg
+GLAT                 :   -0.457 +/- nan deg
+Position Error (68%) : nan deg
+Position Error (95%) : nan deg
+ROI number           : -1
+Spatial model        : Shell
+Spatial components   : 
+TS                   : nan
+sqrt(TS)             : nan
+Size                 : 0.500 +/- nan (UL: nan) deg
+R70                  : nan deg
+RSpec                : 0.600 deg
+Total model excess   : nan
+Excess in RSpec      : nan
+Model Excess in RSpec : nan
+Background in RSpec  : nan
+Livetime             : 164.0 hours
+Energy threshold     : nan TeV
+Source flux (>1 TeV) : (16.879 +/- 0.824) x 10^-12 cm^-2 s^-1 = (74.69 +/- 3.64) % Crab
+
+Fluxes in RSpec (> 1 TeV):
+Map measurement                : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
+Source model                   : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
+Other component model          : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
+Large scale component model    : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
+Total model                    : nan x 10^-12 cm^-2 s^-1 =   nan % Crab
+Containment in RSpec                :   nan %
+Contamination in RSpec              :   nan %
+Flux correction (RSpec -> Total)    :   nan %
+Flux correction (Total -> RSpec)    :   nan %
+
+*** Info from spectral analysis ***
+
+Livetime             : 164.0 hours
+Energy range:        : 0.20 to 40.00 TeV
+Background           : nan
+Excess               : nan
+Spectral model       : ECPL
+TS ECPL over PL      : nan
+Best-fit model flux(> 1 TeV) : (16.879 +/- 0.824) x 10^-12 cm^-2 s^-1  = (74.69 +/- 3.64) % Crab
+Best-fit model energy flux(1 to 10 TeV) : (59.996 +/- 3.173) x 10^-12 erg cm^-2 s^-1
+Pivot energy         : nan TeV
+Flux at pivot energy : (nan +/- nan) x 10^-12 cm^-2 s^-1 TeV^-1  = (nan +/- nan) % Crab
+PL   Flux(> 1 TeV)   : (nan +/- nan) x 10^-12 cm^-2 s^-1  = (nan +/- nan) % Crab
+PL   Flux(@ 1 TeV)   : (nan +/- nan) x 10^-12 cm^-2 s^-1 TeV^-1  = (nan +/- nan) % Crab
+PL   Index           : nan +/- nan
+ECPL   Flux(@ 1 TeV) : (21.284 +/- 0.936) x 10^-12 cm^-2 s^-1 TeV^-1  = (94.18 +/- 2.67) % Crab
+ECPL   Flux(> 1 TeV) : (16.879 +/- 0.824) x 10^-12 cm^-2 s^-1  = (74.69 +/- 3.64) % Crab
+ECPL Index           : 2.06 +/- 0.02
+ECPL Lambda          : 0.078 +/- 0.007 TeV^-1
+ECPL E_cut           : 12.90 +/- 1.10 TeV
+
+*** Flux points info ***
+
+Number of flux points: 30
+Flux points table: 
+
+e_ref  e_min  e_max        dnde         dnde_errn       dnde_errp        dnde_ul     is_ul
+ TeV    TeV    TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)      
+------ ------ ------ --------------- --------------- --------------- --------------- -----
+ 0.230  0.210  0.250       5.239e-10       9.852e-11       9.852e-11             nan False
+ 0.270  0.250  0.290       3.416e-10       4.426e-11       4.426e-11             nan False
+ 0.320  0.290  0.350       2.609e-10       2.146e-11       2.146e-11             nan False
+ 0.380  0.350  0.410       1.694e-10       1.042e-11       1.042e-11             nan False
+ 0.450  0.410  0.490       1.221e-10       6.288e-12       6.288e-12             nan False
+ 0.530  0.490  0.580       7.510e-11       3.844e-12       3.844e-12             nan False
+ 0.630  0.580  0.690       5.394e-11       2.217e-12       2.217e-12             nan False
+ 0.750  0.690  0.810       3.784e-11       1.487e-12       1.487e-12             nan False
+ 0.890  0.810  0.960       2.529e-11       9.613e-13       9.613e-13             nan False
+ 1.050  0.960  1.140       1.664e-11       6.341e-13       6.341e-13             nan False
+ 1.250  1.140  1.360       1.206e-11       4.354e-13       4.354e-13             nan False
+ 1.480  1.360  1.610       9.261e-12       3.049e-13       3.049e-13             nan False
+ 1.760  1.610  1.910       6.025e-12       2.035e-13       2.035e-13             nan False
+ 2.080  1.910  2.260       4.458e-12       1.717e-13       1.717e-13             nan False
+ 2.470  2.260  2.680       2.680e-12       1.269e-13       1.269e-13             nan False
+ 2.930  2.680  3.180       1.847e-12       8.506e-14       8.506e-14             nan False
+ 3.470  3.180  3.770       1.343e-12       6.117e-14       6.117e-14             nan False
+ 4.120  3.770  4.470       8.788e-13       4.707e-14       4.707e-14             nan False
+ 4.880  4.470  5.290       6.552e-13       3.224e-14       3.224e-14             nan False
+ 5.790  5.290  6.280       4.357e-13       2.439e-14       2.439e-14             nan False
+ 6.860  6.280  7.440       2.666e-13       1.830e-14       1.830e-14             nan False
+ 8.140  7.440  8.830       1.639e-13       1.422e-14       1.422e-14             nan False
+ 9.650  8.830 10.470       9.518e-14       1.025e-14       1.025e-14             nan False
+11.440 10.470 12.410       7.535e-14       7.583e-15       7.583e-15             nan False
+13.560 12.410 14.710       2.831e-14       5.771e-15       5.771e-15             nan False
+16.080 14.710 17.450       2.334e-14       4.031e-15       4.031e-15             nan False
+19.990 17.450 22.530       5.967e-15       2.202e-15       2.202e-15             nan False
+24.620 22.530 26.710       5.849e-15       1.802e-15       1.802e-15             nan False
+29.190 26.710 31.670       2.044e-15       1.150e-15       1.150e-15             nan False
+34.610 31.670 37.550       2.647e-15       6.617e-16       6.617e-16             nan False
+
+*** Source associations info ***
+
+  Source_Name    Association_Catalog    Association_Name   Separation
+                                                              deg    
+---------------- ------------------- --------------------- ----------
+  HESS J1713-397                2FHL    2FHL J1713.5-3945e   0.029067
+  HESS J1713-397                2FHL     2FHL J1714.1-4012   0.457815
+  HESS J1713-397                3FGL    3FGL J1713.5-3945e   0.029067
+  HESS J1713-397                 SNR            G347.3-0.5   0.059676
+
+*** Source identification info ***
+
+Source_Name: HESS J1713-397
+Identified_Object: RX J1713.7-3946
+Class: SNR
+Evidence: Morphology
+Reference: 2004Natur.432...75A
+Distance_Reference: SNRCat
+Distance: 3.5 kpc
+Distance_Min: 1.0 kpc
+Distance_Max: 6.0 kpc

--- a/gammapy/catalog/tests/data/hess_j1825-137.txt
+++ b/gammapy/catalog/tests/data/hess_j1825-137.txt
@@ -1,0 +1,127 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 54
+Source name          : HESS J1825-137
+Analysis reference   : HGPS
+Source class         : PWN
+Identified object    : PSR J1826-1334
+Gamma-Cat id         : 118
+
+
+*** Info from map analysis ***
+
+RA                   :  276.260 deg = 18h25m02s
+DEC                  :  -13.966 deg = -13d57m57s
+GLON                 :   17.525 +/- 0.082 deg
+GLAT                 :   -0.618 +/- 0.011 deg
+Position Error (68%) : 0.125 deg
+Position Error (95%) : 0.203 deg
+ROI number           : 6
+Spatial model        : 3-Gaussian
+Spatial components   : HGPSC 065, HGPSC 066, HGPSC 067
+TS                   : 5846.8
+sqrt(TS)             : 76.5
+Size                 : 0.461 +/- 0.032 (UL: nan) deg
+R70                  : 0.709 deg
+RSpec                : 0.500 deg
+Total model excess   : 18291.5
+Excess in RSpec      : 9525.5
+Model Excess in RSpec : 9408.8
+Background in RSpec  : 8608.5
+Livetime             : 109.1 hours
+Energy threshold     : 0.40 TeV
+Source flux (>1 TeV) : (18.408 +/- 0.556) x 10^-12 cm^-2 s^-1 = (81.45 +/- 2.46) % Crab
+
+Fluxes in RSpec (> 1 TeV):
+Map measurement                : 8.997 x 10^-12 cm^-2 s^-1 = 39.81 % Crab
+Source model                   : 8.724 x 10^-12 cm^-2 s^-1 = 38.60 % Crab
+Other component model          : 0.121 x 10^-12 cm^-2 s^-1 =  0.54 % Crab
+Large scale component model    : 0.195 x 10^-12 cm^-2 s^-1 =  0.86 % Crab
+Total model                    : 9.040 x 10^-12 cm^-2 s^-1 = 40.00 % Crab
+Containment in RSpec                :  47.4 %
+Contamination in RSpec              :   3.5 %
+Flux correction (RSpec -> Total)    : 203.6 %
+Flux correction (Total -> RSpec)    :  49.1 %
+
+*** Info from spectral analysis ***
+
+Livetime             : 12.5 hours
+Energy range:        : 0.24 to 61.90 TeV
+Background           : 5843.4
+Excess               : 3129.6
+Spectral model       : ECPL
+TS ECPL over PL      : 11.4
+Best-fit model flux(> 1 TeV) : (19.150 +/- 1.847) x 10^-12 cm^-2 s^-1  = (84.74 +/- 8.17) % Crab
+Best-fit model energy flux(1 to 10 TeV) : (66.403 +/- 7.952) x 10^-12 erg cm^-2 s^-1
+Pivot energy         : 1.16 TeV
+Flux at pivot energy : (17.165 +/- 0.573) x 10^-12 cm^-2 s^-1 TeV^-1  = (75.95 +/- 1.63) % Crab
+PL   Flux(> 1 TeV)   : (17.596 +/- 0.666) x 10^-12 cm^-2 s^-1  = (77.86 +/- 2.95) % Crab
+PL   Flux(@ 1 TeV)   : (24.233 +/- 0.812) x 10^-12 cm^-2 s^-1 TeV^-1  = (107.23 +/- 2.32) % Crab
+PL   Index           : 2.38 +/- 0.03
+ECPL   Flux(@ 1 TeV) : (25.557 +/- 0.900) x 10^-12 cm^-2 s^-1 TeV^-1  = (113.09 +/- 2.57) % Crab
+ECPL   Flux(> 1 TeV) : (19.150 +/- 1.847) x 10^-12 cm^-2 s^-1  = (84.74 +/- 8.17) % Crab
+ECPL Index           : 2.15 +/- 0.06
+ECPL Lambda          : 0.074 +/- 0.021 TeV^-1
+ECPL E_cut           : 13.57 +/- 3.94 TeV
+
+*** Flux points info ***
+
+Number of flux points: 6
+Flux points table: 
+
+e_ref  e_min  e_max        dnde         dnde_errn       dnde_errp        dnde_ul     is_ul
+ TeV    TeV    TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)      
+------ ------ ------ --------------- --------------- --------------- --------------- -----
+ 0.365  0.237  0.562       2.382e-10       1.642e-11       1.654e-11       2.715e-10 False
+ 0.866  0.562  1.334       3.503e-11       1.959e-12       1.954e-12       3.880e-11 False
+ 2.054  1.334  3.162       5.060e-12       3.173e-13       3.169e-13       5.707e-12 False
+ 5.109  3.162  8.254       5.446e-13       5.534e-14       5.658e-14       6.582e-13 False
+12.711  8.254 19.573       4.615e-14       9.341e-15       9.701e-15       6.613e-14 False
+30.142 19.573 46.416       2.724e-15       1.420e-15       1.646e-15       6.221e-15 False
+
+*** Gaussian component info ***
+
+Number of components: 3
+Spatial components   : HGPSC 065, HGPSC 066, HGPSC 067
+
+Component HGPSC 065:
+GLON                 :   16.989 +/- 0.091 deg
+GLAT                 :   -0.491 +/- 0.038 deg
+Size                 : 0.477 +/- 0.030 deg
+Flux (>1 TeV)        : (5.02 +/- 1.13) x 10^-12 cm^-2 s^-1 = (22.2 +/- 5.0) % Crab
+
+Component HGPSC 066:
+GLON                 :   17.712 +/- 0.025 deg
+GLAT                 :   -0.660 +/- 0.014 deg
+Size                 : 0.391 +/- 0.017 deg
+Flux (>1 TeV)        : (11.83 +/- 1.08) x 10^-12 cm^-2 s^-1 = (52.3 +/- 4.8) % Crab
+
+Component HGPSC 067:
+GLON                 :   17.841 +/- 0.009 deg
+GLAT                 :   -0.706 +/- 0.009 deg
+Size                 : 0.109 +/- 0.009 deg
+Flux (>1 TeV)        : (1.56 +/- 0.20) x 10^-12 cm^-2 s^-1 = (6.9 +/- 0.9) % Crab
+
+
+*** Source associations info ***
+
+  Source_Name    Association_Catalog    Association_Name   Separation
+                                                              deg    
+---------------- ------------------- --------------------- ----------
+  HESS J1825-137                2FHL    2FHL J1824.5-1350e   0.170969
+  HESS J1825-137                3FGL    3FGL J1824.5-1351e   0.169707
+  HESS J1825-137                 PWN             G18.0-0.7   0.479912
+  HESS J1825-137                 PSR              B1823-13   0.481048
+
+*** Source identification info ***
+
+Source_Name: HESS J1825-137
+Identified_Object: PSR J1826-1334
+Class: PWN
+Evidence: ED Morph.
+Reference: 2006A%26A...460..365A
+Distance_Reference: ATNF
+Distance: 3.930000066757202 kpc
+Distance_Min: 1.965000033378601 kpc
+Distance_Max: 7.860000133514404 kpc

--- a/gammapy/catalog/tests/data/hess_j1930+188.txt
+++ b/gammapy/catalog/tests/data/hess_j1930+188.txt
@@ -1,0 +1,114 @@
+
+*** Basic info ***
+
+Catalog row index (zero-based) : 76
+Source name          : HESS J1930+188
+Analysis reference   : HGPS
+Source class         : Composite
+Identified object    : G54.1+0.3
+Gamma-Cat id         : 136
+
+
+*** Info from map analysis ***
+
+RA                   :  292.605 deg = 19h30m25s
+DEC                  :   18.836 deg = 18d50m11s
+GLON                 :   54.057 +/- 0.013 deg
+GLAT                 :    0.266 +/- 0.014 deg
+Position Error (68%) : 0.031 deg
+Position Error (95%) : 0.049 deg
+ROI number           : 1
+Spatial model        : Gaussian
+Spatial components   : HGPSC 097
+TS                   : 33.6
+sqrt(TS)             : 5.8
+Size                 : nan +/- nan (UL: 0.072) deg
+R70                  : 0.083 deg
+RSpec                : 0.150 deg
+Total model excess   : 64.6
+Excess in RSpec      : 81.2
+Model Excess in RSpec : 59.2
+Background in RSpec  : 204.8
+Livetime             : 31.8 hours
+Energy threshold     : 0.89 TeV
+Source flux (>1 TeV) : (0.293 +/- 0.093) x 10^-12 cm^-2 s^-1 = (1.30 +/- 0.41) % Crab
+
+Fluxes in RSpec (> 1 TeV):
+Map measurement                : 0.369 x 10^-12 cm^-2 s^-1 =  1.63 % Crab
+Source model                   : 0.268 x 10^-12 cm^-2 s^-1 =  1.19 % Crab
+Other component model          : -0.000 x 10^-12 cm^-2 s^-1 = -0.00 % Crab
+Large scale component model    : 0.024 x 10^-12 cm^-2 s^-1 =  0.10 % Crab
+Total model                    : 0.292 x 10^-12 cm^-2 s^-1 =  1.29 % Crab
+Containment in RSpec                :  91.6 %
+Contamination in RSpec              :   8.1 %
+Flux correction (RSpec -> Total)    : 100.3 %
+Flux correction (Total -> RSpec)    :  99.7 %
+
+*** Info from spectral analysis ***
+
+Livetime             : 12.9 hours
+Energy range:        : 0.46 to 90.85 TeV
+Background           : 611.9
+Excess               : 155.1
+Spectral model       : PL
+TS ECPL over PL      : nan
+Best-fit model flux(> 1 TeV) : (0.318 +/- 0.068) x 10^-12 cm^-2 s^-1  = (1.41 +/- 0.30) % Crab
+Best-fit model energy flux(1 to 10 TeV) : (1.019 +/- 0.236) x 10^-12 erg cm^-2 s^-1
+Pivot energy         : 1.70 TeV
+Flux at pivot energy : (0.128 +/- 0.027) x 10^-12 cm^-2 s^-1 TeV^-1  = (0.57 +/- 0.08) % Crab
+PL   Flux(> 1 TeV)   : (0.318 +/- 0.068) x 10^-12 cm^-2 s^-1  = (1.41 +/- 0.30) % Crab
+PL   Flux(@ 1 TeV)   : (0.506 +/- 0.124) x 10^-12 cm^-2 s^-1 TeV^-1  = (2.24 +/- 0.35) % Crab
+PL   Index           : 2.59 +/- 0.26
+ECPL   Flux(@ 1 TeV) : (nan +/- nan) x 10^-12 cm^-2 s^-1 TeV^-1  = (nan +/- nan) % Crab
+ECPL   Flux(> 1 TeV) : (nan +/- nan) x 10^-12 cm^-2 s^-1  = (nan +/- nan) % Crab
+ECPL Index           : nan +/- nan
+ECPL Lambda          : nan +/- nan TeV^-1
+ECPL E_cut           : nan +/- nan TeV
+
+*** Flux points info ***
+
+Number of flux points: 6
+Flux points table: 
+
+e_ref  e_min  e_max        dnde         dnde_errn       dnde_errp        dnde_ul     is_ul
+ TeV    TeV    TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)      
+------ ------ ------ --------------- --------------- --------------- --------------- -----
+ 0.681  0.464  1.000       1.302e-12       5.114e-13       5.323e-13       2.379e-12 False
+ 1.468  1.000  2.154       2.069e-13       6.154e-14       6.449e-14       3.373e-13 False
+ 3.162  2.154  4.642       1.875e-14       1.236e-14       1.299e-14       4.552e-14 False
+ 6.813  4.642 10.000       2.002e-15       2.535e-15       2.777e-15       7.801e-15  True
+14.678 10.000 21.544       2.197e-15       7.413e-16       8.351e-16       3.962e-15 False
+31.623 21.544 46.416      -1.866e-16       7.490e-17       9.066e-17       5.105e-17  True
+
+*** Gaussian component info ***
+
+Number of components: 1
+Spatial components   : HGPSC 097
+
+Component HGPSC 097:
+GLON                 :   54.057 +/- 0.013 deg
+GLAT                 :    0.266 +/- 0.014 deg
+Size                 : 0.022 +/- 0.025 deg
+Flux (>1 TeV)        : (0.29 +/- 0.09) x 10^-12 cm^-2 s^-1 = (1.3 +/- 0.4) % Crab
+
+
+*** Source associations info ***
+
+  Source_Name    Association_Catalog    Association_Name   Separation
+                                                              deg    
+---------------- ------------------- --------------------- ----------
+  HESS J1930+188                COMP             G54.1+0.3   0.037915
+  HESS J1930+188                 PSR            J1930+1852   0.039313
+  HESS J1930+188               EXTRA         VER J1930+188   0.039313
+
+*** Source identification info ***
+
+Source_Name: HESS J1930+188
+Identified_Object: G54.1+0.3
+Class: Composite
+Evidence: Position
+Reference: 2010ApJ...719L..69A
+Distance_Reference: SNRCat
+Distance: 6.400000095367432 kpc
+Distance_Min: 5.599999904632568 kpc
+Distance_Max: 7.199999809265137 kpc

--- a/gammapy/catalog/tests/data/make.py
+++ b/gammapy/catalog/tests/data/make.py
@@ -11,6 +11,10 @@ open("3fgl_J0835.3-4510.txt", "w").write(str(cat["3FGL J0835.3-4510"]))
 cat = source_catalogs["3fhl"]
 open("3fhl_j2301.9+5855e.txt", "w").write(str(cat["3FHL J2301.9+5855e"]))
 
+cat = source_catalogs["2hwc"]
+open("2hwc_j0534+220.txt", "w").write(str(cat["2HWC J0534+220"]))
+open("2hwc_j0631+169.txt", "w").write(str(cat["2HWC J0631+169"]))
+
 cat = source_catalogs["gamma-cat"]
 open("gammacat_hess_j1813-178.txt", "w").write(str(cat["HESS J1813-178"]))
 open("gammacat_hess_j1848-018.txt", "w").write(str(cat["HESS J1848-018"]))

--- a/gammapy/catalog/tests/data/make.py
+++ b/gammapy/catalog/tests/data/make.py
@@ -1,0 +1,14 @@
+"""Make test reference data files."""
+
+from gammapy.catalog import source_catalogs
+
+cat = source_catalogs["3fgl"]
+open("3fgl_J0000.1+6545.txt", "w").write(str(cat["3FGL J0000.1+6545"]))
+open("3fgl_J0001.4+2120.txt", "w").write(str(cat["3FGL J0001.4+2120"]))
+open("3fgl_J0023.4+0923.txt", "w").write(str(cat["3FGL J0023.4+0923"]))
+open("3fgl_J0835.3-4510.txt", "w").write(str(cat["3FGL J0835.3-4510"]))
+
+cat = source_catalogs["gamma-cat"]
+open("gammacat_hess_j1813-178.txt", "w").write(str(cat["HESS J1813-178"]))
+open("gammacat_hess_j1848-018.txt", "w").write(str(cat["HESS J1848-018"]))
+open("gammacat_vela_x.txt", "w").write(str(cat["Vela X"]))

--- a/gammapy/catalog/tests/data/make.py
+++ b/gammapy/catalog/tests/data/make.py
@@ -15,6 +15,11 @@ cat = source_catalogs["2hwc"]
 open("2hwc_j0534+220.txt", "w").write(str(cat["2HWC J0534+220"]))
 open("2hwc_j0631+169.txt", "w").write(str(cat["2HWC J0631+169"]))
 
+cat = source_catalogs["hgps"]
+open("hess_j1713-397.txt", "w").write(str(cat["HESS J1713-397"]))
+open("hess_j1825-137.txt", "w").write(str(cat["HESS J1825-137"]))
+open("hess_j1930+188.txt", "w").write(str(cat["HESS J1930+188"]))
+
 cat = source_catalogs["gamma-cat"]
 open("gammacat_hess_j1813-178.txt", "w").write(str(cat["HESS J1813-178"]))
 open("gammacat_hess_j1848-018.txt", "w").write(str(cat["HESS J1848-018"]))

--- a/gammapy/catalog/tests/data/make.py
+++ b/gammapy/catalog/tests/data/make.py
@@ -8,6 +8,9 @@ open("3fgl_J0001.4+2120.txt", "w").write(str(cat["3FGL J0001.4+2120"]))
 open("3fgl_J0023.4+0923.txt", "w").write(str(cat["3FGL J0023.4+0923"]))
 open("3fgl_J0835.3-4510.txt", "w").write(str(cat["3FGL J0835.3-4510"]))
 
+cat = source_catalogs["3fhl"]
+open("3fhl_j2301.9+5855e.txt", "w").write(str(cat["3FHL J2301.9+5855e"]))
+
 cat = source_catalogs["gamma-cat"]
 open("gammacat_hess_j1813-178.txt", "w").write(str(cat["HESS J1813-178"]))
 open("gammacat_hess_j1848-018.txt", "w").write(str(cat["HESS J1848-018"]))

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.time import Time
+from astropy.utils.data import get_pkg_data_filename
 from gammapy.catalog import (
     SourceCatalog1FHL,
     SourceCatalog2FHL,
@@ -53,6 +54,7 @@ SOURCES_3FGL = [
     dict(
         idx=0,
         name="3FGL J0000.1+6545",
+        str_ref_file="data/3fgl_J0000.1+6545.txt",
         spec_type=PowerLaw,
         dnde=u.Quantity(1.4351261e-9, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.1356270e-10, "cm-2 s-1 GeV-1"),
@@ -60,6 +62,7 @@ SOURCES_3FGL = [
     dict(
         idx=4,
         name="3FGL J0001.4+2120",
+        str_ref_file="data/3fgl_J0001.4+2120.txt",
         spec_type=LogParabola,
         dnde=u.Quantity(8.3828599e-10, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.6713238e-10, "cm-2 s-1 GeV-1"),
@@ -67,6 +70,7 @@ SOURCES_3FGL = [
     dict(
         idx=55,
         name="3FGL J0023.4+0923",
+        str_ref_file="data/3fgl_J0023.4+0923.txt",
         spec_type=ExponentialCutoffPowerLaw3FGL,
         dnde=u.Quantity(1.8666925e-09, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(2.2068837e-10, "cm-2 s-1 GeV-1"),
@@ -74,6 +78,7 @@ SOURCES_3FGL = [
     dict(
         idx=960,
         name="3FGL J0835.3-4510",
+        str_ref_file="data/3fgl_J0835.3-4510.txt",
         spec_type=PLSuperExpCutoff3FGL,
         dnde=u.Quantity(1.6547128794756733e-06, "cm-2 s-1 GeV-1"),
         dnde_err=u.Quantity(1.6621504e-11, "cm-2 s-1 MeV-1"),
@@ -139,21 +144,11 @@ class TestFermi3FGLObject:
         assert_allclose(position.ra.deg, 83.637199, atol=1e-3)
         assert_allclose(position.dec.deg, 22.024099, atol=1e-3)
 
-    def test_str(self):
-        ss = str(self.source)
-        assert "Source name          : 3FGL J0534.5+2201" in ss
-        assert "RA                   : 83.637 deg" in ss
-        assert "Detection significance (100 MeV - 300 GeV)    : 30.670" in ss
-        assert (
-            "Integral flux (1 - 100 GeV)                   : 1.57e-07 +- 1.08e-09 cm-2 s-1"
-            in ss
-        )
-
     @pytest.mark.parametrize("ref", SOURCES_3FGL, ids=lambda _: _["name"])
-    def test_str_all(self, ref):
-        ss = str(self.cat[ref["idx"]])
-        # TODO: put better assert on content. Maybe like for gamma-cat?
-        assert "Source name" in ss
+    def test_str(self, ref):
+        actual = str(self.cat[ref["idx"]])
+        expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
+        assert actual == expected
 
     def test_data_python_dict(self):
         data = self.source._data_python_dict

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -323,13 +323,9 @@ class TestFermi3FHLObject:
         assert_allclose(self.source.data["Signif_Avg"], 168.64082)
 
     def test_str(self):
-        source = self.cat["3FHL J2301.9+5855e"]  # Picking an extended source
-        ss = str(source)
-        assert "Source name          : 3FHL J2301.9+5855e" in ss
-        assert "RA                   : 345.494 deg" in ss
-        assert "Significance (10 GeV - 2 TeV)    : 7.974" in ss
-        assert "Integral flux (10 GeV - 1 TeV)   : 1.46e-10 +- 2.57e-11 cm-2 s-1" in ss
-        assert "Model form       : Disk" in ss
+        actual = str(self.cat["3FHL J2301.9+5855e"])  # an extended source
+        expected = open(get_pkg_data_filename("data/3fhl_j2301.9+5855e.txt")).read()
+        assert actual == expected
 
     def test_data_python_dict(self):
         data = self.source._data_python_dict

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -222,19 +222,14 @@ class TestFermi3FGLObject:
         assert table["flux_errn"].unit == "cm-2 s-1"
         assert_allclose(table["flux_errn"][0], 8.071e-08, rtol=1e-3)
 
-    @pytest.mark.parametrize(
-        "name",
-        [
+    def test_crab_alias(self):
+        for name in [
             "Crab",
             "3FGL J0534.5+2201",
             "1FHL J0534.5+2201",
-            "2FGL J0534.5+2201",
             "PSR J0534+2200",
-            "0FGL J0534.6+2201",
-        ],
-    )
-    def test_crab_alias(self, name):
-        assert str(self.cat["Crab"]) == str(self.cat[name])
+        ]:
+            assert self.cat[name].index == 621
 
 
 @requires_data()
@@ -377,11 +372,9 @@ class TestFermi3FHLObject:
         desired = [5.169889e-09, 2.245024e-09, 9.243175e-10, 2.758956e-10, 6.684021e-11]
         assert_allclose(flux_points.table["flux"].data, desired, rtol=1e-3)
 
-    @pytest.mark.parametrize(
-        "name", ["Crab Nebula", "3FHL J0534.5+2201", "3FGL J0534.5+2201i"]
-    )
-    def test_crab_alias(self, name):
-        assert str(self.cat["Crab Nebula"]) == str(self.cat[name])
+    def test_crab_alias(self):
+        for name in ["Crab Nebula", "3FHL J0534.5+2201", "3FGL J0534.5+2201i"]:
+            assert self.cat[name].index == 352
 
 
 @requires_data()
@@ -427,11 +420,14 @@ class TestSourceCatalog1FHL:
         table = self.cat.extended_sources_table
         assert len(table) == 18
 
-    @pytest.mark.parametrize(
-        "name", ["Crab", "1FHL J0534.5+2201", "2FGL J0534.5+2201", "PSR J0534+2200"]
-    )
-    def test_crab_alias(self, name):
-        assert str(self.cat["Crab"]) == str(self.cat[name])
+    def test_crab_alias(self):
+        for name in [
+            "Crab",
+            "1FHL J0534.5+2201",
+            "2FGL J0534.5+2201",
+            "PSR J0534+2200",
+        ]:
+            assert self.cat[name].index == 116
 
 
 @requires_data()
@@ -447,11 +443,14 @@ class TestSourceCatalog2FHL:
         table = self.cat.extended_sources_table
         assert len(table) == 25
 
-    @pytest.mark.parametrize(
-        "name", ["Crab", "3FGL J0534.5+2201i", "1FHL J0534.5+2201", "TeV J0534+2200"]
-    )
-    def test_crab_alias(self, name):
-        assert str(self.cat["Crab"]) == str(self.cat[name])
+    def test_crab_alias(self):
+        for name in [
+            "Crab",
+            "3FGL J0534.5+2201i",
+            "1FHL J0534.5+2201",
+            "TeV J0534+2200",
+        ]:
+            assert self.cat[name].index == 85
 
 
 @requires_data()

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -83,16 +83,15 @@ class TestSourceCatalogGammaCat:
         assert len(gammacat.positions) == 162
 
     def test_w28_alias_names(self, gammacat):
-        names = [
+        for name in [
             "W28",
             "HESS J1801-233",
             "W 28",
             "SNR G6.4-0.1",
             "SNR G006.4-00.1",
             "GRO J1801-2320",
-        ]
-        for name in names:
-            assert str(gammacat[name]) == str(gammacat["W28"])
+        ]:
+            assert gammacat[name].index == 112
 
     def test_sort_table(self, gammacat):
         name = "HESS J1848-018"

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
+from astropy.utils.data import get_pkg_data_filename
 from gammapy.catalog import (
     GammaCatResource,
     GammaCatResourceIndex,
@@ -17,6 +18,7 @@ from gammapy.utils.testing import (
 SOURCES = [
     {
         "name": "Vela X",
+        "str_ref_file": "data/gammacat_vela_x.txt",
         "spec_type": "ecpl",
         "dnde_1TeV": 1.36e-11 * u.Unit("cm-2 s-1 TeV-1"),
         "dnde_1TeV_err": 7.531e-13 * u.Unit("cm-2 s-1 TeV-1"),
@@ -32,6 +34,7 @@ SOURCES = [
     },
     {
         "name": "HESS J1848-018",
+        "str_ref_file": "data/gammacat_hess_j1848-018.txt",
         "spec_type": "pl",
         "dnde_1TeV": 3.7e-12 * u.Unit("cm-2 s-1 TeV-1"),
         "dnde_1TeV_err": 4e-13 * u.Unit("cm-2 s-1 TeV-1"),
@@ -47,6 +50,7 @@ SOURCES = [
     },
     {
         "name": "HESS J1813-178",
+        "str_ref_file": "data/gammacat_hess_j1813-178.txt",
         "spec_type": "pl2",
         "dnde_1TeV": 2.678e-12 * u.Unit("cm-2 s-1 TeV-1"),
         "dnde_1TeV_err": 2.55e-13 * u.Unit("cm-2 s-1 TeV-1"),
@@ -119,8 +123,9 @@ class TestSourceCatalogObjectGammaCat:
 
     @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
     def test_str(self, gammacat, ref):
-        ss = str(gammacat[ref["name"]])
-        assert ss == SOURCES_STR[ref["name"]]
+        actual = str(gammacat[ref["name"]])
+        expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
+        assert actual == expected
 
     def test_data_python_dict(self, gammacat):
         source = gammacat[0]
@@ -360,296 +365,3 @@ class TestGammaCatResourceIndex:
         resource_index = self.resource_index.query('type == "sed" and source_id == 42')
         assert len(resource_index.resources) == 1
         assert resource_index.resources[0].global_id == "42|2010A&A...516A..62A|2|sed"
-
-
-SOURCES_STR = {}
-
-SOURCES_STR[
-    "Vela X"
-] = """
-*** Basic info ***
-
-Catalog row index (zero-based) : 36
-Common name     : Vela X
-Other names     : HESS J0835-455
-Location        : gal
-Class           : pwn
-
-TeVCat ID       : 86
-TeVCat 2 ID     : yVoFOS
-TeVCat name     : TeV J0835-456
-
-TGeVCat ID      : 37
-TGeVCat name    : TeV J0835-4536
-
-Discoverer      : hess
-Discovery date  : 2006-03
-Seen by         : hess
-Reference       : 2012A&A...548A..38A
-
-*** Position info ***
-
-SIMBAD:
-RA                   : 128.287 deg
-DEC                  : -45.190 deg
-GLON                 : 263.332 deg
-GLAT                 : -3.106 deg
-
-Measurement:
-RA                   : 128.750 deg
-DEC                  : -45.600 deg
-GLON                 : 263.856 deg
-GLAT                 : -3.089 deg
-Position error       : nan deg
-
-*** Morphology info ***
-
-Morphology model type     : gauss
-Sigma                     : 0.480 deg
-Sigma error               : 0.030 deg
-Sigma2                    : 0.360 deg
-Sigma2 error              : 0.030 deg
-Position angle            : 41.000 deg
-Position angle error      : 7.000 deg
-Position angle frame      : radec
-
-*** Spectral info ***
-
-Significance    : 27.900
-Livetime        : 53.100 h
-
-Spectrum type   : ecpl
-norm            : 1.46e-11 +- 8e-13 (stat) +- 3e-12 (sys) cm-2 s-1 TeV-1
-index           : 1.32 +- 0.06 (stat) +- 0.12 (sys)
-e_cut           : 14.0 +- 1.6 (stat) +- 2.6 (stat) TeV
-reference       : 1.0 TeV
-
-Energy range         : (0.75, nan) TeV
-theta                : 1.2 deg
-
-
-Derived fluxes:
-Spectral model norm (1 TeV)    : 1.36e-11 +- 7.53e-13 (stat) cm-2 s-1 TeV-1
-Integrated flux (>1 TeV)       : 2.1e-11 +- 1.97e-12 (stat) cm-2 s-1
-Integrated flux (>1 TeV)       : 101.425 +- 9.511 (% Crab)
-Integrated flux (1-10 TeV)     : 9.27e-11 +- 9.59e-12 (stat) erg cm-2 s-1
-
-*** Spectral points ***
-
-SED reference id          : 2012A&A...548A..38A
-Number of spectral points : 24
-Number of upper limits    : 0
-
-e_ref        dnde         dnde_errn       dnde_errp   
- TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
------- --------------- --------------- ---------------
- 0.719       1.055e-11       3.284e-12       3.280e-12
- 0.868       1.304e-11       2.130e-12       2.130e-12
- 1.051       9.211e-12       1.401e-12       1.399e-12
- 1.274       8.515e-12       9.580e-13       9.610e-13
- 1.546       5.378e-12       7.070e-13       7.090e-13
- 1.877       4.455e-12       5.050e-13       5.070e-13
- 2.275       3.754e-12       3.300e-13       3.340e-13
- 2.759       2.418e-12       2.680e-13       2.700e-13
- 3.352       1.605e-12       1.800e-13       1.830e-13
- 4.078       1.445e-12       1.260e-13       1.290e-13
- 4.956       9.240e-13       9.490e-14       9.700e-14
- 6.008       7.348e-13       6.470e-14       6.710e-14
- 7.271       3.863e-13       4.540e-14       4.700e-14
- 8.795       3.579e-13       3.570e-14       3.750e-14
-10.650       1.696e-13       2.490e-14       2.590e-14
-12.910       1.549e-13       2.060e-14       2.160e-14
-15.650       6.695e-14       1.134e-14       1.230e-14
-18.880       2.105e-14       1.390e-14       1.320e-14
-22.620       3.279e-14       6.830e-15       7.510e-15
-26.870       3.026e-14       5.910e-15       6.660e-15
-31.610       1.861e-14       4.380e-15       5.120e-15
-36.970       5.653e-15       2.169e-15       2.917e-15
-43.080       3.479e-15       1.641e-15       2.410e-15
-52.370       1.002e-15       8.327e-16       1.615e-15
-"""
-
-SOURCES_STR[
-    "HESS J1848-018"
-] = """
-*** Basic info ***
-
-Catalog row index (zero-based) : 134
-Common name     : HESS J1848-018
-Other names     : HESS J1848-018,1HWC J1849-017c,WR121a,W43
-Location        : gal
-Class           : unid
-
-TeVCat ID       : 187
-TeVCat 2 ID     : hcE3Ou
-TeVCat name     : TeV J1848-017
-
-TGeVCat ID      : 128
-TGeVCat name    : TeV J1848-0147
-
-Discoverer      : hess
-Discovery date  : 2008-07
-Seen by         : hess
-Reference       : 2008AIPC.1085..372C
-
-*** Position info ***
-
-SIMBAD:
-RA                   : 282.120 deg
-DEC                  : -1.792 deg
-GLON                 : 31.000 deg
-GLAT                 : -0.159 deg
-
-Measurement:
-RA                   : 282.121 deg
-DEC                  : -1.792 deg
-GLON                 : 31.000 deg
-GLAT                 : -0.160 deg
-Position error       : nan deg
-
-*** Morphology info ***
-
-Morphology model type     : gauss
-Sigma                     : 0.320 deg
-Sigma error               : 0.020 deg
-Sigma2                    : nan deg
-Sigma2 error              : nan deg
-Position angle            : nan deg
-Position angle error      : nan deg
-Position angle frame      : 
-
-*** Spectral info ***
-
-Significance    : 9.000
-Livetime        : 50.000 h
-
-Spectrum type   : pl
-norm            : 3.7e-12 +- 4e-13 (stat) +- 7e-13 (sys) cm-2 s-1 TeV-1
-index           : 2.8 +- 0.2 (stat) +- 0.2 (sys)
-reference       : 1.0 TeV
-
-Energy range         : (0.9, 12.0) TeV
-theta                : 0.2 deg
-
-
-Derived fluxes:
-Spectral model norm (1 TeV)    : 3.7e-12 +- 4e-13 (stat) cm-2 s-1 TeV-1
-Integrated flux (>1 TeV)       : 2.06e-12 +- 3.19e-13 (stat) cm-2 s-1
-Integrated flux (>1 TeV)       : 9.909 +- 1.536 (% Crab)
-Integrated flux (1-10 TeV)     : 6.24e-12 +- 1.22e-12 (stat) erg cm-2 s-1
-
-*** Spectral points ***
-
-SED reference id          : 2008AIPC.1085..372C
-Number of spectral points : 11
-Number of upper limits    : 0
-
-e_ref        dnde         dnde_errn       dnde_errp   
- TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
------- --------------- --------------- ---------------
- 0.624       9.942e-12       3.301e-12       3.265e-12
- 0.878       6.815e-12       1.042e-12       1.029e-12
- 1.284       1.707e-12       3.889e-13       3.826e-13
- 1.881       5.027e-13       1.566e-13       1.533e-13
- 2.754       3.266e-13       7.526e-14       7.323e-14
- 4.033       8.183e-14       3.609e-14       3.503e-14
- 5.905       2.979e-14       1.981e-14       1.921e-14
- 8.648       4.022e-15       9.068e-15       8.729e-15
-12.663      -6.647e-15       3.786e-15       3.675e-15
-18.542       3.735e-15       2.009e-15       1.786e-15
-27.173      -5.317e-16       9.236e-16       8.568e-16
-"""
-
-SOURCES_STR[
-    "HESS J1813-178"
-] = """
-*** Basic info ***
-
-Catalog row index (zero-based) : 118
-Common name     : HESS J1813-178
-Other names     : HESS J1813-178,G12.82-0.02,PSR J1813-1749,CXOU J181335.1-174957,IGR J18135-1751,W33
-Location        : gal
-Class           : pwn
-
-TeVCat ID       : 114
-TeVCat 2 ID     : Unhlxa
-TeVCat name     : TeV J1813-178
-
-TGeVCat ID      : 116
-TGeVCat name    : TeV J1813-1750
-
-Discoverer      : hess
-Discovery date  : 2005-03
-Seen by         : hess,magic
-Reference       : 2006ApJ...636..777A
-
-*** Position info ***
-
-SIMBAD:
-RA                   : 273.363 deg
-DEC                  : -17.849 deg
-GLON                 : 12.787 deg
-GLAT                 : 0.000 deg
-
-Measurement:
-RA                   : 273.408 deg
-DEC                  : -17.842 deg
-GLON                 : 12.813 deg
-GLAT                 : -0.034 deg
-Position error       : 0.005 deg
-
-*** Morphology info ***
-
-Morphology model type     : gauss
-Sigma                     : 0.036 deg
-Sigma error               : 0.006 deg
-Sigma2                    : nan deg
-Sigma2 error              : nan deg
-Position angle            : nan deg
-Position angle error      : nan deg
-Position angle frame      : 
-
-*** Spectral info ***
-
-Significance    : 13.500
-Livetime        : 9.700 h
-
-Spectrum type   : pl2
-flux            : 1.42e-11 +- 1.1e-12 (stat) +- 3e-13 (sys) cm-2 s-1
-index           : 2.09 +- 0.08 (stat) +- 0.2 (sys)
-e_min           : 0.2 TeV
-e_max           : nan TeV
-
-Energy range         : (nan, nan) TeV
-theta                : 0.15 deg
-
-
-Derived fluxes:
-Spectral model norm (1 TeV)    : 2.68e-12 +- 2.55e-13 (stat) cm-2 s-1 TeV-1
-Integrated flux (>1 TeV)       : 2.46e-12 +- 3.69e-13 (stat) cm-2 s-1
-Integrated flux (>1 TeV)       : 11.844 +- 1.780 (% Crab)
-Integrated flux (1-10 TeV)     : 8.92e-12 +- 1.46e-12 (stat) erg cm-2 s-1
-
-*** Spectral points ***
-
-SED reference id          : 2006ApJ...636..777A
-Number of spectral points : 13
-Number of upper limits    : 0
-
-e_ref        dnde         dnde_errn       dnde_errp   
- TeV   1 / (cm2 s TeV) 1 / (cm2 s TeV) 1 / (cm2 s TeV)
------- --------------- --------------- ---------------
- 0.323       2.736e-11       5.690e-12       5.971e-12
- 0.427       1.554e-11       3.356e-12       3.559e-12
- 0.574       8.142e-12       1.603e-12       1.716e-12
- 0.777       4.567e-12       9.319e-13       1.007e-12
- 1.023       2.669e-12       5.586e-13       6.110e-13
- 1.373       1.518e-12       3.378e-13       3.721e-13
- 1.841       7.966e-13       2.166e-13       2.426e-13
- 2.476       3.570e-13       1.135e-13       1.295e-13
- 3.159       3.321e-13       8.757e-14       1.012e-13
- 4.414       1.934e-13       5.764e-14       6.857e-14
- 5.560       4.461e-14       2.130e-14       2.844e-14
-10.765       1.318e-14       6.056e-15       1.085e-14
-22.052       1.372e-14       6.128e-15       1.178e-14
-"""

--- a/gammapy/catalog/tests/test_hawc.py
+++ b/gammapy/catalog/tests/test_hawc.py
@@ -1,9 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.catalog import SourceCatalog2HWC
 from gammapy.utils.testing import requires_data, requires_dependency
+
+SOURCES = [
+    {
+        "idx": 0,
+        "name": "2HWC J0534+220",
+        "str_ref_file": "data/2hwc_j0534+220.txt",
+    },
+    {
+        "idx": 1,
+        "name": "2HWC J0631+169",
+        "str_ref_file": "data/2hwc_j0631+169.txt",
+    },
+]
 
 
 @pytest.fixture(scope="session")
@@ -37,14 +51,11 @@ class TestSourceCatalogObject2HWC:
         assert_allclose(position.dec.deg, 22.024, atol=1e-3)
 
     @staticmethod
-    def test_str(cat):
-        source = cat[0]
-        assert "2HWC J0534+220" in str(source)
-        assert "No second spectrum available for this source" in str(source)
-
-        source = cat[1]
-        assert "2HWC J0631+169" in str(source)
-        assert "Spectrum 1:" in str(source)
+    @pytest.mark.parametrize("ref", SOURCES)
+    def test_str(cat, ref):
+        actual = str(cat[ref["idx"]])
+        expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
+        assert actual == expected
 
     @staticmethod
     @requires_dependency("uncertainties")

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -2,6 +2,7 @@
 import collections
 import pytest
 import numpy as np
+from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -13,6 +14,24 @@ from gammapy.utils.testing import (
     requires_data,
     requires_dependency,
 )
+
+SOURCES = [
+    {
+        "idx": 33,
+        "name": "HESS J1713-397",
+        "str_ref_file": "data/hess_j1713-397.txt",
+    },
+    {
+        "idx": 54,
+        "name": "HESS J1825-137",
+        "str_ref_file": "data/hess_j1825-137.txt",
+    },
+    {
+        "idx": 76,
+        "name": "HESS J1930+188",
+        "str_ref_file": "data/hess_j1930+188.txt",
+    },
+]
 
 
 @pytest.fixture(scope="session")
@@ -89,18 +108,11 @@ class TestSourceCatalogObjectHGPS:
         assert "Component HGPSC 083:" in ss
 
     @staticmethod
-    def test_str(cat):
-        source = cat["HESS J1930+188"]
-        assert source.data["Spatial_Model"] == "Gaussian"
-        assert "Spatial components   : HGPSC 097" in str(source)
-
-        source = cat["HESS J1825-137"]
-        assert source.data["Spatial_Model"] == "3-Gaussian"
-        assert "Spatial components   : HGPSC 065, HGPSC 066, HGPSC 067" in str(source)
-
-        source = cat["HESS J1713-397"]
-        assert source.data["Spatial_Model"] == "Shell"
-        assert "Source name          : HESS J1713-397" in str(source)
+    @pytest.mark.parametrize("ref", SOURCES)
+    def test_str(cat, ref):
+        actual = str(cat[ref["idx"]])
+        expected = open(get_pkg_data_filename(ref["str_ref_file"])).read()
+        assert actual == expected
 
     @staticmethod
     def test_position(source):

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -2,6 +2,7 @@
 import collections
 import pytest
 import numpy as np
+import astropy
 from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_allclose
 from astropy import units as u
@@ -108,6 +109,7 @@ class TestSourceCatalogObjectHGPS:
         assert "Component HGPSC 083:" in ss
 
     @staticmethod
+    @pytest.mark.skipif(astropy.__version__ <= "3.2", reason="table formatting differences")
     @pytest.mark.parametrize("ref", SOURCES)
     def test_str(cat, ref):
         actual = str(cat[ref["idx"]])

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -25,7 +25,7 @@ def simulate_dataset(
     random_state="random-seed",
 ):
     """Simulate a 3D dataset.
-    
+
     Simulate a source defined with a sky model for a given pointing,
     geometry and irfs for a given exposure time.
     This will return a dataset object which includes the counts cube,

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -75,8 +75,7 @@ class TestEnergyDependentMultiGaussPSF:
         return EnergyDependentMultiGaussPSF.read(filename, hdu="POINT SPREAD FUNCTION")
 
     def test_info(self, psf):
-        filename = get_pkg_data_filename("data/psf_info.txt")
-        info_str = open(filename, "r").read()
+        info_str = open(get_pkg_data_filename("data/psf_info.txt")).read()
 
         assert psf.info() == info_str
 

--- a/gammapy/utils/fitting/datasets.py
+++ b/gammapy/utils/fitting/datasets.py
@@ -145,14 +145,14 @@ class Datasets:
     @classmethod
     def from_yaml(cls, filedata, filemodel):
         """De-serialize datasets from yaml and fits files
-    
+
         Parameters
         ----------
         fdatasets : str
             filepath to yaml datasets file
         filemodel : str
             filepath to yaml models file
-            
+
         Returns
         -------
         dataset : 'gammapy.utils.fitting.Datasets'
@@ -174,7 +174,7 @@ class Datasets:
         path : str
             path to write files
         selection : {"all", "simple"}
-            "simple" option reduce models parameters attributes displayed to only 
+            "simple" option reduce models parameters attributes displayed to only
             name, value, unit,frozen
         """
         from gammapy.utils.scripts import write_yaml

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -203,7 +203,7 @@ def datasets_to_dict(datasets, path, selection, overwrite):
 
 class dict_to_datasets:
     """add models and backgrounds to datasets
-    
+
     Parameters
     ----------
     datasets : `~gammapy.utils.fitting.Datasets`
@@ -212,7 +212,7 @@ class dict_to_datasets:
         dict describing model components
     get_lists : bool
         get the datasets, models and backgrounds lists separetely (used to initialize FitManager)
-        
+
     """
 
     def __init__(self, data_list, components):

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ console_scripts =
 gammapy.scripts = config/*
 gammapy.irf.tests = data/*
 gammapy.utils.serialization.tests = data/*
+gammapy.catalog.tests = data/*
 
 [bdist_wheel]
 universal = true


### PR DESCRIPTION
This PR moves the reference str for 3 test sources from ` gammapy/catalog/tests/test_gammacat.py` to txt files in ` gammapy/catalog/tests/data`.

This has the advantage that `make trailing-spaces` now works, and also that we'll get a better estimate of how much code and tests we have for the upcoming Gammapy paper, if long text data isn't in test Python files, but separate. Overall we'll get a mix in Gammapy tests, sometimes having inline repr strings, sometimes for very long cases (say 10 lines or more) to go do data txt files.