### PR TITLE
Fix Datasets vs Datasets confusion

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -375,7 +375,7 @@ def test_map_fit_one_energy_bin(sky_model, geom_image):
     sky_model.parameters["sigma"].value = 0.21
     dataset.background_model.parameters["norm"].frozen = True
 
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     result = fit.run()
 
     assert result.success
@@ -426,7 +426,6 @@ def test_create(geom, geom_etrue):
 
 
 def test_from_geoms():
-
     migra_axis = MapAxis(nodes=np.linspace(0.0, 3.0, 51), unit="", name="migra")
     rad_axis = MapAxis(nodes=np.linspace(0.0, 1.0, 51), unit="deg", name="theta")
     e_reco = MapAxis.from_edges(
@@ -460,7 +459,6 @@ def test_from_geoms():
 
 @requires_data()
 def test_stack(geom, geom_etrue):
-
     m = Map.from_geom(geom)
     m.quantity = 0.2 * np.ones(m.data.shape)
     background_model1 = BackgroundModel(m)

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -85,18 +85,21 @@ class Dataset(abc.ABC):
 
 
 class Datasets:
-    """Join multiple datasets.
+    """Dataset collection.
 
     Parameters
     ----------
     datasets : `Dataset` or list of `Dataset`
-        List of `Dataset` objects ot be joined.
+        Datasets
     """
 
     def __init__(self, datasets):
-        if not isinstance(datasets, list):
-            datasets = [datasets]
-        self._datasets = datasets
+        if isinstance(datasets, Datasets):
+            self._datasets = list(datasets)
+        elif isinstance(datasets, list):
+            self._datasets = datasets
+        else:
+            raise TypeError(f"Invalid type: {datasets!r}")
 
     @property
     def parameters(self):

--- a/gammapy/modeling/fit.py
+++ b/gammapy/modeling/fit.py
@@ -65,15 +65,12 @@ class Fit:
 
     Parameters
     ----------
-    datasets : `Dataset`, list of `Dataset` or `Datasets`
-        Dataset or joint datasets to be fitted.
+    datasets : `Datasets`
+        Datasets
     """
 
     def __init__(self, datasets):
-        if not isinstance(datasets, Datasets):
-            datasets = Datasets(datasets)
-
-        self.datasets = datasets
+        self.datasets = Datasets(datasets)
 
     @lazyproperty
     def _parameters(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -32,15 +32,18 @@ class SkyModelBase(Model):
 
 
 class SkyModels:
-    """Collection of `~gammapy.modeling.models.SkyModel`
+    """Sky model collection.
 
     Parameters
     ----------
-    skymodels : list of `~gammapy.modeling.models.SkyModel`
+    skymodels : list of `SkyModel`
         Sky models
     """
 
     def __init__(self, skymodels):
+        if not isinstance(skymodels, list):
+            raise TypeError(f"Not a list: {skymodels!r}")
+
         self._skymodels = skymodels
 
     @property

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -63,12 +63,6 @@ class SkyModels:
         components_dict = models_to_dict(self._skymodels)
         write_yaml(components_dict, filename, sort_keys=False)
 
-    def evaluate(self, lon, lat, energy):
-        out = self._skymodels[0].evaluate(lon, lat, energy)
-        for skymodel in self._skymodels[1:]:
-            out += skymodel.evaluate(lon, lat, energy)
-        return out
-
     def __str__(self):
         str_ = f"{self.__class__.__name__}\n\n"
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -173,18 +173,6 @@ class TestSkyModels:
         assert p1 is p2
 
     @staticmethod
-    def test_evaluate(sky_models):
-        lon = 3 * u.deg * np.ones(shape=(3, 4))
-        lat = 4 * u.deg * np.ones(shape=(3, 4))
-        energy = [1, 1, 1, 1, 1] * u.TeV
-
-        q = sky_models.evaluate(lon, lat, energy[:, np.newaxis, np.newaxis])
-
-        assert q.unit == "cm-2 s-1 TeV-1 sr-1"
-        assert q.shape == (5, 3, 4)
-        assert_allclose(q.to_value("cm-2 s-1 TeV-1 deg-2"), 3.53758465e-13)
-
-    @staticmethod
     def test_str(sky_models):
         assert "Component 0" in str(sky_models)
         assert "Component 1" in str(sky_models)

--- a/gammapy/modeling/tests/test_datasets.py
+++ b/gammapy/modeling/tests/test_datasets.py
@@ -11,8 +11,11 @@ def datasets():
 
 
 def test_datasets_init(datasets):
-    # Passing existing Datasets should work
-    d = Datasets(datasets)
+    # Passing a Python list of `Dataset` objects should work
+    Datasets(list(datasets))
+
+    # Passing an existing `Datasets` object should work
+    Datasets(datasets)
 
 
 def test_datasets_types(datasets):

--- a/gammapy/modeling/tests/test_datasets.py
+++ b/gammapy/modeling/tests/test_datasets.py
@@ -10,21 +10,24 @@ def datasets():
     return Datasets([MyDataset(name="test-1"), MyDataset(name="test-2")])
 
 
-class TestDatasets:
-    @staticmethod
-    def test_types(datasets):
-        assert datasets.is_all_same_type
+def test_datasets_init(datasets):
+    # Passing existing Datasets should work
+    d = Datasets(datasets)
 
-    @staticmethod
-    def test_likelihood(datasets):
-        likelihood = datasets.likelihood()
-        assert_allclose(likelihood, 0)
 
-    @staticmethod
-    def test_str(datasets):
-        assert "Datasets" in str(datasets)
+def test_datasets_types(datasets):
+    assert datasets.is_all_same_type
 
-    @staticmethod
-    def test_getitem(datasets):
-        assert datasets["test-1"].name == "test-1"
-        assert datasets["test-2"].name == "test-2"
+
+def test_datasets_likelihood(datasets):
+    likelihood = datasets.likelihood()
+    assert_allclose(likelihood, 0)
+
+
+def test_datasets_str(datasets):
+    assert "Datasets" in str(datasets)
+
+
+def test_datasets_getitem(datasets):
+    assert datasets["test-1"].name == "test-1"
+    assert datasets["test-2"].name == "test-2"

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -36,7 +36,7 @@ class MyDataset:
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_run(backend):
     dataset = MyDataset()
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     result = fit.run(
         optimize_opts={"backend": backend}, covariance_opts={"backend": backend}
     )
@@ -61,7 +61,7 @@ def test_run(backend):
 @pytest.mark.parametrize("backend", ["minuit", "sherpa", "scipy"])
 def test_optimize(backend):
     dataset = MyDataset()
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     result = fit.optimize(backend=backend)
     pars = dataset.parameters
 
@@ -81,7 +81,7 @@ def test_optimize(backend):
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_confidence(backend):
     dataset = MyDataset()
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     fit.optimize(backend=backend)
     result = fit.confidence("x")
 
@@ -97,7 +97,7 @@ def test_confidence(backend):
 def test_confidence_frozen(backend):
     dataset = MyDataset()
     dataset.parameters["x"].frozen = True
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     fit.optimize(backend=backend)
     result = fit.confidence("y")
 
@@ -108,7 +108,7 @@ def test_confidence_frozen(backend):
 
 def test_likelihood_profile():
     dataset = MyDataset()
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     fit.run()
     result = fit.likelihood_profile("x", nvalues=3)
 
@@ -121,7 +121,7 @@ def test_likelihood_profile():
 
 def test_likelihood_profile_reoptimize():
     dataset = MyDataset()
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     fit.run()
 
     dataset.parameters["y"].value = 0
@@ -134,7 +134,7 @@ def test_likelihood_profile_reoptimize():
 def test_minos_contour():
     dataset = MyDataset()
     dataset.parameters["x"].frozen = True
-    fit = Fit(dataset)
+    fit = Fit([dataset])
     fit.optimize(backend="minuit")
     result = fit.minos_contour("y", "z")
 

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -73,7 +73,7 @@ class TestSpectrumDataset:
 
     def test_cash(self):
         """Simple CASH fit to the on vector"""
-        fit = Fit(self.dataset)
+        fit = Fit([self.dataset])
         result = fit.run()
 
         assert result.success
@@ -464,9 +464,12 @@ class TestSpectralFit:
 
     def setup(self):
         path = "$GAMMAPY_DATA/joint-crab/spectra/hess/"
-        obs1 = SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23523.fits")
-        obs2 = SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23592.fits")
-        self.obs_list = [obs1, obs2]
+        self.obs_list = Datasets(
+            [
+                SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23523.fits"),
+                SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23592.fits"),
+            ]
+        )
 
         self.pwl = PowerLawSpectralModel(
             index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
@@ -481,7 +484,7 @@ class TestSpectralFit:
 
         # Example fit for one observation
         self.obs_list[0].model = self.pwl
-        self.fit = Fit(self.obs_list[0])
+        self.fit = Fit([self.obs_list[0]])
 
     def set_model(self, model):
         for obs in self.obs_list:
@@ -513,7 +516,7 @@ class TestSpectralFit:
 
     def test_ecpl_fit(self):
         self.set_model(self.ecpl)
-        fit = Fit(self.obs_list[0])
+        fit = Fit([self.obs_list[0]])
         fit.run()
 
         actual = fit.datasets.parameters["lambda_"].quantity

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -464,7 +464,7 @@ class TestSpectralFit:
 
     def setup(self):
         path = "$GAMMAPY_DATA/joint-crab/spectra/hess/"
-        self.obs_list = Datasets(
+        self.datasets = Datasets(
             [
                 SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23523.fits"),
                 SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23592.fits"),
@@ -483,11 +483,11 @@ class TestSpectralFit:
         )
 
         # Example fit for one observation
-        self.obs_list[0].model = self.pwl
-        self.fit = Fit([self.obs_list[0]])
+        self.datasets[0].model = self.pwl
+        self.fit = Fit([self.datasets[0]])
 
     def set_model(self, model):
-        for obs in self.obs_list:
+        for obs in self.datasets:
             obs.model = model
 
     @requires_dependency("iminuit")
@@ -496,13 +496,13 @@ class TestSpectralFit:
         result = self.fit.run()
         pars = self.fit.datasets.parameters
 
-        assert self.pwl is self.obs_list[0].model
+        assert self.pwl is self.datasets[0].model
 
         assert_allclose(result.total_stat, 38.343, rtol=1e-3)
         assert_allclose(pars["index"].value, 2.817, rtol=1e-3)
         assert pars["amplitude"].unit == "cm-2 s-1 TeV-1"
         assert_allclose(pars["amplitude"].value, 5.142e-11, rtol=1e-3)
-        assert_allclose(self.obs_list[0].npred().data[60], 0.6102, rtol=1e-3)
+        assert_allclose(self.datasets[0].npred().data[60], 0.6102, rtol=1e-3)
         pars.to_table()
 
     def test_basic_errors(self):
@@ -516,7 +516,7 @@ class TestSpectralFit:
 
     def test_ecpl_fit(self):
         self.set_model(self.ecpl)
-        fit = Fit([self.obs_list[0]])
+        fit = Fit([self.datasets[0]])
         fit.run()
 
         actual = fit.datasets.parameters["lambda_"].quantity
@@ -525,7 +525,7 @@ class TestSpectralFit:
 
     def test_joint_fit(self):
         self.set_model(self.pwl)
-        fit = Fit(self.obs_list)
+        fit = Fit(self.datasets)
         fit.run()
         actual = fit.datasets.parameters["index"].value
         assert_allclose(actual, 2.7806, rtol=1e-3)

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -78,7 +78,7 @@ class TestFit:
         """WStat with on source and background spectrum"""
         on_vector = self.src.copy()
         on_vector.data += self.bkg.data
-        obs = SpectrumDatasetOnOff(
+        dataset = SpectrumDatasetOnOff(
             counts=on_vector,
             counts_off=self.off,
             aeff=self.aeff,
@@ -86,11 +86,11 @@ class TestFit:
             acceptance=1,
             acceptance_off=1 / self.alpha,
         )
-        obs.model = self.source_model
+        dataset.model = self.source_model
 
         self.source_model.parameters.index = 1.12
 
-        fit = Fit(obs)
+        fit = Fit([dataset])
         result = fit.run()
         pars = self.source_model.parameters
 

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -236,7 +236,7 @@ def test_compute_flux_points_dnde_fermi():
 
 @pytest.fixture()
 def fit(dataset):
-    return Fit(dataset)
+    return Fit([dataset])
 
 
 @pytest.fixture()

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -49,13 +49,9 @@ class LightCurveEstimator:
         sigma_ul=2,
         reoptimize=False,
     ):
+        self.datasets = Datasets(datasets)
 
-        if not isinstance(datasets, Datasets):
-            datasets = Datasets(datasets)
-
-        self.datasets = datasets
-
-        if not datasets.is_all_same_type and datasets.is_all_same_shape:
+        if not self.datasets.is_all_same_type and self.datasets.is_all_same_shape:
             raise ValueError(
                 "Light Curve estimation requires a list of datasets"
                 " of the same type and data shape."
@@ -165,7 +161,7 @@ class LightCurveEstimator:
         result : dict
             Dict with results for the flux point.
         """
-        self.fit = Fit(dataset)
+        self.fit = Fit([dataset])
 
         result = {
             "e_ref": self.e_ref,

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -70,9 +70,7 @@
     "# Define which data to use and print some information\n",
     "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/cta-1dc/index/gps/\")\n",
     "data_store.info()\n",
-    "print(\n",
-    "    \"Observation time (hours): \", data_store.obs_table[\"ONTIME\"].sum() / 3600\n",
-    ")\n",
+    "print(\"ONTIME (hours): \", data_store.obs_table[\"ONTIME\"].sum() / 3600)\n",
     "print(\"Observation table: \", data_store.obs_table.colnames)\n",
     "print(\"HDU table: \", data_store.hdu_table.colnames)"
    ]
@@ -351,7 +349,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit(stacked)\n",
+    "fit = Fit([stacked])\n",
     "result = fit.run(optimize_opts={\"print_level\": 1})"
    ]
   },
