### PR TITLE
Implement RegionGeom and RegionNDMap

### DIFF
--- a/gammapy/maps/__init__.py
+++ b/gammapy/maps/__init__.py
@@ -11,3 +11,5 @@ from .profile import *
 from .wcs import *
 from .wcsmap import *
 from .wcsnd import *
+from .region import *
+from .regionnd import *

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -215,11 +215,14 @@ class Map(abc.ABC):
 
             from .hpx import HpxGeom
             from .wcs import WcsGeom
+            from .region import RegionGeom
 
             if isinstance(geom, HpxGeom):
                 map_type = "hpx"
             elif isinstance(geom, WcsGeom):
                 map_type = "wcs"
+            elif isinstance(geom, RegionGeom):
+                map_type = "region"
             else:
                 raise ValueError("Unrecognized geom type.")
 
@@ -282,6 +285,10 @@ class Map(abc.ABC):
             return HpxNDMap
         elif map_type == "hpx-sparse":
             raise NotImplementedError()
+        elif map_type == "region":
+            from .regionnd import RegionNDMap
+
+            return RegionNDMap
         else:
             raise ValueError(f"Unrecognized map type: {map_type!r}")
 
@@ -919,6 +926,28 @@ class Map(abc.ABC):
         if "geom" in kwargs:
             raise ValueError("Can't copy and change geometry of the map.")
         return self._init_copy(**kwargs)
+
+    def apply_edisp(self, edisp):
+        """Apply energy dispersion to map. Requires energy axis.
+
+        Parameters
+        ----------
+        edisp : `gammapy.irf.EDispKernel`
+            Energy dispersion matrix
+
+        Returns
+        -------
+        map : `WcsNDMap`
+            Map with energy dispersion applied.
+        """
+        loc = self.geom.get_axis_index_by_name("energy")
+        data = np.rollaxis(self.data, loc, len(self.data.shape))
+        data = np.dot(data, edisp.pdf_matrix)
+        data = np.rollaxis(data, -1, loc)
+
+        e_reco_axis = edisp.e_reco.copy(name="energy")
+        geom_reco = self.geom.to_image().to_cube(axes=[e_reco_axis])
+        return self._init_copy(geom=geom_reco, data=data)
 
     def __repr__(self):
         geom = self.geom.__class__.__name__

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -121,7 +121,7 @@ class Map(abc.ABC):
         frame : str
             Coordinate system, either Galactic ("galactic") or Equatorial
             ("icrs").
-        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse'}
+        map_type : {'wcs', 'wcs-sparse', 'hpx', 'hpx-sparse', 'region'}
             Map type.  Selects the class that will be used to
             instantiate the map.
         binsz : float or `~numpy.ndarray`
@@ -137,6 +137,8 @@ class Map(abc.ABC):
             Data unit.
         meta : `dict`
             Dictionary to store meta data.
+        region : `~regions.SkyRegion`
+            Sky region used for the region map.
 
         Returns
         -------
@@ -145,12 +147,16 @@ class Map(abc.ABC):
         """
         from .hpxmap import HpxMap
         from .wcsmap import WcsMap
+        from .regionnd import RegionNDMap
 
         map_type = kwargs.setdefault("map_type", "wcs")
         if "wcs" in map_type.lower():
             return WcsMap.create(**kwargs)
         elif "hpx" in map_type.lower():
             return HpxMap.create(**kwargs)
+        elif map_type == "region":
+            _ = kwargs.pop("map_type")
+            return RegionNDMap.create(**kwargs)
         else:
             raise ValueError(f"Unrecognized map type: {map_type!r}")
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -32,7 +32,7 @@ class Map(abc.ABC):
     """
 
     def __init__(self, geom, data, meta=None, unit=""):
-        self.geom = geom
+        self._geom = geom
         self.data = data
         self.unit = unit
 
@@ -58,10 +58,6 @@ class Map(abc.ABC):
     def geom(self):
         """Map geometry (`~gammapy.maps.Geom`)"""
         return self._geom
-
-    @geom.setter
-    def geom(self, val):
-        self._geom = val
 
     @property
     def data(self):
@@ -219,14 +215,11 @@ class Map(abc.ABC):
 
             from .hpx import HpxGeom
             from .wcs import WcsGeom
-            from .region import RegionGeom
 
             if isinstance(geom, HpxGeom):
                 map_type = "hpx"
             elif isinstance(geom, WcsGeom):
                 map_type = "wcs"
-            elif isinstance(geom, RegionGeom):
-                map_type = "region"
             else:
                 raise ValueError("Unrecognized geom type.")
 
@@ -288,12 +281,7 @@ class Map(abc.ABC):
 
             return HpxNDMap
         elif map_type == "hpx-sparse":
-            from .hpxsparse import HpxSparseMap
-
-            return HpxSparseMap
-        elif map_type == "region":
-            from .regionnd import RegionNDMap
-            return RegionNDMap
+            raise NotImplementedError()
         else:
             raise ValueError(f"Unrecognized map type: {map_type!r}")
 
@@ -371,48 +359,6 @@ class Map(abc.ABC):
         coords = map_in.geom.get_coord()
         vals = u.Quantity(map_in.get_by_idx(idx), map_in.unit)
         self.fill_by_coord(coords, vals)
