### PR TITLE
Remove Fermi catalog source categories and flags

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -1141,37 +1141,6 @@ class SourceCatalog3FGL(SourceCatalog):
     name = "3fgl"
     description = "LAT 4-year point source catalog"
     source_object_class = SourceCatalogObject3FGL
-    source_categories = {
-        "galactic": ["psr", "pwn", "snr", "spp", "glc"],
-        "extra-galactic": [
-            "css",
-            "bll",
-            "fsrq",
-            "agn",
-            "nlsy1",
-            "rdg",
-            "sey",
-            "bcu",
-            "gal",
-            "sbg",
-            "ssrq",
-        ],
-        "GALACTIC": ["PSR", "PWN", "SNR", "HMB", "BIN", "NOV", "SFR"],
-        "EXTRA-GALACTIC": [
-            "CSS",
-            "BLL",
-            "FSRQ",
-            "AGN",
-            "NLSY1",
-            "RDG",
-            "SEY",
-            "BCU",
-            "GAL",
-            "SBG",
-            "SSRQ",
-        ],
-        "unassociated": [""],
-    }
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psc_v16.fit.gz"):
         filename = make_path(filename)
@@ -1200,70 +1169,6 @@ class SourceCatalog3FGL(SourceCatalog):
         )
 
         self.extended_sources_table = Table.read(filename, hdu="ExtendedSources")
-
-    def is_source_class(self, source_class):
-        """
-        Check if source belongs to a given source class.
-
-        The classes are described in Table 3 of the 3FGL paper:
-
-        https://ui.adsabs.harvard.edu/abs/2015ApJS..218...23A
-
-        Parameters
-        ----------
-        source_class : str
-            Source class designator as defined in Table 3. There are a few extra
-            selections available:
-
-            - 'ALL': all identified objects
-            - 'all': all objects with associations
-            - 'galactic': all sources with an associated galactic object
-            - 'GALACTIC': all identified galactic sources
-            - 'extra-galactic': all sources with an associated extra-galactic object
-            - 'EXTRA-GALACTIC': all identified extra-galactic sources
-            - 'unassociated': all unassociated objects
-
-        Returns
-        -------
-        selection : `~numpy.ndarray`
-            Selection mask.
-        """
-        source_class_info = np.array([_.strip() for _ in self.table["CLASS1"]])
-
-        cats = self.source_categories
-        if source_class in cats:
-            category = set(cats[source_class])
-        elif source_class == "ALL":
-            category = set(cats["EXTRA-GALACTIC"] + cats["GALACTIC"])
-        elif source_class == "all":
-            category = set(cats["extra-galactic"] + cats["galactic"])
-        elif source_class in np.unique(source_class_info):
-            category = {source_class}
-        else:
-            raise ValueError(f"Invalid source_class: {source_class!r}")
-
-        return np.array([_ in category for _ in source_class_info])
-
-    def select_source_class(self, source_class):
-        """
-        Select all sources of a given source class.
-
-        See `SourceCatalog3FHL.is_source_class` for further documentation
-
-        Parameters
-        ----------
-        source_class : str
-            Source class designator.
-
-        Returns
-        -------
-        selection : `SourceCatalog3FHL`
-            Subset of the 3FHL catalog containing only the selected source class.
-        """
-        catalog = self.copy()
-        selection = self.is_source_class(source_class)
-        catalog.table = catalog.table[selection]
-        return catalog
 
 
 class SourceCatalog4FGL(SourceCatalog):
@@ -1351,13 +1256,6 @@ class SourceCatalog3FHL(SourceCatalog):
     name = "3fhl"
     description = "LAT third high-energy source catalog"
     source_object_class = SourceCatalogObject3FHL
-    source_categories = {
-        "galactic": ["glc", "hmb", "psr", "pwn", "sfr", "snr", "spp"],
-        "extra-galactic": ["agn", "bcu", "bll", "fsrq", "rdg", "sbg"],
-        "GALACTIC": ["BIN", "HMB", "PSR", "PWN", "SFR", "SNR"],
-        "EXTRA-GALACTIC": ["BLL", "FSRQ", "NLSY1", "RDG"],
-        "unassociated": [""],
-    }
 
     def __init__(self, filename="$GAMMAPY_DATA/catalogs/fermi/gll_psch_v13.fit.gz"):
         filename = make_path(filename)
