### PR TITLE
Change OrderedDict to dict

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -328,25 +328,20 @@ latitude.  Non-spatial axes are assigned a default name ``axis{I}`` where
 ``{I}`` is the index of the non-spatial dimension. `MapCoord` objects created
 without named axes must have the same axis ordering as the map geometry.
 
-A `MapCoord` with named axes can be created by calling `MapCoord.create` with a
-`dict` or `~collections.OrderedDict`:
+A `MapCoord` with named axes can be created by calling `MapCoord.create` with a `dict`:
 
 .. code:: python
 
-    # Create a MapCoord from a dict
     c = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
     print(c[0], c['lon'], c.lon)
     print(c[1], c['lat'], c.lat)
     print(c[2], c['energy'])
 
-    # Create a MapCoord from an OrderedDict
-    from collections import OrderedDict
-    c = MapCoord.create(OrderedDict([('energy',energy), ('lon',lon), ('lat', lat)]))
+    c = MapCoord.create({'energy': energy, 'lon': lon, 'lat': lat})
     print(c[0], c['energy'])
     print(c[1], c['lon'], c.lon)
     print(c[2], c['lat'], c.lat)
 
-    # Create a MapCoord from a dict + SkyCoord
     c = MapCoord.create(dict(skycoord=skycoord, energy=energy))
     print(c[0], c['lon'], c.lon)
     print(c[1], c['lat'], c.lat)

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Source catalog and object base classes."""
 import copy
-from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
@@ -18,7 +17,7 @@ class SourceCatalogObject:
     base class for the other source catalog classes.
 
     The catalog data on this source is stored in the `source.data`
-    attribute as on OrderedDict.
+    attribute as a dict.
 
     The source catalog object is decoupled from the source catalog,
     it doesn't hold a reference back to it.
@@ -55,7 +54,7 @@ class SourceCatalogObject:
         This is mainly used at the moment to pass the data to
         the gamma-sky.net webpage.
         """
-        out = OrderedDict()
+        out = {}
         for key, value in self.data.items():
             if isinstance(value, int):
                 out_val = value

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -590,7 +590,7 @@ class GammaCatResource:
         return collections.namedtuple("GammaCatResourceNamedTuple", d.keys())(**d)
 
     def to_dict(self):
-        """Convert to `collections.OrderedDict`."""
+        """Convert to `dict`."""
         return {
             "source_id": self.source_id,
             "reference_id": self.reference_id,

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -7,7 +7,6 @@ import collections
 import functools
 import json
 import logging
-from collections import OrderedDict
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
@@ -592,13 +591,13 @@ class GammaCatResource:
 
     def to_dict(self):
         """Convert to `collections.OrderedDict`."""
-        data = OrderedDict()
-        data["source_id"] = self.source_id
-        data["reference_id"] = self.reference_id
-        data["file_id"] = self.file_id
-        data["type"] = self.type
-        data["location"] = self.location
-        return data
+        return {
+            "source_id": self.source_id,
+            "reference_id": self.reference_id,
+            "file_id": self.file_id,
+            "type": self.type,
+            "location": self.location,
+        }
 
     @classmethod
     def from_dict(cls, data):
@@ -673,7 +672,7 @@ class GammaCatResourceIndex:
         """Create from `~astropy.table.Table`."""
         resources = []
         for row in table:
-            data = OrderedDict((k, row[k]) for k in table.colnames)
+            data = {k: row[k] for k in table.colnames}
             resources.append(GammaCatResource.from_dict(data))
         return cls(resources=resources)
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """HESS Galactic plane survey (HGPS) catalog."""
-from collections import OrderedDict
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import Angle
@@ -50,7 +49,7 @@ class SourceCatalogObjectHGPSComponent:
     _source_index_key = "row_index"
 
     def __init__(self, data):
-        self.data = OrderedDict(data)
+        self.data = data
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.name)

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -84,7 +83,7 @@ class TestSourceCatalogObject:
 
     def test_data(self):
         d = self.source.data
-        assert isinstance(d, OrderedDict)
+        assert isinstance(d, dict)
 
         assert isinstance(d["RA"], Quantity)
         assert_quantity_allclose(d["RA"], Quantity(43.3, "deg"))

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import pytest
 from numpy.testing import assert_allclose
 from astropy import units as u
@@ -116,7 +115,7 @@ class TestSourceCatalogObjectGammaCat:
     def test_data(self, gammacat):
         source = gammacat[0]
 
-        assert isinstance(source.data, OrderedDict)
+        assert isinstance(source.data, dict)
         assert source.data["common_name"] == "CTA 1"
         assert_quantity_allclose(source.data["dec"], 72.782997 * u.deg)
 
@@ -254,15 +253,13 @@ class TestGammaCatResource:
         assert repr(self.resource) == expected
 
     def test_to_dict(self):
-        expected = OrderedDict(
-            [
-                ("source_id", 42),
-                ("reference_id", "2010A&A...516A..62A"),
-                ("file_id", 2),
-                ("type", "none"),
-                ("location", "none"),
-            ]
-        )
+        expected = {
+            "source_id": 42,
+            "reference_id": "2010A&A...516A..62A",
+            "file_id": 2,
+            "type": "none",
+            "location": "none",
+        }
         assert self.resource.to_dict() == expected
 
     def test_dict_roundtrip(self):

