### PR TITLE
Implement `Analysis` stack-datasets option

### DIFF
--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -279,15 +279,17 @@ class Analysis:
 
         return maker.run()
 
-    @staticmethod
-    def _extract_irf_kernels(dataset):
-        #TODO: handle IRF maps in fit
+    def _extract_irf_kernels(self, dataset):
+        # TODO: remove hard-coded default value
+        max_radius = self.settings["reduction"].get("psf-kernel-radius", "0.5 deg")
+
+        # TODO: handle IRF maps in fit
         geom = dataset.counts.geom
         geom_irf = dataset.exposure.geom
 
         position = geom.center_skydir
         geom_psf = geom.to_image().to_cube(geom_irf.axes)
-        dataset.psf = dataset.psf.get_psf_kernel(position=position, geom=geom_psf, max_radius="0.5 deg")
+        dataset.psf = dataset.psf.get_psf_kernel(position=position, geom=geom_psf, max_radius=max_radius)
 
         e_reco = geom.get_axis_by_name("energy").edges
         dataset.edisp = dataset.edisp.get_energy_dispersion(position=position, e_reco=e_reco)

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -511,23 +511,18 @@ class AnalysisConfig:
                 self._update_settings(val, target[key])
 
 
+def is_quantity(instance):
+    try:
+        _ = u.Quantity(instance)
+        return True
+    except ValueError:
+        return False
+
+
 def _astropy_quantity(_, instance):
     """Check a number may also be an astropy quantity."""
-    quantity = str(instance).split()
-    if len(quantity) >= 2:
-        value = str(instance).split()[0]
-        unit = "".join(str(instance).split()[1:])
-        try:
-            return u.Quantity(float(value), unit).unit.physical_type != "dimensionless"
-        except ValueError:
-            log.error("{} is not a valid astropy quantity.".format(str(instance)))
-            raise ValueError("Not a valid astropy quantity.")
-    else:
-        try:
-            number = float(instance)
-        except ValueError:
-            number = instance
-        return jsonschema.Draft7Validator.TYPE_CHECKER.is_type(number, "number")
+    is_number = jsonschema.Draft7Validator.TYPE_CHECKER.is_type(instance, "number")
+    return is_number or is_quantity(instance)
 
 
 _type_checker = jsonschema.Draft7Validator.TYPE_CHECKER.redefine(

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -196,13 +196,14 @@ properties:
                             required: [filename]
             dataset-type:
                 enum: [not assigned, SpectrumDatasetOnOff, MapDataset]
+            stack-datasets: {type: boolean}
             containment_correction: {type: boolean}
             offset-max: {type: number}
             geom:
                 "$ref": "#/definitions/map_geom"
             geom-irf:
                 "$ref": "#/definitions/map_geom"
-        required: [dataset-type, geom]
+        required: [dataset-type, geom, stack-datasets]
         if:
             properties:
                 dataset-type:
@@ -212,6 +213,12 @@ properties:
             properties:
                 background:
                     required: [background_estimator]
+        if:
+            properties:
+                dataset-type:
+                    const: MapDataset
+        then:
+            required: [offset-max]
 
 
 # Block: model

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -199,6 +199,7 @@ properties:
             stack-datasets: {type: boolean}
             containment_correction: {type: boolean}
             offset-max: {type: number}
+            psf-kernel-radius: {type: number}
             geom:
                 "$ref": "#/definitions/map_geom"
             geom-irf:

--- a/gammapy/scripts/config/template-1d.yaml
+++ b/gammapy/scripts/config/template-1d.yaml
@@ -13,6 +13,7 @@ observations:
 
 reduction:
     dataset-type: SpectrumDatasetOnOff
+    stack-datasets: false
     background:
         background_estimator: reflected
     geom:

--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -13,6 +13,7 @@ observations:
 
 reduction:
     dataset-type: MapDataset
+    stack-datasets: true
     offset-max: 2.5 deg
     geom:
         skydir: [83.633, 22.014]

--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -31,7 +31,7 @@ reduction:
     geom-irf:
         skydir: [83.633, 22.014]
         width: [5, 5]
-        binsz: 0.02
+        binsz: 0.2
         coordsys: CEL
         proj: TAN
         axes:

--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -15,6 +15,7 @@ reduction:
     dataset-type: MapDataset
     stack-datasets: true
     offset-max: 2.5 deg
+    psf-kernel-radius: 0.3 deg
     geom:
         skydir: [83.633, 22.014]
         width: [5, 5]

--- a/gammapy/scripts/config/template-basic.yaml
+++ b/gammapy/scripts/config/template-basic.yaml
@@ -11,6 +11,7 @@ observations:
 
 reduction:
     dataset-type: not assigned
+    stack-datasets: true
     geom:
         region: {}
         axes: []

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -141,6 +141,24 @@ def test_analysis_1d(config_analysis_data):
 
 @requires_dependency("iminuit")
 @requires_data()
+def test_analysis_1d_stacked():
+    analysis = Analysis.from_template(template="1d")
+    analysis.config.settings["reduction"]["stack-datasets"] = True
+    analysis.get_observations()
+    analysis.get_datasets()
+    analysis.get_model()
+    analysis.run_fit()
+
+    assert len(analysis.datasets.datasets) == 1
+    assert_allclose(analysis.datasets["stacked"].counts.data.sum(), 404)
+    pars = analysis.fit_result.parameters
+
+    assert_allclose(pars["index"].value, 2.689559, rtol=1e-3)
+    assert_allclose(pars["amplitude"].value, 2.81629e-11, rtol=1e-3)
+
+
+@requires_dependency("iminuit")
+@requires_data()
 def test_analysis_3d():
     analysis = Analysis.from_template(template="3d")
     analysis.get_observations()

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -146,6 +146,7 @@ def test_analysis_3d():
     analysis.get_observations()
     analysis.get_datasets()
     analysis.get_model()
+    analysis.datasets["stacked"].background_model.tilt.frozen = False
     analysis.run_fit()
     assert len(analysis.datasets.datasets) == 1
     assert len(analysis.fit_result.parameters.parameters) == 8

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -143,7 +143,7 @@ def test_analysis_1d(config_analysis_data):
 @requires_data()
 def test_analysis_1d_stacked():
     analysis = Analysis.from_template(template="1d")
-    analysis.config.settings["reduction"]["stack-datasets"] = True
+    analysis.settings["reduction"]["stack-datasets"] = True
     analysis.get_observations()
     analysis.get_datasets()
     analysis.get_model()

--- a/tutorials/hess.ipynb
+++ b/tutorials/hess.ipynb
@@ -325,6 +325,7 @@
     "        background_estimator: reflected\n",
     "    containment_correction: true\n",
     "    dataset-type: SpectrumDatasetOnOff\n",
+    "    stack-datasets: false\n",
     "    geom:\n",
     "        region:\n",
     "          center:\n",


### PR DESCRIPTION
This PR finally implements the option to stack the datasets for the analysis or not. For the `MapDataset` it already make use of the new `MapDataset.stack()` method, but finally extracts only a single `PSFKernel` and `EnergyDispersion` object for the fitting.