### PR TITLE
Minor cleanup of Analysis class #4

### DIFF
--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -29,8 +29,9 @@ an IPython console or a notebook.
 
 .. code-block:: python
 
-    >>> from gammapy.scripts import Analysis
-    >>> analysis = Analysis()
+    >>> from gammapy.scripts import Analysis, AnalysisConfig
+    >>> config = AnalysisConfig()
+    >>> analysis = Analysis(config)
         INFO:gammapy.scripts.analysis:Setting logging config: {'level': 'INFO'}
 
 Configuration and methods
@@ -40,21 +41,21 @@ them into a file that you can edit to start a new analysis from the modified con
 
 .. code-block:: python
 
-    >>> print(analysis.config)
-    >>> analysis.config.to_yaml("config.yaml")
+    >>> print(config)
+    >>> config.to_yaml("config.yaml")
     INFO:gammapy.scripts.analysis:Configuration settings saved into config.yaml
-    >>> analysis = Analysis.from_yaml("config.yaml")
+    >>> config = AnalysisConfig.from_yaml("config.yaml")
 
-You may choose to start an analysis using a predefined **settings template**. If no
-value for the settings template is provided, the `basic` template will be used by default.
-You may dump these settings into a file, edit the file and re-initialize your settings
-from the modified file.
+You may choose a predefined **configuration template** for your configuration. If no
+value for the configuration template is provided, the `basic` template will be used by
+default. You may dump the settings into a file, edit the file and re-initialize your
+configuration from the modified file.
 
 .. code-block:: python
 
-    >>> analysis = Analysis.from_template("1d")
-    >>> analysis.config.to_yaml("config.yaml")
-    >>> analysis = Analysis.from_yaml("config.yaml")
+    >>> config = AnalysisConfig.from_template("1d")
+    >>> config.to_yaml("config.yaml")
+    >>> config = AnalysisConfig.from_yaml("config.yaml")
 
 You could also have started with a built-in analysis configuration and extend it with
 with your custom settings declared in a Python nested dictionary. Note how the nested
@@ -65,9 +66,10 @@ file.
 
 .. code-block:: python
 
+    >>> config = AnalysisConfig.from_template("1d")
+    >>> analysis = Analysis(config)
     >>> config_dict = {"general": {"logging": {"level": "WARNING"}}}
-    >>> analysis = Analysis("3d")
-    >>> analysis.config.update_settings(config_dict)
+    >>> config.update_settings(config_dict)
 
 The hierarchical structure of the tens of parameters needed may be hard to follow. You can
 print as a *how-to* documentation a helping sample config file with example values for all
@@ -75,16 +77,16 @@ the sections and parameters or only for one specific section or group of paramet
 
 .. code-block:: python
 
-    >>> analysis.config.help()
-    >>> analysis.config.help("flux")
+    >>> config.help()
+    >>> config.help("flux")
 
 At any moment you can change the value of one specific parameter needed in the analysis. Note
 that it is a good practice to validate your settings when you modify the value of parameters.
 
 .. code-block:: python
 
-    >>> analysis.settings["reduction"]["geom"]["region"]["frame"] = "galactic"
-    >>> analysis.config.validate()
+    >>> config.settings["reduction"]["geom"]["region"]["frame"] = "galactic"
+    >>> config.validate()
 
 It is also possible to add new configuration parameters and values or overwrite the ones already
 defined in your session analysis. In this case you may use the `config.update_settings()` method
@@ -94,8 +96,8 @@ sections and/or from a previous analysis).:
 .. code-block:: python
 
     >>> config_dict = {"observations": {"datastore": "$GAMMAPY_DATA/hess-dl3-dr1"}}
-    >>> analysis.config.update_settings(config=config_dict)
-    >>> analysis.config.update_settings(configfile="fit.yaml")
+    >>> config.update_settings(config=config_dict)
+    >>> config.update_settings(configfile="fit.yaml")
 
 In the following you may find more detailed information on the different sections which
 compose the YAML formatted nested configuration settings hierarchy.
@@ -164,7 +166,12 @@ Model
 -----
 For now we simply declare the model as a reference to a separate YAML file, passing
 the filename into the `get_model()` method to fetch the model and attach it to your
