### PR TITLE
Remove default spectral model from SkyModel

### DIFF
--- a/gammapy/catalog/fermi.py
+++ b/gammapy/catalog/fermi.py
@@ -191,7 +191,11 @@ class SourceCatalogObjectFermiBase(SourceCatalogObject, abc.ABC):
 
     def sky_model(self):
         """Sky model (`~gammapy.modeling.models.SkyModel`)."""
-        return SkyModel(self.spatial_model(), self.spectral_model(), name=self.name)
+        return SkyModel(
+            spatial_model=self.spatial_model(),
+            spectral_model=self.spectral_model(),
+            name=self.name
+        )
 
 
 class SourceCatalogObject4FGL(SourceCatalogObjectFermiBase):

--- a/gammapy/catalog/gammacat.py
+++ b/gammapy/catalog/gammacat.py
@@ -275,7 +275,11 @@ class SourceCatalogObjectGammaCat(SourceCatalogObject):
 
     def sky_model(self):
         """Source sky model (`~gammapy.modeling.models.SkyModel`)."""
-        return SkyModel(self.spatial_model(), self.spectral_model(), name=self.name)
+        return SkyModel(
+            spatial_model=self.spatial_model(),
+            spectral_model=self.spectral_model(),
+            name=self.name
+        )
 
     def _add_source_meta(self, table):
         """Copy over some info to table.meta"""

--- a/gammapy/catalog/hawc.py
+++ b/gammapy/catalog/hawc.py
@@ -160,7 +160,9 @@ class SourceCatalogObject2HWC(SourceCatalogObject):
         of the source size, based on the residual excess..
         """
         return SkyModel(
-            self.spatial_model(which), self.spectral_model(which), name=self.name
+            spatial_model=self.spatial_model(which),
+            spectral_model=self.spectral_model(which),
+            name=self.name
         )
 
 

--- a/gammapy/catalog/hess.py
+++ b/gammapy/catalog/hess.py
@@ -525,14 +525,18 @@ class SourceCatalogObjectHGPS(SourceCatalogObject):
                 weight = component.data["Flux_Map"] / self.data["Flux_Map"]
                 spectral_model.parameters["amplitude"].value *= weight
                 model = SkyModel(
-                    component.spatial_model(), spectral_model, name=component.name
+                    spatial_model=component.spatial_model(),
+                    spectral_model=spectral_model,
+                    name=component.name
                 )
                 models.append(model)
 
             return SkyModels(models)
         else:
             return SkyModel(
-                self.spatial_model(), self.spectral_model(which=which), name=self.name
+                spatial_model=self.spatial_model(),
+                spectral_model=self.spectral_model(which=which),
+                name=self.name
             )
 
     @property

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -108,23 +108,22 @@ class SkyModel(SkyModelBase):
 
     Parameters
     ----------
-    spatial_model : `~gammapy.modeling.models.SpatialModel`
-        Spatial model (must be normalised to integrate to 1)
     spectral_model : `~gammapy.modeling.models.SpectralModel`
         Spectral model
+    spatial_model : `~gammapy.modeling.models.SpatialModel`
+        Spatial model (must be normalised to integrate to 1)
     name : str
         Model identifier
     """
 
     tag = "SkyModel"
 
-    def __init__(self, spatial_model=None, spectral_model=None, name="source"):
-        from . import PointSpatialModel, PowerLawSpectralModel
+    def __init__(self, spectral_model, spatial_model=None, name="source"):
+        from . import PointSpatialModel
 
         if spatial_model is None:
             spatial_model = PointSpatialModel()
-        if spectral_model is None:
-            spectral_model = PowerLawSpectralModel()
+
         self.name = name
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -28,7 +28,7 @@ def sky_model():
     spectral_model = PowerLawSpectralModel(
         index=2, amplitude="1e-11 cm-2 s-1 TeV-1", reference="1 TeV"
     )
-    return SkyModel(spatial_model, spectral_model, name="source-1")
+    return SkyModel(spatial_model=spatial_model, spectral_model=spectral_model, name="source-1")
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -335,7 +335,7 @@ class TestSpectrumOnOff:
 
     @requires_dependency("matplotlib")
     def test_plot_fit(self):
