### PR TITLE
Improve gammapy.catalog

### DIFF
--- a/dev/datasets/gammapy-data-index.json
+++ b/dev/datasets/gammapy-data-index.json
@@ -226,6 +226,12 @@
     "hashmd5": "ac56115c72199a6686cb03616226d234"
    },
    {
+    "path": "catalogs/fermi/gll_psc_v20.fit.gz",
+    "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psc_v20.fit.gz",
+    "filesize": 6362843,
+    "hashmd5": "c65ca6ae4df4210bb766f02720233166"
+   },
+   {
     "path": "catalogs/fermi/gll_psch_v08.fit.gz",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz",
     "filesize": 205855,
@@ -2718,8 +2724,8 @@
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_datasets.yaml",
-    "filesize": 222,
-    "hashmd5": "f4e9cbde47212e3ae195735c5e836df5"
+    "filesize": 194,
+    "hashmd5": "1ff54afe526639b88aaddb57a8dadeea"
    },
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml",

--- a/gammapy/catalog/core.py
+++ b/gammapy/catalog/core.py
@@ -178,10 +178,7 @@ class SourceCatalog:
         elif isinstance(key, numbers.Integral):
             index = key
         else:
-            raise TypeError(
-                f"Invalid key: {key!r}, {type(key)}\n"
-                "Key must be source name string or row index integer. "
-            )
+            raise TypeError(f"Invalid key: {key!r}, {type(key)}\n")
 
         return self._make_source_object(index)
 
@@ -245,10 +242,7 @@ class SourceCatalog:
 
 
 def _skycoord_from_table(table):
-    try:
-        keys = table.colnames
-    except AttributeError:
-        keys = list(table.keys())
+    keys = table.colnames
 
     if {"RAJ2000", "DEJ2000"}.issubset(keys):
         lon, lat, frame = "RAJ2000", "DEJ2000", "icrs"
@@ -256,10 +250,6 @@ def _skycoord_from_table(table):
         lon, lat, frame = "RA", "DEC", "icrs"
     elif {"ra", "dec"}.issubset(keys):
         lon, lat, frame = "ra", "dec", "icrs"
-    elif {"GLON", "GLAT"}.issubset(keys):
-        lon, lat, frame = "GLON", "GLAT", "galactic"
-    elif {"glon", "glat"}.issubset(keys):
-        lon, lat, frame = "glon", "glat", "galactic"
     else:
         raise KeyError("No column GLON / GLAT or RA / DEC or RAJ2000 / DEJ2000 found.")
 

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -463,7 +463,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
         table["flux_errn"] = np.abs(flux_err[:, 0])
         table["flux_errp"] = flux_err[:, 1]
 
-        nuFnu = self._get_flux_values("nuFnu", "erg cm-2 s-1")
+        nuFnu = self._get_flux_values("nuFnu_Band", "erg cm-2 s-1")
         table["e2dnde"] = nuFnu
         table["e2dnde_errn"] = np.abs(nuFnu * flux_err[:, 0] / flux)
         table["e2dnde_errp"] = nuFnu * flux_err[:, 1] / flux
@@ -1340,7 +1340,7 @@ class SourceCatalog4FGL(SourceCatalog):
     description = "LAT 8-year point source catalog"
     source_object_class = SourceCatalogObject4FGL
 
