### PR TITLE
Add GTI export in datasets

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -589,6 +589,9 @@ class MapDataset(Dataset):
             )
             hdulist += mask_fit_map.to_hdulist(hdu="mask_fit")[exclude_primary]
 
+        if self.gti is not None:
+            hdulist += self.gti.to_hdulist()
+
         return hdulist
 
     @classmethod
@@ -633,6 +636,10 @@ class MapDataset(Dataset):
         if "MASK_FIT" in hdulist:
             mask_fit_map = Map.from_hdulist(hdulist, hdu="mask_fit")
             init_kwargs["mask_fit"] = mask_fit_map.data.astype(bool)
+
+        if "GTI" in hdulist:
+            gti = GTI.from_hdulist(hdulist, hdu="GTI")
+            init_kwargs["gti"] = gti
         return cls(**init_kwargs)
 
     def write(self, filename, overwrite=False):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -198,6 +198,9 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
     dataset = get_map_dataset(sky_model, geom, geom_etrue)
     dataset.counts = dataset.npred()
     dataset.mask_safe = dataset.mask_fit
+    gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
+    dataset.gti = gti
+
 
     hdulist = dataset.to_hdulist()
     actual = [hdu.name for hdu in hdulist]
@@ -218,6 +221,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         "MASK_SAFE_BANDS",
         "MASK_FIT",
         "MASK_FIT_BANDS",
+        "GTI"
     ]
 
     assert actual == desired
@@ -251,7 +255,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         dataset.edisp.e_reco.edges.value, dataset_new.edisp.e_reco.edges.value
     )
     assert dataset.edisp.e_true.unit == dataset_new.edisp.e_true.unit
-
+    assert_allclose(dataset.gti.time_sum.to_value('s'), dataset_new.gti.time_sum.to_value('s'))
 
 @requires_dependency("iminuit")
 @requires_dependency("matplotlib")

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -201,7 +201,6 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
     gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
     dataset.gti = gti
 
-
     hdulist = dataset.to_hdulist()
     actual = [hdu.name for hdu in hdulist]
 
@@ -221,7 +220,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         "MASK_SAFE_BANDS",
         "MASK_FIT",
         "MASK_FIT_BANDS",
-        "GTI"
+        "GTI",
     ]
 
     assert actual == desired
@@ -255,7 +254,10 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         dataset.edisp.e_reco.edges.value, dataset_new.edisp.e_reco.edges.value
     )
     assert dataset.edisp.e_true.unit == dataset_new.edisp.e_true.unit
-    assert_allclose(dataset.gti.time_sum.to_value('s'), dataset_new.gti.time_sum.to_value('s'))
+    assert_allclose(
+        dataset.gti.time_sum.to_value("s"), dataset_new.gti.time_sum.to_value("s")
+    )
+
 
 @requires_dependency("iminuit")
 @requires_dependency("matplotlib")

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -111,7 +111,7 @@ class GTI:
     def write(self, filename, **kwargs):
         """Write to file."""
         filename = make_path(filename)
-        hdulist  = fits.HDUList([fits.PrimaryHDU()])
+        hdulist = fits.HDUList([fits.PrimaryHDU()])
         hdulist += self.to_hdulist()
         hdulist.writeto(str(filename), **kwargs)
 

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -111,7 +111,9 @@ class GTI:
     def write(self, filename, **kwargs):
         """Write to file."""
         filename = make_path(filename)
