### PR TITLE
Cleanup background model YAML serilization

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -562,6 +562,21 @@ class MapDataset(Dataset):
         hdulist = fits.open(str(filename))
         return cls.from_hdulist(hdulist, name=name)
 
+    def to_dict(self, filename=""):
+        """Create dict for YAML serilisation
+
+        Returns
+        -------
+        data : dict
+            Dict with data for the YAML serilisation.
+        """
+        data = {}
+        data["name"] = self.name
+        data["models"] = self.model.names
+        data["backgrounds"] = [_.name for _ in self.background_model.models]
+        data["filename"] = filename
+        return data
+
 
 class MapEvaluator:
     """Sky model evaluation on maps.

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -302,6 +302,14 @@ class SkyModel(SkyModelBase):
         kwargs.setdefault("name", self.name + "-copy")
         return self.__class__(**kwargs)
 
+    def to_dict(self, selection):
+        """Create dict for YAML serilisation"""
+        data = {}
+        data["spatial"] = self.spatial_model.to_dict(selection)
+        data["spectral"] = self.spectral_model.to_dict(selection)
+        return data
+
+
 
 class SkyDiffuseCube(SkyModelBase):
     """Cube sky map template model (3D).

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -504,6 +504,8 @@ class BackgroundModel(Model):
     def to_dict(self, selection):
         data = super().to_dict(selection=selection)
         data["name"] = self.name
+        if self.filename is not None:
+            data["filename"] = self.filename
         return data
 
 

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -358,6 +358,9 @@ class SkyDiffuseCube(SkyModelBase):
         interp_kwargs.setdefault("interp", "linear")
         interp_kwargs.setdefault("fill_value", 0)
         self._interp_kwargs = interp_kwargs
+
+        # TODO: onve we have implement a more general and better model caching
+        #  remove this again
         self._cached_value = None
         self._cached_coordinates = (None, None, None)
 
@@ -391,7 +394,10 @@ class SkyDiffuseCube(SkyModelBase):
 
     def evaluate(self, lon, lat, energy):
         """Evaluate model."""
-        if not np.all(_ is ref for _, ref in zip(self._cached_coordinates, [lon, lat, energy])):
+        is_cached_coord = [_ is coord for _, coord in zip((lon, lat, energy), self._cached_coordinates)]
+
+        # reset cache
+        if not np.all(is_cached_coord):
             self._cached_value = None
 
         if self._cached_value is None:

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -476,40 +476,6 @@ class BackgroundModel(Model):
         back_values = norm * self.map.data * tilt_factor.value
         return self.map.copy(data=back_values)
 
-    @classmethod
-    def from_skymodel(
-        cls, skymodel, exposure, name=None, edisp=None, psf=None, **kwargs
-    ):
-        """Create background model from sky model by applying IRFs.
-
-        Typically used for diffuse Galactic or constant emission models.
-
-        Parameters
-        ----------
-        skymodel : `~gammapy.cube.models.SkyModel` or `~gammapy.cube.models.SkyDiffuseCube`
-            Sky model
-        exposure : `~gammapy.maps.Map`
-            Exposure map
-        edisp : `~gammapy.irf.EnergyDispersion`
-            Energy dispersion
-        psf : `~gammapy.cube.PSFKernel`
-            PSF kernel
-        """
-        from .fit import MapEvaluator
-
-        evaluator = MapEvaluator(
-            model=skymodel, exposure=exposure, edisp=edisp, psf=psf
-        )
-        background = evaluator.compute_npred()
-        background_model = cls(background=background, **kwargs)
-        if name is None:
-            background_model.name = skymodel.name
-        else:
-            background_model.name = name
-        if skymodel.__class__.__name__ == "SkyDiffuseCube":
-            background_model.filename = skymodel.filename
-        return background_model
-
     def __add__(self, model):
         models = [self]
         if isinstance(model, BackgroundModels):

