### PR TITLE
Correct GaussianTemporalModel.integral

### DIFF
--- a/gammapy/modeling/models/temporal.py
+++ b/gammapy/modeling/models/temporal.py
@@ -181,17 +181,13 @@ class GaussianTemporalModel(TemporalModel):
         """
 
         pars = self.parameters
-        norm = pars["sigma"].quantity * np.sqrt(2 * np.pi)
-        u_min = norm * (
-            (t_min.mjd - pars["t_ref"].quantity) / (np.sqrt(2) * pars["sigma"].quantity)
-        )
-        u_max = norm * (
-            (t_max.mjd - pars["t_ref"].quantity) / (np.sqrt(2) * pars["sigma"].quantity)
-        )
+        sigma = pars["sigma"].quantity.to_value("d")
+        norm = np.sqrt(np.pi / 2) * sigma
+        u_min = (t_min.mjd - pars["t_ref"].quantity) / (np.sqrt(2) * sigma)
+        u_max = (t_max.mjd - pars["t_ref"].quantity) / (np.sqrt(2) * sigma)
 
-        integ = 1.0 / 2 * (scipy.special.erf(u_max) - scipy.special.erf(u_min))
-        unit = getattr(pars["sigma"], "unit")
-        return integ / self.time_sum(t_min, t_max).to_value(unit)
+        integ = norm * (scipy.special.erf(u_max) - scipy.special.erf(u_min))
+        return (integ / self.time_sum(t_min, t_max).to_value("d")).value
 
 
 class LightCurveTemplateTemporalModel(TemplateTemporalModel):

--- a/gammapy/modeling/models/tests/test_temporal.py
+++ b/gammapy/modeling/models/tests/test_temporal.py
@@ -182,7 +182,7 @@ def test_gaussian_temporal_model_integral():
     gti = GTI.create(start, stop, reference_time=t_ref)
     val = temporal_model.integral(gti.time_start, gti.time_stop)
     assert len(val) == 3
-    assert_allclose(np.sum(val), 0.160278, rtol=1e-5)
+    assert_allclose(np.sum(val), 0.682668, rtol=1e-5)
 
 
 @requires_data()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This PR fixes a bug in the computation of `GaussianTemporalModel.integral`. The normalisation was handled incorrectly before, leading to the integral not depending on sigma at all.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
