### PR TITLE
Adapt MapMakerObs to also compute an EDispMap and PSFMap

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -166,10 +166,8 @@ class MapMaker:
         for name, map in maps.items():
             if name == "exposure":
                 map = _map_spectrum_weight(map, spectrum)
-            if name == "psf":
-                map = map.psf_map
-            if name == "edisp":
-                map = map.edisp_map
+            if name == "psf" or name == "edisp":
+                continue
 
             images[name] = map.sum_over_axes(keepdims=keepdims)
 
@@ -274,6 +272,10 @@ class MapMakerObs:
     @lazyproperty
     def coords(self):
         return self.geom.get_coord()
+
+    @lazyproperty
+    def coords_etrue(self):
+        return self.geom_true.get_coord()
 
     def run(self, selection=None):
         """Make maps.

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.coordinates import Angle
 from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.utils import lazyproperty
-from ..irf import EnergyDependentMultiGaussPSF, PSF3D
+from ..irf import EnergyDependentMultiGaussPSF
 from gammapy.maps import Map, WcsGeom, MapAxis
 from .background import make_map_background_irf
 from .counts import fill_map_counts
@@ -158,9 +158,6 @@ class MapMaker:
         for name, map in maps.items():
             if name == "exposure":
                 map = _map_spectrum_weight(map, spectrum)
-            if name == "psf" or name == "edisp":
-                continue
-
             images[name] = map.sum_over_axes(keepdims=keepdims)
         # TODO: PSF (and edisp) map sum_over_axis
 
@@ -465,7 +462,7 @@ class MapMakerRing(MapMaker):
                 log.info("Skipping obs_id: {} (partial map overlap)".format(obs.obs_id))
                 continue
 
-            maps_obs = obs_maker.run()
+            maps_obs = obs_maker.run(selection=["counts", "exposure", "background"])
             maps_obs["exclusion"] = obs_maker.exclusion_mask
 
             if sum_over_axis:

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -34,10 +34,6 @@ class MapMaker:
         Exclusion mask
     background_oversampling : int
         Background oversampling factor in energy axis.
-    migra_axis : `~gammapy.maps.MapAxis`
-        Migration axis for edisp map
-    rad_axis : `~gammapy.maps.MapAxis`
-        Radial axis for psf map
     """
 
     def __init__(
@@ -47,8 +43,6 @@ class MapMaker:
         geom_true=None,
         exclusion_mask=None,
         background_oversampling=None,
-        migra_axis=None,
-        rad_axis=None,
     ):
         if not isinstance(geom, WcsGeom):
             raise ValueError("MapMaker only works with WcsGeom")
@@ -61,16 +55,6 @@ class MapMaker:
         self.offset_max = Angle(offset_max)
         self.exclusion_mask = exclusion_mask
         self.background_oversampling = background_oversampling
-        self.migra_axis = (
-            migra_axis
-            if migra_axis
-            else MapAxis(nodes=np.linspace(0.0, 1.0, 11), unit="", name="migra")
-        )
-        self.rad_axis = (
-            rad_axis
-            if rad_axis
-            else MapAxis(nodes=np.linspace(0.0, 1.0, 11), unit="deg", name="theta")
-        )
 
     def _get_empty_maps(self, selection):
         # Initialise zero-filled maps

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-import astropy.units as u
 from astropy.coordinates import Angle
 from astropy.nddata.utils import NoOverlapError, PartialOverlapError
 from astropy.utils import lazyproperty
@@ -345,8 +344,7 @@ class MapMakerObs:
     def _make_psf(self):
         psf = self.observation.psf
         if isinstance(psf, EnergyDependentMultiGaussPSF):
-            rad = np.linspace(0, 0.66, 67) * u.deg  # Arbitrary binning of 0.01 in rad
-            psf = psf.to_psf3d(rad)
+            psf = psf.to_psf3d()
         energy_axis = self.geom_true.get_axis_by_name("ENERGY")
         if self.rad_axis is None:
             rad = psf.rad_lo.value

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from astropy.coordinates import Angle
-from gammapy.cube.psf_kernel import PSFKernel
+from gammapy.cube import PSFKernel
 from gammapy.irf import EnergyDependentTablePSF
 from gammapy.maps import Map
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from astropy.coordinates import Angle
-from gammapy.cube import PSFKernel
+from .psf_kernel import PSFKernel
 from gammapy.irf import EnergyDependentTablePSF
 from gammapy.maps import Map
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -3,7 +3,7 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from astropy.coordinates import Angle
-from gammapy.cube import PSFKernel
+from gammapy.cube.psf_kernel import PSFKernel
 from gammapy.irf import EnergyDependentTablePSF
 from gammapy.maps import Map
 

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -150,7 +150,7 @@ def test_map_maker_obs(observations):
     map_obs = maker_obs.run()
     assert map_obs["counts"].geom == geom_reco
     assert map_obs["background"].geom == geom_reco
-    assert map_obs["exposure_irf"].geom == geom_true
     assert map_obs["exposure"].geom == geom_exp
-    assert map_obs["edisp"].edisp_map.data.shape == (3, 48, 5, 10)
+    assert map_obs["edisp"].edisp_map.data.shape == (3, 300, 5, 10)
+    assert map_obs["edisp"].exposure_map.geom == geom_true
     assert map_obs["psf"].psf_map.data.shape == (3, 66, 5, 10)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -152,4 +152,5 @@ def test_map_maker_obs(observations):
     assert map_obs["background"].geom == geom_reco
     assert map_obs["exposure_irf"].geom == geom_true
     assert map_obs["exposure"].geom == geom_exp
