### PR TITLE
Fix analysis background names

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -262,6 +262,8 @@ class Analysis:
                 log.info(f"Processing observation {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
+                dataset.background_model.name =  f"bkg_{dataset.name}"
+                # TODO remove this once dataset and model have unique identifiers
                 log.debug(dataset)
                 stacked.stack(dataset)
             self._extract_irf_kernels(stacked)
@@ -272,6 +274,8 @@ class Analysis:
                 log.info(f"Processing observation {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
+                dataset.background_model.name = f"bkg_{dataset.name}"
+                # TODO remove this once dataset and model have unique identifiers
                 self._extract_irf_kernels(dataset)
                 log.debug(dataset)
                 datasets.append(dataset)


### PR DESCRIPTION
Fix analysis dataset.background_model.name to have unique names
For now this rely on dataset name being unique.