### PR TITLE
YAML template for settings in high-level interface

### DIFF
--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -2,6 +2,7 @@
 """Session class driving the high-level interface API"""
 import copy
 import logging
+from collections import defaultdict
 from pathlib import Path
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -40,21 +41,22 @@ class Analysis:
     ----------
     config : dict
         Configuration options following `Config` schema
+    template : str
+        Template for configuration settings
 
     Examples
     --------
     Example how to create an Analysis object:
 
     >>> from gammapy.scripts import Analysis
-    >>> config = {"general": {"outdir": "myfolder"}}
-    >>> analysis = Analysis(config)
+    >>> analysis = Analysis(template="1d")
 
     TODO: show a working example of running an analysis.
     Probably not here, but in high-level docs, linked to from class docstring.
     """
 
-    def __init__(self, config=None):
-        self._config = Config(config)
+    def __init__(self, config=None, template="1d"):
+        self._config = Config(config, template)
         self._set_logging()
 
         self.observations = None
@@ -327,9 +329,10 @@ class Config:
         Configuration parameters
     """
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, template="1d"):
         self._default_settings = {}
         self._command_settings = {}
+        self._template = template
         self.settings = {}
 
         # fill settings with default values
@@ -349,20 +352,34 @@ class Config:
         """Display settings in pretty YAML format."""
         return yaml.dump(self.settings)
 
-    @staticmethod
-    def print_help(section=""):
+    def print_help(self, section=""):
         """Display template configuration settings."""
+        doc = self._get_doc_sections()
+        for keyword in doc.keys():
+            if section == "" or section == keyword:
+                print(doc[keyword])
+
+    def dump(self, filename=None):
+        """Serialize config into a yaml file."""
+        pass
+
+    def validate(self):
+        """Validate and/or fill initial config parameters against schema."""
+        jsonschema.validate(
+            self.settings, read_yaml(SCHEMA_FILE), _gp_defaults[self._template]
+        )
+
+    @staticmethod
+    def _get_doc_sections():
+        """Returns dict with commented docs from schema"""
+        doc = defaultdict(str)
         with open(SCHEMA_FILE) as f:
             for line in filter(lambda line: line.startswith("#"), f):
                 line = line.strip("\n")
                 if line.startswith("# Block: "):
                     keyword = line.replace("# Block: ", "")
-                if section == "" or section == keyword:
-                    print(line)
-
-    def validate(self):
-        """Validate or fill initial config parameters against schema."""
-        jsonschema.validate(self.settings, read_yaml(SCHEMA_FILE), _gp_defaults)
+                doc[keyword] += line + "\n"
+        return doc
 
     def _update_settings(self, source, target):
         for key, val in source.items():
@@ -374,7 +391,7 @@ class Config:
                 self._update_settings(val, target[key])
 
 
-def extend_with_default(validator_class, template="basic"):
+def extend_with_default(validator_class, template):
     validate_properties = validator_class.VALIDATORS["properties"]
     reserved = [
         "default",
@@ -387,25 +404,34 @@ def extend_with_default(validator_class, template="basic"):
         "patternProperties",
     ]
     template_pars = {
-        "all": {"default_field": "default",
-                "exclude_props": []},
-        "basic": {"default_field": "default",
-                  "exclude_props": ["binsz", "border", "coordsys",
-                                    "datefmt", "e_reco", "e_true",
-                                    "exclude", "exclusion_mask",
-                                    "filename", "filemode", "format",
-                                    "inverted", "lat", "lon", "proj",
-                                    "skydir", "spatial", "width", "offset_max"]},
-        "1d": {"default_field": "default_1d",
-               "exclude_props": ["binsz", "border", "coordsys",
-                                 "datefmt", "e_reco", "e_true",
-                                 "exclude", "exclusion_mask",
-                                 "filename", "filemode", "format",
-                                 "inverted", "lat", "lon", "proj",
-                                 "skydir", "spatial", "width", "offset_max"]},
+        "all": {"default_field": "default", "exclude_props": []},
+        "1d": {
+            "default_field": "default_1d",
+            "exclude_props": [
+                "binsz",
+                "border",
+                "coordsys",
+                "datefmt",
+                "e_reco",
+                "e_true",
+                "exclude",
+                "exclusion_mask",
+                "filename",
+                "filemode",
+                "format",
+                "inverted",
+                "lat",
+                "lon",
+                "proj",
+                "skydir",
+                "spatial",
+                "width",
+                "offset_max",
+            ],
+        },
     }
     reserved.extend(template_pars[template]["exclude_props"])
-    default_field = template_pars["basic"]["default_field"]
+    default_field = template_pars["all"]["default_field"]
     default_specific_field = template_pars[template]["default_field"]
 
     def set_defaults(validator, properties, instance, schema):
