### PR TITLE
Add aeff-max safe energy threshold for MapDataset

### DIFF
--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -132,11 +132,8 @@ class SafeMaskMaker:
             if position is None:
                 position = dataset.counts.geom.center_skydir
             exposure = dataset.exposure
-            position = position.transform_to("icrs")
             energy = exposure.geom.get_axis_by_name("energy_true")
-            coord = MapCoord.create(
-                (position.ra, position.dec, energy.center), frame="icrs"
-            )
+            coord = MapCoord.create({"skycoord": position, "energy_true": energy.center})
             exposure_1d = exposure.interp_by_coord(coord)
             aeff = EffectiveAreaTable(
                 energy_lo=energy.edges[:-1],

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -22,9 +22,12 @@ def test_safe_mask_maker(observations):
     axis = MapAxis.from_bounds(
         0.1, 10, nbin=16, unit="TeV", name="energy", interp="log"
     )
+    axis_true = MapAxis.from_bounds(
+        0.1, 50, nbin=30, unit="TeV", name="energy_true", interp="log"
+    )
     geom = WcsGeom.create(npix=(11, 11), axes=[axis], skydir=obs.pointing_radec)
 
-    empty_dataset = MapDataset.create(geom=geom)
+    empty_dataset = MapDataset.create(geom=geom, energy_axis_true=axis_true)
     dataset_maker = MapDatasetMaker()
     safe_mask_maker = SafeMaskMaker(
         offset_max="3 deg", bias_percent=0.02, position=obs.pointing_radec
@@ -40,13 +43,11 @@ def test_safe_mask_maker(observations):
     )
     assert_allclose(mask_energy_aeff_default.sum(), 1936)
 
+    mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
+    assert_allclose(mask_aeff_max.sum(), 1331)
+
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_edisp_bias.sum(), 121)
 
     mask_bkg_peak = safe_mask_maker.make_mask_energy_bkg_peak(dataset)
     assert_allclose(mask_bkg_peak.sum(), 1815)
-
-    with pytest.raises(NotImplementedError) as excinfo:
-        safe_mask_maker.make_mask_energy_aeff_max(dataset)
-
-    assert "only supported" in str(excinfo.value)


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
I implemented the missing method `SafeMaskMaker.make_mask_energy_aeff_max(...)` for the the case of `MapDataset`.

In the code , I work with the exposure instead of the effective area itself, which is equivalent in this case. I extract the exposure values at the given position, and fill up an `EffectiveAreaTable` on which I can call the `.find_energy()` method.

**Dear reviewer**
Should we pass two additional arguments `emin` and `emax` (as in `make_mask_energy_aeff_max(self, dataset, emin=None, emax=None)`) to narrow down the energy range range in case of non-unique solutions? These would be naturally forwarded to `aeff.find_energy(aeff_thres, emin, emax)`. This question is also valid for the `make_mask_energy_edisp_bias(...)` method.
