### PR TITLE
Improve test coverage in `scripts/analysis.py`

### DIFF
--- a/gammapy/scripts/config/template-3d.yaml
+++ b/gammapy/scripts/config/template-3d.yaml
@@ -19,7 +19,7 @@ datasets:
     geom:
         skydir: [83.633, 22.014]
         width: [5, 5]
-        binsz: 0.02
+        binsz: 0.04
         coordsys: CEL
         proj: TAN
         axes:


### PR DESCRIPTION
This PR improves the test coverage in `scripts/analysis.py`, by adding minimal tests for `AnalysisConfig.__str__`, `AnalysisConfig.to_yaml()` and the 3D joint data reduction. 