### PR TITLE
Add notebook on statistics in gammapy

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -110,6 +110,7 @@ Advanced tutorials
    ../notebooks/exclusion_mask.ipynb
    ../notebooks/overview.ipynb
    ../notebooks/maps.ipynb
+   ../notebooks/statistics_in_gammapy.ipynb
    ../notebooks/modeling.ipynb
    ../notebooks/models.ipynb
    ../notebooks/catalog.ipynb
@@ -140,6 +141,7 @@ Gammapy API.
 
 *Modeling and fitting in gammapy*
 
+- `Working with counts statistics in gammapy <../notebooks/statistics_in_gammapy.html>`__ | *statistics_in_gammapy.ipynb*
 - `Modeling and Fitting <../notebooks/modeling.html>`__  | *modeling.ipynb*
 - `Models <../notebooks/models.html>`__  | *models.ipynb*
 

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -122,4 +122,6 @@
   datasets:
     - catalogs
     - fermi-3fhl-crab
-    
+- name: statistics_in_gammapy
+  url: https://raw.githubusercontent.com/gammapy/gammapy/master/tutorials/statistics_in_gammapy.ipynb
+

--- a/tutorials/statistics_in_gammapy.ipynb
+++ b/tutorials/statistics_in_gammapy.ipynb
@@ -1,0 +1,622 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Counts statistics in gammapy\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "### Context\n",
+    "\n",
+    "Gamma-ray astronomy is based on individual photon measurements. The existence of a signal is usually\n",
+    "determined by comparing measured number of counts to the expected number of background counts. The latter \n",
+    "can be known thanks to a model or can be estimated thanks to a second measurement devoid of any signal.\n",
+    "\n",
+    "Those two situations drive most of the cases that concern gamma-ray data analysis. The first one is dealt with by the Cash statistic, the second by the WStat.\n",
+    "\n",
+    "###Objective\n",
+    "\n",
+    "**Compute some statistical informations on the expected number of signal events in a counting experiment. In particular, we want to estimate the statistical significance of the possible signal, the confidence interval or the upper limit on its estimated value.**\n",
+    "\n",
+    "### Approach\n",
+    "\n",
+    "Counts statistics are handled with dedicated classes in gammapy: `~gammapy.stats.CashCountsStatistic` and\n",
+    "`~gammapy.stats.WStatCountsStatistic`. They are used to estimate the expected signal and the confidence interval of the latter as well as an estimate of the probability that this excess is due to a fluctuation in the number of background counts. This is obtained thanks to a likelihood ratio test and measured as a delta TS in gammapy. This delta TS can be converted to a p-value or to the significance number (often approximated as the square root of the delta TS).  \n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "Some imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from gammapy.stats import CashCountsStatistic, WStatCountsStatistic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Poisson signal with known Poisson background: Cash statistic\n",
+    "\n",
+    "We first study the case of an observation yielding $n_{ON}=13$ events with an expected number of background events of $\\mu_{bkg}=5.5$.\n",
+    "\n",
+    "We are dealing with Cash statistic and create a `CashCountsStatistic` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count_statistic = CashCountsStatistic(n_on=13, mu_bkg=5.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The estimated number of signal events is given by the measured excess and the standard error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "excess = count_statistic.excess\n",
+    "error = count_statistic.error\n",
+    "print(f\"Measured excess : {excess} +- {error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Estimating excess significance\n",
+    "\n",
+    "Significance of the measured excess can be estimated by comparing the statistic value for null hypothesis and best fit value. This is the delta TS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Delta TS : {count_statistic.delta_ts}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "According to the Wilks theorem, this delta TS value is asymptotically distributed as a chi-square with 1 degree of freedom. Hence we can have a estimate of the significance, expressed in number of sigma, by taking the square root of delta_ts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Square root TS : {count_statistic.significance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, we can compute the corresponding p-value: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"p_value: {count_statistic.p_value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here, we show how this is computed, plotting the Cash statistic distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We compute the Cash statistic profile\n",
+    "mu_signal = np.linspace(-1.5, 25, 100)\n",
+    "stat_values = count_statistic._stat_fcn(mu_signal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmin, xmax = -1.5, 25\n",
+    "ymin, ymax = -42, -28.0\n",
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.plot(mu_signal, stat_values, color=\"k\")\n",
+    "plt.xlim(xmin, xmax)\n",
+    "plt.ylim(ymin, ymax)\n",
+    "\n",
+    "plt.xlabel(r\"Number of expected signal event, $\\mu_{sig}$\")\n",
+    "plt.ylabel(r\"Cash statistic value, TS \")\n",
+    "plt.vlines(\n",
+    "    excess,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"k\",\n",
+    "    label=\"Best fit\",\n",
+    ")\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_max,\n",
+    "    xmin=xmin,\n",
+    "    xmax=excess,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"k\",\n",
+    ")\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_null,\n",
+    "    xmin=xmin,\n",
+    "    xmax=0,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"k\",\n",
+    "    label=\"Null hypothesis\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    0, ymin=ymin, ymax=count_statistic.TS_null, linestyle=\"dotted\", color=\"k\"\n",
+    ")\n",
+    "\n",
+    "plt.vlines(\n",
+    "    excess,\n",
+    "    ymin=count_statistic.TS_max,\n",
+    "    ymax=count_statistic.TS_null,\n",
+    "    color=\"r\",\n",
+    ")\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_null, xmin=0, xmax=excess, linestyle=\"dotted\", color=\"r\"\n",
+    ")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Estimating the confidence range and upper limit of the signal\n",
+    "\n",
+    "The 68% confidence interval (or 1 sigma asymmetric errors) is obtained by finding the signal values for which the TS variation is 1. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errn = count_statistic.compute_errn(1.0)\n",
+    "errp = count_statistic.compute_errp(1.0)\n",
+    "print(f\"68% confidence range: {excess+errn} < mu < {excess+errp}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 95% confidence interval (or 2 sigma asymmetric errors) is obtained by finding the signal values for which the TS variation is 4. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errn_2sigma = count_statistic.compute_errn(2.0)\n",
+    "errp_2sigma = count_statistic.compute_errp(2.0)\n",
+    "print(\n",
+    "    f\"95% confidence range: {excess+errn_2sigma} < mu < {excess+errp_2sigma}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again for clarity, we plot the statistic profile and the resulting confidence intervals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmin, xmax = -1.5, 25\n",
+    "ymin, ymax = -42, -28.0\n",
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.plot(mu_signal, stat_values, color=\"k\")\n",
+    "plt.xlim(xmin, xmax)\n",
+    "plt.ylim(ymin, ymax)\n",
+    "plt.xlabel(r\"Number of expected signal event, $\\mu_{sig}$\")\n",
+    "plt.ylabel(r\"Cash statistic value, TS \")\n",
+    "\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_max + 1,\n",
+    "    xmin=excess + errn,\n",
+    "    xmax=excess + errp,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"r\",\n",
+    "    label=\"1 sigma (68% C.L.)\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errn,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 1,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"r\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errp,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 1,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"r\",\n",
+    ")\n",
+    "\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_max + 4,\n",
+    "    xmin=excess + errn_2sigma,\n",
+    "    xmax=excess + errp_2sigma,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"b\",\n",
+    "    label=\"2 sigma (95% C.L.)\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errn_2sigma,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 4,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"b\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errp_2sigma,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 4,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"b\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Poisson signal with unknow background: the WStat\n",
+    "\n",
+    "We now study the case of an observation yielding $n_{ON}=13$ events, but this time without a model of theexpected number of background events. Instead, a second observation in which we expect twice the number of background has measured $n_{OFF}=11$ events. \n",
+    "\n",
+    "The estimated background in the $ON$ observation is therefore:\n",
+    "$n_{ON} - \\alpha n_{OFF} = 5.5$, with $\\alpha = 1/2$.\n",
+    "\n",
+    "We are dealing with WStat and create a `WStatCountsStatistic` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count_statistic = WStatCountsStatistic(n_on=13, n_off=11, alpha=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because of the uncertain $OFF$ measurement, the measured variance is larger than in known background situation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "excess = count_statistic.excess\n",
+    "error = count_statistic.error\n",
+    "print(f\"Measured excess : {excess} +- {error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Estimating excess significance\n",
+    "\n",
+    "Again, the significance of the measured excess can be estimated by comparing the statistic value for null hypothesis and best fit value, the delta TS, which is distributed as chi2 with 1 d.o.f."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Delta TS : {count_statistic.delta_ts}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can have a estimate of the significance, expressed in number of sigma, by taking the square root of delta_ts. For WStat, this is exactly equal to the so-called Li&Ma significance. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Square root TS (Li&Ma significance): {count_statistic.significance}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can compute the corresponding p-value: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"p_value: {count_statistic.p_value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, we show how this works with a plot of the WStat profile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We compute the WStat statistic profile\n",
+    "mu_signal = np.linspace(-2.5, 26, 100)\n",
+    "stat_values = count_statistic._stat_fcn(mu_signal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmin, xmax = -2.5, 26\n",
+    "ymin, ymax = 0, 15\n",
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.plot(mu_signal, stat_values, color=\"k\")\n",
+    "plt.xlim(xmin, xmax)\n",
+    "plt.ylim(ymin, ymax)\n",
+    "\n",
+    "plt.xlabel(r\"Number of expected signal event, $\\mu_{sig}$\")\n",
+    "plt.ylabel(r\"WStat value, TS \")\n",
+    "plt.vlines(\n",
+    "    excess,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"k\",\n",
+    "    label=\"Best fit\",\n",
+    ")\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_max,\n",
+    "    xmin=xmin,\n",
+    "    xmax=excess,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"k\",\n",
+    ")\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_null,\n",
+    "    xmin=xmin,\n",
+    "    xmax=0,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"k\",\n",
+    "    label=\"Null hypothesis\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    0, ymin=ymin, ymax=count_statistic.TS_null, linestyle=\"dotted\", color=\"k\"\n",
+    ")\n",
+    "\n",
+    "plt.vlines(\n",
+    "    excess,\n",
+    "    ymin=count_statistic.TS_max,\n",
+    "    ymax=count_statistic.TS_null,\n",
+    "    color=\"r\",\n",
+    ")\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_null, xmin=0, xmax=excess, linestyle=\"dotted\", color=\"r\"\n",
+    ")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Estimating the confidence range and upper limit of the signal\n",
+    "\n",
+    "Estimation of the confidence range is performed exactly the same way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errn = count_statistic.compute_errn(1.0)\n",
+    "errp = count_statistic.compute_errp(1.0)\n",
+    "print(f\"68% confidence range: {excess+errn} < mu < {excess+errp}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "errn_2sigma = count_statistic.compute_errn(2.0)\n",
+    "errp_2sigma = count_statistic.compute_errp(2.0)\n",
+    "print(\n",
+    "    f\"95% confidence range: {excess+errn_2sigma} < mu < {excess+errp_2sigma}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again for clarity, we plot the statistic profile and the resulting confidence intervals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmin, xmax = -2.5, 26\n",
+    "ymin, ymax = 0, 15\n",
+    "plt.figure(figsize=(7, 7))\n",
+    "plt.plot(mu_signal, stat_values, color=\"k\")\n",
+    "plt.xlim(xmin, xmax)\n",
+    "plt.ylim(ymin, ymax)\n",
+    "\n",
+    "plt.xlabel(r\"Number of expected signal event, $\\mu_{sig}$\")\n",
+    "plt.ylabel(r\"WStat value, TS \")\n",
+    "\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_max + 1,\n",
+    "    xmin=excess + errn,\n",
+    "    xmax=excess + errp,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"r\",\n",
+    "    label=\"1 sigma (68% C.L.)\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errn,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 1,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"r\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errp,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 1,\n",
+    "    linestyle=\"dotted\",\n",
+    "    color=\"r\",\n",
+    ")\n",
+    "\n",
+    "plt.hlines(\n",
+    "    count_statistic.TS_max + 4,\n",
+    "    xmin=excess + errn_2sigma,\n",
+    "    xmax=excess + errp_2sigma,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"b\",\n",
+    "    label=\"2 sigma (95% C.L.)\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errn_2sigma,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 4,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"b\",\n",
+    ")\n",
+    "plt.vlines(\n",
+    "    excess + errp_2sigma,\n",
+    "    ymin=ymin,\n",
+    "    ymax=count_statistic.TS_max + 4,\n",
+    "    linestyle=\"dashed\",\n",
+    "    color=\"b\",\n",
+    ")\n",
+    "\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds a notebook to demonstrate `CountsStatistic` functions and how we compute significances from delta TS as well as confidence errors on excess counts.
We can show some plots of cash and wstat statistic profiles to help a user with little statistic knowledge how calculations are performed and what our TS, sqrt TS, significance and errors mean. 
This is complementary to the modeling notebook which shows how this works in the context of model fitting.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
