### PR TITLE
Adapt TSMapEstimator to take a MapDataset as input

### DIFF
--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -267,33 +267,32 @@ class TSMapEstimator:
                 " size of the kernel"
             )
 
-
         # First create 2D map arrays
         counts = dataset.counts.sum_over_axes(keepdims=False)
         background = dataset.npred().sum_over_axes(keepdims=False)
         exposure = dataset.exposure.sum_over_axes(keepdims=False)
         if dataset.mask is not None:
-            mask = counts.copy(data=(dataset.mask.sum(axis=0)>0).astype('int'))
+            mask = counts.copy(data=(dataset.mask.sum(axis=0) > 0).astype("int"))
         else:
-            mask = counts.copy(data=np.ones_like(counts).astype('int'))
+            mask = counts.copy(data=np.ones_like(counts).astype("int"))
 
         if downsampling_factor:
             shape = counts.data.shape
             pad_width = symmetric_crop_pad_width(shape, shape_2N(shape))[0]
 
             counts = counts.pad(pad_width).downsample(
-                    downsampling_factor, preserve_counts=True
-                )
+                downsampling_factor, preserve_counts=True
+            )
             background = background.pad(pad_width).downsample(
-                    downsampling_factor, preserve_counts=True
-                )
+                downsampling_factor, preserve_counts=True
+            )
             exposure = exposure.pad(pad_width).downsample(
-                    downsampling_factor, preserve_counts=False
-                )
+                downsampling_factor, preserve_counts=False
+            )
             mask = mask.pad(pad_width).downsample(
-                    downsampling_factor, preserve_counts=False
-                )
-            mask.data = mask.data.astype('int')
+                downsampling_factor, preserve_counts=False
+            )
+            mask.data = mask.data.astype("int")
 
         mask.data &= self.mask_default(exposure, background, kernel).data
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -166,7 +166,7 @@ class TSMapEstimator:
         flux_approx : `~gammapy.maps.WcsNDMap`
             Approximate flux map (2D).
         """
-        flux = dataset.counts - dataset.background_model.evaluate()
+        flux = dataset.counts - dataset.npred()
         flux = flux.sum_over_axes(keepdims=False)
         flux /= dataset.exposure.sum_over_axes(keepdims=False)
         flux /= np.sum(kernel.array ** 2)
@@ -268,7 +268,7 @@ class TSMapEstimator:
 
         # First create 2D map arrays
         counts = dataset.counts.sum_over_axes(keepdims=False)
-        background = dataset.background_model.evaluate().sum_over_axes(keepdims=False)
+        background = dataset.npred().sum_over_axes(keepdims=False)
         exposure = dataset.exposure.sum_over_axes(keepdims=False)
         if dataset.mask is not None:
             mask = dataset.mask.sum_over_axes(keepdims=False)

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -205,7 +205,7 @@ class TSMapEstimator:
         # to fail, this is a temporary fix
         mask[background == 0] = 0
 
-        return exposure.copy(data=mask.astype("int"))
+        return exposure.copy(data=mask.astype("int"), unit='')
 
     @staticmethod
     def sqrt_ts(map_ts):
@@ -307,8 +307,10 @@ class TSMapEstimator:
             data = np.nan * np.ones_like(counts.data)
             result[name] = counts.copy(data=data)
 
+        flux_map = self.flux_default(dataset, kernel)
+
         if p["threshold"] or p["method"] == "root newton":
-            flux = self.flux_default(dataset, kernel).data
+            flux = flux_map.data
         else:
             flux = None
 
@@ -366,6 +368,14 @@ class TSMapEstimator:
                     factor=downsampling_factor, preserve_counts=False, order=order
                 )
                 result[name] = result[name].crop(crop_width=pad_width)
+
+        # Set correct units
+        if "flux" in which:
+            result["flux"].unit = flux_map.unit
+        if "flux_err" in which:
+            result["flux_err"].unit = flux_map.unit
+        if "flux_ul" in which:
+            result["flux_ul"].unit = flux_map.unit
 
         return result
 

--- a/gammapy/detect/test_statistics.py
+++ b/gammapy/detect/test_statistics.py
@@ -173,13 +173,15 @@ class TSMapEstimator:
         return flux.convolve(kernel.array)
 
     @staticmethod
-    def mask_default(counts, exposure, background, kernel):
+    def mask_default(exposure, background, kernel):
         """Compute default mask where to estimate TS values.
 
         Parameters
         ----------
