### PR TITLE
Rename MapGeom base class to Geom

### DIFF
--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -24,9 +24,9 @@ non-spatial dimensions and can represent images (2D), cubes (3D), or hypercubes
   sphere. Pixels are equal area but have irregular shapes.
 
 `gammapy.maps` is organized around two data structures: *geometry* classes
-inheriting from `~MapGeom` and *map* classes inheriting from `~Map`. A geometry
+inheriting from `~Geom` and *map* classes inheriting from `~Map`. A geometry
 defines the map boundaries, pixelization scheme, and provides methods for
-converting to/from map and pixel coordinates. A map owns a `~MapGeom` instance
+converting to/from map and pixel coordinates. A map owns a `~Geom` instance
 as well as a data array containing map values. Where possible it is recommended
 to use the abstract `~Map` interface for accessing or updating the contents of a
 map as this allows algorithms to be used interchangeably with different map

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -21,7 +21,7 @@ def make_edisp_map(edisp, pointing, geom, max_offset, exposure_map=None):
         the 2D Energy Dispersion IRF
     pointing : `~astropy.coordinates.SkyCoord`
         the pointing direction
-    geom : `~gammapy.maps.MapGeom`
+    geom : `~gammapy.maps.Geom`
         the map geom to be used. It provides the target geometry.
         rad and true energy axes should be given in this specific order.
     max_offset : `~astropy.coordinates.Angle`

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -723,7 +723,7 @@ class MapEvaluator:
 
     @property
     def geom(self):
-        """True energy map geometry (`~gammapy.maps.MapGeom`)"""
+        """True energy map geometry (`~gammapy.maps.Geom`)"""
         return self.exposure.geom
 
     @property
@@ -748,7 +748,7 @@ class MapEvaluator:
             PSF map.
         edisp : `gammapy.cube.EDispMap`
             Edisp map.
-        geom : `gammapy.maps.MapGeom`
+        geom : `gammapy.maps.Geom`
             Reference geometry of the data.
         """
         log.debug("Updating model evaluator")

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -50,9 +50,9 @@ def _compute_kernel_separations(geom, factor):
 
 
 def table_psf_to_kernel_map(table_psf, geom, factor=4):
-    """Compute a PSF kernel on a given MapGeom.
+    """Compute a PSF kernel on a given Geom.
 
-    If the MapGeom is not an image, the same kernel will be present on all axes.
+    If the Geom is not an image, the same kernel will be present on all axes.
 
     The PSF is estimated by oversampling defined by a given factor.
     The PSF kernel is normalized
@@ -61,7 +61,7 @@ def table_psf_to_kernel_map(table_psf, geom, factor=4):
     ----------
     table_psf : `~gammapy.irf.TablePSF`
         the input table PSF
-    geom : `~gammapy.maps.MapGeom`
+    geom : `~gammapy.maps.Geom`
         the target geometry. The PSF kernel will be centered on the spatial center.
     factor : int
         the oversample factor to compute the PSF
@@ -79,7 +79,7 @@ def table_psf_to_kernel_map(table_psf, geom, factor=4):
 
 
 def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
-    """Compute an energy dependent PSF kernel on a given MapGeom.
+    """Compute an energy dependent PSF kernel on a given Geom.
 
     The PSF is estimated by oversampling defined by a given factor.
 
@@ -87,7 +87,7 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
     ----------
     table_psf : `~gammapy.irf.EnergyDependentTablePSF`
         the input table PSF
-    geom : `~gammapy.maps.MapGeom`
+    geom : `~gammapy.maps.Geom`
         the target geometry.
         The PSF kernel will be centered on the spatial centre.
         the geometry axes should contain an "energy" axis.
@@ -176,9 +176,9 @@ class PSFKernel:
 
     @classmethod
     def from_table_psf(cls, table_psf, geom, max_radius=None, factor=4):
-        """Create a PSF kernel from a TablePSF or an EnergyDependentTablePSF on a given MapGeom.
+        """Create a PSF kernel from a TablePSF or an EnergyDependentTablePSF on a given Geom.
 
-        If the MapGeom is not an image, the same kernel will be present on all axes.
+        If the Geom is not an image, the same kernel will be present on all axes.
 
         The PSF is estimated by oversampling defined by a given factor.
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -24,7 +24,7 @@ def make_psf_map(psf, pointing, geom, max_offset, exposure_map=None):
         the PSF IRF
     pointing : `~astropy.coordinates.SkyCoord`
         the pointing direction
-    geom : `~gammapy.maps.MapGeom`
+    geom : `~gammapy.maps.Geom`
         the map geom to be used. It provides the target geometry.
         rad and true energy axes should be given in this specific order.
     max_offset : `~astropy.coordinates.Angle`
@@ -253,13 +253,13 @@ class PSFMap:
     def get_psf_kernel(self, position, geom, max_radius=None, factor=4):
         """Returns a PSF kernel at the given position.
 
