### PR TITLE
Add config params for get_flux_points method in High-level interface

### DIFF
--- a/docs/analysis/index.rst
+++ b/docs/analysis/index.rst
@@ -188,6 +188,14 @@ is stored in the ``flux_points`` property as a `~gammapy.spectrum.FluxPoints` ob
       7.07945784384138 1.4907957189689605e-12 ...   4.74857915062012e-14 False
     >>> analysis.flux_points.peek()
 
+You may set fine-grained optional parameters for the `~gammapy.spectrum.FluxPointsEstimator` in the
+``flux_points.params`` settings.
+
+.. code-block:: python
+
+    >>>  analysis.config.flux_points.params["reoptimize"]=True
+
+
 Residuals
 ---------
 

--- a/docs/analysis/index.rst
+++ b/docs/analysis/index.rst
@@ -177,7 +177,8 @@ is stored in the ``flux_points`` property as a `~gammapy.spectrum.FluxPoints` ob
 
 .. code-block:: python
 
-    >>> analysis.get_flux_points(source="crab")
+    >>> analysis.config.flux_points.source="crab"
+    >>> analysis.get_flux_points()
     INFO:gammapy.analysis.analysis:Calculating flux points.
     INFO:gammapy.analysis.analysis:
           e_ref               ref_flux        ...        dnde_err        is_ul

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -120,7 +120,7 @@ class TimeRangeConfig(GammapyBaseConfig):
 
 class FluxPointsConfig(GammapyBaseConfig):
     energy: EnergyAxisConfig = EnergyAxisConfig()
-
+    params: dict = {}
 
 class FitConfig(GammapyBaseConfig):
     fit_range: EnergyRangeConfig = EnergyRangeConfig()

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -120,6 +120,7 @@ class TimeRangeConfig(GammapyBaseConfig):
 
 class FluxPointsConfig(GammapyBaseConfig):
     energy: EnergyAxisConfig = EnergyAxisConfig()
+    source: str = "source"
     params: dict = {}
 
 class FitConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -55,4 +55,5 @@ fit:
 # Flux estimation process /optional
 flux_points:
     energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
+    source: "source"
     params: {}

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -55,3 +55,4 @@ fit:
 # Flux estimation process /optional
 flux_points:
     energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
+    params: {}

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -200,8 +200,9 @@ class Analysis:
         # TODO: add "source" to config
         log.info("Calculating flux points.")
         e_edges = self._make_energy_axis(fp_settings.energy).edges
+        fp_params = self.config.flux_points.params
         flux_point_estimator = FluxPointsEstimator(
-            e_edges=e_edges, datasets=self.datasets, source=source
+            e_edges=e_edges, datasets=self.datasets, source=source, **fp_params
         )
         fp = flux_point_estimator.run()
         fp.table["is_ul"] = fp.table["ts"] < 4

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -185,28 +185,20 @@ class Analysis:
         self.fit_result = self.fit.run(optimize_opts=optimize_opts)
         log.info(self.fit_result)
 
-    def get_flux_points(self, source="source"):
-        """Calculate flux points for a specific model component.
-
-        Parameters
-        ----------
-        source : string
-            Name of the model component where to calculate the flux points.
-        """
+    def get_flux_points(self):
+        """Calculate flux points for a specific model component."""
         if not self.fit:
             raise RuntimeError("No results available from Fit.")
 
         fp_settings = self.config.flux_points
-        # TODO: add "source" to config
         log.info("Calculating flux points.")
         e_edges = self._make_energy_axis(fp_settings.energy).edges
-        fp_params = self.config.flux_points.params
         flux_point_estimator = FluxPointsEstimator(
-            e_edges=e_edges, datasets=self.datasets, source=source, **fp_params
+            e_edges=e_edges, datasets=self.datasets, source=fp_settings.source, **fp_settings.params
         )
         fp = flux_point_estimator.run()
         fp.table["is_ul"] = fp.table["ts"] < 4
-        self.flux_points = FluxPointsDataset(data=fp, models=self.models[source])
+        self.flux_points = FluxPointsDataset(data=fp, models=self.models[fp_settings.source])
         cols = ["e_ref", "ref_flux", "dnde", "dnde_ul", "dnde_err", "is_ul"]
         log.info("\n{}".format(self.flux_points.data.table[cols]))
 

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -498,7 +498,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analysis.get_flux_points(source=\"crab\")"
+    "analysis.config.flux_points.source=\"crab\"\n",
+    "analysis.get_flux_points()"
    ]
   },
   {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request addresses issue #2714.

It adds the possibility to set optional configuration params for `FluxPointsEstimator` in a `params` dictionary variable, as part of the `flux_points` settings. This `params` variable can declared in a configuration file or set with a command in the terminal.

```
 analysis.config.flux_points.params["reoptimize"]=True
```

It also adds `source` parameter in the `flux_points` settings.
