### PR TITLE
Remove FluxPointsDataset chi2assym option

### DIFF
--- a/tutorials/sed_fitting_gammacat_fermi.ipynb
+++ b/tutorials/sed_fitting_gammacat_fermi.ipynb
@@ -53,6 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from astropy import units as u\n",
     "from gammapy.modeling.models import (\n",
     "    PowerLawSpectralModel,\n",
@@ -61,11 +62,7 @@
     "    SkyModel,\n",
     ")\n",
     "from gammapy.spectrum import FluxPointsDataset, FluxPoints\n",
-    "from gammapy.catalog import (\n",
-    "    SourceCatalog3FGL,\n",
-    "    SourceCatalogGammaCat,\n",
-    "    SourceCatalog3FHL,\n",
-    ")\n",
+    "from gammapy.catalog import SOURCE_CATALOGS\n",
     "from gammapy.modeling import Fit"
    ]
   },
@@ -84,11 +81,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fermi_3fgl = SourceCatalog3FGL()\n",
-    "fermi_3fhl = SourceCatalog3FHL()\n",
-    "gammacat = SourceCatalogGammaCat(\n",
-    "    \"$GAMMAPY_DATA/catalogs/gammacat/gammacat.fits.gz\"\n",
-    ")"
+    "catalog_3fgl = SOURCE_CATALOGS[\"3fgl\"]()\n",
+    "catalog_3fhl = SOURCE_CATALOGS[\"3fhl\"]()\n",
+    "catalog_gammacat = SOURCE_CATALOGS[\"gamma-cat\"]()"
    ]
   },
   {
@@ -97,9 +92,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source_gammacat = gammacat[\"HESS J1507-622\"]\n",
-    "source_fermi_3fgl = fermi_3fgl[\"3FGL J1506.6-6219\"]\n",
-    "source_fermi_3fhl = fermi_3fhl[\"3FHL J1507.9-6228e\"]"
+    "source_fermi_3fgl = catalog_3fgl[\"3FGL J1506.6-6219\"]\n",
+    "source_fermi_3fhl = catalog_3fhl[\"3FHL J1507.9-6228e\"]\n",
+    "source_gammacat = catalog_gammacat[\"HESS J1507-622\"]"
    ]
   },
   {
@@ -153,13 +148,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# stack flux point tables\n",
+    "# Stack flux point tables\n",
     "flux_points = FluxPoints.stack(\n",
     "    [flux_points_gammacat, flux_points_3fhl, flux_points_3fgl]\n",
     ")\n",
     "\n",
-    "# drop the flux upper limit values\n",
-    "flux_points = flux_points.drop_ul()"
+    "t = flux_points.table\n",
+    "t[\"dnde_err\"] = 0.5 * (t[\"dnde_errn\"] + t[\"dnde_errp\"])\n",
+    "\n",
+    "# Remove upper limit points, where `dnde_errn = nan`\n",
+    "is_ul = np.isfinite(t[\"dnde_err\"])\n",
+    "flux_points = FluxPoints(t[is_ul])\n",
+    "flux_points"
    ]
   },
   {
@@ -196,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_pwl = FluxPointsDataset(model, flux_points, likelihood=\"chi2assym\")\n",
+    "dataset_pwl = FluxPointsDataset(model, flux_points)\n",
     "fitter = Fit([dataset_pwl])\n",
     "result_pwl = fitter.run()"
    ]
@@ -286,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_ecpl = FluxPointsDataset(model, flux_points, likelihood=\"chi2assym\")\n",
+    "dataset_ecpl = FluxPointsDataset(model, flux_points)\n",
     "fitter = Fit([dataset_ecpl])\n",
     "result_ecpl = fitter.run()\n",
     "print(ecpl)"
@@ -342,9 +342,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_log_parabola = FluxPointsDataset(\n",
-    "    model, flux_points, likelihood=\"chi2assym\"\n",
-    ")\n",
+    "dataset_log_parabola = FluxPointsDataset(model, flux_points)\n",
     "fitter = Fit([dataset_log_parabola])\n",
     "result_log_parabola = fitter.run()\n",
     "print(log_parabola)"


### PR DESCRIPTION
This PR removes the `chi2assym` from `FluxPointsDataset`.

It wasn't  covered by a test, and not well documented (with an example and in the [stats](https://docs.gammapy.org/0.14/stats/index.html) docs, explaining it's relation to normal chi2 and likelihood profiles).

My main argument why we shouldn't offer is is that is isn't standard or useful really. At https://cxc.harvard.edu/sherpa/statistics/ there's many chi2 variants, but the asymmetric one isn't one of them. I don't recall having seen the asymmetric chi2 used in papers at all. And it's not a good technique, if the likelihood is asymmetric, then the likelihood profile method which we should add soon is much better.

This is also a follow-up to #2546, removing the last case of confusing of "likelihood" vs "stat" vs "likelihood_type" names in the Gammapy codebase.