### PR TITLE
Improve SkyModels and Datasets

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -174,11 +174,9 @@ class Analysis:
             if isinstance(dataset, MapDataset):
                 dataset.model = self.model
             else:
-                if len(self.model.skymodels) > 1:
-                    raise ValueError(
-                        "Can only fit a single spectral model at one time."
-                    )
-                dataset.model = self.model.skymodels[0].spectral_model
+                if len(self.model) > 1:
+                    raise ValueError("Cannot fit multiple spectral models")
+                dataset.model = self.model[0].spectral_model
         log.info(self.model)
 
     def run_fit(self, optimize_opts=None):

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -170,7 +170,7 @@ class Analysis:
         else:
             return False
         # TODO: Deal with multiple components
-        for dataset in self.datasets.datasets:
+        for dataset in self.datasets:
             if isinstance(dataset, MapDataset):
                 dataset.model = self.model
             else:
@@ -184,7 +184,7 @@ class Analysis:
         if not self._validate_fitting_settings():
             return False
 
-        for ds in self.datasets.datasets:
+        for ds in self.datasets:
             # TODO: fit_range handled in jsonschema validation class
             if "fit" in self.settings and "fit_range" in self.settings["fit"]:
                 e_min = u.Quantity(self.settings["fit"]["fit_range"]["min"])
@@ -359,7 +359,7 @@ class Analysis:
             return False
 
     def _validate_set_model(self):
-        if self.datasets and self.datasets.datasets:
+        if self.datasets and len(self.datasets) != 0:
             self.config.validate()
             return True
         else:

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -151,7 +151,7 @@ def test_analysis_1d(config_analysis_data):
     analysis.run_fit()
     analysis.get_flux_points()
 
-    assert len(analysis.datasets.datasets) == 2
+    assert len(analysis.datasets) == 2
     assert len(analysis.flux_points.data.table) == 4
     dnde = analysis.flux_points.data.table["dnde"].quantity
     assert dnde.unit == "cm-2 s-1 TeV-1"
@@ -171,7 +171,7 @@ def test_analysis_1d_stacked():
     analysis.set_model(filename=MODEL_FILE)
     analysis.run_fit()
 
-    assert len(analysis.datasets.datasets) == 1
+    assert len(analysis.datasets) == 1
     assert_allclose(analysis.datasets["stacked"].counts.data.sum(), 404)
     pars = analysis.fit_result.parameters
 
@@ -191,7 +191,7 @@ def test_analysis_3d():
     analysis.run_fit()
     analysis.get_flux_points()
 
-    assert len(analysis.datasets.datasets) == 1
+    assert len(analysis.datasets) == 1
     assert len(analysis.fit_result.parameters) == 8
     res = analysis.fit_result.parameters
     assert res[3].unit == "cm-2 s-1 TeV-1"
@@ -211,7 +211,7 @@ def test_analysis_3d_joint_datasets():
     analysis = Analysis(config)
     analysis.get_observations()
     analysis.get_datasets()
-    assert len(analysis.datasets.datasets) == 4
+    assert len(analysis.datasets) == 4
 
 
 def test_validate_astropy_quantities():
@@ -243,7 +243,7 @@ def test_analysis_3d_no_geom_irf():
     analysis.get_observations()
     analysis.get_datasets()
 
-    assert len(analysis.datasets.datasets) == 1
+    assert len(analysis.datasets) == 1
 
 
 @requires_dependency("iminuit")

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -3,8 +3,8 @@ from pathlib import Path
 import pytest
 from numpy.testing import assert_allclose
 import yaml
-from gammapy.modeling.models import SkyModels
 from gammapy.analysis import Analysis, AnalysisConfig
+from gammapy.modeling.models import SkyModels
 from gammapy.utils.testing import requires_data, requires_dependency
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -103,12 +103,11 @@ class TestSourceCatalogGammaCat:
             assert cat[name].name == name
 
     def test_to_sky_models(self, gammacat):
-        sources = gammacat.to_sky_models()
-        source = sources.skymodels[0]
+        models = gammacat.to_sky_models()
 
-        assert len(sources.skymodels) == 74
-        assert source.name == "CTA 1"
-        assert_allclose(source.spectral_model.parameters["index"].value, 2.2)
+        assert len(models) == 74
+        assert models[0].name == "CTA 1"
+        assert_allclose(models[0].spectral_model.parameters["index"].value, 2.2)
 
 
 @requires_data()

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -212,15 +212,15 @@ class TestSourceCatalogObjectHGPS:
 
     @staticmethod
     def test_sky_model_gaussian2(cat):
