### PR TITLE
High-level interface: improve test coverage

### DIFF
--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -385,7 +385,10 @@ class Analysis:
         else:
             log.info("No results available from fit.")
             valid = False
-        if "fp_binning" not in self.settings["flux-points"]:
+        if "flux-points" not in self.settings:
+            log.info("No values declared for the energy bins.")
+            valid = False
+        elif "fp_binning" not in self.settings["flux-points"]:
             log.info("No values declared for the energy bins.")
             valid = False
         if not valid:

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -142,18 +142,19 @@ class Analysis:
         else:
             # TODO raise error?
             log.info("Data reduction method not available.")
+            return False
 
     def set_model(self, model=None, filename=""):
         """Read the model from dict or filename and attach it to datasets.
 
         Parameters
         ----------
-        model: dict
-            Dictionary with the serialized model.
+        model: dict or string
+            Dictionary or string in YAML format with the serialized model.
         filename : string
             Name of the model YAML file describing the model.
         """
-        if not self._validate_get_model():
+        if not self._validate_set_model():
             return False
         log.info(f"Reading model.")
         if isinstance(model, str):
@@ -327,7 +328,7 @@ class Analysis:
         else:
             # TODO: raise error?
             log.info("Background estimation only for reflected regions method.")
-            return False
+
         extraction_params = {}
         if "containment_correction" in self.settings["datasets"]:
             extraction_params["containment_correction"] = self.settings["datasets"][
@@ -359,7 +360,7 @@ class Analysis:
             log.info("Data reduction cannot be done.")
             return False
 
-    def _validate_get_model(self):
+    def _validate_set_model(self):
         if self.datasets and self.datasets.datasets:
             self.config.validate()
             return True

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -412,7 +412,7 @@ class AnalysisConfig:
             self.template = CONFIG_PATH / ANALYSIS_TEMPLATES["basic"]
         # add user settings
         self.update_settings(config, self.template)
-        self.filename = filename
+        self.filename = Path(filename).name
 
     def __str__(self):
         """Display settings in pretty YAML format."""
@@ -437,9 +437,8 @@ class AnalysisConfig:
         if filename is None:
             filename = self.filename
 
-        filename = make_path(filename)
-        path_file = Path(self.settings["general"]["outdir"]) / filename
-        self.filename = path_file
+        self.filename = Path(filename).name
+        path_file = Path(self.settings["general"]["outdir"]) / self.filename
 
         if path_file.exists() and not overwrite:
             raise IOError(f"File {filename} already exists.")

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -247,6 +247,7 @@ def test_analysis_3d_no_geom_irf():
     assert len(analysis.datasets.datasets) == 1
 
 
+@requires_data()
 def test_validation_checks():
     config = AnalysisConfig()
     analysis = Analysis(config)
@@ -254,8 +255,8 @@ def test_validation_checks():
     with pytest.raises(FileNotFoundError):
         analysis.get_observations()
 
-    config_1d = AnalysisConfig.from_template("1d")
-    analysis = Analysis(config_1d)
+    config = AnalysisConfig.from_template("1d")
+    analysis = Analysis(config)
     assert analysis.get_flux_points() is False
     assert analysis.run_fit() is False
     assert analysis.set_model() is False

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -209,7 +209,6 @@ def test_analysis_3d_joint_datasets():
     analysis = Analysis(config)
     analysis.get_observations()
     analysis.get_datasets()
-
     assert len(analysis.datasets.datasets) == 4
 
 
@@ -233,3 +232,15 @@ def test_docs_file():
 def test_help():
     config = AnalysisConfig()
     assert config.help() is None
+
+
+@requires_data()
+def test_analysis_3d_no_geom_irf():
+    config = AnalysisConfig.from_template("3d")
+    analysis = Analysis(config)
+    del analysis.settings["datasets"]["geom-irf"]
+    analysis.settings["datasets"]["geom"]["binsz"] = 0.05
+    analysis.get_observations()
+    analysis.get_datasets()
+
+    assert len(analysis.datasets.datasets) == 1

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import yaml
 from gammapy.scripts import Analysis, AnalysisConfig
 from gammapy.utils.testing import requires_data, requires_dependency
+from gammapy.modeling.models import SkyModels
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
 MODEL_FILE = CONFIG_PATH / "model.yaml"
@@ -134,7 +135,7 @@ def config_analysis_data():
             unit: TeV
             interp: log
     """
-    return yaml.safe_load(cfg)
+    return cfg
 
 
 @requires_dependency("iminuit")
@@ -263,3 +264,11 @@ def test_validation_checks():
     analysis.get_observations()
     analysis.settings["datasets"]["dataset-type"] = "not assigned"
     assert analysis.get_datasets() is False
+
+    analysis.settings["datasets"]["dataset-type"] = "SpectrumDatasetOnOff"
+    analysis.get_observations()
+    analysis.get_datasets()
+    model_str = Path(MODEL_FILE).read_text()
+    analysis.set_model(model=model_str)
+    assert isinstance(analysis.model, SkyModels) is True
+    assert analysis.set_model() is False

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -19,6 +19,9 @@ def test_config():
     assert config.settings["general"]["logging"]["level"] == "INFO"
     assert config.settings["general"]["outdir"] == "test"
 
+    with pytest.raises(ValueError):
+        Analysis()
+
     assert "AnalysisConfig" in str(config)
 
 

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -252,3 +252,10 @@ def test_validation_checks():
     analysis.settings["observations"]["datastore"] = "other"
     with pytest.raises(FileNotFoundError):
         analysis.get_observations()
+
+    config_1d = AnalysisConfig.from_template("1d")
+    analysis = Analysis(config_1d)
+    assert analysis.get_flux_points() is False
+    assert analysis.run_fit() is False
+    assert analysis.set_model() is False
+    assert analysis.get_datasets() is False

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -246,7 +246,8 @@ def test_analysis_3d_no_geom_irf():
 
     assert len(analysis.datasets.datasets) == 1
 
-
+    
+@requires_dependency("iminuit")
 @requires_data()
 def test_validation_checks():
     config = AnalysisConfig()

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -25,11 +25,10 @@ def test_config():
     assert "AnalysisConfig" in str(config)
 
 
-def test_config_to_yaml(tmpdir):
+def test_config_to_yaml():
     config = AnalysisConfig()
-    filename = tmpdir / "test_config.yaml"
-    config.to_yaml(filename=filename)
-    text = Path(filename).read_text()
+    config.to_yaml(overwrite=True)
+    text = Path(config.filename).read_text()
     assert "stack-datasets" in text
 
 

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -244,3 +244,11 @@ def test_analysis_3d_no_geom_irf():
     analysis.get_datasets()
 
     assert len(analysis.datasets.datasets) == 1
+
+
+def test_validation_checks():
+    config = AnalysisConfig()
+    analysis = Analysis(config)
+    analysis.settings["observations"]["datastore"] = "other"
+    with pytest.raises(FileNotFoundError):
+        analysis.get_observations()

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -272,3 +272,7 @@ def test_validation_checks():
     analysis.set_model(model=model_str)
     assert isinstance(analysis.model, SkyModels) is True
     assert analysis.set_model() is False
+
+    analysis.run_fit()
+    del analysis.settings["flux-points"]
+    assert analysis.get_flux_points() is False

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -26,10 +26,11 @@ def test_config():
     assert "AnalysisConfig" in str(config)
 
 
-def test_config_to_yaml():
+def test_config_to_yaml(tmpdir):
     config = AnalysisConfig()
+    config.settings["general"]["outdir"] = tmpdir
     config.to_yaml(overwrite=True)
-    text = Path(config.filename).read_text()
+    text = Path(tmpdir/config.filename).read_text()
     assert "stack-datasets" in text
 
 
@@ -240,7 +241,6 @@ def test_analysis_3d_no_geom_irf():
     config = AnalysisConfig.from_template("3d")
     analysis = Analysis(config)
     del analysis.settings["datasets"]["geom-irf"]
-    analysis.settings["datasets"]["geom"]["binsz"] = 0.05
     analysis.get_observations()
     analysis.get_datasets()
 

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -259,3 +259,7 @@ def test_validation_checks():
     assert analysis.run_fit() is False
     assert analysis.set_model() is False
     assert analysis.get_datasets() is False
+
+    analysis.get_observations()
+    analysis.settings["datasets"]["dataset-type"] = "not assigned"
+    assert analysis.get_datasets() is False


### PR DESCRIPTION
This PR is a follow-up of #2421
In general, it adds tests for missing parameters and non-valid options that `schema.yaml` validation cannot detect.
  