### PR TITLE
Remove keepdims option from MapDataset.to_images()

### DIFF
--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -70,16 +70,7 @@ def _map_spectrum_weight(map, spectrum=None):
         spectrum = PowerLawSpectralModel(index=2.0)
 
     # Compute weights vector
-    # Should we change to call spectrum.integrate ?
-    energy_center = map.geom.get_axis_by_name("energy").center
     energy_edges = map.geom.get_axis_by_name("energy").edges
-    energy_width = np.diff(energy_edges)
-    weights = spectrum(energy_center) * energy_width
+    weights = spectrum.integral(emin=energy_edges[:-1], emax=energy_edges[1:], intervals=True)
     weights /= weights.sum()
-
-    # Make new map with weights applied
-    map_weighted = map.copy()
-    for img, idx in map_weighted.iter_by_image():
-        img *= weights[idx].value
-
-    return map_weighted
+    return map * weights.reshape((-1, 1, 1))

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -892,20 +892,20 @@ class MapDataset(Dataset):
             name=self.name,
         )
 
-    def to_image(self, spectrum=None, keepdims=True):
+    def to_image(self, spectrum=None):
         """Create images by summing over the energy axis.
 
         Exposure is weighted with an assumed spectrum,
         resulting in a weighted mean exposure image.
+
+        Currently the PSFMap and EdispMap are dropped from the
+        resulting image dataset.
 
         Parameters
         ----------
         spectrum : `~gammapy.modeling.models.SpectralModel`
             Spectral model to compute the weights.
             Default is power-law with spectral index of 2.
-        keepdims : bool, optional
-            If this is set to True, the energy axes is kept with a single bin.
-            If False, the energy axes is removed
 
         Returns
         -------
@@ -915,14 +915,12 @@ class MapDataset(Dataset):
         counts = self.counts * self.mask_safe
         background = self.background_model.evaluate() * self.mask_safe
 
-        counts = counts.sum_over_axes(keepdims=keepdims)
+        counts = counts.sum_over_axes(keepdims=True)
         exposure = _map_spectrum_weight(self.exposure, spectrum)
-        exposure = exposure.sum_over_axes(keepdims=keepdims)
-        background = background.sum_over_axes(keepdims=keepdims)
+        exposure = exposure.sum_over_axes(keepdims=True)
+        background = background.sum_over_axes(keepdims=True)
 
-        mask_image = self.mask_safe.reduce_over_axes(
-            func=np.logical_or, keepdims=keepdims
-        )
+        mask_image = self.mask_safe.reduce_over_axes(func=np.logical_or, keepdims=True)
 
         # TODO: add edisp and psf
         edisp = None


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses #2537., by removing the `keepdims` option from `MapDataset.to_images()`. The underlying problem is, that `BackgroundModel` requires am energy axis to be defined. Also in Gammapy a 2D analysis currently requires an energy bin defined. In https://docs.gammapy.org/dev/notebooks/cta_data_analysis.html#Compute-images, we show how to extract the images.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
