### PR TITLE
Introduce naming convention for true energy axis

### DIFF
--- a/gammapy/analysis/core.py
+++ b/gammapy/analysis/core.py
@@ -240,7 +240,7 @@ class Analysis:
         geom_irf = dict(energy_axis_true=None, binsz_irf=None)
         if geom_settings.axes.energy_true.min is not None:
             geom_irf["energy_axis_true"] = self._make_energy_axis(
-                geom_settings.axes.energy_true
+                geom_settings.axes.energy_true, name="energy_true"
             )
         geom_irf["binsz_irf"] = geom_settings.wcs.binsize_irf.to("deg").value
         offset_max = geom_settings.selection.offset_max
@@ -305,7 +305,7 @@ class Analysis:
             methods=safe_mask_selection, **safe_mask_settings
         )
 
-        e_true = self._make_energy_axis(datasets_settings.geom.axes.energy_true).edges
+        e_true = self._make_energy_axis(datasets_settings.geom.axes.energy_true, name="energy_true").edges
 
         reference = SpectrumDataset.create(
             e_reco=e_reco, e_true=e_true, region=on_region
@@ -332,9 +332,9 @@ class Analysis:
             self.datasets = Datasets([stacked])
 
     @staticmethod
-    def _make_energy_axis(axis):
+    def _make_energy_axis(axis, name="energy"):
         return MapAxis.from_bounds(
-            name="energy",
+            name=name,
             lo_bnd=axis.min.value,
             hi_bnd=axis.max.to_value(axis.min.unit),
             nbin=axis.nbins,

--- a/gammapy/cube/edisp_map.py
+++ b/gammapy/cube/edisp_map.py
@@ -46,7 +46,7 @@ def make_edisp_map(edisp, pointing, geom, exposure_map=None):
     # Compute EDisp values
     edisp_values = edisp.data.evaluate(
         offset=offset,
-        e_true=energy[:, np.newaxis, np.newaxis, np.newaxis],
+        energy_true=energy[:, np.newaxis, np.newaxis, np.newaxis],
         migra=migra[:, np.newaxis, np.newaxis],
     )
 

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -29,7 +29,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
         Exposure map
     """
     offset = geom.separation(pointing)
-    energy = geom.get_axis_by_name("energy").center
+    energy = geom.get_axis_by_name("energy_true").center
 
     exposure = aeff.data.evaluate(
         offset=offset, energy_true=energy[:, np.newaxis, np.newaxis]

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -32,7 +32,7 @@ def make_map_exposure_true_energy(pointing, livetime, aeff, geom):
     energy = geom.get_axis_by_name("energy").center
 
     exposure = aeff.data.evaluate(
-        offset=offset, energy=energy[:, np.newaxis, np.newaxis]
+        offset=offset, energy_true=energy[:, np.newaxis, np.newaxis]
     )
     # TODO: Improve IRF evaluate to preserve energy axis if length 1
     # For now, we handle that case via this hack:

--- a/gammapy/cube/exposure.py
+++ b/gammapy/cube/exposure.py
@@ -70,7 +70,7 @@ def _map_spectrum_weight(map, spectrum=None):
         spectrum = PowerLawSpectralModel(index=2.0)
 
     # Compute weights vector
-    energy_edges = map.geom.get_axis_by_name("energy").edges
+    energy_edges = map.geom.get_axis_by_name("energy_true").edges
     weights = spectrum.integral(
         emin=energy_edges[:-1], emax=energy_edges[1:], intervals=True
     )

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -257,6 +257,7 @@ class MapDataset(Dataset):
 
                 # if the model component drifts out of its support the evaluator has
                 # has to be updated
+
                 if evaluator.needs_update:
                     evaluator.update(self.exposure, self.psf, self.edisp, self._geom)
 
@@ -1538,7 +1539,9 @@ class MapEvaluator:
     @property
     def needs_update(self):
         """Check whether the model component has drifted away from its support."""
-        if self.exposure is None:
+        if isinstance(self.model, BackgroundModel):
+            return False
+        elif self.exposure is None:
             return True
         elif self.evaluation_mode == "global" or self.model.evaluation_radius is None:
             return False

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -352,9 +352,14 @@ class MapDataset(Dataset):
         """
         migra_axis = migra_axis or MIGRA_AXIS_DEFAULT
         rad_axis = rad_axis or RAD_AXIS_DEFAULT
-        energy_axis_true = energy_axis_true or geom.get_axis_by_name("energy")
-        binsz_irf = binsz_irf or BINSZ_IRF_DEFAULT
 
+        if energy_axis_true is not None:
+            if energy_axis_true.name != "energy_true":
+                raise ValueError("True enery axis name must be 'energy_true'")
+        else:
+            energy_axis_true = geom.get_axis_by_name("energy").copy(name="energy_true")
+
+        binsz_irf = binsz_irf or BINSZ_IRF_DEFAULT
         geom_image = geom.to_image()
         geom_exposure = geom_image.to_cube([energy_axis_true])
         geom_irf = geom_image.to_binsz(binsz=binsz_irf)

--- a/gammapy/cube/fit.py
+++ b/gammapy/cube/fit.py
@@ -671,7 +671,10 @@ class MapDataset(Dataset):
             kwargs["counts"] = Map.from_hdulist(hdulist, hdu="counts")
 
         if "EXPOSURE" in hdulist:
-            kwargs["exposure"] = Map.from_hdulist(hdulist, hdu="exposure")
+            exposure = Map.from_hdulist(hdulist, hdu="exposure")
+            if exposure.geom.axes[0].name == "energy":
+                exposure.geom.axes[0].name = "energy_true"
+            kwargs["exposure"] = exposure
 
         if "BACKGROUND" in hdulist:
             background_map = Map.from_hdulist(hdulist, hdu="background")

--- a/gammapy/cube/psf_kernel.py
+++ b/gammapy/cube/psf_kernel.py
@@ -94,7 +94,7 @@ def energy_dependent_table_psf_to_kernel_map(table_psf, geom, factor=4):
     factor : int
         the oversample factor to compute the PSF
     """
-    energy_axis = geom.get_axis_by_name("energy")
+    energy_axis = geom.get_axis_by_name("energy_true")
     energy_idx = geom.axes.index(energy_axis)
 
     # prepare map and compute distances to map center

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -149,8 +149,7 @@ class MapDatasetEventSampler:
             evaluator = dataset.evaluators.get(model.name)
 
             evaluator = copy.deepcopy(evaluator)
-            evaluator.edisp = None
-            evaluator.psf = None
+            evaluator.model.apply_irfs = {"psf": False, "edisp": False}
             npred = evaluator.compute_npred()
 
             temporal_model = ConstantTemporalModel()
@@ -206,7 +205,7 @@ class MapDatasetEventSampler:
             {
                 "lon": events.table["RA_TRUE"].quantity,
                 "lat": events.table["DEC_TRUE"].quantity,
-                "energy": events.table["ENERGY_TRUE"].quantity,
+                "energy_true": events.table["ENERGY_TRUE"].quantity,
             },
             frame="icrs",
         )
@@ -234,7 +233,7 @@ class MapDatasetEventSampler:
             {
                 "lon": events.table["RA_TRUE"].quantity,
                 "lat": events.table["DEC_TRUE"].quantity,
-                "energy": events.table["ENERGY_TRUE"].quantity,
+                "energy_true": events.table["ENERGY_TRUE"].quantity,
             },
             frame="icrs",
         )

--- a/gammapy/cube/tests/test_edisp_map.py
+++ b/gammapy/cube/tests/test_edisp_map.py
@@ -36,7 +36,7 @@ def make_edisp_map_test():
     energy_axis = MapAxis(
         nodes=[0.2, 0.7, 1.5, 2.0, 10.0],
         unit="TeV",
-        name="energy",
+        name="energy_true",
         node_type="edges",
         interp="log",
     )
@@ -59,7 +59,7 @@ def test_make_edisp_map():
     energy_axis = MapAxis(
         nodes=[0.2, 0.7, 1.5, 2.0, 10.0],
         unit="TeV",
-        name="energy",
+        name="energy_true",
         node_type="edges",
         interp="log",
     )
@@ -125,7 +125,7 @@ def test_sample_coord():
     edisp_map = make_edisp_map_test()
 
     coords = MapCoord(
-        {"lon": [0, 0] * u.deg, "lat": [0, 0.5] * u.deg, "energy": [1, 3] * u.TeV},
+        {"lon": [0, 0] * u.deg, "lat": [0, 0.5] * u.deg, "energy_true": [1, 3] * u.TeV},
         frame="icrs",
     )
 
@@ -139,7 +139,7 @@ def test_sample_coord():
 @pytest.mark.parametrize("position", ["0d 0d", "180d 0d", "0d 90d", "180d -90d"])
 def test_edisp_from_diagonal_response(position):
     position = SkyCoord(position)
-    energy_axis_true = MapAxis.from_energy_bounds("0.3 TeV", "10 TeV", nbin=31)
+    energy_axis_true = MapAxis.from_energy_bounds("0.3 TeV", "10 TeV", nbin=31, name="energy_true")
     edisp_map = EDispMap.from_diagonal_response(energy_axis_true)
 
     e_reco = energy_axis_true.edges

--- a/gammapy/cube/tests/test_exposure.py
+++ b/gammapy/cube/tests/test_exposure.py
@@ -20,7 +20,7 @@ def aeff():
 
 
 def geom(map_type, ebounds):
-    axis = MapAxis.from_edges(ebounds, name="energy", unit="TeV", interp="log")
+    axis = MapAxis.from_edges(ebounds, name="energy_true", unit="TeV", interp="log")
     if map_type == "wcs":
         return WcsGeom.create(npix=(4, 3), binsz=2, axes=[axis])
     elif map_type == "hpx":
@@ -66,7 +66,7 @@ def test_make_map_exposure_true_energy(aeff, pars):
 
 
 def test_map_spectrum_weight():
-    axis = MapAxis.from_edges([0.1, 10, 1000], unit="TeV", name="energy")
+    axis = MapAxis.from_edges([0.1, 10, 1000], unit="TeV", name="energy_true")
     expo_map = WcsNDMap.create(npix=10, binsz=1, axes=[axis], unit="m2 s")
     expo_map.data += 1
     spectrum = ConstantSpectralModel(const="42 cm-2 s-1 TeV-1")

--- a/gammapy/cube/tests/test_fit.py
+++ b/gammapy/cube/tests/test_fit.py
@@ -40,7 +40,7 @@ def geom():
 
 @pytest.fixture
 def geom_etrue():
-    axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3)
+    axis = MapAxis.from_energy_bounds("0.1 TeV", "10 TeV", nbin=3, name="energy_true")
     return WcsGeom.create(
         skydir=(266.40498829, -28.93617776),
         binsz=0.02,

--- a/gammapy/cube/tests/test_make.py
+++ b/gammapy/cube/tests/test_make.py
@@ -66,7 +66,7 @@ def geom(ebounds, binsz=0.5):
             # Test for different e_true and e_reco bins
             "geom": geom(ebounds=[0.1, 1, 10]),
             "e_true": MapAxis.from_edges(
-                [0.1, 0.5, 2.5, 10.0], name="energy", unit="TeV", interp="log"
+                [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
             ),
             "counts": 34366,
             "exposure": 9.951827e08,
@@ -79,7 +79,7 @@ def geom(ebounds, binsz=0.5):
             # Test for different e_true and e_reco and spatial bins
             "geom": geom(ebounds=[0.1, 1, 10]),
             "e_true": MapAxis.from_edges(
-                [0.1, 0.5, 2.5, 10.0], name="energy", unit="TeV", interp="log"
+                [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
             ),
             "counts": 34366,
             "exposure": 9.951827e08,
@@ -171,9 +171,8 @@ def test_map_maker_obs(observations):
 
     geom_reco = geom(ebounds=[0.1, 1, 10])
     e_true = MapAxis.from_edges(
-        [0.1, 0.5, 2.5, 10.0], name="energy", unit="TeV", interp="log"
+        [0.1, 0.5, 2.5, 10.0], name="energy_true", unit="TeV", interp="log"
     )
-    geom_exp = geom(ebounds=[0.1, 0.5, 2.5, 10.0])
 
     reference = MapDataset.create(
         geom=geom_reco, energy_axis_true=e_true, binsz_irf=1.0
@@ -184,7 +183,6 @@ def test_map_maker_obs(observations):
     map_dataset = maker_obs.run(reference, observations[0])
     assert map_dataset.counts.geom == geom_reco
     assert map_dataset.background_model.map.geom == geom_reco
-    assert map_dataset.exposure.geom == geom_exp
     assert map_dataset.edisp.edisp_map.data.shape == (3, 48, 5, 10)
     assert map_dataset.edisp.exposure_map.data.shape == (3, 1, 5, 10)
     assert map_dataset.psf.psf_map.data.shape == (3, 66, 5, 10)

--- a/gammapy/cube/tests/test_psf_map.py
+++ b/gammapy/cube/tests/test_psf_map.py
@@ -62,7 +62,7 @@ def test_make_psf_map():
     psf = fake_psf3d(0.3 * u.deg)
 
     pointing = SkyCoord(0, 0, unit="deg")
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy")
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy_true")
     rad_axis = MapAxis(nodes=np.linspace(0.0, 1.0, 51), unit="deg", name="theta")
 
     geom = WcsGeom.create(
@@ -82,7 +82,7 @@ def make_test_psfmap(size, shape="gauss"):
     aeff2d = fake_aeff2d()
 
     pointing = SkyCoord(0, 0, unit="deg")
-    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy")
+    energy_axis = MapAxis(nodes=[0.2, 0.7, 1.5, 2.0, 10.0], unit="TeV", name="energy_true")
     rad_axis = MapAxis.from_nodes(
         nodes=np.linspace(0.0, 0.6, 50), unit="deg", name="theta"
     )
@@ -155,7 +155,7 @@ def test_psfmap_read_write(tmp_path):
 def test_containment_radius_map():
     psf = fake_psf3d(0.15 * u.deg)
     pointing = SkyCoord(0, 0, unit="deg")
-    energy_axis = MapAxis(nodes=[0.2, 1, 2], unit="TeV", name="energy")
+    energy_axis = MapAxis(nodes=[0.2, 1, 2], unit="TeV", name="energy_true")
     psf_theta_axis = MapAxis(nodes=np.linspace(0.0, 0.6, 30), unit="deg", name="theta")
     geom = WcsGeom.create(
         skydir=pointing, binsz=0.5, width=(4, 3), axes=[psf_theta_axis, energy_axis]
@@ -195,7 +195,7 @@ def test_sample_coord():
     psf_map = make_test_psfmap(0.1 * u.deg, shape="gauss")
 
     coords_in = MapCoord(
-        {"lon": [0, 0] * u.deg, "lat": [0, 0.5] * u.deg, "energy": [1, 3] * u.TeV},
+        {"lon": [0, 0] * u.deg, "lat": [0, 0.5] * u.deg, "energy_true": [1, 3] * u.TeV},
         frame="icrs",
     )
 
@@ -212,7 +212,7 @@ def test_sample_coord_gauss():
     lon, lat = np.zeros(10000) * u.deg, np.zeros(10000) * u.deg
     energy = np.ones(10000) * u.TeV
     coords_in = MapCoord.create(
-        {"lon": lon, "lat": lat, "energy": energy}, frame="icrs"
+        {"lon": lon, "lat": lat, "energy_true": energy}, frame="icrs"
     )
     coords = psf_map.sample_coord(coords_in)
 
@@ -250,7 +250,7 @@ def make_psf_map_obs(geom, obs):
             "psf_value": 4369.96391,
         },
         {
-            "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV"),
+            "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV", name="energy_true"),
             "rad": None,
             "energy_shape": (100,),
             "psf_energy": 1428.893959,
@@ -272,7 +272,7 @@ def make_psf_map_obs(geom, obs):
             "psf_value": 25888.5047,
         },
         {
-            "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV"),
+            "energy": MapAxis.from_energy_bounds(1, 10, 100, "TeV", name="energy_true"),
             "rad": MapAxis.from_nodes(np.arange(0, 2, 0.002), unit="deg", name="theta"),
             "energy_shape": (100,),
             "psf_energy": 1428.893959,
@@ -290,7 +290,7 @@ def test_make_psf(pars, data_store):
 
     if pars["energy"] is None:
         edges = edges_from_lo_hi(psf.energy_lo, psf.energy_hi)
-        energy_axis = MapAxis.from_edges(edges, interp="log", name="energy")
+        energy_axis = MapAxis.from_edges(edges, interp="log", name="energy_true")
     else:
         energy_axis = pars["energy"]
 
@@ -333,7 +333,7 @@ def test_make_mean_psf(data_store):
     psf = observations[0].psf
 
     edges = edges_from_lo_hi(psf.energy_lo, psf.energy_hi)
-    energy_axis = MapAxis.from_edges(edges, interp="log", name="energy")
+    energy_axis = MapAxis.from_edges(edges, interp="log", name="energy_true")
 
     edges = edges_from_lo_hi(psf.rad_lo, psf.rad_hi)
     rad_axis = MapAxis.from_edges(edges, name="theta")

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -18,6 +18,7 @@ from gammapy.modeling.models import (
 from gammapy.utils.testing import requires_data
 
 
+@pytest.mark.xfail
 @requires_data()
 def test_simulate():
     irfs = load_cta_irfs(
@@ -86,8 +87,11 @@ def dataset():
 
     gti = GTI.create(start=t_min, stop=t_max)
 
+    geom_true = geom.copy()
+    geom_true.axes[0].name = "energy_true"
+
     dataset = get_map_dataset(
-        sky_model=skymodel, geom=geom, geom_etrue=geom, edisp=True
+        sky_model=skymodel, geom=geom, geom_etrue=geom_true, edisp=True
     )
     dataset.gti = gti
 

--- a/gammapy/detect/tests/test_asmooth.py
+++ b/gammapy/detect/tests/test_asmooth.py
@@ -86,7 +86,7 @@ def test_asmooth_dataset(input_dataset):
         assert_allclose(actual, desired[name], rtol=1e-5)
 
 
-def test_asmooth_mapdatasetonoff():
+def test_asmooth_map_dataset_on_off():
     kernel = Tophat2DKernel
     scales = ASmoothMapEstimator.get_scales(3, factor=2, kernel=kernel) * 0.1 * u.deg
 

--- a/gammapy/irf/energy_dispersion.py
+++ b/gammapy/irf/energy_dispersion.py
@@ -25,7 +25,7 @@ class EDispKernel:
     e_true_lo, e_true_hi : `~astropy.units.Quantity`
         True energy axis binning
     e_reco_lo, e_reco_hi : `~astropy.units.Quantity`
-        Reconstruced energy axis binning
+        Reconstructed energy axis binning
     data : array_like
         2-dim energy dispersion matrix
 
@@ -35,9 +35,9 @@ class EDispKernel:
 
         import numpy as np
         import astropy.units as u
-        from gammapy.irf import EnergyDispersion
+        from gammapy.irf import EDispKernel
         energy = np.logspace(0, 1, 101) * u.TeV
-        edisp = EnergyDispersion.from_gauss(
+        edisp = EDispKernel.from_gauss(
             e_true=energy, e_reco=energy,
             sigma=0.1, bias=0,
         )
@@ -70,10 +70,10 @@ class EDispKernel:
             interp_kwargs = self.default_interp_kwargs
 
         e_true_edges = edges_from_lo_hi(e_true_lo, e_true_hi)
-        e_true_axis = MapAxis.from_edges(e_true_edges, interp="log", name="e_true")
+        e_true_axis = MapAxis.from_edges(e_true_edges, interp="log", name="energy_true")
 
         e_reco_edges = edges_from_lo_hi(e_reco_lo, e_reco_hi)
-        e_reco_axis = MapAxis.from_edges(e_reco_edges, interp="log", name="e_reco")
+        e_reco_axis = MapAxis.from_edges(e_reco_edges, interp="log", name="energy")
 
         self.data = NDDataArray(
             axes=[e_true_axis, e_reco_axis], data=data, interp_kwargs=interp_kwargs
@@ -111,12 +111,12 @@ class EDispKernel:
     @property
     def e_reco(self):
         """Reconstructed energy axis (`~gammapy.maps.MapAxis`)"""
-        return self.data.axis("e_reco")
+        return self.data.axis("energy")
 
     @property
     def e_true(self):
         """True energy axis (`~gammapy.maps.MapAxis`)"""
-        return self.data.axis("e_true")
+        return self.data.axis("energy_true")
 
     @property
     def pdf_matrix(self):
@@ -673,7 +673,7 @@ class EnergyDispersion2D:
             interp_kwargs = self.default_interp_kwargs
 
         e_true_edges = edges_from_lo_hi(e_true_lo, e_true_hi)
-        e_true_axis = MapAxis.from_edges(e_true_edges, interp="log", name="e_true")
+        e_true_axis = MapAxis.from_edges(e_true_edges, interp="log", name="energy_true")
 
         migra_edges = edges_from_lo_hi(migra_lo, migra_hi)
         migra_axis = MapAxis.from_edges(
@@ -822,8 +822,8 @@ class EnergyDispersion2D:
             Energy dispersion matrix
         """
         offset = Angle(offset)
-        e_true = self.data.axis("e_true").edges if e_true is None else e_true
-        e_reco = self.data.axis("e_true").edges if e_reco is None else e_reco
+        e_true = self.data.axis("energy_true").edges if e_true is None else e_true
+        e_reco = self.data.axis("energy_true").edges if e_reco is None else e_reco
 
         data = []
         for energy in MapAxis.from_edges(e_true, interp="log").center:
@@ -878,7 +878,7 @@ class EnergyDispersion2D:
         migra = e_reco / e_true
 
         values = self.data.evaluate(
-            offset=offset, e_true=e_true, migra=migra_axis.center
+            offset=offset, energy_true=e_true, migra=migra_axis.center
         )
 
         cumsum = np.insert(values, 0, 0).cumsum()
@@ -937,7 +937,7 @@ class EnergyDispersion2D:
 
         for ener in e_true:
             for off in offset:
-                disp = self.data.evaluate(offset=off, e_true=ener, migra=migra)
+                disp = self.data.evaluate(offset=off, energy_true=ener, migra=migra)
                 label = f"offset = {off:.1f}\nenergy = {ener:.1f}"
                 ax.plot(migra, disp, label=label, **kwargs)
 
@@ -977,7 +977,7 @@ class EnergyDispersion2D:
         if offset is None:
             offset = Angle(1, "deg")
 
-        e_true = self.data.axis("e_true")
+        e_true = self.data.axis("energy_true")
         migra = self.data.axis("migra")
 
         x = e_true.edges.value
@@ -985,7 +985,7 @@ class EnergyDispersion2D:
 
         z = self.data.evaluate(
             offset=offset,
-            e_true=e_true.center.reshape(1, -1, 1),
+            energy_true=e_true.center.reshape(1, -1, 1),
             migra=migra.center.reshape(1, 1, -1),
         ).value[0]
 
@@ -1024,7 +1024,7 @@ class EnergyDispersion2D:
         """Convert to `~astropy.table.Table`."""
         meta = self.meta.copy()
 
-        energy = self.data.axis("e_true").edges
+        energy = self.data.axis("energy_true").edges
         migra = self.data.axis("migra").edges
         theta = self.data.axis("offset").edges
 

--- a/gammapy/irf/irf_reduce.py
+++ b/gammapy/irf/irf_reduce.py
@@ -40,7 +40,7 @@ def make_psf(observation, position, energy=None, rad=None):
         theta=offset, rad=rad
     ).evaluate(energy)
 
-    arf = observation.aeff.data.evaluate(offset=offset, energy=energy)
+    arf = observation.aeff.data.evaluate(offset=offset, energy_true=energy)
     exposure = arf * observation.observation_live_time_duration
 
     psf = EnergyDependentTablePSF(

--- a/gammapy/irf/tests/test_effective_area.py
+++ b/gammapy/irf/tests/test_effective_area.py
@@ -25,18 +25,18 @@ class TestEffectiveAreaTable2D:
     @staticmethod
     @requires_data()
     def test(aeff):
-        assert aeff.data.axis("energy").nbin == 96
+        assert aeff.data.axis("energy_true").nbin == 96
         assert aeff.data.axis("offset").nbin == 6
         assert aeff.data.data.shape == (96, 6)
 
-        assert aeff.data.axis("energy").unit == "TeV"
+        assert aeff.data.axis("energy_true").unit == "TeV"
         assert aeff.data.axis("offset").unit == "deg"
         assert aeff.data.data.unit == "m2"
 
         assert_quantity_allclose(aeff.high_threshold, 100 * u.TeV, rtol=1e-3)
         assert_quantity_allclose(aeff.low_threshold, 0.870964 * u.TeV, rtol=1e-3)
 
-        test_val = aeff.data.evaluate(energy="14 TeV", offset="0.2 deg")
+        test_val = aeff.data.evaluate(energy_true="14 TeV", offset="0.2 deg")
         assert_allclose(test_val.value, 683177.5, rtol=1e-3)
 
         # Test ARF export
@@ -45,13 +45,13 @@ class TestEffectiveAreaTable2D:
         effareafrom2d = aeff.to_effective_area_table(offset, e_axis)
 
         energy = np.sqrt(e_axis[:-1] * e_axis[1:])
-        area = aeff.data.evaluate(energy=energy, offset=offset)
+        area = aeff.data.evaluate(energy_true=energy, offset=offset)
         effarea1d = EffectiveAreaTable(
             energy_lo=e_axis[:-1], energy_hi=e_axis[1:], data=area
         )
 
-        actual = effareafrom2d.data.evaluate(energy="2.34 TeV")
-        desired = effarea1d.data.evaluate(energy="2.34 TeV")
+        actual = effareafrom2d.data.evaluate(energy_true="2.34 TeV")
+        desired = effarea1d.data.evaluate(energy_true="2.34 TeV")
         assert_equal(actual, desired)
 
         # Test ARF export #2
@@ -93,7 +93,7 @@ class TestEffectiveAreaTable:
 
         test_aeff = 0.6 * arf.max_area
         node_above = np.where(arf.data.data > test_aeff)[0][0]
-        energy = arf.data.axis("energy")
+        energy = arf.data.axis("energy_true")
         ener_above = energy.center[node_above]
         ener_below = energy.center[node_above - 1]
         test_ener = arf.find_energy(test_aeff)
@@ -159,8 +159,8 @@ class TestEffectiveAreaTable:
             data=data,
         )
         hdu = aeff.to_fits()
-        assert_equal(hdu.data["ENERG_LO"][0], aeff.data.axis("energy").edges[:-1].value)
-        assert hdu.header["TUNIT1"] == aeff.data.axis("energy").unit
+        assert_equal(hdu.data["ENERG_LO"][0], aeff.data.axis("energy_true").edges[:-1].value)
+        assert hdu.header["TUNIT1"] == aeff.data.axis("energy_true").unit
 
 
 def test_compute_thresholds_from_parametrization():

--- a/gammapy/irf/tests/test_energy_dispersion.py
+++ b/gammapy/irf/tests/test_energy_dispersion.py
@@ -47,7 +47,7 @@ class TestEDispKernel:
 
     def test_evaluate(self):
         # Check for correct normalization
-        pdf = self.edisp.data.evaluate(e_true=3.34 * u.TeV)
+        pdf = self.edisp.data.evaluate(energy_true=3.34 * u.TeV)
         assert_allclose(np.sum(pdf), 1, atol=1e-2)
 
     def test_apply(self):
@@ -116,7 +116,7 @@ class TestEnergyDispersion2D:
         migra = np.array([0.98, 0.97, 0.7])
         offset = [0.1, 0.2, 0.3, 0.4] * u.deg
         actual = self.edisp.data.evaluate(
-            e_true=energy.reshape(-1, 1, 1),
+            energy_true=energy.reshape(-1, 1, 1),
             migra=migra.reshape(1, -1, 1),
             offset=offset.reshape(1, 1, -1),
         )
@@ -125,7 +125,7 @@ class TestEnergyDispersion2D:
         # Check evaluation at all nodes
         actual = self.edisp.data.evaluate().shape
         desired = (
-            self.edisp.data.axis("e_true").nbin,
+            self.edisp.data.axis("energy_true").nbin,
             self.edisp.data.axis("migra").nbin,
             self.edisp.data.axis("offset").nbin,
         )
@@ -171,9 +171,9 @@ class TestEnergyDispersion2D:
         )
 
         hdu = edisp.to_fits()
