### PR TITLE
Change catalog source models to methods for API uniformity

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -179,12 +179,9 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject):
     def is_pointlike(self):
         return self.data["Extended_Source_Name"].strip() == ""
 
-    @property
     def sky_model(self):
-        """Source sky model (`~gammapy.modeling.models.SkyModel`)."""
-        spatial_model = self.spatial_model
-        spectral_model = self.spectral_model
-        return SkyModel(spatial_model, spectral_model, name=self.name)
+        """Sky model (`~gammapy.modeling.models.SkyModel`)."""
+        return SkyModel(self.spatial_model(), self.spectral_model(), name=self.name)
 
 
 class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
@@ -348,11 +345,8 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
 
         return ss
 
-    @property
     def spatial_model(self):
-        """
-        Source spatial model (`~gammapy.modeling.models.SpatialModel`).
-        """
+        """Spatial model (`~gammapy.modeling.models.SpatialModel`)."""
         d = self.data
 
         pars = {}
@@ -389,7 +383,6 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
             else:
                 raise ValueError(f"Invalid spatial model: {morph_type!r}")
 
-    @property
     def spectral_model(self):
         """Best fit spectral model (`~gammapy.modeling.models.SpectralModel`)."""
         spec_type = self.data["SpectrumType"].strip()
@@ -654,7 +647,6 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
 
         return ss
 
-    @property
     def spectral_model(self):
         """Best fit spectral model (`~gammapy.modeling.models.SpectralModel`)."""
         spec_type = self.data["SpectrumType"].strip()
@@ -696,11 +688,8 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
         model.parameters.set_parameter_errors(errs)
         return model
 
-    @property
     def spatial_model(self):
-        """
-        Source spatial model (`~gammapy.modeling.models.SpatialModel`).
-        """
+        """Spatial model (`~gammapy.modeling.models.SpatialModel`)."""
         d = self.data
 
         pars = {}
@@ -867,7 +856,6 @@ class SourceCatalogObject1FHL(SourceCatalogObject):
         table["flux_ul"][is_ul] = flux_ul[is_ul]
         return FluxPoints(table)
 
-    @property
     def spectral_model(self):
         """Best fit spectral model `~gammapy.modeling.models.SpectralModel`."""
         pars, errs = {}, {}
@@ -939,7 +927,6 @@ class SourceCatalogObject2FHL(SourceCatalogObject):
         table["flux_ul"][is_ul] = flux_ul[is_ul]
         return FluxPoints(table)
 
-    @property
     def spectral_model(self):
         """Best fit spectral model (`~gammapy.modeling.models.SpectralModel`)."""
         pars, errs = {}, {}
@@ -1074,7 +1061,6 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
 
         return ss
 
-    @property
     def spectral_model(self):
         """Best fit spectral model (`~gammapy.modeling.models.SpectralModel`)."""
         d = self.data
@@ -1137,7 +1123,6 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
         table["sqrt_ts"] = self.data["Sqrt_TS_Band"]
         return FluxPoints(table)
 
-    @property
     def spatial_model(self):
         """Source spatial model (`~gammapy.modeling.models.SpatialModel`)."""
         d = self.data

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -274,7 +274,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
         return ss + "\n"
 
-    @property
     def spectral_model(self):
         """Source spectral model (`~gammapy.modeling.models.SpectralModel`).
 
@@ -320,7 +319,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
         return model
 
-    @property
     def spatial_model(self):
         """Source spatial model (`~gammapy.modeling.models.SpatialModel`).
 
@@ -360,12 +358,9 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         else:
             raise NotImplementedError(f"Unknown spatial model: {morph_type!r}")
 
-    @property
     def sky_model(self):
         """Source sky model (`~gammapy.modeling.models.SkyModel`)."""
-        spatial_model = self.spatial_model
-        spectral_model = self.spectral_model
-        return SkyModel(spatial_model, spectral_model, name=self.name)
+        return SkyModel(self.spatial_model(), self.spectral_model(), name=self.name)
 
     def _add_source_meta(self, table):
         """Copy over some info to table.meta"""
