### PR TITLE
Remove error when ReflectedRegionsBackgroundMaker finds no off region

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -352,6 +352,8 @@ class Analysis:
             selection = ["counts", "aeff", "edisp"]
             dataset = dataset_maker.run(obs, selection=selection)
             dataset = reflected_bkg_maker.run(dataset, obs)
+            if dataset.counts_off is None:
+                log.info(f"No OFF region found for observation {obs.obs_id}")
             dataset = safe_mask_maker.run(dataset, obs)
             log.debug(dataset)
             datasets.append(dataset)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -353,7 +353,8 @@ class Analysis:
             dataset = dataset_maker.run(obs, selection=selection)
             dataset = reflected_bkg_maker.run(dataset, obs)
             if dataset.counts_off is None:
-                log.info(f"No OFF region found for observation {obs.obs_id}")
+                log.info(f"No OFF region found for observation {obs.obs_id}. Discarding.")
+                continue
             dataset = safe_mask_maker.run(dataset, obs)
             log.debug(dataset)
             datasets.append(dataset)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects the `ReflectedRegionsBackgroundMaker` if no OFF region is found. 
Now a `SpectrumDatasetOnOff` is returned with `count_off` set to None and `acceptance_off` set to 0. 
In order to avoid issues for users, the loop in `Analysis.get_observations()` contains a `log.info` to warn that an observation has no OFF region. The dataset is discarded from the final list. 

A test has been added on the `ReflectedRegionsBackgroundMaker`. But not on the `Analysis` class. Maybe there should be one too.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This is ready for review, with the caveat concerning the test on `Analysis`