-
-    def reproject(self, geom, order=1, mode="interp"):
-        """Reproject this map to a different geometry.
-
-        Only spatial axes are reprojected, if you would like to reproject
-        non-spatial axes consider using `Map.interp_by_coord()` instead.
-
-        Parameters
-        ----------
-        geom : `Geom`
-            Geometry of projection.
-        mode : {'interp', 'exact'}
-            Method for reprojection.  'interp' method interpolates at pixel
-            centers.  'exact' method integrates over intersection of pixels.
-        order : int or str
-            Order of interpolating polynomial (0 = nearest-neighbor, 1 =
-            linear, 2 = quadratic, 3 = cubic).
-
-        Returns
-        -------
-        map : `Map`
-            Reprojected map.
-        """
-        if geom.is_image:
-            axes = [ax.copy() for ax in self.geom.axes]
-            geom = geom.copy(axes=axes)
-        else:
-            axes_eq = geom.ndim == self.geom.ndim
-            axes_eq &= np.all(
-                [ax0 == ax1 for ax0, ax1 in zip(geom.axes, self.geom.axes)]
-            )
-
-            if not axes_eq:
-                raise ValueError(
-                    "Map and target geometry non-spatial axes must match."
-                    "Use interp_by_coord to interpolate in non-spatial axes."
-                )
-
-        if geom.is_hpx:
-            return self._reproject_to_hpx(geom, mode=mode, order=order)
-        else:
-            return self._reproject_to_wcs(geom, mode=mode, order=order)
 
     @abc.abstractmethod
     def pad(self, pad_width, mode="constant", cval=0, order=1):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -28,7 +28,7 @@ class RegionGeom(Geom):
     _slice_spatial_axes = slice(0, 2)
     _slice_non_spatial_axes = slice(2, None)
     projection = "TAN"
-    binsz = 1e-5
+    binsz = 0.01
 
     def __init__(self, region, axes=None, wcs=None):
         self._region = region
@@ -165,8 +165,15 @@ class RegionGeom(Geom):
 
         return coords
 
-    def pix_to_idx(self, pix, clip=True):
+    def pix_to_idx(self, pix, clip=False):
         idxs = list(pix_tuple_to_idx(pix))
+
+        for i, idx in enumerate(idxs[self._slice_non_spatial_axes]):
+            if clip:
+                np.clip(idx, 0, self.axes[i].nbin - 1, out=idx)
+            else:
+                np.putmask(idx, (idx < 0) | (idx >= self.axes[i].nbin), -1)
+
         return tuple(idxs)
 
     def coord_to_pix(self, coords):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -28,7 +28,7 @@ class RegionGeom(Geom):
     _slice_spatial_axes = slice(0, 2)
     _slice_non_spatial_axes = slice(2, None)
     projection = "TAN"
-    binsz = 1e-3
+    binsz = 1e-5
 
     def __init__(self, region, axes=None, wcs=None):
         self._region = region
@@ -156,8 +156,8 @@ class RegionGeom(Geom):
         return self._init_copy(axes=axes)
 
     def pix_to_coord(self, pix):
-        lon = np.where((-0.5 < pix[0]) & (pix[0] < 0.5), self.center_skydir.l.deg, np.nan * u.deg) * u.deg
-        lat = np.where((-0.5 < pix[1]) & (pix[1] < 0.5), self.center_skydir.b.deg, np.nan * u.deg) * u.deg
+        lon = np.where((-0.5 < pix[0]) & (pix[0] < 0.5), self.center_skydir.data.lon, np.nan * u.deg)
+        lat = np.where((-0.5 < pix[1]) & (pix[1] < 0.5), self.center_skydir.data.lat, np.nan * u.deg)
         coords = (lon, lat)
 
         for p, ax in zip(pix[self._slice_non_spatial_axes], self.axes):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -1,0 +1,229 @@
