### PR TITLE
Change 1D dataset model to SkyModels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ docs/notebooks
 tutorials/fit_result_LogParabola.yaml
 tutorials/model-best-fit.yaml
 tutorials/hgps_data
+tutorials/crab-3datasets
 gammapy-datasets
 temp
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -213,7 +213,7 @@ class Analysis:
         )
         fp = flux_point_estimator.run()
         fp.table["is_ul"] = fp.table["ts"] < 4
-        model = self.model[source].spectral_model.copy()
+        model = self.model[source].copy()
         self.flux_points = FluxPointsDataset(data=fp, model=model)
         cols = ["e_ref", "ref_flux", "dnde", "dnde_ul", "dnde_err", "is_ul"]
         log.info("\n{}".format(self.flux_points.data.table[cols]))

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -257,7 +257,7 @@ class Analysis:
                 log.info(f"Processing observation {obs.obs_id}")
                 dataset = maker.run(stacked, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
-                dataset.background_model.name =  f"bkg_{dataset.name}"
+                dataset.background_model.name = f"bkg_{dataset.name}"
                 # TODO remove this once dataset and model have unique identifiers
                 log.debug(dataset)
                 stacked.stack(dataset)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -169,14 +169,9 @@ class Analysis:
             self.model = SkyModels.from_yaml(filepath)
         else:
             return False
-        # TODO: Deal with multiple components
         for dataset in self.datasets:
-            if isinstance(dataset, MapDataset):
-                dataset.model = self.model
-            else:
-                if len(self.model) > 1:
-                    raise ValueError("Cannot fit multiple spectral models")
-                dataset.model = self.model[0].spectral_model
+            dataset.model = self.model
+
         log.info(self.model)
 
     def run_fit(self, optimize_opts=None):

--- a/gammapy/astro/population/spatial.py
+++ b/gammapy/astro/population/spatial.py
@@ -223,7 +223,7 @@ class FaucherKaspi2006(Fittable1DModel):
     def evaluate(r, amplitude, r_0, sigma):
         """Evaluate model."""
         term1 = 1.0 / np.sqrt(2 * np.pi * sigma)
-        term2 = np.exp(-(r - r_0) ** 2 / (2 * sigma ** 2))
+        term2 = np.exp(-((r - r_0) ** 2) / (2 * sigma ** 2))
         return amplitude * term1 * term2
 
 

--- a/gammapy/astro/population/velocity.py
+++ b/gammapy/astro/population/velocity.py
@@ -42,7 +42,7 @@ class FaucherKaspi2006VelocityMaxwellian(Fittable1DModel):
     def evaluate(v, amplitude, sigma):
         """One dimensional velocity model function."""
         term1 = np.sqrt(2 / np.pi) * v ** 2 / sigma ** 3
-        term2 = np.exp(-v ** 2 / (2 * sigma ** 2))
+        term2 = np.exp(-(v ** 2) / (2 * sigma ** 2))
         return term1 * term2
 
 
@@ -82,8 +82,8 @@ class FaucherKaspi2006VelocityBimodal(Fittable1DModel):
     def evaluate(v, amplitude, sigma_1, sigma_2, w):
         """One dimensional Faucher-Guigere & Kaspi 2006 velocity model function."""
         A = amplitude * np.sqrt(2 / np.pi) * v ** 2
-        term1 = (w / sigma_1 ** 3) * np.exp(-v ** 2 / (2 * sigma_1 ** 2))
-        term2 = (1 - w) / sigma_2 ** 3 * np.exp(-v ** 2 / (2 * sigma_2 ** 2))
+        term1 = (w / sigma_1 ** 3) * np.exp(-(v ** 2) / (2 * sigma_1 ** 2))
+        term2 = (1 - w) / sigma_2 ** 3 * np.exp(-(v ** 2) / (2 * sigma_2 ** 2))
         return A * (term1 + term2)
 
 

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -4,9 +4,8 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from gammapy.irf import EnergyDispersion
-from gammapy.maps import Map, MapCoord, WcsGeom, MapAxis
+from gammapy.maps import Map, MapAxis, MapCoord, WcsGeom
 from gammapy.utils.random import InverseCDFSampler, get_random_state
-
 
 __all__ = ["make_edisp_map", "EDispMap"]
 
@@ -388,13 +387,11 @@ class EDispMap:
             Energy dispersion map.
         """
         from .fit import MIGRA_AXIS_DEFAULT
+
         migra_axis = migra_axis or MIGRA_AXIS_DEFAULT
 
         geom = WcsGeom.create(
-            npix=(4, 2),
-            proj="CAR",
-            binsz=90,
-            axes=[migra_axis, energy_axis_true]
+            npix=(4, 2), proj="CAR", binsz=90, axes=[migra_axis, energy_axis_true]
         )
 
         return cls.from_geom(geom)

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -876,7 +876,9 @@ class MapDataset(Dataset):
             if isinstance(self.edisp, EnergyDispersion):
                 edisp = self.edisp
             else:
-                edisp = self.edisp.get_energy_dispersion(on_region.center, self._energy_axis.edges)
+                edisp = self.edisp.get_energy_dispersion(
+                    on_region.center, self._energy_axis.edges
+                )
         else:
             edisp = None
 
@@ -1376,7 +1378,7 @@ class MapEvaluator:
             self.edisp = edisp
 
         # TODO: lookup correct PSF for this component
-        self.psf = psf # .get_psf_kernel(self.model.position, geom=exposure.geom)
+        self.psf = psf  # .get_psf_kernel(self.model.position, geom=exposure.geom)
 
         if self.evaluation_mode == "local" and self.model.evaluation_radius is not None:
             self._init_position = self.model.position

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -87,7 +87,7 @@ class MapDataset(Dataset):
         mask_safe=None,
         gti=None,
     ):
-        if model is None :
+        if model is None:
             model = SkyModels([])
         if mask_fit is not None and mask_fit.data.dtype != np.dtype("bool"):
             raise ValueError("mask data must have dtype bool")

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -4,7 +4,7 @@ import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
 from gammapy.irf import EnergyDependentTablePSF
-from gammapy.maps import Map, MapCoord, WcsGeom, MapAxis
+from gammapy.maps import Map, MapAxis, MapCoord, WcsGeom
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 from .psf_kernel import PSFKernel
 
@@ -414,15 +414,14 @@ class PSFMap:
         rad_axis = MapAxis.from_nodes(table_psf.rad, name="theta")
 
         geom = WcsGeom.create(
-            npix=(4, 2),
-            proj="CAR",
-            binsz=180,
-            axes=[rad_axis, energy_axis]
+            npix=(4, 2), proj="CAR", binsz=180, axes=[rad_axis, energy_axis]
         )
         coords = geom.get_coord()
 
         # TODO: support broadcasting in .evaluate()
-        data = table_psf._interpolate((coords["energy"], coords["theta"])).to_value("sr-1")
+        data = table_psf._interpolate((coords["energy"], coords["theta"])).to_value(
+            "sr-1"
+        )
         psf_map = Map.from_geom(geom, data=data, unit="sr-1")
 
         geom_exposure = geom.squash(axis="theta")

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -239,10 +239,7 @@ class PSFMap:
 
         if self.exposure_map is not None:
             exposure_3d = self.exposure_map.slice_by_idx({"theta": 0})
-            coords = {
-                "skycoord": position,
-                "energy": energies.reshape((-1, 1, 1))
-            }
+            coords = {"skycoord": position, "energy": energies.reshape((-1, 1, 1))}
             data = exposure_3d.interp_by_coord(coords).squeeze()
             exposure = data * self.exposure_map.unit
         else:
@@ -250,10 +247,7 @@ class PSFMap:
 
         # Beware. Need to revert rad and energies to follow the TablePSF scheme.
         return EnergyDependentTablePSF(
-            energy=energies,
-            rad=rad,
-            psf_value=psf_values.T,
-            exposure=exposure
+            energy=energies, rad=rad, psf_value=psf_values.T, exposure=exposure
         )
 
     def get_psf_kernel(self, position, geom, max_radius=None, factor=4):

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -135,9 +135,7 @@ def test_sample_coord():
     assert_allclose(coords_corrected["energy"], [0.9961658, 1.11269299], rtol=1e-5)
 
 
-@pytest.mark.parametrize(
-    "position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"]
-)
+@pytest.mark.parametrize("position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"])
 def test_edisp_from_diagonal_response(position):
     position = SkyCoord(position)
     energy_axis_true = MapAxis.from_energy_bounds("0.3 TeV", "10 TeV", nbin=31)
@@ -151,4 +149,3 @@ def test_edisp_from_diagonal_response(position):
     # We exclude the first and last bin, where there is no
     # e_reco to contribute to
     assert_allclose(sum_kernel[1:-1], 1)
-

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -20,7 +20,7 @@ from gammapy.irf import (
     EnergyDispersion,
 )
 from gammapy.maps import Map, MapAxis, WcsGeom, WcsNDMap
-from gammapy.modeling import Fit
+from gammapy.modeling import Datasets, Fit
 from gammapy.modeling.models import (
     BackgroundModel,
     GaussianSpatialModel,
@@ -28,7 +28,7 @@ from gammapy.modeling.models import (
     SkyModel,
 )
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
-from gammapy.modeling import Datasets
+
 
 @pytest.fixture
 def geom():
@@ -683,8 +683,3 @@ def test_datasets_io_no_model(tmpdir):
 
     filename_2 = tmpdir / "test_data_2.fits"
     assert filename_2.exists()
-
-
-
-
-

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -6,12 +6,12 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
 from gammapy.cube import (
+    EDispMap,
     MapDataset,
     MapDatasetOnOff,
     PSFKernel,
+    PSFMap,
     make_map_exposure_true_energy,
-    EDispMap,
-    PSFMap
 )
 from gammapy.data import GTI
 from gammapy.irf import (

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -5,9 +5,9 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
-from gammapy.data import DataStore
 from gammapy.cube import PSFMap, make_map_exposure_true_energy, make_psf_map
 from gammapy.irf import PSF3D, EffectiveAreaTable2D, EnergyDependentTablePSF
+from gammapy.data import DataStore
 from gammapy.maps import MapAxis, MapCoord, WcsGeom
 from gammapy.maps.utils import edges_from_lo_hi
 from gammapy.utils.testing import requires_data
@@ -225,14 +225,11 @@ def make_psf_map_obs(geom, obs):
         geom=geom.squash(axis="theta"),
         pointing=obs.pointing_radec,
         aeff=obs.aeff,
-        livetime=obs.observation_live_time_duration
+        livetime=obs.observation_live_time_duration,
     )
 
     psf_map = make_psf_map(
-        geom=geom,
-        psf=obs.psf,
-        pointing=obs.pointing_radec,
-        exposure_map=exposure_map
+        geom=geom, psf=obs.psf, pointing=obs.pointing_radec, exposure_map=exposure_map
     )
     return psf_map
 
@@ -259,7 +256,7 @@ def make_psf_map_obs(geom, obs):
             "psf_energy": 1428.893959,
             "rad_shape": (144,),
             "psf_rad": 0.0015362848,
-            "psf_exposure": 4.723409e+12,
+            "psf_exposure": 4.723409e12,
             "psf_value_shape": (100, 144),
             "psf_value": 3719.21488,
         },
@@ -281,7 +278,7 @@ def make_psf_map_obs(geom, obs):
             "psf_energy": 1428.893959,
             "rad_shape": (1000,),
             "psf_rad": 0.000524,
-            "psf_exposure": 4.723409e+12,
+            "psf_exposure": 4.723409e12,
             "psf_value_shape": (100, 1000),
             "psf_value": 22561.543595,
         },
@@ -306,10 +303,7 @@ def test_make_psf(pars, data_store):
     position = SkyCoord(83.63, 22.01, unit="deg")
 
     geom = WcsGeom.create(
-        skydir=position,
-        npix=(3, 3),
-        axes=[rad_axis, energy_axis],
-        binsz=0.2
+        skydir=position, npix=(3, 3), axes=[rad_axis, energy_axis], binsz=0.2
     )
     psf_map = make_psf_map_obs(geom, obs)
     psf = psf_map.get_energy_dependent_table_psf(position)
@@ -345,10 +339,7 @@ def test_make_mean_psf(data_store):
     rad_axis = MapAxis.from_edges(edges, name="theta")
 
     geom = WcsGeom.create(
-        skydir=position,
-        npix=(3, 3),
-        axes=[rad_axis, energy_axis],
-        binsz=0.2
+        skydir=position, npix=(3, 3), axes=[rad_axis, energy_axis], binsz=0.2
     )
 
     psf_map_1 = make_psf_map_obs(geom, observations[0])

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -6,8 +6,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.units import Unit
 from gammapy.cube import PSFMap, make_map_exposure_true_energy, make_psf_map
-from gammapy.irf import PSF3D, EffectiveAreaTable2D, EnergyDependentTablePSF
 from gammapy.data import DataStore
+from gammapy.irf import PSF3D, EffectiveAreaTable2D, EnergyDependentTablePSF
 from gammapy.maps import MapAxis, MapCoord, WcsGeom
 from gammapy.maps.utils import edges_from_lo_hi
 from gammapy.utils.testing import requires_data
@@ -355,9 +355,7 @@ def test_make_mean_psf(data_store):
 
 
 @requires_data()
-@pytest.mark.parametrize(
-    "position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"]
-)
+@pytest.mark.parametrize("position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"])
 def test_psf_map_from_table_psf(position):
     position = SkyCoord(position)
     filename = "$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz"

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -9,11 +9,11 @@ from gammapy.utils.fits import earth_location_from_dict
 from gammapy.utils.table import table_row_to_dict
 from gammapy.utils.testing import Checker
 from gammapy.utils.time import time_ref_from_dict
+from ..irf import load_cta_irfs
 from .event_list import EventListChecker
 from .filters import ObservationFilter
-from .pointing import FixedPointingInfo
 from .gti import GTI
-from ..irf import load_cta_irfs
+from .pointing import FixedPointingInfo
 
 __all__ = ["DataStoreObservation", "Observations", "Observation"]
 

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -135,6 +135,7 @@ def test_observations_select_time(
             new_obss[-1].gti.time_stop[-1], expected_times[1], atol=0.01
         )
 
+
 @requires_data()
 def test_observations_select_time_time_intervals_list(data_store):
     obs_ids = data_store.obs_table["OBS_ID"][:8]

--- a/gammapy/irf/psf_3d.py
+++ b/gammapy/irf/psf_3d.py
@@ -323,7 +323,9 @@ class PSF3D:
 
         ax = plt.gca() if ax is None else ax
 
-        energy = MapAxis.from_energy_bounds(self.energy_lo[0], self.energy_hi[-1], 100).edges
+        energy = MapAxis.from_energy_bounds(
+            self.energy_lo[0], self.energy_hi[-1], 100
+        ).edges
 
         for theta in thetas:
             for fraction in fractions:

--- a/gammapy/irf/psf_gauss.py
+++ b/gammapy/irf/psf_gauss.py
@@ -324,7 +324,9 @@ class EnergyDependentMultiGaussPSF:
 
         ax = plt.gca() if ax is None else ax
 
-        energy = MapAxis.from_energy_bounds(self.energy_lo[0], self.energy_hi[-1], 100).edges
+        energy = MapAxis.from_energy_bounds(
+            self.energy_lo[0], self.energy_hi[-1], 100
+        ).edges
 
         for theta in thetas:
             for fraction in fractions:

--- a/gammapy/maps/tests/test_base.py
+++ b/gammapy/maps/tests/test_base.py
@@ -236,6 +236,7 @@ def test_map_properties():
     with pytest.raises(ValueError):
         m.data = np.ones((1, 3))
 
+
 map_arithmetics_args = [("wcs"), ("hpx")]
 
 

--- a/gammapy/maps/tests/test_hpxmap.py
+++ b/gammapy/maps/tests/test_hpxmap.py
@@ -40,9 +40,7 @@ hpx_test_geoms = hpx_test_allsky_geoms + hpx_test_partialsky_geoms
 
 def create_map(nside, nested, coordsys, region, axes):
     return HpxNDMap(
-        HpxGeom(
-            nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes
-        )
+        HpxGeom(nside=nside, nest=nested, coordsys=coordsys, region=region, axes=axes)
     )
 
 

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,6 +8,7 @@ from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
 from gammapy.utils.scripts import make_path, read_yaml, write_yaml
 
+
 class SkyModelBase(Model):
     """Sky model base class"""
 
@@ -119,6 +120,7 @@ class SkyModel(SkyModelBase):
 
     def __init__(self, spatial_model=None, spectral_model=None, name="source"):
         from . import PointSpatialModel, PowerLawSpectralModel
+
         if spatial_model is None:
             spatial_model = PointSpatialModel()
         if spectral_model is None:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,7 +8,6 @@ from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
 from gammapy.utils.scripts import make_path, read_yaml, write_yaml
 
-
 class SkyModelBase(Model):
     """Sky model base class"""
 
@@ -118,12 +117,16 @@ class SkyModel(SkyModelBase):
 
     tag = "SkyModel"
 
-    def __init__(self, spatial_model, spectral_model, name="source"):
+    def __init__(self, spatial_model=None, spectral_model=None, name="source"):
+        from . import PointSpatialModel, PowerLawSpectralModel
+        if spatial_model is None:
+            spatial_model = PointSpatialModel()
+        if spectral_model is None:
+            spectral_model = PowerLawSpectralModel()
         self.name = name
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
         super().__init__()
-
         # TODO: this hack is needed for compound models to work
         self.__dict__.pop("_parameters")
 

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1331,7 +1331,7 @@ class GaussianSpectralModel(SpectralModel):
         return (
             norm
             / (sigma * np.sqrt(2 * np.pi))
-            * np.exp(-(energy - mean) ** 2 / (2 * sigma ** 2))
+            * np.exp(-((energy - mean) ** 2) / (2 * sigma ** 2))
         )
 
     def integral(self, emin, emax, **kwargs):
@@ -1384,6 +1384,6 @@ class GaussianSpectralModel(SpectralModel):
         ).to_value("")
         a = pars["norm"].quantity * pars["sigma"].quantity / np.sqrt(2 * np.pi)
         b = pars["norm"].quantity * pars["mean"].quantity / 2
-        return a * (np.exp(-u_min ** 2) - np.exp(-u_max ** 2)) + b * (
+        return a * (np.exp(-(u_min ** 2)) - np.exp(-(u_max ** 2))) + b * (
             scipy.special.erf(u_max) - scipy.special.erf(u_min)
         )

--- a/gammapy/modeling/models/spectral_cosmic_ray.py
+++ b/gammapy/modeling/models/spectral_cosmic_ray.py
@@ -26,7 +26,7 @@ class _LogGaussianSpectralModel(SpectralModel):
         return (
             L
             / (energy * w * np.sqrt(2 * np.pi))
-            * np.exp(-(np.log(energy / Ep)) ** 2 / (2 * w ** 2))
+            * np.exp(-((np.log(energy / Ep)) ** 2) / (2 * w ** 2))
         )
 
 

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -126,16 +126,15 @@ def datasets_to_dict(datasets, path, prefix, overwrite):
         dataset.write(filename, overwrite)
         datasets_dictlist.append(dataset.to_dict(filename=filename))
 
-        if dataset.model:
-            for model in dataset.model:
-                if model not in unique_models:
-                    unique_models.append(model)
+        for model in dataset.model:
+            if model not in unique_models:
+                unique_models.append(model)
 
-            try:
-                if dataset.background_model not in unique_backgrounds:
-                    unique_backgrounds.append(dataset.background_model)
-            except AttributeError:
-                pass
+        try:
+            if dataset.background_model not in unique_backgrounds:
+                unique_backgrounds.append(dataset.background_model)
+        except AttributeError:
+            pass
 
     datasets_dict = {"datasets": datasets_dictlist}
     components_dict = models_to_dict(unique_models + unique_backgrounds)

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -10,6 +10,7 @@ from gammapy.maps.utils import edges_from_lo_hi
 from gammapy.utils.fits import ebounds_to_energy_axis, energy_axis_to_ebounds
 from gammapy.utils.regions import compound_region_to_list
 from gammapy.utils.scripts import make_path
+from gammapy.modeling.models import SkyModels, SkyModel
 
 __all__ = ["CountsSpectrum", "SpectrumEvaluator"]
 
@@ -332,8 +333,8 @@ class SpectrumEvaluator:
 
     Parameters
     ----------
-    model : `~gammapy.modeling.models.SpectralModel`
-        Spectral model
+    model : `~gammapy.modeling.models.SkyModels` or `~gammapy.modeling.models.SkyModel`
+        Spectral model.
     aeff : `~gammapy.irf.EffectiveAreaTable`
         EffectiveArea
     edisp : `~gammapy.irf.EnergyDispersion`, optional
@@ -371,10 +372,13 @@ class SpectrumEvaluator:
     """
 
     def __init__(self, model, aeff=None, edisp=None, livetime=None, e_true=None):
-        self.model = model
         self.aeff = aeff
         self.edisp = edisp
         self.livetime = livetime
+
+        if isinstance(model,SkyModel):
+            model= SkyModels([model])
+        self.model = model
 
         if aeff is not None:
             e_true = self.aeff.energy.edges
@@ -383,9 +387,11 @@ class SpectrumEvaluator:
         self.e_reco = None
 
     def compute_npred(self):
-        integral_flux = self.model.integral(
-            emin=self.e_true[:-1], emax=self.e_true[1:], intervals=True
-        )
+        integral_flux = 0.
+        for _ in self.model:
+            integral_flux += _.spectral_model.integral(
+                emin=self.e_true[:-1], emax=self.e_true[1:], intervals=True
+            )
 
         true_counts = self.apply_aeff(integral_flux)
         return self.apply_edisp(true_counts)

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -7,10 +7,10 @@ from astropy.io import fits
 from astropy.table import Table
 from gammapy.maps import MapAxis
 from gammapy.maps.utils import edges_from_lo_hi
+from gammapy.modeling.models import SkyModel, SkyModels
 from gammapy.utils.fits import ebounds_to_energy_axis, energy_axis_to_ebounds
 from gammapy.utils.regions import compound_region_to_list
 from gammapy.utils.scripts import make_path
-from gammapy.modeling.models import SkyModels, SkyModel
 
 __all__ = ["CountsSpectrum", "SpectrumEvaluator"]
 
@@ -376,8 +376,8 @@ class SpectrumEvaluator:
         self.edisp = edisp
         self.livetime = livetime
 
-        if isinstance(model,SkyModel):
-            model= SkyModels([model])
+        if isinstance(model, SkyModel):
+            model = SkyModels([model])
         self.model = model
 
         if aeff is not None:
@@ -387,7 +387,7 @@ class SpectrumEvaluator:
         self.e_reco = None
 
     def compute_npred(self):
-        integral_flux = 0.
+        integral_flux = 0.0
         for _ in self.model:
             integral_flux += _.spectral_model.integral(
                 emin=self.e_true[:-1], emax=self.e_true[1:], intervals=True

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -6,14 +6,13 @@ from astropy.io import fits
 from astropy.table import Table
 from gammapy.data import GTI
 from gammapy.irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
+from gammapy.modeling import Dataset, Parameters
+from gammapy.modeling.models import SkyModel, SkyModels
 from gammapy.stats import cash, significance_on_off, wstat
-from gammapy.modeling.models import SkyModels, SkyModel
-from gammapy.modeling import Dataset
 from gammapy.utils.fits import energy_axis_to_ebounds
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_path
 from .core import CountsSpectrum, SpectrumEvaluator
-from gammapy.modeling import Parameters
 
 __all__ = [
     "SpectrumDatasetOnOff",
@@ -175,17 +174,17 @@ class SpectrumDataset(Dataset):
         return self._model
 
     @model.setter
-    def model(self, model):    
+    def model(self, model):
         if isinstance(model, SkyModel):
             model = SkyModels([model])
         if model is not None:
             self._model = model
             parameters_list = []
             for _ in self._model:
-                parameters_list+=list(_.spectral_model.parameters)
+                parameters_list += list(_.spectral_model.parameters)
             self._parameters = Parameters(parameters_list)
             self._predictor = SpectrumEvaluator(
-                model= self.model,
+                model=self.model,
                 livetime=self.livetime,
                 aeff=self.aeff,
                 e_true=self._energy_axis.edges,
@@ -207,16 +206,15 @@ class SpectrumDataset(Dataset):
     def mask_safe(self, mask):
         self._mask_safe = mask
 
-
     @property
     def parameters(self):
         """List of parameters (`~gammapy.modeling.Parameters`)"""
-        
+
         if self._parameters is None:
             raise AttributeError("No model set for Dataset")
         parameters_list = []
         for _ in self._model:
-            parameters_list+=list(_.spectral_model.parameters)
+            parameters_list += list(_.spectral_model.parameters)
         return Parameters(parameters_list)
 
     @property
@@ -887,7 +885,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         'cm2'.
 
         The naming scheme is fixed, with {name} the dataset name:
-        
+
         * PHA file is named pha_obs{name}.fits
         * BKG file is named bkg_obs{name}.fits
         * ARF file is named arf_obs{name}.fits

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -180,10 +180,10 @@ class SpectrumDataset(Dataset):
             model = SkyModels([model])
         if model is not None:
             self._model = model
-            parameters = []
+            parameters_list = []
             for _ in self._model:
-                parameters+=list(_.spectral_model.parameters)
-            self._parameters = Parameters(parameters)
+                parameters_list+=list(_.spectral_model.parameters)
+            self._parameters = Parameters(parameters_list)
             self._predictor = SpectrumEvaluator(
                 model= self.model,
                 livetime=self.livetime,
@@ -207,12 +207,17 @@ class SpectrumDataset(Dataset):
     def mask_safe(self, mask):
         self._mask_safe = mask
 
+
     @property
     def parameters(self):
+        """List of parameters (`~gammapy.modeling.Parameters`)"""
+        
         if self._parameters is None:
             raise AttributeError("No model set for Dataset")
-        else:
-            return self._parameters
+        parameters_list = []
+        for _ in self._model:
+            parameters_list+=list(_.spectral_model.parameters)
+        return Parameters(parameters_list)
 
     @property
     def _energy_axis(self):

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -5,7 +5,12 @@ from astropy import units as u
 from astropy.io.registry import IORegistryError
 from astropy.table import Table, vstack
 from gammapy.modeling import Dataset, Datasets, Fit, Parameters
-from gammapy.modeling.models import PowerLawSpectralModel, ScaleSpectralModel, SkyModels, SkyModel
+from gammapy.modeling.models import (
+    PowerLawSpectralModel,
+    ScaleSpectralModel,
+    SkyModel,
+    SkyModels,
+)
 from gammapy.utils.interpolation import interpolate_profile
 from gammapy.utils.scripts import make_path
 from gammapy.utils.table import table_from_row_data, table_standardise_units_copy
@@ -807,7 +812,7 @@ class FluxPointsEstimator:
 
         dataset = self.datasets[0]
 
-        if len(dataset.model)>1:
+        if len(dataset.model) > 1:
             model = dataset.model[source].spectral_model
         else:
             model = dataset.model[0].spectral_model
@@ -850,7 +855,7 @@ class FluxPointsEstimator:
     def _set_scale_model(self):
         # set the model on all datasets
         for dataset in self.datasets:
-            if len(dataset.model)>1:
+            if len(dataset.model) > 1:
                 dataset.model[self.source].spectral_model = self.model
             else:
                 dataset.model[0].spectral_model = self.model
@@ -901,7 +906,7 @@ class FluxPointsEstimator:
 
     def _energy_mask(self, e_group, dataset):
         energy_mask = np.zeros(dataset.data_shape)
-        energy_mask[e_group["idx_min"]: e_group["idx_max"] + 1] = 1
+        energy_mask[e_group["idx_min"] : e_group["idx_max"] + 1] = 1
         return energy_mask.astype(bool)
 
     def estimate_flux_point(self, e_group, steps="all"):
@@ -1191,7 +1196,7 @@ class FluxPointsDataset(Dataset):
         self.model = model
         parameters_list = []
         for _ in self.model:
-            parameters_list+=list(_.spectral_model.parameters)
+            parameters_list += list(_.spectral_model.parameters)
         self.parameters = Parameters(parameters_list)
         if data.sed_type != "dnde":
             raise ValueError("Currently only flux points of type 'dnde' are supported.")
@@ -1344,7 +1349,7 @@ class FluxPointsDataset(Dataset):
 
     def flux_pred(self, energy):
         """Compute predicted flux."""
-        flux = 0.
+        flux = 0.0
         for _ in self.model:
             flux += _.spectral_model(energy)
         return flux

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from astropy.io.registry import IORegistryError
 from astropy.table import Table, vstack
 from gammapy.modeling import Dataset, Datasets, Fit
-from gammapy.modeling.models import PowerLawSpectralModel, ScaleSpectralModel, SkyModels
+from gammapy.modeling.models import PowerLawSpectralModel, ScaleSpectralModel, SkyModels, SkyModel
 from gammapy.utils.interpolation import interpolate_profile
 from gammapy.utils.scripts import make_path
 from gammapy.utils.table import table_from_row_data, table_standardise_units_copy
@@ -807,10 +807,10 @@ class FluxPointsEstimator:
 
         dataset = self.datasets[0]
 
-        if isinstance(dataset, SpectrumDatasetOnOff):
-            model = dataset.model
-        else:
+        if len(dataset.model)>1:
             model = dataset.model[source].spectral_model
+        else:
+            model = dataset.model[0].spectral_model
 
         self.model = ScaleSpectralModel(model)
         self.model.norm.min = 0
@@ -851,7 +851,7 @@ class FluxPointsEstimator:
         # set the model on all datasets
         for dataset in self.datasets:
             if isinstance(dataset, SpectrumDatasetOnOff):
-                dataset.model = self.model
+                dataset.model = SkyModel(spectral_model=self.model)
             else:
                 dataset.model[self.source].spectral_model = self.model
 
@@ -1143,7 +1143,7 @@ class FluxPointsDataset(Dataset):
 
     Parameters
     ----------
-    model : `~gammapy.modeling.models.SpectralModel`
+    model : `~gammapy.modeling.models.SkyModels` or `~gammapy.modeling.models.SkyModel`
         Spectral model
     data : `~gammapy.spectrum.FluxPoints`
         Flux points.
@@ -1180,12 +1180,17 @@ class FluxPointsDataset(Dataset):
     def __init__(
         self, model, data, mask_fit=None, likelihood="chi2", mask_safe=None, name=""
     ):
-        self.model = model
         self.data = data
         self.mask_fit = mask_fit
         self.parameters = model.parameters
         self.name = name
 
+        if model is None:
+            model = SkyModels([])
+        if isinstance(model, SkyModel):
+            model = SkyModels([model])
+        self.model = model
+            
         if data.sed_type != "dnde":
             raise ValueError("Currently only flux points of type 'dnde' are supported.")
 
@@ -1239,7 +1244,7 @@ class FluxPointsDataset(Dataset):
 
         Returns
         -------
-        dataset : `FluxPointDataset`
+        dataset : `FluxPointsDataset`
             Flux point datasets.
 
         """
@@ -1335,13 +1340,16 @@ class FluxPointsDataset(Dataset):
         sigma[is_p] = sigma_p[is_p]
         return FluxPointsDataset._stat_chi2(data, model, sigma)
 
-    def flux_pred(self):
+    def flux_pred(self, energy):
         """Compute predicted flux."""
-        return self.model(self.data.e_ref)
+        flux = 0.
+        for _ in self.model:
+            flux += _.spectral_model(energy)
+        return flux
 
     def stat_array(self):
         """Fit statistic array."""
-        model = self.flux_pred()
+        model = self.flux_pred(self.data.e_ref)
         data = self.data.table["dnde"].quantity
 
         if self.likelihood_type == "chi2":
@@ -1376,7 +1384,7 @@ class FluxPointsDataset(Dataset):
         fp = self.data
         data = fp.table[fp.sed_type]
 
-        model = self.model(fp.e_ref)
+        model = self.flux_pred(fp.e_ref)
 
         residuals = self._compute_residuals(data, model, method)
         # Remove residuals for upper_limits
@@ -1445,7 +1453,7 @@ class FluxPointsDataset(Dataset):
         if xerr is not None:
             xerr = xerr[0].to_value(self._e_unit), xerr[1].to_value(self._e_unit)
 
-        model = self.model(fp.e_ref)
+        model = self.flux_pred(fp.e_ref)
         yerr = fp._plot_get_flux_err(fp.sed_type)
 
         if method == "diff":
@@ -1516,7 +1524,8 @@ class FluxPointsDataset(Dataset):
         plot_kwargs.setdefault("zorder", 10)
         plot_kwargs.update(model_kwargs)
         plot_kwargs.setdefault("label", "Best fit model")
-        self.model.plot(ax=ax, **plot_kwargs)
+        for _ in self.model:
+            _.spectral_model.plot(ax=ax, **plot_kwargs)
 
         plot_kwargs.setdefault("color", ax.lines[-1].get_color())
         del plot_kwargs["label"]

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import astropy.units as u
 from astropy.table import Column, Table
-from gammapy.modeling.models import PowerLawSpectralModel
+from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
 from gammapy.stats import excess_matching_significance_on_off
 from .core import SpectrumEvaluator
 
@@ -92,7 +92,7 @@ class SensitivityEstimator:
 
         # TODO: simplify the following computation
         predictor = SpectrumEvaluator(
-            model, aeff=self.arf, edisp=self.rmf, livetime=self.livetime
+            SkyModel(spectral_model=model), aeff=self.arf, edisp=self.rmf, livetime=self.livetime
         )
         counts = predictor.compute_npred().data
         phi_0 = excess_counts / counts

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -92,7 +92,10 @@ class SensitivityEstimator:
 
         # TODO: simplify the following computation
         predictor = SpectrumEvaluator(
-            SkyModel(spectral_model=model), aeff=self.arf, edisp=self.rmf, livetime=self.livetime
+            SkyModel(spectral_model=model),
+            aeff=self.arf,
+            edisp=self.rmf,
+            livetime=self.livetime,
         )
         counts = predictor.compute_npred().data
         phi_0 = excess_counts / counts

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -6,7 +6,11 @@ from astropy import units as u
 from astropy.units import Quantity
 from gammapy.irf import EffectiveAreaTable, EnergyDispersion
 from gammapy.maps import MapAxis
-from gammapy.modeling.models import PowerLawSpectralModel, TemplateSpectralModel, SkyModel
+from gammapy.modeling.models import (
+    PowerLawSpectralModel,
+    SkyModel,
+    TemplateSpectralModel,
+)
 from gammapy.spectrum import CountsSpectrum, SpectrumEvaluator
 from gammapy.utils.testing import (
     assert_quantity_allclose,
@@ -61,21 +65,27 @@ def get_test_cases():
     e_reco = Quantity(np.logspace(-1, 2, 100), "TeV")
     return [
         dict(
-            model=SkyModel(spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")),
+            model=SkyModel(
+                spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")
+            ),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             livetime="10 h",
             npred=1448.05960,
         ),
         dict(
-            model=SkyModel(spectral_model=PowerLawSpectralModel(
-                reference="1 GeV", amplitude="1e-11 GeV-1 cm-2 s-1"
-            )),
+            model=SkyModel(
+                spectral_model=PowerLawSpectralModel(
+                    reference="1 GeV", amplitude="1e-11 GeV-1 cm-2 s-1"
+                )
+            ),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             livetime="30 h",
             npred=4.34417881,
         ),
         dict(
-            model=SkyModel(spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")),
+            model=SkyModel(
+                spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")
+            ),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             edisp=EnergyDispersion.from_gauss(
                 e_reco=e_reco, e_true=e_true, bias=0, sigma=0.2
@@ -84,10 +94,12 @@ def get_test_cases():
             npred=1437.450076,
         ),
         dict(
-            model=SkyModel(spectral_model=TemplateSpectralModel(
-                energy=[0.1, 0.2, 0.3, 0.4] * u.TeV,
-                values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
-            )),
+            model=SkyModel(
+                spectral_model=TemplateSpectralModel(
+                    energy=[0.1, 0.2, 0.3, 0.4] * u.TeV,
+                    values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
+                )
+            ),
             e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
             npred=0.554513062,
         ),

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from astropy.units import Quantity
 from gammapy.irf import EffectiveAreaTable, EnergyDispersion
 from gammapy.maps import MapAxis
-from gammapy.modeling.models import PowerLawSpectralModel, TemplateSpectralModel
+from gammapy.modeling.models import PowerLawSpectralModel, TemplateSpectralModel, SkyModel
 from gammapy.spectrum import CountsSpectrum, SpectrumEvaluator
 from gammapy.utils.testing import (
     assert_quantity_allclose,
@@ -61,21 +61,21 @@ def get_test_cases():
     e_reco = Quantity(np.logspace(-1, 2, 100), "TeV")
     return [
         dict(
-            model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1"),
+            model=SkyModel(spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             livetime="10 h",
             npred=1448.05960,
         ),
         dict(
-            model=PowerLawSpectralModel(
+            model=SkyModel(spectral_model=PowerLawSpectralModel(
                 reference="1 GeV", amplitude="1e-11 GeV-1 cm-2 s-1"
-            ),
+            )),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             livetime="30 h",
             npred=4.34417881,
         ),
         dict(
-            model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1"),
+            model=SkyModel(spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
             edisp=EnergyDispersion.from_gauss(
                 e_reco=e_reco, e_true=e_true, bias=0, sigma=0.2
@@ -84,10 +84,10 @@ def get_test_cases():
             npred=1437.450076,
         ),
         dict(
-            model=TemplateSpectralModel(
+            model=SkyModel(spectral_model=TemplateSpectralModel(
                 energy=[0.1, 0.2, 0.3, 0.4] * u.TeV,
                 values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
-            ),
+            )),
             e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
             npred=0.554513062,
         ),

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -12,7 +12,7 @@ from gammapy.modeling.models import (
     ConstantSpectralModel,
     ExpCutoffPowerLawSpectralModel,
     PowerLawSpectralModel,
-    SkyModel
+    SkyModel,
 )
 from gammapy.spectrum import CountsSpectrum, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.utils.random import get_random_state
@@ -33,9 +33,13 @@ class TestSpectrumDataset:
         self.nbins = 30
         binning = np.logspace(-1, 1, self.nbins + 1) * u.TeV
 
-        self.source_model = SkyModel(spectral_model=PowerLawSpectralModel(
-            index=2.1, amplitude=1e5 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
-        ))
+        self.source_model = SkyModel(
+            spectral_model=PowerLawSpectralModel(
+                index=2.1,
+                amplitude=1e5 * u.Unit("cm-2 s-1 TeV-1"),
+                reference=0.1 * u.TeV,
+            )
+        )
 
         self.livetime = 100 * u.s
         aeff = EffectiveAreaTable.from_constant(binning, "1 cm2")
@@ -472,16 +476,20 @@ class TestSpectralFit:
             ]
         )
 
-        self.pwl = SkyModel(spectral_model=PowerLawSpectralModel(
-            index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
-        ))
+        self.pwl = SkyModel(
+            spectral_model=PowerLawSpectralModel(
+                index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
+            )
+        )
 
-        self.ecpl = SkyModel(spectral_model=ExpCutoffPowerLawSpectralModel(
-            index=2,
-            amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
-            reference=1 * u.TeV,
-            lambda_=0.1 / u.TeV,
-        ))
+        self.ecpl = SkyModel(
+            spectral_model=ExpCutoffPowerLawSpectralModel(
+                index=2,
+                amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
+                reference=1 * u.TeV,
+                lambda_=0.1 / u.TeV,
+            )
+        )
 
         # Example fit for one observation
         self.datasets[0].model = self.pwl
@@ -649,9 +657,11 @@ class TestSpectrumDatasetOnOffStack:
 
     def test_verify_npred(self):
         """Veryfing npred is preserved during the stacking"""
-        pwl = SkyModel(spectral_model=PowerLawSpectralModel(
-            index=2, amplitude=2e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
-        ))
+        pwl = SkyModel(
+            spectral_model=PowerLawSpectralModel(
+                index=2, amplitude=2e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
+            )
+        )
         self.stacked_dataset.model = pwl
 
         npred_stacked = self.stacked_dataset.npred().data

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -12,6 +12,7 @@ from gammapy.modeling.models import (
     ConstantSpectralModel,
     ExpCutoffPowerLawSpectralModel,
     PowerLawSpectralModel,
+    SkyModel
 )
 from gammapy.spectrum import CountsSpectrum, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.utils.random import get_random_state
@@ -32,9 +33,9 @@ class TestSpectrumDataset:
         self.nbins = 30
         binning = np.logspace(-1, 1, self.nbins + 1) * u.TeV
 
-        self.source_model = PowerLawSpectralModel(
+        self.source_model = SkyModel(spectral_model=PowerLawSpectralModel(
             index=2.1, amplitude=1e5 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
-        )
+        ))
 
         self.livetime = 100 * u.s
         aeff = EffectiveAreaTable.from_constant(binning, "1 cm2")
@@ -47,7 +48,7 @@ class TestSpectrumDataset:
         )
 
         random_state = get_random_state(23)
-        flux = self.source_model.integral(binning[:-1], binning[1:])
+        flux = self.source_model.spectral_model.integral(binning[:-1], binning[1:])
         self.npred = (flux * aeff.data.data[0] * self.livetime).to_value("")
         self.npred += bkg_expected
         source_counts = random_state.poisson(self.npred)
@@ -122,7 +123,7 @@ class TestSpectrumDataset:
             dataset.parameters
 
         dataset.model = self.source_model
-        assert dataset.parameters[0] == self.source_model.parameters[0]
+        assert dataset.parameters[0] == self.source_model.spectral_model.parameters[0]
 
     def test_str(self):
         assert "SpectrumDataset" in str(self.dataset)
@@ -299,7 +300,7 @@ class TestSpectrumOnOff:
 
     def test_npred_no_edisp(self):
         const = 1 * u.Unit("cm-2 s-1 TeV-1")
-        model = ConstantSpectralModel(const=const)
+        model = SkyModel(spectral_model=ConstantSpectralModel(const=const))
         livetime = 1 * u.s
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
@@ -330,7 +331,7 @@ class TestSpectrumOnOff:
 
     @requires_dependency("matplotlib")
     def test_plot_fit(self):
-        model = PowerLawSpectralModel()
+        model = SkyModel()
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
@@ -396,7 +397,7 @@ class TestSpectrumOnOff:
         assert_allclose(mask, desired)
 
     def test_str(self):
-        model = PowerLawSpectralModel()
+        model = SkyModel()
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
@@ -412,7 +413,7 @@ class TestSpectrumOnOff:
 
     def test_fake(self):
         """Test the fake dataset"""
-        source_model = PowerLawSpectralModel()
+        source_model = SkyModel()
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
@@ -471,16 +472,16 @@ class TestSpectralFit:
             ]
         )
 
-        self.pwl = PowerLawSpectralModel(
+        self.pwl = SkyModel(spectral_model=PowerLawSpectralModel(
             index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
-        )
+        ))
 
-        self.ecpl = ExpCutoffPowerLawSpectralModel(
+        self.ecpl = SkyModel(spectral_model=ExpCutoffPowerLawSpectralModel(
             index=2,
             amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
             reference=1 * u.TeV,
             lambda_=0.1 / u.TeV,
-        )
+        ))
 
         # Example fit for one observation
         self.datasets[0].model = self.pwl
@@ -496,7 +497,7 @@ class TestSpectralFit:
         result = self.fit.run()
         pars = self.fit.datasets.parameters
 
-        assert self.pwl is self.datasets[0].model
+        assert self.pwl is self.datasets[0].model[0]
 
         assert_allclose(result.total_stat, 38.343, rtol=1e-3)
         assert_allclose(pars["index"].value, 2.817, rtol=1e-3)
@@ -648,9 +649,9 @@ class TestSpectrumDatasetOnOffStack:
 
     def test_verify_npred(self):
         """Veryfing npred is preserved during the stacking"""
-        pwl = PowerLawSpectralModel(
+        pwl = SkyModel(spectral_model=PowerLawSpectralModel(
             index=2, amplitude=2e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
-        )
+        ))
         self.stacked_dataset.model = pwl
 
         npred_stacked = self.stacked_dataset.npred().data

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -7,7 +7,7 @@ from gammapy.modeling import Fit
 from gammapy.modeling.models import (
     ExpCutoffPowerLawSpectralModel,
     PowerLawSpectralModel,
-    SkyModel
+    SkyModel,
 )
 from gammapy.spectrum import CountsSpectrum, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.utils.random import get_random_state
@@ -21,16 +21,20 @@ class TestFit:
     def setup(self):
         self.nbins = 30
         binning = np.logspace(-1, 1, self.nbins + 1) * u.TeV
-        self.source_model = SkyModel(spectral_model=PowerLawSpectralModel(
-            index=2, amplitude=1e5 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
-        ))
+        self.source_model = SkyModel(
+            spectral_model=PowerLawSpectralModel(
+                index=2, amplitude=1e5 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
+            )
+        )
         bkg_model = PowerLawSpectralModel(
             index=3, amplitude=1e4 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
         )
 
         self.alpha = 0.1
         random_state = get_random_state(23)
-        npred = self.source_model.spectral_model.integral(binning[:-1], binning[1:]).value
+        npred = self.source_model.spectral_model.integral(
+            binning[:-1], binning[1:]
+        ).value
         source_counts = random_state.poisson(npred)
         self.src = CountsSpectrum(
             energy_lo=binning[:-1], energy_hi=binning[1:], data=source_counts
@@ -140,16 +144,20 @@ class TestSpectralFit:
         obs2 = SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23592.fits")
         self.obs_list = [obs1, obs2]
 
-        self.pwl = SkyModel(spectral_model=PowerLawSpectralModel(
-            index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
-        ))
+        self.pwl = SkyModel(
+            spectral_model=PowerLawSpectralModel(
+                index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
+            )
+        )
 
-        self.ecpl = SkyModel(spectral_model=ExpCutoffPowerLawSpectralModel(
-            index=2,
-            amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
-            reference=1 * u.TeV,
-            lambda_=0.1 / u.TeV,
-        ))
+        self.ecpl = SkyModel(
+            spectral_model=ExpCutoffPowerLawSpectralModel(
+                index=2,
+                amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
+                reference=1 * u.TeV,
+                lambda_=0.1 / u.TeV,
+            )
+        )
 
     def test_stats(self):
         dataset = self.obs_list[0]

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -7,6 +7,7 @@ from gammapy.modeling import Fit
 from gammapy.modeling.models import (
     ExpCutoffPowerLawSpectralModel,
     PowerLawSpectralModel,
+    SkyModel
 )
 from gammapy.spectrum import CountsSpectrum, SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.utils.random import get_random_state
@@ -20,16 +21,16 @@ class TestFit:
     def setup(self):
         self.nbins = 30
         binning = np.logspace(-1, 1, self.nbins + 1) * u.TeV
-        self.source_model = PowerLawSpectralModel(
+        self.source_model = SkyModel(spectral_model=PowerLawSpectralModel(
             index=2, amplitude=1e5 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
-        )
+        ))
         bkg_model = PowerLawSpectralModel(
             index=3, amplitude=1e4 * u.Unit("cm-2 s-1 TeV-1"), reference=0.1 * u.TeV
         )
 
         self.alpha = 0.1
         random_state = get_random_state(23)
-        npred = self.source_model.integral(binning[:-1], binning[1:]).value
+        npred = self.source_model.spectral_model.integral(binning[:-1], binning[1:]).value
         source_counts = random_state.poisson(npred)
         self.src = CountsSpectrum(
             energy_lo=binning[:-1], energy_hi=binning[1:], data=source_counts
@@ -139,16 +140,16 @@ class TestSpectralFit:
         obs2 = SpectrumDatasetOnOff.from_ogip_files(path + "pha_obs23592.fits")
         self.obs_list = [obs1, obs2]
 
-        self.pwl = PowerLawSpectralModel(
+        self.pwl = SkyModel(spectral_model=PowerLawSpectralModel(
             index=2, amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
-        )
+        ))
 
-        self.ecpl = ExpCutoffPowerLawSpectralModel(
+        self.ecpl = SkyModel(spectral_model=ExpCutoffPowerLawSpectralModel(
             index=2,
             amplitude=1e-12 * u.Unit("cm-2 s-1 TeV-1"),
             reference=1 * u.TeV,
             lambda_=0.1 / u.TeV,
-        )
+        ))
 
     def test_stats(self):
         dataset = self.obs_list[0]

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -244,9 +244,9 @@ def dataset():
     path = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
     data = FluxPoints.read(path)
     data.table["e_ref"] = data.e_ref.to("TeV")
-    model = PowerLawSpectralModel(
+    model = SkyModel(spectral_model=PowerLawSpectralModel(
         index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV"
-    )
+    ))
     dataset = FluxPointsDataset(model, data)
     return dataset
 
@@ -262,7 +262,7 @@ def test_flux_point_dataset_serialization(tmp_path):
         index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV"
     )
     model = SkyModel(spatial_model, spectral_model, name="test_model")
-    dataset = FluxPointsDataset(SkyModels([model]), data, name="test_dataset")
+    dataset = FluxPointsDataset(model, data, name="test_dataset")
 
     Datasets([dataset]).to_yaml(tmp_path, prefix="tmp")
     datasets = Datasets.from_yaml(

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -244,9 +244,11 @@ def dataset():
     path = "$GAMMAPY_DATA/tests/spectrum/flux_points/diff_flux_points.fits"
     data = FluxPoints.read(path)
     data.table["e_ref"] = data.e_ref.to("TeV")
-    model = SkyModel(spectral_model=PowerLawSpectralModel(
-        index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV"
-    ))
+    model = SkyModel(
+        spectral_model=PowerLawSpectralModel(
+            index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV"
+        )
+    )
     dataset = FluxPointsDataset(model, data)
     return dataset
 

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -26,7 +26,7 @@ from gammapy.utils.testing import requires_data, requires_dependency
 def simulate_spectrum_dataset(model, random_state=0):
     energy = np.logspace(-0.5, 1.5, 21) * u.TeV
     aeff = EffectiveAreaTable.from_parametrization(energy=energy)
-    bkg_model = PowerLawSpectralModel(index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1")
+    bkg_model = SkyModel(spectral_model=PowerLawSpectralModel(index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1"))
 
     dataset = SpectrumDatasetOnOff(
         aeff=aeff, model=model, livetime=100 * u.h, acceptance=1, acceptance_off=5
@@ -40,6 +40,7 @@ def simulate_spectrum_dataset(model, random_state=0):
 
 
 def create_fpe(model):
+    model = SkyModel(spectral_model=model)
     dataset = simulate_spectrum_dataset(model)
     e_edges = [0.1, 1, 10, 100] * u.TeV
     dataset.model = model
@@ -211,8 +212,8 @@ class TestFluxPointsEstimator:
 
 
 def test_no_likelihood_contribution():
-    dataset = simulate_spectrum_dataset(PowerLawSpectralModel())
-    dataset.model = PowerLawSpectralModel()
+    dataset = simulate_spectrum_dataset(SkyModel())
+    dataset.model = SkyModel()
     dataset.mask_safe = np.zeros(dataset.data_shape, dtype=bool)
 
     fpe = FluxPointsEstimator([dataset], e_edges=[1, 3, 10] * u.TeV)

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -73,10 +73,14 @@ def simulate_map_dataset(random_state=0):
     obs = Observation.create(pointing=skydir, livetime=1 * u.h, irfs=irfs)
     empty = MapDataset.create(geom)
     maker = MapDatasetMaker(offset_max="2 deg", cutout=False)
-    dataset = maker.run(empty, obs, selection=["exposure", "background", "psf", "edisp"])
+    dataset = maker.run(
+        empty, obs, selection=["exposure", "background", "psf", "edisp"]
+    )
 
     position = SkyCoord("0 deg", "0 deg", frame="galactic")
-    dataset.psf = dataset.psf.get_psf_kernel(position=position, geom=geom, max_radius=0.8 *u.deg)
+    dataset.psf = dataset.psf.get_psf_kernel(
+        position=position, geom=geom, max_radius=0.8 * u.deg
+    )
 
     dataset.model = skymodel
     dataset.fake(random_state=random_state)
@@ -185,13 +189,13 @@ class TestFluxPointsEstimator:
         assert_allclose(actual, [1.104696, 1.075925, 1.091443], rtol=1e-2)
 
         actual = fp.table["sqrt_ts"].data
-        assert_allclose(actual, [16.64713 , 28.415688, 18.3774043], rtol=1e-2)
+        assert_allclose(actual, [16.64713, 28.415688, 18.3774043], rtol=1e-2)
 
         actual = fp.table["norm_scan"][0]
         assert_allclose(actual, [0.2, 1, 5])
 
         actual = fp.table["stat_scan"][0] - fp.table["stat"][0]
-        assert_allclose(actual, [1.614884e+02, 2.263890e-01, 2.015639e+03], rtol=1e-2)
+        assert_allclose(actual, [1.614884e02, 2.263890e-01, 2.015639e03], rtol=1e-2)
 
     @staticmethod
     @requires_dependency("iminuit")

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -26,7 +26,11 @@ from gammapy.utils.testing import requires_data, requires_dependency
 def simulate_spectrum_dataset(model, random_state=0):
     energy = np.logspace(-0.5, 1.5, 21) * u.TeV
     aeff = EffectiveAreaTable.from_parametrization(energy=energy)
-    bkg_model = SkyModel(spectral_model=PowerLawSpectralModel(index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1"))
+    bkg_model = SkyModel(
+        spectral_model=PowerLawSpectralModel(
+            index=2.5, amplitude="1e-12 cm-2 s-1 TeV-1"
+        )
+    )
 
     dataset = SpectrumDatasetOnOff(
         aeff=aeff, model=model, livetime=100 * u.h, acceptance=1, acceptance_off=5

--- a/gammapy/time/lightcurve.py
+++ b/gammapy/time/lightcurve.py
@@ -109,7 +109,6 @@ class LightCurve:
         """
         self.table.write(make_path(filename), **kwargs)
 
-
     def plot(self, ax=None, time_format="mjd", flux_unit="cm-2 s-1", **kwargs):
         """Plot flux points.
 

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
 import numpy as np
-from astropy.time import Time
-from astropy.table import Table
 import astropy.units as u
+from astropy.table import Table
+from astropy.time import Time
 from gammapy.modeling import Datasets, Fit
 from gammapy.modeling.models import ScaleSpectralModel
 from gammapy.spectrum import FluxPoints, SpectrumDatasetOnOff

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -188,8 +188,7 @@ class LightCurveEstimator:
             the list of dataset object
 
         """
-        # set the model on all datasets
-        for dataset in self.datasets:
+        for dataset in datasets:
             if len(dataset.model) > 1:
                 dataset.model[self.source].spectral_model = self.model
             else:

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -133,7 +133,7 @@ class LightCurveEstimator:
 
         dataset = self.datasets[0]
 
-        if len(dataset.model)>1:
+        if len(dataset.model) > 1:
             model = dataset.model[source].spectral_model
         else:
             model = dataset.model[0].spectral_model
@@ -190,7 +190,7 @@ class LightCurveEstimator:
         """
         # set the model on all datasets
         for dataset in self.datasets:
-            if len(dataset.model)>1:
+            if len(dataset.model) > 1:
                 dataset.model[self.source].spectral_model = self.model
             else:
                 dataset.model[0].spectral_model = self.model

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -133,10 +133,10 @@ class LightCurveEstimator:
 
         dataset = self.datasets[0]
 
-        if isinstance(dataset, SpectrumDatasetOnOff):
-            model = dataset.model
-        else:
+        if len(dataset.model)>1:
             model = dataset.model[source].spectral_model
+        else:
+            model = dataset.model[0].spectral_model
 
         self.model = ScaleSpectralModel(model)
         self.model.norm.min = 0
@@ -189,11 +189,11 @@ class LightCurveEstimator:
 
         """
         # set the model on all datasets
-        for dataset in datasets:
-            if isinstance(dataset, SpectrumDatasetOnOff):
-                dataset.model = self.model
-            else:
+        for dataset in self.datasets:
+            if len(dataset.model)>1:
                 dataset.model[self.source].spectral_model = self.model
+            else:
+                dataset.model[0].spectral_model = self.model
 
     @property
     def ref_model(self):

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -15,7 +15,6 @@ from gammapy.spectrum.tests.test_flux_point_estimator import (
 from gammapy.time import LightCurve, LightCurveEstimator
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
-
 # time time_min time_max flux flux_err flux_ul
 # 48705.1757 48705.134 48705.2174 0.57 0.29 nan
 # 48732.89195 48732.8503 48732.9336 0.39 0.29 nan

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -13,11 +13,7 @@ from gammapy.spectrum.tests.test_flux_point_estimator import (
     simulate_spectrum_dataset,
 )
 from gammapy.time import LightCurve, LightCurveEstimator
-from gammapy.utils.testing import (
-    mpl_plot_check,
-    requires_data,
-    requires_dependency,
-)
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
 # time time_min time_max flux flux_err flux_ul

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -7,14 +7,13 @@ import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
 from gammapy.data import GTI
-from gammapy.modeling.models import PowerLawSpectralModel
+from gammapy.modeling.models import SkyModel
 from gammapy.spectrum.tests.test_flux_point_estimator import (
     simulate_map_dataset,
     simulate_spectrum_dataset,
 )
 from gammapy.time import LightCurve, LightCurveEstimator
 from gammapy.utils.testing import (
-    assert_quantity_allclose,
     mpl_plot_check,
     requires_data,
     requires_dependency,
@@ -134,7 +133,7 @@ def test_lightcurve_plot_time(lc):
 
 
 def get_spectrum_datasets():
-    model = PowerLawSpectralModel()
+    model = SkyModel()
     dataset_1 = simulate_spectrum_dataset(model=model, random_state=0)
     dataset_1.name = "dataset_1"
     gti1 = GTI.create("0h", "1h", "2010-01-01T00:00:00")

--- a/gammapy/time/tests/test_period.py
+++ b/gammapy/time/tests/test_period.py
@@ -51,7 +51,7 @@ def simulate_test_data(period, amplitude, t_length, n_data, n_obs, n_outliers):
     t = np.linspace(0, t_length, n_data)
     t_obs = np.sort(rand.choice(t, n_obs, replace=False))
     n_outliers = n_outliers
-    dmag = rand.normal(0, 1, n_data) * -1 ** (rand.randint(2, size=n_data))
+    dmag = rand.normal(0, 1, n_data) * -(1 ** (rand.randint(2, size=n_data)))
     dmag_obs = dmag[np.searchsorted(t, t_obs)]
     outliers = rand.randint(0, t.size, n_outliers)
     mag = amplitude * np.sin(2 * np.pi * t / period) + dmag

--- a/gammapy/time/tests/test_variability.py
+++ b/gammapy/time/tests/test_variability.py
@@ -4,8 +4,9 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.table import Column, Table
 from astropy.time import Time
-from gammapy.time import LightCurve, compute_fvar, compute_chisq
+from gammapy.time import LightCurve, compute_chisq, compute_fvar
 from gammapy.utils.testing import assert_quantity_allclose
+
 
 @pytest.fixture(scope="session")
 def lc():
@@ -24,6 +25,7 @@ def lc():
     )
 
     return LightCurve(table=table)
+
 
 def test_lightcurve_fvar(lc):
     flux = lc.table["flux"].astype("float64")

--- a/gammapy/time/variability.py
+++ b/gammapy/time/variability.py
@@ -4,6 +4,7 @@ import scipy.stats as stats
 
 __all__ = ["compute_fvar", "compute_chisq"]
 
+
 def compute_fvar(flux, flux_err):
     r"""Calculate the fractional excess variance.
 

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -596,7 +596,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -54,9 +54,9 @@
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.convolution import Gaussian2DKernel\n",
     "from regions import CircleSkyRegion\n",
-    "from gammapy.modeling import Fit, Datasets, SkyModel\n",
+    "from gammapy.modeling import Fit, Datasets\n",
     "from gammapy.data import DataStore\n",
-    "from gammapy.modeling.models import PowerLawSpectralModel\n",
+    "from gammapy.modeling.models import PowerLawSpectralModel, SkyModel\n",
     "from gammapy.spectrum import (\n",
     "    SpectrumDatasetMaker,\n",
     "    FluxPointsEstimator,\n",
@@ -500,7 +500,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.parameters.covariance = result.parameters.covariance\n",
+    "model.spectral_model.parameters.covariance = result.parameters.covariance\n",
     "flux_points_dataset = FluxPointsDataset(data=flux_points, model=model)"
    ]
   },

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -54,7 +54,7 @@
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.convolution import Gaussian2DKernel\n",
     "from regions import CircleSkyRegion\n",
-    "from gammapy.modeling import Fit, Datasets\n",
+    "from gammapy.modeling import Fit, Datasets, SkyModel\n",
     "from gammapy.data import DataStore\n",
     "from gammapy.modeling.models import PowerLawSpectralModel\n",
     "from gammapy.spectrum import (\n",
@@ -436,10 +436,10 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "model = PowerLawSpectralModel(\n",
+    "spectral_model = PowerLawSpectralModel(\n",
     "    index=2, amplitude=1e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
     ")\n",
-    "\n",
+    "model = SkyModel(spectral_model=spectral_model)\n",
     "for dataset in datasets:\n",
     "    dataset.model = model\n",
     "\n",
@@ -566,7 +566,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -250,8 +250,9 @@
    "source": [
     "datasets = Datasets([dataset_fermi, dataset_hess, dataset_hawc])\n",
     "path = Path(\"crab-3datasets\")\n",
-    "datasets.to_yaml(path=path, prefix=\"crab_10GeV_100TeV\", overwrite=True)\n",
     "path.mkdir(exist_ok=True)\n",
+    "\n",
+    "datasets.to_yaml(path=path, prefix=\"crab_10GeV_100TeV\", overwrite=True)\n",
     "filedata = path / \"crab_10GeV_100TeV_datasets.yaml\"\n",
     "filemodel = path / \"crab_10GeV_100TeV_models.yaml\"\n",
     "datasets = Datasets.from_yaml(filedata=filedata, filemodel=filemodel)"
@@ -361,13 +362,6 @@
     "- https://docs.gammapy.org/dev/notebooks/hess.html\n",
     "- https://docs.gammapy.org/dev/notebooks/spectrum_analysis.html\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -386,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -176,9 +176,7 @@
    "outputs": [],
    "source": [
     "crab_model = [\n",
-    "    model\n",
-    "    for model in dataset_fermi.model\n",
-    "    if model.name == \"Crab Nebula\"\n",
+    "    model for model in dataset_fermi.model if model.name == \"Crab Nebula\"\n",
     "][0]\n",
     "crab_spec = crab_model.spectral_model\n",
     "print(crab_spec)"
@@ -294,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_spec = datasets[0].model['Crab Nebula'].spectral_model\n",
+    "crab_spec = datasets[0].model[\"Crab Nebula\"].spectral_model\n",
     "crab_spec.parameters.covariance = results_joint.parameters.get_subcovariance(\n",
     "    crab_spec.parameters\n",
     ")\n",

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -294,7 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_spec = datasets[0].model["Crab Nebula"].spectral_model\n",
+    "crab_spec = datasets[0].model['Crab Nebula'].spectral_model\n",
     "crab_spec.parameters.covariance = results_joint.parameters.get_subcovariance(\n",
     "    crab_spec.parameters\n",
     ")\n",

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -252,11 +252,11 @@
    "source": [
     "datasets = Datasets([dataset_fermi, dataset_hess, dataset_hawc])\n",
     "path = Path(\"crab-3datasets\")\n",
-    "# datasets.to_yaml(path=path, prefix=\"crab_10GeV_100TeV\", overwrite=True)\n",
+    "datasets.to_yaml(path=path, prefix=\"crab_10GeV_100TeV\", overwrite=True)\n",
     "path.mkdir(exist_ok=True)\n",
     "filedata = path / \"crab_10GeV_100TeV_datasets.yaml\"\n",
     "filemodel = path / \"crab_10GeV_100TeV_models.yaml\"\n",
-    "# datasets.from_yaml(filedata=filedata, filemodel=filemodel)"
+    "datasets = Datasets.from_yaml(filedata=filedata, filemodel=filemodel)"
    ]
   },
   {
@@ -294,6 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "crab_spec = datasets[0].model["Crab Nebula"].spectral_model\n",
     "crab_spec.parameters.covariance = results_joint.parameters.get_subcovariance(\n",
     "    crab_spec.parameters\n",
     ")\n",

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -51,13 +51,9 @@
     "We are going to use pre-made datasets. Links toward other tutorials detailing on how to prepare datasets are given at the end.\n",
     "The datasets serialization produce YAML files listing the datasets and models. In the following cells we show an example containning only the Fermi-LAT dataset and the Crab model.\n",
     "\n",
-    "Fermi-LAT-3FHL_datasets.yaml:"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
+    "Fermi-LAT-3FHL_datasets.yaml:\n",
+    "\n",
+    "```yaml\n",
     "datasets:\n",
     "- name: Fermi-LAT\n",
     "  type: MapDataset\n",
@@ -65,20 +61,12 @@
     "  models:\n",
     "- Crab Nebula\n",
     "  background: background\n",
-    "  filename: $GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Fermi-LAT-3FHL_models.yaml:"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": [
+    "  filename: $GAMMAPY_DATA/fermi-3fhl-crab/Fermi-LAT-3FHL_data_Fermi-LAT.fits\n",
+    "```\n",
+    "\n",
+    "Fermi-LAT-3FHL_models.yaml:\n",
+    "\n",
+    "```yaml\n",
     "components:\n",
     "- name: Crab Nebula\n",
     "  type: SkyModel\n",
@@ -145,7 +133,9 @@
     "    unit: TeV\n",
     "    min: .nan\n",
     "    max: .nan\n",
-    "    frozen: true\n"
+    "    frozen: true\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -176,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We get the Crab spectral model in order to share it with the other datasets"
+    "We get the Crab model in order to share it with the other datasets"
    ]
   },
   {
@@ -185,12 +175,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_spec = [\n",
-    "    model.spectral_model\n",
+    "crab_model = [\n",
+    "    model\n",
     "    for model in dataset_fermi.model\n",
     "    if model.name == \"Crab Nebula\"\n",
     "][0]\n",
-    "\n",
+    "crab_spec = crab_model.spectral_model\n",
     "print(crab_spec)"
    ]
   },
@@ -220,7 +210,7 @@
     "    datasets.append(dataset)\n",
     "dataset_hess = Datasets(datasets).stack_reduce()\n",
     "dataset_hess.name = \"HESS\"\n",
-    "dataset_hess.model = crab_spec"
+    "dataset_hess.model = crab_model"
    ]
   },
   {
@@ -241,7 +231,7 @@
     "# read flux points from https://arxiv.org/pdf/1905.12518.pdf\n",
     "filename = \"$GAMMAPY_DATA/hawc_crab/HAWC19_flux_points.fits\"\n",
     "flux_points_hawc = FluxPoints.read(filename)\n",
-    "dataset_hawc = FluxPointsDataset(crab_spec, flux_points_hawc, name=\"HAWC\")"
+    "dataset_hawc = FluxPointsDataset(crab_model, flux_points_hawc, name=\"HAWC\")"
    ]
   },
   {
@@ -397,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -371,6 +371,11 @@
     "                Time([53345.5,53346.5], format='mjd', scale='utc'),\n",
     "                Time([53347.5,53348.5], format='mjd', scale='utc')\n",
     "                 ]\n"
+    "for dataset in datasets_1d:\n",
+    "    # Copy the source model\n",
+    "    model = spectral_model.copy()\n",
+    "    model.name = \"crab\"\n",
+    "    dataset.model = SkyModel(spectral_model=model)"
    ]
   },
   {

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -371,12 +371,7 @@
     "                Time([53345.5,53346.5], format='mjd', scale='utc'),\n",
     "                Time([53347.5,53348.5], format='mjd', scale='utc')\n",
     "                 ]\n"
-    "for dataset in datasets_1d:\n",
-    "    # Copy the source model\n",
-    "    model = spectral_model.copy()\n",
-    "    model.name = \"crab\"\n",
-    "    dataset.model = SkyModel(spectral_model=model)"
-   ]
+    ]
   },
   {
    "cell_type": "markdown",

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -58,7 +58,7 @@
     "from gammapy.cube import MapDatasetMaker, MapDataset, SafeMaskMaker\n",
     "from gammapy.maps import WcsGeom, MapAxis\n",
     "from gammapy.time import LightCurveEstimator\n",
-    "from gammapy.analysis import Analysis, AnalysisConfig "
+    "from gammapy.analysis import Analysis, AnalysisConfig"
    ]
   },
   {
@@ -91,19 +91,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conf_3d=AnalysisConfig.from_template(\"3d\") \n",
+    "conf_3d = AnalysisConfig.from_template(\"3d\")\n",
     "# We want to extract the data by observation and therefore to not stack them\n",
-    "conf_3d.settings['datasets']['stack-datasets']=False\n",
-    "#Fixing more physical binning\n",
-    "conf_3d.settings['datasets']['geom']['axes'][0]['lo_bnd']=0.7\n",
-    "conf_3d.settings['datasets']['geom']['axes'][0]['nbin']=10\n",
-    "conf_3d.settings['datasets']['energy-axis-true']['lo_bnd']=0.1\n",
-    "conf_3d.settings['datasets']['energy-axis-true']['hi_bnd']=20\n",
-    "conf_3d.settings['datasets']['energy-axis-true']['nbin']=20\n",
-    "conf_3d.settings['datasets']['geom']['width']=[2,2]\n",
-    "conf_3d.settings['datasets']['geom']['binsz']=0.02\n",
+    "conf_3d.settings[\"datasets\"][\"stack-datasets\"] = False\n",
+    "# Fixing more physical binning\n",
+    "conf_3d.settings[\"datasets\"][\"geom\"][\"axes\"][0][\"lo_bnd\"] = 0.7\n",
+    "conf_3d.settings[\"datasets\"][\"geom\"][\"axes\"][0][\"nbin\"] = 10\n",
+    "conf_3d.settings[\"datasets\"][\"energy-axis-true\"][\"lo_bnd\"] = 0.1\n",
+    "conf_3d.settings[\"datasets\"][\"energy-axis-true\"][\"hi_bnd\"] = 20\n",
+    "conf_3d.settings[\"datasets\"][\"energy-axis-true\"][\"nbin\"] = 20\n",
+    "conf_3d.settings[\"datasets\"][\"geom\"][\"width\"] = [2, 2]\n",
+    "conf_3d.settings[\"datasets\"][\"geom\"][\"binsz\"] = 0.02\n",
     "\n",
-    "ana_3d=Analysis(conf_3d)\n",
+    "ana_3d = Analysis(conf_3d)\n",
     "ana_3d.get_observations()\n",
     "ana_3d.get_datasets()"
    ]
@@ -130,19 +130,19 @@
    "source": [
     "target_position = SkyCoord(ra=83.63308, dec=22.01450, unit=\"deg\")\n",
     "spatial_model = PointSpatialModel(\n",
-    "   lon_0=target_position.ra, lat_0=target_position.dec, frame=\"icrs\"\n",
+    "    lon_0=target_position.ra, lat_0=target_position.dec, frame=\"icrs\"\n",
     ")\n",
     "spectral_model = PowerLawSpectralModel(\n",
-    "   index=2.6,\n",
-    "   amplitude=2.0e-11 * u.Unit(\"1 / (cm2 s TeV)\"),\n",
-    "   reference=1 * u.TeV,\n",
+    "    index=2.6,\n",
+    "    amplitude=2.0e-11 * u.Unit(\"1 / (cm2 s TeV)\"),\n",
+    "    reference=1 * u.TeV,\n",
     ")\n",
     "spectral_model.parameters[\"index\"].frozen = False\n",
     "sky_model = SkyModel(\n",
-    "   spatial_model=spatial_model, spectral_model=spectral_model, name=\"crab\"\n",
+    "    spatial_model=spatial_model, spectral_model=spectral_model, name=\"crab\"\n",
     ")\n",
     "sky_model.parameters[\"lon_0\"].frozen = True\n",
-    "sky_model.parameters[\"lat_0\"].frozen = True\n"
+    "sky_model.parameters[\"lat_0\"].frozen = True"
    ]
   },
   {
@@ -199,17 +199,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conf_1d=AnalysisConfig.from_template(\"1d\") \n",
+    "conf_1d = AnalysisConfig.from_template(\"1d\")\n",
     "# We want to extract the data by observation and therefore to not stack them\n",
-    "conf_1d.settings['datasets']['stack-datasets']=False\n",
-    "conf_1d.settings['datasets']['containment_correction']=True\n",
-    "conf_1d.settings['datasets']['geom']['axes'][0]['lo_bnd']=0.7\n",
-    "conf_1d.settings['datasets']['geom']['axes'][0]['hi_bnd']=40\n",
-    "conf_1d.settings['datasets']['geom']['axes'][0]['nbin']=40\n",
+    "conf_1d.settings[\"datasets\"][\"stack-datasets\"] = False\n",
+    "conf_1d.settings[\"datasets\"][\"containment_correction\"] = True\n",
+    "conf_1d.settings[\"datasets\"][\"geom\"][\"axes\"][0][\"lo_bnd\"] = 0.7\n",
+    "conf_1d.settings[\"datasets\"][\"geom\"][\"axes\"][0][\"hi_bnd\"] = 40\n",
+    "conf_1d.settings[\"datasets\"][\"geom\"][\"axes\"][0][\"nbin\"] = 40\n",
     "\n",
-    "ana_1d=Analysis(conf_1d)     \n",
-    "ana_1d.get_observations() \n",
-    "ana_1d.get_datasets() "
+    "ana_1d = Analysis(conf_1d)\n",
+    "ana_1d.get_observations()\n",
+    "ana_1d.get_datasets()"
    ]
   },
   {
@@ -276,7 +276,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_maker_3d = LightCurveEstimator(ana_3d.datasets, source=\"crab\", reoptimize=True)\n",
+    "lc_maker_3d = LightCurveEstimator(\n",
+    "    ana_3d.datasets, source=\"crab\", reoptimize=True\n",
+    ")\n",
     "lc_3d = lc_maker_3d.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
    ]
   },
@@ -329,7 +331,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_maker_1d = LightCurveEstimator(ana_1d.datasets, source=\"crab\", reoptimize=False)\n",
+    "lc_maker_1d = LightCurveEstimator(\n",
+    "    ana_1d.datasets, source=\"crab\", reoptimize=False\n",
+    ")\n",
     "lc_1d = lc_maker_1d.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
    ]
   },
@@ -367,11 +371,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "time_intervals = [Time([53343.5,53344.5], format='mjd', scale='utc'),\n",
-    "                Time([53345.5,53346.5], format='mjd', scale='utc'),\n",
-    "                Time([53347.5,53348.5], format='mjd', scale='utc')\n",
-    "                 ]\n"
-    ]
+    "time_intervals = [\n",
+    "    Time([53343.5, 53344.5], format=\"mjd\", scale=\"utc\"),\n",
+    "    Time([53345.5, 53346.5], format=\"mjd\", scale=\"utc\"),\n",
+    "    Time([53347.5, 53348.5], format=\"mjd\", scale=\"utc\"),\n",
+    "]"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -386,8 +391,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_maker_1d_bynight = LightCurveEstimator(ana_1d.datasets, time_intervals=time_intervals,source=\"crab\", reoptimize=False)\n",
-    "lc_1d_bynight = lc_maker_1d_bynight.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
+    "lc_maker_1d_bynight = LightCurveEstimator(\n",
+    "    ana_1d.datasets,\n",
+    "    time_intervals=time_intervals,\n",
+    "    source=\"crab\",\n",
+    "    reoptimize=False,\n",
+    ")\n",
+    "lc_1d_bynight = lc_maker_1d_bynight.run(\n",
+    "    e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV\n",
+    ")"
    ]
   },
   {
@@ -403,8 +415,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_maker_3d_bynight = LightCurveEstimator(ana_3d.datasets, time_intervals=time_intervals, source=\"crab\", reoptimize=True)\n",
-    "lc_3d_bynight = lc_maker_3d_bynight.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
+    "lc_maker_3d_bynight = LightCurveEstimator(\n",
+    "    ana_3d.datasets,\n",
+    "    time_intervals=time_intervals,\n",
+    "    source=\"crab\",\n",
+    "    reoptimize=True,\n",
+    ")\n",
+    "lc_3d_bynight = lc_maker_3d_bynight.run(\n",
+    "    e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV\n",
+    ")"
    ]
   },
   {

--- a/tutorials/pulsar_analysis.ipynb
+++ b/tutorials/pulsar_analysis.ipynb
@@ -68,6 +68,7 @@
     "    SpectrumDatasetMaker,\n",
     "    FluxPointsEstimator,\n",
     "    FluxPointsDataset,\n",
+    "    SkyModel\n",
     ")"
    ]
   },
@@ -428,10 +429,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = PowerLawSpectralModel(\n",
+    "spectral_model = PowerLawSpectralModel(\n",
     "    index=4, amplitude=\"1.3e-9 cm-2 s-1 TeV-1\", reference=\"0.02 TeV\"\n",
     ")\n",
-    "\n",
+    "model = SkyModel(spectral_model=spectral_model)\n",
     "emin_fit, emax_fit = (0.04 * u.TeV, 0.4 * u.TeV)\n",
     "\n",
     "for dataset in datasets:\n",
@@ -540,7 +541,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tutorials/pulsar_analysis.ipynb
+++ b/tutorials/pulsar_analysis.ipynb
@@ -61,14 +61,13 @@
     "from gammapy.cube import SafeMaskMaker\n",
     "from gammapy.maps import Map, WcsGeom\n",
     "from gammapy.data import DataStore\n",
-    "from gammapy.modeling.models import PowerLawSpectralModel\n",
+    "from gammapy.modeling.models import PowerLawSpectralModel, SkyModel\n",
     "from gammapy.modeling import Fit, Datasets\n",
     "from gammapy.spectrum import (\n",
     "    PhaseBackgroundMaker,\n",
     "    SpectrumDatasetMaker,\n",
     "    FluxPointsEstimator,\n",
     "    FluxPointsDataset,\n",
-    "    SkyModel\n",
     ")"
    ]
   },
@@ -442,7 +441,7 @@
     "joint_fit = Fit(datasets)\n",
     "joint_result = joint_fit.run()\n",
     "\n",
-    "model.parameters.covariance = joint_result.parameters.covariance\n",
+    "model.spectral_model.parameters.covariance = joint_result.parameters.covariance\n",
     "print(joint_result)"
    ]
   },

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -178,7 +178,7 @@
     "pwl = PowerLawSpectralModel(\n",
     "    index=2, amplitude=\"1e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
-    "model = SkyModel(spectral_model=pwl)\n"
+    "model = SkyModel(spectral_model=pwl)"
    ]
   },
   {
@@ -268,7 +268,7 @@
     "    reference=\"1 TeV\",\n",
     "    lambda_=\"0.1 TeV-1\",\n",
     ")\n",
-    "model = SkyModel(spectral_model=ecpl)\n"
+    "model = SkyModel(spectral_model=ecpl)"
    ]
   },
   {
@@ -331,7 +331,7 @@
     "log_parabola = LogParabolaSpectralModel(\n",
     "    alpha=2, amplitude=\"1e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\", beta=0.1\n",
     ")\n",
-    "model = SkyModel(spectral_model=log_parabola)\n"
+    "model = SkyModel(spectral_model=log_parabola)"
    ]
   },
   {

--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -58,6 +58,7 @@
     "    PowerLawSpectralModel,\n",
     "    ExpCutoffPowerLawSpectralModel,\n",
     "    LogParabolaSpectralModel,\n",
+    "    SkyModel,\n",
     ")\n",
     "from gammapy.spectrum import FluxPointsDataset, FluxPoints\n",
     "from gammapy.catalog import (\n",
@@ -176,14 +177,15 @@
    "source": [
     "pwl = PowerLawSpectralModel(\n",
     "    index=2, amplitude=\"1e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
-    ")"
+    ")\n",
+    "model = SkyModel(spectral_model=pwl)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After creating the model we run the fit by passing the `'flux_points'` and `'pwl'` objects:"
+    "After creating the model we run the fit by passing the `'flux_points'` and `'model'` objects:"
    ]
   },
   {
@@ -192,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_pwl = FluxPointsDataset(pwl, flux_points, likelihood=\"chi2assym\")\n",
+    "dataset_pwl = FluxPointsDataset(model, flux_points, likelihood=\"chi2assym\")\n",
     "fitter = Fit([dataset_pwl])\n",
     "result_pwl = fitter.run()"
    ]
@@ -265,14 +267,15 @@
     "    amplitude=\"2e-12 cm-2 s-1 TeV-1\",\n",
     "    reference=\"1 TeV\",\n",
     "    lambda_=\"0.1 TeV-1\",\n",
-    ")"
+    ")\n",
+    "model = SkyModel(spectral_model=ecpl)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We run the fitter again by passing the flux points and the `ecpl` model instance:"
+    "We run the fitter again by passing the flux points and the model instance:"
    ]
   },
   {
@@ -281,7 +284,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_ecpl = FluxPointsDataset(ecpl, flux_points, likelihood=\"chi2assym\")\n",
+    "dataset_ecpl = FluxPointsDataset(model, flux_points, likelihood=\"chi2assym\")\n",
     "fitter = Fit([dataset_ecpl])\n",
     "result_ecpl = fitter.run()\n",
     "print(ecpl)"
@@ -327,7 +330,8 @@
    "source": [
     "log_parabola = LogParabolaSpectralModel(\n",
     "    alpha=2, amplitude=\"1e-12 cm-2 s-1 TeV-1\", reference=\"1 TeV\", beta=0.1\n",
-    ")"
+    ")\n",
+    "model = SkyModel(spectral_model=log_parabola)\n"
    ]
   },
   {
@@ -337,7 +341,7 @@
    "outputs": [],
    "source": [
     "dataset_log_parabola = FluxPointsDataset(\n",
-    "    log_parabola, flux_points, likelihood=\"chi2assym\"\n",
+    "    model, flux_points, likelihood=\"chi2assym\"\n",
     ")\n",
     "fitter = Fit([dataset_log_parabola])\n",
     "result_log_parabola = fitter.run()\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -407,7 +407,7 @@
     "\n",
     "# we make a copy here to compare it later\n",
     "model_best_joint = model.copy()\n",
-    "model_best_joint.parameters.covariance = result_joint.parameters.covariance"
+    "model_best_joint.spectral_model.parameters.covariance = result_joint.parameters.covariance"
    ]
   },
   {
@@ -568,7 +568,7 @@
     "\n",
     "# make a copy to compare later\n",
     "model_best_stacked = model.copy()\n",
-    "model_best_stacked.parameters.covariance = result_stacked.parameters.covariance"
+    "model_best_stacked.spectral_model.parameters.covariance = result_stacked.parameters.covariance"
    ]
   },
   {
@@ -618,12 +618,12 @@
     "}\n",
     "\n",
     "# plot stacked model\n",
-    "model_best_stacked.plot(**plot_kwargs, label=\"Stacked analysis result\")\n",
-    "model_best_stacked.plot_error(**plot_kwargs)\n",
+    "model_best_stacked.spectral_model.plot(**plot_kwargs, label=\"Stacked analysis result\")\n",
+    "model_best_stacked.spectral_model.plot_error(**plot_kwargs)\n",
     "\n",
     "# plot joint model\n",
-    "model_best_joint.plot(**plot_kwargs, label=\"Joint analysis result\", ls=\"--\")\n",
-    "model_best_joint.plot_error(**plot_kwargs)\n",
+    "model_best_joint.spectral_model.plot(**plot_kwargs, label=\"Joint analysis result\", ls=\"--\")\n",
+    "model_best_joint.spectral_model.plot_error(**plot_kwargs)\n",
     "\n",
     "create_crab_spectral_model(\"hess_pl\").plot(\n",
     "    **plot_kwargs, label=\"Crab reference\"\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -97,7 +97,7 @@
     "from gammapy.modeling.models import (\n",
     "    PowerLawSpectralModel,\n",
     "    create_crab_spectral_model,\n",
-    "    SkyModel\n",
+    "    SkyModel,\n",
     ")\n",
     "from gammapy.cube import SafeMaskMaker\n",
     "from gammapy.spectrum import (\n",
@@ -407,7 +407,9 @@
     "\n",
     "# we make a copy here to compare it later\n",
     "model_best_joint = model.copy()\n",
-    "model_best_joint.spectral_model.parameters.covariance = result_joint.parameters.covariance"
+    "model_best_joint.spectral_model.parameters.covariance = (\n",
+    "    result_joint.parameters.covariance\n",
+    ")"
    ]
   },
   {
@@ -568,7 +570,9 @@
     "\n",
     "# make a copy to compare later\n",
     "model_best_stacked = model.copy()\n",
-    "model_best_stacked.spectral_model.parameters.covariance = result_stacked.parameters.covariance"
+    "model_best_stacked.spectral_model.parameters.covariance = (\n",
+    "    result_stacked.parameters.covariance\n",
+    ")"
    ]
   },
   {
@@ -618,11 +622,15 @@
     "}\n",
     "\n",
     "# plot stacked model\n",
-    "model_best_stacked.spectral_model.plot(**plot_kwargs, label=\"Stacked analysis result\")\n",
+    "model_best_stacked.spectral_model.plot(\n",
+    "    **plot_kwargs, label=\"Stacked analysis result\"\n",
+    ")\n",
     "model_best_stacked.spectral_model.plot_error(**plot_kwargs)\n",
     "\n",
     "# plot joint model\n",
-    "model_best_joint.spectral_model.plot(**plot_kwargs, label=\"Joint analysis result\", ls=\"--\")\n",
+    "model_best_joint.spectral_model.plot(\n",
+    "    **plot_kwargs, label=\"Joint analysis result\", ls=\"--\"\n",
+    ")\n",
     "model_best_joint.spectral_model.plot_error(**plot_kwargs)\n",
     "\n",
     "create_crab_spectral_model(\"hess_pl\").plot(\n",

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -97,6 +97,7 @@
     "from gammapy.modeling.models import (\n",
     "    PowerLawSpectralModel,\n",
     "    create_crab_spectral_model,\n",
+    "    SkyModel\n",
     ")\n",
     "from gammapy.cube import SafeMaskMaker\n",
     "from gammapy.spectrum import (\n",
@@ -393,9 +394,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = PowerLawSpectralModel(\n",
+    "spectral_model = PowerLawSpectralModel(\n",
     "    index=2, amplitude=2e-11 * u.Unit(\"cm-2 s-1 TeV-1\"), reference=1 * u.TeV\n",
     ")\n",
+    "model = SkyModel(spectral_model=spectral_model)\n",
     "\n",
     "for dataset in datasets:\n",
     "    dataset.model = model\n",
@@ -667,7 +669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -56,10 +56,9 @@
     "    CountsSpectrum,\n",
     "    SpectrumDataset,\n",
     "    SpectrumDatasetMaker,\n",
-    "    SkyModel\n",
     ")\n",
     "from gammapy.modeling import Fit, Parameter\n",
-    "from gammapy.modeling.models import PowerLawSpectralModel, SpectralModel\n",
+    "from gammapy.modeling.models import PowerLawSpectralModel, SpectralModel, SkyModel\n",
     "from gammapy.irf import load_cta_irfs\n",
     "from gammapy.data import Observation\n",
     "from gammapy.maps import MapAxis"

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -58,7 +58,11 @@
     "    SpectrumDatasetMaker,\n",
     ")\n",
     "from gammapy.modeling import Fit, Parameter\n",
-    "from gammapy.modeling.models import PowerLawSpectralModel, SpectralModel, SkyModel\n",
+    "from gammapy.modeling.models import (\n",
+    "    PowerLawSpectralModel,\n",
+    "    SpectralModel,\n",
+    "    SkyModel,\n",
+    ")\n",
     "from gammapy.irf import load_cta_irfs\n",
     "from gammapy.data import Observation\n",
     "from gammapy.maps import MapAxis"
@@ -109,7 +113,7 @@
     ")\n",
     "print(model_simu)\n",
     "# we set the sky model used in the dataset\n",
-    "model = SkyModel(spectral_model=model_simu)\n"
+    "model = SkyModel(spectral_model=model_simu)"
    ]
   },
   {

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -56,6 +56,7 @@
     "    CountsSpectrum,\n",
     "    SpectrumDataset,\n",
     "    SpectrumDatasetMaker,\n",
+    "    SkyModel\n",
     ")\n",
     "from gammapy.modeling import Fit, Parameter\n",
     "from gammapy.modeling.models import PowerLawSpectralModel, SpectralModel\n",
@@ -107,7 +108,9 @@
     "    amplitude=2.5e-12 * u.Unit(\"cm-2 s-1 TeV-1\"),\n",
     "    reference=1 * u.TeV,\n",
     ")\n",
-    "print(model_simu)"
+    "print(model_simu)\n",
+    "# we set the sky model used in the dataset\n",
+    "model = SkyModel(spectral_model=model_simu)\n"
    ]
   },
   {
@@ -153,7 +156,7 @@
    "outputs": [],
    "source": [
     "# Set the model on the dataset, and fake\n",
-    "dataset.model = model_simu\n",
+    "dataset.model = model\n",
     "dataset.fake(random_state=42)\n",
     "print(dataset)"
    ]
@@ -174,7 +177,7 @@
    "outputs": [],
    "source": [
     "dataset = maker.run(obs, selection=[\"aeff\", \"edisp\", \"background\"])\n",
-    "dataset.model = model_simu\n",
+    "dataset.model = model\n",
     "print(dataset)"
    ]
   },
@@ -203,7 +206,7 @@
     "dataset_onoff = SpectrumDatasetOnOff(\n",
     "    aeff=dataset.aeff,\n",
     "    edisp=dataset.edisp,\n",
-    "    model=model_simu,\n",
+    "    model=model,\n",
     "    livetime=livetime,\n",
     "    acceptance=1,\n",
     "    acceptance_off=5,\n",
@@ -278,7 +281,7 @@
     "%%time\n",
     "results = []\n",
     "for dataset in datasets:\n",
-    "    dataset.model = model_simu.copy()\n",
+    "    dataset.model = model.copy()\n",
     "    fit = Fit([dataset])\n",
     "    result = fit.optimize()\n",
     "    results.append(\n",
@@ -434,7 +437,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Change 1D dataset.model from SpectralModel to SkyModel. This allows the  yaml serialization to work consistently for all datasets as shown in the joint 1d/3d tutorial.