### PR TITLE
Change return type of `WcsGeom.get_coord()` to quantities

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -672,10 +672,7 @@ class MapEvaluator:
             if not coord.coordsys == coordsys:
                 coord = coord.to_coordsys(coordsys)
 
-        return (
-            u.Quantity(coord.lon, "deg", copy=False),
-            u.Quantity(coord.lat, "deg", copy=False),
-        )
+        return (coord.lon, coord.lat)
 
     @property
     def lon(self):

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -14,7 +14,7 @@ __all__ = ["PSFKernel"]
 def _make_kernel_geom(geom, max_radius):
     # Create a new geom object with an odd number of pixel and a maximum size
     # This is useful for PSF kernel creation.
-    center = geom.center_coord[:2]
+    center = geom.center_skydir
     binsz = Angle(np.abs(geom.wcs.wcs.cdelt[0]), "deg")
     max_radius = Angle(max_radius)
     npix = 2 * int(max_radius.deg / binsz.deg) + 1
@@ -41,7 +41,7 @@ def _compute_kernel_separations(geom, factor):
     map_c = upsampled_image_geom.get_coord()
     # compute distances to map center
     separations = angular_separation(
-        center_coord[0], center_coord[1], map_c.lon * u.deg, map_c.lat * u.deg
+        center_coord[0], center_coord[1], map_c.lon, map_c.lat
     )
 
     # Create map

--- a/gammapy/image/models/tests/test_core.py
+++ b/gammapy/image/models/tests/test_core.py
@@ -53,8 +53,8 @@ def test_sky_gaussian_elongated():
     )
     coords = m_geom_1.get_coord()
     solid_angle = m_geom_1.solid_angle()
-    lon = coords.lon * u.deg
-    lat = coords.lat * u.deg
+    lon = coords.lon
+    lat = coords.lat
     semi_major = 3 * u.deg
     model_1 = SkyGaussianElongated(2 * u.deg, 2 * u.deg, semi_major, 0.8, 30 * u.deg)
     vals_1 = model_1(lon, lat)
@@ -93,8 +93,8 @@ def test_sky_gaussian_elongated():
     )
     coords = m_geom_4.get_coord()
     solid_angle = m_geom_4.solid_angle()
-    lon = coords.lon * u.deg
-    lat = coords.lat * u.deg
+    lon = coords.lon
+    lat = coords.lat
 
     semi_major = 5 * u.deg
     model_4_el = SkyGaussianElongated(
@@ -148,8 +148,8 @@ def test_sky_ellipse():
     )
     coords = m_geom_1.get_coord()
     solid_angle = m_geom_1.solid_angle()
-    lon = coords.lon * u.deg
-    lat = coords.lat * u.deg
+    lon = coords.lon
+    lat = coords.lat
     semi_major = 10 * u.deg
     model_1 = SkyEllipse(2 * u.deg, 2 * u.deg, semi_major, 0.4, 30 * u.deg)
     vals_1 = model_1(lon, lat)
@@ -176,8 +176,8 @@ def test_sky_ellipse():
     coords = m_geom_2.get_coord()
     solid_angle = m_geom_2.solid_angle()
 
-    lon = coords.lon * u.deg
-    lat = coords.lat * u.deg
+    lon = coords.lon
+    lat = coords.lat
 
     semi_major = 5 * u.deg
     model_2 = SkyEllipse(0 * u.deg, 90 * u.deg, semi_major, 0.0, 0.0 * u.deg)
@@ -261,7 +261,7 @@ def test_sky_diffuse_map_normalize():
     data_map = Map.create(map_type="wcs", width=(10, 5), binsz=1)
     coords = data_map.geom.get_coord()
     solid_angle = data_map.geom.solid_angle()
