### PR TITLE
Add obs_file and obs_time features for observation selection in Analysis

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -250,7 +250,9 @@ class AnalysisConfig(GammapyBaseConfig):
         # We should change this once pydantic adds support for custom encoders
         # to `dict()`. See https://github.com/samuelcolvin/pydantic/issues/1043
         config = json.loads(self.json())
-        return yaml.dump(config, sort_keys=False, indent=4)
+        return yaml.dump(
+            config, sort_keys=False, indent=4, width=80, default_flow_style=None
+        )
 
     def set_logging(self):
         """Set logging config.

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
+from astropy.table import Table
 from regions import CircleSkyRegion
 import yaml
 from gammapy.analysis.config import AnalysisConfig
@@ -79,9 +80,17 @@ class Analysis:
 
         log.info("Fetching observations.")
         observations_settings = self.config.observations
-        if len(observations_settings.obs_ids) and observations_settings.obs_file is not None:
-            raise ValueError("Values for both parameters obs_ids and obs_file are not accepted.")
-        elif not len(observations_settings.obs_ids) and observations_settings.obs_file is None:
+        if (
+            len(observations_settings.obs_ids)
+            and observations_settings.obs_file is not None
+        ):
+            raise ValueError(
+                "Values for both parameters obs_ids and obs_file are not accepted."
+            )
+        elif (
+            not len(observations_settings.obs_ids)
+            and observations_settings.obs_file is None
+        ):
             obs_list = self.datastore.get_observations()
             ids = [obs.obs_id for obs in obs_list]
         elif len(observations_settings.obs_ids):
@@ -89,8 +98,7 @@ class Analysis:
             ids = [obs.obs_id for obs in obs_list]
         else:
             path = make_path(self.config.observations.obs_file)
-            with open(path, 'r') as f:
-                ids = [int(obs_id) for obs_id in f.readlines()]
+            ids = list(Table.read(path, format="ascii", data_start=0).columns[0])
 
         if observations_settings.obs_cone.lon is not None:
             cone = dict(

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -92,14 +92,13 @@ class Analysis:
                 ids_file = [int(obs_id) for obs_id in f.readlines()]
             ids.extend(ids_file)
         if data_settings.obs_cone.lon is not None:
-            # TODO remove border keyword
             cone = dict(
                 type="sky_circle",
                 frame=data_settings.obs_cone.frame,
                 lon=data_settings.obs_cone.lon,
                 lat=data_settings.obs_cone.lat,
                 radius=data_settings.obs_cone.radius,
-                border="1 deg",
+                border="0 deg",
             )
             selected_cone = self.datastore.obs_table.select_observations(cone)
             ids = list(set(ids) & set(selected_cone["OBS_ID"].tolist()))

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -86,10 +86,11 @@ class Analysis:
             obs_list = self.datastore.get_observations(data_settings.obs_ids)
         selected_obs["OBS_ID"] = [obs.obs_id for obs in obs_list]
         ids = selected_obs["OBS_ID"].tolist()
-        # TODO
-        # if self.config.observations.obs_file:
-        # add obs_ids from file
-        # ids.extend(selected_obs["OBS_ID"].tolist())
+        if self.config.observations.obs_file:
+            path = make_path(self.config.observations.obs_file)
+            with open(path, 'r') as f:
+                ids_file = [int(obs_id) for obs_id in f.readlines()]
+            ids.extend(ids_file)
         if data_settings.obs_cone.lon is not None:
             # TODO remove border keyword
             cone = dict(

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -103,10 +103,11 @@ class Analysis:
             )
             selected_cone = self.datastore.obs_table.select_observations(cone)
             ids = list(set(ids) & set(selected_cone["OBS_ID"].tolist()))
-        # TODO
-        # if self.config.observations.obs_time.start is not None:
-        # filter obs_ids with time filter
         self.observations = self.datastore.get_observations(ids, skip_missing=True)
+        if self.config.observations.obs_time.start is not None:
+            start = self.config.observations.obs_time.start
+            stop = self.config.observations.obs_time.stop
+            self.observations = self.observations.select_time([(start, stop)])
         log.info(f"Number of selected observations: {len(self.observations)}")
         for obs in self.observations:
             log.debug(obs)

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -42,34 +42,68 @@ def test_update_config():
         analysis.update_config(0)
 
 
-@requires_data()
-def test_get_observations(tmp_path):
+def test_get_observations_no_datastore():
     config = AnalysisConfig()
     analysis = Analysis(config)
     analysis.config.observations.datastore = "other"
     with pytest.raises(FileNotFoundError):
         analysis.get_observations()
+
+
+@requires_data()
+def test_get_observations_all():
+    config = AnalysisConfig()
+    analysis = Analysis(config)
     analysis.config.observations.datastore = "$GAMMAPY_DATA/cta-1dc/index/gps/"
     analysis.get_observations()
     assert len(analysis.observations) == 4
+
+
+@requires_data()
+def test_get_observations_obs_ids():
+    config = AnalysisConfig()
+    analysis = Analysis(config)
+    analysis.config.observations.datastore = "$GAMMAPY_DATA/cta-1dc/index/gps/"
     analysis.config.observations.obs_ids = ["110380"]
     analysis.get_observations()
     assert len(analysis.observations) == 1
-    config = AnalysisConfig.from_template("1d")
+
+
+@requires_data()
+def test_get_observations_obs_cone():
+    config = AnalysisConfig()
     analysis = Analysis(config)
+    analysis.config.observations.datastore = "$GAMMAPY_DATA/hess-dl3-dr1"
+    analysis.config.observations.obs_cone = {
+        "frame": "icrs",
+        "lon": "83d",
+        "lat": "22d",
+        "radius": "5d",
+    }
     analysis.get_observations()
     assert len(analysis.observations) == 4
+
+
+@requires_data()
+def test_get_observations_obs_file(tmp_path):
     config = AnalysisConfig()
     analysis = Analysis(config)
     analysis.get_observations()
     filename = tmp_path / "obs_ids.txt"
-    with open(filename, 'w') as f:
-        for item in analysis.observations.ids:
-            f.write(f"{item}\n")
+    filename.write_text("20136\n47829\n")
     analysis.config.observations.obs_file = filename
     analysis.get_observations()
-    assert len(analysis.observations) == 105
-    analysis.config.observations.obs_time = {"start": "2004-03-26", "stop": "2004-05-26"}
+    assert len(analysis.observations) == 2
+
+
+@requires_data()
+def test_get_observations_obs_time(tmp_path):
+    config = AnalysisConfig()
+    analysis = Analysis(config)
+    analysis.config.observations.obs_time = {
+        "start": "2004-03-26",
+        "stop": "2004-05-26",
+    }
     analysis.get_observations()
     assert len(analysis.observations) == 40
     analysis.config.observations.obs_ids = [0]

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -65,13 +65,16 @@ def test_get_observations(tmp_path):
     filename = tmp_path / "obs_ids.txt"
     with open(filename, 'w') as f:
         for item in analysis.observations.ids:
-            f.write(item)
+            f.write(f"{item}\n")
     analysis.config.observations.obs_file = filename
     analysis.get_observations()
     assert len(analysis.observations) == 105
     analysis.config.observations.obs_time = {"start": "2004-03-26", "stop": "2004-05-26"}
     analysis.get_observations()
     assert len(analysis.observations) == 40
+    analysis.config.observations.obs_ids = [0]
+    with pytest.raises(ValueError):
+        analysis.get_observations()
 
 
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -43,7 +43,7 @@ def test_update_config():
 
 
 @requires_data()
-def test_get_observations():
+def test_get_observations(tmp_path):
     config = AnalysisConfig()
     analysis = Analysis(config)
     analysis.config.observations.datastore = "other"
@@ -60,8 +60,17 @@ def test_get_observations():
     analysis.get_observations()
     assert len(analysis.observations) == 4
     # TODO
-    # obs_file
     # obs_time
+    config = AnalysisConfig()
+    analysis = Analysis(config)
+    analysis.get_observations()
+    filename = tmp_path / "obs_ids.txt"
+    with open(filename, 'w') as f:
+        for item in analysis.observations.ids:
+            f.write(item)
+    analysis.config.observations.obs_file = filename
+    analysis.get_observations()
+    assert len(analysis.observations) == 105
 
 
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -59,8 +59,6 @@ def test_get_observations(tmp_path):
     analysis = Analysis(config)
     analysis.get_observations()
     assert len(analysis.observations) == 4
-    # TODO
-    # obs_time
     config = AnalysisConfig()
     analysis = Analysis(config)
     analysis.get_observations()
@@ -71,6 +69,9 @@ def test_get_observations(tmp_path):
     analysis.config.observations.obs_file = filename
     analysis.get_observations()
     assert len(analysis.observations) == 105
+    analysis.config.observations.obs_time = {"start": "2004-03-26", "stop": "2004-05-26"}
+    analysis.get_observations()
+    assert len(analysis.observations) == 40
 
 
 @requires_data()

--- a/tutorials/light_curve.ipynb
+++ b/tutorials/light_curve.ipynb
@@ -216,9 +216,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model = {}\n",
-    "# model[\"components\"] = [sky_model.to_dict()]\n",
-    "# analysis_3d.set_model(model=model)\n",
     "models = SkyModels([sky_model])\n",
     "analysis_3d.set_models(models)"
    ]
@@ -410,9 +407,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model = {}\n",
-    "# model[\"components\"] = [sky_model.to_dict()]\n",
-    "# analysis_1d.set_model(model=model)\n",
     "models = SkyModels([sky_model])\n",
     "analysis_1d.set_models(models)"
    ]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds still missing features to improve observation filtering with the Analysis class of the high-level interface. 

- adds `obs_ids` read from a file declared in `obs_file` parameter
- filters `obs_ids` with start nad stop time declared in `obs_time` parameters
- makes `border=0` when filtering `of obs_ids ` with `obs_cone` parameter
- removes old comments not needed inducing to confusion in `light_curve.ipynb`  


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
