### PR TITLE
Add sampling of temporal models to event sampler

### DIFF
--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -77,11 +77,10 @@ class MapDatasetEventSampler:
             evaluator.model.apply_irf["edisp"] = False
             npred = evaluator.compute_npred()
 
-            # temporal_model = ConstantTemporalModel()
-            if model.temporal_model is None:
-                temporal_model = ConstantTemporalModel()
-            else:
+            if hasattr(model, "temporal_model"):
                 temporal_model = model.temporal_model
+            else:
+                temporal_model = ConstantTemporalModel()
 
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
             table["MC_ID"] = idx + 1

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -78,7 +78,10 @@ class MapDatasetEventSampler:
             npred = evaluator.compute_npred()
 
             # temporal_model = ConstantTemporalModel()
-            temporal_model = model.temporal_model
+            if model.temporal_model is None:
+                temporal_model = ConstantTemporalModel()
+            else:
+                temporal_model = model.temporal_model
 
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
             table["MC_ID"] = idx + 1

--- a/gammapy/datasets/simulate.py
+++ b/gammapy/datasets/simulate.py
@@ -43,7 +43,10 @@ class MapDatasetEventSampler:
 
         time_start, time_stop, time_ref = (gti.time_start, gti.time_stop, gti.time_ref)
         time = temporal_model.sample_time(
-            n_events, time_start, time_stop, self.random_state
+            n_events=n_events,
+            t_min=time_start,
+            t_max=time_stop,
+            random_state=self.random_state,
         )
         table["TIME"] = u.Quantity(((time.mjd - time_ref.mjd) * u.day).to(u.s)).to("s")
         return table
@@ -74,7 +77,8 @@ class MapDatasetEventSampler:
             evaluator.model.apply_irf["edisp"] = False
             npred = evaluator.compute_npred()
 
-            temporal_model = ConstantTemporalModel()
+            # temporal_model = ConstantTemporalModel()
+            temporal_model = model.temporal_model
 
             table = self._sample_coord_time(npred, temporal_model, dataset.gti)
             table["MC_ID"] = idx + 1

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
+from astropy.time import Time
 from gammapy.datasets import MapDatasetEventSampler
 from gammapy.data import GTI, Observation
 from gammapy.datasets.tests.test_map import get_map_dataset
@@ -41,8 +42,9 @@ def dataset():
 
     table = Table()
     table["TIME"] = time
-    table["NORM"] = norm
-    table.meta = dict(MJDREFI=55197.0, MJDREFF=0, TIMEUNIT="s")
+    table["NORM"] = norm / norm.max()
+    t_ref = Time("2000-01-01")
+    table.meta = dict(MJDREFI=t_ref.mjd, MJDREFF=0, TIMEUNIT="s")
     temporal_model = LightCurveTemplateTemporalModel(table)
 
     skymodel = SkyModel(
@@ -55,7 +57,7 @@ def dataset():
         skydir=position, binsz=1, width="5 deg", frame="galactic", axes=[energy_axis]
     )
 
-    gti = GTI.create(start=t_min, stop=t_max)
+    gti = GTI.create(start=t_min, stop=t_max, reference_time=t_ref)
 
     geom_true = geom.copy()
     geom_true.axes[0].name = "energy_true"

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -185,7 +185,7 @@ def test_mde_run_switchoff(dataset):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
-    livetime = 10.0 * u.hr
+    livetime = 1.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
         obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
@@ -206,6 +206,6 @@ def test_mde_run_switchoff(dataset):
     meta = events.table.meta
 
     assert meta["RA_PNT"] == 266.4049882865447
-    assert meta["ONTIME"] == 36000.0
+    assert meta["ONTIME"] == 3600.0
     assert meta["OBS_ID"] == 1001
     assert meta["RADECSYS"] == "icrs"

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -33,10 +33,10 @@ def dataset():
     spectral_model = PowerLawSpectralModel(amplitude="1e-11 cm-2 s-1 TeV-1")
 
     t_min = 0 * u.s
-    t_max = 30000 * u.s
+    t_max = 1000 * u.s
 
     time = np.arange(t_max.value) * u.s
-    tau = u.Quantity("2e3 s")
+    tau = u.Quantity("2e2 s")
     norm = np.exp(-time / tau)
 
     table = Table()
