### PR TITLE
Remove error raising, when model component moves out of the image

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -315,9 +315,9 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     # test model evaluation outside image
 
-    with pytest.raises(ValueError):
-        dataset_1.model.skymodels[0].spatial_model.lon_0.value = 150
-        dataset_1.npred()
+    dataset_1.model.skymodels[0].spatial_model.lon_0.value = 150
+    dataset_1.npred()
+    assert not dataset_1._evaluators[0].contributes
 
     with mpl_plot_check():
         dataset_1.plot_residuals()


### PR DESCRIPTION
This PR removes the error raising, when a model component drift out of the image. Instead the model contribution is just ignored in the likelihood evaluation, which seems the more reasonable choice.