### PR TITLE
Adding the functionality to sample the background only in MapDatasetEventSampler

### DIFF
--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -264,8 +264,7 @@ class MapDatasetEventSampler:
         events : `~gammapy.data.EventList`
             Event list.
         """
-        try:
-          if dataset.models[1]:
+        if len(dataset.models) > 1:
             events_src = self.sample_sources(dataset)
 
             if dataset.psf:
@@ -285,10 +284,9 @@ class MapDatasetEventSampler:
             else:
                 events = events_src
 
-        except:
-            if dataset.background_model:
-                events_bkg = self.sample_background(dataset)
-                events = EventList.stack([events_bkg])
+        if len(dataset.models) == 1 and dataset.background_model is not None:
+            events_bkg = self.sample_background(dataset)
+            events = EventList.stack([events_bkg])
 
         events.table["EVENT_ID"] = np.arange(len(events.table))
         events.table.meta = self.event_list_meta(dataset, observation)

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -185,6 +185,7 @@ class MapDatasetEventSampler:
         meta = {}
 
         meta["HDUCLAS1"] = "EVENTS"
+        meta["EXTNAME"] = "EVENTS"
         meta[
             "HDUDOC"
         ] = "https://github.com/open-gamma-ray-astro/gamma-astro-data-formats"
@@ -263,24 +264,31 @@ class MapDatasetEventSampler:
         events : `~gammapy.data.EventList`
             Event list.
         """
-        events_src = self.sample_sources(dataset)
+        try:
+            dataset.models[1]
+            events_src = self.sample_sources(dataset)
 
-        if dataset.psf:
-            events_src = self.sample_psf(dataset.psf, events_src)
-        else:
-            events_src.table["RA"] = events_src.table["RA_TRUE"]
-            events_src.table["DEC"] = events_src.table["DEC_TRUE"]
+            if dataset.psf:
+                events_src = self.sample_psf(dataset.psf, events_src)
+            else:
+                events_src.table["RA"] = events_src.table["RA_TRUE"]
+                events_src.table["DEC"] = events_src.table["DEC_TRUE"]
 
-        if dataset.edisp:
-            events_src = self.sample_edisp(dataset.edisp, events_src)
-        else:
-            events_src.table["ENERGY"] = events_src.table["ENERGY_TRUE"]
+            if dataset.edisp:
+                events_src = self.sample_edisp(dataset.edisp, events_src)
+            else:
+                events_src.table["ENERGY"] = events_src.table["ENERGY_TRUE"]
 
-        if dataset.background_model:
-            events_bkg = self.sample_background(dataset)
-            events = EventList.stack([events_bkg, events_src])
-        else:
-            events = events_src
+            if dataset.background_model:
+                events_bkg = self.sample_background(dataset)
+                events = EventList.stack([events_bkg, events_src])
+            else:
+                events = events_src
+
+        except:
+            if dataset.background_model:
+                events_bkg = self.sample_background(dataset)
+                events = EventList.stack([events_bkg])
 
         events.table["EVENT_ID"] = np.arange(len(events.table))
         events.table.meta = self.event_list_meta(dataset, observation)

--- a/gammapy/cube/simulate.py
+++ b/gammapy/cube/simulate.py
@@ -265,7 +265,7 @@ class MapDatasetEventSampler:
             Event list.
         """
         try:
-            dataset.models[1]
+          if dataset.models[1]:
             events_src = self.sample_sources(dataset)
 
             if dataset.psf:

--- a/gammapy/cube/tests/test_simulate.py
+++ b/gammapy/cube/tests/test_simulate.py
@@ -5,10 +5,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from gammapy.cube import MapDatasetEventSampler
 from gammapy.data import GTI, Observation
-from gammapy.datasets import MapDataset
 from gammapy.datasets.tests.test_map import get_map_dataset
 from gammapy.irf import load_cta_irfs
-from gammapy.makers import MapDatasetMaker
 from gammapy.maps import MapAxis, WcsGeom
 from gammapy.modeling.models import (
     GaussianSpatialModel,


### PR DESCRIPTION
Currently the `MapDatasetEventSampler` class allows the users to sample sources and background events or, alternatively, source events only. However, the possibility to sample background events only is not taken into account yet.
This PR aims at offering this functionality to the users.