### PR TITLE
Remove `BackgroundModels` class

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -167,32 +167,34 @@ class MapDataset(Dataset):
             "Number of free parameters", len(self.parameters.free_parameters)
         )
 
-        if self.model is not None:
-            for idx, model in enumerate(self.model.skymodels):
-                str_ += "\tSource {}: \n".format(idx)
-                str_ += "\t\t{:28}: {}\n".format("Name", model.name)
-                str_ += "\t\t{:28}: {}\n".format(
-                    "Spatial model type", model.spatial_model.__class__.__name__
-                )
-                info = str(model.spatial_model.parameters)
-                lines = info.split("\n")
-                str_ += "\t\t" + "\n\t\t".join(lines[2:-1])
+        components = []
 
-                str_ += "\n\t\t{:28}: {}\n".format(
-                    "Spectral model type", model.spectral_model.__class__.__name__
-                )
-                info = str(model.spectral_model.parameters)
-                lines = info.split("\n")
-                str_ += "\t\t" + "\n\t\t".join(lines[2:-1])
+        if self.model is not None:
+            components += self.model.skymodels
 
         if self.background_model is not None:
-            str_ += "\n\n\tBackground: \n"
-            str_ += "\t\t{:28}: {}\n".format(
-                "Model type", self.background_model.__class__.__name__
-            )
-            info = str(self.background_model.parameters)
+            components += [self.background_model]
+
+        for idx, model in enumerate(components):
+            str_ += "\tComponent {}: \n".format(idx)
+            str_ += "\t\t{:28}: {}\n".format("Name", model.name)
+            str_ += "\t\t{:28}: {}\n".format("Type", model.__class__.__name__)
+
+            if isinstance(model, SkyModel):
+                str_ += "\t\t{:28}: {}\n".format(
+                    "Spatial  model type", model.spatial_model.__class__.__name__
+                )
+                str_ += "\t\t{:28}: {}\n".format(
+                    "Spectral model type", model.spectral_model.__class__.__name__
+                )
+
+            str_ += "\t\tParameters:\n"
+
+            info = str(model.parameters)
             lines = info.split("\n")
             str_ += "\t\t" + "\n\t\t".join(lines[2:-1])
+
+            str_ += "\n\n"
 
         return str_.expandtabs(tabsize=4)
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -497,7 +497,7 @@ class MapDataset(Dataset):
             init_kwargs["exposure"] = Map.from_hdulist(hdulist, hdu="exposure")
 
         if "BACKGROUND" in hdulist:
-            background_map = Map.from_hdulist(hdulist, hdu=hdu.name)
+            background_map = Map.from_hdulist(hdulist, hdu="background")
             init_kwargs["background_model"] = BackgroundModel(background_map)
 
         if "EDISP_MATRIX" in hdulist:
@@ -561,7 +561,7 @@ class MapDataset(Dataset):
         data = {}
         data["name"] = self.name
         data["models"] = self.model.names
-        data["backgrounds"] = [_.name for _ in self.background_model.models]
+        data["background"] = self.background_model.name
         data["filename"] = filename
         return data
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -166,8 +166,8 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         "COUNTS_BANDS",
         "EXPOSURE",
         "EXPOSURE_BANDS",
-        "BKG_BACKGROUND",
-        "BKG_BACKGROUND_BANDS",
+        "BACKGROUND",
+        "BACKGROUND_BANDS",
         "EDISP_MATRIX",
         "EDISP_MATRIX_EBOUNDS",
         "PSF_KERNEL",
@@ -189,7 +189,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
     assert_allclose(dataset.counts.data, dataset_new.counts.data)
     assert_allclose(
         dataset.background_model.map.data,
-        dataset_new.background_model.models[0].map.data,
+        dataset_new.background_model.map.data,
     )
     assert_allclose(dataset.edisp.data.data.value, dataset_new.edisp.data.data.value)
     assert_allclose(dataset.psf.data, dataset_new.psf.data)
