### PR TITLE
Add datasets_names attribute to cube models

### DIFF
--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -14,7 +14,7 @@ from gammapy.data import GTI
 from gammapy.irf import EDispKernel, EffectiveAreaTable
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling import Dataset, Parameters
-from gammapy.modeling.models import BackgroundModel, Models
+from gammapy.modeling.models import BackgroundModel, Models, SkyModel
 from gammapy.spectrum import SpectrumDataset, SpectrumDatasetOnOff
 from gammapy.stats import cash, cash_sum_cython, wstat
 from gammapy.utils.random import get_random_state
@@ -195,6 +195,12 @@ class MapDataset(Dataset):
         if models is None:
             self._models = None
         else:
+            if isinstance(models, (BackgroundModel, SkyModel)):
+                models = [models]
+            elif isinstance(models,(Models, list)):
+                models = list(models)
+            else:
+                raise TypeError("Invalid models")
             models_list = [
                 model
                 for model in models

--- a/gammapy/cube/make.py
+++ b/gammapy/cube/make.py
@@ -231,7 +231,7 @@ class MapDatasetMaker:
 
         if "background" in self.selection:
             background_map = self.make_background(dataset.counts.geom, observation)
-            kwargs["models"] = BackgroundModel(background_map)
+            kwargs["models"] = BackgroundModel(background_map, datasets_names=[dataset.name])
 
         if "psf" in self.selection:
             psf = self.make_psf(dataset.psf.psf_map.geom, observation)

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -61,7 +61,7 @@ class SkyModel(SkyModelBase):
         temporal_model=None,
         name=None,
         apply_irf=None,
-        datasets_names=None,
+        datasets_names="all",
     ):
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
@@ -74,10 +74,7 @@ class SkyModel(SkyModelBase):
         self.apply_irf = {"exposure": True, "psf": True, "edisp": True}
         if apply_irf is not None:
             self.apply_irf.update(apply_irf)
-        if datasets_names is not None:
-            self.datasets_names = datasets_names
-        else:
-            self.datasets_names = "all"
+        self.datasets_names = datasets_names
 
     @property
     def name(self):
@@ -338,7 +335,7 @@ class SkyDiffuseCube(SkyModelBase):
         name=None,
         filename=None,
         apply_irf=None,
-        datasets_names=None,
+        datasets_names="all",
     ):
 
         self._name = make_name(name)
@@ -359,10 +356,7 @@ class SkyDiffuseCube(SkyModelBase):
         self.apply_irf = {"exposure": True, "psf": True, "edisp": True}
         if apply_irf is not None:
             self.apply_irf.update(apply_irf)
-        if datasets_names is not None:
-            self.datasets_names = datasets_names
-        else:
-            self.datasets_names = "all"
+        self.datasets_names = datasets_names
         super().__init__(norm=norm, tilt=tilt, reference=reference)
 
     @property
@@ -510,7 +504,7 @@ class BackgroundModel(Model):
         reference=reference.quantity,
         name=None,
         filename=None,
-        datasets_names=None,
+        datasets_names="all",
     ):
         axis = map.geom.get_axis_by_name("energy")
         if axis.node_type != "edges":
@@ -520,10 +514,7 @@ class BackgroundModel(Model):
 
         self._name = make_name(name)
         self.filename = filename
-        if datasets_names is not None:
-            self.datasets_names = datasets_names
-        else:
-            self.datasets_names = "all"
+        self.datasets_names = datasets_names
         super().__init__(norm=norm, tilt=tilt, reference=reference)
 
     @property

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -61,6 +61,7 @@ class SkyModel(SkyModelBase):
         temporal_model=None,
         name=None,
         apply_irf=None,
+        datasets_names=None,
     ):
         self.spatial_model = spatial_model
         self.spectral_model = spectral_model
@@ -73,6 +74,10 @@ class SkyModel(SkyModelBase):
         self.apply_irf = {"exposure": True, "psf": True, "edisp": True}
         if apply_irf is not None:
             self.apply_irf.update(apply_irf)
+        if datasets_names is not None:
+            self.datasets_names = datasets_names
+        else:
+            self.datasets_names = "all"
 
     @property
     def name(self):