@@ -1379,67 +1277,3 @@ class SourceCatalog3FHL(SourceCatalog):
         self.extended_sources_table = Table.read(filename, hdu="ExtendedSources")
         self.rois = Table.read(filename, hdu="ROIs")
         self.energy_bounds_table = Table.read(filename, hdu="EnergyBounds")
-
-    def is_source_class(self, source_class):
-        """
-        Check if source belongs to a given source class.
-
-        The classes are described in Table 3 of the 3FGL paper:
-
-        https://ui.adsabs.harvard.edu/abs/2015ApJS..218...23A
-
-        Parameters
-        ----------
-        source_class : str
-            Source class designator as defined in Table 3. There are a few extra
-            selections available:
-
-            - 'ALL': all identified objects
-            - 'all': all objects with associations
-            - 'galactic': all sources with an associated galactic object
-            - 'GALACTIC': all identified galactic sources
-            - 'extra-galactic': all sources with an associated extra-galactic object
-            - 'EXTRA-GALACTIC': all identified extra-galactic sources
-            - 'unassociated': all unassociated objects
-
-        Returns
-        -------
-        selection : `~numpy.ndarray`
-            Selection mask.
-        """
-        source_class_info = np.array([_.strip() for _ in self.table["CLASS"]])
-
-        cats = self.source_categories
-        if source_class in cats:
-            category = set(cats[source_class])
-        elif source_class == "ALL":
-            category = set(cats["EXTRA-GALACTIC"] + cats["GALACTIC"])
-        elif source_class == "all":
-            category = set(cats["extra-galactic"] + cats["galactic"])
-        elif source_class in np.unique(source_class_info):
-            category = {source_class}
-        else:
-            raise ValueError(f"Invalid source_class: {source_class!r}")
-
-        return np.array([_ in category for _ in source_class_info])
-
-    def select_source_class(self, source_class):
-        """
-        Select all sources of a given source class.
-
-        See `SourceCatalog3FHL.is_source_class` for further documentation
-
-        Parameters
-        ----------
-        source_class : str
-            Source class designator.
-
-        Returns
-        -------
-        selection : `SourceCatalog3FHL`
-            Subset of the 3FHL catalog containing only the selected source class.
-        """
-        catalog = self.copy()
-        selection = self.is_source_class(source_class)
-        catalog.table = catalog.table[selection]
-        return catalog

--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -114,19 +114,7 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject):
             ss += "{:<16s} : {}\n".format("Class2", d["CLASS2"])
         except (KeyError):
             pass
-        try:
-            tevcat_flag = d["TEVCAT_FLAG"]
-            if tevcat_flag == "N":
-                tevcat_message = "No TeV association"
-            elif tevcat_flag == "P":
-                tevcat_message = "Small TeV source"
-            elif tevcat_flag == "E":
-                tevcat_message = "Extended TeV source (diameter > 40 arcmins)"
-            else:
-                tevcat_message = "N/A"
-            ss += "{:<16s} : {}\n".format("TeVCat flag", tevcat_message)
-        except (KeyError):
-            pass
+        ss += "{:<16s} : {}\n".format("TeVCat flag", d.get("TEVCAT_FLAG", "N/A"))
         return ss
 
     @abc.abstractmethod
@@ -243,34 +231,7 @@ class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):
         fmt = "{:<32s} : {:.3f}\n"
         ss += fmt.format("Significance (100 MeV - 1 TeV)", d["Signif_Avg"])
         ss += "{:<32s} : {:.1f}\n".format("Npred", d["Npred"])
