### PR TITLE
Fix ObservationTable select time

### DIFF
--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -44,6 +44,22 @@ class ObservationTable(Table):
             self["GLON_PNT"], self["GLAT_PNT"], unit="deg", frame="galactic"
         )
 
+    @property
+    def time_ref(self):
+        """Time reference (`~astropy.time.Time`)."""
+        return time_ref_from_dict(self.meta)
+
+    @property
+    def time_start(self):
+        """Observation start time (`~astropy.time.Time`)."""
+        return self.time_ref + Quantity(self["TSTART"], "second")
+
+    @property
+    def time_stop(self):
+        """Observation stop time (`~astropy.time.Time`)."""
+        return self.time_ref + Quantity(self["TSTOP"], "second")
+
+
     @lazyproperty
     def _index_dict(self):
         """Dict containing row index for all obs ids."""
@@ -140,8 +156,7 @@ class ObservationTable(Table):
 
         Apply a 1D box selection (min, max) to a
         table on any time variable that is in the observation table.
-        It supports both fomats: absolute times in
-        `~astropy.time.Time` variables and [MET]_.
+        It supports absolute times in `~astropy.time.Time` format.
 
         If the inverted flag is activated, the selection is applied to
         keep all elements outside the selected range.

--- a/gammapy/data/obs_table.py
+++ b/gammapy/data/obs_table.py
@@ -9,7 +9,7 @@ from astropy.utils import lazyproperty
 from gammapy.utils.regions import SphericalCircleSkyRegion
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import Checker
-from gammapy.utils.time import time_relative_to_ref
+from gammapy.utils.time import time_ref_from_dict
 from .gti import GTI
 
 __all__ = ["ObservationTable"]
@@ -271,6 +271,8 @@ class ObservationTable(Table):
         """
         if "inverted" not in selection:
             selection["inverted"] = False
+        if "partial_overlap" not in selection:
+            selection["partial_overlap"] = False
 
         if selection["type"] == "sky_circle":
             lon = Angle(selection["lon"], "deg")
@@ -287,7 +289,7 @@ class ObservationTable(Table):
             return self[mask]
         elif selection["type"] == "time_box":
             return self.select_time_range(
-                "TSTART", selection["time_range"], selection["inverted"]
+                 selection["time_range"], selection["partial_overlap"], selection["inverted"]
             )
         elif selection["type"] == "par_box":
             return self.select_range(

--- a/gammapy/data/tests/test_obs_table.py
+++ b/gammapy/data/tests/test_obs_table.py
@@ -259,7 +259,7 @@ def test_select_time_box():
     obs_table_time = make_test_observation_table(
         n_obs=10,
         date_range=(datestart, dateend),
-        use_abs_time=True,
+        use_abs_time=False,
         random_state=random_state,
     )
 
@@ -267,10 +267,18 @@ def test_select_time_box():
     value_range = Time(["2012-01-01T01:00:00", "2012-01-01T02:00:00"])
     selection = dict(type="time_box", time_range=value_range)
     selected_obs_table = obs_table_time.select_observations(selection)
-    time_start = selected_obs_table["TSTART"]
-    assert (value_range[0] < time_start).all()
-    assert (time_start < value_range[1]).all()
+    time_start = selected_obs_table.time_start
+    time_stop = selected_obs_table.time_stop
 
+    assert (value_range[0] < time_start).all() & (time_stop < value_range[1]).all()
+
+    # Test selection with partial overlap of observations and value_range
+    selection_partial = dict(type="time_box", time_range=value_range, partial_overlap=True)
+    selected_obs_table = obs_table_time.select_observations(selection_partial)
+    time_start = selected_obs_table.time_start
+    time_stop = selected_obs_table.time_stop
+
+    assert (value_range[1] > time_start).all() & (time_stop > value_range[0]).all()
 
 def test_select_sky_regions():
     random_state = np.random.RandomState(seed=0)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects an improper behavior in `ObservationTable.select_time` reported in #2613.
This PR modifies the behavior of `ObservationTable.select_time` introducing `time_start` and `time_stop` properties. This creates a behavior closer to `EventList.select_time`.
Here we check for overlap, since an observation can be fully or partly enclosed in the time bin and we leave the option to the user to select one case or the other. 

The test no longer use a table with absolute times stored. `ObservationTable` now assumes only a table with time reference and elapse time as all other time tables in gammapy. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
The PR is ready for review. The new code is tested.