### PR TITLE
Minor cleanup of Analysis class #3

### DIFF
--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -33,6 +33,8 @@ an IPython console or a notebook.
     >>> analysis = Analysis()
         INFO:gammapy.scripts.analysis:Setting logging config: {'level': 'INFO'}
 
+Configuration and methods
+=========================
 You can have a look at the configuration settings provided by default, and also dump
 them into a file that you can edit to start a new analysis from the modified config file.
 
@@ -43,18 +45,30 @@ them into a file that you can edit to start a new analysis from the modified con
     INFO:gammapy.scripts.analysis:Configuration settings saved into config.yaml
     >>> analysis = Analysis.from_yaml("config.yaml")
 
-You could also have started with a builtin analysis configuration and extend it with
+You may choose to start an analysis using a predefined **settings template**. If no
+value for the settings template is provided, the `basic` template will be used by default.
+You may dump these settings into a file, edit the file and re-initialize your settings
+from the modified file.
+
+.. code-block:: python
+
+    >>> analysis = Analysis.from_template("1d")
+    >>> analysis.config.to_yaml("config.yaml")
+    >>> analysis = Analysis.from_yaml("config.yaml")
+
+You could also have started with a built-in analysis configuration and extend it with
 with your custom settings declared in a Python nested dictionary. Note how the nested
-dictionary must follow the parameters hierarchical structure which may be prone to errors.
+dictionary must follow the hierarchical structure of the parameters. Declaring the
+configuration settings of the analysis in this way may be tedious and prone to errors
+if you have several parameters to set, so we suggest you to proceed using a configuration
+file.
 
 .. code-block:: python
 
     >>> config_dict = {"general": {"logging": {"level": "WARNING"}}}
-    >>> analysis = Analysis()
+    >>> analysis = Analysis("3d")
     >>> analysis.config.update_settings(config_dict)
 
-Configuration and methods
-=========================
 The hierarchical structure of the tens of parameters needed may be hard to follow. You can
 print at any moment a *how-to* documentation with example values for all the sections and
 parameters or only for one specific section or group of parameters.
@@ -63,17 +77,6 @@ parameters or only for one specific section or group of parameters.
 
     >>> analysis.config.print_help()
     >>> analysis.config.print_help("flux")
-
-You may also choose to start an analysis using a predefined **settings template**. If no
-value for the settings template is provided, the basic template will be used by default.
-As we have seen before you may dump these settings into a file, edit the file and
-re-initialize your settings from the modified file.
-
-.. code-block:: python
-
-    >>> analysis = Analysis.from_template(template="1d")
-    >>> analysis.config.to_yaml("config.yaml")
-    >>> analysis = Analysis.from_yaml("config.yaml")
 
 At any moment you can change the value of one specific parameter needed in the analysis. Note
 that it is a good practice to validate your settings when you modify the value of parameters.
@@ -85,12 +88,14 @@ that it is a good practice to validate your settings when you modify the value o
 
 It is also possible to add new configuration parameters and values or overwrite the ones already
 defined in your session analysis. In this case you may use the `config.update_settings()` method
-using a custom nested dictionary:
+using a custom nested dictionary or custom YAML file (i.e. re-use a config file for specific
+sections and/or from a previous analysis).:
 
 .. code-block:: python
 
     >>> config_dict = {"observations": {"datastore": "$GAMMAPY_DATA/hess-dl3-dr1"}}
     >>> analysis.config.update_settings(config=config_dict)
+    >>> analysis.config.update_settings(configfile="fit.yaml")
 
 In the following you may find more detailed information on the different sections which
 compose the YAML formatted nested configuration settings hierarchy.
@@ -127,8 +132,10 @@ Data reduction and datasets
 ---------------------------
 The data reduction process needs a choice of a dataset type, declared as the class name
 (MapDataset, SpectrumDatasetOnOff) in the `reduction` section of the settings. For the