-    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v19.fit.gz"):
+    def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v20.fit.gz"):
         filename = make_path(filename)
         table = Table.read(filename, hdu="LAT_Point_Source_Catalog")
         table_standardise_units_inplace(table)

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -34,6 +34,7 @@ __all__ = [
 
 log = logging.getLogger(__name__)
 
+
 class SourceCatalogObjectGammaCat(SourceCatalogObject):
     """One object from the gamma-cat source catalog.
 
@@ -206,10 +207,10 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
                 "TeV",
             )
             ss += "{:<15s} : {:.3}\n".format("reference", d["spec_ecpl_e_ref"])
-
+        elif spec_type == "none":
+            pass
         else:
-            # raise ValueError('Spectral model printout not implemented: {}'.format(spec))
-            ss += "\nSpectral model printout not yet implemented.\n"
+            raise ValueError(f"Invalid spec_type: {spec_type}")
 
         ss += "\n{:<20s} : ({:.3}, {:.3}) TeV\n".format(
             "Energy range", d["spec_erange_min"].value, d["spec_erange_max"].value
@@ -253,11 +254,12 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += "{:<25s} : {}\n".format("Number of spectral points", d["sed_n_points"])
         ss += "{:<25s} : {}\n\n".format("Number of upper limits", d["sed_n_ul"])
 
-        try:
-            lines = self.flux_points.table_formatted.pformat(max_width=-1, max_lines=-1)
-            ss += "\n".join(lines)
-        except LookupError:
+        flux_points = self.flux_points
+        if flux_points is None:
             ss += "\nNo spectral points available for this source."
+        else:
+            lines = flux_points.table_formatted.pformat(max_width=-1, max_lines=-1)
+            ss += "\n".join(lines)
 
         return ss + "\n"
 

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -86,10 +86,6 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
         ss += "Catalog row index (zero-based) : {}\n".format(d["catalog_row_index"])
         ss += "{:<15s} : {}\n".format("Common name", d["common_name"])
 
-        # ss += '{:<15s} : {}\n'.format('Gamma names', d['gamma_names'])
-        # ss += '{:<15s} : {}\n'.format('Fermi names', d['fermi_names'])
-        # ss += '{:<15s} : {}\n'.format('Other names', d['other_names'])
-
         def get_nonentry_keys(keys):
             vals = [d[_].strip() for _ in keys]
             return ",".join([_ for _ in vals if _ != ""])

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -473,7 +473,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             errs["lambda_"] = data["Lambda_Spec_ECPL_Err"]
             model = ExpCutoffPowerLawSpectralModel(**pars)
         else:
-            raise ValueError(f"Invalid spectral model: {spec_type}")
+            raise ValueError(f"Invalid spec_type: {spec_type}")
 
         model.parameters.set_parameter_errors(errs)
         return model
@@ -534,7 +534,8 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
                 dict(lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], radius=d["Size_Err"])
             )
         else:
-            raise ValueError(f"Not a valid spatial model: {spatial_type}")
+            raise ValueError(f"Invalid spatial_type: {spatial_type}")
+
         return model
 
     def sky_model(self, which="best"):

--- a/gammapy/catalog/tests/data/4fgl_J1409.1-6121e.txt
+++ b/gammapy/catalog/tests/data/4fgl_J1409.1-6121e.txt
@@ -4,7 +4,7 @@
 Catalog row index (zero-based) : 2718
 Source name          : 4FGL J1409.1-6121e
 Extended name        : FGES J1409.1-6121 
-Associations     : 3FHL J1409.1-6121e, J1407-6136c
+Associations     : 3FGL J1405.4-6119, 3FHL J1409.1-6121e, J1407-6136c
 ASSOC_PROB_BAY   : nan
 ASSOC_PROB_LR    : nan
 Class1           :      

--- a/gammapy/catalog/tests/test_core.py
+++ b/gammapy/catalog/tests/test_core.py
@@ -40,10 +40,7 @@ class TestSourceCatalog:
         with pytest.raises(IndexError):
             self.cat.source_name(index=99)
 
-        # This seems to raise IndexError or ValueError with
-        # different Astropy versions, so we just check for
-        # any exception here
-        with pytest.raises(Exception):
+        with pytest.raises(IndexError):
             self.cat.source_name("invalid")
 
     def test_getitem(self):

--- a/gammapy/catalog/tests/test_gammacat.py
+++ b/gammapy/catalog/tests/test_gammacat.py
@@ -102,13 +102,6 @@ class TestSourceCatalogGammaCat:
             cat.table.sort(sort_key)
             assert cat[name].name == name
 
-    def test_to_sky_models(self, gammacat):
-        models = gammacat.to_sky_models()
-
-        assert len(models) == 74
-        assert models[0].name == "CTA 1"
-        assert_allclose(models[0].spectral_model.parameters["index"].value, 2.2)
-
 
 @requires_data()
 class TestSourceCatalogObjectGammaCat:

--- a/gammapy/catalog/tests/test_hess.py
+++ b/gammapy/catalog/tests/test_hess.py
@@ -330,17 +330,3 @@ class TestSourceCatalogLargeScaleHGPS:
         )
         assert_quantity_allclose(self.model.peak_latitude(glon), 1 * u.deg)
         assert_quantity_allclose(self.model.width(glon), 0.3 * u.deg)
-
-
-if __name__ == "__main__":
-    # Check all sources
-    for source in SourceCatalogHGPS():
-        print(source.index, source.name)
-        str(source)
-        source.energy_range
-        source.spectral_model_type
-        source.spectral_model()
-        source.spatial_model_type
-        source.is_pointlike
-        source.sky_model()
-        source.flux_points

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -143,7 +143,7 @@ class SkyModel(SkyModelBase):
     def spatial_model(self, model):
         from .spatial import SpatialModel
 
-        if not isinstance(model, SpatialModel):
+        if not isinstance(model, (SpatialModel, type(None))):
             raise TypeError(f"Invalid type: {model!r}")
         self._spatial_model = model
 
@@ -156,7 +156,7 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         from .spectral import SpectralModel
 
-        if not isinstance(model, SpectralModel):
+        if not isinstance(model, (SpectralModel, type(None))):
             raise TypeError(f"Invalid type: {model!r}")
         self._spectral_model = model
 


### PR DESCRIPTION
This PR contains some cleanup in `gammapy.catalog`.

- [x] Make SkyModel spectral and spatial attribute optional (allow None)
- [x] Return None instead of raising errors for missing data.
- [x] Move validation for all catalogs and sources to https://github.com/gammapy/gammapy-benchmarks/tree/master/validation/catalog since it's long-running and slow
- [x] Update 4FGL catalog file to v20