### PR TITLE
Implement `WcsNDMap.stack()` method

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -276,7 +276,7 @@ class MapDataset(Dataset):
                     evaluator.update(self.exposure, self.psf, self.edisp)
 
                 npred = evaluator.compute_npred()
-                npred_total.stack(npred, check=False)
+                npred_total.stack(npred)
 
         return npred_total
 
@@ -357,24 +357,24 @@ class MapDataset(Dataset):
         """
         if self.counts and other.counts:
             self.counts.data[~self.mask_safe] = 0
-            self.counts.stack(other.counts, weights=other.mask_safe, check=False)
+            self.counts.stack(other.counts, weights=other.mask_safe)
 
         if self.exposure and other.exposure:
-            self.exposure.stack(other.exposure, check=False)
+            self.exposure.stack(other.exposure)
 
         if self.background_model and other.background_model:
             bkg = self.background_model.evaluate()
             bkg.data[~self.mask_safe] = 0
             other_bkg = other.background_model.evaluate()
             other_bkg.data[~other.mask_safe] = 0
-            bkg.stack(other_bkg, check=False)
+            bkg.stack(other_bkg)
             self.background_model = BackgroundModel(bkg, name=self.background_model.name)
 
         if self.mask_safe is not None and other.mask_safe is not None:
             # TODO: make mask_safe a Map object
             mask_safe = Map.from_geom(self.counts.geom, data=self.mask_safe)
             mask_safe_other = Map.from_geom(other.counts.geom, data=other.mask_safe)
-            mask_safe.stack(mask_safe_other, check=False)
+            mask_safe.stack(mask_safe_other)
             self.mask_safe = mask_safe.data
 
         if self.psf and other.psf:

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -273,7 +273,7 @@ class MapDataset(Dataset):
                 # if the model component drifts out of its support the evaluator has
                 # has to be updated
                 if evaluator.needs_update:
-                    evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
+                    evaluator.update(self.exposure, self.psf, self.edisp)
 
                 npred = evaluator.compute_npred()
                 npred_total.stack(npred, check=False)

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -225,7 +225,7 @@ class MapDataset(Dataset):
                 evaluator = MapEvaluator(
                     component, evaluation_mode=self.evaluation_mode
                 )
-                evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
+                evaluator.update(self.exposure, self.psf, self.edisp)
                 evaluators.append(evaluator)
 
             self._evaluators = evaluators
@@ -276,12 +276,7 @@ class MapDataset(Dataset):
                     evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
 
                 npred = evaluator.compute_npred()
-
-                # avoid slow fancy indexing, when the shape is equivalent
-                if npred.data.shape == npred_total.data.shape:
-                    npred_total += npred.data
-                else:
-                    npred_total.data[evaluator.coords_idx] += npred.data
+                npred_total.stack(npred, check=False)
 
         return npred_total
 
@@ -294,6 +289,7 @@ class MapDataset(Dataset):
         rad_axis=None,
         reference_time="2000-01-01",
         name="",
+        **kwargs
     ):
         """Creates a MapDataset object with zero filled maps
 
@@ -348,6 +344,7 @@ class MapDataset(Dataset):
             gti=gti,
             mask_safe=mask_safe,
             name=name,
+            **kwargs
         )
 
     def stack(self, other):
