### PR TITLE
Add SafeMaskMaker

### DIFF
--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -217,9 +217,9 @@ class SafeMaskMaker:
     """
 
     def __init__(
-        self, methods=("aeff-default",), aeff_percent=10, bias_percent=10
+        self, methods="aeff-default", aeff_percent=10, bias_percent=10
     ):
-        self.methods = methods
+        self.methods = list(methods)
         self.aeff_percent = aeff_percent
         self.bias_percent = bias_percent
 

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -217,7 +217,7 @@ class SafeMaskMaker:
     """
 
     def __init__(
-        self, methods=["aeff-default"], aeff_percent=10, bias_percent=10
+        self, methods=("aeff-default",), aeff_percent=10, bias_percent=10
     ):
         self.methods = methods
         self.aeff_percent = aeff_percent
@@ -246,8 +246,7 @@ class SafeMaskMaker:
             log.warning(f"No thresholds defined for obs {observation}")
             e_min, e_max = None, None
 
-        mask_safe = dataset.counts.energy_mask(emin=e_min, emax=e_max)
-        return mask_safe
+        return dataset.counts.energy_mask(emin=e_min, emax=e_max)
 
     def make_mask_energy_aeff_max(self, dataset):
         """Make safe energy mask from aeff max.
@@ -264,8 +263,7 @@ class SafeMaskMaker:
         """
         aeff_thres = self.aeff_percent / 100 * dataset.aeff.max_area
         e_min = dataset.aeff.find_energy(aeff_thres)
-        mask_safe = dataset.counts.energy_mask(emin=e_min)
-        return mask_safe
+        return dataset.counts.energy_mask(emin=e_min)
 
     def make_mask_energy_edisp_bias(self, dataset):
         """Make safe energy mask from aeff max.
@@ -281,8 +279,7 @@ class SafeMaskMaker:
             Safe data range mask.
         """
         e_min = dataset.edisp.get_bias_energy(self.bias_percent / 100)
