### PR TITLE
Adapt ExcessMapEstimator to estimators init scheme

### DIFF
--- a/gammapy/estimators/tests/test_excess_map.py
+++ b/gammapy/estimators/tests/test_excess_map.py
@@ -54,8 +54,8 @@ def test_compute_lima_image():
     dataset = MapDataset(counts=counts)
     dataset.models =background_model
 
-    estimator = ExcessMapEstimator(dataset,'0.1 deg')
-    result_lima = estimator.run( steps="ts")
+    estimator = ExcessMapEstimator('0.1 deg')
+    result_lima = estimator.run(dataset, steps="ts")
 
     assert_allclose(result_lima["significance"].data[:,100, 100], 30.814916, atol=1e-3)
     assert_allclose(result_lima["significance"].data[:,1, 1], 0.164, atol=1e-3)
@@ -84,8 +84,8 @@ def test_compute_lima_on_off_image():
 
     significance = Map.read(filename, hdu="SIGNIFICANCE")
     significance = image_to_cube(significance, '1 TeV', '10 TeV')
-    estimator = ExcessMapEstimator(dataset, '0.1 deg')
-    results = estimator.run(steps="ts")
+    estimator = ExcessMapEstimator('0.1 deg')
+    results = estimator.run(dataset, steps="ts")
 
     # Reproduce safe significance threshold from HESS software
     results["significance"].data[results["counts"].data < 5] = 0
@@ -107,8 +107,8 @@ def test_significance_map_estimator_incorrect_dataset():
         ExcessMapEstimator("bad")
 
 def test_significance_map_estimator_map_dataset(simple_dataset):
-    estimator = ExcessMapEstimator(simple_dataset, 0.1 * u.deg)
-    result = estimator.run(steps="all")
+    estimator = ExcessMapEstimator(0.1 * u.deg)
+    result = estimator.run(simple_dataset, steps="all")
 
     assert_allclose(result["counts"].data[0, 10, 10], 162)
     assert_allclose(result["excess"].data[0, 10, 10], 81)
@@ -121,8 +121,8 @@ def test_significance_map_estimator_map_dataset(simple_dataset):
 
 
 def test_significance_map_estimator_map_dataset_on_off(simple_dataset_on_off):
-    estimator = ExcessMapEstimator(simple_dataset_on_off, 0.11 * u.deg)
-    result = estimator.run(steps=["ts"])
+    estimator = ExcessMapEstimator(0.11 * u.deg)
+    result = estimator.run(simple_dataset_on_off, steps=["ts"])
 
     assert_allclose(result["counts"].data[0, 10, 10], 194)
     assert_allclose(result["excess"].data[0, 10, 10], 97)

--- a/tutorials/exclusion_mask.ipynb
+++ b/tutorials/exclusion_mask.ipynb
@@ -310,8 +310,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "estimator = ExcessMapEstimator(dataset, \"0.4 deg\")\n",
-    "result = estimator.run(steps=\"ts\")"
+    "estimator = ExcessMapEstimator(\"0.4 deg\")\n",
+    "result = estimator.run(dataset, steps=\"ts\")"
    ]
   },
   {

--- a/tutorials/ring_background.ipynb
+++ b/tutorials/ring_background.ipynb
@@ -297,8 +297,8 @@
    "outputs": [],
    "source": [
     "# Using a convolution radius of 0.04 degrees\n",
-    "estimator = ExcessMapEstimator(stacked_on_off, 0.04 * u.deg)\n",
-    "lima_maps = estimator.run(steps=\"ts\")"
+    "estimator = ExcessMapEstimator(0.04 * u.deg)\n",
+    "lima_maps = estimator.run(stacked_on_off, steps=\"ts\")"
    ]
   },
   {


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request changes the `__init__` method of `ExcessMapEstimator` and moves the `dataset` argument to the `run()` function. 

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->