-        dataset : `~gammapy.maps.MapDataset`
-            Input dataset. Requires "background" and "exposure".
+        exposure : `~gammapy.maps.Map`
+            Input exposure map.
+        background : `~gammapy.maps.Map`
+            Input background map.
         kernel : `astropy.convolution.Kernel2D`
             Source model kernel.
 
@@ -271,7 +273,7 @@ class TSMapEstimator:
         background = dataset.npred().sum_over_axes(keepdims=False)
         exposure = dataset.exposure.sum_over_axes(keepdims=False)
         if dataset.mask is not None:
-            mask = dataset.mask.sum_over_axes(keepdims=False)
+            mask = counts.copy(data=(dataset.mask.sum(axis=0)>0).astype('int'))
         else:
             mask = counts.copy(data=np.ones_like(counts).astype('int'))
 
@@ -293,7 +295,7 @@ class TSMapEstimator:
                 )
             mask.data = mask.data.astype('int')
 
-        mask.data &= self.mask_default(counts, exposure, background, kernel).data
+        mask.data &= self.mask_default(exposure, background, kernel).data
 
         if not isinstance(kernel, Kernel2D):
             kernel = CustomKernel(kernel)

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from astropy.convolution import Gaussian2DKernel
+import astropy.units as u
 from gammapy.detect import TSMapEstimator
 from gammapy.maps import Map, MapAxis
 from gammapy.cube import MapDataset
@@ -26,7 +27,7 @@ def input_dataset():
     exposure = Map.from_geom(
         exposure2D.geom.to_cube([energy]),
         data=exposure2D.data[np.newaxis, :, :],
-        unit=exposure2D.unit,
+        unit="cm2s",   # no unit in header?
     )
 
     background2D = Map.read(filename, hdu="background")
@@ -67,6 +68,10 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
+    assert result["flux"].unit == u.Unit("cm-2s-1")
+    assert result["flux_err"].unit == u.Unit("cm-2s-1")
+    assert result["flux_ul"].unit == u.Unit("cm-2s-1")
+
     # Check mask is correctly taken into account
     assert np.isnan(result["ts"].data[30, 40])
 
@@ -86,6 +91,10 @@ def test_compute_ts_map_downsampled(input_dataset):
     assert_allclose(result["flux"].data[99, 99], 1.02e-09, rtol=1e-2)
     assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
+
+    assert result["flux"].unit == u.Unit("cm-2s-1")
+    assert result["flux_err"].unit == u.Unit("cm-2s-1")
+    assert result["flux_ul"].unit == u.Unit("cm-2s-1")
 
     # Check mask is correctly taken into account
     assert np.isnan(result["ts"].data[30, 40])

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -36,10 +36,20 @@ def input_dataset():
     )
     background_model = BackgroundModel(background)
 
+    # add mask
+    mask2D = np.ones_like(background2D.data).astype("bool")
+    mask2D[0:40,:] = False
+    mask = Map.from_geom(
+                background2D.geom.to_cube([energy]),
+                data=mask2D[np.newaxis,:,:],
+    )
+
+
     return MapDataset(
         counts=counts,
         exposure=exposure,
         background_model=background_model,
+        mask_safe=mask
     )
 
 
@@ -58,6 +68,8 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
+    # Check mask is correctly taken into account
+    assert np.isnan(result["ts"].data[30,40])
 
 @requires_data()
 def test_compute_ts_map_downsampled(input_dataset):
@@ -74,6 +86,9 @@ def test_compute_ts_map_downsampled(input_dataset):
     assert_allclose(result["flux"].data[99, 99], 1.02e-09, rtol=1e-2)
     assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
