### PR TITLE
Adding the Jacobian in gammapy.cube.PSFMap.psf_map.sample_coord()

### DIFF
--- a/gammapy/cube/psf_map.py
+++ b/gammapy/cube/psf_map.py
@@ -379,7 +379,11 @@ class PSFMap:
             "theta": rad_axis.center,
         }
 
-        pdf = self.psf_map.interp_by_coord(coord)
+        pdf = (
+            self.psf_map.interp_by_coord(coord)
+            * rad_axis.center.value
+            * rad_axis.bin_width.value
+        )
 
         sample_pdf = InverseCDFSampler(pdf, axis=1, random_state=random_state)
         pix_coord = sample_pdf.sample_axis()

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -202,8 +202,8 @@ def test_sample_coord():
     coords = psf_map.sample_coord(map_coord=coords_in)
     assert coords.frame == "icrs"
     assert len(coords.lon) == 2
-    assert_allclose(coords.lon, [0.04262, 0.02797], rtol=1e-3)
-    assert_allclose(coords.lat, [-0.057826, 0.399912], rtol=1e-3)
+    assert_allclose(coords.lon, [0.07498478, 0.04274561], rtol=1e-3)
+    assert_allclose(coords.lat, [-0.10173629, 0.34703959], rtol=1e-3)
 
 
 def test_sample_coord_gauss():

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -137,13 +137,13 @@ def test_mde_sample_psf(dataset):
     events = sampler.sample_psf(dataset.psf, events)
 
     assert len(events.table) == 2407
-    assert_allclose(events.table["ENERGY_TRUE"][0], 2.245024, rtol=1e-5)
+    assert_allclose(events.table["ENERGY_TRUE"][0], 2.2450239, rtol=1e-5)
     assert events.table["ENERGY_TRUE"].unit == "TeV"
 
-    assert_allclose(events.table["RA"][0], 266.909362, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.895383, rtol=1e-5)
     assert events.table["RA"].unit == "deg"
 
-    assert_allclose(events.table["DEC"][0], -29.039877, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -29.052050, rtol=1e-5)
     assert events.table["DEC"].unit == "deg"
 
 


### PR DESCRIPTION
The current implementation of `gammapy.cube.PSFMap.psf_map.sample_coord()` does not take into account the Jacobian (r*dr) of the PSF transformation. This PR aims at fix this bug. 