### PR TITLE
Add region info to `CountsSpectrum` and adapt tutorials

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -9,6 +9,7 @@ from gammapy.maps import MapAxis
 from gammapy.maps.utils import edges_from_lo_hi
 from gammapy.utils.fits import ebounds_to_energy_axis, energy_axis_to_ebounds
 from gammapy.utils.scripts import make_path
+from gammapy.utils.regions import compound_region_to_list
 
 __all__ = ["CountsSpectrum", "SpectrumEvaluator"]
 
@@ -28,6 +29,8 @@ class CountsSpectrum:
         Spectrum data.
     unit : str or `~astropy.units.Unit`
         Data unit
+    region : `~regions.SkyRegion`
+        Region the spectrum is defined for.
 
     Examples
     --------
@@ -48,7 +51,7 @@ class CountsSpectrum:
         spec.plot(show_poisson_errors=True)
     """
 
-    def __init__(self, energy_lo, energy_hi, data=None, unit=""):
+    def __init__(self, energy_lo, energy_hi, data=None, unit="", region=None):
         e_edges = edges_from_lo_hi(energy_lo, energy_hi)
         self.energy = MapAxis.from_edges(e_edges, interp="log", name="energy")
 
@@ -60,6 +63,7 @@ class CountsSpectrum:
             raise ValueError("Incompatible data and energy axis size.")
 
         self.unit = u.Unit(unit)
+        self.region = region
 
     @property
     def quantity(self):
@@ -94,6 +98,8 @@ class CountsSpectrum:
 
         names = ["CHANNEL", "COUNTS"]
         meta = {"name": "COUNTS"}
+        if self.region:
+            meta["region"] = 
         return Table([channel, counts], names=names, meta=meta)
 
     def to_hdulist(self, use_sherpa=False):
@@ -209,6 +215,27 @@ class CountsSpectrum:
         ax.set_xlabel(f"Energy [{energy_unit}]")
         ax.set_ylabel("Counts")
         ax.set_xscale("log")
+        return ax
+
+    def plot_region(self, ax=None, **kwargs):
+        """Plot region
+
+        Parameters
+        ----------
+        ax : `~astropy.vizualisation.WCSAxes`
+            Axes to plot on.
+        **kwargs : dict
+            Keyword arguments forwarded to `~regions.PixelRegion.as_artist`
+        """
+        import matplotlib.pyplot as plt
+
+        ax = plt.gca() or ax
+
+        regions = compound_region_to_list(self.region)
+        for region in regions:
+            patch = region.to_pixel(wcs=ax.wcs).as_artist(**kwargs)
+            ax.add_patch(patch)
+
         return ax
 
     def peek(self, figsize=(5, 10)):

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -229,14 +229,14 @@ class CountsSpectrum:
             Keyword arguments forwarded to `~regions.PixelRegion.as_artist`
         """
         import matplotlib.pyplot as plt
+        from matplotlib.collections import PatchCollection
 
         ax = plt.gca() or ax
-
         regions = compound_region_to_list(self.region)
-        for region in regions:
-            patch = region.to_pixel(wcs=ax.wcs).as_artist(**kwargs)
-            ax.add_patch(patch)
+        artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
 
+        patches = PatchCollection(artists, **kwargs)
+        ax.add_collection(patches)
         return ax
 
     def peek(self, figsize=(5, 10)):

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -77,9 +77,11 @@ class CountsSpectrum:
     @classmethod
     def from_hdulist(cls, hdulist, hdu1="COUNTS", hdu2="EBOUNDS"):
         """Read from HDU list in OGIP format."""
-        counts_table = Table.read(hdulist[hdu1])
-        counts = counts_table["COUNTS"].data
+        table = Table.read(hdulist[hdu1])
+        counts = table["COUNTS"].data
         ebounds = ebounds_to_energy_axis(hdulist[hdu2])
+
+        # TODO: add region serilisation
         return cls(data=counts, energy_lo=ebounds[:-1], energy_hi=ebounds[1:])
 
     @classmethod
@@ -98,8 +100,7 @@ class CountsSpectrum:
 
         names = ["CHANNEL", "COUNTS"]
         meta = {"name": "COUNTS"}