+    
+    # Check mask is correctly taken into account
+    assert np.isnan(result["ts"].data[30,40])
 
 
 @requires_data()

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -52,11 +52,11 @@ def test_compute_ts_map(input_dataset):
     result = ts_estimator.run(input_dataset, kernel=kernel)
 
     assert "leastsq iter" in repr(ts_estimator)
-    assert_allclose(result["ts"].data[0,99, 99], 1714.23, rtol=1e-2)
-    assert_allclose(result["niter"].data[0,99, 99], 3)
-    assert_allclose(result["flux"].data[0,99, 99], 1.02e-09, rtol=1e-2)
-    assert_allclose(result["flux_err"].data[0,99, 99], 3.84e-11, rtol=1e-2)
-    assert_allclose(result["flux_ul"].data[0,99, 99], 1.10e-09, rtol=1e-2)
+    assert_allclose(result["ts"].data[99, 99], 1714.23, rtol=1e-2)
+    assert_allclose(result["niter"].data[99, 99], 3)
+    assert_allclose(result["flux"].data[99, 99], 1.02e-09, rtol=1e-2)
+    assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
+    assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -48,15 +48,15 @@ def test_compute_ts_map(input_dataset):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(5)
 
-    ts_estimator = TSMapEstimator(input_dataset, method="leastsq iter", threshold=1)
-    result = ts_estimator.run(kernel=kernel)
+    ts_estimator = TSMapEstimator(method="leastsq iter", threshold=1)
+    result = ts_estimator.run(input_dataset, kernel=kernel)
 
     assert "leastsq iter" in repr(ts_estimator)
-    assert_allclose(result["ts"].data[99, 99], 1714.23, rtol=1e-2)
-    assert_allclose(result["niter"].data[99, 99], 3)
-    assert_allclose(result["flux"].data[99, 99], 1.02e-09, rtol=1e-2)
-    assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
-    assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
+    assert_allclose(result["ts"].data[0,99, 99], 1714.23, rtol=1e-2)
+    assert_allclose(result["niter"].data[0,99, 99], 3)
+    assert_allclose(result["flux"].data[0,99, 99], 1.02e-09, rtol=1e-2)
+    assert_allclose(result["flux_err"].data[0,99, 99], 3.84e-11, rtol=1e-2)
+    assert_allclose(result["flux_ul"].data[0,99, 99], 1.10e-09, rtol=1e-2)
 
 
 @requires_data()
@@ -77,10 +77,10 @@ def test_compute_ts_map_downsampled(input_dataset):
 
 
 @requires_data()
-def test_large_kernel(input_maps):
+def test_large_kernel(input_dataset):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(100)
     ts_estimator = TSMapEstimator()
 
     with pytest.raises(ValueError):
-        ts_estimator.run(input_maps, kernel=kernel)
+        ts_estimator.run(input_dataset, kernel=kernel)

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -1,29 +1,55 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import numpy as np
 from numpy.testing import assert_allclose
 from astropy.convolution import Gaussian2DKernel
 from gammapy.detect import TSMapEstimator
-from gammapy.maps import Map
+from gammapy.maps import Map, MapAxis
+from gammapy.cube import MapDataset
 from gammapy.utils.testing import requires_data
-
+from gammapy.modeling.models import BackgroundModel
 
 @pytest.fixture(scope="session")
-def input_maps():
+def input_dataset():
     filename = "$GAMMAPY_DATA/tests/unbundled/poisson_stats_image/input_all.fits.gz"
