### PR TITLE
Change path in datasets serialization

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -781,7 +781,7 @@ class MapDataset(Dataset):
             "likelihood": self.likelihood_type,
             "models": self.model.names,
             "background": self.background_model.name,
-            "filename": filename,
+            "filename": str(filename),
         }
 
     def to_spectrum_dataset(self, on_region, containment_correction=False):

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -187,8 +187,8 @@ class Datasets:
         datasets_dict, components_dict = datasets_to_dict(
             self.datasets, path, prefix, overwrite
         )
-        write_yaml(datasets_dict, str(path / f"{prefix}_datasets.yaml"), sort_keys=False)
-        write_yaml(components_dict, str(path / f"{prefix}_models.yaml"), sort_keys=False)
+        write_yaml(datasets_dict, path / f"{prefix}_datasets.yaml", sort_keys=False)
+        write_yaml(components_dict, path / f"{prefix}_models.yaml", sort_keys=False)
 
     def stack_reduce(self):
         """Reduce the Datasets to a unique Dataset by stacking them together.

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -170,23 +170,25 @@ class Datasets:
         datasets = dict_to_datasets(data_list, components)
         return cls(datasets)
 
-    def to_yaml(self, path, overwrite=False):
+    def to_yaml(self, path, prefix="", overwrite=False):
         """Serialize datasets to YAML and FITS files.
 
         Parameters
         ----------
-        path : str
+        path: `pathlib.Path`
             path to write files
+        prefix : str
+            common prefix of file names
         overwrite : bool
             overwrite datasets FITS files
         """
         from .serialize import datasets_to_dict
 
         datasets_dict, components_dict = datasets_to_dict(
-            self.datasets, path, overwrite
+            self.datasets, path, prefix, overwrite
         )
-        write_yaml(datasets_dict, path + "datasets.yaml", sort_keys=False)
-        write_yaml(components_dict, path + "models.yaml", sort_keys=False)
+        write_yaml(datasets_dict, str(path / f"{prefix}_datasets.yaml"), sort_keys=False)
+        write_yaml(components_dict, str(path / f"{prefix}_models.yaml"), sort_keys=False)
 
     def stack_reduce(self):
         """Reduce the Datasets to a unique Dataset by stacking them together.

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -175,7 +175,7 @@ class Datasets:
 
         Parameters
         ----------
-        path: `pathlib.Path`
+        path : `pathlib.Path`
             path to write files
         prefix : str
             common prefix of file names

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -113,14 +113,13 @@ def datasets_to_dict(datasets, path, prefix, overwrite):
     ----------
     datasets : `~gammapy.modeling.Datasets`
         Datasets
