### PR TITLE
Modified spectrum_simulation.ipynb to take background from the IRF

### DIFF
--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -13,7 +13,6 @@
     "We will use the following classes:\n",
     "\n",
     "* [gammapy.spectrum.SpectrumDatasetOnOff](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumDatasetOnOff.html)\n",
-    "* [gammapy.spectrum.SpectrumEvaluator](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumEvaluator.html)\n",
     "* [gammapy.spectrum.SpectrumDataset](https://docs.gammapy.org/dev/api/gammapy.spectrum.SpectrumDataset.html)\n",
     "* [gammapy.irf.load_cta_irfs](https://docs.gammapy.org/dev/api/gammapy.irf.load_cta_irfs.html)\n",
     "* [gammapy.modeling.models.PowerLawSpectralModel](https://docs.gammapy.org/dev/api/gammapy.modeling.models.PowerLawSpectralModel.html)"
@@ -48,7 +47,7 @@
     "import astropy.units as u\n",
     "from gammapy.spectrum import (\n",
     "    SpectrumDatasetOnOff,\n",
-    "    SpectrumEvaluator,\n",
+    "    CountsSpectrum,\n",
     "    SpectrumDataset,\n",
     ")\n",
     "from gammapy.modeling import Fit, Parameter\n",
@@ -62,7 +61,7 @@
    "source": [
     "## Simulation of a single spectrum\n",
     "\n",
-    "To do a simulation, we need to define the observational parameters like the livetime, the offset, the energy range to perform the simulation for and the choice of spectral model. This will then be convolved with the IRFs, and Poission fluctuated, to get the simulated counts for each observation.  "
+    "To do a simulation, we need to define the observational parameters like the livetime, the offset, the assumed integration radius, the energy range to perform the simulation for and the choice of spectral model. This will then be convolved with the IRFs, and Poission fluctuated, to get the simulated counts for each observation.  "
    ]
   },
   {
@@ -74,8 +73,11 @@
     "# Define simulation parameters parameters\n",
     "livetime = 1 * u.h\n",
     "offset = 0.5 * u.deg\n",
+    "integration_radius = 0.1 * u.deg\n",
     "# Energy from 0.1 to 100 TeV with 10 bins/decade\n",
-    "energy = np.logspace(-1, 2, 31) * u.TeV"
+    "energy = np.logspace(-1, 2, 31) * u.TeV\n",
+    "\n",
+    "solid_angle = 2 * np.pi * (1 - np.cos(integration_radius)) * u.sr"
    ]
   },
   {
@@ -195,7 +197,7 @@
    "source": [
     "## Include Background \n",
     "\n",
-    "In this section we will include a background component. Furthermore, we will also simulate more than one observation and fit each one individually in order to get average fit results."
+    "In this section we will include a background component extracted from the IRF. Furthermore, we will also simulate more than one observation and fit each one individually in order to get average fit results."
    ]
   },
   {
@@ -205,13 +207,16 @@
    "outputs": [],
    "source": [
     "# We assume a PowerLawSpectralModel shape of the background as well\n",
-    "bkg_model = PowerLawSpectralModel(\n",
-    "    index=2.5, amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
+    "bkg_data = (\n",
+    "    cta_irf[\"bkg\"].evaluate_integrate(\n",
+    "        fov_lon=0 * u.deg, fov_lat=offset, energy_reco=energy\n",
+    "    )\n",
+    "    * solid_angle\n",
+    "    * livetime\n",
     ")\n",
-    "\n",
-    "evaluator = SpectrumEvaluator(model=bkg_model, aeff=aeff, livetime=livetime)\n",
-    "\n",
-    "npred_bkg = evaluator.compute_npred()"
+    "bkg = CountsSpectrum(\n",
+    "    energy[:-1], energy[1:], data=bkg_data.to_value(\"\"), unit=\"\"\n",
+    ")"
    ]
   },
   {
@@ -244,7 +249,7 @@
     "datasets = []\n",
     "\n",
     "for idx in range(n_obs):\n",
-    "    dataset.fake(random_state=idx, background_model=npred_bkg)\n",
+    "    dataset.fake(random_state=idx, background_model=bkg)\n",
     "    datasets.append(dataset.copy())"
    ]
   },


### PR DESCRIPTION
This PR removes the usage of a power law background model in `spectrum_simulation.ipynb` and replaces it with the background extracted from the IRF. This removes the usage of `SpectrumEvaluator` in the notebook.

I have not added a PSF correction to limit the complexity of the notebook. 
