### PR TITLE
Add SkyModels read and write methods

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -162,7 +162,7 @@ class Analysis:
     def read_models(self, path):
         """Read models from YAML file."""
         path = make_path(path)
-        models = SkyModels.from_yaml(path)
+        models = SkyModels.read(path)
         self.set_models(models)
 
     def run_fit(self, optimize_opts=None):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -8,7 +8,7 @@ import numpy as np
 import astropy.units as u
 from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
-from gammapy.utils.scripts import make_path, write_yaml
+from gammapy.utils.scripts import make_path
 
 
 class SkyModelBase(Model):
@@ -67,12 +67,19 @@ class SkyModels(collections.abc.Sequence):
         skymodels = dict_to_models(data)
         return cls(skymodels)
 
-    def to_yaml(self, filename):
+    def write(self, path, overwrite=False):
         """Write to YAML file."""
+        path = make_path(path)
+        if path.exists() and not overwrite:
+            raise IOError(f"File exists already: {path}")
+        path.write_text(self.to_yaml())
+
+    def to_yaml(self):
+        """Convert to YAML string."""
         from gammapy.modeling.serialize import models_to_dict
 
-        components_dict = models_to_dict(self._skymodels)
-        write_yaml(components_dict, filename, sort_keys=False)
+        data = models_to_dict(self._skymodels)
+        return yaml.dump(data, sort_keys=False, indent=4, width=80, default_flow_style=None)
 
     def __str__(self):
         str_ = f"{self.__class__.__name__}\n\n"

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -3,11 +3,12 @@
 import collections.abc
 import copy
 from pathlib import Path
+import yaml
 import numpy as np
 import astropy.units as u
 from gammapy.maps import Map
 from gammapy.modeling import Model, Parameter, Parameters
-from gammapy.utils.scripts import make_path, read_yaml, write_yaml
+from gammapy.utils.scripts import make_path, write_yaml
 
 
 class SkyModelBase(Model):
@@ -52,11 +53,17 @@ class SkyModels(collections.abc.Sequence):
         return Parameters.from_stack([_.parameters for _ in self._skymodels])
 
     @classmethod
-    def from_yaml(cls, filename):
-        """Write to YAML file."""
+    def read(cls, filename):
+        """Read from YAML file."""
+        yaml_str = Path(filename).read_text()
+        return cls.from_yaml(yaml_str)
+
+    @classmethod
+    def from_yaml(cls, yaml_str):
+        """Create from YAML string."""
         from gammapy.modeling.serialize import dict_to_models
 
-        data = read_yaml(filename)
+        data = yaml.safe_load(yaml_str)
         skymodels = dict_to_models(data)
         return cls(skymodels)
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -123,7 +123,7 @@ def test_sky_model_spatial_none_io(tmpdir):
     models = SkyModels([model])
 
     filename = tmpdir / "test-models-none.yaml"
-    models.to_yaml(filename)
+    models.write(filename)
 
     models = SkyModels.read(filename)
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -125,7 +125,7 @@ def test_sky_model_spatial_none_io(tmpdir):
     filename = tmpdir / "test-models-none.yaml"
     models.to_yaml(filename)
 
-    models = SkyModels.from_yaml(filename)
+    models = SkyModels.read(filename)
 
     assert models["test"].spatial_model is None
 

--- a/gammapy/modeling/tests/data/make.py
+++ b/gammapy/modeling/tests/data/make.py
@@ -26,7 +26,7 @@ def make_example_2():
     spatial = GaussianSpatialModel(lon_0="0 deg", lat_0="0 deg", sigma="1 deg")
     model = SkyModel(spatial, PowerLawSpectralModel())
     models = SkyModels([model])
-    models.to_yaml(DATA_PATH / "example2.yaml")
+    models.write(DATA_PATH / "example2.yaml")
 
 
 def make_datasets_example():

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -87,10 +87,10 @@ def test_dict_to_skymodels():
 def test_sky_models_io(tmp_path):
     # TODO: maybe change to a test case where we create a model programatically?
     filename = get_pkg_data_filename("data/examples.yaml")
-    models = SkyModels.from_yaml(filename)
+    models = SkyModels.read(filename)
 
     models.to_yaml(tmp_path / "tmp.yaml")
-    models = SkyModels.from_yaml(tmp_path / "tmp.yaml")
+    models = SkyModels.read(tmp_path / "tmp.yaml")
 
     assert_allclose(models.parameters["lat_0"].min, -90.0)
 
@@ -259,6 +259,6 @@ def test_all_model_instances(model):
 @requires_data()
 def test_missing_parameters():
     filename = get_pkg_data_filename("data/examples.yaml")
-    models = SkyModels.from_yaml(filename)
+    models = SkyModels.read(filename)
     assert models["source1"].spatial_model.e in models.parameters
     assert len(models["source1"].spatial_model.parameters) == 6

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -89,7 +89,7 @@ def test_sky_models_io(tmp_path):
     filename = get_pkg_data_filename("data/examples.yaml")
     models = SkyModels.read(filename)
 
-    models.to_yaml(tmp_path / "tmp.yaml")
+    models.write(tmp_path / "tmp.yaml")
     models = SkyModels.read(tmp_path / "tmp.yaml")
 
     assert_allclose(models.parameters["lat_0"].min, -90.0)

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -490,7 +490,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analysis.models.to_yaml(\"model-best-fit.yaml\")"
+    "analysis.models.write(\"model-best-fit.yaml\")"
    ]
   },
   {


### PR DESCRIPTION
In #2621,  #2631 and #2642 we change `AnalysisConfig` and `Datasets` to have a `read` and `write` method, which calls `from_yaml` and `to_yaml` and does the I/O.

This two-step way to do I/O, and to have `read` and `write` as the methods that hit the disk is a good pattern in general, it's also done e.g. in Astropy with `Table.read` and `Table.write`.

Suggest to do the same in `SkyModels`, to rename the existing `from_yaml` and `to_yaml` there to `read` and `write` (and to keep the `from_yaml` and `to_yaml` and return YAML strings, as interface for users that want to work with YAML in-memory (e.g. to print in a notebook, or to send to a database or whatever they like).

Example how it should look:

https://github.com/gammapy/gammapy/blob/e93e605084e1dffa0e47eeaff64c3be851717238/gammapy/analysis/config.py#L228-L232

@QRemy @adonath - Thoughts?