### PR TITLE
Adding obs_id to log for dataset production 

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -259,19 +259,21 @@ class Analysis:
 
         if self.settings["datasets"]["stack-datasets"]:
             for obs in self.observations:
-                log.info(f"Processing observation: {obs.obs_id}")
+                log.info(f"Processing observation {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
+                log.debug(dataset)
                 stacked.stack(dataset)
             self._extract_irf_kernels(stacked)
             datasets = [stacked]
         else:
             datasets = []
             for obs in self.observations:
-                log.info(f"Processing observation: {obs.obs_id}")
+                log.info(f"Processing observation {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
                 self._extract_irf_kernels(dataset)
+                log.debug(dataset)
                 datasets.append(dataset)
 
         self.datasets = Datasets(datasets)
@@ -342,11 +344,12 @@ class Analysis:
 
         datasets = []
         for obs in self.observations:
-            log.info(f"Processing observation: {obs.obs_id}")
+            log.info(f"Processing observation {obs.obs_id}")
             selection = ["counts", "aeff", "edisp"]
             dataset = dataset_maker.run(obs, selection=selection)
             dataset = reflected_bkg_maker.run(dataset, obs)
             dataset = safe_mask_maker.run(dataset, obs)
+            log.debug(dataset)
             datasets.append(dataset)
 
         self.datasets = Datasets(datasets)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -130,8 +130,9 @@ class Analysis:
                 else:
                     ids.extend(selected_obs["OBS_ID"].tolist())
         self.observations = self.datastore.get_observations(ids, skip_missing=True)
+        log.info(f"{len(self.observations.list)} observations were selected.")
         for obs in self.observations.list:
-            log.info(obs)
+            log.debug(obs)
 
     def get_datasets(self):
         """Produce reduced datasets."""
@@ -258,6 +259,7 @@ class Analysis:
 
         if self.settings["datasets"]["stack-datasets"]:
             for obs in self.observations:
+                log.info(f"Processing observation: {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
                 stacked.stack(dataset)
@@ -266,6 +268,7 @@ class Analysis:
         else:
             datasets = []
             for obs in self.observations:
+                log.info(f"Processing observation: {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
                 self._extract_irf_kernels(dataset)
@@ -339,6 +342,7 @@ class Analysis:
 
         datasets = []
         for obs in self.observations:
+            log.info(f"Processing observation: {obs.obs_id}")
             selection = ["counts", "aeff", "edisp"]
             dataset = dataset_maker.run(obs, selection=selection)
             dataset = reflected_bkg_maker.run(dataset, obs)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a `log.info` to print the `obs_id` of the observation being processed in `Analysis.get_datasets()`. 
It changes the `log.info(obs)` at the end of the `Analysis.get_observations()` to `log.debug(obs)`. 
Finally, it introduces a `log.debug(dataset)` in the `Analysis.get_datasets()` loop. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
the PR is ready for review.