### PR TITLE
Add an `obs_info` table on datasets

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -68,6 +68,9 @@ class MapDataset(Dataset):
         Mask defining the safe data range.
     gti : '~gammapy.data.GTI'
         GTI of the observation or union of GTI if it is a stacked observation
+    obs_info : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset
+        One line per observation for stacked datasets.
     """
 
     def __init__(
@@ -84,6 +87,7 @@ class MapDataset(Dataset):
         evaluation_mode="local",
         mask_safe=None,
         gti=None,
+        obs_info=None,
     ):
         if mask_fit is not None and mask_fit.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
@@ -100,6 +104,7 @@ class MapDataset(Dataset):
         self.name = name
         self.mask_safe = mask_safe
         self.gti = gti
+        self.obs_info = obs_info
         if likelihood == "cash":
             self._stat = cash
             self._stat_sum = cash_sum_cython
@@ -393,6 +398,9 @@ class MapDataset(Dataset):
 
         if self.gti and other.gti:
             self.gti = self.gti.stack(other.gti).union()
+
+        if self.obs_info is not None:
+            self.obs_info = vstack([self.obs_info, other.obs_info])
 
     def likelihood_per_bin(self):
         """Likelihood per bin given the current model parameters"""

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -5,6 +5,7 @@ import astropy.units as u
 from astropy.io import fits
 from astropy.nddata.utils import NoOverlapError
 from astropy.utils import lazyproperty
+from astropy.table import vstack, Table
 from regions import CircleSkyRegion
 from gammapy.cube.edisp_map import EDispMap
 from gammapy.cube.psf_kernel import PSFKernel
@@ -105,6 +106,7 @@ class MapDataset(Dataset):
         self.mask_safe = mask_safe
         self.gti = gti
         self.obs_info = obs_info
+
         if likelihood == "cash":
             self._stat = cash
             self._stat_sum = cash_sum_cython
@@ -344,6 +346,8 @@ class MapDataset(Dataset):
         psf_map = Map.from_geom(geom_rad, unit="sr-1")
         psf = PSFMap(psf_map, exposure_irf)
 
+        obs_info = Table()
+
         return cls(
             counts=counts,
             exposure=exposure,
@@ -353,6 +357,7 @@ class MapDataset(Dataset):
             gti=gti,
             mask_safe=mask_safe,
             name=name,
+            obs_info=obs_info,
         )
 
     def stack(self, other):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -606,6 +606,10 @@ class MapDataset(Dataset):
         if self.gti is not None:
             hdulist += self.gti.to_hdulist()
 
+        if self.obs_info is not None:
+            header = self.obs_info.meta
+            hdulist += [fits.BinTableHDU(self.obs_info, header=header, name="obs_info")]
+
         return hdulist
 
     @classmethod
@@ -654,6 +658,11 @@ class MapDataset(Dataset):
         if "GTI" in hdulist:
             gti = GTI.from_hdulist(hdulist, hdu="GTI")
             init_kwargs["gti"] = gti
+
+        if "OBS_INFO" in hdulist:
+            obs_info = Table.read(hdulist["obs_info"])
+            init_kwargs["obs_info"] = obs_info
+
         return cls(**init_kwargs)
 
     def write(self, filename, overwrite=False):

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -6,6 +6,7 @@ from astropy.utils import lazyproperty
 from gammapy.irf import EnergyDependentMultiGaussPSF
 from gammapy.maps import Map, WcsGeom
 from gammapy.modeling.models import BackgroundModel
+from gammapy.utils.table import table_from_row_data
 from .background import make_map_background_irf
 from .counts import fill_map_counts
 from .edisp_map import make_edisp_map
@@ -16,7 +17,6 @@ from .psf_map import make_psf_map
 __all__ = ["MapMakerObs", "MapMakerRing"]
 
 log = logging.getLogger(__name__)
-
 
 class MapMakerObs:
     """Make maps for a single IACT observation.
@@ -123,6 +123,12 @@ class MapMakerObs:
         else:
             background_model = None
 
