### PR TITLE
Fix SkyPointSource evaluation

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -12,7 +12,7 @@ from gammapy.data import GTI
 from gammapy.irf import EnergyDispersion
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling import Dataset, Parameters
-from gammapy.modeling.models import BackgroundModel, SkyModel, SkyModels
+from gammapy.modeling.models import BackgroundModel, SkyModel, SkyModels, SkyPointSource
 from gammapy.stats import cash, cash_sum_cython, cstat, cstat_sum_cython
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_path
@@ -737,7 +737,7 @@ class MapEvaluator:
             if not coord.coordsys == coordsys:
                 coord = coord.to_coordsys(coordsys)
 
-        return (coord.lon, coord.lat)
+        return coord.lon, coord.lat
 
     @property
     def lon(self):
@@ -840,9 +840,7 @@ class MapEvaluator:
             Sky cube with data filled with evaluated model values.
             Units: ``cm-2 s-1 TeV-1 deg-2``
         """
-        coord = (self.lon, self.lat, self.energy_center)
-        dnde = self.model.evaluate(*coord)
-        return dnde
+        return self.model.evaluate_geom(self.geom)
 
     def compute_flux(self):
         """Compute model integral flux over map pixel volumes.
@@ -851,8 +849,7 @@ class MapEvaluator:
         """
         dnde = self.compute_dnde()
         volume = self.bin_volume
-        flux = dnde * volume
-        return flux
+        return dnde * volume
 
     def apply_exposure(self, flux):
         """Compute npred cube

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -330,6 +330,7 @@ class MapAxis:
     unit : str
         String specifying the data units.
     """
+
     # TODO: Add methods to faciliate FITS I/O.
     # TODO: Cache an interpolation object?
     def __init__(self, nodes, interp="lin", name="", node_type="edges", unit=""):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -30,6 +30,10 @@ class SkyModelBase(Model):
     def __call__(self, lon, lat, energy):
         return self.evaluate(lon, lat, energy)
 
+    def evaluate_geom(self, geom):
+        coords = geom.get_coord()
+        return self(coords.lon, coords.lat, coords["energy"])
+
 
 class SkyModels:
     """Collection of `~gammapy.modeling.models.SkyModel`
@@ -280,6 +284,13 @@ class SkyModel(SkyModelBase):
         """
         val_spatial = self.spatial_model(lon, lat)  # pylint:disable=not-callable
         val_spectral = self.spectral_model(energy)  # pylint:disable=not-callable
+        return val_spatial * val_spectral
+
+    def evaluate_geom(self, geom):
+        """Evaluate model on `~gammapy.maps.Geom`."""
+        val_spatial = self.spatial_model.evaluate_geom(geom.to_image())
+        energy = geom.get_axis_by_name("energy").center[:, np.newaxis, np.newaxis]
+        val_spectral = self.spectral_model(energy)
         return val_spatial * val_spectral
 
     def copy(self, **kwargs):

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -8,13 +8,13 @@ from gammapy.irf import EnergyDispersion
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
     BackgroundModel,
+    ConstantModel,
     PowerLaw,
     SkyDiffuseCube,
-    SkyPointSource,
     SkyGaussian,
     SkyModel,
     SkyModels,
-    ConstantModel,
+    SkyPointSource,
 )
 from gammapy.utils.testing import requires_data
 
@@ -458,8 +458,8 @@ def test_sky_point_source():
 
     expected = [
         [0, 0, 0, 0],
-        [0, 0.048, 0.020, 0.0],
-        [0, 0.192, 0.080, 0],
+        [0, 0.140, 0.058, 0.0],
+        [0, 0.564, 0.236, 0],
         [0, 0, 0, 0],
     ]
     assert_allclose(flux, expected, atol=0.01)

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -15,18 +15,20 @@ from gammapy.utils.testing import requires_data
 
 
 def test_sky_point_source():
-    model = SkyPointSource(lon_0="2.5 deg", lat_0="2.5 deg")
-    lat, lon = np.mgrid[0:6, 0:6] * u.deg
-    val = model(lon, lat)
-    assert val.unit == "deg-2"
-    assert_allclose(val.sum().value, 1)
-    radius = model.evaluation_radius
-    assert radius.unit == "deg"
-    assert_allclose(radius.value, 0)
-    assert model.frame == "galactic"
+    geom = WcsGeom.create(skydir=(2.4, 2.3), npix=(10, 10), binsz=0.3)
+    model = SkyPointSource(lon_0="2.5 deg", lat_0="2.5 deg", frame="icrs")
 
-    assert_allclose(model.position.l.deg, 2.5)
-    assert_allclose(model.position.b.deg, 2.5)
+    assert model.evaluation_radius.unit == "deg"
+    assert_allclose(model.evaluation_radius.value, 0)
+
+    assert model.frame == "icrs"
+
+    assert_allclose(model.position.ra.deg, 2.5)
+    assert_allclose(model.position.dec.deg, 2.5)
+
+    val = model.evaluate_geom(geom)
+    assert val.unit == "sr-1"
+    assert_allclose(np.sum(val * geom.solid_angle()), 1)
 
 
 def test_sky_gaussian():


### PR DESCRIPTION
In #2366 I remove the lon wrapping in sky model init, and noticed that there's one place in the Gammapy code where we do use lon wrapping that might break with that change: `SkyPointSource` evaluation:

https://github.com/gammapy/gammapy/blob/435798b93d10bd86cff15ca824665e71c1f24c02/gammapy/modeling/models/spatial.py#L91-L104

I don't fully understand the implementation, but presumably it's some spherical variant of this:
https://docs.gammapy.org/0.6/_modules/gammapy/image/models/models.html#Delta2D.evaluate

The only test we have is this:
https://github.com/gammapy/gammapy/blob/435798b93d10bd86cff15ca824665e71c1f24c02/gammapy/modeling/models/tests/test_spatial.py#L20-L32

@adonath or anyone that wants to work on this:

- Probably this current implementation leads to incorrect results for maps where the solid angle isn't given by lon / lat diff (see #2276)
- Is the implementation correct for all cases os position within a pixel like center, edge, corner, 1% or 0.01% inside? Or are there positions where numerical problems arise?
- All flux is put in one pixel? Or is it distributed to preserve centroid?
- Should we keep and improve this algorithm, or choose a completely new one like finding the closest pixel and then distributing flux in a centroid-preserving way into that pixel, and one to the side and on up or down?

I think in any case, the test for this complex and special model should be improved, e.g. also to put the source at lon = 0 or 180 deg, but also at a pixel center or corner, or to have a WCS where lon / lat pixel diff doesn't give the correct solid angle. (or do we have that kind of test already and I just missed it?). About half of analyses will use point source, so it's really important that we give correct results in those cases.

If we stick with the current implementation, we can probably improve it a bit, e.g. use the `axis` option for [numpy.gradient](https://docs.scipy.org/doc/numpy/reference/generated/numpy.gradient.html), or to call `np.where` instead of `np.select` to save some `[...]` and visual clutter on that line.

I don't have the answer here, I don't know how other frameworks handle the point source case. Possibly dealing with this in a good way requires changing the spatial model interface completely to `evaluate_on_geom`, because only then the relevant pixel information is present?
If that's the case - let's do that?