+import numpy as np
+from astropy import units as u
+from astropy.wcs.utils import proj_plane_pixel_area
+from regions import CircleSkyRegion
+from gammapy.utils.regions import make_region
+import copy
+from .geom import Geom, axes_pix_to_coord, pix_tuple_to_idx, make_axes, frame_to_coordsys
+from .wcs import WcsGeom
+from .base import MapCoord
+
+
+class RegionGeom(Geom):
+    """Map geometry representing a region on the sky.
+
+    Parameters
+    ----------
+    region : `~regions.SkyRegion`
+        Region object.
+    axes : list of `MapAxis`
+        Non-spatial data axes.
+    wcs : `~astropy.wcs.WCS`
+        Optional wcs object to project the region if needed.
+    """
+    is_image = False
+    is_allsky = False
+    is_hpx = False
+    _slice_spatial_axes = slice(0, 2)
+    _slice_non_spatial_axes = slice(2, None)
+    projection = "TAN"
+
+    def __init__(self, region, axes=None, wcs=None):
+        self._region = region
+        self._axes = make_axes(axes)
+
+        if wcs is None:
+            wcs = WcsGeom.create(
+                skydir=region.center, binsz=0.001, width=self.width, proj=self.projection
+            ).wcs
+
+        self._wcs = wcs
+        self.ndim = len(self.data_shape)
+        self.coordsys = frame_to_coordsys(region.center.frame.name)
+
+    @property
+    def width(self):
+        if isinstance(self.region, CircleSkyRegion):
+            return 2 * self.region.radius
+        else:
+            raise ValueError("Only circular regions supported")
+
+    @property
+    def region(self):
+        return self._region
+
+    @property
+    def axes(self):
+        return self._axes
+
+    @property
+    def wcs(self):
+        return self._wcs
+
+    @property
+    def center_coord(self):
+        """(`astropy.coordinates.SkyCoord`)"""
+        return self.pix_to_coord(self.center_pix)
+
+    @property
+    def center_pix(self):
+        return tuple((np.array(self.data_shape) - 1.0) / 2)[::-1]
+
+    @property
+    def center_skydir(self):
+        """Center skydir"""
+        return self.region.center
+
+    def contains(self, position):
+        idx = self.coord_to_idx(coords)
+        return np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
+
+    def separation(self, position):
+        coord = self.get_coord()
+        return coord.skycoord.separation(position)
+
+    @property
+    def data_shape(self):
+        """Shape of the Numpy data array matching this geometry."""
+        return self._shape[::-1]
+
+    @property
+    def _shape(self):
+        npix_shape = [1, 1]
+        ax_shape = [ax.nbin for ax in self.axes]
+        return tuple(npix_shape + ax_shape)
+
+    def get_coord(self, coordsys=None):
+        """Get map coordinates from the geometry.
+
+        Returns
+        -------
+        coord : `~MapCoord`
+            Map coordinate object.
+        """
+        cdict = {}
+        cdict["skycoord"] = self.center_skydir.reshape((1, 1))
+
+        if self.axes is not None:
+            for ax in self.axes:
+                cdict[ax.name] = ax.center.reshape((-1, 1, 1))
+
+        if coordsys is None:
+            coordsys = self.coordsys
+
+        return MapCoord.create(cdict, coordsys=self.coordsys).to_coordsys(coordsys)
+
+    def pad(self):
+        raise NotImplementedError("Padding of `RegionGeom` not supported")
+
+    def crop(self):
+        raise NotImplementedError("Cropping of `RegionGeom` not supported")
+
+    def solid_angle(self):
+        area = self.region.to_pixel(self.wcs).area
+        solid_angle = area * proj_plane_pixel_area(self.wcs) * u.deg ** 2
+        return solid_angle.to("sr")
+
+    def bin_volume(self):
+        return self.solid_angle() * self.axes[0].bin_width.reshape((-1, 1, 1))
+
+    def to_cube(self, axes):
+        axes = copy.deepcopy(self.axes) + axes
+        return self._init_copy(axes=axes)
+
+    def to_image(self):
+        return self._init_copy(axes=None)
+
+    def upsample(self, factor, axis):
+        axes = copy.deepcopy(self.axes)
+        idx = self.get_axis_index_by_name(axis)
+        axes[idx] = axes[idx].upsample(factor)
+        return self._init_copy(axes=axes)
+
+    def downsample(self, factor, axis):
+        axes = copy.deepcopy(self.axes)
+        idx = self.get_axis_index_by_name(axis)
+        axes[idx] = axes[idx].downsample(factor)
+        return self._init_copy(axes=axes)
+
+    def pix_to_coord(self, pix):
+        lon = np.where((-0.5 < pix[0]) & (pix[0] < 0.5), self.center_skydir.l.deg, np.nan * u.deg) * u.deg
+        lat = np.where((-0.5 < pix[1]) & (pix[1] < 0.5), self.center_skydir.b.deg, np.nan * u.deg) * u.deg
+        coords = (lon, lat)
+        coords += tuple(axes_pix_to_coord(self.axes, pix[self._slice_non_spatial_axes]))
+        return coords
+
+    def pix_to_idx(self, pix, clip=True):
+        idxs = list(pix_tuple_to_idx(pix))
+        if True:
+            idxs[0] = np.where((-0.5 < pix[0]) & (pix[0] < 0.5), [0], [-1])
+            idxs[1] = np.where((-0.5 < pix[1]) & (pix[1] < 0.5), [0], [-1])
+            idxs[2] = np.clip(idxs[2], 0, self.axes[0].nbin - 1)
+        return tuple(idxs)
+
+    def coord_to_pix(self, coords):
+        coords = MapCoord.create(coords, coordsys=self.coordsys)
+        in_region = self.region.contains(coords.skycoord, wcs=self.wcs)
+
+        x = np.zeros(coords.shape)
+        x[~in_region] = np.nan
+
+        y = np.zeros(coords.shape)
+        y[~in_region] = np.nan
+
+        pix = (x, y)
+        for coord, ax in zip(coords[self._slice_non_spatial_axes], self.axes):
+            pix += (ax.coord_to_pix(coord),)
+
+        return pix
+
+    def get_idx(self):
+        idxs = (0, 0)
+        if self.axes is not None:
+            for ax in self.axes:
+                idxs += (np.arange(ax.nbin).reshape((-1, 1, 1)),)
+        return np.broadcast_arrays(*idxs)
+
+    def _make_bands_cols(self):
+        pass
+
+    @classmethod
+    def create(cls, region, **kwargs):
+        """Create region.
+
+        Parameters
+        ----------
+        region : str or `~regions.SkyRegion`
+            Region
+
+        """
+        if isinstance(region, str):
+            region = make_region(region)
+
+        return cls(region, **kwargs)
+
+    def __repr__(self):
+        axes = ["lon", "lat"] + [_.name for _ in self.axes]
+        lon = self.center_skydir.data.lon.deg
+        lat = self.center_skydir.data.lat.deg
+
+        return (
+            f"{self.__class__.__name__}\n\n"
+            f"\taxes       : {axes}\n"
+            f"\tshape      : {self.data_shape[::-1]}\n"
+            f"\tndim       : {self.ndim}\n"
+            f"\tframe      : {self.center_skydir.frame.name}\n"
+            f"\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n"
+        )
+
+    def __eq__(self, other):
+        # check overall shape and axes compatibility
+        if self.data_shape != other.data_shape:
+            return False
+
+        for axis, otheraxis in zip(self.axes, other.axes):
+            if axis != otheraxis:
+                return False
+
+        # TODO: compare regions
+        return True

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -1,13 +1,13 @@
+import copy
 import numpy as np
 from astropy import units as u
 from astropy.wcs.utils import proj_plane_pixel_area
 from regions import CircleSkyRegion
 from gammapy.utils.regions import make_region
-import copy
-from .geom import Geom, pix_tuple_to_idx, make_axes
-from .wcs import WcsGeom
 from .base import MapCoord
+from .geom import Geom, make_axes, pix_tuple_to_idx
 from .utils import INVALID_INDEX
+from .wcs import WcsGeom
 
 
 class RegionGeom(Geom):
