### PR TITLE
Fixing osx travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-gallery sphinx-click sphinx_rtd_theme pytest-astropy parfive pydantic'
 
-        - CONDA_CHANNELS='conda-forge sherpa'
+        - CONDA_CHANNELS='astropy sherpa'
         - FETCH_GAMMAPY_DATA=true
         - TEST_COVERAGE=false
         - TEST_PACKAGING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ matrix:
         # Test conda build (which runs a bunch of useful tests after building the package)
         # See https://conda.io/docs/bdist_conda.html
         - env: CMD='python setup.py bdist_conda'
-               TEST_PACKAGING=true
+               TEST_PACKAGING=true CONDA_CHANNELS='astropy sherpa conda-forge'
 
         # Test with Astropy dev version
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=dev CMD='make test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
         - TEST_COVERAGE=false
         - TEST_PACKAGING=false
         - RUN_INSTALL=true
-        - DEBUG=true
+        - DEBUG=True
 
 stages:
    # Do the style check and a single test job, don't proceed if it fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ addons:
       - graphviz
       - texlive-latex-extra
       - dvipng
-      - gfortran
 
 env:
     global:
@@ -31,10 +30,10 @@ env:
         - ASTROPY_VERSION=stable
         - ASTROPY_USE_SYSTEM_PYTEST=1
 
-        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa libgfortran regions reproject pandoc ipython iminuit'
+        - CONDA_DEPENDENCIES='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_OSX='Cython click scipy healpy matplotlib pyyaml pandas naima sherpa regions reproject pandoc ipython iminuit'
         - CONDA_DEPENDENCIES_WO_SHERPA='Cython click scipy healpy matplotlib pyyaml pandas naima regions reproject pandoc ipython iminuit'
-        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa libgfortran regions reproject pandoc ipython jupyter iminuit'
+        - CONDA_DEPENDENCIES_DOCS='Cython click scipy healpy matplotlib pyyaml pandas naima pygments sherpa regions reproject pandoc ipython jupyter iminuit'
 
         - PIP_DEPENDENCIES='nbsphinx sphinx-astropy sphinx-gallery sphinx-click sphinx_rtd_theme pytest-astropy parfive pydantic'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ install:
     # bdist_conda must be installed into a root conda environment,
     # as it imports conda and conda_build. It is included as part of the conda build package.
     - if $TEST_PACKAGING; then
-          conda install -n root conda-build astropy Cython click regions;
+          conda install -n root conda-build astropy Cython click regions pydantic;
           conda info;
           conda --version;
           conda build --version;


### PR DESCRIPTION
The root of the problem is that numpy 1.18 is not yet available on conda-forge and somehow the osx build behaves differently than the linux one and thus picking up the older 1.17 version from there, but then everything is being messed up. I don't have a good understanding what goes one.

However, not using conda-forge solving the issue (https://travis-ci.org/bsipocz/gammapy/jobs/645280744), so I suggest to stick with the defaults channel along with the specialized small ones, like astropy and sherpa.

Also, you could consider doing pip installs instead, now when most packages have wheels it's quicker, too, but I recall that there were some strong opinions about sticking with conda, so I didn't change anything on that front.