-    return {
-        "counts": Map.read(filename, hdu="counts"),
-        "exposure": Map.read(filename, hdu="exposure"),
-        "background": Map.read(filename, hdu="background"),
-    }
+
+    energy = MapAxis.from_energy_bounds("0.1 TeV","1 TeV",1)
+
+    counts2D = Map.read(filename, hdu="counts")
+    counts = Map.from_geom(
+                counts2D.geom.to_cube([energy]),
+                data=counts2D.data[np.newaxis,:,:],
+                unit=counts2D.unit
+    )
+    exposure2D = Map.read(filename, hdu="exposure")
+    exposure = Map.from_geom(
+                exposure2D.geom.to_cube([energy]),
+                data=exposure2D.data[np.newaxis,:,:],
+                unit=exposure2D.unit
+    )
+
+    background2D = Map.read(filename, hdu="background")
+    background = Map.from_geom(
+                background2D.geom.to_cube([energy]),
+                data=background2D.data[np.newaxis,:,:],
+                unit=background2D.unit
+    )
+    background_model = BackgroundModel(background)
+
+    return MapDataset(
+        counts=counts,
+        exposure=exposure,
+        background_model=background_model,
+    )
 
 
 @requires_data()
-def test_compute_ts_map(input_maps):
+def test_compute_ts_map(input_dataset):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(5)
 
-    ts_estimator = TSMapEstimator(method="leastsq iter", threshold=1)
-    result = ts_estimator.run(input_maps, kernel=kernel)
+    ts_estimator = TSMapEstimator(input_dataset, method="leastsq iter", threshold=1)
+    result = ts_estimator.run(kernel=kernel)
 
     assert "leastsq iter" in repr(ts_estimator)
     assert_allclose(result["ts"].data[99, 99], 1714.23, rtol=1e-2)
@@ -34,14 +60,14 @@ def test_compute_ts_map(input_maps):
 
 
 @requires_data()
-def test_compute_ts_map_downsampled(input_maps):
+def test_compute_ts_map_downsampled(input_dataset):
     """Minimal test of compute_ts_image"""
     kernel = Gaussian2DKernel(2.5)
 
     ts_estimator = TSMapEstimator(
         method="root brentq", error_method="conf", ul_method="conf"
     )
-    result = ts_estimator.run(input_maps, kernel=kernel, downsampling_factor=2)
+    result = ts_estimator.run(input_dataset, kernel=kernel, downsampling_factor=2)
 
     assert_allclose(result["ts"].data[99, 99], 1675.28, rtol=1e-2)
     assert_allclose(result["niter"].data[99, 99], 7)

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -86,7 +86,7 @@ def test_compute_ts_map_downsampled(input_dataset):
     assert_allclose(result["flux"].data[99, 99], 1.02e-09, rtol=1e-2)
     assert_allclose(result["flux_err"].data[99, 99], 3.84e-11, rtol=1e-2)
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
-    
+
     # Check mask is correctly taken into account
     assert np.isnan(result["ts"].data[30,40])
 
@@ -99,3 +99,10 @@ def test_large_kernel(input_dataset):
 
     with pytest.raises(ValueError):
         ts_estimator.run(input_dataset, kernel=kernel)
+
+def test_incorrect_method():
+    kernel = Gaussian2DKernel(10)
+    with pytest.raises(ValueError):
+        TSMapEstimator(method="bad")
+    with pytest.raises(ValueError):
+        TSMapEstimator(error_method="bad")

--- a/gammapy/detect/tests/test_test_statistics.py
+++ b/gammapy/detect/tests/test_test_statistics.py
@@ -9,47 +9,46 @@ from gammapy.cube import MapDataset
 from gammapy.utils.testing import requires_data
 from gammapy.modeling.models import BackgroundModel
 
+
 @pytest.fixture(scope="session")
 def input_dataset():
     filename = "$GAMMAPY_DATA/tests/unbundled/poisson_stats_image/input_all.fits.gz"
 
