### PR TITLE
Implement `LazyFitsData` descriptor

### DIFF
--- a/docs/analysis/index.rst
+++ b/docs/analysis/index.rst
@@ -102,7 +102,7 @@ create a composed filter.
 .. gp-howto-hli:: observations
 
 You may use the `get_observations()` method to proceed to make the observation filtering.
-The observations are stored as a list of `~gammapy.data.DataStoreObservation` objects.
+The observations are stored as a list of `~gammapy.data.Observation` objects.
 
 .. code-block:: python
 

--- a/docs/overview/DL3.rst
+++ b/docs/overview/DL3.rst
@@ -37,7 +37,7 @@ Application in gammapy
 ----------------------
 
 The main classes in Gammapy to access the DL3 data library are the
-`~gammapy.data.DataStore` and `~gammapy.data.DataStoreObservation`.
+`~gammapy.data.DataStore` and `~gammapy.data.Observation`.
 They are used to store and retrieve dynamically the datasets
 relevant to any observation (event list in the form of an `~gammapy.data.EventList`,
 IRFs see :ref:`irf` and other relevant informations).

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -53,7 +53,7 @@ class MapDatasetMaker:
         ----------
         geom : `~gammapy.maps.Geom`
             Reference map geom.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container.
 
         Returns
@@ -73,7 +73,7 @@ class MapDatasetMaker:
         ----------
         geom : `~gammapy.maps.Geom`
             Reference map geom.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container.
 
         Returns
@@ -96,7 +96,7 @@ class MapDatasetMaker:
         ----------
         geom : `~gammapy.maps.Geom`
             Reference geom.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container.
 
         Returns
@@ -118,7 +118,7 @@ class MapDatasetMaker:
         ----------
         geom : `~gammapy.maps.Geom`
             Reference geom.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container.
 
         Returns
@@ -153,7 +153,7 @@ class MapDatasetMaker:
         ----------
         geom : `~gammapy.maps.Geom`
             Reference geom.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container.
 
         Returns
@@ -177,7 +177,7 @@ class MapDatasetMaker:
         ----------
         geom : `~gammapy.maps.Geom`
             Reference geom.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container.
 
         Returns
@@ -206,7 +206,7 @@ class MapDatasetMaker:
         ----------
         dataset : `~gammapy.cube.MapDataset`
             Reference dataset.
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation
 
         Returns
@@ -303,7 +303,7 @@ class SafeMaskMaker:
         ----------
         dataset : `~gammapy.modeling.Dataset`
             Dataset to compute mask for.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute mask for.
 
         Returns
@@ -322,7 +322,7 @@ class SafeMaskMaker:
         ----------
         dataset : `~gammapy.modeling.Dataset`
             Dataset to compute mask for.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute mask for.
 
         Returns
@@ -432,7 +432,7 @@ class SafeMaskMaker:
         ----------
         dataset : `~gammapy.modeling.Dataset`
             Dataset to compute mask for.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute mask for.
 
         Returns

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -4,11 +4,12 @@ import subprocess
 from pathlib import Path
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
+from gammapy.utils.table import table_row_to_dict
 from gammapy.utils.scripts import make_path
 from gammapy.utils.testing import Checker
 from .hdu_index_table import HDUIndexTable
 from .obs_table import ObservationTable, ObservationTableChecker
-from .observations import DataStoreObservation, ObservationChecker, Observations
+from .observations import Observation, ObservationChecker, Observations
 
 __all__ = ["DataStore"]
 
