### PR TITLE
Add support for FoVBackground on the HLI

### DIFF
--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -67,8 +67,8 @@ class FrameEnum(str, Enum):
 
 class BackgroundMethodEnum(str, Enum):
     reflected = "reflected"
-    fov_background = "fov_background"
-
+    fov = "fov_background"
+    no_background = "None"
 
 class SafeMaskMethodsEnum(str, Enum):
     aeff_default = "aeff-default"

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -68,7 +68,6 @@ class FrameEnum(str, Enum):
 class BackgroundMethodEnum(str, Enum):
     reflected = "reflected"
     fov = "fov_background"
-    no_background = ""
 
 
 class SafeMaskMethodsEnum(str, Enum):
@@ -139,7 +138,7 @@ class FitConfig(GammapyBaseConfig):
 
 
 class BackgroundConfig(GammapyBaseConfig):
-    method: BackgroundMethodEnum = BackgroundMethodEnum.reflected
+    method: BackgroundMethodEnum = None
     exclusion: FilePath = None
     parameters: dict = {}
 

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -130,7 +130,7 @@ class TimeRangeConfig(GammapyBaseConfig):
 class FluxPointsConfig(GammapyBaseConfig):
     energy: EnergyAxisConfig = EnergyAxisConfig()
     source: str = "source"
-    params: dict = {}
+    parameters: dict = {}
 
 
 class FitConfig(GammapyBaseConfig):
@@ -145,7 +145,7 @@ class BackgroundConfig(GammapyBaseConfig):
 
 class SafeMaskConfig(GammapyBaseConfig):
     methods: List[SafeMaskMethodsEnum] = [SafeMaskMethodsEnum.aeff_default]
-    settings: dict = {}
+    parameters: dict = {}
 
 
 class EnergyAxesConfig(GammapyBaseConfig):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -68,7 +68,7 @@ class FrameEnum(str, Enum):
 class BackgroundMethodEnum(str, Enum):
     reflected = "reflected"
     fov = "fov_background"
-    no_background = "None"
+    no_background = ""
 
 
 class SafeMaskMethodsEnum(str, Enum):

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -70,6 +70,7 @@ class BackgroundMethodEnum(str, Enum):
     fov = "fov_background"
     no_background = "None"
 
+
 class SafeMaskMethodsEnum(str, Enum):
     aeff_default = "aeff-default"
     aeff_max = "aeff-max"
@@ -141,6 +142,7 @@ class BackgroundConfig(GammapyBaseConfig):
     method: BackgroundMethodEnum = BackgroundMethodEnum.reflected
     exclusion: FilePath = None
     parameters: dict = {}
+
 
 class SafeMaskConfig(GammapyBaseConfig):
     methods: List[SafeMaskMethodsEnum] = [SafeMaskMethodsEnum.aeff_default]

--- a/gammapy/analysis/config.py
+++ b/gammapy/analysis/config.py
@@ -67,6 +67,7 @@ class FrameEnum(str, Enum):
 
 class BackgroundMethodEnum(str, Enum):
     reflected = "reflected"
+    fov_background = "fov_background"
 
 
 class SafeMaskMethodsEnum(str, Enum):
@@ -139,7 +140,7 @@ class FitConfig(GammapyBaseConfig):
 class BackgroundConfig(GammapyBaseConfig):
     method: BackgroundMethodEnum = BackgroundMethodEnum.reflected
     exclusion: FilePath = None
-
+    parameters: dict = {}
 
 class SafeMaskConfig(GammapyBaseConfig):
     methods: List[SafeMaskMethodsEnum] = [SafeMaskMethodsEnum.aeff_default]

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -41,9 +41,10 @@ datasets:
     background:
         method: reflected   # also fov_background
         exclusion:          # fits file for exclusion mask
+        parameters: {}
     safe_mask:
             methods: ['aeff-default','offset-max' ]
-            settings: {offset_max: 2.5 deg}
+            parameters: {offset_max: 2.5 deg}
     on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 3 deg}
     containment_correction: true
 
@@ -57,4 +58,4 @@ fit:
 flux_points:
     energy: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
     source: "source"
-    params: {}
+    parameters: {}

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -39,8 +39,8 @@ datasets:
             energy_true: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
     map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     background:
-        method: reflected   # also '' (no bkg estimation applied) or fov_background (for 3d)
-        exclusion:    # fits file for exclusion mask
+        method: reflected   # also fov_background
+        exclusion:          # fits file for exclusion mask
     safe_mask:
             methods: ['aeff-default','offset-max' ]
             settings: {offset_max: 2.5 deg}

--- a/gammapy/analysis/config/docs.yaml
+++ b/gammapy/analysis/config/docs.yaml
@@ -39,7 +39,7 @@ datasets:
             energy_true: {min: 0.1 TeV, max: 10 TeV, nbins: 30}
     map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     background:
-        method: reflected
+        method: reflected   # also '' (no bkg estimation applied) or fov_background (for 3d)
         exclusion:    # fits file for exclusion mask
     safe_mask:
             methods: ['aeff-default','offset-max' ]

--- a/gammapy/analysis/config/example-1d.yaml
+++ b/gammapy/analysis/config/example-1d.yaml
@@ -9,8 +9,6 @@ datasets:
     geom:
         axes:
             energy: {min: 0.01 TeV, max: 100 TeV, nbins: 73}
-    background:
-        method: reflected
     on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.1 deg}
     containment_correction: true
 

--- a/gammapy/analysis/config/example-3d.yaml
+++ b/gammapy/analysis/config/example-3d.yaml
@@ -20,7 +20,7 @@ datasets:
     map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
     safe_mask:
         methods: ['offset-max']
-        settings: {offset_max: 2.5 deg}
+        parameters: {offset_max: 2.5 deg}
     background:
         method: fov_background
         parameters: {method: 'scale'}

--- a/gammapy/analysis/config/example-3d.yaml
+++ b/gammapy/analysis/config/example-3d.yaml
@@ -21,6 +21,9 @@ datasets:
     safe_mask:
         methods: ['offset-max']
         settings: {offset_max: 2.5 deg}
+    background:
+        method: fov_background
+        parameters: {method: 'scale'}
 
 fit:
     fit_range: {min: 1 TeV, max: 10 TeV}

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -254,18 +254,22 @@ class Analysis:
             methods=safe_mask_selection, **safe_mask_settings
         )
 
-        bkg_maker_config = {}
-        if self.config.datasets.background.exclusion:
-            exclusion_region = Map.read(self.config.datasets.background.exclusion)
-            bkg_maker_config["exclusion_mask"] = exclusion_region
-        bkg_maker_config.update(self.config.datasets.background.parameters)
-
         bkg_method = self.config.datasets.background.method
         if bkg_method == "fov_background":
-            log.debug(f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}")
+            bkg_maker_config = {}
+            if self.config.datasets.background.exclusion:
+                exclusion_region = Map.read(self.config.datasets.background.exclusion)
+                bkg_maker_config["exclusion_mask"] = exclusion_region
+            bkg_maker_config.update(self.config.datasets.background.parameters)
+            log.debug(
+                f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}"
+            )
             bkg_maker = FoVBackgroundMaker(**bkg_maker_config)
         else:
             bkg_maker = None
+            log.warning(
+                f"No background maker set for 1d analysis. Check configuration."
+            )
 
         stacked = MapDataset.create(geom=geom, name="stacked", **geom_irf)
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -69,7 +69,8 @@ class Analysis:
 
     def get_observations(self):
         """Fetch observations from the data store according to criteria defined in the configuration."""
-        path = make_path(self.config.observations.datastore)
+        observations_settings = self.config.observations
+        path = make_path(observations_settings.datastore)
         if path.is_file():
             self.datastore = DataStore.from_file(path)
         elif path.is_dir():
@@ -78,7 +79,6 @@ class Analysis:
             raise FileNotFoundError(f"Datastore not found: {path}")
 
         log.info("Fetching observations.")
