### PR TITLE
Simplify and extend  background model handling

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -187,7 +187,7 @@ class DMAnnihilation(SpectralModel):
             scale
             * self.jfactor
             * self.THERMAL_RELIC_CROSS_SECTION
-            * self.primary_flux.evaluate(energy=energy * (1 + self.z), norm=1)
+            * self.primary_flux(energy=energy * (1 + self.z))
             / self.k
             / self.mass
             / self.mass

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -618,21 +618,14 @@ class SkyDiffuseConstant(SkySpatialModel):
     value : `~astropy.units.Quantity`
         Value
     """
-
-    __slots__ = ["value"]
-
     frame = None
     tag = "SkyDiffuseConstant"
+    evaluation_radius = None
 
     def __init__(self, value=1):
-        self.value = Parameter("value", value)
+        self.value = Parameter("value", value, frozen=True)
 
         super().__init__([self.value])
-
-    @property
-    def evaluation_radius(self):
-        """Evaluation radius (``None``)."""
-        return None
 
     @staticmethod
     def evaluate(lon, lat, value):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -188,7 +188,7 @@ class Map(abc.ABC):
             return Map.from_hdulist(hdulist, hdu, hdu_bands, map_type)
 
     @staticmethod
-    def from_geom(geom, meta=None, data=None, map_type="auto", unit=""):
+    def from_geom(geom, meta=None, data=None, map_type="auto", unit="", dtype="float32"):
         """Generate an empty map from a `MapGeom` instance.
 
         Parameters
@@ -226,7 +226,7 @@ class Map(abc.ABC):
                 raise ValueError("Unrecognized geom type.")
 
         cls_out = Map._get_map_cls(map_type)
-        return cls_out(geom, data=data, meta=meta, unit=unit)
+        return cls_out(geom, data=data, meta=meta, unit=unit, dtype=dtype)
 
     @staticmethod
     def from_hdulist(hdulist, hdu=None, hdu_bands=None, map_type="auto"):

--- a/gammapy/utils/serialization/tests/test_io.py
+++ b/gammapy/utils/serialization/tests/test_io.py
@@ -145,24 +145,15 @@ def test_datasets_to_io(tmpdir):
     ]
 
     assert isinstance(dataset0.model, SkyModels)
-    assert len(dataset0.model.skymodels) == 2
+    assert len(dataset0.model.skymodels) == 1
     assert dataset0.model.skymodels[0].name == "gc"
-    assert dataset0.model.skymodels[1].name == "g09"
     assert (
         dataset0.model.skymodels[0].parameters["reference"]
-        is dataset0.model.skymodels[1].parameters["reference"]
-    )
-    assert (
-        dataset1.model.skymodels[0].parameters["reference"]
-        is dataset1.model.skymodels[1].parameters["reference"]
-    )
-    assert (
-        dataset0.model.skymodels[0].parameters["reference"]
-        is dataset1.model.skymodels[1].parameters["reference"]
+        is dataset1.model.skymodels[0].parameters["reference"]
     )
 
     assert_allclose(
-        dataset0.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
+        dataset1.model.skymodels[0].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
     path = str(tmpdir / "/written_")

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -61,8 +61,8 @@
     "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
     "from gammapy.spectrum.models import TableModel, PowerLaw\n",
     "from gammapy.image.models import SkyPointSource, SkyDiffuseConstant\n",
-    "from gammapy.cube.models import SkyModel, SkyDiffuseCube, BackgroundModel\n",
-    "from gammapy.cube import MapDataset, PSFKernel\n",
+    "from gammapy.cube.models import SkyModel, SkyDiffuseCube, SkyModels\n",
+    "from gammapy.cube import MapDataset, PSFKernel, MapEvaluator\n",
     "from gammapy.utils.fitting import Fit"
    ]
   },
@@ -176,6 +176,7 @@
     "    coordsys=\"GAL\",\n",
     "    binsz=0.1,\n",
     "    axes=[energy_axis],\n",
