### PR TITLE
Remove MapDataset cstat likelihood option

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -306,7 +306,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_1.counts = dataset_1.npred()
 
     dataset_2 = get_map_dataset(
-        sky_model, geom, geom_etrue, evaluation_mode="global", likelihood="cstat"
+        sky_model, geom, geom_etrue, evaluation_mode="global"
     )
     dataset_2.counts = dataset_2.npred()
 
@@ -323,7 +323,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     npred = dataset_1.npred().data.sum()
     assert_allclose(npred, 6220.529956, rtol=1e-3)
-    assert_allclose(result.total_stat, 11802.750562, rtol=1e-3)
+    assert_allclose(result.total_stat, 27725.577785, rtol=1e-3)
 
     pars = result.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
@@ -349,7 +349,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_2.mask_safe = Map.from_geom(geom, data=mask_safe)
 
     stat = fit.datasets.stat_sum()
-    assert_allclose(stat, 6425.389198)
+    assert_allclose(stat, 15254.470527)
 
     # test model evaluation outside image
 

--- a/gammapy/stats/fit_statistics_cython.pyx
+++ b/gammapy/stats/fit_statistics_cython.pyx
@@ -29,27 +29,3 @@ def cash_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
             if counts[i] > 0:
                 sum -= counts[i] * log(npred[i])
     return 2 * sum
-
-
-@cython.cdivision(True)
-@cython.boundscheck(False)
-def cstat_sum_cython(np.ndarray[np.float_t, ndim=1] counts,
-                     np.ndarray[np.float_t, ndim=1] npred):
-    """Summed cstat fit statistics.
-
-    Parameters
-    ----------
-    counts : `~numpy.ndarray`
-        Counts array.
-    npred : `~numpy.ndarray`
-        Predicted counts array.
-    """
-    cdef np.float_t sum = 0
-    cdef unsigned int i, ni
-    ni = counts.shape[0]
-    for i in range(ni):
-        if npred[i] > 0:
-            sum += npred[i]
-            if counts[i] > 0:
-                sum += (- counts[i] + counts[i] * log(counts[i] / npred[i]))
-    return 2 * sum

--- a/gammapy/stats/tests/test_fit_statistics.py
+++ b/gammapy/stats/tests/test_fit_statistics.py
@@ -118,14 +118,6 @@ def test_cash_sum_cython(test_data):
     assert_allclose(stat, ref)
 
 
-def test_ctstat_sum_cython(test_data):
-    counts = np.array(test_data["n_on"], dtype=float)
-    npred = np.array(test_data["mu_sig"], dtype=float)
-    stat = stats.cstat_sum_cython(counts=counts, npred=npred)
-    ref = stats.cstat(counts, npred).sum()
-    assert_allclose(stat, ref)
-
-
 def test_wstat_corner_cases():
     """test WSTAT formulae for corner cases"""
     n_on = 0


### PR DESCRIPTION
This is a follow-up to #2546, where we renamed "likelihood" to "stat".

While implementing that PR, I noticed that `MapDataset` had an option `likelihood="cash"` which was a string, but then it was set to `self.likelihood_type=likelihood` in init, and in the class `likelihood` actually was the function, not the string. I found this confusing.

Now that the function `likelihood` was renamed to `stat` it's better, but still, I would prefer to be more explicit and to either have `likelihood_type` or `stat_name` or somthing like that as argument for `__init__`, and then to have the same name for the attribute, or to remove the option completely.

This PR removes the option, which is my preference, because then `MapDataset` and `SpectrumDataset` are the same, in `SpectrumDataset` it was already hard-coded to the `cash` statistic. I've actually never seen any gamma-ray paper use `cstat`, I think everyone uses `cash`. `cstat` is something that was only used in a few stats papers where the relation to `chi2` was explored, showing that they match in the high-stats limit - which we never have in gamma-ray astronomy, there's always low stats at high energies and in small spatial bins, so really IMO offering `cstat` isn't doing users a favour, and it's not worth the extra effort (documentation, testing). Instead we should offer more powerful ways to customise the likelihood than by a string, e.g. via subclassing and a datasets registry (see #2512 and #2387), for the few % of users that need it (they likely won't want `cash`, but something else).

@adonath - Thoughts?