### PR TITLE
Remove .to_sherpa() methods

### DIFF
--- a/gammapy/irf/effective_area.py
+++ b/gammapy/irf/effective_area.py
@@ -299,24 +299,6 @@ class EffectiveAreaTable:
         aeff_spectrum = TemplateSpectralModel(energy, self.data.data)
         return aeff_spectrum.inverse(aeff, emin=emin, emax=emax)
 
-    def to_sherpa(self, name):
-        """Convert to `~sherpa.astro.data.DataARF`
-
-        Parameters
-        ----------
-        name : str
-            Instance name
-        """
-        from sherpa.astro.data import DataARF
-
-        table = self.to_table()
-        return DataARF(
-            name=name,
-            energ_lo=table["ENERG_LO"].quantity.to_value("keV"),
-            energ_hi=table["ENERG_HI"].quantity.to_value("keV"),
-            specresp=table["SPECRESP"].quantity.to_value("cm2"),
-        )
-
 
 class EffectiveAreaTable2D:
     """2D effective area table.

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -536,52 +536,6 @@ class EnergyDispersion:
 
         return var / norm
 
-    def to_sherpa(self, name):
-        """Convert to `sherpa.astro.data.DataRMF`.
-
-        Parameters
-        ----------
-        name : str
-            Instance name
-        """
-        from sherpa.astro.data import DataRMF
-        from sherpa.utils import SherpaUInt, SherpaFloat
-
-        # Need to modify RMF data
-        # see https://github.com/sherpa/sherpa/blob/master/sherpa/astro/io/pyfits_backend.py#L727
-
-        table = self.to_table()
-        n_grp = table["N_GRP"].data.astype(SherpaUInt)
-        f_chan = table["F_CHAN"].data
-        n_chan = table["N_CHAN"].data
-        matrix = table["MATRIX"].data
-
-        good = n_grp > 0
-        matrix = matrix[good]
-        matrix = np.concatenate([row for row in matrix])
-        matrix = matrix.astype(SherpaFloat)
-
-        good = n_grp > 0
-        f_chan = f_chan[good]
-        f_chan = np.concatenate([row for row in f_chan]).astype(SherpaUInt)
-        n_chan = n_chan[good]
-        n_chan = np.concatenate([row for row in n_chan]).astype(SherpaUInt)
-
-        energy = self.e_reco.edges.to_value("keV")
-        return DataRMF(
-            name=name,
-            energ_lo=table["ENERG_LO"].quantity.to_value("keV").astype(SherpaFloat),
-            energ_hi=table["ENERG_HI"].quantity.to_value("keV").astype(SherpaFloat),
-            matrix=matrix,
-            n_grp=n_grp,
-            n_chan=n_chan,
-            f_chan=f_chan,
-            detchans=self.e_reco.nbin,
-            e_min=energy[:-1],
-            e_max=energy[1:],
-            offset=0,
-        )
-
     def plot_matrix(self, ax=None, show_energy=None, add_cbar=False, **kwargs):
         """Plot PDF matrix.
 


### PR DESCRIPTION
This PR remove the `EnergyDispersion.to_sherpa()` and `EffectiveAreaTable.to_sherpa()` methods. The were untested and not documented. Our current tutorials show the approach to write the data to disk in a sherpa compatible format and also show how to read it back using sherpa. I think that's the much clearer and consistent interface for now. So I decided to remove it.