-        if self.region:
-            meta["region"] = 
+
         return Table([channel, counts], names=names, meta=meta)
 
     def to_hdulist(self, use_sherpa=False):

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -913,7 +913,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         outdir = Path.cwd() if outdir is None else make_path(outdir)
         outdir.mkdir(exist_ok=True, parents=True)
 
-        phafile = f"pha_{self.name}.fits"
+        phafile = f"pha_obs{self.name}.fits"
 
         bkgfile = phafile.replace("pha", "bkg")
         arffile = phafile.replace("pha", "arf")

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -13,7 +13,7 @@ from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_path
 from .core import CountsSpectrum, SpectrumEvaluator
 
-__all__ = ["SpectrumDatasetOnOff", "SpectrumDataset"]
+__all__ = ["SpectrumDatasetOnOff", "SpectrumDataset", "plot_spectrum_datasets_off_regions"]
 
 
 class SpectrumDataset(Dataset):
@@ -913,7 +913,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         outdir = Path.cwd() if outdir is None else make_path(outdir)
         outdir.mkdir(exist_ok=True, parents=True)
 
-        phafile = f"pha_obs{self.name}.fits"
+        phafile = f"pha_{self.name}.fits"
 
         bkgfile = phafile.replace("pha", "bkg")
         arffile = phafile.replace("pha", "arf")
@@ -1115,3 +1115,31 @@ def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS", hdu3="GTI"):
         is_bkg=False,
         gti=gti,
     )
+
+
+def plot_spectrum_datasets_off_regions(datasets, ax=None):
+    """Plot spectrum datasets of regions.
+
+    Parameters
+    ----------
+    datasets : list of `SpectrumDatasetOnOff`
+        List of spectrum on-off datasets
+    """
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as mpatches
+
+    ax = plt.gca() or ax
+
+    color_cycle = plt.rcParams['axes.prop_cycle']
+    colors = color_cycle.by_key()['color']
+    handles = []
+
+    for color, dataset in zip(colors, datasets):
+        kwargs = {"edgecolor": color, "facecolor": "none"}
+        dataset.counts_off.plot_region(ax=ax, **kwargs)
+
+        # create proxy artist for the custom legend
+        handle = mpatches.Patch(label=dataset.name, **kwargs)
+        handles.append(handle)
+
+    plt.legend(handles=handles)

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -70,7 +70,7 @@ class SpectrumDatasetMaker:
         energy_hi = self.e_reco[1:]
         energy_lo = self.e_reco[:-1]
 
-        counts = CountsSpectrum(energy_hi=energy_hi, energy_lo=energy_lo)
+        counts = CountsSpectrum(energy_hi=energy_hi, energy_lo=energy_lo, region=self.region)
         events_region = observation.events.select_region(
             self.region, wcs=self.geom_ref.wcs
         )

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -181,7 +181,7 @@ class SpectrumDatasetMaker:
             selection = ["counts", "background", "aeff", "edisp"]
 
         kwargs = {
-            "name": f"obs_{observation.obs_id}",
+            "name": f"{observation.obs_id}",
             "gti": observation.gti,
             "livetime": observation.observation_live_time_duration,
         }

--- a/gammapy/spectrum/reflected.py
+++ b/gammapy/spectrum/reflected.py
@@ -6,6 +6,7 @@ from astropy.coordinates import Angle, SkyCoord
 from regions import PixCoord
 from gammapy.maps import Map, WcsGeom, WcsNDMap
 from gammapy.maps.geom import frame_to_coordsys
+from gammapy.utils.regions import list_to_compound_region
 from .background_estimate import BackgroundEstimate
 from .core import CountsSpectrum
 from .dataset import SpectrumDatasetOnOff
@@ -322,9 +323,7 @@ class ReflectedRegionsBackgroundEstimator:
         if a_off == 0:
             off_events = obs.events.select_row_subset([])
         else:
-            off_regions = off_region[0]
-            for reg in off_region[1:]:
-                off_regions = off_regions.union(reg)
+            off_regions = list_to_compound_region(off_region)
             off_events = obs.events.select_region(off_regions, wcs)
 
         log.info(f"Found {a_off} reflected regions for the Obs #{obs.obs_id}")