-        observations_settings = self.config.observations
         if (
             len(observations_settings.obs_ids)
             and observations_settings.obs_file is not None
@@ -96,7 +96,7 @@ class Analysis:
             obs_list = self.datastore.get_observations(observations_settings.obs_ids)
             ids = [obs.obs_id for obs in obs_list]
         else:
-            path = make_path(self.config.observations.obs_file)
+            path = make_path(observations_settings.obs_file)
             ids = list(Table.read(path, format="ascii", data_start=0).columns[0])
 
         if observations_settings.obs_cone.lon is not None:
@@ -111,9 +111,9 @@ class Analysis:
             selected_cone = self.datastore.obs_table.select_observations(cone)
             ids = list(set(ids) & set(selected_cone["OBS_ID"].tolist()))
         self.observations = self.datastore.get_observations(ids, skip_missing=True)
-        if self.config.observations.obs_time.start is not None:
-            start = self.config.observations.obs_time.start
-            stop = self.config.observations.obs_time.stop
+        if observations_settings.obs_time.start is not None:
+            start = observations_settings.obs_time.start
+            stop = observations_settings.obs_time.stop
             self.observations = self.observations.select_time([(start, stop)])
         log.info(f"Number of selected observations: {len(self.observations)}")
         for obs in self.observations:
@@ -121,15 +121,16 @@ class Analysis:
 
     def get_datasets(self):
         """Produce reduced datasets."""
+        datasets_settings = self.config.datasets
         if not self.observations or len(self.observations) == 0:
             raise RuntimeError("No observations have been selected.")
 
-        if self.config.datasets.type == "1d":
+        if datasets_settings.type == "1d":
             self._spectrum_extraction()
-        elif self.config.datasets.type == "3d":
+        elif datasets_settings.type == "3d":
             self._map_making()
         else:
-            ValueError(f"Invalid dataset type: {self.config.datasets.type}")
+            ValueError(f"Invalid dataset type: {datasets_settings.type}")
 
     def set_models(self, models):
         """Set models on datasets.
@@ -233,10 +234,10 @@ class Analysis:
 
     def _map_making(self):
         """Make maps and datasets for 3d analysis."""
+        datasets_settings = self.config.datasets
         log.info("Creating geometry.")
-
         geom = self._create_geometry()
-        geom_settings = self.config.datasets.geom
+        geom_settings = datasets_settings.geom
         geom_irf = dict(energy_axis_true=None, binsz_irf=None)
         if geom_settings.axes.energy_true.min is not None:
             geom_irf["energy_axis_true"] = self._make_energy_axis(
@@ -246,21 +247,21 @@ class Analysis:
         offset_max = geom_settings.selection.offset_max
         log.info("Creating datasets.")
 
-        maker = MapDatasetMaker(selection=self.config.datasets.map_selection)
+        maker = MapDatasetMaker(selection=datasets_settings.map_selection)
 
-        safe_mask_selection = self.config.datasets.safe_mask.methods
-        safe_mask_settings = self.config.datasets.safe_mask.settings
+        safe_mask_selection = datasets_settings.safe_mask.methods
+        safe_mask_settings = datasets_settings.safe_mask.settings
         maker_safe_mask = SafeMaskMaker(
             methods=safe_mask_selection, **safe_mask_settings
         )
 
-        bkg_method = self.config.datasets.background.method
+        bkg_method = datasets_settings.background.method
         if bkg_method == "fov_background":
             bkg_maker_config = {}
-            if self.config.datasets.background.exclusion:
-                exclusion_region = Map.read(self.config.datasets.background.exclusion)
+            if datasets_settings.background.exclusion:
+                exclusion_region = Map.read(datasets_settings.background.exclusion)
                 bkg_maker_config["exclusion_mask"] = exclusion_region
-            bkg_maker_config.update(self.config.datasets.background.parameters)
+            bkg_maker_config.update(datasets_settings.background.parameters)
             log.debug(f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}")
             bkg_maker = FoVBackgroundMaker(**bkg_maker_config)
         else:
@@ -271,7 +272,7 @@ class Analysis:
 
         stacked = MapDataset.create(geom=geom, name="stacked", **geom_irf)
 
-        if self.config.datasets.stack:
+        if datasets_settings.stack:
             for obs in self.observations:
                 log.info(f"Processing observation {obs.obs_id}")
                 cutout = stacked.cutout(obs.pointing_radec, width=2 * offset_max)
@@ -314,13 +315,13 @@ class Analysis:
         maker_config["selection"] = ["counts", "aeff", "edisp"]
         dataset_maker = SpectrumDatasetMaker(**maker_config)
 
-        bkg_method = self.config.datasets.background.method
+        bkg_method = datasets_settings.background.method
         if bkg_method == "reflected":
             bkg_maker_config = {}
             if datasets_settings.background.exclusion:
                 exclusion_region = Map.read(datasets_settings.background.exclusion)
                 bkg_maker_config["exclusion_mask"] = exclusion_region
-            bkg_maker_config.update(self.config.datasets.background.parameters)
+            bkg_maker_config.update(datasets_settings.background.parameters)
             bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
             log.debug(
                 f"Creating ReflectedRegionsBackgroundMaker with arguments {bkg_maker_config}"
@@ -331,8 +332,8 @@ class Analysis:
                 f"No background maker set for 1d analysis. Check configuration."
             )
 
-        safe_mask_selection = self.config.datasets.safe_mask.methods
-        safe_mask_settings = self.config.datasets.safe_mask.settings
+        safe_mask_selection = datasets_settings.safe_mask.methods
+        safe_mask_settings = datasets_settings.safe_mask.settings
         safe_mask_maker = SafeMaskMaker(
             methods=safe_mask_selection, **safe_mask_settings
         )
@@ -360,7 +361,7 @@ class Analysis:
 
         self.datasets = Datasets(datasets)
 
-        if self.config.datasets.stack:
+        if datasets_settings.stack:
             stacked = self.datasets.stack_reduce(name="stacked")
             self.datasets = Datasets([stacked])
 

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -259,7 +259,11 @@ class Analysis:
             exclusion_region = Map.read(self.config.datasets.background.exclusion)
             bkg_maker_config["exclusion_mask"] = exclusion_region
         bkg_maker_config.update(self.config.datasets.background.parameters)
-        if self.config.datasets.background.method == "fov_background":
+
+        bkg_method = self.config.datasets.background.method
+
+        if bkg_method == "fov_background":
+            log.debug(f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}")
             bkg_maker = FoVBackgroundMaker(**bkg_maker_config)
         else:
             bkg_maker = None
@@ -283,6 +287,8 @@ class Analysis:
                 cutout = stacked.cutout(obs.pointing_radec, width=2 * offset_max)
                 dataset = maker.run(cutout, obs)
                 dataset = maker_safe_mask.run(dataset, obs)
+                if bkg_maker is not None:
+                    dataset = bkg_maker.run(dataset)
                 log.debug(dataset)
                 datasets.append(dataset)
         self.datasets = Datasets(datasets)

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -261,12 +261,12 @@ class Analysis:
         bkg_maker_config.update(self.config.datasets.background.parameters)
 
         bkg_method = self.config.datasets.background.method
-
         if bkg_method == "fov_background":
             log.debug(f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}")
             bkg_maker = FoVBackgroundMaker(**bkg_maker_config)
         else:
             bkg_maker = None
+
         stacked = MapDataset.create(geom=geom, name="stacked", **geom_irf)
 
         if self.config.datasets.stack:
@@ -311,11 +311,18 @@ class Analysis:
 
         maker_config["selection"] = ["counts", "aeff", "edisp"]
         dataset_maker = SpectrumDatasetMaker(**maker_config)
-        bkg_maker_config = {}
-        if datasets_settings.background.exclusion:
-            exclusion_region = Map.read(datasets_settings.background.exclusion)
-            bkg_maker_config["exclusion_mask"] = exclusion_region
-        bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
+
+        bkg_method = self.config.datasets.background.method
+        if bkg_method == "reflected":
+            bkg_maker_config = {}
+            if datasets_settings.background.exclusion:
+                exclusion_region = Map.read(datasets_settings.background.exclusion)
+                bkg_maker_config["exclusion_mask"] = exclusion_region
+            bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
+            log.debug(f"Creating ReflectedRegionsBackgroundMaker with arguments {bkg_maker_config}")
+        else:
+            bkg_maker = None
+            log.warning(f"No background maker set for 1d analysis. Check configuration.")
 
         safe_mask_selection = self.config.datasets.safe_mask.methods
         safe_mask_settings = self.config.datasets.safe_mask.settings

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -320,6 +320,7 @@ class Analysis:
             if datasets_settings.background.exclusion:
                 exclusion_region = Map.read(datasets_settings.background.exclusion)
                 bkg_maker_config["exclusion_mask"] = exclusion_region
+            bkg_maker_config.update(self.config.datasets.background.parameters)
             bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
             log.debug(
                 f"Creating ReflectedRegionsBackgroundMaker with arguments {bkg_maker_config}"

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -261,9 +261,7 @@ class Analysis:
                 exclusion_region = Map.read(self.config.datasets.background.exclusion)
                 bkg_maker_config["exclusion_mask"] = exclusion_region
             bkg_maker_config.update(self.config.datasets.background.parameters)
-            log.debug(
-                f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}"
-            )
+            log.debug(f"Creating FoVBackgroundMaker with arguments {bkg_maker_config}")
             bkg_maker = FoVBackgroundMaker(**bkg_maker_config)
         else:
             bkg_maker = None

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -127,10 +127,8 @@ class Analysis:
 
         if datasets_settings.type == "1d":
             self._spectrum_extraction()
-        elif datasets_settings.type == "3d":
+        else:  # 3d
             self._map_making()
-        else:
-            ValueError(f"Invalid dataset type: {datasets_settings.type}")
 
     def set_models(self, models):
         """Set models on datasets.

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -6,7 +6,7 @@ from astropy.table import Table
 from regions import CircleSkyRegion
 import yaml
 from gammapy.analysis.config import AnalysisConfig
-from gammapy.cube import MapDataset, MapDatasetMaker, SafeMaskMaker, FoVBackgroundMaker
+from gammapy.cube import FoVBackgroundMaker, MapDataset, MapDatasetMaker, SafeMaskMaker
 from gammapy.data import DataStore
 from gammapy.maps import Map, MapAxis, WcsGeom
 from gammapy.modeling import Datasets, Fit
@@ -336,7 +336,9 @@ class Analysis:
             methods=safe_mask_selection, **safe_mask_settings
         )
 
