### PR TITLE
Implement `SpectrumDatasetMaker`

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -88,11 +88,13 @@ def energy_axis_from_fgst_ccube(hdu):
 def energy_axis_from_fgst_template(hdu):
     bands = Table.read(hdu)
 
-    # TODO: check upper / lowercase handling
-    try:
-        nodes = bands["Energy"].data
-    except KeyError:
-        nodes = bands["ENERGY"].data
+    allowed_names = ["Energy", "ENERGY", "energy"]
+    for colname in bands.colnames:
+        if colname in allowed_names:
+            tag = colname
+            break
+            
+    nodes = bands[tag].data
 
     return [MapAxis.from_nodes(nodes=nodes, name="energy", unit="MeV", interp="log")]
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -88,13 +88,11 @@ def energy_axis_from_fgst_ccube(hdu):
 def energy_axis_from_fgst_template(hdu):
     bands = Table.read(hdu)
 
-    allowed_names=["Energy","ENERGY","energy"]
-    for colname in bands.colnames:
-        if colname in allowed_names :
-            tag = colname
-            break
-    nodes = bands[tag].data
-
+    # TODO: check upper / lowercase handling
+    try:
+        nodes = bands["Energy"].data
+    except KeyError:
+        nodes = bands["ENERGY"].data
 
     return [MapAxis.from_nodes(nodes=nodes, name="energy", unit="MeV", interp="log")]
 
@@ -176,6 +174,15 @@ def coordsys_to_frame(coordsys):
         return "galactic"
     else:
         raise ValueError(f"Unrecognized coordinate system: {coordsys!r}")
+
+
+def frame_to_coordsys(frame):
+    if frame in ["fk5", "fk4", "icrs"]:
+        return "CEL"
+    elif frame == "galactic":
+        return "GAL"
+    else:
+        raise ValueError(f"Unrecognized coordinate system: {frame!r}")
 
 
 # TODO: remove (or improve)

--- a/gammapy/spectrum/__init__.py
+++ b/gammapy/spectrum/__init__.py
@@ -5,6 +5,7 @@ from .core import *
 from .dataset import *
 from .extract import *
 from .flux_point import *