@@ -22,6 +22,7 @@ class RegionGeom(Geom):
     wcs : `~astropy.wcs.WCS`
         Optional wcs object to project the region if needed.
     """
+
     is_image = False
     is_allsky = False
     is_hpx = False
@@ -40,8 +41,11 @@ class RegionGeom(Geom):
 
         if wcs is None:
             wcs = WcsGeom.create(
-                skydir=region.center, binsz=self.binsz, width=self.width, proj=self.projection,
-                frame=self.frame
+                skydir=region.center,
+                binsz=self.binsz,
+                width=self.width,
+                proj=self.projection,
+                frame=self.frame,
             ).wcs
 
         self._wcs = wcs
@@ -156,8 +160,16 @@ class RegionGeom(Geom):
         return self._init_copy(axes=axes)
 
     def pix_to_coord(self, pix):
-        lon = np.where((-0.5 < pix[0]) & (pix[0] < 0.5), self.center_skydir.data.lon, np.nan * u.deg)
-        lat = np.where((-0.5 < pix[1]) & (pix[1] < 0.5), self.center_skydir.data.lat, np.nan * u.deg)
+        lon = np.where(
+            (-0.5 < pix[0]) & (pix[0] < 0.5),
+            self.center_skydir.data.lon,
+            np.nan * u.deg,
+        )
+        lat = np.where(
+            (-0.5 < pix[1]) & (pix[1] < 0.5),
+            self.center_skydir.data.lat,
+            np.nan * u.deg,
+        )
         coords = (lon, lat)
 
         for p, ax in zip(pix[self._slice_non_spatial_axes], self.axes):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -3,10 +3,10 @@ from astropy import units as u
 from .base import Map
 from .geom import pix_tuple_to_idx
 from .utils import INVALID_INDEX
-from .utils import interp_to_order
 from astropy.visualization import quantity_support
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
-from gammapy.utils.regions import make_region
+from gammapy.utils.regions import make_region, compound_region_to_list
+from gammapy.extern.skimage import block_reduce
 
 
 class RegionNDMap(Map):
@@ -29,7 +29,7 @@ class RegionNDMap(Map):
         if data is None:
             data = np.zeros(geom.data_shape, dtype=dtype)
 
-        self.geom = geom
+        self._geom = geom
         self.data = data
         self.meta = meta
         self.unit = u.Unit(unit)
@@ -56,24 +56,69 @@ class RegionNDMap(Map):
 
         axis = self.geom.axes[0]
         with quantity_support():
-            ax.plot(axis.center, self.quantity.squeeze())
+            ax.step(axis.center, self.quantity.squeeze())
 
         if axis.interp == "log":
             ax.set_xscale("log")
 
+        ax.set_xlabel(axis.name.capitalize() + f" [{axis.unit}]")
+        if not self.unit.is_unity():
+            ax.set_ylabel(f"Data [{self.unit}]")
+
+        ax.set_yscale("log")
+        return ax
+
+    def plot_region(self, ax=None, **kwargs):
+        """Plot region
+
+        Parameters
+        ----------
+        ax : `~astropy.vizualisation.WCSAxes`
+            Axes to plot on.
+        **kwargs : dict
+            Keyword arguments forwarded to `~regions.PixelRegion.as_artist`
+        """
+        import matplotlib.pyplot as plt
+        from matplotlib.collections import PatchCollection
+
+        ax = plt.gca() or ax
+        regions = compound_region_to_list(self.region)
+        artists = [region.to_pixel(wcs=ax.wcs).as_artist() for region in regions]
+
+        patches = PatchCollection(artists, **kwargs)
+        ax.add_collection(patches)
         return ax
 
     @classmethod
     def create(cls, region, **kwargs):
         """
         """
+        from .region import RegionGeom
+
         if isinstance(region, str):
             region = make_region(region)
 
         return cls(region, **kwargs)
 
-    def downsample(self, factor, axis=None):
-        raise NotImplementedError
+    def downsample(self, factor, preserve_counts=True, axis="energy"):
+        geom = self.geom.downsample(factor=factor, axis=axis)
+        block_size = [1] * self.data.ndim
+        idx = self.geom.get_axis_index_by_name(axis)
+        block_size[-(idx + 1)] = factor
+
+        func = np.nansum if preserve_counts else np.nanmean
+        data = block_reduce(self.data, tuple(block_size[::-1]), func=func)
+
+        return self._init_copy(geom=geom, data=data)
+
+    def upsample(self, factor, preserve_counts=True, axis="energy"):
+        geom = self.geom.upsample(factor=factor, axis=axis)
+        data = self.interp_by_coord(geom.get_coord())
+
+        if preserve_counts:
+            data /= factor
+
+        return self._init_copy(geom=geom, data=data)
 
     def fill_by_idx(self, idx, weights=None):
         idx = pix_tuple_to_idx(idx)
@@ -94,8 +139,9 @@ class RegionNDMap(Map):
     def get_by_idx(self, idxs):
         return self.data[idxs[::-1]]
 
-    def interp_by_coord(self):
-        raise NotImplementedError
+    def interp_by_coord(self, coords):
+        pix = self.geom.coord_to_pix(coords)
+        return self.interp_by_pix(pix)
 
     def interp_by_pix(self, pix, method="linear", fill_value=None):
         grid_pix = [np.arange(n, dtype=float) for n in self.data.shape[::-1]]
@@ -113,9 +159,6 @@ class RegionNDMap(Map):
 
     def set_by_idx(self, idx, value):
         self.data[idx[::-1]] = value
-
-    def upsample(self, factor, axis=None):
-        raise NotImplementedError
 
     @staticmethod
     def read(cls, filename):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -215,17 +215,8 @@ class RegionNDMap(Map):
         # TODO: summing over the axis can change the unit, handle this correctly
         return self._init_copy(geom=geom, data=data)
 
-    def get_image_by_coord(self):
-        raise NotImplementedError
-
-    def get_image_by_idx(self):
-        raise NotImplementedError
-
-    def get_image_by_pix(self):
-        raise NotImplementedError
-
     def stack(self, other, weights=None):
-        """Stack cutout into map.
+        """Stack other region map into map.
 
         Parameters
         ----------
@@ -236,7 +227,7 @@ class RegionNDMap(Map):
             to `other` and additional axes must be broadcastable.
         """
         data = other.data