-        e_true = self._make_energy_axis(datasets_settings.geom.axes.energy_true, name="energy_true").edges
+        e_true = self._make_energy_axis(
+            datasets_settings.geom.axes.energy_true, name="energy_true"
+        ).edges
 
         reference = SpectrumDataset.create(
             e_reco=e_reco, e_true=e_true, region=on_region

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -319,10 +319,14 @@ class Analysis:
                 exclusion_region = Map.read(datasets_settings.background.exclusion)
                 bkg_maker_config["exclusion_mask"] = exclusion_region
             bkg_maker = ReflectedRegionsBackgroundMaker(**bkg_maker_config)
-            log.debug(f"Creating ReflectedRegionsBackgroundMaker with arguments {bkg_maker_config}")
+            log.debug(
+                f"Creating ReflectedRegionsBackgroundMaker with arguments {bkg_maker_config}"
+            )
         else:
             bkg_maker = None
-            log.warning(f"No background maker set for 1d analysis. Check configuration.")
+            log.warning(
+                f"No background maker set for 1d analysis. Check configuration."
+            )
 
         safe_mask_selection = self.config.datasets.safe_mask.methods
         safe_mask_settings = self.config.datasets.safe_mask.settings

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -197,7 +197,7 @@ class Analysis:
             e_edges=e_edges,
             datasets=self.datasets,
             source=fp_settings.source,
-            **fp_settings.params,
+            **fp_settings.parameters,
         )
         fp = flux_point_estimator.run()
         fp.table["is_ul"] = fp.table["ts"] < 4
