### PR TITLE
LogGaussianSpectralModel mean position

### DIFF
--- a/gammapy/modeling/models/__init__.py
+++ b/gammapy/modeling/models/__init__.py
@@ -43,7 +43,6 @@ SPECTRAL_MODELS = Registry(
         LogParabolaSpectralModel,
         TemplateSpectralModel,
         GaussianSpectralModel,
-        LogGaussianSpectralModel,
         AbsorbedSpectralModel,
         NaimaSpectralModel,
         ScaleSpectralModel,

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1572,37 +1572,3 @@ class GaussianSpectralModel(SpectralModel):
         return a * (np.exp(-u_min ** 2) - np.exp(-u_max ** 2)) + b * (
             scipy.special.erf(u_max) - scipy.special.erf(u_min)
         )
-
-
-class LogGaussianSpectralModel(SpectralModel):
-    r"""Log Gaussian spectral model.
-
-    .. math::
-        \phi(E) = \frac{N_0}{E \, \sigma \sqrt{2\pi}}
-         \exp{ \frac{- \left( \ln(\frac{E}{\bar{E}}) \right)^2 }{2 \sigma^2} }
-
-    This model was used in this CTA study for the electron spectrum: Table 3
-    in https://ui.adsabs.harvard.edu/abs/2013APh....43..171B
-
-    Parameters
-    ----------
-    norm : `~astropy.units.Quantity`
-        :math:`N_0`
-    mean : `~astropy.units.Quantity`
-        :math:`\bar{E}`
-    sigma : `float`
-        :math:`\sigma`
-    """
-
-    tag = "LogGaussianSpectralModel"
-    norm = Parameter("norm", 1e-12 * u.Unit("cm-2 s-1"))
-    mean = Parameter("mean", 1 * u.TeV)
-    sigma = Parameter("sigma", 2)
-
-    @staticmethod
-    def evaluate(energy, norm, mean, sigma):
-        return (
-            norm
-            / (energy * sigma * np.sqrt(2 * np.pi))
-            * np.exp(-(np.log(energy / mean)) ** 2 / (2 * sigma ** 2))
-        )

--- a/gammapy/modeling/models/spectral_cosmic_ray.py
+++ b/gammapy/modeling/models/spectral_cosmic_ray.py
@@ -6,7 +6,28 @@ http://lpsc.in2p3.fr/cosmic-rays-db/
 """
 import numpy as np
 from astropy import units as u
-from .spectral import LogGaussianSpectralModel, PowerLawSpectralModel
+from gammapy.modeling import Parameter
+from .spectral import PowerLawSpectralModel, SpectralModel
+
+
+class _LogGaussianSpectralModel(SpectralModel):
+    r"""Log Gaussian spectral model with a weird parametrisation.
+
+    This should not be exposed to end-users as a Gammapy spectral model!
+    See Table 3 in https://ui.adsabs.harvard.edu/abs/2013APh....43..171B
+    """
+
+    L = Parameter("L", 1e-12 * u.Unit("cm-2 s-1"))
+    Ep = Parameter("Ep", 0.107 * u.TeV)
+    w = Parameter("w", 0.776)
+
+    @staticmethod
+    def evaluate(energy, L, Ep, w):
+        return (
+            L
+            / (energy * w * np.sqrt(2 * np.pi))
+            * np.exp(-(np.log(energy / Ep)) ** 2 / (2 * w ** 2))
+        )
 
 
 def create_cosmic_ray_spectral_model(particle="proton"):
@@ -66,10 +87,6 @@ def create_cosmic_ray_spectral_model(particle="proton"):
             amplitude=6.85e-5 * u.Unit("1 / (m2 s TeV sr)") * omega,
             index=3.21,
             reference=1 * u.TeV,
-        ) + LogGaussianSpectralModel(
-            norm=3.19e-3 * u.Unit("1 / (m2 s sr)") * omega,
-            mean=0.107 * u.TeV,
-            sigma=0.776,
-        )
+        ) + _LogGaussianSpectralModel(L=3.19e-3 * u.Unit("1 / (m2 s sr)") * omega)
     else:
         raise ValueError(f"Invalid particle: {particle!r}")

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -11,7 +11,6 @@ from gammapy.modeling.models import (
     ExpCutoffPowerLaw3FGLSpectralModel,
     ExpCutoffPowerLawSpectralModel,
     GaussianSpectralModel,
-    LogGaussianSpectralModel,
     LogParabolaSpectralModel,
     NaimaSpectralModel,
     PowerLaw2SpectralModel,
@@ -179,16 +178,6 @@ TEST_MODELS = [
         integral_infinity=u.Quantity(4, "cm-2 s-1"),
         eflux_1_10TeV=u.Quantity(7.999998896163037, "TeV cm-2 s-1"),
     ),
-    dict(
-        name="LogGaussianSpectralModel",
-        model=LogGaussianSpectralModel(
-            norm=4 / u.cm ** 2 / u.s, mean=2 * u.TeV, sigma=0.2
-        ),
-        val_at_2TeV=u.Quantity(3.98942280401, "cm-2 s-1 TeV-1"),
-        val_at_3TeV=u.Quantity(0.34066933236079916, "cm-2 s-1 TeV-1"),
-        integral_1_10TeV=u.Quantity(3.994439, "cm-2 s-1"),
-        eflux_1_10TeV=u.Quantity(8.151414, "TeV cm-2 s-1"),
-    ),
 ]
 
 # Add compound models
@@ -266,7 +255,6 @@ def test_models(spectrum):
         isinstance(model, ConstantSpectralModel)
         or spectrum["name"] == "compound6"
         or spectrum["name"] == "GaussianSpectralModel"
-        or spectrum["name"] == "LogGaussianSpectralModel"
     ):
         assert_quantity_allclose(model.inverse(value), 2 * u.TeV, rtol=0.01)
 

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -221,7 +221,6 @@ def make_all_models():
         "TemplateSpectralModel", energy=[1, 2] * u.cm, values=[3, 4] * u.cm
     )  # TODO: add unit validation?
     yield Model.create("GaussianSpectralModel")
-    yield Model.create("LogGaussianSpectralModel")
     # TODO: yield Model.create("AbsorbedSpectralModel")
     # TODO: yield Model.create("NaimaSpectralModel")
     # TODO: yield Model.create("ScaleSpectralModel")

--- a/tutorials/models.ipynb
+++ b/tutorials/models.ipynb
@@ -263,11 +263,8 @@
    },
    "outputs": [],
    "source": [
-    "gaussian = gm.GaussianSpectralModel(mean=\"10 TeV\")\n",
-    "gaussian.plot(energy_range)\n",
-    "\n",
-    "lgaussian = gm.LogGaussianSpectralModel(mean=\"10 TeV\")\n",
-    "lgaussian.plot(energy_range)"
+    "gaussian = gm.GaussianSpectralModel(mean=\"1 TeV\")\n",
+    "gaussian.plot(energy_range)"
    ]
   },
   {


### PR DESCRIPTION
While doing #2435 I noticed that the LogGaussianSpectralModel mean has unit energy, but doesn't seem to be the parabola peak location when plotting the spectral model in log flux vs log energy. Looks like a bug either in the formula or from not handling Quantity properly?

- https://gist.github.com/cdeil/ee98cb276e06621ca361085319a755d7
- https://docs.gammapy.org/0.14/api/gammapy.modeling.models.LogGaussianSpectralModel.html

Fermi ST or ctools only has the normal Gaussian spectral model? Maybe we could check against those at least? Or check for approximate consistency between our two Gaussian distributions (in lin and log energy)? For the same norm, mean and sigma, with very small sigma, the two distributions should be almost the same, no?

@JouvinLea or @QRemy or anyone - interested to work on this?
(fix if it's a bug, and in any case improve docstring & tests a bit, i.e. send a PR).
