### PR TITLE
Add sample method in LightCurveTableModel and PhaseCurveTableModel

### DIFF
--- a/gammapy/modeling/models/time.py
+++ b/gammapy/modeling/models/time.py
@@ -126,7 +126,7 @@ class PhaseCurveTableModel(Model):
         return np.interp(x=phase, xp=xp, fp=fp, period=1)
 
     #    @property
-    def ontime(self, t_min, t_max):
+    def ontimes(self, t_min, t_max):
         """On time (`~astropy.units.Quantity`)"""
 
         t_min = Time(t_min)
@@ -141,7 +141,7 @@ class PhaseCurveTableModel(Model):
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
         meta = OrderedDict()
         meta["ONTIME"] = np.round(
-            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
+            self.ontimes(t_min=t_min, t_max=t_max).to_value("s"), 1
         )
         return meta
 
@@ -161,7 +161,7 @@ class PhaseCurveTableModel(Model):
         random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
             Defines random number generator initialisation.
             Passed to `~gammapy.utils.random.get_random_state`.
-        
+
         Returns
         -------
         time : `~astropy.units.Quantity`
@@ -175,7 +175,7 @@ class PhaseCurveTableModel(Model):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
+        t_stop = self.ontimes(t_min=t_min, t_max=t_max).to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions
@@ -318,7 +318,7 @@ class LightCurveTableModel(Model):
         return integral / dt
 
     #    @property
-    def ontime(self, t_min, t_max):
+    def ontimes(self, t_min, t_max):
         """On time (`~astropy.units.Quantity`)"""
 
         t_min = Time(t_min)
@@ -333,7 +333,7 @@ class LightCurveTableModel(Model):
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
         meta = OrderedDict()
         meta["ONTIME"] = np.round(
-            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
+            self.ontimes(t_min=t_min, t_max=t_max).to_value("s"), 1
         )
         return meta
 
@@ -367,7 +367,7 @@ class LightCurveTableModel(Model):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
+        t_stop = self.ontimes(t_min=t_min, t_max=t_max).to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions

--- a/gammapy/modeling/models/time.py
+++ b/gammapy/modeling/models/time.py
@@ -15,7 +15,7 @@ __all__ = ["PhaseCurveTableModel", "LightCurveTableModel"]
 
 
 class PhaseCurveTableModel(Model):
-    r"""Temporal phase curve model.
+    """Temporal phase curve model.
 
     Phase for a given time is computed as:
 
@@ -124,6 +124,74 @@ class PhaseCurveTableModel(Model):
         xp = self.table["PHASE"]
         fp = self.table["NORM"]
         return np.interp(x=phase, xp=xp, fp=fp, period=1)
+
+    #    @property
+    def ontime(self, t_min, t_max):
+        """On time (`~astropy.units.Quantity`)"""
+
+        t_min = Time(t_min)
+        t_max = Time(t_max)
+
+        ontime = t_max - t_min
+        return u.Quantity(ontime.sec, "s")
+
+    def _get_time_meta(self, t_min, t_max):
+        """Time meta information (`OrderedDict`)"""
+        # TODO: extend the meta information according to
+        #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
+        meta = OrderedDict()
+        meta["ONTIME"] = np.round(
+            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
+        )
+        return meta
+
+    def sample_time(self, n_events, t_min, t_max, t_delta="1 s", random_state=0):
+        """Sample arrival times of events.
+        
+        Parameters
+        ----------
+        n_events : int
+            Number of events to sample.
+        t_min : `~astropy.time.Time`
+            Start time of the sampling.
+        t_max : `~astropy.time.Time`
+            Stop time of the sampling.
+        t_delta : `~astropy.units.Quantity`
+            Time step used for sampling of the temporal model.
+        random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
+            Defines random number generator initialisation.
+            Passed to `~gammapy.utils.random.get_random_state`.
+        
+        Returns
+        -------
+        time : `~astropy.units.Quantity`
+            Array with times of the sampled events.
+        """
+        time_unit = u.second
+
+        t_min = Time(t_min)
+        t_max = Time(t_max)
+        n_events = n_events
+        t_delta = u.Quantity(t_delta)
+        random_state = get_random_state(random_state)
+
+        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
+
+        # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
+        #  is still incomplete, refactor once we change to recent numpy and astropy versions
+        if self.table is not None:
+            t_step = t_delta.to_value(time_unit)
+            t = np.arange(0, t_stop, t_step)
+
+            pdf = self.evaluate_norm_at_time(t)
+
+            sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
+            time_pix = sampler.sample(n_events)[0]
+            time = np.interp(time_pix, np.arange(len(t)), t) * time_unit
+        else:
+            time = random_state.uniform(high=t_stop, size=n_events) * time_unit
+
+        return time
 
 
 class LightCurveTableModel(Model):