--- a/gammapy/cube/models.py
+++ b/gammapy/cube/models.py
@@ -201,7 +201,7 @@ class SkyModel(SkyModelBase):
     name : str
         Model identifier
     """
-
+    tag = "SkyModel"
     __slots__ = ["name", "_spatial_model", "_spectral_model"]
 
     def __init__(self, spatial_model, spectral_model, name="source"):
@@ -305,10 +305,11 @@ class SkyModel(SkyModelBase):
     def to_dict(self, selection):
         """Create dict for YAML serilisation"""
         data = {}
+        data["type"] = self.tag
+        data["name"] = self.name
         data["spatial"] = self.spatial_model.to_dict(selection)
         data["spectral"] = self.spectral_model.to_dict(selection)
         return data
-
 
 
 class SkyDiffuseCube(SkyModelBase):
@@ -334,7 +335,7 @@ class SkyDiffuseCube(SkyModelBase):
         Default arguments are {'interp': 'linear', 'fill_value': 0}.
 
     """
-
+    tag = "SkyDiffuseCube"
     __slots__ = ["map", "norm", "meta", "_interp_kwargs"]
 
     def __init__(
@@ -421,6 +422,12 @@ class SkyDiffuseCube(SkyModelBase):
             setattr(init, parameter.name, parameter)
         return init
 
+    def to_dict(self, selection):
+        data = super().to_dict(selection=selection)
+        data["filename"] = self.filename
+        data["name"] = self.name
+        return data
+
 
 class BackgroundModel(Model):
     """Background model.
@@ -438,7 +445,7 @@ class BackgroundModel(Model):
     reference : `~astropy.units.Quantity`
         Reference energy of the tilt.
     """
-
+    tag = "BackgroundModel"
     __slots__ = ["map", "norm", "tilt", "reference", "name", "filename"]
 
     def __init__(
@@ -493,6 +500,11 @@ class BackgroundModel(Model):
         else:
             raise NotImplementedError
         return BackgroundModels(models)
+
+    def to_dict(self, selection):
+        data = super().to_dict(selection=selection)
+        data["name"] = self.name
+        return data
 
 
 class BackgroundModels(Model):

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -733,3 +733,9 @@ class SkyDiffuseMap(SkySpatialModel):
         for parameter in init.parameters.parameters:
             setattr(init, parameter.name, parameter)
         return init
+
+    def to_dict(self, selection):
+        data = super().to_dict(selection=selection)
+        data["filename"] = self.filename
+        return data
+

--- a/gammapy/image/models/core.py
+++ b/gammapy/image/models/core.py
@@ -68,7 +68,7 @@ class SkyPointSource(SkySpatialModel):
     frame : {"galactic", "icrs"}
         Coordinate frame of `lon_0` and `lat_0`.
     """
-
+    tag = "SkyPointSource"
     __slots__ = ["frame", "lon_0", "lat_0"]
 
     def __init__(self, lon_0, lat_0, frame="galactic"):

--- a/gammapy/utils/fitting/model.py
+++ b/gammapy/utils/fitting/model.py
@@ -42,7 +42,7 @@ class Model:
 
     def to_dict(self, selection="all"):
         return {
-            "type": getattr(self, "tag", self.__class__.__name__),
+            "type": self.tag,
             "parameters": self.parameters.to_dict(selection)["parameters"],
         }
 

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -30,7 +30,7 @@ def models_to_dict(models, selection="all"):
 
     models_data = []
     for model in models:
-        model_data = _model_to_dict(model, selection)
+        model_data = model.to_dict(selection)
         # De-duplicate if model appears several times
         if model_data not in models_data:
             models_data.append(model_data)
@@ -58,18 +58,6 @@ def _restore_shared_parameters(models):
     for model in models:
         for param in model.parameters:
             param.name = param.name.split("@")[0]
-
-
-def _model_to_dict(model, selection):
-    data = {}
-    if getattr(model, "filename", None) is not None:
-        data["filename"] = model.filename
-    if model.__class__.__name__ == "SkyModel":
-        data.update(model.to_dict(selection=selection))
-    else:
-        data.update(model.to_dict(selection))
-
-    return data
 
 
 def dict_to_models(data, link=True):

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -149,35 +149,32 @@ def _link_shared_parameters(models):
 
 def datasets_to_dict(datasets, path, selection, overwrite):
     from gammapy.utils.serialization import models_to_dict
-    from gammapy.cube.models import BackgroundModels, SkyModels
+    from gammapy.cube.models import BackgroundModels
 
-    models_list = []
-    backgrounds_list = []
+    unique_models = []
+    unique_backgrounds = []
     datasets_dictlist = []
+
     for dataset in datasets:
         filename = path + "data_" + dataset.name + ".fits"
         dataset.write(filename, overwrite)
+        datasets_dictlist.append(dataset.to_dict(filename=filename))
+
+        for model in dataset.model.skymodels:
+            if model not in unique_models:
+                unique_models.append(model)
 
         if isinstance(dataset.background_model, BackgroundModels):
             backgrounds = dataset.background_model.models
         else:
             backgrounds = [dataset.background_model]
-        if isinstance(dataset.model, SkyModels):
-            models = dataset.model.skymodels
-        else:
-            models = [dataset.model]
 
-        datasets_dictlist.append(dataset.to_dict(filename=filename))
-
-        for model in models:
-            if model not in models_list:
-                models_list.append(model)
         for background in backgrounds:
-            if background not in backgrounds_list:
-                backgrounds_list.append(background)
+            if background not in unique_backgrounds:
+                unique_backgrounds.append(background)
 
     datasets_dict = {"datasets": datasets_dictlist}
-    components_dict = models_to_dict(models_list + backgrounds_list, selection)
+    components_dict = models_to_dict(unique_models + unique_backgrounds, selection)
     return datasets_dict, components_dict
 
 

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities to serialize models."""
-import astropy.units as u
-from gammapy.cube.fit import MapDataset
+from gammapy.cube.fit import MapDataset, MapEvaluator
 from gammapy.cube.models import (
     BackgroundModel,
     BackgroundModels,
@@ -248,9 +247,9 @@ class dict_to_datasets:
             except KeyError:
                 cube = SkyDiffuseCube.read(component["filename"])
                 self.cube_register[component["name"]] = cube
-            background_model = BackgroundModel.from_skymodel(
-                cube, exposure=dataset.exposure, psf=dataset.psf, edisp=dataset.edisp
-            )
+
+            evaluator = MapEvaluator(model=cube, exposure=dataset.exposure, psf=dataset.psf, edisp=dataset.edisp)
+            background_model = BackgroundModel(evaluator.compute_npred())
         else:
             if component["name"].strip().upper() in bkg_prev:
                 BGind = bkg_prev.index(component["name"].strip().upper())

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -157,6 +157,7 @@ def datasets_to_dict(datasets, path, selection, overwrite):
     for dataset in datasets:
         filename = path + "data_" + dataset.name + ".fits"
         dataset.write(filename, overwrite)
+
         if isinstance(dataset.background_model, BackgroundModels):
             backgrounds = dataset.background_model.models
         else:
@@ -165,17 +166,9 @@ def datasets_to_dict(datasets, path, selection, overwrite):
             models = dataset.model.skymodels
         else:
             models = [dataset.model]
-        # TODO: remove isinstance checks once #2102  is resolved
-        bkg_names = [background.name for background in backgrounds]
-        models_names = [model.name for model in models]
-        datasets_dictlist.append(
-            {
-                "name": dataset.name,
-                "filename": filename,
-                "backgrounds": bkg_names,
-                "models": models_names,
-            }
-        )
+
+        datasets_dictlist.append(dataset.to_dict(filename=filename))
+
         for model in models:
             if model not in models_list:
                 models_list.append(model)

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -66,10 +66,7 @@ def _model_to_dict(model, selection):
     if getattr(model, "filename", None) is not None:
         data["filename"] = model.filename
     if model.__class__.__name__ == "SkyModel":
-        data["spatial"] = model.spatial_model.to_dict(selection)
-        if getattr(model.spatial_model, "filename", None) is not None:
-            data["spatial"]["filename"] = model.spatial_model.filename
-        data["spectral"] = model.spectral_model.to_dict(selection)
+        data.update(model.to_dict(selection=selection))
     else:
         data["model"] = model.to_dict(selection)
 

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -216,7 +216,6 @@ class dict_to_datasets:
             try:
                 cube = self.cube_register[component["name"]]
             except KeyError:
-                print(component)
                 cube = SkyDiffuseCube.read(component["filename"])
                 self.cube_register[component["name"]] = cube
 

--- a/gammapy/utils/serialization/io.py
+++ b/gammapy/utils/serialization/io.py
@@ -220,7 +220,7 @@ class dict_to_datasets:
                 self.cube_register[component["name"]] = cube
 
             evaluator = MapEvaluator(model=cube, exposure=dataset.exposure, psf=dataset.psf, edisp=dataset.edisp)
-            background_model = BackgroundModel(evaluator.compute_npred())
+            background_model = BackgroundModel(evaluator.compute_npred(), name=cube.name)
         else:
             if component["name"].strip().upper() in bkg_prev:
                 BGind = bkg_prev.index(component["name"].strip().upper())

--- a/gammapy/utils/serialization/tests/data/example2.yaml
+++ b/gammapy/utils/serialization/tests/data/example2.yaml
@@ -1,5 +1,6 @@
 components:
 - name: source
+  type: SkyModel
   spatial:
     parameters:
     - factor: 0.0

--- a/gammapy/utils/serialization/tests/data/examples.yaml
+++ b/gammapy/utils/serialization/tests/data/examples.yaml
@@ -1,5 +1,6 @@
 components:
 - name: source0
+  type: SkyModel
   spatial:
     type: SkyPointSource
     parameters:
@@ -55,6 +56,7 @@ components:
       max: .nan
       frozen: false
 - name: source1
+  type: SkyModel
   spatial:
     type: SkyDisk
     parameters:
@@ -98,6 +100,7 @@ components:
       max: .nan
       frozen: true
 - name: source2
+  type: SkyModel
   spatial:
     type: SkyDiffuseMap
     filename: $GAMMAPY_DATA/catalogs/fermi/Extended_archive_v18/Templates/RXJ1713_2016_250GeV.fits
@@ -131,60 +134,58 @@ components:
       frozen: false
 - name: background_irf
   id: CTA-gc
-  model:
-    type: BackgroundModel
-    parameters:
-    - name: norm
-      value: 1.01
-      factor: 1.01
-      scale: 1.0
-      unit: ''
-      min: 0.0
-      max: .nan
-      frozen: false
-    - name: tilt
-      value: 0.0
-      factor: 0.0
-      scale: 1.0
-      unit: ''
-      min: .nan
-      max: .nan
-      frozen: true
-    - name: reference
-      value: 1.0
-      factor: 1.0
-      scale: 1.0
-      unit: TeV
-      min: .nan
-      max: .nan
-      frozen: true
+  type: BackgroundModel
+  parameters:
+  - name: norm
+    value: 1.01
+    factor: 1.01
+    scale: 1.0
+    unit: ''
+    min: 0.0
+    max: .nan
+    frozen: false
+  - name: tilt
+    value: 0.0
+    factor: 0.0
+    scale: 1.0
+    unit: ''
+    min: .nan
+    max: .nan
+    frozen: true
+  - name: reference
+    value: 1.0
+    factor: 1.0
+    scale: 1.0
+    unit: TeV
+    min: .nan
+    max: .nan
+    frozen: true
 - name: cube_iem
   id: global
   filename: $GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits
-  model:
-    type: BackgroundModel
-    parameters:
-    - name: norm
-      value: 1.09
-      factor: 1.09
-      scale: 1.0
-      unit: ''
-      min: 0.0
-      max: .nan
-      frozen: false
-    - name: tilt
-      value: 0.0
-      factor: 0.0
-      scale: 1.0
-      unit: ''
-      min: .nan
-      max: .nan
-      frozen: true
-    - name: reference
-      value: 1.0
-      factor: 1.0
-      scale: 1.0
-      unit: TeV
-      min: .nan
-      max: .nan
-      frozen: true
+  type: BackgroundModel
+  parameters:
+  - name: norm
+    value: 1.09
+    factor: 1.09
+    scale: 1.0
+    unit: ''
+    min: 0.0
+    max: .nan
+    frozen: false
+  - name: tilt
+    value: 0.0
+    factor: 0.0
+    scale: 1.0
+    unit: ''
+    min: .nan
+    max: .nan
+    frozen: true
+  - name: reference
+    value: 1.0
+    factor: 1.0
+    scale: 1.0
+    unit: TeV
+    min: .nan
+    max: .nan
+    frozen: true

--- a/gammapy/utils/serialization/tests/make_test_data.py
+++ b/gammapy/utils/serialization/tests/make_test_data.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from gammapy.cube import MapDataset, MapMaker, PSFKernel
+from gammapy.cube import MapDataset, MapMaker, PSFKernel, MapEvaluator
 from gammapy.cube.models import BackgroundModel, SkyDiffuseCube, SkyModel, SkyModels
 from gammapy.data import DataStore
 from gammapy.image.models import SkyGaussian, SkyPointSource
@@ -97,9 +97,10 @@ def make_datasets_example():
             observations, position=src_pos, e_true=energy, e_reco=energy
         )
 
-        background_diffuse = BackgroundModel.from_skymodel(
-            diffuse_model, exposure=maps["exposure"], psf=psf_kernel
-        )
+        evaluator = MapEvaluator(diffuse_model, exposure=maps["exposure"], psf=psf_kernel)
+        bkg_map = evaluator.compute_npred()
+        background_diffuse = BackgroundModel(bkg_map, name=diffuse_model.name)
+
         # set diffuse model as global
         try:
             background_diffuse.parameters = diffuse_parameters[background_diffuse.name]
@@ -112,7 +113,7 @@ def make_datasets_example():
 
         dataset = MapDataset(
             name=names[ind],
-            model=SkyModels(models),
+            model=models[ind],
             counts=maps["counts"],
             exposure=maps["exposure"],
             background_model=background_total,

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -650,21 +650,7 @@
    "source": [
     "diffuse_model = SkyDiffuseCube.read(\n",
     "    \"$GAMMAPY_DATA/fermi-3fhl-gc/gll_iem_v06_gc.fits.gz\"\n",
-    ")\n",
-    "\n",
-    "background_diffuse = BackgroundModel.from_skymodel(\n",
-    "    diffuse_model, exposure=maps[\"exposure\"], psf=psf_kernel\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "background_irf = BackgroundModel(maps[\"background\"], norm=1.0, tilt=0.0)\n",
-    "background_total = background_irf + background_diffuse"
    ]
   },
   {
@@ -695,10 +681,10 @@
    "outputs": [],
    "source": [
     "dataset_combined = MapDataset(\n",
-    "    model=model_ecpl,\n",
+    "    model=model_ecpl + diffuse_model,\n",
     "    counts=maps[\"counts\"],\n",
     "    exposure=maps[\"exposure\"],\n",
-    "    background_model=background_total,\n",
+    "    background_model=background_model,\n",
     "    psf=psf_kernel,\n",
     "    edisp=edisp,\n",
     ")"
@@ -730,8 +716,8 @@
    "source": [
     "# Checking normalization value (the closer to 1 the better)\n",
     "print(model_ecpl, \"\\n\")\n",
-    "print(background_irf, \"\\n\")\n",
-    "print(background_diffuse, \"\\n\")"
+    "print(background_model, \"\\n\")\n",
+    "print(diffuse_model, \"\\n\")"
    ]
   },
   {


### PR DESCRIPTION
This PR is a follow-up to #2338 and #2314 to clean-up and unify the dataset and model serialisation of background models. It includes the following changes:

- Add missing `tag` attribute to `SkyModel`, `BackgroundModel` and `SkyDiffuseCube`
- Add missing `tag` attribute to `SkyPointSource`
- Add `SkyModel.to_dict()`, `BackgroundModel.to_dict()` and `SkyDiffuseCube.to_dict()` methods.
- Remove `BackgroundModel.from_skymodel()` method
- Add `MapDataset.to_dict()` method
- Remove the `model` subsection for background model in the YAML file, so that the structure becomes equivalent to `SkyModel` and `SkyDiffuseCube`
- A little bit of further clean-up...