### PR TITLE
Hide `MapEvaluator` and `SpectrumEvaluator` from docs

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -21,7 +21,7 @@ from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_path
 from .exposure import _map_spectrum_weight
 
-__all__ = ["MapEvaluator", "MapDataset", "MapDatasetOnOff"]
+__all__ = ["MapDataset", "MapDatasetOnOff"]
 
 log = logging.getLogger(__name__)
 

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -8,7 +8,8 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
 from regions import CircleSkyRegion
-from gammapy.cube import MapEvaluator, PSFKernel
+from gammapy.cube import PSFKernel
+from gammapy.cube.fit import MapEvaluator
 from gammapy.irf import EnergyDependentMultiGaussPSF
 from gammapy.maps import Map, MapAxis, MapCoord, WcsGeom, WcsNDMap
 from gammapy.maps.utils import fill_poisson

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -3,7 +3,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.cube import MapEvaluator, PSFKernel
+from gammapy.cube import PSFKernel
+from gammapy.cube.fit import MapEvaluator
 from gammapy.irf import EnergyDispersion
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -11,7 +11,7 @@ from gammapy.utils.fits import ebounds_to_energy_axis, energy_axis_to_ebounds
 from gammapy.utils.regions import compound_region_to_list
 from gammapy.utils.scripts import make_path
 
-__all__ = ["CountsSpectrum", "SpectrumEvaluator"]
+__all__ = ["CountsSpectrum"]
 
 log = logging.getLogger(__name__)
 