-
-        flag_message = {
-            0: "None",
-            1: "Source with T S > 35 which went to T S < 25 when changing the diffuse model "
-            "(see Sec. 3.7.1 in catalog paper) or the analysis method (see Sec. 3.7.2 in catalog paper). "
-            "Sources with T S ≤ 35 are not flagged with this bit because normal statistical fluctuations can push them to T S < 25.",
-            2: "Moved beyond its 95% error ellipse when changing the diffuse model. ",
-            3: "Flux (> 1 GeV) or energy flux (> 100 MeV) changed by more than 3σ when "
-            "changing the diffuse model or the analysis method. Requires also that the flux "
-            "change by more than 35% (to not flag strong sources).",
-            4: "Source-to-background ratio less than 10% in highest band in which TS > 25. Background is integrated "
-            "over the 68%-confidence area (pi*r_682) or 1 square degree, whichever is smaller.",
-            5: "Closer than theta_ref from a brighter neighbor, where theta_ref is defined in the highest band in which "
-            " source TS > 25, or the band with highest TS if all are < 25. theta_ref is set to 3.77 degrees (FWHM) below 100 MeV, "
-            "1.68 degrees between 100 and 300 MeV , 1.03 degrees between 300 MeV and 1 GeV, "
-            "0. 76 degree between 1 and 3 GeV (in-between FWHM and 2*r_68), "
-            "0.49 degree between 3 and 10 GeV and 0.25 degree above 10 GeV (2*r_68).",
-            6: "On top of an interstellar gas clump or small-scale defect in the model of diffuse emission. This flag "
-            'is equivalent to the "c" suffix in the source name (see Sec. 3.7.1 in catalog paper).',
-            9: "Localization Quality > 8 in pointlike (see Section 3.1 in catalog paper) or long axis of 95% ellipse > 0.25.",
-            10: "Total Spectral Fit Quality > 20  or Spectral Fit Quality > 9 in any band (see Equation 5 in catalog paper).",
-            12: "Highly curved spectrum; LogParabolaSpectralModel beta fixed to 1 or PLExpCutoff Spectral Index fixed to 0 (see "
-            "Section 3.3 in catalog paper).",
-        }
-        ss += "\n{:<20s} : {}\n".format(
-            "Other flags", flag_message.get(d["Flags"], "N/A")
-        )
-
+        ss += "\n{:<20s} : {}\n".format("Other flags", d["Flags"])
         return ss
 
     def _info_spectral_fit(self):
@@ -550,32 +511,7 @@ class SourceCatalogObject3FGL(SourceCatalogObjectFermiBase):
         """Print other info."""
         d = self.data
         ss = "\n*** Other info ***\n\n"
-        flag_message = {
-            0: "None",
-            1: "Source with TS > 35 which went to TS < 25 when changing the diffuse model. Note that sources with TS < "
-            "35 are not flagged with this bit because normal statistical fluctuations can push them to TS < 25.",
-            3: "Flux (> 1 GeV) or energy flux (> 100 MeV) changed by more than 3 sigma when changing the diffuse model."
-            " Requires also that the flux change by more than 35% (to not flag strong sources).",
-            4: "Source-to-background ratio less than 10% in highest band in which TS > 25. Background is integrated "
-            "over the 68%-confidence area (pi*r_682) or 1 square degree, whichever is smaller.",
-            5: "Closer than theta_ref from a brighter neighbor, where theta_ref is defined in the highest band in which"
-            " source TS > 25, or the band with highest TS if all are < 25. theta_ref is set to 2.17 degrees (FWHM)"
-            " below 300 MeV, 1.38 degrees between 300 MeV and 1 GeV, 0.87 degrees between 1 GeV and 3 GeV, 0.67"
-            " degrees between 3 and 10 GeV and 0.45 degrees about 10 GeV (2*r_68).",
-            6: "On top of an interstellar gas clump or small-scale defect in the model of diffuse emission. This flag "
-            'is equivalent to the "c" suffix in the source name.',
-            7: "Unstable position determination; result from gtfindsrc outside the 95% ellipse from pointlike.",
-            9: "Localization Quality > 8 in pointlike (see Section 3.1 in catalog paper) or long axis of 95% ellipse >"
-            " 0.25.",
-            10: "Spectral Fit Quality > 16.3 (see Equation 3 in 2FGL catalog paper).",
-            11: "Possibly due to the Sun (see Section 3.6 in catalog paper).",
-            12: "Highly curved spectrum; LogParabolaSpectralModel beta fixed to 1 or PLExpCutoff Spectral Index fixed to 0 (see "
-            "Section 3.3 in catalog paper).",
-        }
-        ss += "{:<20s} : {}\n".format(
-            "Other flags", flag_message.get(d["Flags"], "N/A")
-        )
-
+        ss += "{:<20s} : {}\n".format("Other flags", d["Flags"])
         return ss
 
     def _info_spectral_fit(self):

