### PR TITLE
Disallow one energy bin for node-type 'center'

### DIFF
--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -322,6 +322,9 @@ class MapAxis:
         if ~(np.all(nodes == np.sort(nodes)) or np.all(nodes[::-1] == np.sort(nodes))):
             raise ValueError("MapAxis: node values must be sorted")
 
+        if len(nodes) == 1 and node_type == "center":
+            raise ValueError("Single bins can only be used with node-type 'edges'")
+
         if isinstance(nodes, u.Quantity):
             unit = nodes.unit if nodes.unit is not None else ""
             nodes = nodes.value

--- a/gammapy/maps/tests/test_geom.py
+++ b/gammapy/maps/tests/test_geom.py
@@ -369,3 +369,8 @@ def test_group_table_outside_range(energy_axis_ref):
 
     with pytest.raises(ValueError):
         energy_axis_ref.group_table(e_edges)
+
+
+def test_map_axis_single_bin():
+    with pytest.raises(ValueError):
+        _ = MapAxis.from_nodes([1])


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses #1952. While looking at the issue again I noticed that in the modelling and fitting we require the bin-width to be defined, because we integrate the spectral model over a given energy range. This requires the `node_type="edges"` even if there is only a single energy bin defined. This PR just disallows the cases `nbin=1` and `node_type="center"`, so it fails early with a good error message.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
