### PR TITLE
Simplify stacking in edisp map and psf map

### DIFF
--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -132,21 +132,6 @@ class PSFMap:
             data = exposure_map.data[:, np.newaxis, :, :]
             exposure_map = Map.from_geom(geom=geom, data=data, unit=exposure_map.unit)
 
-            # # Reproject the exposure if the geometries are inconsistent
-            # psf_geom = psf_map.geom.to_image().to_cube([psf_map.geom.axes[1]])
-            # if exposure_map.geom != psf_geom:
-            #     exposure_coord = exposure_map.geom.get_coord()
-            #     reproj_exposure = Map.from_geom(
-            #         psf_geom, unit=exposure_map.unit
-            #     )
-            #     reproj_exposure.fill_by_coord(
-            #         exposure_coord, exposure_map.get_by_coord(exposure_coord)
-            #     )
-            #     exposure_map = reproj_exposure
-            # # Reshape the exposure map adding the rad axis
-            # exposure_map.geom = exposure_map.geom.to_image().to_cube([psf_map.geom.axes[0].squash(), psf_map.geom.axes[1]])
-            # exposure_map.quantity = exposure_map.quantity[:, np.newaxis, :, :]
-
         self.exposure_map = exposure_map
 
     @classmethod
@@ -314,8 +299,6 @@ class PSFMap:
 
     def stack(self, other):
         """Stack PSFMap with another one.
-
-        The other PSFMap is projected on the current PSFMap geometry.
 
         Parameters
         ----------

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -118,6 +118,7 @@ def test_edisp_map_stacking():
     edmap2 = make_edisp_map_test()
     edmap2.exposure_map.quantity *= 2
 
-    edmap_stack = edmap1.stack(edmap2)
+    edmap_stack = edmap1.copy()
+    edmap_stack.stack(edmap2)
     assert_allclose(edmap_stack.edisp_map.data, edmap1.edisp_map.data)
     assert_allclose(edmap_stack.exposure_map.data, edmap1.exposure_map.data * 3)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -168,16 +168,18 @@ def test_psfmap_stacking():
     psfmap2 = make_test_psfmap(0.1 * u.deg, shape="flat")
     psfmap2.exposure_map.quantity *= 2
 
-    psfmap_stack = psfmap1.stack(psfmap2)
-    assert_allclose(psfmap_stack.psf_map.data, psfmap1.psf_map.data)
-    assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
+    psf_data = np.copy(psfmap1.psf_map.data)
+    exposure_data = np.copy(psfmap1.exposure_map.data)
+
+    psfmap1.stack(psfmap2)
+    assert_allclose(psfmap1.psf_map.data, psf_data)
+    assert_allclose(psfmap1.exposure_map.data, exposure_data * 3)
 
     psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
-    psfmap_stack = psfmap1.stack(psfmap3)
 
-    assert_allclose(psfmap_stack.psf_map.data[0, 40, 20, 20], 0.0)
-    assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)
-    assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 58052.78955078125)
-
+    psfmap1.stack(psfmap3)
+    assert_allclose(psfmap1.psf_map.data[0, 40, 20, 20], 0.0)
+    assert_allclose(psfmap1.psf_map.data[0, 20, 20, 20], 5805.28955078125)
+    assert_allclose(psfmap1.psf_map.data[0, 0, 20, 20], 58052.78955078125)
 
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -168,18 +168,18 @@ def test_psfmap_stacking():
     psfmap2 = make_test_psfmap(0.1 * u.deg, shape="flat")
     psfmap2.exposure_map.quantity *= 2
 
-    psf_data = np.copy(psfmap1.psf_map.data)
-    exposure_data = np.copy(psfmap1.exposure_map.data)
-
-    psfmap1.stack(psfmap2)
-    assert_allclose(psfmap1.psf_map.data, psf_data)
-    assert_allclose(psfmap1.exposure_map.data, exposure_data * 3)
+    psfmap_stack = psfmap1.copy()
+    psfmap_stack.stack(psfmap2)
+    assert_allclose(psfmap_stack.psf_map.data, psfmap1.psf_map.data)
+    assert_allclose(psfmap_stack.exposure_map.data, psfmap1.exposure_map.data * 3)
 
     psfmap3 = make_test_psfmap(0.3 * u.deg, shape="flat")
 
-    psfmap1.stack(psfmap3)
-    assert_allclose(psfmap1.psf_map.data[0, 40, 20, 20], 0.0)
-    assert_allclose(psfmap1.psf_map.data[0, 20, 20, 20], 5805.28955078125)
-    assert_allclose(psfmap1.psf_map.data[0, 0, 20, 20], 58052.78955078125)
+    psfmap_stack = psfmap1.copy()
+    psfmap_stack.stack(psfmap3)
+
+    assert_allclose(psfmap_stack.psf_map.data[0, 40, 20, 20], 0.0)
+    assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)
+    assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 58052.78955078125)
 
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -182,4 +182,5 @@ def test_psfmap_stacking():
     assert_allclose(psfmap_stack.psf_map.data[0, 20, 20, 20], 5805.28955078125)
     assert_allclose(psfmap_stack.psf_map.data[0, 0, 20, 20], 58052.78955078125)
 
+
 # TODO: add a test comparing make_mean_psf and PSFMap.stack for a set of observations in an Observations


### PR DESCRIPTION
Simplify `EDispMap.stack()` and `PSFMap.stack()` to not reproject the exposure map, but instead reproject the exposure map in `make_edisp_map` and `make_psf_map`.