### PR TITLE
Speed up Observations.select_time

### DIFF
--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -352,12 +352,10 @@ class Observations:
         mask &= self.tstop > time_interval[0]
 
         indices = np.where(mask)[0]
-        print(indices)
         if len(indices)>0:
             for index in indices:
                 obs = self[index]
                 new_obs = obs.select_time(time_interval)
-#                if len(new_obs.gti.table>0):
                 new_obs_list.append(new_obs)
 
         return self.__class__(new_obs_list)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -321,6 +321,14 @@ class Observations:
         return s
 
     @property
+    def tstart(self):
+        return Time([_.tstart for _ in self])
+
+    @property
+    def tstop(self):
+        return Time([_.tstop for _ in self])
+
+    @property
     def ids(self):
         """List of obs IDs (`list`)"""
         return [str(obs.obs_id) for obs in self.list]
@@ -340,9 +348,16 @@ class Observations:
             A new observations instance of the specified time interval
         """
         new_obs_list = []
-        for obs in self:
-            new_obs = obs.select_time(time_interval)
-            if len(new_obs.gti.table) > 0:
+        mask = self.tstart < time_interval[1]
+        mask &= self.tstop > time_interval[0]
+
+        indices = np.where(mask)[0]
+        print(indices)
+        if len(indices)>0:
+            for index in indices:
+                obs = self[index]
+                new_obs = obs.select_time(time_interval)
+#                if len(new_obs.gti.table>0):
                 new_obs_list.append(new_obs)
 
         return self.__class__(new_obs_list)

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -339,18 +339,10 @@ class Observations:
         new_observations : `~gammapy.data.Observations`
             A new observations instance of the specified time interval
         """
-
-        tstart = Time([_.tstart for _ in self])
-        tstop = Time([_.tstop for _ in self])
-
         new_obs_list = []
-        mask = tstart < time_interval[1]
-        mask &= tstop > time_interval[0]
 
-        indices = np.where(mask)[0]
-        if len(indices)>0:
-            for index in indices:
-                obs = self[index]
+        for obs in self:
+            if (obs.tstart < time_interval[1]) & (obs.tstop > time_interval[0]):
                 new_obs = obs.select_time(time_interval)
                 new_obs_list.append(new_obs)
 

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -321,14 +321,6 @@ class Observations:
         return s
 
     @property
-    def tstart(self):
-        return Time([_.tstart for _ in self])
-
-    @property
-    def tstop(self):
-        return Time([_.tstop for _ in self])
-
-    @property
     def ids(self):
         """List of obs IDs (`list`)"""
         return [str(obs.obs_id) for obs in self.list]
@@ -347,9 +339,13 @@ class Observations:
         new_observations : `~gammapy.data.Observations`
             A new observations instance of the specified time interval
         """
+
+        tstart = Time([_.tstart for _ in self])
+        tstop = Time([_.tstop for _ in self])
+
         new_obs_list = []
-        mask = self.tstart < time_interval[1]
-        mask &= self.tstop > time_interval[0]
+        mask = tstart < time_interval[1]
+        mask &= tstop > time_interval[0]
 
         indices = np.where(mask)[0]
         if len(indices)>0:


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the implementation of `Observations.select_time` to make it run faster. It simply creates `Time` objects containing start and stop times for all observations in the list and creates a `mask` to find which ones should be filtered.

On a simple test on PKS 2155 data from hess-dl3-dr1, it was found to speed up observations time selection by a factor of 10.
For selections over very large `Observations`, this can be a significant improvement for observation selection.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
the PR is ready for review.