### PR TITLE
Add TemporalModel integral method

### DIFF
--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -62,18 +62,20 @@ class ConstantTemporalModel(TemporalModel):
         """
         return np.ones_like(time)
 
-    def integral(self, gti):
-        """Evaluate the integrated flux within the given GTIs
+    def integral(self, t_min, t_max):
+        """Evaluate the integrated flux within the given time intervals
 
         Parameters
-        -----------
-        gti: `~gammapy.data.GTI`
-            GTIs of the observation
-
-        Returns:
+        ----------
+        t_min: `~astropy.time.Time`
+            Start times of observation
+        t_max: `~astropy.time.Time`
+            Stop times of observation
+        Returns
+        -------
         norm: The model integrated flux
         """
-        return gti.time_sum.value
+        return u.Quantity(t_max.mjd - t_min.mjd, "day").to_value("s")
 
     def sample_time(self, n_events, t_min, t_max, random_state=0):
         """Sample arrival times of events.
@@ -391,21 +393,23 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         """
         return self._interpolator(time, ext=ext)
 
-    def integral(self, gti, **kwargs):
-        """Evaluate the integrated flux within the given GTIs
+    def integral(self, t_min, t_max):
+        """Evaluate the integrated flux within the given time intervals
 
         Parameters
-        -----------
-        gti: `~gammapy.data.GTI`
-            GTIs of the observation
-
-        Returns:
+        ----------
+        t_min: `~astropy.time.Time`
+            Start times of observation
+        t_max: `~astropy.time.Time`
+            Stop times of observation
+        Returns
+        -------
         norm: The model integrated flux
         """
 
-        n1 = self._interpolator.antiderivative()(gti.time_stop.value)
-        n2 = self._interpolator.antiderivative()(gti.time_start.value)
-        return np.sum(n1 - n2) * 86400.0  # to return in units of sec
+        n1 = self._interpolator.antiderivative()(t_max.mjd)
+        n2 = self._interpolator.antiderivative()(t_min.mjd)
+        return u.Quantity(n1 - n2, "day").to_value("s")
 
     def mean_norm_in_time_interval(self, time_min, time_max):
         """Compute mean ``norm`` in a given time interval.

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -73,7 +73,7 @@ class ConstantTemporalModel(TemporalModel):
         Returns:
         norm: The model integrated flux
         """
-        return gti.time_sum
+        return gti.time_sum.value
 
     def sample_time(self, n_events, t_min, t_max, random_state=0):
         """Sample arrival times of events.
@@ -365,7 +365,9 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
 
     @lazyproperty
     def _time(self):
-        return self._time_ref + self.table["TIME"].data * getattr(u, self.table.meta['TIMEUNIT'])
+        return self._time_ref + self.table["TIME"].data * getattr(
+            u, self.table.meta["TIMEUNIT"]
+        )
 
     def evaluate(self, time, ext=0):
         """Evaluate for a given time.
@@ -389,7 +391,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         """
         return self._interpolator(time, ext=ext)
 
-    def integral(self, gti):
+    def integral(self, gti, **kwargs):
         """Evaluate the integrated flux within the given GTIs
 
         Parameters
@@ -401,8 +403,9 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         norm: The model integrated flux
         """
 
-        return 1
-
+        n1 = self._interpolator.antiderivative()(gti.time_stop.value)
+        n2 = self._interpolator.antiderivative()(gti.time_start.value)
+        return np.sum(n1 - n2) * 86400.0  # to return in units of sec
 
     def mean_norm_in_time_interval(self, time_min, time_max):
         """Compute mean ``norm`` in a given time interval.
@@ -445,7 +448,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         time : `~astropy.units.Quantity`
             Array with times of the sampled events.
         """
-        time_unit = getattr(u, self.table.meta['TIMEUNIT'])
+        time_unit = getattr(u, self.table.meta["TIMEUNIT"])
 
         t_min = Time(t_min)
         t_max = Time(t_max)

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -17,9 +17,8 @@ from .core import Model
 class TemporalModel(Model):
     """Temporal model base class."""
 
-    def __call__(self, time):
+    def __call__(self, time, **kwargs):
         """Call evaluate method"""
-        kwargs = {par.name: par.quantity for par in self.parameters}
         return self.evaluate(time.mjd, **kwargs)
 
 
@@ -62,6 +61,19 @@ class ConstantTemporalModel(TemporalModel):
 
         """
         return np.ones_like(time)
+
+    def integral(self, gti):
+        """Evaluate the integrated flux within the given GTIs
+
+        Parameters
+        -----------
+        gti: `~gammapy.data.GTI`
+            GTIs of the observation
+
+        Returns:
+        norm: The model integrated flux
+        """
+        return gti.time_sum
 
     def sample_time(self, n_events, t_min, t_max, random_state=0):
         """Sample arrival times of events.
@@ -280,7 +292,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
 
     The lightcurve is given as a table with columns ``time`` and ``norm``.
 