-    energy = MapAxis.from_energy_bounds("0.1 TeV","1 TeV",1)
+    energy = MapAxis.from_energy_bounds("0.1 TeV", "1 TeV", 1)
 
     counts2D = Map.read(filename, hdu="counts")
     counts = Map.from_geom(
-                counts2D.geom.to_cube([energy]),
-                data=counts2D.data[np.newaxis,:,:],
-                unit=counts2D.unit
+        counts2D.geom.to_cube([energy]),
+        data=counts2D.data[np.newaxis, :, :],
+        unit=counts2D.unit,
     )
     exposure2D = Map.read(filename, hdu="exposure")
     exposure = Map.from_geom(
-                exposure2D.geom.to_cube([energy]),
-                data=exposure2D.data[np.newaxis,:,:],
-                unit=exposure2D.unit
+        exposure2D.geom.to_cube([energy]),
+        data=exposure2D.data[np.newaxis, :, :],
+        unit=exposure2D.unit,
     )
 
     background2D = Map.read(filename, hdu="background")
     background = Map.from_geom(
-                background2D.geom.to_cube([energy]),
-                data=background2D.data[np.newaxis,:,:],
-                unit=background2D.unit
+        background2D.geom.to_cube([energy]),
+        data=background2D.data[np.newaxis, :, :],
+        unit=background2D.unit,
     )
     background_model = BackgroundModel(background)
 
     # add mask
     mask2D = np.ones_like(background2D.data).astype("bool")
-    mask2D[0:40,:] = False
+    mask2D[0:40, :] = False
     mask = Map.from_geom(
-                background2D.geom.to_cube([energy]),
-                data=mask2D[np.newaxis,:,:],
+        background2D.geom.to_cube([energy]), data=mask2D[np.newaxis, :, :],
     )
-
 
     return MapDataset(
         counts=counts,
         exposure=exposure,
         background_model=background_model,
-        mask_safe=mask
+        mask_safe=mask,
     )
 
 
@@ -69,7 +68,8 @@ def test_compute_ts_map(input_dataset):
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
     # Check mask is correctly taken into account
-    assert np.isnan(result["ts"].data[30,40])
+    assert np.isnan(result["ts"].data[30, 40])
+
 
 @requires_data()
 def test_compute_ts_map_downsampled(input_dataset):
@@ -88,7 +88,7 @@ def test_compute_ts_map_downsampled(input_dataset):
     assert_allclose(result["flux_ul"].data[99, 99], 1.10e-09, rtol=1e-2)
 
     # Check mask is correctly taken into account
-    assert np.isnan(result["ts"].data[30,40])
+    assert np.isnan(result["ts"].data[30, 40])
 
 
 @requires_data()
@@ -100,8 +100,8 @@ def test_large_kernel(input_dataset):
     with pytest.raises(ValueError):
         ts_estimator.run(input_dataset, kernel=kernel)
 
+
 def test_incorrect_method():
-    kernel = Gaussian2DKernel(10)
     with pytest.raises(ValueError):
         TSMapEstimator(method="bad")
     with pytest.raises(ValueError):

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -1023,7 +1023,9 @@ class WcsGeom(Geom):
                 return False
 
         # check WCS consistency with a priori tolerance of 1e-6
-        return self.wcs.wcs.compare(other.wcs.wcs, tolerance=1e-6)
+        # cmp=1 parameter ensures no comparison with ancillary information
+        # see https://github.com/astropy/astropy/pull/4522/files
+        return self.wcs.wcs.compare(other.wcs.wcs, cmp=1, tolerance=1e-6)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/tutorials/cta_data_analysis.ipynb
+++ b/tutorials/cta_data_analysis.ipynb
@@ -297,7 +297,7 @@
    "source": [
     "%%time\n",
     "ts_image_estimator = TSMapEstimator()\n",
-    "images_ts = ts_image_estimator.run(images, kernel)\n",
+    "images_ts = ts_image_estimator.run(dataset_image, kernel)\n",
     "print(images_ts.keys())"
    ]
   },

--- a/tutorials/detect.ipynb
+++ b/tutorials/detect.ipynb
@@ -141,6 +141,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds=dataset.to_image()\n",
+    "print(ds.exposure.geom) \n",
+    "print(ds.counts.geom)\n",
+    "print(ds.counts.geom.axes[0]==ds.exposure.geom.axes[0])\n",
+    "print(ds.counts.geom==ds.exposure.geom)\n",
+    "dataset.counts.geom.wcs"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tutorials/detect.ipynb
+++ b/tutorials/detect.ipynb
@@ -114,7 +114,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = dataset.to_image()\n",
     "kernel = PSFKernel.read(\n",
     "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-psf.fits.gz\"\n",
     ")"