@@ -250,7 +250,7 @@ class Analysis:
         maker = MapDatasetMaker(selection=datasets_settings.map_selection)
 
         safe_mask_selection = datasets_settings.safe_mask.methods
-        safe_mask_settings = datasets_settings.safe_mask.settings
+        safe_mask_settings = datasets_settings.safe_mask.parameters
         maker_safe_mask = SafeMaskMaker(
             methods=safe_mask_selection, **safe_mask_settings
         )
@@ -333,7 +333,7 @@ class Analysis:
             )
 
         safe_mask_selection = datasets_settings.safe_mask.methods
-        safe_mask_settings = datasets_settings.safe_mask.settings
+        safe_mask_settings = datasets_settings.safe_mask.parameters
         safe_mask_maker = SafeMaskMaker(
             methods=safe_mask_selection, **safe_mask_settings
         )

--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -340,12 +340,13 @@ class Analysis:
         for obs in self.observations:
             log.info(f"Processing observation {obs.obs_id}")
             dataset = dataset_maker.run(reference.copy(), obs)
-            dataset = bkg_maker.run(dataset, obs)
-            if dataset.counts_off is None:
-                log.info(
-                    f"No OFF region found for observation {obs.obs_id}. Discarding."
-                )
-                continue
+            if bkg_maker is not None:
+                dataset = bkg_maker.run(dataset, obs)
+                if dataset.counts_off is None:
+                    log.info(
+                        f"No OFF region found for observation {obs.obs_id}. Discarding."
+                    )
+                    continue
             dataset = safe_mask_maker.run(dataset, obs)
             log.debug(dataset)
             datasets.append(dataset)

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -16,7 +16,7 @@ MODEL_FILE = CONFIG_PATH / "model.yaml"
 
 
 def get_example_config(which):
