### PR TITLE
Remove GAMMAPY_EXTRA from variables tested in gammapy info

### DIFF
--- a/gammapy/scripts/info.py
+++ b/gammapy/scripts/info.py
@@ -35,7 +35,7 @@ GAMMAPY_DEPENDENCIES = [
     "parfive",
 ]
 
-GAMMAPY_ENV_VARIABLES = ["GAMMAPY_DATA", "GAMMAPY_EXTRA"]
+GAMMAPY_ENV_VARIABLES = ["GAMMAPY_DATA"]
 
 
 @click.command(name="info")


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request remove GAMMAPY_EXTRA from the list of environment variables tested in `gammapy info`.
This comes from comments received during December user test.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
Ready