### PR TITLE
Refactor ring background maker

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1011,10 +1011,9 @@ class MapDatasetOnOff(MapDataset):
     @property
     def alpha(self):
         """Exposure ratio between signal and background regions"""
-        tmp = self.acceptance / self.acceptance_off
-        mask = np.where(np.isnan(tmp.data))
-        tmp.data[mask] = 0
-        return tmp
+        alpha = self.acceptance / self.acceptance_off
+        alpha.data = np.nan_to_num(alpha.data)
+        return alpha
 
     @property
     def background(self):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1011,7 +1011,10 @@ class MapDatasetOnOff(MapDataset):
     @property
     def alpha(self):
         """Exposure ratio between signal and background regions"""
-        return self.acceptance / self.acceptance_off
+        tmp = self.acceptance / self.acceptance_off
+        mask = np.where(np.isnan(tmp.data))
+        tmp.data[mask] = 0
+        return tmp
 
     @property
     def background(self):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -877,8 +877,8 @@ class MapDataset(Dataset):
         background = background.sum_over_axes(keepdims=keepdims)
 
         idx = self.mask_safe.geom.get_axis_index_by_name("ENERGY")
-        data = np.logical_or.reduce(self.mask_safe.data, axis=idx)
-        mask_image = WcsNDMap(geom=self.mask_safe.geom.to_image(), data=data)
+        data = np.logical_or.reduce(self.mask_safe.data, axis=idx, keepdims=keepdims)
+        mask_image = WcsNDMap(geom=counts.geom, data=data)
 
         # TODO: add edisp and psf
         edisp = None

--- a/gammapy/cube/ring.py
+++ b/gammapy/cube/ring.py
@@ -230,9 +230,7 @@ class AdaptiveRingBackgroundMaker:
             acceptance_off=acceptance_off,
             exposure=dataset.exposure,
             psf=dataset.psf,
-            background_model=None,
             name=dataset.name,
-            evaluation_mode="local",
             mask_safe=mask_safe,
             gti=dataset.gti,
         )
@@ -350,9 +348,7 @@ class RingBackgroundMaker:
             acceptance_off=maps_off["acceptance_off"],
             exposure=dataset.exposure,
             psf=dataset.psf,
-            background_model=None,
             name=dataset.name,
-            evaluation_mode="local",
             mask_safe=mask_safe,
             gti=dataset.gti,
         )

--- a/gammapy/cube/ring.py
+++ b/gammapy/cube/ring.py
@@ -166,10 +166,14 @@ class AdaptiveRingBackgroundMaker:
         background = dataset.background_model.map
         kernels = self.kernels(counts)
 