-        model = cat["HESS J1843-033"].sky_model()
+        models = cat["HESS J1843-033"].sky_model()
 
-        p = model.skymodels[0].parameters
+        p = models[0].parameters
         assert_allclose(p["amplitude"].value, 4.259815e-13, rtol=1e-5)
         assert_allclose(p["lon_0"].value, 29.047216415405273)
         assert_allclose(p["lat_0"].value, 0.24389676749706268)
         assert_allclose(p["sigma"].value, 0.12499100714921951)
 
-        p = model.skymodels[1].parameters
+        p = models[1].parameters
         assert_allclose(p["amplitude"].value, 4.880365e-13, rtol=1e-5)
         assert_allclose(p["lon_0"].value, 28.77037811279297)
         assert_allclose(p["lat_0"].value, -0.0727819949388504)
@@ -228,21 +228,21 @@ class TestSourceCatalogObjectHGPS:
 
     @staticmethod
     def test_sky_model_gaussian3(cat):
-        model = cat["HESS J1825-137"].sky_model()
+        models = cat["HESS J1825-137"].sky_model()
 
-        p = model.skymodels[0].parameters
+        p = models[0].parameters
         assert_allclose(p["amplitude"].value, 1.8952104218765842e-11)
         assert_allclose(p["lon_0"].value, 16.988601684570312)
         assert_allclose(p["lat_0"].value, -0.4913068115711212)
         assert_allclose(p["sigma"].value, 0.47650089859962463)
 
-        p = model.skymodels[1].parameters
+        p = models[1].parameters
         assert_allclose(p["amplitude"].value, 4.4639763971527836e-11)
         assert_allclose(p["lon_0"].value, 17.71169090270996)
         assert_allclose(p["lat_0"].value, -0.6598004102706909)
         assert_allclose(p["sigma"].value, 0.3910967707633972)
 
-        p = model.skymodels[2].parameters
+        p = models[2].parameters
         assert_allclose(p["amplitude"].value, 5.870712920658374e-12)
         assert_allclose(p["lon_0"].value, 17.840524673461914)
         assert_allclose(p["lat_0"].value, -0.7057178020477295)

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -171,7 +171,7 @@ class MapDataset(Dataset):
         # model section
         n_models = 0
         if self.model is not None:
-            n_models = len(self.model.skymodels)
+            n_models = len(self.model)
         str_ += "\t{:32}: {} \n".format("Number of models", n_models)
 
         str_ += "\t{:32}: {}\n".format("Number of parameters", len(self.parameters))
@@ -182,7 +182,7 @@ class MapDataset(Dataset):
         components = []
 
         if self.model is not None:
-            components += self.model.skymodels
+            components += self.model
 
         if self.background_model is not None:
             components += [self.background_model]
@@ -225,7 +225,7 @@ class MapDataset(Dataset):
         if model is not None:
             evaluators = []
 
-            for component in model.skymodels:
+            for component in model:
                 evaluator = MapEvaluator(
                     component, evaluation_mode=self.evaluation_mode
                 )

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -778,7 +778,7 @@ class MapDataset(Dataset):
             "name": self.name,
             "type": self.tag,
             "likelihood": self.likelihood_type,
-            "models": self.model.names,
+            "models": [_.name for _ in self.model],
             "background": self.background_model.name,
             "filename": str(filename),
         }

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1019,7 +1019,7 @@ class MapDatasetOnOff(MapDataset):
         parameters = []
 
         if self.model:
-            parameters += self.model.parameters.parameters
+            parameters += self.model.parameters
 
         return Parameters(parameters)
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -121,9 +121,7 @@ class MapDatasetMaker:
     @lazyproperty
     def geom_edisp(self):
         """EdispMap geom (`Geom`)"""
-        return self.geom_image_irf.to_cube(
-            [self.migra_axis, self.energy_axis_true]
-        )
+        return self.geom_image_irf.to_cube([self.migra_axis, self.energy_axis_true])
 
     def make_counts(self, observation):
         """Make counts map.

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -353,7 +353,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     # test model evaluation outside image
 
-    dataset_1.model.skymodels[0].spatial_model.lon_0.value = 150
+    dataset_1.model[0].spatial_model.lon_0.value = 150
     dataset_1.npred()
     assert not dataset_1._evaluators[0].contributes
 

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -106,23 +106,18 @@ class Datasets:
         Duplicate parameter objects have been removed.
         The order of the unique parameters remains.
         """