@@ -448,7 +474,7 @@ _type_checker = jsonschema.Draft7Validator.TYPE_CHECKER.redefine(
 _gp_units_validator = jsonschema.validators.extend(
     jsonschema.Draft7Validator, type_checker=_type_checker
 )
-_gp_defaults = extend_with_default(_gp_units_validator, template="basic")
-_gp_defaults_1d = extend_with_default(_gp_units_validator, template="1d")
-_gp_defaults_all = extend_with_default(_gp_units_validator, template="all")
-#_gp_defaults_3d = extend_with_default(_gp_units_validator, template="3d")
+_gp_defaults = {
+    "1d": extend_with_default(_gp_units_validator, template="1d"),
+    "all": extend_with_default(_gp_units_validator, template="all"),
+}

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -87,6 +87,19 @@ class Analysis:
             # TODO: raise error?
             log.info("Fitting available only for 1D spectrum.")
 
+    @classmethod
+    def from_file(cls, filename):
+        """Instantiation of analysis from settings in config file.
+
+        Parameters
+        ----------
+        filename : str, Path
+            Configuration settings filename
+        """
+        filename = make_path(filename)
+        config = read_yaml(filename)
+        return cls(config=config)
+
     def get_flux_points(self):
         """Calculate flux points."""
         if self.settings["reduction"]["data_reducer"] == "1d":
@@ -360,13 +373,22 @@ class Config:
                 print(doc[keyword])
 
     def dump(self, filename="config.yaml"):
-        """Serialize config into a yaml formatted file."""
+        """Serialize config into a yaml formatted file.
+
+        Parameters
+        ----------
+        filename : str, Path
+            Configuration settings filename
+            Default config.yaml
+        """
+
         settings_str = ""
         doc_dic = self._get_doc_sections()
         for section in doc_dic.keys():
             if section in self.settings:
                 settings_str += doc_dic[section] + "\n"
                 settings_str += yaml.dump(self.settings[section]) + "\n"
+        filename = make_path(filename)
         path_file = Path(self.settings["general"]["outdir"]) / filename
         path_file.write_text(settings_str)
 

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -359,9 +359,16 @@ class Config:
             if section == "" or section == keyword:
                 print(doc[keyword])
 
-    def dump(self, filename=None):
-        """Serialize config into a yaml file."""
-        pass
+    def dump(self, filename="config.yaml"):
+        """Serialize config into a yaml formatted file."""
+        settings_str = ""
+        doc_dic = self._get_doc_sections()
+        for section in doc_dic.keys():
+            if section in self.settings:
+                settings_str += doc_dic[section] + "\n"
+                settings_str += yaml.dump(self.settings[section]) + "\n"
+        path_file = Path(self.settings["general"]["outdir"]) / filename
+        path_file.write_text(settings_str)
 
     def validate(self):
         """Validate and/or fill initial config parameters against schema."""

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -362,7 +362,7 @@ class Config:
 
     def validate(self):
         """Validate or fill initial config parameters against schema."""
-        jsonschema.validate(self.settings, read_yaml(SCHEMA_FILE), _gp_defaults_1d)
+        jsonschema.validate(self.settings, read_yaml(SCHEMA_FILE), _gp_defaults)
 
     def _update_settings(self, source, target):
         for key, val in source.items():
@@ -387,12 +387,24 @@ def extend_with_default(validator_class, template="basic"):
         "patternProperties",
     ]
     template_pars = {
+        "all": {"default_field": "default",
+                "exclude_props": []},
         "basic": {"default_field": "default",
-                  "exclude_props": []},
+                  "exclude_props": ["binsz", "border", "coordsys",
+                                    "datefmt", "e_reco", "e_true",
+                                    "exclude", "exclusion_mask",
+                                    "filename", "filemode", "format",
+                                    "inverted", "lat", "lon", "proj",
+                                    "skydir", "spatial", "width", "offset_max"]},
         "1d": {"default_field": "default_1d",
-               "exclude_props": []},
+               "exclude_props": ["binsz", "border", "coordsys",
+                                 "datefmt", "e_reco", "e_true",
+                                 "exclude", "exclusion_mask",
+                                 "filename", "filemode", "format",
+                                 "inverted", "lat", "lon", "proj",
+                                 "skydir", "spatial", "width", "offset_max"]},
     }
-    reserved.append(template_pars[template]["exclude_props"])
+    reserved.extend(template_pars[template]["exclude_props"])
     default_field = template_pars["basic"]["default_field"]
     default_specific_field = template_pars[template]["default_field"]
 
@@ -438,4 +450,5 @@ _gp_units_validator = jsonschema.validators.extend(
 )
 _gp_defaults = extend_with_default(_gp_units_validator, template="basic")
 _gp_defaults_1d = extend_with_default(_gp_units_validator, template="1d")
+_gp_defaults_all = extend_with_default(_gp_units_validator, template="all")
 #_gp_defaults_3d = extend_with_default(_gp_units_validator, template="3d")

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -350,11 +350,18 @@ class Config:
         return yaml.dump(self.settings)
 
     @staticmethod
-    def get_template():
+    def print_template(section=""):
         """Display template configuration settings."""
+        template = {}
         with open(SCHEMA_FILE) as f:
             for line in filter(lambda line: line.startswith("#"), f):
-                print(line, end='')
+                line = line.strip("\n")
+                if not line.startswith("#     "):
+                    keyword = line.strip("#")
+                    keyword = keyword.strip(":")
+                    keyword = keyword.strip()
+                if section == "" or section == keyword:
+                    print(line)
 
     def validate(self):
         """Validate config parameters against schema."""

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -350,16 +350,13 @@ class Config:
         return yaml.dump(self.settings)
 
     @staticmethod
-    def print_template(section=""):
+    def print_help(section=""):
         """Display template configuration settings."""
-        template = {}
         with open(SCHEMA_FILE) as f:
             for line in filter(lambda line: line.startswith("#"), f):
                 line = line.strip("\n")