@@ -360,23 +357,24 @@ class MapDataset(Dataset):
         """
         if self.counts and other.counts:
             self.counts.data[~self.mask_safe] = 0
-            self.counts.coadd(other.counts, weights=other.mask_safe)
+            self.counts.stack(other.counts, weights=other.mask_safe)
 
         if self.exposure and other.exposure:
-            self.exposure.coadd(other.exposure)
+            self.exposure.stack(other.exposure)
 
         if self.background_model and other.background_model:
             bkg = self.background_model.evaluate()
             bkg.data[~self.mask_safe] = 0
             other_bkg = other.background_model.evaluate()
             other_bkg.data[~other.mask_safe] = 0
-            bkg.coadd(other_bkg)
+            bkg.stack(other_bkg)
             self.background_model = BackgroundModel(bkg, name=self.background_model.name)
 
         if self.mask_safe is not None and other.mask_safe is not None:
+            # TODO: make mask_safe a Map object
             mask_safe = Map.from_geom(self.counts.geom, data=self.mask_safe)
             mask_safe_other = Map.from_geom(other.counts.geom, data=other.mask_safe)
-            mask_safe.coadd(mask_safe_other)
+            mask_safe.stack(mask_safe_other)
             self.mask_safe = mask_safe.data
 
         if self.psf and other.psf:
@@ -858,7 +856,7 @@ class MapEvaluator:
             update = separation > (self.model.evaluation_radius + CUTOUT_MARGIN)
         return update
 
-    def update(self, exposure, psf, edisp, geom):
+    def update(self, exposure, psf, edisp):
         """Update MapEvaluator, based on the current position of the model component.
 
         Parameters
@@ -869,8 +867,6 @@ class MapEvaluator:
             PSF map.
         edisp : `gammapy.cube.EDispMap`
             Edisp map.
-        geom : `gammapy.maps.Geom`
-            Reference geometry of the data.
         """
         log.debug("Updating model evaluator")
         # cache current position of the model component
@@ -898,11 +894,6 @@ class MapEvaluator:
                     f"Position {self.model.position!r} of model component is outside the image boundaries."
                     " Please check the starting values or position parameter boundaries of the model."
                 )
-
-            coords = self.exposure.geom.to_image().get_coord()
-            idx_x, idx_y = geom.to_image().coord_to_idx(coords)
-            self.coords_idx = (Ellipsis, idx_y, idx_x)
-
         else:
             self.exposure = exposure
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -357,24 +357,24 @@ class MapDataset(Dataset):
         """
         if self.counts and other.counts:
             self.counts.data[~self.mask_safe] = 0
-            self.counts.stack(other.counts, weights=other.mask_safe)
+            self.counts.stack(other.counts, weights=other.mask_safe, check=False)
 
         if self.exposure and other.exposure:
-            self.exposure.stack(other.exposure)
+            self.exposure.stack(other.exposure, check=False)
 
         if self.background_model and other.background_model:
             bkg = self.background_model.evaluate()
             bkg.data[~self.mask_safe] = 0
             other_bkg = other.background_model.evaluate()
             other_bkg.data[~other.mask_safe] = 0
-            bkg.stack(other_bkg)
+            bkg.stack(other_bkg, check=False)
             self.background_model = BackgroundModel(bkg, name=self.background_model.name)
 
         if self.mask_safe is not None and other.mask_safe is not None:
             # TODO: make mask_safe a Map object
             mask_safe = Map.from_geom(self.counts.geom, data=self.mask_safe)
             mask_safe_other = Map.from_geom(other.counts.geom, data=other.mask_safe)
-            mask_safe.stack(mask_safe_other)
+            mask_safe.stack(mask_safe_other, check=False)
             self.mask_safe = mask_safe.data
 
         if self.psf and other.psf:

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -475,7 +475,6 @@ class MapMakerRing:
 
         return images
 
-
     def _run(self, observations, sum_over_axis=False, spectrum=None, keepdims=False):
         selection = ["on", "exposure_on", "off", "exposure_off", "exposure"]
         maps = self._get_empty_maps(selection)
@@ -514,7 +513,8 @@ class MapMakerRing:
 
             # Now paste the returned maps on the ref geom
             for name in selection:
-                maps[name].stack(maps_obs[name], check=False)
+                data = maps_obs[name].quantity.to_value(maps[name].unit)
+                maps[name].fill_by_coord(maps_obs[name].geom.get_coord(), data)
 
         self._maps = maps
         return maps

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -514,7 +514,7 @@ class MapMakerRing:
 
             # Now paste the returned maps on the ref geom
             for name in selection:
