### PR TITLE
Remove spectrum evaluator

### DIFF
--- a/docs/makers/make_rectangular_reflected_background.py
+++ b/docs/makers/make_rectangular_reflected_background.py
@@ -33,7 +33,8 @@ dataset_empty = SpectrumDataset.create(
 datasets = []
 
 for obs in observations:
-    dataset = dataset_maker.run(dataset_empty, obs)
+
+    dataset = dataset_maker.run(dataset_empty.copy(name=f"obs-{obs.obs_id}"), obs)
     dataset_on_off = bkg_maker.run(observation=obs, dataset=dataset)
     datasets.append(dataset_on_off)
 

--- a/gammapy/analysis/config/model-1d.yaml
+++ b/gammapy/analysis/config/model-1d.yaml
@@ -1,0 +1,26 @@
+components:
+    - name: source
+      type: SkyModel
+      spectral:
+          type: PowerLawSpectralModel
+          parameters:
+              - factor: 2.0
+                frozen: false
+                name: index
+                scale: 1.0
+                unit: ''
+                value: 2.6
+              - factor: 1.0e-12
+                frozen: false
+                name: amplitude
+                scale: 1.0
+                unit: cm-2 s-1 TeV-1
+                value: 5.0e-11
+              - factor: 1.0
+                frozen: true
+                name: reference
+                scale: 1.0
+                unit: TeV
+                value: 1.0
+
+

--- a/gammapy/analysis/tests/test_analysis.py
+++ b/gammapy/analysis/tests/test_analysis.py
@@ -14,6 +14,7 @@ from gammapy.utils.testing import requires_data, requires_dependency
 
 CONFIG_PATH = Path(__file__).resolve().parent / ".." / "config"
 MODEL_FILE = CONFIG_PATH / "model.yaml"
+MODEL_FILE_1D = CONFIG_PATH / "model-1d.yaml"
 
 
 def get_example_config(which):
@@ -158,7 +159,7 @@ def test_analysis_1d():
     analysis.update_config(cfg)
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.read_models(MODEL_FILE)
+    analysis.read_models(MODEL_FILE_1D)
     analysis.run_fit()
     analysis.get_flux_points()
 
@@ -250,7 +251,7 @@ def test_analysis_1d_stacked():
     analysis.config.datasets.stack = True
     analysis.get_observations()
     analysis.get_datasets()
-    analysis.read_models(MODEL_FILE)
+    analysis.read_models(MODEL_FILE_1D)
     analysis.run_fit()
 
     assert len(analysis.datasets) == 1
@@ -296,10 +297,10 @@ def test_analysis_3d():
     assert len(analysis.flux_points.data.table) == 2
     dnde = analysis.flux_points.data.table["dnde"].quantity
 
-    assert_allclose(dnde[0].value, 1.380525e-11, rtol=1e-2)
-    assert_allclose(dnde[-1].value, 3.58863e-13, rtol=1e-2)
-    assert_allclose(res["index"].value, 3.097649, rtol=1e-2)
-    assert_allclose(res["tilt"].value, -0.207786, rtol=1e-2)
+    assert_allclose(dnde[0].value, 1.340073e-11, rtol=1e-2)
+    assert_allclose(dnde[-1].value, 3.483509e-13, rtol=1e-2)
+    assert_allclose(res["index"].value, 3.097613, rtol=1e-2)
+    assert_allclose(res["tilt"].value, -0.207792, rtol=1e-2)
 
 
 @requires_data()

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -14,7 +14,7 @@ from gammapy.irf.psf_kernel import PSFKernel
 from gammapy.irf.psf_map import PSFMap
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling import Parameters
-from gammapy.modeling.models import BackgroundModel, Models, SkyModel
+from gammapy.modeling.models import BackgroundModel, Models
 from gammapy.stats import cash, cash_sum_cython, wstat
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_name, make_path

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -14,12 +14,12 @@ from gammapy.irf.psf_kernel import PSFKernel
 from gammapy.irf.psf_map import PSFMap
 from gammapy.maps import Map, MapAxis
 from gammapy.modeling import Parameters
-from gammapy.modeling.models import BackgroundModel, Models
+from gammapy.modeling.models import BackgroundModel, Models, SkyModel
 from gammapy.stats import cash, cash_sum_cython, wstat
 from gammapy.utils.random import get_random_state
 from gammapy.utils.scripts import make_name, make_path
 from .core import Dataset
-from .spectrum import SpectrumDataset, SpectrumDatasetOnOff
+
 
 __all__ = ["MapDataset", "MapDatasetOnOff"]
 
@@ -804,6 +804,8 @@ class MapDataset(Dataset):
         dataset : `~gammapy.spectrum.SpectrumDataset`
             the resulting reduced dataset
         """
+        from .spectrum import SpectrumDataset
+
         kwargs = {"gti": self.gti, "name": name}
 
         if self.gti is not None:
@@ -1389,6 +1391,8 @@ class MapDatasetOnOff(MapDataset):
         dataset : `~gammapy.spectrum.SpectrumDatasetOnOff`
             the resulting reduced dataset
         """
+        from .spectrum import SpectrumDatasetOnOff
+
         dataset = super().to_spectrum_dataset(on_region, containment_correction, name)
 
         kwargs = {}
@@ -1628,16 +1632,14 @@ class MapEvaluator:
 
         For now, we simply multiply dnde with bin volume.
         """
-        dnde = self.compute_dnde()
-        volume = self.geom.bin_volume()
-        return dnde * volume
+        return self.model.integrate(self.geom, self.gti)
 
     def apply_exposure(self, flux):
         """Compute npred cube
 
         For now just divide flux cube by exposure
         """
-        npred = (flux * self.exposure.quantity).to_value("")
+        npred = (flux.quantity * self.exposure.quantity).to_value("")
         return Map.from_geom(self.geom, data=npred, unit="")
 
     def apply_psf(self, npred):
@@ -1671,18 +1673,14 @@ class MapEvaluator:
             Predicted counts on the map (in reco energy bins)
         """
         flux = self.compute_flux()
-        if self.model.apply_irf["exposure"] is True:
-            npred = self.apply_exposure(flux)
-        else:
-            geom_reco = self.geom.copy()
-            if self.edisp is not None:
-                e_reco_axis = self.edisp.e_reco.copy(name="energy")
-                geom_reco = self.geom.to_image().to_cube(axes=[e_reco_axis])
-            npred = Map.from_geom(geom_reco, data=flux.to_value(""), unit="")
 
-        if self.psf is not None and self.model.apply_irf["psf"] == True:
+        if self.model.apply_irf["exposure"]:
+            npred = self.apply_exposure(flux)
+
+        if self.psf and self.model.apply_irf["psf"]:
             npred = self.apply_psf(npred)
-        if self.edisp is not None and self.model.apply_irf["edisp"] == True:
+
+        if self.edisp and self.model.apply_irf["edisp"]:
             npred = self.apply_edisp(npred)
 
         return npred

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1558,6 +1558,7 @@ class MapEvaluator:
     @property
     def needs_update(self):
         """Check whether the model component has drifted away from its support."""
+        # TODO: simplify and clean up
         if isinstance(self.model, BackgroundModel):
             return False
         elif self.exposure is None:
@@ -1584,6 +1585,7 @@ class MapEvaluator:
         geom : `WcsGeom`
             Counts geom
         """
+        # TODO: simplify and clean up
         log.debug("Updating model evaluator")
         # cache current position of the model component
 
@@ -1680,7 +1682,7 @@ class MapEvaluator:
         if self.psf and self.model.apply_irf["psf"]:
             npred = self.apply_psf(npred)
 
-        if self.edisp and self.model.apply_irf["edisp"]:
+        if self.model.apply_irf["edisp"]:
             npred = self.apply_edisp(npred)
 
         return npred

--- a/gammapy/datasets/map.py
+++ b/gammapy/datasets/map.py
@@ -1634,7 +1634,7 @@ class MapEvaluator:
 
         For now, we simply multiply dnde with bin volume.
         """
-        return self.model.integrate(self.geom, self.gti)
+        return self.model.integrate_geom(self.geom, self.gti)
 
     def apply_exposure(self, flux):
         """Compute npred cube

--- a/gammapy/datasets/tests/test_map.py
+++ b/gammapy/datasets/tests/test_map.py
@@ -154,8 +154,8 @@ def test_fake(sky_model, geom, geom_etrue):
     dataset.fake(314)
 
     assert real_dataset.counts.data.shape == dataset.counts.data.shape
-    assert_allclose(real_dataset.counts.data.sum(), 8220.399727)
-    assert_allclose(dataset.counts.data.sum(), 8375)
+    assert_allclose(real_dataset.counts.data.sum(), 9525.755807)
+    assert_allclose(dataset.counts.data.sum(), 9723)
 
 
 @pytest.mark.xfail
@@ -364,22 +364,22 @@ def test_map_fit(sky_model, geom, geom_etrue):
     assert "minuit" in repr(result)
 
     npred = dataset_1.npred().data.sum()
-    assert_allclose(npred, 6220.529956, rtol=1e-3)
-    assert_allclose(result.total_stat, 26008.040889, rtol=1e-3)
+    assert_allclose(npred, 7525.790688, rtol=1e-3)
+    assert_allclose(result.total_stat, 21700.253246, rtol=1e-3)
 
     pars = result.parameters
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
-    assert_allclose(pars.error("lon_0"), 0.002622, rtol=1e-2)
+    assert_allclose(pars.error("lon_0"), 0.002244, rtol=1e-2)
 
     assert_allclose(pars["index"].value, 3, rtol=1e-2)
-    assert_allclose(pars.error("index"), 0.028967, rtol=1e-2)
+    assert_allclose(pars.error("index"), 0.024277, rtol=1e-2)
 
     assert_allclose(pars["amplitude"].value, 1e-11, rtol=1e-2)
-    assert_allclose(pars.error("amplitude"), 4.086756e-13, rtol=1e-2)
+    assert_allclose(pars.error("amplitude"), 4.216154e-13, rtol=1e-2)
 
     # background norm 1
     assert_allclose(pars[8].value, 0.5, rtol=1e-2)
-    assert_allclose(pars.error(pars[8]), 0.0156, rtol=1e-2)
+    assert_allclose(pars.error(pars[8]), 0.015811, rtol=1e-2)
 
     # background norm 2
     assert_allclose(pars[11].value, 1, rtol=1e-2)
@@ -391,7 +391,7 @@ def test_map_fit(sky_model, geom, geom_etrue):
     dataset_2.mask_safe = Map.from_geom(geom, data=mask_safe)
 
     stat = fit.datasets.stat_sum()
-    assert_allclose(stat, 14447.196919)
+    assert_allclose(stat, 14824.282955)
 
     # test model evaluation outside image
 
@@ -426,19 +426,19 @@ def test_map_fit_one_energy_bin(sky_model, geom_image):
     assert result.success
 
     npred = dataset.npred().data.sum()
-    assert_allclose(npred, 4076.779039, rtol=1e-3)
-    assert_allclose(result.total_stat, 5722.439112, rtol=1e-3)
+    assert_allclose(npred, 16538.124036, rtol=1e-3)
+    assert_allclose(result.total_stat, -34844.125047, rtol=1e-3)
 
     pars = result.parameters
 
     assert_allclose(pars["lon_0"].value, 0.2, rtol=1e-2)
-    assert_allclose(pars.error("lon_0"), 0.00407, rtol=1e-2)
+    assert_allclose(pars.error("lon_0"), 0.001689, rtol=1e-2)
 
     assert_allclose(pars["sigma"].value, 0.2, rtol=1e-2)
-    assert_allclose(pars.error("sigma"), 0.00237, rtol=1e-2)
+    assert_allclose(pars.error("sigma"), 0.00092, rtol=1e-2)
 
     assert_allclose(pars["amplitude"].value, 1e-11, rtol=1e-2)
-    assert_allclose(pars.error("amplitude"), 1.901406e-13, rtol=1e-2)
+    assert_allclose(pars.error("amplitude"), 8.127593e-14, rtol=1e-2)
 
 
 def test_create(geom, geom_etrue):

--- a/gammapy/estimators/flux.py
+++ b/gammapy/estimators/flux.py
@@ -7,6 +7,7 @@ from gammapy.estimators.parameter_estimator import ParameterEstimator
 
 log = logging.getLogger(__name__)
 
+
 class FluxEstimator(ParameterEstimator):
     """Flux estimator.
 

--- a/gammapy/estimators/tests/test_flux.py
+++ b/gammapy/estimators/tests/test_flux.py
@@ -31,8 +31,8 @@ def test_flux_estimator_fermi_no_reoptimization(fermi_datasets):
     estimator = FluxEstimator(fermi_datasets, 0, norm_n_values=5, norm_min=0.5, norm_max=2, reoptimize=False)
     result = estimator.run("1 GeV", "100 GeV")
 
-    assert_allclose(result["norm"], 1.00, atol=1e-3)
-    assert_allclose(result["delta_ts"], 29695.756278, atol=1e-3)
+    assert_allclose(result["norm"], 0.970614, atol=1e-3)
+    assert_allclose(result["delta_ts"], 29695.720611, atol=1e-3)
     assert_allclose(result["err"], 0.01998, atol=1e-3)
     assert_allclose(result["errn"], 0.0199, atol=1e-3)
     assert_allclose(result["errp"], 0.0199, atol=1e-3)
@@ -46,9 +46,8 @@ def test_flux_estimator_fermi_with_reoptimization(fermi_datasets):
     estimator = FluxEstimator(fermi_datasets, 0, reoptimize=True)
     result = estimator.run("1 GeV", "100 GeV", steps=["ts"])
 
-    print(estimator)
-    assert_allclose(result["norm"], 1.00, atol=1e-3)
-    assert_allclose(result["delta_ts"], 13005.938759, atol=1e-3)
+    assert_allclose(result["norm"], 0.970614, atol=1e-3)
+    assert_allclose(result["delta_ts"], 13005.903067, atol=1e-3)
     assert_allclose(result["err"], 0.01998, atol=1e-3)
 
 @requires_data()

--- a/gammapy/makers/safe.py
+++ b/gammapy/makers/safe.py
@@ -112,7 +112,7 @@ class SafeMaskMaker:
 
         Parameters
         ----------
-        dataset : ``~gammapy.datasets.MapDataset` or `~gammapy.datasets.SpectrumDataset`
+        dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.SpectrumDataset`
             Dataset to compute mask for.
 
         Returns
@@ -147,7 +147,7 @@ class SafeMaskMaker:
 
         Parameters
         ----------
-        dataset : ``~gammapy.datasets.MapDataset` or `~gammapy.datasets.SpectrumDataset`
+        dataset : `~gammapy.datasets.MapDataset` or `~gammapy.datasets.SpectrumDataset`
             Dataset to compute mask for.
 
         Returns

--- a/gammapy/makers/spectrum.py
+++ b/gammapy/makers/spectrum.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import logging
-import numpy as np
 from astropy import units as u
 from regions import CircleSkyRegion
 from gammapy.datasets import SpectrumDataset
-from gammapy.maps import RegionNDMap, WcsGeom
+from gammapy.maps import RegionNDMap
 
 __all__ = ["SpectrumDatasetMaker"]
 
@@ -36,15 +35,6 @@ class SpectrumDatasetMaker:
             selection = self.available_selection
 
         self.selection = selection
-
-    # TODO: move this to a RegionGeom class
-    @staticmethod
-    def geom_ref(region):
-        """Reference geometry to project region"""
-        frame = region.center.frame.name
-        return WcsGeom.create(
-            skydir=region.center, npix=(1, 1), binsz=1, proj="TAN", frame=frame
-        )
 
     @staticmethod
     def make_counts(geom, observation):

--- a/gammapy/maps/base.py
+++ b/gammapy/maps/base.py
@@ -944,12 +944,17 @@ class Map(abc.ABC):
         map : `WcsNDMap`
             Map with energy dispersion applied.
         """
-        loc = self.geom.get_axis_index_by_name("energy_true")
-        data = np.rollaxis(self.data, loc, len(self.data.shape))
-        data = np.dot(data, edisp.pdf_matrix)
-        data = np.rollaxis(data, -1, loc)
+        # TODO: either use sparse matrix mutiplication or something like edisp.is_diagonal
+        if edisp is not None:
+            loc = self.geom.get_axis_index_by_name("energy_true")
+            data = np.rollaxis(self.data, loc, len(self.data.shape))
+            data = np.dot(data, edisp.pdf_matrix)
+            data = np.rollaxis(data, -1, loc)
+            e_reco_axis = edisp.e_reco.copy(name="energy")
+        else:
+            data = self.data
+            e_reco_axis = self.geom.get_axis_by_name("energy_true").copy(name="energy")
 
-        e_reco_axis = edisp.e_reco.copy(name="energy")
         geom_reco = self.geom.to_image().to_cube(axes=[e_reco_axis])
         return self._init_copy(geom=geom_reco, data=data)
 

--- a/gammapy/maps/region.py
+++ b/gammapy/maps/region.py
@@ -5,15 +5,13 @@ from astropy.table import Table
 from astropy.wcs.utils import proj_plane_pixel_area, wcs_to_celestial_frame
 from astropy.wcs import WCS
 from regions import (
-    CircleSkyRegion,
     fits_region_objects_to_table,
     FITSRegionParser,
-    RectangleSkyRegion,
 )
 from gammapy.utils.regions import make_region, compound_region_to_list, list_to_compound_region
 from .base import MapCoord
 from .geom import Geom, make_axes, pix_tuple_to_idx, MapAxis
-from .utils import INVALID_INDEX, edges_from_lo_hi
+from .utils import edges_from_lo_hi
 from .wcs import WcsGeom
 
 __all__ = ["RegionGeom"]
@@ -68,11 +66,11 @@ class RegionGeom(Geom):
 
     @property
     def width(self):
-        """Width of the region"""
+        """Width of bounding box of the region"""
         region_pix = self.region.to_pixel(self.wcs)
         rectangle_pix = region_pix.bounding_box.to_region()
         rectangle = rectangle_pix.to_sky(self.wcs)
-        return rectangle.width, rectangle.height
+        return u.Quantity([rectangle.width, rectangle.height])
 
     @property
     def region(self):

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -272,7 +272,7 @@ class RegionNDMap(Map):
         table = Table.read(hdulist["SPECTRUM"])
         geom = RegionGeom.from_hdulist(hdulist, format=format)
 
-        return cls(geom=geom, data=table[ogip_column], meta=table.meta)
+        return cls(geom=geom, data=table[ogip_column].data, meta=table.meta)
 
     def crop(self):
         raise NotImplementedError("Crop is not supported by RegionNDMap")
@@ -303,8 +303,8 @@ class RegionNDMap(Map):
         """
         data = other.data
 
-        # TODO: re-think stacking of regions. Is making the union reesonable?
-        self.geom.union(other.geom)
+        # TODO: re-think stacking of regions. Is making the union reasonable?
+        # self.geom.union(other.geom)
 
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/regionnd.py
+++ b/gammapy/maps/regionnd.py
@@ -249,7 +249,23 @@ class RegionNDMap(Map):
 
     @classmethod
     def from_hdulist(cls, hdulist, format="ogip", ogip_column="COUNTS"):
-        """Create from `~astropy.io.fits.HDUList`."""
+        """Create from `~astropy.io.fits.HDUList`.
+
+
+        Parameters
+        ----------
+        hdulist : `~astropy.io.fits.HDUList`
+            HDU list.
+        format : {"ogip"}
+            Format specification
+        ogip_column : str
+            OGIP data format column
+
+        Returns
+        -------
+        region_nd_map : `RegionNDMap`
+            Region map.
+        """
         if format != "ogip":
             raise ValueError("Only 'ogip' format supported")
 
@@ -286,7 +302,9 @@ class RegionNDMap(Map):
             to `other` and additional axes must be broadcastable.
         """
         data = other.data
-        # TODO: handle region stacking here
+
+        # TODO: re-think stacking of regions. Is making the union reesonable?
+        self.geom.union(other.geom)
 
         if weights is not None:
             if not other.geom.to_image() == weights.geom.to_image():

--- a/gammapy/maps/tests/test_region.py
+++ b/gammapy/maps/tests/test_region.py
@@ -32,6 +32,11 @@ def test_centers(region):
     assert_allclose(values, (0, 0))
 
 
+def test_width(region):
+    geom = RegionGeom.create(region)
+    assert_allclose(geom.width.value, [2.02, 2.02])
+
+
 def test_create_axis(region):
     axis = MapAxis.from_energy_bounds("1 TeV", "10 TeV", nbin=3)
     geom = RegionGeom.create(region, axes=[axis])

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -205,8 +205,21 @@ class SkyModel(SkyModelBase):
 
         return value
 
-    def integrate(self, geom, gti=None):
-        """Integrate model on `~gammapy.maps.Geom`."""
+    def integrate_geom(self, geom, gti=None):
+        """Integrate model on `~gammapy.maps.Geom`.
+
+        Parameters
+        ----------
+        geom : `Geom`
+            Map geometry
+        gti : `GTI`
+            GIT table
+
+        Returns
+        -------
+        flux : `Map`
+            Predicted flux map
+        """
         energy = geom.get_axis_by_name("energy_true").edges
         value = self.spectral_model.integral(
             energy[:-1], energy[1:], intervals=True
@@ -459,8 +472,21 @@ class SkyDiffuseCube(SkyModelBase):
         val = norm * self._cached_value * tilt_factor.value
         return u.Quantity(val, self.map.unit, copy=False)
 
-    def integrate(self, geom, gti=None):
-        """Integrate model on `~gammapy.maps.Geom`."""
+    def integrate_geom(self, geom, gti=None):
+        """Integrate model on `~gammapy.maps.Geom`.
+
+        Parameters
+        ----------
+        geom : `Geom`
+            Map geometry
+        gti : `GTI`
+            GIT table (currently not being used...)
+
+        Returns
+        -------
+        flux : `Map`
+            Predicted flux map
+        """
         # TODO: implement better integration method?
         value = self.evaluate_geom(geom)
         value = value * geom.bin_volume()

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -191,7 +191,7 @@ class PointSpatialModel(SpatialModel):
 
     def evaluate_geom(self, geom):
         """Evaluate model on `~gammapy.maps.Geom`."""
-        values = self.integrate(geom)
+        values = self.integrate(geom).data
         return values / geom.solid_angle()
 
     def integrate(self, geom):

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -106,6 +106,12 @@ class SpatialModel(Model):
         coords = geom.get_coord(frame=self.frame)
         return self(coords.lon, coords.lat)
 
+    def integrate(self, geom):
+        """Integrate model on `~gammapy.maps.Geom`."""
+        values = self.evaluate_geom(geom)
+        data = values * geom.solid_angle()
+        return Map.from_geom(geom=geom, data=data.value, unit=data.unit)
+
     def to_dict(self):
         """Create dict for YAML serilisation"""
         data = super().to_dict()
@@ -185,10 +191,14 @@ class PointSpatialModel(SpatialModel):
 
     def evaluate_geom(self, geom):
         """Evaluate model on `~gammapy.maps.Geom`."""
+        values = self.integrate(geom)
+        return values / geom.solid_angle()
+
+    def integrate(self, geom):
         x, y = geom.get_pix()
         x0, y0 = self.position.to_pixel(geom.wcs)
-        w = self._grid_weights(x, y, x0, y0)
-        return w / geom.solid_angle()
+        data = self._grid_weights(x, y, x0, y0)
+        return Map.from_geom(geom=geom, data=data, unit="")
 
     def to_region(self, **kwargs):
         """Model outline (`~regions.PointSkyRegion`)."""

--- a/gammapy/modeling/models/spatial.py
+++ b/gammapy/modeling/models/spatial.py
@@ -191,10 +191,22 @@ class PointSpatialModel(SpatialModel):
 
     def evaluate_geom(self, geom):
         """Evaluate model on `~gammapy.maps.Geom`."""
-        values = self.integrate(geom).data
+        values = self.integrate_geom(geom).data
         return values / geom.solid_angle()
 
-    def integrate(self, geom):
+    def integrate_geom(self, geom):
+        """Integrate model on `~gammapy.maps.Geom`
+
+        Parameters
+        ----------
+        geom : `Geom`
+            Map geometry
+
+        Returns
+        -------
+        flux : `Map`
+            Predicted flux map
+        """
         x, y = geom.get_pix()
         x0, y0 = self.position.to_pixel(geom.wcs)
         data = self._grid_weights(x, y, x0, y0)

--- a/gammapy/modeling/models/spectral.py
+++ b/gammapy/modeling/models/spectral.py
@@ -1031,6 +1031,9 @@ class ScaleSpectralModel(SpectralModel):
     def evaluate(self, energy, norm):
         return norm * self.model(energy)
 
+    def integral(self, emin, emax, **kwargs):
+        return self.norm.value * self.model.integral(emin, emax, **kwargs)
+
 
 class Absorption:
     r"""Gamma-ray absorption models.

--- a/gammapy/modeling/models/tests/test_cube.py
+++ b/gammapy/modeling/models/tests/test_cube.py
@@ -418,8 +418,8 @@ class TestSkyDiffuseCubeMapEvaluator:
     @staticmethod
     def test_compute_flux(diffuse_evaluator):
         out = diffuse_evaluator.compute_flux()
-        assert out.shape == (3, 4, 5)
-        out = out.to("cm-2 s-1")
+        assert out.data.shape == (3, 4, 5)
+        out = out.quantity.to("cm-2 s-1")
         assert_allclose(out.value.sum(), 633263.444803, rtol=1e-5)
         assert_allclose(out.value[0, 0, 0], 1164.656176, rtol=1e-5)
 
@@ -468,10 +468,11 @@ class TestSkyModelMapEvaluator:
 
     @staticmethod
     def test_compute_flux(evaluator):
-        out = evaluator.compute_flux().to_value("cm-2 s-1")
+        out = evaluator.compute_flux()
+        out = out.quantity.to_value("cm-2 s-1")
         assert out.shape == (3, 4, 5)
-        assert_allclose(out.sum(), 1.291414e-12, rtol=1e-5)
-        assert_allclose(out[0, 0, 0], 4.630845e-14, rtol=1e-5)
+        assert_allclose(out.sum(), 2.213817e-12, rtol=1e-5)
+        assert_allclose(out[0, 0, 0], 7.938388e-14, rtol=1e-5)
 
     @staticmethod
     def test_apply_psf(evaluator):
@@ -479,8 +480,8 @@ class TestSkyModelMapEvaluator:
         npred = evaluator.apply_exposure(flux)
         out = evaluator.apply_psf(npred)
         assert out.data.shape == (3, 4, 5)
-        assert_allclose(out.data.sum(), 2.2530737e-06, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 2.407252e-08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 3.862314e-06, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 4.126612e-08, rtol=1e-5)
 
     @staticmethod
     def test_apply_edisp(evaluator):
@@ -488,15 +489,15 @@ class TestSkyModelMapEvaluator:
         npred = evaluator.apply_exposure(flux)
         out = evaluator.apply_edisp(npred)
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.sum(), 3.27582e-06, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 4.630845e-08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 5.615601e-06, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 7.938388e-08, rtol=1e-5)
 
     @staticmethod
     def test_compute_npred(evaluator, gti):
         out = evaluator.compute_npred()
         assert out.data.shape == (2, 4, 5)
-        assert_allclose(out.data.sum(), 2.253073467739508e-06, rtol=1e-5)
-        assert_allclose(out.data[0, 0, 0], 2.407252e-08, rtol=1e-5)
+        assert_allclose(out.data.sum(), 3.862314e-06, rtol=1e-5)
+        assert_allclose(out.data[0, 0, 0], 4.126612e-08, rtol=1e-5)
 
 
 def test_sky_point_source():
@@ -523,7 +524,7 @@ def test_sky_point_source():
     spectral_model.const.value /= spectral_model.integral(1 * u.TeV, 10 * u.TeV).value
     model = SkyModel(spatial_model=spatial_model, spectral_model=spectral_model)
     evaluator = MapEvaluator(model=model, exposure=exposure)
-    flux = evaluator.compute_flux().to_value("cm-2 s-1")[0]
+    flux = evaluator.compute_flux().quantity.to_value("cm-2 s-1")[0]
 
     expected = [
         [0, 0, 0, 0],


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request removes the `SpectrumEvaluator` and unifies the model evaluation with the `MapEvaluator`. I includes the following changes:
- I added  a `SkyModel.integrate(geom)` and `SpatialModel.integrate(geom)` method
- I changed `SkyModel.integrate()` to call into `SpectralModel.integral()` as well. This causes a lot of small (and some major) changes in the test values, because for many test we have use large energy bins.
- I added a `SpectrumDataset.exposure` property

**Dear reviewer**
I think its important, that we re-run the validation on this branch to see, what changes it causes to the result before we merge. @luca-giunti @AtreyeeS @registerrier @QRemy 
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
