### PR TITLE
Remove lon wrapping in spatial models

### DIFF
--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -759,7 +759,7 @@ class SourceCatalogLargeScaleHGPS:
 
         Parameters
         ----------
-        glon : `~astropy.coordinates.Longitude`
+        glon : `~astropy.coordinates.Angle`
             Galactic Longitude.
         """
         return self._interpolate_parameter("Surface_Brightness", glon)
@@ -769,7 +769,7 @@ class SourceCatalogLargeScaleHGPS:
 
         Parameters
         ----------
-        glon : `~astropy.coordinates.Longitude` or `~astropy.coordinates.Angle`
+        glon : `~astropy.coordinates.Angle`
             Galactic Longitude.
         """
         return self._interpolate_parameter("Surface_Brightness_Err", glon)
@@ -779,7 +779,7 @@ class SourceCatalogLargeScaleHGPS:
 
         Parameters
         ----------
-        glon : `~astropy.coordinates.Longitude` or `~astropy.coordinates.Angle`
+        glon : `~astropy.coordinates.Angle`
             Galactic Longitude.
         """
         return self._interpolate_parameter("Width", glon)
@@ -789,7 +789,7 @@ class SourceCatalogLargeScaleHGPS:
 
         Parameters
         ----------
-        glon : `~astropy.coordinates.Longitude` or `~astropy.coordinates.Angle`
+        glon : `~astropy.coordinates.Angle`
             Galactic Longitude.
         """
         return self._interpolate_parameter("Width_Err", glon)
@@ -799,7 +799,7 @@ class SourceCatalogLargeScaleHGPS:
 
         Parameters
         ----------
-        glon : `~astropy.coordinates.Longitude` or `~astropy.coordinates.Angle`
+        glon : `~astropy.coordinates.Angle`
             Galactic Longitude.
         """
         return self._interpolate_parameter("GLAT", glon)
@@ -809,7 +809,7 @@ class SourceCatalogLargeScaleHGPS:
 
         Parameters
         ----------
-        glon : `~astropy.coordinates.Longitude` or `~astropy.coordinates.Angle`
+        glon : `~astropy.coordinates.Angle`
             Galactic Longitude.
         """
         return self._interpolate_parameter("GLAT_Err", glon)

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -201,7 +201,7 @@ class TestSourceCatalogObjectHGPS:
         model = cat["HESS J1119-614"].sky_model()
         p = model.parameters
         assert_allclose(p["amplitude"].value, 7.959899015960725e-13)
-        assert_allclose(p["lon_0"].value, -67.871918)
+        assert_allclose(p["lon_0"].value, 292.128082)
         assert_allclose(p["lat_0"].value, -0.5332353711128235)
         assert_allclose(p["sigma"].value, 0.09785966575145721)
 
@@ -258,7 +258,7 @@ class TestSourceCatalogObjectHGPS:
         model = cat["Vela Junior"].sky_model()
         p = model.parameters
         assert_allclose(p["amplitude"].value, 3.2163001428830995e-11)
-        assert_allclose(p["lon_0"].value, -93.712616)
+        assert_allclose(p["lon_0"].value, 266.287384)
         assert_allclose(p["lat_0"].value, -1.243260383605957)
         assert_allclose(p["radius"].value, 0.95)
         assert_allclose(p["width"].value, 0.05)

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.integrate
 import scipy.special
 import astropy.units as u
-from astropy.coordinates import Angle, Latitude, Longitude, SkyCoord
+from astropy.coordinates import Angle, SkyCoord
 from astropy.coordinates.angle_utilities import angular_separation, position_angle
 from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
@@ -72,7 +72,7 @@ class SkyPointSource(SkySpatialModel):
 
     Parameters
     ----------
-    lon_0 : `~astropy.coordinates.Longitude`
+    lon_0 : `~astropy.coordinates.Angle`
         :math:`lon_0`
     lat_0 : `~astropy.coordinates.Latitude`
         :math:`lat_0`
@@ -84,10 +84,8 @@ class SkyPointSource(SkySpatialModel):
 
     def __init__(self, lon_0, lat_0, frame="galactic"):
         self.frame = frame
-        self.lon_0 = Parameter(
-            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
-        )
-        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.lon_0 = Parameter("lon_0", Angle(lon_0))
+        self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)
 
         super().__init__([self.lon_0, self.lat_0])
 
@@ -163,9 +161,9 @@ class SkyGaussian(SkySpatialModel):
 
     Parameters
     ----------
-    lon_0 : `~astropy.coordinates.Longitude`
+    lon_0 : `~astropy.coordinates.Angle`
         :math:`\text{lon}_0`: `lon` coordinate for the center of the Gaussian.