@@ -371,21 +371,16 @@ class SpectrumEvaluator:
         plt.show()
     """
 
-    def __init__(self, model, aeff=None, edisp=None, livetime=None, e_true=None):
+    def __init__(self, model, aeff=None, edisp=None, livetime=None):
         self.model = model
         self.aeff = aeff
         self.edisp = edisp
         self.livetime = livetime
 
-        if aeff is not None:
-            e_true = self.aeff.energy.edges
-
-        self.e_true = e_true
-        self.e_reco = None
-
     def compute_npred(self):
+        e_true = self.aeff.energy.edges
         integral_flux = self.model.spectral_model.integral(
-            emin=self.e_true[:-1], emax=self.e_true[1:], intervals=True
+            emin=e_true[:-1], emax=e_true[1:], intervals=True
         )
 
         true_counts = self.apply_aeff(integral_flux)
@@ -408,11 +403,11 @@ class SpectrumEvaluator:
 
         if self.edisp is not None:
             cts = self.edisp.apply(true_counts)
-            self.e_reco = self.edisp.e_reco.edges
+            e_reco = self.edisp.e_reco.edges
         else:
             cts = true_counts
-            self.e_reco = self.e_true
+            e_reco = self.aeff.energy.edges
 
         return CountsSpectrum(
-            data=cts, energy_lo=self.e_reco[:-1], energy_hi=self.e_reco[1:]
+            data=cts, energy_lo=e_reco[:-1], energy_hi=e_reco[1:]
         )

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -187,7 +187,6 @@ class SpectrumDataset(Dataset):
                     model=component,
                     livetime=self.livetime,
                     aeff=self.aeff,
-                    e_true=self._energy_axis.edges,
                     edisp=self.edisp,
                 )
                 self._evaluators.append(evaluator)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -100,7 +100,7 @@ def get_test_cases():
                     values=[4.0, 3.0, 1.0, 0.1] * u.Unit("TeV-1"),
                 )
             ),
-            e_true=[0.1, 0.2, 0.3, 0.4] * u.TeV,
+            aeff=EffectiveAreaTable.from_constant([0.1, 0.2, 0.3, 0.4] * u.TeV, 1),
             npred=0.554513062,
         ),
     ]
@@ -111,5 +111,6 @@ def test_counts_predictor(case):
     opts = case.copy()
     del opts["npred"]
     predictor = SpectrumEvaluator(**opts)
-    actual = predictor.compute_npred().total_counts
-    assert_allclose(actual, case["npred"])
+    npred = predictor.compute_npred()
+    assert npred.unit == ""
+    assert_allclose(npred.total_counts, case["npred"])

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -11,7 +11,8 @@ from gammapy.modeling.models import (
     SkyModel,
     TemplateSpectralModel,
 )
-from gammapy.spectrum import CountsSpectrum, SpectrumEvaluator
+from gammapy.spectrum import CountsSpectrum
+from gammapy.spectrum.core import SpectrumEvaluator
 from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -17,8 +17,8 @@ from gammapy.modeling.models import (
 from gammapy.spectrum import (
     FluxPointsEstimator,
     SpectrumDatasetOnOff,
-    SpectrumEvaluator,
 )
+from gammapy.spectrum.core import SpectrumEvaluator
 from gammapy.utils.testing import requires_data, requires_dependency
 
 

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -70,7 +70,7 @@
     "    SkyModels,\n",
     "    create_fermi_isotropic_diffuse_model,\n",
     ")\n",
-    "from gammapy.cube import MapDataset, PSFKernel, MapEvaluator\n",
+    "from gammapy.cube import MapDataset, PSFKernel\n",
     "from gammapy.modeling import Fit"
    ]
   },
@@ -322,9 +322,11 @@
     "diffuse_galactic_fermi = Map.read(\n",
     "    \"$GAMMAPY_DATA/fermi_3fhl/gll_iem_v06_cutout.fits\"\n",
     ")\n",
+    "\n",
     "# Unit is not stored in the file, set it manually\n",
     "diffuse_galactic_fermi.unit = \"cm-2 s-1 MeV-1 sr-1\"\n",
     "print(diffuse_galactic_fermi.geom)\n",
+    "\n",
     "print(diffuse_galactic_fermi.geom.axes[0])"
    ]
   },
@@ -356,7 +358,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse_galactic.slice_by_idx({\"energy\": 0}).plot(add_cbar=True);"
+    "diffuse_gal = SkyDiffuseCube(diffuse_galactic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diffuse_gal.map.slice_by_idx({\"energy\": 0}).plot(add_cbar=True);"
    ]
   },
   {
@@ -367,7 +378,7 @@
    "source": [
     "# Exposure varies very little with energy at these high energies\n",
     "energy = np.logspace(1, 3, 10) * u.GeV\n",
-    "dnde = diffuse_galactic.interp_by_coord(\n",
+    "dnde = diffuse_gal.map.interp_by_coord(\n",
     "    {\"skycoord\": gc_pos, \"energy\": energy}, interp=\"linear\", fill_value=None\n",
     ")\n",
     "plt.plot(energy.value, dnde, \"*\")\n",
@@ -537,90 +548,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Background\n",
-    "\n",
-    "Let's compute a background cube, with predicted number of background events per pixel from the diffuse Galactic and isotropic model components. For this, we use the use the `~gammapy.cube.MapEvaluator` to multiply with the exposure and apply the PSF. The Fermi-LAT energy dispersion at high energies is small, we neglect it here."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_diffuse = SkyDiffuseCube(diffuse_galactic, name=\"diffuse\")\n",
-    "eval_diffuse = MapEvaluator(\n",
-    "    model=model_diffuse, exposure=exposure, psf=psf_kernel, edisp=edisp\n",
-    ")\n",
-    "\n",
-    "background_gal = eval_diffuse.compute_npred()\n",
-    "\n",
-    "background_gal.sum_over_axes().plot()\n",
-    "print(\"Background counts from Galactic diffuse: \", background_gal.data.sum())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "eval_iso = MapEvaluator(model=diffuse_iso, exposure=exposure, edisp=edisp)\n",
-    "\n",
-    "background_iso = eval_iso.compute_npred()\n",
-    "\n",
-    "background_iso.sum_over_axes().plot(add_cbar=True)\n",
-    "print(\"Background counts from isotropic diffuse: \", background_iso.data.sum())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "background_total = background_iso + background_gal"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Excess and flux\n",
-    "\n",
-    "Let's compute an excess and flux image, by subtracting the background, and summing over the energy axis."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "excess = counts.copy()\n",
-    "excess.data -= background_total.data\n",
-    "excess.sum_over_axes().smooth(\"0.1 deg\").plot(\n",
-    "    cmap=\"coolwarm\", vmin=-5, vmax=5, add_cbar=True\n",
-    ")\n",
-    "print(\"Excess counts: \", excess.data.sum())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "flux = excess.copy()\n",
-    "flux.data /= exposure.data\n",
-    "flux.unit = excess.unit / exposure.unit\n",
-    "flux.sum_over_axes().smooth(\"0.1 deg\").plot(stretch=\"sqrt\", add_cbar=True);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Fit\n",
     "\n",
     "Finally, the big finale: let's do a 3D map fit for the source at the Galactic center, to measure it's position and spectrum. We keep the background normalization free."
@@ -639,12 +566,12 @@
     "    index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"\n",
     ")\n",
     "\n",
-    "model = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)\n",
+    "source = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)\n",
     "\n",
-    "model_total = SkyModels([model, model_diffuse, diffuse_iso])\n",
+    "model = SkyModels([source, diffuse_gal, diffuse_iso])\n",
     "\n",
     "dataset = MapDataset(\n",
-    "    model=model_total,\n",
+    "    model=model,\n",
     "    counts=counts,\n",
     "    exposure=exposure,\n",
     "    psf=psf_kernel,\n",


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the `MapEvaluator` and `SpectrumEvaluator` from `__all__` to make it and implementation detail. Experienced users can still import and use it, but we don't advertise it as our API for npred calculation this always happens with `MapDataset.npred()`.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
