### PR TITLE
Allow interpolation of 1 binned axes in ScaledRegularGridInterpolator

### DIFF
--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -391,7 +391,7 @@ class EDispMap:
         migra_axis = migra_axis or MIGRA_AXIS_DEFAULT
 
         geom = WcsGeom.create(
-            npix=(4, 2), proj="CAR", binsz=90, axes=[migra_axis, energy_axis_true]
+            npix=(2, 1), proj="CAR", binsz=180, axes=[migra_axis, energy_axis_true]
         )
 
         return cls.from_geom(geom)

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -232,9 +232,8 @@ class PSFMap:
         psf_values = u.Quantity(data[:, :, 0, 0], unit=self.psf_map.unit, copy=False)
 
         if self.exposure_map is not None:
-            exposure_3d = self.exposure_map.slice_by_idx({"theta": 0})
-            coords = {"skycoord": position, "energy": energy.reshape((-1, 1, 1))}
-            data = exposure_3d.interp_by_coord(coords).squeeze()
+            coords = {"skycoord": position, "energy": energy.reshape((-1, 1, 1)), "theta": 0 * u.deg}
+            data = self.exposure_map.interp_by_coord(coords).squeeze()
             exposure = data * self.exposure_map.unit
         else:
             exposure = None

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -409,7 +409,7 @@ class PSFMap:
         rad_axis = MapAxis.from_nodes(table_psf.rad, name="theta")
 
         geom = WcsGeom.create(
-            npix=(4, 2), proj="CAR", binsz=180, axes=[rad_axis, energy_axis]
+            npix=(2, 1), proj="CAR", binsz=180, axes=[rad_axis, energy_axis]
         )
         coords = geom.get_coord()
 

--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -219,27 +219,21 @@ class PSFMap:
                 "EnergyDependentTablePSF can be extracted at one single position only."
             )
 
-        # axes ordering fixed. Could be changed.
-        pix_ener = np.arange(self.psf_map.geom.axes[1].nbin)
-        pix_rad = np.arange(self.psf_map.geom.axes[0].nbin)
+        energy = self.psf_map.geom.get_axis_by_name("energy").center
+        rad = self.psf_map.geom.get_axis_by_name("theta").center
 
-        # Convert position to pixels
-        pix_lon, pix_lat = self.psf_map.geom.to_image().coord_to_pix(position)
+        coords = {
+            "skycoord": position,
+            "energy": energy.reshape((-1, 1, 1, 1)),
+            "theta": rad.reshape((1, -1, 1, 1))
+        }
 
-        # Build the pixels tuple
-        pix = np.meshgrid(pix_lon, pix_lat, pix_rad, pix_ener)
-
-        # Interpolate in the PSF map. Squeeze to remove dimensions of length 1
-        psf_values = np.squeeze(
-            self.psf_map.interp_by_pix(pix) * u.Unit(self.psf_map.unit)
-        )
-
-        energies = self.psf_map.geom.axes[1].center
-        rad = self.psf_map.geom.axes[0].center
+        data = self.psf_map.interp_by_coord(coords)
+        psf_values = u.Quantity(data[:, :, 0, 0], unit=self.psf_map.unit, copy=False)
 
         if self.exposure_map is not None:
             exposure_3d = self.exposure_map.slice_by_idx({"theta": 0})
-            coords = {"skycoord": position, "energy": energies.reshape((-1, 1, 1))}
+            coords = {"skycoord": position, "energy": energy.reshape((-1, 1, 1))}
             data = exposure_3d.interp_by_coord(coords).squeeze()
             exposure = data * self.exposure_map.unit
         else:
@@ -247,7 +241,7 @@ class PSFMap:
 
         # Beware. Need to revert rad and energies to follow the TablePSF scheme.
         return EnergyDependentTablePSF(
-            energy=energies, rad=rad, psf_value=psf_values.T, exposure=exposure
+            energy=energy, rad=rad, psf_value=psf_values, exposure=exposure
         )
 
     def get_psf_kernel(self, position, geom, max_radius=None, factor=4):

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -603,3 +603,13 @@ def test_map_sampling():
     assert coords["lon"].unit == "deg"
     assert coords["lat"].unit == "deg"
     assert coords["energy"].unit == "TeV"
+
+
+def test_map_interp_one_bin():
+    m = WcsNDMap.create(npix=(2, 1))
+    m.data = np.array([1, 2])
+
+    coords = {"lon": 0, "lat": 0}
+    data = m.interp_by_coord(coords)
+    assert_allclose(data, 1.5)
+

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -607,9 +607,11 @@ def test_map_sampling():
 
 def test_map_interp_one_bin():
     m = WcsNDMap.create(npix=(2, 1))
-    m.data = np.array([1, 2])
+    m.data = np.array([[1, 2]])
 
-    coords = {"lon": 0, "lat": 0}
+    coords = {"lon": 0, "lat": [0, 0]}
     data = m.interp_by_coord(coords)
+
+    assert data.shape == (2,)
     assert_allclose(data, 1.5)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request does a few minor modifications to simplify the extraction of PSF kernels:
- Simply implementation of `PSFMap.get_energy_depedent_table_psf()` a bit
- Use nearest neighbour interpolation in the `ScaledRegularGridInterpolator` for axes with dimension 1. This allows to extract `PSFKernel` objects for pdf maps with a single energy or Lon / lat bin.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