--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 import numpy as np
 from astropy.coordinates import Angle, SkyCoord
 from astropy.table import Table
@@ -310,7 +310,7 @@ class ObservationTable(Table):
         gti : `~gammapy.data.GTI`
             GTI table containing one row (TSTART and TSTOP of the observation with ``obs_id``)
         """
-        meta = OrderedDict(
+        meta = dict(
             EXTNAME="GTI",
             HDUCLASS="GADF",
             HDUDOC="https://github.com/open-gamma-ray-astro/gamma-astro-data-formats",

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
@@ -136,7 +135,7 @@ class DataStoreObservation:
 
     @property
     def obs_info(self):
-        """Observation information (`~collections.OrderedDict`)."""
+        """Observation information (`dict`)."""
         row = self.data_store.obs_table.select_obs_id(obs_id=self.obs_id)[0]
         return table_row_to_dict(row)
 
@@ -381,9 +380,10 @@ class ObservationChecker(Checker):
         """
         # http://fermi.gsfc.nasa.gov/ssc/data/analysis/documentation/Cicerone/Cicerone_Data/Time_in_ScienceTools.html
         # https://hess-confluence.desy.de/confluence/display/HESS/HESS+FITS+data+-+References+and+checks#HESSFITSdata-Referencesandchecks-Time
-        telescope_met_refs = OrderedDict(
-            FERMI=Time("2001-01-01T00:00:00"), HESS=Time("2001-01-01T00:00:00")
-        )
+        telescope_met_refs = {
+            "FERMI": Time("2001-01-01T00:00:00"),
+            "HESS": Time("2001-01-01T00:00:00"),
+        }
 
         meta = self.dset.event_list.table.meta
         telescope = meta["TELESCOP"]

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import numpy as np
 import astropy.units as u
 from astropy.io import fits
@@ -79,7 +78,7 @@ class Background3D:
             data=data,
             interp_kwargs=interp_kwargs,
         )
-        self.meta = OrderedDict(meta) if meta else OrderedDict()
+        self.meta = meta or {}
 
     def __str__(self):
         ss = self.__class__.__name__
@@ -265,7 +264,7 @@ class Background2D:
         self.data = NDDataArray(
             axes=[energy_axis, offset_axis], data=data, interp_kwargs=interp_kwargs
         )
-        self.meta = OrderedDict(meta) if meta else OrderedDict()
+        self.meta = meta or {}
 
     def __str__(self):
         ss = self.__class__.__name__

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import numpy as np
 import astropy.units as u
 from astropy.io import fits
@@ -72,7 +71,7 @@ class EffectiveAreaTable:
         self.data = NDDataArray(
             axes=[energy_axis], data=data, interp_kwargs=interp_kwargs
         )
-        self.meta = OrderedDict(meta) if meta else OrderedDict()
+        self.meta = meta or {}
 
     @property
     def energy(self):
@@ -202,14 +201,12 @@ class EffectiveAreaTable:
         Data format specification: :ref:`gadf:ogip-arf`
         """
         table = Table()
-        table.meta = OrderedDict(
-            [
-                ("EXTNAME", "SPECRESP"),
-                ("hduclass", "OGIP"),
-                ("hduclas1", "RESPONSE"),
-                ("hduclas2", "SPECRESP"),
-            ]
-        )
+        table.meta = {
+            "EXTNAME": "SPECRESP",
+            "hduclass": "OGIP",
+            "hduclas1": "RESPONSE",
+            "hduclas2": "SPECRESP",
+        }
 
         energy = self.energy.edges
         table["ENERG_LO"] = energy[:-1]
@@ -383,7 +380,7 @@ class EffectiveAreaTable2D:
         self.data = NDDataArray(
             axes=[energy_axis, offset_axis], data=data, interp_kwargs=interp_kwargs
         )
-        self.meta = OrderedDict(meta) if meta else OrderedDict()
+        self.meta = meta or {}
 
     def __str__(self):
         ss = self.__class__.__name__

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import numpy as np
 import scipy.special
 from astropy.coordinates import Angle
@@ -79,7 +78,7 @@ class EnergyDispersion:
         self.data = NDDataArray(
             axes=[e_true_axis, e_reco_axis], data=data, interp_kwargs=interp_kwargs
         )
-        self.meta = OrderedDict(meta) if meta else OrderedDict()
+        self.meta = meta or {}
 
     def __str__(self):
         ss = self.__class__.__name__
@@ -402,19 +401,17 @@ class EnergyDispersion:
         table["N_CHAN"] = n_chan
         table["MATRIX"] = matrix
 
-        table.meta = OrderedDict(
-            [
-                ("name", "MATRIX"),
-                ("chantype", "PHA"),
-                ("hduclass", "OGIP"),
-                ("hduclas1", "RESPONSE"),
-                ("hduclas2", "RSP_MATRIX"),
-                ("detchans", self.e_reco.nbin),
-                ("numgrp", numgrp),
-                ("numelt", numelt),
-                ("tlmin4", 0),
-            ]
-        )
+        table.meta = {
+            "name": "MATRIX",
+            "chantype": "PHA",
+            "hduclass": "OGIP",
+            "hduclas1": "RESPONSE",
+            "hduclas2": "RSP_MATRIX",
+            "detchans": self.e_reco.nbin,
+            "numgrp": numgrp,
+            "numelt": numelt,
+            "tlmin4": 0,
+        }
 
         return table
 
@@ -753,7 +750,7 @@ class EnergyDispersion2D:
         axes = [e_true_axis, migra_axis, offset_axis]
 
         self.data = NDDataArray(axes=axes, data=data, interp_kwargs=interp_kwargs)
-        self.meta = OrderedDict(meta) if meta else OrderedDict()
+        self.meta = meta or {}
 
     def __str__(self):
         ss = self.__class__.__name__

--- a/gammapy/irf/psf_check.py
+++ b/gammapy/irf/psf_check.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import math
-from collections import OrderedDict
 import numpy as np
 
 __all__ = []
@@ -43,13 +42,13 @@ class PSF3DChecker:
     ):
         self.psf = psf
 
-        self.config = OrderedDict(
-            d_norm=d_norm,
-            containment_fraction=containment_fraction,
-            d_rel_containment=d_rel_containment,
-        )
+        self.config = {
+            "d_norm": d_norm,
+            "containment_fraction": containment_fraction,
+            "d_rel_containment": d_rel_containment,
+        }
 
-        self.results = OrderedDict()
+        self.results = {}
 
     def check_all(self):
         """Run all checks.
