### PR TITLE
Remove gammapy.utils.nddata.sqrt_space

### DIFF
--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -305,9 +305,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_1.background_model.norm.value = 0.5
     dataset_1.counts = dataset_1.npred()
 
-    dataset_2 = get_map_dataset(
-        sky_model, geom, geom_etrue, evaluation_mode="global"
-    )
+    dataset_2 = get_map_dataset(sky_model, geom, geom_etrue, evaluation_mode="global")
     dataset_2.counts = dataset_2.npred()
 
     sky_model.parameters["sigma"].frozen = True

--- a/gammapy/utils/nddata.py
+++ b/gammapy/utils/nddata.py
@@ -5,7 +5,7 @@ from astropy.units import Quantity
 from .array import array_stats_str
 from .interpolation import ScaledRegularGridInterpolator
 
-__all__ = ["NDDataArray", "sqrt_space"]
+__all__ = ["NDDataArray"]
 
 
 class NDDataArray:
@@ -156,31 +156,3 @@ class NDDataArray:
         self._regular_grid_interp = ScaledRegularGridInterpolator(
             points, self.data, points_scale=points_scale, **interp_kwargs
         )
-
-
-def sqrt_space(start, stop, num):
-    """Return numbers spaced evenly on a square root scale.
-
-    This function is similar to `numpy.linspace` and `numpy.logspace`.
-
-    Parameters
-    ----------
-    start : float
-        start is the starting value of the sequence
-    stop : float
-        stop is the final value of the sequence
-    num : int
-        Number of samples to generate.
-
-    Returns
-    -------
-    samples : `~numpy.ndarray`
-        1D array with a square root scale
-
-    Examples
-    --------
-    >>> from gammapy.utils.nddata import sqrt_space
-    >>> sqrt_space(0, 2, 5)
-    array([0.        , 1.        , 1.41421356, 1.73205081, 2.        ])
-    """
-    return np.sqrt(np.linspace(start ** 2, stop ** 2, num))

--- a/tutorials/background_model.ipynb
+++ b/tutorials/background_model.ipynb
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "from gammapy.utils.nddata import sqrt_space\n",
+    "from gammapy.maps import MapAxis\n",
     "from gammapy.data import DataStore\n",
     "from gammapy.irf import Background2D"
    ]
@@ -170,7 +170,7 @@
    "source": [
     "%%time\n",
     "ebounds = np.logspace(-1, 2, 20) * u.TeV\n",
-    "offset = sqrt_space(start=0, stop=3, num=10) * u.deg\n",
+    "offset = MapAxis.from_bounds(0, 3, nbin=9, interp=\"sqrt\", unit=\"deg\").edges\n",
     "estimator = BackgroundModelEstimator(ebounds, offset)\n",
     "estimator.run(observations)"
    ]
@@ -267,7 +267,7 @@
     "\n",
     "def make_model(observations):\n",
     "    ebounds = np.logspace(-1, 2, 20) * u.TeV\n",
-    "    offset = sqrt_space(start=0, stop=3, num=10) * u.deg\n",
+    "    offset = MapAxis.from_bounds(0, 3, nbin=9, interp=\"sqrt\", unit=\"deg\").edges\n",
     "    estimator = BackgroundModelEstimator(ebounds, offset)\n",
     "    estimator.run(observations)\n",
     "    return estimator.background_rate\n",
@@ -477,5 +477,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR removes `gammapy.utils.nddata.sqrt_space`, using `MapAxis` instead.
One step to fix #2271 .