--- a/gammapy/spectrum/reflected.py
+++ b/gammapy/spectrum/reflected.py
@@ -6,7 +6,7 @@ from astropy.coordinates import Angle, SkyCoord
 from regions import PixCoord
 from gammapy.maps import Map, WcsGeom, WcsNDMap
 from gammapy.maps.geom import frame_to_coordsys
-from gammapy.utils.regions import list_to_compound_region
+from gammapy.utils.regions import list_to_compound_region, compound_region_to_list
 from .background_estimate import BackgroundEstimate
 from .core import CountsSpectrum
 from .dataset import SpectrumDatasetOnOff
@@ -489,25 +489,20 @@ class ReflectedRegionsBackgroundMaker:
             Off counts.
         """
         finder = self._get_finder(observation)
-
         finder.run()
-        regions = finder.reflected_regions
 
-        region_union = regions[0]
-
-        for region in regions[1:]:
-            region_union = region_union.union(region)
+        region_union = list_to_compound_region(finder.reflected_regions)
 
         wcs = finder.reference_map.geom.wcs
         events_off = observation.events.select_region(region_union, wcs)
 
         edges = dataset.counts.energy.edges
-        counts_off = CountsSpectrum(energy_hi=edges[1:], energy_lo=edges[:-1])
+        counts_off = CountsSpectrum(
+            energy_hi=edges[1:],
+            energy_lo=edges[:-1],
+            region=region_union
+        )
         counts_off.fill_events(events_off)
-
-        # TODO: temporarily attach the region info to the CountsSpectrum.
-        #  but CountsSpectrum should be modified to hold this info anyway.
-        counts_off.regions = regions
         return counts_off
 
     def run(self, dataset, observation):
@@ -526,6 +521,7 @@ class ReflectedRegionsBackgroundMaker:
             On off dataset.
         """
         counts_off = self.make_counts_off(dataset, observation)
+        acceptance_off = len(compound_region_to_list(counts_off.region))
 
         return SpectrumDatasetOnOff(
             counts=dataset.counts,
@@ -536,7 +532,7 @@ class ReflectedRegionsBackgroundMaker:
             edisp=dataset.edisp,
             aeff=dataset.aeff,
             acceptance=1,
-            acceptance_off=len(counts_off.regions),
+            acceptance_off=acceptance_off,
             mask_safe=dataset.mask_safe,
             mask_fit=dataset.mask_fit,
         )

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -357,7 +357,7 @@ class TestSpectrumOnOff:
             gti=self.gti,
         )
         dataset.to_ogip_files(outdir=tmp_path)
-        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_test.fits")
+        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_obstest.fits")
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert_allclose(self.off_counts.data, newdataset.counts_off.data)
@@ -374,7 +374,7 @@ class TestSpectrumOnOff:
             name="test",
         )
         dataset.to_ogip_files(outdir=tmp_path)
-        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_test.fits")
+        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_obstest.fits")
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert newdataset.counts_off is None

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -357,7 +357,7 @@ class TestSpectrumOnOff:
             gti=self.gti,
         )
         dataset.to_ogip_files(outdir=tmp_path)
-        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_obstest.fits")
+        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_test.fits")
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert_allclose(self.off_counts.data, newdataset.counts_off.data)
@@ -374,7 +374,7 @@ class TestSpectrumOnOff:
             name="test",
         )
         dataset.to_ogip_files(outdir=tmp_path)
-        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_obstest.fits")
+        newdataset = SpectrumDatasetOnOff.from_ogip_files(tmp_path / "pha_test.fits")
 
         assert_allclose(self.on_counts.data, newdataset.counts.data)
         assert newdataset.counts_off is None

--- a/gammapy/spectrum/tests/test_reflected.py
+++ b/gammapy/spectrum/tests/test_reflected.py
@@ -19,6 +19,7 @@ from gammapy.utils.testing import (
     mpl_plot_check,
     requires_data,
 )
+from gammapy.utils.regions import compound_region_to_list
 
 
 @pytest.fixture(scope="session")