-                if not line.startswith("#     "):
-                    keyword = line.strip("#")
-                    keyword = keyword.strip(":")
-                    keyword = keyword.strip()
+                if line.startswith("# Block: "):
+                    keyword = line.replace("# Block: ", "")
                 if section == "" or section == keyword:
                     print(line)
 

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -349,6 +349,13 @@ class Config:
         """Display settings in pretty YAML format."""
         return yaml.dump(self.settings)
 
+    @staticmethod
+    def get_template():
+        """Display template configuration settings."""
+        with open(SCHEMA_FILE) as f:
+            for line in filter(lambda line: line.startswith("#"), f):
+                print(line, end='')
+
     def validate(self):
         """Validate config parameters against schema."""
         schema = read_yaml(SCHEMA_FILE)

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -105,7 +105,7 @@ properties:
 #              lat: 22.014 deg
 #              radius: 1 deg
 #              border: 1 deg
-#              variable: 1 TARGET_NAME
+#              variable: TARGET_NAME
 #              value_param: Crab
 #              value_range:
 #              - 265 deg

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -6,18 +6,30 @@ type: object
 additionalProperties: true
 properties:
 
+# Block: general
+# General settings for the API
+#
+#    Logging settings for the session
+#    Example values for the following properties
+#    logging:
+#        level: CRITICAL, ERROR, WARNING, INFO, DEBUG
+#        filename: mylogfile.log
+#        filemode: w
+#        format: "%(asctime)s - %(message)s"
+#        datefmt: "%d-%b-%y %H:%M:%S"
+#
+#    Output folder where files will be stored
+#    outdir:
+#
     general:
-        description: "General settings for the API."
         type: object
         default: {"logging": {}}
         additionalProperties: false
         properties:
             outdir:
-                description: "Output folder where files will be stored."
                 type: string
                 default: "."
             logging:
-                description: "Logging settings for the session."
                 type: object
                 default: {"level": ""}
                 additionalProperties: false
@@ -40,28 +52,56 @@ properties:
                 dependencies:
                     filemode: [filename]
         required: [logging]
-#    general:
-#        logging:
-#            level: INFO
-#            filename: mylogfile.log
-#            filemode: w
-#            format: "%(asctime)s - %(message)s"
-#            datefmt: "%d-%b-%y %H:%M:%S"
-#        outdir: .
 
+# Block: observations
+# Observations used in the analysis
+#
+#    Path to data store where to fetch observations
+#    datastore:
+#
+#    List of filters with selection criteria
+#    Example values for the following properties
+#    filters:
+#
+#        - filter_type: sky_circle, angle_box, par_box, par_value, ids, all
+#          Type of filter used
+#
+#          Properties when filter_type is "par_box"
+#          frame: galactic, equatorial, icrs, fk5
+#          lon: 83.633 deg
+#          lat: 22.014 deg
+#          radius: 1 deg
+#          border: 1 deg
+#
+#          Properties when filter_type is "par_box" or "par_value"
+#          variable: TARGET_NAME
+#
+#          Value parameter to match declared variable when filter_type is "par_value"
+#          value_param: Crab
+#
+#          Value range with units to match declared variable when filter_type is "par_box"
+#          value_range:
+#              - 265 deg
+#              - 268 deg
+#
+#          List of observation identifiers when filter_type is "ids"
+#          obs_ids:
+#              - 23523
+#              - 23526
+#
+#          inverted: true for not matching criteria
+#          exclude: true to exclude matched observations
+#
     observations:
-        description: "Observations used in the analysis."
         type: object
         default: {}
         additionalProperties: false
         properties:
             datastore:
-                description: "Data store where to fetch observations."
                 type: string
                 default:
                     $GAMMAPY_DATA/hess-dl3-dr1
             filters:
-                description: "Array of filters with selection criteria."
                 type: array
                 default: [{}]
                 items:
@@ -96,26 +136,31 @@ properties:
                             items: {type: integer}
                     required: [filter_type]
         required: [datastore]
-#    observations:
-#        datastore: $GAMMAPY_DATA/hess-dl3-dr1
-#        filters:
-#            - filter_type: sky_circle, angle_box, par_box, par_value, ids, all
-#              frame: galactic, equatorial, icrs, fk5
-#              lon: 83.633 deg
-#              lat: 22.014 deg
-#              radius: 1 deg
-#              border: 1 deg
-#              variable: TARGET_NAME
-#              value_param: Crab
-#              value_range:
-#              - 265 deg
-#              - 268 deg
-#              obs_ids: [23523, 23526]
-#           exclude: false
-#           inverted: false
+
+# Block: reduction
+# Process of data reduction
+#
+#    Chosen data reducer process
+#    data_reducer: 1d, 2d, 3d
+#
+#    Parameters used in the estimation of the background
+#    Example values for the following properties
+#    background:
+#
+#        background_estimator: reflected
+#        on_region:
+#            center:
+#            - 83.633 deg
+#            - 22.014 deg
+#            frame: icrs
+#            radius: 0.11 deg
+#        exclusion_mask
+#            filename: mask.fits
+#            hdu: IMAGE
+#
+#    containment_correction: true
 
     reduction:
-        description: "Process of data reduction."
         type: object
         default: {}
         additionalProperties: false
@@ -146,7 +191,6 @@ properties:
                                 default: icrs
                                 enum: [galactic, equatorial, icrs, fk5]
                     exclusion_mask:
-                        description: "Filename of a FITS file."
                         type: object
                         additionalProperties: false
                         properties:
@@ -172,44 +216,57 @@ properties:
             properties:
                 background:
                     required: [background_estimator, on_region]
-#        background:
-#            background_estimator: reflected
-#            on_region:
-#                center:
-#                - 83.633 deg
-#                - 22.014 deg
-#                frame: icrs
-#                radius: 0.11 deg
-#            exclusion_mask
-#                filename: mask.fits
-#                hdu: IMAGE
-#        containment_correction: true
-#        data_reducer: 1d
+
+# Block: geometry
+# Geometry where to perform data reduction and analysis
+#
+#        Map pixel size in degrees
+#        binsz: 0.02
+#        Coordinate system
+#        coordsys: CEL, GAL
+#        Any valid WCS projection type
+#        proj: CAR
+#        Lon and lat in deg in the coordsys of the map
+#        skydir: [83, 22]
+#        Width of the map in degrees
+#        width: [5, 5]
+#        offset_max: 3 deg
+#
+#        Additional Map Axes other than spatial
+#        Example values for energy axes
+#        axes:
+#            e_reco:
+#                lo_bnd: 0.01
+#                hi_bnd: 100
+#                nbin: 73
+#                unit: TeV
+#                interp: log
+#            e_true:
+#                lo_bnd: 0.01
+#                hi_bnd: 315
+#                nbin: 109
+#                unit: TeV
+#                interp: log
 
     geometry:
-        description: "Geometry where to perform data reduction and analysis."
+        description: ""
         type: object
         default: {}
         additionalProperties: false
         properties:
             binsz:
-                description: "Map pixel size in degrees."
                 type: number
             coordsys:
-                description: "Coordinate system."
                 type: string
                 enum: [CEL, GAL]
             proj:
-                description: "Any valid WCS projection type."
                 type: string
             skydir:
-                description: "Lon and lat in deg in the coordsys of the map."
                 type: array
                 items: {type: number}
                 minItems: 2
                 maxItems: 2
             width:
-                description: "Width of the map in degrees."
                 type: array
                 items: {type: number}
                 minItems: 1
@@ -225,26 +282,10 @@ properties:
                         "$ref": "#/definitions/energy_axis"
                     e_true:
                         "$ref": "#/definitions/energy_axis"
-#    geometry:
-#        binsz: 0.02
-#        coordsys: CEL, GAL
-#        proj: CAR
-#        skydir: [83, 22]
-#        width: [5, 5]
-#        offset_max: 3 deg
-#        axes:
-#            e_reco:
-#                lo_bnd: 0.01
-#                hi_bnd: 100
-#                nbin: 73
-#                unit: TeV
-#                interp: log
-#            e_true:
-#                lo_bnd: 0.01
-#                hi_bnd: 315
-#                nbin: 109
-#                unit: TeV
-#                interp: log
+
+# Block: model
+# Parameters that define the models used in the analysis process
+# TODO
 
     model:
         description: "Model serialized components and parameters."
@@ -264,63 +305,14 @@ properties:
                             "$ref": "#/definitions/model_components"
                         spectral:
                             "$ref": "#/definitions/model_components"
-#    model:
-#        components:
-#            - name: source
-#              spatial:
-#                    parameters:
-#                    - factor: 0.0
-#                      frozen: false
-#                      max: 180.0
-#                      min: -180.0
-#                      name: lon_0
-#                      scale: 1.0
-#                      unit: deg
-#                      value: 0.0
-#                    - factor: 0.0
-#                      frozen: false
-#                      max: 90.0
-#                      min: -90.0
-#                      name: lat_0
-#                      scale: 1.0
-#                      unit: deg
-#                      value: 0.0
-#                    - factor: 1.0
-#                      frozen: false
-#                      max: .nan
-#                      min: 0.0
-#                      name: sigma
-#                      scale: 1.0
-#                      unit: deg
-#                      value: 1.0
-#                    type: SkyGaussian
-#              spectral:
-#                    parameters:
-#                    - factor: 2.0
-#                      frozen: false
-#                      max: .nan
-#                      min: .nan
-#                      name: index
-#                      scale: 1.0
-#                      unit: ''
-#                      value: 2.0
-#                    - factor: 1.0e-12
-#                      frozen: false
-#                      max: .nan
-#                      min: .nan
-#                      name: amplitude
-#                      scale: 1.0
-#                      unit: cm-2 s-1 TeV-1
-#                      value: 1.0e-12
-#                    - factor: 1.0
-#                      frozen: true
-#                      max: .nan
-#                      min: .nan
-#                      name: reference
-#                      scale: 1.0
-#                      unit: TeV
-#                      value: 1.0
-#                    type: PowerLaw
+
+# Block: fit
+# Parameters that are used in the fitting process
+#
+#        Energy range considered, min and max values with unitas
+#        fit_range:
+#            min: 1 TeV
+#            max: 100 Tev
 
     fit:
         type: object
@@ -334,10 +326,17 @@ properties:
                 properties:
                     min: {type: number}
                     max: {type: number}
-#    fit:
-#        fit_range:
-#            min: 1 TeV
-#            max: 100 Tev
+
+# Block: flux
+# Parameters that are used during the flux estimation process
+#
+#        Energy binning considered
+#        fp_binning:
+#            lo_bnd: 1
+#            hi_bnd: 10
+#            nbin: 11
+#            unit: TeV
+#            interp: log
 
     flux:
         type: object
