### PR TITLE
Add FoVBackgroundMaker class

### DIFF
--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -8,4 +8,5 @@ from .make import *
 from .psf_kernel import *
 from .psf_map import *
 from .ring import *
+from .fov import *
 from .simulate import *

--- a/gammapy/cube/__init__.py
+++ b/gammapy/cube/__init__.py
@@ -4,9 +4,9 @@ from .background import *
 from .edisp_map import *
 from .exposure import *
 from .fit import *
+from .fov import *
 from .make import *
 from .psf_kernel import *
 from .psf_map import *
 from .ring import *
-from .fov import *
 from .simulate import *

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -1,10 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """FoV background estimation."""
+import logging
 from gammapy.maps import Map
 from gammapy.modeling import Fit
 
 __all__ = ["FoVBackgroundMaker"]
 
+log = logging.getLogger(__name__)
 
 class FoVBackgroundMaker:
     """Normalize template background on the whole field-of-view.
@@ -43,7 +45,7 @@ class FoVBackgroundMaker:
         fit = Fit([dataset])
         fit_result = fit.run()
         if fit_result.success == False:
-            print("FoVBackgroundMaker failed. No fit convergence.")
+            log.info("FoVBackgroundMaker failed. No fit convergence for {dataset.name}.")
 
         dataset.mask_fit = mask_fit
         return dataset

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -29,7 +29,12 @@ class FoVBackgroundMaker:
 
         """
         mask_safe = dataset.mask_safe
-        
+
         # Here we assume that the model is only the background model
         # TODO : freeze all model components not related to background model?
         fit = Fit([dataset])
+        fit_result = fit.run()
+        if fit_result.success == False:
+            print("FoVBackgroundMaker failed. No fit convergence.")
+
+        return dataset

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""FoV background estimation."""
+import numpy as np
+from astropy.convolution import Ring2DKernel, Tophat2DKernel
+from astropy.coordinates import Angle
+from gammapy.cube.fit import MapDatasetOnOff
+from gammapy.maps import Map, scale_cube
+
+__all__ = ["FoVBackgroundMaker"]
+
+
+class FoVBackgroundMaker:
+    """Normalize template background on the whole field-of-view.
+
+    Parameters
+    ----------
+    exclusion_mask : `~gammapy.maps.WcsNDMap`
+        Exclusion mask
+    """
+    def __init__(self, exclusion_mask=None):
+        self.exclusion_mask = exclusion_mask
+
+    def run(self, dataset):
+        """Run FoV background maker.
+
+        Fit the background model norm
+
+        Parameters
+        ----------
+        dataset : `~gammapy.cube.fit.MapDataset`
+            Input map dataset.
+
+        """
+         

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -98,11 +98,11 @@ class FoVBackgroundMaker:
 
         if count_tot <= 0.0:
             log.info(
-                "FoVBackgroundMaker failed. No counts found outside exlcusion mask for {dataset.name}."
+                f"FoVBackgroundMaker failed. No counts found outside exclusion mask for {dataset.name}."
             )
         elif bkg_tot <= 0.0:
             log.info(
-                "FoVBackgroundMaker failed. No positive background found outside exlcusion mask for {dataset.name}."
+                f"FoVBackgroundMaker failed. No positive background found outside exclusion mask for {dataset.name}."
             )
         else:
             scale = count_tot / bkg_tot

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -30,7 +30,7 @@ class FoVBackgroundMaker:
             self.method = method
         else:
             raise ValueError(
-                f"{method} is not a correct method for FoVBackgroundMaker."
+                f"Incorrect method for FoVBackgroundMaker: {method}."
             )
         self.exclusion_mask = exclusion_mask
 

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -1,10 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """FoV background estimation."""
 import numpy as np
-from astropy.convolution import Ring2DKernel, Tophat2DKernel
-from astropy.coordinates import Angle
-from gammapy.cube.fit import MapDatasetOnOff
-from gammapy.maps import Map, scale_cube
+from gammapy.modeling import Fit
 
 __all__ = ["FoVBackgroundMaker"]
 
@@ -31,4 +28,8 @@ class FoVBackgroundMaker:
             Input map dataset.
 
         """
-         
+        mask_safe = dataset.mask_safe
+        
+        # Here we assume that the model is only the background model
+        # TODO : freeze all model components not related to background model?
+        fit = Fit([dataset])

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """FoV background estimation."""
-import numpy as np
+from gammapy.maps import Map
 from gammapy.modeling import Fit
 
 __all__ = ["FoVBackgroundMaker"]