@@ -201,7 +201,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
     assert dataset.exposure.geom == dataset_new.exposure.geom
     assert (
         dataset.background_model.map.geom
-        == dataset_new.background_model.models[0].map.geom
+        == dataset_new.background_model.map.geom
     )
 
     assert_allclose(

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -182,5 +182,5 @@ class Datasets:
         datasets_dict, components_dict = datasets_to_dict(
             self.datasets, path, selection, overwrite
         )
-        write_yaml(datasets_dict, path + "datasets.yaml")
-        write_yaml(components_dict, path + "models.yaml")
+        write_yaml(datasets_dict, path + "datasets.yaml", sort_keys=False)
+        write_yaml(components_dict, path + "models.yaml", sort_keys=False)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -311,6 +311,23 @@ class SkyModel(SkyModelBase):
         data["spectral"] = self.spectral_model.to_dict(selection)
         return data
 
+    @classmethod
+    def from_dict(cls, data):
+        """Create SkyModel from dict"""
+        from gammapy.modeling.models import SPATIAL_MODELS, SPECTRAL_MODELS
+
+        model_class = SPECTRAL_MODELS[data["spectral"]["type"]]
+        spectral_model = model_class.from_dict(data["spectral"])
+
+        model_class = SPATIAL_MODELS[data["spatial"]["type"]]
+        spatial_model = model_class.from_dict(data["spatial"])
+
+        return cls(
+            name=data["name"],
+            spatial_model=spatial_model,
+            spectral_model=spectral_model,
+        )
+
 
 class SkyDiffuseCube(SkyModelBase):
     """Cube sky map template model (3D).

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -549,3 +549,12 @@ class BackgroundModel(Model):
         if self.filename is not None:
             data["filename"] = self.filename
         return data
+
+    @classmethod
+    def from_dict(cls, data):
+        data = Map.read(data["filename"])
+        init = cls(background=data, name=data["name"])
+        init.parameters = Parameters.from_dict(data)
+        for parameter in init.parameters.parameters:
+            setattr(init, parameter.name, parameter)
+        return init

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -548,12 +548,19 @@ class BackgroundModel(Model):
         data.update(super().to_dict(selection=selection))
         if self.filename is not None:
             data["filename"] = self.filename
+        data["parameters"] = data.pop("parameters")
         return data
 
     @classmethod
     def from_dict(cls, data):
-        data = Map.read(data["filename"])
-        init = cls(background=data, name=data["name"])
+        if "filename" in data:
+            background = Map.read(data["filename"])
+        elif "map" in data:
+            background = data["map"]
+        else:
+            raise ValueError("Requires either filename or `Map` object")
+
+        init = cls(background=background, name=data["name"])
         init.parameters = Parameters.from_dict(data)
         for parameter in init.parameters.parameters:
             setattr(init, parameter.name, parameter)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -305,8 +305,8 @@ class SkyModel(SkyModelBase):
     def to_dict(self, selection):
         """Create dict for YAML serilisation"""
         data = {}
-        data["type"] = self.tag
         data["name"] = self.name
+        data["type"] = self.tag
         data["spatial"] = self.spatial_model.to_dict(selection)
         data["spectral"] = self.spectral_model.to_dict(selection)
         return data
@@ -453,8 +453,12 @@ class SkyDiffuseCube(SkyModelBase):
 
     def to_dict(self, selection):
         data = super().to_dict(selection=selection)
-        data["filename"] = self.filename
         data["name"] = self.name
+        data["type"] = data.pop("type")
+        data["filename"] = self.filename
+
+        # Move parameters at the end
+        data["parameters"] = data.pop("parameters")
         return data
 
 
@@ -522,8 +526,9 @@ class BackgroundModel(Model):
         return self.map.copy(data=back_values)
 
     def to_dict(self, selection):
-        data = super().to_dict(selection=selection)
+        data = {}
         data["name"] = self.name
+        data.update(super().to_dict(selection=selection))
         if self.filename is not None:
             data["filename"] = self.filename
         return data

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -8,7 +8,6 @@ from gammapy.irf import EnergyDispersion
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
     BackgroundModel,
-    BackgroundModels,
     PowerLaw,
     SkyDiffuseCube,
     SkyGaussian,
@@ -150,14 +149,6 @@ def test_background_model(background):
     ).evaluate()
     assert_allclose(bkg2.data[0][0][0], 2.254e-07, rtol=1e-3)
     assert_allclose(bkg2.data.sum(), 7.352e-06, rtol=1e-3)
-
-
-def test_background_models(background):
-    bkg_1 = BackgroundModel(background, norm=1.0)
-    bkg_2 = BackgroundModel(background, norm=2.0)
-    models = BackgroundModels([bkg_1, bkg_2])
-    bkg_eval = models.evaluate()
-    assert_allclose(3 * bkg_1.map.data[0][0][0], bkg_eval.data[0][0][0])
 
 
 class TestSkyModels:

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -2,10 +2,7 @@
 """Utilities to serialize models."""
 from gammapy.cube.fit import MapDataset, MapEvaluator
 from .models import (
-    SPATIAL_MODELS,
-    SPECTRAL_MODELS,
     BackgroundModel,
-    BackgroundModels,
     SkyDiffuseCube,
     SkyModel,
     SkyModels,
@@ -71,38 +68,22 @@ def dict_to_models(data, link=True):
         check for shared parameters and link them
     """
     models = []
-    for model in data["components"]:
+    for component in data["components"]:
         # background models are created separately
-        if model["type"] == "BackgroundModel":
-            continue
+        if component["type"] == "BackgroundModel":
+            model = BackgroundModel.from_dict(component)
 
-        model = _dict_to_skymodel(model)
+        if component["type"] == "SkyDiffuseCube":
+            model = SkyDiffuseCube.from_dict(component)
+
+        if component["type"] == "SkyModel":
+            model = SkyModel.from_dict(component)
+
         models.append(model)
+
     if link is True:
         _link_shared_parameters(models)
     return models
-
-
-def _dict_to_skymodel(model):
-    if "spatial" in model and model["spatial"]["type"] in SPATIAL_MODELS:
-        model_class = SPATIAL_MODELS[model["spatial"]["type"]]
-        spatial_model = model_class.from_dict(model["spatial"])
-    else:
-        spatial_model = None
-    if "spectral" in model and model["spectral"]["type"] in SPECTRAL_MODELS:
-        model_class = SPECTRAL_MODELS[(model["spectral"]["type"])]
-        spectral_model = model_class.from_dict(model["spectral"])
-    else:
-        spectral_model = None
-    #    TODO add temporal model to SkyModel once applicable
-    #    if "temporal" in model and model["temporal"]["type"] in temporal_models:
-    #        model_class= tenporal_models[(model["tenporal"]["type"])]
-    #        temporal_model = model_class.from_dict( model["temporal"])
-    #    else:
-    #        temporal_model = None
-    return SkyModel(
-        name=model["name"], spatial_model=spatial_model, spectral_model=spectral_model
-    )
 
 
 def _link_shared_parameters(models):
@@ -130,8 +111,6 @@ def _link_shared_parameters(models):
 
 
 def datasets_to_dict(datasets, path, selection, overwrite):
-    from .models import BackgroundModels
-
     unique_models = []
     unique_backgrounds = []
     datasets_dictlist = []
@@ -145,14 +124,8 @@ def datasets_to_dict(datasets, path, selection, overwrite):
             if model not in unique_models:
                 unique_models.append(model)
 
-        if isinstance(dataset.background_model, BackgroundModels):
-            backgrounds = dataset.background_model.models
-        else:
-            backgrounds = [dataset.background_model]
-
-        for background in backgrounds:
-            if background not in unique_backgrounds:
-                unique_backgrounds.append(background)
+        if dataset.background_model not in unique_backgrounds:
+            unique_backgrounds.append(dataset.background_model)
 
     datasets_dict = {"datasets": datasets_dictlist}
     components_dict = models_to_dict(unique_models + unique_backgrounds, selection)
@@ -168,9 +141,6 @@ class dict_to_datasets:
         Datasets
     components : dict
         dict describing model components
-    get_lists : bool
-        get the datasets, models and backgrounds lists separetely (used to initialize FitManager)
-
     """
 
     def __init__(self, data_list, components):
@@ -180,25 +150,20 @@ class dict_to_datasets:
         self.models = dict_to_models(components, link=False)
         self.backgrounds = []
         self.datasets = []
+
         for data in data_list["datasets"]:
             dataset = MapDataset.read(data["filename"], name=data["name"])
-            bkg_names = data["backgrounds"]
+            bkg_name = data["background"]
             model_names = data["models"]
-            self.update_dataset(dataset, components, bkg_names, model_names)
+            self.update_dataset(dataset, components, bkg_name, model_names)
             self.datasets.append(dataset)
         _link_shared_parameters(self.models + self.backgrounds)
 
-    def update_dataset(self, dataset, components, bkg_names, model_names):
-        if not isinstance(dataset.background_model, BackgroundModels):
-            dataset.background_model = BackgroundModels([dataset.background_model])
-        # TODO: remove isinstance checks once #2102  is resolved
-        bkg_prev = [model.name for model in dataset.background_model.models]
+    def update_dataset(self, dataset, components, model_names):
+
         backgrounds = []
         for component in components["components"]:
-            if (
-                component["type"] == "BackgroundModel"
-                and component["name"] in bkg_names
-            ):
+            if component["type"] == "BackgroundModel":
                 background_model = self.add_background(dataset, component, bkg_prev)
                 self.link_background_parameters(component, background_model)
                 backgrounds.append(background_model)
@@ -210,28 +175,10 @@ class dict_to_datasets:
         dataset.model = SkyModels(models)
 
     def add_background(self, dataset, component, bkg_prev):
-        if "filename" in component:
-            # check if file is already loaded in memory else read
-            try:
-                cube = self.cube_register[component["name"]]
-            except KeyError:
-                cube = SkyDiffuseCube.read(component["filename"])
-                self.cube_register[component["name"]] = cube
-
-            evaluator = MapEvaluator(
-                model=cube,
-                exposure=dataset.exposure,
-                psf=dataset.psf,
-                edisp=dataset.edisp,
-            )
-            background_model = BackgroundModel(
-                evaluator.compute_npred(), name=cube.name
-            )
-        else:
-            if component["name"].strip().upper() in bkg_prev:
-                BGind = bkg_prev.index(component["name"].strip().upper())
-            elif component["name"] in bkg_prev:
-                BGind = bkg_prev.index(component["name"])
+        if component["name"].strip().upper() in bkg_prev:
+            BGind = bkg_prev.index(component["name"].strip().upper())
+        elif component["name"] in bkg_prev:
+            BGind = bkg_prev.index(component["name"])
             background_model = dataset.background_model.models[BGind]
         background_model.name = component["name"]
         return background_model

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -122,6 +122,8 @@ def test_datasets_to_io(tmpdir):
     dataset1 = datasets.datasets[1]
     assert dataset1.background_model.name == "background_irf_g09"
 
+    assert dataset0.model["gll_iem_v06_cutout"] == dataset1.model["gll_iem_v06_cutout"]
+
     assert isinstance(dataset0.model, SkyModels)
     assert len(dataset0.model.skymodels) == 2
     assert dataset0.model.skymodels[0].name == "gc"

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -113,44 +113,27 @@ def test_datasets_to_io(tmpdir):
     assert dataset0.psf is not None
     assert dataset0.edisp is not None
 
-    assert isinstance(dataset0.background_model, BackgroundModels)
-    assert len(dataset0.background_model.models) == 2
     assert_allclose(
-        dataset0.background_model.models[0].evaluate().data.sum(), 4094.2, atol=0.1
+        dataset0.background_model.evaluate().data.sum(), 4094.2, atol=0.1
     )
-    assert_allclose(
-        dataset0.background_model.models[1].evaluate().data.sum(), 928.8, atol=0.1
-    )
-    assert dataset0.background_model.models[0].name in [
-        "background_irf_gc",
-        "gll_iem_v06_cutout",
-    ]
-    assert dataset0.background_model.models[1].name in [
-        "background_irf_gc",
-        "gll_iem_v06_cutout",
-    ]
+
+    assert dataset0.background_model.name == "background_irf_gc"
 
     dataset1 = datasets.datasets[1]
-    assert len(dataset1.background_model.models) == 2
-    assert dataset1.background_model.models[0].name in [
-        "background_irf_g09",
-        "gll_iem_v06_cutout",
-    ]
-    assert dataset1.background_model.models[1].name in [
-        "background_irf_g09",
-        "gll_iem_v06_cutout",
-    ]
+    assert dataset1.background_model.name == "background_irf_g09"
 
     assert isinstance(dataset0.model, SkyModels)
-    assert len(dataset0.model.skymodels) == 1
+    assert len(dataset0.model.skymodels) == 2
     assert dataset0.model.skymodels[0].name == "gc"
+    assert dataset0.model.skymodels[1].name == "gll_iem_v06_cutout"
+
     assert (
         dataset0.model.skymodels[0].parameters["reference"]
-        is dataset1.model.skymodels[0].parameters["reference"]
+        is dataset1.model.skymodels[1].parameters["reference"]
     )
 
     assert_allclose(
-        dataset1.model.skymodels[0].parameters["lon_0"].value, 0.9, atol=0.1
+        dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
     path = str(tmpdir / "/written_")
@@ -162,11 +145,6 @@ def test_datasets_to_io(tmpdir):
     assert_allclose(dataset0.exposure.data.sum(), 2072125400000.0, atol=0.1)
     assert dataset0.psf is not None
     assert dataset0.edisp is not None
-    assert isinstance(dataset0.background_model, BackgroundModels)
-    assert len(dataset0.background_model.models) == 2
     assert_allclose(
-        dataset0.background_model.models[0].evaluate().data.sum(), 4094.2, atol=0.1
-    )
-    assert_allclose(
-        dataset0.background_model.models[1].evaluate().data.sum(), 928.8, atol=0.1
+        dataset0.background_model.evaluate().data.sum(), 4094.2, atol=0.1
     )

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.utils.data import get_pkg_data_filename
 from gammapy.modeling import Datasets
-from gammapy.modeling.models import BackgroundModels, SkyModels, spatial, spectral
+from gammapy.modeling.models import SkyModels, spatial, spectral
 from gammapy.modeling.serialize import dict_to_models
 from gammapy.utils.scripts import read_yaml
 from gammapy.utils.testing import requires_data

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -65,7 +65,7 @@ def read_yaml(filename, logger=None):
     return yaml.safe_load(text)
 
 
-def write_yaml(dictionary, filename, logger=None):
+def write_yaml(dictionary, filename, logger=None, sort_keys=True):
     """Write YAML file.
 
     Parameters
@@ -76,8 +76,10 @@ def write_yaml(dictionary, filename, logger=None):
         Filename
     logger : `~logging.Logger`
         Logger
+    sort_keys : bool
+        Whether to sort keys.
     """
-    text = yaml.safe_dump(dictionary, default_flow_style=False)
+    text = yaml.safe_dump(dictionary, default_flow_style=False, sort_keys=sort_keys)
 
     path = make_path(filename)
     path.parent.mkdir(exist_ok=True)


### PR DESCRIPTION
This PR includes the following changes:
- Remove `BackgroundModels` class
- Introduce `sort_keys` option to `write_yaml`
- Move `_dict_to_skymodel` to `SkyModel.from_dict()`

I adapted the tests, so that the `SkyDiffuseCube` is now part of the sky model and not a `BackgroundModel` anymore.

I'd like to apologize @QRemy for removing so much of the code, that you have written to handle those multiple background models. Introducing the `BackgroundModels` some time ago, was a mistake that I did and I think it's better if I correct for it now, then to stick with it, because it would create a lot of extra code we had to write in future.  