### PR TITLE
Move make_psf and make_mean_psf tests

### DIFF
--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -237,8 +237,24 @@ class PSFMap:
         energies = self.psf_map.geom.axes[1].center
         rad = self.psf_map.geom.axes[0].center
 
+        if self.exposure_map is not None:
+            exposure_3d = self.exposure_map.slice_by_idx({"theta": 0})
+            coords = {
+                "skycoord": position,
+                "energy": energies.reshape((-1, 1, 1))
+            }
+            data = exposure_3d.interp_by_coord(coords).squeeze()
+            exposure = data * self.exposure_map.unit
+        else:
+            exposure = None
+
         # Beware. Need to revert rad and energies to follow the TablePSF scheme.
-        return EnergyDependentTablePSF(energy=energies, rad=rad, psf_value=psf_values.T)
+        return EnergyDependentTablePSF(
+            energy=energies,
+            rad=rad,
+            psf_value=psf_values.T,
+            exposure=exposure
+        )
 
     def get_psf_kernel(self, position, geom, max_radius=None, factor=4):
         """Returns a PSF kernel at the given position.

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -1,12 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
+from gammapy.data import DataStore
 from gammapy.cube import PSFMap, make_map_exposure_true_energy, make_psf_map
 from gammapy.irf import PSF3D, EffectiveAreaTable2D
 from gammapy.maps import MapAxis, MapCoord, WcsGeom
+from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.utils.testing import requires_data
+
+
+@pytest.fixture(scope="session")
+def data_store():
+    return DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
 
 
 def fake_psf3d(sigma=0.15 * u.deg, shape="gauss"):
@@ -209,3 +218,111 @@ def test_sample_coord_gauss():
 
     assert_allclose(np.mean(coords.skycoord.data.lon.wrap_at("180d").deg), 0, atol=1e-3)
     assert_allclose(np.mean(coords.lat), 0, atol=1e-3)
+
+
+@requires_data()
+@pytest.mark.parametrize(
+    "pars",
+    [
+        {
+            "energy": None,
+            "rad": None,
+            "energy_shape": (32,),
+            "psf_energy": 865.9643,
+            "rad_shape": (144,),
+            "psf_rad": 0.0015362848,
+            "psf_exposure": 3.14711e12,
+            "psf_value_shape": (32, 144),
+            "psf_value": 4369.96391,
+        },
+        {
+            "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV"),
+            "rad": None,
+            "energy_shape": (100,),
+            "psf_energy": 1428.893959,
+            "rad_shape": (144,),
+            "psf_rad": 0.0015362848,
+            "psf_exposure": 4.723409e+12,
+            "psf_value_shape": (100, 144),
+            "psf_value": 3719.21488,
+        },
+        {
+            "energy": None,
+            "rad": MapAxis.from_nodes(np.arange(0, 2, 0.002), unit="deg", name="theta"),
+            "energy_shape": (32,),
+            "psf_energy": 865.9643,
+            "rad_shape": (1000,),
+            "psf_rad": 0.000524,
+            "psf_exposure": 3.14711e12,
+            "psf_value_shape": (32, 1000),
+            "psf_value": 25888.5047,
+        },
+        {
+            "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV"),
+            "rad": MapAxis.from_nodes(np.arange(0, 2, 0.002), unit="deg", name="theta"),
+            "energy_shape": (100,),
+            "psf_energy": 1428.893959,
+            "rad_shape": (1000,),
+            "psf_rad": 0.000524,
+            "psf_exposure": 4.723409e+12,
+            "psf_value_shape": (100, 1000),
+            "psf_value": 22561.543595,
+        },
+    ],
+)
+def test_make_psf(pars, data_store):
+    obs = data_store.obs(23523)
+    psf = obs.psf
+
+    if pars["energy"] is None:
+        edges = edges_from_lo_hi(psf.energy_lo, psf.energy_hi)
+        energy_axis = MapAxis.from_edges(edges, interp="log", name="energy")
+    else:
+        energy_axis = pars["energy"]
+
+    if pars["rad"] is None:
+        edges = edges_from_lo_hi(psf.rad_lo, psf.rad_hi)
+        rad_axis = MapAxis.from_edges(edges, name="theta")
+    else:
+        rad_axis = pars["rad"]
+
+    position = SkyCoord(83.63, 22.01, unit="deg")
+
+    geom = WcsGeom.create(
+        skydir=position,
+        npix=(3, 3),
+        axes=[rad_axis, energy_axis],
+        binsz=0.2
+    )
+
+    exposure_map = make_map_exposure_true_energy(
+        geom=geom.squash(axis="theta"),
+        pointing=obs.pointing_radec,
+        aeff=obs.aeff,
+        livetime=obs.observation_live_time_duration
+    )
+
+    psf_map = make_psf_map(
+        geom=geom,
+        psf=obs.psf,
+        pointing=obs.pointing_radec,
+        exposure_map=exposure_map
+    )
+
+    psf = psf_map.get_energy_dependent_table_psf(position)
+
+    assert psf.energy.unit == "GeV"
+    assert psf.energy.shape == pars["energy_shape"]
+    assert_allclose(psf.energy.value[15], pars["psf_energy"], rtol=1e-3)
+
+    assert psf.rad.unit == "rad"
+    assert psf.rad.shape == pars["rad_shape"]
+    assert_allclose(psf.rad.value[15], pars["psf_rad"], rtol=1e-3)
+
+    assert psf.exposure.unit == "cm2 s"
+    assert psf.exposure.shape == pars["energy_shape"]
+    assert_allclose(psf.exposure.value[15], pars["psf_exposure"], rtol=1e-3)
+
+    assert psf.psf_value.unit == "sr-1"
+    assert psf.psf_value.shape == pars["psf_value_shape"]
+    assert_allclose(psf.psf_value.value[15, 50], pars["psf_value"], rtol=1e-3)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -161,7 +161,7 @@ def test_containment_radius_map():
         skydir=pointing, binsz=0.5, width=(4, 3), axes=[psf_theta_axis, energy_axis]
     )
 
-    psfmap = make_psf_map(psf, pointing, geom, 3 * u.deg)
+    psfmap = make_psf_map(psf=psf, pointing=pointing, geom=geom)
     m = psfmap.containment_radius_map(1 * u.TeV)
     coord = SkyCoord(0.3, 0, unit="deg")
     val = m.interp_by_coord(coord)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request moves the `test_make_psf` and `test_make_mean_psf` to `gammapy/cube/tests/test_psf_map.py` and changes it to use `PSFMap.get_energy_dependent_table_psf()`.

This change was implement pair-coding with @AtreyeeS. While making the change we noticed there was a bug in `test_make_psf()`, where the energy edges where used to create the `EnergyDependentTablePSF`. That is why the test numbers changed. The `test_make_mean_psf()` gives the same result.

**Dear reviewer**
We will work on a follow-up PR to remove `make_mean_psf()` and corresponding tests.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