@@ -175,5 +176,7 @@ def test_reflected_bkg_maker(spectrum_dataset_maker, reflected_bkg_maker, observ
     assert_allclose(datasets[0].counts_off.data.sum(), 76)
     assert_allclose(datasets[1].counts_off.data.sum(), 60)
 
-    assert_allclose(len(datasets[0].counts_off.regions), 11)
-    assert_allclose(len(datasets[1].counts_off.regions), 11)
+    regions_0 = compound_region_to_list(datasets[0].counts_off.region)
+    regions_1 = compound_region_to_list(datasets[1].counts_off.region)
+    assert_allclose(len(regions_0), 11)
+    assert_allclose(len(regions_1), 11)

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -149,7 +149,7 @@ def list_to_compound_region(regions):
     region_union = regions[0]
 
     for region in regions[1:]:
-        region_union.union(region)
+        region_union = region_union.union(region)
 
     return region_union
 

--- a/gammapy/utils/regions.py
+++ b/gammapy/utils/regions.py
@@ -16,7 +16,8 @@ TODO: before Gammapy v1.0, discuss what to do about ``gammapy.utils.regions``.
 Options: keep as-is, hide from the docs, or to remove it completely
 (if the functionality is available in ``astropy-regions`` directly.
 """
-from regions import CircleSkyRegion, DS9Parser, PixelRegion, Region, SkyRegion
+import operator
+from regions import CircleSkyRegion, DS9Parser, PixelRegion, Region, SkyRegion, CompoundSkyRegion
 
 __all__ = ["make_region", "make_pixel_region"]
 
@@ -99,6 +100,58 @@ def make_pixel_region(region, wcs=None):
         return region
     else:
         raise TypeError(f"Invalid type: {region!r}")
+
+
+def compound_region_to_list(region):
+    """Create list of regions from compound regions.
+
+    Parameters
+    ----------
+    regions : `~regions.CompoundSkyRegion` or `~regions.SkyRegion`
+        Compound sky region
+
+    Returns
+    -------
+    regions : list of `~regions.SkyRegion`
+        List of regions.
+    """
+    regions = []
+
+    if isinstance(region, CompoundSkyRegion):
+        if region.operator is operator.or_:
+            regions_1 = compound_region_to_list(region.region1)
+            regions.extend(regions_1)
+
+            regions_2 = compound_region_to_list(region.region2)
+            regions.extend(regions_2)
+        else:
+            raise ValueError("Only union operator supported")
+    else:
+        return [region]
+
+    return regions
+
+
+def list_to_compound_region(regions):
+    """Create compound region from list of regions, by creating the union.
+
+    Parameters
+    ----------
+    regions : list of `~regions.SkyRegion`
+        List of regions.
+
+    Returns
+    -------
+    compound : `~regions.CompoundSkyRegion`
+        Compound sky region
+    """
+
+    region_union = regions[0]
+
+    for region in regions[1:]:
+        region_union.union(region)
+
+    return region_union
 
 
 class SphericalCircleSkyRegion(CircleSkyRegion):

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -60,10 +60,12 @@
     "from gammapy.data import DataStore\n",
     "from gammapy.modeling.models import PowerLawSpectralModel\n",
     "from gammapy.spectrum import (\n",
-    "    SpectrumExtraction,\n",
+    "    SpectrumDatasetMaker,\n",
+    "    SafeMaskMaker,\n",
     "    FluxPointsEstimator,\n",
     "    FluxPointsDataset,\n",
-    "    ReflectedRegionsBackgroundEstimator,\n",
+    "    ReflectedRegionsBackgroundMaker,\n",
+    "    plot_spectrum_datasets_off_regions,\n",
     ")\n",
     "from gammapy.maps import MapAxis, WcsNDMap, WcsGeom\n",
     "from gammapy.cube import MapDatasetMaker, MapDataset\n",
@@ -357,11 +359,35 @@
     "## Spectrum\n",
     "\n",
     "We'll run a spectral analysis using the classical reflected regions background estimation method,\n",
-    "and using the on-off (often called WSTAT) likelihood function.\n",
-    "\n",
-    "### Extraction\n",
-    "\n",
-    "The first step is to \"extract\" the spectrum, i.e. 1-dimensional counts and exposure and background vectors, as well as an energy dispersion matrix from the data and IRFs."
+    "and using the on-off (often called WSTAT) likelihood function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e_reco = np.logspace(-1, np.log10(40), 40) * u.TeV\n",
+    "e_true = np.logspace(np.log10(0.05), 2, 200) * u.TeV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_maker = SpectrumDatasetMaker(\n",
+    "    region=on_region,\n",
+    "    e_reco=e_reco,\n",
+    "    e_true=e_true,\n",
+    "    containment_correction=False,\n",
+    ")\n",
+    "bkg_maker = ReflectedRegionsBackgroundMaker(\n",
+    "    region=on_region, exclusion_mask=exclusion_mask\n",
+    ")\n",
+    "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"
    ]
   },
   {
@@ -371,14 +397,15 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "bkg_estimator = ReflectedRegionsBackgroundEstimator(\n",
-    "    observations=observations,\n",
-    "    on_region=on_region,\n",
-    "    exclusion_mask=exclusion_mask,\n",
-    ")\n",
-    "bkg_estimator.run()\n",
-    "bkg_estimate = bkg_estimator.result\n",
-    "bkg_estimator.plot();"
+    "datasets = []\n",
+    "\n",
+    "for observation in observations:\n",
+    "    dataset = dataset_maker.run(\n",
+    "        observation, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
+    "    )\n",
+    "    dataset_on_off = bkg_maker.run(dataset, observation)\n",
+    "    dataset_on_off = safe_mask_masker.run(dataset_on_off, observation)\n",
+    "    datasets.append(dataset_on_off)"
    ]
   },
   {
@@ -387,12 +414,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "extract = SpectrumExtraction(\n",
-    "    observations=observations, bkg_estimate=bkg_estimate\n",
-    ")\n",
-    "extract.run()\n",
-    "extract.compute_energy_threshold()"
+    "plt.figure(figsize=(8, 8))\n",
+    "_, ax, _ = images[\"counts\"].smooth(\"0.03 deg\").plot(vmax=8)\n",
+    "\n",
+    "on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor=\"white\")\n",
+    "plot_spectrum_datasets_off_regions(datasets, ax=ax)"
    ]
   },
   {
@@ -415,10 +441,10 @@
     "    index=2, amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
     ")\n",
     "\n",
-    "for dataset in extract.spectrum_observations:\n",
+    "for dataset in datasets:\n",
     "    dataset.model = model\n",
     "\n",
-    "fit = Fit(extract.spectrum_observations)\n",
+    "fit = Fit(datasets)\n",
     "result = fit.run()\n",
     "print(result)"
    ]
@@ -439,9 +465,9 @@
    "outputs": [],
    "source": [
     "# Flux points are computed on stacked observation\n",
-    "stacked_obs = Datasets(extract.spectrum_observations).stack_reduce()\n",
+    "stacked_dataset = Datasets(datasets).stack_reduce()\n",
     "\n",
-    "print(stacked_obs)"
+    "print(stacked_dataset)"
    ]
   },
   {
@@ -452,9 +478,9 @@
    "source": [
     "e_edges = np.logspace(0, 1.5, 5) * u.TeV\n",
     "\n",
-    "stacked_obs.model = model\n",
+    "stacked_dataset.model = model\n",
     "\n",
-    "fpe = FluxPointsEstimator(datasets=[dataset], e_edges=e_edges)\n",
+    "fpe = FluxPointsEstimator(datasets=[stacked_dataset], e_edges=e_edges)\n",
     "flux_points = fpe.run()\n",
     "flux_points.table_formatted"
    ]

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -25,6 +25,7 @@
    "source": [
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "\n",
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord\n",
@@ -340,8 +341,9 @@
     "from regions import CircleSkyRegion\n",
     "from astropy.coordinates import Angle\n",
     "from gammapy.spectrum import (\n",
-    "    SpectrumExtraction,\n",
-    "    ReflectedRegionsBackgroundEstimator,\n",
+    "    SpectrumDatasetMaker,\n",
+    "    ReflectedRegionsBackgroundMaker,\n",
+    "    SafeMaskMaker,\n",
     ")"
    ]
   },
@@ -361,17 +363,31 @@
    "outputs": [],
    "source": [
     "# Target definition\n",
+    "e_reco = np.logspace(-1, np.log10(40), 40) * u.TeV\n",
+    "e_true = np.logspace(np.log10(0.05), 2, 100) * u.TeV\n",
+    "\n",
     "on_region_radius = Angle(\"0.11 deg\")\n",
     "on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_maker = SpectrumDatasetMaker(\n",
+    "    region=on_region, e_reco=e_reco, e_true=e_true, containment_correction=True\n",
+    ")\n",
+    "bkg_maker = ReflectedRegionsBackgroundMaker(region=on_region)\n",
+    "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Extracting the background\n",
-    "\n",
-    "We perform here an ON - OFF measurement with reflected regions. We perform first the background extraction. "
+    "### Creation of the datasets"
    ]
   },
   {
@@ -380,47 +396,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bkg_estimator = ReflectedRegionsBackgroundEstimator(\n",
-    "    on_region=on_region, observations=crab_obs\n",
-    ")\n",
-    "bkg_estimator.run()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Creation of the datasets\n",
+    "datasets_1d = []\n",
     "\n",
-    "We now apply spectral extraction to create the datasets. \n",
+    "for time_interval in time_intervals:\n",
+    "    observation = crab_obs.select_time(time_interval)[0]\n",
     "\n",
-    "NB: we are using here time intervals defined by the observations start and stop times. The standard observation based spectral extraction is therefore defined in the right time bins. \n",
+    "    dataset = dataset_maker.run(\n",
+    "        observation, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
+    "    )\n",
     "\n",
-    "A proper time resolved spectral extraction will be included in a coming gammapy release."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Note that we are not performing the extraction in time bins\n",
-    "extraction = SpectrumExtraction(\n",
-    "    observations=crab_obs,\n",
-    "    bkg_estimate=bkg_estimator.result,\n",
-    "    containment_correction=True,\n",
-    "    e_reco=energy_axis.edges,\n",
-    "    e_true=energy_axis_true.edges,\n",
-    ")\n",
-    "extraction.run()\n",
-    "datasets_1d = extraction.spectrum_observations\n",
-    "\n",
-    "# we need to set the times manually for now\n",
-    "for dataset, time_interval in zip(datasets_1d, time_intervals):\n",
     "    dataset.counts.meta = dict()\n",
     "    dataset.counts.meta[\"t_start\"] = time_interval[0]\n",
-    "    dataset.counts.meta[\"t_stop\"] = time_interval[1]"
+    "    dataset.counts.meta[\"t_stop\"] = time_interval[1]\n",
+    "\n",
+    "    dataset_on_off = bkg_maker.run(dataset, observation)\n",
+    "    dataset_on_off = safe_mask_masker.run(dataset_on_off, observation)\n",
+    "    datasets_1d.append(dataset_on_off)"
    ]
   },
   {
@@ -490,13 +481,6 @@
     "lc.plot(ax=ax, marker=\"o\", label=\"3D\")\n",
     "plt.legend()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -345,7 +345,7 @@
    "source": [
     "datasets = []\n",
     "for obs_id in obs_ids:\n",
-    "    filename = path / f\"pha_obs_{obs_id}.fits\"\n",
+    "    filename = path / f\"pha_obs{obs_id}.fits\"\n",
     "    datasets.append(SpectrumDatasetOnOff.from_ogip_files(filename))"
    ]
   },

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -27,8 +27,9 @@
     "\n",
     "To extract the 1-dim spectral information:\n",
     "\n",
-    "* `~gammapy.spectrum.SpectrumExtraction`\n",
-    "* `~gammapy.spectrum.ReflectedRegionsBackgroundEstimator`\n",
+    "* `~gammapy.spectrum.SpectrumDatasetMaker`\n",
+    "* `~gammapy.spectrum.SafeMaskMaker`\n",
+    "* `~gammapy.spectrum.ReflectedRegionsBackgroundMaker`\n",
     "\n",
     "To perform the joint fit:\n",
     "\n",
@@ -88,6 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "import astropy.units as u\n",
     "from astropy.coordinates import SkyCoord, Angle\n",
     "from regions import CircleSkyRegion\n",
@@ -99,10 +101,13 @@
     "    create_crab_spectral_model,\n",
     ")\n",
     "from gammapy.spectrum import (\n",
-    "    SpectrumExtraction,\n",
+    "    SpectrumDatasetMaker,\n",
+    "    SpectrumDatasetOnOff,\n",
+    "    SafeMaskMaker,\n",
     "    FluxPointsEstimator,\n",
     "    FluxPointsDataset,\n",
-    "    ReflectedRegionsBackgroundEstimator,\n",
+    "    ReflectedRegionsBackgroundMaker,\n",
+    "    plot_spectrum_datasets_off_regions,\n",
     ")"
    ]
   },
@@ -175,7 +180,7 @@
     "\n",
     "skydir = target_position.galactic\n",
     "exclusion_mask = Map.create(\n",
-    "    npix=(150, 150), binsz=0.05, skydir=skydir, proj=\"TAN\", coordsys=\"GAL\"\n",
+    "    npix=(150, 150), binsz=0.05, skydir=skydir, proj=\"TAN\", coordsys=\"CEL\"\n",
     ")\n",
     "\n",
     "mask = exclusion_mask.geom.region_mask([exclusion_region], inside=False)\n",
@@ -187,9 +192,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Estimate background\n",
+    "## Run data reduction chain\n",
     "\n",
-    "Next we will manually perform a background estimate by placing [reflected regions](../spectrum/reflected.rst) around the pointing position and looking at the source statistics. This will result in a  `~gammapy.spectrum.BackgroundEstimate` that serves as input for other classes in gammapy."
+    "We begin with the configuration of the maker classes:"
    ]
   },
   {
@@ -198,13 +203,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "background_estimator = ReflectedRegionsBackgroundEstimator(\n",
-    "    observations=observations,\n",
-    "    on_region=on_region,\n",
-    "    exclusion_mask=exclusion_mask,\n",
+    "e_reco = np.logspace(-1, np.log10(40), 40) * u.TeV\n",
+    "e_true = np.logspace(np.log10(0.05), 2, 200) * u.TeV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_maker = SpectrumDatasetMaker(\n",
+    "    region=on_region,\n",
+    "    e_reco=e_reco,\n",
+    "    e_true=e_true,\n",
+    "    containment_correction=False,\n",
     ")\n",
+    "bkg_maker = ReflectedRegionsBackgroundMaker(\n",
+    "    region=on_region, exclusion_mask=exclusion_mask\n",
+    ")\n",
+    "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "datasets = []\n",
     "\n",
-    "background_estimator.run()"
+    "for observation in observations:\n",
+    "    dataset = dataset_maker.run(\n",
+    "        observation, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
+    "    )\n",
+    "    dataset_on_off = bkg_maker.run(dataset, observation)\n",
+    "    dataset_on_off = safe_mask_masker.run(dataset_on_off, observation)\n",
+    "    datasets.append(dataset_on_off)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot off regions"
    ]
   },
   {
@@ -214,7 +257,9 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(8, 8))\n",
-    "background_estimator.plot(add_legend=True);"
+    "_, ax, _ = exclusion_mask.plot()\n",
+    "on_region.to_pixel(ax.wcs).plot(ax=ax, edgecolor=\"k\")\n",
+    "plot_spectrum_datasets_off_regions(ax=ax, datasets=datasets)"
    ]
   },
   {
@@ -233,8 +278,10 @@
    "outputs": [],
    "source": [
     "stats = []\n",
-    "for obs, bkg in zip(observations, background_estimator.result):\n",
-    "    stats.append(ObservationStats.from_observation(obs, bkg))\n",
+    "for dataset in datasets:\n",
+    "    info = dataset._info_dict()\n",
+    "    info[\"obs_id\"] = int(info.pop(\"name\").split(\"_\")[-1])\n",
+    "    stats.append(ObservationStats(**info))\n",
     "\n",
     "print(stats[1])\n",
     "\n",
@@ -248,90 +295,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Extract spectrum\n",
-    "\n",
-    "Now, we're going to extract a spectrum using the `~gammapy.spectrum.SpectrumExtraction` class. We provide the reconstructed energy binning we want to use. It is expected to be a Quantity with unit energy, i.e. an array with an energy unit. We also provide the true energy binning to use."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "e_reco = np.logspace(-1, np.log10(40), 40) * u.TeV\n",
-    "e_true = np.logspace(np.log10(0.05), 2, 200) * u.TeV"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Instantiate a `~gammapy.spectrum.SpectrumExtraction` object that will do the extraction. The containment_correction parameter is there to allow for PSF leakage correction if one is working with full enclosure IRFs. We also compute a threshold energy and store the result in OGIP compliant files (pha, rmf, arf). This last step might be omitted though."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "extraction = SpectrumExtraction(\n",
-    "    observations=observations,\n",
-    "    bkg_estimate=background_estimator.result,\n",
-    "    containment_correction=False,\n",
-    "    e_reco=e_reco,\n",
-    "    e_true=e_true,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "extraction.run()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we can (optionally) compute the energy thresholds for the analysis, according to different methods. Here we choose the energy where the effective area drops below 10% of the maximum:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Add a condition on correct energy range in case it is not set by default\n",
-    "extraction.compute_energy_threshold(method_lo=\"area_max\", area_percent_lo=10.0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's take a look at the datasets, we just extracted:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Requires IPython widgets\n",
-    "# extraction.spectrum_observations.peek()\n",
-    "\n",
-    "extraction.spectrum_observations[0].peek()"
+    "datasets[0].peek()"
    ]
   },
   {
@@ -347,8 +316,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ANALYSIS_DIR = \"crab_analysis\"\n",
-    "# extraction.write(outdir=ANALYSIS_DIR, overwrite=True)"
+    "path = Path(\"spectrum_analysis\")\n",
+    "path.mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for dataset in datasets:\n",
+    "    dataset.to_ogip_files(outdir=path, overwrite=True)"
    ]
   },
   {
@@ -364,10 +343,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# datasets = []\n",
-    "# for obs_id in obs_ids:\n",
-    "#     filename = ANALYSIS_DIR + f\"/ogip_data/pha_obs{obs_id}.fits\"\n",
-    "#     datasets.append(SpectrumDatasetOnOff.from_ogip_files(filename))"
+    "datasets = []\n",
+    "for obs_id in obs_ids:\n",
+    "    filename = path / f\"pha_obs_{obs_id}.fits\"\n",
+    "    datasets.append(SpectrumDatasetOnOff.from_ogip_files(filename))"
    ]
   },
   {
@@ -389,12 +368,10 @@
     "    index=2, amplitude=2e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
     ")\n",
     "\n",
-    "datasets_joint = extraction.spectrum_observations\n",
-    "\n",
-    "for dataset in datasets_joint:\n",
+    "for dataset in datasets:\n",
     "    dataset.model = model\n",
     "\n",
-    "fit_joint = Fit(datasets_joint)\n",
+    "fit_joint = Fit(datasets)\n",
     "result_joint = fit_joint.run()\n",
     "\n",
     "# we make a copy here to compare it later\n",
@@ -418,7 +395,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(8, 6))\n",
-    "ax_spectrum, ax_residual = datasets_joint[0].plot_fit()\n",
+    "ax_spectrum, ax_residual = datasets[0].plot_fit()\n",
     "ax_spectrum.set_ylim(0, 25)"
    ]
   },
@@ -454,7 +431,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpe = FluxPointsEstimator(datasets=datasets_joint, e_edges=e_edges)\n",
+    "fpe = FluxPointsEstimator(datasets=datasets, e_edges=e_edges)\n",
     "flux_points = fpe.run()"
    ]
   },
@@ -538,7 +515,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_stacked = Datasets(datasets_joint).stack_reduce()"
+    "dataset_stacked = Datasets(datasets).stack_reduce()"
    ]
   },
   {
@@ -617,7 +594,9 @@
     "model_best_joint.plot(**plot_kwargs, label=\"Joint analysis result\", ls=\"--\")\n",
     "model_best_joint.plot_error(**plot_kwargs)\n",
     "\n",
-    "create_crab_spectral_model().plot(**plot_kwargs, label=\"Crab reference\")\n",
+    "create_crab_spectral_model(\"hess_pl\").plot(\n",
+    "    **plot_kwargs, label=\"Crab reference\"\n",
+    ")\n",
     "plt.legend()"
    ]
   },


### PR DESCRIPTION
This PR add region information to the `CountsSpectrum` object and adapts the tutorials to use this information for plotting. It concludes the following changes:

- Add `CountsSpectrum.region` attribute
- Implement `compound_region_to_list()` and `list_to_compound_region()` helper functions
- Implement `CountsSpectrum.plot_region()` method
- Implement `plot_spectrum_datasets_off_regions` helper function
- Adapt tutorials to the new `SpectrumDatasetMaker` reduction scheme