@@ -83,7 +83,7 @@ def test_mde_sample_sources(dataset):
     assert_allclose(events.table["DEC_TRUE"][0], -29.034641, rtol=1e-5)
     assert events.table["DEC_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["TIME"][0], 2150.712124, rtol=1e-5)
+    assert_allclose(events.table["TIME"][0], 94.7121239, rtol=1e-5)
     assert events.table["TIME"].unit == "s"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -148,7 +148,7 @@ def test_mde_run(dataset):
     irfs = load_cta_irfs(
         "$GAMMAPY_DATA/cta-1dc/caldb/data/cta/1dc/bcf/South_z20_50h/irf_file.fits"
     )
-    livetime = 10.0 * u.hr
+    livetime = 1.0 * u.hr
     pointing = SkyCoord(0, 0, unit="deg", frame="galactic")
     obs = Observation.create(
         obs_id=1001, pointing=pointing, livetime=livetime, irfs=irfs
@@ -175,7 +175,7 @@ def test_mde_run(dataset):
     meta = events.table.meta
 
     assert meta["RA_PNT"] == 266.4049882865447
-    assert meta["ONTIME"] == 36000.0
+    assert meta["ONTIME"] == 3600.0
     assert meta["OBS_ID"] == 1001
     assert meta["RADECSYS"] == "icrs"
 

--- a/gammapy/datasets/tests/test_simulate.py
+++ b/gammapy/datasets/tests/test_simulate.py
@@ -75,17 +75,17 @@ def test_mde_sample_sources(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.sample_sources(dataset=dataset)
 
-    assert len(events.table["ENERGY_TRUE"]) == 2407
-    assert_allclose(events.table["ENERGY_TRUE"][0], 2.245024, rtol=1e-5)
+    assert len(events.table["ENERGY_TRUE"]) == 348
+    assert_allclose(events.table["ENERGY_TRUE"][0], 3.536090852832, rtol=1e-5)
     assert events.table["ENERGY_TRUE"].unit == "TeV"
 
-    assert_allclose(events.table["RA_TRUE"][0], 266.912888, rtol=1e-5)
+    assert_allclose(events.table["RA_TRUE"][0], 266.296592804, rtol=1e-5)
     assert events.table["RA_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["DEC_TRUE"][0], -29.034641, rtol=1e-5)
+    assert_allclose(events.table["DEC_TRUE"][0], -29.056521954, rtol=1e-5)
     assert events.table["DEC_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["TIME"][0], 94.7121239, rtol=1e-5)
+    assert_allclose(events.table["TIME"][0], 32.73797244764, rtol=1e-5)
     assert events.table["TIME"].unit == "s"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)
@@ -115,14 +115,14 @@ def test_mde_sample_psf(dataset):
     events = sampler.sample_sources(dataset=dataset)
     events = sampler.sample_psf(dataset.psf, events)
 
-    assert len(events.table) == 2407
-    assert_allclose(events.table["ENERGY_TRUE"][0], 2.2450239, rtol=1e-5)
+    assert len(events.table) == 348
+    assert_allclose(events.table["ENERGY_TRUE"][0], 3.536090852832, rtol=1e-5)
     assert events.table["ENERGY_TRUE"].unit == "TeV"
 
-    assert_allclose(events.table["RA"][0], 266.88654311, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.2757792220, rtol=1e-5)
     assert events.table["RA"].unit == "deg"
 
-    assert_allclose(events.table["DEC"][0], -29.01084895, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -29.030257126, rtol=1e-5)
     assert events.table["DEC"].unit == "deg"
 
 
@@ -132,14 +132,14 @@ def test_mde_sample_edisp(dataset):
     events = sampler.sample_sources(dataset=dataset)
     events = sampler.sample_edisp(dataset.edisp, events)
 
-    assert len(events.table) == 2407
-    assert_allclose(events.table["ENERGY"][0], 2.24502, rtol=1e-5)
+    assert len(events.table) == 348
+    assert_allclose(events.table["ENERGY"][0], 3.53609085283, rtol=1e-5)
     assert events.table["ENERGY"].unit == "TeV"
 
-    assert_allclose(events.table["RA_TRUE"][0], 266.912888, rtol=1e-5)
+    assert_allclose(events.table["RA_TRUE"][0], 266.296592804, rtol=1e-5)
     assert events.table["RA_TRUE"].unit == "deg"
 
-    assert_allclose(events.table["DEC_TRUE"][0], -29.034641, rtol=1e-5)
+    assert_allclose(events.table["DEC_TRUE"][0], -29.05652195, rtol=1e-5)
     assert events.table["DEC_TRUE"].unit == "deg"
 
     assert_allclose(events.table["MC_ID"][0], 1, rtol=1e-5)
@@ -163,15 +163,15 @@ def test_mde_run(dataset):
     dataset_bkg.models = dataset_bkg.models[1]
     events_bkg = sampler.run(dataset=dataset_bkg, observation=obs)
 
-    assert len(events.table) == 2423
-    assert_allclose(events.table["ENERGY"][0], 3.582666040117894, rtol=1e-5)
-    assert_allclose(events.table["RA"][0], 263.876666324552, rtol=1e-5)
-    assert_allclose(events.table["DEC"][0], -28.72531131917506, rtol=1e-5)
+    assert len(events.table) == 374
+    assert_allclose(events.table["ENERGY"][0], 4.09979515940, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 263.611383742, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -28.89318805, rtol=1e-5)
 
-    assert len(events_bkg.table) == 16
-    assert_allclose(events_bkg.table["ENERGY"][0], 2.874495158620, rtol=1e-5)
-    assert_allclose(events_bkg.table["RA"][0], 264.56394364251, rtol=1e-5)
-    assert_allclose(events_bkg.table["DEC"][0], -28.676648107, rtol=1e-5)
+    assert len(events_bkg.table) == 10
+    assert_allclose(events_bkg.table["ENERGY"][0], 2.84808850102, rtol=1e-5)
+    assert_allclose(events_bkg.table["RA"][0], 266.6138405848, rtol=1e-5)
+    assert_allclose(events_bkg.table["DEC"][0], -29.0489180785, rtol=1e-5)
     assert_allclose(events_bkg.table["MC_ID"][0], 0, rtol=1e-5)
 
     meta = events.table.meta
@@ -200,10 +200,10 @@ def test_mde_run_switchoff(dataset):
     sampler = MapDatasetEventSampler(random_state=0)
     events = sampler.run(dataset=dataset, observation=obs)
 
-    assert len(events.table) == 2407
-    assert_allclose(events.table["ENERGY"][0], 2.2450239000119323, rtol=1e-5)
-    assert_allclose(events.table["RA"][0], 266.9128884464542, rtol=1e-5)
-    assert_allclose(events.table["DEC"][0], -29.034641131874313, rtol=1e-5)
+    assert len(events.table) == 348
+    assert_allclose(events.table["ENERGY"][0], 3.5360908528324453, rtol=1e-5)
+    assert_allclose(events.table["RA"][0], 266.2965928042457, rtol=1e-5)
+    assert_allclose(events.table["DEC"][0], -29.056521954411902, rtol=1e-5)
 
     meta = events.table.meta
 

--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -141,7 +141,9 @@ class ExpDecayTemporalModel(TemporalModel):
     tag = "ExponentialDecayTemporalModel"
 
     t0 = Parameter("t0", "1 d", frozen=False)
-    t_ref = Parameter("t_ref", 55555, frozen=True)
+
+    _t_ref_default = Time("2000-01-01")
+    t_ref = Parameter("t_ref", _t_ref_default.mjd, frozen=True)
 
     def evaluate(self, time, t0, t_ref):
         return np.exp(-(time.mjd - t_ref) / t0.to_value("d"))
@@ -165,10 +167,13 @@ class GaussianTemporalModel(TemporalModel):
     """
 
     tag = "GaussianTemporalModel"
-    t_ref = Parameter("t_ref", 55555, frozen=False)
+
+    _t_ref_default = Time("2000-01-01")
+    t_ref = Parameter("t_ref", _t_ref_default.mjd, frozen=False)
     sigma = Parameter("sigma", "1 d", frozen=False)
 
-    def evaluate(self, time, t_ref, sigma):
+    @staticmethod
+    def evaluate(time, t_ref, sigma):
         return np.exp(-((time.mjd - t_ref) ** 2) / (2 * sigma.to_value("d") ** 2))
 
     def integral(self, t_min, t_max, **kwargs):

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -155,10 +155,11 @@ def test_exponential_temporal_model_evaluate():
 
 
 def test_exponential_temporal_model_integral():
-    temporal_model = ExpDecayTemporalModel()
+    t_ref = Time(55555, format="mjd")
+
+    temporal_model = ExpDecayTemporalModel(t_ref=t_ref.mjd)
     start = [1, 3, 5] * u.day
     stop = [2, 3.5, 6] * u.day
-    t_ref = Time(55555, format="mjd")
     gti = GTI.create(start, stop, reference_time=t_ref)
     val = temporal_model.integral(gti.time_start, gti.time_stop)
     assert len(val) == 3


### PR DESCRIPTION
This PR aims at modifying the `MapDatasetEventSamplers.sample_sources()` function, in order to allow the users to sample the time of the source events from a given `dataset.temporal_model`. Currently, the class just adopt a `ConstantTemporalModel`.