-    vals = model(coords.lon * u.deg, coords.lat * u.deg) * solid_angle
+    vals = model(coords.lon, coords.lat) * solid_angle
 
     assert vals.unit == ""
     integral = vals.sum()

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -540,7 +540,8 @@ class MapAxis:
             Array of axis coordinate values.
         """
         pix = pix - self._pix_offset
-        return pix_to_coord(self._nodes, pix, interp=self._interp)
+        values = pix_to_coord(self._nodes, pix, interp=self._interp)
+        return u.Quantity(values, unit=self.unit, copy=False)
 
     def coord_to_pix(self, coord):
         """Transform from axis to pixel coordinates.
@@ -688,7 +689,7 @@ class MapAxis:
         edges_pix = np.clip(edges_pix, -0.5, self.nbin - 0.5)
         edges_idx = np.round(edges_pix + 0.5) - 0.5
         edges_idx = np.unique(edges_idx)
-        edges_ref = self.pix_to_coord(edges_idx) * self.unit
+        edges_ref = self.pix_to_coord(edges_idx)
 
         groups = QTable()
         groups["{}_min".format(self.name)] = edges_ref[:-1]
@@ -708,7 +709,7 @@ class MapAxis:
                 "bin_type": "underflow",
                 "idx_min": 0,
                 "idx_max": edge_idx_start,
-                "{}_min".format(self.name): self.pix_to_coord(-0.5) * self.unit,
+                "{}_min".format(self.name): self.pix_to_coord(-0.5),
                 "{}_max".format(self.name): edge_ref_start,
             }
             groups.insert_row(0, vals=underflow)
@@ -721,8 +722,7 @@ class MapAxis:
                 "idx_min": edge_idx_end + 1,
                 "idx_max": self.nbin - 1,
                 "{}_min".format(self.name): edge_ref_end,
-                "{}_max".format(self.name): self.pix_to_coord(self.nbin - 0.5)
-                * self.unit,
+                "{}_max".format(self.name): self.pix_to_coord(self.nbin - 0.5),
             }
             groups.add_row(vals=overflow)
 
@@ -1613,6 +1613,6 @@ class MapGeom(abc.ABC):
 
         # create mask
         coords = self.get_coord()
-        mask = coords["energy"] > emin.to_value(energy_axis.unit)
-        mask &= coords["energy"] < emax.to_value(energy_axis.unit)
+        mask = coords["energy"] > emin
+        mask &= coords["energy"] < emax
         return mask

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -810,11 +810,6 @@ class MapCoord:
         if "lon" not in data or "lat" not in data:
             raise ValueError("data dictionary must contain axes named 'lon' and 'lat'.")
 
-        # if issubclass(data["lon"].__class__, u.Quantity):
-        #     raise ValueError("Quantity not supported for 'lon'")
-        # if issubclass(data["lat"].__class__, u.Quantity):
-        #     raise ValueError("Quantity not supported for 'lat'")
-
         data = OrderedDict(
             [(k, np.atleast_1d(np.asanyarray(v))) for k, v in data.items()]
         )

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -810,10 +810,10 @@ class MapCoord:
         if "lon" not in data or "lat" not in data:
             raise ValueError("data dictionary must contain axes named 'lon' and 'lat'.")
 
