### PR TITLE
Add `MapDatasetEventSampler` event_list_meta() and run() method

### DIFF
--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -366,7 +366,9 @@ class EDispMap:
 
         sample_edisp = InverseCDFSampler(pdf_edisp, axis=1, random_state=random_state)
         pix_edisp = sample_edisp.sample_axis()
-        energy_reco = migra_axis.pix_to_coord(pix_edisp)
+        migra = migra_axis.pix_to_coord(pix_edisp)
+
+        energy_reco = map_coord["energy"] * migra
 
         return MapCoord.create({"skycoord": map_coord.skycoord, "energy": energy_reco})
 

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -253,17 +253,13 @@ class MapDatasetEventSampler:
         """
         # See: https://gamma-astro-data-formats.readthedocs.io/en/latest/events/events.html#mandatory-header-keywords
         meta = {}
-        # TODO: currently additional meta data is missing
 
-        meta["MJDREFI"] = int(dataset.gti.time_ref.mjd)
-        meta["MJDREFF"] = dataset.gti.time_ref.mjd % 1
-        meta["TIMEUNIT"] = "s"
-        meta["TIMESYS"] = "TT"
-        meta["TIMEREF"] = "LOCAL"
-        #         meta["DATE-OBS"] = dataset.gti.time_start.isot[0][0:10]
-        #         meta["DATE-END"] = dataset.gti.time_stop.isot[0][0:10]
-        meta["TIME-OBS"] = dataset.gti.time_start.isot[0]
-        meta["TIME-END"] = dataset.gti.time_stop.isot[0]
+        meta["HDUCLAS1"] = "EVENTS"
+        meta[
+            "HDUDOC"
+        ] = "https://github.com/open-gamma-ray-astro/gamma-astro-data-formats"
+        meta["HDUVER"] = "0.2"
+        meta["HDUCLASS"] = "GADF"
 
         meta["OBS_ID"] = observation.obs_id
 
@@ -276,27 +272,39 @@ class MapDatasetEventSampler:
         meta["ONTIME"] = observation.observation_time_duration.to("s").value
         meta["LIVETIME"] = observation.observation_live_time_duration.to("s").value
         meta["DEADC"] = observation.observation_dead_time_fraction
+
         meta["RA_PNT"] = observation.pointing_radec.icrs.ra.deg
         meta["DEC_PNT"] = observation.pointing_radec.icrs.dec.deg
 
         meta["EQUINOX"] = "J2000"
         meta["RADECSYS"] = "icrs"
         # TO DO: these keywords should be taken from the IRF of the dataset
-        meta["ORIGIN"] = ""
+        meta["ORIGIN"] = "Gammapy"
         meta["TELESCOP"] = ""
         meta["INSTRUME"] = ""
         #
-
         meta["CREATOR"] = "Gammapy {}".format(gammapy.__version__)
 
-        meta["OBSERVER"] = ""
-        meta["CREATED"] = ""
-        meta["OBJECT"] = ""
-        meta["RA_OBJ"] = ""
-        meta["DEC_OBJ"] = ""
-        meta["OBS_MODE"] = ""
-        meta["EV_CLASS"] = ""
-        meta["TELAPSE"] = ""
+        #        TO COMPLETE
+        #        meta["OBSERVER"] = ""
+        #        meta["CREATED"] = ""
+        #        meta["OBJECT"] = ""
+        #        meta["RA_OBJ"] = ""
+        #        meta["DEC_OBJ"] = ""
+        #        meta["OBS_MODE"] = ""
+        #        meta["EV_CLASS"] = ""
+        #        meta["TELAPSE"] = ""
+        #
+        #        meta["MJDREFI"] = int(dataset.gti.time_ref.mjd)
+        #        meta["MJDREFF"] = dataset.gti.time_ref.mjd % 1
+        #        meta["TIMEUNIT"] = "s"
+        #        meta["TIMESYS"] = "TT"
+        #        meta["TIMEREF"] = "LOCAL"
+        #        #         meta["DATE-OBS"] = dataset.gti.time_start.isot[0][0:10]
+        #        #         meta["DATE-END"] = dataset.gti.time_stop.isot[0][0:10]
+        #        meta["TIME-OBS"] = dataset.gti.time_start.isot[0]
+        #        meta["TIME-END"] = dataset.gti.time_stop.isot[0]
+        #
 
         meta["GEOLON"] = 0
         meta["GEOLAT"] = 0

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Simulate observations"""
 import numpy as np
+import copy
 import astropy.units as u
 from astropy.table import Table
 import gammapy