-estimation of the background, a `background_estimator` is needed, other parameters
-related with the `on_region` and `exclusion_mask` FITS file may be also present.
+estimation of the background with a dataset type SpectrumDatasetOnOff, a `background_estimator`
+is needed, other parameters related with the `on_region` and `exclusion_mask` FITS file
+may be also present. Parameters for geometry are also needed and declared in this section,
+as well as a boolean flag `stack-datasets`.
 
 .. gp-howto-hli:: reduction
 
@@ -156,6 +163,8 @@ stored in the `background_estimator` property.
 Model
 -----
 For now we simply declare the model as a reference to a separate yaml file.
+You may use the `get_model()` method to fetch the model and attach it to your
+datasets.
 
 Fitting
 -------

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -489,7 +489,11 @@ class AnalysisConfig:
     def validate(self):
         """Validate and/or fill initial config parameters against schema."""
         validator = _gp_units_validator
-        jsonschema.validate(self.settings, read_yaml(SCHEMA_FILE), validator)
+        try:
+            jsonschema.validate(self.settings, read_yaml(SCHEMA_FILE), validator)
+        except jsonschema.exceptions.ValidationError as ex:
+            log.error('Error when validating configuration parameters against schema.')
+            log.error(ex.message)
 
     @staticmethod
     def _get_doc_sections():

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -500,7 +500,7 @@ class AnalysisConfig:
         """Returns dict with commented docs from schema"""
         doc = defaultdict(str)
         with open(SCHEMA_FILE) as f:
-            for line in filter(lambda line: line.startswith("#"), f):
+            for line in filter(lambda line: line.startswith("# "), f):
                 line = line.strip("\n")
                 if line.startswith("# Block: "):
                     keyword = line.replace("# Block: ", "")

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -91,7 +91,7 @@ class Analysis:
         return self.config.settings
 
     def run_fit(self, optimize_opts=None):
-        """Fitting reduced data sets to model."""
+        """Fitting reduced datasets to model."""
         if self._validate_fitting_settings():
             for ds in self.datasets.datasets:
                 # TODO: fit_range handled in jsonschema validation class
@@ -103,7 +103,7 @@ class Analysis:
                     else:
                         ds.mask_fit = ds.counts.energy_mask(e_min, e_max)
 
-            log.info("Fitting reduced data sets.")
+            log.info("Fitting reduced datasets.")
             self.fit = Fit(self.datasets)
             self.fit_result = self.fit.run(optimize_opts=optimize_opts)
             log.info(self.fit_result)
@@ -143,7 +143,7 @@ class Analysis:
         return cls.from_yaml(filename)
 
     def get_datasets(self):
-        """Produce reduced data sets."""
+        """Produce reduced datasets."""
         if not self._validate_reduction_settings():
             return False
         if self.settings["reduction"]["dataset-type"] == "SpectrumDatasetOnOff":
@@ -240,7 +240,7 @@ class Analysis:
         return WcsGeom.create(**geom_params)
 
     def _map_making(self):
-        """Make maps and data sets for 3d analysis."""
+        """Make maps and datasets for 3d analysis."""
         geom = self._create_geometry(self.settings["reduction"]["geom"])
         geom_irf = self._create_geometry(self.settings["reduction"]["geom-irf"])
         offset_max = Angle(self.settings["reduction"]["offset-max"])
@@ -323,7 +323,7 @@ class Analysis:
     def _spectrum_extraction(self):
         """Run all steps for the spectrum extraction."""
         region = self.settings["reduction"]["geom"]["region"]
-        log.info("Reducing spectrum data sets.")
+        log.info("Reducing spectrum datasets.")
         on_lon = Angle(region["center"][0])
         on_lat = Angle(region["center"][1])
         on_center = SkyCoord(on_lon, on_lat, frame=region["frame"])

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -375,6 +375,7 @@ class Analysis:
 
     def _validate_fitting_settings(self):
         """Validate settings before proceeding to fit 1D."""