-    The ``norm`` is supposed to be a unite-less multiplicative factor in the model,
+    The ``norm`` is supposed to be a unit-less multiplicative factor in the model,
     to be multiplied with a spectral model.
 
     The model does linear interpolation for times between the given ``(time, norm)`` values.
@@ -314,7 +326,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
 
     Compute ``norm`` at a given time:
 
-    >>> light_curve.evaluate_norm_at_time(46300)
+    >>> light_curve.evaluate(46300)
     0.49059393580053845
 
     Compute mean ``norm`` in a given time interval:
@@ -342,10 +354,10 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         )
 
     @lazyproperty
-    def _interpolator(self):
-        x = self.table["TIME"].data
+    def _interpolator(self, ext=0):
+        x = self._time.value
         y = self.table["NORM"].data
-        return scipy.interpolate.InterpolatedUnivariateSpline(x, y, k=1)
+        return scipy.interpolate.InterpolatedUnivariateSpline(x, y, k=1, ext=ext)
 
     @lazyproperty
     def _time_ref(self):
@@ -353,17 +365,18 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
 
     @lazyproperty
     def _time(self):
-        return self._time_ref + self.table["TIME"].data * u.s
+        return self._time_ref + self.table["TIME"].data * getattr(u, self.table.meta['TIMEUNIT'])
 
-    def evaluate(self, time, ext_mode=3):
+    def evaluate(self, time, ext=0):
         """Evaluate for a given time.
 
         Parameters
         ----------
         time : array_like
             Time since the ``reference`` time.
-        ext_mode : int or str, optional
-            Controls the extrapolation mode for elements not in the interval defined by the knot sequence.
+        ext : int or str, optional
+            Parameter passed to ~scipy.interpolate.InterpolatedUnivariateSpline
+            Controls the extrapolation mode for GTIs outside the range
             if ext=0 or ‘extrapolate’, return the extrapolated value.
             if ext=1 or ‘zeros’, return 0
             if ext=2 or ‘raise’, raise a ValueError
@@ -374,7 +387,22 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         -------
         norm : array_like
         """
-        return self._interpolator(time, ext=ext_mode)
+        return self._interpolator(time, ext=ext)
+
+    def integral(self, gti):
+        """Evaluate the integrated flux within the given GTIs
+
+        Parameters
+        -----------
+        gti: `~gammapy.data.GTI`
+            GTIs of the observation
+
+        Returns:
+        norm: The model integrated flux
+        """
+
+        return 1
+
 
     def mean_norm_in_time_interval(self, time_min, time_max):
         """Compute mean ``norm`` in a given time interval.
@@ -417,7 +445,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         time : `~astropy.units.Quantity`
             Array with times of the sampled events.
         """
-        time_unit = u.second
+        time_unit = getattr(u, self.table.meta['TIMEUNIT'])
 
         t_min = Time(t_min)
         t_max = Time(t_max)
@@ -432,7 +460,7 @@ class LightCurveTemplateTemporalModel(TemplateTemporalModel):
         t_step = t_delta.to_value(time_unit)
         t = np.arange(0, t_stop, t_step)
 
-        pdf = self.evaluate(t * time_unit)
+        pdf = self.evaluate(t)
 
         sampler = InverseCDFSampler(pdf=pdf, random_state=random_state)
         time_pix = sampler.sample(n_events)[0]

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -139,8 +139,9 @@ def test_lightcurve_temporal_model_integral():
     stop = [2, 3.5, 6] * u.day
     gti = GTI.create(start, stop, reference_time=Time("2010-01-01T00:00:00"))
 
-    val = temporal_model.integral(gti)
-    assert_allclose(val, 2.5 * 86400, rtol=1e-5)
+    val = temporal_model.integral(gti.time_start, gti.time_stop)
+    assert len(val) == 3
+    assert_allclose(np.sum(val), 2.5 * 86400, rtol=1e-5)
 
 
 def test_constant_temporal_model_sample():
@@ -172,8 +173,9 @@ def test_constant_temporal_model_integral():
     start = [1, 3, 5] * u.day
     stop = [2, 3.5, 6] * u.day
     gti = GTI.create(start, stop)
-    val = temporal_model.integral(gti)
-    assert_allclose(val, 2.5 * 86400, rtol=1e-5)
+    val = temporal_model.integral(gti.time_start, gti.time_stop)
+    assert len(val) == 3
+    assert_allclose(np.sum(val), 2.5 * 86400, rtol=1e-5)
 
 
 def test_phase_time_sampling():


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a `.integral()` on the temporal models.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

There are a few issues I am not sure about.

1. The integral returned should physically have units of time. Should this method then return a `Quantity`?  At present, I am implicitly assuming that it returns in units of seconds, but am returning a float.
2. I have made some changes to the existing code and tests to ensure that the time handling is done properly between the times on the template model and the gtis passed - please do take a look!
