### PR TITLE
Change value clipping in `LogScale` class

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1218,16 +1218,14 @@ class TemplateSpectralModel(SpectralModel):
         self.reference = Parameter("reference", reference, frozen=True)
 
         self.energy = energy
-        exponents = np.floor(np.log10(np.abs(values.value)))
-        scale = max(exponents, key=abs)
-        self.values = u.Quantity(values.value / 10 ** scale, 10 ** scale * values.unit)
+        self.values = values
         self.meta = dict() if meta is None else meta
         interp_kwargs = interp_kwargs or {}
         interp_kwargs.setdefault("values_scale", "log")
         interp_kwargs.setdefault("points_scale", ("log",))
 
         self._evaluate = ScaledRegularGridInterpolator(
-            points=(energy,), values=self.values.value, **interp_kwargs
+            points=(energy,), values=values, **interp_kwargs
         )
 
         super().__init__([self.norm, self.tilt, self.reference])
@@ -1301,7 +1299,7 @@ class TemplateSpectralModel(SpectralModel):
 
     def evaluate(self, energy, norm, tilt, reference):
         """Evaluate the model (static function)."""
-        values = self._evaluate((energy,), clip=True) * self.values.unit
+        values = self._evaluate((energy,), clip=True)
         tilt_factor = np.power(energy / reference, -tilt)
         return norm * values * tilt_factor
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -426,7 +426,7 @@ def test_fermi_isotropic():
     assert_quantity_allclose(
         model(50 * u.GeV), 1.463 * u.Unit("1e-13 MeV-1 cm-2 s-1 sr-1"), rtol=1e-3
     )
-    
+
 
 def test_ecpl_integrate():
     # regression test to check the numerical integration for small energy bins
@@ -443,6 +443,21 @@ def test_pwl_pivot_energy():
     )
 
     assert_quantity_allclose(pwl.pivot_energy, 3.3540034240210987 * u.TeV)
+
+
+def test_TableModel_evaluate_tiny():
+    energy = np.array([1.00000000e06, 1.25892541e06, 1.58489319e06, 1.99526231e06])
+    values = np.array([4.39150790e-38, 1.96639562e-38, 8.80497507e-39, 3.94262401e-39])
+
+    model = TableModel(energy=energy, values=values * u.Unit("MeV-1 s-1 sr-1"))
+    result = model.evaluate(energy, norm=1.0, tilt=0.0, reference=1 * u.TeV)
+    tiny = np.finfo(np.float32).tiny
+    mask = abs(values) - tiny > tiny
+    np.testing.assert_allclose(
+        values[mask] / values.max(), result[mask].value / values.max()
+    )
+    mask = abs(result.value) - tiny <= tiny
+    assert np.all(result[mask] == 0.0)
 
 
 @requires_dependency("naima")

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -445,11 +445,11 @@ def test_pwl_pivot_energy():
     assert_quantity_allclose(pwl.pivot_energy, 3.3540034240210987 * u.TeV)
 
 
-def test_TableModel_evaluate_tiny():
+def test_TemplateSpectralModel_evaluate_tiny():
     energy = np.array([1.00000000e06, 1.25892541e06, 1.58489319e06, 1.99526231e06])
     values = np.array([4.39150790e-38, 1.96639562e-38, 8.80497507e-39, 3.94262401e-39])
 
-    model = TableModel(energy=energy, values=values * u.Unit("MeV-1 s-1 sr-1"))
+    model = TemplateSpectralModel(energy=energy, values=values * u.Unit("MeV-1 s-1 sr-1"))
     result = model.evaluate(energy, norm=1.0, tilt=0.0, reference=1 * u.TeV)
     tiny = np.finfo(np.float32).tiny
     mask = abs(values) - tiny > tiny

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -428,6 +428,15 @@ def test_fermi_isotropic():
     )
 
 
+def test_TableModel_evaluate_tiny():
+    energy = np.array([1.00000000e06, 1.25892541e06, 1.58489319e06, 1.99526231e06])
+    values = np.array([4.39150790e-38, 1.96639562e-38, 8.80497507e-39, 3.94262401e-39])
+
+    model = TableModel(energy=energy, values=values * u.Unit("MeV-1 s-1 sr-1"))
+    result = model.evaluate(energy, norm=1.0, tilt=0.0, reference=1 * u.TeV)
+    np.testing.assert_allclose(values / values.max(), result.value / values.max())
+
+
 def test_ecpl_integrate():
     # regression test to check the numerical integration for small energy bins
     ecpl = ExpCutoffPowerLawSpectralModel()

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -426,7 +426,7 @@ def test_fermi_isotropic():
     assert_quantity_allclose(
         model(50 * u.GeV), 1.463 * u.Unit("1e-13 MeV-1 cm-2 s-1 sr-1"), rtol=1e-3
     )
