### PR TITLE
Add MapDatasetEventSampler with .sample_background() method

### DIFF
--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -111,7 +111,6 @@ def test_MDE_sample_background():
 
     assert len(bkg_evt.table["ENERGY"]) == 375084
     assert_allclose(bkg_evt.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
-    assert_allclose(bkg_evt.table["ENERGY"][1], 1.7671637269378804, rtol=1e-5)
     assert_allclose(bkg_evt.table["RA"][0], 0.7167667097717688, rtol=1e-5)
     assert_allclose(bkg_evt.table["DEC"][0], 1.1422945173936792, rtol=1e-5)
     assert_allclose(bkg_evt.table["MC_ID"][0], 0, rtol=1e-5)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -111,6 +111,7 @@ def test_MDE_sample_background():
 
     assert len(bkg_evt.table["ENERGY"]) == 375084
     assert_allclose(bkg_evt.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
+    assert_allclose(bkg_evt.table["ENERGY"][1], 1.7671637269378804, rtol=1e-5)
     assert_allclose(bkg_evt.table["RA"][0], 0.7167667097717688, rtol=1e-5)
     assert_allclose(bkg_evt.table["DEC"][0], 1.1422945173936792, rtol=1e-5)
     assert_allclose(bkg_evt.table["MC_ID"][0], 0, rtol=1e-5)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -62,7 +62,6 @@ def test_simulate():
     assert_allclose(dataset.edisp.data.data[10, 10], 0.85944298, rtol=1e-5)
 
 
-@requires_data()
 def dataset_maker():
     position = SkyCoord(0.0, 0.0, frame="galactic", unit="deg")
     energy_axis = MapAxis.from_bounds(
@@ -93,6 +92,7 @@ def dataset_maker():
     return dataset
 
 
+@requires_data()
 def test_MDE_sample_background():
     dataset = dataset_maker()
     sampler = MapDatasetEventSampler(random_state=0)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -1,14 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from numpy.testing import assert_allclose
-from astropy.time import Time
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from gammapy.cube import MapDataset, simulate_dataset, MapDatasetEventSampler
 from gammapy.cube.tests.test_fit import get_map_dataset
 from gammapy.data import GTI
 from gammapy.irf import load_cta_irfs
-from gammapy.maps import Map, MapAxis, WcsGeom
+from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import (
     GaussianSpatialModel,
     PowerLawSpectralModel,

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -1,11 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 from numpy.testing import assert_allclose
+from astropy.time import Time
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from gammapy.cube import MapDataset, simulate_dataset
+from gammapy.cube import MapDataset, simulate_dataset, MapDatasetEventSampler
+from gammapy.cube.tests.test_fit import get_map_dataset
+from gammapy.data import GTI
 from gammapy.irf import load_cta_irfs
-from gammapy.maps import MapAxis, WcsGeom
+from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
     GaussianSpatialModel,
     PowerLawSpectralModel,
@@ -58,3 +61,56 @@ def test_simulate():
     )
     assert_allclose(dataset.psf.data[5, 32, 32], 0.04203219)
     assert_allclose(dataset.edisp.data.data[10, 10], 0.85944298, rtol=1e-5)
+
+
+def dataset_maker():
+    position = SkyCoord(0.0, 0.0, frame="galactic", unit="deg")
+    energy_axis = MapAxis.from_bounds(
+        1, 100, nbin=30, unit="TeV", name="energy", interp="log"
+    )
+
+    exposure = Map.create(
+        binsz=0.02,
+        map_type="wcs",
+        skydir=position,
+        width="2 deg",
+        axes=[energy_axis],
+        coordsys="GAL",
+        unit="cm2 s",
+    )
+
+    spatial_model = GaussianSpatialModel(
+        lon_0="0 deg", lat_0="0 deg", sigma="0.2 deg", frame="galactic"
+    )
+
+    spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
+    skymodel = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
+
+    geom = WcsGeom.create(
+        skydir=position, binsz=0.02, width="5 deg", coordsys="GAL", axes=[energy_axis]
+    )
+
+    t_ref = Time("2010-01-01T00:00:00")
+    t_min = 0 * u.s
+    t_max = 30000 * u.s
+
+    gti = GTI.create(start=t_min, stop=t_max)
+
+    dataset = get_map_dataset(
+        sky_model=skymodel, geom=geom, geom_etrue=geom, edisp=True
+    )
+    dataset.gti = gti
+
+    return dataset
+
+
+def test_MDE_sample_background():
+    dataset = dataset_maker()
+    sampler = MapDatasetEventSampler(random_state=0)
+    bkg_evt = sampler.sample_background(dataset=dataset)
+
+    assert len(bkg_evt.table["ENERGY"]) == 375084
+    assert_allclose(bkg_evt.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
+    assert_allclose(bkg_evt.table["RA"][0], 0.7167667097717688, rtol=1e-5)
+    assert_allclose(bkg_evt.table["DEC"][0], 1.1422945173936792, rtol=1e-5)
+    assert_allclose(bkg_evt.table["MC_ID"][0], 0, rtol=1e-5)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -63,20 +63,11 @@ def test_simulate():
     assert_allclose(dataset.edisp.data.data[10, 10], 0.85944298, rtol=1e-5)
 
 
+@requires_data()
 def dataset_maker():
     position = SkyCoord(0.0, 0.0, frame="galactic", unit="deg")
     energy_axis = MapAxis.from_bounds(
         1, 100, nbin=30, unit="TeV", name="energy", interp="log"
-    )
-
-    exposure = Map.create(
-        binsz=0.02,
-        map_type="wcs",
-        skydir=position,
-        width="2 deg",
-        axes=[energy_axis],
-        coordsys="GAL",
-        unit="cm2 s",
     )
 
     spatial_model = GaussianSpatialModel(
@@ -90,7 +81,6 @@ def dataset_maker():
         skydir=position, binsz=0.02, width="5 deg", coordsys="GAL", axes=[energy_axis]
     )
 
-    t_ref = Time("2010-01-01T00:00:00")
     t_min = 0 * u.s
     t_max = 30000 * u.s
 
@@ -111,6 +101,6 @@ def test_MDE_sample_background():
 
     assert len(bkg_evt.table["ENERGY"]) == 375084
     assert_allclose(bkg_evt.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
-    assert_allclose(bkg_evt.table["RA"][0], 0.7167667097717688, rtol=1e-5)
-    assert_allclose(bkg_evt.table["DEC"][0], 1.1422945173936792, rtol=1e-5)
+    assert_allclose(bkg_evt.table["RA"][0], 265.7253792887848, rtol=1e-5)
+    assert_allclose(bkg_evt.table["DEC"][0], -27.727581635186304, rtol=1e-5)
     assert_allclose(bkg_evt.table["MC_ID"][0], 0, rtol=1e-5)


### PR DESCRIPTION
I am introducing the new class `MapDatasetEventSampler` into `~gammapy.cube.simulate` and its method `sample_background`.
The class is needed for the high level interface for the event sampler (PIG 9), while the method is developed to sample the events of a given background map.