-        parameters = Parameters.from_stack(_.parameters for _ in self.datasets)
+        parameters = Parameters.from_stack(_.parameters for _ in self)
         return parameters.unique_parameters
 
     @property
     def names(self):
         """List of dataset names"""
-        return [_.name for _ in self.datasets]
-
-    @property
-    def datasets(self):
-        """List of datasets"""
-        return self._datasets
+        return [_.name for _ in self]
 
     @property
     def types(self):
         """Types of the contained datasets"""
-        return [type(dataset).__name__ for dataset in self.datasets]
+        return [type(dataset).__name__ for dataset in self]
 
     @property
     def is_all_same_type(self):
@@ -132,15 +127,15 @@ class Datasets:
     @property
     def is_all_same_shape(self):
         """Whether all contained datasets have the same data shape"""
-        ref_shape = self.datasets[0].data_shape
-        is_ref_shape = [dataset.data_shape == ref_shape for dataset in self.datasets]
+        ref_shape = self._datasets[0].data_shape
+        is_ref_shape = [dataset.data_shape == ref_shape for dataset in self]
         return np.all(is_ref_shape)
 
     def likelihood(self):
         """Compute joint likelihood"""
         total_likelihood = 0
         # TODO: add parallel evaluation of likelihoods
-        for dataset in self.datasets:
+        for dataset in self:
             total_likelihood += dataset.likelihood()
         return total_likelihood
 
@@ -198,9 +193,7 @@ class Datasets:
 
         path = make_path(path)
 
-        datasets_dict, components_dict = datasets_to_dict(
-            self.datasets, path, prefix, overwrite
-        )
+        datasets_dict, components_dict = datasets_to_dict(self, path, prefix, overwrite)
         write_yaml(datasets_dict, path / f"{prefix}_datasets.yaml", sort_keys=False)
         write_yaml(components_dict, path / f"{prefix}_models.yaml", sort_keys=False)
 
@@ -220,8 +213,8 @@ class Datasets:
                 "Stacking impossible: all Datasets contained are not of a unique type."
             )
 
-        dataset = self.datasets[0].copy()
-        for ds in self.datasets[1:]:
+        dataset = self[0].copy()
+        for ds in self[1:]:
             dataset.stack(ds)
         return dataset
 
@@ -241,11 +234,11 @@ class Datasets:
         if not self.is_all_same_type:
             raise ValueError("Info table not supported for mixed dataset type.")
 
-        stacked = self.datasets[0].copy()
+        stacked = self[0].copy()
 
         rows = [stacked.info_dict()]
 
-        for dataset in self.datasets[1:]:
+        for dataset in self[1:]:
             if cumulative:
                 stacked.stack(dataset)
                 row = stacked.info_dict()
@@ -256,7 +249,16 @@ class Datasets:
 
         return table_from_row_data(rows=rows)
 
-    def __getitem__(self, item):
-        if isinstance(item, str):
-            item = self.names.index(item)
-        return self.datasets[item]
+    def __getitem__(self, val):
+        if isinstance(val, (int, slice)):
+            return self._datasets[val]
+        elif isinstance(val, str):
+            for idx, dataset in enumerate(self._datasets):
+                if val == dataset.name:
+                    return self._datasets[idx]
+            raise IndexError(f"No dataset: {val!r}")
+        else:
+            raise TypeError(f"Invalid type: {type(val)!r}")
+
+    def __len__(self):
+        return len(self._datasets)

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
 import copy
-from collections import Counter
 import numpy as np
 from gammapy.utils.scripts import make_path, read_yaml, write_yaml
 from gammapy.utils.table import table_from_row_data
@@ -110,26 +109,14 @@ class Datasets:
         return parameters.unique_parameters
 
     @property
-    def names(self):
-        """List of dataset names"""
-        return [_.name for _ in self]
-
-    @property
-    def types(self):
-        """Types of the contained datasets"""
-        return [type(dataset).__name__ for dataset in self]
-
-    @property
     def is_all_same_type(self):
         """Whether all contained datasets are of the same type"""
