### PR TITLE
Rename EnergyDispersion to EDispKernel

### DIFF
--- a/docs/development/dataformats.rst
+++ b/docs/development/dataformats.rst
@@ -30,7 +30,7 @@ Effective area    AEFF_2D              `~gammapy.irf.EffectiveAreaTable2D`      
 Effective area    ARF                  `~gammapy.irf.EffectiveAreaTable`                 `GCTAAeffArf`_
 ----------------- -------------------- ------------------------------------------------- ----------------------------
 Energy dispersion EDISP_2D             `~gammapy.irf.EnergyDispersion2D`                 `GCTAEdisp2D`_
-Energy dispersion RMF                  `~gammapy.irf.EnergyDispersion`                   `GCTAEdispRMF`_
+Energy dispersion RMF                  `~gammapy.irf.EDispKernel`                        `GCTAEdispRMF`_
 ----------------- -------------------- ------------------------------------------------- ----------------------------
 PSF               PSF_2D_GAUSS         `~gammapy.irf.EnergyDependentMultiGaussPSF`       `GCTAPsf2D`_
 PSF               PSF_2D_KING          `~gammapy.irf.PSFKing`                            `GCTAPsfKing`_

--- a/docs/irf/edisp.rst
+++ b/docs/irf/edisp.rst
@@ -5,7 +5,7 @@ Energy dispersion
 
 TODO: describe / illustrate the existing classes:
 
-* `~gammapy.irf.EnergyDispersion`
+* `~gammapy.irf.EDispKernel`
 * `~gammapy.irf.EnergyDispersion2D`
 
 .. plot:: irf/plot_edisp.py

--- a/docs/irf/plot_edisp.py
+++ b/docs/irf/plot_edisp.py
@@ -2,11 +2,11 @@
 import numpy as np
 import astropy.units as u
 import matplotlib.pyplot as plt
-from gammapy.irf import EnergyDispersion
+from gammapy.irf import EDispKernel
 
 ebounds = np.logspace(-1, 2, 101) * u.TeV
 
-edisp = EnergyDispersion.from_gauss(e_true=ebounds, e_reco=ebounds, bias=0, sigma=0.3)
+edisp = EDispKernel.from_gauss(e_true=ebounds, e_reco=ebounds, bias=0, sigma=0.3)
 
 edisp.peek()
 plt.show()

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import numpy as np
 import astropy.io.fits as fits
 import astropy.units as u
-from gammapy.irf import EnergyDispersion
+from gammapy.irf import EDispKernel
 from gammapy.maps import Map, MapCoord, WcsGeom
 from gammapy.utils.random import InverseCDFSampler, get_random_state
 
@@ -270,7 +270,7 @@ class EDispMap:
         e_lo, e_hi = e_true_edges[:-1], e_true_edges[1:]
         ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
 