+from .make import *
 from .phase import *
 from .reflected import *
 from .sensitivity import *

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -1,0 +1,220 @@
+import logging
+from astropy import units as u
+from astropy.coordinates import Angle
+from astropy.utils import lazyproperty
+from regions import CircleSkyRegion
+from gammapy.irf import EnergyDependentMultiGaussPSF, apply_containment_fraction
+from gammapy.maps import WcsGeom
+from gammapy.maps.geom import frame_to_coordsys
+from .core import CountsSpectrum
+from .dataset import SpectrumDataset
+
+log = logging.getLogger(__name__)
+
+
+class SpectrumDatasetMaker:
+    """Make spectrum for a single IACT observation.
+
+    The irfs and background are computed at a single fixed offset,
+    which is recommend only for point-sources.
+
+    Parameters
+    ----------
+    region : `~regions.SkyRegion`
+        Region to compute spectrum dataset for.
+    e_reco : `~astropy.units.Quantity`
+        Reconstructed energy binning
+    e_true : `~astropy.units.Quantity`
+        True energy binning
+    containment_correction : bool
+        Apply containment correction for point sources and circular on regions.
+    binsz : `~astropy.coordinates.Angle`
+        Reference map bin size.
+    width : `~astropy.coordinates.Angle`
+        Reference map width, should encompass the whole region.
+
+    """
+
+    def __init__(
+        self,
+        region,
+        e_reco,
+        e_true=None,
+        containment_correction=True,
+        binsz="0.01 deg",
+        width="0.5 deg",
+    ):
+        self.region = region
+        self.e_reco = e_reco
+        self.e_true = e_true or e_reco
+        self.containment_correction = containment_correction
+        self.binsz = Angle(binsz)
+        self.width = Angle(width)
+
+    # TODO: move this to a RegionGeom class
+    @lazyproperty
+    def geom_ref(self):
+        """Reference geometry to project region"""
+        coordsys = frame_to_coordsys(self.region.center.frame.name)
+        return WcsGeom.create(
+            skydir=self.region.center,
+            width=self.width,
+            binsz=self.binsz,
+            proj="TAN",
+            coordsys=coordsys,
+        )
+
+    @lazyproperty
+    # TODO: move this to a RegionGeom class
+    def region_solid_angle(self):
+        """Solid angle of the region"""
+        geom = self.geom_ref
+        coords = geom.get_coord()
+        solid_angle = geom.solid_angle()
+        mask = self.region.contains(coords.skycoord, wcs=geom.wcs)
+        return solid_angle[mask].sum()
+
+    def make_counts(self, observation):
+        """Make counts
+
+        Parameters
+        ----------
+        observation: `DataStoreObservation`
+            Observation to compute effective area for.
+
+        Returns
+        -------
+        counts : `CountsSpectrum`
+            Counts spectrum
+        """
+        energy_hi = self.e_reco[1:]
+        energy_lo = self.e_reco[:-1]
+
+        counts = CountsSpectrum(energy_hi=energy_hi, energy_lo=energy_lo)
+        events_region = observation.events.select_region(
+            self.region, wcs=self.geom_ref.wcs
+        )
+        counts.fill(events_region)
+        return counts
+
+    def make_background(self, observation):
+        """Make background
+
+        Parameters
+        ----------
+        observation: `DataStoreObservation`
+            Observation to compute effective area for.
+
+        Returns
+        -------
+        background : `CountsSpectrum`
+            Background spectrum
+        """
+        offset = observation.pointing_radec.separation(self.region.center)
+        energy_hi = self.e_reco[1:]
+        energy_lo = self.e_reco[:-1]
+
+        bkg = observation.bkg
+
+        data = bkg.evaluate_integrate(
+            fov_lon=0 * u.deg, fov_lat=offset, energy_reco=self.e_reco
+        )
+
+        data *= self.region_solid_angle
+        data *= observation.observation_time_duration
+
+        counts = CountsSpectrum(
+            energy_hi=energy_hi, energy_lo=energy_lo, data=data.to_value(""), unit=""
+        )
+        return counts
+
+    def make_aeff(self, observation):
+        """Make effective area
+
+        Parameters
+        ----------
+        observation: `DataStoreObservation`
+            Observation to compute effective area for.
+
+        Returns
+        -------
+        aeff : `EffectiveAreaTable`
+            Effective area table.
+        """
+        offset = observation.pointing_radec.separation(self.region.center)
+        aeff = observation.aeff.to_effective_area_table(offset, energy=self.e_true)
+
+        if self.containment_correction:
+            if not isinstance(self.region, CircleSkyRegion):
+                raise TypeError(
+                    "Containment correction only support for circular regions."
+                )
+            psf = observation.psf
+
+            if isinstance(psf, EnergyDependentMultiGaussPSF):
+                psf = psf.to_psf3d()
+
+            table_psf = psf.to_energy_dependent_table_psf(theta=offset)
+            aeff = apply_containment_fraction(aeff, table_psf, self.region.radius)
+
+        return aeff
+
+    def make_edisp(self, observation):
+        """Make energy dispersion
+
+        Parameters
+        ----------
+        observation: `DataStoreObservation`
+            Observation to compute edisp for.
+
+        Returns
+        -------
+        edisp : `EnergyDispersion`
+            Energy dispersion
+
+        """
+        offset = observation.pointing_radec.separation(self.region.center)
+        edisp = observation.edisp.to_energy_dispersion(
+            offset, e_reco=self.e_reco, e_true=self.e_true
+        )
+        return edisp
+
+    def run(self, observation, selection=None):
+        """Make spectrum dataset.
+
+        Parameters
+        ----------
+        observation: `DataStoreObservation`
+            Observation to reduce.
+        selection : list
+            List of str, selecting which maps to make.
+            Available: 'counts', 'aeff', 'background', 'edisp'
+            By default, all spectra are made.
+
+        Returns
+        -------
+        dataset : `SpectrumDataset`
+            Spectrum dataset.
+        """
+        if selection is None:
+            selection = ["counts", "background", "aeff", "edisp"]
+
+        kwargs = {}
+
+        kwargs["gti"] = observation.gti
+        kwargs["name"] = "obs_{}".format(observation.obs_id)
+        kwargs["livetime"] = observation.observation_live_time_duration
+
+        if "counts" in selection:
+            kwargs["counts"] = self.make_counts(observation)
+
+        if "background" in selection:
+            kwargs["background"] = self.make_background(observation)
+
+        if "aeff" in selection:
+            kwargs["aeff"] = self.make_aeff(observation)
+
+        if "edisp" in selection:
+            kwargs["edisp"] = self.make_edisp(observation)
+
+        return SpectrumDataset(**kwargs)