-        self.to_hdulist().writeto(str(filename), **kwargs)
+        hdulist  = fits.HDUList([fits.PrimaryHDU()])
+        hdulist += self.to_hdulist()
+        hdulist.writeto(str(filename), **kwargs)
 
     def __str__(self):
         return (

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -126,6 +126,7 @@ def test_gti_create():
     assert_allclose(gti.time_ref.mjd, time_ref.tt.mjd)
     assert_allclose(gti.table["START"], start.to_value("s"))
 
+
 def test_gti_write(tmpdir):
     gti = make_gti({"START": [5, 6, 1, 2], "STOP": [8, 7, 3, 4]})
     filename = tmpdir / "test.fits"
@@ -134,4 +135,4 @@ def test_gti_write(tmpdir):
     new_gti = GTI.read(filename)
     assert_time_allclose(new_gti.time_start, gti.time_start)
     assert_time_allclose(new_gti.time_stop, gti.time_stop)
-    assert new_gti.table.meta['MJDREFF'] ==  gti.table.meta['MJDREFF']
+    assert new_gti.table.meta["MJDREFF"] == gti.table.meta["MJDREFF"]

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -125,3 +125,13 @@ def test_gti_create():
     assert len(gti.table) == 2
     assert_allclose(gti.time_ref.mjd, time_ref.tt.mjd)
     assert_allclose(gti.table["START"], start.to_value("s"))
+
+def test_gti_write(tmpdir):
+    gti = make_gti({"START": [5, 6, 1, 2], "STOP": [8, 7, 3, 4]})
+    filename = tmpdir / "test.fits"
+    gti.write(filename, overwrite=True)
+
+    new_gti = GTI.read(filename)
+    assert_time_allclose(new_gti.time_start, gti.time_start)
+    assert_time_allclose(new_gti.time_stop, gti.time_stop)
+    assert new_gti.table.meta['MJDREFF'] ==  gti.table.meta['MJDREFF']

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -926,6 +926,10 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         hdu = fits.BinTableHDU(counts_table, name=name)
         hdulist = fits.HDUList([fits.PrimaryHDU(), hdu, self._ebounds_hdu(use_sherpa)])
 
+        if self.gti is not None:
+            gti_hdu = self.gti.to_hdulist()
+            hdulist += gti_hdu
+
         hdulist.writeto(str(outdir / phafile), overwrite=overwrite)
 
         self.aeff.write(outdir / arffile, overwrite=overwrite, use_sherpa=use_sherpa)
@@ -1042,6 +1046,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             acceptance=data["backscal"],
             acceptance_off=acceptance_off,
             name=str(data["obs_id"]),
+            gti=data["gti"],
         )
 
     # TODO: decide on a design for dataset info tables / dicts and make it part
@@ -1067,12 +1072,17 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         return info
 
 
-def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS"):
+def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS", hdu3="GTI"):
     """Create from `~astropy.io.fits.HDUList`."""
     counts_table = Table.read(hdulist[hdu1])
     ebounds = Table.read(hdulist[hdu2])
     emin = ebounds["E_MIN"].quantity
     emax = ebounds["E_MAX"].quantity
+
+    if hdu3 in hdulist:
+        gti = GTI.from_hdulist(hdulist, hdu3)
+    else:
+        gti=None
 
     # Check if column are present in the header
     quality = None
@@ -1096,4 +1106,5 @@ def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS"):
         livetime=counts_table.meta["EXPOSURE"] * u.s,
         obs_id=counts_table.meta["OBS_ID"],
         is_bkg=False,
+        gti=gti,
     )

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -1082,7 +1082,7 @@ def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS", hdu3="GTI"):
     if hdu3 in hdulist:
         gti = GTI.from_hdulist(hdulist, hdu3)
     else:
-        gti=None
+        gti = None
 
     # Check if column are present in the header
     quality = None

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -15,7 +15,12 @@ from gammapy.modeling.models import (
 )
 from gammapy.spectrum import CountsSpectrum, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.utils.random import get_random_state
-from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency, assert_time_allclose
+from gammapy.utils.testing import (
+    mpl_plot_check,
+    requires_data,
+    requires_dependency,
+    assert_time_allclose,
+)
 from gammapy.utils.time import time_ref_to_dict
 
 


### PR DESCRIPTION
GTIs have been added to datasets but were not exported in the `SpectrumDatasetOnOff.to_ogip()` and `MapDataset.write()` methods. They were also not read in `SpectrumDatasetOnOff.from_ogip()` and `MapDataset.read()` methods.

This PR solves this issue by introducing  `GTI.to_hdulist()` and `GTI.from_hdulist()` methods.
