### PR TITLE
Add region serialization on CountsSpectrum and SpectrumDataset

### DIFF
--- a/gammapy/spectrum/core.py
+++ b/gammapy/spectrum/core.py
@@ -31,6 +31,8 @@ class CountsSpectrum:
         Data unit
     region : `~regions.SkyRegion`
         Region the spectrum is defined for.
+    wcs : `~astropy.wcs.WCS`
+        the wcs system used to perform region based event selection
 
     Examples
     --------
@@ -51,7 +53,7 @@ class CountsSpectrum:
         spec.plot(show_poisson_errors=True)
     """
 
-    def __init__(self, energy_lo, energy_hi, data=None, unit="", region=None):
+    def __init__(self, energy_lo, energy_hi, data=None, unit="", region=None, wcs=None):
         e_edges = edges_from_lo_hi(energy_lo, energy_hi)
         self.energy = MapAxis.from_edges(e_edges, interp="log", name="energy")
 
@@ -64,6 +66,7 @@ class CountsSpectrum:
 
         self.unit = u.Unit(unit)
         self.region = region
+        self.wcs = wcs
 
     @property
     def quantity(self):

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -67,7 +67,7 @@ class SpectrumDatasetMaker:
         edges = energy_axis.edges
 
         counts = CountsSpectrum(
-            energy_hi=edges[1:], energy_lo=edges[:-1], region=region
+            energy_hi=edges[1:], energy_lo=edges[:-1], region=region, wcs=self.geom_ref(region).wcs
         )
         events_region = observation.events.select_region(
             region, wcs=self.geom_ref(region).wcs
@@ -112,7 +112,7 @@ class SpectrumDatasetMaker:
         data *= observation.observation_time_duration
 
         return CountsSpectrum(
-            energy_hi=e_reco[1:], energy_lo=e_reco[:-1], data=data.to_value(""), unit=""
+            energy_hi=e_reco[1:], energy_lo=e_reco[:-1], data=data.to_value(""), unit="",
         )
 
     def make_aeff(self, region, energy_axis_true, observation):

--- a/gammapy/spectrum/reflected.py
+++ b/gammapy/spectrum/reflected.py
@@ -324,7 +324,7 @@ class ReflectedRegionsBackgroundMaker:
 
             edges = dataset.counts.energy.edges
             counts_off = CountsSpectrum(
-                energy_hi=edges[1:], energy_lo=edges[:-1], region=region_union
+                energy_hi=edges[1:], energy_lo=edges[:-1], region=region_union, wcs=wcs
             )
             counts_off.fill_events(events_off)
             acceptance_off = len(finder.reflected_regions)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -5,8 +5,7 @@ from numpy.testing import assert_allclose
 from astropy import units as u
 from astropy.units import Quantity
 from gammapy.irf import EDispKernel, EffectiveAreaTable
-from gammapy.maps import MapAxis
-from gammapy.maps import WcsGeom
+from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -6,6 +6,7 @@ from astropy import units as u
 from astropy.units import Quantity
 from gammapy.irf import EDispKernel, EffectiveAreaTable
 from gammapy.maps import MapAxis
+from gammapy.maps import WcsGeom
 from gammapy.modeling.models import (
     PowerLawSpectralModel,
     SkyModel,
@@ -13,6 +14,7 @@ from gammapy.modeling.models import (
 )
 from gammapy.spectrum import CountsSpectrum
 from gammapy.spectrum.core import SpectrumEvaluator
+from gammapy.utils.regions import make_region
 from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
@@ -24,8 +26,14 @@ class TestCountsSpectrum:
     def setup(self):
         self.counts = [0, 0, 2, 5, 17, 3]
         self.bins = MapAxis.from_energy_bounds(1, 10, 6, "TeV").edges
+
+        # Create region and associated wcs
+        region = make_region("galactic;circle(0,1,0.5)")
+        self.region = region.union(make_region("galactic;box(1,-0.25,1.2,3.5,30)"))
+        self.wcs = WcsGeom.create(npix=500, binsz=0.01,skydir=(0,0), frame='galactic').wcs
+
         self.spec = CountsSpectrum(
-            data=self.counts, energy_lo=self.bins[:-1], energy_hi=self.bins[1:]
+            data=self.counts, energy_lo=self.bins[:-1], energy_hi=self.bins[1:], region=self.region, wcs=self.wcs
         )
 
     def test_wrong_init(self):

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -13,7 +13,7 @@ from gammapy.modeling.models import (
 )
 from gammapy.spectrum import CountsSpectrum
 from gammapy.spectrum.core import SpectrumEvaluator
-from gammapy.utils.regions import make_region
+from gammapy.utils.regions import make_region, compound_region_to_list
 from gammapy.utils.testing import (
     assert_quantity_allclose,
     mpl_plot_check,
@@ -55,11 +55,12 @@ class TestCountsSpectrum:
         self.spec.write(tmp_path / "tmp.fits")
         spec2 = CountsSpectrum.read(tmp_path / "tmp.fits")
         assert_quantity_allclose(spec2.energy.edges, self.bins)
-        assert len(spec2.region) == 2
-        assert_allclose(spec2.region[0].center.l.to_value("deg"),0.)
-        assert_allclose(spec2.region[0].radius.to_value("deg"),0.5)
-        assert_allclose(spec2.region[1].center.b.to_value("deg"),-0.25)
-        assert_allclose(spec2.region[1].angle.to_value("deg"),30)
+        regions = compound_region_to_list(spec2.region)
+        assert len(regions) == 2
+        assert_allclose(regions[0].center.l.to_value("deg"),0.)
+        assert_allclose(regions[0].radius.to_value("deg"),0.5)
+        assert_allclose(regions[1].center.b.to_value("deg"),-0.25)
+        assert_allclose(regions[1].angle.to_value("deg"),30)
 
     def test_downsample(self):
         rebinned_spec = self.spec.downsample(2)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -56,7 +56,10 @@ class TestCountsSpectrum:
         spec2 = CountsSpectrum.read(tmp_path / "tmp.fits")
         assert_quantity_allclose(spec2.energy.edges, self.bins)
         assert len(spec2.region) == 2
-        assert_allclose(spec2.region[0].center.l,0.)
+        assert_allclose(spec2.region[0].center.l.to_value("deg"),0.)
+        assert_allclose(spec2.region[0].radius.to_value("deg"),0.5)
+        assert_allclose(spec2.region[1].center.b.to_value("deg"),-0.25)
+        assert_allclose(spec2.region[1].angle.to_value("deg"),30)
 
     def test_downsample(self):
         rebinned_spec = self.spec.downsample(2)

--- a/gammapy/spectrum/tests/test_core.py
+++ b/gammapy/spectrum/tests/test_core.py
@@ -55,6 +55,8 @@ class TestCountsSpectrum:
         self.spec.write(tmp_path / "tmp.fits")
         spec2 = CountsSpectrum.read(tmp_path / "tmp.fits")
         assert_quantity_allclose(spec2.energy.edges, self.bins)
+        assert len(spec2.region) == 2
+        assert_allclose(spec2.region[0].center.l,0.)
 
     def test_downsample(self):
         rebinned_spec = self.spec.downsample(2)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces a region serialization mechanism on the `CountsSpectrum` and the `SpectrumDataset`.
It follows the scheme defined here https://fits.gsfc.nasa.gov/registry/region/region.pdf, which is implemented in `regions.fits_region_objects_to_table` and  `regions.FITSRegionParser`. A `Table` storing the `PixelRegion` is build and a `WCS` object is added to be able to convert to and from `SkyRegion`.

Tests have been added to check that the regions after serialization match the input ones.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
This should be ready for review. The stacking process still remains to be implemented for `CountsSpectrum.region`. It is not totally clear how to include this in the arithmetic implemented there.