### PR TITLE
Add sample_sources to MapDatasetEventSampler

### DIFF
--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -137,8 +137,8 @@ class MapDatasetEventSampler:
         table["RA_TRUE"] = coords.skycoord.icrs.ra.deg
         table["DEC_TRUE"] = coords.skycoord.icrs.dec.deg
         table["MC_ID"] = MC_ID
-        table["RA_TRUE"].unit= "Deg"
-        table["DEC_TRUE"].unit= "Deg"
+        table["RA_TRUE"].unit= "deg"
+        table["DEC_TRUE"].unit= "deg"
 
         # sample time
         # TODO: .temporal_model does not exist yet

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -137,6 +137,8 @@ class MapDatasetEventSampler:
         table["RA_TRUE"] = coords.skycoord.icrs.ra.deg
         table["DEC_TRUE"] = coords.skycoord.icrs.dec.deg
         table["MC_ID"] = MC_ID
+        table["RA_TRUE"].unit= "Deg"
+        table["DEC_TRUE"].unit= "Deg"
 
         # sample time
         # TODO: .temporal_model does not exist yet
@@ -145,6 +147,7 @@ class MapDatasetEventSampler:
             n_events, time_start, time_stop, self.random_state
         )
         table["TIME"] = u.Quantity(((time.mjd - time_ref.mjd) * u.day).to(u.s)).value
+        table["TIME"].unit= "s"
 
         return table
 

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -120,7 +120,7 @@ class MapDatasetEventSampler:
             Temporal model.
         gti : `MapDataset` object
             Good time intervals of the given MapDataset object.
-        MC_ID : `Int`
+        MC_ID : int
             Monte Carlo identifier of the sampled source.
 
         Returns

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -98,10 +98,10 @@ def test_MDE_sample_sources():
     sampler = MapDatasetEventSampler(random_state=0)
     src_evt = sampler.sample_sources(dataset=dataset)
 
-    assert len(src_evt.table["ENERGY"]) == 726
-    assert_allclose(src_evt.table["ENERGY"][0], 9.637228658895618, rtol=1e-5)
-    assert_allclose(src_evt.table["RA"][0], 266.3541109343822, rtol=1e-5)
-    assert_allclose(src_evt.table["DEC"][0], -28.88356606406115, rtol=1e-5)
+    assert len(src_evt.table["ENERGY_TRUE"]) == 726
+    assert_allclose(src_evt.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert_allclose(src_evt.table["RA_TRUE"][0], 266.3541109343822, rtol=1e-5)
+    assert_allclose(src_evt.table["DEC_TRUE"][0], -28.88356606406115, rtol=1e-5)
     assert_allclose(src_evt.table["MC_ID"][0], 1, rtol=1e-5)
 
 

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -93,6 +93,19 @@ def dataset_maker():
 
 
 @requires_data()
+def test_MDE_sample_sources():
+    dataset = dataset_maker()
+    sampler = MapDatasetEventSampler(random_state=0)
+    src_evt = sampler.sample_sources(dataset=dataset)
+
+    assert len(src_evt.table["ENERGY"]) == 726
+    assert_allclose(src_evt.table["ENERGY"][0], 9.637228658895618, rtol=1e-5)
+    assert_allclose(src_evt.table["RA"][0], 266.3541109343822, rtol=1e-5)
+    assert_allclose(src_evt.table["DEC"][0], -28.88356606406115, rtol=1e-5)
+    assert_allclose(src_evt.table["MC_ID"][0], 1, rtol=1e-5)
+
+
+@requires_data()
 def test_MDE_sample_background():
     dataset = dataset_maker()
     sampler = MapDatasetEventSampler(random_state=0)


### PR DESCRIPTION
This PR aims at adding the method `sample_sources` to the `MapDatasetEventSampler` class. The method will sample source events once a `Mapdataset` object is given in input.