-datasets.
+datasets. Note that You may also pass a serialized model as a dictionary.
+
+.. code-block:: python
+
+    >>> analysis.get_model(filename="model.yaml")
+    >>> analysis.get_model(model=dict_model)
 
 Fitting
 -------

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -70,20 +70,20 @@ file.
     >>> analysis.config.update_settings(config_dict)
 
 The hierarchical structure of the tens of parameters needed may be hard to follow. You can
-print at any moment a *how-to* documentation with example values for all the sections and
-parameters or only for one specific section or group of parameters.
+print as a *how-to* documentation a helping sample config file with example values for all
+the sections and parameters or only for one specific section or group of parameters.
 
 .. code-block:: python
 
-    >>> analysis.config.print_help()
-    >>> analysis.config.print_help("flux")
+    >>> analysis.config.help()
+    >>> analysis.config.help("flux")
 
 At any moment you can change the value of one specific parameter needed in the analysis. Note
 that it is a good practice to validate your settings when you modify the value of parameters.
 
 .. code-block:: python
 
-    >>> analysis.settings["reduction"]["background"]["on_region"]["frame"] = "galactic"
+    >>> analysis.settings["reduction"]["geom"]["on_region"]["frame"] = "galactic"
     >>> analysis.config.validate()
 
 It is also possible to add new configuration parameters and values or overwrite the ones already
@@ -131,8 +131,8 @@ The observations are stored as a list of `DataStoreObservation` containers.
 Data reduction and datasets
 ---------------------------
 The data reduction process needs a choice of a dataset type, declared as the class name
-(MapDataset, SpectrumDatasetOnOff) in the `reduction` section of the settings. For the
-estimation of the background with a dataset type SpectrumDatasetOnOff, a `background_estimator`
+(`MapDataset`, `SpectrumDatasetOnOff`) in the `reduction` section of the settings. For the
+estimation of the background with a dataset type `SpectrumDatasetOnOff`, a `background_estimator`
 is needed, other parameters related with the `on_region` and `exclusion_mask` FITS file
 may be also present. Parameters for geometry are also needed and declared in this section,
 as well as a boolean flag `stack-datasets`.
@@ -140,7 +140,7 @@ as well as a boolean flag `stack-datasets`.
 .. gp-howto-hli:: reduction
 
 You may use the `get_datasets()` method to proceed to the data reduction process.
-The final reduced datasets are stored in the `.datasets` attribute.
+The final reduced datasets are stored in the `datasets` attribute.
 For spectral reduction the information related with the background estimation is
 stored in the `background_estimator` property.
 
@@ -162,8 +162,8 @@ stored in the `background_estimator` property.
 
 Model
 -----
-For now we simply declare the model as a reference to a separate yaml file.
-You may use the `get_model()` method to fetch the model and attach it to your
+For now we simply declare the model as a reference to a separate YAML file, passing
+the filename into the `get_model()` method to fetch the model and attach it to your
 datasets.
 
 Fitting

--- a/docs/scripts/index.rst
+++ b/docs/scripts/index.rst
@@ -83,7 +83,7 @@ that it is a good practice to validate your settings when you modify the value o
 
 .. code-block:: python
 
-    >>> analysis.settings["reduction"]["geom"]["on_region"]["frame"] = "galactic"
+    >>> analysis.settings["reduction"]["geom"]["region"]["frame"] = "galactic"
     >>> analysis.config.validate()
 
 It is also possible to add new configuration parameters and values or overwrite the ones already

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -27,6 +27,7 @@ __all__ = ["Analysis", "AnalysisConfig"]
 log = logging.getLogger(__name__)
 CONFIG_PATH = Path(__file__).resolve().parent / "config"
 SCHEMA_FILE = CONFIG_PATH / "schema.yaml"