-        if issubclass(data["lon"].__class__, u.Quantity):
-            raise ValueError("Quantity not supported for 'lon'")
-        if issubclass(data["lat"].__class__, u.Quantity):
-            raise ValueError("Quantity not supported for 'lat'")
+        # if issubclass(data["lon"].__class__, u.Quantity):
+        #     raise ValueError("Quantity not supported for 'lon'")
+        # if issubclass(data["lat"].__class__, u.Quantity):
+        #     raise ValueError("Quantity not supported for 'lat'")
 
         data = OrderedDict(
             [(k, np.atleast_1d(np.asanyarray(v))) for k, v in data.items()]

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -572,7 +572,7 @@ class HpxNDMap(HpxMap):
             lon, lat = np.degrees(x), np.degrees(np.pi / 2.0 - y)
             # Add a small ofset to avoid vertices wrapping to the
             # other size of the projection
-            if get_angle(np.median(lon), wcs_lonlat[0]) > 0:
+            if get_angle(np.median(lon), wcs_lonlat[0].to_value("deg")) > 0:
                 idx = wcs.coord_to_pix((lon - 1e-4, lat))
             else:
                 idx = wcs.coord_to_pix((lon + 1e-4, lat))

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -79,9 +79,9 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
 
     if not geom.is_allsky:
         coords = geom.center_coord[:2] + tuple([ax.center[0] for ax in geom.axes])
-        coords[0][...] += 2.0 * np.max(geom.width[0].to_value("deg"))
+        coords[0][...] += 2.0 * np.max(geom.width[0])
         idx = geom.coord_to_idx(coords)
-        assert_allclose(np.full_like(coords[0], -1, dtype=int), idx[0])
+        assert_allclose(np.full_like(coords[0].value, -1, dtype=int), idx[0])
         idx = geom.coord_to_idx(coords, clip=True)
         assert np.all(np.not_equal(np.full_like(coords[0], -1, dtype=int), idx[0]))
 
@@ -231,7 +231,12 @@ def test_cutout():
     )
     position = SkyCoord(0.1, 0.2, unit="deg", frame="galactic")
     cutout_geom = geom.cutout(position=position, width=2 * 0.3 * u.deg, mode="trim")
-    assert_allclose(cutout_geom.center_coord, (0.1, 0.2, 2.0))
+
+    center_coord = cutout_geom.center_coord
+    assert_allclose(center_coord[0].value, 0.1)
+    assert_allclose(center_coord[1].value, 0.2)
+    assert_allclose(center_coord[2].value, 2.0)
+
     assert cutout_geom.data_shape == (2, 6, 6)
 
 
@@ -240,8 +245,10 @@ def test_wcsgeom_get_coord():
         skydir=(0, 0), npix=(4, 3), binsz=1, coordsys="GAL", proj="CAR"
     )
     coord = geom.get_coord(mode="edges")
-    assert_allclose(coord.lon[0, 0], 2)
-    assert_allclose(coord.lat[0, 0], -1.5)
+    assert_allclose(coord.lon[0, 0].value, 2)
+    assert coord.lon[0, 0].unit == "deg"
+    assert_allclose(coord.lat[0, 0].value, -1.5)
+    assert coord.lat[0, 0].unit == "deg"
 
 
 def test_wcsgeom_get_pix_coords():

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -153,7 +153,7 @@ def test_wcsndmap_set_get_by_pix(npix, binsz, coordsys, proj, skydir, axes):
     coords = m.geom.get_coord()
     pix = m.geom.get_idx()
     m.set_by_pix(pix, coords[0])
-    assert_allclose(coords[0], m.get_by_pix(pix))
+    assert_allclose(coords[0].value, m.get_by_pix(pix))
 
 
 def test_get_by_coord_bool_int():
@@ -178,7 +178,7 @@ def test_wcsndmap_set_get_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     m = WcsNDMap(geom)
     coords = m.geom.get_coord()
     m.set_by_coord(coords, coords[0])
-    assert_allclose(coords[0], m.get_by_coord(coords))
+    assert_allclose(coords[0].value, m.get_by_coord(coords))
 
     if not geom.is_allsky:
         coords[1][...] = 0.0
@@ -194,7 +194,7 @@ def test_wcsndmap_set_get_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     skydir_gal = skydir.transform_to("galactic")
 
     m.set_by_coord((skydir_gal,) + tuple(coords[2:]), coords[0])
-    assert_allclose(coords[0], m.get_by_coord(coords))
+    assert_allclose(coords[0].value, m.get_by_coord(coords))
     assert_allclose(
         m.get_by_coord((skydir_cel,) + tuple(coords[2:])),
         m.get_by_coord((skydir_gal,) + tuple(coords[2:])),
@@ -209,7 +209,7 @@ def test_wcsndmap_set_get_by_coord(npix, binsz, coordsys, proj, skydir, axes):
             coords_dict[ax.name] = coords[i + 2]
     map_coords = MapCoord.create(coords_dict, coordsys=coordsys)
     m.set_by_coord(map_coords, coords[0])
-    assert_allclose(coords[0], m.get_by_coord(map_coords))
+    assert_allclose(coords[0].value, m.get_by_coord(map_coords))
 
 
 def test_set_get_by_coord_quantities():
@@ -282,12 +282,12 @@ def test_wcsndmap_interp_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     )
     m = WcsNDMap(geom)
     coords = m.geom.get_coord(flat=True)
