### PR TITLE
Fix fails in Azure pipelines CI 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,14 @@ jobs:
       python -m gammapy info
     displayName: 'Install Gammapy'
 
+  - task: Cache@2
+    inputs:
+      key: 'gammapy_data'
+      restoreKeys: |
+         gammapy_data
+      path: $(GAMMAPY_DATA)
+    displayName: Cache GAMMAPY_DATA
+
   - script: |
       gammapy download datasets --out=$(GAMMAPY_DATA) --silent --tests
     displayName: 'Get GAMMAPY_DATA'
@@ -74,6 +82,14 @@ jobs:
       pip install -e .
       python -m gammapy info
     displayName: 'Install Gammapy'
+
+  - task: Cache@2
+    inputs:
+      key: 'gammapy_data'
+      restoreKeys: |
+         gammapy_data
+      path: $(GAMMAPY_DATA)
+    displayName: Cache GAMMAPY_DATA
 
   - script: |
       gammapy download datasets --out=$(GAMMAPY_DATA) --silent --tests
@@ -143,6 +159,14 @@ jobs:
       pip install -e .
       gammapy info
     displayName: 'Create gammapy-dev conda environment'
+
+  - task: Cache@2
+    inputs:
+      key: 'gammapy_data'
+      restoreKeys: |
+         gammapy_data
+      path: $(GAMMAPY_DATA)
+    displayName: Cache GAMMAPY_DATA
 
   - script: |
       source activate gammapy-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,8 +41,9 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: 'gammapy_data'
+      key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
+         gammapy_data | $(Build.SourceVersion)
          gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
@@ -85,8 +86,9 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: 'gammapy_data'
+      key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
+         gammapy_data | $(Build.SourceVersion)
          gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
@@ -162,8 +164,9 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: 'gammapy_data'
+      key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
+         gammapy_data | $(Build.SourceVersion)
          gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,6 @@ jobs:
       key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
          gammapy_data | $(Build.SourceVersion)
-         gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
 
@@ -166,7 +165,6 @@ jobs:
       key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
          gammapy_data | $(Build.SourceVersion)
-         gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,6 @@ jobs:
       key: gammapy_data | $(Build.SourceVersion)
       restoreKeys: |
          gammapy_data | $(Build.SourceVersion)
-         gammapy_data
       path: $(GAMMAPY_DATA)
     displayName: Cache GAMMAPY_DATA
 

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -253,10 +253,9 @@ class ParallelDownload:
             if retrieve:
                 dl.enqueue_file(url, path=str(path.parent))
                 if not parallel:
-                    import requests
+                    import urllib.request
                     Path.mkdir(path.parent, parents=True, exist_ok=True)
-                    file = requests.get(url)
-                    open(str(path), 'wb').write(file.content)
+                    urllib.request.urlretrieve(url, str(path))
                     log.info(f"Downloading {str(path)}")
 
         if parallel:

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -255,9 +255,11 @@ class ParallelDownload:
         log.info(f"{dl.queued_downloads} files to download.")
         res = dl.download()
         log.info(f"{len(res)} files downloaded.")
-        for err in res.errors:
-            _, _, exception = err
-            log.error(f"Error: {exception}")
+        if dl.queued_downloads != len(res):
+            for err in res.errors:
+                _, _, exception = err
+                log.error(f"Error: {exception}")
+            raise IOError("Error when downloading datasets.")
 
     def show_info_datasets(self):
         print("")

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -255,10 +255,10 @@ class ParallelDownload:
         log.info(f"{dl.queued_downloads} files to download.")
         res = dl.download()
         log.info(f"{len(res)} files downloaded.")
-        if dl.queued_downloads != len(res):
-            for err in res.errors:
-                _, _, exception = err
-                log.error(f"Error: {exception}")
+        for err in res.errors:
+            _, _, exception = err
+            log.error(f"Error: {exception}")
+        if len(res.errors):
             raise IOError("Error when downloading datasets.")
 
     def show_info_datasets(self):

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -7,6 +7,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from urllib.request import urlopen, urlretrieve
+import time
 import yaml
 from gammapy import __version__
 
@@ -258,6 +259,7 @@ class ParallelDownload:
                     Path.mkdir(path.parent, parents=True, exist_ok=True)
                     urlretrieve(url, str(path))
                     log.info(f"{datetime.now()} - Downloading {str(path)}")
+                    time.sleep(0.5)
 
         if parallel:
             log.info(f"{dl.queued_downloads} files to download.")

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -4,12 +4,14 @@ import hashlib
 import json
 import logging
 import sys
+from datetime import datetime
 from pathlib import Path
-from urllib.request import urlopen
+from urllib.request import urlopen, urlretrieve
 import yaml
 from gammapy import __version__
 
 log = logging.getLogger(__name__)
+
 
 BASE_URL = "https://gammapy.org/download"
 BASE_URL_DEV = "https://raw.githubusercontent.com/gammapy/gammapy/master/"
@@ -253,10 +255,9 @@ class ParallelDownload:
             if retrieve:
                 dl.enqueue_file(url, path=str(path.parent))
                 if not parallel:
-                    import urllib.request
                     Path.mkdir(path.parent, parents=True, exist_ok=True)
-                    urllib.request.urlretrieve(url, str(path))
-                    log.info(f"Downloading {str(path)}")
+                    urlretrieve(url, str(path))
+                    log.info(f"{datetime.now()} - Downloading {str(path)}")
 
         if parallel:
             log.info(f"{dl.queued_downloads} files to download.")

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -237,7 +237,7 @@ class ParallelDownload:
         if self.listfiles:
             log.info(f"Content will be downloaded in {self.outfolder}")
 
-        dl = Downloader(progress=self.progress, file_progress=False)
+        dl = Downloader(max_conn=1, progress=self.progress, file_progress=False)
         for rec in self.listfiles:
             url = self.listfiles[rec]["url"]
             path = self.outfolder / self.listfiles[rec]["path"]

--- a/gammapy/scripts/downloadclasses.py
+++ b/gammapy/scripts/downloadclasses.py
@@ -237,7 +237,7 @@ class ParallelDownload:
         if self.listfiles:
             log.info(f"Content will be downloaded in {self.outfolder}")
 
-        dl = Downloader(max_conn=1, progress=self.progress, file_progress=False)
+        dl = Downloader(progress=self.progress, file_progress=False)
         for rec in self.listfiles:
             url = self.listfiles[rec]["url"]
             path = self.outfolder / self.listfiles[rec]["path"]


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request tries to fix fails in Azure pipelines CI because of *files not found* errors due to *429 too many requests* errors when downloading GAMMAPY_DATA.

It just adds a cache for `GAMMAPY_DATA` folder.

**Dear reviewer**

This is a work-in progress PR.
When azure CI tests turn into green we could merge it.