--- a/gammapy/spectrum/reflected.py
+++ b/gammapy/spectrum/reflected.py
@@ -5,6 +5,7 @@ from astropy import units as u
 from astropy.coordinates import Angle, SkyCoord
 from regions import PixCoord
 from gammapy.maps import Map, WcsGeom, WcsNDMap
+from gammapy.maps.geom import frame_to_coordsys
 from .background_estimate import BackgroundEstimate
 
 __all__ = ["ReflectedRegionsFinder", "ReflectedRegionsBackgroundEstimator"]
@@ -140,14 +141,7 @@ class ReflectedRegionsFinder:
         reference_map : `~gammapy.maps.WcsNDMap`
             Map containing the region
         """
-
-        try:
-            if "ra" in region.center.representation_component_names:
-                coordsys = "CEL"
-            else:
-                coordsys = "GAL"
-        except:
-            raise TypeError("Algorithm not yet adapted to this Region shape")
+        coordsys = frame_to_coordsys(region.center.frame.name)
 
         # width is the full width of an image (not the radius)
         width = 4 * region.center.separation(center) + Angle(min_width)

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -178,27 +178,3 @@ class TestSpectrumExtraction:
         actual = extraction.spectrum_observations[0].energy_range[0]
         assert_quantity_allclose(actual, 0.8799225 * u.TeV, rtol=1e-3)
 
-
-@requires_data()
-def test_extract_cta_1dc_data(caplog):
-    datastore = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
-    obs_ids = [110380, 111140]
-    observations = datastore.get_observations(obs_ids)
-
-    pos = SkyCoord(0.0, 0.0, unit="deg", frame="galactic")
-    radius = Angle(0.11, "deg")
-    on_region = CircleSkyRegion(pos, radius)
-
-    est = ReflectedRegionsBackgroundEstimator(
-        observations=observations, on_region=on_region, min_distance_input="0.2 deg"
-    )
-    est.run()
-    # This will test non PSF3D input as well as absence of default thresholds
-    extract = SpectrumExtraction(
-        bkg_estimate=est.result, observations=observations, containment_correction=True
-    )
-    extract.run()
-
-    extract.compute_energy_threshold(method_lo="area_max", area_percent_lo=10)
-    actual = extract.spectrum_observations[0].energy_range[0]
-    assert_quantity_allclose(actual, 0.774263 * u.TeV, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -1,0 +1,46 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+import astropy.units as u
+from astropy.coordinates import Angle, SkyCoord
+from regions import CircleSkyRegion
+from gammapy.data import DataStore
+from gammapy.spectrum import SpectrumDatasetMaker
+
+
+@pytest.fixture
+def observations():
+    """Example observation list for testing."""
+    datastore = DataStore.from_file(
+        "$GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz"
+    )
+    obs_ids = [23523, 23526]
+    return datastore.get_observations(obs_ids)
+
+
+@pytest.fixture()
+def spectrum_dataset_maker():
+    pos = SkyCoord(83.63, 22.01, unit="deg", frame="icrs")
+    radius = Angle(0.11, "deg")
+    region = CircleSkyRegion(pos, radius)
+    e_reco = np.logspace(0, 2, 5) * u.TeV
+    e_true = np.logspace(-0.5, 2, 11) * u.TeV
+    return SpectrumDatasetMaker(region=region, e_reco=e_reco, e_true=e_true)
+
+
+def test_spectrum_dataset_maker(spectrum_dataset_maker, observations):
+    datasets = []
+
+    for obs in observations:
+        dataset = spectrum_dataset_maker.run(obs)
+        datasets.append(dataset)
+
+    assert_allclose(datasets[0].counts.data.sum(), 100)
+    assert_allclose(datasets[1].counts.data.sum(), 92)
+
+    assert_allclose(datasets[0].livetime.value, 1581.736758)
+    assert_allclose(datasets[1].livetime.value, 1572.686724)
+
+    assert_allclose(datasets[0].background.data.sum(), 1.754928, rtol=1e-5)
+    assert_allclose(datasets[1].background.data.sum(), 1.759318, rtol=1e-5)

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -7,6 +7,7 @@ from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
 from gammapy.data import DataStore
 from gammapy.spectrum import SpectrumDatasetMaker
+from gammapy.utils.testing import requires_data
 
 
 @pytest.fixture
@@ -48,6 +49,7 @@ def spectrum_dataset_maker_crab():
     return SpectrumDatasetMaker(region=region, e_reco=e_reco, e_true=e_true)
 
 
+@requires_data()
 def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_maker_crab, observations_hess_dl3):
     datasets = []
 
@@ -65,6 +67,7 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_maker_crab, observatio
     assert_allclose(datasets[1].background.data.sum(), 1.741604, rtol=1e-5)
 
 
+@requires_data()
 def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_maker_gc, observations_cta_dc1):
     datasets = []
 

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -61,8 +61,8 @@ def test_spectrum_dataset_maker_hess_dl3(spectrum_dataset_maker_crab, observatio
     assert_allclose(datasets[0].livetime.value, 1581.736758)
     assert_allclose(datasets[1].livetime.value, 1572.686724)
 
-    assert_allclose(datasets[0].background.data.sum(), 1.754928, rtol=1e-5)
-    assert_allclose(datasets[1].background.data.sum(), 1.759318, rtol=1e-5)
+    assert_allclose(datasets[0].background.data.sum(), 1.737258, rtol=1e-5)
+    assert_allclose(datasets[1].background.data.sum(), 1.741604, rtol=1e-5)
 
 
 def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_maker_gc, observations_cta_dc1):
@@ -78,5 +78,5 @@ def test_spectrum_dataset_maker_hess_cta(spectrum_dataset_maker_gc, observations
     assert_allclose(datasets[0].livetime.value, 1764.000034)
     assert_allclose(datasets[1].livetime.value, 1764.000034)
 
-    assert_allclose(datasets[0].background.data.sum(), 2.261111, rtol=1e-5)
-    assert_allclose(datasets[1].background.data.sum(), 2.186609, rtol=1e-5)
+    assert_allclose(datasets[0].background.data.sum(), 2.238345, rtol=1e-5)
+    assert_allclose(datasets[1].background.data.sum(), 2.164593, rtol=1e-5)


### PR DESCRIPTION
This PR implements a first version of a `SpectrumDatasetMaker`. It follows the design of the `MapDatasetMaker` closely. The plan is that `SpectrumExraction` and the `ReflectedRegionBackgroundEstimator` will be replaced by the following pattern, step by step:

```
spec_maker = SpectrumDatasetMaker(...)
bkg_maker = ReflectedRegionsBackgroundMaker(...)
datasets = []
for obs in observations:
    dataset = spec_maker.run(obs)
    dataset = bkg_maker.run(dataset, obs)
    datasets.append(dataset)
```

I will implement the `ReflectedRegionsBackgroundMaker` in a subsequent PR and start adapting tutorials and tests, so that we can finally remove the `SpectrumExtraction` class.