-        The PSF is returned in the form a WcsNDMap defined by the input MapGeom.
+        The PSF is returned in the form a WcsNDMap defined by the input Geom.
 
         Parameters
         ----------
         position : `~astropy.coordinates.SkyCoord`
             the target position. Should be a single coordinate
-        geom : `~gammapy.maps.MapGeom`
+        geom : `~gammapy.maps.Geom`
             the target geometry to use
         max_radius : `~astropy.coordinates.Angle`
             maximum angular size of the kernel map

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -483,7 +483,7 @@ class EventListBase:
 
         Parameters
         ----------
-        geom : `~gammapy.maps.MapGeom`
+        geom : `~gammapy.maps.Geom`
             the geom used to define the MapCoord
 
         Returns

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -21,7 +21,7 @@ class Map(abc.ABC):
 
     Parameters
     ----------
-    geom : `~gammapy.maps.MapGeom`
+    geom : `~gammapy.maps.Geom`
         Geometry
     data : `~numpy.ndarray`
         Data array
@@ -56,7 +56,7 @@ class Map(abc.ABC):
 
     @property
     def geom(self):
-        """Map geometry (`~gammapy.maps.MapGeom`)"""
+        """Map geometry (`~gammapy.maps.Geom`)"""
         return self._geom
 
     @geom.setter
@@ -189,11 +189,11 @@ class Map(abc.ABC):
     def from_geom(
         geom, meta=None, data=None, map_type="auto", unit="", dtype="float32"
     ):
-        """Generate an empty map from a `MapGeom` instance.
+        """Generate an empty map from a `Geom` instance.
 
         Parameters
         ----------
-        geom : `MapGeom`
+        geom : `Geom`
             Map geometry.
         data : `numpy.ndarray`
             data array
@@ -372,7 +372,7 @@ class Map(abc.ABC):
 
         Parameters
         ----------
-        geom : `MapGeom`
+        geom : `Geom`
             Geometry of projection.
         mode : {'interp', 'exact'}
             Method for reprojection.  'interp' method interpolates at pixel

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -13,7 +13,7 @@ from astropy.utils import lazyproperty
 from gammapy.utils.interpolation import interpolation_scale
 from .utils import INVALID_INDEX, edges_from_lo_hi, find_bands_hdu, find_hdu
 
-__all__ = ["MapCoord", "MapGeom", "MapAxis"]
+__all__ = ["MapCoord", "Geom", "MapAxis"]
 
 log = logging.getLogger(__name__)
 
@@ -1068,7 +1068,7 @@ class MapCoord:
 
         Parameters
         ----------
-        geom : `MapGeom`
+        geom : `Geom`
             Map geometry with specified units per axis.
 
         Returns
@@ -1088,7 +1088,7 @@ class MapCoord:
         return self.__class__(coords, coordsys=self.coordsys)
 
 
-class MapGeom(abc.ABC):
+class Geom(abc.ABC):
     """Map geometry base class.
 
     See also: `~gammapy.maps.WcsGeom` and `~gammapy.maps.HpxGeom`
@@ -1137,7 +1137,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Geometry object.
         """
         if hdu is None:
@@ -1371,7 +1371,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Sliced geometry.
         """
         axes = []
@@ -1390,7 +1390,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Image geometry.
         """
         pass
@@ -1410,7 +1410,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Map geometry.
         """
         pass
@@ -1446,7 +1446,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Padded geometry.
         """
         pass
@@ -1463,7 +1463,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Cropped geometry.
         """
         pass
@@ -1481,7 +1481,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Downsampled geometry.
 
         """
