### PR TITLE
Add `SpectrumDatasetOnOff.stack()`

### DIFF
--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -417,6 +417,33 @@ class SpectrumDataset(Dataset):
 
         Stacking is performed in-place.
 
+        The stacking of 2 datasets is implemented as follows.
+        Here, :math:`k`  denotes a bin in reconstructed energy and :math: `j = {1,2}` is the dataset number
+
+        The `mask_safe` of each dataset is defined as:
+
+        .. math::
+            \epsilon_{jk} =\left\{\begin{array}{cl} 1, & \mbox{if
+                bin k is inside the energy thresholds}\\ 0, & \mbox{otherwise} \end{array}\right.
+
+        Then the total `counts` and model background `bkg` are computed according to:
+
+        .. math::
+            \overline{\mathrm{n_{on}}}_k =  \mathrm{n_{on}}_{1k} \cdot \epsilon_{1k} +
+             \mathrm{n_{on}}_{2k} \cdot \epsilon_{2k}
+
+            \overline{bkg}_k = bkg_{1k} \cdot \epsilon_{1k} +
+             bkg_{2k} \cdot \epsilon_{2k}
+
+        The stacked `safe_mask` is then:
+
+        .. math::
+            \overline{\epsilon_k} = \epsilon_{1k} OR \epsilon_{2k}
+
+        Please refer to the `~gammapy.irf.IRFStacker` for the description
+        of how the IRFs are stacked.
+
+
         Parameters
         ----------
         other : `~gammapy.spectrum.SpectrumDataset`

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -452,8 +452,7 @@ class SpectrumDataset(Dataset):
                 self.edisp = irf_stacker.stacked_edisp
 
         if self.gti is not None:
-            self.gti.stack(other.gti)
-            self.gti.union()
+            self.gti = self.gti.stack(other.gti).union()
 
         #TODO: for the moment, since dead time is not accounted for, livetime cannot be the sum
         # of GTIs
@@ -712,14 +711,14 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         total_alpha[other.mask_safe] += (other.alpha*other.counts_off)[other.mask_safe]
 
         with np.errstate(divide="ignore", invalid="ignore"):
-            acceptance_off = total_alpha / total_off
+            acceptance_off = total_off / total_alpha
             average_alpha = total_alpha.sum()/total_off.sum()
 
         acceptance = np.ones_like(self.counts_off.data, dtype=float)
         idx = np.where(total_off == 0)[0]
         # For the bins where the stacked OFF counts equal 0, the alpha value is performed by weighting on the total
         # OFF counts of each run
-        total_alpha[idx] = 1 / average_alpha
+        acceptance_off[idx] = 1 / average_alpha
 
         self.acceptance = acceptance
         self.acceptance_off = acceptance_off
@@ -749,8 +748,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
                 self.edisp = irf_stacker.stacked_edisp
 
         if self.gti is not None:
-            self.gti.stack(other.gti)
-            self.gti.union()
+            self.gti = self.gti.stack(other.gti).union()
 
         # TODO: for the moment, since dead time is not accounted for, livetime cannot be the sum
         # of GTIs

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -736,6 +736,22 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         ----------
         other : `~gammapy.spectrum.SpectrumDatasetOnOff`
             the dataset to stack to the current one
+
+         Examples
+        --------
+        >>> from gammapy.spectrum import SpectrumDatasetOnOff
+        >>> obs_ids = [23523, 23526, 23559, 23592]
+        >>> datasets = []
+        >>> for obs in obs_ids:
+        >>>     filename = "$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs{}.fits"
+        >>>     ds = SpectrumDatasetOnOff.from_ogip_files(filename.format(obs))
+        >>>     datasets.append(ds)
+        >>> stacked = datasets[0]
+        >>> for ds in datasets[1:]:
+        >>>     stacked.stack(ds)
+        >>> print(stacked.livetime)
+        6313.8116406202325 s
+
         """
         if not isinstance(other, SpectrumDatasetOnOff):
             raise TypeError("Incompatible types for SpectrumDatasetOnOff stacking")

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -427,7 +427,7 @@ class SpectrumDataset(Dataset):
             raise TypeError("Incompatible types for SpectrumDataset stacking")
 
         if self.counts is not None:
-            self.counts.data[~self.ask_safe] = 0
+            self.counts.data[~self.mask_safe] = 0
             self.counts.data[other.mask_safe] += other.counts.data[other.mask_safe]
 
         if self.background is not None:

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -703,19 +703,19 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         if not is_valid(self) or not is_valid(other):
             raise ValueError("Cannot stack incomplete SpectrumDatsetOnOff.")
 
-        total_off = np.zeros_like(self.counts_off.data)
-        total_alpha = np.zeros_like(self.counts_off.data)
+        total_off = np.zeros_like(self.counts_off.data, dtype=float)
+        total_alpha = np.zeros_like(self.counts_off.data, dtype=float)
 
-        total_off[self.mask_safe] = self.counts_off.data[self.mask_safe]
+        total_off[self.mask_safe] += self.counts_off.data[self.mask_safe]
         total_off[other.mask_safe] += other.counts_off.data[other.mask_safe]
-        total_alpha[self.mask_safe] = (self.alpha*self.counts_off)[self.mask_safe]
-        total_alpha[self.mask_safe] += (other.alpha*other.counts_off)[other.mask_safe]
+        total_alpha[self.mask_safe] += (self.alpha*self.counts_off)[self.mask_safe]
+        total_alpha[other.mask_safe] += (other.alpha*other.counts_off)[other.mask_safe]
 
         with np.errstate(divide="ignore", invalid="ignore"):
             acceptance_off = total_alpha / total_off
             average_alpha = total_alpha.sum()/total_off.sum()
 
-        acceptance = self.ones_like(self.counts_off.data)
+        acceptance = np.ones_like(self.counts_off.data, dtype=float)
         idx = np.where(total_off == 0)[0]
         # For the bins where the stacked OFF counts equal 0, the alpha value is performed by weighting on the total
         # OFF counts of each run

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -628,19 +628,20 @@ class TestSpectrumDatasetOnOffStacker:
             emax=20 * u.TeV
         )
 
-        self.obs_stacker = SpectrumDatasetOnOffStacker(self.obs_list)
-        self.obs_stacker.run()
+        self.stacked_dataset = self.obs_list[0].copy()
+        self.stacked_dataset.stack(self.obs_list[1])
+#        self.obs_stacker = SpectrumDatasetOnOffStacker(self.obs_list)
+#        self.obs_stacker.run()
 
     def test_basic(self):
-        assert "Stacker" in str(self.obs_stacker)
         obs_1, obs_2 = self.obs_list
 
         counts1 = obs_1.counts.data[obs_1.mask_safe].sum()
         counts2 = obs_2.counts.data[obs_2.mask_safe].sum()
         summed_counts = counts1 + counts2
 
-        obs_stacked = self.obs_stacker.stacked_obs
-        stacked_counts = obs_stacked.counts.data.sum()
+#        obs_stacked = self.obs_stacker.stacked_obs
+        stacked_counts = self.stacked_dataset.counts.data.sum()
 
         assert summed_counts == stacked_counts
 


### PR DESCRIPTION
This PR adds a the `stack()` method on the `SpectrumDatasetOnOff`. The tests from the `SpectrumDatasetOnOffStacker` are reused to test the new method.

Once this PR is merged. The `SpectrumDatasetOnOffStacker` will be removed and replaced by a `classmethod` on `SpectrumDatasetOnOff`: `SpectrumDatasetOnOff.stack_from_list(dataset_list)` that will create a a stacked dataset from a list.