-                maps[name].stack(maps_obs[name])
+                maps[name].stack(maps_obs[name], check=False)
 
         self._maps = maps
         return maps

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -514,8 +514,7 @@ class MapMakerRing:
 
             # Now paste the returned maps on the ref geom
             for name in selection:
-                data = maps_obs[name].quantity.to_value(maps[name].unit)
-                maps[name].fill_by_coord(maps_obs[name].geom.get_coord(), data)
+                maps[name].stack(maps_obs[name])
 
         self._maps = maps
         return maps

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -179,13 +179,15 @@ class WcsGeom(Geom):
         Reference pixel coordinate in each image plane.
     axes : list
         Axes for non-spatial dimensions
+    cutout_info : dict
+        Dict with cutout info, if the `WcsGeom` was created by `WcsGeom.cutout()`
     """
 
     _slice_spatial_axes = slice(0, 2)
     _slice_non_spatial_axes = slice(2, None)
     is_hpx = False
 
-    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None):
+    def __init__(self, wcs, npix, cdelt=None, crpix=None, axes=None, cutout_info=None):
         self._wcs = wcs
         self._coordsys = get_coordys(wcs)
         self._projection = get_projection(wcs)
@@ -204,6 +206,7 @@ class WcsGeom(Geom):
             crpix = tuple(1.0 + (np.array(self._npix) - 1.0) / 2.0)
 
         self._crpix = crpix
+        self._cutout_info = cutout_info
 
     @property
     def data_shape(self):
@@ -239,6 +242,11 @@ class WcsGeom(Geom):
         Galactic ('GAL') or Equatorial ('CEL').
         """
         return self._coordsys
+
+    @property
+    def cutout_info(self):
+        """Cutout info dict."""
+        return self._cutout_info
 
     @property
     def projection(self):
@@ -880,7 +888,13 @@ class WcsGeom(Geom):
             mode=mode,
         )
 
-        return self._init_copy(wcs=c2d.wcs, npix=c2d.shape[::-1])
+        cutout_info = {
+            "parent-geom": self,
+            "parent-slices": c2d.slices_original,
+            "cutout-slices": c2d.slices_cutout
+        }
+
+        return self._init_copy(wcs=c2d.wcs, npix=c2d.shape[::-1], cutout_info=cutout_info)
 
     def region_mask(self, regions, inside=True):
         """Create a mask from a given list of regions

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -703,13 +703,26 @@ class WcsGeom(Geom):
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
-        return self.__class__(self._wcs, npix, cdelt=cdelt, cutout_info=self.cutout_info)
+
+        if self.cutout_info:
+            cutout_info = self.cutout_info.copy()
+            cutout_info["parent-geom"] = cutout_info["parent-geom"].to_image()
+        else:
+            cutout_info = None
+        return self.__class__(self._wcs, npix, cdelt=cdelt, cutout_info=cutout_info)
 
     def to_cube(self, axes):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
         axes = copy.deepcopy(self.axes) + axes
-        return self.__class__(self._wcs.deepcopy(), npix, cdelt=cdelt, axes=axes, cutout_info=self.cutout_info)
+
+        if self.cutout_info:
+            cutout_info = self.cutout_info.copy()
+            cutout_info["parent-geom"] = cutout_info["parent-geom"].to_cube(axes)
+        else:
+            cutout_info = None
+
+        return self.__class__(self._wcs.deepcopy(), npix, cdelt=cdelt, axes=axes, cutout_info=cutout_info)
 
     def pad(self, pad_width):
         if np.isscalar(pad_width):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -703,13 +703,13 @@ class WcsGeom(Geom):
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
-        return self.__class__(self._wcs, npix, cdelt=cdelt)
+        return self.__class__(self._wcs, npix, cdelt=cdelt, cutout_info=self.cutout_info)
 
     def to_cube(self, axes):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
         axes = copy.deepcopy(self.axes) + axes
-        return self.__class__(self._wcs.deepcopy(), npix, cdelt=cdelt, axes=axes)
+        return self.__class__(self._wcs.deepcopy(), npix, cdelt=cdelt, axes=axes, cutout_info=self.cutout_info)
 
     def pad(self, pad_width):
         if np.isscalar(pad_width):

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -685,20 +685,19 @@ class WcsNDMap(WcsMap):
         ----------
         other : `WcsNDMap`
             Other map to stack
-        weights : `WcsNDMap`
+        weights : `~numpy.ndarray`
             Other map to be used as weights.
         check : bool
-            Check whether geoms are aligned.
-
+            Check whether other is cutout of self.geom.
         """
