### PR TITLE
Fix fgst ccube format unit handling

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -79,10 +79,10 @@ def make_axes_cols(axes, axis_names=None):
 
 def energy_axis_from_fgst_ccube(hdu):
     bands = Table.read(hdu)
-    edges_min = bands["E_MIN"].data
-    edges_max = bands["E_MAX"].data
+    edges_min = bands["E_MIN"].quantity
+    edges_max = bands["E_MAX"].quantity
     edges = edges_from_lo_hi(edges_min, edges_max)
-    return [MapAxis.from_edges(edges=edges, name="energy", unit="MeV", interp="log")]
+    return [MapAxis.from_edges(edges=edges, name="energy", interp="log")]
 
 
 def energy_axis_from_fgst_template(hdu):

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -113,6 +113,14 @@ def test_wcsndmap_read_write_fgst(tmpdir):
         assert "ENERGIES" in h
 
 
+@requires_data()
+def test_wcsndmap_read_ccube():
+    counts = Map.read("$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-counts-cube.fits.gz")
+    energy_axis = counts.geom.get_axis_by_name("energy")
+    # for the 3FGL data the lower energy threshold should be at 10 GeV
+    assert_allclose(energy_axis.edges.min().to_value("GeV"), 10, rtol=1e-3)
+
+
 def test_wcs_nd_map_data_transpose_issue(tmpdir):
     # Regression test for https://github.com/gammapy/gammapy/issues/1346
 


### PR DESCRIPTION
This PR fixes a bug reported by @QRemy in private communication. The error was introduced in #2379, because of confusing meta information in the Fermi counts cube files. While the primary header specifies `MeV` as a unit for the third axis, the `EBOUNDS` table actually uses `keV`.
A regression test was also added.