### PR TITLE
Remove multiprocessing code

### DIFF
--- a/docs/detect/index.rst
+++ b/docs/detect/index.rst
@@ -46,8 +46,6 @@ the null hypothesis is computed using `~gammapy.stats.cash` statistics.
 To optimize the performance of the code, the fitting procedure is simplified by
 finding roots of the derivative of the fit statistics with respect to the flux
 amplitude. This approach is described in detail in Appendix A of [Stewart2009]_.
-To further improve the performance, Pythons's `multiprocessing` facility is
-used.
 
 The following example shows how to compute a TS image for Fermi-LAT 3FHL galactic
 center data:

--- a/docs/development/howto.rst
+++ b/docs/development/howto.rst
@@ -194,33 +194,23 @@ has pixel coordinates ``(0, 0)`` (and not ``(1, 1)`` as shown e.g. in ds9).
 
 You should use ``origin=0`` when calling any of the pixel to world or world to pixel coordinate transformations in `astropy.wcs`.
 
-When to use C or Cython or Numba for speed
-------------------------------------------
+Performance
+-----------
 
-Most of Gammapy is written using Python and Numpy array expressions calling functions (e.g. from Scipy)
-that operate on Numpy arrays.
-This is often nice because it means that algorithms can be implemented with few lines of high-level code,
+Currently Gammapy is 99% Python and scientific Python code. Most memory used is in Numpy arrays,
+since most Gammapy and Astropy objects hold the data in Numpy arrays, and there's some fraction
+of memory in Python objects. We have 1% of Cython code, although it's not really needed in those
+cases, we could rewrite that using just Numpy.
 
-There is a very small fraction of code though (one or a few percent) where this results in code that is
-either cumbersome or too slow. E.g. to compute TS or upper limit images, one needs to do a root finding
-method with different number of iterations for each pixel ... that's impossible (or at least very
-cumbersome / hard to read) to implement with array expressions and Python loops over pixels are slow.
+In the future, we plan to benchmark and improve the performance both of our existing code
+(e.g. avoid temp copies of Numpy arrays, better algorithms), and also to introduce parallel
+execution that can take advantage of multi-core CPUs (and maybe even multiple machines).
+There's many options how to do that, e.g. using Numba, Cython, Dask, Ray, multiprocessing
+to name a few. Also, parallelism can be introduced for different tasks and at different levels,
+e.g. during data reduction, or at the dataset or model component or at the function level.
+This is planned for 2020, but really prototyping and pull requests on performance are welcome
+any time.
 
-In these cases we encourage the use of `Cython <http://cython.org/>`__ or `Numba <http://numba.pydata.org/>`__,
-or writing the core code in C and exposing it to Python via Cython.
-These are popular and simple ways to get C speed from Python.
-
-To use several CPU cores consider using the Python standard library
-`multiprocessing <https://docs.python.org/3/library/multiprocessing.html>`__ module.
-
-Note that especially the use of Numba should be considered an experiment.
-It is a very nice, but new technology and no-one uses it in production.
-Before the Gammapy 1.0 release we will re-evaluate the status of Numba and decide whether it's
-an optional dependency we use for speed, or whether we use the much more established Cython
-(Scipy, scikit-image, Astropy, ... all use Cython).
-
-At the time of writing (April 2015), the TS map computation code uses Cython and multiprocessing
-and Numba is not used yet.
 
 Assert convention
 -----------------

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Functions to compute TS images."""
-import contextlib
 import functools
 import logging
-import multiprocessing
 import warnings
 import numpy as np
 import scipy.optimize
@@ -72,7 +70,6 @@ def f_cash(x, counts, background, model):
 class TSMapEstimator:
     r"""Compute TS map using different optimization methods.
 
-
     The map is computed fitting by a single parameter amplitude fit. The fit is
     simplified by finding roots of the the derivative of the fit statistics using
     various root finding algorithms. The approach is sescribed in Appendix A
@@ -100,8 +97,6 @@ class TSMapEstimator:
         Upper limit estimation method.
     ul_sigma : int (2)
         Sigma for flux upper limits.
-    n_jobs : int
-        Number of parallel jobs to use for the computation.
     threshold : float (None)
         If the TS value corresponding to the initial flux estimate is not above
         this threshold, the optimizing step is omitted to save computing time.