@@ -205,6 +210,7 @@ class SkyModel(SkyModelBase):
         kwargs.setdefault("spatial_model", spatial_model)
         kwargs.setdefault("temporal_model", temporal_model)
         kwargs.setdefault("apply_irf", self.apply_irf)
+        kwargs.setdefault("datasets_names", self.datasets_names)
 
         return self.__class__(**kwargs)
 
@@ -223,6 +229,9 @@ class SkyModel(SkyModelBase):
 
         if self.apply_irf != {"exposure": True, "psf": True, "edisp": True}:
             data["apply_irf"] = self.apply_irf
+
+        if self.datasets_names != "all":
+            data["datasets_names"] = self.datasets_names
 
         return data
 
@@ -260,6 +269,7 @@ class SkyModel(SkyModelBase):
             apply_irf=data.get(
                 "apply_irf", {"exposure": True, "psf": True, "edisp": True}
             ),
+            datasets_names=data.get("datasets_names", "all"),
         )
 
     def __str__(self):
@@ -328,6 +338,7 @@ class SkyDiffuseCube(SkyModelBase):
         name=None,
         filename=None,
         apply_irf=None,
+        datasets_names=None,
     ):
 
         self._name = make_name(name)
@@ -348,7 +359,10 @@ class SkyDiffuseCube(SkyModelBase):
         self.apply_irf = {"exposure": True, "psf": True, "edisp": True}
         if apply_irf is not None:
             self.apply_irf.update(apply_irf)
-
+        if datasets_names is not None:
+            self.datasets_names = datasets_names
+        else:
+            self.datasets_names = "all"
         super().__init__(norm=norm, tilt=tilt, reference=reference)
 
     @property
@@ -435,6 +449,8 @@ class SkyDiffuseCube(SkyModelBase):
             "apply_irf", {"exposure": True, "psf": True, "edisp": True}
         )
         model.apply_irf.update(apply_irf)
+        model.datasets_names = data.get("datasets_names", "all")
+
         return model
 
     def to_dict(self):
@@ -447,6 +463,8 @@ class SkyDiffuseCube(SkyModelBase):
         data["parameters"] = data.pop("parameters")
         if self.apply_irf != {"exposure": True, "psf": True, "edisp": True}:
             data["apply_irf"] = self.apply_irf
+        if self.datasets_names != "all":
+            data["datasets_names"] = self.datasets_names
 
         return data
 
@@ -492,6 +510,7 @@ class BackgroundModel(Model):
         reference=reference.quantity,
         name=None,
         filename=None,
+        datasets_names=None,
     ):
         axis = map.geom.get_axis_by_name("energy")
         if axis.node_type != "edges":
@@ -501,7 +520,10 @@ class BackgroundModel(Model):
 
         self._name = make_name(name)
         self.filename = filename
-
+        if datasets_names is not None:
+            self.datasets_names = datasets_names
+        else:
+            self.datasets_names = "all"
         super().__init__(norm=norm, tilt=tilt, reference=reference)
 
     @property
@@ -537,6 +559,8 @@ class BackgroundModel(Model):
         if self.filename is not None:
             data["filename"] = self.filename
         data["parameters"] = data.pop("parameters")
+        if self.datasets_names != "all":
+            data["datasets_names"] = self.datasets_names
         return data
 
     @classmethod
@@ -547,8 +571,9 @@ class BackgroundModel(Model):
             map = data["map"]
         else:
             raise ValueError("Requires either filename or `Map` object")
-
-        model = cls(map=map, name=data["name"])
+        model = cls(
+            map=map, name=data["name"], datasets_names=data.get("datasets_names", "all")
+        )
         model._update_from_dict(data)
         return model
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -365,6 +365,18 @@ class TestSkyDiffuseCube:
         assert out["apply_irf"] == {"exposure": True, "psf": True, "edisp": False}
         diffuse_model.apply_irf["edisp"] = True
 
