### PR TITLE
Add MapDataset.create method 

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -31,6 +31,7 @@ MIGRA_AXIS_DEFAULT = MapAxis.from_bounds(
 )
 #TODO: Choose optimal binnings depending on IRFs
 
+
 class MapDataset(Dataset):
     """Perform sky model likelihood fit on maps.
 
@@ -278,7 +279,17 @@ class MapDataset(Dataset):
         return npred_total
 
     @classmethod
-    def create(cls, geom, geom_irf=None, migra_axis=None, rad_axis=None, reference_time="2000-01-01",):
+
+
+    def create(
+        cls,
+        geom,
+        geom_irf=None,
+        migra_axis=None,
+        rad_axis=None,
+        reference_time="2000-01-01",
+    ):
+
         """Creates a MapDataset object with zero filled maps
 
         Parameters
@@ -309,7 +320,6 @@ class MapDataset(Dataset):
         mask = np.ones(geom.data_shape, dtype=bool)
 
         gti = GTI.create([] * u.s, [] * u.s, reference_time=reference_time)
-
 
         geom_migra = geom_irf.to_image().to_cube([migra_axis, energy_axis])
         edisp_map = Map.from_geom(geom_migra, unit="")

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -29,7 +29,7 @@ RAD_AXIS_DEFAULT = MapAxis.from_bounds(
 MIGRA_AXIS_DEFAULT = MapAxis.from_bounds(
     0.2, 5, nbin=48, node_type="edges", name="migra"
 )
-#TODO: Choose optimal binnings depending on IRFs
+# TODO: Choose optimal binnings depending on IRFs
 
 
 class MapDataset(Dataset):
@@ -279,8 +279,6 @@ class MapDataset(Dataset):
         return npred_total
 
     @classmethod
-
-
     def create(
         cls,
         geom,
@@ -326,7 +324,6 @@ class MapDataset(Dataset):
         loc = migra_axis.edges.searchsorted(1.0)
         edisp_map.data[:, loc, :, :] = 1.0
         edisp = EDispMap(edisp_map, exposure_irf)
-
 
         geom_rad = geom_irf.to_image().to_cube([rad_axis, energy_axis])
         psf_map = Map.from_geom(geom_rad, unit="sr-1")

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -8,6 +8,7 @@ from astropy.utils import lazyproperty
 from gammapy.cube.psf_kernel import PSFKernel
 from gammapy.irf import EnergyDispersion
 from gammapy.maps import Map
+from gammapy.data import GTI
 from gammapy.modeling import Dataset, Parameters
 from gammapy.modeling.models import BackgroundModel, SkyModel, SkyModels
 from gammapy.stats import cash, cash_sum_cython, cstat, cstat_sum_cython
@@ -266,6 +267,63 @@ class MapDataset(Dataset):
                     npred_total.data[evaluator.coords_idx] += npred.data
 
         return npred_total
+
+    @classmethod
+    def create(cls, geom, geom_irf=None, migra_axis=None, rad_axis=None):
+        """Creates a MapDataset object with zero filled maps
+
+        Parameters
+        ----------
+        geom: `~gammapy.maps.WcsGeom`
+            Reference target geometry in reco energy, used for counts and background maps
+        geom_irf: `~gammapy.maps.WcsGeom`
+            Reference image geometry in true energy, used for IRF maps.
+        migra_axis: `~gammapy.maps.MapAxis`
+            Migration axis for the energy dispersion map
+        rad_axis: `~gammapy.maps.MapAxis`
+            Rad axis for the psf map
+        """
+
+        geom_irf = geom_irf or geom
+
+        counts = Map.from_geom(geom, unit="")
+
+        background = Map.from_geom(geom, unit="")
+        background_model = BackgroundModel(background)
+
+        energy_axis = geom_irf.get_axis_by_name("ENERGY")
+
+        exposure_geom = geom.to_image().to_cube([energy_axis])
+        exposure = Map.from_geom(exposure_geom, unit="m2 s")
+
+        mask = np.ones(geom.data_shape, dtype=bool)
+
+        gti = GTI.create([0 * u.s], [0 * u.s])
+
+        edisp, psf = None, None
+        if migra_axis:
+            geom_migra = geom_irf.to_image().to_cube([migra_axis, energy_axis])
+            edisp = Map.from_geom(geom_migra, unit="")
+            loc = migra_axis.edges.searchsorted(1.0)
+            edisp.data[:, loc, :, :] = 1.0
+        if rad_axis:
+            geom_rad = geom_irf.to_image().to_cube([rad_axis, energy_axis])
+            psf = Map.from_geom(geom_rad, unit="sr-1")
+
+        return cls(
+            model=None,
+            counts=counts,
+            exposure=exposure,
+            mask_fit=None,
+            psf=psf,
+            edisp=edisp,
+            background_model=background_model,
+            name="empty_",
+            likelihood="cash",
+            evaluation_mode="local",
+            mask_safe=mask,
+            gti=gti,
+        )
 
     def likelihood_per_bin(self):
         """Likelihood per bin given the current model parameters"""

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -339,7 +339,7 @@ class MapDataset(Dataset):
             psf=psf,
             edisp=edisp,
             background_model=background_model,
-            name="empty_",
+            name="",
             likelihood="cash",
             evaluation_mode="local",
             mask_safe=mask,

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -303,6 +303,8 @@ class MapDataset(Dataset):
         """
 
         geom_irf = geom_irf or geom
+        migra_axis = migra_axis or MIGRA_AXIS_DEFAULT
+        rad_axis = rad_axis or RAD_AXIS_DEFAULT
 
         counts = Map.from_geom(geom, unit="")
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -4,6 +4,7 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from astropy.coordinates import Angle
+from gammapy.cube.psf_kernel import PSFKernel
 from gammapy.irf import EnergyDependentTablePSF
 from gammapy.maps import Map
 from .psf_kernel import PSFKernel

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -309,3 +309,22 @@ def test_map_fit_one_energy_bin(sky_model, geom_image):
 
     assert_allclose(pars["amplitude"].value, 1e-11, rtol=1e-2)
     assert_allclose(pars.error("amplitude"), 2.163318e-12, rtol=1e-2)
+
+
+def test_create(geom, geom_etrue):
+    # tests empty datasets created
+
+    migra_axis = MapAxis(nodes=np.linspace(0.0, 3.0, 51), unit="", name="migra")
+    rad_axis = MapAxis(nodes=np.linspace(0.0, 1.0, 51), unit="deg", name="theta")
+
+    empty_dataset = MapDataset.create(geom, geom_etrue, migra_axis, rad_axis)
+
+    assert_allclose(empty_dataset.counts.data.sum(), 0.0)
+    assert_allclose(empty_dataset.background_model.map.data.sum(), 0.0)
+
+    assert empty_dataset.psf.data.shape == (3, 50, 100, 100)
+
+    assert empty_dataset.edisp.data.shape == (3, 50, 100, 100)
+    assert_allclose(empty_dataset.edisp.data.sum(), 30000)
+
+    assert_allclose(empty_dataset.gti.time_delta, 0.0 * u.s)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -322,9 +322,10 @@ def test_create(geom, geom_etrue):
     assert_allclose(empty_dataset.counts.data.sum(), 0.0)
     assert_allclose(empty_dataset.background_model.map.data.sum(), 0.0)
 
-    assert empty_dataset.psf.data.shape == (3, 50, 100, 100)
+    assert empty_dataset.psf.psf_map.data.shape == (3, 50, 100, 100)
+    assert empty_dataset.psf.exposure_map.data.shape == (3, 100, 100)
 
-    assert empty_dataset.edisp.data.shape == (3, 50, 100, 100)
-    assert_allclose(empty_dataset.edisp.data.sum(), 30000)
+    assert empty_dataset.edisp.edisp_map.data.shape == (3, 50, 100, 100)
+    assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 30000)
 
     assert_allclose(empty_dataset.gti.time_delta, 0.0 * u.s)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -151,7 +151,7 @@ def test_map_maker_obs(observations):
     assert map_obs["counts"].geom == geom_reco
     assert map_obs["background"].geom == geom_reco
     assert map_obs["exposure"].geom == geom_exp
-    assert map_obs["edisp"].edisp_map.data.shape == (3, 300, 5, 10)
+    assert map_obs["edisp"].edisp_map.data.shape == (3, 48, 5, 10)
     assert map_obs["edisp"].exposure_map.data.shape == (3, 1, 5, 10)
     assert map_obs["psf"].psf_map.data.shape == (3, 66, 5, 10)
     assert map_obs["psf"].exposure_map.data.shape == (3, 1, 5, 10)


### PR DESCRIPTION
This PR adds a `MapDataset.create()` which will be useful for stacking datasets.
We need to agree on the parameters. Instead of the ones I have now, we can have (as per @adonath original suggestion) 
`MapDataset.create(geom, energy_true_axis=None, migra_axis=None, rad_axis=None, binsz_irf=”0.2 deg”)`.
My issue with this is that we might want to compute the IRFs on not just a coarser binning but also a larger spatial map (to account for spill overs). In this case, we should specify a `IRF_spatial_geom` instead. This should be only in 2-d. This might be a bit confusing, so I have stuck with `geom` and `geom_irf` are both 3-d.
I suppose the users should not really have to worry about these binnings at all.
Maybe it might be helpful to have a helper function `get_default_binnings(obs, geom)` which returns `rad`, `migra` and `e_true` bins from the IRFs, and a coarse IRF geometry depending upon `geom`? 

@registerrier @adonath @luca-giunti : Please opine!

