### PR TITLE
Change spatial model default frame to icrs

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -72,7 +72,7 @@ def get_psf(geom_etrue):
 
 @pytest.fixture
 def sky_model():
-    spatial_model = SkyGaussian(lon_0="0.2 deg", lat_0="0.1 deg", sigma="0.2 deg")
+    spatial_model = SkyGaussian(lon_0="0.2 deg", lat_0="0.1 deg", sigma="0.2 deg", frame="galactic")
     spectral_model = PowerLaw(
         index=3, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
     )

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -17,7 +17,7 @@ def test_simulate():
     )
 
     # Define sky model to simulate the data
-    spatial_model = SkyGaussian(lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg")
+    spatial_model = SkyGaussian(lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic")
     spectral_model = PowerLaw(
         index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
     )

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -603,7 +603,7 @@ def get_npred_map():
         unit="cm2 s",
     )
 
-    spatial_model = SkyGaussian("0 deg", "0 deg", sigma="0.2 deg")
+    spatial_model = SkyGaussian("0 deg", "0 deg", sigma="0.2 deg", frame="galactic")
     spectral_model = PowerLaw(amplitude="1e-11 cm-2 s-1 TeV-1")
     skymodel = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 

--- a/gammapy/modeling/model.py
+++ b/gammapy/modeling/model.py
@@ -52,6 +52,11 @@ class Model:
             x["name"].split("@")[0]: x["value"] * u.Unit(x["unit"])
             for x in data["parameters"]
         }
+
+        # TODO: this is a special case for spatial models, maybe better move to `SkySpatialModel` base class
+        if "frame" in data:
+            params["frame"] = data["frame"]
+
         init = cls(**params)
         init.parameters = Parameters.from_dict(data)
         for parameter in init.parameters.parameters:

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -64,6 +64,12 @@ class SkySpatialModel(Model):
         coords = geom.get_coord(coordsys=coordsys)
         return self(coords.lon, coords.lat)
 
