### PR TITLE
Add numpy dependency for macOS on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
         - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa libgfortran regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES_OSX='Cython click numpy scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter iminuit'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
 
         # MacOS X tests
         - os: osx
-          env: PYTHON_VERSION=3.6 CMD='make test'
+          env: PYTHON_VERSION=3.7 CMD='make test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OSX
 
         # Run tests without optional dependencies


### PR DESCRIPTION
This PR is an attempt to address this fail:

https://travis-ci.org/gammapy/gammapy/jobs/620116799

```
Traceback (most recent call last):

  File "<string>", line 1, in <module>

  File "/Users/travis/miniconda/envs/test/lib/python3.6/site-packages/astropy/__init__.py", line 122, in <module>

    _check_numpy()

  File "/Users/travis/miniconda/envs/test/lib/python3.6/site-packages/astropy/__init__.py", line 117, in _check_numpy

    raise ImportError(msg)

ImportError: Numpy version 1.13.0 or later must be installed to use Astropy
```

Based on https://github.com/astropy/astropy/issues/9398 and https://github.com/astropy/astropy/pull/9405 and the comments by @pllim there I think maybe `numpy` isn't installed?

That's weird, looking at the full log I think Numpy and Astropy are installed!?
https://api.travis-ci.org/v3/job/620116799/log.txt

@pllim or @bsipocz as Astropy and CI wizards (witches?) - Any idea what's really going on here?

Is there a missing dependency of Astropy `conda-forge/osx-64::astropy-3.2.3-py36h0b31af3_0` on Numpy, or is the install of that version broken for some reason? We only see this issue on macOS, since ~ a week.