@@ -135,7 +130,6 @@ class TSMapEstimator:
         error_sigma=1,
         ul_method="covar",
         ul_sigma=2,
-        n_jobs=1,
         threshold=None,
         rtol=0.001,
     ):
@@ -152,7 +146,6 @@ class TSMapEstimator:
             "error_sigma": error_sigma,
             "ul_method": ul_method,
             "ul_sigma": ul_sigma,
-            "n_jobs": n_jobs,
             "threshold": threshold,
             "rtol": rtol,
         }
@@ -336,11 +329,7 @@ class TSMapEstimator:
         x, y = np.where(mask.data)
         positions = list(zip(x, y))
 
-        with contextlib.closing(multiprocessing.Pool(processes=p["n_jobs"])) as pool:
-            log.info(f"Number of jobs to compute TS map: {p['n_jobs']}")
-            results = pool.map(wrap, positions)
-
-        pool.join()
+        results = list(map(wrap, positions))
 
         # Set TS values at given positions
         j, i = zip(*positions)

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -22,7 +22,7 @@ def test_compute_ts_map(input_maps):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(5)
 
-    ts_estimator = TSMapEstimator(method="leastsq iter", n_jobs=4, threshold=1)
+    ts_estimator = TSMapEstimator(method="leastsq iter", threshold=1)
     result = ts_estimator.run(input_maps, kernel=kernel)
 
     assert "leastsq iter" in repr(ts_estimator)
@@ -39,7 +39,7 @@ def test_compute_ts_map_downsampled(input_maps):
     kernel = Gaussian2DKernel(2.5)
 
     ts_estimator = TSMapEstimator(
-        method="root brentq", n_jobs=4, error_method="conf", ul_method="conf"
+        method="root brentq", error_method="conf", ul_method="conf"
     )
     result = ts_estimator.run(input_maps, kernel=kernel, downsampling_factor=2)
 

--- a/gammapy/maps/image_utils.py
+++ b/gammapy/maps/image_utils.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Image utility functions"""
-import functools
 import logging
-import multiprocessing
 import numpy as np
 import scipy.ndimage
 import scipy.signal
@@ -24,7 +22,7 @@ def _fftconvolve_wrap(kernel, data):
         return scipy.signal.fftconvolve(data, kernel.array, mode="same")
 
 
-def scale_cube(data, kernels, parallel=True):
+def scale_cube(data, kernels):
     """
     Compute scale space cube.
 
@@ -37,21 +35,10 @@ def scale_cube(data, kernels, parallel=True):
         Input data.
     kernels: list of `~astropy.convolution.Kernel`
         List of convolution kernels.
-    parallel : bool
-        Whether to use multiprocessing.
 
     Returns
     -------
     cube : `~numpy.ndarray`
         Array of the shape (len(kernels), data.shape)
     """
-    wrap = functools.partial(_fftconvolve_wrap, data=data)
-
-    if parallel:
-        pool = multiprocessing.Pool()
-        result = pool.map(wrap, kernels)
-        pool.close()
-        pool.join()
-    else:
-        result = map(wrap, kernels)
-    return np.dstack(result)
+    return np.dstack(_fftconvolve_wrap(kernel, data) for kernel in kernels)


### PR DESCRIPTION
This PR removes the use of multiprocessing Pool in Gammapy.

The reason for this is that multiprocessing isn't reliable, and acutely we had the issue of crashes on macOS: #2453

It's not really clear if CPython or matplotlib or Apple is to blame for these crashes, but overall I think the situation can be characterised like this: multiprocessing mostly works, but sometimes doesn't on some platforms and Python and library versions, and it is tricky to make it work and get good performance consistently. That's why e.g. scikit-learn has written their on replacement, `loky` and `joblib`, because they have to not crash and deliver good performance consistently (see https://youtu.be/UVL4LFy8ch0).

@adonath and I discussed whether we should attempt to change to `loky` or something else like numba or dask or ray or cython now, but agreed to just remove `multiprocessing` for now (a few line change), and then to bring parallel processing back later, once we have benchmarks and working analyses.

Note that currently we're using multiprocessing for ring convolution and for TS map computation, where really our most CPU-intensive tasks are data reduction and modeling & fitting. When we re-introduce parallelism in Gammapy, we should introduce it for those tasks where it's most relevant first.

