### PR TITLE
Rename likelihood to stat

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -464,7 +464,7 @@ class MapDataset(Dataset):
         if self.gti and other.gti:
             self.gti = self.gti.stack(other.gti).union()
 
-    def likelihood_per_bin(self):
+    def stat_array(self):
         """Likelihood per bin given the current model parameters"""
         return self._stat(n_on=self.counts.data, mu_on=self.npred().data)
 
@@ -1049,7 +1049,7 @@ class MapDatasetOnOff(MapDataset):
         """Excess (counts - alpha * counts_off)"""
         return self.counts.data - self.background.data
 
-    def likelihood_per_bin(self):
+    def stat_array(self):
         """Likelihood per bin given the current model parameters"""
         mu_sig = self.npred().data
         on_stat_ = wstat(

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -165,7 +165,7 @@ class MapDataset(Dataset):
 
         stat = np.nan
         if self.model is not None or self.background_model is not None:
-            stat = self.likelihood()
+            stat = self.stat_sum()
         str_ += "\t{:32}: {:.2f}\n\n".format("Fit statistic value (-2 log(L))", stat)
 
         # model section
@@ -581,7 +581,7 @@ class MapDataset(Dataset):
     def _counts_data(self):
         return self.counts.data.astype(float)
 
-    def likelihood(self):
+    def stat_sum(self):
         """Total likelihood given the current model parameters."""
         counts, npred = self._counts_data, self.npred().data
 
@@ -1167,9 +1167,9 @@ class MapDatasetOnOff(MapDataset):
 
         super().stack(other)
 
-    def likelihood(self):
+    def stat_sum(self):
         """Total likelihood given the current model parameters."""
-        return Dataset.likelihood(self)
+        return Dataset.stat_sum(self)
 
     def fake(self, background_model, random_state="random-seed"):
         """Simulate fake counts (on and off) for the current model and reduced IRFs.

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -348,7 +348,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_1.mask_safe = Map.from_geom(geom, data=mask_safe)
     dataset_2.mask_safe = Map.from_geom(geom, data=mask_safe)
 
-    stat = fit.datasets.likelihood()
+    stat = fit.datasets.stat_sum()
     assert_allclose(stat, 6425.389198)
 
     # test model evaluation outside image

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -51,7 +51,7 @@ class Dataset(abc.ABC):
 
     def stat_sum(self):
         """Total statistic given the current model parameters."""
-        stat = self.likelihood_per_bin()
+        stat = self.stat_array()
 
         if self.mask is not None:
             stat = stat[self.mask]
@@ -59,8 +59,8 @@ class Dataset(abc.ABC):
         return np.sum(stat, dtype=np.float64)
 
     @abc.abstractmethod
-    def likelihood_per_bin(self):
-        """Likelihood per bin given the current model parameters"""
+    def stat_array(self):
+        """Statistic array, one value per data point."""
 
     def copy(self):
         """A deep copy."""

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -120,13 +120,13 @@ class Datasets:
         """Whether all contained datasets have the same data shape"""
         return len(set(_.data_shape for _ in self)) == 1
 
-    def likelihood(self):
+    def stat_sum(self):
         """Compute joint likelihood"""
-        total_likelihood = 0
+        stat_sum = 0
         # TODO: add parallel evaluation of likelihoods
         for dataset in self:
-            total_likelihood += dataset.likelihood()
-        return total_likelihood
+            stat_sum += dataset.stat_sum()
+        return stat_sum
 
     def __str__(self):
         str_ = self.__class__.__name__ + "\n"

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -49,9 +49,8 @@ class Dataset(abc.ABC):
             mask = None
         return mask
 
-    def likelihood(self):
-        """Total likelihood given the current model parameters.
-        """
+    def stat_sum(self):
+        """Total statistic given the current model parameters."""
         stat = self.likelihood_per_bin()
 
         if self.mask is not None:

--- a/gammapy/modeling/sampling.py
+++ b/gammapy/modeling/sampling.py
@@ -55,7 +55,7 @@ def lnprob(pars, dataset):
 
     # dataset.likelihood returns Cash statistics values
     # emcee will maximisise the LogLikelihood so we need -dataset.likelihood
-    total_lnprob = -dataset.likelihood() + lnprob_priors
+    total_lnprob = -dataset.stat_sum() + lnprob_priors
 
     return total_lnprob
 

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 import scipy.optimize
-from gammapy.utils.interpolation import interpolate_likelihood_profile
+from gammapy.utils.interpolation import interpolate_profile
 from .likelihood import Likelihood
 
 __all__ = [
     "optimize_scipy",
     "covariance_scipy",
     "confidence_scipy",
-    "likelihood_profile_ul_scipy",
+    "stat_profile_ul_scipy",
 ]
 
 
@@ -35,7 +35,7 @@ def optimize_scipy(parameters, function, **kwargs):
 
 
 class TSDifference:
-    """Likelihood wrapper to compute TS differences"""
+    """Fit statistic function wrapper to compute TS differences"""
 
     def __init__(self, function, parameters, parameter, reoptimize, ts_diff):
         self.loglike_ref = function()
@@ -138,8 +138,8 @@ def covariance_scipy(parameters, function):
     raise NotImplementedError
 
 
-def likelihood_profile_ul_scipy(
-    value_scan, dloglike_scan, delta_ts=4, interp_scale="sqrt", **kwargs
+def stat_profile_ul_scipy(
+    value_scan, stat_scan, delta_ts=4, interp_scale="sqrt", **kwargs
 ):
     """Compute upper limit of a parameter from a likelihood profile.
 
@@ -147,12 +147,12 @@ def likelihood_profile_ul_scipy(
     ----------
     value_scan : `~numpy.ndarray`
         Array of parameter values.
-    dloglike_scan : `~numpy.ndarray`
-        Array of delta log-likelihood values, with respect to the minimum.
+    stat_scan : `~numpy.ndarray`
+        Array of delta fit statistic values, with respect to the minimum.
     delta_ts : float
         Difference in test statistics for the upper limit.
     interp_scale : {"sqrt", "lin"}
-        Interpolation scale applied to the likelihood profile. If the profile is
+        Interpolation scale applied to the fit statistic profile. If the profile is
         of parabolic shape, a "sqrt" scaling is recommended. In other cases or
         for fine sampled profiles a "lin" can also be used.
     **kwargs : dict
@@ -163,14 +163,12 @@ def likelihood_profile_ul_scipy(
     ul : float
         Upper limit value.
     """
-    interp = interpolate_likelihood_profile(
-        value_scan, dloglike_scan, interp_scale=interp_scale
-    )
+    interp = interpolate_profile(value_scan, stat_scan, interp_scale=interp_scale)
 
     def f(x):
         return interp((x,)) - delta_ts
 
-    idx = np.argmin(dloglike_scan)
+    idx = np.argmin(stat_scan)
     norm_best_fit = value_scan[idx]
     ul = scipy.optimize.brentq(f, a=norm_best_fit, b=value_scan[-1], **kwargs)
 

--- a/gammapy/modeling/scipy.py
+++ b/gammapy/modeling/scipy.py
@@ -38,7 +38,7 @@ class TSDifference:
     """Fit statistic function wrapper to compute TS differences"""
 
     def __init__(self, function, parameters, parameter, reoptimize, ts_diff):
-        self.loglike_ref = function()
+        self.stat_null = function()
         self.parameters = parameters
         self.function = function
         self.parameter = parameter
@@ -50,7 +50,7 @@ class TSDifference:
         self.parameter.factor = factor
         if self.reoptimize:
             optimize_scipy(self.parameters, self.function, method="L-BFGS-B")
-        value = self.function() - self.loglike_ref - self.ts_diff
+        value = self.function() - self.stat_null - self.ts_diff
         return value
 
 
@@ -98,7 +98,7 @@ def _confidence_scipy_brentq(
         suffix: np.abs(result[0] - kwargs["a"]),
         "success_" + suffix: success,
         "message_" + suffix: message,
-        "loglike_ref": ts_diff.loglike_ref,
+        "stat_null": ts_diff.stat_null,
     }
 
 

--- a/gammapy/modeling/tests/test_datasets.py
+++ b/gammapy/modeling/tests/test_datasets.py
@@ -23,7 +23,7 @@ def test_datasets_types(datasets):
 
 
 def test_datasets_likelihood(datasets):
-    likelihood = datasets.likelihood()
+    likelihood = datasets.stat_sum()
     assert_allclose(likelihood, 0)
 
 

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -16,7 +16,7 @@ class MyDataset:
         )
         self.data_shape = (1,)
 
-    def likelihood(self):
+    def stat_sum(self):
         # self._model.parameters = parameters
         x, y, z = [p.value for p in self.parameters]
         x_opt, y_opt, z_opt = 2, 3e2, 4e-2
@@ -106,29 +106,29 @@ def test_confidence_frozen(backend):
     assert_allclose(result["errn"], 1)
 
 
-def test_likelihood_profile():
+def test_stat_profile():
     dataset = MyDataset()
     fit = Fit([dataset])
     fit.run()
-    result = fit.likelihood_profile("x", nvalues=3)
+    result = fit.stat_profile("x", nvalues=3)
 
     assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
-    assert_allclose(result["likelihood"], [4, 0, 4], atol=1e-7)
+    assert_allclose(result["stat"], [4, 0, 4], atol=1e-7)
 
     # Check that original value state wasn't changed
     assert_allclose(dataset.parameters["x"].value, 2)
 
 
-def test_likelihood_profile_reoptimize():
+def test_stat_profile_reoptimize():
     dataset = MyDataset()
     fit = Fit([dataset])
     fit.run()
 
     dataset.parameters["y"].value = 0
-    result = fit.likelihood_profile("x", nvalues=3, reoptimize=True)
+    result = fit.stat_profile("x", nvalues=3, reoptimize=True)
 
     assert_allclose(result["values"], [0, 2, 4], atol=1e-7)
-    assert_allclose(result["likelihood"], [4, 0, 4], atol=1e-7)
+    assert_allclose(result["stat"], [4, 0, 4], atol=1e-7)
 
 
 def test_minos_contour():

--- a/gammapy/modeling/tests/test_scipy.py
+++ b/gammapy/modeling/tests/test_scipy.py
@@ -5,8 +5,8 @@ from numpy.testing import assert_allclose
 from gammapy.modeling import Parameter, Parameters
 from gammapy.modeling.scipy import (
     confidence_scipy,
-    likelihood_profile_ul_scipy,
     optimize_scipy,
+    stat_profile_ul_scipy,
 )
 
 
@@ -100,11 +100,11 @@ def test_scipy_confidence(pars):
     assert_allclose(result["errn"], 0.2, rtol=1e-3)
 
 
-def test_likelihood_profile_ul_scipy():
+def test_stat_profile_ul_scipy():
     x = np.linspace(-5, 5, 7)
     y = x ** 2
-    ul = likelihood_profile_ul_scipy(x, y)
+    ul = stat_profile_ul_scipy(x, y)
     assert_allclose(ul, 2)
 
-    ul = likelihood_profile_ul_scipy(x, x, interp_scale="lin")
+    ul = stat_profile_ul_scipy(x, x, interp_scale="lin")
     assert_allclose(ul, 4)

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -225,7 +225,7 @@ class SpectrumDataset(Dataset):
             npred.data += self.background.data
         return npred
 
-    def likelihood_per_bin(self):
+    def stat_array(self):
         """Likelihood per bin given the current model parameters"""
         return cash(n_on=self.counts.data, mu_on=self.npred().data)
 
@@ -607,7 +607,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         npred = self._predictor.compute_npred()
         return npred
 
-    def likelihood_per_bin(self):
+    def stat_array(self):
         """Likelihood per bin given the current model parameters"""
         mu_sig = self.npred_sig().data
         on_stat_ = wstat(

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -142,7 +142,7 @@ class SpectrumDataset(Dataset):
 
         stat = np.nan
         if self.model is not None:
-            stat = self.likelihood()
+            stat = self.stat_sum()
         str_ += "\t{:32}: {:.2f}\n\n".format("Fit statistic value (-2 log(L))", stat)
 
         n_pars, n_free_pars = 0, 0

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1058,7 +1058,7 @@ class FluxPointsEstimator:
         result : dict
             Dict with ts and sqrt(ts) for the flux point.
         """
-        loglike = self.datasets.likelihood()
+        loglike = self.datasets.stat_sum()
 
         # store best fit amplitude, set amplitude of fit model to zero
         self.model.norm.value = 0
@@ -1067,7 +1067,7 @@ class FluxPointsEstimator:
         if self.reoptimize:
             _ = self.fit.optimize()
 
-        loglike_null = self.datasets.likelihood()
+        loglike_null = self.datasets.stat_sum()
 
         # compute sqrt TS
         ts = np.abs(loglike_null - loglike)
@@ -1289,7 +1289,7 @@ class FluxPointsDataset(Dataset):
                             par.name, par.value, par.unit
                         )
             str_ += "\t{:32}:   {}\n".format("Likelihood type", self.likelihood_type)
-            str_ += "\t{:32}:   {:.2f}\n".format("Likelihood value", self.likelihood())
+            str_ += "\t{:32}:   {:.2f}\n".format("Likelihood value", self.stat_sum())
         return str_
 
     def data_shape(self):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1312,7 +1312,7 @@ class FluxPointsDataset(Dataset):
         """Compute predicted flux."""
         return self.model(self.data.e_ref)
 
-    def likelihood_per_bin(self):
+    def stat_array(self):
         """Likelihood per bin given the current model parameters."""
         model = self.flux_pred()
         data = self.data.table["dnde"].quantity

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -145,7 +145,7 @@ class FluxPoints:
             if column.startswith(("dnde", "eflux", "flux", "e2dnde", "ref")):
                 table[column].format = ".3e"
             elif column.startswith(
-                ("e_min", "e_max", "e_ref", "sqrt_ts", "norm", "ts", "loglike")
+                ("e_min", "e_max", "e_ref", "sqrt_ts", "norm", "ts", "stat")
             ):
                 table[column].format = ".3f"
 
@@ -697,7 +697,7 @@ class FluxPoints:
             y_ref = self.table["ref_" + self.sed_type].quantity[idx]
             norm = (y_values / y_ref).to_value("")
             norm_scan = row["norm_scan"]
-            dloglike_scan = row["dloglike_scan"] - row["loglike"]
+            dloglike_scan = row["dloglike_scan"] - row["stat"]
             interp = interpolate_profile(norm_scan, dloglike_scan)
             z[idx] = interp((norm,))
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -61,7 +61,7 @@ class TestFit:
         npred = dataset.npred().data
         assert_allclose(npred[5], 660.5171, rtol=1e-5)
 
-        stat_val = dataset.likelihood()
+        stat_val = dataset.stat_sum()
         assert_allclose(stat_val, -107346.5291, rtol=1e-5)
 
         self.source_model.parameters["index"].value = 1.12

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -111,7 +111,7 @@ class TestFit:
         assert_allclose(e_max.value, 10)
         assert_allclose(e_min.value, 0.1)
 
-    def test_likelihood_profile(self):
+    def test_stat_profile(self):
         dataset = SpectrumDataset(
             model=self.source_model,
             aeff=self.aeff,
@@ -123,8 +123,8 @@ class TestFit:
         result = fit.run()
         true_idx = result.parameters["index"].value
         values = np.linspace(0.95 * true_idx, 1.05 * true_idx, 100)
-        profile = fit.likelihood_profile("index", values=values)
-        actual = values[np.argmin(profile["likelihood"])]
+        profile = fit.stat_profile("index", values=values)
+        actual = values[np.argmin(profile["stat"])]
         assert_allclose(actual, true_idx, rtol=0.01)
 
 

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -157,7 +157,7 @@ class TestSpectralFit:
         fit = Fit([dataset])
         result = fit.run()
 
-        stats = dataset.likelihood_per_bin()
+        stats = dataset.stat_array()
         actual = np.sum(stats[dataset.mask_safe])
 
         desired = result.total_stat

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -215,7 +215,7 @@ class TestFluxPoints:
     @requires_dependency("matplotlib")
     def test_plot_likelihood(self, flux_points_likelihood):
         with mpl_plot_check():
-            flux_points_likelihood.plot_stat_profiles()
+            flux_points_likelihood.plot_ts_profiles()
 
 
 @requires_data()

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -215,7 +215,7 @@ class TestFluxPoints:
     @requires_dependency("matplotlib")
     def test_plot_likelihood(self, flux_points_likelihood):
         with mpl_plot_check():
-            flux_points_likelihood.plot_likelihood()
+            flux_points_likelihood.plot_stat_profiles()
 
 
 @requires_data()
@@ -310,23 +310,23 @@ class TestFluxPointFit:
 
     @staticmethod
     @requires_dependency("iminuit")
-    def test_likelihood_profile(fit):
+    def test_stat_profile(fit):
         optimize_opts = {"backend": "minuit"}
 
         result = fit.run(optimize_opts=optimize_opts)
 
-        profile = fit.likelihood_profile("amplitude", nvalues=3, bounds=1)
+        profile = fit.stat_profile("amplitude", nvalues=3, bounds=1)
 
-        ts_diff = profile["likelihood"] - result.total_stat
+        ts_diff = profile["stat"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
 
         value = result.parameters["amplitude"].value
         err = result.parameters.error("amplitude")
         values = np.array([value - err, value, value + err])
 
-        profile = fit.likelihood_profile("amplitude", values=values)
+        profile = fit.stat_profile("amplitude", values=values)
 
-        ts_diff = profile["likelihood"] - result.total_stat
+        ts_diff = profile["stat"] - result.total_stat
         assert_allclose(ts_diff, [110.1, 0, 110.1], rtol=1e-2, atol=1e-7)
 
     @staticmethod

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -147,7 +147,7 @@ class TestFluxPointsEstimator:
         actual = fp.table["norm_scan"][0][[0, 5, -1]]
         assert_allclose(actual, [0.2, 1, 5])
 
-        actual = fp.table["dloglike_scan"][0][[0, 5, -1]]
+        actual = fp.table["stat_scan"][0][[0, 5, -1]]
         assert_allclose(actual, [220.368653, 4.301011, 1881.626454], rtol=1e-2)
 
     @staticmethod
@@ -180,7 +180,7 @@ class TestFluxPointsEstimator:
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, [0.2, 1, 5])
 
-        actual = fp.table["dloglike_scan"][0] - fp.table["stat"][0]
+        actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
         assert_allclose(actual, [1.555231e02, 4.734243e-01, 2.045164e03], rtol=1e-2)
 
     @staticmethod
@@ -201,7 +201,7 @@ class TestFluxPointsEstimator:
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, 1)
 
-        actual = fp.table["dloglike_scan"][0] - fp.table["stat"][0]
+        actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
         assert_allclose(actual, 2.484034, rtol=1e-2)
 
 

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -180,7 +180,7 @@ class TestFluxPointsEstimator:
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, [0.2, 1, 5])
 
-        actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
+        actual = fp.table["dloglike_scan"][0] - fp.table["stat"][0]
         assert_allclose(actual, [1.555231e02, 4.734243e-01, 2.045164e03], rtol=1e-2)
 
     @staticmethod
@@ -201,7 +201,7 @@ class TestFluxPointsEstimator:
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, 1)
 
