### PR TITLE
Add `SpectrumDataset.create()`

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -2,8 +2,9 @@
 import numpy as np
 from astropy.table import Table, vstack
 from astropy.units import Quantity
+from astropy.time import Time
 from gammapy.utils.scripts import make_path
-from gammapy.utils.time import time_ref_from_dict, time_relative_to_ref
+from gammapy.utils.time import time_ref_from_dict, time_relative_to_ref, time_ref_to_dict
 
 __all__ = ["GTI"]
 
@@ -189,3 +190,22 @@ class GTI:
 
         merged = Table(rows=merged, names=["START", "STOP"], meta=self.table.meta)
         return self.__class__(merged)
+
+    @classmethod
+    def create(cls, start, stop, reference_time="2000-01-01"):
+        """Creates a GTI table from start and stop times.
+
+        Parameter
+        ---------
+        start : `~astropy.units.Quantity`
+            start times w.r.t. reference time
+        stop : `~astropy.units.Quantity`
+            stop times w.r.t. reference time
+        reference_time : `~astropy.time.Time`
+            the reference time to use in GTI definition
+        """
+        reference_time = Time(reference_time)
+        meta = time_ref_to_dict(reference_time)
+        table=Table({"START": start.to('s'), "STOP": stop.to('s')}, meta=meta)
+        return cls(table)
+

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -204,6 +204,8 @@ class GTI:
         reference_time : `~astropy.time.Time`
             the reference time to use in GTI definition
         """
+        start = Quantity(start)
+        stop = Quantity(stop)
         reference_time = Time(reference_time)
         meta = time_ref_to_dict(reference_time)
         table=Table({"START": start.to('s'), "STOP": stop.to('s')}, meta=meta)

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -124,4 +124,3 @@ def test_gti_create():
     assert len(gti.table) == 2
     assert_allclose(gti.time_ref.mjd, time_ref.tt.mjd)
     assert_allclose(gti.table['START'], start.to_value('s'))
-    

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -114,3 +114,14 @@ def test_gti_union():
 
     assert_allclose(gti.table["START"], [1, 5])
     assert_allclose(gti.table["STOP"], [4, 8])
+
+def test_gti_create():
+    start = u.Quantity([1, 2], 'min')
+    stop = u.Quantity([1.5,2.5],'min')
+    time_ref = Time("2010-01-01 00:00:00.0")
+    gti = GTI.create(start,stop, time_ref)
+
+    assert len(gti.table) == 2
+    assert_allclose(gti.time_ref.mjd, time_ref.tt.mjd)
+    assert_allclose(gti.table['START'], start.to_value('s'))
+    

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -359,6 +359,34 @@ class SpectrumDataset(Dataset):
         ax.set_ylabel("Residuals ({})".format(label))
         return ax
 
+    @classmethod
+    def create(cls, e_reco, e_true=None):
+        """Creates empty SpectrumDataset
+
+        Empty containers are created with the correct geometry.
+        counts, background and aeff are zero and edisp is diagonal.
+
+        Parameters
+        ----------
+        e_reco : `~astropy.units.Quantity`
+            edges of counts vector
+        e_true : `~astropy.units.Quantity`
+            edges of effective area table. If not set use reco energy values. Default : None
+        """
+        counts = CountsSpectrum(e_reco[:-1], e_reco[1:])
+        background = CountsSpectrum(e_reco[:-1], e_reco[1:])
+        aeff = EffectiveAreaTable(e_true[:-1],e_true[1:], np.zeros(e_etrue[:-1].shape)*u.m**2)
+        edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
+        mask_safe = np.ones_like(counts.data.data, 'bool')
+        livetime = 0*u.s
+
+        return SpectrumDataset(counts=counts,
+                               aeff=aeff,
+                               edisp=edisp,
+                               mask_safe=mask_safe,
+                               background=background,
+                               livetime=livetime,
+                               )
 
 class SpectrumDatasetOnOff(SpectrumDataset):
     """Spectrum dataset for on-off likelihood fitting.

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -375,11 +375,13 @@ class SpectrumDataset(Dataset):
         reference_time : `~astropy.time.Time`
             reference time of the dataset, Default is "2000-01-01"
         """
+        if e_true is None:
+            e_true = e_reco
         counts = CountsSpectrum(e_reco[:-1], e_reco[1:])
         background = CountsSpectrum(e_reco[:-1], e_reco[1:])
         aeff = EffectiveAreaTable(e_true[:-1],e_true[1:], np.zeros(e_true[:-1].shape)*u.m**2)
         edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
-        mask_safe = np.ones_like(counts.data.data, 'bool')
+        mask_safe = np.ones_like(counts.data, 'bool')
         gti = GTI.create(u.Quantity([],'s'), u.Quantity([],'s'), reference_time)
         livetime = gti.time_sum
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
-from gammapy.data import ObservationStats
+from gammapy.data import ObservationStats, GTI
 from gammapy.irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
 from gammapy.stats import cash, wstat
 from gammapy.utils.fits import energy_axis_to_ebounds
@@ -360,7 +360,7 @@ class SpectrumDataset(Dataset):
         return ax
 
     @classmethod
-    def create(cls, e_reco, e_true=None):
+    def create(cls, e_reco, e_true=None, reference_time="2000-01-01"):
         """Creates empty SpectrumDataset
 
         Empty containers are created with the correct geometry.
