### PR TITLE
Add plotting to  Background3D

### DIFF
--- a/gammapy/irf/tests/test_background.py
+++ b/gammapy/irf/tests/test_background.py
@@ -130,6 +130,12 @@ def test_background_3d_integrate(bkg_3d):
     assert_allclose(rate.to("s-1 sr-1").value, [[99000000.0, 99000000.0]], rtol=1e-5)
 
 
+@requires_dependency("matplotlib")
+def test_plot(bkg_2d):
+    with mpl_plot_check():
+        bkg_2d.peek()
+
+
 @pytest.fixture(scope="session")
 def bkg_2d():
     """A simple Background2D test case"""
@@ -231,3 +237,6 @@ def test_plot(bkg_2d):
 
     with mpl_plot_check():
         bkg_2d.plot_offset_dependence()
+
+    with mpl_plot_check():
+        bkg_2d.plot_spectrum()


### PR DESCRIPTION
<!-- These are hidden commments. You can leave them or delete them. -->

<!-- Don't be shy! Github issues or pull requests are welcome any time. -->
<!-- But if you first want to chat, use the Gammapy Slack. -->
<!-- See https://gammapy.org/contact.html -->

**Description**
<!-- What is the motivation for this pull request? -->
<!-- Briefly: what changes are done here? -->
<!-- If this is to address a Github issue, metion it's number to create a link -->
<!-- Example: This PR is to fix issue #42 -->

This pull request adds  `Background3D.peek()` and `Background2D.plot_spectrum()`.

**Dear reviewer**
<!-- Let the reviewer and Gammapy team know what you want: -->
<!-- * Is this ready for review? Or is it work in progress and you want some feedback? -->
<!-- * Do you want ot go through review here? Or if someone just finish this up and merge it in? -->
<!-- Do you have any specific questions, e.g. about API or implementation? -->
<!-- Do you include a test executing new code you're adding (to make sure it runs)? -->
<!-- Do you include some documentation? Is it needed? -->

I tried to add a `.plot_interactive` but am running into some issues. Will do it after 0.17 release