### PR TITLE
Create unique parameters list in Datasets

### DIFF
--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -101,7 +101,13 @@ class Datasets:
 
     @property
     def parameters(self):
-        return Parameters.from_stack(_.parameters for _ in self.datasets)
+        """Unique parameters (`~gammapy.modeling.Parameters`).
+
+        Duplicate parameter objects have been removed.
+        The order of the unique parameters remains.
+        """
+        parameters = Parameters.from_stack(_.parameters for _ in self.datasets)
+        return parameters.unique_parameters
 
     @property
     def names(self):

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -262,9 +262,6 @@ class Parameters:
         self._parameters = parameters
         self._covariance = covariance
 
-        # TODO: move unique parameter filtering out of __init__, add covar handling
-        self._parameters = self.unique_parameters
-
     @property
     def covariance(self):
         """Covariance matrix (`numpy.ndarray`)."""
@@ -338,8 +335,8 @@ class Parameters:
 
     @property
     def unique_parameters(self):
-        """List of unique parameters"""
-        return list(dict.fromkeys(self._parameters))
+        """Unique parameters (`Parameters`)."""
+        return self.__class__(dict.fromkeys(self._parameters))
 
     @property
     def names(self):

--- a/gammapy/modeling/tests/test_model.py
+++ b/gammapy/modeling/tests/test_model.py
@@ -12,7 +12,6 @@ class MyModel(Model):
     y = Parameter("y", 2)
 
 
-# TODO: change example to also hold parameters?
 class CoModel(Model):
     """Compound model example"""
 

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -131,6 +131,15 @@ def test_parameters_from_stack():
     # assert_allclose(pars.covariance[0], [2, 2, 0, 0, 0])
     # assert_allclose(pars.covariance[4], [0, 0, 3, 3, 3])
 
+def test_unique_parameters():
+    a = Parameter("a", 1)
+    b = Parameter("b", 2)
+    c = Parameter("c", 3)
+    parameters = Parameters([a, b, a, c])
+    assert parameters.names == ["a", "b", "a", "c"]
+    parameters_unique = parameters.unique_parameters
+    assert parameters_unique.names == ["a", "b", "c"]
+
 
 def test_parameters_getitem(pars):
     assert pars[1].name == "ham"


### PR DESCRIPTION
This PR moves the creation of unique parameters from `Parameters.__init__` to `Datasets.parameters`.

I think that's much better to have that as an explicit operation, not something that silently occurs on `Parameters.__init__`. Some arguments were given in #2494 .

Unfortunately we don't have any unit tests for `Datasets` yet, but there were three failing tests if I simply removed the unique operation, one for serialsation, one for 1D and one for 3D analysis. With this change they all pass.

I would suggest to merge this as-is, as a very small, but important change, and then to continue with covariance and parameters stacking related changes in a follow-up PR.