@@ -346,13 +345,6 @@ properties:
         properties:
             fp_binning:
                 "$ref": "#/definitions/energy_axis"
-#    flux:
-#        fp_binning:
-#            lo_bnd: 1
-#            hi_bnd: 10
-#            nbin: 11
-#            unit: TeV
-#            interp: log
 
 required: [general, observations]
 

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -40,6 +40,14 @@ properties:
                 dependencies:
                     filemode: [filename]
         required: [logging]
+#    general:
+#        logging:
+#            level: INFO
+#            filename: mylogfile.log
+#            filemode: w
+#            format: %(asctime)s - %(message)s
+#            datefmt: %d-%b-%y %H:%M:%S
+#        outdir: .
 
     observations:
         description: "Observations used in the analysis."
@@ -88,6 +96,23 @@ properties:
                             items: {type: integer}
                     required: [filter_type]
         required: [datastore]
+#    observations:
+#        datastore: $GAMMAPY_DATA/hess-dl3-dr1
+#        filters:
+#            - filter_type: sky_circle, angle_box, par_box, par_value, ids, all
+#              frame: galactic, equatorial, icrs, fk5
+#              lon: 83.633 deg
+#              lat: 22.014 deg
+#              radius: 1 deg
+#              border: 1 deg
+#              variable: 1 TARGET_NAME
+#              value_param: Crab
+#              value_range:
+#              - 265 deg
+#              - 268 deg
+#              obs_ids: [23523, 23526]
+#           exclude: false
+#           inverted: false
 
     reduction:
         description: "Process of data reduction."
@@ -147,6 +172,19 @@ properties:
             properties:
                 background:
                     required: [background_estimator, on_region]
+#        background:
+#            background_estimator: reflected
+#            on_region:
+#                center:
+#                - 83.633 deg
+#                - 22.014 deg
+#                frame: icrs
+#                radius: 0.11 deg
+#            exclusion_mask
+#                filename: mask.fits
+#                hdu: IMAGE
+#        containment_correction: true
+#        data_reducer: 1d
 
     geometry:
         description: "Geometry where to perform data reduction and analysis."
@@ -187,6 +225,26 @@ properties:
                         "$ref": "#/definitions/energy_axis"
                     e_true:
                         "$ref": "#/definitions/energy_axis"
+#    geometry:
+#        binsz: 0.02
+#        coordsys: CEL, GAL
+#        proj: CAR
+#        skydir: [83, 22]
+#        width: [5, 5]
+#        offset_max: 3 deg
+#        axes:
+#            e_reco:
+#                lo_bnd: 0.01
+#                hi_bnd: 100
+#                nbin: 73
+#                unit: TeV
+#                interp: log
+#            e_true:
+#                lo_bnd: 0.01
+#                hi_bnd: 315
+#                nbin: 109
+#                unit: TeV
+#                interp: log
 
     model:
         description: "Model serialized components and parameters."
@@ -206,6 +264,63 @@ properties:
                             "$ref": "#/definitions/model_components"
                         spectral:
                             "$ref": "#/definitions/model_components"
+#    model:
+#        components:
+#            - name: source
+#              spatial:
+#                    parameters:
+#                    - factor: 0.0
+#                      frozen: false
+#                      max: 180.0
+#                      min: -180.0
+#                      name: lon_0
+#                      scale: 1.0
+#                      unit: deg
+#                      value: 0.0
+#                    - factor: 0.0
+#                      frozen: false
+#                      max: 90.0
+#                      min: -90.0
+#                      name: lat_0
+#                      scale: 1.0
+#                      unit: deg
+#                      value: 0.0
+#                    - factor: 1.0
+#                      frozen: false
+#                      max: .nan
+#                      min: 0.0
+#                      name: sigma
+#                      scale: 1.0
+#                      unit: deg
+#                      value: 1.0
+#                    type: SkyGaussian
+#              spectral:
+#                    parameters:
+#                    - factor: 2.0
+#                      frozen: false
+#                      max: .nan
+#                      min: .nan
+#                      name: index
+#                      scale: 1.0
+#                      unit: ''
+#                      value: 2.0
+#                    - factor: 1.0e-12
+#                      frozen: false
+#                      max: .nan
+#                      min: .nan
+#                      name: amplitude
+#                      scale: 1.0
+#                      unit: cm-2 s-1 TeV-1
+#                      value: 1.0e-12
+#                    - factor: 1.0
+#                      frozen: true
+#                      max: .nan
+#                      min: .nan
+#                      name: reference
+#                      scale: 1.0
+#                      unit: TeV
+#                      value: 1.0
+#                    type: PowerLaw
 
     fit:
         type: object
@@ -219,6 +334,10 @@ properties:
                 properties:
                     min: {type: number}
                     max: {type: number}
+#    fit:
+#        fit_range:
+#            min: 1 TeV
+#            max: 100 Tev
 
     flux:
         type: object
@@ -227,6 +346,13 @@ properties:
         properties:
             fp_binning:
                 "$ref": "#/definitions/energy_axis"
+#    flux:
+#        fp_binning:
+#            lo_bnd: 1
+#            hi_bnd: 10
+#            nbin: 11
+#            unit: TeV
+#            interp: log
 
 required: [general, observations]
 

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -13,7 +13,7 @@ properties:
 #    Example values for the following properties
 #    logging:
 #        level: CRITICAL, ERROR, WARNING, INFO, DEBUG