-        # TODO: handle region info here
+        # TODO: handle region stacking here
 
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -1,0 +1,156 @@
+import numpy as np
+from astropy import units as u
+from .base import Map
+from .geom import pix_tuple_to_idx
+from .utils import INVALID_INDEX
+from .utils import interp_to_order
+from astropy.visualization import quantity_support
+from gammapy.utils.interpolation import ScaledRegularGridInterpolator
+
+
+class RegionNDMap(Map):
+    """Region ND map
+
+    Parameters
+    ----------
+    geom : `~gammapy.maps.RegionGeom`
+        WCS geometry object.
+    data : `~numpy.ndarray`
+        Data array. If none then an empty array will be allocated.
+    dtype : str, optional
+        Data type, default is float32
+    meta : `dict`
+        Dictionary to store meta data.
+    unit : str or `~astropy.units.Unit`
+        The map unit
+    """
+
+    def __init__(self, geom, data=None, dtype="float32", meta=None, unit=""):
+        if data is None:
+            data = np.zeros(geom.data_shape, dtype=dtype)
+
+        self.geom = geom
+        self.data = data
+        self.meta = meta
+        self.unit = u.Unit(unit)
+
+    def plot(self, ax=None):
+        """Plot map.
+        """
+        import matplotlib.pyplot as plt
+
+        ax = ax or plt.gca()
+
+        if len(self.geom.axes) > 1:
+            raise TypeError("Use `.plot_interactive()` if more the one extra axis is present.")
+
+        axis = self.geom.axes[0]
+        with quantity_support():
+            ax.plot(axis.center, self.quantity.squeeze())
+
+        if axis.interp == "log":
+            ax.set_xscale("log")
+
+    @classmethod
+    def create(cls, region, **kwargs):
+        """
+        """
+        if isinstance(region, str):
+            region = None
+
+        return cls(region, **kwargs)
+
+    def downsample(self, factor, axis=None):
+        raise NotImplementedError
+
+    def fill_by_idx(self, idx, weights=None):
+        idx = pix_tuple_to_idx(idx)
+
+        msk = np.all(np.stack([t != INVALID_INDEX.int for t in idx]), axis=0)
+        idx = [t[msk] for t in idx]
+
+        if weights is not None:
+            if isinstance(weights, u.Quantity):
+                weights = weights.to_value(self.unit)
+            weights = weights[msk]
+
+        idx = np.ravel_multi_index(idx, self.data.T.shape)
+        idx, idx_inv = np.unique(idx, return_inverse=True)
+        weights = np.bincount(idx_inv, weights=weights).astype(self.data.dtype)
+        self.data.T.flat[idx] += weights
+
+    def get_by_idx(self, idxs):
+        return self.data[idxs[::-1]]
+
+    def interp_by_coord(self):
+        raise NotImplementedError
+
+    def interp_by_pix(self, pix, interp=None, fill_value=None):
+        method_lookup = {0: "nearest", 1: "linear"}
+        order = interp_to_order(interp)
+        try:
+            method = method_lookup[order]
+        except KeyError:
+            raise ValueError(f"Invalid interpolation order: {order!r}")
+
+        grid_pix = [np.arange(n, dtype=float) for n in self.data.shape[::-1]]
+
+        if np.any(np.isfinite(self.data)):
+            data = self.data.copy().T
+            data[~np.isfinite(data)] = 0.0
+        else:
+            data = self.data.T
+
+        fn = ScaledRegularGridInterpolator(
+            grid_pix, data, fill_value=fill_value, bounds_error=False, method=method
+        )
+        return fn(tuple(pix), clip=False)
+
+    def set_by_idx(self, idx, value):
+        self.data[idx[::-1]] = value
+
+    def upsample(self, factor, axis=None):
+        raise NotImplementedError
+
+    @staticmethod
+    def read(cls, filename):
+        pass
+
+    def write(self, filename):
+        pass
+
+    def to_hdulist(self):
+        pass
+
+    @classmethod
+    def from_hdulist(cls):
+        pass
+
+    def crop(self):
+        raise NotImplementedError("Crop is not supported by RegionNDMap")
+
+    def pad(self):
+        raise NotImplementedError("Pad is not supported by RegionNDMap")
+
+    def sum_over_axes(self):
+        axis = tuple(range(self.data.ndim - 2))
+        geom = self.geom.to_image()
+        if keepdims:
+            for ax in self.geom.axes:
+                geom = geom.to_cube([ax.squash()])
+        data = np.nansum(self.data, axis=axis, keepdims=keepdims)
+        # TODO: summing over the axis can change the unit, handle this correctly
+        return self._init_copy(geom=geom, data=data)
+        raise NotImplementedError
+
+    def get_image_by_coord(self):
+        raise NotImplementedError
+
+    def get_image_by_idx(self):
+        raise NotImplementedError
+
+    def get_image_by_pix(self):
+        raise NotImplementedError
+
+    def stack(self, other):
+        self.data += other.data

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -1,13 +1,13 @@
 import numpy as np
 from astropy import units as u
-from .base import Map
-from .geom import pix_tuple_to_idx
-from .utils import INVALID_INDEX
-from .region import RegionGeom
 from astropy.visualization import quantity_support
+from gammapy.extern.skimage import block_reduce
 from gammapy.utils.interpolation import ScaledRegularGridInterpolator
 from gammapy.utils.regions import compound_region_to_list
