### PR TITLE
Li&Ma statistics

### DIFF
--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -81,6 +81,34 @@ Li \& Ma formula:
     >>> significance_on_off(n_on=18, n_off=97, alpha=1. / 10, method='lima')
     2.2421704424844875
 
+Error on an excess
+-------------------
+
+The computation of the error on an excess is of practical utility. Two
+possibilities are possible, either using the Li&Ma maximum likelihood
+estimate (the method per default) or using the following approximation:
+
+.. math::
+    error = \sqrt{n_{on} + \alpha^2 * n_{off}}.
+
+.. code-block:: python
+
+    >>> from gammapy.stats import excess_error
+    >>> excess_error(n_on=4, n_off=9, alpha=0.5, method='lima')
+    2.552490234375
+    >>> excess_error(n_on=4, n_off=9, alpha=0.5, method='simple')
+    2.5
+
+On can derive also the positive and negative errors of an excess following the Li&Ma methodology, as following:
+
+.. code-block:: python
+
+    >>> from gammapy.stats import lm_dexcess_up, , lm_dexcess_down
+    >>> lm_dexcess_up(n_on=30, n_off=10, alpha=0.9)
+    6.39453125
+    >>> lm_dexcess_down(n_on=30, n_off=10, alpha=0.9)
+    6.001953125
+
 Confidence Intervals
 --------------------
 
@@ -111,8 +139,8 @@ Using `gammapy.stats`
     :maxdepth: 1
 
     feldman_cousins
+    li_ma
     fit_statistics
-    wstat_derivation
 
 Reference/API
 =============

--- a/docs/stats/li_ma.rst
+++ b/docs/stats/li_ma.rst
@@ -1,0 +1,98 @@
+.. li_ma:
+
+Li \& Ma methods of estimate errors and significance
+====================================================
+
+Li, T.-P. and Ma, Y.-Q. [LiMa1983]_ have derived procedures to derive significance of
+a gamma-ray signal based on a likelihood ratio method. This method, verified by Monte-Carlo
+simulations, is very accurate in the Gaussian regime and also in the Poisson regime. This
+methodology have been extended to compute errors on excess, as well as the asymmetric errors
+(positive and negative).
+
+The functions ``gammapy.stats.lm_*`` give you access to a numerical solution to
+the Li&Ma formulae.
+
+The significance estimate of Li \& Ma (eq. 17)
+--------------------------------------------
+
+The standard use of their work is the computation of the significance of an excess.
+The method used the likelihood ratio :math:`\lambda = \frac{L(X|{H_1})}{L(X|H_0)}`,
+where the null hypothesis :math:`H_0` assumes no signal and the hypothesis :math:`H_1`
+assumes a gamma-ray excess, using the Poisson statistics. Assymptotically, :math:`-2 \ln \lambda` follows a :math:`\chi^2`
+distribution with 1 degree of freedom.
+
+Extensive Monte-Carlo simulations have been used to check the statistical behaviour of the Li&Ma formula for different regime (weak and large
+counts, small and big :math:`\alpha = \frac{Acceptance_{ON}}{Acceptance_{OFF}}` values).
+
+Let's note that the Li&Ma formula assumes a correct estimation of the :math:`\alpha` parameter. If a
+large statistical error exists on it, the :math:`\sigma` estimation is biased and its
+distribution does not follow anymore a Gaussian with a width of 1. Its distribution is enlarged
+significantly.
+
+.. code-block:: python
+
+    >>> from gammapy.stats.li_ma import lm_significance_on_off
+    >>> non = 8
+    >>> noff = 60
+    >>> alpha = 0.1
+    >>> lm_significance_on_off(non, noff, alpha)
+    0.7368243826529305
+
+    >>> non = [8, 13]
+    >>> noff = [60, 45]
+    >>> alpha = [0.1, 1.]
+    >>> lm_significance_on_off(non, noff, alpha)
+    array([ 0.73682438, -4.32226689])
+
+An other equivalent way to have this estimate if the following:
+
+.. code-block:: python
+
+    >>> from gammapy.stats.poisson import significance_on_off
+    >>> non = 8
+    >>> noff = 60
+    >>> alpha = 0.1
+    >>> lm_significance_on_off(non, noff, alpha)
+    0.7368243826529305
+
+The errors estimate based on Li \& Ma
+--------------------------------------
+
+The likelihood estimation of Li&Ma has been used to estimate errors on an excess, as
+well as its positive and negative estimations. Its implementation uses the computation of the
+likelihood value, via ``gammapy.stats.lm_loglikelihood``. The downward, upward and averaged
+excess uncertainties of an on-off observation can be then computed as follow:
+
+.. code-block:: python
+
+    >>> from gammapy.stats.li_ma import lm_dexcess_down, lm_dexcess_up
+    >>> non = 12
+    >>> noff = 40
+    >>> alpha = 0.25
+    >>> lm_dexcess_down(non, noff, alpha)
+    3.56689453125
+    >>> lm_dexcess_up(non, noff, alpha)
+    4.0869140625
+
+And the average error is then:
+
+.. code-block:: python
+
+    >>> from gammapy.stats.li_ma import lm_dexcess
+    >>> non = 12
+    >>> noff = 40
+    >>> alpha = 0.25
+    >>> lm_dexcess(non, noff, alpha)
+    3.826904296875
+
+
+An other equivalent way to have this estimate if the following:
+
+.. code-block:: python
+
+    >>> from gammapy.stats.poisson import excess_error
+    >>> non = 8
+    >>> noff = 60
+    >>> alpha = 0.1
+    >>> excess_error(non, noff, alpha, method='lima')
+    2.947509765625

