### PR TITLE
Improve How To page

### DIFF
--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -5,131 +5,98 @@
 How To
 ======
 
-Data access and manipulation
-----------------------------
+This page contains short "how to" or "frequently asked question" entries for
+Gammapy. Each entry is for a very specific task, with a short answer, and links
+to examples and documentation.
 
-How to open a data store and access observations?
-+++++++++++++++++++++++++++++++++++++++++++++++++
+If you're new to Gammapy, please read the :ref:`overview` and have a look at the
+list of :ref:`tutorials`. The information below is in addition to those pages,
+it's not a complete list of how to do everything in Gammapy.
 
-Gammapy accesses data through a `~gammapy.data.DataStore` object. You can see how to create one with the high
-level interface `~gammapy.analysis.Analysis` `here <notebooks/analysis_1.html#Setting-the-data-to-use>`__.
-You can also create the object directly, see
-this `example <notebooks/analysis_2.html#Defining-the-datastore-and-selecting-observations>`__.
+Please give feedback and suggest additions to this page!
 
-..  How to select observations?
-    +++++++++++++++++++++++++++
+Access IACT data
+++++++++++++++++
 
-..  How to filter selected observations?
-    ++++++++++++++++++++++++++++++++++++
+To access IACT data use the `~gammapy.data.DataStore`. You can see how to create
+one with the high level interface `~gammapy.analysis.Analysis` `here
+<notebooks/analysis_1.html#Setting-the-data-to-use>`__. You can also create it
+directly, see `here
+<notebooks/analysis_2.html#Defining-the-datastore-and-selecting-observations>`__.
 
-How to explore the IRFs of an observation?
-++++++++++++++++++++++++++++++++++++++++++
+Check IRFs
+++++++++++
 
-Gammapy offers a number of methods to explore the content of the various IRFs contained in an observation.
-This is usually done thanks to their `peek()` methods.
+Gammapy offers a number of methods to explore the content of the various IRFs
+contained in an observation. This is usually done thanks to their ``peek()``
+methods. See example for CTA `here <notebooks/cta.html#IRFs>`__ and for H.E.S.S.
+`here <notebooks/hess.html#DL3-DR1>`__.
 
-You can find `here <notebooks/cta.html#IRFs>`__ an example using the CTA 1DC dataset and
-`here <notebooks/hess.html#DL3-DR1>`__ an example using the H.E.S.S. DL3 DR1 data.
+Extract 1D spectra
+++++++++++++++++++
 
-Data reduction: spectra
------------------------
+The `~gammapy.analysis.Analysis` class can perform spectral extraction. The
+`~gammapy.analysis.AnalysisConfig` must be defined to produce '1d' datasets.
+Alternatively, you can follow the `spectrum extraction notebook
+<notebooks/spectrum_analysis.html>`__.
 
-How to extract 1D spectra?
-++++++++++++++++++++++++++
+Extract a lightcurve
+++++++++++++++++++++
 
-The `~gammapy.analysis.Analysis` class can perform spectral extraction. The `~gammapy.analysis.AnalysisConfig`
-must be defined to produce '1d' datasets.
+The `Light curve estimation <notebooks/light_curve.html>`__ tutorial shows how
+to extract a run-wise lightcurve.
 
-Alternatively, you can follow the `spectrum extraction notebook <notebooks/spectrum_analysis.html>`__.
+To perform an analysis in a time range smaller than that of an observation, it
+is necessary to filter the latter with its `select_time` method. This produces
+an new observation containing events in the specified time range. With the new
+`~gammapy.data.Observations` it is then possible to perform the usual data
+reduction which will produce datasets in the correct time range. The light curve
+extraction can then be performed as usual with the
+`~gammapy.time.LightCurveEstimator`. This is demonstrated in the `Light curve -
+Flare <notebooks/light_curve_flare.html>`__ tutorial.
 
-How to compute the cumulative significance of a source?
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Compute source significance
++++++++++++++++++++++++++++
 
-A classical plot in gamma-ray astronomy is the cumulative significance of a source as a function
-of observing time. In Gammapy, you can produce it with 1D (spectral) analysis. Once datasets are produced
-for a given ON region, you can access the total statistics with the `info_table(cumulative=True)` method
-of `~gammapy.modeling.Datasets`.
+Estimate the significance of a source, or more generally of an additional model
+component (such as e.g. a spectral line on top of a power-law spectrum), is done
+via a hypothesis test. You fit two models, with and without the extra source or
+component, then use the test statistic values from both fits to compute the
+significance or p-value. To obtain the test statistic, call
+`~gammapy.modeling.Dataset.stat_sum` for the model corresponding to your two
+hypotheses (or take this value from the print output when running the fit), and
+take the difference. Note that in Gammapy, the fit statistic is defined as ``S =
+- 2 * log(L)`` for likelihood ``L``, such that ``TS = S_1 - S_0``. See
+:ref:`overview_datasets` for an overview of fit statistics used.
 
-You can find an example usage `here <notebooks/spectrum_analysis.html#Source-statistic>`__.
-
-Data reduction: maps
---------------------
-
-..  How to build maps?
-    ++++++++++++++++++
-
-..  How to plot a excess map?
-    +++++++++++++++++++++++++
-
-..  How to overlay significance and excess on maps?
-    +++++++++++++++++++++++++++++++++++++++++++++++
-
-How to detect sources in a map?
+Compute cumulative significance
 +++++++++++++++++++++++++++++++
 
