### PR TITLE
Update versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
 env:
     global:
         - PYTHON_VERSION=3.7
-        - NUMPY_VERSION=1.15
+        - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - ASTROPY_USE_SYSTEM_PYTEST=1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,10 +90,6 @@ matrix:
         - env: CMD='python setup.py bdist_conda'
                TEST_PACKAGING=true
 
-        # Test with Astropy LTS version
-        - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts CMD='make test'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-
         # Test with Astropy dev version
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=dev CMD='make test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES


### PR DESCRIPTION
Current version requirements state astropy>=3.2 and numpy>=1.16, so can't/shouldn't test older versions.

There are also mentions of numpy 1.9 in files in  `dev/docker`, I would suggest to clean up/remove those as well rather than letting them code rot there.