@@ -196,7 +197,32 @@ class DataStore:
         observation : `~gammapy.data.DataStoreObservation`
             Observation container
         """
-        return DataStoreObservation(obs_id=int(obs_id), data_store=self)
+        if obs_id not in self.obs_table["OBS_ID"]:
+            raise ValueError(f"OBS_ID = {obs_id} not in obs index table.")
+
+        if obs_id not in self.hdu_table["OBS_ID"]:
+            raise ValueError(f"OBS_ID = {obs_id} not in HDU index table.")
+
+        row = self.obs_table.select_obs_id(obs_id=obs_id)[0]
+        obs_info = table_row_to_dict(row)
+
+        aeff_hdu = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type="aeff")
+        edisp_hdu = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type="edisp")
+        bkg_hdu = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type="bkg")
+        psf_hdu = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type="psf")
+        events_hdu = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type="events")
+        gti_hdu = self.hdu_table.hdu_location(obs_id=obs_id, hdu_type="gti")
+
+        return Observation(
+            obs_id=int(obs_id),
+            obs_info=obs_info,
+            bkg=bkg_hdu,
+            aeff=aeff_hdu,
+            edisp=edisp_hdu,
+            events=events_hdu,
+            gti=gti_hdu,
+            psf=psf_hdu,
+        )
 
     def get_observations(self, obs_id=None, skip_missing=False):
         """Generate a `~gammapy.data.Observations`.

--- a/gammapy/data/data_store.py
+++ b/gammapy/data/data_store.py
@@ -185,7 +185,7 @@ class DataStore:
             return s
 
     def obs(self, obs_id):
-        """Access a given `~gammapy.data.DataStoreObservation`.
+        """Access a given `~gammapy.data.Observation`.
 
         Parameters
         ----------
@@ -194,7 +194,7 @@ class DataStore:
 
         Returns
         -------
-        observation : `~gammapy.data.DataStoreObservation`
+        observation : `~gammapy.data.Observation`
             Observation container
         """
         if obs_id not in self.obs_table["OBS_ID"]:
@@ -237,7 +237,7 @@ class DataStore:
         Returns
         -------
         observations : `~gammapy.data.Observations`
-            Container holding a list of `~gammapy.data.DataStoreObservation`
+            Container holding a list of `~gammapy.data.Observation`
         """
         if obs_id is None:
             obs_id = self.obs_table["OBS_ID"].data

--- a/gammapy/data/filters.py
+++ b/gammapy/data/filters.py
@@ -25,7 +25,7 @@ class ObservationFilter:
 
     Examples
     --------
-    >>> from gammapy.data import ObservationFilter, DataStore, DataStoreObservation
+    >>> from gammapy.data import ObservationFilter, DataStore, Observation
     >>> from astropy.time import Time
     >>> from astropy.coordinates import Angle
     >>>
@@ -35,7 +35,8 @@ class ObservationFilter:
     >>> my_obs_filter = ObservationFilter(time_filter=time_filter, event_filters=[phase_filter])
     >>>
     >>> ds = DataStore.from_dir("$GAMMAPY_DATA/cta-1dc/index/gps")
-    >>> my_obs = DataStoreObservation(obs_id=111630, data_store=ds, obs_filter=my_obs_filter)
+    >>> my_obs = ds.obs(obs_id=111630)
+    >>> my_obs.obs_filter = my_obs_filter
     """
 
     EVENT_FILTER_TYPES = dict(sky_region="select_region", custom="select_parameter")

--- a/gammapy/data/hdu_index_table.py
+++ b/gammapy/data/hdu_index_table.py
@@ -17,7 +17,7 @@ class HDULocation:
 
     This represents one row in `HDUIndexTable`.
 
-    It's more a helper class, that is wrapped by `~gammapy.data.DataStoreObservation`,
+    It's more a helper class, that is wrapped by `~gammapy.data.Observation`,
     usually those objects will be used to access data.
 
     See also :ref:`gadf:hdu-index`.

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -131,7 +131,7 @@ class Observation:
         obs : `gammapy.data.MemoryObservation`
         """
         if "DataStore" in cls.__name__:
-            raise ValueError("DataStoreObservation cannot be created in memory")
+            raise ValueError("Observation cannot be created in memory")
 
         tstart = tstart or Quantity(0.0, "hr")
         tstop = (tstart + Quantity(livetime)) or tstop
@@ -370,7 +370,7 @@ class Observation:
 
         Returns
         -------