-        actual = fp.table["dloglike_scan"][0] - fp.table["loglike"][0]
+        actual = fp.table["dloglike_scan"][0] - fp.table["stat"][0]
         assert_allclose(actual, 2.484034, rtol=1e-2)
 
 

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -22,19 +22,19 @@ class LightCurveEstimator:
     source : str
         For which source in the model to compute the flux points. Default is ''
     norm_min : float
-        Minimum value for the norm used for the likelihood profile evaluation.
+        Minimum value for the norm used for the fit statistic profile evaluation.
     norm_max : float
-        Maximum value for the norm used for the likelihood profile evaluation.
+        Maximum value for the norm used for the fit statistic profile evaluation.
     norm_n_values : int
-        Number of norm values used for the likelihood profile.
+        Number of norm values used for the fit statistic profile.
     norm_values : `numpy.ndarray`
-        Array of norm values to be used for the likelihood profile.
+        Array of norm values to be used for the fit statistic profile.
     sigma : int
         Sigma to use for asymmetric error computation.
     sigma_ul : int
         Sigma to use for upper limit computation.
     reoptimize : bool
-        reoptimize other parameters during likelihod scan
+        reoptimize other parameters during fit statistic scan?
     """
 
     def __init__(
@@ -114,7 +114,7 @@ class LightCurveEstimator:
                 * "errn-errp": estimate asymmetric errors.
                 * "ul": estimate upper limits.
                 * "ts": estimate ts and sqrt(ts) values.
-                * "norm-scan": estimate likelihood profiles.
+                * "norm-scan": estimate fit statistic profiles.
 
             By default all steps are executed.
 
@@ -265,7 +265,7 @@ class LightCurveEstimator:
         """
         norm = self.model.norm
 
