### PR TITLE
Fix `SpectrumDatasetOnOff.energy_range` for empty mask_safe

### DIFF
--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -139,7 +139,7 @@ class EnergyDispersion:
         """
         data = self.pdf_matrix.copy()
         energy = self.e_reco.edges
-        idx = np.where((energy[:-1] < lo_threshold) | (energy[1:] > hi_threshold))
+        idx = (energy[:-1] < lo_threshold) | (energy[1:] > hi_threshold)
         data[:, idx] = 0
         return data
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -139,7 +139,11 @@ class EnergyDispersion:
         """
         data = self.pdf_matrix.copy()
         energy = self.e_reco.edges
-        idx = (energy[:-1] < lo_threshold) | (energy[1:] > hi_threshold)
+
+        if lo_threshold is None and hi_threshold is None:
+            idx = slice(None)
+        else:
+            idx = (energy[:-1] < lo_threshold) | (energy[1:] > hi_threshold)
         data[:, idx] = 0
         return data
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -254,9 +254,13 @@ class SpectrumDataset(Dataset):
     def energy_range(self):
         """Energy range defined by the safe mask"""
         energy = self._energy_axis.edges
-        e_lo = energy[:-1][self.mask_safe]
-        e_hi = energy[1:][self.mask_safe]
-        return u.Quantity([e_lo.min(), e_hi.max()])
+        e_min, e_max = energy[:-1], energy[1:]
+
+        if self.mask_safe is not None and self.mask_safe.any():
+            e_min = e_min[self.mask_safe]
+            e_max = e_max[self.mask_safe]
+
+        return u.Quantity([e_min.min(), e_max.max()])
 
     def plot_fit(self):
         """Plot counts and residuals in two panels.
@@ -392,7 +396,7 @@ class SpectrumDataset(Dataset):
             e_true[:-1], e_true[1:], np.zeros(e_true[:-1].shape) * u.m ** 2
         )
         edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
-        mask_safe = np.ones_like(counts.data, "bool")
+        mask_safe = np.zeros_like(counts.data, "bool")
         gti = GTI.create(u.Quantity([], "s"), u.Quantity([], "s"), reference_time)
         livetime = gti.time_sum
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -256,9 +256,12 @@ class SpectrumDataset(Dataset):
         energy = self._energy_axis.edges
         e_min, e_max = energy[:-1], energy[1:]
 
-        if self.mask_safe is not None and self.mask_safe.any():
-            e_min = e_min[self.mask_safe]
-            e_max = e_max[self.mask_safe]
+        if self.mask_safe is not None:
+            if self.mask_safe.any():
+                e_min = e_min[self.mask_safe]
+                e_max = e_max[self.mask_safe]
+            else:
+                return None, None
 
         return u.Quantity([e_min.min(), e_max.max()])
 

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -139,8 +139,7 @@ class TestSpectrumDataset:
         assert empty_dataset.edisp.data.axis("e_reco").nbin == 2
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
-
-        assert_allclose(empty_dataset.energy_range[0].value, 0.1)
+        assert empty_dataset.energy_range[0] is None
 
     def test_spectrum_dataset_stack_diagonal_safe_mask(self):
         aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")
@@ -234,7 +233,7 @@ class TestSpectrumOnOff:
         ereco = np.logspace(-1, 1, 5) * u.TeV
         elo = ereco[:-1]
         ehi = ereco[1:]
-
+        self.e_reco = ereco
         self.aeff = EffectiveAreaTable(etrue[:-1], etrue[1:], np.ones(9) * u.cm ** 2)
         self.edisp = EnergyDispersion.from_diagonal_response(etrue, ereco)
 
@@ -258,6 +257,7 @@ class TestSpectrumOnOff:
             acceptance=np.ones(elo.shape),
             acceptance_off=np.ones(elo.shape) * 10,
             name="test",
+            gti=self.gti
         )
 
     def test_spectrumdatasetonoff_create(self):
@@ -275,8 +275,12 @@ class TestSpectrumOnOff:
         assert empty_dataset.acceptance_off.shape[0] == 2
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
+        assert empty_dataset.energy_range[0] is None
 
-        assert_allclose(empty_dataset.energy_range[0].value, 0.1)
+    def test_create_stack(self):
+        stacked = SpectrumDatasetOnOff.create(self.e_reco, self.e_true)
+        stacked.stack(self.dataset)
+        assert_allclose(stacked.energy_range.value, self.dataset.energy_range.value)
 
     def test_init_no_model(self):
         with pytest.raises(AttributeError):

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -140,6 +140,8 @@ class TestSpectrumDataset:
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
 
+        assert_allclose(empty_dataset.energy_range[0].value, 0.1)
+
     def test_spectrum_dataset_stack_diagonal_safe_mask(self):
         aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")
         edisp = EnergyDispersion.from_diagonal_response(
@@ -273,6 +275,8 @@ class TestSpectrumOnOff:
         assert empty_dataset.acceptance_off.shape[0] == 2
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
+
+        assert_allclose(empty_dataset.energy_range[0].value, 0.1)
 
     def test_init_no_model(self):
         with pytest.raises(AttributeError):

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -140,6 +140,7 @@ class TestSpectrumDataset:
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
         assert empty_dataset.energy_range[0] is None
+        assert_allclose(empty_dataset.mask_safe, 0)
 
     def test_spectrum_dataset_stack_diagonal_safe_mask(self):
         aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")


### PR DESCRIPTION
This PRs fixes an issue reported by @lmohrmann in private: `SpectrumDatasetOnOff.energy_range` would fail, if the `mask_safe` is empty. This PR adds a regression test and fixe the behaviour. 