-        new_obs : `~gammapy.data.DataStoreObservation`
+        new_obs : `~gammapy.data.Observation`
             A new observation instance of the specified time interval
         """
         new_obs_filter = self.obs_filter.copy()
@@ -386,7 +386,7 @@ class Observations(collections.abc.MutableSequence):
     Parameters
     ----------
     observations : list
-        A list of `~gammapy.data.DataStoreObservation`
+        A list of `~gammapy.data.Observation`
     """
 
     def __init__(self, observations=None):

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -10,7 +10,6 @@ from gammapy.irf import (
     Background3D, load_cta_irfs, Background2D, EffectiveAreaTable2D, EnergyDispersion2D, PSF3D, PSFKing, EnergyDependentMultiGaussPSF
 )
 from gammapy.utils.fits import earth_location_from_dict, LazyFitsData
-from gammapy.utils.table import table_row_to_dict
 from gammapy.utils.testing import Checker
 from .event_list import EventListChecker, EventList
 from .filters import ObservationFilter
@@ -46,12 +45,12 @@ class Observation:
     obs_filter : `ObservationFilter`
         Observation filter.
     """
-    aeff = LazyFitsData(cls=EffectiveAreaTable2D, cache=False)
-    edisp = LazyFitsData(cls=EnergyDispersion2D, cache=False)
-    psf= LazyFitsData(cls=(PSFKing, PSF3D, EnergyDependentMultiGaussPSF), cache=False)
-    bkg = LazyFitsData(cls=(Background2D, Background3D), cache=False)
-    _events = LazyFitsData(cls=EventList, cache=False)
-    _gti = LazyFitsData(cls=GTI, cache=False)
+    aeff = LazyFitsData(cache=False)
+    edisp = LazyFitsData(cache=False)
+    psf = LazyFitsData(cache=False)
+    bkg = LazyFitsData(cache=False)
+    _events = LazyFitsData(cache=False)
+    _gti = LazyFitsData(cache=False)
 
     def __init__(
         self,

--- a/gammapy/data/observations.py
+++ b/gammapy/data/observations.py
@@ -6,12 +6,10 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
-from gammapy.irf import (
-    Background3D, load_cta_irfs, Background2D, EffectiveAreaTable2D, EnergyDispersion2D, PSF3D, PSFKing, EnergyDependentMultiGaussPSF
-)
+from gammapy.irf import Background3D, load_cta_irfs
 from gammapy.utils.fits import earth_location_from_dict, LazyFitsData
 from gammapy.utils.testing import Checker
-from .event_list import EventListChecker, EventList
+from .event_list import EventListChecker
 from .filters import ObservationFilter
 from .gti import GTI
 from .pointing import FixedPointingInfo

--- a/gammapy/data/tests/test_observations.py
+++ b/gammapy/data/tests/test_observations.py
@@ -22,8 +22,8 @@ def data_store():
 
 
 @requires_data()
-def test_data_store_observation(data_store):
-    """Test DataStoreObservation class"""
+def test_observation(data_store):
+    """Test Observation class"""
     obs = data_store.obs(23523)
 
     assert_time_allclose(obs.tstart, Time(53343.92234009259, scale="tt", format="mjd"))

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -12,7 +12,7 @@ def make_psf(observation, position, energy=None, rad=None):
 
     Parameters
     ----------
-    observation : `~gammapy.data.DataStoreObservation`
+    observation : `~gammapy.data.Observation`
         Observation for which to compute the PSF
     position : `~astropy.coordinates.SkyCoord`
         Position at which to compute the PSF

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -56,7 +56,7 @@ class SpectrumDatasetMaker:
             Region to compute counts spectrum for.
         energy_axis : `~gammapy.maps.MapAxis`
             Reconstructed energy axis.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute effective area for.
 
         Returns
@@ -85,7 +85,7 @@ class SpectrumDatasetMaker:
             Region to compute background spectrum for.
         energy_axis : `~gammapy.maps.MapAxis`
             Reconstructed energy axis.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute effective area for.
 
         Returns
@@ -124,7 +124,7 @@ class SpectrumDatasetMaker:
             Region to compute background effective area.
         energy_axis_true : `~gammapy.maps.MapAxis`
             True energy axis.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute effective area for.
 
         Returns
@@ -160,7 +160,7 @@ class SpectrumDatasetMaker:
             Reconstructed energy axis.
         energy_axis_true : `~gammapy.maps.MapAxis`
             True energy axis.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to compute edisp for.
 
         Returns
@@ -180,7 +180,7 @@ class SpectrumDatasetMaker:
         ----------
         dataset : `~gammapy.spectrum.SpectrumDataset`
             Spectrum dataset.
-        observation: `~gammapy.data.DataStoreObservation`
+        observation: `~gammapy.data.Observation`
             Observation to reduce.
 
         Returns

--- a/gammapy/spectrum/phase.py
+++ b/gammapy/spectrum/phase.py
@@ -90,7 +90,7 @@ class PhaseBackgroundMaker:
         ----------
         dataset : `SpectrumDataset`
             Input dataset.
-        observation : `DataStoreObservation`
+        observation : `Observation`
             Data store observation.
 
         Returns

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -206,14 +206,11 @@ class LazyFitsData(object):
 
     Parameters
     ----------
-    cls : object
-        Class to be instantiated.
     cache : bool
         Whether to cache the data.
     """
 