@@ -463,7 +461,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit_combined = Fit(dataset_combined)\n",
+    "fit_combined = Fit([dataset_combined])\n",
     "result_combined = fit_combined.run()"
    ]
   },

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -645,8 +645,17 @@
     "    exposure=exposure,\n",
     "    psf=psf_kernel,\n",
     "    edisp=edisp,\n",
-    ")\n",
-    "fit = Fit(dataset)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fit = Fit([dataset])\n",
     "result = fit.run()"
    ]
   },

--- a/tutorials/image_analysis.ipynb
+++ b/tutorials/image_analysis.ipynb
@@ -288,7 +288,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit(dataset)\n",
+    "fit = Fit([dataset])\n",
     "result = fit.run()"
    ]
   },

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -207,12 +207,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs_ids = [23523, 23526, 23559, 23592]\n",
+    "obs_ids = [23523, 23526]\n",
     "datasets = []\n",
     "for obs_id in obs_ids:\n",
-    "    datasets = SpectrumDatasetOnOff.from_ogip_files(\n",
-    "        \"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs\" + str(obs_id) + \".fits\"\n",
+    "    dataset = SpectrumDatasetOnOff.from_ogip_files(\n",
+    "        f\"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs{obs_id}.fits\"\n",
     "    )\n",
+    "    datasets.append(dataset)\n",
     "dataset_hess = Datasets(datasets).stack_reduce()\n",
     "dataset_hess.name = \"HESS\"\n",
     "dataset_hess.model = crab_spec"
