### PR TITLE
Add covariance serialization

### DIFF
--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -122,8 +122,7 @@ class Covariance:
         data = arr.view(np.float).reshape(arr.shape + (-1,))
         return cls(models.parameters, data=data, filename=filename)
 
-
-    def write(self,models, filename, **kwargs):
+    def write(self, models, filename, **kwargs):
         """Write covariance to file
 
         Parameters
@@ -135,10 +134,10 @@ class Covariance:
 
         """
         self.filename = filename
-        param_names=[]
+        param_names = []
         for m in models:
             for p in m.parameters:
-                param_names.append(p.name+make_name())
+                param_names.append(p.name + make_name())
         # TODO: param_names.append(p.name+"@"+m.name)
         # this name would be unique once models won't have duplicate
         # parameters names, then remove make_name

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -158,7 +158,9 @@ class Covariance:
             t1["Parameters"] = param_names
             t2 = Table(self._data, names=param_names)
             t = hstack([t1, t2])
-            t.write(filename, format="ascii.fixed_width", delimiter="|", overwrite = overwrite)
+            t.write(
+                filename, format="ascii.fixed_width", delimiter="|", overwrite=overwrite
+            )
 
     def get_subcovariance(self, parameters):
         """Get sub-covariance matrix

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -120,7 +120,7 @@ class Covariance:
         data = arr.view(np.float).reshape(arr.shape + (-1,))
         return cls(models.parameters, data=data, filename=filename)
 
-    def write(self, models, filename, **kwargs):
+    def write(self, models, filename, overwrite=True, **kwargs):
         """Write covariance to file
 
         Parameters
@@ -158,7 +158,7 @@ class Covariance:
             t1["Parameters"] = param_names
             t2 = Table(self.data, names=param_names)
             t = hstack([t1, t2])