--- a/gammapy/stats/__init__.py
+++ b/gammapy/stats/__init__.py
@@ -5,3 +5,4 @@ from .fit_statistics import *
 from .fit_statistics_cython import *
 from .normal import *
 from .poisson import *
+from .li_ma import *

--- a/gammapy/stats/li_ma.py
+++ b/gammapy/stats/li_ma.py
@@ -1,0 +1,347 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Li and Ma algorithm to compute parameter confidence limits and significance."""
+import logging
+import numpy as np
+
+__all__ = [
+    "lm_loglikelihood",
+    "lm_dexcess_down",
+    "lm_dexcess_up",
+    "lm_dexcess",
+    "lm_significance_on_off",
+    "lm_significance"
+]
+
+log = logging.getLogger(__name__)
+
+
+def lm_loglikelihood(n_on, n_off, alpha, signal):
+    r"""Compute Li&Ma Log-likelihood.
+
+    Note: This is a little trick to avoid problems for negative signal
+    (note that this method is often called with signal=excess).
+    In that case the Poisson signal + b0 can become negative
+    and log(signal + b0) isn't defined, i.e. the likelihood cannot be computed.
+    To avoid this problem, the on and off regions are switched
+
+    For more information see :ref:`documentation <li_ma>`.
+
+    Parameters
+    ----------
+    n_on : float
+        Observed number of counts in the on region
+    n_off : float
+        Observed number of counts in the off region
+    alpha : float
+        On / off region exposure ratio for background events
+    signal : float
+        Number of excess in the on region
+
+    Returns
+    -------
+    log_likelihood : `~numpy.ndarray`
+
+    """
+    if signal > 0:
+        n1 = n_on
+        n2 = n_off
+        aa = alpha
+    else:
+        n2 = n_on
+        n1 = n_off
+        aa = 1.0 / alpha
+        signal = -aa * signal
+
+    # Maximum likelihood background estimate b0
+    tt = (1+aa) * signal - aa * (n1+n2)
+    delta = tt*tt + 4 * aa * (1+aa) * signal * n2
+    b0 = (np.sqrt(delta) - tt) / (2 + 2*aa)
+    # b0 should always be >= 0.
+    # Just to avoid possible problems with rounding errors:
+    if b0 < 0:
+        b0 = 0.
+
+    # Compute Poisson log likelihood r for two measurements: on / off
+    ll = n1 * np.log(signal + b0) + n2 * np.log(b0 / aa) - (signal + b0) - b0 / aa
+    return ll
+
+
+def lm_dexcess_down(n_on, n_off, alpha, n_sig=1.):
+    r"""Compute downward excess uncertainties of an on-off observation based on Li&Ma [1]. [LiMa1983]_
+
+    Searches the average value of the signal for which the log-likelihood ratio is n_sig away
+
+    Note: The required step in log likelihood for "nsig sigma errors" is offset = 0.5*n_sig^2
+            http://wwwasdoc.web.cern.ch/wwwasdoc/minuit/node30.html
+
+    For more information see :ref:`documentation <li_ma>`.
+
+    Parameters
+    ----------
+    n_on : array_like
+        Observed number of counts in the on region
+    n_off : array_like
+        Observed number of counts in the off region
+    alpha : array_like
+        On / off region exposure ratio for background events
+    n_sig : float
+        Number of sigma
+
+    Returns
+    -------
+    significance : `~numpy.ndarray`
+        Error estimate
+
+     References
+    ----------
+    * Li and Ma, "Analysis methods for results in gamma-ray astronomy"
+      <https://ui.adsabs.harvard.edu/abs/1983ApJ...272..317L>`_
+    """
+    scalar = False
+    if np.isscalar(n_on):
+        n_on = np.array([n_on])
+        scalar = True
+    if np.isscalar(n_off):
+        n_off = np.array([n_off])
+        scalar = True
+    if np.isscalar(alpha):
+        alpha = np.array([alpha])
+        scalar = True
+    n_on = np.asanyarray(n_on, dtype=np.float64)
+    n_off = np.asanyarray(n_off, dtype=np.float64)
+    alpha = np.asanyarray(alpha, dtype=np.float64)
+    n_sig = np.full(n_on.shape, n_sig)
+
+    # Optimal value of signal
+    excess0 = n_on - n_off * alpha
+    l0 = np.zeros(n_on.shape)
+    for ii in range(len(n_on)):
+        l0[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], excess0[ii])
+
+    # Search for signal such as -2 * log H > 1 * sig
+    # i.e. find a signal > dExcess_Up so that we can
+    # use an interval bisection algorithm to find dExcess_Up
+    offset = np.full(n_on.shape, n_sig*n_sig*0.5)
+    signal = excess0.copy() - 1
+    ll = np.zeros(n_on.shape)
+    for ii in range(len(n_on)):
+        ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+        count = 0
+        while (l0[ii]-ll[ii]) < offset[ii] and np.isfinite(ll[ii]) and count < 100:
+            signal[ii] = (signal[ii]-excess0[ii]) * 2. + excess0[ii]
+            ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+            count += 1
+
+    # Dichotomic search (i.e. interval bisection algorithm)
+    up = excess0.copy()
+    low = signal.copy()
+    signal = (up+low)/2.
+    for ii in range(len(n_on)):
+        ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+        count = 0.
+        while np.abs(l0[ii]-ll[ii]-offset[ii]) > 1e-4 and np.isfinite(ll[ii]) and count < 100:
+            if l0[ii]-ll[ii] > offset[ii]:
+                low[ii] = signal[ii]
+            else:
+                up[ii] = signal[ii]
+            signal[ii] = (up[ii]+low[ii])/2.
+            ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+            count += 1
+
+    if scalar:
+        return np.abs(signal[0] - excess0[0])
+    return np.abs(signal - excess0)
+
+
+def lm_dexcess_up(n_on, n_off, alpha, n_sig=1.):
+    r"""Compute upward excess uncertainties of an on-off observation based on Li&Ma [1].
+
+    Searches the average value of the signal for which the log-likelihood ratio is n_sig away
+
+    Note: The required step in log likelihood for "nsig sigma errors" is offset = 0.5*n_sig^2
+            http://wwwasdoc.web.cern.ch/wwwasdoc/minuit/node30.html
+
+    Parameters
+    ----------
+    n_on : array_like
+        Observed number of counts in the on region
+    n_off : array_like
+        Observed number of counts in the off region
+    alpha : array_like
+        On / off region exposure ratio for background events
+    n_sig : float
+        Number of sigma
+
+    Returns
+    -------
+    significance : `~numpy.ndarray`
+        Error estimate
+
+    References
+    ----------
+    .. [1] Li and Ma, "Analysis methods for results in gamma-ray astronomy",
+       `Link <https://ui.adsabs.harvard.edu/abs/1983ApJ...272..317L>`_
+    """
+    scalar = False
+    if np.isscalar(n_on):
+        n_on = np.array([n_on])
+        scalar = True
+    if np.isscalar(n_off):
+        n_off = np.array([n_off])
+        scalar = True
+    if np.isscalar(alpha):
+        alpha = np.array([alpha])
+        scalar = True
+    n_on = np.asarray(n_on, dtype=np.float64)
+    n_off = np.asanyarray(n_off, dtype=np.float64)
+    alpha = np.asanyarray(alpha, dtype=np.float64)
+    n_sig = np.full(n_on.shape, n_sig)
+
+    # Optimal value of signal
+    excess0 = n_on - n_off * alpha
+    l0 = np.zeros(n_on.shape)
+    for ii in range(len(n_on)):
+        l0[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], excess0[ii])
+
+    # Search for signal such as -2 * log H > 1 * sig
+    # i.e. find a signal > dExcess_Up so that we can
+    # use an interval bisection algorithm to find dExcess_Up
+    offset = np.full(n_on.shape, n_sig*n_sig*0.5)
+    signal = excess0.copy() + 1
+    ll = np.zeros(n_on.shape)
+    for ii in range(len(ll)):
+        ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+        count = 0
+        while (l0[ii]-ll[ii]) < offset[ii] and np.isfinite(ll[ii]) and count < 100:
+            signal[ii] = (signal[ii]-excess0[ii]) * 2. + excess0[ii]
+            ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+            count += 1
+
+    # Dichotomic search (i.e. interval bisection algorithm)
+    low = excess0.copy()
+    up = signal.copy()
+    signal = (up+low)/2.
+    for ii in range(len(ll)):
+        ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+        count = 0.
+        while np.abs(l0[ii]-ll[ii]-offset[ii]) > 1e-4 and np.isfinite(ll[ii]) and count < 100:
+            if (l0[ii]-ll[ii]) > offset[ii]:
+                up[ii] = signal[ii]
+            else:
+                low[ii] = signal[ii]
+            signal[ii] = (up[ii]+low[ii])/2.
+            ll[ii] = lm_loglikelihood(n_on[ii], n_off[ii], alpha[ii], signal[ii])
+            count += 1
+
+    if scalar:
+        return np.abs(signal[0] - excess0[0])
+    return np.abs(signal - excess0)
+
+
+def lm_dexcess(n_on, n_off, alpha, n_sig=1.):
+    r"""Compute mean excess uncertainties of an on-off observation based on Li&Ma [1].
+
+    lm_dexcess = (lm_dexcess_up + lm_dexcess_down) / 2
+
+    Parameters
+    ----------
+    n_on : array_like
+        Observed number of counts in the on region
+    n_off : array_like
+        Observed number of counts in the off region
+    alpha : array_like
+        On / off region exposure ratio for background events
+    n_sig : float
+        Number of sigma
+
+    Returns
+    -------
+    significance : `~numpy.ndarray`
+        Error estimate
+
+    References
+    ----------
+    .. [1] Li and Ma, "Analysis methods for results in gamma-ray astronomy",
+       `Link <https://ui.adsabs.harvard.edu/abs/1983ApJ...272..317L>`_
+    """
+    err_up = lm_dexcess_up(n_on, n_off, alpha, n_sig)
+    err_down = lm_dexcess_down(n_on, n_off, alpha, n_sig)
+    err = (err_up + err_down) / 2.
+    return err
+
+
+def lm_significance_on_off(n_on, n_off, alpha):
+    r"""
+    Compute significance with the Li & Ma formula (17) [1]_.
+
+    Parameters
+    ----------
+    n_on : array_like
+        Observed number of counts in the on region
+    n_off : array_like
+        Observed number of counts in the off region
+    alpha : array_like
+        On / off region exposure ratio for background events
+
+    Returns
+    -------
+    significance : `~numpy.ndarray`
+        Significance estimate
+
+    References
+    ----------
+    .. [1] Li and Ma, "Analysis methods for results in gamma-ray astronomy",
+       `Link <https://ui.adsabs.harvard.edu/abs/1983ApJ...272..317L>`_
+    """
+    n_on = np.asanyarray(n_on, dtype=np.float64)
+    n_off = np.asanyarray(n_off, dtype=np.float64)
+    alpha = np.asanyarray(alpha, dtype=np.float64)
+
+    sign = np.sign(n_on - alpha*n_off)
+
+    tt = (alpha + 1) / (n_on + n_off)
+    ll = n_on * np.log(n_on * tt / alpha)
+    mm = n_off * np.log(n_off * tt)
+    val = np.sqrt(np.abs(2 * (ll + mm)))
+
+    return sign * val
+
+
+def lm_significance(n_on, mu_bkg):
+    r"""Compute significance for an observed number of counts and known background.
+
+    IT gives the significance estimate corresponding
+    to equation (17) from the Li & Ma paper [1]_ in the limiting of known background
+    :math:`\mu_{bkg} = \alpha \times n_{off}` with :math:`\alpha \to 0`.
+
+    It is given by the following formula:
+
+    .. math::
+        S_{lima} = \sqrt{2} \left[
+          n_{on} \log \left( \frac{n_{on}}{\mu_{bkg}} \right) - n_{on} + \mu_{bkg}
+        \right] ^ {1/2}
+
+   Parameters
+    ----------
+    n_on : array_like
+        Observed number of counts
+    mu_bkg : array_like
+        Known background level
+
+    Returns
+    -------
+    significance : `~numpy.ndarray`
+        Significance estimate
+
+    References
+    ----------
+    .. [1] Li and Ma, "Analysis methods for results in gamma-ray astronomy",
+       `Link <https://ui.adsabs.harvard.edu/abs/1983ApJ...272..317L>`_
+
+    See Also
+    --------
+    excess, significance_on_off
+    """
+    sign = np.sign(n_on - mu_bkg)
+    val = np.sqrt(2) * np.sqrt(n_on * np.log(n_on / mu_bkg) - n_on + mu_bkg)
+    return sign * val

--- a/gammapy/stats/tests/test_li_ma.py
+++ b/gammapy/stats/tests/test_li_ma.py
@@ -1,0 +1,44 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+from gammapy.stats import (
+    lm_loglikelihood,
+    lm_dexcess_down,
+    lm_dexcess_up,
+    lm_dexcess,
+    lm_significance
+)
+
+
+def test_significance():
+    n_on = 10
+    n_off = 20
+    alpha = 0.1
+    assert_allclose(lm_significance(n_on, n_off, alpha), 3.6850322319420274, atol=0.01)
+
+    n_off = [20, 8]
+    alpha = [0.1, 1]
+    sol = [3.6850322319420274, 0.47189166410776]
+    assert_allclose(lm_significance(n_on, n_off, alpha), sol, atol=0.01)
+
+
+def test_error():
+    n_on = 10
+    n_off = 200
+    alpha = 0.1
+    assert_allclose(lm_dexcess_up(n_on, n_off, alpha), 3.7529, atol=0.01)
+    assert_allclose(lm_dexcess_down(n_on, n_off, alpha), 3.2104, atol=0.01)
+    assert_allclose(lm_dexcess(n_on, n_off, alpha), 3.4816, atol=0.01)
+
+    n_on = [50, 7.]
+    n_off = [20, 8]
+    alpha = [0.1, 1]
+    sol = [7.0893, 3.9353]
+    assert_allclose(lm_dexcess(n_on, n_off, alpha), sol, atol=0.01)
+
+    n_on = 7
+    n_off = 8
+    alpha = 1.
+    assert_allclose(lm_dexcess_up(n_on, n_off, alpha), 3.9140, atol=0.01)
+    assert_allclose(lm_dexcess_down(n_on, n_off, alpha), 3.9565, atol=0.01)


### PR DESCRIPTION
**Description**
This pull request aims to add functions based on Li&Ma methods to compute excess errors. Following recommendations of @registerrier, a new class has been created that contains all functions to compute the Li&Ma errors. For logical reasons, the Li&Ma significance computation that exists has been moved from poisson.py to this new class.

This PR contains also the test functions, and also the improvement of the documentation in order to describe this new class.

**Possible improvements**
In this current implementation, few points might be improved/cleaned:
- As by default the 'significance' functions can take as arguments either an int or an array, the current codes support this feature. The 'tricks' to make it could be improved however: see lines 100-113 and 185-198 of li_ma.py
- The reference of the Li&Ma paper in the docstrings and the rst files is not coded identically. What is the good way?
- The content of the Li&Ma general documentation could be developed as a statistical lecture. But I think that the reading of the paper is the best. Feel free to adapt/change the documentation.