### PR TITLE
Fix PSF convolution

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -806,7 +806,9 @@ class MapEvaluator:
 
     def apply_psf(self, npred):
         """Convolve npred cube with PSF"""
-        return npred.convolve(self.psf)
+        tmp = npred.convolve(self.psf)
+        tmp.data[tmp.data < 0.0] = 0
+        return tmp
 
     def apply_edisp(self, npred):
         """Convolve map data with energy dispersion.

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -125,7 +125,9 @@ def test_map_dataset_str(sky_model, geom, geom_etrue):
 def test_fake(sky_model, geom, geom_etrue):
     """Test the fake dataset"""
     dataset = get_map_dataset(sky_model, geom, geom_etrue)
-    dataset.counts = dataset.npred()
+    npred = dataset.npred()
+    assert len(np.where(npred.data < 0)[0]) == 0  # npred must be positive
+    dataset.counts = npred
     real_dataset = dataset.copy()
     dataset.fake(314)
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -126,7 +126,7 @@ def test_fake(sky_model, geom, geom_etrue):
     """Test the fake dataset"""
     dataset = get_map_dataset(sky_model, geom, geom_etrue)
     npred = dataset.npred()
-    assert len(np.where(npred.data < 0)[0]) == 0  # npred must be positive
+    assert np.all(npred.data >= 0)  # npred must be positive
     dataset.counts = npred
     real_dataset = dataset.copy()
     dataset.fake(314)


### PR DESCRIPTION
This minimal PR fixes a bug in the PSF convolution.

Without this fix, calling dataset.npred() could predict negative counts in some bins, as shown in the attached figure (that whas produced calling `dataset.npred().slice_by_idx({'energy' : 7}).plot(vmax=0, add_cbar=True)
![psf_wrong_map](https://user-images.githubusercontent.com/47325742/64340682-07fe1d80-cfe7-11e9-82b3-d0d3a594d762.png)