@@ -95,7 +94,7 @@ class PSF3DChecker:
                         fail_count += 1
                         break
 
-        results = OrderedDict()
+        results = {}
         if fail_count == 0:
             results["status"] = "ok"
         else:
@@ -145,7 +144,7 @@ class PSF3DChecker:
                     fail_count += 1
 
         # write results to dict
-        results = OrderedDict()
+        results = {}
         if fail_count == 0:
             results["status"] = "ok"
         else:
@@ -251,7 +250,7 @@ class PSF3DChecker:
                         fail_count += 1
 
         # write results to dict
-        results = OrderedDict()
+        results = {}
         if fail_count == 0:
             results["status"] = "ok"
         else:
@@ -263,7 +262,7 @@ class PSF3DChecker:
 def check_all_table_psf(data_store):
     """Check all `gammapy.irf.PSF3D` for a given `gammapy.data.DataStore`.
     """
-    config = OrderedDict(d_norm=0.01, containment_fraction=0.68, d_rel_containment=0.7)
+    config = {"d_norm": 0.01, "containment_fraction": 0.68, "d_rel_containment": 0.7}
 
     obs_ids = data_store.obs_table["OBS_ID"].data
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -137,7 +137,7 @@ class Map(abc.ABC):
             Data type, default is 'float32'
         unit : str or `~astropy.units.Unit`
             Data unit.
-        meta : `~collections.OrderedDict`
+        meta : `dict`
             Dictionary to store meta data.
 
         Returns
@@ -198,7 +198,7 @@ class Map(abc.ABC):
             Map geometry.
         data : `numpy.ndarray`
             data array
-        meta : `~collections.OrderedDict`
+        meta : `dict`
             Dictionary to store meta data.
         map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'auto'}
             Map type.  Selects the class that will be used to

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -3,7 +3,6 @@ import abc
 import copy
 import inspect
 import json
-from collections import OrderedDict
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
@@ -26,8 +25,8 @@ class Map(abc.ABC):
         Geometry
     data : `~numpy.ndarray`
         Data array
-    meta : `~collections.OrderedDict`
-        Dictionary to store meta data.
+    meta : `dict`
+        Dictionary to store meta data
     unit : str or `~astropy.units.Unit`
         Data unit
     """
@@ -93,12 +92,12 @@ class Map(abc.ABC):
 
     @property
     def meta(self):
-        """Map meta (`~collections.OrderedDict`)"""
+        """Map meta (`dict`)"""
         return self._meta
 
     @meta.setter
     def meta(self, val):
-        self._meta = OrderedDict(val)
+        self._meta = val
 
     @property
     def quantity(self):
@@ -242,10 +241,9 @@ class Map(abc.ABC):
     def _get_meta_from_header(header):
         """Load meta data from a FITS header."""
         if "META" in header:
-            meta = json.loads(header["META"], object_pairs_hook=OrderedDict)
+            return json.loads(header["META"])
         else:
-            meta = OrderedDict()
-        return meta
+            return {}
 
     @staticmethod
     def _get_map_type(hdu_list, hdu_name):
@@ -578,7 +576,7 @@ class Map(abc.ABC):
         """
         if isinstance(coords, tuple):
             axes_names = [_.name for _ in self.geom.axes]
-            coords = OrderedDict(zip(axes_names, coords))
+            coords = dict(zip(axes_names, coords))
 
         idx = []
         for ax in self.geom.axes:

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -4,7 +4,6 @@ import copy
 import inspect
 import logging
 import re
-from collections import OrderedDict
 import numpy as np
 import scipy.interpolate
 from astropy import units as u