+        valid = True
         if self.datasets.datasets:
             if (self.extraction and
                 self.settings["reduction"]["background"]["background_estimator"]
@@ -384,11 +385,15 @@ class Analysis:
                 log.info("Background estimation only for reflected regions method.")
                 return False
             self.config.validate()
-            return True
         else:
             log.info("No datasets reduced.")
+            valid = False
+        if not self.model:
+            log.info("No model fetched for datasets.")
+            valid = False
+        if not valid:
             log.info("Fit cannot be done.")
-            return False
+        return valid
 
     def _validate_fp_settings(self):
         """Validate settings before proceeding to flux points estimation."""

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -484,7 +484,7 @@ class AnalysisConfig:
         if len(config):
             self._user_settings.update(config)
             self._update_settings(config, self.settings)
-            self.validate()
+        self.validate()
 
     def validate(self):
         """Validate and/or fill initial config parameters against schema."""

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -241,10 +241,12 @@ class Analysis:
 
     def _map_making(self):
         """Make maps and datasets for 3d analysis."""
+        log.info("Creating geometry.")
         geom = self._create_geometry(self.settings["reduction"]["geom"])
         geom_irf = self._create_geometry(self.settings["reduction"]["geom-irf"])
         offset_max = Angle(self.settings["reduction"]["offset-max"])
         stack_datasets = self.settings["reduction"]["stack-datasets"]
+        log.info("Creating datasets.")
 
         if stack_datasets:
             stacked = MapDataset.create(geom=geom, geom_irf=geom_irf, name="stacked")
@@ -376,7 +378,7 @@ class Analysis:
     def _validate_fitting_settings(self):
         """Validate settings before proceeding to fit 1D."""
         valid = True
-        if self.datasets.datasets:
+        if self.datasets and self.datasets.datasets:
             if (self.extraction and
                 self.settings["reduction"]["background"]["background_estimator"]
                 != "reflected"
@@ -397,13 +399,19 @@ class Analysis:
 
     def _validate_fp_settings(self):
         """Validate settings before proceeding to flux points estimation."""
+        valid = True
         if self.fit:
             self.config.validate()
-            return True
         else:
             log.info("No results available from fit.")
+            valid = False
+        if "fp_binning" not in self.settings["flux"]:
+            log.info("No values declared for the energy bins.")
+            valid = False
+        if not valid:
             log.info("Flux points calculation cannot be done.")
-            return False
+
+        return valid
 
     def _validate_reduction_settings(self):
         """Validate settings before proceeding to data reduction."""

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -154,11 +154,16 @@ class Analysis:
             # TODO raise error?
             log.info("Data reduction method not available.")
 
-    def get_flux_points(self):
-        """Calculate flux points."""
+    def get_flux_points(self, source="source"):
+        """Calculate flux points for a specific model component.
+
+        Parameters
+        ----------
+        source : string
+            Name of the model component where to calculate the flux points.
+        """
         if self._validate_fp_settings():
             # TODO: add "source" to config
-            source = "source"
             log.info("Calculating flux points.")
 
             axis_params = self.settings["flux"]["fp_binning"]

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -134,6 +134,9 @@ properties:
 #    Chosen dataset type
 #    dataset-type: SpectrumDatasetOnOff, MapDataset
 #
+#    Stack datasets flag
+#    stack-datasets: False
+#
 #    Parameters used in the estimation of the background
 #    Example values for the following properties
 #    background:
@@ -151,6 +154,8 @@ properties:
 #
 #        containment_correction: true
 #
+#    Geometry settings for the analysis
+#    Note that there may be different values for geom and geom-irf
 #    geom:
 #        Map pixel size in degrees
 #        binsz: 0.02

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -223,26 +223,27 @@ properties:
 
 
 # Block: model
-# Parameters that define the models used in the analysis process
-# List of models with spatial and /or spectral components
-# TODO
+# Filename containing the YAML definition of your model.
 #
+#   model: model.yaml
+
     model: {type: string}
-#        type: object
-#        additionalProperties: false
-#        properties:
-#            components:
-#                type: array
-#                items:
-#                    type: object
-#                    additionalProperties: false
-#                    properties:
-#                        name: {type: string}
-#                        type: {type: string}
-#                        spatial:
-#                            "$ref": "#/definitions/model_components"
-#                        spectral:
-#                            "$ref": "#/definitions/model_components"
+
+##        type: object
+##        additionalProperties: false
+##        properties:
+##            components:
+##                type: array
+##                items:
+##                    type: object
+##                    additionalProperties: false
+##                    properties:
+##                        name: {type: string}
+##                        type: {type: string}
+##                        spatial:
+##                            "$ref": "#/definitions/model_components"
+##                        spectral:
+##                            "$ref": "#/definitions/model_components"
 
 # Block: fit
 # Parameters that are used in the fitting process

--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -26,7 +26,7 @@ reduction:
           - name: energy
             hi_bnd: 10
             lo_bnd: 1
-            nbin: 4
+            nbin: 11
             interp: log
             node_type: edges
             unit: TeV
@@ -47,6 +47,15 @@ reduction:
 
 model: model.yaml
 
-fit: {}
+fit:
+    fit_range:
+        max: 100 TeV
+        min: 1 TeV
 
-flux: {}
+flux:
+    fp_binning:
+        hi_bnd: 10
+        interp: log
+        lo_bnd: 1
+        nbin: 11
+        unit: TeV

--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -26,7 +26,7 @@ reduction:
           - name: energy
             hi_bnd: 10
             lo_bnd: 1
-            nbin: 11
+            nbin: 4
             interp: log
             node_type: edges
             unit: TeV
@@ -47,15 +47,12 @@ reduction:
 
 model: model.yaml
 
-fit:
-    fit_range:
-        max: 100 TeV
-        min: 1 TeV
+fit: {}
 
 flux:
     fp_binning:
         hi_bnd: 10
         interp: log
         lo_bnd: 1
-        nbin: 11
+        nbin: 2
         unit: TeV

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -166,10 +166,18 @@ def test_analysis_3d():
     analysis.get_model()
     analysis.datasets["stacked"].background_model.tilt.frozen = False
     analysis.run_fit()
+    analysis.get_flux_points()
+
     assert len(analysis.datasets.datasets) == 1
     assert len(analysis.fit_result.parameters.parameters) == 8
     res = analysis.fit_result.parameters.parameters
     assert res[3].unit == "cm-2 s-1 TeV-1"
+    assert len(analysis.flux_points_dataset.data.table) == 2
+    dnde = analysis.flux_points_dataset.data.table["dnde"].quantity
+    print(dnde[0].value, dnde[-1].value)
+
+    assert_allclose(dnde[0].value, 1.175e-11, rtol=1e-1)
+    assert_allclose(dnde[-1].value, 4.061e-13, rtol=1e-1)
     assert_allclose(res[5].value, 2.920, rtol=1e-1)
     assert_allclose(res[6].value, -1.983e-02, rtol=1e-1)
 


### PR DESCRIPTION
This PR is a follow up to #2397. It implements the following changes: 

- Provide a shorter and more explicit error message on validation of settings with `json-schema`.
- Always validate settings when updating with `config.update_settings` method.
- Print only single-# comments in `config.print_help()` to avoid printing undesired other comments as help (yes, we need to handle help display in a different way in the future..)
- Add validation for non-empty model in `run_fit()`
- Improve documentation and consistency in docstrings.
- Add validation for non-empty `fp_binning` in `get_flux_points`method.
- Add a default parameter `source` in `get_flux_points`method.

In the meantime I've noticed that the flux points binning used for `MapDatasets` comes from the actual energy axis binning of the dataset, and does not use the `e_edges` param  of `FluxPointEstimator` method. I don't know if there's a reason for that.