### PR TITLE
Test error propagation for NaimaModel

### DIFF
--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -447,6 +447,12 @@ class TestNaimaModel:
         val = model(self.e_array)
         assert val.shape == self.e_array.shape
 
+        # Test error propagation
+        # TODO: This test is failing. it has to be fixed before merging
+        model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
+        dnde, dnde_err = model.evaluate_error(1 * u.TeV)
+        assert_allclose(dnde_err / dnde, 0.1)
+
     def test_ic(self):
         import naima
 
@@ -581,12 +587,6 @@ class TestSpectralModelErrorPropagation:
 
         out = model.evaluate_error(0.1 * u.TeV)
         assert_allclose(out.data, [1.548176e-10, 1.933612e-11], rtol=1e-3)
-
-    def test_naima_model_error_proprgation(self):
-        # Regression test for Naima model
-        # https://github.com/gammapy/gammapy/issues/2190
-        # TODO: implement test case. Move to Naima model tests!
-        pass
 
     def test_absorption_model_error_propagation(self):
         # Regression test for absorption model


### PR DESCRIPTION
**Description**

I implemented a minimal test for error propagation in case of NaimaModel. Notice that the test is failing by now: fixes elsewhere are needed before merging.

Here is a code snippet to reproduce the problem:
```
from gammapy.modeling.models import PowerLawSpectralModel, NaimaSpectralModel
import astropy.units as u
import naima

#Test error propagation for a simple powerlaw
model=PowerLawSpectralModel()
model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
dnde, dnde_err = model.evaluate_error(1 * u.TeV)
print(dnde_err / dnde)

#Test error propagation for a naimamodel
particle_distribution = naima.models.PowerLaw(
    amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5
)
radiative_model = naima.radiative.PionDecay(
    particle_distribution, nh=1 * u.cm ** -3
)
model = NaimaSpectralModel(radiative_model)
model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
dnde, dnde_err = model.evaluate_error(1 * u.TeV)
print(dnde_err / dnde)
```
The second print statement returns `0.0` instead of the expected value `0.1`.  The problem seems to be due to the large amplitude value 2e33 , if I change that to a typical value like 1e-11 then I do get non-zero output.

This might be related to #2434, or to the introduction of an absolute `eps` in [`_evaluate_gradient`](https://github.com/gammapy/gammapy/blob/a2adc298d1635948c69acc4807b4416dbaba0b16/gammapy/modeling/models/spectral.py#L50).

**Dear reviewer**
Please, commit some fixes before merging... Thanks!