+DOCS_FILE = CONFIG_PATH / "docs.yaml"
 
 ANALYSIS_TEMPLATES = {
     "basic": "template-basic.yaml",
@@ -492,7 +493,7 @@ class AnalysisConfig:
         config = read_yaml(filename)
         return cls(config, filename=filename)
 
-    def print_help(self, section=""):
+    def help(self, section=""):
         """Print template configuration settings."""
         doc = self._get_doc_sections()
         for keyword in doc.keys():
@@ -522,13 +523,13 @@ class AnalysisConfig:
 
     @staticmethod
     def _get_doc_sections():
-        """Returns dict with commented docs from schema"""
+        """Returns dict with commented docs from docs file"""
         doc = defaultdict(str)
-        with open(SCHEMA_FILE) as f:
-            for line in filter(lambda line: line.startswith("# "), f):
+        with open(DOCS_FILE) as f:
+            for line in filter(lambda line: not line.startswith("---"), f):
                 line = line.strip("\n")
-                if line.startswith("# Block: "):
-                    keyword = line.replace("# Block: ", "")
+                if line.startswith("# Section: "):
+                    keyword = line.replace("# Section: ", "")
                 doc[keyword] += line + "\n"
         return doc
 

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -55,10 +55,7 @@ class Analysis:
         """
 
     def __init__(self, config=None):
-        if config is None:
-            filename = CONFIG_PATH / ANALYSIS_TEMPLATES["basic"]
-            self._config = AnalysisConfig.from_yaml(filename)
-        elif isinstance(config, dict):
+        if isinstance(config, dict):
             self._config = AnalysisConfig(config)
         elif isinstance(config, AnalysisConfig):
             self._config = config
@@ -84,40 +81,6 @@ class Analysis:
     def settings(self):
         """Configuration settings for the analysis session."""
         return self.config.settings
-
-    @classmethod
-    def from_yaml(cls, filename):
-        """Create analysis from settings in config file.
-
-        Parameters
-        ----------
-        filename : str, Path
-            Configuration settings filename
-
-        Returns
-        -------
-        analysis : `Analysis`
-            Analysis class
-        """
-        config = AnalysisConfig.from_yaml(filename)
-        return cls(config=config)
-
-    @classmethod
-    def from_template(cls, template="basic"):
-        """Create Analysis from existing templates.
-
-        Parameters
-        ----------
-        template : {"basic", "1d", "3d"}
-            Build in templates.
-
-        Returns
-        -------
-        analysis : `Analysis`
-            Analysis class
-        """
-        filename = CONFIG_PATH / ANALYSIS_TEMPLATES[template]
-        return cls.from_yaml(filename)
 
     def get_observations(self):
         """Fetch observations from the data store according to criteria defined in the configuration."""
@@ -436,8 +399,11 @@ class AnalysisConfig:
     def __init__(self, config=None, filename="config.yaml"):
         self._user_settings = {}
         self.settings = {}
+        self.template = ""
+        if config is None:
+            self.template = CONFIG_PATH / ANALYSIS_TEMPLATES["basic"]
         # add user settings
-        self.update_settings(config)
+        self.update_settings(config, self.template)
         self.filename = filename
 
     def __str__(self):
@@ -479,6 +445,23 @@ class AnalysisConfig:
         filename = make_path(filename)
         config = read_yaml(filename)
         return cls(config, filename=filename)
+
+    @classmethod
+    def from_template(cls, template="basic"):
+        """Create AnalysisConfig from existing templates.
+
+        Parameters
+        ----------
+        template : {"basic", "1d", "3d"}
+            Build in templates.
+
+        Returns
+        -------
+        analysis : `AnalysisConfig`
+            AnalysisConfig class
+        """
+        filename = CONFIG_PATH / ANALYSIS_TEMPLATES[template]
+        return cls.from_yaml(filename)
 
     def help(self, section=""):
         """Print template configuration settings."""

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -156,11 +156,11 @@ class Analysis:
         if not self._validate_get_model():
             return False
         log.info(f"Reading model.")
+        if isinstance(model, str):
+            model = yaml.safe_load(model)
         if model:
-            model_yaml = yaml.safe_load(model)
-            self.model = SkyModels(dict_to_models(model_yaml))
+            self.model = SkyModels(dict_to_models(model))
         elif filename:
-            print(filename)
             filepath = make_path(filename)
             self.model = SkyModels.from_yaml(filepath)
         else:
@@ -477,6 +477,8 @@ class AnalysisConfig:
             config = read_yaml(filepath)
         if config is None:
             config = {}
+        if isinstance(config, str):
+            config = yaml.safe_load(config)
         if len(config):
             self._user_settings.update(config)
             self._update_settings(config, self.settings)

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -44,21 +44,14 @@ class Analysis:
     parameters passed as a nested dictionary at the moment of instantiation. In that case these
     parameters will overwrite the default values of those present in the configuration file.
 
+    You may find usage examples in :ref:`HLI`
+
     Parameters
     ----------
     config : dict or `AnalysisConfig`
         Configuration options following `AnalysisConfig` schema
 
-    Examples
-    --------
-    Example how to create an Analysis object:
-
-    >>> from gammapy.scripts import Analysis
-    >>> analysis = Analysis.from_template(template="1d")
-
-    TODO: show a working example of running an analysis.
-    Probably not here, but in high-level docs, linked to from class docstring.
-    """
+        """
 
     def __init__(self, config=None):
         if config is None:

--- a/gammapy/scripts/config/docs.yaml
+++ b/gammapy/scripts/config/docs.yaml
@@ -1,0 +1,91 @@
+---
+# General settings for the API
+general:
+    # logging settings for the session
+    logging:
+        # choose one of the example values for level
+        level: INFO            # also CRITICAL, ERROR, WARNING, DEBUG
+        filename: filename.log
+        filemode: w
+        format: "%(asctime)s - %(message)s"
+        datefmt: "%d-%b-%y %H:%M:%S"
+    # output folder where files will be stored
+    outdir: .
+
+# Observations used in the analysis
+observations:
+    # path to data store where to fetch observations
+    datastore: $GAMMAPY_DATA/hess-dl3-dr1
+    # filtering composed of a list of filters with selection criteria
+    filters:
+        - filter_type: sky_circle
+          # also angle_box, par_box, par_value, ids, all
+          # filter_type "sky_circle"
+          frame: icrs          # also equatorial, galactic, fk5
+          lon: 83.633 deg
+          lat: 22.014 deg
+          radius: 1 deg
+          border: 1 deg
+          # alternatively define the box search within a given variable
+          # filter_type "par_box" and values with units for value_range
+          variable: ENERGY
+          value_range: [1 TeV, 100 TeV]
+          # alternatively define the search for a specific value
+          # filter_type "par_value" with value_param parameter
+          value_param: Crab    # used for i.e variable TARGET
+          # alternatively choose a list of specific observations
+          # filter_type "ids" providing a list of identifiers in obs_ids
+          obs_ids: [23523, 23526]
+          inverted: false      # true for not matching criteria
+          exclude: false       # true to exclude matched observations
+
+# Process of data reduction
+reduction:
+    dataset-type: SpectrumDatasetOnOff   # also MapDataset
+    stack-datasets: false
+    # parameters for the estimation of the background if SpectrumDatasetOnOff
+    background:
+        background_estimator: reflected
+        exclusion_mask:
+            filename: mask.fits
+            hdu: IMAGE
+    containment_correction: true
+    # geometry settings
+    # note that there may be different values for geom and geom-irf
+    geom:
+        # on region in spectrum extraction
+        region:
+            center: [83.633 deg, 22.014 deg]
+            frame: icrs        # also equatorial, galactic, fk5
+            radius: 0.1 deg
+        # spatial geometry ofr 2d maps
+        binsz: 0.02             # map pixel size in degrees
+        coordsys: CEL           # coordinate system also GAL
+        proj: CAR               # any valid WCS projection type
+        skydir: [83, 22]        # lon and lat in deg in the coordsys of the map
+        width: [5, 5]           # width of the map in degrees
+        # additional axes other than spatial
+        # example values for energy axis
+        axes:
+            - name: energy
+              lo_bnd: 0.01
+              hi_bnd: 100
+              nbin: 73
+              unit: TeV
+              interp: log
+
+# Fitting process
+fit:
+    fit_range:
+        min: 1 TeV
+        max: 100 TeV
+
+# Flux estimation process
+flux:
+    fp_binning:
+        lo_bnd: 1
+        hi_bnd: 10
+        nbin: 11
+        unit: TeV
+        interp: log
+        node_type: edges

--- a/gammapy/scripts/config/docs.yaml
+++ b/gammapy/scripts/config/docs.yaml
@@ -17,7 +17,7 @@ general:
 # Observations used in the analysis
 observations:
     # path to data store where to fetch observations
-    datastore: $GAMMAPY_DATA/hess-dl3-dr1
+    datastore: "$GAMMAPY_DATA/hess-dl3-dr1"
     # filtering composed of a list of filters with selection criteria
     filters:
         - filter_type: sky_circle

--- a/gammapy/scripts/config/docs.yaml
+++ b/gammapy/scripts/config/docs.yaml
@@ -1,5 +1,6 @@
 ---
-# General settings for the API
+# Section: general
+# General settings for the high-level interface
 general:
     # logging settings for the session
     logging:
@@ -12,6 +13,7 @@ general:
     # output folder where files will be stored
     outdir: .
 
+# Section: observations
 # Observations used in the analysis
 observations:
     # path to data store where to fetch observations
@@ -39,6 +41,7 @@ observations:
           inverted: false      # true for not matching criteria
           exclude: false       # true to exclude matched observations
 
+# Section: reduction
 # Process of data reduction
 reduction:
     dataset-type: SpectrumDatasetOnOff   # also MapDataset
@@ -74,12 +77,14 @@ reduction:
               unit: TeV
               interp: log
 
+# Section: fit
 # Fitting process
 fit:
     fit_range:
         min: 1 TeV
         max: 100 TeV
 
+# Section: flux
 # Flux estimation process
 flux:
     fp_binning:

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -6,21 +6,6 @@ type: object
 additionalProperties: true
 properties:
 
-# Block: general
-# General settings for the API
-#
-#    Logging settings for the session
-#    Example values for the following properties
-#    logging:
-#        level: CRITICAL, ERROR, WARNING, INFO, DEBUG
-#        filename: filename.log
-#        filemode: w
-#        format: "%(asctime)s - %(message)s"
-#        datefmt: "%d-%b-%y %H:%M:%S"
-#
-#    Output folder where files will be stored
-#    outdir:
-#
     general:
         type: object
         additionalProperties: false
@@ -40,55 +25,13 @@ properties:
                                NOTSET]
                     filename: {type: string}
                     filemode: {type: string}
-                    format:
-                        type: string
+                    format: {type: string}
                     datefmt: {type: string}
                 required: [level]
                 dependencies:
                     filemode: [filename]
         required: [outdir, logging]
 
-# Block: observations
-# Observations used in the analysis
-#
-#    Path to data store where to fetch observations
-#    datastore:
-#
-#    List of filters with selection criteria
-#    Example values for the following properties
-#    filters:
-#
-#        - filter_type: sky_circle, angle_box, par_box, par_value, ids, all
-#          Type of filter used
-#
-#          Properties when filter_type is "par_box"
-#          frame: galactic, equatorial, icrs, fk5
-#          lon: 83.633 deg
-#          lat: 22.014 deg
-#          radius: 1 deg
-#          border: 1 deg
-#
-#          Properties when filter_type is "par_box" or "par_value"
-#          variable: TARGET_NAME
-#
-#          Value to match declared variable
-#          when filter_type is "par_value"
-#          value_param: Crab
-#
-#          Value range with units to match declared variable
-#          when filter_type is "par_box"
-#          value_range:
-#              - 265 deg
-#              - 268 deg
-#
-#          List of observation identifiers when filter_type is "ids"
-#          obs_ids:
-#              - 23523
-#              - 23526
-#
-#          inverted: true for not matching criteria
-#          exclude: true to exclude matched observations
-#
     observations:
         type: object
         additionalProperties: false
@@ -127,57 +70,6 @@ properties:
                             items: {type: integer}
                     required: [filter_type]
         required: [datastore, filters]
-
-# Block: reduction
-# Process of data reduction
-#
-#    Chosen dataset type
-#    dataset-type: SpectrumDatasetOnOff, MapDataset
-#
-#    Stack datasets flag
-#    stack-datasets: False
-#
-#    Parameters used in the estimation of the background
-#    Example values for the following properties
-#    background:
-#
-#        background_estimator: reflected
-#        region:
-#            center:
-#            - 83.633 deg
-#            - 22.014 deg
-#            frame: icrs
-#            radius: 0.11 deg
-#        exclusion_mask
-#            filename: mask.fits
-#            hdu: IMAGE
-#
-#        containment_correction: true
-#
-#    Geometry settings for the analysis
-#    Note that there may be different values for geom and geom-irf
-#    geom:
-#        Map pixel size in degrees
-#        binsz: 0.02
-#        Coordinate system
-#        coordsys: CEL, GAL
-#        Any valid WCS projection type
-#        proj: CAR
-#        Lon and lat in deg in the coordsys of the map
-#        skydir: [83, 22]
-#        Width of the map in degrees
-#        width: [5, 5]
-#
-#        Additional Map Axes other than spatial
-#        Example values for energy axes
-#        axes:
-#            - name: energy
-#              lo_bnd: 0.01
-#              hi_bnd: 100
-#              nbin: 73
-#              unit: TeV
-#              interp: log
-
 
     reduction:
         type: object
@@ -226,38 +118,6 @@ properties:
         then:
             required: [offset-max]
 
-
-# Block: model
-# Filename containing the YAML definition of your model.
-#
-#   model: model.yaml
-
-    model: {type: string}
-
-##        type: object
-##        additionalProperties: false
-##        properties:
-##            components:
-##                type: array
-##                items:
-##                    type: object
-##                    additionalProperties: false
-##                    properties:
-##                        name: {type: string}
-##                        type: {type: string}
-##                        spatial:
-##                            "$ref": "#/definitions/model_components"
-##                        spectral:
-##                            "$ref": "#/definitions/model_components"
-
-# Block: fit
-# Parameters that are used in the fitting process
-#
-#        Energy range considered, min and max values with units
-#        fit_range:
-#            min: 1 TeV
-#            max: 100 Tev
-#
     fit:
         type: object
         additionalProperties: false
@@ -272,18 +132,6 @@ properties:
                     min: [max]
                     max: [min]
 
-# Block: flux
-# Parameters that are used during the flux estimation process
-#
-#        Energy binning considered
-#        fp_binning:
-#            lo_bnd: 1
-#            hi_bnd: 10
-#            nbin: 11
-#            unit: TeV
-#            interp: log
-#            node_type: edges
-#
     flux:
         type: object
         additionalProperties: false
@@ -307,28 +155,10 @@ then:
                 geom:
                     required: [region, axes]
 
-required: [general, observations, reduction, model, fit, flux]
+required: [general, observations, reduction, fit, flux]
 
 definitions:
-    model_components:
-        type: object
-        additionalProperties: false
-        properties:
-            type: {type: string}
-            parameters:
-                type: array
-                items:
-                    type: object
-                    additionalProperties: false
-                    properties:
-                        name: {type: string}
-                        value: {type: number}
-                        factor: {type: number}
-                        scale: {type: number}
-                        unit: {type: string}
-                        min: {type: number}
-                        max: {type: number}
-                        frozen: {type: boolean}
+
     map_axis:
         type: object
         additionalProperties: false

--- a/gammapy/scripts/config/template-1d.yaml
+++ b/gammapy/scripts/config/template-1d.yaml
@@ -32,8 +32,6 @@ reduction:
             node_type: edges
             unit: TeV
 
-model: model.yaml
-
 fit:
     fit_range:
         max: 100 TeV

--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -45,8 +45,6 @@ reduction:
               node_type: center
               unit: TeV
 
-model: model.yaml
-
 fit: {}
 
 flux:

--- a/gammapy/scripts/config/template-basic.yaml
+++ b/gammapy/scripts/config/template-basic.yaml
@@ -16,8 +16,6 @@ reduction:
         region: {}
         axes: []
 
-model: model.yaml
-
 fit:
     fit_range: {}
 

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -6,6 +6,10 @@ import yaml
 from gammapy.scripts import Analysis
 from gammapy.utils.testing import requires_data, requires_dependency
 
+CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
+MODEL_FILE = CONFIG_PATH / "model.yaml"
+DOC_FILE = CONFIG_PATH / "docs.yaml"
+
 
 def test_config():
     analysis = Analysis.from_template(template="basic")
@@ -129,7 +133,7 @@ def test_analysis_1d(config_analysis_data):
     analysis.config.update_settings(config_analysis_data)
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.get_model()
+    analysis.get_model(MODEL_FILE)
     analysis.run_fit()
     analysis.get_flux_points()
 
@@ -149,7 +153,7 @@ def test_analysis_1d_stacked():
     analysis.settings["reduction"]["stack-datasets"] = True
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.get_model()
+    analysis.get_model(MODEL_FILE)
     analysis.run_fit()
 
     assert len(analysis.datasets.datasets) == 1
@@ -166,7 +170,7 @@ def test_analysis_3d():
     analysis = Analysis.from_template(template="3d")
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.get_model()
+    analysis.get_model(MODEL_FILE)
     analysis.datasets["stacked"].background_model.tilt.frozen = False
     analysis.run_fit()
     analysis.get_flux_points()
@@ -197,9 +201,7 @@ def test_validate_config():
 
 
 def test_docs_file():
-    path = Path(__file__).resolve().parent / ".." / "config"
-    filename = path / "docs.yaml"
-    analysis = Analysis.from_yaml(filename)
+    analysis = Analysis.from_yaml(DOC_FILE)
     assert analysis.config.validate() is None
 
 

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -131,10 +131,12 @@ def test_analysis_1d(config_analysis_data):
     analysis.get_model()
     analysis.run_fit()
     analysis.get_flux_points()
+
     assert len(analysis.datasets.datasets) == 2
     assert len(analysis.flux_points_dataset.data.table) == 4
     dnde = analysis.flux_points_dataset.data.table["dnde"].quantity
     assert dnde.unit == "cm-2 s-1 TeV-1"
+
     assert_allclose(dnde[0].value, 8.03604e-12, rtol=1e-2)
     assert_allclose(dnde[-1].value, 4.780021e-21, rtol=1e-2)
 
@@ -174,7 +176,6 @@ def test_analysis_3d():
     assert res[3].unit == "cm-2 s-1 TeV-1"
     assert len(analysis.flux_points_dataset.data.table) == 2
     dnde = analysis.flux_points_dataset.data.table["dnde"].quantity
-    print(dnde[0].value, dnde[-1].value)
 
     assert_allclose(dnde[0].value, 1.175e-11, rtol=1e-1)
     assert_allclose(dnde[-1].value, 4.061e-13, rtol=1e-1)
@@ -192,3 +193,8 @@ def test_validate_astropy_quantities():
 def test_validate_config():
     analysis = Analysis.from_template(template="basic")
     assert analysis.config.validate() is None
+
+
+def test_help():
+    analysis = Analysis.from_template(template="basic")
+    assert analysis.config.help() is None

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -133,7 +133,7 @@ def test_analysis_1d(config_analysis_data):
     analysis.config.update_settings(config_analysis_data)
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.get_model(MODEL_FILE)
+    analysis.get_model(filename=MODEL_FILE)
     analysis.run_fit()
     analysis.get_flux_points()
 
@@ -153,7 +153,7 @@ def test_analysis_1d_stacked():
     analysis.settings["reduction"]["stack-datasets"] = True
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.get_model(MODEL_FILE)
+    analysis.get_model(filename=MODEL_FILE)
     analysis.run_fit()
 
     assert len(analysis.datasets.datasets) == 1
@@ -170,7 +170,7 @@ def test_analysis_3d():
     analysis = Analysis.from_template(template="3d")
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.get_model(MODEL_FILE)
+    analysis.get_model(filename=MODEL_FILE)
     analysis.datasets["stacked"].background_model.tilt.frozen = False
     analysis.run_fit()
     analysis.get_flux_points()

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose
+from pathlib import Path
 import yaml
 from gammapy.scripts import Analysis
 from gammapy.utils.testing import requires_data, requires_dependency
@@ -192,6 +193,13 @@ def test_validate_astropy_quantities():
 
 def test_validate_config():
     analysis = Analysis.from_template(template="basic")
+    assert analysis.config.validate() is None
+
+
+def test_docs_file():
+    path = Path(__file__).resolve().parent / ".." / "config"
+    filename = path / "docs.yaml"
+    analysis = Analysis.from_yaml(filename)
     assert analysis.config.validate() is None
 
 

--- a/tutorials/hess.ipynb
+++ b/tutorials/hess.ipynb
@@ -53,7 +53,7 @@
     "from gammapy.modeling.models import create_crab_spectral_model\n",
     "from gammapy.modeling.models import PointSpatialModel\n",
     "from gammapy.detect import compute_lima_on_off_image\n",
-    "from gammapy.scripts import Analysis\n",
+    "from gammapy.scripts import Analysis, AnalysisConfig\n",
     "from gammapy.modeling import Fit"
    ]
   },
@@ -307,19 +307,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = \"\"\"\n",
-    "general:\n",
-    "    logging:\n",
-    "        level: INFO\n",
-    "    outdir: .\n",
-    "\n",
+    "config = AnalysisConfig()\n",
+    "analysis = Analysis(config)\n",
+    "print(analysis.config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observations_settings = \"\"\"\n",
     "observations:\n",
     "  datastore: $GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz\n",
     "  filters:\n",
     "  - filter_type: par_value\n",
     "    variable: TARGET_NAME\n",
     "    value_param: Crab\n",
-    "\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis.config.update_settings(observations_settings)\n",
+    "print(analysis.config)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reduction_fit_flux = \"\"\"\n",
     "reduction:\n",
     "    background:\n",
     "        background_estimator: reflected\n",
@@ -341,9 +366,6 @@
     "            interp: log\n",
     "            node_type: edges\n",
     "            unit: TeV\n",
-    "\n",
-    "model: model.yaml\n",
-    "\n",
     "fit:\n",
     "    fit_range:\n",
     "        min: 1 TeV\n",
@@ -354,10 +376,8 @@
     "        hi_bnd: 10\n",
     "        nbin: 10\n",
     "        unit: TeV\n",
-    "        interp: log      \n",
-    "\"\"\"\n",
-    "filename = Path(\"config.yaml\")\n",
-    "filename.write_text(config)"
+    "        interp: log\n",
+    "\"\"\""
    ]
   },
   {
@@ -366,7 +386,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_config = \"\"\"\n",
+    "analysis.config.update_settings(reduction_fit_flux)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "analysis.get_observations()\n",
+    "analysis.get_datasets()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = \"\"\"\n",
     "components:\n",
     "- name: source\n",
     "  type: SkyModel\n",
@@ -395,25 +437,33 @@
     "      value: 1.0\n",
     "      unit: TeV\n",
     "      frozen: true\n",
-    "\"\"\"\n",
-    "filename = Path(\"model.yaml\")\n",
-    "filename.write_text(model_config)"
+    "\"\"\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "analysis = Analysis.from_yaml(\"config.yaml\")\n",
-    "analysis.get_observations()\n",
-    "analysis.get_datasets()\n",
-    "analysis.get_model()\n",
-    "analysis.run_fit()\n",
+    "analysis.get_model(model=model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis.run_fit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "analysis.get_flux_points()"
    ]
   },
@@ -451,7 +501,7 @@
     "ax_spectrum, ax_residuals = dataset_fp.peek(model_kwargs=model_kwargs)\n",
     "\n",
     "crab_ref.plot(ax=ax_spectrum, label=\"H.E.S.S. 2006 PWL\", **plot_kwargs)\n",
-    "model.spectral_model.plot(\n",
+    "analysis.model.skymodels[0].spectral_model.plot(\n",
     "    ax=ax_spectrum, label=\"3D best fit model\", **plot_kwargs\n",
     ")\n",
     "\n",


### PR DESCRIPTION
This PR is a follow up to #2407. It implements the following changes agreed in the developers call this morning:

- Generation of settings sections YAML code in the documentation is generated from anew `docs.yaml` file and no more from comments in the `schema.yaml`. The `docs.yaml` file is validated in tests and include some comments to guide the user. So we have now five YAML files to maintain including `schema.yaml`, I think there's room for improving this in the future..
- Rename `config.print_help()` method into `config.help()` and display the whole content of the `docs.yaml` file or a specific section of the settings in that file.
- Remove example code in the docstring of the `Analysis` class and put a link to the documentation instead.
- Remove parameter model from the config settings. Fetch the model with the `get_model()`method providing the filename of its YAML serialization and attach it to the datasets.
- Update of the documentation, improvement of internal validation methods and code refactoring.

