### PR TITLE
Correct MapDataset.to_spectrum_dataset 

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -873,9 +873,8 @@ class MapDataset(Dataset):
                 raise ValueError("No PSFMap set. Containement correction impossible")
             else:
                 psf = self.psf.get_energy_dependent_table_psf(on_region.center)
-                containment = psf.containment(aeff.energy.center, self.region.radius)
+                containment = psf.containment(aeff.energy.center, on_region.radius)
                 aeff.data.data *= containment.squeeze()
-
         if self.edisp is not None:
             if isinstance(self.edisp, EDispKernel):
                 edisp = self.edisp

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -186,16 +186,24 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue):
 
     gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
     dataset_ref.gti = gti
-    on_region = CircleSkyRegion(center=geom.center_skydir, radius=0.1 * u.deg)
+    on_region = CircleSkyRegion(center=geom.center_skydir, radius=0.05 * u.deg)
     spectrum_dataset = dataset_ref.to_spectrum_dataset(on_region)
+    spectrum_dataset_corrected = dataset_ref.to_spectrum_dataset(
+        on_region, containment_correction=True
+    )
 
     assert np.sum(spectrum_dataset.counts.data) == 1
     assert spectrum_dataset.data_shape == (2,)
     assert spectrum_dataset.background.energy.nbin == 2
     assert spectrum_dataset.aeff.energy.nbin == 3
-    assert spectrum_dataset.aeff.data.data.unit == 'm2'
+    assert spectrum_dataset.aeff.data.data.unit == "m2"
+    assert_allclose(spectrum_dataset.aeff.data.data.value[1], 853023.423047, rtol=1e-5)
     assert spectrum_dataset.edisp.e_reco.nbin == 2
     assert spectrum_dataset.edisp.e_true.nbin == 3
+    assert spectrum_dataset_corrected.aeff.data.data.unit == "m2"
+    assert_allclose(
+        spectrum_dataset_corrected.aeff.data.data.value[1], 559476.3357, rtol=1e-5
+    )
 
 
 def test_to_image(geom):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -197,10 +197,10 @@ def test_to_spectrum_dataset(sky_model, geom, geom_etrue):
     assert spectrum_dataset.background.energy.nbin == 2
     assert spectrum_dataset.aeff.energy.nbin == 3
     assert spectrum_dataset.aeff.data.data.unit == "m2"
-    assert_allclose(spectrum_dataset.aeff.data.data.value[1], 853023.423047, rtol=1e-5)
     assert spectrum_dataset.edisp.e_reco.nbin == 2
     assert spectrum_dataset.edisp.e_true.nbin == 3
     assert spectrum_dataset_corrected.aeff.data.data.unit == "m2"
+    assert_allclose(spectrum_dataset.aeff.data.data.value[1], 853023.423047, rtol=1e-5)
     assert_allclose(
         spectrum_dataset_corrected.aeff.data.data.value[1], 559476.3357, rtol=1e-5
     )


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request corrects a bug in `MapDataset.to_spectrum_dataset`. The containment correction option yields an error because of a an incorrect spelling of the `on_region`. This should have been spotted by a test. This PR also adds a test for the case `containment_correction=True` case.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This should be ready to merge.