-from gammapy.extern.skimage import block_reduce
+from .base import Map
+from .geom import pix_tuple_to_idx
+from .region import RegionGeom
+from .utils import INVALID_INDEX
 
 
 class RegionNDMap(Map):
@@ -26,6 +26,7 @@ class RegionNDMap(Map):
     unit : str or `~astropy.units.Unit`
         The map unit
     """
+
     def __init__(self, geom, data=None, dtype="float32", meta=None, unit=""):
         if data is None:
             data = np.zeros(geom.data_shape, dtype=dtype)
@@ -53,7 +54,9 @@ class RegionNDMap(Map):
         ax = ax or plt.gca()
 
         if len(self.geom.axes) > 1:
-            raise TypeError("Use `.plot_interactive()` if more the one extra axis is present.")
+            raise TypeError(
+                "Use `.plot_interactive()` if more the one extra axis is present."
+            )
 
         axis = self.geom.axes[0]
         with quantity_support():
@@ -70,7 +73,9 @@ class RegionNDMap(Map):
         return ax
 
     def plot_interactive(self):
-        raise NotImplementedError("Interactive plotting currently not support for RegionNDMap")
+        raise NotImplementedError(
+            "Interactive plotting currently not support for RegionNDMap"
+        )
 
     def plot_region(self, ax=None, **kwargs):
         """Plot region