@@ -476,7 +471,7 @@ class SourceCatalogGammaCat(SourceCatalog):
         for source_idx in range(len(self.table)):
             source = self[source_idx]
             try:
-                source_list.append(source.sky_model)
+                source_list.append(source.sky_model())
             except NoDataAvailableError:
                 log.warning(
                     f"Skipping source {source.name} (missing data in gamma-cat)"

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -165,11 +165,9 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
         According to the paper, the radius of the extended source model is only a rough estimate
         of the source size, based on the residual excess..
         """
-        model = SkyModel(
+        return SkyModel(
             self.spatial_model(which), self.spectral_model(which), name=self.name
         )
-        # TODO: set model covariance matrix from sub covariance infos
-        return model
 
 
 class SourceCatalog2HWC(SourceCatalog):

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -81,7 +81,6 @@ class SourceCatalogObjectHGPSComponent:
         """Row index of source in table (int)"""
         return self.data[self._source_index_key]
 
-    @property
     def spatial_model(self):
         """Component spatial model (`~gammapy.modeling.models.GaussianSpatialModel`)."""
         d = self.data
@@ -495,7 +494,6 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         pointlike = d["Spatial_Model"] == "Point-Like"
         return pointlike or has_size_ul
 
-    @property
     def spatial_model(self):
         """Spatial model (`~gammapy.modeling.models.SpatialModel`).
 
@@ -558,7 +556,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
                 spectral_model_comp.parameters["amplitude"].value *= weight
                 models.append(
                     SkyModel(
-                        component.spatial_model,
+                        component.spatial_model(),
                         spectral_model_comp,
                         name=component.name,
                     )
@@ -566,9 +564,9 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
 
             return SkyModels(models)
         else:
-            spatial_model = self.spatial_model
-            spectral_model = self.spectral_model(which=which)
-            return SkyModel(spatial_model, spectral_model, name=self.name)
+            return SkyModel(
+                self.spatial_model(), self.spectral_model(which=which), name=self.name
+            )
 
     @property
     def flux_points(self):

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -137,7 +137,7 @@ class TestFermi4FGLObject:
     @requires_dependency("uncertainties")
     @pytest.mark.parametrize("ref", SOURCES_4FGL, ids=lambda _: _["name"])
     def test_spectral_model(self, ref):
-        model = self.cat[ref["idx"]].spectral_model
+        model = self.cat[ref["idx"]].spectral_model()
 
         e_ref = model.reference.quantity
         dnde, dnde_err = model.evaluate_error(e_ref)
@@ -147,14 +147,14 @@ class TestFermi4FGLObject:
 
     def test_spatial_model(self):
         # TODO: check spatial parameter errors as soon as they are filled
-        model = self.cat["4FGL J0000.3-7355"].spatial_model
+        model = self.cat["4FGL J0000.3-7355"].spatial_model()
         assert model.tag == "PointSpatialModel"
         assert model.frame == "galactic"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 307.709)
         assert_allclose(p["lat_0"].value, -42.729538)
 
-        model = self.cat["4FGL J1409.1-6121e"].spatial_model
+        model = self.cat["4FGL J1409.1-6121e"].spatial_model()
         assert model.tag == "DiskSpatialModel"
         assert model.frame == "galactic"
         p = model.parameters
@@ -162,7 +162,7 @@ class TestFermi4FGLObject:
         assert_allclose(p["lat_0"].value, 0.12567082047462463)
         assert_allclose(p["r_0"].value, 0.7331369519233704)
 
-        model = self.cat["4FGL J0617.2+2234e"].spatial_model
+        model = self.cat["4FGL J0617.2+2234e"].spatial_model()
         assert model.tag == "GaussianSpatialModel"
         assert model.frame == "galactic"
         p = model.parameters
@@ -170,7 +170,7 @@ class TestFermi4FGLObject:
         assert_allclose(p["lat_0"].value, 3.033451)
         assert_allclose(p["sigma"].value, 0.27)
 
-        model = self.cat["4FGL J1443.0-6227e"].spatial_model
+        model = self.cat["4FGL J1443.0-6227e"].spatial_model()
         assert model.tag == "TemplateSpatialModel"
         assert model.frame == "fk5"
         assert model.normalize is True
@@ -281,7 +281,7 @@ class TestFermi3FGLObject:
     @requires_dependency("uncertainties")
     @pytest.mark.parametrize("ref", SOURCES_3FGL, ids=lambda _: _["name"])
     def test_spectral_model(self, ref):
-        model = self.cat[ref["idx"]].spectral_model
+        model = self.cat[ref["idx"]].spectral_model()
 
         dnde, dnde_err = model.evaluate_error(1 * u.GeV)
 
@@ -291,14 +291,14 @@ class TestFermi3FGLObject:
 
     def test_spatial_model(self):
         # TODO: check spatial parameter errors as soon as they are filled
-        model = self.cat[0].spatial_model
+        model = self.cat[0].spatial_model()
         assert model.tag == "PointSpatialModel"
         assert model.frame == "galactic"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 117.693878)
         assert_allclose(p["lat_0"].value, 3.402958)
 