-        if check:
-            if other.geom != self.geom:
-                if other.geom.cutout_info is None:
-                    raise ValueError("Can only stack into the map, the cutout was created from.")
-
         if self.geom == other.geom:
             parent_slices, cutout_slices = None, None
         else:
+            if other.geom.cutout_info is None:
+                raise ValueError("Can only stack cutout into larger map.")
+            elif other.geom.cutout_info["parent-geom"] is not self.geom and check:
+                raise ValueError("Can only stack into map, the cutout was created from.")
+
             slices = other.geom.cutout_info["parent-slices"]
             parent_slices = Ellipsis, slices[0], slices[1]
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -678,31 +678,26 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(geom=geom_cutout, data=data)
 
-    def stack(self, other, weights=None, check=True):
-        """Stack cutout into larger map.
+    def stack(self, other, weights=None):
+        """Stack cutout into map.
 
         Parameters
         ----------
         other : `WcsNDMap`
             Other map to stack
         weights : `~numpy.ndarray`
-            Other map to be used as weights.
-        check : bool
-            Check whether other is cutout of self.geom.
+            Array to be used as weights.
         """
         if self.geom == other.geom:
             parent_slices, cutout_slices = None, None
-        else:
-            if other.geom.cutout_info is None:
-                raise ValueError("Can only stack cutout into larger map.")
-            elif other.geom.cutout_info["parent-geom"] is not self.geom and check:
-                raise ValueError("Can only stack into map, the cutout was created from.")
-
+        elif other.geom.cutout_info is not None and self.geom == other.geom.cutout_info["parent-geom"]:
             slices = other.geom.cutout_info["parent-slices"]
             parent_slices = Ellipsis, slices[0], slices[1]
 
             slices = other.geom.cutout_info["cutout-slices"]
             cutout_slices = Ellipsis, slices[0], slices[1]
+        else:
+            raise ValueError("Can only stack equivalent maps or cutout of the same map.")
 
         data = other.data[cutout_slices]
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -669,24 +669,14 @@ class WcsNDMap(WcsMap):
         cutout : `~gammapy.maps.WcsNDMap`
             Cutout map
         """
-        width = _check_width(width)
-        idx = (0,) * len(self.geom.axes)
-        c2d = Cutout2D(
-            data=self.data[idx],
-            wcs=self.geom.wcs,
-            position=position,
-            # Cutout2D takes size with order (lat, lon)
-            size=width[::-1] * u.deg,
-            mode=mode,
-        )
+        geom_cutout = self.geom.cutout(position=position, width=width, mode=mode)
 
-        # Create the slices with the non-spatial axis
-        cutout_slices = Ellipsis, c2d.slices_original[0], c2d.slices_original[1]
+        slices = geom_cutout.cutout_info["parent-slices"]
+        cutout_slices = Ellipsis, slices[0], slices[1]
 
-        geom = WcsGeom(c2d.wcs, c2d.shape[::-1], axes=self.geom.axes)
         data = self.data[cutout_slices]
 
