### PR TITLE
Make DataStoreObservation inherit from Observation

### DIFF
--- a/gammapy/utils/testing.py
+++ b/gammapy/utils/testing.py
@@ -140,8 +140,8 @@ def assert_skycoord_allclose(actual, desired):
     """
     assert isinstance(actual, SkyCoord)
     assert isinstance(desired, SkyCoord)
-    assert_allclose(actual.data.lon.value, desired.data.lon.value)
-    assert_allclose(actual.data.lat.value, desired.data.lat.value)
+    assert_allclose(actual.data.lon.deg, desired.data.lon.deg)
+    assert_allclose(actual.data.lat.deg, desired.data.lat.deg)
 
 
 def assert_time_allclose(actual, desired, atol=1e-3):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request is a follow up to #2744 . It implements the following changes:
- Add `Observation.obs_info` attribute
- Make `DataStoreObservation` inherit from `Observation`

This change guarantees the API homogeneity between both class and reduces code duplication.
This also addresses #2638.

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
