### PR TITLE
Improve Parameters class

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -244,7 +244,7 @@ class MapDataset(Dataset):
         if self.background_model:
             parameters_list.append(self.background_model.parameters)
 
-        return Parameters.stack(parameters_list)
+        return Parameters.from_stack(parameters_list)
 
     @property
     def _geom(self):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -173,9 +173,7 @@ class MapDataset(Dataset):
             n_models = len(self.model.skymodels)
         str_ += "\t{:32}: {} \n".format("Number of models", n_models)
 
-        str_ += "\t{:32}: {}\n".format(
-            "Number of parameters", len(self.parameters)
-        )
+        str_ += "\t{:32}: {}\n".format("Number of parameters", len(self.parameters))
         str_ += "\t{:32}: {}\n\n".format(
             "Number of free parameters", len(self.parameters.free_parameters)
         )

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -174,7 +174,7 @@ class MapDataset(Dataset):
         str_ += "\t{:32}: {} \n".format("Number of models", n_models)
 
         str_ += "\t{:32}: {}\n".format(
-            "Number of parameters", len(self.parameters.parameters)
+            "Number of parameters", len(self.parameters)
         )
         str_ += "\t{:32}: {}\n\n".format(
             "Number of free parameters", len(self.parameters.free_parameters)
@@ -238,15 +238,15 @@ class MapDataset(Dataset):
     @property
     def parameters(self):
         """List of parameters (`~gammapy.modeling.Parameters`)"""
-        parameters = []
+        parameters_list = []
 
         if self.model:
-            parameters += self.model.parameters.parameters
+            parameters_list.append(self.model.parameters)
 
         if self.background_model:
-            parameters += self.background_model.parameters.parameters
+            parameters_list.append(self.background_model.parameters)
 
-        return Parameters(parameters)
+        return Parameters.stack(parameters_list)
 
     @property
     def _geom(self):

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -91,11 +91,7 @@ class Datasets:
 
     @property
     def parameters(self):
-        # join parameter lists
-        parameters = []
-        for dataset in self.datasets:
-            parameters += dataset.parameters.parameters
-        return Parameters(parameters)
+        return Parameters.stack(_.parameters for _ in self.datasets)
 
     @property
     def names(self):

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -3,7 +3,7 @@ import abc
 import copy
 from collections import Counter
 import numpy as np
-from gammapy.utils.scripts import read_yaml, write_yaml, make_path
+from gammapy.utils.scripts import make_path, read_yaml, write_yaml
 from .parameter import Parameters
 
 __all__ = ["Dataset", "Datasets"]

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -91,7 +91,7 @@ class Datasets:
 
     @property
     def parameters(self):
-        return Parameters.stack(_.parameters for _ in self.datasets)
+        return Parameters.from_stack(_.parameters for _ in self.datasets)
 
     @property
     def names(self):

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -3,7 +3,7 @@ import abc
 import copy
 from collections import Counter
 import numpy as np
-from gammapy.utils.scripts import read_yaml, write_yaml
+from gammapy.utils.scripts import read_yaml, write_yaml, make_path
 from .parameter import Parameters
 
 __all__ = ["Dataset", "Datasets"]
@@ -179,6 +179,8 @@ class Datasets:
             overwrite datasets FITS files
         """
         from .serialize import datasets_to_dict
+
+        path = make_path(path)
 
         datasets_dict, components_dict = datasets_to_dict(
             self.datasets, path, prefix, overwrite

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -149,7 +149,8 @@ class Fit:
         """
         parameters = self._parameters
 
-        if parameters.apply_autoscale:
+        # TODO: expose options if / when to scale? On the Fit class?
+        if parameters.covariance is None:
             parameters.autoscale()
 
         compute = registry.get("optimize", backend)

--- a/gammapy/modeling/iminuit.py
+++ b/gammapy/modeling/iminuit.py
@@ -158,17 +158,10 @@ def make_minuit_par_kwargs(parameters):
         max_ = None if np.isnan(par.factor_max) else par.factor_max
         kwargs[f"limit_{name}"] = (min_, max_)
 
-        if parameters.covariance is not None:
-            error = parameters.error(par) / par.scale
-        elif parameters.apply_autoscale:
+        if parameters.covariance is None:
             error = 1
         else:
-            error = 1
-            log.warning(
-                "Neither covariance matrix set nor auto-scaling of parameters activated."
-                "Assuming stepsize of 1, which could lead to convergence problems of the "
-                "Minuit optimizer."
-            )
+            error = parameters.error(par) / par.scale
 
         kwargs[f"error_{name}"] = error
 

--- a/gammapy/modeling/model.py
+++ b/gammapy/modeling/model.py
@@ -55,11 +55,14 @@ class Model:
         if "frame" in data:
             params["frame"] = data["frame"]
 
-        init = cls(**params)
-        init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters.parameters:
-            setattr(init, parameter.name, parameter)
-        return init
+        model = cls(**params)
+        model._update_from_dict(data)
+        return model
+
+    def _update_from_dict(self, data):
+        self.parameters = Parameters.from_dict(data)
+        for parameter in self.parameters.parameters:
+            setattr(self, parameter.name, parameter)
 
     @staticmethod
     def create(tag, *args, **kwargs):

--- a/gammapy/modeling/model.py
+++ b/gammapy/modeling/model.py
@@ -61,7 +61,7 @@ class Model:
 
     def _update_from_dict(self, data):
         self.parameters = Parameters.from_dict(data)
-        for parameter in self.parameters.parameters:
+        for parameter in self.parameters:
             setattr(self, parameter.name, parameter)
 
     @staticmethod

--- a/gammapy/modeling/model.py
+++ b/gammapy/modeling/model.py
@@ -28,17 +28,7 @@ class Model:
         return copy.deepcopy(self)
 
     def __str__(self):
-        ss = self.__class__.__name__
-        ss += "\n\nParameters: \n\n\t"
-
-        table = self.parameters.to_table()
-        ss += "\n\t".join(table.pformat())
-
-        if self.parameters.covariance is not None:
-            ss += "\n\nCovariance: \n\n\t"
-            covariance = self.parameters.covariance_to_table()
-            ss += "\n\t".join(covariance.pformat())
-        return ss
+        return f"{self.__class__.__name__}\n\n" f"{self.parameters.to_table()}"
 
     def to_dict(self):
         """Create dict for YAML serilisation"""

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -172,10 +172,9 @@ class SkyModel(SkyModelBase):
 
         self._spectral_model = spectral_model
 
-        parameters = (
-            spatial_model.parameters.parameters + spectral_model.parameters.parameters
+        super().__init__(
+            Parameters.stack([spatial_model.parameters, spectral_model.parameters])
         )
-        super().__init__(parameters)
 
     @property
     def spatial_model(self):
@@ -191,10 +190,7 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         """`~gammapy.modeling.models.SpectralModel`"""
         self._spectral_model = model
-        self._parameters = Parameters(
-            self.spatial_model.parameters.parameters
-            + self.spectral_model.parameters.parameters
-        )
+        self._parameters = Parameters.stack([self.spatial_model.parameters, self.spectral_model.parameters])
 
     @property
     def position(self):
@@ -417,7 +413,7 @@ class SkyDiffuseCube(SkyModelBase):
     def from_dict(cls, data):
         init = cls.read(data["filename"])
         init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters.parameters:
+        for parameter in init.parameters:
             setattr(init, parameter.name, parameter)
         return init
 
@@ -509,6 +505,6 @@ class BackgroundModel(Model):
 
         init = cls(map=map, name=data["name"])
         init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters.parameters:
+        for parameter in init.parameters:
             setattr(init, parameter.name, parameter)
         return init

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -172,9 +172,7 @@ class SkyModel(SkyModelBase):
 
         self._spectral_model = spectral_model
 
-        super().__init__(
-            Parameters.stack([spatial_model.parameters, spectral_model.parameters])
-        )
+        super().__init__(spatial_model.parameters + spectral_model.parameters)
 
     @property
     def spatial_model(self):
@@ -190,9 +188,7 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         """`~gammapy.modeling.models.SpectralModel`"""
         self._spectral_model = model
-        self._parameters = Parameters.stack(
-            [self.spatial_model.parameters, self.spectral_model.parameters]
-        )
+        self._parameters = self.spatial_model.parameters + self.spectral_model.parameters
 
     @property
     def position(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -94,15 +94,11 @@ class SkyModels:
         return out
 
     def __str__(self):
-        str_ = self.__class__.__name__ + "\n\n"
+        str_ = f"{self.__class__.__name__}\n\n"
 
         for idx, skymodel in enumerate(self.skymodels):
             str_ += f"Component {idx}: {skymodel}\n\n\t\n\n"
 
-        if self.parameters.covariance is not None:
-            str_ += "\n\nCovariance: \n\n\t"
-            covariance = self.parameters.covariance_to_table()
-            str_ += "\n\t".join(covariance.pformat())
         return str_
 
     def __iadd__(self, skymodel):
@@ -188,7 +184,9 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         """`~gammapy.modeling.models.SpectralModel`"""
         self._spectral_model = model
-        self._parameters = self.spatial_model.parameters + self.spectral_model.parameters
+        self._parameters = (
+            self.spatial_model.parameters + self.spectral_model.parameters
+        )
 
     @property
     def position(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -190,7 +190,9 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         """`~gammapy.modeling.models.SpectralModel`"""
         self._spectral_model = model
-        self._parameters = Parameters.stack([self.spatial_model.parameters, self.spectral_model.parameters])
+        self._parameters = Parameters.stack(
+            [self.spatial_model.parameters, self.spectral_model.parameters]
+        )
 
     @property
     def position(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -411,11 +411,9 @@ class SkyDiffuseCube(SkyModelBase):
 
     @classmethod
     def from_dict(cls, data):
-        init = cls.read(data["filename"])
-        init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters:
-            setattr(init, parameter.name, parameter)
-        return init
+        model = cls.read(data["filename"])
+        model._update_from_dict(data)
+        return model
 
     def to_dict(self):
         data = super().to_dict()
@@ -503,8 +501,6 @@ class BackgroundModel(Model):
         else:
             raise ValueError("Requires either filename or `Map` object")
 
-        init = cls(map=map, name=data["name"])
-        init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters:
-            setattr(init, parameter.name, parameter)
-        return init
+        model = cls(map=map, name=data["name"])
+        model._update_from_dict(data)
+        return model

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -511,11 +511,9 @@ class TemplateSpatialModel(SpatialModel):
 
     @classmethod
     def from_dict(cls, data):
-        init = cls.read(data["filename"], normalize=data.get("normalize", True))
-        init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters:
-            setattr(init, parameter.name, parameter)
-        return init
+        model = cls.read(data["filename"], normalize=data.get("normalize", True))
+        model._update_from_dict(data)
+        return model
 
     def to_dict(self):
         """Create dict for YAML serilisation"""

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -513,7 +513,7 @@ class TemplateSpatialModel(SpatialModel):
     def from_dict(cls, data):
         init = cls.read(data["filename"], normalize=data.get("normalize", True))
         init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters.parameters:
+        for parameter in init.parameters:
             setattr(init, parameter.name, parameter)
         return init
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1241,7 +1241,7 @@ class TemplateSpectralModel(SpectralModel):
         values = u.Quantity(data["values"]["data"], data["values"]["unit"])
         init = cls(energy=energy, values=values)
         init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters.parameters:
+        for parameter in init.parameters:
             setattr(init, parameter.name, parameter)
         return init
 
@@ -1455,8 +1455,10 @@ class AbsorbedSpectralModel(SpectralModel):
         max_ = self.absorption.param.max()
         par = Parameter(parameter_name, parameter, min=min_, max=max_, frozen=True)
         self.alpha_norm = Parameter("alpha_norm", alpha_norm, frozen=True)
-
-        super().__init__(spectral_model.parameters.parameters + [par, self.alpha_norm])
+        absorption_parameters = Parameters([par, self.alpha_norm])
+        super().__init__(
+            Parameters.stack([spectral_model.parameters, absorption_parameters])
+        )
 
     def evaluate(self, energy, **kwargs):
         """Evaluate the model at a given energy."""
@@ -1496,7 +1498,7 @@ class AbsorbedSpectralModel(SpectralModel):
             parameter_name=data["absorption_parameter"]["name"],
         )
         init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters.parameters:
+        for parameter in init.parameters:
             setattr(init, parameter.name, parameter)
         return init
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -431,9 +431,7 @@ class CompoundSpectralModel(SpectralModel):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
-        super().__init__(
-            Parameters.stack([self.model1.parameters, self.model2.parameters])
-        )
+        super().__init__(self.model1.parameters + self.model2.parameters)
 
     def __str__(self):
         return (
@@ -1454,9 +1452,7 @@ class AbsorbedSpectralModel(SpectralModel):
         par = Parameter(parameter_name, parameter, min=min_, max=max_, frozen=True)
         self.alpha_norm = Parameter("alpha_norm", alpha_norm, frozen=True)
         absorption_parameters = Parameters([par, self.alpha_norm])
-        super().__init__(
-            Parameters.stack([spectral_model.parameters, absorption_parameters])
-        )
+        super().__init__(spectral_model.parameters + absorption_parameters)
 
     def evaluate(self, energy, **kwargs):
         """Evaluate the model at a given energy."""

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -18,7 +18,7 @@ class SpectralModel(Model):
 
     def __call__(self, energy):
         kwargs = {}
-        for par in self.parameters.parameters:
+        for par in self.parameters:
             quantity = par.quantity
             if quantity.unit.physical_type == "energy":
                 quantity = quantity.to(energy.unit)
@@ -431,31 +431,29 @@ class CompoundSpectralModel(SpectralModel):
         self.model1 = model1
         self.model2 = model2
         self.operator = operator
-        parameters = (
-            self.model1.parameters.parameters + self.model2.parameters.parameters
+        super().__init__(
+            Parameters.stack([self.model1.parameters, self.model2.parameters])
         )
-        super().__init__(parameters)
-
-    # TODO: Think about how to deal with covariance matrix
 
     def __str__(self):
-        ss = self.__class__.__name__
-        ss += f"\n    Component 1 : {self.model1}"
-        ss += f"\n    Component 2 : {self.model2}"
-        ss += f"\n    Operator : {self.operator}"
-        return ss
+        return (
+            f"{self.__class__.__name__}\n"
+            f"    Component 1 : {self.model1}\n"
+            f"    Component 2 : {self.model2}\n"
+            f"    Operator : {self.operator}\n"
+        )
 
     def __call__(self, energy):
         val1 = self.model1(energy)
         val2 = self.model2(energy)
-
         return self.operator(val1, val2)
 
     def to_dict(self):
-        retval = dict()
-        retval["model1"] = self.model1.to_dict()
-        retval["model2"] = self.model2.to_dict()
-        retval["operator"] = self.operator
+        return {
+            "model1": self.model1.to_dict(),
+            "model2": self.model2.to_dict(),
+            "operator": self.operator,
+        }
 
 
 class PowerLawSpectralModel(SpectralModel):

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1239,11 +1239,9 @@ class TemplateSpectralModel(SpectralModel):
     def from_dict(cls, data):
         energy = u.Quantity(data["energy"]["data"], data["energy"]["unit"])
         values = u.Quantity(data["values"]["data"], data["values"]["unit"])
-        init = cls(energy=energy, values=values)
-        init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters:
-            setattr(init, parameter.name, parameter)
-        return init
+        model = cls(energy=energy, values=values)
+        model._update_from_dict(data)
+        return model
 
 
 class ScaleSpectralModel(SpectralModel):
@@ -1491,16 +1489,14 @@ class AbsorbedSpectralModel(SpectralModel):
         from gammapy.modeling.models import SPECTRAL_MODELS
 
         model_class = SPECTRAL_MODELS.get_cls(data["base_model"]["type"])
-        init = cls(
+        model = cls(
             spectral_model=model_class.from_dict(data["base_model"]),
             absorption=Absorption.from_dict(data["absorption"]),
             parameter=data["absorption_parameter"]["value"],
             parameter_name=data["absorption_parameter"]["name"],
         )
-        init.parameters = Parameters.from_dict(data)
-        for parameter in init.parameters:
-            setattr(init, parameter.name, parameter)
-        return init
+        model._update_from_dict(data)
+        return model
 
 
 class NaimaSpectralModel(SpectralModel):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -1,21 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Model parameter classes."""
 import copy
-import inspect
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
 
 __all__ = ["Parameter", "Parameters"]
-
-
-def get_default_args(func):
-    signature = inspect.signature(func)
-    return {
-        k: v.default
-        for k, v in signature.parameters.items()
-        if v.default is not inspect.Parameter.empty
-    }
 
 
 class Parameter:
@@ -185,21 +175,14 @@ class Parameter:
 
     def to_dict(self):
         """Convert to dict."""
-        data = {
+        return {
             "name": self.name,
             "value": self.value,
             "unit": self.unit.to_string("fits"),
+            "min": self.min,
+            "max": self.max,
+            "frozen": self.frozen,
         }
-
-        defaults = get_default_args(self.__init__)
-
-        for attr in ["frozen", "min", "max"]:
-            value = getattr(self, attr)
-            default = defaults[attr]
-            if value != default and value is not default:
-                data[attr] = value
-
-        return data
 
     def autoscale(self, method="scale10"):
         """Autoscale the parameters.

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -240,19 +240,17 @@ class Parameters:
     def __init__(self, parameters=None, covariance=None, apply_autoscale=True):
         if parameters is None:
             parameters = []
-        # elif isinstance(parameters, Parameters):
-        #     apply_autoscale = parameters.apply_autoscale
-        #     covariance = parameters.covariance if covariance is None else covariance
-        #     parameters = list(parameters)
-        # else:
-        #     # Handle any sequence of Parameter objects (list, tuple, generator)
-        #     parameters = list(parameters)
+        else:
+            parameters = list(parameters)
 
-        # TODO: remove unique filtering on __init__
-        self._parameters = self._filter_unique_parameters(parameters)
+        self._parameters = parameters
         self.covariance = covariance
         # TODO: remove autoscale attribute somehow?
         self.apply_autoscale = apply_autoscale
+
+        # TODO: move unique parameter filtering out of __init__, add covar handling
+        self._parameters = self.unique_parameters
+
 
     @classmethod
     def from_values(cls, values=None, covariance=None):
@@ -293,17 +291,6 @@ class Parameters:
         covariance = None
         return cls(pars, covariance)
 
-    @staticmethod
-    def _filter_unique_parameters(parameters):
-        """Filter unique parameters from a list of parameters"""
-        unique_parameters = []
-
-        for par in parameters:
-            if par not in unique_parameters:
-                unique_parameters.append(par)
-
-        return unique_parameters
-
     @property
     def _empty_covariance(self):
         return np.zeros((len(self), len(self)))
@@ -320,6 +307,11 @@ class Parameters:
     def free_parameters(self):
         """List of free parameters"""
         return [par for par in self._parameters if not par.frozen]
+
+    @property
+    def unique_parameters(self):
+        """List of unique parameters"""
+        return list(dict.fromkeys(self._parameters))
 
     @property
     def names(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -232,12 +232,9 @@ class Parameters:
     covariance : `~numpy.ndarray`, optional
         Parameters covariance matrix.
         Order of values as specified by `parameters`.
-    apply_autoscale : bool, optional
-        Flag for optimizers, if True parameters are autoscaled before the fit,
-        see `~gammapy.modeling.Parameter.autoscale`
     """
 
-    def __init__(self, parameters=None, covariance=None, apply_autoscale=True):
+    def __init__(self, parameters=None, covariance=None):
         if parameters is None:
             parameters = []
         else:
@@ -245,8 +242,6 @@ class Parameters:
 
         self._parameters = parameters
         self.covariance = covariance
-        # TODO: remove autoscale attribute somehow?
-        self.apply_autoscale = apply_autoscale
 
         # TODO: move unique parameter filtering out of __init__, add covar handling
         self._parameters = self.unique_parameters

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -284,25 +284,6 @@ class Parameters:
         """List of parameter names"""
         return [par.name for par in self._parameters]
 
-    def __str__(self):
-        str_ = self.__class__.__name__ + "\n\n"
-
-        for par in self._parameters:
-            if par.name == "amplitude":
-                line = "\t{:12} {:11}: {:.2e} {} {}\n"
-            else:
-                line = "\t{:12} {:11}: {:.3f} {} {}\n"
-
-            frozen = "(frozen)" if par.frozen else ""
-            try:
-                error = "+/- {:.2f}".format(self.get_error(par))
-            except AttributeError:
-                error = ""
-
-            str_ += line.format(par.name, frozen, par.value, error, par.unit)
-
-        return str_
-
     def _get_idx(self, val):
         """Get position index for a given parameter.
 

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -234,9 +234,10 @@ class Parameter:
 
 
 class Parameters:
-    """List of `Parameter`.
+    """Parameters container.
 
-    Holds covariance matrix.
+    - List of `Parameter` objects.
+    - Covariance matrix.
 
     Parameters
     ----------
@@ -287,11 +288,6 @@ class Parameters:
     def free_parameters(self):
         """List of free parameters"""
         return [par for par in self.parameters if not par.frozen]
-
-    # TODO: replace this with a better API to update parameters
-    @parameters.setter
-    def parameters(self, vals):
-        self._parameters = vals
 
     @property
     def names(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Model parameter classes."""
 import copy
+import itertools
+
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
@@ -244,10 +246,7 @@ class Parameters:
 
     @classmethod
     def stack(cls, parameters_list):
-        pars = []
-        for parameters in parameters_list:
-            for par in parameters:
-                pars.append(par)
+        pars = itertools.chain(*parameters_list)
         # TODO: stack covariance
         covariance = None
         # TODO: remove autoscale attribute somehow?

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -280,7 +280,11 @@ class Parameters:
         )
 
     @classmethod
-    def stack(cls, parameters_list):
+    def from_stack(cls, parameters_list):
+        """Create `Parameters` by stacking smaller `Parameters`.
+
+        TODO: document
+        """
         pars = itertools.chain(*parameters_list)
 
         # TODO: Fix covariance stacking!
@@ -353,6 +357,12 @@ class Parameters:
 
     def __len__(self):
         return len(self._parameters)
+
+    def __add__(self, other):
+        if isinstance(other, Parameters):
+            return Parameters.from_stack([self, other])
+        else:
+            raise TypeError(f"Invalid type: {other!r}")
 
     def to_dict(self):
         data = dict(parameters=[], covariance=None)

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -3,8 +3,8 @@
 import copy
 import itertools
 import numpy as np
-import scipy.stats
 import scipy.linalg
+import scipy.stats
 from astropy import units as u
 from astropy.table import Table
 
@@ -246,7 +246,6 @@ class Parameters:
         # TODO: move unique parameter filtering out of __init__, add covar handling
         self._parameters = self.unique_parameters
 
-
     @classmethod
     def from_values(cls, values=None, covariance=None):
         """Create `Parameters` from values.
@@ -400,19 +399,6 @@ class Parameters:
             covariance = None
 
         return cls(parameters=parameters, covariance=covariance)
-
-    def covariance_to_table(self):
-        """Convert covariance matrix to `~astropy.table.Table`."""
-        if self.covariance is None:
-            raise ValueError("No covariance available")
-
-        table = Table()
-        table["name"] = self.names
-        for idx, par in enumerate(self._parameters):
-            vals = self.covariance[idx]
-            table[par.name] = vals
-            table[par.name].format = ".3e"
-        return table
 
     @property
     def _ufloats(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -242,6 +242,18 @@ class Parameters:
         self.covariance = covariance
         self.apply_autoscale = apply_autoscale
 
+    @classmethod
+    def stack(cls, parameters_list):
+        pars = []
+        for parameters in parameters_list:
+            for par in parameters:
+                pars.append(par)
+        # TODO: stack covariance
+        covariance = None
+        # TODO: remove autoscale attribute somehow?
+        apply_autoscale = True
+        return cls(pars, covariance, apply_autoscale)
+
     @staticmethod
     def _filter_unique_parameters(parameters):
         """Filter unique parameters from a list of parameters"""
@@ -318,6 +330,9 @@ class Parameters:
         """Access parameter by name or index"""
         idx = self._get_idx(name)
         return self.parameters[idx]
+
+    def __len__(self):
+        return len(self.parameters)
 
     def to_dict(self):
         data = dict(parameters=[], covariance=None)

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -90,17 +90,14 @@ def _link_shared_parameters(models):
             if "@" in name:
                 if name in shared_register:
                     new_param = shared_register[name]
-                    ind = model.parameters.names.index(name)
-                    model.parameters.parameters[ind] = new_param
+                    model.parameters.link(name, new_param)
                     if isinstance(model, SkyModel):
                         spatial_params = model.spatial_model.parameters
                         spectral_params = model.spectral_model.parameters
                         if name in spatial_params.names:
-                            ind = spatial_params.names.index(name)
-                            spatial_params.parameters[ind] = new_param
+                            spatial_params.link(name, new_param)
                         elif name in spectral_params.names:
-                            ind = spectral_params.names.index(name)
-                            spectral_params.parameters[ind] = new_param
+                            spectral_params.link(name, new_param)
                 else:
                     param.name = name.split("@")[0]
                     shared_register[name] = param

--- a/gammapy/modeling/tests/data/example2.yaml
+++ b/gammapy/modeling/tests/data/example2.yaml
@@ -1,73 +1,58 @@
 components:
 - name: source
-  spatial:
-    parameters:
-    - factor: 0.0
-      frozen: false
-      max: 180.0
-      min: -180.0
-      name: lon_0
-      scale: 1.0
-      unit: deg
-      value: 0.0
-    - factor: 0.0
-      frozen: false
-      max: 90.0
-      min: -90.0
-      name: lat_0
-      scale: 1.0
-      unit: deg
-      value: 0.0
-    - factor: 1.0
-      frozen: false
-      max: .nan
-      min: 0.0
-      name: sigma
-      scale: 1.0
-      unit: deg
-      value: 1.0
-    - factor: 0.0
-      frozen: true
-      max: 1.0
-      min: 0.0
-      name: e
-      scale: 1.0
-      unit: ''
-      value: 0.0
-    - factor: 0.0
-      frozen: true
-      max: .nan
-      min: .nan
-      name: phi
-      scale: 1.0
-      unit: deg
-      value: 0.0
-    type: GaussianSpatialModel
-  spectral:
-    parameters:
-    - factor: 2.0
-      frozen: false
-      max: .nan
-      min: .nan
-      name: index
-      scale: 1.0
-      unit: ''
-      value: 2.0
-    - factor: 1.0e-12
-      frozen: false
-      max: .nan
-      min: .nan
-      name: amplitude
-      scale: 1.0
-      unit: cm-2 s-1 TeV-1
-      value: 1.0e-12
-    - factor: 1.0
-      frozen: true
-      max: .nan
-      min: .nan
-      name: reference
-      scale: 1.0
-      unit: TeV
-      value: 1.0
-    type: PowerLawSpectralModel
   type: SkyModel
+  spatial:
+    type: GaussianSpatialModel
+    frame: icrs
+    parameters:
+    - name: lon_0
+      value: 0.0
+      unit: deg
+      min: .nan
+      max: .nan
+      frozen: false
+    - name: lat_0
+      value: 0.0
+      unit: deg
+      min: -90.0
+      max: 90.0
+      frozen: false
+    - name: sigma
+      value: 1.0
+      unit: deg
+      min: 0.0
+      max: .nan
+      frozen: false
+    - name: e
+      value: 0.0
+      unit: ''
+      min: 0.0
+      max: 1.0
+      frozen: true
+    - name: phi
+      value: 0.0
+      unit: deg
+      min: .nan
+      max: .nan
+      frozen: true
+  spectral:
+    type: PowerLawSpectralModel
+    parameters:
+    - name: index
+      value: 2.0
+      unit: ''
+      min: .nan
+      max: .nan
+      frozen: false
+    - name: amplitude
+      value: 1.0e-12
+      unit: cm-2 s-1 TeV-1
+      min: .nan
+      max: .nan
+      frozen: false
+    - name: reference
+      value: 1.0
+      unit: TeV
+      min: .nan
+      max: .nan
+      frozen: true

--- a/gammapy/modeling/tests/data/make.py
+++ b/gammapy/modeling/tests/data/make.py
@@ -57,7 +57,7 @@ def make_datasets_example():
     names = ["gc", "g09"]
     models = []
 
-    for ind, (lon, lat) in enumerate(sources_coords):
+    for idx, (lon, lat) in enumerate(sources_coords):
         spatial_model = PointSpatialModel(
             lon_0=lon * u.deg, lat_0=lat * u.deg, frame="galactic"
         )
@@ -68,19 +68,16 @@ def make_datasets_example():
             lambda_=0.1 / u.TeV,
         )
         model_ecpl = SkyModel(
-            spatial_model=spatial_model, spectral_model=spectral_model, name=names[ind]
+            spatial_model=spatial_model, spectral_model=spectral_model, name=names[idx]
         )
         models.append(model_ecpl)
 
     # test to link a spectral parameter
     params0 = models[0].spectral_model.parameters
     params1 = models[1].spectral_model.parameters
-    ind = params0.parameters.index(params0["reference"])
-    params0.parameters[ind] = params1["reference"]
-
+    params0.link("reference", params1["reference"])
     # update the sky model
-    ind = models[0].parameters.parameters.index(models[0].parameters["reference"])
-    models[0].parameters.parameters[ind] = params1["reference"]
+    models[0].parameters.link("reference", params1["reference"])
 
     obs_ids = [110380, 111140, 111159]
     data_store = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps/")
@@ -121,8 +118,7 @@ def make_datasets_example():
     print("expo sum : ", dataset0.exposure.data.sum())
     print("bkg0 sum : ", dataset0.background_model.evaluate().data.sum())
 
-    path = "$GAMMAPY_DATA/tests/models/gc_example_"
-    datasets.to_yaml(path, overwrite=True)
+    datasets.to_yaml("$GAMMAPY_DATA/tests/models", prefix="gc_example_", overwrite=True)
 
 
 if __name__ == "__main__":

--- a/gammapy/modeling/tests/test_iminuit.py
+++ b/gammapy/modeling/tests/test_iminuit.py
@@ -54,7 +54,6 @@ def test_iminuit_basic(pars):
 def test_iminuit_stepsize(pars):
     ds = MyDataset(pars)
 
-    pars.apply_autoscale = False
     pars.covariance = np.diag([0.2, 3e4, 4e-6]) ** 2
 
     factors, info, minuit = optimize_iminuit(function=ds.fcn, parameters=pars)

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -106,20 +106,22 @@ def test_parameters_basics(pars):
     assert_allclose(pars.error(1), 10)
 
 
-def test_parameters_stack():
+def test_parameters_from_stack():
     a = Parameter("a", 1)
     b = Parameter("b", 2)
     c = Parameter("c", 3)
-    pars = Parameters.stack([[a], [], [b, c]])
+    pars = Parameters.from_stack([[a], [], [b, c]])
     assert pars.names == ["a", "b", "c"]
 
+    pars = Parameters([a, b]) + Parameters([]) + Parameters([c])
+    assert pars.names == ["a", "b", "c"]
 
-def test_from_stack():
     pars1 = Parameters.from_values([1, 2], covariance=np.full((2, 2), 2))
     pars2 = Parameters.from_values([3, 4, 5], covariance=np.full((3, 3), 3))
-    pars = Parameters.stack([pars1, pars2])
+    pars = pars1 + pars2
 
     assert_allclose(pars.values, [1, 2, 3, 4, 5])
+    # FIXME: covar stacking is broken ATM
     # assert_allclose(pars.covariance[0], [2, 2, 0, 0, 0])
     # assert_allclose(pars.covariance[4], [0, 0, 3, 3, 3])
 

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -151,15 +151,6 @@ def test_parameters_to_table(pars):
     assert len(table.columns) == 7
 
 
-def test_parameters_covariance_to_table(pars):
-    with pytest.raises(ValueError):
-        pars.covariance_to_table()
-
-    pars.set_error("ham", 10)
-    table = pars.covariance_to_table()
-    assert_allclose(table["ham"][1], 100)
-
-
 def test_parameters_set_parameter_factors(pars):
     pars.set_parameter_factors([77, 78])
     assert_allclose(pars["spam"].factor, 77)

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -105,6 +105,13 @@ def test_parameters_basics(pars):
     assert_allclose(pars.error("spam"), 0.1)
     assert_allclose(pars.error(1), 10)
 
+def test_parameters_stack():
+    a = Parameter("a", 1)
+    b = Parameter("b", 2)
+    c = Parameter("c", 3)
+    pars = Parameters.stack([[a], [], [b, c]])
+    assert pars.names == ["a", "b", "c"]
+
 
 def test_parameters_getitem(pars):
     assert pars[1].name == "ham"

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -105,12 +105,23 @@ def test_parameters_basics(pars):
     assert_allclose(pars.error("spam"), 0.1)
     assert_allclose(pars.error(1), 10)
 
+
 def test_parameters_stack():
     a = Parameter("a", 1)
     b = Parameter("b", 2)
     c = Parameter("c", 3)
     pars = Parameters.stack([[a], [], [b, c]])
     assert pars.names == ["a", "b", "c"]
+
+
+def test_from_stack():
+    pars1 = Parameters.from_values([1, 2], covariance=np.full((2, 2), 2))
+    pars2 = Parameters.from_values([3, 4, 5], covariance=np.full((3, 3), 3))
+    pars = Parameters.stack([pars1, pars2])
+
+    assert_allclose(pars.values, [1, 2, 3, 4, 5])
+    # assert_allclose(pars.covariance[0], [2, 2, 0, 0, 0])
+    # assert_allclose(pars.covariance[4], [0, 0, 3, 3, 3])
 
 
 def test_parameters_getitem(pars):

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -107,7 +107,7 @@ def test_datasets_to_io(tmp_path):
     datasets = Datasets.from_yaml(filedata, filemodel)
 
     assert len(datasets.datasets) == 2
-    assert len(datasets.parameters.parameters) == 20
+    assert len(datasets.parameters) == 20
 
     dataset0 = datasets.datasets[0]
     assert dataset0.counts.data.sum() == 6824
@@ -169,7 +169,7 @@ def test_absorption_io(tmp_path):
     assert new_model.spectral_model.tag == "PowerLawSpectralModel"
     assert_allclose(new_model.absorption.energy, dominguez.energy)
     assert_allclose(new_model.absorption.param, dominguez.param)
-    assert len(new_model.parameters.parameters) == 5
+    assert len(new_model.parameters) == 5
 
     test_absorption = Absorption(
         u.Quantity(range(3), "keV"),

--- a/gammapy/scripts/tests/test_analysis.py
+++ b/gammapy/scripts/tests/test_analysis.py
@@ -192,7 +192,7 @@ def test_analysis_3d():
     analysis.get_flux_points()
 
     assert len(analysis.datasets.datasets) == 1
-    assert len(analysis.fit_result.parameters.parameters) == 8
+    assert len(analysis.fit_result.parameters) == 8
     res = analysis.fit_result.parameters
     assert res[3].unit == "cm-2 s-1 TeV-1"
     assert len(analysis.flux_points.data.table) == 2

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -143,7 +143,7 @@ class SpectrumDataset(Dataset):
 
         n_pars, n_free_pars = 0, 0
         if self.model is not None:
-            n_pars = len(self.model.parameters.parameters)
+            n_pars = len(self.model.parameters)
             n_free_pars = len(self.parameters.free_parameters)
 
         str_ += "\t{:32}: {}\n".format("Number of parameters", n_pars)
@@ -166,7 +166,7 @@ class SpectrumDataset(Dataset):
     def model(self, model):
         self._model = model
         if model is not None:
-            self._parameters = Parameters(self._model.parameters.parameters)
+            self._parameters = self._model.parameters
             self._predictor = SpectrumEvaluator(
                 model=self.model,
                 livetime=self.livetime,

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1265,13 +1265,13 @@ class FluxPointsDataset(Dataset):
                 "Model Name", self.model.__class__.__name__
             )
             str_ += "\t{:32}:   {}\n".format(
-                "N parameters", len(self.parameters.parameters)
+                "N parameters", len(self.parameters)
             )
             str_ += "\t{:32}:   {}\n".format(
                 "N free parameters", len(self.parameters.free_parameters)
             )
             str_ += "\tList of parameters\n"
-            for par in self.parameters.parameters:
+            for par in self.parameters:
                 if par.frozen:
                     if par.name == "amplitude":
                         str_ += "\t \t {:14} (Frozen):   {:.2e} {} \n".format(

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1264,9 +1264,7 @@ class FluxPointsDataset(Dataset):
             str_ += "\t{:32}:   {}\n".format(
                 "Model Name", self.model.__class__.__name__
             )
-            str_ += "\t{:32}:   {}\n".format(
-                "N parameters", len(self.parameters)
-            )
+            str_ += "\t{:32}:   {}\n".format("N parameters", len(self.parameters))
             str_ += "\t{:32}:   {}\n".format(
                 "N free parameters", len(self.parameters.free_parameters)
             )

--- a/tutorials/image_analysis.ipynb
+++ b/tutorials/image_analysis.ipynb
@@ -313,8 +313,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# To get the errors on the model, we can check the covariance table:\n",
-    "result.parameters.covariance_to_table()"
+    "result.parameters.to_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.parameters.correlation[:4, :4]"
    ]
   },
   {

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -344,7 +344,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get the errors on the model, we can check the covariance table:"
+    "To get the errors on the model, we can check the parameter table, or the covariance matrix"
    ]
   },
   {
@@ -353,7 +353,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.parameters.covariance_to_table()"
+    "result.parameters.to_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.parameters.covariance[:3, :3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.parameters.correlation[:3, :3]"
    ]
   },
   {


### PR DESCRIPTION
This PR contains fixes, improvements and cleanup for `gammapy.modeling.Parameters`, and related changes to `Parameter`, `Model` and some model `__init__` methods.

- [x] Make `Parameters._parameters` completely private (no getter or setter)
- [x] Add `Parameters.values` Numpy array
- [x] Add `Parameters.__len__`
- [x] Add `Parameters.from_stack` and `Parameters.__add__` (covar stacking not done yet)
- [x] Add `Model._update_from_dict` (temp solution, left TODO comment)
- [x] Remove broken `Parameters.__str__`
- [x] Remove `Parameters.apply_autoscale` flag (not a good place to offer this optimiser option)
- [x] Remove `Parameters.covariance_to_table`
- [x] Misc cleanup