### PR TITLE
Add model evaluation of Temporal Models

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -1510,17 +1510,26 @@ class MapEvaluator:
         PSF kernel
     edisp : `~gammapy.irf.EDispKernel`
         Energy dispersion
+    times : `~astropy.time.Time`
+        Time of computation of temporal model
     evaluation_mode : {"local", "global"}
         Model evaluation mode.
     """
 
     def __init__(
-        self, model=None, exposure=None, psf=None, edisp=None, evaluation_mode="local"
+        self,
+        model=None,
+        exposure=None,
+        psf=None,
+        edisp=None,
+        times=None,
+        evaluation_mode="local",
     ):
         self.model = model
         self.exposure = exposure
         self.psf = psf
         self.edisp = edisp
+        self.times = times
         self.contributes = True
 
         if evaluation_mode not in {"local", "global"}:
@@ -1599,7 +1608,7 @@ class MapEvaluator:
             Sky cube with data filled with evaluated model values.
             Units: ``cm-2 s-1 TeV-1 deg-2``
         """
-        return self.model.evaluate_geom(self.geom)
+        return self.model.evaluate_geom(self.geom, self.times)
 
     def compute_flux(self):
         """Compute model integral flux over map pixel volumes.

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -19,7 +19,7 @@ class TemporalModel(Model):
 
     def __call__(self, time):
         """Call evaluate method"""
-        # Works for Time object with a list, but not a list of Time objects
+        # Works for Time object list, but not a list of Time objects
         kwargs = {par.name: par.quantity for par in self.parameters}
         return self.evaluate(time.mjd, **kwargs)
 

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -17,6 +17,12 @@ from .core import Model
 class TemporalModel(Model):
     """Temporal model base class."""
 
+    def __call__(self, time):
+        """Call evaluate method"""
+        # Works for Time object with a list, but not a list of Time objects
+        kwargs = {par.name: par.quantity for par in self.parameters}
+        return self.evaluate(time.mjd, **kwargs)
+
 
 # TODO: make this a small ABC to define a uniform interface.
 class TemplateTemporalModel(TemporalModel):
@@ -43,30 +49,20 @@ class TemplateTemporalModel(TemporalModel):
 
 class ConstantTemporalModel(TemporalModel):
     """Constant temporal model.
-
-    Parameters
-    ----------
-    norm : float
-        The normalization of the constant temporal model
     """
 
     tag = "ConstantTemporalModel"
-    norm = Parameter("norm", 1)
 
-    def evaluate_norm_at_time(self, time):
+    def evaluate(self, time):
         """Evaluate for a given time.
 
         Parameters
         ----------
-        time : array_like
+        time : `~astropy.time,Time`, array_like
             Time since the ``reference`` time.
 
-        Returns
-        -------
-        norm : float
-            Mean norm
         """
-        return np.ones_like(time) * self.norm.value
+        return np.ones_like(time)
 
     def sample_time(self, n_events, t_min, t_max, random_state=0):
         """Sample arrival times of events.
@@ -285,7 +281,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
 
     The lightcurve is given as a table with columns ``time`` and ``norm``.
 
-    The ``norm`` is supposed to be a unite-less multiplicative factor in the model,
+    The ``norm`` is supposed to be a unit-less multiplicative factor in the model,
     to be multiplied with a spectral model.
 
     The model does linear interpolation for times between the given ``(time, norm)`` values.
@@ -360,7 +356,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
     def _time(self):
         return self._time_ref + self.table["TIME"].data * u.s
 
-    def evaluate_norm_at_time(self, time, ext_mode=3):
+    def evaluate(self, time, ext_mode=3):
         """Evaluate for a given time.
 
         Parameters
@@ -437,7 +433,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         t_step = t_delta.to_value(time_unit)
         t = np.arange(0, t_stop, t_step)
 
-        pdf = self.evaluate_norm_at_time(t * time_unit)
+        pdf = self.evaluate(t * time_unit)
 
         sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
         time_pix = sampler.sample(n_events)[0]

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -59,7 +59,7 @@ def test_light_curve_str(light_curve):
 
 @requires_data()
 def test_light_curve_evaluate_norm_at_time(light_curve):
-    val = light_curve.evaluate_norm_at_time(46300)
+    val = light_curve.evaluate(46300)
     assert_allclose(val, 0.021192223042749835)
 
 
@@ -121,7 +121,7 @@ def test_time_sampling(tmp_path):
 
 
 def test_constant_temporal_model_sample():
-    temporal_model = ConstantTemporalModel(norm=10.0)
+    temporal_model = ConstantTemporalModel()
 
     t_ref = "2010-01-01T00:00:00"
     t_min = "2010-01-01T00:00:00"
@@ -137,10 +137,10 @@ def test_constant_temporal_model_sample():
     assert_allclose(sampler.value, [15805.82891311, 20597.45375153], rtol=1e-5)
 
 
-def test_constant_temporal_model_evaluate_norm_at_time():
-    temporal_model = ConstantTemporalModel(norm=10.0)
-    val = temporal_model.evaluate_norm_at_time(46300)
-    assert_allclose(val, 10.0, rtol=1e-5)
+def test_constant_temporal_model_evaluate():
+    temporal_model = ConstantTemporalModel()
+    val = temporal_model.evaluate(46300)
+    assert_allclose(val, 1.0, rtol=1e-5)
 
 
 def test_phase_time_sampling():

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -234,7 +234,7 @@ def make_all_models():
     # TODO: yield Model.create("AbsorbedSpectralModel")
     # TODO: yield Model.create("NaimaSpectralModel")
     # TODO: yield Model.create("ScaleSpectralModel")
-    yield Model.create("ConstantTemporalModel", norm=2)
+    yield Model.create("ConstantTemporalModel")
     yield Model.create(
         "PhaseCurveTemplateTemporalModel", Table(), time_0=1, phase_0=2, f0=3
     )  # TODO: add table content validation?


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds evaluation of temporal models on `SkyModel`

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

This PR is in progress.
1. The test fail `test_datasets_to_io` in `modeling/tests/test_serialize_yaml.py` is happening on my master as well. I do not understand why the parameter name is getting corrupted.
2. I assume that one `MapDataset` will be evaluated only at ONE specific instance of time.
3. The `time` argument is passed to `SkyDiffuseCube.evaluate()` to maintain a uniform interface. Maybe there is a better way to do it? Or it might be easier to just add a `TemporalModel` on it.