+    @staticmethod
+    def test_datasets_name(diffuse_model):
+        assert diffuse_model.datasets == "all"
+
+        diffuse_model.datasets = ["1", "2"]
+        out = diffuse_model.to_dict()
+        assert out["datasets"] == ["1", "2"]
+
+        diffuse_model.datasets = "all"
+        out = diffuse_model.to_dict()
+        assert "datasets" not in out
+
 
 class TestSkyDiffuseCubeMapEvaluator:
     @staticmethod

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -367,15 +367,15 @@ class TestSkyDiffuseCube:
 
     @staticmethod
     def test_datasets_name(diffuse_model):
-        assert diffuse_model.datasets == "all"
+        assert diffuse_model.datasets_names == "all"
 
-        diffuse_model.datasets = ["1", "2"]
+        diffuse_model.datasets_names = ["1", "2"]
         out = diffuse_model.to_dict()
-        assert out["datasets"] == ["1", "2"]
+        assert out["datasets_names"] == ["1", "2"]
 
-        diffuse_model.datasets = "all"
+        diffuse_model.datasets_names = "all"
         out = diffuse_model.to_dict()
-        assert "datasets" not in out
+        assert "datasets_names" not in out
 
 
 class TestSkyDiffuseCubeMapEvaluator:

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -115,9 +115,9 @@ def test_datasets_to_io(tmp_path):
     datasets = Datasets.read(filedata, filemodel)
 
     assert len(datasets) == 2
-    assert len(datasets.parameters) == 22
 
     dataset0 = datasets[0]
+    assert dataset0.name == "gc"
     assert dataset0.counts.data.sum() == 6824
     assert_allclose(dataset0.exposure.data.sum(), 2072125400000.0, atol=0.1)
     assert dataset0.psf is not None
@@ -128,6 +128,7 @@ def test_datasets_to_io(tmp_path):
     assert dataset0.background_model.name == "background_irf_gc"
 
     dataset1 = datasets[1]