-        # reproject exclusion mask
-        coords = counts.geom.get_coord()
-        data = self.exclusion_mask.get_by_coord(coords)
-        exclusion = Map.from_geom(geom=counts.geom, data=data)
+        if self.exclusion_mask is not None:
+            # reproject exclusion mask
+            coords = counts.geom.get_coord()
+            data = self.exclusion_mask.get_by_coord(coords)
+            exclusion = Map.from_geom(geom=counts.geom, data=data)
+        else:
+            data = np.ones(counts.geom.data_shape, dtype=bool)
+            exclusion = Map.from_geom(geom=counts.geom, data=data)
 
         cubes = {}
         cubes["counts_off"] = scale_cube(
@@ -286,10 +290,15 @@ class RingBackgroundMaker:
         counts = dataset.counts
         background = dataset.background_model.map
 
-        # reproject exclusion mask
-        coords = counts.geom.get_coord()
-        data = self.exclusion_mask.get_by_coord(coords)
-        exclusion = Map.from_geom(geom=counts.geom, data=data)
+        if self.exclusion_mask is not None:
+            # reproject exclusion mask
+            coords = counts.geom.get_coord()
+            data = self.exclusion_mask.get_by_coord(coords)
+            exclusion = Map.from_geom(geom=counts.geom, data=data)
+        else:
+            data = np.ones(counts.geom.data_shape, dtype=bool)
+            exclusion = Map.from_geom(geom=counts.geom, data=data)
+
 
         maps_off = {}
         ring = self.kernel(counts)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -5,12 +5,8 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from gammapy.cube import (
-    MapDataset,
-    MapDatasetMaker,
-    MapMakerRing,
-    RingBackgroundEstimator,
-)
+from gammapy.cube import MapDataset, MapDatasetMaker, MapMakerRing, RingBackgroundMaker
+from gammapy.cube.fit import MapDatasetOnOff
 from gammapy.data import DataStore
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.utils.testing import requires_data
@@ -27,7 +23,7 @@ def geom(ebounds, binsz=0.5):
     skydir = SkyCoord(0, -1, unit="deg", frame="galactic")
     energy_axis = MapAxis.from_edges(ebounds, name="energy", unit="TeV", interp="log")
     return WcsGeom.create(
-        binsz=binsz, skydir=skydir, width=(10, 5), coordsys="GAL", axes=[energy_axis]
+        skydir=skydir, binsz=binsz, width=(10, 5), coordsys="GAL", axes=[energy_axis]
     )
 
 
@@ -147,27 +143,31 @@ def test_map_maker(pars, observations):
 
 @requires_data()
 def test_map_maker_ring(observations):
-    ring_bkg = RingBackgroundEstimator(r_in="0.5 deg", width="0.4 deg")
     geomd = geom(ebounds=[0.1, 1, 10])
+    map_dataset_maker = MapDatasetMaker(geom=geomd, offset_max="2 deg")
+    ring_bkg = RingBackgroundMaker(r_in="0.5 deg", width="0.4 deg")
 
-    mask = Map.from_geom(geomd)
+    axis = geomd.get_axis_by_name("energy")
+    geom_squashed = geomd.to_image().to_cube([axis.squash()])
+    stacked = MapDatasetOnOff.create(geom_squashed)
 
     regions = CircleSkyRegion(
         SkyCoord(0, 0, unit="deg", frame="galactic"), radius=0.5 * u.deg
     )
-    mask.data = mask.geom.region_mask([regions], inside=False)
 
-    maker = MapMakerRing(geomd, 2.0 * u.deg, mask, ring_bkg)
+    for obs in observations:
+        dataset = map_dataset_maker.run(obs)
+        dataset = dataset.to_image()
 
-    maps = maker.run(observations)
-    assert_allclose(np.nansum(maps["on"].data), 34366, rtol=1e-2)
-    assert_allclose(np.nansum(maps["exposure_off"].data), 12362.756, rtol=1e-2)
-    assert not maps["on"].geom.is_image
+        geom_cutout = dataset.counts.geom
+        exclusion = Map.from_geom(geom_cutout)
+        exclusion.data = exclusion.geom.region_mask([regions], inside=False)
 
-    images = maker.run_images(observations)
-    assert_allclose(np.nansum(images["on"].data), 34366, rtol=1e-2)
-    assert_allclose(np.nansum(images["exposure_off"].data), 163730.62, rtol=1e-2)
-    assert images["on"].geom.is_image
+        dataset_on_off = ring_bkg.run(dataset, exclusion)
+        stacked.stack(dataset_on_off)
+
+    assert_allclose(np.nansum(stacked.counts.data), 34366, rtol=1e-2)
+    assert_allclose(np.nansum(stacked.acceptance_off.data), 434.36, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/cube/tests/test_ring.py
+++ b/gammapy/cube/tests/test_ring.py
@@ -63,10 +63,10 @@ def test_ring_bkg_maker(map_dataset_maker, observations, exclusion_mask):
 
     assert_allclose(datasets[0].counts_off.data.sum(), 2511417.0)
     assert_allclose(datasets[1].counts_off.data.sum(), 2143577.0)
-    assert_allclose(datasets[0].acceptance_off.data.sum(), 686236.1)
-    assert_allclose(datasets[1].acceptance_off.data.sum(), 684627.44)
-    assert_allclose(datasets[0].alpha.data[0][100][100], 0.000402089920)
-    assert_allclose(datasets[0].exposure.data[0][100][100], 8.062544e08)
+    assert_allclose(datasets[0].acceptance_off.data.sum(), 2960680.)
+    assert_allclose(datasets[1].acceptance_off.data.sum(), 2364657.2)
+    assert_allclose(datasets[0].alpha.data[0][100][100], 0.00063745599)
+    assert_allclose(datasets[0].exposure.data[0][100][100], 806254444.8480084)
 
 
 @pytest.mark.parametrize(
@@ -76,32 +76,32 @@ def test_ring_bkg_maker(map_dataset_maker, observations, exclusion_mask):
             "obs_idx": 0,
             "method": "fixed_r_in",
             "counts_off": 2511417.0,
-            "acceptance_off": 686236.102242,
-            "alpha": 0.00040208992,
+            "acceptance_off": 2960679.91214,
+            "alpha": 0.000637456020,
             "exposure": 806254444.8480084,
         },
         {
             "obs_idx": 0,
             "method": "fixed_width",
             "counts_off": 2511417.0,
-            "acceptance_off": 686236.102242,
-            "alpha": 0.00040208992,
+            "acceptance_off": 2960679.91214,
+            "alpha": 0.000637456020,
             "exposure": 806254444.8480084,
         },
         {
             "obs_idx": 1,
             "method": "fixed_r_in",
             "counts_off": 2143577.0,
-            "acceptance_off": 684627.4335880268,
-            "alpha": 0.000328803213,
+            "acceptance_off": 2364657.352647,
+            "alpha": 0.00061841976,
             "exposure": 779613265.2688407,
         },
         {
             "obs_idx": 1,
             "method": "fixed_width",
             "counts_off": 2143577.0,
-            "acceptance_off": 684627.4335880268,
-            "alpha": 0.000328803213,
+            "acceptance_off": 2364657.352647,
+            "alpha": 0.00061841976,
             "exposure": 779613265.2688407,
         },
     ],

--- a/gammapy/cube/tests/test_ring.py
+++ b/gammapy/cube/tests/test_ring.py
@@ -61,10 +61,11 @@ def test_ring_bkg_maker(map_dataset_maker, observations, exclusion_mask):
         dataset_on_off = ring_bkg_maker.run(dataset)
         datasets.append(dataset_on_off)
 
-    assert_allclose(datasets[0].counts_off.data.sum(), 2511417.0)
-    assert_allclose(datasets[1].counts_off.data.sum(), 2143577.0)
-    assert_allclose(datasets[0].acceptance_off.data.sum(), 2960680.)
-    assert_allclose(datasets[1].acceptance_off.data.sum(), 2364657.2)
+    mask = dataset.mask_safe
+    assert_allclose(datasets[0].counts_off.data[mask].sum(), 2511333)
+    assert_allclose(datasets[1].counts_off.data[mask].sum(), 2143577.0)
+    assert_allclose(datasets[0].acceptance_off.data[mask].sum(), 2961300)
+    assert_allclose(datasets[1].acceptance_off.data[mask].sum(), 2364657.2)
     assert_allclose(datasets[0].alpha.data[0][100][100], 0.00063745599)
     assert_allclose(datasets[0].exposure.data[0][100][100], 806254444.8480084)
 
@@ -122,7 +123,8 @@ def test_adaptive_ring_bkg_maker(pars, map_dataset_maker, observations, exclusio
     dataset = dataset.to_image()
     dataset_on_off = adaptive_ring_bkg_maker.run(dataset)
 
-    assert_allclose(dataset_on_off.counts_off.data.sum(), pars["counts_off"])
-    assert_allclose(dataset_on_off.acceptance_off.data.sum(), pars["acceptance_off"])
+    mask = dataset.mask_safe
+    assert_allclose(dataset_on_off.counts_off.data[mask].sum(), pars["counts_off"])
+    assert_allclose(dataset_on_off.acceptance_off.data[mask].sum(), pars["acceptance_off"])
     assert_allclose(dataset_on_off.alpha.data[0][100][100], pars["alpha"])
     assert_allclose(dataset_on_off.exposure.data[0][100][100], pars["exposure"])

--- a/gammapy/cube/tests/test_ring.py
+++ b/gammapy/cube/tests/test_ring.py
@@ -14,7 +14,7 @@ from gammapy.data import DataStore
 @pytest.fixture(scope="session")
 def observations():
     """Example observation list for testing."""
-    datastore = DataStore.from_file("$GAMMAPY_DATA/hess-dl3-dr1")
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
     obs_ids = [23523, 23526]
     return datastore.get_observations(obs_ids)
 

--- a/gammapy/cube/tests/test_ring.py
+++ b/gammapy/cube/tests/test_ring.py
@@ -2,94 +2,109 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy import units as u
-from gammapy.cube import AdaptiveRingBackgroundEstimator, RingBackgroundEstimator
-from gammapy.maps import WcsNDMap
+from regions import CircleSkyRegion
+from astropy.coordinates import Angle, SkyCoord
+from gammapy.cube import AdaptiveRingBackgroundMaker, RingBackgroundMaker
+from gammapy.maps import WcsNDMap, WcsGeom, MapAxis
+from gammapy.cube.make import MapDatasetMaker
+from gammapy.utils.testing import requires_data
+from gammapy.data import DataStore
 
 
-@pytest.fixture
-def images():
-    fov = 2.5 * u.deg
-
-    m_ref = WcsNDMap.create(binsz=0.05, npix=201, dtype=float)
-    m_ref.data += 1.0
-    coords = m_ref.geom.get_coord().skycoord
-    center = m_ref.geom.center_skydir
-    mask = coords.separation(center) < fov
-
-    images = dict()
-    images["counts"] = m_ref.copy(data=np.zeros_like(m_ref.data) + 2.0)
-    images["counts"].data *= mask
-
-    images["background"] = m_ref.copy(data=np.zeros_like(m_ref.data) + 1.0)
-    images["background"].data *= mask
-
-    exclusion = m_ref.copy(data=np.zeros_like(m_ref.data) + 1.0)
-    exclusion.data[90:110, 90:110] = 0
-    images["exclusion"] = exclusion
-    return images
+@pytest.fixture(scope="session")
+def exclusion_region():
+    """Example mask for testing."""
+    pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
+    return CircleSkyRegion(pos, Angle(0.15, "deg"))
 
 
-def test_ring_background_estimator(images):
-    ring = RingBackgroundEstimator(0.35 * u.deg, 0.3 * u.deg)
-
-    result = ring.run(images)
-
-    in_fov = images["background"].data > 0
-
-    assert_allclose(result["background_ring"].data[in_fov], 2.0)
-    assert_allclose(result["alpha"].data[in_fov].mean(), 0.003488538457592745)
-    assert_allclose(result["exposure_off"].data[in_fov].mean(), 305.1268970794541)
-    assert_allclose(result["off"].data[in_fov].mean(), 610.2537941589082)
-
-    assert_allclose(result["off"].data[~in_fov], 0.0)
-    assert_allclose(result["exposure_off"].data[~in_fov], 0.0)
-    assert_allclose(result["alpha"].data[~in_fov], 0.0)
+@pytest.fixture(scope="session")
+def observations():
+    """Example observation list for testing."""
+    datastore = DataStore.from_file(
+        "$GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz"
+    )
+    obs_ids = [23523, 23526]
+    return datastore.get_observations(obs_ids)
 
 
-class TestAdaptiveRingBackgroundEstimator:
-    def setup(self):
-        self.images = {}
-        self.images["counts"] = WcsNDMap.create(binsz=0.02, npix=101, dtype=float)
-        self.images["counts"].data += 1.0
-        self.images["background"] = WcsNDMap.create(binsz=0.02, npix=101, dtype=float)
-        self.images["background"].data += 1e10
-        exclusion = WcsNDMap.create(binsz=0.02, npix=101, dtype=float)
-        exclusion.data += 1
-        exclusion.data[40:60, 40:60] = 0
-        self.images["exclusion"] = exclusion
+@pytest.fixture()
+def map_dataset_maker():
+    energy_axis = MapAxis.from_edges(
+        np.logspace(0, 1.0, 5), unit="TeV", name="ENERGY", interp="log"
+    )
+    geom = WcsGeom.create(
+        skydir=SkyCoord(83.633, 22.014, unit="deg"),
+        binsz=0.02,
+        width=(10, 10),
+        coordsys="GAL",
+        proj="CAR",
+        axes=[energy_axis],
+    )
+    return MapDatasetMaker(geom=geom, offset_max="2 deg")
 
-    def test_run_const_width(self):
-        ring = AdaptiveRingBackgroundEstimator(
-            r_in=0.22 * u.deg, r_out_max=0.8 * u.deg, width=0.1 * u.deg
-        )
-        result = ring.run(self.images)
 
-        assert_allclose(result["background_ring"].data[50, 50], 1)
-        assert_allclose(result["alpha"].data[50, 50], 0.002638522427440632)
-        assert_allclose(result["exposure_off"].data[50, 50], 379 * 1e10)
-        assert_allclose(result["off"].data[50, 50], 379)
+def adaptive_ring_bkg_maker(method):
+    return AdaptiveRingBackgroundMaker(
+        r_in="0.2 deg",
+        width="0.3 deg",
+        r_out_max="2 deg",
+        stepsize="0.2 deg",
+        method=method,
+    )
 
-        assert_allclose(result["background_ring"].data[0, 0], 1)
-        assert_allclose(result["alpha"].data[0, 0], 0.008928571428571418)
-        assert_allclose(result["exposure_off"].data[0, 0], 112 * 1e10)
-        assert_allclose(result["off"].data[0, 0], 112)
 
-    def test_run_const_r_in(self):
-        ring = AdaptiveRingBackgroundEstimator(
-            r_in=0.22 * u.deg,
-            r_out_max=0.8 * u.deg,
-            width=0.1 * u.deg,
-            method="fixed_r_in",
-        )
-        result = ring.run(self.images)
+@requires_data()
+def test_ring_bkg_maker(map_dataset_maker, observations, exclusion_region):
+    ring_bkg_maker = RingBackgroundMaker(r_in="0.2 deg", width="0.3 deg")
+    datasets = []
 
-        assert_allclose(result["background_ring"].data[50, 50], 1)
-        assert_allclose(result["alpha"].data[50, 50], 0.002638522427440632)
-        assert_allclose(result["exposure_off"].data[50, 50], 379 * 1e10)
-        assert_allclose(result["off"].data[50, 50], 379)
+    for obs in observations:
+        dataset = map_dataset_maker.run(obs)
+        dataset = dataset.to_image()
 
-        assert_allclose(result["background_ring"].data[0, 0], 1)
-        assert_allclose(result["alpha"].data[0, 0], 0.008928571428571418)
-        assert_allclose(result["exposure_off"].data[0, 0], 112 * 1e10)
-        assert_allclose(result["off"].data[0, 0], 112)
+        geom_cutout = dataset.counts.geom
+        exclusion = WcsNDMap.from_geom(geom_cutout)
+        exclusion.data = exclusion.geom.region_mask([exclusion_region], inside=False)
+
+        dataset_on_off = ring_bkg_maker.run(dataset, exclusion)
+        datasets.append(dataset_on_off)
+
+    assert_allclose(datasets[0].counts_off.data.sum(), 2511417.0)
+    assert_allclose(datasets[1].counts_off.data.sum(), 2143577.0)
+    assert_allclose(datasets[0].acceptance_off.data.sum(), 698869.8)
+    assert_allclose(datasets[1].acceptance_off.data.sum(), 697233.6)
+
+    assert_allclose(datasets[0].alpha.data[0][100][100], 0.000668635)
+    assert_allclose(datasets[0].exposure.data[0][100][100], 639038346.7895743)
+
+
+@requires_data()
+def test_adaptive_ring_bkg_maker(map_dataset_maker, observations, exclusion_region):
+    datasets = {}
+
+    for method in ["fixed_width", "fixed_r_in"]:
+        datasets.update({method: []})
+        for obs in observations:
+            dataset = map_dataset_maker.run(obs)
+            dataset = dataset.to_image()
+
+            geom_cutout = dataset.counts.geom
+            exclusion = WcsNDMap.from_geom(geom_cutout)
+            exclusion.data = exclusion.geom.region_mask(
+                [exclusion_region], inside=False
+            )
+
+            dataset_on_off = adaptive_ring_bkg_maker(method).run(dataset, exclusion)
+            datasets[method].append(dataset_on_off)
+
+    assert_allclose(datasets["fixed_r_in"][0].counts_off.data.sum(), 2511417.0)
+    assert_allclose(datasets["fixed_width"][0].counts_off.data.sum(), 2511417.0)
+    assert_allclose(datasets["fixed_r_in"][1].counts_off.data.sum(), 2143577.0)
+    assert_allclose(datasets["fixed_r_in"][0].acceptance_off.data.sum(), 698869.8)
+    assert_allclose(datasets["fixed_width"][1].acceptance_off.data.sum(), 697233.6)
+
+    assert_allclose(datasets["fixed_r_in"][0].alpha.data[0][100][100], 0.000668635)
+    assert_allclose(
+        datasets["fixed_width"][0].exposure.data[0][100][100], 639038346.7895743
+    )

--- a/gammapy/cube/tests/test_ring.py
+++ b/gammapy/cube/tests/test_ring.py
@@ -12,28 +12,17 @@ from gammapy.data import DataStore
 
 
 @pytest.fixture(scope="session")
-def exclusion_region():
-    """Example mask for testing."""
-    pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
-    return CircleSkyRegion(pos, Angle(0.15, "deg"))
-
-
-@pytest.fixture(scope="session")
 def observations():
     """Example observation list for testing."""
-    datastore = DataStore.from_file(
-        "$GAMMAPY_DATA/hess-dl3-dr1/hess-dl3-dr3-with-background.fits.gz"
-    )
+    datastore = DataStore.from_file("$GAMMAPY_DATA/hess-dl3-dr1")
     obs_ids = [23523, 23526]
     return datastore.get_observations(obs_ids)
 
 
-@pytest.fixture()
-def map_dataset_maker():
-    energy_axis = MapAxis.from_edges(
-        np.logspace(0, 1.0, 5), unit="TeV", name="ENERGY", interp="log"
-    )
-    geom = WcsGeom.create(
+@pytest.fixture(scope="session")
+def geom():
+    energy_axis = MapAxis.from_edges([1, 10], unit="TeV", name="ENERGY", interp="log")
+    return WcsGeom.create(
         skydir=SkyCoord(83.633, 22.014, unit="deg"),
         binsz=0.02,
         width=(10, 10),
@@ -41,70 +30,99 @@ def map_dataset_maker():
         proj="CAR",
         axes=[energy_axis],
     )
+
+
+@pytest.fixture(scope="session")
+def exclusion_mask(geom):
+    """Example mask for testing."""
+    pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
+    region = CircleSkyRegion(pos, Angle(0.15, "deg"))
+    exclusion = WcsNDMap.from_geom(geom)
+    exclusion.data = geom.region_mask([region], inside=False)
+    return exclusion
+
+
+@pytest.fixture(scope="session")
+def map_dataset_maker(geom):
     return MapDatasetMaker(geom=geom, offset_max="2 deg")
 
 
-def adaptive_ring_bkg_maker(method):
-    return AdaptiveRingBackgroundMaker(
-        r_in="0.2 deg",
-        width="0.3 deg",
-        r_out_max="2 deg",
-        stepsize="0.2 deg",
-        method=method,
-    )
-
-
 @requires_data()
-def test_ring_bkg_maker(map_dataset_maker, observations, exclusion_region):
-    ring_bkg_maker = RingBackgroundMaker(r_in="0.2 deg", width="0.3 deg")
+def test_ring_bkg_maker(map_dataset_maker, observations, exclusion_mask):
+    ring_bkg_maker = RingBackgroundMaker(
+        r_in="0.2 deg", width="0.3 deg", exclusion_mask=exclusion_mask
+    )
     datasets = []
 
     for obs in observations:
         dataset = map_dataset_maker.run(obs)
         dataset = dataset.to_image()
 
-        geom_cutout = dataset.counts.geom
-        exclusion = WcsNDMap.from_geom(geom_cutout)
-        exclusion.data = exclusion.geom.region_mask([exclusion_region], inside=False)
-
-        dataset_on_off = ring_bkg_maker.run(dataset, exclusion)
+        dataset_on_off = ring_bkg_maker.run(dataset)
         datasets.append(dataset_on_off)
 
     assert_allclose(datasets[0].counts_off.data.sum(), 2511417.0)
     assert_allclose(datasets[1].counts_off.data.sum(), 2143577.0)
-    assert_allclose(datasets[0].acceptance_off.data.sum(), 698869.8)
-    assert_allclose(datasets[1].acceptance_off.data.sum(), 697233.6)
+    assert_allclose(datasets[0].acceptance_off.data.sum(), 686236.1)
+    assert_allclose(datasets[1].acceptance_off.data.sum(), 684627.44)
+    assert_allclose(datasets[0].alpha.data[0][100][100], 0.000402089920)
+    assert_allclose(datasets[0].exposure.data[0][100][100], 8.062544e08)
 
-    assert_allclose(datasets[0].alpha.data[0][100][100], 0.000668635)
-    assert_allclose(datasets[0].exposure.data[0][100][100], 639038346.7895743)
 
-
+@pytest.mark.parametrize(
+    "pars",
+    [
+        {
+            "obs_idx": 0,
+            "method": "fixed_r_in",
+            "counts_off": 2511417.0,
+            "acceptance_off": 686236.102242,
+            "alpha": 0.00040208992,
+            "exposure": 806254444.8480084,
+        },
+        {
+            "obs_idx": 0,
+            "method": "fixed_width",
+            "counts_off": 2511417.0,
+            "acceptance_off": 686236.102242,
+            "alpha": 0.00040208992,
+            "exposure": 806254444.8480084,
+        },
+        {
+            "obs_idx": 1,
+            "method": "fixed_r_in",
+            "counts_off": 2143577.0,
+            "acceptance_off": 684627.4335880268,
+            "alpha": 0.000328803213,
+            "exposure": 779613265.2688407,
+        },
+        {
+            "obs_idx": 1,
+            "method": "fixed_width",
+            "counts_off": 2143577.0,
+            "acceptance_off": 684627.4335880268,
+            "alpha": 0.000328803213,
+            "exposure": 779613265.2688407,
+        },
+    ],
+)
 @requires_data()
-def test_adaptive_ring_bkg_maker(map_dataset_maker, observations, exclusion_region):
-    datasets = {}
-
-    for method in ["fixed_width", "fixed_r_in"]:
-        datasets.update({method: []})
-        for obs in observations:
-            dataset = map_dataset_maker.run(obs)
-            dataset = dataset.to_image()
-
-            geom_cutout = dataset.counts.geom
-            exclusion = WcsNDMap.from_geom(geom_cutout)
-            exclusion.data = exclusion.geom.region_mask(
-                [exclusion_region], inside=False
-            )
-
-            dataset_on_off = adaptive_ring_bkg_maker(method).run(dataset, exclusion)
-            datasets[method].append(dataset_on_off)
-
-    assert_allclose(datasets["fixed_r_in"][0].counts_off.data.sum(), 2511417.0)
-    assert_allclose(datasets["fixed_width"][0].counts_off.data.sum(), 2511417.0)
-    assert_allclose(datasets["fixed_r_in"][1].counts_off.data.sum(), 2143577.0)
-    assert_allclose(datasets["fixed_r_in"][0].acceptance_off.data.sum(), 698869.8)
-    assert_allclose(datasets["fixed_width"][1].acceptance_off.data.sum(), 697233.6)
-
-    assert_allclose(datasets["fixed_r_in"][0].alpha.data[0][100][100], 0.000668635)
-    assert_allclose(
-        datasets["fixed_width"][0].exposure.data[0][100][100], 639038346.7895743
+def test_adaptive_ring_bkg_maker(pars, map_dataset_maker, observations, exclusion_mask):
+    adaptive_ring_bkg_maker = AdaptiveRingBackgroundMaker(
+        r_in="0.2 deg",
+        width="0.3 deg",
+        r_out_max="2 deg",
+        stepsize="0.2 deg",
+        exclusion_mask=exclusion_mask,
+        method=pars["method"],
     )
+
+    obs = observations[pars["obs_idx"]]
+    dataset = map_dataset_maker.run(obs)
+    dataset = dataset.to_image()
+    dataset_on_off = adaptive_ring_bkg_maker.run(dataset)
+
+    assert_allclose(dataset_on_off.counts_off.data.sum(), pars["counts_off"])
+    assert_allclose(dataset_on_off.acceptance_off.data.sum(), pars["acceptance_off"])
+    assert_allclose(dataset_on_off.alpha.data[0][100][100], pars["alpha"])
+    assert_allclose(dataset_on_off.exposure.data[0][100][100], pars["exposure"])

--- a/tutorials/image_analysis.ipynb
+++ b/tutorials/image_analysis.ipynb
@@ -47,8 +47,9 @@
     "    MapDatasetMaker,\n",
     "    PSFKernel,\n",
     "    MapDataset,\n",
-    "    MapMakerRing,\n",
-    "    RingBackgroundEstimator,\n",
+    "    MapDatasetMaker,\n",
+    "    MapDatasetOnOff,\n",
+    "    RingBackgroundMaker,\n",
     ")\n",
     "from gammapy.modeling.models import (\n",
     "    SkyModel,\n",
@@ -340,13 +341,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "geom_image = geom.to_image()\n",
+    "geom_image = geom.to_image().to_cube([energy_axis.squash()])\n",
     "\n",
     "regions = CircleSkyRegion(center=spatial_model.position, radius=0.3 * u.deg)\n",
     "\n",
     "exclusion_mask = Map.from_geom(geom_image)\n",
     "exclusion_mask.data = geom_image.region_mask([regions], inside=False)\n",
-    "exclusion_mask.plot();"
+    "exclusion_mask.sum_over_axes().plot();"
    ]
   },
   {
@@ -362,7 +363,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ring_bkg = RingBackgroundEstimator(r_in=\"0.3 deg\", width=\"0.3 deg\")"
+    "ring_maker = RingBackgroundMaker(r_in=\"0.3 deg\", width=\"0.3 deg\", exclusion_mask=exclusion_mask)"
    ]
   },
   {
@@ -372,17 +373,13 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "im = MapMakerRing(\n",
-    "    geom=geom,\n",
-    "    offset_max=3.0 * u.deg,\n",
-    "    exclusion_mask=exclusion_mask,\n",
-    "    background_estimator=ring_bkg,\n",
-    ")\n",
+    "stacked_on_off = MapDatasetOnOff.create(geom=geom_image)\n",
     "\n",
     "for obs in observations:\n",
-    "    im._get_obs_maker(obs)\n",
-    "\n",
-    "images = im.run_images(observations)"
+    "    dataset = maker.run(obs)\n",
+    "    dataset_image = dataset.to_image()\n",
+    "    dataset_on_off = ring_maker.run(dataset_image)\n",
+    "    stacked_on_off.stack(dataset_on_off)"
    ]
   },
   {
@@ -405,10 +402,10 @@
     "tophat.normalize(\"peak\")\n",
     "\n",
     "lima_maps = compute_lima_on_off_image(\n",
-    "    images[\"on\"],\n",
-    "    images[\"off\"],\n",
-    "    images[\"exposure_on\"],\n",
-    "    images[\"exposure_off\"],\n",
+    "    stacked_on_off.counts,\n",
+    "    stacked_on_off.counts_off,\n",
+    "    stacked_on_off.acceptance,\n",
+    "    stacked_on_off.acceptance_off,\n",
     "    tophat,\n",
     ")"
    ]
@@ -441,10 +438,10 @@
     "ax2 = plt.subplot(222, projection=excess_map.geom.wcs)\n",
     "\n",
     "ax1.set_title(\"Significance map\")\n",
-    "significance_map.plot(ax=ax1, add_cbar=True)\n",
+    "significance_map.get_image_by_idx((0,)).plot(ax=ax1, add_cbar=True)\n",
     "\n",
     "ax2.set_title(\"Excess map\")\n",
-    "excess_map.plot(ax=ax2, add_cbar=True);"
+    "significance_map.get_image_by_idx((0,)).plot(ax=ax2, add_cbar=True)"
    ]
   },
   {


### PR DESCRIPTION
In this PR, I refactor the `RingBackgroundEstimator` into `RingBackgroundMaker` and `AdaptiveRingBackgroundEstimator` into `AdaptiveRingBackgroundMaker`. For the moment, those are still two independent makers, but could eventually be merged into a single maker later on.

I compared the performances of the new "maker" pattern to the old scheme. You can see this comparison in two notebooks:
- Using v0.13: https://github.com/luca-giunti/share/blob/master/ring_13.ipynb
-  Using the new class: https://github.com/luca-giunti/share/blob/master/ring_dev.ipynb

Using 4 runs, the computation time for the non-adaptive ring algorithm drops from `5.46 s ± 469 ms` to `2.61 s ± 125 ms`, and for the adaptive ring from `7.52 s ± 622 ms` to `3.08 s ± 334 ms`.

Also,the results look very similar. However, as you can see in the notebooks, there is a small shift in `alpha`: taking a random bin, I find a shift from `0.00077920605` to `0.000740094`. I think this might be related to the fact that in v0.13 we were stacking the off_exposure using a simple `fill_by_coord()` (see [here](https://github.com/gammapy/gammapy/blob/7d06f74d407f42a164477da8d8922bd70c93ae76/gammapy/cube/make.py#L553)), i.e. no weighting by the obs time or off counts was performed... Is that possible?