-        mask_safe = dataset.counts.energy_mask(emin=e_min)
-        return mask_safe
+        return dataset.counts.energy_mask(emin=e_min)
 
     def run(self, dataset, observation):
         """Make safe data range mask.

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -195,3 +195,120 @@ class SpectrumDatasetMaker:
             kwargs["edisp"] = self.make_edisp(observation)
 
         return SpectrumDataset(**kwargs)
+
+
+class SafeMaskMaker:
+    """Make safe data range mask for a given observation.
+
+    Parameters
+    ----------
+    methods : {"aeff-default", "aeff-max", "edisp-bias"}
+        Method to use for the safe energy range. Can be a
+        list with a combination of those. Resulting masks
+        are combined with logical `and`. "aeff-default"
+        uses the energy ranged specified in the DL3 data
+        files, if available.
+    aeff_percent : float
+        Percentage of the maximal effective area to be used
+        as lower energy threshold for method "aeff-max".
+    bias_percent : float
+        Percentage of the energy bias to be used as lower
+        energy threshold for method "edisp-bias"
+    """
+
+    def __init__(
+        self, methods=["aeff-default"], aeff_percent=10, bias_percent=10
+    ):
+        self.methods = methods
+        self.aeff_percent = aeff_percent
+        self.bias_percent = bias_percent
+
+    @staticmethod
+    def make_mask_energy_aeff_default(dataset, observation):
+        """Make safe energy mask from aeff default.
+
+        Parameters
+        ----------
+        dataset : `Dataset`
+            Dataset to compute mask for.
+        observation: `DataStoreObservation`
+            Observation to compute mask for.
+
+        Returns
+        -------
+        mask_safe : `~numpy.ndarray`
+            Safe data range mask.
+        """
+        try:
+            e_max = observation.aeff.high_threshold
+            e_min = observation.aeff.low_threshold
+        except KeyError:
+            log.warning(f"No thresholds defined for obs {observation}")
+            e_min, e_max = None, None
+
+        mask_safe = dataset.counts.energy_mask(emin=e_min, emax=e_max)
+        return mask_safe
+
+    def make_mask_energy_aeff_max(self, dataset):
+        """Make safe energy mask from aeff max.
+
+        Parameters
+        ----------
+        dataset : `SpectrumDataset` or `SpectrumDatasetOnOff`
+            Dataset to compute mask for.
+
+        Returns
+        -------
+        mask_safe : `~numpy.ndarray`
+            Safe data range mask.
+        """
+        aeff_thres = self.aeff_percent / 100 * dataset.aeff.max_area
+        e_min = dataset.aeff.find_energy(aeff_thres)
+        mask_safe = dataset.counts.energy_mask(emin=e_min)
+        return mask_safe
+
+    def make_mask_energy_edisp_bias(self, dataset):
+        """Make safe energy mask from aeff max.
+
+        Parameters
+        ----------
+        dataset : `SpectrumDataset` or `SpectrumDatasetOnOff`
+            Dataset to compute mask for.
+
+        Returns
+        -------
+        mask_safe : `~numpy.ndarray`
+            Safe data range mask.
+        """
+        e_min = dataset.edisp.get_bias_energy(self.bias_percent / 100)
+        mask_safe = dataset.counts.energy_mask(emin=e_min)
+        return mask_safe
+
+    def run(self, dataset, observation):
+        """Make safe data range mask.
+
+        Parameters
+        ----------
+        dataset : `Dataset`
+            Dataset to compute mask for.
+        observation: `DataStoreObservation`
+            Observation to compute mask for.
+
+        Returns
+        -------
+        dataset : `Dataset`
+            Dataset with defined safe range mask.
+        """
+        mask_safe = np.ones(dataset.data_shape, dtype=bool)
+
+        if "aeff-default" in self.methods:
+            mask_safe &= self.make_mask_energy_aeff_default(dataset, observation)
+
+        if "aeff-max" in self.methods:
+            mask_safe &= self.make_mask_energy_aeff_max(dataset)
+
+        if "edisp-bias" in self.methods:
+            mask_safe &= self.make_mask_energy_edisp_bias(dataset)
+
+        dataset.mask_safe = mask_safe
+        return dataset

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -12,6 +12,8 @@ from .dataset import SpectrumDataset
 
 log = logging.getLogger(__name__)
 
+__all__ = ["SpectrumDatasetMaker", "SafeMaskMaker"]
+
 
 class SpectrumDatasetMaker:
     """Make spectrum for a single IACT observation.

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -90,7 +90,7 @@ def test_spectrum_dataset_maker_hess_cta(
 
 
 @requires_data()
-def test_safe_mask_maker(spectrum_dataset_maker_crab, observations_hess_dl3):
+def test_safe_mask_maker_dl3(spectrum_dataset_maker_crab, observations_hess_dl3):
     safe_mask_maker = SafeMaskMaker()
 
     obs = observations_hess_dl3[0]
@@ -106,3 +106,12 @@ def test_safe_mask_maker(spectrum_dataset_maker_crab, observations_hess_dl3):
     assert mask_safe.sum() == 3
 
 
+@requires_data()
+def test_safe_mask_maker_dc1(spectrum_dataset_maker_gc, observations_cta_dc1):
+    safe_mask_maker = SafeMaskMaker(methods=["edisp-bias", "aeff-max"])
+
+    obs = observations_cta_dc1[0]
+    dataset = spectrum_dataset_maker_gc.run(obs)
+    dataset = safe_mask_maker.run(dataset, obs)
+    assert_allclose(dataset.energy_range[0].value, 3.162278, rtol=1e-3)
+    assert dataset.energy_range[0].unit == "TeV"

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -49,11 +49,6 @@ def spectrum_dataset_maker_crab():
     return SpectrumDatasetMaker(region=region, e_reco=e_reco, e_true=e_true)
 
 
-@pytest.fixture()
-def safe_mask_maker():
-    return SafeMaskMaker()
-
-
 @requires_data()
 def test_spectrum_dataset_maker_hess_dl3(
     spectrum_dataset_maker_crab, observations_hess_dl3
@@ -94,7 +89,9 @@ def test_spectrum_dataset_maker_hess_cta(
     assert_allclose(datasets[1].background.data.sum(), 2.164593, rtol=1e-5)
 
 
-def test_safe_mask_maker(spectrum_dataset_maker_crab, safe_mask_maker, observations_hess_dl3):
+@requires_data()
+def test_safe_mask_maker(spectrum_dataset_maker_crab, observations_hess_dl3):
+    safe_mask_maker = SafeMaskMaker()
 
     obs = observations_hess_dl3[0]
     dataset = spectrum_dataset_maker_crab.run(obs)


### PR DESCRIPTION
This PR implements a `SafeMaskMaker`. Currently it only support spectral datasets, it can be later adapted / extended to support `MapDataset` as well. This PR also adds a simple test. Again existing tests will be moved in subsequent PRs.