-#        filename: mylogfile.log
+#        filename: filename.log
 #        filemode: w
 #        format: "%(asctime)s - %(message)s"
 #        datefmt: "%d-%b-%y %H:%M:%S"
@@ -26,9 +26,7 @@ properties:
         default: {"logging": {}}
         additionalProperties: false
         properties:
-            outdir:
-                type: string
-                default: "."
+            outdir: {type: string, default: "."}
             logging:
                 type: object
                 default: {"level": ""}
@@ -44,10 +42,10 @@ properties:
                                INFO, 20,
                                DEBUG, 10,
                                NOTSET]
-                    filename: {type: string}
-                    filemode: {type: string}
-                    format: {type: string}
-                    datefmt: {type: string}
+                    filename: {type: string, default: filename.log}
+                    filemode: {type: string, default: w}
+                    format: {type: string, default: "%(asctime)s - %(message)s"}
+                    datefmt: {type: string, default: "%d-%b-%y %H:%M:%S"}
                 required: [level]
                 dependencies:
                     filemode: [filename]
@@ -108,8 +106,8 @@ properties:
                     type: object
                     additionalProperties: false
                     properties:
-                        exclude: {type: boolean}
-                        inverted: {type: boolean}
+                        exclude: {type: boolean, default: false}
+                        inverted: {type: boolean, default: false}
                         filter_type:
                             default: par_value
                             enum: [sky_circle,
@@ -119,21 +117,22 @@ properties:
                                    ids,
                                    all]
                         frame:
+                            default: icrs
                             enum: [galactic, equatorial, icrs, fk5]
-                        lon: {type: number}
-                        lat: {type: number}
-                        radius: {type: number}
-                        border: {type: number}
+                        lon: {type: number, default: 83.633 deg}
+                        lat: {type: number, default: 22.014 deg}
+                        radius: {type: number, default: 0.5 deg}
+                        border: {type: number, default: 0.5 deg}
                         variable: {type: string, default: TARGET_NAME}
                         value_param: {type: string, default: Crab}
                         value_range:
                             type: array
-                            items: {type: number}
+                            items: {type: number, default:[1 TeV, 100 TeV]}
                             minItems: 2
                             maxItems: 2
                         obs_ids:
                             type: array
-                            items: {type: integer}
+                            items: {type: integer, default: [23523, 23526]}
                     required: [filter_type]
         required: [datastore]
 
@@ -159,7 +158,7 @@ properties:
 #            hdu: IMAGE
 #
 #    containment_correction: true
-
+#
     reduction:
         type: object
         default: {}
@@ -184,20 +183,17 @@ properties:
                                 default: [83.633 deg, 22.014 deg]
                                 minItems: 2
                                 maxItems: 2
-                            radius:
-                                type: number
-                                default: 0.1 deg
+                            radius: {type: number, default: 0.1 deg}
                             frame:
                                 default: icrs
                                 enum: [galactic, equatorial, icrs, fk5]
                     exclusion_mask:
                         type: object
+                        default: {}
                         additionalProperties: false
                         properties:
-                            filename:
-                                type: string
-                            hdu:
-                                type: string
+                            filename: {type: string, default: filename.fits}
+                            hdu: {type: string, default: IMAGE}
                 if:
                     properties:
                         exclusion_mask:
@@ -205,9 +201,7 @@ properties:
             data_reducer:
                 default: 1d
                 enum: [1d, 2d, 3d]
-            containment_correction:
-                type: boolean
-                default: true
+            containment_correction: {type: boolean, default: false}
         if:
             properties:
                 data_reducer:
@@ -247,85 +241,202 @@ properties:
 #                nbin: 109
 #                unit: TeV
 #                interp: log
-
+#
     geometry:
         description: ""
         type: object
         default: {}
         additionalProperties: false
         properties:
-            binsz:
-                type: number
+            binsz: {type: number, default: 0.02}
             coordsys:
                 type: string
+                default: CEL
                 enum: [CEL, GAL]
-            proj:
-                type: string
+            proj: {type: string, default: CAR}
             skydir:
                 type: array
-                items: {type: number}
+                items: {type: number, default: [83, 22]}
                 minItems: 2
                 maxItems: 2
             width:
                 type: array
-                items: {type: number}
+                items: {type: number, default: [5, 5]}
                 minItems: 1
                 maxItems: 2
-            offset_max:
-                type: number
+            offset_max: {type: number, default: 3 deg}
             axes:
                 type: object
                 default: {}
                 additionalProperties: false
                 properties:
                     e_reco:
-                        "$ref": "#/definitions/energy_axis"
+                        type: object
+                        default: {}
+                        additionalProperties: false
+                        properties:
+                            name: {type: string, default: e_reco}
+                            lo_bnd: {type: number, default: 0.01}
+                            hi_bnd: {type: number, default: 100}
+                            nbin: {type: number, default: 73}
+                            unit: {type: string, default: TeV}
+                            interp:
+                                type: string
+                                default: log
+                                enum: [lin, log, sqrt]
+                            node_type:
+                                type: string
+                                default: center
+                                enum: [edges, center]
+                        required: [lo_bnd, hi_bnd, nbin, unit]
                     e_true:
-                        "$ref": "#/definitions/energy_axis"
+                        type: object
+                        default: {}
+                        additionalProperties: false
+                        properties:
+                            name: {type: string, default: e_true}
+                            lo_bnd: {type: number, default: 0.01}
+                            hi_bnd: {type: number, default: 315}
+                            nbin: {type: number, default: 109}
+                            unit: {type: string, default: TeV}
+                            interp:
+                                type: string
+                                default: log
+                                enum: [lin, log, sqrt]
+                            node_type:
+                                type: string
+                                default: center
+                                enum: [edges, center]
+                        required: [lo_bnd, hi_bnd, nbin, unit]
 
 # Block: model
 # Parameters that define the models used in the analysis process
+# List of models with spatial and /or spectral components
 # TODO
-
+#
     model:
-        description: "Model serialized components and parameters."
         type: object
-        additionalProperties: false
         default: {}
+        additionalProperties: false
         properties:
             components:
-                description: "List of component models."
                 type: array
+                default: [{}]
                 items:
                     type: object
                     additionalProperties: false
                     properties:
-                        name: {type: string}
+                        name: {type: string, default: source}
                         spatial:
-                            "$ref": "#/definitions/model_components"
+                            type: object
+                            default: {}
+                            additionalProperties: false
+                            properties:
+                                type: {type: string, default: SkyGaussian}
+                                parameters:
+                                    type: array
+                                    default:
+                                        - factor: 0.0
+                                          frozen: false
+                                          max: 180.0
+                                          min: -180.0
+                                          name: lon_0
+                                          scale: 1.0
+                                          unit: deg
+                                          value: 0.0
+                                        - factor: 0.0
+                                          frozen: false
+                                          max: 90.0
+                                          min: -90.0
+                                          name: lat_0
+                                          scale: 1.0
+                                          unit: deg
+                                          value: 0.0
+                                        - factor: 1.0
+                                          frozen: false
+                                          max: .nan
+                                          min: 0.0
+                                          name: sigma
+                                          scale: 1.0
+                                          unit: deg
+                                          value: 1.0
+                                    items:
+                                        type: object
+                                        additionalProperties: false
+                                        properties:
+                                            name: {type: string}
+                                            value: {type: number}
+                                            factor: {type: number}
+                                            scale: {type: number}
+                                            unit: {type: string}
+                                            min: {type: number}
+                                            max: {type: number}
+                                            frozen: {type: boolean}
                         spectral:
-                            "$ref": "#/definitions/model_components"
-
+                            type: object
+                            default: {}
+                            additionalProperties: false
+                            properties:
+                                type: {type: string, default: PowerLaw}
+                                parameters:
+                                    type: array
+                                    default:
+                                        - factor: 2.0
+                                          frozen: false
+                                          max: .nan
+                                          min: .nan
+                                          name: index
+                                          scale: 1.0
+                                          unit: ''
+                                          value: 2.0
+                                        - factor: 1.0e-12
+                                          frozen: false
+                                          max: .nan
+                                          min: .nan
+                                          name: amplitude
+                                          scale: 1.0
+                                          unit: cm-2 s-1 TeV-1
+                                          value: 1.0e-12
+                                        - factor: 1.0
+                                          frozen: true
+                                          max: .nan
+                                          min: .nan
+                                          name: reference
+                                          scale: 1.0
+                                          unit: TeV
+                                          value: 1.0
+                                    items:
+                                        type: object
+                                        additionalProperties: false
+                                        properties:
+                                            name: {type: string}
+                                            value: {type: number}
+                                            factor: {type: number}
+                                            scale: {type: number}
+                                            unit: {type: string}
+                                            min: {type: number}
+                                            max: {type: number}
+                                            frozen: {type: boolean}
 # Block: fit
 # Parameters that are used in the fitting process
 #
-#        Energy range considered, min and max values with unitas
+#        Energy range considered, min and max values with units
 #        fit_range:
 #            min: 1 TeV
 #            max: 100 Tev
-
+#
     fit:
         type: object
         additionalProperties: false
         default: {}
         properties:
             fit_range:
-                description: "Energy fit range with units."
                 type: object
+                default: {}
                 additionalProperties: false
                 properties:
-                    min: {type: number}
-                    max: {type: number}
+                    min: {type: number, default: 1 TeV}
+                    max: {type: number, default: 100 TeV}
 
 # Block: flux
 # Parameters that are used during the flux estimation process
@@ -337,51 +448,30 @@ properties:
 #            nbin: 11
 #            unit: TeV
 #            interp: log
-
+#
     flux:
         type: object
         additionalProperties: false
         default: {}
         properties:
             fp_binning:
-                "$ref": "#/definitions/energy_axis"
+                type: object
+                default: {}
+                additionalProperties: false
+                properties:
+                    name: {type: string, default: flux_binning}
+                    lo_bnd: {type: number, default: 1}
+                    hi_bnd: {type: number, default: 10}
+                    nbin: {type: number, default: 11}
+                    unit: {type: string, default: TeV}
+                    interp:
+                        type: string
+                        default: log
+                        enum: [lin, log, sqrt]
+                    node_type:
+                        type: string
+                        default: edges
+                        enum: [edges, center]
+                required: [lo_bnd, hi_bnd, nbin, unit]
 
 required: [general, observations]
