### PR TITLE
Add Model.create and tests for all models

### DIFF
--- a/gammapy/modeling/model.py
+++ b/gammapy/modeling/model.py
@@ -3,7 +3,7 @@ import copy
 import astropy.units as u
 from .parameter import Parameters
 
-__all__ = ["Model", "make_model"]
+__all__ = ["Model"]
 
 
 class Model:
@@ -60,26 +60,17 @@ class Model:
             setattr(init, parameter.name, parameter)
         return init
 
+    @staticmethod
+    def create(tag, *args, **kwargs):
+        """Create a model instance.
 
-def make_model(tag, *args, **kwargs):
-    """Make a model, the easy way.
-
-    Examples
-    --------
-    >>> from gammapy.modeling import make_model
-    >>> spectral_model = make_model("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
-    >>> print(spectral_model)
-    PowerLaw2SpectralModel
-
-    Parameters:
-
-           name     value   error   unit   min max frozen
-        --------- --------- ----- -------- --- --- ------
-            index 2.000e+00   nan          nan nan  False
-        amplitude 1.000e-12   nan cm-2 s-1 nan nan  False
-             emin 1.000e-01   nan      TeV nan nan   True
-             emax 1.000e+02   nan      TeV nan nan   True
-    """
-    from .models import MODELS
-    cls = MODELS.get_cls(tag)
-    return cls(*args, **kwargs)
+        Examples
+        --------
+        >>> from gammapy.modeling import Model
+        >>> spectral_model = Model.create("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
+        >>> type(spectral_model)
+        gammapy.modeling.models.spectral.PowerLaw2SpectralModel
+        """
+        from .models import MODELS
+        cls = MODELS.get_cls(tag)
+        return cls(*args, **kwargs)

--- a/gammapy/modeling/model.py
+++ b/gammapy/modeling/model.py
@@ -3,7 +3,7 @@ import copy
 import astropy.units as u
 from .parameter import Parameters
 
-__all__ = ["Model"]
+__all__ = ["Model", "make_model"]
 
 
 class Model:
@@ -59,3 +59,27 @@ class Model:
         for parameter in init.parameters.parameters:
             setattr(init, parameter.name, parameter)
         return init
+
+
+def make_model(tag, *args, **kwargs):
+    """Make a model, the easy way.
+
+    Examples
+    --------
+    >>> from gammapy.modeling import make_model
+    >>> spectral_model = make_model("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
+    >>> print(spectral_model)
+    PowerLaw2SpectralModel
+
+    Parameters:
+
+           name     value   error   unit   min max frozen
+        --------- --------- ----- -------- --- --- ------
+            index 2.000e+00   nan          nan nan  False
+        amplitude 1.000e-12   nan cm-2 s-1 nan nan  False
+             emin 1.000e-01   nan      TeV nan nan   True
+             emax 1.000e+02   nan      TeV nan nan   True
+    """
+    from .models import MODELS
+    cls = MODELS.get_cls(tag)
+    return cls(*args, **kwargs)

--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -54,6 +54,15 @@ TEMPORAL_MODELS = ModelRegistry(
 )
 """Built-in temporal models."""
 
+MODELS = ModelRegistry(
+    SPATIAL_MODELS
+    + SPECTRAL_MODELS
+    + TEMPORAL_MODELS
+    + [SkyModel, SkyDiffuseCube, BackgroundModel]
+)
+"""All built-in models."""
+
+
 __all__ = [
     "SPATIAL_MODELS",
     "TEMPORAL_MODELS",

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -483,7 +483,7 @@ class BackgroundModel(Model):
 
     Parameters
     ----------
-    background : `~gammapy.maps.Map`
+    map : `~gammapy.maps.Map`
         Background model map
     norm : float
         Background normalisation
@@ -498,18 +498,18 @@ class BackgroundModel(Model):
 
     def __init__(
         self,
-        background,
+        map,
         norm=1,
         tilt=0,
         reference="1 TeV",
         name="background",
         filename=None,
     ):
-        axis = background.geom.get_axis_by_name("energy")
+        axis = map.geom.get_axis_by_name("energy")
         if axis.node_type != "edges":
             raise ValueError('Need an integrated map, energy axis node_type="edges"')
 
-        self.map = background
+        self.map = map
         self.norm = Parameter("norm", norm, unit="", min=0)
         self.tilt = Parameter("tilt", tilt, unit="", frozen=True)
         self.reference = Parameter("reference", reference, frozen=True)
@@ -551,13 +551,13 @@ class BackgroundModel(Model):
     @classmethod
     def from_dict(cls, data):
         if "filename" in data:
-            background = Map.read(data["filename"])
+            map = Map.read(data["filename"])
         elif "map" in data:
-            background = data["map"]
+            map = data["map"]
         else:
             raise ValueError("Requires either filename or `Map` object")
 
-        init = cls(background=background, name=data["name"])
+        init = cls(map=map, name=data["name"])
         init.parameters = Parameters.from_dict(data)
         for parameter in init.parameters.parameters:
             setattr(init, parameter.name, parameter)

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -66,6 +66,7 @@ class PhaseCurveTemplateTemporalModel(TemporalModel):
     """
 
     __slots__ = ["table", "time_0", "phase_0", "f0", "f1", "f2"]
+    tag = "PhaseCurveTemplateTemporalModel"
 
     def __init__(self, table, time_0, phase_0, f0, f1, f2):
         self.table = table
@@ -220,6 +221,7 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
     >>> light_curve.mean_norm_in_time_interval(46300, 46301)
     """
+    tag = "LightCurveTemplateTemporalModel"
 
     def __init__(self, table):
         self.table = table

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -68,7 +68,7 @@ class PhaseCurveTemplateTemporalModel(TemporalModel):
     __slots__ = ["table", "time_0", "phase_0", "f0", "f1", "f2"]
     tag = "PhaseCurveTemplateTemporalModel"
 
-    def __init__(self, table, time_0, phase_0, f0, f1, f2):
+    def __init__(self, table, time_0, phase_0, f0, f1=0, f2=0):
         self.table = table
         self.time_0 = Parameter("time_0", time_0)
         self.phase_0 = Parameter("phase_0", phase_0)

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -18,7 +18,7 @@ def phase_curve():
     filename = make_path("$GAMMAPY_DATA/tests/phasecurve_LSI_DC.fits")
     table = Table.read(str(filename))
     return PhaseCurveTemplateTemporalModel(
-        table, time_0=43366.275, phase_0=0.0, f0=4.367575e-7, f1=0.0, f2=0.0
+        table, time_0=43366.275, phase_0=0.0, f0=4.367575e-7
     )
 
 

--- a/gammapy/modeling/tests/test_model.py
+++ b/gammapy/modeling/tests/test_model.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from numpy.testing import assert_allclose
-from gammapy.modeling import Model, make_model, Parameter, Parameters
+from gammapy.modeling import Model, Parameter, Parameters
 
 
 class MyModel(Model):
@@ -20,7 +20,7 @@ def test_model():
     assert m.parameters[0] is not m2.parameters[0]
 
 
-def test_make_model():
-    spectral_model = make_model("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
+def test_model_create():
+    spectral_model = Model.create("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
     assert spectral_model.tag == "PowerLaw2SpectralModel"
     assert_allclose(spectral_model.index.value, 3)

--- a/gammapy/modeling/tests/test_model.py
+++ b/gammapy/modeling/tests/test_model.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from gammapy.modeling import Model, Parameter, Parameters
+from numpy.testing import assert_allclose
+from gammapy.modeling import Model, make_model, Parameter, Parameters
 
 
 class MyModel(Model):
@@ -17,3 +18,9 @@ def test_model():
     # Models should be independent
     assert m.parameters is not m2.parameters
     assert m.parameters[0] is not m2.parameters[0]
+
+
+def test_make_model():
+    spectral_model = make_model("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
+    assert spectral_model.tag == "PowerLaw2SpectralModel"
+    assert_allclose(spectral_model.index.value, 3)

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 from gammapy.maps import Map, MapAxis
-from gammapy.modeling import Datasets, make_model
+from gammapy.modeling import Datasets, Model
 from gammapy.modeling.models import SkyModels, MODELS, Absorption, AbsorbedSpectralModel
 from gammapy.modeling.serialize import dict_to_models
 from gammapy.utils.scripts import read_yaml, write_yaml
@@ -152,7 +152,7 @@ def test_datasets_to_io(tmpdir):
 def test_absorption_io(tmpdir):
     dominguez = Absorption.read_builtin("dominguez")
     model = AbsorbedSpectralModel(
-        spectral_model=make_model("PowerLawSpectralModel"),
+        spectral_model=Model.create("PowerLawSpectralModel"),
         absorption=dominguez,
         parameter=0.5,
         parameter_name="redshift",
@@ -172,7 +172,7 @@ def test_absorption_io(tmpdir):
         u.Quantity(np.ones((2, 3)), ""),
     )
     model = AbsorbedSpectralModel(
-        spectral_model=make_model("PowerLawSpectralModel"),
+        spectral_model=Model.create("PowerLawSpectralModel"),
         absorption=test_absorption,
         parameter=0.5,
         parameter_name="redshift",
@@ -187,46 +187,46 @@ def test_absorption_io(tmpdir):
 
 def make_all_models():
     """Make an instance of each model, for testing."""
-    yield make_model("ConstantSpatialModel")
-    yield make_model("TemplateSpatialModel", map=Map.create(npix=(10, 20)))
-    yield make_model("DiskSpatialModel", lon_0="1d", lat_0="2d", r_0="3d")
-    yield make_model("GaussianSpatialModel", lon_0="1d", lat_0="2d", sigma="3d")
-    yield make_model("PointSpatialModel", lon_0="1d", lat_0="2d")
-    yield make_model(
+    yield Model.create("ConstantSpatialModel")
+    yield Model.create("TemplateSpatialModel", map=Map.create(npix=(10, 20)))
+    yield Model.create("DiskSpatialModel", lon_0="1d", lat_0="2d", r_0="3d")
+    yield Model.create("GaussianSpatialModel", lon_0="1d", lat_0="2d", sigma="3d")
+    yield Model.create("PointSpatialModel", lon_0="1d", lat_0="2d")
+    yield Model.create(
         "ShellSpatialModel", lon_0="1d", lat_0="2d", radius="3d", width="4d"
     )
-    yield make_model(
+    yield Model.create(
         "ConstantSpectralModel", const="99 cm"
     )  # TODO: add unit validation?
-    # TODO: yield make_model("CompoundSpectralModel")
-    yield make_model("PowerLawSpectralModel")
-    yield make_model("PowerLaw2SpectralModel")
-    yield make_model("ExpCutoffPowerLawSpectralModel")
-    yield make_model("ExpCutoffPowerLaw3FGLSpectralModel")
-    yield make_model("SuperExpCutoffPowerLaw3FGLSpectralModel")
-    yield make_model("SuperExpCutoffPowerLaw4FGLSpectralModel")
-    yield make_model("LogParabolaSpectralModel")
-    yield make_model(
+    # TODO: yield Model.create("CompoundSpectralModel")
+    yield Model.create("PowerLawSpectralModel")
+    yield Model.create("PowerLaw2SpectralModel")
+    yield Model.create("ExpCutoffPowerLawSpectralModel")
+    yield Model.create("ExpCutoffPowerLaw3FGLSpectralModel")
+    yield Model.create("SuperExpCutoffPowerLaw3FGLSpectralModel")
+    yield Model.create("SuperExpCutoffPowerLaw4FGLSpectralModel")
+    yield Model.create("LogParabolaSpectralModel")
+    yield Model.create(
         "TemplateSpectralModel", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?
-    yield make_model("GaussianSpectralModel")
-    yield make_model("LogGaussianSpectralModel")
-    # TODO: yield make_model("AbsorbedSpectralModel")
-    # TODO: yield make_model("NaimaSpectralModel")
-    # TODO: yield make_model("ScaleSpectralModel")
-    yield make_model(
+    yield Model.create("GaussianSpectralModel")
+    yield Model.create("LogGaussianSpectralModel")
+    # TODO: yield Model.create("AbsorbedSpectralModel")
+    # TODO: yield Model.create("NaimaSpectralModel")
+    # TODO: yield Model.create("ScaleSpectralModel")
+    yield Model.create(
         "PhaseCurveTemplateTemporalModel", Table(), time_0=1, phase_0=2, f0=3
     )  # TODO: add table content validation?
-    yield make_model("LightCurveTemplateTemporalModel", Table())
-    yield make_model(
+    yield Model.create("LightCurveTemplateTemporalModel", Table())
+    yield Model.create(
         "SkyModel",
-        spatial_model=make_model("ConstantSpatialModel"),
-        spectral_model=make_model("PowerLawSpectralModel"),
+        spatial_model=Model.create("ConstantSpatialModel"),
+        spectral_model=Model.create("PowerLawSpectralModel"),
     )
     m1 = Map.create(npix=(10, 20, 30), axes=[MapAxis.from_nodes([1, 2] * u.TeV, name="energy")])
-    yield make_model("SkyDiffuseCube", map=m1)
+    yield Model.create("SkyDiffuseCube", map=m1)
     m2 = Map.create(npix=(10, 20, 30), axes=[MapAxis.from_edges([1, 2] * u.TeV, name="energy")])
-    yield make_model("BackgroundModel", map=m2)
+    yield Model.create("BackgroundModel", map=m2)
 
 
 @pytest.mark.parametrize("model_class", MODELS)


### PR DESCRIPTION
This PR adds a first, super rough version of a `make_model` factory function.

I mainly introduced it because I wanted to start adding tests for all models, to see if they serialise properly or not. But I imagine apart from being used in tests, this is also the function that will evolve to the common end-user convenience API to make models.

Clearly there's many options: I exposed `make_model` in the `gammapy.modeling` namespace where `Model` and `Models` is also (could have been `gammapy.modeling.models`). I made it a function, whereas in gammapy.maps we have `Map.create`, i.e. this pattern to have the factory functions attached to base classes. I would prefer to go uniform and put `gammapy.maps.make_map`, and also break the API a bit to support quantities better (see #2286) in v0.15. One can argue it's better to break in a clear way, also changing function name, instead of only changing arguments and break some callers, but really most users will have to update.

So if there's strong opposition here, I will change to `Model.create` today and bring this up again later. Otherwise I'd suggest we merge this in now. I have to leave shortly, but tonight I could continue a bit here. E.g. one change I would like to make is from
```
spectral_model = make_model("PowerLaw2SpectralModel", amplitude="1e-10 cm-2 s-1", index=3)
```
to
```
spectral_model = make_model("spectral", "powerlaw2", amplitude="1e-10 cm-2 s-1", index=3)
```
and to change to `PowerLaw2SpectralModel.tag = "powerlaw2"` (and simliarly for all other tags).
I didn't manage to write down a proposal for tag names and there's many options (snake case, camel case, underscores, keep full classname). Preferences?

@adonath @registerrier @QRemy - thoughts?