-Gammapy provides methods to perform source detection in a 2D map. First step is to produce
-a significance map, i.e. a map giving the probability that the flux measured at each position
-is a background fluctuation. For a `~gammapy.cube.MapDataset`, the class `~gammapy.detect.TSMapEstimator`
-can be used. A simple correlated Li & Ma significance can be used, in particular for ON-OFF datasets.
-The second step consists in applying a peak finer algorithm, such as `~gammapy.detect.find_peaks`.
+A classical plot in gamma-ray astronomy is the cumulative significance of a
+source as a function of observing time. In Gammapy, you can produce it with 1D
+(spectral) analysis. Once datasets are produced for a given ON region, you can
+access the total statistics with the ``info_table(cumulative=True)`` method of
+`~gammapy.modeling.Datasets`. See example `here
+<notebooks/spectrum_analysis.html#Source-statistic>`__.
 
-This is demonstrated in the `detect notebook <notebooks/detect.html>`__
+Detect sources in a map
++++++++++++++++++++++++
 
-How to compute the significance of a source?
-++++++++++++++++++++++++++++++++++++++++++++
+Gammapy provides methods to perform source detection in a 2D map. First step is
+to produce a significance map, i.e. a map giving the probability that the flux
+measured at each position is a background fluctuation. For a
+`~gammapy.cube.MapDataset`, the class `~gammapy.detect.TSMapEstimator` can be
+used. A simple correlated Li & Ma significance can be used, in particular for
+ON-OFF datasets. The second step consists in applying a peak finer algorithm,
+such as `~gammapy.detect.find_peaks`. This is demonstrated in the `Source
+detection tutorial <notebooks/detect.html>`__.
 
-Estimate the significance of a source, or more generally of an additional model component
-(such as e.g. a spectral line on top of a power-law spectrum), is done via a hypothesis test.
-You fit two models, with and without the extra source or component, then use the test statistic
-values from both fits to compute the significance or p-value.
+Astrophysical source modeling
++++++++++++++++++++++++++++++
 
-..  TODO: link to notebook
-    TODO: update this entry once https://github.com/gammapy/gammapy/issues/2149
-    and https://github.com/gammapy/gammapy/issues/1540 are resolved, linking to the documentation
-    developed there.
-
-
-Modeling and fitting
---------------------
-
-..  How to share a model between two datasets?
-    ++++++++++++++++++++++++++++++++++++++++++
-
-How to use Gammapy with astrophysical modeling packages?
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-It is possible to combine Gammapy with astrophysical modeling codes, if they provide a Python interface.
-Usually this requires some glue code to be written, e.g. `~gammapy.modeling.models.NaimaSpectralModel` is
-an example of a Gammapy wrapper class around the Naima spectral model and radiation classes, which then
-allows modeling and fitting of Naima models within Gammapy (e.g. using CTA, H.E.S.S. or Fermi-LAT data).
-
-
-.. How to add a user defined model?
-    ++++++++++++++++++++++++++++++++
-    **TODO: move content from spectrum_simulation.ipynb**
-
-How to extract a lightcurve?
-++++++++++++++++++++++++++++
-
-This is demonstrated in the following `notebook <notebooks/Light_curve.html>`__.
-
-How to create a light curve with time intervals shorter than observations?
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-To perform an analysis in a time range smaller than that of an observation, it is necessary to filter
-the latter with its `select_time` method. This produces an new observation containing events in the
-specified time range.
-
-With the new `~gammapy.data.Observations` it is then possible to perform the usual data reduction
-which will produce datasets in the correct time range. The light curve extraction can then be performed
-as usual with the `~gammapy.time.LightCurveEstimator`.
-
-This is demonstrated in the following `notebook <notebooks/Light_curve_flare.html>`__. In particular,
-the time selection is performed `here <notebooks/Light_curve_flare.html#Filter-the-observations-list-in-time-intervals>`__
-
-
-
-Other Ideas
------------
-
-If you think an entry is missing, please send us a request to add it.
+It is possible to combine Gammapy with astrophysical modeling codes, if they
+provide a Python interface. Usually this requires some glue code to be written,
+e.g. `~gammapy.modeling.models.NaimaSpectralModel` is an example of a Gammapy
+wrapper class around the Naima spectral model and radiation classes, which then
+allows modeling and fitting of Naima models within Gammapy (e.g. using CTA,
+H.E.S.S. or Fermi-LAT data).


### PR DESCRIPTION
This PR is an attempt to (hopefully) improve the How To page.

- Fix links to the two light curve notebooks (was "Light_curve", fixed to lower-case "light_curve" to match the filename). I guess this might not show up on some macOS where the filesystem is case-insensitive.
- Add info at the top: what is this page? link to overview and tutorials. Ask for user feedback.
- Shorten the headings
- Put one paragraph per HOWTO entry to have a shorter and more uniform page
- Re-order entries a bit: put the two significance entries together, and put the LC after the spec entry
- Remove uncommented entries. IMO we should first do a minimal viable version of the docs (e.g. write the `modeling.ipynb`, and then in 2020 and beyond this HOWTO can grow based on user feedback. Trying to document Gammapy there now with tons of entries isn't a good way to proceed IMO. First the RST and IPYNB pages throughout Gammapy need to be filled some more.
- For now, I've removed the category headings, meaning that each HOWTO entry shows up directly in the navigation bar. For the future, when this grows beyond 10 entries, I think we should add "tags" instead of putting each entry in a single category. E.g. the significance one could get a "modeling" and "statistics" tag, so that we don't have to put it under either the "modeling" or "statistics" heading, where half of the users don't find it because they look in the other category. People are familiar with tags from their Photos app, or scientific papers which have keywords, etc, and others are using it, e.g. http://learn.astropy.org/.
- Put more infos concerning fit statistic and TS to make the entry useful, needs further improvements, but that's the main info to explain that our likelihood contains the factor 2 already, and how to compute TS.

@registerrier @adonath - Thoughts?