### PR TITLE
Set dark matter primary flux to zero beyond particle mass energy

### DIFF
--- a/gammapy/astro/darkmatter/spectra.py
+++ b/gammapy/astro/darkmatter/spectra.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 from gammapy.modeling import Parameter
 from gammapy.modeling.models import SpectralModel, TemplateSpectralModel
 from gammapy.utils.scripts import make_path
+from gammapy.utils.interpolation import LogScale
 
 __all__ = ["PrimaryFlux", "DarkMatterAnnihilationSpectralModel"]
 
@@ -117,7 +118,7 @@ class PrimaryFlux:
         channel_name = self.channel_registry[self.channel]
         dN_dlogx = subtable[channel_name]
         dN_dE = dN_dlogx / (energies * np.log(10))
-        return TemplateSpectralModel(energy=energies, values=dN_dE)
+        return TemplateSpectralModel(energy=energies, values=dN_dE, interp_kwargs={"fill_value":np.log(LogScale.tiny)})
 
 
 class DarkMatterAnnihilationSpectralModel(SpectralModel):

--- a/gammapy/astro/darkmatter/tests/test_utils.py
+++ b/gammapy/astro/darkmatter/tests/test_utils.py
@@ -31,5 +31,5 @@ def test_dmfluxmap(jfact):
     diff_flux = DarkMatterAnnihilationSpectralModel(mass=massDM, channel=channel)
     int_flux = (jfact * diff_flux.integral(emin=emin, emax=emax)).to("cm-2 s-1")
     actual = int_flux[5, 5]
-    desired = 1.948518e-12 / u.cm ** 2 / u.s
+    desired = 1.94834138e-12 / u.cm ** 2 / u.s
     assert_quantity_allclose(actual, desired, rtol=1e-5)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request fixes issue #2770 

It sets the primary flux to zero for energy ranges beyond the dark matter particle masses considered in tabular spectra given by `AtProduction_gammas.dat`. Hence the `TemplateSpectralModel` built with this tabular data are extrapolated to zero, providing the expected cut-off.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
