### PR TITLE
Add dataset-index target to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ help:
 	@echo '     flake8             Run flake8 static code analysis'
 	@echo '     pylint             Run pylint static code analysis'
 	@echo '     pydocstyle         Run docstring checks'
-	@echo '     datasets-index     Create download dataset index json file'
+	@echo '     dataset-index      Create download dataset index json file'
+	@echo '     dataset-download   Download the latest data to the $GAMMAPY_DATA folder'
 	@echo ''
 	@echo ' Note that most things are done via `python setup.py`, we only use'
 	@echo ' make for things that are not trivial to execute via `setup.py`.'
@@ -142,7 +143,10 @@ pydocstyle:
 	--match='(?!test_).*\.py' \
 	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D205,D400,D401,D403,D410
 
-datasets-index:
+dataset-index:
 	python dev/datasets/make_dataset_index.py dataset-index
+
+dataset-download:
+	gammapy download datasets --out=$GAMMAPY_DATA
 
 # TODO: add test and code quality checks for `examples`

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,11 @@ help:
 	@echo ''
 	@echo '     trailing-spaces    Remove trailing spaces at the end of lines in *.py files'
 	@echo '     black              Run black code formatter'
+	@echo '     isort              Run isort code formatter to sort imports'
 	@echo '     flake8             Run flake8 static code analysis'
 	@echo '     pylint             Run pylint static code analysis'
 	@echo '     pydocstyle         Run docstring checks'
+	@echo '     datasets-index     Create download dataset index json file'
 	@echo ''
 	@echo ' Note that most things are done via `python setup.py`, we only use'
 	@echo ' make for things that are not trivial to execute via `setup.py`.'
@@ -89,7 +91,7 @@ test-scripts:
 clean-nb:
 	python -m gammapy jupyter --src=tutorials black
 	python -m gammapy jupyter --src=tutorials strip
-    
+
 docs-sphinx:
 	cd docs && python -m sphinx . _build/html -b html
 
@@ -115,8 +117,8 @@ isort:
 # Note: flake8 is very fast and almost never has false positives
 flake8:
 	flake8 $(PROJECT) \
-    --exclude=gammapy/extern,gammapy/conftest.py,__init__.py \
-    --ignore=E501
+	--exclude=gammapy/extern,gammapy/conftest.py,__init__.py \
+	--ignore=E501
 
 # TODO: once the errors are fixed, remove the -E option and tackle the warnings
 # Note: pylint is very thorough, but slow, and has false positives or nitpicky stuff
@@ -139,5 +141,8 @@ pydocstyle:
 	--match-dir='^(?!extern).*' \
 	--match='(?!test_).*\.py' \
 	--add-ignore=D100,D102,D103,D104,D105,D200,D202,D205,D400,D401,D403,D410
+
+datasets-index:
+	python dev/datasets/make_dataset_index.py dataset-index
 
 # TODO: add test and code quality checks for `examples`

--- a/dev/datasets/make_dataset_index.py
+++ b/dev/datasets/make_dataset_index.py
@@ -206,7 +206,7 @@ class DatasetFermi3FHLGC(DownloadDataset):
 
 
 class DownloadDatasetIndex:
-    path = "gammapy-data-index.json"
+    path = Path(__file__).parent / "gammapy-data-index.json"
     download_datasets = [
         DatasetCTA1DC,
         DatasetDarkMatter,

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -130,8 +130,7 @@ class ComputePlan:
                 # for development just use the local index file
                 filename = (Path(__file__).parent / DEV_DATA_JSON_LOCAL).resolve()
                 log.info("Reading {}".format(filename))
-                with filename.open(mode="r") as f:
-                    txt = f.read()
+                txt = filename.read_text()
 
             datasets = json.loads(txt)
             datafound = {}

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -15,7 +15,7 @@ BASE_URL = "https://gammapy.org/download"
 BASE_URL_DEV = "https://raw.githubusercontent.com/gammapy/gammapy/master/"
 DEV_NBS_YAML_URL = BASE_URL_DEV + "tutorials/notebooks.yaml"
 DEV_SCRIPTS_YAML_URL = BASE_URL_DEV + "examples/scripts.yaml"
-DEV_DATA_JSON_URL = BASE_URL_DEV + "dev/datasets/gammapy-data-index.json"
+DEV_DATA_JSON_LOCAL = "../../dev/datasets/gammapy-data-index.json"
 
 
 def parse_datafiles(datasearch, datasetslist):
@@ -117,17 +117,21 @@ class ComputePlan:
             if self.modetutorials and not self.listfiles:
                 sys.exit()
 
-            url = DEV_DATA_JSON_URL
             if self.release:
                 filename_datasets = "gammapy-" + self.release + "-data-index.json"
                 url = BASE_URL + "/data/" + filename_datasets
-
-            log.info("Reading {}".format(url))
-            try:
-                txt = urlopen(url).read().decode("utf-8")
-            except Exception as ex:
-                log.error(ex)
-                return False
+                log.info("Reading {}".format(url))
+                try:
+                    txt = urlopen(url).read().decode("utf-8")
+                except Exception as ex:
+                    log.error(ex)
+                    return False
+            else:
+                # for development just use the local index file
+                filename = (Path(__file__).parent / DEV_DATA_JSON_LOCAL).resolve()
+                log.info("Reading {}".format(filename))
+                with filename.open(mode="r") as f:
+                    txt = f.read()
 
             datasets = json.loads(txt)
             datafound = {}


### PR DESCRIPTION
This PR includes the following changes:
- Add `dataset-index` target to our `Makefile` to run the creation of the JSON index file.
- Add `dataset-download` target to our `Makefile` to update datasets for developers.
- Change the default index file of `gammapy download datasets` to the local one. This has the slight advantage, that contributors or maintainers can add the updated index file to the PR, that modifies the data files. This way the continuous integration system will download the updated data already. 