### PR TITLE
Simplify trapz_loglog integrate method

### DIFF
--- a/gammapy/astro/darkmatter/profiles.py
+++ b/gammapy/astro/darkmatter/profiles.py
@@ -4,7 +4,7 @@ import abc
 import numpy as np
 import astropy.units as u
 from gammapy.modeling import Parameter, Parameters
-from gammapy.utils.integrate import integrate_spectrum
+from gammapy.modeling.models.spectral import integrate_spectrum
 
 __all__ = [
     "DMProfile",

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -31,5 +31,5 @@ def test_dmfluxmap(jfact):
     diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
     int_flux = (jfact * diff_flux.integral(emin=emin, emax=emax)).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 1.94839226e-12 / u.cm ** 2 / u.s
+    desired = 1.948518e-12 / u.cm ** 2 / u.s
     assert_quantity_allclose(actual, desired, rtol=1e-5)

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -5,7 +5,7 @@ from astropy.io import fits
 from astropy.table import Table
 from gammapy.maps import MapAxis
 from gammapy.maps.utils import edges_from_lo_hi
-from gammapy.utils.integrate import _trapz_loglog
+from gammapy.utils.integrate import trapz_loglog
 from gammapy.utils.nddata import NDDataArray
 from gammapy.utils.scripts import make_path
 
@@ -195,7 +195,7 @@ class Background3D:
             Returns 2D array with axes offset
         """
         data = self.evaluate(fov_lon, fov_lat, energy_reco, method=method)
-        return _trapz_loglog(data, energy_reco, axis=0, intervals=True)
+        return trapz_loglog(data, energy_reco, axis=0, intervals=True)
 
     def to_2d(self):
         """Convert to `Background2D`.
@@ -369,7 +369,7 @@ class Background2D:
             Returns 2D array with axes offset
         """
         data = self.evaluate(fov_lon, fov_lat, energy_reco, method=method)
-        return _trapz_loglog(data, energy_reco, axis=0, intervals=True)
+        return trapz_loglog(data, energy_reco, axis=0, intervals=True)
 
     def to_3d(self):
         """Convert to `Background3D`.

--- a/gammapy/irf/background.py
+++ b/gammapy/irf/background.py
@@ -195,7 +195,7 @@ class Background3D:
             Returns 2D array with axes offset
         """
         data = self.evaluate(fov_lon, fov_lat, energy_reco, method=method)
-        return trapz_loglog(data, energy_reco, axis=0, intervals=True)
+        return trapz_loglog(data, energy_reco, axis=0)
 
     def to_2d(self):
         """Convert to `Background2D`.
@@ -369,7 +369,7 @@ class Background2D:
             Returns 2D array with axes offset
         """
         data = self.evaluate(fov_lon, fov_lat, energy_reco, method=method)
-        return trapz_loglog(data, energy_reco, axis=0, intervals=True)
+        return trapz_loglog(data, energy_reco, axis=0)
 
     def to_3d(self):
         """Convert to `Background3D`.

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -442,7 +442,7 @@ class MapAxis:
         return cls(nodes, **kwargs)
 
     @classmethod
-    def from_energy_bounds(cls, emin, emax, nbin, per_decade=False, unit=None):
+    def from_energy_bounds(cls, emin, emax, nbin, unit=None, per_decade=False):
         """Make an energy axis.
 
         Used frequently also to make energy grids, by making
@@ -454,10 +454,10 @@ class MapAxis:
             Energy range
         nbin : int
             Number of bins
-        per_decade : bool
-            Whether `nbin` is given per decade.
         unit : `~astropy.units.Unit`
             Energy unit
+        per_decade : bool
+            Whether `nbin` is given per decade.
 
         Returns
         -------

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -442,7 +442,7 @@ class MapAxis:
         return cls(nodes, **kwargs)
 
     @classmethod
-    def from_energy_bounds(cls, emin, emax, nbin, unit=None):
+    def from_energy_bounds(cls, emin, emax, nbin, per_decade=False, unit=None):
         """Make an energy axis.
 
         Used frequently also to make energy grids, by making
@@ -454,6 +454,8 @@ class MapAxis:
             Energy range
         nbin : int
             Number of bins
+        per_decade : bool
+            Whether `nbin` is given per decade.
         unit : `~astropy.units.Unit`
             Energy unit
 
@@ -471,6 +473,9 @@ class MapAxis:
             unit = u.Unit(unit)
             emin = u.Quantity(emin, unit)
             emax = u.Quantity(emax, unit)
+
+        if per_decade:
+            nbin = np.ceil(np.log10(emax / emin) * nbin)
 
         return cls.from_bounds(
             emin.value, emax.value, nbin=nbin, unit=unit, interp="log", name="energy"

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -209,16 +209,6 @@ TEST_MODELS.append(
 
 TEST_MODELS.append(
     dict(
-        name="compound4",
-        model=TEST_MODELS[0]["model"] - 0.1 * TEST_MODELS[0]["val_at_2TeV"],
-        val_at_2TeV=0.9 * TEST_MODELS[0]["val_at_2TeV"],
-        integral_1_10TeV=2.1919819216346936 * u.Unit("cm-2 s-1"),
-        eflux_1_10TeV=2.6322140512045697 * u.Unit("TeV cm-2 s-1"),
-    )
-)
-
-TEST_MODELS.append(
-    dict(
         name="compound6",
         model=TEST_MODELS[8]["model"] + u.Quantity(4, "cm-2 s-1 TeV-1"),
         val_at_2TeV=TEST_MODELS[8]["val_at_2TeV"] * 2,
@@ -383,7 +373,7 @@ def test_ecpl_integrate():
     # regression test to check the numerical integration for small energy bins
     ecpl = ExpCutoffPowerLawSpectralModel()
     value = ecpl.integral(1 * u.TeV, 1.1 * u.TeV)
-    assert_quantity_allclose(value, 8.380714e-14 * u.Unit("s-1 cm-2"))
+    assert_quantity_allclose(value, 8.380761e-14 * u.Unit("s-1 cm-2"))
 
 
 def test_pwl_pivot_energy():
@@ -477,16 +467,16 @@ class TestNaimaModel:
         model = NaimaSpectralModel(radiative_model)
 
         val_at_2TeV = 4.347836316893546e-12 * u.Unit("cm-2 s-1 TeV-1")
-        integral_1_10TeV = 1.5958109911918303e-11 * u.Unit("cm-2 s-1")
-        eflux_1_10TeV = 2.851281562480875e-11 * u.Unit("TeV cm-2 s-1")
+        integral_1_10TeV = 1.595813e-11 * u.Unit("cm-2 s-1")
+        eflux_1_10TeV = 2.851283e-11 * u.Unit("TeV cm-2 s-1")
 
         value = model(self.energy)
         assert_quantity_allclose(value, val_at_2TeV)
         assert_quantity_allclose(
-            model.integral(emin=self.emin, emax=self.emax), integral_1_10TeV
+            model.integral(emin=self.emin, emax=self.emax), integral_1_10TeV, rtol=1e-5
         )
         assert_quantity_allclose(
-            model.energy_flux(emin=self.emin, emax=self.emax), eflux_1_10TeV
+            model.energy_flux(emin=self.emin, emax=self.emax), eflux_1_10TeV, rtol=1e-5
         )
         val = model(self.e_array)
         assert val.shape == self.e_array.shape
@@ -502,16 +492,16 @@ class TestNaimaModel:
         model = NaimaSpectralModel(radiative_model)
 
         val_at_2TeV = 1.0565840392550432e-24 * u.Unit("cm-2 s-1 TeV-1")
-        integral_1_10TeV = 4.4491861907713736e-13 * u.Unit("cm-2 s-1")
-        eflux_1_10TeV = 4.594120986691428e-13 * u.Unit("TeV cm-2 s-1")
+        integral_1_10TeV = 4.449303e-13 * u.Unit("cm-2 s-1")
+        eflux_1_10TeV = 4.594242e-13 * u.Unit("TeV cm-2 s-1")
 
         value = model(self.energy)
         assert_quantity_allclose(value, val_at_2TeV)
         assert_quantity_allclose(
-            model.integral(emin=self.emin, emax=self.emax), integral_1_10TeV
+            model.integral(emin=self.emin, emax=self.emax), integral_1_10TeV, rtol=1e-5
         )
         assert_quantity_allclose(
-            model.energy_flux(emin=self.emin, emax=self.emax), eflux_1_10TeV
+            model.energy_flux(emin=self.emin, emax=self.emax), eflux_1_10TeV, rtol=1e-5
         )
         val = model(self.e_array)
         assert val.shape == self.e_array.shape

--- a/gammapy/modeling/models/tests/test_spectral.py
+++ b/gammapy/modeling/models/tests/test_spectral.py
@@ -245,19 +245,19 @@ def test_models(spectrum):
     model = spectrum["model"]
     energy = 2 * u.TeV
     value = model(energy)
-    assert_quantity_allclose(value, spectrum["val_at_2TeV"])
+    assert_quantity_allclose(value, spectrum["val_at_2TeV"], rtol=1e-7)
     if "val_at_3TeV" in spectrum:
         energy = 3 * u.TeV
         value = model(energy)
-        assert_quantity_allclose(value, spectrum["val_at_3TeV"])
+        assert_quantity_allclose(value, spectrum["val_at_3TeV"], rtol=1e-7)
 
     emin = 1 * u.TeV
     emax = 10 * u.TeV
     assert_quantity_allclose(
-        model.integral(emin=emin, emax=emax), spectrum["integral_1_10TeV"]
+        model.integral(emin=emin, emax=emax), spectrum["integral_1_10TeV"], rtol=1e-5
     )
     assert_quantity_allclose(
-        model.energy_flux(emin=emin, emax=emax), spectrum["eflux_1_10TeV"]
+        model.energy_flux(emin=emin, emax=emax), spectrum["eflux_1_10TeV"], rtol=1e-5
     )
 
     if "e_peak" in spectrum:

--- a/gammapy/modeling/models/tests/test_spectral_crab.py
+++ b/gammapy/modeling/models/tests/test_spectral_crab.py
@@ -52,7 +52,7 @@ def test_crab_spectrum(spec):
     assert_quantity_allclose(dnde, spec["dnde"])
 
     flux = crab_spectrum.integral(1 * u.TeV, 1e3 * u.TeV)
-    assert_quantity_allclose(flux, spec["flux"])
+    assert_quantity_allclose(flux, spec["flux"], rtol=1e-6)
 
     index = crab_spectrum.spectral_index(2 * u.TeV)
     assert_quantity_allclose(index, spec["index"], rtol=1e-5)

--- a/gammapy/utils/tests/test_integrate.py
+++ b/gammapy/utils/tests/test_integrate.py
@@ -1,19 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.units import Quantity
 from gammapy.modeling.models import PowerLawSpectralModel
-from gammapy.utils.integrate import integrate_spectrum
+from gammapy.utils.integrate import evaluate_integral_pwl, trapz_loglog
 from gammapy.utils.testing import assert_quantity_allclose
 
 
-def test_integrate_spectrum():
-    """
-    Test numerical integration against analytical solution.
-    """
-    emin = Quantity(1, "TeV")
-    emax = Quantity(10, "TeV")
+def test_trapz_loglog():
+    energy = Quantity([1, 10], "TeV")
     pwl = PowerLawSpectralModel(index=2.3)
 
-    ref = pwl.integral(emin=emin, emax=emax)
+    ref = pwl.integral(emin=energy[0], emax=energy[1])
 
-    val = integrate_spectrum(pwl, emin, emax)
+    val = trapz_loglog(pwl(energy), energy)
     assert_quantity_allclose(val, ref)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request simplifies the `trapz_loglog` method  and adapts its usages. To avoid circular imports. I decided to move the `integrate_spectrum` method `gammapy.modeling.models.spectral`

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
