### PR TITLE
Cleanup `WcsNDMap` FITS convention handling

### DIFF
--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -72,7 +72,7 @@ class Map(abc.ABC):
     def data(self, val):
         if val.shape != self.geom.data_shape:
             raise ValueError(
-                "Shape {val.shape!r} does not match map data shape {self.geom.data_shape!r}"
+                f"Shape {val.shape!r} does not match map data shape {self.geom.data_shape!r}"
             )
 
         if isinstance(val, u.Quantity):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -151,7 +151,6 @@ def find_and_read_bands(hdu):
         axes = energy_axis_from_fgst_ccube(hdu)
     else:
         axes = axes_from_bands_hdu(hdu)
-        print(axes)
 
     return axes
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -3,15 +3,14 @@ import abc
 import copy
 import inspect
 import logging
-import re
 import numpy as np
 import scipy.interpolate
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.table import Column, QTable
+from astropy.table import Column, QTable, Table
 from gammapy.utils.interpolation import interpolation_scale
-from .utils import INVALID_INDEX, find_bands_hdu, find_hdu
+from .utils import INVALID_INDEX, find_bands_hdu, find_hdu, edges_from_lo_hi
 
 __all__ = ["MapCoord", "MapGeom", "MapAxis"]
 
@@ -77,69 +76,82 @@ def make_axes_cols(axes, axis_names=None):
     return cols
 
 
-def find_and_read_bands(hdu, header=None):
+def energy_axis_from_fgst_ccube(hdu):
+    bands = Table.read(hdu)
+    edges_min = bands["E_MIN"].data
+    edges_max = bands["E_MAX"].data
+    edges = edges_from_lo_hi(edges_min, edges_max)
+    return [MapAxis.from_edges(edges=edges, name="energy", unit="MeV", interp="log")]
+
+
+def energy_axis_from_fgst_template(hdu):
+    bands = Table.read(hdu)
+
+    # TODO: check upper / lowercase handling
+    try:
+        nodes = bands["Energy"].data
+    except KeyError:
+        nodes = bands["ENERGY"].data
+
+    return [MapAxis.from_nodes(nodes=nodes, name="energy", unit="MeV", interp="log")]
+
+
+def axes_from_bands_hdu(hdu):
     """Read and returns the map axes from a BANDS table.
 
     Parameters
     ----------
     hdu : `~astropy.io.fits.BinTableHDU`
         The BANDS table HDU.
-    header : `~astropy.io.fits.Header`
-        Header
 
     Returns
     -------
     axes : list of `~MapAxis`
         List of axis objects.
     """
+    axes = []
+
+    bands = Table.read(hdu)
+
+    for idx in range(5):
+        axcols = bands.meta.get("AXCOLS{}".format(idx + 1))
+
+        if axcols is None:
+            break
+
+        colnames = axcols.split(",")
+        node_type = "edges" if len(colnames) == 2 else "center"
+
+        # TODO: check why this extra case is needed
+        if colnames[0] == "E_MIN":
+            name = "energy"
+        else:
+            name = colnames[0].split("_")[0].lower()
+        interp = bands.meta.get("INTERP{}".format(idx + 1), "lin")
+
+        if node_type == "center":
+            nodes = np.unique(bands[colnames[0]].quantity)
+        else:
+            edges_min = np.unique(bands[colnames[0]].quantity)
+            edges_max = np.unique(bands[colnames[1]].quantity)
+            nodes = edges_from_lo_hi(edges_min, edges_max)
+
+        axis = MapAxis(nodes=nodes, node_type=node_type, interp=interp, name=name)
+        axes.append(axis)
+
+    return axes
+
+def find_and_read_bands(hdu):
     if hdu is None:
         return []
 
-    axes = []
-    axis_cols = []
     if hdu.name == "ENERGIES":
-        axis_cols = [["ENERGY"]]
+        axes = energy_axis_from_fgst_template(hdu)
     elif hdu.name == "EBOUNDS":
-        axis_cols = [["E_MIN", "E_MAX"]]
+        axes = energy_axis_from_fgst_ccube(hdu)
     else:
-        for i in range(5):
-            if "AXCOLS%i" % i in hdu.header:
-                axis_cols += [hdu.header["AXCOLS%i" % i].split(",")]
-
-    interp = "lin"
-    for i, cols in enumerate(axis_cols):
-
-        if "ENERGY" in cols or "E_MIN" in cols:
-            name = "energy"
-            interp = "log"
-        elif re.search("(.+)_MIN", cols[0]):
-            name = re.search("(.+)_MIN", cols[0]).group(1)
-        else:
-            name = cols[0]
-
-        interp_header_key = "INTERP%i" % (i + 1)
-        if header is not None and interp_header_key in header:
-            interp_header_val = header[interp_header_key]
-            if interp_header_val in ["sqrt", "log", "lin"]:
-                interp = interp_header_val
-            else:
-                log.warning(
-                    f"Invalid map axis interp: {interp_header_val!r}. Using default: {interp!r}"
-                )
-
-        unit = hdu.data.columns[cols[0]].unit
-        if unit is None and header is not None:
-            unit = header.get("CUNIT%i" % (3 + i), "")
-        if unit is None:
-            unit = ""
-        if len(cols) == 2:
-            xmin = np.unique(hdu.data.field(cols[0]))
-            xmax = np.unique(hdu.data.field(cols[1]))
-            nodes = np.append(xmin, xmax[-1])
-            axes.append(MapAxis(nodes, name=name, unit=unit, interp=interp))
-        else:
-            nodes = np.unique(hdu.data.field(cols[0]))
-            axes.append(MapAxis.from_nodes(nodes, name=name, unit=unit, interp=interp))
+        axes = axes_from_bands_hdu(hdu)
+        print(axes)
 
     return axes
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -18,20 +18,18 @@ __all__ = ["MapCoord", "MapGeom", "MapAxis"]
 log = logging.getLogger(__name__)
 
 
-def make_axes(axes_in, conv):
+def make_axes(axes_in):
     """Make a sequence of `~MapAxis` objects."""
     if axes_in is None:
         return []
 
     axes_out = []
-    for i, ax in enumerate(axes_in):
+    for idx, ax in enumerate(axes_in):
         if isinstance(ax, np.ndarray):
             ax = MapAxis(ax)
 
-        if conv in ["fgst-ccube", "fgst-template"]:
-            ax.name = "energy"
-        elif ax.name == "":
-            ax.name = "axis%i" % i
+        if ax.name == "":
+            ax.name = "axis{}".format(idx)
 
         axes_out += [ax]
 
@@ -1139,7 +1137,6 @@ class MapGeom(abc.ABC):
         return cls.from_header(hdu.header, hdu_bands)
 
     def make_bands_hdu(self, hdu=None, hdu_skymap=None, conv=None):
-        conv = self.conv if conv is None else conv
         header = fits.Header()
         self._fill_header_from_axes(header)
         axis_names = None

--- a/gammapy/maps/hpxmap.py
+++ b/gammapy/maps/hpxmap.py
@@ -44,7 +44,6 @@ class HpxMap(Map):
         dtype="float32",
         region=None,
         axes=None,
-        conv="gadf",
         meta=None,
         unit="",
     ):
@@ -75,9 +74,6 @@ class HpxMap(Map):
             geometry will be created.
         axes : list
             List of `~MapAxis` objects for each non-spatial dimension.
-        conv : {'fgst-ccube','fgst-template','gadf'}, optional
-            Default FITS format convention that will be used when
-            writing this map to a file.  Default is 'gadf'.
         meta : `dict`
             Dictionary to store meta data.
         unit : str or `~astropy.units.Unit`
@@ -97,7 +93,6 @@ class HpxMap(Map):
             nest=nest,
             coordsys=coordsys,
             region=region,
-            conv=conv,
             axes=axes,
             skydir=skydir,
             width=width,
@@ -147,7 +142,7 @@ class HpxMap(Map):
 
         return cls.from_hdu(hdu_out, hdu_bands_out)
 