-    def __init__(self, cls, cache=True):
-        self.cls = cls
+    def __init__(self, cache=True):
         self.cache = cache
 
     def __set_name__(self, owner, name):
@@ -233,14 +230,10 @@ class LazyFitsData(object):
     def __set__(self, instance, value):
         from gammapy.data import HDULocation
 
-        if isinstance(value, self.cls) or value is None:
-            instance.__dict__[self.name] = value
-
-        elif isinstance(value, HDULocation):
+        if isinstance(value, HDULocation):
             instance.__dict__[self.name + "_hdu"] = value
-
         else:
-            raise ValueError(f"Either instance of {self.cls} or {HDULocation} required")
+            instance.__dict__[self.name] = value
 
 
 def energy_axis_to_ebounds(energy):

--- a/gammapy/utils/fits.py
+++ b/gammapy/utils/fits.py
@@ -197,7 +197,50 @@ from astropy.io import fits
 from astropy.table import Table
 from astropy.units import Quantity
 
-__all__ = ["energy_axis_to_ebounds", "earth_location_from_dict"]
+
+__all__ = ["energy_axis_to_ebounds", "earth_location_from_dict", "LazyFitsData"]
+
+
+class LazyFitsData(object):
+    """A lazy FITS data descriptor.
+
+    Parameters
+    ----------
+    cls : object
+        Class to be instantiated.
+    cache : bool
+        Whether to cache the data.
+    """
+
+    def __init__(self, cls, cache=True):
+        self.cls = cls
+        self.cache = cache
+
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, instance, objtype):
+        value = instance.__dict__.get(self.name)
+        if value is not None:
+            return value
+        else:
+            hdu_loc = instance.__dict__.get(self.name + "_hdu")
+            value = hdu_loc.load()
+            if self.cache:
+                instance.__dict__[self.name] = value
+            return value
+
+    def __set__(self, instance, value):
+        from gammapy.data import HDULocation
+
+        if isinstance(value, self.cls) or value is None:
+            instance.__dict__[self.name] = value
+
+        elif isinstance(value, HDULocation):
+            instance.__dict__[self.name + "_hdu"] = value
+
+        else:
+            raise ValueError(f"Either instance of {self.cls} or {HDULocation} required")
 
 
 def energy_axis_to_ebounds(energy):


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a `LazyFitsData` descriptor, which allows to merge the `Observation` and `DataStoreObservation` class. Instead of the data class itself, the `Observation` can now be instantiated with an `HDULocation` object. If this is the case the location is stored in the `Observation.__dict__` and the data is load (and optionally cached) on access of `Observation.events`, `Observations.edisp` etc.

This pattern could also be re-used later for lazy loading of `MapDataset` objects. For now there is just the advantage of getting rid of the `DataStoreObservation` class.

From https://github.com/gammapy/gammapy-benchmarks/pull/53 one can see that the benchmark results are not affected.

**Dear reviewer**
Please double check the benchmark results. 

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
