### PR TITLE
Add documentation for SpectrumDatasetOnOff to and from ogip methods

### DIFF
--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -868,6 +868,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         'cm2'.
 
         The naming scheme is fixed, with {name} the dataset name:
+        
         * PHA file is named pha_obs{name}.fits
         * BKG file is named bkg_obs{name}.fits
         * ARF file is named arf_obs{name}.fits
@@ -973,6 +974,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         the same folder.
 
         The naming scheme is fixed to the following scheme
+
         * PHA file is named pha_obs{name}.fits
         * BKG file is named bkg_obs{name}.fits
         * ARF file is named arf_obs{name}.fits

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -867,6 +867,12 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         ``use_sherpa`` flag. Then all files will be written in units 'keV' and
         'cm2'.
 
+        The naming scheme is fixed, with {name} the dataset name:
+        * PHA file is named pha_obs{name}.fits
+        * BKG file is named bkg_obs{name}.fits
+        * ARF file is named arf_obs{name}.fits
+        * RMF file is named rmf_obs{name}.fits
+
         Parameters
         ----------
         outdir : `pathlib.Path`
@@ -965,6 +971,13 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         BKG file, ARF, and RMF must be set in the PHA header and be present in
         the same folder.
+
+        The naming scheme is fixed to the following scheme
+        * PHA file is named pha_obs{name}.fits
+        * BKG file is named bkg_obs{name}.fits
+        * ARF file is named arf_obs{name}.fits
+        * RMF file is named rmf_obs{name}.fits
+         with {name} the dataset name.
 
         Parameters
         ----------


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->
This PR proposes a fix for issue #2542 concerning OGIP file names for `SpectrumDatasetOnOff`. No change is made in the code, but documentation is improved to explicitly explain the naming scheme that we apply.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
the sphinx documentation has been recompiled and the addition normally works. 