-
+    
 
 def test_ecpl_integrate():
     # regression test to check the numerical integration for small energy bins

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -426,16 +426,7 @@ def test_fermi_isotropic():
     assert_quantity_allclose(
         model(50 * u.GeV), 1.463 * u.Unit("1e-13 MeV-1 cm-2 s-1 sr-1"), rtol=1e-3
     )
-
-
-def test_TableModel_evaluate_tiny():
-    energy = np.array([1.00000000e06, 1.25892541e06, 1.58489319e06, 1.99526231e06])
-    values = np.array([4.39150790e-38, 1.96639562e-38, 8.80497507e-39, 3.94262401e-39])
-
-    model = TableModel(energy=energy, values=values * u.Unit("MeV-1 s-1 sr-1"))
-    result = model.evaluate(energy, norm=1.0, tilt=0.0, reference=1 * u.TeV)
-    np.testing.assert_allclose(values / values.max(), result.value / values.max())
-
+    
 
 def test_ecpl_integrate():
     # regression test to check the numerical integration for small energy bins

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -426,7 +426,7 @@ def test_fermi_isotropic():
     assert_quantity_allclose(
         model(50 * u.GeV), 1.463 * u.Unit("1e-13 MeV-1 cm-2 s-1 sr-1"), rtol=1e-3
     )
-    
+
 
 def test_ecpl_integrate():
     # regression test to check the numerical integration for small energy bins

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -139,7 +139,7 @@ class InterpolationScale:
 class LogScale(InterpolationScale):
     """Logarithmic scaling"""
 
-    tiny = np.finfo(np.float32).tiny
+    tiny = np.finfo(np.float64).tiny
 
     def _scale(self, values):
         values = np.clip(values, self.tiny, np.inf)

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -151,7 +151,10 @@ class LogScale(InterpolationScale):
         output = np.exp(values)
         is_tiny = abs(output) - self.tiny <= self.tiny
         if np.any(is_tiny):
-            output[is_tiny] = 0.0
+            try:
+                output[is_tiny] = 0.0
+            except(TypeError):
+                output = 0.0
             warnings.warn(
                 "Interpolated values reached float32 precision limit", Warning
             )

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -95,10 +95,7 @@ class ScaledRegularGridInterpolator:
             values = self.scale.inverse(values)
 
         tiny = np.finfo(np.float32).tiny
-        try:
-            mask = abs(values.value) - tiny <= tiny
-        except (AttributeError):
-            mask = abs(values) - tiny <= tiny
+        mask = abs(values.value) - tiny <= tiny
         if np.any(mask):
             values[mask] = 0.0
             warnings.warn(

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -95,7 +95,10 @@ class ScaledRegularGridInterpolator:
             values = self.scale.inverse(values)
 
         tiny = np.finfo(np.float32).tiny
-        mask = abs(values.value) - tiny <= tiny
+        try:
+            mask = abs(values.value) - tiny <= tiny
+        except (AttributeError):
+            mask = abs(values) - tiny <= tiny
         if np.any(mask):
             values[mask] = 0.0
             warnings.warn(

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -95,12 +95,18 @@ class ScaledRegularGridInterpolator:
             values = self.scale.inverse(values)
 
         tiny = np.finfo(np.float32).tiny
-        mask = abs(values.value) - tiny <= tiny
+        try:
+            mask = abs(values.value) - tiny <= tiny
+        except (AttributeError):
+            mask = values - tiny <= tiny
         if np.any(mask):
             values[mask] = 0.0
             warnings.warn(
                 "Interpolated values reached float32 precision limit", Warning
             )
+            # for example TableModel used to define a diffuse model
+            # could require large precision so users may want to redefine unit scaling.
+
         if clip:
             values = np.clip(values, 0, np.inf)
         return values


### PR DESCRIPTION
Change interpolation clipping to float64 precision
The clipping to float32 precision caused a bug when evaluating a table model containing the gamma-ray emissivity spectrum of the gas (that is <<10**-38/MeV/s/sr above 500GeV)