### PR TITLE
Add `SpectrumDataset.stack()`

### DIFF
--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -429,14 +429,10 @@ class SpectrumDataset(Dataset):
         if self.counts is not None:
             self.counts.data[~self.mask_safe] *= 0
             self.counts.data[other.mask_safe] += other.counts.data[other.mask_safe]
-        else:
-            self.counts = None
 
         if self.background is not None:
             self.background.data[~self.mask_safe] *= 0
             self.background.data[other.mask_safe] += other.background.data[other.mask_safe]
-        else:
-            self.background = None
 
         self.mask_safe = np.logical_or(self.mask_safe, other.mask_safe)
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -427,7 +427,7 @@ class SpectrumDataset(Dataset):
         else:
             self.background = None
 
-        self.safe_mask = np.logical_or(self.safe_mask, other.safe_mask)
+        self.mask_safe = np.logical_or(self.mask_safe, other.mask_safe)
 
         irf_stacker = IRFStacker(list_aeff=[self.aeff, other.aeff],
                                  list_livetime=[self.livetime, other.livetime],

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -180,6 +180,17 @@ class SpectrumDataset(Dataset):
             self._predictor = None
 
     @property
+    def mask_safe(self):
+        if self._mask_safe is None:
+            return np.ones(self.data_shape,bool)
+        else:
+            return self._mask_safe
+
+    @mask_safe.setter
+    def mask_safe(self, mask):
+        self._mask_safe = mask
+
+    @property
     def parameters(self):
         if self._parameters is None:
             raise AttributeError("No model set for Dataset")
@@ -401,31 +412,30 @@ class SpectrumDataset(Dataset):
     def stack(self, other):
         """Stack this dataset with another one.
 
-        Stacking is done in place.
-
         Safe mask is applied to compute the stacked counts vector.
         Counts outside each dataset safe mask are lost.
+
+        Stacking is performed in-place.
 
         Parameters
         ----------
         other : `~gammapy.spectrum.SpectrumDataset`
             the dataset to stack to the current one
-        """
+       """
+
         if not isinstance(other, SpectrumDataset):
             raise TypeError("Incompatible types for SpectrumDataset stacking")
 
-        if self.counts is not None and other.counts is not None:
-            self.counts.data[self.mask_safe] *= 0.
+        print(self.mask_safe)
+
+        if self.counts is not None:
+            self.counts.data[self.mask_safe] *= 0
             self.counts.data[other.mask_safe] += other.counts.data[other.mask_safe]
         else:
-            # TODO: Add warning
             self.counts = None
 
-        if self.mask_safe is None:
-            self.mask_safe = np.ones_like(self.counts.data)
-
-        if self.background is not None and other.background is not None:
-            self.background.data[self.mask_safe] *= 0.
+        if self.background is not None:
+            self.background.data[self.mask_safe] *= 0
             self.background.data[other.mask_safe] += other.background.data[other.mask_safe]
         else:
             self.background = None
@@ -434,13 +444,15 @@ class SpectrumDataset(Dataset):
 
         irf_stacker = IRFStacker(list_aeff=[self.aeff, other.aeff],
                                  list_livetime=[self.livetime, other.livetime],
-                                 list_edisp=[self.edisp, other.edisp]
+                                 list_edisp=[self.edisp, other.edisp],
+                                 list_low_threshold=[self.energy_range[0], other.energy_range[0]],
+                                 list_high_threshold=[self.energy_range[1], other.energy_range[1]],
                                  )
 
-        if self.aeff is not None and other.aeff is not None:
+        if self.aeff is not None:
             irf_stacker.stack_aeff()
             self.aeff = irf_stacker.stacked_aeff
-            if self.edisp is not None and other.edisp is not None:
+            if self.edisp is not None:
                 irf_stacker.stack_edisp()
                 self.edisp = irf_stacker.stacked_edisp
             else:
@@ -449,13 +461,15 @@ class SpectrumDataset(Dataset):
             self.aeff = None
             self.edisp = None
 
-
-        if self.gti is not None and other.gti is not None:
+        if self.gti is not None:
             self.gti.stack(other.gti)
             self.gti.union()
         else:
-            # TODO : add warning if one gti is missing
             self.gti = None
+
+        #TODO: for the moment, since dead time is not accounted for, livetime cannot be the sum
+        # of GTIs
+        self.livetime += other.livetime
 
 class SpectrumDatasetOnOff(SpectrumDataset):
     """Spectrum dataset for on-off likelihood fitting.

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -227,7 +227,7 @@ class SpectrumDataset(Dataset):
         return cash(n_on=self.counts.data, mu_on=self.npred().data)
 
     def _as_counts_spectrum(self, data):
-        energy = self.counts.energy.edges
+        energy = self._energy_axis.edges
         return CountsSpectrum(data=data, energy_lo=energy[:-1], energy_hi=energy[1:])
 
     @property
@@ -255,7 +255,7 @@ class SpectrumDataset(Dataset):
     @property
     def energy_range(self):
         """Energy range defined by the safe mask"""
-        energy = self.counts.energy.edges
+        energy = self._energy_axis.edges
         e_lo = energy[:-1][self.mask_safe]
         e_hi = energy[1:][self.mask_safe]
         return u.Quantity([e_lo.min(), e_hi.max()])

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -426,16 +426,14 @@ class SpectrumDataset(Dataset):
         if not isinstance(other, SpectrumDataset):
             raise TypeError("Incompatible types for SpectrumDataset stacking")
 
-        print(self.mask_safe)
-
         if self.counts is not None:
-            self.counts.data[self.mask_safe] *= 0
+            self.counts.data[~self.mask_safe] *= 0
             self.counts.data[other.mask_safe] += other.counts.data[other.mask_safe]
         else:
             self.counts = None
 
         if self.background is not None:
-            self.background.data[self.mask_safe] *= 0
+            self.background.data[~self.mask_safe] *= 0
             self.background.data[other.mask_safe] += other.background.data[other.mask_safe]
         else:
             self.background = None

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -421,6 +421,9 @@ class SpectrumDataset(Dataset):
             # TODO: Add warning
             self.counts = None
 
+        if self.mask_safe is None:
+            self.mask_safe = np.ones_like(self.counts.data)
+
         if self.background is not None and other.background is not None:
             self.background.data[self.mask_safe] *= 0.
             self.background.data[other.mask_safe] += other.background.data[other.mask_safe]

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -136,6 +136,26 @@ class TestSpectrumDataset:
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
 
+    def test_spectrum_dataset_stack(self):
+        aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")
+        edisp = EnergyDispersion.from_diagonal_response(
+            self.src.energy.edges, self.src.energy.edges
+        )
+        livetime = self.livetime
+        dataset1 = SpectrumDataset(
+            None, self.src, livetime, None, aeff, edisp, self.bkg
+        )
+
+        livetime2 = 0.5*livetime
+        aeff2 = EffectiveAreaTable(self.src.energy.edges[:-1], self.src.energy.edges[1:], 2*aeff.data.data)
+        bkg2 = CountsSpectrum(self.src.energy.edges[:-1], self.src.energy.edges[1:],2*self.bkg.data)
+        dataset2 = SpectrumDataset(
+            None, self.src, livetime2, None, aeff2, edisp, bkg2
+        )
+
+        dataset1.stack(dataset2)
+
+        assert dataset1.counts.data.sum() == self.src.data.sum()*2
 
 class TestSpectrumOnOff:
     """ Test ON OFF SpectrumDataset"""

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -145,8 +145,7 @@ class TestSpectrumDataset:
         dataset1 = SpectrumDataset(
             counts = self.src, livetime=livetime, aeff=aeff, edisp=edisp, background=self.bkg
         )
-        print(dataset1.mask_safe)
-
+ 
         livetime2 = 0.5*livetime
         aeff2 = EffectiveAreaTable(self.src.energy.edges[:-1], self.src.energy.edges[1:], 2*aeff.data.data)
         bkg2 = CountsSpectrum(self.src.energy.edges[:-1], self.src.energy.edges[1:],2*self.bkg.data)
@@ -157,6 +156,8 @@ class TestSpectrumDataset:
         dataset1.stack(dataset2)
 
         assert dataset1.counts.data.sum() == self.src.data.sum()*2
+        assert dataset1.livetime == 1.5*self.livetime
+        assert dataset1.background.data.sum() == 3*self.bkg.data.sum()
 
 class TestSpectrumOnOff:
     """ Test ON OFF SpectrumDataset"""

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -143,14 +143,15 @@ class TestSpectrumDataset:
         )
         livetime = self.livetime
         dataset1 = SpectrumDataset(
-            None, self.src, livetime, None, aeff, edisp, self.bkg
+            counts = self.src, livetime=livetime, aeff=aeff, edisp=edisp, background=self.bkg
         )
