### PR TITLE
Add map_selection parameter in Analysis 

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -12,6 +12,7 @@ import yaml
 from pydantic import BaseModel, FilePath
 from pydantic.utils import deep_update
 from gammapy.utils.scripts import make_path, read_yaml
+from gammapy.cube import MapDatasetMaker
 
 __all__ = ["AnalysisConfig"]
 
@@ -67,6 +68,14 @@ class FrameEnum(str, Enum):
 
 class BackgroundMethodEnum(str, Enum):
     reflected = "reflected"
+
+
+class MapSelectionEnum(str, Enum):
+    counts = "counts"
+    exposure = "exposure"
+    background = "background"
+    psf = "psf"
+    edisp = "edisp"
 
 
 class GammapyBaseConfig(BaseModel):
@@ -155,7 +164,7 @@ class DatasetsConfig(GammapyBaseConfig):
     type: ReductionTypeEnum = ReductionTypeEnum.spectrum
     stack: bool = True
     geom: GeomConfig = GeomConfig()
-    map_selection: List[str] = None
+    map_selection: List[MapSelectionEnum] = MapDatasetMaker.available_selection
     background: BackgroundConfig = BackgroundConfig()
     on_region: SpatialCircleConfig = SpatialCircleConfig()
     containment_correction: bool = True

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -155,6 +155,7 @@ class DatasetsConfig(GammapyBaseConfig):
     type: ReductionTypeEnum = ReductionTypeEnum.spectrum
     stack: bool = True
     geom: GeomConfig = GeomConfig()
+    map_selection: List[str] = None
     background: BackgroundConfig = BackgroundConfig()
     on_region: SpatialCircleConfig = SpatialCircleConfig()
     containment_correction: bool = True

--- a/gammapy/analysis/config/config.yaml
+++ b/gammapy/analysis/config/config.yaml
@@ -28,6 +28,7 @@ datasets:
         axes:
             energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
             energy_true: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
+    map_selection:
     background:
         method: reflected
         exclusion:    # fits file for exclusion mask

--- a/gammapy/analysis/config/config.yaml
+++ b/gammapy/analysis/config/config.yaml
@@ -11,7 +11,7 @@ observations:
     obs_ids: [23523, 23526]
     obs_file:                             # csv file with obs_ids
     obs_cone: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 3 deg}
-    obs_time: {start: "2019-12-01", stop: "2020-03-01"}
+    obs_time: {start: '2019-12-01', stop: '2020-03-01'}
 
 datasets:
     type: 3d  # 1d
@@ -28,7 +28,7 @@ datasets:
         axes:
             energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
             energy_true: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
-    map_selection:
+    map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     background:
         method: reflected
         exclusion:    # fits file for exclusion mask

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -21,7 +21,7 @@ observations:
     obs_file:   # csv file with obs_ids
     # spatial /time filters applied on the obs_ids
     obs_cone: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 3 deg}
-    obs_time: {start: "2019-12-01", stop: "2020-03-01"}
+    obs_time: {start: '2019-12-01', stop: '2020-03-01'}
 
 # Section: datasets
 # Process of data reduction / mandatory
@@ -40,7 +40,7 @@ datasets:
         axes:
             energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
             energy_true: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
-    map_selection:
+    map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     background:
         method: reflected
         exclusion:    # fits file for exclusion mask

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -40,6 +40,7 @@ datasets:
         axes:
             energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
             energy_true: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
+    map_selection:
     background:
         method: reflected
         exclusion:    # fits file for exclusion mask

--- a/gammapy/analysis/config/template-1d.yaml
+++ b/gammapy/analysis/config/template-1d.yaml
@@ -8,7 +8,7 @@ datasets:
     geom:
         axes:
             energy: {min: 0.01 TeV, max: 100 TeV, nbins: 73}
-    map_selection:
+    map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     background:
         method: reflected
     on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.1 deg}

--- a/gammapy/analysis/config/template-1d.yaml
+++ b/gammapy/analysis/config/template-1d.yaml
@@ -8,6 +8,7 @@ datasets:
     geom:
         axes:
             energy: {min: 0.01 TeV, max: 100 TeV, nbins: 73}
+    map_selection:
     background:
         method: reflected
     on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.1 deg}

--- a/gammapy/analysis/config/template-3d.yaml
+++ b/gammapy/analysis/config/template-3d.yaml
@@ -17,7 +17,7 @@ datasets:
         axes:
             energy: {min: 1 TeV, max: 10 TeV, nbins: 4}
             energy_true: {min: 1 TeV, max: 10 TeV, nbins: 5}
-    map_selection:
+    map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
 
 fit:
     fit_range: {min: 1 TeV, max: 10 TeV}

--- a/gammapy/analysis/config/template-3d.yaml
+++ b/gammapy/analysis/config/template-3d.yaml
@@ -17,6 +17,7 @@ datasets:
         axes:
             energy: {min: 1 TeV, max: 10 TeV, nbins: 4}
             energy_true: {min: 1 TeV, max: 10 TeV, nbins: 5}
+    map_selection:
 
 fit:
     fit_range: {min: 1 TeV, max: 10 TeV}

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -237,7 +237,7 @@ class Analysis:
         offset_max = geom_settings.selection.offset_max
         log.info("Creating datasets.")
 
-        maker = MapDatasetMaker()
+        maker = MapDatasetMaker(selection=self.config.datasets.map_selection)
         maker_safe_mask = SafeMaskMaker(methods=["offset-max"], offset_max=offset_max)
         stacked = MapDataset.create(geom=geom, name="stacked", **geom_irf)
 
@@ -247,8 +247,9 @@ class Analysis:
                 cutout = stacked.cutout(obs.pointing_radec, width=2 * offset_max)
                 dataset = maker.run(cutout, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
-                dataset.background_model.name = f"bkg_{dataset.name}"
-                # TODO remove this once dataset and model have unique identifiers
+                if "background" in self.config.datasets.map_selection:
+                    dataset.background_model.name = f"bkg_{dataset.name}"
+                    # TODO remove this once dataset and model have unique identifiers
                 log.debug(dataset)
                 stacked.stack(dataset)
             self._extract_irf_kernels(stacked)
@@ -260,8 +261,9 @@ class Analysis:
                 cutout = stacked.cutout(obs.pointing_radec, width=2 * offset_max)
                 dataset = maker.run(cutout, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
-                dataset.background_model.name = f"bkg_{dataset.name}"
-                # TODO remove this once dataset and model have unique identifiers
+                if "background" in self.config.datasets.map_selection:
+                    dataset.background_model.name = f"bkg_{dataset.name}"
+                    # TODO remove this once dataset and model have unique identifiers
                 self._extract_irf_kernels(dataset)
                 log.debug(dataset)
                 datasets.append(dataset)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds `map_selection` parameter to the Analysis class and YAML files of the High-lelve interface, as an optional param for `MapDatasetMaker`. 


**Dear reviewer**

I have the following warning when `map_selection=['background']`

```
/Users/jer/git/gammapy/gammapy/gammapy/cube/psf_kernel.py:109: RuntimeWarning: invalid value encountered in true_divide
  img += vals.value / vals.sum().value
```

Tests have not been implemented, but test_coverage has not decreased.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
