### PR TITLE
Adding checks for edisp, psf and bkg in MapDatasetEventSampler.run()

### DIFF
--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -339,9 +339,18 @@ class MapDatasetEventSampler:
 
         if dataset.psf:
             events_src = self.sample_psf(dataset.psf, events_src)
+        else:
+            events_src.table.add_columns(
+                (events_src.table["RA_TRUE"].data, events_src.table["DEC_TRUE"].data),
+                names=("RA", "DEC"),
+            )
 
         if dataset.edisp:
             events_src = self.sample_edisp(dataset.edisp, events_src)
+        else:
+            events_src.table.add_column(
+                events_src.table["ENERGY_TRUE"].data, name="ENERGY"
+            )
 
         if dataset.background_model:
             events_bkg = self.sample_background(dataset)

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -321,27 +321,34 @@ class MapDatasetEventSampler:
     def run(self, dataset, observation=None):
         """Run the event sampler, applying IRF corrections.
 
-        Parameters
-        ----------
-        dataset : `~gammapy.cube.MapDataset`
-            Map dataset
-        observation : `~gammapy.data.Observation`
-            In memory observation.
-        edisp : Bool
-            It allows to include or exclude the Edisp in the simulation.
+            Parameters
+            ----------
+            dataset : `~gammapy.cube.MapDataset`
+                Map dataset
+            observation : `~gammapy.data.Observation`
+                In memory observation.
+            edisp : Bool
+                It allows to include or exclude the Edisp in the simulation.
 
-        Returns
-        -------
-        events : `~gammapy.data.EventList`
-            Event list.
+            Returns
+            -------
+            events : `~gammapy.data.EventList`
+                Event list.
         """
-        events_bkg = self.sample_background(dataset)
         events_src = self.sample_sources(dataset)
-        events_src = self.sample_psf(dataset.psf, events_src)
 
-        events_src = self.sample_edisp(dataset.edisp, events_src)
+        if dataset.psf:
+            events_src = self.sample_psf(dataset.psf, events_src)
 
-        events = EventList.stack([events_bkg, events_src])
+        if dataset.edisp:
+            events_src = self.sample_edisp(dataset.edisp, events_src)
+
+        if dataset.background_model:
+            events_bkg = self.sample_background(dataset)
+            events = EventList.stack([events_bkg, events_src])
+        else:
+            events = events_src
+
         events.table["EVENT_ID"] = np.arange(len(events.table))
         events.table.meta = self.event_list_meta(dataset, observation)
 

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -321,36 +321,32 @@ class MapDatasetEventSampler:
     def run(self, dataset, observation=None):
         """Run the event sampler, applying IRF corrections.
 
-            Parameters
-            ----------
-            dataset : `~gammapy.cube.MapDataset`
-                Map dataset
-            observation : `~gammapy.data.Observation`
-                In memory observation.
-            edisp : Bool
-                It allows to include or exclude the Edisp in the simulation.
+        Parameters
+        ----------
+        dataset : `~gammapy.cube.MapDataset`
+            Map dataset
+        observation : `~gammapy.data.Observation`
+            In memory observation.
+        edisp : Bool
+            It allows to include or exclude the Edisp in the simulation.
 
-            Returns
-            -------
-            events : `~gammapy.data.EventList`
-                Event list.
+        Returns
+        -------
+        events : `~gammapy.data.EventList`
+            Event list.
         """
         events_src = self.sample_sources(dataset)
 
         if dataset.psf:
             events_src = self.sample_psf(dataset.psf, events_src)
         else:
-            events_src.table.add_columns(
-                (events_src.table["RA_TRUE"].data, events_src.table["DEC_TRUE"].data),
-                names=("RA", "DEC"),
-            )
+            events_src.table["RA"] = events_src.table["RA_TRUE"]
+            events_src.table["DEC"] = events_src.table["DEC_TRUE"]
 
         if dataset.edisp:
             events_src = self.sample_edisp(dataset.edisp, events_src)
         else:
-            events_src.table.add_column(
-                events_src.table["ENERGY_TRUE"].data, name="ENERGY"
-            )
+            events_src.table["ENERGY"] = events_src.table["ENERGY_TRUE"]
 
         if dataset.background_model:
             events_bkg = self.sample_background(dataset)

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -182,10 +182,40 @@ def test_mde_run(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.run(dataset=dataset, observation=obs)
 
-    assert len(events.table) == 2349
-    assert_allclose(events.table["ENERGY"][0], 1.894698, rtol=1e-5)
-    assert_allclose(events.table["RA"][0], 266.454448, rtol=1e-5)
-    assert_allclose(events.table["DEC"][0], -30.870316, rtol=1e-5)
+    assert len(events.table) == 2422
+    assert_allclose(events.table["ENERGY"][0], 1.56446303986587, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 268.8180057255861, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -28.45051813404372, rtol=1e-5)
+
+    meta = events.table.meta
+
+    assert meta["RA_PNT"] == 266.4049882865447
+    assert meta["ONTIME"] == 36000.0
+    assert meta["OBS_ID"] == 1001
+    assert meta["RADECSYS"] == "icrs"
+
+
+def test_mde_run_switchoff(dataset):
+    irfs = load_cta_irfs(
+        "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
+    )
+    livetime = 10.0 * u.hr
+    pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
+    obs = Observation.create(
+        obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
+    )
+
+    dataset.psf = None
+    dataset.edisp = None
+    dataset.background_model = None
+
+    sampler = MapDatasetEventSampler(random_state=0)
+    events = sampler.run(dataset=dataset, observation=obs)
+
+    assert len(events.table) == 2407
+    assert_allclose(events.table["ENERGY_TRUE"][0], 2.2450239000119323, rtol=1e-5)
+    assert_allclose(events.table["RA_TRUE"][0], 266.9128884464542, rtol=1e-5)
+    assert_allclose(events.table["DEC_TRUE"][0], -29.034641131874313, rtol=1e-5)
 
     meta = events.table.meta
 

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -213,9 +213,9 @@ def test_mde_run_switchoff(dataset):
     events = sampler.run(dataset=dataset, observation=obs)
 
     assert len(events.table) == 2407
-    assert_allclose(events.table["ENERGY_TRUE"][0], 2.2450239000119323, rtol=1e-5)
-    assert_allclose(events.table["RA_TRUE"][0], 266.9128884464542, rtol=1e-5)
-    assert_allclose(events.table["DEC_TRUE"][0], -29.034641131874313, rtol=1e-5)
+    assert_allclose(events.table["ENERGY"][0], 2.2450239000119323, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.9128884464542, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -29.034641131874313, rtol=1e-5)
 
     meta = events.table.meta
 

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -195,6 +195,7 @@ def test_mde_run(dataset):
     assert meta["RADECSYS"] == "icrs"
 
 
+@requires_data()
 def test_mde_run_switchoff(dataset):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"


### PR DESCRIPTION
This PR introduces a check for the existence of either the psf or edisp or bkg in the dataset object in the `MapDatasetEventSampler.run` method in `gammapy.cube`.