### PR TITLE
Change Datasets model to models

### DIFF
--- a/examples/example_2_gauss.py
+++ b/examples/example_2_gauss.py
@@ -61,7 +61,7 @@ exposure_map = make_map_exposure_true_energy(
     pointing=pointing, livetime=livetime, aeff=aeff, geom=geom
 )
 
-dataset = MapDataset(model=models, exposure=exposure_map)
+dataset = MapDataset(models=models, exposure=exposure_map)
 npred = dataset.npred()
 
 dataset.fake()

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -48,7 +48,7 @@ class Analysis:
         self.datastore = None
         self.observations = None
         self.datasets = None
-        self.model = None
+        self.models = None
         self.fit = None
         self.fit_result = None
         self.flux_points = None
@@ -122,42 +122,42 @@ class Analysis:
         else:
             ValueError(f"Invalid dataset type: {self.config.datasets.type}")
 
-    def set_model(self, model):
+    def set_models(self, models):
         """Set models on datasets.
 
         Parameters
         ----------
-        model : `~gammapy.modeling.models.SkyModels` or str
+        models : `~gammapy.modeling.models.SkyModels` or str
             SkyModels object or YAML models string
         """
         if not self.datasets or len(self.datasets) == 0:
             raise RuntimeError("Missing datasets")
 
         log.info(f"Reading model.")
-        if isinstance(model, str):
+        if isinstance(models, str):
             # FIXME: SkyModels should offer a method to create from YAML str
-            model = yaml.safe_load(model)
-            self.model = SkyModels(dict_to_models(model))
-        elif isinstance(model, SkyModels):
-            self.model = model
+            models = yaml.safe_load(models)
+            self.models = SkyModels(dict_to_models(models))
+        elif isinstance(models, SkyModels):
+            self.models = models
         else:
-            raise TypeError(f"Invalid type: {model!r}")
+            raise TypeError(f"Invalid type: {models!r}")
 
         for dataset in self.datasets:
-            dataset.models = self.model
+            dataset.models = self.models
 
-        log.info(self.model)
+        log.info(self.models)
 
-    def read_model(self, path):
+    def read_models(self, path):
         """Read models from YAML file."""
         path = make_path(path)
         models = SkyModels.from_yaml(path)
-        self.set_model(models)
+        self.set_models(models)
 
     def run_fit(self, optimize_opts=None):
         """Fitting reduced datasets to model."""
-        if not self.model:
-            raise RuntimeError("Missing model")
+        if not self.models:
+            raise RuntimeError("Missing models")
 
         fit_settings = self.config.fit
         for dataset in self.datasets:
@@ -194,7 +194,7 @@ class Analysis:
         )
         fp = flux_point_estimator.run()
         fp.table["is_ul"] = fp.table["ts"] < 4
-        self.flux_points = FluxPointsDataset(data=fp, models=self.model[source])
+        self.flux_points = FluxPointsDataset(data=fp, models=self.models[source])
         cols = ["e_ref", "ref_flux", "dnde", "dnde_ul", "dnde_err", "is_ul"]
         log.info("\n{}".format(self.flux_points.data.table[cols]))
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -144,7 +144,7 @@ class Analysis:
             raise TypeError(f"Invalid type: {model!r}")
 
         for dataset in self.datasets:
-            dataset.model = self.model
+            dataset.models = self.model
 
         log.info(self.model)
 
@@ -194,7 +194,7 @@ class Analysis:
         )
         fp = flux_point_estimator.run()
         fp.table["is_ul"] = fp.table["ts"] < 4
-        self.flux_points = FluxPointsDataset(data=fp, model=self.model[source])
+        self.flux_points = FluxPointsDataset(data=fp, models=self.model[source])
         cols = ["e_ref", "ref_flux", "dnde", "dnde_ul", "dnde_err", "is_ul"]
         log.info("\n{}".format(self.flux_points.data.table[cols]))
 

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -70,11 +70,11 @@ def test_set_models():
     analysis = Analysis(config)
     analysis.get_observations()
     analysis.get_datasets()
-    model_str = Path(MODEL_FILE).read_text()
-    analysis.set_model(model=model_str)
-    assert isinstance(analysis.model, SkyModels) is True
+    models_str = Path(MODEL_FILE).read_text()
+    analysis.set_models(models=models_str)
+    assert isinstance(analysis.models, SkyModels) is True
     with pytest.raises(TypeError):
-        analysis.set_model(0)
+        analysis.set_models(0)
 
 
 @requires_dependency("iminuit")
@@ -98,7 +98,7 @@ def test_analysis_1d():
     analysis.update_config(cfg)
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.read_model(MODEL_FILE)
+    analysis.read_models(MODEL_FILE)
     analysis.run_fit()
     analysis.get_flux_points()
 
