### PR TITLE
Add `.cutout_info` information to WCS header

### DIFF
--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -241,6 +241,33 @@ def test_cutout():
     assert cutout_geom.data_shape == (2, 6, 6)
 
 
+def test_cutout_info():
+    geom = WcsGeom.create(
+        skydir=(0, 0),
+        npix=10,
+    )
+    position = SkyCoord(0, 0, unit="deg")
+    cutout_geom = geom.cutout(position=position, width="2 deg")
+    assert cutout_geom.cutout_info["parent-slices"][0].start == 3
+    assert cutout_geom.cutout_info["parent-slices"][1].start == 3
+
+    assert cutout_geom.cutout_info["cutout-slices"][0].start == 0
+    assert cutout_geom.cutout_info["cutout-slices"][1].start == 0
+
+    header = cutout_geom.make_header()
+    assert "PSLICE1" in header
+    assert "PSLICE2" in header
+    assert "CSLICE1" in header
+    assert "CSLICE2" in header
+
+    geom = WcsGeom.from_header(header)
+    assert geom.cutout_info["parent-slices"][0].start == 3
+    assert geom.cutout_info["parent-slices"][1].start == 3
+
+    assert geom.cutout_info["cutout-slices"][0].start == 0
+    assert geom.cutout_info["cutout-slices"][1].start == 0
+
+
 def test_wcsgeom_get_coord():
     geom = WcsGeom.create(
         skydir=(0, 0), npix=(4, 3), binsz=1, coordsys="GAL", proj="CAR"

--- a/gammapy/maps/utils.py
+++ b/gammapy/maps/utils.py
@@ -157,3 +157,13 @@ def edges_from_lo_hi(edges_lo, edges_hi):
     except AttributeError:
         edges = np.insert(edges, len(edges), edges_hi[-1])
     return edges
+
+
+def slice_to_str(slice_):
+    return f"{slice_.start}:{slice_.stop}"
+
+
+def str_to_slice(slice_str):
+    start, stop = slice_str.split(":")
+    return slice(int(start), int(stop))
+

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -688,10 +688,7 @@ class WcsNDMap(WcsMap):
         """
         if self.geom == other.geom:
             parent_slices, cutout_slices = None, None
-        elif (
-            other.geom.cutout_info is not None
-            and self.geom == other.geom.cutout_info["parent-geom"]
-        ):
+        elif self.geom.is_aligned(other.geom):
             slices = other.geom.cutout_info["parent-slices"]
             parent_slices = Ellipsis, slices[0], slices[1]
 

--- a/tutorials/analysis_3d_joint.ipynb
+++ b/tutorials/analysis_3d_joint.ipynb
@@ -213,7 +213,8 @@
     "\n",
     "    # optionally define a safe energy threshold\n",
     "    emin = None\n",
-    "    dataset.mask_safe = dataset.counts.geom.energy_mask(emin=emin)\n",
+    "    data = dataset.counts.geom.energy_mask(emin=emin)\n",
+    "    dataset.mask_safe = Map.from_geom(geom=dataset.counts.geom, data=data)\n",
     "    datasets.append(dataset)"
    ]
   },
@@ -356,9 +357,7 @@
     "\n",
     "for dataset in datasets:\n",
     "    residuals = dataset.residuals()\n",
-    "    coords = residuals.geom.get_coord()\n",
-    "\n",
-    "    residuals_stacked.fill_by_coord(coords, residuals.data)"
+    "    residuals_stacked.stack(residuals)"
    ]
   },
   {
@@ -367,7 +366,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "residuals_stacked.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
+    "residuals_stacked.sum_over_axes().smooth(\"0.08 deg\").plot(\n",
     "    vmin=-1, vmax=1, cmap=\"coolwarm\", add_cbar=True, stretch=\"linear\"\n",
     ");"
    ]


### PR DESCRIPTION
This PR adds the (optional) `cutout_info` of a `WcsGeom` to the WCS header. This allow to cutout maps, write them to file, read them back and stack into a larger map with an aligned WCS geometry. This also allows to get rid of the reference to the parent geometry. 