-        model = self.cat[122].spatial_model
+        model = self.cat[122].spatial_model()
         assert model.tag == "GaussianSpatialModel"
         assert model.frame == "galactic"
         p = model.parameters
@@ -306,7 +306,7 @@ class TestFermi3FGLObject:
         assert_allclose(p["lat_0"].value, -44.41674)
         assert_allclose(p["sigma"].value, 1.35)
 
-        model = self.cat[955].spatial_model
+        model = self.cat[955].spatial_model()
         assert model.tag == "DiskSpatialModel"
         assert model.frame == "galactic"
         p = model.parameters
@@ -314,14 +314,14 @@ class TestFermi3FGLObject:
         assert_allclose(p["lat_0"].value, -3.105928)
         assert_allclose(p["r_0"].value, 0.91)
 
-        model = self.cat[602].spatial_model
+        model = self.cat[602].spatial_model()
         assert model.tag == "TemplateSpatialModel"
         assert model.frame == "fk5"
         assert model.normalize is True
 
     @pytest.mark.parametrize("ref", SOURCES_3FGL, ids=lambda _: _["name"])
     def test_sky_model(self, ref):
-        self.cat[ref["idx"]].sky_model
+        self.cat[ref["idx"]].sky_model()
 
     def test_flux_points(self):
         flux_points = self.source.flux_points
@@ -396,7 +396,7 @@ class TestFermi1FHLObject:
         assert_allclose(position.dec.deg, 22.0191, atol=1e-3)
 
     def test_spectral_model(self):
-        model = self.source.spectral_model
+        model = self.source.spectral_model()
         energy = u.Quantity(100, "GeV")
         desired = u.Quantity(4.7717464131e-12, "cm-2 GeV-1 s-1")
         assert_quantity_allclose(model(energy), desired)
@@ -432,7 +432,7 @@ class TestFermi2FHLObject:
         assert_allclose(position.dec.deg, 22.0215, atol=1e-3)
 
     def test_spectral_model(self):
-        model = self.source.spectral_model
+        model = self.source.spectral_model()
         energy = u.Quantity(100, "GeV")
         desired = u.Quantity(6.8700477298e-12, "cm-2 GeV-1 s-1")
         assert_quantity_allclose(model(energy), desired)
@@ -489,7 +489,7 @@ class TestFermi3FHLObject:
     @requires_dependency("uncertainties")
     @pytest.mark.parametrize("ref", SOURCES_3FHL, ids=lambda _: _["name"])
     def test_spectral_model(self, ref):
-        model = self.cat[ref["idx"]].spectral_model
+        model = self.cat[ref["idx"]].spectral_model()
 
         dnde, dnde_err = model.evaluate_error(100 * u.GeV)
 
