### PR TITLE
Cleanup `MapEvaluator`

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -695,18 +695,13 @@ class MapEvaluator:
     def geom_reco(self):
         """Reco energy map geometry (`~gammapy.maps.MapGeom`)"""
         e_reco_axis = self.edisp.e_reco.copy(name="energy")
-        return self.geom_image.to_cube(axes=[e_reco_axis])
-
-    @property
-    def geom_image(self):
-        """Image map geometry (`~gammapy.maps.MapGeom`)"""
-        return self.geom.to_image()
+        return self.geom.to_image().to_cube(axes=[e_reco_axis])
 
     @lazyproperty
     def lon_lat(self):
         """Spatial coordinate pixel centers (``lon, lat`` tuple of `~astropy.units.Quantity`).
         """
-        coord = self.geom_image.get_coord()
+        coord = self.geom.to_image().get_coord()
         frame = self.model.frame
 
         if frame is not None:

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -781,7 +781,9 @@ class MapEvaluator:
             for cached_property in self._cached_properties:
                 self.__dict__.pop(cached_property, None)
 
-            self.coords_idx = geom.coord_to_idx(self.coords)[::-1]
+            coords = self.exposure.geom.to_image().get_coord()
+            idx_x, idx_y = geom.to_image().coord_to_idx(coords)
+            self.coords_idx = (Ellipsis, idx_y, idx_x)
 
         else:
             self.exposure = exposure

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -840,11 +840,7 @@ class MapEvaluator:
         npred_reco : `~gammapy.maps.Map`
             Predicted counts in reco energy bins
         """
-        loc = npred.geom.get_axis_index_by_name("energy")
-        data = np.rollaxis(npred.data, loc, len(npred.data.shape))
-        data = np.dot(data, self.edisp.pdf_matrix)
-        data = np.rollaxis(data, -1, loc)
-        return Map.from_geom(self.geom_reco, data=data, unit="")
+        return npred.apply_edisp(self.edisp)
 
     def compute_npred(self):
         """

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -671,7 +671,6 @@ class MapEvaluator:
     _cached_properties = [
         "lon_lat",
         "geom_reco",
-        "energy_center",
     ]
 
     def __init__(
@@ -704,12 +703,6 @@ class MapEvaluator:
         return self.geom.to_image()
 
     @lazyproperty
-    def energy_center(self):
-        """True energy axis bin centers (`~astropy.units.Quantity`)"""
-        energy_axis = self.geom.get_axis_by_name("energy")
-        return energy_axis.center[:, np.newaxis, np.newaxis]
-
-    @lazyproperty
     def lon_lat(self):
         """Spatial coordinate pixel centers (``lon, lat`` tuple of `~astropy.units.Quantity`).
         """
@@ -739,7 +732,8 @@ class MapEvaluator:
         if self.edisp:
             energy = self.edisp.e_reco.center[:, np.newaxis, np.newaxis]
         else:
-            energy = self.energy_center
+            energy_axis = self.geom.get_axis_by_name("energy")
+            energy = energy_axis.center[:, np.newaxis, np.newaxis]
 
         return {"lon": lon, "lat": lat, "energy": energy}
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -670,11 +670,7 @@ class MapEvaluator:
 
     _cached_properties = [
         "lon_lat",
-        "solid_angle",
-        "bin_volume",
         "geom_reco",
-        "energy_bin_width",
-        "energy_edges",
         "energy_center",
     ]
 
@@ -712,12 +708,6 @@ class MapEvaluator:
         """True energy axis bin centers (`~astropy.units.Quantity`)"""
         energy_axis = self.geom.get_axis_by_name("energy")
         return energy_axis.center[:, np.newaxis, np.newaxis]
-
-    @lazyproperty
-    def energy_edges(self):
-        """True energy axis bin edges (`~astropy.units.Quantity`)"""
-        energy_axis = self.geom.get_axis_by_name("energy")
-        return energy_axis.edges[:, np.newaxis, np.newaxis]
 
     @lazyproperty
     def lon_lat(self):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -670,7 +670,6 @@ class MapEvaluator:
 
     _cached_properties = [
         "lon_lat",
-        "geom_reco",
     ]
 
     def __init__(
@@ -690,12 +689,6 @@ class MapEvaluator:
     def geom(self):
         """True energy map geometry (`~gammapy.maps.MapGeom`)"""
         return self.exposure.geom
-
-    @lazyproperty
-    def geom_reco(self):
-        """Reco energy map geometry (`~gammapy.maps.MapGeom`)"""
-        e_reco_axis = self.edisp.e_reco.copy(name="energy")
-        return self.geom.to_image().to_cube(axes=[e_reco_axis])
 
     @lazyproperty
     def lon_lat(self):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -720,11 +720,6 @@ class MapEvaluator:
         return energy_axis.edges[:, np.newaxis, np.newaxis]
 
     @lazyproperty
-    def energy_bin_width(self):
-        """Energy axis bin widths (`astropy.units.Quantity`)"""
-        return np.diff(self.energy_edges, axis=0)
-
-    @lazyproperty
     def lon_lat(self):
         """Spatial coordinate pixel centers (``lon, lat`` tuple of `~astropy.units.Quantity`).
         """
@@ -746,18 +741,6 @@ class MapEvaluator:
     @property
     def lat(self):
         return self.lon_lat[1]
-
-    @lazyproperty
-    def solid_angle(self):
-        """Solid angle per pixel"""
-        return self.geom.solid_angle()
-
-    @lazyproperty
-    def bin_volume(self):
-        """Map pixel bin volume (solid angle times energy bin width)."""
-        omega = self.solid_angle
-        de = self.energy_bin_width
-        return omega * de
 
     @property
     def coords(self):
@@ -848,7 +831,7 @@ class MapEvaluator:
         For now, we simply multiply dnde with bin volume.
         """
         dnde = self.compute_dnde()
-        volume = self.bin_volume
+        volume = self.geom.bin_volume()
         return dnde * volume
 
     def apply_exposure(self, flux):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -22,7 +22,7 @@ def geom():
     ebounds = np.logspace(-1.0, 1.0, 3)
     axis = MapAxis.from_edges(ebounds, name="energy", unit=u.TeV)
     return WcsGeom.create(
-        skydir=(266.42, -29.0), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
+        skydir=(266.40498829, -28.93617776), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
     )
 
 
@@ -31,7 +31,7 @@ def geom_etrue():
     ebounds_true = np.logspace(-1.0, 1.0, 4)
     axis = MapAxis.from_edges(ebounds_true, name="energy", unit=u.TeV)
     return WcsGeom.create(
-        skydir=(266.42, -29.0), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
+        skydir=(266.40498829, -28.93617776), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
     )
 
 
@@ -132,8 +132,8 @@ def test_fake(sky_model, geom, geom_etrue):
     dataset.fake(314)
 
     assert real_dataset.counts.data.shape == dataset.counts.data.shape
-    assert_allclose(real_dataset.counts.data.sum(), 6455.037802)
-    assert_allclose(dataset.counts.data.sum(), 6553)
+    assert_allclose(real_dataset.counts.data.sum(), 6454.959516)
+    assert_allclose(dataset.counts.data.sum(), 6581)
 
 
 @requires_data()
@@ -238,7 +238,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     npred = dataset_1.npred().data.sum()
     assert_allclose(npred, 4454.932873, rtol=1e-3)
-    assert_allclose(result.total_stat, 12728.351643, rtol=1e-3)
+    assert_allclose(result.total_stat, 12811.238924, rtol=1e-3)
 
     pars = result.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
@@ -264,7 +264,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_2.mask_safe = mask_safe
 
     stat = fit.datasets.likelihood()
-    assert_allclose(stat, 5895.205587)
+    assert_allclose(stat, 5936.781716)
 
     # test model evaluation outside image
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -137,14 +137,14 @@ def test_fake(sky_model, geom, geom_etrue):
 
 
 @requires_data()
-def test_different_exposure_unit(sky_model, geom, geom_etrue):
-    dataset_ref = get_map_dataset(sky_model, geom, geom_etrue, edisp=False)
+def test_different_exposure_unit(sky_model, geom):
+    dataset_ref = get_map_dataset(sky_model, geom, geom, edisp=False)
     npred_ref = dataset_ref.npred()
 
-    ebounds_true = np.logspace(2, 4, 4)
+    ebounds_true = np.logspace(2, 4, 3)
     axis = MapAxis.from_edges(ebounds_true, name="energy", unit="GeV")
     geom_gev = WcsGeom.create(
-        skydir=(0, 0), binsz=0.02, width=(2, 2), coordsys="GAL", axes=[axis]
+        skydir=(266.40498829, -28.93617776), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
     )
 
     dataset = get_map_dataset(sky_model, geom, geom_gev, edisp=False)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -22,7 +22,7 @@ def geom():
     ebounds = np.logspace(-1.0, 1.0, 3)
     axis = MapAxis.from_edges(ebounds, name="energy", unit=u.TeV)
     return WcsGeom.create(
-        skydir=(0, 0), binsz=0.02, width=(2, 2), coordsys="GAL", axes=[axis]
+        skydir=(266.42, -29.0), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
     )
 
 
@@ -31,7 +31,7 @@ def geom_etrue():
     ebounds_true = np.logspace(-1.0, 1.0, 4)
     axis = MapAxis.from_edges(ebounds_true, name="energy", unit=u.TeV)
     return WcsGeom.create(
-        skydir=(0, 0), binsz=0.02, width=(2, 2), coordsys="GAL", axes=[axis]
+        skydir=(266.42, -29.0), binsz=0.02, width=(2, 2), coordsys="CEL", axes=[axis]
     )
 
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -851,12 +851,14 @@ class MapCoord:
     @property
     def theta(self):
         """Theta co-latitude angle in radians."""
-        return np.pi / 2.0 - np.radians(self.lat)
+        theta = u.Quantity(self.lat, unit="deg", copy=False).to_value("rad")
+        return np.pi / 2.0 - theta
 
     @property
     def phi(self):
         """Phi longitude angle in radians."""
-        return np.radians(self.lon)
+        phi = u.Quantity(self.lat, unit="deg", copy=False).to_value("rad")
+        return phi
 
     @property
     def coordsys(self):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -857,7 +857,7 @@ class MapCoord:
     @property
     def phi(self):
         """Phi longitude angle in radians."""
-        phi = u.Quantity(self.lat, unit="deg", copy=False).to_value("rad")
+        phi = u.Quantity(self.lon, unit="deg", copy=False).to_value("rad")
         return phi
 
     @property

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -420,6 +420,11 @@ class MapAxis:
         pix = np.arange(self.nbin, dtype=float)
         return u.Quantity(self.pix_to_coord(pix), self._unit, copy=False)
 
+    @lazyproperty
+    def bin_width(self):
+        """Return array of bin widths"""
+        return np.diff(self.edges)
+
     @property
     def nbin(self):
         """Return number of bins."""

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1019,8 +1019,14 @@ class MapCoord:
             skycoord = lonlat_to_skycoord(self.lon, self.lat, self.coordsys)
             lon, lat, frame = skycoord_to_lonlat(skycoord, coordsys=coordsys)
             data = copy.deepcopy(self._data)
-            data["lon"] = u.Quantity(lon, unit="deg", copy=False)
-            data["lat"] = u.Quantity(lat, unit="deg", copy=False)
+            if isinstance(self.lon, u.Quantity):
+                lon = u.Quantity(lon, unit="deg", copy=False)
+
+            if isinstance(self.lon, u.Quantity):
+                lat = u.Quantity(lat, unit="deg", copy=False)
+
+            data["lon"] = lon
+            data["lat"] = lat
             return self.__class__(data, coordsys, self._match_by_name)
 
     def apply_mask(self, mask):

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1019,8 +1019,8 @@ class MapCoord:
             skycoord = lonlat_to_skycoord(self.lon, self.lat, self.coordsys)
             lon, lat, frame = skycoord_to_lonlat(skycoord, coordsys=coordsys)
             data = copy.deepcopy(self._data)
-            data["lon"] = lon
-            data["lat"] = lat
+            data["lon"] = u.Quantity(lon, unit="deg", copy=False)
+            data["lat"] = u.Quantity(lat, unit="deg", copy=False)
             return self.__class__(data, coordsys, self._match_by_name)
 
     def apply_mask(self, mask):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -587,7 +587,7 @@ class WcsGeom(MapGeom):
         return pix
 
     @lru_cache()
-    def get_coord(self, idx=None, flat=False, mode="center"):
+    def get_coord(self, idx=None, flat=False, mode="center", coordsys=None):
         """Get map coordinates from the geometry.
 
         Parameters
@@ -610,7 +610,10 @@ class WcsGeom(MapGeom):
         axes_names = ["lon", "lat"] + [ax.name for ax in self.axes]
         cdict = dict(zip(axes_names, coords))
 
-        return MapCoord.create(cdict, coordsys=self.coordsys)
+        if coordsys is None:
+            coordsys = self.coordsys
+
+        return MapCoord.create(cdict, coordsys=self.coordsys).to_coordsys(coordsys)
 
     def coord_to_pix(self, coords):
         coords = MapCoord.create(coords, coordsys=self.coordsys)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -797,6 +797,18 @@ class WcsGeom(MapGeom):
 
         return u.Quantity(area_low_right + area_up_left, "sr", copy=False)
 
+    @lru_cache()
+    def bin_volume(self):
+        """Bin volume (`~astropy.units.Quantity`)"""
+        bin_volume = self.to_image().solid_angle()
+
+        for idx, ax in enumerate(self.axes):
+            shape = self.ndim * [1]
+            shape[-(idx + 3)] = -1
+            bin_volume = bin_volume * ax.bin_width.reshape(tuple(shape))
+
+        return bin_volume
+
     def separation(self, center):
         """Compute sky separation wrt a given center.
 

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -688,6 +688,7 @@ class WcsGeom(MapGeom):
         idx = self.coord_to_idx(coords)
         return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
 
+    @lru_cache()
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -652,6 +652,28 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(data=convolved_data)
 
+    def apply_edisp(self, edisp):
+        """Apply energy dispersion to map. Requires energy axis.
+
+        Parameters
+        ----------
+        edisp : `EnergyDispersion`
+            Energy dispersion.
+
+        Returns
+        -------
+        map : `WcsNDMap`
+            Map with energy dispersion applied.
+        """
+        loc = self.geom.get_axis_index_by_name("energy")
+        data = np.rollaxis(self.data, loc, len(self.data.shape))
+        data = np.dot(data, edisp.pdf_matrix)
+        data = np.rollaxis(data, -1, loc)
+
+        e_reco_axis = edisp.e_reco.copy(name="energy")
+        geom_reco = self.geom.to_image().to_cube(axes=[e_reco_axis])
+        return self._init_copy(geom=geom_reco, data=data)
+
     def cutout(self, position, width, mode="trim"):
         """
         Create a cutout around a given position.

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -59,7 +59,9 @@ class SkySpatialModel(Model):
 
     def evaluate_geom(self, geom):
         """Evaluate model on `~gammapy.maps.Geom`."""
-        coords = geom.get_coord()
+        # TODO: change to uniform coordinate frame names
+        coordsys = "CEL" if self.frame == "icrs" else "GAL"
+        coords = geom.get_coord(coordsys=coordsys)
         return self(coords.lon, coords.lat)
 
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -346,16 +346,6 @@ class TestSkyDiffuseCubeMapEvaluator:
 
 class TestSkyModelMapEvaluator:
     @staticmethod
-    def test_lon_lat(evaluator):
-        val = evaluator.lon
-        assert val.shape == (4, 5)
-        assert val.unit == "deg"
-
-        val = evaluator.lat
-        assert val.shape == (4, 5)
-        assert val.unit == "deg"
-
-    @staticmethod
     def test_compute_dnde(evaluator):
         out = evaluator.compute_dnde()
         assert out.shape == (3, 4, 5)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -346,24 +346,6 @@ class TestSkyDiffuseCubeMapEvaluator:
 
 class TestSkyModelMapEvaluator:
     @staticmethod
-    def test_energy_center(evaluator):
-        val = evaluator.energy_center
-        assert val.shape == (3, 1, 1)
-        assert val.unit == "TeV"
-
-    @staticmethod
-    def test_energy_edges(evaluator):
-        val = evaluator.energy_edges
-        assert val.shape == (4, 1, 1)
-        assert val.unit == "TeV"
-
-    @staticmethod
-    def test_energy_bin_width(evaluator):
-        val = evaluator.energy_bin_width
-        assert val.shape == (3, 1, 1)
-        assert val.unit == "TeV"
-
-    @staticmethod
     def test_lon_lat(evaluator):
         val = evaluator.lon
         assert val.shape == (4, 5)
@@ -372,18 +354,6 @@ class TestSkyModelMapEvaluator:
         val = evaluator.lat
         assert val.shape == (4, 5)
         assert val.unit == "deg"
-
-    @staticmethod
-    def test_solid_angle(evaluator):
-        val = evaluator.solid_angle
-        assert val.shape == (3, 4, 5)
-        assert val.unit == "sr"
-
-    @staticmethod
-    def test_bin_volume(evaluator):
-        val = evaluator.bin_volume
-        assert val.shape == (3, 4, 5)
-        assert val.unit == "TeV sr"
 
     @staticmethod
     def test_compute_dnde(evaluator):


### PR DESCRIPTION
Following #2367 and #2377 this PR cleans up the `MapEvaluator`. It mainly removes the coordinate caching, that has now moved to the `WcsGeom` object.