### PR TITLE
Improve Parameters.set_error

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -206,7 +206,7 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject):
         scale_1sigma = Gauss2DPDF().containment_radius(percent)
         lat_err = semi_major.to("deg") / scale_1sigma
         lon_err = semi_minor.to("deg") / scale_1sigma / np.cos(d["DEJ2000"].to("rad"))
-        model.parameters.set_parameter_errors(dict(lon_0=lon_err, lat_0=lat_err))
+        model.parameters.set_error(lon_0=lon_err, lat_0=lat_err)
         model.phi_0 = phi_0
 
     def sky_model(self):
@@ -445,7 +445,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type!r}")
 
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
         return model
 
     @property
@@ -713,7 +713,7 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type!r}")
 
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
         return model
 
     def spatial_model(self):
@@ -939,7 +939,7 @@ class SourceCatalogObject2FHL(SourceCatalogObjectFermiBase):
         errs["index"] = self.data["Unc_Spectral_Index"]
 
         model = PowerLaw2SpectralModel(**pars)
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
         return model
 
     @property
@@ -1112,7 +1112,7 @@ class SourceCatalogObject3FHL(SourceCatalogObjectFermiBase):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type!r}")
 
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
         return model
 
     @property

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -401,7 +401,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
                 )
                 with warnings.catch_warnings():  # ignore FITS units warnings
                     warnings.simplefilter("ignore", FITSFixedWarning)
-                model = TemplateSpatialModel.read(path / filename)
+                    model = TemplateSpatialModel.read(path / filename)
             elif morph_type == "2D Gaussian":
                 model = GaussianSpatialModel(
                     lon_0=ra, lat_0=dec, sigma=sigma, e=e, phi=phi, frame="icrs"

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -186,6 +186,9 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject):
     def is_pointlike(self):
         return self.data["Extended_Source_Name"].strip() == ""
 
+    # FIXME: this should be renamed `set_position_error`,
+    # and `phi_0` isn't filled correctly, other parameters missing
+    # see https://github.com/gammapy/gammapy/pull/2533#issuecomment-553329049
     def _set_spatial_errors(self, model):
         d = self.data
 
@@ -206,8 +209,10 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject):
         scale_1sigma = Gauss2DPDF().containment_radius(percent)
         lat_err = semi_major.to("deg") / scale_1sigma
         lon_err = semi_minor.to("deg") / scale_1sigma / np.cos(d["DEJ2000"].to("rad"))
-        model.parameters.set_error(lon_0=lon_err, lat_0=lat_err)
-        model.phi_0 = phi_0
+
+        if model.tag != "TemplateSpatialModel":
+            model.parameters.set_error(lon_0=lon_err, lat_0=lat_err)
+            model.phi_0 = phi_0
 
     def sky_model(self):
         """Sky model (`~gammapy.modeling.models.SkyModel`)."""

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -306,7 +306,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
             raise ValueError(f"Invalid spec_type: {spec_type}")
 
         model = model_class(**pars)
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
 
         return model
 
@@ -351,7 +351,7 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
         lat_err = self.data["pos_err"].to("deg")
         lon_err = self.data["pos_err"].to("deg") / np.cos(self.data["glat"].to("rad"))
-        model.parameters.set_parameter_errors(dict(lon_0=lon_err, lat_0=lat_err))
+        model.parameters.set_error(lon_0=lon_err, lat_0=lat_err)
         # TODO: check if pos_err is really 1sigma
         return model
 

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -129,7 +129,7 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
         pars["reference"] = "7 TeV"
 
         model = PowerLawSpectralModel(**pars)
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
 
         return model
 
@@ -156,7 +156,7 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
 
         lat_err = self.data["pos_err"].to("deg")
         lon_err = self.data["pos_err"].to("deg") / np.cos(self.data["glat"].to("rad"))
-        model.parameters.set_parameter_errors(dict(lon_0=lon_err, lat_0=lat_err))
+        model.parameters.set_error(lon_0=lon_err, lat_0=lat_err)
 
         return model
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -87,8 +87,8 @@ class SourceCatalogObjectHGPSComponent:
         model = GaussianSpatialModel(
             lon_0=d["GLON"], lat_0=d["GLAT"], sigma=d["Size"], frame="galactic"
         )
-        model.parameters.set_parameter_errors(
-            dict(lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], sigma=d["Size_Err"])
+        model.parameters.set_error(
+            lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], sigma=d["Size_Err"]
         )
         return model
 
@@ -475,7 +475,7 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
         else:
             raise ValueError(f"Invalid spec_type: {spec_type}")
 
