### PR TITLE
Activate PSFMap for fitting

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1418,20 +1418,23 @@ class MapEvaluator:
         log.debug("Updating model evaluator")
         # cache current position of the model component
 
-        # TODO: lookup correct Edisp for this component
         if isinstance(edisp, EDispMap):
             e_reco = geom.get_axis_by_name("energy").edges
             self.edisp = edisp.get_energy_dispersion(self.model.position, e_reco=e_reco)
         else:
             self.edisp = edisp
 
-        # TODO: lookup correct PSF for this component
-        self.psf = psf  # .get_psf_kernel(self.model.position, geom=exposure.geom)
+        if isinstance(psf, PSFMap):
+            self.psf = psf.get_psf_kernel(
+                self.model.position, geom=exposure.geom, max_radius=0.8 * u.deg
+            )
+        # else:
+        #    self.psf = psf
 
         if self.evaluation_mode == "local" and self.model.evaluation_radius is not None:
             self._init_position = self.model.position
-            if psf is not None:
-                psf_width = np.max(psf.psf_kernel_map.geom.width)
+            if self.psf is not None:
+                psf_width = np.max(self.psf.psf_kernel_map.geom.width)
             else:
                 psf_width = 0 * u.deg
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1425,9 +1425,7 @@ class MapEvaluator:
             self.edisp = edisp
 
         if isinstance(psf, PSFMap):
-            self.psf = psf.get_psf_kernel(
-                self.model.position, geom=exposure.geom, max_radius=0.8 * u.deg
-            )
+            self.psf = psf.get_psf_kernel(self.model.position, geom=exposure.geom)
         else:
             self.psf = psf
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1428,8 +1428,8 @@ class MapEvaluator:
             self.psf = psf.get_psf_kernel(
                 self.model.position, geom=exposure.geom, max_radius=0.8 * u.deg
             )
