### PR TITLE
Add MapDatasetEventSampler sample_psf method

### DIFF
--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -10,7 +10,7 @@ from gammapy.cube import (
     make_map_exposure_true_energy,
 )
 from gammapy.data import EventList
-from gammapy.maps import WcsNDMap
+from gammapy.maps import WcsNDMap, MapCoord
 from gammapy.modeling.models import BackgroundModel, ConstantTemporalModel
 from gammapy.utils.random import get_random_state
 
@@ -176,3 +176,37 @@ class MapDatasetEventSampler:
         table.rename_column("DEC_TRUE", "DEC")
 
         return EventList(table)
+
+    def sample_psf(self, psf_map, events):
+        """Sample psf map.
+
+        Parameters
+        ----------
+        psf_map : `PSFMap`
+            PSF map.
+        events : `EventList`
+            Event list.
+
+        Returns
+        -------
+        events : `EventList`
+            Event list with reconstructed position columns.
+        """
+
+        energy_unit = events.table["RA_TRUE"].unit
+        coord = MapCoord(
+            {
+                "lon": events.table["RA_TRUE"].quantity,
+                "lat": events.table["DEC_TRUE"].quantity,
+                "energy": events.table["ENERGY_TRUE"].quantity,
+            },
+            coordsys="icrs",
+        )
+
+        coords_reco = psf_map.sample_coord(coord, self.random_state)
+        events.table["RA_TRUE"] = coords_reco["lon"] * energy_unit
+        events.table["DEC_TRUE"] = coords_reco["lat"] * energy_unit
+        events.table.rename_column("RA_TRUE", "RA")
+        events.table.rename_column("DEC_TRUE", "DEC")
+
+        return events

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -202,9 +202,6 @@ class MapDatasetEventSampler:
         )
 
         coords_reco = psf_map.sample_coord(coord, self.random_state)
-        events.table["RA_TRUE"] = coords_reco["lon"] * u.deg
-        events.table["DEC_TRUE"] = coords_reco["lat"] * u.deg
-        events.table.rename_column("RA_TRUE", "RA")
-        events.table.rename_column("DEC_TRUE", "DEC")
-
+        events.table["RA"] = coords_reco["lon"] * u.deg
+        events.table["DEC"] = coords_reco["lat"] * u.deg
         return events

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -182,9 +182,9 @@ class MapDatasetEventSampler:
 
         Parameters
         ----------
-        psf_map : `PSFMap`
+        psf_map : `~gammapy.cube.PSFMap`
             PSF map.
-        events : `EventList`
+        events : `~gammapy.data.EventList`
             Event list.
 
         Returns