-    path: `pathlib.Path`
+    path : `pathlib.Path`
         path to write files
     prefix : str
         common prefix of file names
     overwrite : bool
         overwrite datasets FITS files
     """
-
     unique_models = []
     unique_backgrounds = []
     datasets_dictlist = []

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -106,13 +106,27 @@ def _link_shared_parameters(models):
                     shared_register[name] = param
 
 
-def datasets_to_dict(datasets, path, overwrite):
+def datasets_to_dict(datasets, path, prefix, overwrite):
+    """Convert datasets to dicts for serialization.
+
+    Parameters
+    ----------
+    datasets : `~gammapy.modeling.Datasets`
+        Datasets
+    path: `pathlib.Path`
+        path to write files
+    prefix : str
+        common prefix of file names
+    overwrite : bool
+        overwrite datasets FITS files
+    """
+
     unique_models = []
     unique_backgrounds = []
     datasets_dictlist = []
 
     for dataset in datasets:
-        filename = path + "data_" + dataset.name + ".fits"
+        filename = str(path / f"{prefix}_data_{dataset.name}.fits")
         dataset.write(filename, overwrite)
         datasets_dictlist.append(dataset.to_dict(filename=filename))
 

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -126,7 +126,7 @@ def datasets_to_dict(datasets, path, prefix, overwrite):
     datasets_dictlist = []
 
     for dataset in datasets:
-        filename = str(path / f"{prefix}_data_{dataset.name}.fits")
+        filename = path / f"{prefix}_data_{dataset.name}.fits"
         dataset.write(filename, overwrite)
         datasets_dictlist.append(dataset.to_dict(filename=filename))
 

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -138,9 +138,9 @@ def test_datasets_to_io(tmp_path):
         dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
-    datasets.to_yaml(str(tmp_path / "written_"))
+    datasets.to_yaml(tmp_path, prefix="written")
     datasets_read = Datasets.from_yaml(
-        tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
+        str(tmp_path / "written_datasets.yaml"), str(tmp_path / "written_models.yaml")
     )
     assert len(datasets_read.datasets) == 2
     dataset0 = datasets_read.datasets[0]

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -11,6 +11,7 @@ from gammapy.modeling.models import MODELS, AbsorbedSpectralModel, Absorption, S
 from gammapy.modeling.serialize import dict_to_models
 from gammapy.utils.scripts import read_yaml, write_yaml
 from gammapy.utils.testing import requires_data
+from pathlib import Path
 
 
 @requires_data()
@@ -138,9 +139,10 @@ def test_datasets_to_io(tmp_path):
         dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
-    datasets.to_yaml(tmp_path, prefix="written")
+    path = Path(tmp_path)
+    datasets.to_yaml(path, prefix="written")
     datasets_read = Datasets.from_yaml(
-        str(tmp_path / "written_datasets.yaml"), str(tmp_path / "written_models.yaml")
+        str(path / "written_datasets.yaml"), str(path / "written_models.yaml")
     )
     assert len(datasets_read.datasets) == 2
     dataset0 = datasets_read.datasets[0]

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -11,8 +11,6 @@ from gammapy.modeling.models import MODELS, AbsorbedSpectralModel, Absorption, S
 from gammapy.modeling.serialize import dict_to_models
 from gammapy.utils.scripts import read_yaml, write_yaml
 from gammapy.utils.testing import requires_data
-from pathlib import Path
-
 
 @requires_data()
 def test_dict_to_skymodels():
@@ -139,10 +137,9 @@ def test_datasets_to_io(tmp_path):
         dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
-    path = Path(tmp_path)
-    datasets.to_yaml(path, prefix="written")
+    datasets.to_yaml(tmp_path, prefix="written")
     datasets_read = Datasets.from_yaml(
-        path / "written_datasets.yaml", path / "written_models.yaml"
+        tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
     )
     assert len(datasets_read.datasets) == 2
     dataset0 = datasets_read.datasets[0]

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -142,7 +142,7 @@ def test_datasets_to_io(tmp_path):
     path = Path(tmp_path)
     datasets.to_yaml(path, prefix="written")
     datasets_read = Datasets.from_yaml(
-        str(path / "written_datasets.yaml"), str(path / "written_models.yaml")
+        path / "written_datasets.yaml", path / "written_models.yaml"
     )
     assert len(datasets_read.datasets) == 2
     dataset0 = datasets_read.datasets[0]

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1239,7 +1239,7 @@ class FluxPointsDataset(Dataset):
             "type": self.tag,
             "models": self.model.names,
             "likelihood": self.likelihood_type,
-            "filename": filename,
+            "filename": str(filename),
         }
 
     def __str__(self):

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -264,7 +264,7 @@ def test_flux_point_dataset_serialization(tmp_path):
     model = SkyModel(spatial_model, spectral_model, name="test_model")
     dataset = FluxPointsDataset(SkyModels([model]), data, name="test_dataset")
 
-    Datasets([dataset]).to_yaml(str(tmp_path / "tmp_"))
+    Datasets([dataset]).to_yaml(tmp_path, prefix="tmp")
     datasets = Datasets.from_yaml(
         tmp_path / "tmp_datasets.yaml", tmp_path / "tmp_models.yaml"
     )


### PR DESCRIPTION
- use`pathlib.Path` for path instead of str
- add a common str prefix to files names
