### PR TITLE
Simplify number type checking

### DIFF
--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -1,10 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Source catalog and object base classes."""
 import copy
+import numbers
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.utils import lazyproperty
-from gammapy.utils.array import _is_int
 from gammapy.utils.table import table_from_row_data, table_row_to_dict
 
 __all__ = ["SourceCatalog", "SourceCatalogObject"]
@@ -175,11 +175,11 @@ class SourceCatalog:
         """
         if isinstance(key, str):
             index = self.row_index(key)
-        elif _is_int(key):
+        elif isinstance(key, numbers.Integral):
             index = key
         else:
             raise TypeError(
-                f"Invalid type: {key!r}\n"
+                f"Invalid key: {key!r}, {type(key)}\n"
                 "Key must be source name string or row index integer. "
             )
 

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -53,7 +53,7 @@ class TestSourceCatalog:
         source = self.cat[0]
         assert source.data["Source_Name"] == "a"
 
-        source = self.cat[np.int(0)]
+        source = self.cat[np.int32(0)]
         assert source.data["Source_Name"] == "a"
 
         with pytest.raises(KeyError):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -5,7 +5,6 @@ import inspect
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
-from gammapy.utils.array import check_type
 
 __all__ = ["Parameter", "Parameters"]
 
@@ -81,7 +80,7 @@ class Parameter:
 
     @name.setter
     def name(self, val):
-        self._name = check_type(val, "str")
+        self._name = str(val)
 
     @property
     def factor(self):
@@ -151,7 +150,7 @@ class Parameter:
 
     @frozen.setter
     def frozen(self, val):
-        self._frozen = check_type(val, "bool")
+        self._frozen = bool(val)
 
     @property
     def value(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -80,7 +80,9 @@ class Parameter:
 
     @name.setter
     def name(self, val):
-        self._name = str(val)
+        if not isinstance(val, str):
+            raise TypeError(f"Invalid type: {val}, {type(val)}")
+        self._name = val
 
     @property
     def factor(self):
@@ -150,7 +152,9 @@ class Parameter:
 
     @frozen.setter
     def frozen(self, val):
-        self._frozen = bool(val)
+        if not isinstance(val, bool):
+            raise TypeError(f"Invalid type: {val}, {type(val)}")
+        self._frozen = val
 
     @property
     def value(self):

--- a/gammapy/utils/array.py
+++ b/gammapy/utils/array.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utility functions to deal with arrays and quantities."""
-import numbers
 import numpy as np
 
 __all__ = [

--- a/gammapy/utils/array.py
+++ b/gammapy/utils/array.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utility functions to deal with arrays and quantities."""
+import numbers
 import numpy as np
 
 __all__ = [
@@ -107,42 +108,3 @@ def symmetric_crop_pad_width(shape, new_shape):
     ywidth = (ydiff // 2, ydiff // 2)
     xwidth = (xdiff // 2, xdiff // 2)
     return ywidth, xwidth
-
-
-def check_type(val, category):
-    if category == "str":
-        return _check_str(val)
-    elif category == "number":
-        return _check_number(val)
-    elif category == "bool":
-        return _check_bool(val)
-    else:
-        raise ValueError(f"Invalid category: {category}")
-
-
-def _check_str(val):
-    if isinstance(val, str):
-        return val
-    else:
-        raise TypeError(f"Expected a string. Got: {val!r}")
-
-
-def _check_bool(val):
-    if isinstance(val, bool):
-        return val
-    else:
-        raise TypeError(f"Expected a bool. Got: {val!r}")
-
-
-def _check_number(val):
-    if _is_float(val) or _is_int(val):
-        return val
-    raise TypeError(f"Expected a number. Got: {val!r}")
-
-
-def _is_int(val):
-    return isinstance(val, (int, np.integer))
-
-
-def _is_float(val):
-    return isinstance(val, (float, np.floating))


### PR DESCRIPTION
This PR does some clean-up on number type checking, removing the `check_type` and `_is_int` helper functions.

`_is_int` was used in `gammapy.catalog`, to check for both Numpy int scalars or Python int scalars when indexing into a catalog object to get the corresponding row. Actually the unit test for that was broken, it used `np.int(0)`, but `np.int == int`. I changed that to `np.int32(0)` to actually get a Numpy scalar object. I changed the call to `_is_int` to `isinstance(val, numbers.Number)`, using  https://docs.python.org/3.7/library/numbers.html. At least on my machine with recent Numpy, this worked, i.e. `np.int32` is recognised as a `numbers.Number`. Let's see what CI says.

The `check_type` was used for the `frozen` and `name` attributes in `Parameter`. For now I just changed those in the property setters to do type casting. We should probably improve all properties to do some type checking, but not manually, but using some generic pattern throughout Gammapy. Something to re-discuss in the future.