@@ -137,7 +137,7 @@ def test_analysis_1d_stacked():
     analysis.config.datasets.stack = True
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.read_model(MODEL_FILE)
+    analysis.read_models(MODEL_FILE)
     analysis.run_fit()
 
     assert len(analysis.datasets) == 1
@@ -155,7 +155,7 @@ def test_analysis_3d():
     analysis = Analysis(config)
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.read_model(MODEL_FILE)
+    analysis.read_models(MODEL_FILE)
     analysis.datasets["stacked"].background_model.tilt.frozen = False
     analysis.run_fit()
     analysis.get_flux_points()
@@ -191,7 +191,7 @@ def test_usage_errors():
     with pytest.raises(RuntimeError):
         analysis.get_datasets()
     with pytest.raises(RuntimeError):
-        analysis.read_model(MODEL_FILE)
+        analysis.read_models(MODEL_FILE)
     with pytest.raises(RuntimeError):
         analysis.run_fit()
     with pytest.raises(RuntimeError):

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -229,9 +229,7 @@ class MapDataset(Dataset):
 
         evaluators = []
         for model in self.models:
-            evaluator = MapEvaluator(
-                model, evaluation_mode=self.evaluation_mode
-            )
+            evaluator = MapEvaluator(model, evaluation_mode=self.evaluation_mode)
             evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
             evaluators.append(evaluator)
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -998,7 +998,7 @@ class MapDatasetOnOff(MapDataset):
 
     Parameters
     ----------
-    model : `~gammapy.modeling.models.SkyModel` or `~gammapy.modeling.models.SkyModels`
+    models : `~gammapy.modeling.models.SkyModels`
         Source sky models.
     counts : `~gammapy.maps.WcsNDMap`
         Counts cube