@@ -140,6 +141,7 @@ class MapDatasetEventSampler:
         """
         events_all = []
         for idx, evaluator in enumerate(dataset._evaluators):
+            evaluator = copy.deepcopy(evaluator)
             evaluator.edisp = None
             evaluator.psf = None
             npred = evaluator.compute_npred()
@@ -203,7 +205,7 @@ class MapDatasetEventSampler:
         )
 
         coords_reco = edisp_map.sample_coord(coord, self.random_state)
-        events.table["ENERGY"] = coords_reco["energy"] * u.TeV
+        events.table["ENERGY"] = coords_reco["energy"]
         return events
 
     def sample_psf(self, psf_map, events):

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -132,7 +132,8 @@ def test_sample_coord():
     coords_corrected = edisp_map.sample_coord(map_coord=coords)
 
     assert len(coords_corrected["energy"]) == 2
-    assert_allclose(coords_corrected["energy"], [0.9961658, 1.11269299], rtol=1e-5)
+    assert coords_corrected["energy"].unit == "TeV"
+    assert_allclose(coords_corrected["energy"].value, [0.9961658, 3.338079], rtol=1e-5)
 
 
 @pytest.mark.parametrize("position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"])

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -204,5 +204,5 @@ def test_mde_meta():
 
     assert meta["MJDREFI"] == 51544
     assert meta["MJDREFF"] == 0.0007428703684126958
-    assert meta["TSTOP"] == 29999.999999720603
+    assert meta["TSTOP"] == 35999.99999979045
     assert meta["RADECSYS"] == "icrs"

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -162,7 +162,7 @@ def test_mde_sample_edisp():
     events = sampler.sample_edisp(edisp_map, events)
 
     assert len(events.table) == 726
-    assert_allclose(events.table["ENERGY"][0], 1.0600765557667795, rtol=1e-5)
+    assert_allclose(events.table["ENERGY"][0], 10.2162, rtol=1e-5)
     assert events.table["ENERGY"].unit == "TeV"
 
     assert_allclose(events.table["RA_TRUE"][0], 266.3541109343822, rtol=1e-5)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -202,7 +202,7 @@ def test_mde_meta():
     events = test_mde_run()
     meta = events.table.meta
 
-    assert meta["MJDREFI"] == 51544
-    assert meta["MJDREFF"] == 0.0007428703684126958
-    assert meta["TSTOP"] == 35999.99999979045
+    assert meta["RA_PNT"] == 266.4049882865447
+    assert meta["ONTIME"] == 36000.0
+    assert meta["OBS_ID"] == 1001
     assert meta["RADECSYS"] == "icrs"

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -64,10 +65,11 @@ def test_simulate():
     assert_allclose(dataset.edisp.data.data[10, 10], 0.85944298, rtol=1e-5)
 
 
-def dataset_maker():
+@pytest.fixture(scope="session")
+def dataset():
     position = SkyCoord(0.0, 0.0, frame="galactic", unit="deg")
     energy_axis = MapAxis.from_bounds(
-        1, 100, nbin=30, unit="TeV", name="energy", interp="log"
+        1, 10, nbin=3, unit="TeV", name="energy", interp="log"
     )
 
     spatial_model = GaussianSpatialModel(
@@ -78,7 +80,7 @@ def dataset_maker():
     skymodel = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
 
     geom = WcsGeom.create(
-        skydir=position, binsz=0.02, width="5 deg", coordsys="GAL", axes=[energy_axis]
+        skydir=position, binsz=1, width="5 deg", coordsys="GAL", axes=[energy_axis]
     )
 
     t_min = 0 * u.s
@@ -95,87 +97,79 @@ def dataset_maker():
 
 
 @requires_data()
-def test_mde_sample_sources():
-    dataset = dataset_maker()
+def test_mde_sample_sources(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_sources(dataset=dataset)
 
-    assert len(events.table["ENERGY_TRUE"]) == 726
-    assert_allclose(events.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert len(events.table["ENERGY_TRUE"]) == 2407
+    assert_allclose(events.table["ENERGY_TRUE"][0], 2.245024, rtol=1e-5)
     assert events.table["ENERGY_TRUE"].unit == "TeV"
 
-    assert_allclose(events.table["RA_TRUE"][0], 266.3541109343822, rtol=1e-5)
+    assert_allclose(events.table["RA_TRUE"][0], 266.912888, rtol=1e-5)
     assert events.table["RA_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["DEC_TRUE"][0], -28.88356606406115, rtol=1e-5)
+    assert_allclose(events.table["DEC_TRUE"][0], -29.034641, rtol=1e-5)
     assert events.table["DEC_TRUE"].unit == "deg"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)
 
 
 @requires_data()
-def test_mde_sample_background():
-    dataset = dataset_maker()
+def test_mde_sample_background(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_background(dataset=dataset)
 
-    assert len(events.table["ENERGY"]) == 375084
-    assert_allclose(events.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
+    assert len(events.table["ENERGY"]) == 15
+    assert_allclose(events.table["ENERGY"][0], 1.894698, rtol=1e-5)
     assert events.table["ENERGY"].unit == "TeV"
 
-    assert_allclose(events.table["RA"][0], 265.7253792887848, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.454448, rtol=1e-5)
     assert events.table["RA"].unit == "deg"
 
-    assert_allclose(events.table["DEC"][0], -27.727581635186304, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -30.870316, rtol=1e-5)
     assert events.table["DEC"].unit == "deg"
 
     assert_allclose(events.table["MC_ID"][0], 0, rtol=1e-5)
 
 
 @requires_data()
-def test_mde_sample_psf():
-    psf_map = make_test_psfmap(0.1 * u.deg, shape="gauss")
-
-    dataset = dataset_maker()
+def test_mde_sample_psf(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_sources(dataset=dataset)
-    events = sampler.sample_psf(psf_map, events)
+    events = sampler.sample_psf(dataset.psf, events)
 
-    assert len(events.table) == 726
-    assert_allclose(events.table["ENERGY_TRUE"][0], 9.637228658895618, rtol=1e-5)
+    assert len(events.table) == 2407
+    assert_allclose(events.table["ENERGY_TRUE"][0], 2.245024, rtol=1e-5)
     assert events.table["ENERGY_TRUE"].unit == "TeV"
 
-    assert_allclose(events.table["RA"][0], 266.46418313134603, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.909362, rtol=1e-5)
     assert events.table["RA"].unit == "deg"
 
-    assert_allclose(events.table["DEC"][0], -28.85688796198139, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -29.031458, rtol=1e-5)
     assert events.table["DEC"].unit == "deg"
 
 
 @requires_data()
-def test_mde_sample_edisp():
-    edisp_map = make_edisp_map_test()
-
-    dataset = dataset_maker()
+def test_mde_sample_edisp(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_sources(dataset=dataset)
-    events = sampler.sample_edisp(edisp_map, events)
+    events = sampler.sample_edisp(dataset.edisp, events)
 
-    assert len(events.table) == 726
-    assert_allclose(events.table["ENERGY"][0], 10.2162, rtol=1e-5)
+    assert len(events.table) == 2407
+    assert_allclose(events.table["ENERGY"][0], 0.535733, rtol=1e-5)
     assert events.table["ENERGY"].unit == "TeV"
 
-    assert_allclose(events.table["RA_TRUE"][0], 266.3541109343822, rtol=1e-5)
+    assert_allclose(events.table["RA_TRUE"][0], 266.912888, rtol=1e-5)
     assert events.table["RA_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["DEC_TRUE"][0], -28.88356606406115, rtol=1e-5)
+    assert_allclose(events.table["DEC_TRUE"][0], -29.034641, rtol=1e-5)
     assert events.table["DEC_TRUE"].unit == "deg"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)
 
 
 @requires_data()
-def test_mde_run():
+def test_mde_run(dataset):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
@@ -185,21 +179,14 @@ def test_mde_run():
         obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
     )
 
-    dataset = dataset_maker()
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.run(dataset=dataset, observation=obs)
 
-    assert len(events.table) == 375764
-    assert_allclose(events.table["ENERGY"][0], 2.1613281656472028, rtol=1e-5)
-    assert_allclose(events.table["RA"][0], 265.7253792887848, rtol=1e-5)
-    assert_allclose(events.table["DEC"][0], -27.727581635186304, rtol=1e-5)
+    assert len(events.table) == 2349
+    assert_allclose(events.table["ENERGY"][0], 1.894698, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.454448, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -30.870316, rtol=1e-5)
 
-    return events
-
-
-@requires_data()
-def test_mde_meta():
-    events = test_mde_run()
     meta = events.table.meta
 
     assert meta["RA_PNT"] == 266.4049882865447


### PR DESCRIPTION
This PR aims at adding the methods `run()` and `event_list_meta()` to the `~gammapy.cube.MapDatasetEventSampler` class. 
The `run` method samples events from the background and sources, and applies IRF corrections to the latters. The Edisp can be switched off if necessary. The output is a `~gammapy.data.EventList` object.
Metadata information are stored through the `event_list_meta()` method.