### PR TITLE
Add maxsize limit to lru_cache()

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -79,6 +79,9 @@ class MapDatasetMaker:
         self.cutout_width = 2 * self.offset_max
         self.cutout = cutout
 
+        # define cached methods
+        self.make_exposure_irf = lru_cache(maxsize=1)(self.make_exposure_irf)
+
     def _cutout_geom(self, geom, observation):
         if self.cutout:
             return geom.cutout(
@@ -164,7 +167,6 @@ class MapDatasetMaker:
             geom=geom,
         )
 
-    @lru_cache(maxsize=1)
     def make_exposure_irf(self, observation):
         """Make exposure map with irf geometry.
 
@@ -274,7 +276,6 @@ class MapDatasetMaker:
             exposure_map=exposure,
         )
 
-    @lru_cache(maxsize=1)
     def make_mask_safe(self, observation):
         """Make offset mask.
 
@@ -293,7 +294,6 @@ class MapDatasetMaker:
         data = offset >= self.offset_max
         return Map.from_geom(geom, data=data)
 
-    @lru_cache(maxsize=1)
     def make_mask_safe_irf(self, observation):
         """Make offset mask with irf geometry.
 

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -251,9 +251,26 @@ def test_wcsgeom_get_coord():
     assert_allclose(coord.lat[0, 0].value, -1.5)
     assert coord.lat[0, 0].unit == "deg"
 
-    coord_cached = geom.get_coord(mode="edges")
-    # test coord caching
-    assert id(coord) == id(coord_cached)
+
+def test_wcsgeom_instance_cache():
+    geom_1 = WcsGeom.create(npix=(3, 3))
+    geom_2 = WcsGeom.create(npix=(3, 3))
+
+    coord_1, coord_2 = geom_1.get_coord(), geom_2.get_coord()
+
+    assert geom_1.get_coord.cache_info().misses == 1
+    assert geom_2.get_coord.cache_info().misses == 1
+
+    coord_1_cached, coord_2_cached = geom_1.get_coord(), geom_2.get_coord()
+
+    assert geom_1.get_coord.cache_info().hits == 1
+    assert geom_2.get_coord.cache_info().hits == 1
+
+    assert geom_1.get_coord.cache_info().currsize == 1
+    assert geom_2.get_coord.cache_info().currsize == 1
+
+    assert id(coord_1) == id(coord_1_cached)
+    assert id(coord_2) == id(coord_2_cached)
 
 
 def test_wcsgeom_get_pix_coords():

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -546,7 +546,7 @@ class WcsGeom(Geom):
         else:
             return int(self.npix[0][idx]), int(self.npix[1][idx])
 
-    @lru_cache()
+    @lru_cache(maxsize=5)
     def get_idx(self, idx=None, flat=False):
         pix = self.get_pix(idx=idx, mode="center")
         if flat:
@@ -573,7 +573,7 @@ class WcsGeom(Geom):
         pix = np.meshgrid(*pix[::-1], indexing="ij")[::-1]
         return pix
 
-    @lru_cache()
+    @lru_cache(maxsize=5)
     def get_pix(self, idx=None, mode="center"):
         """Get map pix coordinates from the geometry.
 
@@ -594,7 +594,7 @@ class WcsGeom(Geom):
             _[~m] = INVALID_INDEX.float
         return pix
 
-    @lru_cache()
+    @lru_cache(maxsize=5)
     def get_coord(self, idx=None, flat=False, mode="center", coordsys=None):
         """Get map coordinates from the geometry.
 
@@ -699,7 +699,7 @@ class WcsGeom(Geom):
         idx = self.coord_to_idx(coords)
         return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
 
-    @lru_cache()
+    @lru_cache(maxsize=5)
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
@@ -807,7 +807,7 @@ class WcsGeom(Geom):
             axes=copy.deepcopy(self.axes),
         )
 
-    @lru_cache()
+    @lru_cache(maxsize=5)
     def solid_angle(self):
         """Solid angle array (`~astropy.units.Quantity` in ``sr``).
 
@@ -845,7 +845,7 @@ class WcsGeom(Geom):
 
         return u.Quantity(area_low_right + area_up_left, "sr", copy=False)
 