+    def to_dict(self, selection="all"):
+        data = super().to_dict(selection=selection)
+        data["frame"] = self.frame
+        data["parameters"] = data.pop("parameters")
+        return data
+
 
 class SkyPointSource(SkySpatialModel):
     r"""Point Source.

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -82,7 +82,7 @@ class SkyPointSource(SkySpatialModel):
     tag = "SkyPointSource"
     __slots__ = ["frame", "lon_0", "lat_0"]
 
-    def __init__(self, lon_0, lat_0, frame="galactic"):
+    def __init__(self, lon_0, lat_0, frame="icrs"):
         self.frame = frame
         self.lon_0 = Parameter("lon_0", Angle(lon_0))
         self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)
@@ -212,7 +212,7 @@ class SkyGaussian(SkySpatialModel):
     __slots__ = ["frame", "lon_0", "lat_0", "sigma", "e", "phi"]
     tag = "SkyGaussian"
 
-    def __init__(self, lon_0, lat_0, sigma, e=0, phi="0 deg", frame="galactic"):
+    def __init__(self, lon_0, lat_0, sigma, e=0, phi="0 deg", frame="icrs"):
         self.frame = frame
         self.lon_0 = Parameter("lon_0", Angle(lon_0))
         self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)
@@ -332,7 +332,7 @@ class SkyDisk(SkySpatialModel):
     tag = "SkyDisk"
 
     def __init__(
-        self, lon_0, lat_0, r_0, e=0, phi="0 deg", edge="0.01 deg", frame="galactic"
+        self, lon_0, lat_0, r_0, e=0, phi="0 deg", edge="0.01 deg", frame="icrs"
     ):
         self.frame = frame
         self.lon_0 = Parameter("lon_0", Angle(lon_0))
@@ -428,7 +428,7 @@ class SkyShell(SkySpatialModel):
     __slots__ = ["frame", "lon_0", "lat_0", "radius", "width"]
     tag = "SkyShell"
 
-    def __init__(self, lon_0, lat_0, radius, width, frame="galactic"):
+    def __init__(self, lon_0, lat_0, radius, width, frame="icrs"):
         self.frame = frame
         self.lon_0 = Parameter("lon_0", Angle(lon_0))
         self.lat_0 = Parameter("lat_0", Angle(lat_0), min=-90, max=90)

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -21,7 +21,7 @@ from gammapy.utils.testing import requires_data
 
 @pytest.fixture(scope="session")
 def sky_model():
-    spatial_model = SkyGaussian(lon_0="3 deg", lat_0="4 deg", sigma="3 deg")
+    spatial_model = SkyGaussian(lon_0="3 deg", lat_0="4 deg", sigma="3 deg", frame="galactic")
     spectral_model = PowerLaw(
         index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
     )

--- a/gammapy/modeling/tests/data/make.py
+++ b/gammapy/modeling/tests/data/make.py
@@ -61,7 +61,7 @@ def make_datasets_example():
     models = []
 
     for ind, (lon, lat) in enumerate(sources_coords):
-        spatial_model = SkyPointSource(lon_0=lon * u.deg, lat_0=lat * u.deg)
+        spatial_model = SkyPointSource(lon_0=lon * u.deg, lat_0=lat * u.deg, frame="galactic")
         spectral_model = ExponentialCutoffPowerLaw(
             index=2 * u.Unit(""),
             amplitude=3e-12 * u.Unit("cm-2 s-1 TeV-1"),

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -40,9 +40,14 @@
     "from gammapy.irf import EnergyDispersion, make_mean_psf, make_mean_edisp\n",
     "from gammapy.maps import WcsGeom, MapAxis, Map, WcsNDMap\n",
     "from gammapy.cube import MapMaker, PSFKernel, MapDataset\n",
-    "from gammapy.modeling.models import SkyModel, SkyDiffuseCube, BackgroundModel\n",
-    "from gammapy.modeling.models import PowerLaw, ExponentialCutoffPowerLaw\n",
-    "from gammapy.modeling.models import SkyPointSource\n",
+    "from gammapy.modeling.models import (\n",
+    "    SkyModel,\n",
+    "    SkyDiffuseCube,\n",
+    "    BackgroundModel,\n",
+    "    PowerLaw,\n",
+    "    ExponentialCutoffPowerLaw,\n",
+    "    SkyPointSource,\n",
+    ")\n",
     "from gammapy.spectrum import FluxPointsEstimator\n",
     "from gammapy.modeling import Fit"
    ]
@@ -68,8 +73,7 @@
     "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/cta-1dc/index/gps/\")\n",
     "data_store.info()\n",
     "print(\n",
-    "    \"Total observation time (hours): \",\n",
-    "    data_store.obs_table[\"ONTIME\"].sum() / 3600,\n",
+    "    \"Observation time (hours): \", data_store.obs_table[\"ONTIME\"].sum() / 3600\n",
     ")\n",
     "print(\"Observation table: \", data_store.obs_table.colnames)\n",
     "print(\"HDU table: \", data_store.hdu_table.colnames)"
@@ -471,7 +475,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spatial_model = SkyPointSource(lon_0=\"0.01 deg\", lat_0=\"0.01 deg\")\n",
+    "spatial_model = SkyPointSource(\n",
+    "    lon_0=\"0.01 deg\", lat_0=\"0.01 deg\", frame=\"galactic\"\n",
+    ")\n",
     "spectral_model = PowerLaw(\n",
     "    index=2.2, amplitude=\"3e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
@@ -654,9 +660,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spatial_model = SkyPointSource(lon_0=\"-0.05 deg\", lat_0=\"-0.05 deg\")\n",
+    "spatial_model = SkyPointSource(\n",
+    "    lon_0=\"-0.05 deg\", lat_0=\"-0.05 deg\", frame=\"galactic\"\n",
+    ")\n",
     "spectral_model = ExponentialCutoffPowerLaw(\n",
-    "    index=2 * u.Unit(\"\"),\n",
+    "    index=2,\n",
     "    amplitude=3e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
     "    reference=1.0 * u.TeV,\n",
     "    lambda_=0.1 / u.TeV,\n",
@@ -870,5 +878,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/analysis_3d_joint.ipynb
+++ b/tutorials/analysis_3d_joint.ipynb
@@ -15,7 +15,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from matplotlib.patches import Circle\n",
     "import numpy as np"
    ]
   },
@@ -41,9 +40,12 @@
     "from gammapy.irf import EnergyDispersion, make_psf\n",
     "from gammapy.maps import WcsGeom, MapAxis, Map\n",
     "from gammapy.cube import MapMaker, PSFKernel, MapDataset\n",
-    "from gammapy.modeling.models import SkyModel, BackgroundModel\n",
-    "from gammapy.modeling.models import PowerLaw\n",
-    "from gammapy.modeling.models import SkyPointSource\n",
+    "from gammapy.modeling.models import (\n",
+    "    SkyModel,\n",
+    "    BackgroundModel,\n",
+    "    PowerLaw,\n",
+    "    SkyPointSource,\n",
+    ")\n",
     "from gammapy.modeling import Fit"
    ]
   },
@@ -227,7 +229,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spatial_model = SkyPointSource(lon_0=\"-0.05 deg\", lat_0=\"-0.05 deg\")\n",
+    "spatial_model = SkyPointSource(\n",
+    "    lon_0=\"-0.05 deg\", lat_0=\"-0.05 deg\", frame=\"galactic\"\n",
+    ")\n",
     "spectral_model = PowerLaw(\n",
     "    index=2.4, amplitude=\"2.7e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
@@ -436,6 +440,13 @@
     "    vmin=-1, vmax=1, cmap=\"coolwarm\", add_cbar=True, stretch=\"linear\"\n",
     ");"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -458,5 +469,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -59,9 +59,15 @@
     "from gammapy.data import EventList\n",
     "from gammapy.irf import EnergyDependentTablePSF, EnergyDispersion\n",
     "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
-    "from gammapy.modeling.models import TableModel, PowerLaw\n",
-    "from gammapy.modeling.models import SkyPointSource, SkyDiffuseConstant\n",
-    "from gammapy.modeling.models import SkyModel, SkyDiffuseCube, SkyModels\n",
+    "from gammapy.modeling.models import (\n",
+    "    TableModel,\n",
+    "    PowerLaw,\n",
+    "    SkyPointSource,\n",
+    "    SkyDiffuseConstant,\n",
+    "    SkyModel,\n",
+    "    SkyDiffuseCube,\n",
+    "    SkyModels,\n",
+    ")\n",
     "from gammapy.cube import MapDataset, PSFKernel, MapEvaluator\n",
     "from gammapy.modeling import Fit"
    ]
@@ -181,15 +187,7 @@
     "# We put this call into the same Jupyter cell as the Map.create\n",
     "# because otherwise we could accidentally fill the counts\n",
     "# multiple times when executing the ``fill_by_coord`` multiple times.\n",
-    "counts.fill_by_coord(\n",
-    "    {\n",
-    "        \"skycoord\": events.radec,\n",
-    "        # The coord-based interface doesn't use Quantity,\n",
-    "        # so we need to pass energy in the same unit as\n",
-    "        # used for the map axis\n",
-    "        \"energy\": events.energy,\n",
-    "    }\n",
-    ")"
+    "counts.fill_by_coord({\"skycoord\": events.radec, \"energy\": events.energy})"
    ]
   },
   {
@@ -402,10 +400,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = \"$GAMMAPY_DATA/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt\"\n",
-    "interp_kwargs = {\"fill_value\": None}\n",
     "diffuse_iso = TableModel.read_fermi_isotropic_model(\n",
-    "    filename=filename, interp_kwargs=interp_kwargs\n",
+    "    filename=\"$GAMMAPY_DATA/fermi_3fhl/iso_P8R2_SOURCE_V6_v06.txt\",\n",
+    "    interp_kwargs={\"fill_value\": None},\n",
     ")"
    ]
   },
@@ -635,7 +632,7 @@
    "outputs": [],
    "source": [
     "model = SkyModel(\n",
-    "    SkyPointSource(\"0 deg\", \"0 deg\"),\n",
+    "    SkyPointSource(\"0 deg\", \"0 deg\", frame=\"galactic\"),\n",
     "    PowerLaw(index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"),\n",
     ")\n",
     "\n",
@@ -765,5 +762,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/image_analysis.ipynb
+++ b/tutorials/image_analysis.ipynb
@@ -70,11 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\n",
-    "    \"Total observation time: {}\".format(\n",
-    "        data_store.obs_table[\"ONTIME\"].quantity.sum().to(\"hour\")\n",
-    "    )\n",
-    ")"
+    "data_store.obs_table[\"ONTIME\"].quantity.sum().to(\"hour\")"
    ]
   },
   {
@@ -203,7 +199,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spatial_model = SkyPointSource(lon_0=\"0.01 deg\", lat_0=\"0.01 deg\")\n",
+    "spatial_model = SkyPointSource(\n",
+    "    lon_0=\"0.01 deg\", lat_0=\"0.01 deg\", frame=\"galactic\"\n",
+    ")\n",
     "spectral_model = PowerLaw2(\n",
     "    emin=emin, emax=emax, index=2.0, amplitude=\"3e-12 cm-2 s-1\"\n",
     ")\n",
@@ -329,5 +327,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -64,9 +64,11 @@
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.irf import load_cta_irfs\n",
     "from gammapy.maps import WcsGeom, MapAxis\n",
-    "from gammapy.modeling.models import ExponentialCutoffPowerLaw\n",
-    "from gammapy.modeling.models import SkyGaussian\n",
-    "from gammapy.modeling.models import SkyModel\n",
+    "from gammapy.modeling.models import (\n",
+    "    ExponentialCutoffPowerLaw,\n",
+    "    SkyGaussian,\n",
+    "    SkyModel,\n",
+    ")\n",
     "from gammapy.cube.simulate import simulate_dataset\n",
     "from gammapy.modeling import Fit\n",
     "from gammapy.modeling.sampling import (\n",
@@ -115,7 +117,9 @@
    "outputs": [],
    "source": [
     "# Define sky model to simulate the data\n",
-    "spatial_model = SkyGaussian(lon_0=\"0 deg\", lat_0=\"0 deg\", sigma=\"0.2 deg\")\n",
+    "spatial_model = SkyGaussian(\n",
+    "    lon_0=\"0 deg\", lat_0=\"0 deg\", sigma=\"0.2 deg\", frame=\"galactic\"\n",
+    ")\n",
     "\n",
     "spectral_model = ExponentialCutoffPowerLaw(\n",
     "    index=2,\n",
@@ -251,9 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Now let's define a function to init parameters and run the MCMC with emcee\n",
@@ -413,5 +415,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -72,10 +72,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filename = (\n",
+    "irfs = load_cta_irfs(\n",
     "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
-    ")\n",
-    "irfs = load_cta_irfs(filename)"
+    ")"
    ]
   },
   {
@@ -85,7 +84,9 @@
    "outputs": [],
    "source": [
     "# Define sky model to simulate the data\n",
-    "spatial_model = SkyGaussian(lon_0=\"0.2 deg\", lat_0=\"0.1 deg\", sigma=\"0.3 deg\")\n",
+    "spatial_model = SkyGaussian(\n",
+    "    lon_0=\"0.2 deg\", lat_0=\"0.1 deg\", sigma=\"0.3 deg\", frame=\"galactic\"\n",
+    ")\n",
     "spectral_model = PowerLaw(\n",
     "    index=3, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
@@ -257,7 +258,9 @@
    "outputs": [],
    "source": [
     "# Define sky model to fit the data\n",
-    "spatial_model = SkyGaussian(lon_0=\"0.1 deg\", lat_0=\"0.1 deg\", sigma=\"0.5 deg\")\n",
+    "spatial_model = SkyGaussian(\n",
+    "    lon_0=\"0.1 deg\", lat_0=\"0.1 deg\", sigma=\"0.5 deg\", frame=\"galactic\"\n",
+    ")\n",
     "spectral_model = PowerLaw(\n",
     "    index=2, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
@@ -390,9 +393,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR changes the spatial model default frame from "galactic" to "icrs".

Using ICRS is much more common in astronomy, Galactic frame is more exotic, that was introduced just because the Gammapy devs do Galactic science.

Putting "icrs" gives consistency with SkyCoord and Map.

@adonath - Could you please fix this reference file?
https://gist.github.com/cdeil/53057a588522e1fe8ec521214d67606f
It's pretty annoying to have this non-stable reference data file while we iterate on models. E.g. it will need another update once we change any parameter or model name. I guess it's hard to avoid that reference file.