--- a/tutorials/detect.ipynb
+++ b/tutorials/detect.ipynb
@@ -32,7 +32,9 @@
     "* `~gammapy.detect.ASmooth`\n",
     "* `~gammapy.detect.TSMapEstimator`\n",
     "* `~gammapy.detect.find_peaks`\n",
-    "* `~gammapy.detect.compute_lima_image`\n"
+    "* `~gammapy.detect.compute_lima_image`\n",
+    "\n",
+    "**TODO: Adapt to ASmooth and Li & Ma significance**"
    ]
   },
   {
@@ -61,32 +63,13 @@
     "    compute_lima_image,\n",
     ")\n",
     "from gammapy.catalog import SOURCE_CATALOGS\n",
-    "from gammapy.cube import PSFKernel\n",
+    "from gammapy.modeling.models import BackgroundModel\n",
+    "from gammapy.cube import PSFKernel, MapDataset\n",
     "from gammapy.stats import significance\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.convolution import Tophat2DKernel\n",
     "import astropy.units as u\n",
     "import numpy as np"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# defalut matplotlib colors without grey\n",
-    "colors = [\n",
-    "    u\"#1f77b4\",\n",
-    "    u\"#ff7f0e\",\n",
-    "    u\"#2ca02c\",\n",
-    "    u\"#d62728\",\n",
-    "    u\"#9467bd\",\n",
-    "    u\"#8c564b\",\n",
-    "    u\"#e377c2\",\n",
-    "    u\"#bcbd22\",\n",
-    "    u\"#17becf\",\n",
-    "]"
    ]
   },
   {
@@ -104,51 +87,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "counts = Map.read(\"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-counts.fits.gz\")\n",
+    "counts = Map.read(\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-counts-cube.fits.gz\"\n",
+    ")\n",
     "background = Map.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-background.fits.gz\"\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-background-cube.fits.gz\"\n",
     ")\n",
+    "background = BackgroundModel(background)\n",
+    "\n",
     "exposure = Map.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-exposure.fits.gz\"\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-exposure-cube.fits.gz\"\n",
     ")\n",
+    "mask_safe = counts.copy(data=np.ones_like(counts.data).astype(\"bool\"))\n",
     "\n",
-    "maps = {\"counts\": counts, \"background\": background, \"exposure\": exposure}\n",
-    "\n",
-    "kernel = PSFKernel.read(\n",
-    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-psf.fits.gz\"\n",
+    "dataset = MapDataset(\n",
+    "    counts=counts,\n",
+    "    background_model=background,\n",
+    "    exposure=exposure,\n",
+    "    mask_safe=mask_safe,\n",
     ")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Adaptive smoothing\n",
-    "\n",
-    "For visualisation purpose it can be nice to look at a smoothed counts image. This can be performed using the adaptive smoothing algorithm from [Ebeling et al. (2006)](https://ui.adsabs.harvard.edu/abs/2006MNRAS.368...65E/abstract).\n",
-    "In the following example the `threshold` argument gives the minimum significance expected, values below are clipped.\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "scales = u.Quantity(np.arange(0.05, 1, 0.05), unit=\"deg\")\n",
-    "smooth = ASmooth(threshold=3, scales=scales)\n",
-    "images = smooth.run(**maps)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure(figsize=(15, 5))\n",
-    "images[\"counts\"].plot(add_cbar=True, vmax=10);"
+    "dataset = dataset.to_image()\n",
+    "kernel = PSFKernel.read(\n",
+    "    \"$GAMMAPY_DATA/fermi-3fhl-gc/fermi-3fhl-gc-psf.fits.gz\"\n",
+    ")"
    ]
   },
   {
@@ -169,7 +138,7 @@
    "source": [
     "%%time\n",
     "estimator = TSMapEstimator()\n",
-    "images = estimator.run(maps, kernel.data)"
+    "images = estimator.run(dataset.to_image(), kernel.data)"
    ]
   },
   {
@@ -264,105 +233,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Li & Ma significance maps\n",
-    "\n",
-    "We can compute significance for an observed number of counts and known background using an extension of equation (17) from the [Li & Ma (1983)](https://ui.adsabs.harvard.edu/abs/1983ApJ...272..317L/abstract) (see `gammapy.stats.significance` for details). We can perform this calculation intergating the counts within different radius. To do so we use an astropy Tophat kernel with the `compute_lima_image` function.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "radius = np.array([0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5])\n",
-    "pixsize = counts.geom.pixel_scales[0].value\n",
-    "nr = len(radius)\n",
-    "signi = np.zeros((nsou, nr))\n",
-    "excess = np.zeros((nsou, nr))\n",
-    "for kr in range(nr):\n",
-    "    npixel = radius[kr] / pixsize\n",
-    "    kernel = Tophat2DKernel(npixel)\n",
-    "    result = compute_lima_image(counts, background, kernel)\n",
-    "    signi[:, kr] = result[\"significance\"].data[sources[\"y\"], sources[\"x\"]]\n",
-    "    excess[:, kr] = result[\"excess\"].data[sources[\"y\"], sources[\"x\"]]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For simplicity we saved the significance and excess at the position of the candidates found previously on the TS map, but we could aslo have applied the peak finder on these significances maps for each scale, or alternatively implemented a 3D peak detection (in longitude, latitude, radius). Now let's look at the significance versus integration radius:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
-    "for ks in range(nsou):\n",
-    "    plt.plot(radius, signi[ks, :], color=colors[ks])\n",
-    "plt.xlabel(\"Radius\")\n",
-    "plt.ylabel(\"Li & Ma Significance\")\n",
-    "plt.title(\"Guessing optimal radius of each candidate\");"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can add the optimal radius guessed and the corresdponding excess to the source candidate properties table."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# rename the value key to sqrt(TS)_PS\n",
-    "sources.rename_column(\"value\", \"sqrt(TS)_PS\")\n",
-    "\n",
-    "index = np.argmax(signi, axis=1)\n",
-    "sources[\"significance\"] = signi[range(nsou), index]\n",
-    "sources[\"radius\"] = radius[index]\n",
-    "sources[\"excess\"] = excess[range(nsou), index]\n",
-    "sources"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Plot candidates sources on top of significance sky image with radius guess\n",
-    "plt.figure(figsize=(15, 5))\n",
-    "\n",
-    "_, ax, _ = images[\"sqrt_ts\"].plot(add_cbar=True, cmap=cm.Greys_r)\n",
-    "\n",
-    "phi = np.arange(0, 2 * np.pi, 0.01)\n",
-    "for ks in range(nsou):\n",
-    "    x = sources[\"x\"][ks] + sources[\"radius\"][ks] / pixsize * np.cos(phi)\n",
-    "    y = sources[\"y\"][ks] + sources[\"radius\"][ks] / pixsize * np.sin(phi)\n",
-    "    ax.plot(x, y, \"-\", color=colors[ks], lw=1.5);"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the optimal radius of nested sources is likely overestimated due to their neighbor. We limited this example to only the most significant source above ~8 sigma. When lowering the detection threshold the number of candidated increase together with the source confusion."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## What next?\n",
     "\n",
     "In this notebook, we have seen how to work with images and compute TS and significance images from counts data, if a background estimate is already available.\n",
@@ -399,9 +269,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adapts the `TSMapEstimator` to take a `MapDataset` as argument. This requires an adaptation since 2D maps with an energy axis are needed. Typically one would call it after `dataset.to_image()`.
An improvement over the previous version is that it now uses `npred` rather than the simple background, so that one can compute the TSMap of residuals from a model.

The detect.ipynb has been adapted. Since the `ASmooth ` and Li & Ma significance parts are not adapted yet, they have been temporarily removed and will be put back once these parts are adapted as well.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
should be ready for review.