@@ -1035,7 +1035,7 @@ class MapDatasetOnOff(MapDataset):
 
     def __init__(
         self,
-        model=None,
+        models=None,
         counts=None,
         counts_off=None,
         acceptance=None,
@@ -1070,7 +1070,7 @@ class MapDatasetOnOff(MapDataset):
         self.mask_fit = mask_fit
         self.psf = psf
         self.edisp = edisp
-        self.model = model
+        self.models = models
         self.name = name
         self.mask_safe = mask_safe
         self.gti = gti
@@ -1100,8 +1100,8 @@ class MapDatasetOnOff(MapDataset):
         """List of parameters (`~gammapy.modeling.Parameters`)"""
         parameters = []
 
-        if self.model:
-            parameters += self.model.parameters
+        if self.models:
+            parameters += self.models.parameters
 
         return Parameters(parameters)
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -807,11 +807,16 @@ class MapDataset(Dataset):
 
     def to_dict(self, filename=""):
         """Convert to dict for YAML serialization."""
+        if self.models is None:
+            models = []
+        else:
+            models = [_.name for _ in self.models]
+
         return {
             "name": self.name,
             "type": self.tag,
             "likelihood": self.likelihood_type,
-            "models": [_.name for _ in self.models],
+            "models": models,
             "background": self.background_model.name,
             "filename": str(filename),
         }

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -79,7 +79,7 @@ def simulate_dataset(
         edisp = None
 
     dataset = MapDataset(
-        model=skymodel,
+        models=skymodel,
         exposure=exposure,
         background_model=background_model,
         psf=psf_map,

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -506,7 +506,7 @@ def get_map_dataset_onoff(images, **kwargs):
     mask_safe = Map.from_geom(mask_geom, data=mask_data)
 
     return MapDatasetOnOff(
-        model=None,
+        models=None,
         counts=images["counts"],
         counts_off=images["counts_off"],
         acceptance=images["acceptance"],
@@ -545,7 +545,7 @@ def test_map_dataset_onoff_fits_io(images, tmp_path):
     dataset.write(tmp_path / "test.fits")
 
     dataset_new = MapDatasetOnOff.read(tmp_path / "test.fits")
-    assert dataset_new.model is None
+    assert dataset_new.models is None
     assert dataset_new.mask.dtype == bool
 
     assert_allclose(dataset.counts.data, dataset_new.counts.data)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -254,7 +254,7 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
     dataset.write(tmp_path / "test.fits")
 
     dataset_new = MapDataset.read(tmp_path / "test.fits")
-    assert len(dataset_new.models) == 0
+    assert dataset_new.models is None
     assert dataset_new.mask.dtype == bool
 
     assert_allclose(dataset.counts.data, dataset_new.counts.data)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -121,7 +121,7 @@ def get_map_dataset(sky_model, geom, geom_etrue, edisp=True, **kwargs):
     mask_fit = Map.from_geom(geom, data=mask_fit)
 
     return MapDataset(
-        model=sky_model,
+        models=sky_model,
         exposure=exposure,
         background_model=background_model,
         psf=psf,
@@ -254,7 +254,7 @@ def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
     dataset.write(tmp_path / "test.fits")
 
     dataset_new = MapDataset.read(tmp_path / "test.fits")
-    assert len(dataset_new.model) == 0
+    assert len(dataset_new.models) == 0
     assert dataset_new.mask.dtype == bool
 
     assert_allclose(dataset.counts.data, dataset_new.counts.data)
@@ -344,7 +344,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
 
     # test model evaluation outside image
 
-    dataset_1.model[0].spatial_model.lon_0.value = 150
+    dataset_1.models[0].spatial_model.lon_0.value = 150
     dataset_1.npred()
     assert not dataset_1._evaluators[0].contributes
 

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -50,7 +50,7 @@ def test_simulate():
     )
 
     assert isinstance(dataset, MapDataset)
-    assert isinstance(dataset.model, SkyModels)
+    assert isinstance(dataset.models, SkyModels)
 
     assert dataset.counts.data.dtype is np.dtype("int")
     assert_allclose(dataset.counts.data[5, 20, 20], 2)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -146,8 +146,9 @@ class SkyModel(SkyModelBase):
     def spatial_model(self, model):
         from .spatial import SpatialModel
 
-        if not isinstance(model, (SpatialModel, type(None))):
+        if not (model is None or isinstance(model, SpatialModel)):
             raise TypeError(f"Invalid type: {model!r}")
+
         self._spatial_model = model
 
     @property
@@ -159,7 +160,7 @@ class SkyModel(SkyModelBase):
     def spectral_model(self, model):
         from .spectral import SpectralModel
 
-        if not isinstance(model, (SpectralModel, type(None))):
+        if not (model is None or isinstance(model, SpectralModel)):
             raise TypeError(f"Invalid type: {model!r}")
         self._spectral_model = model
 

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -126,8 +126,8 @@ def datasets_to_dict(datasets, path, prefix, overwrite):
         dataset.write(filename, overwrite)
         datasets_dictlist.append(dataset.to_dict(filename=filename))
 
-        if dataset.model is not None:
-            for model in dataset.model:
+        if dataset.models is not None:
+            for model in dataset.models:
                 if model not in unique_models:
                     unique_models.append(model)
 

--- a/gammapy/modeling/tests/data/make.py
+++ b/gammapy/modeling/tests/data/make.py
@@ -104,7 +104,7 @@ def make_datasets_example():
         )
 
         stacked.name = names[idx]
-        stacked.model = models[idx] + diffuse_model
+        stacked.models = models[idx] + diffuse_model
         datasets_list.append(stacked)
 
     datasets = Datasets(datasets_list)

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -122,7 +122,9 @@ def test_datasets_to_io(tmp_path):
     dataset1 = datasets[1]
     assert dataset1.background_model.name == "background_irf_g09"
 
-    assert dataset0.models["gll_iem_v06_cutout"] == dataset1.models["gll_iem_v06_cutout"]
+    assert (
+        dataset0.models["gll_iem_v06_cutout"] == dataset1.models["gll_iem_v06_cutout"]
+    )
 
     assert isinstance(dataset0.models, SkyModels)
     assert len(dataset0.models) == 2

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -122,19 +122,19 @@ def test_datasets_to_io(tmp_path):
     dataset1 = datasets[1]
     assert dataset1.background_model.name == "background_irf_g09"
 
-    assert dataset0.model["gll_iem_v06_cutout"] == dataset1.model["gll_iem_v06_cutout"]
+    assert dataset0.models["gll_iem_v06_cutout"] == dataset1.models["gll_iem_v06_cutout"]
 
-    assert isinstance(dataset0.model, SkyModels)
-    assert len(dataset0.model) == 2
-    assert dataset0.model[0].name == "gc"
-    assert dataset0.model[1].name == "gll_iem_v06_cutout"
+    assert isinstance(dataset0.models, SkyModels)
+    assert len(dataset0.models) == 2
+    assert dataset0.models[0].name == "gc"
+    assert dataset0.models[1].name == "gll_iem_v06_cutout"
 
     assert (
-        dataset0.model[0].parameters["reference"]
-        is dataset1.model[1].parameters["reference"]
+        dataset0.models[0].parameters["reference"]
+        is dataset1.models[1].parameters["reference"]
     )
 
-    assert_allclose(dataset1.model[1].parameters["lon_0"].value, 0.9, atol=0.1)
+    assert_allclose(dataset1.models[1].parameters["lon_0"].value, 0.9, atol=0.1)
 
     datasets.write(tmp_path, prefix="written")
     datasets_read = Datasets.read(

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -172,12 +172,14 @@ class SpectrumDataset(Dataset):
     @property
     def models(self):
         """Models (`gammapy.modeling.models.SkyModels`)."""
-        return self._model
+        return self._models
 
     @models.setter
     def models(self, value):
         if value is None or isinstance(value, SkyModels):
             models = value
+        elif isinstance(value, list):
+            models = SkyModels(value)
         elif isinstance(value, SkyModel):
             models = SkyModels([value])
         else:

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -1120,10 +1120,10 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         outdir = Path(filename).parent
         filename = str(outdir / f"pha_obs{self.name}.fits")
 
-        if self.models is not None:
-            models = [_.name for _ in self.models]
-        else:
+        if self.models is None:
             models = []
+        else:
+            models = [_.name for _ in self.models]
 
         return {
             "name": self.name,

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -535,7 +535,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     Parameters
     ----------
-    model : `~gammapy.modeling.models.SpectralModel`
+    models : `~gammapy.modeling.models.SkyModels`
         Fit model
     counts : `~gammapy.spectrum.CountsSpectrum`
         ON Counts spectrum
@@ -570,7 +570,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
     def __init__(
         self,
-        model=None,
+        models=None,
         counts=None,
         counts_off=None,
         livetime=None,
@@ -594,7 +594,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp
-        self.model = model
+        self.models = models
         self.mask_safe = mask_safe
 
         if np.isscalar(acceptance):
@@ -1118,8 +1118,8 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         outdir = Path(filename).parent
         filename = str(outdir / f"pha_obs{self.name}.fits")
 
-        if self.model is not None:
-            models = [_.name for _ in self.model]
+        if self.models is not None:
+            models = [_.name for _ in self.models]
         else:
             models = []
 
@@ -1165,7 +1165,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             Spectrum dataset on off.
 
         """
-        model = SkyModels([model for model in models if model.name in data["models"]])
+        models = [model for model in models if model.name in data["models"]]
 
         # TODO: assumes that the model is a skymodel
         # so this will work only when this change will be effective
@@ -1173,7 +1173,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         dataset = cls.from_ogip_files(filename=filename)
         dataset.mask_fit = None
-        dataset.model = model
+        dataset.models = models
         return dataset
 
 

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -197,10 +197,7 @@ class SpectrumDataset(Dataset):
         evaluators = []
         for model in self.models:
             evaluator = SpectrumEvaluator(
-                model=model,
-                livetime=self.livetime,
-                aeff=self.aeff,
-                edisp=self.edisp,
+                model=model, livetime=self.livetime, aeff=self.aeff, edisp=self.edisp
             )
             evaluators.append(evaluator)
 

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -146,7 +146,7 @@ class TestSpectrumDataset:
         model_1 = SkyModel(spectral_model=pwl_1)
         model_2 = SkyModel(spectral_model=pwl_2)
 
-        dataset.model = SkyModels([model_1, model_2])
+        dataset.models = SkyModels([model_1, model_2])
 
         npred = dataset.npred()
 
@@ -512,12 +512,12 @@ class TestSpectralFit:
         )
 
         # Example fit for one observation
-        self.datasets[0].model = self.pwl
+        self.datasets[0].models = self.pwl
         self.fit = Fit([self.datasets[0]])
 
     def set_model(self, model):
         for obs in self.datasets:
-            obs.model = model
+            obs.models = model
 
     @requires_dependency("iminuit")
     def test_basic_results(self):
@@ -525,7 +525,7 @@ class TestSpectralFit:
         result = self.fit.run()
         pars = self.fit.datasets.parameters
 
-        assert self.pwl is self.datasets[0].model[0]
+        assert self.pwl is self.datasets[0].models[0]
 
         assert_allclose(result.total_stat, 38.343, rtol=1e-3)
         assert_allclose(pars["index"].value, 2.817, rtol=1e-3)
@@ -682,14 +682,14 @@ class TestSpectrumDatasetOnOffStack:
                 index=2, amplitude=2e-11 * u.Unit("cm-2 s-1 TeV-1"), reference=1 * u.TeV
             )
         )
-        self.stacked_dataset.model = pwl
+        self.stacked_dataset.models = pwl
 
         npred_stacked = self.stacked_dataset.npred().data
         npred_stacked[~self.stacked_dataset.mask_safe] = 0
         npred_summed = np.zeros_like(npred_stacked)
 
         for obs in self.obs_list:
-            obs.model = pwl
+            obs.models = pwl
             npred_summed[obs.mask_safe] += obs.npred().data[obs.mask_safe]
 
         assert_allclose(npred_stacked, npred_summed)

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -330,7 +330,7 @@ class TestSpectrumOnOff:
             counts=self.on_counts,
             counts_off=self.off_counts,
             aeff=aeff,
-            model=model,
+            models=model,
             livetime=livetime,
         )
 
@@ -359,7 +359,7 @@ class TestSpectrumOnOff:
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
-            model=model,
+            models=model,
             aeff=self.aeff,
             livetime=self.livetime,
             edisp=self.edisp,
@@ -425,7 +425,7 @@ class TestSpectrumOnOff:
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
-            model=model,
+            models=model,
             aeff=self.aeff,
             livetime=self.livetime,
             edisp=self.edisp,
@@ -441,7 +441,7 @@ class TestSpectrumOnOff:
         dataset = SpectrumDatasetOnOff(
             counts=self.on_counts,
             counts_off=self.off_counts,
-            model=source_model,
+            models=source_model,
             aeff=self.aeff,
             livetime=self.livetime,
             edisp=self.edisp,

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -63,7 +63,7 @@ class TestSpectrumDataset:
             energy_lo=binning[:-1], energy_hi=binning[1:], data=source_counts
         )
         self.dataset = SpectrumDataset(
-            model=self.source_model,
+            models=self.source_model,
             counts=self.src,
             aeff=aeff,
             livetime=self.livetime,
@@ -110,7 +110,7 @@ class TestSpectrumDataset:
         mask_fit = np.ones(self.nbins, dtype=np.dtype("float"))
         with pytest.raises(ValueError):
             SpectrumDataset(
-                model=self.source_model,
+                models=self.source_model,
                 counts=self.src,
                 livetime=self.livetime,
                 mask_fit=mask_fit,
@@ -128,12 +128,12 @@ class TestSpectrumDataset:
 
         spectral_model = PowerLawSpectralModel()
         model = SkyModel(spectral_model=spectral_model, name="test")
-        dataset.model = model
-        assert dataset.model["test"] is model
+        dataset.models = model
+        assert dataset.models["test"] is model
 
         models = SkyModels([model])
-        dataset.model = models
-        assert dataset.model["test"] is model
+        dataset.models = models
+        assert dataset.models["test"] is model
 
     def test_npred_models(self):
         e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3).edges

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -91,7 +91,7 @@ class TestFit:
             acceptance=1,
             acceptance_off=1 / self.alpha,
         )
-        dataset.model = self.source_model
+        dataset.models = self.source_model
 
         self.source_model.parameters.index = 1.12
 
@@ -108,7 +108,7 @@ class TestFit:
         dataset = SpectrumDatasetOnOff(
             counts=self.src, mask_safe=np.ones(self.src.energy.nbin, dtype=bool)
         )
-        dataset.model = self.source_model
+        dataset.models = self.source_model
 
         assert np.sum(dataset.mask_safe) == self.nbins
         e_min, e_max = dataset.energy_range

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -57,7 +57,7 @@ class TestFit:
     def test_cash(self):
         """Simple CASH fit to the on vector"""
         dataset = SpectrumDataset(
-            model=self.source_model,
+            models=self.source_model,
             counts=self.src,
             aeff=self.aeff,
             livetime=self.src.livetime,
@@ -118,7 +118,7 @@ class TestFit:
 
     def test_stat_profile(self):
         dataset = SpectrumDataset(
-            model=self.source_model,
+            models=self.source_model,
             aeff=self.aeff,
             livetime=self.src.livetime,
             counts=self.src,

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -161,7 +161,7 @@ class TestSpectralFit:
 
     def test_stats(self):
         dataset = self.obs_list[0]
-        dataset.model = self.pwl
+        dataset.models = self.pwl
 
         fit = Fit([dataset])
         result = fit.run()
@@ -192,7 +192,7 @@ class TestSpectralFit:
             data=data, energy_lo=e_edges[:-1], energy_hi=e_edges[1:]
         )
         dataset.edisp = None
-        dataset.model = self.pwl
+        dataset.models = self.pwl
 
         fit = Fit([dataset])
         result = fit.run()
@@ -201,7 +201,7 @@ class TestSpectralFit:
     def test_stacked_fit(self):
         dataset = self.obs_list[0].copy()
         dataset.stack(self.obs_list[1])
-        dataset.model = self.pwl
+        dataset.models = self.pwl
 
         fit = Fit([dataset])
         result = fit.run()

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -30,7 +30,7 @@ def simulate_spectrum_dataset(model, random_state=0):
     )
 
     dataset = SpectrumDatasetOnOff(
-        aeff=aeff, model=model, livetime=100 * u.h, acceptance=1, acceptance_off=5
+        aeff=aeff, models=model, livetime=100 * u.h, acceptance=1, acceptance_off=5
     )
 
     eval = SpectrumEvaluator(model=bkg_model, aeff=aeff, livetime=100 * u.h)
@@ -44,7 +44,7 @@ def create_fpe(model):
     model = SkyModel(spectral_model=model)
     dataset = simulate_spectrum_dataset(model)
     e_edges = [0.1, 1, 10, 100] * u.TeV
-    dataset.model = model
+    dataset.models = model
     return FluxPointsEstimator(datasets=[dataset], e_edges=e_edges, norm_n_values=11)
 
 

--- a/gammapy/spectrum/tests/test_flux_point_estimator.py
+++ b/gammapy/spectrum/tests/test_flux_point_estimator.py
@@ -72,7 +72,7 @@ def simulate_map_dataset(random_state=0):
     maker = MapDatasetMaker(selection=["exposure", "background", "psf", "edisp"])
     dataset = maker.run(empty, obs)
 
-    dataset.model = skymodel
+    dataset.models = skymodel
     dataset.fake(random_state=random_state)
     return dataset
 
@@ -241,8 +241,8 @@ def test_mask_shape():
         spectral_model=PowerLawSpectralModel(), spatial_model=GaussianSpatialModel()
     )
 
-    dataset_1.model = model
-    dataset_2.model = model
+    dataset_1.models = model
+    dataset_2.models = model
 
     fpe = FluxPointsEstimator(
         datasets=[dataset_2, dataset_1], e_edges=[1, 10] * u.TeV, source="source"

--- a/gammapy/time/lightcurve_estimator.py
+++ b/gammapy/time/lightcurve_estimator.py
@@ -133,10 +133,10 @@ class LightCurveEstimator:
 
         dataset = self.datasets[0]
 
-        if len(dataset.model) > 1:
-            model = dataset.model[source].spectral_model
+        if len(dataset.models) > 1:
+            model = dataset.models[source].spectral_model
         else:
-            model = dataset.model[0].spectral_model
+            model = dataset.models[0].spectral_model
 
         self.model = ScaleSpectralModel(model)
         self.model.norm.min = 0
@@ -189,10 +189,10 @@ class LightCurveEstimator:
 
         """
         for dataset in datasets:
-            if len(dataset.model) > 1:
-                dataset.model[self.source].spectral_model = self.model
+            if len(dataset.models) > 1:
+                dataset.models[self.source].spectral_model = self.model
             else:
-                dataset.model[0].spectral_model = self.model
+                dataset.models[0].spectral_model = self.model
 
     @property
     def ref_model(self):

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -431,7 +431,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analysis.set_model(model_config)"
+    "analysis.set_models(model_config)"
    ]
   },
   {
@@ -440,7 +440,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(analysis.model)"
+    "print(analysis.models)"
    ]
   },
   {
@@ -449,7 +449,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(analysis.model[\"crab\"])"
+    "print(analysis.models[\"crab\"])"
    ]
   },
   {
@@ -490,7 +490,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analysis.model.to_yaml(\"model-best-fit.yaml\")"
+    "analysis.models.to_yaml(\"model-best-fit.yaml\")"
    ]
   },
   {

--- a/tutorials/analysis_3d.ipynb
+++ b/tutorials/analysis_3d.ipynb
@@ -336,7 +336,7 @@
     "    spectral_model=spectral_model,\n",
     "    name=\"gc-source\",\n",
     ")\n",
-    "stacked.model = model\n",
+    "stacked.models = model\n",
     "\n",
     "stacked.background_model.norm.value = 1.3"
    ]
@@ -402,8 +402,8 @@
     "spec = model.spectral_model\n",
     "\n",
     "# set covariance on the spectral model\n",
-    "covariance = result.parameters.covariance\n",
-    "spec.parameters.covariance = covariance[2:7, 2:7]\n",
+    "covar = result.parameters.get_subcovariance(spec.parameters)\n",
+    "spec.parameters.covariance = covar\n",
     "\n",
     "energy_range = [0.3, 10] * u.TeV\n",
     "spec.plot(energy_range=energy_range, energy_power=2)\n",
@@ -617,7 +617,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -438,7 +438,7 @@
     ")\n",
     "model = SkyModel(spectral_model=spectral_model)\n",
     "for dataset in datasets:\n",
-    "    dataset.model = model\n",
+    "    dataset.models = model\n",
     "\n",
     "fit = Fit(datasets)\n",
     "result = fit.run()\n",
@@ -498,7 +498,7 @@
    "outputs": [],
    "source": [
     "model.spectral_model.parameters.covariance = result.parameters.covariance\n",
-    "flux_points_dataset = FluxPointsDataset(data=flux_points, model=model)"
+    "flux_points_dataset = FluxPointsDataset(data=flux_points, models=model)"
    ]
   },
   {

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -568,10 +568,10 @@
     "\n",
     "source = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)\n",
     "\n",
-    "model = SkyModels([source, diffuse_gal, diffuse_iso])\n",
+    "models = SkyModels([source, diffuse_gal, diffuse_iso])\n",
     "\n",
     "dataset = MapDataset(\n",
-    "    model=model, counts=counts, exposure=exposure, psf=psf_kernel, edisp=edisp\n",
+    "    models=models, counts=counts, exposure=exposure, psf=psf_kernel, edisp=edisp\n",
     ")"
    ]
   },

--- a/tutorials/image_analysis.ipynb
+++ b/tutorials/image_analysis.ipynb
@@ -281,7 +281,7 @@
    "outputs": [],
    "source": [
     "dataset = MapDataset(\n",
-    "    model=model,\n",
+    "    models=model,\n",
     "    counts=maps2D[\"counts\"],\n",
     "    exposure=maps2D[\"exposure\"],\n",
     "    background_model=background_model,\n",
@@ -536,7 +536,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/joint_1d_3d_analysis.ipynb
+++ b/tutorials/joint_1d_3d_analysis.ipynb
@@ -41,6 +41,7 @@
     "    FluxPointsDataset,\n",
     "    SpectrumDatasetOnOff,\n",
     ")\n",
+    "from gammapy.maps import MapAxis\n",
     "from pathlib import Path"
    ]
   },
@@ -179,9 +180,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_model = [\n",
-    "    model for model in dataset_fermi.model if model.name == \"Crab Nebula\"\n",
-    "][0]\n",
+    "crab_model = dataset_fermi.models[\"Crab Nebula\"]\n",
     "crab_spec = crab_model.spectral_model\n",
     "print(crab_spec)"
    ]
@@ -203,16 +202,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs_ids = [23523, 23526]\n",
     "datasets = []\n",
-    "for obs_id in obs_ids:\n",
+    "\n",
+    "for obs_id in [23523, 23526]:\n",
     "    dataset = SpectrumDatasetOnOff.from_ogip_files(\n",
     "        f\"$GAMMAPY_DATA/joint-crab/spectra/hess/pha_obs{obs_id}.fits\"\n",
     "    )\n",
     "    datasets.append(dataset)\n",
+    "\n",
     "dataset_hess = Datasets(datasets).stack_reduce()\n",
     "dataset_hess.name = \"HESS\"\n",
-    "dataset_hess.model = crab_model"
+    "dataset_hess.models = crab_model"
    ]
   },
   {
@@ -297,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "crab_spec = datasets[0].model[\"Crab Nebula\"].spectral_model\n",
+    "crab_spec = datasets[0].models[\"Crab Nebula\"].spectral_model\n",
     "crab_spec.parameters.covariance = results_joint.parameters.get_subcovariance(\n",
     "    crab_spec.parameters\n",
     ")\n",
@@ -318,16 +318,16 @@
    "outputs": [],
    "source": [
     "# compute Fermi-LAT and HESS flux points\n",
-    "e_min, e_max = 0.01, 2.0\n",
-    "El_fermi = np.logspace(np.log10(e_min), np.log10(e_max), 6) * u.TeV\n",
+    "e_edges = MapAxis.from_bounds(0.01, 2.0, nbin=6, interp=\"log\", unit=\"TeV\").edges\n",
+    "\n",
     "flux_points_fermi = FluxPointsEstimator(\n",
-    "    datasets=[dataset_fermi], e_edges=El_fermi, source=\"Crab Nebula\"\n",
+    "    datasets=[dataset_fermi], e_edges=e_edges, source=\"Crab Nebula\"\n",
     ").run()\n",
     "\n",
-    "e_min, e_max = 1.0, 15.0\n",
-    "El_hess = np.logspace(np.log10(e_min), np.log10(e_max), 6) * u.TeV\n",
+    "\n",
+    "e_edges = MapAxis.from_bounds(1, 15, nbin=6, interp=\"log\", unit=\"TeV\").edges\n",
     "flux_points_hess = FluxPointsEstimator(\n",
-    "    datasets=[dataset_hess], e_edges=El_hess\n",
+    "    datasets=[dataset_hess], e_edges=e_edges\n",
     ").run()"
    ]
   },
