### PR TITLE
Using dataset GTI table in LightCurveEstimator

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -74,8 +74,8 @@ class GTI:
         reference_time : `~astropy.time.Time`
             the reference time to use in GTI definition
         """
-        start = Quantity(start)
-        stop = Quantity(stop)
+        start = np.atleast_1d(Quantity(start))
+        stop = np.atleast_1d(Quantity(stop))
         reference_time = Time(reference_time)
         meta = time_ref_to_dict(reference_time)
         table = Table({"START": start.to("s"), "STOP": stop.to("s")}, meta=meta)

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -130,8 +130,8 @@ class LightCurveEstimator:
         rows = []
         for dataset in self.datasets:
             row = {
-                "time_min": dataset.counts.meta["t_start"].mjd,
-                "time_max": dataset.counts.meta["t_stop"].mjd,
+                "time_min": dataset.gti.time_start[0].mjd,
+                "time_max": dataset.gti.time_stop[-1].mjd,
             }
             row.update(self.estimate_time_bin_flux(dataset, steps))
             rows.append(row)
@@ -179,8 +179,8 @@ class LightCurveEstimator:
             log.warning(
                 "Fit failed for time bin between {t_min} and {t_max},"
                 " setting NaN.".format(
-                    t_min=dataset.counts.meta["t_start"],
-                    t_max=dataset.counts.meta["t_stop"],
+                    t_min=dataset.gti.time_start[0].mjd,
+                    t_max=dataset.gti.time_stop[-1].mjd,
                 )
             )
 

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
+from gammapy.data import GTI
 from gammapy.modeling.models import PowerLawSpectralModel
 from gammapy.spectrum.tests.test_flux_point_estimator import (
     simulate_map_dataset,
@@ -152,16 +153,13 @@ def test_lightcurve_plot_time(lc):
 def get_spectrum_datasets():
     model = PowerLawSpectralModel()
     dataset_1 = simulate_spectrum_dataset(model=model, random_state=0)
-    dataset_1.counts.meta = {
-        "t_start": Time("2010-01-01T00:00:00"),
-        "t_stop": Time("2010-01-01T01:00:00"),
-    }
+    gti1 = GTI.create("0h", "1h", "2010-01-01T00:00:00")
+    dataset_1.gti = gti1
 
     dataset_2 = simulate_spectrum_dataset(model, random_state=1)
-    dataset_2.counts.meta = {
-        "t_start": Time("2010-01-01T01:00:00"),
-        "t_stop": Time("2010-01-01T02:00:00"),
-    }
+    gti2 = GTI.create("1h", "2h", "2010-01-01T00:00:00")
+    dataset_2.gti = gti2
+
 
     return [dataset_1, dataset_2]
 
@@ -202,16 +200,12 @@ def test_lightcurve_estimator_spectrum_datasets():
 
 def get_map_datasets():
     dataset_1 = simulate_map_dataset(random_state=0)
-    dataset_1.counts.meta = {
-        "t_start": Time("2010-01-01T00:00:00"),
-        "t_stop": Time("2010-01-01T01:00:00"),
-    }
+    gti1 = GTI.create("0 h", "1 h", "2010-01-01T00:00:00")
+    dataset_1.gti = gti1
 
     dataset_2 = simulate_map_dataset(random_state=1)
-    dataset_2.counts.meta = {
-        "t_start": Time("2010-01-01T01:00:00"),
-        "t_stop": Time("2010-01-01T02:00:00"),
-    }
+    gti2 = GTI.create("1 h", "2 h", "2010-01-01T00:00:00")
+    dataset_2.gti = gti2
 
     return [dataset_1, dataset_2]
 

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -227,8 +227,6 @@
     "        max_radius=\"0.3 deg\",\n",
     "    )\n",
     "\n",
-    "    stacked.counts.meta[\"t_start\"] = time_interval[0]\n",
-    "    stacked.counts.meta[\"t_stop\"] = time_interval[1]\n",
     "    datasets.append(stacked)"
    ]
   },
@@ -401,10 +399,6 @@
     "    dataset = dataset_maker.run(\n",
     "        observation, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
     "    )\n",
-    "\n",
-    "    dataset.counts.meta = dict()\n",
-    "    dataset.counts.meta[\"t_start\"] = time_interval[0]\n",
-    "    dataset.counts.meta[\"t_stop\"] = time_interval[1]\n",
     "\n",
     "    dataset_on_off = bkg_maker.run(dataset, observation)\n",
     "    dataset_on_off = safe_mask_masker.run(dataset_on_off, observation)\n",


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
The time information of a `dataset`is now stored on a `GTI` table. The `LightCurveEstimator` uses a hack where the `t_start` `t_stop` information is stored on the `dataset.counts.meta`. See issue #2547.
This pull request solves this by making `LightCurveEstimator` use the `dataset.GTI` information for the definition of the time bin.
The PR is paid-coded with @JouvinLea at the Granada coding sprint.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
Please merge my PR.