-    """Example config: which can be "1d" or "3d"."""
+    """Example config: which can be 1d or 3d."""
     return AnalysisConfig.read(CONFIG_PATH / f"example-{which}.yaml")
 
 
@@ -212,6 +212,7 @@ def test_exclusion_region(tmp_path):
     exclusion_mask.data = mask.astype(int)
     filename = tmp_path / "exclusion.fits"
     exclusion_mask.write(filename)
+    config.datasets.background.method = "reflected"
     config.datasets.background.exclusion = filename
 
     analysis.get_observations()
@@ -227,6 +228,8 @@ def test_analysis_1d_stacked():
         geom:
             axes:
                 energy_true: {min: 0.03 TeV, max: 100 TeV, nbins: 50}
+        background:
+            method: reflected
     """
 
     config = get_example_config("1d")
@@ -248,24 +251,8 @@ def test_analysis_1d_stacked():
 
 @requires_data()
 def test_analysis_1d_no_bkg():
-    cfg = """
-    observations:
-        datastore: $GAMMAPY_DATA/hess-dl3-dr1
-        obs_ids: [23523]
-    datasets:
-        type: 1d
-        background:
-            method: ''
-        on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.11 deg}
-        geom:
-            axes:
-                energy: {min: 0.1 TeV, max: 30 TeV, nbins: 5}
-                energy_true: {min: 0.03 TeV, max: 100 TeV, nbins: 10}
-        containment_correction: false
-    """
     config = get_example_config("1d")
     analysis = Analysis(config)
-    analysis.update_config(cfg)
     analysis.get_observations()
     analysis.get_datasets()
 

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -147,7 +147,7 @@ def test_analysis_1d():
         on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.11 deg}
         safe_mask:
             methods: [aeff-default, edisp-bias]
-            settings: {bias_percent: 10.0}
+            parameters: {bias_percent: 10.0}
         containment_correction: false
     flux_points:
         energy: {min: 1 TeV, max: 50 TeV, nbins: 4}

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -278,7 +278,9 @@ def test_analysis_3d_joint_datasets():
     analysis.get_observations()
     analysis.get_datasets()
     assert len(analysis.datasets) == 2
-
+    assert_allclose(analysis.datasets[0].background_model.norm.value, 1.031743694988066)
+    assert_allclose(analysis.datasets[0].background_model.tilt.value, 0.)
+    assert_allclose(analysis.datasets[1].background_model.norm.value, 0.9776349021876344)
 
 @requires_dependency("iminuit")
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -255,7 +255,7 @@ def test_analysis_1d_no_bkg():
     datasets:
         type: 1d
         background:
-            method: None
+            method: ''
         on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.11 deg}
         geom:
             axes:

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
 from gammapy.analysis import Analysis, AnalysisConfig
 from gammapy.maps import Map
+from gammapy.spectrum import SpectrumDatasetOnOff
 from gammapy.modeling.models import Models
 from gammapy.utils.testing import requires_data, requires_dependency
 
@@ -244,6 +245,30 @@ def test_analysis_1d_stacked():
     assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
     assert_allclose(pars["amplitude"].value, 5.496388e-11, rtol=1e-2)
 
+@requires_data()
+def test_analysis_1d_no_bkg():
+    cfg = """
+    observations:
+        datastore: $GAMMAPY_DATA/hess-dl3-dr1
+        obs_ids: [23523]
+    datasets:
+        type: 1d
+        background:
+            method: None
+        on_region: {frame: icrs, lon: 83.633 deg, lat: 22.014 deg, radius: 0.11 deg}
+        geom:
+            axes:
+                energy: {min: 0.1 TeV, max: 30 TeV, nbins: 5}
+                energy_true: {min: 0.03 TeV, max: 100 TeV, nbins: 10}
+        containment_correction: false
+    """
+    config = get_example_config("1d")
+    analysis = Analysis(config)
+    analysis.update_config(cfg)
+    analysis.get_observations()
+    analysis.get_datasets()
+
+    assert isinstance(analysis.datasets[0], SpectrumDatasetOnOff) is False
 
 @requires_dependency("iminuit")
 @requires_data()

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -5,13 +5,13 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 from regions import CircleSkyRegion
-from gammapy.analysis import Analysis, AnalysisConfig
-from gammapy.maps import Map, WcsNDMap
-from gammapy.cube import MapDataset
-from gammapy.spectrum import SpectrumDatasetOnOff
-from gammapy.modeling.models import Models
-from gammapy.utils.testing import requires_data, requires_dependency
 from pydantic.error_wrappers import ValidationError
+from gammapy.analysis import Analysis, AnalysisConfig
+from gammapy.cube import MapDataset
+from gammapy.maps import Map, WcsNDMap
+from gammapy.modeling.models import Models
+from gammapy.spectrum import SpectrumDatasetOnOff
+from gammapy.utils.testing import requires_data, requires_dependency
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
 MODEL_FILE = CONFIG_PATH / "model.yaml"

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -245,6 +245,7 @@ def test_analysis_1d_stacked():
     assert_allclose(pars["index"].value, 2.76913, rtol=1e-2)
     assert_allclose(pars["amplitude"].value, 5.496388e-11, rtol=1e-2)
 
+
 @requires_data()
 def test_analysis_1d_no_bkg():
     cfg = """
