### PR TITLE
Simplify `MapDataset` simulation

### DIFF
--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -3,22 +3,22 @@
 import astropy.units as u
 from gammapy.data import Observation
 from gammapy.cube import MapDatasetMaker, MapDataset
-from gammapy.maps import WcsNDMap
-from gammapy.modeling.models import BackgroundModel
-from gammapy.utils.random import get_random_state
-
-__all__ = ["simulate_dataset"]
 
 
-def simulate_dataset(
+__all__ = ["simulate_map"]
+
+
+def simulate_map(
     skymodel,
     geom,
     pointing,
     irfs,
     livetime=1 * u.h,
-    offset_max=2.0*u.deg,
-    selection = ["exposure", "background", "psf", "edisp"],
+    offset_max=2.0 * u.deg,
+    selection=["exposure", "background", "psf", "edisp"],
+    background_pars={"norm": 1.0, "tilt": 0.0},
     random_state="random-seed",
+    **kwargs,
 ):
     """Simulate a 3D dataset.
 
@@ -26,6 +26,8 @@ def simulate_dataset(
     geometry and irfs for a given exposure time.
     This will return a MapDataset object which includes the counts cube,
     exposure cube, psf cube, energy dispersion cube, background model and the sky model.
+    By default, a background model will be made from the IRFs. The user can also pass some
+    other model if desired.
 
     Parameters
     ----------
@@ -41,12 +43,15 @@ def simulate_dataset(
         Livetime exposure of the simulated observation
     offset_max : `~astropy.units.Quantity`
         FoV offset cut
-    selection: list
+    selection: list, optional
         List of str, selecting which IRFs to use.
         Available: 'exposure', 'background', 'psf', 'edisp'
         By default, all are made.
     random_state: {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
         Defines random number generator initialisation.
+    background pars: dict
+        Dictionary specifying an additional norm and tilt in the background
+    **kwargs: additional default `MapAxis` to pass to `MapDataset.create`
 
     Returns
     -------
@@ -55,9 +60,14 @@ def simulate_dataset(
     """
 
     obs = Observation.create(pointing=pointing, livetime=livetime, irfs=irfs)
-    empty = MapDataset.create(geom)
+    empty = MapDataset.create(geom, **kwargs)
     maker = MapDatasetMaker(offset_max=offset_max)
     dataset = maker.run(empty, obs, selection=selection)
+    dataset.psf = dataset.psf.get_psf_kernel(
+        position=pointing, geom=geom, max_radius="0.3 deg",
+    )
+    dataset.background_model.parameters["norm"].value = background_pars["norm"]
+    dataset.background_model.parameters["tilt"].value = background_pars["tilt"]
     dataset.model = skymodel
     dataset.fake(random_state=random_state)
     return dataset

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from gammapy.cube import MapDataset, simulate_dataset
+from gammapy.cube import MapDataset, simulate_map
 from gammapy.irf import load_cta_irfs
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import (
@@ -23,38 +23,47 @@ def test_simulate():
 
     # Define sky model to simulate the data
     spatial_model = GaussianSpatialModel(
-        lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic"
+        lon_0="0.2 deg", lat_0="0.1 deg", sigma="0.3 deg", frame="galactic"
     )
     spectral_model = PowerLawSpectralModel(
-        index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
+        index=2.0, amplitude="1e-10 cm-2 s-1 TeV-1", reference="1 TeV"
     )
-    sky_model_simu = SkyModel(
-        spatial_model=spatial_model, spectral_model=spectral_model
-    )
+    model_simu = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
     # Define map geometry
-    axis = MapAxis.from_edges(
-        np.logspace(-1, 1.0, 20), unit="TeV", name="energy", interp="log"
+    energy_reco = MapAxis.from_edges(
+        np.logspace(-1, 1.0, 10), unit="TeV", name="energy", interp="log"
     )
     geom = WcsGeom.create(
-        skydir=(0, 0), binsz=0.025, width=(1, 1), coordsys="GAL", axes=[axis]
+        skydir=(0, 0), binsz=0.02, width=(2, 2), coordsys="GAL", axes=[energy_reco]
+    )
+    energy_axis_true = MapAxis.from_nodes(
+        np.logspace(0.1, 2, 20), unit="TeV", name="energy_axis_true", interp="log"
     )
 
     # Define some observation parameters
     pointing = SkyCoord(0 * u.deg, 0 * u.deg, frame="galactic")
 
-    dataset = simulate_dataset(
-        sky_model_simu, geom, pointing, irfs, livetime=10 * u.h, random_state=42
+    livetime = 10 * u.h
+
+    dataset = simulate_map(
+        skymodel=model_simu,
+        geom=geom,
+        pointing=pointing,
+        irfs=irfs,
+        livetime=livetime,
+        background_pars={"norm": 1.0, "tilt": 0.0},
+        random_state=42,
     )
 
     assert isinstance(dataset, MapDataset)
     assert isinstance(dataset.model, SkyModels)
 
     assert dataset.counts.data.dtype is np.dtype("int")
-    assert_allclose(dataset.counts.data[5, 20, 20], 2)
-    assert_allclose(dataset.exposure.data[5, 20, 20], 16122681486.381285)
-    assert_allclose(
-        dataset.background_model.map.data[5, 20, 20], 0.9765545345855245, rtol=1e-5
-    )
-    assert_allclose(dataset.psf.data[5, 32, 32], 0.04203219)
-    assert_allclose(dataset.edisp.data.data[10, 10], 0.85944298, rtol=1e-5)
+    assert_allclose(dataset.counts.data[4, 29, 21], 2)
+    assert_allclose(dataset.counts.data.shape, [9, 100, 100])
+    assert_allclose(dataset.exposure.data.shape, [9, 100, 100])
+    assert_allclose(dataset.exposure.data[5, 20, 20], 5.208063e10)
+    assert_allclose(dataset.background_model.map.data[5, 20, 20], 0.162572, rtol=1e-5)
+    # assert_allclose(dataset.psf.data[5, 32, 32], 0.04203219)
+    assert_allclose(dataset.edisp.edisp_map.data.shape, [9, 48, 12, 12])

--- a/tutorials/simulate_3d.ipynb
+++ b/tutorials/simulate_3d.ipynb
@@ -39,11 +39,11 @@
     "import astropy.units as u\n",
     "from astropy.coordinates import Angle, SkyCoord\n",
     "from gammapy.irf import load_cta_irfs\n",
-    "from gammapy.maps import WcsGeom, MapAxis, WcsNDMap\n",
+    "from gammapy.maps import WcsGeom, MapAxis\n",
     "from gammapy.modeling.models import PowerLawSpectralModel\n",
     "from gammapy.modeling.models import GaussianSpatialModel\n",
-    "from gammapy.modeling.models import SkyModel, BackgroundModel\n",
-    "from gammapy.cube import MapDataset, MapDatasetMaker\n",
+    "from gammapy.modeling.models import SkyModel\n",
+    "from gammapy.cube import MapDataset, MapDatasetMaker, simulate_map\n",
     "from gammapy.modeling import Fit\n",
     "from gammapy.data import Observation"
    ]
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will simulate using the CTA-1DC IRFs shipped with gammapy. Note that for dedictaed CTA simulations, you can simply use [`Observation.from_caldb()`]() without having to externally load the IRFs"
+    "We will simulate using the CTA-1DC IRFs shipped with gammapy. The main things to do are load the IRFs, define the observation parameters and the sky model to use for simulation. We then use `simualate_map()` to  create an in-memory observation and an empty dataset, predict the number of counts for the given model, and Poission fluctuate it to make a simulated counts maps."
    ]
   },
   {
@@ -90,7 +90,7 @@
    "outputs": [],
    "source": [
     "# Define the observation parameters (typically the observation duration and the pointing position):\n",
-    "livetime = 2.0 * u.hr\n",
+    "livetime = 1.0 * u.hr\n",
     "pointing = SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\")"
    ]
   },
@@ -102,15 +102,12 @@
    "source": [
     "# Define map geometry for binned simulation\n",
     "energy_reco = MapAxis.from_edges(\n",
-    "    np.logspace(-1.0, 1.0, 10), unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
+    "    np.logspace(-1, 1.0, 10), unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
     ")\n",
     "geom = WcsGeom.create(\n",
     "    skydir=(0, 0), binsz=0.02, width=(5, 4), coordsys=\"GAL\", axes=[energy_reco]\n",
     ")\n",
-    "# It is usually useful to have a separate binning for the true energy axis\n",
-    "energy_true = MapAxis.from_edges(\n",
-    "    np.logspace(-1.5, 1.5, 30), unit=\"TeV\", name=\"energy\", interp=\"log\"\n",
-    ")"
+    "print(energy_reco.edges)"
    ]
   },
   {
@@ -125,7 +122,7 @@
     "    lon_0=\"0.2 deg\", lat_0=\"0.1 deg\", sigma=\"0.3 deg\", frame=\"galactic\"\n",
     ")\n",
     "spectral_model = PowerLawSpectralModel(\n",
-    "    index=3, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
+    "    index=2.0, amplitude=\"1e-10 cm-2 s-1 TeV-1\", reference=\"1 TeV\"\n",
     ")\n",
     "model_simu = SkyModel(\n",
     "    spatial_model=spatial_model, spectral_model=spectral_model\n",
@@ -137,7 +134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, comes the main part of dataset simulation. We create an in-memory observation and an empty dataset. We then predict the number of counts for the given model, and Poission fluctuate it using `fake()` to make a simulated counts maps."
+    "Now, comes the main part of dataset simulation. You can pass further arguments into `simulate_map` like the parameters of the background model and the binnings for the IRF maps."
    ]
   },
   {
@@ -146,47 +143,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create an in-memory observation\n",
-    "obs = Observation.create(pointing=pointing, livetime=livetime, irfs=irfs)\n",
-    "print(obs)\n",
-    "# Make the MapDataset\n",
-    "empty = MapDataset.create(geom)\n",
-    "maker = MapDatasetMaker(offset_max=2.0 * u.deg)\n",
-    "dataset = maker.run(\n",
-    "    empty, obs, selection=[\"exposure\", \"background\", \"psf\", \"edisp\"]\n",
-    ")\n",
-    "print(dataset)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Ugly lines to change PSF and EDISP maps - will be removed soon\n",
-    "dataset.edisp = dataset.edisp.get_energy_dispersion(\n",
-    "    position=SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"),\n",
-    "    e_reco=energy_reco.edges,\n",
-    ")\n",
-    "dataset.psf = dataset.psf.get_psf_kernel(\n",
-    "    position=SkyCoord(0, 0, unit=\"deg\", frame=\"galactic\"),\n",
+    "dataset = simulate_map(\n",
+    "    skymodel=model_simu,\n",
+    "    irfs=irfs,\n",
+    "    pointing=pointing,\n",
+    "    livetime=livetime,\n",
     "    geom=geom,\n",
-    "    max_radius=\"0.3 deg\",\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Add the model on the dataset and Poission fluctuate\n",
-    "dataset.model = model_simu\n",
-    "dataset.fake()\n",
-    "# Do a print on the dataset - there is now a counts maps\n",
-    "print(dataset)"
    ]
   },
   {
@@ -205,6 +168,15 @@
    "source": [
     "# To plot, eg, counts:\n",
     "dataset.counts.smooth(0.1 * u.deg).plot_interactive(add_cbar=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dataset)"
    ]
   },
   {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
!-- What is the motivation for this pull request? --
This PR simplifies MapDataset simulation.
Instead of having to write 6 lines of code to create a fake observation and an empty dataset (which can be quite non-intuitive), the user just needs to call `simulate_map` and pass the simulation parameters.
<!-- Briefly: what changes are done here? -->
Adapts the old `simulate_dataset.py` and uses it in `simulate_3d` notebook
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->


**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

I do not know if it might be useful to do the same for spectral simulation as well.
On one hand, it will make the API uniform, and simulation really easy.
But for spectral simulation, users would probably like to play to different sorts of background shapes etc, so I don't know how we can support that easily.


Also, I propose that we club the simulation tutorials into one in a future PR instead of having separate ones for Map and spectrum.
