### PR TITLE
Improve model registries and __all__ lists

### DIFF
--- a/gammapy/catalog/registry.py
+++ b/gammapy/catalog/registry.py
@@ -1,5 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.table import Table
+from .hess import SourceCatalogHGPS
+from .gammacat import SourceCatalogGammaCat
+from .fermi import SourceCatalog3FGL
+from .fermi import SourceCatalog1FHL
+from .fermi import SourceCatalog2FHL
+from .fermi import SourceCatalog3FHL
+from .hawc import SourceCatalog2HWC
 
 __all__ = ["source_catalogs", "SourceCatalogRegistry"]
 
@@ -22,37 +29,15 @@ class SourceCatalogRegistry:
     @classmethod
     def builtins(cls):
         """Create a catalog registry containing the built-in catalogs."""
-        source_catalogs = cls()
-
-        from .hess import SourceCatalogHGPS
-
-        source_catalogs.register("hgps", SourceCatalogHGPS)
-
-        from .gammacat import SourceCatalogGammaCat
-
-        source_catalogs.register("gamma-cat", SourceCatalogGammaCat)
-
-        from .fermi import SourceCatalog3FGL
-
-        source_catalogs.register("3fgl", SourceCatalog3FGL)
-
-        from .fermi import SourceCatalog1FHL
-
-        source_catalogs.register("1fhl", SourceCatalog1FHL)
-
-        from .fermi import SourceCatalog2FHL
-
-        source_catalogs.register("2fhl", SourceCatalog2FHL)
-
-        from .fermi import SourceCatalog3FHL
-
-        source_catalogs.register("3fhl", SourceCatalog3FHL)
-
-        from .hawc import SourceCatalog2HWC
-
-        source_catalogs.register("2hwc", SourceCatalog2HWC)
-
-        return source_catalogs
+        cats = cls()
+        cats.register("hgps", SourceCatalogHGPS)
+        cats.register("gamma-cat", SourceCatalogGammaCat)
+        cats.register("3fgl", SourceCatalog3FGL)
+        cats.register("1fhl", SourceCatalog1FHL)
+        cats.register("2fhl", SourceCatalog2FHL)
+        cats.register("3fhl", SourceCatalog3FHL)
+        cats.register("2hwc", SourceCatalog2HWC)
+        return cats
 
     @property
     def catalog_names(self):
@@ -104,9 +89,4 @@ class SourceCatalogRegistry:
 
 
 source_catalogs = SourceCatalogRegistry.builtins()
-"""Registry of built-in catalogs in Gammapy.
-
-The main point of the registry is to have one point that
-knows about all available catalogs and there's an easy way
-to load them.
-"""
+"""Registry of built-in catalogs in Gammapy."""

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -7,34 +7,70 @@ from .spectral_cosmic_ray import *
 from .spectral_crab import *
 from .temporal import *
 
-SPATIAL_MODELS = {
-    "ConstantSpatialModel": ConstantSpatialModel,
-    "TemplateSpatialModel": TemplateSpatialModel,
-    "DiskSpatialModel": DiskSpatialModel,
-    "GaussianSpatialModel": GaussianSpatialModel,
-    "PointSpatialModel": PointSpatialModel,
-    "ShellSpatialModel": ShellSpatialModel,
-}
 
-TIME_MODELS = {
-    "PhaseCurveTemplateTemporalModel": PhaseCurveTemplateTemporalModel,
-    "LightCurveTemplateTemporalModel": LightCurveTemplateTemporalModel,
-}
+class ModelRegistry(list):
+    def get_cls(self, tag):
+        for cls in self:
+            if hasattr(cls, "tag") and cls.tag == tag:
+                return cls
+        raise KeyError(f"No model found with tag: {tag!r}")
 