-        return np.all(np.array(self.types) == self.types[0])
+        return len(set(_.__class__ for _ in self)) == 1
 
     @property
     def is_all_same_shape(self):
         """Whether all contained datasets have the same data shape"""
-        ref_shape = self._datasets[0].data_shape
-        is_ref_shape = [dataset.data_shape == ref_shape for dataset in self]
-        return np.all(is_ref_shape)
+        return len(set(_.data_shape for _ in self)) == 1
 
     def likelihood(self):
         """Compute joint likelihood"""
@@ -141,12 +128,10 @@ class Datasets:
 
     def __str__(self):
         str_ = self.__class__.__name__ + "\n"
-        str_ += "--------\n\n"
+        str_ += "--------\n"
 
-        counter = Counter(self.types)
-
-        for key, value in counter.items():
-            str_ += f"\t{key}: {value} \n"
+        for dataset in self:
+            str_ += f"{dataset}\n"
 
         return str_
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -43,16 +43,6 @@ class SkyModels:
     """
 
     def __init__(self, skymodels):
-        existing_names = []
-
-        for model in skymodels:
-            if model.name in existing_names:
-                raise ValueError(
-                    f"SkyModel already exists: {model.name}\n"
-                    f"Please choose another name."
-                )
-            existing_names.append(model.name)
-
         self.skymodels = skymodels
 
     @property

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -99,6 +99,7 @@ class SkyModels:
     def __len__(self):
         return len(self._skymodels)
 
+
 class SkyModel(SkyModelBase):
     """Sky model component.
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -49,11 +49,6 @@ class SkyModels:
     def parameters(self):
         return Parameters.from_stack([_.parameters for _ in self.skymodels])
 
-    @property
-    def names(self):
-        """Sky model names"""
-        return [_.name for _ in self.skymodels]
-
     @classmethod
     def from_yaml(cls, filename):
         """Write to YAML file."""
@@ -84,15 +79,6 @@ class SkyModels:
 
         return str_
 
-    def __iadd__(self, skymodel):
-        if isinstance(skymodel, SkyModels):
-            self.skymodels += skymodel.skymodels
-        elif isinstance(skymodel, (SkyModel, SkyDiffuseCube)):
-            self.skymodels += [skymodel]
-        else:
-            raise NotImplementedError
-        return self
-
     def __add__(self, skymodel):
         skymodels = self.skymodels.copy()
         if isinstance(skymodel, SkyModels):
@@ -103,9 +89,16 @@ class SkyModels:
             raise NotImplementedError
         return SkyModels(skymodels)
 
-    def __getitem__(self, item):
-        idx = self.names.index(item)
-        return self.skymodels[idx]
+    def __getitem__(self, val):
+        if isinstance(val, int):
+            return self.skymodels[val]
+        elif isinstance(val, str):
+            for idx, model in enumerate(self.skymodels):
+                if val == model.name:
+                    return self.skymodels[idx]
+            raise IndexError(f"No model: {val!r}")
+        else:
+            raise TypeError(f"Invalid type: {type(val)!r}")
 
 
 class SkyModel(SkyModelBase):

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -115,29 +115,29 @@ def test_sky_model_init():
 
 
 def test_skymodel_addition(sky_model, sky_models, sky_models_2, diffuse_model):
-    result = sky_model + sky_model.copy()
-    assert isinstance(result, SkyModels)
-    assert len(result.skymodels) == 2
+    models = sky_model + sky_model.copy()
+    assert isinstance(models, SkyModels)
+    assert len(models) == 2
 
-    result = sky_model + sky_models
-    assert isinstance(result, SkyModels)
-    assert len(result.skymodels) == 3
+    models = sky_model + sky_models
+    assert isinstance(models, SkyModels)
+    assert len(models) == 3
 
-    result = sky_models + sky_model
-    assert isinstance(result, SkyModels)
-    assert len(result.skymodels) == 3
+    models = sky_models + sky_model
+    assert isinstance(models, SkyModels)
+    assert len(models) == 3
 
-    result = sky_models + diffuse_model
-    assert isinstance(result, SkyModels)
-    assert len(result.skymodels) == 3
+    models = sky_models + diffuse_model
+    assert isinstance(models, SkyModels)
+    assert len(models) == 3
 
-    result = sky_models + sky_models_2
-    assert isinstance(result, SkyModels)
-    assert len(result.skymodels) == 4
+    models = sky_models + sky_models_2
+    assert isinstance(models, SkyModels)
+    assert len(models) == 4
 