@@ -499,12 +499,12 @@ class TestFermi3FHLObject:
 
     @pytest.mark.parametrize("ref", SOURCES_3FHL, ids=lambda _: _["name"])
     def test_spatial_model(self, ref):
-        model = self.cat[ref["idx"]].spatial_model
+        model = self.cat[ref["idx"]].spatial_model()
         assert model.frame == "galactic"
 
     @pytest.mark.parametrize("ref", SOURCES_3FHL, ids=lambda _: _["name"])
     def test_sky_model(self, ref):
-        self.cat[ref["idx"]].sky_model
+        self.cat[ref["idx"]].sky_model()
 
     def test_flux_points(self):
         flux_points = self.source.flux_points

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -137,7 +137,7 @@ class TestSourceCatalogObjectGammaCat:
     @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
     def test_spectral_model(self, gammacat, ref):
         source = gammacat[ref["name"]]
-        spectral_model = source.spectral_model
+        spectral_model = source.spectral_model()
 
         assert source.data["spec_type"] == ref["spec_type"]
 
@@ -155,7 +155,7 @@ class TestSourceCatalogObjectGammaCat:
     @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
     def test_spectral_model_err(self, gammacat, ref):
         source = gammacat[ref["name"]]
-        spectral_model = source.spectral_model
+        spectral_model = source.spectral_model()
 
         e_min, e_max, e_inf = [1, 10, 1e10] * u.TeV
 
@@ -194,7 +194,7 @@ class TestSourceCatalogObjectGammaCat:
     def test_spatial_model(self, gammacat, ref):
         source = gammacat[ref["name"]]
 
-        spatial_model = source.spatial_model
+        spatial_model = source.spatial_model()
         assert spatial_model.frame == "galactic"
 
         # TODO: put better asserts on model properties
@@ -205,7 +205,7 @@ class TestSourceCatalogObjectGammaCat:
 
     @pytest.mark.parametrize("ref", SOURCES, ids=lambda _: _["name"])
     def test_sky_model(self, gammacat, ref):
-        gammacat[ref["name"]].sky_model
+        gammacat[ref["name"]].sky_model()
 
 
 class TestGammaCatResource:

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -291,7 +291,7 @@ class TestSourceCatalogObjectHGPSComponent:
 
     @staticmethod
     def test_spatial_model(component):
-        model = component.spatial_model
+        model = component.spatial_model()
         assert model.frame == "galactic"
         p = model.parameters
         assert_allclose(p["lon_0"].value, 28.77037811279297)

--- a/gammapy/scripts/jupyter.py
+++ b/gammapy/scripts/jupyter.py
@@ -70,6 +70,7 @@ def cli_jupyter_strip(ctx):
 
         for cell in rawnb.cells:
             if cell["cell_type"] == "code":
+                cell["metadata"].pop("pycharm", None)
                 cell["execution_count"] = None
                 cell["outputs"] = []
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -226,7 +226,7 @@ def test_compute_flux_points_dnde_fermi():
     fermi_3fgl = SourceCatalog3FGL()
     source = fermi_3fgl["3FGL J0835.3-4510"]
     flux_points = source.flux_points.to_sed_type(
-        "dnde", model=source.spectral_model, method="log_center", pwl_approx=True
+        "dnde", model=source.spectral_model(), method="log_center", pwl_approx=True
     )
     for column in ["dnde", "dnde_errn", "dnde_errp", "dnde_ul"]:
         actual = flux_points.table["e2" + column].quantity