@@ -795,7 +794,7 @@ class MapCoord:
 
     Parameters
     ----------
-    data : `~collections.OrderedDict` of `~numpy.ndarray`
+    data : `dict` of `~numpy.ndarray`
         Dictionary of coordinate arrays.
     coordsys : {'CEL', 'GAL', None}
         Spatial coordinate system.  If None then the coordinate system
@@ -810,11 +809,9 @@ class MapCoord:
         if "lon" not in data or "lat" not in data:
             raise ValueError("data dictionary must contain axes named 'lon' and 'lat'.")
 
-        data = OrderedDict(
-            [(k, np.atleast_1d(np.asanyarray(v))) for k, v in data.items()]
-        )
+        data = {k: np.atleast_1d(np.asanyarray(v)) for k, v in data.items()}
         vals = np.broadcast_arrays(*data.values(), subok=True)
-        self._data = OrderedDict(zip(data.keys(), vals))
+        self._data = dict(zip(data.keys(), vals))
         self._coordsys = coordsys
         self._match_by_name = match_by_name
 
@@ -894,7 +891,7 @@ class MapCoord:
             A coordinates object.
         """
         if isinstance(coords, (list, tuple)):
-            coords_dict = OrderedDict([("lon", coords[0]), ("lat", coords[1])])
+            coords_dict = {"lon": coords[0], "lat": coords[1]}
             for i, c in enumerate(coords[2:]):
                 coords_dict["axis{}".format(i)] = c
         else:
@@ -948,10 +945,8 @@ class MapCoord:
         if "lon" in coords and "lat" in coords:
             return cls(coords, coordsys=coordsys)
         elif "skycoord" in coords:
-            coords_dict = OrderedDict()
             lon, lat, frame = skycoord_to_lonlat(coords["skycoord"], coordsys=coordsys)
-            coords_dict["lon"] = lon
-            coords_dict["lat"] = lat
+            coords_dict = {"lon": lon, "lat": lat}
             for k, v in coords.items():
                 if k == "skycoord":
                     continue
@@ -1041,7 +1036,7 @@ class MapCoord:
         coords : `~MapCoord`
             A coordinates object.
         """
-        data = OrderedDict([(k, v[mask]) for k, v in self._data.items()])
+        data = {k: v[mask] for k, v in self._data.items()}
         return self.__class__(data, self.coordsys, self._match_by_name)
 
     def copy(self):
@@ -1073,7 +1068,7 @@ class MapCoord:
         coords : `MapCoord`
             Map coord object with matched units
         """
-        coords = OrderedDict()
+        coords = {}
 
         for name, coord in self._data.items():
             if name in ["lon", "lat"]:

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -2,7 +2,6 @@
 """Utilities for dealing with HEALPix projections and mappings."""
 import copy
 import re
-from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -1690,7 +1689,7 @@ class HpxGeom(MapGeom):
     def get_coord(self, idx=None, flat=False):
         pix = self.get_idx(idx=idx, flat=flat)
         coords = self.pix_to_coord(pix)
-        cdict = OrderedDict([("lon", coords[0]), ("lat", coords[1])])
+        cdict = {"lon": coords[0], "lat": coords[1]}
 
         for i, axis in enumerate(self.axes):
             cdict[axis.name] = coords[i + 2]

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -19,7 +19,7 @@ class HpxMap(Map):
         HEALPix geometry object.
     data : `~numpy.ndarray`
         Data array.
-    meta : `~collections.OrderedDict`
+    meta : `dict`
         Dictionary to store meta data.
     unit : `~astropy.units.Unit`
         The map unit
@@ -78,7 +78,7 @@ class HpxMap(Map):
         conv : {'fgst-ccube','fgst-template','gadf'}, optional
             Default FITS format convention that will be used when
             writing this map to a file.  Default is 'gadf'.
-        meta : `~collections.OrderedDict`
+        meta : `dict`
             Dictionary to store meta data.
         unit : str or `~astropy.units.Unit`
             The map unit

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -26,7 +26,7 @@ class HpxNDMap(HpxMap):
     data : `~numpy.ndarray`
         HEALPIX data array.
         If none then an empty array will be allocated.
-    meta : `~collections.OrderedDict`
+    meta : `dict`
         Dictionary to store meta data.
     unit : str or `~astropy.units.Unit`
         The map unit

--- a/gammapy/maps/hpxsparse.py
+++ b/gammapy/maps/hpxsparse.py
@@ -20,7 +20,7 @@ class HpxSparseMap(HpxMap):
         HEALPIX geometry object.
     data : `~numpy.ndarray`
         HEALPIX data array.
-    meta : `~collections.OrderedDict`
+    meta : `dict`
         Dictionary to store meta data.
     unit : `~astropy.units.Unit`
         The map unit

--- a/gammapy/maps/plotting.py
+++ b/gammapy/maps/plotting.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Helper functions and functions for plotting gamma-ray images."""
-from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import Angle
 
@@ -36,7 +35,7 @@ class MapPanelPlotter:
         from matplotlib.gridspec import GridSpec
 
         self.figure = figure
