### PR TITLE
Removing hard coded true energy axis in 1D HLI

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -304,14 +304,7 @@ class Analysis:
         bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
         safe_mask_maker = SafeMaskMaker(methods=["aeff-default", "aeff-max"])
 
-        # TODO : introduce config validation?
-#        try:
-        print(datasets_settings.geom.axes.energy_true.min)
         e_true = self._make_energy_axis(datasets_settings.geom.axes.energy_true).edges
-
- #       except:
- #           e_true = e_reco
- #           log.WARNING("True energy binning not properly set. Using reco energy binning.")
 
         reference = SpectrumDataset.create(
             e_reco=e_reco, e_true=e_true, region=on_region

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -304,8 +304,17 @@ class Analysis:
         bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
         safe_mask_maker = SafeMaskMaker(methods=["aeff-default", "aeff-max"])
 
+        # TODO : introduce config validation?
+#        try:
+        print(datasets_settings.geom.axes.energy_true.min)
+        e_true = self._make_energy_axis(datasets_settings.geom.axes.energy_true).edges
+
+ #       except:
+ #           e_true = e_reco
+ #           log.WARNING("True energy binning not properly set. Using reco energy binning.")
+
         reference = SpectrumDataset.create(
-            e_reco=e_reco, e_true=np.logspace(-2, 2.5, 109) * u.TeV, region=on_region
+            e_reco=e_reco, e_true=e_true, region=on_region
         )
 
         datasets = []

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -195,33 +195,6 @@ def test_geom_analysis_1d():
     assert_allclose(analysis.datasets[0].aeff.energy.edges[0].to_value('TeV'), 0.03)
     assert_allclose(analysis.datasets[0].aeff.energy.edges[-1].to_value('TeV'), 100)
 
-@requires_data()
-def test_geom_analysis_1d_no_etrue():
-    cfg = """
-    observations:
-        datastore: $GAMMAPY_DATA/hess-dl3-dr1
-        obs_ids: [23523]
-    datasets:
-        type: 1d
-        background:
-            method: reflected
-        on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.11 deg}
-        geom:
-            axes:
-                energy: {min: 0.1 TeV, max: 30 TeV, nbins: 20}
-    """
-    config = get_example_config("1d")
-    analysis = Analysis(config)
-    analysis.update_config(cfg)
-    analysis.get_observations()
-    analysis.get_datasets()
-
-#    print(analysis.datasets[0].counts.energy.edges)
-#    print(analysis.datasets[0].aeff.energy.edges)
-    assert len(analysis.datasets[0].aeff.energy.center) == 20
-    assert_allclose(analysis.datasets[0].aeff.energy.edges[0].to_value('TeV'), 0.1)
-    assert_allclose(analysis.datasets[0].aeff.energy.edges[-1].to_value('TeV'), 30)
-
 
 @requires_data()
 def test_exclusion_region(tmp_path):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the hard coded value of the true energy bins in `Analysis._spectrum_extraction`. A test has been added to check that true bins are correctly set.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
this should be OK to merge. All tests pass locally.