### PR TITLE
Remove FK5 option in spatial models

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -168,9 +168,9 @@ def get_shape(param):
 
 
 def coordsys_to_frame(coordsys):
-    if coordsys in ["CEL", "C"]:
+    if coordsys in ["CEL", "C", "fk5", "fk4", "icrs"]:
         return "icrs"
-    elif coordsys in ["GAL", "G"]:
+    elif coordsys in ["GAL", "G", "galactic"]:
         return "galactic"
     else:
         raise ValueError(f"Unrecognized coordinate system: {coordsys!r}")
@@ -186,21 +186,12 @@ def skycoord_to_lonlat(skycoord, coordsys=None):
         Longitude in degrees.
     lat : `~numpy.ndarray`
         Latitude in degrees.
-    frame : str
-        Name of coordinate frame.
     """
-    if coordsys in ["CEL", "C"]:
-        skycoord = skycoord.transform_to("icrs")
-    elif coordsys in ["GAL", "G"]:
-        skycoord = skycoord.transform_to("galactic")
+    if coordsys:
+        frame = coordsys_to_frame(coordsys)
+        skycoord = skycoord.transform_to(frame)
 
-    frame = skycoord.frame.name
-    if frame in ["icrs", "fk5"]:
-        return skycoord.ra.deg, skycoord.dec.deg, frame
-    elif frame in ["galactic"]:
-        return skycoord.l.deg, skycoord.b.deg, frame
-    else:
-        raise ValueError(f"Unrecognized SkyCoord frame: {frame!r}")
+    return skycoord.data.lon.deg, skycoord.data.lat.deg, skycoord.frame
 
 
 def lonlat_to_skycoord(lon, lat, coordsys):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -29,8 +29,7 @@ class SkyModelBase(Model):
         return self.evaluate(lon, lat, energy)
 
     def evaluate_geom(self, geom):
-        coordsys = "CEL" if self.frame in ["icrs", "fk5"] else "GAL"
-        coords = geom.get_coord(coordsys=coordsys)
+        coords = geom.get_coord(coordsys=self.frame)
         return self(coords.lon, coords.lat, coords["energy"])
 
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -49,9 +49,7 @@ class SpatialModel(Model):
 
     def evaluate_geom(self, geom):
         """Evaluate model on `~gammapy.maps.Geom`."""
-        # TODO: change to uniform coordinate frame names
-        coordsys = "CEL" if self.frame in ["icrs", "fk5"] else "GAL"
-        coords = geom.get_coord(coordsys=coordsys)
+        coords = geom.get_coord(coordsys=self.frame)
         return self(coords.lon, coords.lat)
 
     def to_dict(self):

--- a/gammapy/modeling/models/tests/test_spatial.py
+++ b/gammapy/modeling/models/tests/test_spatial.py
@@ -2,6 +2,8 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
+from astropy.wcs.utils import celestial_frame_to_wcs
+from astropy.coordinates import FK5
 from gammapy.maps import Map, WcsGeom
 from gammapy.modeling.models import (
     ConstantSpatialModel,
@@ -216,8 +218,11 @@ def test_sky_diffuse_map_normalize():
     assert_allclose(integral.value, 1, rtol=1e-4)
 
 
-def test_evaluate_fk5():
-    geom = WcsGeom.create(width=(5, 5), binsz=0.1, coordsys="CEL")
-    model = GaussianSpatialModel("0 deg", "0 deg", "0.1 deg", frame="fk5")
+def test_evaluate_on_fk5_map():
+    # Check if spatial model can be evaluated on a map with FK5 frame
+    # Regression test for GH-2402
+    wcs = celestial_frame_to_wcs(FK5())
+    geom = WcsGeom(wcs, npix=(10, 10))
+    model = GaussianSpatialModel("0 deg", "0 deg", "0.1 deg")
     data = model.evaluate_geom(geom)
-    assert data.value[12, 12] > 0
+    assert data.sum() > 0

--- a/gammapy/scripts/config/docs.yaml
+++ b/gammapy/scripts/config/docs.yaml
@@ -23,7 +23,7 @@ observations:
         - filter_type: sky_circle
           # also angle_box, par_box, par_value, ids, all
           # filter_type "sky_circle"
-          frame: icrs          # also equatorial, galactic, fk5
+          frame: icrs          #  or galactic
           lon: 83.633 deg
           lat: 22.014 deg
           radius: 1 deg
@@ -59,7 +59,7 @@ reduction:
         # on region in spectrum extraction
         region:
             center: [83.633 deg, 22.014 deg]
-            frame: icrs        # also equatorial, galactic, fk5
+            frame: icrs        # or galactic
             radius: 0.1 deg
         # spatial geometry ofr 2d maps
         binsz: 0.02             # map pixel size in degrees

--- a/gammapy/scripts/config/schema.yaml
+++ b/gammapy/scripts/config/schema.yaml
@@ -53,7 +53,7 @@ properties:
                                    ids,
                                    all]
                         frame:
-                            enum: [galactic, equatorial, icrs, fk5]
+                            enum: [galactic, icrs]
                         lon: {type: number}
                         lat: {type: number}
                         radius: {type: number}
@@ -191,7 +191,7 @@ definitions:
                         maxItems: 2
                     radius: {type: number}
                     frame:
-                        enum: [galactic, equatorial, icrs, fk5]
+                        enum: [galactic, icrs]
             binsz: {type: number}
             coordsys:
                 type: string


### PR DESCRIPTION
This is a follow-up PR to  #2406 which addressed #2402.

I revert the option and handling of "fk5" as a possible frame for spatial models.

Trying to handle "fk5" ourselves isn't a good strategy, because then we'd have to handle "fk4" as well and basically all the frames astronomers use and that Astropy already has built-in with 1000s of lines of code.

So either we change spatial models to use SkyCoord and Astropy Frame (like we did in `regions`), or we keep the limit to only "icrs" and "galactic" as the two valid options (like e.g. Fermi tools or Gammalib does). Either way seems acceptable to me, with pros and cons. Especially if we keep using Quantity for most models, and Time for time models, then using SkyCoord for spatial models makes sense, we'd just have to find a way to map it to Parameter objects.

This PR is unfinished, there's two fails:
https://gist.github.com/cdeil/7b222ec808fa860af8b9c7ba6fd0a22b

I'm not sure why - is it because there's an example spatial template with FK5 frame involved? or do we have to call some frame -- coordsys tranlation function from gammapy.maps or adjust an API there?

@adonath - Could you please take over?