-        model = SkyModel()
+        model = SkyModel(spectral_model=PowerLawSpectralModel())
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
@@ -401,7 +401,7 @@ class TestSpectrumOnOff:
         assert_allclose(mask, desired)
 
     def test_str(self):
-        model = SkyModel()
+        model = SkyModel(spectral_model=PowerLawSpectralModel())
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
@@ -417,7 +417,7 @@ class TestSpectrumOnOff:
 
     def test_fake(self):
         """Test the fake dataset"""
-        source_model = SkyModel()
+        source_model = SkyModel(spectral_model=PowerLawSpectralModel())
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,

--- a/gammapy/spectrum/tests/test_flux_point.py
+++ b/gammapy/spectrum/tests/test_flux_point.py
@@ -262,7 +262,7 @@ def test_flux_point_dataset_serialization(tmp_path):
     spectral_model = PowerLawSpectralModel(
         index=2.3, amplitude="2e-13 cm-2 s-1 TeV-1", reference="1 TeV"
     )
-    model = SkyModel(spatial_model, spectral_model, name="test_model")
+    model = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model, name="test_model")
     dataset = FluxPointsDataset(model, data, name="test_dataset")
 
     Datasets([dataset]).to_yaml(tmp_path, prefix="tmp")

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -218,8 +218,7 @@ class TestFluxPointsEstimator:
 
 
 def test_no_likelihood_contribution():
-    dataset = simulate_spectrum_dataset(SkyModel())
-    dataset.model = SkyModel()
+    dataset = simulate_spectrum_dataset(SkyModel(spectral_model=PowerLawSpectralModel()))
     dataset.mask_safe = np.zeros(dataset.data_shape, dtype=bool)
 
     fpe = FluxPointsEstimator([dataset], e_edges=[1, 3, 10] * u.TeV)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -7,7 +7,7 @@ import astropy.units as u
 from astropy.table import Column, Table
 from astropy.time import Time
 from gammapy.data import GTI
-from gammapy.modeling.models import SkyModel
+from gammapy.modeling.models import SkyModel, PowerLawSpectralModel
 from gammapy.spectrum.tests.test_flux_point_estimator import (
     simulate_map_dataset,
     simulate_spectrum_dataset,
@@ -128,7 +128,7 @@ def test_lightcurve_plot_time(lc):
 
 
 def get_spectrum_datasets():
-    model = SkyModel()
+    model = SkyModel(spectral_model=PowerLawSpectralModel())
     dataset_1 = simulate_spectrum_dataset(model=model, random_state=0)
     dataset_1.name = "dataset_1"
     gti1 = GTI.create("0h", "1h", "2010-01-01T00:00:00")

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -632,12 +632,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = SkyModel(\n",
-    "    PointSpatialModel(lon_0=\"0 deg\", lat_0=\"0 deg\", frame=\"galactic\"),\n",
-    "    PowerLawSpectralModel(\n",
+    "spatial_model = PointSpatialModel(lon_0=\"0 deg\", lat_0=\"0 deg\", frame=\"galactic\")\n",
+    "spectral_model = PowerLawSpectralModel(\n",
     "        index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"\n",
-    "    ),\n",
-    ")\n",
+    "    )\n",
+    "\n",
+    "model = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)\n",
     "\n",
     "model_total = SkyModels([model, model_diffuse, diffuse_iso])\n",
     "\n",
@@ -732,7 +732,7 @@
    "version": "3.7.0"
   },
   "toc": {
-   "base_numbering": 1.0,
+   "base_numbering": 1,
    "nav_menu": {
     "height": "237px",
     "width": "253px"
@@ -749,9 +749,9 @@
   },
   "varInspector": {
    "cols": {
-    "lenName": 16.0,
-    "lenType": 16.0,
-    "lenVar": 40.0
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
    },
    "kernels_config": {
     "python": {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow-up to #2505. Removing the default for the spectral model in `SkyModel`.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
