### PR TITLE
Adapt MapMakerObs to return a MapDataset

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -101,15 +101,13 @@ class MapMaker:
 
             for name in selection:
                 if name == "exposure":
-                    data = maps_dataset.exposure.quantity.to_value(maps[name].unit)
+                    data = maps_dataset.exposure.quantity
                     maps[name].fill_by_coord(obs_maker.coords_etrue, data)
                 if name == "counts":
-                    data = maps_dataset.counts.quantity.to_value(maps[name].unit)
+                    data = maps_dataset.counts.quantity
                     maps[name].fill_by_coord(obs_maker.coords, data)
                 if name == "background":
-                    data = maps_dataset.background_model.map.quantity.to_value(
-                        maps[name].unit
-                    )
+                    data = maps_dataset.background_model.map.quantity
                     maps[name].fill_by_coord(obs_maker.coords, data)
         self._maps = maps
         return maps
@@ -277,15 +275,8 @@ class MapMakerObs:
 
         background_model = BackgroundModel(self.maps["background"])
 
-        if "psf" in self.maps:
-            psf = self.maps["psf"]
-        else:
-            psf = None
-
-        if "edisp" in self.maps:
-            edisp = self.maps["edisp"]
-        else:
-            edisp = None
+        psf = self.maps.get("psf")
+        edisp = self.maps.get("edisp")
 
         dataset = MapDataset(
             counts=self.maps["counts"],
@@ -293,6 +284,8 @@ class MapMakerObs:
             background_model=background_model,
             psf=psf,
             edisp=edisp,
+            gti=self.observation.gti,
+            name="obs_{}".format(self.observation.obs_id),
         )
 
         if "exposure_irf" in self.maps:

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -147,11 +147,11 @@ def test_map_maker_obs(observations):
         offset_max=2.0 * u.deg,
     )
 
-    map_obs = maker_obs.run()
-    assert map_obs["counts"].geom == geom_reco
-    assert map_obs["background"].geom == geom_reco
-    assert map_obs["exposure"].geom == geom_exp
-    assert map_obs["edisp"].edisp_map.data.shape == (3, 48, 5, 10)
-    assert map_obs["edisp"].exposure_map.data.shape == (3, 1, 5, 10)
-    assert map_obs["psf"].psf_map.data.shape == (3, 66, 5, 10)
-    assert map_obs["psf"].exposure_map.data.shape == (3, 1, 5, 10)
+    map_dataset = maker_obs.run()
+    assert map_dataset.counts.geom == geom_reco
+    assert map_dataset.background_model.map.geom == geom_reco
+    assert map_dataset.exposure.geom == geom_exp
+    assert map_dataset.edisp.edisp_map.data.shape == (3, 48, 5, 10)
+    assert map_dataset.edisp.exposure_map.data.shape == (3, 1, 5, 10)
+    assert map_dataset.psf.psf_map.data.shape == (3, 66, 5, 10)
+    assert map_dataset.psf.exposure_map.data.shape == (3, 1, 5, 10)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -155,3 +155,5 @@ def test_map_maker_obs(observations):
     assert map_dataset.edisp.exposure_map.data.shape == (3, 1, 5, 10)
     assert map_dataset.psf.psf_map.data.shape == (3, 66, 5, 10)
     assert map_dataset.psf.exposure_map.data.shape == (3, 1, 5, 10)
+    assert_allclose(map_dataset.gti.time_delta, 1800.0 * u.s)
+    assert map_dataset.name == "obs_110380"


### PR DESCRIPTION
This PR adapts `MapMakerObs` to return a `MapDataset` instead of a dictionary.
This needs some adaption in `MapMaker` and `MapMakerRing` as well. Since these classes will move away in near future, I have put in some temporary ugly lines.