-# TODO: add support for these models writing their .from_dict()
-# "NaimaSpectralModel":NaimaSpectralModel,
-# "ScaleSpectralModel": ScaleSpectralModel,
-SPECTRAL_MODELS = {
-    "ConstantSpectralModel": ConstantSpectralModel,
-    "PowerLawSpectralModel": PowerLawSpectralModel,
-    "PowerLaw2SpectralModel": PowerLaw2SpectralModel,
-    "ExpCutoffPowerLawSpectralModel": ExpCutoffPowerLawSpectralModel,
-    "ExpCutoffPowerLaw3FGLSpectralModel": ExpCutoffPowerLaw3FGLSpectralModel,
-    "SuperExpCutoffPowerLaw3FGLSpectralModel": SuperExpCutoffPowerLaw3FGLSpectralModel,
-    "SuperExpCutoffPowerLaw4FGLSpectralModel": SuperExpCutoffPowerLaw4FGLSpectralModel,
-    "LogParabolaSpectralModel": LogParabolaSpectralModel,
-    "TemplateSpectralModel": TemplateSpectralModel,
-    "GaussianSpectralModel": GaussianSpectralModel,
-    "LogGaussianSpectralModel": LogGaussianSpectralModel,
-    "AbsorbedSpectralModel": AbsorbedSpectralModel,
-}
+
+SPATIAL_MODELS = ModelRegistry(
+    [
+        ConstantSpatialModel,
+        TemplateSpatialModel,
+        DiskSpatialModel,
+        GaussianSpatialModel,
+        PointSpatialModel,
+        ShellSpatialModel,
+    ]
+)
+"""Built-in spatial models."""
+
+SPECTRAL_MODELS = ModelRegistry(
+    [
+        ConstantSpectralModel,
+        CompoundSpectralModel,
+        PowerLawSpectralModel,
+        PowerLaw2SpectralModel,
+        ExpCutoffPowerLawSpectralModel,
+        ExpCutoffPowerLaw3FGLSpectralModel,
+        SuperExpCutoffPowerLaw3FGLSpectralModel,
+        SuperExpCutoffPowerLaw4FGLSpectralModel,
+        LogParabolaSpectralModel,
+        TemplateSpectralModel,
+        GaussianSpectralModel,
+        LogGaussianSpectralModel,
+        AbsorbedSpectralModel,
+        NaimaSpectralModel,
+        ScaleSpectralModel,
+    ]
+)
+"""Built-in spectral models."""
+
+TEMPORAL_MODELS = ModelRegistry(
+    [PhaseCurveTemplateTemporalModel, LightCurveTemplateTemporalModel]
+)
+"""Built-in temporal models."""
+
+__all__ = [
+    "SPATIAL_MODELS",
+    "TEMPORAL_MODELS",
+    "SPECTRAL_MODELS",
+    "SkyModelBase",
+    "SkyModels",
+    "SkyModel",
+    "SkyDiffuseCube",
+    "BackgroundModel",
+    "create_crab_spectral_model",
+    "create_cosmic_ray_spectral_model",
+    "Absorption",
+    "SpatialModel",
+    "SpectralModel",
+    "TemporalModel",
+]
+
+__all__.extend(cls.__name__ for cls in SPATIAL_MODELS)
+__all__.extend(cls.__name__ for cls in SPECTRAL_MODELS)
+__all__.extend(cls.__name__ for cls in TEMPORAL_MODELS)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,8 +8,6 @@ from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
 from gammapy.utils.scripts import make_path, read_yaml, write_yaml
 
-__all__ = ["SkyModelBase", "SkyModels", "SkyModel", "SkyDiffuseCube", "BackgroundModel"]
-
 
 class SkyModelBase(Model):
     """Sky model base class"""
@@ -315,10 +313,10 @@ class SkyModel(SkyModelBase):
         """Create SkyModel from dict"""
         from gammapy.modeling.models import SPATIAL_MODELS, SPECTRAL_MODELS
 
-        model_class = SPECTRAL_MODELS[data["spectral"]["type"]]
+        model_class = SPECTRAL_MODELS.get_cls(data["spectral"]["type"])
         spectral_model = model_class.from_dict(data["spectral"])
 
