### PR TITLE
Implement better fix for #2425

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -31,6 +31,7 @@ RAD_AXIS_DEFAULT = MapAxis.from_bounds(
 MIGRA_AXIS_DEFAULT = MapAxis.from_bounds(
     0.2, 5, nbin=48, node_type="edges", name="migra"
 )
+BINSZ_IRF = 0.2
 # TODO: Choose optimal binnings depending on IRFs
 
 
@@ -308,7 +309,7 @@ class MapDataset(Dataset):
         name : str
             Name of the dataset.
         """
-        geom_irf = geom_irf or geom
+        geom_irf = geom_irf or geom.to_binsz(BINSZ_IRF)
         migra_axis = migra_axis or MIGRA_AXIS_DEFAULT
         rad_axis = rad_axis or RAD_AXIS_DEFAULT
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -51,7 +51,7 @@ class MapMaker:
             raise ValueError("MapMaker only works with geom with an energy axis")
 
         self.geom = geom
-        self.geom_true = geom_true if geom_true else geom
+        self.geom_true = geom_true if geom_true else geom.to_binsz()
         self.offset_max = Angle(offset_max)
         self.exclusion_mask = exclusion_mask
         self.background_oversampling = background_oversampling

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -419,3 +419,17 @@ def test_read_write(tmpdir, node_type, interp):
     m.write(filename, overwrite=True)
     m2 = Map.read(filename)
     assert m2.geom == m.geom
+
+
+@pytest.mark.parametrize(
+    ("npix", "binsz", "coordsys", "proj", "skypos", "axes", "result"),
+    compatibility_test_geoms,
+)
+def test_wcs_geom_to_binsz(npix, binsz, coordsys, proj, skypos, axes, result):
+    geom = WcsGeom.create(
+        skydir=skydir, npix=10, binsz=0.1, proj="CAR", coordsys="GAL", axes=test_axis1
+    )
+
+    geom_new = geom.to_binsz(binsz=0.5)
+
+    assert_allclose(geom_new.pixel_scales.value, 0.5)

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -773,7 +773,7 @@ class WcsGeom(Geom):
         Returns
         -------
         geom : `WcsGeom`
-            Geometry with new bin size.
+            Geometry with new pixel size.
         """
         kwargs = {}
         kwargs["skydir"] = self.center_skydir

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -762,6 +762,28 @@ class WcsGeom(Geom):
             axes[idx] = axes[idx].upsample(factor)
             return self._init_copy(axes=axes)
 
+    def to_binsz(self, binsz):
+        """Change pixel size of the geometry
+
+        Parameters
+        ----------
+        binsz : float or tuple or list
+            New pixel size in degree.
+
+        Returns
+        -------
+        geom : `WcsGeom`
+            Geometry with new bin size.
+        """
+        kwargs = {}
+        kwargs["skydir"] = self.center_skydir
+        kwargs["binsz"] = binsz
+        kwargs["width"] = self.width
+        kwargs["proj"] = self.projection
+        kwargs["coordsys"] = self.coordsys
+        kwargs["axes"] = copy.deepcopy(self.axes)
+        return self.create(**kwargs)
+
     @lru_cache()
     def solid_angle(self):
         """Solid angle array (`~astropy.units.Quantity` in ``sr``).

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -4,13 +4,13 @@ import copy
 import logging
 from collections import defaultdict
 from pathlib import Path
-import numpy as np
 from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
 import jsonschema
 import yaml
 from gammapy.cube import MapDataset, MapMakerObs
+from gammapy.cube.fit import BINSZ_IRF
 from gammapy.data import DataStore, ObservationTable
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Datasets, Fit
@@ -244,9 +244,7 @@ class Analysis:
         if "geom-irf" in self.settings["datasets"]:
             geom_irf = self._create_geometry(self.settings["datasets"]["geom-irf"])
         else:
-            # TODO: change parametrisation from geom-irf to binsz_irf and energy_true_axis
-            #  and remove hard coded pixel size for IRF maps
-            geom_irf = geom.to_binsz(binsz=0.5)
+            geom_irf = geom.to_binsz(binsz=BINSZ_IRF)
 
         offset_max = Angle(self.settings["datasets"]["offset-max"])
         stack_datasets = self.settings["datasets"]["stack-datasets"]

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -246,8 +246,7 @@ class Analysis:
         else:
             # TODO: change parametrisation from geom-irf to binsz_irf and energy_true_axis
             #  and remove hard coded pixel size for IRF maps
-            factor = int(np.ceil((0.2 * u.deg) / geom.pixel_scales[0]))
-            geom_irf = geom.downsample(factor=factor)
+            geom_irf = geom.to_binsz(binsz=0.5)
 
         offset_max = Angle(self.settings["datasets"]["offset-max"])
         stack_datasets = self.settings["datasets"]["stack-datasets"]


### PR DESCRIPTION
This PR implements a better fix for #2425. In https://github.com/gammapy/gammapy/commit/09aed0b6810b878848cf74098940835cfaf0ddf8 I implemented a fix for #2425, but I realised it was not a good change either, because it would also fail, if the shape of the spatial axes of the geom was not divisible by the given factor. This PR now implements `WcsGeom.to_binsz()`, which allows to copy a given geom and adapting the bins at the same time.