### PR TITLE
High-level interface: refactor config settings templates

### DIFF
--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -40,6 +40,7 @@ them into a file that you can edit to start a new analysis from the modified con
 
     >>> print(analysis.config)
     >>> analysis.config.dump("config.yaml")
+    INFO:gammapy.scripts.analysis:Configuration settings saved into config.yaml
     >>> analysis = Analysis.from_file("config.yaml")
 
 You could also have started the analysis with your custom settings declared in a Python

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -425,8 +425,8 @@ class Config:
         if config is None:
             config = {}
         if len(config):
-            self._user_settings = config
-            self._update_settings(self._user_settings, self.settings)
+            self._user_settings.update(config)
+            self._update_settings(config, self.settings)
             self.validate()
 
     def validate(self):

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -388,7 +388,7 @@ class Config:
 
     def __str__(self):
         """Display settings in pretty YAML format."""
-        return yaml.dump(self.settings)
+        return yaml.dump(self.settings, indent=4)
 
     def dump(self, filename="config.yaml"):
         """Serialize config into a yaml formatted file.
@@ -401,7 +401,7 @@ class Config:
         """
         filename = make_path(filename)
         path_file = Path(self.settings["general"]["outdir"]) / filename
-        path_file.write_text(yaml.dump(self.settings))
+        path_file.write_text(yaml.dump(self.settings, indent=4))
         log.info(f"Configuration settings saved into {path_file}")
 
     def print_help(self, section=""):

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -399,16 +399,10 @@ class Config:
             Configuration settings filename
             Default config.yaml
         """
-
-        settings_str = ""
-        doc_dic = self._get_doc_sections()
-        for section in doc_dic.keys():
-            if section in self.settings:
-                settings_str += doc_dic[section] + "\n"
-                settings_str += yaml.dump({section: self.settings[section]}) + "\n"
         filename = make_path(filename)
         path_file = Path(self.settings["general"]["outdir"]) / filename
-        path_file.write_text(settings_str)
+        path_file.write_text(yaml.dump(self.settings))
+        log.info(f"Configuration settings saved into {path_file}")
 
     def print_help(self, section=""):
         """Print template configuration settings."""

--- a/gammapy/scripts/config/1D.yaml
+++ b/gammapy/scripts/config/1D.yaml
@@ -1,0 +1,78 @@
+---
+general:
+  logging:
+    level: INFO
+  outdir: .
+
+observations:
+  datastore: $GAMMAPY_DATA/hess-dl3-dr1
+  filters:
+  - filter_type: par_value
+    value_param: Crab
+    variable: TARGET_NAME
+
+reduction:
+  background:
+    background_estimator: reflected
+    on_region:
+      center:
+      - 83.633 deg
+      - 22.014 deg
+      frame: icrs
+      radius: 0.1 deg
+  data_reducer: 1d
+
+geometry:
+  axes: {}
+
+model:
+  components:
+  - name: source
+    spatial:
+      parameters:
+      - frozen: true
+        name: lon_0
+        scale: 1.0
+        unit: deg
+        value: 83.633
+      - frozen: true
+        name: lat_0
+        scale: 1.0
+        unit: deg
+        value: 22.14
+      type: SkyPointSource
+    spectral:
+      parameters:
+      - factor: 2.0
+        frozen: false
+        name: index
+        scale: 1.0
+        unit: ''
+        value: 2.0
+      - factor: 1.0e-12
+        frozen: false
+        name: amplitude
+        scale: 1.0
+        unit: cm-2 s-1 TeV-1
+        value: 1.0e-12
+      - factor: 1.0
+        frozen: true
+        name: reference
+        scale: 1.0
+        unit: TeV
+        value: 1.0
+      type: PowerLaw
+    type: SkyModel
+
+fit:
+  fit_range:
+    max: 100 TeV
+    min: 1 TeV
+
+flux:
+  fp_binning:
+    hi_bnd: 10
+    interp: log
+    lo_bnd: 1
+    nbin: 11
+    unit: TeV

--- a/gammapy/scripts/config/1D.yaml
+++ b/gammapy/scripts/config/1D.yaml
@@ -1,78 +1,78 @@
 ---
 general:
-  logging:
-    level: INFO
-  outdir: .
+    logging:
+        level: INFO
+    outdir: .
 
 observations:
-  datastore: $GAMMAPY_DATA/hess-dl3-dr1
-  filters:
-  - filter_type: par_value
-    value_param: Crab
-    variable: TARGET_NAME
+    datastore: $GAMMAPY_DATA/hess-dl3-dr1
+    filters:
+        - filter_type: par_value
+          value_param: Crab
+          variable: TARGET_NAME
 
 reduction:
-  background:
-    background_estimator: reflected
-    on_region:
-      center:
-      - 83.633 deg
-      - 22.014 deg
-      frame: icrs
-      radius: 0.1 deg
-  data_reducer: 1d
+    background:
+        background_estimator: reflected
+        on_region:
+            center:
+                - 83.633 deg
+                - 22.014 deg
+            frame: icrs
+            radius: 0.1 deg
+    data_reducer: 1d
 
 geometry:
-  axes: {}
+    axes: {}
 
 model:
-  components:
-  - name: source
-    spatial:
-      parameters:
-      - frozen: true
-        name: lon_0
-        scale: 1.0
-        unit: deg
-        value: 83.633
-      - frozen: true
-        name: lat_0
-        scale: 1.0
-        unit: deg
-        value: 22.14
-      type: SkyPointSource
-    spectral:
-      parameters:
-      - factor: 2.0
-        frozen: false
-        name: index
-        scale: 1.0
-        unit: ''
-        value: 2.0
-      - factor: 1.0e-12
-        frozen: false
-        name: amplitude
-        scale: 1.0
-        unit: cm-2 s-1 TeV-1
-        value: 1.0e-12
-      - factor: 1.0
-        frozen: true
-        name: reference
-        scale: 1.0
-        unit: TeV
-        value: 1.0
-      type: PowerLaw
-    type: SkyModel
+    components:
+        - name: source
+          spatial:
+              parameters:
+                  - frozen: true
+                    name: lon_0
+                    scale: 1.0
+                    unit: deg
+                    value: 83.633
+                  - frozen: true
+                    name: lat_0
+                    scale: 1.0
+                    unit: deg
+                    value: 22.14
+              type: SkyPointSource
+          spectral:
+              parameters:
+                  - factor: 2.0
+                    frozen: false
+                    name: index
+                    scale: 1.0
+                    unit: ''
+                    value: 2.0
+                  - factor: 1.0e-12
+                    frozen: false
+                    name: amplitude
+                    scale: 1.0
+                    unit: cm-2 s-1 TeV-1
+                    value: 1.0e-12
+                  - factor: 1.0
+                    frozen: true
+                    name: reference
+                    scale: 1.0
+                    unit: TeV
+                    value: 1.0
+              type: PowerLaw
+          type: SkyModel
 
 fit:
-  fit_range:
-    max: 100 TeV
-    min: 1 TeV
+    fit_range:
+        max: 100 TeV
+        min: 1 TeV
 
 flux:
-  fp_binning:
-    hi_bnd: 10
-    interp: log
-    lo_bnd: 1
-    nbin: 11
-    unit: TeV
+    fp_binning:
+        hi_bnd: 10
+        interp: log
+        lo_bnd: 1
+        nbin: 11
+        unit: TeV

--- a/gammapy/scripts/config/3D.yaml
+++ b/gammapy/scripts/config/3D.yaml
@@ -1,83 +1,83 @@
 ---
 general:
-  logging:
-    level: INFO
-  outdir: .
+    logging:
+        level: INFO
+    outdir: .
 
 observations:
-  datastore: $GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz
-  filters:
-  - filter_type: par_value
-    value_param: Crab
-    variable: TARGET_NAME
+    datastore: $GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz
+    filters:
+        - filter_type: par_value
+          value_param: Crab
+          variable: TARGET_NAME
 
 reduction:
-  data_reducer: 3d
+    data_reducer: 3d
 
 geometry:
-  axes:
-    e_reco:
-      hi_bnd: 10
-      interp: log
-      lo_bnd: 1
-      name: energy
-      nbin: 4
-      node_type: edges
-      unit: TeV
-  binsz: 0.02
-  coordsys: CEL
-  offset_max: 2.5 deg
-  proj: TAN
-  psf_max_radius: 0.3 deg
-  skydir:
-  - 83.633
-  - 22.014
-  width:
-  - 5
-  - 5
+    axes:
+        e_reco:
+            hi_bnd: 10
+            interp: log
+            lo_bnd: 1
+            name: energy
+            nbin: 4
+            node_type: edges
+            unit: TeV
+    binsz: 0.02
+    coordsys: CEL
+    offset_max: 2.5 deg
+    proj: TAN
+    psf_max_radius: 0.3 deg
+    skydir:
+        - 83.633
+        - 22.014
+    width:
+        - 5
+        - 5
 
 model:
-  components:
-  - name: source
-    spatial:
-      parameters:
-      - frozen: false
-        max: 85
-        min: 80
-        name: lon_0
-        scale: 1.0
-        unit: deg
-        value: 83.633
-      - frozen: false
-        max: 24
-        min: 20
-        name: lat_0
-        scale: 1.0
-        unit: deg
-        value: 22.14
-      type: SkyPointSource
-    spectral:
-      parameters:
-      - factor: 2.0
-        frozen: false
-        name: index
-        scale: 1.0
-        unit: ''
-        value: 2.6
-      - factor: 1.0e-12
-        frozen: false
-        name: amplitude
-        scale: 1.0
-        unit: cm-2 s-1 TeV-1
-        value: 5.0e-11
-      - factor: 1.0
-        frozen: true
-        name: reference
-        scale: 1.0
-        unit: TeV
-        value: 1.0
-      type: PowerLaw
-    type: SkyModel
+    components:
+        - name: source
+          spatial:
+              parameters:
+                  - frozen: false
+                    max: 85
+                    min: 80
+                    name: lon_0
+                    scale: 1.0
+                    unit: deg
+                    value: 83.633
+                  - frozen: false
+                    max: 24
+                    min: 20
+                    name: lat_0
+                    scale: 1.0
+                    unit: deg
+                    value: 22.14
+              type: SkyPointSource
+          spectral:
+              parameters:
+                  - factor: 2.0
+                    frozen: false
+                    name: index
+                    scale: 1.0
+                    unit: ''
+                    value: 2.6
+                  - factor: 1.0e-12
+                    frozen: false
+                    name: amplitude
+                    scale: 1.0
+                    unit: cm-2 s-1 TeV-1
+                    value: 5.0e-11
+                  - factor: 1.0
+                    frozen: true
+                    name: reference
+                    scale: 1.0
+                    unit: TeV
+                    value: 1.0
+              type: PowerLaw
+          type: SkyModel
 
 fit: {}
 

--- a/gammapy/scripts/config/3D.yaml
+++ b/gammapy/scripts/config/3D.yaml
@@ -1,0 +1,84 @@
+---
+general:
+  logging:
+    level: INFO
+  outdir: .
+
+observations:
+  datastore: $GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz
+  filters:
+  - filter_type: par_value
+    value_param: Crab
+    variable: TARGET_NAME
+
+reduction:
+  data_reducer: 3d
+
+geometry:
+  axes:
+    e_reco:
+      hi_bnd: 10
+      interp: log
+      lo_bnd: 1
+      name: energy
+      nbin: 4
+      node_type: edges
+      unit: TeV
+  binsz: 0.02
+  coordsys: CEL
+  offset_max: 2.5 deg
+  proj: TAN
+  psf_max_radius: 0.3 deg
+  skydir:
+  - 83.633
+  - 22.014
+  width:
+  - 5
+  - 5
+
+model:
+  components:
+  - name: source
+    spatial:
+      parameters:
+      - frozen: false
+        max: 85
+        min: 80
+        name: lon_0
+        scale: 1.0
+        unit: deg
+        value: 83.633
+      - frozen: false
+        max: 24
+        min: 20
+        name: lat_0
+        scale: 1.0
+        unit: deg
+        value: 22.14
+      type: SkyPointSource
+    spectral:
+      parameters:
+      - factor: 2.0
+        frozen: false
+        name: index
+        scale: 1.0
+        unit: ''
+        value: 2.6
+      - factor: 1.0e-12
+        frozen: false
+        name: amplitude
+        scale: 1.0
+        unit: cm-2 s-1 TeV-1
+        value: 5.0e-11
+      - factor: 1.0
+        frozen: true
+        name: reference
+        scale: 1.0
+        unit: TeV
+        value: 1.0
+      type: PowerLaw
+    type: SkyModel
+
+fit: {}
+
+flux: {}

--- a/gammapy/scripts/config/basic.yaml
+++ b/gammapy/scripts/config/basic.yaml
@@ -1,47 +1,46 @@
 ---
 general:
-  logging:
-    level: INFO
-  outdir: .
+    logging:
+        level: INFO
+    outdir: .
 
 observations:
-  datastore: $GAMMAPY_DATA/hess-dl3-dr1
-  filters:
-  - filter_type: all
+    datastore: $GAMMAPY_DATA/hess-dl3-dr1
+    filters:
+        - filter_type: all
 
 reduction:
-  data_reducer: not assigned
+    data_reducer: not assigned
 
 geometry:
-  axes: {}
+    axes: {}
 
 model:
-  components:
-  - name: source
-    spectral:
-      parameters:
-      - factor: 2.0
-        frozen: false
-        name: index
-        scale: 1.0
-        unit: ''
-        value: 2.0
-      - factor: 1.0e-12
-        frozen: false
-        name: amplitude
-        scale: 1.0
-        unit: cm-2 s-1 TeV-1
-        value: 1.0e-12
-      - factor: 1.0
-        frozen: true
-        name: reference
-        scale: 1.0
-        unit: TeV
-        value: 1.0
-    type: SkyModel
+    components:
+        - name: source
+          spectral:
+              parameters:
+                  - factor: 2.0
+                    frozen: false
+                    name: index
+                    scale: 1.0
+                    unit: ''
+                    value: 2.0
+                  - factor: 1.0e-12
+                    frozen: false
+                    name: amplitude
+                    scale: 1.0
+                    unit: cm-2 s-1 TeV-1
+                    value: 1.0e-12
+                  - factor: 1.0
+                    frozen: true
+                    name: reference
+                    scale: 1.0
+                    unit: TeV
+                    value: 1.0
+          type: SkyModel
 
 fit:
-  fit_range: {}
+    fit_range: {}
 
 flux: {}
-

--- a/gammapy/scripts/config/basic.yaml
+++ b/gammapy/scripts/config/basic.yaml
@@ -1,0 +1,47 @@
+---
+general:
+  logging:
+    level: INFO
+  outdir: .
+
+observations:
+  datastore: $GAMMAPY_DATA/hess-dl3-dr1
+  filters:
+  - filter_type: all
+
+reduction:
+  data_reducer: not assigned
+
+geometry:
+  axes: {}
+
+model:
+  components:
+  - name: source
+    spectral:
+      parameters:
+      - factor: 2.0
+        frozen: false
+        name: index
+        scale: 1.0
+        unit: ''
+        value: 2.0
+      - factor: 1.0e-12
+        frozen: false
+        name: amplitude
+        scale: 1.0
+        unit: cm-2 s-1 TeV-1
+        value: 1.0e-12
+      - factor: 1.0
+        frozen: true
+        name: reference
+        scale: 1.0
+        unit: TeV
+        value: 1.0
+    type: SkyModel
+
+fit:
+  fit_range: {}
+
+flux: {}
+

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -230,7 +230,6 @@ properties:
 #                interp: log
 #
     geometry:
-        description: ""
         type: object
         additionalProperties: false
         properties:
@@ -256,37 +255,9 @@ properties:
                 additionalProperties: false
                 properties:
                     e_reco:
-                        type: object
-                        additionalProperties: false
-                        properties:
-                            name: {type: string}
-                            lo_bnd: {type: number}
-                            hi_bnd: {type: number}
-                            nbin: {type: number}
-                            unit: {type: string}
-                            interp:
-                                type: string
-                                enum: [lin, log, sqrt]
-                            node_type:
-                                type: string
-                                enum: [edges, center]
-                        required: [lo_bnd, hi_bnd, nbin, unit]
+                        "$ref": "#/definitions/energy_axis"
                     e_true:
-                        type: object
-                        additionalProperties: false
-                        properties:
-                            name: {type: string}
-                            lo_bnd: {type: number}
-                            hi_bnd: {type: number}
-                            nbin: {type: number}
-                            unit: {type: string}
-                            interp:
-                                type: string
-                                enum: [lin, log, sqrt]
-                            node_type:
-                                type: string
-                                enum: [edges, center]
-                        required: [lo_bnd, hi_bnd, nbin, unit]
+                        "$ref": "#/definitions/energy_axis"
         required: [axes]
 
 # Block: model
@@ -307,43 +278,10 @@ properties:
                         name: {type: string}
                         type: {type: string}
                         spatial:
-                            type: object
-                            additionalProperties: false
-                            properties:
-                                type: {type: string}
-                                parameters:
-                                    type: array
-                                    items:
-                                        type: object
-                                        additionalProperties: false
-                                        properties:
-                                            name: {type: string}
-                                            value: {type: number}
-                                            factor: {type: number}
-                                            scale: {type: number}
-                                            unit: {type: string}
-                                            min: {type: number}
-                                            max: {type: number}
-                                            frozen: {type: boolean}
+                            "$ref": "#/definitions/model_components"
                         spectral:
-                            type: object
-                            additionalProperties: false
-                            properties:
-                                type: {type: string}
-                                parameters:
-                                    type: array
-                                    items:
-                                        type: object
-                                        additionalProperties: false
-                                        properties:
-                                            name: {type: string}
-                                            value: {type: number}
-                                            factor: {type: number}
-                                            scale: {type: number}
-                                            unit: {type: string}
-                                            min: {type: number}
-                                            max: {type: number}
-                                            frozen: {type: boolean}
+                            "$ref": "#/definitions/model_components"
+
 # Block: fit
 # Parameters that are used in the fitting process
 #
@@ -383,21 +321,7 @@ properties:
         additionalProperties: false
         properties:
             fp_binning:
-                type: object
-                additionalProperties: false
-                properties:
-                    name: {type: string}
-                    lo_bnd: {type: number}
-                    hi_bnd: {type: number}
-                    nbin: {type: number}
-                    unit: {type: string}
-                    interp:
-                        type: string
-                        enum: [lin, log, sqrt]
-                    node_type:
-                        type: string
-                        enum: [edges, center]
-                required: [lo_bnd, hi_bnd, nbin, unit]
+                "$ref": "#/definitions/energy_axis"
 
 if:
     properties:
@@ -425,3 +349,40 @@ then:
                     required: [e_reco]
 
 required: [general, observations, reduction, model, fit, flux]
+
+definitions:
+    model_components:
+        type: object
+        additionalProperties: false
+        properties:
+            type: {type: string}
+            parameters:
+                type: array
+                items:
+                    type: object
+                    additionalProperties: false
+                    properties:
+                        name: {type: string}
+                        value: {type: number}
+                        factor: {type: number}
+                        scale: {type: number}
+                        unit: {type: string}
+                        min: {type: number}
+                        max: {type: number}
+                        frozen: {type: boolean}
+    energy_axis:
+        type: object
+        additionalProperties: false
+        properties:
+            name: {type: string}
+            lo_bnd: {type: number}
+            hi_bnd: {type: number}
+            nbin: {type: number}
+            unit: {type: string}
+            interp:
+                type: string
+                enum: [lin, log, sqrt]
+            node_type:
+                type: string
+                enum: [edges, center]
+        required: [lo_bnd, hi_bnd, nbin, unit]

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -23,44 +23,26 @@ properties:
 #
     general:
         type: object
-        default_all: {"logging": {}}
-        default_basic: {"logging": {}}
-        default_1d: {"logging": {}}
-        default_3d: {"logging": {}}
         additionalProperties: false
         properties:
-            outdir:
-                type: string
-                default_all: "."
-                default_basic: "."
-                default_1d: "."
-                default_3d: "."
+            outdir: {type: string}
             logging:
                 type: object
-                default_all: {}
-                default_basic: {}
-                default_1d: {}
-                default_3d: {}
                 additionalProperties: false
                 properties:
                     level:
                         type: string
-                        default_all: "INFO"
-                        default_basic: "INFO"
-                        default_1d: "INFO"
-                        default_3d: "INFO"
                         enum: [CRITICAL, 50,
                                ERROR, 40,
                                WARNING, 30,
                                INFO, 20,
                                DEBUG, 10,
                                NOTSET]
-                    filename: {type: string, default_all: gammapy.log}
-                    filemode: {type: string, default_all: w}
+                    filename: {type: string}
+                    filemode: {type: string}
                     format:
                         type: string
-                        default_all: "%(asctime)s - %(message)s"
-                    datefmt: {type: string, default_all: "%d-%b-%y %H:%M:%S"}
+                    datefmt: {type: string}
                 required: [level]
                 dependencies:
                     filemode: [filename]
@@ -109,36 +91,18 @@ properties:
 #
     observations:
         type: object
-        default_all: {}
-        default_basic: {}
-        default_1d: {}
-        default_3d: {}
         additionalProperties: false
         properties:
-            datastore:
-                type: string
-                default_all: $GAMMAPY_DATA/hess-dl3-dr1
-                default_basic: $GAMMAPY_DATA/hess-dl3-dr1
-                default_1d: $GAMMAPY_DATA/hess-dl3-dr1
-                default_3d:
-                    $GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz
+            datastore: {type: string}
             filters:
                 type: array
-                default_all: [{}]
-                default_basic: [{}]
-                default_1d: [{}]
-                default_3d: [{}]
                 items:
                     type: object
                     additionalProperties: false
                     properties:
-                        exclude: {type: boolean, default_all: false}
-                        inverted: {type: boolean, default_all: false}
+                        exclude: {type: boolean}
+                        inverted: {type: boolean}
                         filter_type:
-                            default_all: all
-                            default_basic: all
-                            default_1d: par_value
-                            default_3d: par_value
                             enum: [sky_circle,
                                    angle_box,
                                    par_box,
@@ -146,30 +110,21 @@ properties:
                                    ids,
                                    all]
                         frame:
-                            default_all: icrs
                             enum: [galactic, equatorial, icrs, fk5]
-                        lon: {type: number, default_all: 83.633 deg}
-                        lat: {type: number, default_all: 22.014 deg}
-                        radius: {type: number, default_all: 0.5 deg}
-                        border: {type: number, default_all: 0.5 deg}
-                        variable:
-                            type: string
-                            default_all: TARGET_NAME
-                            default_1d: TARGET_NAME
-                            default_3d: TARGET_NAME
-                        value_param:
-                            type: string
-                            default_all: Crab
-                            default_1d: Crab
-                            default_3d: Crab
+                        lon: {type: number}
+                        lat: {type: number}
+                        radius: {type: number}
+                        border: {type: number}
+                        variable: {type: string}
+                        value_param: {type: string}
                         value_range:
                             type: array
-                            items: {type: number, default_all:[1 TeV, 100 TeV]}
+                            items: {type: number}
                             minItems: 2
                             maxItems: 2
                         obs_ids:
                             type: array
-                            items: {type: integer, default_all: [23523, 23526]}
+                            items: {type: integer}
                     required: [filter_type]
         required: [datastore, filters]
 
@@ -198,61 +153,39 @@ properties:
 #
     reduction:
         type: object
-        default_all: {}
-        default_basic: {}
-        default_1d: {}
-        default_3d: {}
         additionalProperties: false
         properties:
             background:
                 type: object
-                default_all: {}
-                default_1d: {}
                 additionalProperties: false
                 properties:
                     background_estimator:
-                        default_all: reflected
-                        default_1d: reflected
                         enum: [reflected, ring]
                     on_region:
                         type: object
-                        default_all: {}
-                        default_1d: {}
                         additionalProperties: false
                         properties:
                             center:
                                 type: array
                                 items: {type: number}
-                                default_all: [83.633 deg, 22.014 deg]
-                                default_1d: [83.633 deg, 22.014 deg]
                                 minItems: 2
                                 maxItems: 2
-                            radius:
-                                type: number
-                                default_all: 0.1 deg
-                                default_1d: 0.1 deg
+                            radius: {type: number}
                             frame:
-                                default_all: icrs
-                                default_1d: icrs
                                 enum: [galactic, equatorial, icrs, fk5]
                     exclusion_mask:
                         type: object
-                        default_all: {}
                         additionalProperties: false
                         properties:
-                            filename: {type: string, default_all: mask.fits}
-                            hdu: {type: string, default_all: IMAGE}
+                            filename: {type: string}
+                            hdu: {type: string}
                 if:
                     properties:
                         exclusion_mask:
                             required: [filename]
             data_reducer:
-                default_all: 1d
-                default_basic: not assigned
-                default_1d: 1d
-                default_3d: 3d
                 enum: [not assigned, 1d, 2d, 3d]
-            containment_correction: {type: boolean, default_all: false}
+            containment_correction: {type: boolean}
         if:
             properties:
                 data_reducer:
@@ -298,109 +231,59 @@ properties:
     geometry:
         description: ""
         type: object
-        default_all: {}
-        default_basic: {}
-        default_1d: {}
-        default_3d: {}
         additionalProperties: false
         properties:
-            binsz:
-                type: number
-                default_all: 0.02
-                default_3d: 0.02
+            binsz: {type: number}
             coordsys:
                 type: string
-                default_all: CEL
-                default_3d: CEL
                 enum: [CEL, GAL]
-            proj:
-                type: string
-                default_all: TAN
-                default_3d: TAN
+            proj: {type: string}
             skydir:
                 type: array
-                default_all: [83.633, 22.014]
-                default_3d: [83.633, 22.014]
                 items: {type: number}
                 minItems: 2
                 maxItems: 2
             width:
                 type: array
-                default_all: [5, 5]
-                default_3d: [5, 5]
                 items: {type: number}
                 minItems: 1
                 maxItems: 2
-            offset_max:
-                type: string
-                default_all: 3 deg
-                default_3d: 2.5 deg
-            psf_max_radius:
-                type: string
-                default_all: 0.3 deg
-                default_3d: 0.3 deg
+            offset_max: {type: string}
+            psf_max_radius: {type: string}
             axes:
                 type: object
-                default_all: {}
-                default_basic: {}
-                default_1d: {}
-                default_3d: {}
                 additionalProperties: false
                 properties:
                     e_reco:
                         type: object
-                        default_all: {}
-                        default_3d: {}
                         additionalProperties: false
                         properties:
-                            name:
-                                type: string
-                                default_all: e_reco
-                                default_3d: energy
-                            lo_bnd:
-                                type: number
-                                default_all: 0.01
-                                default_3d: 1
-                            hi_bnd:
-                                type: number
-                                default_all: 100
-                                default_3d: 10
-                            nbin:
-                                type: number
-                                default_all: 73
-                                default_3d: 4
-                            unit:
-                                type: string
-                                default_all: TeV
-                                default_3d: TeV
+                            name: {type: string}
+                            lo_bnd: {type: number}
+                            hi_bnd: {type: number}
+                            nbin: {type: number}
+                            unit: {type: string}
                             interp:
                                 type: string
-                                default_all: log
-                                default_3d: log
                                 enum: [lin, log, sqrt]
                             node_type:
                                 type: string
-                                default_all: center
-                                default_3d: edges
                                 enum: [edges, center]
                         required: [lo_bnd, hi_bnd, nbin, unit]
                     e_true:
                         type: object
-                        default_all: {}
                         additionalProperties: false
                         properties:
-                            name: {type: string, default_all: e_true}
-                            lo_bnd: {type: number, default_all: 0.01}
-                            hi_bnd: {type: number, default_all: 315}
-                            nbin: {type: number, default_all: 109}
-                            unit: {type: string, default_all: TeV}
+                            name: {type: string}
+                            lo_bnd: {type: number}
+                            hi_bnd: {type: number}
+                            nbin: {type: number}
+                            unit: {type: string}
                             interp:
                                 type: string
-                                default_all: log
                                 enum: [lin, log, sqrt]
                             node_type:
                                 type: string
-                                default_all: center
                                 enum: [edges, center]
                         required: [lo_bnd, hi_bnd, nbin, unit]
 
@@ -411,99 +294,23 @@ properties:
 #
     model:
         type: object
-        default_all: {}
-        default_basic: {}
-        default_1d: {}
-        default_3d: {}
         additionalProperties: false
         properties:
             components:
                 type: array
-                default_all: [{}]
-                default_basic: [{}]
-                default_1d: [{}]
-                default_3d: [{}]
                 items:
                     type: object
                     additionalProperties: false
                     properties:
-                        name:
-                            type: string
-                            default_all: source
-                            default_basic: source
-                            default_1d: source
-                            default_3d: source
-                        type:
-                            type: string
-                            default_all: SkyModel
-                            default_basic: SkyModel
-                            default_1d: SkyModel
-                            default_3d: SkyModel
+                        name: {type: string}
+                        type: {type: string}
                         spatial:
                             type: object
-                            default_all: {}
-                            default_1d: {}
-                            default_3d: {}
                             additionalProperties: false
                             properties:
-                                type:
-                                    type: string
-                                    default_all: SkyGaussian
-                                    default_1d: SkyPointSource
-                                    default_3d: SkyPointSource
+                                type: {type: string}
                                 parameters:
                                     type: array
-                                    default_all:
-                                        - factor: 0.0
-                                          frozen: false
-                                          max: 180.0
-                                          min: -180.0
-                                          name: lon_0
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 0.0
-                                        - factor: 0.0
-                                          frozen: false
-                                          max: 90.0
-                                          min: -90.0
-                                          name: lat_0
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 0.0
-                                        - factor: 1.0
-                                          frozen: false
-                                          max: .nan
-                                          min: 0.0
-                                          name: sigma
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 1.0
-                                    default_1d:
-                                        - frozen: true
-                                          name: lon_0
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 83.633
-                                        - frozen: true
-                                          name: lat_0
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 22.14
-                                    default_3d:
-                                        - frozen: false
-                                          name: lon_0
-                                          max: 85
-                                          min: 80
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 83.633
-                                        - frozen: false
-                                          name: lat_0
-                                          max: 24
-                                          min: 20
-                                          scale: 1.0
-                                          unit: deg
-                                          value: 22.14
                                     items:
                                         type: object
                                         additionalProperties: false
@@ -518,99 +325,11 @@ properties:
                                             frozen: {type: boolean}
                         spectral:
                             type: object
-                            default_all: {}
-                            default_basic: {}
-                            default_1d: {}
-                            default_3d: {}
                             additionalProperties: false
                             properties:
-                                type:
-                                    type: string
-                                    default_all: PowerLaw
-                                    default_1d: PowerLaw
-                                    default_3d: PowerLaw
+                                type: {type: string}
                                 parameters:
                                     type: array
-                                    default_all:
-                                        - factor: 2.0
-                                          frozen: false
-                                          name: index
-                                          scale: 1.0
-                                          unit: ''
-                                          value: 2.0
-                                        - factor: 1.0e-12
-                                          frozen: false
-                                          max: .nan
-                                          min: .nan
-                                          name: amplitude
-                                          scale: 1.0
-                                          unit: cm-2 s-1 TeV-1
-                                          value: 1.0e-12
-                                        - factor: 1.0
-                                          frozen: true
-                                          max: .nan
-                                          min: .nan
-                                          name: reference
-                                          scale: 1.0
-                                          unit: TeV
-                                          value: 1.0
-                                    default_basic:
-                                        - factor: 2.0
-                                          frozen: false
-                                          name: index
-                                          scale: 1.0
-                                          unit: ''
-                                          value: 2.0
-                                        - factor: 1.0e-12
-                                          frozen: false
-                                          name: amplitude
-                                          scale: 1.0
-                                          unit: cm-2 s-1 TeV-1
-                                          value: 1.0e-12
-                                        - factor: 1.0
-                                          frozen: true
-                                          name: reference
-                                          scale: 1.0
-                                          unit: TeV
-                                          value: 1.0
-                                    default_1d:
-                                        - factor: 2.0
-                                          frozen: false
-                                          name: index
-                                          scale: 1.0
-                                          unit: ''
-                                          value: 2.0
-                                        - factor: 1.0e-12
-                                          frozen: false
-                                          name: amplitude
-                                          scale: 1.0
-                                          unit: cm-2 s-1 TeV-1
-                                          value: 1.0e-12
-                                        - factor: 1.0
-                                          frozen: true
-                                          name: reference
-                                          scale: 1.0
-                                          unit: TeV
-                                          value: 1.0
-                                    default_3d:
-                                        - factor: 2.0
-                                          frozen: false
-                                          name: index
-                                          scale: 1.0
-                                          unit: ''
-                                          value: 2.6
-                                        - factor: 1.0e-12
-                                          frozen: false
-                                          name: amplitude
-                                          scale: 1.0
-                                          unit: cm-2 s-1 TeV-1
-                                          value: 5.0e-11
-                                        - factor: 1.0
-                                          frozen: true
-                                          name: reference
-                                          scale: 1.0
-                                          unit: TeV
-                                          value: 1.0
                                     items:
                                         type: object
                                         additionalProperties: false
@@ -634,26 +353,13 @@ properties:
     fit:
         type: object
         additionalProperties: false
-        default_all: {}
-        default_basic: {}
-        default_1d: {}
-        default_3d: {}
         properties:
             fit_range:
                 type: object
-                default_all: {}
-                default_basic: {}
-                default_1d: {}
                 additionalProperties: false
                 properties:
-                    min:
-                        type: number
-                        default_all: 1 TeV
-                        default_1d: 1 TeV
-                    max:
-                        type: number
-                        default_all: 100 TeV
-                        default_1d: 100 TeV
+                    min: {type: number}
+                    max: {type: number}
                 dependencies:
                     min: [max]
                     max: [min]
@@ -673,25 +379,9 @@ properties:
     flux:
         type: object
         additionalProperties: false
-        default_all: {}
-        default_basic: {}
-        default_1d: {}
-        default_3d: {}
         properties:
             fp_binning:
                 type: object
-                default_all:
-                    lo_bnd: 1
-                    hi_bnd: 10
-                    nbin: 11
-                    unit: TeV
-                    interp: log
-                default_1d:
-                    lo_bnd: 1
-                    hi_bnd: 10
-                    nbin: 11
-                    unit: TeV
-                    interp: log
                 additionalProperties: false
                 properties:
                     name: {type: string}

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -46,7 +46,7 @@ properties:
                 required: [level]
                 dependencies:
                     filemode: [filename]
-        required: [logging]
+        required: [outdir, logging]
 
 # Block: observations
 # Observations used in the analysis
@@ -186,6 +186,7 @@ properties:
             data_reducer:
                 enum: [not assigned, 1d, 2d, 3d]
             containment_correction: {type: boolean}
+        required: [data_reducer]
         if:
             properties:
                 data_reducer:
@@ -286,6 +287,7 @@ properties:
                                 type: string
                                 enum: [edges, center]
                         required: [lo_bnd, hi_bnd, nbin, unit]
+        required: [axes]
 
 # Block: model
 # Parameters that define the models used in the analysis process

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -150,8 +150,9 @@ def test_analysis_3d():
 
 
 def test_validate_astropy_quantities():
-    config = {"observations": {"filters": [{"lon": "1 deg"}]}}
-    analysis = Analysis(config)
+    analysis = Analysis()
+    config = {"observations": {"filters": [{"filter_type": "all", "lon": "1 deg"}]}}
+    analysis.config.update_settings(config)
     assert analysis.config.validate() is None
 
 


### PR DESCRIPTION
This PR addresses some/most of the points discussed in last developers call concerning refactoring and handling of templates for default configuration settings. The main idea is to use several YAML files as templates for the default values of config settings, instead of a single centralized `schema.yaml` file, hoping that maintenance of several simple files will be easier than for a single complex centralized file. The `schema.yaml` will now only be used to validate the values of the settings provided by the user via the interface or custom config file. 

The dump of the settings to a file with `analysis.config.dump()` writes only the YAML formatted param/values of the settings, not commented helping lines are provided in the dump. 

It remains the question of how to provide clear documentation for the format and structure of the parameter/values in the configuration settings. The commented helping lines in the internal `schema.yaml` file have been kept, these are used to generate the different sections of the docs on config settings and also in the `analysis.config.print_help()` method.

Another issue that have to be solved is how to link to YAML files describing the models, in the `schema.yaml` file used for validation. Do we already use a mechanism to validate the param/values of YAML serialized models?