-        model.parameters.set_parameter_errors(errs)
+        model.parameters.set_error(**errs)
         return model
 
     @property
@@ -516,8 +516,8 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             model = GaussianSpatialModel(
                 lon_0=glon, lat_0=glat, sigma=d["Size"], frame="galactic"
             )
-            model.parameters.set_parameter_errors(
-                dict(lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], sigma=d["Size_Err"])
+            model.parameters.set_error(
+                lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], sigma=d["Size_Err"]
             )
         elif spatial_type in {"2-gaussian", "3-gaussian"}:
             raise ValueError("For Gaussian or Multi-Gaussian models, use sky_model()!")
@@ -530,8 +530,8 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
             model = ShellSpatialModel(
                 lon_0=glon, lat_0=glat, width=width, radius=radius, frame="galactic"
             )
-            model.parameters.set_parameter_errors(
-                dict(lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], radius=d["Size_Err"])
+            model.parameters.set_error(
+                lon_0=d["GLON_Err"], lat_0=d["GLAT_Err"], radius=d["Size_Err"]
             )
         else:
             raise ValueError(f"Invalid spatial_type: {spatial_type}")

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -302,9 +302,7 @@ def test_model_plot():
     pwl = PowerLawSpectralModel(
         amplitude=1e-12 * u.Unit("TeV-1 cm-2 s-1"), reference=1 * u.Unit("TeV"), index=2
     )
-    pwl.parameters.set_parameter_errors(
-        {"amplitude": 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")}
-    )
+    pwl.parameters.set_error(amplitude=0.1e-12 * u.Unit("TeV-1 cm-2 s-1"))
     with mpl_plot_check():
         pwl.plot((1 * u.TeV, 10 * u.TeV))
 
@@ -379,9 +377,7 @@ def test_pwl_index_2_error():
     pwl = PowerLawSpectralModel(
         amplitude=1e-12 * u.Unit("TeV-1 cm-2 s-1"), reference=1 * u.Unit("TeV"), index=2
     )
-    pwl.parameters.set_parameter_errors(
-        {"amplitude": 0.1e-12 * u.Unit("TeV-1 cm-2 s-1")}
-    )
+    pwl.parameters.set_error(amplitude=1e-13 * u.Unit("TeV-1 cm-2 s-1"))
 
     val, val_err = pwl.evaluate_error(1 * u.TeV)
     assert_quantity_allclose(val, 1e-12 * u.Unit("TeV-1 cm-2 s-1"))

--- a/gammapy/modeling/tests/test_parameter.py
+++ b/gammapy/modeling/tests/test_parameter.py
@@ -98,8 +98,8 @@ def pars():
 
 def test_parameters_basics(pars):
     # This applies a unit transformation
-    pars.set_parameter_errors({"ham": "10000 GeV"})
-    pars.set_error(0, 0.1)
+    pars.set_error(ham="10000 GeV")
+    pars.set_error(spam=0.1)
     assert_allclose(pars.covariance, [[1e-2, 0], [0, 100]])
     assert_allclose(pars.correlation, [[1, 0], [0, 1]])
     assert_allclose(pars.error("spam"), 0.1)
@@ -158,7 +158,7 @@ def test_parameters_getitem(pars):
 
 
 def test_parameters_to_table(pars):
-    pars.set_error("ham", 1e-10 / 3)
+    pars.set_error(ham=1e-10)
     table = pars.to_table()
     assert len(table) == 2
     assert len(table.columns) == 7

--- a/gammapy/utils/tests/test_integrate.py
+++ b/gammapy/utils/tests/test_integrate.py
@@ -36,9 +36,7 @@ def test_integrate_spectrum_ecpl():
         reference=1 * u.TeV,
         lambda_=0.1 / u.TeV,
     )
-    ecpl.parameters.set_parameter_errors(
-        {"index": 0.2, "amplitude": 1e-13 * u.Unit("cm-2 s-1 TeV-1")}
-    )
+    ecpl.parameters.set_error(index=0.2, amplitude=1e-13 * u.Unit("cm-2 s-1 TeV-1"))
     emin, emax = 1 * u.TeV, 1e10 * u.TeV
     res = ecpl.integral_error(emin, emax)
 


### PR DESCRIPTION
This PR improves `Parameters.set_error`, to work like `Parameters.__init__` via keyword arguments.
See the docstring and example.

This replaces the previous `set_error` and `set_parameter_errors` methods and unifies them into one method (avoiding the code duplication, and resolving the TODO comments that this needs cleanup).