### PR TITLE
Modernise Gammapy codebase

### DIFF
--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -464,25 +464,6 @@ File and directory path handling
 
 In Gammapy use `pathlib.Path` objects to handle file and directory paths.
 
-.. code-block:: python
-
-    from pathlib import Path
-
-    dir = Path('folder/subfolder')
-    filename = dir / 'filename.fits'
-    dir.mkdir(exist_ok=True)
-    table.write(str(filename))
-
-Note how the ``/`` operator makes it easy to construct paths
-(as opposed to repeated calls to the string-handling function ``os.path.join``)
-and how methods on ``Path`` objects provide a nicer interface to most
-of the functionality from ``os.path`` (``mkdir`` in this example).
-
-One gotcha is that many functions (such as ``table.write`` in this example)
-expect ``str`` objects and refuse to work with ``Path`` objects, so you have
-to explicitly convert to ``str(path)``.
-
-
 Bundled gammapy.extern code
 ---------------------------
 

--- a/docs/spectrum/fitting.rst
+++ b/docs/spectrum/fitting.rst
@@ -95,8 +95,8 @@ example dataset used above. It makes use of the Sherpa `datastack module
     from sherpa.astro import datastack
     from sherpa.models import PowLaw1D
 
-    pha1 = str(Path(os.environ["GAMMAPY_DATA"]) / "joint-crab" / "spectra" / "hess" / "pha_obs23592.fits")
-    pha2 = str(Path(os.environ["GAMMAPY_DATA"]) / "joint-crab" / "spectra" / "hess" / "pha_obs23523.fits")
+    pha1 = str(Path(os.environ["GAMMAPY_DATA"]) / "joint-crab/spectra/hess/pha_obs23592.fits")
+    pha2 = str(Path(os.environ["GAMMAPY_DATA"]) / "joint-crab/spectra/hess/pha_obs23523.fits")
     phalist = ','.join([pha1, pha2])
 
     ds = datastack.DataStack()

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1238,7 +1238,7 @@ class SourceCatalog3FGL(SourceCatalog):
     }
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v16.fit.gz"):
-        filename = str(make_path(filename))
+        filename = make_path(filename)
 
         with warnings.catch_warnings():  # ignore FITS units warnings
             warnings.simplefilter("ignore", u.UnitsWarning)
@@ -1346,7 +1346,7 @@ class SourceCatalog4FGL(SourceCatalog):
     source_object_class = SourceCatalogObject4FGL
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v19.fit.gz"):
-        filename = str(make_path(filename))
+        filename = make_path(filename)
         table = Table.read(filename, hdu="LAT_Point_Source_Catalog")
         table_standardise_units_inplace(table)
 
@@ -1384,7 +1384,7 @@ class SourceCatalog1FHL(SourceCatalog):
     source_object_class = SourceCatalogObject1FHL
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v07.fit.gz"):
-        filename = str(make_path(filename))
+        filename = make_path(filename)
 
         with warnings.catch_warnings():  # ignore FITS units warnings
             warnings.simplefilter("ignore", u.UnitsWarning)
@@ -1416,7 +1416,7 @@ class SourceCatalog2FHL(SourceCatalog):
     source_object_class = SourceCatalogObject2FHL
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v08.fit.gz"):
-        filename = str(make_path(filename))
+        filename = make_path(filename)
 
         with warnings.catch_warnings():  # ignore FITS units warnings
             warnings.simplefilter("ignore", u.UnitsWarning)
@@ -1457,7 +1457,7 @@ class SourceCatalog3FHL(SourceCatalog):
     }
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v13.fit.gz"):
-        filename = str(make_path(filename))
+        filename = make_path(filename)
 
         with warnings.catch_warnings():  # ignore FITS units warnings
             warnings.simplefilter("ignore", u.UnitsWarning)

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -455,9 +455,8 @@ class SourceCatalogGammaCat(SourceCatalog):
     source_object_class = SourceCatalogObjectGammaCat
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/gammacat/gammacat.fits.gz"):
-        filename = str(make_path(filename))
+        filename = make_path(filename)
         table = Table.read(filename, hdu=1)
-        self.filename = filename
 
         source_name_key = "common_name"
         source_name_alias = ("other_names", "gamma_names")

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -199,8 +199,7 @@ class SourceCatalog2HWC(SourceCatalog):
     source_object_class = SourceCatalogObject2HWC
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/2HWC.ecsv"):
-        filename = str(make_path(filename))
-        table = Table.read(filename, format="ascii.ecsv")
+        table = Table.read(make_path(filename), format="ascii.ecsv")
 
         source_name_key = "source_name"
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -641,11 +641,12 @@ class SourceCatalogHGPS(SourceCatalog):
 
     source_object_class = SourceCatalogObjectHGPS
 
-    def __init__(self, filename=None, hdu="HGPS_SOURCES"):
-        if not filename:
-            filename = "$GAMMAPY_DATA/catalogs/hgps_catalog_v1.fits.gz"
-
-        filename = str(make_path(filename))
+    def __init__(
+        self,
+        filename="$GAMMAPY_DATA/catalogs/hgps_catalog_v1.fits.gz",
+        hdu="HGPS_SOURCES",
+    ):
+        filename = make_path(filename)
         table = Table.read(filename, hdu=hdu)
 
         source_name_alias = ("Identified_Object",)

--- a/gammapy/catalog/tests/test_snrcat.py
+++ b/gammapy/catalog/tests/test_snrcat.py
@@ -5,7 +5,7 @@ from gammapy.catalog import SourceCatalogSNRcat
 
 @pytest.mark.skip(reason="see https://github.com/gammapy/gammapy/issues/2162")
 @pytest.mark.remote_data
-def test_load_catalog_snrcat(tmpdir):
+def test_load_catalog_snrcat(tmp_path):
     snrcat = SourceCatalogSNRcat()
 
     # Check SNR table
@@ -14,15 +14,12 @@ def test_load_catalog_snrcat(tmpdir):
     expected_colnames = ["Source_Name", "RAJ2000"]
     assert set(expected_colnames).issubset(table.colnames)
     # Check if catalog can be serialized to FITS
-    filename = str(tmpdir / "snrcat_test.fits")
-    table.write(filename)
+    table.write(tmp_path / "snrcat_test.fits")
 
     # Check OBS table
     table = snrcat.obs_table
     assert len(table) > 1000
     expected_colnames = ["SNR_id", "source_id"]
     assert set(expected_colnames).issubset(table.colnames)
-
     # Check if catalog can be serialized to FITS
-    filename = str(tmpdir / "obs_test.fits")
-    table.write(filename)
+    table.write(tmp_path / "obs_test.fits")

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -3,19 +3,9 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 import os
-import astropy.version
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
-if astropy.version.version < "3.0":
-    # With older versions of Astropy, we actually need to import the pytest
-    # plugins themselves in order to make them discoverable by pytest.
-    from astropy.tests.pytest_plugins import *
-else:
-    # As of Astropy 3.0, the pytest plugins provided by Astropy are
-    # automatically made available when Astropy is installed. This means it's
-    # not necessary to import them here, but we still need to import global
-    # variables that are used for configuration.
-    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 
 
 # TODO: add numpy again once https://github.com/astropy/regions/pull/252 is addressed

--- a/gammapy/conftest.py
+++ b/gammapy/conftest.py
@@ -4,9 +4,7 @@
 # no matter how it is invoked within the source tree.
 import os
 from astropy.tests.helper import enable_deprecations_as_exceptions
-
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
-
 
 # TODO: add numpy again once https://github.com/astropy/regions/pull/252 is addressed
 enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=["numpy", "astropy"])

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -6,7 +6,7 @@ from astropy.coordinates import Angle
 from astropy.nddata.utils import NoOverlapError
 from astropy.utils import lazyproperty
 from gammapy.irf import EnergyDependentMultiGaussPSF
-from gammapy.maps import Map, WcsGeom
+from gammapy.maps import Map
 from gammapy.modeling.models import BackgroundModel
 from .background import make_map_background_irf
 from .counts import fill_map_counts

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -91,14 +91,13 @@ def test_edisp_map_to_from_hdulist():
     assert new_edmap.exposure_map.geom == edmap.exposure_map.geom
 
 
-def test_edisp_map_read_write(tmpdir):
-    edmap = make_edisp_map_test()
+def test_edisp_map_read_write(tmp_path):
+    edisp_map = make_edisp_map_test()
 
-    filename = str(tmpdir / "edispmap.fits")
-    edmap.write(filename, overwrite=True)
-    new_edmap = EDispMap.read(filename)
+    edisp_map.write(tmp_path / "tmp.fits")
+    new_edmap = EDispMap.read(tmp_path / "tmp.fits")
 
-    assert_allclose(edmap.edisp_map.quantity, new_edmap.edisp_map.quantity)
+    assert_allclose(edisp_map.edisp_map.quantity, new_edmap.edisp_map.quantity)
 
 
 def test_edisp_map_to_energydispersion():
@@ -108,7 +107,7 @@ def test_edisp_map_to_energydispersion():
     e_reco = np.logspace(-0.3, 0.2, 200) * u.TeV
 
     edisp = edmap.get_energy_dispersion(position, e_reco)
-    # Note that the bias and resolution are rather poorly evaluated on an EnergyDisperion object
+    # Note that the bias and resolution are rather poorly evaluated on an EnergyDispersion object
     assert_allclose(edisp.get_bias(e_true=1.0 * u.TeV), 0.0, atol=3e-2)
     assert_allclose(edisp.get_resolution(e_true=1.0 * u.TeV), 0.2, atol=3e-2)
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -194,7 +194,7 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue):
 
 
 @requires_data()
-def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
+def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
     dataset = get_map_dataset(sky_model, geom, geom_etrue)
     dataset.counts = dataset.npred()
     dataset.mask_safe = dataset.mask_fit
@@ -225,9 +225,9 @@ def test_map_dataset_fits_io(tmpdir, sky_model, geom, geom_etrue):
 
     assert actual == desired
 
-    dataset.write(tmpdir / "test.fits")
+    dataset.write(tmp_path / "test.fits")
 
-    dataset_new = MapDataset.read(tmpdir / "test.fits")
+    dataset_new = MapDataset.read(tmp_path / "test.fits")
     assert dataset_new.model is None
     assert dataset_new.mask.dtype == bool
 

--- a/gammapy/cube/tests/test_psf_kernel.py
+++ b/gammapy/cube/tests/test_psf_kernel.py
@@ -27,7 +27,7 @@ def test_table_psf_to_kernel_map():
     assert_allclose(ind, geom.center_pix, atol=0.5)
 
 
-def test_psf_kernel_from_gauss_read_write(tmpdir):
+def test_psf_kernel_from_gauss_read_write(tmp_path):
     sigma = 0.5 * u.deg
     binsz = 0.1 * u.deg
     geom = WcsGeom.create(binsz=binsz, npix=150, axes=[MapAxis((0, 1, 2))])
@@ -40,11 +40,9 @@ def test_psf_kernel_from_gauss_read_write(tmpdir):
     # Is there an odd number of pixels
     assert_allclose(np.array(kernel.psf_kernel_map.geom.npix) % 2, 1)
 
-    filename = str(tmpdir / "test_kernel.fits")
-    # Test read and write
-    kernel.write(filename, overwrite=True)
-    newkernel = PSFKernel.read(filename)
-    assert_allclose(kernel.psf_kernel_map.data, newkernel.psf_kernel_map.data)
+    kernel.write(tmp_path / "tmp.fits", overwrite=True)
+    kernel2 = PSFKernel.read(tmp_path / "tmp.fits")
+    assert_allclose(kernel.psf_kernel_map.data, kernel2.psf_kernel_map.data)
 
 
 def test_make_image():

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -136,13 +136,11 @@ def test_psfmap_to_from_hdulist():
     assert new_psfmap.exposure_map.geom == psfmap.exposure_map.geom
 
 
-def test_psfmap_read_write(tmpdir):
+def test_psfmap_read_write(tmp_path):
     psfmap = make_test_psfmap(0.15 * u.deg)
 
-    # test read/write
-    filename = str(tmpdir / "psfmap.fits")
-    psfmap.write(filename, overwrite=True)
-    new_psfmap = PSFMap.read(filename)
+    psfmap.write(tmp_path / "tmp.fits")
+    new_psfmap = PSFMap.read(tmp_path / "tmp.fits")
 
     assert_allclose(psfmap.psf_map.quantity, new_psfmap.psf_map.quantity)
 

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -307,7 +307,7 @@ class DataStore:
             targetdir.mkdir(exist_ok=True, parents=True)
             cmd = ["cp"]
             if verbose:
-                cmd += ['-v']
+                cmd += ["-v"]
             if not overwrite:
                 cmd += ["-n"]
             cmd += [str(loc.path()), str(targetdir)]

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -111,13 +111,13 @@ class DataStore:
         if not hdu_table_filename.exists():
             raise OSError(f"File not found: {hdu_table_filename}")
         log.debug(f"Reading {hdu_table_filename}")
-        hdu_table = HDUIndexTable.read(str(hdu_table_filename), format="fits")
+        hdu_table = HDUIndexTable.read(hdu_table_filename, format="fits")
         hdu_table.meta["BASE_DIR"] = str(base_dir)
 
         if not obs_table_filename.exists():
             raise OSError(f"File not found: {obs_table_filename}")
         log.debug(f"Reading {obs_table_filename}")
-        obs_table = ObservationTable.read(str(obs_table_filename), format="fits")
+        obs_table = ObservationTable.read(obs_table_filename, format="fits")
 
         return cls(hdu_table=hdu_table, obs_table=obs_table)
 
@@ -282,9 +282,11 @@ class DataStore:
         overwrite : bool
             Overwrite
         """
-        # TODO : Does rsync give any benefits here?
-
         outdir = make_path(outdir)
+
+        if not outdir.is_dir():
+            raise OSError(f"Not a directory: outdir={outdir}")
+
         if isinstance(obs_id, ObservationTable):
             obs_id = obs_id["OBS_ID"].data
 
@@ -303,17 +305,19 @@ class DataStore:
             loc = subhdutable.location_info(idx)
             targetdir = outdir / loc.file_dir
             targetdir.mkdir(exist_ok=True, parents=True)
-            cmd = ["cp", "-v"] if verbose else ["cp"]
+            cmd = ["cp"]
+            if verbose:
+                cmd += ['-v']
             if not overwrite:
                 cmd += ["-n"]
             cmd += [str(loc.path()), str(targetdir)]
             subprocess.run(cmd)
 
-        filename = str(outdir / self.DEFAULT_HDU_TABLE)
+        filename = outdir / self.DEFAULT_HDU_TABLE
         subhdutable.write(filename, format="fits", overwrite=overwrite)
 
-        filename = str(outdir / self.DEFAULT_OBS_TABLE)
-        subobstable.write(filename, format="fits", overwrite=overwrite)
+        filename = outdir / self.DEFAULT_OBS_TABLE
+        subobstable.write(str(filename), format="fits", overwrite=overwrite)
 
     def check(self, checks="all"):
         """Check index tables and data files.
@@ -426,7 +430,7 @@ class DataStoreMaker:
     @staticmethod
     def read_events_info(path):
         log.debug(f"Reading {path}")
-        with fits.open(str(path)) as hdu_list:
+        with fits.open(path, memmap=False) as hdu_list:
             header = hdu_list["EVENTS"].header
 
         na_int, na_str = -1, "NOT AVAILABLE"

--- a/gammapy/data/event_list.py
+++ b/gammapy/data/event_list.py
@@ -78,7 +78,7 @@ class EventListBase:
         """
         filename = make_path(filename)
         kwargs.setdefault("hdu", "EVENTS")
-        table = Table.read(str(filename), **kwargs)
+        table = Table.read(filename, **kwargs)
         return cls(table=table)
 
     @classmethod

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -83,17 +83,6 @@ class GTI:
         return cls(table)
 
     @classmethod
-    def from_hdulist(cls, hdulist, hdu="GTI"):
-        """Create from `~astropy.io.fits.HDUList`."""
-        gti = Table.read(hdulist[hdu])
-        return cls(gti)
-
-    def to_hdulist(self):
-        """Convert to `~astropy.io.fits.HDUList`."""
-        hdu = fits.BinTableHDU(self.table, name="GTI")
-        return fits.HDUList([hdu])
-
-    @classmethod
     def read(cls, filename, hdu="GTI"):
         """Read from FITS file.
 
@@ -105,15 +94,12 @@ class GTI:
             hdu name. Default GTI.
         """
         filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            return cls.from_hdulist(hdulist, hdu)
+        table = Table.read(filename, hdu=hdu)
+        return cls(table)
 
     def write(self, filename, **kwargs):
         """Write to file."""
-        filename = make_path(filename)
-        hdulist = fits.HDUList([fits.PrimaryHDU()])
-        hdulist += self.to_hdulist()
-        hdulist.writeto(str(filename), **kwargs)
+        self.table.write(make_path(filename), **kwargs)
 
     def __str__(self):
         return (

--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
-from astropy.io import fits
 from astropy.table import Table, vstack
 from astropy.time import Time
 from astropy.units import Quantity

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -59,7 +59,7 @@ class HDULocation:
 
     def get_hdu(self):
         """Get HDU."""
-        filename = str(self.path(abs_path=True))
+        filename = self.path(abs_path=True)
         # Here we're intentionally not calling `with fits.open`
         # because we don't want the file to remain open.
         hdu_list = fits.open(filename, memmap=False)
@@ -146,7 +146,7 @@ class HDUIndexTable(Table):
             Filename
         """
         filename = make_path(filename)
-        table = super().read(str(filename), **kwargs)
+        table = super().read(filename, **kwargs)
         table.meta["BASE_DIR"] = filename.parent.as_posix()
 
         return table

--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -30,8 +30,7 @@ class ObservationTable(Table):
         filename : `pathlib.Path`, str
             Filename
         """
-        filename = make_path(filename)
-        return super().read(str(filename), **kwargs)
+        return super().read(make_path(filename), **kwargs)
 
     @property
     def pointing_radec(self):

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -4,7 +4,6 @@ from astropy.coordinates import AltAz, CartesianRepresentation, SkyCoord
 from astropy.table import Table
 from astropy.units import Quantity
 from astropy.utils import lazyproperty
-from astropy.version import version as astropy_version
 from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.scripts import make_path
 from gammapy.utils.time import time_ref_from_dict
@@ -232,12 +231,6 @@ class PointingInfo:
         z_new = scipy.interpolate.interp1d(t, xyz.z)(t_new)
         xyz_new = CartesianRepresentation(x_new, y_new, z_new)
         altaz_frame = AltAz(obstime=time, location=self.location)
-
-        # FIXME: an API change in Astropy in 3.1 broke this
-        # See https://github.com/gammapy/gammapy/pull/1906
-        if astropy_version >= "3.1":
-            kwargs = {"representation_type": "unitspherical"}
-        else:
-            kwargs = {"representation": "unitspherical"}
-
-        return SkyCoord(xyz_new, frame=altaz_frame, unit="deg", **kwargs)
+        return SkyCoord(
+            xyz_new, frame=altaz_frame, unit="deg", representation_type="unitspherical"
+        )

--- a/gammapy/data/pointing.py
+++ b/gammapy/data/pointing.py
@@ -49,7 +49,7 @@ class FixedPointingInfo:
             Pointing info object
         """
         filename = make_path(filename)
-        table = Table.read(str(filename), hdu=hdu)
+        table = Table.read(filename, hdu=hdu)
         return cls(meta=table.meta)
 
     @lazyproperty
@@ -142,7 +142,7 @@ class PointingInfo:
             Pointing info object
         """
         filename = make_path(filename)
-        table = Table.read(str(filename), hdu=hdu)
+        table = Table.read(filename, hdu=hdu)
         return cls(table=table)
 
     def __str__(self):

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -91,6 +91,7 @@ def test_datastore_copy_obs(tmp_path, data_store):
 
     assert str(actual.events.table) == str(desired.events.table)
 
+
 @requires_data()
 def test_datastore_copy_obs_subset(tmp_path, data_store):
     # Copy only certain HDU classes

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -78,17 +78,16 @@ def test_datastore_get_observations(data_store):
 
 
 @requires_data()
-def test_datastore_subset(tmpdir, data_store):
+def test_datastore_subset(tmp_path, data_store):
     """Test creating a datastore as subset of another datastore"""
     selected_obs = data_store.obs_table.select_obs_id([23523, 23592])
-    storedir = tmpdir / "substore"
-    data_store.copy_obs(selected_obs, storedir)
+    data_store.copy_obs(selected_obs, tmp_path / "dir1")
     obs_id = [23523, 23592]
-    data_store.copy_obs(obs_id, storedir, overwrite=True)
+    data_store.copy_obs(obs_id, tmp_path / "dir1", overwrite=True)
 
-    substore = DataStore.from_dir(storedir)
+    substore = DataStore.from_dir(tmp_path / "dir1")
 
-    assert str(substore.hdu_table.base_dir) == str(storedir)
+    assert str(substore.hdu_table.base_dir) == str(tmp_path / "dir1")
     assert len(substore.obs_table) == 2
 
     desired = data_store.obs(23523)
@@ -97,10 +96,9 @@ def test_datastore_subset(tmpdir, data_store):
     assert str(actual.events.table) == str(desired.events.table)
 
     # Copy only certain HDU classes
-    storedir = tmpdir / "substore2"
-    data_store.copy_obs(obs_id, storedir, hdu_class=["events"])
+    data_store.copy_obs(obs_id, tmp_path / "dir2", hdu_class=["events"])
 
-    substore = DataStore.from_dir(storedir)
+    substore = DataStore.from_dir(tmp_path / "dir2")
     assert len(substore.hdu_table) == 2
 
 

--- a/gammapy/data/tests/test_data_store.py
+++ b/gammapy/data/tests/test_data_store.py
@@ -78,16 +78,12 @@ def test_datastore_get_observations(data_store):
 
 
 @requires_data()
-def test_datastore_subset(tmp_path, data_store):
-    """Test creating a datastore as subset of another datastore"""
-    selected_obs = data_store.obs_table.select_obs_id([23523, 23592])
-    data_store.copy_obs(selected_obs, tmp_path / "dir1")
-    obs_id = [23523, 23592]
-    data_store.copy_obs(obs_id, tmp_path / "dir1", overwrite=True)
+def test_datastore_copy_obs(tmp_path, data_store):
+    data_store.copy_obs([23523, 23592], tmp_path, overwrite=True)
 
-    substore = DataStore.from_dir(tmp_path / "dir1")
+    substore = DataStore.from_dir(tmp_path)
 
-    assert str(substore.hdu_table.base_dir) == str(tmp_path / "dir1")
+    assert str(substore.hdu_table.base_dir) == str(tmp_path)
     assert len(substore.obs_table) == 2
 
     desired = data_store.obs(23523)
@@ -95,10 +91,12 @@ def test_datastore_subset(tmp_path, data_store):
 
     assert str(actual.events.table) == str(desired.events.table)
 
+@requires_data()
+def test_datastore_copy_obs_subset(tmp_path, data_store):
     # Copy only certain HDU classes
-    data_store.copy_obs(obs_id, tmp_path / "dir2", hdu_class=["events"])
+    data_store.copy_obs([23523, 23592], tmp_path, hdu_class=["events"])
 
-    substore = DataStore.from_dir(tmp_path / "dir2")
+    substore = DataStore.from_dir(tmp_path)
     assert len(substore.hdu_table) == 2
 
 

--- a/gammapy/data/tests/test_gti.py
+++ b/gammapy/data/tests/test_gti.py
@@ -120,6 +120,7 @@ def test_gti_create():
     start = u.Quantity([1, 2], "min")
     stop = u.Quantity([1.5, 2.5], "min")
     time_ref = Time("2010-01-01 00:00:00.0")
+
     gti = GTI.create(start, stop, time_ref)
 
     assert len(gti.table) == 2
@@ -127,12 +128,12 @@ def test_gti_create():
     assert_allclose(gti.table["START"], start.to_value("s"))
 
 
-def test_gti_write(tmpdir):
+def test_gti_write(tmp_path):
     gti = make_gti({"START": [5, 6, 1, 2], "STOP": [8, 7, 3, 4]})
-    filename = tmpdir / "test.fits"
-    gti.write(filename, overwrite=True)
 
-    new_gti = GTI.read(filename)
+    gti.write(tmp_path / "tmp.fits")
+    new_gti = GTI.read(tmp_path / "tmp.fits")
+
     assert_time_allclose(new_gti.time_start, gti.time_start)
     assert_time_allclose(new_gti.time_stop, gti.time_stop)
     assert new_gti.table.meta["MJDREFF"] == gti.table.meta["MJDREFF"]

--- a/gammapy/detect/tests/test_cwt.py
+++ b/gammapy/detect/tests/test_cwt.py
@@ -241,14 +241,13 @@ class TestCWTData:
         assert_equal(diff.support_3d.data.sum(), 0)
         assert_allclose(diff.model.data.sum(), 20.4132906267)
 
-    def test_io(self, tmpdir):
-        filename = str(tmpdir / "test-cwt.fits")
-        self.cwt_data.write(filename=filename, overwrite=True)
-        approx = Map.read(filename, hdu="APPROX")
+    def test_io(self, tmp_path):
+        self.cwt_data.write(tmp_path / "tmp.fits")
+        approx = Map.read(tmp_path / "tmp.fits", hdu="APPROX")
         assert_allclose(approx.data[100, 100], self.cwt_data._approx[100, 100])
         assert_allclose(approx.data[36, 63], self.cwt_data._approx[36, 63])
 
-        transform_2d = Map.read(filename, hdu="TRANSFORM_2D")
+        transform_2d = Map.read(tmp_path / "tmp.fits", hdu="TRANSFORM_2D")
         assert_allclose(
             transform_2d.data[100, 100], self.cwt_data.transform_2d.data[100, 100]
         )

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -123,11 +123,8 @@ class Background3D:
     @classmethod
     def read(cls, filename, hdu="BACKGROUND"):
         """Read from file."""
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            bkg = cls.from_hdulist(hdulist, hdu=hdu)
-
-        return bkg
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_table(self):
         """Convert to `~astropy.table.Table`."""
@@ -304,11 +301,8 @@ class Background2D:
     @classmethod
     def read(cls, filename, hdu="BACKGROUND"):
         """Read from file."""
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            bkg = cls.from_hdulist(hdulist, hdu=hdu)
-
-        return bkg
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_table(self):
         """Convert to `~astropy.table.Table`."""

--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -185,16 +185,14 @@ class EffectiveAreaTable:
     def read(cls, filename, hdu="SPECRESP"):
         """Read from file."""
         filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
+        with fits.open(filename, memmap=False) as hdulist:
             try:
-                aeff = cls.from_hdulist(hdulist, hdu=hdu)
+                return cls.from_hdulist(hdulist, hdu=hdu)
             except KeyError:
                 raise ValueError(
                     f"File {filename} contains no HDU {hdu!r}\n"
                     f"Available: {[_.name for _ in hdulist]}"
                 )
-
-        return aeff
 
     def to_table(self):
         """Convert to `~astropy.table.Table` in ARF format.
@@ -229,7 +227,7 @@ class EffectiveAreaTable:
     def write(self, filename, use_sherpa=False, **kwargs):
         """Write to file."""
         filename = make_path(filename)
-        self.to_hdulist(use_sherpa=use_sherpa).writeto(str(filename), **kwargs)
+        self.to_hdulist(use_sherpa=use_sherpa).writeto(filename, **kwargs)
 
     def evaluate_fill_nan(self, **kwargs):
         """Modified evaluate function.
@@ -418,11 +416,8 @@ class EffectiveAreaTable2D:
     @classmethod
     def read(cls, filename, hdu="EFFECTIVE AREA"):
         """Read from file."""
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            aeff = cls.from_hdulist(hdulist, hdu=hdu)
-
-        return aeff
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu=hdu)
 
     def to_effective_area_table(self, offset, energy=None):
         """Evaluate at a given offset and return `~gammapy.irf.EffectiveAreaTable`.

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -290,11 +290,8 @@ class EnergyDispersion:
         hdu2 : str, optional
             HDU containing the energy axis information, default, EBOUNDS
         """
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            edisp = cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
-
-        return edisp
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
     def to_hdulist(self, use_sherpa=False, **kwargs):
         """Convert RMF to FITS HDU list format.
@@ -420,7 +417,7 @@ class EnergyDispersion:
     def write(self, filename, use_sherpa=False, **kwargs):
         """Write to file."""
         filename = make_path(filename)
-        self.to_hdulist(use_sherpa=use_sherpa).writeto(str(filename), **kwargs)
+        self.to_hdulist(use_sherpa=use_sherpa).writeto(filename, **kwargs)
 
     def get_resolution(self, e_true):
         """Get energy resolution for a given true energy.
@@ -860,11 +857,8 @@ class EnergyDispersion2D:
         filename : str
             File name
         """
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            edisp = cls.from_hdulist(hdulist, hdu)
-
-        return edisp
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_hdulist(hdulist, hdu)
 
     def to_energy_dispersion(self, offset, e_true=None, e_reco=None):
         """Detector response R(Delta E_reco, Delta E_true)

--- a/gammapy/irf/io.py
+++ b/gammapy/irf/io.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from gammapy.utils.scripts import make_path
 from .background import Background3D
 from .effective_area import EffectiveAreaTable2D
 from .energy_dispersion import EnergyDispersion2D
@@ -41,8 +40,6 @@ def load_cta_irfs(filename):
         cta_irf = load_cta_irfs("$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits")
         print(cta_irf['aeff'])
     """
-    filename = str(make_path(filename))
-
     aeff = EffectiveAreaTable2D.read(filename, hdu="EFFECTIVE AREA")
     bkg = Background3D.read(filename, hdu="BACKGROUND")
     edisp = EnergyDispersion2D.read(filename, hdu="ENERGY DISPERSION")

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -114,8 +114,7 @@ class PSF3D:
         hdu : str
             HDU name
         """
-        filename = str(make_path(filename))
-        table = Table.read(filename, hdu=hdu)
+        table = Table.read(make_path(filename), hdu=hdu)
         return cls.from_table(table)
 
     @classmethod

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -107,11 +107,8 @@ class EnergyDependentMultiGaussPSF:
         filename : str
             File name
         """
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
-            psf = cls.from_fits(hdulist[hdu])
-
-        return psf
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_fits(hdulist[hdu])
 
     @classmethod
     def from_fits(cls, hdu):

--- a/gammapy/irf/psf_king.py
+++ b/gammapy/irf/psf_king.py
@@ -76,16 +76,11 @@ class PSFKing:
         filename : str
             File name
         """
-        filename = str(make_path(filename))
         # TODO: implement it so that HDUCLASS is used
         # http://gamma-astro-data-formats.readthedocs.io/en/latest/data_storage/hdu_index/index.html
 
-        table = Table.read(filename, hdu=hdu)
+        table = Table.read(make_path(filename), hdu=hdu)
         return cls.from_table(table)
-
-        # hdu_list = fits.open(filename)
-        # hdu = hdu_list[hdu]
-        # return cls.from_fits(hdu)
 
     @classmethod
     def from_table(cls, table):

--- a/gammapy/irf/psf_table.py
+++ b/gammapy/irf/psf_table.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 class TablePSF:
-    r"""Radially-symmetric table PSF.
+    """Radially-symmetric table PSF.
 
     Parameters
     ----------
@@ -347,11 +347,8 @@ class EnergyDependentTablePSF:
         filename : str
             File name
         """
-        filename = str(make_path(filename))
-        with fits.open(filename, memmap=False) as hdulist:
-            psf = cls.from_fits(hdulist)
-
-        return psf
+        with fits.open(make_path(filename), memmap=False) as hdulist:
+            return cls.from_fits(hdulist)
 
     def write(self, *args, **kwargs):
         """Write to FITS file.

--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -53,11 +53,9 @@ def test_background_3d_basics(bkg_3d):
     assert bkg_2d.data.data.shape == (2, 3)
 
 
-def test_background_3d_read_write(tmpdir, bkg_3d):
-    filename = str(tmpdir / "bkg3d.fits")
-    bkg_3d.to_fits().writeto(filename)
-
-    bkg_3d_2 = Background3D.read(filename)
+def test_background_3d_read_write(tmp_path, bkg_3d):
+    bkg_3d.to_fits().writeto(tmp_path / "bkg3d.fits")
+    bkg_3d_2 = Background3D.read(tmp_path / "bkg3d.fits")
 
     axis = bkg_3d_2.data.axis("energy")
     assert axis.nbin == 2
@@ -181,11 +179,9 @@ def test_background_2d_evaluate(bkg_2d):
     assert res.shape == (2,)
 
 
-def test_background_2d_read_write(tmpdir, bkg_2d):
-    filename = str(tmpdir / "bkg2d.fits")
-    bkg_2d.to_fits().writeto(filename)
-
-    bkg_2d_2 = Background2D.read(filename)
+def test_background_2d_read_write(tmp_path, bkg_2d):
+    bkg_2d.to_fits().writeto(tmp_path / "tmp.fits")
+    bkg_2d_2 = Background2D.read(tmp_path / "tmp.fits")
 
     axis = bkg_2d_2.data.axis("energy")
     assert axis.nbin == 2

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -78,7 +78,7 @@ class TestEffectiveAreaTable:
     @staticmethod
     @requires_dependency("matplotlib")
     @requires_data()
-    def test_EffectiveAreaTable(tmpdir, aeff):
+    def test_EffectiveAreaTable(tmp_path, aeff):
         arf = aeff.to_effective_area_table(offset=0.3 * u.deg)
 
         assert_quantity_allclose(arf.data.evaluate(), arf.data.data)
@@ -86,9 +86,8 @@ class TestEffectiveAreaTable:
         with mpl_plot_check():
             arf.plot()
 
-        filename = str(tmpdir / "effarea_test.fits")
-        arf.write(filename)
-        arf2 = EffectiveAreaTable.read(filename)
+        arf.write(tmp_path / "tmp.fits")
+        arf2 = EffectiveAreaTable.read(tmp_path / "tmp.fits")
 
         assert_quantity_allclose(arf.data.evaluate(), arf2.data.evaluate())
 

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -69,12 +69,11 @@ class TestEnergyDispersion:
         resolution = self.edisp.get_resolution(3.34 * u.TeV)
         assert_allclose(resolution, self.resolution, atol=1e-2)
 
-    def test_io(self, tmpdir):
+    def test_io(self, tmp_path):
         indices = np.array([[1, 3, 6], [3, 3, 2]])
         desired = self.edisp.pdf_matrix[indices]
-        writename = str(tmpdir / "rmf_test.fits")
-        self.edisp.write(writename)
-        edisp2 = EnergyDispersion.read(writename)
+        self.edisp.write(tmp_path / "tmp.fits")
+        edisp2 = EnergyDispersion.read(tmp_path / "tmp.fits")
         actual = edisp2.pdf_matrix[indices]
         assert_allclose(actual, desired)
 

--- a/gammapy/irf/tests/test_irf_write.py
+++ b/gammapy/irf/tests/test_irf_write.py
@@ -96,8 +96,8 @@ class TestIRFWrite:
         hdu = self.bkg.to_fits()
         assert_allclose(hdu.data[hdu.header["TTYPE7"]][0], self.bkg.data.data.value)
 
-    def test_writeread(self, tmpdir):
-        filename = str(tmpdir / "testirf.fits")
+    def test_writeread(self, tmp_path):
+        path = tmp_path / "tmp.fits"
         fits.HDUList(
             [
                 fits.PrimaryHDU(),
@@ -105,13 +105,13 @@ class TestIRFWrite:
                 self.edisp.to_fits(),
                 self.bkg.to_fits(),
             ]
-        ).writeto(filename)
+        ).writeto(path)
 
-        read_aeff = EffectiveAreaTable2D.read(filename=filename, hdu="EFFECTIVE AREA")
+        read_aeff = EffectiveAreaTable2D.read(path, hdu="EFFECTIVE AREA")
         assert_allclose(read_aeff.data.data, self.aeff_data)
 
-        read_edisp = EnergyDispersion2D.read(filename=filename, hdu="ENERGY DISPERSION")
+        read_edisp = EnergyDispersion2D.read(path, hdu="ENERGY DISPERSION")
         assert_allclose(read_edisp.data.data, self.edisp_data)
 
-        read_bkg = Background3D.read(filename=filename, hdu="BACKGROUND")
+        read_bkg = Background3D.read(path, hdu="BACKGROUND")
         assert_allclose(read_bkg.data.data, self.bkg_data)

--- a/gammapy/irf/tests/test_psf_3d.py
+++ b/gammapy/irf/tests/test_psf_3d.py
@@ -61,10 +61,9 @@ def test_psf_3d_containment_radius(psf_3d):
 
 
 @requires_data()
-def test_psf_3d_write(psf_3d, tmpdir):
-    filename = str(tmpdir / "temp.fits")
-    psf_3d.write(filename)
-    psf_3d = PSF3D.read(filename)
+def test_psf_3d_write(psf_3d, tmp_path):
+    psf_3d.write(tmp_path / "tmp.fits")
+    psf_3d = PSF3D.read(tmp_path / "tmp.fits")
 
     assert_allclose(psf_3d.energy_lo[0].value, 0.02)
 

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -80,10 +80,9 @@ class TestEnergyDependentMultiGaussPSF:
         assert psf.info() == info_str
 
     def test_write(self, tmp_path, psf):
-        path = tmp_path / "multigauss_psf_test.fits"
-        psf.write(path)
+        psf.write(tmp_path / "tmp.fits")
 
-        with fits.open(path) as hdu_list:
+        with fits.open(tmp_path / "tmp.fits", memmap=False) as hdu_list:
             assert len(hdu_list) == 2
 
     def test_to_table_psf(self, psf):

--- a/gammapy/irf/tests/test_psf_gauss.py
+++ b/gammapy/irf/tests/test_psf_gauss.py
@@ -79,17 +79,11 @@ class TestEnergyDependentMultiGaussPSF:
 
         assert psf.info() == info_str
 
-    def test_write(self, tmpdir, psf):
-        # Write it back to disk
-        filename = str(tmpdir / "multigauss_psf_test.fits")
-        psf.write(filename)
+    def test_write(self, tmp_path, psf):
+        path = tmp_path / "multigauss_psf_test.fits"
+        psf.write(path)
 
-        # Verify checksum
-        with fits.open(filename) as hdu_list:
-            # TODO: replace this assert with something else.
-            # For unknown reasons this verify_checksum fails non-deterministically
-            # see e.g. https://travis-ci.org/gammapy/gammapy/jobs/31056341#L1162
-            # assert hdu_list[1].verify_checksum() == 1
+        with fits.open(path) as hdu_list:
             assert len(hdu_list) == 2
 
     def test_to_table_psf(self, psf):

--- a/gammapy/irf/tests/test_psf_king.py
+++ b/gammapy/irf/tests/test_psf_king.py
@@ -52,10 +52,10 @@ def test_psf_king_to_table(psf_king):
 
 
 @requires_data()
-def test_psf_king_write(psf_king, tmpdir):
-    filename = str(tmpdir / "king.fits")
-    psf_king.write(filename)
-    psf_king2 = PSFKing.read(filename)
+def test_psf_king_write(psf_king, tmp_path):
+    psf_king.write(tmp_path / "tmp.fits")
+    psf_king2 = PSFKing.read(tmp_path / "tmp.fits")
+
     assert_quantity_allclose(psf_king2.energy, psf_king.energy)
     assert_quantity_allclose(psf_king2.offset, psf_king.offset)
     assert_quantity_allclose(psf_king2.gamma, psf_king.gamma)

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -181,8 +181,7 @@ class Map(abc.ABC):
         map_out : `Map`
             Map object
         """
-        filename = str(make_path(filename))
-        with fits.open(filename, memmap=False) as hdulist:
+        with fits.open(make_path(filename), memmap=False) as hdulist:
             return Map.from_hdulist(hdulist, hdu, hdu_bands, map_type)
 
     @staticmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -88,13 +88,12 @@ def energy_axis_from_fgst_ccube(hdu):
 def energy_axis_from_fgst_template(hdu):
     bands = Table.read(hdu)
 
-    allowed_names=["Energy","ENERGY","energy"]
+    allowed_names = ["Energy", "ENERGY", "energy"]
     for colname in bands.colnames:
-        if colname in allowed_names :
+        if colname in allowed_names:
             tag = colname
             break
     nodes = bands[tag].data
-
 
     return [MapAxis.from_nodes(nodes=nodes, name="energy", unit="MeV", interp="log")]
 

--- a/gammapy/maps/hpx.py
+++ b/gammapy/maps/hpx.py
@@ -706,7 +706,7 @@ class HpxGeom(Geom):
 
         if self._rmap is not None:
             retval = np.full(idx.size, -1, "i")
-            m = np.in1d(idx.flat, self._ipix)
+            m = np.isin(idx.flat, self._ipix)
             retval[m] = np.searchsorted(self._ipix, idx.flat[m])
             retval = retval.reshape(idx.shape)
         else:
@@ -1058,11 +1058,7 @@ class HpxGeom(Geom):
         idx_nb = ravel_hpx_index(idx_nb, self._maxpix)
 
         for _ in range(pad_width):
-            # Mask of neighbors that are not contained in the geometry
-            # TODO: change this to numpy.isin when we require Numpy 1.13+
-            # Here and everywhere in Gamampy -> search for "isin"
-            # see https://github.com/gammapy/gammapy/pull/1371
-            mask_edge = np.in1d(idx_nb, idx_r, invert=True).reshape(idx_nb.shape)
+            mask_edge = np.isin(idx_nb, idx_r, invert=True)
             idx_edge = idx_nb[mask_edge]
             idx_edge = np.unique(idx_edge)
             idx_r = np.sort(np.concatenate((idx_r, idx_edge)))
@@ -1093,8 +1089,7 @@ class HpxGeom(Geom):
         for _ in range(crop_width):
             # Mask of pixels that have at least one neighbor not
             # contained in the geometry
-            mask_edge = np.in1d(idx_nb, idx_r, invert=True)
-            mask_edge = np.any(mask_edge, axis=0)
+            mask_edge = np.any(np.isin(idx_nb, idx_r, invert=True), axis=0)
             idx_r = idx_r[~mask_edge]
             idx_nb = idx_nb[:, ~mask_edge]
 

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -8,7 +8,6 @@ from astropy.units import Quantity, Unit
 from gammapy.maps import HpxGeom, HpxNDMap, Map, MapAxis, WcsGeom, WcsNDMap
 from gammapy.utils.testing import requires_dependency
 
-pytest.importorskip("numpy", "1.12.0")
 pytest.importorskip("healpy")
 
 map_axes = [

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -385,16 +385,15 @@ map_serialization_args = [("log")]
 
 
 @pytest.mark.parametrize(("interp"), map_serialization_args)
-def test_arithmetics_after_serialization(tmpdir, interp):
+def test_arithmetics_after_serialization(tmp_path, interp):
     axis = MapAxis.from_bounds(
         1.0, 10.0, 3, interp=interp, name="energy", node_type="center", unit="TeV"
     )
     m_wcs = Map.create(binsz=0.1, width=1.0, map_type="wcs", skydir=(0, 0), axes=[axis])
     m_wcs += 1
 
-    filename = str(tmpdir / "map.fits")
-    m_wcs.write(filename, overwrite=True)
-    m_wcs_serialized = Map.read(filename)
+    m_wcs.write(tmp_path / "tmp.fits")
+    m_wcs_serialized = Map.read(tmp_path / "tmp.fits")
 
     m_wcs += m_wcs_serialized
 

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -667,17 +667,16 @@ def test_hpxgeom_from_header():
 @pytest.mark.parametrize(
     ("nside", "nested", "coordsys", "region", "axes"), hpx_test_geoms
 )
-def test_hpxgeom_read_write(tmpdir, nside, nested, coordsys, region, axes):
+def test_hpxgeom_read_write(tmp_path, nside, nested, coordsys, region, axes):
     geom0 = HpxGeom(nside, nested, coordsys, region=region, axes=axes)
     hdu_bands = geom0.make_bands_hdu(hdu="BANDS")
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.make_header())
 
-    filename = str(tmpdir / "hpxgeom.fits")
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
-    hdulist.writeto(filename, overwrite=True)
+    hdulist.writeto(tmp_path / "tmp.fits")
 
-    hdulist = fits.open(filename)
+    hdulist = fits.open(tmp_path / "tmp.fits")
     geom1 = HpxGeom.from_header(hdulist[0].header, hdulist["BANDS"])
 
     assert_allclose(geom0.nside, geom1.nside)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -676,8 +676,8 @@ def test_hpxgeom_read_write(tmp_path, nside, nested, coordsys, region, axes):
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
     hdulist.writeto(tmp_path / "tmp.fits")
 
-    hdulist = fits.open(tmp_path / "tmp.fits")
-    geom1 = HpxGeom.from_header(hdulist[0].header, hdulist["BANDS"])
+    with fits.open(tmp_path / "tmp.fits", memmap=False) as hdulist:
+        geom1 = HpxGeom.from_header(hdulist[0].header, hdulist["BANDS"])
 
     assert_allclose(geom0.nside, geom1.nside)
     assert_allclose(geom0.npix, geom1.npix)

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -17,7 +17,6 @@ from gammapy.maps.hpx import (
     unravel_hpx_index,
 )
 
-pytest.importorskip("numpy", "1.13.0")
 pytest.importorskip("healpy")
 
 hpx_allsky_test_geoms = [

--- a/gammapy/maps/tests/test_hpx.py
+++ b/gammapy/maps/tests/test_hpx.py
@@ -244,7 +244,7 @@ def test_hpxgeom_to_slice(nside, nested, coordsys, region, axes):
     idx = geom.get_idx(flat=True)
     idx_slice = geom_slice.get_idx(flat=True)
     if geom.ndim > 2:
-        m = np.all([np.in1d(t, [1]) for t in idx[1:]], axis=0)
+        m = np.all([np.isin(t, [1]) for t in idx[1:]], axis=0)
         assert_allclose(idx_slice, (idx[0][m],))
     else:
         assert_allclose(idx_slice, idx)
@@ -260,8 +260,8 @@ def test_hpxgeom_to_slice(nside, nested, coordsys, region, axes):
     idx = geom.get_idx()
     idx_slice = geom_slice.get_idx()
     if geom.ndim > 2:
-        m = np.all([np.in1d(t, [1]) for t in idx[1:]], axis=0)
-        assert_allclose(idx_slice, (idx[0].flat[m],))
+        m = np.all([np.isin(t, [1]) for t in idx[1:]], axis=0)
+        assert_allclose(idx_slice, (idx[0][m],))
     else:
         assert_allclose(idx_slice, idx)
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -10,7 +10,6 @@ from gammapy.maps.geom import coordsys_to_frame
 from gammapy.maps.utils import fill_poisson
 from gammapy.utils.testing import mpl_plot_check, requires_dependency
 
-pytest.importorskip("numpy", "1.12.0")
 pytest.importorskip("healpy")
 
 axes1 = [MapAxis(np.logspace(0.0, 3.0, 3), interp="log")]

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -86,16 +86,16 @@ def test_hpxmap_create(nside, nested, coordsys, region, axes, sparse):
 @pytest.mark.parametrize(
     ("nside", "nested", "coordsys", "region", "axes", "sparse"), hpx_test_geoms_sparse
 )
-def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse):
-    filename = str(tmpdir / "map.fits")
+def test_hpxmap_read_write(tmp_path, nside, nested, coordsys, region, axes, sparse):
+    path = tmp_path / "tmp.fits"
 
     m = create_map(nside, nested, coordsys, region, axes, sparse)
     fill_poisson(m, mu=0.5, random_state=0)
-    m.write(filename, sparse=sparse, overwrite=True)
+    m.write(path, sparse=sparse, overwrite=True)
 
-    m2 = HpxNDMap.read(filename)
-    m3 = HpxSparseMap.read(filename)
-    m4 = Map.read(filename, map_type="hpx")
+    m2 = HpxNDMap.read(path)
+    m3 = HpxSparseMap.read(path)
+    m4 = Map.read(path, map_type="hpx")
     if sparse:
         msk = np.isfinite(m2.data[...])
     else:
@@ -105,46 +105,46 @@ def test_hpxmap_read_write(tmpdir, nside, nested, coordsys, region, axes, sparse
     assert_allclose(m.data[...][msk], m3.data[...][msk])
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
-    m.write(filename, sparse=True, overwrite=True)
-    m2 = HpxNDMap.read(filename)
-    m3 = HpxMap.read(filename, map_type="hpx")
-    m4 = Map.read(filename, map_type="hpx")
+    m.write(path, sparse=True, overwrite=True)
+    m2 = HpxNDMap.read(path)
+    m3 = HpxMap.read(path, map_type="hpx")
+    m4 = Map.read(path, map_type="hpx")
     assert_allclose(m.data[...][msk], m2.data[...][msk])
     assert_allclose(m.data[...][msk], m3.data[...][msk])
     assert_allclose(m.data[...][msk], m4.data[...][msk])
 
     # Specify alternate HDU name for IMAGE and BANDS table
-    m.write(filename, hdu="IMAGE", hdu_bands="TEST", overwrite=True)
-    m2 = HpxNDMap.read(filename)
-    m3 = Map.read(filename)
-    m4 = Map.read(filename, map_type="hpx")
+    m.write(path, hdu="IMAGE", hdu_bands="TEST", overwrite=True)
+    m2 = HpxNDMap.read(path)
+    m3 = Map.read(path)
+    m4 = Map.read(path, map_type="hpx")
 
 
-def test_hpxmap_read_write_fgst(tmpdir):
-    filename = str(tmpdir / "map.fits")
+def test_hpxmap_read_write_fgst(tmp_path):
+    path = tmp_path / "tmp.fits"
 
     axis = MapAxis.from_bounds(100.0, 1000.0, 4, name="energy", unit="MeV")
 
     # Test Counts Cube
     m = create_map(8, False, "GAL", None, [axis], False)
-    m.write(filename, conv="fgst-ccube", overwrite=True)
-    with fits.open(filename) as h:
+    m.write(path, conv="fgst-ccube", overwrite=True)
+    with fits.open(path) as h:
         assert "SKYMAP" in h
         assert "EBOUNDS" in h
         assert h["SKYMAP"].header["HPX_CONV"] == "FGST-CCUBE"
         assert h["SKYMAP"].header["TTYPE1"] == "CHANNEL1"
 
-    m2 = Map.read(filename)
+    m2 = Map.read(path)
 
     # Test Model Cube
-    m.write(filename, conv="fgst-template", overwrite=True)
-    with fits.open(filename) as h:
+    m.write(path, conv="fgst-template", overwrite=True)
+    with fits.open(path) as h:
         assert "SKYMAP" in h
         assert "ENERGIES" in h
         assert h["SKYMAP"].header["HPX_CONV"] == "FGST-TEMPLATE"
         assert h["SKYMAP"].header["TTYPE1"] == "ENERGY1"
 
-    m2 = Map.read(filename)
+    m2 = Map.read(path)
 
 
 @pytest.mark.parametrize(

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -128,21 +128,21 @@ def test_hpxmap_read_write_fgst(tmp_path):
     # Test Counts Cube
     m = create_map(8, False, "GAL", None, [axis], False)
     m.write(path, conv="fgst-ccube", overwrite=True)
-    with fits.open(path) as h:
-        assert "SKYMAP" in h
-        assert "EBOUNDS" in h
-        assert h["SKYMAP"].header["HPX_CONV"] == "FGST-CCUBE"
-        assert h["SKYMAP"].header["TTYPE1"] == "CHANNEL1"
+    with fits.open(path, memmap=False) as hdulist:
+        assert "SKYMAP" in hdulist
+        assert "EBOUNDS" in hdulist
+        assert hdulist["SKYMAP"].header["HPX_CONV"] == "FGST-CCUBE"
+        assert hdulist["SKYMAP"].header["TTYPE1"] == "CHANNEL1"
 
     m2 = Map.read(path)
 
     # Test Model Cube
     m.write(path, conv="fgst-template", overwrite=True)
-    with fits.open(path) as h:
-        assert "SKYMAP" in h
-        assert "ENERGIES" in h
-        assert h["SKYMAP"].header["HPX_CONV"] == "FGST-TEMPLATE"
-        assert h["SKYMAP"].header["TTYPE1"] == "ENERGY1"
+    with fits.open(path, memmap=False) as hdulist:
+        assert "SKYMAP" in hdulist
+        assert "ENERGIES" in hdulist
+        assert hdulist["SKYMAP"].header["HPX_CONV"] == "FGST-TEMPLATE"
+        assert hdulist["SKYMAP"].header["TTYPE1"] == "ENERGY1"
 
     m2 = Map.read(path)
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -103,7 +103,7 @@ def test_wcsgeom_read_write(tmp_path, npix, binsz, coordsys, proj, skydir, axes)
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
     hdulist.writeto(tmp_path / "tmp.fits")
 
-    with fits.open(tmp_path / "tmp.fits") as hdulist:
+    with fits.open(tmp_path / "tmp.fits", memmap=False) as hdulist:
         geom1 = WcsGeom.from_header(hdulist[0].header, hdulist["BANDS"])
 
     assert_allclose(geom0.npix, geom1.npix)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -91,7 +91,7 @@ def test_wcsgeom_test_coord_to_idx(npix, binsz, coordsys, proj, skydir, axes):
 @pytest.mark.parametrize(
     ("npix", "binsz", "coordsys", "proj", "skydir", "axes"), wcs_test_geoms
 )
-def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
+def test_wcsgeom_read_write(tmp_path, npix, binsz, coordsys, proj, skydir, axes):
     geom0 = WcsGeom.create(
         npix=npix, binsz=binsz, proj=proj, coordsys=coordsys, axes=axes
     )
@@ -100,11 +100,10 @@ def test_wcsgeom_read_write(tmpdir, npix, binsz, coordsys, proj, skydir, axes):
     hdu_prim = fits.PrimaryHDU()
     hdu_prim.header.update(geom0.make_header())
 
-    filename = str(tmpdir / "wcsgeom.fits")
     hdulist = fits.HDUList([hdu_prim, hdu_bands])
-    hdulist.writeto(filename, overwrite=True)
+    hdulist.writeto(tmp_path / "tmp.fits")
 
-    with fits.open(filename) as hdulist:
+    with fits.open(tmp_path / "tmp.fits") as hdulist:
         geom1 = WcsGeom.from_header(hdulist[0].header, hdulist["BANDS"])
 
     assert_allclose(geom0.npix, geom1.npix)
@@ -404,7 +403,7 @@ def test_wcs_geom_equal(npix, binsz, coordsys, proj, skypos, axes, result):
 
 @pytest.mark.parametrize("node_type", ["edges", "center"])
 @pytest.mark.parametrize("interp", ["log", "lin", "sqrt"])
-def test_read_write(tmpdir, node_type, interp):
+def test_read_write(tmp_path, node_type, interp):
     # Regression test for MapAxis interp and node_type FITS serialization
     # https://github.com/gammapy/gammapy/issues/1887
     e_ax = MapAxis([1, 2], interp, "energy", node_type, "TeV")
@@ -417,9 +416,8 @@ def test_read_write(tmpdir, node_type, interp):
     assert header["INTERP2"] == interp
 
     # Check that all MapAxis properties are preserved on FITS I/O
-    filename = str(tmpdir / "geom_test.fits")
-    m.write(filename, overwrite=True)
-    m2 = Map.read(filename)
+    m.write(tmp_path / "tmp.fits", overwrite=True)
+    m2 = Map.read(tmp_path / "tmp.fits")
     assert m2.geom == m.geom
 
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -104,16 +104,16 @@ def test_wcsndmap_read_write_fgst(tmp_path):
     # Test Counts Cube
     m = WcsNDMap(geom)
     m.write(path, conv="fgst-ccube", overwrite=True)
-    with fits.open(path) as h:
-        assert "EBOUNDS" in h
+    with fits.open(path, memmap=False) as hdulist:
+        assert "EBOUNDS" in hdulist
 
     m2 = Map.read(path)
     assert m2.geom.axes[0].name == "energy"
 
     # Test Model Cube
     m.write(path, conv="fgst-template", overwrite=True)
-    with fits.open(path) as h:
-        assert "ENERGIES" in h
+    with fits.open(path, memmap=False) as hdulist:
+        assert "ENERGIES" in hdulist
 
 
 @requires_data()

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -8,7 +8,6 @@ import scipy.signal
 import astropy.units as u
 from astropy.convolution import Tophat2DKernel
 from astropy.io import fits
-from astropy.nddata import Cutout2D
 from gammapy.extern.skimage import block_reduce
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.random import InverseCDFSampler, get_random_state
@@ -16,7 +15,6 @@ from gammapy.utils.units import unit_from_fits_image_hdu
 from .geom import MapCoord, pix_tuple_to_idx
 from .reproject import reproject_car_to_hpx, reproject_car_to_wcs
 from .utils import INVALID_INDEX, interp_to_order
-from .wcs import _check_width
 from .wcsmap import WcsGeom, WcsMap
 
 __all__ = ["WcsNDMap"]

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -9,6 +9,7 @@ from astropy.coordinates import Angle, SkyCoord
 from astropy.coordinates.angle_utilities import angular_separation, position_angle
 from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
+from gammapy.utils.scripts import make_path
 
 log = logging.getLogger(__name__)
 
@@ -448,6 +449,9 @@ class TemplateSpatialModel(SpatialModel):
         if (map.data < 0).any():
             log.warning("Diffuse map has negative values. Check and fix this!")
 
+        if filename is not None:
+            filename = str(make_path(filename))
+
         self.map = map
         self.normalize = normalize
         if normalize:
@@ -491,7 +495,7 @@ class TemplateSpatialModel(SpatialModel):
         m = Map.read(filename, **kwargs)
         if m.unit == "":
             m.unit = "sr-1"
-        return cls(m, normalize=normalize, filename=str(filename))
+        return cls(m, normalize=normalize, filename=filename)
 
     def evaluate(self, lon, lat, norm):
         """Evaluate model."""

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1176,7 +1176,7 @@ class TemplateSpectralModel(SpectralModel):
         >>> filename = '$GAMMAPY_DATA/ebl/ebl_franceschini.fits.gz'
         >>> table_model = TemplateSpectralModel.read_xspec_model(filename=filename, param=0.3)
         """
-        filename = str(make_path(filename))
+        filename = make_path(filename)
 
         # Check if parameter value is in range
         table_param = Table.read(filename, hdu="PARAMETERS")
@@ -1212,8 +1212,7 @@ class TemplateSpectralModel(SpectralModel):
         filename : str
             filename
         """
-        filename = str(make_path(filename))
-        vals = np.loadtxt(filename)
+        vals = np.loadtxt(make_path(filename))
         energy = u.Quantity(vals[:, 0], "MeV", copy=False)
         values = u.Quantity(vals[:, 1], "MeV-1 s-1 cm-2 sr-1", copy=False)
         return cls(energy=energy, values=values, **kwargs)
@@ -1346,7 +1345,7 @@ class Absorption:
             File containing the model.
         """
         # Create EBL data array
-        filename = str(make_path(filename))
+        filename = make_path(filename)
         table_param = Table.read(filename, hdu="PARAMETERS")
 
         # TODO: for some reason the table contain duplicated values

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -117,7 +117,7 @@ class PhaseCurveTemplateTemporalModel(TemporalModel):
         from gammapy.utils.scripts import make_path
         from gammapy.modeling.models import PhaseCurveTemplateTemporalModel
         filename = make_path('$GAMMAPY_DATA/tests/phasecurve_LSI_DC.fits')
-        table = Table.read(str(filename))
+        table = Table.read(filename)
         phase_curve = PhaseCurveTemplateTemporalModel(table, time_0=43366.275, phase_0=0.0, f0=4.367575e-7, f1=0.0, f2=0.0)
 
     Use it to compute a phase and evaluate the phase curve model for a given time:
@@ -302,9 +302,7 @@ class LightCurveTemplateTemporalModel(TemporalModel):
 
         TODO: This doesn't read the XML part of the model yet.
         """
-        path = make_path(path)
-        table = Table.read(str(path))
-        return cls(table)
+        return cls(Table.read(make_path(path)))
 
     @lazyproperty
     def _interpolator(self):

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -254,21 +254,16 @@ TEST_MODELS.append(
     )
 )
 
-# The table model imports scipy.interpolate in `__init__`,
-# so we skip it if scipy is not available
-try:
-    TEST_MODELS.append(
-        dict(
-            name="table_model",
-            model=table_model(),
-            # Values took from power law expectation
-            val_at_2TeV=u.Quantity(4 * 2.0 ** (-2.3), "cm-2 s-1 TeV-1"),
-            integral_1_10TeV=u.Quantity(2.9227116204223784, "cm-2 s-1"),
-            eflux_1_10TeV=u.Quantity(6.650836884969039, "TeV cm-2 s-1"),
-        )
+TEST_MODELS.append(
+    dict(
+        name="table_model",
+        model=table_model(),
+        # Values took from power law expectation
+        val_at_2TeV=u.Quantity(4 * 2.0 ** (-2.3), "cm-2 s-1 TeV-1"),
+        integral_1_10TeV=u.Quantity(2.9227116204223784, "cm-2 s-1"),
+        eflux_1_10TeV=u.Quantity(6.650836884969039, "TeV cm-2 s-1"),
     )
-except ImportError:
-    pass
+)
 
 
 @requires_dependency("uncertainties")

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -16,8 +16,8 @@ from gammapy.utils.testing import requires_data
 
 @pytest.fixture(scope="session")
 def phase_curve():
-    filename = make_path("$GAMMAPY_DATA/tests/phasecurve_LSI_DC.fits")
-    table = Table.read(str(filename))
+    path = make_path("$GAMMAPY_DATA/tests/phasecurve_LSI_DC.fits")
+    table = Table.read(path)
     return PhaseCurveTemplateTemporalModel(
         table, time_0=43366.275, phase_0=0.0, f0=4.367575e-7
     )

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -141,7 +141,6 @@ def dict_to_datasets(data_list, components):
     components : dict
         dict describing model components
     """
-
     models = dict_to_models(components)
     datasets = []
 

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -14,7 +14,7 @@ from gammapy.utils.testing import requires_data
 
 
 @requires_data()
-def test_dict_to_skymodels(tmpdir):
+def test_dict_to_skymodels():
     filename = get_pkg_data_filename("data/examples.yaml")
     models_data = read_yaml(filename)
 
@@ -84,14 +84,14 @@ def test_dict_to_skymodels(tmpdir):
 
 
 @requires_data()
-def test_sky_models_io(tmpdir):
+def test_sky_models_io(tmp_path):
     # TODO: maybe change to a test case where we create a model programatically?
     filename = get_pkg_data_filename("data/examples.yaml")
     models = SkyModels.from_yaml(filename)
 
-    filename = str(tmpdir / "io_example.yaml")
-    models.to_yaml(filename)
-    models = SkyModels.from_yaml(filename)
+    models.to_yaml(tmp_path / "tmp.yaml")
+    models = SkyModels.from_yaml(tmp_path / "tmp.yaml")
+
     assert_allclose(models.parameters["lat_0"].min, -90.0)
 
     # TODO: not sure if we should just round-trip, or if we should
@@ -100,7 +100,7 @@ def test_sky_models_io(tmpdir):
 
 
 @requires_data()
-def test_datasets_to_io(tmpdir):
+def test_datasets_to_io(tmp_path):
     filedata = "$GAMMAPY_DATA/tests/models/gc_example_datasets.yaml"
     filemodel = "$GAMMAPY_DATA/tests/models/gc_example_models.yaml"
 
@@ -130,17 +130,18 @@ def test_datasets_to_io(tmpdir):
     assert dataset0.model.skymodels[1].name == "gll_iem_v06_cutout"
 
     assert (
-        dataset0.model.skymodels[0].parameters["reference"]
-        is dataset1.model.skymodels[1].parameters["reference"]
+            dataset0.model.skymodels[0].parameters["reference"]
+            is dataset1.model.skymodels[1].parameters["reference"]
     )
 
     assert_allclose(
         dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
-    path = str(tmpdir / "/written_")
-    datasets.to_yaml(path, overwrite=True)
-    datasets_read = Datasets.from_yaml(path + "datasets.yaml", path + "models.yaml")
+    datasets.to_yaml(tmp_path / "written_", overwrite=True)
+    datasets_read = Datasets.from_yaml(
+        tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
+    )
     assert len(datasets_read.datasets) == 2
     dataset0 = datasets_read.datasets[0]
     assert dataset0.counts.data.sum() == 6824
@@ -151,7 +152,7 @@ def test_datasets_to_io(tmpdir):
 
 
 @requires_data()
-def test_absorption_io(tmpdir):
+def test_absorption_io(tmp_path):
     dominguez = Absorption.read_builtin("dominguez")
     model = AbsorbedSpectralModel(
         spectral_model=Model.create("PowerLawSpectralModel"),
@@ -182,11 +183,13 @@ def test_absorption_io(tmpdir):
         parameter_name="redshift",
     )
     model_dict = model.to_dict()
-    write_yaml(model_dict, tmpdir / "written.yaml")
-    read_yaml(tmpdir / "written.yaml")
     new_model = AbsorbedSpectralModel.from_dict(model_dict)
+
     assert_allclose(new_model.absorption.energy, test_absorption.energy)
     assert_allclose(new_model.absorption.param, test_absorption.param)
+
+    write_yaml(model_dict, tmp_path / "tmp.yaml")
+    read_yaml(tmp_path / "tmp.yaml")
 
 
 def make_all_models():

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -138,7 +138,7 @@ def test_datasets_to_io(tmp_path):
         dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
-    datasets.to_yaml(tmp_path / "written_", overwrite=True)
+    datasets.to_yaml(str(tmp_path / "written_"))
     datasets_read = Datasets.from_yaml(
         tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
     )

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -130,8 +130,8 @@ def test_datasets_to_io(tmp_path):
     assert dataset0.model.skymodels[1].name == "gll_iem_v06_cutout"
 
     assert (
-            dataset0.model.skymodels[0].parameters["reference"]
-            is dataset1.model.skymodels[1].parameters["reference"]
+        dataset0.model.skymodels[0].parameters["reference"]
+        is dataset1.model.skymodels[1].parameters["reference"]
     )
 
     assert_allclose(

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -50,7 +50,7 @@ def execute_notebook(path, kernel="python3", loglevel=30):
     completed_process = subprocess.run(cmd)
     t = time.time() - t
     if completed_process.returncode:
-        log.error("Error executing file {}".format(str(path)))
+        log.error(f"Error executing file: {path}")
         return False
     else:
         log.info(f"   ... Executing duration: {t:.1f} seconds")
@@ -74,7 +74,7 @@ def cli_jupyter_strip(ctx):
                 cell["outputs"] = []
 
         nbformat.write(rawnb, str(path))
-        log.info("Strip output cells in notebook: {}".format(str(path)))
+        log.info(f"Strip output cells in notebook: {path}")
 
 
 @click.command(name="black")
@@ -89,7 +89,7 @@ def cli_jupyter_black(ctx):
         blacknb.blackformat()
         rawnb = blacknb.rawnb
         nbformat.write(rawnb, str(path))
-        log.info("Applied black to notebook: {}".format(str(path)))
+        log.info(f"Applied black to notebook: {path}")
 
 
 class BlackNotebook:
@@ -157,7 +157,7 @@ def notebook_test(path, kernel="python3"):
     """Execute and parse a Jupyter notebook exposing broken cells."""
     import nbformat
 
-    log.info("   ... EXECUTING {}".format(str(path)))
+    log.info(f"   ... EXECUTING: {path}")
     passed = execute_notebook(path, kernel)
     rawnb = nbformat.read(str(path), as_version=nbformat.NO_CONVERT)
     report = ""
@@ -208,7 +208,7 @@ class environment:
             if abspath.is_file():
                 datapath = abspath.parent.parent / "datasets"
             os.environ["GAMMAPY_DATA"] = str(datapath)
-            log.info("Setting GAMMAPY_DATA={}".format(os.environ["GAMMAPY_DATA"]))
+            log.info(f"Setting GAMMAPY_DATA={datapath}")
 
     def __exit__(self, type, value, traceback):
         if self.tutor:

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -26,11 +26,11 @@ def test_config():
     assert "AnalysisConfig" in str(config)
 
 
-def test_config_to_yaml(tmpdir):
+def test_config_to_yaml(tmp_path):
     config = AnalysisConfig()
-    config.settings["general"]["outdir"] = tmpdir
+    config.settings["general"]["outdir"] = tmp_path
     config.to_yaml(overwrite=True)
-    text = Path(tmpdir / config.filename).read_text()
+    text = (tmp_path / config.filename).read_text()
     assert "stack-datasets" in text
 
 

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -1,13 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from pathlib import Path
 import pytest
 from gammapy.scripts.main import cli
 from gammapy.utils.testing import requires_dependency, run_cli
-
-
-@pytest.fixture(scope="session")
-def files_dir(tmpdir_factory):
-    return str(tmpdir_factory.mktemp("tmpdwn"))
 
 
 @pytest.fixture(scope="session")
@@ -24,80 +18,83 @@ def config():
 
 def test_cli_download_help():
     result = run_cli(cli, ["download", "--help"])
+
     assert "Usage" in result.output
 
 
 @requires_dependency("parfive")
 @pytest.mark.remote_data
-def test_cli_download_datasets(files_dir, config):
+def test_cli_download_datasets(tmp_path, config):
     args = [
         "download",
         "datasets",
         f"--src={config['dataset']}",
-        f"--out={files_dir}",
+        f"--out={tmp_path}",
         f"--release={config['release']}",
     ]
     result = run_cli(cli, args)
-    assert (Path(files_dir) / config["dataset"]).exists()
+
+    assert (tmp_path / config["dataset"]).exists()
     assert "GAMMAPY_DATA" in result.output
 
 
 @requires_dependency("parfive")
 @pytest.mark.remote_data
-def test_cli_download_notebooks(files_dir, config):
-    option_out = f"--out={files_dir}"
-    option_src = "--src={}".format(config["notebook"])
-    option_release = "--release={}".format(config["release"])
-    filename = "{}.ipynb".format(config["notebook"])
-    dirname = "notebooks-{}".format(config["release"])
-
-    args = ["download", "notebooks", option_src, option_out, option_release]
+def test_cli_download_notebooks(tmp_path, config):
+    args = [
+        "download",
+        "notebooks",
+        f"--src={config['notebook']}",
+        f"--out={tmp_path}",
+        f"--release={config['release']}",
+    ]
     run_cli(cli, args)
-    assert (Path(files_dir) / config["envfilename"]).exists()
-    # assert (Path(files_dir) / dirname / "images" / config["imagefile"]).exists()
-    assert (Path(files_dir) / dirname / filename).exists()
+
+    assert (tmp_path / config["envfilename"]).exists()
+    path = tmp_path / f"notebooks-{config['release']}/{config['notebook']}.ipynb"
+    assert path.exists()
 
 
 @requires_dependency("parfive")
 @pytest.mark.remote_data
-def test_cli_download_scripts(files_dir, config):
-    option_out = f"--out={files_dir}"
-    option_src = "--src={}".format(config["script"])
-    option_release = "--release={}".format(config["release"])
-    filename = "{}.py".format(config["script"])
-    dirname = "scripts-{}".format(config["release"])
-
-    args = ["download", "scripts", option_src, option_out, option_release]
+def test_cli_download_scripts(tmp_path, config):
+    args = [
+        "download",
+        "scripts",
+        f"--src={config['script']}",
+        f"--out={tmp_path}",
+        f"--release={config['release']}",
+    ]
     run_cli(cli, args)
-    assert (Path(files_dir) / config["envfilename"]).exists()
-    assert (Path(files_dir) / dirname / filename).exists()
+
+    assert (tmp_path / config["envfilename"]).exists()
+    assert (tmp_path / f"scripts-{config['release']}/{config['script']}.py").exists()
 
 
 @requires_dependency("parfive")
 @pytest.mark.remote_data
-def test_cli_download_tutorials(files_dir, config):
-    option_out = f"--out={files_dir}"
-    nboption_src = "--src={}".format(config["notebook"])
-    scoption_src = "--src={}".format(config["script"])
-    option_release = "--release={}".format(config["release"])
+def test_cli_download_tutorials(tmp_path, config):
+    option_out = f"--out={tmp_path}"
+    nboption_src = f"--src={config['notebook']}"
+    scoption_src = f"--src={config['script']}"
+    option_release = f"--release={config['release']}"
     dsdirname = "datasets"
-    nbdirname = "notebooks-{}".format(config["release"])
-    scdirname = "scripts-{}".format(config["release"])
-    nbfilename = "{}.ipynb".format(config["notebook"])
-    scfilename = "{}.py".format(config["script"])
+    nbdirname = f"notebooks-{config['release']}"
+    scdirname = f"scripts-{config['release']}"
+    nbfilename = f"{config['notebook']}.ipynb"
+    scfilename = f"{config['script']}.py"
 
     args = ["download", "tutorials", nboption_src, option_out, option_release]
     result = run_cli(cli, args)
-    assert (Path(files_dir) / config["envfilename"]).exists()
-    assert (Path(files_dir) / nbdirname / nbfilename).exists()
-    # assert (Path(files_dir) / nbdirname / "images" / config["imagefile"]).exists()
-    assert (Path(files_dir) / dsdirname / config["dataset"]).exists()
+    assert (tmp_path / config["envfilename"]).exists()
+    assert (tmp_path / nbdirname / nbfilename).exists()
+    assert (tmp_path / dsdirname / config["dataset"]).exists()
     assert "GAMMAPY_DATA" in result.output
     assert "jupyter lab" in result.output
 
     args = ["download", "tutorials", scoption_src, option_out, option_release]
     result = run_cli(cli, args)
-    assert (Path(files_dir) / config["envfilename"]).exists()
-    assert (Path(files_dir) / scdirname / scfilename).exists()
+    assert (tmp_path / config["envfilename"]).exists()
+    assert (tmp_path / scdirname / scfilename).exists()
     assert "GAMMAPY_DATA" in result.output
     assert "jupyter lab" in result.output

--- a/gammapy/scripts/tests/test_image_bin.py
+++ b/gammapy/scripts/tests/test_image_bin.py
@@ -6,12 +6,10 @@ from gammapy.utils.testing import assert_wcs_allclose, requires_data, run_cli
 
 
 @requires_data()
-def test_bin_image_main(tmpdir):
-    """Run ``gammapy-bin-image`` and compare result to ``ctskymap``.
-    """
+def test_bin_image_main(tmp_path):
     event_file = "$GAMMAPY_DATA/tests/irf/hess/pa/hess_events_023523.fits.gz"
     reference_file = "$GAMMAPY_DATA/tests/irf/hess/pa/ctskymap.fits.gz"
-    out_file = str(tmpdir / "gammapy_ctskymap.fits.gz")
+    out_file = str(tmp_path / "gammapy_ctskymap.fits.gz")
 
     args = ["image", "bin", event_file, reference_file, out_file]
     run_cli(cli, args)

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -82,8 +82,7 @@ class CountsSpectrum:
     @classmethod
     def read(cls, filename, hdu1="COUNTS", hdu2="EBOUNDS"):
         """Read from file."""
-        filename = make_path(filename)
-        with fits.open(str(filename), memmap=False) as hdulist:
+        with fits.open(make_path(filename), memmap=False) as hdulist:
             return cls.from_hdulist(hdulist, hdu1=hdu1, hdu2=hdu2)
 
     def to_table(self):
@@ -119,7 +118,7 @@ class CountsSpectrum:
     def write(self, filename, use_sherpa=False, **kwargs):
         """Write to file."""
         filename = make_path(filename)
-        self.to_hdulist(use_sherpa=use_sherpa).writeto(str(filename), **kwargs)
+        self.to_hdulist(use_sherpa=use_sherpa).writeto(filename, **kwargs)
 
     def fill(self, events):
         """Fill with list of events.

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -164,10 +164,10 @@ class FluxPoints:
         """
         filename = make_path(filename)
         try:
-            table = Table.read(str(filename), **kwargs)
+            table = Table.read(filename, **kwargs)
         except IORegistryError:
             kwargs.setdefault("format", "ascii.ecsv")
-            table = Table.read(str(filename), **kwargs)
+            table = Table.read(filename, **kwargs)
 
         if "SED_TYPE" not in table.meta.keys():
             sed_type = cls._guess_sed_type(table)
@@ -187,10 +187,10 @@ class FluxPoints:
         """
         filename = make_path(filename)
         try:
-            self.table.write(str(filename), **kwargs)
+            self.table.write(filename, **kwargs)
         except IORegistryError:
             kwargs.setdefault("format", "ascii.ecsv")
-            self.table.write(str(filename), **kwargs)
+            self.table.write(filename, **kwargs)
 
     @classmethod
     def stack(cls, flux_points):
@@ -1195,7 +1195,7 @@ class FluxPointsDataset(Dataset):
 
         table["mask_fit"] = mask_fit
         table["mask_safe"] = self.mask_safe
-        table.write(str(filename), overwrite=overwrite, **kwargs)
+        table.write(filename, overwrite=overwrite, **kwargs)
 
     @classmethod
     def from_dict(cls, data, components, models):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1500,7 +1500,6 @@ class FluxPointsDataset(Dataset):
                 self.model.plot_error(ax=ax, **plot_kwargs)
             except AttributeError:
                 log.debug("Model does not support evaluation of errors")
-                pass
 
         # format axes
         ax.set_xlim(self._e_range.to_value(self._e_unit))

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -43,10 +43,9 @@ class TestCountsSpectrum:
         with mpl_plot_check():
             self.spec.peek()
 
-    def test_io(self, tmpdir):
-        filename = tmpdir / "test.fits"
-        self.spec.write(filename)
-        spec2 = CountsSpectrum.read(filename)
+    def test_io(self, tmp_path):
+        self.spec.write(tmp_path / "tmp.fits")
+        spec2 = CountsSpectrum.read(tmp_path / "tmp.fits")
         assert_quantity_allclose(spec2.energy.edges, self.bins)
 
     def test_downsample(self):

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -343,7 +343,7 @@ class TestSpectrumOnOff:
         with mpl_plot_check():
             dataset.plot_fit()
 
-    def test_to_from_ogip_files(self, tmpdir):
+    def test_to_from_ogip_files(self, tmp_path):
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
@@ -356,16 +356,15 @@ class TestSpectrumOnOff:
             name="test",
             gti=self.gti,
         )
-        dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
-        filename = tmpdir / "pha_obstest.fits"
-        newdataset = SpectrumDatasetOnOff.from_ogip_files(filename)
+        dataset.to_ogip_files(outdir=tmp_path)
+        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_obstest.fits")
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert_allclose(self.off_counts.data, newdataset.counts_off.data)
         assert_allclose(self.edisp.pdf_matrix, newdataset.edisp.pdf_matrix)
         assert_time_allclose(newdataset.gti.time_start, dataset.gti.time_start)
 
-    def test_to_from_ogip_files_no_edisp(self, tmpdir):
+    def test_to_from_ogip_files_no_edisp(self, tmp_path):
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             aeff=self.aeff,
@@ -374,9 +373,8 @@ class TestSpectrumOnOff:
             acceptance=1,
             name="test",
         )
-        dataset.to_ogip_files(outdir=tmpdir, overwrite=True)
-        filename = tmpdir / "pha_obstest.fits"
-        newdataset = SpectrumDatasetOnOff.from_ogip_files(filename)
+        dataset.to_ogip_files(outdir=tmp_path)
+        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_obstest.fits")
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert newdataset.counts_off is None

--- a/gammapy/spectrum/tests/test_extract.py
+++ b/gammapy/spectrum/tests/test_extract.py
@@ -140,12 +140,12 @@ class TestSpectrumExtraction:
         assert len(extraction.spectrum_observations) == 0
 
     @staticmethod
-    def test_run(tmpdir, extraction):
+    def test_run(tmp_path, extraction):
         """Test the run method and check if files are written correctly"""
         extraction.run()
-        extraction.write(outdir=str(tmpdir), overwrite=True)
+        extraction.write(outdir=tmp_path)
         testobs = SpectrumDatasetOnOff.from_ogip_files(
-            str(tmpdir / "ogip_data" / "pha_obs23523.fits")
+            tmp_path / "ogip_data/pha_obs23523.fits"
         )
         assert_quantity_allclose(
             testobs.aeff.data.data, extraction.spectrum_observations[0].aeff.data.data
@@ -159,13 +159,13 @@ class TestSpectrumExtraction:
         )
 
     @requires_dependency("sherpa")
-    def test_sherpa(self, tmpdir, extraction):
+    def test_sherpa(self, tmp_path, extraction):
         """Same as above for files to be used with sherpa"""
         import sherpa.astro.ui as sau
 
         extraction.run()
-        extraction.write(outdir=str(tmpdir), use_sherpa=True, overwrite=True)
-        sau.load_pha(str(tmpdir / "ogip_data" / "pha_obs23523.fits"))
+        extraction.write(outdir=tmp_path, use_sherpa=True)
+        sau.load_pha(str(tmp_path / "ogip_data/pha_obs23523.fits"))
         arf = sau.get_arf()
 
         actual = arf._arf._specresp

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -171,7 +171,7 @@ class TestSpectralFit:
         assert_allclose(pars["amplitude"].value, 5.191e-11, rtol=1e-3)
 
     @requires_dependency("sherpa")
-    def test_sherpa_fit(self, tmpdir):
+    def test_sherpa_fit(self, tmp_path):
         # this is to make sure that the written PHA files work with sherpa
         import sherpa.astro.ui as sau
         from sherpa.models import PowLaw1D
@@ -183,10 +183,9 @@ class TestSpectralFit:
         logging.getLogger("sherpa").setLevel("ERROR")
 
         for obs in self.obs_list:
-            obs.to_ogip_files(str(tmpdir), use_sherpa=True)
+            obs.to_ogip_files(tmp_path, use_sherpa=True)
 
-        filename = tmpdir / "pha_obs23523.fits"
-        sau.load_pha(str(filename))
+        sau.load_pha(str(tmp_path / "pha_obs23523.fits"))
         sau.set_stat("wstat")
         model = PowLaw1D("powlaw1d.default")
         model.ref = 1e9

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -264,7 +264,7 @@ def test_flux_point_dataset_serialization(tmp_path):
     model = SkyModel(spatial_model, spectral_model, name="test_model")
     dataset = FluxPointsDataset(SkyModels([model]), data, name="test_dataset")
 
-    Datasets([dataset]).to_yaml(tmp_path / "tmp_")
+    Datasets([dataset]).to_yaml(str(tmp_path / "tmp_"))
     datasets = Datasets.from_yaml(tmp_path / "tmp_datasets.yaml", tmp_path / "tmp_models.yaml")
     new_dataset = datasets.datasets[0]
     assert_allclose(new_dataset.data.table["dnde"], dataset.data.table["dnde"], 1e-4)

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -5,13 +5,13 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table
 from gammapy.catalog.fermi import SourceCatalog3FGL
-from gammapy.modeling import Fit, Datasets
+from gammapy.modeling import Datasets, Fit
 from gammapy.modeling.models import (
-    PowerLawSpectralModel,
-    SpectralModel,
     ConstantSpatialModel,
+    PowerLawSpectralModel,
     SkyModel,
     SkyModels,
+    SpectralModel,
 )
 from gammapy.spectrum import FluxPoints, FluxPointsDataset
 from gammapy.utils.testing import (
@@ -265,7 +265,9 @@ def test_flux_point_dataset_serialization(tmp_path):
     dataset = FluxPointsDataset(SkyModels([model]), data, name="test_dataset")
 
     Datasets([dataset]).to_yaml(str(tmp_path / "tmp_"))
-    datasets = Datasets.from_yaml(tmp_path / "tmp_datasets.yaml", tmp_path / "tmp_models.yaml")
+    datasets = Datasets.from_yaml(
+        tmp_path / "tmp_datasets.yaml", tmp_path / "tmp_models.yaml"
+    )
     new_dataset = datasets.datasets[0]
     assert_allclose(new_dataset.data.table["dnde"], dataset.data.table["dnde"], 1e-4)
     if dataset.mask_fit is None:

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -188,16 +188,14 @@ class TestFluxPoints:
             desired = 399430.975 * u.MeV
             assert_quantity_allclose(actual.sum(), desired)
 
-    def test_write_fits(self, tmpdir, flux_points):
-        filename = tmpdir / "flux_points.fits"
-        flux_points.write(filename)
-        actual = FluxPoints.read(filename)
+    def test_write_fits(self, tmp_path, flux_points):
+        flux_points.write(tmp_path / "tmp.fits")
+        actual = FluxPoints.read(tmp_path / "tmp.fits")
         assert str(flux_points) == str(actual)
 
-    def test_write_ecsv(self, tmpdir, flux_points):
-        filename = tmpdir / "flux_points.ecsv"
-        flux_points.write(filename)
-        actual = FluxPoints.read(filename)
+    def test_write_ecsv(self, tmp_path, flux_points):
+        flux_points.write(tmp_path / "flux_points.ecsv")
+        actual = FluxPoints.read(tmp_path / "flux_points.ecsv")
         assert str(flux_points) == str(actual)
 
     def test_drop_ul(self, flux_points):
@@ -254,11 +252,11 @@ def dataset():
 
 
 @requires_data()
-def test_flux_point_dataset_serialization(tmpdir):
+def test_flux_point_dataset_serialization(tmp_path):
     path = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
     data = FluxPoints.read(path)
     data.table["e_ref"] = data.e_ref.to("TeV")
-    #    TODO: remove duplicate definition this once model is redefine as skymodel
+    # TODO: remove duplicate definition this once model is redefine as skymodel
     spatial_model = ConstantSpatialModel()
     spectral_model = PowerLawSpectralModel(
         index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV"
@@ -266,9 +264,8 @@ def test_flux_point_dataset_serialization(tmpdir):
     model = SkyModel(spatial_model, spectral_model, name="test_model")
     dataset = FluxPointsDataset(SkyModels([model]), data, name="test_dataset")
 
-    respath = str(tmpdir / "/written_")
-    Datasets([dataset]).to_yaml(respath, overwrite=True)
-    datasets = Datasets.from_yaml(respath + "datasets.yaml", respath + "models.yaml")
+    Datasets([dataset]).to_yaml(tmp_path / "tmp_")
+    datasets = Datasets.from_yaml(tmp_path / "tmp_datasets.yaml", tmp_path / "tmp_models.yaml")
     new_dataset = datasets.datasets[0]
     assert_allclose(new_dataset.data.table["dnde"], dataset.data.table["dnde"], 1e-4)
     if dataset.mask_fit is None:

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -200,9 +200,9 @@ class LightCurve:
         if ax is None:
             ax = plt.gca()
 
+        x, xerr = self._get_times_and_errors(time_format)
         y, yerr = self._get_fluxes_and_errors(flux_unit)
         is_ul, yul = self._get_flux_uls(flux_unit)
-        x, xerr = self._get_times_and_errors(time_format)
 
         # length of the ul arrow
         ul_arr = (
@@ -312,8 +312,6 @@ class LightCurve:
             Tuple of time error values or `~datetime.timedelta` instances if
             'iso' is chosen as time format
         """
-        from matplotlib.dates import num2timedelta
-
         x = self.time
 
         try:
@@ -321,16 +319,14 @@ class LightCurve:
         except KeyError:
             xn, xp = x - x, x - x
 
-        # convert to given time format
         if time_format == "iso":
             x = x.datetime
-            # TODO: In astropy version >3.1 the TimeDelta.to_datetime() method
-            # should start working, for now i will use num2timedelta.
-            xn = np.asarray(num2timedelta(xn.to("d").value))
-            xp = np.asarray(num2timedelta(xp.to("d").value))
+            xn = xn.to_datetime()
+            xp = xp.to_datetime()
         elif time_format == "mjd":
             x = x.mjd
-            xn, xp = xn.to("d").value, xp.to("d").value
+            xn = xn.to("d").value
+            xp = xp.to("d").value
         else:
             raise ValueError(f"Invalid time_format: {time_format}")
 

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -94,8 +94,7 @@ class LightCurve:
         kwargs : dict
             Keyword arguments passed to `astropy.table.Table.read`.
         """
-        filename = make_path(filename)
-        table = Table.read(str(filename), **kwargs)
+        table = Table.read(make_path(filename), **kwargs)
         return cls(table=table)
 
     def write(self, filename, **kwargs):
@@ -108,8 +107,7 @@ class LightCurve:
         kwargs : dict
             Keyword arguments passed to `astropy.table.Table.write`.
         """
-        filename = make_path(filename)
-        self.table.write(str(filename), **kwargs)
+        self.table.write(make_path(filename), **kwargs)
 
     def compute_fvar(self):
         r"""Calculate the fractional excess variance.

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -133,27 +133,22 @@ def test_lightcurve_plot_flux_ul(lc, flux_unit):
     assert_allclose(ful, [np.nan, 3.6e-11])
 
 
-@requires_dependency("matplotlib")
-@pytest.mark.parametrize(
-    "time_format, output",
-    [
-        ("mjd", ([55198.0, 55202.5], ([1.0, 3.5], [1.0, 3.5]))),
-        (
-            "iso",
-            (
-                [datetime.datetime(2010, 1, 2), datetime.datetime(2010, 1, 6, 12)],
-                (
-                    [datetime.timedelta(1), datetime.timedelta(3.5)],
-                    [datetime.timedelta(1), datetime.timedelta(3.5)],
-                ),
-            ),
-        ),
-    ],
-)
-def test_lightcurve_plot_time(lc, time_format, output):
-    t, terr = lc._get_times_and_errors(time_format)
-    assert np.array_equal(t, output[0])
-    assert np.array_equal(terr, output[1])
+def test_lightcurve_plot_time(lc):
+    t, terr = lc._get_times_and_errors("mjd")
+    assert np.array_equal(t, [55198.0, 55202.5])
+    assert np.array_equal(terr, [[1.0, 3.5], [1.0, 3.5]])
+
+    t, terr = lc._get_times_and_errors("iso")
+    assert np.array_equal(
+        t, [datetime.datetime(2010, 1, 2), datetime.datetime(2010, 1, 6, 12)]
+    )
+    assert np.array_equal(
+        terr,
+        [
+            [datetime.timedelta(1), datetime.timedelta(3.5)],
+            [datetime.timedelta(1), datetime.timedelta(3.5)],
+        ],
+    )
 
 
 def get_spectrum_datasets():

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -86,11 +86,9 @@ def test_lightcurve_properties_flux(lc):
 
 
 @pytest.mark.parametrize("format", ["fits", "ascii.ecsv", "ascii.csv"])
-def test_lightcurve_read_write(tmpdir, lc, format):
-    filename = str(tmpdir / "spam")
-
-    lc.write(filename, format=format)
-    lc = LightCurve.read(filename, format=format)
+def test_lightcurve_read_write(tmp_path, lc, format):
+    lc.write(tmp_path / "tmp", format=format)
+    lc = LightCurve.read(tmp_path / "tmp", format=format)
 
     # Check if time-related info round-trips
     time = lc.time

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -6,8 +6,6 @@ from astropy.stats import LombScargle
 from gammapy.time import plot_periodogram, robust_periodogram
 from gammapy.utils.testing import requires_dependency
 
-pytest.importorskip("astropy", "3.0")
-
 
 def simulate_test_data(period, amplitude, t_length, n_data, n_obs, n_outliers):
     """

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -256,7 +256,7 @@ class SmartHDUList:
         filename : str
             Filename
         """
-        filename = str(make_path(filename))
+        filename = make_path(filename)
         memmap = kwargs.pop("memmap", False)
         hdu_list = fits.open(filename, memmap=memmap, **kwargs)
         return cls(hdu_list)
@@ -274,8 +274,7 @@ class SmartHDUList:
         filename : str
             Filename
         """
-        filename = str(make_path(filename))
-        self.hdu_list.writeto(filename, **kwargs)
+        self.hdu_list.writeto(make_path(filename), **kwargs)
 
     @property
     def names(self):
@@ -312,13 +311,6 @@ class SmartHDUList:
             raise ValueError(
                 "Must give either `hdu` or `hdu_type`. Got `None` for both."
             )
-
-        # if (hdu_key is not None) and (hdu_type is not None):
-        #     raise ValueError(
-        #         'Must give either `hdu` or `hdu_type`.'
-        #         ' Got a value for both: hdu={} and hdu_type={}'
-        #         ''.format(hdu_key, hdu_type)
-        #     )
 
         if hdu_key is not None:
             idx = self.hdu_list.index_of(hdu_key)

--- a/gammapy/utils/scripts.py
+++ b/gammapy/utils/scripts.py
@@ -99,7 +99,7 @@ def make_path(path):
     # TODO: raise error or warning if environment variables that don't resolve are used
     # e.g. "spam/$DAMN/ham" where `$DAMN` is not defined
     # Otherwise this can result in cryptic errors later on
-    return Path(os.path.expandvars(str(path)))
+    return Path(os.path.expandvars(path))
 
 
 def recursive_merge_dicts(a, b):

--- a/gammapy/utils/scripts_test.py
+++ b/gammapy/utils/scripts_test.py
@@ -33,7 +33,7 @@ def requirement_missing(script):
 
 def script_test(path):
     """Check if example Python script is broken."""
-    log.info("   ... EXECUTING {}".format(str(path)))
+    log.info(f"   ... EXECUTING {path}")
 
     cmd = [sys.executable, str(path)]
     cp = subprocess.run(cmd, stderr=subprocess.PIPE)
@@ -60,7 +60,7 @@ def main():
 
     for script in get_scripts():
         if requirement_missing(script):
-            log.info("Skipping script (missing requirement): {}".format(script["name"]))
+            log.info(f"Skipping script (missing requirement): {script['name']}")
             continue
 
         filename = script["name"] + ".py"

--- a/gammapy/utils/tests/test_fits.py
+++ b/gammapy/utils/tests/test_fits.py
@@ -81,10 +81,9 @@ class TestSmartHDUList:
         # make sure it returns an int index all right.
         assert self.hdus.get_hdu_index(hdu="TABLE2") == 3
 
-    def test_read_write(self, tmpdir):
-        filename = str(tmpdir / "data.fits")
-        self.hdus.write(filename)
-        hdus2 = SmartHDUList.open(filename)
+    def test_read_write(self, tmp_path):
+        self.hdus.write(tmp_path / "tmp.fits")
+        hdus2 = SmartHDUList.open(tmp_path / "tmp.fits")
         assert self.hdus.names == hdus2.names
 
 

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -55,20 +55,20 @@ def build_notebooks(args):
     path_filled_nbs = Path("docs") / "notebooks"
     path_static_nbs = Path("docs") / "_static" / "notebooks"
 
-    shutil.rmtree(str(path_temp), ignore_errors=True)
+    shutil.rmtree(path_temp, ignore_errors=True)
     path_temp.mkdir(parents=True, exist_ok=True)
     path_filled_nbs.mkdir(parents=True, exist_ok=True)
     path_static_nbs.mkdir(parents=True, exist_ok=True)
 
     if pathsrc == path_empty_nbs:
-        shutil.rmtree(str(path_temp), ignore_errors=True)
-        shutil.rmtree(str(path_static_nbs), ignore_errors=True)
-        shutil.rmtree(str(path_filled_nbs), ignore_errors=True)
-        shutil.copytree(str(path_empty_nbs), str(path_temp), ignore=ignorefiles)
+        shutil.rmtree(path_temp, ignore_errors=True)
+        shutil.rmtree(path_static_nbs, ignore_errors=True)
+        shutil.rmtree(path_filled_nbs, ignore_errors=True)
+        shutil.copytree(path_empty_nbs, path_temp, ignore=ignorefiles)
     elif pathsrc.exists():
         notebookname = pathsrc.name
         pathdest = path_temp / notebookname
-        shutil.copyfile(str(pathsrc), str(pathdest))
+        shutil.copyfile(pathsrc, pathdest)
     else:
         log.info("Notebook file does not exist.")
         sys.exit()
@@ -88,7 +88,7 @@ def build_notebooks(args):
     # copy generated filled notebooks to doc
     if pathsrc == path_empty_nbs:
         # copytree is needed to copy subfolder images
-        shutil.copytree(str(path_empty_nbs), str(path_static_nbs), ignore=ignorefiles)
+        shutil.copytree(path_empty_nbs, path_static_nbs, ignore=ignorefiles)
         for path in path_static_nbs.glob("*.ipynb"):
             subprocess.run(
                 [
@@ -101,11 +101,11 @@ def build_notebooks(args):
                     str(path),
                 ]
             )
-        shutil.copytree(str(path_temp), str(path_filled_nbs), ignore=ignorefiles)
+        shutil.copytree(path_temp, path_filled_nbs, ignore=ignorefiles)
     else:
         pathsrc = path_temp / notebookname
         pathdest = path_static_nbs / notebookname
-        shutil.copyfile(str(pathsrc), str(pathdest))
+        shutil.copyfile(pathsrc, pathdest)
         subprocess.run(
             [
                 sys.executable,
@@ -118,10 +118,10 @@ def build_notebooks(args):
             ]
         )
         pathdest = path_filled_nbs / notebookname
-        shutil.copyfile(str(pathsrc), str(pathdest))
+        shutil.copyfile(pathsrc, pathdest)
 
     # tear down
-    shutil.rmtree(str(path_temp), ignore_errors=True)
+    shutil.rmtree(path_temp, ignore_errors=True)
 
 
 def main():

--- a/gammapy/utils/tutorials_test.py
+++ b/gammapy/utils/tutorials_test.py
@@ -46,16 +46,12 @@ def main():
     # setup
     path_temp = Path("temp")
     path_empty_nbs = Path("tutorials")
-    shutil.rmtree(str(path_temp), ignore_errors=True)
-    shutil.copytree(str(path_empty_nbs), str(path_temp))
+    shutil.rmtree(path_temp, ignore_errors=True)
+    shutil.copytree(path_empty_nbs, path_temp)
 
     for notebook in get_notebooks():
         if requirement_missing(notebook):
-            log.info(
-                "Skipping notebook {} because requirement is missing.".format(
-                    notebook["name"]
-                )
-            )
+            log.info(f"Skipping notebook (requirement missing): {notebook['name']}")
             continue
 
         filename = notebook["name"] + ".ipynb"
@@ -65,7 +61,7 @@ def main():
             passed = False
 
     # tear down
-    shutil.rmtree(str(path_temp), ignore_errors=True)
+    shutil.rmtree(path_temp, ignore_errors=True)
 
     if not passed:
         sys.exit("Some tests failed. Existing now.")

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -260,8 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# write dataset to file\n",
-    "filename = str(path / \"stacked-dataset.fits.gz\")\n",
+    "filename = path / \"stacked-dataset.fits.gz\"\n",
     "stacked.write(filename, overwrite=True)"
    ]
   },

--- a/tutorials/background_model.ipynb
+++ b/tutorials/background_model.ipynb
@@ -419,7 +419,7 @@
     "    Path(os.environ[\"GAMMAPY_DATA\"])\n",
     "    / \"hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz\"\n",
     ")\n",
-    "hdu_list.writeto(str(path), overwrite=True)"
+    "hdu_list.writeto(path, overwrite=True)"
    ]
   },
   {

--- a/tutorials/hgps.ipynb
+++ b/tutorials/hgps.ipynb
@@ -204,10 +204,7 @@
     "\n",
     "### FITS file content\n",
     "\n",
-    "Let's start by just opening up `hgps_catalog_v1.fits.gz` and looking at the content.\n",
-    "\n",
-    "Note that ``astropy.io.fits.open`` doesn't work with `Path` objects yet,\n",
-    "so you have to call `str(path)` and pass a string."
+    "Let's start by just opening up `hgps_catalog_v1.fits.gz` and looking at the content."
    ]
   },
   {
@@ -217,7 +214,7 @@
    "outputs": [],
    "source": [
     "path = hgps_data_path / \"hgps_catalog_v1.fits.gz\"\n",
-    "hdu_list = fits.open(str(path))"
+    "hdu_list = fits.open(path)"
    ]
   },
   {
@@ -252,7 +249,7 @@
     "table = Table.read(hdu_list[\"HGPS_SOURCES\"])\n",
     "\n",
     "# Alternatively, reading from file directly would work like this:\n",
-    "# table = Table.read(str(path), hdu='HGPS_SOURCES')\n",
+    "# table = Table.read(path, hdu='HGPS_SOURCES')\n",
     "# Usually you have to look first what HDUs are in a FITS file\n",
     "# like we did above; `Table` is just for one table"
    ]
@@ -373,9 +370,7 @@
    "source": [
     "# To save it to a DS9 region text file\n",
     "path = hgps_data_path / \"hgps_my_format.reg\"\n",
-    "\n",
-    "with open(str(path), \"w\") as f:\n",
-    "    f.write(txt)\n",
+    "path.write_text(txt)\n",
     "\n",
     "# Print content of the file to check\n",
     "print(path.read_text())"
@@ -531,7 +526,7 @@
    "outputs": [],
    "source": [
     "path = hgps_data_path / \"hgps_map_significance_0.1deg_v1.fits.gz\"\n",
-    "hdu_list = fits.open(str(path))\n",
+    "hdu_list = fits.open(path)\n",
     "hdu_list.info()"
    ]
   },


### PR DESCRIPTION
This is a reminder issue to update the Gammapy codebase to use recent features from Numpy, Astropy, ..., i.e. workarounds for old versions of those dependencies can be removed. Partially this can be done by reviewing `TODO` comments or grepping for `version`, partially this has to be done manually by browsing our codebase.

See #2218 and [PIG 13](https://github.com/gammapy/gammapy/blob/master/docs/development/pigs/pig-013.rst) and the related #2349.