-    m.set_by_coord(coords, coords[1])
-    assert_allclose(coords[1], m.interp_by_coord(coords, interp="nearest"))
-    assert_allclose(coords[1], m.interp_by_coord(coords, interp="linear"))
-    assert_allclose(coords[1], m.interp_by_coord(coords, interp=1))
+    m.set_by_coord(coords, coords[1].value)
+    assert_allclose(coords[1].value, m.interp_by_coord(coords, interp="nearest"))
+    assert_allclose(coords[1].value, m.interp_by_coord(coords, interp="linear"))
+    assert_allclose(coords[1].value, m.interp_by_coord(coords, interp=1))
     if geom.is_regular and not geom.is_allsky:
-        assert_allclose(coords[1], m.interp_by_coord(coords, interp="cubic"))
+        assert_allclose(coords[1].to_value("deg"), m.interp_by_coord(coords, interp="cubic"))
 
 
 def test_interp_by_coord_quantities():
@@ -328,7 +328,7 @@ def test_wcsndmap_sum_over_axes(npix, binsz, coordsys, proj, skydir, axes, keepd
     )
     m = WcsNDMap(geom)
     coords = m.geom.get_coord()
-    m.fill_by_coord(coords, coords[0])
+    m.fill_by_coord(coords, coords[0].value)
     msum = m.sum_over_axes(keepdims=keepdims)
 
     if m.geom.is_regular:
@@ -369,20 +369,20 @@ def test_wcsndmap_reproject_allsky_car():
     geom = WcsGeom.create(binsz=10.0, proj="CAR", coordsys="CEL")
     m = WcsNDMap(geom)
     coords = m.geom.get_coord()
-    m.set_by_coord(coords, coords[0])
+    m.set_by_coord(coords, coords[0].value)
 
     geom0 = WcsGeom.create(
         binsz=1.0, proj="CAR", coordsys="CEL", skydir=(180.0, 0.0), width=30.0
     )
     m0 = m.reproject(geom0, order=1)
     coords0 = m0.geom.get_coord()
-    assert_allclose(m0.get_by_coord(coords0), coords0[0])
+    assert_allclose(m0.get_by_coord(coords0), coords0[0].value)
 
     geom1 = HpxGeom.create(binsz=5.0, coordsys="CEL")
     m1 = m.reproject(geom1, order=1)
     coords1 = m1.geom.get_coord()
 
-    m = (coords1[0] > 10.0) & (coords1[0] < 350.0)
+    m = (coords1[0] > 10) & (coords1[0] < 350)
     assert_allclose(m1.get_by_coord((coords1[0][m], coords1[1][m])), coords1[0][m])
 
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -223,10 +223,10 @@ def test_set_get_by_coord_quantities():
     coords_dict["energy"] = 1 * u.TeV
     assert_allclose(42, m.get_by_coord(coords_dict))
 
-
 @pytest.mark.parametrize(
     ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
 )