--- a/gammapy/catalog/tests/data/2fhl_j0822.6-4250e.txt
+++ b/gammapy/catalog/tests/data/2fhl_j0822.6-4250e.txt
@@ -7,6 +7,7 @@ Associations     : Puppis A, 3FGL J0822.6-4250e, 1FHL J0822.6-4250e
 ASSOC_PROB_BAY   : nan
 ASSOC_PROB_LR    : nan
 Class            : snr
+TeVCat flag      : N/A
 
 *** Other info ***
 

--- a/gammapy/catalog/tests/data/2fhl_j1445.1-0329.txt
+++ b/gammapy/catalog/tests/data/2fhl_j1445.1-0329.txt
@@ -7,6 +7,7 @@ Associations     : RBS 1424, 3FGL J1445.0-0328
 ASSOC_PROB_BAY   : 0.997
 ASSOC_PROB_LR    : 0.944
 Class            : bll
+TeVCat flag      : N/A
 
 *** Other info ***
 

--- a/gammapy/catalog/tests/data/3fgl_J0000.1+6545.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0000.1+6545.txt
@@ -6,11 +6,11 @@ Source name          : 3FGL J0000.1+6545
 Extended name        :                   
 Associations     : 
 Class1           :      
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
-Other flags          : Source-to-background ratio less than 10% in highest band in which TS > 25. Background is integrated over the 68%-confidence area (pi*r_682) or 1 square degree, whichever is smaller.
+Other flags          : 4
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/3fgl_J0001.4+2120.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0001.4+2120.txt
@@ -6,11 +6,11 @@ Source name          : 3FGL J0001.4+2120
 Extended name        :                   
 Associations     : TXS 2358+209, 3EG J2359+2041
 Class1           : fsrq 
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
-Other flags          : None
+Other flags          : 0
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/3fgl_J0023.4+0923.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0023.4+0923.txt
@@ -6,11 +6,11 @@ Source name          : 3FGL J0023.4+0923
 Extended name        :                   
 Associations     : PSR J0023+0923
 Class1           : PSR  
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
-Other flags          : None
+Other flags          : 0
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/3fgl_J0835.3-4510.txt
+++ b/gammapy/catalog/tests/data/3fgl_J0835.3-4510.txt
@@ -6,11 +6,11 @@ Source name          : 3FGL J0835.3-4510
 Extended name        :                   
 Associations     : PSR J0835-4510, Vela, Vela Pulsar, 1AGL J0835-4509
 Class1           : PSR  
-TeVCat flag      : Small TeV source
+TeVCat flag      : P
 
 *** Other info ***
 
-Other flags          : None
+Other flags          : 0
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/3fhl_j2301.9+5855e.txt
+++ b/gammapy/catalog/tests/data/3fhl_j2301.9+5855e.txt
@@ -8,7 +8,7 @@ Associations     : CTB 109, 3FGL J2301.2+5853
 ASSOC_PROB_BAY   : nan
 ASSOC_PROB_LR    : nan
 Class            : SNR    
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 

--- a/gammapy/catalog/tests/data/4fgl_J0000.3-7355.txt
+++ b/gammapy/catalog/tests/data/4fgl_J0000.3-7355.txt
@@ -9,14 +9,14 @@ ASSOC_PROB_BAY   : 0.000
 ASSOC_PROB_LR    : 0.000
 Class1           :      
 Class2           :      
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
 Significance (100 MeV - 1 TeV)   : 7.400
 Npred                            : 230.9
 
