### PR TITLE
Fix Travis CI fails due to not found datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,11 @@ jobs:
 
         # MacOS X tests
         - os: osx
-          env: PYTHON_VERSION=3.6 CMD='make test'
+          env: PYTHON_VERSION=3.7 CMD='make test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OSX
 
         # Run tests without optional dependencies
-        - env: PYTHON_VERSION=3.6 CMD='make test'
+        - env: PYTHON_VERSION=3.7 CMD='make test'
                CONDA_DEPENDENCIES='Cython click regions'
                PIP_DEPENDENCIES='pytest-astropy parfive pydantic'
 
@@ -86,20 +86,20 @@ jobs:
                TEST_PACKAGING=true CONDA_CHANNELS='astropy sherpa conda-forge'
 
         # Test with Astropy dev version
-        - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=dev CMD='make test'
+        - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=dev CMD='make test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
         # Test with Sherpa dev, this may take a longer time
-        - env: PYTHON_VERSION=3.6 SETUP_CMD='make test'
+        - env: PYTHON_VERSION=3.7 SETUP_CMD='make test'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_WO_SHERPA DEBUG=True
                PIP_DEPENDENCIES='git+http://github.com/sherpa/sherpa.git#egg=sherpa pytest-astropy parfive pydantic'
 
         # Test Jupyter notebooks
-        - env: PYTHON_VERSION=3.6 CMD='make test-nb'
+        - env: PYTHON_VERSION=3.7 CMD='make test-nb'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_DOCS
 
         # Test example scripts
-        - env: PYTHON_VERSION=3.6 CMD='make test-scripts'
+        - env: PYTHON_VERSION=3.7 CMD='make test-scripts'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
                FETCH_GAMMAPY_DATA=false
 
         # Build docs
-        - env: CMD='make docs-all'
+        - env: CMD='make docs-all fmt=False'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_DOCS
 
         # Test conda build (which runs a bunch of useful tests after building the package)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ addons:
       - texlive-latex-extra
       - dvipng
 
+cache:
+  directories:
+  - $HOME/gammapy-data
+
 env:
     global:
         - PYTHON_VERSION=3.7

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ docs-sphinx:
 	python -m gammapy.utils.tutorials_links
 
 docs-all:
-	python -m gammapy.utils.tutorials_process --src="$(src)" --nbs="$(nbs)"
+	python -m gammapy.utils.tutorials_process --src="$(src)" --nbs="$(nbs)" --fmt="$(fmt)"
 	cd docs && python -m sphinx . _build/html -b html
 	python -m gammapy.utils.tutorials_links
 

--- a/dev/datasets/gammapy-data-index.json
+++ b/dev/datasets/gammapy-data-index.json
@@ -2575,13 +2575,13 @@
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_datasets.yaml",
     "filesize": 194,
-    "hashmd5": "1ff54afe526639b88aaddb57a8dadeea"
+    "hashmd5": "5e17b2f385049b660ce2bd6c1bebf65d"
    },
    {
     "path": "fermi-3fhl-crab/Fermi-LAT-3FHL_models.yaml",
     "url": "https://github.com/gammapy/gammapy-fermi-lat-data/raw/master/3fhl/crab/Fermi-LAT-3FHL_models.yaml",
     "filesize": 1251,
-    "hashmd5": "23336c63661ac35291b4a3a95f5c73df"
+    "hashmd5": "e99438be2fe12115cada40b5c2ace4a7"
    }
   ]
  },
@@ -2665,13 +2665,13 @@
     "path": "tests/models/gc_example_datasets.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_datasets.yaml",
     "filesize": 344,
