### PR TITLE
Move parameter link reference to a separate key 

### DIFF
--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -67,9 +67,18 @@ class Parameter:
     """
 
     def __init__(
-        self, name, factor, unit="", scale=1, min=np.nan, max=np.nan, frozen=False
+        self,
+        name,
+        factor,
+        unit="",
+        scale=1,
+        min=np.nan,
+        max=np.nan,
+        frozen=False,
+        linkage="",
     ):
         self.name = name
+        self.linkage = linkage
         self.scale = scale
 
         # TODO: move this to a setter method that can be called from `__set__` also!
@@ -208,7 +217,8 @@ class Parameter:
         return (
             f"{self.__class__.__name__}(name={self.name!r}, value={self.value!r}, "
             f"factor={self.factor!r}, scale={self.scale!r}, unit={self.unit!r}, "
-            f"min={self.min!r}, max={self.max!r}, frozen={self.frozen!r}, id={hex(id(self))})"
+            f"min={self.min!r}, max={self.max!r}, frozen={self.frozen!r}, "
+            f"linkage={self.linkage!r}, id={hex(id(self))})"
         )
 
     def copy(self):
@@ -224,6 +234,7 @@ class Parameter:
             "min": self.min,
             "max": self.max,
             "frozen": self.frozen,
+            "linkage": self.linkage,
         }
 
     def autoscale(self, method="scale10"):
@@ -449,6 +460,7 @@ class Parameters(collections.abc.Sequence):
                 min=float(par.get("min", np.nan)),
                 max=float(par.get("max", np.nan)),
                 frozen=par.get("frozen", False),
+                linkage=par.get("linkage", ""),
             )
             parameters.append(parameter)
 
@@ -461,16 +473,13 @@ class Parameters(collections.abc.Sequence):
 
     def update_from_dict(self, data):
         for par in data["parameters"]:
-            # TODO: not sure if we should allow this
-            # parameter names should be fixed on init
-            # To be rediscussed
-            parameter = self[par["name"].split("@")[0]]
-            parameter.name = par["name"]
+            parameter = self[par["name"]]
             parameter.value = float(par["value"])
             parameter.unit = u.Unit(par.get("unit", parameter.unit))
             parameter.min = float(par.get("min", parameter.min))
             parameter.max = float(par.get("max", parameter.max))
             parameter.frozen = par.get("frozen", parameter.frozen)
+            parameter.linkage = par.get("linkage", parameter.linkage)
 
         if "covariance" in data:
             self.covariance = np.array(data["covariance"])

--- a/gammapy/modeling/parameter.py
+++ b/gammapy/modeling/parameter.py
@@ -67,18 +67,10 @@ class Parameter:
     """
 
     def __init__(
-        self,
-        name,
-        factor,
-        unit="",
-        scale=1,
-        min=np.nan,
-        max=np.nan,
-        frozen=False,
-        linkage="",
+        self, name, factor, unit="", scale=1, min=np.nan, max=np.nan, frozen=False
     ):
         self.name = name
-        self.linkage = linkage
+        self._link_label_io = None
         self.scale = scale
 
         # TODO: move this to a setter method that can be called from `__set__` also!
@@ -217,8 +209,7 @@ class Parameter:
         return (
             f"{self.__class__.__name__}(name={self.name!r}, value={self.value!r}, "
             f"factor={self.factor!r}, scale={self.scale!r}, unit={self.unit!r}, "
-            f"min={self.min!r}, max={self.max!r}, frozen={self.frozen!r}, "
-            f"linkage={self.linkage!r}, id={hex(id(self))})"
+            f"min={self.min!r}, max={self.max!r}, frozen={self.frozen!r}, id={hex(id(self))})"
         )
 
     def copy(self):
@@ -227,15 +218,17 @@ class Parameter:
 
     def to_dict(self):
         """Convert to dict."""
-        return {
+        output = {
             "name": self.name,
             "value": self.value,
             "unit": self.unit.to_string("fits"),
             "min": self.min,
             "max": self.max,
             "frozen": self.frozen,
-            "linkage": self.linkage,
         }
+        if self._link_label_io is not None:
+            output["link"] = self._link_label_io
+        return output
 
     def autoscale(self, method="scale10"):
         """Autoscale the parameters.
@@ -460,7 +453,6 @@ class Parameters(collections.abc.Sequence):
                 min=float(par.get("min", np.nan)),
                 max=float(par.get("max", np.nan)),
                 frozen=par.get("frozen", False),
-                linkage=par.get("linkage", ""),
             )
             parameters.append(parameter)
 
@@ -479,7 +471,7 @@ class Parameters(collections.abc.Sequence):
             parameter.min = float(par.get("min", parameter.min))
             parameter.max = float(par.get("max", parameter.max))
             parameter.frozen = par.get("frozen", parameter.frozen)
-            parameter.linkage = par.get("linkage", parameter.linkage)
+            parameter._link_label_io = par.get("link", parameter._link_label_io)
 
         if "covariance" in data:
             self.covariance = np.array(data["covariance"])

--- a/gammapy/modeling/serialize.py
+++ b/gammapy/modeling/serialize.py
@@ -41,7 +41,7 @@ def _update_link_reference(models):
             elif param not in params_shared:
                 params_shared.append(param)
     for k, param in enumerate(params_shared):
-        param.linkage = param.name + "@shared_" + str(k)
+        param._link_label_io = param.name + "@shared_" + str(k)
 
 
 def dict_to_models(data, link=True):
@@ -78,10 +78,10 @@ def _link_shared_parameters(models):
     for model in models:
         for param in model.parameters:
             name = param.name
-            linkage = param.linkage
-            if linkage != "":
-                if linkage in shared_register:
-                    new_param = shared_register[linkage]
+            link_label = param._link_label_io
+            if link_label is not None:
+                if link_label in shared_register:
+                    new_param = shared_register[link_label]
                     model.parameters.link(name, new_param)
                     if isinstance(model, SkyModel):
                         spatial_params = model.spatial_model.parameters
@@ -91,7 +91,7 @@ def _link_shared_parameters(models):
                         elif name in spectral_params.names:
                             spectral_params.link(name, new_param)
                 else:
-                    shared_register[linkage] = param
+                    shared_register[link_label] = param
 
 
 def datasets_to_dict(datasets, path, prefix, overwrite):


### PR DESCRIPTION
-Move parameter link reference to a separate key for serialisation instead of being  encapsulated in the name
-keep it separate from parameter instance id so it is more readable and remains the same than user define linkage in yaml file