### PR TITLE
Fix WcsNDMap and MapDataset cutout to support mode='partial'

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1255,11 +1255,11 @@ class MapDatasetOnOff(MapDataset):
         # Factor containing: self.alpha * self.counts_off + other.alpha * other.counts_off
         tmp_factor = (self.alpha * self.counts_off).copy()
         tmp_factor.data[~self.mask_safe.data] = 0
-        tmp_factor.stack(other.alpha * other.counts_off, weights=other.mask_safe.data)
+        tmp_factor.stack(other.alpha * other.counts_off, weights=other.mask_safe)
 
         # Stack the off counts (in place)
         self.counts_off.data[~self.mask_safe.data] = 0
-        self.counts_off.stack(other.counts_off, weights=other.mask_safe.data)
+        self.counts_off.stack(other.counts_off, weights=other.mask_safe)
 
         self.acceptance_off = self.counts_off / tmp_factor
         self.acceptance.data = np.ones(self.data_shape)

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -150,7 +150,7 @@ def test_map_maker_ring(observations):
     )
 
     for obs in observations:
-        cutout = stacked.cutout(position=obs.pointing_radec, width="4 deg")
+        cutout = stacked.cutout(position=obs.pointing_radec, width="4 deg", mode='partial')
         dataset = map_dataset_maker.run(cutout, obs)
         dataset = safe_mask_maker.run(dataset, obs)
 
@@ -160,7 +160,7 @@ def test_map_maker_ring(observations):
         stacked.stack(dataset_on_off)
 
     assert_allclose(np.nansum(stacked.counts.data), 34366, rtol=1e-2)
-    assert_allclose(np.nansum(stacked.acceptance_off.data), 434.36, rtol=1e-2)
+    assert_allclose(np.nansum(stacked.acceptance_off.data), 278.142796, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -677,7 +677,7 @@ class WcsNDMap(WcsMap):
         slices = geom_cutout.cutout_info["cutout-slices"]
         cutout_slices = Ellipsis, slices[0], slices[1]
 
-        data = np.zeros(shape=geom_cutout.data_shape)
+        data = np.zeros(shape=geom_cutout.data_shape, dtype=self.data.dtype)
         data[cutout_slices] = self.data[parent_slices]
 
         return self._init_copy(geom=geom_cutout, data=data)
@@ -708,7 +708,7 @@ class WcsNDMap(WcsMap):
         data = other.data[cutout_slices]
 
         if weights is not None:
-            data = data * weights.data
+            data = data * weights.data[cutout_slices]
 
         self.data[parent_slices] += data
 

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -672,9 +672,13 @@ class WcsNDMap(WcsMap):
         geom_cutout = self.geom.cutout(position=position, width=width, mode=mode)
 
         slices = geom_cutout.cutout_info["parent-slices"]
+        parent_slices = Ellipsis, slices[0], slices[1]
+
+        slices = geom_cutout.cutout_info["cutout-slices"]
         cutout_slices = Ellipsis, slices[0], slices[1]
 
-        data = self.data[cutout_slices]
+        data = np.zeros(shape=geom_cutout.data_shape)
+        data[cutout_slices] = self.data[parent_slices]
 
         return self._init_copy(geom=geom_cutout, data=data)
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request solves issue #2754. First, an array of the correct size filled with 0 is created with the correct `dtype`. Then we add the content of the `WcsNDMap` using the the parenting cutout slices.
The `cutout-slices` are also used for the `weight` map that is used in `WcsNDMap`.

Note that I had put a test to ensure that `other` and `weights` have the same `WcsGeom`. This breaks many tests as it seems not to be the case in many situation. I found that puzzling. Maybe this should be clarified.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This is ready for review. We need to see whether `mode='partial'` should be the default for most observation loops. I tend to believe it should be since at least `RingBackgroundMaker` and `FoVBrackgroundMaker` need for field of view datasets to properly work.
Any opinion @adonath @AtreyeeS ?

I put v0.16 as milestone, and we'll see if we can really merge this in on time.