### PR TITLE
Fix incorrect energy unit in WcsNDMap.sample_coord()

### DIFF
--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -652,3 +652,7 @@ def test_map_sampling():
     assert_allclose(events["RA_TRUE"].data, [266.307081, 266.442255], rtol=1e-5)
     assert_allclose(events["DEC_TRUE"].data, [-28.753408, -28.742696], rtol=1e-5)
     assert_allclose(events["ENERGY_TRUE"].data, [2.755397, 1.72316], rtol=1e-5)
+
+    assert coords["lon"].unit == "deg"
+    assert coords["lat"].unit == "deg"
+    assert coords["energy"].unit == "TeV"

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -735,6 +735,5 @@ class WcsNDMap(WcsMap):
         # TODO: pix_to_coord should return a MapCoord object
         axes_names = ["lon", "lat"] + [ax.name for ax in self.geom.axes]
         cdict = OrderedDict(zip(axes_names, coords))
-        cdict["energy"] *= self.geom.get_axis_by_name("energy").unit
 
         return MapCoord.create(cdict, coordsys=self.geom.coordsys)


### PR DESCRIPTION
There was a bug related to the units of the output of `sample_coord` in `~gammapy.maps.wcsnd`. The energies of the sampled events were uncorrectly defined as `TeV2` instead of only `TeV`. This pull request fixes the reported issue.