+    "    dtype=float,\n",
     ")\n",
     "# We put this call into the same Jupyter cell as the Map.create\n",
     "# because otherwise we could accidentally fill the counts\n",
@@ -269,7 +270,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exposure = WcsNDMap(geom, data, unit=exposure_hpx.unit)\n",
+    "exposure = WcsNDMap(geom, data, unit=exposure_hpx.unit, dtype=float)\n",
     "print(exposure.geom)\n",
     "print(exposure.geom.axes[0])"
    ]
@@ -552,15 +553,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = SkyDiffuseCube(diffuse_galactic)\n",
+    "model_diffuse = SkyDiffuseCube(diffuse_galactic, name=\"diffuse\")\n",
+    "eval_diffuse = MapEvaluator(model=model_diffuse, exposure=exposure, psf=psf_kernel, edisp=edisp)\n",
     "\n",
-    "background_gal = BackgroundModel.from_skymodel(\n",
-    "    model, exposure=exposure, psf=psf_kernel, edisp=edisp\n",
-    ")\n",
+    "background_gal = eval_diffuse.compute_npred()\n",
     "\n",
-    "background_gal.map.sum_over_axes().plot()\n",
+    "background_gal.sum_over_axes().plot()\n",
     "print(\n",
-    "    \"Background counts from Galactic diffuse: \", background_gal.map.data.sum()\n",
+    "    \"Background counts from Galactic diffuse: \", background_gal.data.sum()\n",
     ")"
    ]
   },
@@ -570,15 +570,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = SkyModel(SkyDiffuseConstant(), diffuse_iso)\n",
+    "model_iso = SkyModel(SkyDiffuseConstant(), diffuse_iso, name=\"diffuse-iso\")\n",
     "\n",
-    "background_iso = BackgroundModel.from_skymodel(\n",
-    "    model, exposure=exposure, edisp=edisp\n",
-    ")\n",
+    "eval_iso = MapEvaluator(model=model_iso, exposure=exposure, edisp=edisp)\n",
     "\n",
-    "background_iso.map.sum_over_axes().plot(add_cbar=True)\n",
+    "background_iso = eval_iso.compute_npred()\n",
+    "\n",
+    "background_iso.sum_over_axes().plot(add_cbar=True)\n",
     "print(\n",
-    "    \"Background counts from isotropic diffuse: \", background_iso.map.data.sum()\n",
+    "    \"Background counts from isotropic diffuse: \", background_iso.data.sum()\n",
     ")"
    ]
   },
@@ -607,7 +607,7 @@
    "outputs": [],
    "source": [
     "excess = counts.copy()\n",
-    "excess.data -= background_total.evaluate().data\n",
+    "excess.data -= background_total.data\n",
     "excess.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
     "    cmap=\"coolwarm\", vmin=-5, vmax=5, add_cbar=True\n",
     ")\n",
@@ -646,11 +646,12 @@
     "    PowerLaw(index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"),\n",
     ")\n",
     "\n",
+    "model_total = SkyModels([model, model_diffuse, model_iso])\n",
+    "\n",
     "dataset = MapDataset(\n",
-    "    model=model,\n",
+    "    model=model_total,\n",
     "    counts=counts,\n",
     "    exposure=exposure,\n",
-    "    background_model=background_total,\n",
     "    psf=psf_kernel,\n",
     ")\n",
     "fit = Fit(dataset)\n",


### PR DESCRIPTION
This PR improve the background model handling on the tutorial and implements related changes:
- Add the background models as `SkyModel` and not separate `BackgroundModel` components in the Fermi-LAT tutorial
- Add `tilt` and `reference` parameter to `SkyDiffuseCube`
- Add `tilt` and `reference` parameter to `TableModel`
- Add `dtype` argument for `Map.from_geom()`, which was previously missing
- Set `SkyDiffuseConstant.evaluation_radius` to `None`, which switches of the evaluation radius handling