-        # TODO: the minuit backend has convergence problems when the likelihood is not
+        # TODO: the minuit backend has convergence problems when the fit statistic is not
         #  of parabolic shape, which is the case, when there are zero counts in the
         #  bin. For this case we change to the scipy backend.
         counts = self.estimate_counts(dataset)["counts"]
@@ -290,7 +290,7 @@ class LightCurveEstimator:
         result : dict
             Dict with ts and sqrt(ts) for the flux point.
         """
-        loglike = self.datasets.likelihood()
+        stat = self.datasets.stat_sum()
 
         # store best fit amplitude, set amplitude of fit model to zero
         self.model.norm.value = 0
@@ -299,25 +299,25 @@ class LightCurveEstimator:
         if self.reoptimize:
             _ = self.fit.optimize()
 
-        loglike_null = self.datasets.likelihood()
+        stat_null = self.datasets.stat_sum()
 
         # compute sqrt TS
-        ts = np.abs(loglike_null - loglike)
+        ts = np.abs(stat_null - stat)
         sqrt_ts = np.sqrt(ts)
         return {"sqrt_ts": sqrt_ts, "ts": ts}
 
     def estimate_norm_scan(self):
-        """Estimate likelihood profile for the norm parameter.
+        """Estimate fit statistic profile for the norm parameter.
 
         Returns
         -------
         result : dict
             Dict with norm_scan and dloglike_scan for the flux point.
         """
