### PR TITLE
Implement MapDatasetOnOff.to_spectrum_dataset() and .cutout()

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1425,7 +1425,6 @@ class MapDatasetOnOff(MapDataset):
         cutout : `MapDatasetOnOff`
             Cutout map dataset.
         """
-        kwargs = {"gti": self.gti}
         cutout_kwargs = {"position": position, "width": width, "mode": mode}
 
         cutout_dataset = super().cutout(**cutout_kwargs)

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1428,34 +1428,18 @@ class MapDatasetOnOff(MapDataset):
         kwargs = {"gti": self.gti}
         cutout_kwargs = {"position": position, "width": width, "mode": mode}
 
-        if self.counts is not None:
-            kwargs["counts"] = self.counts.cutout(**cutout_kwargs)
+        cutout_dataset = super().cutout(**cutout_kwargs)
 
         if self.counts_off is not None:
-            kwargs["counts_off"] = self.counts_off.cutout(**cutout_kwargs)
-
-        if self.exposure is not None:
-            kwargs["exposure"] = self.exposure.cutout(**cutout_kwargs)
+            cutout_dataset.counts_off = self.counts_off.cutout(**cutout_kwargs)
 
         if self.acceptance is not None:
-            kwargs["acceptance"] = self.acceptance.cutout(**cutout_kwargs)
+            cutout_dataset.acceptance = self.acceptance.cutout(**cutout_kwargs)
 
         if self.acceptance_off is not None:
-            kwargs["acceptance_off"] = self.acceptance_off.cutout(**cutout_kwargs)
+            cutout_dataset.acceptance_off = self.acceptance_off.cutout(**cutout_kwargs)
 
-        if self.edisp is not None:
-            kwargs["edisp"] = self.edisp.cutout(**cutout_kwargs)
-
-        if self.psf is not None:
-            kwargs["psf"] = self.psf.cutout(**cutout_kwargs)
-
-        if self.mask_safe is not None:
-            kwargs["mask_safe"] = self.mask_safe.cutout(**cutout_kwargs)
-
-        if self.mask_fit is not None:
-            kwargs["mask_fit"] = self.mask_fit.cutout(**cutout_kwargs)
-
-        return self.__class__(**kwargs)
+        return cutout_dataset
 
 
 class MapEvaluator:

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1407,6 +1407,56 @@ class MapDatasetOnOff(MapDataset):
             gti=dataset.gti,
         )
 
+    def cutout(self, position, width, mode="trim"):
+        """Cutout map dataset.
+
+        Parameters
+        ----------
+        position : `~astropy.coordinates.SkyCoord`
+            Center position of the cutout region.
+        width : tuple of `~astropy.coordinates.Angle`
+            Angular sizes of the region in (lon, lat) in that specific order.
+            If only one value is passed, a square region is extracted.
+        mode : {'trim', 'partial', 'strict'}
+            Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
+
+        Returns
+        -------
+        cutout : `MapDatasetOnOff`
+            Cutout map dataset.
+        """
+        kwargs = {"gti": self.gti}
+        cutout_kwargs = {"position": position, "width": width, "mode": mode}
+
+        if self.counts is not None:
+            kwargs["counts"] = self.counts.cutout(**cutout_kwargs)
+
+        if self.counts_off is not None:
+            kwargs["counts_off"] = self.counts_off.cutout(**cutout_kwargs)
+
+        if self.exposure is not None:
+            kwargs["exposure"] = self.exposure.cutout(**cutout_kwargs)
+
+        if self.acceptance is not None:
+            kwargs["acceptance"] = self.acceptance.cutout(**cutout_kwargs)
+
+        if self.acceptance_off is not None:
+            kwargs["acceptance_off"] = self.acceptance_off.cutout(**cutout_kwargs)
+
+        if self.edisp is not None:
+            kwargs["edisp"] = self.edisp.cutout(**cutout_kwargs)
+
+        if self.psf is not None:
+            kwargs["psf"] = self.psf.cutout(**cutout_kwargs)
+
+        if self.mask_safe is not None:
+            kwargs["mask_safe"] = self.mask_safe.cutout(**cutout_kwargs)
+
+        if self.mask_fit is not None:
+            kwargs["mask_fit"] = self.mask_fit.cutout(**cutout_kwargs)
+
+        return self.__class__(**kwargs)
+
 
 class MapEvaluator:
     """Sky model evaluation on maps.

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -730,3 +730,4 @@ def test_mapdatasetonoff_cutout(images):
     assert cutout_dataset.counts_off.data.shape == (50, 50)
     assert cutout_dataset.acceptance.data.shape == (50, 50)
     assert cutout_dataset.acceptance_off.data.shape == (50, 50)