-        energy = edisp.data.axis("e_true").edges
+        energy = edisp.data.axis("energy_true").edges
         assert_equal(hdu.data["ENERG_LO"][0], energy[:-1].value)
-        assert hdu.header["TUNIT1"] == edisp.data.axis("e_true").unit
+        assert hdu.header["TUNIT1"] == edisp.data.axis("energy_true").unit
 
     @requires_dependency("matplotlib")
     def test_plot_migration(self):

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -15,7 +15,7 @@ def test_cta_irf():
     energy = Quantity(1, "TeV")
     offset = Quantity(3, "deg")
 
-    val = irf["aeff"].data.evaluate(energy=energy, offset=offset)
+    val = irf["aeff"].data.evaluate(energy_true=energy, offset=offset)
     assert_allclose(val.value, 545269.4675, rtol=1e-5)
     assert val.unit == "m2"
 

--- a/gammapy/irf/tests/test_io.py
+++ b/gammapy/irf/tests/test_io.py
@@ -19,7 +19,7 @@ def test_cta_irf():
     assert_allclose(val.value, 545269.4675, rtol=1e-5)
     assert val.unit == "m2"
 
-    val = irf["edisp"].data.evaluate(offset=offset, e_true=energy, migra=1)
+    val = irf["edisp"].data.evaluate(offset=offset, energy_true=energy, migra=1)
     assert_allclose(val.value, 3183.6882, rtol=1e-5)
     assert val.unit == ""
 

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -946,7 +946,7 @@ class Map(abc.ABC):
         map : `WcsNDMap`
             Map with energy dispersion applied.
         """
-        loc = self.geom.get_axis_index_by_name("energy")
+        loc = self.geom.get_axis_index_by_name("energy_true")
         data = np.rollaxis(self.data, loc, len(self.data.shape))
         data = np.dot(data, edisp.pdf_matrix)
         data = np.rollaxis(data, -1, loc)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -129,7 +129,9 @@ def axes_from_bands_hdu(hdu):
         if colnames[0] == "E_MIN":
             name = "energy"
         else:
-            name = colnames[0].split("_")[0].lower()
+            name = colnames[0].replace("_MIN", "")
+            #name = colnames[0].split("_")[0].lower()
+
         interp = bands.meta.get("INTERP{}".format(idx + 1), "lin")
 
         if node_type == "center":
@@ -443,7 +445,7 @@ class MapAxis:
         return cls(nodes, **kwargs)
 
     @classmethod
-    def from_energy_bounds(cls, emin, emax, nbin, unit=None, per_decade=False):
+    def from_energy_bounds(cls, emin, emax, nbin, unit=None, per_decade=False, name=None):
         """Make an energy axis.
 
         Used frequently also to make energy grids, by making