+        print(dataset1.mask_safe)
 
         livetime2 = 0.5*livetime
         aeff2 = EffectiveAreaTable(self.src.energy.edges[:-1], self.src.energy.edges[1:], 2*aeff.data.data)
         bkg2 = CountsSpectrum(self.src.energy.edges[:-1], self.src.energy.edges[1:],2*self.bkg.data)
         dataset2 = SpectrumDataset(
-            None, self.src, livetime2, None, aeff2, edisp, bkg2
+            counts=self.src, livetime=livetime2, aeff=aeff2, edisp=edisp, background=bkg2
         )
 
         dataset1.stack(dataset2)

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -145,7 +145,7 @@ class TestSpectrumDataset:
         dataset1 = SpectrumDataset(
             counts = self.src.copy(), livetime=livetime, aeff=aeff, edisp=edisp, background=self.bkg.copy()
         )
- 
+
         livetime2 = 0.5*livetime
         aeff2 = EffectiveAreaTable(self.src.energy.edges[:-1], self.src.energy.edges[1:], 2*aeff.data.data)
         bkg2 = CountsSpectrum(self.src.energy.edges[:-1], self.src.energy.edges[1:], data=2*self.bkg.data)


### PR DESCRIPTION
This PR adds a `stack()` method to `SpectrumDataset`. The stacking is done in-place. 

To properly deal with the `safe_mask` when it is not set, I have added a property to have it return a vector of `True` values.