-        self.parameters = OrderedDict(xlim=xlim, ylim=ylim, npanels=npanels)
+        self.parameters = {"xlim": xlim, "ylim": ylim, "npanels": npanels}
         self.grid_spec = GridSpec(nrows=npanels, ncols=1, **kwargs)
 
     def _get_ax_extend(self, ax, panel):

--- a/gammapy/maps/profile.py
+++ b/gammapy/maps/profile.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Tools to create profiles (i.e. 1D "slices" from 2D images)"""
-from collections import OrderedDict
 import numpy as np
 import scipy.ndimage
 from astropy import units as u
@@ -104,7 +103,7 @@ class ImageProfileEstimator:
         if method == "radial" and center is None:
             raise ValueError("Please provide center coordinate for radial profiles")
 
-        self.parameters = OrderedDict(method=method, axis=axis, center=center)
+        self.parameters = {"method": method, "axis": axis, "center": center}
 
     def _get_x_edges(self, image):
         if self._x_edges is not None:

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -55,7 +54,7 @@ def test_map_copy(binsz, width, map_type, skydir, axes, unit):
     assert m_copy.unit == "cm-2 s-1"
     assert m_copy.unit is not m.unit
 
-    m_copy = m.copy(meta=OrderedDict([("is_copy", True)]))
+    m_copy = m.copy(meta={"is_copy": True})
     assert m_copy.meta["is_copy"]
     assert m_copy.meta is not m.meta
 
@@ -141,7 +140,7 @@ def test_map_slice_by_idx(binsz, width, map_type, skydir, axes, unit):
 
 @pytest.mark.parametrize("map_type", ["wcs", "hpx", "hpx-sparse"])
 def test_map_meta_read_write(map_type):
-    meta = OrderedDict([("user", "test")])
+    meta = {"user": "test"}
 
     m = Map.create(
         binsz=0.1,
@@ -210,9 +209,9 @@ def test_map_properties():
     m.unit = "cm-2 s-1"
     assert m.unit.to_string() == "1 / (cm2 s)"
 
-    assert isinstance(m.meta, OrderedDict)
+    assert isinstance(m.meta, dict)
     m.meta = {"spam": 42}
-    assert isinstance(m.meta, OrderedDict)
+    assert isinstance(m.meta, dict)
 
     # The rest of the tests are for the `data` property
 

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -154,30 +153,28 @@ def test_mapcoords_create():
     assert coords.coordsys == "GAL"
     assert coords.ndim == 2
 
-    # 2D Dict w/ vectors
+    # 2D dict w/ vectors
     coords = MapCoord.create(dict(lon=lon, lat=lat))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert coords.ndim == 2
 
-    # 3D Dict w/ vectors
+    # 3D dict w/ vectors
     coords = MapCoord.create(dict(lon=lon, lat=lat, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords["energy"], energy)
     assert coords.ndim == 3
 
-    # 3D Dict w/ SkyCoord
+    # 3D dict w/ SkyCoord
     coords = MapCoord.create(dict(skycoord=skycoord_cel, energy=energy))
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords["energy"], energy)
     assert coords.ndim == 3
 
-    # 3D OrderedDict w/ vectors
-    coords = MapCoord.create(
-        OrderedDict([("energy", energy), ("lat", lat), ("lon", lon)])
-    )
+    # 3D dict  w/ vectors
+    coords = MapCoord.create({"energy": energy, "lat": lat, "lon": lon})
     assert_allclose(coords.lon, lon)
     assert_allclose(coords.lat, lat)
     assert_allclose(coords["energy"], energy)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import copy
-from collections import OrderedDict
 import numpy as np
 import astropy.units as u
 from astropy.coordinates import Angle, SkyCoord
@@ -626,7 +625,7 @@ class WcsGeom(MapGeom):
             coords = tuple([c[is_finite] for c in coords])
 
         axes_names = ["lon", "lat"] + [ax.name for ax in self.axes]
-        cdict = OrderedDict(zip(axes_names, coords))
+        cdict = dict(zip(axes_names, coords))
 
         return MapCoord.create(cdict, coordsys=self.coordsys)
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -77,7 +77,7 @@ class WcsMap(Map):
             Data type, default is float32
         conv : {'fgst-ccube','fgst-template','gadf'}, optional
             FITS format convention.  Default is 'gadf'.
-        meta : `~collections.OrderedDict`
+        meta : `dict`
             Dictionary to store meta data.
         unit : str or `~astropy.units.Unit`
             The unit of the map

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -37,7 +37,7 @@ class WcsNDMap(WcsMap):
         Data array. If none then an empty array will be allocated.
     dtype : str, optional
         Data type, default is float32
-    meta : `~collections.OrderedDict`
+    meta : `dict`
         Dictionary to store meta data.
     unit : str or `~astropy.units.Unit`
         The map unit

--- a/gammapy/modeling/models/spectrum/tests/test_crab.py
+++ b/gammapy/modeling/models/spectrum/tests/test_crab.py
@@ -5,42 +5,42 @@ from gammapy.modeling.models import create_crab_spectral_model
 from gammapy.utils.testing import assert_quantity_allclose
 
 CRAB_SPECTRA = [
-    dict(
-        name="meyer",
-        dnde=u.Quantity(5.572437502365652e-12, "cm-2 s-1 TeV-1"),
-        flux=u.Quantity(2.0744425607240974e-11, "cm-2 s-1"),
-        index=2.631535530090332,
-    ),
-    dict(
-        name="hegra",
-        dnde=u.Quantity(4.60349681e-12, "cm-2 s-1 TeV-1"),
-        flux=u.Quantity(1.74688947e-11, "cm-2 s-1"),
-        index=2.62000000,
-    ),
-    dict(
-        name="hess_pl",
-        dnde=u.Quantity(5.57327158e-12, "cm-2 s-1 TeV-1"),
-        flux=u.Quantity(2.11653715e-11, "cm-2 s-1"),
-        index=2.63000000,
-    ),
-    dict(
-        name="hess_ecpl",
-        dnde=u.Quantity(6.23714253e-12, "cm-2 s-1 TeV-1"),
-        flux=u.Quantity(2.267957713046026e-11, "cm-2 s-1"),
-        index=2.529860258102417,
-    ),
-    dict(
-        name="magic_lp",
-        dnde=u.Quantity(5.5451060834144166e-12, "cm-2 s-1 TeV-1"),
-        flux=u.Quantity(2.028222279117e-11, "cm-2 s-1"),
-        index=2.614495440236207,
-    ),
-    dict(
-        name="magic_ecpl",
-        dnde=u.Quantity(5.88494595619e-12, "cm-2 s-1 TeV-1"),
-        flux=u.Quantity(2.070767119534948e-11, "cm-2 s-1"),
-        index=2.5433349999859405,
-    ),
+    {
+        "name": "meyer",
+        "dnde": u.Quantity(5.572437502365652e-12, "cm-2 s-1 TeV-1"),
+        "flux": u.Quantity(2.0744425607240974e-11, "cm-2 s-1"),
+        "index": 2.631535530090332,
+    },
+    {
+        "name": "hegra",
+        "dnde": u.Quantity(4.60349681e-12, "cm-2 s-1 TeV-1"),
+        "flux": u.Quantity(1.74688947e-11, "cm-2 s-1"),
+        "index": 2.62000000,
+    },
+    {
+        "name": "hess_pl",
+        "dnde": u.Quantity(5.57327158e-12, "cm-2 s-1 TeV-1"),
+        "flux": u.Quantity(2.11653715e-11, "cm-2 s-1"),
+        "index": 2.63000000,
+    },
+    {
+        "name": "hess_ecpl",
+        "dnde": u.Quantity(6.23714253e-12, "cm-2 s-1 TeV-1"),
+        "flux": u.Quantity(2.267957713046026e-11, "cm-2 s-1"),
+        "index": 2.529860258102417,
+    },
+    {
+        "name": "magic_lp",
+        "dnde": u.Quantity(5.5451060834144166e-12, "cm-2 s-1 TeV-1"),
+        "flux": u.Quantity(2.028222279117e-11, "cm-2 s-1"),
+        "index": 2.614495440236207,
+    },
+    {
+        "name": "magic_ecpl",
+        "dnde": u.Quantity(5.88494595619e-12, "cm-2 s-1 TeV-1"),
+        "flux": u.Quantity(2.070767119534948e-11, "cm-2 s-1"),
+        "index": 2.5433349999859405,
+    },
 ]
 
 

--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -5,7 +5,6 @@ import os
 import platform
 import sys
 import warnings
-from collections import OrderedDict
 import click
 from gammapy import __version__
 
@@ -76,31 +75,29 @@ def print_info(info, title):
 
 def get_info_system():
     """Get info about user system"""
-    info = OrderedDict()
-    info["python_executable"] = sys.executable
-    info["python_version"] = platform.python_version()
-    info["machine"] = platform.machine()
-    info["system"] = platform.system()
-    return info
+    return {
+        "python_executable": sys.executable,
+        "python_version": platform.python_version(),
+        "machine": platform.machine(),
+        "system": platform.system(),
+    }
 
 
 def get_info_version():
     """Get detailed info about Gammapy version."""
-    info = OrderedDict()
+    info = {"version": __version__}
     try:
         path = sys.modules["gammapy"].__path__[0]
     except:
         path = "unknown"
     info["path"] = path
 
-    info["version"] = __version__
-
     return info
 
 
 def get_info_dependencies():
     """Get info about Gammapy dependencies."""
-    info = OrderedDict()
+    info = {}
     for name in GAMMAPY_DEPENDENCIES:
         try:
             with warnings.catch_warnings():
@@ -116,7 +113,4 @@ def get_info_dependencies():
 
 def get_info_envvar():
     """Get info about Gammapy environment variables."""
-    info = OrderedDict()
-    for name in GAMMAPY_ENV_VARIABLES:
-        info[name] = os.environ.get(name, "not set")
-    return info
+    return {name: os.environ.get(name, "not set") for name in GAMMAPY_ENV_VARIABLES}

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 from pathlib import Path
 import numpy as np
 from astropy import units as u
@@ -695,23 +694,23 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     def _ogip_meta(self):
         """Meta info for the OGIP data format"""
-        meta = OrderedDict()
-        meta["name"] = "SPECTRUM"
-        meta["hduclass"] = "OGIP"
-        meta["hduclas1"] = "SPECTRUM"
-        meta["corrscal"] = ""
-        meta["chantype"] = "PHA"
-        meta["detchans"] = self.counts.energy.nbin
-        meta["filter"] = "None"
-        meta["corrfile"] = ""
-        meta["poisserr"] = True
-        meta["hduclas3"] = "COUNT"
-        meta["hduclas4"] = "TYPE:1"
-        meta["lo_thres"] = self.energy_range[0].to_value("TeV")
-        meta["hi_thres"] = self.energy_range[1].to_value("TeV")
-        meta["exposure"] = self.livetime.to_value("s")
-        meta["obs_id"] = self.obs_id
-        return meta
+        return {
+            "name": "SPECTRUM",
+            "hduclass": "OGIP",
+            "hduclas1": "SPECTRUM",
+            "corrscal": "",
+            "chantype": "PHA",
+            "detchans": self.counts.energy.nbin,
+            "filter": "None",
+            "corrfile": "",
+            "poisserr": True,
+            "hduclas3": "COUNT",
+            "hduclas4": "TYPE:1",
+            "lo_thres": self.energy_range[0].to_value("TeV"),
+            "hi_thres": self.energy_range[1].to_value("TeV"),
+            "exposure": self.livetime.to_value("s"),
+            "obs_id": self.obs_id,
+        }
 
     @classmethod
     def from_ogip_files(cls, filename):

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-from collections import OrderedDict
 import numpy as np
 from gammapy.modeling.models import ScaleModel
 from gammapy.spectrum import FluxPoints, SpectrumDatasetOnOff
@@ -15,8 +14,6 @@ log = logging.getLogger(__name__)
 
 class LightCurveEstimator:
     """Estimate flux points for a given list of datasets, each per time bin.
