### PR TITLE
Add time intervals as an argument to the LIghtCurveEstimator

### DIFF
--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -2,6 +2,7 @@
 import logging
 import numpy as np
 from astropy.time import Time
+from astropy.table import Table
 import astropy.units as u
 from gammapy.modeling import Datasets, Fit
 from gammapy.modeling.models import ScaleSpectralModel
@@ -12,6 +13,45 @@ from gammapy.utils.table import table_from_row_data
 __all__ = ["LightCurveEstimator"]
 
 log = logging.getLogger(__name__)
+
+
+def group_datasets_in_time_interval(datasets, time_intervals, atol="1e-6 s"):
+    """Compute the table with the info on the group to which belong each dataset
+    The Tsart and Tstop are stored in MJD from a scale in "utc"
+    Parameters
+    ----------
+    datasets : list of `~gammapy.spectrum.SpectrumDataset` or `~gammapy.cube.MapDataset`
+        Spectrum or Map datasets.
+    time_intervals : list of `astropy.time.Time`
+        Start and stop time for each intervals to compute the LC
+
+    Returns
+    -------
+    table_info : `~astropy.table.Table`
+        Contains the grouping info for each dataset
+    atol : `~astropy.units.Quantity`
+        Tolerance value for time comparison with different scale (Ex= "tt", "utc")
+
+    """
+    table_info = Table(names=('Name', 'Tstart', 'Tstop', 'Bin_type', 'Group_ID'), meta={'name': 'first table'},
+                       dtype=('S10', 'f8', 'f8', 'S10', 'i8'))
+    time_intervals_lowedges = [time_interval[0] for time_interval in time_intervals]
+    time_intervals_upedges = [time_interval[1] for time_interval in time_intervals]
+
+    for dataset in datasets:
+        tstart = dataset.gti.time_start[0]
+        tstop = dataset.gti.time_stop[-1]
+        mask = tstart >= Time(time_intervals_lowedges) - atol
+        mask &= tstop <= Time(time_intervals_upedges) + atol
+        if np.any(mask):
+            group_index = np.where(mask)[0]
+            bin_type = ""
+        else:
+            group_index = -1
+            bin_type = "Overflow"
+        table_info.add_row([dataset.name, tstart.utc.mjd, tstop.utc.mjd, bin_type, group_index])
+
+    return table_info
 
 
 class LightCurveEstimator:
@@ -45,17 +85,17 @@ class LightCurveEstimator:
     """
 
     def __init__(
-        self,
-        datasets,
-        time_intervals=None,
-        source="",
-        norm_min=0.2,
-        norm_max=5,
-        norm_n_values=11,
-        norm_values=None,
-        sigma=1,
-        sigma_ul=2,
-        reoptimize=False,
+            self,
+            datasets,
+            time_intervals=None,
+            source="",
+            norm_min=0.2,
+            norm_max=5,
+            norm_n_values=11,
+            norm_values=None,
+            sigma=1,
+            sigma_ul=2,
+            reoptimize=False,
     ):
         self.datasets = Datasets(datasets)
 
@@ -77,7 +117,6 @@ class LightCurveEstimator:
         time_stop_sorted = time_stop[sorted_indices]
         diff_time_stop = np.diff(time_stop_sorted)
         diff_time_interval_edges = time_start_sorted[1:] - time_stop_sorted[:-1]
-
         if np.any(diff_time_stop < 0) or np.any(diff_time_interval_edges < 0):
             raise ValueError("You give overlapping time bin to perform the LC.")
         else:
@@ -110,6 +149,7 @@ class LightCurveEstimator:
         self.source = source
 
         self._set_scale_model()
+        self.group_table_info = None
 
     def _set_scale_model(self):
         # set the model on all datasets
@@ -146,7 +186,8 @@ class LightCurveEstimator:
                 * "norm-scan": estimate fit statistic profiles.
 
             By default all steps are executed.
-        atol :
+        atol : `~astropy.units.Quantity`
+            Tolerance value for time comparison with different scale (Ex= "tt", "utc")
 
         Returns
         -------
@@ -158,32 +199,25 @@ class LightCurveEstimator:
         self.e_min = e_min
         self.e_max = e_max
 
-        list_tstart_dataset = Time([d.gti.time_start[0] for d in self.datasets])
-        list_tstop_dataset = Time([d.gti.time_stop[-1] for d in self.datasets])
         rows = []
-
-        for time_interval in self.time_intervals:
-            mask = list_tstart_dataset >= time_interval[0] - atol
-            mask &= list_tstop_dataset <= time_interval[1] + atol
-            if np.any(mask):
-                index = np.where(mask)[0]
-                row = {
-                    "time_min": time_interval[0].mjd,
-                    "time_max": time_interval[1].mjd,
-                }
-                interval_list_dataset = Datasets([self.datasets[int(_)] for _ in index])
-                row.update(
-                    self.estimate_time_bin_flux(
-                        interval_list_dataset, time_interval, steps
-                    )
-                )
-                rows.append(row)
-            else:
-                continue
-        if len(rows) == 0:
+        self.group_table_info = group_datasets_in_time_interval(datasets=self.datasets,
+                                                                time_intervals=self.time_intervals,
+                                                                atol=atol)
+        if np.all(self.group_table_info["Bin_type"] == "Overflow"):
             raise ValueError(
                 "None of your dataset GTI are include in the time intervals"
             )
+        for igroup, time_interval in enumerate(self.time_intervals):
+            index_dataset = np.where(self.group_table_info["Group_ID"] == igroup)[0]
+            row = {
+                "time_min": time_interval[0].mjd,
+                "time_max": time_interval[1].mjd,
+            }
+            interval_list_dataset = Datasets([self.datasets[int(_)] for _ in index_dataset])
+            row.update(
+                self.estimate_time_bin_flux(interval_list_dataset, time_interval, steps)
+            )
+            rows.append(row)
         table = table_from_row_data(rows=rows, meta={"SED_TYPE": "likelihood"})
         table = FluxPoints(table).to_sed_type("flux").table
         return LightCurve(table)

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -26,7 +26,7 @@ def group_datasets_in_time_interval(datasets, time_intervals, atol="1e-6 s"):
     time_intervals : list of `astropy.time.Time`
         Start and stop time for each interval to compute the LC
     atol : `~astropy.units.Quantity`
-        Tolerance value for time comparison with different scale (Ex= "tt", "utc"). Default 1e-6 sec.
+        Tolerance value for time comparison with different scale. Default 1e-6 sec.
 
     Returns
     -------
@@ -133,7 +133,7 @@ class LightCurveEstimator:
         diff_time_stop = np.diff(time_stop_sorted)
         diff_time_interval_edges = time_start_sorted[1:] - time_stop_sorted[:-1]
         if np.any(diff_time_stop < 0) or np.any(diff_time_interval_edges < 0):
-            raise ValueError("You give overlapping time bin to perform the LC.")
+            raise ValueError("LightCurveEstimator requires non-overlapping time bins.")
         else:
             self.time_intervals = [
                 Time([tstart, tstop])
@@ -208,7 +208,7 @@ class LightCurveEstimator:
 
             By default all steps are executed.
         atol : `~astropy.units.Quantity`
-            Tolerance value for time comparison with different scale (Ex= "tt", "utc"). Default 1e-6 sec.
+            Tolerance value for time comparison with different scale. Default 1e-6 sec.
 
         Returns
         -------
@@ -225,13 +225,11 @@ class LightCurveEstimator:
             datasets=self.datasets, time_intervals=self.time_intervals, atol=atol
         )
         if np.all(self.group_table_info["Group_ID"] == -1):
-            raise ValueError(
-                "None of your dataset GTI are include in the time intervals"
-            )
+            raise ValueError("LightCurveEstimator: No datasets in time intervals")
         for igroup, time_interval in enumerate(self.time_intervals):
             index_dataset = np.where(self.group_table_info["Group_ID"] == igroup)[0]
             if len(index_dataset) == 0:
-                log.info("No Dataset for the time interval " + str(igroup))
+                log.debug("No Dataset for the time interval " + str(igroup))
                 continue
 
             row = {"time_min": time_interval[0].mjd, "time_max": time_interval[1].mjd}

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -136,10 +136,12 @@ def test_lightcurve_plot_time(lc):
 def get_spectrum_datasets():
     model = PowerLawSpectralModel()
     dataset_1 = simulate_spectrum_dataset(model=model, random_state=0)
+    dataset_1.name="dataset_1"
     gti1 = GTI.create("0h", "1h", "2010-01-01T00:00:00")
     dataset_1.gti = gti1
 
     dataset_2 = simulate_spectrum_dataset(model, random_state=1)
+    dataset_2.name = "dataset_2"
     gti2 = GTI.create("1h", "2h", "2010-01-01T00:00:00")
     dataset_2.gti = gti2
 
@@ -184,6 +186,12 @@ def test_lightcurve_estimator_spectrum_datasets():
         [444.426957, 23.375417, 3945.382802],
         rtol=1e-5,
     )
+
+    assert len(estimator.group_table_info) == 2
+    assert estimator.group_table_info["Name"][0] == "dataset_1"
+    assert_allclose(estimator.group_table_info["Tstart"], [55197.0, 55197.04166666667])
+    assert_allclose(estimator.group_table_info["Tstop"], [55197.04166666667, 55197.083333333336])
+    assert_allclose(estimator.group_table_info["Group_ID"], [0, 1])
 
     # Test default time interval: each time interval is equal to the gti of each dataset, here one hour
     datasets = get_spectrum_datasets()
@@ -268,11 +276,13 @@ def test_lightcurve_estimator_spectrum_datasets():
 
 def get_map_datasets():
     dataset_1 = simulate_map_dataset(random_state=0)
+    dataset_1.name = "dataset_1"
     gti1 = GTI.create("0 h", "1 h", "2010-01-01T00:00:00")
     dataset_1.gti = gti1
 
     dataset_2 = simulate_map_dataset(random_state=1)
     gti2 = GTI.create("1 h", "2 h", "2010-01-01T00:00:00")
+    dataset_2.name = "dataset_2"
     dataset_2.gti = gti2
 
     return [dataset_1, dataset_2]

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -346,7 +346,7 @@ def test_lightcurve_estimator_spectrum_datasets_timeoverlaped():
     ]
     with pytest.raises(ValueError) as excinfo:
         LightCurveEstimator(datasets, norm_n_values=3, time_intervals=time_intervals)
-    msg = "You give overlapping time bin to perform the LC."
+    msg = "LightCurveEstimator requires non-overlapping time bins."
     assert str(excinfo.value) == msg
 
 
@@ -365,7 +365,7 @@ def test_lightcurve_estimator_spectrum_datasets_gti_not_include_in_time_interval
     with pytest.raises(ValueError) as excinfo:
         steps = ["err", "counts", "ts", "norm-scan"]
         estimator.run(e_ref=10 * u.TeV, e_min=1 * u.TeV, e_max=100 * u.TeV, steps=steps)
-    msg = "None of your dataset GTI are include in the time intervals"
+    msg = "LightCurveEstimator: No datasets in time intervals"
     assert str(excinfo.value) == msg
 
 

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -239,6 +239,7 @@ def test_lightcurve_estimator_spectrum_datasets():
         rtol=1e-5,
     )
 
+
 @requires_data()
 @requires_dependency("iminuit")
 def test_lightcurve_estimator_spectrum_datasets_withmaskfit():
@@ -257,11 +258,14 @@ def test_lightcurve_estimator_spectrum_datasets_withmaskfit():
 
     steps = ["err", "counts", "ts", "norm-scan"]
     estimator = LightCurveEstimator(
-        datasets, norm_n_values=3, time_intervals=time_intervals)
-    lightcurve = estimator.run(e_ref=10 * u.TeV, e_min=1 * u.TeV, e_max=100 * u.TeV, steps=steps)
+        datasets, norm_n_values=3, time_intervals=time_intervals
+    )
+    lightcurve = estimator.run(
+        e_ref=10 * u.TeV, e_min=1 * u.TeV, e_max=100 * u.TeV, steps=steps
+    )
     assert_allclose(lightcurve.table["time_min"], [55197.0, 55197.041667])
     assert_allclose(lightcurve.table["time_max"], [55197.041667, 55197.083333])
-    assert_allclose(lightcurve.table["stat"], [6.60304 , 0.421047], rtol=1e-5)
+    assert_allclose(lightcurve.table["stat"], [6.60304, 0.421047], rtol=1e-5)
     assert_allclose(lightcurve.table["norm"], [0.885082, 0.967022], rtol=1e-5)
 
 

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -33,6 +33,8 @@
     "from astropy.coordinates import SkyCoord\n",
     "import logging\n",
     "\n",
+    "from astropy.time import Time\n",
+    "\n",
     "log = logging.getLogger(__name__)"
    ]
   },
@@ -302,6 +304,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to add a fit range for each of you time intervals when computing the LC."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "e_min_fit = 0.8 * u.TeV\n",
+    "e_max_fit = 10 * u.TeV\n",
+    "for dataset in ana_1d.datasets:\n",
+    "    mask_fit = dataset.counts.energy_mask(emin=e_min_fit, emax=e_max_fit)\n",
+    "    dataset.mask_fit = mask_fit"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -335,8 +357,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Perform a LC by night\n",
-    "Here we define the time intervals to compute the LC by night"
+    "## LC estimation by night\n",
+    "We define the time intervals to compute the LC by night, here three nights."
    ]
   },
   {
@@ -345,10 +367,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.time import Time\n",
-    "time_int_obs = [round(obs.tstart.utc.mjd) for obs in ana_1d.observations]\n",
-    "time_int_night = np.unique(time_int_obs)\n",
-    "time_intervals = [Time([t_night-0.5,t_night+0.5], format='mjd', scale='utc') for t_night in time_int_night]"
+    "time_intervals = [Time([53343.5,53344.5], format='mjd', scale='utc'),\n",
+    "                Time([53345.5,53346.5], format='mjd', scale='utc'),\n",
+    "                Time([53347.5,53348.5], format='mjd', scale='utc')\n",
+    "                 ]\n"
    ]
   },
   {

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -10,6 +10,8 @@
     "\n",
     "This tutorial presents a new light curve estimator that works with dataset objects. We will demonstrate how to compute a `~gammapy.time.LightCurve` from 3D data cubes as well as 1D spectral data using the `~gammapy.cube.MapDataset`, `~gammapy.spectrum.SpectrumDatasetOnOff` and `~gammapy.time.LightCurveEstimator` classes. \n",
     "\n",
+    "We will compute two LCs: one per observation and one by night for which you have to provide the time intervals\n",
+    "    \n",
     "We will use the four Crab nebula observations from the [H.E.S.S. first public test data release](https://www.mpi-hd.mpg.de/hfm/HESS/pages/dl3-dr1/) and compute per-observation fluxes. The Crab nebula is not known to be variable at TeV energies, so we expect constant brightness within statistical and systematic errors.\n",
     "\n",
     "## Setup\n",
@@ -19,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,264 +55,227 @@
     "from gammapy.modeling.models import SkyModel\n",
     "from gammapy.cube import MapDatasetMaker, MapDataset, SafeMaskMaker\n",
     "from gammapy.maps import WcsGeom, MapAxis\n",
-    "from gammapy.time import LightCurveEstimator"
+    "from gammapy.time import LightCurveEstimator\n",
+    "from gammapy.analysis import Analysis, AnalysisConfig "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Select the data\n",
+    "## Analysis configuration \n",
+    "For the 1D and 3D extraction, we will use the same CrabNebula configuration than in the notebook analysis_1.ipynb using the high level interface of Gammapy.\n",
     "\n",
-    "We look for relevant observations in the datastore."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")\n",
-    "mask = data_store.obs_table[\"TARGET_NAME\"] == \"Crab\"\n",
-    "obs_ids = data_store.obs_table[\"OBS_ID\"][mask].data\n",
-    "crab_obs = data_store.get_observations(obs_ids)"
+    "From the high level interface, the datareduction for those observations is performed as followed"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Define time intervals\n",
-    "We create a list of time intervals. Here we use one time bin per observation."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "time_intervals = [(obs.tstart, obs.tstop) for obs in crab_obs]"
+    "### 3D data reduction + Fit\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3D data reduction \n",
-    "\n",
-    "### Define the analysis geometry\n",
-    "\n",
-    "Here we define the geometry used in the analysis. We use the same WCS map structure but we use two different binnings for reco and true energy axes. This allows for a broader coverage of the response."
+    "#### Data reduction"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Target definition\n",
+    "conf_3d=AnalysisConfig.from_template(\"3d\") \n",
+    "# We want to extract the data by observation and therefore to not stack them\n",
+    "conf_3d.settings['datasets']['stack-datasets']=False\n",
+    "#Fixing more physical binning\n",
+    "conf_3d.settings['datasets']['geom']['axes'][0]['lo_bnd']=0.7\n",
+    "conf_3d.settings['datasets']['geom']['axes'][0]['nbin']=10\n",
+    "conf_3d.settings['datasets']['energy-axis-true']['lo_bnd']=0.1\n",
+    "conf_3d.settings['datasets']['energy-axis-true']['hi_bnd']=20\n",
+    "conf_3d.settings['datasets']['energy-axis-true']['nbin']=20\n",
+    "conf_3d.settings['datasets']['geom']['width']=[2,2]\n",
+    "conf_3d.settings['datasets']['geom']['binsz']=0.02\n",
+    "\n",
+    "ana_3d=Analysis(conf_3d)\n",
+    "ana_3d.get_observations()\n",
+    "ana_3d.get_datasets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### 3D Fit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the model to be fitted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "target_position = SkyCoord(ra=83.63308, dec=22.01450, unit=\"deg\")\n",
-    "\n",
-    "# Define geoms\n",
-    "emin, emax = [0.7, 10] * u.TeV\n",
-    "energy_axis = MapAxis.from_bounds(\n",
-    "    emin.value, emax.value, 10, unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
-    ")\n",
-    "geom = WcsGeom.create(\n",
-    "    skydir=target_position,\n",
-    "    binsz=0.02,\n",
-    "    width=(2, 2),\n",
-    "    coordsys=\"CEL\",\n",
-    "    proj=\"CAR\",\n",
-    "    axes=[energy_axis],\n",
-    ")\n",
-    "\n",
-    "energy_axis_true = MapAxis.from_bounds(\n",
-    "    0.1, 20, 20, unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
-    ")\n",
-    "\n",
-    "offset_max = 2 * u.deg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Define the 3D model \n",
-    "\n",
-    "The light curve is based on a 3D fit of a map dataset in time bins. We therefore need to define the source model to be applied. Here a point source with power law spectrum. We freeze its parameters assuming they were previously extracted"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define the source model - Use a pointsource + integrated power law model to directly get flux\n",
-    "\n",
     "spatial_model = PointSpatialModel(\n",
-    "    lon_0=target_position.ra, lat_0=target_position.dec, frame=\"icrs\"\n",
+    "   lon_0=target_position.ra, lat_0=target_position.dec, frame=\"icrs\"\n",
     ")\n",
-    "\n",
     "spectral_model = PowerLawSpectralModel(\n",
-    "    index=2.6,\n",
-    "    amplitude=2.0e-11 * u.Unit(\"1 / (cm2 s TeV)\"),\n",
-    "    reference=1 * u.TeV,\n",
+    "   index=2.6,\n",
+    "   amplitude=2.0e-11 * u.Unit(\"1 / (cm2 s TeV)\"),\n",
+    "   reference=1 * u.TeV,\n",
     ")\n",
     "spectral_model.parameters[\"index\"].frozen = False\n",
-    "\n",
     "sky_model = SkyModel(\n",
-    "    spatial_model=spatial_model, spectral_model=spectral_model, name=\"\"\n",
+    "   spatial_model=spatial_model, spectral_model=spectral_model, name=\"crab\"\n",
     ")\n",
     "sky_model.parameters[\"lon_0\"].frozen = True\n",
-    "sky_model.parameters[\"lat_0\"].frozen = True"
+    "sky_model.parameters[\"lat_0\"].frozen = True\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Make the map datasets\n",
-    "\n",
-    "The following function is in charge of the MapDataset production. It will later be fully covered in the data reduction chain "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we perform the actual data reduction in time bins"
+    "We assign them the model to be fitted to each dataset"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ljouvin/installation_python/miniconda3/envs/gammapy-dev/lib/python3.7/site-packages/astropy/units/quantity.py:464: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  result = super().__array_ufunc__(function, method, *arrays, **kwargs)\n",
-      "/home/ljouvin/installation_gammapy/gammapy/gammapy/cube/psf_kernel.py:109: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  img += vals.value / vals.sum().value\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 2.12 s, sys: 68.1 ms, total: 2.19 s\n",
-      "Wall time: 2.18 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "\n",
-    "datasets = []\n",
-    "\n",
-    "maker = MapDatasetMaker(offset_max=offset_max)\n",
-    "maker_safe_mask = SafeMaskMaker(methods=[\"offset-max\"], offset_max=offset_max)\n",
-    "\n",
-    "for time_interval in time_intervals:\n",
-    "    # get filtered observation lists in time interval\n",
-    "    observations = crab_obs.select_time(time_interval)\n",
-    "\n",
-    "    # Proceed with further analysis only if there are observations\n",
-    "    # in the selected time window\n",
-    "    if len(observations) == 0:\n",
-    "        log.warning(f\"No observations in time interval: {time_interval}\")\n",
-    "        continue\n",
-    "\n",
-    "    stacked = MapDataset.create(geom=geom, energy_axis_true=energy_axis_true)\n",
-    "\n",
-    "    for obs in observations:\n",
-    "        dataset = maker.run(stacked, obs)\n",
-    "        dataset = maker_safe_mask.run(dataset, obs)\n",
-    "        stacked.stack(dataset)\n",
-    "\n",
-    "    # TODO: remove once IRF maps are handled correctly in fit\n",
-    "    stacked.edisp = stacked.edisp.get_energy_dispersion(\n",
-    "        position=target_position, e_reco=energy_axis.edges\n",
-    "    )\n",
-    "\n",
-    "    stacked.psf = stacked.psf.get_psf_kernel(\n",
-    "        position=target_position,\n",
-    "        geom=stacked.exposure.geom,\n",
-    "        max_radius=\"0.3 deg\",\n",
-    "    )\n",
-    "\n",
-    "    datasets.append(stacked)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Light Curve estimation: the 3D case\n",
-    "\n",
-    "Now that we have created the datasets we assign them the model to be fitted:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "for dataset in datasets:\n",
-    "    # Copy the source model\n",
-    "    model = sky_model.copy(name=\"crab\")\n",
-    "    dataset.model = model"
+    "model = {}\n",
+    "model[\"components\"] = [sky_model.to_dict()]\n",
+    "ana_3d.set_model(model=model)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now create the light curve estimator by passing it the list of datasets. \n",
-    "We can optionally ask for parameters reoptimization during fit, e.g. to fit background normalization in each time bin."
+    "Do the fit"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_maker = LightCurveEstimator(datasets, source=\"crab\", reoptimize=True)"
+    "ana_3d.run_fit()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now run the estimator once we pass it the energy interval on which to compute the integral flux of the source."
+    "### 1D data reduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Data reduction"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 13 s, sys: 61.2 ms, total: 13 s\n",
-      "Wall time: 13 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%time\n",
-    "lc = lc_maker.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
+    "conf_1d=AnalysisConfig.from_template(\"1d\") \n",
+    "# We want to extract the data by observation and therefore to not stack them\n",
+    "conf_1d.settings['datasets']['stack-datasets']=False\n",
+    "conf_1d.settings['datasets']['containment_correction']=True\n",
+    "conf_1d.settings['datasets']['geom']['axes'][0]['lo_bnd']=0.7\n",
+    "conf_1d.settings['datasets']['geom']['axes'][0]['hi_bnd']=40\n",
+    "conf_1d.settings['datasets']['geom']['axes'][0]['nbin']=40\n",
+    "\n",
+    "ana_1d=Analysis(conf_1d)     \n",
+    "ana_1d.get_observations() \n",
+    "ana_1d.get_datasets() "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### 1D Fit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We assign the spectral model to be fitted to each dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = {}\n",
+    "model[\"components\"] = [sky_model.to_dict()]\n",
+    "ana_1d.set_model(model=model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Do the fit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ana_1d.run_fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Light Curve estimation: by observation\n",
+    "We can now create the light curve estimator by passing it the list of datasets. We can optionally ask for parameters reoptimization during fit, e.g. to fit background normalization in each time bin.\n",
+    "\n",
+    "By default, the LightCurveEstimator is performed by dataset, here one dataset=one observation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc_maker_3d = LightCurveEstimator(ana_3d.datasets, source=\"crab\", reoptimize=True)\n",
+    "lc_3d = lc_maker_3d.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
    ]
   },
   {
@@ -322,242 +287,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=4</i>\n",
-       "<table id=\"table140186384886416\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>time_min</th><th>time_max</th><th>flux</th><th>flux_err</th></tr></thead>\n",
-       "<thead><tr><th></th><th></th><th>1 / (cm2 s)</th><th>1 / (cm2 s)</th></tr></thead>\n",
-       "<thead><tr><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
-       "<tr><td>53343.92234009259</td><td>53343.94186555556</td><td>2.5854277282288015e-11</td><td>1.9875463397770685e-12</td></tr>\n",
-       "<tr><td>53343.95421509259</td><td>53343.97369425926</td><td>2.319630064068609e-11</td><td>1.9201169445408757e-12</td></tr>\n",
-       "<tr><td>53345.96198129629</td><td>53345.98149518518</td><td>2.995335044221267e-11</td><td>2.647801685325784e-12</td></tr>\n",
-       "<tr><td>53347.913196574074</td><td>53347.93271046296</td><td>2.752076433659184e-11</td><td>2.4998874622862153e-12</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=4>\n",
-       "     time_min           time_max     ...        flux_err       \n",
-       "                                     ...      1 / (cm2 s)      \n",
-       "     float64            float64      ...        float64        \n",
-       "------------------ ----------------- ... ----------------------\n",
-       " 53343.92234009259 53343.94186555556 ... 1.9875463397770685e-12\n",
-       " 53343.95421509259 53343.97369425926 ... 1.9201169445408757e-12\n",
-       " 53345.96198129629 53345.98149518518 ...  2.647801685325784e-12\n",
-       "53347.913196574074 53347.93271046296 ... 2.4998874622862153e-12"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lc.table[\"time_min\", \"time_max\", \"flux\", \"flux_err\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We finally plot the light curve"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7fafaccb00>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAERCAYAAAB2CKBkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAaY0lEQVR4nO3df5xddX3n8dfbZJCBoFEzVZiQRlFjrZGERgjN2vKrBrALEe2iZWOhUKAPf4BlI42768rSLWgUW+3yI4UKfRRRhGmWIhDYAlVKSJhkQoYkBKPRkEncDD+GH3UKyeSzf5wzcHO5M/fM5J57ZnLez8djHrn3e7733M+czMz7fs+P71FEYGZm5fWGogswM7NiOQjMzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkxmUQSPo7STslPd6g9d0jqU/SnVXtn5W0WVJImtKI9zIzG2vGZRAANwInN3B9S4CFNdr/FTgJ+EUD38vMbEwZl0EQET8Cnq1sk3RE+sl+taQfS3rfCNb3z8CLNdq7IuLn+1ywmdkYNrHoAhpoKXBhRPxE0jHA1cAJBddkZjbm7RdBIGkS8NvADyQNNr8xXXYG8D9rvKwnIuY3p0Izs7FrvwgCkl1cfRExq3pBRHQAHc0vycxsfBiXxwiqRcQLwBZJfwCgxJEFl2VmNi6MyyCQdAuwApghaZukc4GzgHMlPQasB04fwfp+DPwAODFd3/y0/fOStgFTgXWSrm/092JmVjR5Gmozs3IblyMCMzNrnHF3sHjKlCkxffr0osswMxtXVq9e/XREtNVaNu6CYPr06XR2dhZdhpnZuCJpyBkSvGvIzKzkHARmZiXnIDAzKzkHgZlZyTkIzMxKzkFgZlZyDgIzs5JzEJiZlZyDwCwHZ163gjOvW1F0GWaZOAjMzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiXnIDAzKzkHgZlZyeUWBJIOlLRK0mOS1ku6rEafsyStS78elnRkXvWYmVlted6q8mXghIh4SVIL8JCkuyPikYo+W4DfjYjnJJ0CLAWOybEmMzOrklsQREQAL6VPW9KvqOrzcMXTR4CpedVjZma15XqMQNIESWuBncB9EbFymO7nAncPsZ7zJXVK6uzt7c2jVDOz0so1CCJiICJmkXzSP1rSB2r1k3Q8SRBcOsR6lkbEnIiY09bWll/BZmYl1JSzhiKiD3gQOLl6maQPAtcDp0fEM82ox8zMXpPnWUNtkianj1uBk4AnqvpMAzqAhRHxZF61mJnZ0PI8a+hQ4CZJE0gC59aIuFPShQARcS3wZeBtwNWSAHZHxJwcazIzsyp5njW0Dphdo/3aisfnAeflVYOZmdXnK4vNzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiXnIDAzKzkHgZlZyTkIzMxKzkFgZlZyDgIzs5JzEJiZlZyDwMys5BwEZmYl5yAwMys5B4GZWck5CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJecgMDMrOQeBmVnJOQjMzErOQWBmVnK5BYGkAyWtkvSYpPWSLqvRR5K+JWmzpHWSjsqrHjMzqy3PEcHLwAkRcSQwCzhZ0tyqPqcA70m/zgeuybEes6ZY1tVD19Y+Vm55lnlX3s+yrp6iSzIbVm5BEImX0qct6VdUdTsd+Pu07yPAZEmH5lWTWd6WdfWwuKObVwb2ANDT18/ijm6Hge2TM69bwZnXrcht/bkeI5A0QdJaYCdwX0SsrOrSDjxV8Xxb2la9nvMldUrq7O3tza9gs320ZPkm+ncN7NXWv2uAJcs3FVSRWX25BkFEDETELGAqcLSkD1R1Ua2X1VjP0oiYExFz2tra8ijVrCG29/WPqN1sLGjKWUMR0Qc8CJxctWgbcHjF86nA9mbUZJaHwya3jqjdbCzI86yhNkmT08etwEnAE1Xd7gA+nZ49NBd4PiJ25FWTWd4WzZ9Ba8uEvdpaWyawaP6Mgioyq29ijus+FLhJ0gSSwLk1Iu6UdCFARFwL3AWcCmwGfgWck2M9ZrlbMDs5xPXF29bxysAe2ie3smj+jFfbzcai3IIgItYBs2u0X1vxOIDP5FWDWREWzG7nllVbAfj+BccWXI1Zfb6y2Mys5BwEZmYl5yAwMys5B4GZWck5CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJecgMDMruUxzDUn6NWAecBjQDzwOdEbEnhxrMzOzJhg2CCQdD/w58Fagi+ROYwcCC4AjJN0GfCMiXsi7UDMzy0e9EcGpwJ9ExNbqBZImAr8P/B5wew61mZlZEwwbBBGxaJhlu4FlDa/IzMyaatQHiyX5JjJmZvuBfTlr6LKGVWFmZoWpd7B43VCLgLc3vhwzM2u2egeL3w7MB56rahfwcC4VmZlZU9ULgjuBSRGxtnqBpAdzqcjMzJqq3llD5w6z7A8bX46ZmTXbiA8WSzo/j0LMzKwYozlr6MKGV2FmZoUZTRCo4VWYmVlhRhME/7HhVZiZWWEyBYGkiyS9SZKAyyStkfSROq85XNIDkjZKWi/pohp93izpnyQ9lvbx1cpmZk2WdUTwx+kMox8B2oBzgCvrvGY3cElE/AYwF/iMpPdX9fkMsCEijgSOA74h6YCsxZuZ2b7LGgSDxwVOBb4TEY9R51hBROyIiDXp4xeBjUB7dTfgkHSkMQl4liRAzMysSTLdmAZYLele4J3AYkmHAJlvSiNpOjAbWFm16G+AO4DtwCHAmb7ZjZlZc2UNgnOBWcDPIuJXkt5GsnuoLkmTSO5XcHGNG9jMB9YCJwBHAPdJ+nF1v/TahfMBpk2blrFkMzPLItOuoYjYExFrIqIvff5MRAw1Id2rJLWQhMDNEdFRo8s5QEckNgNbgPfVeP+lETEnIua0tbVlKdnMzDLK7eb16X7/G4CNEXHVEN22Aiem/d8OzAB+lldNZ163gjOvW5HX6s3MxqWsu4ZGYx6wEOiWNDhp3ZeAaQARcS1wOXCjpG6Sg8+XRsTTOdZkZmZVcguCiHiI+mcWbSc5JdXMzAoy7K4hSTMlPSLpKUlLJb2lYtmq/MszMyu3ZV09dG3tY+WWZ5l35f0s6+pp+HvUO0ZwDfAVYCbwJPCQpCPSZS0Nr8bMzF61rKuHxR3dvDKQnFXf09fP4o7uhodBvSCYFBH3RERfRHwd+Cxwj6S5JBeDmZlZTpYs30T/roG92vp3DbBk+aaGvk+9YwSS9OaIeB4gIh6Q9HGSU0Lf2tBKzMxsL9v7+kfUPlr1RgRfBX6jsiG9fuBEoNZ1AWZm1iCHTW4dUfto1btV5Xer2yS9IyK2An/S0ErM9iPfv+DYokuw/cCi+TNY3NG91+6h1pYJLJo/o6HvM5oLyu5qaAVmZlbTgtntXHHGTA6YkPypbp/cyhVnzGTB7Or5O/fNaK4j8B3KzMyaZMHsdm5ZtRXIb6Q5mhHB3za8CjMzK0zmEUF6MdnhwCOSjgIYvN+AmZmNX5mCQNLlwNnAT3nt+oEgmT7azMzGsawjgv8EHBERr+RZjJmZNV/WYwSPA5PzLMTMzIqRdURwBdAl6XHg5cHGiDgtl6rMzKxpsgbBTSRXGXczgnsVm5nZ2Jc1CJ6OiG/lWomZmRUiaxCslnQFcAd77xry6aNmZuNc1iCYnf47t6LNp4+ame0HMgVBRByfdyFmZlaMTKePSvpLSZMrnr9F0l/kV5aZmTVL1usITomIvsEnEfEccGo+JZmZWTNlDYIJkt44+ERSK/DGYfqbmdk4kfVg8T8A/yzpOyQHif+Y5NoCMzMb57IeLP6apHXASST3I7g8IpbnWpmZmTXFsEEgSRERABFxD3DPcH3MzGz8qXeM4AFJn5M0rbJR0gGSTpB0E/BH+ZVnZmZ5qxcEJwMDwC2StkvaIGkL8BPgU8A3I+LGWi+UdLikByRtlLRe0kVD9DtO0tq0z7/sw/diZmajMOyuoYj4d+Bq4GpJLcAUoL/yVNJh7AYuiYg1kg4hmabivojYMNghvTbhauDkiNgq6ddG/Z2YmdmoZL5VZUTsAnaMoP+Owf4R8aKkjUA7sKGi2x8CHRGxNe23M+v6zcysMUZz8/oRkzSdZL6ilVWL3gu8RdKDklZL+vQQrz9fUqekzt7e3lHVsKyrh66tfazc8izzrryfZV09o1qPmdn+JvcgkDQJuB24OCJeqFo8Efgt4KPAfOC/S3pv9ToiYmlEzImIOW1tbSOuYVlXD4s7unllILmVQk9fP4s7uh0GZmZkn2vo/TXajsvwuhaSELg5IjpqdNkG3BMR/xYRTwM/Ao7MUtNILFm+if5dA3u19e8aYMnyTY1+KzOzcSfriOBWSZcq0Srp2yS3rxySJAE3ABsj4qohuv0f4MOSJko6CDgG2Ji1+Ky29/WPqN3MrEyyBsExwOHAw8CjwHZgXp3XzAMWAiekp4eulXSqpAslXQgQERtJLlJbB6wCro+Ix0fxfQzrsMmtI2o3MyuTrGcN7QL6gVbgQGBLRAx77+KIeIhkOophRcQSYEnGOkZl0fwZLO7o3mv3UGvLBBbNn5Hn25qZjQtZRwSPkgTBh4D/AHxK0m25VdVgC2a3c8UZMzlgQvLttk9u5YozZrJgdnvBlZmZFS/riODciOhMH/8SOF3SwpxqysWC2e3csmorAN+/4NiCqzEzGzuyBsHO6vmGAE8HYWa2H8gaBD8kuQ+BSI4RvBPYBPxmTnWZmVmTZL0fwczK55KOAi7IpSIzM2uqUV1ZHBFrSA4cm5nZOJdpRCDpzyqevgE4ChjdpD9mZjamZD1GcEjF490kxwxub3w5ZmbWbFmPEVyWdyFmZlaMevcs/ieSs4VqiojTGl5Rk5x53QrA1xSYmdUbEXy9KVWYmVlh6gXBlsG7h5mZWTHy3nNR7/TRZYMPJPngsJnZfqheEFTOHvquPAsxM7Ni1AuCGOKxmZntJ+odIzhS0gskI4PW9DHp84iIN+VanZmZ5W7YIIiICc0qxMzMijGquYbMzGz/4SAwMys5B4GZWck5CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJZdbEEg6XNIDkjZKWi/pomH6fkjSgKRP5FWPmZnVlvWexaOxG7gkItZIOgRYLem+iNhQ2UnSBOCrwPIcazEzsyHkNiKIiB0RsSZ9/CKwEWiv0fVzwO3AzrxqMTOzoTXlGIGk6cBsYGVVezvwMeDaOq8/X1KnpM7e3t68yjQzK6Xcg0DSJJJP/BdHxAtVi/8KuDQiBoZbR0QsjYg5ETGnra0tr1LNzEopz2MESGohCYGbI6KjRpc5wPckAUwBTpW0OyKW1ei7z/K+76eZ2XiUWxAo+et+A7AxIq6q1Sci3lnR/0bgzrxCwMzMastzRDAPWAh0S1qbtn0JmAYQEcMeFzAzs+bILQgi4iGSW1pm7X92XrWYmdnQfGWxmVnJOQjMzErOQWBmVnIOAjOzknMQmJmVXCmDYFlXD11b+1i55VnmXXk/y7p6ii7JzKwwpQuCZV09LO7o5pWBPQD09PWzuKPbYWBmpVW6IFiyfBP9u/ae2qh/1wBLlm8qqCIzs2KVLgi29/WPqN3MbH9XuiA4bHLriNrNzPZ3pQuCRfNn0NoyYa+21pYJLJo/o6CKzMyKles01GPRgtnJTdK+eNs6XhnYQ/vkVhbNn/Fqu5lZ2ZQuCCAJg1tWbQV8jwIzs9LtGjIzs705CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJecgMDMrOQeBmVnJOQjMzErOQWBmVnIOAjOzknMQmJmVXG5BIOlwSQ9I2ihpvaSLavQ5S9K69OthSUfmVY+ZmdWW5zTUu4FLImKNpEOA1ZLui4gNFX22AL8bEc9JOgVYChyTY01mZlYltyCIiB3AjvTxi5I2Au3Ahoo+D1e85BFgal71mJlZbU05RiBpOjAbWDlMt3OBu4d4/fmSOiV19vb2Nr5AM7MSyz0IJE0CbgcujogXhuhzPEkQXFpreUQsjYg5ETGnra0tv2LNzEoo11tVSmohCYGbI6JjiD4fBK4HTomIZ/Ksx8zMXi/Ps4YE3ABsjIirhugzDegAFkbEk3nVYmZmQ8tzRDAPWAh0S1qbtn0JmAYQEdcCXwbeBlyd5Aa7I2JOjjWZmVmVPM8aeghQnT7nAeflVYOZmdXnK4vNzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiWX65XFY9n3Lzi26BLMzMYEjwjMzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiXnIDAzKzkHgZlZyTkIzMxKThFRdA0jIqkX+EWDVzsFeLrB62wE1zUyrmtkXNfIjPe6fj0i2motGHdBkAdJnWPxFpmua2Rc18i4rpHZn+vyriEzs5JzEJiZlZyDILG06AKG4LpGxnWNjOsamf22Lh8jMDMrOY8IzMxKzkFgZlZypQsCSRMkdUm6s8YySfqWpM2S1kk6aozUdZyk5yWtTb++3KSafi6pO33PzhrLC9leGeoqantNlnSbpCckbZR0bNXyorZXvbqavr0kzah4v7WSXpB0cVWfpm+vjHUV9fP1BUnrJT0u6RZJB1YtH/32iohSfQF/BnwXuLPGslOBuwEBc4GVY6Su42q1N6GmnwNThlleyPbKUFdR2+sm4Lz08QHA5DGyverVVcj2qnj/CcAvSS54Knx7Zair6dsLaAe2AK3p81uBsxu1vUo1IpA0FfgocP0QXU4H/j4SjwCTJR06BuoaqwrZXmORpDcBvwPcABARr0REX1W3pm+vjHUV7UTgpxFRPWNA0T9fQ9VVlIlAq6SJwEHA9qrlo95epQoC4K+ALwJ7hljeDjxV8Xxb2pa3enUBHCvpMUl3S/rNJtQEEMC9klZLOr/G8qK2V726oPnb611AL/CddBff9ZIOrupTxPbKUhcU8/M16JPALTXai/r5GjRUXdDk7RURPcDXga3ADuD5iLi3qtuot1dpgkDS7wM7I2L1cN1qtOV6fm3GutaQDE+PBL4NLMuzpgrzIuIo4BTgM5J+p2p507dXql5dRWyvicBRwDURMRv4N+DPq/oUsb2y1FXUzxeSDgBOA35Qa3GNtqac716nrqZvL0lvIfnE/07gMOBgSf+5uluNl2baXqUJAmAecJqknwPfA06Q9A9VfbYBh1c8n8rrh19NrysiXoiIl9LHdwEtkqbkXBcRsT39dyfwj8DRVV2K2F516ypoe20DtkXEyvT5bSR/gKv7NHt71a2rqJ+v1CnAmoj4fzWWFfLzlRqyroK210nAlojojYhdQAfw21V9Rr29ShMEEbE4IqZGxHSSId/9EVGdqHcAn06Pvs8lGX7tKLouSe+QpPTx0ST/b8/kWZekgyUdMvgY+AjweFW3pm+vLHUVsb0i4pfAU5JmpE0nAhuquhXx81W3riK2V4VPMfTul6Zvryx1FbS9tgJzJR2UvveJwMaqPqPeXhMbW+v4I+lCgIi4FriL5Mj7ZuBXwDljpK5PAH8qaTfQD3wy0tMEcvR24B/Tn/eJwHcj4p4xsL2y1FXE9gL4HHBzulvhZ8A5Y2B7ZamrkO0l6SDg94ALKtoK314Z6mr69oqIlZJuI9kttRvoApY2ant5igkzs5Irza4hMzOrzUFgZlZyDgIzs5JzEJiZlZyDwMxsH0j6iqQevTYJ3ak1+hwoaVV6NfJ6SZdVLLtcySRxayXdK+mwqtdOk/SSpP8ygpq+LemlrP0dBLZfk/S2il/QX1b9wj6c03vOlnR9+vhsSSHpxIrlH0vbPpE+f1DSnPTx4Myq3ZI2SPoLSW9Ml7VJuiePmi0bJTOP3lhj0TcjYlb6dVeN5S8DJ6RXI88CTk7P9QdYEhEfjIhZwJ1A9Wym3ySZTC5rjXOAyVn7g4PA9nMR8czgLyhwLXv/wlZfmdkoXyKZemBQN8kFSoM+CTw2zOuPj4iZJFdMv4v0VoQR0QvskDSvseVa3tKJ4AY/obekX5Eue6Gi68FUTAshaQHJtR/rK9cn6SOSVkhaI+kHkial7ROAJSRzl2XmILDSGhw6p5/y/kXSrZKelHSlpLPSoXy3pCPSfm2Sbpf0aPr1uj/ISq56/mBEVP6h/zFwtKSW9Bf23cDaevWlfzguBBZIemvavAw4a5++ccvDZ9PdO3+nZF6g11Fyz5G1wE7gvoppP5D0vyQ9RfJ/++W07WDgUuCyqvVMAf4bcFI651YnyTT2AJ8F7hjpFdgOArPEkcBFwExgIfDeiDiaZGrwz6V9/ppkRPEh4OPUnjZ8Dq+fiiOA/wvMJ5k47I6sRaWfFrcA70mbOoEPZ329NYaklekf8etJ5gYb3L04H7gGOIJkl88O4Bu11hERA+nIdCrJB4MPVCz7rxFxOHAzyR9zSALgmxUjiUFzgfcD/5rW9EfAr6fHFv6AvUejmZR+igmz1KODn6Ik/RQYnOK3Gzg+fXwS8P50eguAN0k6JCJerFjPoSTTPlf7HvB54M3AJSS7j7KqnFVyJ8nsk9ZEEXEMJKNHkhvCnF2rn6S/JdnPP9y6+iQ9CJzM6z80fBf4IfA/gGOAT0j6Gsk+/z2S/h34BcmIonJ3I5I+SjLa3Jz+jB4kaXNEvLve9+cgMEu8XPF4T8XzPbz2e/IG4NiI6B9mPf3AgdWNEbEq/QTYHxFPVoTJsNJdTdOBJ9OmA9P3sDFC0qEVu2I+xuv/uCOpDdiVhkAryYeKr6bL3hMRP0m7ngY8ARARH654/VeAlyLib9J1/W9J746IzencSFMj4ofAOype81KWEADvGjIbiXt5bdiOpFk1+mwk+VRWy2JGMBJIjydcDSyLiOfS5vdS4w+NFepr6bGkdSSjxy8ASDpM0uAZRIcCD6R9HiX5RD84crhSyX2I15HMpnvRcG+WnjRwNnBL+ppHgPftyzfgEYFZdp8n+SS2juR350ckB3NfFRFPSHpzjV1GRMRQpwBOZO8RyQNKhgxvILnfwuUVy44n2XVgBYiIB4EHq9oWDtF3O8lsoETEOmD2EP0+nuF9v1L1/H7gQ3VeM6neegd59lGzBpP0BeDFiKh7D+r0GoHNwAci4vkM/X8EnF4xQjDbZ941ZNZ417D3J/ya0gt/1gJXZwyBNuAqh4A1mkcEZmYl5xGBmVnJOQjMzErOQWBmVnIOAjOzknMQmJmV3P8HERa6uD1nv7cAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "lc.plot(marker=\"o\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Performing the same analysis with 1D spectra\n",
-    "\n",
-    "### First the relevant imports\n",
-    "\n",
-    "We import the missing classes for spectral data reduction"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from regions import CircleSkyRegion\n",
-    "from astropy.coordinates import Angle\n",
-    "from gammapy.spectrum import (\n",
-    "    SpectrumDatasetMaker,\n",
-    "    ReflectedRegionsBackgroundMaker,\n",
-    ")"
+    "lc_3d.table[\"time_min\", \"time_max\", \"flux\", \"flux_err\"]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Defining the geometry\n",
-    "\n",
-    "We need to define the ON extraction region. We will keep the same reco and true energy axes as in 3D."
+    "### 1d"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Target definition\n",
-    "e_reco = np.logspace(-1, np.log10(40), 40) * u.TeV\n",
-    "e_true = np.logspace(np.log10(0.05), 2, 100) * u.TeV\n",
-    "\n",
-    "on_region_radius = Angle(\"0.11 deg\")\n",
-    "on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError. [astropy.units.quantity]\n"
-     ]
-    }
-   ],
-   "source": [
-    "dataset_maker = SpectrumDatasetMaker(\n",
-    "    region=on_region, e_reco=e_reco, e_true=e_true, containment_correction=True\n",
-    ")\n",
-    "bkg_maker = ReflectedRegionsBackgroundMaker()\n",
-    "safe_mask_masker = SafeMaskMaker(methods=[\"aeff-max\"], aeff_percent=10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Creation of the datasets"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ljouvin/installation_gammapy/gammapy/gammapy/utils/interpolation.py:159: Warning: Interpolated values reached float32 precision limit\n",
-      "  \"Interpolated values reached float32 precision limit\", Warning\n"
-     ]
-    }
-   ],
-   "source": [
-    "datasets_1d = []\n",
-    "\n",
-    "for time_interval in time_intervals:\n",
-    "    observation = crab_obs.select_time(time_interval)[0]\n",
-    "\n",
-    "    dataset = dataset_maker.run(\n",
-    "        observation, selection=[\"counts\", \"aeff\", \"edisp\"]\n",
-    "    )\n",
-    "\n",
-    "    dataset_on_off = bkg_maker.run(dataset, observation)\n",
-    "    dataset_on_off = safe_mask_masker.run(dataset_on_off, observation)\n",
-    "    datasets_1d.append(dataset_on_off)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Light Curve estimation for 1D spectra\n",
-    "\n",
-    "Now that we've reduced the 1D data we assign again the model to the datasets "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for dataset in datasets_1d:\n",
-    "    # Copy the source model\n",
-    "    model = spectral_model.copy()\n",
-    "    model.name = \"crab\"\n",
-    "    dataset.model = model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now call the LightCurveEstimator in a perfectly identical manner."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lc_maker_1d = LightCurveEstimator(datasets_1d, source=\"crab\", reoptimize=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 161 ms, sys: 0 ns, total: 161 ms\n",
-      "Wall time: 159 ms\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
+    "lc_maker_1d = LightCurveEstimator(ana_1d.datasets, source=\"crab\", reoptimize=False)\n",
     "lc_1d = lc_maker_1d.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
    ]
   },
@@ -572,37 +322,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.legend.Legend at 0x7f7faf819e10>"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAERCAYAAAB2CKBkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3de5gdVZnv8e/P0CGNCYmGRsjNRIQoCblNuGRglBAwgAqoCDqcMEEcYLwgDCcCnnlQ8AIaBzB6ACMMyhGRCJkMIFe5iAwQyI0OkARxUOgQhxDNhaExnfCeP6padu/s7t7dvWvv7tTv8zz7oWrVqqo3RXe/e9WqWksRgZmZ5dfbah2AmZnVlhOBmVnOORGYmeWcE4GZWc45EZiZ5ZwTgZlZzvXJRCDp3yS9IunpCh3vbkkbJd1RVP4FSc9LCkl7VOJcZma9TZ9MBMCPgaMreLy5wKwS5f8JHAn8oYLnMjPrVfpkIoiIh4E/FZZJ2if9Zr9U0m8kva8Lx7sf2FKifHlE/L7HAZuZ9WK71DqACpoPnBURv5V0MHAVcESNYzIz6/V2ikQgaSDwt8AvJLUW75pu+zhwSYnd1kbEzOpEaGbWe+0UiYDkFtfGiJhUvCEiFgILqx+SmVnf0Cf7CIpFxGbgBUmfBFBiYo3DMjPrE/pkIpB0E/AYMFZSk6TTgVOA0yU9BTwDHN+F4/0G+AUwIz3ezLT8bElNwAigUdK1lf63mJnVmjwMtZlZvvXJFoGZmVVOn+ss3mOPPWL06NG1DsPMrE9ZunTpqxHRUGpbn0sEo0ePZsmSJbUOw8ysT5HU7ggJvjVkZpZzTgRmZjnnRGBmlnN9ro/AzCwrLS0tNDU18cYbb9Q6lG4bMGAAI0aMoK6urux9nAjMzFJNTU0MGjSI0aNHUzBuWZ8REWzYsIGmpibGjBlT9n6+NWRmlnrjjTcYOnRon0wCAJIYOnRol1s0TgRmZgX6ahJo1Z34nQjMzHrg5B8+xsk/fKzWYfSIE4FZBp751mE8863Dah2G9UGf+cxn2HPPPRk/fvxfyz7xqVMY+e7RTJw4kf32249TTz2VtWvXVuycTgRmZt20aPlalr+4kcUv/IlDL3uARct7/sd59uzZ3H333TuUn//Vb/DUU0+xZs0aJk+ezPTp09m6dWuPzwdOBGZm3bJo+VouXLiSrdvfBGDtxmYuXLiyx8ngAx/4AO985zvb3S6Jc889l7322ou77rqrR+dq5URgZtYFrX0CX76lkeaW7W22Nbds58u3NFalz2DKlCmsXr26IsdyIjAz64bWlkC55ZVWyblknAjMzLrg5jOncfOZ0xg+pL7k9uFD6rn5zGmZx7F8+XLe//73V+RYTgRmZt0wZ+ZY6uv6tSmrr+vHnJljMz1vRDBv3jzWrVvH0UcfXZFjOhGYmXXDCZOHc+nHD6B/v+TP6PAh9Vz68QM4YfLwHh3305/+NNOmTWPNmjWMGDGC6667DoBvX/wvf3189Mknn+TBBx+kf//+Pf53QIZjDUkaADwM7Jqe55aI+GpRnVOA89PV14B/ioinsorJzKySTpg8nJueeBGgYreDbrrpph3KDj/uZAD2aRhYkXMUy3LQub8AR0TEa5LqgEck3RURjxfUeQH4YET8WdIxwHzg4AxjMjOrqGr0B2Qts0QQSZf2a+lqXfqJojqPFqw+DozIKh4zMyst0z4CSf0krQBeAe6LiMUdVD8dKPl2hKQzJC2RtGT9+vVZhGpmlluZJoKI2B4Rk0i+6R8kaXypepKmkySC80ttj4j5ETE1IqY2NDRkF7CZWQ5V5amhiNgIPATs8KyTpAnAtcDxEbGhGvGYmdlbMksEkhokDUmX64EjgdVFdUYBC4FZEfFcVrGYmWXm+g8nnz4syxbB3sCDkhqBJ0n6CO6QdJaks9I6FwFDgaskrZC0JMN4zMx6vTfeeIODDjqIiRMnMm7cOL761eSp+y9/8UzGjBmTyVDUWT411AhMLlF+TcHyZ4HPZhWDmVmmGhdA05Ow/S9wxXiYcRFMOKlHh9x111154IEHGDhwIC0tLRx22GEccMgHAZg7dy4nnngiEcGVV17J9OnTefrpp3v8YpnfLDYz647GBXD72UkSANj0UrLeuKBHh5XEwIHJi2MtLS20tLTsMP1kpYeidiIwM+uK1j6B//gCtDS33dbSnJT3sM9g+/btTJo0iT333JOjjjqKSX9zYMl6lRqK2onAzKw7WlsC5ZZ3Qb9+/VixYgVNTU088cQTPLfq2ZL1KjUUtROBmVlXnPbL5DN4ZOntg0cm2ytgyJAhHH744Tz8wH0lt1dqKGonAjOz7phxEdQVzUlQV5+U98D69evZuHEjAM3NzfzqV7/iPfvu16ZOpYeidiIwM+uOCSfBR+dBv12T9cEjk/UePjW0bt06pk+fzoQJEzjwwAM56qijOOJDxwAwZ86cTIaiznL0UTOznduEk2DpT5LlCt0OmjBhAsuXL29T9rv1r/Gd7/+wTw5DbWa286tQAqgl3xoyM8s5JwIzswKVeiSzVroTvxOBmVlqwIABbNiwoc8mg4hgw4YNDBgwoEv7uY/AzCw1YsQImpqa6G0TYK3fkryktvXVXTutO2DAAEaM6Npkj04EZmapuro6xowZU+swdvC1Hz4GwM1nTsrk+L41ZGaWc04EZmY550RgZpZzTgRmZjnnRGBmlnNOBGZmOedEYGaWc04EZmY550RgZpZzmSUCSQMkPSHpKUnPSLq4RB1JmifpeUmNkqZkFY+ZmZWWZYvgL8ARETERmAQcLemQojrHAPumnzOAqzOMx6w6Ghew79bV7L91JVwxHhoX1Doisw5lNtZQJMP3vZau1qWf4iH9jgduSOs+LmmIpL0jYl1WcZllqnEB3H42/WlJ1je9BLefnSz3cApDy6+LNsxJlx7J5PiZ9hFI6idpBfAKcF9ELC6qMhx4qWC9KS0rPs4ZkpZIWtLbRgU0a+P+S6CluW1ZS3NSbtZLZZoIImJ7REwCRgAHSRpfVEWlditxnPkRMTUipjY0NGQRqllFxKamLpWb9QZVeWooIjYCDwFHF21qAkYWrI8AXq5GTGZZ+G/26FK5WW+Q5VNDDZKGpMv1wJHA6qJqtwGnpk8PHQJscv+A9WWXbv0kr0f/NmWvR38u3frJGkVkfd2i5WuZveVzfGTzBRx62QMsWr624ufIcmKavYGfSOpHknAWRMQdks4CiIhrgDuBY4HngdeB0zKMxyxzS3Y/igs2w5d3WcAwbeDlGMp3tp3E0t2PqnVo1gctWr6WCxeupDkGA7B2YzMXLlwJwAmTd+hO7bYsnxpqBCaXKL+mYDmAz2cVg1m1zZk5lgsXbuW2rYf9tay+rh+Xzhxbw6isr5p7zxqaW7a3KWtu2c7ce9b0jURglketv5zfXPBrXo3dGTZkN+bMHFvRX1rLj5c3NnepvLucCMwq7ITJw9n3rqsAGHdBNs99Wz4MG1LP2hJ/9IcNqa/oeTzWkJlZLzVn5ljq6/q1Kauv68ecCt9qzFWL4OQfPgbAzWdOq3EkZmadq9atxlwlAjOzvqYatxp9a8jMLOecCMzMcs6JwMws55wIzMxyzonAzCznnAjMzHLOicDMLOecCMzMcs6JwMws55wIzMxyzonAzCznyhprSNKewKHAMKAZeBpYEhFvZhibmZlVQYeJQNJ04ALgncBy4BVgAHACsI+kW4B/jYjNWQdqZmbZ6KxFcCzwjxHxYvEGSbsAHwGOAm7NIDYzM6uCDhNBRMzpYNs2YFHFIzIzs6rqdmexpNMqGYiZmdVGT54aurhiUZiZWc101lnc2N4m4F2d7DsSuAHYC3gTmB8R3yuqMxj4KTAqjeW7EXF9eaGbmVkldNZZ/C5gJvDnonIBj3ay7zbgvIhYJmkQsFTSfRHxbEGdzwPPRsRHJTUAayTdGBFbu/BvMDOzHugsEdwBDIyIFcUbJD3U0Y4RsQ5Yly5vkbQKGA4UJoIABkkSMBD4E0kCMTOzKunsqaHTO9j29+WeRNJoYDKwuGjTD4DbgJeBQcDJpV5Sk3QGcAbAqFGjyj2tmZmVocudxekf5a7UH0jynsE5JV48mwmsIHljeRLwA0m7Fx8jIuZHxNSImNrQ0NDVkM3MrANlDTFR5CxgfjkVJdWRJIEbI2JhiSqnAZdFRADPS3oBeB/wRDfi6tRFG1pfi3gki8ObmfVJ3Xl8VGVVSu77XwesiojL26n2IjAjrf8uYCzwX92IyczMuqk7LYKPllnvUGAWsFJSa2fzV0geFSUirgG+DvxY0kqSBHN+RLzajZjMzHZOjQvYd+tq6miBK8bDjItgwkkVPUW5o49+Cbge2AJcLGkycEFE3NvePhHxCJ20HiLiZeBD5YdrZpYjjQvg9rPpT0uyvukluP3sZLmCyaDcW0OfSTt6PwQ0kN7br1gUZma2o/svgZbmtmUtzUl5BZWbCFq/2R8LXB8RT1FmX4GZmXXTpqaulXdTuYlgqaR7SRLBPembwp6UxswsS4NHdK28m8pNBKeTTFBzYES8DvQnuT1kZmZZmXER1NW3LaurT8orqKzO4vRt32UF6xuADRWNxGwncsnQuQDcXOM4rI9LO4S3LvwcdbSgwSNr99SQmZnVyIST+O0d8wAYd242L8P2ZD4CMzPbCeQmESxavpbZWz7HRzZfwKGXPcCi5WtrHZKZWa/Q2cQ0BwA/Ihk++i6SN3//nG57IiIOyj7Enlu0fC0XLlxJcwwGYO3GZi5cuBKAEyYPr2VotpO6+cxptQ7BrGydtQiuBr4GHAA8BzwiaZ90W12GcVXU3HvW0NyyvU1Zc8t25t6zpkYRmZn1Hp11Fg+MiLvT5e9KWgrcLWkWyaQyfcLLG5u7VG5mliedtQiUzisMQEQ8CHwC+H/Au7MMrJKGDanvUrmZWZ50lgi+Dby/sCAiGkmGji41v0CvNGfmWOrr+rUpq6/rx5yZY2sUkZlZ79HZVJU/Ky6TtFdEvAj8Y2ZRVVhrh/A3F/yaV2N3hg3ZjTkzx7qj2MyM7r1QdicwpdKBZO2EycPZ966rABh3gWcoMzNr1Z1E4FFHzcyqaNzegzuv1APdeaHsRxWPwszMaqbsFoGkdwAjgcclTQGIiGUd72VmZr1duVNVfh2YDfyOt94fCOCIbMIyM7NqKbdFcBKwT0RszTIYMzOrvnL7CJ4GhmQZiJmZ1Ua5LYJLgeWSngb+0loYEcdlEpWZmVVNuYngJyRvGa+kzLmKJY0EbgD2SveZHxHfK1HvcOBKkkHsXo2ID5YZk5mZVUC5ieDViJjXxWNvA86LiGXpZPdLJd0XEc+2VpA0BLgKODoiXpS0ZxfPYWZmPVRuH8FSSZdKmiZpSuunox0iYl3r46URsQVYRTKvQaG/BxamQ1YQEa90Mf7yNS5g362r2X/rSrhiPDQuyOxUZmZ9Sbktgsnpfw8pKCv78VFJo9NjLC7atB9QJ+khYBDwvYi4ocT+ZwBnAIwaNarMkAs0LoDbz6Y/Lcn6ppfg9rOT5QpPAm1m1teUlQgiYnp3TyBpIHArcE5EbC5x/r8hGc20HnhM0uMR8VzR+ecD8wGmTp3a9XkQ7r8EWormHmhpTsqdCMws58q6NSTpW+n9/Nb1d0j6Rhn71ZEkgRsjotSw1U3A3RHxPxHxKvAwMLG80LtgU1PXys3McqTcPoJjImJj60o6b/GxHe0gScB1wKqIuLydav8B/J2kXSTtBhxM0pdQWYNHdK3czCxHyk0E/STt2roiqR7YtYP6AIcCs4AjJK1IP8dKOkvSWQARsQq4G2gEngCujYinu/yv6MyMi6CuaDayuvqk3Mws58rtLP4pcL+k60k6iT9D8m5BuyLiEcoYsjoi5gJzy4yje9J+gK0LP0cdLWjwyCQJuH/AzKzszuLvSGoEjiT54/71iLgn08gqbcJJ/PaO5FWIced6Yhozs1YdJgJJiogAiIi7SW7jtFvHzMz6ns76CB6U9EVJbR7el9Rf0hGSfgL8Q3bhmZlZ1jq7NXQ0SX/ATZLGABtJnvd/G3AvcEVErMg2RDMzy1KHiSAi3iAZC+iq9J2APYDmwkdJzcysbyt7qsqIaAHWZRiLmZnVQHcmrzczs51IfhPB9R9OPmZmOVfu5PX7F84jkJYdHhEPZRKVmZm95bRfZnr4clsECySdr0S9pO+TTF9pZmZ9XLmJ4GBgJPAo8CTwMslYQmZm1seVmwhagGaSdwgGAC9ERFlzF5uZWe9WbiJ4kiQRHAgcBnxa0i2ZRWVmZlVT7nsEp0fEknT5j8DxkmZlFJOZmVVRuYngleLxhoBfVzoYMzOrvnITwS9J5iEQSR/BGGANMC6juDIxbu/BtQ7BzKzXKXc+ggMK1yVNAc7MJCIzM6uqbr1ZHBHLSDqOzcysjyv3zeJ/Llh9GzAFWJ9JRGZmVlXl9hEMKljeRtJncGvlwzEzs2ort4/g4qwDMTOz2uhszuLbSZ4WKikijqt4RGZmVlWdtQi+290DSxoJ3ADsBbwJzI+I77VT90DgceDkiPAby2ZmVdRZInghIl7s5rG3AedFxDJJg4Clku4rMZx1P+DbwD3dPI+ZmfVAZ4+PLmpdkNSlzuGIWJc+ZkpEbAFWAcNLVP0iScfzK105vpmZVUZniUAFy+/p7kkkjQYmA4uLyocDHwOu6WT/MyQtkbRk/Xo/tWpmVkmdJYJoZ7lskgaSfOM/JyI2F22+Ejg/IrZ3GETE/IiYGhFTGxoauhOGmZm1o7M+gomSNpO0DOrTZdL1iIjdO9pZUh1JErgxIhaWqDIV+LkkgD2AYyVti4hFJer2XMbTvZmZ9UUdJoKI6NfdAyv5634dsCoiLm/n+GMK6v8YuCOzJGBmZiWV+2ZxdxwKzAJWSlqRln0FGAUQER32C5iZWXVklggi4hHadjZ3Vn92VrGU8sy6TUAfG0fbzCwD3Rp91MzMdh5OBGZmOedEYGaWc/lMBI0L2HfravbfuhKuGA+NC2odkZlZzWT51FDv1LgAbj+b/rQk65tegtvPTpYnnFS7uMzMaiR/LYL7L4GW5rZlLc1JuZlZDuUvEWxq6lq5mdlOLn+JYPCIrpWbme3k8pcIZlwEdfVty+rqk3IzsxzKXyKYcBJ8dB5bqUuGUx08Ej46zx3FZpZb+XtqCGDCSfz2jnkAjDv3kRoHY2ZWW/lrEZiZWRtOBGZmOedEYGaWc04EZmY550RgZpZzTgRmZjnnRGBmlnNOBGZmOedEYGaWc04EZmY550RgZpZzmSUCSSMlPShplaRnJH2pRJ1TJDWmn0clTcwqHjMzKy3LQee2AedFxDJJg4Clku6LiGcL6rwAfDAi/izpGGA+cHCGMZmZWZHMEkFErAPWpctbJK0ChgPPFtR5tGCXxwHPDmNmVmVV6SOQNBqYDCzuoNrpwF3t7H+GpCWSlqxfv77yAZqZ5VjmiUDSQOBW4JyI2NxOnekkieD8UtsjYn5ETI2IqQ0NDT2OadHytcze8jk+svkCDr3sARYtX9vjY5qZ9VWZTkwjqY4kCdwYEQvbqTMBuBY4JiI2ZBkPJEngwoUraY7BAKzd2MyFC1cCcMLk4Vmf3sys18nyqSEB1wGrIuLyduqMAhYCsyLiuaxiKTT3njU0t2xvU9bcsp2596ypxunNzHqdLFsEhwKzgJWSVqRlXwFGAUTENcBFwFDgqiRvsC0ipmYYEy9vbO5SuZnZzi7Lp4YeAdRJnc8Cn80qhlKGDalnbYk/+sOG1FczDDOzXiN3bxbPmTmW+rp+bcrq6/oxZ+bYGkVkZlZbmXYW90atHcLfXPBrXo3dGTZkN+bMHOuOYjPLrdwlAkiSwb53XQXAuAseqXE0Zma1lbtbQ2Zm1pYTgZlZzuXy1hDAJUPnAnBzjeMwM6s1twjMzHLOicDMLOecCMzMcs6JwMws55wIzMxyzonAzCznnAjMzHLOicDMLOecCMzMcs6JwMws55wIzMxyzonAzCznnAjMzHLOicDMLOecCMzMcs6JwMws5zJLBJJGSnpQ0ipJz0j6Uok6kjRP0vOSGiVNySoeMzMrLcsZyrYB50XEMkmDgKWS7ouIZwvqHAPsm34OBq5O/2tmZlWSWYsgItZFxLJ0eQuwChheVO144IZIPA4MkbR3VjGZmdmOqtJHIGk0MBlYXLRpOPBSwXoTOyYLJJ0haYmkJevXr88qTDOzXMp88npJA4FbgXMiYnPx5hK7xA4FEfOB+QBTp07dYXt33HzmtEocxsysz8u0RSCpjiQJ3BgRC0tUaQJGFqyPAF7OMiYzM2sry6eGBFwHrIqIy9updhtwavr00CHApohYl1VMZma2oyxvDR0KzAJWSlqRln0FGAUQEdcAdwLHAs8DrwOnZRiPmZmVkFkiiIhHKN0HUFgngM9nFYOZmXXObxabmeWcE4GZWc45EZiZ5ZwTgZlZzjkRmJnlnJIHd/oOSeuBP1T4sHsAr1b4mJXguLrGcXWN4+qavh7XuyOiodSGPpcIsiBpSURMrXUcxRxX1ziurnFcXbMzx+VbQ2ZmOedEYGaWc04Eifm1DqAdjqtrHFfXOK6u2Wnjch+BmVnOuUVgZpZzTgRmZjmXu0QgqZ+k5ZLuKLFNkuZJel5So6QpvSSuwyVtkrQi/VxUpZh+L2lles4lJbbX5HqVEVetrtcQSbdIWi1plaRpRdtrdb06i6vq10vS2ILzrZC0WdI5RXWqfr3KjKtWP1/nSnpG0tOSbpI0oGh7969XROTqA/wz8DPgjhLbjgXuIhk++xBgcS+J6/BS5VWI6ffAHh1sr8n1KiOuWl2vnwCfTZf7A0N6yfXqLK6aXK+C8/cD/kjywlPNr1cZcVX9epHM5f4CUJ+uLwBmV+p65apFIGkE8GHg2naqHA/cEInHgSGS9u4FcfVWNblevZGk3YEPkMzKR0RsjYiNRdWqfr3KjKvWZgC/i4jiEQNq/fPVXly1sgtQL2kXYDd2nNa329crV4kAuBL4MvBmO9uHAy8VrDelZVnrLC6AaZKeknSXpHFViAkggHslLZV0RonttbpencUF1b9e7wHWA9ent/iulfT2ojq1uF7lxAW1+flq9SngphLltfr5atVeXFDl6xURa4HvAi8C60im9b23qFq3r1duEoGkjwCvRMTSjqqVKMv0+doy41pG0jydCHwfWJRlTAUOjYgpwDHA5yV9oGh71a9XqrO4anG9dgGmAFdHxGTgf4ALiurU4nqVE1etfr6Q1B84DvhFqc0lyqryvHsncVX9ekl6B8k3/jHAMODtkv5XcbUSu5Z1vXKTCEjmUD5O0u+BnwNHSPppUZ0mYGTB+gh2bH5VPa6I2BwRr6XLdwJ1kvbIOC4i4uX0v68A/w4cVFSlFter07hqdL2agKaIWJyu30LyB7i4TrWvV6dx1ernK3UMsCwi/rvEtpr8fKXajatG1+tI4IWIWB8RLcBC4G+L6nT7euUmEUTEhRExIiJGkzT5HoiI4ox6G3Bq2vt+CEnza12t45K0lySlyweR/H/bkGVckt4uaVDrMvAh4OmialW/XuXEVYvrFRF/BF6SNDYtmgE8W1StFj9fncZVi+tV4NO0f/ul6ternLhqdL1eBA6RtFt67hnAqqI63b5emU1e31dIOgsgIq4B7iTpeX8eeB04rZfEdSLwT5K2Ac3ApyJ9TCBD7wL+Pf153wX4WUTc3QuuVzlx1eJ6AXwRuDG9rfBfwGm94HqVE1dNrpek3YCjgDMLymp+vcqIq+rXKyIWS7qF5LbUNmA5ML9S18tDTJiZ5Vxubg2ZmVlpTgRmZjnnRGBmlnNOBGZmOedEYGbWA5K+Jmmt3hqE7tgSdQZIeiJ9G/kZSRcXbPu6kkHiVki6V9Kwon1HSXpN0v/uQkzfl/RaufWdCGynJmlowS/oH4t+YR/N6JyTJV2bLs+WFJJmFGz/WFp2Yrr+kKSp6XLryKorJT0r6RuSdk23NUi6O4uYrTxKRh79cYlNV0TEpPRzZ4ntfwGOSN9GngQcnT7rDzA3IiZExCTgDqB4NNMrSAaTKzfGqcCQcuuDE4Ht5CJiQ+svKHANbX9hi9/MrJSvkAw90GolyQtKrT4FPNXB/tMj4gCSN6bfQzoVYUSsB9ZJOrSy4VrW0oHgWr+h16WfSLdtLqj6dgqGhZB0Asm7H88UHk/ShyQ9JmmZpF9IGpiW9wPmkoxdVjYnAsut1qZz+i3v15IWSHpO0mWSTkmb8isl7ZPWa5B0q6Qn088Of5CVvPU8ISIK/9D/BjhIUl36C/teYEVn8aV/OM4CTpD0zrR4EXBKj/7hloUvpLd3/k3JuEA7UDLnyArgFeC+gmE/kPRNSS+R/L+9KC17O3A+cHHRcfYA/gU4Mh1zawnJMPYAXwBu6+ob2E4EZomJwJeAA4BZwH4RcRDJ0OBfTOt8j6RFcSDwCUoPGz6VHYfiCOBXwEySgcNuKzeo9NviC8C+adES4O/K3d8qQ9Li9I/4tSRjg7XeXpwJXA3sQ3LLZx3wr6WOERHb05bpCJIvBuMLtv2fiBgJ3EjyxxySBHBFQUui1SHA/sB/pjH9A/DutG/hk7RtjZYl90NMmKWebP0WJel3QOsQvyuB6enykcD+6fAWALtLGhQRWwqOszfJsM/Ffg6cDQwGziO5fVSuwlElXyEZfdKqKCIOhqT1SDIhzOxS9ST9iOQ+f0fH2ijpIeBodvzS8DPgl8BXgYOBEyV9h+Se/5uS3gD+QNKiKLzdiKQPk7Q2n09/RneT9HxEvLezf58TgVniLwXLbxasv8lbvydvA6ZFRHMHx2kGBhQXRsQT6TfA5oh4riCZdCi91TQaeC4tGpCew3oJSXsX3Ir5GDv+cUdSA9CSJoF6ki8V30637RsRv02rHgesBoiIvyvY/2vAaxHxg/RY/1fSeyPi+XRspBER8Utgr4J9XisnCYBvDZl1xb281WxH0qQSdVaRfCsr5UK60BJI+xOuAhZFxJ/T4v0o8YfGauo7aV9SI0nr8VwAScMktT5BtDfwYFrnSZJv9K0th8uUzEPcSDKa7pc6Oln60MBs4KZ0n8eB9/XkH+AWgVn5zib5JtZI8rvzMEln7l9FxGpJg0vcMiIi2nsEcBfatqjDh60AAACgSURBVEgeVNJkeBvJfAtfL9g2neTWgdVARDwEPFRUNqudui+TjAZKRDQCk9up94kyzvu1ovUHgAM72WdgZ8dt5dFHzSpM0rnAlojodA7q9B2B54HxEbGpjPoPA8cXtBDMesy3hswq72rafsMvKX3xZwVwVZlJoAG43EnAKs0tAjOznHOLwMws55wIzMxyzonAzCznnAjMzHLOicDMLOf+P/tx3YlKLKSTAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ax = lc_1d.plot(marker=\"o\", label=\"1D\")\n",
-    "lc.plot(ax=ax, marker=\"o\", label=\"3D\")\n",
+    "lc_3d.plot(ax=ax, marker=\"o\", label=\"3D\")\n",
     "plt.legend()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Perform a LC by night\n",
+    "Here we define the time intervals to compute the LC by night"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.time import Time\n",
+    "time_int_obs = [round(obs.tstart.utc.mjd) for obs in ana_1d.observations]\n",
+    "time_int_night = np.unique(time_int_obs)\n",
+    "time_intervals = [Time([t_night-0.5,t_night+0.5], format='mjd', scale='utc') for t_night in time_int_night]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute 1D LC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc_maker_1d_bynight = LightCurveEstimator(ana_1d.datasets, time_intervals=time_intervals,source=\"crab\", reoptimize=False)\n",
+    "lc_1d_bynight = lc_maker_1d_bynight.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute 3D LC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc_maker_3d_bynight = LightCurveEstimator(ana_3d.datasets, time_intervals=time_intervals, source=\"crab\", reoptimize=True)\n",
+    "lc_3d_bynight = lc_maker_3d_bynight.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare LC by night"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ax = lc_1d_bynight.plot(marker=\"o\", label=\"1D\")\n",
+    "lc_3d_bynight.plot(ax=ax, marker=\"o\", label=\"3D\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = lc_1d_bynight.plot(marker=\"o\", label=\"1D\")\n",
+    "lc_3d_bynight.plot(ax=ax, marker=\"o\", label=\"3D\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,9 +188,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ljouvin/installation_python/miniconda3/envs/gammapy-dev/lib/python3.7/site-packages/astropy/units/quantity.py:464: RuntimeWarning: invalid value encountered in true_divide\n",
+      "  result = super().__array_ufunc__(function, method, *arrays, **kwargs)\n",
+      "/home/ljouvin/installation_gammapy/gammapy/gammapy/cube/psf_kernel.py:109: RuntimeWarning: invalid value encountered in true_divide\n",
+      "  img += vals.value / vals.sum().value\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.12 s, sys: 68.1 ms, total: 2.19 s\n",
+      "Wall time: 2.18 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "\n",
@@ -241,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,9 +296,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 13 s, sys: 61.2 ms, total: 13 s\n",
+      "Wall time: 13 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "lc = lc_maker.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
@@ -294,9 +322,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<i>Table length=4</i>\n",
+       "<table id=\"table140186384886416\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>time_min</th><th>time_max</th><th>flux</th><th>flux_err</th></tr></thead>\n",
+       "<thead><tr><th></th><th></th><th>1 / (cm2 s)</th><th>1 / (cm2 s)</th></tr></thead>\n",
+       "<thead><tr><th>float64</th><th>float64</th><th>float64</th><th>float64</th></tr></thead>\n",
+       "<tr><td>53343.92234009259</td><td>53343.94186555556</td><td>2.5854277282288015e-11</td><td>1.9875463397770685e-12</td></tr>\n",
+       "<tr><td>53343.95421509259</td><td>53343.97369425926</td><td>2.319630064068609e-11</td><td>1.9201169445408757e-12</td></tr>\n",
+       "<tr><td>53345.96198129629</td><td>53345.98149518518</td><td>2.995335044221267e-11</td><td>2.647801685325784e-12</td></tr>\n",
+       "<tr><td>53347.913196574074</td><td>53347.93271046296</td><td>2.752076433659184e-11</td><td>2.4998874622862153e-12</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=4>\n",
+       "     time_min           time_max     ...        flux_err       \n",
+       "                                     ...      1 / (cm2 s)      \n",
+       "     float64            float64      ...        float64        \n",
+       "------------------ ----------------- ... ----------------------\n",
+       " 53343.92234009259 53343.94186555556 ... 1.9875463397770685e-12\n",
+       " 53343.95421509259 53343.97369425926 ... 1.9201169445408757e-12\n",
+       " 53345.96198129629 53345.98149518518 ...  2.647801685325784e-12\n",
+       "53347.913196574074 53347.93271046296 ... 2.4998874622862153e-12"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "lc.table[\"time_min\", \"time_max\", \"flux\", \"flux_err\"]"
    ]
@@ -310,9 +369,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f7fafaccb00>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAERCAYAAAB2CKBkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAaY0lEQVR4nO3df5xddX3n8dfbZJCBoFEzVZiQRlFjrZGERgjN2vKrBrALEe2iZWOhUKAPf4BlI42768rSLWgUW+3yI4UKfRRRhGmWIhDYAlVKSJhkQoYkBKPRkEncDD+GH3UKyeSzf5wzcHO5M/fM5J57ZnLez8djHrn3e7733M+czMz7fs+P71FEYGZm5fWGogswM7NiOQjMzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkxmUQSPo7STslPd6g9d0jqU/SnVXtn5W0WVJImtKI9zIzG2vGZRAANwInN3B9S4CFNdr/FTgJ+EUD38vMbEwZl0EQET8Cnq1sk3RE+sl+taQfS3rfCNb3z8CLNdq7IuLn+1ywmdkYNrHoAhpoKXBhRPxE0jHA1cAJBddkZjbm7RdBIGkS8NvADyQNNr8xXXYG8D9rvKwnIuY3p0Izs7FrvwgCkl1cfRExq3pBRHQAHc0vycxsfBiXxwiqRcQLwBZJfwCgxJEFl2VmNi6MyyCQdAuwApghaZukc4GzgHMlPQasB04fwfp+DPwAODFd3/y0/fOStgFTgXWSrm/092JmVjR5Gmozs3IblyMCMzNrnHF3sHjKlCkxffr0osswMxtXVq9e/XREtNVaNu6CYPr06XR2dhZdhpnZuCJpyBkSvGvIzKzkHARmZiXnIDAzKzkHgZlZyTkIzMxKzkFgZlZyDgIzs5JzEJiZlZyDwCwHZ163gjOvW1F0GWaZOAjMzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiXnIDAzKzkHgZlZyeUWBJIOlLRK0mOS1ku6rEafsyStS78elnRkXvWYmVlted6q8mXghIh4SVIL8JCkuyPikYo+W4DfjYjnJJ0CLAWOybEmMzOrklsQREQAL6VPW9KvqOrzcMXTR4CpedVjZma15XqMQNIESWuBncB9EbFymO7nAncPsZ7zJXVK6uzt7c2jVDOz0so1CCJiICJmkXzSP1rSB2r1k3Q8SRBcOsR6lkbEnIiY09bWll/BZmYl1JSzhiKiD3gQOLl6maQPAtcDp0fEM82ox8zMXpPnWUNtkianj1uBk4AnqvpMAzqAhRHxZF61mJnZ0PI8a+hQ4CZJE0gC59aIuFPShQARcS3wZeBtwNWSAHZHxJwcazIzsyp5njW0Dphdo/3aisfnAeflVYOZmdXnK4vNzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiXnIDAzKzkHgZlZyTkIzMxKzkFgZlZyDgIzs5JzEJiZlZyDwMys5BwEZmYl5yAwMys5B4GZWck5CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJecgMDMrOQeBmVnJOQjMzErOQWBmVnK5BYGkAyWtkvSYpPWSLqvRR5K+JWmzpHWSjsqrHjMzqy3PEcHLwAkRcSQwCzhZ0tyqPqcA70m/zgeuybEes6ZY1tVD19Y+Vm55lnlX3s+yrp6iSzIbVm5BEImX0qct6VdUdTsd+Pu07yPAZEmH5lWTWd6WdfWwuKObVwb2ANDT18/ijm6Hge2TM69bwZnXrcht/bkeI5A0QdJaYCdwX0SsrOrSDjxV8Xxb2la9nvMldUrq7O3tza9gs320ZPkm+ncN7NXWv2uAJcs3FVSRWX25BkFEDETELGAqcLSkD1R1Ua2X1VjP0oiYExFz2tra8ijVrCG29/WPqN1sLGjKWUMR0Qc8CJxctWgbcHjF86nA9mbUZJaHwya3jqjdbCzI86yhNkmT08etwEnAE1Xd7gA+nZ49NBd4PiJ25FWTWd4WzZ9Ba8uEvdpaWyawaP6Mgioyq29ijus+FLhJ0gSSwLk1Iu6UdCFARFwL3AWcCmwGfgWck2M9ZrlbMDs5xPXF29bxysAe2ie3smj+jFfbzcai3IIgItYBs2u0X1vxOIDP5FWDWREWzG7nllVbAfj+BccWXI1Zfb6y2Mys5BwEZmYl5yAwMys5B4GZWck5CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJecgMDMruUxzDUn6NWAecBjQDzwOdEbEnhxrMzOzJhg2CCQdD/w58Fagi+ROYwcCC4AjJN0GfCMiXsi7UDMzy0e9EcGpwJ9ExNbqBZImAr8P/B5wew61mZlZEwwbBBGxaJhlu4FlDa/IzMyaatQHiyX5JjJmZvuBfTlr6LKGVWFmZoWpd7B43VCLgLc3vhwzM2u2egeL3w7MB56rahfwcC4VmZlZU9ULgjuBSRGxtnqBpAdzqcjMzJqq3llD5w6z7A8bX46ZmTXbiA8WSzo/j0LMzKwYozlr6MKGV2FmZoUZTRCo4VWYmVlhRhME/7HhVZiZWWEyBYGkiyS9SZKAyyStkfSROq85XNIDkjZKWi/pohp93izpnyQ9lvbx1cpmZk2WdUTwx+kMox8B2oBzgCvrvGY3cElE/AYwF/iMpPdX9fkMsCEijgSOA74h6YCsxZuZ2b7LGgSDxwVOBb4TEY9R51hBROyIiDXp4xeBjUB7dTfgkHSkMQl4liRAzMysSTLdmAZYLele4J3AYkmHAJlvSiNpOjAbWFm16G+AO4DtwCHAmb7ZjZlZc2UNgnOBWcDPIuJXkt5GsnuoLkmTSO5XcHGNG9jMB9YCJwBHAPdJ+nF1v/TahfMBpk2blrFkMzPLItOuoYjYExFrIqIvff5MRAw1Id2rJLWQhMDNEdFRo8s5QEckNgNbgPfVeP+lETEnIua0tbVlKdnMzDLK7eb16X7/G4CNEXHVEN22Aiem/d8OzAB+lldNZ163gjOvW5HX6s3MxqWsu4ZGYx6wEOiWNDhp3ZeAaQARcS1wOXCjpG6Sg8+XRsTTOdZkZmZVcguCiHiI+mcWbSc5JdXMzAoy7K4hSTMlPSLpKUlLJb2lYtmq/MszMyu3ZV09dG3tY+WWZ5l35f0s6+pp+HvUO0ZwDfAVYCbwJPCQpCPSZS0Nr8bMzF61rKuHxR3dvDKQnFXf09fP4o7uhodBvSCYFBH3RERfRHwd+Cxwj6S5JBeDmZlZTpYs30T/roG92vp3DbBk+aaGvk+9YwSS9OaIeB4gIh6Q9HGSU0Lf2tBKzMxsL9v7+kfUPlr1RgRfBX6jsiG9fuBEoNZ1AWZm1iCHTW4dUfto1btV5Xer2yS9IyK2An/S0ErM9iPfv+DYokuw/cCi+TNY3NG91+6h1pYJLJo/o6HvM5oLyu5qaAVmZlbTgtntXHHGTA6YkPypbp/cyhVnzGTB7Or5O/fNaK4j8B3KzMyaZMHsdm5ZtRXIb6Q5mhHB3za8CjMzK0zmEUF6MdnhwCOSjgIYvN+AmZmNX5mCQNLlwNnAT3nt+oEgmT7azMzGsawjgv8EHBERr+RZjJmZNV/WYwSPA5PzLMTMzIqRdURwBdAl6XHg5cHGiDgtl6rMzKxpsgbBTSRXGXczgnsVm5nZ2Jc1CJ6OiG/lWomZmRUiaxCslnQFcAd77xry6aNmZuNc1iCYnf47t6LNp4+ame0HMgVBRByfdyFmZlaMTKePSvpLSZMrnr9F0l/kV5aZmTVL1usITomIvsEnEfEccGo+JZmZWTNlDYIJkt44+ERSK/DGYfqbmdk4kfVg8T8A/yzpOyQHif+Y5NoCMzMb57IeLP6apHXASST3I7g8IpbnWpmZmTXFsEEgSRERABFxD3DPcH3MzGz8qXeM4AFJn5M0rbJR0gGSTpB0E/BH+ZVnZmZ5qxcEJwMDwC2StkvaIGkL8BPgU8A3I+LGWi+UdLikByRtlLRe0kVD9DtO0tq0z7/sw/diZmajMOyuoYj4d+Bq4GpJLcAUoL/yVNJh7AYuiYg1kg4hmabivojYMNghvTbhauDkiNgq6ddG/Z2YmdmoZL5VZUTsAnaMoP+Owf4R8aKkjUA7sKGi2x8CHRGxNe23M+v6zcysMUZz8/oRkzSdZL6ilVWL3gu8RdKDklZL+vQQrz9fUqekzt7e3lHVsKyrh66tfazc8izzrryfZV09o1qPmdn+JvcgkDQJuB24OCJeqFo8Efgt4KPAfOC/S3pv9ToiYmlEzImIOW1tbSOuYVlXD4s7unllILmVQk9fP4s7uh0GZmZkn2vo/TXajsvwuhaSELg5IjpqdNkG3BMR/xYRTwM/Ao7MUtNILFm+if5dA3u19e8aYMnyTY1+KzOzcSfriOBWSZcq0Srp2yS3rxySJAE3ABsj4qohuv0f4MOSJko6CDgG2Ji1+Ky29/WPqN3MrEyyBsExwOHAw8CjwHZgXp3XzAMWAiekp4eulXSqpAslXQgQERtJLlJbB6wCro+Ix0fxfQzrsMmtI2o3MyuTrGcN7QL6gVbgQGBLRAx77+KIeIhkOophRcQSYEnGOkZl0fwZLO7o3mv3UGvLBBbNn5Hn25qZjQtZRwSPkgTBh4D/AHxK0m25VdVgC2a3c8UZMzlgQvLttk9u5YozZrJgdnvBlZmZFS/riODciOhMH/8SOF3SwpxqysWC2e3csmorAN+/4NiCqzEzGzuyBsHO6vmGAE8HYWa2H8gaBD8kuQ+BSI4RvBPYBPxmTnWZmVmTZL0fwczK55KOAi7IpSIzM2uqUV1ZHBFrSA4cm5nZOJdpRCDpzyqevgE4ChjdpD9mZjamZD1GcEjF490kxwxub3w5ZmbWbFmPEVyWdyFmZlaMevcs/ieSs4VqiojTGl5Rk5x53QrA1xSYmdUbEXy9KVWYmVlh6gXBlsG7h5mZWTHy3nNR7/TRZYMPJPngsJnZfqheEFTOHvquPAsxM7Ni1AuCGOKxmZntJ+odIzhS0gskI4PW9DHp84iIN+VanZmZ5W7YIIiICc0qxMzMijGquYbMzGz/4SAwMys5B4GZWck5CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJZdbEEg6XNIDkjZKWi/pomH6fkjSgKRP5FWPmZnVlvWexaOxG7gkItZIOgRYLem+iNhQ2UnSBOCrwPIcazEzsyHkNiKIiB0RsSZ9/CKwEWiv0fVzwO3AzrxqMTOzoTXlGIGk6cBsYGVVezvwMeDaOq8/X1KnpM7e3t68yjQzK6Xcg0DSJJJP/BdHxAtVi/8KuDQiBoZbR0QsjYg5ETGnra0tr1LNzEopz2MESGohCYGbI6KjRpc5wPckAUwBTpW0OyKW1ei7z/K+76eZ2XiUWxAo+et+A7AxIq6q1Sci3lnR/0bgzrxCwMzMastzRDAPWAh0S1qbtn0JmAYQEcMeFzAzs+bILQgi4iGSW1pm7X92XrWYmdnQfGWxmVnJOQjMzErOQWBmVnIOAjOzknMQmJmVXCmDYFlXD11b+1i55VnmXXk/y7p6ii7JzKwwpQuCZV09LO7o5pWBPQD09PWzuKPbYWBmpVW6IFiyfBP9u/ae2qh/1wBLlm8qqCIzs2KVLgi29/WPqN3MbH9XuiA4bHLriNrNzPZ3pQuCRfNn0NoyYa+21pYJLJo/o6CKzMyKles01GPRgtnJTdK+eNs6XhnYQ/vkVhbNn/Fqu5lZ2ZQuCCAJg1tWbQV8jwIzs9LtGjIzs705CMzMSs5BYGZWcg4CM7OScxCYmZWcg8DMrOQcBGZmJecgMDMrOQeBmVnJOQjMzErOQWBmVnIOAjOzknMQmJmVXG5BIOlwSQ9I2ihpvaSLavQ5S9K69OthSUfmVY+ZmdWW5zTUu4FLImKNpEOA1ZLui4gNFX22AL8bEc9JOgVYChyTY01mZlYltyCIiB3AjvTxi5I2Au3Ahoo+D1e85BFgal71mJlZbU05RiBpOjAbWDlMt3OBu4d4/fmSOiV19vb2Nr5AM7MSyz0IJE0CbgcujogXhuhzPEkQXFpreUQsjYg5ETGnra0tv2LNzEoo11tVSmohCYGbI6JjiD4fBK4HTomIZ/Ksx8zMXi/Ps4YE3ABsjIirhugzDegAFkbEk3nVYmZmQ8tzRDAPWAh0S1qbtn0JmAYQEdcCXwbeBlyd5Aa7I2JOjjWZmVmVPM8aeghQnT7nAeflVYOZmdXnK4vNzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiWX65XFY9n3Lzi26BLMzMYEjwjMzErOQWBmVnIOAjOzknMQmJmVnIPAzKzkHARmZiXnIDAzKzkHgZlZyTkIzMxKThFRdA0jIqkX+EWDVzsFeLrB62wE1zUyrmtkXNfIjPe6fj0i2motGHdBkAdJnWPxFpmua2Rc18i4rpHZn+vyriEzs5JzEJiZlZyDILG06AKG4LpGxnWNjOsamf22Lh8jMDMrOY8IzMxKzkFgZlZypQsCSRMkdUm6s8YySfqWpM2S1kk6aozUdZyk5yWtTb++3KSafi6pO33PzhrLC9leGeoqantNlnSbpCckbZR0bNXyorZXvbqavr0kzah4v7WSXpB0cVWfpm+vjHUV9fP1BUnrJT0u6RZJB1YtH/32iohSfQF/BnwXuLPGslOBuwEBc4GVY6Su42q1N6GmnwNThlleyPbKUFdR2+sm4Lz08QHA5DGyverVVcj2qnj/CcAvSS54Knx7Zair6dsLaAe2AK3p81uBsxu1vUo1IpA0FfgocP0QXU4H/j4SjwCTJR06BuoaqwrZXmORpDcBvwPcABARr0REX1W3pm+vjHUV7UTgpxFRPWNA0T9fQ9VVlIlAq6SJwEHA9qrlo95epQoC4K+ALwJ7hljeDjxV8Xxb2pa3enUBHCvpMUl3S/rNJtQEEMC9klZLOr/G8qK2V726oPnb611AL/CddBff9ZIOrupTxPbKUhcU8/M16JPALTXai/r5GjRUXdDk7RURPcDXga3ADuD5iLi3qtuot1dpgkDS7wM7I2L1cN1qtOV6fm3GutaQDE+PBL4NLMuzpgrzIuIo4BTgM5J+p2p507dXql5dRWyvicBRwDURMRv4N+DPq/oUsb2y1FXUzxeSDgBOA35Qa3GNtqac716nrqZvL0lvIfnE/07gMOBgSf+5uluNl2baXqUJAmAecJqknwPfA06Q9A9VfbYBh1c8n8rrh19NrysiXoiIl9LHdwEtkqbkXBcRsT39dyfwj8DRVV2K2F516ypoe20DtkXEyvT5bSR/gKv7NHt71a2rqJ+v1CnAmoj4fzWWFfLzlRqyroK210nAlojojYhdQAfw21V9Rr29ShMEEbE4IqZGxHSSId/9EVGdqHcAn06Pvs8lGX7tKLouSe+QpPTx0ST/b8/kWZekgyUdMvgY+AjweFW3pm+vLHUVsb0i4pfAU5JmpE0nAhuquhXx81W3riK2V4VPMfTul6Zvryx1FbS9tgJzJR2UvveJwMaqPqPeXhMbW+v4I+lCgIi4FriL5Mj7ZuBXwDljpK5PAH8qaTfQD3wy0tMEcvR24B/Tn/eJwHcj4p4xsL2y1FXE9gL4HHBzulvhZ8A5Y2B7ZamrkO0l6SDg94ALKtoK314Z6mr69oqIlZJuI9kttRvoApY2ant5igkzs5Irza4hMzOrzUFgZlZyDgIzs5JzEJiZlZyDwMxsH0j6iqQevTYJ3ak1+hwoaVV6NfJ6SZdVLLtcySRxayXdK+mwqtdOk/SSpP8ygpq+LemlrP0dBLZfk/S2il/QX1b9wj6c03vOlnR9+vhsSSHpxIrlH0vbPpE+f1DSnPTx4Myq3ZI2SPoLSW9Ml7VJuiePmi0bJTOP3lhj0TcjYlb6dVeN5S8DJ6RXI88CTk7P9QdYEhEfjIhZwJ1A9Wym3ySZTC5rjXOAyVn7g4PA9nMR8czgLyhwLXv/wlZfmdkoXyKZemBQN8kFSoM+CTw2zOuPj4iZJFdMv4v0VoQR0QvskDSvseVa3tKJ4AY/obekX5Eue6Gi68FUTAshaQHJtR/rK9cn6SOSVkhaI+kHkial7ROAJSRzl2XmILDSGhw6p5/y/kXSrZKelHSlpLPSoXy3pCPSfm2Sbpf0aPr1uj/ISq56/mBEVP6h/zFwtKSW9Bf23cDaevWlfzguBBZIemvavAw4a5++ccvDZ9PdO3+nZF6g11Fyz5G1wE7gvoppP5D0vyQ9RfJ/++W07WDgUuCyqvVMAf4bcFI651YnyTT2AJ8F7hjpFdgOArPEkcBFwExgIfDeiDiaZGrwz6V9/ppkRPEh4OPUnjZ8Dq+fiiOA/wvMJ5k47I6sRaWfFrcA70mbOoEPZ329NYaklekf8etJ5gYb3L04H7gGOIJkl88O4Bu11hERA+nIdCrJB4MPVCz7rxFxOHAzyR9zSALgmxUjiUFzgfcD/5rW9EfAr6fHFv6AvUejmZR+igmz1KODn6Ik/RQYnOK3Gzg+fXwS8P50eguAN0k6JCJerFjPoSTTPlf7HvB54M3AJSS7j7KqnFVyJ8nsk9ZEEXEMJKNHkhvCnF2rn6S/JdnPP9y6+iQ9CJzM6z80fBf4IfA/gGOAT0j6Gsk+/z2S/h34BcmIonJ3I5I+SjLa3Jz+jB4kaXNEvLve9+cgMEu8XPF4T8XzPbz2e/IG4NiI6B9mPf3AgdWNEbEq/QTYHxFPVoTJsNJdTdOBJ9OmA9P3sDFC0qEVu2I+xuv/uCOpDdiVhkAryYeKr6bL3hMRP0m7ngY8ARARH654/VeAlyLib9J1/W9J746IzencSFMj4ofAOype81KWEADvGjIbiXt5bdiOpFk1+mwk+VRWy2JGMBJIjydcDSyLiOfS5vdS4w+NFepr6bGkdSSjxy8ASDpM0uAZRIcCD6R9HiX5RD84crhSyX2I15HMpnvRcG+WnjRwNnBL+ppHgPftyzfgEYFZdp8n+SS2juR350ckB3NfFRFPSHpzjV1GRMRQpwBOZO8RyQNKhgxvILnfwuUVy44n2XVgBYiIB4EHq9oWDtF3O8lsoETEOmD2EP0+nuF9v1L1/H7gQ3VeM6neegd59lGzBpP0BeDFiKh7D+r0GoHNwAci4vkM/X8EnF4xQjDbZ941ZNZ417D3J/ya0gt/1gJXZwyBNuAqh4A1mkcEZmYl5xGBmVnJOQjMzErOQWBmVnIOAjOzknMQmJmV3P8HERa6uD1nv7cAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "lc.plot(marker=\"o\")"
    ]
@@ -330,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,9 +449,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: AstropyDeprecationWarning: The truth value of a Quantity is ambiguous. In the future this will raise a ValueError. [astropy.units.quantity]\n"
+     ]
+    }
+   ],
    "source": [
     "dataset_maker = SpectrumDatasetMaker(\n",
     "    region=on_region, e_reco=e_reco, e_true=e_true, containment_correction=True\n",
@@ -387,9 +477,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ljouvin/installation_gammapy/gammapy/gammapy/utils/interpolation.py:159: Warning: Interpolated values reached float32 precision limit\n",
+      "  \"Interpolated values reached float32 precision limit\", Warning\n"
+     ]
+    }
+   ],
    "source": [
     "datasets_1d = []\n",
     "\n",
@@ -416,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,9 +544,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 161 ms, sys: 0 ns, total: 161 ms\n",
+      "Wall time: 159 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "lc_1d = lc_maker_1d.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
@@ -464,9 +572,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f7faf819e10>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAERCAYAAAB2CKBkAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nO3de5gdVZnv8e/P0CGNCYmGRsjNRIQoCblNuGRglBAwgAqoCDqcMEEcYLwgDCcCnnlQ8AIaBzB6ACMMyhGRCJkMIFe5iAwQyI0OkARxUOgQhxDNhaExnfCeP6padu/s7t7dvWvv7tTv8zz7oWrVqqo3RXe/e9WqWksRgZmZ5dfbah2AmZnVlhOBmVnOORGYmeWcE4GZWc45EZiZ5ZwTgZlZzvXJRCDp3yS9IunpCh3vbkkbJd1RVP4FSc9LCkl7VOJcZma9TZ9MBMCPgaMreLy5wKwS5f8JHAn8oYLnMjPrVfpkIoiIh4E/FZZJ2if9Zr9U0m8kva8Lx7sf2FKifHlE/L7HAZuZ9WK71DqACpoPnBURv5V0MHAVcESNYzIz6/V2ikQgaSDwt8AvJLUW75pu+zhwSYnd1kbEzOpEaGbWe+0UiYDkFtfGiJhUvCEiFgILqx+SmVnf0Cf7CIpFxGbgBUmfBFBiYo3DMjPrE/pkIpB0E/AYMFZSk6TTgVOA0yU9BTwDHN+F4/0G+AUwIz3ezLT8bElNwAigUdK1lf63mJnVmjwMtZlZvvXJFoGZmVVOn+ss3mOPPWL06NG1DsPMrE9ZunTpqxHRUGpbn0sEo0ePZsmSJbUOw8ysT5HU7ggJvjVkZpZzTgRmZjnnRGBmlnN9ro/AzCwrLS0tNDU18cYbb9Q6lG4bMGAAI0aMoK6urux9nAjMzFJNTU0MGjSI0aNHUzBuWZ8REWzYsIGmpibGjBlT9n6+NWRmlnrjjTcYOnRon0wCAJIYOnRol1s0TgRmZgX6ahJo1Z34nQjMzHrg5B8+xsk/fKzWYfSIE4FZBp751mE8863Dah2G9UGf+cxn2HPPPRk/fvxfyz7xqVMY+e7RTJw4kf32249TTz2VtWvXVuycTgRmZt20aPlalr+4kcUv/IlDL3uARct7/sd59uzZ3H333TuUn//Vb/DUU0+xZs0aJk+ezPTp09m6dWuPzwdOBGZm3bJo+VouXLiSrdvfBGDtxmYuXLiyx8ngAx/4AO985zvb3S6Jc889l7322ou77rqrR+dq5URgZtYFrX0CX76lkeaW7W22Nbds58u3NFalz2DKlCmsXr26IsdyIjAz64bWlkC55ZVWyblknAjMzLrg5jOncfOZ0xg+pL7k9uFD6rn5zGmZx7F8+XLe//73V+RYTgRmZt0wZ+ZY6uv6tSmrr+vHnJljMz1vRDBv3jzWrVvH0UcfXZFjOhGYmXXDCZOHc+nHD6B/v+TP6PAh9Vz68QM4YfLwHh3305/+NNOmTWPNmjWMGDGC6667DoBvX/wvf3189Mknn+TBBx+kf//+Pf53QIZjDUkaADwM7Jqe55aI+GpRnVOA89PV14B/ioinsorJzKySTpg8nJueeBGgYreDbrrpph3KDj/uZAD2aRhYkXMUy3LQub8AR0TEa5LqgEck3RURjxfUeQH4YET8WdIxwHzg4AxjMjOrqGr0B2Qts0QQSZf2a+lqXfqJojqPFqw+DozIKh4zMyst0z4CSf0krQBeAe6LiMUdVD8dKPl2hKQzJC2RtGT9+vVZhGpmlluZJoKI2B4Rk0i+6R8kaXypepKmkySC80ttj4j5ETE1IqY2NDRkF7CZWQ5V5amhiNgIPATs8KyTpAnAtcDxEbGhGvGYmdlbMksEkhokDUmX64EjgdVFdUYBC4FZEfFcVrGYmWXm+g8nnz4syxbB3sCDkhqBJ0n6CO6QdJaks9I6FwFDgaskrZC0JMN4zMx6vTfeeIODDjqIiRMnMm7cOL761eSp+y9/8UzGjBmTyVDUWT411AhMLlF+TcHyZ4HPZhWDmVmmGhdA05Ow/S9wxXiYcRFMOKlHh9x111154IEHGDhwIC0tLRx22GEccMgHAZg7dy4nnngiEcGVV17J9OnTefrpp3v8YpnfLDYz647GBXD72UkSANj0UrLeuKBHh5XEwIHJi2MtLS20tLTsMP1kpYeidiIwM+uK1j6B//gCtDS33dbSnJT3sM9g+/btTJo0iT333JOjjjqKSX9zYMl6lRqK2onAzKw7WlsC5ZZ3Qb9+/VixYgVNTU088cQTPLfq2ZL1KjUUtROBmVlXnPbL5DN4ZOntg0cm2ytgyJAhHH744Tz8wH0lt1dqKGonAjOz7phxEdQVzUlQV5+U98D69evZuHEjAM3NzfzqV7/iPfvu16ZOpYeidiIwM+uOCSfBR+dBv12T9cEjk/UePjW0bt06pk+fzoQJEzjwwAM56qijOOJDxwAwZ86cTIaiznL0UTOznduEk2DpT5LlCt0OmjBhAsuXL29T9rv1r/Gd7/+wTw5DbWa286tQAqgl3xoyM8s5JwIzswKVeiSzVroTvxOBmVlqwIABbNiwoc8mg4hgw4YNDBgwoEv7uY/AzCw1YsQImpqa6G0TYK3fkryktvXVXTutO2DAAEaM6Npkj04EZmapuro6xowZU+swdvC1Hz4GwM1nTsrk+L41ZGaWc04EZmY550RgZpZzTgRmZjnnRGBmlnNOBGZmOedEYGaWc04EZmY550RgZpZzmSUCSQMkPSHpKUnPSLq4RB1JmifpeUmNkqZkFY+ZmZWWZYvgL8ARETERmAQcLemQojrHAPumnzOAqzOMx6w6Ghew79bV7L91JVwxHhoX1Doisw5lNtZQJMP3vZau1qWf4iH9jgduSOs+LmmIpL0jYl1WcZllqnEB3H42/WlJ1je9BLefnSz3cApDy6+LNsxJlx7J5PiZ9hFI6idpBfAKcF9ELC6qMhx4qWC9KS0rPs4ZkpZIWtLbRgU0a+P+S6CluW1ZS3NSbtZLZZoIImJ7REwCRgAHSRpfVEWlditxnPkRMTUipjY0NGQRqllFxKamLpWb9QZVeWooIjYCDwFHF21qAkYWrI8AXq5GTGZZ+G/26FK5WW+Q5VNDDZKGpMv1wJHA6qJqtwGnpk8PHQJscv+A9WWXbv0kr0f/NmWvR38u3frJGkVkfd2i5WuZveVzfGTzBRx62QMsWr624ufIcmKavYGfSOpHknAWRMQdks4CiIhrgDuBY4HngdeB0zKMxyxzS3Y/igs2w5d3WcAwbeDlGMp3tp3E0t2PqnVo1gctWr6WCxeupDkGA7B2YzMXLlwJwAmTd+hO7bYsnxpqBCaXKL+mYDmAz2cVg1m1zZk5lgsXbuW2rYf9tay+rh+Xzhxbw6isr5p7zxqaW7a3KWtu2c7ce9b0jURglketv5zfXPBrXo3dGTZkN+bMHFvRX1rLj5c3NnepvLucCMwq7ITJw9n3rqsAGHdBNs99Wz4MG1LP2hJ/9IcNqa/oeTzWkJlZLzVn5ljq6/q1Kauv68ecCt9qzFWL4OQfPgbAzWdOq3EkZmadq9atxlwlAjOzvqYatxp9a8jMLOecCMzMcs6JwMws55wIzMxyzonAzCznnAjMzHLOicDMLOecCMzMcs6JwMws55wIzMxyzonAzCznyhprSNKewKHAMKAZeBpYEhFvZhibmZlVQYeJQNJ04ALgncBy4BVgAHACsI+kW4B/jYjNWQdqZmbZ6KxFcCzwjxHxYvEGSbsAHwGOAm7NIDYzM6uCDhNBRMzpYNs2YFHFIzIzs6rqdmexpNMqGYiZmdVGT54aurhiUZiZWc101lnc2N4m4F2d7DsSuAHYC3gTmB8R3yuqMxj4KTAqjeW7EXF9eaGbmVkldNZZ/C5gJvDnonIBj3ay7zbgvIhYJmkQsFTSfRHxbEGdzwPPRsRHJTUAayTdGBFbu/BvMDOzHugsEdwBDIyIFcUbJD3U0Y4RsQ5Yly5vkbQKGA4UJoIABkkSMBD4E0kCMTOzKunsqaHTO9j29+WeRNJoYDKwuGjTD4DbgJeBQcDJpV5Sk3QGcAbAqFGjyj2tmZmVocudxekf5a7UH0jynsE5JV48mwmsIHljeRLwA0m7Fx8jIuZHxNSImNrQ0NDVkM3MrANlDTFR5CxgfjkVJdWRJIEbI2JhiSqnAZdFRADPS3oBeB/wRDfi6tRFG1pfi3gki8ObmfVJ3Xl8VGVVSu77XwesiojL26n2IjAjrf8uYCzwX92IyczMuqk7LYKPllnvUGAWsFJSa2fzV0geFSUirgG+DvxY0kqSBHN+RLzajZjMzHZOjQvYd+tq6miBK8bDjItgwkkVPUW5o49+Cbge2AJcLGkycEFE3NvePhHxCJ20HiLiZeBD5YdrZpYjjQvg9rPpT0uyvukluP3sZLmCyaDcW0OfSTt6PwQ0kN7br1gUZma2o/svgZbmtmUtzUl5BZWbCFq/2R8LXB8RT1FmX4GZmXXTpqaulXdTuYlgqaR7SRLBPembwp6UxswsS4NHdK28m8pNBKeTTFBzYES8DvQnuT1kZmZZmXER1NW3LaurT8orqKzO4vRt32UF6xuADRWNxGwncsnQuQDcXOM4rI9LO4S3LvwcdbSgwSNr99SQmZnVyIST+O0d8wAYd242L8P2ZD4CMzPbCeQmESxavpbZWz7HRzZfwKGXPcCi5WtrHZKZWa/Q2cQ0BwA/Ihk++i6SN3//nG57IiIOyj7Enlu0fC0XLlxJcwwGYO3GZi5cuBKAEyYPr2VotpO6+cxptQ7BrGydtQiuBr4GHAA8BzwiaZ90W12GcVXU3HvW0NyyvU1Zc8t25t6zpkYRmZn1Hp11Fg+MiLvT5e9KWgrcLWkWyaQyfcLLG5u7VG5mliedtQiUzisMQEQ8CHwC+H/Au7MMrJKGDanvUrmZWZ50lgi+Dby/sCAiGkmGji41v0CvNGfmWOrr+rUpq6/rx5yZY2sUkZlZ79HZVJU/Ky6TtFdEvAj8Y2ZRVVhrh/A3F/yaV2N3hg3ZjTkzx7qj2MyM7r1QdicwpdKBZO2EycPZ966rABh3gWcoMzNr1Z1E4FFHzcyqaNzegzuv1APdeaHsRxWPwszMaqbsFoGkdwAjgcclTQGIiGUd72VmZr1duVNVfh2YDfyOt94fCOCIbMIyM7NqKbdFcBKwT0RszTIYMzOrvnL7CJ4GhmQZiJmZ1Ua5LYJLgeWSngb+0loYEcdlEpWZmVVNuYngJyRvGa+kzLmKJY0EbgD2SveZHxHfK1HvcOBKkkHsXo2ID5YZk5mZVUC5ieDViJjXxWNvA86LiGXpZPdLJd0XEc+2VpA0BLgKODoiXpS0ZxfPYWZmPVRuH8FSSZdKmiZpSuunox0iYl3r46URsQVYRTKvQaG/BxamQ1YQEa90Mf7yNS5g362r2X/rSrhiPDQuyOxUZmZ9Sbktgsnpfw8pKCv78VFJo9NjLC7atB9QJ+khYBDwvYi4ocT+ZwBnAIwaNarMkAs0LoDbz6Y/Lcn6ppfg9rOT5QpPAm1m1teUlQgiYnp3TyBpIHArcE5EbC5x/r8hGc20HnhM0uMR8VzR+ecD8wGmTp3a9XkQ7r8EWormHmhpTsqdCMws58q6NSTpW+n9/Nb1d0j6Rhn71ZEkgRsjotSw1U3A3RHxPxHxKvAwMLG80LtgU1PXys3McqTcPoJjImJj60o6b/GxHe0gScB1wKqIuLydav8B/J2kXSTtBhxM0pdQWYNHdK3czCxHyk0E/STt2roiqR7YtYP6AIcCs4AjJK1IP8dKOkvSWQARsQq4G2gEngCujYinu/yv6MyMi6CuaDayuvqk3Mws58rtLP4pcL+k60k6iT9D8m5BuyLiEcoYsjoi5gJzy4yje9J+gK0LP0cdLWjwyCQJuH/AzKzszuLvSGoEjiT54/71iLgn08gqbcJJ/PaO5FWIced6Yhozs1YdJgJJiogAiIi7SW7jtFvHzMz6ns76CB6U9EVJbR7el9Rf0hGSfgL8Q3bhmZlZ1jq7NXQ0SX/ATZLGABtJnvd/G3AvcEVErMg2RDMzy1KHiSAi3iAZC+iq9J2APYDmwkdJzcysbyt7qsqIaAHWZRiLmZnVQHcmrzczs51IfhPB9R9OPmZmOVfu5PX7F84jkJYdHhEPZRKVmZm95bRfZnr4clsECySdr0S9pO+TTF9pZmZ9XLmJ4GBgJPAo8CTwMslYQmZm1seVmwhagGaSdwgGAC9ERFlzF5uZWe9WbiJ4kiQRHAgcBnxa0i2ZRWVmZlVT7nsEp0fEknT5j8DxkmZlFJOZmVVRuYngleLxhoBfVzoYMzOrvnITwS9J5iEQSR/BGGANMC6juDIxbu/BtQ7BzKzXKXc+ggMK1yVNAc7MJCIzM6uqbr1ZHBHLSDqOzcysjyv3zeJ/Llh9GzAFWJ9JRGZmVlXl9hEMKljeRtJncGvlwzEzs2ort4/g4qwDMTOz2uhszuLbSZ4WKikijqt4RGZmVlWdtQi+290DSxoJ3ADsBbwJzI+I77VT90DgceDkiPAby2ZmVdRZInghIl7s5rG3AedFxDJJg4Clku4rMZx1P+DbwD3dPI+ZmfVAZ4+PLmpdkNSlzuGIWJc+ZkpEbAFWAcNLVP0iScfzK105vpmZVUZniUAFy+/p7kkkjQYmA4uLyocDHwOu6WT/MyQtkbRk/Xo/tWpmVkmdJYJoZ7lskgaSfOM/JyI2F22+Ejg/IrZ3GETE/IiYGhFTGxoauhOGmZm1o7M+gomSNpO0DOrTZdL1iIjdO9pZUh1JErgxIhaWqDIV+LkkgD2AYyVti4hFJer2XMbTvZmZ9UUdJoKI6NfdAyv5634dsCoiLm/n+GMK6v8YuCOzJGBmZiWV+2ZxdxwKzAJWSlqRln0FGAUQER32C5iZWXVklggi4hHadjZ3Vn92VrGU8sy6TUAfG0fbzCwD3Rp91MzMdh5OBGZmOedEYGaWc/lMBI0L2HfravbfuhKuGA+NC2odkZlZzWT51FDv1LgAbj+b/rQk65tegtvPTpYnnFS7uMzMaiR/LYL7L4GW5rZlLc1JuZlZDuUvEWxq6lq5mdlOLn+JYPCIrpWbme3k8pcIZlwEdfVty+rqk3IzsxzKXyKYcBJ8dB5bqUuGUx08Ej46zx3FZpZb+XtqCGDCSfz2jnkAjDv3kRoHY2ZWW/lrEZiZWRtOBGZmOedEYGaWc04EZmY550RgZpZzTgRmZjnnRGBmlnNOBGZmOedEYGaWc04EZmY550RgZpZzmSUCSSMlPShplaRnJH2pRJ1TJDWmn0clTcwqHjMzKy3LQee2AedFxDJJg4Clku6LiGcL6rwAfDAi/izpGGA+cHCGMZmZWZHMEkFErAPWpctbJK0ChgPPFtR5tGCXxwHPDmNmVmVV6SOQNBqYDCzuoNrpwF3t7H+GpCWSlqxfv77yAZqZ5VjmiUDSQOBW4JyI2NxOnekkieD8UtsjYn5ETI2IqQ0NDT2OadHytcze8jk+svkCDr3sARYtX9vjY5qZ9VWZTkwjqY4kCdwYEQvbqTMBuBY4JiI2ZBkPJEngwoUraY7BAKzd2MyFC1cCcMLk4Vmf3sys18nyqSEB1wGrIuLyduqMAhYCsyLiuaxiKTT3njU0t2xvU9bcsp2596ypxunNzHqdLFsEhwKzgJWSVqRlXwFGAUTENcBFwFDgqiRvsC0ipmYYEy9vbO5SuZnZzi7Lp4YeAdRJnc8Cn80qhlKGDalnbYk/+sOG1FczDDOzXiN3bxbPmTmW+rp+bcrq6/oxZ+bYGkVkZlZbmXYW90atHcLfXPBrXo3dGTZkN+bMHOuOYjPLrdwlAkiSwb53XQXAuAseqXE0Zma1lbtbQ2Zm1pYTgZlZzuXy1hDAJUPnAnBzjeMwM6s1twjMzHLOicDMLOecCMzMcs6JwMws55wIzMxyzonAzCznnAjMzHLOicDMLOecCMzMcs6JwMws55wIzMxyzonAzCznnAjMzHLOicDMLOecCMzMcs6JwMws5zJLBJJGSnpQ0ipJz0j6Uok6kjRP0vOSGiVNySoeMzMrLcsZyrYB50XEMkmDgKWS7ouIZwvqHAPsm34OBq5O/2tmZlWSWYsgItZFxLJ0eQuwChheVO144IZIPA4MkbR3VjGZmdmOqtJHIGk0MBlYXLRpOPBSwXoTOyYLJJ0haYmkJevXr88qTDOzXMp88npJA4FbgXMiYnPx5hK7xA4FEfOB+QBTp07dYXt33HzmtEocxsysz8u0RSCpjiQJ3BgRC0tUaQJGFqyPAF7OMiYzM2sry6eGBFwHrIqIy9updhtwavr00CHApohYl1VMZma2oyxvDR0KzAJWSlqRln0FGAUQEdcAdwLHAs8DrwOnZRiPmZmVkFkiiIhHKN0HUFgngM9nFYOZmXXObxabmeWcE4GZWc45EZiZ5ZwTgZlZzjkRmJnlnJIHd/oOSeuBP1T4sHsAr1b4mJXguLrGcXWN4+qavh7XuyOiodSGPpcIsiBpSURMrXUcxRxX1ziurnFcXbMzx+VbQ2ZmOedEYGaWc04Eifm1DqAdjqtrHFfXOK6u2Wnjch+BmVnOuUVgZpZzTgRmZjmXu0QgqZ+k5ZLuKLFNkuZJel5So6QpvSSuwyVtkrQi/VxUpZh+L2lles4lJbbX5HqVEVetrtcQSbdIWi1plaRpRdtrdb06i6vq10vS2ILzrZC0WdI5RXWqfr3KjKtWP1/nSnpG0tOSbpI0oGh7969XROTqA/wz8DPgjhLbjgXuIhk++xBgcS+J6/BS5VWI6ffAHh1sr8n1KiOuWl2vnwCfTZf7A0N6yfXqLK6aXK+C8/cD/kjywlPNr1cZcVX9epHM5f4CUJ+uLwBmV+p65apFIGkE8GHg2naqHA/cEInHgSGS9u4FcfVWNblevZGk3YEPkMzKR0RsjYiNRdWqfr3KjKvWZgC/i4jiEQNq/fPVXly1sgtQL2kXYDd2nNa329crV4kAuBL4MvBmO9uHAy8VrDelZVnrLC6AaZKeknSXpHFViAkggHslLZV0RonttbpencUF1b9e7wHWA9ent/iulfT2ojq1uF7lxAW1+flq9SngphLltfr5atVeXFDl6xURa4HvAi8C60im9b23qFq3r1duEoGkjwCvRMTSjqqVKMv0+doy41pG0jydCHwfWJRlTAUOjYgpwDHA5yV9oGh71a9XqrO4anG9dgGmAFdHxGTgf4ALiurU4nqVE1etfr6Q1B84DvhFqc0lyqryvHsncVX9ekl6B8k3/jHAMODtkv5XcbUSu5Z1vXKTCEjmUD5O0u+BnwNHSPppUZ0mYGTB+gh2bH5VPa6I2BwRr6XLdwJ1kvbIOC4i4uX0v68A/w4cVFSlFter07hqdL2agKaIWJyu30LyB7i4TrWvV6dx1ernK3UMsCwi/rvEtpr8fKXajatG1+tI4IWIWB8RLcBC4G+L6nT7euUmEUTEhRExIiJGkzT5HoiI4ox6G3Bq2vt+CEnza12t45K0lySlyweR/H/bkGVckt4uaVDrMvAh4OmialW/XuXEVYvrFRF/BF6SNDYtmgE8W1StFj9fncZVi+tV4NO0f/ul6ternLhqdL1eBA6RtFt67hnAqqI63b5emU1e31dIOgsgIq4B7iTpeX8eeB04rZfEdSLwT5K2Ac3ApyJ9TCBD7wL+Pf153wX4WUTc3QuuVzlx1eJ6AXwRuDG9rfBfwGm94HqVE1dNrpek3YCjgDMLymp+vcqIq+rXKyIWS7qF5LbUNmA5ML9S18tDTJiZ5Vxubg2ZmVlpTgRmZjnnRGBmlnNOBGZmOedEYGbWA5K+Jmmt3hqE7tgSdQZIeiJ9G/kZSRcXbPu6kkHiVki6V9Kwon1HSXpN0v/uQkzfl/RaufWdCGynJmlowS/oH4t+YR/N6JyTJV2bLs+WFJJmFGz/WFp2Yrr+kKSp6XLryKorJT0r6RuSdk23NUi6O4uYrTxKRh79cYlNV0TEpPRzZ4ntfwGOSN9GngQcnT7rDzA3IiZExCTgDqB4NNMrSAaTKzfGqcCQcuuDE4Ht5CJiQ+svKHANbX9hi9/MrJSvkAw90GolyQtKrT4FPNXB/tMj4gCSN6bfQzoVYUSsB9ZJOrSy4VrW0oHgWr+h16WfSLdtLqj6dgqGhZB0Asm7H88UHk/ShyQ9JmmZpF9IGpiW9wPmkoxdVjYnAsut1qZz+i3v15IWSHpO0mWSTkmb8isl7ZPWa5B0q6Qn088Of5CVvPU8ISIK/9D/BjhIUl36C/teYEVn8aV/OM4CTpD0zrR4EXBKj/7hloUvpLd3/k3JuEA7UDLnyArgFeC+gmE/kPRNSS+R/L+9KC17O3A+cHHRcfYA/gU4Mh1zawnJMPYAXwBu6+ob2E4EZomJwJeAA4BZwH4RcRDJ0OBfTOt8j6RFcSDwCUoPGz6VHYfiCOBXwEySgcNuKzeo9NviC8C+adES4O/K3d8qQ9Li9I/4tSRjg7XeXpwJXA3sQ3LLZx3wr6WOERHb05bpCJIvBuMLtv2fiBgJ3EjyxxySBHBFQUui1SHA/sB/pjH9A/DutG/hk7RtjZYl90NMmKWebP0WJel3QOsQvyuB6enykcD+6fAWALtLGhQRWwqOszfJsM/Ffg6cDQwGziO5fVSuwlElXyEZfdKqKCIOhqT1SDIhzOxS9ST9iOQ+f0fH2ijpIeBodvzS8DPgl8BXgYOBEyV9h+Se/5uS3gD+QNKiKLzdiKQPk7Q2n09/RneT9HxEvLezf58TgVniLwXLbxasv8lbvydvA6ZFRHMHx2kGBhQXRsQT6TfA5oh4riCZdCi91TQaeC4tGpCew3oJSXsX3Ir5GDv+cUdSA9CSJoF6ki8V30637RsRv02rHgesBoiIvyvY/2vAaxHxg/RY/1fSeyPi+XRspBER8Utgr4J9XisnCYBvDZl1xb281WxH0qQSdVaRfCsr5UK60BJI+xOuAhZFxJ/T4v0o8YfGauo7aV9SI0nr8VwAScMktT5BtDfwYFrnSZJv9K0th8uUzEPcSDKa7pc6Oln60MBs4KZ0n8eB9/XkH+AWgVn5zib5JtZI8rvzMEln7l9FxGpJg0vcMiIi2nsEcBfatqjDh60AAACgSURBVEgeVNJkeBvJfAtfL9g2neTWgdVARDwEPFRUNqudui+TjAZKRDQCk9up94kyzvu1ovUHgAM72WdgZ8dt5dFHzSpM0rnAlojodA7q9B2B54HxEbGpjPoPA8cXtBDMesy3hswq72rafsMvKX3xZwVwVZlJoAG43EnAKs0tAjOznHOLwMws55wIzMxyzonAzCznnAjMzHLOicDMLOf+P/tx3YlKLKSTAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ax = lc_1d.plot(marker=\"o\", label=\"1D\")\n",
     "lc.plot(ax=ax, marker=\"o\", label=\"3D\")\n",


### PR DESCRIPTION
This PR introduced given time intervals to compute the LC!


<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a `time_intervals` argument on the `LightCurveEstimator`. This allows to extract light curves with different time binning over the same `Datasets`.

The main requirement is that a `dataset.GTI` in the `Datasets` is fully contained in a `time_interval` to be taken into account for the flux extraction.

This PR is intended to resolve issue #2548.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