-    def to_hdulist(self, hdu="SKYMAP", hdu_bands=None, sparse=False, conv=None):
+    def to_hdulist(self, hdu="SKYMAP", hdu_bands=None, sparse=False, conv="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.
 
         Parameters
@@ -282,10 +277,9 @@ class HpxMap(Map):
         hdu_out : `~astropy.io.fits.BinTableHDU` or `~astropy.io.fits.ImageHDU`
             Output HDU containing map data.
         """
-        convname = self.geom.conv if conv is None else conv
-        conv = HpxConv.create(convname)
-        hduname = conv.hduname if hdu is None else hdu
-        hduname_bands = conv.bands_hdu if hdu_bands is None else hdu_bands
+        hpxconv = HpxConv.create(conv)
+        hduname = hpxconv.hduname if hdu is None else hdu
+        hduname_bands = hpxconv.bands_hdu if hdu_bands is None else hdu_bands
 
         header = self.geom.make_header(conv=conv)
 
@@ -303,5 +297,5 @@ class HpxMap(Map):
             array = np.arange(self.data.shape[-1])
             cols.append(fits.Column("PIX", "J", array=array))
 
-        cols += self._make_cols(header, conv)
+        cols += self._make_cols(header, hpxconv)
         return fits.BinTableHDU.from_columns(cols, header=header, name=hduname)

--- a/gammapy/maps/hpxnd.py
+++ b/gammapy/maps/hpxnd.py
@@ -4,7 +4,7 @@ from astropy.io import fits
 from astropy.units import Quantity
 from gammapy.utils.units import unit_from_fits_image_hdu
 from .geom import MapCoord, pix_tuple_to_idx
-from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order
+from .hpx import HpxGeom, HpxToWcsMapping, nside_to_order, HPX_FITS_CONVENTIONS
 from .hpxmap import HpxMap
 from .utils import INVALID_INDEX, interp_to_order
 
@@ -65,6 +65,10 @@ class HpxNDMap(HpxMap):
             The BANDS table HDU
         """
         hpx = HpxGeom.from_header(hdu.header, hdu_bands)
+
+        convname = HpxGeom.identify_hpx_convention(hdu.header)
+        hpx_conv = HPX_FITS_CONVENTIONS[convname]
+
         shape = tuple([ax.nbin for ax in hpx.axes[::-1]])
         # shape_data = shape + tuple([np.max(hpx.npix)])
 
@@ -89,7 +93,7 @@ class HpxNDMap(HpxMap):
             map_out.set_by_idx(idx[::-1], vals)
         else:
             for c in colnames:
-                if c.find(hpx.hpx_conv.colstring) == 0:
+                if c.find(hpx_conv.colstring) == 0:
                     cnames.append(c)
             nbin = len(cnames)
             if nbin == 1:

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -388,7 +388,7 @@ map_serialization_args = [("log")]
 @pytest.mark.parametrize(("interp"), map_serialization_args)
 def test_arithmetics_after_serialization(tmpdir, interp):
     axis = MapAxis.from_bounds(
-        1.0, 10.0, 3, interp=interp, name="energy", node_type="center"
+        1.0, 10.0, 3, interp=interp, name="energy", node_type="center", unit="TeV"
     )
     m_wcs = Map.create(binsz=0.1, width=1.0, map_type="wcs", skydir=(0, 0), axes=[axis])
     m_wcs += 1

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -136,7 +136,6 @@ def test_hpxmap_read_write_fgst(tmpdir):
         assert h["SKYMAP"].header["TTYPE1"] == "CHANNEL1"
 
     m2 = Map.read(filename)
-    assert m2.geom.conv == "fgst-ccube"
 
     # Test Model Cube
     m.write(filename, conv="fgst-template", overwrite=True)
@@ -147,8 +146,6 @@ def test_hpxmap_read_write_fgst(tmpdir):
         assert h["SKYMAP"].header["TTYPE1"] == "ENERGY1"
 
     m2 = Map.read(filename)
-    assert m2.geom.conv == "fgst-template"
-
 
 @pytest.mark.parametrize(
     ("nside", "nested", "coordsys", "region", "axes", "sparse"), hpx_test_geoms_sparse

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -105,15 +105,12 @@ def test_wcsndmap_read_write_fgst(tmpdir):
         assert "EBOUNDS" in h
 
     m2 = Map.read(filename)
-    assert m2.geom.conv == "fgst-ccube"
+    assert m2.geom.axes[0].name == "energy"
 
     # Test Model Cube
     m.write(filename, conv="fgst-template", overwrite=True)
     with fits.open(filename) as h:
         assert "ENERGIES" in h
-
-    m2 = Map.read(filename)
-    assert m2.geom.conv == "fgst-template"
 
 
 def test_wcs_nd_map_data_transpose_issue(tmpdir):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -469,16 +469,8 @@ class WcsGeom(MapGeom):
         for i in range(naxis - 2):
             wcs = wcs.dropaxis(2)
 
-        axes = find_and_read_bands(hdu_bands, header)
+        axes = find_and_read_bands(hdu_bands)
         shape = tuple([ax.nbin for ax in axes])
-        conv = "gadf"
-
-        # Discover FITS convention
-        if hdu_bands is not None:
-            if hdu_bands.name == "EBOUNDS":
-                conv = "fgst-ccube"
-            elif hdu_bands.name == "ENERGIES":
-                conv = "fgst-template"
 
         if hdu_bands is not None and "NPIX" in hdu_bands.columns.names:
             npix = hdu_bands.data.field("NPIX").reshape(shape + (2,))

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -178,21 +178,17 @@ class WcsGeom(MapGeom):
         Reference pixel coordinate in each image plane.
     axes : list
         Axes for non-spatial dimensions
-    conv : {'gadf', 'fgst-ccube', 'fgst-template'}
-        Serialization format convention.  This sets the default format
-        that will be used when writing this geometry to a file.
     """
 
     _slice_spatial_axes = slice(0, 2)
     _slice_non_spatial_axes = slice(2, None)
     is_hpx = False
 
-    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, conv="gadf"):
+    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None):
         self._wcs = wcs
         self._coordsys = get_coordys(wcs)
         self._projection = get_projection(wcs)
-        self._conv = conv
-        self._axes = make_axes(axes, conv)
+        self._axes = make_axes(axes)
 
         if cdelt is None:
             cdelt = tuple(np.abs(self.wcs.wcs.cdelt))
@@ -287,11 +283,6 @@ class WcsGeom(MapGeom):
         return self._npix
 
     @property
-    def conv(self):
-        """Name of default FITS convention associated with this geometry."""
-        return self._conv
-
-    @property
     def axes(self):
         """List of non-spatial axes."""
         return self._axes
@@ -355,7 +346,6 @@ class WcsGeom(MapGeom):
         axes=None,
         skydir=None,
         width=None,
-        conv="gadf",
     ):
         """Create a WCS geometry object.
 
@@ -397,9 +387,6 @@ class WcsGeom(MapGeom):
         refpix : tuple
             Reference pixel of the projection.  If None this will be
             set to the center of the map.
-        conv : string, optional
-            FITS format convention ('fgst-ccube', 'fgst-template',
-            'gadf').  Default is 'gadf'.
 
         Returns
         -------
@@ -459,7 +446,7 @@ class WcsGeom(MapGeom):
             yrefpix=refpix[1],
         )
         wcs = WCS(header)
-        return cls(wcs, npix, cdelt=binsz, axes=axes, conv=conv)
+        return cls(wcs, npix, cdelt=binsz, axes=axes)
 
     @classmethod
     def from_header(cls, header, hdu_bands=None):
@@ -506,7 +493,7 @@ class WcsGeom(MapGeom):
             npix = (header["NAXIS1"], header["NAXIS2"])
             cdelt = None
 
-        return cls(wcs, npix, cdelt=cdelt, axes=axes, conv=conv)
+        return cls(wcs, npix, cdelt=cdelt, axes=axes)
 
     def _make_bands_cols(self, hdu=None, conv=None):
 

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -165,6 +165,10 @@ class WcsMap(Map):
         if sparse and hdu == "PRIMARY":
             raise ValueError("Sparse maps cannot be written to the PRIMARY HDU.")
 
+        if conv in ["fgst-ccube", "fgst-template"]:
+            if self.geom.axes[0].name != "energy" or len(self.geom.axes) > 1:
+                raise ValueError("All 'fgst' formats don't support extra axes except for energy.")
+
         if self.geom.axes:
             hdu_bands_out = self.geom.make_bands_hdu(
                 hdu=hdu_bands, hdu_skymap=hdu, conv=conv

--- a/gammapy/maps/wcsmap.py
+++ b/gammapy/maps/wcsmap.py
@@ -33,7 +33,6 @@ class WcsMap(Map):
         axes=None,
         skydir=None,
         dtype="float32",
-        conv="gadf",
         meta=None,
         unit="",
     ):
@@ -89,8 +88,6 @@ class WcsMap(Map):
         """
         from .wcsnd import WcsNDMap
 
-        # from .wcssparse import WcsMapSparse
-
         geom = WcsGeom.create(
             npix=npix,
             binsz=binsz,
@@ -100,7 +97,6 @@ class WcsMap(Map):
             coordsys=coordsys,
             refpix=refpix,
             axes=axes,
-            conv=conv,
         )
 
         if map_type == "wcs":
@@ -141,7 +137,7 @@ class WcsMap(Map):
 
         return cls.from_hdu(hdu, hdu_bands)
 
-    def to_hdulist(self, hdu=None, hdu_bands=None, sparse=False, conv=None):
+    def to_hdulist(self, hdu=None, hdu_bands=None, sparse=False, conv="gadf"):
         """Convert to `~astropy.io.fits.HDUList`.
 
         Parameters
@@ -153,9 +149,8 @@ class WcsMap(Map):
         sparse : bool
             Sparsify the map by only writing pixels with non-zero
             amplitude.
-        conv : {'fgst-ccube','fgst-template','gadf',None}, optional
-            FITS format convention.  If None this will be set to the
-            default convention of the map.
+        conv : {'gadf', 'fgst-ccube','fgst-template'}
+            FITS format convention.
 
         Returns
         -------

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -234,7 +234,6 @@
     ")\n",
     "# Unit is not stored in the file, set it manually\n",
     "exposure_hpx.unit = \"cm2 s\"\n",
-    "exposure_hpx.geom.axes[0].unit = \"GeV\"\n",
     "print(exposure_hpx.geom)\n",
     "print(exposure_hpx.geom.axes[0])"
    ]


### PR DESCRIPTION
This PR cleans-up and simplifies the fits convention handling for maps. It includes the following changes:
- Remove the `Map.conv` attribute
- Move the handling of `conv` completely to I/O methods
- Simplify `find_and_read_bands` method