### PR TITLE
Add gammapy download datasets -- tests flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
         - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
         - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa libgfortran iminuit regions reproject pandoc ipython jupyter'
 
-        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy parfive jsonschema'
+        - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy parfive jsonschema pydantic'
 
         - CONDA_CHANNELS='conda-forge sherpa'
 
@@ -74,7 +74,7 @@ matrix:
         # Run tests without optional dependencies
         - env: PYTHON_VERSION=3.6 CMD='make test'
                CONDA_DEPENDENCIES='Cython click regions'
-               PIP_DEPENDENCIES='pytest-astropy parfive jsonschema'
+               PIP_DEPENDENCIES='pytest-astropy parfive jsonschema pydantic'
 
         # Run tests without GAMMAPY_EXTRA available
         - stage: Initial tests
@@ -97,7 +97,7 @@ matrix:
         # Test with Sherpa dev, this may take a longer time
         - env: PYTHON_VERSION=3.6 SETUP_CMD='make test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
-               PIP_DEPENDENCIES='git+http://github.com/sherpa/sherpa.git#egg=sherpa pytest-astropy parfive jsonschema'
+               PIP_DEPENDENCIES='git+http://github.com/sherpa/sherpa.git#egg=sherpa pytest-astropy parfive jsonschema pydantic'
 
         # Test Fermipy master against gammapy master
         - env: PYTHON_VERSION=3.6 CMD='pip install .'
@@ -143,7 +143,7 @@ script:
     - if $FETCH_GAMMAPY_DATA; then
           export GAMMAPY_DATA=${HOME}/gammapy-data;
           pip install -e .;
-          gammapy download datasets --out=$GAMMAPY_DATA --silent;
+          gammapy download datasets --out=$GAMMAPY_DATA --tests --silent;
       fi
 
     - if $RUN_INSTALL; then

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,6 @@ dataset-index:
 	python dev/datasets/make_dataset_index.py dataset-index
 
 dataset-download:
-	gammapy download datasets --out=$(GAMMAPY_DATA)
+	gammapy download datasets --out=$(GAMMAPY_DATA) --tests
 
 # TODO: add test and code quality checks for `examples`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ jobs:
     displayName: 'Install Gammapy'
 
   - script: |
-      gammapy download datasets --out=$(GAMMAPY_DATA) --silent
+      gammapy download datasets --out=$(GAMMAPY_DATA) --silent --tests
     displayName: 'Get GAMMAPY_DATA'
 
   - script: |
@@ -115,7 +115,7 @@ jobs:
 
   - script: |
       source activate gammapy-dev
-      gammapy download datasets --out=$(GAMMAPY_DATA) --silent
+      gammapy download datasets --out=$(GAMMAPY_DATA) --silent --tests
     displayName: 'Get GAMMAPY_DATA'
 
   - script: |

--- a/gammapy/scripts/download.py
+++ b/gammapy/scripts/download.py
@@ -72,11 +72,12 @@ def cli_download_scripts(src, out, release, modetutorials, silent):
     help="Path where datasets will be copied.",
     show_default=True,
 )
+@click.option("--tests", default=False, is_flag=True, help="Include datasets needed for development tests.")
 @click.option("--modetutorials", default=False, hidden=True)
 @click.option("--silent", default=True, is_flag=True, hidden=True)
-def cli_download_datasets(src, out, release, modetutorials, silent):
+def cli_download_datasets(src, out, release, tests, modetutorials, silent):
     """Download datasets"""
-    plan = ComputePlan(src, out, release, "datasets", modetutorials=modetutorials)
+    plan = ComputePlan(src, out, release, "datasets", modetutorials=modetutorials, download_tests=tests)
     down = ParallelDownload(
         plan.getfilelist(),
         plan.getlocalfolder(),

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -18,8 +18,10 @@ DEV_SCRIPTS_YAML_URL = BASE_URL_DEV + "examples/scripts.yaml"
 DEV_DATA_JSON_LOCAL = "../../dev/datasets/gammapy-data-index.json"
 
 
-def parse_datafiles(datasearch, datasetslist):
+def parse_datafiles(datasearch, datasetslist, download_tests=False):
     for dataset in datasetslist:
+        if dataset["name"] == "tests" and not download_tests and datasearch != "tests":
+            continue
         if (datasearch == dataset["name"] or datasearch == "") and dataset.get(
             "files", ""
         ):
@@ -48,12 +50,13 @@ def parse_imagefiles(notebookslist):
 class ComputePlan:
     """Generates the whole list of files to download"""
 
-    def __init__(self, src, outfolder, release, option, modetutorials=False):
+    def __init__(self, src, outfolder, release, option, modetutorials=False, download_tests=False):
         self.src = src
         self.outfolder = Path(outfolder)
         self.release = release
         self.option = option
         self.modetutorials = modetutorials
+        self.download_tests = download_tests
         self.listfiles = {}
         log.info(f"Looking for {self.option}...")
 
@@ -137,7 +140,7 @@ class ComputePlan:
             datasets = json.loads(txt)
             datafound = {}
             if not self.modetutorials:
-                datafound.update(dict(parse_datafiles(self.src, datasets)))
+                datafound.update(dict(parse_datafiles(self.src, datasets, download_tests=self.download_tests)))
             else:
                 for item in self.listfiles:
                     record = self.listfiles[item]


### PR DESCRIPTION
This PR adds an optional `--tests` flag to `gammapy download datasets` command line tool, so to include datasets needed for development tests in the download only when the flag is set.

With this PR `gammapy download datasets` will download 433 files/ 172MB whilst `gammapy download datasets --tests` will download 503 files/ 177MB