@@ -192,8 +192,6 @@ class MapDatasetEventSampler:
         events : `EventList`
             Event list with reconstructed position columns.
         """
-
-        energy_unit = events.table["RA_TRUE"].unit
         coord = MapCoord(
             {
                 "lon": events.table["RA_TRUE"].quantity,
@@ -204,8 +202,8 @@ class MapDatasetEventSampler:
         )
 
         coords_reco = psf_map.sample_coord(coord, self.random_state)
-        events.table["RA_TRUE"] = coords_reco["lon"] * energy_unit
-        events.table["DEC_TRUE"] = coords_reco["lat"] * energy_unit
+        events.table["RA_TRUE"] = coords_reco["lon"] * u.deg
+        events.table["DEC_TRUE"] = coords_reco["lat"] * u.deg
         events.table.rename_column("RA_TRUE", "RA")
         events.table.rename_column("DEC_TRUE", "DEC")
 

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -125,11 +125,11 @@ def test_MDE_sample_psf():
 
     dataset = dataset_maker()
     sampler = MapDatasetEventSampler(random_state=0)
-    src_evt = sampler.sample_sources(dataset=dataset)
-    src_evt_corr = sampler.sample_psf(psf_map, src_evt)
+    events = sampler.sample_sources(dataset=dataset)
+    events = sampler.sample_psf(psf_map, events)
 
-    assert len(src_evt_corr.table) == 726
-    assert_allclose(src_evt_corr.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
-    assert_allclose(src_evt_corr.table["RA"][0], 266.46418313134603, rtol=1e-5)
-    assert_allclose(src_evt_corr.table["DEC"][0], -28.85688796198139, rtol=1e-5)
-    assert_allclose(src_evt_corr.table["MC_ID"][0], 1, rtol=1e-5)
+    assert len(events.table) == 726
+    assert_allclose(events.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.46418313134603, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -28.85688796198139, rtol=1e-5)
+    assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -15,6 +15,7 @@ from gammapy.modeling.models import (
     SkyModels,
 )
 from gammapy.utils.testing import requires_data
+from gammapy.cube.tests.test_psf_map import make_test_psfmap
 
 
 @requires_data()
@@ -116,3 +117,19 @@ def test_MDE_sample_background():
     assert_allclose(bkg_evt.table["RA"][0], 265.7253792887848, rtol=1e-5)
     assert_allclose(bkg_evt.table["DEC"][0], -27.727581635186304, rtol=1e-5)
     assert_allclose(bkg_evt.table["MC_ID"][0], 0, rtol=1e-5)
+
+
+@requires_data()
+def test_MDE_sample_psf():
+    psf_map = make_test_psfmap(0.1 * u.deg, shape="gauss")
+
+    dataset = dataset_maker()
+    sampler = MapDatasetEventSampler(random_state=0)
+    src_evt = sampler.sample_sources(dataset=dataset)
+    src_evt_corr = sampler.sample_psf(psf_map, src_evt)
+
+    assert len(src_evt_corr.table) == 726
+    assert_allclose(src_evt_corr.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert_allclose(src_evt_corr.table["RA"][0], 266.46418313134603, rtol=1e-5)
+    assert_allclose(src_evt_corr.table["DEC"][0], -28.85688796198139, rtol=1e-5)
+    assert_allclose(src_evt_corr.table["MC_ID"][0], 1, rtol=1e-5)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -94,33 +94,45 @@ def dataset_maker():
 
 
 @requires_data()
-def test_MDE_sample_sources():
+def test_mde_sample_sources():
     dataset = dataset_maker()
     sampler = MapDatasetEventSampler(random_state=0)
-    src_evt = sampler.sample_sources(dataset=dataset)
+    events = sampler.sample_sources(dataset=dataset)
 
-    assert len(src_evt.table["ENERGY_TRUE"]) == 726
-    assert_allclose(src_evt.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
-    assert_allclose(src_evt.table["RA_TRUE"][0], 266.3541109343822, rtol=1e-5)
-    assert_allclose(src_evt.table["DEC_TRUE"][0], -28.88356606406115, rtol=1e-5)
-    assert_allclose(src_evt.table["MC_ID"][0], 1, rtol=1e-5)
+    assert len(events.table["ENERGY_TRUE"]) == 726
+    assert_allclose(events.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert events.table["ENERGY_TRUE"].unit == "TeV"
+
+    assert_allclose(events.table["RA_TRUE"][0], 266.3541109343822, rtol=1e-5)
+    assert events.table["RA_TRUE"].unit == "deg"
+
+    assert_allclose(events.table["DEC_TRUE"][0], -28.88356606406115, rtol=1e-5)
+    assert events.table["DEC_TRUE"].unit == "deg"
+
+    assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)
 
 
 @requires_data()
-def test_MDE_sample_background():
+def test_mde_sample_background():
     dataset = dataset_maker()
     sampler = MapDatasetEventSampler(random_state=0)
-    bkg_evt = sampler.sample_background(dataset=dataset)
+    events = sampler.sample_background(dataset=dataset)
 
-    assert len(bkg_evt.table["ENERGY"]) == 375084
-    assert_allclose(bkg_evt.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
-    assert_allclose(bkg_evt.table["RA"][0], 265.7253792887848, rtol=1e-5)
-    assert_allclose(bkg_evt.table["DEC"][0], -27.727581635186304, rtol=1e-5)
-    assert_allclose(bkg_evt.table["MC_ID"][0], 0, rtol=1e-5)
+    assert len(events.table["ENERGY"]) == 375084
+    assert_allclose(events.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
+    assert events.table["ENERGY"].unit == "TeV"
+
+    assert_allclose(events.table["RA"][0], 265.7253792887848, rtol=1e-5)
+    assert events.table["RA"].unit == "deg"
+
+    assert_allclose(events.table["DEC"][0], -27.727581635186304, rtol=1e-5)
+    assert events.table["DEC"].unit == "deg"
+
+    assert_allclose(events.table["MC_ID"][0], 0, rtol=1e-5)
 
 
 @requires_data()
-def test_MDE_sample_psf():
+def test_mde_sample_psf():
     psf_map = make_test_psfmap(0.1 * u.deg, shape="gauss")
 
     dataset = dataset_maker()
@@ -130,6 +142,12 @@ def test_MDE_sample_psf():
 
     assert len(events.table) == 726
     assert_allclose(events.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert events.table["ENERGY_TRUE"].unit == "TeV"
+
     assert_allclose(events.table["RA"][0], 266.46418313134603, rtol=1e-5)
+    assert events.table["RA"].unit == "deg"
+
     assert_allclose(events.table["DEC"][0], -28.85688796198139, rtol=1e-5)
+    assert events.table["DEC"].unit == "deg"
+
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)


### PR DESCRIPTION
This PR aims at adding a `sample_psf` method in the `MapDatasetEventSampler` class. The method applies PSF correction to the coordinates of the simulated events.