### PR TITLE
Improve gammapy.data.Observations

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -84,7 +84,7 @@ class Analysis:
         obs_list = self.datastore.get_observations()
         if len(self.config.observations.obs_ids):
             obs_list = self.datastore.get_observations(data_settings.obs_ids)
-        selected_obs["OBS_ID"] = [obs.obs_id for obs in obs_list.list]
+        selected_obs["OBS_ID"] = [obs.obs_id for obs in obs_list]
         ids = selected_obs["OBS_ID"].tolist()
         # TODO
         # if self.config.observations.obs_file:
@@ -106,8 +106,8 @@ class Analysis:
         # if self.config.observations.obs_time.start is not None:
         # filter obs_ids with time filter
         self.observations = self.datastore.get_observations(ids, skip_missing=True)
-        log.info(f"{len(self.observations.list)} observations were selected.")
-        for obs in self.observations.list:
+        log.info(f"Number of selected observations: {len(self.observations)}")
+        for obs in self.observations:
             log.debug(obs)
 
     def get_datasets(self):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import collections.abc
 import logging
 import numpy as np
 from astropy.coordinates import SkyCoord
@@ -292,26 +293,26 @@ class DataStoreObservation:
         return checker.run(checks=checks)
 
 
-class Observations:
+class Observations(collections.abc.Sequence):
     """Container class that holds a list of observations.
 
     Parameters
     ----------
-    obs_list : list
+    observations : list
         A list of `~gammapy.data.DataStoreObservation`
     """
 
-    def __init__(self, obs_list=None):
-        self.list = obs_list or []
+    def __init__(self, observations=None):
+        self._observations = observations or []
 
     def __getitem__(self, key):
         if isinstance(key, str):
             key = self.ids.index(key)
 
-        return self.list[key]
+        return self._observations[key]
 
     def __len__(self):
-        return len(self.list)
+        return len(self._observations)
 
     def __str__(self):
         s = self.__class__.__name__ + "\n"
@@ -323,7 +324,7 @@ class Observations:
     @property
     def ids(self):
         """List of obs IDs (`list`)"""
-        return [str(obs.obs_id) for obs in self.list]
+        return [str(obs.obs_id) for obs in self]
 
     def select_time(self, time_intervals):
         """Select a time interval of the observations.

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -148,7 +148,7 @@ def test_observations_select_time_time_intervals_list(data_store):
     ]
     new_obss = obss.select_time(time_intervals)
 
-    assert len(new_obss.list) == 2
+    assert len(new_obss) == 2
     assert new_obss[0].events.time[0] >= time_intervals[0][0]
     assert new_obss[0].events.time[-1] < time_intervals[0][1]
     assert new_obss[1].events.time[0] >= time_intervals[1][0]

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import abc
+import collections.abc
 import copy
 import numpy as np
 from gammapy.utils.scripts import make_path, read_yaml, write_yaml
@@ -83,7 +84,7 @@ class Dataset(abc.ABC):
         return residuals
 
 
-class Datasets:
+class Datasets(collections.abc.Sequence):
     """Dataset collection.
 
     Parameters

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Cube models (axes: lon, lat, energy)."""
+import collections.abc
 import copy
 from pathlib import Path
 import numpy as np
@@ -31,7 +32,7 @@ class SkyModelBase(Model):
         return self(coords.lon, coords.lat, coords["energy"])
 
 
-class SkyModels:
+class SkyModels(collections.abc.Sequence):
     """Sky model collection.
 
     Parameters

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Model parameter classes."""
+import collections.abc
 import copy
 import itertools
 import numpy as np
@@ -238,7 +239,7 @@ class Parameter:
             raise ValueError(f"Invalid method: {method}")
 
 
-class Parameters:
+class Parameters(collections.abc.Sequence):
     """Parameters container.
 
     - List of `Parameter` objects.


### PR DESCRIPTION
This PR improves `gammapy.data.Observations`. It changes from a public data member `list` to a private one `_observations`. This matches what I recently did for other containers in Gammapy: Parameters, Datasets, SkyModels.

It doesn't add much value, but I would suggest we sub-class `collections.abc.Sequence` here and also for `Parameters`, `Datasets` and `SkyModels`. This checks that the required `__getitem__` and `__len__` have been added (which is the case), and offers mixin methods `__contains__`, `__iter__`, `__reversed__`, `index`, and `count`, so that overall those containers then satisfy the so-called Python `Sequence` protocol. See https://docs.python.org/3/library/collections.abc.html

@adonath - OK?

Should I add `collections.abc.Sequence` now in this PR?