### PR TITLE
Add filename argument in BackgroundModel().from_dict()

### DIFF
--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -586,7 +586,10 @@ class BackgroundModel(Model):
         else:
             raise ValueError("Requires either filename or `Map` object")
         model = cls(
-            map=map, name=data["name"], datasets_names=data.get("datasets_names")
+            map=map,
+            name=data["name"],
+            datasets_names=data.get("datasets_names"),
+            filename=data.get("filename"),
         )
         model._update_from_dict(data)
         return model

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -178,13 +178,15 @@ def test_background_model(background):
 
 
 def test_background_model_io(tmpdir, background):
-    filename = tmpdir / "test-bkg-file.fits"
+    filename = str(tmpdir / "test-bkg-file.fits")
     bkg = BackgroundModel(background, norm=2.0, filename=filename)
     bkg.map.write(filename, overwrite=True)
     bkg_dict = bkg.to_dict()
     bkg_read = bkg.from_dict(bkg_dict)
 
-    assert_allclose(bkg_read.evaluate().data.sum(), background.data.sum() * 2.0, rtol=1e-3)
+    assert_allclose(
+        bkg_read.evaluate().data.sum(), background.data.sum() * 2.0, rtol=1e-3
+    )
     assert bkg_read.filename == filename
 
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -184,7 +184,7 @@ def test_background_model_io(tmpdir, background):
     bkg_dict = bkg.to_dict()
     bkg_read = bkg.from_dict(bkg_dict)
 
-    assert_allclose(bkg.evaluate().data.sum(), background.data.sum() * 2.0, rtol=1e-3)
+    assert_allclose(bkg_read.evaluate().data.sum(), background.data.sum() * 2.0, rtol=1e-3)
     assert bkg_read.filename == filename
 
 

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -177,6 +177,17 @@ def test_background_model(background):
     assert_allclose(bkg2.data.sum(), 7.352e-06, rtol=1e-3)
 
 
+def test_background_model_io(tmpdir, background):
+    filename = tmpdir / "test-bkg-file.fits"
+    bkg = BackgroundModel(background, norm=2.0, filename=filename)
+    bkg.map.write(filename, overwrite=True)
+    bkg_dict = bkg.to_dict()
+    bkg_read = bkg.from_dict(bkg_dict)
+
+    assert_allclose(bkg.evaluate().data.sum(), background.data.sum() * 2.0, rtol=1e-3)
+    assert bkg_read.filename == filename
+
+
 class TestSkyModels:
     @staticmethod
     def test_parameters(sky_models):


### PR DESCRIPTION
Fix minor bug in BackgroundModel serialization: filename argument was not set when reading background using .from_dict()