### PR TITLE
Edit doc-string of `MapDatasetOnOff`

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -999,9 +999,9 @@ class MapDatasetOnOff(MapDataset):
         Counts cube
     counts_off : `~gammapy.maps.WcsNDMap`
         Ring-convolved counts cube
-    acceptance : `~gammapy.maps.WcsNDMap` or float
+    acceptance : `~gammapy.maps.WcsNDMap`
         Acceptance from the IRFs
-    acceptance_off : `~gammapy.maps.WcsNDMap` or float
+    acceptance_off : `~gammapy.maps.WcsNDMap`
         Acceptance off
     exposure : `~gammapy.maps.WcsNDMap`
         Exposure cube


### PR DESCRIPTION
**Description**
`acceptance` and `acceptance_off` are only accepted as `gammapy.maps.Map` in the present implementation, whereas the doc-string mentioned them to be either `maps` or `floats`. This is corrected now. Whether we support floats in future shall be decided later.

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->


<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->




<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->