-    "hashmd5": "cf743fa5d5f06c8ebfd81d8a72c0f9c9"
+    "hashmd5": "72e07fe7aca6d77d18e61261334aab49"
    },
    {
     "path": "tests/models/gc_example_models.yaml",
     "url": "https://github.com/gammapy/gammapy-extra/raw/master/datasets/tests/models/gc_example_models.yaml",
     "filesize": 2092,
-    "hashmd5": "e7e57442ecb09b3edb13d9a7140cc85a"
+    "hashmd5": "430b3ee537c243fbc1952d697efad079"
    },
    {
     "path": "tests/models/gc_example_data_gc.fits",

--- a/gammapy/scripts/check.py
+++ b/gammapy/scripts/check.py
@@ -23,3 +23,4 @@ def cli_check_logging():
     log.info("this is log.info() output")
     log.warning("this is log.warning() output")
     warnings.warn("this is warnings.warn() output")
+    print("this is stdout output")

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -256,7 +256,7 @@ class ParallelDownload:
         res = dl.download()
         log.info(f"{len(res)} files downloaded.")
         for err in res.errors:
-            fpt, url, exception = err
+            _, _, exception = err
             log.error(f"Error: {exception}")
 
     def show_info_datasets(self):

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -252,11 +252,12 @@ class ParallelDownload:
             if retrieve:
                 dl.enqueue_file(url, path=str(path.parent))
 
-        try:
-            dl.download()
-        except Exception as ex:
-            log.error("Failed to download files.")
-            log.error(ex)
+        log.info(f"{dl.queued_downloads} files to download.")
+        res = dl.download()
+        log.info(f"{len(res)} files downloaded.")
+        for err in res.errors:
+            fpt, url, exception = err
+            log.error(f"Error: {exception}")
 
     def show_info_datasets(self):
         print("")

--- a/gammapy/scripts/tests/test_download.py
+++ b/gammapy/scripts/tests/test_download.py
@@ -18,7 +18,6 @@ def config():
 
 def test_cli_download_help():
     result = run_cli(cli, ["download", "--help"])
-
     assert "Usage" in result.output
 
 

--- a/gammapy/scripts/tests/test_main.py
+++ b/gammapy/scripts/tests/test_main.py
@@ -18,3 +18,8 @@ def test_cli_help():
 def test_cli_version():
     result = run_cli(cli, ["--version"])
     assert f"gammapy version {__version__}" in result.output
+
+
+def test_check_logging():
+    result = run_cli(cli, ["check", "logging"])
+    assert f"output" in result.output

--- a/gammapy/utils/tutorials_process.py
+++ b/gammapy/utils/tutorials_process.py
@@ -73,9 +73,10 @@ def build_notebooks(args):
         log.info("Notebook file does not exist.")
         sys.exit()
 
-    subprocess.run(
-        [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "black"]
-    )
+    if args.fmt:
+        subprocess.run(
+            [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "black"]
+        )
     subprocess.run(
         [sys.executable, "-m", "gammapy", "jupyter", "--src", "temp", "strip"]
     )
@@ -130,15 +131,19 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--src", help="Tutorial notebook or folder to process")
     parser.add_argument("--nbs", help="Notebooks are considered in Sphinx")
+    parser.add_argument("--fmt", help="Black format notebooks")
     args = parser.parse_args()
 
     if not args.src:
         args.src = "tutorials"
     if not args.nbs:
         args.nbs = "True"
+    if not args.fmt:
+        args.fmt = "True"
 
     try:
         args.nbs = strtobool(args.nbs)
+        args.fmt = strtobool(args.fmt)
     except Exception as ex:
         log.error(ex)
         sys.exit()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request intends to fix Travis CI fails due to not found datasets. When these fails happen, the datasets not found could not be downloaded from `GAMMAPY_EXTRA` repo with `gammapy download datasets` command, Github service throwing error `429 too many requests`.

To fix this issue, caching of `gammapy-data` folder across jobs of a Travis build is implemented in the `.travis.yaml` settings. 

Other modifs relate to better exposing errors in `gammapy download` and updating MD5 hashes of four datasets to not download the when they are already present.

**Dear reviewer**
This PR is still in working progress status, so to test Travis behavior.
