### PR TITLE
Use `Conda activate root` in travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ install:
           conda info;
           conda --version;
           conda build --version;
-          source activate root;
+          conda activate root;
       fi
 
     # This is needed to make matplotlib plot testing work


### PR DESCRIPTION
This PR tries to fix https://travis-ci.org/gammapy/gammapy/jobs/598124925, by changing `source activate root` to `condo activate root` in the `.travis.yml` file.