-        # else:
-        #    self.psf = psf
+        else:
+            self.psf = psf
 
         if self.evaluation_mode == "local" and self.model.evaluation_radius is not None:
             self._init_position = self.model.position

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -272,6 +272,8 @@ class PSFMap:
             the resulting kernel
         """
         table_psf = self.get_energy_dependent_table_psf(position)
+        if max_radius is None:
+            max_radius = np.max(table_psf.rad)
         return PSFKernel.from_table_psf(table_psf, geom, max_radius, factor)
 
     def containment_radius_map(self, energy, fraction=0.68):

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -5,7 +5,7 @@ from astropy.table import Table
 import astropy.units as u
 from gammapy.cube import (
     MapDataset,
-    PSFKernel,
+    PSFMap,
     make_map_background_irf,
     make_map_exposure_true_energy,
 )
@@ -68,7 +68,7 @@ def simulate_dataset(
     background_model = BackgroundModel(background)
 
     psf = irfs["psf"].to_energy_dependent_table_psf(theta=offset)
-    psf_kernel = PSFKernel.from_table_psf(psf, geom, max_radius=max_radius)
+    psf_map = PSFMap.from_energy_dependent_table_psf(psf)
 
     exposure = make_map_exposure_true_energy(
         pointing=pointing, livetime=livetime, aeff=irfs["aeff"], geom=geom
@@ -84,7 +84,7 @@ def simulate_dataset(
         model=skymodel,
         exposure=exposure,
         background_model=background_model,
-        psf=psf_kernel,
+        psf=psf_map,
         edisp=edisp,
     )
 

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -9,7 +9,7 @@ from gammapy.cube import (
     EDispMap,
     MapDataset,
     MapDatasetOnOff,
-    PSFKernel,
+    PSFMap,
     make_map_exposure_true_energy,
 )
 from gammapy.data import GTI
@@ -75,15 +75,15 @@ def get_exposure(geom_etrue):
     return exposure_map
 
 
-def get_psf(geom_etrue):
+def get_psf():
     filename = (
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
     psf = EnergyDependentMultiGaussPSF.read(filename, hdu="POINT SPREAD FUNCTION")
 
     table_psf = psf.to_energy_dependent_table_psf(theta=0.5 * u.deg)
-    psf_kernel = PSFKernel.from_table_psf(table_psf, geom_etrue, max_radius=0.5 * u.deg)
-    return psf_kernel
+    psf_map = PSFMap.from_energy_dependent_table_psf(table_psf)
+    return psf_map
 
 
 @pytest.fixture
@@ -104,7 +104,7 @@ def get_map_dataset(sky_model, geom, geom_etrue, edisp=True, **kwargs):
     m.quantity = 0.2 * np.ones(m.data.shape)
     background_model = BackgroundModel(m)
 
-    psf = get_psf(geom_etrue)
+    psf = get_psf()
     exposure = get_exposure(geom_etrue)
 
     if edisp:
@@ -238,8 +238,10 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
         "EDISP_BANDS",
         "EDISP_EXPOSURE",
         "EDISP_EXPOSURE_BANDS",
-        "PSF_KERNEL",
-        "PSF_KERNEL_BANDS",
+        "PSF",
+        "PSF_BANDS",
+        "PSF_EXPOSURE",
+        "PSF_EXPOSURE_BANDS",
         "MASK_SAFE",
         "MASK_SAFE_BANDS",
         "MASK_FIT",
@@ -260,7 +262,7 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
         dataset.background_model.map.data, dataset_new.background_model.map.data
     )
     assert_allclose(dataset.edisp.edisp_map.data, dataset_new.edisp.edisp_map.data)
-    assert_allclose(dataset.psf.data, dataset_new.psf.data)
+    assert_allclose(dataset.psf.psf_map.data, dataset_new.psf.psf_map.data)
     assert_allclose(dataset.exposure.data, dataset_new.exposure.data)
     assert_allclose(dataset.mask_fit.data, dataset_new.mask_fit.data)
     assert_allclose(dataset.mask_safe.data, dataset_new.mask_safe.data)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -58,7 +58,7 @@ def test_simulate():
     assert_allclose(
         dataset.background_model.map.data[5, 20, 20], 0.9765545345855245, rtol=1e-5
     )
-    assert_allclose(dataset.psf.data[5, 32, 32], 0.04203219)
+    assert_allclose(dataset.psf.psf_map.data[5, 5, 0, 0], 91987.862)
     assert_allclose(dataset.edisp.data.data[10, 10], 0.85944298, rtol=1e-5)
 
 

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -75,11 +75,6 @@ def simulate_map_dataset(random_state=0):
     maker = MapDatasetMaker(selection=["exposure", "background", "psf", "edisp"])
     dataset = maker.run(empty, obs)
 
-    position = SkyCoord("0 deg", "0 deg", frame="galactic")
-    dataset.psf = dataset.psf.get_psf_kernel(
-        position=position, geom=geom, max_radius=0.8 * u.deg
-    )
-
     dataset.model = skymodel
     dataset.fake(random_state=random_state)
     return dataset
@@ -175,7 +170,7 @@ class TestFluxPointsEstimator:
         fp = fpe_map_pwl.run()
 
         actual = fp.table["norm"].data
-        assert_allclose(actual, [0.968217, 0.968712, 0.897872], rtol=1e-3)
+        assert_allclose(actual, [0.974651, 0.966819, 0.897374], rtol=1e-2)
 
         actual = fp.table["norm_err"].data
         assert_allclose(actual, [0.067386, 0.052279, 0.091548], rtol=1e-2)
@@ -218,7 +213,9 @@ class TestFluxPointsEstimator:
 
 
 def test_no_likelihood_contribution():
-    dataset = simulate_spectrum_dataset(SkyModel(spectral_model=PowerLawSpectralModel()))
+    dataset = simulate_spectrum_dataset(
+        SkyModel(spectral_model=PowerLawSpectralModel())
+    )
     dataset.mask_safe = np.zeros(dataset.data_shape, dtype=bool)
 
     fpe = FluxPointsEstimator([dataset], e_edges=[1, 3, 10] * u.TeV)

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -402,8 +402,8 @@ def test_lightcurve_estimator_map_datasets():
     assert_allclose(lightcurve.table["ref_flux"], [9.9e-12, 9.9e-12])
     assert_allclose(lightcurve.table["ref_eflux"], [4.60517e-11, 4.60517e-11])
     assert_allclose(lightcurve.table["ref_e2dnde"], [1e-11, 1e-11])
-    assert_allclose(lightcurve.table["stat"], [-87332.448423, -89904.0102], rtol=1e-5)
-    assert_allclose(lightcurve.table["norm_err"], [0.044116, 0.043618], rtol=1e-3)
+    assert_allclose(lightcurve.table["stat"], [-87323.380934, -89847.300576], rtol=1e-5)
+    assert_allclose(lightcurve.table["norm_err"], [0.044008, 0.043487], rtol=1e-3)
     assert_allclose(lightcurve.table["sqrt_ts"], [38.243713, 39.351595], atol=0.01)
     assert_allclose(lightcurve.table["ts"], [1462.581621, 1548.548039], atol=0.01)
 

--- a/gammapy/time/tests/test_lightcurve.py
+++ b/gammapy/time/tests/test_lightcurve.py
@@ -402,8 +402,8 @@ def test_lightcurve_estimator_map_datasets():
     assert_allclose(lightcurve.table["ref_flux"], [9.9e-12, 9.9e-12])
     assert_allclose(lightcurve.table["ref_eflux"], [4.60517e-11, 4.60517e-11])
     assert_allclose(lightcurve.table["ref_e2dnde"], [1e-11, 1e-11])
-    assert_allclose(lightcurve.table["stat"], [-87323.380934, -89847.300576], rtol=1e-5)
-    assert_allclose(lightcurve.table["norm_err"], [0.044008, 0.043487], rtol=1e-3)
+    assert_allclose(lightcurve.table["stat"], [-87332.44842 , -89904.010197], rtol=1e-5)
+    assert_allclose(lightcurve.table["norm_err"], [0.044114, 0.04362], rtol=1e-3)
     assert_allclose(lightcurve.table["sqrt_ts"], [38.243713, 39.351595], atol=0.01)
     assert_allclose(lightcurve.table["ts"], [1462.581621, 1548.548039], atol=0.01)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request activates `PSFMap` on the MapEvaluator. Similar to what is done in #2587 , the option to keep PSFKernel is still on. Once this PR is merged, I will deactivate the kernels and adapt the notebooks.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

One specific doubt I have is what should be the `max_radius` in 
`self.psf = psf.get_psf_kernel(self.model.position, geom=exposure.geom, max_radius=0.8 * u.deg)`
Having it as a parameter will be extremely confusing for the users. Currently I am passing a large enough value which should hopefully suffice for most cases.

I did not adapt the tests in `analysis` to avoid conflicts with the changes @Bultako might be making.