+    assert dataset1.name == "g09"
     assert dataset1.background_model.name == "background_irf_g09"
 
     assert (
@@ -150,6 +151,9 @@ def test_datasets_to_io(tmp_path):
     datasets_read = Datasets.read(
         tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
     )
+    
+    assert len(datasets.parameters) == 22
+
     assert len(datasets_read) == 2
     dataset0 = datasets_read[0]
     assert dataset0.counts.data.sum() == 6824

--- a/gammapy/modeling/tests/test_serialize_yaml.py
+++ b/gammapy/modeling/tests/test_serialize_yaml.py
@@ -151,7 +151,7 @@ def test_datasets_to_io(tmp_path):
     datasets_read = Datasets.read(
         tmp_path / "written_datasets.yaml", tmp_path / "written_models.yaml"
     )
-    
+
     assert len(datasets.parameters) == 22
 
     assert len(datasets_read) == 2

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -182,11 +182,16 @@ class SpectrumDataset(Dataset):
         return self._models
 
     @models.setter
-    def models(self, value):
-        if value is not None:
-            self._models = Models(value)
-        else:
+    def models(self, models):
+        if models is None:
             self._models = None
+        else:
+            models_list = [
+                model
+                for model in models
+                if self.name in model.datasets_names or model.datasets_names == "all"
+            ]
+            self._models = Models(models_list)
 
         evaluators = []
         if self.models is not None:
@@ -1212,11 +1217,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             Spectrum dataset on off.
 
         """
-        models = [
-            model
-            for model in models
-            if data["name"] in model.datasets_names or model.datasets_names == "all"
-        ]
+
         filename = data["filename"]
 
         dataset = cls.from_ogip_files(filename=filename)

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -126,7 +126,9 @@ class SpectrumDataset(Dataset):
         aeff_min, aeff_max, aeff_unit = np.nan, np.nan, ""
         if self.aeff is not None:
             try:
-                aeff_min = np.min(self.aeff.data.data.value[self.aeff.data.data.value > 0])
+                aeff_min = np.min(
+                    self.aeff.data.data.value[self.aeff.data.data.value > 0]
+                )
             except ValueError:
                 aeff_min = 0
             aeff_max = np.max(self.aeff.data.data.value)
@@ -1079,7 +1081,11 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             data = _read_ogip_hdulist(hdulist)
 
         counts = CountsSpectrum(
-            energy_hi=data["energy_hi"], energy_lo=data["energy_lo"], data=data["data"],region=data["region"],wcs=data["wcs"]
+            energy_hi=data["energy_hi"],
+            energy_lo=data["energy_lo"],
+            data=data["data"],
+            region=data["region"],
+            wcs=data["wcs"],
         )
 
         phafile = filename.name
@@ -1100,7 +1106,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
                     energy_lo=data_bkg["energy_lo"],
                     data=data_bkg["data"],
                     region=data_bkg["region"],
-                    wcs=data_bkg["wcs"]
+                    wcs=data_bkg["wcs"],
                 )
 
                 acceptance_off = data_bkg["backscal"]
@@ -1166,15 +1172,9 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         outdir = Path(filename).parent
         filename = str(outdir / f"pha_obs{self.name}.fits")
 
-        if self.models is None:
-            models = []
-        else:
-            models = [_.name for _ in self.models]
-
         return {
             "name": self.name,
             "type": self.tag,
-            "models": models,
             "filename": filename,
         }
 
@@ -1212,10 +1212,11 @@ class SpectrumDatasetOnOff(SpectrumDataset):
             Spectrum dataset on off.
 
         """
-        models = [model for model in models if model.name in data["models"]]
-
-        # TODO: assumes that the model is a skymodel
-        # so this will work only when this change will be effective
+        models = [
+            model
+            for model in models
+            if data["name"] in model.datasets_names or model.datasets_names == "all"
+        ]
         filename = data["filename"]
 
         dataset = cls.from_ogip_files(filename=filename)
@@ -1267,7 +1268,9 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         )
 
 
-def _read_ogip_hdulist(hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS", hdu3="GTI", hdu4="REGION"):
+def _read_ogip_hdulist(
+    hdulist, hdu1="SPECTRUM", hdu2="EBOUNDS", hdu3="GTI", hdu4="REGION"
+):
     """Create from `~astropy.io.fits.HDUList`."""
     counts_table = Table.read(hdulist[hdu1])
     ebounds = Table.read(hdulist[hdu2])

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -86,11 +86,11 @@ class SpectrumDataset(Dataset):
         self.aeff = aeff
         self.edisp = edisp
         self.background = background
-        self.models = models
         self.mask_safe = mask_safe
         self.gti = gti
 
         self._name = make_name(name)
+        self.models = models
 
     @property
     def name(self):
@@ -188,7 +188,7 @@ class SpectrumDataset(Dataset):
         else:
             if isinstance(models, SkyModel):
                 models = [models]
-            elif isinstance(models, Models):
+            elif isinstance(models, (Models, list)):
                 models = list(models)
             else:
                 raise TypeError("Invalid models")
@@ -692,7 +692,6 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self.mask_fit = mask_fit
         self.aeff = aeff
         self.edisp = edisp
-        self.models = models
         self.mask_safe = mask_safe
 
         if np.isscalar(acceptance):
@@ -705,6 +704,7 @@ class SpectrumDatasetOnOff(SpectrumDataset):
         self.acceptance_off = acceptance_off
         self._name = make_name(name)
         self.gti = gti
+        self.models = models
 
     def __str__(self):
         str_ = super().__str__()

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -7,7 +7,7 @@ from astropy.table import Table
 from gammapy.data import GTI
 from gammapy.irf import EDispKernel, EffectiveAreaTable, IRFStacker
 from gammapy.modeling import Dataset, Parameters
-from gammapy.modeling.models import Models
+from gammapy.modeling.models import Models, SkyModel
 from gammapy.stats import cash, significance, significance_on_off, wstat
 from gammapy.utils.fits import energy_axis_to_ebounds
 from gammapy.utils.random import get_random_state
@@ -186,6 +186,12 @@ class SpectrumDataset(Dataset):
         if models is None:
             self._models = None
         else:
+            if isinstance(models, SkyModel):
+                models = [models]
+            elif isinstance(models, Models):
+                models = list(models)
+            else:
+                raise TypeError("Invalid models")
             models_list = [
                 model
                 for model in models

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1267,9 +1267,11 @@ class FluxPointsDataset(Dataset):
         dataset : `FluxPointsDataset`
             Flux point datasets.
         """
-        models = [model for model in models if model.name in data["models"]]
-        # TODO: assumes that the model is a skymodel
-        # so this will work only when this change will be effective
+        models = [
+            model
+            for model in models
+            if data["name"] in model.datasets_names or model.datasets_names == "all"
+        ]
         table = Table.read(data["filename"])
         mask_fit = table["mask_fit"].data.astype("bool")
         mask_safe = table["mask_safe"].data.astype("bool")
@@ -1284,15 +1286,9 @@ class FluxPointsDataset(Dataset):
 
     def to_dict(self, filename=""):
         """Convert to dict for YAML serialization."""
-        if self.models is not None:
-            models = [_.name for _ in self.models]
-        else:
-            models = []
-
         return {
             "name": self.name,
             "type": self.tag,
-            "models": models,
             "filename": str(filename),
         }
 

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1211,11 +1211,16 @@ class FluxPointsDataset(Dataset):
         return self._models
 
     @models.setter
-    def models(self, value):
-        if value is not None:
-            self._models = Models(value)
-        else:
+    def models(self, models):
+        if models is None:
             self._models = None
+        else:
+            models_list = [
+                model
+                for model in models
+                if self.name in model.datasets_names or model.datasets_names == "all"
+            ]
+            self._models = Models(models_list)
 
     @property
     def parameters(self):
@@ -1267,11 +1272,7 @@ class FluxPointsDataset(Dataset):
         dataset : `FluxPointsDataset`
             Flux point datasets.
         """
-        models = [
-            model
-            for model in models
-            if data["name"] in model.datasets_names or model.datasets_names == "all"
-        ]
+
         table = Table.read(data["filename"])
         mask_fit = table["mask_fit"].data.astype("bool")
         mask_safe = table["mask_safe"].data.astype("bool")

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -1195,9 +1195,8 @@ class FluxPointsDataset(Dataset):
     def __init__(self, models, data, mask_fit=None, mask_safe=None, name=None):
         self.data = data
         self.mask_fit = mask_fit
-        self.models = models
-
         self._name = make_name(name)
+        self.models = models
 
         if data.sed_type != "dnde":
             raise ValueError("Currently only flux points of type 'dnde' are supported.")
@@ -1222,7 +1221,7 @@ class FluxPointsDataset(Dataset):
         else:
             if isinstance(models, SkyModel):
                 models = [models]
-            elif isinstance(models, Models):
+            elif isinstance(models, (Models,list)):
                 models = list(models)
             else:
                 raise TypeError("Invalid models")

--- a/gammapy/spectrum/flux_point.py
+++ b/gammapy/spectrum/flux_point.py
@@ -5,7 +5,12 @@ from astropy import units as u
 from astropy.io.registry import IORegistryError
 from astropy.table import Table, vstack
 from gammapy.modeling import Dataset, Datasets, Fit, Parameters
-from gammapy.modeling.models import Models, PowerLawSpectralModel, ScaleSpectralModel
+from gammapy.modeling.models import (
+    Models,
+    SkyModel,
+    PowerLawSpectralModel,
+    ScaleSpectralModel,
+)
 from gammapy.utils.interpolation import interpolate_profile
 from gammapy.utils.scripts import make_name, make_path
 from gammapy.utils.table import table_from_row_data, table_standardise_units_copy
@@ -1215,6 +1220,12 @@ class FluxPointsDataset(Dataset):
         if models is None:
             self._models = None
         else:
+            if isinstance(models, SkyModel):
+                models = [models]
+            elif isinstance(models, Models):
+                models = list(models)
+            else:
+                raise TypeError("Invalid models")
             models_list = [
                 model
                 for model in models


### PR DESCRIPTION
Add datasets_names attribute to each 3d model.
Adapt serialization so the models.yaml file contains datasets list for each model and remove the models and backgrounds lists from the datasets.yaml file.
If model.datasets_names is  not set or set as "all" the model is applied to all datasets. 