-    assert map_obs["edisp"].edisp_map.data.shape == (3, 10, 5, 10)
+    assert map_obs["edisp"].edisp_map.data.shape == (3, 48, 5, 10)
+    assert map_obs["psf"].psf_map.data.shape == (3, 66, 5, 10)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -79,15 +79,11 @@ def test_map_maker(pars, observations, keepdims):
         background_oversampling=pars.get("background_oversampling"),
     )
 
-
-"""
     maps = maker.run(observations)
-
 
     counts = maps["counts"]
     assert counts.unit == ""
     assert_allclose(counts.data.sum(), pars["counts"], rtol=1e-5)
-
 
     exposure = maps["exposure"]
     assert exposure.unit == "m2 s"
@@ -135,7 +131,6 @@ def test_map_maker_ring(observations):
     assert_allclose(np.nansum(images["on"].data), 21981, rtol=1e-2)
     assert_allclose(np.nansum(images["exposure_off"].data), 109751.45, rtol=1e-2)
     assert images["on"].geom.is_image is True
-"""
 
 
 @requires_data()

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from gammapy.cube import MapMaker, MapMakerRing, RingBackgroundEstimator
+from gammapy.cube import MapMaker, MapMakerRing, RingBackgroundEstimator, MapMakerObs
 from gammapy.data import DataStore
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data
@@ -18,15 +18,11 @@ def observations():
     return data_store.get_observations(obs_id)
 
 
-def geom(ebounds):
+def geom(ebounds, binsz=0.5):
     skydir = SkyCoord(0, -1, unit="deg", frame="galactic")
     energy_axis = MapAxis.from_edges(ebounds, name="energy", unit="TeV", interp="log")
     return WcsGeom.create(
-        binsz=0.5 * u.deg,
-        skydir=skydir,
-        width=(10, 5),
-        coordsys="GAL",
-        axes=[energy_axis],
+        binsz=binsz, skydir=skydir, width=(10, 5), coordsys="GAL", axes=[energy_axis]
     )
 
 
@@ -83,11 +79,15 @@ def test_map_maker(pars, observations, keepdims):
         background_oversampling=pars.get("background_oversampling"),
     )
 
+
+"""
     maps = maker.run(observations)
+
 
     counts = maps["counts"]
     assert counts.unit == ""
     assert_allclose(counts.data.sum(), pars["counts"], rtol=1e-5)
+
 
     exposure = maps["exposure"]
     assert exposure.unit == "m2 s"
@@ -135,3 +135,26 @@ def test_map_maker_ring(observations):
     assert_allclose(np.nansum(images["on"].data), 21981, rtol=1e-2)
     assert_allclose(np.nansum(images["exposure_off"].data), 109751.45, rtol=1e-2)
     assert images["on"].geom.is_image is True
+"""
+
+
+@requires_data()
+def test_map_maker_obs(observations):
+    # Test for different spatial geoms and etrue, ereco bins
+
+    geom_reco = geom(ebounds=[0.1, 1, 10])
+    geom_true = geom(ebounds=[0.1, 0.5, 2.5, 10.0], binsz=1.0)
+    geom_exp = geom(ebounds=[0.1, 0.5, 2.5, 10.0])
+    maker_obs = MapMakerObs(
+        observation=observations[0],
+        geom=geom_reco,
+        geom_true=geom_true,
+        offset_max=2.0 * u.deg,
+    )
+
+    map_obs = maker_obs.run()
+    assert map_obs["counts"].geom == geom_reco
+    assert map_obs["background"].geom == geom_reco
+    assert map_obs["exposure_irf"].geom == geom_true
+    assert map_obs["exposure"].geom == geom_exp
+    assert map_obs["edisp"].edisp_map.data.shape == (3, 10, 5, 10)

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -448,7 +448,7 @@ class EnergyDependentMultiGaussPSF:
             energy=energies, rad=rad, exposure=exposure, psf_value=psf_value
         )
 
-    def to_psf3d(self, rad):
+    def to_psf3d(self, rad=None):
         """Create a PSF3D from an analytical PSF.
 
         Parameters
@@ -465,6 +465,8 @@ class EnergyDependentMultiGaussPSF:
         energy = self.energy
         energy_lo = self.energy_lo
         energy_hi = self.energy_hi
+        if rad is None:
+            rad = np.linspace(0, 0.66, 67) * Unit("deg") # Arbitrary binning of 0.01 in rad
         rad_lo = rad[:-1]
         rad_hi = rad[1:]
 


### PR DESCRIPTION
Hello @adonath @registerrier @luca-giunti ! This PR addresses one of the steps towards dataset stacking.

I had to modify `MapMaker` a bit to ensure tests do not fail. This is mostly a patchwork, as `MapMaker` will go away soon. I am not sure how the `sum_over_axes()` should work for the psf, and edisp maps. Since stackings are being implemented separately, I did not do the stacking of the maps in the MapMaker either.

The CTA DC1 psf files are `gammapy.irf.psf_gauss.EnergyDependentMultiGaussPSF` instead of `gammapy.irf.psf_3d.PSF3D`. I do not know how to handle this, so for now, I have just put a check.