-Other flags          : None
+Other flags          : 0
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/4fgl_J0001.5+2113.txt
+++ b/gammapy/catalog/tests/data/4fgl_J0001.5+2113.txt
@@ -9,14 +9,14 @@ ASSOC_PROB_BAY   : 0.998
 ASSOC_PROB_LR    : 0.958
 Class1           : fsrq 
 Class2           :      
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
 Significance (100 MeV - 1 TeV)   : 30.666
 Npred                            : 3110.9
 
-Other flags          : None
+Other flags          : 0
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/4fgl_J0002.8+6217.txt
+++ b/gammapy/catalog/tests/data/4fgl_J0002.8+6217.txt
@@ -9,14 +9,14 @@ ASSOC_PROB_BAY   : 1.000
 ASSOC_PROB_LR    : 0.000
 Class1           : PSR  
 Class2           :      
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
 Significance (100 MeV - 1 TeV)   : 27.669
 Npred                            : 2344.5
 
-Other flags          : None
+Other flags          : 0
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/data/4fgl_J1409.1-6121e.txt
+++ b/gammapy/catalog/tests/data/4fgl_J1409.1-6121e.txt
@@ -9,14 +9,14 @@ ASSOC_PROB_BAY   : nan
 ASSOC_PROB_LR    : nan
 Class1           :      
 Class2           :      
-TeVCat flag      : No TeV association
+TeVCat flag      : N
 
 *** Other info ***
 
 Significance (100 MeV - 1 TeV)   : 35.921
 Npred                            : 11034.4
 
-Other flags          : Source-to-background ratio less than 10% in highest band in which TS > 25. Background is integrated over the 68%-confidence area (pi*r_682) or 1 square degree, whichever is smaller.
+Other flags          : 4
 
 *** Position info ***
 

--- a/gammapy/catalog/tests/test_fermi.py
+++ b/gammapy/catalog/tests/test_fermi.py
@@ -581,22 +581,6 @@ class TestSourceCatalog3FGL:
         table = self.cat.extended_sources_table
         assert len(table) == 25
 
-    def test_select_source_classes(self):
-        selection = self.cat.select_source_class("galactic")
-        assert len(selection.table) == 101
-
-        selection = self.cat.select_source_class("extra-galactic")
-        assert len(selection.table) == 1684
-
-        selection = self.cat.select_source_class("unassociated")
-        assert len(selection.table) == 1010
-
-        selection = self.cat.select_source_class("ALL")
-        assert len(selection.table) == 239
-
-        selection = self.cat.select_source_class("PSR")
-        assert len(selection.table) == 143
-
 
 @requires_data()
 class TestSourceCatalog2FHL:
@@ -628,19 +612,3 @@ class TestSourceCatalog3FHL:
     def test_extended_sources(self):
         table = self.cat.extended_sources_table
         assert len(table) == 55
-
-    def test_select_source_classes(self):
-        selection = self.cat.select_source_class("galactic")
-        assert len(selection.table) == 44
-
-        selection = self.cat.select_source_class("extra-galactic")
-        assert len(selection.table) == 1177
-
-        selection = self.cat.select_source_class("unassociated")
-        assert len(selection.table) == 177
-
-        selection = self.cat.select_source_class("ALL")
-        assert len(selection.table) == 135
-
-        selection = self.cat.select_source_class("PSR")
-        assert len(selection.table) == 53


### PR DESCRIPTION
This PR removes the `source_categories` grouping of source classes as well as the associated `is_source_class` and `select_source_class` methods. Custom message text printout for the analysis codes in `flag_message` is also removed, instead the codes are now shown.

This removes 260 lines of code from `fermi.py`, that was partly duplicated code, copy & pasted methods to some, but not all Fermi catalogs. It would have been significant work to review that code, add it to other Fermi catalogs like 4FGL where it was still missing, and ensure accuracy by comparing to the papers and possibly adding tests. The overall value of those things to Gammapy users is minimal, so IMO removing is the way to go.