-        return EnergyDispersion(
+        return EDispKernel(
             e_true_lo=e_lo,
             e_true_hi=e_hi,
             e_reco_lo=ereco_lo,

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -105,7 +105,7 @@ class EDispMap:
         # Get an Energy Dispersion (1D) at any position in the image
         pos = SkyCoord(2.0, 2.5, unit="deg")
         e_reco = np.logspace(-1.0, 1.0, 10) * u.TeV
-        edisp = edisp_map.get_energy_dispersion(pos=pos, e_reco=e_reco)
+        edisp = edisp_map.get_edisp_kernel(pos=pos, e_reco=e_reco)
 
         # Write map to disk
         edisp_map.write("edisp_map.fits")
@@ -196,7 +196,7 @@ class EDispMap:
         hdulist = self.to_hdulist(**kwargs)
         hdulist.writeto(filename, overwrite=overwrite)
 
-    def get_energy_dispersion(self, position, e_reco, migra_step=5e-3):
+    def get_edisp_kernel(self, position, e_reco, migra_step=5e-3):
         """Get energy dispersion at a given position.
 
         Parameters

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -51,10 +51,10 @@ class MapDataset(Dataset):
         Exposure cube
     mask_fit : `~gammapy.maps.WcsNDMap`
         Mask to apply to the likelihood for fitting.
-    psf : `~gammapy.cube.PSFKernel`
+    psf : `~gammapy.cube.PSFKernel` or `~gammapy.cube.PSFMap`
         PSF kernel
-    edisp : `~gammapy.irf.EnergyDispersion`
-        Energy dispersion
+    edisp : `~gammapy.irf.EDispKernel` or `~gammapy.cube.EDispMap`
+        Energy dispersion kernel
     background_model : `~gammapy.modeling.models.BackgroundModel`
         Background model to use for the fit.
     evaluation_mode : {"local", "global"}
@@ -818,7 +818,7 @@ class MapDataset(Dataset):
         Effective area is taken from the average exposure divided by the livetime.
         Here we assume it is the sum of the GTIs.
 
-        EnergyDispersion is obtained at the on_region center.
+        The energy dispersion kernel is obtained at the on_region center.
         Only regions with centers are supported.
 
         The model is not exported to the ~gammapy.spectrum.SpectrumDataset.
@@ -880,7 +880,7 @@ class MapDataset(Dataset):
             if isinstance(self.edisp, EDispKernel):
                 edisp = self.edisp
             else:
-                edisp = self.edisp.get_energy_dispersion(
+                edisp = self.edisp.get_edisp_kernel(
                     on_region.center, self._energy_axis.edges
                 )
         else:
@@ -1015,7 +1015,7 @@ class MapDatasetOnOff(MapDataset):
         Mask to apply to the likelihood for fitting.
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel
-    edisp : `~gammapy.irf.EnergyDispersion`
+    edisp : `~gammapy.irf.EDispKernel`
         Energy dispersion
     background_model : `~gammapy.modeling.models.BackgroundModel`
         Background model to use for the fit.
@@ -1371,7 +1371,7 @@ class MapEvaluator:
         Exposure map
     psf : `~gammapy.cube.PSFKernel`
         PSF kernel
-    edisp : `~gammapy.irf.EnergyDispersion`
+    edisp : `~gammapy.irf.EDispKernel`
         Energy dispersion
     evaluation_mode : {"local", "global"}
         Model evaluation mode.
@@ -1426,7 +1426,7 @@ class MapEvaluator:
 
         if isinstance(edisp, EDispMap):
             e_reco = geom.get_axis_by_name("energy").edges
-            self.edisp = edisp.get_energy_dispersion(self.model.position, e_reco=e_reco)
+            self.edisp = edisp.get_edisp_kernel(self.model.position, e_reco=e_reco)
         else:
             self.edisp = edisp
 

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -11,7 +11,7 @@ from gammapy.cube.edisp_map import EDispMap
 from gammapy.cube.psf_kernel import PSFKernel
 from gammapy.cube.psf_map import PSFMap
 from gammapy.data import GTI
-from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.irf import EffectiveAreaTable, EDispKernel
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling import Dataset, Parameters
 from gammapy.modeling.models import BackgroundModel, SkyModel, SkyModels
@@ -647,7 +647,7 @@ class MapDataset(Dataset):
             ]
 
         if self.edisp is not None:
-            if isinstance(self.edisp, EnergyDispersion):
+            if isinstance(self.edisp, EDispKernel):
                 hdus = self.edisp.to_hdulist()
                 hdus["MATRIX"].name = "edisp_matrix"
                 hdus["EBOUNDS"].name = "edisp_matrix_ebounds"
@@ -712,7 +712,7 @@ class MapDataset(Dataset):
             kwargs["background_model"] = BackgroundModel(background_map)
 
         if "EDISP_MATRIX" in hdulist:
-            kwargs["edisp"] = EnergyDispersion.from_hdulist(
+            kwargs["edisp"] = EDispKernel.from_hdulist(
                 hdulist, hdu1="EDISP_MATRIX", hdu2="EDISP_MATRIX_EBOUNDS"
             )
         if "EDISP" in hdulist:
@@ -877,7 +877,7 @@ class MapDataset(Dataset):
                 aeff.data.data *= containment.squeeze()
 
         if self.edisp is not None:
-            if isinstance(self.edisp, EnergyDispersion):
+            if isinstance(self.edisp, EDispKernel):
                 edisp = self.edisp
             else:
                 edisp = self.edisp.get_energy_dispersion(
@@ -1330,7 +1330,7 @@ class MapDatasetOnOff(MapDataset):
             init_kwargs["exposure"] = Map.from_hdulist(hdulist, hdu="exposure")
 
         if "EDISP_MATRIX" in hdulist:
-            init_kwargs["edisp"] = EnergyDispersion.from_hdulist(
+            init_kwargs["edisp"] = EDispKernel.from_hdulist(
                 hdulist, hdu1="EDISP_MATRIX", hdu2="EDISP_MATRIX_EBOUNDS"
             )
 

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -387,7 +387,7 @@ class SafeMaskMaker:
             if position is None:
                 position = dataset.counts.geom.center_skydir
             e_reco = dataset.counts.geom.get_axis_by_name("energy").edges
-            edisp = edisp.get_energy_dispersion(position, e_reco)
+            edisp = edisp.get_edisp_kernel(position, e_reco)
             counts = dataset.counts.geom
         else:
             counts = dataset.counts

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -104,7 +104,7 @@ def test_edisp_map_to_energydispersion():
     position = SkyCoord(0, 0, unit="deg")
     e_reco = np.logspace(-0.3, 0.2, 200) * u.TeV
 
-    edisp = edmap.get_energy_dispersion(position, e_reco)
+    edisp = edmap.get_edisp_kernel(position, e_reco)
     # Note that the bias and resolution are rather poorly evaluated on an EnergyDispersion object
     assert_allclose(edisp.get_bias(e_true=1.0 * u.TeV), 0.0, atol=3e-2)
     assert_allclose(edisp.get_resolution(e_true=1.0 * u.TeV), 0.2, atol=3e-2)
@@ -143,7 +143,7 @@ def test_edisp_from_diagonal_response(position):
     edisp_map = EDispMap.from_diagonal_response(energy_axis_true)
 
     e_reco = energy_axis_true.edges
-    edisp_kernel = edisp_map.get_energy_dispersion(position, e_reco=e_reco)
+    edisp_kernel = edisp_map.get_edisp_kernel(position, e_reco=e_reco)
 
     sum_kernel = np.sum(edisp_kernel.data.data, axis=1).data
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -11,10 +11,10 @@ from gammapy.utils.fits import energy_axis_to_ebounds
 from gammapy.utils.nddata import NDDataArray
 from gammapy.utils.scripts import make_path
 
-__all__ = ["EnergyDispersion", "EnergyDispersion2D"]
+__all__ = ["EDispKernel", "EnergyDispersion2D"]
 
 
-class EnergyDispersion:
+class EDispKernel:
     """Energy dispersion matrix.
 
     Data format specification: :ref:`gadf:ogip-rmf`
@@ -833,7 +833,7 @@ class EnergyDispersion2D:
         e_lo, e_hi = e_true[:-1], e_true[1:]
         ereco_lo, ereco_hi = (e_reco[:-1], e_reco[1:])
 
-        return EnergyDispersion(
+        return EDispKernel(
             e_true_lo=e_lo,
             e_true_hi=e_hi,
             e_reco_lo=ereco_lo,

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -41,7 +41,7 @@ class IRFStacker:
     list_livetime : list
         list of `~astropy.units.Quantity` (livetime)
     list_edisp : list
-        list of `~gammapy.irf.EnergyDispersion`
+        list of `~gammapy.irf.EDispKernel`
     list_low_threshold : list
         list of low energy threshold, optional for effective area mean computation
     list_high_threshold : list
@@ -86,7 +86,7 @@ class IRFStacker:
 
     def stack_edisp(self):
         """
-        Compute mean energy dispersion (`~gammapy.irf.EnergyDispersion`).
+        Compute mean energy dispersion (`~gammapy.irf.EDispKernel`).
         """
         reco_bins = self.list_edisp[0].e_reco.nbin
         true_bins = self.list_edisp[0].e_true.nbin

--- a/gammapy/irf/irf_stack.py
+++ b/gammapy/irf/irf_stack.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 from astropy.units import Quantity
 from .effective_area import EffectiveAreaTable
-from .energy_dispersion import EnergyDispersion
+from .energy_dispersion import EDispKernel
 
 __all__ = ["IRFStacker"]
 
@@ -110,7 +110,7 @@ class IRFStacker:
 
         e_true = self.list_edisp[0].e_true.edges
         e_reco = self.list_edisp[0].e_reco.edges
-        self.stacked_edisp = EnergyDispersion(
+        self.stacked_edisp = EDispKernel(
             e_true_lo=e_true[:-1],
             e_true_hi=e_true[1:],
             e_reco_lo=e_reco[:-1],

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -9,7 +9,7 @@ from gammapy.maps import MapAxis
 from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 
 
-class TestEnergyDispersion:
+class TestEDispKernel:
     def setup(self):
         self.e_true = np.logspace(0, 1, 101) * u.TeV
         self.e_reco = self.e_true

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -631,7 +631,7 @@ class WcsNDMap(WcsMap):
 
         Parameters
         ----------
-        edisp : `gammapy.irf.EnergyDispersion`
+        edisp : `gammapy.irf.EDispKernel`
             Energy dispersion matrix
 
         Returns

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from gammapy.cube import PSFKernel
 from gammapy.cube.fit import MapEvaluator
-from gammapy.irf import EnergyDispersion
+from gammapy.irf import EDispKernel
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling.models import (
     BackgroundModel,
@@ -75,7 +75,7 @@ def background(geom):
 def edisp(geom, geom_true):
     e_reco = geom.get_axis_by_name("energy").edges
     e_true = geom_true.get_axis_by_name("energy").edges
-    return EnergyDispersion.from_diagonal_response(e_true=e_true, e_reco=e_reco)
+    return EDispKernel.from_diagonal_response(e_true=e_true, e_reco=e_reco)
 
 
 @pytest.fixture(scope="session")

--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -336,8 +336,8 @@ class SpectrumEvaluator:
         Spectral model
     aeff : `~gammapy.irf.EffectiveAreaTable`
         EffectiveArea
-    edisp : `~gammapy.irf.EnergyDispersion`, optional
-        EnergyDispersion
+    edisp : `~gammapy.irf.EDispKernel`, optional
+        Energy dispersion kernel.
     livetime : `~astropy.units.Quantity`
         Observation duration (may be contained in aeff)
     e_true : `~astropy.units.Quantity`, optional
@@ -353,7 +353,7 @@ class SpectrumEvaluator:
         import numpy as np
         import astropy.units as u
         import matplotlib.pyplot as plt
-        from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+        from gammapy.irf import EffectiveAreaTable, EDispKernel
         from gammapy.modeling.models import PowerLawSpectralModel, SkyModel
         from gammapy.spectrum import SpectrumEvaluator
 
@@ -361,7 +361,7 @@ class SpectrumEvaluator:
         e_reco = np.logspace(-2, 2, 73) * u.TeV
 
         aeff = EffectiveAreaTable.from_parametrization(energy=e_true)
-        edisp = EnergyDispersion.from_gauss(e_true=e_true, e_reco=e_reco, sigma=0.3, bias=0)
+        edisp = EDispKernel.from_gauss(e_true=e_true, e_reco=e_reco, sigma=0.3, bias=0)
 
         pwl = PowerLawSpectralModel(index=2.3, amplitude="2.5e-12 cm-2 s-1 TeV-1", reference="1 TeV")
         model = SkyModel(spectral_model=pwl)

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from astropy.io import fits
 from astropy.table import Table
 from gammapy.data import GTI
-from gammapy.irf import EffectiveAreaTable, EnergyDispersion, IRFStacker
+from gammapy.irf import EffectiveAreaTable, EDispKernel, IRFStacker
 from gammapy.modeling import Dataset, Parameters
 from gammapy.modeling.models import SkyModel, SkyModels
 from gammapy.stats import cash, significance_on_off, wstat
@@ -433,7 +433,7 @@ class SpectrumDataset(Dataset):
         aeff = EffectiveAreaTable(
             e_true[:-1], e_true[1:], np.zeros(e_true[:-1].shape) * u.m ** 2
         )
-        edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
+        edisp = EDispKernel.from_diagonal_response(e_true, e_reco)
         mask_safe = np.zeros_like(counts.data, "bool")
         gti = GTI.create(u.Quantity([], "s"), u.Quantity([], "s"), reference_time)
         livetime = gti.time_sum
@@ -709,7 +709,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         aeff = EffectiveAreaTable(
             e_true[:-1], e_true[1:], np.zeros(e_true[:-1].shape) * u.m ** 2
         )
-        edisp = EnergyDispersion.from_diagonal_response(e_true, e_reco)
+        edisp = EDispKernel.from_diagonal_response(e_true, e_reco)
         mask_safe = np.zeros_like(counts.data, "bool")
         gti = GTI.create(u.Quantity([], "s"), u.Quantity([], "s"), reference_time)
         livetime = gti.time_sum
@@ -1037,7 +1037,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
 
         try:
             rmffile = phafile.replace("pha", "rmf")
-            energy_dispersion = EnergyDispersion.read(dirname / rmffile)
+            energy_dispersion = EDispKernel.read(dirname / rmffile)
         except OSError:
             # TODO : Add logger and echo warning
             energy_dispersion = None

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -38,7 +38,7 @@ class SpectrumDataset(Dataset):
         Livetime
     aeff : `~gammapy.irf.EffectiveAreaTable`
         Effective area
-    edisp : `~gammapy.irf.EnergyDispersion`
+    edisp : `~gammapy.irf.EDispKernel`
         Energy dispersion
     background : `~gammapy.spectrum.CountsSpectrum`
         Background to use for the fit.
@@ -548,7 +548,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         Livetime
     aeff : `~gammapy.irf.EffectiveAreaTable`
         Effective area
-    edisp : `~gammapy.irf.EnergyDispersion`
+    edisp : `~gammapy.irf.EDispKernel`
         Energy dispersion
     mask_safe : `~numpy.array`
         Mask defining the safe data range.

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -166,7 +166,7 @@ class SpectrumDatasetMaker:
 
         Returns
         -------
-        edisp : `~gammapy.irf.EnergyDispersion`
+        edisp : `~gammapy.irf.EDispKernel`
             Energy dispersion
         """
         offset = observation.pointing_radec.separation(position)

--- a/gammapy/spectrum/sensitivity.py
+++ b/gammapy/spectrum/sensitivity.py
@@ -19,7 +19,7 @@ class SensitivityEstimator:
     ----------
     arf : `~gammapy.irf.EffectiveAreaTable`
         1D effective area
-    rmf : `~gammapy.irf.EnergyDispersion`
+    rmf : `~gammapy.irf.EDispKernel`
         energy dispersion table
     bkg : `~gammapy.spectrum.CountsSpectrum`
         the background array

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.units import Quantity
-from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.irf import EffectiveAreaTable, EDispKernel
 from gammapy.maps import MapAxis
 from gammapy.modeling.models import (
     PowerLawSpectralModel,
@@ -88,7 +88,7 @@ def get_test_cases():
                 spectral_model=PowerLawSpectralModel(amplitude="1e-11 TeV-1 cm-2 s-1")
             ),
             aeff=EffectiveAreaTable.from_parametrization(e_true),
-            edisp=EnergyDispersion.from_gauss(
+            edisp=EDispKernel.from_gauss(
                 e_reco=e_reco, e_true=e_true, bias=0, sigma=0.2
             ),
             livetime="10 h",

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.table import Table
 from astropy.time import Time
 from gammapy.data import GTI
-from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.irf import EffectiveAreaTable, EDispKernel
 from gammapy.maps import MapAxis
 from gammapy.modeling import Datasets, Fit
 from gammapy.modeling.models import (
@@ -119,7 +119,7 @@ class TestSpectrumDataset:
 
     def test_set_model(self):
         aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")
-        edisp = EnergyDispersion.from_diagonal_response(
+        edisp = EDispKernel.from_diagonal_response(
             self.src.energy.edges, self.src.energy.edges
         )
         dataset = SpectrumDataset(
@@ -173,7 +173,7 @@ class TestSpectrumDataset:
 
     def test_spectrum_dataset_stack_diagonal_safe_mask(self):
         aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")
-        edisp = EnergyDispersion.from_diagonal_response(
+        edisp = EDispKernel.from_diagonal_response(
             self.src.energy.edges, self.src.energy.edges
         )
         livetime = self.livetime
@@ -220,7 +220,7 @@ class TestSpectrumDataset:
 
     def test_spectrum_dataset_stack_nondiagonal_no_bkg(self):
         aeff = EffectiveAreaTable.from_parametrization(self.src.energy.edges, "HESS")
-        edisp1 = EnergyDispersion.from_gauss(
+        edisp1 = EDispKernel.from_gauss(
             self.src.energy.edges, self.src.energy.edges, 0.1, 0.0
         )
         livetime = self.livetime
@@ -232,7 +232,7 @@ class TestSpectrumDataset:
         aeff2 = EffectiveAreaTable(
             self.src.energy.edges[:-1], self.src.energy.edges[1:], aeff.data.data
         )
-        edisp2 = EnergyDispersion.from_gauss(
+        edisp2 = EDispKernel.from_gauss(
             self.src.energy.edges, self.src.energy.edges, 0.2, 0.0
         )
         dataset2 = SpectrumDataset(
@@ -265,7 +265,7 @@ class TestSpectrumOnOff:
         ehi = ereco[1:]
         self.e_reco = ereco
         self.aeff = EffectiveAreaTable(etrue[:-1], etrue[1:], np.ones(9) * u.cm ** 2)
-        self.edisp = EnergyDispersion.from_diagonal_response(etrue, ereco)
+        self.edisp = EDispKernel.from_diagonal_response(etrue, ereco)
 
         data = np.ones(elo.shape)
         data[-1] = 0  # to test stats calculation with empty bins
@@ -598,7 +598,7 @@ def make_observation_list():
         energy_lo=energy[:-1], energy_hi=energy[1:], data=dataoff_2
     )
     aeff = EffectiveAreaTable.from_constant(energy, "1 cm2")
-    edisp = EnergyDispersion.from_gauss(e_true=energy, e_reco=energy, sigma=0.2, bias=0)
+    edisp = EDispKernel.from_gauss(e_true=energy, e_reco=energy, sigma=0.2, bias=0)
 
     time_ref = Time("2010-01-01")
     gti1 = make_gti({"START": [5, 6, 1, 2], "STOP": [8, 7, 3, 4]}, time_ref=time_ref)

--- a/gammapy/spectrum/tests/test_sensitivity.py
+++ b/gammapy/spectrum/tests/test_sensitivity.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 import astropy.units as u
-from gammapy.irf import EffectiveAreaTable, EnergyDispersion
+from gammapy.irf import EffectiveAreaTable, EDispKernel
 from gammapy.spectrum import CountsSpectrum, SensitivityEstimator
 from gammapy.utils.testing import requires_data
 
@@ -18,7 +18,7 @@ def sens():
     arf = EffectiveAreaTable(energy_lo=elo, energy_hi=ehi, data=area)
 
     ereco = np.logspace(0, 1, 5) * u.TeV
-    rmf = EnergyDispersion.from_diagonal_response(etrue, ereco)
+    rmf = EDispKernel.from_diagonal_response(etrue, ereco)
 
     bkg_array = np.ones(4)
     bkg_array[-1] = 1e-3

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -57,7 +57,7 @@
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.data import EventList\n",
-    "from gammapy.irf import EnergyDependentTablePSF, EnergyDispersion\n",
+    "from gammapy.irf import EnergyDependentTablePSF, EDispKernel\n",
     "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
     "from gammapy.modeling.models import (\n",
     "    PowerLawSpectralModel,\n",
@@ -538,7 +538,7 @@
    "source": [
     "e_true = exposure.geom.axes[0].edges\n",
     "e_reco = counts.geom.axes[0].edges\n",
-    "edisp = EnergyDispersion.from_diagonal_response(e_true=e_true, e_reco=e_reco)"
+    "edisp = EDispKernel.from_diagonal_response(e_true=e_true, e_reco=e_reco)"
    ]
   },
   {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request renames the `EnergyDispersion` class to `EDispKernel`. The main motivation is consistency with `PSFKernel` and clarify that `EDispKernel` is and already integrated redistribution matrix. We could also consider to include RMF in the name somehow, but I slightly prefer to introduce consistency with the `PSFKernel` in the naming. 