@@ -279,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Joint fitting\n",
+    "%%time\n",
     "fit_joint = Fit(datasets)\n",
     "results_joint = fit_joint.run()\n",
     "print(results_joint)\n",
@@ -322,13 +323,13 @@
     "e_min, e_max = 0.01, 2.0\n",
     "El_fermi = np.logspace(np.log10(e_min), np.log10(e_max), 6) * u.TeV\n",
     "flux_points_fermi = FluxPointsEstimator(\n",
-    "    datasets=dataset_fermi, e_edges=El_fermi, source=\"Crab Nebula\"\n",
+    "    datasets=[dataset_fermi], e_edges=El_fermi, source=\"Crab Nebula\"\n",
     ").run()\n",
     "\n",
     "e_min, e_max = 1.0, 15.0\n",
     "El_hess = np.logspace(np.log10(e_min), np.log10(e_max), 6) * u.TeV\n",
     "flux_points_hess = FluxPointsEstimator(\n",
-    "    datasets=dataset_hess, e_edges=El_hess\n",
+    "    datasets=[dataset_hess], e_edges=El_hess\n",
     ").run()"
    ]
   },

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -193,7 +193,7 @@
    "outputs": [],
    "source": [
     "dataset_pwl = FluxPointsDataset(pwl, flux_points, likelihood=\"chi2assym\")\n",
-    "fitter = Fit(dataset_pwl)\n",
+    "fitter = Fit([dataset_pwl])\n",
     "result_pwl = fitter.run()"
    ]
   },