-    result = sky_model + sky_models
-    assert isinstance(result, SkyModels)
-    assert len(result.skymodels) == 3
+    models = sky_model + sky_models
+    assert isinstance(models, SkyModels)
+    assert len(models) == 3
 
 
 def test_background_model(background):
@@ -169,7 +169,7 @@ class TestSkyModels:
 
         # Check that model parameters are references to the parts
         p1 = sky_models.parameters["lon_0"]
-        p2 = sky_models.skymodels[0].parameters["lon_0"]
+        p2 = sky_models[0].parameters["lon_0"]
         assert p1 is p2
 
     @staticmethod

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -197,10 +197,8 @@ class TestSkyModels:
         model = sky_models["source-3"]
         assert model.name == "source-3"
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(IndexError):
             sky_models["spam"]
-
-        assert "'spam' is not in list" == str(excinfo.value)
 
 
 class TestSkyModel:

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -126,14 +126,14 @@ def datasets_to_dict(datasets, path, prefix, overwrite):
         dataset.write(filename, overwrite)
         datasets_dictlist.append(dataset.to_dict(filename=filename))
 
-        for model in dataset.model.skymodels:
+        for model in dataset.model:
             if model not in unique_models:
                 unique_models.append(model)
 
         try:
             if dataset.background_model not in unique_backgrounds:
                 unique_backgrounds.append(dataset.background_model)
-        except (AttributeError):
+        except AttributeError:
             pass
 
     datasets_dict = {"datasets": datasets_dictlist}

--- a/gammapy/modeling/tests/data/make.py
+++ b/gammapy/modeling/tests/data/make.py
@@ -112,7 +112,7 @@ def make_datasets_example():
 
     datasets = Datasets(datasets_list)
 
-    dataset0 = datasets.datasets[0]
+    dataset0 = datasets[0]
     print("dataset0")
     print("counts sum : ", dataset0.counts.data.sum())
     print("expo sum : ", dataset0.exposure.data.sum())

--- a/gammapy/modeling/tests/test_datasets.py
+++ b/gammapy/modeling/tests/test_datasets.py
@@ -22,7 +22,7 @@ class TestDatasets:
 
     @staticmethod
     def test_str(datasets):
-        assert "MyDataset: 2" in str(datasets)
+        assert "Datasets" in str(datasets)
 
     @staticmethod
     def test_getitem(datasets):

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -106,10 +106,10 @@ def test_datasets_to_io(tmp_path):
 
     datasets = Datasets.from_yaml(filedata, filemodel)
 
-    assert len(datasets.datasets) == 2
+    assert len(datasets) == 2
     assert len(datasets.parameters) == 20
 
-    dataset0 = datasets.datasets[0]
+    dataset0 = datasets[0]
     assert dataset0.counts.data.sum() == 6824
     assert_allclose(dataset0.exposure.data.sum(), 2072125400000.0, atol=0.1)
     assert dataset0.psf is not None
@@ -119,7 +119,7 @@ def test_datasets_to_io(tmp_path):
 
     assert dataset0.background_model.name == "background_irf_gc"
 
-    dataset1 = datasets.datasets[1]
+    dataset1 = datasets[1]
     assert dataset1.background_model.name == "background_irf_g09"
 
     assert dataset0.model["gll_iem_v06_cutout"] == dataset1.model["gll_iem_v06_cutout"]
@@ -140,8 +140,8 @@ def test_datasets_to_io(tmp_path):
     datasets_read = Datasets.from_yaml(
         tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
     )
-    assert len(datasets_read.datasets) == 2
-    dataset0 = datasets_read.datasets[0]
+    assert len(datasets_read) == 2
+    dataset0 = datasets_read[0]
     assert dataset0.counts.data.sum() == 6824
     assert_allclose(dataset0.exposure.data.sum(), 2072125400000.0, atol=0.1)
     assert dataset0.psf is not None

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -134,9 +134,7 @@ def test_datasets_to_io(tmp_path):
         is dataset1.model[1].parameters["reference"]
     )
 
