### PR TITLE
Fix SpectralModel.evaluate_error gradient computation

### DIFF
--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -65,16 +65,16 @@ class SpectralModel(Model):
 
         return df_dp
 
-    def evaluate_error(self, energy, precision=1e-4):
+    def evaluate_error(self, energy, epsilon=1e-4):
         """Evaluate spectral model with error propagation.
 
         Parameters
         ----------
         energy : `~astropy.units.Quantity`
             Energy at which to evaluate
-        precision : float
-            Numerical precision of the gradient evaluation.
-            Given as a fraction of the parameter error.
+        epsilon : float
+            Step size of the gradient evaluation. Given as a
+            fraction of the parameter error.
 
         Returns
         -------
@@ -82,7 +82,7 @@ class SpectralModel(Model):
             Tuple of flux and flux error.
         """
         p_cov = self.parameters.covariance
-        eps = np.sqrt(np.diag(self.parameters.covariance)) * precision
+        eps = np.sqrt(np.diag(self.parameters.covariance)) * epsilon
 
         df_dp = self._evaluate_gradient(energy, eps)
         f_cov = df_dp.T @ p_cov @ df_dp

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -605,5 +605,5 @@ def test_naima_model_error_propagation():
     model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
 
     out = model.evaluate_error(1 * u.TeV)
-    assert_allclose(out.data, [5.266068e-13, 0], rtol=1e-3)
+    assert_allclose(out.data, [5.266068e-13, 5.266068e-14], rtol=1e-3)
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -454,6 +454,11 @@ class TestNaimaModel:
         val = model(self.e_array)
         assert val.shape == self.e_array.shape
 
+        model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
+
+        out = model.evaluate_error(1 * u.TeV)
+        assert_allclose(out.data, [5.266068e-13, 5.266068e-14], rtol=1e-3)
+
     def test_ic(self):
         import naima
 
@@ -588,22 +593,4 @@ class TestSpectralModelErrorPropagation:
 
         out = model.evaluate_error(0.1 * u.TeV)
         assert_allclose(out.data, [1.548176e-10, 1.933612e-11], rtol=1e-3)
-
-
-@requires_dependency("naima")
-def test_naima_model_error_propagation():
-    import naima
-
-    particle_distribution = naima.models.PowerLaw(
-        amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5
-    )
-
-    radiative_model = naima.radiative.PionDecay(
-        particle_distribution, nh=1 * u.cm ** -3
-    )
-    model = NaimaSpectralModel(radiative_model)
-    model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
-
-    out = model.evaluate_error(1 * u.TeV)
-    assert_allclose(out.data, [5.266068e-13, 5.266068e-14], rtol=1e-3)
 

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -589,8 +589,21 @@ class TestSpectralModelErrorPropagation:
         out = model.evaluate_error(0.1 * u.TeV)
         assert_allclose(out.data, [1.548176e-10, 1.933612e-11], rtol=1e-3)
 
-    def test_naima_model_error_proprgation(self):
-        # Regression test for Naima model
-        # https://github.com/gammapy/gammapy/issues/2190
-        # TODO: implement test case. Move to Naima model tests!
-        pass
+
+@requires_dependency("naima")
+def test_naima_model_error_propagation():
+    import naima
+
+    particle_distribution = naima.models.PowerLaw(
+        amplitude=2e33 / u.eV, e_0=10 * u.TeV, alpha=2.5
+    )
+
+    radiative_model = naima.radiative.PionDecay(
+        particle_distribution, nh=1 * u.cm ** -3
+    )
+    model = NaimaSpectralModel(radiative_model)
+    model.parameters.set_error(amplitude=0.1 * model.amplitude.value)
+
+    out = model.evaluate_error(1 * u.TeV)
+    assert_allclose(out.data, [5.266068e-13, 0], rtol=1e-3)
+


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses #2601. I've change to the alternative method proposed in the [prototype notebook](https://github.com/gammapy/gammapy-extra/blob/master/experiments/uncertainty_estimation_prototype.ipynb), which allowed to use a separate eps per parameter. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