@@ -354,13 +354,6 @@
     "flux_points_hawc.plot(ax=ax, energy_power=2, label=\"HAWC\")\n",
     "plt.legend();"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -379,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -220,7 +220,7 @@
     "# model[\"components\"] = [sky_model.to_dict()]\n",
     "# analysis_3d.set_model(model=model)\n",
     "models = SkyModels([sky_model])\n",
-    "analysis_3d.set_model(models)"
+    "analysis_3d.set_models(models)"
    ]
   },
   {
@@ -414,7 +414,7 @@
     "# model[\"components\"] = [sky_model.to_dict()]\n",
     "# analysis_1d.set_model(model=model)\n",
     "models = SkyModels([sky_model])\n",
-    "analysis_1d.set_model(models)"
+    "analysis_1d.set_models(models)"
    ]
   },
   {
@@ -506,6 +506,13 @@
     "\n",
     "nightwise_lc.plot()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/light_curve_flare.ipynb
+++ b/tutorials/light_curve_flare.ipynb
@@ -256,7 +256,7 @@
    "outputs": [],
    "source": [
     "for dataset in datasets:\n",
-    "    dataset.model = sky_model"
+    "    dataset.models = sky_model"
    ]
   },
   {

--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -247,7 +247,7 @@
     "dataset.parameters[\"amplitude\"].value = 3.2e-12\n",
     "dataset.parameters[\"lambda_\"].value = 0.05\n",
     "\n",
-    "print(dataset.model)\n",
+    "print(dataset.models)\n",
     "print(\"stat =\", dataset.stat_sum())"
    ]
   },