-    assert_allclose(
-        dataset1.model[1].parameters["lon_0"].value, 0.9, atol=0.1
-    )
+    assert_allclose(dataset1.model[1].parameters["lon_0"].value, 0.9, atol=0.1)
 
     datasets.to_yaml(tmp_path, prefix="written")
     datasets_read = Datasets.from_yaml(

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -125,17 +125,17 @@ def test_datasets_to_io(tmp_path):
     assert dataset0.model["gll_iem_v06_cutout"] == dataset1.model["gll_iem_v06_cutout"]
 
     assert isinstance(dataset0.model, SkyModels)
-    assert len(dataset0.model.skymodels) == 2
-    assert dataset0.model.skymodels[0].name == "gc"
-    assert dataset0.model.skymodels[1].name == "gll_iem_v06_cutout"
+    assert len(dataset0.model) == 2
+    assert dataset0.model[0].name == "gc"
+    assert dataset0.model[1].name == "gll_iem_v06_cutout"
 
     assert (
-        dataset0.model.skymodels[0].parameters["reference"]
-        is dataset1.model.skymodels[1].parameters["reference"]
+        dataset0.model[0].parameters["reference"]
+        is dataset1.model[1].parameters["reference"]
     )
 
     assert_allclose(
-        dataset1.model.skymodels[1].parameters["lon_0"].value, 0.9, atol=0.1
+        dataset1.model[1].parameters["lon_0"].value, 0.9, atol=0.1
     )
 
     datasets.to_yaml(tmp_path, prefix="written")

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1237,7 +1237,7 @@ class FluxPointsDataset(Dataset):
         return {
             "name": self.name,
             "type": self.tag,
-            "models": self.model.names,
+            "models": [_.name for _ in self.model],
             "likelihood": self.likelihood_type,
             "filename": str(filename),
         }

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -790,7 +790,7 @@ class FluxPointsEstimator:
         self.datasets = datasets.copy()
         self.e_edges = e_edges
 
-        dataset = self.datasets.datasets[0]
+        dataset = self.datasets[0]
 
         if isinstance(dataset, SpectrumDatasetOnOff):
             model = dataset.model
@@ -826,14 +826,14 @@ class FluxPointsEstimator:
 
         counts_all = self.estimate_counts()["counts"]
 
-        for counts, dataset in zip(counts_all, self.datasets.datasets):
+        for counts, dataset in zip(counts_all, self.datasets):
             if isinstance(dataset, MapDataset) and counts == 0:
                 if dataset.background_model is not None:
                     dataset.background_model.parameters.freeze_all()
 
     def _set_scale_model(self):
         # set the model on all datasets
-        for dataset in self.datasets.datasets:
+        for dataset in self.datasets:
             if isinstance(dataset, SpectrumDatasetOnOff):
                 dataset.model = self.model
             else:
@@ -846,7 +846,7 @@ class FluxPointsEstimator:
     @property
     def e_groups(self):
         """Energy grouping table `~astropy.table.Table`"""
-        dataset = self.datasets.datasets[0]
+        dataset = self.datasets[0]
         if isinstance(dataset, SpectrumDatasetOnOff):
             energy_axis = dataset.counts.energy
         else:
@@ -926,7 +926,7 @@ class FluxPointsEstimator:
         }
         contribute_to_likelihood = False
 
-        for dataset in self.datasets.datasets:
+        for dataset in self.datasets:
             dataset.mask_fit = self._energy_mask(e_group=e_group, dataset=dataset)
             mask = dataset.mask_fit
 
