### PR TITLE
Change SkyModels and Datasets inheritance to MutableSequence

### DIFF
--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -86,7 +86,7 @@ class Dataset(abc.ABC):
         return residuals
 
 
-class Datasets(collections.abc.Sequence):
+class Datasets(collections.abc.MutableSequence):
     """Dataset collection.
 
     Parameters
@@ -257,16 +257,32 @@ class Datasets(collections.abc.Sequence):
 
         return table_from_row_data(rows=rows)
 
-    def __getitem__(self, val):
-        if isinstance(val, (int, slice)):
-            return self._datasets[val]
-        elif isinstance(val, str):
+    def __getitem__(self, key):
+        return self._datasets[self._get_idx(key)]
+
+    def __delitem__(self, key):
+        del self._datasets[self._get_idx(key)]
+
+    def __setitem__(self, key, dataset):
+        if dataset.name in self.names:
+            raise (ValueError("Dataset names must be unique"))
+        self._datasets[self._get_idx(key)] = dataset
+
+    def insert(self, idx, dataset):
+        if dataset.name in self.names:
+            raise (ValueError("Dataset names must be unique"))
+        self._datasets.insert(idx, dataset)
+
+    def _get_idx(self, key):
+        if isinstance(key, (int, slice)):
+            return key
+        elif isinstance(key, str):
             for idx, dataset in enumerate(self._datasets):
-                if val == dataset.name:
-                    return self._datasets[idx]
-            raise IndexError(f"No dataset: {val!r}")
+                if key == dataset.name:
+                    return idx
+            raise IndexError(f"No dataset: {key!r}")
         else:
-            raise TypeError(f"Invalid type: {type(val)!r}")
+            raise TypeError(f"Invalid type: {type(key)!r}")
 
     def __len__(self):
         return len(self._datasets)

--- a/gammapy/modeling/datasets.py
+++ b/gammapy/modeling/datasets.py
@@ -264,14 +264,20 @@ class Datasets(collections.abc.MutableSequence):
         del self._datasets[self._get_idx(key)]
 
     def __setitem__(self, key, dataset):
-        if dataset.name in self.names:
-            raise (ValueError("Dataset names must be unique"))
-        self._datasets[self._get_idx(key)] = dataset
+        if isinstance(dataset, Dataset):
+            if dataset.name in self.names:
+                raise (ValueError("Dataset names must be unique"))
+            self._datasets[self._get_idx(key)] = dataset
+        else:
+            raise TypeError(f"Invalid type: {type(dataset)!r}")
 
     def insert(self, idx, dataset):
-        if dataset.name in self.names:
-            raise (ValueError("Dataset names must be unique"))
-        self._datasets.insert(idx, dataset)
+        if isinstance(dataset, Dataset):
+            if dataset.name in self.names:
+                raise (ValueError("Dataset names must be unique"))
+            self._datasets.insert(idx, dataset)
+        else:
+            raise TypeError(f"Invalid type: {type(dataset)!r}")
 
     def _get_idx(self, key):
         if isinstance(key, (int, slice)):

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -201,9 +201,14 @@ class Models(collections.abc.MutableSequence):
         del self._models[self._get_idx(key)]
 
     def __setitem__(self, key, model):
-        if model.name in self.names:
-            raise (ValueError("Model names must be unique"))
-        self._models[self._get_idx(key)] = model
+        from gammapy.modeling.models import SkyModel, SkyDiffuseCube
+
+        if isinstance(model, (SkyModel, SkyDiffuseCube)):
+            if model.name in self.names:
+                raise (ValueError("Model names must be unique"))
+            self._models[self._get_idx(key)] = model
+        else:
+            raise TypeError(f"Invalid type: {model!r}")
 
     def insert(self, idx, model):
         if model.name in self.names:

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -19,6 +19,7 @@ from gammapy.modeling.models import (
     create_fermi_isotropic_diffuse_model,
 )
 from gammapy.utils.testing import requires_data
+from copy import deepcopy
 
 
 @pytest.fixture(scope="session")
@@ -217,6 +218,34 @@ class TestSkyModels:
     @staticmethod
     def test_names(sky_models):
         assert sky_models.names == ["source-2", "source-3"]
+
+
+@requires_data()
+def test_SkyModels_mutation(sky_model, sky_models, sky_models_2):
+    mods = sky_models
+
+    mods.insert(0, sky_model)
+    assert mods.names == ["source-1", "source-2", "source-3"]
+
+    mods.extend(sky_models_2)
+    assert mods.names == ["source-1", "source-2", "source-3", "source-4", "source-5"]
+
+    mod3 = mods[3]
+    mods.remove(mods[3])
+    assert mods.names == ["source-1", "source-2", "source-3", "source-5"]
+    mods.append(mod3)
+    assert mods.names == ["source-1", "source-2", "source-3", "source-5", "source-4"]
+    mods.pop(3)
+    assert mods.names == ["source-1", "source-2", "source-3", "source-4"]
+
+    with pytest.raises(ValueError, match="Model names must be unique"):
+        mods.append(sky_model)
+    with pytest.raises(ValueError, match="Model names must be unique"):
+        mods.insert(0, sky_model)
+    with pytest.raises(ValueError, match="Model names must be unique"):
+        mods.extend(sky_models_2)
+    with pytest.raises(ValueError, match="Model names must be unique"):
+        sky_models + sky_models_2
 
 
 class TestSkyModel:

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -19,7 +19,6 @@ from gammapy.modeling.models import (
     create_fermi_isotropic_diffuse_model,
 )
 from gammapy.utils.testing import requires_data
-from copy import deepcopy
 
 
 @pytest.fixture(scope="session")
@@ -245,7 +244,7 @@ def test_SkyModels_mutation(sky_model, sky_models, sky_models_2):
     with pytest.raises(ValueError, match="Model names must be unique"):
         mods.extend(sky_models_2)
     with pytest.raises(ValueError, match="Model names must be unique"):
-        sky_models + sky_models_2
+        mods = sky_models + sky_models_2
 
 
 class TestSkyModel:

--- a/gammapy/modeling/tests/test_datasets.py
+++ b/gammapy/modeling/tests/test_datasets.py
@@ -38,3 +38,30 @@ def test_datasets_getitem(datasets):
 
 def test_names(datasets):
     assert datasets.names == ["test-1", "test-2"]
+
+
+def test_Datasets_mutation():
+    dat = MyDataset(name="test-1")
+    dats = Datasets([MyDataset(name="test-2"), MyDataset(name="test-3")])
+    dats2 = Datasets([MyDataset(name="test-4"), MyDataset(name="test-5")])
+
+    dats.insert(0, dat)
+    assert dats.names == ["test-1", "test-2", "test-3"]
+
+    dats.extend(dats2)
+    assert dats.names == ["test-1", "test-2", "test-3", "test-4", "test-5"]
+
+    dat3 = dats[3]
+    dats.remove(dats[3])
+    assert dats.names == ["test-1", "test-2", "test-3", "test-5"]
+    dats.append(dat3)
+    assert dats.names == ["test-1", "test-2", "test-3", "test-5", "test-4"]
+    dats.pop(3)
+    assert dats.names == ["test-1", "test-2", "test-3", "test-4"]
+
+    with pytest.raises(ValueError, match="Dataset names must be unique"):
+        dats.append(dat)
+    with pytest.raises(ValueError, match="Dataset names must be unique"):
+        dats.insert(0, dat)
+    with pytest.raises(ValueError, match="Dataset names must be unique"):
+        dats.extend(dats2)

--- a/gammapy/modeling/tests/test_fit.py
+++ b/gammapy/modeling/tests/test_fit.py
@@ -2,13 +2,13 @@
 """Unit tests for the Fit class"""
 import pytest
 from numpy.testing import assert_allclose
-from gammapy.modeling import Fit, Parameter, Parameters
+from gammapy.modeling import Fit, Parameter, Parameters, Dataset
 from gammapy.utils.testing import requires_dependency
 
 pytest.importorskip("iminuit")
 
 
-class MyDataset:
+class MyDataset(Dataset):
     def __init__(self, name=""):
         self.name = name
         self.parameters = Parameters(
@@ -32,7 +32,9 @@ class MyDataset:
             + ((z - z_opt) / z_err) ** 2
         )
 
-
+    def stat_array(self):
+        """Statistic array, one value per data point."""
+    
 @pytest.mark.parametrize("backend", ["minuit"])
 def test_run(backend):
     dataset = MyDataset()


### PR DESCRIPTION
- change SkyModels and Datasets inheritance to MutableSequence in order to gain .append(), .extend(), .pop(), .remove() methods as discussed in #2678