+        # Export observation info if it exists
+        if self.observation.obs_info is not None:
+            obs_info = table_from_row_data([self.observation.obs_info])
+        else:
+            obs_info = None
+
         dataset = MapDataset(
             counts=self.maps.get("counts"),
             exposure=self.maps.get("exposure"),
@@ -132,6 +138,7 @@ class MapMakerObs:
             gti=self.observation.gti,
             name="obs_{}".format(self.observation.obs_id),
             mask_safe=~self.fov_mask,
+            obs_info=obs_info,
         )
         return dataset
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -202,6 +202,8 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
     gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
     dataset.gti = gti
 
+    dataset.obs_info = Table([[1], [2], [3]], names=('col1', 'col2', 'col3'))
+
     hdulist = dataset.to_hdulist()
     actual = [hdu.name for hdu in hdulist]
 
@@ -222,6 +224,7 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         "MASK_FIT",
         "MASK_FIT_BANDS",
         "GTI",
+        "OBS_INFO"
     ]
 
     assert actual == desired
@@ -259,6 +262,9 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
         dataset.gti.time_sum.to_value("s"), dataset_new.gti.time_sum.to_value("s")
     )
 
+    assert len(dataset_new.obs_info) == 1
+    assert dataset_new.obs_info['col1'][0] == 1
+    assert dataset_new.obs_info['col3'][0] == 3
 
 @requires_dependency("iminuit")
 @requires_dependency("matplotlib")

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -3,6 +3,7 @@ import abc
 import copy
 from collections import Counter
 import numpy as np
+from astropy.table import vstack
 from gammapy.utils.scripts import read_yaml, write_yaml
 from .parameter import Parameters
 
@@ -111,6 +112,10 @@ class Datasets:
     def types(self):
         """Types of the contained datasets"""
         return [type(dataset).__name__ for dataset in self.datasets]
+
+    @property
+    def obs_info(self):
+        return vstack([_.obs_info for _ in self.datasets])
 
     @property
     def is_all_same_type(self):

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -941,6 +941,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         name = counts_table.meta["name"]
         hdu = fits.BinTableHDU(counts_table, name=name)
+        # TODO add export of obs_info table into OGIP counts spectrum file?
         hdulist = fits.HDUList([fits.PrimaryHDU(), hdu, self._ebounds_hdu(use_sherpa)])
 
         if self.gti is not None:

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import Table, vstack
 from gammapy.data import GTI, ObservationStats
 from gammapy.irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
 from gammapy.modeling import Dataset, Parameters
@@ -488,6 +488,9 @@ class SpectrumDataset(Dataset):
         # of GTIs
         self.livetime += other.livetime
 