@@ -1014,7 +1014,7 @@ class FluxPointsEstimator:
             Dict with an array with one entry per dataset with counts for the flux point.
         """
         counts = []
-        for dataset in self.datasets.datasets:
+        for dataset in self.datasets:
             mask = dataset.mask_fit
             if dataset.mask_safe is not None:
                 mask &= dataset.mask_safe

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -268,7 +268,7 @@ def test_flux_point_dataset_serialization(tmp_path):
     datasets = Datasets.from_yaml(
         tmp_path / "tmp_datasets.yaml", tmp_path / "tmp_models.yaml"
     )
-    new_dataset = datasets.datasets[0]
+    new_dataset = datasets[0]
     assert_allclose(new_dataset.data.table["dnde"], dataset.data.table["dnde"], 1e-4)
     if dataset.mask_fit is None:
         assert np.all(new_dataset.mask_fit == dataset.mask_safe)
@@ -332,7 +332,7 @@ class TestFluxPointFit:
     @staticmethod
     @requires_dependency("matplotlib")
     def test_fp_dataset_peek(fit):
-        fp_dataset = fit.datasets.datasets[0]
+        fp_dataset = fit.datasets[0]
 
         with mpl_plot_check():
             fp_dataset.peek(method="diff/model")

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -61,7 +61,7 @@ class LightCurveEstimator:
                 " of the same type and data shape."
             )
 
-        dataset = self.datasets.datasets[0]
+        dataset = self.datasets[0]
 
         if isinstance(dataset, SpectrumDatasetOnOff):
             model = dataset.model
@@ -88,7 +88,7 @@ class LightCurveEstimator:
 
     def _set_scale_model(self):
         # set the model on all datasets
-        for dataset in self.datasets.datasets:
+        for dataset in self.datasets:
             if isinstance(dataset, SpectrumDatasetOnOff):
                 dataset.model = self.model
             else:
@@ -132,7 +132,7 @@ class LightCurveEstimator:
         self.e_max = e_max
 
         rows = []
-        for dataset in self.datasets.datasets:
+        for dataset in self.datasets:
             row = {
                 "time_min": dataset.counts.meta["t_start"].mjd,
                 "time_max": dataset.counts.meta["t_stop"].mjd,

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -24,7 +24,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#%load_ext nb_black\n",
     "import os\n",
     "import numpy as np\n",
     "from astropy import units as u\n",
@@ -166,7 +165,7 @@
     "filedata = Path(path + \"_datasets.yaml\")\n",
     "filemodel = Path(path + \"_models.yaml\")\n",
     "datasets = Datasets.from_yaml(filedata=filedata, filemodel=filemodel)\n",
-    "dataset_fermi = datasets.datasets[0]"
+    "dataset_fermi = datasets[0]"
    ]
   },
   {
@@ -184,7 +183,7 @@
    "source": [
     "crab_spec = [\n",
     "    model.spectral_model\n",
-    "    for model in dataset_fermi.model.skymodels\n",
+    "    for model in dataset_fermi.model\n",
     "    if model.name == \"Crab Nebula\"\n",
     "][0]\n",
     "\n",
@@ -349,9 +348,7 @@
     "# display spectrum and flux points\n",
     "energy_range = [0.01, 120] * u.TeV\n",
     "plt.figure(figsize=(8, 6))\n",
-    "ax = crab_spec.plot(\n",
-    "    energy_range=energy_range, energy_power=2, label=\"Fitted log-parabola\"\n",
-    ")\n",
+    "ax = crab_spec.plot(energy_range=energy_range, energy_power=2, label=\"Model\")\n",
     "crab_spec.plot_error(ax=ax, energy_range=energy_range, energy_power=2)\n",
     "flux_points_fermi.plot(ax=ax, energy_power=2, label=\"Fermi-LAT\")\n",
     "flux_points_hess.plot(ax=ax, energy_power=2, label=\"HESS\")\n",
@@ -363,7 +360,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## To go furher\n",
+    "## To go further\n",
     "\n",
     "More details on how to prepare datasets with the high and low level interfaces are available in these tutorials: \n",
     "- https://docs.gammapy.org/0.14/notebooks/fermi_lat.html\n",
@@ -399,5 +396,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -322,7 +322,7 @@
     "\n",
     "        # set model parameters\n",
     "        par_to_model(dataset, pars)\n",
-    "        spectral_model = dataset.model.skymodels[0].spectral_model\n",
+    "        spectral_model = dataset.model[0].spectral_model\n",
     "\n",
     "        spectral_model.plot(\n",
     "            energy_range=(emin, emax),\n",


### PR DESCRIPTION
This PR improves the `SkyModels` and `Datasets` containers by making their internal list representation private and only offering a minimal API. This is required to achieve internal consistency between the models/datasets and parameter/covariance attributes, and possibly name uniqueness checks (see #2517). If the Python list `sky_models.sky_models` is accessed from outside, users can do whatever they like, and we have no chance of keeping a `sky_models.parameters` in sync.

I've removed the `names` check in `SkyModels.__init__` for now. We can add it back with tests (there wasn't any), and a better implementation that prints the object IDs and name of a duplicate entry. We could do it in `__init__`, or on `models.get("crab")`, i.e. only if someone used name-based access. Should be done in a consistent way for models and datasets.

The scope here is limited to cleanup - I'd prefer to merge this in soon, and then to send other PRs to implement #2517 and polish these classes.
