### PR TITLE
Remove use of simulate_dataset from mcmc tutorial

### DIFF
--- a/tutorials/mcmc_sampling.ipynb
+++ b/tutorials/mcmc_sampling.ipynb
@@ -69,7 +69,8 @@
     "    GaussianSpatialModel,\n",
     "    SkyModel,\n",
     ")\n",
-    "from gammapy.cube.simulate import simulate_dataset\n",
+    "from gammapy.cube import MapDataset, MapDatasetMaker\n",
+    "from gammapy.data import Observation\n",
     "from gammapy.modeling.sampling import (\n",
     "    run_mcmc,\n",
     "    par_to_model,\n",
@@ -106,6 +107,12 @@
    "source": [
     "irfs = load_cta_irfs(\n",
     "    \"$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits\"\n",
+    ")\n",
+    "\n",
+    "observation = Observation.create(\n",
+    "    pointing=SkyCoord(0 * u.deg, 0 * u.deg, frame=\"galactic\"),\n",
+    "    livetime=20 * u.h,\n",
+    "    irfs=irfs\n",
     ")"
    ]
   },
@@ -147,13 +154,11 @@
     "    skydir=(0, 0), binsz=0.05, width=(2, 2), frame=\"galactic\", axes=[axis]\n",
     ")\n",
     "\n",
-    "# Define some observation parameters\n",
-    "pointing = SkyCoord(0 * u.deg, 0 * u.deg, frame=\"galactic\")\n",
-    "\n",
-    "\n",
-    "dataset = simulate_dataset(\n",
-    "    sky_model_simu, geom, pointing, irfs, livetime=20 * u.h, random_state=42\n",
-    ")"
+    "empty_dataset = MapDataset.create(geom=geom)\n",
+    "maker = MapDatasetMaker(selection=[\"background\", \"edisp\", \"psf\", \"exposure\"])\n",
+    "dataset = maker.run(empty_dataset, observation)\n",
+    "dataset.models = sky_model_simu\n",
+    "dataset.fake()"
    ]
   },
   {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the use of the `simulate_dataset` function from the `mcmc_sampling.ipynb` tutorial and replaces it with the new pattern using the in-memory `Observation` class. The motivation for this change is the zen of Python "There should be one-- and preferably only one --obvious way to do it." and "Explicit is better than implicit." 

Even if it is more code to write, we show users a consistent way of simulating datasets and give them full flexibility in choosing geometries. Nicely enough this way is also very similar to how analyses are done in general. I think it's better to show users how to do new things with known concepts, then introducing new concepts that we have to explain and document.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
