### PR TITLE
Add a MapDatasetOnOff.to_image() method

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1483,7 +1483,29 @@ class MapDatasetOnOff(MapDataset):
         """
         dataset = super().to_image(spectrum, name)
 
-        return dataset
+        kwargs = {}
+        if self.counts_off is not None:
+            kwargs["counts_off"] = self.counts_off.sum_over_axes(keepdims=True)
+
+        if self.acceptance is not None:
+            kwargs["acceptance"] = self.acceptance.reduce_over_axes(func=np.mean, keepdims=True)
+            background = self.background.sum_over_axes(keepdims=True)
+            kwargs["acceptance_off"] = (
+                    kwargs["acceptance"] * kwargs["counts_off"] / background
+            )
+        kwargs["counts"]=dataset.counts
+        kwargs["exposure"]=dataset.exposure
+        # A priori these are None
+        kwargs["psf"]=dataset.psf
+        kwargs["edisp"]=dataset.edisp
+        # We keep name
+        kwargs["name"]=dataset.name
+        kwargs["mask_fit"]=dataset.mask_fit
+        kwargs["mask_safe"]=dataset.mask_safe
+        kwargs["gti"]=dataset.gti
+        kwargs["evaluation_mode"]=dataset.evaluation_mode
+
+        return MapDatasetOnOff(**kwargs)
 
 class MapEvaluator:
     """Sky model evaluation on maps.

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1442,7 +1442,12 @@ class MapDatasetOnOff(MapDataset):
         cutout : `MapDatasetOnOff`
             Cutout map dataset.
         """
-        cutout_kwargs = {"position": position, "width": width, "mode": mode, "name":name}
+        cutout_kwargs = {
+            "position": position,
+            "width": width,
+            "mode": mode,
+            "name": name,
+        }
 
         cutout_dataset = super().cutout(**cutout_kwargs)
 
@@ -1500,21 +1505,22 @@ class MapDatasetOnOff(MapDataset):
             background = self.background * mask_safe
             background = background.sum_over_axes(keepdims=True)
             kwargs["acceptance_off"] = (
-                    kwargs["acceptance"] * kwargs["counts_off"] / background
+                kwargs["acceptance"] * kwargs["counts_off"] / background
             )
-        kwargs["counts"]=dataset.counts
-        kwargs["exposure"]=dataset.exposure
+        kwargs["counts"] = dataset.counts
+        kwargs["exposure"] = dataset.exposure
         # A priori these are None
-        kwargs["psf"]=dataset.psf
-        kwargs["edisp"]=dataset.edisp
+        kwargs["psf"] = dataset.psf
+        kwargs["edisp"] = dataset.edisp
         # We keep name
-        kwargs["name"]=dataset.name
-        kwargs["mask_fit"]=dataset.mask_fit
-        kwargs["mask_safe"]=dataset.mask_safe
-        kwargs["gti"]=dataset.gti
-        kwargs["evaluation_mode"]=dataset.evaluation_mode
+        kwargs["name"] = dataset.name
+        kwargs["mask_fit"] = dataset.mask_fit
+        kwargs["mask_safe"] = dataset.mask_safe
+        kwargs["gti"] = dataset.gti
+        kwargs["evaluation_mode"] = dataset.evaluation_mode
 
         return MapDatasetOnOff(**kwargs)
+
 
 class MapEvaluator:
     """Sky model evaluation on maps.

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -616,6 +616,8 @@ class MapDataset(Dataset):
         random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
                 Defines random number generator initialisation.
                 Passed to `~gammapy.utils.random.get_random_state`.