-            t.write(filename, format="ascii.fixed_width", delimiter="|")
+            t.write(filename, format="ascii.fixed_width", delimiter="|", overwrite = overwrite)
 
     def get_subcovariance(self, parameters):
         """Get sub-covariance matrix

--- a/gammapy/modeling/covariance.py
+++ b/gammapy/modeling/covariance.py
@@ -156,7 +156,7 @@ class Covariance:
         if len(param_names) != 0:
             t1 = Table()
             t1["Parameters"] = param_names
-            t2 = Table(self.data, names=param_names)
+            t2 = Table(self._data, names=param_names)
             t = hstack([t1, t2])
             t.write(filename, format="ascii.fixed_width", delimiter="|", overwrite = overwrite)
 

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -239,7 +239,7 @@ class Models(collections.abc.MutableSequence):
         path = make_path(path)
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
-        if self._covariance is not None:
+        if self._covariance is not None and len(self.parameters) != 0:
             filename = splitext(str(path))[0] + "_covariance.dat"
             self._covariance.write(self._models, filename)
         path.write_text(self.to_yaml())

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -216,7 +216,7 @@ class Models(collections.abc.MutableSequence):
         models = cls(models)
         if "covariance" in data:
             models.covariance = Covariance.read(
-                models.parameters, filename=data["covariance"]
+                models, filename=data["covariance"]
             )
 
         shared_register = {}
@@ -239,8 +239,9 @@ class Models(collections.abc.MutableSequence):
         path = make_path(path)
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
-        if self.covariance is not None:
-            self._covariance.write(splitext(str(path))[0] + "_covariance.dat")
+        if self._covariance is not None:
+            filename = splitext(str(path))[0] + "_covariance.dat"
+            self._covariance.write(self._models, filename)
         path.write_text(self.to_yaml())
 
     def to_yaml(self):

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -215,9 +215,9 @@ class Models(collections.abc.MutableSequence):
             models.append(model)
         models = cls(models)
         if "covariance" in data:
-            models.covariance = Covariance.read(
-                models, filename=data["covariance"]
-            )
+            covar = Covariance.read(models, filename=data["covariance"])
+            models.covariance = covar.data
+            models._covariance.filename = covar.filename
 
         shared_register = {}
         for model in models:

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -241,7 +241,7 @@ class Models(collections.abc.MutableSequence):
             raise IOError(f"File exists already: {path}")
         if self._covariance is not None and len(self.parameters) != 0:
             filename = splitext(str(path))[0] + "_covariance.dat"
-            self._covariance.write(self._models, filename)
+            self._covariance.write(self._models, filename, overwrite)
         path.write_text(self.to_yaml())
 
     def to_yaml(self):

--- a/gammapy/modeling/models/core.py
+++ b/gammapy/modeling/models/core.py
@@ -239,9 +239,9 @@ class Models(collections.abc.MutableSequence):
         path = make_path(path)
         if path.exists() and not overwrite:
             raise IOError(f"File exists already: {path}")
-        if self._covariance is not None and len(self.parameters) != 0:
+        if self.covariance is not None and len(self.parameters) != 0:
             filename = splitext(str(path))[0] + "_covariance.dat"
-            self._covariance.write(self._models, filename, overwrite)
+            self.covariance.write(self._models, filename, overwrite)
         path.write_text(self.to_yaml())
 
     def to_yaml(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -105,9 +105,7 @@ class SkyModel(SkyModelBase):
         self._covariance.data = covariance
 
         for model in self._models:
-            subcovar = self._covariance.get_subcovariance(
-                model.covariance.parameters
-            )
+            subcovar = self._covariance.get_subcovariance(model.covariance.parameters)
             model.covariance = subcovar
 
     @property
@@ -127,6 +125,20 @@ class SkyModel(SkyModelBase):
             parameters.append(self.temporal_model.parameters)
 
         return Parameters.from_stack(parameters)
+
+    @property
+    def parameters_unique_names(self):
+        param_names = []
+        for m in self.models:
+            for p in m.parameters:
+                if m.spectral_model is not None and p in m.spectral_model:
+                    tag = ".spectral."
+                elif m.spatial_model is not None and p in m.spectral_model:
+                    tag = ".spatial."
+                elif m.temporal_model is not None and p in m.temporal_model:
+                    tag = ".temporal."
+                param_names.append(m.name + tag + p.name)
+        return param_names
 
     @property
     def spatial_model(self):
@@ -562,7 +574,7 @@ class SkyDiffuseCube(SkyModelBase):
             apply_irf=apply_irf,
             datasets_names=datasets_names,
             filename=filename,
-            name=name
+            name=name,
         )
 
     def to_dict(self):

--- a/gammapy/modeling/models/cube.py
+++ b/gammapy/modeling/models/cube.py
@@ -127,20 +127,6 @@ class SkyModel(SkyModelBase):
         return Parameters.from_stack(parameters)
 
     @property
-    def parameters_unique_names(self):
-        param_names = []
-        for m in self.models:
-            for p in m.parameters:
-                if m.spectral_model is not None and p in m.spectral_model:
-                    tag = ".spectral."
-                elif m.spatial_model is not None and p in m.spectral_model:
-                    tag = ".spatial."
-                elif m.temporal_model is not None and p in m.temporal_model:
-                    tag = ".temporal."
-                param_names.append(m.name + tag + p.name)
-        return param_names
-
-    @property
     def spatial_model(self):
         """`~gammapy.modeling.models.SpatialModel`"""
         return self._spatial_model

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -98,10 +98,11 @@ def test_sky_models_io(tmp_path):
     # TODO: maybe change to a test case where we create a model programatically?
     filename = get_pkg_data_filename("data/examples.yaml")
     models = Models.read(filename)
-
+    models.covariance = np.eye(len(models.parameters))
     models.write(tmp_path / "tmp.yaml")
     models = Models.read(tmp_path / "tmp.yaml")
-
+    assert models.covariance.filename == str(tmp_path / "tmp_covariance.dat")
+    assert_allclose(models.covariance.data, np.eye(len(models.parameters)))
     assert_allclose(models.parameters["lat_0"].min, -90.0)
 
     # TODO: not sure if we should just round-trip, or if we should

--- a/gammapy/modeling/models/tests/test_io.py
+++ b/gammapy/modeling/models/tests/test_io.py
@@ -104,7 +104,7 @@ def test_sky_models_io(tmp_path):
     models.covariance = np.eye(len(models.parameters))
     models.write(tmp_path / "tmp.yaml")
     models = Models.read(tmp_path / "tmp.yaml")
-    assert models._covar_file == str(tmp_path / "tmp_covariance.ecsv")
+    assert models._covar_file == str(tmp_path / "tmp_covariance.dat")
     assert_allclose(models.covariance.data, np.eye(len(models.parameters)))
     assert_allclose(models.parameters["lat_0"].min, -90.0)
 
@@ -113,17 +113,18 @@ def test_sky_models_io(tmp_path):
     # or check serialised dict content
 
 
-def test_covariance_io(tmp_path):
-    s1 = SkyModel(PowerLawSpectralModel(), PointSpatialModel())
-    s2 = SkyModel(PowerLawSpectralModel(), PointSpatialModel())
-    models = Models([s1, s2])
-    models_copy = models.copy()
-    models_copy.covariance = None
-
-    filename = str(tmp_path / "covar.dat")
-    models.write_covariance(filename)
-    models.read_covariance(filename)
-    assert_allclose(models.covariance, models_copy.covariance)
+#
+# def test_covariance_io(tmp_path):
+#    s1 = SkyModel(PowerLawSpectralModel(), PointSpatialModel())
+#    s2 = SkyModel(PowerLawSpectralModel(), PointSpatialModel())
+#    models = Models([s1, s2])
+#    models_copy = models.copy()
+#    models_copy.covariance = None
+#
+#    filename = str(tmp_path / "covar.dat")
+#    models.write_covariance(filename)
+#    models.read_covariance(filename)
+#    assert_allclose(models.covariance, models_copy.covariance)
 
 
 @requires_data()

--- a/gammapy/modeling/tests/test_covariance.py
+++ b/gammapy/modeling/tests/test_covariance.py
@@ -5,12 +5,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 from gammapy.utils.testing import mpl_plot_check, requires_dependency
 from gammapy.modeling import Parameters, Parameter, Covariance
-from gammapy.modeling.models import (
-    Models,
-    SkyModel,
-    PointSpatialModel,
-    PowerLawSpectralModel,
-)
 
 
 @pytest.fixture
@@ -46,21 +40,9 @@ def test_set_data(covariance_diagonal):
         covariance_diagonal.data = data
 
 
-def test_io(tmp_path,covariance_diagonal):
-    s1 = SkyModel(PowerLawSpectralModel(),PointSpatialModel())
-    s2 = SkyModel(PowerLawSpectralModel(),PointSpatialModel())
-    models = Models([s1, s2])
-    filename = str(tmp_path/"covar.dat")
-    models.covariance.write(models, filename)
-    covar = Covariance.read(models, filename)
-    assert_allclose(covar, models.covariance)
-
 def test_set_subcovariance(covariance_diagonal, covariance):
     covariance_diagonal.set_subcovariance(covariance)
-    assert_allclose(
-        covariance_diagonal.data[:2, :2],
-        np.ones((2, 2))
-    )
+    assert_allclose(covariance_diagonal.data[:2, :2], np.ones((2, 2)))
 
 
 def test_get_subcovariance(covariance_diagonal, covariance):


### PR DESCRIPTION
- add Covariance.read() and modify Covariance.write() to work with models serialization
- remove .to_table() which is broken if parameters have duplicate names.
  For now unique names are generated on .write() using make_name() but once 
  models won't have duplicate parameters names, we could use param_name +
 model_name that will make the covariance matrix files more readable.