@@ -323,7 +323,7 @@
     "\n",
     "        # set model parameters\n",
     "        par_to_model(dataset, pars)\n",
-    "        spectral_model = dataset.model[0].spectral_model\n",
+    "        spectral_model = dataset.models[0].spectral_model\n",
     "\n",
     "        spectral_model.plot(\n",
     "            energy_range=(emin, emax),\n",

--- a/tutorials/pulsar_analysis.ipynb
+++ b/tutorials/pulsar_analysis.ipynb
@@ -435,7 +435,7 @@
     "emin_fit, emax_fit = (0.04 * u.TeV, 0.4 * u.TeV)\n",
     "\n",
     "for dataset in datasets:\n",
-    "    dataset.model = model\n",
+    "    dataset.models = model\n",
     "    dataset.mask_fit = dataset.counts.energy_mask(emin=emin_fit, emax=emax_fit)\n",
     "\n",
     "joint_fit = Fit(datasets)\n",
@@ -475,7 +475,7 @@
     "    index=4.5, amplitude=amplitude_ref, reference=\"20 GeV\"\n",
     ")\n",
     "\n",
-    "flux_points_dataset = FluxPointsDataset(data=flux_points, model=model)"
+    "flux_points_dataset = FluxPointsDataset(data=flux_points, models=model)"
    ]
   },
   {
@@ -540,7 +540,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/spectrum_analysis.ipynb
+++ b/tutorials/spectrum_analysis.ipynb
@@ -400,7 +400,7 @@
     "model = SkyModel(spectral_model=spectral_model)\n",
     "\n",
     "for dataset in datasets:\n",
-    "    dataset.model = model\n",
+    "    dataset.models = model\n",
     "\n",
     "fit_joint = Fit(datasets)\n",
     "result_joint = fit_joint.run()\n",
@@ -519,7 +519,7 @@
    "outputs": [],
    "source": [
     "flux_points_dataset = FluxPointsDataset(\n",
-    "    data=flux_points, model=model_best_joint\n",
+    "    data=flux_points, models=model_best_joint\n",
     ")"
    ]
   },