+        name : str
+            Name of the new dataset.
         """
         self._name = make_name(name)
         random_state = get_random_state(random_state)
@@ -694,6 +696,8 @@ class MapDataset(Dataset):
         ----------
         hdulist : `~astropy.io.fits.HDUList`
             List of HDUs.
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
@@ -765,6 +769,8 @@ class MapDataset(Dataset):
         ----------
         filename : str
             Filename to read from.
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
@@ -827,6 +833,8 @@ class MapDataset(Dataset):
             the input ON region on which to extract the spectrum
         containment_correction : bool
             Apply containment correction for point sources and circular on regions
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
@@ -895,6 +903,8 @@ class MapDataset(Dataset):
         spectrum : `~gammapy.modeling.models.SpectralModel`
             Spectral model to compute the weights.
             Default is power-law with spectral index of 2.
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
@@ -960,6 +970,8 @@ class MapDataset(Dataset):
             If only one value is passed, a square region is extracted.
         mode : {'trim', 'partial', 'strict'}
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
@@ -1033,6 +1045,9 @@ class MapDatasetOnOff(MapDataset):
         Mask defining the safe data range.
     gti : `~gammapy.data.GTI`
         GTI of the observation or union of GTI if it is a stacked observation
+    name : str
+        Name of the dataset.
+
     """
 
     stat_type = "wstat"
@@ -1262,6 +1277,8 @@ class MapDatasetOnOff(MapDataset):
         random_state : {int, 'random-seed', 'global-rng', `~numpy.random.RandomState`}
                 Defines random number generator initialisation.
                 Passed to `~gammapy.utils.random.get_random_state`.
+        name : str
+            Name of the new dataset.
         """
         self._name = make_name(name)
         random_state = get_random_state(random_state)
@@ -1309,6 +1326,8 @@ class MapDatasetOnOff(MapDataset):
         ----------
         hdulist : `~astropy.io.fits.HDUList`
             List of HDUs.
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
@@ -1354,7 +1373,7 @@ class MapDatasetOnOff(MapDataset):
             kwargs["gti"] = gti
         return cls(**kwargs)
 
-    def to_spectrum_dataset(self, on_region, containment_correction=False):
+    def to_spectrum_dataset(self, on_region, containment_correction=False, name=None):
         """Return a ~gammapy.spectrum.SpectrumDatasetOnOff from on_region.
 
         Counts and OFF counts are summed in the on_region.
@@ -1377,13 +1396,15 @@ class MapDatasetOnOff(MapDataset):
             the input ON region on which to extract the spectrum
         containment_correction : bool
             Apply containment correction for point sources and circular on regions
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
         dataset : `~gammapy.spectrum.SpectrumDatasetOnOff`
             the resulting reduced dataset
         """
-        dataset = super().to_spectrum_dataset(on_region, containment_correction)
+        dataset = super().to_spectrum_dataset(on_region, containment_correction, name)
 
         kwargs = {}
         if self.counts_off is not None:
@@ -1398,7 +1419,7 @@ class MapDatasetOnOff(MapDataset):
 
         return SpectrumDatasetOnOff.from_spectrum_dataset(dataset=dataset, **kwargs)
 
-    def cutout(self, position, width, mode="trim"):
+    def cutout(self, position, width, mode="trim", name=None):
         """Cutout map dataset.
 
         Parameters
@@ -1410,13 +1431,15 @@ class MapDatasetOnOff(MapDataset):
             If only one value is passed, a square region is extracted.
         mode : {'trim', 'partial', 'strict'}
             Mode option for Cutout2D, for details see `~astropy.nddata.utils.Cutout2D`.
+        name : str
+            Name of the new dataset.
 
         Returns
         -------
         cutout : `MapDatasetOnOff`
             Cutout map dataset.
         """
-        cutout_kwargs = {"position": position, "width": width, "mode": mode}
+        cutout_kwargs = {"position": position, "width": width, "mode": mode, "name": name}
 
         cutout_dataset = super().cutout(**cutout_kwargs)
 
@@ -1431,6 +1454,31 @@ class MapDatasetOnOff(MapDataset):
 
         return cutout_dataset
 
+    def to_image(self, spectrum=None, name=None):
+        """Create images by summing over the energy axis.
+
+        Exposure is weighted with an assumed spectrum,
+        resulting in a weighted mean exposure image.
+
+        Currently the PSFMap and EdispMap are dropped from the
+        resulting image dataset.
+
+        Parameters
+        ----------
+        spectrum : `~gammapy.modeling.models.SpectralModel`
+            Spectral model to compute the weights.
+            Default is power-law with spectral index of 2.
+        name : str
+            Name of the new dataset.
+
+        Returns
+        -------
+        dataset : `MapDataset`
+            Map dataset containing images.
+        """
+        dataset = super().to_image(spectrum, name)
+        
+        return dataset
 
 class MapEvaluator:
     """Sky model evaluation on maps.

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -135,8 +135,11 @@ class MapDataset(Dataset):
 
         exposure_min, exposure_max, exposure_unit = np.nan, np.nan, ""
         if self.exposure is not None:
-            mask = self.mask_safe.reduce_over_axes(np.logical_or).data
-            if not mask.any():
+            if self.mask_safe is not None:
+                mask = self.mask_safe.reduce_over_axes(np.logical_or).data
+                if not mask.any():
+                    mask = None
+            else:
                 mask = None
             exposure_min = np.min(self.exposure.data[..., mask])
             exposure_max = np.max(self.exposure.data[..., mask])
@@ -1439,9 +1442,11 @@ class MapDatasetOnOff(MapDataset):
         cutout : `MapDatasetOnOff`
             Cutout map dataset.
         """
-        cutout_kwargs = {"position": position, "width": width, "mode": mode, "name": name}
+        cutout_kwargs = {"position": position, "width": width, "mode": mode, "name":name}
 
         cutout_dataset = super().cutout(**cutout_kwargs)
+
+        del cutout_kwargs["name"]
 
         if self.counts_off is not None:
             cutout_dataset.counts_off = self.counts_off.cutout(**cutout_kwargs)
@@ -1477,7 +1482,7 @@ class MapDatasetOnOff(MapDataset):
             Map dataset containing images.
         """
         dataset = super().to_image(spectrum, name)
-        
+
         return dataset
 
 class MapEvaluator:

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1478,18 +1478,27 @@ class MapDatasetOnOff(MapDataset):
 
         Returns
         -------
