### PR TITLE
Set NaN for no likelihood contribution in FluxPointsEstimator

### DIFF
--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -210,10 +210,14 @@ def test_no_likelihood_contribution():
     dataset.model = PowerLawSpectralModel()
     dataset.mask_safe = np.zeros(dataset.data_shape, dtype=bool)
 
-    fpe = FluxPointsEstimator([dataset], e_edges=[1, 10] * u.TeV)
+    fpe = FluxPointsEstimator([dataset], e_edges=[1, 3, 10] * u.TeV)
+    fp = fpe.run()
 
-    with pytest.raises(ValueError):
-        fpe.run()
+    assert np.isnan(fp.table["norm"]).all()
+    assert np.isnan(fp.table["norm_err"]).all()
+    assert np.isnan(fp.table["norm_ul"]).all()
+    assert np.isnan(fp.table["norm_scan"]).all()
+    assert_allclose(fp.table["counts"], 0)
 
 
 def test_mask_shape():
@@ -239,5 +243,6 @@ def test_mask_shape():
         datasets=[dataset_2, dataset_1], e_edges=[1, 10] * u.TeV, source="source"
     )
 
-    with pytest.raises(ValueError):
-        fpe.run()
+    fp = fpe.run()
+
+    assert_allclose(fp.table["counts"], 0)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
This PR changes the `FluxPointEstimator` to return `NaN` in case there is no likelihood contribution from any dataset, instead of raising an error. This change was requested by
@luca-giunti, who worked on the DL3 validation, where the `FluxPointEstimator` failed at 
a late stage in the analysis, which is undesirable for users.

<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

**Dear reviewer**
@luca-giunti Please try and see other this changes fix the issue you encountered.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
