### PR TITLE
Add time scale info in GTI.__repr__

### DIFF
--- a/gammapy/data/gti.py
+++ b/gammapy/data/gti.py
@@ -38,9 +38,9 @@ class GTI:
     - Number of GTIs: 1
     - Duration: 1687.0 s
     - Start: 53343.92234009259 MET
-    - Start: 2004-12-04T22:08:10.184(TT)
+    - Start: 2004-12-04T22:08:10.184 (time standard: TT)
     - Stop: 53343.94186555556 MET
-    - Stop: 2004-12-04T22:36:17.184(TT)
+    - Stop: 2004-12-04T22:36:17.184 (time standard: TT)
 
     Load GTIs for a Fermi-LAT event list:
 
@@ -50,9 +50,9 @@ class GTI:
     - Number of GTIs: 39042
     - Duration: 183139597.9032163 s
     - Start: 54682.65603794185 MET
-    - Start: 2008-08-04T15:44:41.678(TT)
+    - Start: 2008-08-04T15:44:41.678 (time standard: TT)
     - Stop: 57236.96833546296 MET
-    - Stop: 2015-08-02T23:14:24.184(TT)
+    - Stop: 2015-08-02T23:14:24.184 (time standard: TT)
     """
 
     def __init__(self, table):
@@ -106,9 +106,9 @@ class GTI:
             f"- Number of GTIs: {len(self.table)}\n"
             f"- Duration: {self.time_sum}\n"
             f"- Start: {self.time_start[0]} MET\n"
-            f"- Start: {self.time_start[0].fits}\n"
+            f"- Start: {self.time_start[0].fits} (time standard: {self.time_start[-1].scale.upper()})\n"
             f"- Stop: {self.time_stop[-1]} MET\n"
-            f"- Stop: {self.time_stop[-1].fits}\n"
+            f"- Stop: {self.time_stop[-1].fits} (time standard: {self.time_stop[-1].scale.upper()})\n"
         )
 
     @property


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds the time scale (time standard) information to the `GTI.__repr__` to avoid issues when comparing GTI times to `Time` objects defined with the `utc` time scale.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