-
-
 
     Parameters
     ----------
@@ -135,7 +132,6 @@ class LightCurveEstimator:
         self.e_max = e_max
 
         rows = []
-
         for dataset in self.datasets.datasets:
             row = {
                 "time_min": dataset.counts.meta["t_start"].mjd,
@@ -144,8 +140,7 @@ class LightCurveEstimator:
             row.update(self.estimate_time_bin_flux(dataset, steps))
             rows.append(row)
 
-        meta = OrderedDict([("SED_TYPE", "likelihood")])
-        table = table_from_row_data(rows=rows, meta=meta)
+        table = table_from_row_data(rows=rows, meta={"SED_TYPE": "likelihood"})
         table = FluxPoints(table).to_sed_type("flux").table
         return LightCurve(table)
 
@@ -172,17 +167,15 @@ class LightCurveEstimator:
         """
         self.fit = Fit(dataset)
 
-        result = OrderedDict(
-            [
-                ("e_ref", self.e_ref),
-                ("e_min", self.e_min),
-                ("e_max", self.e_max),
-                ("ref_dnde", self.ref_model(self.e_ref)),
-                ("ref_flux", self.ref_model.integral(self.e_min, self.e_max)),
-                ("ref_eflux", self.ref_model.energy_flux(self.e_min, self.e_max)),
-                ("ref_e2dnde", self.ref_model(self.e_ref) * self.e_ref ** 2),
-            ]
-        )
+        result = {
+            "e_ref": self.e_ref,
+            "e_min": self.e_min,
+            "e_max": self.e_max,
+            "ref_dnde": self.ref_model(self.e_ref),
+            "ref_flux": self.ref_model.integral(self.e_min, self.e_max),
+            "ref_eflux": self.ref_model.energy_flux(self.e_min, self.e_max),
+            "ref_e2dnde": self.ref_model(self.e_ref) * self.e_ref ** 2,
+        }
 
         result.update(self.estimate_norm())
 

--- a/gammapy/time/period.py
+++ b/gammapy/time/period.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import numpy as np
 import scipy.optimize
 
@@ -51,7 +50,7 @@ def robust_periodogram(time, flux, flux_err=None, periods=None, loss="linear", s
 
     Returns
     -------
-    results : `~collections.OrderedDict`
+    results : `dict`
         Results dictionary (see description above).
 
     References
@@ -74,9 +73,7 @@ def robust_periodogram(time, flux, flux_err=None, periods=None, loss="linear", s
     # find period of highest periodogram peak
     best_period = periods[np.argmax(psd_data)]
 
-    return OrderedDict(
-        [("periods", periods), ("power", psd_data), ("best_period", best_period)]
-    )
+    return {"periods": periods, "power": psd_data, "best_period": best_period}
 
 
 def _period_grid(time):

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -191,7 +191,6 @@ For further information on Astropy, see the Astropy docs at
 We will have to see if / what we need here in `gammapy.utils.fits`
 as a stable and nice interface on top of what Astropy provides.
 """
-from collections import OrderedDict
 import numpy as np
 from astropy.coordinates import Angle, EarthLocation
 from astropy.io import fits
@@ -361,13 +360,13 @@ class SmartHDUList:
 
 
 def fits_header_to_meta_dict(header):
-    """Convert `astropy.io.fits.Header` to `~collections.OrderedDict`.
+    """Convert `astropy.io.fits.Header` to `dict`.
 
     This is a lossy conversion, only key, value is stored
     (and not e.g. comments for each FITS "card").
     Also, "COMMENT" and "HISTORY" cards are completely removed.
     """
-    meta = OrderedDict(header)
+    meta = dict(header)
 
     # Drop problematic header content, i.e. values of type
     # `astropy.io.fits.header._HeaderCommentaryCards`

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utility functions and classes for n-dimensional data and axes."""
-from collections import OrderedDict
 import numpy as np
 from astropy.units import Quantity
 from .array import array_stats_str
@@ -34,8 +33,7 @@ class NDDataArray:
         self._axes = axes
         if data is not None:
             self.data = data
-        if meta is not None:
-            self.meta = OrderedDict(meta)
+        self.meta = meta or {}
         self.interp_kwargs = interp_kwargs or self.default_interp_kwargs
 
         self._regular_grid_interp = None

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
@@ -162,7 +161,7 @@ class MapEventSampler:
         # TODO: pix_to_coord should return a MapCoord object
         geom = self.npred_map.geom
         axes_names = ["lon", "lat"] + [ax.name for ax in geom.axes]
-        cdict = OrderedDict(zip(axes_names, coords))
+        cdict = dict(zip(axes_names, coords))
         cdict["energy"] *= geom.get_axis_by_name("energy").unit
         return MapCoord.create(cdict, coordsys=geom.coordsys)
 
@@ -176,9 +175,7 @@ class MapEventSampler:
         """Time meta information (`OrderedDict`)"""
         # TODO: extend the meta information according to
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
-        meta = OrderedDict()
-        meta["ONTIME"] = np.round(self.ontime.to_value("s"), 1)
-        return meta
+        return {"ONTIME": np.round(self.ontime.to_value("s"), 1)}
 
     def sample_time(self, n_events=None):
         """Sample arrival times of events.

--- a/gammapy/utils/random/inverse_cdf.py
+++ b/gammapy/utils/random/inverse_cdf.py
@@ -172,7 +172,7 @@ class MapEventSampler:
         return u.Quantity(ontime.sec, "s")
 
     def _get_time_meta(self):
-        """Time meta information (`OrderedDict`)"""
+        """Time meta information (`dict`)"""
         # TODO: extend the meta information according to
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
         return {"ONTIME": np.round(self.ontime.to_value("s"), 1)}

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Table helper utilities."""
-from collections import OrderedDict
 from astropy.table import Table
 from astropy.units import Quantity
 from .units import standardise_unit
@@ -56,10 +55,10 @@ def table_row_to_dict(row, make_quantity=True):
 
     Returns
     -------
-    data : `~collections.OrderedDict`
+    data : `dict`
         Row data
     """
-    data = OrderedDict()
+    data = {}
     for name, col in row.columns.items():
         val = row[name]
         if make_quantity and col.unit:

--- a/gammapy/utils/table.py
+++ b/gammapy/utils/table.py
@@ -70,13 +70,12 @@ def table_row_to_dict(row, make_quantity=True):
 def table_from_row_data(rows, **kwargs):
     """Helper function to create table objects from row data.
 
-    - Works with quantities.
-    - Preserves order of keys if OrderedDicts are used.
+    Works with quantities.
 
     Parameters
     ----------
     rows : list
-        List of row data (each row a dict or OrderedDict)
+        List of row data (each row a dict)
     """
     table = Table(**kwargs)
     colnames = list(rows[0].keys())

--- a/gammapy/utils/tests/test_table.py
+++ b/gammapy/utils/tests/test_table.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 import pytest
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -38,7 +37,7 @@ def table():
 
 def test_table_row_to_dict(table):
     actual = table_row_to_dict(table[1])
-    expected = OrderedDict([("a", 2), ("b", 2 * u.m), ("c", "yy")])
+    expected = {"a": 2, "b": 2 * u.m, "c": "yy"}
     assert actual == expected
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ classifiers =
     'Programming Language :: C',
     'Programming Language :: Cython',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Scientific/Engineering :: Astronomy',
     'Development Status :: 3 - Alpha',
@@ -36,7 +36,7 @@ build_notebooks = True
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.6
 setup_requires =
     setuptools
     setuptools_scm


### PR DESCRIPTION
This PR changes all code in Gammapy from OrderedDict to dict, since we now require Python 3.6 or later and there dict is ordered. See #2349.

I noticed that there were a few init methods where we did `self.meta = OrderedDict(meta) if meta else OrderedDict()`. I changed those to `self.meta = meta`. Before always a copy was made, now the object is just stored, no copy. That's consistent with how `Table` or most other code in Astropy, Gammapy, ... works, to not make copies of things passed to `__init__`. All tests pass, but there could be users that relied on the copy being made. I don't think we should make copies, I just wanted to note that point if someone reports an issue after updating to v0.14.

Another cleanup I'm doing here is to use more dict literals, i.e. `{...}`. We still have a mix within Gammapy, but generally that's the preferred style (by me, but also by default by PyCharm and other style tools, they suggest to change to `{...}` where possible). It's a really minor style point, no need to completely clean up now.