### PR TITLE
Add EdispMap.sample_coord method

### DIFF
--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -342,10 +342,9 @@ class EDispMap:
 
         Returns
         -------
-        `~gammapy.maps.MapCoord` object.
+        `~gammapy.maps.MapCoord`.
             Sequence of Edisp-corrected coordinates of the input map_coord map.
         """
-
         random_state = get_random_state(random_state)
         migra_axis = self.edisp_map.geom.get_axis_by_name("migra")
 
@@ -359,10 +358,6 @@ class EDispMap:
 
         sample_edisp = InverseCDFSampler(pdf_edisp, axis=1, random_state=random_state)
         pix_edisp = sample_edisp.sample_axis()
-        e_corr = migra_axis.pix_to_coord(pix_edisp)
+        energy_reco = migra_axis.pix_to_coord(pix_edisp)
 
-        corr_energies = MapCoord(
-            {"lon": map_coord.lon, "lat": map_coord.lat, "energy": e_corr}
-        )
-
-        return corr_energies
+        return MapCoord.create({"skycoord": map_coord.skycoord, "energy": energy_reco})

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.table import Table
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
@@ -126,14 +125,13 @@ def test_edisp_map_stacking():
 
 def test_sample_coord():
     edisp_map = make_edisp_map_test()
+
     coords = MapCoord(
-        {"lon": [0, 0] * u.deg, "lat": [0, 0.5] * u.deg, "energy": [1, 3] * u.TeV}
+        {"lon": [0, 0] * u.deg, "lat": [0, 0.5] * u.deg, "energy": [1, 3] * u.TeV},
+        coordsys="CEL",
     )
 
     coords_corrected = edisp_map.sample_coord(map_coord=coords)
 
-    events = Table()
-    events["ENERGY_CORR"] = coords_corrected["energy"]
-
-    assert len(events) == 2
-    assert_allclose(events["ENERGY_CORR"].data, [0.9961658, 1.11269299], rtol=1e-5)
+    assert len(coords_corrected["energy"]) == 2
+    assert_allclose(coords_corrected["energy"], [0.9961658, 1.11269299], rtol=1e-5)


### PR DESCRIPTION
This PR aims at adding the method sample_coord into ~gammapy.cube.edisp_map. The method is developed to take as input an Edisp map and a ~gammapy.maps.MapCoord objects, where the latter represents the map of a set of simulated events (with lon, lat and energies). The method gives as output a ~gammapy.maps.MapCoord object where the new energies of the events have been corrected for the given Edisp.
