### PR TITLE
Implement additional methods on the safe mask maker

### DIFF
--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -459,7 +459,7 @@ class SafeMaskMaker:
         e_min = background_spectrum.energy.edges[idx + 1]
         return counts.energy_mask(emin=e_min)
 
-    def run(self, dataset, observation):
+    def run(self, dataset, observation=None):
         """Make safe data range mask.
 
         Parameters

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -226,6 +226,9 @@ def test_safe_mask_maker(observations):
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_edisp_bias.sum(), 1815)
 
+    mask_bkg_peak = safe_mask_maker.make_mask_bkg_peak_energy(dataset)
+    assert_allclose(mask_bkg_peak.sum(), 1815)
+
     with pytest.raises(NotImplementedError) as excinfo:
         safe_mask_maker.make_mask_energy_aeff_max(dataset)
 

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -226,7 +226,7 @@ def test_safe_mask_maker(observations):
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_edisp_bias.sum(), 1815)
 
-    mask_bkg_peak = safe_mask_maker.make_mask_bkg_peak_energy(dataset)
+    mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.sum(), 1815)
 
     with pytest.raises(NotImplementedError) as excinfo:

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -128,8 +128,9 @@ def test_safe_mask_maker_dl3(spectrum_dataset_maker_crab, observations_hess_dl3)
     mask_safe = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
     assert mask_safe.sum() == 3
 
-    mask_safe = safe_mask_maker.make_mask_bkg_peak_energy(dataset)
+    mask_safe = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert mask_safe.sum() == 3
+
 
 @requires_data()
 def test_safe_mask_maker_dc1(spectrum_dataset_maker_gc, observations_cta_dc1):

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -128,6 +128,8 @@ def test_safe_mask_maker_dl3(spectrum_dataset_maker_crab, observations_hess_dl3)
     mask_safe = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
     assert mask_safe.sum() == 3
 
+    mask_safe = safe_mask_maker.make_mask_bkg_peak_energy(dataset)
+    assert mask_safe.sum() == 3
 
 @requires_data()
 def test_safe_mask_maker_dc1(spectrum_dataset_maker_gc, observations_cta_dc1):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->


In this PR:
- I implemented the `SafeMaskMaker.make_mask_edisp_bias(...)` method for `MapDataset` and `MapDatasetOnOff`, that was previously raising `NotImplementedError`
- I implemented a new `SafeMaskMaker.make_mask_bkg_peak(...)` method, motivated by the HESS DL3 analysis validation paper ([page 11, section 5.5.1](https://arxiv.org/pdf/1910.08088.pdf))

As soon as this gets merged, I will resolve corresponding the [TODO](https://github.com/gammapy/gammapy-benchmarks/blob/3097a6a73c13b16f5b170002b7c0ef7461725100/validation/hess-dl3-dr1/make.py#L207) in the validation script. This will make the code simpler and shorter there.




<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