@@ -269,6 +270,7 @@ def test_analysis_1d_no_bkg():
     analysis.get_datasets()
 
     assert isinstance(analysis.datasets[0], SpectrumDatasetOnOff) is False
+
 
 @requires_dependency("iminuit")
 @requires_data()
@@ -304,8 +306,11 @@ def test_analysis_3d_joint_datasets():
     analysis.get_datasets()
     assert len(analysis.datasets) == 2
     assert_allclose(analysis.datasets[0].background_model.norm.value, 1.031743694988066)
-    assert_allclose(analysis.datasets[0].background_model.tilt.value, 0.)
-    assert_allclose(analysis.datasets[1].background_model.norm.value, 0.9776349021876344)
+    assert_allclose(analysis.datasets[0].background_model.tilt.value, 0.0)
+    assert_allclose(
+        analysis.datasets[1].background_model.norm.value, 0.9776349021876344
+    )
+
 
 @requires_dependency("iminuit")
 @requires_data()

--- a/gammapy/cube/fov.py
+++ b/gammapy/cube/fov.py
@@ -64,6 +64,8 @@ class FoVBackgroundMaker:
             coords = dataset.counts.geom.get_coord()
             vals = self.exclusion_mask.get_by_coord(coords)
             mask_map.data += vals
+        else:
+            mask_map.data[...] = 1
 
         return mask_map.data.astype("bool")
 

--- a/gammapy/scripts/analysis.py
+++ b/gammapy/scripts/analysis.py
@@ -42,6 +42,7 @@ def cli_make_config(filename, overwrite):
 def cli_run_analysis(filename, out, overwrite):
     """Performs automated data reduction process."""
     config = AnalysisConfig.read(filename)
+    config.datasets.background.method = "reflected"
     analysis = Analysis(config)
     analysis.get_observations()
     analysis.get_datasets()

--- a/tutorials/analysis_1.ipynb
+++ b/tutorials/analysis_1.ipynb
@@ -173,6 +173,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Setting the background normalization maker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config.datasets.background.method = \"fov_background\"\n",
+    "config.datasets.background.parameters = {\"method\": \"scale\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Setting modeling and fitting parameters\n",
     "`Analysis` can perform a few modeling and fitting tasks besides data reduction. Parameters have then to be passed to the configuration object."
    ]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds the `FoVBackgroundMaker` to the `Analysis` class.

A `fov_background` method is added to the `BackgroundMethodEnum` as well as a `none`  method. (This is meant to avoid asking users to select `reflected` if they want no background estimate on a 3d method.)

A `parameters` dict is added to the `BackgroundConfig` and is empty by default.

In the `Analysis` class itself, a test is added for the background method to create the correct `BackgroundMaker`. If the `maker` exists it is called in the dataset production loop.
The analysis_1 notebook has been adapted to include the FoVBackground.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
is this is the right approach?