@@ -264,7 +332,9 @@ class LightCurveTableModel(Model):
         # TODO: extend the meta information according to
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
         meta = OrderedDict()
-        meta["ONTIME"] = np.round(self.ontime(t_min, t_max).to_value("s"), 1)
+        meta["ONTIME"] = np.round(
+            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
+        )
         return meta
 
     def sample_time(self, n_events, t_min, t_max, t_delta="1 s", random_state=0):
@@ -291,26 +361,26 @@ class LightCurveTableModel(Model):
         """
         time_unit = u.second
 
-        self.t_min = Time(t_min)
-        self.t_max = Time(t_max)
-        self.n_events = n_events
-        self.t_delta = u.Quantity(t_delta)
-        self.random_state = get_random_state(random_state)
+        t_min = Time(t_min)
+        t_max = Time(t_max)
+        n_events = n_events
+        t_delta = u.Quantity(t_delta)
+        random_state = get_random_state(random_state)
 
         t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions
         if self.table is not None:
-            t_step = self.t_delta.to_value(time_unit)
+            t_step = t_delta.to_value(time_unit)
             t = np.arange(0, t_stop, t_step)
 
             pdf = self.evaluate_norm_at_time(t * time_unit)
 
-            sampler = InverseCDFSampler(pdf=pdf, random_state=self.random_state)
+            sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
             time_pix = sampler.sample(n_events)[0]
             time = np.interp(time_pix, np.arange(len(t)), t) * time_unit
         else:
-            time = self.random_state.uniform(high=t_stop, size=n_events) * time_unit
+            time = random_state.uniform(high=t_stop, size=n_events) * time_unit
 
         return time

--- a/gammapy/modeling/models/time.py
+++ b/gammapy/modeling/models/time.py
@@ -126,7 +126,7 @@ class PhaseCurveTableModel(Model):
         return np.interp(x=phase, xp=xp, fp=fp, period=1)
 
     #    @property
-    def ontimes(self, t_min, t_max):
+    def ontime(self, t_min, t_max):
         """On time (`~astropy.units.Quantity`)"""
 
         t_min = Time(t_min)
@@ -141,13 +141,13 @@ class PhaseCurveTableModel(Model):
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
         meta = OrderedDict()
         meta["ONTIME"] = np.round(
-            self.ontimes(t_min=t_min, t_max=t_max).to_value("s"), 1
+            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
         )
         return meta
 
     def sample_time(self, n_events, t_min, t_max, t_delta="1 s", random_state=0):
         """Sample arrival times of events.
-        
+
         Parameters
         ----------
         n_events : int
@@ -175,7 +175,7 @@ class PhaseCurveTableModel(Model):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        t_stop = self.ontimes(t_min=t_min, t_max=t_max).to_value(time_unit)
+        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions
@@ -318,7 +318,7 @@ class LightCurveTableModel(Model):
         return integral / dt
 
     #    @property
-    def ontimes(self, t_min, t_max):
+    def ontime(self, t_min, t_max):
         """On time (`~astropy.units.Quantity`)"""
 
         t_min = Time(t_min)
@@ -333,7 +333,7 @@ class LightCurveTableModel(Model):
         #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
         meta = OrderedDict()
         meta["ONTIME"] = np.round(
-            self.ontimes(t_min=t_min, t_max=t_max).to_value("s"), 1
+            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
         )
         return meta
 
@@ -367,7 +367,7 @@ class LightCurveTableModel(Model):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        t_stop = self.ontimes(t_min=t_min, t_max=t_max).to_value(time_unit)
+        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions

--- a/gammapy/modeling/models/time.py
+++ b/gammapy/modeling/models/time.py
@@ -125,26 +125,6 @@ class PhaseCurveTableModel(Model):
         fp = self.table["NORM"]
         return np.interp(x=phase, xp=xp, fp=fp, period=1)
 