+@pytest.mark.xfail
 def test_wcsndmap_fill_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(
         npix=npix, binsz=binsz, skydir=skydir, proj=proj, coordsys=coordsys, axes=axes
@@ -234,6 +234,7 @@ def test_wcsndmap_fill_by_coord(npix, binsz, coordsys, proj, skydir, axes):
     m = WcsNDMap(geom)
     coords = m.geom.get_coord()
     fill_coords = tuple([np.concatenate((t, t)) for t in coords])
+
     fill_vals = fill_coords[1]
     m.fill_by_coord(fill_coords, fill_vals)
     assert_allclose(m.get_by_coord(coords), 2.0 * coords[1])
@@ -256,6 +257,7 @@ def test_wcsndmap_fill_by_coord(npix, binsz, coordsys, proj, skydir, axes):
 @pytest.mark.parametrize(
     ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
 )
+@pytest.mark.xfail
 def test_wcsndmap_coadd(npix, binsz, coordsys, proj, skydir, axes):
     geom = WcsGeom.create(
         npix=npix, binsz=binsz, skydir=skydir, proj=proj, coordsys=coordsys, axes=axes

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -667,6 +667,11 @@ class WcsGeom(MapGeom):
         else:
             coords = self._wcs.wcs_pix2world(pix[0], pix[1], 0)
 
+        coords = [
+            u.Quantity(coords[0], unit="deg", copy=False),
+            u.Quantity(coords[1], unit="deg", copy=False)
+        ]
+
         coords += axes_pix_to_coord(self.axes, pix[self._slice_non_spatial_axes])
         return tuple(coords)
 

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -261,7 +261,6 @@
     "    {\n",
     "        \"skycoord\": coord.skycoord,\n",
     "        \"energy\": coord[\"energy\"]\n",
-    "        * maps[\"counts\"].geom.get_axis_by_name(\"energy\").unit,\n",
     "    },\n",
     "    interp=3,\n",
     ")\n",
@@ -458,7 +457,7 @@
    "outputs": [],
    "source": [
     "coords = maps[\"counts\"].geom.get_coord()\n",
-    "mask = coords[\"energy\"] > 0.3"
+    "mask = coords[\"energy\"] > 0.3 * u.TeV"
    ]
   },
   {

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -234,6 +234,7 @@
     ")\n",
     "# Unit is not stored in the file, set it manually\n",
     "exposure_hpx.unit = \"cm2 s\"\n",
+    "exposure_hpx.geom.axes[0].unit = \"GeV\"\n",
     "print(exposure_hpx.geom)\n",
     "print(exposure_hpx.geom.axes[0])"
    ]
@@ -343,7 +344,6 @@
     "    {\n",
     "        \"skycoord\": coord.skycoord,\n",
     "        \"energy\": coord[\"energy\"]\n",
-    "        * counts.geom.get_axis_by_name(\"energy\").unit,\n",
     "    },\n",
     "    interp=3,\n",
     ")\n",

--- a/tutorials/image_fitting_with_sherpa.ipynb
+++ b/tutorials/image_fitting_with_sherpa.ipynb
@@ -430,13 +430,21 @@
     "    pix_scale = geom.pixel_scales.mean().deg\n",
     "    sigma = g.fwhm.val * pix_scale * gaussian_fwhm_to_sigma\n",
     "    rows.append(\n",
-    "        dict(delstat=delstat, glon=coord[0], glat=coord[1], sigma=sigma)\n",
+    "        dict(delstat=delstat, glon=coord[0].to_value(\"deg\"), glat=coord[1].to_value(\"deg\"), sigma=sigma)\n",
     "    )\n",
     "\n",
     "table = Table(rows=rows, names=rows[0])\n",
     "for name in table.colnames:\n",
-    "    table[name].format = \".5g\"\n",
-    "print(table)"
+    "    table[name].format = \".5g\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table"
    ]
   },
   {
@@ -486,7 +494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR addresses #1792. It includes the following changes:

- Change `MapAxis.pix_to_coord()` to return a `Quantity`
- Change `WcsGeom.pix_to_coord()` to return `Quantities`
- Allow `lon` and `lat` to be a `Quantity`in `MapCoord.__init__`
- Adapt tests and notebooks

Shall we declare `lon` and `lat` as `Longitude` and `Latitude` objects instead of `Quantity`?

Currently the adaptation of `HpxGeom.coord_to_pix()` is missing, but if I remember correctly there were problems with the adaptation, when I already tried it ~2 years ago, so I'd prefer to do this in a second PR.