### PR TITLE
Changed light flare notebook to PKS 2155 flare.

### DIFF
--- a/tutorials/light_curve_flare.ipynb
+++ b/tutorials/light_curve_flare.ipynb
@@ -6,13 +6,32 @@
    "source": [
     "# Light curve - Flare\n",
     "\n",
-    "To see the general presentation on our light curve estimator, please refer to the [light curve notebook](light_curve.ipynb)\n",
+    "## Prerequisites:\n",
     "\n",
-    "Here we present the way to compute a light curve on time intervals smaller than the duration of an observation.\n",
+    "- Understanding of how th elight curve estimator works, please refer to the [light curve notebook](light_curve.ipynb).\n",
     "\n",
-    "We will use the Crab nebula observations from the H.E.S.S. first public test data release. We will use time intervals of 15 minutes duration. \n",
+    "## Context\n",
     "\n",
-    "The first important step is to filter the observations to produce shorter observations for each time bin. We can then perform data reduction as before and then estimate the light curve in all of those time bins.\n",
+    "Frequently, especially when studying flares of bright sources, it is necessary to explore the time behaviour of a source on short time scales, in particular on time scales shorter than observing runs.\n",
+    "\n",
+    "A typical example is given by the flare of PKS 2155-304 during the night from July 29 to 30 2006. See the [following article](https://ui.adsabs.harvard.edu/abs/2009A%26A...502..749A/abstract).\n",
+    "\n",
+    "**Objective: Compute the light curve of a PKS 2155 flare on 5 minutes time intervals, i.e. smaller than the duration of individual observations.**\n",
+    "\n",
+    "## Proposed approach:\n",
+    "\n",
+    "We have seen in the general presentation of the light curve estimator, see [light curve notebook](light_curve.ipynb), Gammapy produces datasets in a given time interval, by default that of the parent observation. To be able to produce datasets on smaller time steps, it is necessary to split the observations into the required time intervals. \n",
+    "\n",
+    "This is easily performed with the `select_time` method of `~gammapy.Observations`. If you pass it a list of time intervals it will produce a list of time filtered observations in a new `~gammapy.Observations` object. Data reduction can then be performed and will result in datasets defined on the required time intervals and light curve estimation can proceed directly.\n",
+    "\n",
+    "In summary, we have to:\n",
+    "- Select relevant `~gammapy.data.Observations` from the `~gammapy.data.DataStore`\n",
+    "- Apply the time selection in our predefined time intervals to obtain a new `~gammapy.data.Observations`\n",
+    "- Perform the data reduction (in 1D or 3D)\n",
+    "- Define the source model\n",
+    "- Extract the light curve from the reduced dataset\n",
+    "\n",
+    "Here, we will use the PKS 2155-304 observations from the H.E.S.S. first public test data release. We will use time intervals of 5 minutes duration. We use here the intermediate API.\n",
     "\n",
     "## Setup \n",
     "\n",
@@ -27,6 +46,7 @@
    "source": [
     "%matplotlib inline\n",
     "import astropy.units as u\n",
+    "import numpy as np\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.time import Time\n",
     "from regions import CircleSkyRegion\n",
@@ -68,7 +88,7 @@
    "source": [
     "## Select the data\n",
     "\n",
-    "We look for relevant observations in the datastore."
+    "We first set the datastore."
    ]
   },
   {
@@ -77,10 +97,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")\n",
-    "mask = data_store.obs_table[\"TARGET_NAME\"] == \"Crab\"\n",
-    "obs_ids = data_store.obs_table[\"OBS_ID\"][mask].data\n",
-    "crab_obs = data_store.get_observations(obs_ids)"
+    "data_store = DataStore.from_dir(\"$GAMMAPY_DATA/hess-dl3-dr1/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we select observations within 2 degrees of PKS 2155-304. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_position = SkyCoord(\n",
+    "    329.71693826 * u.deg, -30.2255890 * u.deg, frame=\"icrs\"\n",
+    ")\n",
+    "selection = dict(\n",
+    "    type=\"sky_circle\",\n",
+    "    frame=\"icrs\",\n",
+    "    lon=target_position.ra,\n",
+    "    lat=target_position.dec,\n",
+    "    radius=2 * u.deg,\n",
+    ")\n",
+    "obs_ids = data_store.obs_table.select_observations(selection)[\"OBS_ID\"]\n",
+    "observations = data_store.get_observations(obs_ids)\n",
+    "print(f\"Number of selected observations : {len(observations)}\")"
    ]
   },
   {
@@ -97,15 +142,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "t0 = Time(\"2006-07-29T20:30\")\n",
+    "duration = 10 * u.min\n",
+    "n_time_bins = 35\n",
+    "times = t0 + np.arange(n_time_bins) * duration\n",
     "time_intervals = [\n",
-    "    [\"2004-12-04T22:00\", \"2004-12-04T22:15\"],\n",
-    "    [\"2004-12-04T22:15\", \"2004-12-04T22:30\"],\n",
-    "    [\"2004-12-04T22:30\", \"2004-12-04T22:45\"],\n",
-    "    [\"2004-12-04T22:45\", \"2004-12-04T23:00\"],\n",
-    "    [\"2004-12-04T23:00\", \"2004-12-04T23:15\"],\n",
-    "    [\"2004-12-04T23:15\", \"2004-12-04T23:30\"],\n",
+    "    Time([tstart, tstop]) for tstart, tstop in zip(times[:-1], times[1:])\n",
     "]\n",
-    "time_intervals = [Time(_) for _ in time_intervals]"
+    "print(time_intervals[0].mjd)"
    ]
   },
   {
@@ -125,9 +169,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "observations = crab_obs.select_time(time_intervals)\n",
+    "short_observations = observations.select_time(time_intervals)\n",
     "# check that observations have been filtered\n",
-    "print(observations[3].gti)"
+    "print(\n",
+    "    f\"Number of observations after time filtering: {len(short_observations)}\\n\"\n",
+    ")\n",
+    "print(short_observations[1].gti)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, we have now observations of duration equal to the chosen time step.\n",
+    "\n",
+    "Now data reduction and light curve extraction can proceed exactly as before."
    ]
   },
   {
@@ -138,7 +194,7 @@
     "\n",
     "Here we will perform the data reduction in 1D with reflected regions.\n",
     "\n",
-    "Beware, with small time intervals the background normalization with OFF regions might become problematic."
+    "*Beware, with small time intervals the background normalization with OFF regions might become problematic.*"
    ]
   },
   {
@@ -147,7 +203,9 @@
    "source": [
     "### Defining the geometry\n",
     "\n",
-    "We need to define the ON extraction region. We will keep the same reco and true energy axes as in 3D."
+    "We define the energy axes. As usual, the true energy axis has to cover a wider range to ensure a good coverage of the measured energy range chosen. \n",
+    "\n",
+    "We need to define the ON extraction region. Its size follows typical spectral extraction regions for HESS analyses."
    ]
   },
   {
@@ -157,10 +215,9 @@
    "outputs": [],
    "source": [
     "# Target definition\n",
-    "e_reco = MapAxis.from_energy_bounds(0.1, 40, 100, \"TeV\").edges\n",
-    "e_true = MapAxis.from_energy_bounds(0.05, 100, 100, \"TeV\").edges\n",
+    "e_reco = MapAxis.from_energy_bounds(0.4, 20, 10, \"TeV\").edges\n",
+    "e_true = MapAxis.from_energy_bounds(0.1, 40, 20, \"TeV\").edges\n",
     "\n",
-    "target_position = SkyCoord(83.63308 * u.deg, 22.01450 * u.deg, frame=\"icrs\")\n",
     "on_region_radius = Angle(\"0.11 deg\")\n",
     "on_region = CircleSkyRegion(center=target_position, radius=on_region_radius)"
    ]
@@ -202,13 +259,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "datasets = []\n",
     "\n",
     "dataset_empty = SpectrumDataset.create(\n",
     "    e_reco=e_reco, e_true=e_true, region=on_region\n",
     ")\n",
     "\n",
-    "for obs in observations:\n",
+    "for obs in short_observations:\n",
     "    dataset = dataset_maker.run(dataset_empty, obs)\n",
     "\n",
     "    dataset_on_off = bkg_maker.run(dataset, obs)\n",
@@ -220,7 +278,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Define the Model\n",
+    "## Define the Model\n",
+    "\n",
+    "The actual flux will depend on the spectral shape assumed. For simplicity, we use the power law spectral model of index 3.4 used in the [reference paper](https://ui.adsabs.harvard.edu/abs/2009A%26A...502..749A/abstract).\n",
     "\n",
     "Here we use only a spectral model in the `~gammapy.modeling.models.SkyModel` object."
    ]