+    assert cutout_dataset.background_model is None

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -193,7 +193,7 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue):
     assert spectrum_dataset.data_shape == (2,)
     assert spectrum_dataset.background.energy.nbin == 2
     assert spectrum_dataset.aeff.energy.nbin == 3
-    assert spectrum_dataset.aeff.data.data.unit == 'm2'
+    assert spectrum_dataset.aeff.data.data.unit == "m2"
     assert spectrum_dataset.edisp.e_reco.nbin == 2
     assert spectrum_dataset.edisp.e_true.nbin == 3
 
@@ -499,6 +499,7 @@ def images():
         "acceptance": WcsNDMap.read(filename, hdu="ONEXPOSURE"),
         "acceptance_off": WcsNDMap.read(filename, hdu="OFFEXPOSURE"),
         "exposure": WcsNDMap.read(filename, hdu="EXPGAMMAMAP"),
+        "background": WcsNDMap.read(filename, hdu="BACKGROUND"),
     }
 
 
@@ -684,3 +685,32 @@ def test_datasets_io_no_model(tmpdir):
 
     filename_2 = tmpdir / "test_data_2.fits"
     assert filename_2.exists()
+
+
+@requires_data()
+def test_mapdatasetonoff_to_spectrum_dataset(sky_model, images):
+    e_reco = MapAxis.from_bounds(0.1, 10.0, 1, name="energy", unit=u.TeV, interp="log")
+    new_images = dict()
+    for key, image in images.items():
+        new_images[key] = Map.from_geom(
+            image.geom.to_cube([e_reco]), data=image.data[np.newaxis, :, :]
+        )
+    dataset = get_map_dataset_onoff(new_images)
+    gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
+    dataset.gti = gti
+
+    on_region = CircleSkyRegion(
+        center=dataset.counts.geom.center_skydir, radius=0.1 * u.deg
+    )
+    spectrum_dataset = dataset.to_spectrum_dataset(on_region)
+
+    assert spectrum_dataset.counts.data[0] == 8
+    assert spectrum_dataset.data_shape == (1,)
+    assert spectrum_dataset.counts_off.data[0] == 33914
+    assert_allclose(spectrum_dataset.alpha.data[0], 0.0002143, atol=1e-7)
+
+    excess_map = new_images["counts"] - new_images["background"]
+    excess_true = excess_map.get_spectrum(on_region, np.sum).data[0]
+
+    excess = spectrum_dataset.excess.data[0]
+    assert_allclose(excess, excess_true, atol=1e-6)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -688,7 +688,7 @@ def test_datasets_io_no_model(tmpdir):
 
 
 @requires_data()
-def test_mapdatasetonoff_to_spectrum_dataset(sky_model, images):
+def test_mapdatasetonoff_to_spectrum_dataset(images):
     e_reco = MapAxis.from_bounds(0.1, 10.0, 1, name="energy", unit=u.TeV, interp="log")
     new_images = dict()
     for key, image in images.items():
@@ -714,3 +714,19 @@ def test_mapdatasetonoff_to_spectrum_dataset(sky_model, images):
 
     excess = spectrum_dataset.excess.data[0]
     assert_allclose(excess, excess_true, atol=1e-6)
+
+
+@requires_data()
+def test_mapdatasetonoff_cutout(images):
+    dataset = get_map_dataset_onoff(images)
+    gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
+    dataset.gti = gti
+
+    cutout_dataset = dataset.cutout(
+        images["counts"].geom.center_skydir, ["1 deg", "1 deg"]
+    )
+
+    assert cutout_dataset.counts.data.shape == (50, 50)
+    assert cutout_dataset.counts_off.data.shape == (50, 50)
+    assert cutout_dataset.acceptance.data.shape == (50, 50)
+    assert cutout_dataset.acceptance_off.data.shape == (50, 50)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces the `MapDatasetOnOff.to_spectrum_dataset()` to properly compute the `SpectrumDatasetOnOff` with the `counts_off`, `acceptance`, and `acceptance_off` computed. They are evaluated such that excess number is conserved. This is tested using the hgps map.
The typical usage would be to produce profiles from a list of regions or possibly to build a spectrum from a true ON OFF dataset.

While doing the PR I noticed that `.cutout()` is not properly overloaded. Currently it does not return a `.acceptance` and `.counts_off` etc. This PR corrects for this by adding an overloaded `cutout` for `MapDatasetOnOff` with an associated test. (Note that `MapDataset.cutout` is not explicitly tested by tested through `MapEvaluator`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
this should be ready to merge.