-    #    @property
-    def ontime(self, t_min, t_max):
-        """On time (`~astropy.units.Quantity`)"""
-
-        t_min = Time(t_min)
-        t_max = Time(t_max)
-
-        ontime = t_max - t_min
-        return u.Quantity(ontime.sec, "s")
-
-    def _get_time_meta(self, t_min, t_max):
-        """Time meta information (`OrderedDict`)"""
-        # TODO: extend the meta information according to
-        #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
-        meta = OrderedDict()
-        meta["ONTIME"] = np.round(
-            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
-        )
-        return meta
-
     def sample_time(self, n_events, t_min, t_max, t_delta="1 s", random_state=0):
         """Sample arrival times of events.
 
@@ -175,7 +155,8 @@ class PhaseCurveTableModel(Model):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
+        ontime = u.Quantity((t_max - t_min).sec, "s")
+        t_stop = ontime.to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions
@@ -317,26 +298,6 @@ class LightCurveTableModel(Model):
         integral = self._interpolator.integral(time_min, time_max)
         return integral / dt
 
-    #    @property
-    def ontime(self, t_min, t_max):
-        """On time (`~astropy.units.Quantity`)"""
-
-        t_min = Time(t_min)
-        t_max = Time(t_max)
-
-        ontime = t_max - t_min
-        return u.Quantity(ontime.sec, "s")
-
-    def _get_time_meta(self, t_min, t_max):
-        """Time meta information (`OrderedDict`)"""
-        # TODO: extend the meta information according to
-        #  https://gamma-astro-data-formats.readthedocs.io/en/latest/general/time.html#time-formats
-        meta = OrderedDict()
-        meta["ONTIME"] = np.round(
-            self.ontime(t_min=t_min, t_max=t_max).to_value("s"), 1
-        )
-        return meta
-
     def sample_time(self, n_events, t_min, t_max, t_delta="1 s", random_state=0):
         """Sample arrival times of events.
 
@@ -367,7 +328,8 @@ class LightCurveTableModel(Model):
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
-        t_stop = self.ontime(t_min=t_min, t_max=t_max).to_value(time_unit)
+        ontime = u.Quantity((t_max - t_min).sec, "s")
+        t_stop = ontime.to_value(time_unit)
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions

--- a/gammapy/modeling/models/time.py
+++ b/gammapy/modeling/models/time.py
@@ -151,7 +151,6 @@ class PhaseCurveTableModel(Model):
 
         t_min = Time(t_min)
         t_max = Time(t_max)
-        n_events = n_events
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
@@ -160,19 +159,16 @@ class PhaseCurveTableModel(Model):
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions
-        if self.table is not None:
-            t_step = t_delta.to_value(time_unit)
-            t = np.arange(0, t_stop, t_step)
+        t_step = t_delta.to_value(time_unit)
+        t = np.arange(0, t_stop, t_step)
 
-            pdf = self.evaluate_norm_at_time(t)
+        pdf = self.evaluate_norm_at_time(t)
 
-            sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
-            time_pix = sampler.sample(n_events)[0]
-            time = np.interp(time_pix, np.arange(len(t)), t) * time_unit
-        else:
-            time = random_state.uniform(high=t_stop, size=n_events) * time_unit
+        sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
+        time_pix = sampler.sample(n_events)[0]
+        time = np.interp(time_pix, np.arange(len(t)), t) * time_unit
 
-        return time
+        return t_min + time
 
 
 class LightCurveTableModel(Model):
@@ -324,7 +320,6 @@ class LightCurveTableModel(Model):
 
         t_min = Time(t_min)
         t_max = Time(t_max)
-        n_events = n_events
         t_delta = u.Quantity(t_delta)
         random_state = get_random_state(random_state)
 
@@ -333,16 +328,13 @@ class LightCurveTableModel(Model):
 
         # TODO: the separate time unit handling is unfortunate, but the quantity support for np.arange and np.interp
         #  is still incomplete, refactor once we change to recent numpy and astropy versions
-        if self.table is not None:
-            t_step = t_delta.to_value(time_unit)
-            t = np.arange(0, t_stop, t_step)
+        t_step = t_delta.to_value(time_unit)
+        t = np.arange(0, t_stop, t_step)
 
-            pdf = self.evaluate_norm_at_time(t * time_unit)
+        pdf = self.evaluate_norm_at_time(t * time_unit)
 
-            sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
-            time_pix = sampler.sample(n_events)[0]
-            time = np.interp(time_pix, np.arange(len(t)), t) * time_unit
-        else:
-            time = random_state.uniform(high=t_stop, size=n_events) * time_unit
+        sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
+        time_pix = sampler.sample(n_events)[0]
+        time = np.interp(time_pix, np.arange(len(t)), t) * time_unit
 
-        return time
+        return t_min + time


### PR DESCRIPTION
This is second PR listed in the PIG 9 and aims at implementing a sampling method of the time into `gammapy.time.models.LightCurveTableModel` and `gammapy.time.models.PhaseCurveTableModel`. 
Tests have been added.

