### PR TITLE
Add offset cut to IRF exposure map

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -323,9 +323,11 @@ def test_create(geom, geom_etrue):
     assert_allclose(empty_dataset.background_model.map.data.sum(), 0.0)
 
     assert empty_dataset.psf.psf_map.data.shape == (3, 50, 100, 100)
-    assert empty_dataset.psf.exposure_map.data.shape == (3, 100, 100)
+    assert empty_dataset.psf.exposure_map.data.shape == (3, 1, 100, 100)
 
     assert empty_dataset.edisp.edisp_map.data.shape == (3, 50, 100, 100)
+    assert empty_dataset.edisp.exposure_map.data.shape == (3, 1, 100, 100)
+
     assert_allclose(empty_dataset.edisp.edisp_map.data.sum(), 30000)
 
     assert_allclose(empty_dataset.gti.time_delta, 0.0 * u.s)


### PR DESCRIPTION
This PR contains the following changes:
- Apply the offset cut to `exposure_irf` in the `MapMakerObs`
- Adapt `EdispMap.stack` and `PSFMap.stack` to handle the case of zero exposure
- Minor fixes and cleanup to `MapDataset.stack`