--- a/tutorials/first_steps.ipynb
+++ b/tutorials/first_steps.ipynb
@@ -576,14 +576,15 @@
    "outputs": [],
    "source": [
     "crab_3fhl = fermi_3fhl[\"Crab Nebula\"]\n",
-    "print(crab_3fhl.spectral_model)"
+    "crab_3fhl_spec = crab_3fhl.spectral_model()\n",
+    "print(crab_3fhl_spec)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `crab_3fhl.spectral_model` is an instance of the [gammapy.modeling.models.PowerLaw2SpectralModel](https://docs.gammapy.org/dev/api/gammapy.modeling.models.PowerLaw2SpectralModel.html#gammapy.modeling.models.PowerLaw2SpectralModel) model, with the parameter values and errors taken from the 3FHL catalog. \n",
+    "The `crab_3fhl_spec` is an instance of the [gammapy.modeling.models.PowerLaw2SpectralModel](https://docs.gammapy.org/dev/api/gammapy.modeling.models.PowerLaw2SpectralModel.html#gammapy.modeling.models.PowerLaw2SpectralModel) model, with the parameter values and errors taken from the 3FHL catalog. \n",
     "\n",
     "Let's plot the spectral model in the energy range between 10 GeV and 2000 GeV:"
    ]
@@ -594,7 +595,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax_crab_3fhl = crab_3fhl.spectral_model.plot(\n",
+    "ax_crab_3fhl = crab_3fhl_spec.plot(\n",
     "    energy_range=[10, 2000] * u.GeV, energy_power=0\n",
     ")"
    ]
@@ -614,7 +615,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_3fhl.spectral_model(100 * u.GeV).to(\"cm-2 s-1 GeV-1\")"
+    "crab_3fhl_spec(100 * u.GeV).to(\"cm-2 s-1 GeV-1\")"
    ]
   },
   {
@@ -630,9 +631,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_3fhl.spectral_model.integral(emin=10 * u.GeV, emax=2000 * u.GeV).to(\n",
-    "    \"cm-2 s-1\"\n",
-    ")"
+    "crab_3fhl_spec.integral(emin=10 * u.GeV, emax=2000 * u.GeV).to(\"cm-2 s-1\")"
    ]
   },
   {
@@ -664,7 +663,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_3fhl.spectral_model.energy_flux(emin=10 * u.GeV, emax=2000 * u.GeV).to(\n",
+    "crab_3fhl_spec.energy_flux(emin=10 * u.GeV, emax=2000 * u.GeV).to(\n",
     "    \"erg cm-2 s-1\"\n",
     ")"
    ]
@@ -716,9 +715,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ax = crab_3fhl.spectral_model.plot(\n",
-    "    energy_range=[10, 2000] * u.GeV, energy_power=2\n",
-    ")\n",
+    "ax = crab_3fhl_spec.plot(energy_range=[10, 2000] * u.GeV, energy_power=2)\n",
     "crab_3fhl.flux_points.to_sed_type(\"dnde\").plot(ax=ax, energy_power=2);"
    ]
   },

--- a/tutorials/models.ipynb
+++ b/tutorials/models.ipynb
@@ -28,12 +28,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -62,10 +57,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -102,10 +93,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -150,10 +137,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -191,10 +174,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -228,10 +207,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -278,10 +253,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
     }
    },
    "outputs": [],
@@ -300,9 +271,6 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    },
-    "pycharm": {
-     "name": "#%%\n"
     }
    },
    "outputs": [],

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -132,10 +132,10 @@
    "outputs": [],
    "source": [
     "flux_points_3fgl = source_fermi_3fgl.flux_points.to_sed_type(\n",
-    "    sed_type=\"dnde\", model=source_fermi_3fgl.spectral_model\n",
+    "    sed_type=\"dnde\", model=source_fermi_3fgl.spectral_model()\n",
     ")\n",
     "flux_points_3fhl = source_fermi_3fhl.flux_points.to_sed_type(\n",
-    "    sed_type=\"dnde\", model=source_fermi_3fhl.spectral_model\n",
+    "    sed_type=\"dnde\", model=source_fermi_3fhl.spectral_model()\n",
     ")"
    ]
   },


### PR DESCRIPTION
So far we had a mix of properties and methods for `catalog.source` models (spatial, spectral, sky).
This PR changes to methods everywhere, for better API uniformity.