@@ -282,7 +282,7 @@
    "outputs": [],
    "source": [
     "dataset_ecpl = FluxPointsDataset(ecpl, flux_points, likelihood=\"chi2assym\")\n",
-    "fitter = Fit(dataset_ecpl)\n",
+    "fitter = Fit([dataset_ecpl])\n",
     "result_ecpl = fitter.run()\n",
     "print(ecpl)"
    ]
@@ -339,7 +339,7 @@
     "dataset_log_parabola = FluxPointsDataset(\n",
     "    log_parabola, flux_points, likelihood=\"chi2assym\"\n",
     ")\n",
-    "fitter = Fit(dataset_log_parabola)\n",
+    "fitter = Fit([dataset_log_parabola])\n",
     "result_log_parabola = fitter.run()\n",
     "print(log_parabola)"
    ]
@@ -410,9 +410,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -304,7 +304,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "fit = Fit(dataset)\n",
+    "fit = Fit([dataset])\n",
     "result = fit.run(optimize_opts={\"print_level\": 1})"
    ]
   },


### PR DESCRIPTION
This PR is one step to address #2102, it fixes some confusion of `Datasets` vs `Dataset`.

The general idea is to be more strict, to simplify code within Gammapy, but also to make it easier for users to learn the one right way to do it, and not rely on `Datasets` <-> `Dataset` auto-conversions for the common case of one dataset. I think this is clearer, and it will even be required to move `Parameters` to `Datasets.__init__` and to let users access the results from `Datasets`. (Same arguments for `SkyModels`. Being more strinct in `Datasets.__init__` caught one usage bug [here](https://nbviewer.jupyter.org/github/gammapy/gammapy/blob/master/tutorials/joint_1d_3d_analysis.ipynb#HESS-DL3:-1D-ON/OFF-dataset-for-spectral-fitting) where accidentally a single `Dataset` instead of a list of datasets was created.

There's still plenty of more cleanup needed, especially many datasets have a `model` attribute which really is a `models` object. That's for a follow-up PR. One change I'm doing here already is to remove `SkyModels.evaluate`, with the idea that `SkyModels` is the dumb container that does book-keeping and I/O, but evaluation is only at the `SkyModel` level, and typically done on cutouts, not how the current `SkyModels.evaluate` was written. Looks like it wasn't used.

@adonath - Please review.