### PR TITLE
Remove RegionGeom.energy_mask()

### DIFF
--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -296,10 +296,10 @@ def test_analysis_3d():
     assert len(analysis.flux_points.data.table) == 2
     dnde = analysis.flux_points.data.table["dnde"].quantity
 
-    assert_allclose(dnde[0].value, 1.408433e-11, rtol=1e-2)
-    assert_allclose(dnde[-1].value, 3.948827e-13, rtol=1e-2)
-    assert_allclose(res["index"].value, 2.921873, rtol=1e-2)
-    assert_allclose(res["tilt"].value, -0.133544, rtol=1e-2)
+    assert_allclose(dnde[0].value, 1.380525e-11, rtol=1e-2)
+    assert_allclose(dnde[-1].value, 3.58863e-13, rtol=1e-2)
+    assert_allclose(res["index"].value, 3.097649, rtol=1e-2)
+    assert_allclose(res["tilt"].value, -0.207786, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/makers/tests/test_safe.py
+++ b/gammapy/makers/tests/test_safe.py
@@ -44,7 +44,7 @@ def test_safe_mask_maker(observations):
     assert_allclose(mask_energy_aeff_default.sum(), 1936)
 
     mask_aeff_max = safe_mask_maker.make_mask_energy_aeff_max(dataset)
-    assert_allclose(mask_aeff_max.sum(), 1331)
+    assert_allclose(mask_aeff_max.sum(), 1210)
 
     mask_edisp_bias = safe_mask_maker.make_mask_energy_edisp_bias(dataset)
     assert_allclose(mask_edisp_bias.sum(), 121)

--- a/gammapy/maps/geom.py
+++ b/gammapy/maps/geom.py
@@ -1547,21 +1547,25 @@ class Geom(abc.ABC):
     def energy_mask(self, emin=None, emax=None):
         """Create a mask for a given energy range.
 
+        The energy bin must be fully contained to be included in the mask.
+
         Parameters
         ----------
         emin, emax : `~astropy.units.Quantity`
             Energy range
+
+        Returns
+        -------
+        mask : `~numpy.ndarray`
+            Energy mask
         """
         # get energy axes and values
         energy_axis = self.get_axis_by_name("energy")
-        edges = energy_axis.edges
+        edges = energy_axis.edges.reshape((-1, 1, 1))
 
         # set default values
         emin = emin if emin is not None else edges[0]
         emax = emax if emax is not None else edges[-1]
 
-        # create mask
-        coords = self.get_coord()
-        mask = coords["energy"] > emin
-        mask &= coords["energy"] < emax
-        return mask
+        mask = (edges[:-1] >= emin) & (edges[1:] <= emax)
+        return np.broadcast_to(mask, shape=self.data_shape)

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -305,19 +305,3 @@ class RegionGeom(Geom):
         edges = edges_from_lo_hi(emin, emax)
         axis = MapAxis.from_edges(edges, interp="log", name="energy")
         return cls(region=region, wcs=wcs, axes=[axis])
-
-    def energy_mask(self, emin=None, emax=None):
-        """Create a mask for a given energy range.
-
-        Parameters
-        ----------
-        emin, emax : `~astropy.units.Quantity`
-            Energy range
-        """
-        edges = self.axes[0].edges.reshape((-1, 1, 1))
-
-        # set default values
-        emin = emin if emin is not None else edges[0]
-        emax = emax if emax is not None else edges[-1]
-
-        return (edges[:-1] >= emin) & (edges[1:] <= emax)

--- a/gammapy/maps/tests/test_wcs.py
+++ b/gammapy/maps/tests/test_wcs.py
@@ -368,12 +368,12 @@ def test_energy_mask():
 
     mask = geom.energy_mask(emax=30 * u.TeV)
     assert mask[0, 0, 0]
-    assert mask[1, 0, 0]
+    assert not mask[1, 0, 0]
     assert not mask[2, 0, 0]
 
-    mask = geom.energy_mask(emin=3 * u.TeV, emax=30 * u.TeV)
+    mask = geom.energy_mask(emin=3 * u.TeV, emax=40 * u.TeV)
     assert not mask[0, 0, 0]
-    assert not mask[-1, 0, 0]
+    assert not mask[2, 0, 0]
     assert mask[1, 0, 0]
 
 


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes `RegionGeom.energy_mask()` and unifies the energy mask handling between 1D and 3D analyses. Small adaptions of some test values were needed.  

<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
