### PR TITLE
Implement SpectrumDataset.name and SpectrumDatasetOnOff.name

### DIFF
--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -99,6 +99,11 @@ class Datasets:
         return Parameters(parameters)
 
     @property
+    def names(self):
+        """List of dataset names"""
+        return [_.name for _ in self.datasets]
+
+    @property
     def datasets(self):
         """List of datasets"""
         return self._datasets
@@ -205,3 +210,7 @@ class Datasets:
         for ds in self.datasets[1:]:
             dataset.stack(ds)
         return dataset
+
+    def __getitem__(self, item):
+        idx = self.names.index(item)
+        return self.datasets[idx]

--- a/gammapy/modeling/tests/test_datasets.py
+++ b/gammapy/modeling/tests/test_datasets.py
@@ -7,7 +7,7 @@ from .test_fit import MyDataset
 
 @pytest.fixture(scope="session")
 def datasets():
-    return Datasets([MyDataset(), MyDataset()])
+    return Datasets([MyDataset(name="test-1"), MyDataset(name="test-2")])
 
 
 class TestDatasets:
@@ -23,3 +23,8 @@ class TestDatasets:
     @staticmethod
     def test_str(datasets):
         assert "MyDataset: 2" in str(datasets)
+
+    @staticmethod
+    def test_getitem(datasets):
+        assert datasets["test-1"].name == "test-1"
+        assert datasets["test-2"].name == "test-2"

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -9,7 +9,8 @@ pytest.importorskip("iminuit")
 
 
 class MyDataset:
-    def __init__(self):
+    def __init__(self, name=""):
+        self.name = name
         self.parameters = Parameters(
             [Parameter("x", 2), Parameter("y", 3e2), Parameter("z", 4e-2)]
         )

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -133,7 +133,7 @@ class SpectrumExtraction:
             livetime=observation.observation_live_time_duration,
             acceptance=1,
             acceptance_off=bkg.a_off,
-            obs_id=observation.obs_id,
+            name=str(observation.obs_id),
             gti=observation.gti,
         )
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1149,11 +1149,12 @@ class FluxPointsDataset(Dataset):
         print(result.parameters.to_table())
     """
 
-    def __init__(self, model, data, mask_fit=None, likelihood="chi2", mask_safe=None):
+    def __init__(self, model, data, mask_fit=None, likelihood="chi2", mask_safe=None, name=""):
         self.model = model
         self.data = data
         self.mask_fit = mask_fit
         self.parameters = model.parameters
+        self.name = name
 
         if data.sed_type != "dnde":
             raise ValueError("Currently only flux points of type 'dnde' are supported.")

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -242,7 +242,7 @@ class TestSpectrumOnOff:
             livetime=self.livetime,
             acceptance=np.ones(elo.shape),
             acceptance_off=np.ones(elo.shape) * 10,
-            obs_id="test",
+            name="test",
         )
 
     def test_spectrumdatasetonoff_create(self):
@@ -331,7 +331,7 @@ class TestSpectrumOnOff:
             mask_safe=np.ones(self.on_counts.energy.nbin, dtype=bool),
             acceptance=1,
             acceptance_off=10,
-            obs_id="test",
+            name="test",
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
         filename = tmpdir / "pha_obstest.fits"
@@ -348,7 +348,7 @@ class TestSpectrumOnOff:
             livetime=self.livetime,
             mask_safe=np.ones(self.on_counts.energy.nbin, dtype=bool),
             acceptance=1,
-            obs_id="test",
+            name="test",
         )
         dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
         filename = tmpdir / "pha_obstest.fits"
@@ -614,7 +614,7 @@ def make_observation_list():
         mask_safe=np.ones(on_vector.energy.nbin, dtype=bool),
         acceptance=1,
         acceptance_off=2,
-        obs_id=2,
+        name="2",
         gti=gti1,
     )
     obs2 = SpectrumDatasetOnOff(
@@ -626,7 +626,7 @@ def make_observation_list():
         mask_safe=np.ones(on_vector.energy.nbin, dtype=bool),
         acceptance=1,
         acceptance_off=4,
-        obs_id=2,
+        name="2",
         gti=gti2,
     )
 

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -114,7 +114,9 @@ class TestSpectrumExtraction:
         containment_actual = extraction.containment[60]
 
         # TODO: Introduce assert_stats_allclose
-        stats = ObservationStats(**obs._info_dict())
+        info = obs._info_dict()
+        info["obs_id"] = info.pop("name")
+        stats = ObservationStats(**info)
         n_on_actual = stats.n_on
         sigma_actual = stats.sigma
 

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -173,7 +173,7 @@
    "outputs": [],
    "source": [
     "dataset = SpectrumDataset(\n",
-    "    aeff=aeff, edisp=edisp, model=model_ref, livetime=livetime, obs_id=0\n",
+    "    aeff=aeff, edisp=edisp, model=model_ref, livetime=livetime, name=\"obs-0\"\n",
     ")\n",
     "\n",
     "dataset.fake(random_state=42)"


### PR DESCRIPTION
This PR changes from `obs_id` to name for the `SpectrumDataset` and the `SpectrumDatasetOnOff`. Technically it is just a rename of the `obs_id` attribute, but this gives now consistency with the `MapDataset`. This PR also adds a convenience `Datasets.__getitem__` method, which allows to access a dataset in the list by name.