@@ -232,14 +292,14 @@
    "outputs": [],
    "source": [
     "spectral_model = PowerLawSpectralModel(\n",
-    "    index=2.702,\n",
-    "    amplitude=4.712e-11 * u.Unit(\"1 / (cm2 s TeV)\"),\n",
+    "    index=3.4,\n",
+    "    amplitude=2e-11 * u.Unit(\"1 / (cm2 s TeV)\"),\n",
     "    reference=1 * u.TeV,\n",
     ")\n",
     "spectral_model.parameters[\"index\"].frozen = False\n",
     "\n",
     "sky_model = SkyModel(\n",
-    "    spatial_model=None, spectral_model=spectral_model, name=\"crab\"\n",
+    "    spatial_model=None, spectral_model=spectral_model, name=\"pks2155\"\n",
     ")"
    ]
   },
@@ -247,7 +307,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We affect to each dataset it spectral model"
+    "### Assign to model to all datasets\n",
+    "\n",
+    "We assign each dataset its spectral model"
    ]
   },
   {
@@ -261,12 +323,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "lc_maker_1d = LightCurveEstimator(datasets, source=\"crab\")"
+    "## Extract the light curve\n",
+    "\n",
+    "We first create the `~gammapy.time.LightCurveEstimator` for the list of datasets we just produced. We give the estimator the name of the source component to be fitted."
    ]
   },
   {
@@ -275,7 +337,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lc_1d = lc_maker_1d.run(e_ref=1 * u.TeV, e_min=1.0 * u.TeV, e_max=10.0 * u.TeV)"
+    "lc_maker_1d = LightCurveEstimator(datasets, source=\"pks2155\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now perform the light curve extraction itself. To compare with the [reference paper](https://ui.adsabs.harvard.edu/abs/2009A%26A...502..749A/abstract), we select the 0.7-20 TeV range."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "lc_1d = lc_maker_1d.run(e_ref=1 * u.TeV, e_min=0.7 * u.TeV, e_max=20.0 * u.TeV)"
    ]
   },
   {
@@ -293,13 +372,6 @@
    "source": [
     "lc_1d.plot(marker=\"o\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
… decription.

<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request modifies the light_curve_flare.ipynb notebook.
- The data used are now those of PKS 2155-304. In the user test, people were confused to see Crab data in a light curve dedicated to flare analysis. Using the July 2006 flare data is therefore more explicit and better shows the capabilities of gammapy. 
- More physical context is given. The introduction explicitly states what the objective is and details the different steps required to reach it.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This runs more slowly than the previous version, but it should still be acceptable. Locally, it changed from 6.7s to 24.3s