@@ -677,7 +677,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/spectrum_simulation.ipynb
+++ b/tutorials/spectrum_simulation.ipynb
@@ -209,7 +209,7 @@
     "dataset_onoff = SpectrumDatasetOnOff(\n",
     "    aeff=dataset.aeff,\n",
     "    edisp=dataset.edisp,\n",
-    "    model=model,\n",
+    "    models=model,\n",
     "    livetime=livetime,\n",
     "    acceptance=1,\n",
     "    acceptance_off=5,\n",
@@ -284,7 +284,7 @@
     "%%time\n",
     "results = []\n",
     "for dataset in datasets:\n",
-    "    dataset.model = model.copy()\n",
+    "    dataset.models = model.copy()\n",
     "    fit = Fit([dataset])\n",
     "    result = fit.optimize()\n",
     "    results.append(\n",
@@ -440,7 +440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is an attempt to fix #2102 by changing `dataset.model` to `dataset.model` on all our five dataset classes. If we do this change, we should do it now, before v0.15.

There's still two failing tests (see [here](https://gist.github.com/cdeil/3cb466921b87b79acd91dffb930916be)) and I didn't update the tutorials or docs yet. There's merge conflicts already. Probably I'll have to re-start, but this PR shows that the change can be done within an hour.

As far as I understand it, our codebase already has migrated to this design that `dataset.model` should always be a `SkyModels` (plural) object. So IMO this change is the logical consequence, easier to understand for users. The logic is to accept for convenience different objects in init and in the setter (usually `SkyModel`, `SkyModels` and `list` of `SkyModel`), but then in the `@models.setter` to have checks and converters that guarantee that `_models` will always be a `SkyModels`, so everywhere where we access it (~ 1000 places) we can rely on that.

There's still the concern that we allow `None` and empty `SkyModels` list, which can cause issues (see [here](https://gist.github.com/cdeil/3cb466921b87b79acd91dffb930916be)). We could either allow both and getters have to check on access. Or we only allow one in the setter.

@adonath @registerrier @QRemy - Thoughts?

If we go this way: should I rebase here and we try to push this in? Or should I re-start at a better time (e.g. Sunday evening)?