@@ -372,13 +372,16 @@ class SpectrumDataset(Dataset):
             edges of counts vector
         e_true : `~astropy.units.Quantity`
             edges of effective area table. If not set use reco energy values. Default : None
+        reference_time : `~astropy.time.Time`
+            reference time of the dataset, Default is "2000-01-01"
         """
         counts = CountsSpectrum(e_reco[:-1], e_reco[1:])
         background = CountsSpectrum(e_reco[:-1], e_reco[1:])
         aeff = EffectiveAreaTable(e_true[:-1],e_true[1:], np.zeros(e_true[:-1].shape)*u.m**2)
         edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
         mask_safe = np.ones_like(counts.data.data, 'bool')
-        livetime = 0*u.s
+        gti = GTI.create(u.Quantity([],'s'), u.Quantity([],'s'), reference_time)
+        livetime = gti.time_sum
 
         return SpectrumDataset(counts=counts,
                                aeff=aeff,
@@ -386,6 +389,7 @@ class SpectrumDataset(Dataset):
                                mask_safe=mask_safe,
                                background=background,
                                livetime=livetime,
+                               gti=gti,
                                )
 
 class SpectrumDatasetOnOff(SpectrumDataset):

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -375,7 +375,7 @@ class SpectrumDataset(Dataset):
         """
         counts = CountsSpectrum(e_reco[:-1], e_reco[1:])
         background = CountsSpectrum(e_reco[:-1], e_reco[1:])
-        aeff = EffectiveAreaTable(e_true[:-1],e_true[1:], np.zeros(e_etrue[:-1].shape)*u.m**2)
+        aeff = EffectiveAreaTable(e_true[:-1],e_true[1:], np.zeros(e_true[:-1].shape)*u.m**2)
         edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
         mask_safe = np.ones_like(counts.data.data, 'bool')
         livetime = 0*u.s

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -154,6 +154,20 @@ class TestSpectrumOnOff:
             obs_id="test",
         )
 
+    def test_spectrumdataset_create(self):
+        e_reco = u.Quantity([0.1,1,10.], 'TeV')
+        e_true = u.Quantity([0.05, 0.5, 5, 20.], 'TeV')
+        empty_dataset = SpectrumDataset.create(e_reco, e_true)
+
+        assert empty_dataset.counts.total_counts == 0
+        assert empty_dataset.data_shape[0] == 2
+        assert empty_dataset.background.total_counts == 0
+        assert empty_dataset.background.energy.nbin == 2
+        assert empty_dataset.aeff.data.axis("energy").nbin == 3
+        assert empty_dataset.edisp.data.axis("e_reco").nbin == 2
+        assert empty_dataset.livetime.value == 0
+
+
     def test_init_no_model(self):
         with pytest.raises(AttributeError):
             self.dataset.npred()

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -166,7 +166,7 @@ class TestSpectrumOnOff:
         assert empty_dataset.aeff.data.axis("energy").nbin == 3
         assert empty_dataset.edisp.data.axis("e_reco").nbin == 2
         assert empty_dataset.livetime.value == 0
-
+        assert len(empty_dataset.gti.table) == 0
 
     def test_init_no_model(self):
         with pytest.raises(AttributeError):


### PR DESCRIPTION
This is a first PR to introduce creation of empty datasets for data reduction processing. 

The `counts` and `background` are empty. the `aeff` is 0 but `edisp` is diagonal.
`livetime` is set to 0 as well.