-        return self._init_copy(geom=geom, data=data)
+        return self._init_copy(geom=geom_cutout, data=data)
 
     def sample_coord(self, n_events, random_state=0):
         """Sample position and energy of events.

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -678,6 +678,40 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(geom=geom_cutout, data=data)
 
+    def stack(self, other, weights=None, check=True):
+        """Stack cutout into larger map.
+
+        Parameters
+        ----------
+        other : `WcsNDMap`
+            Other map to stack
+        weights : `WcsNDMap`
+            Other map to be used as weights.
+        check : bool
+            Check whether geoms are aligned.
+
+        """
+        if check:
+            if other.geom != self.geom:
+                if other.geom.cutout_info is None:
+                    raise ValueError("Can only stack into the map, the cutout was created from.")
+
+        if self.geom == other.geom:
+            parent_slices, cutout_slices = None, None
+        else:
+            slices = other.geom.cutout_info["parent-slices"]
+            parent_slices = Ellipsis, slices[0], slices[1]
+
+            slices = other.geom.cutout_info["cutout-slices"]
+            cutout_slices = Ellipsis, slices[0], slices[1]
+
+        data = other.data[cutout_slices]
+
+        if weights is not None:
+            data = data * weights
+
+        self.data[parent_slices] += data
+
     def sample_coord(self, n_events, random_state=0):
         """Sample position and energy of events.
 

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -198,10 +198,10 @@ def test_analysis_3d():
     assert len(analysis.flux_points.data.table) == 2
     dnde = analysis.flux_points.data.table["dnde"].quantity
 
-    assert_allclose(dnde[0].value, 1.175e-11, rtol=1e-1)
-    assert_allclose(dnde[-1].value, 4.061e-13, rtol=1e-1)
+    assert_allclose(dnde[0].value, 5.256007e-12, rtol=1e-1)
+    assert_allclose(dnde[-1].value, 1.932315e-13, rtol=1e-1)
     assert_allclose(res["index"].value, 2.76607, rtol=1e-1)
-    assert_allclose(res["tilt"].value, -0.021689, rtol=1e-1)
+    assert_allclose(res["tilt"].value, -0.011254, rtol=1e-1)
 
 
 @requires_data()

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -198,10 +198,10 @@ def test_analysis_3d():
     assert len(analysis.flux_points.data.table) == 2
     dnde = analysis.flux_points.data.table["dnde"].quantity
 
-    assert_allclose(dnde[0].value, 5.256007e-12, rtol=1e-1)
-    assert_allclose(dnde[-1].value, 1.932315e-13, rtol=1e-1)
+    assert_allclose(dnde[0].value, 1.182768e-11, rtol=1e-1)
+    assert_allclose(dnde[-1].value, 4.051367e-13, rtol=1e-1)
     assert_allclose(res["index"].value, 2.76607, rtol=1e-1)
-    assert_allclose(res["tilt"].value, -0.011254, rtol=1e-1)
+    assert_allclose(res["tilt"].value, -0.021688, rtol=1e-1)
 
 
 @requires_data()

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -641,7 +641,7 @@
     "model_total = SkyModels([model, model_diffuse, model_iso])\n",
     "\n",
     "dataset = MapDataset(\n",
-    "    model=model_total, counts=counts, exposure=exposure, psf=psf_kernel\n",
+    "    model=model_total, counts=counts, exposure=exposure, psf=psf_kernel, edisp=edisp\n",
     ")\n",
     "fit = Fit(dataset)\n",
     "result = fit.run()"


### PR DESCRIPTION
This PR implements a `WcsNDMap.stack()` method. The `.stack()` methode is meant to be used together with `WcsNDMap.cutout()` to handle the common use-case of processing a cutout of a map and the pasting the result into a larger map. To achieve this in a consistent manner a `WcsGeom.cutout_info` is added, which contains a reference to the parent geom as well as the parent and cutout slices. Later the info could be extended e.g. to also contain views e.g. into larger coordinate arrays. 