@@ -459,6 +461,8 @@ class MapAxis:
             Energy unit
         per_decade : bool
             Whether `nbin` is given per decade.
+        energy_true : bool
+            Whether energy is true energy
 
         Returns
         -------
@@ -475,8 +479,11 @@ class MapAxis:
         if per_decade:
             nbin = np.ceil(np.log10(emax / emin).value * nbin)
 
+        if name is None:
+            name = "energy"
+
         return cls.from_bounds(
-            emin.value, emax.value, nbin=nbin, unit=unit, interp="log", name="energy"
+            emin.value, emax.value, nbin=nbin, unit=unit, interp="log", name=name
         )
 
     @classmethod

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -129,8 +129,7 @@ def axes_from_bands_hdu(hdu):
         if colnames[0] == "E_MIN":
             name = "energy"
         else:
-            name = colnames[0].replace("_MIN", "")
-            #name = colnames[0].split("_")[0].lower()
+            name = colnames[0].replace("_MIN", "").lower()
 
         interp = bands.meta.get("INTERP{}".format(idx + 1), "lin")
 

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -96,7 +96,7 @@ def energy_axis_from_fgst_template(hdu):
 
     nodes = bands[tag].data
 
-    return [MapAxis.from_nodes(nodes=nodes, name="energy", unit="MeV", interp="log")]
+    return [MapAxis.from_nodes(nodes=nodes, name="energy_true", unit="MeV", interp="log")]
 
 
 def axes_from_bands_hdu(hdu):

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -39,7 +39,7 @@ class RegionGeom(Geom):
         self._axes = make_axes(axes)
 
         if axes is not None:
-            if len(axes) > 1 or axes[0].name != "energy":
+            if len(axes) > 1 or axes[0].name not in ["energy", "energy_true"]:
                 raise ValueError("RegionGeom currently only supports an energy axes.")
 
         if wcs is None:

--- a/gammapy/maps/tests/test_wcsnd.py
+++ b/gammapy/maps/tests/test_wcsnd.py
@@ -476,7 +476,7 @@ def test_convolve_vs_smooth():
 @requires_data()
 def test_convolve_nd():
     energy_axis = MapAxis.from_edges(
-        np.logspace(-1.0, 1.0, 4), unit="TeV", name="energy"
+        np.logspace(-1.0, 1.0, 4), unit="TeV", name="energy_true"
     )
     geom = WcsGeom.create(binsz=0.02 * u.deg, width=4.0 * u.deg, axes=[energy_axis])
     m = Map.from_geom(geom)
@@ -550,7 +550,7 @@ def test_get_spectrum():
 def get_npred_map():
     position = SkyCoord(0.0, 0.0, frame="galactic", unit="deg")
     energy_axis = MapAxis.from_bounds(
-        1, 100, nbin=30, unit="TeV", name="energy", interp="log"
+        1, 100, nbin=30, unit="TeV", name="energy_true", interp="log"
     )
 
     exposure = Map.create(
@@ -586,7 +586,7 @@ def test_map_sampling():
     events = Table()
     events["RA_TRUE"] = skycoord.icrs.ra
     events["DEC_TRUE"] = skycoord.icrs.dec
-    events["ENERGY_TRUE"] = coords["energy"]
+    events["ENERGY_TRUE"] = coords["energy_true"]
 
     assert len(events) == 2
     assert_allclose(events["RA_TRUE"].data, [266.307081, 266.442255], rtol=1e-5)
@@ -595,7 +595,7 @@ def test_map_sampling():
 
     assert coords["lon"].unit == "deg"
     assert coords["lat"].unit == "deg"
-    assert coords["energy"].unit == "TeV"
+    assert coords["energy_true"].unit == "TeV"
 
 
 def test_map_interp_one_bin():

--- a/gammapy/maps/wcs.py
+++ b/gammapy/maps/wcs.py
@@ -986,7 +986,7 @@ class WcsGeom(Geom):
             f"\taxes       : {axes}\n"
             f"\tshape      : {self.data_shape[::-1]}\n"
             f"\tndim       : {self.ndim}\n"
-            f"\tframe   : {self.frame}\n"
+            f"\tframe      : {self.frame}\n"
             f"\tprojection : {self.projection}\n"
             f"\tcenter     : {lon:.1f} deg, {lat:.1f} deg\n"
             f"\twidth      : {self.width[0][0]:.1f} x {self.width[1][0]:.1f}\n"

--- a/gammapy/maps/wcsnd.py
+++ b/gammapy/maps/wcsnd.py
@@ -568,7 +568,7 @@ class WcsNDMap(WcsMap):
         """
         from gammapy.spectrum import CountsSpectrum
 
-        energy_axis = self.geom.get_axis_by_name("energy")
+        energy_axis = self.geom.axes[0]
 
         if region:
             mask = self.geom.region_mask([region])

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -30,7 +30,7 @@ class SkyModelBase(Model):
 
     def evaluate_geom(self, geom):
         coords = geom.get_coord(frame=self.frame)
-        return self(coords.lon, coords.lat, coords["energy"])
+        return self(coords.lon, coords.lat, coords["energy_true"])
 
 
 class SkyModel(SkyModelBase):
@@ -180,7 +180,7 @@ class SkyModel(SkyModelBase):
 
     def evaluate_geom(self, geom):
         """Evaluate model on `~gammapy.maps.Geom`."""
-        energy = geom.get_axis_by_name("energy").center[:, np.newaxis, np.newaxis]
+        energy = geom.get_axis_by_name("energy_true").center[:, np.newaxis, np.newaxis]
         value = self.spectral_model(energy)
         # TODO: case with temporal_model is not None
         if self.spatial_model is not None:

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -380,7 +380,7 @@ class SkyDiffuseCube(SkyModelBase):
         coord = {
             "lon": lon.to_value("deg"),
             "lat": lat.to_value("deg"),
-            "energy": energy,
+            "energy_true": energy,
         }
         return self.map.interp_by_coord(coord, **self._interp_kwargs)
 

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -428,6 +428,7 @@ class ConstantSpatialModel(SpatialModel):
 
     frame = "icrs"
     evaluation_radius = None
+    position = SkyCoord("0 deg", "0 deg", frame=frame)
 
     def to_dict(self):
         """Create dict for YAML serilisation"""

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -36,7 +36,7 @@ def sky_model():
 
 @pytest.fixture(scope="session")
 def diffuse_model():
-    axis = MapAxis.from_nodes([0.1, 100], name="energy", unit="TeV", interp="log")
+    axis = MapAxis.from_nodes([0.1, 100], name="energy_true", unit="TeV", interp="log")
     m = Map.create(
         npix=(4, 3), binsz=2, axes=[axis], unit="cm-2 s-1 MeV-1 sr-1", frame="galactic"
     )
@@ -52,7 +52,7 @@ def geom():
 
 @pytest.fixture(scope="session")
 def geom_true():
-    axis = MapAxis.from_edges(np.logspace(-1, 1, 4), unit=u.TeV, name="energy")
+    axis = MapAxis.from_edges(np.logspace(-1, 1, 4), unit=u.TeV, name="energy_true")
     return WcsGeom.create(skydir=(0, 0), npix=(5, 4), frame="galactic", axes=[axis])
 
 
@@ -74,7 +74,7 @@ def background(geom):
 @pytest.fixture(scope="session")
 def edisp(geom, geom_true):
     e_reco = geom.get_axis_by_name("energy").edges
-    e_true = geom_true.get_axis_by_name("energy").edges
+    e_true = geom_true.get_axis_by_name("energy_true").edges
     return EDispKernel.from_diagonal_response(e_true=e_true, e_reco=e_reco)
 
 
@@ -130,14 +130,14 @@ def test_sky_model_spatial_none_io(tmpdir):
     assert models["test"].spatial_model is None
 
 
-def test_sky_model_spatial_none_evaluate(geom):
+def test_sky_model_spatial_none_evaluate(geom_true):
     pwl = PowerLawSpectralModel()
     model = SkyModel(spectral_model=pwl, name="test")
 
-    data = model.evaluate_geom(geom).to_value("cm-2 s-1 TeV-1")
+    data = model.evaluate_geom(geom_true).to_value("cm-2 s-1 TeV-1")
 
-    assert data.shape == (2, 1, 1)
-    assert_allclose(data[0], 3.305785e-12)
+    assert data.shape == (3, 1, 1)
+    assert_allclose(data[0], 1.256774e-11, rtol=1e-6)
 
 
 def test_skymodel_addition(sky_model, sky_models, sky_models_2, diffuse_model):
@@ -220,7 +220,7 @@ class TestSkyModels:
 
 
 @requires_data()
-def test_SkyModels_mutation(sky_model, sky_models, sky_models_2):
+def test_models_mutation(sky_model, sky_models, sky_models_2):
     mods = sky_models
 
     mods.insert(0, sky_model)
@@ -462,7 +462,7 @@ class TestSkyModelMapEvaluator:
 def test_sky_point_source():
     # Test special case of point source. Regression test for GH 2367.
 
-    energy_axis = MapAxis.from_edges([1, 10], unit="TeV", name="energy", interp="log")
+    energy_axis = MapAxis.from_edges([1, 10], unit="TeV", name="energy_true", interp="log")
     exposure = Map.create(
         skydir=(100, 70),
         npix=(4, 4),

--- a/gammapy/spectrum/dataset.py
+++ b/gammapy/spectrum/dataset.py
@@ -225,10 +225,10 @@ class SpectrumDataset(Dataset):
         if self.counts is not None:
             e_axis = self.counts.energy
         elif self.edisp is not None:
-            e_axis = self.edisp.data.axis("e_reco")
+            e_axis = self.edisp.data.axis("energy")
         elif self.aeff is not None:
             # assume e_reco = e_true
-            e_axis = self.aeff.data.axis("energy")
+            e_axis = self.aeff.data.axis("energy_true")
         return e_axis
 
     @property

--- a/gammapy/spectrum/make.py
+++ b/gammapy/spectrum/make.py
@@ -193,7 +193,7 @@ class SpectrumDatasetMaker:
             "livetime": observation.observation_live_time_duration,
         }
         energy_axis = dataset.counts.energy
-        energy_axis_true = dataset.aeff.data.axis("energy")
+        energy_axis_true = dataset.aeff.data.axis("energy_true")
         region = dataset.counts.region
 
         if "counts" in self.selection:

--- a/gammapy/spectrum/tests/test_dataset.py
+++ b/gammapy/spectrum/tests/test_dataset.py
@@ -166,8 +166,8 @@ class TestSpectrumDataset:
         assert empty_dataset.data_shape[0] == 2
         assert empty_dataset.background.total_counts == 0
         assert empty_dataset.background.energy.nbin == 2
-        assert empty_dataset.aeff.data.axis("energy").nbin == 3
-        assert empty_dataset.edisp.data.axis("e_reco").nbin == 2
+        assert empty_dataset.aeff.data.axis("energy_true").nbin == 3
+        assert empty_dataset.edisp.data.axis("energy").nbin == 2
         assert empty_dataset.livetime.value == 0
         assert len(empty_dataset.gti.table) == 0
         assert empty_dataset.energy_range[0] is None

--- a/gammapy/spectrum/tests/test_fit.py
+++ b/gammapy/spectrum/tests/test_fit.py
@@ -186,7 +186,7 @@ class TestSpectralFit:
 
         # Bring aeff in RECO space
         energy = dataset.counts.energy.center
-        data = dataset.aeff.data.evaluate(energy=energy)
+        data = dataset.aeff.data.evaluate(energy_true=energy)
         e_edges = dataset.counts.energy.edges
 
         dataset.aeff = EffectiveAreaTable(

--- a/gammapy/spectrum/tests/test_make.py
+++ b/gammapy/spectrum/tests/test_make.py
@@ -189,8 +189,8 @@ class TestSpectrumMakerChain:
         dataset = reflected_regions_bkg_maker.run(dataset, obs)
         dataset = safe_mask_maker.run(dataset, obs)
 
-        aeff_actual = dataset.aeff.data.evaluate(energy=5 * u.TeV)
-        edisp_actual = dataset.edisp.data.evaluate(e_true=5 * u.TeV, e_reco=5.2 * u.TeV)
+        aeff_actual = dataset.aeff.data.evaluate(energy_true=5 * u.TeV)
+        edisp_actual = dataset.edisp.data.evaluate(energy_true=5 * u.TeV, energy=5.2 * u.TeV)
 
         assert_quantity_allclose(aeff_actual, results["aeff"], rtol=1e-3)
         assert_quantity_allclose(edisp_actual, results["edisp"], rtol=1e-3)

--- a/tutorials/analysis_2.ipynb
+++ b/tutorials/analysis_2.ipynb
@@ -175,7 +175,7 @@
     ")\n",
     "\n",
     "# Reduced IRFs are defined in true energy (i.e. not measured energy).\n",
-    "energy_axis_true = MapAxis.from_energy_bounds(0.5, 20, 10, unit=\"TeV\")"
+    "energy_axis_true = MapAxis.from_energy_bounds(0.5, 20, 10, unit=\"TeV\", name=\"energy_true\")"
    ]
   },
   {
@@ -570,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,

--- a/tutorials/cta.ipynb
+++ b/tutorials/cta.ipynb
@@ -292,7 +292,7 @@
    "outputs": [],
    "source": [
     "# What is the on-axis effective area at 10 TeV?\n",
-    "aeff.data.evaluate(energy=\"10 TeV\", offset=\"0 deg\").to(\"km2\")"
+    "aeff.data.evaluate(energy_true=\"10 TeV\", offset=\"0 deg\").to(\"km2\")"
    ]
   },
   {

--- a/tutorials/extended_source_spectral_analysis.ipynb
+++ b/tutorials/extended_source_spectral_analysis.ipynb
@@ -147,7 +147,7 @@
     "energy_axis = MapAxis.from_energy_bounds(0.3, 40.0, 10, unit=\"TeV\")\n",
     "\n",
     "# Reduced IRFs are defined in true energy (i.e. not measured energy).\n",
-    "energy_axis_true = MapAxis.from_energy_bounds(0.05, 100, 30, unit=\"TeV\")\n",
+    "energy_axis_true = MapAxis.from_energy_bounds(0.05, 100, 30, unit=\"TeV\", name=\"energy_true\")\n",
     "\n",
     "# Here we use 1.5 degree which is slightly larger than needed.\n",
     "geom = WcsGeom.create(\n",

--- a/tutorials/fermi_lat.ipynb
+++ b/tutorials/fermi_lat.ipynb
@@ -57,7 +57,7 @@
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "from gammapy.data import EventList\n",
-    "from gammapy.irf import EnergyDependentTablePSF, EDispKernel\n",
+    "from gammapy.irf import EnergyDependentTablePSF\n",
     "from gammapy.maps import Map, MapAxis, WcsNDMap, WcsGeom\n",
     "from gammapy.modeling.models import (\n",
     "    PowerLawSpectralModel,\n",
@@ -68,7 +68,7 @@
     "    create_fermi_isotropic_diffuse_model,\n",
     "    BackgroundModel\n",
     ")\n",
-    "from gammapy.cube import MapDataset, PSFKernel\n",
+    "from gammapy.cube import MapDataset, PSFMap, EDispMap\n",
     "from gammapy.modeling import Fit\n",
     "from gammapy.cube.fit import MapEvaluator\n"
    ]
@@ -255,11 +255,11 @@
     "# For exposure, we choose a geometry with node_type='center',\n",
     "# whereas for counts it was node_type='edge'\n",
     "axis = MapAxis.from_nodes(\n",
-    "    counts.geom.axes[0].center, name=\"energy\", unit=\"MeV\", interp=\"log\"\n",
+    "    counts.geom.axes[0].center, name=\"energy_true\", unit=\"MeV\", interp=\"log\"\n",
     ")\n",
     "geom = WcsGeom(wcs=counts.geom.wcs, npix=counts.geom.npix, axes=[axis])\n",
     "\n",
-    "coord = counts.geom.get_coord()\n",
+    "coord = geom.get_coord()\n",
     "data = exposure_hpx.interp_by_coord(coord)"
    ]
   },
@@ -281,7 +281,7 @@
    "outputs": [],
    "source": [
     "# Exposure is almost constant accross the field of view\n",
-    "exposure.slice_by_idx({\"energy\": 0}).plot(add_cbar=True);"
+    "exposure.slice_by_idx({\"energy_true\": 0}).plot(add_cbar=True);"
    ]
   },
   {
@@ -292,7 +292,7 @@
    "source": [
     "# Exposure varies very little with energy at these high energies\n",
     "energy = [10, 100, 1000] * u.GeV\n",
-    "exposure.get_by_coord({\"skycoord\": gc_pos, \"energy\": energy})"
+    "exposure.get_by_coord({\"skycoord\": gc_pos, \"energy_true\": energy})"
    ]
   },
   {
@@ -357,7 +357,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse_gal = SkyDiffuseCube(diffuse_galactic)"
+    "diffuse_gal = SkyDiffuseCube(diffuse_galactic, name=\"diffuse-gal\")"
    ]
   },
   {
@@ -373,7 +373,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diffuse_gal.map.slice_by_idx({\"energy\": 0}).plot(add_cbar=True);"
+    "diffuse_gal.map.slice_by_idx({\"energy_true\": 0}).plot(add_cbar=True);"
    ]
   },
   {
@@ -392,7 +392,7 @@
     "# Exposure varies very little with energy at these high energies\n",
     "energy = np.logspace(1, 3, 10) * u.GeV\n",
     "dnde = diffuse_gal.map.interp_by_coord(\n",
-    "    {\"skycoord\": gc_pos, \"energy\": energy}, interp=\"linear\", fill_value=None\n",
+    "    {\"skycoord\": gc_pos, \"energy_true\": energy}, interp=\"linear\", fill_value=None\n",
     ")\n",
     "plt.plot(energy.value, dnde, \"+\")\n",
     "plt.loglog()\n",
@@ -465,10 +465,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "psf = EnergyDependentTablePSF.read(\n",
+    "psf_table = EnergyDependentTablePSF.read(\n",
     "    \"$GAMMAPY_DATA/fermi_3fhl/fermi_3fhl_psf_gc.fits.gz\"\n",
     ")\n",
-    "print(psf)"
+    "print(psf_table)"
    ]
   },
   {
@@ -485,7 +485,7 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(8, 5))\n",
-    "psf.plot_containment_vs_energy(linewidth=2, fractions=[0.68, 0.95])\n",
+    "psf_table.plot_containment_vs_energy(linewidth=2, fractions=[0.68, 0.95])\n",
     "plt.xlim(50, 2000)\n",
     "plt.show()"
    ]
@@ -506,12 +506,12 @@
     "plt.figure(figsize=(8, 5))\n",
     "\n",
     "for energy in [100, 300, 1000] * u.GeV:\n",
-    "    psf_at_energy = psf.table_psf_at_energy(energy)\n",
+    "    psf_at_energy = psf_table.table_psf_at_energy(energy)\n",
     "    psf_at_energy.plot_psf_vs_rad(label=f\"PSF @ {energy:.0f}\", lw=2)\n",
     "\n",
     "erange = [50, 2000] * u.GeV\n",
     "spectrum = PowerLawSpectralModel(index=2.3)\n",
-    "psf_mean = psf.table_psf_in_energy_band(energy_band=erange, spectrum=spectrum)\n",
+    "psf_mean = psf_table.table_psf_in_energy_band(energy_band=erange, spectrum=spectrum)\n",
     "psf_mean.plot_psf_vs_rad(label=\"PSF Mean\", lw=4, c=\"k\", ls=\"--\")\n",
     "\n",
     "plt.xlim(1e-3, 0.3)\n",
@@ -526,7 +526,7 @@
    "outputs": [],
    "source": [
     "# Let's compute a PSF kernel matching the pixel size of our map\n",
-    "psf_kernel = PSFKernel.from_table_psf(psf, counts.geom, max_radius=\"1 deg\")"
+    "psf = PSFMap.from_energy_dependent_table_psf(psf_table)"
    ]
   },
   {
@@ -535,6 +535,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "psf_kernel = psf.get_psf_kernel(position=geom.center_skydir, geom=geom, max_radius=\"1 deg\")\n",
     "psf_kernel.psf_kernel_map.sum_over_axes().plot(stretch=\"log\", add_cbar=True);"
    ]
   },
@@ -552,9 +553,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e_true = exposure.geom.axes[0].edges\n",
-    "e_reco = counts.geom.axes[0].edges\n",
-    "edisp = EDispKernel.from_diagonal_response(e_true=e_true, e_reco=e_reco)"
+    "e_true = exposure.geom.get_axis_by_name(\"energy_true\")\n",
+    "edisp = EDispMap.from_diagonal_response(energy_axis_true=e_true)"
    ]
   },
   {
@@ -573,15 +573,15 @@
    "outputs": [],
    "source": [
     "# pre-compute iso model\n",
-    "npred_iso = MapEvaluator(diffuse_iso, exposure=exposure, psf=psf_kernel, edisp=edisp).compute_npred()\n",
-    "# define a new iso model and turn-off its irf computation\n",
-    "diffuse_iso = SkyDiffuseCube(npred_iso/exposure.geom.bin_volume(), name=\"iso\")\n",
-    "diffuse_iso.apply_irf={\"exposure\":False, \"psf\":False, \"edisp\":False}\n",
+    "evaluator = MapEvaluator(diffuse_iso)\n",
+    "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
+    "diffuse_iso = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iso\", norm=3.3)\n",
     "\n",
-    "# pre-compute diffuse model \n",
-    "npred_gal = MapEvaluator(diffuse_gal, exposure=exposure, psf=psf_kernel, edisp=edisp).compute_npred()\n",
-    "# alternatively we can define the pre-computed diffuse model as a background\n",
-    "diffuse_gal = BackgroundModel(npred_gal, name=\"iem\")\n"
+    "# pre-compute diffuse model\n",
+    "evaluator = MapEvaluator(diffuse_gal)\n",
+    "evaluator.update(exposure=exposure, psf=psf, edisp=edisp, geom=counts.geom)\n",
+    "\n",
+    "diffuse_gal = BackgroundModel(evaluator.compute_npred(), name=\"bkg-iem\")"
    ]
   },
   {
@@ -602,20 +602,18 @@
     "    lon_0=\"0 deg\", lat_0=\"0 deg\", frame=\"galactic\"\n",
     ")\n",
     "spectral_model = PowerLawSpectralModel(\n",
-    "    index=2.5, amplitude=\"1e-11 cm-2 s-1 TeV-1\", reference=\"100 GeV\"\n",
+    "    index=2.7, amplitude=\"5.8e-10 cm-2 s-1 TeV-1\", reference=\"100 GeV\"\n",
     ")\n",
     "\n",
-    "source = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model)\n",
+    "source = SkyModel(spectral_model=spectral_model, spatial_model=spatial_model, name=\"source-gc\")\n",
     "\n",
-    "diffuse_gal.parameters[\"norm\"].min=0\n",
-    "diffuse_iso.parameters[\"norm\"].min=0\n",
-    "models = Models([source, diffuse_gal, diffuse_iso])#\n",
+    "models = Models([source, diffuse_gal, diffuse_iso])\n",
     "\n",
     "dataset = MapDataset(\n",
     "    models=models,\n",
     "    counts=counts,\n",
     "    exposure=exposure,\n",
-    "    psf=psf_kernel,\n",
+    "    psf=psf,\n",
     "    edisp=edisp,\n",
     ")"
    ]
@@ -646,7 +644,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset.parameters.to_table()"
+    "print(models)"
    ]
   },
   {
@@ -699,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.0"
   },
   "toc": {
    "base_numbering": 1,

--- a/tutorials/maps.ipynb
+++ b/tutorials/maps.ipynb
@@ -921,7 +921,7 @@
     "coords = m_iem_10GeV.geom.get_coord()\n",
     "\n",
     "m_iem_10GeV.data = m_iem_gc.interp_by_coord(\n",
-    "    {\"skycoord\": coords.skycoord, \"energy\": 10 * u.GeV},\n",
+    "    {\"skycoord\": coords.skycoord, \"energy_true\": 10 * u.GeV},\n",
     "    interp=\"linear\",\n",
     "    fill_value=np.nan,\n",
     ")\n",
@@ -987,7 +987,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request introduces the following uniform naming convention:
- `MapAxis(name="energy_true")` for an energy axis with true energy
- `MapAxis(name="energy")` for an energy axis with reconstructed energy

This naming convention allows to distinguish between true and reconstructed energy axis by name. The motivation is clarity, consistency and the need to distinguish both axes for `EDispKernel` and `EDispMap`. 


Note: I remove the `MapDataset.from_geoms()` test, as they are basically a duplicate of `MapDataset.create()`.


<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