-        result = self.fit.likelihood_profile(
+        result = self.fit.stat_profile(
             self.model.norm, values=self.norm_values, reoptimize=self.reoptimize
         )
-        dloglike_scan = result["likelihood"]
+        dloglike_scan = result["stat"]
         return {"norm_scan": result["values"], "dloglike_scan": dloglike_scan}
 
     def estimate_norm(self):
@@ -326,7 +326,7 @@ class LightCurveEstimator:
         Returns
         -------
         result : dict
-            Dict with "norm" and "loglike" for the flux point.
+            Dict with "norm" and "stat" for the flux point.
         """
         # start optimization with norm=1
         self.model.norm.value = 1.0
@@ -339,4 +339,4 @@ class LightCurveEstimator:
         else:
             norm = np.nan
 
-        return {"norm": norm, "loglike": result.total_stat, "success": result.success}
+        return {"norm": norm, "stat": result.total_stat, "success": result.success}

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -312,13 +312,12 @@ class LightCurveEstimator:
         Returns
         -------
         result : dict
-            Dict with norm_scan and dloglike_scan for the flux point.
+            Keys "norm_scan", "stat_scan"
         """
         result = self.fit.stat_profile(
             self.model.norm, values=self.norm_values, reoptimize=self.reoptimize
         )
-        dloglike_scan = result["stat"]
-        return {"norm_scan": result["values"], "dloglike_scan": dloglike_scan}
+        return {"norm_scan": result["values"], "stat_scan": result["stat"]}
 
     def estimate_norm(self):
         """Fit norm of the flux point.

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -194,7 +194,7 @@ def test_lightcurve_estimator_spectrum_datasets():
     assert_allclose(lightcurve.table["ts"], [1381.461738, 1381.462675], rtol=1e-5)
     assert_allclose(lightcurve.table[0]["norm_scan"], [0.2, 1.0, 5.0])
     assert_allclose(
-        lightcurve.table[0]["dloglike_scan"],
+        lightcurve.table[0]["stat_scan"],
         [444.426957, 23.375417, 3945.382802],
         rtol=1e-5,
     )

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -183,7 +183,7 @@ def test_lightcurve_estimator_spectrum_datasets():
     assert_allclose(lightcurve.table["ref_flux"], [9.9e-13, 9.9e-13])
     assert_allclose(lightcurve.table["ref_eflux"], [4.60517e-12, 4.60517e-12])
     assert_allclose(lightcurve.table["ref_e2dnde"], [1e-12, 1e-12])
-    assert_allclose(lightcurve.table["loglike"], [23.302288, 22.457766], rtol=1e-5)
+    assert_allclose(lightcurve.table["stat"], [23.302288, 22.457766], rtol=1e-5)
     assert_allclose(lightcurve.table["norm"], [0.988127, 0.948108], rtol=1e-5)
     assert_allclose(lightcurve.table["norm_err"], [0.043985, 0.043498], rtol=1e-4)
     assert_allclose(lightcurve.table["counts"], [2281, 2222])
@@ -236,9 +236,7 @@ def test_lightcurve_estimator_map_datasets():
     assert_allclose(lightcurve.table["ref_flux"], [9.9e-12, 9.9e-12])
     assert_allclose(lightcurve.table["ref_eflux"], [4.60517e-11, 4.60517e-11])
     assert_allclose(lightcurve.table["ref_e2dnde"], [1e-11, 1e-11])
-    assert_allclose(
-        lightcurve.table["loglike"], [-86845.74348, -90386.086642], rtol=1e-5
-    )
+    assert_allclose(lightcurve.table["stat"], [-86845.74348, -90386.086642], rtol=1e-5)
     assert_allclose(lightcurve.table["norm_err"], [0.041529, 0.041785], rtol=1e-3)
     assert_allclose(lightcurve.table["counts"], [46702, 47508])
     assert_allclose(lightcurve.table["sqrt_ts"], [54.503321, 54.296488], atol=0.01)

--- a/gammapy/utils/interpolation.py
+++ b/gammapy/utils/interpolation.py
@@ -8,7 +8,7 @@ from astropy import units as u
 __all__ = [
     "ScaledRegularGridInterpolator",
     "interpolation_scale",
-    "interpolate_likelihood_profile",
+    "interpolate_profile",
 ]
 
 
@@ -188,29 +188,26 @@ class LinearScale(InterpolationScale):
         return values
 
 
-def interpolate_likelihood_profile(value_scan, dloglike_scan, interp_scale="sqrt"):
-    """Helper function to interpolate likelihood profiles.
+def interpolate_profile(x, y, interp_scale="sqrt"):
+    """Helper function to interpolate one-dimensional profiles.
 
     Parameters
     ----------
-    value_scan : `~numpy.ndarray`
-        Array of parameter values.
-    dloglike_scan : `~numpy.ndarray`
-        Array of delta log-likelihood values, with respect to the minimum.
+    x : `~numpy.ndarray`
+        Array of x values
+    y : `~numpy.ndarray`
+        Array of y values
     interp_scale : {"sqrt", "lin"}
-        Interpolation scale applied to the likelihood profile. If the profile is
+        Interpolation scale applied to the profile. If the profile is
         of parabolic shape, a "sqrt" scaling is recommended. In other cases or
         for fine sampled profiles a "lin" can also be used.
 
     Returns
     -------
     interp : `ScaledRegularGridInterpolator`
-        Interpolator instance.
+        Interpolator
     """
-    # likelihood profiles are typically of parabolic shape, so we use a
-    # sqrt scaling of the values and perform linear interpolation on the scaled
-    # values
-    sign = np.sign(np.gradient(dloglike_scan))
+    sign = np.sign(np.gradient(y))
     return ScaledRegularGridInterpolator(
-        points=(value_scan,), values=sign * dloglike_scan, values_scale=interp_scale
+        points=(x,), values=sign * y, values_scale=interp_scale
     )

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -503,10 +503,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Inspecting likelihood profiles\n",
+    "### Inspecting fit statistic profiles\n",
     "\n",
-    "To check the quality of the fit it is also useful to plot likelihood profiles for specific parameters.\n",
-    "For this we use `~gammapy.modeling.Fit.likelihood_profile()`"
+    "To check the quality of the fit it is also useful to plot fit statistic profiles for specific parameters.\n",
+    "For this we use `~gammapy.modeling.Fit.stat_profile()`."
    ]
   },
   {
@@ -515,7 +515,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "profile = analysis.fit.likelihood_profile(parameter=\"lon_0\")"
+    "profile = analysis.fit.stat_profile(parameter=\"lon_0\")"
    ]
   },
   {

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -532,7 +532,7 @@
    "outputs": [],
    "source": [
     "total_stat = analysis.fit_result.total_stat\n",
-    "plt.plot(profile[\"values\"], profile[\"likelihood\"] - total_stat)\n",
+    "plt.plot(profile[\"values\"], profile[\"stat\"] - total_stat)\n",
     "plt.xlabel(\"Lon (deg)\")\n",
     "plt.ylabel(\"Delta TS\")"
    ]

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -248,7 +248,7 @@
     "dataset.parameters[\"lambda_\"].value = 0.05\n",
     "\n",
     "print(dataset.model)\n",
-    "print(\"log(L) =\", dataset.likelihood())"
+    "print(\"stat =\", dataset.stat_sum())"
    ]
   },
   {
@@ -257,6 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "# Now let's define a function to init parameters and run the MCMC with emcee\n",
     "# Depending on your number of walkers, Nrun and dimensionality, this can take a while (> minutes)\n",
     "sampler = run_mcmc(dataset, nwalkers=6, nrun=150)  # to speedup the notebook\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -498,7 +498,7 @@
     "ax = flux_points.plot(\n",
     "    energy_power=2, flux_unit=\"erg-1 cm-2 s-1\", color=\"darkorange\"\n",
     ")\n",
-    "flux_points.to_sed_type(\"e2dnde\").plot_likelihood(ax=ax)"
+    "flux_points.to_sed_type(\"e2dnde\").plot_stat_profiles(ax=ax)"
    ]
   },
   {
@@ -642,6 +642,13 @@
     "- Compute flux points for the stacked dataset.\n",
     "- Create a `~gammapy.spectrum.FluxPointsDataset` with the flux points you have computed for the stacked dataset and fit the flux points again with obe of the spectral models. How does the result compare to the best fit model, that was directly fitted to the counts data?"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -664,5 +671,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -498,7 +498,7 @@
     "ax = flux_points.plot(\n",
     "    energy_power=2, flux_unit=\"erg-1 cm-2 s-1\", color=\"darkorange\"\n",
     ")\n",
-    "flux_points.to_sed_type(\"e2dnde\").plot_stat_profiles(ax=ax)"
+    "flux_points.to_sed_type(\"e2dnde\").plot_ts_profiles(ax=ax)"
    ]
   },
   {


### PR DESCRIPTION
This pull request fixes #2149, it renames "likelihood", "loglike" terms to "stat".
The idea is that we always use the fit statistic consistently, and for Poisson likelihood it is given by `stat = -2 * log(L)`.
I went with the variant that I prefer, where I use an explicit `stat_sum` and `stat_array` for cases where both sum and array are involved. In output results where only the sum is stored, I use `stat`.

I noticed that the flux point and light curve code is a lot of duplicated copy & paste, I had to do the same edits twice (possibly introducing bugs along the way). Can we do better?

Tests pass, but @adonath - there's probably places I missed?

(I didn't do the `dloglike` cases yet. Are those TS values? -> have to check)