### PR TITLE
Remove requirements check for tutorial CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa libgfortran regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
+        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter iminuit'
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy parfive pydantic'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ env:
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter'
-        - CONDA_DEPENDENCIES_NOTEBOOKS='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa libgfortran iminuit regions reproject pandoc ipython jupyter'
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-click sphinx_rtd_theme pytest-astropy parfive pydantic'
 
@@ -105,7 +104,7 @@ matrix:
 
         # Test Jupyter notebooks
         - env: PYTHON_VERSION=3.6 CMD='make test-nb'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_NOTEBOOKS
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_DOCS
 
         # Test example scripts
         - env: PYTHON_VERSION=3.6 CMD='make test-scripts'

--- a/gammapy/utils/tutorials_test.py
+++ b/gammapy/utils/tutorials_test.py
@@ -5,7 +5,6 @@ import os
 import shutil
 import sys
 from pathlib import Path
-import pkg_resources
 import yaml
 from gammapy.scripts.jupyter import notebook_test
 
@@ -17,19 +16,6 @@ def get_notebooks():
     path = Path("tutorials") / "notebooks.yaml"
     with path.open() as fh:
         return yaml.safe_load(fh)
-
-
-def requirement_missing(notebook):
-    """Check if one of the requirements is missing."""
-    if "requires" in notebook:
-        if notebook["requires"] is None:
-            return False
-        for package in notebook["requires"].split():
-            try:
-                pkg_resources.working_set.require(package)
-            except Exception:
-                return True
-    return False
 
 
 def main():
@@ -50,9 +36,6 @@ def main():
     shutil.copytree(path_empty_nbs, path_temp)
 
     for notebook in get_notebooks():
-        if requirement_missing(notebook):
-            log.info(f"Skipping notebook (requirement missing): {notebook['name']}")
-            continue
 
         filename = notebook["name"] + ".ipynb"
         path = path_temp / filename

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -4,7 +4,6 @@
 # Let's keep it alphabetical.
 - name: analysis_3d
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/analysis_3d.ipynb
-  requires: iminuit
   datasets:
     - cta-1dc
     - fermi-3fhl-gc
@@ -12,7 +11,6 @@
     - DC1_3d
 - name: analysis_3d_joint
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/analysis_3d_joint.ipynb
-  requires: iminuit
   datasets:
     - cta-1dc  
 - name: astro_dark_matter
@@ -76,14 +74,12 @@
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/modeling.ipynb
 - name: models
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/models.ipynb
-  requires: naima
 - name: light_curve
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/light_curve.ipynb
   datasets:
     - hess-dl3-dr1
 - name: mcmc_sampling
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/mcmc_sampling.ipynb
-  requires: emcee
   datasets:
     - cta-1dc
   images:
@@ -94,20 +90,17 @@
     - cta-1dc
 - name: sed_fitting_gammacat_fermi
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/sed_fitting_gammacat_fermi.ipynb
-  requires: iminuit
   datasets:
     - catalogs
     - gamma-cat
 - name: simulate_3d
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/simulate_3d.ipynb
-  requires: iminuit
   datasets:
     - cta-1dc
 - name: source_population_model
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/source_population_model.ipynb
 - name: spectrum_analysis
   url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/spectrum_analysis.ipynb
-  requires: iminuit
   datasets:
     - hess-dl3-dr1
 - name: spectrum_simulation


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the `requires` attribute from the list of tutorial notebooks in `tutorials/notebooks.yaml`. It also removes the functionality that checks if the package required was available when testing a specific notebook, and the `CONDA_DEPENDENCIES_NOTEBOOKS` envar declared in `.travis.yaml`. The notebooks are then tested in the CI with the `CONDA_DEPENDENCIES_DOCS` envvar used to build the documentation (since most or all of the notebooks are part of the docs)


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