-        dataset : `MapDataset`
+        dataset : `MapDatasetOnOff`
             Map dataset containing images.
         """
         dataset = super().to_image(spectrum, name)
 
+        if self.mask_safe is None:
+            mask_safe = 1
+        else:
+            mask_safe = self.mask_safe
+
         kwargs = {}
+
         if self.counts_off is not None:
-            kwargs["counts_off"] = self.counts_off.sum_over_axes(keepdims=True)
+            counts_off = self.counts_off * mask_safe
+            kwargs["counts_off"] = counts_off.sum_over_axes(keepdims=True)
 
         if self.acceptance is not None:
-            kwargs["acceptance"] = self.acceptance.reduce_over_axes(func=np.mean, keepdims=True)
-            background = self.background.sum_over_axes(keepdims=True)
+            acceptance = self.acceptance * mask_safe
+            kwargs["acceptance"] = acceptance.sum_over_axes(keepdims=True)
+            background = self.background * mask_safe
+            background = background.sum_over_axes(keepdims=True)
             kwargs["acceptance_off"] = (
                     kwargs["acceptance"] * kwargs["counts_off"] / background
             )

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -141,6 +141,9 @@ def test_map_dataset_str(sky_model, geom, geom_etrue):
     assert "(frozen)" in str(dataset)
     assert "background" in str(dataset)
 
+    dataset.mask_safe = None
+    assert "MapDataset" in str(dataset)
+
 
 @requires_data()
 def test_fake(sky_model, geom, geom_etrue):

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -774,6 +774,21 @@ def test_mapdatasetonoff_cutout(images):
     assert cutout_dataset.background_model is None
     assert cutout_dataset.name != dataset.name
 
+@requires_data()
+def test_mapdatasetonoff_to_image(images):
+    dataset = get_map_dataset_onoff(images)
+    gti = GTI.create([0 * u.s], [1 * u.h], reference_time="2010-01-01T00:00:00")
+    dataset.gti = gti
+
+    image_dataset = dataset.to_image()
+
+    assert image_dataset.counts.data.shape == (1, 50, 50)
+    assert cutout_dataset.counts_off.data.shape == (50, 50)
+    assert cutout_dataset.acceptance.data.shape == (50, 50)
+    assert cutout_dataset.acceptance_off.data.shape == (50, 50)
+    assert cutout_dataset.background_model is None
+    assert image_dataset.name != dataset.name
+
 
 def test_map_dataset_geom(geom, sky_model):
     e_true = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -259,6 +259,7 @@ def test_to_image(geom):
     dataset_im = dataset_copy.to_image()
     assert dataset_im.counts is None
 
+
 @requires_data()
 def test_map_dataset_fits_io(tmp_path, sky_model, geom, geom_etrue):
     dataset = get_map_dataset(sky_model, geom, geom_etrue)
@@ -777,16 +778,17 @@ def test_mapdatasetonoff_cutout(images):
     assert cutout_dataset.background_model is None
     assert cutout_dataset.name != dataset.name
 
+
 @requires_data()
 def test_mapdatasetonoff_to_image():
-    axis = MapAxis.from_energy_bounds(1,10,2, unit="TeV")
-    geom = WcsGeom.create(npix=(10,10),binsz=0.05,axes=[axis])
+    axis = MapAxis.from_energy_bounds(1, 10, 2, unit="TeV")
+    geom = WcsGeom.create(npix=(10, 10), binsz=0.05, axes=[axis])
 
-    counts = Map.from_geom(geom, data=np.ones((2,10,10)))
-    counts_off = Map.from_geom(geom, data=np.ones((2,10,10)))
-    acceptance = Map.from_geom(geom, data=np.ones((2,10,10)))
-    acceptance_off = Map.from_geom(geom, data=np.ones((2,10,10)))
-    acceptance_off*=2
+    counts = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    counts_off = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    acceptance = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    acceptance_off = Map.from_geom(geom, data=np.ones((2, 10, 10)))
+    acceptance_off *= 2
 
     dataset = MapDatasetOnOff(
         counts=counts,
@@ -798,20 +800,21 @@ def test_mapdatasetonoff_to_image():
 
     assert image_dataset.counts.data.shape == (1, 10, 10)
     assert image_dataset.acceptance_off.data.shape == (1, 10, 10)
-    assert_allclose(image_dataset.acceptance,2)
-    assert_allclose(image_dataset.acceptance_off,4)
-    assert_allclose(image_dataset.counts_off,2)
+    assert_allclose(image_dataset.acceptance, 2)
+    assert_allclose(image_dataset.acceptance_off, 4)
+    assert_allclose(image_dataset.counts_off, 2)
     assert image_dataset.name != dataset.name
 
     # Try with a safe_mask
-    mask_safe = Map.from_geom(geom, data=np.ones((2,10,10),dtype='bool'))
-    mask_safe.data[0]=0
+    mask_safe = Map.from_geom(geom, data=np.ones((2, 10, 10), dtype="bool"))
+    mask_safe.data[0] = 0
     dataset.mask_safe = mask_safe
     image_dataset = dataset.to_image()
 
-    assert_allclose(image_dataset.acceptance,1)
-    assert_allclose(image_dataset.acceptance_off,2)
-    assert_allclose(image_dataset.counts_off,1)
+    assert_allclose(image_dataset.acceptance, 1)
+    assert_allclose(image_dataset.acceptance_off, 2)
+    assert_allclose(image_dataset.counts_off, 1)
+
 
 def test_map_dataset_geom(geom, sky_model):
     e_true = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=5)
@@ -828,6 +831,7 @@ def test_map_dataset_geom(geom, sky_model):
 
     with pytest.raises(ValueError):
         dataset._geom
+
 
 @requires_data()
 def test_names(geom, geom_etrue, sky_model):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a `MapDatasetOnOff.to_image()` to `MapDatasetOnOff`. Previously it was only using the parent `to_image` method. Now it is properly overloaded to sum `counts_off`, `acceptance`, `acceptance_off`.
I also added `name` in many docstrings where it was missing. 
I also added a change to `MapDataset.__str__` to test if `mask_safe` is set or not and added a test for that.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This should solve issue #2734 . Part of issue #2736 as well. The `stack` methods should be adapted to deal with possible absence of `mask_safe`