@@ -28,7 +28,15 @@ class FoVBackgroundMaker:
             Input map dataset.
 
         """
-        mask_safe = dataset.mask_safe
+        mask_fit = dataset.mask_fit
+
+        mask_map = Map.from_geom(dataset.counts.geom)
+        if self.exclusion_mask is not None:
+            coords = dataset.counts.geom.get_coord()
+            vals = self.exclusion_mask.get_by_coord(coords)
+            mask_map.data += vals
+
+        dataset.mask_fit = mask_map.data.astype('bool')
 
         # Here we assume that the model is only the background model
         # TODO : freeze all model components not related to background model?
@@ -37,4 +45,5 @@ class FoVBackgroundMaker:
         if fit_result.success == False:
             print("FoVBackgroundMaker failed. No fit convergence.")
 
+        dataset.mask_fit = mask_fit
         return dataset

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -73,7 +73,7 @@ class FoVBackgroundMaker:
         # TODO : freeze all model components not related to background model?
         fit = Fit([dataset])
         fit_result = fit.run()
-        if fit_result.success == False:
+        if fit_result.success is False:
             log.info(
                 f"FoVBackgroundMaker failed. No fit convergence for {dataset.name}."
             )

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -48,7 +48,7 @@ def exclusion_mask(geom):
 
 
 @pytest.fixture(scope="session")
-def test_dataset(geom, observation):
+def obs_dataset(geom, observation):
     safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
     map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
 
@@ -66,58 +66,58 @@ def test_fov_bkg_maker_incorrect_method():
 
 
 @requires_data()
-def test_fov_bkg_maker_scale(test_dataset, exclusion_mask):
+def test_fov_bkg_maker_scale(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)
 
-    my_dataset = test_dataset.copy()
-    dataset = fov_bkg_maker.run(my_dataset)
+    test_dataset = obs_dataset.copy()
+    dataset = fov_bkg_maker.run(test_dataset)
 
     assert_allclose(dataset.background_model.norm.value, 0.83078, rtol=1e-4)
     assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
 
 
 @requires_data()
-def test_fov_bkg_maker_fit(test_dataset, exclusion_mask):
+def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 
-    my_dataset = test_dataset.copy()
-    dataset = fov_bkg_maker.run(my_dataset)
+    test_dataset = obs_dataset.copy()
+    dataset = fov_bkg_maker.run(test_dataset)
 
     assert_allclose(dataset.background_model.norm.value, 0.8307, rtol=1e-4)
     assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
 
 
 @requires_data()
-def test_fov_bkg_maker_fit_with_tilt(test_dataset, exclusion_mask):
+def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 
-    my_dataset = test_dataset.copy()
-    my_dataset.background_model.tilt.frozen = False
-    dataset = fov_bkg_maker.run(my_dataset)
+    test_dataset = obs_dataset.copy()
+    test_dataset.background_model.tilt.frozen = False
+    dataset = fov_bkg_maker.run(test_dataset)
 
     assert_allclose(dataset.background_model.norm.value, 0.9034, rtol=1e-4)
     assert_allclose(dataset.background_model.tilt.value, 0.0728, rtol=1e-4)
 
 
 @requires_data()
-def test_fov_bkg_maker_fit_fail(test_dataset, exclusion_mask):
+def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 
-    my_dataset = test_dataset.copy()
+    test_dataset = obs_dataset.copy()
     # Putting negative background model to prevent convergence
-    my_dataset.background_model.map.data *= -1
-    dataset = fov_bkg_maker.run(my_dataset)
+    test_dataset.background_model.map.data *= -1
+    dataset = fov_bkg_maker.run(test_dataset)
 
     assert_allclose(dataset.background_model.norm.value, 1, rtol=1e-4)
 
 
 @requires_data()
-def test_fov_bkg_maker_scale_fail(test_dataset, exclusion_mask):
+def test_fov_bkg_maker_scale_fail(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)
 
-    my_dataset = test_dataset.copy()
+    test_dataset = obs_dataset.copy()
     # Putting negative background model to prevent correct scaling
-    my_dataset.background_model.map.data *= -1
-    dataset = fov_bkg_maker.run(my_dataset)
+    test_dataset.background_model.map.data *= -1
+    dataset = fov_bkg_maker.run(test_dataset)
 
     assert_allclose(dataset.background_model.norm.value, 1, rtol=1e-4)

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -42,6 +42,10 @@ def exclusion_mask(geom):
     return exclusion
 
 
+def test_fov_bkg_maker_incorrect_method():
+    with pytest.raises(ValueError):
+        FoVBackgroundMaker(method="bad")
+
 @requires_data()
 def test_fov_bkg_maker_scale(geom, observations, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -4,7 +4,8 @@ from numpy.testing import assert_allclose
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
 from gammapy.cube import MapDataset
-from gammapy.cube.make import MapDatasetMaker, SafeMaskMaker, FoVBackgroundMaker
+from gammapy.cube.make import MapDatasetMaker, SafeMaskMaker
+from gammapy.cube.fov import FoVBackgroundMaker
 from gammapy.data import DataStore
 from gammapy.maps import MapAxis, WcsGeom, WcsNDMap
 from gammapy.utils.testing import requires_data
@@ -56,12 +57,13 @@ def test_fov_bkg_maker(geom, observations, exclusion_mask):
         dataset = fov_bkg_maker.run(dataset)
         datasets.append(dataset)
 
-    mask = dataset.mask_safe
-    assert_allclose(datasets[0].counts_off.data[mask].sum(), 2511333)
-    assert_allclose(datasets[1].counts_off.data[mask].sum(), 2143577.0)
-    assert_allclose(datasets[0].acceptance_off.data[mask].sum(), 2961300, rtol=1e-5)
-    assert_allclose(datasets[1].acceptance_off.data[mask].sum(), 2364657.2, rtol=1e-5)
-    assert_allclose(datasets[0].alpha.data[0][100][100], 0.00063745599, rtol=1e-5)
+#    mask = dataset.mask_safe
+#    assert_allclose(datasets[0].counts_off.data[mask].sum(), 2511333)
+#    assert_allclose(datasets[1].counts_off.data[mask].sum(), 2143577.0)
+#    assert_allclose(datasets[0].acceptance_off.data[mask].sum(), 2961300, rtol=1e-5)
+#    assert_allclose(datasets[1].acceptance_off.data[mask].sum(), 2364657.2, rtol=1e-5)
+    assert_allclose(datasets[0].background_model.norm.value, 0.98, rtol=1e-2)
     assert_allclose(
         datasets[0].exposure.data[0][100][100], 806254444.8480084, rtol=1e-5
     )
+    assert 1==0

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -1,0 +1,67 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+from numpy.testing import assert_allclose
+from astropy.coordinates import Angle, SkyCoord
+from regions import CircleSkyRegion
+from gammapy.cube import MapDataset
+from gammapy.cube.make import MapDatasetMaker, SafeMaskMaker, FoVBackgroundMaker
+from gammapy.data import DataStore
+from gammapy.maps import MapAxis, WcsGeom, WcsNDMap
+from gammapy.utils.testing import requires_data
+
+@pytest.fixture(scope="session")
+def observations():
+    """Example observation list for testing."""
+    datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
+    obs_ids = [23523, 23526]
+    return datastore.get_observations(obs_ids)
+
+
+@pytest.fixture(scope="session")
+def geom():
+    energy_axis = MapAxis.from_edges([1, 10], unit="TeV", name="ENERGY", interp="log")
+    return WcsGeom.create(
+        skydir=SkyCoord(83.633, 22.014, unit="deg"),
+        binsz=0.02,
+        width=(10, 10),
+        coordsys="GAL",
+        proj="CAR",
+        axes=[energy_axis],
+    )
+
+
+@pytest.fixture(scope="session")
+def exclusion_mask(geom):
+    """Example mask for testing."""
+    pos = SkyCoord(83.633, 22.014, unit="deg", frame="icrs")
+    region = CircleSkyRegion(pos, Angle(0.15, "deg"))
+    exclusion = WcsNDMap.from_geom(geom)
+    exclusion.data = geom.region_mask([region], inside=False)
+    return exclusion
+
+@requires_data()
+def test_fov_bkg_maker(geom, observations, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(exclusion_mask=exclusion_mask)
+    safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
+    map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
+
+    reference = MapDataset.create(geom)
+    datasets = []
+
+    for obs in observations:
+        cutout = reference.cutout(obs.pointing_radec, width="4 deg")
+        dataset = map_dataset_maker.run(cutout, obs)
+        dataset = safe_mask_maker.run(dataset, obs)
+
+        dataset = fov_bkg_maker.run(dataset)
+        datasets.append(dataset)
+
+    mask = dataset.mask_safe
+    assert_allclose(datasets[0].counts_off.data[mask].sum(), 2511333)
+    assert_allclose(datasets[1].counts_off.data[mask].sum(), 2143577.0)
+    assert_allclose(datasets[0].acceptance_off.data[mask].sum(), 2961300, rtol=1e-5)
+    assert_allclose(datasets[1].acceptance_off.data[mask].sum(), 2364657.2, rtol=1e-5)
+    assert_allclose(datasets[0].alpha.data[0][100][100], 0.00063745599, rtol=1e-5)
+    assert_allclose(
+        datasets[0].exposure.data[0][100][100], 806254444.8480084, rtol=1e-5
+    )

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -4,17 +4,18 @@ from numpy.testing import assert_allclose
 from astropy.coordinates import Angle, SkyCoord
 from regions import CircleSkyRegion
 from gammapy.cube import MapDataset
-from gammapy.cube.make import MapDatasetMaker, SafeMaskMaker
 from gammapy.cube.fov import FoVBackgroundMaker
+from gammapy.cube.make import MapDatasetMaker, SafeMaskMaker
 from gammapy.data import DataStore
 from gammapy.maps import MapAxis, WcsGeom, WcsNDMap
 from gammapy.utils.testing import requires_data
+
 
 @pytest.fixture(scope="session")
 def observations():
     """Example observation list for testing."""
     datastore = DataStore.from_dir("$GAMMAPY_DATA/hess-dl3-dr1/")
-    obs_ids = [23523, 23526]
+    obs_ids = [23523]
     return datastore.get_observations(obs_ids)
 
 
@@ -40,9 +41,31 @@ def exclusion_mask(geom):
     exclusion.data = geom.region_mask([region], inside=False)
     return exclusion
 
+
 @requires_data()
-def test_fov_bkg_maker(geom, observations, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(exclusion_mask=exclusion_mask)
+def test_fov_bkg_maker_scale(geom, observations, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)
+    safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
+    map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
+
+    reference = MapDataset.create(geom)
+    datasets = []
+
+    for obs in observations:
+        cutout = reference.cutout(obs.pointing_radec, width="4 deg")
+        dataset = map_dataset_maker.run(cutout, obs)
+        dataset = safe_mask_maker.run(dataset, obs)
+        dataset = fov_bkg_maker.run(dataset)
+
+        datasets.append(dataset)
+
+    assert_allclose(datasets[0].background_model.norm.value, 0.83078, rtol=1e-4)
+    assert_allclose(datasets[0].background_model.tilt.value, 0.0, rtol=1e-4)
+
+
+@requires_data()
+def test_fov_bkg_maker_fit(geom, observations, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
     safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
     map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
 
@@ -58,11 +81,12 @@ def test_fov_bkg_maker(geom, observations, exclusion_mask):
         datasets.append(dataset)
 
     assert_allclose(datasets[0].background_model.norm.value, 0.8307, rtol=1e-4)
-    assert_allclose(datasets[0].background_model.tilt.value, 0.0, rtol = 1e-4)
+    assert_allclose(datasets[0].background_model.tilt.value, 0.0, rtol=1e-4)
+
 
 @requires_data()
-def test_fov_bkg_maker_with_tilt(geom, observations, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(exclusion_mask=exclusion_mask)
+def test_fov_bkg_maker_fit_with_tilt(geom, observations, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
     safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
     map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
 
@@ -79,24 +103,48 @@ def test_fov_bkg_maker_with_tilt(geom, observations, exclusion_mask):
         datasets.append(dataset)
 
     assert_allclose(datasets[0].background_model.norm.value, 0.9034, rtol=1e-4)
-    assert_allclose(datasets[0].background_model.tilt.value, 0.0728, rtol = 1e-4)
+    assert_allclose(datasets[0].background_model.tilt.value, 0.0728, rtol=1e-4)
+
 
 @requires_data()
-def test_fov_bkg_maker_fail(geom, observations, exclusion_mask):
-    fov_bkg_maker = FoVBackgroundMaker(exclusion_mask=exclusion_mask)
+def test_fov_bkg_maker_fit_fail(geom, observations, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
     safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
     map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
 
     reference = MapDataset.create(geom)
     datasets = []
 
-    for obs in observations[:1]:
+    for obs in observations:
         cutout = reference.cutout(obs.pointing_radec, width="4 deg")
         dataset = map_dataset_maker.run(cutout, obs)
         dataset = safe_mask_maker.run(dataset, obs)
         # Putting negative background model to prevent convergence
         dataset.background_model.map.data *= -1
-        #TODO : assert on log.warning
+        # TODO : assert on log.warning
+        dataset = fov_bkg_maker.run(dataset)
+
+        datasets.append(dataset)
+
+    assert_allclose(datasets[0].background_model.norm.value, 1, rtol=1e-4)
+
+
+@requires_data()
+def test_fov_bkg_maker_scale_fail(geom, observations, exclusion_mask):
+    fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
+    safe_mask_maker = SafeMaskMaker(methods=["offset-max"], offset_max="2 deg")
+    map_dataset_maker = MapDatasetMaker(selection=["counts", "background", "exposure"])
+
+    reference = MapDataset.create(geom)
+    datasets = []
+
+    for obs in observations:
+        cutout = reference.cutout(obs.pointing_radec, width="4 deg")
+        dataset = map_dataset_maker.run(cutout, obs)
+        dataset = safe_mask_maker.run(dataset, obs)
+        # Putting negative background model to prevent convergence
+        dataset.background_model.map.data *= -1
+        # TODO : assert on log.warning
         dataset = fov_bkg_maker.run(dataset)
 
         datasets.append(dataset)

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -143,7 +143,6 @@ def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask):
 
     assert_allclose(dataset.background_model.norm.value, 1, rtol=1e-4)
 
-
 @requires_data()
 def test_fov_bkg_maker_scale_fail(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="scale", exclusion_mask=exclusion_mask)

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -76,8 +76,8 @@ def test_fov_bkg_maker_scale(obs_dataset, exclusion_mask):
     assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
 
 
-@requires_dependency("iminuit")
 @requires_data()
+@requires_dependency("iminuit")
 def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 
@@ -88,8 +88,8 @@ def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
 
 
-@requires_dependency("iminuit")
 @requires_data()
+@requires_dependency("iminuit")
 def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 
@@ -101,8 +101,8 @@ def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     assert_allclose(dataset.background_model.tilt.value, 0.0728, rtol=1e-4)
 
 
-@requires_dependency("iminuit")
 @requires_data()
+@requires_dependency("iminuit")
 def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
 

--- a/gammapy/cube/tests/test_fov.py
+++ b/gammapy/cube/tests/test_fov.py
@@ -8,7 +8,7 @@ from gammapy.cube.fov import FoVBackgroundMaker
 from gammapy.cube.make import MapDatasetMaker, SafeMaskMaker
 from gammapy.data import DataStore
 from gammapy.maps import MapAxis, WcsGeom, WcsNDMap
-from gammapy.utils.testing import requires_data
+from gammapy.utils.testing import requires_data, requires_dependency
 
 
 @pytest.fixture(scope="session")
@@ -76,6 +76,7 @@ def test_fov_bkg_maker_scale(obs_dataset, exclusion_mask):
     assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
 
 
+@requires_dependency("iminuit")
 @requires_data()
 def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
@@ -87,6 +88,7 @@ def test_fov_bkg_maker_fit(obs_dataset, exclusion_mask):
     assert_allclose(dataset.background_model.tilt.value, 0.0, rtol=1e-4)
 
 
+@requires_dependency("iminuit")
 @requires_data()
 def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)
@@ -99,6 +101,7 @@ def test_fov_bkg_maker_fit_with_tilt(obs_dataset, exclusion_mask):
     assert_allclose(dataset.background_model.tilt.value, 0.0728, rtol=1e-4)
 
 
+@requires_dependency("iminuit")
 @requires_data()
 def test_fov_bkg_maker_fit_fail(obs_dataset, exclusion_mask):
     fov_bkg_maker = FoVBackgroundMaker(method="fit", exclusion_mask=exclusion_mask)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a `FoVBackgroundMaker` class. It is very simple. It takes an exclusion mask on `__init__`. `FoVBackgroundMaker.run(dataset)` simply performs a fit of the model. The assumption here is that it only consists of the `background_model`.

Tests have been included, in particular one checking that in case of non-convergence the parameters are the initial ones. In this case a simple `log.warning` is raised. (this should be tested properly). It is not clear that this is the best behavior. Because ideally the dataset should be excluded.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
please comment on the choice of for non-convergence.