### PR TITLE
Add temporal evaluation for spectral datasets

### DIFF
--- a/gammapy/datasets/spectrum.py
+++ b/gammapy/datasets/spectrum.py
@@ -257,6 +257,7 @@ class SpectrumDataset(Dataset):
                         model=model,
                         exposure=self.exposure,
                         edisp=self.edisp,
+                        gti=self.gti,
                     )
                     self._evaluators[model.name] = evaluator
 


### PR DESCRIPTION
This pull request passes GTIs to `MapEvaluator` from `SpectrumDataset` to enable computation of temporal models