@@ -231,7 +236,7 @@ class RegionNDMap(Map):
             to `other` and additional axes must be broadcastable.
         """
         data = other.data
-        #TODO: handle region info here
+        # TODO: handle region info here
 
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -132,7 +132,7 @@ class RegionNDMap(Map):
     def pad(self):
         raise NotImplementedError("Pad is not supported by RegionNDMap")
 
-    def sum_over_axes(self):
+    def sum_over_axes(self, keepdims=True):
         axis = tuple(range(self.data.ndim - 2))
         geom = self.geom.to_image()
         if keepdims:
@@ -141,7 +141,6 @@ class RegionNDMap(Map):
         data = np.nansum(self.data, axis=axis, keepdims=keepdims)
         # TODO: summing over the axis can change the unit, handle this correctly
         return self._init_copy(geom=geom, data=data)
-        raise NotImplementedError
 
     def get_image_by_coord(self):
         raise NotImplementedError

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -1,0 +1,177 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+import astropy.units as u
+from astropy.coordinates import Angle, SkyCoord
+from gammapy.maps import RegionGeom, MapAxis
+from regions import CircleSkyRegion
+
+
+@pytest.fixture()
+def region():
+    center = SkyCoord("0 deg", "0 deg", frame="galactic")
+    return CircleSkyRegion(center=center, radius=1 * u.deg)
+
+
+def test_create(region):
+    geom = RegionGeom.create(region)
+    assert geom.coordsys == "GAL"
+    assert geom.projection == "TAN"
+    assert not geom.is_image
+    assert not geom.is_allsky
+
+
+def test_centers(region):
+    geom = RegionGeom.create(region)
+    assert_allclose(geom.center_skydir.l.deg, 0)
+    assert_allclose(geom.center_skydir.b.deg, 0)
+    assert_allclose(geom.center_pix, (0, 0))
+
+
+def test_create_axis(region):
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
+    geom = RegionGeom.create(region, axes=[axis])
+
+    assert geom.ndim == 3
+    assert len(geom.axes) == 1
+    assert geom.data_shape == (3, 1, 1)
+
+    with pytest.raises(ValueError):
+        axis = MapAxis.from_nodes([1, 2], name="test")
+        geom = RegionGeom.create(region, axes=[axis])
+
+
+def test_get_coord(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+    coords = geom.get_coord()
+
+    assert_allclose(coords.lon, 0)
+    assert_allclose(coords.lat, 0)
+    assert_allclose(coords["energy"].value, 3.162278, rtol=1e-5)
+
+
+def test_get_idx(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+    pix = geom.get_idx()
+
+    assert_allclose(pix[0], 0)
+    assert_allclose(pix[1], 0)
+    assert_allclose(pix[2], 0)
+
+
+def test_coord_to_pix(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+
+    position = SkyCoord(0, 0, frame="galactic", unit="deg")
+    coords = {"skycoord": position, "energy": 1 * u.TeV}
+    coords_pix = geom.coord_to_pix(coords)
+
+    assert_allclose(coords_pix[0], 0)
+    assert_allclose(coords_pix[1], 0)
+    assert_allclose(coords_pix[2], -0.5)
+
+
+def test_pix_to_coord(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+
+    pix = (0, 0, 0)
+    coords = geom.pix_to_coord(pix)
+    assert_allclose(coords[0].value, 0)
+    assert_allclose(coords[1].value, 0)
+    assert_allclose(coords[2].value, 3.162278, rtol=1e-5)
+
+    pix = (1, 1, 1)
+    coords = geom.pix_to_coord(pix)
+    assert_allclose(coords[0].value, np.nan)
+    assert_allclose(coords[1].value, np.nan)
+    assert_allclose(coords[2].value, 31.62278, rtol=1e-5)
+
+
+def test_contains(region):
+    geom = RegionGeom.create(region)
+    position = SkyCoord([0, 0], [0, 1.1], frame="galactic", unit="deg")
+
+    contains = geom.contains(coords={"skycoord": position})
+    assert_allclose(contains, [1, 0])
+
+
+def test_solid_angle(region):
+    geom = RegionGeom.create(region)
+    omega = geom.solid_angle()
+
+    assert omega.unit == "sr"
+    reference = 2 * np.pi * (1 - np.cos(region.radius))
+    assert_allclose(omega.value, reference.value, rtol=1e-3)
+
+
+def test_bin_volume(region):
+    axis = MapAxis.from_edges([1, 3] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+    volume = geom.bin_volume()
+
+    assert volume.unit == "sr TeV"
+    reference = 2 * 2 * np.pi * (1 - np.cos(region.radius))
+    assert_allclose(volume.value, reference.value, rtol=1e-3)
+
+
+def test_separation(region):
+    geom = RegionGeom.create(region)
+
+    position = SkyCoord([0, 0], [0, 1.1], frame="galactic", unit="deg")
+    separation = geom.separation(position)
+
+    assert_allclose(separation.deg, [0, 1.1])
+
+
+def test_upsample(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+    geom_up = geom.upsample(factor=2, axis="energy")
+
+    assert_allclose(geom_up.axes[0].edges.value, [1., 3.162278, 10.], rtol=1e-5)
+
+
+def test_downsample(region):
+    axis = MapAxis.from_edges([1, 3.162278, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+    geom_down = geom.downsample(factor=2, axis="energy")
+
+    assert_allclose(geom_down.axes[0].edges.value, [1., 10.], rtol=1e-5)
+
+
+def test_repr(region):
+    axis = MapAxis.from_edges([1, 3.162278, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region, axes=[axis])
+
+    assert "RegionGeom" in repr(geom)
+    assert "CircleSkyRegion" in repr(geom)
+
+
+def test_eq(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom_1 = RegionGeom.create(region, axes=[axis])
+    geom_2 = RegionGeom.create(region, axes=[axis])
+
+    assert geom_1 == geom_2
+
+    axis = MapAxis.from_edges([1, 100] * u.TeV, name="energy", interp="log")
+    geom_3 = RegionGeom.create(region, axes=[axis])
+
+    assert not geom_2 == geom_3
+
+
+def test_to_cube_to_image(region):
+    axis = MapAxis.from_edges([1, 10] * u.TeV, name="energy", interp="log")
+    geom = RegionGeom.create(region)
+
+    geom_cube = geom.to_cube([axis])
+    assert geom_cube.ndim == 3
+
+    geom = geom_cube.to_image()
+    assert geom.ndim == 2
+

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -16,7 +16,7 @@ def region():
 
 def test_create(region):
     geom = RegionGeom.create(region)
-    assert geom.coordsys == "GAL"
+    assert geom.frame == "galactic"
     assert geom.projection == "TAN"
     assert not geom.is_image
     assert not geom.is_allsky

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -28,6 +28,9 @@ def test_centers(region):
     assert_allclose(geom.center_skydir.b.deg, 0)
     assert_allclose(geom.center_pix, (0, 0))
 
+    values = [_.value for _ in geom.center_coord]
+    assert_allclose(values, (0, 0))
+
 
 def test_create_axis(region):
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
@@ -174,4 +177,3 @@ def test_to_cube_to_image(region):
 
     geom = geom_cube.to_image()
     assert geom.ndim == 2
-

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -1,0 +1,12 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+from regions import CircleSkyRegion
+from gammapy.maps import Map
+
+
+def test_region_nd_map():
+    pass

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from gammapy.maps import Map, MapAxis
-from gammapy.utils.testing import mpl_plot_check, requires_data
+from gammapy.utils.testing import mpl_plot_check, requires_data, requires_dependency
 from gammapy.data import EventList
 from gammapy.irf import EDispKernel
 
@@ -31,6 +31,7 @@ def test_region_nd_map(region_map):
     assert "1 / TeV" in str(region_map)
 
 
+@requires_dependency("matplotlib")
 def test_region_nd_map_plot(region_map):
     import matplotlib.pyplot as plt
 

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 from gammapy.maps import Map, MapAxis
 from gammapy.utils.testing import mpl_plot_check, requires_data
 from gammapy.data import EventList
+from gammapy.irf import EDispKernel
 
 
 @pytest.fixture
@@ -109,5 +110,21 @@ def test_region_nd_map_fill_events(region_map):
     region_map.fill_events(events)
 
     assert_allclose(region_map.data.sum(), 665)
+
+
+def test_apply_edisp(region_map):
+    e_true = region_map.geom.axes[0].edges
+    e_reco = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3).edges
+
+    edisp = EDispKernel.from_diagonal_response(e_true=e_true, e_reco=e_reco)
+
+    m = region_map.apply_edisp(edisp)
+    assert m.geom.data_shape == (3, 1, 1)
+
+    e_reco = m.geom.axes[0].edges
+    assert e_reco.unit == "TeV"
+    assert_allclose(e_reco[[0, -1]].value, [1, 10])
+
+
 
 

--- a/gammapy/maps/tests/test_regionnd.py
+++ b/gammapy/maps/tests/test_regionnd.py
@@ -1,12 +1,113 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
-import astropy.units as u
-from astropy.coordinates import SkyCoord
-from regions import CircleSkyRegion
-from gammapy.maps import Map
+from numpy.testing import assert_allclose
+from gammapy.maps import Map, MapAxis
+from gammapy.utils.testing import mpl_plot_check, requires_data
+from gammapy.data import EventList
 
 
-def test_region_nd_map():
-    pass
+@pytest.fixture
+def region_map():
+    axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=6)
+    m = Map.create(
+        region="icrs;circle(83.63, 21.51, 1)",
+        map_type="region",
+        axes=[axis],
+        unit="1/TeV",
+        dtype=np.int
+    )
+    m.data = np.arange(m.data.size).reshape(m.geom.data_shape)
+    return m
+
+
+def test_region_nd_map(region_map):
+    assert_allclose(region_map.data.sum(), 15)
+    assert region_map.geom.frame == "icrs"
+    assert region_map.unit == "TeV-1"
+    assert region_map.data.dtype == np.int
+    assert "RegionNDMap" in str(region_map)
+    assert "1 / TeV" in str(region_map)
+
+
+def test_region_nd_map_plot(region_map):
+    import matplotlib.pyplot as plt
+
+    with mpl_plot_check():
+        region_map.plot()
+
+    ax = plt.subplot(projection=region_map.geom.wcs)
+    with mpl_plot_check():
+        region_map.plot_region(ax=ax)
+
+
+def test_region_nd_map_misc(region_map):
+    assert_allclose(region_map.sum_over_axes(), 15)
+
+    stacked = region_map.copy()
+    stacked.stack(region_map)
+    assert_allclose(stacked.data.sum(), 30)
+
+    stacked = region_map.copy()
+    weights = Map.from_geom(region_map.geom, dtype=np.int)
+    stacked.stack(region_map, weights=weights)
+    assert_allclose(stacked.data.sum(), 15)
+
+
+def test_region_nd_map_sample(region_map):
+    upsampled = region_map.upsample(factor=2)
+    assert_allclose(upsampled.data.sum(), 15)
+    assert upsampled.data.shape == (12, 1, 1)
+
+    upsampled = region_map.upsample(factor=2, preserve_counts=False)
+    assert_allclose(upsampled.data[3, 0, 0], 1.25)
+    assert upsampled.data.shape == (12, 1, 1)
+
+    downsampled = region_map.downsample(factor=2)
+    assert_allclose(downsampled.data.sum(), 15)
+    assert_allclose(downsampled.data[2, 0, 0], 9)
+    assert downsampled.data.shape == (3, 1, 1)
+
+    downsampled = region_map.downsample(factor=2, preserve_counts=False)
+    assert_allclose(downsampled.data.sum(), 7.5)
+    assert_allclose(downsampled.data[2, 0, 0], 4.5)
+    assert downsampled.data.shape == (3, 1, 1)
+
+
+def test_region_nd_map_get(region_map):
+    values = region_map.get_by_idx((0, 0, [2, 3]))
+    assert_allclose(values.squeeze(), [2, 3])
+
+    values = region_map.get_by_pix((0, 0, [2.3, 3.7]))
+    assert_allclose(values.squeeze(), [2, 4])
+
+    energies = region_map.geom.axes[0].center
+    values = region_map.get_by_coord((83.63, 21.51, energies[[0, -1]]))
+    assert_allclose(values.squeeze(), [0, 5])
+
+
+def test_region_nd_map_set(region_map):
+    region_map = region_map.copy()
+    region_map.set_by_idx((0, 0, [2, 3]), [42, 42])
+    assert_allclose(region_map.data[[2, 3]], 42)
+
+    region_map = region_map.copy()
+    region_map.set_by_pix((0, 0, [2.3, 3.7]),  [42, 42])
+    assert_allclose(region_map.data[[2, 3]], 42)
+
+    region_map = region_map.copy()
+    energies = region_map.geom.axes[0].center
+    region_map.set_by_coord((83.63, 21.51, energies[[0, -1]]),  [42, 42])
+    assert_allclose(region_map.data[[0, -1]], 42)
+
+
+@requires_data()
+def test_region_nd_map_fill_events(region_map):
+    filename = '$GAMMAPY_DATA/hess-dl3-dr1/data/hess_dl3_dr1_obs_id_023523.fits.gz'
+    events = EventList.read(filename)
+    region_map = Map.from_geom(region_map.geom)
+    region_map.fill_events(events)
+
+    assert_allclose(region_map.data.sum(), 665)
+
+

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -632,28 +632,6 @@ class WcsNDMap(WcsMap):
 
         return self._init_copy(data=convolved_data)
 
-    def apply_edisp(self, edisp):
-        """Apply energy dispersion to map. Requires energy axis.
-
-        Parameters
-        ----------
-        edisp : `gammapy.irf.EDispKernel`
-            Energy dispersion matrix
-
-        Returns
-        -------
-        map : `WcsNDMap`
-            Map with energy dispersion applied.
-        """
-        loc = self.geom.get_axis_index_by_name("energy")
-        data = np.rollaxis(self.data, loc, len(self.data.shape))
-        data = np.dot(data, edisp.pdf_matrix)
-        data = np.rollaxis(data, -1, loc)
-
-        e_reco_axis = edisp.e_reco.copy(name="energy")
-        geom_reco = self.geom.to_image().to_cube(axes=[e_reco_axis])
-        return self._init_copy(geom=geom_reco, data=data)
-
     def cutout(self, position, width, mode="trim"):
         """
         Create a cutout around a given position.


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request address issue #1805. The motivation is to unify the data structures for region based analyses with our current map API. So far we used the `CountsSpectrum` class for this,
but it features a different API. It also misses the handling of additional meta data such as region and wcs information for projected regions (those were added just recently...basically as a hack...).

The existence of a different data structure for region based analyses leads (beside the different API) to inconsistencies and code duplication. E.g. the need for a separate `SpectrumEvaluator` (even `SpectrumDataset` and `SpectrumDatasetOnOff`, but this leads a bit to far for now..).

The plan is to replace the current `CountsSpectrum` with the `RegionNDMap` everywhere in Gammapy and also use it later for irf maps such as `EDispMap`.

Currently the `RegionNDMap` implemented in this PR comes with the following (minor) limitations:
- Only support one extra energy axis
- Only supports circular sky regions
- No interactive plotting
- The `.crop()` and `.pad()` method are not defined
- Methods like `.get_image_by_xxx()` technically work, but return maps with one pixel, which is of limited use

In follow-up PRs I will implement serialisation for the `RegionNDMap`, refactor the code to get rid of `CountsSectrum` and add documentation on how to work with `RegionNDMap` and `RegionGeom`.

A few details need to be figured out:
- How to handle different regions in `RegionNDMap.stack()`? I think there are mainly two use-cases: stacking data in the same region and stacking data from different regions. In the latter case a compound region must be created, while in the first cases the region info remains untouched.
- How to find the tangential WCS for arbitrary region shapes and compound regions (especially the width). 
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