@@ -1500,7 +1500,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        geom : `~MapGeom`
+        geom : `~Geom`
             Upsampled geometry.
 
         """
@@ -1581,7 +1581,7 @@ class MapGeom(abc.ABC):
         return self.__class__(**kwargs)
 
     def copy(self, **kwargs):
-        """Copy `MapGeom` instance and overwrite given attributes.
+        """Copy and overwrite given attributes.
 
         Parameters
         ----------
@@ -1590,7 +1590,7 @@ class MapGeom(abc.ABC):
 
         Returns
         -------
-        copy : `MapGeom`
+        copy : `Geom`
             Copied map geometry.
         """
         return self._init_copy(**kwargs)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1089,7 +1089,10 @@ class MapCoord:
 
 
 class MapGeom(abc.ABC):
-    """Base class for WCS and HEALPix geometries."""
+    """Map geometry base class.
+
+    See also: `~gammapy.maps.WcsGeom` and `~gammapy.maps.HpxGeom`
+    """
 
     @property
     @abc.abstractmethod

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from astropy.units import Quantity
 from .geom import (
     MapCoord,
-    MapGeom,
+    Geom,
     coordsys_to_frame,
     find_and_read_bands,
     make_axes,
@@ -523,7 +523,7 @@ def get_subpixels(idx, nside_superpix, nside_subpix, nest=True):
     return idx
 
 
-class HpxGeom(MapGeom):
+class HpxGeom(Geom):
     """Geometry class for HEALPIX maps.
 
     This class performs mapping between partial-sky indices (pixel

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -11,7 +11,7 @@ from astropy.wcs.utils import proj_plane_pixel_scales
 from regions import SkyRegion
 from .geom import (
     MapCoord,
-    MapGeom,
+    Geom,
     axes_pix_to_coord,
     find_and_read_bands,
     get_shape,
@@ -159,7 +159,7 @@ def _make_image_header(
     return header
 
 
-class WcsGeom(MapGeom):
+class WcsGeom(Geom):
     """Geometry class for WCS maps.
 
     This class encapsulates both the WCS transformation object and the

--- a/tutorials/intro_maps.ipynb
+++ b/tutorials/intro_maps.ipynb
@@ -98,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `.geom` attribute is a `MapGeom` object, that defines the basic geometry of the map, such as size of the pixels, width and height of the image, coordinate system etc., but we will learn more about this object later.\n",
+    "The `.geom` attribute is a `Geom` object, that defines the basic geometry of the map, such as size of the pixels, width and height of the image, coordinate system etc., but we will learn more about this object later.\n",
     "\n",
     "Besides the `.geom` attribute the map has also a `.data` attribute, which is just a plain `numpy.ndarray` and stores the data associated with this map:"
    ]
@@ -147,7 +147,7 @@
    "source": [
     "### 1.2 Creating from a Map Geometry\n",
     "\n",
-    "As we have seen in the first examples, the `Map` object couples the data (stored as a `numpy.ndarray`) with a `MapGeom` object. The `MapGeom` object can be seen as a generalization of an `astropy.wcs.WCS` object, providing the information on how the data maps to physical coordinate systems. In some cases e.g. when creating many maps with the same WCS geometry it can be advantegeous to first create the map geometry independent of the map object itsself: "
+    "As we have seen in the first examples, the `Map` object couples the data (stored as a `numpy.ndarray`) with a `Geom` object. The `Geom` object can be seen as a generalization of an `astropy.wcs.WCS` object, providing the information on how the data maps to physical coordinate systems. In some cases e.g. when creating many maps with the same WCS geometry it can be advantegeous to first create the map geometry independent of the map object itsself: "
    ]
   },
   {
@@ -184,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `MapGeom` object also has a few helpful methods. E.g. we can check whether a given position on the sky is contained in the map geometry:"
+    "The `Geom` object also has a few helpful methods. E.g. we can check whether a given position on the sky is contained in the map geometry:"
    ]
   },
   {


### PR DESCRIPTION
@adonath @registerrier - as discussed yesterday, this PR renames the `MapGeom` base class to `Geom`.

It's a minor cleanup - IMO it gives a bit more consistency to the class names in `gammapy.maps` (sub-classes are `WcsGeom` and `HpxGeom`, not `WcsMapGeom` and `HpxMapGeom`), and IMO makes it a bit easier to see which classes are geom or map classes (see [here](https://docs.gammapy.org/0.13/maps/index.html#classes). Overall it's a very minor improvement. It shouldn't affect any user - it's just a base class name. The diff is small and simple, all tests pass locally.

![Screenshot 2019-09-26 at 09 10 29](https://user-images.githubusercontent.com/852409/65669239-7ad94200-e043-11e9-8866-44a049d9ac68.png)