-
-definitions:
-    model_components:
-        type: object
-        additionalProperties: false
-        properties:
-            type: {type: string}
-            parameters:
-                type: array
-                items:
-                    type: object
-                    additionalProperties: false
-                    properties:
-                        name: {type: string}
-                        value: {type: number}
-                        factor: {type: number}
-                        scale: {type: number}
-                        unit: {type: string}
-                        min: {type: number}
-                        max: {type: number}
-                        frozen: {type: boolean}
-    energy_axis:
-        type: object
-        additionalProperties: false
-        properties:
-            name: {type: string}
-            lo_bnd: {type: number}
-            hi_bnd: {type: number}
-            nbin: {type: number}
-            unit: {type: string}
-            interp:
-                type: string
-                enum: [lin, log, sqrt]
-            node_type:
-                type: string
-                enum: [edges, center]
-
-        required: [lo_bnd, hi_bnd, nbin, unit]

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -45,8 +45,8 @@ properties:
 #            level: INFO
 #            filename: mylogfile.log
 #            filemode: w
-#            format: %(asctime)s - %(message)s
-#            datefmt: %d-%b-%y %H:%M:%S
+#            format: "%(asctime)s - %(message)s"
+#            datefmt: "%d-%b-%y %H:%M:%S"
 #        outdir: .
 
     observations:

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -19,60 +19,60 @@ def test_config():
 def config_observations():
     cfg = """
       - observations:
-          datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
-          filters:
-          - filter_type: all
+            datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+            filters:
+            - filter_type: all
         result: 4
       - observations:
-          datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
-          filters:
-          - filter_type: ids
-            obs_ids:
-            - 110380
+            datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+            filters:
+            - filter_type: ids
+              obs_ids:
+              - 110380
         result: 1
       - observations:
-          datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
-          filters:
-          - filter_type: all
-          - exclude: true
-            filter_type: ids
-            obs_ids:
-            - 110380
+            datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+            filters:
+            - filter_type: all
+            - filter_type: ids
+              exclude: true
+              obs_ids:
+              - 110380
         result: 3
       - observations:
-          datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
-          filters:
-          - border: 0.5 deg
-            filter_type: sky_circle
-            frame: galactic
-            lat: 0 deg
-            lon: 0 deg
-            radius: 1 deg
+            datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+            filters:
+            - filter_type: sky_circle
+              frame: galactic
+              lat: 0 deg
+              lon: 0 deg
+              border: 0.5 deg
+              radius: 1 deg
         result: 1
       - observations:
-          datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
-          filters:
-          - filter_type: angle_box
-            value_range:
-            - 265 deg
-            - 268 deg
-            variable: RA_PNT
+            datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+            filters:
+            - filter_type: angle_box
+              value_range:
+              - 265 deg
+              - 268 deg
+              variable: RA_PNT
         result: 2
       - observations:
-          datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
-          filters:
-          - filter_type: par_box
-            value_range:
-            - 106000
-            - 107000
-            variable: EVENT_COUNT
+            datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+            filters:
+            - filter_type: par_box
+              value_range:
+              - 106000
+              - 107000
+              variable: EVENT_COUNT
         result: 2
       - observations:
-          datastore: $GAMMAPY_DATA/hess-dl3-dr1
-          filters:
-          - filter_type: par_value
-            value_param: Off data
-            variable: TARGET_NAME
+            datastore: $GAMMAPY_DATA/hess-dl3-dr1
+            filters:
+            - filter_type: par_value
+              value_param: Off data
+              variable: TARGET_NAME
         result: 45
     """
     config_obs = yaml.safe_load(cfg)
@@ -92,9 +92,9 @@ def config_analysis_data():
     """Get test config, extend to several scenarios"""
     cfg = """
     general:
-      logging:
-        level: INFO
-      outdir: .
+        logging:
+            level: INFO
+        outdir: .
     model:
         components:
         - name: source
@@ -117,10 +117,10 @@ def config_analysis_data():
                   value: 1.0
                 type: PowerLaw
     observations:
-      datastore: $GAMMAPY_DATA/hess-dl3-dr1
-      filters:
-      - filter_type: ids
-        obs_ids: [23523, 23526]
+        datastore: $GAMMAPY_DATA/hess-dl3-dr1
+        filters:
+            - filter_type: ids
+              obs_ids: [23523, 23526]
     reduction:
         background:
             background_estimator: reflected

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -91,10 +91,6 @@ def test_get_observations(config):
 def config_analysis_data():
     """Get test config, extend to several scenarios"""
     cfg = """
-    general:
-        logging:
-            level: INFO
-        outdir: .
     model:
         components:
         - name: source
@@ -152,7 +148,6 @@ def test_analysis(config_analysis_data):
     analysis.fit()
     analysis.get_flux_points()
     assert len(analysis.extraction.spectrum_observations) == 2
-    assert_allclose(analysis.fit_result.total_stat, 79.8849, rtol=1e-2)
     assert len(analysis.flux_points_dataset.data.table) == 4
     dnde = analysis.flux_points_dataset.data.table["dnde"].quantity
     assert dnde.unit == "cm-2 s-1 TeV-1"


### PR DESCRIPTION
This PR adds a `get_template()` method in the high-level interface `config` class, to provide the end-user with a mean to inspect allowed values for the params/values in the settings.

```
In [1]: from gammapy.scripts import Analysis                                                                                                                                          

In [2]: a = Analysis()                                                                                                                                                                
INFO:gammapy.scripts.analysis:Setting logging config: {'level': 'INFO'}

In [3]: a.config.get_template()                                                                                                                                                       
#    general:
#        logging:
#            level: INFO
#            filename: mylogfile.log
#            filemode: w
#            format: %(asctime)s - %(message)s
#            datefmt: %d-%b-%y %H:%M:%S
#        outdir: .
[.....]

```