### PR TITLE
Add empty docs pages: "Overview" and "How To"

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -216,6 +216,8 @@ running some Python code, use IPython like this:
 
     $ ipython -i example.py
 
+For examples how to run Gammapy analyses from Python scripts, see :ref:`tutorials_scripts`.
+
 Command line
 ++++++++++++
 

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -1,0 +1,79 @@
+.. include:: references.txt
+
+.. _howto:
+
+How To
+======
+
+TODO: add short entries explaining how to do something specific in Gammapy.
+
+Probably each HOWTO should be a short section with just 1-2 sentences and links to tutorials and API docs,
+or if it should be small mini-tutorials with code snippets, possibly on sub-pages.
+
+See docs PIG: https://github.com/gammapy/gammapy/pull/2463
+
+How to compute the significance of a source?
+--------------------------------------------
+
+Estimate the significance of a source, or more generally of an additional model component
+(such as e.g. a spectral line on top of a power-law spectrum), is done via a hypothesis test.
+You fit two models, with and without the extra source or component, then use the test statistic
+values from both fits to compute the significance or p-value.
+
+TODO: update this entry once https://github.com/gammapy/gammapy/issues/2149
+and https://github.com/gammapy/gammapy/issues/1540 are resolved, linking to the documentation
+developed there.
+
+How to use Gammapy with astrophysical modeling packages?
+--------------------------------------------------------
+
+It is possible to combine Gammapy with astrophysical modeling codes, if they provide a Python interface.
+Usually this requires some glue code to be written, e.g. `~gammapy.modeling.models.NaimaSpectralModel` is
+an example of a Gammapy wrapper class around the Naima spectral model and radiation classes, which then
+allows modeling and fitting of Naima models within Gammapy (e.g. using CTA, H.E.S.S. or Fermi-LAT data).
+
+TOOD: give more and better examples.
+
+Other Ideas
+===========
+
+Below some examples what "How to" entries could be, taken
+from https://github.com/gammapy/gammapy/pull/2463#issuecomment-544126183
+
+See also https://github.com/gammapy/gammapy/pull/2463#issuecomment-545309352
+for links to examples what other projects put as HOWTO or FAQ.
+
+
+Modeling
+++++++++
+
+- How to test the spectral and/or spatial model?
+- How to calculate lower/upper limits for a spectral parameter?
+
+SED
++++
+
+- How to calculate integral/differential flux and upper limits?
+- How to calculate spectral points and residuals?
+- How to plot the SED with errors?
+
+Source Detection
+++++++++++++++++
+
+- How to build and display the on region?
+- How to get the significance?
+- How to get excess and its error?
+- How to get background counts?
+
+2D Morphology
++++++++++++++
+
+- How to define/get position and spatial dimensions at different energy thresholds?
+- How to calculate surface brightness or radial profile in within a specific mask/region?
+- How to calculate a spectrum within a specific mask/region?
+- How to overlay significance and excess on maps?
+
+Light Curves
+++++++++++++
+
+- How to do analysis of light curves and upper limits

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -35,7 +35,7 @@ allows modeling and fitting of Naima models within Gammapy (e.g. using CTA, H.E.
 TOOD: give more and better examples.
 
 Other Ideas
-===========
+-----------
 
 Below some examples what "How to" entries could be, taken
 from https://github.com/gammapy/gammapy/pull/2463#issuecomment-544126183
@@ -43,22 +43,21 @@ from https://github.com/gammapy/gammapy/pull/2463#issuecomment-544126183
 See also https://github.com/gammapy/gammapy/pull/2463#issuecomment-545309352
 for links to examples what other projects put as HOWTO or FAQ.
 
-
 Modeling
---------
+++++++++
 
 - How to test the spectral and/or spatial model?
 - How to calculate lower/upper limits for a spectral parameter?
 
 SED
----
++++
 
 - How to calculate integral/differential flux and upper limits?
 - How to calculate spectral points and residuals?
 - How to plot the SED with errors?
 
 Source Detection
-----------------
+++++++++++++++++
 
 - How to build and display the on region?
 - How to get the significance?
@@ -66,7 +65,7 @@ Source Detection
 - How to get background counts?
 
 2D Morphology
--------------
++++++++++++++
 
 - How to define/get position and spatial dimensions at different energy thresholds?
 - How to calculate surface brightness or radial profile in within a specific mask/region?
@@ -74,6 +73,6 @@ Source Detection
 - How to overlay significance and excess on maps?
 
 Light Curves
-------------
+++++++++++++
 
 - How to do analysis of light curves and upper limits

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -45,20 +45,20 @@ for links to examples what other projects put as HOWTO or FAQ.
 
 
 Modeling
-++++++++
+--------
 
 - How to test the spectral and/or spatial model?
 - How to calculate lower/upper limits for a spectral parameter?
 
 SED
-+++
+---
 
 - How to calculate integral/differential flux and upper limits?
 - How to calculate spectral points and residuals?
 - How to plot the SED with errors?
 
 Source Detection
-++++++++++++++++
+----------------
 
 - How to build and display the on region?
 - How to get the significance?
@@ -66,7 +66,7 @@ Source Detection
 - How to get background counts?
 
 2D Morphology
-+++++++++++++
+-------------
 
 - How to define/get position and spatial dimensions at different energy thresholds?
 - How to calculate surface brightness or radial profile in within a specific mask/region?
@@ -74,6 +74,6 @@ Source Detection
 - How to overlay significance and excess on maps?
 
 Light Curves
-++++++++++++
+------------
 
 - How to do analysis of light curves and upper limits

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ or request a feature, or need help with anything Gammapy-related.
     install/index
     getting-started
     tutorials
+    howto
     references
     changelog
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ or request a feature, or need help with anything Gammapy-related.
     :caption: Getting Started
     :maxdepth: 1
 
+    overview
     install/index
     getting-started
     tutorials

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -581,7 +581,6 @@ found in the following sub-pages:
     :maxdepth: 1
 
     hpxmap
-    wcsmap
     plotting
 
 Reference/API

--- a/docs/maps/index.rst
+++ b/docs/maps/index.rst
@@ -31,8 +31,7 @@ as well as a data array containing map values. Where possible it is recommended
 to use the abstract `~Map` interface for accessing or updating the contents of a
 map as this allows algorithms to be used interchangeably with different map
 representations. The following reviews methods of the abstract map interface.
-Documentation specific to WCS- and HEALPix-based maps is provided in
-:doc:`hpxmap` and :doc:`wcsmap`.
+Documentation specific to WCS- and HEALPix-based maps is provided in :doc:`hpxmap`.
 
 
 Getting Started

--- a/docs/maps/wcsmap.rst
+++ b/docs/maps/wcsmap.rst
@@ -1,4 +1,0 @@
-.. _wcsmap:
-
-WCS-based Maps
-==============

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,0 +1,12 @@
+.. include:: references.txt
+
+.. _overview:
+
+Overview
+========
+
+TODO: give a big-picture overview of Gammapy
+
+Should be a 5 - 10 min read, including nice diagram figures.
+
+See https://github.com/gammapy/gammapy/pull/2463

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -87,6 +87,21 @@ Sensitivity:
 
 - `Compute the CTA sensitivity <notebooks/cta_sensitivity.html>`__ | *cta_sensitivity.ipynb*
 
+.. _tutorials_scripts:
+
+Scripts
+-------
+
+TODO: show a few examples how to use Gammapy from Python scripts.
+
+::
+
+    cd $GAMMAPY_DATA/../scripts-0.13
+    python cta_1dc_survey_map.py
+
+- TODO: Make a CTA 1DC survey counts map
+- TODO: some other long-running analysis or simulation
+
 .. _tutorials_extras:
 
 Extra topics

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -2,8 +2,8 @@
 
 .. _tutorials:
 
-Tutorial notebooks
-==================
+Tutorials
+=========
 
 This page lists the Gammapy tutorials that are available as `Jupyter`_ notebooks.
 


### PR DESCRIPTION
This PR adds an "Overview" and "How To" RST page for Gammapy. It's empty placeholders for now.

This came out of  #2463 and was agreed in the docs call with @Bultako and @adonath  this morning.
Merging without further review.

For the How To page I pus some examples and transferred the content from your comment @Bultako .
PRs welcome any time starting now to improve that.
(let's finish up the PIG, and not work out the details of what HOWTO entries we want there with further review and discussion phases)