+        if self.obs_info is not None:
+            self.obs_info = vstack([self.obs_info, other.obs_info])
+
 
 class SpectrumDatasetOnOff(SpectrumDataset):
     """Spectrum dataset for on-off likelihood fitting.
@@ -844,6 +847,10 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         # TODO: for the moment, since dead time is not accounted for, livetime cannot be the sum
         # of GTIs
         self.livetime += other.livetime
+
+        if self.obs_info is not None:
+            self.obs_info = vstack([self.obs_info, other.obs_info])
+
 
     def peek(self, figsize=(10, 10)):
         """Quick-look summary plots."""

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -45,6 +45,9 @@ class SpectrumDataset(Dataset):
         Dataset name.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    obs_info : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset
+        One line per observation for stacked datasets.
 
     See Also
     --------
@@ -65,6 +68,7 @@ class SpectrumDataset(Dataset):
         mask_fit=None,
         name="",
         gti=None,
+        obs_info=None,
     ):
         if mask_fit is not None and mask_fit.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")
@@ -83,6 +87,7 @@ class SpectrumDataset(Dataset):
         self.mask_safe = mask_safe
         self.name = name
         self.gti = gti
+        self.obs_info = obs_info
 
     def __str__(self):
         str_ = self.__class__.__name__
@@ -518,6 +523,9 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         Name of the dataset.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    obs_info : `~astropy.table.Table`
+        Table listing informations on observations used to create the dataset
+        One line per observation for stacked datasets.
 
     See Also
     --------
@@ -540,6 +548,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         acceptance_off=None,
         name="",
         gti=None,
+        obs_info=None,
     ):
 
         self.counts = counts
@@ -565,6 +574,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self.acceptance_off = acceptance_off
         self.name = name
         self.gti = gti
+        self.obs_info = obs_info
 
     def __str__(self):
         str_ = super().__str__()

--- a/gammapy/spectrum/extract.py
+++ b/gammapy/spectrum/extract.py
@@ -4,8 +4,10 @@ from pathlib import Path
 import numpy as np
 import astropy.units as u
 from regions import CircleSkyRegion
+
 from gammapy.irf import PSF3D, apply_containment_fraction, compute_energy_thresholds
 from gammapy.utils.scripts import make_path
+from gammapy.utils.table import table_from_row_data
 from .core import CountsSpectrum
 from .dataset import SpectrumDatasetOnOff
 
@@ -125,6 +127,12 @@ class SpectrumExtraction:
         else:
             self.containment = np.ones(self._aeff.energy.nbin)
 
+        # Export observation info if it exists
+        if observation.obs_info is not None:
+            obs_info = table_from_row_data([observation.obs_info])
+        else:
+            obs_info = None
+
         spectrum_observation = SpectrumDatasetOnOff(
             counts=self._on_vector,
             aeff=self._aeff,
@@ -135,6 +143,7 @@ class SpectrumExtraction:
             acceptance_off=bkg.a_off,
             name=str(observation.obs_id),
             gti=observation.gti,
+            obs_info=obs_info,
         )
 
         if self.use_recommended_erange:

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -623,6 +623,9 @@ def make_observation_list():
     gti1 = make_gti({"START": [5, 6, 1, 2], "STOP": [8, 7, 3, 4]}, time_ref=time_ref)
     gti2 = make_gti({"START": [14], "STOP": [15]}, time_ref=time_ref)
 
+    obs_info1 = Table([[1],[2],[3]], names=('col1', 'col2', 'col3'))
+    obs_info2 = Table([[4],[5],[6]], names=('col1', 'col2', 'col3'))
+
     obs1 = SpectrumDatasetOnOff(
         counts=on_vector,
         counts_off=off_vector1,
@@ -634,6 +637,7 @@ def make_observation_list():
         acceptance_off=2,
         name="2",
         gti=gti1,
+        obs_info=obs_info1,
     )
     obs2 = SpectrumDatasetOnOff(
         counts=on_vector,
@@ -646,6 +650,7 @@ def make_observation_list():
         acceptance_off=4,
         name="2",
         gti=gti2,
+        obs_info=obs_info2,
     )
 
     obs_list = [obs1, obs2]
@@ -727,7 +732,6 @@ class TestSpectrumDatasetOnOffStack:
         assert_allclose(table_gti_stacked_obs["START"], table_gti["START"])
         assert_allclose(table_gti_stacked_obs["STOP"], table_gti["STOP"])
 
-
 @requires_data("gammapy-data")
 def test_datasets_stack_reduce():
     obs_ids = [23523, 23526, 23559, 23592]
@@ -739,3 +743,5 @@ def test_datasets_stack_reduce():
     datasets = Datasets(dataset_list)
     stacked = datasets.stack_reduce()
     assert_allclose(stacked.livetime.to_value("s"), 6313.8116406202325)
+    assert len(stacked.obs_info) == 4
+

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -129,6 +129,9 @@ class TestSpectrumExtraction:
         assert_allclose(gti_dataset["START"], gti_obs["START"])
         assert_allclose(gti_dataset["STOP"], gti_obs["STOP"])
 
+        obs_info = extraction.spectrum_observations[0].obs_info
+        assert 'OBS_ID' in obs_info.colnames
+
     @staticmethod
     def test_alpha(observations, bkg_estimate):
         bkg_estimate[0].a_off = 0


### PR DESCRIPTION
This PR is a small addition to datasets classes (`SpectrumDataset`, `SpectrumDatasetOnOff`, `MapDataset`) to add the `obs_info` from the `DatastoreObservation` in the form of a `Table`. This allows to keep track of the parameters of the parent observation(s).

The `Table` offers easier usage than e.g. a `dict` in a `meta`. In particular, stacking is simply obtained with a `vstack` and allows for the set of `obs_info` of the observations that were reduced to create the dataset. A property is added on `Datasets` to stack the `obs_info` of all datasets in the list. 

This addition is useful to obtain the distribution of typical parameters .e.g. zenith angle, efficiency etc. It can be useful for dataset grouping and stacking for similar observation conditions.