-        model_class = SPATIAL_MODELS[data["spatial"]["type"]]
+        model_class = SPATIAL_MODELS.get_cls(data["spatial"]["type"])
         spatial_model = model_class.from_dict(data["spatial"])
 
         return cls(

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -10,16 +10,6 @@ from astropy.coordinates.angle_utilities import angular_separation, position_ang
 from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
 
-__all__ = [
-    "SpatialModel",
-    "PointSpatialModel",
-    "GaussianSpatialModel",
-    "DiskSpatialModel",
-    "ShellSpatialModel",
-    "ConstantSpatialModel",
-    "TemplateSpatialModel",
-]
-
 log = logging.getLogger(__name__)
 
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -12,26 +12,6 @@ from gammapy.utils.integrate import integrate_spectrum
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.scripts import make_path
 
-__all__ = [
-    "SpectralModel",
-    "ConstantSpectralModel",
-    "CompoundSpectralModel",
-    "PowerLawSpectralModel",
-    "PowerLaw2SpectralModel",
-    "ExpCutoffPowerLawSpectralModel",
-    "ExpCutoffPowerLaw3FGLSpectralModel",
-    "SuperExpCutoffPowerLaw3FGLSpectralModel",
-    "SuperExpCutoffPowerLaw4FGLSpectralModel",
-    "LogParabolaSpectralModel",
-    "TemplateSpectralModel",
-    "AbsorbedSpectralModel",
-    "Absorption",
-    "NaimaSpectralModel",
-    "GaussianSpectralModel",
-    "LogGaussianSpectralModel",
-    "ScaleSpectralModel",
-]
-
 
 class SpectralModel(Model):
     """Spectral model base class.
@@ -1605,9 +1585,9 @@ class AbsorbedSpectralModel(SpectralModel):
     def from_dict(cls, data):
         from gammapy.modeling.models import SPECTRAL_MODELS
 
-        base_model = SPECTRAL_MODELS[data["base_model"]["type"]]
+        model_class = SPECTRAL_MODELS.get_cls(data["base_model"]["type"])
         init = cls(
-            spectral_model=base_model.from_dict(data["base_model"]),
+            spectral_model=model_class.from_dict(data["base_model"]),
             absorption=Absorption.from_dict(data["absorption"]),
             parameter=data["absorption_parameter"]["value"],
             parameter_name=data["absorption_parameter"]["name"],

--- a/gammapy/modeling/models/spectral_cosmic_ray.py
+++ b/gammapy/modeling/models/spectral_cosmic_ray.py
@@ -7,8 +7,6 @@ http://lpsc.in2p3.fr/cosmic-rays-db/
 from astropy import units as u
 from .spectral import LogGaussianSpectralModel, PowerLawSpectralModel
 
-__all__ = ["create_cosmic_ray_spectral_model"]
-
 
 def create_cosmic_ray_spectral_model(particle="proton"):
     """Cosmic a cosmic ray spectral model at Earth.

--- a/gammapy/modeling/models/spectral_crab.py
+++ b/gammapy/modeling/models/spectral_crab.py
@@ -8,8 +8,6 @@ from .spectral import (
     SpectralModel,
 )
 
-__all__ = ["create_crab_spectral_model"]
-
 
 class MeyerCrabSpectralModel(SpectralModel):
     """Meyer 2010 log polynomial Crab spectral model.

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -11,12 +11,6 @@ from gammapy.utils.random import InverseCDFSampler, get_random_state
 from gammapy.utils.scripts import make_path
 from gammapy.utils.time import time_ref_from_dict
 
-__all__ = [
-    "PhaseCurveTemplateTemporalModel",
-    "LightCurveTemplateTemporalModel",
-    "TemporalModel",
-]
-
 
 # TODO: make this a small ABC to define a uniform interface.
 class TemporalModel(Model):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -354,7 +354,7 @@ def test_to_from_dict():
     model = spectrum["model"]
 
     model_dict = model.to_dict()
-    model_class = SPECTRAL_MODELS[model_dict["type"]]
+    model_class = SPECTRAL_MODELS.get_cls(model_dict["type"])
     new_model = model_class.from_dict(model_dict)
 
     assert isinstance(new_model, PowerLawSpectralModel)


### PR DESCRIPTION
This PR improves the model registries and __all__ lists a bit. See #2387.

I introduce a custom list class with currently 5 lines of code. I think this will grow a little bit and we will use it to generate very nice docs, or to offer the option to print a `Table` listing models and descriptions at runtime. It also offers another place where we can have serialisation logic / validation if deemed useful.

The other change here is to define a good `__all__`, so that the API docs appear in better order (currently was pretty random), and also I think it's easier to maintain explicit lists of models in a single file (before was duplicated in the `models/spatial.py` etc and `models.__init__`, and indeed there were inconsistencies, i.e. things we forgot to add to the registry.