-    @lru_cache()
+    @lru_cache(maxsize=5)
     def bin_volume(self):
         """Bin volume (`~astropy.units.Quantity`)"""
         bin_volume = self.to_image().solid_angle()

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -208,6 +208,12 @@ class WcsGeom(Geom):
         self._crpix = crpix
         self._cutout_info = cutout_info
 
+        # define cached methods
+        self.get_coord = lru_cache()(self.get_coord)
+        self.solid_angle = lru_cache()(self.solid_angle)
+        self.bin_volume = lru_cache()(self.bin_volume)
+        self.to_image = lru_cache()(self.to_image)
+
     @property
     def data_shape(self):
         """Shape of the Numpy data array matching this geometry."""
@@ -546,7 +552,6 @@ class WcsGeom(Geom):
         else:
             return int(self.npix[0][idx]), int(self.npix[1][idx])
 
-    @lru_cache(maxsize=5)
     def get_idx(self, idx=None, flat=False):
         pix = self.get_pix(idx=idx, mode="center")
         if flat:
@@ -573,7 +578,6 @@ class WcsGeom(Geom):
         pix = np.meshgrid(*pix[::-1], indexing="ij")[::-1]
         return pix
 
-    @lru_cache(maxsize=5)
     def get_pix(self, idx=None, mode="center"):
         """Get map pix coordinates from the geometry.
 
@@ -594,7 +598,6 @@ class WcsGeom(Geom):
             _[~m] = INVALID_INDEX.float
         return pix
 
-    @lru_cache(maxsize=5)
     def get_coord(self, idx=None, flat=False, mode="center", coordsys=None):
         """Get map coordinates from the geometry.
 
@@ -699,7 +702,6 @@ class WcsGeom(Geom):
         idx = self.coord_to_idx(coords)
         return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
 
-    @lru_cache(maxsize=5)
     def to_image(self):
         npix = (np.max(self._npix[0]), np.max(self._npix[1]))
         cdelt = (np.max(self._cdelt[0]), np.max(self._cdelt[1]))
@@ -807,7 +809,6 @@ class WcsGeom(Geom):
             axes=copy.deepcopy(self.axes),
         )
 
-    @lru_cache(maxsize=5)
     def solid_angle(self):
         """Solid angle array (`~astropy.units.Quantity` in ``sr``).
 
@@ -845,7 +846,6 @@ class WcsGeom(Geom):
 
         return u.Quantity(area_low_right + area_up_left, "sr", copy=False)
 
-    @lru_cache(maxsize=5)
     def bin_volume(self):
         """Bin volume (`~astropy.units.Quantity`)"""
         bin_volume = self.to_image().solid_angle()


### PR DESCRIPTION
This PR defines the `maxsize` parameter in the `lru_cache()` we use in `WcsGeom` to fix a memory leak reported by Aion Viana in private and confirmed by the first benchmarks of e.g. [maps_3d](https://github.com/gammapy/gammapy-benchmarks/blob/master/benchmarks/results/maps_3d/0.15.dev373%2Bg74763d09f/2019-10-31/results.png).

The memory leak was due to a misunderstanding from my side of the `maxsize` parameter and the `lru_cache()` in general. The `lru_cache()` acts on the class level and not the instance level, this means the `maxsize` parameter refers to the last recent calls on the class level (i.e. across all instances). This also means that even if an instance of `WcsGeom` goes out of scope, the cache is still kept if `maxsize=None`. I now changed `maxsize` to the typical number of `WcsGeom` objects involved in the data reduction, so the cache is cleared after 5 independent calls. I already re-run the benchmarks and now the results look as expected:
- [maps_3d](https://github.com/gammapy/gammapy-benchmarks/blob/master/benchmarks/results/maps_3d/0.15.dev491%2Bg955a692a6.d20191108/2019-11-08/results.png)
- [spectrum_1d](https://github.com/gammapy/gammapy-benchmarks/blob/master/benchmarks/results/spectrum_1d/0.15.dev491%2Bg955a692a6.d20191108/2019-11-08/results.png)

In general it's not ideal that `lru_cache()` acts on the class level, because you have to limit the `maxsize` to prevent memory leaks, and this also means, that the caching behaviour depends on the number of instances of `WcsGeom` and previous calls to cached methods the user has done in the same process. On the other hand right now the `lru_cache` is not critical for performance of the data reduction and could be also removed. Pragmatically I would say as a users it's still better to get the faster performance of `.get_coord()` in most cases then never. 