-    lat_0 : `~astropy.coordinates.Latitude`
+    lat_0 : `~astropy.coordinates.Angle`
         :math:`\text{lat}_0`: `lat` coordinate for the center of the Gaussian.
     sigma : `~astropy.coordinates.Angle`
         Length of the major semiaxis of the Gaussian, in angular units.
@@ -216,10 +214,8 @@ class SkyGaussian(SkySpatialModel):
 
     def __init__(self, lon_0, lat_0, sigma, e=0, phi="0 deg", frame="galactic"):
         self.frame = frame
-        self.lon_0 = Parameter(
-            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
-        )
-        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.lon_0 = Parameter("lon_0", Angle(lon_0))
+        self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)
         self.sigma = Parameter("sigma", Angle(sigma), min=0)
         self.e = Parameter("e", e, min=0, max=1, frozen=True)
         self.phi = Parameter("phi", Angle(phi), frozen=True)
@@ -279,9 +275,9 @@ class SkyDisk(SkySpatialModel):
 
     Parameters
     ----------
-    lon_0 : `~astropy.coordinates.Longitude`
+    lon_0 : `~astropy.coordinates.Angle`
         :math:`\text{lon}_0`: `lon` coordinate for the center of the ellipse.
-    lat_0 : `~astropy.coordinates.Latitude`
+    lat_0 : `~astropy.coordinates.Angle`
         :math:`\text{lat}_0`: `lat` coordinate for the center of the ellipse.
     r_0 : `~astropy.coordinates.Angle`
         :math:`a`: length of the major semiaxis, in angular units.
@@ -339,10 +335,8 @@ class SkyDisk(SkySpatialModel):
         self, lon_0, lat_0, r_0, e=0, phi="0 deg", edge="0.01 deg", frame="galactic"
     ):
         self.frame = frame
-        self.lon_0 = Parameter(
-            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
-        )
-        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.lon_0 = Parameter("lon_0", Angle(lon_0))
+        self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)
         self.r_0 = Parameter("r_0", Angle(r_0), min=0)
         self.e = Parameter("e", e, min=0, max=1, frozen=True)
         self.phi = Parameter("phi", Angle(phi), frozen=True)
@@ -419,9 +413,9 @@ class SkyShell(SkySpatialModel):
 
     Parameters
     ----------
-    lon_0 : `~astropy.coordinates.Longitude`
+    lon_0 : `~astropy.coordinates.Angle`
         :math:`lon_0`
-    lat_0 : `~astropy.coordinates.Latitude`
+    lat_0 : `~astropy.coordinates.Angle`
         :math:`lat_0`
     radius : `~astropy.coordinates.Angle`
         Inner radius, :math:`r_{in}`
@@ -436,10 +430,8 @@ class SkyShell(SkySpatialModel):
 
     def __init__(self, lon_0, lat_0, radius, width, frame="galactic"):
         self.frame = frame
-        self.lon_0 = Parameter(
-            "lon_0", Longitude(lon_0).wrap_at("180d"), min=-180, max=180
-        )
-        self.lat_0 = Parameter("lat_0", Latitude(lat_0), min=-90, max=90)
+        self.lon_0 = Parameter("lon_0", Angle(lon_0))
+        self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)
         self.radius = Parameter("radius", Angle(radius))
         self.width = Parameter("width", Angle(width))
 


### PR DESCRIPTION
This PR removes long wrapping in the `__init__` of spatial models.

Currently the code wraps to lon = -180 to +180, with the intent to get correct results at lon = 0 and to avoid wrapping issues with 0 = 360, and I think because it's considered user friendly to have a "standard range" for lon and to never get e.g. lon = 181 deg or lon = 361 deg or lon = -185 deg.

I think it would be better to not wrap at all: if a user puts a starting value of lon = 200 deg, fine, it's their choice. Changing this to -160 deg in model init will be confusing for them. Also wrapping to any fixed range means fitting a source at the edge of that range will be problematic, because the lon value is jumping by 360 deg. So with the current implementation one cannot fit a source at or near 180 deg. Not wrapping avoids this issue.

As discussed offline with @adonath and @QRemy a week or two ago, in the future we might want to add logic to the source fitting to avoid sources leaving the sky map to get more user-friendly behaviour, i.e. the optimiser finding a source position more often. But "inside a sky map" does not correspond to a simple min/max limit on lon, we'll have to implement this in a different way (and that can be Gammapy v2.0, not urgent at all, Fermi ST or other codes don't have that).

@adonath - While working on this I noticed one possible issue with `SkyPointSource` evaluation, I'll open a separate issue for that.